### PR TITLE
feat(backend): add is_admin RBAC helper and FORBIDDEN error code

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -192,8 +192,10 @@ func run(ctx context.Context, logger *slog.Logger) error {
 	cardRepo := repository.NewCardRepository(db.GORM)
 	swipeRecordRepo := repository.NewSwipeRecordRepository(db.GORM)
 	pingRecordRepo := repository.NewPingRecordRepository(db.GORM)
+	userRoleRepo := repository.NewUserRoleRepository(db.GORM)
 	// Constructed to surface compile-time wiring even though no resolver references it yet.
-	_ = repository.NewUserRoleRepository(db.GORM)
+	// First consumer lands with the upcoming admin features.
+	_ = auth.NewService(userRoleRepo)
 
 	userUC := usecase.NewUserUsecase(userRepo)
 	cardgroupUC := usecase.NewCardgroupUsecase(cardgroupRepo)

--- a/backend/internal/auth/role.go
+++ b/backend/internal/auth/role.go
@@ -1,0 +1,34 @@
+package auth
+
+import (
+	"context"
+
+	"github.com/rotisserie/eris"
+
+	"backend/internal/repository"
+)
+
+// Service centralises authorisation helpers that depend on durable role state.
+// Construct once at boot and pass into resolvers / usecases that need to gate
+// on role membership. Keeping this struct distinct from the request-scoped
+// AuthUser lets us inject a mock UserRoleRepository in tests.
+type Service struct {
+	userRoles repository.UserRoleRepository
+}
+
+// NewService wires the auth.Service against a UserRoleRepository.
+func NewService(userRoles repository.UserRoleRepository) *Service {
+	return &Service{userRoles: userRoles}
+}
+
+// IsAdmin reports whether userID holds the "admin" role. The role name is a
+// constant (see docs/backend.md "Authorization at the usecase layer"); we
+// deliberately avoid taking the role name as a parameter so usecases cannot
+// drift to bespoke role names.
+func (s *Service) IsAdmin(ctx context.Context, userID string) (bool, error) {
+	ok, err := s.userRoles.HasRole(ctx, userID, "admin")
+	if err != nil {
+		return false, eris.Wrap(err, "auth: check admin role")
+	}
+	return ok, nil
+}

--- a/backend/internal/auth/role.go
+++ b/backend/internal/auth/role.go
@@ -21,10 +21,8 @@ func NewService(userRoles repository.UserRoleRepository) *Service {
 	return &Service{userRoles: userRoles}
 }
 
-// IsAdmin reports whether userID holds the "admin" role. The role name is a
-// constant (see docs/backend.md "Authorization at the usecase layer"); we
-// deliberately avoid taking the role name as a parameter so usecases cannot
-// drift to bespoke role names.
+// IsAdmin reports whether userID holds the "admin" role. The role name is
+// hardcoded to keep usecases from drifting to bespoke names.
 func (s *Service) IsAdmin(ctx context.Context, userID string) (bool, error) {
 	ok, err := s.userRoles.HasRole(ctx, userID, "admin")
 	if err != nil {

--- a/backend/internal/auth/role_test.go
+++ b/backend/internal/auth/role_test.go
@@ -1,0 +1,60 @@
+package auth_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"backend/internal/auth"
+)
+
+type stubUserRoles struct {
+	hasRole bool
+	err     error
+	gotUID  string
+	gotRole string
+}
+
+func (s *stubUserRoles) HasRole(_ context.Context, userID, roleName string) (bool, error) {
+	s.gotUID = userID
+	s.gotRole = roleName
+	return s.hasRole, s.err
+}
+
+func TestServiceIsAdmin(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		stub    *stubUserRoles
+		wantOK  bool
+		wantErr bool
+	}{
+		{"admin returns true", &stubUserRoles{hasRole: true}, true, false},
+		{"non-admin returns false", &stubUserRoles{hasRole: false}, false, false},
+		{"db error wrapped", &stubUserRoles{err: errors.New("boom")}, false, true},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			svc := auth.NewService(tc.stub)
+			ok, err := svc.IsAdmin(context.Background(), "user-1")
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("err mismatch: got %v, wantErr=%v", err, tc.wantErr)
+			}
+			if ok != tc.wantOK {
+				t.Fatalf("IsAdmin: got %v want %v", ok, tc.wantOK)
+			}
+			if !tc.wantErr {
+				if tc.stub.gotUID != "user-1" {
+					t.Errorf("uid passed through: got %q", tc.stub.gotUID)
+				}
+				if tc.stub.gotRole != "admin" {
+					t.Errorf("role passed through: got %q", tc.stub.gotRole)
+				}
+			}
+		})
+	}
+}

