### PR TITLE
feat(frontend): Supabase auth — login/logout, OAuth callback, bearer-forwarded GraphQL

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -35,6 +35,10 @@ jobs:
       # CI does not reach the backend; the value is a placeholder that only
       # needs to satisfy `z.string().url()`.
       BACKEND_URL: http://localhost:1323
+      # Supabase client env vars — dummy values satisfy Zod validation at
+      # build/test time without a running Supabase instance.
+      NEXT_PUBLIC_SUPABASE_URL: http://localhost:54321
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.ci-dummy-key-1234567890
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,7 @@ backend/server
 /backend/graph/generated/
 /backend/graph/model/models_gen.go
 /frontend/src/generated/
+
+# Supabase CLI local state
+supabase/.branches/
+supabase/.temp/

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -102,6 +102,16 @@ Per "pnpm workspace filter exits 0 for missing scripts" above, a missing `test` 
 
 The workflow uses the same `jdx/mise-action@v4` step that `backend.yml` uses, relying on the repo-root `.tool-versions` to pin Node (`nodejs 24`). `corepack enable` then activates the `packageManager` field from root `package.json` (`pnpm@9.15.0`), so the pnpm version is pinned by the repo — not by the CI runner's preinstalled toolchain. This keeps local and CI Node/pnpm versions in lockstep with a single source of truth.
 
-### `BACKEND_URL` is a build-time placeholder
+### Build-time env vars: server and client
 
-`frontend/src/env.ts` uses `@t3-oss/env-nextjs` to Zod-validate `BACKEND_URL` at **build** time, not just at runtime. `next build` therefore fails if `BACKEND_URL` is unset — a deliberate failure mode documented in `docs/frontend.md`. CI sets `BACKEND_URL=http://localhost:1323` at the job level purely to satisfy `z.string().url()`; no request is actually made during the build, so the value does not need to resolve. Do **not** remove this env: stripping it reintroduces the silent-fail shape the validation was designed to prevent.
+`frontend/src/env.ts` uses `@t3-oss/env-nextjs` to Zod-validate **all** declared vars at build time. `next build` fails if any required var is unset — a deliberate failure mode.
+
+CI sets dummy values at the job level for every required var:
+
+| Var | Why needed at build time |
+|---|---|
+| `BACKEND_URL` | Server var; validated by `@t3-oss/env-nextjs` at build. |
+| `NEXT_PUBLIC_SUPABASE_URL` | Client var; `@t3-oss/env-nextjs` validates and **bundles** client vars into the JS bundle at build time — missing = build failure. |
+| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Same as above. |
+
+No request is made during the build, so dummy values only need to satisfy the Zod schema (e.g. `z.string().url()` requires a URL-shaped string). Do **not** remove any of these: each missing env reintroduces a silent-fail shape the validation was designed to prevent. When a new required var is added to `src/env.ts`, add a corresponding dummy to the workflow's `env:` block.

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -68,4 +68,34 @@ Do **not** install pnpm via `npm i -g pnpm` or `brew install pnpm`. Those paths 
 
 ## Supabase CLI
 
-TBD — `supabase start` 手順は Supabase 連携時に追記。
+ローカル開発は `supabase start` で完結する（本番 Supabase プロジェクト不要、PR9 で接続）。
+
+### 初回セットアップ
+
+1. Supabase CLI をインストール（`brew install supabase/tap/supabase` または `mise use supabase@latest`）。
+2. Google Cloud Console で OAuth 2.0 client ID を作成:
+   - Authorized redirect URIs に `http://127.0.0.1:54321/auth/v1/callback` を追加。
+   - Authorized JavaScript origins に `http://127.0.0.1:3000` を追加。
+3. リポジトリルートで `supabase start` を実行。初回のみ Docker イメージ取得で数分かかる。出力に anon key / service role key が表示される。
+4. `frontend/.env.local` に以下を追記（`supabase start` の出力から `anon key` をコピー）:
+   ```
+   NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321
+   NEXT_PUBLIC_SUPABASE_ANON_KEY=<supabase start の出力から anon key>
+   SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID=<Google OAuth client ID>
+   SUPABASE_AUTH_EXTERNAL_GOOGLE_SECRET=<Google OAuth secret>
+   ```
+5. Supabase Studio: http://127.0.0.1:54323
+
+### 日常運用
+
+| タスク | コマンド |
+|---|---|
+| Supabase 起動 | `supabase start` |
+| Supabase 停止 | `supabase stop` |
+| DB リセット | `supabase db reset` |
+| ステータス確認 | `supabase status` |
+
+### Gotchas
+
+- **`localhost` ではなく `127.0.0.1` を使う**: Google OAuth の redirect URI 検証は `localhost` と `127.0.0.1` を別ホスト扱いする。`supabase start` のデフォルト出力に合わせて `127.0.0.1:3000` でアクセス。
+- **シークレットは `.env.local` (gitignored)**: `supabase/config.toml` は `env()` プレースホルダで参照するだけで、実値はコミットしない。

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -26,8 +26,8 @@ pnpm --filter frontend typecheck               # tsc --noEmit
 | Name | Where validated | Default (example) | Purpose |
 |---|---|---|---|
 | `BACKEND_URL` | `frontend/src/env.ts` (server) | `http://localhost:1323` | Base URL for the `/api/graphql` rewrite in `next.config.ts`. |
-
-`NEXT_PUBLIC_SUPABASE_URL` / `NEXT_PUBLIC_SUPABASE_ANON_KEY` arrive in PR6.
+| `NEXT_PUBLIC_SUPABASE_URL` | `frontend/src/env.ts` (client) | `http://127.0.0.1:54321` | Supabase API base URL. Public — bundled into client. |
+| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | `frontend/src/env.ts` (client) | `eyJ...` (from `supabase start`) | Supabase anonymous JWT. Public — RLS gates real access. |
 
 ## Backend rewrite contract
 
@@ -83,6 +83,37 @@ Files:
 - `frontend/src/app/providers.tsx` — wraps the app in `ApolloNextAppProvider`.
 
 Browser code calls `/api/graphql` (same-origin via the Next rewrite — avoids CORS/cookie issues). `ApolloClient` and `InMemoryCache` come from `@apollo/client-integration-nextjs` (SSR-streaming-safe variants) — see Gotcha below.
+
+## Auth (Supabase)
+
+PR6 introduces a 3-layer Supabase SSR client setup mirroring the official `@supabase/ssr` template. Each layer exists because cookie reading/writing differs between contexts:
+
+| Layer | File | Cookie source | Used by |
+|---|---|---|---|
+| Browser | `src/lib/supabase/client.ts` | `document.cookie` (handled by `createBrowserClient`) | Client components, `authLink` |
+| Server (RSC / route handler) | `src/lib/supabase/server.ts` | `next/headers` `cookies()` | Server components, route handlers, `auth/callback/route.ts` |
+| Middleware | `src/lib/supabase/middleware.ts` | `NextRequest.cookies` / `NextResponse.cookies` | `src/middleware.ts` (cookie rotation) |
+
+### authLink for browser GraphQL
+
+`src/lib/apollo/client.ts` composes `from([authLink, httpLink])`. `authLink` calls `supabase.auth.getSession()` on every request and attaches `Authorization: Bearer <jwt>` when a session exists. `getSession()` reads from local cookies — it is not an HTTP call, so per-request invocation is cheap. When the JWT is stale, the SDK refreshes internally.
+
+If no session exists the header is omitted (not set to an empty string). Backend treats missing `Authorization` as anonymous (PR7).
+
+### RSC token forwarding (deferred to PR9)
+
+`src/lib/apollo/server.ts` does NOT forward an auth token in PR6. Reason: PR6's only RSC query is `{ health }` (anonymous-safe). PR9 introduces `me`, at which point we extend `gqlFetch` to optionally pull the token from `createServerClient(cookies())`. A `TODO(PR9)` comment marks the intended hook point.
+
+### Middleware cookie rotation
+
+`src/middleware.ts` calls `updateSession(request)` from `lib/supabase/middleware.ts`. The implementation MUST call `supabase.auth.getUser()` once — without it Supabase does not refresh expiring tokens and the session silently drops. The `matcher` excludes `_next/static`, `_next/image`, `favicon.ico`, and common image extensions.
+
+### Gotchas
+
+- **`src/middleware.ts`, not `frontend/middleware.ts`**: Next.js with `src/` layout expects middleware under `src/`.
+- **Supabase cookie names**: `sb-<project_ref>-auth-token` (split across `sb-...-auth-token.0` / `.1` for large JWTs). Useful when DevTools-debugging a missing session.
+- **`@supabase/ssr` mocking in Vitest**: Real `createBrowserClient` crashes in node env. Use `vi.mock("@supabase/ssr", ...)` to stub `createBrowserClient` / `createServerClient` and return controllable `auth` objects.
+- **OAuth redirect: 127.0.0.1 vs localhost**: Google treats them as separate origins. Match what `supabase start` prints (`127.0.0.1`).
 
 ## shadcn/ui
 

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -108,12 +108,16 @@ If no session exists the header is omitted (not set to an empty string). Backend
 
 `src/middleware.ts` calls `updateSession(request)` from `lib/supabase/middleware.ts`. The implementation MUST call `supabase.auth.getUser()` once — without it Supabase does not refresh expiring tokens and the session silently drops. The `matcher` excludes `_next/static`, `_next/image`, `favicon.ico`, and common image extensions.
 
+The `matcher` must also explicitly exclude `/api/:path*` and `/auth/callback`. Without the `/api` exclusion, every Apollo browser POST to `/api/graphql` triggers a full Supabase token-refresh round-trip in middleware, adding latency per GraphQL call. Without the `/auth/callback` exclusion, middleware cookie writes race against the route handler's own `exchangeCodeForSession` and can corrupt the new session.
+
 ### Gotchas
 
 - **`src/middleware.ts`, not `frontend/middleware.ts`**: Next.js with `src/` layout expects middleware under `src/`.
 - **Supabase cookie names**: `sb-<project_ref>-auth-token` (split across `sb-...-auth-token.0` / `.1` for large JWTs). Useful when DevTools-debugging a missing session.
 - **`@supabase/ssr` mocking in Vitest**: Real `createBrowserClient` crashes in node env. Use `vi.mock("@supabase/ssr", ...)` to stub `createBrowserClient` / `createServerClient` and return controllable `auth` objects.
 - **OAuth redirect: 127.0.0.1 vs localhost**: Google treats them as separate origins. Match what `supabase start` prints (`127.0.0.1`).
