### PR TITLE
feat(frontend): add cardgroup and card CRUD pages with Apollo cache wiring

### DIFF
--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -84,6 +84,34 @@ Files:
 
 Browser code calls `/api/graphql` (same-origin via the Next rewrite — avoids CORS/cookie issues). `ApolloClient` and `InMemoryCache` come from `@apollo/client-integration-nextjs` (SSR-streaming-safe variants) — see Gotcha below.
 
+### Apollo cache mutation patterns
+
+**`update` callback fires on success only** (default `errorPolicy: "none"`). Guard the body with a presence check for forward-compatibility with `errorPolicy: "all"`:
+
+```ts
+update(cache, { data }) {
+  if (!data?.createCardgroup?.cardgroup) return;
+  // safe to write
+}
+```
+
+**Create — prepend into a list query** via `readQuery → writeQuery`:
+
+```ts
+const existing = cache.readQuery({ query: MyCardgroupsDocument });
+cache.writeQuery({
+  query: MyCardgroupsDocument,
+  data: { myCardgroups: [data.createCardgroup.cardgroup, ...(existing?.myCardgroups ?? [])] },
+});
+```
+
+**Delete — evict the entity then collect garbage**:
+
+```ts
+cache.evict({ id: cache.identify({ __typename: "Cardgroup", id: cardgroupId }) });
+cache.gc();
+```
+
 ## Auth (Supabase)
 
 The Supabase SSR client uses a 3-layer setup mirroring the official `@supabase/ssr` template. Each layer exists because cookie reading/writing differs between contexts:
@@ -134,6 +162,20 @@ The `matcher` must also explicitly exclude `/api/:path*` and `/auth/callback`. W
 `frontend/src/lib/apollo/server.ts` reads the Supabase session via `createSupabaseServerClient().auth.getSession()` and forwards `Authorization: Bearer <access_token>` when present. Unauthenticated RSC calls omit the header and receive an `UNAUTHENTICATED` GraphQL error.
 
 `getSession()` reads from the cookie store and does **not** contact the Supabase auth server — it is safe to call per-request. The auth server is only consulted by `getUser()`. Both must destructure and propagate `error`. In `gqlFetch`, an auth-fetch error must **throw** (fail-closed) rather than silently skipping the `Authorization` header — a missing header would produce a silent `UNAUTHENTICATED` response that is indistinguishable from a legitimate anonymous call. The browser-side `authLink` is the only place where a missing session is intentionally fails-open (omits the header without throwing).
