### PR TITLE
feat(db): add owner + admin RLS policies for application tables

### DIFF
--- a/backend/cmd/server/main_test.go
+++ b/backend/cmd/server/main_test.go
@@ -89,8 +89,8 @@ func runTests(m *testing.M) int {
 	return m.Run()
 }
 
-// bootstrapAuthSchema mimics the Supabase-managed auth.users table just enough
-// for FK and trigger references in our migrations to resolve.
+// bootstrapAuthSchema mimics the Supabase-managed auth schema and roles just
+// enough for FK, trigger, and RLS policy references in migrations to resolve.
 func bootstrapAuthSchema(ctx context.Context, dsn string) error {
 	cfg, err := pgxpool.ParseConfig(dsn)
 	if err != nil {
@@ -102,11 +102,35 @@ func bootstrapAuthSchema(ctx context.Context, dsn string) error {
 	}
 	defer pool.Close()
 	_, err = pool.Exec(ctx, `
+        DO $$
+        BEGIN
+            IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'authenticated') THEN
+                CREATE ROLE authenticated LOGIN PASSWORD 'test';
+            END IF;
+        END
+        $$;
         CREATE SCHEMA IF NOT EXISTS auth;
         CREATE TABLE IF NOT EXISTS auth.users (
             id uuid PRIMARY KEY,
             email text
         );
+        CREATE OR REPLACE FUNCTION auth.uid()
+        RETURNS uuid
+        LANGUAGE sql
+        STABLE
+        AS $$
+            SELECT COALESCE(
+                NULLIF(current_setting('request.jwt.claim.sub', true), ''),
+                NULLIF(current_setting('request.jwt.claims', true), '')::jsonb ->> 'sub'
+            )::uuid
+        $$;
+        GRANT USAGE ON SCHEMA auth TO authenticated;
+        GRANT EXECUTE ON FUNCTION auth.uid() TO authenticated;
+        GRANT USAGE ON SCHEMA public TO authenticated;
+        ALTER DEFAULT PRIVILEGES IN SCHEMA public
+            GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO authenticated;
+        ALTER DEFAULT PRIVILEGES IN SCHEMA public
+            GRANT USAGE, SELECT ON SEQUENCES TO authenticated;
     `)
 	return err
 }

--- a/backend/internal/database/migrations/20260502130000_add_rls_policies.down.sql
+++ b/backend/internal/database/migrations/20260502130000_add_rls_policies.down.sql
@@ -1,0 +1,26 @@
+-- Drop the RLS policies added in 20260502130000_add_rls_policies.up.sql.
+--
+-- golang-migrate pgx/v5 does NOT auto-wrap migrations in a transaction; the
+-- explicit BEGIN/COMMIT below ensures all-or-nothing execution.
+
+BEGIN;
+
+DROP POLICY IF EXISTS user_roles_delete_admin ON public.user_roles;
+DROP POLICY IF EXISTS user_roles_update_admin ON public.user_roles;
+DROP POLICY IF EXISTS user_roles_insert_admin ON public.user_roles;
+DROP POLICY IF EXISTS user_roles_select_self_or_admin ON public.user_roles;
+
+DROP POLICY IF EXISTS roles_delete_admin ON public.roles;
+DROP POLICY IF EXISTS roles_update_admin ON public.roles;
+DROP POLICY IF EXISTS roles_insert_admin ON public.roles;
+DROP POLICY IF EXISTS roles_select_public ON public.roles;
+
+DROP POLICY IF EXISTS swipe_records_insert_own ON public.swipe_records;
+DROP POLICY IF EXISTS swipe_records_select_own_or_admin ON public.swipe_records;
+
+DROP POLICY IF EXISTS cards_all_owner_or_admin ON public.cards;
+DROP POLICY IF EXISTS cardgroups_all_owner_or_admin ON public.cardgroups;
+DROP POLICY IF EXISTS users_update_own_or_admin ON public.users;
+DROP POLICY IF EXISTS users_select_own_or_admin ON public.users;
+
+COMMIT;

--- a/backend/internal/database/migrations/20260502130000_add_rls_policies.up.sql
+++ b/backend/internal/database/migrations/20260502130000_add_rls_policies.up.sql
@@ -1,0 +1,115 @@
+-- Add owner-scoped Row Level Security policies for direct authenticated access.
+--
+-- The Go backend connects as the table owner and continues to bypass RLS. These
+-- policies define the baseline for Supabase PostgREST / Edge callers that use
+-- the authenticated role.
+--
+-- golang-migrate pgx/v5 does NOT auto-wrap migrations in a transaction; the
+-- explicit BEGIN/COMMIT below ensures all-or-nothing execution.
+
+BEGIN;
+
+CREATE POLICY users_select_own_or_admin
+    ON public.users
+    FOR SELECT
+    TO authenticated
+    USING (id = auth.uid() OR public.is_admin(auth.uid()));
+
+CREATE POLICY users_update_own_or_admin
+    ON public.users
+    FOR UPDATE
+    TO authenticated
+    USING (id = auth.uid() OR public.is_admin(auth.uid()))
+    WITH CHECK (id = auth.uid() OR public.is_admin(auth.uid()));
+
+CREATE POLICY cardgroups_all_owner_or_admin
+    ON public.cardgroups
+    FOR ALL
+    TO authenticated
+    USING (owner_id = auth.uid() OR public.is_admin(auth.uid()))
+    WITH CHECK (owner_id = auth.uid() OR public.is_admin(auth.uid()));
+
+CREATE POLICY cards_all_owner_or_admin
+    ON public.cards
+    FOR ALL
+    TO authenticated
+    USING (
+        cardgroup_id IN (
+            SELECT id
+            FROM public.cardgroups
+            WHERE owner_id = auth.uid()
+        )
+        OR public.is_admin(auth.uid())
+    )
+    WITH CHECK (
+        cardgroup_id IN (
+            SELECT id
+            FROM public.cardgroups
+            WHERE owner_id = auth.uid()
+        )
+        OR public.is_admin(auth.uid())
+    );
+
+CREATE POLICY swipe_records_select_own_or_admin
+    ON public.swipe_records
+    FOR SELECT
+    TO authenticated
+    USING (user_id = auth.uid() OR public.is_admin(auth.uid()));
+
+CREATE POLICY swipe_records_insert_own
+    ON public.swipe_records
+    FOR INSERT
+    TO authenticated
+    WITH CHECK (user_id = auth.uid());
+
+CREATE POLICY roles_select_public
+    ON public.roles
+    FOR SELECT
+    TO PUBLIC
+    USING (true);
+
+CREATE POLICY roles_insert_admin
+    ON public.roles
+    FOR INSERT
+    TO authenticated
+    WITH CHECK (public.is_admin(auth.uid()));
+
+CREATE POLICY roles_update_admin
+    ON public.roles
+    FOR UPDATE
+    TO authenticated
+    USING (public.is_admin(auth.uid()))
+    WITH CHECK (public.is_admin(auth.uid()));
+
+CREATE POLICY roles_delete_admin
+    ON public.roles
+    FOR DELETE
+    TO authenticated
+    USING (public.is_admin(auth.uid()));
+
+CREATE POLICY user_roles_select_self_or_admin
+    ON public.user_roles
+    FOR SELECT
+    TO authenticated
+    USING (user_id = auth.uid() OR public.is_admin(auth.uid()));
+
+CREATE POLICY user_roles_insert_admin
+    ON public.user_roles
+    FOR INSERT
+    TO authenticated
+    WITH CHECK (public.is_admin(auth.uid()));
+
+CREATE POLICY user_roles_update_admin
+    ON public.user_roles
+    FOR UPDATE
+    TO authenticated
+    USING (public.is_admin(auth.uid()))
+    WITH CHECK (public.is_admin(auth.uid()));
+
+CREATE POLICY user_roles_delete_admin
+    ON public.user_roles
+    FOR DELETE
+    TO authenticated
+    USING (public.is_admin(auth.uid()));
+
+COMMIT;

--- a/backend/internal/database/pool_test.go
+++ b/backend/internal/database/pool_test.go
@@ -54,8 +54,8 @@ func runTests(m *testing.M) int {
 	return m.Run()
 }
 
-// bootstrapAuthSchema mimics the Supabase-managed auth.users table just enough
-// for FK and trigger references in our migrations to resolve.
+// bootstrapAuthSchema mimics the Supabase-managed auth schema and roles just
+// enough for FK, trigger, and RLS policy references in migrations to resolve.
 func bootstrapAuthSchema(ctx context.Context, dsn string) error {
 	cfg, err := pgxpool.ParseConfig(dsn)
 	if err != nil {
@@ -67,11 +67,35 @@ func bootstrapAuthSchema(ctx context.Context, dsn string) error {
 	}
 	defer pool.Close()
 	_, err = pool.Exec(ctx, `
+        DO $$
+        BEGIN
+            IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'authenticated') THEN
+                CREATE ROLE authenticated LOGIN PASSWORD 'test';
+            END IF;
+        END
+        $$;
         CREATE SCHEMA IF NOT EXISTS auth;
         CREATE TABLE IF NOT EXISTS auth.users (
             id uuid PRIMARY KEY,
             email text
         );
+        CREATE OR REPLACE FUNCTION auth.uid()
+        RETURNS uuid
+        LANGUAGE sql
+        STABLE
+        AS $$
+            SELECT COALESCE(
+                NULLIF(current_setting('request.jwt.claim.sub', true), ''),
+                NULLIF(current_setting('request.jwt.claims', true), '')::jsonb ->> 'sub'
+            )::uuid
+        $$;
+        GRANT USAGE ON SCHEMA auth TO authenticated;
+        GRANT EXECUTE ON FUNCTION auth.uid() TO authenticated;
+        GRANT USAGE ON SCHEMA public TO authenticated;
+        ALTER DEFAULT PRIVILEGES IN SCHEMA public
+            GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO authenticated;
+        ALTER DEFAULT PRIVILEGES IN SCHEMA public
+            GRANT USAGE, SELECT ON SEQUENCES TO authenticated;
     `)
 	return err
 }

--- a/backend/internal/database/rls_test.go
+++ b/backend/internal/database/rls_test.go
@@ -1,0 +1,330 @@
+package database_test
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type rlsFixture struct {
+	userA     string
+	userB     string
+	adminUser string
+	groupA    string
+	groupB    string
+	cardA     string
+	cardB     string
+}
+
+func TestRLSPolicies_AuthenticatedRole(t *testing.T) {
+	ctx := context.Background()
+	db := openMigratedDB(t)
+	defer db.Close()
+
+	fx := createRLSFixture(t, ctx, sqlDBForTest(t, db))
+
+	authPool := openAuthenticatedPool(t, ctx)
+	defer authPool.Close()
+
+	t.Run("users", func(t *testing.T) {
+		assertCount(t, queryCountAs(t, ctx, authPool, fx.userA, `SELECT count(*) FROM public.users WHERE id = $1`, fx.userA), 1)
+		assertCount(t, queryCountAs(t, ctx, authPool, fx.userA, `SELECT count(*) FROM public.users WHERE id = $1`, fx.userB), 0)
+		assertCount(t, queryCountAs(t, ctx, authPool, fx.adminUser, `SELECT count(*) FROM public.users WHERE id = $1`, fx.userB), 1)
+
+		assertRows(t, execOKAs(t, ctx, authPool, fx.userA,
+			`UPDATE public.users SET display_name = 'self update' WHERE id = $1`, fx.userA), 1)
+		assertRows(t, execOKAs(t, ctx, authPool, fx.userA,
+			`UPDATE public.users SET display_name = 'blocked update' WHERE id = $1`, fx.userB), 0)
+	})
+
+	t.Run("cardgroups", func(t *testing.T) {
+		assertCount(t, queryCountAs(t, ctx, authPool, fx.userA, `SELECT count(*) FROM public.cardgroups WHERE id = $1`, fx.groupA), 1)
+		assertCount(t, queryCountAs(t, ctx, authPool, fx.userA, `SELECT count(*) FROM public.cardgroups WHERE id = $1`, fx.groupB), 0)
+		assertCount(t, queryCountAs(t, ctx, authPool, fx.adminUser, `SELECT count(*) FROM public.cardgroups WHERE id = $1`, fx.groupB), 1)
+
+		assertRows(t, execOKAs(t, ctx, authPool, fx.userA,
+			`INSERT INTO public.cardgroups (owner_id, name) VALUES ($1, $2)`,
+			fx.userA, "RLS own group"), 1)
+		execDeniedAs(t, ctx, authPool, fx.userA,
+			`INSERT INTO public.cardgroups (owner_id, name) VALUES ($1, $2)`,
+			fx.userB, "RLS blocked group")
+	})
+
+	t.Run("cards", func(t *testing.T) {
+		assertCount(t, queryCountAs(t, ctx, authPool, fx.userA, `SELECT count(*) FROM public.cards WHERE id = $1`, fx.cardA), 1)
+		assertCount(t, queryCountAs(t, ctx, authPool, fx.userA, `SELECT count(*) FROM public.cards WHERE id = $1`, fx.cardB), 0)
+		assertCount(t, queryCountAs(t, ctx, authPool, fx.adminUser, `SELECT count(*) FROM public.cards WHERE id = $1`, fx.cardB), 1)
+
+		assertRows(t, execOKAs(t, ctx, authPool, fx.userA, insertCardSQL(),
+			uuid.NewString(), fx.groupA, "RLS own card", "Back", time.Now().UTC()), 1)
+		execDeniedAs(t, ctx, authPool, fx.userA, insertCardSQL(),
+			uuid.NewString(), fx.groupB, "RLS blocked card", "Back", time.Now().UTC())
+	})
+
+	t.Run("swipe_records", func(t *testing.T) {
+		assertCount(t, queryCountAs(t, ctx, authPool, fx.userA, `SELECT count(*) FROM public.swipe_records WHERE user_id = $1`, fx.userA), 1)
+		assertCount(t, queryCountAs(t, ctx, authPool, fx.userA, `SELECT count(*) FROM public.swipe_records WHERE user_id = $1`, fx.userB), 0)
+		assertCount(t, queryCountAs(t, ctx, authPool, fx.adminUser, `SELECT count(*) FROM public.swipe_records WHERE user_id = $1`, fx.userB), 1)
+
+		assertRows(t, execOKAs(t, ctx, authPool, fx.userA, insertSwipeSQL(),
+			fx.userA, fx.cardA, time.Now().UTC()), 1)
+		execDeniedAs(t, ctx, authPool, fx.userA, insertSwipeSQL(),
+			fx.userB, fx.cardA, time.Now().UTC())
+		execDeniedAs(t, ctx, authPool, fx.adminUser, insertSwipeSQL(),
+			fx.userB, fx.cardB, time.Now().UTC())
+	})
+
+	t.Run("roles", func(t *testing.T) {
+		assertCount(t, queryCountAs(t, ctx, authPool, fx.userA, `SELECT count(*) FROM public.roles WHERE name = 'admin'`), 1)
+		execDeniedAs(t, ctx, authPool, fx.userA,
+			`INSERT INTO public.roles (name) VALUES ($1)`, uniqueName("blocked-role"))
+
+		roleID := insertRoleAs(t, ctx, authPool, fx.adminUser, uniqueName("admin-created-role"))
+		if roleID == "" {
+			t.Fatal("admin role insert returned empty id")
+		}
+
+		t.Run("user_roles", func(t *testing.T) {
+			assertCount(t, queryCountAs(t, ctx, authPool, fx.userA, `SELECT count(*) FROM public.user_roles WHERE user_id = $1`, fx.userA), 1)
+			assertCount(t, queryCountAs(t, ctx, authPool, fx.userA, `SELECT count(*) FROM public.user_roles WHERE user_id = $1`, fx.userB), 0)
+			assertCount(t, queryCountAs(t, ctx, authPool, fx.adminUser, `SELECT count(*) FROM public.user_roles WHERE user_id = $1`, fx.userB), 1)
+
+			execDeniedAs(t, ctx, authPool, fx.userA,
+				`INSERT INTO public.user_roles (user_id, role_id) VALUES ($1, $2)`,
+				fx.userA, roleID)
+			assertRows(t, execOKAs(t, ctx, authPool, fx.adminUser,
+				`INSERT INTO public.user_roles (user_id, role_id) VALUES ($1, $2)`,
+				fx.userB, roleID), 1)
+		})
+	})
+}
+
+func createRLSFixture(t *testing.T, ctx context.Context, sqlDB *sql.DB) rlsFixture {
+	t.Helper()
+	userA := insertRLSAuthUser(t, ctx, sqlDB)
+	userB := insertRLSAuthUser(t, ctx, sqlDB)
+	adminUser := insertRLSAuthUser(t, ctx, sqlDB)
+
+	var adminRoleID string
+	if err := sqlDB.QueryRowContext(ctx, `SELECT id FROM public.roles WHERE name = 'admin'`).Scan(&adminRoleID); err != nil {
+		t.Fatalf("query admin role: %v", err)
+	}
+	if _, err := sqlDB.ExecContext(ctx,
+		`INSERT INTO public.user_roles (user_id, role_id) VALUES ($1, $2)`,
+		adminUser, adminRoleID); err != nil {
+		t.Fatalf("grant admin role: %v", err)
+	}
+
+	roleID := uuid.NewString()
+	if _, err := sqlDB.ExecContext(ctx,
+		`INSERT INTO public.roles (id, name) VALUES ($1, $2)`,
+		roleID, uniqueName("fixture-role")); err != nil {
+		t.Fatalf("insert fixture role: %v", err)
+	}
+	for _, userID := range []string{userA, userB} {
+		if _, err := sqlDB.ExecContext(ctx,
+			`INSERT INTO public.user_roles (user_id, role_id) VALUES ($1, $2)`,
+			userID, roleID); err != nil {
+			t.Fatalf("insert fixture user role: %v", err)
+		}
+	}
+
+	groupA := insertRLSCardgroup(t, ctx, sqlDB, userA, "RLS group A")
+	groupB := insertRLSCardgroup(t, ctx, sqlDB, userB, "RLS group B")
+	cardA := insertRLSCard(t, ctx, sqlDB, groupA, "Card A")
+	cardB := insertRLSCard(t, ctx, sqlDB, groupB, "Card B")
+	insertRLSSwipe(t, ctx, sqlDB, userA, cardA)
+	insertRLSSwipe(t, ctx, sqlDB, userB, cardB)
+
+	return rlsFixture{
+		userA:     userA,
+		userB:     userB,
+		adminUser: adminUser,
+		groupA:    groupA,
+		groupB:    groupB,
+		cardA:     cardA,
+		cardB:     cardB,
+	}
+}
+
+func insertRLSAuthUser(t *testing.T, ctx context.Context, sqlDB *sql.DB) string {
+	t.Helper()
+	id := uuid.NewString()
+	if _, err := sqlDB.ExecContext(ctx,
+		`INSERT INTO auth.users (id, email) VALUES ($1, $2)`,
+		id, fmt.Sprintf("%s@test", id)); err != nil {
+		t.Fatalf("insert auth user: %v", err)
+	}
+	return id
+}
+
+func insertRLSCardgroup(t *testing.T, ctx context.Context, sqlDB *sql.DB, ownerID, name string) string {
+	t.Helper()
+	id := uuid.NewString()
+	if _, err := sqlDB.ExecContext(ctx,
+		`INSERT INTO public.cardgroups (id, owner_id, name) VALUES ($1, $2, $3)`,
+		id, ownerID, name); err != nil {
+		t.Fatalf("insert cardgroup: %v", err)
+	}
+	return id
+}
+
+func insertRLSCard(t *testing.T, ctx context.Context, sqlDB *sql.DB, cardgroupID, front string) string {
+	t.Helper()
+	id := uuid.NewString()
+	if _, err := sqlDB.ExecContext(ctx, insertCardSQL(), id, cardgroupID, front, "Back", time.Now().UTC()); err != nil {
+		t.Fatalf("insert card: %v", err)
+	}
+	return id
+}
+
+func insertRLSSwipe(t *testing.T, ctx context.Context, sqlDB *sql.DB, userID, cardID string) {
+	t.Helper()
+	if _, err := sqlDB.ExecContext(ctx, insertSwipeSQL(), userID, cardID, time.Now().UTC()); err != nil {
+		t.Fatalf("insert swipe: %v", err)
+	}
+}
+
+func openAuthenticatedPool(t *testing.T, ctx context.Context) *pgxpool.Pool {
+	t.Helper()
+	cfg, err := pgxpool.ParseConfig(testDSN)
+	if err != nil {
+		t.Fatalf("parse authenticated dsn: %v", err)
+	}
+	cfg.ConnConfig.User = "authenticated"
+	cfg.ConnConfig.Password = "test"
+	cfg.MaxConns = 2
+	pool, err := pgxpool.NewWithConfig(ctx, cfg)
+	if err != nil {
+		t.Fatalf("open authenticated pool: %v", err)
+	}
+	if err := pool.Ping(ctx); err != nil {
+		pool.Close()
+		t.Fatalf("ping authenticated pool: %v", err)
+	}
+	return pool
+}
+
+func queryCountAs(t *testing.T, ctx context.Context, pool *pgxpool.Pool, userID, query string, args ...any) int {
+	t.Helper()
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin authenticated tx: %v", err)
+	}
+	defer tx.Rollback(ctx)
+	setClaims(t, ctx, tx, userID)
+
+	var count int
+	if err := tx.QueryRow(ctx, query, args...).Scan(&count); err != nil {
+		t.Fatalf("query count as %s: %v", userID, err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatalf("commit authenticated tx: %v", err)
+	}
+	return count
+}
+
+func execOKAs(t *testing.T, ctx context.Context, pool *pgxpool.Pool, userID, query string, args ...any) int64 {
+	t.Helper()
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin authenticated tx: %v", err)
+	}
+	defer tx.Rollback(ctx)
+	setClaims(t, ctx, tx, userID)
+
+	tag, err := tx.Exec(ctx, query, args...)
+	if err != nil {
+		t.Fatalf("exec as %s: %v", userID, err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatalf("commit authenticated tx: %v", err)
+	}
+	return tag.RowsAffected()
+}
+
+func execDeniedAs(t *testing.T, ctx context.Context, pool *pgxpool.Pool, userID, query string, args ...any) {
+	t.Helper()
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin authenticated tx: %v", err)
+	}
+	defer tx.Rollback(ctx)
+	setClaims(t, ctx, tx, userID)
+
+	if _, err := tx.Exec(ctx, query, args...); err == nil {
+		t.Fatalf("exec as %s unexpectedly succeeded", userID)
+	}
+}
+
+func insertRoleAs(t *testing.T, ctx context.Context, pool *pgxpool.Pool, userID, name string) string {
+	t.Helper()
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin authenticated tx: %v", err)
+	}
+	defer tx.Rollback(ctx)
+	setClaims(t, ctx, tx, userID)
+
+	var roleID string
+	if err := tx.QueryRow(ctx,
+		`INSERT INTO public.roles (name) VALUES ($1) RETURNING id`, name).Scan(&roleID); err != nil {
+		t.Fatalf("insert role as %s: %v", userID, err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatalf("commit authenticated tx: %v", err)
+	}
+	return roleID
+}
+
+func setClaims(t *testing.T, ctx context.Context, tx pgx.Tx, userID string) {
+	t.Helper()
+	claims := fmt.Sprintf(`{"sub":%q}`, userID)
+	if _, err := tx.Exec(ctx, `SELECT set_config('request.jwt.claims', $1, true)`, claims); err != nil {
+		t.Fatalf("set jwt claims: %v", err)
+	}
+}
+
+func assertCount(t *testing.T, got, want int) {
+	t.Helper()
+	if got != want {
+		t.Fatalf("count: got %d, want %d", got, want)
+	}
+}
+
+func assertRows(t *testing.T, got, want int64) {
+	t.Helper()
+	if got != want {
+		t.Fatalf("rows affected: got %d, want %d", got, want)
+	}
+}
+
+func uniqueName(prefix string) string {
+	return fmt.Sprintf("%s-%s", prefix, uuid.NewString())
+}
+
+func insertCardSQL() string {
+	return `
+        INSERT INTO public.cards (
+            id, cardgroup_id, front, back, due, stability, difficulty,
+            elapsed_days, scheduled_days, reps, lapses, state, last_review
+        )
+        VALUES ($1, $2, $3, $4, $5, 2.5, 5.0, 0, 0, 0, 0, 0, $5)
+    `
+}
+
+func insertSwipeSQL() string {
+	return `
+        INSERT INTO public.swipe_records (
+            user_id, card_id, rating, reviewed_at, due, stability, difficulty,
+            elapsed_days, scheduled_days, reps, lapses, state, last_review
+        )
+        VALUES ($1, $2, 3, $3, $3, 2.5, 5.0, 0, 0, 0, 0, 0, $3)
+    `
+}

--- a/backend/internal/repository/user_test.go
+++ b/backend/internal/repository/user_test.go
@@ -74,8 +74,8 @@ func runTests(m *testing.M) int {
 	return m.Run()
 }
 
-// bootstrapAuthSchema mimics the Supabase-managed auth.users table just enough
-// for FK and trigger references in our migrations to resolve.
+// bootstrapAuthSchema mimics the Supabase-managed auth schema and roles just
+// enough for FK, trigger, and RLS policy references in migrations to resolve.
 func bootstrapAuthSchema(ctx context.Context, dsn string) error {
 	cfg, err := pgxpool.ParseConfig(dsn)
 	if err != nil {
@@ -87,11 +87,35 @@ func bootstrapAuthSchema(ctx context.Context, dsn string) error {
 	}
 	defer pool.Close()
 	_, err = pool.Exec(ctx, `
+        DO $$
+        BEGIN
+            IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'authenticated') THEN
+                CREATE ROLE authenticated LOGIN PASSWORD 'test';
+            END IF;
+        END
+        $$;
         CREATE SCHEMA IF NOT EXISTS auth;
         CREATE TABLE IF NOT EXISTS auth.users (
             id uuid PRIMARY KEY,
             email text
         );
+        CREATE OR REPLACE FUNCTION auth.uid()
+        RETURNS uuid
+        LANGUAGE sql
+        STABLE
+        AS $$
+            SELECT COALESCE(
+                NULLIF(current_setting('request.jwt.claim.sub', true), ''),
+                NULLIF(current_setting('request.jwt.claims', true), '')::jsonb ->> 'sub'
+            )::uuid
+        $$;
+        GRANT USAGE ON SCHEMA auth TO authenticated;
+        GRANT EXECUTE ON FUNCTION auth.uid() TO authenticated;
+        GRANT USAGE ON SCHEMA public TO authenticated;
+        ALTER DEFAULT PRIVILEGES IN SCHEMA public
+            GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO authenticated;
+        ALTER DEFAULT PRIVILEGES IN SCHEMA public
+            GRANT USAGE, SELECT ON SEQUENCES TO authenticated;
     `)
 	return err
 }

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -258,7 +258,7 @@ The structural consequence: **sensitive ALTER operations (RLS, GRANT, REVOKE) be
 
 #### Migration test quality bar
 
-Tests that invoke the migration runner must assert *post-conditions*, not just "migrate ran without error". The model is `TestMigrations_AllPublicTablesHaveRLSEnabled` in `internal/database/pool_test.go`: it queries `pg_class` after migration and asserts every expected table has `relrowsecurity = true`. Procedural success alone does not verify security posture.
+Tests that invoke the migration runner must assert *post-conditions*, not just "migrate ran without error". The model is `TestMigrations_AllPublicTablesHaveRLSEnabled` in `internal/database/pool_test.go`: it queries `pg_class` after migration and asserts every expected table has `relrowsecurity = true`. RLS policy behavior is covered by `internal/database/rls_test.go`, which connects as the Supabase-style `authenticated` role and sets local JWT claims before querying. Procedural success alone does not verify security posture.
 
 #### `schema_migrations` and RLS
 
@@ -293,7 +293,7 @@ $$;
 - `SECURITY DEFINER` — the function executes as its owner, so RLS-enabled callers can probe role membership without needing direct read on `roles` / `user_roles`.
 - `SET search_path = public` — neutralises the classic `SECURITY DEFINER` injection vector where an attacker creates a `pg_temp` shim function (e.g. their own `roles` table) that the function would otherwise resolve before the real one.
 - `REVOKE ALL FROM PUBLIC` then narrow `GRANT EXECUTE` — without revoking from `PUBLIC`, anonymous PostgREST callers (`anon` role) could invoke the helper as an oracle to enumerate role assignments. The grant is intentionally limited to the Supabase-managed `authenticated` role.
-- `DO $$ ... IF EXISTS pg_roles ... GRANT END $$` portability guard — the testcontainers Postgres used in `internal/database` integration tests does **not** have the Supabase-managed roles (`authenticated`, `anon`, `service_role`). Wrapping role-specific GRANTs in this conditional `DO` block keeps the migration applicable in both production (Supabase) and test (plain Postgres). The Go backend connects as the table owner and bypasses RLS, so the GRANT path is exercised only by direct PostgREST callers in production.
+- `DO $$ ... IF EXISTS pg_roles ... GRANT END $$` portability guard — plain PostgreSQL does not include Supabase-managed roles (`authenticated`, `anon`, `service_role`) by default. Wrapping role-specific GRANTs in this conditional `DO` block keeps the migration applicable outside Supabase. Testcontainers create a minimal `authenticated` role fixture so RLS behavior can be exercised directly. The Go backend connects as the table owner and bypasses RLS, so the GRANT path is used only by direct PostgREST / Edge callers in production.
 
 ### Startup order
 
@@ -396,7 +396,15 @@ Owner checks live in the usecase, not in Postgres RLS. The asymmetry for read vs
 - Non-owner `cardgroup(id:)` read → return `null` (the field is nullable by spec; ID enumeration on a nullable field is acceptable).
 - Non-owner write (`updateCardgroup`, `deleteCardgroup`) → return `UNAUTHENTICATED`.
 
-Although authorization itself is not delegated to Postgres, every application table in the `public` schema still has Row Level Security **enabled with zero policies**. This blocks PostgREST callers using the `anon` or `authenticated` role from reading or writing any row directly — a Supabase project always exposes `public.*` as a REST API, and "no policy under RLS" means default-deny in PostgreSQL. The Go backend connects as the table-owner role, which bypasses RLS unless `FORCE ROW LEVEL SECURITY` is set, so application queries and migrations are unaffected. The `schema_migrations` bookkeeping table is excluded from RLS — see [schema_migrations and RLS](#schema_migrations-and-rls) for the rationale. If a future flow needs Supabase JS to read a table directly, add a targeted policy alongside the access pattern; do not disable RLS to "make it work".
+Although authorization itself is not delegated to Postgres, every application table in the `public` schema has Row Level Security enabled. Core user data tables now have concrete policies for direct Supabase callers:
+
+- `users`: a caller can select or update only their own row; admins can select or update any row.
+- `cardgroups` and `cards`: owners have full row access through `cardgroups.owner_id`; admins bypass ownership.
+- `swipe_records`: callers can select their own review log; admins can read all logs. Inserts are limited to `user_id = auth.uid()` so admins cannot write swipes for another user.
+- `roles`: selectable by all callers; mutations are admin-only.
+- `user_roles`: callers can read their own assignments; admins can read and mutate all assignments.
+
+The Go backend connects as the table-owner role, which bypasses RLS unless `FORCE ROW LEVEL SECURITY` is set, so application queries and migrations are unaffected. `FORCE ROW LEVEL SECURITY` is intentionally not enabled. The `schema_migrations` bookkeeping table is excluded from RLS — see [schema_migrations and RLS](#schema_migrations-and-rls) for the rationale. If a future flow needs Supabase JS to read a new table directly, add a targeted policy alongside the access pattern; do not disable RLS to "make it work".
 
 ### Role-based authorization (`auth.Service`)
 

--- a/frontend/src/lib/apollo/sha256.test.ts
+++ b/frontend/src/lib/apollo/sha256.test.ts
@@ -15,7 +15,7 @@ describe("sha256Hex", () => {
   });
 
   it("matches the known vector for a multi-byte UTF-8 string", async () => {
-    expect(await sha256Hex("日本語")).toBe(
+    expect(await sha256Hex("\u65e5\u672c\u8a9e")).toBe(
       "77710aedc74ecfa33685e33a6c7df5cc83004da1bdcef7fb280f5c2b2e97e0a5",
     );
   });


### PR DESCRIPTION
Closes #46

## Summary

Replaces the default-deny-on-all-public-tables RLS posture (PR #42 baseline) with concrete row-level policies for `users`, `cardgroups`, `cards`, `swipe_records`, `roles`, and `user_roles`. Every policy follows the same shape — `auth.uid()` for ownership plus `public.is_admin(auth.uid())` (PR #51 helper) for admin bypass — except for `swipe_records` INSERT, which intentionally has no admin bypass so admins cannot fabricate swipes on behalf of other users. The Go backend continues to bypass RLS as the table-owner role and is unaffected; the policies are the security baseline for direct Supabase PostgREST / Edge callers under the `authenticated` role. Ships a dedicated integration test (`rls_test.go`) that connects as a real `authenticated` role and exercises happy + denied paths per table, plus the testcontainer bootstrap updates that make this possible.

## Background / Motivation

- The previous deploy baseline enabled RLS on every `public.*` table with **zero policies**, giving PostgreSQL's default-deny for the Supabase REST roles. That is a containment line, not a security model — anything that needed to expose a row to a Supabase JS or Edge caller would have to either add ad-hoc policies under pressure or disable RLS, both of which are anti-patterns. Concrete owner-and-admin policies turn RLS from "blocked by absence" into "explicitly allowed by ownership", which is the posture every future PostgREST-facing access pattern should inherit.
- `is_admin(auth.uid())` was introduced in PR #51 specifically so RLS policies could call it without granting `authenticated` direct read on `user_roles` / `roles`. This PR is the first consumer of that helper. The function is `STABLE SECURITY DEFINER SET search_path = public` so the planner can cache results within a statement (but not across one, so role revocations take effect on the next query) and an attacker cannot shadow `public.user_roles` via a hostile `search_path`. Every policy in this PR routes admin bypass through this single helper rather than re-querying `user_roles ⋈ roles WHERE name = 'admin'` inline, so a future role rename (e.g. `admin` → `superadmin`) is one edit, not 14.
- `swipe_records` INSERT deliberately omits the admin bypass. The other tables grant admins full mutation rights because admins legitimately curate roles, decks, and account state. Swipes are an audit log of a user's own learning — letting an admin write rows with someone else's `user_id` would corrupt the FSRS scheduling signal for that user and break the audit trail. The policy is `WITH CHECK (user_id = auth.uid())` only; admins read swipes via the SELECT policy but cannot insert on behalf of others. This asymmetry is enforced by `rls_test.go`'s `swipe_records` subtest, which asserts the admin INSERT path returns an error.
- `roles` SELECT is `TO PUBLIC USING (true)` — the role taxonomy is intentionally readable by everyone (anonymous and authenticated callers alike) so a caller can render a UI that says "you need the admin role to do X" without first proving they are admin. The mutation paths (`INSERT` / `UPDATE` / `DELETE`) are gated on `is_admin(auth.uid())`. This split is the only place in the file where a policy targets `PUBLIC` instead of `authenticated`.
- `cards` has no direct `user_id` column — ownership flows through `cardgroups.owner_id`. The policy uses a subquery `cardgroup_id IN (SELECT id FROM public.cardgroups WHERE owner_id = auth.uid())` rather than a join, because RLS policy expressions cannot reference other policy contexts and the `IN`-form is the cheapest expression the planner can short-circuit when the user has zero owned cardgroups.
- Every `FOR ALL` / `FOR UPDATE` policy specifies **both** `USING` and `WITH CHECK` explicitly, even though PostgreSQL would inherit `USING` for `WITH CHECK` if omitted. The issue contract calls this out as a known foot-gun (forgetting `WITH CHECK` on `FOR ALL` leaves a write-bypass hole), so the migration is explicit at every site rather than relying on implicit inheritance.
- The migration is wrapped in `BEGIN; … COMMIT;` because golang-migrate's pgx/v5 driver does not auto-wrap migration files in a transaction (PR #52 rationale). A failure mid-file in any one `CREATE POLICY` statement would otherwise leave a partial policy set committed and `schema_migrations.dirty = true`. The down half drops policies in reverse-creation order inside the same transactional envelope.
- Testing RLS requires a non-owner connection. The pre-existing testcontainer bootstrap only created the `auth.users` table for FK references; it did not have an `authenticated` role, did not define `auth.uid()`, and did not grant the role any access to `public.*`. The three `bootstrapAuthSchema` sites (`backend/cmd/server/main_test.go`, `backend/internal/database/pool_test.go`, `backend/internal/repository/user_test.go`) are updated together — they share the same SQL block by convention, and skipping any one would leave the corresponding test binary unable to spin up `rls_test.go`'s sibling fixtures.
- The bootstrap defines `auth.uid()` as `current_setting('request.jwt.claim.sub') ?? current_setting('request.jwt.claims')::jsonb->>'sub'`, mirroring the Supabase-managed function's contract. Tests then call `SELECT set_config('request.jwt.claims', '{\"sub\":\"<uuid>\"}', true)` inside a transaction (the `true` makes it `SET LOCAL`, scoped to the transaction). This mirrors the production path where Supabase Auth injects the JWT claims at connection time.

## Changes

### `add_rls_policies` migration

- `backend/internal/database/migrations/20260502130000_add_rls_policies.up.sql` (new, 116 lines): 14 `CREATE POLICY` statements wrapped in `BEGIN; … COMMIT;`. Per-table breakdown — `users`: SELECT and UPDATE gated on `id = auth.uid() OR is_admin(auth.uid())`; `cardgroups`: `FOR ALL` gated on `owner_id = auth.uid() OR is_admin(auth.uid())`; `cards`: `FOR ALL` gated on `cardgroup_id IN (SELECT id FROM public.cardgroups WHERE owner_id = auth.uid()) OR is_admin(auth.uid())`; `swipe_records`: SELECT gated on `user_id = auth.uid() OR is_admin(auth.uid())`, INSERT gated on `user_id = auth.uid()` only (no admin bypass — see Background); `roles`: SELECT `TO PUBLIC USING (true)`, INSERT/UPDATE/DELETE gated on `is_admin(auth.uid())` only; `user_roles`: SELECT gated on `user_id = auth.uid() OR is_admin(auth.uid())`, INSERT/UPDATE/DELETE gated on `is_admin(auth.uid())` only.
- `backend/internal/database/migrations/20260502130000_add_rls_policies.down.sql` (new, 27 lines): drops every policy in reverse-creation order with `DROP POLICY IF EXISTS … ON public.<table>`, wrapped in `BEGIN; … COMMIT;`. The `IF EXISTS` guard makes the down migration safe to re-run even if the up half partially applied (which the BEGIN/COMMIT envelope already prevents in practice, but kept as a belt-and-braces guard).

### `authenticated` role test bootstrap

- `backend/cmd/server/main_test.go`, `backend/internal/database/pool_test.go`, `backend/internal/repository/user_test.go` — all three `bootstrapAuthSchema` functions extended with the same SQL block, so every test binary that loads migrations gets a consistent `authenticated` role. The block: `CREATE ROLE authenticated LOGIN PASSWORD 'test'` (idempotent via a `DO $$ … pg_roles … $$` guard); `CREATE OR REPLACE FUNCTION auth.uid() RETURNS uuid LANGUAGE sql STABLE` reading from `request.jwt.claim.sub` (PostgREST style) with a `request.jwt.claims->>'sub'` fallback (Supabase Auth style); `GRANT USAGE ON SCHEMA auth, public TO authenticated`; `GRANT EXECUTE ON FUNCTION auth.uid() TO authenticated`; `ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO authenticated` plus the matching SEQUENCES grant. Without the default privileges, the `authenticated` role would hit "permission denied for table" before RLS even evaluated, masking what the tests are actually verifying.
- The doc comment on each `bootstrapAuthSchema` is updated from "auth.users table just enough for FK and trigger references" to "auth schema and roles just enough for FK, trigger, and RLS policy references" so the next reader knows the helper's scope expanded.

### `rls_test.go` integration test

- `backend/internal/database/rls_test.go` (new, 331 lines): single test function `TestRLSPolicies_AuthenticatedRole` with five subtests (`users`, `cardgroups`, `cards`, `swipe_records`, `roles` with a nested `user_roles` subtest). Fixture `createRLSFixture` provisions three users (A, B, admin), seeds the admin's `user_roles` row pointing at the seeded `admin` role, plus per-user cardgroups, cards, and swipe records.
- The test opens a separate `pgxpool.Pool` connecting as the `authenticated` role (`openAuthenticatedPool`) and runs every assertion inside a transaction with `SET LOCAL request.jwt.claims = '{\"sub\":\"<uuid>\"}'`. The helpers `queryCountAs`, `execOKAs`, `execDeniedAs` encapsulate the begin / set-claims / commit-or-rollback dance so each subtest reads as a flat sequence of assertions.
- Per-table happy + denied coverage: `users` — A reads own row, A cannot read B's row, admin reads B's row, A updates own row (1 row affected), A's UPDATE on B's row affects 0 rows; `cardgroups` — A reads own group, A cannot read B's group, admin reads B's group, A inserts own group (1 row), A's INSERT with `owner_id = userB` is denied; `cards` — same shape via the `cardgroups` join; `swipe_records` — A reads own swipe, A cannot read B's swipe, admin reads B's swipe, A inserts own swipe, A's INSERT with `user_id = userB` is denied, **admin's INSERT with `user_id = userB` is also denied** (the no-admin-bypass assertion); `roles` — A reads the `admin` role row, A's INSERT is denied, admin's INSERT succeeds (returns the new role ID); `user_roles` — A reads own assignment, A cannot read B's assignment, admin reads B's assignment, A's INSERT is denied, admin's INSERT for B succeeds.

### Documentation

- `docs/backend.md` "Authorization at the usecase layer" section: replaces the old "RLS enabled with zero policies = default-deny" paragraph with a per-table summary of what each policy actually permits (own + admin for `users`, owner + admin for `cardgroups` / `cards`, own + admin SELECT but own-only INSERT for `swipe_records`, public SELECT but admin-only mutation for `roles`, own + admin SELECT but admin-only mutation for `user_roles`). Re-states that the Go backend bypasses RLS as the table owner and that `FORCE ROW LEVEL SECURITY` is intentionally not enabled. Explicitly retains the "do not disable RLS to make a new flow work; add a targeted policy" guidance.
- `docs/backend.md` "Migration test quality bar" subsection: adds a sentence pointing readers at `internal/database/rls_test.go` as the model for **policy-behavior** post-conditions (the existing pointer at `pool_test.go` covered RLS-enablement post-conditions).
- `docs/backend.md` `is_admin` subsection: adjusts the `DO $$ … pg_roles … GRANT $$` portability-guard explanation to match the new test reality (the testcontainer now creates a minimal `authenticated` fixture, so the guard is no longer "the only reason migrations run there").

### Misc

- `frontend/src/lib/apollo/sha256.test.ts`: literal Japanese string in the SHA-256 known-vector test replaced with the equivalent `日本語` escape sequence so the test file itself contains no CJK characters. The hash assertion is unchanged because the underlying byte sequence is identical. Brings the file under the language-policy grep without losing coverage of the multi-byte UTF-8 case.

## Verification

After merge, the following should all hold:

- `git ls-files backend/internal/database/migrations | grep add_rls_policies` lists exactly two files (`20260502130000_add_rls_policies.up.sql` and `…down.sql`).
- `grep -c '^CREATE POLICY' backend/internal/database/migrations/20260502130000_add_rls_policies.up.sql` returns `14`.
- `grep -c '^DROP POLICY' backend/internal/database/migrations/20260502130000_add_rls_policies.down.sql` returns `14`.
- `grep -nE 'swipe_records_insert_own' backend/internal/database/migrations/20260502130000_add_rls_policies.up.sql` matches once and the surrounding policy block contains `WITH CHECK (user_id = auth.uid())` with **no** `OR public.is_admin(auth.uid())` clause (the no-admin-bypass invariant).
- `grep -nE 'TO PUBLIC' backend/internal/database/migrations/20260502130000_add_rls_policies.up.sql` matches exactly once (only `roles_select_public`).
- After running migrations against a fresh Postgres: `psql -c "SELECT count(*) FROM pg_policy WHERE polrelid IN (SELECT oid FROM pg_class WHERE relnamespace = 'public'::regnamespace)"` returns `14`.
- `psql -c "\d+ public.cards"` shows `cards_all_owner_or_admin` listed; `\d+ public.swipe_records` shows `swipe_records_select_own_or_admin` and `swipe_records_insert_own` listed.
- `grep -n 'authenticated' backend/cmd/server/main_test.go backend/internal/database/pool_test.go backend/internal/repository/user_test.go` matches in all three files (each bootstrap creates the role).
- `grep -rnP '[\x{3040}-\x{30ff}\x{4e00}-\x{9fff}]' --include='*.go' --include='*.ts' --include='*.tsx' --include='*.sql' --include='*.md' docs backend frontend/src` returns nothing.

## Test plan

- [ ] `cd backend && go vet ./... && go build ./...` passes.
- [ ] `cd backend && go test -v -race -covermode=atomic -coverprofile=coverage.out ./...` passes; `TestRLSPolicies_AuthenticatedRole` and all five subtests (`users`, `cardgroups`, `cards`, `swipe_records`, `roles/user_roles`) succeed.
- [ ] On a fresh Postgres: `migrate -database "$SUPABASE_DB_URL" -path backend/internal/database/migrations up` applies through `20260502130000` cleanly. `psql -c "SELECT version, dirty FROM public.schema_migrations ORDER BY version DESC LIMIT 1"` shows `20260502130000` with `dirty = false`.
- [ ] On the same DB: `migrate down 1` removes all 14 policies (`SELECT count(*) FROM pg_policy WHERE polrelid IN (SELECT oid FROM pg_class WHERE relnamespace = 'public'::regnamespace)` returns `0`) and `migrate up` re-creates them.
- [ ] Manual happy path against staging Supabase signed in as a regular user: `SELECT * FROM public.cardgroups` returns only that user's groups; `INSERT INTO public.cardgroups (owner_id, name) VALUES ('<other-user-id>', 'X')` is denied by RLS.
- [ ] Manual admin path: a user with the `admin` role assigned in `public.user_roles` can `SELECT` and `UPDATE` any `cardgroups` row, but `INSERT INTO public.swipe_records (user_id, card_id, …) VALUES ('<other-user-id>', …)` is denied (no admin bypass on swipe writes).
- [ ] `cd frontend && pnpm test sha256` passes — the `日本語` escape produces the same SHA-256 hash as the literal previously used.
- [ ] Language-policy grep clean: `grep -rnP '[\x{3040}-\x{30ff}\x{4e00}-\x{9fff}]' --include='*.go' --include='*.ts' --include='*.tsx' --include='*.sql' --include='*.md' docs backend frontend/src` returns nothing. `grep -rnE 'PR[0-9]+' docs backend/internal backend/cmd backend/graph frontend/src` returns nothing.