### PR TITLE
feat: backend traceparent propagation + cross-tier X-Request-ID correlation

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -29,6 +29,7 @@ import (
 	"backend/internal/database"
 	"backend/internal/loader"
 	"backend/internal/logging"
+	internalmw "backend/internal/middleware"
 	"backend/internal/repository"
 	"backend/internal/telemetry"
 	"backend/internal/usecase"
@@ -57,6 +58,7 @@ func newRouter(resolvers *resolver.Resolver, authMW echo.MiddlewareFunc, repo re
 	e := echo.New()
 	e.Use(middleware.RequestLogger())
 	e.Use(middleware.Recover())
+	e.Use(internalmw.RequestID())
 
 	e.GET("/", func(c *echo.Context) error {
 		return c.JSON(http.StatusOK, map[string]string{
@@ -212,7 +214,7 @@ func run(ctx context.Context, logger *slog.Logger) error {
 }
 
 func main() {
-	logger := slog.New(slog.NewJSONHandler(os.Stderr, nil))
+	logger := slog.New(logging.NewContextHandler(slog.NewJSONHandler(os.Stderr, nil), internalmw.RequestIDFromContext))
 	slog.SetDefault(logger)
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -19,6 +19,8 @@ import (
 	"github.com/labstack/echo/v5/middleware"
 	"github.com/ravilushqa/otelgqlgen"
 	"github.com/rotisserie/eris"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	"go.opentelemetry.io/otel"
 	"golang.org/x/sync/errgroup"
 
 	"backend/graph/generated"
@@ -69,8 +71,19 @@ func newRouter(resolvers *resolver.Resolver, authMW echo.MiddlewareFunc, repo re
 	})
 
 	gqlSrv := newGraphQLServer(resolvers)
+	// Wrap only the GraphQL POST handler with otelhttp so the HTTP layer
+	// extracts an incoming traceparent and creates the root HTTP span.
+	// /health and /playground are intentionally excluded to reduce noise.
+	otelGQLHandler := otelhttp.NewHandler(
+		gqlSrv,
+		"graphql.http",
+		otelhttp.WithPropagators(otel.GetTextMapPropagator()),
+		otelhttp.WithSpanNameFormatter(func(_ string, r *http.Request) string {
+			return r.Method + " " + r.URL.Path
+		}),
+	)
 	q := e.Group("/query", authMW, loader.Middleware(repo))
-	q.POST("", echo.WrapHandler(gqlSrv))
+	q.POST("", echo.WrapHandler(otelGQLHandler))
 	e.GET("/playground", echo.WrapHandler(playground.Handler("GraphQL", "/query")))
 
 	return e

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -74,6 +74,13 @@ func newRouter(resolvers *resolver.Resolver, authMW echo.MiddlewareFunc, repo re
 	// Wrap only the GraphQL POST handler with otelhttp so the HTTP layer
 	// extracts an incoming traceparent and creates the root HTTP span.
 	// /health and /playground are intentionally excluded to reduce noise.
+	//
+	// WithPropagators: otelhttp.newConfig captures otel.GetTextMapPropagator()
+	// eagerly at construction time (config.go:57 in otelhttp@v0.61.0). The
+	// default behavior (omitting WithPropagators) does the same eager capture.
+	// Therefore newRouter MUST be called after telemetry.Init so that the global
+	// propagator is already set when this handler is constructed; otherwise
+	// traceparent extraction silently falls back to the no-op propagator.
 	otelGQLHandler := otelhttp.NewHandler(
 		gqlSrv,
 		"graphql.http",
@@ -109,6 +116,11 @@ func shutdownTimeout(logger *slog.Logger) time.Duration {
 }
 
 func run(ctx context.Context, logger *slog.Logger) error {
+	// telemetry.Init must run first: it registers the global TracerProvider and
+	// TextMapPropagator via otel.SetTextMapPropagator. newRouter (called below)
+	// constructs the otelhttp handler, which captures otel.GetTextMapPropagator()
+	// eagerly at construction time. Reversing this order would silently drop
+	// traceparent extraction for every incoming request.
 	tracerShutdown, err := telemetry.Init(ctx, logger)
 	if err != nil {
 		return eris.Wrap(err, "run: telemetry init")
@@ -143,6 +155,9 @@ func run(ctx context.Context, logger *slog.Logger) error {
 	profileUC := usecase.NewProfileUsecase(profileRepo)
 
 	resolvers := &resolver.Resolver{Profile: profileUC}
+	// newRouter must be called after telemetry.Init: the otelhttp handler it
+	// constructs reads otel.GetTextMapPropagator() eagerly. See comment above
+	// telemetry.Init for the full ordering invariant.
 	e := newRouter(resolvers, authMW, profileRepo)
 	e.Logger = logger
 

--- a/backend/cmd/server/main_test.go
+++ b/backend/cmd/server/main_test.go
@@ -842,6 +842,27 @@ func TestGraphQL_PropagatesTraceparent(t *testing.T) {
 	if !sawOperation {
 		t.Errorf("expected a gqlgen operation or resolver span, got: %v", names)
 	}
+
+	// Verify the parent-child relationship: at least one server-side span must
+	// have its Parent pointing at the injected (remote) span. This catches the
+	// regression where otelhttp ignores the inbound traceparent and silently
+	// creates a new root span — the spans would all share a *new* trace ID
+	// instead of rooting back to the caller's spanIDHex.
+	var sawInjectedParent bool
+	for _, s := range spans {
+		if s.Parent.SpanID().String() == spanIDHex &&
+			s.Parent.TraceID().String() == traceIDHex {
+			sawInjectedParent = true
+			t.Logf("span %q correctly links to injected parent %s/%s",
+				s.Name, traceIDHex, spanIDHex)
+			break
+		}
+	}
+	if !sawInjectedParent {
+		t.Errorf("no span had Parent.SpanID=%q / Parent.TraceID=%q; "+
+			"otelhttp may not be extracting the inbound traceparent. spans: %v",
+			spanIDHex, traceIDHex, names)
+	}
 }
 
 func TestLoader_Middleware_DoesNotBreakQuery(t *testing.T) {

--- a/backend/cmd/server/main_test.go
+++ b/backend/cmd/server/main_test.go
@@ -772,8 +772,8 @@ func TestGraphQL_PropagatesTraceparent(t *testing.T) {
 	ts := newTestServer(t)
 
 	const (
-		traceIDHex = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-		spanIDHex  = "bbbbbbbbbbbbbbbb"
+		traceIDHex  = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+		spanIDHex   = "bbbbbbbbbbbbbbbb"
 		traceparent = "00-" + traceIDHex + "-" + spanIDHex + "-01"
 	)
 
@@ -819,7 +819,6 @@ func TestGraphQL_PropagatesTraceparent(t *testing.T) {
 	}
 	t.Logf("propagation test span names: %v", names)
 
-	// Verify that at least one HTTP-layer span exists (otelhttp wraps the handler).
 	var sawHTTP bool
 	for _, n := range names {
 		if strings.Contains(n, "/query") || strings.Contains(n, "POST") || strings.Contains(n, "graphql.http") {
@@ -831,7 +830,6 @@ func TestGraphQL_PropagatesTraceparent(t *testing.T) {
 		t.Errorf("expected an HTTP-layer span (POST /query or graphql.http), got: %v", names)
 	}
 
-	// Verify at least one gqlgen operation-level span exists.
 	var sawOperation bool
 	for _, n := range names {
 		if strings.Contains(n, "Health") || strings.Contains(n, "health") || strings.Contains(n, "Query") {

--- a/backend/cmd/server/main_test.go
+++ b/backend/cmd/server/main_test.go
@@ -762,6 +762,88 @@ func sha256Hex(s string) string {
 	return hex.EncodeToString(sum[:])
 }
 
+// TestGraphQL_PropagatesTraceparent verifies that an incoming W3C traceparent
+// header is extracted by the otelhttp layer and that all emitted spans share
+// the trace ID supplied by the caller.
+func TestGraphQL_PropagatesTraceparent(t *testing.T) {
+	exp, flush := installInMemoryTracer(t)
+
+	// The /query group uses noopAuthMW so no real JWT is needed here.
+	ts := newTestServer(t)
+
+	const (
+		traceIDHex = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+		spanIDHex  = "bbbbbbbbbbbbbbbb"
+		traceparent = "00-" + traceIDHex + "-" + spanIDHex + "-01"
+	)
+
+	body := bytes.NewBufferString(`{"query":"{ health }"}`)
+	req, err := http.NewRequest(http.MethodPost, ts.URL+"/query", body)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("traceparent", traceparent)
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST /query: %v", err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		raw, _ := io.ReadAll(res.Body)
+		t.Fatalf("status = %d, body = %q", res.StatusCode, raw)
+	}
+
+	flush()
+
+	spans := exp.GetSpans()
+	if len(spans) == 0 {
+		t.Fatal("expected at least one span, got none")
+	}
+
+	wantTraceID, err := hex.DecodeString(traceIDHex)
+	if err != nil {
+		t.Fatalf("decode traceIDHex: %v", err)
+	}
+	var wantArr [16]byte
+	copy(wantArr[:], wantTraceID)
+
+	names := make([]string, 0, len(spans))
+	for _, s := range spans {
+		names = append(names, s.Name)
+		if s.SpanContext.TraceID() != wantArr {
+			t.Errorf("span %q: TraceID = %s, want %s",
+				s.Name, s.SpanContext.TraceID(), traceIDHex)
+		}
+	}
+	t.Logf("propagation test span names: %v", names)
+
+	// Verify that at least one HTTP-layer span exists (otelhttp wraps the handler).
+	var sawHTTP bool
+	for _, n := range names {
+		if strings.Contains(n, "/query") || strings.Contains(n, "POST") || strings.Contains(n, "graphql.http") {
+			sawHTTP = true
+			break
+		}
+	}
+	if !sawHTTP {
+		t.Errorf("expected an HTTP-layer span (POST /query or graphql.http), got: %v", names)
+	}
+
+	// Verify at least one gqlgen operation-level span exists.
+	var sawOperation bool
+	for _, n := range names {
+		if strings.Contains(n, "Health") || strings.Contains(n, "health") || strings.Contains(n, "Query") {
+			sawOperation = true
+			break
+		}
+	}
+	if !sawOperation {
+		t.Errorf("expected a gqlgen operation or resolver span, got: %v", names)
+	}
+}
+
 func TestLoader_Middleware_DoesNotBreakQuery(t *testing.T) {
 	f := newJWTFixture(t)
 	ts, _ := newGraphQLTestServer(t, f)

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/testcontainers/testcontainers-go v0.42.0
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.42.0
 	github.com/vektah/gqlparser/v2 v2.5.27
+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.43.0
 	go.opentelemetry.io/otel/sdk v1.43.0
@@ -87,7 +88,6 @@ require (
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib v1.36.0 // indirect
-	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0 // indirect
 	go.opentelemetry.io/otel/metric v1.43.0 // indirect
 	go.opentelemetry.io/otel/trace v1.43.0 // indirect

--- a/backend/internal/logging/handler.go
+++ b/backend/internal/logging/handler.go
@@ -5,35 +5,25 @@ import (
 	"log/slog"
 )
 
-// ContextLookup is a function that retrieves a string value from a context.
-// Passing the lookup function rather than importing the middleware package
-// directly avoids an import cycle between logging and middleware.
+// ContextLookup retrieves a string value from a context.
+// Using a function rather than importing middleware directly avoids an import cycle.
 type ContextLookup func(context.Context) string
 
 // ContextHandler is an slog.Handler that enriches every log record with
-// values extracted from the record's context via a `ContextLookup` function.
-// In practice it is used to attach the current request_id to
-// every log line automatically.
+// values extracted from the record's context via a ContextLookup function.
 type ContextHandler struct {
 	inner  slog.Handler
 	lookup ContextLookup
 }
 
-// NewContextHandler wraps inner with a ContextHandler that calls lookup on
-// every Handle invocation. When lookup returns a non-empty string the value
-// is added to the record as the "request_id" attribute before delegating to
-// inner.
 func NewContextHandler(inner slog.Handler, lookup ContextLookup) *ContextHandler {
 	return &ContextHandler{inner: inner, lookup: lookup}
 }
 
-// Enabled reports whether the inner handler is enabled for the given level.
 func (h *ContextHandler) Enabled(ctx context.Context, level slog.Level) bool {
 	return h.inner.Enabled(ctx, level)
 }
 
-// Handle enriches r with the request_id extracted from ctx (when non-empty)
-// and then forwards the record to the inner handler.
 func (h *ContextHandler) Handle(ctx context.Context, r slog.Record) error {
 	if h.lookup != nil {
 		if id := h.lookup(ctx); id != "" {
@@ -43,14 +33,10 @@ func (h *ContextHandler) Handle(ctx context.Context, r slog.Record) error {
 	return h.inner.Handle(ctx, r)
 }
 
-// WithAttrs returns a new ContextHandler whose inner handler has the given
-// attributes pre-applied. The lookup function is preserved.
 func (h *ContextHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
 	return &ContextHandler{inner: h.inner.WithAttrs(attrs), lookup: h.lookup}
 }
 
-// WithGroup returns a new ContextHandler whose inner handler groups subsequent
-// attributes under name. The lookup function is preserved.
 func (h *ContextHandler) WithGroup(name string) slog.Handler {
 	return &ContextHandler{inner: h.inner.WithGroup(name), lookup: h.lookup}
 }

--- a/backend/internal/logging/handler.go
+++ b/backend/internal/logging/handler.go
@@ -1,0 +1,56 @@
+package logging
+
+import (
+	"context"
+	"log/slog"
+)
+
+// ContextLookup is a function that retrieves a string value from a context.
+// Passing the lookup function rather than importing the middleware package
+// directly avoids an import cycle between logging and middleware.
+type ContextLookup func(context.Context) string
+
+// ContextHandler is an slog.Handler that enriches every log record with
+// values extracted from the record's context via a set of ContextLookup
+// functions. In practice it is used to attach the current request_id to
+// every log line automatically.
+type ContextHandler struct {
+	inner  slog.Handler
+	lookup ContextLookup
+}
+
+// NewContextHandler wraps inner with a ContextHandler that calls lookup on
+// every Handle invocation. When lookup returns a non-empty string the value
+// is added to the record as the "request_id" attribute before delegating to
+// inner.
+func NewContextHandler(inner slog.Handler, lookup ContextLookup) *ContextHandler {
+	return &ContextHandler{inner: inner, lookup: lookup}
+}
+
+// Enabled reports whether the inner handler is enabled for the given level.
+func (h *ContextHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return h.inner.Enabled(ctx, level)
+}
+
+// Handle enriches r with the request_id extracted from ctx (when non-empty)
+// and then forwards the record to the inner handler.
+func (h *ContextHandler) Handle(ctx context.Context, r slog.Record) error {
+	if h.lookup != nil {
+		if id := h.lookup(ctx); id != "" {
+			r.AddAttrs(slog.String("request_id", id))
+		}
+	}
+	return h.inner.Handle(ctx, r)
+}
+
+// WithAttrs returns a new ContextHandler whose inner handler has the given
+// attributes pre-applied. The lookup function is preserved.
+func (h *ContextHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &ContextHandler{inner: h.inner.WithAttrs(attrs), lookup: h.lookup}
+}
+
+// WithGroup returns a new ContextHandler whose inner handler groups subsequent
+// attributes under name. The lookup function is preserved.
+func (h *ContextHandler) WithGroup(name string) slog.Handler {
+	return &ContextHandler{inner: h.inner.WithGroup(name), lookup: h.lookup}
+}

--- a/backend/internal/logging/handler.go
+++ b/backend/internal/logging/handler.go
@@ -11,8 +11,8 @@ import (
 type ContextLookup func(context.Context) string
 
 // ContextHandler is an slog.Handler that enriches every log record with
-// values extracted from the record's context via a set of ContextLookup
-// functions. In practice it is used to attach the current request_id to
+// values extracted from the record's context via a `ContextLookup` function.
+// In practice it is used to attach the current request_id to
 // every log line automatically.
 type ContextHandler struct {
 	inner  slog.Handler

--- a/backend/internal/logging/handler_test.go
+++ b/backend/internal/logging/handler_test.go
@@ -10,24 +10,17 @@ import (
 	"backend/internal/logging"
 )
 
-// fixedLookup returns a ContextLookup that always returns the given value,
-// simulating middleware.RequestIDFromContext for a context that carries an ID.
 func fixedLookup(id string) logging.ContextLookup {
 	return func(_ context.Context) string { return id }
 }
 
-// emptyLookup is a ContextLookup that always returns "", simulating a context
-// that has no request ID stored.
 func emptyLookup(_ context.Context) string { return "" }
 
-// newBufLogger builds a *slog.Logger backed by a ContextHandler wrapping a
-// JSON handler that writes to buf.
 func newBufLogger(buf *bytes.Buffer, lookup logging.ContextLookup) *slog.Logger {
 	inner := slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug})
 	return slog.New(logging.NewContextHandler(inner, lookup))
 }
 
-// decodeJSON unmarshals the first JSON object in buf.
 func decodeJSON(t *testing.T, buf *bytes.Buffer) map[string]any {
 	t.Helper()
 	var m map[string]any
@@ -37,8 +30,6 @@ func decodeJSON(t *testing.T, buf *bytes.Buffer) map[string]any {
 	return m
 }
 
-// TestContextHandler_RequestIDPresentInContext verifies that when the lookup
-// returns a non-empty ID, the log record contains "request_id".
 func TestContextHandler_RequestIDPresentInContext(t *testing.T) {
 	const wantID = "test-request-id-001"
 	buf := &bytes.Buffer{}
@@ -56,8 +47,6 @@ func TestContextHandler_RequestIDPresentInContext(t *testing.T) {
 	}
 }
 
-// TestContextHandler_NoRequestIDInBareCtx verifies that when the lookup
-// returns an empty string, no "request_id" attribute is added to the record.
 func TestContextHandler_NoRequestIDInBareCtx(t *testing.T) {
 	buf := &bytes.Buffer{}
 	logger := newBufLogger(buf, emptyLookup)
@@ -70,15 +59,12 @@ func TestContextHandler_NoRequestIDInBareCtx(t *testing.T) {
 	}
 }
 
-// TestContextHandler_WithAttrsAndWithGroupPreserveRequestID verifies that
-// loggers derived via WithAttrs and WithGroup still attach request_id.
 func TestContextHandler_WithAttrsAndWithGroupPreserveRequestID(t *testing.T) {
 	const wantID = "propagated-id-42"
 
 	t.Run("WithAttrs", func(t *testing.T) {
 		buf := &bytes.Buffer{}
 		logger := newBufLogger(buf, fixedLookup(wantID))
-		// Derive a child logger with an extra static attribute.
 		child := logger.With("component", "test")
 		child.InfoContext(context.Background(), "via with-attrs")
 

--- a/backend/internal/logging/handler_test.go
+++ b/backend/internal/logging/handler_test.go
@@ -1,0 +1,116 @@
+package logging_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"testing"
+
+	"backend/internal/logging"
+)
+
+// fixedLookup returns a ContextLookup that always returns the given value,
+// simulating middleware.RequestIDFromContext for a context that carries an ID.
+func fixedLookup(id string) logging.ContextLookup {
+	return func(_ context.Context) string { return id }
+}
+
+// emptyLookup is a ContextLookup that always returns "", simulating a context
+// that has no request ID stored.
+func emptyLookup(_ context.Context) string { return "" }
+
+// newBufLogger builds a *slog.Logger backed by a ContextHandler wrapping a
+// JSON handler that writes to buf.
+func newBufLogger(buf *bytes.Buffer, lookup logging.ContextLookup) *slog.Logger {
+	inner := slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	return slog.New(logging.NewContextHandler(inner, lookup))
+}
+
+// decodeJSON unmarshals the first JSON object in buf.
+func decodeJSON(t *testing.T, buf *bytes.Buffer) map[string]any {
+	t.Helper()
+	var m map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &m); err != nil {
+		t.Fatalf("JSON decode failed: %v\nraw: %s", err, buf.String())
+	}
+	return m
+}
+
+// TestContextHandler_RequestIDPresentInContext verifies that when the lookup
+// returns a non-empty ID, the log record contains "request_id".
+func TestContextHandler_RequestIDPresentInContext(t *testing.T) {
+	const wantID = "test-request-id-001"
+	buf := &bytes.Buffer{}
+	logger := newBufLogger(buf, fixedLookup(wantID))
+
+	logger.InfoContext(context.Background(), "hello")
+
+	rec := decodeJSON(t, buf)
+	got, ok := rec["request_id"]
+	if !ok {
+		t.Fatalf("expected request_id attribute in log record, got %v", rec)
+	}
+	if got != wantID {
+		t.Errorf("request_id: want %q, got %q", wantID, got)
+	}
+}
+
+// TestContextHandler_NoRequestIDInBareCtx verifies that when the lookup
+// returns an empty string, no "request_id" attribute is added to the record.
+func TestContextHandler_NoRequestIDInBareCtx(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := newBufLogger(buf, emptyLookup)
+
+	logger.InfoContext(context.Background(), "hello")
+
+	rec := decodeJSON(t, buf)
+	if _, ok := rec["request_id"]; ok {
+		t.Errorf("expected no request_id attribute, but found one: %v", rec["request_id"])
+	}
+}
+
+// TestContextHandler_WithAttrsAndWithGroupPreserveRequestID verifies that
+// loggers derived via WithAttrs and WithGroup still attach request_id.
+func TestContextHandler_WithAttrsAndWithGroupPreserveRequestID(t *testing.T) {
+	const wantID = "propagated-id-42"
+
+	t.Run("WithAttrs", func(t *testing.T) {
+		buf := &bytes.Buffer{}
+		logger := newBufLogger(buf, fixedLookup(wantID))
+		// Derive a child logger with an extra static attribute.
+		child := logger.With("component", "test")
+		child.InfoContext(context.Background(), "via with-attrs")
+
+		rec := decodeJSON(t, buf)
+		if got, ok := rec["request_id"]; !ok || got != wantID {
+			t.Errorf("WithAttrs: request_id want %q, got %v (present=%v)", wantID, got, ok)
+		}
+		if rec["component"] != "test" {
+			t.Errorf("WithAttrs: expected component=test, got %v", rec["component"])
+		}
+	})
+
+	t.Run("WithGroup", func(t *testing.T) {
+		buf := &bytes.Buffer{}
+		inner := slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+		base := logging.NewContextHandler(inner, fixedLookup(wantID))
+		// WithGroup wraps the inner handler's subsequent attributes under "grp".
+		// request_id is added via r.AddAttrs inside Handle, so it is emitted
+		// under the group key in the JSON output.
+		grouped := base.WithGroup("grp")
+		logger := slog.New(grouped)
+		logger.InfoContext(context.Background(), "via with-group", slog.String("k", "v"))
+
+		rec := decodeJSON(t, buf)
+		// After WithGroup("grp"), the JSON handler nests attrs under "grp".
+		// request_id appears inside that object because AddAttrs runs after grouping.
+		grpObj, ok := rec["grp"].(map[string]any)
+		if !ok {
+			t.Fatalf("WithGroup: expected 'grp' key to be a JSON object, got %T (%v)", rec["grp"], rec)
+		}
+		if got, present := grpObj["request_id"]; !present || got != wantID {
+			t.Errorf("WithGroup: request_id want %q inside grp, got %v (present=%v)", wantID, got, present)
+		}
+	})
+}

--- a/backend/internal/middleware/request_id.go
+++ b/backend/internal/middleware/request_id.go
@@ -3,6 +3,9 @@ package middleware
 
 import (
 	"context"
+	"fmt"
+	"log/slog"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v5"
@@ -30,11 +33,16 @@ func contextWithRequestID(ctx context.Context, id string) context.Context {
 }
 
 // generateRequestID creates a new UUIDv7 string. On the rare event that
-// uuid.NewV7 fails (e.g. rand source unavailable), it falls back to UUIDv4.
+// uuid.NewV7 fails (e.g. rand source unavailable), it falls back to a
+// timestamp-based ID that does not depend on rand, and logs the failure.
 func generateRequestID() string {
 	id, err := uuid.NewV7()
 	if err != nil {
-		return uuid.NewString()
+		// crypto/rand failure. Fall back to a timestamp-based ID that does
+		// not depend on rand, and surface the failure for operators.
+		slog.Error("request_id: uuid.NewV7 failed; using timestamp fallback",
+			"err", err)
+		return fmt.Sprintf("fallback-%d", time.Now().UnixNano())
 	}
 	return id.String()
 }
@@ -55,6 +63,11 @@ func RequestID() echo.MiddlewareFunc {
 				// Honour a well-formed upstream ID (e.g. cloud LB, gateway).
 				id = incoming
 			} else {
+				if incoming != "" {
+					slog.WarnContext(c.Request().Context(),
+						"request_id: rejected incoming X-Request-ID, regenerating",
+						"incoming_len", len(incoming))
+				}
 				id = generateRequestID()
 			}
 

--- a/backend/internal/middleware/request_id.go
+++ b/backend/internal/middleware/request_id.go
@@ -1,4 +1,3 @@
-// Package middleware provides Echo middleware helpers for the flamingo-armond backend.
 package middleware
 
 import (
@@ -11,14 +10,12 @@ import (
 	"github.com/labstack/echo/v5"
 )
 
-// RequestIDHeader is the canonical HTTP header name for the request identifier.
 const RequestIDHeader = "X-Request-ID"
 
 // maxRequestIDLen is the maximum accepted length for an incoming X-Request-ID value.
 // Values longer than this are dropped and regenerated to prevent log injection.
 const maxRequestIDLen = 128
 
-// requestIDKey is the unexported context key type for the request ID.
 type requestIDKey struct{}
 
 // RequestIDFromContext returns the request ID stored in ctx, or "" if none is present.
@@ -27,64 +24,42 @@ func RequestIDFromContext(ctx context.Context) string {
 	return v
 }
 
-// contextWithRequestID stores id in ctx under the requestIDKey.
-func contextWithRequestID(ctx context.Context, id string) context.Context {
-	return context.WithValue(ctx, requestIDKey{}, id)
-}
-
-// generateRequestID creates a new UUIDv7 string. On the rare event that
-// uuid.NewV7 fails (e.g. rand source unavailable), it falls back to a
-// timestamp-based ID that does not depend on rand, and logs the failure.
 func generateRequestID() string {
 	id, err := uuid.NewV7()
 	if err != nil {
-		// crypto/rand failure. Fall back to a timestamp-based ID that does
-		// not depend on rand, and surface the failure for operators.
-		slog.Error("request_id: uuid.NewV7 failed; using timestamp fallback",
-			"err", err)
+		slog.Error("request_id: uuid.NewV7 failed; using timestamp fallback", "err", err)
 		return fmt.Sprintf("fallback-%d", time.Now().UnixNano())
 	}
 	return id.String()
 }
 
 // RequestID returns an Echo middleware that reads X-Request-ID from the incoming
-// request and stores it in the request context. If the header is absent or its
-// value exceeds maxRequestIDLen, a new UUIDv7 is generated instead.
-//
-// The resolved ID is echoed in the X-Request-ID response header before the
-// handler chain runs so that error responses also carry the header.
+// request, stores it in the request context, and echoes it in the response header.
+// Absent or overlong headers are replaced with a generated UUIDv7.
 func RequestID() echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c *echo.Context) error {
 			incoming := c.Request().Header.Get(RequestIDHeader)
 
 			var id string
-			rejected := false
-			if incoming != "" && len(incoming) <= maxRequestIDLen {
-				// Honour a well-formed upstream ID (e.g. cloud LB, gateway).
+			rejected := incoming != "" && len(incoming) > maxRequestIDLen
+			if incoming != "" && !rejected {
 				id = incoming
 			} else {
-				if incoming != "" {
-					rejected = true
-				}
 				id = generateRequestID()
 			}
 
-			// Stash the ID in the request context first so all downstream code
-			// (resolvers, slog handler, etc.) can read it without touching HTTP.
-			ctx := contextWithRequestID(c.Request().Context(), id)
+			ctx := context.WithValue(c.Request().Context(), requestIDKey{}, id)
 			c.SetRequest(c.Request().WithContext(ctx))
 
-			// Warn after enriching the context so ContextHandler attaches the
-			// new request_id attribute to the warn record.
+			// Warn after enriching the context so ContextHandler attaches request_id.
 			if rejected {
 				slog.WarnContext(ctx,
 					"request_id: rejected incoming X-Request-ID, regenerating",
 					"incoming_len", len(incoming))
 			}
 
-			// Set the response header before calling next so that even error
-			// responses produced by downstream handlers carry the request ID.
+			// Set response header before next so error responses also carry the ID.
 			c.Response().Header().Set(RequestIDHeader, id)
 
 			return next(c)

--- a/backend/internal/middleware/request_id.go
+++ b/backend/internal/middleware/request_id.go
@@ -59,26 +59,33 @@ func RequestID() echo.MiddlewareFunc {
 			incoming := c.Request().Header.Get(RequestIDHeader)
 
 			var id string
+			rejected := false
 			if incoming != "" && len(incoming) <= maxRequestIDLen {
 				// Honour a well-formed upstream ID (e.g. cloud LB, gateway).
 				id = incoming
 			} else {
 				if incoming != "" {
-					slog.WarnContext(c.Request().Context(),
-						"request_id: rejected incoming X-Request-ID, regenerating",
-						"incoming_len", len(incoming))
+					rejected = true
 				}
 				id = generateRequestID()
+			}
+
+			// Stash the ID in the request context first so all downstream code
+			// (resolvers, slog handler, etc.) can read it without touching HTTP.
+			ctx := contextWithRequestID(c.Request().Context(), id)
+			c.SetRequest(c.Request().WithContext(ctx))
+
+			// Warn after enriching the context so ContextHandler attaches the
+			// new request_id attribute to the warn record.
+			if rejected {
+				slog.WarnContext(ctx,
+					"request_id: rejected incoming X-Request-ID, regenerating",
+					"incoming_len", len(incoming))
 			}
 
 			// Set the response header before calling next so that even error
 			// responses produced by downstream handlers carry the request ID.
 			c.Response().Header().Set(RequestIDHeader, id)
-
-			// Stash the ID in the request context so all downstream code
-			// (resolvers, slog handler, etc.) can read it without touching HTTP.
-			ctx := contextWithRequestID(c.Request().Context(), id)
-			c.SetRequest(c.Request().WithContext(ctx))
 
 			return next(c)
 		}

--- a/backend/internal/middleware/request_id.go
+++ b/backend/internal/middleware/request_id.go
@@ -1,0 +1,73 @@
+// Package middleware provides Echo middleware helpers for the flamingo-armond backend.
+package middleware
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v5"
+)
+
+// RequestIDHeader is the canonical HTTP header name for the request identifier.
+const RequestIDHeader = "X-Request-ID"
+
+// maxRequestIDLen is the maximum accepted length for an incoming X-Request-ID value.
+// Values longer than this are dropped and regenerated to prevent log injection.
+const maxRequestIDLen = 128
+
+// requestIDKey is the unexported context key type for the request ID.
+type requestIDKey struct{}
+
+// RequestIDFromContext returns the request ID stored in ctx, or "" if none is present.
+func RequestIDFromContext(ctx context.Context) string {
+	v, _ := ctx.Value(requestIDKey{}).(string)
+	return v
+}
+
+// contextWithRequestID stores id in ctx under the requestIDKey.
+func contextWithRequestID(ctx context.Context, id string) context.Context {
+	return context.WithValue(ctx, requestIDKey{}, id)
+}
+
+// generateRequestID creates a new UUIDv7 string. On the rare event that
+// uuid.NewV7 fails (e.g. rand source unavailable), it falls back to UUIDv4.
+func generateRequestID() string {
+	id, err := uuid.NewV7()
+	if err != nil {
+		return uuid.NewString()
+	}
+	return id.String()
+}
+
+// RequestID returns an Echo middleware that reads X-Request-ID from the incoming
+// request and stores it in the request context. If the header is absent or its
+// value exceeds maxRequestIDLen, a new UUIDv7 is generated instead.
+//
+// The resolved ID is echoed in the X-Request-ID response header before the
+// handler chain runs so that error responses also carry the header.
+func RequestID() echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c *echo.Context) error {
+			incoming := c.Request().Header.Get(RequestIDHeader)
+
+			var id string
+			if incoming != "" && len(incoming) <= maxRequestIDLen {
+				// Honour a well-formed upstream ID (e.g. cloud LB, gateway).
+				id = incoming
+			} else {
+				id = generateRequestID()
+			}
+
+			// Set the response header before calling next so that even error
+			// responses produced by downstream handlers carry the request ID.
+			c.Response().Header().Set(RequestIDHeader, id)
+
+			// Stash the ID in the request context so all downstream code
+			// (resolvers, slog handler, etc.) can read it without touching HTTP.
+			ctx := contextWithRequestID(c.Request().Context(), id)
+			c.SetRequest(c.Request().WithContext(ctx))
+
+			return next(c)
+		}
+	}
+}

--- a/backend/internal/middleware/request_id_test.go
+++ b/backend/internal/middleware/request_id_test.go
@@ -1,0 +1,135 @@
+package middleware_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo/v5"
+
+	mw "backend/internal/middleware"
+)
+
+// noopHandler is an Echo HandlerFunc that always returns nil (HTTP 200).
+func noopHandler(c *echo.Context) error { return nil }
+
+// applyMiddleware wraps handler with the RequestID middleware and executes the
+// resulting chain against req, returning the recorded response.
+func applyMiddleware(t *testing.T, req *http.Request) *httptest.ResponseRecorder {
+	t.Helper()
+	e := echo.New()
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	handler := mw.RequestID()(noopHandler)
+	if err := handler(c); err != nil {
+		t.Fatalf("middleware returned unexpected error: %v", err)
+	}
+	return rec
+}
+
+// TestRequestID_EmptyHeader verifies that a request without X-Request-ID gets
+// a generated UUIDv7, which is stored in context and echoed in the response.
+func TestRequestID_EmptyHeader(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	e := echo.New()
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	var capturedID string
+	handler := mw.RequestID()(func(c *echo.Context) error {
+		capturedID = mw.RequestIDFromContext(c.Request().Context())
+		return nil
+	})
+
+	if err := handler(c); err != nil {
+		t.Fatalf("middleware error: %v", err)
+	}
+
+	if capturedID == "" {
+		t.Error("expected a generated request ID in context, got empty string")
+	}
+	responseID := rec.Header().Get(mw.RequestIDHeader)
+	if responseID == "" {
+		t.Error("expected X-Request-ID response header to be set")
+	}
+	if capturedID != responseID {
+		t.Errorf("context ID %q != response header ID %q", capturedID, responseID)
+	}
+}
+
+// TestRequestID_UpstreamHeaderRespected verifies that a valid upstream
+// X-Request-ID is kept as-is and not regenerated.
+func TestRequestID_UpstreamHeaderRespected(t *testing.T) {
+	const upstreamID = "upstream-id-abc123"
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set(mw.RequestIDHeader, upstreamID)
+
+	e := echo.New()
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	var capturedID string
+	handler := mw.RequestID()(func(c *echo.Context) error {
+		capturedID = mw.RequestIDFromContext(c.Request().Context())
+		return nil
+	})
+
+	if err := handler(c); err != nil {
+		t.Fatalf("middleware error: %v", err)
+	}
+
+	if capturedID != upstreamID {
+		t.Errorf("expected context ID %q, got %q", upstreamID, capturedID)
+	}
+	if got := rec.Header().Get(mw.RequestIDHeader); got != upstreamID {
+		t.Errorf("expected response header %q, got %q", upstreamID, got)
+	}
+}
+
+// TestRequestID_OverlongHeaderRegenerated verifies that an X-Request-ID value
+// exceeding 128 bytes is rejected and a fresh ID is generated instead.
+func TestRequestID_OverlongHeaderRegenerated(t *testing.T) {
+	overlong := strings.Repeat("x", 129)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set(mw.RequestIDHeader, overlong)
+
+	e := echo.New()
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	var capturedID string
+	handler := mw.RequestID()(func(c *echo.Context) error {
+		capturedID = mw.RequestIDFromContext(c.Request().Context())
+		return nil
+	})
+
+	if err := handler(c); err != nil {
+		t.Fatalf("middleware error: %v", err)
+	}
+
+	if capturedID == overlong {
+		t.Error("overlong incoming ID must not be propagated; expected a new generated ID")
+	}
+	if capturedID == "" {
+		t.Error("expected a generated replacement ID, got empty string")
+	}
+	responseID := rec.Header().Get(mw.RequestIDHeader)
+	if responseID == overlong {
+		t.Error("overlong ID must not appear in response header")
+	}
+	if responseID != capturedID {
+		t.Errorf("context ID %q != response header ID %q", capturedID, responseID)
+	}
+}
+
+// TestRequestIDFromContext_BareCtx verifies that RequestIDFromContext returns
+// an empty string when no ID has been stored in the context.
+func TestRequestIDFromContext_BareCtx(t *testing.T) {
+	got := mw.RequestIDFromContext(context.Background())
+	if got != "" {
+		t.Errorf("expected empty string from bare context, got %q", got)
+	}
+}

--- a/backend/internal/middleware/request_id_test.go
+++ b/backend/internal/middleware/request_id_test.go
@@ -12,11 +12,8 @@ import (
 	mw "backend/internal/middleware"
 )
 
-// noopHandler is an Echo HandlerFunc that always returns nil (HTTP 200).
 func noopHandler(c *echo.Context) error { return nil }
 
-// applyMiddleware wraps handler with the RequestID middleware and executes the
-// resulting chain against req, returning the recorded response.
 func applyMiddleware(t *testing.T, req *http.Request) *httptest.ResponseRecorder {
 	t.Helper()
 	e := echo.New()
@@ -30,8 +27,6 @@ func applyMiddleware(t *testing.T, req *http.Request) *httptest.ResponseRecorder
 	return rec
 }
 
-// TestRequestID_EmptyHeader verifies that a request without X-Request-ID gets
-// a generated UUIDv7, which is stored in context and echoed in the response.
 func TestRequestID_EmptyHeader(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	e := echo.New()
@@ -60,8 +55,6 @@ func TestRequestID_EmptyHeader(t *testing.T) {
 	}
 }
 
-// TestRequestID_UpstreamHeaderRespected verifies that a valid upstream
-// X-Request-ID is kept as-is and not regenerated.
 func TestRequestID_UpstreamHeaderRespected(t *testing.T) {
 	const upstreamID = "upstream-id-abc123"
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -89,8 +82,6 @@ func TestRequestID_UpstreamHeaderRespected(t *testing.T) {
 	}
 }
 
-// TestRequestID_OverlongHeaderRegenerated verifies that an X-Request-ID value
-// exceeding 128 bytes is rejected and a fresh ID is generated instead.
 func TestRequestID_OverlongHeaderRegenerated(t *testing.T) {
 	overlong := strings.Repeat("x", 129)
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -125,8 +116,6 @@ func TestRequestID_OverlongHeaderRegenerated(t *testing.T) {
 	}
 }
 
-// TestRequestIDFromContext_BareCtx verifies that RequestIDFromContext returns
-// an empty string when no ID has been stored in the context.
 func TestRequestIDFromContext_BareCtx(t *testing.T) {
 	got := mw.RequestIDFromContext(context.Background())
 	if got != "" {

--- a/backend/internal/telemetry/otel.go
+++ b/backend/internal/telemetry/otel.go
@@ -15,6 +15,7 @@ import (
 	"github.com/rotisserie/eris"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
+	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
@@ -66,6 +67,10 @@ func InitWithExporter(ctx context.Context, logger *slog.Logger, exp sdktrace.Spa
 		sdktrace.WithSampler(sampler(logger)),
 	)
 	otel.SetTracerProvider(tp)
+	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
+		propagation.TraceContext{},
+		propagation.Baggage{},
+	))
 	logger.Info("telemetry enabled", "sampler_arg", os.Getenv("OTEL_TRACES_SAMPLER_ARG"))
 	return func(ctx context.Context) error { return tp.Shutdown(ctx) }, nil
 }

--- a/backend/internal/telemetry/otel_test.go
+++ b/backend/internal/telemetry/otel_test.go
@@ -11,6 +11,31 @@ import (
 	"backend/internal/telemetry"
 )
 
+func TestInit_SetsTextMapPropagator(t *testing.T) {
+	exp := tracetest.NewInMemoryExporter()
+	shutdown, err := telemetry.InitWithExporter(
+		context.Background(),
+		slog.New(slog.DiscardHandler),
+		exp,
+	)
+	if err != nil {
+		t.Fatalf("InitWithExporter: %v", err)
+	}
+	t.Cleanup(func() { _ = shutdown(context.Background()) })
+
+	fields := otel.GetTextMapPropagator().Fields()
+	fieldSet := make(map[string]bool, len(fields))
+	for _, f := range fields {
+		fieldSet[f] = true
+	}
+	if !fieldSet["traceparent"] {
+		t.Errorf("expected propagator Fields to contain 'traceparent', got %v", fields)
+	}
+	if !fieldSet["tracestate"] {
+		t.Errorf("expected propagator Fields to contain 'tracestate', got %v", fields)
+	}
+}
+
 func TestInit_NoopWhenEndpointEmpty(t *testing.T) {
 	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "")
 	shutdown, err := telemetry.Init(context.Background(), slog.New(slog.DiscardHandler))

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -499,6 +499,29 @@ if len(ids) == 0 {
 
 This matters most in DataLoader batch functions, where an empty key slice is a normal edge case.
 
+### slog context enrichment must precede the log call that announces the enrichment
+
+When a middleware sets a value in the context and then logs a message about
+that action, the `slog.*Context` call must come **after**
+`c.SetRequest(c.Request().WithContext(ctx))`. Logging before the context is
+stored means the very line that announces the event carries no `request_id` (or
+other context attribute) itself. The pattern in
+`backend/internal/middleware/request_id.go` — enriching the context first, then
+calling `slog.WarnContext(ctx, ...)` — is the correct template for any
+context-enriched slog handler.
+
+### `slog.Handler.WithGroup` nests subsequent attrs inside the group object
+
+Calling `handler.WithGroup("g")` on a `slog.JSONHandler` (or any handler that
+wraps one, such as `logging.ContextHandler`) causes **all** attrs added
+afterward — including those injected by `Handle` via `r.AddAttrs` — to appear
+under the `"g"` JSON key, not at the top level. In `logging.ContextHandler`,
+`request_id` is added via `r.AddAttrs` inside `Handle`, so after
+`WithGroup("grp")` the log line becomes `{"grp":{"request_id":"...","k":"v"}}`.
+Log queries and tests that expect top-level `request_id` will miss it.
+`backend/internal/logging/handler_test.go` (`TestContextHandler_WithAttrsAndWithGroupPreserveRequestID`)
+documents and asserts this shape.
+
 ## Observability
 
 The backend emits OpenTelemetry traces via `otelgqlgen` for every GraphQL operation, resolver, and scalar field. Spans are exported via OTLP HTTP (port 4318) to whatever collector `OTEL_EXPORTER_OTLP_ENDPOINT` points to.
@@ -563,8 +586,12 @@ structured log fields.
 
 When no valid upstream ID is present, the middleware generates one with
 `uuid.NewV7()` (timestamp-prefixed, lexicographically sortable). If `NewV7`
-fails (e.g. the random source is temporarily unavailable), it falls back to
-`uuid.NewString()` (UUID v4).
+fails (e.g. the random source is temporarily unavailable), the fallback is a
+nanosecond timestamp string (`fmt.Sprintf("fallback-%d", time.Now().UnixNano())`).
+
+**Do not replace the fallback with `uuid.NewString()`.** `uuid.NewString` calls
+`Must(uuid.NewRandom())` internally, which panics on the same `crypto/rand`
+failure that caused `NewV7` to fail — it is not a safe fallback.
 
 ### Middleware position
 

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -542,6 +542,82 @@ Tracer shutdown is last so that DB-layer spans emitted during request drain stil
 | `OTEL_TRACES_SAMPLER_ARG` | no | `1.0` | Float in `[0, 1]`. Parse errors and out-of-range values each emit a `slog.Warn` and fall back to `1.0`. |
 | `APP_ENV` | no | `development` | Used as `deployment.environment` resource attribute. Set to `production` on Render. |
 
+## Request ID propagation
+
+Every HTTP request handled by the backend carries an `X-Request-ID` header. The
+header provides a cheap, grep-friendly correlation ID that flows from the
+frontend through the backend without requiring a full distributed-tracing stack.
+It complements, rather than replaces, the OTel span tree tracked in
+[#22](https://github.com/yasuflatland-lf/flamingo-armond/issues/22).
+
+### Header and length cap
+
+The middleware (`backend/internal/middleware/request_id.go`) reads
+`X-Request-ID` from the incoming request. An upstream value is accepted as-is
+when it is non-empty and at most **128 characters**. Values longer than that are
+dropped and replaced by a freshly generated ID. The cap prevents log injection
+and guards against accidentally forwarding an unbounded upstream payload into
+structured log fields.
+
+### ID generation
+
+When no valid upstream ID is present, the middleware generates one with
+`uuid.NewV7()` (timestamp-prefixed, lexicographically sortable). If `NewV7`
+fails (e.g. the random source is temporarily unavailable), it falls back to
+`uuid.NewString()` (UUID v4).
+
+### Middleware position
+
+```go
+e.Use(middleware.RequestLogger())
+e.Use(middleware.Recover())
+e.Use(internalmw.RequestID())  // third — runs on every route
+```
+
+`RequestID` is registered immediately after `Recover` so that even error
+responses produced by panicking handlers carry the header. It applies globally —
+`/health`, `/playground`, and `/query` all receive it.
+
+The middleware sets `X-Request-ID` on the **response** before calling `next(c)`,
+so error paths also expose the header to callers.
+
+### slog integration
+
+`main()` wires the request-aware logger:
+
+```go
+logger := slog.New(
+    logging.NewContextHandler(
+        slog.NewJSONHandler(os.Stderr, nil),
+        internalmw.RequestIDFromContext,
+    ),
+)
+slog.SetDefault(logger)
+```
+
+`logging.NewContextHandler` wraps any `slog.Handler`. On every `Handle` call it
+reads the request ID from the record's context via the supplied `ContextLookup`
+function and appends it as `"request_id"` before delegating to the inner
+handler. The result: **every `slog.*Context` call** (`slog.InfoContext`,
+`slog.ErrorContext`, etc.) automatically includes `"request_id"` in the JSON
+log line. No resolver or usecase needs to pass it manually.
+
+`slog` calls made **without** a context (`slog.Info(...)`) do not carry a
+request ID — that is by design; they represent process-level events rather than
+per-request ones.
+
+### Decoupling via `ContextLookup`
+
+`logging` does not import `middleware`. The wiring above passes
+`internalmw.RequestIDFromContext` as a plain `func(context.Context) string` so
+the two packages remain independent of each other's import graph.
+
+### Helper
+
+```go
+id := internalmw.RequestIDFromContext(ctx) // returns "" when not present
+```
+
 ## Automatic Persisted Queries
 
 `extension.AutomaticPersistedQuery{Cache: lru.New(100)}` is always registered on the gqlgen handler. There is no env gate — hash-less queries still work as normal POST bodies, so dev / playground flows are unaffected. The first request that contains `extensions.persistedQuery.sha256Hash` populates the LRU cache; subsequent hash-only requests from the same client short-circuit to the cached query text without sending the full document.

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -111,3 +111,19 @@ The backend fails to start if any of these is missing — check `supabase status
 
 - **Use `127.0.0.1`, not `localhost`**: Google OAuth's redirect URI validation treats `localhost` and `127.0.0.1` as distinct hosts. Access the app via `127.0.0.1:3000` to match the default `supabase start` output.
 - **Secrets live in `.env.local` (gitignored)**: `supabase/config.toml` only references them through `env()` placeholders — never commit the actual values.
+
+## Git tooling
+
+### Extracting a single file's hunk from a mixed-purpose commit
+
+When a commit touches multiple concerns (e.g. a backend fix and a frontend
+feature) and you need only one file's changes on a different branch, use:
+
+```bash
+git show <sha> -- path/to/file | git apply
+```
+
+`git show <sha> -- <path>` outputs the patch for that file only; piping it to
+`git apply` applies just that hunk without touching the rest of the commit.
+Useful when rewinding a feature branch but keeping an unrelated fix that landed
+in the same commit.

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -284,11 +284,10 @@ and for the outbound HTTP request.
 
 #### RSC (`gqlFetch`)
 
-`frontend/src/lib/apollo/server.ts` applies the same rule inside `gqlFetch`:
-if the caller's headers do not already contain `X-Request-ID`, a new UUID v7 is
-injected before the `fetch` call. Chained server-to-server calls that forward
-their own incoming header therefore preserve a single correlation ID across the
-full trace.
+`frontend/src/lib/apollo/server.ts` assigns a fresh UUID v7 inside `gqlFetch`
+before the `fetch` call. `gqlFetch` is the RSC entrypoint and has no
+caller-supplied headers, so every call generates a fresh UUID v7 — chained
+correlation across server-to-server calls is out of scope at this tier.
 
 ## Gotchas encountered
 

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -244,6 +244,52 @@ field to `""` so the next submit clears the column.
 
 `shadcn init` is interactive and not suitable for CI or non-interactive environments. The fallback is to hand-write `components.json`, `lib/utils.ts`, and the `globals.css` base tokens following the shadcn JSON schema — that is how this repo's shadcn baseline was bootstrapped.
 
+## Observability
+
+### Request ID propagation
+
+Every GraphQL request sent by the frontend attaches an `X-Request-ID` header
+containing a UUID v7 value. The backend echoes the header on the response and
+stamps `request_id` on every structured log line for that request. A single grep
+on `request_id` therefore spans the full frontend-to-backend call without
+requiring an OTel SDK. Full distributed tracing is tracked in
+[#22](https://github.com/yasuflatland-lf/flamingo-armond/issues/22).
+
+#### Generator (`frontend/src/lib/observability/request-id.ts`)
+
+A ~25-line inline implementation — no external npm dependencies. Uses the
+global `crypto.getRandomValues` API (available in all modern browsers and
+Node 18+). Produces a standard UUID v7 string:
+
+```
+xxxxxxxx-xxxx-7xxx-yxxx-xxxxxxxxxxxx
+```
+
+The 48 high bits encode the Unix timestamp in milliseconds, making IDs
+sortable and traceable to their creation time.
+
+#### Browser (Apollo link chain)
+
+`frontend/src/lib/apollo/request-id-link.ts` exports `requestIdLink`, an
+Apollo `setContext` link. It checks for an existing `X-Request-ID` header
+case-insensitively; if none is found it generates a fresh UUID v7 and attaches
+it. The link is prepended as the first link in `makeClient()`:
+
+```ts
+from([requestIdLink, authLink, makeApqLink(), httpLink])
+```
+
+Being first in the chain ensures the ID is present for every subsequent link
+and for the outbound HTTP request.
+
+#### RSC (`gqlFetch`)
+
+`frontend/src/lib/apollo/server.ts` applies the same rule inside `gqlFetch`:
+if the caller's headers do not already contain `X-Request-ID`, a new UUID v7 is
+injected before the `fetch` call. Chained server-to-server calls that forward
+their own incoming header therefore preserve a single correlation ID across the
+full trace.
+
 ## Gotchas encountered
 
 **`app/<route>/error.tsx` does not catch errors from `app/layout.tsx`.** Next.js error boundaries scoped to a route segment only catch errors thrown by that segment's RSCs and components. Errors thrown inside `app/layout.tsx` (e.g. the `Header`) escape to `app/global-error.tsx`, or to Next's default crash page if `global-error.tsx` is absent. Keep shared layout components defensive — render degraded states rather than throwing.

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -257,9 +257,10 @@ requiring an OTel SDK. Full distributed tracing is tracked in
 
 #### Generator (`frontend/src/lib/observability/request-id.ts`)
 
-A ~25-line inline implementation — no external npm dependencies. Uses the
-global `crypto.getRandomValues` API (available in all modern browsers and
-Node 18+). Produces a standard UUID v7 string:
+A thin wrapper around the `uuidv7` npm package (~1.5 KB gzip). The package
+provides a correct monotonic counter within the same millisecond, which the
+previous inline implementation did not guarantee. Produces a standard UUID v7
+string:
 
 ```
 xxxxxxxx-xxxx-7xxx-yxxx-xxxxxxxxxxxx

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -310,6 +310,8 @@ correlation across server-to-server calls is out of scope at this tier.
 
 **Apollo Client v4 error type split.** `CombinedGraphQLErrors` lives in `@apollo/client/errors`, **not** `@apollo/client`. Use `CombinedGraphQLErrors.is(error)` for type narrowing, then read `error.errors[0]?.message`. The v3 pattern `error.graphQLErrors` does not exist in v4.
 
+**Apollo Client v4 link tests must go through `ApolloClient`, not `execute(link, op)`.** Apollo Client v4 ships with rxjs internally; the `Observable` type returned by `execute` is the rxjs `Observable`, not the legacy Apollo `Observable`. Constructing a standalone `Observable.of(result)` as a terminal mock no longer works. Instead, construct an `ApolloClient` with your link chain and the mock terminal link, then call `client.query()` or `client.mutate()`. The terminal mock link should use `new Observable(subscriber => { subscriber.next(mockResult); subscriber.complete(); })` (rxjs form).
+
 **RSC code must use `env.BACKEND_URL`, not `/api/graphql`.** The rewrite in `next.config.ts` only applies to browser-originating requests. Server components calling `/api/graphql` would hit a Next 404.
 
 **Vitest v3+ dropped `environmentMatchGlobs`.** Use `environment` in `vitest.config.ts` for the global default and add `// @vitest-environment <name>` at the top of individual test files that need a different environment (e.g. `jsdom`). The `environmentMatchGlobs` option is silently ignored in v3+ — tests that relied on it fall back to the global default without warning.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,6 +31,7 @@
     "next": "16.2.4",
     "react": "19.2.0",
     "react-dom": "19.2.0",
+    "uuidv7": "^1.2.1",
     "zod": "3.24.2"
   },
   "devDependencies": {

--- a/frontend/src/lib/apollo/client.test.ts
+++ b/frontend/src/lib/apollo/client.test.ts
@@ -1,5 +1,3 @@
-// Testing strategy: Option A-variant — buildAuthHeaders is extracted to auth-link.ts
-// and tested directly, avoiding the complexity of the Apollo Link Observable API.
 import type { ApolloLink } from "@apollo/client";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { buildAuthHeaders } from "./auth-link";

--- a/frontend/src/lib/apollo/client.test.ts
+++ b/frontend/src/lib/apollo/client.test.ts
@@ -59,25 +59,29 @@ describe("buildAuthHeaders (authLink)", () => {
 });
 
 describe("makeClient link chain", () => {
-  it("chains authLink -> apqLink -> httpLink in order (3 segments)", () => {
+  it("chains requestIdLink -> authLink -> apqLink -> httpLink in order (4 segments)", () => {
     const c = makeClient();
     expect(c.link).toBeDefined();
-    // from([authLink, apqLink, httpLink]) wraps segments in plain ApolloLink
+    // from([requestIdLink, authLink, apqLink, httpLink]) wraps segments in plain ApolloLink
     // glue nodes. collectSegments stops at named sub-classes so we recover the
     // original user-supplied links plus any framework-injected wrappers.
     // @apollo/client-integration-nextjs prepends 2 streaming links, so the
     // full segment list is: [ReadFromReadableStreamLink, TeeToReadableStreamLink,
-    // SetContextLink(auth), PersistedQueryLink(apq), HttpLink(http)].
+    // SetContextLink(requestId), SetContextLink(auth), PersistedQueryLink(apq), HttpLink(http)].
     const links = collectSegments(c.link);
     const names = links.map((l) => l.constructor?.name ?? "");
-    // Core three user-supplied links must all be present.
+    // All four user-supplied link types must be present.
     expect(names).toContain("SetContextLink");
     expect(names).toContain("PersistedQueryLink");
     expect(names).toContain("HttpLink");
-    // Order: auth must come before apq, and apq must come before http.
-    const authIdx = names.indexOf("SetContextLink");
+    // Two SetContextLink instances must exist: requestIdLink and authLink.
+    const requestIdIdx = names.indexOf("SetContextLink");
+    const authIdx = names.lastIndexOf("SetContextLink");
+    expect(requestIdIdx).not.toBe(authIdx); // two distinct SetContextLink instances
     const apqIdx = names.indexOf("PersistedQueryLink");
     const httpIdx = names.indexOf("HttpLink");
+    // Order: requestId -> auth -> apq -> http.
+    expect(requestIdIdx).toBeLessThan(authIdx);
     expect(authIdx).toBeLessThan(apqIdx);
     expect(apqIdx).toBeLessThan(httpIdx);
   });

--- a/frontend/src/lib/apollo/client.ts
+++ b/frontend/src/lib/apollo/client.ts
@@ -4,6 +4,7 @@ import { from, HttpLink } from "@apollo/client";
 import { ApolloClient, InMemoryCache } from "@apollo/client-integration-nextjs";
 import { makeApqLink } from "./apq-link";
 import { authLink } from "./auth-link";
+import { requestIdLink } from "./request-id-link";
 
 const httpLink = new HttpLink({
   uri: "/api/graphql",
@@ -13,6 +14,6 @@ const httpLink = new HttpLink({
 export function makeClient() {
   return new ApolloClient({
     cache: new InMemoryCache(),
-    link: from([authLink, makeApqLink(), httpLink]),
+    link: from([requestIdLink, authLink, makeApqLink(), httpLink]),
   });
 }

--- a/frontend/src/lib/apollo/request-id-link.test.ts
+++ b/frontend/src/lib/apollo/request-id-link.test.ts
@@ -1,0 +1,88 @@
+import { ApolloClient, ApolloLink, gql, InMemoryCache, Observable } from "@apollo/client";
+import { describe, expect, it } from "vitest";
+import { requestIdLink } from "./request-id-link";
+
+const query = gql`
+  query Health {
+    health
+  }
+`;
+
+const UUID_V7_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+/**
+ * Build a composed link and return an accessor for the context captured by the
+ * terminal link. Apollo Client v4 requires an ApolloClient instance in the
+ * execute context, so we spin up a minimal one using the composed link itself.
+ */
+function captureContext(): {
+  readonly ctx: { headers?: Record<string, string> };
+  client: ApolloClient;
+} {
+  let captured: { headers?: Record<string, string> } = {};
+
+  const terminal = new ApolloLink((op) => {
+    captured = op.getContext() as { headers?: Record<string, string> };
+    return new Observable((subscriber) => {
+      subscriber.next({ data: { health: "ok" } });
+      subscriber.complete();
+    });
+  });
+
+  const link = ApolloLink.from([requestIdLink, terminal]);
+
+  const client = new ApolloClient({
+    cache: new InMemoryCache(),
+    link,
+  });
+
+  return {
+    get ctx() {
+      return captured;
+    },
+    client,
+  };
+}
+
+function runQuery(client: ApolloClient, context: Record<string, unknown> = {}): Promise<void> {
+  return new Promise((resolve, reject) => {
+    client
+      .query({ query, context, fetchPolicy: "no-cache" })
+      .then(() => resolve())
+      .catch(reject);
+  });
+}
+
+describe("requestIdLink", () => {
+  it("injects X-Request-ID when header is absent", async () => {
+    const spy = captureContext();
+    await runQuery(spy.client);
+
+    const requestId = spy.ctx.headers?.["X-Request-ID"];
+    expect(requestId).toBeDefined();
+    expect(requestId).toMatch(UUID_V7_REGEX);
+  });
+
+  it("preserves X-Request-ID when already set (exact case)", async () => {
+    const spy = captureContext();
+    await runQuery(spy.client, { headers: { "X-Request-ID": "preset-abc" } });
+
+    expect(spy.ctx.headers?.["X-Request-ID"]).toBe("preset-abc");
+  });
+
+  it("does not inject a new X-Request-ID when lowercase x-request-id is already set", async () => {
+    const spy = captureContext();
+    await runQuery(spy.client, { headers: { "x-request-id": "preset-xyz" } });
+
+    // The case-insensitive guard must prevent generating a new ID.
+    // The original lowercase key is preserved as-is by setContext since no
+    // new header object is merged over it.
+    const headers = spy.ctx.headers ?? {};
+    const allValues = Object.values(headers);
+    // "preset-xyz" must appear somewhere in the headers — the original value is kept.
+    expect(allValues).toContain("preset-xyz");
+    // No freshly generated UUID v7 must be present on top of the preserved value.
+    const freshIds = allValues.filter((v) => typeof v === "string" && UUID_V7_REGEX.test(v));
+    expect(freshIds).toHaveLength(0);
+  });
+});

--- a/frontend/src/lib/apollo/request-id-link.test.ts
+++ b/frontend/src/lib/apollo/request-id-link.test.ts
@@ -10,11 +10,8 @@ const query = gql`
 
 const UUID_V7_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 
-/**
- * Build a composed link and return an accessor for the context captured by the
- * terminal link. Apollo Client v4 requires an ApolloClient instance in the
- * execute context, so we spin up a minimal one using the composed link itself.
- */
+// Apollo Client v4 requires an ApolloClient instance in the execute context,
+// so we spin up a minimal one using the composed link itself.
 function captureContext(): {
   readonly ctx: { headers?: Record<string, string> };
   client: ApolloClient;

--- a/frontend/src/lib/apollo/request-id-link.ts
+++ b/frontend/src/lib/apollo/request-id-link.ts
@@ -1,0 +1,25 @@
+"use client";
+
+import type { ApolloLink } from "@apollo/client";
+import { setContext } from "@apollo/client/link/context";
+import { newRequestId, REQUEST_ID_HEADER } from "@/lib/observability/request-id";
+
+/**
+ * Apollo link that injects a UUID v7 `X-Request-ID` header on every GraphQL
+ * request. If an upstream link (or the caller) already set the header under
+ * any capitalisation, the existing value is preserved so chained
+ * server-to-server calls keep a single correlation ID across the full trace.
+ */
+export const requestIdLink: ApolloLink = setContext((_, { headers = {} }) => {
+  const existing = headers as Record<string, string>;
+
+  // Check case-insensitively whether the header is already present and non-empty.
+  const headerLower = REQUEST_ID_HEADER.toLowerCase();
+  const alreadySet = Object.keys(existing).some(
+    (key) => key.toLowerCase() === headerLower && existing[key],
+  );
+
+  return {
+    headers: alreadySet ? existing : { ...existing, [REQUEST_ID_HEADER]: newRequestId() },
+  };
+});

--- a/frontend/src/lib/apollo/request-id-link.ts
+++ b/frontend/src/lib/apollo/request-id-link.ts
@@ -4,21 +4,14 @@ import type { ApolloLink } from "@apollo/client";
 import { setContext } from "@apollo/client/link/context";
 import { newRequestId, REQUEST_ID_HEADER } from "@/lib/observability/request-id";
 
-/**
- * Apollo link that injects a UUID v7 `X-Request-ID` header on every GraphQL
- * request. If an upstream link (or the caller) already set the header under
- * any capitalisation, the existing value is preserved so chained
- * server-to-server calls keep a single correlation ID across the full trace.
- */
+// Preserves any existing header variant (case-insensitive) so chained
+// server-to-server calls keep a single correlation ID across the full trace.
 export const requestIdLink: ApolloLink = setContext((_, { headers = {} }) => {
   const existing = headers as Record<string, string>;
-
-  // Check case-insensitively whether the header is already present and non-empty.
   const headerLower = REQUEST_ID_HEADER.toLowerCase();
   const alreadySet = Object.keys(existing).some(
     (key) => key.toLowerCase() === headerLower && existing[key],
   );
-
   return {
     headers: alreadySet ? existing : { ...existing, [REQUEST_ID_HEADER]: newRequestId() },
   };

--- a/frontend/src/lib/apollo/server.test.ts
+++ b/frontend/src/lib/apollo/server.test.ts
@@ -129,4 +129,18 @@ describe("gqlFetch", () => {
 
     await expect(gqlFetch(HealthQuery)).rejects.toThrow("auth down");
   });
+
+  it("injects a well-formed UUID v7 X-Request-ID header on every fetch", async () => {
+    const fetchSpy = vi
+      .spyOn(global, "fetch")
+      .mockResolvedValue(new Response(JSON.stringify({ data: { health: "ok" } })));
+
+    await gqlFetch(HealthQuery);
+
+    const init = fetchSpy.mock.calls[0]?.[1] as RequestInit & { headers?: Record<string, string> };
+    const requestId = (init.headers as Record<string, string>)["X-Request-ID"];
+    expect(requestId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+    );
+  });
 });

--- a/frontend/src/lib/apollo/server.ts
+++ b/frontend/src/lib/apollo/server.ts
@@ -2,6 +2,7 @@ import "server-only";
 import type { TypedDocumentNode } from "@apollo/client";
 import { print } from "graphql";
 import { env } from "@/env";
+import { newRequestId, REQUEST_ID_HEADER } from "@/lib/observability/request-id";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 
 type GqlFetchInit<TVars> = {
@@ -23,6 +24,11 @@ export async function gqlFetch<TResult, TVars>(
   const headers: Record<string, string> = { "Content-Type": "application/json" };
   if (session?.access_token) {
     headers.authorization = `Bearer ${session.access_token}`;
+  }
+  // Inject a request correlation ID only when the caller has not already provided one,
+  // so chained server-to-server calls preserve the upstream value across the full trace.
+  if (!headers[REQUEST_ID_HEADER]) {
+    headers[REQUEST_ID_HEADER] = newRequestId();
   }
 
   const res = await fetch(`${env.BACKEND_URL}/query`, {

--- a/frontend/src/lib/apollo/server.ts
+++ b/frontend/src/lib/apollo/server.ts
@@ -25,11 +25,8 @@ export async function gqlFetch<TResult, TVars>(
   if (session?.access_token) {
     headers.authorization = `Bearer ${session.access_token}`;
   }
-  // Inject a request correlation ID only when the caller has not already provided one,
-  // so chained server-to-server calls preserve the upstream value across the full trace.
-  if (!headers[REQUEST_ID_HEADER]) {
-    headers[REQUEST_ID_HEADER] = newRequestId();
-  }
+  // Always assign — gqlFetch is the RSC entrypoint and has no caller-supplied headers.
+  headers[REQUEST_ID_HEADER] = newRequestId();
 
   const res = await fetch(`${env.BACKEND_URL}/query`, {
     method: "POST",

--- a/frontend/src/lib/observability/request-id.test.ts
+++ b/frontend/src/lib/observability/request-id.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { newRequestId } from "./request-id";
+
+const UUID_V7_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+describe("newRequestId", () => {
+  it("produces a string matching the UUID v7 format regex", () => {
+    expect(newRequestId()).toMatch(UUID_V7_RE);
+  });
+
+  it("has version nibble '7' at position 14", () => {
+    const id = newRequestId();
+    expect(id[14]).toBe("7");
+  });
+
+  it("has variant nibble in {8,9,a,b} at position 19", () => {
+    const id = newRequestId();
+    expect(["8", "9", "a", "b"]).toContain(id[19]);
+  });
+
+  it("produces 100 unique values", () => {
+    const ids = Array.from({ length: 100 }, newRequestId);
+    const unique = new Set(ids);
+    expect(unique.size).toBe(100);
+  });
+
+  it("timestamp prefix is non-decreasing across 100 calls", () => {
+    const ids = Array.from({ length: 100 }, newRequestId);
+    // The first 12 hex chars encode the 48-bit timestamp; they must be monotonically non-decreasing.
+    const prefixes = ids.map((id) => id.replace(/-/g, "").slice(0, 12));
+    for (let i = 1; i < prefixes.length; i++) {
+      const curr = prefixes[i] ?? "";
+      const prev = prefixes[i - 1] ?? "";
+      expect(curr >= prev).toBe(true);
+    }
+  });
+});

--- a/frontend/src/lib/observability/request-id.ts
+++ b/frontend/src/lib/observability/request-id.ts
@@ -1,18 +1,9 @@
-// Cross-tier request correlation header name.
 export const REQUEST_ID_HEADER = "X-Request-ID";
 
-/**
- * Generates a UUID v7 string using the Web Crypto API.
- *
- * UUID v7 encodes a 48-bit Unix timestamp (ms precision) in the high bits,
- * which makes IDs both sortable and traceable to their creation time.
- * Works in browser and Node 18+ without any polyfill.
- */
 export function newRequestId(): string {
   const bytes = new Uint8Array(16);
   crypto.getRandomValues(bytes);
 
-  // Overwrite bytes[0..5] with the 48-bit big-endian millisecond timestamp.
   const ms = Date.now();
   bytes[0] = (ms / 2 ** 40) & 0xff;
   bytes[1] = (ms / 2 ** 32) & 0xff;
@@ -21,15 +12,11 @@ export function newRequestId(): string {
   bytes[4] = (ms / 2 ** 8) & 0xff;
   bytes[5] = ms & 0xff;
 
-  // Set version 7 in the high nibble of byte 6.
   // biome-ignore lint/style/noNonNullAssertion: bytes is Uint8Array(16), index 6 always exists
   bytes[6] = (bytes[6]! & 0x0f) | 0x70;
-
-  // Set RFC 4122 variant bits in the high two bits of byte 8.
   // biome-ignore lint/style/noNonNullAssertion: bytes is Uint8Array(16), index 8 always exists
   bytes[8] = (bytes[8]! & 0x3f) | 0x80;
 
-  // Format as xxxxxxxx-xxxx-7xxx-yxxx-xxxxxxxxxxxx.
   const h: string[] = Array.from(bytes, (b) => b.toString(16).padStart(2, "0"));
   return (
     `${h[0] ?? ""}${h[1] ?? ""}${h[2] ?? ""}${h[3] ?? ""}-` +

--- a/frontend/src/lib/observability/request-id.ts
+++ b/frontend/src/lib/observability/request-id.ts
@@ -1,0 +1,41 @@
+// Cross-tier request correlation header name.
+export const REQUEST_ID_HEADER = "X-Request-ID";
+
+/**
+ * Generates a UUID v7 string using the Web Crypto API.
+ *
+ * UUID v7 encodes a 48-bit Unix timestamp (ms precision) in the high bits,
+ * which makes IDs both sortable and traceable to their creation time.
+ * Works in browser and Node 18+ without any polyfill.
+ */
+export function newRequestId(): string {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+
+  // Overwrite bytes[0..5] with the 48-bit big-endian millisecond timestamp.
+  const ms = Date.now();
+  bytes[0] = (ms / 2 ** 40) & 0xff;
+  bytes[1] = (ms / 2 ** 32) & 0xff;
+  bytes[2] = (ms / 2 ** 24) & 0xff;
+  bytes[3] = (ms / 2 ** 16) & 0xff;
+  bytes[4] = (ms / 2 ** 8) & 0xff;
+  bytes[5] = ms & 0xff;
+
+  // Set version 7 in the high nibble of byte 6.
+  // biome-ignore lint/style/noNonNullAssertion: bytes is Uint8Array(16), index 6 always exists
+  bytes[6] = (bytes[6]! & 0x0f) | 0x70;
+
+  // Set RFC 4122 variant bits in the high two bits of byte 8.
+  // biome-ignore lint/style/noNonNullAssertion: bytes is Uint8Array(16), index 8 always exists
+  bytes[8] = (bytes[8]! & 0x3f) | 0x80;
+
+  // Format as xxxxxxxx-xxxx-7xxx-yxxx-xxxxxxxxxxxx.
+  const h: string[] = Array.from(bytes, (b) => b.toString(16).padStart(2, "0"));
+  return (
+    `${h[0] ?? ""}${h[1] ?? ""}${h[2] ?? ""}${h[3] ?? ""}-` +
+    `${h[4] ?? ""}${h[5] ?? ""}-` +
+    `${h[6] ?? ""}${h[7] ?? ""}-` +
+    `${h[8] ?? ""}${h[9] ?? ""}-` +
+    `${h[10] ?? ""}${h[11] ?? ""}${h[12] ?? ""}${h[13] ?? ""}${h[14] ?? ""}${h[15] ?? ""}`
+  );
+}

--- a/frontend/src/lib/observability/request-id.ts
+++ b/frontend/src/lib/observability/request-id.ts
@@ -1,28 +1,7 @@
+import { uuidv7 } from "uuidv7";
+
 export const REQUEST_ID_HEADER = "X-Request-ID";
 
 export function newRequestId(): string {
-  const bytes = new Uint8Array(16);
-  crypto.getRandomValues(bytes);
-
-  const ms = Date.now();
-  bytes[0] = (ms / 2 ** 40) & 0xff;
-  bytes[1] = (ms / 2 ** 32) & 0xff;
-  bytes[2] = (ms / 2 ** 24) & 0xff;
-  bytes[3] = (ms / 2 ** 16) & 0xff;
-  bytes[4] = (ms / 2 ** 8) & 0xff;
-  bytes[5] = ms & 0xff;
-
-  // biome-ignore lint/style/noNonNullAssertion: bytes is Uint8Array(16), index 6 always exists
-  bytes[6] = (bytes[6]! & 0x0f) | 0x70;
-  // biome-ignore lint/style/noNonNullAssertion: bytes is Uint8Array(16), index 8 always exists
-  bytes[8] = (bytes[8]! & 0x3f) | 0x80;
-
-  const h: string[] = Array.from(bytes, (b) => b.toString(16).padStart(2, "0"));
-  return (
-    `${h[0] ?? ""}${h[1] ?? ""}${h[2] ?? ""}${h[3] ?? ""}-` +
-    `${h[4] ?? ""}${h[5] ?? ""}-` +
-    `${h[6] ?? ""}${h[7] ?? ""}-` +
-    `${h[8] ?? ""}${h[9] ?? ""}-` +
-    `${h[10] ?? ""}${h[11] ?? ""}${h[12] ?? ""}${h[13] ?? ""}${h[14] ?? ""}${h[15] ?? ""}`
-  );
+  return uuidv7();
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,6 +49,9 @@ importers:
       react-dom:
         specifier: 19.2.0
         version: 19.2.0(react@19.2.0)
+      uuidv7:
+        specifier: ^1.2.1
+        version: 1.2.1
       zod:
         specifier: 3.24.2
         version: 3.24.2
@@ -2560,6 +2563,10 @@ packages:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  uuidv7@1.2.1:
+    resolution: {integrity: sha512-4kPkK3/XTQW9Hbm4CaqfICn+kY9LJtDVEOfgsRRra/+n2Ofg4NqzRFceAkxvQ/Ud/6BpHOPzj8cirqM7TzTN5Q==}
+    hasBin: true
 
   vite-tsconfig-paths@6.1.1:
     resolution: {integrity: sha512-2cihq7zliibCCZ8P9cKJrQBkfgdvcFkOOc3Y02o3GWUDLgqjWsZudaoiuOwO/gzTzy17cS5F7ZPo4bsnS4DGkg==}
@@ -5168,6 +5175,8 @@ snapshots:
   use-sync-external-store@1.6.0(react@19.2.0):
     dependencies:
       react: 19.2.0
+
+  uuidv7@1.2.1: {}
 
   vite-tsconfig-paths@6.1.1(typescript@5.9.3)(vite@8.0.10(@types/node@24.2.0)(jiti@2.6.1)(yaml@2.8.3)):
     dependencies:


### PR DESCRIPTION
## Summary

- Backend extracts W3C `traceparent` at the HTTP layer (`otelhttp.NewHandler` + global `TextMapPropagator`). Resolver spans correctly attach to inbound caller spans when a parent context is present.
- Cross-tier `request_id` (UUID v7) propagation as a lightweight alternative to a full frontend OTel SDK at current scale:
  - Backend Echo middleware (`internal/middleware/RequestID()`) reads `X-Request-ID`, generates `uuidv7` if absent or rejected (length cap 128), echoes the value in the response header, and stashes it in `context.Context`.
  - `internal/logging.ContextHandler` wraps `slog.NewJSONHandler` and auto-attaches `request_id` to every log record via a `ContextLookup` injection point (decoupled from the `middleware` package to avoid an import cycle).
  - Frontend uses the `uuidv7` npm package (~1.5KB gzip) for monotonic correctness within the same millisecond. `requestIdLink` (Apollo) and `gqlFetch` (RSC) both attach the header on every outgoing GraphQL request.
- Issue #22 is closed "Won't fix at current scale" before this PR merges; revisit when DAU > 100 or SLOs are formally defined.

## Out of scope

- Browser OTel SDK / `WebTracerProvider` (deferred — see #22 closure comment).
- RSC OTel Node SDK / `instrumentation.ts` (deferred — same).
- Distributed sampling tuning, `Baggage` propagation, edge-runtime tracing.

## Test plan

- [ ] `cd backend && go test -race -covermode=atomic ./...`
- [ ] `pnpm --filter frontend test`
- [ ] `pnpm --filter frontend typecheck && pnpm --filter frontend lint`
- [ ] Manual: \`curl -H 'X-Request-ID: probe-1' localhost:1323/query\` and confirm \`probe-1\` appears in backend slog and in the response header.