### PR TITLE
feat(backend): Supabase JWT verification middleware on /query

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,9 @@
+# Server
+PORT=1323
+SHUTDOWN_TIMEOUT=25s
+
+# Supabase Auth (JWT verification, see docs/backend.md §Authentication)
+# All three are REQUIRED — server fails to start if any is missing.
+SUPABASE_JWKS_URL=http://127.0.0.1:54321/auth/v1/.well-known/jwks.json
+SUPABASE_JWT_AUDIENCE=authenticated
+SUPABASE_JWT_ISSUER=http://127.0.0.1:54321/auth/v1

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"os"
@@ -20,6 +21,7 @@ import (
 
 	"backend/graph/generated"
 	"backend/graph/resolver"
+	"backend/internal/auth"
 )
 
 const defaultShutdownTimeout = 25 * time.Second
@@ -32,7 +34,7 @@ func newGraphQLServer(r *resolver.Resolver) *handler.Server {
 	return srv
 }
 
-func newRouter(resolvers *resolver.Resolver) *echo.Echo {
+func newRouter(resolvers *resolver.Resolver, authMW echo.MiddlewareFunc) *echo.Echo {
 	e := echo.New()
 	e.Use(middleware.RequestLogger())
 	e.Use(middleware.Recover())
@@ -50,7 +52,8 @@ func newRouter(resolvers *resolver.Resolver) *echo.Echo {
 	})
 
 	gqlSrv := newGraphQLServer(resolvers)
-	e.POST("/query", echo.WrapHandler(gqlSrv))
+	q := e.Group("/query", authMW)
+	q.POST("", echo.WrapHandler(gqlSrv))
 	e.GET("/playground", echo.WrapHandler(playground.Handler("GraphQL", "/query")))
 
 	return e
@@ -76,8 +79,18 @@ func shutdownTimeout(logger *slog.Logger) time.Duration {
 }
 
 func run(ctx context.Context, logger *slog.Logger) error {
+	cfg, err := auth.ConfigFromEnv()
+	if err != nil {
+		return err
+	}
+	kf, err := auth.NewJWKSKeyfunc(ctx, cfg)
+	if err != nil {
+		return fmt.Errorf("run: %w", err)
+	}
+	authMW := auth.AuthMiddleware(kf, cfg)
+
 	resolvers := &resolver.Resolver{}
-	e := newRouter(resolvers)
+	e := newRouter(resolvers, authMW)
 	e.Logger = logger
 
 	port := os.Getenv("PORT")

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -87,7 +87,10 @@ func run(ctx context.Context, logger *slog.Logger) error {
 	if err != nil {
 		return fmt.Errorf("run: %w", err)
 	}
-	authMW := auth.AuthMiddleware(kf, cfg)
+	authMW, err := auth.AuthMiddleware(kf, cfg)
+	if err != nil {
+		return fmt.Errorf("run: %w", err)
+	}
 
 	resolvers := &resolver.Resolver{}
 	e := newRouter(resolvers, authMW)

--- a/backend/cmd/server/main_test.go
+++ b/backend/cmd/server/main_test.go
@@ -142,6 +142,17 @@ func TestRunGracefulShutdown(t *testing.T) {
 	}
 }
 
+func TestRun_FailsWhenJWKSURLMissing(t *testing.T) {
+	t.Setenv("SUPABASE_JWKS_URL", "")
+	t.Setenv("SUPABASE_JWT_AUDIENCE", "authenticated")
+	t.Setenv("SUPABASE_JWT_ISSUER", "http://issuer.test")
+
+	err := run(context.Background(), slog.New(slog.DiscardHandler))
+	if err == nil {
+		t.Fatal("expected run to fail when SUPABASE_JWKS_URL is empty")
+	}
+}
+
 func TestGraphQLHealth(t *testing.T) {
 	t.Parallel()
 	ts := newTestServer(t)

--- a/backend/cmd/server/main_test.go
+++ b/backend/cmd/server/main_test.go
@@ -12,12 +12,18 @@ import (
 	"testing"
 	"time"
 
+	"github.com/labstack/echo/v5"
+
 	"backend/graph/resolver"
 )
 
+func noopAuthMW(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(c *echo.Context) error { return next(c) }
+}
+
 func newTestServer(t *testing.T) *httptest.Server {
 	t.Helper()
-	ts := httptest.NewServer(newRouter(&resolver.Resolver{}))
+	ts := httptest.NewServer(newRouter(&resolver.Resolver{}, noopAuthMW))
 	t.Cleanup(ts.Close)
 	return ts
 }
@@ -100,6 +106,16 @@ func waitHealthy(t *testing.T, port string, timeout time.Duration) {
 }
 
 func TestRunGracefulShutdown(t *testing.T) {
+	tsJWKS := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"keys": []}`))
+	}))
+	defer tsJWKS.Close()
+
+	t.Setenv("SUPABASE_JWKS_URL", tsJWKS.URL)
+	t.Setenv("SUPABASE_JWT_AUDIENCE", "authenticated")
+	t.Setenv("SUPABASE_JWT_ISSUER", "http://issuer.test")
+
 	port := freePort(t)
 	t.Setenv("PORT", port)
 	t.Setenv("SHUTDOWN_TIMEOUT", "2s")

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -4,12 +4,15 @@ go 1.26.2
 
 require (
 	github.com/99designs/gqlgen v0.17.66
+	github.com/MicahParks/keyfunc/v3 v3.8.0
+	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/labstack/echo/v5 v5.1.0
 	github.com/vektah/gqlparser/v2 v2.5.22
 	golang.org/x/sync v0.20.0
 )
 
 require (
+	github.com/MicahParks/jwkset v0.11.0 // indirect
 	github.com/agnivade/levenshtein v1.2.0 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.5 // indirect
 	github.com/go-viper/mapstructure/v2 v2.2.1 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -1,5 +1,9 @@
 github.com/99designs/gqlgen v0.17.66 h1:2/SRc+h3115fCOZeTtsqrB5R5gTGm+8qCAwcrZa+CXA=
 github.com/99designs/gqlgen v0.17.66/go.mod h1:gucrb5jK5pgCKzAGuOMMVU9C8PnReecHEHd2UxLQwCg=
+github.com/MicahParks/jwkset v0.11.0 h1:yc0zG+jCvZpWgFDFmvs8/8jqqVBG9oyIbmBtmjOhoyQ=
+github.com/MicahParks/jwkset v0.11.0/go.mod h1:U2oRhRaLgDCLjtpGL2GseNKGmZtLs/3O7p+OZaL5vo0=
+github.com/MicahParks/keyfunc/v3 v3.8.0 h1:Hx2dgIjAXGk9slakM6rV9BOeaWDPEXXZ4Us8guNBfds=
+github.com/MicahParks/keyfunc/v3 v3.8.0/go.mod h1:z66bkCviwqfg2YUp+Jcc/xRE9IXLcMq6DrgV/+Htru0=
 github.com/PuerkitoBio/goquery v1.9.3 h1:mpJr/ikUA9/GNJB/DBZcGeFDXUtosHRyRrwh7KGdTG0=
 github.com/PuerkitoBio/goquery v1.9.3/go.mod h1:1ndLHPdTz+DyQPICCWYlYQMPl0oXZj0G6D4LCYA6u4U=
 github.com/agnivade/levenshtein v1.2.0 h1:U9L4IOT0Y3i0TIlUIDJ7rVUziKi/zPbrJGaFrtYH3SY=
@@ -18,6 +22,8 @@ github.com/dgryski/trifles v0.0.0-20230903005119-f50d829f2e54 h1:SG7nF6SRlWhcT7c
 github.com/dgryski/trifles v0.0.0-20230903005119-f50d829f2e54/go.mod h1:if7Fbed8SFyPtHLHbg49SI7NAdJiC5WIA09pe59rfAA=
 github.com/go-viper/mapstructure/v2 v2.2.1 h1:ZAaOCxANMuZx5RCeg0mBdEZk7DZasvvZIxtHqx8aGss=
 github.com/go-viper/mapstructure/v2 v2.2.1/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
+github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
+github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=

--- a/backend/internal/auth/claims.go
+++ b/backend/internal/auth/claims.go
@@ -2,7 +2,6 @@ package auth
 
 import "github.com/golang-jwt/jwt/v5"
 
-// supabaseClaims captures the subset of Supabase-issued JWT claims the middleware consumes.
 type supabaseClaims struct {
 	Email string `json:"email,omitempty"`
 	Role  string `json:"role,omitempty"`

--- a/backend/internal/auth/claims.go
+++ b/backend/internal/auth/claims.go
@@ -1,0 +1,10 @@
+package auth
+
+import "github.com/golang-jwt/jwt/v5"
+
+// supabaseClaims captures the subset of Supabase-issued JWT claims the middleware consumes.
+type supabaseClaims struct {
+	Email string `json:"email,omitempty"`
+	Role  string `json:"role,omitempty"`
+	jwt.RegisteredClaims
+}

--- a/backend/internal/auth/jwks.go
+++ b/backend/internal/auth/jwks.go
@@ -16,6 +16,20 @@ type Config struct {
 	Issuer   string
 }
 
+// Validate returns a non-nil error if any required Config field is empty.
+func (c Config) Validate() error {
+	if c.JWKSURL == "" {
+		return errors.New("auth: SUPABASE_JWKS_URL is required")
+	}
+	if c.Audience == "" {
+		return errors.New("auth: SUPABASE_JWT_AUDIENCE is required")
+	}
+	if c.Issuer == "" {
+		return errors.New("auth: SUPABASE_JWT_ISSUER is required")
+	}
+	return nil
+}
+
 // ConfigFromEnv reads the three required auth environment variables and returns
 // a Config. Returns an error if any variable is unset or empty.
 func ConfigFromEnv() (Config, error) {
@@ -24,14 +38,8 @@ func ConfigFromEnv() (Config, error) {
 		Audience: os.Getenv("SUPABASE_JWT_AUDIENCE"),
 		Issuer:   os.Getenv("SUPABASE_JWT_ISSUER"),
 	}
-	if cfg.JWKSURL == "" {
-		return cfg, errors.New("auth: SUPABASE_JWKS_URL is required")
-	}
-	if cfg.Audience == "" {
-		return cfg, errors.New("auth: SUPABASE_JWT_AUDIENCE is required")
-	}
-	if cfg.Issuer == "" {
-		return cfg, errors.New("auth: SUPABASE_JWT_ISSUER is required")
+	if err := cfg.Validate(); err != nil {
+		return cfg, err
 	}
 	return cfg, nil
 }
@@ -40,11 +48,13 @@ func ConfigFromEnv() (Config, error) {
 // refreshes in the background. The refresh goroutine stops when ctx is canceled.
 // Returns an error if the initial fetch fails — silent failure is disallowed.
 func NewJWKSKeyfunc(ctx context.Context, cfg Config) (keyfunc.Keyfunc, error) {
-	failOnFirstFetch := false
-	override := keyfunc.Override{
-		NoErrorReturnFirstHTTPReq: &failOnFirstFetch,
-	}
-	kf, err := keyfunc.NewDefaultOverrideCtx(ctx, []string{cfg.JWKSURL}, override)
+	// keyfunc.NewDefaultCtx (and a zero-value Override) defaults
+	// NoErrorReturnFirstHTTPReq=true, which silently swallows the initial fetch
+	// failure. Set it explicitly to false so a misconfigured JWKS URL surfaces at boot.
+	noSwallowFirstFetchErr := false
+	kf, err := keyfunc.NewDefaultOverrideCtx(ctx, []string{cfg.JWKSURL}, keyfunc.Override{
+		NoErrorReturnFirstHTTPReq: &noSwallowFirstFetchErr,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("auth: JWKS initial fetch failed: %w", err)
 	}

--- a/backend/internal/auth/jwks.go
+++ b/backend/internal/auth/jwks.go
@@ -30,8 +30,6 @@ func (c Config) Validate() error {
 	return nil
 }
 
-// ConfigFromEnv reads the three required auth environment variables and returns
-// a Config. Returns an error if any variable is unset or empty.
 func ConfigFromEnv() (Config, error) {
 	cfg := Config{
 		JWKSURL:  os.Getenv("SUPABASE_JWKS_URL"),
@@ -46,14 +44,11 @@ func ConfigFromEnv() (Config, error) {
 
 // NewJWKSKeyfunc initializes a keyfunc that fetches JWKS from cfg.JWKSURL and
 // refreshes in the background. The refresh goroutine stops when ctx is canceled.
-// Returns an error if the initial fetch fails — silent failure is disallowed.
 func NewJWKSKeyfunc(ctx context.Context, cfg Config) (keyfunc.Keyfunc, error) {
-	// keyfunc.NewDefaultCtx (and a zero-value Override) defaults
-	// NoErrorReturnFirstHTTPReq=true, which silently swallows the initial fetch
-	// failure. Set it explicitly to false so a misconfigured JWKS URL surfaces at boot.
-	noSwallowFirstFetchErr := false
+	// The zero-value Override has NoErrorReturnFirstHTTPReq=true, which silently
+	// swallows initial fetch failure. Override to false so a bad URL surfaces at boot.
 	kf, err := keyfunc.NewDefaultOverrideCtx(ctx, []string{cfg.JWKSURL}, keyfunc.Override{
-		NoErrorReturnFirstHTTPReq: &noSwallowFirstFetchErr,
+		NoErrorReturnFirstHTTPReq: new(bool),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("auth: JWKS initial fetch failed: %w", err)

--- a/backend/internal/auth/jwks.go
+++ b/backend/internal/auth/jwks.go
@@ -1,0 +1,52 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/MicahParks/keyfunc/v3"
+)
+
+// Config holds the required configuration for JWT verification.
+type Config struct {
+	JWKSURL  string
+	Audience string
+	Issuer   string
+}
+
+// ConfigFromEnv reads the three required auth environment variables and returns
+// a Config. Returns an error if any variable is unset or empty.
+func ConfigFromEnv() (Config, error) {
+	cfg := Config{
+		JWKSURL:  os.Getenv("SUPABASE_JWKS_URL"),
+		Audience: os.Getenv("SUPABASE_JWT_AUDIENCE"),
+		Issuer:   os.Getenv("SUPABASE_JWT_ISSUER"),
+	}
+	if cfg.JWKSURL == "" {
+		return cfg, errors.New("auth: SUPABASE_JWKS_URL is required")
+	}
+	if cfg.Audience == "" {
+		return cfg, errors.New("auth: SUPABASE_JWT_AUDIENCE is required")
+	}
+	if cfg.Issuer == "" {
+		return cfg, errors.New("auth: SUPABASE_JWT_ISSUER is required")
+	}
+	return cfg, nil
+}
+
+// NewJWKSKeyfunc initializes a keyfunc that fetches JWKS from cfg.JWKSURL and
+// refreshes in the background. The refresh goroutine stops when ctx is canceled.
+// Returns an error if the initial fetch fails — silent failure is disallowed.
+func NewJWKSKeyfunc(ctx context.Context, cfg Config) (keyfunc.Keyfunc, error) {
+	failOnFirstFetch := false
+	override := keyfunc.Override{
+		NoErrorReturnFirstHTTPReq: &failOnFirstFetch,
+	}
+	kf, err := keyfunc.NewDefaultOverrideCtx(ctx, []string{cfg.JWKSURL}, override)
+	if err != nil {
+		return nil, fmt.Errorf("auth: JWKS initial fetch failed: %w", err)
+	}
+	return kf, nil
+}

--- a/backend/internal/auth/jwks_test.go
+++ b/backend/internal/auth/jwks_test.go
@@ -1,0 +1,81 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestConfigFromEnv_MissingJWKSURL(t *testing.T) {
+	t.Setenv("SUPABASE_JWKS_URL", "")
+	t.Setenv("SUPABASE_JWT_AUDIENCE", "authenticated")
+	t.Setenv("SUPABASE_JWT_ISSUER", "http://127.0.0.1:54321/auth/v1")
+	if _, err := ConfigFromEnv(); err == nil {
+		t.Fatal("expected error for missing SUPABASE_JWKS_URL")
+	}
+}
+
+func TestConfigFromEnv_MissingAudience(t *testing.T) {
+	t.Setenv("SUPABASE_JWKS_URL", "http://example/jwks")
+	t.Setenv("SUPABASE_JWT_AUDIENCE", "")
+	t.Setenv("SUPABASE_JWT_ISSUER", "http://127.0.0.1:54321/auth/v1")
+	if _, err := ConfigFromEnv(); err == nil {
+		t.Fatal("expected error for missing SUPABASE_JWT_AUDIENCE")
+	}
+}
+
+func TestConfigFromEnv_MissingIssuer(t *testing.T) {
+	t.Setenv("SUPABASE_JWKS_URL", "http://example/jwks")
+	t.Setenv("SUPABASE_JWT_AUDIENCE", "authenticated")
+	t.Setenv("SUPABASE_JWT_ISSUER", "")
+	if _, err := ConfigFromEnv(); err == nil {
+		t.Fatal("expected error for missing SUPABASE_JWT_ISSUER")
+	}
+}
+
+func TestConfigFromEnv_AllSet(t *testing.T) {
+	t.Setenv("SUPABASE_JWKS_URL", "http://example/jwks")
+	t.Setenv("SUPABASE_JWT_AUDIENCE", "authenticated")
+	t.Setenv("SUPABASE_JWT_ISSUER", "http://127.0.0.1:54321/auth/v1")
+	cfg, err := ConfigFromEnv()
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if cfg.JWKSURL == "" || cfg.Audience == "" || cfg.Issuer == "" {
+		t.Fatalf("unexpected empty field in %+v", cfg)
+	}
+}
+
+func TestNewJWKSKeyfunc_FetchesJWKS(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"keys": []any{}})
+	}))
+	t.Cleanup(ts.Close)
+
+	kf, err := NewJWKSKeyfunc(context.Background(), Config{
+		JWKSURL: ts.URL, Audience: "authenticated", Issuer: "http://iss",
+	})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if kf == nil {
+		t.Fatal("expected non-nil keyfunc")
+	}
+}
+
+func TestNewJWKSKeyfunc_FetchFailure(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	t.Cleanup(ts.Close)
+
+	_, err := NewJWKSKeyfunc(context.Background(), Config{
+		JWKSURL: ts.URL, Audience: "authenticated", Issuer: "http://iss",
+	})
+	if err == nil {
+		t.Fatal("expected error for JWKS fetch failure at boot")
+	}
+}

--- a/backend/internal/auth/middleware.go
+++ b/backend/internal/auth/middleware.go
@@ -18,7 +18,12 @@ const wwwAuthenticate = `Bearer realm="api"`
 // No header → request proceeds as anonymous (ctx has no AuthUser).
 // Header present + verification succeeds → AuthUser attached to ctx.
 // Header present + verification fails → 401 with WWW-Authenticate: Bearer realm="api".
-func AuthMiddleware(kf keyfunc.Keyfunc, cfg Config) echo.MiddlewareFunc {
+// Returns an error at construction if cfg is missing required fields, since
+// jwt.WithAudience("")/WithIssuer("") would silently match tokens with empty claims.
+func AuthMiddleware(kf keyfunc.Keyfunc, cfg Config) (echo.MiddlewareFunc, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
 	parser := jwt.NewParser(
 		jwt.WithValidMethods([]string{"ES256", "RS256"}),
 		jwt.WithAudience(cfg.Audience),
@@ -53,7 +58,7 @@ func AuthMiddleware(kf keyfunc.Keyfunc, cfg Config) echo.MiddlewareFunc {
 			c.SetRequest(r.WithContext(withUser(r.Context(), u)))
 			return next(c)
 		}
-	}
+	}, nil
 }
 
 func extractBearer(header string) (string, error) {
@@ -69,7 +74,11 @@ func extractBearer(header string) (string, error) {
 }
 
 func reject(c *echo.Context, cause error) error {
-	slog.Warn("auth: token rejected", "err", cause, "path", c.Request().URL.Path)
+	slog.Warn("auth: token rejected",
+		"err", cause,
+		"path", c.Request().URL.Path,
+		"remote_addr", c.Request().RemoteAddr,
+	)
 	c.Response().Header().Set(echo.HeaderWWWAuthenticate, wwwAuthenticate)
 	return c.String(http.StatusUnauthorized, "invalid token")
 }

--- a/backend/internal/auth/middleware.go
+++ b/backend/internal/auth/middleware.go
@@ -14,12 +14,8 @@ import (
 
 const wwwAuthenticate = `Bearer realm="api"`
 
-// AuthMiddleware verifies a Supabase-issued JWT from the Authorization header.
-// No header → request proceeds as anonymous (ctx has no AuthUser).
-// Header present + verification succeeds → AuthUser attached to ctx.
-// Header present + verification fails → 401 with WWW-Authenticate: Bearer realm="api".
-// Returns an error at construction if cfg is missing required fields, since
-// jwt.WithAudience("")/WithIssuer("") would silently match tokens with empty claims.
+// AuthMiddleware returns an error at construction if cfg is missing required fields,
+// because jwt.WithAudience("")/WithIssuer("") would silently match tokens with empty claims.
 func AuthMiddleware(kf keyfunc.Keyfunc, cfg Config) (echo.MiddlewareFunc, error) {
 	if err := cfg.Validate(); err != nil {
 		return nil, err

--- a/backend/internal/auth/middleware.go
+++ b/backend/internal/auth/middleware.go
@@ -1,0 +1,75 @@
+package auth
+
+import (
+	"errors"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/MicahParks/keyfunc/v3"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/labstack/echo/v5"
+)
+
+const wwwAuthenticate = `Bearer realm="api"`
+
+// AuthMiddleware verifies a Supabase-issued JWT from the Authorization header.
+// No header → request proceeds as anonymous (ctx has no AuthUser).
+// Header present + verification succeeds → AuthUser attached to ctx.
+// Header present + verification fails → 401 with WWW-Authenticate: Bearer realm="api".
+func AuthMiddleware(kf keyfunc.Keyfunc, cfg Config) echo.MiddlewareFunc {
+	parser := jwt.NewParser(
+		jwt.WithValidMethods([]string{"ES256", "RS256"}),
+		jwt.WithAudience(cfg.Audience),
+		jwt.WithIssuer(cfg.Issuer),
+		jwt.WithExpirationRequired(),
+		jwt.WithLeeway(30*time.Second),
+	)
+
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c *echo.Context) error {
+			raw := c.Request().Header.Get("Authorization")
+			if raw == "" {
+				return next(c)
+			}
+
+			tokenStr, err := extractBearer(raw)
+			if err != nil {
+				return reject(c, err)
+			}
+
+			var claims supabaseClaims
+			if _, err := parser.ParseWithClaims(tokenStr, &claims, kf.Keyfunc); err != nil {
+				return reject(c, err)
+			}
+
+			u := &AuthUser{
+				Sub:   claims.Subject,
+				Email: claims.Email,
+				Role:  claims.Role,
+			}
+			r := c.Request()
+			c.SetRequest(r.WithContext(withUser(r.Context(), u)))
+			return next(c)
+		}
+	}
+}
+
+func extractBearer(header string) (string, error) {
+	parts := strings.SplitN(header, " ", 2)
+	if len(parts) != 2 || !strings.EqualFold(parts[0], "Bearer") {
+		return "", errors.New("auth: Authorization header must use Bearer scheme")
+	}
+	token := strings.TrimSpace(parts[1])
+	if token == "" {
+		return "", errors.New("auth: empty bearer token")
+	}
+	return token, nil
+}
+
+func reject(c *echo.Context, cause error) error {
+	slog.Warn("auth: token rejected", "err", cause, "path", c.Request().URL.Path)
+	c.Response().Header().Set(echo.HeaderWWWAuthenticate, wwwAuthenticate)
+	return c.String(http.StatusUnauthorized, "invalid token")
+}

--- a/backend/internal/auth/middleware_test.go
+++ b/backend/internal/auth/middleware_test.go
@@ -1,0 +1,245 @@
+package auth
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/labstack/echo/v5"
+)
+
+type testFixture struct {
+	priv     *ecdsa.PrivateKey
+	kid      string
+	jwksURL  string
+	audience string
+	issuer   string
+	mwCtx    context.Context
+}
+
+func newFixture(t *testing.T) *testFixture {
+	t.Helper()
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	kid := "test-kid"
+	xB64 := base64.RawURLEncoding.EncodeToString(priv.PublicKey.X.Bytes())
+	yB64 := base64.RawURLEncoding.EncodeToString(priv.PublicKey.Y.Bytes())
+	jwks := map[string]any{"keys": []map[string]any{{
+		"kty": "EC", "crv": "P-256", "alg": "ES256",
+		"kid": kid, "x": xB64, "y": yB64, "use": "sig",
+	}}}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(jwks)
+	}))
+	t.Cleanup(ts.Close)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	return &testFixture{
+		priv: priv, kid: kid, jwksURL: ts.URL,
+		audience: "authenticated", issuer: "http://issuer.test", mwCtx: ctx,
+	}
+}
+
+// signJWT signs claims with the given method. If key is nil, the fixture's ES256 private key is used.
+// Pass jwt.UnsafeAllowNoneSignatureType for SigningMethodNone, or []byte for HS*.
+func (f *testFixture) signJWT(t *testing.T, claims jwt.MapClaims, alg jwt.SigningMethod, key any, kid string) string {
+	t.Helper()
+	tok := jwt.NewWithClaims(alg, claims)
+	if kid == "" {
+		kid = f.kid
+	}
+	tok.Header["kid"] = kid
+	if key == nil {
+		key = f.priv
+	}
+	signed, err := tok.SignedString(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return signed
+}
+
+func (f *testFixture) newEcho(t *testing.T) *echo.Echo {
+	t.Helper()
+	kf, err := NewJWKSKeyfunc(f.mwCtx, Config{JWKSURL: f.jwksURL, Audience: f.audience, Issuer: f.issuer})
+	if err != nil {
+		t.Fatal(err)
+	}
+	mw := AuthMiddleware(kf, Config{JWKSURL: f.jwksURL, Audience: f.audience, Issuer: f.issuer})
+	e := echo.New()
+	q := e.Group("/query", mw)
+	q.POST("", func(c *echo.Context) error {
+		u := UserFrom(c.Request().Context())
+		if u == nil {
+			return c.String(http.StatusOK, "anon")
+		}
+		return c.String(http.StatusOK, "authed:"+u.Sub)
+	})
+	return e
+}
+
+func send(e *echo.Echo, authz string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodPost, "/query", nil)
+	if authz != "" {
+		req.Header.Set("Authorization", authz)
+	}
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	return rec
+}
+
+func assert401(t *testing.T, rec *httptest.ResponseRecorder) {
+	t.Helper()
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	if got := rec.Header().Get("WWW-Authenticate"); got != `Bearer realm="api"` {
+		t.Fatalf("expected WWW-Authenticate Bearer realm=\"api\", got %q", got)
+	}
+}
+
+func assert200(t *testing.T, rec *httptest.ResponseRecorder, want string) {
+	t.Helper()
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	if got := rec.Body.String(); got != want {
+		t.Fatalf("expected body %q, got %q", want, got)
+	}
+}
+
+func validClaims(f *testFixture, sub string) jwt.MapClaims {
+	return jwt.MapClaims{
+		"sub": sub, "aud": f.audience, "iss": f.issuer,
+		"exp": time.Now().Add(time.Hour).Unix(),
+	}
+}
+
+func TestMiddleware_AnonymousPassthrough(t *testing.T) {
+	t.Parallel()
+	f := newFixture(t)
+	assert200(t, send(f.newEcho(t), ""), "anon")
+}
+
+func TestMiddleware_ValidJWT(t *testing.T) {
+	t.Parallel()
+	f := newFixture(t)
+	tok := f.signJWT(t, jwt.MapClaims{
+		"sub": "uuid-42", "email": "u@example.test", "role": "authenticated",
+		"aud": f.audience, "iss": f.issuer,
+		"exp": time.Now().Add(time.Hour).Unix(),
+	}, jwt.SigningMethodES256, nil, "")
+	assert200(t, send(f.newEcho(t), "Bearer "+tok), "authed:uuid-42")
+}
+
+func TestMiddleware_Expired(t *testing.T) {
+	t.Parallel()
+	f := newFixture(t)
+	tok := f.signJWT(t, jwt.MapClaims{
+		"sub": "x", "aud": f.audience, "iss": f.issuer,
+		"exp": time.Now().Add(-time.Hour).Unix(),
+	}, jwt.SigningMethodES256, nil, "")
+	assert401(t, send(f.newEcho(t), "Bearer "+tok))
+}
+
+func TestMiddleware_Tampered(t *testing.T) {
+	t.Parallel()
+	f := newFixture(t)
+	other, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tok := f.signJWT(t, validClaims(f, "x"), jwt.SigningMethodES256, other, "")
+	assert401(t, send(f.newEcho(t), "Bearer "+tok))
+}
+
+func TestMiddleware_BadScheme(t *testing.T) {
+	t.Parallel()
+	f := newFixture(t)
+	assert401(t, send(f.newEcho(t), "foo.bar.baz"))
+}
+
+func TestMiddleware_EmptyBearer(t *testing.T) {
+	t.Parallel()
+	f := newFixture(t)
+	assert401(t, send(f.newEcho(t), "Bearer "))
+}
+
+func TestMiddleware_WrongAudience(t *testing.T) {
+	t.Parallel()
+	f := newFixture(t)
+	tok := f.signJWT(t, jwt.MapClaims{
+		"sub": "x", "aud": "wrong", "iss": f.issuer,
+		"exp": time.Now().Add(time.Hour).Unix(),
+	}, jwt.SigningMethodES256, nil, "")
+	assert401(t, send(f.newEcho(t), "Bearer "+tok))
+}
+
+func TestMiddleware_WrongIssuer(t *testing.T) {
+	t.Parallel()
+	f := newFixture(t)
+	tok := f.signJWT(t, jwt.MapClaims{
+		"sub": "x", "aud": f.audience, "iss": "wrong",
+		"exp": time.Now().Add(time.Hour).Unix(),
+	}, jwt.SigningMethodES256, nil, "")
+	assert401(t, send(f.newEcho(t), "Bearer "+tok))
+}
+
+func TestMiddleware_AlgHS256_Rejected(t *testing.T) {
+	t.Parallel()
+	f := newFixture(t)
+	tok := f.signJWT(t, validClaims(f, "x"), jwt.SigningMethodHS256, []byte("secret"), "")
+	assert401(t, send(f.newEcho(t), "Bearer "+tok))
+}
+
+func TestMiddleware_AlgNone_Rejected(t *testing.T) {
+	t.Parallel()
+	f := newFixture(t)
+	// jwt/v5 requires the UnsafeAllowNoneSignatureType sentinel as the key for SigningMethodNone.
+	tok := f.signJWT(t, validClaims(f, "x"), jwt.SigningMethodNone, jwt.UnsafeAllowNoneSignatureType, "")
+	assert401(t, send(f.newEcho(t), "Bearer "+tok))
+}
+
+func TestMiddleware_MissingExp(t *testing.T) {
+	t.Parallel()
+	f := newFixture(t)
+	tok := f.signJWT(t, jwt.MapClaims{
+		"sub": "x", "aud": f.audience, "iss": f.issuer,
+	}, jwt.SigningMethodES256, nil, "")
+	assert401(t, send(f.newEcho(t), "Bearer "+tok))
+}
+
+func TestMiddleware_ClockSkewWithinLeeway(t *testing.T) {
+	t.Parallel()
+	f := newFixture(t)
+	tok := f.signJWT(t, jwt.MapClaims{
+		"sub": "uuid-skew", "aud": f.audience, "iss": f.issuer,
+		"exp": time.Now().Add(-10 * time.Second).Unix(),
+	}, jwt.SigningMethodES256, nil, "")
+	assert200(t, send(f.newEcho(t), "Bearer "+tok), "authed:uuid-skew")
+}
+
+func TestMiddleware_LowercaseBearer(t *testing.T) {
+	t.Parallel()
+	f := newFixture(t)
+	tok := f.signJWT(t, validClaims(f, "uuid-lc"), jwt.SigningMethodES256, nil, "")
+	assert200(t, send(f.newEcho(t), "bearer "+tok), "authed:uuid-lc")
+}
+
+func TestMiddleware_WrongKid(t *testing.T) {
+	t.Parallel()
+	f := newFixture(t)
+	tok := f.signJWT(t, validClaims(f, "x"), jwt.SigningMethodES256, nil, "nonexistent-kid")
+	assert401(t, send(f.newEcho(t), "Bearer "+tok))
+}

--- a/backend/internal/auth/middleware_test.go
+++ b/backend/internal/auth/middleware_test.go
@@ -76,7 +76,10 @@ func (f *testFixture) newEcho(t *testing.T) *echo.Echo {
 	if err != nil {
 		t.Fatal(err)
 	}
-	mw := AuthMiddleware(kf, Config{JWKSURL: f.jwksURL, Audience: f.audience, Issuer: f.issuer})
+	mw, err := AuthMiddleware(kf, Config{JWKSURL: f.jwksURL, Audience: f.audience, Issuer: f.issuer})
+	if err != nil {
+		t.Fatal(err)
+	}
 	e := echo.New()
 	q := e.Group("/query", mw)
 	q.POST("", func(c *echo.Context) error {
@@ -242,4 +245,19 @@ func TestMiddleware_WrongKid(t *testing.T) {
 	f := newFixture(t)
 	tok := f.signJWT(t, validClaims(f, "x"), jwt.SigningMethodES256, nil, "nonexistent-kid")
 	assert401(t, send(f.newEcho(t), "Bearer "+tok))
+}
+
+func TestAuthMiddleware_RejectsEmptyConfig(t *testing.T) {
+	t.Parallel()
+	f := newFixture(t)
+	kf, err := NewJWKSKeyfunc(f.mwCtx, Config{
+		JWKSURL: f.jwksURL, Audience: f.audience, Issuer: f.issuer,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := AuthMiddleware(kf, Config{}); err == nil {
+		t.Fatal("expected error from empty Config")
+	}
 }

--- a/backend/internal/auth/user.go
+++ b/backend/internal/auth/user.go
@@ -1,0 +1,22 @@
+// Package auth provides JWT verification middleware and authenticated-user context access.
+package auth
+
+import "context"
+
+type AuthUser struct {
+	Sub   string
+	Email string
+	Role  string
+}
+
+type contextKey struct{}
+
+func withUser(ctx context.Context, u *AuthUser) context.Context {
+	return context.WithValue(ctx, contextKey{}, u)
+}
+
+// UserFrom returns the authenticated user stored by AuthMiddleware, or nil for anonymous requests.
+func UserFrom(ctx context.Context) *AuthUser {
+	u, _ := ctx.Value(contextKey{}).(*AuthUser)
+	return u
+}

--- a/backend/internal/auth/user_test.go
+++ b/backend/internal/auth/user_test.go
@@ -1,0 +1,30 @@
+package auth
+
+import (
+	"context"
+	"testing"
+)
+
+func TestUserFrom_EmptyContext(t *testing.T) {
+	if got := UserFrom(context.Background()); got != nil {
+		t.Fatalf("expected nil, got %+v", got)
+	}
+}
+
+func TestWithUser_Roundtrip(t *testing.T) {
+	u := &AuthUser{Sub: "uuid-1", Email: "a@b.c", Role: "authenticated"}
+	ctx := withUser(context.Background(), u)
+	got := UserFrom(ctx)
+	if got != u {
+		t.Fatalf("expected same pointer, got %+v", got)
+	}
+}
+
+func TestUserFrom_WrongType_ReturnsNil(t *testing.T) {
+	// indirect verification that external packages cannot share the same key type:
+	// inserting with a string key does not surface via UserFrom
+	ctx := context.WithValue(context.Background(), "contextKey{}", &AuthUser{Sub: "x"})
+	if got := UserFrom(ctx); got != nil {
+		t.Fatalf("expected nil, got %+v", got)
+	}
+}

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -61,6 +61,7 @@ These values target a public API on Render. Revisit if the threat model or deplo
 - **Free port discovery**: `net.Listen("tcp", "127.0.0.1:0")` → read `Addr()` → `Close()` → start the server on that port (`freePort` + `waitHealthy` polling). Never hardcode ports.
 - **Do not send real signals to the test process** (e.g. `syscall.Kill(os.Getpid(), SIGTERM)`). Signals are delivered process-wide and race with `t.Parallel()` tests and the test runner itself. Reproduce the meaning of `signal.NotifyContext` by **cancelling a `context.WithCancel` directly**.
 - **Silence logs in tests** with `slog.New(slog.DiscardHandler)`.
+- **`t.Parallel()` is incompatible with `t.Setenv()`** — `t.Setenv` mutates process-global env state and the Go test framework will panic if a parallel test calls it. Tests that manipulate env vars must be sequential (no `t.Parallel()`).
 
 ## Logging
 
@@ -160,6 +161,8 @@ All 401 responses carry `WWW-Authenticate: Bearer realm="api"`. The header delib
 - **Initial fetch is required** — if the JWKS endpoint is unreachable at startup, `ConfigFromEnv` / server startup fails immediately rather than silently caching nothing.
 - **Periodic refresh failures are non-fatal** — the keyfunc library keeps the last successfully fetched key set in memory and continues verifying tokens. A transient JWKS outage does not bring down the server.
 
+`NoErrorReturnFirstHTTPReq` defaults to **`true`** in `keyfunc/v3`, meaning the plain `keyfunc.NewDefaultCtx(ctx, urls)` constructor silently discards initial-fetch errors and returns a keyfunc that will verify nothing. To enforce fail-fast boot you must use `keyfunc.NewDefaultOverrideCtx` and pass an `Override{NoErrorReturnFirstHTTPReq: new(bool)}` (a pointer to `false`). The field name's polarity is the opposite of what "No error = good" suggests — treat it as "suppress-error flag" and always override it to `false`.
+
 ### Environment variables (auth)
 
 See also the general env-vars table above.
@@ -175,3 +178,38 @@ All three are required. `ConfigFromEnv()` returns an error and the server fails 
 ### Echo v5 + gqlgen error propagation
 
 `echo.WrapHandler` (v5) converts a `http.Handler` into an `echo.HandlerFunc` that always returns `nil`. gqlgen's `handler.Server` is an `http.Handler`: it writes GraphQL errors into the response body as `{"errors":[...]}` with HTTP 200, and only ever writes a 5xx for catastrophic transport failures. Because `WrapHandler` returns `nil`, Echo's central error pipeline never sees these, which is fine: the GraphQL error is already transported in-band. Do **not** wrap gqlgen with a custom adapter that translates non-2xx into `echo.NewHTTPError` — that would cause a double write on the already-committed `ResponseWriter`.
+
+## Backend gotchas
+
+### Echo v5 handler signature uses a pointer receiver
+
+Echo v5 handler and middleware signatures changed from v4. Every handler and middleware factory must use `*echo.Context` (pointer), not the v4 interface form:
+
+```go
+// v5 — correct
+func handler(c *echo.Context) error { ... }
+
+// v4 — will not compile or will behave wrong in v5
+func handler(c echo.Context) error { ... }
+```
+
+Online samples, AI-generated code, and the official Echo v4 docs all use the interface form. Any paste from those sources requires this fix.
+
+### `echo.NewHTTPError` discards manually-set response headers
+
+Echo's default `HTTPErrorHandler` serializes the error and writes a fresh response, discarding any headers set on the context before returning the error. Setting `c.Response().Header().Set("WWW-Authenticate", "...")` and then `return echo.NewHTTPError(401, "...")` will drop the header in the rendered response. The fix is to write the response directly and return `nil`:
+
+```go
+c.Response().Header().Set("WWW-Authenticate", `Bearer realm="api"`)
+return c.String(http.StatusUnauthorized, "unauthorized")
+```
+
+Any future middleware that must send headers on an error response must use this pattern.
+
+### Config struct validation belongs at the consumption boundary, not only the constructor
+
+Validating fields only inside `ConfigFromEnv` is bypassable — callers can construct `Config{}` directly and pass empty strings to `jwt.WithAudience("")` / `jwt.WithIssuer("")`, which silently match any token claim. Add a `Validate() error` method to the config type and call it at the consumption point (e.g., the middleware factory). The factory should return `(echo.MiddlewareFunc, error)` so the DI wiring in `run()` catches misconfiguration at boot rather than at the first request. This pattern generalises to any config struct whose zero value is semantically dangerous.
+
+### JWT algorithm confusion: always whitelist valid algorithms
+
+Without `jwt.WithValidMethods([]string{"ES256", "RS256"})`, an attacker can re-sign a token with `HS256` using the JWKS public key as the HMAC secret, or use `alg=none` to bypass signature verification entirely. `golang-jwt/v5` does not reject these by default if the keyfunc returns a key. Always pass `WithValidMethods` with the exact set of algorithms your JWKS endpoint issues.

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -44,8 +44,15 @@ These values target a public API on Render. Revisit if the threat model or deplo
 
 ## Environment variables
 
-- `PORT` — listen port. Default `1323`.
-- `SHUTDOWN_TIMEOUT` — Go duration (e.g. `10s`, `1m`). Default `25s`. Invalid or `<= 0` values log a warning and fall back to the default — **do not remove this guard**; it prevents env-var typos from being silently ignored in production.
+| Variable | Required | Default | Purpose |
+|---|---|---|---|
+| `PORT` | no | `1323` | Listen port |
+| `SHUTDOWN_TIMEOUT` | no | `25s` | Go duration for graceful shutdown. Invalid or `<= 0` values log a warning and fall back to the default. |
+| `SUPABASE_JWKS_URL` | yes | — | JWKS endpoint for JWT verification |
+| `SUPABASE_JWT_AUDIENCE` | yes | — | Expected `aud` claim in incoming JWTs |
+| `SUPABASE_JWT_ISSUER` | yes | — | Expected `iss` claim in incoming JWTs |
+
+`PORT` and `SHUTDOWN_TIMEOUT` are optional with safe defaults. The three `SUPABASE_*` variables are all required — the server refuses to start if any is missing (fail-fast via `ConfigFromEnv`).
 
 ## Testing patterns
 
@@ -91,6 +98,79 @@ gqlgen deletes `graph/model/models_gen.go` at the start of every run before rege
 ### Resolver DI seam
 
 `newRouter(resolvers *resolver.Resolver) *echo.Echo` is the DI wiring seam. `run(ctx, logger) error` is the lifecycle seam — it constructs the `Resolver`, passes it to `newRouter`, and owns the `http.Server`. Future dependencies (auth, DB, loaders) add fields to `Resolver` and wire them in `run`.
+
+## Authentication
+
+The backend uses an opt-in JWT verification model. Routes are divided into two groups:
+
+```
+GET  /            open (no auth)
+GET  /health      open (no auth)
+GET  /playground  open (no auth)
+POST /query       AuthMiddleware → gqlgen handler
+```
+
+When an `Authorization` header is **absent**, the request passes through as anonymous — no `auth.AuthUser` is attached to the context. This allows unauthenticated queries to proceed until individual resolvers start enforcing identity (PR9). When the header is **present and valid**, `auth.UserFrom(ctx)` returns the verified `*auth.AuthUser` (`Sub`, `Email`, `Role`). When the header is **present but invalid**, the middleware short-circuits with HTTP 401 and sets `WWW-Authenticate: Bearer realm="api"`.
+
+### Middleware layering
+
+`e.Group("/query", authMW)` registers `AuthMiddleware` only on the `/query` route group. Playground, health, and the root handler live outside the group and are never touched by auth logic.
+
+### Resolver usage
+
+```go
+func (r *queryResolver) Me(ctx context.Context) (*model.User, error) {
+    u := auth.UserFrom(ctx)
+    if u == nil {
+        // anonymous — return guest data or error depending on the resolver's policy
+        return nil, nil
+    }
+    // u.Sub, u.Email, u.Role are available here
+    _ = u.Sub
+    return nil, nil
+}
+```
+
+### 401 condition matrix
+
+| Condition | Result |
+|---|---|
+| `Authorization` header absent | Anonymous passthrough (no 401) |
+| Bearer token present, valid | 200 — `AuthUser` in context |
+| Expired JWT (`exp` in past, outside 30 s leeway) | 401 |
+| Tampered signature | 401 |
+| Wrong `kid` (not in JWKS) | 401 |
+| Missing or empty Bearer scheme | 401 |
+| `alg=HS256` (confusion attack) | 401 |
+| `alg=none` | 401 |
+| Missing `exp` claim | 401 |
+| Wrong `aud` | 401 |
+| Wrong `iss` | 401 |
+
+Accepted algorithms: ES256, RS256. A 30-second leeway is applied to `exp` to tolerate minor clock skew between services.
+
+### WWW-Authenticate policy
+
+All 401 responses carry `WWW-Authenticate: Bearer realm="api"`. The header deliberately omits `error` and `error_description` parameters (RFC 6750 §3.1) to minimize information disclosure — callers learn only that a valid Bearer token is required, not why verification failed.
+
+### JWKS lifecycle
+
+`NewJWKSKeyfunc` wraps `MicahParks/keyfunc/v3` with `NoErrorReturnFirstHTTPReq: false`. This means:
+
+- **Initial fetch is required** — if the JWKS endpoint is unreachable at startup, `ConfigFromEnv` / server startup fails immediately rather than silently caching nothing.
+- **Periodic refresh failures are non-fatal** — the keyfunc library keeps the last successfully fetched key set in memory and continues verifying tokens. A transient JWKS outage does not bring down the server.
+
+### Environment variables (auth)
+
+See also the general env-vars table above.
+
+| Variable | Required | Default | Purpose |
+|---|---|---|---|
+| `SUPABASE_JWKS_URL` | yes | — | JWKS endpoint URL (e.g. `https://<project>.supabase.co/auth/v1/.well-known/jwks.json`) |
+| `SUPABASE_JWT_AUDIENCE` | yes | — | Expected `aud` claim value |
+| `SUPABASE_JWT_ISSUER` | yes | — | Expected `iss` claim value |
+
+All three are required. `ConfigFromEnv()` returns an error and the server fails to start if any is missing or empty — silent misconfiguration is not allowed.
 
 ### Echo v5 + gqlgen error propagation
 

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -97,7 +97,7 @@ gqlgen deletes `graph/model/models_gen.go` at the start of every run before rege
 
 ### Resolver DI seam
 
-`newRouter(resolvers *resolver.Resolver) *echo.Echo` is the DI wiring seam. `run(ctx, logger) error` is the lifecycle seam — it constructs the `Resolver`, passes it to `newRouter`, and owns the `http.Server`. Future dependencies (auth, DB, loaders) add fields to `Resolver` and wire them in `run`.
+`newRouter(resolvers *resolver.Resolver, authMW echo.MiddlewareFunc) *echo.Echo` is the DI wiring seam. `run(ctx, logger) error` is the lifecycle seam — it constructs the `Resolver`, passes it to `newRouter`, and owns the `http.Server`. Middleware-shaped dependencies (auth, future per-request observability) are passed as `echo.MiddlewareFunc` parameters to `newRouter`, while data-access dependencies (DB, dataloaders) add fields to `Resolver` and wire them in `run`.
 
 ## Authentication
 

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -95,6 +95,18 @@ Do **not** install pnpm via `npm i -g pnpm` or `brew install pnpm`. Those paths 
 | DB リセット | `supabase db reset` |
 | ステータス確認 | `supabase status` |
 
+### Backend JWT verification (local)
+
+To run backend JWT verification locally, run `supabase status` to confirm the JWKS URL (typically `http://127.0.0.1:54321/auth/v1/.well-known/jwks.json`) and copy it into `backend/.env.local`. The defaults in `backend/.env.example` should already match. The three required variables are:
+
+```
+SUPABASE_JWKS_URL=http://127.0.0.1:54321/auth/v1/.well-known/jwks.json
+SUPABASE_JWT_AUDIENCE=authenticated
+SUPABASE_JWT_ISSUER=http://127.0.0.1:54321/auth/v1
+```
+
+The backend fails to start if any of these is missing — check `supabase status` output if startup fails with a config error.
+
 ### Gotchas
 
 - **`localhost` ではなく `127.0.0.1` を使う**: Google OAuth の redirect URI 検証は `localhost` と `127.0.0.1` を別ホスト扱いする。`supabase start` のデフォルト出力に合わせて `127.0.0.1:3000` でアクセス。

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -100,6 +100,8 @@ PR6 introduces a 3-layer Supabase SSR client setup mirroring the official `@supa
 
 If no session exists the header is omitted (not set to an empty string). Backend treats missing `Authorization` as anonymous (PR7).
 
+Backend JWT verification is enabled in PR7. Without a Supabase session, only unauthenticated queries (e.g., `health`) succeed against `/query` until resolvers begin enforcing authentication (PR9).
+
 ### RSC token forwarding (deferred to PR9)
 
 `src/lib/apollo/server.ts` does NOT forward an auth token in PR6. Reason: PR6's only RSC query is `{ health }` (anonymous-safe). PR9 introduces `me`, at which point we extend `gqlFetch` to optionally pull the token from `createServerClient(cookies())`. A `TODO(PR9)` comment marks the intended hook point.


### PR DESCRIPTION
Closes #8

## Summary

Adds Supabase-issued JWT verification on the backend's `/query` endpoint while keeping `/health`, `/playground`, and `/` open. A new `backend/internal/auth/` package owns the JWKS keyfunc, the `Config` (validated both at `ConfigFromEnv` and at the `AuthMiddleware` boundary), the Echo v5 middleware, and the `AuthUser` context plumbing. `newRouter` gains an `echo.MiddlewareFunc` parameter, `run()` constructs the keyfunc / middleware and fails fast when any of the three required `SUPABASE_*` env vars is missing or the initial JWKS fetch fails. `docs/backend.md` gains a full §Authentication chapter plus four §Backend gotchas entries (Echo v5 pointer signature, `echo.NewHTTPError` header drop, double-validate the config, JWT alg-confusion whitelist) so the non-obvious traps stay captured.

## Background / Motivation

- PR #14 mounted `gqlgen` on `POST /query` with no authentication. PR #17 (frontend) now sends `Authorization: Bearer <jwt>` on every browser-originated GraphQL request — the backend has to actually verify those tokens before any resolver can trust an identity claim. Issue #8 tracks this.
- `keyfunc/v3.NewDefaultCtx` defaults `Override.NoErrorReturnFirstHTTPReq` to **`true`**, which silently swallows the initial JWKS fetch error and returns a keyfunc that will verify nothing — a textbook silent failure. Caught early during PR review; the fix uses `NewDefaultOverrideCtx` with an explicit `new(bool)` (pointer to `false`) so a missing or unreachable JWKS endpoint surfaces at server boot.
- `jwt.WithAudience("")` / `jwt.WithIssuer("")` silently match tokens with empty `aud` / `iss` claims rather than rejecting them. Validating only inside `ConfigFromEnv` is bypassable — a caller can still construct `Config{}` directly and reach the parser. The `Validate()` method has to be called at the consumption boundary (the middleware factory), and the factory has to return `(echo.MiddlewareFunc, error)` so misconfiguration trips at boot, not at first request.
- Without `jwt.WithValidMethods([]string{"ES256","RS256"})`, an attacker can re-sign a token with `HS256` using the JWKS public key as the HMAC secret, or send `alg=none` to skip signature verification. `golang-jwt/v5` does not reject these by default when the keyfunc returns a key — the algorithm whitelist is load-bearing, not defensive depth.
- Echo's default `HTTPErrorHandler` discards manually-set response headers when `echo.NewHTTPError` is returned. Setting `WWW-Authenticate` then returning `echo.NewHTTPError(401, ...)` drops the header in the rendered response. The fix is to write the response directly via `c.String(401, ...)` after setting the header and return `nil`.
- Echo v5 changed the handler signature from the v4 interface form (`echo.Context`) to a pointer (`*echo.Context`). Online samples and AI-assisted code overwhelmingly use the v4 form; pasted snippets either fail to compile or, worse, compile against a stale type alias. Documented in §Backend gotchas because every future middleware author will hit it.
- `t.Parallel()` is incompatible with `t.Setenv()` — the env mutation is process-global and the Go test framework panics if a parallel test calls it. The new `TestRun_FailsWhenJWKSURLMissing` and the JWKS-using branch of `TestRunGracefulShutdown` both manipulate env, so neither can be `t.Parallel()`. Captured in `docs/backend.md` §Testing patterns so it does not regress.
- `AuthUser.Raw` (the raw JWT string the resolvers will eventually forward to Postgres for RLS) is **deferred to PR9**. PR7's scope is "verify the token and attach a verified identity"; the RLS pass-through requires resolver-side wiring that PR9 owns.

## Changes

### `backend/internal/auth/` package

- `user.go` — `AuthUser{Sub, Email, Role}` plus an unexported `contextKey` and `withUser` / `UserFrom(ctx)` helpers. The context key is a struct type (not a string) so it cannot collide with other packages' context values. `UserFrom` returns `nil` for anonymous requests so resolvers can branch on identity without panicking.
- `claims.go` — `supabaseClaims` embeds `jwt.RegisteredClaims` and adds `Email` / `Role` JSON tags with `omitempty`. Internal-only; never exported.
- `jwks.go` — `Config{JWKSURL, Audience, Issuer}` with `Validate() error` (returns a non-nil error if any field is empty). `ConfigFromEnv()` reads the three `SUPABASE_*` env vars and runs `Validate()` before returning. `NewJWKSKeyfunc(ctx, cfg)` calls `keyfunc.NewDefaultOverrideCtx` with `Override{NoErrorReturnFirstHTTPReq: new(bool)}` so the initial fetch failure surfaces at boot; the refresh goroutine stops when `ctx` is cancelled. Periodic refresh failures stay non-fatal (the library keeps the last good key set in memory) — only the *initial* fetch is fail-fast.
- `middleware.go` — `AuthMiddleware(kf, cfg) (echo.MiddlewareFunc, error)` re-runs `cfg.Validate()` before constructing the parser, then builds a `jwt.Parser` with `WithValidMethods({ES256,RS256})`, `WithAudience(cfg.Audience)`, `WithIssuer(cfg.Issuer)`, `WithExpirationRequired()`, and `WithLeeway(30s)`. Anonymous passthrough when `Authorization` is absent; on validation failure the helper `reject()` sets `WWW-Authenticate: Bearer realm=\"api\"` and writes `c.String(401, \"invalid token\")` directly (bypassing `echo.NewHTTPError`'s header-clobbering default handler). On success, `AuthUser{Sub, Email, Role}` is attached to `c.Request().Context()` via `withUser`.

### Echo v5 wiring (`backend/cmd/server/main.go`)

- `newRouter` gains a second parameter: `authMW echo.MiddlewareFunc`. `/query` is mounted via `e.Group(\"/query\", authMW)` + `q.POST(\"\", echo.WrapHandler(gqlSrv))`, so auth runs only on the GraphQL route group. `/health`, `/playground`, and `/` stay outside the group and are never touched by auth logic.
- `run(ctx, logger)` now sequences `auth.ConfigFromEnv()` → `auth.NewJWKSKeyfunc(ctx, cfg)` → `auth.AuthMiddleware(kf, cfg)`, returning early on any error. This is the fail-fast boundary: missing env, unreachable JWKS, or empty config all surface as a non-zero exit at startup, never as a silent 500-on-first-request.

### Dependencies + env (`backend/go.mod`, `backend/.env.example`)

- New runtime deps: `github.com/golang-jwt/jwt/v5 v5.3.0`, `github.com/MicahParks/keyfunc/v3 v3.4.0` (with its transitive `MicahParks/jwkset`).
- `backend/.env.example` adds the three required `SUPABASE_*` vars with localhost-Supabase defaults (`http://127.0.0.1:54321/...`, `authenticated`, `http://127.0.0.1:54321/auth/v1`) so a fresh checkout has reproducible local values that match `supabase start` output.

### Tests

- `backend/internal/auth/middleware_test.go` — 15 cases driven by a shared `testFixture` that spins up an in-process JWKS server backed by a generated ECDSA P-256 keypair: anonymous passthrough, valid token attaches `AuthUser`, expired token (outside 30 s leeway), tampered signature, wrong `kid`, missing/empty Bearer scheme, non-Bearer scheme, `alg=HS256` confusion attack, `alg=none`, missing `exp`, wrong `aud`, wrong `iss`, leeway-window acceptance, `WWW-Authenticate` header on every 401, factory rejects empty `Config`.
- `backend/internal/auth/jwks_test.go` — 6 cases on `Config.Validate` (each empty field returns its named error) and `NewJWKSKeyfunc` (initial fetch failure surfaces, valid endpoint returns a usable keyfunc, ctx cancellation stops the refresh goroutine).
- `backend/internal/auth/user_test.go` — 3 cases on `UserFrom`: returns `nil` for an empty context, returns the attached `*AuthUser`, does not collide with a sibling context key.
- `backend/cmd/server/main_test.go` — `TestGraphQLHealth` and friends now thread a no-op `authMW` (`func(next) HandlerFunc { return next }`) through `newRouter` so the existing tests stay independent of JWKS. `TestRunGracefulShutdown` now stands up an in-test JWKS server and sets the three `SUPABASE_*` env vars before calling `run`. New `TestRun_FailsWhenJWKSURLMissing` proves the fail-fast boundary by setting `SUPABASE_JWKS_URL=\"\"` and asserting `run` returns an error.

### Docs

- `docs/backend.md` — env-var section converted to a table covering `PORT`, `SHUTDOWN_TIMEOUT`, and the three `SUPABASE_*` rows. New §Authentication chapter covers the open/protected route split, middleware layering (`e.Group(\"/query\", authMW)`), resolver usage example, the full 401 condition matrix, the `WWW-Authenticate` policy (no `error` / `error_description`), the JWKS lifecycle (initial fail-fast, refresh non-fatal), and the auth-only env-var subtable. New §Backend gotchas section captures four traps: Echo v5 pointer-receiver handler signature, `echo.NewHTTPError` discarding manually-set headers, why `Validate()` must run at the consumption boundary not just `ConfigFromEnv`, and the JWT alg-confusion whitelist requirement. §Testing patterns adds the `t.Parallel()` + `t.Setenv()` incompatibility note.
- `docs/dev-setup.md` — new \"Backend JWT verification (local)\" subsection with the three env values to copy from `supabase status` and the failure mode if any is missing.
- `docs/frontend.md` — single-line update noting that PR7 enables backend verification, so without a Supabase session only anonymous queries (`health`) succeed against `/query` until resolvers begin enforcing identity in PR9.

## Verification

Once merged:

- `cd backend && go run ./cmd/server` with the three `SUPABASE_*` env vars set boots cleanly on `:1323`; without `SUPABASE_JWKS_URL` (or any of the others) the process exits non-zero with `auth: SUPABASE_JWKS_URL is required` (or the matching field) before opening the listener.
- With `supabase start` running, `curl -i -X POST -H 'Content-Type: application/json' -d '{\"query\":\"{ health }\"}' http://localhost:1323/query` returns HTTP 200 + `{\"data\":{\"health\":\"ok\"}}` even with no `Authorization` header (anonymous passthrough).
- The same request with `-H \"Authorization: Bearer <expired-jwt>\"` returns HTTP 401, `WWW-Authenticate: Bearer realm=\"api\"`, body `invalid token`. No `error` / `error_description` parameters in the header.
- `curl -i http://localhost:1323/health` and `curl -i http://localhost:1323/playground` both return 200 with no auth interaction — confirming the route group correctly scopes `AuthMiddleware`.
- After PR #17 lands and a user signs in via the frontend, DevTools → Network shows the browser's Apollo POST to `/api/graphql` carrying `Authorization: Bearer eyJ...`; the backend's request log shows the request reaching the resolver (no 401), and resolver-side `auth.UserFrom(ctx)` (manually inspected via a temporary log line, not committed) returns a non-nil `*AuthUser` with the expected `Sub` / `Email`.
- Backend CI on `main` shows the existing `Generate gqlgen artifacts → Vet → Build → Test` order all green; coverage on `backend/internal/auth/...` reports the 24 cases above.

## Test plan

- [x] `cd backend && go test -v -race -covermode=atomic -coverprofile=coverage.out ./...` — all 15 + 6 + 3 auth cases plus the updated `cmd/server` suite pass green; coverage on `backend/internal/auth/` is meaningful (resolver-stub paths excluded as before).
- [x] `cd backend && go vet ./...` and `go build ./...` — clean.
- [ ] Local end-to-end: `supabase start`; `cd backend && SUPABASE_JWKS_URL=http://127.0.0.1:54321/auth/v1/.well-known/jwks.json SUPABASE_JWT_AUDIENCE=authenticated SUPABASE_JWT_ISSUER=http://127.0.0.1:54321/auth/v1 go run ./cmd/server` — boots on `:1323` without errors.
- [ ] Anonymous passthrough: `curl -X POST -H 'Content-Type: application/json' -d '{\"query\":\"{ health }\"}' http://localhost:1323/query` returns HTTP 200 + `{\"data\":{\"health\":\"ok\"}}`.
- [ ] Expired-token 401: mint an expired JWT (`exp = now - 1h`) with the local Supabase signer; `curl -i -X POST -H 'Authorization: Bearer <jwt>' -H 'Content-Type: application/json' -d '{\"query\":\"{ health }\"}' http://localhost:1323/query` returns HTTP 401, `WWW-Authenticate: Bearer realm=\"api\"`, body `invalid token`. Header carries no `error` / `error_description` params.
- [ ] Valid-token round-trip: with PR #17 frontend running, sign in via Google OAuth at `http://127.0.0.1:3000/login`, then trigger any client-originated Apollo query. Backend log shows the request reaching `/query` with no 401; resolver-side `auth.UserFrom(ctx)` returns a non-nil `*AuthUser` with the expected `Sub`.
- [ ] Open-routes regression: `curl -I http://localhost:1323/health` → 200; `curl -I http://localhost:1323/playground` → 200 `text/html`. Neither is touched by auth logic.
- [ ] Fail-fast on missing env: `unset SUPABASE_JWKS_URL && go run ./cmd/server` exits non-zero with `auth: SUPABASE_JWKS_URL is required` before binding `:1323`. Same for `SUPABASE_JWT_AUDIENCE` and `SUPABASE_JWT_ISSUER`.
- [ ] Fail-fast on unreachable JWKS: set `SUPABASE_JWKS_URL=http://127.0.0.1:1/does-not-exist` and run — `run` returns `auth: JWKS initial fetch failed: ...` and the server never accepts connections (proves the `NoErrorReturnFirstHTTPReq=false` override).
- [ ] alg-confusion: hand-mint an HS256 token using the JWKS public key as the HMAC secret (or `alg=none`); both yield 401, never 200.
- [ ] Regression: PRs #14 / #16 / #17 paths still work — `TestGraphQLHealth`, `TestRunGracefulShutdown`, `TestHealthEndpoint`, `TestRootEndpoint` all green; backend graceful shutdown on SIGTERM still respects `SHUTDOWN_TIMEOUT`.
- [ ] Regression: a PR touching only `frontend/` or `schema/` does NOT trigger backend CI (paths filter intact).