### PR TITLE
ci(frontend): track Codecov coverage with per-flag thresholds

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -73,8 +73,30 @@ jobs:
       - name: Build
         run: pnpm --filter frontend build
 
-      - name: Vitest
-        run: pnpm --filter frontend --if-present test
+      - name: Vitest with coverage
+        run: pnpm --filter frontend --if-present test:coverage
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: frontend-coverage
+          path: frontend/coverage/
+          retention-days: 14
+
+      - name: Upload coverage to Codecov
+        id: codecov
+        uses: codecov/codecov-action@v6
+        continue-on-error: true
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: frontend/coverage/lcov.info
+          flags: frontend
+          working-directory: frontend
+          fail_ci_if_error: true
+
+      - name: Warn on Codecov upload failure
+        if: steps.codecov.outcome == 'failure'
+        run: echo "::warning::Codecov upload failed — coverage trend may not be updated"
 
   deploy:
     name: Deploy to Vercel

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 [![backend CI](https://github.com/yasuflatland-lf/flamingo-armond/actions/workflows/backend.yml/badge.svg?branch=main)](https://github.com/yasuflatland-lf/flamingo-armond/actions/workflows/backend.yml)
 [![frontend CI](https://github.com/yasuflatland-lf/flamingo-armond/actions/workflows/frontend.yml/badge.svg?branch=main)](https://github.com/yasuflatland-lf/flamingo-armond/actions/workflows/frontend.yml)
-[![codecov](https://codecov.io/gh/yasuflatland-lf/flamingo-armond/branch/main/graph/badge.svg)](https://codecov.io/gh/yasuflatland-lf/flamingo-armond)
+[![codecov backend](https://codecov.io/gh/yasuflatland-lf/flamingo-armond/branch/main/graph/badge.svg?flag=backend)](https://codecov.io/gh/yasuflatland-lf/flamingo-armond)
+[![codecov frontend](https://codecov.io/gh/yasuflatland-lf/flamingo-armond/branch/main/graph/badge.svg?flag=frontend)](https://codecov.io/gh/yasuflatland-lf/flamingo-armond)
 
 🦩 Swiping Flashcard app — a Go (Echo) backend, a Next.js 16 frontend, and a shared GraphQL schema, with Supabase for Postgres + Auth.
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,33 @@
+coverage:
+  status:
+    project:
+      backend:
+        target: 70%
+        threshold: 1%
+        flags: [backend]
+      frontend:
+        target: 70%
+        threshold: 1%
+        flags: [frontend]
+    patch:
+      backend:
+        target: 70%
+        flags: [backend]
+      frontend:
+        target: 70%
+        flags: [frontend]
+
+flags:
+  backend:
+    paths:
+      - backend/
+    carryforward: true
+  frontend:
+    paths:
+      - frontend/
+    carryforward: true
+
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: false

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -43,6 +43,7 @@ Coverage goes to **both Codecov and a GHA artifact**:
 
 - Codecov — trend visualization, PR comments.
 - GHA artifact (`coverage.out` + `coverage.html`, 14-day retention) — backup for Codecov outages, and a human-readable HTML report via `go tool cover -html`.
+- The frontend coverage artifact (`frontend-coverage`, lcov + HTML) follows the same `retention-days: 14` rule.
 
 `retention-days: 14` is tighter than the 90-day default to save storage; extend it if needed.
 
@@ -137,6 +138,25 @@ CI sets dummy values at the job level for every required var:
 | `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Same as above. |
 
 No request is made during the build, so dummy values only need to satisfy the Zod schema (e.g. `z.string().url()` requires a URL-shaped string). Do **not** remove any of these: each missing env reintroduces a silent-fail shape the validation was designed to prevent. When a new required var is added to `src/env.ts`, add a corresponding dummy to the workflow's `env:` block.
+
+### Frontend Codecov upload
+
+The frontend coverage pipeline mirrors the backend's three-piece pattern
+(see § "Codecov upload must not be a silent failure") and is wired with
+`flags: frontend` so Codecov reports backend and frontend separately.
+
+Two frontend-specific notes:
+
+- `working-directory: frontend` is required on `codecov-action` because
+  Vitest writes lcov entries as `src/...`, relative to the frontend
+  workspace. Without the working-directory hint, the entries land in
+  Codecov without a `frontend/` prefix and silently fall outside the
+  `flags.frontend.paths` filter declared in `codecov.yml`.
+- `carryforward: true` per flag (in `codecov.yml`) is non-negotiable while
+  CI is path-scoped: a backend-only PR never uploads frontend coverage,
+  and Codecov would otherwise treat the missing upload as 0%, failing the
+  frontend project status. See `docs/ci.md` § "Workflow scope and
+  concurrency" for why path-scoping is the canonical pattern.
 
 ### Frontend deploy job
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,8 @@
     "codegen:watch": "graphql-codegen --config codegen.ts --watch",
     "prebuild": "pnpm codegen",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@apollo/client": "^4.1.9",

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -26,9 +26,14 @@ export default defineConfig({
     },
     coverage: {
       provider: "v8",
-      reporter: ["text", "html"],
-      include: ["src/lib/**/*.ts"],
-      exclude: ["src/generated/**", "src/**/*.test.{ts,tsx}"],
+      reporter: ["text", "html", "lcov"],
+      include: ["src/**/*.{ts,tsx}"],
+      exclude: [
+        "src/generated/**",
+        "src/**/*.test.{ts,tsx}",
+        "src/__test-setup__/**",
+        "src/__mocks__/**",
+      ],
     },
   },
 });


### PR DESCRIPTION
## Summary

Wires the frontend Vitest coverage pipeline into Codecov as a separate `frontend` flag, alongside the existing backend `backend` flag, so the two suites are tracked independently rather than blended into a single repo-level number. Lands a root-level `codecov.yml` that pins per-flag targets (70% / 1% threshold) with `carryforward: true`, broadens the Vitest coverage scope from `src/lib/**/*.ts` to `src/**/*.{ts,tsx}` so app-router pages and hooks count toward the trend, and splits the README badge into two per-flag badges so both lines move under their own paths.

## Background / Motivation

- The frontend pipeline produced a Vitest run but never uploaded coverage to Codecov, so the `frontend CI` badge passed while the Codecov badge reflected backend-only data — making the repo look healthier than it was for any frontend regression. Wiring the upload behind a `frontend` flag (rather than mixing into the existing backend report) keeps the per-language trend lines independent so a backend coverage drop does not mask a frontend regression and vice versa.
- `codecov.yml` carries `carryforward: true` on each flag because both CI workflows are path-scoped (`backend.yml` only triggers on `backend/**`, `frontend.yml` only on `frontend/**`). Without carryforward, a backend-only PR would never upload a frontend report, and Codecov would treat the missing upload as 0% and fail the `frontend` project status — giving a permanent red check on every backend PR. Carryforward reuses the most recent successful frontend upload from the target branch, which is the canonical pattern when CI is path-scoped.
- `working-directory: frontend` on `codecov-action` is required because Vitest writes lcov entries as `src/...` (relative to the `frontend/` workspace, not the repo root). Without the working-directory hint, the entries reach Codecov without a `frontend/` prefix and silently fall outside the `flags.frontend.paths: [frontend/]` filter declared in `codecov.yml` — the upload looks successful but contributes zero coverage, which is exactly the silent-failure shape the per-flag setup is meant to prevent.
- The Vitest `coverage.include` pattern was previously narrowed to `src/lib/**/*.ts`, which excluded the entire app router (`src/app/**`), components (`src/components/**`), and hooks. Broadening to `src/**/*.{ts,tsx}` aligns the measured surface with what users actually exercise and gives the 70% target a meaningful denominator. The new `exclude` entries (`__test-setup__/`, `__mocks__/`) keep test scaffolding out of the coverage denominator so a future scaffolding-only PR cannot artificially shift the percentage.
- The Codecov upload step uses `continue-on-error: true` paired with `fail_ci_if_error: true`, plus a follow-up `Warn on Codecov upload failure` step that emits `::warning::` on the run. This combination treats a Codecov outage as a soft failure (CI stays green so a backend-passing PR is still mergeable) but surfaces the failure as an annotation so reviewers see that the coverage trend is stale rather than silently accepting a missing upload. The pattern matches the backend's existing Codecov step.
- The README badge is split into two per-flag badges (`flag=backend`, `flag=frontend`) rather than kept as a single repo-level badge so each language has its own visible trend line and a regression in one suite turns its own badge red. The single-badge form would have averaged the two flags together, which defeats the purpose of separating them in `codecov.yml`.

## Changes

### Codecov configuration

- `codecov.yml` (new, repo root): defines `flags.backend` and `flags.frontend` with `paths: [backend/]` / `paths: [frontend/]` and `carryforward: true` on both. `coverage.status.project` and `coverage.status.patch` each declare per-flag `target: 70%` / `threshold: 1%` blocks so Codecov posts separate `codecov/project/backend` and `codecov/project/frontend` checks. `comment.layout` is `"reach, diff, flags, files"` so the per-flag breakdown is visible in PR comments; `comment.require_changes: false` keeps the comment present even when coverage does not move.

### Frontend test / coverage scope

- `frontend/vitest.config.ts`: `coverage.include` broadened from `["src/lib/**/*.ts"]` to `["src/**/*.{ts,tsx}"]`. `coverage.exclude` adds `src/__test-setup__/**` and `src/__mocks__/**` so test scaffolding does not enter the denominator. `coverage.reporter` adds `"lcov"` alongside the existing `text` and `html` reporters so the Codecov upload step has a Codecov-native input.
- `frontend/package.json`: adds `"test:coverage": "vitest run --coverage"` so CI and local runs share a single entry point. The pre-existing `"test": "vitest run"` is unchanged so any local script that already calls `pnpm test` keeps working.

### CI upload

- `.github/workflows/frontend.yml`: replaces the `Vitest` step (`pnpm --filter frontend --if-present test`) with `Vitest with coverage` (`pnpm --filter frontend --if-present test:coverage`). Adds `Upload coverage artifact` (`actions/upload-artifact@v7`, `name: frontend-coverage`, `path: frontend/coverage/`, `retention-days: 14`) so the lcov + HTML report is downloadable from the run page when Codecov is degraded. Adds `Upload coverage to Codecov` (`codecov/codecov-action@v6`) with `files: frontend/coverage/lcov.info`, `flags: frontend`, `working-directory: frontend`, `fail_ci_if_error: true`, and `continue-on-error: true` so an upload failure does not break the merge gate. Adds `Warn on Codecov upload failure` (`if: steps.codecov.outcome == 'failure'`) emitting a `::warning::` annotation so the soft failure is visible in the run UI.

### Documentation

- `README.md`: replaces the single repo-level `codecov` badge with two per-flag badges (`flag=backend` and `flag=frontend`), each pointing at `branch/main/graph/badge.svg?flag=<name>` so the badges track the same trend lines surfaced in `codecov.yml`.
- `docs/ci.md`: under the existing coverage-artifact note, adds a one-line entry noting that the frontend artifact follows the same `retention-days: 14` rule. Adds a new `### Frontend Codecov upload` subsection that records (a) the `working-directory: frontend` requirement and the lcov-path-prefix reason, (b) the `carryforward: true` rationale tied to path-scoped CI, with a forward pointer to the existing § "Workflow scope and concurrency" so the two notes stay cross-referenced.

## Verification

After merge, the following should all hold:

- `grep -nE "flags:\s*frontend" .github/workflows/frontend.yml` matches once on the `Upload coverage to Codecov` step. `grep -n "working-directory: frontend" .github/workflows/frontend.yml` matches once on the same step.
- `grep -nE "fail_ci_if_error:\s*true" .github/workflows/frontend.yml` matches once and is paired with `continue-on-error: true` so an upload failure does not break the merge gate.
- `grep -nE "flags:\s*\[backend\]|flags:\s*\[frontend\]" codecov.yml` matches four times (two `coverage.status.project` blocks plus two `coverage.status.patch` blocks).
- `grep -nE "carryforward:\s*true" codecov.yml` matches exactly twice (once per flag).
- `grep -nE "target:\s*70%" codecov.yml` matches four times (project x2 + patch x2).
- `grep -nE '"test:coverage":\s*"vitest run --coverage"' frontend/package.json` matches once.
- `grep -nE 'include:\s*\["src/\*\*/\*\.\{ts,tsx\}"\]' frontend/vitest.config.ts` matches once and the surrounding `exclude` block names `src/__test-setup__/**` and `src/__mocks__/**`.
- `grep -nE "reporter:.*\"lcov\"" frontend/vitest.config.ts` matches once.
- `grep -nE "flag=backend|flag=frontend" README.md` matches twice (one per badge).
- `grep -n "### Frontend Codecov upload" docs/ci.md` matches once.
- On Codecov, the repository page shows two flags (`backend`, `frontend`) and the status checks `codecov/project/backend` and `codecov/project/frontend` post separately on every PR.

## Test plan

- [ ] CI run on this branch shows the new `Vitest with coverage`, `Upload coverage artifact`, and `Upload coverage to Codecov` steps complete successfully; the `Warn on Codecov upload failure` step does not fire.
- [ ] After merge to `main`, the Codecov dashboard shows the `frontend` flag with at least one report; the `codecov/project/frontend` status check posts on subsequent PRs and reports against the 70% target.
- [ ] On a backend-only follow-up PR (no `frontend/**` changes), `frontend.yml` does not run, but Codecov's `frontend` project status still posts a passing check via `carryforward: true` from the most recent `main` upload.
- [ ] Locally: `pnpm --filter frontend install && pnpm --filter frontend test:coverage` produces `frontend/coverage/lcov.info`. The lcov entries start with `SF:src/...` (relative to `frontend/`, not the repo root) — this is the path shape that `working-directory: frontend` translates for Codecov.
- [ ] Locally: opening `frontend/coverage/index.html` shows coverage rows for files under `src/app/**`, `src/components/**`, and `src/hooks/**` (not just `src/lib/**`) — the broadened include pattern is in effect.
- [ ] Both README badges (`codecov backend`, `codecov frontend`) render with their own percentages on the rendered README once at least one upload of each flag has landed on `main`.
- [ ] Language-policy grep clean: `grep -rnP "[\x{3040}-\x{30ff}\x{4e00}-\x{9fff}]" --include="*.go" --include="*.ts" --include="*.tsx" --include="*.graphql" --include="*.sql" --include="*.md" docs backend/internal backend/cmd backend/graph frontend/src` returns nothing. `grep -rnE "PR[0-9]+" docs backend/internal backend/cmd backend/graph frontend/src` returns nothing.