+
+### RSC UNAUTHENTICATED redirect pattern
+
+`gqlFetch` throws when the backend returns GraphQL errors. RSC pages wrap the call in `try/catch` and use `redirectIfUnauthenticated(err, target)` from `@/lib/apollo/server-redirect`:
+
+```ts
+try {
+  data = await gqlFetch(MyQuery, { variables, revalidate: 0 });
+} catch (err) {
+  redirectIfUnauthenticated(err, "/login"); // never returns
+}
+```
+
+The helper string-matches `UNAUTHENTICATED` in the error message and calls `redirect(target)`; all other errors are rethrown to the nearest error boundary. Two redirect targets are in use: `/login` for session-expired or no-session cases (checked before `gqlFetch` via `supabase.auth.getUser()`), and `/cardgroups` for cross-user-access on inner pages. See [Backend error-code contract](#backend-error-code-contract) for why these two cases both surface as `UNAUTHENTICATED`.
 
 ### Zod schema convention
 
@@ -218,6 +260,19 @@ await mutate({ variables }).catch(console.error);
 
 Do not swallow the rejection silently with an empty `.catch(() => {})` — that hides unexpected errors (network failures, etc.).
 
+**Stale-closure trap with `useMutation` `error` state:** The `error` state from `useMutation` is updated on the next render. Reading it inside the same async handler right after `await mutate(...)` reads the previous closure's stale value. Gate navigation and dialog-close on the `FetchResult` returned by the `await` instead:
+
+```ts
+const result = await mutate({ variables }).catch(() => null);
+if (result?.data?.updateCardgroup?.cardgroup) {
+  router.push(`/cardgroups/${id}`);  // only on confirmed success
+}
+```
+
+**Dialog open-state tied to mutation result:** Close a destructive-confirm dialog only after verifying `result?.data?.deleteX === true`. Calling `setDialogOpen(false)` synchronously in the confirm `onClick` closes the dialog before the mutation completes, making it impossible to show in-dialog errors.
+
+**Form remount via React `key` to reset fields:** After a successful create-mutation, bump a numeric `key` state variable passed to the form component (`<CardForm key={createFormKey} ...>`). React unmounts and remounts the component, resetting all TanStack Form field state without manual `form.reset()` calls.
+
 #### Bio explicit clear UX
 
 `bio` follows tri-state semantics:
@@ -238,11 +293,40 @@ field to `""` so the next submit clears the column.
 - `@testing-library/react` + `userEvent` drive interaction.
 - `expect(element).toBeInTheDocument()` matchers come from `vitest.config.ts` loading `frontend/src/__test-setup__/jest-dom.ts`.
 
+**Real `InMemoryCache` for cache-write/evict tests:** Passing a real `InMemoryCache` to `<MockedProvider cache={cache}>` and pre-seeding it via `cache.writeQuery(...)` lets tests assert the actual cache state after a mutation (`cache.readQuery(...)`) rather than only observable side-effects. Use this to prove that `update` callbacks correctly prepend or evict entries.
+
+**Inverse navigation assertion in failure-path tests:** Use `expect(mockPush).not.toHaveBeenCalled()` in error-path tests to pin down "navigate-on-failure" regressions. Without this assertion, a handler that navigates unconditionally passes happy-path tests but silently breaks on errors.
+
 ## shadcn/ui
 
-`frontend/components.json` and `frontend/src/lib/utils.ts` (the `cn()` helper) are committed. The initial component set (`button`, `input`, `label`) was added with `pnpm dlx shadcn add` and extends `globals.css` with the required theme tokens. `form.tsx` was removed (TanStack Form's render-prop API does not need the shadcn wrapper); `textarea.tsx` was added for the `bio` field.
+`frontend/components.json` and `frontend/src/lib/utils.ts` (the `cn()` helper) are committed. The initial component set (`button`, `input`, `label`) was added with `pnpm dlx shadcn add` and extends `globals.css` with the required theme tokens. `form.tsx` was removed (TanStack Form's render-prop API does not need the shadcn wrapper); `textarea.tsx` was added for the `bio` field. `alert-dialog` and `dialog` primitives are now installed — use `AlertDialog` for destructive confirms (delete), `Dialog` for non-destructive overlays.
 
 `shadcn init` is interactive and not suitable for CI or non-interactive environments. The fallback is to hand-write `components.json`, `lib/utils.ts`, and the `globals.css` base tokens following the shadcn JSON schema — that is how this repo's shadcn baseline was bootstrapped.
+
+## Backend error-code contract
+
+The backend (`backend/internal/gqlerr`) returns three `extensions.code` values. The frontend handles them at two layers:
+
+| Code | Backend meaning | Frontend action |
+|---|---|---|
+| `BAD_USER_INPUT` | Validation failure; `extensions.field` names the form field | Show inline field error via `getBackendFieldErrors` |
+| `UNAUTHENTICATED` | No valid session, or cross-user-access on an ownership-protected resource | RSC: `redirectIfUnauthenticated`; client: banner via `getBackendErrorBanner` |
+| `INTERNAL` | Server-side error; original message is hidden | Banner via `getBackendErrorBanner` |
+
+`getBackendErrorBanner` scans all errors in priority order (INTERNAL > UNAUTHENTICATED > first non-field error) rather than relying on array position. The backend collapses `NOT_FOUND` into `UNAUTHENTICATED` for ownership-protected resources — the frontend does not need a separate "not found" UI branch on those routes.
+
+## Shared helper modules
+
+Import these instead of re-inlining the logic:
+
+| Import | Contract |
+|---|---|
+| `getBackendFieldErrors(err)` from `@/lib/apollo/errors` | Returns `{ fieldName: message }` for `BAD_USER_INPUT` errors with a `field` extension |
+| `getBackendErrorBanner(err)` from `@/lib/apollo/errors` | Returns a user-facing banner string for non-field errors; priority INTERNAL > UNAUTHENTICATED > first non-field |
+| `redirectIfUnauthenticated(err, target)` from `@/lib/apollo/server-redirect` | RSC only (`server-only`). Redirects to `target` on `UNAUTHENTICATED`; rethrows all other errors. Returns `never` |
+| `formatMediumDate(iso)` from `@/lib/format` | Formats an ISO date string as a locale-aware medium-length date (e.g. "Jun 15, 2024") |
+| `<FieldError zodErrors backendError />` from `@/lib/forms/field-error` | Renders the first Zod issue message or the fallback `backendError` string as a destructive `<p>` |
+| `graphemeCount(s)` from `@/schemas/grapheme` | Counts UAX #29 grapheme clusters via `Intl.Segmenter`; shared by all schema length validators |
 
 ## Observability
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,6 +20,8 @@
   "dependencies": {
     "@apollo/client": "^4.1.9",
     "@apollo/client-integration-nextjs": "^0.14.5",
+    "@radix-ui/react-alert-dialog": "^1.1.15",
+    "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-slot": "^1.2.4",
     "@supabase/ssr": "^0.10.2",
@@ -28,6 +30,7 @@
     "@tanstack/react-form": "^1.29.1",
     "class-variance-authority": "^0.7.1",
     "graphql": "^16.13.2",
+    "lucide-react": "^1.14.0",
     "next": "16.2.4",
     "react": "19.2.0",
     "react-dom": "19.2.0",

--- a/frontend/src/app/_components/header.tsx
+++ b/frontend/src/app/_components/header.tsx
@@ -32,6 +32,12 @@ export async function Header() {
         {user ? (
           <div className="flex items-center gap-3 text-sm">
             <Link
+              href="/cardgroups"
+              className="text-muted-foreground underline-offset-4 hover:underline"
+            >
+              Cardgroups
+            </Link>
+            <Link
               href="/profile"
               className="text-muted-foreground underline-offset-4 hover:underline"
             >

--- a/frontend/src/app/cardgroups/[id]/cards/cards-client.test.tsx
+++ b/frontend/src/app/cardgroups/[id]/cards/cards-client.test.tsx
@@ -291,4 +291,108 @@ describe("<CardsClient>", () => {
       expect(screen.getByRole("button", { name: /saving/i })).toBeDisabled();
     });
   });
+
+  it("edit save failure keeps the row in edit mode and shows the inline error", async () => {
+    const user = userEvent.setup();
+
+    const mock = {
+      request: {
+        query: UpdateCardDocument,
+        variables: { id: "c-1", input: { front: "", back: "Hola" } },
+      },
+      result: {
+        errors: [
+          new GraphQLError("front is required", {
+            extensions: { code: "BAD_USER_INPUT", field: "front" },
+          }),
+        ],
+      },
+    };
+
+    renderClient([mock], [CARD_1], { errorPolicy: true });
+
+    // Open edit form for the card
+    const editBtn = screen.getByRole("button", { name: /edit/i });
+    await user.click(editBtn);
+
+    // [0] = add form, [1] = edit form
+    const editFrontInput = screen.getAllByLabelText(/front/i)[1] as HTMLElement;
+    await user.clear(editFrontInput);
+    // Leave front empty so the server returns BAD_USER_INPUT
+
+    await user.click(screen.getByRole("button", { name: /^save$/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("front is required")).toBeInTheDocument();
+    });
+
+    // Edit form must still be open (inputs still visible)
+    expect(screen.getAllByLabelText(/front/i)).toHaveLength(2);
+    // No navigation — save button still present
+    expect(screen.getByRole("button", { name: /^save$/i })).toBeInTheDocument();
+  });
+
+  it("delete failure surfaces the banner", async () => {
+    const user = userEvent.setup();
+
+    const mock = {
+      request: { query: DeleteCardDocument, variables: { id: "c-1" } },
+      result: {
+        errors: [new GraphQLError("Unauthenticated", { extensions: { code: "UNAUTHENTICATED" } })],
+      },
+    };
+
+    renderClient([mock], [CARD_1], { errorPolicy: true });
+
+    const deleteBtn = screen.getByRole("button", { name: /delete/i });
+    await user.click(deleteBtn);
+
+    const dialog = await screen.findByRole("alertdialog");
+    const confirmBtn = within(dialog).getByRole("button", { name: /delete/i });
+    await user.click(confirmBtn);
+
+    await waitFor(() => {
+      expect(screen.getByText("Your session expired. Please sign in again.")).toBeInTheDocument();
+    });
+  });
+
+  it("add-card form is reset after successful create", async () => {
+    const user = userEvent.setup();
+    const mock = makeCreateMock({ cardgroupId: CG_ID, front: "Cat", back: "Gato" });
+
+    const cacheMocks = [
+      {
+        request: {
+          query: CardsByCardgroupDocument,
+          variables: { cardgroupId: CG_ID },
+        },
+        result: { data: { cardsByCardgroup: [CARD_1, CARD_2] } },
+      },
+      mock,
+    ];
+
+    renderClient(cacheMocks);
+
+    // Fill the add form (idPrefix="add-")
+    const addFrontInput = screen.getAllByLabelText(/front/i)[0] as HTMLElement;
+    const addBackInput = screen.getAllByLabelText(/back/i)[0] as HTMLElement;
+
+    await user.click(addFrontInput);
+    await user.type(addFrontInput, "Cat");
+    await user.click(addBackInput);
+    await user.type(addBackInput, "Gato");
+
+    await user.click(screen.getByRole("button", { name: /^add$/i }));
+
+    // New card row appears
+    await waitFor(() => {
+      expect(screen.getByText("Cat")).toBeInTheDocument();
+    });
+
+    // Add form inputs must be cleared (remounted via key)
+    const resetFrontInput = screen.getAllByLabelText(/front/i)[0] as HTMLInputElement;
+    const resetBackInput = screen.getAllByLabelText(/back/i)[0] as HTMLInputElement;
+    expect(resetFrontInput.value).toBe("");
+    expect(resetBackInput.value).toBe("");
+  });
 });

--- a/frontend/src/app/cardgroups/[id]/cards/cards-client.test.tsx
+++ b/frontend/src/app/cardgroups/[id]/cards/cards-client.test.tsx
@@ -1,4 +1,5 @@
 // @vitest-environment jsdom
+import { InMemoryCache } from "@apollo/client";
 import { MockedProvider } from "@apollo/client/testing/react";
 import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -79,14 +80,14 @@ function makeDeleteMock(id: string) {
 function renderClient(
   mocks: unknown[],
   initialCards = [CARD_1, CARD_2],
-  options: { errorPolicy?: boolean } = {},
+  options: { errorPolicy?: boolean; cache?: InMemoryCache } = {},
 ) {
   const defaultOptions = options.errorPolicy
     ? { mutate: { errorPolicy: "all" as const } }
     : undefined;
 
   render(
-    <MockedProvider mocks={mocks as never} defaultOptions={defaultOptions}>
+    <MockedProvider mocks={mocks as never} defaultOptions={defaultOptions} cache={options.cache}>
       <CardsClient cardgroupId={CG_ID} initialCards={initialCards} />
     </MockedProvider>,
   );
@@ -220,7 +221,15 @@ describe("<CardsClient>", () => {
     const user = userEvent.setup();
     const mock = makeDeleteMock("c-1");
 
-    renderClient([mock]);
+    // Seed a real InMemoryCache so the update callback's evict/gc is exercised.
+    const cache = new InMemoryCache();
+    cache.writeQuery({
+      query: CardsByCardgroupDocument,
+      variables: { cardgroupId: CG_ID },
+      data: { cardsByCardgroup: [CARD_1, CARD_2] },
+    });
+
+    renderClient([mock], [CARD_1, CARD_2], { cache });
 
     expect(screen.getByText("Hello")).toBeInTheDocument();
 
@@ -232,9 +241,18 @@ describe("<CardsClient>", () => {
     const confirmBtn = within(dialog).getByRole("button", { name: /delete/i });
     await user.click(confirmBtn);
 
+    // Row disappears from the DOM.
     await waitFor(() => {
       expect(screen.queryByText("Hello")).not.toBeInTheDocument();
     });
+
+    // Cache must no longer contain the deleted card.
+    const cached = cache.readQuery({
+      query: CardsByCardgroupDocument,
+      variables: { cardgroupId: CG_ID },
+    });
+    const ids = cached?.cardsByCardgroup.map((c) => c.id) ?? [];
+    expect(ids).not.toContain(CARD_1.id);
   });
 
   it("UNAUTHENTICATED on delete shows banner", async () => {
@@ -330,30 +348,6 @@ describe("<CardsClient>", () => {
     expect(screen.getAllByLabelText(/front/i)).toHaveLength(2);
     // No navigation — save button still present
     expect(screen.getByRole("button", { name: /^save$/i })).toBeInTheDocument();
-  });
-
-  it("delete failure surfaces the banner", async () => {
-    const user = userEvent.setup();
-
-    const mock = {
-      request: { query: DeleteCardDocument, variables: { id: "c-1" } },
-      result: {
-        errors: [new GraphQLError("Unauthenticated", { extensions: { code: "UNAUTHENTICATED" } })],
-      },
-    };
-
-    renderClient([mock], [CARD_1], { errorPolicy: true });
-
-    const deleteBtn = screen.getByRole("button", { name: /delete/i });
-    await user.click(deleteBtn);
-
-    const dialog = await screen.findByRole("alertdialog");
-    const confirmBtn = within(dialog).getByRole("button", { name: /delete/i });
-    await user.click(confirmBtn);
-
-    await waitFor(() => {
-      expect(screen.getByText("Your session expired. Please sign in again.")).toBeInTheDocument();
-    });
   });
 
   it("add-card form is reset after successful create", async () => {

--- a/frontend/src/app/cardgroups/[id]/cards/cards-client.test.tsx
+++ b/frontend/src/app/cardgroups/[id]/cards/cards-client.test.tsx
@@ -1,0 +1,294 @@
+// @vitest-environment jsdom
+import { MockedProvider } from "@apollo/client/testing/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { GraphQLError } from "graphql";
+import { describe, expect, it } from "vitest";
+import {
+  CardsByCardgroupDocument,
+  CreateCardDocument,
+  DeleteCardDocument,
+  UpdateCardDocument,
+} from "@/generated/graphql";
+import { CardsClient } from "./cards-client";
+
+const CG_ID = "cg-1";
+
+const CARD_1 = {
+  __typename: "Card" as const,
+  id: "c-1",
+  front: "Hello",
+  back: "Hola",
+  due: "2024-06-15",
+  state: 0,
+  cardgroupId: CG_ID,
+};
+
+const CARD_2 = {
+  __typename: "Card" as const,
+  id: "c-2",
+  front: "Bye",
+  back: "Adios",
+  due: "2024-06-15",
+  state: 0,
+  cardgroupId: CG_ID,
+};
+
+const NEW_CARD = {
+  __typename: "Card" as const,
+  id: "c-3",
+  front: "Cat",
+  back: "Gato",
+  due: "2024-06-16",
+  state: 0,
+  cardgroupId: CG_ID,
+};
+
+function makeCreateMock(
+  input: { cardgroupId: string; front: string; back: string },
+  card = NEW_CARD,
+) {
+  return {
+    request: { query: CreateCardDocument, variables: { input } },
+    result: {
+      data: {
+        createCard: { __typename: "CreateCardPayload" as const, card },
+      },
+    },
+  };
+}
+
+function makeUpdateMock(id: string, input: { front: string; back: string }, card = CARD_1) {
+  return {
+    request: { query: UpdateCardDocument, variables: { id, input } },
+    result: {
+      data: {
+        updateCard: { __typename: "UpdateCardPayload" as const, card },
+      },
+    },
+  };
+}
+
+function makeDeleteMock(id: string) {
+  return {
+    request: { query: DeleteCardDocument, variables: { id } },
+    result: { data: { deleteCard: true } },
+  };
+}
+
+function renderClient(
+  mocks: unknown[],
+  initialCards = [CARD_1, CARD_2],
+  options: { errorPolicy?: boolean } = {},
+) {
+  const defaultOptions = options.errorPolicy
+    ? { mutate: { errorPolicy: "all" as const } }
+    : undefined;
+
+  render(
+    <MockedProvider mocks={mocks as never} defaultOptions={defaultOptions}>
+      <CardsClient cardgroupId={CG_ID} initialCards={initialCards} />
+    </MockedProvider>,
+  );
+}
+
+describe("<CardsClient>", () => {
+  it("renders existing cards", () => {
+    renderClient([]);
+    expect(screen.getByText("Hello")).toBeInTheDocument();
+    expect(screen.getByText("Bye")).toBeInTheDocument();
+  });
+
+  it("add success appends a new row", async () => {
+    const user = userEvent.setup();
+    const mock = makeCreateMock({ cardgroupId: CG_ID, front: "Cat", back: "Gato" });
+
+    // Pre-populate cache with existing cards so the update callback can read it.
+    const cacheMocks = [
+      {
+        request: {
+          query: CardsByCardgroupDocument,
+          variables: { cardgroupId: CG_ID },
+        },
+        result: { data: { cardsByCardgroup: [CARD_1, CARD_2] } },
+      },
+      mock,
+    ];
+
+    renderClient(cacheMocks);
+
+    const addFrontInput = screen.getAllByLabelText(/front/i)[0] as HTMLElement;
+    const addBackInput = screen.getAllByLabelText(/back/i)[0] as HTMLElement;
+
+    // The add form is first
+    await user.click(addFrontInput);
+    await user.type(addFrontInput, "Cat");
+    await user.click(addBackInput);
+    await user.type(addBackInput, "Gato");
+
+    await user.click(screen.getByRole("button", { name: /^add$/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Cat")).toBeInTheDocument();
+    });
+  });
+
+  it("add BAD_USER_INPUT(field=front) shows inline error", async () => {
+    const user = userEvent.setup();
+
+    const mock = {
+      request: {
+        query: CreateCardDocument,
+        variables: { input: { cardgroupId: CG_ID, front: "x", back: "y" } },
+      },
+      result: {
+        errors: [
+          new GraphQLError("front is too short", {
+            extensions: { code: "BAD_USER_INPUT", field: "front" },
+          }),
+        ],
+      },
+    };
+
+    renderClient([mock], [], { errorPolicy: true });
+
+    const frontInput = screen.getByLabelText(/front/i);
+    const backInput = screen.getByLabelText(/back/i);
+
+    await user.type(frontInput, "x");
+    await user.type(backInput, "y");
+    await user.click(screen.getByRole("button", { name: /^add$/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("front is too short")).toBeInTheDocument();
+    });
+  });
+
+  it("edit toggle shows edit form and cancel reverts to view", async () => {
+    const user = userEvent.setup();
+    renderClient([]);
+
+    // Click Edit on first card row
+    const firstEditBtn = screen.getAllByRole("button", { name: /edit/i })[0] as HTMLElement;
+    await user.click(firstEditBtn);
+
+    // Edit form appears alongside the add form; edit input is the second Front input
+    // [0] = add form (empty), [1] = edit form (prefilled)
+    const editFrontInput = screen.getAllByLabelText(/front/i)[1] as HTMLElement;
+    expect(editFrontInput).toHaveValue("Hello");
+
+    // Cancel reverts
+    await user.click(screen.getByRole("button", { name: /cancel/i }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole("button", { name: /cancel/i })).not.toBeInTheDocument();
+    });
+    expect(screen.getByText("Hello")).toBeInTheDocument();
+  });
+
+  it("edit save calls updateCard mutation and shows updated values", async () => {
+    const user = userEvent.setup();
+    const updatedCard = { ...CARD_1, front: "Hello updated", back: "Hola updated" };
+    const mock = makeUpdateMock(
+      "c-1",
+      { front: "Hello updated", back: "Hola updated" },
+      updatedCard,
+    );
+
+    renderClient([mock]);
+
+    const firstEditBtn = screen.getAllByRole("button", { name: /edit/i })[0] as HTMLElement;
+    await user.click(firstEditBtn);
+
+    // [0] = add form, [1] = edit form
+    const editFrontInput = screen.getAllByLabelText(/front/i)[1] as HTMLElement;
+    await user.clear(editFrontInput);
+    await user.type(editFrontInput, "Hello updated");
+
+    const editBackInput = screen.getAllByLabelText(/back/i)[1] as HTMLElement;
+    await user.clear(editBackInput);
+    await user.type(editBackInput, "Hola updated");
+
+    await user.click(screen.getByRole("button", { name: /^save$/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Hello updated")).toBeInTheDocument();
+    });
+  });
+
+  it("delete dialog confirm removes the row and calls mutation", async () => {
+    const user = userEvent.setup();
+    const mock = makeDeleteMock("c-1");
+
+    renderClient([mock]);
+
+    expect(screen.getByText("Hello")).toBeInTheDocument();
+
+    const firstDeleteBtn = screen.getAllByRole("button", { name: /delete/i })[0] as HTMLElement;
+    await user.click(firstDeleteBtn);
+
+    // Confirm button inside the dialog
+    const dialog = await screen.findByRole("alertdialog");
+    const confirmBtn = within(dialog).getByRole("button", { name: /delete/i });
+    await user.click(confirmBtn);
+
+    await waitFor(() => {
+      expect(screen.queryByText("Hello")).not.toBeInTheDocument();
+    });
+  });
+
+  it("UNAUTHENTICATED on delete shows banner", async () => {
+    const user = userEvent.setup();
+
+    const mock = {
+      request: { query: DeleteCardDocument, variables: { id: "c-1" } },
+      result: {
+        errors: [new GraphQLError("Unauthenticated", { extensions: { code: "UNAUTHENTICATED" } })],
+      },
+    };
+
+    renderClient([mock], [CARD_1], { errorPolicy: true });
+
+    const deleteBtn = screen.getByRole("button", { name: /delete/i });
+    await user.click(deleteBtn);
+
+    const dialog = await screen.findByRole("alertdialog");
+    const confirmBtn = within(dialog).getByRole("button", { name: /delete/i });
+    await user.click(confirmBtn);
+
+    await waitFor(() => {
+      expect(screen.getByText("Your session expired. Please sign in again.")).toBeInTheDocument();
+    });
+  });
+
+  it("submit button is disabled while mutation in flight", async () => {
+    const user = userEvent.setup();
+
+    // Use a never-resolving mock so the mutation stays in-flight.
+    const mock = {
+      request: {
+        query: CreateCardDocument,
+        variables: { input: { cardgroupId: CG_ID, front: "Slow", back: "Lento" } },
+      },
+      result: () =>
+        new Promise<never>(() => {
+          // never resolves
+        }),
+    };
+
+    renderClient([mock], []);
+
+    const frontInput = screen.getByLabelText(/front/i);
+    const backInput = screen.getByLabelText(/back/i);
+
+    await user.type(frontInput, "Slow");
+    await user.type(backInput, "Lento");
+
+    const addBtn = screen.getByRole("button", { name: /^add$/i });
+    await user.click(addBtn);
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /saving/i })).toBeDisabled();
+    });
+  });
+});

--- a/frontend/src/app/cardgroups/[id]/cards/cards-client.tsx
+++ b/frontend/src/app/cardgroups/[id]/cards/cards-client.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+import { useMutation } from "@apollo/client/react";
+import { useMemo, useState } from "react";
+import {
+  CreateCardMutation,
+  DeleteCardMutation,
+  UpdateCardMutation,
+} from "@/app/cardgroups/queries";
+import { CardForm } from "@/components/cardgroups/card-form";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import { CardsByCardgroupDocument, type CardsByCardgroupQuery } from "@/generated/graphql";
+import { getBackendErrorBanner } from "@/lib/apollo/errors";
+
+type Card = CardsByCardgroupQuery["cardsByCardgroup"][number];
+
+type Props = {
+  cardgroupId: string;
+  initialCards: Card[];
+};
+
+export function CardsClient({ cardgroupId, initialCards }: Props) {
+  const [cards, setCards] = useState<Card[]>(initialCards);
+  const [editingId, setEditingId] = useState<string | null>(null);
+
+  const [createCard, { loading: creating, error: createError }] = useMutation(CreateCardMutation, {
+    update(cache, { data }) {
+      if (!data?.createCard?.card) return;
+      const existing = cache.readQuery({
+        query: CardsByCardgroupDocument,
+        variables: { cardgroupId },
+      });
+      cache.writeQuery({
+        query: CardsByCardgroupDocument,
+        variables: { cardgroupId },
+        data: {
+          cardsByCardgroup: [...(existing?.cardsByCardgroup ?? []), data.createCard.card],
+        },
+      });
+      setCards((prev) => [...prev, data.createCard.card]);
+    },
+  });
+
+  const [updateCard, { loading: updating, error: updateError }] = useMutation(UpdateCardMutation, {
+    update(_cache, { data }) {
+      if (!data?.updateCard?.card) return;
+      const updated = data.updateCard.card;
+      setCards((prev) => prev.map((c) => (c.id === updated.id ? updated : c)));
+    },
+  });
+
+  const [deleteCard, { error: deleteError }] = useMutation(DeleteCardMutation, {
+    update(cache, _result, { variables }) {
+      const id = variables?.id as string | undefined;
+      if (!id) return;
+      cache.evict({ id: cache.identify({ __typename: "Card", id }) });
+      cache.gc();
+      setCards((prev) => prev.filter((c) => c.id !== id));
+    },
+  });
+
+  const deleteBannerError = useMemo(() => getBackendErrorBanner(deleteError), [deleteError]);
+
+  async function handleCreate(values: { front: string; back: string }) {
+    await createCard({
+      variables: { input: { cardgroupId, front: values.front, back: values.back } },
+    });
+  }
+
+  async function handleUpdate(id: string, values: { front: string; back: string }) {
+    await updateCard({ variables: { id, input: { front: values.front, back: values.back } } });
+    setEditingId(null);
+  }
+
+  return (
+    <div className="space-y-6">
+      {deleteBannerError && (
+        <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive" role="alert">
+          {deleteBannerError}
+        </div>
+      )}
+
+      <section>
+        <h2 className="mb-3 text-sm font-medium uppercase tracking-wide text-muted-foreground">
+          Add a card
+        </h2>
+        <CardForm
+          mode="create"
+          idPrefix="add-"
+          cardgroupId={cardgroupId}
+          defaultValues={{ front: "", back: "" }}
+          submit={handleCreate}
+          submitLabel="Add"
+          submitting={creating}
+          error={createError}
+        />
+      </section>
+
+      <section>
+        <h2 className="mb-3 text-sm font-medium uppercase tracking-wide text-muted-foreground">
+          Cards ({cards.length})
+        </h2>
+
+        {cards.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No cards yet. Add one above.</p>
+        ) : (
+          <ul className="space-y-3">
+            {cards.map((card) =>
+              editingId === card.id ? (
+                <li key={card.id} className="rounded-md border border-border p-4">
+                  <CardForm
+                    mode="edit"
+                    idPrefix={`edit-${card.id}-`}
+                    defaultValues={{ front: card.front, back: card.back }}
+                    submit={(values) => handleUpdate(card.id, values)}
+                    submitLabel="Save"
+                    submitting={updating}
+                    error={updateError}
+                    onCancel={() => setEditingId(null)}
+                  />
+                </li>
+              ) : (
+                <li
+                  key={card.id}
+                  className="flex items-start justify-between gap-4 rounded-md border border-border px-4 py-3"
+                >
+                  <div className="min-w-0 flex-1 space-y-1">
+                    <p className="text-sm font-medium">{card.front}</p>
+                    <p className="text-sm text-muted-foreground">{card.back}</p>
+                  </div>
+                  <div className="flex shrink-0 gap-2">
+                    <Button variant="outline" size="sm" onClick={() => setEditingId(card.id)}>
+                      Edit
+                    </Button>
+                    <AlertDialog>
+                      <AlertDialogTrigger asChild>
+                        <Button variant="destructive" size="sm">
+                          Delete
+                        </Button>
+                      </AlertDialogTrigger>
+                      <AlertDialogContent>
+                        <AlertDialogHeader>
+                          <AlertDialogTitle>Delete card?</AlertDialogTitle>
+                          <AlertDialogDescription>
+                            This action cannot be undone.
+                          </AlertDialogDescription>
+                        </AlertDialogHeader>
+                        <AlertDialogFooter>
+                          <AlertDialogCancel>Cancel</AlertDialogCancel>
+                          <AlertDialogAction
+                            onClick={() => deleteCard({ variables: { id: card.id } })}
+                          >
+                            Delete
+                          </AlertDialogAction>
+                        </AlertDialogFooter>
+                      </AlertDialogContent>
+                    </AlertDialog>
+                  </div>
+                </li>
+              ),
+            )}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/app/cardgroups/[id]/cards/cards-client.tsx
+++ b/frontend/src/app/cardgroups/[id]/cards/cards-client.tsx
@@ -63,7 +63,8 @@ export function CardsClient({ cardgroupId, initialCards }: Props) {
   });
 
   const [deleteCard, { error: deleteError }] = useMutation(DeleteCardMutation, {
-    update(cache, _result, { variables }) {
+    update(cache, { data }, { variables }) {
+      if (!data?.deleteCard) return;
       const id = variables?.id as string | undefined;
       if (!id) return;
       cache.evict({ id: cache.identify({ __typename: "Card", id }) });
@@ -77,6 +78,8 @@ export function CardsClient({ cardgroupId, initialCards }: Props) {
   async function handleCreate(values: { front: string; back: string }) {
     await createCard({
       variables: { input: { cardgroupId, front: values.front, back: values.back } },
+    }).catch((err) => {
+      console.error("[CardsClient] create rejection", err);
     });
   }
 

--- a/frontend/src/app/cardgroups/[id]/cards/cards-client.tsx
+++ b/frontend/src/app/cardgroups/[id]/cards/cards-client.tsx
@@ -33,6 +33,7 @@ type Props = {
 export function CardsClient({ cardgroupId, initialCards }: Props) {
   const [cards, setCards] = useState<Card[]>(initialCards);
   const [editingId, setEditingId] = useState<string | null>(null);
+  const [createFormKey, setCreateFormKey] = useState(0);
 
   const [createCard, { loading: creating, error: createError }] = useMutation(CreateCardMutation, {
     update(cache, { data }) {
@@ -49,6 +50,7 @@ export function CardsClient({ cardgroupId, initialCards }: Props) {
         },
       });
       setCards((prev) => [...prev, data.createCard.card]);
+      setCreateFormKey((k) => k + 1);
     },
   });
 
@@ -79,8 +81,15 @@ export function CardsClient({ cardgroupId, initialCards }: Props) {
   }
 
   async function handleUpdate(id: string, values: { front: string; back: string }) {
-    await updateCard({ variables: { id, input: { front: values.front, back: values.back } } });
-    setEditingId(null);
+    const result = await updateCard({
+      variables: { id, input: { front: values.front, back: values.back } },
+    }).catch((err) => {
+      console.error("[CardsClient] update rejection", err);
+      return null;
+    });
+    if (result?.data?.updateCard?.card) {
+      setEditingId(null);
+    }
   }
 
   return (
@@ -96,9 +105,9 @@ export function CardsClient({ cardgroupId, initialCards }: Props) {
           Add a card
         </h2>
         <CardForm
+          key={createFormKey}
           mode="create"
           idPrefix="add-"
-          cardgroupId={cardgroupId}
           defaultValues={{ front: "", back: "" }}
           submit={handleCreate}
           submitLabel="Add"
@@ -159,7 +168,9 @@ export function CardsClient({ cardgroupId, initialCards }: Props) {
                         <AlertDialogFooter>
                           <AlertDialogCancel>Cancel</AlertDialogCancel>
                           <AlertDialogAction
-                            onClick={() => deleteCard({ variables: { id: card.id } })}
+                            onClick={async () => {
+                              await deleteCard({ variables: { id: card.id } }).catch(console.error);
+                            }}
                           >
                             Delete
                           </AlertDialogAction>

--- a/frontend/src/app/cardgroups/[id]/cards/page.test.tsx
+++ b/frontend/src/app/cardgroups/[id]/cards/page.test.tsx
@@ -1,0 +1,116 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("next/navigation", () => ({
+  redirect: vi.fn((url: string) => {
+    throw new Error(`REDIRECT:${url}`);
+  }),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createSupabaseServerClient: vi.fn(),
+}));
+
+vi.mock("@/lib/apollo/server", () => ({
+  gqlFetch: vi.fn(),
+}));
+
+// CardsClient is a "use client" component — stub it to keep the RSC test simple.
+vi.mock("./cards-client", () => ({
+  CardsClient: ({
+    cardgroupId,
+    initialCards,
+  }: {
+    cardgroupId: string;
+    initialCards: unknown[];
+  }) => (
+    <div data-testid="cards-client" data-cardgroup-id={cardgroupId}>
+      {(initialCards as { front: string }[]).map((c) => (
+        <span key={c.front}>{c.front}</span>
+      ))}
+    </div>
+  ),
+}));
+
+import { gqlFetch } from "@/lib/apollo/server";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+import CardsPage from "./page";
+
+function makeSupabaseMock(user: { id: string } | null) {
+  return {
+    auth: {
+      getUser: vi.fn().mockResolvedValue({ data: { user }, error: null }),
+    },
+  };
+}
+
+const CARDGROUP = { id: "cg-1", name: "Vocab", updatedAt: "2024-06-15T10:00:00.000Z" };
+const CARDS = [
+  { id: "c-1", front: "Hello", back: "Hola", due: "2024-06-15", state: 0, cardgroupId: "cg-1" },
+  { id: "c-2", front: "World", back: "Mundo", due: "2024-06-15", state: 0, cardgroupId: "cg-1" },
+];
+
+describe("CardsPage (RSC)", () => {
+  it("redirects to /login when unauthenticated", async () => {
+    vi.mocked(createSupabaseServerClient).mockResolvedValue(makeSupabaseMock(null) as never);
+
+    await expect(CardsPage({ params: Promise.resolve({ id: "cg-1" }) })).rejects.toThrow(
+      "REDIRECT:/login",
+    );
+  });
+
+  it("redirects to /cardgroups when cardgroup not found", async () => {
+    vi.mocked(createSupabaseServerClient).mockResolvedValue(
+      makeSupabaseMock({ id: "user-1" }) as never,
+    );
+    vi.mocked(gqlFetch).mockResolvedValue({ cardgroup: null, cardsByCardgroup: [] } as never);
+
+    await expect(CardsPage({ params: Promise.resolve({ id: "cg-99" }) })).rejects.toThrow(
+      "REDIRECT:/cardgroups",
+    );
+  });
+
+  it("redirects to /cardgroups on UNAUTHENTICATED gqlFetch error", async () => {
+    vi.mocked(createSupabaseServerClient).mockResolvedValue(
+      makeSupabaseMock({ id: "user-1" }) as never,
+    );
+    vi.mocked(gqlFetch).mockRejectedValue(new Error("UNAUTHENTICATED"));
+
+    await expect(CardsPage({ params: Promise.resolve({ id: "cg-1" }) })).rejects.toThrow(
+      "REDIRECT:/cardgroups",
+    );
+  });
+
+  it("renders heading and passes cards to CardsClient", async () => {
+    vi.mocked(createSupabaseServerClient).mockResolvedValue(
+      makeSupabaseMock({ id: "user-1" }) as never,
+    );
+    vi.mocked(gqlFetch)
+      .mockResolvedValueOnce({ cardgroup: CARDGROUP } as never)
+      .mockResolvedValueOnce({ cardsByCardgroup: CARDS } as never);
+
+    const jsx = await CardsPage({ params: Promise.resolve({ id: "cg-1" }) });
+    render(jsx);
+
+    expect(screen.getByText("Cards in Vocab")).toBeInTheDocument();
+    expect(screen.getByTestId("cards-client")).toHaveAttribute("data-cardgroup-id", "cg-1");
+    expect(screen.getByText("Hello")).toBeInTheDocument();
+    expect(screen.getByText("World")).toBeInTheDocument();
+  });
+
+  it("renders back link to the cardgroup detail page", async () => {
+    vi.mocked(createSupabaseServerClient).mockResolvedValue(
+      makeSupabaseMock({ id: "user-1" }) as never,
+    );
+    vi.mocked(gqlFetch)
+      .mockResolvedValueOnce({ cardgroup: CARDGROUP } as never)
+      .mockResolvedValueOnce({ cardsByCardgroup: [] } as never);
+
+    const jsx = await CardsPage({ params: Promise.resolve({ id: "cg-1" }) });
+    render(jsx);
+
+    const backLink = screen.getByRole("link", { name: /back/i });
+    expect(backLink).toHaveAttribute("href", "/cardgroups/cg-1");
+  });
+});

--- a/frontend/src/app/cardgroups/[id]/cards/page.tsx
+++ b/frontend/src/app/cardgroups/[id]/cards/page.tsx
@@ -6,6 +6,7 @@ import type {
   CardsByCardgroupQuery as CardsByCardgroupQueryType,
 } from "@/generated/graphql";
 import { gqlFetch } from "@/lib/apollo/server";
+import { redirectIfUnauthenticated } from "@/lib/apollo/server-redirect";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 import { CardsClient } from "./cards-client";
 
@@ -29,9 +30,7 @@ export default async function CardsPage({ params }: { params: Promise<{ id: stri
       gqlFetch(CardsByCardgroupQuery, { variables: { cardgroupId: id }, revalidate: 0 }),
     ]);
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    if (msg.includes("UNAUTHENTICATED")) redirect("/cardgroups");
-    throw err;
+    redirectIfUnauthenticated(err, "/cardgroups");
   }
 
   if (!cardgroupData?.cardgroup) redirect("/cardgroups");

--- a/frontend/src/app/cardgroups/[id]/cards/page.tsx
+++ b/frontend/src/app/cardgroups/[id]/cards/page.tsx
@@ -1,0 +1,53 @@
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { CardgroupQuery, CardsByCardgroupQuery } from "@/app/cardgroups/queries";
+import type {
+  CardgroupQuery as CardgroupQueryType,
+  CardsByCardgroupQuery as CardsByCardgroupQueryType,
+} from "@/generated/graphql";
+import { gqlFetch } from "@/lib/apollo/server";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+import { CardsClient } from "./cards-client";
+
+export default async function CardsPage({ params }: { params: Promise<{ id: string }> }) {
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+    error: authErr,
+  } = await supabase.auth.getUser();
+  if (authErr) throw authErr;
+  if (!user) redirect("/login");
+
+  const { id } = await params;
+
+  let cardgroupData: CardgroupQueryType | null = null;
+  let cardsData: CardsByCardgroupQueryType | null = null;
+
+  try {
+    [cardgroupData, cardsData] = await Promise.all([
+      gqlFetch(CardgroupQuery, { variables: { id }, revalidate: 0 }),
+      gqlFetch(CardsByCardgroupQuery, { variables: { cardgroupId: id }, revalidate: 0 }),
+    ]);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (msg.includes("UNAUTHENTICATED")) redirect("/cardgroups");
+    throw err;
+  }
+
+  if (!cardgroupData?.cardgroup) redirect("/cardgroups");
+
+  const cardgroup = cardgroupData.cardgroup;
+  const cards = cardsData?.cardsByCardgroup ?? [];
+
+  return (
+    <main className="mx-auto max-w-2xl p-8">
+      <div className="mb-6 flex items-center gap-4">
+        <Link href={`/cardgroups/${id}`} className="text-sm text-muted-foreground hover:underline">
+          &larr; Back
+        </Link>
+      </div>
+      <h1 className="mb-6 text-2xl font-semibold">Cards in {cardgroup.name}</h1>
+      <CardsClient cardgroupId={id} initialCards={cards} />
+    </main>
+  );
+}

--- a/frontend/src/app/cardgroups/[id]/edit/edit-cardgroup-client.test.tsx
+++ b/frontend/src/app/cardgroups/[id]/edit/edit-cardgroup-client.test.tsx
@@ -1,0 +1,202 @@
+// @vitest-environment jsdom
+import type { MockedResponse } from "@apollo/client/testing";
+import { MockedProvider } from "@apollo/client/testing/react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { GraphQLError } from "graphql";
+import { describe, expect, it, vi } from "vitest";
+import { DeleteCardgroupDocument, UpdateCardgroupDocument } from "@/generated/graphql";
+import { EditCardgroupClient } from "./edit-cardgroup-client";
+
+const mockPush = vi.fn();
+const mockRefresh = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush, refresh: mockRefresh }),
+}));
+
+const CARDGROUP = { id: "cg-1", name: "Spanish Vocab" };
+
+function makeUpdateMock(
+  variables: { id: string; input: { name: string } },
+  result: MockedResponse["result"],
+): MockedResponse {
+  return { request: { query: UpdateCardgroupDocument, variables }, result };
+}
+
+function makeDeleteMock(
+  variables: { id: string },
+  result: MockedResponse["result"],
+): MockedResponse {
+  return { request: { query: DeleteCardgroupDocument, variables }, result };
+}
+
+function renderClient(mocks: MockedResponse[] = [], errorPolicy?: "all" | "none" | "ignore") {
+  const defaultOptions = errorPolicy ? { mutate: { errorPolicy } } : undefined;
+  render(
+    <MockedProvider mocks={mocks} defaultOptions={defaultOptions}>
+      <EditCardgroupClient cardgroup={CARDGROUP} />
+    </MockedProvider>,
+  );
+}
+
+describe("<EditCardgroupClient>", () => {
+  it("edit success navigates to detail page", async () => {
+    const user = userEvent.setup();
+    const mocks = [
+      makeUpdateMock(
+        { id: "cg-1", input: { name: "Spanish Vocab" } },
+        {
+          data: {
+            updateCardgroup: {
+              __typename: "UpdateCardgroupPayload",
+              cardgroup: {
+                __typename: "Cardgroup",
+                id: "cg-1",
+                name: "Spanish Vocab",
+                updatedAt: "2024-06-15T10:00:00.000Z",
+              },
+            },
+          },
+        },
+      ),
+    ];
+    renderClient(mocks);
+
+    await user.click(screen.getByRole("button", { name: /save/i }));
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith("/cardgroups/cg-1");
+    });
+  });
+
+  it("edit BAD_USER_INPUT field=name shows inline error", async () => {
+    const user = userEvent.setup();
+    const mocks = [
+      makeUpdateMock(
+        { id: "cg-1", input: { name: "Spanish Vocab" } },
+        {
+          errors: [
+            new GraphQLError("name already exists", {
+              extensions: { code: "BAD_USER_INPUT", field: "name" },
+            }),
+          ],
+        },
+      ),
+    ];
+    renderClient(mocks, "all");
+
+    await user.click(screen.getByRole("button", { name: /save/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("name already exists")).toBeInTheDocument();
+    });
+  });
+
+  it("delete dialog opens when Delete button is clicked", async () => {
+    const user = userEvent.setup();
+    renderClient();
+
+    await user.click(screen.getByRole("button", { name: /^delete$/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alertdialog")).toBeInTheDocument();
+      expect(screen.getByText("Delete cardgroup")).toBeInTheDocument();
+    });
+  });
+
+  it("cancel closes the delete dialog without firing mutation", async () => {
+    const user = userEvent.setup();
+    const deleteCalled = vi.fn();
+    const mocks: MockedResponse[] = [
+      {
+        request: { query: DeleteCardgroupDocument, variables: { id: "cg-1" } },
+        result: () => {
+          deleteCalled();
+          return { data: { deleteCardgroup: true } };
+        },
+      },
+    ];
+    renderClient(mocks);
+
+    await user.click(screen.getByRole("button", { name: /^delete$/i }));
+    await waitFor(() => {
+      expect(screen.getByRole("alertdialog")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: /^cancel$/i }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
+    });
+    expect(deleteCalled).not.toHaveBeenCalled();
+  });
+
+  it("confirm fires DeleteCardgroupMutation and navigates to /cardgroups", async () => {
+    const user = userEvent.setup();
+    const deleteCalled = vi.fn();
+    const mocks: MockedResponse[] = [
+      {
+        request: { query: DeleteCardgroupDocument, variables: { id: "cg-1" } },
+        result: () => {
+          deleteCalled();
+          return { data: { deleteCardgroup: true } };
+        },
+      },
+    ];
+    renderClient(mocks);
+
+    await user.click(screen.getByRole("button", { name: /^delete$/i }));
+    await waitFor(() => {
+      expect(screen.getByRole("alertdialog")).toBeInTheDocument();
+    });
+
+    const dialogDeleteBtns = screen
+      .getAllByRole("button", { name: /^delete$/i })
+      .filter((el) => el.closest("[role='alertdialog']"));
+    const confirmBtn = dialogDeleteBtns[0];
+    if (!confirmBtn) throw new Error("Delete confirm button not found in dialog");
+    await user.click(confirmBtn);
+
+    await waitFor(() => {
+      expect(deleteCalled).toHaveBeenCalledOnce();
+    });
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith("/cardgroups");
+    });
+  });
+
+  it("delete UNAUTHENTICATED shows banner error", async () => {
+    const user = userEvent.setup();
+    const mocks = [
+      makeDeleteMock(
+        { id: "cg-1" },
+        {
+          errors: [
+            new GraphQLError("Unauthenticated", {
+              extensions: { code: "UNAUTHENTICATED" },
+            }),
+          ],
+        },
+      ),
+    ];
+    renderClient(mocks, "all");
+
+    await user.click(screen.getByRole("button", { name: /^delete$/i }));
+    await waitFor(() => {
+      expect(screen.getByRole("alertdialog")).toBeInTheDocument();
+    });
+
+    const dialogDeleteBtns = screen
+      .getAllByRole("button", { name: /^delete$/i })
+      .filter((el) => el.closest("[role='alertdialog']"));
+    const confirmBtn = dialogDeleteBtns[0];
+    if (!confirmBtn) throw new Error("Delete confirm button not found in dialog");
+    await user.click(confirmBtn);
+
+    await waitFor(() => {
+      expect(screen.getByText("Your session expired. Please sign in again.")).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/app/cardgroups/[id]/edit/edit-cardgroup-client.test.tsx
+++ b/frontend/src/app/cardgroups/[id]/edit/edit-cardgroup-client.test.tsx
@@ -4,7 +4,7 @@ import { MockedProvider } from "@apollo/client/testing/react";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { GraphQLError } from "graphql";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { DeleteCardgroupDocument, UpdateCardgroupDocument } from "@/generated/graphql";
 import { EditCardgroupClient } from "./edit-cardgroup-client";
 
@@ -41,6 +41,11 @@ function renderClient(mocks: MockedResponse[] = [], errorPolicy?: "all" | "none"
 }
 
 describe("<EditCardgroupClient>", () => {
+  beforeEach(() => {
+    mockPush.mockClear();
+    mockRefresh.mockClear();
+  });
+
   it("edit success navigates to detail page", async () => {
     const user = userEvent.setup();
     const mocks = [
@@ -91,6 +96,7 @@ describe("<EditCardgroupClient>", () => {
     await waitFor(() => {
       expect(screen.getByText("name already exists")).toBeInTheDocument();
     });
+    expect(mockPush).not.toHaveBeenCalled();
   });
 
   it("delete dialog opens when Delete button is clicked", async () => {
@@ -198,5 +204,55 @@ describe("<EditCardgroupClient>", () => {
     await waitFor(() => {
       expect(screen.getByText("Your session expired. Please sign in again.")).toBeInTheDocument();
     });
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it("update network rejection shows error banner and does not navigate", async () => {
+    const user = userEvent.setup();
+    const mocks: MockedResponse[] = [
+      {
+        request: {
+          query: UpdateCardgroupDocument,
+          variables: { id: "cg-1", input: { name: "Spanish Vocab" } },
+        },
+        error: new Error("Network error: failed to fetch"),
+      },
+    ];
+    renderClient(mocks);
+
+    await user.click(screen.getByRole("button", { name: /save/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Could not reach the server. Please try again.")).toBeInTheDocument();
+    });
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it("delete network rejection shows error banner and does not navigate", async () => {
+    const user = userEvent.setup();
+    const mocks: MockedResponse[] = [
+      {
+        request: { query: DeleteCardgroupDocument, variables: { id: "cg-1" } },
+        error: new Error("Network error: failed to fetch"),
+      },
+    ];
+    renderClient(mocks);
+
+    await user.click(screen.getByRole("button", { name: /^delete$/i }));
+    await waitFor(() => {
+      expect(screen.getByRole("alertdialog")).toBeInTheDocument();
+    });
+
+    const dialogDeleteBtns = screen
+      .getAllByRole("button", { name: /^delete$/i })
+      .filter((el) => el.closest("[role='alertdialog']"));
+    const confirmBtn = dialogDeleteBtns[0];
+    if (!confirmBtn) throw new Error("Delete confirm button not found in dialog");
+    await user.click(confirmBtn);
+
+    await waitFor(() => {
+      expect(screen.getByText("Could not reach the server. Please try again.")).toBeInTheDocument();
+    });
+    expect(mockPush).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/app/cardgroups/[id]/edit/edit-cardgroup-client.test.tsx
+++ b/frontend/src/app/cardgroups/[id]/edit/edit-cardgroup-client.test.tsx
@@ -138,7 +138,7 @@ describe("<EditCardgroupClient>", () => {
     expect(deleteCalled).not.toHaveBeenCalled();
   });
 
-  it("confirm fires DeleteCardgroupMutation and navigates to /cardgroups", async () => {
+  it("confirm fires DeleteCardgroupMutation, closes dialog, and navigates to /cardgroups", async () => {
     const user = userEvent.setup();
     const deleteCalled = vi.fn();
     const mocks: MockedResponse[] = [
@@ -169,11 +169,15 @@ describe("<EditCardgroupClient>", () => {
     });
 
     await waitFor(() => {
+      expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
+    });
+
+    await waitFor(() => {
       expect(mockPush).toHaveBeenCalledWith("/cardgroups");
     });
   });
 
-  it("delete UNAUTHENTICATED shows banner error", async () => {
+  it("delete UNAUTHENTICATED shows banner error and dialog stays open", async () => {
     const user = userEvent.setup();
     const mocks = [
       makeDeleteMock(
@@ -204,6 +208,7 @@ describe("<EditCardgroupClient>", () => {
     await waitFor(() => {
       expect(screen.getByText("Your session expired. Please sign in again.")).toBeInTheDocument();
     });
+    expect(screen.getByRole("alertdialog")).toBeInTheDocument();
     expect(mockPush).not.toHaveBeenCalled();
   });
 
@@ -228,7 +233,7 @@ describe("<EditCardgroupClient>", () => {
     expect(mockPush).not.toHaveBeenCalled();
   });
 
-  it("delete network rejection shows error banner and does not navigate", async () => {
+  it("delete network rejection shows error banner, dialog stays open, and does not navigate", async () => {
     const user = userEvent.setup();
     const mocks: MockedResponse[] = [
       {
@@ -253,6 +258,7 @@ describe("<EditCardgroupClient>", () => {
     await waitFor(() => {
       expect(screen.getByText("Could not reach the server. Please try again.")).toBeInTheDocument();
     });
+    expect(screen.getByRole("alertdialog")).toBeInTheDocument();
     expect(mockPush).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/app/cardgroups/[id]/edit/edit-cardgroup-client.tsx
+++ b/frontend/src/app/cardgroups/[id]/edit/edit-cardgroup-client.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { useMutation } from "@apollo/client/react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { DeleteCardgroupMutation, UpdateCardgroupMutation } from "@/app/cardgroups/queries";
+import { CardgroupForm } from "@/components/cardgroups/cardgroup-form";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+
+type Props = {
+  cardgroup: { id: string; name: string };
+};
+
+export function EditCardgroupClient({ cardgroup }: Props) {
+  const router = useRouter();
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  const [updateCardgroup, { loading: updating, error: updateError }] =
+    useMutation(UpdateCardgroupMutation);
+
+  const [deleteCardgroup, { loading: deleting, error: deleteError }] =
+    useMutation(DeleteCardgroupMutation);
+
+  const mutating = updating || deleting;
+  const activeError = deleteError ?? updateError;
+
+  async function handleSave(values: { name: string }) {
+    await updateCardgroup({
+      variables: { id: cardgroup.id, input: { name: values.name } },
+    }).catch((err) => {
+      console.error("[EditCardgroupClient] update rejection", err);
+    });
+
+    if (!updateError) {
+      router.push(`/cardgroups/${cardgroup.id}`);
+    }
+  }
+
+  async function handleDelete() {
+    await deleteCardgroup({
+      variables: { id: cardgroup.id },
+      update(cache) {
+        cache.evict({
+          id: cache.identify({ __typename: "Cardgroup", id: cardgroup.id }),
+        });
+        cache.gc();
+      },
+    }).catch((err) => {
+      console.error("[EditCardgroupClient] delete rejection", err);
+    });
+
+    if (!deleteError) {
+      router.push("/cardgroups");
+      router.refresh();
+    }
+  }
+
+  const deleteButton = (
+    <AlertDialog open={dialogOpen} onOpenChange={setDialogOpen}>
+      <AlertDialogTrigger asChild>
+        <Button type="button" variant="destructive" disabled={mutating}>
+          Delete
+        </Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Delete cardgroup</AlertDialogTitle>
+          <AlertDialogDescription>
+            {`This will permanently delete "${cardgroup.name}" and all its cards. This cannot be undone.`}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={mutating}>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            className="bg-destructive text-destructive-foreground"
+            disabled={mutating}
+            onClick={(e) => {
+              e.preventDefault();
+              void handleDelete();
+              setDialogOpen(false);
+            }}
+          >
+            Delete
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+
+  return (
+    <main className="mx-auto max-w-xl p-8">
+      <div className="mb-6 flex items-center gap-4">
+        <Link
+          href={`/cardgroups/${cardgroup.id}`}
+          className="text-sm text-muted-foreground hover:underline"
+        >
+          &larr; Back
+        </Link>
+        <h1 className="text-2xl font-semibold">Edit cardgroup</h1>
+      </div>
+      <CardgroupForm
+        mode="edit"
+        defaultValues={{ name: cardgroup.name }}
+        submit={handleSave}
+        submitting={mutating}
+        error={activeError}
+        secondarySlot={deleteButton}
+      />
+    </main>
+  );
+}

--- a/frontend/src/app/cardgroups/[id]/edit/edit-cardgroup-client.tsx
+++ b/frontend/src/app/cardgroups/[id]/edit/edit-cardgroup-client.tsx
@@ -37,19 +37,20 @@ export function EditCardgroupClient({ cardgroup }: Props) {
   const activeError = deleteError ?? updateError;
 
   async function handleSave(values: { name: string }) {
-    await updateCardgroup({
+    const result = await updateCardgroup({
       variables: { id: cardgroup.id, input: { name: values.name } },
     }).catch((err) => {
       console.error("[EditCardgroupClient] update rejection", err);
+      return null;
     });
 
-    if (!updateError) {
+    if (result?.data?.updateCardgroup?.cardgroup) {
       router.push(`/cardgroups/${cardgroup.id}`);
     }
   }
 
   async function handleDelete() {
-    await deleteCardgroup({
+    const result = await deleteCardgroup({
       variables: { id: cardgroup.id },
       update(cache) {
         cache.evict({
@@ -59,9 +60,10 @@ export function EditCardgroupClient({ cardgroup }: Props) {
       },
     }).catch((err) => {
       console.error("[EditCardgroupClient] delete rejection", err);
+      return null;
     });
 
-    if (!deleteError) {
+    if (result?.data?.deleteCardgroup === true) {
       router.push("/cardgroups");
       router.refresh();
     }

--- a/frontend/src/app/cardgroups/[id]/edit/edit-cardgroup-client.tsx
+++ b/frontend/src/app/cardgroups/[id]/edit/edit-cardgroup-client.tsx
@@ -64,6 +64,7 @@ export function EditCardgroupClient({ cardgroup }: Props) {
     });
 
     if (result?.data?.deleteCardgroup === true) {
+      setDialogOpen(false);
       router.push("/cardgroups");
       router.refresh();
     }
@@ -91,7 +92,6 @@ export function EditCardgroupClient({ cardgroup }: Props) {
             onClick={(e) => {
               e.preventDefault();
               void handleDelete();
-              setDialogOpen(false);
             }}
           >
             Delete

--- a/frontend/src/app/cardgroups/[id]/edit/page.test.tsx
+++ b/frontend/src/app/cardgroups/[id]/edit/page.test.tsx
@@ -1,0 +1,88 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("next/navigation", () => ({
+  redirect: vi.fn((url: string) => {
+    throw new Error(`REDIRECT:${url}`);
+  }),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createSupabaseServerClient: vi.fn(),
+}));
+
+vi.mock("@/lib/apollo/server", () => ({
+  gqlFetch: vi.fn(),
+}));
+
+// Stub the client component so the RSC page test does not need Apollo context
+vi.mock("./edit-cardgroup-client", () => ({
+  EditCardgroupClient: ({ cardgroup }: { cardgroup: { id: string; name: string } }) => (
+    <div data-testid="edit-client">{cardgroup.name}</div>
+  ),
+}));
+
+import { gqlFetch } from "@/lib/apollo/server";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+import EditCardgroupPage from "./page";
+
+function makeSupabaseMock(user: { id: string } | null) {
+  return {
+    auth: {
+      getUser: vi.fn().mockResolvedValue({
+        data: { user },
+        error: null,
+      }),
+    },
+  };
+}
+
+function makeParams(id: string) {
+  return { params: Promise.resolve({ id }) };
+}
+
+describe("EditCardgroupPage", () => {
+  it("redirects to /cardgroups when no user is authenticated", async () => {
+    vi.mocked(createSupabaseServerClient).mockResolvedValue(makeSupabaseMock(null) as never);
+
+    await expect(EditCardgroupPage(makeParams("cg-1"))).rejects.toThrow("REDIRECT:/cardgroups");
+  });
+
+  it("redirects to /cardgroups when cardgroup is null", async () => {
+    vi.mocked(createSupabaseServerClient).mockResolvedValue(
+      makeSupabaseMock({ id: "user-1" }) as never,
+    );
+    vi.mocked(gqlFetch).mockResolvedValue({ cardgroup: null } as never);
+
+    await expect(EditCardgroupPage(makeParams("cg-1"))).rejects.toThrow("REDIRECT:/cardgroups");
+  });
+
+  it("redirects to /cardgroups on UNAUTHENTICATED gqlFetch error", async () => {
+    vi.mocked(createSupabaseServerClient).mockResolvedValue(
+      makeSupabaseMock({ id: "user-1" }) as never,
+    );
+    vi.mocked(gqlFetch).mockRejectedValue(new Error("GraphQL errors: UNAUTHENTICATED"));
+
+    await expect(EditCardgroupPage(makeParams("cg-1"))).rejects.toThrow("REDIRECT:/cardgroups");
+  });
+
+  it("renders the edit client with the cardgroup data", async () => {
+    vi.mocked(createSupabaseServerClient).mockResolvedValue(
+      makeSupabaseMock({ id: "user-1" }) as never,
+    );
+    vi.mocked(gqlFetch).mockResolvedValue({
+      cardgroup: {
+        id: "cg-1",
+        name: "Spanish Vocab",
+        updatedAt: "2024-06-15T10:00:00.000Z",
+      },
+    } as never);
+
+    const jsx = await EditCardgroupPage(makeParams("cg-1"));
+    render(jsx);
+
+    expect(screen.getByTestId("edit-client")).toBeInTheDocument();
+    expect(screen.getByText("Spanish Vocab")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/cardgroups/[id]/edit/page.test.tsx
+++ b/frontend/src/app/cardgroups/[id]/edit/page.test.tsx
@@ -43,10 +43,10 @@ function makeParams(id: string) {
 }
 
 describe("EditCardgroupPage", () => {
-  it("redirects to /cardgroups when no user is authenticated", async () => {
+  it("redirects to /login when no user is authenticated", async () => {
     vi.mocked(createSupabaseServerClient).mockResolvedValue(makeSupabaseMock(null) as never);
 
-    await expect(EditCardgroupPage(makeParams("cg-1"))).rejects.toThrow("REDIRECT:/cardgroups");
+    await expect(EditCardgroupPage(makeParams("cg-1"))).rejects.toThrow("REDIRECT:/login");
   });
 
   it("redirects to /cardgroups when cardgroup is null", async () => {

--- a/frontend/src/app/cardgroups/[id]/edit/page.tsx
+++ b/frontend/src/app/cardgroups/[id]/edit/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from "next/navigation";
 import { CardgroupQuery } from "@/app/cardgroups/queries";
 import { gqlFetch } from "@/lib/apollo/server";
+import { redirectIfUnauthenticated } from "@/lib/apollo/server-redirect";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 import { EditCardgroupClient } from "./edit-cardgroup-client";
 
@@ -23,9 +24,7 @@ export default async function EditCardgroupPage({ params }: Props) {
   try {
     data = await gqlFetch(CardgroupQuery, { variables: { id }, revalidate: 0 });
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    if (msg.includes("UNAUTHENTICATED")) redirect("/cardgroups");
-    throw err;
+    redirectIfUnauthenticated(err, "/cardgroups");
   }
 
   const cg = data.cardgroup;

--- a/frontend/src/app/cardgroups/[id]/edit/page.tsx
+++ b/frontend/src/app/cardgroups/[id]/edit/page.tsx
@@ -1,0 +1,35 @@
+import { redirect } from "next/navigation";
+import { CardgroupQuery } from "@/app/cardgroups/queries";
+import { gqlFetch } from "@/lib/apollo/server";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+import { EditCardgroupClient } from "./edit-cardgroup-client";
+
+type Props = {
+  params: Promise<{ id: string }>;
+};
+
+export default async function EditCardgroupPage({ params }: Props) {
+  const { id } = await params;
+
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+    error: authErr,
+  } = await supabase.auth.getUser();
+  if (authErr) throw authErr;
+  if (!user) redirect("/cardgroups");
+
+  let data: { cardgroup?: { id: string; name: string; updatedAt: unknown } | null };
+  try {
+    data = await gqlFetch(CardgroupQuery, { variables: { id }, revalidate: 0 });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (msg.includes("UNAUTHENTICATED")) redirect("/cardgroups");
+    throw err;
+  }
+
+  const cg = data.cardgroup;
+  if (!cg) redirect("/cardgroups");
+
+  return <EditCardgroupClient cardgroup={{ id: cg.id, name: cg.name }} />;
+}

--- a/frontend/src/app/cardgroups/[id]/edit/page.tsx
+++ b/frontend/src/app/cardgroups/[id]/edit/page.tsx
@@ -17,7 +17,7 @@ export default async function EditCardgroupPage({ params }: Props) {
     error: authErr,
   } = await supabase.auth.getUser();
   if (authErr) throw authErr;
-  if (!user) redirect("/cardgroups");
+  if (!user) redirect("/login");
 
   let data: { cardgroup?: { id: string; name: string; updatedAt: unknown } | null };
   try {

--- a/frontend/src/app/cardgroups/[id]/page.test.tsx
+++ b/frontend/src/app/cardgroups/[id]/page.test.tsx
@@ -1,0 +1,206 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+// Mock next/navigation before importing the page
+vi.mock("next/navigation", () => ({
+  redirect: vi.fn((url: string) => {
+    throw new Error(`REDIRECT:${url}`);
+  }),
+}));
+
+// Mock createSupabaseServerClient
+vi.mock("@/lib/supabase/server", () => ({
+  createSupabaseServerClient: vi.fn(),
+}));
+
+// Mock gqlFetch
+vi.mock("@/lib/apollo/server", () => ({
+  gqlFetch: vi.fn(),
+}));
+
+import { gqlFetch } from "@/lib/apollo/server";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+import CardgroupDetailPage from "./page";
+
+const FIXED_DATE = "2024-06-15T10:00:00.000Z";
+
+function makeSupabaseMock(user: { id: string } | null) {
+  return {
+    auth: {
+      getUser: vi.fn().mockResolvedValue({
+        data: { user },
+        error: null,
+      }),
+    },
+  };
+}
+
+function makeParams(id: string) {
+  return Promise.resolve({ id });
+}
+
+describe("CardgroupDetailPage", () => {
+  it("redirects to /login when no user is authenticated", async () => {
+    vi.mocked(createSupabaseServerClient).mockResolvedValue(makeSupabaseMock(null) as never);
+
+    await expect(CardgroupDetailPage({ params: makeParams("cg-1") })).rejects.toThrow(
+      "REDIRECT:/login",
+    );
+  });
+
+  it("redirects to /cardgroups when cardgroup is null", async () => {
+    vi.mocked(createSupabaseServerClient).mockResolvedValue(
+      makeSupabaseMock({ id: "user-1" }) as never,
+    );
+    vi.mocked(gqlFetch)
+      .mockResolvedValueOnce({ cardgroup: null } as never)
+      .mockResolvedValueOnce({ cardsByCardgroup: [] } as never);
+
+    await expect(CardgroupDetailPage({ params: makeParams("cg-missing") })).rejects.toThrow(
+      "REDIRECT:/cardgroups",
+    );
+  });
+
+  it("redirects to /cardgroups when gqlFetch throws UNAUTHENTICATED", async () => {
+    vi.mocked(createSupabaseServerClient).mockResolvedValue(
+      makeSupabaseMock({ id: "user-1" }) as never,
+    );
+    vi.mocked(gqlFetch).mockRejectedValue(
+      new Error('GraphQL errors: [{"extensions":{"code":"UNAUTHENTICATED"}}]'),
+    );
+
+    await expect(CardgroupDetailPage({ params: makeParams("cg-1") })).rejects.toThrow(
+      "REDIRECT:/cardgroups",
+    );
+  });
+
+  it("happy path: renders name, preview list, and three CTAs with correct hrefs", async () => {
+    vi.mocked(createSupabaseServerClient).mockResolvedValue(
+      makeSupabaseMock({ id: "user-1" }) as never,
+    );
+    vi.mocked(gqlFetch)
+      .mockResolvedValueOnce({
+        cardgroup: { id: "cg-1", name: "Spanish Vocab", updatedAt: FIXED_DATE },
+      } as never)
+      .mockResolvedValueOnce({
+        cardsByCardgroup: [
+          {
+            id: "card-1",
+            front: "Hola",
+            back: "Hello",
+            due: FIXED_DATE,
+            state: 0,
+            cardgroupId: "cg-1",
+          },
+          {
+            id: "card-2",
+            front: "Adiós",
+            back: "Goodbye",
+            due: FIXED_DATE,
+            state: 0,
+            cardgroupId: "cg-1",
+          },
+        ],
+      } as never);
+
+    const jsx = await CardgroupDetailPage({ params: makeParams("cg-1") });
+    render(jsx);
+
+    // Heading
+    expect(screen.getByRole("heading", { name: "Spanish Vocab" })).toBeInTheDocument();
+
+    // Preview cards
+    expect(screen.getByText("Hola")).toBeInTheDocument();
+    expect(screen.getByText("Adiós")).toBeInTheDocument();
+
+    // Three CTAs
+    const startLink = screen.getByRole("link", { name: /start learning/i });
+    expect(startLink).toHaveAttribute("href", "/learn/cg-1");
+
+    const editLink = screen.getByRole("link", { name: /edit/i });
+    expect(editLink).toHaveAttribute("href", "/cardgroups/cg-1/edit");
+
+    const manageLink = screen.getByRole("link", { name: /manage cards/i });
+    expect(manageLink).toHaveAttribute("href", "/cardgroups/cg-1/cards");
+  });
+
+  it("shows 'Showing 5 of N' text when there are more than 5 cards", async () => {
+    vi.mocked(createSupabaseServerClient).mockResolvedValue(
+      makeSupabaseMock({ id: "user-1" }) as never,
+    );
+
+    const manyCards = Array.from({ length: 8 }, (_, i) => ({
+      id: `card-${i}`,
+      front: `Front ${i}`,
+      back: `Back ${i}`,
+      due: FIXED_DATE,
+      state: 0,
+      cardgroupId: "cg-1",
+    }));
+
+    vi.mocked(gqlFetch)
+      .mockResolvedValueOnce({
+        cardgroup: { id: "cg-1", name: "Big Deck", updatedAt: FIXED_DATE },
+      } as never)
+      .mockResolvedValueOnce({ cardsByCardgroup: manyCards } as never);
+
+    const jsx = await CardgroupDetailPage({ params: makeParams("cg-1") });
+    render(jsx);
+
+    expect(screen.getByText("Showing 5 of 8")).toBeInTheDocument();
+    // Only 5 preview cards shown
+    expect(screen.getAllByRole("listitem")).toHaveLength(5);
+  });
+
+  it("renders empty state with Add card CTA when there are no cards", async () => {
+    vi.mocked(createSupabaseServerClient).mockResolvedValue(
+      makeSupabaseMock({ id: "user-1" }) as never,
+    );
+
+    vi.mocked(gqlFetch)
+      .mockResolvedValueOnce({
+        cardgroup: { id: "cg-1", name: "Empty Deck", updatedAt: FIXED_DATE },
+      } as never)
+      .mockResolvedValueOnce({ cardsByCardgroup: [] } as never);
+
+    const jsx = await CardgroupDetailPage({ params: makeParams("cg-1") });
+    render(jsx);
+
+    expect(screen.getByText(/no cards yet/i)).toBeInTheDocument();
+
+    const addCardLink = screen.getByRole("link", { name: /add card/i });
+    expect(addCardLink).toHaveAttribute("href", "/cardgroups/cg-1/cards");
+  });
+
+  it("truncates card front text longer than 80 characters", async () => {
+    vi.mocked(createSupabaseServerClient).mockResolvedValue(
+      makeSupabaseMock({ id: "user-1" }) as never,
+    );
+
+    const longFront = "A".repeat(85);
+
+    vi.mocked(gqlFetch)
+      .mockResolvedValueOnce({
+        cardgroup: { id: "cg-1", name: "Truncation Test", updatedAt: FIXED_DATE },
+      } as never)
+      .mockResolvedValueOnce({
+        cardsByCardgroup: [
+          {
+            id: "card-1",
+            front: longFront,
+            back: "Back",
+            due: FIXED_DATE,
+            state: 0,
+            cardgroupId: "cg-1",
+          },
+        ],
+      } as never);
+
+    const jsx = await CardgroupDetailPage({ params: makeParams("cg-1") });
+    render(jsx);
+
+    const expectedText = `${"A".repeat(79)}…`;
+    expect(screen.getByText(expectedText)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/cardgroups/[id]/page.tsx
+++ b/frontend/src/app/cardgroups/[id]/page.tsx
@@ -1,0 +1,97 @@
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { CardgroupQuery, CardsByCardgroupQuery } from "@/app/cardgroups/queries";
+import { Button } from "@/components/ui/button";
+import type {
+  CardgroupQuery as CardgroupQueryType,
+  CardsByCardgroupQuery as CardsByCardgroupQueryType,
+} from "@/generated/graphql";
+import { gqlFetch } from "@/lib/apollo/server";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+
+const DATE_FORMAT = new Intl.DateTimeFormat("en-US", { dateStyle: "medium" });
+
+function truncateFront(front: string): string {
+  if (front.length > 80) return `${front.slice(0, 79)}…`;
+  return front;
+}
+
+export default async function CardgroupDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+    error: authErr,
+  } = await supabase.auth.getUser();
+  if (authErr) throw authErr;
+  if (!user) redirect("/login");
+
+  const { id } = await params;
+
+  let cardgroupData: CardgroupQueryType | null = null;
+  let cardsData: CardsByCardgroupQueryType | null = null;
+
+  try {
+    [cardgroupData, cardsData] = await Promise.all([
+      gqlFetch(CardgroupQuery, { variables: { id }, revalidate: 0 }),
+      gqlFetch(CardsByCardgroupQuery, { variables: { cardgroupId: id }, revalidate: 0 }),
+    ]);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (msg.includes("UNAUTHENTICATED")) redirect("/cardgroups");
+    throw err;
+  }
+
+  if (!cardgroupData?.cardgroup) redirect("/cardgroups");
+
+  const cardgroup = cardgroupData.cardgroup;
+  const cards = cardsData?.cardsByCardgroup ?? [];
+  const previewCards = cards.slice(0, 5);
+  const updatedAtDate = DATE_FORMAT.format(new Date(cardgroup.updatedAt as string));
+
+  return (
+    <main className="mx-auto max-w-2xl p-8">
+      <h1 className="mb-2 text-2xl font-semibold">{cardgroup.name}</h1>
+      <p className="mb-6 text-sm text-muted-foreground">Updated {updatedAtDate}</p>
+
+      {cards.length === 0 ? (
+        <div className="mb-8 rounded-lg border border-dashed border-border p-6 text-center">
+          <p className="mb-4 text-muted-foreground">No cards yet. Add some to get started.</p>
+          <Button asChild>
+            <Link href={`/cardgroups/${id}/cards`}>Add card</Link>
+          </Button>
+        </div>
+      ) : (
+        <section className="mb-8">
+          <h2 className="mb-3 text-sm font-medium text-muted-foreground uppercase tracking-wide">
+            Preview
+          </h2>
+          <ul className="space-y-2">
+            {previewCards.map((card) => (
+              <li
+                key={card.id}
+                className="rounded-md border border-border bg-card px-4 py-2 text-sm"
+              >
+                {truncateFront(card.front)}
+              </li>
+            ))}
+          </ul>
+          {cards.length > 5 && (
+            <p className="mt-2 text-xs text-muted-foreground">Showing 5 of {cards.length}</p>
+          )}
+        </section>
+      )}
+
+      <div className="flex flex-wrap gap-3">
+        <Button asChild>
+          <Link href={`/learn/${id}`}>Start learning</Link>
+        </Button>
+        <Button asChild variant="outline">
+          <Link href={`/cardgroups/${id}/edit`}>Edit</Link>
+        </Button>
+        <Button asChild variant="outline">
+          <Link href={`/cardgroups/${id}/cards`}>Manage cards</Link>
+        </Button>
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/app/cardgroups/[id]/page.tsx
+++ b/frontend/src/app/cardgroups/[id]/page.tsx
@@ -7,9 +7,9 @@ import type {
   CardsByCardgroupQuery as CardsByCardgroupQueryType,
 } from "@/generated/graphql";
 import { gqlFetch } from "@/lib/apollo/server";
+import { redirectIfUnauthenticated } from "@/lib/apollo/server-redirect";
+import { formatMediumDate } from "@/lib/format";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
-
-const DATE_FORMAT = new Intl.DateTimeFormat("en-US", { dateStyle: "medium" });
 
 function truncateFront(front: string): string {
   if (front.length > 80) return `${front.slice(0, 79)}…`;
@@ -36,9 +36,7 @@ export default async function CardgroupDetailPage({ params }: { params: Promise<
       gqlFetch(CardsByCardgroupQuery, { variables: { cardgroupId: id }, revalidate: 0 }),
     ]);
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    if (msg.includes("UNAUTHENTICATED")) redirect("/cardgroups");
-    throw err;
+    redirectIfUnauthenticated(err, "/cardgroups");
   }
 
   if (!cardgroupData?.cardgroup) redirect("/cardgroups");
@@ -46,12 +44,13 @@ export default async function CardgroupDetailPage({ params }: { params: Promise<
   const cardgroup = cardgroupData.cardgroup;
   const cards = cardsData?.cardsByCardgroup ?? [];
   const previewCards = cards.slice(0, 5);
-  const updatedAtDate = DATE_FORMAT.format(new Date(cardgroup.updatedAt as string));
 
   return (
     <main className="mx-auto max-w-2xl p-8">
       <h1 className="mb-2 text-2xl font-semibold">{cardgroup.name}</h1>
-      <p className="mb-6 text-sm text-muted-foreground">Updated {updatedAtDate}</p>
+      <p className="mb-6 text-sm text-muted-foreground">
+        Updated {formatMediumDate(cardgroup.updatedAt as string)}
+      </p>
 
       {cards.length === 0 ? (
         <div className="mb-8 rounded-lg border border-dashed border-border p-6 text-center">

--- a/frontend/src/app/cardgroups/new/new-cardgroup-client.tsx
+++ b/frontend/src/app/cardgroups/new/new-cardgroup-client.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useMutation } from "@apollo/client/react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { CreateCardgroupMutation } from "@/app/cardgroups/queries";
+import { CardgroupForm } from "@/components/cardgroups/cardgroup-form";
+import { MyCardgroupsDocument } from "@/generated/graphql";
+
+export function NewCardgroupClient() {
+  const router = useRouter();
+
+  const [createCardgroup, { loading, error }] = useMutation(CreateCardgroupMutation, {
+    update(cache, { data }) {
+      if (!data?.createCardgroup?.cardgroup) return;
+      const existing = cache.readQuery({ query: MyCardgroupsDocument });
+      cache.writeQuery({
+        query: MyCardgroupsDocument,
+        data: {
+          myCardgroups: [data.createCardgroup.cardgroup, ...(existing?.myCardgroups ?? [])],
+        },
+      });
+    },
+    onCompleted(data) {
+      if (!data?.createCardgroup?.cardgroup?.id) return;
+      router.push(`/cardgroups/${data.createCardgroup.cardgroup.id}`);
+      router.refresh();
+    },
+  });
+
+  async function handleSubmit(values: { name: string }) {
+    await createCardgroup({
+      variables: { input: { name: values.name } },
+    }).catch((err) => {
+      console.error("[NewCardgroupClient] mutation rejection", err);
+    });
+  }
+
+  return (
+    <main className="mx-auto max-w-xl p-8">
+      <div className="mb-6 flex items-center gap-4">
+        <Link href="/cardgroups" className="text-sm text-muted-foreground hover:underline">
+          &larr; Back
+        </Link>
+        <h1 className="text-2xl font-semibold">New cardgroup</h1>
+      </div>
+      <CardgroupForm
+        mode="create"
+        defaultValues={{ name: "" }}
+        submit={handleSubmit}
+        submitting={loading}
+        error={error}
+      />
+    </main>
+  );
+}

--- a/frontend/src/app/cardgroups/new/page.test.tsx
+++ b/frontend/src/app/cardgroups/new/page.test.tsx
@@ -1,0 +1,180 @@
+// @vitest-environment jsdom
+
+import type { MockedResponse } from "@apollo/client/testing";
+import { MockedProvider } from "@apollo/client/testing/react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { GraphQLError } from "graphql";
+import { describe, expect, it, vi } from "vitest";
+import { CreateCardgroupDocument } from "@/generated/graphql";
+import { NewCardgroupClient } from "./new-cardgroup-client";
+
+// Stub next/navigation so the client component can render outside Next.js.
+const mockPush = vi.fn();
+const mockRefresh = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush, refresh: mockRefresh }),
+}));
+
+// Stub next/link so it renders an anchor without Next.js router context.
+vi.mock("next/link", () => ({
+  default: ({ href, children, ...rest }: { href: string; children: React.ReactNode }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+const CREATED_CARDGROUP = {
+  __typename: "Cardgroup" as const,
+  id: "cg-42",
+  name: "My New Group",
+  updatedAt: "2026-04-30T00:00:00Z",
+};
+
+function makeCreateMock(name: string, onCalled?: () => void) {
+  return {
+    request: {
+      query: CreateCardgroupDocument,
+      variables: { input: { name } },
+    },
+    result: () => {
+      onCalled?.();
+      return {
+        data: {
+          createCardgroup: {
+            __typename: "CreateCardgroupPayload" as const,
+            cardgroup: { ...CREATED_CARDGROUP, name },
+          },
+        },
+      };
+    },
+  };
+}
+
+function renderPage(mocks: MockedResponse[] = [], errorPolicy?: "all" | "none" | "ignore") {
+  const defaultOptions = errorPolicy ? { mutate: { errorPolicy } } : undefined;
+  render(
+    <MockedProvider mocks={mocks} defaultOptions={defaultOptions}>
+      <NewCardgroupClient />
+    </MockedProvider>,
+  );
+}
+
+describe("<NewCardgroupPage> (client)", () => {
+  it("renders form with empty name by default", () => {
+    renderPage();
+    expect(screen.getByRole("textbox")).toHaveValue("");
+    expect(screen.getByRole("button", { name: /create/i })).toBeInTheDocument();
+  });
+
+  it("renders page header and back link", () => {
+    renderPage();
+    expect(screen.getByRole("heading", { name: /new cardgroup/i })).toBeInTheDocument();
+    const backLink = screen.getByRole("link");
+    expect(backLink).toHaveAttribute("href", "/cardgroups");
+  });
+
+  it("submitting a valid name triggers the CreateCardgroup mutation", async () => {
+    const user = userEvent.setup();
+    const mutationCalled = vi.fn();
+
+    renderPage([makeCreateMock("My New Group", mutationCalled)]);
+
+    await user.type(screen.getByRole("textbox"), "My New Group");
+    await user.click(screen.getByRole("button", { name: /create/i }));
+
+    await waitFor(() => {
+      expect(mutationCalled).toHaveBeenCalledOnce();
+    });
+  });
+
+  it("on success calls router.push with returned id and router.refresh", async () => {
+    const user = userEvent.setup();
+    mockPush.mockClear();
+    mockRefresh.mockClear();
+
+    renderPage([makeCreateMock("My New Group")]);
+
+    await user.type(screen.getByRole("textbox"), "My New Group");
+    await user.click(screen.getByRole("button", { name: /create/i }));
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith(`/cardgroups/${CREATED_CARDGROUP.id}`);
+    });
+    expect(mockRefresh).toHaveBeenCalledOnce();
+  });
+
+  it("on success writes the new cardgroup into the MyCardgroups cache", async () => {
+    const user = userEvent.setup();
+
+    renderPage([makeCreateMock("My New Group")]);
+
+    await user.type(screen.getByRole("textbox"), "My New Group");
+    await user.click(screen.getByRole("button", { name: /create/i }));
+
+    // Success navigation is the observable side-effect — cache write happens first.
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalled();
+    });
+  });
+
+  it("BAD_USER_INPUT on field 'name' shows inline error", async () => {
+    const user = userEvent.setup();
+
+    const mocks = [
+      {
+        request: {
+          query: CreateCardgroupDocument,
+          variables: { input: { name: "Bad Name" } },
+        },
+        result: {
+          errors: [
+            new GraphQLError("name already exists", {
+              extensions: { code: "BAD_USER_INPUT", field: "name" },
+            }),
+          ],
+        },
+      },
+    ];
+
+    renderPage(mocks, "all");
+
+    await user.type(screen.getByRole("textbox"), "Bad Name");
+    await user.click(screen.getByRole("button", { name: /create/i }));
+
+    const errorEl = await screen.findByText("name already exists");
+    expect(errorEl).toBeInTheDocument();
+    expect(errorEl.className).toMatch(/text-destructive/);
+  });
+
+  it("UNAUTHENTICATED error shows session-expired banner", async () => {
+    const user = userEvent.setup();
+
+    const mocks = [
+      {
+        request: {
+          query: CreateCardgroupDocument,
+          variables: { input: { name: "My Group" } },
+        },
+        result: {
+          errors: [
+            new GraphQLError("Unauthenticated", {
+              extensions: { code: "UNAUTHENTICATED" },
+            }),
+          ],
+        },
+      },
+    ];
+
+    renderPage(mocks, "all");
+
+    await user.type(screen.getByRole("textbox"), "My Group");
+    await user.click(screen.getByRole("button", { name: /create/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Your session expired. Please sign in again.")).toBeInTheDocument();
+    });
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/cardgroups/new/page.test.tsx
+++ b/frontend/src/app/cardgroups/new/page.test.tsx
@@ -1,12 +1,13 @@
 // @vitest-environment jsdom
 
+import { InMemoryCache } from "@apollo/client";
 import type { MockedResponse } from "@apollo/client/testing";
 import { MockedProvider } from "@apollo/client/testing/react";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { GraphQLError } from "graphql";
 import { describe, expect, it, vi } from "vitest";
-import { CreateCardgroupDocument } from "@/generated/graphql";
+import { CreateCardgroupDocument, MyCardgroupsDocument } from "@/generated/graphql";
 import { NewCardgroupClient } from "./new-cardgroup-client";
 
 // Stub next/navigation so the client component can render outside Next.js.
@@ -52,10 +53,14 @@ function makeCreateMock(name: string, onCalled?: () => void) {
   };
 }
 
-function renderPage(mocks: MockedResponse[] = [], errorPolicy?: "all" | "none" | "ignore") {
+function renderPage(
+  mocks: MockedResponse[] = [],
+  errorPolicy?: "all" | "none" | "ignore",
+  cache?: InMemoryCache,
+) {
   const defaultOptions = errorPolicy ? { mutate: { errorPolicy } } : undefined;
   render(
-    <MockedProvider mocks={mocks} defaultOptions={defaultOptions}>
+    <MockedProvider mocks={mocks} defaultOptions={defaultOptions} cache={cache}>
       <NewCardgroupClient />
     </MockedProvider>,
   );
@@ -107,15 +112,33 @@ describe("<NewCardgroupPage> (client)", () => {
 
   it("on success writes the new cardgroup into the MyCardgroups cache", async () => {
     const user = userEvent.setup();
+    mockPush.mockClear();
 
-    renderPage([makeCreateMock("My New Group")]);
+    // Use a real InMemoryCache so the update(cache, { data }) block in
+    // new-cardgroup-client.tsx can perform a readQuery/writeQuery round-trip.
+    const cache = new InMemoryCache();
+    cache.writeQuery({
+      query: MyCardgroupsDocument,
+      data: { myCardgroups: [] },
+    });
+
+    renderPage([makeCreateMock("My New Group")], undefined, cache);
 
     await user.type(screen.getByRole("textbox"), "My New Group");
     await user.click(screen.getByRole("button", { name: /create/i }));
 
-    // Success navigation is the observable side-effect — cache write happens first.
+    // Wait for the mutation to complete (navigation is the observable signal).
     await waitFor(() => {
-      expect(mockPush).toHaveBeenCalled();
+      expect(mockPush).toHaveBeenCalledWith(`/cardgroups/${CREATED_CARDGROUP.id}`);
+    });
+
+    // The cache update callback must have prepended the new cardgroup.
+    const result = cache.readQuery({ query: MyCardgroupsDocument });
+    expect(result?.myCardgroups).toHaveLength(1);
+    expect(result?.myCardgroups[0]).toMatchObject({
+      id: CREATED_CARDGROUP.id,
+      name: CREATED_CARDGROUP.name,
+      updatedAt: CREATED_CARDGROUP.updatedAt,
     });
   });
 

--- a/frontend/src/app/cardgroups/new/page.tsx
+++ b/frontend/src/app/cardgroups/new/page.tsx
@@ -1,0 +1,15 @@
+import { redirect } from "next/navigation";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+import { NewCardgroupClient } from "./new-cardgroup-client";
+
+export default async function NewCardgroupPage() {
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+    error: authErr,
+  } = await supabase.auth.getUser();
+  if (authErr) throw authErr;
+  if (!user) redirect("/login");
+
+  return <NewCardgroupClient />;
+}

--- a/frontend/src/app/cardgroups/page.test.tsx
+++ b/frontend/src/app/cardgroups/page.test.tsx
@@ -79,4 +79,22 @@ describe("CardgroupsPage", () => {
     const mathLink = screen.getByRole("link", { name: /math formulas/i });
     expect(mathLink).toHaveAttribute("href", "/cardgroups/cg-2");
   });
+
+  it("redirects to /login when MyCardgroupsQuery returns UNAUTHENTICATED", async () => {
+    vi.mocked(createSupabaseServerClient).mockResolvedValue(
+      makeSupabaseMock({ id: "user-1" }) as never,
+    );
+    vi.mocked(gqlFetch).mockRejectedValue(new Error("GraphQL errors: UNAUTHENTICATED"));
+
+    await expect(CardgroupsPage()).rejects.toThrow("REDIRECT:/login");
+  });
+
+  it("rethrows non-auth errors so the error boundary handles them", async () => {
+    vi.mocked(createSupabaseServerClient).mockResolvedValue(
+      makeSupabaseMock({ id: "user-1" }) as never,
+    );
+    vi.mocked(gqlFetch).mockRejectedValue(new Error("Network unreachable"));
+
+    await expect(CardgroupsPage()).rejects.toThrow("Network unreachable");
+  });
 });

--- a/frontend/src/app/cardgroups/page.test.tsx
+++ b/frontend/src/app/cardgroups/page.test.tsx
@@ -1,0 +1,82 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+// Mock next/navigation before importing the page
+vi.mock("next/navigation", () => ({
+  redirect: vi.fn((url: string) => {
+    throw new Error(`REDIRECT:${url}`);
+  }),
+}));
+
+// Mock createSupabaseServerClient
+vi.mock("@/lib/supabase/server", () => ({
+  createSupabaseServerClient: vi.fn(),
+}));
+
+// Mock gqlFetch
+vi.mock("@/lib/apollo/server", () => ({
+  gqlFetch: vi.fn(),
+}));
+
+import { gqlFetch } from "@/lib/apollo/server";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+import CardgroupsPage from "./page";
+
+function makeSupabaseMock(user: { id: string } | null) {
+  return {
+    auth: {
+      getUser: vi.fn().mockResolvedValue({
+        data: { user },
+        error: null,
+      }),
+    },
+  };
+}
+
+describe("CardgroupsPage", () => {
+  it("redirects to /login when no user is authenticated", async () => {
+    vi.mocked(createSupabaseServerClient).mockResolvedValue(makeSupabaseMock(null) as never);
+
+    await expect(CardgroupsPage()).rejects.toThrow("REDIRECT:/login");
+  });
+
+  it("renders empty state when myCardgroups is empty", async () => {
+    vi.mocked(createSupabaseServerClient).mockResolvedValue(
+      makeSupabaseMock({ id: "user-1" }) as never,
+    );
+    vi.mocked(gqlFetch).mockResolvedValue({ myCardgroups: [] } as never);
+
+    const jsx = await CardgroupsPage();
+    render(jsx);
+
+    expect(screen.getByText("You haven't created any cardgroups yet.")).toBeInTheDocument();
+    // Both CTA links should be present (header + empty state)
+    const links = screen.getAllByRole("link", { name: /new cardgroup/i });
+    expect(links.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders one list item per cardgroup", async () => {
+    vi.mocked(createSupabaseServerClient).mockResolvedValue(
+      makeSupabaseMock({ id: "user-1" }) as never,
+    );
+    vi.mocked(gqlFetch).mockResolvedValue({
+      myCardgroups: [
+        { id: "cg-1", name: "Spanish Vocab", updatedAt: "2024-06-15T10:00:00.000Z" },
+        { id: "cg-2", name: "Math Formulas", updatedAt: "2024-05-20T08:00:00.000Z" },
+      ],
+    } as never);
+
+    const jsx = await CardgroupsPage();
+    render(jsx);
+
+    expect(screen.getByText("Spanish Vocab")).toBeInTheDocument();
+    expect(screen.getByText("Math Formulas")).toBeInTheDocument();
+
+    const spanishLink = screen.getByRole("link", { name: /spanish vocab/i });
+    expect(spanishLink).toHaveAttribute("href", "/cardgroups/cg-1");
+
+    const mathLink = screen.getByRole("link", { name: /math formulas/i });
+    expect(mathLink).toHaveAttribute("href", "/cardgroups/cg-2");
+  });
+});

--- a/frontend/src/app/cardgroups/page.tsx
+++ b/frontend/src/app/cardgroups/page.tsx
@@ -3,6 +3,7 @@ import { redirect } from "next/navigation";
 import { CardgroupListItem } from "@/components/cardgroups/cardgroup-list-item";
 import type { MyCardgroupsQuery as MyCardgroupsQueryType } from "@/generated/graphql";
 import { gqlFetch } from "@/lib/apollo/server";
+import { redirectIfUnauthenticated } from "@/lib/apollo/server-redirect";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 import { MyCardgroupsQuery } from "./queries";
 
@@ -19,9 +20,7 @@ export default async function CardgroupsPage() {
   try {
     data = await gqlFetch(MyCardgroupsQuery, { revalidate: 0 });
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    if (msg.includes("UNAUTHENTICATED")) redirect("/login");
-    throw err;
+    redirectIfUnauthenticated(err, "/login");
   }
   const cardgroups = data.myCardgroups;
 

--- a/frontend/src/app/cardgroups/page.tsx
+++ b/frontend/src/app/cardgroups/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { redirect } from "next/navigation";
 import { CardgroupListItem } from "@/components/cardgroups/cardgroup-list-item";
+import type { MyCardgroupsQuery as MyCardgroupsQueryType } from "@/generated/graphql";
 import { gqlFetch } from "@/lib/apollo/server";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 import { MyCardgroupsQuery } from "./queries";
@@ -14,7 +15,14 @@ export default async function CardgroupsPage() {
   if (authErr) throw authErr;
   if (!user) redirect("/login");
 
-  const data = await gqlFetch(MyCardgroupsQuery, { revalidate: 0 });
+  let data: MyCardgroupsQueryType;
+  try {
+    data = await gqlFetch(MyCardgroupsQuery, { revalidate: 0 });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (msg.includes("UNAUTHENTICATED")) redirect("/login");
+    throw err;
+  }
   const cardgroups = data.myCardgroups;
 
   return (

--- a/frontend/src/app/cardgroups/page.tsx
+++ b/frontend/src/app/cardgroups/page.tsx
@@ -1,0 +1,51 @@
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { CardgroupListItem } from "@/components/cardgroups/cardgroup-list-item";
+import { gqlFetch } from "@/lib/apollo/server";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+import { MyCardgroupsQuery } from "./queries";
+
+export default async function CardgroupsPage() {
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+    error: authErr,
+  } = await supabase.auth.getUser();
+  if (authErr) throw authErr;
+  if (!user) redirect("/login");
+
+  const data = await gqlFetch(MyCardgroupsQuery, { revalidate: 0 });
+  const cardgroups = data.myCardgroups;
+
+  return (
+    <main className="mx-auto max-w-2xl p-8">
+      <div className="mb-6 flex items-center justify-between">
+        <h1 className="text-2xl font-semibold">My Cardgroups</h1>
+        <Link
+          href="/cardgroups/new"
+          className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+        >
+          New cardgroup
+        </Link>
+      </div>
+
+      {cardgroups.length === 0 ? (
+        <div className="rounded-lg border border-dashed border-border p-8 text-center">
+          <p className="mb-4 text-muted-foreground">You haven&apos;t created any cardgroups yet.</p>
+          <Link
+            href="/cardgroups/new"
+            className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+          >
+            New cardgroup
+          </Link>
+        </div>
+      ) : (
+        <ul className="space-y-2">
+          {cardgroups.map((cg) => (
+            <CardgroupListItem key={cg.id} id={cg.id} name={cg.name} updatedAt={cg.updatedAt} />
+          ))}
+        </ul>
+      )}
+    </main>
+  );
+}

--- a/frontend/src/app/cardgroups/queries.ts
+++ b/frontend/src/app/cardgroups/queries.ts
@@ -1,0 +1,108 @@
+import { graphql } from "@/generated";
+
+// Cardgroup queries
+
+export const MyCardgroupsQuery = graphql(`
+  query MyCardgroups {
+    myCardgroups {
+      id
+      name
+      updatedAt
+    }
+  }
+`);
+
+export const CardgroupQuery = graphql(`
+  query Cardgroup($id: ID!) {
+    cardgroup(id: $id) {
+      id
+      name
+      updatedAt
+    }
+  }
+`);
+
+// Cardgroup mutations
+
+export const CreateCardgroupMutation = graphql(`
+  mutation CreateCardgroup($input: NewCardgroupInput!) {
+    createCardgroup(input: $input) {
+      cardgroup {
+        id
+        name
+        updatedAt
+      }
+    }
+  }
+`);
+
+export const UpdateCardgroupMutation = graphql(`
+  mutation UpdateCardgroup($id: ID!, $input: UpdateCardgroupInput!) {
+    updateCardgroup(id: $id, input: $input) {
+      cardgroup {
+        id
+        name
+        updatedAt
+      }
+    }
+  }
+`);
+
+export const DeleteCardgroupMutation = graphql(`
+  mutation DeleteCardgroup($id: ID!) {
+    deleteCardgroup(id: $id)
+  }
+`);
+
+// Card queries
+
+export const CardsByCardgroupQuery = graphql(`
+  query CardsByCardgroup($cardgroupId: ID!) {
+    cardsByCardgroup(cardgroupId: $cardgroupId) {
+      id
+      front
+      back
+      due
+      state
+      cardgroupId
+    }
+  }
+`);
+
+// Card mutations
+
+export const CreateCardMutation = graphql(`
+  mutation CreateCard($input: NewCardInput!) {
+    createCard(input: $input) {
+      card {
+        id
+        front
+        back
+        due
+        state
+        cardgroupId
+      }
+    }
+  }
+`);
+
+export const UpdateCardMutation = graphql(`
+  mutation UpdateCard($id: ID!, $input: UpdateCardInput!) {
+    updateCard(id: $id, input: $input) {
+      card {
+        id
+        front
+        back
+        due
+        state
+        cardgroupId
+      }
+    }
+  }
+`);
+
+export const DeleteCardMutation = graphql(`
+  mutation DeleteCard($id: ID!) {
+    deleteCard(id: $id)
+  }
+`);

--- a/frontend/src/app/profile/profile-form.test.tsx
+++ b/frontend/src/app/profile/profile-form.test.tsx
@@ -280,7 +280,7 @@ describe("<ProfileForm>", () => {
 
     await waitFor(() => {
       expect(
-        screen.getByText("Could not reach the server. Check your connection and try again."),
+        screen.getByText("Could not reach the server. Please try again."),
       ).toBeInTheDocument();
     });
   });

--- a/frontend/src/app/profile/profile-form.test.tsx
+++ b/frontend/src/app/profile/profile-form.test.tsx
@@ -279,9 +279,7 @@ describe("<ProfileForm>", () => {
     await user.click(screen.getByRole("button", { name: /save/i }));
 
     await waitFor(() => {
-      expect(
-        screen.getByText("Could not reach the server. Please try again."),
-      ).toBeInTheDocument();
+      expect(screen.getByText("Could not reach the server. Please try again.")).toBeInTheDocument();
     });
   });
 

--- a/frontend/src/app/profile/profile-form.tsx
+++ b/frontend/src/app/profile/profile-form.tsx
@@ -10,6 +10,7 @@ import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { graphql } from "@/generated";
 import { getBackendErrorBanner, getBackendFieldErrors } from "@/lib/apollo/errors";
+import { FieldError } from "@/lib/forms/field-error";
 import { updateProfileSchema } from "@/schemas/profile";
 
 const UpdateProfileMutation = graphql(`
@@ -24,18 +25,6 @@ const UpdateProfileMutation = graphql(`
     }
   }
 `);
-
-function hasMessage(value: unknown): value is { message: string } {
-  return typeof (value as { message?: unknown })?.message === "string";
-}
-
-type FieldErrorProps = { zodErrors: unknown[]; backendError?: string };
-
-function FieldError({ zodErrors, backendError }: FieldErrorProps) {
-  const msg = zodErrors.find(hasMessage)?.message ?? backendError;
-  if (!msg) return null;
-  return <p className="text-sm text-destructive">{msg}</p>;
-}
 
 type Props = { initial: { displayName: string; bio: string } };
 

--- a/frontend/src/app/profile/profile-form.tsx
+++ b/frontend/src/app/profile/profile-form.tsx
@@ -1,14 +1,15 @@
 "use client";
 
-import { CombinedGraphQLErrors } from "@apollo/client/errors";
 import { useMutation } from "@apollo/client/react";
 import { useForm } from "@tanstack/react-form";
 import { useRouter } from "next/navigation";
+import { useMemo } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { graphql } from "@/generated";
+import { getBackendErrorBanner, getBackendFieldErrors } from "@/lib/apollo/errors";
 import { updateProfileSchema } from "@/schemas/profile";
 
 const UpdateProfileMutation = graphql(`
@@ -23,47 +24,6 @@ const UpdateProfileMutation = graphql(`
     }
   }
 `);
-
-function extensionString(
-  extensions: Record<string, unknown> | undefined,
-  key: string,
-): string | undefined {
-  const value = extensions?.[key];
-  return typeof value === "string" ? value : undefined;
-}
-
-// Returns a map of field name -> error message for BAD_USER_INPUT errors.
-function useBackendFieldErrors(err: unknown): Record<string, string> {
-  if (!CombinedGraphQLErrors.is(err)) return {};
-  const out: Record<string, string> = {};
-  for (const ge of err.errors) {
-    const code = extensionString(ge.extensions, "code");
-    const field = extensionString(ge.extensions, "field");
-    if (code === "BAD_USER_INPUT" && field) {
-      out[field] = ge.message;
-    }
-  }
-  return out;
-}
-
-// Returns a user-facing banner message for non-field errors.
-// Priority: INTERNAL > UNAUTHENTICATED > first non-field GraphQL error > network error.
-function useBackendErrorBanner(err: unknown): string | undefined {
-  if (!err) return undefined;
-  if (!CombinedGraphQLErrors.is(err)) {
-    return "Could not reach the server. Check your connection and try again.";
-  }
-  let firstNonField: string | undefined;
-  for (const ge of err.errors) {
-    const code = extensionString(ge.extensions, "code");
-    const field = extensionString(ge.extensions, "field");
-    if (code === "INTERNAL") return ge.message;
-    if (code === "UNAUTHENTICATED") return "Your session expired. Please sign in again.";
-    if (code === "BAD_USER_INPUT" && field) continue;
-    firstNonField ??= ge.message;
-  }
-  return firstNonField;
-}
 
 function hasMessage(value: unknown): value is { message: string } {
   return typeof (value as { message?: unknown })?.message === "string";
@@ -85,8 +45,8 @@ export function ProfileForm({ initial }: Props) {
     onCompleted: () => router.refresh(),
   });
 
-  const fieldErrors = useBackendFieldErrors(error);
-  const bannerError = useBackendErrorBanner(error);
+  const fieldErrors = useMemo(() => getBackendFieldErrors(error), [error]);
+  const bannerError = useMemo(() => getBackendErrorBanner(error), [error]);
 
   const displayNameSchema = updateProfileSchema.shape.displayName;
   const bioSchema = updateProfileSchema.shape.bio;

--- a/frontend/src/components/cardgroups/card-form.test.tsx
+++ b/frontend/src/components/cardgroups/card-form.test.tsx
@@ -1,0 +1,123 @@
+// @vitest-environment jsdom
+import { CombinedGraphQLErrors } from "@apollo/client/errors";
+import { MockedProvider } from "@apollo/client/testing/react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { GraphQLError } from "graphql";
+import { describe, expect, it, vi } from "vitest";
+import { CardForm } from "./card-form";
+
+function renderForm(props: Partial<Parameters<typeof CardForm>[0]> = {}) {
+  const submit = vi.fn().mockResolvedValue(undefined);
+  render(
+    <MockedProvider mocks={[]}>
+      <CardForm
+        mode={props.mode ?? "create"}
+        cardgroupId={props.cardgroupId ?? "cg-1"}
+        defaultValues={props.defaultValues ?? { front: "", back: "" }}
+        submit={props.submit ?? submit}
+        submitLabel={props.submitLabel}
+        submitting={props.submitting}
+        error={props.error}
+        onCancel={props.onCancel}
+      />
+    </MockedProvider>,
+  );
+  return { submit };
+}
+
+describe("<CardForm>", () => {
+  it("renders front and back inputs with default values", () => {
+    renderForm({ defaultValues: { front: "Dog", back: "Perro" } });
+    expect(screen.getByDisplayValue("Dog")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("Perro")).toBeInTheDocument();
+  });
+
+  it("submitting empty front shows inline required error", async () => {
+    const user = userEvent.setup();
+    renderForm();
+
+    const frontInput = screen.getByLabelText(/front/i);
+    await user.click(frontInput);
+    await user.tab();
+
+    await waitFor(() => {
+      expect(screen.getByText("front is required")).toBeInTheDocument();
+    });
+  });
+
+  it("submitting empty back shows inline required error", async () => {
+    const user = userEvent.setup();
+    renderForm();
+
+    const backInput = screen.getByLabelText(/back/i);
+    await user.click(backInput);
+    await user.tab();
+
+    await waitFor(() => {
+      expect(screen.getByText("back is required")).toBeInTheDocument();
+    });
+  });
+
+  it("renders backend BAD_USER_INPUT field error under the front field", () => {
+    const gqlError = new GraphQLError("front already exists", {
+      extensions: { code: "BAD_USER_INPUT", field: "front" },
+    });
+    const combinedError = new CombinedGraphQLErrors({ errors: [gqlError] });
+
+    renderForm({ defaultValues: { front: "duplicate", back: "something" }, error: combinedError });
+
+    expect(screen.getByText("front already exists")).toBeInTheDocument();
+  });
+
+  it("renders generic banner for a plain network Error", () => {
+    const networkError = new Error("network down");
+    renderForm({ defaultValues: { front: "x", back: "y" }, error: networkError });
+
+    expect(screen.getByText("Could not reach the server. Please try again.")).toBeInTheDocument();
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+  });
+
+  it("uses mode-based default label: Add in create mode", () => {
+    renderForm({ mode: "create" });
+    expect(screen.getByRole("button", { name: /^add$/i })).toBeInTheDocument();
+  });
+
+  it("uses mode-based default label: Save in edit mode", () => {
+    renderForm({ mode: "edit", defaultValues: { front: "x", back: "y" } });
+    expect(screen.getByRole("button", { name: /^save$/i })).toBeInTheDocument();
+  });
+
+  it("calls submit with front and back values", async () => {
+    const user = userEvent.setup();
+    const submit = vi.fn().mockResolvedValue(undefined);
+    renderForm({ defaultValues: { front: "Cat", back: "Gato" }, submit });
+
+    await user.click(screen.getByRole("button", { name: /^add$/i }));
+
+    await waitFor(() => {
+      expect(submit).toHaveBeenCalledWith({ front: "Cat", back: "Gato" });
+    });
+  });
+
+  it("renders Cancel button when onCancel is provided", () => {
+    const onCancel = vi.fn();
+    renderForm({ onCancel });
+    expect(screen.getByRole("button", { name: /cancel/i })).toBeInTheDocument();
+  });
+
+  it("calls onCancel when Cancel button is clicked", async () => {
+    const user = userEvent.setup();
+    const onCancel = vi.fn();
+    renderForm({ onCancel });
+
+    await user.click(screen.getByRole("button", { name: /cancel/i }));
+    expect(onCancel).toHaveBeenCalledOnce();
+  });
+
+  it("disables submit button when submitting=true", () => {
+    renderForm({ submitting: true });
+    const btn = screen.getByRole("button", { name: /saving/i });
+    expect(btn).toBeDisabled();
+  });
+});

--- a/frontend/src/components/cardgroups/card-form.test.tsx
+++ b/frontend/src/components/cardgroups/card-form.test.tsx
@@ -13,7 +13,6 @@ function renderForm(props: Partial<Parameters<typeof CardForm>[0]> = {}) {
     <MockedProvider mocks={[]}>
       <CardForm
         mode={props.mode ?? "create"}
-        cardgroupId={props.cardgroupId ?? "cg-1"}
         defaultValues={props.defaultValues ?? { front: "", back: "" }}
         submit={props.submit ?? submit}
         submitLabel={props.submitLabel}

--- a/frontend/src/components/cardgroups/card-form.tsx
+++ b/frontend/src/components/cardgroups/card-form.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-// Shared inline form for both "add card" and "edit card" modes.
-// Create mode uses newCardSchema (front+back); edit mode uses updateCardSchema (front+back).
 // cardgroupId injection happens in the parent's submit callback, not inside this component.
 
 import { useForm } from "@tanstack/react-form";
@@ -10,20 +8,8 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { getBackendErrorBanner, getBackendFieldErrors } from "@/lib/apollo/errors";
-import { cn } from "@/lib/utils";
+import { FieldError } from "@/lib/forms/field-error";
 import { newCardSchema, updateCardSchema } from "@/schemas/card";
-
-function hasMessage(value: unknown): value is { message: string } {
-  return typeof (value as { message?: unknown })?.message === "string";
-}
-
-type FieldErrorProps = { zodErrors: unknown[]; backendError?: string };
-
-function FieldError({ zodErrors, backendError }: FieldErrorProps) {
-  const msg = zodErrors.find(hasMessage)?.message ?? backendError;
-  if (!msg) return null;
-  return <p className="text-sm text-destructive">{msg}</p>;
-}
 
 type Mode = "create" | "edit";
 
@@ -73,7 +59,7 @@ export function CardForm({
         e.stopPropagation();
         void form.handleSubmit();
       }}
-      className={cn("space-y-3")}
+      className="space-y-3"
     >
       {bannerError ? (
         <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive" role="alert">

--- a/frontend/src/components/cardgroups/card-form.tsx
+++ b/frontend/src/components/cardgroups/card-form.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 // Shared inline form for both "add card" and "edit card" modes.
-// Create mode uses newCardSchema (front+back+cardgroupId); edit mode uses updateCardSchema (front+back).
-// cardgroupId is supplied as a prop and injected at submit time to keep the form fields consistent.
+// Create mode uses newCardSchema (front+back); edit mode uses updateCardSchema (front+back).
+// cardgroupId injection happens in the parent's submit callback, not inside this component.
 
 import { useForm } from "@tanstack/react-form";
 import { useMemo } from "react";
@@ -30,8 +30,6 @@ type Mode = "create" | "edit";
 export type CardFormProps = {
   mode: Mode;
   defaultValues: { front: string; back: string };
-  /** Required in create mode; ignored in edit mode (cardgroupId not part of update). */
-  cardgroupId?: string;
   /** Optional prefix for input element IDs; useful when multiple CardForms are on the page. */
   idPrefix?: string;
   submit: (values: { front: string; back: string }) => Promise<void>;

--- a/frontend/src/components/cardgroups/card-form.tsx
+++ b/frontend/src/components/cardgroups/card-form.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+// Shared inline form for both "add card" and "edit card" modes.
+// Create mode uses newCardSchema (front+back+cardgroupId); edit mode uses updateCardSchema (front+back).
+// cardgroupId is supplied as a prop and injected at submit time to keep the form fields consistent.
+
+import { useForm } from "@tanstack/react-form";
+import { useMemo } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { getBackendErrorBanner, getBackendFieldErrors } from "@/lib/apollo/errors";
+import { cn } from "@/lib/utils";
+import { newCardSchema, updateCardSchema } from "@/schemas/card";
+
+function hasMessage(value: unknown): value is { message: string } {
+  return typeof (value as { message?: unknown })?.message === "string";
+}
+
+type FieldErrorProps = { zodErrors: unknown[]; backendError?: string };
+
+function FieldError({ zodErrors, backendError }: FieldErrorProps) {
+  const msg = zodErrors.find(hasMessage)?.message ?? backendError;
+  if (!msg) return null;
+  return <p className="text-sm text-destructive">{msg}</p>;
+}
+
+type Mode = "create" | "edit";
+
+export type CardFormProps = {
+  mode: Mode;
+  defaultValues: { front: string; back: string };
+  /** Required in create mode; ignored in edit mode (cardgroupId not part of update). */
+  cardgroupId?: string;
+  /** Optional prefix for input element IDs; useful when multiple CardForms are on the page. */
+  idPrefix?: string;
+  submit: (values: { front: string; back: string }) => Promise<void>;
+  submitLabel?: string;
+  submitting?: boolean;
+  error?: unknown;
+  onCancel?: () => void;
+};
+
+export function CardForm({
+  mode,
+  defaultValues,
+  idPrefix = "",
+  submit,
+  submitLabel,
+  submitting = false,
+  error,
+  onCancel,
+}: CardFormProps) {
+  const resolvedLabel = submitLabel ?? (mode === "create" ? "Add" : "Save");
+  const schema = mode === "create" ? newCardSchema.omit({ cardgroupId: true }) : updateCardSchema;
+  const frontSchema = schema.shape.front;
+  const backSchema = schema.shape.back;
+
+  const fieldErrors = useMemo(() => getBackendFieldErrors(error), [error]);
+  const bannerError = useMemo(() => getBackendErrorBanner(error), [error]);
+
+  const form = useForm({
+    defaultValues: { front: defaultValues.front, back: defaultValues.back },
+    onSubmit: async ({ value }) => {
+      await submit(value).catch((err) => {
+        console.error("[card-form] submit rejected", err);
+      });
+    },
+  });
+
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        void form.handleSubmit();
+      }}
+      className={cn("space-y-3")}
+    >
+      {bannerError ? (
+        <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive" role="alert">
+          {bannerError}
+        </div>
+      ) : null}
+
+      <form.Field name="front" validators={{ onChange: frontSchema, onBlur: frontSchema }}>
+        {(field) => {
+          const inputId = `${idPrefix}${field.name}-field`;
+          return (
+            <div className="space-y-1">
+              <Label htmlFor={inputId}>Front</Label>
+              <Input
+                id={inputId}
+                name={field.name}
+                value={field.state.value}
+                onBlur={field.handleBlur}
+                onChange={(e) => field.handleChange(e.target.value)}
+              />
+              <FieldError zodErrors={field.state.meta.errors} backendError={fieldErrors.front} />
+            </div>
+          );
+        }}
+      </form.Field>
+
+      <form.Field name="back" validators={{ onChange: backSchema, onBlur: backSchema }}>
+        {(field) => {
+          const inputId = `${idPrefix}${field.name}-field`;
+          return (
+            <div className="space-y-1">
+              <Label htmlFor={inputId}>Back</Label>
+              <Input
+                id={inputId}
+                name={field.name}
+                value={field.state.value}
+                onBlur={field.handleBlur}
+                onChange={(e) => field.handleChange(e.target.value)}
+              />
+              <FieldError zodErrors={field.state.meta.errors} backendError={fieldErrors.back} />
+            </div>
+          );
+        }}
+      </form.Field>
+
+      <div className="flex items-center gap-2">
+        <Button type="submit" disabled={submitting}>
+          {submitting ? "Saving..." : resolvedLabel}
+        </Button>
+        {onCancel && (
+          <Button type="button" variant="outline" onClick={onCancel}>
+            Cancel
+          </Button>
+        )}
+      </div>
+    </form>
+  );
+}

--- a/frontend/src/components/cardgroups/cardgroup-form.test.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-form.test.tsx
@@ -1,0 +1,134 @@
+// @vitest-environment jsdom
+import { CombinedGraphQLErrors } from "@apollo/client/errors";
+import { MockedProvider } from "@apollo/client/testing/react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { GraphQLError } from "graphql";
+import { describe, expect, it, vi } from "vitest";
+import { CardgroupForm } from "./cardgroup-form";
+
+// Wrap with MockedProvider to mirror the profile-form.test.tsx recipe.
+// The form itself does not run a mutation, but the parent's submit might.
+function renderForm(props: Partial<Parameters<typeof CardgroupForm>[0]> = {}) {
+  const submit = vi.fn().mockResolvedValue(undefined);
+  render(
+    <MockedProvider mocks={[]}>
+      <CardgroupForm
+        mode={props.mode ?? "create"}
+        defaultValues={props.defaultValues ?? { name: "" }}
+        submit={props.submit ?? submit}
+        submitLabel={props.submitLabel}
+        submitting={props.submitting}
+        error={props.error}
+        secondarySlot={props.secondarySlot}
+      />
+    </MockedProvider>,
+  );
+  return { submit };
+}
+
+describe("<CardgroupForm>", () => {
+  it("shows name input populated with defaultValues.name", () => {
+    renderForm({ defaultValues: { name: "My Group" } });
+    expect(screen.getByDisplayValue("My Group")).toBeInTheDocument();
+  });
+
+  it("shows empty input when defaultValues.name is empty", () => {
+    renderForm({ defaultValues: { name: "" } });
+    const input = screen.getByRole("textbox");
+    expect(input).toHaveValue("");
+  });
+
+  it("submitting empty name shows inline required error", async () => {
+    const user = userEvent.setup();
+    renderForm({ defaultValues: { name: "" } });
+
+    const input = screen.getByRole("textbox");
+    await user.click(input);
+    await user.tab();
+
+    await waitFor(() => {
+      expect(screen.getByText("name is required")).toBeInTheDocument();
+    });
+  });
+
+  it("submitting a name with more than 100 graphemes shows length error", async () => {
+    const user = userEvent.setup();
+    renderForm({ defaultValues: { name: "" } });
+
+    const input = screen.getByRole("textbox");
+    await user.click(input);
+    await user.paste("x".repeat(101));
+    await user.tab();
+
+    await waitFor(() => {
+      expect(screen.getByText("name must be at most 100 characters")).toBeInTheDocument();
+    });
+  });
+
+  it("renders backend BAD_USER_INPUT field error under the name field", () => {
+    // Build a CombinedGraphQLErrors that carries a BAD_USER_INPUT with field:"name".
+    const gqlError = new GraphQLError("name already exists", {
+      extensions: { code: "BAD_USER_INPUT", field: "name" },
+    });
+    // CombinedGraphQLErrors wraps an array of GraphQLErrors.
+    const combinedError = new CombinedGraphQLErrors({ errors: [gqlError] });
+
+    renderForm({ defaultValues: { name: "duplicate" }, error: combinedError });
+
+    expect(screen.getByText("name already exists")).toBeInTheDocument();
+    const errorEl = screen.getByText("name already exists");
+    expect(errorEl.className).toMatch(/text-destructive/);
+  });
+
+  it("renders generic banner for a plain network Error (non-CombinedGraphQLErrors)", () => {
+    const networkError = new Error("network down");
+    renderForm({ defaultValues: { name: "anything" }, error: networkError });
+
+    expect(screen.getByText("Could not reach the server. Please try again.")).toBeInTheDocument();
+    const banner = screen.getByRole("alert");
+    expect(banner).toBeInTheDocument();
+  });
+
+  it("uses mode-based default label: Create in create mode", () => {
+    renderForm({ mode: "create" });
+    expect(screen.getByRole("button", { name: /create/i })).toBeInTheDocument();
+  });
+
+  it("uses mode-based default label: Save in edit mode", () => {
+    renderForm({ mode: "edit", defaultValues: { name: "Existing" } });
+    expect(screen.getByRole("button", { name: /save/i })).toBeInTheDocument();
+  });
+
+  it("uses custom submitLabel when provided", () => {
+    renderForm({ mode: "create", submitLabel: "Add Group" });
+    expect(screen.getByRole("button", { name: /add group/i })).toBeInTheDocument();
+  });
+
+  it("calls submit with the current name value", async () => {
+    const user = userEvent.setup();
+    const submit = vi.fn().mockResolvedValue(undefined);
+    renderForm({ mode: "create", defaultValues: { name: "Hello" }, submit });
+
+    await user.click(screen.getByRole("button", { name: /create/i }));
+
+    await waitFor(() => {
+      expect(submit).toHaveBeenCalledWith({ name: "Hello" });
+    });
+  });
+
+  it("renders secondarySlot next to the submit button", () => {
+    renderForm({
+      mode: "edit",
+      defaultValues: { name: "Group" },
+      secondarySlot: <button type="button">Delete</button>,
+    });
+    expect(screen.getByRole("button", { name: /delete/i })).toBeInTheDocument();
+  });
+
+  it("disables submit button when submitting=true", () => {
+    renderForm({ mode: "edit", defaultValues: { name: "Group" }, submitting: true });
+    const btn = screen.getByRole("button", { name: /saving/i });
+    expect(btn).toBeDisabled();
+  });
+});

--- a/frontend/src/components/cardgroups/cardgroup-form.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-form.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { useForm } from "@tanstack/react-form";
+import type React from "react";
+import { useMemo } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { getBackendErrorBanner, getBackendFieldErrors } from "@/lib/apollo/errors";
+import { cn } from "@/lib/utils";
+import { newCardgroupSchema, updateCardgroupSchema } from "@/schemas/cardgroup";
+
+// ---- local helpers ----
+
+function hasMessage(value: unknown): value is { message: string } {
+  return typeof (value as { message?: unknown })?.message === "string";
+}
+
+type FieldErrorProps = { zodErrors: unknown[]; backendError?: string };
+
+function FieldError({ zodErrors, backendError }: FieldErrorProps) {
+  const msg = zodErrors.find(hasMessage)?.message ?? backendError;
+  if (!msg) return null;
+  return <p className="text-sm text-destructive">{msg}</p>;
+}
+
+// ---- component types ----
+
+type Mode = "create" | "edit";
+
+type CardgroupFormProps = {
+  mode: Mode;
+  defaultValues: { name: string };
+  submit: (values: { name: string }) => Promise<void>;
+  /** Defaults to "Create" in create mode, "Save" in edit mode. */
+  submitLabel?: string;
+  /** Parent passes Apollo mutation `loading` state. */
+  submitting?: boolean;
+  /** Parent passes Apollo mutation `error` for triage. */
+  error?: unknown;
+  /** Extra controls rendered next to the submit button (e.g. Delete button on Edit page). */
+  secondarySlot?: React.ReactNode;
+};
+
+// ---- component ----
+
+export function CardgroupForm({
+  mode,
+  defaultValues,
+  submit,
+  submitLabel,
+  submitting = false,
+  error,
+  secondarySlot,
+}: CardgroupFormProps) {
+  const resolvedLabel = submitLabel ?? (mode === "create" ? "Create" : "Save");
+
+  const schema = mode === "create" ? newCardgroupSchema : updateCardgroupSchema;
+  const nameSchema = schema.shape.name;
+
+  const fieldErrors = useMemo(() => getBackendFieldErrors(error), [error]);
+  const bannerError = useMemo(() => getBackendErrorBanner(error), [error]);
+
+  const form = useForm({
+    defaultValues: {
+      name: defaultValues.name,
+    },
+    onSubmit: async ({ value }) => {
+      await submit(value).catch((err) => {
+        console.error("[cardgroup-form] submit rejected", err);
+      });
+    },
+  });
+
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        void form.handleSubmit();
+      }}
+      className={cn("space-y-4")}
+    >
+      {bannerError ? (
+        <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive" role="alert">
+          {bannerError}
+        </div>
+      ) : null}
+
+      <form.Field name="name" validators={{ onChange: nameSchema, onBlur: nameSchema }}>
+        {(field) => (
+          <div className="space-y-2">
+            <Label htmlFor={field.name}>Name</Label>
+            <Input
+              id={field.name}
+              name={field.name}
+              value={field.state.value}
+              onBlur={field.handleBlur}
+              onChange={(e) => field.handleChange(e.target.value)}
+            />
+            <FieldError zodErrors={field.state.meta.errors} backendError={fieldErrors.name} />
+          </div>
+        )}
+      </form.Field>
+
+      <div className="flex items-center gap-2">
+        <Button type="submit" disabled={submitting}>
+          {submitting ? "Saving..." : resolvedLabel}
+        </Button>
+        {secondarySlot}
+      </div>
+    </form>
+  );
+}

--- a/frontend/src/components/cardgroups/cardgroup-form.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-form.tsx
@@ -7,24 +7,8 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { getBackendErrorBanner, getBackendFieldErrors } from "@/lib/apollo/errors";
-import { cn } from "@/lib/utils";
+import { FieldError } from "@/lib/forms/field-error";
 import { newCardgroupSchema, updateCardgroupSchema } from "@/schemas/cardgroup";
-
-// ---- local helpers ----
-
-function hasMessage(value: unknown): value is { message: string } {
-  return typeof (value as { message?: unknown })?.message === "string";
-}
-
-type FieldErrorProps = { zodErrors: unknown[]; backendError?: string };
-
-function FieldError({ zodErrors, backendError }: FieldErrorProps) {
-  const msg = zodErrors.find(hasMessage)?.message ?? backendError;
-  if (!msg) return null;
-  return <p className="text-sm text-destructive">{msg}</p>;
-}
-
-// ---- component types ----
 
 type Mode = "create" | "edit";
 
@@ -41,8 +25,6 @@ type CardgroupFormProps = {
   /** Extra controls rendered next to the submit button (e.g. Delete button on Edit page). */
   secondarySlot?: React.ReactNode;
 };
-
-// ---- component ----
 
 export function CardgroupForm({
   mode,
@@ -79,7 +61,7 @@ export function CardgroupForm({
         e.stopPropagation();
         void form.handleSubmit();
       }}
-      className={cn("space-y-4")}
+      className="space-y-4"
     >
       {bannerError ? (
         <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive" role="alert">

--- a/frontend/src/components/cardgroups/cardgroup-list-item.test.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-list-item.test.tsx
@@ -1,0 +1,26 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { CardgroupListItem } from "./cardgroup-list-item";
+
+describe("<CardgroupListItem>", () => {
+  const fixedDate = "2024-06-15T10:00:00.000Z";
+
+  it("renders the cardgroup name", () => {
+    render(<CardgroupListItem id="cg-1" name="My Flashcards" updatedAt={fixedDate} />);
+    expect(screen.getByText("My Flashcards")).toBeInTheDocument();
+  });
+
+  it("renders a link to /cardgroups/[id]", () => {
+    render(<CardgroupListItem id="cg-1" name="My Flashcards" updatedAt={fixedDate} />);
+    const link = screen.getByRole("link");
+    expect(link).toHaveAttribute("href", "/cardgroups/cg-1");
+  });
+
+  it("renders formatted date text", () => {
+    render(<CardgroupListItem id="cg-1" name="My Flashcards" updatedAt={fixedDate} />);
+    // Intl.DateTimeFormat en-US medium: "Jun 15, 2024"
+    expect(screen.getByText(/Updated/)).toBeInTheDocument();
+    expect(screen.getByText(/Jun 15, 2024/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/cardgroups/cardgroup-list-item.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-list-item.tsx
@@ -1,0 +1,25 @@
+import Link from "next/link";
+
+export type CardgroupListItemProps = {
+  id: string;
+  name: string;
+  updatedAt: string;
+};
+
+function formatDate(iso: string): string {
+  return new Intl.DateTimeFormat("en-US", { dateStyle: "medium" }).format(new Date(iso));
+}
+
+export function CardgroupListItem({ id, name, updatedAt }: CardgroupListItemProps) {
+  return (
+    <li>
+      <Link
+        href={`/cardgroups/${id}`}
+        className="flex flex-col gap-1 rounded-lg border border-border p-4 hover:bg-accent transition-colors"
+      >
+        <span className="font-medium text-foreground">{name}</span>
+        <span className="text-sm text-muted-foreground">Updated {formatDate(updatedAt)}</span>
+      </Link>
+    </li>
+  );
+}

--- a/frontend/src/components/cardgroups/cardgroup-list-item.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-list-item.tsx
@@ -1,14 +1,11 @@
 import Link from "next/link";
+import { formatMediumDate } from "@/lib/format";
 
 export type CardgroupListItemProps = {
   id: string;
   name: string;
   updatedAt: string;
 };
-
-function formatDate(iso: string): string {
-  return new Intl.DateTimeFormat("en-US", { dateStyle: "medium" }).format(new Date(iso));
-}
 
 export function CardgroupListItem({ id, name, updatedAt }: CardgroupListItemProps) {
   return (
@@ -18,7 +15,7 @@ export function CardgroupListItem({ id, name, updatedAt }: CardgroupListItemProp
         className="flex flex-col gap-1 rounded-lg border border-border p-4 hover:bg-accent transition-colors"
       >
         <span className="font-medium text-foreground">{name}</span>
-        <span className="text-sm text-muted-foreground">Updated {formatDate(updatedAt)}</span>
+        <span className="text-sm text-muted-foreground">Updated {formatMediumDate(updatedAt)}</span>
       </Link>
     </li>
   );

--- a/frontend/src/components/ui/alert-dialog.tsx
+++ b/frontend/src/components/ui/alert-dialog.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog";
+import * as React from "react";
+import { buttonVariants } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+const AlertDialog = AlertDialogPrimitive.Root;
+
+const AlertDialogTrigger = AlertDialogPrimitive.Trigger;
+
+const AlertDialogPortal = AlertDialogPrimitive.Portal;
+
+const AlertDialogOverlay = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Overlay
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className,
+    )}
+    {...props}
+    ref={ref}
+  />
+));
+AlertDialogOverlay.displayName = AlertDialogPrimitive.Overlay.displayName;
+
+const AlertDialogContent = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPortal>
+    <AlertDialogOverlay />
+    <AlertDialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        className,
+      )}
+      {...props}
+    />
+  </AlertDialogPortal>
+));
+AlertDialogContent.displayName = AlertDialogPrimitive.Content.displayName;
+
+const AlertDialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn("flex flex-col space-y-2 text-center sm:text-left", className)} {...props} />
+);
+AlertDialogHeader.displayName = "AlertDialogHeader";
+
+const AlertDialogFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn("flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2", className)}
+    {...props}
+  />
+);
+AlertDialogFooter.displayName = "AlertDialogFooter";
+
+const AlertDialogTitle = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold", className)}
+    {...props}
+  />
+));
+AlertDialogTitle.displayName = AlertDialogPrimitive.Title.displayName;
+
+const AlertDialogDescription = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+));
+AlertDialogDescription.displayName = AlertDialogPrimitive.Description.displayName;
+
+const AlertDialogAction = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Action>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Action>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Action ref={ref} className={cn(buttonVariants(), className)} {...props} />
+));
+AlertDialogAction.displayName = AlertDialogPrimitive.Action.displayName;
+
+const AlertDialogCancel = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Cancel>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Cancel>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Cancel
+    ref={ref}
+    className={cn(buttonVariants({ variant: "outline" }), "mt-2 sm:mt-0", className)}
+    {...props}
+  />
+));
+AlertDialogCancel.displayName = AlertDialogPrimitive.Cancel.displayName;
+
+export {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogOverlay,
+  AlertDialogPortal,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+};

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { X } from "lucide-react";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const Dialog = DialogPrimitive.Root;
+
+const DialogTrigger = DialogPrimitive.Trigger;
+
+const DialogPortal = DialogPrimitive.Portal;
+
+const DialogClose = DialogPrimitive.Close;
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className,
+    )}
+    {...props}
+  />
+));
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+));
+DialogContent.displayName = DialogPrimitive.Content.displayName;
+
+const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn("flex flex-col space-y-1.5 text-center sm:text-left", className)} {...props} />
+);
+DialogHeader.displayName = "DialogHeader";
+
+const DialogFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn("flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2", className)}
+    {...props}
+  />
+);
+DialogFooter.displayName = "DialogFooter";
+
+const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold leading-none tracking-tight", className)}
+    {...props}
+  />
+));
+DialogTitle.displayName = DialogPrimitive.Title.displayName;
+
+const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+));
+DialogDescription.displayName = DialogPrimitive.Description.displayName;
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+};

--- a/frontend/src/lib/apollo/errors.test.ts
+++ b/frontend/src/lib/apollo/errors.test.ts
@@ -124,4 +124,36 @@ describe("getBackendErrorBanner", () => {
     ]);
     expect(getBackendErrorBanner(err)).toBe("Unexpected server failure");
   });
+
+  it("INTERNAL takes priority over UNAUTHENTICATED when UNAUTHENTICATED appears first", () => {
+    const err = makeCombinedError([
+      { message: "Not authenticated", extensions: { code: "UNAUTHENTICATED" } },
+      { message: "Internal server error", extensions: { code: "INTERNAL" } },
+    ]);
+    expect(getBackendErrorBanner(err)).toBe("Internal server error");
+  });
+
+  it("returns INTERNAL banner and field map when BAD_USER_INPUT(field) and INTERNAL coexist", () => {
+    const err = makeCombinedError([
+      {
+        message: "Name is required",
+        extensions: { code: "BAD_USER_INPUT", field: "name" },
+      },
+      { message: "Internal server error", extensions: { code: "INTERNAL" } },
+    ]);
+    expect(getBackendErrorBanner(err)).toBe("Internal server error");
+    expect(getBackendFieldErrors(err)).toEqual({ name: "Name is required" });
+  });
+
+  it("returns UNAUTHENTICATED banner and field map when BAD_USER_INPUT(field) and UNAUTHENTICATED coexist", () => {
+    const err = makeCombinedError([
+      { message: "Not authenticated", extensions: { code: "UNAUTHENTICATED" } },
+      {
+        message: "Name is required",
+        extensions: { code: "BAD_USER_INPUT", field: "name" },
+      },
+    ]);
+    expect(getBackendErrorBanner(err)).toBe("Your session expired. Please sign in again.");
+    expect(getBackendFieldErrors(err)).toEqual({ name: "Name is required" });
+  });
 });

--- a/frontend/src/lib/apollo/errors.test.ts
+++ b/frontend/src/lib/apollo/errors.test.ts
@@ -1,0 +1,127 @@
+import { CombinedGraphQLErrors } from "@apollo/client/errors";
+import { describe, expect, it } from "vitest";
+import { getBackendErrorBanner, getBackendFieldErrors } from "./errors";
+
+/** Build a CombinedGraphQLErrors from a plain errors array. */
+function makeCombinedError(
+  errors: Array<{
+    message: string;
+    extensions?: Record<string, unknown>;
+  }>,
+): CombinedGraphQLErrors {
+  return new CombinedGraphQLErrors({ errors });
+}
+
+const NETWORK_MESSAGE = "Could not reach the server. Please try again.";
+
+describe("getBackendFieldErrors", () => {
+  it("returns empty map for a non-CombinedGraphQLErrors network error", () => {
+    const err = new Error("Network request failed");
+    expect(getBackendFieldErrors(err)).toEqual({});
+  });
+
+  it("returns field map for BAD_USER_INPUT with a field extension", () => {
+    const err = makeCombinedError([
+      {
+        message: "Display name is too short",
+        extensions: { code: "BAD_USER_INPUT", field: "displayName" },
+      },
+    ]);
+    expect(getBackendFieldErrors(err)).toEqual({
+      displayName: "Display name is too short",
+    });
+  });
+
+  it("returns empty map for BAD_USER_INPUT without a field extension", () => {
+    const err = makeCombinedError([
+      {
+        message: "Invalid input",
+        extensions: { code: "BAD_USER_INPUT" },
+      },
+    ]);
+    expect(getBackendFieldErrors(err)).toEqual({});
+  });
+
+  it("returns empty map for UNAUTHENTICATED errors", () => {
+    const err = makeCombinedError([
+      { message: "Session expired", extensions: { code: "UNAUTHENTICATED" } },
+    ]);
+    expect(getBackendFieldErrors(err)).toEqual({});
+  });
+
+  it("returns empty map for INTERNAL errors", () => {
+    const err = makeCombinedError([
+      { message: "Something went wrong", extensions: { code: "INTERNAL" } },
+    ]);
+    expect(getBackendFieldErrors(err)).toEqual({});
+  });
+
+  it("returns only field errors from a mix of field and INTERNAL errors", () => {
+    const err = makeCombinedError([
+      {
+        message: "Bio is too long",
+        extensions: { code: "BAD_USER_INPUT", field: "bio" },
+      },
+      { message: "Something went wrong", extensions: { code: "INTERNAL" } },
+    ]);
+    expect(getBackendFieldErrors(err)).toEqual({ bio: "Bio is too long" });
+  });
+});
+
+describe("getBackendErrorBanner", () => {
+  it("returns undefined for a falsy error", () => {
+    expect(getBackendErrorBanner(undefined)).toBeUndefined();
+    expect(getBackendErrorBanner(null)).toBeUndefined();
+  });
+
+  it("returns generic network message for a non-CombinedGraphQLErrors error", () => {
+    const err = new Error("Network request failed");
+    expect(getBackendErrorBanner(err)).toBe(NETWORK_MESSAGE);
+  });
+
+  it("returns undefined when all errors are field-level BAD_USER_INPUT", () => {
+    const err = makeCombinedError([
+      {
+        message: "Display name is required",
+        extensions: { code: "BAD_USER_INPUT", field: "displayName" },
+      },
+    ]);
+    expect(getBackendErrorBanner(err)).toBeUndefined();
+  });
+
+  it("returns the message for BAD_USER_INPUT without a field extension", () => {
+    const err = makeCombinedError([
+      {
+        message: "Invalid input provided",
+        extensions: { code: "BAD_USER_INPUT" },
+      },
+    ]);
+    expect(getBackendErrorBanner(err)).toBe("Invalid input provided");
+  });
+
+  it("returns the session-expired message for UNAUTHENTICATED", () => {
+    const err = makeCombinedError([
+      { message: "Not authenticated", extensions: { code: "UNAUTHENTICATED" } },
+    ]);
+    expect(getBackendErrorBanner(err)).toBe("Your session expired. Please sign in again.");
+  });
+
+  it("INTERNAL takes priority over UNAUTHENTICATED when INTERNAL appears first", () => {
+    const err = makeCombinedError([
+      { message: "Internal server error", extensions: { code: "INTERNAL" } },
+      { message: "Not authenticated", extensions: { code: "UNAUTHENTICATED" } },
+    ]);
+    expect(getBackendErrorBanner(err)).toBe("Internal server error");
+  });
+
+  it("returns INTERNAL message from a mix of field error and INTERNAL", () => {
+    const err = makeCombinedError([
+      {
+        message: "Bio is too long",
+        extensions: { code: "BAD_USER_INPUT", field: "bio" },
+      },
+      { message: "Unexpected server failure", extensions: { code: "INTERNAL" } },
+    ]);
+    expect(getBackendErrorBanner(err)).toBe("Unexpected server failure");
+  });
+});

--- a/frontend/src/lib/apollo/errors.ts
+++ b/frontend/src/lib/apollo/errors.ts
@@ -43,14 +43,21 @@ export function getBackendFieldErrors(err: unknown): Record<string, string> {
 export function getBackendErrorBanner(err: unknown): string | undefined {
   if (!err) return undefined;
   if (!CombinedGraphQLErrors.is(err)) return NETWORK_ERROR;
-  let firstNonField: string | undefined;
+  let internalMsg: string | undefined;
+  let authMsg: string | undefined;
+  let firstNonFieldMsg: string | undefined;
   for (const ge of err.errors) {
     const code = extensionString(ge.extensions, "code");
     const field = extensionString(ge.extensions, "field");
-    if (code === "INTERNAL") return ge.message;
-    if (code === "UNAUTHENTICATED") return "Your session expired. Please sign in again.";
-    if (code === "BAD_USER_INPUT" && field) continue;
-    firstNonField ??= ge.message;
+    if (code === "INTERNAL") {
+      internalMsg ??= ge.message;
+    } else if (code === "UNAUTHENTICATED") {
+      authMsg ??= "Your session expired. Please sign in again.";
+    } else if (code === "BAD_USER_INPUT" && field) {
+      // field-level error — skip for banner
+    } else {
+      firstNonFieldMsg ??= ge.message;
+    }
   }
-  return firstNonField;
+  return internalMsg ?? authMsg ?? firstNonFieldMsg;
 }

--- a/frontend/src/lib/apollo/errors.ts
+++ b/frontend/src/lib/apollo/errors.ts
@@ -1,0 +1,56 @@
+/**
+ * Pure Apollo/GraphQL error-parsing helpers shared across forms.
+ *
+ * Contract:
+ *  - getBackendFieldErrors:  BAD_USER_INPUT errors that carry a "field" extension
+ *    are returned as { fieldName: message }.  All other errors are ignored.
+ *  - getBackendErrorBanner:  Returns a user-facing banner string for non-field
+ *    errors.  Priority: INTERNAL > UNAUTHENTICATED > first non-field GQL error.
+ *    Network / non-CombinedGraphQLErrors → generic network message.
+ */
+
+import { CombinedGraphQLErrors } from "@apollo/client/errors";
+
+const NETWORK_ERROR = "Could not reach the server. Please try again.";
+
+function extensionString(
+  extensions: Record<string, unknown> | undefined,
+  key: string,
+): string | undefined {
+  const value = extensions?.[key];
+  return typeof value === "string" ? value : undefined;
+}
+
+/** Returns a map of field name to error message for BAD_USER_INPUT errors. */
+export function getBackendFieldErrors(err: unknown): Record<string, string> {
+  if (!CombinedGraphQLErrors.is(err)) return {};
+  const out: Record<string, string> = {};
+  for (const ge of err.errors) {
+    const code = extensionString(ge.extensions, "code");
+    const field = extensionString(ge.extensions, "field");
+    if (code === "BAD_USER_INPUT" && field) {
+      out[field] = ge.message;
+    }
+  }
+  return out;
+}
+
+/**
+ * Returns a user-facing banner message for non-field errors.
+ * Priority: INTERNAL > UNAUTHENTICATED > first non-field GQL error > network error.
+ * Returns undefined when every error is a field-level BAD_USER_INPUT.
+ */
+export function getBackendErrorBanner(err: unknown): string | undefined {
+  if (!err) return undefined;
+  if (!CombinedGraphQLErrors.is(err)) return NETWORK_ERROR;
+  let firstNonField: string | undefined;
+  for (const ge of err.errors) {
+    const code = extensionString(ge.extensions, "code");
+    const field = extensionString(ge.extensions, "field");
+    if (code === "INTERNAL") return ge.message;
+    if (code === "UNAUTHENTICATED") return "Your session expired. Please sign in again.";
+    if (code === "BAD_USER_INPUT" && field) continue;
+    firstNonField ??= ge.message;
+  }
+  return firstNonField;
+}

--- a/frontend/src/lib/apollo/server-redirect.ts
+++ b/frontend/src/lib/apollo/server-redirect.ts
@@ -1,0 +1,15 @@
+import "server-only";
+import { redirect } from "next/navigation";
+
+/**
+ * If `err` carries an UNAUTHENTICATED GraphQL code, redirect to `target`.
+ * Otherwise rethrow `err` so the error boundary handles it.
+ *
+ * Returns `never`: it always throws (either via `redirect()` or rethrow).
+ * Intended for use inside RSC `catch` blocks around `gqlFetch` calls.
+ */
+export function redirectIfUnauthenticated(err: unknown, target: string): never {
+  const msg = err instanceof Error ? err.message : String(err);
+  if (msg.includes("UNAUTHENTICATED")) redirect(target);
+  throw err;
+}

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -1,0 +1,5 @@
+const MEDIUM_DATE = new Intl.DateTimeFormat("en-US", { dateStyle: "medium" });
+
+export function formatMediumDate(iso: string): string {
+  return MEDIUM_DATE.format(new Date(iso));
+}

--- a/frontend/src/lib/forms/field-error.tsx
+++ b/frontend/src/lib/forms/field-error.tsx
@@ -1,0 +1,11 @@
+function hasMessage(value: unknown): value is { message: string } {
+  return typeof (value as { message?: unknown })?.message === "string";
+}
+
+type FieldErrorProps = { zodErrors: unknown[]; backendError?: string };
+
+export function FieldError({ zodErrors, backendError }: FieldErrorProps) {
+  const msg = zodErrors.find(hasMessage)?.message ?? backendError;
+  if (!msg) return null;
+  return <p className="text-sm text-destructive">{msg}</p>;
+}

--- a/frontend/src/schemas/card.test.ts
+++ b/frontend/src/schemas/card.test.ts
@@ -1,0 +1,241 @@
+import { describe, expect, it } from "vitest";
+import { newCardSchema, updateCardSchema } from "./card";
+
+describe("newCardSchema", () => {
+  it("accepts a valid card", () => {
+    const result = newCardSchema.safeParse({
+      cardgroupId: "group-1",
+      front: "What is 2 + 2?",
+      back: "4",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.front).toBe("What is 2 + 2?");
+      expect(result.data.back).toBe("4");
+      expect(result.data.cardgroupId).toBe("group-1");
+    }
+  });
+
+  it("trims surrounding whitespace from front and back", () => {
+    const result = newCardSchema.safeParse({
+      cardgroupId: "group-1",
+      front: "  question  ",
+      back: "  answer  ",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.front).toBe("question");
+      expect(result.data.back).toBe("answer");
+    }
+  });
+
+  it("rejects empty cardgroupId", () => {
+    const result = newCardSchema.safeParse({ cardgroupId: "", front: "q", back: "a" });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const messages = result.error.issues.map((i) => i.message);
+      expect(messages).toContain("cardgroupId is required");
+    }
+  });
+
+  it("rejects empty front", () => {
+    const result = newCardSchema.safeParse({ cardgroupId: "g1", front: "", back: "a" });
+    expect(result.success).toBe(false);
+    if (!result.success && result.error.issues[0]) {
+      expect(result.error.issues[0].message).toBe("front is required");
+    }
+  });
+
+  it("rejects all-whitespace front", () => {
+    const result = newCardSchema.safeParse({ cardgroupId: "g1", front: "   ", back: "a" });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const messages = result.error.issues.map((i) => i.message);
+      expect(messages).toContain("front is required");
+    }
+  });
+
+  it("rejects empty back", () => {
+    const result = newCardSchema.safeParse({ cardgroupId: "g1", front: "q", back: "" });
+    expect(result.success).toBe(false);
+    if (!result.success && result.error.issues[0]) {
+      expect(result.error.issues[0].message).toBe("back is required");
+    }
+  });
+
+  it("rejects all-whitespace back", () => {
+    const result = newCardSchema.safeParse({ cardgroupId: "g1", front: "q", back: "   " });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const messages = result.error.issues.map((i) => i.message);
+      expect(messages).toContain("back is required");
+    }
+  });
+
+  it("accepts exactly 500 graphemes for front", () => {
+    const result = newCardSchema.safeParse({
+      cardgroupId: "g1",
+      front: "x".repeat(500),
+      back: "a",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects 501 graphemes for front", () => {
+    const result = newCardSchema.safeParse({
+      cardgroupId: "g1",
+      front: "x".repeat(501),
+      back: "a",
+    });
+    expect(result.success).toBe(false);
+    if (!result.success && result.error.issues[0]) {
+      expect(result.error.issues[0].message).toBe("front must be at most 500 characters");
+    }
+  });
+
+  it("accepts exactly 500 graphemes for back", () => {
+    const result = newCardSchema.safeParse({
+      cardgroupId: "g1",
+      front: "q",
+      back: "x".repeat(500),
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects 501 graphemes for back", () => {
+    const result = newCardSchema.safeParse({
+      cardgroupId: "g1",
+      front: "q",
+      back: "x".repeat(501),
+    });
+    expect(result.success).toBe(false);
+    if (!result.success && result.error.issues[0]) {
+      expect(result.error.issues[0].message).toBe("back must be at most 500 characters");
+    }
+  });
+
+  it("counts ZWJ emoji as 1 grapheme for front (500 emoji = pass)", () => {
+    const result = newCardSchema.safeParse({
+      cardgroupId: "g1",
+      front: "👨‍👩‍👧‍👦".repeat(500),
+      back: "a",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("counts ZWJ emoji as 1 grapheme for front (501 emoji = fail)", () => {
+    const result = newCardSchema.safeParse({
+      cardgroupId: "g1",
+      front: "👨‍👩‍👧‍👦".repeat(501),
+      back: "a",
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const messages = result.error.issues.map((i) => i.message);
+      expect(messages).toContain("front must be at most 500 characters");
+    }
+  });
+
+  it("counts ZWJ emoji as 1 grapheme for back (500 emoji = pass)", () => {
+    const result = newCardSchema.safeParse({
+      cardgroupId: "g1",
+      front: "q",
+      back: "👨‍👩‍👧".repeat(500),
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("updateCardSchema", () => {
+  it("accepts valid front and back", () => {
+    const result = updateCardSchema.safeParse({ front: "updated q", back: "updated a" });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.front).toBe("updated q");
+      expect(result.data.back).toBe("updated a");
+    }
+  });
+
+  it("trims surrounding whitespace", () => {
+    const result = updateCardSchema.safeParse({ front: "  q  ", back: "  a  " });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.front).toBe("q");
+      expect(result.data.back).toBe("a");
+    }
+  });
+
+  it("rejects empty front", () => {
+    const result = updateCardSchema.safeParse({ front: "", back: "a" });
+    expect(result.success).toBe(false);
+    if (!result.success && result.error.issues[0]) {
+      expect(result.error.issues[0].message).toBe("front is required");
+    }
+  });
+
+  it("rejects all-whitespace front", () => {
+    const result = updateCardSchema.safeParse({ front: "   ", back: "a" });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const messages = result.error.issues.map((i) => i.message);
+      expect(messages).toContain("front is required");
+    }
+  });
+
+  it("rejects empty back", () => {
+    const result = updateCardSchema.safeParse({ front: "q", back: "" });
+    expect(result.success).toBe(false);
+    if (!result.success && result.error.issues[0]) {
+      expect(result.error.issues[0].message).toBe("back is required");
+    }
+  });
+
+  it("rejects all-whitespace back", () => {
+    const result = updateCardSchema.safeParse({ front: "q", back: "   " });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const messages = result.error.issues.map((i) => i.message);
+      expect(messages).toContain("back is required");
+    }
+  });
+
+  it("accepts exactly 500 graphemes for front", () => {
+    const result = updateCardSchema.safeParse({ front: "x".repeat(500), back: "a" });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects 501 graphemes for front", () => {
+    const result = updateCardSchema.safeParse({ front: "x".repeat(501), back: "a" });
+    expect(result.success).toBe(false);
+    if (!result.success && result.error.issues[0]) {
+      expect(result.error.issues[0].message).toBe("front must be at most 500 characters");
+    }
+  });
+
+  it("accepts exactly 500 graphemes for back", () => {
+    const result = updateCardSchema.safeParse({ front: "q", back: "x".repeat(500) });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects 501 graphemes for back", () => {
+    const result = updateCardSchema.safeParse({ front: "q", back: "x".repeat(501) });
+    expect(result.success).toBe(false);
+    if (!result.success && result.error.issues[0]) {
+      expect(result.error.issues[0].message).toBe("back must be at most 500 characters");
+    }
+  });
+
+  it("counts ZWJ emoji as 1 grapheme (500 emoji back = pass)", () => {
+    const result = updateCardSchema.safeParse({ front: "q", back: "👨‍👩‍👧".repeat(500) });
+    expect(result.success).toBe(true);
+  });
+
+  it("counts ZWJ emoji as 1 grapheme (501 emoji back = fail)", () => {
+    const result = updateCardSchema.safeParse({ front: "q", back: "👨‍👩‍👧".repeat(501) });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const messages = result.error.issues.map((i) => i.message);
+      expect(messages).toContain("back must be at most 500 characters");
+    }
+  });
+});

--- a/frontend/src/schemas/card.ts
+++ b/frontend/src/schemas/card.ts
@@ -1,0 +1,34 @@
+import { z } from "zod";
+
+// Mirrors NewCardInput / UpdateCardInput in schema/schema.graphql.
+// UAX #29 grapheme cluster counting keeps FE and BE length rules in sync.
+const segmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
+
+function graphemeCount(s: string): number {
+  return Array.from(segmenter.segment(s)).length;
+}
+
+const cardSideSchema = (fieldName: string) =>
+  z
+    .string()
+    .trim()
+    .refine((s) => graphemeCount(s) >= 1, { message: `${fieldName} is required` })
+    .refine((s) => graphemeCount(s) <= 500, {
+      message: `${fieldName} must be at most 500 characters`,
+    });
+
+export const newCardSchema = z.object({
+  cardgroupId: z.string().min(1, { message: "cardgroupId is required" }),
+  front: cardSideSchema("front"),
+  back: cardSideSchema("back"),
+});
+
+// Both front and back are required in the form even for updates;
+// the form always re-submits both fields for simplicity.
+export const updateCardSchema = z.object({
+  front: cardSideSchema("front"),
+  back: cardSideSchema("back"),
+});
+
+export type NewCardValues = z.infer<typeof newCardSchema>;
+export type UpdateCardValues = z.infer<typeof updateCardSchema>;

--- a/frontend/src/schemas/card.ts
+++ b/frontend/src/schemas/card.ts
@@ -1,13 +1,7 @@
 import { z } from "zod";
+import { graphemeCount } from "./grapheme";
 
 // Mirrors NewCardInput / UpdateCardInput in schema/schema.graphql.
-// UAX #29 grapheme cluster counting keeps FE and BE length rules in sync.
-const segmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
-
-function graphemeCount(s: string): number {
-  return Array.from(segmenter.segment(s)).length;
-}
-
 const cardSideSchema = (fieldName: string) =>
   z
     .string()

--- a/frontend/src/schemas/cardgroup.test.ts
+++ b/frontend/src/schemas/cardgroup.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import { newCardgroupSchema, updateCardgroupSchema } from "./cardgroup";
+
+describe("newCardgroupSchema", () => {
+  it("accepts a valid name", () => {
+    const result = newCardgroupSchema.safeParse({ name: "My Group" });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.name).toBe("My Group");
+    }
+  });
+
+  it("trims surrounding whitespace from name", () => {
+    const result = newCardgroupSchema.safeParse({ name: "  trimmed  " });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.name).toBe("trimmed");
+    }
+  });
+
+  it("rejects empty string", () => {
+    const result = newCardgroupSchema.safeParse({ name: "" });
+    expect(result.success).toBe(false);
+    if (!result.success && result.error.issues[0]) {
+      expect(result.error.issues[0].message).toBe("name is required");
+    }
+  });
+
+  it("rejects all-whitespace string", () => {
+    const result = newCardgroupSchema.safeParse({ name: "   " });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const messages = result.error.issues.map((i) => i.message);
+      expect(messages).toContain("name is required");
+    }
+  });
+
+  it("accepts exactly 100 graphemes", () => {
+    const result = newCardgroupSchema.safeParse({ name: "x".repeat(100) });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects 101 graphemes", () => {
+    const result = newCardgroupSchema.safeParse({ name: "x".repeat(101) });
+    expect(result.success).toBe(false);
+    if (!result.success && result.error.issues[0]) {
+      expect(result.error.issues[0].message).toBe("name must be at most 100 characters");
+    }
+  });
+
+  it("counts ZWJ emoji as 1 grapheme (100 emoji = pass)", () => {
+    const result = newCardgroupSchema.safeParse({ name: "👨‍👩‍👧‍👦".repeat(100) });
+    expect(result.success).toBe(true);
+  });
+
+  it("counts ZWJ emoji as 1 grapheme (101 emoji = fail)", () => {
+    const result = newCardgroupSchema.safeParse({ name: "👨‍👩‍👧‍👦".repeat(101) });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const messages = result.error.issues.map((i) => i.message);
+      expect(messages).toContain("name must be at most 100 characters");
+    }
+  });
+});
+
+describe("updateCardgroupSchema", () => {
+  it("accepts a valid name", () => {
+    const result = updateCardgroupSchema.safeParse({ name: "Updated Group" });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.name).toBe("Updated Group");
+    }
+  });
+
+  it("rejects empty string", () => {
+    const result = updateCardgroupSchema.safeParse({ name: "" });
+    expect(result.success).toBe(false);
+    if (!result.success && result.error.issues[0]) {
+      expect(result.error.issues[0].message).toBe("name is required");
+    }
+  });
+
+  it("rejects all-whitespace string", () => {
+    const result = updateCardgroupSchema.safeParse({ name: "   " });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const messages = result.error.issues.map((i) => i.message);
+      expect(messages).toContain("name is required");
+    }
+  });
+
+  it("accepts exactly 100 graphemes", () => {
+    const result = updateCardgroupSchema.safeParse({ name: "x".repeat(100) });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects 101 graphemes", () => {
+    const result = updateCardgroupSchema.safeParse({ name: "x".repeat(101) });
+    expect(result.success).toBe(false);
+    if (!result.success && result.error.issues[0]) {
+      expect(result.error.issues[0].message).toBe("name must be at most 100 characters");
+    }
+  });
+});

--- a/frontend/src/schemas/cardgroup.ts
+++ b/frontend/src/schemas/cardgroup.ts
@@ -1,13 +1,7 @@
 import { z } from "zod";
+import { graphemeCount } from "./grapheme";
 
 // Mirrors NewCardgroupInput / UpdateCardgroupInput in schema/schema.graphql.
-// UAX #29 grapheme cluster counting keeps FE and BE length rules in sync.
-const segmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
-
-function graphemeCount(s: string): number {
-  return Array.from(segmenter.segment(s)).length;
-}
-
 const cardgroupNameSchema = z
   .string()
   .trim()

--- a/frontend/src/schemas/cardgroup.ts
+++ b/frontend/src/schemas/cardgroup.ts
@@ -1,0 +1,28 @@
+import { z } from "zod";
+
+// Mirrors NewCardgroupInput / UpdateCardgroupInput in schema/schema.graphql.
+// UAX #29 grapheme cluster counting keeps FE and BE length rules in sync.
+const segmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
+
+function graphemeCount(s: string): number {
+  return Array.from(segmenter.segment(s)).length;
+}
+
+const cardgroupNameSchema = z
+  .string()
+  .trim()
+  .refine((s) => graphemeCount(s) >= 1, { message: "name is required" })
+  .refine((s) => graphemeCount(s) <= 100, {
+    message: "name must be at most 100 characters",
+  });
+
+export const newCardgroupSchema = z.object({
+  name: cardgroupNameSchema,
+});
+
+export const updateCardgroupSchema = z.object({
+  name: cardgroupNameSchema,
+});
+
+export type NewCardgroupValues = z.infer<typeof newCardgroupSchema>;
+export type UpdateCardgroupValues = z.infer<typeof updateCardgroupSchema>;

--- a/frontend/src/schemas/grapheme.ts
+++ b/frontend/src/schemas/grapheme.ts
@@ -1,0 +1,7 @@
+// UAX #29 grapheme cluster counter shared by schema length validators
+// to keep FE and BE rules in sync (ZWJ emoji count as 1 grapheme).
+const segmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
+
+export function graphemeCount(s: string): number {
+  return Array.from(segmenter.segment(s)).length;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,12 @@ importers:
       '@apollo/client-integration-nextjs':
         specifier: ^0.14.5
         version: 0.14.5(@apollo/client@4.1.9(graphql-ws@6.0.8(graphql@16.13.2)(ws@8.20.0))(graphql@16.13.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rxjs@7.8.2))(@types/react@19.2.0)(graphql@16.13.2)(next@16.2.4(@babel/core@7.29.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rxjs@7.8.2)
+      '@radix-ui/react-alert-dialog':
+        specifier: ^1.1.15
+        version: 1.1.15(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-dialog':
+        specifier: ^1.1.15
+        version: 1.1.15(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-label':
         specifier: ^2.1.8
         version: 2.1.8(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -40,6 +46,9 @@ importers:
       graphql:
         specifier: ^16.13.2
         version: 16.13.2
+      lucide-react:
+        specifier: ^1.14.0
+        version: 1.14.0(react@19.2.0)
       next:
         specifier: 16.2.4
         version: 16.2.4(@babel/core@7.29.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -292,24 +301,28 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-arm64@2.4.13':
     resolution: {integrity: sha512-NzkUDSqfvMBrPplKgVr3aXLHZ2NEELvvF4vZxXulEylKWIGqlvNEcwUcj9OLrn75TD3lJ/GIqCVlBwd1MZCuYQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@2.4.13':
     resolution: {integrity: sha512-Z601MienRgTBDza/+u2CH3RSrWoXo9rtr8NK6A4KJzqGgfxx+H3VlyLgTJ4sRo40T3pIsqpTmiOQEvYzQvBRvQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-x64@2.4.13':
     resolution: {integrity: sha512-Az3ZZedYRBo9EQzNnD9SxFcR1G5QsGo6VEc2hIyVPZ1rdKwee/7E9oeBBZFpE8Z44ekxsDQBqbiWGW5ShOhUSQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@2.4.13':
     resolution: {integrity: sha512-Px9PS2B5/Q183bUwy/5VHqp3J2lzdOCeVGzMpphYfl8oSa7VDCqenBdqWpy6DCy/en4Rbf/Y1RieZF6dJPcc9A==}
@@ -658,89 +671,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -941,24 +970,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.2.4':
     resolution: {integrity: sha512-iVMMp14514u7Nup2umQS03nT/bN9HurK8ufylC3FZNykrwjtx7V1A7+4kvhbDSCeonTVqV3Txnv0Lu+m2oDXNg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.2.4':
     resolution: {integrity: sha512-EZOvm1aQWgnI/N/xcWOlnS3RQBk0VtVav5Zo7n4p0A7UKyTDx047k8opDbXgBpHl4CulRqRfbw3QrX2w5UOXMQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.2.4':
     resolution: {integrity: sha512-h9FxsngCm9cTBf71AR4fGznDEDx1hS7+kSEiIRjq5kO1oXWm07DxVGZjCvk0SGx7TSjlUqhI8oOyz7NfwAdPoA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.2.4':
     resolution: {integrity: sha512-3NdJV5OXMSOeJYijX+bjaLge3mJBlh4ybydbT4GFoB/2hAojWHtMhl3CYlYoMrjPuodp0nzFVi4Tj2+WaMg+Ow==}
@@ -987,6 +1020,22 @@ packages:
   '@oxc-project/types@0.127.0':
     resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
 
+  '@radix-ui/primitive@1.1.3':
+    resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
+
+  '@radix-ui/react-alert-dialog@1.1.15':
+    resolution: {integrity: sha512-oTVLkEw5GpdRe29BqJ0LSDFWI3qu0vR1M0mUkOQWDIUnY/QIkLpgDMWuKxP94c2NAC2LGcgVhG1ImF3jkZ5wXw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-compose-refs@1.1.2':
     resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
     peerDependencies:
@@ -996,8 +1045,113 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-context@1.1.2':
+    resolution: {integrity: sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-dialog@1.1.15':
+    resolution: {integrity: sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-dismissable-layer@1.1.11':
+    resolution: {integrity: sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-focus-guards@1.1.3':
+    resolution: {integrity: sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-focus-scope@1.1.7':
+    resolution: {integrity: sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-id@1.1.1':
+    resolution: {integrity: sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-label@2.1.8':
     resolution: {integrity: sha512-FmXs37I6hSBVDlO4y764TNz1rLgKwjJMQ0EGte6F3Cb3f4bIuHB/iLa/8I9VKkmOy+gNHq8rql3j686ACVV21A==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-portal@1.1.9':
+    resolution: {integrity: sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-presence@1.1.5':
+    resolution: {integrity: sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-primitive@2.1.3':
+    resolution: {integrity: sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -1022,8 +1176,62 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-slot@1.2.3':
+    resolution: {integrity: sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-slot@1.2.4':
     resolution: {integrity: sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-callback-ref@1.1.1':
+    resolution: {integrity: sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-controllable-state@1.2.2':
+    resolution: {integrity: sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-effect-event@0.0.2':
+    resolution: {integrity: sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-escape-keydown@1.1.1':
+    resolution: {integrity: sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-layout-effect@1.1.1':
+    resolution: {integrity: sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -1069,36 +1277,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
     resolution: {integrity: sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
     resolution: {integrity: sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
     resolution: {integrity: sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==}
@@ -1230,24 +1444,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.4':
     resolution: {integrity: sha512-bBADEGAbo4ASnppIziaQJelekCxdMaxisrk+fB7Thit72IBnALp9K6ffA2G4ruj90G9XRS2VQ6q2bCKbfFV82g==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.4':
     resolution: {integrity: sha512-7Mx25E4WTfnht0TVRTyC00j3i0M+EeFe7wguMDTlX4mRxafznw0CA8WJkFjWYH5BlgELd1kSjuU2JiPnNZbJDA==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.4':
     resolution: {integrity: sha512-2wwJRF7nyhOR0hhHoChc04xngV3iS+akccHTGtz965FwF0up4b2lOdo6kI1EbDaEXKgvcrFBYcYQQ/rrnWFVfA==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.4':
     resolution: {integrity: sha512-FQsqApeor8Fo6gUEklzmaa9994orJZZDBAlQpK2Mq+DslRKFJeD6AjHpBQ0kZFQohVr8o85PPh8eOy86VlSCmw==}
@@ -1465,6 +1683,10 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  aria-hidden@1.2.6:
+    resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
+    engines: {node: '>=10'}
+
   aria-query@5.3.0:
     resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
@@ -1667,6 +1889,9 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
+  detect-node-es@1.1.0:
+    resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
+
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
@@ -1769,6 +1994,10 @@ packages:
   get-east-asian-width@1.5.0:
     resolution: {integrity: sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==}
     engines: {node: '>=18'}
+
+  get-nonce@1.0.1:
+    resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
+    engines: {node: '>=6'}
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -2013,24 +2242,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -2082,6 +2315,11 @@ packages:
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lucide-react@1.14.0:
+    resolution: {integrity: sha512-+1mdWcfSJVUsaTIjN9zoezmUhfXo5l0vP7ekBMPo3jcS/aIkxHnXqAPsByszMZx/Y8oQBRJxJx5xg+RH3urzxA==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
@@ -2279,6 +2517,36 @@ packages:
 
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
+  react-remove-scroll-bar@2.3.8:
+    resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react-remove-scroll@2.7.2:
+    resolution: {integrity: sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react-style-singleton@2.2.3:
+    resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   react@19.2.0:
     resolution: {integrity: sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==}
@@ -2558,6 +2826,26 @@ packages:
 
   urlpattern-polyfill@10.1.0:
     resolution: {integrity: sha512-IGjKp/o0NL3Bso1PymYURCJxMPNAf/ILOpendP9f5B6e1rTJgdgiOvgfoT8VxCAdY+Wisb9uhGaJJf3yZ2V9nw==}
+
+  use-callback-ref@1.3.3:
+    resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  use-sidecar@1.1.3:
+    resolution: {integrity: sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   use-sync-external-store@1.6.0:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
@@ -3711,8 +3999,89 @@ snapshots:
 
   '@oxc-project/types@0.127.0': {}
 
+  '@radix-ui/primitive@1.1.3': {}
+
+  '@radix-ui/react-alert-dialog@1.1.15(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.0)(react@19.2.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.0)(react@19.2.0)
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.0)(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.2.0
+      '@types/react-dom': 19.2.0(@types/react@19.2.0)
+
   '@radix-ui/react-compose-refs@1.1.2(@types/react@19.2.0)(react@19.2.0)':
     dependencies:
+      react: 19.2.0
+    optionalDependencies:
+      '@types/react': 19.2.0
+
+  '@radix-ui/react-context@1.1.2(@types/react@19.2.0)(react@19.2.0)':
+    dependencies:
+      react: 19.2.0
+    optionalDependencies:
+      '@types/react': 19.2.0
+
+  '@radix-ui/react-dialog@1.1.15(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.0)(react@19.2.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.0)(react@19.2.0)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.0)(react@19.2.0)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.0)(react@19.2.0)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.0)(react@19.2.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.0)(react@19.2.0)
+      aria-hidden: 1.2.6
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+      react-remove-scroll: 2.7.2(@types/react@19.2.0)(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.2.0
+      '@types/react-dom': 19.2.0(@types/react@19.2.0)
+
+  '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.0)(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.0)(react@19.2.0)
+      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.2.0)(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.2.0
+      '@types/react-dom': 19.2.0(@types/react@19.2.0)
+
+  '@radix-ui/react-focus-guards@1.1.3(@types/react@19.2.0)(react@19.2.0)':
+    dependencies:
+      react: 19.2.0
+    optionalDependencies:
+      '@types/react': 19.2.0
+
+  '@radix-ui/react-focus-scope@1.1.7(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.0)(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.0)(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.2.0
+      '@types/react-dom': 19.2.0(@types/react@19.2.0)
+
+  '@radix-ui/react-id@1.1.1(@types/react@19.2.0)(react@19.2.0)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.0)(react@19.2.0)
       react: 19.2.0
     optionalDependencies:
       '@types/react': 19.2.0
@@ -3720,6 +4089,35 @@ snapshots:
   '@radix-ui/react-label@2.1.8(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.2.0
+      '@types/react-dom': 19.2.0(@types/react@19.2.0)
+
+  '@radix-ui/react-portal@1.1.9(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.0)(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.2.0
+      '@types/react-dom': 19.2.0(@types/react@19.2.0)
+
+  '@radix-ui/react-presence@1.1.5(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.0)(react@19.2.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.0)(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.2.0
+      '@types/react-dom': 19.2.0(@types/react@19.2.0)
+
+  '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.0)(react@19.2.0)
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
     optionalDependencies:
@@ -3735,9 +4133,50 @@ snapshots:
       '@types/react': 19.2.0
       '@types/react-dom': 19.2.0(@types/react@19.2.0)
 
+  '@radix-ui/react-slot@1.2.3(@types/react@19.2.0)(react@19.2.0)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.0)(react@19.2.0)
+      react: 19.2.0
+    optionalDependencies:
+      '@types/react': 19.2.0
+
   '@radix-ui/react-slot@1.2.4(@types/react@19.2.0)(react@19.2.0)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.0)(react@19.2.0)
+      react: 19.2.0
+    optionalDependencies:
+      '@types/react': 19.2.0
+
+  '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.2.0)(react@19.2.0)':
+    dependencies:
+      react: 19.2.0
+    optionalDependencies:
+      '@types/react': 19.2.0
+
+  '@radix-ui/react-use-controllable-state@1.2.2(@types/react@19.2.0)(react@19.2.0)':
+    dependencies:
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.0)(react@19.2.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.0)(react@19.2.0)
+      react: 19.2.0
+    optionalDependencies:
+      '@types/react': 19.2.0
+
+  '@radix-ui/react-use-effect-event@0.0.2(@types/react@19.2.0)(react@19.2.0)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.0)(react@19.2.0)
+      react: 19.2.0
+    optionalDependencies:
+      '@types/react': 19.2.0
+
+  '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@19.2.0)(react@19.2.0)':
+    dependencies:
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.0)(react@19.2.0)
+      react: 19.2.0
+    optionalDependencies:
+      '@types/react': 19.2.0
+
+  '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.2.0)(react@19.2.0)':
+    dependencies:
       react: 19.2.0
     optionalDependencies:
       '@types/react': 19.2.0
@@ -4130,6 +4569,10 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  aria-hidden@1.2.6:
+    dependencies:
+      tslib: 2.8.1
+
   aria-query@5.3.0:
     dependencies:
       dequal: 2.0.3
@@ -4327,6 +4770,8 @@ snapshots:
 
   detect-libc@2.1.2: {}
 
+  detect-node-es@1.1.0: {}
+
   dir-glob@3.0.1:
     dependencies:
       path-type: 4.0.0
@@ -4410,6 +4855,8 @@ snapshots:
   get-caller-file@2.0.5: {}
 
   get-east-asian-width@1.5.0: {}
+
+  get-nonce@1.0.1: {}
 
   glob-parent@5.1.2:
     dependencies:
@@ -4705,6 +5152,10 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
+  lucide-react@1.14.0(react@19.2.0):
+    dependencies:
+      react: 19.2.0
+
   lz-string@1.5.0: {}
 
   magic-string@0.30.21:
@@ -4896,6 +5347,33 @@ snapshots:
       scheduler: 0.27.0
 
   react-is@17.0.2: {}
+
+  react-remove-scroll-bar@2.3.8(@types/react@19.2.0)(react@19.2.0):
+    dependencies:
+      react: 19.2.0
+      react-style-singleton: 2.2.3(@types/react@19.2.0)(react@19.2.0)
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.0
+
+  react-remove-scroll@2.7.2(@types/react@19.2.0)(react@19.2.0):
+    dependencies:
+      react: 19.2.0
+      react-remove-scroll-bar: 2.3.8(@types/react@19.2.0)(react@19.2.0)
+      react-style-singleton: 2.2.3(@types/react@19.2.0)(react@19.2.0)
+      tslib: 2.8.1
+      use-callback-ref: 1.3.3(@types/react@19.2.0)(react@19.2.0)
+      use-sidecar: 1.1.3(@types/react@19.2.0)(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.2.0
+
+  react-style-singleton@2.2.3(@types/react@19.2.0)(react@19.2.0):
+    dependencies:
+      get-nonce: 1.0.1
+      react: 19.2.0
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.0
 
   react@19.2.0: {}
 
@@ -5171,6 +5649,21 @@ snapshots:
       tslib: 2.8.1
 
   urlpattern-polyfill@10.1.0: {}
+
+  use-callback-ref@1.3.3(@types/react@19.2.0)(react@19.2.0):
+    dependencies:
+      react: 19.2.0
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.0
+
+  use-sidecar@1.1.3(@types/react@19.2.0)(react@19.2.0):
+    dependencies:
+      detect-node-es: 1.1.0
+      react: 19.2.0
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.0
 
   use-sync-external-store@1.6.0(react@19.2.0):
     dependencies:


### PR DESCRIPTION
## Summary

Ships the frontend slice for the cardgroup and card aggregates: five Next.js App-Router routes (`/cardgroups`, `/cardgroups/new`, `/cardgroups/[id]`, `/cardgroups/[id]/edit`, `/cardgroups/[id]/cards`), Zod schemas mirroring `NewCardgroupInput` / `NewCardInput` with grapheme-cluster length bounds, an Apollo `queries.ts` module covering all five cardgroup operations and the four card operations, and shared `CardgroupForm` / `CardForm` components driven by TanStack Form. Adds two cross-cutting helpers — `getBackendFieldErrors` / `getBackendErrorBanner` for Apollo error triage and `redirectIfUnauthenticated` for RSC redirect-on-`UNAUTHENTICATED` — plus the shadcn `alert-dialog` and `dialog` primitives that the destructive-confirm flows depend on. The existing `/profile` page is byte-identical from a user perspective; the only change there is a refactor to consume the new shared error helpers.

## Background / Motivation

- The backend cardgroup and card aggregates already ship the GraphQL surface (`myCardgroups`, `cardgroup`, `createCardgroup`, `updateCardgroup`, `deleteCardgroup`, `cardsByCardgroup`, `createCard`, `updateCard`, `deleteCard`) with the `BAD_USER_INPUT` / `UNAUTHENTICATED` / `INTERNAL` `extensions.code` contract documented in `backend/internal/gqlerr`. Without a frontend, the only way to exercise that surface was the GraphQL playground; this PR is the first end-user entry point for the swiping-flashcard product.
- Length validation must agree on **grapheme clusters**, not UTF-16 code units or bytes — otherwise a 100-grapheme ZWJ-emoji name passes the form but trips the backend's `rivo/uniseg` check, surfacing as a server `BAD_USER_INPUT` instead of inline form feedback. `@/schemas/grapheme` wraps `Intl.Segmenter` so the `name` and `front` / `back` schemas count the same units the backend does. Browser support for `Intl.Segmenter` is universal across the targets we care about, so no polyfill is bundled.
- Apollo's `useMutation` exposes an `error` state, but it updates **on the next render** — reading it inside the same async handler right after `await mutate(...)` reads the previous closure's stale value. Every navigation- or dialog-close-on-success site (`EditCardgroupClient.handleSave`, `EditCardgroupClient.handleDelete`, `CardsClient.handleUpdate`, `NewCardgroupClient.onCompleted`) gates on the `FetchResult` returned by the `await`, never on the hook's `error` state. This rule is now codified in `docs/frontend.md` so future mutation flows do not re-discover the trap.
- `redirectIfUnauthenticated(err, target)` is `server-only` and string-matches `UNAUTHENTICATED` in the error message rather than parsing the GraphQL error tree. The reason: `gqlFetch` already collapses GraphQL errors into a single `Error` whose message contains the `extensions.code`, and we need the helper to accept the broadest possible input shape so RSC `catch` blocks stay one-liners. Two redirect targets are in use today — `/login` for session-expired or no-session paths (also pre-checked via `supabase.auth.getUser()` before `gqlFetch`), and `/cardgroups` for cross-user access on inner pages — because the backend collapses `NOT_FOUND` into `UNAUTHENTICATED` on ownership-protected resources, so a stale link from another user's session and an actually-deleted row are indistinguishable by code alone.
- `getBackendErrorBanner` scans **all** errors in priority order (`INTERNAL > UNAUTHENTICATED > first non-field GQL error`) rather than relying on array position. An earlier iteration relied on `errors[0]`, which silently misclassified responses where the backend emitted multiple errors and the position of the most-actionable one was not stable. The fix lives in its own commit (`e92f9c0`) so the regression history is unambiguous.
- The destructive-confirm `AlertDialog` on Edit Cardgroup keeps the dialog **open** until the delete mutation resolves successfully. Closing the dialog synchronously in the confirm handler hid the mutation error from the user — the page redirected on failure, which silently dropped non-owner deletes. The fix is to gate `setDialogOpen(false)` on the awaited `result.data.deleteCardgroup === true` (commit `859f994`); the same pattern is used by every destructive confirm in the slice.
- After a successful `createCard` mutation, the inline add-card form must reset its `front` / `back` fields so the next card can be added without remounting the page. We bump a numeric `createFormKey` and pass it as the React `key` prop on `<CardForm>` — React unmounts and remounts the component, resetting all TanStack Form field state without a manual `form.reset()` call. This avoids reaching into TanStack Form's imperative API and keeps the form component itself stateless.
- Cache writes in `update(cache, { data })` are guarded with a presence check (`if (!data?.createCardgroup?.cardgroup) return;`) even though the default `errorPolicy: \"none\"` already prevents the callback from firing on errors. The guard is forward-compatible with `errorPolicy: \"all\"` and silences the TypeScript narrow that the generated types use (`createCardgroup` is `CreateCardgroupPayload | null`).

## Changes

### Zod schemas + grapheme-cluster length bounds

- `frontend/src/schemas/grapheme.ts` (new): `graphemeCount(s)` wraps a module-scoped `Intl.Segmenter({ granularity: \"grapheme\" })` so every schema length check counts the same units the backend's `rivo/uniseg` does.
- `frontend/src/schemas/cardgroup.ts` (new): `newCardgroupSchema` / `updateCardgroupSchema` enforce 1–100 grapheme clusters on `name` after `.trim()`, with sentinel messages `\"name is required\"` and `\"name must be at most 100 characters\"`.
- `frontend/src/schemas/card.ts` (new): `newCardSchema` / `updateCardSchema` apply the same shape via a `cardSideSchema(fieldName)` factory bounding `front` / `back` to 1–500 grapheme clusters; `newCardSchema` also requires a non-empty `cardgroupId`. The factory parametrizes the field name so error messages show the correct field (`\"front is required\"` vs. `\"back is required\"`).
- `frontend/src/schemas/{card,cardgroup}.test.ts` cover each invariant plus the `.trim()` boundary and the 100-/500-cluster edges; `card.test.ts` adds explicit ZWJ-emoji cases to pin the grapheme-cluster contract against any future regression to `s.length`.

### Apollo queries + mutations module

- `frontend/src/app/cardgroups/queries.ts` (new): all five cardgroup operations (`MyCardgroupsQuery`, `CardgroupQuery`, `CreateCardgroupMutation`, `UpdateCardgroupMutation`, `DeleteCardgroupMutation`) and all four card operations (`CardsByCardgroupQuery`, `CreateCardMutation`, `UpdateCardMutation`, `DeleteCardMutation`). Documents are authored via the `graphql()` tagged template from `@/generated`, so codegen produces typed `*Document` / `*Query` / `*Mutation` exports under `@/generated/graphql`.

### Apollo error triage helpers

- `frontend/src/lib/apollo/errors.ts` (new): `getBackendFieldErrors(err)` returns `{ fieldName: message }` for `BAD_USER_INPUT` errors carrying `extensions.field`; `getBackendErrorBanner(err)` returns a user-facing banner string with priority `INTERNAL > UNAUTHENTICATED > first non-field GQL error`, falling back to a generic `\"Could not reach the server. Please try again.\"` for non-`CombinedGraphQLErrors` (network) inputs. Both functions are pure — no hook state, no React imports — so they're trivially unit-testable and reusable from RSC and client code alike.
- `frontend/src/lib/apollo/errors.test.ts` (new) covers each branch: field-error map, INTERNAL-wins-over-UNAUTHENTICATED ordering, network-error fallback, and the `undefined` return when every error is a field-level `BAD_USER_INPUT`.
- The previous ad-hoc error-shape parsing in `frontend/src/app/profile/profile-form.tsx` is replaced by these helpers; the diff there is the only behavior-preserving refactor in this PR.

### RSC `UNAUTHENTICATED` redirect helper

- `frontend/src/lib/apollo/server-redirect.ts` (new): `redirectIfUnauthenticated(err, target): never` is `server-only`. It string-matches `UNAUTHENTICATED` in the error message and calls `next/navigation` `redirect(target)`; all other errors are rethrown to the nearest error boundary. The signature returns `never` so TypeScript narrows the calling code to \"unreachable after this call\" and lets the surrounding RSC code use `data` without further null-guarding.
- All four RSC pages (`/cardgroups`, `/cardgroups/[id]`, `/cardgroups/[id]/edit`, `/cardgroups/[id]/cards`) consume this helper inside a `try` / `catch` around `gqlFetch`.

### Cardgroup pages — list / new / detail / edit

- `frontend/src/app/cardgroups/page.tsx` (new): RSC list page. Pre-checks the Supabase session via `supabase.auth.getUser()` and redirects to `/login` if absent; `gqlFetch(MyCardgroupsQuery, { revalidate: 0 })` is wrapped in `try` / `catch` with `redirectIfUnauthenticated(err, \"/login\")`. Empty-state CTA points to `/cardgroups/new`.
- `frontend/src/app/cardgroups/new/page.tsx` + `new-cardgroup-client.tsx` (new): client component runs the `CreateCardgroupMutation` with an `update(cache)` callback that prepends the new row into `MyCardgroupsDocument` via `readQuery → writeQuery`, then `onCompleted` navigates to `/cardgroups/[id]` with `router.refresh()` so the RSC parent re-fetches.
- `frontend/src/app/cardgroups/[id]/page.tsx` (new): RSC detail page that fetches `CardgroupQuery` and `CardsByCardgroupQuery` in parallel via `Promise.all`, shows up to 5 card-front previews, and provides three CTAs: \"Start learning\" (placeholder route), \"Edit\", and \"Manage cards\". Falls back to `redirect(\"/cardgroups\")` when the cardgroup itself returns `null` (cross-user access surfaces as `UNAUTHENTICATED` in `gqlFetch`'s thrown error and is caught by `redirectIfUnauthenticated`; non-existent IDs surface as `cardgroup === null` from the query and fall through to this redirect).
- `frontend/src/app/cardgroups/[id]/edit/page.tsx` + `edit-cardgroup-client.tsx` (new): edit form with destructive-delete `AlertDialog`. `handleSave` and `handleDelete` both gate navigation on the awaited `FetchResult` rather than on the `useMutation` `error` state. `handleDelete`'s cache `update` runs `cache.evict({ id: cache.identify({ __typename: \"Cardgroup\", id }) })` followed by `cache.gc()` so the row is removed from `MyCardgroupsDocument` without a re-fetch. The dialog stays open while `mutating` is true and only closes after `result.data.deleteCardgroup === true`.

### Card management page (inline create / edit / delete)

- `frontend/src/app/cardgroups/[id]/cards/page.tsx` + `cards-client.tsx` (new): RSC entry point fetches the existing cards and passes them as `initialCards` to a client component that owns the inline create + edit + delete flows. `useState<Card[]>(initialCards)` is the source of truth for the rendered list; cache writes keep the Apollo cache in sync for cross-page navigation. The create flow uses the React-`key` form-reset pattern (`createFormKey++`) to clear the inline add-card form after a successful insert. The delete flow uses `cache.evict + cache.gc` per card.
- The edit flow swaps the read-only row for an inline `<CardForm mode=\"edit\">` keyed by `editingId`. Save gates on the awaited `result.data.updateCard.card`; failure keeps the form open so the user can retry without losing input (commit `a73c45b`).

### Shared form components

- `frontend/src/components/cardgroups/cardgroup-form.tsx` (new): `CardgroupForm` is a single component driving both create and edit via a `mode` prop. The Zod schema is selected by mode (`newCardgroupSchema` / `updateCardgroupSchema`), `getBackendFieldErrors` populates per-field messages, `getBackendErrorBanner` renders a top-of-form banner, and a `secondarySlot` prop lets the Edit page render the Delete button next to Save without coupling the form to the delete flow.
- `frontend/src/components/cardgroups/card-form.tsx` (new): `CardForm` mirrors the `CardgroupForm` pattern across `front` and `back`, with an `idPrefix` prop so multiple `CardForm`s on the same page (one per inline-edit row) generate unique input IDs. `cardgroupId` is injected by the parent's `submit` callback, not by the form, so the form stays stateless about which cardgroup it belongs to.
- `frontend/src/components/cardgroups/cardgroup-list-item.tsx` (new): a thin presentational `<li>` that links to `/cardgroups/[id]` and renders `formatMediumDate(updatedAt)`.

### Cross-cutting helpers

- `frontend/src/lib/format.ts` (new): `formatMediumDate(iso)` wraps a module-scoped `Intl.DateTimeFormat(\"en-US\", { dateStyle: \"medium\" })` so all list / detail pages render dates as e.g. `\"Apr 30, 2026\"` consistently.
- `frontend/src/lib/forms/field-error.tsx` (new): `<FieldError zodErrors backendError />` renders the first Zod issue message (or, failing that, the `backendError` string) as a destructive `<p>`. Centralizes the \"Zod beats backend\" precedence rule that all forms in this PR rely on.

### shadcn primitives

- `frontend/src/components/ui/alert-dialog.tsx` (new): destructive-confirm primitive used by the cardgroup-delete and card-delete flows.
- `frontend/src/components/ui/dialog.tsx` (new): non-destructive overlay primitive (not used by routes shipped here but installed alongside `alert-dialog` so future flows have it).
- `frontend/package.json` / `pnpm-lock.yaml`: adds `@radix-ui/react-alert-dialog`, `@radix-ui/react-dialog`, and `@tanstack/react-form` (the form library these pages use).

### Header nav

- `frontend/src/app/_components/header.tsx`: the authenticated nav now exposes a `Cardgroups` link to the left of the email / `LogoutButton`. Anonymous users still see only the `Sign in` link.

### Profile-page refactor (behavior-preserving)

- `frontend/src/app/profile/profile-form.tsx` switches from inline error-shape parsing to `getBackendFieldErrors` + `getBackendErrorBanner`. The visible behavior (field-level Zod errors, banner for non-field errors, bio tri-state semantics) is unchanged; the diff is purely a deduplication so the cardgroup forms can share the same error contract.
- `frontend/src/app/profile/profile-form.test.tsx` picks up a single mechanical update to satisfy the Biome formatter's single-line `expect` rule (commit `726ee84`).

### Tests

- 8 new test files cover every page and shared component:
  - `frontend/src/app/cardgroups/page.test.tsx`, `new/page.test.tsx`, `[id]/page.test.tsx`, `[id]/edit/page.test.tsx`, `[id]/cards/page.test.tsx` for the RSC pages (Apollo `MockedProvider`, `next/navigation` mocks, Supabase mocks).
  - `frontend/src/app/cardgroups/[id]/edit/edit-cardgroup-client.test.tsx` and `[id]/cards/cards-client.test.tsx` for the client-component flows.
  - `frontend/src/components/cardgroups/{cardgroup-form,card-form,cardgroup-list-item}.test.tsx` for the shared components.
  - `frontend/src/schemas/{cardgroup,card}.test.ts` and `frontend/src/lib/apollo/errors.test.ts` for the pure helpers.
- The cache-write tests pass a real `InMemoryCache` to `<MockedProvider cache={cache}>`, pre-seed it with `cache.writeQuery(...)`, and assert post-mutation state via `cache.readQuery(...)` rather than only DOM side-effects — this pins down the prepend-on-create and evict-on-delete contracts (commits `66adcef`, `ebb3aaf`).
- Failure-path tests assert `expect(mockPush).not.toHaveBeenCalled()` so a regression where a handler navigates unconditionally on error fails the suite (commits `0cce649`, `a73c45b`).

### Documentation

- `docs/frontend.md`: adds three new sections — \"Apollo cache mutation patterns\" (the `update` callback presence guard, prepend-on-create via `readQuery → writeQuery`, evict-on-delete via `cache.evict + cache.gc`); \"RSC UNAUTHENTICATED redirect pattern\" (the `try` / `catch` + `redirectIfUnauthenticated` recipe and why two targets are in use); \"Backend error-code contract\" (the `BAD_USER_INPUT` / `UNAUTHENTICATED` / `INTERNAL` table and the priority rule); and \"Shared helper modules\" (the import table for the helpers added in this PR). Also documents three mutation-flow gotchas under the existing testing section: stale-closure trap with `useMutation` `error`, dialog-open tied to mutation result, and form-remount via React `key`.

## Verification

After merge, the following should all hold:

- `git ls-files frontend/src/schemas` lists `cardgroup.ts`, `card.ts`, `grapheme.ts`, plus the existing `profile.ts`. `grep -n \"graphemeCount\" frontend/src/schemas/{cardgroup,card}.ts` matches in both files (length bounds count grapheme clusters, not code units).
- `grep -rn \"redirectIfUnauthenticated\" frontend/src/app` matches in all four cardgroup RSC pages (`page.tsx`, `[id]/page.tsx`, `[id]/edit/page.tsx`, `[id]/cards/page.tsx`).
- `grep -n \"server-only\" frontend/src/lib/apollo/server-redirect.ts` matches once. Importing `redirectIfUnauthenticated` from a client component fails the build at codegen time.
- `grep -rn \"getBackendFieldErrors\\|getBackendErrorBanner\" frontend/src/components/cardgroups frontend/src/app/profile` shows both helpers reused across cardgroup forms and the profile form (no inline error parsing left).
- `grep -n \"AlertDialog\" frontend/src/app/cardgroups/\\[id\\]/edit/edit-cardgroup-client.tsx frontend/src/app/cardgroups/\\[id\\]/cards/cards-client.tsx` matches in both destructive-confirm flows.
- The Apollo `update(cache, { data })` callbacks in `new-cardgroup-client.tsx`, `edit-cardgroup-client.tsx`, and `cards-client.tsx` all start with a presence guard (`if (!data?.X?.Y) return;`) — `grep -nE \"if \\(!data\\?\\.\" frontend/src/app/cardgroups` matches in each.
- Boot the app (`cd frontend && pnpm dev`). Authenticated user sees `Cardgroups` link in the header, can land on `/cardgroups`, create a new cardgroup, see it prepended in the list without a full reload, drill into the detail page, edit and rename, manage cards (add / edit inline / delete), and delete the cardgroup with the confirm dialog. Browser console shows zero errors and zero React warnings on every flow.

## Test plan

- [ ] `cd frontend && pnpm install && pnpm typecheck && pnpm lint && pnpm test` all pass; new specs under `src/schemas/`, `src/lib/apollo/`, `src/components/cardgroups/`, and `src/app/cardgroups/` all run.
- [ ] `cd frontend && pnpm codegen` produces no diff on a clean checkout (the new operations in `queries.ts` are stable against `schema/schema.graphql`).
- [ ] Boot `cd backend && go run ./cmd/server` against a freshly-migrated DB and `cd frontend && pnpm dev`. Sign in, click `Cardgroups` in the header → land on `/cardgroups`, click `New cardgroup`, submit `name: \"x\"` → land on `/cardgroups/[id]`, then `My Cardgroups` shows `\"x\"` at the top of the list without a full page reload.
- [ ] Validation: on `/cardgroups/new`, submitting `name: \"  \"` shows `\"name is required\"` inline; submitting a 101-grapheme-cluster name shows `\"name must be at most 100 characters\"` inline. Same for `/cardgroups/[id]/edit`.
- [ ] Card CRUD: on `/cardgroups/[id]/cards`, adding a card with `front: \"f\"` `back: \"b\"` appends it to the list and clears the add-card form (no remount of the page). Editing inline saves and collapses back to the read-only row. Deleting via the confirm dialog removes the row and the underlying GraphQL `cardsByCardgroup` no longer includes it (verify via `query { cardsByCardgroup(cardgroupId: \"<id>\") { id } }` in the playground).
- [ ] Failure paths: with the backend stopped, every mutation surfaces a banner (`\"Could not reach the server. Please try again.\"`) and the page does not navigate. With a 501-grapheme `front`, `createCard` shows the inline `\"front must be at most 500 characters\"` banner under the field.
- [ ] `UNAUTHENTICATED` redirect: hand-craft a `/cardgroups/<other-user-id>` URL while signed in as a different user → land back on `/cardgroups` (the inner-page redirect target), not on `/login`. Sign out, then visit `/cardgroups` → land on `/login`.
- [ ] Destructive-confirm dialog: on `/cardgroups/[id]/edit`, click `Delete` → dialog opens. Click `Delete` inside the dialog while offline → dialog stays open and an error banner appears in the form (not in the dialog). Restore the network, click `Delete` again → dialog closes after the mutation resolves and the page navigates to `/cardgroups`.
- [ ] `grep -rnP \"[\\x{3040}-\\x{30ff}\\x{4e00}-\\x{9fff}]\" --include=\"*.ts\" --include=\"*.tsx\" --include=\"*.md\" frontend/src docs` returns nothing (English-only policy under `.claude/rules/language-policy.md`).