### PR TITLE
feat(backend): add /internal/ping endpoint and readiness-ping cron

### DIFF
--- a/.github/workflows/readiness-ping.yml
+++ b/.github/workflows/readiness-ping.yml
@@ -1,0 +1,27 @@
+name: readiness-ping
+
+on:
+  schedule:
+    - cron: '*/15 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  ping:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Ping Vercel frontend
+        run: |
+          curl -fsS --retry 3 --retry-delay 5 --max-time 30 \
+            -o /dev/null -w "frontend status=%{http_code} time=%{time_total}s\n" \
+            "${{ secrets.VERCEL_PING_URL }}"
+      - name: Ping Render backend (writes to Supabase)
+        run: |
+          curl -fsS --retry 3 --retry-delay 5 --max-time 60 \
+            -X POST \
+            -H "Authorization: Bearer ${{ secrets.PING_TOKEN }}" \
+            -w "backend status=%{http_code} time=%{time_total}s\n" \
+            "${{ secrets.RENDER_PING_URL }}"

--- a/.github/workflows/readiness-ping.yml
+++ b/.github/workflows/readiness-ping.yml
@@ -15,13 +15,13 @@ jobs:
     steps:
       - name: Ping Vercel frontend
         run: |
-          curl -fsS --retry 3 --retry-delay 5 --max-time 30 \
+          curl -fsS --retry 3 --retry-delay 5 --retry-all-errors --max-time 30 \
             -o /dev/null -w "frontend status=%{http_code} time=%{time_total}s\n" \
             "${{ secrets.VERCEL_PING_URL }}"
       - name: Ping Render backend (writes to Supabase)
         run: |
-          curl -fsS --retry 3 --retry-delay 5 --max-time 60 \
+          curl -fsS --retry 3 --retry-delay 5 --retry-all-errors --max-time 60 \
             -X POST \
             -H "Authorization: Bearer ${{ secrets.PING_TOKEN }}" \
             -w "backend status=%{http_code} time=%{time_total}s\n" \