+- **`createSupabaseServerClient` `setAll` catch is scoped to Server Components.** The helper is also used by Route Handlers (e.g. `auth/callback/route.ts`) where cookie writes DO succeed. The `try/catch` in `setAll` silently swallows errors in both paths; a failure inside a Route Handler would be invisible. Do not repurpose `createSupabaseServerClient` in contexts where a write failure must surface (e.g. a middleware-like flow) without removing or re-throwing from that catch.
+- **Open redirect via `?next=`.** `WHATWG URL` accepts absolute URLs and protocol-relative paths even when given a base-URL argument; a bare `startsWith("/")` check is insufficient. The correct guard: `value.startsWith("/") && !value.startsWith("//") && !value.includes("\\")`. The backslash variant bypasses naive checks because http(s) special-scheme parsers normalize `\` → `/`.
 
 ## shadcn/ui
 
@@ -122,6 +126,8 @@ If no session exists the header is omitted (not set to an empty string). Backend
 `shadcn init` is interactive and not suitable for CI or non-interactive environments. The fallback is to hand-write `components.json`, `lib/utils.ts`, and the `globals.css` base tokens following the shadcn JSON schema — exactly what PR3 did.
 
 ## Gotchas encountered
+
+**Next 16 deprecates `middleware.ts` in favour of `proxy.ts`.** The build emits a deprecation warning (not an error) when `src/middleware.ts` exists. PR6 intentionally stays on `middleware.ts` because `@supabase/ssr` templates and ecosystem docs still reference the old name. When the ecosystem catches up and Next removes the old name, rename `src/middleware.ts` → `src/proxy.ts` (and `src/lib/supabase/middleware.ts` → `src/lib/supabase/proxy.ts` for consistency).
 
 **Biome 2 — Tailwind 4 directive parsing**: Without `css.parser.tailwindDirectives: true` in `biome.json`, directives like `@theme`, `@custom-variant`, and `@import "tw-animate-css"` can trigger false-positive lint errors. Add the flag whenever Tailwind 4 CSS is in scope.
 
@@ -135,7 +141,7 @@ If no session exists the header is omitted (not set to an empty string). Backend
 
 **RSC code must use `env.BACKEND_URL`, not `/api/graphql`.** The rewrite in `next.config.ts` only applies to browser-originating requests. Server components calling `/api/graphql` would hit a Next 404.
 
-**Vitest loads `src/env.ts` and crashes if `BACKEND_URL` is unset.** `vitest.config.ts` injects a placeholder via `test.env.BACKEND_URL = "http://localhost:1323"`. Keep that placeholder valid for `z.string().url()`.
+**Vitest loads `src/env.ts` and crashes if required env vars are unset.** `vitest.config.ts` injects placeholders via `test.env` — currently `BACKEND_URL`, `NEXT_PUBLIC_SUPABASE_URL`, and `NEXT_PUBLIC_SUPABASE_ANON_KEY`. Any new required var added to `src/env.ts` (server or client) must get a corresponding `test.env` entry, otherwise Vitest crashes at module load time before any test runs. Keep values valid for their Zod schema (e.g. `z.string().url()` requires a real URL shape).
 
 **`server-only` has no standalone npm package** — it ships inside Next.js and the Next compiler resolves it. Vitest's node env cannot, so `vitest.config.ts` aliases `server-only` to an empty stub. Without the alias, importing `src/lib/apollo/server.ts` in any test fails to resolve.
 

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -3,3 +3,7 @@
 # Backend base URL — rewritten from /api/graphql in next.config.ts.
 # Matches `cmd/server` PORT default in docs/backend.md.
 BACKEND_URL=http://localhost:1323
+
+# Supabase local dev — populated automatically by `supabase start`.
+NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321
+NEXT_PUBLIC_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.dummy-anon-key-replace-with-supabase-start-output

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,11 +20,18 @@
   "dependencies": {
     "@apollo/client": "^4.1.9",
     "@apollo/client-integration-nextjs": "^0.14.5",
+    "@hookform/resolvers": "^5.2.2",
+    "@radix-ui/react-label": "^2.1.8",
+    "@radix-ui/react-slot": "^1.2.4",
+    "@supabase/ssr": "^0.10.2",
+    "@supabase/supabase-js": "^2.104.1",
     "@t3-oss/env-nextjs": "0.12.0",
+    "class-variance-authority": "^0.7.1",
     "graphql": "^16.13.2",
     "next": "16.2.4",
     "react": "19.2.0",
     "react-dom": "19.2.0",
+    "react-hook-form": "^7.73.1",
     "zod": "3.24.2"
   },
   "devDependencies": {

--- a/frontend/src/app/_components/header.tsx
+++ b/frontend/src/app/_components/header.tsx
@@ -6,7 +6,11 @@ export async function Header() {
   const supabase = await createSupabaseServerClient();
   const {
     data: { user },
+    error,
   } = await supabase.auth.getUser();
+  if (error) {
+    console.error("[header] getUser() failed:", error.message);
+  }
 
   return (
     <header className="flex items-center justify-between border-b px-6 py-3">

--- a/frontend/src/app/_components/header.tsx
+++ b/frontend/src/app/_components/header.tsx
@@ -1,0 +1,30 @@
+import Link from "next/link";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+import { LogoutButton } from "./logout-button";
+
+export async function Header() {
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  return (
+    <header className="flex items-center justify-between border-b px-6 py-3">
+      <Link href="/" className="font-semibold">
+        🦩 flamingo-armond
+      </Link>
+      <nav>
+        {user ? (
+          <div className="flex items-center gap-3 text-sm">
+            <span className="text-muted-foreground">{user.email}</span>
+            <LogoutButton />
+          </div>
+        ) : (
+          <Link href="/login" className="text-sm underline">
+            Sign in
+          </Link>
+        )}
+      </nav>
+    </header>
+  );
+}

--- a/frontend/src/app/_components/logout-button.tsx
+++ b/frontend/src/app/_components/logout-button.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { createSupabaseBrowserClient } from "@/lib/supabase/client";
+
+export function LogoutButton() {
+  const router = useRouter();
+
+  async function handleLogout() {
+    const supabase = createSupabaseBrowserClient();
+    await supabase.auth.signOut();
+    router.refresh();
+  }
+
+  return (
+    <Button onClick={handleLogout} type="button" variant="outline" size="sm">
+      Logout
+    </Button>
+  );
+}

--- a/frontend/src/app/_components/logout-button.tsx
+++ b/frontend/src/app/_components/logout-button.tsx
@@ -9,7 +9,11 @@ export function LogoutButton() {
 
   async function handleLogout() {
     const supabase = createSupabaseBrowserClient();
-    await supabase.auth.signOut();
+    const { error } = await supabase.auth.signOut();
+    if (error) {
+      console.error("[logout] signOut failed:", error.message);
+      return;
+    }
     router.refresh();
   }
 

--- a/frontend/src/app/auth/callback/route.test.ts
+++ b/frontend/src/app/auth/callback/route.test.ts
@@ -91,4 +91,14 @@ describe("GET /auth/callback", () => {
     expect(location.startsWith("http://localhost")).toBe(true);
     expect(new URL(location).pathname).toBe("/");
   });
+
+  it("falls back to / when next contains a backslash (URL-parser normalizes to /)", async () => {
+    mockExchangeCodeForSession.mockResolvedValueOnce({ error: null });
+    const response = await GET(
+      makeRequest("http://localhost/auth/callback?code=valid&next=/%5Cevil.com"),
+    );
+    // location header should NOT have host "evil.com"
+    const location = response.headers.get("location");
+    expect(location).toBe("http://localhost/");
+  });
 });

--- a/frontend/src/app/auth/callback/route.test.ts
+++ b/frontend/src/app/auth/callback/route.test.ts
@@ -1,0 +1,59 @@
+import { NextRequest } from "next/server";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { GET } from "./route";
+
+const mockExchangeCodeForSession = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/supabase/server", () => ({
+  createSupabaseServerClient: vi.fn().mockResolvedValue({
+    auth: { exchangeCodeForSession: mockExchangeCodeForSession },
+  }),
+}));
+
+function makeRequest(url: string) {
+  return new NextRequest(new URL(url));
+}
+
+describe("GET /auth/callback", () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it("exchanges valid code and redirects to /", async () => {
+    mockExchangeCodeForSession.mockResolvedValueOnce({ error: null });
+
+    const response = await GET(makeRequest("http://localhost/auth/callback?code=abc123"));
+
+    expect(mockExchangeCodeForSession).toHaveBeenCalledWith("abc123");
+    expect([301, 302, 307, 308]).toContain(response.status);
+    expect(response.headers.get("location")).toBe("http://localhost/");
+  });
+
+  it("redirects to /login?error=missing_code when code is absent", async () => {
+    const response = await GET(makeRequest("http://localhost/auth/callback"));
+
+    expect(mockExchangeCodeForSession).not.toHaveBeenCalled();
+    expect([301, 302, 307, 308]).toContain(response.status);
+    expect(response.headers.get("location")).toBe("http://localhost/login?error=missing_code");
+  });
+
+  it("redirects to /login?error=exchange_failed when exchangeCodeForSession errors", async () => {
+    mockExchangeCodeForSession.mockResolvedValueOnce({
+      error: new Error("exchange error"),
+    });
+
+    const response = await GET(makeRequest("http://localhost/auth/callback?code=bad"));
+
+    expect([301, 302, 307, 308]).toContain(response.status);
+    expect(response.headers.get("location")).toBe("http://localhost/login?error=exchange_failed");
+  });
+
+  it("honors ?next query param for deep-link redirect", async () => {
+    mockExchangeCodeForSession.mockResolvedValueOnce({ error: null });
+
+    const response = await GET(
+      makeRequest("http://localhost/auth/callback?code=xyz&next=/profile"),
+    );
+
+    expect([301, 302, 307, 308]).toContain(response.status);
+    expect(response.headers.get("location")).toBe("http://localhost/profile");
+  });
+});

--- a/frontend/src/app/auth/callback/route.test.ts
+++ b/frontend/src/app/auth/callback/route.test.ts
@@ -1,5 +1,5 @@
 import { NextRequest } from "next/server";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { GET } from "./route";
 
 const mockExchangeCodeForSession = vi.hoisted(() => vi.fn());
@@ -15,7 +15,16 @@ function makeRequest(url: string) {
 }
 
 describe("GET /auth/callback", () => {
-  afterEach(() => vi.clearAllMocks());
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+    vi.clearAllMocks();
+  });
 
   it("exchanges valid code and redirects to /", async () => {
     mockExchangeCodeForSession.mockResolvedValueOnce({ error: null });
@@ -55,5 +64,31 @@ describe("GET /auth/callback", () => {
 
     expect([301, 302, 307, 308]).toContain(response.status);
     expect(response.headers.get("location")).toBe("http://localhost/profile");
+  });
+
+  it("falls back to / when next is an absolute URL", async () => {
+    mockExchangeCodeForSession.mockResolvedValueOnce({ error: null });
+
+    const response = await GET(
+      makeRequest("http://localhost/auth/callback?code=valid&next=https://evil.com"),
+    );
+
+    expect([301, 302, 307, 308]).toContain(response.status);
+    const location = response.headers.get("location") ?? "";
+    expect(location.startsWith("http://localhost")).toBe(true);
+    expect(new URL(location).pathname).toBe("/");
+  });
+
+  it("falls back to / when next is protocol-relative", async () => {
+    mockExchangeCodeForSession.mockResolvedValueOnce({ error: null });
+
+    const response = await GET(
+      makeRequest("http://localhost/auth/callback?code=valid&next=//evil.com"),
+    );
+
+    expect([301, 302, 307, 308]).toContain(response.status);
+    const location = response.headers.get("location") ?? "";
+    expect(location.startsWith("http://localhost")).toBe(true);
+    expect(new URL(location).pathname).toBe("/");
   });
 });

--- a/frontend/src/app/auth/callback/route.ts
+++ b/frontend/src/app/auth/callback/route.ts
@@ -1,0 +1,24 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+
+export async function GET(request: NextRequest) {
+  const url = new URL(request.url);
+  const code = url.searchParams.get("code");
+  const next = url.searchParams.get("next") ?? "/";
+
+  if (!code) {
+    const loginUrl = new URL("/login", url.origin);
+    loginUrl.searchParams.set("error", "missing_code");
+    return NextResponse.redirect(loginUrl);
+  }
+
+  const supabase = await createSupabaseServerClient();
+  const { error } = await supabase.auth.exchangeCodeForSession(code);
+  if (error) {
+    const loginUrl = new URL("/login", url.origin);
+    loginUrl.searchParams.set("error", "exchange_failed");
+    return NextResponse.redirect(loginUrl);
+  }
+
+  return NextResponse.redirect(new URL(next, url.origin));
+}

--- a/frontend/src/app/auth/callback/route.ts
+++ b/frontend/src/app/auth/callback/route.ts
@@ -4,7 +4,8 @@ import { createSupabaseServerClient } from "@/lib/supabase/server";
 export async function GET(request: NextRequest) {
   const url = new URL(request.url);
   const code = url.searchParams.get("code");
-  const next = url.searchParams.get("next") ?? "/";
+  const rawNext = url.searchParams.get("next") ?? "/";
+  const safeNext = rawNext.startsWith("/") && !rawNext.startsWith("//") ? rawNext : "/";
 
   if (!code) {
     const loginUrl = new URL("/login", url.origin);
@@ -15,10 +16,11 @@ export async function GET(request: NextRequest) {
   const supabase = await createSupabaseServerClient();
   const { error } = await supabase.auth.exchangeCodeForSession(code);
   if (error) {
+    console.error("[auth/callback] exchangeCodeForSession failed:", error.message);
     const loginUrl = new URL("/login", url.origin);
     loginUrl.searchParams.set("error", "exchange_failed");
     return NextResponse.redirect(loginUrl);
   }
 
-  return NextResponse.redirect(new URL(next, url.origin));
+  return NextResponse.redirect(new URL(safeNext, url.origin));
 }

--- a/frontend/src/app/auth/callback/route.ts
+++ b/frontend/src/app/auth/callback/route.ts
@@ -5,7 +5,9 @@ export async function GET(request: NextRequest) {
   const url = new URL(request.url);
   const code = url.searchParams.get("code");
   const rawNext = url.searchParams.get("next") ?? "/";
-  const safeNext = rawNext.startsWith("/") && !rawNext.startsWith("//") ? rawNext : "/";
+  const isSafeNext =
+    rawNext.startsWith("/") && !rawNext.startsWith("//") && !rawNext.includes("\\");
+  const safeNext = isSafeNext ? rawNext : "/";
 
   if (!code) {
     const loginUrl = new URL("/login", url.origin);

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import type { ReactNode } from "react";
+import { Header } from "./_components/header";
 import { Providers } from "./providers";
 import "./globals.css";
 
@@ -12,7 +13,10 @@ export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
       <body>
-        <Providers>{children}</Providers>
+        <Providers>
+          <Header />
+          {children}
+        </Providers>
       </body>
     </html>
   );

--- a/frontend/src/app/login/login-button.tsx
+++ b/frontend/src/app/login/login-button.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { createSupabaseBrowserClient } from "@/lib/supabase/client";
+
+export function LoginButton() {
+  async function handleSignIn() {
+    const supabase = createSupabaseBrowserClient();
+    await supabase.auth.signInWithOAuth({
+      provider: "google",
+      options: {
+        redirectTo: `${window.location.origin}/auth/callback`,
+      },
+    });
+  }
+
+  return (
+    <Button onClick={handleSignIn} type="button">
+      Continue with Google
+    </Button>
+  );
+}

--- a/frontend/src/app/login/login-button.tsx
+++ b/frontend/src/app/login/login-button.tsx
@@ -6,12 +6,15 @@ import { createSupabaseBrowserClient } from "@/lib/supabase/client";
 export function LoginButton() {
   async function handleSignIn() {
     const supabase = createSupabaseBrowserClient();
-    await supabase.auth.signInWithOAuth({
+    const { error } = await supabase.auth.signInWithOAuth({
       provider: "google",
       options: {
         redirectTo: `${window.location.origin}/auth/callback`,
       },
     });
+    if (error) {
+      console.error("[login] signInWithOAuth failed:", error.message);
+    }
   }
 
   return (

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -1,0 +1,16 @@
+import { LoginButton } from "./login-button";
+
+type SearchParams = Promise<{ error?: string }>;
+
+export default async function LoginPage({ searchParams }: { searchParams: SearchParams }) {
+  const { error } = await searchParams;
+  return (
+    <main className="flex min-h-screen items-center justify-center p-8">
+      <div className="flex flex-col items-center gap-4">
+        <h1 className="text-2xl font-semibold">Sign in</h1>
+        {error ? <p className="text-sm text-destructive">Sign-in failed: {error}</p> : null}
+        <LoginButton />
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -1,0 +1,49 @@
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        destructive: "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+        outline: "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+        secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default: "h-10 px-4 py-2",
+        sm: "h-9 rounded-md px-3",
+        lg: "h-11 rounded-md px-8",
+        icon: "h-10 w-10",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  },
+);
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean;
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : "button";
+    return (
+      <Comp className={cn(buttonVariants({ variant, size, className }))} ref={ref} {...props} />
+    );
+  },
+);
+Button.displayName = "Button";
+
+export { Button, buttonVariants };

--- a/frontend/src/components/ui/form.tsx
+++ b/frontend/src/components/ui/form.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+import type * as LabelPrimitive from "@radix-ui/react-label";
+import { Slot } from "@radix-ui/react-slot";
+import * as React from "react";
+import {
+  Controller,
+  type ControllerProps,
+  type FieldPath,
+  type FieldValues,
+  FormProvider,
+  useFormContext,
+} from "react-hook-form";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
+
+const Form = FormProvider;
+
+type FormFieldContextValue<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+> = {
+  name: TName;
+};
+
+const FormFieldContext = React.createContext<FormFieldContextValue | null>(null);
+
+const FormField = <
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+>({
+  ...props
+}: ControllerProps<TFieldValues, TName>) => {
+  return (
+    <FormFieldContext.Provider value={{ name: props.name }}>
+      <Controller {...props} />
+    </FormFieldContext.Provider>
+  );
+};
+
+const useFormField = () => {
+  const fieldContext = React.useContext(FormFieldContext);
+  const itemContext = React.useContext(FormItemContext);
+  const { getFieldState, formState } = useFormContext();
+
+  if (!fieldContext) {
+    throw new Error("useFormField should be used within <FormField>");
+  }
+
+  if (!itemContext) {
+    throw new Error("useFormField should be used within <FormItem>");
+  }
+
+  const fieldState = getFieldState(fieldContext.name, formState);
+
+  const { id } = itemContext;
+
+  return {
+    id,
+    name: fieldContext.name,
+    formItemId: `${id}-form-item`,
+    formDescriptionId: `${id}-form-item-description`,
+    formMessageId: `${id}-form-item-message`,
+    ...fieldState,
+  };
+};
+
+type FormItemContextValue = {
+  id: string;
+};
+
+const FormItemContext = React.createContext<FormItemContextValue | null>(null);
+
+const FormItem = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => {
+    const id = React.useId();
+
+    return (
+      <FormItemContext.Provider value={{ id }}>
+        <div ref={ref} className={cn("space-y-2", className)} {...props} />
+      </FormItemContext.Provider>
+    );
+  },
+);
+FormItem.displayName = "FormItem";
+
+const FormLabel = React.forwardRef<
+  React.ElementRef<typeof LabelPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root>
+>(({ className, ...props }, ref) => {
+  const { error, formItemId } = useFormField();
+
+  return (
+    <Label
+      ref={ref}
+      className={cn(error && "text-destructive", className)}
+      htmlFor={formItemId}
+      {...props}
+    />
+  );
+});
+FormLabel.displayName = "FormLabel";
+
+const FormControl = React.forwardRef<
+  React.ElementRef<typeof Slot>,
+  React.ComponentPropsWithoutRef<typeof Slot>
+>(({ ...props }, ref) => {
+  const { error, formItemId, formDescriptionId, formMessageId } = useFormField();
+
+  return (
+    <Slot
+      ref={ref}
+      id={formItemId}
+      aria-describedby={!error ? `${formDescriptionId}` : `${formDescriptionId} ${formMessageId}`}
+      aria-invalid={!!error}
+      {...props}
+    />
+  );
+});
+FormControl.displayName = "FormControl";
+
+const FormDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => {
+  const { formDescriptionId } = useFormField();
+
+  return (
+    <p
+      ref={ref}
+      id={formDescriptionId}
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  );
+});
+FormDescription.displayName = "FormDescription";
+
+const FormMessage = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, children, ...props }, ref) => {
+  const { error, formMessageId } = useFormField();
+  const body = error ? String(error?.message ?? "") : children;
+
+  if (!body) {
+    return null;
+  }
+
+  return (
+    <p
+      ref={ref}
+      id={formMessageId}
+      className={cn("text-sm font-medium text-destructive", className)}
+      {...props}
+    >
+      {body}
+    </p>
+  );
+});
+FormMessage.displayName = "FormMessage";
+
+export {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+  useFormField,
+};

--- a/frontend/src/components/ui/input.tsx
+++ b/frontend/src/components/ui/input.tsx
@@ -1,0 +1,22 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          className,
+        )}
+        ref={ref}
+        {...props}
+      />
+    );
+  },
+);
+Input.displayName = "Input";
+
+export { Input };

--- a/frontend/src/components/ui/label.tsx
+++ b/frontend/src/components/ui/label.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import * as LabelPrimitive from "@radix-ui/react-label";
+import { cva, type VariantProps } from "class-variance-authority";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const labelVariants = cva(
+  "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
+);
+
+const Label = React.forwardRef<
+  React.ElementRef<typeof LabelPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> & VariantProps<typeof labelVariants>
+>(({ className, ...props }, ref) => (
+  <LabelPrimitive.Root ref={ref} className={cn(labelVariants(), className)} {...props} />
+));
+Label.displayName = LabelPrimitive.Root.displayName;
+
+export { Label };

--- a/frontend/src/env.ts
+++ b/frontend/src/env.ts
@@ -1,7 +1,8 @@
-// Validated server-side env facade. Importing this module triggers Zod validation at
-// load time — any server component / route handler that reads BACKEND_URL through
-// `env` will crash the build/process if the variable is missing or malformed.
-// next.config.ts intentionally bypasses this (see that file for why).
+// Validated env facade. Importing this module triggers Zod validation at load
+// time. Server vars (BACKEND_URL) crash the build/process if missing or
+// malformed; client vars (NEXT_PUBLIC_SUPABASE_*) fail the same way at the
+// client bundle level. next.config.ts intentionally bypasses this (see that
+// file for why).
 import { createEnv } from "@t3-oss/env-nextjs";
 import { z } from "zod";
 

--- a/frontend/src/env.ts
+++ b/frontend/src/env.ts
@@ -9,9 +9,14 @@ export const env = createEnv({
   server: {
     BACKEND_URL: z.string().url(),
   },
-  client: {},
+  client: {
+    NEXT_PUBLIC_SUPABASE_URL: z.string().url(),
+    NEXT_PUBLIC_SUPABASE_ANON_KEY: z.string().min(20),
+  },
   runtimeEnv: {
     BACKEND_URL: process.env.BACKEND_URL,
+    NEXT_PUBLIC_SUPABASE_URL: process.env.NEXT_PUBLIC_SUPABASE_URL,
+    NEXT_PUBLIC_SUPABASE_ANON_KEY: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
   },
   emptyStringAsUndefined: true,
 });

--- a/frontend/src/lib/apollo/auth-link.ts
+++ b/frontend/src/lib/apollo/auth-link.ts
@@ -1,0 +1,27 @@
+"use client";
+
+import { setContext } from "@apollo/client/link/context";
+import { createSupabaseBrowserClient } from "@/lib/supabase/client";
+
+// buildAuthHeaders is exported for unit-testability (Option A-variant: sibling file).
+export async function buildAuthHeaders(
+  headers: Record<string, string> = {},
+): Promise<Record<string, string>> {
+  try {
+    const supabase = createSupabaseBrowserClient();
+    const {
+      data: { session },
+    } = await supabase.auth.getSession();
+    if (!session?.access_token) return headers;
+    return { ...headers, authorization: `Bearer ${session.access_token}` };
+  } catch {
+    // Fail open: if Supabase can't return a session, send the request
+    // anonymously and let the backend decide.
+    // PR7 will treat missing Authorization as anonymous.
+    return headers;
+  }
+}
+
+export const authLink = setContext(async (_, { headers }) => ({
+  headers: await buildAuthHeaders(headers as Record<string, string>),
+}));

--- a/frontend/src/lib/apollo/auth-link.ts
+++ b/frontend/src/lib/apollo/auth-link.ts
@@ -3,25 +3,26 @@
 import { setContext } from "@apollo/client/link/context";
 import { createSupabaseBrowserClient } from "@/lib/supabase/client";
 
-// buildAuthHeaders is exported for unit-testability (Option A-variant: sibling file).
+// Exported separately so tests can call it directly without going through the Apollo link machinery.
 export async function buildAuthHeaders(
-  headers: Record<string, string> = {},
+  headers: Record<string, string> | undefined = {},
 ): Promise<Record<string, string>> {
+  const base = headers ?? {};
   try {
     const supabase = createSupabaseBrowserClient();
     const {
       data: { session },
     } = await supabase.auth.getSession();
-    if (!session?.access_token) return headers;
-    return { ...headers, authorization: `Bearer ${session.access_token}` };
-  } catch {
-    // Fail open: if Supabase can't return a session, send the request
-    // anonymously and let the backend decide.
-    // PR7 will treat missing Authorization as anonymous.
-    return headers;
+    if (!session?.access_token) return base;
+    return { ...base, authorization: `Bearer ${session.access_token}` };
+  } catch (err) {
+    // Fail open: if Supabase can't return a session, send the request anonymously
+    // and let the backend decide. The backend treats missing Authorization as anonymous.
+    console.warn("[authLink] getSession() failed, proceeding anonymously:", err);
+    return base;
   }
 }
 
 export const authLink = setContext(async (_, { headers }) => ({
-  headers: await buildAuthHeaders(headers as Record<string, string>),
+  headers: await buildAuthHeaders(headers as Record<string, string> | undefined),
 }));

--- a/frontend/src/lib/apollo/auth-link.ts
+++ b/frontend/src/lib/apollo/auth-link.ts
@@ -5,24 +5,23 @@ import { createSupabaseBrowserClient } from "@/lib/supabase/client";
 
 // Exported separately so tests can call it directly without going through the Apollo link machinery.
 export async function buildAuthHeaders(
-  headers: Record<string, string> | undefined = {},
+  headers: Record<string, string> = {},
 ): Promise<Record<string, string>> {
-  const base = headers ?? {};
   try {
     const supabase = createSupabaseBrowserClient();
     const {
       data: { session },
     } = await supabase.auth.getSession();
-    if (!session?.access_token) return base;
-    return { ...base, authorization: `Bearer ${session.access_token}` };
+    if (!session?.access_token) return headers;
+    return { ...headers, authorization: `Bearer ${session.access_token}` };
   } catch (err) {
     // Fail open: if Supabase can't return a session, send the request anonymously
     // and let the backend decide. The backend treats missing Authorization as anonymous.
     console.warn("[authLink] getSession() failed, proceeding anonymously:", err);
-    return base;
+    return headers;
   }
 }
 
 export const authLink = setContext(async (_, { headers }) => ({
-  headers: await buildAuthHeaders(headers as Record<string, string> | undefined),
+  headers: await buildAuthHeaders(headers as Record<string, string>),
 }));

--- a/frontend/src/lib/apollo/client.test.ts
+++ b/frontend/src/lib/apollo/client.test.ts
@@ -1,0 +1,46 @@
+// Testing strategy: Option A-variant — buildAuthHeaders is extracted to auth-link.ts
+// and tested directly, avoiding the complexity of the Apollo Link Observable API.
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { buildAuthHeaders } from "./auth-link";
+
+const mockGetSession = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({ data: { session: null }, error: null }),
+);
+
+vi.mock("@/lib/supabase/client", () => ({
+  createSupabaseBrowserClient: vi.fn().mockReturnValue({
+    auth: { getSession: mockGetSession },
+  }),
+}));
+
+describe("buildAuthHeaders (authLink)", () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it("attaches Bearer token when getSession returns an access_token", async () => {
+    mockGetSession.mockResolvedValueOnce({
+      data: { session: { access_token: "tok_abc123" } },
+    });
+
+    const result = await buildAuthHeaders({ "content-type": "application/json" });
+
+    expect(result.authorization).toBe("Bearer tok_abc123");
+    expect(result["content-type"]).toBe("application/json");
+  });
+
+  it("omits authorization header when getSession returns no session", async () => {
+    mockGetSession.mockResolvedValueOnce({ data: { session: null } });
+
+    const result = await buildAuthHeaders({});
+
+    expect(result.authorization).toBeUndefined();
+  });
+
+  it("fails open when getSession rejects — request proceeds with no authorization header", async () => {
+    mockGetSession.mockRejectedValueOnce(new Error("network error"));
+
+    const result = await buildAuthHeaders({ "x-custom": "keep" });
+
+    expect(result.authorization).toBeUndefined();
+    expect(result["x-custom"]).toBe("keep");
+  });
+});

--- a/frontend/src/lib/apollo/client.ts
+++ b/frontend/src/lib/apollo/client.ts
@@ -1,14 +1,17 @@
 "use client";
 
-import { HttpLink } from "@apollo/client";
+import { from, HttpLink } from "@apollo/client";
 import { ApolloClient, InMemoryCache } from "@apollo/client-integration-nextjs";
+import { authLink } from "./auth-link";
+
+const httpLink = new HttpLink({
+  uri: "/api/graphql",
+  fetchOptions: { cache: "no-store" },
+});
 
 export function makeClient() {
   return new ApolloClient({
     cache: new InMemoryCache(),
-    link: new HttpLink({
-      uri: "/api/graphql",
-      fetchOptions: { cache: "no-store" },
-    }),
+    link: from([authLink, httpLink]),
   });
 }

--- a/frontend/src/lib/apollo/server.ts
+++ b/frontend/src/lib/apollo/server.ts
@@ -1,4 +1,5 @@
 import "server-only";
+// TODO(PR9): forward auth token via createSupabaseServerClient(cookies()) when `me` query lands.
 import type { TypedDocumentNode } from "@apollo/client";
 import { print } from "graphql";
 import { env } from "@/env";

--- a/frontend/src/lib/apollo/server.ts
+++ b/frontend/src/lib/apollo/server.ts
@@ -1,5 +1,5 @@
 import "server-only";
-// TODO(PR9): forward auth token via createSupabaseServerClient(cookies()) when `me` query lands.
+// TODO(PR9): forward auth token via createSupabaseServerClient() when `me` query lands.
 import type { TypedDocumentNode } from "@apollo/client";
 import { print } from "graphql";
 import { env } from "@/env";

--- a/frontend/src/lib/supabase/client.ts
+++ b/frontend/src/lib/supabase/client.ts
@@ -1,0 +1,8 @@
+"use client";
+
+import { createBrowserClient } from "@supabase/ssr";
+import { env } from "@/env";
+
+export function createSupabaseBrowserClient() {
+  return createBrowserClient(env.NEXT_PUBLIC_SUPABASE_URL, env.NEXT_PUBLIC_SUPABASE_ANON_KEY);
+}

--- a/frontend/src/lib/supabase/middleware.test.ts
+++ b/frontend/src/lib/supabase/middleware.test.ts
@@ -1,0 +1,67 @@
+import { NextRequest, NextResponse } from "next/server";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { updateSession } from "./middleware";
+
+const mockGetUser = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({ data: { user: null }, error: null }),
+);
+
+vi.mock("@supabase/ssr", () => ({
+  createServerClient: vi.fn().mockReturnValue({
+    auth: { getUser: mockGetUser },
+  }),
+}));
+
+function makeRequest(url = "http://localhost/", cookies: Record<string, string> = {}) {
+  const req = new NextRequest(new URL(url));
+  for (const [name, value] of Object.entries(cookies)) {
+    req.cookies.set(name, value);
+  }
+  return req;
+}
+
+describe("updateSession", () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it("calls auth.getUser() exactly once", async () => {
+    await updateSession(makeRequest());
+    expect(mockGetUser).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns a NextResponse instance in the pass-through (no session) case", async () => {
+    const response = await updateSession(makeRequest());
+    expect(response).toBeInstanceOf(NextResponse);
+  });
+
+  it("carries request cookies into response cookies when setAll is invoked by the SDK", async () => {
+    const { createServerClient } = await import("@supabase/ssr");
+    vi.mocked(createServerClient).mockImplementationOnce(
+      // biome-ignore lint/suspicious/noExplicitAny: test-only cast to drive setAll
+      (_url, _key, opts: any) => {
+        // Simulate SDK calling setAll to persist refreshed auth cookies
+        opts.cookies.setAll([{ name: "sb-auth-token", value: "refreshed", options: {} }]);
+        // biome-ignore lint/suspicious/noExplicitAny: test-only stub return
+        return { auth: { getUser: mockGetUser } } as any;
+      },
+    );
+
+    const response = await updateSession(
+      makeRequest("http://localhost/", { "sb-auth-token": "old" }),
+    );
+    expect(response.cookies.get("sb-auth-token")?.value).toBe("refreshed");
+  });
+
+  it("returns a valid response for any request path", async () => {
+    const response = await updateSession(makeRequest("http://localhost/dashboard"));
+    expect(response).toBeInstanceOf(NextResponse);
+    expect(mockGetUser).toHaveBeenCalledTimes(1);
+  });
+
+  it("handles requests with pre-existing cookies without mutating them unexpectedly", async () => {
+    const req = makeRequest("http://localhost/", { "existing-cookie": "stays" });
+    const response = await updateSession(req);
+    expect(response).toBeInstanceOf(NextResponse);
+    // No new cookies were set by the mock SDK, so response cookies should be empty
+    expect(response.cookies.get("existing-cookie")).toBeUndefined();
+  });
+});

--- a/frontend/src/lib/supabase/middleware.ts
+++ b/frontend/src/lib/supabase/middleware.ts
@@ -28,7 +28,11 @@ export async function updateSession(request: NextRequest) {
 
   // CRITICAL: getUser() is what triggers token refresh — removing this call
   // silently breaks session renewal, leaving users with expired tokens.
-  await supabase.auth.getUser();
+  const { error } = await supabase.auth.getUser();
+  if (error) {
+    // Surface to edge-runtime stderr; failure here is anonymous-pass-through, not auth bug
+    console.error("[supabase/middleware] getUser() failed:", error.message);
+  }
 
   return supabaseResponse;
 }

--- a/frontend/src/lib/supabase/middleware.ts
+++ b/frontend/src/lib/supabase/middleware.ts
@@ -1,0 +1,34 @@
+import { createServerClient } from "@supabase/ssr";
+import { type NextRequest, NextResponse } from "next/server";
+import { env } from "@/env";
+
+export async function updateSession(request: NextRequest) {
+  let supabaseResponse = NextResponse.next({ request });
+
+  const supabase = createServerClient(
+    env.NEXT_PUBLIC_SUPABASE_URL,
+    env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+    {
+      cookies: {
+        getAll() {
+          return request.cookies.getAll();
+        },
+        setAll(cookiesToSet) {
+          for (const { name, value } of cookiesToSet) {
+            request.cookies.set(name, value);
+          }
+          supabaseResponse = NextResponse.next({ request });
+          for (const { name, value, options } of cookiesToSet) {
+            supabaseResponse.cookies.set(name, value, options);
+          }
+        },
+      },
+    },
+  );
+
+  // CRITICAL: getUser() is what triggers token refresh — removing this call
+  // silently breaks session renewal, leaving users with expired tokens.
+  await supabase.auth.getUser();
+
+  return supabaseResponse;
+}

--- a/frontend/src/lib/supabase/server.test.ts
+++ b/frontend/src/lib/supabase/server.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createSupabaseServerClient } from "./server";
+
+// Shared spy captured by vi.hoisted so mock factories can reference it
+const mockCookieStore = vi.hoisted(() => ({
+  getAll: vi.fn().mockReturnValue([]),
+  set: vi.fn(),
+}));
+
+vi.mock("next/headers", () => ({
+  cookies: vi.fn().mockResolvedValue(mockCookieStore),
+}));
+
+// Capture the options passed to createServerClient so tests can invoke callbacks
+let capturedOptions: {
+  cookies: {
+    getAll: () => unknown;
+    setAll: (c: { name: string; value: string; options: object }[]) => void;
+  };
+} | null = null;
+
+vi.mock("@supabase/ssr", () => ({
+  createServerClient: vi
+    .fn()
+    .mockImplementation((_url: string, _key: string, opts: typeof capturedOptions) => {
+      capturedOptions = opts;
+      return {};
+    }),
+}));
+
+describe("createSupabaseServerClient", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    // Reset any one-off implementations so subsequent tests start clean
+    mockCookieStore.set.mockReset();
+    capturedOptions = null;
+  });
+
+  it("does NOT propagate exceptions thrown by cookieStore.set (silent-swallow contract)", async () => {
+    mockCookieStore.set.mockImplementation(() => {
+      throw new Error("read-only in Server Component");
+    });
+
+    await createSupabaseServerClient();
+
+    expect(capturedOptions).not.toBeNull();
+    // Calling setAll must not throw even though cookieStore.set throws
+    expect(() =>
+      capturedOptions?.cookies.setAll([{ name: "sb-token", value: "x", options: {} }]),
+    ).not.toThrow();
+  });
+
+  it("invokes cookieStore.set for each entry when set does NOT throw", async () => {
+    await createSupabaseServerClient();
+
+    expect(capturedOptions).not.toBeNull();
+    const entries = [
+      { name: "sb-access-token", value: "abc", options: { path: "/" } },
+      { name: "sb-refresh-token", value: "def", options: { path: "/" } },
+    ];
+    capturedOptions?.cookies.setAll(entries);
+
+    expect(mockCookieStore.set).toHaveBeenCalledTimes(2);
+    expect(mockCookieStore.set).toHaveBeenNthCalledWith(1, "sb-access-token", "abc", {
+      path: "/",
+    });
+    expect(mockCookieStore.set).toHaveBeenNthCalledWith(2, "sb-refresh-token", "def", {
+      path: "/",
+    });
+  });
+
+  it("delegates getAll to cookieStore.getAll", async () => {
+    mockCookieStore.getAll.mockReturnValueOnce([{ name: "session", value: "s1" }]);
+    await createSupabaseServerClient();
+
+    const result = capturedOptions?.cookies.getAll();
+    expect(result).toEqual([{ name: "session", value: "s1" }]);
+    expect(mockCookieStore.getAll).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/lib/supabase/server.ts
+++ b/frontend/src/lib/supabase/server.ts
@@ -1,0 +1,23 @@
+import { createServerClient } from "@supabase/ssr";
+import { cookies } from "next/headers";
+import { env } from "@/env";
+
+export async function createSupabaseServerClient() {
+  const cookieStore = await cookies();
+  return createServerClient(env.NEXT_PUBLIC_SUPABASE_URL, env.NEXT_PUBLIC_SUPABASE_ANON_KEY, {
+    cookies: {
+      getAll() {
+        return cookieStore.getAll();
+      },
+      setAll(cookiesToSet) {
+        try {
+          for (const { name, value, options } of cookiesToSet) {
+            cookieStore.set(name, value, options);
+          }
+        } catch {
+          // Server Components cannot set cookies — handled by middleware refresh path.
+        }
+      },
+    },
+  });
+}

--- a/frontend/src/lib/supabase/server.ts
+++ b/frontend/src/lib/supabase/server.ts
@@ -15,7 +15,10 @@ export async function createSupabaseServerClient() {
             cookieStore.set(name, value, options);
           }
         } catch {
-          // Server Components cannot set cookies — handled by middleware refresh path.
+          // next/headers cookies() is read-only when called from Server Component renders
+          // (Next.js restriction). Middleware handles token refresh in its own mutable
+          // response context. Route Handlers should not throw here; if they do this
+          // catch hides a real failure — diagnose via the route's own error path.
         }
       },
     },

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -1,0 +1,10 @@
+import type { NextRequest } from "next/server";
+import { updateSession } from "@/lib/supabase/middleware";
+
+export async function middleware(request: NextRequest) {
+  return updateSession(request);
+}
+
+export const config = {
+  matcher: ["/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)"],
+};

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -6,5 +6,7 @@ export async function middleware(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ["/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)"],
+  matcher: [
+    "/((?!api|auth/callback|_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
+  ],
 };

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -15,6 +15,9 @@ export default defineConfig({
     include: ["src/**/*.test.ts"],
     env: {
       BACKEND_URL: "http://localhost:1323",
+      NEXT_PUBLIC_SUPABASE_URL: "http://localhost:54321",
+      NEXT_PUBLIC_SUPABASE_ANON_KEY:
+        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.vitest-dummy-key-1234567890",
     },
     coverage: {
       provider: "v8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,9 +16,27 @@ importers:
       '@apollo/client-integration-nextjs':
         specifier: ^0.14.5
         version: 0.14.5(@apollo/client@4.1.9(graphql-ws@6.0.8(graphql@16.13.2)(ws@8.20.0))(graphql@16.13.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rxjs@7.8.2))(@types/react@19.2.0)(graphql@16.13.2)(next@16.2.4(@babel/core@7.29.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rxjs@7.8.2)
+      '@hookform/resolvers':
+        specifier: ^5.2.2
+        version: 5.2.2(react-hook-form@7.73.1(react@19.2.0))
+      '@radix-ui/react-label':
+        specifier: ^2.1.8
+        version: 2.1.8(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-slot':
+        specifier: ^1.2.4
+        version: 1.2.4(@types/react@19.2.0)(react@19.2.0)
+      '@supabase/ssr':
+        specifier: ^0.10.2
+        version: 0.10.2(@supabase/supabase-js@2.104.1)
+      '@supabase/supabase-js':
+        specifier: ^2.104.1
+        version: 2.104.1
       '@t3-oss/env-nextjs':
         specifier: 0.12.0
         version: 0.12.0(typescript@5.9.3)(zod@3.24.2)
+      class-variance-authority:
+        specifier: ^0.7.1
+        version: 0.7.1
       graphql:
         specifier: ^16.13.2
         version: 16.13.2
@@ -31,6 +49,9 @@ importers:
       react-dom:
         specifier: 19.2.0
         version: 19.2.0(react@19.2.0)
+      react-hook-form:
+        specifier: ^7.73.1
+        version: 7.73.1(react@19.2.0)
       zod:
         specifier: 3.24.2
         version: 3.24.2
@@ -528,6 +549,11 @@ packages:
     peerDependencies:
       graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
 
+  '@hookform/resolvers@5.2.2':
+    resolution: {integrity: sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==}
+    peerDependencies:
+      react-hook-form: ^7.55.0
+
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
     engines: {node: '>=18'}
@@ -887,6 +913,50 @@ packages:
   '@oxc-project/types@0.127.0':
     resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
 
+  '@radix-ui/react-compose-refs@1.1.2':
+    resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-label@2.1.8':
+    resolution: {integrity: sha512-FmXs37I6hSBVDlO4y764TNz1rLgKwjJMQ0EGte6F3Cb3f4bIuHB/iLa/8I9VKkmOy+gNHq8rql3j686ACVV21A==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-primitive@2.1.4':
+    resolution: {integrity: sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-slot@1.2.4':
+    resolution: {integrity: sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@repeaterjs/repeater@3.0.6':
     resolution: {integrity: sha512-Javneu5lsuhwNCryN+pXH93VPQ8g0dBX7wItHFgYiwQmzE1sVdg5tWHiOgHywzL2W21XQopa7IwIEnNbmeUJYA==}
 
@@ -984,6 +1054,41 @@ packages:
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@standard-schema/utils@0.3.0':
+    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
+
+  '@supabase/auth-js@2.104.1':
+    resolution: {integrity: sha512-pqFnDKekq1isqlqnzqzyJ3mzmho+o+FjfVTqhKY3PFlwj2anx3OPznO1kbo1ZEwD8zg1r4EAFf/7pplLyX0ocQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/functions-js@2.104.1':
+    resolution: {integrity: sha512-JjAH4JN9rZzxh4plQnILPrQZXAG6ccoRS6z9hQAGmXpRSwJA+7CWbsDV2R82I8MROlGDsjqj1Ot/cWpTfdf6xg==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/phoenix@0.4.0':
+    resolution: {integrity: sha512-RHSx8bHS02xwfHdAbX5Lpbo6PXbgyf7lTaXTlwtFDPwOIw64NnVRwFAXGojHhjtVYI+PEPNSWwkL90f4agN3bw==}
+
+  '@supabase/postgrest-js@2.104.1':
+    resolution: {integrity: sha512-RqlLpvgXsjcc27fLyHNGm3zN0KDWXbkdTdaFtaEdX83RsTEqH7BAmshH7zoUMml5lL04naUeRjS3B81O6jZcJw==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/realtime-js@2.104.1':
+    resolution: {integrity: sha512-dVJHhFB2ErBd0/2qE9G8CedCrGoAtBfL9Q4zbSMXO7b1Cpld916ljSiX21mURUqijPf1WoPQG4Bp/averUzk/g==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/ssr@0.10.2':
+    resolution: {integrity: sha512-JFbchN63CXLFHJRNT7udec4/RoD9PmXkSGko3QSO6vUuqGBtSzdmxR7FPfQNr7SuFd65I7Xv46q66ALjEN1cgQ==}
+    peerDependencies:
+      '@supabase/supabase-js': ^2.102.1
+
+  '@supabase/storage-js@2.104.1':
+    resolution: {integrity: sha512-2bQaLbkRshctkUVuqamwYZDEd+0cGSc9DY9sjh92DcA5hu1F/1AP8p6gxGr76sgdK9Ngi0rh+2Kdh+uC4hcnGA==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/supabase-js@2.104.1':
+    resolution: {integrity: sha512-E0H/CtVmaGjiAy+ieZ5ZB/1EqxXcGdaFaAc23AE5zaYfz6NtCNDcmaEdoGPYMPFH5pE6drGG6e3ljPmkFoGVxQ==}
+    engines: {node: '>=20.0.0'}
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
@@ -1290,6 +1395,9 @@ packages:
   chardet@2.1.1:
     resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
 
+  class-variance-authority@0.7.1:
+    resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
+
   cli-cursor@5.0.0:
     resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
     engines: {node: '>=18'}
@@ -1332,6 +1440,10 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
 
   cosmiconfig@8.3.6:
     resolution: {integrity: sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==}
@@ -1542,6 +1654,10 @@ packages:
 
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
+  iceberg-js@0.8.1:
+    resolution: {integrity: sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==}
+    engines: {node: '>=20.0.0'}
 
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
@@ -1939,6 +2055,12 @@ packages:
     resolution: {integrity: sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==}
     peerDependencies:
       react: ^19.2.0
+
+  react-hook-form@7.73.1:
+    resolution: {integrity: sha512-VAfVYOPcx3piiEVQy95vyFmBwbVUsP/AUIN+mpFG8h11yshDd444nn0VyfaGWSRnhOLVgiDu7HIuBtAIzxn9dA==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18 || ^19
 
   react@19.2.0:
     resolution: {integrity: sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==}
@@ -2961,6 +3083,11 @@ snapshots:
     dependencies:
       graphql: 16.13.2
 
+  '@hookform/resolvers@5.2.2(react-hook-form@7.73.1(react@19.2.0))':
+    dependencies:
+      '@standard-schema/utils': 0.3.0
+      react-hook-form: 7.73.1(react@19.2.0)
+
   '@img/colour@1.1.0':
     optional: true
 
@@ -3249,6 +3376,37 @@ snapshots:
 
   '@oxc-project/types@0.127.0': {}
 
+  '@radix-ui/react-compose-refs@1.1.2(@types/react@19.2.0)(react@19.2.0)':
+    dependencies:
+      react: 19.2.0
+    optionalDependencies:
+      '@types/react': 19.2.0
+
+  '@radix-ui/react-label@2.1.8(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.2.0
+      '@types/react-dom': 19.2.0(@types/react@19.2.0)
+
+  '@radix-ui/react-primitive@2.1.4(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/react-slot': 1.2.4(@types/react@19.2.0)(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.2.0
+      '@types/react-dom': 19.2.0(@types/react@19.2.0)
+
+  '@radix-ui/react-slot@1.2.4(@types/react@19.2.0)(react@19.2.0)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.0)(react@19.2.0)
+      react: 19.2.0
+    optionalDependencies:
+      '@types/react': 19.2.0
+
   '@repeaterjs/repeater@3.0.6': {}
 
   '@rolldown/binding-android-arm64@1.0.0-rc.17':
@@ -3303,6 +3461,53 @@ snapshots:
   '@rolldown/pluginutils@1.0.0-rc.17': {}
 
   '@standard-schema/spec@1.1.0': {}
+
+  '@standard-schema/utils@0.3.0': {}
+
+  '@supabase/auth-js@2.104.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/functions-js@2.104.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/phoenix@0.4.0': {}
+
+  '@supabase/postgrest-js@2.104.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/realtime-js@2.104.1':
+    dependencies:
+      '@supabase/phoenix': 0.4.0
+      '@types/ws': 8.18.1
+      tslib: 2.8.1
+      ws: 8.20.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@supabase/ssr@0.10.2(@supabase/supabase-js@2.104.1)':
+    dependencies:
+      '@supabase/supabase-js': 2.104.1
+      cookie: 1.1.1
+
+  '@supabase/storage-js@2.104.1':
+    dependencies:
+      iceberg-js: 0.8.1
+      tslib: 2.8.1
+
+  '@supabase/supabase-js@2.104.1':
+    dependencies:
+      '@supabase/auth-js': 2.104.1
+      '@supabase/functions-js': 2.104.1
+      '@supabase/postgrest-js': 2.104.1
+      '@supabase/realtime-js': 2.104.1
+      '@supabase/storage-js': 2.104.1
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   '@swc/helpers@0.5.15':
     dependencies:
@@ -3611,6 +3816,10 @@ snapshots:
 
   chardet@2.1.1: {}
 
+  class-variance-authority@0.7.1:
+    dependencies:
+      clsx: 2.1.1
+
   cli-cursor@5.0.0:
     dependencies:
       restore-cursor: 5.1.0
@@ -3649,6 +3858,8 @@ snapshots:
       upper-case: 2.0.2
 
   convert-source-map@2.0.0: {}
+
+  cookie@1.1.1: {}
 
   cosmiconfig@8.3.6(typescript@5.9.3):
     dependencies:
@@ -3828,6 +4039,8 @@ snapshots:
       tslib: 2.8.1
 
   html-escaper@2.0.2: {}
+
+  iceberg-js@0.8.1: {}
 
   iconv-lite@0.7.2:
     dependencies:
@@ -4193,6 +4406,10 @@ snapshots:
     dependencies:
       react: 19.2.0
       scheduler: 0.27.0
+
+  react-hook-form@7.73.1(react@19.2.0):
+    dependencies:
+      react: 19.2.0
 
   react@19.2.0: {}
 

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,0 +1,77 @@
+# Supabase configuration for flamingo-armond
+# Reference: https://supabase.com/docs/guides/local-development/cli/config
+
+project_id = "flamingo-armond"
+account_id = ""
+
+[api]
+port = 54321
+schemas = ["public", "graphql_public"]
+extra_search_path = ["public", "extensions"]
+max_rows = 1000
+
+[db]
+port = 54322
+major_version = 15
+dialect = "postgresql"
+seed_file_path = "./supabase/seed.sql"
+queued_tables_publisher_attempt_interval_millis = 100
+
+[realtime]
+enabled = true
+max_bytes_per_second = 1048576
+rateLimiters = []
+
+[studio]
+port = 54323
+enabled = true
+
+[inbucket]
+enabled = true
+port = 54324
+smtp_port = 54325
+pop3_port = 54326
+tls_enabled = false
+
+[auth]
+enabled = true
+port = 54321
+site_url = "http://127.0.0.1:3000"
+additional_redirect_urls = ["http://127.0.0.1:3000/auth/callback"]
+jwt_expiry = 3600
+enable_signup = true
+enable_anonymous_sign_ins = false
+password_min_length = 6
+
+[auth.external.google]
+enabled = true
+client_id = "env(SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID)"
+secret = "env(SUPABASE_AUTH_EXTERNAL_GOOGLE_SECRET)"
+redirect_uri = "http://127.0.0.1:54321/auth/v1/callback"
+skip_nonce_check = false
+
+[storage]
+file_size_limit = 52428800
+s3_host = "http://127.0.0.1:54321"
+s3_protocol = "http"
+s3_region = "local"
+s3_access_key = "625729a08b95bf1b7ff351a20b2a"
+s3_secret_key = "850181e4652dd023e1d3e3ba73d7ca668382c9245fe236bfa5fcf965f0f17266"
+s3_bucket = "stub"
+public_url = ""
+
+[functions]
+port = 54321
+docker_image = ""
+verify_jwt = true
+
+[analytics]
+enabled = false
+port = 54327
+vector_port = 54328
+api_domain = ""
+
+[logs]
+vector_enabled = true
+vector_port = 54329
+use_jemalloc = true

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -37,7 +37,10 @@ tls_enabled = false
 enabled = true
 port = 54321
 site_url = "http://127.0.0.1:3000"
-additional_redirect_urls = ["http://127.0.0.1:3000/auth/callback"]
+additional_redirect_urls = [
+  "http://127.0.0.1:3000/auth/callback",
+  "http://localhost:3000/auth/callback",
+]
 jwt_expiry = 3600
 enable_signup = true
 enable_anonymous_sign_ins = false


### PR DESCRIPTION
Closes #7

## Summary

Brings the `frontend/` workspace from anonymous-only to fully authenticated: a 3-layer `@supabase/ssr` client setup (browser / server / middleware) handles the cookie shape Supabase expects across each Next.js execution context, a `/auth/callback` Route Handler completes the OAuth code exchange, a `/login` page drives the Google OAuth flow, and `Header` / `LogoutButton` give signed-in users an `email + Logout` chrome. Apollo's browser-side link chain gains an `authLink` that pulls the access token from `supabase.auth.getSession()` and attaches `Authorization: Bearer <jwt>` per request. RSC token forwarding is intentionally deferred to PR9 (the only RSC query today is `{ health }`). `supabase/config.toml` plus `docs/dev-setup.md` capture the local-dev contract (`supabase start` on `127.0.0.1:54321`, Google OAuth via `env()` placeholders), and `docs/frontend.md` documents the seven non-obvious traps we hit landing this.

## Background / Motivation

- PR #16 wired Apollo browser + RSC paths but assumed every request was anonymous — `httpLink` posts to `/api/graphql` with no `Authorization` header. PR7 (backend JWT verification, issue #8) needs the frontend to actually *send* a bearer token before its middleware has anything to validate against, so authLink has to land first.
- `@supabase/ssr` cookie reading/writing differs by Next.js execution context: browser (`document.cookie`), server components / route handlers (`next/headers cookies()`), and middleware (`NextRequest.cookies` / `NextResponse.cookies`). A single shared client cannot cover all three — collapsing them silently breaks token refresh in whichever context's cookie API was wrong. The official template publishes three separate factories for this reason; we mirror it.
- Supabase's middleware contract requires calling `supabase.auth.getUser()` on every request even if the result is discarded — *that* call is what triggers internal token refresh. Skipping it leaves users with expired tokens that the rest of the app cannot tell apart from a legitimately logged-out state.
- Google OAuth's redirect URI verification treats `localhost` and `127.0.0.1` as separate origins. `supabase start` prints `127.0.0.1:54321`, so the whole local-dev story has to align on `127.0.0.1`. Mixing the two surfaces as `redirect_uri_mismatch` only after the Google round-trip — too late to be obvious.
- `WHATWG URL` accepts absolute URLs and protocol-relative paths even when given a base-URL argument, and special-scheme parsers normalize `\` → `/`. A naive `next.startsWith("/")` guard on the `/auth/callback ?next=` parameter is an open redirect — `next=//evil.com` and `next=/\evil.com` both bypass it. The guard has to reject `//`-prefixed and `\\`-containing values explicitly.
- `frontend/src/env.ts` validates required vars at *build* time via `@t3-oss/env-nextjs`, including the new `NEXT_PUBLIC_SUPABASE_*` client vars. Missing values fail `next build` rather than emitting a runtime warning. CI must therefore inject dummy values that satisfy the Zod schemas (URL shape, min length 20) at the job level — without them, `pnpm --filter frontend build` exits non-zero on a clean runner.
- `next/headers cookies()` returns a read-only store inside Server Component renders but a writable store inside Route Handlers. The shared `createSupabaseServerClient` factory handles both call sites; the silent-swallow `try/catch` in `setAll` is correct for the Server Component path but invisibly hides genuine failures inside Route Handlers. Future contributors must not repurpose this factory in contexts where a write failure must surface.
- `supabase.auth.getSession()` reads from local storage / cookies and is *not* an HTTP call, so per-request invocation from `authLink` is cheap. The `setContext` link composition runs once per outgoing operation, which is fine — but the link must be ordered *before* `httpLink` in `from([...])` because Apollo runs links left-to-right on the request side.