--- a/backend/internal/database/is_admin_function_test.go
+++ b/backend/internal/database/is_admin_function_test.go
@@ -2,6 +2,7 @@ package database_test
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"testing"
 
@@ -9,6 +10,17 @@ import (
 
 	"backend/internal/database"
 )
+
+// sqlDBForTest unwraps the underlying *sql.DB from db.GORM, failing the test on
+// error.
+func sqlDBForTest(t *testing.T, db *database.DB) *sql.DB {
+	t.Helper()
+	sqlDB, err := db.GORM.DB()
+	if err != nil {
+		t.Fatalf("gorm.DB(): %v", err)
+	}
+	return sqlDB
+}
 
 // openMigratedDB migrates testDSN and returns an open *database.DB.
 // The caller is responsible for calling db.Close().
@@ -29,10 +41,7 @@ func openMigratedDB(t *testing.T) *database.DB {
 func insertAuthUserForAdmin(t *testing.T, ctx context.Context, db *database.DB) string {
 	t.Helper()
 	id := uuid.NewString()
-	sqlDB, err := db.GORM.DB()
-	if err != nil {
-		t.Fatalf("gorm.DB(): %v", err)
-	}
+	sqlDB := sqlDBForTest(t, db)
 	email := fmt.Sprintf("%s@test", id)
 	if _, err := sqlDB.ExecContext(ctx,
 		`INSERT INTO auth.users (id, email) VALUES ($1, $2)`, id, email); err != nil {
@@ -49,11 +58,7 @@ func TestIsAdminFunction_True(t *testing.T) {
 	defer db.Close()
 
 	userID := insertAuthUserForAdmin(t, ctx, db)
-
-	sqlDB, err := db.GORM.DB()
-	if err != nil {
-		t.Fatalf("gorm.DB(): %v", err)
-	}
+	sqlDB := sqlDBForTest(t, db)
 
 	// Look up the seeded admin role id.
 	var adminRoleID string
@@ -86,11 +91,7 @@ func TestIsAdminFunction_FalseWhenNoRole(t *testing.T) {
 	defer db.Close()
 
 	userID := insertAuthUserForAdmin(t, ctx, db)
-
-	sqlDB, err := db.GORM.DB()
-	if err != nil {
-		t.Fatalf("gorm.DB(): %v", err)
-	}
+	sqlDB := sqlDBForTest(t, db)
 
 	var got bool
 	if err := sqlDB.QueryRowContext(ctx,
@@ -109,10 +110,7 @@ func TestIsAdminFunction_FalseWhenUnknownUser(t *testing.T) {
 	db := openMigratedDB(t)
 	defer db.Close()
 
-	sqlDB, err := db.GORM.DB()
-	if err != nil {
-		t.Fatalf("gorm.DB(): %v", err)
-	}
+	sqlDB := sqlDBForTest(t, db)
 
 	const unknownUID = "00000000-0000-0000-0000-000000000000"
 	var got bool

--- a/backend/internal/database/is_admin_function_test.go
+++ b/backend/internal/database/is_admin_function_test.go
@@ -1,0 +1,126 @@
+package database_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"backend/internal/database"
+)
+
+// openMigratedDB migrates testDSN and returns an open *database.DB.
+// The caller is responsible for calling db.Close().
+func openMigratedDB(t *testing.T) *database.DB {
+	t.Helper()
+	if err := database.Migrate(testDSN); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	db, err := database.Open(context.Background(), database.Config{URL: testDSN, MaxConns: 4})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	return db
+}
+
+// insertAuthUserForAdmin inserts a row in auth.users and returns the uuid string.
+// The corresponding public.users row is created automatically by the trigger.
+func insertAuthUserForAdmin(t *testing.T, ctx context.Context, db *database.DB) string {
+	t.Helper()
+	id := uuid.NewString()
+	sqlDB, err := db.GORM.DB()
+	if err != nil {
+		t.Fatalf("gorm.DB(): %v", err)
+	}
+	email := fmt.Sprintf("%s@test", id)
+	if _, err := sqlDB.ExecContext(ctx,
+		`INSERT INTO auth.users (id, email) VALUES ($1, $2)`, id, email); err != nil {
+		t.Fatalf("insert auth.users: %v", err)
+	}
+	return id
+}
+
+// TestIsAdminFunction_True verifies that a user assigned the admin role is
+// reported as admin by public.is_admin.
+func TestIsAdminFunction_True(t *testing.T) {
+	ctx := context.Background()
+	db := openMigratedDB(t)
+	defer db.Close()
+
+	userID := insertAuthUserForAdmin(t, ctx, db)
+
+	sqlDB, err := db.GORM.DB()
+	if err != nil {
+		t.Fatalf("gorm.DB(): %v", err)
+	}
+
+	// Look up the seeded admin role id.
+	var adminRoleID string
+	if err := sqlDB.QueryRowContext(ctx,
+		`SELECT id FROM public.roles WHERE name = 'admin'`).Scan(&adminRoleID); err != nil {
+		t.Fatalf("query admin role id: %v", err)
+	}
+
+	// Grant admin role to user.
+	if _, err := sqlDB.ExecContext(ctx,
+		`INSERT INTO public.user_roles (user_id, role_id) VALUES ($1, $2)`, userID, adminRoleID); err != nil {
+		t.Fatalf("insert user_roles: %v", err)
+	}
+
+	var got bool
+	if err := sqlDB.QueryRowContext(ctx,
+		`SELECT public.is_admin($1::uuid)`, userID).Scan(&got); err != nil {
+		t.Fatalf("query is_admin: %v", err)
+	}
+	if !got {
+		t.Fatal("is_admin: got false, want true for user with admin role")
+	}
+}
+
+// TestIsAdminFunction_FalseWhenNoRole verifies that a user without any role
+// assignment is not reported as admin.
+func TestIsAdminFunction_FalseWhenNoRole(t *testing.T) {
+	ctx := context.Background()
+	db := openMigratedDB(t)
+	defer db.Close()
+
+	userID := insertAuthUserForAdmin(t, ctx, db)
+
+	sqlDB, err := db.GORM.DB()
+	if err != nil {
+		t.Fatalf("gorm.DB(): %v", err)
+	}
+
+	var got bool
+	if err := sqlDB.QueryRowContext(ctx,
+		`SELECT public.is_admin($1::uuid)`, userID).Scan(&got); err != nil {
+		t.Fatalf("query is_admin: %v", err)
+	}
+	if got {
+		t.Fatal("is_admin: got true, want false for user with no role")
+	}
+}
+
+// TestIsAdminFunction_FalseWhenUnknownUser verifies that a uuid that does not
+// correspond to any user returns false (not an error).
+func TestIsAdminFunction_FalseWhenUnknownUser(t *testing.T) {
+	ctx := context.Background()
+	db := openMigratedDB(t)
+	defer db.Close()
+
+	sqlDB, err := db.GORM.DB()
+	if err != nil {
+		t.Fatalf("gorm.DB(): %v", err)
+	}
+
+	const unknownUID = "00000000-0000-0000-0000-000000000000"
+	var got bool
+	if err := sqlDB.QueryRowContext(ctx,
+		`SELECT public.is_admin($1::uuid)`, unknownUID).Scan(&got); err != nil {
+		t.Fatalf("query is_admin: %v", err)
+	}
+	if got {
+		t.Fatal("is_admin: got true, want false for unknown user")
+	}
+}

--- a/backend/internal/database/migrations/20260502000000_add_rbac_helpers.down.sql
+++ b/backend/internal/database/migrations/20260502000000_add_rbac_helpers.down.sql
@@ -1,0 +1,1 @@
+DROP FUNCTION IF EXISTS public.is_admin(uuid);

--- a/backend/internal/database/migrations/20260502000000_add_rbac_helpers.up.sql
+++ b/backend/internal/database/migrations/20260502000000_add_rbac_helpers.up.sql
@@ -1,0 +1,32 @@
+-- Add the RBAC helper function consumed by upcoming RLS policies and Go handlers.
+-- STABLE: reads tables, must not be IMMUTABLE.
+-- SECURITY DEFINER: function executes as owner so RLS-enabled callers can probe.
+-- search_path locked to public to neutralise SECURITY DEFINER injection vector.
+CREATE OR REPLACE FUNCTION public.is_admin(uid uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+    SELECT EXISTS (
+        SELECT 1
+        FROM public.user_roles ur
+        JOIN public.roles r ON r.id = ur.role_id
+        WHERE ur.user_id = uid
+          AND r.name = 'admin'
+    );
+$$;
+
+-- Lock down access: anonymous PostgREST callers must not probe role membership.
+REVOKE ALL ON FUNCTION public.is_admin(uuid) FROM PUBLIC;
+-- Grant only when the Supabase-managed "authenticated" role exists (production).
+-- The test container is a plain PostgreSQL instance without this role, so the
+-- grant is skipped there to keep migrations idempotent across both environments.
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'authenticated') THEN
+        GRANT EXECUTE ON FUNCTION public.is_admin(uuid) TO authenticated;
+    END IF;
+END
+$$;

--- a/backend/internal/gqlerr/errors.go
+++ b/backend/internal/gqlerr/errors.go
@@ -16,6 +16,7 @@ const (
 	CodeUnauthenticated Code = "UNAUTHENTICATED"
 	CodeBadUserInput    Code = "BAD_USER_INPUT"
 	CodeInternal        Code = "INTERNAL"
+	CodeForbidden       Code = "FORBIDDEN"
 )
 
 func Unauthenticated() *gqlerror.Error {
@@ -43,6 +44,18 @@ func Internal(ctx context.Context, err error) *gqlerror.Error {
 		Message: "internal server error",
 		Extensions: map[string]any{
 			"code": string(CodeInternal),
+		},
+	}
+}
+
+// NewForbidden returns a FORBIDDEN GraphQL error. The caller supplies a
+// human-readable message; do not include sensitive details (e.g. "user X is
+// not admin") — keep the message generic.
+func NewForbidden(msg string) *gqlerror.Error {
+	return &gqlerror.Error{
+		Message: msg,
+		Extensions: map[string]any{
+			"code": string(CodeForbidden),
 		},
 	}
 }

--- a/backend/internal/gqlerr/errors_test.go
+++ b/backend/internal/gqlerr/errors_test.go
@@ -142,3 +142,24 @@ func TestInternal_EmitsErrorChain(t *testing.T) {
 		t.Errorf("expected error_chain.root, got %v", chainMap)
 	}
 }
+
+func TestNewForbidden(t *testing.T) {
+	t.Parallel()
+
+	got := gqlerr.NewForbidden("access denied")
+
+	if got.Message != "access denied" {
+		t.Errorf("Message = %q, want %q", got.Message, "access denied")
+	}
+	if code := extString(t, got, "code"); code != "FORBIDDEN" {
+		t.Errorf("Extensions[code] = %q, want %q", code, "FORBIDDEN")
+	}
+}
+
+func TestIsCode_Forbidden(t *testing.T) {
+	t.Parallel()
+
+	if !gqlerr.IsCode(gqlerr.NewForbidden("x"), gqlerr.CodeForbidden) {
+		t.Error("IsCode should return true for FORBIDDEN code")
+	}
+}

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -252,6 +252,35 @@ When a migration fails mid-run, `schema_migrations.dirty=true` is set. Recovery 
 
 **Renaming or renumbering migration files is not transparent to the DB.** `golang-migrate` records the numeric version of each applied migration in `public.schema_migrations`. Renaming a file (e.g. `0001_create_profiles.up.sql` → `20250101000000_create_profiles.up.sql`) rewrites the source tree but **not** the DB row, so the next boot fails with `no migration found for version <N>: read down for version <N> migrations: file does not exist` — migrate's source-state reconciliation expects the recorded version to exist on disk. When the rename is identifier-only (up/down SQL bodies are byte-identical, `git log -M` reports an `R100` rename), the safe recovery is `UPDATE public.schema_migrations SET version = <new_version>, dirty = false WHERE version = <old_version>` against the production DB; the runbook lives in `playbooks/setup-prod/recover-migration-version-rebase.sql`. Do **not** apply this shortcut when the rename also changed migration content — in that case, squash the changes and use `migrate force <version>` against a known-good source state so the new content actually runs.
 
+#### SECURITY DEFINER helper recipe
+
+`SECURITY DEFINER` SQL functions used by RLS policies (e.g. `public.is_admin(uid uuid)`) must replicate this exact shape — each attribute has a load-bearing reason:
+
+```sql
+CREATE OR REPLACE FUNCTION public.is_admin(uid uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$ ... $$;
+
+REVOKE ALL ON FUNCTION public.is_admin(uuid) FROM PUBLIC;
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'authenticated') THEN
+        GRANT EXECUTE ON FUNCTION public.is_admin(uuid) TO authenticated;
+    END IF;
+END
+$$;
+```
+
+- `STABLE`, **not** `IMMUTABLE` — the function reads tables, and marking a table-reading function `IMMUTABLE` corrupts the planner's plan cache (the planner assumes the result is constant for fixed inputs).
+- `SECURITY DEFINER` — the function executes as its owner, so RLS-enabled callers can probe role membership without needing direct read on `roles` / `user_roles`.
+- `SET search_path = public` — neutralises the classic `SECURITY DEFINER` injection vector where an attacker creates a `pg_temp` shim function (e.g. their own `roles` table) that the function would otherwise resolve before the real one.
+- `REVOKE ALL FROM PUBLIC` then narrow `GRANT EXECUTE` — without revoking from `PUBLIC`, anonymous PostgREST callers (`anon` role) could invoke the helper as an oracle to enumerate role assignments. The grant is intentionally limited to the Supabase-managed `authenticated` role.
+- `DO $$ ... IF EXISTS pg_roles ... GRANT END $$` portability guard — the testcontainers Postgres used in `internal/database` integration tests does **not** have the Supabase-managed roles (`authenticated`, `anon`, `service_role`). Wrapping role-specific GRANTs in this conditional `DO` block keeps the migration applicable in both production (Supabase) and test (plain Postgres). The Go backend connects as the table owner and bypasses RLS, so the GRANT path is exercised only by direct PostgREST callers in production.
+
 ### Startup order
 
 ```
@@ -355,6 +384,21 @@ Owner checks live in the usecase, not in Postgres RLS. The asymmetry for read vs
 
 Although authorization itself is not delegated to Postgres, every table in the `public` schema still has Row Level Security **enabled with zero policies** (migration `20260430080000_initial_schema`). This blocks PostgREST callers using the `anon` or `authenticated` role from reading or writing any row directly — a Supabase project always exposes `public.*` as a REST API, and "no policy under RLS" means default-deny in PostgreSQL. The Go backend connects as the table-owner role, which bypasses RLS unless `FORCE ROW LEVEL SECURITY` is set, so application queries and migrations are unaffected. If a future flow needs Supabase JS to read a table directly, add a targeted policy alongside the access pattern; do not disable RLS to "make it work".
 
+### Role-based authorization (`auth.Service`)
+
+The `auth` package exposes two distinct types with different lifetimes and data sources. They answer different questions and must not be conflated:
+
+| Type | Lifetime | Source | Question |
+|---|---|---|---|
+| `AuthUser` (`auth/user.go`) | Request-scoped | JWT claims (Supabase) | Who is the caller? |
+| `auth.Service` (`auth/role.go`) | Boot-scoped | DB-backed (`UserRoleRepository`) | What can the caller do? |
+
+The split is deliberate: the JWT does not carry roles in this project, so every role check goes through the DB. `auth.Service` is constructed once at boot in `run()` against the `UserRoleRepository` and injected into resolvers/usecases that need to gate on role membership.
+
+`auth.Service.IsAdmin(ctx, userID)` hardcodes the literal `"admin"` role name in the method body — callers cannot pass a role string. This prevents drift to bespoke role names; add a new dedicated method (e.g. `IsModerator`) when a second role is needed rather than parameterising `IsAdmin`.
+
+The DB side of the same check is `public.is_admin(uid uuid) RETURNS boolean`, defined in migration `20260502000000_add_rbac_helpers`. See [SECURITY DEFINER helper recipe](#security-definer-helper-recipe) for the function shape RLS policies and future RBAC helpers must replicate.
+
 ### Sentinel errors and domain validation
 
 `domain.Cardgroup.Validate()` returns typed sentinels (`ErrCardgroupNameRequired`, `ErrCardgroupNameTooLong`). The usecase translates them via a dedicated helper (`translateCardgroupNameErr`) to `gqlerr.BadUserInput`. The rule itself lives only in the domain; the usecase holds only the domain→GraphQL mapping. Apply this pattern to every new aggregate.
@@ -433,7 +477,10 @@ usecases make `extensions.code` values inconsistent and hard to grep. The
 |---|---|---|
 | `gqlerr.Unauthenticated()` | `"UNAUTHENTICATED"` | No `field`; caller is not authenticated |
 | `gqlerr.BadUserInput(field, message)` | `"BAD_USER_INPUT"` | `extensions.field` carries the form field name for FE error display |
+| `gqlerr.NewForbidden(msg)` | `"FORBIDDEN"` | Caller is authenticated but lacks the required role/permission. Caller supplies a generic message — do not include sensitive details (e.g. "user X is not admin") |
 | `gqlerr.Internal(ctx, err)` | `"INTERNAL"` | Message fixed to `"internal server error"`; original `err` logged via `slog.ErrorContext` and never sent to the client |
+
+**Logging convention.** `Internal(ctx, err)` is the only constructor that logs — internal errors are server bugs and must surface in the structured log stream. The 4xx constructors (`Unauthenticated`, `BadUserInput`, `NewForbidden`) deliberately do **not** log: they describe expected client-side faults, and emitting an ERROR/WARN line on every malformed request would drown the signal. Call sites that want 401/403/400 observability must log themselves before constructing the error (a `slog.WarnContext` with the relevant attrs is the canonical pattern; see `auth/middleware.go` `reject()`).
 
 Usage in the usecase layer:
 


### PR DESCRIPTION
Closes #45

## Summary

Adds the RBAC backend foundation: an `is_admin(uuid) → boolean` SQL helper, a Go `auth.Service.IsAdmin` wrapper that delegates to `UserRoleRepository.HasRole`, a new `FORBIDDEN` GraphQL error code with the `gqlerr.NewForbidden` constructor, and the DI wiring that threads `UserRoleRepository` into `auth.Service` at boot. Nothing in the GraphQL surface or the frontend changes — this is the seam every upcoming admin feature, and the planned default-deny RLS policies, will call into.

## Background / Motivation

- The `roles` and `user_roles` tables, the `RoleRepository` / `UserRoleRepository` interfaces, the `Role` DataLoader, and the `admin` role seed all already exist in the consolidated initial-schema migration. What is missing is a single canonical "is this user admin?" entry point — both for upcoming RLS policies that gate `public.*` writes by role and for Go usecases that need to reject non-admins. Without this seam, every consumer would re-query `user_roles ⋈ roles WHERE name = 'admin'` and drift toward bespoke role names.
- `is_admin(uuid)` is `STABLE`, not `IMMUTABLE`, because it reads `user_roles` and `roles`. `IMMUTABLE` would let the planner cache results across a single statement and silently miss role revocations within the same query.
- `is_admin(uuid)` is `SECURITY DEFINER` so it can be called from RLS policies running under `anon` / `authenticated` without granting those roles direct read access on `user_roles`. `SECURITY DEFINER` opens an injection vector via `search_path` (a callable function under a non-public schema can shadow `public.user_roles` if `search_path` is attacker-controlled), so the function pins `SET search_path = public` to neutralise that path. The grant ladder is `REVOKE ALL ON FUNCTION … FROM PUBLIC` followed by a conditional `GRANT EXECUTE … TO authenticated` — anonymous PostgREST callers cannot probe role membership at all, and only callers who have authenticated through Supabase Auth can ask "am I admin?".
- The conditional `GRANT` is gated on `EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'authenticated')` because the Supabase-managed `authenticated` role only exists in the production project. The repository test suite spins up a plain Postgres testcontainer with no Supabase roles, so an unconditional `GRANT EXECUTE TO authenticated` would fail the migration there. The `DO $$ … $$` block keeps the migration idempotent across both environments without forking the file.
- `auth.Service.IsAdmin` deliberately does **not** take a `roleName` parameter. Hard-coding `"admin"` inside the service prevents usecases from drifting to bespoke role names like `"superadmin"` or `"sysadmin"`; if a second role-gated capability is needed later it gets its own helper (`IsModerator`, etc.), not a parameterised `HasRole` exposed to callers. The `Service` struct is constructed once at boot and reused across requests — distinct from the request-scoped `AuthUser` middleware in the same package.
- `gqlerr.NewForbidden(msg)` returns the GraphQL-shaped `extensions.code = "FORBIDDEN"` envelope. The doc comment instructs callers to keep the message generic ("admin role required" rather than "user X is not admin") so authorization failures cannot be used to enumerate role membership of other users. Consumers land in upcoming admin mutations; the constructor itself ships ahead of those so the error code is stable when the first consumer arrives.
- The DI wiring in `run()` constructs `auth.NewService(userRoleRepo)` and immediately discards it via `_ = …`. This intentional dead binding documents the wiring for compile-time verification today and is replaced by a real assignment as soon as the first consumer (an admin resolver or middleware) lands — the goal of this change is to leave a working seam, not to add a user-visible feature.

## Changes

### `is_admin` SQL helper migration

- `backend/internal/database/migrations/20260502000000_add_rbac_helpers.up.sql` (new): defines `public.is_admin(uid uuid) RETURNS boolean LANGUAGE sql STABLE SECURITY DEFINER SET search_path = public`. Body is `SELECT EXISTS (SELECT 1 FROM public.user_roles ur JOIN public.roles r ON r.id = ur.role_id WHERE ur.user_id = uid AND r.name = 'admin')`. Followed by `REVOKE ALL ON FUNCTION public.is_admin(uuid) FROM PUBLIC` and a `DO $$ … $$` block that grants `EXECUTE TO authenticated` only when the role exists in `pg_roles`.
- `backend/internal/database/migrations/20260502000000_add_rbac_helpers.down.sql` (new): single-statement `DROP FUNCTION IF EXISTS public.is_admin(uuid)`.
- `backend/internal/database/is_admin_function_test.go` (new): three integration tests against the testcontainer Postgres exercising the function directly via `SELECT public.is_admin($1::uuid)` — admin user returns `true`, user with no role assignment returns `false`, unknown UUID returns `false` (not an error). Helper `insertAuthUserForAdmin` inserts a row in `auth.users` and relies on the existing `trg_handle_new_user` trigger to populate `public.users`; the `admin` role is read by `name` from the seeded `public.roles`.

### `auth.Service.IsAdmin` Go wrapper

- `backend/internal/auth/role.go` (new): `Service { userRoles repository.UserRoleRepository }`. `NewService(userRoles)` constructor. `IsAdmin(ctx, userID)` calls `userRoles.HasRole(ctx, userID, "admin")`, wraps any error with `eris.Wrap(err, "auth: check admin role")`, and propagates the boolean unchanged. The role name is intentionally hard-coded inside the method body, not exposed as a parameter.
- `backend/internal/auth/role_test.go` (new): table-driven test covering the three branches (admin returns true, non-admin returns false, db error wrapped) using a `stubUserRoles` fake. Asserts the stub receives `userID = "user-1"` and `roleName = "admin"` so the hard-coded `"admin"` cannot regress to a parameter without a test failure.

### `FORBIDDEN` GraphQL error code

- `backend/internal/gqlerr/errors.go`: adds `CodeForbidden Code = "FORBIDDEN"` to the `Code` constant block and a `NewForbidden(msg string) *gqlerror.Error` constructor returning `Extensions: { "code": "FORBIDDEN" }` with the caller-supplied message. The doc comment instructs callers to keep the message generic so authorization failures cannot be used to enumerate role membership of other users.

### DI wiring

- `backend/cmd/server/main.go`: inside `run(ctx, logger)`, the previous `_ = repository.NewUserRoleRepository(db.GORM)` placeholder is replaced with a real binding `userRoleRepo := repository.NewUserRoleRepository(db.GORM)` and a follow-up `_ = auth.NewService(userRoleRepo)` whose comment names the upcoming consumer. The dead assignment is intentional — it surfaces a compile-time wiring error if `auth.NewService`'s signature drifts before the first real consumer lands.

## Verification

After merge, the following should all hold:

- `git ls-files backend/internal/database/migrations | grep add_rbac_helpers` lists exactly two files (`20260502000000_add_rbac_helpers.up.sql` and `…down.sql`).
- `grep -nE "STABLE|SECURITY DEFINER|search_path = public" backend/internal/database/migrations/20260502000000_add_rbac_helpers.up.sql` matches three distinct lines (one per property).
- `grep -nE "REVOKE ALL ON FUNCTION public\.is_admin" backend/internal/database/migrations/20260502000000_add_rbac_helpers.up.sql` matches once and the file contains a `DO $$ … pg_roles WHERE rolname = 'authenticated' …` block (no unconditional `GRANT EXECUTE TO authenticated`).
- `grep -nE "func \(s \*Service\) IsAdmin" backend/internal/auth/role.go` matches once. `grep -n '"admin"' backend/internal/auth/role.go` matches once and `grep -nE "IsAdmin\(.*roleName" backend/internal/auth/role.go` returns nothing (the role name is not a parameter).
- `grep -n "CodeForbidden" backend/internal/gqlerr/errors.go` matches once and `grep -n "func NewForbidden" backend/internal/gqlerr/errors.go` matches once.
- `grep -n "auth.NewService(userRoleRepo)" backend/cmd/server/main.go` matches once. The previous placeholder is gone: `grep -n "_ = repository.NewUserRoleRepository" backend/cmd/server/main.go` returns nothing.
- After running migrations against a fresh Postgres: `psql -c "SELECT proname, prosecdef, provolatile FROM pg_proc WHERE proname = 'is_admin'"` returns one row with `prosecdef = t` and `provolatile = s` (STABLE).

## Test plan

- [ ] `cd backend && go vet ./... && go build ./...` passes.
- [ ] `cd backend && go test -v -race -covermode=atomic -coverprofile=coverage.out ./...` passes; new tests under `internal/auth/role_test.go` and `internal/database/is_admin_function_test.go` all run.
- [ ] On a freshly-migrated DB: `psql … -c "SELECT public.is_admin('00000000-0000-0000-0000-000000000000'::uuid)"` returns `f` (unknown user, no error).
- [ ] On the same DB: insert an `auth.users` row, attach the seeded `admin` role via `INSERT INTO public.user_roles (user_id, role_id) VALUES ($auth_id, (SELECT id FROM public.roles WHERE name='admin'))`, then `SELECT public.is_admin($auth_id::uuid)` returns `t`.
- [ ] On the same DB: a second user with no `user_roles` row returns `f` from `is_admin`.
- [ ] `migrate up` then `migrate down 1` removes `public.is_admin` cleanly (`SELECT proname FROM pg_proc WHERE proname = 'is_admin'` returns zero rows after down).
- [ ] `cd backend && go run ./cmd/server` boots without errors against a freshly-migrated DB — `auth.NewService(userRoleRepo)` is constructed at startup with no panic.
- [ ] `grep -rnP "[\x{3040}-\x{30ff}\x{4e00}-\x{9fff}]" --include="*.go" --include="*.sql" --include="*.md" backend docs` returns nothing (English-only policy under `.claude/rules/language-policy.md`).