-            "${{ secrets.RENDER_PING_URL }}"
+            "${{ secrets.RENDER_PING_URL }}/internal/ping"

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -30,7 +30,7 @@ import (
 	"backend/internal/auth"
 	"backend/internal/database"
 	"backend/internal/domain/service"
-	ping "backend/internal/handler/ping"
+	"backend/internal/handler/ping"
 	"backend/internal/loader"
 	"backend/internal/logging"
 	internalmw "backend/internal/middleware"

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"crypto/subtle"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -10,7 +9,6 @@ import (
 	"os"
 	"os/signal"
 	"strconv"
-	"strings"
 	"syscall"
 	"time"
 
@@ -27,13 +25,13 @@ import (
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel"
 	"golang.org/x/sync/errgroup"
-	"golang.org/x/time/rate"
 
 	"backend/graph/generated"
 	"backend/graph/resolver"
 	"backend/internal/auth"
 	"backend/internal/database"
 	"backend/internal/domain/service"
+	ping "backend/internal/handler/ping"
 	"backend/internal/loader"
 	"backend/internal/logging"
 	internalmw "backend/internal/middleware"
@@ -68,8 +66,7 @@ func newRouter(
 	roleRepo repository.RoleRepository,
 	cardgroupRepo repository.CardgroupRepository,
 	cardRepo repository.CardRepository,
-	pingRepo repository.PingRecordRepository,
-	pingToken string,
+	pingHandler *ping.Handler,
 	swipeRecordRepo ...repository.SwipeRecordRepository,
 ) *echo.Echo {
 	e := echo.New()
@@ -89,55 +86,7 @@ func newRouter(
 		})
 	})
 
-	// Rate limiter: 1 req/s sustained, burst of 5, per client IP.
-	pingRateLimiter := middleware.RateLimiterWithConfig(middleware.RateLimiterConfig{
-		Store: middleware.NewRateLimiterMemoryStoreWithConfig(
-			middleware.RateLimiterMemoryStoreConfig{
-				Rate:      float64(rate.Limit(1)),
-				Burst:     5,
-				ExpiresIn: 3 * time.Minute,
-			},
-		),
-		IdentifierExtractor: func(c *echo.Context) (string, error) {
-			return c.RealIP(), nil
-		},
-		ErrorHandler: func(c *echo.Context, err error) error {
-			return c.JSON(http.StatusForbidden, map[string]string{"error": err.Error()})
-		},
-		DenyHandler: func(c *echo.Context, identifier string, err error) error {
-			return c.JSON(http.StatusTooManyRequests, map[string]string{"error": "rate limit exceeded"})
-		},
-	})
-
-	pingTokenBytes := []byte(pingToken)
-
-	e.POST("/internal/ping", func(c *echo.Context) error {
-		authHeader := c.Request().Header.Get("Authorization")
-		token := strings.TrimPrefix(authHeader, "Bearer ")
-		// Constant-time compare to prevent timing oracle attacks.
-		if subtle.ConstantTimeCompare([]byte(token), pingTokenBytes) != 1 {
-			return c.JSON(http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
-		}
-
-		ctx := c.Request().Context()
-		n, err := pingRepo.Count(ctx)
-		if err != nil {
-			return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
-		}
-
-		if n == 0 {
-			if err := pingRepo.Create(ctx); err != nil {
-				return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
-			}
-			return c.JSON(http.StatusOK, map[string]any{"action": "created", "count": 1})
-		}
-
-		deleted, err := pingRepo.DeleteAll(ctx)
-		if err != nil {
-			return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
-		}
-		return c.JSON(http.StatusOK, map[string]any{"action": "deleted", "count": deleted})
-	}, pingRateLimiter)
+	e.POST("/internal/ping", pingHandler.Handle, pingHandler.RateLimiter())
 
 	gqlSrv := newGraphQLServer(resolvers)
 	// Wrap only the GraphQL POST handler with otelhttp so the HTTP layer
@@ -258,10 +207,11 @@ func run(ctx context.Context, logger *slog.Logger) error {
 		CardUC:      cardUC,
 		SwipeUC:     swipeUC,
 	}
+	pingHandler := ping.New(pingRecordRepo, pingToken)
 	// newRouter must be called after telemetry.Init: the otelhttp handler it
 	// constructs reads otel.GetTextMapPropagator() eagerly. See comment above
 	// telemetry.Init for the full ordering invariant.
-	e := newRouter(resolvers, authMW, userRepo, roleRepo, cardgroupRepo, cardRepo, pingRecordRepo, pingToken, swipeRecordRepo)
+	e := newRouter(resolvers, authMW, userRepo, roleRepo, cardgroupRepo, cardRepo, pingHandler, swipeRecordRepo)
 	e.Logger = logger
 
 	port := os.Getenv("PORT")

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -2,12 +2,15 @@ package main
 
 import (
 	"context"
+	"crypto/subtle"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"os"
 	"os/signal"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -24,6 +27,7 @@ import (
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel"
 	"golang.org/x/sync/errgroup"
+	"golang.org/x/time/rate"
 
 	"backend/graph/generated"
 	"backend/graph/resolver"
@@ -64,6 +68,8 @@ func newRouter(
 	roleRepo repository.RoleRepository,
 	cardgroupRepo repository.CardgroupRepository,
 	cardRepo repository.CardRepository,
+	pingRepo repository.PingRecordRepository,
+	pingToken string,
 	swipeRecordRepo ...repository.SwipeRecordRepository,
 ) *echo.Echo {
 	e := echo.New()
@@ -82,6 +88,56 @@ func newRouter(
 			"status": "ok",
 		})
 	})
+
+	// Rate limiter: 1 req/s sustained, burst of 5, per client IP.
+	pingRateLimiter := middleware.RateLimiterWithConfig(middleware.RateLimiterConfig{
+		Store: middleware.NewRateLimiterMemoryStoreWithConfig(
+			middleware.RateLimiterMemoryStoreConfig{
+				Rate:      float64(rate.Limit(1)),
+				Burst:     5,
+				ExpiresIn: 3 * time.Minute,
+			},
+		),
+		IdentifierExtractor: func(c *echo.Context) (string, error) {
+			return c.RealIP(), nil
+		},
+		ErrorHandler: func(c *echo.Context, err error) error {
+			return c.JSON(http.StatusForbidden, map[string]string{"error": err.Error()})
+		},
+		DenyHandler: func(c *echo.Context, identifier string, err error) error {
+			return c.JSON(http.StatusTooManyRequests, map[string]string{"error": "rate limit exceeded"})
+		},
+	})
+
+	pingTokenBytes := []byte(pingToken)
+
+	e.POST("/internal/ping", func(c *echo.Context) error {
+		authHeader := c.Request().Header.Get("Authorization")
+		token := strings.TrimPrefix(authHeader, "Bearer ")
+		// Constant-time compare to prevent timing oracle attacks.
+		if subtle.ConstantTimeCompare([]byte(token), pingTokenBytes) != 1 {
+			return c.JSON(http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+		}
+
+		ctx := c.Request().Context()
+		n, err := pingRepo.Count(ctx)
+		if err != nil {
+			return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		}
+
+		if n == 0 {
+			if err := pingRepo.Create(ctx); err != nil {
+				return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			}
+			return c.JSON(http.StatusOK, map[string]any{"action": "created", "count": 1})
+		}
+
+		deleted, err := pingRepo.DeleteAll(ctx)
+		if err != nil {
+			return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		}
+		return c.JSON(http.StatusOK, map[string]any{"action": "deleted", "count": deleted})
+	}, pingRateLimiter)
 
 	gqlSrv := newGraphQLServer(resolvers)
 	// Wrap only the GraphQL POST handler with otelhttp so the HTTP layer
@@ -152,6 +208,11 @@ func run(ctx context.Context, logger *slog.Logger) error {
 		return eris.Wrap(err, "run: telemetry init")
 	}
 
+	pingToken := os.Getenv("PING_TOKEN")
+	if pingToken == "" {
+		return fmt.Errorf("run: PING_TOKEN env var is required")
+	}
+
 	cfg, err := auth.ConfigFromEnv()
 	if err != nil {
 		return err
@@ -182,6 +243,7 @@ func run(ctx context.Context, logger *slog.Logger) error {
 	cardgroupRepo := repository.NewCardgroupRepository(db.GORM)
 	cardRepo := repository.NewCardRepository(db.GORM)
 	swipeRecordRepo := repository.NewSwipeRecordRepository(db.GORM)
+	pingRecordRepo := repository.NewPingRecordRepository(db.GORM)
 	// Constructed to surface compile-time wiring even though no resolver references it yet.
 	_ = repository.NewUserRoleRepository(db.GORM)
 
@@ -199,7 +261,7 @@ func run(ctx context.Context, logger *slog.Logger) error {
 	// newRouter must be called after telemetry.Init: the otelhttp handler it
 	// constructs reads otel.GetTextMapPropagator() eagerly. See comment above
 	// telemetry.Init for the full ordering invariant.
-	e := newRouter(resolvers, authMW, userRepo, roleRepo, cardgroupRepo, cardRepo, swipeRecordRepo)
+	e := newRouter(resolvers, authMW, userRepo, roleRepo, cardgroupRepo, cardRepo, pingRecordRepo, pingToken, swipeRecordRepo)
 	e.Logger = logger
 
 	port := os.Getenv("PORT")

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"errors"
-	"fmt"
 	"log/slog"
 	"net/http"
 	"os"
@@ -159,7 +158,7 @@ func run(ctx context.Context, logger *slog.Logger) error {
 
 	pingToken := os.Getenv("PING_TOKEN")
 	if pingToken == "" {
-		return fmt.Errorf("run: PING_TOKEN env var is required")
+		return eris.New("run: PING_TOKEN env var is required")
 	}
 
 	cfg, err := auth.ConfigFromEnv()

--- a/backend/cmd/server/main_test.go
+++ b/backend/cmd/server/main_test.go
@@ -39,7 +39,7 @@ import (
 	"backend/internal/database"
 	"backend/internal/domain"
 	"backend/internal/domain/service"
-	ping "backend/internal/handler/ping"
+	"backend/internal/handler/ping"
 	"backend/internal/repository"
 	"backend/internal/telemetry"
 	"backend/internal/usecase"

--- a/backend/cmd/server/main_test.go
+++ b/backend/cmd/server/main_test.go
@@ -39,6 +39,7 @@ import (
 	"backend/internal/database"
 	"backend/internal/domain"
 	"backend/internal/domain/service"
+	ping "backend/internal/handler/ping"
 	"backend/internal/repository"
 	"backend/internal/telemetry"
 	"backend/internal/usecase"
@@ -116,7 +117,7 @@ func noopAuthMW(next echo.HandlerFunc) echo.HandlerFunc {
 
 func newTestServer(t *testing.T) *httptest.Server {
 	t.Helper()
-	ts := httptest.NewServer(newRouter(&resolver.Resolver{}, noopAuthMW, nil, nil, nil, nil, nil, "test-token"))
+	ts := httptest.NewServer(newRouter(&resolver.Resolver{}, noopAuthMW, nil, nil, nil, nil, ping.New(nil, "test-token")))
 	t.Cleanup(ts.Close)
 	return ts
 }
@@ -404,7 +405,7 @@ func newGraphQLTestServerWithUserRepo(t *testing.T, f *jwtFixture, userRepo repo
 	cardUC := usecase.NewCardUsecase(cardRepo, cardgroupRepo)
 	swipeUC := usecase.NewSwipeUsecase(db.GORM, cardRepo, cardgroupRepo, swipeRecordRepo, service.NewFSRSScheduler(), 10)
 	pingRecordRepo := repository.NewPingRecordRepository(db.GORM)
-	e := newRouter(&resolver.Resolver{User: userUC, CardgroupUC: cardgroupUC, CardUC: cardUC, SwipeUC: swipeUC}, mw, userRepo, roleRepo, cardgroupRepo, cardRepo, pingRecordRepo, "test-token", swipeRecordRepo)
+	e := newRouter(&resolver.Resolver{User: userUC, CardgroupUC: cardgroupUC, CardUC: cardUC, SwipeUC: swipeUC}, mw, userRepo, roleRepo, cardgroupRepo, cardRepo, ping.New(pingRecordRepo, "test-token"), swipeRecordRepo)
 
 	ts := httptest.NewServer(e)
 	t.Cleanup(ts.Close)

--- a/backend/cmd/server/main_test.go
+++ b/backend/cmd/server/main_test.go
@@ -116,7 +116,7 @@ func noopAuthMW(next echo.HandlerFunc) echo.HandlerFunc {
 
 func newTestServer(t *testing.T) *httptest.Server {
 	t.Helper()
-	ts := httptest.NewServer(newRouter(&resolver.Resolver{}, noopAuthMW, nil, nil, nil, nil))
+	ts := httptest.NewServer(newRouter(&resolver.Resolver{}, noopAuthMW, nil, nil, nil, nil, nil, "test-token"))
 	t.Cleanup(ts.Close)
 	return ts
 }
@@ -209,6 +209,7 @@ func TestRunGracefulShutdown(t *testing.T) {
 	t.Setenv("SUPABASE_JWT_AUDIENCE", "authenticated")
 	t.Setenv("SUPABASE_JWT_ISSUER", "http://issuer.test")
 	t.Setenv("SUPABASE_DB_URL", testDBURL)
+	t.Setenv("PING_TOKEN", "test-token")
 
 	port := freePort(t)
 	t.Setenv("PORT", port)
@@ -241,6 +242,7 @@ func TestRun_FailsWhenJWKSURLMissing(t *testing.T) {
 	t.Setenv("SUPABASE_JWT_AUDIENCE", "authenticated")
 	t.Setenv("SUPABASE_JWT_ISSUER", "http://issuer.test")
 	t.Setenv("SUPABASE_DB_URL", testDBURL)
+	t.Setenv("PING_TOKEN", "test-token")
 
 	err := run(context.Background(), slog.New(slog.DiscardHandler))
 	if err == nil {
@@ -262,6 +264,7 @@ func TestRun_FailsWhenDBURLMissing(t *testing.T) {
 	t.Setenv("SUPABASE_JWT_AUDIENCE", "authenticated")
 	t.Setenv("SUPABASE_JWT_ISSUER", "http://issuer.test")
 	t.Setenv("SUPABASE_DB_URL", "")
+	t.Setenv("PING_TOKEN", "test-token")
 
 	err := run(context.Background(), slog.New(slog.DiscardHandler))
 	if err == nil {
@@ -400,7 +403,8 @@ func newGraphQLTestServerWithUserRepo(t *testing.T, f *jwtFixture, userRepo repo
 	cardgroupUC := usecase.NewCardgroupUsecase(cardgroupRepo)
 	cardUC := usecase.NewCardUsecase(cardRepo, cardgroupRepo)
 	swipeUC := usecase.NewSwipeUsecase(db.GORM, cardRepo, cardgroupRepo, swipeRecordRepo, service.NewFSRSScheduler(), 10)
-	e := newRouter(&resolver.Resolver{User: userUC, CardgroupUC: cardgroupUC, CardUC: cardUC, SwipeUC: swipeUC}, mw, userRepo, roleRepo, cardgroupRepo, cardRepo, swipeRecordRepo)
+	pingRecordRepo := repository.NewPingRecordRepository(db.GORM)
+	e := newRouter(&resolver.Resolver{User: userUC, CardgroupUC: cardgroupUC, CardUC: cardUC, SwipeUC: swipeUC}, mw, userRepo, roleRepo, cardgroupRepo, cardRepo, pingRecordRepo, "test-token", swipeRecordRepo)
 
 	ts := httptest.NewServer(e)
 	t.Cleanup(ts.Close)

--- a/backend/cmd/server/main_test.go
+++ b/backend/cmd/server/main_test.go
@@ -276,6 +276,28 @@ func TestRun_FailsWhenDBURLMissing(t *testing.T) {
 	}
 }
 
+func TestRun_FailsWhenPINGTokenMissing(t *testing.T) {
+	tsJWKS := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"keys": []}`))
+	}))
+	defer tsJWKS.Close()
+
+	t.Setenv("SUPABASE_JWKS_URL", tsJWKS.URL)
+	t.Setenv("SUPABASE_JWT_AUDIENCE", "authenticated")
+	t.Setenv("SUPABASE_JWT_ISSUER", "http://issuer.test")
+	t.Setenv("SUPABASE_DB_URL", testDBURL)
+	t.Setenv("PING_TOKEN", "")
+
+	err := run(context.Background(), slog.New(slog.DiscardHandler))
+	if err == nil {
+		t.Fatal("expected error when PING_TOKEN is empty, got nil")
+	}
+	if !strings.Contains(err.Error(), "PING_TOKEN") {
+		t.Fatalf("expected error to mention PING_TOKEN, got: %v", err)
+	}
+}
+
 func TestGraphQLHealth(t *testing.T) {
 	t.Parallel()
 	ts := newTestServer(t)

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -25,6 +25,7 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.43.0
 	go.opentelemetry.io/otel/sdk v1.43.0
 	golang.org/x/sync v0.20.0
+	golang.org/x/time v0.14.0
 	gorm.io/driver/postgres v1.6.0
 	gorm.io/gorm v1.31.1
 )
@@ -99,7 +100,6 @@ require (
 	golang.org/x/net v0.52.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/text v0.36.0 // indirect
-	golang.org/x/time v0.14.0 // indirect
 	golang.org/x/tools v0.43.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260401024825-9d38bb4040a9 // indirect

--- a/backend/internal/database/migrations/20260501000000_add_ping_records.down.sql
+++ b/backend/internal/database/migrations/20260501000000_add_ping_records.down.sql
@@ -1,0 +1,6 @@
+-- Reverse of 20260501000000_add_ping_records.up.sql.
+-- Disable RLS, then drop the ping_records table.
+
+ALTER TABLE IF EXISTS public.ping_records DISABLE ROW LEVEL SECURITY;
+
+DROP TABLE IF EXISTS public.ping_records;

--- a/backend/internal/database/migrations/20260501000000_add_ping_records.up.sql
+++ b/backend/internal/database/migrations/20260501000000_add_ping_records.up.sql
@@ -1,0 +1,22 @@
+-- Add ping_records table for service readiness monitoring.
+--
+-- Stores periodic ping heartbeat records with minimal data (just id, created_at,
+-- updated_at). Table holds 0 or 1 row. Row Level Security is enabled with zero
+-- policies so PostgREST callers default-deny; the backend connects as the
+-- table-owner role and bypasses RLS.
+
+-- ---------------------------------------------------------------------------
+-- ping_records
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS public.ping_records (
+    id         uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- ---------------------------------------------------------------------------
+-- Row Level Security: enable with zero policies.
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE public.ping_records ENABLE ROW LEVEL SECURITY;

--- a/backend/internal/handler/ping/handler.go
+++ b/backend/internal/handler/ping/handler.go
@@ -1,0 +1,83 @@
+package ping
+
+import (
+	"crypto/subtle"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/labstack/echo/v5"
+	"github.com/labstack/echo/v5/middleware"
+	"golang.org/x/time/rate"
+
+	"backend/internal/repository"
+)
+
+// Handler holds dependencies for the /internal/ping endpoint.
+type Handler struct {
+	repo  repository.PingRecordRepository
+	token string
+}
+
+// New builds a Handler. Caller must ensure token is non-empty.
+func New(repo repository.PingRecordRepository, token string) *Handler {
+	return &Handler{repo: repo, token: token}
+}
+
+// Handle is the echo.HandlerFunc for POST /internal/ping.
+// Behavior:
+//   - 401 + {"error":"unauthorized"} on missing/invalid bearer token (constant-time compare).
+//   - On count==0: Create → 200 {"action":"created","count":1}.
+//   - On count>0:  DeleteAll → 200 {"action":"deleted","count":<rowsAffected>}.
+//   - On any repo error: 500 + {"error":"<msg>"}.
+func (h *Handler) Handle(c *echo.Context) error {
+	tokenBytes := []byte(h.token)
+	authHeader := c.Request().Header.Get("Authorization")
+	token := strings.TrimPrefix(authHeader, "Bearer ")
+	// Constant-time compare to prevent timing oracle attacks.
+	if subtle.ConstantTimeCompare([]byte(token), tokenBytes) != 1 {
+		return c.JSON(http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+	}
+
+	ctx := c.Request().Context()
+	n, err := h.repo.Count(ctx)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+
+	if n == 0 {
+		if err := h.repo.Create(ctx); err != nil {
+			return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		}
+		return c.JSON(http.StatusOK, map[string]any{"action": "created", "count": 1})
+	}
+
+	deleted, err := h.repo.DeleteAll(ctx)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+	return c.JSON(http.StatusOK, map[string]any{"action": "deleted", "count": deleted})
+}
+
+// RateLimiter returns the per-IP rate limiter middleware configured for this endpoint.
+// Config: Rate=1 req/s, Burst=5, ExpiresIn=3m, key=c.RealIP().
+func (h *Handler) RateLimiter() echo.MiddlewareFunc {
+	return middleware.RateLimiterWithConfig(middleware.RateLimiterConfig{
+		Store: middleware.NewRateLimiterMemoryStoreWithConfig(
+			middleware.RateLimiterMemoryStoreConfig{
+				Rate:      float64(rate.Limit(1)),
+				Burst:     5,
+				ExpiresIn: 3 * time.Minute,
+			},
+		),
+		IdentifierExtractor: func(c *echo.Context) (string, error) {
+			return c.RealIP(), nil
+		},
+		ErrorHandler: func(c *echo.Context, err error) error {
+			return c.JSON(http.StatusForbidden, map[string]string{"error": err.Error()})
+		},
+		DenyHandler: func(c *echo.Context, identifier string, err error) error {
+			return c.JSON(http.StatusTooManyRequests, map[string]string{"error": "rate limit exceeded"})
+		},
+	})
+}

--- a/backend/internal/handler/ping/handler.go
+++ b/backend/internal/handler/ping/handler.go
@@ -2,6 +2,7 @@ package ping
 
 import (
 	"crypto/subtle"
+	"log/slog"
 	"net/http"
 	"strings"
 	"time"
@@ -19,8 +20,11 @@ type Handler struct {
 	token string
 }
 
-// New builds a Handler. Caller must ensure token is non-empty.
+// New builds a Handler. Panics if token is empty.
 func New(repo repository.PingRecordRepository, token string) *Handler {
+	if token == "" {
+		panic("ping.New: token must not be empty")
+	}
 	return &Handler{repo: repo, token: token}
 }
 
@@ -29,32 +33,38 @@ func New(repo repository.PingRecordRepository, token string) *Handler {
 //   - 401 + {"error":"unauthorized"} on missing/invalid bearer token (constant-time compare).
 //   - On count==0: Create → 200 {"action":"created","count":1}.
 //   - On count>0:  DeleteAll → 200 {"action":"deleted","count":<rowsAffected>}.
-//   - On any repo error: 500 + {"error":"<msg>"}.
+//   - On any repo error: 500 + {"error":"internal server error"}.
 func (h *Handler) Handle(c *echo.Context) error {
 	tokenBytes := []byte(h.token)
 	authHeader := c.Request().Header.Get("Authorization")
 	token := strings.TrimPrefix(authHeader, "Bearer ")
 	// Constant-time compare to prevent timing oracle attacks.
 	if subtle.ConstantTimeCompare([]byte(token), tokenBytes) != 1 {
+		slog.WarnContext(c.Request().Context(), "ping: unauthorized",
+			"remote_ip", c.RealIP(),
+		)
 		return c.JSON(http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
 	}
 
 	ctx := c.Request().Context()
 	n, err := h.repo.Count(ctx)
 	if err != nil {
-		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		slog.ErrorContext(ctx, "ping: count failed", "err", err)
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "internal server error"})
 	}
 
 	if n == 0 {
 		if err := h.repo.Create(ctx); err != nil {
-			return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			slog.ErrorContext(ctx, "ping: create failed", "err", err)
+			return c.JSON(http.StatusInternalServerError, map[string]string{"error": "internal server error"})
 		}
 		return c.JSON(http.StatusOK, map[string]any{"action": "created", "count": 1})
 	}
 
 	deleted, err := h.repo.DeleteAll(ctx)
 	if err != nil {
-		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		slog.ErrorContext(ctx, "ping: delete failed", "err", err)
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "internal server error"})
 	}
 	return c.JSON(http.StatusOK, map[string]any{"action": "deleted", "count": deleted})
 }
@@ -77,6 +87,7 @@ func (h *Handler) RateLimiter() echo.MiddlewareFunc {
 			return c.JSON(http.StatusForbidden, map[string]string{"error": err.Error()})
 		},
 		DenyHandler: func(c *echo.Context, identifier string, err error) error {
+			slog.WarnContext(c.Request().Context(), "ping: rate limit exceeded", "ip", identifier)
 			return c.JSON(http.StatusTooManyRequests, map[string]string{"error": "rate limit exceeded"})
 		},
 	})

--- a/backend/internal/handler/ping/handler.go
+++ b/backend/internal/handler/ping/handler.go
@@ -20,7 +20,9 @@ type Handler struct {
 	token string
 }
 
-// New builds a Handler. Panics if token is empty.
+// New builds a Handler. The panic on empty token is a programmer-error guard
+// (defense in depth); production startup is gated earlier by the PING_TOKEN
+// fail-fast in run().
 func New(repo repository.PingRecordRepository, token string) *Handler {
 	if token == "" {
 		panic("ping.New: token must not be empty")
@@ -84,7 +86,8 @@ func (h *Handler) RateLimiter() echo.MiddlewareFunc {
 			return c.RealIP(), nil
 		},
 		ErrorHandler: func(c *echo.Context, err error) error {
-			return c.JSON(http.StatusForbidden, map[string]string{"error": err.Error()})
+			slog.WarnContext(c.Request().Context(), "ping: rate limiter extractor error", "err", err)
+			return c.JSON(http.StatusForbidden, map[string]string{"error": "forbidden"})
 		},
 		DenyHandler: func(c *echo.Context, identifier string, err error) error {
 			slog.WarnContext(c.Request().Context(), "ping: rate limit exceeded", "ip", identifier)

--- a/backend/internal/handler/ping/handler.go
+++ b/backend/internal/handler/ping/handler.go
@@ -30,6 +30,13 @@ func New(repo repository.PingRecordRepository, token string) *Handler {
 	return &Handler{repo: repo, token: token}
 }
 
+// internalError logs the given message and returns a sanitized 500 response.
+// Using a helper de-duplicates the three identical error-response sites in Handle.
+func internalError(c *echo.Context, msg string, err error) error {
+	slog.ErrorContext(c.Request().Context(), msg, "err", err)
+	return c.JSON(http.StatusInternalServerError, map[string]string{"error": "internal server error"})
+}
+
 // Handle is the echo.HandlerFunc for POST /internal/ping.
 // Behavior:
 //   - 401 + {"error":"unauthorized"} on missing/invalid bearer token (constant-time compare).
@@ -51,22 +58,19 @@ func (h *Handler) Handle(c *echo.Context) error {
 	ctx := c.Request().Context()
 	n, err := h.repo.Count(ctx)
 	if err != nil {
-		slog.ErrorContext(ctx, "ping: count failed", "err", err)
-		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "internal server error"})
+		return internalError(c, "ping: count failed", err)
 	}
 
 	if n == 0 {
 		if err := h.repo.Create(ctx); err != nil {
-			slog.ErrorContext(ctx, "ping: create failed", "err", err)
-			return c.JSON(http.StatusInternalServerError, map[string]string{"error": "internal server error"})
+			return internalError(c, "ping: create failed", err)
 		}
 		return c.JSON(http.StatusOK, map[string]any{"action": "created", "count": 1})
 	}
 
 	deleted, err := h.repo.DeleteAll(ctx)
 	if err != nil {
-		slog.ErrorContext(ctx, "ping: delete failed", "err", err)
-		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "internal server error"})
+		return internalError(c, "ping: delete failed", err)
 	}
 	return c.JSON(http.StatusOK, map[string]any{"action": "deleted", "count": deleted})
 }

--- a/backend/internal/handler/ping/handler_test.go
+++ b/backend/internal/handler/ping/handler_test.go
@@ -55,6 +55,15 @@ func newTestContext(e *echo.Echo, token string) (*echo.Context, *httptest.Respon
 	return c, rec
 }
 
+func TestNew_PanicsOnEmptyToken(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic on empty token, got none")
+		}
+	}()
+	_ = New(&fakePingRepo{}, "")
+}
+
 func TestHandler_Create(t *testing.T) {
 	e := echo.New()
 	h := New(&fakePingRepo{rows: 0}, testToken)
@@ -156,8 +165,52 @@ func TestHandler_Count_RepoError(t *testing.T) {
 	if rec.Code != http.StatusInternalServerError {
 		t.Errorf("status = %d, want %d", rec.Code, http.StatusInternalServerError)
 	}
-	if !strings.Contains(rec.Body.String(), `"error"`) {
-		t.Errorf("body %q missing error field", rec.Body.String())
+	body := rec.Body.String()
+	if !strings.Contains(body, `"error":"internal server error"`) {
+		t.Errorf("body %q missing sanitized error message", body)
+	}
+	if strings.Contains(body, "boom") {
+		t.Errorf("body %q must not contain raw error string", body)
+	}
+}
+
+func TestHandler_Create_RepoError(t *testing.T) {
+	e := echo.New()
+	h := New(&fakePingRepo{rows: 0, createErr: errors.New("create boom")}, testToken)
+	c, rec := newTestContext(e, testToken)
+
+	if err := h.Handle(c); err != nil {
+		t.Fatalf("Handle returned error: %v", err)
+	}
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusInternalServerError)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, `"error":"internal server error"`) {
+		t.Errorf("body %q missing sanitized error message", body)
+	}
+	if strings.Contains(body, "create boom") {
+		t.Errorf("body %q must not contain raw error string", body)
+	}
+}
+
+func TestHandler_DeleteAll_RepoError(t *testing.T) {
+	e := echo.New()
+	h := New(&fakePingRepo{rows: 1, deleteErr: errors.New("delete boom")}, testToken)
+	c, rec := newTestContext(e, testToken)
+
+	if err := h.Handle(c); err != nil {
+		t.Fatalf("Handle returned error: %v", err)
+	}
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusInternalServerError)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, `"error":"internal server error"`) {
+		t.Errorf("body %q missing sanitized error message", body)
+	}
+	if strings.Contains(body, "delete boom") {
+		t.Errorf("body %q must not contain raw error string", body)
 	}
 }
 
@@ -169,6 +222,7 @@ func TestHandler_RateLimiter_429(t *testing.T) {
 	// Register route with rate limiter to get real middleware chain.
 	e.POST("/internal/ping", h.Handle, h.RateLimiter())
 
+	got200 := false
 	got429 := false
 	for i := 0; i < 10; i++ {
 		req := httptest.NewRequest(http.MethodPost, "/internal/ping", nil)
@@ -177,10 +231,16 @@ func TestHandler_RateLimiter_429(t *testing.T) {
 		req.Header.Set("X-Real-IP", "192.0.2.1")
 		rec := httptest.NewRecorder()
 		e.ServeHTTP(rec, req)
+		if rec.Code == http.StatusOK {
+			got200 = true
+		}
 		if rec.Code == http.StatusTooManyRequests {
 			got429 = true
 			break
 		}
+	}
+	if !got200 {
+		t.Error("expected at least one 200 from initial requests, got none")
 	}
 	if !got429 {
 		t.Error("expected at least one 429 after 10 rapid requests, got none")

--- a/backend/internal/handler/ping/handler_test.go
+++ b/backend/internal/handler/ping/handler_test.go
@@ -1,0 +1,188 @@
+package ping
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo/v5"
+)
+
+// fakePingRepo is an in-memory implementation of repository.PingRecordRepository.
+type fakePingRepo struct {
+	rows      int64
+	countErr  error
+	createErr error
+	deleteErr error
+}
+
+func (f *fakePingRepo) Count(_ context.Context) (int64, error) {
+	if f.countErr != nil {
+		return 0, f.countErr
+	}
+	return f.rows, nil
+}
+
+func (f *fakePingRepo) Create(_ context.Context) error {
+	if f.createErr != nil {
+		return f.createErr
+	}
+	f.rows++
+	return nil
+}
+
+func (f *fakePingRepo) DeleteAll(_ context.Context) (int64, error) {
+	if f.deleteErr != nil {
+		return 0, f.deleteErr
+	}
+	deleted := f.rows
+	f.rows = 0
+	return deleted, nil
+}
+
+const testToken = "secret-token"
+
+func newTestContext(e *echo.Echo, token string) (*echo.Context, *httptest.ResponseRecorder) {
+	req := httptest.NewRequest(http.MethodPost, "/internal/ping", nil)
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	return c, rec
+}
+
+func TestHandler_Create(t *testing.T) {
+	e := echo.New()
+	h := New(&fakePingRepo{rows: 0}, testToken)
+	c, rec := newTestContext(e, testToken)
+
+	if err := h.Handle(c); err != nil {
+		t.Fatalf("Handle returned error: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, `"action":"created"`) {
+		t.Errorf("body %q missing action:created", body)
+	}
+	if !strings.Contains(body, `"count":1`) {
+		t.Errorf("body %q missing count:1", body)
+	}
+}
+
+func TestHandler_Delete(t *testing.T) {
+	e := echo.New()
+	h := New(&fakePingRepo{rows: 1}, testToken)
+	c, rec := newTestContext(e, testToken)
+
+	if err := h.Handle(c); err != nil {
+		t.Fatalf("Handle returned error: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, `"action":"deleted"`) {
+		t.Errorf("body %q missing action:deleted", body)
+	}
+	if !strings.Contains(body, `"count":1`) {
+		t.Errorf("body %q missing count:1", body)
+	}
+}
+
+func TestHandler_Unauthorized_NoHeader(t *testing.T) {
+	e := echo.New()
+	h := New(&fakePingRepo{}, testToken)
+	req := httptest.NewRequest(http.MethodPost, "/internal/ping", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	if err := h.Handle(c); err != nil {
+		t.Fatalf("Handle returned error: %v", err)
+	}
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusUnauthorized)
+	}
+	if !strings.Contains(rec.Body.String(), `"error":"unauthorized"`) {
+		t.Errorf("body %q missing error:unauthorized", rec.Body.String())
+	}
+}
+
+func TestHandler_Unauthorized_WrongToken(t *testing.T) {
+	e := echo.New()
+	h := New(&fakePingRepo{}, testToken)
+	req := httptest.NewRequest(http.MethodPost, "/internal/ping", nil)
+	req.Header.Set("Authorization", "Bearer wrong")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	if err := h.Handle(c); err != nil {
+		t.Fatalf("Handle returned error: %v", err)
+	}
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestHandler_Unauthorized_MalformedHeader(t *testing.T) {
+	e := echo.New()
+	h := New(&fakePingRepo{}, testToken)
+	req := httptest.NewRequest(http.MethodPost, "/internal/ping", nil)
+	req.Header.Set("Authorization", "foo bar baz")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	if err := h.Handle(c); err != nil {
+		t.Fatalf("Handle returned error: %v", err)
+	}
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestHandler_Count_RepoError(t *testing.T) {
+	e := echo.New()
+	h := New(&fakePingRepo{countErr: errors.New("boom")}, testToken)
+	c, rec := newTestContext(e, testToken)
+
+	if err := h.Handle(c); err != nil {
+		t.Fatalf("Handle returned error: %v", err)
+	}
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusInternalServerError)
+	}
+	if !strings.Contains(rec.Body.String(), `"error"`) {
+		t.Errorf("body %q missing error field", rec.Body.String())
+	}
+}
+
+func TestHandler_RateLimiter_429(t *testing.T) {
+	e := echo.New()
+	repo := &fakePingRepo{}
+	h := New(repo, testToken)
+
+	// Register route with rate limiter to get real middleware chain.
+	e.POST("/internal/ping", h.Handle, h.RateLimiter())
+
+	got429 := false
+	for i := 0; i < 10; i++ {
+		req := httptest.NewRequest(http.MethodPost, "/internal/ping", nil)
+		req.Header.Set("Authorization", "Bearer "+testToken)
+		// Use a fixed IP so all requests share the same rate-limiter bucket.
+		req.Header.Set("X-Real-IP", "192.0.2.1")
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+		if rec.Code == http.StatusTooManyRequests {
+			got429 = true
+			break
+		}
+	}
+	if !got429 {
+		t.Error("expected at least one 429 after 10 rapid requests, got none")
+	}
+}

--- a/backend/internal/handler/ping/handler_test.go
+++ b/backend/internal/handler/ping/handler_test.go
@@ -107,9 +107,7 @@ func TestHandler_Delete(t *testing.T) {
 func TestHandler_Unauthorized_NoHeader(t *testing.T) {
 	e := echo.New()
 	h := New(&fakePingRepo{}, testToken)
-	req := httptest.NewRequest(http.MethodPost, "/internal/ping", nil)
-	rec := httptest.NewRecorder()
-	c := e.NewContext(req, rec)
+	c, rec := newTestContext(e, "")
 
 	if err := h.Handle(c); err != nil {
 		t.Fatalf("Handle returned error: %v", err)
@@ -125,10 +123,7 @@ func TestHandler_Unauthorized_NoHeader(t *testing.T) {
 func TestHandler_Unauthorized_WrongToken(t *testing.T) {
 	e := echo.New()
 	h := New(&fakePingRepo{}, testToken)
-	req := httptest.NewRequest(http.MethodPost, "/internal/ping", nil)
-	req.Header.Set("Authorization", "Bearer wrong")
-	rec := httptest.NewRecorder()
-	c := e.NewContext(req, rec)
+	c, rec := newTestContext(e, "wrong")
 
 	if err := h.Handle(c); err != nil {
 		t.Fatalf("Handle returned error: %v", err)

--- a/backend/internal/repository/ping_record.go
+++ b/backend/internal/repository/ping_record.go
@@ -1,0 +1,49 @@
+package repository
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+type gormPingRecord struct {
+	ID        uuid.UUID `gorm:"column:id;primaryKey;type:uuid;default:gen_random_uuid()"`
+	CreatedAt time.Time `gorm:"column:created_at"`
+	UpdatedAt time.Time `gorm:"column:updated_at"`
+}
+
+func (gormPingRecord) TableName() string { return "ping_records" }
+
+// PingRecordRepository provides read/write access to public.ping_records.
+type PingRecordRepository interface {
+	Count(ctx context.Context) (int64, error)
+	Create(ctx context.Context) error
+	DeleteAll(ctx context.Context) (int64, error)
+}
+
+type pingRecordRepo struct{ db *gorm.DB }
+
+func NewPingRecordRepository(db *gorm.DB) PingRecordRepository {
+	return &pingRecordRepo{db: db}
+}
+
+func (r *pingRecordRepo) Count(ctx context.Context) (int64, error) {
+	var n int64
+	if err := r.db.WithContext(ctx).Model(&gormPingRecord{}).Count(&n).Error; err != nil {
+		return 0, err
+	}
+	return n, nil
+}
+
+// Create inserts a single ping record; the DB supplies id and timestamps.
+func (r *pingRecordRepo) Create(ctx context.Context) error {
+	return r.db.WithContext(ctx).Create(&gormPingRecord{}).Error
+}
+
+// DeleteAll removes all rows and returns the number of rows affected.
+func (r *pingRecordRepo) DeleteAll(ctx context.Context) (int64, error) {
+	result := r.db.WithContext(ctx).Where("1 = 1").Delete(&gormPingRecord{})
+	return result.RowsAffected, result.Error
+}

--- a/backend/internal/repository/ping_record.go
+++ b/backend/internal/repository/ping_record.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"time"
 
-	"github.com/google/uuid"
+	"github.com/rotisserie/eris"
 	"gorm.io/gorm"
 )
 
 type gormPingRecord struct {
-	ID        uuid.UUID `gorm:"column:id;primaryKey;type:uuid;default:gen_random_uuid()"`
+	ID        string    `gorm:"column:id;primaryKey;type:uuid;default:gen_random_uuid()"`
 	CreatedAt time.Time `gorm:"column:created_at"`
 	UpdatedAt time.Time `gorm:"column:updated_at"`
 }
@@ -32,18 +32,24 @@ func NewPingRecordRepository(db *gorm.DB) PingRecordRepository {
 func (r *pingRecordRepo) Count(ctx context.Context) (int64, error) {
 	var n int64
 	if err := r.db.WithContext(ctx).Model(&gormPingRecord{}).Count(&n).Error; err != nil {
-		return 0, err
+		return 0, eris.Wrap(err, "repository: ping_record count")
 	}
 	return n, nil
 }
 
 // Create inserts a single ping record; the DB supplies id and timestamps.
 func (r *pingRecordRepo) Create(ctx context.Context) error {
-	return r.db.WithContext(ctx).Create(&gormPingRecord{}).Error
+	if err := r.db.WithContext(ctx).Create(&gormPingRecord{}).Error; err != nil {
+		return eris.Wrap(err, "repository: ping_record create")
+	}
+	return nil
 }
 
 // DeleteAll removes all rows and returns the number of rows affected.
 func (r *pingRecordRepo) DeleteAll(ctx context.Context) (int64, error) {
 	result := r.db.WithContext(ctx).Where("1 = 1").Delete(&gormPingRecord{})
-	return result.RowsAffected, result.Error
+	if result.Error != nil {
+		return 0, eris.Wrap(result.Error, "repository: ping_record delete")
+	}
+	return result.RowsAffected, nil
 }

--- a/backend/internal/repository/ping_record_test.go
+++ b/backend/internal/repository/ping_record_test.go
@@ -8,7 +8,6 @@ import (
 )
 
 func TestPingRecord_CreateOnEmpty(t *testing.T) {
-	t.Parallel()
 	ctx := context.Background()
 	repo := repository.NewPingRecordRepository(testDB.GORM)
 
@@ -38,7 +37,6 @@ func TestPingRecord_CreateOnEmpty(t *testing.T) {
 }
 
 func TestPingRecord_DeleteAllOnPopulated(t *testing.T) {
-	t.Parallel()
 	ctx := context.Background()
 	repo := repository.NewPingRecordRepository(testDB.GORM)
 

--- a/backend/internal/repository/ping_record_test.go
+++ b/backend/internal/repository/ping_record_test.go
@@ -1,0 +1,121 @@
+package repository_test
+
+import (
+	"context"
+	"testing"
+
+	"backend/internal/repository"
+)
+
+func TestPingRecord_CreateOnEmpty(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	repo := repository.NewPingRecordRepository(testDB.GORM)
+
+	t.Cleanup(func() {
+		testDB.GORM.Exec("DELETE FROM ping_records")
+	})
+
+	n, err := repo.Count(ctx)
+	if err != nil {
+		t.Fatalf("Count (before create): %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("Count: got %d, want 0", n)
+	}
+
+	if err := repo.Create(ctx); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	n, err = repo.Count(ctx)
+	if err != nil {
+		t.Fatalf("Count (after create): %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("Count: got %d, want 1", n)
+	}
+}
+
+func TestPingRecord_DeleteAllOnPopulated(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	repo := repository.NewPingRecordRepository(testDB.GORM)
+
+	t.Cleanup(func() {
+		testDB.GORM.Exec("DELETE FROM ping_records")
+	})
+
+	if err := repo.Create(ctx); err != nil {
+		t.Fatalf("Create (seed): %v", err)
+	}
+
+	affected, err := repo.DeleteAll(ctx)
+	if err != nil {
+		t.Fatalf("DeleteAll: %v", err)
+	}
+	if affected != 1 {
+		t.Fatalf("DeleteAll rows affected: got %d, want 1", affected)
+	}
+
+	n, err := repo.Count(ctx)
+	if err != nil {
+		t.Fatalf("Count (after delete): %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("Count: got %d, want 0", n)
+	}
+}
+
+// TestPingRecord_OscillationFourCycles verifies the create/delete cycle four
+// times producing the sequence 0 -> 1 -> 0 -> 1 -> 0.
+func TestPingRecord_OscillationFourCycles(t *testing.T) {
+	ctx := context.Background()
+	repo := repository.NewPingRecordRepository(testDB.GORM)
+
+	t.Cleanup(func() {
+		testDB.GORM.Exec("DELETE FROM ping_records")
+	})
+
+	// Ensure starting from empty.
+	if _, err := repo.DeleteAll(ctx); err != nil {
+		t.Fatalf("initial DeleteAll: %v", err)
+	}
+
+	assertCount := func(want int64) {
+		t.Helper()
+		got, err := repo.Count(ctx)
+		if err != nil {
+			t.Fatalf("Count: %v", err)
+		}
+		if got != want {
+			t.Fatalf("Count: got %d, want %d", got, want)
+		}
+	}
+
+	assertCount(0)
+
+	// cycle 1: create -> 1
+	if err := repo.Create(ctx); err != nil {
+		t.Fatalf("cycle1 Create: %v", err)
+	}
+	assertCount(1)
+
+	// cycle 2: delete -> 0
+	if affected, err := repo.DeleteAll(ctx); err != nil || affected == 0 {
+		t.Fatalf("cycle2 DeleteAll: err=%v affected=%d", err, affected)
+	}
+	assertCount(0)
+
+	// cycle 3: create -> 1
+	if err := repo.Create(ctx); err != nil {
+		t.Fatalf("cycle3 Create: %v", err)
+	}
+	assertCount(1)
+
+	// cycle 4: delete -> 0
+	if affected, err := repo.DeleteAll(ctx); err != nil || affected == 0 {
+		t.Fatalf("cycle4 DeleteAll: err=%v affected=%d", err, affected)
+	}
+	assertCount(0)
+}

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -59,8 +59,9 @@ These values target a public API on Render. Revisit if the threat model or deplo
 | `DB_MIN_CONNS` | no | `0` | Minimum pool connections kept alive |
 | `DB_MAX_CONN_LIFETIME` | no | `30m` | Maximum lifetime of a pooled connection |
 | `DB_MAX_CONN_IDLE_TIME` | no | `5m` | Maximum idle time before a connection is evicted |
+| `PING_TOKEN` | yes | — | Bearer token for `POST /internal/ping`. Server refuses to start if empty. |
 
-`PORT`, `SHUTDOWN_TIMEOUT`, and `SWIPE_NEXT_BATCH_SIZE` are optional with safe defaults. The three `SUPABASE_JWT_*` variables and `SUPABASE_DB_URL` are all required — the server refuses to start if any is missing (fail-fast via `ConfigFromEnv`).
+`PORT`, `SHUTDOWN_TIMEOUT`, and `SWIPE_NEXT_BATCH_SIZE` are optional with safe defaults. The three `SUPABASE_JWT_*` variables, `SUPABASE_DB_URL`, and `PING_TOKEN` are all required — the server refuses to start if any is missing (fail-fast via `ConfigFromEnv` or inline check in `run()`).
 
 ## Testing patterns
 
@@ -259,6 +260,7 @@ database.Migrate(url)
 → repository.NewUserRepository(db.GORM)
 → repository.NewRoleRepository(db.GORM)
 → repository.NewCardgroupRepository(db.GORM)
+→ repository.NewPingRecordRepository(db.GORM)
 → server start
 ```
 
@@ -585,6 +587,30 @@ if len(ids) == 0 {
 ```
 
 This matters most in DataLoader batch functions, where an empty key slice is a normal edge case.
+
+### GORM v1 string-typed primary key with DB-generated UUID requires `default:` tag
+
+GORM's `BeforeCreate` hook auto-generates a UUID when a primary key field is a `string` type and is zero-valued — but only when the field carries `gorm:"default:..."` in its tag. Without the tag, GORM leaves the field empty and the INSERT fails.
+
+Peer models (`gormUser`, `gormCard`) avoid this by supplying the UUID in the application layer before calling `Create`. `gormPingRecord` is different: `Create` inserts a row without any caller-supplied ID, so the DB must generate it via `gen_random_uuid()`. The tag `gorm:"default:gen_random_uuid()"` is therefore load-bearing even though `AutoMigrate` is not used and the column default is already defined in the migration SQL.
+
+### GORM rejects unconditional `Delete` — use `Where("1 = 1")` to opt out
+
+GORM v2+ refuses a `Delete` call that has no `WHERE` clause as a safety net against accidental full-table deletes. It returns an `ErrMissingWhereClause` error.
+
+The deliberate opt-out for legitimate full-table deletes is:
+
+```go
+result := db.Where("1 = 1").Delete(&gormPingRecord{})
+```
+
+This makes the intent explicit and satisfies GORM's guard without suppressing the error check.
+
+### `subtle.ConstantTimeCompare` leaks token length — pair with a rate limiter
+
+`crypto/subtle.ConstantTimeCompare` returns early (0) when the two byte slices differ in length, leaking length via timing. For equal-length inputs the comparison runs in constant time. The practical impact for bearer-token checking is small when the token length is public knowledge (e.g. a fixed 64-hex-char token), but the leak becomes meaningful for variable-length or secret-length tokens without an external mitigation.
+
+The `/internal/ping` handler pairs `ConstantTimeCompare` with a per-IP rate limiter (1 req/s, burst 5). The rate limiter makes the length-oracle non-exploitable in practice: an attacker cannot iterate quickly enough to extract useful information before being throttled. Any future endpoint that adopts bearer-token comparison **without** a rate limiter must also add one — or switch to a constant-time scheme that does not branch on length.
 
 ### slog context enrichment must precede the log call that announces the enrichment
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -91,6 +91,18 @@ Two safe forms:
 
 Do **not** mix the two by keeping the full `backend/...` path when `working-directory` is already `backend/`.
 
+## `curl --retry` does not retry 5xx by default — add `--retry-all-errors`
+
+`curl --retry N` retries only on connection-level failures (timeouts, refused connections). It does **not** retry HTTP 5xx responses by default. A workflow step that uses `curl -fsS --retry 3` will appear to succeed (exit 0) even if the server returns 503 or 504 on every attempt, because `-f` causes curl to exit non-zero only on 4xx/5xx **after** exhausting all retries — and retries only fire when the failure is at the transport layer, not the HTTP layer.
+
+The fix is `--retry-all-errors`, which instructs curl to treat any failure, including HTTP error codes, as a retry trigger:
+
+```bash
+curl -fsS --retry 3 --retry-delay 5 --retry-all-errors --max-time 60 "$URL"
+```
+
+This is the canonical form used in `.github/workflows/readiness-ping.yml`. Apply it to any future workflow step that must detect transient 5xx responses rather than silently treating them as success.
+
 ## Frontend workflow
 
 `.github/workflows/frontend.yml` mirrors the backend workflow's structure — per-service scope, major-tag pinning, per-ref concurrency — but has a different install/verify pipeline because the frontend is a pnpm workspace rooted at the repo root.
@@ -103,7 +115,7 @@ For the same reason, the frontend workflow's `paths:` filter includes `pnpm-lock
 
 ### `--if-present` on the test step (revisit when Vitest lands)
 
-Per "pnpm workspace filter exits 0 for missing scripts" above, a missing `test` script in `frontend/package.json` would silently pass with plain `pnpm --filter frontend test`. The current workflow runs `pnpm --filter frontend --if-present test` specifically so the step becomes a documented no-op today and **automatically activates** once PR 5 adds the `test` script plus a Vitest config — no workflow edit needed at that point. When Vitest lands, do not drop the `--if-present` flag: it stays as a guard against future script renames.
+Per "pnpm workspace filter exits 0 for missing scripts" above, a missing `test` script in `frontend/package.json` would silently pass with plain `pnpm --filter frontend test`. The current workflow runs `pnpm --filter frontend --if-present test` specifically so the step becomes a documented no-op today and **automatically activates** once the `test` script plus a Vitest config are added — no workflow edit needed at that point. When Vitest lands, do not drop the `--if-present` flag: it stays as a guard against future script renames.
 
 ### Node/pnpm provisioning via mise
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -272,6 +272,8 @@ For an end-to-end check, sign in via Google on the Vercel domain and load `/prof
 
 The readiness-ping workflow keeps Render and Vercel warm and ensures Supabase detects continuous activity (required for free-tier retention). A scheduled cron job runs every 15 minutes to ping the backend, which issues a write to Supabase to trigger activity detection — reads alone do not prevent free-tier inactivity timeouts.
 
+**Why writes, not reads:** Supabase's activity tracking counts only write operations (INSERT/UPDATE/DELETE) toward the free-tier "last active" timestamp. A read-only `SELECT` is invisible to this metric. The 0↔1 row oscillation design guarantees that every ping call performs either an INSERT or a DELETE, keeping the "last active" timestamp current without unbounded table growth.
+
 ### Endpoint
 
 ```

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -267,6 +267,51 @@ For an end-to-end check, sign in via Google on the Vercel domain and load `/prof
 - **Render free tier sleeps idle services.** The first request after idleness incurs a cold start. Health checks on `/health` keep the service warm only while traffic flows.
 - **Custom domains.** When adding a Vercel custom domain, also update the Supabase Auth Site URL and add the new origin to the Redirect URLs allow list.
 
+## Keep-alive ping workflow
+
+The readiness-ping workflow keeps Render and Vercel warm and ensures Supabase detects continuous activity (required for free-tier retention). A scheduled cron job runs every 15 minutes to ping the backend, which issues a write to Supabase to trigger activity detection — reads alone do not prevent free-tier inactivity timeouts.
+
+### Endpoint
+
+```
+POST /internal/ping
+Authorization: Bearer $PING_TOKEN
+```
+
+Response: `{"action":"created"|"deleted","count":N}` (200 OK). The endpoint oscillates a single row in `public.ping_records`: creates it when absent, deletes it when present. Each call guarantees a write, keeping Supabase active.
+
+Authentication is bearer-token based. Rate limiting is 1 request per second per IP, with a burst allowance of 5. The server **requires** the `PING_TOKEN` env var at startup and refuses to boot if it is empty.
+
+### Workflow and secrets
+
+The workflow file `.github/workflows/readiness-ping.yml` triggers on a 15-minute schedule (defined within the file). Required GitHub Actions secrets:
+
+| Secret | Purpose |
+|---|---|
+| `VERCEL_PING_URL` | Frontend domain to warm; the workflow GETs this URL to prevent Vercel cold starts. |
+| `RENDER_PING_URL` | Backend URL with scheme; the workflow POSTs to `/internal/ping` at this URL (e.g. `https://flamingo-backend.render.com`). |
+| `PING_TOKEN` | Bearer token for the POST request; must match the `PING_TOKEN` env var on the Render service. |
+
+On Render, set the environment variable:
+
+| Variable | Value |
+|---|---|
+| `PING_TOKEN` | Must match the GitHub Actions secret value. |
+
+### Manual trigger
+
+```bash
+gh workflow run readiness-ping.yml
+```
+
+### Verification
+
+List successful workflow runs:
+
+```bash
+gh run list --workflow=readiness-ping.yml --status=success
+```
+
 ## Tearing down production via `make teardown-prod`
 
 ### Why teardown is irreversible

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -53,7 +53,7 @@ The playbook persists collected values across phases in a YAML file at the repo 
 | Permissions | `0600` (re-asserted on every write) |
 | Backup | `<file>.<pid>.<timestamp>~` siblings created on every write (`copy: backup: yes`). Mode bits are preserved from the source (already `0600`). |
 | Vault | Not encrypted; gitignore + `0600` is the baseline |
-| Tier 1 secrets | `supabase_db_url` (DB password embedded). Do not share, copy across machines, or print on screen-share. |
+| Tier 1 secrets | `supabase_db_url` (DB password embedded) and `ping_token` (bearer token for `/internal/ping`). Do not share, copy across machines, or print on screen-share. |
 | Tier 2 publishable | `supabase_anon_key`. Safe to display on the operator's own screen. |
 | Tier 3 IDs / URLs | `supabase_project_ref`, `*_url`, `render_service_id`, `vercel_project_id`, `production_url`, `backend_url`. Public values, used as `--tags <phase>` re-run inputs. |
 | Out-of-state | API tokens (read from env each run) and the Render deploy-hook URL (consumed once via `gh secret set`, never persisted). |
@@ -64,9 +64,9 @@ Every phase that needs prior values follows a three-step idiom: `stat:` to detec
 
 `confirm=true` is the unattended-mode flag (intended for CI / scripted re-runs). Phases 2, 3, 4, and 5 all `fail` immediately when `confirm=true` is set, because each requires the operator to paste back values from a dashboard the playbook cannot read (project ref / anon key / DSN / service ID / deploy-hook / project ID / production URL / OAuth redirect URI). Failing fast with a clear message beats hanging on a `pause:` prompt that no one will answer. Phases 1 (preflight) and 6 (postapply) are the only fully unattended phases: postapply re-runs are how operators recover from a transient Render or Vercel cold-start smoke failure.
 
-### Three external side effects
+### External side effects
 
-The playbook only writes to three places outside the operator's machine: (1) `gh secret set RENDER_DEPLOY_HOOK_URL` on the GitHub repo (idempotent overwrite), (2) `POST /v1/services/<id>/deploys` against the Render API (each call enqueues a deploy, which is the operator's intent), and (3) the local state file. Re-running any phase is safe — none of the three writes accumulate state in a way that corrupts the next run.
+The playbook writes outside the operator's machine in five places: (1) `gh secret set RENDER_DEPLOY_HOOK_URL` on the GitHub repo (Phase 3, idempotent overwrite), (2) `gh secret set PING_TOKEN`, `gh secret set RENDER_PING_URL`, and `gh secret set VERCEL_PING_URL` on the GitHub repo (Phase 6, idempotent overwrite), (3) `PUT /v1/services/<id>/env-vars/<key>` against the Render API for dynamic env vars including `PING_TOKEN` (Phase 6), (4) `POST /v1/services/<id>/deploys` against the Render API (each call enqueues a deploy, which is the operator's intent), and (5) the local state file. Re-running any phase is safe — none of the writes accumulate state in a way that corrupts the next run.
 
 ### Two security patterns worth knowing
 
@@ -288,15 +288,13 @@ The workflow file `.github/workflows/readiness-ping.yml` triggers on a 15-minute
 
 | Secret | Purpose |
 |---|---|
-| `VERCEL_PING_URL` | Frontend domain to warm; the workflow GETs this URL to prevent Vercel cold starts. |
-| `RENDER_PING_URL` | Backend URL with scheme; the workflow POSTs to `/internal/ping` at this URL (e.g. `https://flamingo-backend.render.com`). |
+| `VERCEL_PING_URL` | Frontend base URL to warm; the workflow GETs this URL to prevent Vercel cold starts. |
+| `RENDER_PING_URL` | Backend base URL with scheme (e.g. `https://flamingo-backend.onrender.com`). The workflow appends `/internal/ping` automatically — do **not** include the path in the secret value. |
 | `PING_TOKEN` | Bearer token for the POST request; must match the `PING_TOKEN` env var on the Render service. |
 
-On Render, set the environment variable:
+All three secrets and the Render `PING_TOKEN` env var are provisioned automatically by `make setup-prod`: `PING_TOKEN` is auto-generated in Phase 3 and pushed to Render via the API in Phase 6 alongside the other dynamic env vars; `PING_TOKEN`, `RENDER_PING_URL`, and `VERCEL_PING_URL` are then registered as GitHub Actions secrets via `gh secret set` in Phase 6. `make teardown-prod` deletes the Render service (and with it the `PING_TOKEN` env var) but does **not** delete the GitHub secrets — they remain in place and are overwritten on the next `make setup-prod`.
 
-| Variable | Value |
-|---|---|
-| `PING_TOKEN` | Must match the GitHub Actions secret value. |
+On Render, `PING_TOKEN` is declared with `sync: false` in `render.yaml` (Blueprint creates the placeholder; Phase 6 fills the value). No manual action is needed.
 
 ### Manual trigger
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -195,6 +195,7 @@ Dynamic env vars (declared with `sync: false` in `render.yaml`; Blueprint create
 | `SUPABASE_DB_URL` | Session-mode pooler DSN from Step 1.4. | Phase 6 (`postapply.yml`) via `PUT /v1/services/{id}/env-vars/{key}`. |
 | `SUPABASE_JWKS_URL` | `https://<project-ref>.supabase.co/auth/v1/.well-known/jwks.json` | Phase 6. |
 | `SUPABASE_JWT_ISSUER` | `https://<project-ref>.supabase.co/auth/v1` | Phase 6. |
+| `PING_TOKEN` | Auto-generated 32-byte hex token consumed by the readiness-ping workflow (see [Keep-alive ping workflow](#keep-alive-ping-workflow)). | Phase 6 (`postapply.yml`). |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | OTLP endpoint, or empty for no-op tracing. | Operator (manual, persisted across Blueprint syncs because of `sync: false`). |
 
 When the Blueprint apply wizard prompts for the `sync: false` placeholders, leave them blank and click Save. Re-running `make setup-prod-postapply` reconciles the Supabase-derived three from the state file via the Render API, then triggers the first deploy.

--- a/docs/playbook-patterns.md
+++ b/docs/playbook-patterns.md
@@ -30,6 +30,19 @@ The `uri` module uses Python's `urllib`/`urllib3` stack, not the `requests` libr
 
 `verify_identity.yml` asserts `not (testing | default(false)) or resource_id is match('^test_.*')` before issuing any destructive call. When `testing=true`, any resource id that does not begin with `test_` fails the assertion and aborts the phase with a clear message. Production runs set `testing=false` (or omit it), so the prefix check never fires. The value of this pattern is that it cannot be bypassed by accident: a CI run that accidentally receives a real production resource id while `testing=true` is set will abort before the DELETE, not after.
 
+### Idempotent secret generation: guard before generating, not after
+
+When a phase auto-generates a secret (e.g. `openssl rand -hex 32` for `PING_TOKEN`), wrap the generation in a `when:` guard so that re-runs preserve an already-generated token rather than rotating it unexpectedly:
+
+```yaml
+- name: Generate PING_TOKEN if not present
+  set_fact:
+    ping_token: "{{ lookup('pipe', 'openssl rand -hex 32') }}"
+  when: ping_token is not defined or (ping_token | string | length) == 0
+```
+
+The guard checks both `is not defined` (first run, key absent from state file) and `length == 0` (key present but empty, e.g. from a corrupted state file). Without this guard, every `make setup-prod` re-run would rotate `PING_TOKEN`, requiring a simultaneous update of the GitHub secret, the Render env var, and any other consumer — defeating the purpose of automation.
+
 ## Cross-references
 
 The following operational expressions of the above patterns are documented in `docs/deployment.md`:

--- a/playbooks/setup-prod/postapply.yml
+++ b/playbooks/setup-prod/postapply.yml
@@ -46,6 +46,7 @@
       - production_url is defined and (production_url | length) > 0
       - vercel_project_id is defined and (vercel_project_id | length) > 0
       - vercel_repo_id is defined and (vercel_repo_id | string | length) > 0
+      - ping_token is defined and (ping_token | string | length) > 0
     fail_msg: |
       State file is missing or incomplete:
         state file exists : {{ _state_stat.stat.exists }}
@@ -54,8 +55,9 @@
         production_url    : {{ production_url | default('(missing)') }}
         vercel_project_id : {{ vercel_project_id | default('(missing)') }}
         vercel_repo_id    : {{ vercel_repo_id | default('(missing)') }}
+        ping_token        : {{ '(present)' if (ping_token is defined and (ping_token | string | length) > 0) else '(missing)' }}
       Run the prerequisite phases first:
-        - render_service_id, backend_url               -> ansible-playbook -i playbooks/inventory.local playbooks/setup-prod.yml --tags render   (Phase 3)
+        - render_service_id, backend_url, ping_token    -> ansible-playbook -i playbooks/inventory.local playbooks/setup-prod.yml --tags render   (Phase 3)
         - production_url, vercel_project_id, vercel_repo_id -> ansible-playbook -i playbooks/inventory.local playbooks/setup-prod.yml --tags vercel  (Phase 4)
       If the state file appears corrupt, restore from the most recent backup:
         cp "$(ls -1t {{ state_file }}.*~ 2>/dev/null | head -1)" {{ state_file }}
@@ -231,6 +233,8 @@
           value: "{{ supabase_jwks_url }}"
         - key: SUPABASE_JWT_ISSUER
           value: "{{ supabase_jwt_issuer }}"
+        - key: PING_TOKEN
+          value: "{{ ping_token }}"
       loop_control:
         label: "{{ item.key }}"
   rescue:
@@ -253,6 +257,121 @@
 
           Fix the underlying issue, then re-run:
             make setup-prod-postapply
+
+# ---------------------------------------------------------------------------
+# Register ping-related GitHub Actions secrets.
+#
+# Three secrets are pushed idempotently via `gh secret set`:
+#   PING_TOKEN       -- the bearer token for POST /internal/ping (auto-generated
+#                       in Phase 3 and persisted in the state file).
+#   RENDER_PING_URL  -- the Render backend base URL (backend_url from state).
+#                       The workflow appends /internal/ping itself, so this is
+#                       just the scheme + host (e.g. https://flamingo-backend.onrender.com).
+#   VERCEL_PING_URL  -- the Vercel production URL (production_url from state).
+#                       Guaranteed to have a scheme because Phase 4 asserts it
+#                       starts with https://.
+#
+# Mirror the RENDER_DEPLOY_HOOK_URL pattern from render.yml:
+#   - shell: + stdin: (never argv) to keep secret off ps / audit logs.
+#   - stdin_add_newline: false to prevent a trailing \n in the stored value.
+#   - failed_when: false + manual rc check so the rescue can surface context.
+#   - no_log: true on all tasks that handle secret values.
+# ---------------------------------------------------------------------------
+- name: Register PING_TOKEN as GitHub Actions secret
+  ansible.builtin.shell:
+    cmd: gh secret set PING_TOKEN --repo {{ repo }}
+    stdin: "{{ ping_token }}"
+    stdin_add_newline: false
+  register: _gh_ping_token_result
+  no_log: true
+  failed_when: false
+  changed_when: _gh_ping_token_result.rc == 0
+
+- name: Fail with remediation if PING_TOKEN secret set failed
+  ansible.builtin.fail:
+    msg: |
+      gh secret set PING_TOKEN failed (rc={{ _gh_ping_token_result.rc }}).
+
+      gh diagnostic:
+        stderr: {{ _gh_ping_token_result.stderr | default('(none)') }}
+        stdout: {{ _gh_ping_token_result.stdout | default('(none)') }}
+
+      Common causes:
+        - gh CLI lost the `repo` write scope. Re-run:
+            gh auth refresh -s repo
+        - GitHub API rate limit. Wait a minute and retry.
+        - `repo` var is wrong / repo not found. Verify {{ repo }} is correct.
+
+      Then retry: ansible-playbook -i playbooks/inventory.local playbooks/setup-prod.yml --tags postapply
+  when: _gh_ping_token_result.rc != 0
+
+- name: Confirm PING_TOKEN GitHub secret registered
+  ansible.builtin.debug:
+    msg: "PING_TOKEN registered as a GitHub Actions secret in {{ repo }}."
+
+- name: Register RENDER_PING_URL as GitHub Actions secret
+  ansible.builtin.shell:
+    cmd: gh secret set RENDER_PING_URL --repo {{ repo }}
+    stdin: "{{ backend_url }}"
+    stdin_add_newline: false
+  register: _gh_render_ping_url_result
+  no_log: true
+  failed_when: false
+  changed_when: _gh_render_ping_url_result.rc == 0
+
+- name: Fail with remediation if RENDER_PING_URL secret set failed
+  ansible.builtin.fail:
+    msg: |
+      gh secret set RENDER_PING_URL failed (rc={{ _gh_render_ping_url_result.rc }}).
+
+      gh diagnostic:
+        stderr: {{ _gh_render_ping_url_result.stderr | default('(none)') }}
+        stdout: {{ _gh_render_ping_url_result.stdout | default('(none)') }}
+
+      Common causes:
+        - gh CLI lost the `repo` write scope. Re-run:
+            gh auth refresh -s repo
+        - GitHub API rate limit. Wait a minute and retry.
+        - `repo` var is wrong / repo not found. Verify {{ repo }} is correct.
+
+      Then retry: ansible-playbook -i playbooks/inventory.local playbooks/setup-prod.yml --tags postapply
+  when: _gh_render_ping_url_result.rc != 0
+
+- name: Confirm RENDER_PING_URL GitHub secret registered
+  ansible.builtin.debug:
+    msg: "RENDER_PING_URL registered as a GitHub Actions secret in {{ repo }}."
+
+- name: Register VERCEL_PING_URL as GitHub Actions secret
+  ansible.builtin.shell:
+    cmd: gh secret set VERCEL_PING_URL --repo {{ repo }}
+    stdin: "{{ production_url }}"
+    stdin_add_newline: false
+  register: _gh_vercel_ping_url_result
+  no_log: true
+  failed_when: false
+  changed_when: _gh_vercel_ping_url_result.rc == 0
+
+- name: Fail with remediation if VERCEL_PING_URL secret set failed
+  ansible.builtin.fail:
+    msg: |
+      gh secret set VERCEL_PING_URL failed (rc={{ _gh_vercel_ping_url_result.rc }}).
+
+      gh diagnostic:
+        stderr: {{ _gh_vercel_ping_url_result.stderr | default('(none)') }}
+        stdout: {{ _gh_vercel_ping_url_result.stdout | default('(none)') }}
+
+      Common causes:
+        - gh CLI lost the `repo` write scope. Re-run:
+            gh auth refresh -s repo
+        - GitHub API rate limit. Wait a minute and retry.
+        - `repo` var is wrong / repo not found. Verify {{ repo }} is correct.
+
+      Then retry: ansible-playbook -i playbooks/inventory.local playbooks/setup-prod.yml --tags postapply
+  when: _gh_vercel_ping_url_result.rc != 0
+
+- name: Confirm VERCEL_PING_URL GitHub secret registered
+  ansible.builtin.debug:
+    msg: "VERCEL_PING_URL registered as a GitHub Actions secret in {{ repo }}."
 
 # Wrapped in block/rescue because the inner task carries `no_log: true`
 # (the request URL embeds render_service_id and the Bearer header carries

--- a/playbooks/setup-prod/render.yml
+++ b/playbooks/setup-prod/render.yml
@@ -2,7 +2,7 @@
 # Phase 3: Render web service bring-up.
 #
 # Reads:  state file (supabase_* keys written by Phase 2)
-# Writes: state file adds render_service_id, backend_url
+# Writes: state file adds render_service_id, backend_url, ping_token
 # Side-effect: gh secret set RENDER_DEPLOY_HOOK_URL (idempotent overwrite)
 #
 # `state_file`, `repo`, and `confirm` come from the entry playbook
@@ -202,10 +202,23 @@
   ansible.builtin.debug:
     msg: "RENDER_DEPLOY_HOOK_URL registered as a GitHub Actions secret in {{ repo }}."
 
-# --- Persist render_service_id and backend_url into state file ---
+# --- Generate PING_TOKEN if not already in state ---
+# The token is auto-generated (no external source); generating it here, in
+# Phase 3, means it is available in the state file before Phase 6 needs to
+# push it to Render via the API. Idempotent: if the state file already
+# carries a non-empty ping_token (re-run of Phase 3), the existing value is
+# loaded by include_vars above and the generation task is skipped.
+- name: Generate PING_TOKEN if not already in state
+  ansible.builtin.set_fact:
+    ping_token: "{{ lookup('pipe', 'openssl rand -hex 32') }}"
+  when: ping_token is not defined or (ping_token | string | length) == 0
+  no_log: true
+
+# --- Persist render_service_id, backend_url, and ping_token into state file ---
 # State file is known to exist at this point (assert above would have failed
 # otherwise), so re-reading via lookup is safe without errors='ignore'.
-# no_log on both tasks: the merged dict carries supabase_db_url (DB password).
+# no_log on both tasks: the merged dict carries supabase_db_url (DB password)
+# and ping_token.
 - name: Merge new values into existing state
   ansible.builtin.set_fact:
     state_merged: >-
@@ -213,6 +226,7 @@
          | combine({
              'render_service_id': render_service_id,
              'backend_url': backend_url,
+             'ping_token': ping_token,
            }) }}
   no_log: true
 
@@ -232,5 +246,6 @@
       Phase 3 complete.
         render_service_id : {{ render_service_id }}
         backend_url       : {{ backend_url }}
+        ping_token        : (generated; stored in state file -- do not print)
       State written to {{ state_file }}.
       Next: ansible-playbook -i playbooks/inventory.local playbooks/setup-prod.yml --tags vercel

--- a/render.yaml
+++ b/render.yaml
@@ -9,11 +9,11 @@
 #     OTEL_TRACES_SAMPLER_ARG, SUPABASE_JWT_AUDIENCE) are declared with
 #     `value:` and are reconciled by Blueprint sync.
 #   - Dynamic env var VALUES (SUPABASE_DB_URL, SUPABASE_JWKS_URL,
-#     SUPABASE_JWT_ISSUER) are declared with `sync: false` so Blueprint
-#     only creates the placeholder; the actual value is upserted by
-#     `playbooks/setup-prod/postapply.yml` via
-#     `PUT /v1/services/{id}/env-vars/{key}` after Phase 2 has produced
-#     the Supabase-derived values.
+#     SUPABASE_JWT_ISSUER, PING_TOKEN) are declared with `sync: false` so
+#     Blueprint only creates the placeholder; the actual value is upserted
+#     by `playbooks/setup-prod/postapply.yml` via
+#     `PUT /v1/services/{id}/env-vars/{key}` after the relevant setup phases
+#     have produced the derived values.
 #   - OTEL_EXPORTER_OTLP_ENDPOINT is operator-discretionary, so it is
 #     declared `sync: false` and left for the operator to set manually
 #     in the dashboard (or leave blank for no-op tracing).
@@ -62,4 +62,6 @@ services:
       - key: SUPABASE_JWT_ISSUER
         sync: false
       - key: OTEL_EXPORTER_OTLP_ENDPOINT
+        sync: false
+      - key: PING_TOKEN
         sync: false


### PR DESCRIPTION
## Summary

Adds an end-to-end keep-alive ping system spanning the backend, CI, and the production setup playbooks. A scheduled GitHub Actions workflow (`readiness-ping`, every 15 minutes) pings the Vercel frontend with `GET` and the Render backend with `POST /internal/ping` carrying a bearer token. The new endpoint oscillates a single row in `public.ping_records` — creating when absent, deleting when present — so every call writes to Supabase, keeping the free-tier "last active" timestamp current. `PING_TOKEN` is auto-generated by `make setup-prod` Phase 3, persisted into the state file, pushed to Render via the API in Phase 6, and registered as a GitHub Actions secret alongside `RENDER_PING_URL` and `VERCEL_PING_URL`.

## Background / Motivation

- Render free-tier services sleep after idle periods, Vercel cold-starts, and Supabase free-tier projects pause when their "last active" timestamp ages out. Health-check probes mitigate the first two, but Supabase's activity tracking counts **only write operations** (INSERT / UPDATE / DELETE) toward the timestamp — a `SELECT` is invisible to it. Any keep-alive scheme has to issue a write on every tick, not a read.
- The 0↔1 row oscillation design (`Count == 0` → `Create`, otherwise → `DeleteAll`) guarantees that every ping performs exactly one write while the table stays at most one row. Unbounded growth is impossible by construction; no scheduled cleanup job is needed. The repository surface is intentionally small — `Count`, `Create`, `DeleteAll`, no `Update` — so the oscillation is the only behavior the table supports.
- `subtle.ConstantTimeCompare` returns early (`0`) when the two byte slices differ in length, leaking length via timing. For a fixed-length 64-hex-char token the leak is bounded, but to make it non-exploitable in practice the handler pairs the comparison with an Echo per-IP rate limiter (1 req/s, burst 5, 3-minute key expiry). The doc note in `docs/backend.md` flags this so any future bearer-token endpoint must also pair a rate limiter — or switch to a length-independent scheme.
- `curl --retry N` retries only at the transport layer (timeouts, refused connections); HTTP 5xx responses are **not** retried by default. A workflow step using `curl -fsS --retry 3` against a service mid-cold-start would silently pass on the first non-5xx attempt — but never retry through a 503 streak. The fix is `--retry-all-errors`, which the readiness-ping workflow uses for both the Vercel and Render calls. Codified in `docs/ci.md` so future workflow authors do not re-discover it.
- GORM gotchas surfaced while wiring `gormPingRecord` are now in `docs/backend.md`: (1) a `string`-typed primary key with a DB-generated UUID needs the `gorm:"default:gen_random_uuid()"` tag — without it GORM leaves the column empty and the INSERT fails, even when the SQL column default is already set in the migration; (2) GORM v2+ rejects an unconditional `Delete` with `ErrMissingWhereClause`, so legitimate full-table deletes must use the `Where("1 = 1").Delete(...)` opt-out, which makes the intent explicit.
- `PING_TOKEN` is a Tier 1 secret (alongside `supabase_db_url`): the Phase 3 set_fact task generates it via `openssl rand -hex 32` only when not already in state (`when: ping_token is not defined or (ping_token | string | length) == 0`), so re-running `make setup-prod` does not rotate the token and force a simultaneous update of the GitHub secret and the Render env var. The idempotent-secret-generation pattern is now codified in `docs/playbook-patterns.md`.
- The server enforces `PING_TOKEN` at startup with an `eris.New` fail-fast inside `run()`. `ping.New` *also* panics on an empty token — that is defense-in-depth for a programmer error (a future caller wiring the handler with an unconfigured token in tests or a refactor) and is covered by a regression test (`TestRun_FailsWhenPINGTokenMissing`) so the env-level guard cannot be silently removed.

## Changes

### `ping_records` table + repository

- `backend/internal/database/migrations/20260501000000_add_ping_records.{up,down}.sql` (new): `public.ping_records (id uuid pk default gen_random_uuid(), created_at timestamptz default now(), updated_at timestamptz default now())`. The up migration ends with `ALTER TABLE … ENABLE ROW LEVEL SECURITY` (zero policies — default-deny for `anon` / `authenticated` PostgREST callers, while the table-owner role used by the backend bypasses RLS). The down migration disables RLS first, then drops the table.
- `backend/internal/repository/ping_record.go` (new): `PingRecordRepository` interface exposing `Count(ctx) (int64, error)`, `Create(ctx) error`, `DeleteAll(ctx) (int64, error)`. The `gormPingRecord` model carries `gorm:"column:id;primaryKey;type:uuid;default:gen_random_uuid()"` so GORM accepts the zero-valued ID and lets Postgres fill it. `DeleteAll` uses `Where("1 = 1").Delete(...)` to opt out of GORM's missing-WHERE guard and returns `RowsAffected`. There are no `Update` or `FindByID` methods — by design.
- `backend/internal/repository/ping_record_test.go` (new) covers `TestPingRecord_CreateOnEmpty`, `TestPingRecord_DeleteAllOnPopulated`, and `TestPingRecord_OscillationFourCycles` (four full create→delete→create→delete rounds against testcontainer Postgres) to lock the oscillation invariant.

### `/internal/ping` HTTP handler

- `backend/internal/handler/ping/handler.go` (new): `Handler` holds `repo PingRecordRepository` and `token string`. `New(repo, token)` panics on an empty token. `Handle(c)` parses `Authorization: Bearer <token>`, runs `subtle.ConstantTimeCompare` against the configured token, then dispatches: `Count == 0` → `Create` → `200 {"action":"created","count":1}`; otherwise → `DeleteAll` → `200 {"action":"deleted","count":<RowsAffected>}`. Authentication failures return `401 {"error":"unauthorized"}` and log a `WarnContext` with `remote_ip` only (the rejected token is never logged). Repo failures route through `internalError(c, msg, err)`, which logs a structured `ErrorContext` with the wrapped error and returns `500 {"error":"internal server error"}` — the helper de-duplicates the three identical 500 sites in `Handle`.
- `RateLimiter()` returns `middleware.RateLimiterWithConfig` keyed on `c.RealIP()`, configured `Rate=1`, `Burst=5`, `ExpiresIn=3m`. Both `ErrorHandler` and `DenyHandler` log a `WarnContext` and return a sanitized JSON body (`403 {"error":"forbidden"}` and `429 {"error":"rate limit exceeded"}` respectively); the upstream Echo middleware error is **not** echoed in the response.
- `backend/internal/handler/ping/handler_test.go` (new): table-driven coverage for unauthorized (missing header, wrong token, empty token), the create branch, the delete branch with multiple rows, the 500 paths for `Count` / `Create` / `DeleteAll` failures, and the rate-limiter `429` after burst exhaustion.

### Server wiring + `PING_TOKEN` fail-fast

- `backend/cmd/server/main.go`: `run(ctx, logger)` reads `os.Getenv("PING_TOKEN")` and returns `eris.New("run: PING_TOKEN env var is required")` when empty — the check sits before `ConfigFromEnv` so the server refuses to start without a token regardless of which other env vars are set. `repository.NewPingRecordRepository(db.GORM)` is constructed alongside the existing repos; `ping.New(pingRecordRepo, pingToken)` is constructed and threaded into `newRouter`. `newRouter` adds `e.POST("/internal/ping", pingHandler.Handle, pingHandler.RateLimiter())` — the rate limiter is per-handler, not application-wide, so the GraphQL endpoint is unaffected.
- `backend/cmd/server/main_test.go`: `newTestServer` and `newGraphQLTestServerWithUserRepo` are updated to construct `ping.New(...)` (with `nil` repo / placeholder repo + `"test-token"`) so existing tests keep compiling. New `TestRun_FailsWhenPINGTokenMissing` asserts the env-level fail-fast: with `PING_TOKEN=""` set, `run` returns an error whose message contains `"PING_TOKEN"`. The three existing `TestRun_FailsWhen*Missing` tests are updated to set `PING_TOKEN=test-token` so they continue to exercise the JWT / DB-URL paths in isolation.

### Readiness-ping GitHub Actions workflow

- `.github/workflows/readiness-ping.yml` (new): cron `*/15 * * * *` plus `workflow_dispatch`, `permissions: contents: read`, `timeout-minutes: 5`. Two steps: a `GET` against `${{ secrets.VERCEL_PING_URL }}` and a `POST` against `${{ secrets.RENDER_PING_URL }}/internal/ping` carrying `Authorization: Bearer ${{ secrets.PING_TOKEN }}`. Both invocations use `curl -fsS --retry 3 --retry-delay 5 --retry-all-errors --max-time {30,60}` so transient 5xx responses are retried (not silently treated as success) and `-w "...status=%{http_code} time=%{time_total}s\n"` prints a structured one-liner to the Actions log. The workflow appends `/internal/ping` itself, so `RENDER_PING_URL` is just the scheme + host.

### Ansible auto-provisioning (Phase 3 + Phase 6)

- `playbooks/setup-prod/render.yml`: a new `set_fact` task generates `ping_token` via `lookup('pipe', 'openssl rand -hex 32')`, **gated** with `when: ping_token is not defined or (ping_token | string | length) == 0` so re-runs preserve the existing token rather than rotating it. `ping_token` is merged into the existing state-file write task alongside `render_service_id` and `backend_url`. Both tasks carry `no_log: true` because the merged dict already contains `supabase_db_url`.
- `playbooks/setup-prod/postapply.yml`: the preflight assert block now requires `ping_token` to be present and non-empty in the state file — the failure message lists `ping_token` alongside the other Phase-3 outputs and points at the same `--tags render` re-run path. The Render env-var loop adds `{ key: PING_TOKEN, value: "{{ ping_token }}" }` so the token is upserted via `PUT /v1/services/{id}/env-vars/PING_TOKEN`. Three new task pairs (each: `gh secret set` + `fail` with remediation + `debug` confirmation) push `PING_TOKEN`, `RENDER_PING_URL` (= `backend_url` from state), and `VERCEL_PING_URL` (= `production_url` from state) to the GitHub repo. Each `gh secret set` follows the existing `RENDER_DEPLOY_HOOK_URL` pattern: `cmd:` + `stdin:` (never argv, so the secret never lands on `ps` / audit logs), `stdin_add_newline: false`, `no_log: true`, `failed_when: false` + manual rc check so the rescue can surface gh's stderr.

### Render Blueprint

- `render.yaml`: appends `- key: PING_TOKEN; sync: false` to the env-var list — Blueprint creates the placeholder, Phase 6 fills the value via the API. The header comment is updated to list `PING_TOKEN` alongside the other dynamic env vars.

### Documentation

- `docs/backend.md`: adds `PING_TOKEN` to the env-var table (required); extends the optional-with-defaults paragraph; documents three discovered gotchas under the Repository section — GORM string-PK + DB-generated UUID requires the `default:` tag, GORM rejects unconditional `Delete` (use `Where("1 = 1")`), and `subtle.ConstantTimeCompare` leaks length so any bearer-token endpoint must pair a rate limiter.
- `docs/ci.md`: adds the `curl --retry` does-not-retry-5xx-by-default note with the canonical `--retry-all-errors` invocation, citing `readiness-ping.yml` as the reference.
- `docs/deployment.md`: extends the state-file Tier 1 row to list `ping_token`; renames "Three external side effects" to "External side effects" and updates the count to five (the three new GitHub secrets, plus the existing Render API + state-file writes); adds `PING_TOKEN` to the dynamic env-vars table; adds a "Keep-alive ping workflow" section covering the writes-not-reads rationale, the endpoint contract, the secrets table, the manual-trigger command, and the verification command.
- `docs/playbook-patterns.md`: adds an "Idempotent secret generation: guard before generating, not after" section codifying the `when: ping_token is not defined or (ping_token | string | length) == 0` pattern with the rationale that re-runs must not rotate auto-generated secrets.

## Verification

After merge, the following should all hold:

- `git ls-files backend/internal/database/migrations | grep ping_records` lists exactly two files: `20260501000000_add_ping_records.up.sql` and `…down.sql`.
- `grep -nE \"ENABLE ROW LEVEL SECURITY\" backend/internal/database/migrations/20260501000000_add_ping_records.up.sql` matches once; the corresponding down file has one `DISABLE ROW LEVEL SECURITY`.
- `grep -nE \"func \\(r \\*pingRecordRepo\\) (Update|FindByID)\" backend/internal/repository/ping_record.go` returns nothing — confirming the append-only-ish surface.
- `grep -n 'gorm:\"column:id;primaryKey;type:uuid;default:gen_random_uuid()\"' backend/internal/repository/ping_record.go` matches once and `grep -n 'Where(\"1 = 1\")' backend/internal/repository/ping_record.go` matches once.
- `grep -n \"subtle.ConstantTimeCompare\" backend/internal/handler/ping/handler.go` matches once and `grep -nE \"Rate:\\s*float64|Burst:\\s*5\" backend/internal/handler/ping/handler.go` confirms the 1 req/s, burst 5 configuration.
- `grep -n 'PING_TOKEN env var is required' backend/cmd/server/main.go` matches once and `TestRun_FailsWhenPINGTokenMissing` exists in `backend/cmd/server/main_test.go`.
- `grep -n '\\-\\-retry\\-all\\-errors' .github/workflows/readiness-ping.yml` matches twice (once per ping step).
- `grep -n 'sync: false' render.yaml | grep -B1 -A1 PING_TOKEN` shows the `PING_TOKEN; sync: false` pair.
- `grep -n \"ping_token is not defined\" playbooks/setup-prod/render.yml` matches once. `grep -n \"gh secret set PING_TOKEN\\|gh secret set RENDER_PING_URL\\|gh secret set VERCEL_PING_URL\" playbooks/setup-prod/postapply.yml` matches all three.
- `grep -n \"Keep-alive ping workflow\" docs/deployment.md` matches once. `grep -n \"Idempotent secret generation\" docs/playbook-patterns.md` matches once.

## Test plan

- [ ] `cd backend && go vet ./... && go build ./...` passes.
- [ ] `cd backend && go test -v -race -covermode=atomic -coverprofile=coverage.out ./...` passes; new tests under `internal/repository/ping_record_test.go`, `internal/handler/ping/handler_test.go`, and the `TestRun_FailsWhenPINGTokenMissing` case in `cmd/server/main_test.go` all run.
- [ ] Boot `cd backend && go run ./cmd/server` against a freshly-migrated DB with `PING_TOKEN=test-token` set. `curl -i -X POST -H \"Authorization: Bearer test-token\" http://localhost:1323/internal/ping` returns `200` with `{\"action\":\"created\",\"count\":1}`. A second identical call returns `{\"action\":\"deleted\",\"count\":1}`. A third returns `created` again. `SELECT count(*) FROM public.ping_records` toggles between 0 and 1 across the calls.
- [ ] Auth failure: `curl -i -X POST http://localhost:1323/internal/ping` returns `401 {\"error\":\"unauthorized\"}` (no header). `curl -i -X POST -H \"Authorization: Bearer wrong\" http://localhost:1323/internal/ping` also returns `401`.
- [ ] Rate limit: a tight loop of `curl` calls from the same source IP eventually returns `429 {\"error\":\"rate limit exceeded\"}` after the 5-request burst. Backend logs include a single `ping: rate limit exceeded` warn line per blocked request.
- [ ] Server fail-fast: `PING_TOKEN= go run ./cmd/server` (empty) exits with an error containing `PING_TOKEN`. Unsetting the env var produces the same behavior.
- [ ] Workflow dry-run: `gh workflow run readiness-ping.yml`, then `gh run list --workflow=readiness-ping.yml --status=success` shows the manually-triggered run. Inspect the run log: both `frontend status=200` and `backend status=200` lines appear.
- [ ] 5xx retry: temporarily point `RENDER_PING_URL` at a host that returns `503` (e.g. an httpbin mirror). Trigger the workflow manually — the backend step retries three times before failing the job (`time=` summary shows ~3 attempts), proving `--retry-all-errors` is in effect.
- [ ] Ansible idempotency: run `make setup-prod` end-to-end, capture `ping_token` from the state file, then re-run `--tags render` only. Confirm `ping_token` in the state file is **unchanged** (not rotated). Re-running `--tags postapply` re-applies the same value to Render and re-pushes the same value to the GitHub secret.
- [ ] State file Tier 1: confirm `ping_token` is in the state file at mode `0600` and is **not** echoed in any `-v` Ansible output (the `no_log: true` markers on the generation and merge tasks should keep it out).
- [ ] `grep -rnP \"[\\x{3040}-\\x{30ff}\\x{4e00}-\\x{9fff}]\" --include=\"*.go\" --include=\"*.sql\" --include=\"*.yml\" --include=\"*.yaml\" --include=\"*.md\" .github backend docs playbooks render.yaml` returns nothing (English-only policy under \`.claude/rules/language-policy.md\`).