## Changes

### Dependency pins (`frontend/package.json`)

- Adds runtime deps: `@supabase/ssr ^0.10.2`, `@supabase/supabase-js ^2.104.1`, `@hookform/resolvers ^5.2.2`, `@radix-ui/react-label ^2.1.8`, `@radix-ui/react-slot ^1.2.4`, `class-variance-authority ^0.7.1`, `react-hook-form ^7.73.1`. The Radix + cva + react-hook-form set lands now to back the shadcn `button` / `input` / `label` / `form` primitives — `/login` is the first consumer; PR9 forms will reuse them.
- No new dev deps. `pnpm-lock.yaml` grows by ~217 lines, auto-collapsed in the PR diff via the `linguist-generated=true` attribute from PR #15.

### Supabase SSR factories (`frontend/src/lib/supabase/`)

- `client.ts` — `createSupabaseBrowserClient()` calls `createBrowserClient(env.NEXT_PUBLIC_SUPABASE_URL, env.NEXT_PUBLIC_SUPABASE_ANON_KEY)`. Tagged `"use client"`. Used by `LoginButton`, `LogoutButton`, and `authLink`.
- `server.ts` — `createSupabaseServerClient()` constructs `createServerClient` with `cookies.getAll` / `setAll` callbacks bound to `next/headers cookies()`. The `setAll` body wraps `cookieStore.set` in `try/catch` so Server Component renders (read-only context) do not throw; the catch is a documented contract, not error-eating. Used by `Header` (RSC) and `auth/callback/route.ts` (Route Handler).
- `middleware.ts` — `updateSession(request)` builds a Supabase client whose `cookies.setAll` mutates **both** `request.cookies` and the rebuilt `supabaseResponse.cookies` (necessary so downstream handlers see the refreshed cookies AND the browser receives the `Set-Cookie` header). Calls `supabase.auth.getUser()` exactly once to trigger token refresh; surfaces any error to edge stderr without short-circuiting the response (anonymous pass-through, not auth failure).

