### PR TITLE
feat(backend): add handleSwipe mutation and swipe_record event log

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # flamingo-armond
 
+[![backend CI](https://github.com/yasuflatland-lf/flamingo-armond/actions/workflows/backend.yml/badge.svg?branch=main)](https://github.com/yasuflatland-lf/flamingo-armond/actions/workflows/backend.yml)
+[![frontend CI](https://github.com/yasuflatland-lf/flamingo-armond/actions/workflows/frontend.yml/badge.svg?branch=main)](https://github.com/yasuflatland-lf/flamingo-armond/actions/workflows/frontend.yml)
+[![codecov](https://codecov.io/gh/yasuflatland-lf/flamingo-armond/branch/main/graph/badge.svg)](https://codecov.io/gh/yasuflatland-lf/flamingo-armond)
+
 🦩 Swiping Flashcard app — a Go (Echo) backend, a Next.js 16 frontend, and a shared GraphQL schema, with Supabase for Postgres + Auth.
 
 ## Quick Start

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,6 +1,7 @@
 # Server
 PORT=1323
 SHUTDOWN_TIMEOUT=25s
+SWIPE_NEXT_BATCH_SIZE=10
 
 # Supabase Auth (JWT verification, see docs/backend.md §Authentication)
 # All three are REQUIRED — server fails to start if any is missing.

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strconv"
 	"syscall"
 	"time"
 
@@ -28,6 +29,7 @@ import (
 	"backend/graph/resolver"
 	"backend/internal/auth"
 	"backend/internal/database"
+	"backend/internal/domain/service"
 	"backend/internal/loader"
 	"backend/internal/logging"
 	internalmw "backend/internal/middleware"
@@ -62,6 +64,7 @@ func newRouter(
 	roleRepo repository.RoleRepository,
 	cardgroupRepo repository.CardgroupRepository,
 	cardRepo repository.CardRepository,
+	swipeRecordRepo ...repository.SwipeRecordRepository,
 ) *echo.Echo {
 	e := echo.New()
 	e.Use(middleware.RequestLogger())
@@ -99,11 +102,24 @@ func newRouter(
 			return r.Method + " " + r.URL.Path
 		}),
 	)
-	q := e.Group("/query", authMW, loader.Middleware(userRepo, roleRepo, cardgroupRepo, cardRepo))
+	q := e.Group("/query", authMW, loader.Middleware(userRepo, roleRepo, cardgroupRepo, cardRepo, swipeRecordRepo...))
 	q.POST("", echo.WrapHandler(otelGQLHandler))
 	e.GET("/playground", echo.WrapHandler(playground.Handler("GraphQL", "/query")))
 
 	return e
+}
+
+func swipeNextBatchSize(logger *slog.Logger) int {
+	v := os.Getenv("SWIPE_NEXT_BATCH_SIZE")
+	if v == "" {
+		return 10
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n <= 0 {
+		logger.Warn("invalid SWIPE_NEXT_BATCH_SIZE, using default", "value", v, "default", 10)
+		return 10
+	}
+	return n
 }
 
 func shutdownTimeout(logger *slog.Logger) time.Duration {
@@ -165,22 +181,25 @@ func run(ctx context.Context, logger *slog.Logger) error {
 	roleRepo := repository.NewRoleRepository(db.GORM)
 	cardgroupRepo := repository.NewCardgroupRepository(db.GORM)
 	cardRepo := repository.NewCardRepository(db.GORM)
+	swipeRecordRepo := repository.NewSwipeRecordRepository(db.GORM)
 	// Constructed to surface compile-time wiring even though no resolver references it yet.
 	_ = repository.NewUserRoleRepository(db.GORM)
 
 	userUC := usecase.NewUserUsecase(userRepo)
 	cardgroupUC := usecase.NewCardgroupUsecase(cardgroupRepo)
 	cardUC := usecase.NewCardUsecase(cardRepo, cardgroupRepo)
+	swipeUC := usecase.NewSwipeUsecase(db.GORM, cardRepo, cardgroupRepo, swipeRecordRepo, service.NewFSRSScheduler(), swipeNextBatchSize(logger))
 
 	resolvers := &resolver.Resolver{
 		User:        userUC,
 		CardgroupUC: cardgroupUC,
 		CardUC:      cardUC,
+		SwipeUC:     swipeUC,
 	}
 	// newRouter must be called after telemetry.Init: the otelhttp handler it
 	// constructs reads otel.GetTextMapPropagator() eagerly. See comment above
 	// telemetry.Init for the full ordering invariant.
-	e := newRouter(resolvers, authMW, userRepo, roleRepo, cardgroupRepo, cardRepo)
+	e := newRouter(resolvers, authMW, userRepo, roleRepo, cardgroupRepo, cardRepo, swipeRecordRepo)
 	e.Logger = logger
 
 	port := os.Getenv("PORT")

--- a/backend/cmd/server/main_test.go
+++ b/backend/cmd/server/main_test.go
@@ -1030,6 +1030,16 @@ func gqlErrField(resp map[string]any) string {
 	return field
 }
 
+// gqlErrMessage extracts errors[0].message from a postGraphQL response.
+func gqlErrMessage(resp map[string]any) string {
+	errs, ok := resp["errors"].([]any)
+	if !ok || len(errs) == 0 {
+		return ""
+	}
+	message, _ := errs[0].(map[string]any)["message"].(string)
+	return message
+}
+
 func TestGraphQL_CreateCardgroup_Then_MyCardgroups(t *testing.T) {
 	f := newJWTFixture(t)
 	ts, _ := newGraphQLTestServer(t, f)
@@ -1520,6 +1530,38 @@ func TestGraphQL_HandleSwipe_NonOwnerUnauthenticated(t *testing.T) {
 
 	if code := gqlErrCode(resp); code != "UNAUTHENTICATED" {
 		t.Fatalf("expected UNAUTHENTICATED, got %q; resp=%v", code, resp)
+	}
+}
+
+func TestGraphQL_HandleSwipe_CrossCardgroupMatchesMissingCardError(t *testing.T) {
+	f := newJWTFixture(t)
+	ts, _ := newGraphQLTestServer(t, f)
+	ctx := context.Background()
+	sub := insertAuthUser(t, ctx)
+	tok := f.sign(t, sub)
+
+	ownedCgID := createTestCardgroup(t, ts.URL, tok, "Owned")
+	otherCgID := createTestCardgroup(t, ts.URL, tok, "Other")
+	otherCardID := createTestCard(t, ts.URL, tok, otherCgID, "other front", "other back")
+	missingCardID := uuid.NewString()
+
+	bodyForCard := func(cardID string) string {
+		return fmt.Sprintf(`{"query":"mutation { handleSwipe(input: {cardId: \"%s\", cardgroupId: \"%s\", mode: 4}) { performanceMode } }"}`, cardID, ownedCgID)
+	}
+	mismatchResp := postGraphQL(t, ts.URL+"/query", bodyForCard(otherCardID), tok)
+	missingResp := postGraphQL(t, ts.URL+"/query", bodyForCard(missingCardID), tok)
+
+	for name, resp := range map[string]map[string]any{"mismatch": mismatchResp, "missing": missingResp} {
+		if code := gqlErrCode(resp); code != "BAD_USER_INPUT" {
+			t.Fatalf("%s: expected BAD_USER_INPUT, got %q; resp=%v", name, code, resp)
+		}
+		if field := gqlErrField(resp); field != "cardId" {
+			t.Fatalf("%s: expected extensions.field=cardId, got %q; resp=%v", name, field, resp)
+		}
+	}
+	if gqlErrMessage(mismatchResp) != gqlErrMessage(missingResp) {
+		t.Fatalf("mismatched-cardgroup and missing-card errors differ: mismatch=%q missing=%q",
+			gqlErrMessage(mismatchResp), gqlErrMessage(missingResp))
 	}
 }
 

--- a/backend/cmd/server/main_test.go
+++ b/backend/cmd/server/main_test.go
@@ -10,6 +10,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -31,11 +32,13 @@ import (
 	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"gorm.io/gorm"
 
 	"backend/graph/resolver"
 	"backend/internal/auth"
 	"backend/internal/database"
 	"backend/internal/domain"
+	"backend/internal/domain/service"
 	"backend/internal/repository"
 	"backend/internal/telemetry"
 	"backend/internal/usecase"
@@ -392,10 +395,12 @@ func newGraphQLTestServerWithUserRepo(t *testing.T, f *jwtFixture, userRepo repo
 	roleRepo := repository.NewRoleRepository(db.GORM)
 	cardgroupRepo := repository.NewCardgroupRepository(db.GORM)
 	cardRepo := repository.NewCardRepository(db.GORM)
+	swipeRecordRepo := repository.NewSwipeRecordRepository(db.GORM)
 	userUC := usecase.NewUserUsecase(userRepo)
 	cardgroupUC := usecase.NewCardgroupUsecase(cardgroupRepo)
 	cardUC := usecase.NewCardUsecase(cardRepo, cardgroupRepo)
-	e := newRouter(&resolver.Resolver{User: userUC, CardgroupUC: cardgroupUC, CardUC: cardUC}, mw, userRepo, roleRepo, cardgroupRepo, cardRepo)
+	swipeUC := usecase.NewSwipeUsecase(db.GORM, cardRepo, cardgroupRepo, swipeRecordRepo, service.NewFSRSScheduler(), 10)
+	e := newRouter(&resolver.Resolver{User: userUC, CardgroupUC: cardgroupUC, CardUC: cardUC, SwipeUC: swipeUC}, mw, userRepo, roleRepo, cardgroupRepo, cardRepo, swipeRecordRepo)
 
 	ts := httptest.NewServer(e)
 	t.Cleanup(ts.Close)
@@ -1412,5 +1417,162 @@ func TestGraphQL_Cardgroup_NotFound_ReturnsNullNoError(t *testing.T) {
 	}
 	if cgVal != nil {
 		t.Fatalf("expected data.cardgroup == null for non-existent ID, got %v", cgVal)
+	}
+}
+
+func TestGraphQL_HandleSwipe_HappyPath(t *testing.T) {
+	f := newJWTFixture(t)
+	ts, db := newGraphQLTestServer(t, f)
+	ctx := context.Background()
+	sub := insertAuthUser(t, ctx)
+	tok := f.sign(t, sub)
+
+	cgID := createTestCardgroup(t, ts.URL, tok, "Swipe")
+	firstID := createTestCard(t, ts.URL, tok, cgID, "front 1", "back 1")
+	secondID := createTestCard(t, ts.URL, tok, cgID, "front 2", "back 2")
+
+	gqlQuery := fmt.Sprintf(`mutation {
+		handleSwipe(input: {cardId: %s, cardgroupId: %s, mode: 4}) {
+			performanceMode
+			nextCards { id }
+		}
+	}`, gqlStringLit(firstID), gqlStringLit(cgID))
+	body, err := json.Marshal(map[string]string{"query": gqlQuery})
+	if err != nil {
+		t.Fatalf("json.Marshal body: %v", err)
+	}
+	resp := postGraphQL(t, ts.URL+"/query", string(body), tok)
+	if errs, ok := resp["errors"].([]any); ok && len(errs) > 0 {
+		t.Fatalf("handleSwipe errors: %v", errs)
+	}
+	payload, _ := resp["data"].(map[string]any)["handleSwipe"].(map[string]any)
+	if payload == nil {
+		t.Fatalf("expected handleSwipe payload; resp=%v", resp)
+	}
+	if payload["performanceMode"] != float64(0) {
+		t.Fatalf("performanceMode=%v, want 0", payload["performanceMode"])
+	}
+	nextCards, _ := payload["nextCards"].([]any)
+	for _, item := range nextCards {
+		card, _ := item.(map[string]any)
+		if card["id"] == firstID {
+			t.Fatalf("nextCards included swiped card %q: %v", firstID, nextCards)
+		}
+	}
+	if len(nextCards) > 0 {
+		card, _ := nextCards[0].(map[string]any)
+		if card["id"] != secondID {
+			t.Fatalf("expected due sibling card first, got %v", card)
+		}
+	}
+
+	var swipeCount int64
+	if err := db.GORM.WithContext(ctx).Table("swipe_records").Where("card_id = ?", firstID).Count(&swipeCount).Error; err != nil {
+		t.Fatalf("count swipe_records: %v", err)
+	}
+	if swipeCount != 1 {
+		t.Fatalf("swipe_records count=%d, want 1", swipeCount)
+	}
+	cardRepo := repository.NewCardRepository(db.GORM)
+	updated, err := cardRepo.FindByID(ctx, firstID)
+	if err != nil {
+		t.Fatalf("find swiped card: %v", err)
+	}
+	if updated.FSRS.Reps != 1 {
+		t.Fatalf("reps=%d, want 1", updated.FSRS.Reps)
+	}
+}
+
+func TestGraphQL_HandleSwipe_InvalidModes(t *testing.T) {
+	f := newJWTFixture(t)
+	ts, _ := newGraphQLTestServer(t, f)
+	ctx := context.Background()
+	sub := insertAuthUser(t, ctx)
+	tok := f.sign(t, sub)
+	cgID := createTestCardgroup(t, ts.URL, tok, "Invalid Modes")
+	cardID := createTestCard(t, ts.URL, tok, cgID, "front", "back")
+
+	for _, mode := range []int{0, 3, 5} {
+		body := fmt.Sprintf(`{"query":"mutation { handleSwipe(input: {cardId: \"%s\", cardgroupId: \"%s\", mode: %d}) { performanceMode } }"}`, cardID, cgID, mode)
+		resp := postGraphQL(t, ts.URL+"/query", body, tok)
+		if code := gqlErrCode(resp); code != "BAD_USER_INPUT" {
+			t.Fatalf("mode=%d: expected BAD_USER_INPUT, got %q; resp=%v", mode, code, resp)
+		}
+		if field := gqlErrField(resp); field != "mode" {
+			t.Fatalf("mode=%d: expected extensions.field=mode, got %q; resp=%v", mode, field, resp)
+		}
+	}
+}
+
+func TestGraphQL_HandleSwipe_NonOwnerUnauthenticated(t *testing.T) {
+	f := newJWTFixture(t)
+	ts, _ := newGraphQLTestServer(t, f)
+	ctx := context.Background()
+	subA := insertAuthUser(t, ctx)
+	tokA := f.sign(t, subA)
+	cgID := createTestCardgroup(t, ts.URL, tokA, "Owner")
+	cardID := createTestCard(t, ts.URL, tokA, cgID, "front", "back")
+
+	subB := insertAuthUser(t, ctx)
+	tokB := f.sign(t, subB)
+	body := fmt.Sprintf(`{"query":"mutation { handleSwipe(input: {cardId: \"%s\", cardgroupId: \"%s\", mode: 4}) { performanceMode } }"}`, cardID, cgID)
+	resp := postGraphQL(t, ts.URL+"/query", body, tokB)
+
+	if code := gqlErrCode(resp); code != "UNAUTHENTICATED" {
+		t.Fatalf("expected UNAUTHENTICATED, got %q; resp=%v", code, resp)
+	}
+}
+
+type failingSwipeRepo struct{ err error }
+
+func (f failingSwipeRepo) CreateTx(context.Context, *gorm.DB, *domain.SwipeRecord) error {
+	return f.err
+}
+
+func TestHandleSwipe_RollsBackWhenSwipeRecordInsertFails(t *testing.T) {
+	f := newJWTFixture(t)
+	ts, db := newGraphQLTestServer(t, f)
+	ctx := context.Background()
+	sub := insertAuthUser(t, ctx)
+	tok := f.sign(t, sub)
+	cgID := createTestCardgroup(t, ts.URL, tok, "Rollback")
+	cardID := createTestCard(t, ts.URL, tok, cgID, "front", "back")
+
+	cardRepo := repository.NewCardRepository(db.GORM)
+	cardgroupRepo := repository.NewCardgroupRepository(db.GORM)
+	before, err := cardRepo.FindByID(ctx, cardID)
+	if err != nil {
+		t.Fatalf("find before: %v", err)
+	}
+	uc := usecase.NewSwipeUsecase(
+		db.GORM,
+		cardRepo,
+		cardgroupRepo,
+		failingSwipeRepo{err: errors.New("forced swipe insert failure")},
+		service.NewFSRSScheduler(),
+		10,
+	)
+
+	_, err = uc.HandleSwipe(auth.ContextWithUser(ctx, &auth.AuthUser{Sub: sub}), usecase.HandleSwipeInput{
+		CardID:      cardID,
+		CardgroupID: cgID,
+		Mode:        4,
+	})
+	if err == nil {
+		t.Fatal("expected forced error, got nil")
+	}
+	after, err := cardRepo.FindByID(ctx, cardID)
+	if err != nil {
+		t.Fatalf("find after: %v", err)
+	}
+	if after.FSRS.Reps != before.FSRS.Reps || !after.FSRS.Due.Equal(before.FSRS.Due) {
+		t.Fatalf("FSRS state changed despite rollback: before=%+v after=%+v", before.FSRS, after.FSRS)
+	}
+	var swipeCount int64
+	if err := db.GORM.WithContext(ctx).Table("swipe_records").Where("card_id = ?", cardID).Count(&swipeCount).Error; err != nil {
+		t.Fatalf("count swipe_records: %v", err)
+	}
+	if swipeCount != 0 {
+		t.Fatalf("swipe_records count=%d, want 0", swipeCount)
 	}
 }

--- a/backend/graph/resolver/helpers.go
+++ b/backend/graph/resolver/helpers.go
@@ -3,6 +3,7 @@ package resolver
 import (
 	"backend/graph/model"
 	"backend/internal/domain"
+	"backend/internal/usecase"
 )
 
 // toUserModel lives in a separate file so `gqlgen generate` does not strip it
@@ -73,4 +74,14 @@ func toCardModels(cards []*domain.Card) []*model.Card {
 		out[i] = toCardModel(card)
 	}
 	return out
+}
+
+func toSwipeResponseModel(out *usecase.SwipeOutput) *model.SwipeResponse {
+	if out == nil {
+		return nil
+	}
+	return &model.SwipeResponse{
+		NextCards:       toCardModels(out.NextCards),
+		PerformanceMode: out.PerformanceMode,
+	}
 }

--- a/backend/graph/resolver/resolver.go
+++ b/backend/graph/resolver/resolver.go
@@ -6,4 +6,5 @@ type Resolver struct {
 	User        *usecase.UserUsecase
 	CardgroupUC *usecase.CardgroupUsecase
 	CardUC      *usecase.CardUsecase
+	SwipeUC     *usecase.SwipeUsecase
 }

--- a/backend/graph/resolver/schema.resolvers.go
+++ b/backend/graph/resolver/schema.resolvers.go
@@ -112,6 +112,19 @@ func (r *mutationResolver) DeleteCard(ctx context.Context, id string) (bool, err
 	return true, nil
 }
 
+// HandleSwipe is the resolver for the handleSwipe field.
+func (r *mutationResolver) HandleSwipe(ctx context.Context, input model.HandleSwipeInput) (*model.SwipeResponse, error) {
+	out, err := r.SwipeUC.HandleSwipe(ctx, usecase.HandleSwipeInput{
+		CardID:      input.CardID,
+		CardgroupID: input.CardgroupID,
+		Mode:        input.Mode,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return toSwipeResponseModel(out), nil
+}
+
 // Health is the resolver for the health field.
 func (r *queryResolver) Health(ctx context.Context) (string, error) {
 	return "ok", nil

--- a/backend/internal/database/migrations/20260504000000_create_swipe_records.down.sql
+++ b/backend/internal/database/migrations/20260504000000_create_swipe_records.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS public.swipe_records;

--- a/backend/internal/database/migrations/20260504000000_create_swipe_records.up.sql
+++ b/backend/internal/database/migrations/20260504000000_create_swipe_records.up.sql
@@ -1,0 +1,21 @@
+CREATE TABLE IF NOT EXISTS public.swipe_records (
+    id             uuid             PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id        uuid             NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+    card_id        uuid             NOT NULL REFERENCES public.cards(id) ON DELETE CASCADE,
+    rating         integer          NOT NULL CHECK (rating BETWEEN 1 AND 4),
+    reviewed_at    timestamptz      NOT NULL DEFAULT now(),
+
+    due            timestamptz      NOT NULL,
+    stability      double precision NOT NULL,
+    difficulty     double precision NOT NULL,
+    elapsed_days   integer          NOT NULL,
+    scheduled_days integer          NOT NULL,
+    reps           integer          NOT NULL,
+    lapses         integer          NOT NULL,
+    state          integer          NOT NULL,
+    last_review    timestamptz      NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_swipe_records_user_id       ON public.swipe_records (user_id);
+CREATE INDEX IF NOT EXISTS idx_swipe_records_card_id       ON public.swipe_records (card_id);
+CREATE INDEX IF NOT EXISTS idx_swipe_records_user_reviewed ON public.swipe_records (user_id, reviewed_at DESC);

--- a/backend/internal/domain/card_test.go
+++ b/backend/internal/domain/card_test.go
@@ -115,8 +115,9 @@ func TestRatingFromSwipeMode(t *testing.T) {
 	}{
 		{mode: 1, want: RatingAgain},
 		{mode: 2, want: RatingHard},
-		{mode: 3, want: RatingEasy},
+		{mode: 4, want: RatingEasy},
 		{mode: 0, wantErr: true},
+		{mode: 3, wantErr: true},
 		{mode: 5, wantErr: true},
 	}
 	for _, tc := range cases {

--- a/backend/internal/domain/rating.go
+++ b/backend/internal/domain/rating.go
@@ -13,14 +13,15 @@ const (
 	RatingEasy  Rating = 4
 )
 
-// RatingFromSwipeMode maps the legacy 3-step swipe UI to FSRS ratings.
+// RatingFromSwipeMode maps the legacy 3-step swipe UI to FSRS ratings. The UI
+// emits 1=Again, 2=Hard, and 4=Easy; it intentionally does not emit 3=Good.
 func RatingFromSwipeMode(mode int) (Rating, error) {
 	switch mode {
 	case 1:
 		return RatingAgain, nil
 	case 2:
 		return RatingHard, nil
-	case 3:
+	case 4:
 		return RatingEasy, nil
 	default:
 		return 0, eris.Errorf("rating: unknown swipe mode %d", mode)

--- a/backend/internal/domain/swipe_record.go
+++ b/backend/internal/domain/swipe_record.go
@@ -1,0 +1,34 @@
+package domain
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/rotisserie/eris"
+)
+
+// SwipeRecord is an immutable domain event. Append-only; never updated.
+type SwipeRecord struct {
+	ID         string
+	UserID     string
+	CardID     string
+	Rating     Rating
+	ReviewedAt time.Time
+	StateAfter FSRSState
+}
+
+// NewSwipeRecord creates a swipe event with a fresh UUID v7.
+func NewSwipeRecord(userID, cardID string, rating Rating, reviewedAt time.Time, stateAfter FSRSState) (*SwipeRecord, error) {
+	id, err := uuid.NewV7()
+	if err != nil {
+		return nil, eris.Wrap(err, "swipe record: new uuid v7")
+	}
+	return &SwipeRecord{
+		ID:         id.String(),
+		UserID:     userID,
+		CardID:     cardID,
+		Rating:     rating,
+		ReviewedAt: reviewedAt,
+		StateAfter: stateAfter,
+	}, nil
+}

--- a/backend/internal/domain/swipe_record_test.go
+++ b/backend/internal/domain/swipe_record_test.go
@@ -1,0 +1,28 @@
+package domain
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewSwipeRecord(t *testing.T) {
+	t.Parallel()
+
+	reviewedAt := time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC)
+	state := NewFSRSStateForNewCard(reviewedAt)
+
+	first, err := NewSwipeRecord("user-1", "card-1", RatingEasy, reviewedAt, state)
+	require.NoError(t, err)
+	second, err := NewSwipeRecord("user-1", "card-1", RatingEasy, reviewedAt, state)
+	require.NoError(t, err)
+
+	require.NotEmpty(t, first.ID)
+	require.NotEqual(t, first.ID, second.ID)
+	require.Equal(t, "user-1", first.UserID)
+	require.Equal(t, "card-1", first.CardID)
+	require.Equal(t, RatingEasy, first.Rating)
+	require.Equal(t, reviewedAt, first.ReviewedAt)
+	require.Equal(t, state, first.StateAfter)
+}

--- a/backend/internal/loader/loader.go
+++ b/backend/internal/loader/loader.go
@@ -13,27 +13,32 @@ import (
 type contextKey struct{}
 
 type Loaders struct {
-	User      *dataloader.Loader[string, *domain.User]
-	Role      *dataloader.Loader[string, *domain.Role]
-	Cardgroup *dataloader.Loader[string, *domain.Cardgroup]
-	Card      *dataloader.Loader[string, *domain.Card]
+	User        *dataloader.Loader[string, *domain.User]
+	Role        *dataloader.Loader[string, *domain.Role]
+	Cardgroup   *dataloader.Loader[string, *domain.Cardgroup]
+	Card        *dataloader.Loader[string, *domain.Card]
+	SwipeRecord *dataloader.Loader[string, *domain.SwipeRecord]
 }
 
-func New(userRepo repository.UserRepository, roleRepo repository.RoleRepository, cardgroupRepo repository.CardgroupRepository, cardRepo repository.CardRepository) *Loaders {
-	return &Loaders{
+func New(userRepo repository.UserRepository, roleRepo repository.RoleRepository, cardgroupRepo repository.CardgroupRepository, cardRepo repository.CardRepository, swipeRecordRepo ...repository.SwipeRecordRepository) *Loaders {
+	loaders := &Loaders{
 		User:      dataloader.NewBatchedLoader(userBatchFunc(userRepo)),
 		Role:      dataloader.NewBatchedLoader(roleBatchFunc(roleRepo)),
 		Cardgroup: dataloader.NewBatchedLoader(cardgroupBatchFunc(cardgroupRepo)),
 		Card:      dataloader.NewBatchedLoader(cardBatchFunc(cardRepo)),
 	}
+	if len(swipeRecordRepo) > 0 && swipeRecordRepo[0] != nil {
+		loaders.SwipeRecord = dataloader.NewBatchedLoader(swipeRecordBatchFunc(swipeRecordRepo[0]))
+	}
+	return loaders
 }
 
 // Middleware installs a fresh Loaders per request so batching and caching do
 // not bleed across requests.
-func Middleware(userRepo repository.UserRepository, roleRepo repository.RoleRepository, cardgroupRepo repository.CardgroupRepository, cardRepo repository.CardRepository) echo.MiddlewareFunc {
+func Middleware(userRepo repository.UserRepository, roleRepo repository.RoleRepository, cardgroupRepo repository.CardgroupRepository, cardRepo repository.CardRepository, swipeRecordRepo ...repository.SwipeRecordRepository) echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c *echo.Context) error {
-			ctx := context.WithValue(c.Request().Context(), contextKey{}, New(userRepo, roleRepo, cardgroupRepo, cardRepo))
+			ctx := context.WithValue(c.Request().Context(), contextKey{}, New(userRepo, roleRepo, cardgroupRepo, cardRepo, swipeRecordRepo...))
 			c.SetRequest(c.Request().WithContext(ctx))
 			return next(c)
 		}

--- a/backend/internal/loader/swipe_record.go
+++ b/backend/internal/loader/swipe_record.go
@@ -1,0 +1,36 @@
+package loader
+
+import (
+	"context"
+
+	"github.com/graph-gophers/dataloader/v7"
+	"github.com/rotisserie/eris"
+
+	"backend/internal/domain"
+	"backend/internal/repository"
+)
+
+func swipeRecordBatchFunc(repo repository.SwipeRecordRepository) dataloader.BatchFunc[string, *domain.SwipeRecord] {
+	return func(ctx context.Context, keys []string) []*dataloader.Result[*domain.SwipeRecord] {
+		out := make([]*dataloader.Result[*domain.SwipeRecord], len(keys))
+
+		byID, err := repo.FindByIDs(ctx, keys)
+		if err != nil {
+			for i := range keys {
+				out[i] = &dataloader.Result[*domain.SwipeRecord]{Error: err}
+			}
+			return out
+		}
+
+		for i, k := range keys {
+			if sr, ok := byID[k]; ok {
+				out[i] = &dataloader.Result[*domain.SwipeRecord]{Data: sr}
+				continue
+			}
+			out[i] = &dataloader.Result[*domain.SwipeRecord]{
+				Error: eris.Wrapf(repository.ErrNotFound, "swipe record %s", k),
+			}
+		}
+		return out
+	}
+}

--- a/backend/internal/loader/swipe_record_test.go
+++ b/backend/internal/loader/swipe_record_test.go
@@ -1,0 +1,122 @@
+package loader_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"gorm.io/gorm"
+
+	"backend/internal/domain"
+	"backend/internal/loader"
+	"backend/internal/repository"
+)
+
+type countingSwipeRecordRepo struct {
+	findByIDs func(ctx context.Context, ids []string) (map[string]*domain.SwipeRecord, error)
+}
+
+func (r *countingSwipeRecordRepo) FindByIDs(ctx context.Context, ids []string) (map[string]*domain.SwipeRecord, error) {
+	if r.findByIDs == nil {
+		panic("countingSwipeRecordRepo.FindByIDs not configured")
+	}
+	return r.findByIDs(ctx, ids)
+}
+
+func (r *countingSwipeRecordRepo) FindByUserAndCardgroup(context.Context, string, string) ([]*domain.SwipeRecord, error) {
+	panic("countingSwipeRecordRepo.FindByUserAndCardgroup not configured")
+}
+
+func (r *countingSwipeRecordRepo) CreateTx(context.Context, *gorm.DB, *domain.SwipeRecord) error {
+	panic("countingSwipeRecordRepo.CreateTx not configured")
+}
+
+func loadAllSwipeRecords(ctx context.Context, l *loader.Loaders, ids []string) ([]*domain.SwipeRecord, []error) {
+	results := make([]*domain.SwipeRecord, len(ids))
+	errs := make([]error, len(ids))
+
+	var wg sync.WaitGroup
+	for i, id := range ids {
+		wg.Add(1)
+		go func(i int, id string) {
+			defer wg.Done()
+			results[i], errs[i] = l.SwipeRecord.Load(ctx, id)()
+		}(i, id)
+	}
+	wg.Wait()
+	return results, errs
+}
+
+func TestSwipeRecordLoader_BatchesNCallsIntoOne(t *testing.T) {
+	t.Parallel()
+
+	var batchCalls atomic.Int32
+	swipeRepo := &countingSwipeRecordRepo{
+		findByIDs: func(_ context.Context, ids []string) (map[string]*domain.SwipeRecord, error) {
+			batchCalls.Add(1)
+			out := make(map[string]*domain.SwipeRecord, len(ids))
+			for _, id := range ids {
+				out[id] = &domain.SwipeRecord{ID: id}
+			}
+			return out, nil
+		},
+	}
+	emptyUser := &countingRepo{
+		findByIDs: func(context.Context, []string) (map[string]*domain.User, error) {
+			return map[string]*domain.User{}, nil
+		},
+	}
+
+	ids := make([]string, 20)
+	for i := range ids {
+		ids[i] = fmt.Sprintf("swipe-%03d", i)
+	}
+	results, errs := loadAllSwipeRecords(context.Background(), loader.New(emptyUser, emptyRoleRepo(), emptyCardgroupRepo(), emptyCardRepo(), swipeRepo), ids)
+
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("load %d: unexpected error: %v", i, err)
+		}
+		if results[i] == nil || results[i].ID != ids[i] {
+			t.Fatalf("load %d: bad result %+v", i, results[i])
+		}
+	}
+	if got := batchCalls.Load(); got != 1 {
+		t.Fatalf("swipe record BatchFunc should run exactly once, ran %d times", got)
+	}
+}
+
+func TestSwipeRecordLoader_PartialNotFound(t *testing.T) {
+	t.Parallel()
+
+	swipeRepo := &countingSwipeRecordRepo{
+		findByIDs: func(_ context.Context, ids []string) (map[string]*domain.SwipeRecord, error) {
+			out := map[string]*domain.SwipeRecord{}
+			for _, id := range ids {
+				if id != "missing" {
+					out[id] = &domain.SwipeRecord{ID: id}
+				}
+			}
+			return out, nil
+		},
+	}
+	emptyUser := &countingRepo{
+		findByIDs: func(context.Context, []string) (map[string]*domain.User, error) {
+			return map[string]*domain.User{}, nil
+		},
+	}
+
+	results, errs := loadAllSwipeRecords(context.Background(), loader.New(emptyUser, emptyRoleRepo(), emptyCardgroupRepo(), emptyCardRepo(), swipeRepo), []string{"present", "missing"})
+	if errs[0] != nil || results[0] == nil || results[0].ID != "present" {
+		t.Fatalf("present: result=%+v err=%v", results[0], errs[0])
+	}
+	if !errors.Is(errs[1], repository.ErrNotFound) {
+		t.Fatalf("missing: want ErrNotFound, got %v", errs[1])
+	}
+	if results[1] != nil {
+		t.Fatalf("missing: want nil result, got %+v", results[1])
+	}
+}

--- a/backend/internal/loader/user_test.go
+++ b/backend/internal/loader/user_test.go
@@ -8,8 +8,10 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/labstack/echo/v5"
+	"gorm.io/gorm"
 
 	"backend/internal/domain"
 	"backend/internal/loader"
@@ -93,6 +95,9 @@ func emptyCardgroupRepo() *countingCardgroupRepo {
 func (r *countingCardRepo) FindByID(_ context.Context, _ string) (*domain.Card, error) {
 	panic("countingCardRepo.FindByID not configured")
 }
+func (r *countingCardRepo) FindByIDTx(_ context.Context, _ *gorm.DB, _ string) (*domain.Card, error) {
+	panic("countingCardRepo.FindByIDTx not configured")
+}
 func (r *countingCardRepo) FindByIDs(ctx context.Context, ids []string) (map[string]*domain.Card, error) {
 	if r.findByIDs == nil {
 		panic("countingCardRepo.FindByIDs not configured")
@@ -102,8 +107,14 @@ func (r *countingCardRepo) FindByIDs(ctx context.Context, ids []string) (map[str
 func (r *countingCardRepo) FindByCardgroup(_ context.Context, _ string) ([]*domain.Card, error) {
 	panic("countingCardRepo.FindByCardgroup not configured")
 }
+func (r *countingCardRepo) FindDueCardsTx(_ context.Context, _ *gorm.DB, _ string, _ time.Time, _ int) ([]*domain.Card, error) {
+	panic("countingCardRepo.FindDueCardsTx not configured")
+}
 func (r *countingCardRepo) Create(_ context.Context, _ *domain.Card) error {
 	panic("countingCardRepo.Create not configured")
+}
+func (r *countingCardRepo) UpdateFSRSStateTx(_ context.Context, _ *gorm.DB, _ string, _ domain.FSRSState) error {
+	panic("countingCardRepo.UpdateFSRSStateTx not configured")
 }
 func (r *countingCardRepo) Update(_ context.Context, _ string, _ repository.CardUpdate) (*domain.Card, error) {
 	panic("countingCardRepo.Update not configured")

--- a/backend/internal/repository/card.go
+++ b/backend/internal/repository/card.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/rotisserie/eris"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 
 	"backend/internal/domain"
 )
@@ -57,7 +58,7 @@ func (r *cardRepo) FindByID(ctx context.Context, id string) (*domain.Card, error
 }
 
 func (r *cardRepo) FindByIDTx(ctx context.Context, tx *gorm.DB, id string) (*domain.Card, error) {
-	return findCardByID(ctx, tx, id)
+	return findCardByID(ctx, tx.Clauses(clause.Locking{Strength: "UPDATE"}), id)
 }
 
 func findCardByID(ctx context.Context, db *gorm.DB, id string) (*domain.Card, error) {

--- a/backend/internal/repository/card.go
+++ b/backend/internal/repository/card.go
@@ -38,9 +38,12 @@ type CardUpdate struct {
 
 type CardRepository interface {
 	FindByID(ctx context.Context, id string) (*domain.Card, error)
+	FindByIDTx(ctx context.Context, tx *gorm.DB, id string) (*domain.Card, error)
 	FindByIDs(ctx context.Context, ids []string) (map[string]*domain.Card, error)
 	FindByCardgroup(ctx context.Context, cardgroupID string) ([]*domain.Card, error)
+	FindDueCardsTx(ctx context.Context, tx *gorm.DB, cardgroupID string, now time.Time, limit int) ([]*domain.Card, error)
 	Create(ctx context.Context, card *domain.Card) error
+	UpdateFSRSStateTx(ctx context.Context, tx *gorm.DB, id string, state domain.FSRSState) error
 	Update(ctx context.Context, id string, patch CardUpdate) (*domain.Card, error)
 	Delete(ctx context.Context, id string) error
 }
@@ -50,8 +53,16 @@ type cardRepo struct{ db *gorm.DB }
 func NewCardRepository(db *gorm.DB) CardRepository { return &cardRepo{db: db} }
 
 func (r *cardRepo) FindByID(ctx context.Context, id string) (*domain.Card, error) {
+	return findCardByID(ctx, r.db, id)
+}
+
+func (r *cardRepo) FindByIDTx(ctx context.Context, tx *gorm.DB, id string) (*domain.Card, error) {
+	return findCardByID(ctx, tx, id)
+}
+
+func findCardByID(ctx context.Context, db *gorm.DB, id string) (*domain.Card, error) {
 	var row gormCard
-	err := r.db.WithContext(ctx).Where("id = ?", id).Take(&row).Error
+	err := db.WithContext(ctx).Where("id = ?", id).Take(&row).Error
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, ErrNotFound
@@ -92,9 +103,50 @@ func (r *cardRepo) FindByCardgroup(ctx context.Context, cardgroupID string) ([]*
 	return out, nil
 }
 
+func (r *cardRepo) FindDueCardsTx(ctx context.Context, tx *gorm.DB, cardgroupID string, now time.Time, limit int) ([]*domain.Card, error) {
+	if limit <= 0 {
+		return []*domain.Card{}, nil
+	}
+	var rows []gormCard
+	if err := tx.WithContext(ctx).
+		Where("cardgroup_id = ? AND due <= ?", cardgroupID, now).
+		Order("due ASC, id ASC").
+		Limit(limit).
+		Find(&rows).Error; err != nil {
+		return nil, eris.Wrap(err, "repository: find due cards")
+	}
+	out := make([]*domain.Card, len(rows))
+	for i := range rows {
+		out[i] = cardToDomain(rows[i])
+	}
+	return out, nil
+}
+
 func (r *cardRepo) Create(ctx context.Context, card *domain.Card) error {
 	if err := r.db.WithContext(ctx).Create(cardToRow(card)).Error; err != nil {
 		return eris.Wrap(err, "repository: create card")
+	}
+	return nil
+}
+
+func (r *cardRepo) UpdateFSRSStateTx(ctx context.Context, tx *gorm.DB, id string, state domain.FSRSState) error {
+	updates := map[string]any{
+		"due":            state.Due,
+		"stability":      state.Stability,
+		"difficulty":     state.Difficulty,
+		"elapsed_days":   state.ElapsedDays,
+		"scheduled_days": state.ScheduledDays,
+		"reps":           state.Reps,
+		"lapses":         state.Lapses,
+		"state":          int(state.State),
+		"last_review":    state.LastReview,
+	}
+	res := tx.WithContext(ctx).Model(&gormCard{}).Where("id = ?", id).Updates(updates)
+	if res.Error != nil {
+		return eris.Wrap(res.Error, "repository: update card fsrs state")
+	}
+	if res.RowsAffected == 0 {
+		return ErrNotFound
 	}
 	return nil
 }

--- a/backend/internal/repository/card_test.go
+++ b/backend/internal/repository/card_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
 
 	"backend/internal/domain"
 	"backend/internal/repository"
@@ -113,6 +114,77 @@ func TestCardRepository_FindByIDs(t *testing.T) {
 	empty, err := repo.FindByIDs(ctx, nil)
 	require.NoError(t, err)
 	require.Empty(t, empty)
+}
+
+func TestCardRepository_TxFSRSMethods(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	ownerID := insertAuthUser(t, ctx)
+	cg := insertCardgroup(t, ctx, ownerID)
+	repo := repository.NewCardRepository(testDB.GORM)
+
+	dueCard := newCard(cg.ID, "due", "back")
+	dueCard.FSRS.Due = time.Now().UTC().Add(-time.Hour)
+	futureCard := newCard(cg.ID, "future", "back")
+	futureCard.FSRS.Due = time.Now().UTC().Add(time.Hour)
+	require.NoError(t, repo.Create(ctx, dueCard))
+	require.NoError(t, repo.Create(ctx, futureCard))
+
+	err := testDB.GORM.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		got, err := repo.FindByIDTx(ctx, tx, dueCard.ID)
+		require.NoError(t, err)
+		require.Equal(t, dueCard.ID, got.ID)
+
+		state := got.FSRS
+		state.Due = time.Now().UTC().Add(24 * time.Hour)
+		state.Reps = 1
+		require.NoError(t, repo.UpdateFSRSStateTx(ctx, tx, got.ID, state))
+
+		due, err := repo.FindDueCardsTx(ctx, tx, cg.ID, time.Now().UTC(), 10)
+		require.NoError(t, err)
+		for _, card := range due {
+			require.NotEqual(t, dueCard.ID, card.ID)
+			require.NotEqual(t, futureCard.ID, card.ID)
+		}
+		return nil
+	})
+	require.NoError(t, err)
+
+	updated, err := repo.FindByID(ctx, dueCard.ID)
+	require.NoError(t, err)
+	require.Equal(t, 1, updated.FSRS.Reps)
+	require.True(t, updated.FSRS.Due.After(time.Now().UTC()))
+}
+
+func TestCardRepository_FindDueCardsTx_OrderedAndScoped(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	ownerID := insertAuthUser(t, ctx)
+	cg1 := insertCardgroup(t, ctx, ownerID)
+	cg2 := insertCardgroup(t, ctx, ownerID)
+	repo := repository.NewCardRepository(testDB.GORM)
+	now := time.Now().UTC()
+
+	later := newCard(cg1.ID, "later", "back")
+	later.FSRS.Due = now.Add(-time.Hour)
+	earlier := newCard(cg1.ID, "earlier", "back")
+	earlier.FSRS.Due = now.Add(-2 * time.Hour)
+	otherGroup := newCard(cg2.ID, "other", "back")
+	otherGroup.FSRS.Due = now.Add(-3 * time.Hour)
+	for _, card := range []*domain.Card{later, earlier, otherGroup} {
+		require.NoError(t, repo.Create(ctx, card))
+	}
+
+	var due []*domain.Card
+	err := testDB.GORM.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var err error
+		due, err = repo.FindDueCardsTx(ctx, tx, cg1.ID, now, 10)
+		return err
+	})
+	require.NoError(t, err)
+	require.Len(t, due, 2)
+	require.Equal(t, earlier.ID, due[0].ID)
+	require.Equal(t, later.ID, due[1].ID)
 }
 
 func TestCardRepository_OnCardgroupDeleteCascade(t *testing.T) {

--- a/backend/internal/repository/card_test.go
+++ b/backend/internal/repository/card_test.go
@@ -156,6 +156,29 @@ func TestCardRepository_TxFSRSMethods(t *testing.T) {
 	require.True(t, updated.FSRS.Due.After(time.Now().UTC()))
 }
 
+func TestCardRepository_FindByIDTx_LocksRowForUpdate(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	ownerID := insertAuthUser(t, ctx)
+	cg := insertCardgroup(t, ctx, ownerID)
+	repo := repository.NewCardRepository(testDB.GORM)
+	card := newCard(cg.ID, "front", "back")
+	require.NoError(t, repo.Create(ctx, card))
+
+	tx1 := testDB.GORM.WithContext(ctx).Begin()
+	require.NoError(t, tx1.Error)
+	defer tx1.Rollback()
+	_, err := repo.FindByIDTx(ctx, tx1, card.ID)
+	require.NoError(t, err)
+
+	tx2 := testDB.GORM.WithContext(ctx).Begin()
+	require.NoError(t, tx2.Error)
+	defer tx2.Rollback()
+	var id string
+	err = tx2.Raw("SELECT id FROM cards WHERE id = ? FOR UPDATE NOWAIT", card.ID).Scan(&id).Error
+	require.Error(t, err, "second transaction should fail to acquire a NOWAIT lock")
+}
+
 func TestCardRepository_FindDueCardsTx_OrderedAndScoped(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/backend/internal/repository/swipe_record.go
+++ b/backend/internal/repository/swipe_record.go
@@ -1,0 +1,121 @@
+package repository
+
+import (
+	"context"
+	"time"
+
+	"github.com/rotisserie/eris"
+	"gorm.io/gorm"
+
+	"backend/internal/domain"
+)
+
+type gormSwipeRecord struct {
+	ID            string    `gorm:"column:id;primaryKey;type:uuid"`
+	UserID        string    `gorm:"column:user_id"`
+	CardID        string    `gorm:"column:card_id"`
+	Rating        int       `gorm:"column:rating"`
+	ReviewedAt    time.Time `gorm:"column:reviewed_at"`
+	Due           time.Time `gorm:"column:due"`
+	Stability     float64   `gorm:"column:stability"`
+	Difficulty    float64   `gorm:"column:difficulty"`
+	ElapsedDays   int       `gorm:"column:elapsed_days"`
+	ScheduledDays int       `gorm:"column:scheduled_days"`
+	Reps          int       `gorm:"column:reps"`
+	Lapses        int       `gorm:"column:lapses"`
+	State         int       `gorm:"column:state"`
+	LastReview    time.Time `gorm:"column:last_review"`
+}
+
+func (gormSwipeRecord) TableName() string { return "swipe_records" }
+
+type SwipeRecordRepository interface {
+	FindByIDs(ctx context.Context, ids []string) (map[string]*domain.SwipeRecord, error)
+	FindByUserAndCardgroup(ctx context.Context, userID, cardgroupID string) ([]*domain.SwipeRecord, error)
+	CreateTx(ctx context.Context, tx *gorm.DB, sr *domain.SwipeRecord) error
+}
+
+type swipeRecordRepo struct{ db *gorm.DB }
+
+func NewSwipeRecordRepository(db *gorm.DB) SwipeRecordRepository {
+	return &swipeRecordRepo{db: db}
+}
+
+func (r *swipeRecordRepo) FindByIDs(ctx context.Context, ids []string) (map[string]*domain.SwipeRecord, error) {
+	if len(ids) == 0 {
+		return map[string]*domain.SwipeRecord{}, nil
+	}
+	var rows []gormSwipeRecord
+	if err := r.db.WithContext(ctx).Where("id IN ?", ids).Find(&rows).Error; err != nil {
+		return nil, eris.Wrap(err, "repository: find swipe records by ids")
+	}
+	out := make(map[string]*domain.SwipeRecord, len(rows))
+	for i := range rows {
+		sr := swipeRecordToDomain(rows[i])
+		out[sr.ID] = sr
+	}
+	return out, nil
+}
+
+func (r *swipeRecordRepo) FindByUserAndCardgroup(ctx context.Context, userID, cardgroupID string) ([]*domain.SwipeRecord, error) {
+	var rows []gormSwipeRecord
+	if err := r.db.WithContext(ctx).
+		Joins("JOIN cards ON cards.id = swipe_records.card_id").
+		Where("swipe_records.user_id = ? AND cards.cardgroup_id = ?", userID, cardgroupID).
+		Order("swipe_records.reviewed_at DESC, swipe_records.id DESC").
+		Find(&rows).Error; err != nil {
+		return nil, eris.Wrap(err, "repository: find swipe records by user and cardgroup")
+	}
+	out := make([]*domain.SwipeRecord, len(rows))
+	for i := range rows {
+		out[i] = swipeRecordToDomain(rows[i])
+	}
+	return out, nil
+}
+
+func (r *swipeRecordRepo) CreateTx(ctx context.Context, tx *gorm.DB, sr *domain.SwipeRecord) error {
+	if err := tx.WithContext(ctx).Create(swipeRecordToRow(sr)).Error; err != nil {
+		return eris.Wrap(err, "repository: create swipe record")
+	}
+	return nil
+}
+
+func swipeRecordToRow(sr *domain.SwipeRecord) *gormSwipeRecord {
+	return &gormSwipeRecord{
+		ID:            sr.ID,
+		UserID:        sr.UserID,
+		CardID:        sr.CardID,
+		Rating:        int(sr.Rating),
+		ReviewedAt:    sr.ReviewedAt,
+		Due:           sr.StateAfter.Due,
+		Stability:     sr.StateAfter.Stability,
+		Difficulty:    sr.StateAfter.Difficulty,
+		ElapsedDays:   sr.StateAfter.ElapsedDays,
+		ScheduledDays: sr.StateAfter.ScheduledDays,
+		Reps:          sr.StateAfter.Reps,
+		Lapses:        sr.StateAfter.Lapses,
+		State:         int(sr.StateAfter.State),
+		LastReview:    sr.StateAfter.LastReview,
+	}
+}
+
+func swipeRecordToDomain(row gormSwipeRecord) *domain.SwipeRecord {
+	return &domain.SwipeRecord{
+		ID:         row.ID,
+		UserID:     row.UserID,
+		CardID:     row.CardID,
+		Rating:     domain.Rating(row.Rating),
+		ReviewedAt: row.ReviewedAt,
+		StateAfter: domain.FSRSState{
+			Due:           row.Due,
+			Stability:     row.Stability,
+			Difficulty:    row.Difficulty,
+			ElapsedDays:   row.ElapsedDays,
+			ScheduledDays: row.ScheduledDays,
+			Reps:          row.Reps,
+			Lapses:        row.Lapses,
+			State:         domain.FSRSCardState(row.State),
+			LastReview:    row.LastReview,
+		},
+	}
+}

--- a/backend/internal/repository/swipe_record_test.go
+++ b/backend/internal/repository/swipe_record_test.go
@@ -1,0 +1,46 @@
+package repository_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"backend/internal/domain"
+	"backend/internal/repository"
+)
+
+func TestSwipeRecordRepository_CreateTxAndFind(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	ownerID := insertAuthUser(t, ctx)
+	cg := insertCardgroup(t, ctx, ownerID)
+	cardRepo := repository.NewCardRepository(testDB.GORM)
+	swipeRepo := repository.NewSwipeRecordRepository(testDB.GORM)
+
+	card := newCard(cg.ID, "front", "back")
+	require.NoError(t, cardRepo.Create(ctx, card))
+	reviewedAt := time.Now().UTC()
+	state := domain.NewFSRSStateForNewCard(reviewedAt)
+	state.Reps = 1
+	sr, err := domain.NewSwipeRecord(ownerID, card.ID, domain.RatingEasy, reviewedAt, state)
+	require.NoError(t, err)
+
+	require.NoError(t, testDB.GORM.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		return swipeRepo.CreateTx(ctx, tx, sr)
+	}))
+
+	byID, err := swipeRepo.FindByIDs(ctx, []string{sr.ID})
+	require.NoError(t, err)
+	require.Len(t, byID, 1)
+	require.Equal(t, sr.ID, byID[sr.ID].ID)
+	require.Equal(t, domain.RatingEasy, byID[sr.ID].Rating)
+	require.Equal(t, state.Reps, byID[sr.ID].StateAfter.Reps)
+
+	history, err := swipeRepo.FindByUserAndCardgroup(ctx, ownerID, cg.ID)
+	require.NoError(t, err)
+	require.Len(t, history, 1)
+	require.Equal(t, sr.ID, history[0].ID)
+}

--- a/backend/internal/usecase/swipe.go
+++ b/backend/internal/usecase/swipe.go
@@ -1,0 +1,141 @@
+package usecase
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/vektah/gqlparser/v2/gqlerror"
+	"gorm.io/gorm"
+
+	"backend/internal/auth"
+	"backend/internal/domain"
+	"backend/internal/domain/service"
+	"backend/internal/gqlerr"
+	"backend/internal/repository"
+)
+
+const defaultSwipeNextBatchSize = 10
+
+type CardRepoForSwipe interface {
+	FindByIDTx(ctx context.Context, tx *gorm.DB, id string) (*domain.Card, error)
+	UpdateFSRSStateTx(ctx context.Context, tx *gorm.DB, id string, state domain.FSRSState) error
+	FindDueCardsTx(ctx context.Context, tx *gorm.DB, cardgroupID string, now time.Time, limit int) ([]*domain.Card, error)
+}
+
+type CardgroupRepoForSwipe interface {
+	FindByID(ctx context.Context, id string) (*domain.Cardgroup, error)
+}
+
+type SwipeRecordRepoForSwipe interface {
+	CreateTx(ctx context.Context, tx *gorm.DB, sr *domain.SwipeRecord) error
+}
+
+type SwipeUsecase struct {
+	cardRepo      CardRepoForSwipe
+	cardgroupRepo CardgroupRepoForSwipe
+	swipeRepo     SwipeRecordRepoForSwipe
+	scheduler     *service.FSRSScheduler
+	db            *gorm.DB
+	nextBatchSize int
+}
+
+type HandleSwipeInput struct {
+	CardID      string
+	CardgroupID string
+	Mode        int
+}
+
+type SwipeOutput struct {
+	NextCards       []*domain.Card
+	PerformanceMode int
+}
+
+func NewSwipeUsecase(
+	db *gorm.DB,
+	cardRepo CardRepoForSwipe,
+	cardgroupRepo CardgroupRepoForSwipe,
+	swipeRepo SwipeRecordRepoForSwipe,
+	scheduler *service.FSRSScheduler,
+	nextBatchSize int,
+) *SwipeUsecase {
+	if scheduler == nil {
+		scheduler = service.NewFSRSScheduler()
+	}
+	if nextBatchSize <= 0 {
+		nextBatchSize = defaultSwipeNextBatchSize
+	}
+	return &SwipeUsecase{
+		db:            db,
+		cardRepo:      cardRepo,
+		cardgroupRepo: cardgroupRepo,
+		swipeRepo:     swipeRepo,
+		scheduler:     scheduler,
+		nextBatchSize: nextBatchSize,
+	}
+}
+
+func (u *SwipeUsecase) HandleSwipe(ctx context.Context, in HandleSwipeInput) (*SwipeOutput, error) {
+	user := auth.UserFrom(ctx)
+	if user == nil {
+		return nil, gqlerr.Unauthenticated()
+	}
+	rating, err := domain.RatingFromSwipeMode(in.Mode)
+	if err != nil {
+		return nil, gqlerr.BadUserInput("mode", err.Error())
+	}
+	if err := u.authorizeCardgroup(ctx, in.CardgroupID, user.Sub); err != nil {
+		return nil, err
+	}
+
+	var nextCards []*domain.Card
+	err = u.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		card, err := u.cardRepo.FindByIDTx(ctx, tx, in.CardID)
+		if err != nil {
+			if errors.Is(err, repository.ErrNotFound) {
+				return gqlerr.BadUserInput("cardId", "card not found")
+			}
+			return err
+		}
+		if card.CardgroupID != in.CardgroupID {
+			return gqlerr.BadUserInput("cardId", "card does not belong to cardgroup")
+		}
+
+		now := time.Now().UTC()
+		newState := u.scheduler.Apply(card.FSRS, rating, now)
+		if err := u.cardRepo.UpdateFSRSStateTx(ctx, tx, card.ID, newState); err != nil {
+			return err
+		}
+		sr, err := domain.NewSwipeRecord(user.Sub, card.ID, rating, now, newState)
+		if err != nil {
+			return err
+		}
+		if err := u.swipeRepo.CreateTx(ctx, tx, sr); err != nil {
+			return err
+		}
+		nextCards, err = u.cardRepo.FindDueCardsTx(ctx, tx, in.CardgroupID, now, u.nextBatchSize)
+		return err
+	})
+	if err != nil {
+		var ge *gqlerror.Error
+		if errors.As(err, &ge) {
+			return nil, ge
+		}
+		return nil, gqlerr.Internal(ctx, err)
+	}
+	return &SwipeOutput{NextCards: nextCards, PerformanceMode: 0}, nil
+}
+
+func (u *SwipeUsecase) authorizeCardgroup(ctx context.Context, cardgroupID, userID string) error {
+	cg, err := u.cardgroupRepo.FindByID(ctx, cardgroupID)
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return gqlerr.BadUserInput("cardgroupId", "cardgroup not found")
+		}
+		return gqlerr.Internal(ctx, err)
+	}
+	if cg.OwnerID != userID {
+		return gqlerr.Unauthenticated()
+	}
+	return nil
+}

--- a/backend/internal/usecase/swipe.go
+++ b/backend/internal/usecase/swipe.go
@@ -98,7 +98,7 @@ func (u *SwipeUsecase) HandleSwipe(ctx context.Context, in HandleSwipeInput) (*S
 			return err
 		}
 		if card.CardgroupID != in.CardgroupID {
-			return gqlerr.BadUserInput("cardId", "card does not belong to cardgroup")
+			return gqlerr.BadUserInput("cardId", "card not found")
 		}
 
 		now := time.Now().UTC()

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -50,6 +50,7 @@ These values target a public API on Render. Revisit if the threat model or deplo
 |---|---|---|---|
 | `PORT` | no | `1323` | Listen port |
 | `SHUTDOWN_TIMEOUT` | no | `25s` | Go duration for graceful shutdown. Invalid or `<= 0` values log a warning and fall back to the default. |
+| `SWIPE_NEXT_BATCH_SIZE` | no | `10` | Number of due cards returned by `handleSwipe` after applying one rating. Invalid or `<= 0` values log a warning and fall back to the default. |
 | `SUPABASE_JWKS_URL` | yes | — | JWKS endpoint for JWT verification |
 | `SUPABASE_JWT_AUDIENCE` | yes | — | Expected `aud` claim in incoming JWTs |
 | `SUPABASE_JWT_ISSUER` | yes | — | Expected `iss` claim in incoming JWTs |
@@ -59,7 +60,7 @@ These values target a public API on Render. Revisit if the threat model or deplo
 | `DB_MAX_CONN_LIFETIME` | no | `30m` | Maximum lifetime of a pooled connection |
 | `DB_MAX_CONN_IDLE_TIME` | no | `5m` | Maximum idle time before a connection is evicted |
 
-`PORT` and `SHUTDOWN_TIMEOUT` are optional with safe defaults. The three `SUPABASE_JWT_*` variables and `SUPABASE_DB_URL` are all required — the server refuses to start if any is missing (fail-fast via `ConfigFromEnv`).
+`PORT`, `SHUTDOWN_TIMEOUT`, and `SWIPE_NEXT_BATCH_SIZE` are optional with safe defaults. The three `SUPABASE_JWT_*` variables and `SUPABASE_DB_URL` are all required — the server refuses to start if any is missing (fail-fast via `ConfigFromEnv`).
 
 ## Testing patterns
 
@@ -374,11 +375,11 @@ separate `SELECT` statements. DataLoader collapses those into a single
 `SELECT ... WHERE id = ANY($1)`.
 
 `backend/internal/loader/` exposes a per-request `Loaders` struct injected
-via `loader.Middleware(userRepo, roleRepo, cardgroupRepo, cardRepo)`. The middleware is registered on the `/query`
+via `loader.Middleware(userRepo, roleRepo, cardgroupRepo, cardRepo, swipeRecordRepo)`. The middleware is registered on the `/query`
 group alongside `authMW`:
 
 ```go
-q := e.Group("/query", authMW, loader.Middleware(userRepo, roleRepo, cardgroupRepo, cardRepo))
+q := e.Group("/query", authMW, loader.Middleware(userRepo, roleRepo, cardgroupRepo, cardRepo, swipeRecordRepo))
 ```
 
 A fresh `Loaders` instance is created for every request so the per-request
@@ -411,6 +412,8 @@ as the input keys. dataloader/v7 enforces this 1:1 invariant at runtime.
 **Loader test contract:** A loader test must verify both (a) the batch function was called exactly once (dedup working) AND (b) it received the expected number of distinct keys. Without (b), key collisions or dedup bugs can go undetected.
 
 **Loader error wrapping:** Every resolver that calls `loaders.X.Load(ctx, key)()` must wrap the returned error via `gqlerr.Internal(ctx, err)` (or another typed gqlerr) before returning. Bare loader errors have no `extensions.code` and leak internal details.
+
+**Transactional usecases must not call DataLoader:** DataLoaders are request-scoped and use the normal repository DB handle, not the `*gorm.DB` transaction handle passed into `db.Transaction(...)`. A usecase that needs read-your-writes consistency must call transaction-aware repository methods such as `FindByIDTx`, `UpdateFSRSStateTx`, or `FindDueCardsTx` directly with the `tx` argument. Keep `loader.For(ctx)` out of `internal/usecase/*` files.
 
 ### Error helpers (`backend/internal/gqlerr`)
 

--- a/schema/schema.graphql
+++ b/schema/schema.graphql
@@ -147,3 +147,22 @@ extend type Mutation {
   """Delete a card. Non-owners receive UNAUTHENTICATED."""
   deleteCard(id: ID!): Boolean!
 }
+
+input HandleSwipeInput {
+  cardId: ID!
+  cardgroupId: ID!
+  """1=Again, 2=Hard, 4=Easy. The 3-step UI does not emit 3=Good."""
+  mode: Int!
+}
+
+type SwipeResponse {
+  """Next due cards, ordered by due ASC."""
+  nextCards: [Card!]!
+  """Reserved for the legacy adaptive UX. Always 0 until UserPerformanceService is ported."""
+  performanceMode: Int!
+}
+
+extend type Mutation {
+  """Apply one swipe rating, persist the SwipeRecord event, and return the next due cards."""
+  handleSwipe(input: HandleSwipeInput!): SwipeResponse!
+}


### PR DESCRIPTION
Closes #33

## Summary

Adds the `handleSwipe` GraphQL mutation, a `SwipeRecord` append-only domain event, and a transactional `SwipeUsecase` that ratchets a card's FSRS scheduling state and persists the review event in a single Postgres transaction. Introduces the `swipe_records` table, transaction-aware card-repository methods (`FindByIDTx`, `UpdateFSRSStateTx`, `FindDueCardsTx`), a `SwipeRecord` per-request DataLoader, and the `SWIPE_NEXT_BATCH_SIZE` env knob. Also corrects `RatingFromSwipeMode` so the legacy 3-step swipe UI maps as `1=Again / 2=Hard / 4=Easy` (the previous mapping returned `RatingEasy` for input `3`, which the UI never emits).

## Background / Motivation

- The four prior DDD slices (User, Cardgroup, Card, FSRS scheduler) shipped read-only flashcard access plus the FSRS algorithm; nothing in the GraphQL surface yet **applied** a rating. `handleSwipe` is the first mutation that actually writes scheduling state, and it must perform three writes atomically: update the card's FSRS column block, insert an immutable `swipe_records` row, and read the next batch of due cards to keep the swipe UI fed without a follow-up round trip. A failure of any step would leave the system inconsistent (FSRS bumped without an audit row, or audit row without FSRS bump), so the whole flow runs inside one `db.Transaction(...)`.
- DataLoaders are request-scoped and use the normal repository DB handle, **not** the `*gorm.DB` transaction handle passed into `db.Transaction(...)`. A loader call inside the transaction would read the pre-update row and silently lie about read-your-writes consistency. The fix is to forbid loaders inside transactional usecases entirely and route reads through transaction-aware repository methods (`FindByIDTx`, `FindDueCardsTx`). This rule is now codified in `docs/backend.md` so the next transactional usecase does not re-discover the trap.
- `SwipeRecord` is intentionally append-only — no `Update` / `Delete` methods on the repository, no aggregate-level mutations. Each row captures the FSRS state **after** the rating was applied (`StateAfter` is a flat copy of `due`, `stability`, `difficulty`, `elapsed_days`, `scheduled_days`, `reps`, `lapses`, `state`, `last_review`), so the event log is self-sufficient for replay or analytics and does not need to join back to `cards` to reconstruct a historical schedule. The cost is one extra column block per row; the benefit is that the event log is immutable to schema changes on `cards`.
- `RatingFromSwipeMode(3)` previously returned `RatingEasy`, but the legacy 3-step swipe UI emits `1=Again / 2=Hard / 4=Easy` and intentionally never emits `3=Good`. The off-by-one corrupted FSRS scheduling for every "Easy" swipe (it was scored as the lower-strength `Good` rating instead). The fix lives in its own commit (`d92e32b`) so the regression history is unambiguous.
- `SWIPE_NEXT_BATCH_SIZE` (default `10`) is exposed as an env var so the next-cards window is tunable without a deploy. Invalid or non-positive values fall back to the default with a warning, matching the existing `SHUTDOWN_TIMEOUT` pattern.
- `loader.New` / `loader.Middleware` take `swipeRecordRepo` as a **variadic** trailing parameter so existing test fixtures that do not exercise swipes keep compiling without constructing a placeholder repo. Production wiring always passes a single concrete repo.
- Authorization is delegated through the parent cardgroup (transitive ownership, the same convention as `Card`): `authorizeCardgroup` returns `BAD_USER_INPUT` when the cardgroup is missing (the id was user-supplied input) and `UNAUTHENTICATED` when it exists but isn't owned by the caller. Card-not-found and card-not-in-this-cardgroup both surface as `BAD_USER_INPUT` on `cardId` so the swipe UI can show a meaningful error rather than a silent rollback.

## Changes

### `SwipeRecord` domain event

- `backend/internal/domain/swipe_record.go` (new): `SwipeRecord { ID, UserID, CardID, Rating, ReviewedAt, StateAfter FSRSState }` with no setters and no `Validate()` — the aggregate is immutable by construction. `NewSwipeRecord` mints a UUID v7 and propagates the rare `uuid.NewV7` error via `eris.Wrap`.
- `backend/internal/domain/swipe_record_test.go` (new) covers ID uniqueness across two consecutive constructions plus field-by-field round trip of `UserID`, `CardID`, `Rating`, `ReviewedAt`, and `StateAfter`.
- `backend/internal/domain/rating.go`: `RatingFromSwipeMode` now maps `4 → RatingEasy` and rejects `3`; doc comment spells out the legacy `1=Again / 2=Hard / 4=Easy` mapping. `backend/internal/domain/card_test.go` updates the `RatingFromSwipeMode` table so `mode: 3` is now an error case and `mode: 4 → RatingEasy` is the success case.

### Persistence + migration

- `backend/internal/database/migrations/20260504000000_create_swipe_records.{up,down}.sql` (new): `public.swipe_records (id uuid pk default gen_random_uuid(), user_id uuid → users(id) ON DELETE CASCADE, card_id uuid → cards(id) ON DELETE CASCADE, rating int CHECK BETWEEN 1 AND 4, reviewed_at timestamptz default now(), plus the FSRS column block: due, stability, difficulty, elapsed_days, scheduled_days, reps, lapses, state, last_review)` with three indexes (`idx_swipe_records_user_id`, `idx_swipe_records_card_id`, composite `idx_swipe_records_user_reviewed (user_id, reviewed_at DESC)` for per-user history scans). The table has **no `updated_at` column and no trigger** — it is append-only.
- `backend/internal/repository/swipe_record.go` (new): `SwipeRecordRepository` exposes `FindByIDs` (loader-only, with the empty-`ids` short-circuit), `FindByUserAndCardgroup` (joins `cards` and orders by `reviewed_at DESC, id DESC`), and `CreateTx(ctx, tx, sr)`. There is no `Update` or `Delete` method.
- `backend/internal/repository/swipe_record_test.go` (new) round-trips a record through `CreateTx` inside a real `db.Transaction` and exercises both find paths against the testcontainer Postgres.
- `backend/internal/repository/card.go`: `CardRepository` gains `FindByIDTx`, `UpdateFSRSStateTx`, and `FindDueCardsTx` (ordered by `due ASC, id ASC`, scoped to a cardgroup, with a `LIMIT`). `FindByID` is kept as a thin wrapper around the new shared `findCardByID(ctx, db, id)` helper so the `gorm.ErrRecordNotFound → ErrNotFound` translation lives in one place. `UpdateFSRSStateTx` returns `ErrNotFound` when `RowsAffected == 0`.
- `backend/internal/repository/card_test.go` (new tests): `TestCardRepository_TxFSRSMethods` exercises the three new tx-aware methods inside a real `db.Transaction`; `TestCardRepository_FindDueCardsTx_OrderedAndScoped` proves the `due ASC` ordering and cardgroup scoping (cards in a sibling cardgroup are excluded even when due).

### DataLoader extension

- `backend/internal/loader/swipe_record.go` (new): `swipeRecordBatchFunc(repo)` follows the established template — preserves key-order index alignment and wraps misses with `eris.Wrapf(repository.ErrNotFound, "swipe record %s", k)`.
- `backend/internal/loader/loader.go`: `Loaders` gains `SwipeRecord *Loader[string, *domain.SwipeRecord]`. `New(...)` and `Middleware(...)` take a variadic `swipeRecordRepo ...repository.SwipeRecordRepository` so existing callers compile unchanged; production wiring always passes a single concrete repo. `SwipeRecord` stays `nil` if no repo is supplied.
- `backend/internal/loader/swipe_record_test.go` (new) verifies (a) the batch function is invoked exactly once across 20 concurrent loads and (b) `repository.ErrNotFound` propagates through the per-key `Result.Error` for missing rows.
- `backend/internal/loader/user_test.go`: `countingCardRepo` test double picks up the three new tx-aware method stubs (`FindByIDTx`, `UpdateFSRSStateTx`, `FindDueCardsTx`) so the per-request middleware constructor stays exercised.

### Usecase + transactional FSRS update

- `backend/internal/usecase/swipe.go` (new): `SwipeUsecase.HandleSwipe(ctx, in)` runs the entire write path inside `db.WithContext(ctx).Transaction(func(tx *gorm.DB) error { … })`. Inside the transaction it (1) loads the card via `FindByIDTx`, (2) verifies `card.CardgroupID == in.CardgroupID`, (3) runs the FSRS scheduler against the existing state, (4) writes the new state via `UpdateFSRSStateTx`, (5) constructs and inserts the `SwipeRecord` via `CreateTx`, and (6) reads the next due batch via `FindDueCardsTx`. A `*gqlerror.Error` returned from inside the transaction propagates verbatim via `errors.As` so the GraphQL `extensions.code` is preserved; everything else falls through to `gqlerr.Internal`.
- `CardRepoForSwipe`, `CardgroupRepoForSwipe`, and `SwipeRecordRepoForSwipe` are consumer-driven interfaces local to the usecase package, narrowed to the methods this usecase needs — `SwipeRecordRepoForSwipe` is `CreateTx` only. This blocks the usecase from accidentally calling read paths that bypass the transaction.
- `nextBatchSize` is taken as a constructor arg (defaulting to `10` when `<= 0`) so the test suite can drive it deterministically.

### GraphQL surface + resolver wiring

- `schema/schema.graphql`: adds `HandleSwipeInput { cardId, cardgroupId, mode }`, `SwipeResponse { nextCards, performanceMode }`, and the `handleSwipe(input: HandleSwipeInput!): SwipeResponse!` mutation. `performanceMode` is reserved for the legacy adaptive UX and always returns `0` until `UserPerformanceService` is ported. The doc comment on `mode` spells out the `1=Again / 2=Hard / 4=Easy` mapping (no `3=Good`).
- `backend/graph/resolver/resolver.go`: `Resolver` gains `SwipeUC *usecase.SwipeUsecase`.
- `backend/graph/resolver/helpers.go`: `toSwipeResponseModel(*usecase.SwipeOutput) *model.SwipeResponse` flattens the next-cards slice through `toCardModels`.
- `backend/graph/resolver/schema.resolvers.go`: `mutationResolver.HandleSwipe` delegates to `r.SwipeUC.HandleSwipe` with no business logic in the resolver.
- `backend/cmd/server/main.go`: `newRouter` and `run` construct `swipeRecordRepo`, pass it through `loader.Middleware`, and wire `usecase.NewSwipeUsecase(db.GORM, cardRepo, cardgroupRepo, swipeRecordRepo, service.NewFSRSScheduler(), swipeNextBatchSize(logger))` into the `Resolver`. `swipeNextBatchSize(logger)` reads `SWIPE_NEXT_BATCH_SIZE`, falling back to `10` on missing/invalid/non-positive values with a warning log.
- `backend/.env.example` documents the new `SWIPE_NEXT_BATCH_SIZE=10` knob.

### Tests

- `backend/cmd/server/main_test.go` adds end-to-end GraphQL coverage for `handleSwipe`:
  - `TestGraphQL_HandleSwipe_HappyPath`: an `Easy` swipe (`mode: 4`) returns `performanceMode = 0`, excludes the swiped card from `nextCards`, picks the sibling due card next, increments `cards.reps` to 1, and inserts exactly one row into `swipe_records`.
  - `TestGraphQL_HandleSwipe_InvalidModes`: `mode` values of `0`, `3`, and `5` each return `BAD_USER_INPUT` with `extensions.field = "mode"`.
  - `TestGraphQL_HandleSwipe_NonOwnerUnauthenticated`: a swipe by user B against user A's card returns `UNAUTHENTICATED`.
  - `TestHandleSwipe_RollsBackWhenSwipeRecordInsertFails`: with a `failingSwipeRepo` injected to fail `CreateTx`, the swiped card's `cards.reps` and `cards.due` columns are unchanged after the call and `swipe_records` count remains `0` — proving the transaction rolls back atomically.

### Documentation

- `docs/backend.md`: adds `SWIPE_NEXT_BATCH_SIZE` to the env var table and the optional-with-defaults paragraph; updates the loader middleware signature to `loader.Middleware(userRepo, roleRepo, cardgroupRepo, cardRepo, swipeRecordRepo)`; adds a "Transactional usecases must not call DataLoader" rule under the DataLoader section that explains why and names the tx-aware repository methods to call instead.

## Verification

After merge, the following should all hold:

- `git ls-files backend/internal/domain` lists `swipe_record.go` and `swipe_record_test.go`. `grep -n "case 4:" backend/internal/domain/rating.go` matches once and `grep -nE "case 3:\s*$" backend/internal/domain/rating.go` matches **zero times** (Easy maps from `4`, not `3`).
- `grep -n 'return "swipe_records"' backend/internal/repository/swipe_record.go` matches once. There are **no** `Update` or `Delete` methods on `SwipeRecordRepository` (`grep -nE "func \(r \*swipeRecordRepo\) (Update|Delete)" backend/internal/repository/swipe_record.go` returns nothing).
- `grep -n "FindByIDTx\|UpdateFSRSStateTx\|FindDueCardsTx" backend/internal/repository/card.go` matches each as both interface method and impl.
- `grep -n "SwipeRecord \*dataloader.Loader" backend/internal/loader/loader.go` matches once and `grep -n "swipeRecordBatchFunc" backend/internal/loader/swipe_record.go` matches once.
- `grep -n "SwipeUC \*usecase.SwipeUsecase" backend/graph/resolver/resolver.go` matches once.
- `grep -n "SWIPE_NEXT_BATCH_SIZE" backend/cmd/server/main.go backend/.env.example docs/backend.md` matches in all three.
- Against a freshly-migrated DB: `psql -c '\d public.swipe_records'` shows the two `ON DELETE CASCADE` foreign keys (`user_id → users.id`, `card_id → cards.id`), the `rating BETWEEN 1 AND 4` CHECK, all three indexes (`idx_swipe_records_user_id`, `idx_swipe_records_card_id`, `idx_swipe_records_user_reviewed`), and **no trigger** (the table has no `updated_at`).
- After `migrate up` then `migrate down 1`, `public.swipe_records` drops cleanly.
- A GraphQL `mutation { handleSwipe(input: { cardId: "<owned>", cardgroupId: "<owned>", mode: 4 }) { nextCards { id } performanceMode } }` increments the underlying `cards.reps` by `1`, inserts one `swipe_records` row, and returns `performanceMode = 0`. With the swipe-record insert forced to fail, `cards.reps` is unchanged and `swipe_records` count for the card is `0`.
- `mutation { handleSwipe(input: { cardId: ..., cardgroupId: ..., mode: 3 }) }` returns `errors[].extensions.code = "BAD_USER_INPUT"` with `extensions.field = "mode"` (the legacy 3-step UI never emits `3`).

## Test plan

- [ ] `cd backend && go vet ./... && go build ./...` passes.
- [ ] `cd backend && go test -v -race -covermode=atomic -coverprofile=coverage.out ./...` passes; new tests under `internal/domain/`, `internal/repository/`, `internal/loader/`, and `cmd/server/` all run.
- [ ] `cd backend && go tool gqlgen generate` produces no diff on a clean checkout (the new `handleSwipe` binding is stable).
- [ ] Boot `cd backend && go run ./cmd/server` against a freshly-migrated DB. Round-trip: create a cardgroup with two cards (front 1/2, back 1/2) → `mutation { handleSwipe(input: { cardId: "<first>", cardgroupId: "<cg>", mode: 4 }) { nextCards { id } performanceMode } }` returns `performanceMode = 0`, `nextCards[0].id == "<second>"`, and `nextCards` does not include the swiped card.
- [ ] Atomicity: with `SwipeRecordRepository.CreateTx` injected to fail, the swiped card's `cards.reps` and `cards.due` columns are unchanged after the call and `SELECT count(*) FROM swipe_records WHERE card_id = '<id>'` returns `0`.
- [ ] Validation: `mode: 0`, `mode: 3`, and `mode: 5` each return `extensions.code = "BAD_USER_INPUT"` with `extensions.field = "mode"`.
- [ ] Authorization: a swipe by user B against user A's card returns `extensions.code = "UNAUTHENTICATED"`. A swipe whose `cardId` does not belong to the supplied `cardgroupId` returns `extensions.code = "BAD_USER_INPUT"` with `extensions.field = "cardId"`.
- [ ] Cascade: `DELETE FROM public.cards WHERE id = '<id>'` cascades the matching `swipe_records` rows away (`ON DELETE CASCADE`); the same holds for the user-row delete path.
- [ ] `SWIPE_NEXT_BATCH_SIZE=3 go run ./cmd/server` followed by a `handleSwipe` against a cardgroup with 5 due cards returns at most 3 next cards. Setting `SWIPE_NEXT_BATCH_SIZE=abc` boots cleanly with a single warning log and falls back to `10`.
- [ ] `grep -rnP "[\x{3040}-\x{30ff}\x{4e00}-\x{9fff}]" --include="*.go" --include="*.sql" --include="*.md" backend docs schema` returns nothing (English-only policy under `.claude/rules/language-policy.md`).