### PR TITLE
ci(frontend): add Vercel deploy job

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -80,6 +80,9 @@ jobs:
     name: Deploy to Vercel
     needs: lint-test-build
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    concurrency:
+      group: frontend-deploy-${{ github.ref }}
+      cancel-in-progress: false
     runs-on: ubuntu-24.04
     env:
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -84,6 +84,7 @@ jobs:
     env:
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -91,29 +92,44 @@ jobs:
       - name: Set up mise (Node from .tool-versions)
         uses: jdx/mise-action@v4
 
-      - name: Verify VERCEL_TOKEN is set
-        env:
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      - name: Verify Vercel secrets are set
         run: |
           if [ -z "$VERCEL_TOKEN" ]; then
             echo "Error: VERCEL_TOKEN secret is not configured" >&2
             exit 1
           fi
+          if [ -z "$VERCEL_ORG_ID" ]; then
+            echo "Error: VERCEL_ORG_ID secret is not configured" >&2
+            exit 1
+          fi
+          if [ -z "$VERCEL_PROJECT_ID" ]; then
+            echo "Error: VERCEL_PROJECT_ID secret is not configured" >&2
+            exit 1
+          fi
+
+      - name: Resolve pnpm store path
+        id: pnpm-store
+        run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: ${{ runner.os }}-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
 
       - name: Install Vercel CLI
-        run: npm install --global vercel@latest
+        run: npm install --global vercel@52
 
       - name: Pull Vercel environment
-        env:
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-        run: vercel pull --yes --environment=production --token=$VERCEL_TOKEN
+        run: vercel pull --yes --environment=production
 
       - name: Build
-        env:
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-        run: vercel build --prod --token=$VERCEL_TOKEN
+        run: vercel build --prod
 
       - name: Deploy
-        env:
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-        run: vercel deploy --prebuilt --prod --token=$VERCEL_TOKEN
+        run: vercel deploy --prebuilt --prod

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -75,3 +75,45 @@ jobs:
 
       - name: Vitest
         run: pnpm --filter frontend --if-present test