### Top-level middleware (`frontend/src/middleware.ts`)

- `middleware(request)` delegates to `updateSession(request)` and returns its `NextResponse`.
- `config.matcher` excludes `_next/static`, `_next/image`, `favicon.ico`, common image extensions, **and** `api` + `auth/callback`. The `api` exclusion is load-bearing — without it, every Apollo browser POST to `/api/graphql` would trigger a full Supabase token-refresh round-trip in middleware. The `auth/callback` exclusion prevents middleware cookie writes from racing the Route Handler's own `exchangeCodeForSession`.

### Apollo authLink (`frontend/src/lib/apollo/auth-link.ts`, `client.ts`)

- New `buildAuthHeaders(headers)` helper exported separately from the link itself — direct unit-testable pure function. Calls `createSupabaseBrowserClient().auth.getSession()`, returns `headers` unchanged if no session or no `access_token`, otherwise appends `authorization: Bearer <jwt>`. Wraps the call in `try/catch` and **fails open** (returns the original headers and logs to `console.warn`) when Supabase throws — backend treats missing `Authorization` as anonymous, so degraded auth never blocks the request.
- New `authLink = setContext(async (_, { headers }) => ({ headers: await buildAuthHeaders(headers) }))`.
- `client.ts` — `makeClient()` now composes `from([authLink, httpLink])` (link order matters: request-side runs left → right). `httpLink` URI / fetchOptions unchanged.
- `apollo/server.ts` — adds a `TODO(PR9)` marking the intended hook point for RSC token forwarding via `createSupabaseServerClient(cookies())`. No behavior change today.

