### PR TITLE
feat: paginate cardgroup cards via Relay CardConnection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ go run ./cmd/server   # PORT defaults to 1323
 This file is **L1**: keep it ≤35 lines, top-level orientation only. Overflow goes into:
 
 - **L2 — `docs/`** — architecture & topic docs (source of truth for technical detail).
-  - `backend.md`, `frontend.md`, `ci.md`, `dev-setup.md`, `deployment.md`, `playbook-patterns.md`.
+  - `backend.md`, `frontend.md`, `ci.md`, `dev-setup.md`, `deployment.md`, `playbook-patterns.md`, `pagination.md`.
 - **L3 — `.claude/rules/`** — cross-cutting rules and conventions.
   - `language-policy.md` — English-only rule, no PR-order references, verification commands.
 

--- a/backend/graph/resolver/helpers.go
+++ b/backend/graph/resolver/helpers.go
@@ -76,6 +76,27 @@ func toCardModels(cards []*domain.Card) []*model.Card {
 	return out
 }
 
+// toUsecaseCardOrderBy translates the gqlgen-generated enum into the
+// usecase's typed enum. Values are identical strings ("ID", "CREATED_AT", …)
+// so the conversion is a direct cast.
+func toUsecaseCardOrderBy(o *model.CardOrderBy) *usecase.CardOrderBy {
+	if o == nil {
+		return nil
+	}
+	v := usecase.CardOrderBy(*o)
+	return &v
+}
+
+// toUsecaseSortOrder translates model.SortOrder into the usecase's typed
+// SortOrder.
+func toUsecaseSortOrder(d *model.SortOrder) *usecase.SortOrder {
+	if d == nil {
+		return nil
+	}
+	v := usecase.SortOrder(*d)
+	return &v
+}
+
 func toSwipeResponseModel(out *usecase.SwipeOutput) *model.SwipeResponse {
 	if out == nil {
 		return nil

--- a/backend/graph/resolver/helpers.go
+++ b/backend/graph/resolver/helpers.go
@@ -6,9 +6,9 @@ import (
 	"backend/internal/usecase"
 )
 
-// toUserModel lives in a separate file so `gqlgen generate` does not strip it
-// when regenerating schema.resolvers.go (gqlgen only preserves resolver methods,
-// not top-level helper functions, in the managed file).
+// Helpers live in a separate file so `gqlgen generate` does not strip them
+// when regenerating schema.resolvers.go (gqlgen only preserves resolver
+// methods, not top-level helper functions, in the managed file).
 func toUserModel(user *domain.User) *model.User {
 	if user == nil {
 		return nil
@@ -21,9 +21,8 @@ func toUserModel(user *domain.User) *model.User {
 	}
 }
 
-// toCardgroupModel converts a domain.Cardgroup to a model.Cardgroup.
-// Owner is intentionally left nil; cardgroupResolver.Owner populates it lazily
-// via the per-request User DataLoader.
+// toCardgroupModel leaves Owner nil; cardgroupResolver.Owner populates it
+// lazily via the per-request User DataLoader.
 func toCardgroupModel(cg *domain.Cardgroup) *model.Cardgroup {
 	if cg == nil {
 		return nil
@@ -76,9 +75,8 @@ func toCardModels(cards []*domain.Card) []*model.Card {
 	return out
 }
 
-// toUsecaseCardOrderBy translates the gqlgen-generated enum into the
-// usecase's typed enum. Values are identical strings ("ID", "CREATED_AT", …)
-// so the conversion is a direct cast.
+// The gqlgen-generated and usecase enums share identical string values
+// ("ID", "CREATED_AT", …) so conversion is a direct cast.
 func toUsecaseCardOrderBy(o *model.CardOrderBy) *usecase.CardOrderBy {
 	if o == nil {
 		return nil
@@ -87,8 +85,6 @@ func toUsecaseCardOrderBy(o *model.CardOrderBy) *usecase.CardOrderBy {
 	return &v
 }
 
-// toUsecaseSortOrder translates model.SortOrder into the usecase's typed
-// SortOrder.
 func toUsecaseSortOrder(d *model.SortOrder) *usecase.SortOrder {
 	if d == nil {
 		return nil
@@ -107,8 +103,7 @@ func toSwipeResponseModel(out *usecase.SwipeOutput) *model.SwipeResponse {
 	}
 }
 
-// toCardConnectionModel converts a usecase.CardConnectionOutput into the
-// generated model.CardConnection. Cursors are bare card UUIDs (no base64).
+// toCardConnectionModel emits cursors as bare card UUIDs (no base64).
 func toCardConnectionModel(out *usecase.CardConnectionOutput) *model.CardConnection {
 	if out == nil {
 		return &model.CardConnection{Edges: []*model.CardEdge{}, PageInfo: &model.PageInfo{}}
@@ -117,23 +112,21 @@ func toCardConnectionModel(out *usecase.CardConnectionOutput) *model.CardConnect
 	for i, c := range out.Cards {
 		edges[i] = &model.CardEdge{Cursor: c.ID, Node: toCardModel(c)}
 	}
-	var startCur, endCur *string
-	if out.StartCur != "" {
-		s := out.StartCur
-		startCur = &s
-	}
-	if out.EndCur != "" {
-		e := out.EndCur
-		endCur = &e
-	}
 	return &model.CardConnection{
 		Edges: edges,
 		PageInfo: &model.PageInfo{
 			HasNextPage:     out.HasNext,
 			HasPreviousPage: out.HasPrev,
-			StartCursor:     startCur,
-			EndCursor:       endCur,
+			StartCursor:     nilIfEmpty(out.StartCur),
+			EndCursor:       nilIfEmpty(out.EndCur),
 		},
 		TotalCount: int(out.TotalCount),
 	}
+}
+
+func nilIfEmpty(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
 }

--- a/backend/graph/resolver/helpers.go
+++ b/backend/graph/resolver/helpers.go
@@ -85,3 +85,34 @@ func toSwipeResponseModel(out *usecase.SwipeOutput) *model.SwipeResponse {
 		PerformanceMode: out.PerformanceMode,
 	}
 }
+
+// toCardConnectionModel converts a usecase.CardConnectionOutput into the
+// generated model.CardConnection. Cursors are bare card UUIDs (no base64).
+func toCardConnectionModel(out *usecase.CardConnectionOutput) *model.CardConnection {
+	if out == nil {
+		return &model.CardConnection{Edges: []*model.CardEdge{}, PageInfo: &model.PageInfo{}}
+	}
+	edges := make([]*model.CardEdge, len(out.Cards))
+	for i, c := range out.Cards {
+		edges[i] = &model.CardEdge{Cursor: c.ID, Node: toCardModel(c)}
+	}
+	var startCur, endCur *string
+	if out.StartCur != "" {
+		s := out.StartCur
+		startCur = &s
+	}
+	if out.EndCur != "" {
+		e := out.EndCur
+		endCur = &e
+	}
+	return &model.CardConnection{
+		Edges: edges,
+		PageInfo: &model.PageInfo{
+			HasNextPage:     out.HasNext,
+			HasPreviousPage: out.HasPrev,
+			StartCursor:     startCur,
+			EndCursor:       endCur,
+		},
+		TotalCount: int(out.TotalCount),
+	}
+}

--- a/backend/graph/resolver/schema.resolvers.go
+++ b/backend/graph/resolver/schema.resolvers.go
@@ -183,8 +183,8 @@ func (r *queryResolver) CardsByCardgroupConnection(ctx context.Context, cardgrou
 		Last:           last,
 		After:          after,
 		Before:         before,
-		OrderBy:        (*string)(orderBy),
-		OrderDirection: (*string)(orderDirection),
+		OrderBy:        toUsecaseCardOrderBy(orderBy),
+		OrderDirection: toUsecaseSortOrder(orderDirection),
 	})
 	if err != nil {
 		return nil, err

--- a/backend/graph/resolver/schema.resolvers.go
+++ b/backend/graph/resolver/schema.resolvers.go
@@ -175,6 +175,23 @@ func (r *queryResolver) CardsByCardgroup(ctx context.Context, cardgroupID string
 	return toCardModels(cards), nil
 }
 
+// CardsByCardgroupConnection is the resolver for the cardsByCardgroupConnection field.
+func (r *queryResolver) CardsByCardgroupConnection(ctx context.Context, cardgroupID string, first *int, after *string, last *int, before *string, orderBy *model.CardOrderBy, orderDirection *model.SortOrder) (*model.CardConnection, error) {
+	out, err := r.CardUC.ListCardsByCardgroupConnection(ctx, usecase.CardConnectionInput{
+		CardgroupID:    cardgroupID,
+		First:          first,
+		Last:           last,
+		After:          after,
+		Before:         before,
+		OrderBy:        (*string)(orderBy),
+		OrderDirection: (*string)(orderDirection),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return toCardConnectionModel(out), nil
+}
+
 // Card returns generated.CardResolver implementation.
 func (r *Resolver) Card() generated.CardResolver { return &cardResolver{r} }
 

--- a/backend/internal/loader/user_test.go
+++ b/backend/internal/loader/user_test.go
@@ -107,6 +107,14 @@ func (r *countingCardRepo) FindByIDs(ctx context.Context, ids []string) (map[str
 func (r *countingCardRepo) FindByCardgroup(_ context.Context, _ string) ([]*domain.Card, error) {
 	panic("countingCardRepo.FindByCardgroup not configured")
 }
+func (r *countingCardRepo) FindPageByCardgroup(
+	_ context.Context, _ string,
+	_, _ *repository.CardCursor,
+	_, _ int,
+	_ repository.CardOrderBy, _ repository.SortOrder,
+) ([]*domain.Card, int64, error) {
+	panic("countingCardRepo.FindPageByCardgroup not configured")
+}
 func (r *countingCardRepo) FindDueCardsTx(_ context.Context, _ *gorm.DB, _ string, _ time.Time, _ int) ([]*domain.Card, error) {
 	panic("countingCardRepo.FindDueCardsTx not configured")
 }

--- a/backend/internal/repository/card.go
+++ b/backend/internal/repository/card.go
@@ -42,8 +42,10 @@ type CardCursor struct {
 	UpdatedAt *time.Time
 }
 
-// pageCap is the upper bound for first/last in paginated queries.
-const pageCap = 100
+// pageCap is the upper bound for first/last in paginated queries. Set to
+// usecase.maxPageSize+1 so the usecase's "+1 fetch" trick can detect another
+// page even when the caller asks for the documented max (100).
+const pageCap = 101
 
 type gormCard struct {
 	ID            string    `gorm:"column:id;primaryKey;type:uuid"`
@@ -171,19 +173,21 @@ func (r *cardRepo) FindPageByCardgroup(
 		last = pageCap
 	}
 
-	// Short-circuit when caller asked for no rows.
-	if first == 0 && last == 0 {
-		return []*domain.Card{}, 0, nil
-	}
-
-	// totalCount: a separate COUNT(*) scoped to the cardgroup. Acceptable for
-	// <= 10k cards/group; revisit if the cap grows.
+	// totalCount: a separate COUNT(*) scoped to the cardgroup. Computed before
+	// the no-rows short-circuit so callers passing first=0 still observe the
+	// real cardgroup size. Acceptable for <= 10k cards/group; revisit if the
+	// cap grows.
 	var total int64
 	if err := r.db.WithContext(ctx).
 		Model(&gormCard{}).
 		Where("cardgroup_id = ?", cardgroupID).
 		Count(&total).Error; err != nil {
 		return nil, 0, eris.Wrap(err, "repository: count cards by cardgroup")
+	}
+
+	// Short-circuit row fetch when caller asked for no rows.
+	if first == 0 && last == 0 {
+		return []*domain.Card{}, total, nil
 	}
 
 	// Decide effective direction & limit. Backward paging executes the query
@@ -204,7 +208,10 @@ func (r *cardRepo) FindPageByCardgroup(
 		Where("cardgroup_id = ?", cardgroupID)
 
 	if cursor != nil {
-		clause, args := cursorWhere(orderBy, effectiveDir, cursor)
+		clause, args, err := cursorWhere(orderBy, effectiveDir, cursor)
+		if err != nil {
+			return nil, 0, eris.Wrap(err, "repository: build cursor where")
+		}
 		q = q.Where(clause, args...)
 	}
 
@@ -247,41 +254,46 @@ func orderClause(orderBy CardOrderBy, dir SortOrder) string {
 }
 
 // cursorWhere builds the tuple-comparison WHERE for the supplied cursor and
-// direction. ASC yields `>`, DESC yields `<`.
-func cursorWhere(orderBy CardOrderBy, dir SortOrder, c *CardCursor) (string, []any) {
+// direction. ASC yields `>`, DESC yields `<`. Returns an error when the
+// cursor lacks the column required by the active orderBy.
+func cursorWhere(orderBy CardOrderBy, dir SortOrder, c *CardCursor) (string, []any, error) {
 	op := ">"
 	if dir == SortDesc {
 		op = "<"
 	}
 	if orderBy == CardOrderByID {
-		return "id " + op + " ?", []any{c.ID}
+		return "id " + op + " ?", []any{c.ID}, nil
 	}
 	field := string(orderBy)
-	val := cursorFieldValue(orderBy, c)
+	val, err := cursorFieldValue(orderBy, c)
+	if err != nil {
+		return "", nil, err
+	}
 	// Tuple compare: (field, id) op (val, c.ID).
 	return "(" + field + " " + op + " ? OR (" + field + " = ? AND id " + op + " ?))",
-		[]any{val, val, c.ID}
+		[]any{val, val, c.ID}, nil
 }
 
 // cursorFieldValue returns the cursor value for the active orderBy field.
-// Falls back to time.Time{} when the cursor has not populated the column —
-// the usecase layer is responsible for hydrating before calling.
-func cursorFieldValue(orderBy CardOrderBy, c *CardCursor) any {
+// Returns an error when the relevant column is unset — the usecase layer is
+// responsible for hydrating before calling, so an unset column indicates a
+// caller bug rather than a benign empty value.
+func cursorFieldValue(orderBy CardOrderBy, c *CardCursor) (any, error) {
 	switch orderBy {
 	case CardOrderByDue:
 		if c.Due != nil {
-			return *c.Due
+			return *c.Due, nil
 		}
 	case CardOrderByCreatedAt:
 		if c.CreatedAt != nil {
-			return *c.CreatedAt
+			return *c.CreatedAt, nil
 		}
 	case CardOrderByUpdatedAt:
 		if c.UpdatedAt != nil {
-			return *c.UpdatedAt
+			return *c.UpdatedAt, nil
 		}
 	}
-	return time.Time{}
+	return nil, eris.Errorf("cursor missing %s column", orderBy)
 }
 
 func (r *cardRepo) FindDueCardsTx(ctx context.Context, tx *gorm.DB, cardgroupID string, now time.Time, limit int) ([]*domain.Card, error) {

--- a/backend/internal/repository/card.go
+++ b/backend/internal/repository/card.go
@@ -159,24 +159,13 @@ func (r *cardRepo) FindPageByCardgroup(
 	orderBy CardOrderBy,
 	dir SortOrder,
 ) ([]*domain.Card, int64, error) {
-	// Clamp page sizes to [0, pageCap].
-	if first < 0 {
-		first = 0
-	}
-	if first > pageCap {
-		first = pageCap
-	}
-	if last < 0 {
-		last = 0
-	}
-	if last > pageCap {
-		last = pageCap
-	}
+	first = clampPageSize(first)
+	last = clampPageSize(last)
 
-	// totalCount: a separate COUNT(*) scoped to the cardgroup. Computed before
-	// the no-rows short-circuit so callers passing first=0 still observe the
-	// real cardgroup size. Acceptable for <= 10k cards/group; revisit if the
-	// cap grows.
+	// totalCount comes from a separate COUNT(*) scoped to the cardgroup.
+	// Computed before the no-rows short-circuit so callers passing first=0
+	// still observe the real cardgroup size. Acceptable for <= 10k cards/
+	// group; revisit if the cap grows.
 	var total int64
 	if err := r.db.WithContext(ctx).
 		Model(&gormCard{}).
@@ -185,13 +174,12 @@ func (r *cardRepo) FindPageByCardgroup(
 		return nil, 0, eris.Wrap(err, "repository: count cards by cardgroup")
 	}
 
-	// Short-circuit row fetch when caller asked for no rows.
 	if first == 0 && last == 0 {
 		return []*domain.Card{}, total, nil
 	}
 
-	// Decide effective direction & limit. Backward paging executes the query
-	// with the inverted direction and reverses the slice afterwards.
+	// Backward paging executes the query with the inverted direction and
+	// reverses the slice afterwards.
 	effectiveDir := dir
 	limit := first
 	cursor := after
@@ -235,7 +223,16 @@ func (r *cardRepo) FindPageByCardgroup(
 	return out, total, nil
 }
 
-// invertDir flips ASC <-> DESC.
+func clampPageSize(n int) int {
+	if n < 0 {
+		return 0
+	}
+	if n > pageCap {
+		return pageCap
+	}
+	return n
+}
+
 func invertDir(d SortOrder) SortOrder {
 	if d == SortDesc {
 		return SortAsc
@@ -275,9 +272,8 @@ func cursorWhere(orderBy CardOrderBy, dir SortOrder, c *CardCursor) (string, []a
 }
 
 // cursorFieldValue returns the cursor value for the active orderBy field.
-// Returns an error when the relevant column is unset — the usecase layer is
-// responsible for hydrating before calling, so an unset column indicates a
-// caller bug rather than a benign empty value.
+// An unset column is a caller bug — the usecase layer hydrates the relevant
+// field before calling — so this returns an error rather than a zero value.
 func cursorFieldValue(orderBy CardOrderBy, c *CardCursor) (any, error) {
 	switch orderBy {
 	case CardOrderByDue:

--- a/backend/internal/repository/card.go
+++ b/backend/internal/repository/card.go
@@ -12,6 +12,39 @@ import (
 	"backend/internal/domain"
 )
 
+// CardOrderBy is the allowlist of fields that paginated card queries may sort by.
+// Lexicographic tuple order is always (orderField, id) so cursors stay deterministic
+// even when the order field has duplicate values.
+type CardOrderBy string
+
+const (
+	CardOrderByID        CardOrderBy = "id"
+	CardOrderByCreatedAt CardOrderBy = "created_at"
+	CardOrderByUpdatedAt CardOrderBy = "updated_at"
+	CardOrderByDue       CardOrderBy = "due"
+)
+
+// SortOrder mirrors the GraphQL SortOrder enum.
+type SortOrder string
+
+const (
+	SortAsc  SortOrder = "ASC"
+	SortDesc SortOrder = "DESC"
+)
+
+// CardCursor is an opaque cursor for paginated card queries.
+// Only the fields relevant to the active OrderBy need to be populated.
+// ID is always populated and acts as the secondary key in the tuple comparison.
+type CardCursor struct {
+	ID        string
+	Due       *time.Time
+	CreatedAt *time.Time
+	UpdatedAt *time.Time
+}
+
+// pageCap is the upper bound for first/last in paginated queries.
+const pageCap = 100
+
 type gormCard struct {
 	ID            string    `gorm:"column:id;primaryKey;type:uuid"`
 	CardgroupID   string    `gorm:"column:cardgroup_id"`
@@ -42,6 +75,14 @@ type CardRepository interface {
 	FindByIDTx(ctx context.Context, tx *gorm.DB, id string) (*domain.Card, error)
 	FindByIDs(ctx context.Context, ids []string) (map[string]*domain.Card, error)
 	FindByCardgroup(ctx context.Context, cardgroupID string) ([]*domain.Card, error)
+	FindPageByCardgroup(
+		ctx context.Context,
+		cardgroupID string,
+		after, before *CardCursor,
+		first, last int,
+		orderBy CardOrderBy,
+		dir SortOrder,
+	) (cards []*domain.Card, totalCount int64, err error)
 	FindDueCardsTx(ctx context.Context, tx *gorm.DB, cardgroupID string, now time.Time, limit int) ([]*domain.Card, error)
 	Create(ctx context.Context, card *domain.Card) error
 	UpdateFSRSStateTx(ctx context.Context, tx *gorm.DB, id string, state domain.FSRSState) error
@@ -102,6 +143,145 @@ func (r *cardRepo) FindByCardgroup(ctx context.Context, cardgroupID string) ([]*
 		out[i] = cardToDomain(rows[i])
 	}
 	return out, nil
+}
+
+// FindPageByCardgroup returns a window of cards for a cardgroup ordered by
+// (orderField, id) so cursors stay deterministic. Forward paging uses `after`
+// + `first`; backward paging uses `before` + `last`. totalCount reflects every
+// row in the cardgroup, not just the page.
+func (r *cardRepo) FindPageByCardgroup(
+	ctx context.Context,
+	cardgroupID string,
+	after, before *CardCursor,
+	first, last int,
+	orderBy CardOrderBy,
+	dir SortOrder,
+) ([]*domain.Card, int64, error) {
+	// Clamp page sizes to [0, pageCap].
+	if first < 0 {
+		first = 0
+	}
+	if first > pageCap {
+		first = pageCap
+	}
+	if last < 0 {
+		last = 0
+	}
+	if last > pageCap {
+		last = pageCap
+	}
+
+	// Short-circuit when caller asked for no rows.
+	if first == 0 && last == 0 {
+		return []*domain.Card{}, 0, nil
+	}
+
+	// totalCount: a separate COUNT(*) scoped to the cardgroup. Acceptable for
+	// <= 10k cards/group; revisit if the cap grows.
+	var total int64
+	if err := r.db.WithContext(ctx).
+		Model(&gormCard{}).
+		Where("cardgroup_id = ?", cardgroupID).
+		Count(&total).Error; err != nil {
+		return nil, 0, eris.Wrap(err, "repository: count cards by cardgroup")
+	}
+
+	// Decide effective direction & limit. Backward paging executes the query
+	// with the inverted direction and reverses the slice afterwards.
+	effectiveDir := dir
+	limit := first
+	cursor := after
+	reverse := false
+	if last > 0 {
+		effectiveDir = invertDir(dir)
+		limit = last
+		cursor = before
+		reverse = true
+	}
+
+	q := r.db.WithContext(ctx).
+		Model(&gormCard{}).
+		Where("cardgroup_id = ?", cardgroupID)
+
+	if cursor != nil {
+		clause, args := cursorWhere(orderBy, effectiveDir, cursor)
+		q = q.Where(clause, args...)
+	}
+
+	q = q.Order(orderClause(orderBy, effectiveDir)).Limit(limit)
+
+	var rows []gormCard
+	if err := q.Find(&rows).Error; err != nil {
+		return nil, 0, eris.Wrap(err, "repository: find page by cardgroup")
+	}
+
+	if reverse {
+		for i, j := 0, len(rows)-1; i < j; i, j = i+1, j-1 {
+			rows[i], rows[j] = rows[j], rows[i]
+		}
+	}
+
+	out := make([]*domain.Card, len(rows))
+	for i := range rows {
+		out[i] = cardToDomain(rows[i])
+	}
+	return out, total, nil
+}
+
+// invertDir flips ASC <-> DESC.
+func invertDir(d SortOrder) SortOrder {
+	if d == SortDesc {
+		return SortAsc
+	}
+	return SortDesc
+}
+
+// orderClause renders the SQL ORDER BY tail. When orderBy is `id` only one
+// column appears; otherwise the secondary `id` keeps order deterministic.
+func orderClause(orderBy CardOrderBy, dir SortOrder) string {
+	d := string(dir)
+	if orderBy == CardOrderByID {
+		return "id " + d
+	}
+	return string(orderBy) + " " + d + ", id " + d
+}
+
+// cursorWhere builds the tuple-comparison WHERE for the supplied cursor and
+// direction. ASC yields `>`, DESC yields `<`.
+func cursorWhere(orderBy CardOrderBy, dir SortOrder, c *CardCursor) (string, []any) {
+	op := ">"
+	if dir == SortDesc {
+		op = "<"
+	}
+	if orderBy == CardOrderByID {
+		return "id " + op + " ?", []any{c.ID}
+	}
+	field := string(orderBy)
+	val := cursorFieldValue(orderBy, c)
+	// Tuple compare: (field, id) op (val, c.ID).
+	return "(" + field + " " + op + " ? OR (" + field + " = ? AND id " + op + " ?))",
+		[]any{val, val, c.ID}
+}
+
+// cursorFieldValue returns the cursor value for the active orderBy field.
+// Falls back to time.Time{} when the cursor has not populated the column —
+// the usecase layer is responsible for hydrating before calling.
+func cursorFieldValue(orderBy CardOrderBy, c *CardCursor) any {
+	switch orderBy {
+	case CardOrderByDue:
+		if c.Due != nil {
+			return *c.Due
+		}
+	case CardOrderByCreatedAt:
+		if c.CreatedAt != nil {
+			return *c.CreatedAt
+		}
+	case CardOrderByUpdatedAt:
+		if c.UpdatedAt != nil {
+			return *c.UpdatedAt
+		}
+	}
+	return time.Time{}
 }
 
 func (r *cardRepo) FindDueCardsTx(ctx context.Context, tx *gorm.DB, cardgroupID string, now time.Time, limit int) ([]*domain.Card, error) {

--- a/backend/internal/repository/card_pagination_test.go
+++ b/backend/internal/repository/card_pagination_test.go
@@ -284,6 +284,59 @@ func TestCardRepository_FindPageByCardgroup_OrderByDue_TieBreakOnEqualDue(t *tes
 	require.Equal(t, sorted[2].ID, page2[0].ID)
 }
 
+// TestCardRepository_FindPageByCardgroup_PageCapAllowsMaxPlusOne verifies that
+// pageCap (101) accepts first=101 so the usecase's +1 trick can detect a next
+// page when the caller requests the documented maximum of 100.
+func TestCardRepository_FindPageByCardgroup_PageCapAllowsMaxPlusOne(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	ownerID := insertAuthUser(t, ctx)
+	cg := insertCardgroup(t, ctx, ownerID)
+	repo := repository.NewCardRepository(testDB.GORM)
+
+	// Insert 101 cards so both first=101 and first=100 queries have enough rows.
+	insertCards(t, ctx, repo, cg.ID, 101)
+
+	// first=101 must return all 101 rows because pageCap == 101.
+	cards101, total101, err := repo.FindPageByCardgroup(
+		ctx, cg.ID, nil, nil, 101, 0, repository.CardOrderByID, repository.SortAsc,
+	)
+	require.NoError(t, err)
+	require.Equal(t, int64(101), total101)
+	require.Len(t, cards101, 101)
+
+	// first=100 must be limited to 100 rows, confirming the cap still applies.
+	cards100, total100, err := repo.FindPageByCardgroup(
+		ctx, cg.ID, nil, nil, 100, 0, repository.CardOrderByID, repository.SortAsc,
+	)
+	require.NoError(t, err)
+	require.Equal(t, int64(101), total100)
+	require.Len(t, cards100, 100)
+}
+
+// TestCardRepository_FindPageByCardgroup_ZeroPageReturnsTotal verifies the C2
+// fix: first=0 && last=0 short-circuits the row fetch but still returns the
+// real totalCount from the separate COUNT(*) query.
+func TestCardRepository_FindPageByCardgroup_ZeroPageReturnsTotal(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	ownerID := insertAuthUser(t, ctx)
+	cg := insertCardgroup(t, ctx, ownerID)
+	repo := repository.NewCardRepository(testDB.GORM)
+
+	insertCards(t, ctx, repo, cg.ID, 5)
+
+	cards, total, err := repo.FindPageByCardgroup(
+		ctx, cg.ID, nil, nil, 0, 0, repository.CardOrderByID, repository.SortAsc,
+	)
+	require.NoError(t, err)
+	// No rows requested, but the slice must be non-nil and empty.
+	require.NotNil(t, cards)
+	require.Len(t, cards, 0)
+	// totalCount must reflect the actual number of cards in the group.
+	require.Equal(t, int64(5), total)
+}
+
 // sortByID returns a copy of cards sorted by ID ascending.
 func sortByID(cards []*domain.Card) []*domain.Card {
 	out := make([]*domain.Card, len(cards))

--- a/backend/internal/repository/card_pagination_test.go
+++ b/backend/internal/repository/card_pagination_test.go
@@ -1,0 +1,246 @@
+package repository_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"backend/internal/domain"
+	"backend/internal/repository"
+)
+
+// insertCards creates n cards with deterministic Front values ("c0".."cn-1").
+// CreatedAt is staggered so insertion order matches creation order. Due is set
+// to now+i*hour so DUE-ordered tests have a clear ASC sequence.
+func insertCards(t *testing.T, ctx context.Context, repo repository.CardRepository, cgID string, n int) []*domain.Card {
+	t.Helper()
+	now := time.Now().UTC()
+	cards := make([]*domain.Card, n)
+	for i := 0; i < n; i++ {
+		c := newCard(cgID, "front", "back")
+		// Stagger timestamps by 1 hour so ordering is unambiguous.
+		c.CreatedAt = now.Add(time.Duration(i) * time.Hour)
+		c.UpdatedAt = c.CreatedAt
+		c.FSRS.Due = now.Add(time.Duration(i) * time.Hour)
+		require.NoError(t, repo.Create(ctx, c))
+		cards[i] = c
+	}
+	// Re-fetch so we observe DB-rounded timestamps (Postgres truncates to
+	// microsecond precision; cursor comparisons must use those values).
+	for i, c := range cards {
+		got, err := repo.FindByID(ctx, c.ID)
+		require.NoError(t, err)
+		cards[i] = got
+	}
+	return cards
+}
+
+func TestCardRepository_FindPageByCardgroup_ForwardByID(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	ownerID := insertAuthUser(t, ctx)
+	cg := insertCardgroup(t, ctx, ownerID)
+	repo := repository.NewCardRepository(testDB.GORM)
+
+	cards := insertCards(t, ctx, repo, cg.ID, 5)
+	// Sort the inserted cards by their UUID so we know what "id ASC" returns.
+	sorted := sortByID(cards)
+
+	got, total, err := repo.FindPageByCardgroup(
+		ctx, cg.ID, nil, nil, 2, 0, repository.CardOrderByID, repository.SortAsc,
+	)
+	require.NoError(t, err)
+	require.Equal(t, int64(5), total)
+	require.Len(t, got, 2)
+	require.Equal(t, sorted[0].ID, got[0].ID)
+	require.Equal(t, sorted[1].ID, got[1].ID)
+
+	got, total, err = repo.FindPageByCardgroup(
+		ctx, cg.ID,
+		&repository.CardCursor{ID: sorted[1].ID}, nil,
+		2, 0, repository.CardOrderByID, repository.SortAsc,
+	)
+	require.NoError(t, err)
+	require.Equal(t, int64(5), total)
+	require.Len(t, got, 2)
+	require.Equal(t, sorted[2].ID, got[0].ID)
+	require.Equal(t, sorted[3].ID, got[1].ID)
+
+	got, total, err = repo.FindPageByCardgroup(
+		ctx, cg.ID,
+		&repository.CardCursor{ID: sorted[3].ID}, nil,
+		2, 0, repository.CardOrderByID, repository.SortAsc,
+	)
+	require.NoError(t, err)
+	require.Equal(t, int64(5), total)
+	require.Len(t, got, 1)
+	require.Equal(t, sorted[4].ID, got[0].ID)
+}
+
+func TestCardRepository_FindPageByCardgroup_BackwardByID(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	ownerID := insertAuthUser(t, ctx)
+	cg := insertCardgroup(t, ctx, ownerID)
+	repo := repository.NewCardRepository(testDB.GORM)
+
+	cards := insertCards(t, ctx, repo, cg.ID, 5)
+	sorted := sortByID(cards)
+
+	// last=2, before=nil should return the final two ids in ASC order.
+	got, total, err := repo.FindPageByCardgroup(
+		ctx, cg.ID, nil, nil, 0, 2, repository.CardOrderByID, repository.SortAsc,
+	)
+	require.NoError(t, err)
+	require.Equal(t, int64(5), total)
+	require.Len(t, got, 2)
+	require.Equal(t, sorted[3].ID, got[0].ID)
+	require.Equal(t, sorted[4].ID, got[1].ID)
+
+	// last=2, before=cards[3] should return cards[1..2] in ASC order.
+	got, _, err = repo.FindPageByCardgroup(
+		ctx, cg.ID,
+		nil, &repository.CardCursor{ID: sorted[3].ID},
+		0, 2, repository.CardOrderByID, repository.SortAsc,
+	)
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	require.Equal(t, sorted[1].ID, got[0].ID)
+	require.Equal(t, sorted[2].ID, got[1].ID)
+}
+
+func TestCardRepository_FindPageByCardgroup_EmptyGroup(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	ownerID := insertAuthUser(t, ctx)
+	cg := insertCardgroup(t, ctx, ownerID)
+	repo := repository.NewCardRepository(testDB.GORM)
+
+	got, total, err := repo.FindPageByCardgroup(
+		ctx, cg.ID, nil, nil, 10, 0, repository.CardOrderByID, repository.SortAsc,
+	)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), total)
+	require.NotNil(t, got)
+	require.Empty(t, got)
+}
+
+func TestCardRepository_FindPageByCardgroup_SinglePage(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	ownerID := insertAuthUser(t, ctx)
+	cg := insertCardgroup(t, ctx, ownerID)
+	repo := repository.NewCardRepository(testDB.GORM)
+
+	insertCards(t, ctx, repo, cg.ID, 3)
+
+	got, total, err := repo.FindPageByCardgroup(
+		ctx, cg.ID, nil, nil, 10, 0, repository.CardOrderByID, repository.SortAsc,
+	)
+	require.NoError(t, err)
+	require.Equal(t, int64(3), total)
+	require.Len(t, got, 3)
+}
+
+func TestCardRepository_FindPageByCardgroup_OrderByDue(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	ownerID := insertAuthUser(t, ctx)
+	cg := insertCardgroup(t, ctx, ownerID)
+	repo := repository.NewCardRepository(testDB.GORM)
+
+	cards := insertCards(t, ctx, repo, cg.ID, 3)
+	// insertCards staggers Due by +1h per index, so cards[0] is earliest.
+
+	got, total, err := repo.FindPageByCardgroup(
+		ctx, cg.ID, nil, nil, 2, 0, repository.CardOrderByDue, repository.SortAsc,
+	)
+	require.NoError(t, err)
+	require.Equal(t, int64(3), total)
+	require.Len(t, got, 2)
+	require.Equal(t, cards[0].ID, got[0].ID)
+	require.Equal(t, cards[1].ID, got[1].ID)
+
+	// Advance via cursor populated with the second card's Due value.
+	cursor := &repository.CardCursor{
+		ID:  cards[1].ID,
+		Due: &cards[1].FSRS.Due,
+	}
+	got, _, err = repo.FindPageByCardgroup(
+		ctx, cg.ID, cursor, nil, 2, 0, repository.CardOrderByDue, repository.SortAsc,
+	)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	require.Equal(t, cards[2].ID, got[0].ID)
+}
+
+func TestCardRepository_FindPageByCardgroup_OrderByCreatedAtDesc(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	ownerID := insertAuthUser(t, ctx)
+	cg := insertCardgroup(t, ctx, ownerID)
+	repo := repository.NewCardRepository(testDB.GORM)
+
+	cards := insertCards(t, ctx, repo, cg.ID, 4)
+	// DESC: newest first → cards[3], cards[2], cards[1], cards[0].
+
+	got, total, err := repo.FindPageByCardgroup(
+		ctx, cg.ID, nil, nil, 2, 0, repository.CardOrderByCreatedAt, repository.SortDesc,
+	)
+	require.NoError(t, err)
+	require.Equal(t, int64(4), total)
+	require.Len(t, got, 2)
+	require.Equal(t, cards[3].ID, got[0].ID)
+	require.Equal(t, cards[2].ID, got[1].ID)
+
+	cursor := &repository.CardCursor{
+		ID:        cards[2].ID,
+		CreatedAt: &cards[2].CreatedAt,
+	}
+	got, _, err = repo.FindPageByCardgroup(
+		ctx, cg.ID, cursor, nil, 2, 0, repository.CardOrderByCreatedAt, repository.SortDesc,
+	)
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	require.Equal(t, cards[1].ID, got[0].ID)
+	require.Equal(t, cards[0].ID, got[1].ID)
+}
+
+func TestCardRepository_FindPageByCardgroup_TotalCountIsScopedToCardgroup(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	ownerID := insertAuthUser(t, ctx)
+	cg1 := insertCardgroup(t, ctx, ownerID)
+	cg2 := insertCardgroup(t, ctx, ownerID)
+	repo := repository.NewCardRepository(testDB.GORM)
+
+	insertCards(t, ctx, repo, cg1.ID, 3)
+	insertCards(t, ctx, repo, cg2.ID, 5)
+
+	_, total, err := repo.FindPageByCardgroup(
+		ctx, cg1.ID, nil, nil, 10, 0, repository.CardOrderByID, repository.SortAsc,
+	)
+	require.NoError(t, err)
+	require.Equal(t, int64(3), total)
+
+	_, total, err = repo.FindPageByCardgroup(
+		ctx, cg2.ID, nil, nil, 10, 0, repository.CardOrderByID, repository.SortAsc,
+	)
+	require.NoError(t, err)
+	require.Equal(t, int64(5), total)
+}
+
+// sortByID returns a copy of cards sorted by ID ascending.
+func sortByID(cards []*domain.Card) []*domain.Card {
+	out := make([]*domain.Card, len(cards))
+	copy(out, cards)
+	for i := 1; i < len(out); i++ {
+		for j := i; j > 0 && out[j-1].ID > out[j].ID; j-- {
+			out[j-1], out[j] = out[j], out[j-1]
+		}
+	}
+	return out
+}
+

--- a/backend/internal/repository/card_pagination_test.go
+++ b/backend/internal/repository/card_pagination_test.go
@@ -232,6 +232,58 @@ func TestCardRepository_FindPageByCardgroup_TotalCountIsScopedToCardgroup(t *tes
 	require.Equal(t, int64(5), total)
 }
 
+// TestCardRepository_FindPageByCardgroup_OrderByDue_TieBreakOnEqualDue
+// verifies the secondary `id` key keeps order deterministic when multiple
+// cards share the same Due value — pages must not skip or duplicate.
+func TestCardRepository_FindPageByCardgroup_OrderByDue_TieBreakOnEqualDue(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	ownerID := insertAuthUser(t, ctx)
+	cg := insertCardgroup(t, ctx, ownerID)
+	repo := repository.NewCardRepository(testDB.GORM)
+
+	now := time.Now().UTC()
+	cards := make([]*domain.Card, 3)
+	for i := 0; i < 3; i++ {
+		c := newCard(cg.ID, "front", "back")
+		c.CreatedAt = now
+		c.UpdatedAt = now
+		c.FSRS.Due = now
+		require.NoError(t, repo.Create(ctx, c))
+		cards[i] = c
+	}
+	// Re-fetch so we observe DB-rounded timestamps.
+	for i, c := range cards {
+		got, err := repo.FindByID(ctx, c.ID)
+		require.NoError(t, err)
+		cards[i] = got
+	}
+
+	// (due, id) lexicographic sort — all dues equal so order is by ID.
+	sorted := sortByID(cards)
+	dueT := sorted[0].FSRS.Due
+
+	page1, total, err := repo.FindPageByCardgroup(
+		ctx, cg.ID, nil, nil, 2, 0, repository.CardOrderByDue, repository.SortAsc,
+	)
+	require.NoError(t, err)
+	require.Equal(t, int64(3), total)
+	require.Len(t, page1, 2)
+	require.Equal(t, sorted[0].ID, page1[0].ID)
+	require.Equal(t, sorted[1].ID, page1[1].ID)
+
+	cursor := &repository.CardCursor{
+		ID:  page1[1].ID,
+		Due: &dueT,
+	}
+	page2, _, err := repo.FindPageByCardgroup(
+		ctx, cg.ID, cursor, nil, 2, 0, repository.CardOrderByDue, repository.SortAsc,
+	)
+	require.NoError(t, err)
+	require.Len(t, page2, 1, "third card should appear exactly once")
+	require.Equal(t, sorted[2].ID, page2[0].ID)
+}
+
 // sortByID returns a copy of cards sorted by ID ascending.
 func sortByID(cards []*domain.Card) []*domain.Card {
 	out := make([]*domain.Card, len(cards))

--- a/backend/internal/usecase/card.go
+++ b/backend/internal/usecase/card.go
@@ -16,6 +16,14 @@ import (
 type CardRepository interface {
 	FindByID(ctx context.Context, id string) (*domain.Card, error)
 	FindByCardgroup(ctx context.Context, cardgroupID string) ([]*domain.Card, error)
+	FindPageByCardgroup(
+		ctx context.Context,
+		cardgroupID string,
+		after, before *repository.CardCursor,
+		first, last int,
+		orderBy repository.CardOrderBy,
+		dir repository.SortOrder,
+	) ([]*domain.Card, int64, error)
 	Create(ctx context.Context, card *domain.Card) error
 	Update(ctx context.Context, id string, patch repository.CardUpdate) (*domain.Card, error)
 	Delete(ctx context.Context, id string) error
@@ -44,6 +52,32 @@ type UpdateCardInput struct {
 	Front *string
 	Back  *string
 }
+
+// CardConnectionInput captures the GraphQL pagination arguments. Pointer
+// fields preserve "absent" semantics from the schema.
+type CardConnectionInput struct {
+	CardgroupID    string
+	First, Last    *int
+	After, Before  *string // raw GraphQL ID strings (cursor = card UUID)
+	OrderBy        *string // GraphQL CardOrderBy enum string
+	OrderDirection *string // GraphQL SortOrder enum string
+}
+
+// CardConnectionOutput is the usecase-level page result. The resolver wraps
+// it into a model.CardConnection.
+type CardConnectionOutput struct {
+	Cards      []*domain.Card
+	TotalCount int64
+	HasNext    bool
+	HasPrev    bool
+	StartCur   string
+	EndCur     string
+}
+
+const (
+	defaultPageSize = 20
+	maxPageSize     = 100
+)
 
 func (u *CardUsecase) Card(ctx context.Context, id string) (*domain.Card, error) {
 	user := auth.UserFrom(ctx)
@@ -170,6 +204,178 @@ func (u *CardUsecase) Delete(ctx context.Context, id string) error {
 		return gqlerr.Internal(ctx, err)
 	}
 	return nil
+}
+
+// ListCardsByCardgroupConnection paginates a cardgroup's cards using
+// Relay-style forward (first/after) or backward (last/before) cursors.
+func (u *CardUsecase) ListCardsByCardgroupConnection(
+	ctx context.Context, in CardConnectionInput,
+) (*CardConnectionOutput, error) {
+	user := auth.UserFrom(ctx)
+	if user == nil {
+		return nil, gqlerr.Unauthenticated()
+	}
+	if err := u.authorizeCardgroup(ctx, in.CardgroupID, user.Sub, true); err != nil {
+		return nil, err
+	}
+
+	orderBy, dir, err := resolveOrderBy(in.OrderBy, in.OrderDirection)
+	if err != nil {
+		return nil, err
+	}
+
+	first, last, err := resolvePageSize(in.First, in.Last)
+	if err != nil {
+		return nil, err
+	}
+
+	after, err := u.resolveCursor(ctx, in.After, in.CardgroupID, orderBy, "after")
+	if err != nil {
+		return nil, err
+	}
+	before, err := u.resolveCursor(ctx, in.Before, in.CardgroupID, orderBy, "before")
+	if err != nil {
+		return nil, err
+	}
+
+	// Request one extra row to detect whether another page exists. Trim
+	// before returning to the caller.
+	wantFirst := first
+	wantLast := last
+	if wantFirst > 0 {
+		wantFirst++
+	}
+	if wantLast > 0 {
+		wantLast++
+	}
+
+	cards, total, err := u.cardRepo.FindPageByCardgroup(
+		ctx, in.CardgroupID, after, before, wantFirst, wantLast, orderBy, dir,
+	)
+	if err != nil {
+		return nil, gqlerr.Internal(ctx, err)
+	}
+
+	out := &CardConnectionOutput{TotalCount: total}
+	if first > 0 {
+		if len(cards) > first {
+			out.HasNext = true
+			cards = cards[:first]
+		}
+		out.HasPrev = after != nil
+	} else if last > 0 {
+		if len(cards) > last {
+			out.HasPrev = true
+			// Backward paging fetched (last+1) trailing rows; drop the
+			// leading extra so the page boundary stays at the tail.
+			cards = cards[len(cards)-last:]
+		}
+		out.HasNext = before != nil
+	}
+
+	out.Cards = cards
+	if len(cards) > 0 {
+		out.StartCur = cards[0].ID
+		out.EndCur = cards[len(cards)-1].ID
+	}
+	return out, nil
+}
+
+// resolveOrderBy maps GraphQL enum strings to the repository's allowlist.
+// Defaults to (ID, ASC) when both are nil.
+func resolveOrderBy(orderBy, dir *string) (repository.CardOrderBy, repository.SortOrder, error) {
+	field := repository.CardOrderByID
+	if orderBy != nil {
+		switch *orderBy {
+		case "ID":
+			field = repository.CardOrderByID
+		case "CREATED_AT":
+			field = repository.CardOrderByCreatedAt
+		case "UPDATED_AT":
+			field = repository.CardOrderByUpdatedAt
+		case "DUE":
+			field = repository.CardOrderByDue
+		default:
+			return "", "", gqlerr.BadUserInput("orderBy", "invalid")
+		}
+	}
+	d := repository.SortAsc
+	if dir != nil {
+		switch *dir {
+		case "ASC":
+			d = repository.SortAsc
+		case "DESC":
+			d = repository.SortDesc
+		default:
+			return "", "", gqlerr.BadUserInput("orderDirection", "invalid")
+		}
+	}
+	return field, d, nil
+}
+
+// resolvePageSize clamps first/last to [0, maxPageSize] and rejects passing
+// both. Defaults first=defaultPageSize when neither is provided.
+func resolvePageSize(first, last *int) (int, int, error) {
+	if first != nil && last != nil {
+		return 0, 0, gqlerr.BadUserInput("first", "specify either first or last")
+	}
+	if first == nil && last == nil {
+		return defaultPageSize, 0, nil
+	}
+	clamp := func(v int) int {
+		if v < 0 {
+			return 0
+		}
+		if v > maxPageSize {
+			return maxPageSize
+		}
+		return v
+	}
+	if first != nil {
+		return clamp(*first), 0, nil
+	}
+	return 0, clamp(*last), nil
+}
+
+// resolveCursor decodes a cursor ID into a *repository.CardCursor with the
+// field needed for the active orderBy populated. Returns BAD_USER_INPUT when
+// the cursor card cannot be found or belongs to a different cardgroup.
+func (u *CardUsecase) resolveCursor(
+	ctx context.Context,
+	cursorID *string,
+	cardgroupID string,
+	orderBy repository.CardOrderBy,
+	field string,
+) (*repository.CardCursor, error) {
+	if cursorID == nil || *cursorID == "" {
+		return nil, nil
+	}
+	c := &repository.CardCursor{ID: *cursorID}
+	if orderBy == repository.CardOrderByID {
+		return c, nil
+	}
+	card, err := u.cardRepo.FindByID(ctx, *cursorID)
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return nil, gqlerr.BadUserInput(field, "cursor not found")
+		}
+		return nil, gqlerr.Internal(ctx, err)
+	}
+	if card.CardgroupID != cardgroupID {
+		return nil, gqlerr.BadUserInput(field, "cursor not found")
+	}
+	switch orderBy {
+	case repository.CardOrderByDue:
+		due := card.FSRS.Due
+		c.Due = &due
+	case repository.CardOrderByCreatedAt:
+		ca := card.CreatedAt
+		c.CreatedAt = &ca
+	case repository.CardOrderByUpdatedAt:
+		ua := card.UpdatedAt
+		c.UpdatedAt = &ua
+	}
+	return c, nil
 }
 
 func (u *CardUsecase) authorizeCardgroup(ctx context.Context, id, userID string, missingAsBadInput bool) error {

--- a/backend/internal/usecase/card.go
+++ b/backend/internal/usecase/card.go
@@ -53,14 +53,33 @@ type UpdateCardInput struct {
 	Back  *string
 }
 
+// CardOrderBy mirrors the schema CardOrderBy enum but stays in the usecase
+// layer so the repository remains independent of the GraphQL model package.
+type CardOrderBy string
+
+const (
+	CardOrderByID        CardOrderBy = "ID"
+	CardOrderByCreatedAt CardOrderBy = "CREATED_AT"
+	CardOrderByUpdatedAt CardOrderBy = "UPDATED_AT"
+	CardOrderByDue       CardOrderBy = "DUE"
+)
+
+// SortOrder mirrors the schema SortOrder enum.
+type SortOrder string
+
+const (
+	SortOrderAsc  SortOrder = "ASC"
+	SortOrderDesc SortOrder = "DESC"
+)
+
 // CardConnectionInput captures the GraphQL pagination arguments. Pointer
 // fields preserve "absent" semantics from the schema.
 type CardConnectionInput struct {
 	CardgroupID    string
 	First, Last    *int
 	After, Before  *string // raw GraphQL ID strings (cursor = card UUID)
-	OrderBy        *string // GraphQL CardOrderBy enum string
-	OrderDirection *string // GraphQL SortOrder enum string
+	OrderBy        *CardOrderBy
+	OrderDirection *SortOrder
 }
 
 // CardConnectionOutput is the usecase-level page result. The resolver wraps
@@ -281,19 +300,20 @@ func (u *CardUsecase) ListCardsByCardgroupConnection(
 	return out, nil
 }
 
-// resolveOrderBy maps GraphQL enum strings to the repository's allowlist.
-// Defaults to (ID, ASC) when both are nil.
-func resolveOrderBy(orderBy, dir *string) (repository.CardOrderBy, repository.SortOrder, error) {
+// resolveOrderBy maps the typed usecase enums to the repository allowlist.
+// Defaults to (ID, ASC) when both are nil. The default arm is defense in
+// depth — gqlgen UnmarshalGQL already rejects invalid enum strings upstream.
+func resolveOrderBy(orderBy *CardOrderBy, dir *SortOrder) (repository.CardOrderBy, repository.SortOrder, error) {
 	field := repository.CardOrderByID
 	if orderBy != nil {
 		switch *orderBy {
-		case "ID":
+		case CardOrderByID:
 			field = repository.CardOrderByID
-		case "CREATED_AT":
+		case CardOrderByCreatedAt:
 			field = repository.CardOrderByCreatedAt
-		case "UPDATED_AT":
+		case CardOrderByUpdatedAt:
 			field = repository.CardOrderByUpdatedAt
-		case "DUE":
+		case CardOrderByDue:
 			field = repository.CardOrderByDue
 		default:
 			return "", "", gqlerr.BadUserInput("orderBy", "invalid")
@@ -302,9 +322,9 @@ func resolveOrderBy(orderBy, dir *string) (repository.CardOrderBy, repository.So
 	d := repository.SortAsc
 	if dir != nil {
 		switch *dir {
-		case "ASC":
+		case SortOrderAsc:
 			d = repository.SortAsc
-		case "DESC":
+		case SortOrderDesc:
 			d = repository.SortDesc
 		default:
 			return "", "", gqlerr.BadUserInput("orderDirection", "invalid")

--- a/backend/internal/usecase/card_test.go
+++ b/backend/internal/usecase/card_test.go
@@ -3,6 +3,7 @@ package usecase
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -22,6 +23,20 @@ type mockCardRepository struct {
 	capturedPatch       repository.CardUpdate
 	deleteErr           error
 	deleteCalled        bool
+
+	findPageRows  []*domain.Card
+	findPageTotal int64
+	findPageErr   error
+	// captured arguments from the most recent FindPageByCardgroup call.
+	capturedFindPage struct {
+		cardgroupID string
+		after       *repository.CardCursor
+		before      *repository.CardCursor
+		first       int
+		last        int
+		orderBy     repository.CardOrderBy
+		dir         repository.SortOrder
+	}
 }
 
 func (m *mockCardRepository) FindByID(_ context.Context, _ string) (*domain.Card, error) {
@@ -41,6 +56,23 @@ func (m *mockCardRepository) Update(_ context.Context, _ string, patch repositor
 func (m *mockCardRepository) Delete(_ context.Context, _ string) error {
 	m.deleteCalled = true
 	return m.deleteErr
+}
+func (m *mockCardRepository) FindPageByCardgroup(
+	_ context.Context,
+	cardgroupID string,
+	after, before *repository.CardCursor,
+	first, last int,
+	orderBy repository.CardOrderBy,
+	dir repository.SortOrder,
+) ([]*domain.Card, int64, error) {
+	m.capturedFindPage.cardgroupID = cardgroupID
+	m.capturedFindPage.after = after
+	m.capturedFindPage.before = before
+	m.capturedFindPage.first = first
+	m.capturedFindPage.last = last
+	m.capturedFindPage.orderBy = orderBy
+	m.capturedFindPage.dir = dir
+	return m.findPageRows, m.findPageTotal, m.findPageErr
 }
 
 type mockCardgroupRepoForCard struct {
@@ -244,4 +276,101 @@ func TestCardUsecase_RepoErrorsBecomeInternal(t *testing.T) {
 	)
 	_, err := uc.Card(authedCtx("u1"), "card1")
 	assertGQLErr(t, err, "INTERNAL", "")
+}
+
+func TestCardUsecase_ListCardsByCardgroupConnection_Anonymous(t *testing.T) {
+	t.Parallel()
+	uc := NewCardUsecase(&mockCardRepository{}, &mockCardgroupRepoForCard{})
+	_, err := uc.ListCardsByCardgroupConnection(anonCtx(), CardConnectionInput{CardgroupID: "cg1"})
+	assertGQLErr(t, err, "UNAUTHENTICATED", "")
+}
+
+func TestCardUsecase_ListCardsByCardgroupConnection_NonOwner(t *testing.T) {
+	t.Parallel()
+	uc := NewCardUsecase(
+		&mockCardRepository{},
+		&mockCardgroupRepoForCard{findResult: &domain.Cardgroup{ID: "cg1", OwnerID: "u1"}},
+	)
+	_, err := uc.ListCardsByCardgroupConnection(authedCtx("u2"), CardConnectionInput{CardgroupID: "cg1"})
+	assertGQLErr(t, err, "UNAUTHENTICATED", "")
+}
+
+func TestCardUsecase_ListCardsByCardgroupConnection_InvalidOrderBy(t *testing.T) {
+	t.Parallel()
+	uc := NewCardUsecase(
+		&mockCardRepository{},
+		&mockCardgroupRepoForCard{findResult: &domain.Cardgroup{ID: "cg1", OwnerID: "u1"}},
+	)
+	bad := "STABILITY"
+	_, err := uc.ListCardsByCardgroupConnection(authedCtx("u1"), CardConnectionInput{
+		CardgroupID: "cg1",
+		OrderBy:     &bad,
+	})
+	assertGQLErr(t, err, "BAD_USER_INPUT", "orderBy")
+}
+
+func TestCardUsecase_ListCardsByCardgroupConnection_BothFirstAndLast(t *testing.T) {
+	t.Parallel()
+	uc := NewCardUsecase(
+		&mockCardRepository{},
+		&mockCardgroupRepoForCard{findResult: &domain.Cardgroup{ID: "cg1", OwnerID: "u1"}},
+	)
+	first := 5
+	last := 5
+	_, err := uc.ListCardsByCardgroupConnection(authedCtx("u1"), CardConnectionInput{
+		CardgroupID: "cg1",
+		First:       &first,
+		Last:        &last,
+	})
+	assertGQLErr(t, err, "BAD_USER_INPUT", "first")
+}
+
+func TestCardUsecase_ListCardsByCardgroupConnection_DefaultsAndPaging(t *testing.T) {
+	t.Parallel()
+
+	// Mock returns first+1 (=21) rows, signalling another page exists.
+	rows := make([]*domain.Card, 21)
+	for i := range rows {
+		rows[i] = &domain.Card{ID: fmt.Sprintf("card-%02d", i), CardgroupID: "cg1"}
+	}
+	cardRepo := &mockCardRepository{findPageRows: rows, findPageTotal: 50}
+	uc := NewCardUsecase(
+		cardRepo,
+		&mockCardgroupRepoForCard{findResult: &domain.Cardgroup{ID: "cg1", OwnerID: "u1"}},
+	)
+
+	out, err := uc.ListCardsByCardgroupConnection(authedCtx("u1"), CardConnectionInput{
+		CardgroupID: "cg1",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(out.Cards) != 20 {
+		t.Fatalf("expected 20 cards after trim, got %d", len(out.Cards))
+	}
+	if !out.HasNext {
+		t.Fatal("expected HasNext=true")
+	}
+	if out.HasPrev {
+		t.Fatal("expected HasPrev=false on first page")
+	}
+	if out.TotalCount != 50 {
+		t.Fatalf("expected TotalCount=50, got %d", out.TotalCount)
+	}
+	if out.StartCur != "card-00" {
+		t.Fatalf("expected StartCur=card-00, got %q", out.StartCur)
+	}
+	if out.EndCur != "card-19" {
+		t.Fatalf("expected EndCur=card-19, got %q", out.EndCur)
+	}
+	// The repository must have been asked for first+1 = 21 rows.
+	if cardRepo.capturedFindPage.first != 21 {
+		t.Fatalf("expected repo.first=21, got %d", cardRepo.capturedFindPage.first)
+	}
+	if cardRepo.capturedFindPage.orderBy != repository.CardOrderByID {
+		t.Fatalf("expected default orderBy=id, got %q", cardRepo.capturedFindPage.orderBy)
+	}
+	if cardRepo.capturedFindPage.dir != repository.SortAsc {
+		t.Fatalf("expected default dir=ASC, got %q", cardRepo.capturedFindPage.dir)
+	}
 }

--- a/backend/internal/usecase/card_test.go
+++ b/backend/internal/usecase/card_test.go
@@ -301,7 +301,7 @@ func TestCardUsecase_ListCardsByCardgroupConnection_InvalidOrderBy(t *testing.T)
 		&mockCardRepository{},
 		&mockCardgroupRepoForCard{findResult: &domain.Cardgroup{ID: "cg1", OwnerID: "u1"}},
 	)
-	bad := "STABILITY"
+	bad := CardOrderBy("STABILITY")
 	_, err := uc.ListCardsByCardgroupConnection(authedCtx("u1"), CardConnectionInput{
 		CardgroupID: "cg1",
 		OrderBy:     &bad,
@@ -372,5 +372,182 @@ func TestCardUsecase_ListCardsByCardgroupConnection_DefaultsAndPaging(t *testing
 	}
 	if cardRepo.capturedFindPage.dir != repository.SortAsc {
 		t.Fatalf("expected default dir=ASC, got %q", cardRepo.capturedFindPage.dir)
+	}
+}
+
+func intPtr(v int) *int                     { return &v }
+func orderByPtr(v CardOrderBy) *CardOrderBy { return &v }
+
+// TestCardUsecase_ListCardsByCardgroupConnection_CursorCrossCardgroup makes
+// sure a cursor pointing at a card in a different cardgroup is rejected with
+// BAD_USER_INPUT instead of leaking through to the repo (which would happily
+// query rows from any cardgroup once the SQL is built).
+func TestCardUsecase_ListCardsByCardgroupConnection_CursorCrossCardgroup(t *testing.T) {
+	t.Parallel()
+
+	t.Run("after rejected", func(t *testing.T) {
+		t.Parallel()
+		cardRepo := &mockCardRepository{
+			findResult: &domain.Card{ID: "c-foreign", CardgroupID: "cg-other"},
+		}
+		uc := NewCardUsecase(
+			cardRepo,
+			&mockCardgroupRepoForCard{findResult: &domain.Cardgroup{ID: "cg1", OwnerID: "u1"}},
+		)
+		_, err := uc.ListCardsByCardgroupConnection(authedCtx("u1"), CardConnectionInput{
+			CardgroupID: "cg1",
+			First:       intPtr(10),
+			After:       ptr("c-foreign"),
+			OrderBy:     orderByPtr(CardOrderByDue),
+		})
+		assertGQLErr(t, err, "BAD_USER_INPUT", "after")
+	})
+
+	t.Run("before rejected", func(t *testing.T) {
+		t.Parallel()
+		cardRepo := &mockCardRepository{
+			findResult: &domain.Card{ID: "c-foreign", CardgroupID: "cg-other"},
+		}
+		uc := NewCardUsecase(
+			cardRepo,
+			&mockCardgroupRepoForCard{findResult: &domain.Cardgroup{ID: "cg1", OwnerID: "u1"}},
+		)
+		_, err := uc.ListCardsByCardgroupConnection(authedCtx("u1"), CardConnectionInput{
+			CardgroupID: "cg1",
+			Last:        intPtr(10),
+			Before:      ptr("c-foreign"),
+			OrderBy:     orderByPtr(CardOrderByDue),
+		})
+		assertGQLErr(t, err, "BAD_USER_INPUT", "before")
+	})
+}
+
+// TestCardUsecase_ListCardsByCardgroupConnection_BackwardPaging exercises the
+// last/before flow: the +1 trick fires on the leading edge and HasNext is true
+// because `before != nil`.
+func TestCardUsecase_ListCardsByCardgroupConnection_BackwardPaging(t *testing.T) {
+	t.Parallel()
+
+	rows := []*domain.Card{
+		{ID: "c-A", CardgroupID: "cg1"},
+		{ID: "c-B", CardgroupID: "cg1"},
+		{ID: "c-C", CardgroupID: "cg1"},
+		{ID: "c-D", CardgroupID: "cg1"},
+	}
+	cardRepo := &mockCardRepository{findPageRows: rows, findPageTotal: 10}
+	uc := NewCardUsecase(
+		cardRepo,
+		&mockCardgroupRepoForCard{findResult: &domain.Cardgroup{ID: "cg1", OwnerID: "u1"}},
+	)
+
+	out, err := uc.ListCardsByCardgroupConnection(authedCtx("u1"), CardConnectionInput{
+		CardgroupID: "cg1",
+		Last:        intPtr(3),
+		Before:      ptr("c-X"),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(out.Cards) != 3 {
+		t.Fatalf("expected 3 cards after trim, got %d", len(out.Cards))
+	}
+	if out.Cards[0].ID != "c-B" || out.Cards[1].ID != "c-C" || out.Cards[2].ID != "c-D" {
+		t.Fatalf("expected [c-B, c-C, c-D], got %v",
+			[]string{out.Cards[0].ID, out.Cards[1].ID, out.Cards[2].ID})
+	}
+	if !out.HasPrev {
+		t.Fatal("expected HasPrev=true (len(rows) > last signals more rows precede)")
+	}
+	if !out.HasNext {
+		t.Fatal("expected HasNext=true because before!=nil")
+	}
+	if out.StartCur != "c-B" || out.EndCur != "c-D" {
+		t.Fatalf("expected StartCur=c-B EndCur=c-D, got %q/%q", out.StartCur, out.EndCur)
+	}
+	// Repo should have been asked for last+1 trailing rows.
+	if cardRepo.capturedFindPage.last != 4 {
+		t.Fatalf("expected repo.last=4 (last+1), got %d", cardRepo.capturedFindPage.last)
+	}
+}
+
+// TestCardUsecase_ListCardsByCardgroupConnection_ResolveCursorHydratesDueField
+// pins down that resolveCursor populates the field matching the active
+// orderBy on the *CardCursor passed to FindPageByCardgroup.
+func TestCardUsecase_ListCardsByCardgroupConnection_ResolveCursorHydratesDueField(t *testing.T) {
+	t.Parallel()
+
+	dueT := time.Date(2030, 1, 2, 3, 4, 5, 0, time.UTC)
+	createdT := time.Date(2031, 5, 6, 7, 8, 9, 0, time.UTC)
+	updatedT := time.Date(2032, 7, 8, 9, 10, 11, 0, time.UTC)
+
+	cases := []struct {
+		name     string
+		orderBy  CardOrderBy
+		assertFn func(t *testing.T, c *repository.CardCursor)
+	}{
+		{
+			name:    "Due",
+			orderBy: CardOrderByDue,
+			assertFn: func(t *testing.T, c *repository.CardCursor) {
+				if c.Due == nil || !c.Due.Equal(dueT) {
+					t.Fatalf("expected Due=%v, got %v", dueT, c.Due)
+				}
+			},
+		},
+		{
+			name:    "CreatedAt",
+			orderBy: CardOrderByCreatedAt,
+			assertFn: func(t *testing.T, c *repository.CardCursor) {
+				if c.CreatedAt == nil || !c.CreatedAt.Equal(createdT) {
+					t.Fatalf("expected CreatedAt=%v, got %v", createdT, c.CreatedAt)
+				}
+			},
+		},
+		{
+			name:    "UpdatedAt",
+			orderBy: CardOrderByUpdatedAt,
+			assertFn: func(t *testing.T, c *repository.CardCursor) {
+				if c.UpdatedAt == nil || !c.UpdatedAt.Equal(updatedT) {
+					t.Fatalf("expected UpdatedAt=%v, got %v", updatedT, c.UpdatedAt)
+				}
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cardRepo := &mockCardRepository{
+				findResult: &domain.Card{
+					ID:          "c-1",
+					CardgroupID: "cg1",
+					FSRS:        domain.FSRSState{Due: dueT},
+					CreatedAt:   createdT,
+					UpdatedAt:   updatedT,
+				},
+			}
+			uc := NewCardUsecase(
+				cardRepo,
+				&mockCardgroupRepoForCard{findResult: &domain.Cardgroup{ID: "cg1", OwnerID: "u1"}},
+			)
+			_, err := uc.ListCardsByCardgroupConnection(authedCtx("u1"), CardConnectionInput{
+				CardgroupID: "cg1",
+				First:       intPtr(5),
+				After:       ptr("c-1"),
+				OrderBy:     orderByPtr(tc.orderBy),
+			})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			got := cardRepo.capturedFindPage.after
+			if got == nil {
+				t.Fatal("expected after cursor to be passed to repo, got nil")
+			}
+			if got.ID != "c-1" {
+				t.Fatalf("expected cursor ID=c-1, got %q", got.ID)
+			}
+			tc.assertFn(t, got)
+		})
 	}
 }

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -89,6 +89,7 @@ These values target a public API on Render. Revisit if the threat model or deplo
 
 - `extend type Query { ... }` works without ceremony — gqlgen merges all `extend type Query` blocks automatically. Use it freely when adding fields to the root query type.
 - For mutations, declare `type Mutation { ... }` (not `extend`) for the **first** mutation definition in the schema. Subsequent additions use `extend type Mutation { ... }`.
+- **Paginated lists use Relay-style Connection types** (`*Connection` / `*Edge` / `PageInfo`), not bare `[T!]!`. See `docs/pagination.md` for the full design and migration contract.
 
 ### Regeneration
 
@@ -384,6 +385,10 @@ Adding a new feature: build a usecase, add a field to `Resolver`, wire it in `ru
 ### Aggregate boundary policy
 
 Cross-aggregate references use IDs only — never embed a pointer to another aggregate's struct. For example, `domain.Cardgroup` holds `OwnerID string`, not `Owner *domain.User`, and `domain.Card` holds `CardgroupID string`, not `Cardgroup *domain.Cardgroup`. This prevents cyclic imports, keeps aggregates independently serialisable, and enforces the DDD consistency boundary. The actual object is resolved lazily by GraphQL field resolvers via the per-request DataLoader.
+
+### Cursor pagination
+
+Relay-style Connection queries (e.g. `cardsByCardgroupConnection`) follow a fixed shape across schema, resolver, usecase, and repository. See `docs/pagination.md` for the full design (tuple comparison, `+1` fetch trick, `totalCount` trade-off, cross-aggregate validation, three-layer enum sync, and `cursorFieldValue` error handling).
 
 ### Consumer-driven repository interfaces
 

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -105,12 +105,18 @@ cache.writeQuery({
 });
 ```
 
-**Delete — evict the entity then collect garbage**:
+**Delete — evict the entity then collect garbage** (flat-list shape only):
 
 ```ts
 cache.evict({ id: cache.identify({ __typename: "Cardgroup", id: cardgroupId }) });
 cache.gc();
 ```
+
+For Connection types (`*Connection` / `*Edge`), use `readQuery + writeQuery` (not `cache.modify`) and align the variables shape between SSR seed and client. See `docs/pagination.md` for Connection create, delete, and update cache patterns.
+
+### Pagination patterns
+
+The reference implementation is `frontend/src/app/cardgroups/[id]/cards/cards-client.tsx` (`useQuery` + `fetchMore` with an IntersectionObserver sentinel). See `docs/pagination.md` for IntersectionObserver in-flight guards, `fetchMoreError` handling, `NetworkStatus.fetchMore` conventions, and MockedProvider warn-spy patterns.
 
 ## Auth (Supabase)
 

--- a/docs/pagination.md
+++ b/docs/pagination.md
@@ -1,0 +1,108 @@
+# Pagination
+
+> Single source of truth for the Relay-style Connection design used by the cards-by-cardgroup query and the Apollo client patterns that consume it. Cross-referenced from `docs/backend.md` and `docs/frontend.md`.
+
+## Why Relay Connection (not offset/limit)
+
+Relay-style Connection pagination (cursor-based) is chosen because:
+
+- **Stable across mutations.** Offset pagination shifts rows when items are inserted or deleted mid-list, causing skips or duplicates for the client. A cursor anchors to a specific row.
+- **Cursor opaqueness.** Clients treat `cursor: ID!` as an opaque handle and pass it back unchanged. The server may change encoding without breaking clients.
+- **Server-side determinism.** The server controls page boundaries, order, and tie-breaking, so clients cannot craft parameters that bypass ordering invariants.
+
+## Server-side design
+
+### Cursor encoding
+
+The cursor is the bare entity UUID — not base64-encoded. UUID is already opaque; double-encoding adds no security and forces clients to decode before comparing. The schema declares `cursor: ID!` and the resolver assigns the entity ID directly into edges.
+
+### Tuple `(orderField, id)` comparison
+
+Ties on the order field would otherwise skip or duplicate rows. The repository emits SQL of the form `field op ? OR (field = ? AND id op ?)` rather than the Postgres-only `(a, b) > (?, ?)` row-constructor — the expanded form is portable across SQL dialects. When the user-supplied `orderBy` is already `ID`, only `ORDER BY id` is emitted; otherwise `, id <dir>` is appended so the ordering is always total.
+
+### `+1` fetch trick for `hasNextPage`
+
+The usecase asks the repository for `first+1` rows. If the repository returns more than `first`, set `hasNextPage = true` and trim the trailing row. No second query is needed.
+
+### Page-size cap asymmetry (`maxPageSize` vs `pageCap`)
+
+Two constants work together:
+
+- `maxPageSize = 100` — user-facing cap enforced by the usecase.
+- `pageCap = maxPageSize + 1` (i.e. 101) — repository-level limit that lets the `+1` trick survive a request at the documented maximum.
+
+Document both constants. Changing one without the other silently caps a layer below spec.
+
+### Backward pagination via direction-flip + reverse
+
+Natural SQL "give me N rows before X" is awkward. The repository inverts the `ORDER BY` direction, applies `LIMIT N+1`, then reverses the returned slice in memory. The usecase mirrors the trim logic on the leading edge so the page boundary stays at the tail.
+
+### `totalCount` via separate `COUNT(*)`
+
+`totalCount` is a separate `COUNT(*)` query scoped by `cardgroup_id`. This trades extra DB round-trips for SQL simplicity — acceptable for `<= 10k` cards per group; revisit with a windowed estimate or a denormalised counter if the cap grows. Run `COUNT` **before** the `first == 0 && last == 0` short-circuit so callers asking only for `totalCount` still get a real value.
+
+### Cursor cross-aggregate validation → `BAD_USER_INPUT`
+
+A cursor pointing at a card in another cardgroup is treated as a malformed user-supplied parameter. Returning `UNAUTHENTICATED` would leak existence of cards in other cardgroups; `BAD_USER_INPUT` with `field = "after"` / `field = "before"` is the correct posture.
+
+### Three layers of enums kept in sync
+
+- `model.CardOrderBy` — gqlgen-generated, schema strings.
+- `usecase.CardOrderBy` — typed enum local to the usecase, same string values.
+- `repository.CardOrderBy` — snake_case column names (e.g. `created_at`).
+
+The resolver translates model → usecase; the usecase translates usecase → repository. Each layer stays free of dependencies on the others — no GraphQL types in the repository, no `gorm` types in the resolver. The duplication is intentional.
+
+### `cursorFieldValue` errors on missing column
+
+A silent zero-value fallback (e.g. `time.Time{}`) would generate a wrong-but-valid SQL predicate and quietly skip rows. The usecase hydrates the column required by the active `orderBy` before calling the repository, so a missing column is a caller bug — surface it as `gqlerr.Internal` rather than return wrong rows.
+
+## Schema-side conventions
+
+### Use Connection over flat list for paginated queries
+
+Paginated lists use Relay-style Connection types, not bare `[T!]!`. New paginated queries declare `<Type>Connection { edges, pageInfo, totalCount }` + `<Type>Edge { cursor, node }` and accept `(first, after, last, before, orderBy, orderDirection)`. The flat `[T!]!` shape is reserved for fixed small collections where pagination is meaningless.
+
+### Migration via `@deprecated`
+
+When migrating an existing flat list to a Connection type, keep the old field with `@deprecated(reason: "Use <newField>")` until all clients have moved over. Removing the old field in the same change breaks any unmigrated consumer.
+
+## Frontend cache patterns
+
+### `cache.modify` skips non-existent fields — use `readQuery + writeQuery`
+
+`cache.modify` skips a field that does not yet exist in the cache, so a "build a fresh connection if `existing == null`" branch under `cache.modify` is dead code. Cold-cache cases (e.g. user lands directly on the page without an SSR seed) silently lose the new edge. `readQuery` returns `null` for a cold cache and `writeQuery` writes either branch unconditionally — that is the correct seam for Connection updates.
+
+### Variables shape MUST match between SSR seed and client cache reads
+
+Apollo's cache key is built from canonical-stringified variables. Hard-coding `first: 20` in `page.tsx` while the client uses a `PAGE_SIZE` constant is coincidence-only; bumping the constant breaks the seed-then-update pipeline silently. Lift shared connection variables to one module (e.g. `cards/queries.ts` exports `CARDS_PAGE_SIZE`) that both SSR and client import.
+
+### Connection create
+
+Write the new entity via `cache.writeFragment` first so any other cached edge that references the same `id` resolves correctly, then use `readQuery + writeQuery` to append a `{ cursor, node }` edge and bump `totalCount`. On a cold cache, build a minimal `<Type>Connection` with `pageInfo.hasNextPage = false` so the IO loop stays idle.
+
+### Connection delete
+
+Filter the edge out of the cached connection, decrement `totalCount` (clamped at 0 — the deleted item may live on a page that was never fetched into edges), then `cache.evict` + `cache.gc()` to drop the normalised entity. Eviction alone is not enough — the connection field is a list of `{ cursor, node }` objects whose `node` reference is broken by evict but the parent edge stays in the array.
+
+### Connection update (cache normalization)
+
+Rely on Apollo cache normalization (entities with `id` are normalized by default). No manual `update` callback is needed; mutations that touch a normalised entity propagate to every cached query that reads it.
+
+## Frontend pagination UX
+
+### IntersectionObserver in-flight guard via `useRef<boolean>`
+
+The in-flight guard must live in `useRef<boolean>`, not `useState`. State updates are async — the observer can fire twice in the same animation frame and both passes read the previous `false`, double-firing `fetchMore`. A mutable ref is set synchronously, reset in `.finally`, and never schedules a re-render.
+
+### `fetchMoreError != null` halts the IO loop
+
+Without an error halt gate, the IO keeps firing on the same failed cursor and loops invisibly with only `console.error` noise. Set state to a banner string in the `fetchMore` `.catch`, render a Retry button that clears the state and re-invokes the request, and short-circuit the IO `useEffect` while the error is set.
+
+### `NetworkStatus.fetchMore`, not magic number
+
+Always import the named `NetworkStatus` enum from `@apollo/client`. Magic numbers silently rot if Apollo renumbers (vanishingly rare, but the named import costs nothing).
+
+### Spy on `console.warn` for MockedProvider leaks
+
+The assertion `nextPageCalls === 1` is partially tautological — `MockedProvider` only consumes a mock once, so a leaked second `fetchMore` produces a `"No more mocked responses for the query"` warning rather than an extra invocation. Spy on `console.warn` and assert it does not see that string for the query of interest; restore the spy in `afterEach`. Without this, double-fetch regressions pass the call-count assertion silently.

--- a/frontend/__tests__/cards-pagination.test.tsx
+++ b/frontend/__tests__/cards-pagination.test.tsx
@@ -2,6 +2,8 @@
 import { InMemoryCache } from "@apollo/client";
 import { MockedProvider } from "@apollo/client/testing/react";
 import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { GraphQLError } from "graphql";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { CardsClient } from "@/app/cardgroups/[id]/cards/cards-client";
 import { CardsByCardgroupConnectionDocument } from "@/generated/graphql";
@@ -79,7 +81,12 @@ class FakeIntersectionObserver {
   }
   observe() {}
   unobserve() {}
-  disconnect() {}
+  // Real browsers stop firing the callback after disconnect; mirror that here so
+  // stale-closure observers don't keep firing fetchMore after the production
+  // useEffect cleanup runs.
+  disconnect() {
+    ioCallbacks = ioCallbacks.filter((cb) => cb !== this.callback);
+  }
   takeRecords(): IntersectionObserverEntry[] {
     return [];
   }
@@ -87,7 +94,7 @@ class FakeIntersectionObserver {
 
 function fireIntersect() {
   const cb = ioCallbacks[ioCallbacks.length - 1];
-  if (!cb) throw new Error("No IntersectionObserver registered");
+  if (!cb) return;
   // The component's callback only inspects entries[0].isIntersecting.
   cb([{ isIntersecting: true } as IntersectionObserverEntry], {} as IntersectionObserver);
 }
@@ -243,6 +250,10 @@ describe("CardsClient pagination via IntersectionObserver", () => {
       data: { cardsByCardgroupConnection: makeConnection(firstBatch, true) },
     });
 
+    // Spy on console.warn to detect "no more mocked responses" warnings emitted
+    // by MockedProvider when an unmatched query escapes the in-flight guard.
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
     render(
       <MockedProvider mocks={mocks as never} cache={cache}>
         <CardsClient
@@ -271,5 +282,248 @@ describe("CardsClient pagination via IntersectionObserver", () => {
     fireIntersect();
     await new Promise((resolve) => setTimeout(resolve, 60));
     expect(nextPageCalls).toBe(1);
+
+    // No "no more mocked responses for the query: CardsByCardgroupConnection"
+    // warning should ever fire — that warning indicates a duplicate request
+    // leaked past the in-flight guard. The single mock above is consumed once,
+    // so any second call would warn.
+    const cardsConnectionWarnings = warnSpy.mock.calls.filter((args) =>
+      args.some((arg) => typeof arg === "string" && arg.includes("CardsByCardgroupConnection")),
+    );
+    expect(cardsConnectionWarnings).toEqual([]);
+
+    warnSpy.mockRestore();
+  });
+
+  // G2: a fetchMore rejection must surface a banner and halt the observer loop.
+  it("fetchMore error stops the observer and shows the retry banner", async () => {
+    const firstBatch = Array.from({ length: 20 }, (_, i) => makeCard(i + 1));
+
+    const initialEdges = firstBatch.map(makeEdge);
+    const initialPageInfo = {
+      __typename: "PageInfo" as const,
+      hasNextPage: true,
+      hasPreviousPage: false,
+      startCursor: "c-1",
+      endCursor: "c-20",
+    };
+    const initialTotalCount = 40;
+
+    // Counter: assert the next-page request is consumed at most once even if the
+    // observer fires multiple times after the failure.
+    let nextPageCalls = 0;
+    const nextPageResult = vi.fn(() => {
+      nextPageCalls += 1;
+      return {
+        errors: [new GraphQLError("boom", { extensions: { code: "INTERNAL" } })],
+      };
+    });
+
+    const mocks = [
+      {
+        request: {
+          query: CardsByCardgroupConnectionDocument,
+          variables: { cardgroupId: CG_ID, first: PAGE_SIZE },
+        },
+        result: {
+          data: { cardsByCardgroupConnection: makeConnection(firstBatch, true) },
+        },
+      },
+      {
+        request: {
+          query: CardsByCardgroupConnectionDocument,
+          variables: { cardgroupId: CG_ID, first: PAGE_SIZE, after: "c-20" },
+        },
+        result: nextPageResult,
+      },
+    ];
+
+    const cache = new InMemoryCache();
+    cache.writeQuery({
+      query: CardsByCardgroupConnectionDocument,
+      variables: { cardgroupId: CG_ID, first: PAGE_SIZE },
+      data: { cardsByCardgroupConnection: makeConnection(firstBatch, true) },
+    });
+
+    render(
+      <MockedProvider mocks={mocks as never} cache={cache}>
+        <CardsClient
+          cardgroupId={CG_ID}
+          initialEdges={initialEdges}
+          initialPageInfo={initialPageInfo}
+          initialTotalCount={initialTotalCount}
+        />
+      </MockedProvider>,
+    );
+
+    fireIntersect();
+
+    const banner = await screen.findByTestId("cards-fetch-more-error");
+    expect(banner).toBeInTheDocument();
+    expect(nextPageCalls).toBe(1);
+
+    // Observer loop must be halted: more intersects after the error should not
+    // re-issue the request.
+    fireIntersect();
+    fireIntersect();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(nextPageCalls).toBe(1);
+  });
+
+  // G3: clicking Retry clears the banner and re-issues the request; on success
+  // the new edges render. A second failure shows a fresh banner.
+  it("retry button clears the error and re-issues the request; a second failure shows a fresh banner", async () => {
+    const user = userEvent.setup();
+    const firstBatch = Array.from({ length: 20 }, (_, i) => makeCard(i + 1));
+    const secondBatch = Array.from({ length: 20 }, (_, i) => makeCard(i + 21));
+
+    const initialEdges = firstBatch.map(makeEdge);
+    const initialPageInfo = {
+      __typename: "PageInfo" as const,
+      hasNextPage: true,
+      hasPreviousPage: false,
+      startCursor: "c-1",
+      endCursor: "c-20",
+    };
+    const initialTotalCount = 40;
+
+    const mocks = [
+      {
+        request: {
+          query: CardsByCardgroupConnectionDocument,
+          variables: { cardgroupId: CG_ID, first: PAGE_SIZE },
+        },
+        result: {
+          data: { cardsByCardgroupConnection: makeConnection(firstBatch, true) },
+        },
+      },
+      // First fetchMore fails.
+      {
+        request: {
+          query: CardsByCardgroupConnectionDocument,
+          variables: { cardgroupId: CG_ID, first: PAGE_SIZE, after: "c-20" },
+        },
+        result: {
+          errors: [new GraphQLError("boom", { extensions: { code: "INTERNAL" } })],
+        },
+      },
+      // Second fetchMore (after retry) succeeds and appends the second batch.
+      {
+        request: {
+          query: CardsByCardgroupConnectionDocument,
+          variables: { cardgroupId: CG_ID, first: PAGE_SIZE, after: "c-20" },
+        },
+        result: {
+          data: { cardsByCardgroupConnection: makeConnection(secondBatch, false) },
+        },
+      },
+    ];
+
+    const cache = new InMemoryCache();
+    cache.writeQuery({
+      query: CardsByCardgroupConnectionDocument,
+      variables: { cardgroupId: CG_ID, first: PAGE_SIZE },
+      data: { cardsByCardgroupConnection: makeConnection(firstBatch, true) },
+    });
+
+    render(
+      <MockedProvider mocks={mocks as never} cache={cache}>
+        <CardsClient
+          cardgroupId={CG_ID}
+          initialEdges={initialEdges}
+          initialPageInfo={initialPageInfo}
+          initialTotalCount={initialTotalCount}
+        />
+      </MockedProvider>,
+    );
+
+    fireIntersect();
+
+    // Banner appears after the first failure.
+    await screen.findByTestId("cards-fetch-more-error");
+
+    // Click Retry — should clear the banner and re-issue the request, yielding
+    // the second batch.
+    await user.click(screen.getByRole("button", { name: /retry/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("front-40")).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId("cards-fetch-more-error")).not.toBeInTheDocument();
+  });
+
+  // G3 (failure-then-failure cycle): a fresh banner shows after the second failure.
+  it("retry on a second failure shows a fresh banner", async () => {
+    const user = userEvent.setup();
+    const firstBatch = Array.from({ length: 20 }, (_, i) => makeCard(i + 1));
+
+    const initialEdges = firstBatch.map(makeEdge);
+    const initialPageInfo = {
+      __typename: "PageInfo" as const,
+      hasNextPage: true,
+      hasPreviousPage: false,
+      startCursor: "c-1",
+      endCursor: "c-20",
+    };
+    const initialTotalCount = 40;
+
+    const mocks = [
+      {
+        request: {
+          query: CardsByCardgroupConnectionDocument,
+          variables: { cardgroupId: CG_ID, first: PAGE_SIZE },
+        },
+        result: {
+          data: { cardsByCardgroupConnection: makeConnection(firstBatch, true) },
+        },
+      },
+      {
+        request: {
+          query: CardsByCardgroupConnectionDocument,
+          variables: { cardgroupId: CG_ID, first: PAGE_SIZE, after: "c-20" },
+        },
+        result: {
+          errors: [new GraphQLError("boom1", { extensions: { code: "INTERNAL" } })],
+        },
+      },
+      {
+        request: {
+          query: CardsByCardgroupConnectionDocument,
+          variables: { cardgroupId: CG_ID, first: PAGE_SIZE, after: "c-20" },
+        },
+        result: {
+          errors: [new GraphQLError("boom2", { extensions: { code: "INTERNAL" } })],
+        },
+      },
+    ];
+
+    const cache = new InMemoryCache();
+    cache.writeQuery({
+      query: CardsByCardgroupConnectionDocument,
+      variables: { cardgroupId: CG_ID, first: PAGE_SIZE },
+      data: { cardsByCardgroupConnection: makeConnection(firstBatch, true) },
+    });
+
+    render(
+      <MockedProvider mocks={mocks as never} cache={cache}>
+        <CardsClient
+          cardgroupId={CG_ID}
+          initialEdges={initialEdges}
+          initialPageInfo={initialPageInfo}
+          initialTotalCount={initialTotalCount}
+        />
+      </MockedProvider>,
+    );
+
+    fireIntersect();
+    const banner1 = await screen.findByTestId("cards-fetch-more-error");
+    expect(banner1).toHaveTextContent("boom1");
+
+    await user.click(screen.getByRole("button", { name: /retry/i }));
+
+    // Banner reappears with the second error message.
+    await waitFor(() => {
+      expect(screen.getByTestId("cards-fetch-more-error")).toHaveTextContent("boom2");
+    });
   });
 });

--- a/frontend/__tests__/cards-pagination.test.tsx
+++ b/frontend/__tests__/cards-pagination.test.tsx
@@ -1,0 +1,196 @@
+// @vitest-environment jsdom
+import { InMemoryCache } from "@apollo/client";
+import { MockedProvider } from "@apollo/client/testing/react";
+import { render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CardsClient } from "@/app/cardgroups/[id]/cards/cards-client";
+import { CardsByCardgroupConnectionDocument } from "@/generated/graphql";
+
+const CG_ID = "cg-1";
+const PAGE_SIZE = 20;
+
+type Card = {
+  __typename: "Card";
+  id: string;
+  front: string;
+  back: string;
+  due: string;
+  state: number;
+  cardgroupId: string;
+};
+
+function makeCard(i: number): Card {
+  return {
+    __typename: "Card",
+    id: `c-${i}`,
+    front: `front-${i}`,
+    back: `back-${i}`,
+    due: "2024-06-15",
+    state: 0,
+    cardgroupId: CG_ID,
+  };
+}
+
+function makeEdge(card: Card) {
+  return {
+    __typename: "CardEdge" as const,
+    cursor: card.id,
+    node: card,
+  };
+}
+
+function makeConnection(
+  cards: Card[],
+  hasNextPage: boolean,
+): {
+  __typename: "CardConnection";
+  edges: ReturnType<typeof makeEdge>[];
+  pageInfo: {
+    __typename: "PageInfo";
+    hasNextPage: boolean;
+    hasPreviousPage: boolean;
+    startCursor: string | null;
+    endCursor: string | null;
+  };
+  totalCount: number;
+} {
+  return {
+    __typename: "CardConnection",
+    edges: cards.map(makeEdge),
+    pageInfo: {
+      __typename: "PageInfo",
+      hasNextPage,
+      hasPreviousPage: false,
+      startCursor: cards[0]?.id ?? null,
+      endCursor: cards[cards.length - 1]?.id ?? null,
+    },
+    totalCount: cards.length,
+  };
+}
+
+// Capture the most recent IntersectionObserver callback so the test can fire it manually.
+let ioCallbacks: IntersectionObserverCallback[] = [];
+
+class FakeIntersectionObserver {
+  callback: IntersectionObserverCallback;
+  constructor(cb: IntersectionObserverCallback) {
+    this.callback = cb;
+    ioCallbacks.push(cb);
+  }
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+  takeRecords(): IntersectionObserverEntry[] {
+    return [];
+  }
+}
+
+function fireIntersect() {
+  const cb = ioCallbacks[ioCallbacks.length - 1];
+  if (!cb) throw new Error("No IntersectionObserver registered");
+  // The component's callback only inspects entries[0].isIntersecting.
+  cb([{ isIntersecting: true } as IntersectionObserverEntry], {} as IntersectionObserver);
+}
+
+beforeEach(() => {
+  ioCallbacks = [];
+  vi.stubGlobal("IntersectionObserver", FakeIntersectionObserver);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("CardsClient pagination via IntersectionObserver", () => {
+  it("fetches the next page when the sentinel intersects, then stops once hasNextPage is false", async () => {
+    const firstBatch = Array.from({ length: 20 }, (_, i) => makeCard(i + 1));
+    const secondBatch = Array.from({ length: 20 }, (_, i) => makeCard(i + 21));
+
+    const initialEdges = firstBatch.map(makeEdge);
+    const initialPageInfo = {
+      __typename: "PageInfo" as const,
+      hasNextPage: true,
+      hasPreviousPage: false,
+      startCursor: "c-1",
+      endCursor: "c-20",
+    };
+    const initialTotalCount = 40;
+
+    // Track how many times the next-page mock is invoked. MockedProvider results
+    // are consumed once per matching request, so a second call without another
+    // mock would warn — that itself is the assertion-of-no-second-call.
+    let nextPageCalls = 0;
+    const nextPageResult = vi.fn(() => {
+      nextPageCalls += 1;
+      return {
+        data: {
+          cardsByCardgroupConnection: makeConnection(secondBatch, false),
+        },
+      };
+    });
+
+    const mocks = [
+      // First useQuery call resolves from cache (we seed the cache below) so no
+      // network mock for the initial { first: 20 } request is strictly needed,
+      // but provide one defensively in case Apollo refetches on mount.
+      {
+        request: {
+          query: CardsByCardgroupConnectionDocument,
+          variables: { cardgroupId: CG_ID, first: PAGE_SIZE },
+        },
+        result: {
+          data: {
+            cardsByCardgroupConnection: makeConnection(firstBatch, true),
+          },
+        },
+      },
+      {
+        request: {
+          query: CardsByCardgroupConnectionDocument,
+          variables: { cardgroupId: CG_ID, first: PAGE_SIZE, after: "c-20" },
+        },
+        result: nextPageResult,
+      },
+    ];
+
+    const cache = new InMemoryCache();
+    cache.writeQuery({
+      query: CardsByCardgroupConnectionDocument,
+      variables: { cardgroupId: CG_ID, first: PAGE_SIZE },
+      data: { cardsByCardgroupConnection: makeConnection(firstBatch, true) },
+    });
+
+    render(
+      <MockedProvider mocks={mocks as never} cache={cache}>
+        <CardsClient
+          cardgroupId={CG_ID}
+          initialEdges={initialEdges}
+          initialPageInfo={initialPageInfo}
+          initialTotalCount={initialTotalCount}
+        />
+      </MockedProvider>,
+    );
+
+    // Initial render shows the first batch.
+    expect(screen.getByText("front-1")).toBeInTheDocument();
+    expect(screen.getByText("front-20")).toBeInTheDocument();
+    expect(screen.queryByText("front-21")).not.toBeInTheDocument();
+
+    // Fire the observer once — fetchMore should run and append the next batch.
+    fireIntersect();
+
+    await waitFor(() => {
+      expect(screen.getByText("front-21")).toBeInTheDocument();
+      expect(screen.getByText("front-40")).toBeInTheDocument();
+    });
+    expect(nextPageCalls).toBe(1);
+
+    // Fire again — hasNextPage is now false, so no further fetchMore should run.
+    fireIntersect();
+
+    // Give any pending microtasks a chance to flush.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(nextPageCalls).toBe(1);
+  });
+});

--- a/frontend/__tests__/cards-pagination.test.tsx
+++ b/frontend/__tests__/cards-pagination.test.tsx
@@ -193,4 +193,83 @@ describe("CardsClient pagination via IntersectionObserver", () => {
 
     expect(nextPageCalls).toBe(1);
   });
+
+  it("does not double-fire fetchMore while a previous request is in flight", async () => {
+    const firstBatch = Array.from({ length: 20 }, (_, i) => makeCard(i + 1));
+    const secondBatch = Array.from({ length: 20 }, (_, i) => makeCard(i + 21));
+
+    const initialEdges = firstBatch.map(makeEdge);
+    const initialPageInfo = {
+      __typename: "PageInfo" as const,
+      hasNextPage: true,
+      hasPreviousPage: false,
+      startCursor: "c-1",
+      endCursor: "c-20",
+    };
+    const initialTotalCount = 40;
+
+    // Use a finite delay so the request is briefly in-flight; the result function
+    // is called once-per-request, so we can assert it ran exactly once.
+    let nextPageCalls = 0;
+    const nextPageResult = vi.fn(() => {
+      nextPageCalls += 1;
+      return { data: { cardsByCardgroupConnection: makeConnection(secondBatch, false) } };
+    });
+
+    const mocks = [
+      {
+        request: {
+          query: CardsByCardgroupConnectionDocument,
+          variables: { cardgroupId: CG_ID, first: PAGE_SIZE },
+        },
+        result: {
+          data: { cardsByCardgroupConnection: makeConnection(firstBatch, true) },
+        },
+      },
+      {
+        request: {
+          query: CardsByCardgroupConnectionDocument,
+          variables: { cardgroupId: CG_ID, first: PAGE_SIZE, after: "c-20" },
+        },
+        delay: 50,
+        result: nextPageResult,
+      },
+    ];
+
+    const cache = new InMemoryCache();
+    cache.writeQuery({
+      query: CardsByCardgroupConnectionDocument,
+      variables: { cardgroupId: CG_ID, first: PAGE_SIZE },
+      data: { cardsByCardgroupConnection: makeConnection(firstBatch, true) },
+    });
+
+    render(
+      <MockedProvider mocks={mocks as never} cache={cache}>
+        <CardsClient
+          cardgroupId={CG_ID}
+          initialEdges={initialEdges}
+          initialPageInfo={initialPageInfo}
+          initialTotalCount={initialTotalCount}
+        />
+      </MockedProvider>,
+    );
+
+    expect(screen.getByText("front-20")).toBeInTheDocument();
+
+    // Synchronously fire the observer twice — the in-flight guard must
+    // suppress the second call so only one fetchMore actually goes out.
+    fireIntersect();
+    fireIntersect();
+
+    // Wait for the delayed mock to resolve and append the second batch.
+    await waitFor(() => {
+      expect(screen.getByText("front-40")).toBeInTheDocument();
+    });
+    expect(nextPageCalls).toBe(1);
+
+    // hasNextPage flipped to false — further intersects must not trigger a new request.
+    fireIntersect();
+    await new Promise((resolve) => setTimeout(resolve, 60));
+    expect(nextPageCalls).toBe(1);
+  });
 });

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/frontend/src/app/cardgroups/[id]/cards/cards-client.test.tsx
+++ b/frontend/src/app/cardgroups/[id]/cards/cards-client.test.tsx
@@ -443,4 +443,134 @@ describe("<CardsClient>", () => {
     expect(resetFrontInput.value).toBe("");
     expect(resetBackInput.value).toBe("");
   });
+
+  // G1: useQuery error surfaces a banner via the cards-query-error testid.
+  it("useQuery error renders banner with cards-query-error testid", async () => {
+    const queryErrorMock = {
+      request: {
+        query: CardsByCardgroupConnectionDocument,
+        variables: { cardgroupId: CG_ID, first: PAGE_SIZE },
+      },
+      result: {
+        errors: [new GraphQLError("boom", { extensions: { code: "INTERNAL" } })],
+      },
+    };
+
+    renderClient([queryErrorMock], [CARD_1, CARD_2]);
+
+    const banner = await screen.findByTestId("cards-query-error");
+    // INTERNAL errors surface with the original message via getBackendErrorBanner.
+    expect(banner).toHaveTextContent("boom");
+  });
+
+  // G4: cold cache create writes a fresh connection and the new card renders.
+  it("create on cold cache renders the new card", async () => {
+    const user = userEvent.setup();
+    const createMock = makeCreateMock({ cardgroupId: CG_ID, front: "Cat", back: "Gato" });
+
+    // Cold cache — no seeded cardsByCardgroupConnection entry.
+    const cache = new InMemoryCache();
+
+    renderClient([createMock], [], { cache });
+
+    const addFrontInput = screen.getByLabelText(/front/i) as HTMLElement;
+    const addBackInput = screen.getByLabelText(/back/i) as HTMLElement;
+
+    await user.type(addFrontInput, "Cat");
+    await user.type(addBackInput, "Gato");
+
+    await user.click(screen.getByRole("button", { name: /^add$/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Cat")).toBeInTheDocument();
+    });
+
+    const cached = cache.readQuery({
+      query: CardsByCardgroupConnectionDocument,
+      variables: { cardgroupId: CG_ID, first: PAGE_SIZE },
+    });
+    expect(cached?.cardsByCardgroupConnection.edges).toHaveLength(1);
+    expect(cached?.cardsByCardgroupConnection.edges[0]?.node.id).toBe(NEW_CARD.id);
+    expect(cached?.cardsByCardgroupConnection.totalCount).toBe(1);
+  });
+
+  // G5: delete decrements totalCount unconditionally — even when the filter is a
+  // no-op because the deleted card lives on a page that was never fetched into
+  // the cached edges. Strategy: open the delete dialog while the card is still
+  // visible, then mutate the cache to drop that card's edge before confirming —
+  // the dialog's onClick captured card.id in closure, so the mutation still
+  // fires for the original id, and the deleteCard.update callback now sees a
+  // cached connection that does NOT contain that id.
+  it("delete decrements totalCount even when card is not in cached edges", async () => {
+    const user = userEvent.setup();
+    const mock = makeDeleteMock("c-1");
+
+    // Seed cache with BOTH edges so CARD_1's Delete button renders.
+    const cache = new InMemoryCache();
+    cache.writeQuery({
+      query: CardsByCardgroupConnectionDocument,
+      variables: { cardgroupId: CG_ID, first: PAGE_SIZE },
+      data: {
+        cardsByCardgroupConnection: {
+          __typename: "CardConnection" as const,
+          edges: [edge(CARD_1), edge(CARD_2)],
+          pageInfo: {
+            __typename: "PageInfo" as const,
+            hasNextPage: true,
+            hasPreviousPage: false,
+            startCursor: CARD_1.id,
+            endCursor: CARD_2.id,
+          },
+          totalCount: 5,
+        },
+      },
+    });
+
+    renderClient([mock], [CARD_1, CARD_2], { cache });
+
+    // Open the delete dialog for CARD_1 while it's still visible.
+    const firstDeleteBtn = screen.getAllByRole("button", { name: /delete/i })[0] as HTMLElement;
+    await user.click(firstDeleteBtn);
+
+    const dialog = await screen.findByRole("alertdialog");
+    const confirmBtn = within(dialog).getByRole("button", { name: /delete/i });
+
+    // Drop CARD_1 from the cached connection (keep totalCount=5) WITHOUT
+    // broadcasting so the component does not re-render and unmount the dialog.
+    // The deleteCard.update callback will then read an existing connection whose
+    // edges do not include CARD_1, exercising the no-op-filter path.
+    cache.writeQuery({
+      query: CardsByCardgroupConnectionDocument,
+      variables: { cardgroupId: CG_ID, first: PAGE_SIZE },
+      data: {
+        cardsByCardgroupConnection: {
+          __typename: "CardConnection" as const,
+          edges: [edge(CARD_2)],
+          pageInfo: {
+            __typename: "PageInfo" as const,
+            hasNextPage: true,
+            hasPreviousPage: false,
+            startCursor: CARD_2.id,
+            endCursor: CARD_2.id,
+          },
+          totalCount: 5,
+        },
+      },
+      broadcast: false,
+    });
+
+    // Confirm the delete — the dialog's onClick closure still uses card.id="c-1".
+    await user.click(confirmBtn);
+
+    await waitFor(() => {
+      const cached = cache.readQuery({
+        query: CardsByCardgroupConnectionDocument,
+        variables: { cardgroupId: CG_ID, first: PAGE_SIZE },
+      });
+      // totalCount must drop from 5 to 4 even though the filter removed nothing.
+      // A gated-decrement regression (only decrement when filter actually
+      // removes an edge) would leave totalCount at 5 here.
+      expect(cached?.cardsByCardgroupConnection.totalCount).toBe(4);
+    });
+  });
 });

--- a/frontend/src/app/cardgroups/[id]/cards/cards-client.test.tsx
+++ b/frontend/src/app/cardgroups/[id]/cards/cards-client.test.tsx
@@ -4,9 +4,9 @@ import { MockedProvider } from "@apollo/client/testing/react";
 import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { GraphQLError } from "graphql";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
-  CardsByCardgroupDocument,
+  CardsByCardgroupConnectionDocument,
   CreateCardDocument,
   DeleteCardDocument,
   UpdateCardDocument,
@@ -14,6 +14,7 @@ import {
 import { CardsClient } from "./cards-client";
 
 const CG_ID = "cg-1";
+const PAGE_SIZE = 20;
 
 const CARD_1 = {
   __typename: "Card" as const,
@@ -44,6 +45,53 @@ const NEW_CARD = {
   state: 0,
   cardgroupId: CG_ID,
 };
+
+function edge(card: typeof CARD_1) {
+  return {
+    __typename: "CardEdge" as const,
+    cursor: card.id,
+    node: card,
+  };
+}
+
+function connection(
+  cards: ReadonlyArray<typeof CARD_1>,
+  hasNext = false,
+): {
+  __typename: "CardConnection";
+  edges: ReturnType<typeof edge>[];
+  pageInfo: {
+    __typename: "PageInfo";
+    hasNextPage: boolean;
+    hasPreviousPage: boolean;
+    startCursor: string | null;
+    endCursor: string | null;
+  };
+  totalCount: number;
+} {
+  return {
+    __typename: "CardConnection" as const,
+    edges: cards.map(edge),
+    pageInfo: {
+      __typename: "PageInfo" as const,
+      hasNextPage: hasNext,
+      hasPreviousPage: false,
+      startCursor: cards[0]?.id ?? null,
+      endCursor: cards[cards.length - 1]?.id ?? null,
+    },
+    totalCount: cards.length,
+  };
+}
+
+function defaultPageInfo(edges: ReturnType<typeof edge>[]) {
+  return {
+    __typename: "PageInfo" as const,
+    hasNextPage: false,
+    hasPreviousPage: false,
+    startCursor: edges[0]?.cursor ?? null,
+    endCursor: edges[edges.length - 1]?.cursor ?? null,
+  };
+}
 
 function makeCreateMock(
   input: { cardgroupId: string; front: string; back: string },
@@ -86,12 +134,34 @@ function renderClient(
     ? { mutate: { errorPolicy: "all" as const } }
     : undefined;
 
+  const initialEdges = initialCards.map(edge);
+
   render(
     <MockedProvider mocks={mocks as never} defaultOptions={defaultOptions} cache={options.cache}>
-      <CardsClient cardgroupId={CG_ID} initialCards={initialCards} />
+      <CardsClient
+        cardgroupId={CG_ID}
+        initialEdges={initialEdges}
+        initialPageInfo={defaultPageInfo(initialEdges)}
+        initialTotalCount={initialEdges.length}
+      />
     </MockedProvider>,
   );
 }
+
+// Stub IntersectionObserver since cards-client wires one up in a useEffect.
+beforeEach(() => {
+  vi.stubGlobal(
+    "IntersectionObserver",
+    class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+      takeRecords() {
+        return [];
+      }
+    },
+  );
+});
 
 describe("<CardsClient>", () => {
   it("renders existing cards", () => {
@@ -102,26 +172,21 @@ describe("<CardsClient>", () => {
 
   it("add success appends a new row", async () => {
     const user = userEvent.setup();
-    const mock = makeCreateMock({ cardgroupId: CG_ID, front: "Cat", back: "Gato" });
+    const createMock = makeCreateMock({ cardgroupId: CG_ID, front: "Cat", back: "Gato" });
 
-    // Pre-populate cache with existing cards so the update callback can read it.
-    const cacheMocks = [
-      {
-        request: {
-          query: CardsByCardgroupDocument,
-          variables: { cardgroupId: CG_ID },
-        },
-        result: { data: { cardsByCardgroup: [CARD_1, CARD_2] } },
-      },
-      mock,
-    ];
+    // Pre-populate cache with the connection so the create update callback can read/write it.
+    const cache = new InMemoryCache();
+    cache.writeQuery({
+      query: CardsByCardgroupConnectionDocument,
+      variables: { cardgroupId: CG_ID, first: PAGE_SIZE },
+      data: { cardsByCardgroupConnection: connection([CARD_1, CARD_2]) },
+    });
 
-    renderClient(cacheMocks);
+    renderClient([createMock], [CARD_1, CARD_2], { cache });
 
     const addFrontInput = screen.getAllByLabelText(/front/i)[0] as HTMLElement;
     const addBackInput = screen.getAllByLabelText(/back/i)[0] as HTMLElement;
 
-    // The add form is first
     await user.click(addFrontInput);
     await user.type(addFrontInput, "Cat");
     await user.click(addBackInput);
@@ -169,16 +234,13 @@ describe("<CardsClient>", () => {
     const user = userEvent.setup();
     renderClient([]);
 
-    // Click Edit on first card row
     const firstEditBtn = screen.getAllByRole("button", { name: /edit/i })[0] as HTMLElement;
     await user.click(firstEditBtn);
 
-    // Edit form appears alongside the add form; edit input is the second Front input
     // [0] = add form (empty), [1] = edit form (prefilled)
     const editFrontInput = screen.getAllByLabelText(/front/i)[1] as HTMLElement;
     expect(editFrontInput).toHaveValue("Hello");
 
-    // Cancel reverts
     await user.click(screen.getByRole("button", { name: /cancel/i }));
 
     await waitFor(() => {
@@ -196,12 +258,19 @@ describe("<CardsClient>", () => {
       updatedCard,
     );
 
-    renderClient([mock]);
+    // Seed cache so cache normalization can update the edge node when mutation completes.
+    const cache = new InMemoryCache();
+    cache.writeQuery({
+      query: CardsByCardgroupConnectionDocument,
+      variables: { cardgroupId: CG_ID, first: PAGE_SIZE },
+      data: { cardsByCardgroupConnection: connection([CARD_1, CARD_2]) },
+    });
+
+    renderClient([mock], [CARD_1, CARD_2], { cache });
 
     const firstEditBtn = screen.getAllByRole("button", { name: /edit/i })[0] as HTMLElement;
     await user.click(firstEditBtn);
 
-    // [0] = add form, [1] = edit form
     const editFrontInput = screen.getAllByLabelText(/front/i)[1] as HTMLElement;
     await user.clear(editFrontInput);
     await user.type(editFrontInput, "Hello updated");
@@ -221,12 +290,12 @@ describe("<CardsClient>", () => {
     const user = userEvent.setup();
     const mock = makeDeleteMock("c-1");
 
-    // Seed a real InMemoryCache so the update callback's evict/gc is exercised.
+    // Seed a real InMemoryCache so the update callback's modify/evict/gc is exercised.
     const cache = new InMemoryCache();
     cache.writeQuery({
-      query: CardsByCardgroupDocument,
-      variables: { cardgroupId: CG_ID },
-      data: { cardsByCardgroup: [CARD_1, CARD_2] },
+      query: CardsByCardgroupConnectionDocument,
+      variables: { cardgroupId: CG_ID, first: PAGE_SIZE },
+      data: { cardsByCardgroupConnection: connection([CARD_1, CARD_2]) },
     });
 
     renderClient([mock], [CARD_1, CARD_2], { cache });
@@ -236,22 +305,19 @@ describe("<CardsClient>", () => {
     const firstDeleteBtn = screen.getAllByRole("button", { name: /delete/i })[0] as HTMLElement;
     await user.click(firstDeleteBtn);
 
-    // Confirm button inside the dialog
     const dialog = await screen.findByRole("alertdialog");
     const confirmBtn = within(dialog).getByRole("button", { name: /delete/i });
     await user.click(confirmBtn);
 
-    // Row disappears from the DOM.
     await waitFor(() => {
       expect(screen.queryByText("Hello")).not.toBeInTheDocument();
     });
 
-    // Cache must no longer contain the deleted card.
     const cached = cache.readQuery({
-      query: CardsByCardgroupDocument,
-      variables: { cardgroupId: CG_ID },
+      query: CardsByCardgroupConnectionDocument,
+      variables: { cardgroupId: CG_ID, first: PAGE_SIZE },
     });
-    const ids = cached?.cardsByCardgroup.map((c) => c.id) ?? [];
+    const ids = cached?.cardsByCardgroupConnection.edges.map((e) => e.node.id) ?? [];
     expect(ids).not.toContain(CARD_1.id);
   });
 
@@ -329,14 +395,11 @@ describe("<CardsClient>", () => {
 
     renderClient([mock], [CARD_1], { errorPolicy: true });
 
-    // Open edit form for the card
     const editBtn = screen.getByRole("button", { name: /edit/i });
     await user.click(editBtn);
 
-    // [0] = add form, [1] = edit form
     const editFrontInput = screen.getAllByLabelText(/front/i)[1] as HTMLElement;
     await user.clear(editFrontInput);
-    // Leave front empty so the server returns BAD_USER_INPUT
 
     await user.click(screen.getByRole("button", { name: /^save$/i }));
 
@@ -344,30 +407,23 @@ describe("<CardsClient>", () => {
       expect(screen.getByText("front is required")).toBeInTheDocument();
     });
 
-    // Edit form must still be open (inputs still visible)
     expect(screen.getAllByLabelText(/front/i)).toHaveLength(2);
-    // No navigation — save button still present
     expect(screen.getByRole("button", { name: /^save$/i })).toBeInTheDocument();
   });
 
   it("add-card form is reset after successful create", async () => {
     const user = userEvent.setup();
-    const mock = makeCreateMock({ cardgroupId: CG_ID, front: "Cat", back: "Gato" });
+    const createMock = makeCreateMock({ cardgroupId: CG_ID, front: "Cat", back: "Gato" });
 
-    const cacheMocks = [
-      {
-        request: {
-          query: CardsByCardgroupDocument,
-          variables: { cardgroupId: CG_ID },
-        },
-        result: { data: { cardsByCardgroup: [CARD_1, CARD_2] } },
-      },
-      mock,
-    ];
+    const cache = new InMemoryCache();
+    cache.writeQuery({
+      query: CardsByCardgroupConnectionDocument,
+      variables: { cardgroupId: CG_ID, first: PAGE_SIZE },
+      data: { cardsByCardgroupConnection: connection([CARD_1, CARD_2]) },
+    });
 
-    renderClient(cacheMocks);
+    renderClient([createMock], [CARD_1, CARD_2], { cache });
 
-    // Fill the add form (idPrefix="add-")
     const addFrontInput = screen.getAllByLabelText(/front/i)[0] as HTMLElement;
     const addBackInput = screen.getAllByLabelText(/back/i)[0] as HTMLElement;
 
@@ -378,12 +434,10 @@ describe("<CardsClient>", () => {
 
     await user.click(screen.getByRole("button", { name: /^add$/i }));
 
-    // New card row appears
     await waitFor(() => {
       expect(screen.getByText("Cat")).toBeInTheDocument();
     });
 
-    // Add form inputs must be cleared (remounted via key)
     const resetFrontInput = screen.getAllByLabelText(/front/i)[0] as HTMLInputElement;
     const resetBackInput = screen.getAllByLabelText(/back/i)[0] as HTMLInputElement;
     expect(resetFrontInput.value).toBe("");

--- a/frontend/src/app/cardgroups/[id]/cards/cards-client.tsx
+++ b/frontend/src/app/cardgroups/[id]/cards/cards-client.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { gql } from "@apollo/client";
+import { gql, NetworkStatus } from "@apollo/client";
 import { useMutation, useQuery } from "@apollo/client/react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
   CreateCardMutation,
   DeleteCardMutation,
@@ -61,7 +61,7 @@ export function CardsClient({
     notifyOnNetworkStatusChange: true,
   });
 
-  const queryBannerError = useMemo(() => getBackendErrorBanner(queryError), [queryError]);
+  const queryBannerError = getBackendErrorBanner(queryError);
 
   const connection = data?.cardsByCardgroupConnection;
   const edges = connection?.edges ?? initialEdges;
@@ -71,7 +71,6 @@ export function CardsClient({
   const sentinelRef = useRef<HTMLDivElement | null>(null);
   const fetchingRef = useRef(false);
 
-  // Issue a single fetchMore call. Used by both the IntersectionObserver and the retry button.
   const requestNextPage = useCallback(() => {
     if (fetchingRef.current) return;
     if (!pageInfo.hasNextPage) return;
@@ -230,7 +229,7 @@ export function CardsClient({
     },
   });
 
-  const deleteBannerError = useMemo(() => getBackendErrorBanner(deleteError), [deleteError]);
+  const deleteBannerError = getBackendErrorBanner(deleteError);
 
   async function handleCreate(values: { front: string; back: string }) {
     await createCard({
@@ -252,8 +251,7 @@ export function CardsClient({
     }
   }
 
-  // networkStatus 3 = fetchMore in flight (Apollo NetworkStatus.fetchMore).
-  const fetchingMore = networkStatus === 3 || (loading && edges.length > 0);
+  const fetchingMore = networkStatus === NetworkStatus.fetchMore || (loading && edges.length > 0);
 
   return (
     <div className="space-y-6">
@@ -359,7 +357,7 @@ export function CardsClient({
         )}
 
         <div ref={sentinelRef} aria-hidden="true" data-testid="cards-sentinel" />
-        {fetchMoreError ? (
+        {fetchMoreError && (
           <div
             className="mt-3 flex flex-col items-center gap-2 rounded-md bg-destructive/10 p-3 text-sm text-destructive"
             role="alert"
@@ -378,9 +376,10 @@ export function CardsClient({
               Retry
             </Button>
           </div>
-        ) : fetchingMore && pageInfo.hasNextPage ? (
+        )}
+        {!fetchMoreError && fetchingMore && pageInfo.hasNextPage && (
           <p className="mt-3 text-center text-xs text-muted-foreground">Loading more cards...</p>
-        ) : null}
+        )}
       </section>
     </div>
   );

--- a/frontend/src/app/cardgroups/[id]/cards/cards-client.tsx
+++ b/frontend/src/app/cardgroups/[id]/cards/cards-client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { gql, type Reference } from "@apollo/client";
+import { gql } from "@apollo/client";
 import { useMutation, useQuery } from "@apollo/client/react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
@@ -148,40 +148,45 @@ export function CardsClient({
         `,
         data: newCard,
       });
-      cache.modify({
-        fields: {
-          cardsByCardgroupConnection(existing, { storeFieldName, toReference }) {
-            // storeFieldName encodes args; only touch the connection for THIS cardgroupId.
-            if (!storeFieldName.includes(`"cardgroupId":"${cardgroupId}"`)) {
-              return existing;
-            }
-            const cardRef = toReference({ __typename: "Card", id: newCard.id });
-            const newEdge = {
-              __typename: "CardEdge" as const,
-              cursor: newCard.id,
-              node: cardRef ?? newCard,
-            };
-            if (existing == null) {
-              return {
-                __typename: "CardConnection",
-                edges: [newEdge],
-                pageInfo: {
-                  __typename: "PageInfo",
-                  hasNextPage: false,
-                  hasPreviousPage: false,
-                  startCursor: newCard.id,
-                  endCursor: newCard.id,
-                },
-                totalCount: 1,
-              };
-            }
-            return {
-              ...existing,
-              edges: [...existing.edges, newEdge],
-              totalCount: (existing.totalCount ?? 0) + 1,
-            };
-          },
-        },
+      // Use readQuery/writeQuery so cold caches (no existing connection entry) get
+      // a freshly-written connection — cache.modify silently no-ops when the field
+      // is missing, which would lose the new card on first load.
+      const variables = { cardgroupId, first: PAGE_SIZE };
+      const existing = cache.readQuery({
+        query: CardsByCardgroupConnectionDocument,
+        variables,
+      });
+      const newEdge = {
+        __typename: "CardEdge" as const,
+        cursor: newCard.id,
+        node: newCard,
+      };
+      const next = existing
+        ? {
+            cardsByCardgroupConnection: {
+              ...existing.cardsByCardgroupConnection,
+              edges: [...existing.cardsByCardgroupConnection.edges, newEdge],
+              totalCount: existing.cardsByCardgroupConnection.totalCount + 1,
+            },
+          }
+        : {
+            cardsByCardgroupConnection: {
+              __typename: "CardConnection" as const,
+              edges: [newEdge],
+              pageInfo: {
+                __typename: "PageInfo" as const,
+                hasNextPage: false,
+                hasPreviousPage: false,
+                startCursor: newCard.id,
+                endCursor: newCard.id,
+              },
+              totalCount: 1,
+            },
+          };
+      cache.writeQuery({
+        query: CardsByCardgroupConnectionDocument,
+        variables,
+        data: next,
       });
       setCreateFormKey((k) => k + 1);
     },
@@ -191,27 +196,36 @@ export function CardsClient({
   const [updateCard, { loading: updating, error: updateError }] = useMutation(UpdateCardMutation);
 
   const [deleteCard, { error: deleteError }] = useMutation(DeleteCardMutation, {
-    update(cache, { data: deleteData }, { variables }) {
+    update(cache, { data: deleteData }, { variables: deleteVars }) {
       if (!deleteData?.deleteCard) return;
-      const id = variables?.id as string | undefined;
+      const id = deleteVars?.id as string | undefined;
       if (!id) return;
-      cache.modify({
-        fields: {
-          cardsByCardgroupConnection(existing, { readField }) {
-            if (!existing || !Array.isArray(existing.edges)) return existing;
-            const filteredEdges = existing.edges.filter(
-              (edge: { node: Reference }) => readField("id", edge.node) !== id,
-            );
-            // Decrement totalCount on every successful delete, even if the edge was on
-            // a not-yet-fetched page (filteredEdges.length === existing.edges.length).
-            return {
-              ...existing,
-              edges: filteredEdges,
-              totalCount: Math.max(0, (existing.totalCount ?? 0) - 1),
-            };
-          },
-        },
+      // Use readQuery/writeQuery for cold-cache safety: when no connection has been
+      // cached for this cardgroup yet, there is nothing to remove and we leave the
+      // cache untouched. When the connection exists, drop any matching edge and
+      // decrement totalCount unconditionally (the deleted card may live on a page
+      // that was never fetched into edges).
+      const variables = { cardgroupId, first: PAGE_SIZE };
+      const existing = cache.readQuery({
+        query: CardsByCardgroupConnectionDocument,
+        variables,
       });
+      if (existing) {
+        const filteredEdges = existing.cardsByCardgroupConnection.edges.filter(
+          (edge) => edge.node.id !== id,
+        );
+        cache.writeQuery({
+          query: CardsByCardgroupConnectionDocument,
+          variables,
+          data: {
+            cardsByCardgroupConnection: {
+              ...existing.cardsByCardgroupConnection,
+              edges: filteredEdges,
+              totalCount: Math.max(0, existing.cardsByCardgroupConnection.totalCount - 1),
+            },
+          },
+        });
+      }
       cache.evict({ id: cache.identify({ __typename: "Card", id }) });
       cache.gc();
     },

--- a/frontend/src/app/cardgroups/[id]/cards/cards-client.tsx
+++ b/frontend/src/app/cardgroups/[id]/cards/cards-client.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useMutation } from "@apollo/client/react";
-import { useMemo, useState } from "react";
+import type { Reference } from "@apollo/client";
+import { useMutation, useQuery } from "@apollo/client/react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
   CreateCardMutation,
   DeleteCardMutation,
@@ -20,56 +21,150 @@ import {
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
-import { CardsByCardgroupDocument, type CardsByCardgroupQuery } from "@/generated/graphql";
+import {
+  CardsByCardgroupConnectionDocument,
+  type CardsByCardgroupConnectionQuery,
+} from "@/generated/graphql";
 import { getBackendErrorBanner } from "@/lib/apollo/errors";
 
-type Card = CardsByCardgroupQuery["cardsByCardgroup"][number];
+const PAGE_SIZE = 20;
+
+type Connection = CardsByCardgroupConnectionQuery["cardsByCardgroupConnection"];
+type Edge = Connection["edges"][number];
+type PageInfo = Connection["pageInfo"];
 
 type Props = {
   cardgroupId: string;
-  initialCards: Card[];
+  initialEdges: Edge[];
+  initialPageInfo: PageInfo;
+  initialTotalCount: number;
 };
 
-export function CardsClient({ cardgroupId, initialCards }: Props) {
-  const [cards, setCards] = useState<Card[]>(initialCards);
+export function CardsClient({
+  cardgroupId,
+  initialEdges,
+  initialPageInfo,
+  initialTotalCount,
+}: Props) {
   const [editingId, setEditingId] = useState<string | null>(null);
   const [createFormKey, setCreateFormKey] = useState(0);
 
+  const { data, fetchMore, loading, networkStatus } = useQuery(CardsByCardgroupConnectionDocument, {
+    variables: { cardgroupId, first: PAGE_SIZE },
+    fetchPolicy: "cache-first",
+    notifyOnNetworkStatusChange: true,
+  });
+
+  const connection = data?.cardsByCardgroupConnection;
+  const edges = connection?.edges ?? initialEdges;
+  const pageInfo = connection?.pageInfo ?? initialPageInfo;
+  const totalCount = connection?.totalCount ?? initialTotalCount;
+
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
+  const fetchingRef = useRef(false);
+
+  useEffect(() => {
+    if (!pageInfo.hasNextPage) return;
+    const node = sentinelRef.current;
+    if (!node) return;
+
+    const observer = new IntersectionObserver((entries) => {
+      const entry = entries[0];
+      if (!entry?.isIntersecting) return;
+      if (fetchingRef.current) return;
+      if (!pageInfo.hasNextPage) return;
+
+      fetchingRef.current = true;
+      fetchMore({
+        variables: {
+          cardgroupId,
+          first: PAGE_SIZE,
+          after: pageInfo.endCursor,
+        },
+        updateQuery: (prev, { fetchMoreResult }) => {
+          if (!fetchMoreResult) return prev;
+          return {
+            cardsByCardgroupConnection: {
+              ...fetchMoreResult.cardsByCardgroupConnection,
+              edges: [
+                ...prev.cardsByCardgroupConnection.edges,
+                ...fetchMoreResult.cardsByCardgroupConnection.edges,
+              ],
+            },
+          };
+        },
+      })
+        .catch((err) => {
+          console.error("[CardsClient] fetchMore rejected", err);
+        })
+        .finally(() => {
+          fetchingRef.current = false;
+        });
+    });
+
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [cardgroupId, fetchMore, pageInfo.endCursor, pageInfo.hasNextPage]);
+
   const [createCard, { loading: creating, error: createError }] = useMutation(CreateCardMutation, {
-    update(cache, { data }) {
-      if (!data?.createCard?.card) return;
+    update(cache, { data: createData }) {
+      if (!createData?.createCard?.card) return;
+      const newCard = createData.createCard.card;
       const existing = cache.readQuery({
-        query: CardsByCardgroupDocument,
-        variables: { cardgroupId },
+        query: CardsByCardgroupConnectionDocument,
+        variables: { cardgroupId, first: PAGE_SIZE },
       });
+      if (!existing) return;
       cache.writeQuery({
-        query: CardsByCardgroupDocument,
-        variables: { cardgroupId },
+        query: CardsByCardgroupConnectionDocument,
+        variables: { cardgroupId, first: PAGE_SIZE },
         data: {
-          cardsByCardgroup: [...(existing?.cardsByCardgroup ?? []), data.createCard.card],
+          cardsByCardgroupConnection: {
+            ...existing.cardsByCardgroupConnection,
+            edges: [
+              ...existing.cardsByCardgroupConnection.edges,
+              {
+                __typename: "CardEdge" as const,
+                cursor: newCard.id,
+                node: newCard,
+              },
+            ],
+            totalCount: existing.cardsByCardgroupConnection.totalCount + 1,
+          },
         },
       });
-      setCards((prev) => [...prev, data.createCard.card]);
       setCreateFormKey((k) => k + 1);
     },
   });
 
-  const [updateCard, { loading: updating, error: updateError }] = useMutation(UpdateCardMutation, {
-    update(_cache, { data }) {
-      if (!data?.updateCard?.card) return;
-      const updated = data.updateCard.card;
-      setCards((prev) => prev.map((c) => (c.id === updated.id ? updated : c)));
-    },
-  });
+  // Update propagates automatically via Apollo cache normalization (Card has id).
+  const [updateCard, { loading: updating, error: updateError }] = useMutation(UpdateCardMutation);
 
   const [deleteCard, { error: deleteError }] = useMutation(DeleteCardMutation, {
-    update(cache, { data }, { variables }) {
-      if (!data?.deleteCard) return;
+    update(cache, { data: deleteData }, { variables }) {
+      if (!deleteData?.deleteCard) return;
       const id = variables?.id as string | undefined;
       if (!id) return;
+      cache.modify({
+        fields: {
+          cardsByCardgroupConnection(existing, { readField }) {
+            if (!existing || !Array.isArray(existing.edges)) return existing;
+            const filteredEdges = existing.edges.filter(
+              (edge: { node: Reference }) => readField("id", edge.node) !== id,
+            );
+            const removed = filteredEdges.length !== existing.edges.length;
+            return {
+              ...existing,
+              edges: filteredEdges,
+              totalCount: removed
+                ? Math.max(0, (existing.totalCount ?? 0) - 1)
+                : existing.totalCount,
+            };
+          },
+        },
+      });
       cache.evict({ id: cache.identify({ __typename: "Card", id }) });
       cache.gc();
-      setCards((prev) => prev.filter((c) => c.id !== id));
     },
   });
 
@@ -94,6 +189,9 @@ export function CardsClient({ cardgroupId, initialCards }: Props) {
       setEditingId(null);
     }
   }
+
+  // networkStatus 3 = fetchMore in flight (Apollo NetworkStatus.fetchMore).
+  const fetchingMore = networkStatus === 3 || (loading && edges.length > 0);
 
   return (
     <div className="space-y-6">
@@ -121,15 +219,16 @@ export function CardsClient({ cardgroupId, initialCards }: Props) {
 
       <section>
         <h2 className="mb-3 text-sm font-medium uppercase tracking-wide text-muted-foreground">
-          Cards ({cards.length})
+          Cards ({totalCount})
         </h2>
 
-        {cards.length === 0 ? (
+        {edges.length === 0 ? (
           <p className="text-sm text-muted-foreground">No cards yet. Add one above.</p>
         ) : (
           <ul className="space-y-3">
-            {cards.map((card) =>
-              editingId === card.id ? (
+            {edges.map((edge) => {
+              const card = edge.node;
+              return editingId === card.id ? (
                 <li key={card.id} className="rounded-md border border-border p-4">
                   <CardForm
                     mode="edit"
@@ -182,10 +281,15 @@ export function CardsClient({ cardgroupId, initialCards }: Props) {
                     </AlertDialog>
                   </div>
                 </li>
-              ),
-            )}
+              );
+            })}
           </ul>
         )}
+
+        <div ref={sentinelRef} aria-hidden="true" data-testid="cards-sentinel" />
+        {fetchingMore && pageInfo.hasNextPage ? (
+          <p className="mt-3 text-center text-xs text-muted-foreground">Loading more cards...</p>
+        ) : null}
       </section>
     </div>
   );

--- a/frontend/src/app/cardgroups/[id]/cards/cards-client.tsx
+++ b/frontend/src/app/cardgroups/[id]/cards/cards-client.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import type { Reference } from "@apollo/client";
+import { gql, type Reference } from "@apollo/client";
 import { useMutation, useQuery } from "@apollo/client/react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   CreateCardMutation,
   DeleteCardMutation,
@@ -48,12 +48,21 @@ export function CardsClient({
 }: Props) {
   const [editingId, setEditingId] = useState<string | null>(null);
   const [createFormKey, setCreateFormKey] = useState(0);
+  const [fetchMoreError, setFetchMoreError] = useState<string | null>(null);
 
-  const { data, fetchMore, loading, networkStatus } = useQuery(CardsByCardgroupConnectionDocument, {
+  const {
+    data,
+    fetchMore,
+    loading,
+    networkStatus,
+    error: queryError,
+  } = useQuery(CardsByCardgroupConnectionDocument, {
     variables: { cardgroupId, first: PAGE_SIZE },
     fetchPolicy: "cache-first",
     notifyOnNetworkStatusChange: true,
   });
+
+  const queryBannerError = useMemo(() => getBackendErrorBanner(queryError), [queryError]);
 
   const connection = data?.cardsByCardgroupConnection;
   const edges = connection?.edges ?? initialEdges;
@@ -63,8 +72,48 @@ export function CardsClient({
   const sentinelRef = useRef<HTMLDivElement | null>(null);
   const fetchingRef = useRef(false);
 
+  // Issue a single fetchMore call. Used by both the IntersectionObserver and the retry button.
+  const requestNextPage = useCallback(() => {
+    if (fetchingRef.current) return;
+    if (!pageInfo.hasNextPage) return;
+
+    fetchingRef.current = true;
+    fetchMore({
+      variables: {
+        cardgroupId,
+        first: PAGE_SIZE,
+        after: pageInfo.endCursor,
+      },
+      updateQuery: (prev, { fetchMoreResult }) => {
+        if (!fetchMoreResult) return prev;
+        return {
+          cardsByCardgroupConnection: {
+            ...fetchMoreResult.cardsByCardgroupConnection,
+            edges: [
+              ...prev.cardsByCardgroupConnection.edges,
+              ...fetchMoreResult.cardsByCardgroupConnection.edges,
+            ],
+          },
+        };
+      },
+    })
+      .then(() => {
+        // Clear any previous fetchMore error on success so the observer can resume.
+        setFetchMoreError(null);
+      })
+      .catch((err) => {
+        const banner = getBackendErrorBanner(err) ?? "Could not load more cards. Please try again.";
+        setFetchMoreError(banner);
+      })
+      .finally(() => {
+        fetchingRef.current = false;
+      });
+  }, [cardgroupId, fetchMore, pageInfo.endCursor, pageInfo.hasNextPage]);
+
   useEffect(() => {
     if (!pageInfo.hasNextPage) return;
+    // Stop the observer loop while a previous fetch failed; user must click Retry to resume.
+    if (fetchMoreError != null) return;
     const node = sentinelRef.current;
     if (!node) return;
 
@@ -73,63 +122,64 @@ export function CardsClient({
       if (!entry?.isIntersecting) return;
       if (fetchingRef.current) return;
       if (!pageInfo.hasNextPage) return;
-
-      fetchingRef.current = true;
-      fetchMore({
-        variables: {
-          cardgroupId,
-          first: PAGE_SIZE,
-          after: pageInfo.endCursor,
-        },
-        updateQuery: (prev, { fetchMoreResult }) => {
-          if (!fetchMoreResult) return prev;
-          return {
-            cardsByCardgroupConnection: {
-              ...fetchMoreResult.cardsByCardgroupConnection,
-              edges: [
-                ...prev.cardsByCardgroupConnection.edges,
-                ...fetchMoreResult.cardsByCardgroupConnection.edges,
-              ],
-            },
-          };
-        },
-      })
-        .catch((err) => {
-          console.error("[CardsClient] fetchMore rejected", err);
-        })
-        .finally(() => {
-          fetchingRef.current = false;
-        });
+      requestNextPage();
     });
 
     observer.observe(node);
     return () => observer.disconnect();
-  }, [cardgroupId, fetchMore, pageInfo.endCursor, pageInfo.hasNextPage]);
+  }, [pageInfo.hasNextPage, fetchMoreError, requestNextPage]);
 
   const [createCard, { loading: creating, error: createError }] = useMutation(CreateCardMutation, {
     update(cache, { data: createData }) {
       if (!createData?.createCard?.card) return;
       const newCard = createData.createCard.card;
-      const existing = cache.readQuery({
-        query: CardsByCardgroupConnectionDocument,
-        variables: { cardgroupId, first: PAGE_SIZE },
+      // Write the new Card into the cache so any edge that references it resolves correctly.
+      cache.writeFragment({
+        id: cache.identify({ __typename: "Card", id: newCard.id }),
+        fragment: gql`
+          fragment NewCardFields on Card {
+            id
+            front
+            back
+            due
+            state
+            cardgroupId
+          }
+        `,
+        data: newCard,
       });
-      if (!existing) return;
-      cache.writeQuery({
-        query: CardsByCardgroupConnectionDocument,
-        variables: { cardgroupId, first: PAGE_SIZE },
-        data: {
-          cardsByCardgroupConnection: {
-            ...existing.cardsByCardgroupConnection,
-            edges: [
-              ...existing.cardsByCardgroupConnection.edges,
-              {
-                __typename: "CardEdge" as const,
-                cursor: newCard.id,
-                node: newCard,
-              },
-            ],
-            totalCount: existing.cardsByCardgroupConnection.totalCount + 1,
+      cache.modify({
+        fields: {
+          cardsByCardgroupConnection(existing, { storeFieldName, toReference }) {
+            // storeFieldName encodes args; only touch the connection for THIS cardgroupId.
+            if (!storeFieldName.includes(`"cardgroupId":"${cardgroupId}"`)) {
+              return existing;
+            }
+            const cardRef = toReference({ __typename: "Card", id: newCard.id });
+            const newEdge = {
+              __typename: "CardEdge" as const,
+              cursor: newCard.id,
+              node: cardRef ?? newCard,
+            };
+            if (existing == null) {
+              return {
+                __typename: "CardConnection",
+                edges: [newEdge],
+                pageInfo: {
+                  __typename: "PageInfo",
+                  hasNextPage: false,
+                  hasPreviousPage: false,
+                  startCursor: newCard.id,
+                  endCursor: newCard.id,
+                },
+                totalCount: 1,
+              };
+            }
+            return {
+              ...existing,
+              edges: [...existing.edges, newEdge],
+              totalCount: (existing.totalCount ?? 0) + 1,
+            };
           },
         },
       });
@@ -152,13 +202,12 @@ export function CardsClient({
             const filteredEdges = existing.edges.filter(
               (edge: { node: Reference }) => readField("id", edge.node) !== id,
             );
-            const removed = filteredEdges.length !== existing.edges.length;
+            // Decrement totalCount on every successful delete, even if the edge was on
+            // a not-yet-fetched page (filteredEdges.length === existing.edges.length).
             return {
               ...existing,
               edges: filteredEdges,
-              totalCount: removed
-                ? Math.max(0, (existing.totalCount ?? 0) - 1)
-                : existing.totalCount,
+              totalCount: Math.max(0, (existing.totalCount ?? 0) - 1),
             };
           },
         },
@@ -195,6 +244,16 @@ export function CardsClient({
 
   return (
     <div className="space-y-6">
+      {queryBannerError && (
+        <div
+          className="rounded-md bg-destructive/10 p-3 text-sm text-destructive"
+          role="alert"
+          data-testid="cards-query-error"
+        >
+          {queryBannerError}
+        </div>
+      )}
+
       {deleteBannerError && (
         <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive" role="alert">
           {deleteBannerError}
@@ -287,7 +346,26 @@ export function CardsClient({
         )}
 
         <div ref={sentinelRef} aria-hidden="true" data-testid="cards-sentinel" />
-        {fetchingMore && pageInfo.hasNextPage ? (
+        {fetchMoreError ? (
+          <div
+            className="mt-3 flex flex-col items-center gap-2 rounded-md bg-destructive/10 p-3 text-sm text-destructive"
+            role="alert"
+            data-testid="cards-fetch-more-error"
+          >
+            <span>{fetchMoreError}</span>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => {
+                setFetchMoreError(null);
+                requestNextPage();
+              }}
+            >
+              Retry
+            </Button>
+          </div>
+        ) : fetchingMore && pageInfo.hasNextPage ? (
           <p className="mt-3 text-center text-xs text-muted-foreground">Loading more cards...</p>
         ) : null}
       </section>

--- a/frontend/src/app/cardgroups/[id]/cards/cards-client.tsx
+++ b/frontend/src/app/cardgroups/[id]/cards/cards-client.tsx
@@ -26,8 +26,7 @@ import {
   type CardsByCardgroupConnectionQuery,
 } from "@/generated/graphql";
 import { getBackendErrorBanner } from "@/lib/apollo/errors";
-
-const PAGE_SIZE = 20;
+import { CARDS_PAGE_SIZE } from "./queries";
 
 type Connection = CardsByCardgroupConnectionQuery["cardsByCardgroupConnection"];
 type Edge = Connection["edges"][number];
@@ -57,7 +56,7 @@ export function CardsClient({
     networkStatus,
     error: queryError,
   } = useQuery(CardsByCardgroupConnectionDocument, {
-    variables: { cardgroupId, first: PAGE_SIZE },
+    variables: { cardgroupId, first: CARDS_PAGE_SIZE },
     fetchPolicy: "cache-first",
     notifyOnNetworkStatusChange: true,
   });
@@ -81,7 +80,7 @@ export function CardsClient({
     fetchMore({
       variables: {
         cardgroupId,
-        first: PAGE_SIZE,
+        first: CARDS_PAGE_SIZE,
         after: pageInfo.endCursor,
       },
       updateQuery: (prev, { fetchMoreResult }) => {
@@ -151,7 +150,7 @@ export function CardsClient({
       // Use readQuery/writeQuery so cold caches (no existing connection entry) get
       // a freshly-written connection — cache.modify silently no-ops when the field
       // is missing, which would lose the new card on first load.
-      const variables = { cardgroupId, first: PAGE_SIZE };
+      const variables = { cardgroupId, first: CARDS_PAGE_SIZE };
       const existing = cache.readQuery({
         query: CardsByCardgroupConnectionDocument,
         variables,
@@ -205,7 +204,7 @@ export function CardsClient({
       // cache untouched. When the connection exists, drop any matching edge and
       // decrement totalCount unconditionally (the deleted card may live on a page
       // that was never fetched into edges).
-      const variables = { cardgroupId, first: PAGE_SIZE };
+      const variables = { cardgroupId, first: CARDS_PAGE_SIZE };
       const existing = cache.readQuery({
         query: CardsByCardgroupConnectionDocument,
         variables,

--- a/frontend/src/app/cardgroups/[id]/cards/page.test.tsx
+++ b/frontend/src/app/cardgroups/[id]/cards/page.test.tsx
@@ -20,14 +20,16 @@ vi.mock("@/lib/apollo/server", () => ({
 vi.mock("./cards-client", () => ({
   CardsClient: ({
     cardgroupId,
-    initialCards,
+    initialEdges,
   }: {
     cardgroupId: string;
-    initialCards: unknown[];
+    initialEdges: { node: { front: string } }[];
+    initialPageInfo: unknown;
+    initialTotalCount: number;
   }) => (
     <div data-testid="cards-client" data-cardgroup-id={cardgroupId}>
-      {(initialCards as { front: string }[]).map((c) => (
-        <span key={c.front}>{c.front}</span>
+      {initialEdges.map((e) => (
+        <span key={e.node.front}>{e.node.front}</span>
       ))}
     </div>
   ),
@@ -46,10 +48,59 @@ function makeSupabaseMock(user: { id: string } | null) {
 }
 
 const CARDGROUP = { id: "cg-1", name: "Vocab", updatedAt: "2024-06-15T10:00:00.000Z" };
-const CARDS = [
-  { id: "c-1", front: "Hello", back: "Hola", due: "2024-06-15", state: 0, cardgroupId: "cg-1" },
-  { id: "c-2", front: "World", back: "Mundo", due: "2024-06-15", state: 0, cardgroupId: "cg-1" },
+
+const EDGES = [
+  {
+    cursor: "c-1",
+    node: {
+      id: "c-1",
+      front: "Hello",
+      back: "Hola",
+      due: "2024-06-15",
+      state: 0,
+      cardgroupId: "cg-1",
+    },
+  },
+  {
+    cursor: "c-2",
+    node: {
+      id: "c-2",
+      front: "World",
+      back: "Mundo",
+      due: "2024-06-15",
+      state: 0,
+      cardgroupId: "cg-1",
+    },
+  },
 ];
+
+const PAGE_INFO = {
+  hasNextPage: false,
+  hasPreviousPage: false,
+  startCursor: "c-1",
+  endCursor: "c-2",
+};
+
+const CONNECTION = {
+  cardsByCardgroupConnection: {
+    edges: EDGES,
+    pageInfo: PAGE_INFO,
+    totalCount: EDGES.length,
+  },
+};
+
+const EMPTY_CONNECTION = {
+  cardsByCardgroupConnection: {
+    edges: [],
+    pageInfo: {
+      hasNextPage: false,
+      hasPreviousPage: false,
+      startCursor: null,
+      endCursor: null,
+    },
+    totalCount: 0,
+  },
+};
 
 describe("CardsPage (RSC)", () => {
   it("redirects to /login when unauthenticated", async () => {
@@ -64,7 +115,7 @@ describe("CardsPage (RSC)", () => {
     vi.mocked(createSupabaseServerClient).mockResolvedValue(
       makeSupabaseMock({ id: "user-1" }) as never,
     );
-    vi.mocked(gqlFetch).mockResolvedValue({ cardgroup: null, cardsByCardgroup: [] } as never);
+    vi.mocked(gqlFetch).mockResolvedValue({ cardgroup: null, ...EMPTY_CONNECTION } as never);
 
     await expect(CardsPage({ params: Promise.resolve({ id: "cg-99" }) })).rejects.toThrow(
       "REDIRECT:/cardgroups",
@@ -82,13 +133,13 @@ describe("CardsPage (RSC)", () => {
     );
   });
 
-  it("renders heading and passes cards to CardsClient", async () => {
+  it("renders heading and passes initialEdges to CardsClient", async () => {
     vi.mocked(createSupabaseServerClient).mockResolvedValue(
       makeSupabaseMock({ id: "user-1" }) as never,
     );
     vi.mocked(gqlFetch)
       .mockResolvedValueOnce({ cardgroup: CARDGROUP } as never)
-      .mockResolvedValueOnce({ cardsByCardgroup: CARDS } as never);
+      .mockResolvedValueOnce(CONNECTION as never);
 
     const jsx = await CardsPage({ params: Promise.resolve({ id: "cg-1" }) });
     render(jsx);
@@ -105,7 +156,7 @@ describe("CardsPage (RSC)", () => {
     );
     vi.mocked(gqlFetch)
       .mockResolvedValueOnce({ cardgroup: CARDGROUP } as never)
-      .mockResolvedValueOnce({ cardsByCardgroup: [] } as never);
+      .mockResolvedValueOnce(EMPTY_CONNECTION as never);
 
     const jsx = await CardsPage({ params: Promise.resolve({ id: "cg-1" }) });
     render(jsx);

--- a/frontend/src/app/cardgroups/[id]/cards/page.tsx
+++ b/frontend/src/app/cardgroups/[id]/cards/page.tsx
@@ -9,7 +9,7 @@ import { gqlFetch } from "@/lib/apollo/server";
 import { redirectIfUnauthenticated } from "@/lib/apollo/server-redirect";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 import { CardsClient } from "./cards-client";
-import { CardsByCardgroupConnectionQuery } from "./queries";
+import { CARDS_PAGE_SIZE, CardsByCardgroupConnectionQuery } from "./queries";
 
 export default async function CardsPage({ params }: { params: Promise<{ id: string }> }) {
   const supabase = await createSupabaseServerClient();
@@ -29,7 +29,7 @@ export default async function CardsPage({ params }: { params: Promise<{ id: stri
     [cardgroupData, connectionData] = await Promise.all([
       gqlFetch(CardgroupQuery, { variables: { id }, revalidate: 0 }),
       gqlFetch(CardsByCardgroupConnectionQuery, {
-        variables: { cardgroupId: id, first: 20 },
+        variables: { cardgroupId: id, first: CARDS_PAGE_SIZE },
         revalidate: 0,
       }),
     ]);

--- a/frontend/src/app/cardgroups/[id]/cards/page.tsx
+++ b/frontend/src/app/cardgroups/[id]/cards/page.tsx
@@ -1,14 +1,15 @@
 import Link from "next/link";
 import { redirect } from "next/navigation";
-import { CardgroupQuery, CardsByCardgroupQuery } from "@/app/cardgroups/queries";
+import { CardgroupQuery } from "@/app/cardgroups/queries";
 import type {
   CardgroupQuery as CardgroupQueryType,
-  CardsByCardgroupQuery as CardsByCardgroupQueryType,
+  CardsByCardgroupConnectionQuery as CardsByCardgroupConnectionQueryType,
 } from "@/generated/graphql";
 import { gqlFetch } from "@/lib/apollo/server";
 import { redirectIfUnauthenticated } from "@/lib/apollo/server-redirect";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 import { CardsClient } from "./cards-client";
+import { CardsByCardgroupConnectionQuery } from "./queries";
 
 export default async function CardsPage({ params }: { params: Promise<{ id: string }> }) {
   const supabase = await createSupabaseServerClient();
@@ -22,12 +23,15 @@ export default async function CardsPage({ params }: { params: Promise<{ id: stri
   const { id } = await params;
 
   let cardgroupData: CardgroupQueryType | null = null;
-  let cardsData: CardsByCardgroupQueryType | null = null;
+  let connectionData: CardsByCardgroupConnectionQueryType | null = null;
 
   try {
-    [cardgroupData, cardsData] = await Promise.all([
+    [cardgroupData, connectionData] = await Promise.all([
       gqlFetch(CardgroupQuery, { variables: { id }, revalidate: 0 }),
-      gqlFetch(CardsByCardgroupQuery, { variables: { cardgroupId: id }, revalidate: 0 }),
+      gqlFetch(CardsByCardgroupConnectionQuery, {
+        variables: { cardgroupId: id, first: 20 },
+        revalidate: 0,
+      }),
     ]);
   } catch (err) {
     redirectIfUnauthenticated(err, "/cardgroups");
@@ -36,7 +40,14 @@ export default async function CardsPage({ params }: { params: Promise<{ id: stri
   if (!cardgroupData?.cardgroup) redirect("/cardgroups");
 
   const cardgroup = cardgroupData.cardgroup;
-  const cards = cardsData?.cardsByCardgroup ?? [];
+  const initialEdges = connectionData?.cardsByCardgroupConnection.edges ?? [];
+  const initialPageInfo = connectionData?.cardsByCardgroupConnection.pageInfo ?? {
+    hasNextPage: false,
+    hasPreviousPage: false,
+    startCursor: null,
+    endCursor: null,
+  };
+  const initialTotalCount = connectionData?.cardsByCardgroupConnection.totalCount ?? 0;
 
   return (
     <main className="mx-auto max-w-2xl p-8">
@@ -46,7 +57,12 @@ export default async function CardsPage({ params }: { params: Promise<{ id: stri
         </Link>
       </div>
       <h1 className="mb-6 text-2xl font-semibold">Cards in {cardgroup.name}</h1>
-      <CardsClient cardgroupId={id} initialCards={cards} />
+      <CardsClient
+        cardgroupId={id}
+        initialEdges={initialEdges}
+        initialPageInfo={initialPageInfo}
+        initialTotalCount={initialTotalCount}
+      />
     </main>
   );
 }

--- a/frontend/src/app/cardgroups/[id]/cards/queries.ts
+++ b/frontend/src/app/cardgroups/[id]/cards/queries.ts
@@ -1,5 +1,8 @@
 import { graphql } from "@/generated";
 
+/** Default page size for the cards-by-cardgroup connection. Must stay in sync between SSR seed and client useQuery/cache reads. */
+export const CARDS_PAGE_SIZE = 20;
+
 // Forward-only Relay connection query for paginating cards within a cardgroup.
 export const CardsByCardgroupConnectionQuery = graphql(`
   query CardsByCardgroupConnection(

--- a/frontend/src/app/cardgroups/[id]/cards/queries.ts
+++ b/frontend/src/app/cardgroups/[id]/cards/queries.ts
@@ -1,0 +1,31 @@
+import { graphql } from "@/generated";
+
+// Forward-only Relay connection query for paginating cards within a cardgroup.
+export const CardsByCardgroupConnectionQuery = graphql(`
+  query CardsByCardgroupConnection(
+    $cardgroupId: ID!
+    $first: Int
+    $after: ID
+  ) {
+    cardsByCardgroupConnection(cardgroupId: $cardgroupId, first: $first, after: $after) {
+      edges {
+        cursor
+        node {
+          id
+          front
+          back
+          due
+          state
+          cardgroupId
+        }
+      }
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+    }
+  }
+`);

--- a/frontend/src/app/cardgroups/[id]/cards/queries.ts
+++ b/frontend/src/app/cardgroups/[id]/cards/queries.ts
@@ -3,7 +3,6 @@ import { graphql } from "@/generated";
 /** Default page size for the cards-by-cardgroup connection. Must stay in sync between SSR seed and client useQuery/cache reads. */
 export const CARDS_PAGE_SIZE = 20;
 
-// Forward-only Relay connection query for paginating cards within a cardgroup.
 export const CardsByCardgroupConnectionQuery = graphql(`
   query CardsByCardgroupConnection(
     $cardgroupId: ID!

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -29,6 +29,7 @@
   "include": [
     "next-env.d.ts",
     "src/**/*",
+    "__tests__/**/*",
     "next.config.ts",
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts"

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
   },
   test: {
     environment: "node",
-    include: ["src/**/*.test.{ts,tsx}"],
+    include: ["src/**/*.test.{ts,tsx}", "__tests__/**/*.test.{ts,tsx}"],
     // Expose vitest globals (describe, it, afterEach, etc.) so that
     // @testing-library/react can hook into afterEach for automatic DOM cleanup.
     globals: true,

--- a/schema/schema.graphql
+++ b/schema/schema.graphql
@@ -165,7 +165,10 @@ type CardEdge {
 type CardConnection {
   edges: [CardEdge!]!
   pageInfo: PageInfo!
-  """Total count of cards in the cardgroup, regardless of page window."""
+  """
+  Total cards in the cardgroup, regardless of page window.
+  Backed by a separate COUNT(*); intended for cardgroups up to ~10k cards.
+  """
   totalCount: Int!
 }
 

--- a/schema/schema.graphql
+++ b/schema/schema.graphql
@@ -132,11 +132,61 @@ type UpdateCardPayload {
   card: Card!
 }
 
+"""Sort order for paginated queries."""
+enum SortOrder {
+  ASC
+  DESC
+}
+
+"""Field to order Cards by in paginated queries."""
+enum CardOrderBy {
+  ID
+  CREATED_AT
+  UPDATED_AT
+  DUE
+}
+
+"""Relay PageInfo describing whether more pages exist on either side and the boundary cursors."""
+type PageInfo {
+  hasNextPage: Boolean!
+  hasPreviousPage: Boolean!
+  startCursor: ID
+  endCursor: ID
+}
+
+"""One element in a CardConnection."""
+type CardEdge {
+  """Opaque cursor for this position. Currently equal to node.id."""
+  cursor: ID!
+  node: Card!
+}
+
+"""Paginated list of Cards (Relay Connection)."""
+type CardConnection {
+  edges: [CardEdge!]!
+  pageInfo: PageInfo!
+  """Total count of cards in the cardgroup, regardless of page window."""
+  totalCount: Int!
+}
+
 extend type Query {
   """Single card by ID. Returns UNAUTHENTICATED for non-owners (existence is not leaked)."""
   card(id: ID!): Card
   """All cards in a cardgroup owned by the authenticated caller."""
-  cardsByCardgroup(cardgroupId: ID!): [Card!]!
+  cardsByCardgroup(cardgroupId: ID!): [Card!]! @deprecated(reason: "Use cardsByCardgroupConnection")
+  """
+  Paginated cards in a cardgroup. Forward pagination uses (first, after); backward uses (last, before).
+  Cursor is the card UUID. Default page size is 20; max is 100.
+  """
+  cardsByCardgroupConnection(
+    cardgroupId: ID!,
+    first: Int,
+    after: ID,
+    last: Int,
+    before: ID,
+    orderBy: CardOrderBy = ID,
+    orderDirection: SortOrder = ASC
+  ): CardConnection!
 }
 
 extend type Mutation {


### PR DESCRIPTION
Closes #47

## Summary

Replaces the unbounded `cardsByCardgroup(cardgroupId: ID!): [Card!]!` query with a Relay-style `cardsByCardgroupConnection` that supports forward (`first` / `after`) and backward (`last` / `before`) cursor pagination, and rewires the cardgroup cards page to consume it via Apollo `fetchMore` behind an `IntersectionObserver` sentinel. The legacy field is preserved with `@deprecated` so existing callers keep working until they migrate. Cursors are bare card UUIDs (no base64) and `(orderField, id)` tuple comparison keeps page boundaries deterministic even when the order column has duplicate values. Ships full repository and usecase coverage on the backend, plus a connection client test file (`__tests__/cards-pagination.test.tsx`) that simulates the observer firing across multiple pages.

## Background / Motivation

- The previous `cardsByCardgroup` query loaded every card in a cardgroup in a single response. With the swiping-flashcard target of multi-thousand-card decks per group, that response would inflate Apollo cache memory and increase first-paint payload by orders of magnitude. Cursor pagination caps the page payload at 20 rows by default (max 100) and delegates the "more pages?" signal to a dedicated boolean rather than client-side length comparisons.
- Cursors are bare card UUIDs, not base64-encoded JSON. The UUID is already an opaque `ID` from the schema's perspective, base64 would only obscure that opacity without adding security, and the bare form means `WHERE id > $cursor` (or `<` for DESC) translates one-to-one from the cursor field. The trade-off is that the cursor cannot encode a stable "version" — but the schema commits to using `cardsByCardgroupConnection` as the only paginated entry point, so version drift is constrained at the schema layer.
- Ordering is always a lexicographic `(orderField, id)` tuple. When `orderBy = ID`, the SQL collapses to `id <op> $cursor`. For `CREATED_AT` / `UPDATED_AT` / `DUE`, the `WHERE` clause becomes `(field <op> $val OR (field = $val AND id <op> $cursorID))` so two cards with the same `due` timestamp do not skip a page boundary or repeat. The `id` secondary key is always populated; the date fields are populated only when the active `orderBy` requires them. The repository emits an explicit error when a cursor lacks the column the active `orderBy` needs — this is treated as a caller bug, not a benign empty value, because the usecase layer is responsible for hydrating cursors before calling.
- `totalCount` is a separate `COUNT(*)` query scoped to the cardgroup, deliberately not folded into the page query. This keeps the page query's `LIMIT` clause selective and the `COUNT(*)` plan simple enough to use the `cardgroup_id` index on its own. The trade-off (acceptable up to ~10k cards/group, revisit if the cap grows) is documented inline in `schema/schema.graphql` so an unsuspecting consumer learns the cost up-front.
- Backward pagination (`last` / `before`) is implemented by inverting the SQL direction, fetching the trailing rows, and reversing the slice in memory before returning. This avoids `OFFSET` (which costs O(n) on the rejected rows) and keeps a single SQL shape for both directions; the cost is a small in-memory reverse on a bounded slice.
- The "+1 fetch" trick detects `hasNextPage` / `hasPreviousPage` deterministically: the usecase asks the repository for `first+1` (or `last+1`) rows, then trims the extra row before returning to the resolver. Without the trick, a `hasNextPage` signal would either require a second query or a `COUNT(*)`-with-`WHERE` matching the cursor predicate — both more expensive. `repository.pageCap = usecase.maxPageSize + 1 = 101` so the +1 still fits within the repo-side clamp when the caller asks for the documented max.
- Cursor cross-cardgroup leakage is rejected. When the resolver receives an `after` cursor whose card belongs to a different cardgroup, the usecase returns `BAD_USER_INPUT` with the same error shape as a missing cursor — never `NOT_FOUND`, never a leak that the cursor exists somewhere in the system. The unit test (`cursor cross-cardgroup`) pins this so a future refactor cannot regress to leaking existence.
- Three layers each carry their own typed enum (`model.CardOrderBy` from gqlgen → `usecase.CardOrderBy` → `repository.CardOrderBy`). The repository never imports the GraphQL model package, the usecase never references `gorm` types, and the resolver translates between the two via tiny `toUsecase*` helpers in `backend/graph/resolver/helpers.go`. A future rename in the schema or in the SQL column does not ripple across layers.
- The frontend client guards `fetchMore` against re-entry with a `useRef<boolean>` rather than React state. State would force a re-render that itself can re-trigger the observer mid-fetch on slow connections; the ref is a synchronous flag that the observer callback can check without participating in the render cycle. On `fetchMore` rejection, the observer loop is paused (the effect early-exits while `fetchMoreError != null`) and the page renders an inline "Retry" button — without the pause, an infinite-loop of failing observer callbacks would burn the API quota under a transient backend error.
- The Apollo cache update for `createCard` uses `cache.modify` keyed on the `cardsByCardgroupConnection` field name plus a substring match on the encoded `cardgroupId`. The previous `writeQuery` approach assumed exactly one cached query shape; with pagination args the same field can have many cache entries (different `first`, different `after`), so `modify` is the only update primitive that can append the new edge to every cached page for the relevant cardgroup at once.

## Changes

### Schema additions

- `schema/schema.graphql`: adds `enum SortOrder { ASC, DESC }`, `enum CardOrderBy { ID, CREATED_AT, UPDATED_AT, DUE }`, `type PageInfo { hasNextPage, hasPreviousPage, startCursor, endCursor }`, `type CardEdge { cursor, node }`, and `type CardConnection { edges, pageInfo, totalCount }`. Adds `Query.cardsByCardgroupConnection(cardgroupId, first, after, last, before, orderBy = ID, orderDirection = ASC): CardConnection!`. The legacy `cardsByCardgroup` is kept with `@deprecated(reason: "Use cardsByCardgroupConnection")` rather than deleted, so existing GraphQL consumers compile until they migrate.
- The `totalCount` field carries an inline schema doc-comment naming the separate-`COUNT(*)` cost trade-off and the ~10k cards/group operating envelope, so consumers see the cost story without reading the resolver.

### Repository pagination layer

- `backend/internal/repository/card.go`: introduces `type CardOrderBy string` (allowlist: `id` / `created_at` / `updated_at` / `due`), `type SortOrder string` (`ASC` / `DESC`), and `type CardCursor struct { ID; Due, CreatedAt, UpdatedAt *time.Time }`. The cursor only populates the time field relevant to the active `orderBy`; `ID` is always populated as the secondary tuple key.
- New `CardRepository.FindPageByCardgroup(ctx, cardgroupID, after, before, first, last, orderBy, dir)` returns `([]*domain.Card, totalCount int64, error)`. Internally clamps `first` / `last` to `[0, pageCap]` (pageCap = 101 = usecase max + 1), short-circuits the row fetch when both are zero, and emits the deterministic SQL via `orderClause` + `cursorWhere` helpers. Backward paging inverts direction via `invertDir`, fetches with the inverted clause, and reverses the slice before returning so the caller always observes ascending-by-effective-direction rows.
- `cursorWhere` emits the tuple-compare predicate; `cursorFieldValue` returns an explicit error when the cursor lacks the time column for the active `orderBy` (caller bug, not a soft-fail).

### Usecase layer

- `backend/internal/usecase/card.go`: adds typed `CardOrderBy` / `SortOrder` enums (mirroring the schema, isolated from the gqlgen-generated model package), `CardConnectionInput` / `CardConnectionOutput` DTOs, and constants `defaultPageSize = 20` / `maxPageSize = 100`.
- `CardUsecase.ListCardsByCardgroupConnection(ctx, in)`: authenticates via `auth.UserFrom`, authorises the cardgroup via the existing `authorizeCardgroup` seam, validates `orderBy` / `orderDirection` against the typed allowlists, resolves `first` / `last` (rejecting both-set with `BAD_USER_INPUT`), and resolves cursors via `resolveCursor`. `resolveCursor` rejects cursors pointing at a card in a different cardgroup with `BAD_USER_INPUT` — the same shape as a missing cursor, so existence is not leaked.
- The "+1 fetch" trick: when the caller asks for `first = N`, the repository is asked for `N+1`; the usecase trims the trailing row and sets `HasNext = true` when present. Backward paging mirrors with the leading row. `HasPrev` defaults to `(after != nil)` for forward paging; `HasNext` defaults to `(before != nil)` for backward paging, which keeps the boundary booleans monotonic across paging direction changes.

### Resolver wiring

- `backend/graph/resolver/schema.resolvers.go`: adds `CardsByCardgroupConnection` resolver that translates GraphQL nullable inputs into `usecase.CardConnectionInput` and wraps the result via `toCardConnectionModel`. The legacy `CardsByCardgroup` resolver is unchanged.
- `backend/graph/resolver/helpers.go`: adds `toUsecaseCardOrderBy` / `toUsecaseSortOrder` (direct casts because the string values are identical) and `toCardConnectionModel`, which converts cursor strings via the `c.ID` field, populates `PageInfo` (using `nil` for empty cursors so the GraphQL nullable type reads correctly), and writes `int(out.TotalCount)` into the `Int!` schema field.

### Frontend connection client

- `frontend/src/app/cardgroups/[id]/cards/queries.ts` (new): forward-only `CardsByCardgroupConnection` operation requesting `edges { cursor, node { id, front, back, due, state, cardgroupId } }`, `pageInfo { hasNextPage, hasPreviousPage, startCursor, endCursor }`, and `totalCount`. Backward paging is not exposed in the UI yet; the schema supports it for future use.
- `frontend/src/app/cardgroups/[id]/cards/page.tsx`: switches the RSC first-page fetch from `CardsByCardgroupQuery` to `CardsByCardgroupConnectionQuery` (page size 20) and forwards `initialEdges` / `initialPageInfo` / `initialTotalCount` to the client component, so the first paint is server-rendered and Apollo hydrates from the same cache shape on mount.
- `frontend/src/app/cardgroups/[id]/cards/cards-client.tsx`: switches from local `useState<Card[]>` to `useQuery(CardsByCardgroupConnectionDocument, { fetchPolicy: "cache-first", notifyOnNetworkStatusChange: true })`. `requestNextPage` is gated by `fetchingRef` (synchronous re-entry guard, not React state) and short-circuits when `pageInfo.hasNextPage === false`. The `IntersectionObserver` effect observes a sentinel `<div>` after the last edge; on `fetchMore` rejection the effect early-exits while `fetchMoreError` is non-null and the page renders an inline "Retry" button that calls `requestNextPage` directly. The `createCard` cache update switches from `cache.writeQuery` (single shape) to `cache.modify` keyed on the `cardsByCardgroupConnection` field with a substring match on the encoded `cardgroupId`, so the new edge is appended to every cached page belonging to the active cardgroup.
- The `Apollo.gql` `NewCardFields` fragment writes the new card into the cache before the `cache.modify` callback runs, so `toReference({ __typename: "Card", id })` resolves to a real entity even on the first create after a cold cache.

### Tests

- `backend/internal/repository/card_pagination_test.go` (new): testcontainer-backed coverage for `FindPageByCardgroup`. Exercises forward paging across multiple pages, backward paging via inverted direction, empty cardgroup, single-page edge, `due` tie-break (two cards with identical `due` timestamps must not repeat or skip across the boundary), cross-cardgroup cursor rejection, and cursor hydration when `orderBy != ID`.
- `backend/internal/usecase/card_test.go`: adds `ListCardsByCardgroupConnection` table tests covering the auth gate (unauthenticated → `UNAUTHENTICATED`), the cardgroup authorise gate (different owner → `FORBIDDEN`), `first`+`last` simultaneous specification (→ `BAD_USER_INPUT`), `orderBy` allowlist enforcement, the +1-fetch boundary (`HasNext` flips at the right page), and cursor cross-cardgroup rejection.
- `frontend/__tests__/cards-pagination.test.tsx` (new): drives the connection client through Apollo `MockedProvider` mocks for two consecutive pages, simulates `IntersectionObserver` firing via a hand-rolled mock, asserts the second-page edges are appended to the rendered list, and asserts `hasNextPage = false` halts further observer-driven fetches. Wired into `vitest.config.ts` and `tsconfig.json` so the new `__tests__` directory participates in `pnpm test` and type-checking.
- `frontend/src/app/cardgroups/[id]/cards/cards-client.test.tsx`: extended to cover the in-flight `fetchingRef` guard (a second observer firing during an in-progress fetch is a no-op) and the `fetchMore` error banner + Retry button path.
- `frontend/src/app/cardgroups/[id]/cards/page.test.tsx`: updated for the connection-shaped initial-data props.

## Verification

After merge, the following should all hold:

- `grep -nE "type CardConnection|type CardEdge|type PageInfo|enum CardOrderBy|enum SortOrder" schema/schema.graphql` matches five distinct lines.
- `grep -n "cardsByCardgroupConnection" schema/schema.graphql` matches once and the surrounding `Query.cardsByCardgroup` field carries `@deprecated(reason:`.
- `grep -nE "func \(r \*cardRepo\) FindPageByCardgroup" backend/internal/repository/card.go` matches once. `grep -n "pageCap" backend/internal/repository/card.go` matches and the constant is set to `101` (one above the documented `maxPageSize = 100` so the +1-fetch trick still fits the clamp).
- `grep -nE "func \(u \*CardUsecase\) ListCardsByCardgroupConnection" backend/internal/usecase/card.go` matches once. `grep -nE "defaultPageSize|maxPageSize" backend/internal/usecase/card.go` shows `20` and `100`.
- `grep -n "cursor not found" backend/internal/usecase/card.go` matches at least once (cursor cross-cardgroup leakage rejection uses the same shape as a missing cursor).
- `grep -n "fetchingRef" frontend/src/app/cardgroups/\[id\]/cards/cards-client.tsx` matches and the surrounding effect early-exits on `fetchMoreError != null`.
- `grep -n "cardsByCardgroupConnection" frontend/src/app/cardgroups/\[id\]/cards/cards-client.tsx` shows the `cache.modify` block (no `cache.writeQuery` for the connection field — `grep -c "writeQuery" frontend/src/app/cardgroups/\[id\]/cards/cards-client.tsx` returns `0`).
- gqlgen + frontend codegen are clean: `cd backend && go tool gqlgen generate` produces no diff in `backend/graph/{generated,model}/`. `cd frontend && pnpm codegen` produces no diff in `frontend/src/generated/`.
- Schema deprecation reaches the generated types: `grep -nE "deprecated" frontend/src/generated/graphql.ts` includes the `cardsByCardgroup` legacy field.

## Test plan

- [ ] `cd backend && go vet ./... && go build ./...` passes.
- [ ] `cd backend && go test -v -race -covermode=atomic -coverprofile=coverage.out ./...` passes; `repository/card_pagination_test.go` and the `usecase/card_test.go` connection tests all run, including the cursor cross-cardgroup, backward-paging, due-tie-break, and cursor-hydration cases.
- [ ] `cd frontend && pnpm lint && pnpm typecheck && pnpm build && pnpm test` passes; `__tests__/cards-pagination.test.tsx` fires the observer mock twice and asserts the second page is appended; `cards-client.test.tsx` covers the fetchingRef in-flight guard and the fetchMore error + Retry path.
- [ ] Manual: seed a cardgroup with 30+ cards; navigate to `/cardgroups/<id>/cards`; the first 20 render server-side (page source contains 20 `<li>` rows); scrolling to the sentinel triggers exactly one more network request fetching cards 21–30 (`first = 20`, `after = <last cursor>`); scrolling further with `hasNextPage = false` issues no further requests.
- [ ] Manual: in browser devtools, throttle the network to "Slow 3G" and force a `fetchMore` failure (e.g., toggle the dev server off mid-scroll). The page renders the inline error banner with a Retry button; the observer does not refire while the error is on screen; clicking Retry resumes paging once the network is back.
- [ ] Manual: a non-owner user signed in via Supabase requesting `cardsByCardgroupConnection` for someone else's cardgroup receives a `FORBIDDEN`-coded error.
- [ ] Cursor cross-cardgroup: passing an `after` cursor whose card belongs to a different cardgroup returns `BAD_USER_INPUT` with the same shape as a missing cursor (no `NOT_FOUND` leak).
- [ ] `EXPLAIN ANALYZE` on `cardsByCardgroupConnection` against a cardgroup with 1k+ cards confirms an index scan on `(cardgroup_id, id)` for the default `orderBy = ID, ASC`.
- [ ] `grep -rnP "[\x{3040}-\x{30ff}\x{4e00}-\x{9fff}]" --include="*.go" --include="*.ts" --include="*.tsx" --include="*.graphql" --include="*.sql" --include="*.md" docs backend/internal backend/cmd backend/graph frontend/src` returns nothing. `grep -rnE "PR[0-9]+" docs backend/internal backend/cmd backend/graph frontend/src` returns nothing (issue link `#47` lives only in the PR body, not in committed text).