+
+  deploy:
+    name: Deploy to Vercel
+    needs: lint-test-build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-24.04
+    env:
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up mise (Node from .tool-versions)
+        uses: jdx/mise-action@v4
+
+      - name: Verify VERCEL_TOKEN is set
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: |
+          if [ -z "$VERCEL_TOKEN" ]; then
+            echo "Error: VERCEL_TOKEN secret is not configured" >&2
+            exit 1
+          fi
+
+      - name: Install Vercel CLI
+        run: npm install --global vercel@latest
+
+      - name: Pull Vercel environment
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: vercel pull --yes --environment=production --token=$VERCEL_TOKEN
+
+      - name: Build
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: vercel build --prod --token=$VERCEL_TOKEN
+
+      - name: Deploy
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: vercel deploy --prebuilt --prod --token=$VERCEL_TOKEN

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -8,6 +8,7 @@ Two independent workflows: `.github/workflows/backend.yml` and `.github/workflow
 
 - **Triggers are `paths:`-scoped** per workflow — backend to `backend/**` + workflow file; frontend to `frontend/**` + `schema/**` + the root pnpm/workspace/tool-version manifests + the frontend workflow file. When adding a third service, **add its own workflow** — do not broaden an existing one. Mixing scopes breaks CI granularity and responsibility.
 - **`concurrency` groups are per-workflow** (`backend-${{ github.ref }}`, `frontend-${{ github.ref }}`) with `cancel-in-progress: true` — rapid pushes on the same ref supersede in-flight runs per service (important for feature-branch iteration). The two workflows do not cancel each other.
+- **Deploy-job concurrency exception:** The `deploy` job in `frontend.yml` overrides the workflow-level cancellation policy with a job-scoped `concurrency:` group (`frontend-deploy-${{ github.ref }}`) that has `cancel-in-progress: false`. This ensures that once a `vercel deploy --prebuilt` begins, it cannot be cancelled mid-flight — Vercel may have already committed the deployment server-side, so cancelling the runner would leave an indeterminate state. Lint-test-build runs continue to cancel each other aggressively to save CI minutes on stale feature-branch commits.
 
 ## Deploy gating
 
@@ -161,7 +162,7 @@ The `deploy` job runs `pnpm install --frozen-lockfile` (with a pnpm store cache 
 
 #### Build env mismatch risk
 
-`vercel build` runs Vercel's own build pipeline, which is distinct from the repo's `pnpm build`. If the Node version configured in the Vercel project dashboard differs from the version pinned in `frontend/.tool-versions` (managed by mise), validation can pass in CI while the Vercel-side build fails — or, worse, silently produces a different output. Verify that the Vercel project's Node version setting matches `frontend/.tool-versions` in the Vercel dashboard under Project → Settings → General → Node.js Version.
+`vercel build` runs Vercel's own build pipeline, which is distinct from the repo's `pnpm build`. If the Node version configured in the Vercel project dashboard differs from the version pinned in `.tool-versions` at the repo root (managed by mise), validation can pass in CI while the Vercel-side build fails — or, worse, silently produces a different output. Verify that the Vercel project's Node version setting matches the Node version in `.tool-versions` in the Vercel dashboard under Project → Settings → General → Node.js Version.
 
 #### Why the deploy job intentionally omits build-time env vars
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -153,11 +153,11 @@ Register all three in the repository's GitHub secrets before the workflow runs. 
 
 #### pnpm install in the deploy job
 
-The `deploy` job runs `pnpm install --frozen-lockfile` (with a pnpm store cache sharing the same cache key as `lint-test-build`) before invoking `vercel build`, because `vercel build` executes `next build` locally on the runner and requires `node_modules` to be populated. See § "`pnpm install --frozen-lockfile` is the gate" for the repo-wide invariant this satisfies.
+The `deploy` job runs `pnpm install --frozen-lockfile` (with a pnpm store cache that uses the same key as `lint-test-build`, so the deploy job benefits from the warm cache produced by the preceding job — both run on the same OS and the same `pnpm-lock.yaml` hash, so divergent keys would only waste cache space) before invoking `vercel build`, because `vercel build` executes `next build` locally on the runner and requires `node_modules` to be populated. See § "`pnpm install --frozen-lockfile` is the gate" for the repo-wide invariant this satisfies.
 
 #### CLI deploy path vs. Vercel Git integration
 
-Both the CLI deploy path (via this workflow) and Vercel's native Git integration are active today — Vercel's integration fires on every push independently of the workflow. The CLI deploy is the *authoritative* path going forward: it is controlled by the same gating (`needs: lint-test-build`, main-only) that governs the rest of the release pipeline, and its output is observable in the Actions log alongside all other CI steps. The Git integration will be disabled in a follow-up change; see `docs/deployment.md` for the resolution plan and the steps to disable it in the Vercel dashboard.
+**This is a transitional configuration.** Both the CLI deploy path (via this workflow) and Vercel's native Git integration are currently active — Vercel's integration fires on every push independently of the workflow. The CLI deploy is the *authoritative* path going forward: it is controlled by the same gating (`needs: lint-test-build`, main-only) that governs the rest of the release pipeline, and its output is observable in the Actions log alongside all other CI steps. The Git integration will be disabled in a follow-up change; see `docs/deployment.md` § 'Why CI deploy is now the authoritative path' for the resolution plan.
 
 #### Build env mismatch risk
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -137,19 +137,23 @@ No request is made during the build, so dummy values only need to satisfy the Zo
 
 ### Frontend deploy job
 
-The `deploy` job in `frontend.yml` is gated identically to the backend: `needs: lint-test-build` ensures the full quality gate must pass before any deploy is attempted, and `if: github.event_name == 'push' && github.ref == 'refs/heads/main'` restricts execution to direct pushes to main (pull-request events and branch pushes are excluded). See § "Deploy gating" for the backend equivalent.
+The `deploy` job in `frontend.yml` follows the same gating pattern as the backend: `needs: lint-test-build` ensures the full quality gate must pass before any deploy is attempted, and the job condition restricts execution to direct pushes to `main` — pull-request events and branch pushes are excluded. See § "Deploy gating" for the backend equivalent.
 
-If `VERCEL_TOKEN` is empty or unset, the deploy step **explicitly exits 1** rather than silently no-oping. Failing loud on a missing secret beats a silent skip — misconfiguration must be visible. **Do not replace this with a silent skip.**
+If any of `VERCEL_TOKEN`, `VERCEL_ORG_ID`, or `VERCEL_PROJECT_ID` is empty or unset, a guard step **explicitly exits 1** rather than silently no-oping. Failing loud on a missing secret beats a silent skip — misconfiguration must be visible. **Do not replace this with a silent skip.**
 
 #### Required GitHub secrets
 
 | Secret | Purpose |
 |---|---|
-| `VERCEL_TOKEN` | Authenticates the Vercel CLI. Use a project-scoped token when the Vercel org plan supports it (limits blast radius to a single project); otherwise use an account-scoped token with a **quarterly rotation reminder**. The token must be non-empty — an empty value causes the deploy step to exit 1. |
-| `VERCEL_ORG_ID` | Identifies the Vercel organization. Exposed as the `VERCEL_ORG_ID` environment variable; the Vercel CLI auto-reads this name, so no explicit `--org` flag is needed. |
-| `VERCEL_PROJECT_ID` | Identifies the target Vercel project. Exposed as the `VERCEL_PROJECT_ID` environment variable; the Vercel CLI resolves the project without a `vercel link` step. |
+| `VERCEL_TOKEN` | Authenticates the Vercel CLI. Use a project-scoped token when the Vercel org plan supports it (limits blast radius to a single project); otherwise use an account-scoped token with a **quarterly rotation reminder**. Must be non-empty — the guard step checks all three Vercel secrets and exits 1 if any is absent. |
+| `VERCEL_ORG_ID` | Identifies the Vercel organization. Exposed as a job-level env var; the Vercel CLI auto-reads it, so no explicit `--org` flag is needed. Must be non-empty — see `VERCEL_TOKEN` note above. |
+| `VERCEL_PROJECT_ID` | Identifies the target Vercel project. Exposed as a job-level env var; the Vercel CLI resolves the project without a `vercel link` step. Must be non-empty — see `VERCEL_TOKEN` note above. |
 
 Register all three in the repository's GitHub secrets before the workflow runs. `VERCEL_ORG_ID` and `VERCEL_PROJECT_ID` are visible in the Vercel dashboard under Project → Settings → General.
+
+#### pnpm install in the deploy job
+
+The `deploy` job runs `pnpm install --frozen-lockfile` (with a pnpm store cache sharing the same cache key as `lint-test-build`) before invoking `vercel build`, because `vercel build` executes `next build` locally on the runner and requires `node_modules` to be populated. See § "`pnpm install --frozen-lockfile` is the gate" for the repo-wide invariant this satisfies.
 
 #### CLI deploy path vs. Vercel Git integration
 
@@ -158,4 +162,10 @@ Both the CLI deploy path (via this workflow) and Vercel's native Git integration
 #### Build env mismatch risk
 
 `vercel build` runs Vercel's own build pipeline, which is distinct from the repo's `pnpm build`. If the Node version configured in the Vercel project dashboard differs from the version pinned in `frontend/.tool-versions` (managed by mise), validation can pass in CI while the Vercel-side build fails — or, worse, silently produces a different output. Verify that the Vercel project's Node version setting matches `frontend/.tool-versions` in the Vercel dashboard under Project → Settings → General → Node.js Version.
+
+#### Why the deploy job intentionally omits build-time env vars
+
+The `lint-test-build` job sets `BACKEND_URL`, `NEXT_PUBLIC_SUPABASE_URL`, and `NEXT_PUBLIC_SUPABASE_ANON_KEY` to dummy values so `next build` can validate the env schema without real credentials. The `deploy` job **deliberately does not set any of these**. Instead, `vercel pull --environment=production` retrieves the real production values from the Vercel project's environment configuration and writes them to `.vercel/.env.production.local`, which `vercel build` then consumes.
+
+**Trap**: if a maintainer copies the dummy-value `env:` block from `lint-test-build` into the `deploy` job, the production build will silently bake those dummy values (e.g. a `localhost` Supabase URL) into the client-side JavaScript bundle. The Vercel project's production environment configuration must be the only source of truth for these values — never duplicate them in the deploy job.
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -8,7 +8,7 @@ Two independent workflows: `.github/workflows/backend.yml` and `.github/workflow
 
 - **Triggers are `paths:`-scoped** per workflow — backend to `backend/**` + workflow file; frontend to `frontend/**` + `schema/**` + the root pnpm/workspace/tool-version manifests + the frontend workflow file. When adding a third service, **add its own workflow** — do not broaden an existing one. Mixing scopes breaks CI granularity and responsibility.
 - **`concurrency` groups are per-workflow** (`backend-${{ github.ref }}`, `frontend-${{ github.ref }}`) with `cancel-in-progress: true` — rapid pushes on the same ref supersede in-flight runs per service (important for feature-branch iteration). The two workflows do not cancel each other.
-- **Deploy-job concurrency exception:** The `deploy` job in `frontend.yml` overrides the workflow-level cancellation policy with a job-scoped `concurrency:` group (`frontend-deploy-${{ github.ref }}`) that has `cancel-in-progress: false`. This ensures that once a `vercel deploy --prebuilt` begins, it cannot be cancelled mid-flight — Vercel may have already committed the deployment server-side, so cancelling the runner would leave an indeterminate state. Lint-test-build runs continue to cancel each other aggressively to save CI minutes on stale feature-branch commits.
+- **Deploy-job concurrency exception:** The `deploy` job in `frontend.yml` overrides the workflow-level cancellation policy with a job-scoped `concurrency:` group (`frontend-deploy-${{ github.ref }}`) that has `cancel-in-progress: false`. This ensures that once a `vercel deploy --prebuilt` begins, it cannot be cancelled mid-flight — Vercel may have already committed the deployment server-side, so cancelling the runner would leave an indeterminate state. Lint-test-build runs continue to cancel each other aggressively to save CI minutes on stale feature-branch commits. **General rule:** jobs whose effects are confined to the runner (lint, test, build artifacts in transit) are safe for `cancel-in-progress: true`; jobs that have already committed external state (deploys, releases, side-effecting API calls) must override with `cancel-in-progress: false` to avoid leaving external systems in an indeterminate state.
 
 ## Deploy gating
 
@@ -64,6 +64,8 @@ When skipping majors (e.g. `upload-artifact@v4 → @v7`), verify the breaking ch
 - `codecov-action@v6` — switched internals to the Codecov CLI (auth flow changed).
 
 Pin to commit SHAs when you need stronger supply-chain guarantees, at the cost of maintenance burden. The project uses major tags for now.
+
+**In-band npm tool installs follow the same policy.** When a CI step installs a global npm package (e.g. `npm install --global vercel@52`), pin to a major version (`@52`) for the same reason: security fixes auto-follow at minor/patch level, and a major bump requires an explicit, reviewable diff. The Vercel CLI install in `.github/workflows/frontend.yml` (line 126) is the canonical example. When adding any in-band `npm install` for a global tool, apply this principle by default.
 
 ## Codegen must run before Vet and Build
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -154,7 +154,7 @@ Register all three in the repository's GitHub secrets before the workflow runs. 
 
 #### pnpm install in the deploy job
 
-The `deploy` job runs `pnpm install --frozen-lockfile` (with a pnpm store cache that uses the same key as `lint-test-build`, so the deploy job benefits from the warm cache produced by the preceding job — both run on the same OS and the same `pnpm-lock.yaml` hash, so divergent keys would only waste cache space) before invoking `vercel build`, because `vercel build` executes `next build` locally on the runner and requires `node_modules` to be populated. See § "`pnpm install --frozen-lockfile` is the gate" for the repo-wide invariant this satisfies.
+The `deploy` job runs `pnpm install --frozen-lockfile` before invoking `vercel build`, because `vercel build` executes `next build` locally on the runner and requires `node_modules` to be populated. The pnpm store cache uses the same key as `lint-test-build` (same OS, same `pnpm-lock.yaml` hash), so the deploy job benefits from the warm cache produced by the preceding job — divergent keys would only waste cache space. See § "`pnpm install --frozen-lockfile` is the gate" for the repo-wide invariant this satisfies.
 
 #### CLI deploy path vs. Vercel Git integration
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -135,3 +135,27 @@ CI sets dummy values at the job level for every required var:
 
 No request is made during the build, so dummy values only need to satisfy the Zod schema (e.g. `z.string().url()` requires a URL-shaped string). Do **not** remove any of these: each missing env reintroduces a silent-fail shape the validation was designed to prevent. When a new required var is added to `src/env.ts`, add a corresponding dummy to the workflow's `env:` block.
 
+### Frontend deploy job
+
+The `deploy` job in `frontend.yml` is gated identically to the backend: `needs: lint-test-build` ensures the full quality gate must pass before any deploy is attempted, and `if: github.event_name == 'push' && github.ref == 'refs/heads/main'` restricts execution to direct pushes to main (pull-request events and branch pushes are excluded). See § "Deploy gating" for the backend equivalent.
+
+If `VERCEL_TOKEN` is empty or unset, the deploy step **explicitly exits 1** rather than silently no-oping. Failing loud on a missing secret beats a silent skip — misconfiguration must be visible. **Do not replace this with a silent skip.**
+
+#### Required GitHub secrets
+
+| Secret | Purpose |
+|---|---|
+| `VERCEL_TOKEN` | Authenticates the Vercel CLI. Use a project-scoped token when the Vercel org plan supports it (limits blast radius to a single project); otherwise use an account-scoped token with a **quarterly rotation reminder**. The token must be non-empty — an empty value causes the deploy step to exit 1. |
+| `VERCEL_ORG_ID` | Identifies the Vercel organization. Exposed as the `VERCEL_ORG_ID` environment variable; the Vercel CLI auto-reads this name, so no explicit `--org` flag is needed. |
+| `VERCEL_PROJECT_ID` | Identifies the target Vercel project. Exposed as the `VERCEL_PROJECT_ID` environment variable; the Vercel CLI resolves the project without a `vercel link` step. |
+
+Register all three in the repository's GitHub secrets before the workflow runs. `VERCEL_ORG_ID` and `VERCEL_PROJECT_ID` are visible in the Vercel dashboard under Project → Settings → General.
+
+#### CLI deploy path vs. Vercel Git integration
+
+Both the CLI deploy path (via this workflow) and Vercel's native Git integration are active today — Vercel's integration fires on every push independently of the workflow. The CLI deploy is the *authoritative* path going forward: it is controlled by the same gating (`needs: lint-test-build`, main-only) that governs the rest of the release pipeline, and its output is observable in the Actions log alongside all other CI steps. The Git integration will be disabled in a follow-up change; see `docs/deployment.md` for the resolution plan and the steps to disable it in the Vercel dashboard.
+
+#### Build env mismatch risk
+
+`vercel build` runs Vercel's own build pipeline, which is distinct from the repo's `pnpm build`. If the Node version configured in the Vercel project dashboard differs from the version pinned in `frontend/.tool-versions` (managed by mise), validation can pass in CI while the Vercel-side build fails — or, worse, silently produces a different output. Verify that the Vercel project's Node version setting matches `frontend/.tool-versions` in the Vercel dashboard under Project → Settings → General → Node.js Version.
+

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -251,9 +251,11 @@ vercel build --prod
 vercel deploy --prebuilt --prod
 ```
 
+`VERCEL_TOKEN` is exposed via a job-level `env:` block (not as a `--token` CLI flag); the Vercel CLI reads it automatically from the environment — do not add `--token` flags to these commands.
+
 #### Why CI deploy is now the authoritative path
 
-The project temporarily keeps two deploy paths active:
+**This is a transitional configuration.** Until the Vercel Git integration is disabled (a follow-up task), two deploy paths fire on every push to `main`:
 
 1. **Vercel automatic Git integration** — Vercel detects the push to `main` and starts a build automatically via its built-in GitHub integration.
 2. **CI deploy job** (this section) — the `deploy` job in the frontend workflow runs the same CLI sequence after `lint-test-build` passes.
@@ -264,7 +266,7 @@ CI deploy is the **authoritative path** going forward for three reasons:
 - The deploy logic lives in the workflow file, which is reviewable in a pull request alongside the code change.
 - Deploy reproducibility is version-controlled rather than stored in the Vercel dashboard configuration.
 
-The Vercel Git integration will be disabled in a follow-up once CI deploy is confirmed stable. Until that follow-up is merged, both paths may fire on the same push, which means two builds race to become the live deployment. This is benign (the last-write wins and both builds are from the same commit) but wastes build minutes. The follow-up will eliminate the race by disabling the Git integration in the Vercel project settings.
+The Vercel Git integration will be disabled in a follow-up once CI deploy is confirmed stable. Until that follow-up is merged, both paths may fire on the same push, which means two builds race to become the live deployment. This is benign — both builds come from the same commit, so whichever completes last serves the same artifact — but it wastes build minutes. The follow-up will eliminate the race by disabling the Git integration in the Vercel project settings.
 
 #### Required GitHub secrets
 
@@ -288,7 +290,7 @@ To prevent mismatches: open the Vercel project's **Settings → General → Node
 
 #### Interaction with `make setup-prod`
 
-The existing bring-up playbook (`make setup-prod` Phase 4, `--tags vercel`) registers the three Vercel environment variables (`BACKEND_URL`, `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`) as GitHub Actions secrets and imports the project. It does **not** provision `VERCEL_TOKEN`, `VERCEL_ORG_ID`, or `VERCEL_PROJECT_ID`.
+`make setup-prod` Phase 4 (`--tags vercel`) provisions the application environment variables (`BACKEND_URL`, `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`) into the Vercel project and stores them as GitHub Actions secrets. It does **not** provision the Vercel CLI authentication secrets (`VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`).
 
 This is an intentional gap: this section documents the CI deploy job and the secrets it needs, but does not modify the playbook. Adding the three secrets to `make setup-prod` is a follow-up task. Until that follow-up is merged, operators must provision `VERCEL_TOKEN`, `VERCEL_ORG_ID`, and `VERCEL_PROJECT_ID` manually via `gh secret set` by piping the value through stdin after running `make setup-prod` (see § "Two security patterns worth knowing" for why `--body` is unsafe):
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -68,10 +68,11 @@ Every phase that needs prior values follows a three-step idiom: `stat:` to detec
 
 The playbook writes outside the operator's machine in five places: (1) `gh secret set RENDER_DEPLOY_HOOK_URL` on the GitHub repo (Phase 3, idempotent overwrite), (2) `gh secret set PING_TOKEN`, `gh secret set RENDER_PING_URL`, and `gh secret set VERCEL_PING_URL` on the GitHub repo (Phase 6, idempotent overwrite), (3) `PUT /v1/services/<id>/env-vars/<key>` against the Render API for dynamic env vars including `PING_TOKEN` (Phase 6), (4) `POST /v1/services/<id>/deploys` against the Render API (each call enqueues a deploy, which is the operator's intent), and (5) the local state file. Re-running any phase is safe — none of the writes accumulate state in a way that corrupts the next run.
 
-### Two security patterns worth knowing
+### Three security patterns worth knowing
 
 - **`gh secret set` via `shell:` with `stdin:`, not `--body "<URL>"`.** `--body` puts the secret on argv, where it leaks to `ps`, audit logs, and shell history. Ansible's `no_log: true` masks playbook output but does not affect argv, so piping the value through stdin is the only way to keep the deploy-hook URL out of process listings.
 - **Tier-1 values are never `debug:`-printed inline with non-secret values.** `SUPABASE_DB_URL` (which carries the DB password) is shown in its own task with a "leave screen-share before reading this" warning banner, so the operator can pause sharing for that one paste.
+- **CLI tools that auto-read tokens from env should be invoked without explicit token flags.** Passing a secret as `--token <value>` exposes it on argv, which is visible in `/proc/<pid>/cmdline` to other processes on the same runner and in `set -x` debug output — the same argv-leak failure mode as the `gh secret set --body` case above. The Vercel CLI auto-reads `VERCEL_TOKEN`, `VERCEL_ORG_ID`, and `VERCEL_PROJECT_ID` from the environment; `.github/workflows/frontend.yml` exposes them only via the job-level `env:` block and never passes `--token <value>` to any `vercel` command.
 
 ### Render deploy polling: terminal failure states
 
@@ -200,7 +201,7 @@ Dynamic env vars (declared with `sync: false` in `render.yaml`; Blueprint create
 
 When the Blueprint apply wizard prompts for the `sync: false` placeholders, leave them blank and click Save. Re-running `make setup-prod-postapply` reconciles the Supabase-derived three from the state file via the Render API, then triggers the first deploy.
 
-After the service is created, copy the deploy hook URL from **Settings → Deploy Hook** and store it as the GitHub Actions secret `RENDER_DEPLOY_HOOK_URL` (used by `.github/workflows/backend.yml`). When using `make setup-prod`, this registration is automated via `gh secret set` with the value piped through stdin — see the "Two security patterns" subsection above.
+After the service is created, copy the deploy hook URL from **Settings → Deploy Hook** and store it as the GitHub Actions secret `RENDER_DEPLOY_HOOK_URL` (used by `.github/workflows/backend.yml`). When using `make setup-prod`, this registration is automated via `gh secret set` with the value piped through stdin — see the "Three security patterns" subsection above.
 
 When `render.yaml` itself changes (e.g. you bump `buildCommand`), reapply via **Blueprints → flamingo-armond → Manual Sync** in the dashboard, then re-run `make setup-prod-postapply` to deploy.
 
@@ -292,7 +293,7 @@ To prevent mismatches: open the Vercel project's **Settings → General → Node
 
 `make setup-prod` Phase 4 (`--tags vercel`) provisions the application environment variables (`BACKEND_URL`, `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`) into the Vercel project and stores them as GitHub Actions secrets. It does **not** provision the Vercel CLI authentication secrets (`VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`).
 
-This is an intentional gap: this section documents the CI deploy job and the secrets it needs, but does not modify the playbook. Adding the three secrets to `make setup-prod` is a follow-up task. Until that follow-up is merged, operators must provision `VERCEL_TOKEN`, `VERCEL_ORG_ID`, and `VERCEL_PROJECT_ID` manually via `gh secret set` by piping the value through stdin after running `make setup-prod` (see § "Two security patterns worth knowing" for why `--body` is unsafe):
+This is an intentional gap: this section documents the CI deploy job and the secrets it needs, but does not modify the playbook. Adding the three secrets to `make setup-prod` is a follow-up task. Until that follow-up is merged, operators must provision `VERCEL_TOKEN`, `VERCEL_ORG_ID`, and `VERCEL_PROJECT_ID` manually via `gh secret set` by piping the value through stdin after running `make setup-prod` (see § "Three security patterns worth knowing" for why `--body` is unsafe):
 
 ```bash
 printf '%s' "<token>" | gh secret set VERCEL_TOKEN

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -284,9 +284,9 @@ These three secrets are a **manual provisioning step** until the playbook is upd
 
 #### Build environment mismatch risk
 
-`vercel build` runs Vercel's own build pipeline, not the repository's `pnpm build` script directly. Vercel selects a Node version according to the project's dashboard settings — if that version differs from the version pinned in `frontend/.tool-versions`, the build may succeed locally but behave differently in CI or produce a subtly different artifact.
+`vercel build` runs Vercel's own build pipeline, not the repository's `pnpm build` script directly. Vercel selects a Node version according to the project's dashboard settings — if that version differs from the version pinned in `.tool-versions` at the repo root, the build may succeed locally but behave differently in CI or produce a subtly different artifact.
 
-To prevent mismatches: open the Vercel project's **Settings → General → Node.js Version** and set it to match the version in `frontend/.tool-versions`. This is a one-time operator step that cannot be automated — Vercel project settings live in the dashboard and have no API surface exposed in the repository.
+To prevent mismatches: open the Vercel project's **Settings → General → Node.js Version** and set it to match the version in `.tool-versions`. This is a one-time operator step that cannot be automated — Vercel project settings live in the dashboard and have no API surface exposed in the repository.
 
 #### Interaction with `make setup-prod`
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -266,7 +266,7 @@ CI deploy is the **authoritative path** going forward for three reasons:
 - The deploy logic lives in the workflow file, which is reviewable in a pull request alongside the code change.
 - Deploy reproducibility is version-controlled rather than stored in the Vercel dashboard configuration.
 
-The Vercel Git integration will be disabled in a follow-up once CI deploy is confirmed stable. Until that follow-up is merged, both paths may fire on the same push, which means two builds race to become the live deployment. This is benign — both builds come from the same commit, so whichever completes last serves the same artifact — but it wastes build minutes. The follow-up will eliminate the race by disabling the Git integration in the Vercel project settings.
+The Vercel Git integration will be disabled in a follow-up once CI deploy is confirmed stable. Until that follow-up is merged, both paths may fire on the same push, which means two builds race to become the live deployment. This is benign — both builds come from the same commit, so they produce equivalent artifacts when the CI Node/pnpm versions match the Vercel project's settings (see § 'Build environment mismatch risk') — but the race wastes build minutes. The follow-up will eliminate the race by disabling the Git integration in the Vercel project settings.
 
 #### Required GitHub secrets
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -241,6 +241,65 @@ Auto-deploy is off so schema migrations stay tied to explicit deploys. There are
 - **`make setup-prod` users**: Phase 6 (postapply) already triggered a fresh production deploy via the Vercel API after Phase 4 registered env, and the front-end HEAD probe verified it returns 200. Skip this section.
 - **Manual operators (no `make setup-prod`)**: push a commit to `main`, or click **Deploy** on the Vercel project page.
 
+### Vercel CI deploy
+
+Every push to `main` triggers a `deploy` job in `.github/workflows/frontend.yml`. The job runs after `lint-test-build` succeeds and executes the Vercel CLI three-step sequence:
+
+```
+vercel pull --yes --environment=production
+vercel build --prod
+vercel deploy --prebuilt --prod
+```
+
+#### Why CI deploy is now the authoritative path
+
+The project temporarily keeps two deploy paths active:
+
+1. **Vercel automatic Git integration** — Vercel detects the push to `main` and starts a build automatically via its built-in GitHub integration.
+2. **CI deploy job** (this section) — the `deploy` job in the frontend workflow runs the same CLI sequence after `lint-test-build` passes.
+
+CI deploy is the **authoritative path** going forward for three reasons:
+
+- It gates on `lint-test-build`: a broken build or failing lint cannot reach production.
+- The deploy logic lives in the workflow file, which is reviewable in a pull request alongside the code change.
+- Deploy reproducibility is version-controlled rather than stored in the Vercel dashboard configuration.
+
+The Vercel Git integration will be disabled in a follow-up once CI deploy is confirmed stable. Until that follow-up is merged, both paths may fire on the same push, which means two builds race to become the live deployment. This is benign (the last-write wins and both builds are from the same commit) but wastes build minutes. The follow-up will eliminate the race by disabling the Git integration in the Vercel project settings.
+
+#### Required GitHub secrets
+
+The CI deploy job requires three secrets registered on the GitHub repository:
+
+| Secret | Purpose |
+|---|---|
+| `VERCEL_TOKEN` | Personal access token (or team token) that authenticates the Vercel CLI. |
+| `VERCEL_ORG_ID` | The Vercel team or personal account ID that owns the project. |
+| `VERCEL_PROJECT_ID` | The Vercel project ID for the frontend. |
+
+For the rotation policy and the full secrets table covering all workflows, see `docs/ci.md` § "Frontend deploy job".
+
+These three secrets are a **manual provisioning step** until the playbook is updated (see "Interaction with `make setup-prod`" below).
+
+#### Build environment mismatch risk
+
+`vercel build` runs Vercel's own build pipeline, not the repository's `pnpm build` script directly. Vercel selects a Node version according to the project's dashboard settings — if that version differs from the version pinned in `frontend/.tool-versions`, the build may succeed locally but behave differently in CI or produce a subtly different artifact.
+
+To prevent mismatches: open the Vercel project's **Settings → General → Node.js Version** and set it to match the version in `frontend/.tool-versions`. This is a one-time operator step that cannot be automated — Vercel project settings live in the dashboard and have no API surface exposed in the repository.
+
+#### Interaction with `make setup-prod`
+
+The existing bring-up playbook (`make setup-prod` Phase 4, `--tags vercel`) registers the three Vercel environment variables (`BACKEND_URL`, `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`) as GitHub Actions secrets and imports the project. It does **not** provision `VERCEL_TOKEN`, `VERCEL_ORG_ID`, or `VERCEL_PROJECT_ID`.
+
+This is an intentional gap: this section documents the CI deploy job and the secrets it needs, but does not modify the playbook. Adding the three secrets to `make setup-prod` is a follow-up task. Until that follow-up is merged, operators must provision `VERCEL_TOKEN`, `VERCEL_ORG_ID`, and `VERCEL_PROJECT_ID` manually via `gh secret set` by piping the value through stdin after running `make setup-prod` (see § "Two security patterns worth knowing" for why `--body` is unsafe):
+
+```bash
+printf '%s' "<token>" | gh secret set VERCEL_TOKEN
+printf '%s' "<org-id>" | gh secret set VERCEL_ORG_ID
+printf '%s' "<project-id>" | gh secret set VERCEL_PROJECT_ID
+```
+
+The `VERCEL_PROJECT_ID` value is available in the Vercel dashboard under **Settings → General → Project ID** after the project is imported in Step 3.
+
 ## Smoke tests after the initial setup
 
 Replace `<backend-url>` and `<frontend-url>` with the URLs printed by Render and Vercel.


### PR DESCRIPTION
Closes #49

## Summary

Adds a `deploy` job to `.github/workflows/frontend.yml` that runs after `lint-test-build` succeeds on pushes to `main`, deploying the frontend via the Vercel CLI three-step sequence (`vercel pull --environment=production` → `vercel build --prod` → `vercel deploy --prebuilt --prod`). Establishes CI as the authoritative deploy path, gated behind the same lint/test/build wall as the rest of the pipeline. Ships supporting docs that codify a job-scoped concurrency exception for jobs with external side effects, a third operational security pattern (never pass tokens on argv when the CLI auto-reads them from env), and the secrets-provisioning gap with `make setup-prod` that operators must close manually until a follow-up is merged.

## Background / Motivation

- The repo previously relied on Vercel's native Git integration for `main` deploys. That path bypasses the `lint-test-build` quality gate — a broken build or failing lint can still ship, because Vercel only sees the git push, not the CI status. The new CI deploy job restores the same gating discipline already in force on the backend (`needs: lint-test-build`, `if: github.event_name == 'push' && github.ref == 'refs/heads/main'`), so PR events and feature-branch pushes never trigger a deploy.
- The `deploy` job overrides the workflow-level `concurrency.cancel-in-progress: true` policy with a job-scoped `concurrency: { group: frontend-deploy-${{ github.ref }}, cancel-in-progress: false }`. Once `vercel deploy --prebuilt` begins, Vercel may have already committed deployment state server-side; cancelling the runner mid-flight would leave external state indeterminate. Lint-test-build runs continue to cancel each other aggressively to save CI minutes on stale feature-branch commits — the asymmetry is the load-bearing invariant. The general rule (codified in `docs/ci.md`): jobs whose effects are confined to the runner are safe for `cancel-in-progress: true`; jobs that have already committed external state must override with `cancel-in-progress: false`.
- Token handling is argv-safe by construction. `VERCEL_TOKEN`, `VERCEL_ORG_ID`, and `VERCEL_PROJECT_ID` are exposed only via the job-level `env:` block and never passed as `--token <value>` flags; the Vercel CLI auto-reads them from the environment. Passing a secret on argv puts it in `/proc/<pid>/cmdline` and `set -x` debug output — the same failure mode as `gh secret set --body "<URL>"`. This third pattern joins the existing two ("`gh secret set` via stdin", "tier-1 values never `debug:`-printed inline") in `docs/deployment.md`.
- Build-time env vars are intentionally **not** duplicated from `lint-test-build` into `deploy`. The lint job sets `BACKEND_URL`, `NEXT_PUBLIC_SUPABASE_URL`, and `NEXT_PUBLIC_SUPABASE_ANON_KEY` to dummy values so `next build` can validate the env schema offline. The deploy job runs `vercel pull --environment=production` to fetch the real values from Vercel's project configuration into `.vercel/.env.production.local`; if a maintainer copies the dummy `env:` block into `deploy`, the production build silently bakes `localhost` URLs into the client-side JS bundle. This trap is documented in `docs/ci.md` so the next contributor sees the prohibition before reaching for the copy-paste.
- The Vercel CLI is installed via `npm install --global vercel@52` — pinned to a major version, not a fixed minor/patch. Same rationale as the existing GitHub Action major-pin policy: security fixes auto-follow at minor/patch level; a major bump requires an explicit, reviewable diff. The `docs/ci.md` "Action version policy" section now explicitly extends this rule to in-band `npm install --global` invocations, with the Vercel CLI install as the canonical example.
- Secret provisioning has a known gap with `make setup-prod`. Phase 4 (`--tags vercel`) provisions application env vars (`BACKEND_URL`, `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`) but not the Vercel CLI authentication trio (`VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`). Closing this gap is a follow-up; until then operators must run `printf '%s' "<value>" | gh secret set <NAME>` manually after `make setup-prod`, and `docs/deployment.md` spells the commands out so the manual step is mechanical (and stdin-piped, never `--body`).
- Both deploy paths fire on every push during the transition. Vercel's Git integration cannot be disabled in the same change that lands the CI job (chicken-and-egg — disabling the Git integration before the CI job is confirmed stable would block all deploys). Both paths build the same commit so the artifacts are equivalent when Node/pnpm versions match; the only cost is wasted build minutes. The Git integration disable is sequenced as a follow-up.
- Build environment mismatches between Vercel's dashboard Node version and the repo's `.tool-versions` are silent — `vercel build` runs Vercel's own build pipeline, distinct from `pnpm build`, and validation can pass in CI while the Vercel side produces a subtly different artifact. This cannot be automated (Vercel project settings have no API surface exposed from the repo), so the docs flag it as a one-time operator step under Vercel project **Settings → General → Node.js Version**.

## Changes

### `deploy` job in `.github/workflows/frontend.yml`

- New `deploy` job (`name: Deploy to Vercel`, `runs-on: ubuntu-24.04`) that runs after `lint-test-build` succeeds. Triggered on `push` to `refs/heads/main` only — PR events and other branches are excluded by the job-level `if: github.event_name == 'push' && github.ref == 'refs/heads/main'` condition, mirroring the backend-deploy gating in `.github/workflows/backend.yml`.
- Job-scoped `concurrency: { group: frontend-deploy-${{ github.ref }}, cancel-in-progress: false }` overrides the workflow-level `cancel-in-progress: true` policy. Lint-test-build retains the workflow-level cancellation behavior; only the deploy job is sticky.
- Job-level `env:` block exposes `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`, and `VERCEL_TOKEN` from the matching repository secrets; no `vercel` invocation in the job uses `--token`. The Vercel CLI auto-reads all three from the environment.
- A "Verify Vercel secrets are set" guard step explicitly exits 1 with a stderr error message if any of the three env vars is empty. Failing loud beats a silent skip — a misconfigured secret must be visible.
- Sets up Node via `jdx/mise-action@v4` (mise reads `.tool-versions` at the repo root), then resolves the pnpm store path via `pnpm store path --silent` and caches it under the same key the `lint-test-build` job uses (`${{ runner.os }}-pnpm-${{ hashFiles('pnpm-lock.yaml') }}`). Same key by design — divergent keys would only waste cache space.
- Runs `pnpm install --frozen-lockfile` before `vercel build`, because `vercel build` invokes `next build` locally on the runner and needs a populated `node_modules`.
- Installs the Vercel CLI globally pinned to `vercel@52`, then runs `vercel pull --yes --environment=production`, `vercel build --prod`, `vercel deploy --prebuilt --prod` as three separate steps so a failure pinpoints the responsible phase in the Actions log.

### `docs/ci.md` updates

- New bullet under "Triggers and concurrency" documents the deploy-job concurrency exception and codifies the general rule about runner-confined vs. external-state jobs (the principle that explains why `cancel-in-progress: false` is required for deploys, releases, and other side-effecting steps).
- New paragraph under "Action version policy" extends the major-version-pin rule to in-band global npm installs in CI, with `npm install --global vercel@52` as the canonical example. The same principle applies to any future `npm install --global <tool>@<major>` step.
- New "Frontend deploy job" subsection under "Frontend env vars are validated at build time" gathers the deploy-specific guidance: required GitHub secrets table (with the per-secret rotation note for `VERCEL_TOKEN`), pnpm install rationale (cache key parity with `lint-test-build`), CLI deploy path vs. Vercel Git integration (transitional state), build environment mismatch risk (Node version pin), and the "deploy job intentionally omits build-time env vars" trap explaining why the dummy `env:` block from `lint-test-build` must not be copy-pasted into `deploy`.

### `docs/deployment.md` updates

- "Two security patterns worth knowing" → "Three security patterns worth knowing" (heading rename + new third bullet). The third pattern: CLI tools that auto-read tokens from the environment must be invoked without explicit `--token <value>` flags. Passing a secret on argv exposes it in `/proc/<pid>/cmdline` and `set -x` debug output. The Vercel CLI is the canonical example; the workflow exposes `VERCEL_TOKEN` only via the job-level `env:` block.
- One downstream cross-reference updated from "Two security patterns" to "Three security patterns" so the link target name matches the new heading.
- New "Vercel CI deploy" subsection under "Vercel deploy" documents the three-step CLI sequence, why CI deploy is now the authoritative path (gating, reviewability, version control vs. dashboard configuration), the transitional dual-fire state with Vercel's Git integration, the required GitHub secrets table, the build environment mismatch risk, and the `make setup-prod` interaction gap. The section ends with explicit `printf '%s' "<value>" | gh secret set <NAME>` commands operators must run manually until the playbook is updated.

## Verification

After merge, the following should all hold:

- `grep -n "name: Deploy to Vercel" .github/workflows/frontend.yml` matches once.
- `grep -n "needs: lint-test-build" .github/workflows/frontend.yml` matches once (the `deploy` job).
- `grep -nE "if: github\.event_name == 'push' && github\.ref == 'refs/heads/main'" .github/workflows/frontend.yml` matches once.
- `grep -nE "cancel-in-progress: false" .github/workflows/frontend.yml` matches once (the deploy job's job-scoped concurrency override) and `grep -nE "frontend-deploy-\\\$\\{\\{ github\.ref \\}\\}" .github/workflows/frontend.yml` matches once.
- `grep -n "vercel@52" .github/workflows/frontend.yml` matches once.
- `grep -nE -- "--token" .github/workflows/frontend.yml` returns nothing — no `--token` flag anywhere in the workflow.
- `grep -nE "Verify Vercel secrets are set" .github/workflows/frontend.yml` matches once.
- `grep -nE "BACKEND_URL|NEXT_PUBLIC_SUPABASE" .github/workflows/frontend.yml` matches only inside the `lint-test-build` job's `env:` block, never inside the `deploy` job (the dummy-env trap is closed structurally).
- `grep -n "Three security patterns worth knowing" docs/deployment.md` matches once; `grep -n "Two security patterns worth knowing" docs/deployment.md` returns nothing.
- `grep -n "Frontend deploy job" docs/ci.md` matches once and the section contains the secrets table, the pnpm cache-parity rationale, the CLI-vs-Git-integration transitional note, the Node version mismatch warning, and the dummy-env-vars trap.
- `grep -n "Vercel CI deploy" docs/deployment.md` matches once.

## Test plan

- [ ] `gh workflow view frontend.yml --ref feature/improve_pr10` shows the new `deploy` job definition.
- [ ] Push a no-op commit to a feature branch — only `lint-test-build` is scheduled; the `deploy` job is **not** scheduled (the `if:` condition excludes non-`main` refs).
- [ ] Open a PR against `main` from the same branch — the `deploy` job is **not** scheduled (the `if:` condition excludes `pull_request` events).
- [ ] Merge to `main` — `lint-test-build` runs first, then `deploy` runs once and only once. The Actions tab shows both jobs; no concurrent second `deploy` run is started for the same `main` ref.
- [ ] During an in-flight `deploy`, push another commit to `main` — the second `deploy` waits for the first to finish (because the deploy job's `cancel-in-progress: false` makes it sticky); the in-flight `lint-test-build` for the new commit cancels the previous in-flight `lint-test-build` (workflow-level `cancel-in-progress: true` is unchanged).
- [ ] Temporarily delete one of `VERCEL_TOKEN` / `VERCEL_ORG_ID` / `VERCEL_PROJECT_ID` from the repo secrets, push to `main` — the "Verify Vercel secrets are set" step fails with a non-zero exit and a clear stderr message; subsequent steps in the deploy job do not run.
- [ ] Open the production URL after the first successful CI deploy — the deployed bundle's network calls hit the real `BACKEND_URL` / `NEXT_PUBLIC_SUPABASE_URL` (not `localhost`), confirming `vercel pull --environment=production` populated the env from the Vercel project, not from the lint-test-build dummy block.
- [ ] In the Vercel dashboard, confirm the project's **Settings → General → Node.js Version** matches the Node version in `.tool-versions`. If they diverge, update the Vercel side.
- [ ] `grep -rnP "[\x{3040}-\x{30ff}\x{4e00}-\x{9fff}]" --include="*.yml" --include="*.md" .github docs` returns nothing (English-only policy under \`.claude/rules/language-policy.md\`). `grep -rnE "PR[0-9]+" docs .github` returns nothing.