### OAuth callback Route Handler (`frontend/src/app/auth/callback/route.ts`)

- `GET` reads `?code` and `?next` from the request URL, **safely** parses `next`: rejects values that do not start with `/`, that start with `//` (protocol-relative), or that contain `\` (URL-parser normalizes to `/`, opens a redirect bypass). Falls back to `/` on any of those.
- Missing `code` → `307 /login?error=missing_code`. `exchangeCodeForSession` failure → `307 /login?error=exchange_failed` and `console.error` for the underlying message. Success → `307 <safeNext>`.

### Login + logout chrome

- `src/app/login/page.tsx` — server component renders an `h1`, an inline `error` query-string banner if present, and the `<LoginButton />` client component.
- `src/app/login/login-button.tsx` — client component; `signInWithOAuth({ provider: \"google\", options: { redirectTo: \`\${window.location.origin}/auth/callback\` } })`. Logs failures via `console.error` (toast surface deferred until shadcn `Toaster` lands).
- `src/app/_components/header.tsx` — async server component; calls `createSupabaseServerClient().auth.getUser()`, renders `🦩 flamingo-armond` + either `<email> Logout` (when authenticated) or a `Sign in` link.
- `src/app/_components/logout-button.tsx` — client component; `signOut()` then `router.refresh()` to invalidate RSC caches.
- `src/app/layout.tsx` — wraps `{children}` with `<Providers>` (unchanged) and now renders `<Header />` above them.

### shadcn UI primitives (`frontend/src/components/ui/`)

- `button.tsx`, `input.tsx`, `label.tsx`, `form.tsx` — generated via `pnpm dlx shadcn add` against the `components.json` from PR #15. `form.tsx` re-exports `react-hook-form` `FormProvider` + `Controller` plus the contextual `FormField` / `FormItem` / `FormLabel` / `FormControl` / `FormDescription` / `FormMessage` wrappers shadcn ships. `/login`'s `LoginButton` is the only consumer in this PR; PR9 will use the form set.

### Local Supabase config (`supabase/config.toml`)

- `project_id = \"flamingo-armond\"`. `[api]` exposes `public` + `graphql_public` schemas on `:54321`. `[auth]` enables signup, sets `site_url = \"http://127.0.0.1:3000\"`, allows both `127.0.0.1:3000/auth/callback` and `localhost:3000/auth/callback` as additional redirect URLs (browser-side typing leniency — Supabase still validates against this list).
- `[auth.external.google]` is `enabled = true` with `client_id` / `secret` referencing `env(SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID)` / `env(SUPABASE_AUTH_EXTERNAL_GOOGLE_SECRET)` placeholders — actual values stay in gitignored `frontend/.env.local`. `redirect_uri = \"http://127.0.0.1:54321/auth/v1/callback\"` matches what `supabase start` prints.
- Studio on `:54323`, Inbucket SMTP capture on `:54324–:54326`, DB on `:54322` (`major_version = 15`).

### Env validation + CI

- `frontend/src/env.ts` — adds `NEXT_PUBLIC_SUPABASE_URL: z.string().url()` and `NEXT_PUBLIC_SUPABASE_ANON_KEY: z.string().min(20)` to the `client:` block; both wired into `runtimeEnv`. Top-of-file comment now documents the build-time validation contract for both server and client vars.
- `frontend/.env.example` — adds `NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321` and a placeholder `NEXT_PUBLIC_SUPABASE_ANON_KEY` (real value comes from `supabase start` output).
- `.github/workflows/frontend.yml` — adds `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY` to the job-level `env:` block (dummy values shaped to satisfy Zod). Without these the `Build` step fails at `next build` time with a Zod parse error.

### Tests (`frontend/src/lib/{supabase,apollo}/*.test.ts`, `app/auth/callback/route.test.ts`)

- `lib/supabase/middleware.test.ts` — five cases on `updateSession`: `getUser()` is called exactly once, returns a `NextResponse` in the no-session pass-through, propagates the SDK's `setAll` writes onto the response cookies, handles arbitrary request paths, and does not mutate pre-existing cookies that the SDK never touches.
- `lib/supabase/server.test.ts` — three cases on `createSupabaseServerClient`: silent-swallows when `cookieStore.set` throws (Server Component contract), invokes `cookieStore.set` once per entry when it does not throw, delegates `getAll` to the underlying `cookieStore.getAll`.
- `lib/apollo/client.test.ts` — three cases on `buildAuthHeaders`: attaches `Bearer <token>` when a session exists, omits the header when no session, and fails open (returns original headers, no throw) when `getSession` rejects.
- `app/auth/callback/route.test.ts` — seven cases on `GET /auth/callback`: happy-path code exchange + redirect to `/`, missing-code → `?error=missing_code`, exchange failure → `?error=exchange_failed`, `?next=/profile` deep-link honored, `?next=https://evil.com` falls back to `/`, `?next=//evil.com` falls back to `/`, `?next=/\\evil.com` (backslash) falls back to `/`.
- `vitest.config.ts` — adds `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY` to `test.env` so `src/env.ts` Zod parse does not crash at module load when Vitest imports any module that touches `@/env`.

### Docs

- `docs/frontend.md` — new **Auth (Supabase)** chapter covering the 3-layer client table, `authLink` semantics, the deferred RSC token-forwarding plan (PR9), the middleware cookie-rotation rule, and Gotchas for: `src/middleware.ts` location, Supabase cookie-name shape, `@supabase/ssr` mocking strategy in Vitest, the `127.0.0.1` vs `localhost` OAuth distinction, the read-only `setAll` swallow scoped to Server Components, and the open-redirect guard on `?next=`.
- `docs/dev-setup.md` — new **Supabase CLI** chapter (initial setup with Google OAuth client provisioning, `supabase start` first-run, `.env.local` population from CLI output, day-to-day commands, the `127.0.0.1` Gotcha).
- `docs/ci.md` — **Build-time env vars: server and client** table extended with the two `NEXT_PUBLIC_SUPABASE_*` rows and the rationale ("client vars are bundled at build time — missing = build failure").

### Housekeeping

- `.gitignore` — adds `supabase/.temp/`, `supabase/.branches/`, `supabase/.env`, and a placeholder `frontend/src/schemas/.gitkeep` so PR9's Zod schema directory has a stable home.

## Verification

Once merged:

- `supabase start` on a fresh checkout boots the local stack on `127.0.0.1:54321`; Studio at `127.0.0.1:54323` shows the `auth` schema with the Google provider enabled.
- With `cd backend && go run ./cmd/server` and `pnpm --filter frontend dev` running, visiting `http://127.0.0.1:3000` while logged out renders the `Header` with a `Sign in` link in the top-right. Clicking it lands on `/login`; clicking `Continue with Google` redirects through `accounts.google.com`, then back to `/auth/callback?code=...`, then to `/`.
- After the round-trip, `Header` re-renders with `<your-google-email> Logout` in the top-right. DevTools → Application → Cookies shows `sb-<project_ref>-auth-token` (and possibly `.0` / `.1` splits) on `127.0.0.1`.
- Opening DevTools → Network and triggering any client-originating Apollo request shows the request to `/api/graphql` carrying `Authorization: Bearer eyJ...` (the JWT from the cookie). Logging out via `Logout` removes the cookies; subsequent Apollo requests go out without the `Authorization` header.
- Typing `http://127.0.0.1:3000/auth/callback?code=valid&next=//evil.com` in the address bar redirects to `http://127.0.0.1:3000/` — never to `evil.com`. Same for `?next=https://evil.com` and `?next=/\\evil.com`.
- Frontend CI on `main` shows the existing `Install dependencies → Codegen → Biome check → TypeScript typecheck → Build → Vitest` order, all green; `Build` succeeds with the dummy `NEXT_PUBLIC_SUPABASE_*` env values from the workflow's job-level `env:` block.

## Test plan

- [ ] `pnpm install --frozen-lockfile` — resolves `@supabase/ssr`, `@supabase/supabase-js`, `@hookform/resolvers`, `react-hook-form`, `@radix-ui/*`, `class-variance-authority` against the committed lockfile.
- [ ] `pnpm --filter frontend codegen` — exits 0; no schema changes since PR #16.
- [ ] `pnpm --filter frontend lint` — Biome reports no errors; the new shadcn `form.tsx` honors the documented `noExplicitAny` exemptions.
- [ ] `pnpm --filter frontend typecheck` — exits 0 with the new `@supabase/ssr` types resolved and `src/components/ui/*` participating in the project tsconfig.
- [ ] `pnpm --filter frontend test` — all 18 cases pass (5 middleware + 3 server + 3 authLink + 7 callback route + the 6 pre-existing `gqlFetch` cases).
- [ ] `pnpm --filter frontend build` — succeeds with `BACKEND_URL`, `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY` set; **fails fast** with a Zod error mentioning the missing var when any of the three is unset (proves build-time validation is active for both server and client vars).
- [ ] End-to-end: provision a Google OAuth client (authorized JS origin `http://127.0.0.1:3000`, redirect URI `http://127.0.0.1:54321/auth/v1/callback`); export `SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID` / `_SECRET` in `frontend/.env.local`; `supabase start`; `pnpm --filter frontend dev`; sign in via `/login` — lands back on `/` with `<email> Logout` rendered in the header.
- [ ] DevTools Network: any Apollo client query (e.g. trigger one from a browser console `useQuery` hand-test) carries `Authorization: Bearer eyJ...` against `/api/graphql` after sign-in; the same query carries no `Authorization` header before sign-in or after `Logout`.
- [ ] Open-redirect guard: visiting `/auth/callback?code=valid&next=//evil.com`, `?next=https://evil.com`, and `?next=/%5Cevil.com` each redirects to `http://127.0.0.1:3000/` (never to `evil.com`). The covering Vitest cases (`falls back to /` x3) lock this in.
- [ ] Middleware contract: temporarily comment out `await supabase.auth.getUser()` in `lib/supabase/middleware.ts` — after ~1 hour the session silently expires (token never refreshed). Restore the call; session persists across page reloads. (Sanity-only; do NOT commit the comment.)
- [ ] `/api/graphql` excluded from middleware: with DevTools Network showing per-request timing, Apollo POSTs to `/api/graphql` should not show the ~50–100ms Supabase round-trip that other navigations show — confirms the `matcher` exclusion is honored.
- [ ] Regression: `cd backend && go test -v -race -covermode=atomic ./...` passes unchanged (no backend changes in this PR).
- [ ] Regression: a PR touching only `backend/` does NOT trigger frontend CI (paths filter intact from PR #15).
- [ ] Regression: `pnpm --filter frontend dev` with the backend down still surfaces the `gqlFetch` error from PR #16's RSC `{ health }` path in the Next dev overlay (no behavior change to the RSC code path).