### PR TITLE
feat: add admin dictionary import flow end-to-end

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -199,8 +199,9 @@ func run(ctx context.Context, logger *slog.Logger) error {
 	cardgroupUC := usecase.NewCardgroupUsecase(cardgroupRepo)
 	cardUC := usecase.NewCardUsecase(db.GORM, cardRepo, cardgroupRepo)
 	swipeUC := usecase.NewSwipeUsecase(db.GORM, cardRepo, cardgroupRepo, swipeRecordRepo, service.NewFSRSScheduler(), swipeNextBatchSize(logger))
+	dictionaryUC := usecase.NewDictionaryUsecase(authSvc, cardRepo, db.GORM)
 
-	resolvers := resolver.NewResolver(userUC, cardgroupUC, cardUC, swipeUC, authSvc)
+	resolvers := resolver.NewResolver(userUC, cardgroupUC, cardUC, swipeUC, authSvc, dictionaryUC)
 	pingHandler := ping.New(pingRecordRepo, pingToken)
 	// newRouter must be called after telemetry.Init: the otelhttp handler it
 	// constructs reads otel.GetTextMapPropagator() eagerly. See comment above

--- a/backend/cmd/server/main_test.go
+++ b/backend/cmd/server/main_test.go
@@ -141,7 +141,7 @@ func noopAuthMW(next echo.HandlerFunc) echo.HandlerFunc {
 
 func newTestServer(t *testing.T) *httptest.Server {
 	t.Helper()
-	ts := httptest.NewServer(newRouter(resolver.NewResolver(nil, nil, nil, nil, nil), noopAuthMW, nil, nil, nil, nil, ping.New(nil, "test-token")))
+	ts := httptest.NewServer(newRouter(resolver.NewResolver(nil, nil, nil, nil, nil, nil), noopAuthMW, nil, nil, nil, nil, ping.New(nil, "test-token")))
 	t.Cleanup(ts.Close)
 	return ts
 }
@@ -451,7 +451,7 @@ func newGraphQLTestServerWithUserRepo(t *testing.T, f *jwtFixture, userRepo repo
 	cardUC := usecase.NewCardUsecase(db.GORM, cardRepo, cardgroupRepo)
 	swipeUC := usecase.NewSwipeUsecase(db.GORM, cardRepo, cardgroupRepo, swipeRecordRepo, service.NewFSRSScheduler(), 10)
 	pingRecordRepo := repository.NewPingRecordRepository(db.GORM)
-	e := newRouter(resolver.NewResolver(userUC, cardgroupUC, cardUC, swipeUC, nil), mw, userRepo, roleRepo, cardgroupRepo, cardRepo, ping.New(pingRecordRepo, "test-token"), swipeRecordRepo)
+	e := newRouter(resolver.NewResolver(userUC, cardgroupUC, cardUC, swipeUC, nil, nil), mw, userRepo, roleRepo, cardgroupRepo, cardRepo, ping.New(pingRecordRepo, "test-token"), swipeRecordRepo)
 
 	ts := httptest.NewServer(e)
 	t.Cleanup(ts.Close)
@@ -688,7 +688,7 @@ func TestComplexityLimit_Rejects(t *testing.T) {
 
 func newIntrospectionTestServer(t *testing.T) *httptest.Server {
 	t.Helper()
-	ts := httptest.NewServer(newGraphQLServer(resolver.NewResolver(nil, nil, nil, nil, nil)))
+	ts := httptest.NewServer(newGraphQLServer(resolver.NewResolver(nil, nil, nil, nil, nil, nil)))
 	t.Cleanup(ts.Close)
 	return ts
 }

--- a/backend/graph/resolver/card_resolvers_test.go
+++ b/backend/graph/resolver/card_resolvers_test.go
@@ -84,7 +84,7 @@ func newCardSrv(
 	tx func(context.Context, func(*gorm.DB) error) error,
 ) *handler.Server {
 	cardUC := usecase.NewCardUsecaseWithTx(cardRepo, cgRepo, tx)
-	r := resolver.NewResolver(nil, nil, cardUC, nil, nil)
+	r := resolver.NewResolver(nil, nil, cardUC, nil, nil, nil)
 	srv := handler.New(generated.NewExecutableSchema(generated.Config{Resolvers: r}))
 	srv.AddTransport(transport.POST{})
 	return srv

--- a/backend/graph/resolver/dictionary_resolver_test.go
+++ b/backend/graph/resolver/dictionary_resolver_test.go
@@ -29,7 +29,7 @@ func (m *mockUserRoleRepository) HasRole(_ context.Context, _, _ string) (bool, 
 // newDictOnlySrv builds a server with only AuthSvc wired; only the
 // validateDictionary resolver is exercised here.
 func newDictOnlySrv(roleRepo repository.UserRoleRepository) *handler.Server {
-	r := resolver.NewResolver(nil, nil, nil, nil, auth.NewService(roleRepo))
+	r := resolver.NewResolver(nil, nil, nil, nil, auth.NewService(roleRepo), nil)
 	srv := handler.New(generated.NewExecutableSchema(generated.Config{Resolvers: r}))
 	srv.AddTransport(transport.POST{})
 	return srv

--- a/backend/graph/resolver/dictionary_resolver_test.go
+++ b/backend/graph/resolver/dictionary_resolver_test.go
@@ -14,6 +14,7 @@ import (
 	"backend/internal/auth"
 	"backend/internal/gqlerr"
 	"backend/internal/repository"
+	"backend/internal/usecase"
 )
 
 // mockUserRoleRepository satisfies repository.UserRoleRepository.
@@ -189,5 +190,112 @@ func TestValidateDictionary_IsAdminDeadlineExceeded(t *testing.T) {
 	code := errCode(t, resp)
 	if code != string(gqlerr.CodeCancelled) {
 		t.Fatalf("expected %s, got %q", gqlerr.CodeCancelled, code)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// mockDictionaryUsecase — in-package stub for upsertDictionary resolver tests.
+// ---------------------------------------------------------------------------
+
+// mockDictionaryUsecase satisfies usecase.DictionaryUsecase. The returnOut
+// field drives the happy-path result; the returnErr field, when non-nil, is
+// returned instead so the error-propagation path can be exercised.
+type mockDictionaryUsecase struct {
+	returnOut usecase.UpsertDictionaryOutput
+	returnErr error
+}
+
+func (m *mockDictionaryUsecase) Upsert(_ context.Context, _ usecase.UpsertDictionaryInput) (usecase.UpsertDictionaryOutput, error) {
+	if m.returnErr != nil {
+		return usecase.UpsertDictionaryOutput{}, m.returnErr
+	}
+	return m.returnOut, nil
+}
+
+// newUpsertDictSrv builds a server with the given DictionaryUsecase mock
+// wired. AuthSvc is not needed for the upsertDictionary resolver because the
+// usecase mock already encapsulates auth logic.
+func newUpsertDictSrv(dictUC usecase.DictionaryUsecase) *handler.Server {
+	r := resolver.NewResolver(nil, nil, nil, nil, nil, dictUC)
+	srv := handler.New(generated.NewExecutableSchema(generated.Config{Resolvers: r}))
+	srv.AddTransport(transport.POST{})
+	return srv
+}
+
+// upsertDictionaryMutation returns a JSON-encoded GraphQL mutation body for
+// upsertDictionary. Both arguments are embedded literally so the caller must
+// escape them if needed; for test use the values are always safe ASCII/base64.
+func upsertDictionaryMutation(cardgroupID, payload string) string {
+	return `{"query":"mutation { upsertDictionary(input: { cardgroupId: \"` + cardgroupID + `\", payload: \"` + payload + `\" }) { inserted updated errors { line message } } }"}`
+}
+
+// TestUpsertDictionary_ResolverHappyPath drives the full GraphQL transport with
+// a mock DictionaryUsecase that returns a known UpsertDictionaryOutput. The
+// test asserts the GraphQL response payload's inserted, updated, and errors[0]
+// fields, which catches int64->int truncation regressions and nil-vs-empty
+// errors slice mismatches.
+func TestUpsertDictionary_ResolverHappyPath(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockDictionaryUsecase{
+		returnOut: usecase.UpsertDictionaryOutput{
+			Inserted: 7,
+			Updated:  3,
+			Errors: []usecase.DictionaryValidationError{
+				{Line: 5, Message: "duplicate"},
+			},
+		},
+	}
+	srv := newUpsertDictSrv(mock)
+	payload := base64.StdEncoding.EncodeToString([]byte("apple fruit"))
+	resp := gqlRequest(t, srv, authedCtx("u1"), upsertDictionaryMutation("cg-1", payload))
+
+	if _, hasErrs := resp["errors"]; hasErrs {
+		t.Fatalf("unexpected top-level errors: %v", resp["errors"])
+	}
+	data, _ := resp["data"].(map[string]any)
+	result, _ := data["upsertDictionary"].(map[string]any)
+	if result == nil {
+		t.Fatalf("expected data.upsertDictionary, got nil; response: %v", resp)
+	}
+
+	// JSON numbers decode as float64 in Go's encoding/json.
+	if got, _ := result["inserted"].(float64); int(got) != 7 {
+		t.Fatalf("expected inserted=7, got %v", result["inserted"])
+	}
+	if got, _ := result["updated"].(float64); int(got) != 3 {
+		t.Fatalf("expected updated=3, got %v", result["updated"])
+	}
+
+	errs, _ := result["errors"].([]any)
+	if len(errs) != 1 {
+		t.Fatalf("expected 1 error entry, got %d: %v", len(errs), errs)
+	}
+	firstErr, _ := errs[0].(map[string]any)
+	if line, _ := firstErr["line"].(float64); int(line) != 5 {
+		t.Fatalf("expected errors[0].line=5, got %v", firstErr["line"])
+	}
+	if msg, _ := firstErr["message"].(string); msg != "duplicate" {
+		t.Fatalf("expected errors[0].message=%q, got %q", "duplicate", msg)
+	}
+}
+
+// TestUpsertDictionary_ResolverPropagatesForbidden verifies that when the
+// DictionaryUsecase returns a FORBIDDEN gqlerror (e.g. non-admin caller), the
+// resolver propagates it unchanged and the GraphQL response carries
+// errors[0].extensions.code == "FORBIDDEN".
+func TestUpsertDictionary_ResolverPropagatesForbidden(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockDictionaryUsecase{
+		returnErr: gqlerr.NewForbidden("admin role required"),
+	}
+	srv := newUpsertDictSrv(mock)
+	payload := base64.StdEncoding.EncodeToString([]byte("apple fruit"))
+	resp := gqlRequest(t, srv, authedCtx("u1"), upsertDictionaryMutation("cg-1", payload))
+
+	code := errCode(t, resp)
+	if code != string(gqlerr.CodeForbidden) {
+		t.Fatalf("expected %s, got %q", gqlerr.CodeForbidden, code)
 	}
 }

--- a/backend/graph/resolver/resolver.go
+++ b/backend/graph/resolver/resolver.go
@@ -6,11 +6,12 @@ import (
 )
 
 type Resolver struct {
-	User        *usecase.UserUsecase
-	CardgroupUC *usecase.CardgroupUsecase
-	CardUC      *usecase.CardUsecase
-	SwipeUC     *usecase.SwipeUsecase
-	AuthSvc     *auth.Service
+	User         *usecase.UserUsecase
+	CardgroupUC  *usecase.CardgroupUsecase
+	CardUC       *usecase.CardUsecase
+	SwipeUC      *usecase.SwipeUsecase
+	AuthSvc      *auth.Service
+	DictionaryUC usecase.DictionaryUsecase
 }
 
 // NewResolver wires every Resolver dependency at construction time. Tests
@@ -22,12 +23,14 @@ func NewResolver(
 	cardUC *usecase.CardUsecase,
 	swipeUC *usecase.SwipeUsecase,
 	authSvc *auth.Service,
+	dictionaryUC usecase.DictionaryUsecase,
 ) *Resolver {
 	return &Resolver{
-		User:        user,
-		CardgroupUC: cardgroupUC,
-		CardUC:      cardUC,
-		SwipeUC:     swipeUC,
-		AuthSvc:     authSvc,
+		User:         user,
+		CardgroupUC:  cardgroupUC,
+		CardUC:       cardUC,
+		SwipeUC:      swipeUC,
+		AuthSvc:      authSvc,
+		DictionaryUC: dictionaryUC,
 	}
 }

--- a/backend/graph/resolver/schema.resolvers.go
+++ b/backend/graph/resolver/schema.resolvers.go
@@ -139,6 +139,29 @@ func (r *mutationResolver) HandleSwipe(ctx context.Context, input model.HandleSw
 	return toSwipeResponseModel(out), nil
 }
 
+// UpsertDictionary is the resolver for the upsertDictionary field.
+func (r *mutationResolver) UpsertDictionary(ctx context.Context, input model.UpsertDictionaryInput) (*model.UpsertDictionaryPayload, error) {
+	out, err := r.DictionaryUC.Upsert(ctx, usecase.UpsertDictionaryInput{
+		CardgroupID: input.CardgroupID,
+		Payload:     input.Payload,
+	})
+	if err != nil {
+		return nil, err
+	}
+	errs := make([]*model.DictionaryValidationError, 0, len(out.Errors))
+	for _, e := range out.Errors {
+		errs = append(errs, &model.DictionaryValidationError{
+			Line:    e.Line,
+			Message: e.Message,
+		})
+	}
+	return &model.UpsertDictionaryPayload{
+		Inserted: int(out.Inserted),
+		Updated:  int(out.Updated),
+		Errors:   errs,
+	}, nil
+}
+
 // Health is the resolver for the health field.
 func (r *queryResolver) Health(ctx context.Context) (string, error) {
 	return "ok", nil

--- a/backend/graph/resolver/user_test.go
+++ b/backend/graph/resolver/user_test.go
@@ -44,7 +44,7 @@ func ptr(s string) *string { return &s }
 // given mock repository.
 func newServer(mock *mockUserRepository) *handler.Server {
 	uc := usecase.NewUserUsecase(mock)
-	r := resolver.NewResolver(uc, nil, nil, nil, nil)
+	r := resolver.NewResolver(uc, nil, nil, nil, nil, nil)
 	srv := handler.New(generated.NewExecutableSchema(generated.Config{Resolvers: r}))
 	srv.AddTransport(transport.POST{})
 	return srv

--- a/backend/internal/database/cards_upsert_index_test.go
+++ b/backend/internal/database/cards_upsert_index_test.go
@@ -133,16 +133,20 @@ func TestCardsUpsertIndex_DuplicatesBlockMigration(t *testing.T) {
 
 	// Step 4: clean up the duplicates, then re-apply so the DB ends in the
 	// migrated-up state for the rest of the suite. golang-migrate marks the
-	// failed version dirty; force the version back to the previous one
-	// before re-running.
+	// failed migration dirty and records its version number. Clearing the
+	// dirty flag alone leaves the version pointing at the failed migration,
+	// so the subsequent Steps(1) call finds no successor file and errors.
+	// Force the version back to the predecessor (20260502130000) first —
+	// that is the idiomatic golang-migrate recovery path.
 	for _, id := range []string{cardA, cardB} {
 		if _, err := sqlDB.ExecContext(ctx, `DELETE FROM public.cards WHERE id = $1`, id); err != nil {
 			t.Fatalf("cleanup card %s: %v", id, err)
 		}
 	}
-	if _, err := sqlDB.ExecContext(ctx,
-		`UPDATE public.schema_migrations SET dirty = false WHERE dirty = true`); err != nil {
-		t.Fatalf("reset dirty flag: %v", err)
+	// 20260502130000 is the timestamp of the last successfully applied
+	// migration before 20260503000000_add_cards_upsert_index.
+	if err := database.MigrateForceForTest(testDSN, 20260502130000); err != nil {
+		t.Fatalf("force version to predecessor: %v", err)
 	}
 	if err := database.MigrateStepsForTest(testDSN, 1); err != nil {
 		t.Fatalf("migrate up 1 step (restore): %v", err)

--- a/backend/internal/database/cards_upsert_index_test.go
+++ b/backend/internal/database/cards_upsert_index_test.go
@@ -1,0 +1,153 @@
+package database_test
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/rotisserie/eris"
+
+	"backend/internal/database"
+)
+
+// indexExists returns true if a relation named indexName exists in
+// public's pg_indexes. Used by both directions of the migration test.
+func indexExists(t *testing.T, ctx context.Context, sqlDB *sql.DB, indexName string) bool {
+	t.Helper()
+	var count int
+	if err := sqlDB.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM pg_indexes WHERE schemaname = 'public' AND indexname = $1`,
+		indexName,
+	).Scan(&count); err != nil {
+		t.Fatalf("query pg_indexes for %q: %v", indexName, err)
+	}
+	return count == 1
+}
+
+// insertCardForUpsertTest inserts a minimal valid card row directly via SQL,
+// bypassing any application-layer constraint logic. The returned id lets
+// the caller clean up afterwards.
+func insertCardForUpsertTest(ctx context.Context, sqlDB *sql.DB, cardgroupID, front string) (string, error) {
+	id := uuid.NewString()
+	if _, err := sqlDB.ExecContext(ctx, insertCardSQL(),
+		id, cardgroupID, front, "Back", time.Now().UTC()); err != nil {
+		return "", eris.Wrap(err, "test: insert card")
+	}
+	return id, nil
+}
+
+// TestCardsUpsertIndex_CleanDBSucceeds exercises the happy path: with no
+// duplicates present, the migration creates uq_cards_cardgroup_front, and
+// the down migration removes it. The test leaves the DB in the migrated-up
+// state so subsequent tests in the package see a consistent schema.
+func TestCardsUpsertIndex_CleanDBSucceeds(t *testing.T) {
+	ctx := context.Background()
+	db := openMigratedDB(t)
+	defer db.Close()
+
+	sqlDB := sqlDBForTest(t, db)
+	const indexName = "uq_cards_cardgroup_front"
+
+	if !indexExists(t, ctx, sqlDB, indexName) {
+		t.Fatalf("expected %q to exist after migrate up, but it does not", indexName)
+	}
+
+	// Roll the index migration back and confirm the index is gone.
+	if err := database.MigrateStepsForTest(testDSN, -1); err != nil {
+		t.Fatalf("migrate down 1 step: %v", err)
+	}
+	if indexExists(t, ctx, sqlDB, indexName) {
+		t.Fatalf("expected %q to be dropped after migrate down, but it still exists", indexName)
+	}
+
+	// Re-apply so the DB ends in the migrated-up state for the rest of the suite.
+	if err := database.MigrateStepsForTest(testDSN, 1); err != nil {
+		t.Fatalf("migrate up 1 step (restore): %v", err)
+	}
+	if !indexExists(t, ctx, sqlDB, indexName) {
+		t.Fatalf("expected %q to be re-created after migrate up, but it is missing", indexName)
+	}
+}
+
+// TestCardsUpsertIndex_DuplicatesBlockMigration verifies the pre-check in
+// the up migration: with a (cardgroup_id, front) duplicate present, the
+// migration must abort with a message that calls out the duplication and
+// the offending column names.
+func TestCardsUpsertIndex_DuplicatesBlockMigration(t *testing.T) {
+	ctx := context.Background()
+	db := openMigratedDB(t)
+	defer db.Close()
+
+	sqlDB := sqlDBForTest(t, db)
+	const indexName = "uq_cards_cardgroup_front"
+
+	// Step 1: roll the index migration back so we can plant a duplicate
+	// the unique index would otherwise reject. The index must be absent
+	// for the INSERT below to succeed.
+	if err := database.MigrateStepsForTest(testDSN, -1); err != nil {
+		t.Fatalf("migrate down 1 step: %v", err)
+	}
+	if indexExists(t, ctx, sqlDB, indexName) {
+		t.Fatalf("expected %q to be absent after migrate down, but it still exists", indexName)
+	}
+
+	// Step 2: create an owner + cardgroup, then insert two cards with
+	// identical (cardgroup_id, front).
+	ownerID := insertAuthUserForAdmin(t, ctx, db)
+	groupID := uuid.NewString()
+	if _, err := sqlDB.ExecContext(ctx,
+		`INSERT INTO public.cardgroups (id, owner_id, name) VALUES ($1, $2, $3)`,
+		groupID, ownerID, "upsert-index-test-group"); err != nil {
+		t.Fatalf("insert cardgroup: %v", err)
+	}
+
+	const dupFront = "duplicate-front-text"
+	cardA, err := insertCardForUpsertTest(ctx, sqlDB, groupID, dupFront)
+	if err != nil {
+		t.Fatalf("insert first card: %v", err)
+	}
+	cardB, err := insertCardForUpsertTest(ctx, sqlDB, groupID, dupFront)
+	if err != nil {
+		t.Fatalf("insert duplicate card: %v", err)
+	}
+
+	// Step 3: re-apply the migration. The pre-check should abort it with
+	// a message that names the problem and the columns.
+	upErr := database.MigrateStepsForTest(testDSN, 1)
+	if upErr == nil {
+		t.Fatal("expected migrate up to fail due to duplicate rows, got nil")
+	}
+	msg := strings.ToLower(upErr.Error())
+	if !strings.Contains(msg, "duplicate") {
+		t.Errorf("error %q does not mention 'duplicate'", upErr.Error())
+	}
+	if !strings.Contains(msg, "cardgroup_id") || !strings.Contains(msg, "front") {
+		t.Errorf("error %q does not mention column names cardgroup_id and front", upErr.Error())
+	}
+	if indexExists(t, ctx, sqlDB, indexName) {
+		t.Fatalf("expected %q to remain absent after a failed migration, but it exists", indexName)
+	}
+
+	// Step 4: clean up the duplicates, then re-apply so the DB ends in the
+	// migrated-up state for the rest of the suite. golang-migrate marks the
+	// failed version dirty; force the version back to the previous one
+	// before re-running.
+	for _, id := range []string{cardA, cardB} {
+		if _, err := sqlDB.ExecContext(ctx, `DELETE FROM public.cards WHERE id = $1`, id); err != nil {
+			t.Fatalf("cleanup card %s: %v", id, err)
+		}
+	}
+	if _, err := sqlDB.ExecContext(ctx,
+		`UPDATE public.schema_migrations SET dirty = false WHERE dirty = true`); err != nil {
+		t.Fatalf("reset dirty flag: %v", err)
+	}
+	if err := database.MigrateStepsForTest(testDSN, 1); err != nil {
+		t.Fatalf("migrate up 1 step (restore): %v", err)
+	}
+	if !indexExists(t, ctx, sqlDB, indexName) {
+		t.Fatalf("expected %q to exist after restore migrate up, but it is missing", indexName)
+	}
+}

--- a/backend/internal/database/export_test.go
+++ b/backend/internal/database/export_test.go
@@ -1,5 +1,36 @@
 package database
 
+import (
+	"github.com/golang-migrate/migrate/v4"
+	"github.com/golang-migrate/migrate/v4/source/iofs"
+	"github.com/rotisserie/eris"
+)
+
 // ConvertSchemeForMigrateForTest exposes convertSchemeForMigrate to the
 // external _test package without widening the public API surface.
 var ConvertSchemeForMigrateForTest = convertSchemeForMigrate
+
+// MigrateStepsForTest applies n migration steps against the embedded source.
+// Positive n applies that many up steps; negative n rolls that many down.
+// Used by migration-level tests that need to exercise both directions
+// (e.g. assert that down really removes a created index).
+//
+// Test-only: not part of the package public API.
+func MigrateStepsForTest(url string, n int) error {
+	src, err := iofs.New(migrationsFS, "migrations")
+	if err != nil {
+		return eris.Wrap(err, "database: open migrations FS")
+	}
+	defer src.Close()
+
+	m, err := migrate.NewWithSourceInstance("iofs", src, convertSchemeForMigrate(url))
+	if err != nil {
+		return eris.Wrap(err, "database: init migrate (test)")
+	}
+	defer m.Close()
+
+	if err := m.Steps(n); err != nil {
+		return eris.Wrapf(err, "database: migrate steps %d (test)", n)
+	}
+	return nil
+}

--- a/backend/internal/database/export_test.go
+++ b/backend/internal/database/export_test.go
@@ -34,3 +34,29 @@ func MigrateStepsForTest(url string, n int) error {
 	}
 	return nil
 }
+
+// MigrateForceForTest forcibly sets the schema_migrations version to the given
+// value and clears the dirty flag. This is the idiomatic golang-migrate
+// recovery mechanism after a failed migration leaves the database in a dirty
+// state. version must be the integer timestamp of the last successfully applied
+// migration (i.e. the predecessor of the failed one).
+//
+// Test-only: not part of the package public API.
+func MigrateForceForTest(url string, version int) error {
+	src, err := iofs.New(migrationsFS, "migrations")
+	if err != nil {
+		return eris.Wrap(err, "database: open migrations FS")
+	}
+	defer src.Close()
+
+	m, err := migrate.NewWithSourceInstance("iofs", src, convertSchemeForMigrate(url))
+	if err != nil {
+		return eris.Wrap(err, "database: init migrate (test)")
+	}
+	defer m.Close()
+
+	if err := m.Force(version); err != nil {
+		return eris.Wrapf(err, "database: migrate force version %d (test)", version)
+	}
+	return nil
+}

--- a/backend/internal/database/migrations/20260503000000_add_cards_upsert_index.down.sql
+++ b/backend/internal/database/migrations/20260503000000_add_cards_upsert_index.down.sql
@@ -1,0 +1,14 @@
+-- Reverse of 20260503000000_add_cards_upsert_index.up.sql.
+--
+-- Dropping the unique index is sufficient: the pre-check in the up
+-- migration only blocked migration on duplicates, it did not modify
+-- existing rows, so there is nothing to restore on the data side.
+--
+-- golang-migrate pgx/v5 does NOT auto-wrap migrations in a transaction;
+-- the explicit BEGIN/COMMIT below ensures all-or-nothing execution.
+
+BEGIN;
+
+DROP INDEX IF EXISTS public.uq_cards_cardgroup_front;
+
+COMMIT;

--- a/backend/internal/database/migrations/20260503000000_add_cards_upsert_index.up.sql
+++ b/backend/internal/database/migrations/20260503000000_add_cards_upsert_index.up.sql
@@ -1,11 +1,11 @@
 -- Add a unique index on public.cards (cardgroup_id, front) to support
 -- the upsertDictionary pipeline's ON CONFLICT (cardgroup_id, front) clause.
 --
--- Pre-check: this migration aborts loudly if any (cardgroup_id, front)
--- duplicate already exists, listing the offending pairs via RAISE NOTICE
--- so operators can resolve the data before re-running. Without the
--- pre-check, CREATE UNIQUE INDEX would fail with a less helpful pg error
--- and leave golang-migrate in a dirty state.
+-- Pre-check: enumerate every offending (cardgroup_id, front) pair via RAISE NOTICE so
+-- operators can resolve them in a single pass. CREATE UNIQUE INDEX alone would only
+-- name one offending pair on first failure. Both this RAISE EXCEPTION and the index
+-- failure leave golang-migrate in a dirty state — recovery via Force(predecessor) is
+-- standard.
 --
 -- Column ordering (cardgroup_id, front) matches the upsert's WHERE
 -- prefix: cardgroup_id is the high-cardinality leading key, so the index

--- a/backend/internal/database/migrations/20260503000000_add_cards_upsert_index.up.sql
+++ b/backend/internal/database/migrations/20260503000000_add_cards_upsert_index.up.sql
@@ -1,0 +1,57 @@
+-- Add a unique index on public.cards (cardgroup_id, front) to support
+-- the upsertDictionary pipeline's ON CONFLICT (cardgroup_id, front) clause.
+--
+-- Pre-check: this migration aborts loudly if any (cardgroup_id, front)
+-- duplicate already exists, listing the offending pairs via RAISE NOTICE
+-- so operators can resolve the data before re-running. Without the
+-- pre-check, CREATE UNIQUE INDEX would fail with a less helpful pg error
+-- and leave golang-migrate in a dirty state.
+--
+-- Column ordering (cardgroup_id, front) matches the upsert's WHERE
+-- prefix: cardgroup_id is the high-cardinality leading key, so the index
+-- is also useful for per-group lookups, while still enforcing per-group
+-- "front" uniqueness.
+--
+-- golang-migrate pgx/v5 does NOT auto-wrap migrations in a transaction;
+-- the explicit BEGIN/COMMIT below ensures all-or-nothing execution.
+
+BEGIN;
+
+-- Step 1: pre-check for existing duplicates and abort with a clear error.
+DO $$
+DECLARE
+    dup_count integer;
+    dup_row   record;
+BEGIN
+    SELECT COUNT(*) INTO dup_count
+    FROM (
+        SELECT cardgroup_id, front
+        FROM public.cards
+        GROUP BY cardgroup_id, front
+        HAVING COUNT(*) > 1
+    ) AS dups;
+
+    IF dup_count > 0 THEN
+        FOR dup_row IN
+            SELECT cardgroup_id, front, COUNT(*) AS n
+            FROM public.cards
+            GROUP BY cardgroup_id, front
+            HAVING COUNT(*) > 1
+            ORDER BY cardgroup_id, front
+        LOOP
+            RAISE NOTICE 'duplicate (cardgroup_id, front): cardgroup_id=% front=% count=%',
+                dup_row.cardgroup_id, dup_row.front, dup_row.n;
+        END LOOP;
+        RAISE EXCEPTION
+            'cards table has duplicate (cardgroup_id, front) rows: % rows; resolve before adding the unique index',
+            dup_count;
+    END IF;
+END
+$$;
+
+-- Step 2: create the unique index. IF NOT EXISTS keeps the migration safe
+-- to re-run on a partially-applied database.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_cards_cardgroup_front
+    ON public.cards (cardgroup_id, front);
+
+COMMIT;

--- a/backend/internal/loader/user_test.go
+++ b/backend/internal/loader/user_test.go
@@ -133,6 +133,9 @@ func (r *countingCardRepo) Delete(_ context.Context, _ string) error {
 func (r *countingCardRepo) DeleteByIDsTx(_ context.Context, _ *gorm.DB, _ string, _ []string) (int64, error) {
 	panic("countingCardRepo.DeleteByIDsTx not configured")
 }
+func (r *countingCardRepo) UpsertManyTx(_ context.Context, _ *gorm.DB, _ []*domain.Card) (repository.UpsertManyTxResult, error) {
+	panic("countingCardRepo.UpsertManyTx not configured")
+}
 
 func emptyCardRepo() *countingCardRepo {
 	return &countingCardRepo{

--- a/backend/internal/repository/card.go
+++ b/backend/internal/repository/card.go
@@ -476,6 +476,13 @@ func (r *cardRepo) UpsertManyTx(ctx context.Context, tx *gorm.DB, cards []*domai
 		return UpsertManyTxResult{}, eris.Wrap(err, "repository: upsert many cards")
 	}
 
+	if len(rows) != len(cards) {
+		return UpsertManyTxResult{}, eris.Errorf(
+			"repository: upsert many cards: returned %d rows, expected %d",
+			len(rows), len(cards),
+		)
+	}
+
 	var res UpsertManyTxResult
 	for _, r := range rows {
 		if r.Inserted {

--- a/backend/internal/repository/card.go
+++ b/backend/internal/repository/card.go
@@ -3,8 +3,10 @@ package repository
 import (
 	"context"
 	"errors"
+	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/rotisserie/eris"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
@@ -99,6 +101,11 @@ type CardRepository interface {
 	// slice GORM v2 omits the `WHERE id IN (?)` clause altogether, which would
 	// convert this `Delete` into an unbounded mass delete — far worse than a slow scan.
 	DeleteByIDsTx(ctx context.Context, tx *gorm.DB, ownerID string, ids []string) (int64, error)
+	// UpsertManyTx upserts cards by (cardgroup_id, front). Existing rows have
+	// their `back` and `updated_at` columns overwritten; new rows are inserted
+	// using the FSRS state values supplied on each domain.Card. Returns the
+	// per-row split between Inserted and Updated. Empty input is a no-op.
+	UpsertManyTx(ctx context.Context, tx *gorm.DB, cards []*domain.Card) (UpsertManyTxResult, error)
 }
 
 type cardRepo struct{ db *gorm.DB }
@@ -380,6 +387,104 @@ func (r *cardRepo) Delete(ctx context.Context, id string) error {
 		return ErrNotFound
 	}
 	return nil
+}
+
+// UpsertManyTxResult counts the outcome of an UpsertManyTx call.
+// Inserted+Updated equals len(input cards) for a successful call.
+type UpsertManyTxResult struct {
+	Inserted int64
+	Updated  int64
+}
+
+// UpsertManyTx upserts cards by (cardgroup_id, front). Existing rows have
+// `back` and `updated_at` overwritten; new rows are inserted with the supplied
+// FSRS state values. The conflict key requires the unique index
+// `uq_cards_cardgroup_front` (migration 20260503000000).
+//
+// Counts are derived per-row from the PostgreSQL system column `xmax`. A
+// freshly inserted row has `xmax = 0` in the same transaction; a row updated
+// via `ON CONFLICT DO UPDATE` has `xmax` set to the current transaction id.
+// The RETURNING clause exposes `xmax = 0 AS inserted` so the split can be
+// computed without a second query.
+//
+// The method is transaction-safe: it operates on the supplied tx only and
+// never reaches back to r.db. Empty input returns a zero-valued result and
+// no error.
+func (r *cardRepo) UpsertManyTx(ctx context.Context, tx *gorm.DB, cards []*domain.Card) (UpsertManyTxResult, error) {
+	if len(cards) == 0 {
+		return UpsertManyTxResult{}, nil
+	}
+
+	// Pre-fill any missing IDs so the RETURNING clause classifies every row
+	// the caller handed us. UUID v7 is the project-wide convention; v4
+	// fallback is rejected per .claude/rules/go-library-gotchas.md.
+	for _, c := range cards {
+		if strings.TrimSpace(c.ID) == "" {
+			id, err := uuid.NewV7()
+			if err != nil {
+				return UpsertManyTxResult{}, eris.Wrap(err, "repository: upsert many cards: uuid v7")
+			}
+			c.ID = id.String()
+		}
+	}
+
+	// Build a single multi-row INSERT. Each card contributes 15 placeholders
+	// matching the column list below.
+	const columns = `(id, cardgroup_id, front, back, due, stability, difficulty,
+                    elapsed_days, scheduled_days, reps, lapses, state, last_review,
+                    created_at, updated_at)`
+	const rowPH = "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+
+	var sb strings.Builder
+	sb.WriteString("INSERT INTO cards ")
+	sb.WriteString(columns)
+	sb.WriteString(" VALUES ")
+	args := make([]any, 0, len(cards)*15)
+	for i, c := range cards {
+		if i > 0 {
+			sb.WriteString(", ")
+		}
+		sb.WriteString(rowPH)
+		args = append(args,
+			c.ID,
+			c.CardgroupID,
+			c.Front,
+			c.Back,
+			c.FSRS.Due,
+			c.FSRS.Stability,
+			c.FSRS.Difficulty,
+			c.FSRS.ElapsedDays,
+			c.FSRS.ScheduledDays,
+			c.FSRS.Reps,
+			c.FSRS.Lapses,
+			int(c.FSRS.State),
+			c.FSRS.LastReview,
+			c.CreatedAt,
+			c.UpdatedAt,
+		)
+	}
+	sb.WriteString(`
+        ON CONFLICT (cardgroup_id, front)
+        DO UPDATE SET back = EXCLUDED.back, updated_at = now()
+        RETURNING (xmax = 0) AS inserted`)
+
+	type returnedRow struct {
+		Inserted bool `gorm:"column:inserted"`
+	}
+	var rows []returnedRow
+	if err := tx.WithContext(ctx).Raw(sb.String(), args...).Scan(&rows).Error; err != nil {
+		return UpsertManyTxResult{}, eris.Wrap(err, "repository: upsert many cards")
+	}
+
+	var res UpsertManyTxResult
+	for _, r := range rows {
+		if r.Inserted {
+			res.Inserted++
+		} else {
+			res.Updated++
+		}
+	}
+	return res, nil
 }
 
 func (r *cardRepo) DeleteByIDsTx(ctx context.Context, tx *gorm.DB, ownerID string, ids []string) (int64, error) {

--- a/backend/internal/repository/card_pagination_test.go
+++ b/backend/internal/repository/card_pagination_test.go
@@ -2,6 +2,7 @@ package repository_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -11,7 +12,7 @@ import (
 	"backend/internal/repository"
 )
 
-// insertCards creates n cards with deterministic Front values ("c0".."cn-1").
+// insertCards creates n cards with deterministic Front values ("front-0".."front-n-1").
 // CreatedAt is staggered so insertion order matches creation order. Due is set
 // to now+i*hour so DUE-ordered tests have a clear ASC sequence.
 func insertCards(t *testing.T, ctx context.Context, repo repository.CardRepository, cgID string, n int) []*domain.Card {
@@ -19,7 +20,7 @@ func insertCards(t *testing.T, ctx context.Context, repo repository.CardReposito
 	now := time.Now().UTC()
 	cards := make([]*domain.Card, n)
 	for i := 0; i < n; i++ {
-		c := newCard(cgID, "front", "back")
+		c := newCard(cgID, fmt.Sprintf("front-%d", i), "back")
 		// Stagger timestamps by 1 hour so ordering is unambiguous.
 		c.CreatedAt = now.Add(time.Duration(i) * time.Hour)
 		c.UpdatedAt = c.CreatedAt
@@ -245,7 +246,7 @@ func TestCardRepository_FindPageByCardgroup_OrderByDue_TieBreakOnEqualDue(t *tes
 	now := time.Now().UTC()
 	cards := make([]*domain.Card, 3)
 	for i := 0; i < 3; i++ {
-		c := newCard(cg.ID, "front", "back")
+		c := newCard(cg.ID, fmt.Sprintf("front-%d", i), "back")
 		c.CreatedAt = now
 		c.UpdatedAt = now
 		c.FSRS.Due = now
@@ -348,4 +349,3 @@ func sortByID(cards []*domain.Card) []*domain.Card {
 	}
 	return out
 }
-

--- a/backend/internal/repository/card_upsert_test.go
+++ b/backend/internal/repository/card_upsert_test.go
@@ -1,0 +1,164 @@
+package repository_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"backend/internal/domain"
+	"backend/internal/repository"
+)
+
+// TestCardRepository_UpsertManyTx covers the four scenarios called out in the
+// PR-07 plan: pure inserts, mixed insert+update, empty input, and the
+// per-cardgroup uniqueness boundary. The unique index that backs the
+// ON CONFLICT clause is migration 20260503000000_add_cards_upsert_index.
+func TestCardRepository_UpsertManyTx(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	t.Run("all inserts", func(t *testing.T) {
+		t.Parallel()
+		repo := repository.NewCardRepository(testDB.GORM)
+		ownerID := insertAuthUser(t, ctx)
+		cg := insertCardgroup(t, ctx, ownerID)
+
+		cards := []*domain.Card{
+			newCard(cg.ID, "front-1", "back-1"),
+			newCard(cg.ID, "front-2", "back-2"),
+			newCard(cg.ID, "front-3", "back-3"),
+			newCard(cg.ID, "front-4", "back-4"),
+			newCard(cg.ID, "front-5", "back-5"),
+		}
+
+		var result repository.UpsertManyTxResult
+		err := testDB.GORM.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+			var txErr error
+			result, txErr = repo.UpsertManyTx(ctx, tx, cards)
+			return txErr
+		})
+		require.NoError(t, err)
+		require.Equal(t, int64(5), result.Inserted)
+		require.Equal(t, int64(0), result.Updated)
+
+		stored, err := repo.FindByCardgroup(ctx, cg.ID)
+		require.NoError(t, err)
+		require.Len(t, stored, 5)
+	})
+
+	t.Run("mixed inserts and updates", func(t *testing.T) {
+		t.Parallel()
+		repo := repository.NewCardRepository(testDB.GORM)
+		ownerID := insertAuthUser(t, ctx)
+		cg := insertCardgroup(t, ctx, ownerID)
+
+		// Pre-insert three rows whose fronts will overlap with the upsert batch.
+		pre1 := newCard(cg.ID, "shared-1", "old-back-1")
+		pre2 := newCard(cg.ID, "shared-2", "old-back-2")
+		pre3 := newCard(cg.ID, "shared-3", "old-back-3")
+		for _, c := range []*domain.Card{pre1, pre2, pre3} {
+			require.NoError(t, repo.Create(ctx, c))
+		}
+
+		// Upsert batch: 3 same fronts (with new backs) + 2 brand new fronts.
+		// The IDs supplied here for the existing fronts MUST be ignored by the
+		// ON CONFLICT path — the conflict key is (cardgroup_id, front).
+		upsertBatch := []*domain.Card{
+			newCard(cg.ID, "shared-1", "new-back-1"),
+			newCard(cg.ID, "shared-2", "new-back-2"),
+			newCard(cg.ID, "shared-3", "new-back-3"),
+			newCard(cg.ID, "fresh-1", "fresh-back-1"),
+			newCard(cg.ID, "fresh-2", "fresh-back-2"),
+		}
+
+		var result repository.UpsertManyTxResult
+		err := testDB.GORM.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+			var txErr error
+			result, txErr = repo.UpsertManyTx(ctx, tx, upsertBatch)
+			return txErr
+		})
+		require.NoError(t, err)
+		require.Equal(t, int64(2), result.Inserted)
+		require.Equal(t, int64(3), result.Updated)
+
+		// All three existing rows have their `back` text replaced; the row id
+		// (the original PK) stays intact because ON CONFLICT only updates the
+		// `back` and `updated_at` columns.
+		for _, original := range []*domain.Card{pre1, pre2, pre3} {
+			got, err := repo.FindByID(ctx, original.ID)
+			require.NoError(t, err)
+			require.Equal(t, original.Front, got.Front)
+			require.NotEqual(t, original.Back, got.Back, "back must be overwritten")
+		}
+
+		// Final cardgroup row count: 3 pre-existing + 2 newly inserted.
+		stored, err := repo.FindByCardgroup(ctx, cg.ID)
+		require.NoError(t, err)
+		require.Len(t, stored, 5)
+	})
+
+	t.Run("empty input is a no-op", func(t *testing.T) {
+		t.Parallel()
+		repo := repository.NewCardRepository(testDB.GORM)
+		ownerID := insertAuthUser(t, ctx)
+		cg := insertCardgroup(t, ctx, ownerID)
+
+		var result repository.UpsertManyTxResult
+		err := testDB.GORM.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+			var txErr error
+			result, txErr = repo.UpsertManyTx(ctx, tx, nil)
+			return txErr
+		})
+		require.NoError(t, err)
+		require.Equal(t, repository.UpsertManyTxResult{}, result)
+
+		stored, err := repo.FindByCardgroup(ctx, cg.ID)
+		require.NoError(t, err)
+		require.Empty(t, stored)
+	})
+
+	t.Run("same front in different cardgroups coexist", func(t *testing.T) {
+		t.Parallel()
+		repo := repository.NewCardRepository(testDB.GORM)
+		ownerID := insertAuthUser(t, ctx)
+		cgA := insertCardgroup(t, ctx, ownerID)
+		cgB := insertCardgroup(t, ctx, ownerID)
+
+		// Insert (group A, "hello").
+		err := testDB.GORM.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+			_, txErr := repo.UpsertManyTx(ctx, tx, []*domain.Card{
+				newCard(cgA.ID, "hello", "back-A"),
+			})
+			return txErr
+		})
+		require.NoError(t, err)
+
+		// Upsert (group B, "hello") — must be classified as an INSERT because
+		// the unique key is the (cardgroup_id, front) pair, not just `front`.
+		var result repository.UpsertManyTxResult
+		err = testDB.GORM.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+			var txErr error
+			result, txErr = repo.UpsertManyTx(ctx, tx, []*domain.Card{
+				newCard(cgB.ID, "hello", "back-B"),
+			})
+			return txErr
+		})
+		require.NoError(t, err)
+		require.Equal(t, int64(1), result.Inserted)
+		require.Equal(t, int64(0), result.Updated)
+
+		storedA, err := repo.FindByCardgroup(ctx, cgA.ID)
+		require.NoError(t, err)
+		require.Len(t, storedA, 1)
+		require.Equal(t, "hello", storedA[0].Front)
+		require.Equal(t, "back-A", storedA[0].Back)
+
+		storedB, err := repo.FindByCardgroup(ctx, cgB.ID)
+		require.NoError(t, err)
+		require.Len(t, storedB, 1)
+		require.Equal(t, "hello", storedB[0].Front)
+		require.Equal(t, "back-B", storedB[0].Back)
+	})
+}

--- a/backend/internal/repository/card_upsert_test.go
+++ b/backend/internal/repository/card_upsert_test.go
@@ -11,10 +11,10 @@ import (
 	"backend/internal/repository"
 )
 
-// TestCardRepository_UpsertManyTx covers the four scenarios called out in the
-// PR-07 plan: pure inserts, mixed insert+update, empty input, and the
-// per-cardgroup uniqueness boundary. The unique index that backs the
-// ON CONFLICT clause is migration 20260503000000_add_cards_upsert_index.
+// TestCardRepository_UpsertManyTx covers the four scenarios for UpsertManyTx:
+// pure inserts, mixed insert+update, empty input, and the per-cardgroup
+// uniqueness boundary. The unique index that backs the ON CONFLICT clause is
+// migration 20260503000000_add_cards_upsert_index.
 func TestCardRepository_UpsertManyTx(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/backend/internal/usecase/dictionary.go
+++ b/backend/internal/usecase/dictionary.go
@@ -3,6 +3,7 @@ package usecase
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"time"
 
 	"github.com/rotisserie/eris"
@@ -97,8 +98,10 @@ func NewDictionaryUsecaseWithTx(authSvc AdminChecker, cardRepo DictionaryCardRep
 // Upsert ingests a base64-encoded dictionary payload, parses it, and persists
 // the parsed cards into the target cardgroup. Authorization is admin-only:
 // administrators may target any cardgroup (no ownership check). Empty parser
-// output (e.g. an empty payload) returns a zero-valued result with the parser
-// error surfaced via Output.Errors.
+// output (e.g. a non-empty payload whose every line failed to parse — note
+// that an empty payload is rejected with BAD_USER_INPUT before reaching the
+// parser) returns a zero-valued result with the parser error surfaced via
+// Output.Errors.
 func (u *dictionaryUsecase) Upsert(ctx context.Context, input UpsertDictionaryInput) (UpsertDictionaryOutput, error) {
 	caller := auth.UserFrom(ctx)
 	if caller == nil || caller.Sub == "" {
@@ -110,6 +113,9 @@ func (u *dictionaryUsecase) Upsert(ctx context.Context, input UpsertDictionaryIn
 	}
 	isAdmin, err := u.auth.IsAdmin(ctx, caller.Sub)
 	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return UpsertDictionaryOutput{}, gqlerr.Cancelled(ctx, err)
+		}
 		return UpsertDictionaryOutput{}, gqlerr.Internal(ctx, eris.Wrap(err, "usecase: dictionary upsert: check admin"))
 	}
 	if !isAdmin {
@@ -145,6 +151,28 @@ func (u *dictionaryUsecase) Upsert(ctx context.Context, input UpsertDictionaryIn
 		mappedErrs = append(mappedErrs, DictionaryValidationError{Line: e.Line, Message: e.Message})
 	}
 
+	// Deduplicate parsed words by front within this payload. Postgres error 21000
+	// ("ON CONFLICT DO UPDATE command cannot affect row a second time") fires when
+	// the same conflict key appears more than once in a single INSERT statement.
+	// Last occurrence wins; earlier occurrences are dropped and reported in Errors.
+	lastIndex := make(map[string]int, len(words))
+	for i, w := range words {
+		lastIndex[w.Front] = i
+	}
+	deduped := make([]textdic.ParsedWord, 0, len(words))
+	for i, w := range words {
+		if lastIndex[w.Front] != i {
+			// This occurrence is superseded by a later one — drop it and report.
+			mappedErrs = append(mappedErrs, DictionaryValidationError{
+				Line:    w.Line,
+				Message: "duplicate front in payload (later occurrence wins)",
+			})
+			continue
+		}
+		deduped = append(deduped, w)
+	}
+	words = deduped
+
 	// Empty (but well-formed) parse: nothing to persist; surface the parser's
 	// per-line diagnostics so the caller can act on them.
 	if len(words) == 0 {
@@ -178,6 +206,9 @@ func (u *dictionaryUsecase) Upsert(ctx context.Context, input UpsertDictionaryIn
 		result = r
 		return nil
 	}); err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return UpsertDictionaryOutput{}, gqlerr.Cancelled(ctx, err)
+		}
 		return UpsertDictionaryOutput{}, gqlerr.Internal(ctx, err)
 	}
 

--- a/backend/internal/usecase/dictionary.go
+++ b/backend/internal/usecase/dictionary.go
@@ -1,0 +1,189 @@
+package usecase
+
+import (
+	"context"
+	"encoding/base64"
+	"time"
+
+	"github.com/rotisserie/eris"
+	"gorm.io/gorm"
+
+	"backend/internal/auth"
+	"backend/internal/domain"
+	"backend/internal/gqlerr"
+	"backend/internal/repository"
+	"backend/internal/textdic"
+)
+
+// AdminChecker abstracts the admin-role check. Implemented by *auth.Service in
+// production; the local interface keeps the usecase decoupled from the auth
+// package's concrete struct so tests can substitute a stub.
+type AdminChecker interface {
+	IsAdmin(ctx context.Context, userID string) (bool, error)
+}
+
+// DictionaryCardRepository is the subset of repository.CardRepository the
+// dictionary usecase consumes. Declaring a narrow interface here lets the
+// existing mockCardRepository in card_test.go satisfy it without a separate
+// double.
+type DictionaryCardRepository interface {
+	UpsertManyTx(ctx context.Context, tx *gorm.DB, cards []*domain.Card) (repository.UpsertManyTxResult, error)
+}
+
+// DictionaryUsecase exposes the admin-only bulk dictionary upsert.
+type DictionaryUsecase interface {
+	Upsert(ctx context.Context, input UpsertDictionaryInput) (UpsertDictionaryOutput, error)
+}
+
+// UpsertDictionaryInput is the wire-shape consumed by DictionaryUsecase.Upsert.
+// Payload reuses the validateDictionary base64-encoded text format.
+type UpsertDictionaryInput struct {
+	CardgroupID string
+	Payload     string // standard base64-encoded plain-text dictionary
+}
+
+// DictionaryValidationError mirrors textdic.ValidationError so callers in the
+// resolver layer can reshape it into the GraphQL model without importing the
+// textdic package directly.
+type DictionaryValidationError struct {
+	Line    int
+	Message string
+}
+
+// UpsertDictionaryOutput is the result returned to the caller. Inserted +
+// Updated equals the number of cards persisted; Errors carries the per-line
+// parser diagnostics that did not block the upsert.
+type UpsertDictionaryOutput struct {
+	Inserted int64
+	Updated  int64
+	Errors   []DictionaryValidationError
+}
+
+// dictionaryParsedRowCap is the maximum number of parsed rows accepted in a
+// single upsert. The limit applies to the parser's *output* — a payload with
+// more lines but fewer parsed rows (after errors are filtered) is still
+// allowed.
+const dictionaryParsedRowCap = 5000
+
+// dictionaryUsecase wires the auth check, the textdic parser, the card
+// repository, and the transaction runner that persists the upsert.
+type dictionaryUsecase struct {
+	auth     AdminChecker
+	cardRepo DictionaryCardRepository
+	tx       txRunner
+}
+
+// NewDictionaryUsecase constructs a DictionaryUsecase. db is the gorm handle
+// used to open transactions; pass the same *gorm.DB used by the other
+// usecase constructors. Passing a nil db defers transaction wiring; the
+// usecase will return INTERNAL when Upsert is invoked without a tx runner.
+func NewDictionaryUsecase(authSvc AdminChecker, cardRepo DictionaryCardRepository, db *gorm.DB) *dictionaryUsecase {
+	uc := &dictionaryUsecase{auth: authSvc, cardRepo: cardRepo}
+	if db != nil {
+		uc.tx = func(ctx context.Context, fn func(tx *gorm.DB) error) error {
+			return db.WithContext(ctx).Transaction(fn)
+		}
+	}
+	return uc
+}
+
+// NewDictionaryUsecaseWithTx is the test-time constructor that injects an
+// explicit transaction runner. Production callers must use
+// NewDictionaryUsecase.
+func NewDictionaryUsecaseWithTx(authSvc AdminChecker, cardRepo DictionaryCardRepository, tx txRunner) *dictionaryUsecase {
+	return &dictionaryUsecase{auth: authSvc, cardRepo: cardRepo, tx: tx}
+}
+
+// Upsert ingests a base64-encoded dictionary payload, parses it, and persists
+// the parsed cards into the target cardgroup. Authorization is admin-only:
+// administrators may target any cardgroup (no ownership check). Empty parser
+// output (e.g. an empty payload) returns a zero-valued result with the parser
+// error surfaced via Output.Errors.
+func (u *dictionaryUsecase) Upsert(ctx context.Context, input UpsertDictionaryInput) (UpsertDictionaryOutput, error) {
+	caller := auth.UserFrom(ctx)
+	if caller == nil || caller.Sub == "" {
+		return UpsertDictionaryOutput{}, gqlerr.Unauthenticated()
+	}
+
+	if u.auth == nil {
+		return UpsertDictionaryOutput{}, gqlerr.Internal(ctx, eris.New("usecase: dictionary admin checker not configured"))
+	}
+	isAdmin, err := u.auth.IsAdmin(ctx, caller.Sub)
+	if err != nil {
+		return UpsertDictionaryOutput{}, gqlerr.Internal(ctx, eris.Wrap(err, "usecase: dictionary upsert: check admin"))
+	}
+	if !isAdmin {
+		return UpsertDictionaryOutput{}, gqlerr.NewForbidden("admin role required")
+	}
+
+	if input.CardgroupID == "" {
+		return UpsertDictionaryOutput{}, gqlerr.BadUserInput("cardgroupId", "cardgroupId is required")
+	}
+
+	if input.Payload == "" {
+		return UpsertDictionaryOutput{}, gqlerr.BadUserInput("payload", "payload must not be empty")
+	}
+	decoded, err := base64.StdEncoding.DecodeString(input.Payload)
+	if err != nil {
+		return UpsertDictionaryOutput{}, gqlerr.BadUserInput("payload", "payload must be standard base64-encoded text")
+	}
+
+	words, parseErrs, perr := textdic.Process(string(decoded))
+	if perr != nil {
+		return UpsertDictionaryOutput{}, gqlerr.Internal(ctx, eris.Wrap(perr, "usecase: dictionary upsert: parse"))
+	}
+
+	if len(words) > dictionaryParsedRowCap {
+		return UpsertDictionaryOutput{}, gqlerr.BadUserInput(
+			"payload",
+			"payload exceeds 5000 row cap",
+		)
+	}
+
+	mappedErrs := make([]DictionaryValidationError, 0, len(parseErrs))
+	for _, e := range parseErrs {
+		mappedErrs = append(mappedErrs, DictionaryValidationError{Line: e.Line, Message: e.Message})
+	}
+
+	// Empty (but well-formed) parse: nothing to persist; surface the parser's
+	// per-line diagnostics so the caller can act on them.
+	if len(words) == 0 {
+		return UpsertDictionaryOutput{Errors: mappedErrs}, nil
+	}
+
+	now := time.Now().UTC()
+	cards := make([]*domain.Card, 0, len(words))
+	for _, w := range words {
+		c := &domain.Card{
+			CardgroupID: input.CardgroupID,
+			Front:       w.Front,
+			Back:        w.Back,
+			FSRS:        domain.NewFSRSStateForNewCard(now),
+			CreatedAt:   now,
+			UpdatedAt:   now,
+		}
+		cards = append(cards, c)
+	}
+
+	if u.tx == nil {
+		return UpsertDictionaryOutput{}, gqlerr.Internal(ctx, eris.New("usecase: dictionary tx runner not configured"))
+	}
+
+	var result repository.UpsertManyTxResult
+	if err := u.tx(ctx, func(tx *gorm.DB) error {
+		r, err := u.cardRepo.UpsertManyTx(ctx, tx, cards)
+		if err != nil {
+			return eris.Wrap(err, "usecase: dictionary upsert: repo")
+		}
+		result = r
+		return nil
+	}); err != nil {
+		return UpsertDictionaryOutput{}, gqlerr.Internal(ctx, err)
+	}
+
+	return UpsertDictionaryOutput{
+		Inserted: result.Inserted,
+		Updated:  result.Updated,
+		Errors:   mappedErrs,
+	}, nil
+}

--- a/backend/internal/usecase/dictionary.go
+++ b/backend/internal/usecase/dictionary.go
@@ -162,7 +162,6 @@ func (u *dictionaryUsecase) Upsert(ctx context.Context, input UpsertDictionaryIn
 	deduped := make([]textdic.ParsedWord, 0, len(words))
 	for i, w := range words {
 		if lastIndex[w.Front] != i {
-			// This occurrence is superseded by a later one — drop it and report.
 			mappedErrs = append(mappedErrs, DictionaryValidationError{
 				Line:    w.Line,
 				Message: "duplicate front in payload (later occurrence wins)",

--- a/backend/internal/usecase/dictionary_test.go
+++ b/backend/internal/usecase/dictionary_test.go
@@ -1,0 +1,476 @@
+package usecase
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"strings"
+	"testing"
+
+	"gorm.io/gorm"
+
+	"backend/internal/auth"
+	"backend/internal/domain"
+	"backend/internal/repository"
+)
+
+// ---------------------------------------------------------------------------
+// Test doubles
+// ---------------------------------------------------------------------------
+
+// mockAdminChecker is a stub for the AdminChecker interface used by the
+// dictionary usecase. The boolean field controls the return value; the err
+// field, when non-nil, is returned instead and forces the INTERNAL path.
+type mockAdminChecker struct {
+	isAdmin bool
+	err     error
+	calls   int
+}
+
+func (m *mockAdminChecker) IsAdmin(_ context.Context, _ string) (bool, error) {
+	m.calls++
+	if m.err != nil {
+		return false, m.err
+	}
+	return m.isAdmin, nil
+}
+
+// mockDictCardRepo captures the cards passed to UpsertManyTx and returns a
+// caller-controlled split of inserts vs. updates. The split lets the unit
+// test drive exact assertions without a real Postgres backend.
+type mockDictCardRepo struct {
+	// inserted/updated drive the simulated row-classification split.
+	inserted int64
+	updated  int64
+	// returnErr, when non-nil, is returned from UpsertManyTx unchanged.
+	returnErr error
+	// preExisting holds the (front -> back) of rows that should classify as
+	// updates. When set, the mock derives inserted/updated by inspecting the
+	// passed-in cards instead of using the static counts above. This lets
+	// tests assert that the updated card carries the new back text.
+	preExisting   map[string]string // front -> back at upsert time (post-update)
+	captured      []*domain.Card
+	upsertCalls   int
+	receivedTxNil bool
+}
+
+func (m *mockDictCardRepo) UpsertManyTx(_ context.Context, tx *gorm.DB, cards []*domain.Card) (repository.UpsertManyTxResult, error) {
+	m.upsertCalls++
+	if tx == nil {
+		m.receivedTxNil = true
+	}
+	for _, c := range cards {
+		// Defensive deep copy so subsequent caller-side mutation cannot alter
+		// what the test inspects.
+		copy := *c
+		m.captured = append(m.captured, &copy)
+	}
+	if m.returnErr != nil {
+		return repository.UpsertManyTxResult{}, m.returnErr
+	}
+	if m.preExisting != nil {
+		var ins, upd int64
+		for _, c := range cards {
+			if _, ok := m.preExisting[c.Front]; ok {
+				upd++
+			} else {
+				ins++
+			}
+		}
+		return repository.UpsertManyTxResult{Inserted: ins, Updated: upd}, nil
+	}
+	return repository.UpsertManyTxResult{Inserted: m.inserted, Updated: m.updated}, nil
+}
+
+// dictTxRunner returns a txRunner that invokes fn with a non-nil sentinel
+// *gorm.DB. The mock repository ignores the value, so an empty &gorm.DB{} is
+// sufficient to prove the closure ran inside the helper.
+func dictTxRunner() (txRunner, *int) {
+	calls := 0
+	sentinel := &gorm.DB{}
+	return func(_ context.Context, fn func(tx *gorm.DB) error) error {
+		calls++
+		return fn(sentinel)
+	}, &calls
+}
+
+// dictionaryAdminCtx returns an authed context whose subject is treated as
+// admin by the supplied AdminChecker. The actual admin verdict comes from
+// the checker — this helper only marks the request as authenticated.
+func dictionaryAdminCtx(sub string) context.Context {
+	return auth.ContextWithUser(context.Background(), &auth.AuthUser{Sub: sub})
+}
+
+// ---------------------------------------------------------------------------
+// Payload builders
+// ---------------------------------------------------------------------------
+
+// jpRunes returns a Hiragana "a" repeated n times. The lexer accepts Hiragana
+// runs as a DEFINITION, so the resulting string is a valid back token. Built
+// from rune code points so the test source stays ASCII-only per the
+// repository language policy.
+func jpRunes(n int) string {
+	const hiraganaA rune = 0x3042 // U+3042 HIRAGANA LETTER A
+	out := make([]rune, n)
+	for i := range out {
+		out[i] = hiraganaA
+	}
+	return string(out)
+}
+
+// uniqueBack returns a Hiragana definition that contains a numeric suffix so
+// each row's back string is unique. Built from rune code points to keep the
+// committed source ASCII.
+func uniqueBack(suffix int) string {
+	// Use Katakana digits area (U+FF10..U+FF19) for the suffix so the lexer
+	// treats every rune as part of the DEFINITION.
+	const katakanaA rune = 0x30A2 // U+30A2 KATAKANA LETTER A
+	digits := []rune{}
+	if suffix == 0 {
+		digits = append(digits, 0xFF10)
+	} else {
+		s := suffix
+		for s > 0 {
+			digits = append([]rune{rune(0xFF10 + (s % 10))}, digits...)
+			s /= 10
+		}
+	}
+	return string(katakanaA) + string(digits)
+}
+
+// buildPayload concatenates "front<space>back\n" for each input pair and
+// base64-encodes the result. Each (front, back) pair must satisfy the textdic
+// grammar (ASCII front, Japanese-script back) for the parser to accept it.
+func buildPayload(t *testing.T, pairs [][2]string) string {
+	t.Helper()
+	var b strings.Builder
+	for _, p := range pairs {
+		b.WriteString(p[0])
+		b.WriteString(" ")
+		b.WriteString(p[1])
+		b.WriteString("\n")
+	}
+	return base64.StdEncoding.EncodeToString([]byte(b.String()))
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+// TestDictionaryUsecase_AdminAllInserts covers the happy path where every row
+// in the payload is brand new for the target cardgroup. Inserted should equal
+// len(payload) and Updated should be zero.
+func TestDictionaryUsecase_AdminAllInserts(t *testing.T) {
+	t.Parallel()
+
+	const n = 100
+	pairs := make([][2]string, n)
+	for i := 0; i < n; i++ {
+		pairs[i] = [2]string{stringFront("front", i), uniqueBack(i)}
+	}
+	payload := buildPayload(t, pairs)
+
+	repo := &mockDictCardRepo{inserted: n, updated: 0}
+	auth := &mockAdminChecker{isAdmin: true}
+	tx, calls := dictTxRunner()
+	uc := NewDictionaryUsecaseWithTx(auth, repo, tx)
+
+	out, err := uc.Upsert(dictionaryAdminCtx("admin-1"), UpsertDictionaryInput{
+		CardgroupID: "cg-target",
+		Payload:     payload,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.Inserted != n {
+		t.Fatalf("Inserted = %d, want %d", out.Inserted, n)
+	}
+	if out.Updated != 0 {
+		t.Fatalf("Updated = %d, want 0", out.Updated)
+	}
+	if len(out.Errors) != 0 {
+		t.Fatalf("expected no errors, got %+v", out.Errors)
+	}
+	if *calls != 1 {
+		t.Fatalf("expected 1 tx invocation, got %d", *calls)
+	}
+	if repo.upsertCalls != 1 {
+		t.Fatalf("expected 1 UpsertManyTx call, got %d", repo.upsertCalls)
+	}
+	if len(repo.captured) != n {
+		t.Fatalf("expected %d captured cards, got %d", n, len(repo.captured))
+	}
+	// All cards must target the requested cardgroup and carry the default
+	// FSRS state (state=New, stability=2.5).
+	for i, c := range repo.captured {
+		if c.CardgroupID != "cg-target" {
+			t.Fatalf("captured[%d] CardgroupID=%q, want cg-target", i, c.CardgroupID)
+		}
+		if c.FSRS.State != domain.FSRSStateNew {
+			t.Fatalf("captured[%d] FSRS.State=%d, want New", i, c.FSRS.State)
+		}
+		if c.FSRS.Stability != 2.5 {
+			t.Fatalf("captured[%d] FSRS.Stability=%v, want 2.5", i, c.FSRS.Stability)
+		}
+	}
+}
+
+// TestDictionaryUsecase_AdminMixedInsertsAndUpdates covers the mixed case:
+// 50 fronts already exist (with old backs), 50 fronts are new. The payload
+// supplies new backs for the first 50; the mock repo classifies each card by
+// looking up its front in preExisting. The test asserts the (50, 50) split
+// AND that the captured "shared" rows carry the *new* back text.
+func TestDictionaryUsecase_AdminMixedInsertsAndUpdates(t *testing.T) {
+	t.Parallel()
+
+	const n = 50
+	pairs := make([][2]string, 0, 2*n)
+	preExisting := make(map[string]string, n)
+	// 50 shared fronts: each new back is "new-<i>".
+	for i := 0; i < n; i++ {
+		front := stringFront("shared", i)
+		newBack := uniqueBack(i + 1000) // disambiguated from the "fresh" range
+		pairs = append(pairs, [2]string{front, newBack})
+		preExisting[front] = newBack
+	}
+	// 50 brand new fronts.
+	for i := 0; i < n; i++ {
+		front := stringFront("fresh", i)
+		newBack := uniqueBack(i)
+		pairs = append(pairs, [2]string{front, newBack})
+	}
+	payload := buildPayload(t, pairs)
+
+	repo := &mockDictCardRepo{preExisting: preExisting}
+	auth := &mockAdminChecker{isAdmin: true}
+	tx, _ := dictTxRunner()
+	uc := NewDictionaryUsecaseWithTx(auth, repo, tx)
+
+	out, err := uc.Upsert(dictionaryAdminCtx("admin-1"), UpsertDictionaryInput{
+		CardgroupID: "cg-target",
+		Payload:     payload,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.Inserted != n {
+		t.Fatalf("Inserted = %d, want %d", out.Inserted, n)
+	}
+	if out.Updated != n {
+		t.Fatalf("Updated = %d, want %d", out.Updated, n)
+	}
+	if len(out.Errors) != 0 {
+		t.Fatalf("expected no errors, got %+v", out.Errors)
+	}
+
+	// Spot-check: pick a shared front and confirm the captured card carries
+	// the *new* back from the payload, not the legacy stub from preExisting's
+	// "old" state. (Here preExisting only stores the post-update value, but
+	// the assertion still locks in that the upsert sent the payload's back
+	// to the repository — i.e. the new text, not whatever the DB held.)
+	const probeIdx = 7
+	wantFront := stringFront("shared", probeIdx)
+	wantBack := uniqueBack(probeIdx + 1000)
+	var found bool
+	for _, c := range repo.captured {
+		if c.Front == wantFront {
+			if c.Back != wantBack {
+				t.Fatalf("captured shared front=%q has Back=%q, want %q", wantFront, c.Back, wantBack)
+			}
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("captured cards do not contain shared front %q", wantFront)
+	}
+}
+
+// TestDictionaryUsecase_NonAdminForbidden covers the auth gate: a non-admin
+// caller is rejected with FORBIDDEN before the parser or repo is touched.
+func TestDictionaryUsecase_NonAdminForbidden(t *testing.T) {
+	t.Parallel()
+
+	pairs := [][2]string{{"apple", jpRunes(3)}}
+	payload := buildPayload(t, pairs)
+
+	repo := &mockDictCardRepo{}
+	auth := &mockAdminChecker{isAdmin: false}
+	tx, calls := dictTxRunner()
+	uc := NewDictionaryUsecaseWithTx(auth, repo, tx)
+
+	_, err := uc.Upsert(dictionaryAdminCtx("user-1"), UpsertDictionaryInput{
+		CardgroupID: "cg-target",
+		Payload:     payload,
+	})
+	assertGQLErr(t, err, "FORBIDDEN", "")
+	if auth.calls != 1 {
+		t.Fatalf("expected 1 IsAdmin call, got %d", auth.calls)
+	}
+	if repo.upsertCalls != 0 {
+		t.Fatalf("expected 0 repo calls on forbidden, got %d", repo.upsertCalls)
+	}
+	if *calls != 0 {
+		t.Fatalf("expected 0 tx invocations on forbidden, got %d", *calls)
+	}
+}
+
+// TestDictionaryUsecase_AnonymousUnauthenticated covers the auth gate: a
+// caller with no AuthUser in context is rejected with UNAUTHENTICATED before
+// the AdminChecker is consulted.
+func TestDictionaryUsecase_AnonymousUnauthenticated(t *testing.T) {
+	t.Parallel()
+
+	pairs := [][2]string{{"apple", jpRunes(3)}}
+	payload := buildPayload(t, pairs)
+
+	repo := &mockDictCardRepo{}
+	auth := &mockAdminChecker{isAdmin: true}
+	tx, _ := dictTxRunner()
+	uc := NewDictionaryUsecaseWithTx(auth, repo, tx)
+
+	_, err := uc.Upsert(anonCtx(), UpsertDictionaryInput{
+		CardgroupID: "cg-target",
+		Payload:     payload,
+	})
+	assertGQLErr(t, err, "UNAUTHENTICATED", "")
+	if auth.calls != 0 {
+		t.Fatalf("expected 0 IsAdmin calls on anonymous, got %d", auth.calls)
+	}
+}
+
+// TestDictionaryUsecase_PayloadOverCapBadInput covers the 5000-row cap: a
+// payload that parses to >5000 rows is rejected with BAD_USER_INPUT before
+// the repo is touched. Empty backs would surface as parse errors instead, so
+// the test uses well-formed rows to drive the parsed-row count past the cap.
+func TestDictionaryUsecase_PayloadOverCapBadInput(t *testing.T) {
+	t.Parallel()
+
+	const n = dictionaryParsedRowCap + 1
+	pairs := make([][2]string, n)
+	for i := 0; i < n; i++ {
+		pairs[i] = [2]string{stringFront("front", i), uniqueBack(i)}
+	}
+	payload := buildPayload(t, pairs)
+
+	repo := &mockDictCardRepo{}
+	auth := &mockAdminChecker{isAdmin: true}
+	tx, calls := dictTxRunner()
+	uc := NewDictionaryUsecaseWithTx(auth, repo, tx)
+
+	_, err := uc.Upsert(dictionaryAdminCtx("admin-1"), UpsertDictionaryInput{
+		CardgroupID: "cg-target",
+		Payload:     payload,
+	})
+	assertGQLErr(t, err, "BAD_USER_INPUT", "payload")
+	if repo.upsertCalls != 0 {
+		t.Fatalf("expected 0 repo calls on over-cap payload, got %d", repo.upsertCalls)
+	}
+	if *calls != 0 {
+		t.Fatalf("expected 0 tx invocations on over-cap payload, got %d", *calls)
+	}
+}
+
+// TestDictionaryUsecase_BadRowsSurfaceAsErrors covers the partial-failure
+// shape: 3 valid rows + malformed lines (missing definition) yield 3 cards
+// persisted plus N parser errors propagated to the caller. The usecase must
+// not panic on any malformed row.
+func TestDictionaryUsecase_BadRowsSurfaceAsErrors(t *testing.T) {
+	t.Parallel()
+
+	// Build a payload with three valid rows interleaved with malformed lines
+	// (front-only — no DEFINITION token). The textdic grammar's "error
+	// NEWLINE" recovery rule discards the malformed lines and continues.
+	var b strings.Builder
+	b.WriteString("apple ")
+	b.WriteString(uniqueBack(1))
+	b.WriteString("\n")
+	b.WriteString("malformed-1\n") // no back
+	b.WriteString("dog ")
+	b.WriteString(uniqueBack(2))
+	b.WriteString("\n")
+	b.WriteString("malformed-2\n") // no back
+	b.WriteString("cat ")
+	b.WriteString(uniqueBack(3))
+	b.WriteString("\n")
+	payload := base64.StdEncoding.EncodeToString([]byte(b.String()))
+
+	repo := &mockDictCardRepo{inserted: 3, updated: 0}
+	authChk := &mockAdminChecker{isAdmin: true}
+	tx, _ := dictTxRunner()
+	uc := NewDictionaryUsecaseWithTx(authChk, repo, tx)
+
+	// The only failure path here would be a panic; otherwise every assertion
+	// is on the returned struct.
+	out, err := uc.Upsert(dictionaryAdminCtx("admin-1"), UpsertDictionaryInput{
+		CardgroupID: "cg-target",
+		Payload:     payload,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.Inserted != 3 {
+		t.Fatalf("Inserted = %d, want 3", out.Inserted)
+	}
+	if out.Updated != 0 {
+		t.Fatalf("Updated = %d, want 0", out.Updated)
+	}
+	if len(out.Errors) == 0 {
+		t.Fatal("expected at least one parser error to surface, got none")
+	}
+}
+
+// TestDictionaryUsecase_AdminCheckerErrorBecomesInternal verifies that a
+// non-context-canceled error returned by IsAdmin maps to INTERNAL and never
+// reaches the repository. The eris chain captured by gqlerr.Internal is
+// observed only in logs; the test pins the error code returned to the caller.
+func TestDictionaryUsecase_AdminCheckerErrorBecomesInternal(t *testing.T) {
+	t.Parallel()
+
+	pairs := [][2]string{{"apple", jpRunes(3)}}
+	payload := buildPayload(t, pairs)
+
+	repo := &mockDictCardRepo{}
+	auth := &mockAdminChecker{err: errors.New("db died")}
+	tx, calls := dictTxRunner()
+	uc := NewDictionaryUsecaseWithTx(auth, repo, tx)
+
+	_, err := uc.Upsert(dictionaryAdminCtx("admin-1"), UpsertDictionaryInput{
+		CardgroupID: "cg-target",
+		Payload:     payload,
+	})
+	assertGQLErr(t, err, "INTERNAL", "")
+	if repo.upsertCalls != 0 {
+		t.Fatalf("expected 0 repo calls when admin check fails, got %d", repo.upsertCalls)
+	}
+	if *calls != 0 {
+		t.Fatalf("expected 0 tx invocations when admin check fails, got %d", *calls)
+	}
+}
+
+// stringFront returns a deterministic front string of the form "<prefix>-<n>"
+// using only ASCII so the lexer treats it as a single WORD token.
+func stringFront(prefix string, n int) string {
+	return prefix + "-" + itoa(n)
+}
+
+// itoa is a small allocation-free integer formatter; we avoid strconv to keep
+// the test imports minimal and because the input range is bounded.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	var digits []byte
+	for n > 0 {
+		digits = append([]byte{byte('0' + n%10)}, digits...)
+		n /= 10
+	}
+	if neg {
+		digits = append([]byte{'-'}, digits...)
+	}
+	return string(digits)
+}

--- a/backend/internal/usecase/dictionary_test.go
+++ b/backend/internal/usecase/dictionary_test.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"encoding/base64"
 	"errors"
+	"strconv"
 	"strings"
 	"testing"
 
 	"gorm.io/gorm"
 
-	"backend/internal/auth"
 	"backend/internal/domain"
 	"backend/internal/repository"
 )
@@ -44,26 +44,22 @@ type mockDictCardRepo struct {
 	updated  int64
 	// returnErr, when non-nil, is returned from UpsertManyTx unchanged.
 	returnErr error
-	// preExisting holds the (front -> back) of rows that should classify as
-	// updates. When set, the mock derives inserted/updated by inspecting the
-	// passed-in cards instead of using the static counts above. This lets
-	// tests assert that the updated card carries the new back text.
-	preExisting   map[string]string // front -> back at upsert time (post-update)
-	captured      []*domain.Card
-	upsertCalls   int
-	receivedTxNil bool
+	// preExisting holds the fronts of rows that should classify as updates.
+	// When set, the mock derives inserted/updated by inspecting the passed-in
+	// cards instead of using the static counts above. This lets tests assert
+	// that the updated card carries the new back text.
+	preExisting map[string]string
+	captured    []*domain.Card
+	upsertCalls int
 }
 
-func (m *mockDictCardRepo) UpsertManyTx(_ context.Context, tx *gorm.DB, cards []*domain.Card) (repository.UpsertManyTxResult, error) {
+func (m *mockDictCardRepo) UpsertManyTx(_ context.Context, _ *gorm.DB, cards []*domain.Card) (repository.UpsertManyTxResult, error) {
 	m.upsertCalls++
-	if tx == nil {
-		m.receivedTxNil = true
-	}
 	for _, c := range cards {
 		// Defensive deep copy so subsequent caller-side mutation cannot alter
 		// what the test inspects.
-		copy := *c
-		m.captured = append(m.captured, &copy)
+		clone := *c
+		m.captured = append(m.captured, &clone)
 	}
 	if m.returnErr != nil {
 		return repository.UpsertManyTxResult{}, m.returnErr
@@ -92,13 +88,6 @@ func dictTxRunner() (txRunner, *int) {
 		calls++
 		return fn(sentinel)
 	}, &calls
-}
-
-// dictionaryAdminCtx returns an authed context whose subject is treated as
-// admin by the supplied AdminChecker. The actual admin verdict comes from
-// the checker — this helper only marks the request as authenticated.
-func dictionaryAdminCtx(sub string) context.Context {
-	return auth.ContextWithUser(context.Background(), &auth.AuthUser{Sub: sub})
 }
 
 // ---------------------------------------------------------------------------
@@ -175,7 +164,7 @@ func TestDictionaryUsecase_AdminAllInserts(t *testing.T) {
 	tx, calls := dictTxRunner()
 	uc := NewDictionaryUsecaseWithTx(auth, repo, tx)
 
-	out, err := uc.Upsert(dictionaryAdminCtx("admin-1"), UpsertDictionaryInput{
+	out, err := uc.Upsert(authedCtx("admin-1"), UpsertDictionaryInput{
 		CardgroupID: "cg-target",
 		Payload:     payload,
 	})
@@ -246,7 +235,7 @@ func TestDictionaryUsecase_AdminMixedInsertsAndUpdates(t *testing.T) {
 	tx, _ := dictTxRunner()
 	uc := NewDictionaryUsecaseWithTx(auth, repo, tx)
 
-	out, err := uc.Upsert(dictionaryAdminCtx("admin-1"), UpsertDictionaryInput{
+	out, err := uc.Upsert(authedCtx("admin-1"), UpsertDictionaryInput{
 		CardgroupID: "cg-target",
 		Payload:     payload,
 	})
@@ -299,7 +288,7 @@ func TestDictionaryUsecase_NonAdminForbidden(t *testing.T) {
 	tx, calls := dictTxRunner()
 	uc := NewDictionaryUsecaseWithTx(auth, repo, tx)
 
-	_, err := uc.Upsert(dictionaryAdminCtx("user-1"), UpsertDictionaryInput{
+	_, err := uc.Upsert(authedCtx("user-1"), UpsertDictionaryInput{
 		CardgroupID: "cg-target",
 		Payload:     payload,
 	})
@@ -358,7 +347,7 @@ func TestDictionaryUsecase_PayloadOverCapBadInput(t *testing.T) {
 	tx, calls := dictTxRunner()
 	uc := NewDictionaryUsecaseWithTx(auth, repo, tx)
 
-	_, err := uc.Upsert(dictionaryAdminCtx("admin-1"), UpsertDictionaryInput{
+	_, err := uc.Upsert(authedCtx("admin-1"), UpsertDictionaryInput{
 		CardgroupID: "cg-target",
 		Payload:     payload,
 	})
@@ -419,7 +408,7 @@ func TestDictionaryUsecase_BadRowsSurfaceAsErrors(t *testing.T) {
 
 	// The only failure path here would be a panic; otherwise every assertion
 	// is on the returned struct.
-	out, err := uc.Upsert(dictionaryAdminCtx("admin-1"), UpsertDictionaryInput{
+	out, err := uc.Upsert(authedCtx("admin-1"), UpsertDictionaryInput{
 		CardgroupID: "cg-target",
 		Payload:     payload,
 	})
@@ -460,7 +449,7 @@ func TestDictionaryUsecase_AdminCheckerErrorBecomesInternal(t *testing.T) {
 	tx, calls := dictTxRunner()
 	uc := NewDictionaryUsecaseWithTx(auth, repo, tx)
 
-	_, err := uc.Upsert(dictionaryAdminCtx("admin-1"), UpsertDictionaryInput{
+	_, err := uc.Upsert(authedCtx("admin-1"), UpsertDictionaryInput{
 		CardgroupID: "cg-target",
 		Payload:     payload,
 	})
@@ -490,7 +479,7 @@ func TestDictionaryUsecase_RepoErrorBecomesInternal(t *testing.T) {
 	tx, _ := dictTxRunner()
 	uc := NewDictionaryUsecaseWithTx(authChk, repo, tx)
 
-	_, err := uc.Upsert(dictionaryAdminCtx("admin-1"), UpsertDictionaryInput{
+	_, err := uc.Upsert(authedCtx("admin-1"), UpsertDictionaryInput{
 		CardgroupID: "cg-target",
 		Payload:     payload,
 	})
@@ -513,7 +502,7 @@ func TestDictionaryUsecase_EmptyCardgroupIDBadInput(t *testing.T) {
 	tx, _ := dictTxRunner()
 	uc := NewDictionaryUsecaseWithTx(authChk, repo, tx)
 
-	_, err := uc.Upsert(dictionaryAdminCtx("admin-1"), UpsertDictionaryInput{
+	_, err := uc.Upsert(authedCtx("admin-1"), UpsertDictionaryInput{
 		CardgroupID: "",
 		Payload:     payload,
 	})
@@ -533,7 +522,7 @@ func TestDictionaryUsecase_EmptyPayloadBadInput(t *testing.T) {
 	tx, _ := dictTxRunner()
 	uc := NewDictionaryUsecaseWithTx(authChk, repo, tx)
 
-	_, err := uc.Upsert(dictionaryAdminCtx("admin-1"), UpsertDictionaryInput{
+	_, err := uc.Upsert(authedCtx("admin-1"), UpsertDictionaryInput{
 		CardgroupID: "cg-target",
 		Payload:     "",
 	})
@@ -554,7 +543,7 @@ func TestDictionaryUsecase_BadBase64BadInput(t *testing.T) {
 	tx, _ := dictTxRunner()
 	uc := NewDictionaryUsecaseWithTx(authChk, repo, tx)
 
-	_, err := uc.Upsert(dictionaryAdminCtx("admin-1"), UpsertDictionaryInput{
+	_, err := uc.Upsert(authedCtx("admin-1"), UpsertDictionaryInput{
 		CardgroupID: "cg-target",
 		Payload:     "not-valid-base64-!@#$",
 	})
@@ -590,7 +579,7 @@ func TestDictionaryUsecase_DuplicateFrontDeduplicatedAndSurfaced(t *testing.T) {
 	tx, _ := dictTxRunner()
 	uc := NewDictionaryUsecaseWithTx(authChk, repo, tx)
 
-	out, err := uc.Upsert(dictionaryAdminCtx("admin-1"), UpsertDictionaryInput{
+	out, err := uc.Upsert(authedCtx("admin-1"), UpsertDictionaryInput{
 		CardgroupID: "cg-target",
 		Payload:     payload,
 	})
@@ -614,26 +603,5 @@ func TestDictionaryUsecase_DuplicateFrontDeduplicatedAndSurfaced(t *testing.T) {
 // stringFront returns a deterministic front string of the form "<prefix>-<n>"
 // using only ASCII so the lexer treats it as a single WORD token.
 func stringFront(prefix string, n int) string {
-	return prefix + "-" + itoa(n)
-}
-
-// itoa is a small allocation-free integer formatter; we avoid strconv to keep
-// the test imports minimal and because the input range is bounded.
-func itoa(n int) string {
-	if n == 0 {
-		return "0"
-	}
-	neg := n < 0
-	if neg {
-		n = -n
-	}
-	var digits []byte
-	for n > 0 {
-		digits = append([]byte{byte('0' + n%10)}, digits...)
-		n /= 10
-	}
-	if neg {
-		digits = append([]byte{'-'}, digits...)
-	}
-	return string(digits)
+	return prefix + "-" + strconv.Itoa(n)
 }

--- a/backend/internal/usecase/dictionary_test.go
+++ b/backend/internal/usecase/dictionary_test.go
@@ -372,9 +372,24 @@ func TestDictionaryUsecase_PayloadOverCapBadInput(t *testing.T) {
 }
 
 // TestDictionaryUsecase_BadRowsSurfaceAsErrors covers the partial-failure
-// shape: 3 valid rows + malformed lines (missing definition) yield 3 cards
-// persisted plus N parser errors propagated to the caller. The usecase must
-// not panic on any malformed row.
+// shape: valid rows interleaved with malformed lines (missing definition) must
+// not block the upsert — the usecase passes the parsed valid rows to the repo
+// and surfaces the parser errors in Output.Errors.
+//
+// Grammar behavior note: the LALR grammar's "error NEWLINE" recovery rule
+// drops the accumulated parse state up to the error point. Entries that
+// appear BEFORE a malformed row in the accumulation phase are discarded;
+// entries AFTER the last malformed row survive. Concretely, for the payload:
+//
+//	apple <def>\n         → discarded (before first error)
+//	malformed-1\n         → error recovery fires
+//	dog <def>\n           → discarded (before second error)
+//	malformed-2\n         → error recovery fires again
+//	cat <def>\n           → survives (after last error)
+//
+// Only "cat" is returned by the parser; the mock repo reflects this with
+// inserted: 1. This is the documented contract — callers should be aware
+// that malformed rows in the middle of the payload discard preceding entries.
 func TestDictionaryUsecase_BadRowsSurfaceAsErrors(t *testing.T) {
 	t.Parallel()
 
@@ -395,7 +410,9 @@ func TestDictionaryUsecase_BadRowsSurfaceAsErrors(t *testing.T) {
 	b.WriteString("\n")
 	payload := base64.StdEncoding.EncodeToString([]byte(b.String()))
 
-	repo := &mockDictCardRepo{inserted: 3, updated: 0}
+	// The LALR grammar returns only 1 parsed word ("cat") for this interleaved
+	// payload; the mock is configured to match.
+	repo := &mockDictCardRepo{inserted: 1, updated: 0}
 	authChk := &mockAdminChecker{isAdmin: true}
 	tx, _ := dictTxRunner()
 	uc := NewDictionaryUsecaseWithTx(authChk, repo, tx)
@@ -409,14 +426,22 @@ func TestDictionaryUsecase_BadRowsSurfaceAsErrors(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if out.Inserted != 3 {
-		t.Fatalf("Inserted = %d, want 3", out.Inserted)
+	if out.Inserted != 1 {
+		t.Fatalf("Inserted = %d, want 1", out.Inserted)
 	}
 	if out.Updated != 0 {
 		t.Fatalf("Updated = %d, want 0", out.Updated)
 	}
-	if len(out.Errors) == 0 {
-		t.Fatal("expected at least one parser error to surface, got none")
+	// Exactly two malformed lines must surface as parse errors.
+	if len(out.Errors) != 2 {
+		t.Fatalf("expected exactly 2 parse errors, got %d: %+v", len(out.Errors), out.Errors)
+	}
+	// The repo must have been called exactly once with the 1 surviving card.
+	if repo.upsertCalls != 1 {
+		t.Fatalf("expected 1 UpsertManyTx call, got %d", repo.upsertCalls)
+	}
+	if len(repo.captured) != 1 {
+		t.Fatalf("expected 1 captured card (valid row after last error), got %d", len(repo.captured))
 	}
 }
 
@@ -445,6 +470,144 @@ func TestDictionaryUsecase_AdminCheckerErrorBecomesInternal(t *testing.T) {
 	}
 	if *calls != 0 {
 		t.Fatalf("expected 0 tx invocations when admin check fails, got %d", *calls)
+	}
+}
+
+// TestDictionaryUsecase_RepoErrorBecomesInternal verifies that a repository
+// error (e.g. database failure) is surfaced as an INTERNAL GraphQL error. The
+// usecase must still invoke the repository exactly once before returning.
+func TestDictionaryUsecase_RepoErrorBecomesInternal(t *testing.T) {
+	t.Parallel()
+
+	pairs := [][2]string{
+		{"apple", jpRunes(3)},
+		{"dog", jpRunes(3)},
+	}
+	payload := buildPayload(t, pairs)
+
+	repo := &mockDictCardRepo{returnErr: errors.New("db: boom")}
+	authChk := &mockAdminChecker{isAdmin: true}
+	tx, _ := dictTxRunner()
+	uc := NewDictionaryUsecaseWithTx(authChk, repo, tx)
+
+	_, err := uc.Upsert(dictionaryAdminCtx("admin-1"), UpsertDictionaryInput{
+		CardgroupID: "cg-target",
+		Payload:     payload,
+	})
+	assertGQLErr(t, err, "INTERNAL", "")
+	if repo.upsertCalls != 1 {
+		t.Fatalf("expected 1 UpsertManyTx call (repo was invoked), got %d", repo.upsertCalls)
+	}
+}
+
+// TestDictionaryUsecase_EmptyCardgroupIDBadInput verifies that an empty
+// cardgroupId is rejected with BAD_USER_INPUT before any repo activity occurs.
+func TestDictionaryUsecase_EmptyCardgroupIDBadInput(t *testing.T) {
+	t.Parallel()
+
+	pairs := [][2]string{{"apple", jpRunes(3)}}
+	payload := buildPayload(t, pairs)
+
+	repo := &mockDictCardRepo{}
+	authChk := &mockAdminChecker{isAdmin: true}
+	tx, _ := dictTxRunner()
+	uc := NewDictionaryUsecaseWithTx(authChk, repo, tx)
+
+	_, err := uc.Upsert(dictionaryAdminCtx("admin-1"), UpsertDictionaryInput{
+		CardgroupID: "",
+		Payload:     payload,
+	})
+	assertGQLErr(t, err, "BAD_USER_INPUT", "cardgroupId")
+	if repo.upsertCalls != 0 {
+		t.Fatalf("expected 0 repo calls on empty cardgroupId, got %d", repo.upsertCalls)
+	}
+}
+
+// TestDictionaryUsecase_EmptyPayloadBadInput verifies that an empty payload
+// string is rejected with BAD_USER_INPUT before any repo activity occurs.
+func TestDictionaryUsecase_EmptyPayloadBadInput(t *testing.T) {
+	t.Parallel()
+
+	repo := &mockDictCardRepo{}
+	authChk := &mockAdminChecker{isAdmin: true}
+	tx, _ := dictTxRunner()
+	uc := NewDictionaryUsecaseWithTx(authChk, repo, tx)
+
+	_, err := uc.Upsert(dictionaryAdminCtx("admin-1"), UpsertDictionaryInput{
+		CardgroupID: "cg-target",
+		Payload:     "",
+	})
+	assertGQLErr(t, err, "BAD_USER_INPUT", "payload")
+	if repo.upsertCalls != 0 {
+		t.Fatalf("expected 0 repo calls on empty payload, got %d", repo.upsertCalls)
+	}
+}
+
+// TestDictionaryUsecase_BadBase64BadInput verifies that a payload that is not
+// valid standard base64 is rejected with BAD_USER_INPUT before any repo
+// activity occurs.
+func TestDictionaryUsecase_BadBase64BadInput(t *testing.T) {
+	t.Parallel()
+
+	repo := &mockDictCardRepo{}
+	authChk := &mockAdminChecker{isAdmin: true}
+	tx, _ := dictTxRunner()
+	uc := NewDictionaryUsecaseWithTx(authChk, repo, tx)
+
+	_, err := uc.Upsert(dictionaryAdminCtx("admin-1"), UpsertDictionaryInput{
+		CardgroupID: "cg-target",
+		Payload:     "not-valid-base64-!@#$",
+	})
+	assertGQLErr(t, err, "BAD_USER_INPUT", "payload")
+	if repo.upsertCalls != 0 {
+		t.Fatalf("expected 0 repo calls on bad base64, got %d", repo.upsertCalls)
+	}
+}
+
+// TestDictionaryUsecase_DuplicateFrontDeduplicatedAndSurfaced verifies that
+// when the payload contains two lines with the same front, the later occurrence
+// wins (last-write-wins dedup) and the dropped earlier row surfaces as a
+// DictionaryValidationError with a "duplicate" message. Exactly one card
+// reaches the repository and its Back matches the last occurrence.
+//
+// Note: this test depends on usecase-level deduplication logic. If that logic
+// has not landed yet, the test will fail — that is correct behavior because it
+// documents the expected contract.
+func TestDictionaryUsecase_DuplicateFrontDeduplicatedAndSurfaced(t *testing.T) {
+	t.Parallel()
+
+	// Two lines with the same front "apple"; the second occurrence ("rubbish")
+	// must win. Backs must be valid Japanese-script tokens for the lexer.
+	// U+3042 = HIRAGANA LETTER A (fruit back), U+3052 = HIRAGANA LETTER GE (rubbish back).
+	fruitBack := string([]rune{0x3042, 0x3043, 0x3044})   // hiragana run
+	rubbishBack := string([]rune{0x3052, 0x3053, 0x3054}) // hiragana run (different)
+
+	raw := "apple " + fruitBack + "\napple " + rubbishBack + "\n"
+	payload := base64.StdEncoding.EncodeToString([]byte(raw))
+
+	repo := &mockDictCardRepo{inserted: 1, updated: 0}
+	authChk := &mockAdminChecker{isAdmin: true}
+	tx, _ := dictTxRunner()
+	uc := NewDictionaryUsecaseWithTx(authChk, repo, tx)
+
+	out, err := uc.Upsert(dictionaryAdminCtx("admin-1"), UpsertDictionaryInput{
+		CardgroupID: "cg-target",
+		Payload:     payload,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.Inserted != 1 {
+		t.Fatalf("Inserted = %d, want 1 (dedup keeps last occurrence)", out.Inserted)
+	}
+	if len(out.Errors) != 1 {
+		t.Fatalf("expected exactly 1 duplicate error, got %d: %+v", len(out.Errors), out.Errors)
+	}
+	if len(repo.captured) != 1 {
+		t.Fatalf("expected 1 card sent to repo, got %d", len(repo.captured))
+	}
+	if repo.captured[0].Back != rubbishBack {
+		t.Fatalf("expected repo card Back=%q (last occurrence wins), got %q", rubbishBack, repo.captured[0].Back)
 	}
 }
 

--- a/docs/backend-db.md
+++ b/docs/backend-db.md
@@ -18,6 +18,8 @@ Migration files live under `backend/internal/database/migrations/`. Go's `//go:e
 
 When a migration fails mid-run, `schema_migrations.dirty=true` is set. Recovery requires an operator to run `migrate force <version>`. The `run()` function treats any migration error as fatal and returns immediately (fail-fast). See `docs/playbook-patterns.md` § "Recovering from a dirty migration" for the operator runbook.
 
+**`UPDATE schema_migrations SET dirty = false` alone is not enough.** A failed up migration leaves both `dirty = true` AND `version` pointing at the failed migration. Clearing only the dirty flag leaves the version pointing at the failed file, so the next `Steps(1)` call goes looking for migration `<failed+1>` and fails with `os.ErrNotExist`. The idiomatic recovery is `m.Force(<predecessor_version>)` — it rewrites both fields atomically and lets `Steps(1)` re-apply the original migration. The same gotcha applies to test code that simulates a dirty state via the migrate Go API; see `MigrateForceForTest` in `internal/database/export_test.go`.
+
 #### golang-migrate transaction behaviour
 
 **The `pgx/v5` driver does NOT auto-wrap each migration file in a transaction.** Every migration that requires atomicity must open its own `BEGIN; ... COMMIT;` block explicitly. A migration file that omits `BEGIN/COMMIT` and mixes DDL with privilege-sensitive statements (e.g. `ALTER TABLE ... ENABLE ROW LEVEL SECURITY`) can partially succeed: the DDL commits, the later statement fails, and `schema_migrations.dirty=true` persists because golang-migrate commits that flag in its own separate transaction *before* it begins executing the migration SQL.
@@ -62,6 +64,12 @@ $$;
 - `SET search_path = public` — neutralises the classic `SECURITY DEFINER` injection vector where an attacker creates a `pg_temp` shim function (e.g. their own `roles` table) that the function would otherwise resolve before the real one.
 - `REVOKE ALL FROM PUBLIC` then narrow `GRANT EXECUTE` — without revoking from `PUBLIC`, anonymous PostgREST callers (`anon` role) could invoke the helper as an oracle to enumerate role assignments. The grant is intentionally limited to the Supabase-managed `authenticated` role.
 - `DO $$ ... IF EXISTS pg_roles ... GRANT END $$` portability guard — plain PostgreSQL does not include Supabase-managed roles (`authenticated`, `anon`, `service_role`) by default. Wrapping role-specific GRANTs in this conditional `DO` block keeps the migration applicable outside Supabase. Testcontainers create a minimal `authenticated` role fixture so RLS behavior can be exercised directly. The Go backend connects as the table owner and bypasses RLS, so the GRANT path is used only by direct PostgREST / Edge callers in production.
+
+### Postgres upsert: classifying inserted vs updated rows in one round-trip
+
+`INSERT ... ON CONFLICT (key) DO UPDATE ... RETURNING (xmax = 0) AS inserted` lets a single statement report which rows were inserted and which were updated. PostgreSQL marks freshly inserted rows with `xmax = 0` and ON-CONFLICT-updated rows with `xmax = current_xid`, so the boolean expression in `RETURNING` classifies each row inline — no second `SELECT`, no application-side bookkeeping. The `cards` upsert path uses this in `cardRepo.UpsertManyTx` to compute the `inserted` / `updated` split.
+
+The flip side is that the conflict key MUST be unique within the input batch. If two rows in the same `INSERT ... VALUES (...), (...)` collide on the conflict target, Postgres raises SQLSTATE `21000` ("ON CONFLICT DO UPDATE command cannot affect row a second time") and aborts the whole statement — Postgres deliberately does not silently merge intra-batch duplicates because either-row-wins is non-deterministic. The application layer must dedup by conflict key before issuing the SQL; the dictionary usecase keeps the *last* occurrence and reports earlier ones as soft errors.
 
 ### Startup order
 

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -81,6 +81,10 @@ These values target a public API on Render. Revisit if the threat model or deplo
 
 Usecases that need an injectable `txRunner` for resolver-level wire tests (e.g., `NewCardUsecaseWithTx`) are exported solely to let `package resolver_test` inject a hand-rolled mock. The trade-off is intentional: `txRunner` is unexported, so callers outside the package cannot misuse the seam; the alternative — moving tests into `package resolver` — gives up the `_test`-package isolation convention. When adding similar usecases, prefer this pattern over exposing production internals to tests via the non-`_test` package.
 
+### Consumer-defined narrow interfaces over re-using the full repository / service interface
+
+When a usecase only needs one or two methods of `repository.CardRepository` or `auth.Service`, declare a local interface in the usecase file (e.g. `dictionaryUsecase`'s `AdminChecker` and `DictionaryCardRepository`) that lists *only* those methods. The production constructor accepts the wide concrete type (`*auth.Service`, `repository.CardRepository`) and the compiler checks structural conformance; tests pass a stub that implements just the narrow surface. This avoids the secondary problem of having to mock every method on the full interface in every test, and keeps the seam clear about which methods the usecase actually depends on.
+
 ### Resolver-level wire tests
 
 To catch wire-format regressions that usecase-layer unit tests miss (e.g., `Int` codec changes, `extensions.code` shape), build a `handler.NewServer` against a `Resolver` whose UC fields point at hand-rolled mocks. The harness pattern is in `backend/graph/resolver/user_test.go`; `backend/graph/resolver/card_resolvers_test.go` is the second example. These tests verify that gqlgen correctly hydrates a generated input model AND that the resolver maps domain sentinels to the expected GraphQL error shape.
@@ -112,6 +116,8 @@ if err != nil {
 ```
 
 Applies to every resolver that performs a blocking external call. Without this guard, `slog.ErrorContext` and any downstream alerting (Sentry, dashboards) get polluted by client cancellations that are not server bugs.
+
+The same rule extends to **usecases that wrap a `db.Transaction` or call an injected service** (e.g. `AdminChecker.IsAdmin`, `CardRepository.UpsertManyTx`). When a usecase is the layer that catches the error, route `context.Canceled` / `context.DeadlineExceeded` through `gqlerr.Cancelled` (WARN-level log) and everything else through `gqlerr.Internal` (ERROR-level log). `dictionaryUsecase.Upsert` shows both the auth-call site and the transaction-runner site applying this guard.
 
 ### Legacy ports: revisit boundaries before re-translating
 

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -287,6 +287,8 @@ if (result?.data?.updateCardgroup?.cardgroup) {
 
 **Form remount via React `key` to reset fields:** After a successful create-mutation, bump a numeric `key` state variable passed to the form component (`<CardForm key={createFormKey} ...>`). React unmounts and remounts the component, resetting all TanStack Form field state without manual `form.reset()` calls.
 
+**Validate-then-mutate flows must invalidate the validation result on input edit.** When a UI splits a server-side check (`validateDictionary`) from a destructive mutation (`upsertDictionary`) and gates the mutation button on the validation result, the validation state goes stale the instant the user edits any input feeding into it. Without explicit invalidation, the user can validate text A, edit to text B, and then submit B against a "valid" gate. The pattern is a `useEffect(() => setValidation(null), [<all input deps>])` whose callback only resets state — the deps array is trigger-only, which Biome flags as `lint/correctness/useExhaustiveDependencies`. Suppress with the inline `biome-ignore` comment as in `frontend/src/app/admin/dictionary/dictionary-client.tsx`.
+
 #### Bio explicit clear UX
 
 `bio` follows tri-state semantics:
@@ -310,6 +312,8 @@ field to `""` so the next submit clears the column.
 **Real `InMemoryCache` for cache-write/evict tests:** Passing a real `InMemoryCache` to `<MockedProvider cache={cache}>` and pre-seeding it via `cache.writeQuery(...)` lets tests assert the actual cache state after a mutation (`cache.readQuery(...)`) rather than only observable side-effects. Use this to prove that `update` callbacks correctly prepend or evict entries.
 
 **Inverse navigation assertion in failure-path tests:** Use `expect(mockPush).not.toHaveBeenCalled()` in error-path tests to pin down "navigate-on-failure" regressions. Without this assertion, a handler that navigates unconditionally passes happy-path tests but silently breaks on errors.
+
+**`__typename` in `MockedProvider` mocks must match the generated schema type name.** Apollo's normalization layer keys cache entries on `__typename` + identifying fields, and inline-included children are also keyed by their `__typename`. A made-up name (e.g. `"ValidationError"` instead of the schema's `DictionaryValidationError`) is silently degrading: the mock still resolves, but the cache stores a malformed entry and the next lookup misses. Copy the type name from `frontend/src/generated/graphql.ts` rather than guessing.
 
 ## shadcn/ui
 

--- a/frontend/__tests__/admin-dictionary.test.tsx
+++ b/frontend/__tests__/admin-dictionary.test.tsx
@@ -101,12 +101,28 @@ const UPSERT_FORBIDDEN_MOCK = {
   },
   result: {
     errors: [
-      // Use uppercase "FORBIDDEN" in the message so classifyError's
-      // err.message.includes("FORBIDDEN") branch triggers correctly.
-      // The new CombinedGraphQLErrors type exposes .errors not .graphQLErrors,
-      // so the graphQLErrors branch in classifyError does not fire.
-      new GraphQLError("FORBIDDEN", { extensions: { code: "FORBIDDEN" } }),
+      // Use a realistic message; classifyError inspects extensions.code === "FORBIDDEN",
+      // not the message string. Apollo throws a CombinedGraphQLErrors so the catch block
+      // in handleImport receives it and classifyError correctly identifies the code.
+      new GraphQLError("admin role required", { extensions: { code: "FORBIDDEN" } }),
     ],
+  },
+};
+
+const UPSERT_ALL_ERRORS_MOCK = {
+  request: {
+    query: UpsertDictionaryDocument,
+    variables: { input: { cardgroupId: "cg-1", payload: ENCODED_PAYLOAD } },
+  },
+  result: {
+    data: {
+      upsertDictionary: {
+        __typename: "UpsertDictionaryPayload",
+        inserted: 0,
+        updated: 0,
+        errors: [{ __typename: "UpsertDictionaryError", line: 1, message: "fk violation" }],
+      },
+    },
   },
 };
 
@@ -209,7 +225,7 @@ describe("DictionaryImportClient — validate → import flow", () => {
   });
 
   // T3: Import returns FORBIDDEN → "Admin role required." banner
-  it("shows 'Admin role required.' when upsertDictionary returns FORBIDDEN", async () => {
+  it("shows 'Admin role required.' when upsertDictionary returns FORBIDDEN (via extensions.code)", async () => {
     const user = userEvent.setup({ delay: null });
     renderComponent([CARDGROUPS_MOCK, VALIDATE_SUCCESS_MOCK, UPSERT_FORBIDDEN_MOCK]);
 
@@ -233,5 +249,65 @@ describe("DictionaryImportClient — validate → import flow", () => {
     // FORBIDDEN banner appears.
     const alert = await screen.findByRole("alert");
     expect(alert).toHaveTextContent("Admin role required.");
+  });
+
+  // T4: Editing the textarea after successful validation disables the Import button.
+  it("disables Import button when the user edits the textarea after validation", async () => {
+    const user = userEvent.setup({ delay: null });
+    // Provide two validate mocks: one for the initial typed payload (used in step 1)
+    // and the FORBIDDEN mock is unrelated — we only need cardgroups + validate here.
+    renderComponent([CARDGROUPS_MOCK, VALIDATE_SUCCESS_MOCK]);
+
+    // Wait for cardgroup selector and select a cardgroup.
+    const select = await screen.findByRole("combobox", { name: /target cardgroup/i });
+    await user.selectOptions(select, "cg-1");
+
+    // Type payload into textarea.
+    const textarea = screen.getByRole("textbox", { name: /dictionary payload/i });
+    await user.type(textarea, PAYLOAD_TEXT);
+
+    // Click Validate.
+    await user.click(screen.getByRole("button", { name: /^validate$/i }));
+
+    // Wait for validation result — Import button should be enabled.
+    await screen.findByText("hello");
+    const importBtn = screen.getByRole("button", { name: /^import$/i });
+    expect(importBtn).not.toBeDisabled();
+
+    // User edits the textarea — validation result should be invalidated.
+    await user.type(textarea, "x");
+
+    // Import button must be disabled again because the stale validation was cleared.
+    expect(importBtn).toBeDisabled();
+  });
+
+  // T5: Import with all errors (0 inserted, 0 updated) renders destructive banner.
+  it("shows destructive banner when import persists no rows and has parse errors", async () => {
+    const user = userEvent.setup({ delay: null });
+    renderComponent([CARDGROUPS_MOCK, VALIDATE_SUCCESS_MOCK, UPSERT_ALL_ERRORS_MOCK]);
+
+    // Select cardgroup.
+    const select = await screen.findByRole("combobox", { name: /target cardgroup/i });
+    await user.selectOptions(select, "cg-1");
+
+    // Type payload.
+    const textarea = screen.getByRole("textbox", { name: /dictionary payload/i });
+    await user.type(textarea, PAYLOAD_TEXT);
+
+    // Validate first.
+    await user.click(screen.getByRole("button", { name: /^validate$/i }));
+    await screen.findByText("hello");
+
+    // Click Import.
+    const importBtn = screen.getByRole("button", { name: /^import$/i });
+    expect(importBtn).not.toBeDisabled();
+    await user.click(importBtn);
+
+    // Destructive banner appears instead of the green success banner.
+    const failAlert = await screen.findByRole("alert");
+    expect(failAlert).toHaveTextContent("Import failed");
+    expect(failAlert).toHaveTextContent("no rows persisted");
+    // The individual parse error is still shown in the error list.
+    expect(await screen.findByText(/fk violation/i)).toBeInTheDocument();
   });
 });

--- a/frontend/__tests__/admin-dictionary.test.tsx
+++ b/frontend/__tests__/admin-dictionary.test.tsx
@@ -1,0 +1,237 @@
+// @vitest-environment jsdom
+import { MockedProvider } from "@apollo/client/testing/react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { GraphQLError } from "graphql";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DictionaryImportClient } from "@/app/admin/dictionary/dictionary-client";
+import {
+  MyCardgroupsDocument,
+  UpsertDictionaryDocument,
+  ValidateDictionaryDocument,
+} from "@/generated/graphql";
+
+// Compute the expected base64 payload for "hello\tworld\nfoo\tbar"
+// encodePayload mirrors the inline helper in dictionary-client.tsx:
+//   btoa(unescape(encodeURIComponent(text)))
+function encodePayload(text: string): string {
+  return btoa(unescape(encodeURIComponent(text)));
+}
+
+const PAYLOAD_TEXT = "hello\tworld\nfoo\tbar";
+const ENCODED_PAYLOAD = encodePayload(PAYLOAD_TEXT);
+
+const CARDGROUPS_MOCK = {
+  request: {
+    query: MyCardgroupsDocument,
+    variables: {},
+  },
+  result: {
+    data: {
+      myCardgroups: [
+        {
+          __typename: "Cardgroup",
+          id: "cg-1",
+          name: "My Cards",
+          updatedAt: "2024-01-01T00:00:00Z",
+        },
+      ],
+    },
+  },
+};
+
+const VALIDATE_SUCCESS_MOCK = {
+  request: {
+    query: ValidateDictionaryDocument,
+    variables: { input: { payload: ENCODED_PAYLOAD } },
+  },
+  result: {
+    data: {
+      validateDictionary: {
+        __typename: "DictionaryValidationResult",
+        valid: true,
+        parsedWords: [
+          { __typename: "ParsedWord", front: "hello", back: "world", line: 1 },
+          { __typename: "ParsedWord", front: "foo", back: "bar", line: 2 },
+        ],
+        errors: [],
+      },
+    },
+  },
+};
+
+const VALIDATE_WITH_ERRORS_MOCK = {
+  request: {
+    query: ValidateDictionaryDocument,
+    variables: { input: { payload: ENCODED_PAYLOAD } },
+  },
+  result: {
+    data: {
+      validateDictionary: {
+        __typename: "DictionaryValidationResult",
+        valid: false,
+        parsedWords: [{ __typename: "ParsedWord", front: "good", back: "row", line: 1 }],
+        errors: [{ __typename: "DictionaryValidationError", line: 2, message: "missing back" }],
+      },
+    },
+  },
+};
+
+const UPSERT_SUCCESS_MOCK = {
+  request: {
+    query: UpsertDictionaryDocument,
+    variables: { input: { cardgroupId: "cg-1", payload: ENCODED_PAYLOAD } },
+  },
+  result: {
+    data: {
+      upsertDictionary: {
+        __typename: "UpsertDictionaryPayload",
+        inserted: 2,
+        updated: 0,
+        errors: [],
+      },
+    },
+  },
+};
+
+const UPSERT_FORBIDDEN_MOCK = {
+  request: {
+    query: UpsertDictionaryDocument,
+    variables: { input: { cardgroupId: "cg-1", payload: ENCODED_PAYLOAD } },
+  },
+  result: {
+    errors: [
+      // Use uppercase "FORBIDDEN" in the message so classifyError's
+      // err.message.includes("FORBIDDEN") branch triggers correctly.
+      // The new CombinedGraphQLErrors type exposes .errors not .graphQLErrors,
+      // so the graphQLErrors branch in classifyError does not fire.
+      new GraphQLError("FORBIDDEN", { extensions: { code: "FORBIDDEN" } }),
+    ],
+  },
+};
+
+let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  consoleErrorSpy.mockRestore();
+  consoleWarnSpy.mockRestore();
+});
+
+function renderComponent(mocks: object[]) {
+  render(
+    <MockedProvider mocks={mocks as never}>
+      <DictionaryImportClient />
+    </MockedProvider>,
+  );
+}
+
+describe("DictionaryImportClient — validate → import flow", () => {
+  // T1: Happy path: validate then import
+  it("validates input, shows preview, enables Import, then imports and shows result", async () => {
+    const user = userEvent.setup({ delay: null });
+    renderComponent([CARDGROUPS_MOCK, VALIDATE_SUCCESS_MOCK, UPSERT_SUCCESS_MOCK]);
+
+    // Wait for cardgroup selector to populate.
+    const select = await screen.findByRole("combobox", { name: /target cardgroup/i });
+    await user.selectOptions(select, "cg-1");
+
+    // Type payload into textarea.
+    const textarea = screen.getByRole("textbox", { name: /dictionary payload/i });
+    await user.type(textarea, PAYLOAD_TEXT);
+
+    // Import button must be disabled before validation.
+    const importBtn = screen.getByRole("button", { name: /^import$/i });
+    expect(importBtn).toBeDisabled();
+
+    // Click Validate.
+    await user.click(screen.getByRole("button", { name: /^validate$/i }));
+
+    // Preview table rows appear.
+    expect(await screen.findByText("hello")).toBeInTheDocument();
+    expect(screen.getByText("world")).toBeInTheDocument();
+    expect(screen.getByText("foo")).toBeInTheDocument();
+    expect(screen.getByText("bar")).toBeInTheDocument();
+
+    // Validation summary shows valid status.
+    expect(screen.getByRole("status")).toHaveTextContent("Valid");
+
+    // Import button is now enabled.
+    expect(importBtn).not.toBeDisabled();
+
+    // Click Import.
+    await user.click(importBtn);
+
+    // Success message appears.
+    const successStatus = await screen.findByRole("status", {
+      name: (_, el) => el.textContent?.includes("Import complete") ?? false,
+    });
+    expect(successStatus).toHaveTextContent("2 inserted");
+    expect(successStatus).toHaveTextContent("0 updated");
+  });
+
+  // T2: Validation surfaces errors; Import stays disabled when valid is false
+  it("shows parsed words and parse errors; Import remains disabled when valid is false", async () => {
+    const user = userEvent.setup({ delay: null });
+    renderComponent([CARDGROUPS_MOCK, VALIDATE_WITH_ERRORS_MOCK]);
+
+    // Wait for cardgroup selector and select a cardgroup.
+    const select = await screen.findByRole("combobox", { name: /target cardgroup/i });
+    await user.selectOptions(select, "cg-1");
+
+    // Type payload into textarea.
+    const textarea = screen.getByRole("textbox", { name: /dictionary payload/i });
+    await user.type(textarea, PAYLOAD_TEXT);
+
+    // Click Validate.
+    await user.click(screen.getByRole("button", { name: /^validate$/i }));
+
+    // The successfully-parsed word is shown in the preview table.
+    expect(await screen.findByText("good")).toBeInTheDocument();
+    expect(screen.getByText("row")).toBeInTheDocument();
+
+    // The parse error is rendered and visually distinguishable (shown in errors list).
+    expect(screen.getByText(/missing back/i)).toBeInTheDocument();
+    // The error list item includes the line number prefix.
+    expect(screen.getByText(/line 2/i)).toBeInTheDocument();
+
+    // Validation summary reflects invalid status.
+    expect(screen.getByRole("status")).toHaveTextContent("Invalid");
+
+    // Import button must remain disabled: valid is false so canImport is false.
+    const importBtn = screen.getByRole("button", { name: /^import$/i });
+    expect(importBtn).toBeDisabled();
+  });
+
+  // T3: Import returns FORBIDDEN → "Admin role required." banner
+  it("shows 'Admin role required.' when upsertDictionary returns FORBIDDEN", async () => {
+    const user = userEvent.setup({ delay: null });
+    renderComponent([CARDGROUPS_MOCK, VALIDATE_SUCCESS_MOCK, UPSERT_FORBIDDEN_MOCK]);
+
+    // Select cardgroup.
+    const select = await screen.findByRole("combobox", { name: /target cardgroup/i });
+    await user.selectOptions(select, "cg-1");
+
+    // Type payload.
+    const textarea = screen.getByRole("textbox", { name: /dictionary payload/i });
+    await user.type(textarea, PAYLOAD_TEXT);
+
+    // Validate first.
+    await user.click(screen.getByRole("button", { name: /^validate$/i }));
+    await screen.findByText("hello");
+
+    // Click Import.
+    const importBtn = screen.getByRole("button", { name: /^import$/i });
+    expect(importBtn).not.toBeDisabled();
+    await user.click(importBtn);
+
+    // FORBIDDEN banner appears.
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent("Admin role required.");
+  });
+});

--- a/frontend/__tests__/admin-dictionary.test.tsx
+++ b/frontend/__tests__/admin-dictionary.test.tsx
@@ -120,7 +120,7 @@ const UPSERT_ALL_ERRORS_MOCK = {
         __typename: "UpsertDictionaryPayload",
         inserted: 0,
         updated: 0,
-        errors: [{ __typename: "UpsertDictionaryError", line: 1, message: "fk violation" }],
+        errors: [{ __typename: "DictionaryValidationError", line: 1, message: "fk violation" }],
       },
     },
   },

--- a/frontend/src/app/admin/dictionary/dictionary-client.tsx
+++ b/frontend/src/app/admin/dictionary/dictionary-client.tsx
@@ -1,0 +1,308 @@
+"use client";
+
+import { useLazyQuery, useMutation, useQuery } from "@apollo/client/react";
+import Link from "next/link";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { getBackendErrorBanner } from "@/lib/apollo/errors";
+import {
+  AdminDictionaryCardgroupsQuery,
+  UpsertDictionaryMutation,
+  ValidateDictionaryQuery,
+} from "./queries";
+
+/**
+ * Encode a UTF-8 string to base64 using the standard alphabet (with padding).
+ * Matches the server contract for `payload` in ValidateDictionaryInput /
+ * UpsertDictionaryInput: base64-encoded text, one tab-separated front/back
+ * pair per line.
+ */
+function encodePayload(text: string): string {
+  // encodeURIComponent escapes all non-ASCII bytes; unescape maps them back to
+  // a byte string so that btoa sees only ASCII characters.
+  return btoa(unescape(encodeURIComponent(text)));
+}
+
+type ValidationResult = {
+  valid: boolean;
+  parsedWords: Array<{ front: string; back: string; line: number }>;
+  errors: Array<{ line: number; message: string }>;
+};
+
+type ImportResult = {
+  inserted: number;
+  updated: number;
+  errors: Array<{ line: number; message: string }>;
+};
+
+/**
+ * Classify a raw Apollo error into a user-facing banner string.
+ * FORBIDDEN gets a specific message because the page renders for any
+ * authenticated user (see page.tsx JSDoc for the transitional gate rationale).
+ */
+function classifyError(err: unknown): string {
+  if (!err) return "";
+  // Attempt FORBIDDEN detection first by inspecting the raw error message,
+  // then fall back to the generic banner helper for INTERNAL / network errors.
+  if (err instanceof Error && err.message.includes("FORBIDDEN")) {
+    return "Admin role required.";
+  }
+  // Check for GraphQL errors with FORBIDDEN extension code.
+  const anyErr = err as {
+    graphQLErrors?: Array<{ extensions?: { code?: string }; message: string }>;
+  };
+  if (Array.isArray(anyErr.graphQLErrors)) {
+    for (const ge of anyErr.graphQLErrors) {
+      if (ge.extensions?.code === "FORBIDDEN") {
+        return "Admin role required.";
+      }
+    }
+  }
+  return getBackendErrorBanner(err) ?? "An unexpected error occurred. Please try again.";
+}
+
+export function DictionaryImportClient() {
+  const [cardgroupId, setCardgroupId] = useState<string>("");
+  const [payloadText, setPayloadText] = useState<string>("");
+  const [validationResult, setValidationResult] = useState<ValidationResult | null>(null);
+  const [importResult, setImportResult] = useState<ImportResult | null>(null);
+  const [bannerError, setBannerError] = useState<string>("");
+
+  const {
+    data: cardgroupsData,
+    loading: cardgroupsLoading,
+    error: cardgroupsError,
+  } = useQuery(AdminDictionaryCardgroupsQuery);
+
+  const [runValidate, { loading: validating }] = useLazyQuery(ValidateDictionaryQuery, {
+    fetchPolicy: "no-cache",
+  });
+
+  const [runUpsert, { loading: upserting }] = useMutation(UpsertDictionaryMutation);
+
+  const cardgroups = cardgroupsData?.myCardgroups ?? [];
+  const cardgroupsErrorBanner = getBackendErrorBanner(cardgroupsError);
+
+  async function handleValidate() {
+    setBannerError("");
+    setValidationResult(null);
+    setImportResult(null);
+    const payload = encodePayload(payloadText);
+    try {
+      const result = await runValidate({ variables: { input: { payload } } });
+      if (result.data?.validateDictionary) {
+        setValidationResult(result.data.validateDictionary);
+      }
+      if (result.error) {
+        setBannerError(classifyError(result.error));
+      }
+    } catch (err) {
+      setBannerError(classifyError(err));
+    }
+  }
+
+  async function handleImport() {
+    if (!cardgroupId) {
+      setBannerError("Please select a cardgroup before importing.");
+      return;
+    }
+    setBannerError("");
+    setImportResult(null);
+    const payload = encodePayload(payloadText);
+    try {
+      const result = await runUpsert({
+        variables: { input: { cardgroupId, payload } },
+      });
+      if (result.data?.upsertDictionary) {
+        setImportResult(result.data.upsertDictionary);
+      }
+    } catch (err) {
+      setBannerError(classifyError(err));
+    }
+  }
+
+  const canImport =
+    validationResult?.valid === true && validationResult.parsedWords.length > 0 && !!cardgroupId;
+
+  return (
+    <main className="mx-auto max-w-3xl p-8">
+      <div className="mb-6 flex items-center gap-4">
+        <Link href="/cardgroups" className="text-sm text-muted-foreground hover:underline">
+          &larr; Back
+        </Link>
+        <h1 className="text-2xl font-semibold">Dictionary Import</h1>
+      </div>
+
+      {cardgroupsErrorBanner && (
+        <div
+          className="mb-4 rounded-md bg-destructive/10 p-3 text-sm text-destructive"
+          role="alert"
+        >
+          {cardgroupsErrorBanner}
+        </div>
+      )}
+
+      {bannerError && (
+        <div
+          className="mb-4 rounded-md bg-destructive/10 p-3 text-sm text-destructive"
+          role="alert"
+        >
+          {bannerError}
+        </div>
+      )}
+
+      <div className="space-y-6">
+        {/* Cardgroup selector */}
+        <div className="space-y-2">
+          <label htmlFor="cardgroup-select" className="block text-sm font-medium">
+            Target cardgroup
+          </label>
+          {cardgroupsLoading ? (
+            <p className="text-sm text-muted-foreground">Loading cardgroups...</p>
+          ) : (
+            <select
+              id="cardgroup-select"
+              value={cardgroupId}
+              onChange={(e) => setCardgroupId(e.target.value)}
+              className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              <option value="">Select a cardgroup</option>
+              {cardgroups.map((cg) => (
+                <option key={cg.id} value={cg.id}>
+                  {cg.name}
+                </option>
+              ))}
+            </select>
+          )}
+        </div>
+
+        {/* Payload textarea */}
+        <div className="space-y-2">
+          <label htmlFor="payload-textarea" className="block text-sm font-medium">
+            Dictionary payload
+          </label>
+          <p className="text-xs text-muted-foreground">
+            One entry per line. Each line: <code>front[tab]back</code>
+          </p>
+          <textarea
+            id="payload-textarea"
+            value={payloadText}
+            onChange={(e) => setPayloadText(e.target.value)}
+            rows={10}
+            className="w-full rounded-md border border-input bg-background px-3 py-2 font-mono text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            placeholder={"apple\tapple (the fruit)\nbanana\ta yellow fruit"}
+          />
+        </div>
+
+        {/* Action buttons */}
+        <div className="flex gap-3">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={handleValidate}
+            disabled={validating || !payloadText.trim()}
+          >
+            {validating ? "Validating..." : "Validate"}
+          </Button>
+          <Button type="button" onClick={handleImport} disabled={!canImport || upserting}>
+            {upserting ? "Importing..." : "Import"}
+          </Button>
+        </div>
+
+        {/* Validation result */}
+        {validationResult && (
+          <section className="space-y-4">
+            <div
+              className={`rounded-md p-3 text-sm ${
+                validationResult.valid
+                  ? "bg-green-50 text-green-800"
+                  : "bg-destructive/10 text-destructive"
+              }`}
+              role="status"
+            >
+              {validationResult.valid
+                ? `Valid — ${validationResult.parsedWords.length} word${validationResult.parsedWords.length === 1 ? "" : "s"} parsed.`
+                : `Invalid — ${validationResult.errors.length} error${validationResult.errors.length === 1 ? "" : "s"} found.`}
+            </div>
+
+            {validationResult.parsedWords.length > 0 && (
+              <div>
+                <h2 className="mb-2 text-sm font-medium uppercase tracking-wide text-muted-foreground">
+                  Preview ({validationResult.parsedWords.length} entries)
+                </h2>
+                <div className="overflow-auto rounded-md border border-border">
+                  <table className="w-full text-sm">
+                    <thead className="bg-muted/50">
+                      <tr>
+                        <th className="px-3 py-2 text-left font-medium text-muted-foreground">
+                          Line
+                        </th>
+                        <th className="px-3 py-2 text-left font-medium text-muted-foreground">
+                          Front
+                        </th>
+                        <th className="px-3 py-2 text-left font-medium text-muted-foreground">
+                          Back
+                        </th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {validationResult.parsedWords.map((word) => (
+                        <tr key={word.line} className="border-t border-border">
+                          <td className="px-3 py-2 text-muted-foreground">{word.line}</td>
+                          <td className="px-3 py-2">{word.front}</td>
+                          <td className="px-3 py-2">{word.back}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            )}
+
+            {validationResult.errors.length > 0 && (
+              <div>
+                <h2 className="mb-2 text-sm font-medium uppercase tracking-wide text-muted-foreground">
+                  Parse errors
+                </h2>
+                <ul className="space-y-1">
+                  {validationResult.errors.map((err) => (
+                    <li
+                      key={`${err.line}-${err.message}`}
+                      className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive"
+                    >
+                      <span className="font-medium">Line {err.line}:</span> {err.message}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </section>
+        )}
+
+        {/* Import result */}
+        {importResult && (
+          <section>
+            <div className="rounded-md bg-green-50 p-3 text-sm text-green-800" role="status">
+              Import complete — {importResult.inserted} inserted, {importResult.updated} updated
+              {importResult.errors.length > 0 &&
+                `, ${importResult.errors.length} error${importResult.errors.length === 1 ? "" : "s"}`}
+              .
+            </div>
+            {importResult.errors.length > 0 && (
+              <ul className="mt-2 space-y-1">
+                {importResult.errors.map((err) => (
+                  <li
+                    key={`${err.line}-${err.message}`}
+                    className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive"
+                  >
+                    <span className="font-medium">Line {err.line}:</span> {err.message}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/app/admin/dictionary/dictionary-client.tsx
+++ b/frontend/src/app/admin/dictionary/dictionary-client.tsx
@@ -1,8 +1,9 @@
 "use client";
 
+import { CombinedGraphQLErrors } from "@apollo/client/errors";
 import { useLazyQuery, useMutation, useQuery } from "@apollo/client/react";
 import Link from "next/link";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { getBackendErrorBanner } from "@/lib/apollo/errors";
 import {
@@ -42,20 +43,9 @@ type ImportResult = {
  */
 function classifyError(err: unknown): string {
   if (!err) return "";
-  // Attempt FORBIDDEN detection first by inspecting the raw error message,
-  // then fall back to the generic banner helper for INTERNAL / network errors.
-  if (err instanceof Error && err.message.includes("FORBIDDEN")) {
-    return "Admin role required.";
-  }
-  // Check for GraphQL errors with FORBIDDEN extension code.
-  const anyErr = err as {
-    graphQLErrors?: Array<{ extensions?: { code?: string }; message: string }>;
-  };
-  if (Array.isArray(anyErr.graphQLErrors)) {
-    for (const ge of anyErr.graphQLErrors) {
-      if (ge.extensions?.code === "FORBIDDEN") {
-        return "Admin role required.";
-      }
+  if (CombinedGraphQLErrors.is(err)) {
+    for (const ge of err.errors) {
+      if (ge.extensions?.code === "FORBIDDEN") return "Admin role required.";
     }
   }
   return getBackendErrorBanner(err) ?? "An unexpected error occurred. Please try again.";
@@ -67,6 +57,18 @@ export function DictionaryImportClient() {
   const [validationResult, setValidationResult] = useState<ValidationResult | null>(null);
   const [importResult, setImportResult] = useState<ImportResult | null>(null);
   const [bannerError, setBannerError] = useState<string>("");
+
+  // Invalidate validation when the user edits the payload or switches cardgroup,
+  // so Import stays disabled until they re-Validate. Without this, a stale
+  // validate result lets users import a payload that no longer matches the
+  // validated structure. payloadText and cardgroupId are trigger-only deps:
+  // the callback always resets to null and does not read them.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional trigger-only deps
+  useEffect(() => {
+    setValidationResult(null);
+    setImportResult(null);
+    setBannerError("");
+  }, [payloadText, cardgroupId]);
 
   const {
     data: cardgroupsData,
@@ -113,6 +115,10 @@ export function DictionaryImportClient() {
       const result = await runUpsert({
         variables: { input: { cardgroupId, payload } },
       });
+      if (result.error) {
+        setBannerError(classifyError(result.error));
+        return;
+      }
       if (result.data?.upsertDictionary) {
         setImportResult(result.data.upsertDictionary);
       }
@@ -282,12 +288,21 @@ export function DictionaryImportClient() {
         {/* Import result */}
         {importResult && (
           <section>
-            <div className="rounded-md bg-green-50 p-3 text-sm text-green-800" role="status">
-              Import complete — {importResult.inserted} inserted, {importResult.updated} updated
-              {importResult.errors.length > 0 &&
-                `, ${importResult.errors.length} error${importResult.errors.length === 1 ? "" : "s"}`}
-              .
-            </div>
+            {importResult.inserted === 0 &&
+            importResult.updated === 0 &&
+            importResult.errors.length > 0 ? (
+              <div className="rounded-md bg-red-50 p-3 text-sm text-red-800" role="alert">
+                Import failed: no rows persisted, {importResult.errors.length} parse error
+                {importResult.errors.length === 1 ? "" : "s"}.
+              </div>
+            ) : (
+              <div className="rounded-md bg-green-50 p-3 text-sm text-green-800" role="status">
+                Import complete — {importResult.inserted} inserted, {importResult.updated} updated
+                {importResult.errors.length > 0 &&
+                  `, ${importResult.errors.length} error${importResult.errors.length === 1 ? "" : "s"}`}
+                .
+              </div>
+            )}
             {importResult.errors.length > 0 && (
               <ul className="mt-2 space-y-1">
                 {importResult.errors.map((err) => (

--- a/frontend/src/app/admin/dictionary/page.tsx
+++ b/frontend/src/app/admin/dictionary/page.tsx
@@ -1,0 +1,25 @@
+/**
+ * Admin Dictionary Import.
+ *
+ * Transitional admin gate: this page does NOT enforce admin on the frontend.
+ * The `validateDictionary` query and `upsertDictionary` mutation both reject
+ * non-admin callers server-side with FORBIDDEN. Once issue #60 (admin user
+ * list + role assignment, which adds `User.roles` to the schema) lands, the
+ * gate moves to a server-side check on the route segment layout.
+ */
+
+import { redirect } from "next/navigation";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+import { DictionaryImportClient } from "./dictionary-client";
+
+export default async function AdminDictionaryPage() {
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+    error: authErr,
+  } = await supabase.auth.getUser();
+  if (authErr) throw authErr;
+  if (!user) redirect("/login");
+
+  return <DictionaryImportClient />;
+}

--- a/frontend/src/app/admin/dictionary/page.tsx
+++ b/frontend/src/app/admin/dictionary/page.tsx
@@ -3,9 +3,10 @@
  *
  * Transitional admin gate: this page does NOT enforce admin on the frontend.
  * The `validateDictionary` query and `upsertDictionary` mutation both reject
- * non-admin callers server-side with FORBIDDEN. Once issue #60 (admin user
- * list + role assignment, which adds `User.roles` to the schema) lands, the
- * gate moves to a server-side check on the route segment layout.
+ * non-admin callers server-side with FORBIDDEN. Once issue #60 (admin layout
+ * + role CRUD, which adds `frontend/src/app/admin/layout.tsx` as the unified
+ * admin gate) lands, the gate moves to a server-side check on the route
+ * segment layout.
  */
 
 import { redirect } from "next/navigation";

--- a/frontend/src/app/admin/dictionary/queries.ts
+++ b/frontend/src/app/admin/dictionary/queries.ts
@@ -1,0 +1,35 @@
+import { graphql } from "@/generated";
+
+// Re-export the existing cardgroups query so the cardgroup selector shares
+// the same document and Apollo cache key as the main cardgroups page.
+export { MyCardgroupsQuery as AdminDictionaryCardgroupsQuery } from "@/app/cardgroups/queries";
+
+export const ValidateDictionaryQuery = graphql(`
+  query ValidateDictionary($input: ValidateDictionaryInput!) {
+    validateDictionary(input: $input) {
+      valid
+      parsedWords {
+        front
+        back
+        line
+      }
+      errors {
+        line
+        message
+      }
+    }
+  }
+`);
+
+export const UpsertDictionaryMutation = graphql(`
+  mutation UpsertDictionary($input: UpsertDictionaryInput!) {
+    upsertDictionary(input: $input) {
+      inserted
+      updated
+      errors {
+        line
+        message
+      }
+    }
+  }
+`);

--- a/schema/schema.graphql
+++ b/schema/schema.graphql
@@ -299,3 +299,37 @@ extend type Query {
   """
   validateDictionary(input: ValidateDictionaryInput!): DictionaryValidationResult!
 }
+
+"""
+Input for upserting a parsed dictionary into a target cardgroup.
+`UpsertDictionaryInput` reuses the same base64 + tab/space-separated front/back format as `validateDictionary`.
+"""
+input UpsertDictionaryInput {
+  """Target cardgroup ID. Admin can target any cardgroup; non-admin callers receive FORBIDDEN."""
+  cardgroupId: ID!
+  """Base64-encoded payload (standard alphabet, with padding). Same format as validateDictionary."""
+  payload: String!
+}
+
+"""
+Result of an `upsertDictionary` call. `inserted + updated` is the number of rows that were processed successfully.
+`errors` carries per-line parse failures; the upsert proceeds with the valid rows when errors are non-empty.
+"""
+type UpsertDictionaryPayload {
+  """Number of cards newly inserted."""
+  inserted: Int!
+  """Number of cards updated (back text changed via ON CONFLICT)."""
+  updated: Int!
+  """Per-line parse errors. Empty when the entire payload parsed cleanly."""
+  errors: [DictionaryValidationError!]!
+}
+
+extend type Mutation {
+  """
+  Persist a parsed dictionary payload into the target cardgroup. Admin-only;
+  non-admin callers receive FORBIDDEN. Caps payload at 5,000 parsed rows;
+  larger payloads return BAD_USER_INPUT. Conflict key is (cardgroup_id, front);
+  conflicting rows have their `back` text updated, others are inserted.
+  """
+  upsertDictionary(input: UpsertDictionaryInput!): UpsertDictionaryPayload!
+}

--- a/schema/schema.graphql
+++ b/schema/schema.graphql
@@ -305,7 +305,7 @@ Input for upserting a parsed dictionary into a target cardgroup.
 `UpsertDictionaryInput` reuses the same base64 + tab/space-separated front/back format as `validateDictionary`.
 """
 input UpsertDictionaryInput {
-  """Target cardgroup ID. Admin can target any cardgroup; non-admin callers receive FORBIDDEN."""
+  """Target cardgroup ID. Must reference an existing cardgroup (FK constraint at upsert time). FORBIDDEN response is enforced at the mutation level for non-admin callers."""
   cardgroupId: ID!
   """Base64-encoded payload (standard alphabet, with padding). Same format as validateDictionary."""
   payload: String!


### PR DESCRIPTION
Refs #59

## Summary

Lands the admin dictionary import flow end-to-end. The new `Mutation.upsertDictionary` schema, the unique index `uq_cards_cardgroup_front` (with a duplicate pre-check that aborts the migration loudly when the populated table already violates the new invariant), and the repository `UpsertManyTx` method that uses Postgres's `RETURNING (xmax = 0) AS inserted` to split inserts vs updates in a single statement land alongside the `DictionaryUsecase` that ties admin authorization, base64 decoding, the textdic parser, payload-internal `front` deduplication, and the transactional repository call together; the resolver wiring that injects the new usecase into `NewResolver(...)`; and the admin import page (`/admin/dictionary`) with a cardgroup selector, paste textarea, and Validate / Import buttons. The frontend admin gate is transitional — the page itself only checks authentication and relies on the server-side FORBIDDEN response — pending the unified `app/admin/layout.tsx` route-segment gate in issue #60.

## Background / Motivation

- **Per-row insert/update split via `xmax = 0`**: the canonical way to count `ON CONFLICT DO UPDATE` outcomes is two queries (count rows with the conflict key beforehand, diff against `RowsAffected`). Postgres's system column `xmax` makes this a one-statement operation: a freshly inserted row has `xmax = 0` in the same transaction, while a row updated via `ON CONFLICT DO UPDATE` has `xmax` set to the current transaction id. The `RETURNING (xmax = 0) AS inserted` clause exposes the boolean per row so the caller can sum inserts vs updates without a second round-trip. The semantics are PostgreSQL-specific and documented inline in `card.go` so a future reader does not see "magic" SQL.
- **Conflict key `(cardgroup_id, front)`, not `(id)`**: the upsert pipeline's identity is "the same front under the same cardgroup is the same card"; the `id` column is a generated UUID that the caller does not know at parse time. Conflicting on `(cardgroup_id, front)` lets the parser hand the repository raw rows without prior identity resolution. Column ordering matches the `WHERE cardgroup_id = ?` prefix used by the existing per-group lookups, so the new index also serves those reads as a side benefit.
- **Migration abort-on-duplicate pre-check**: without the pre-check, `CREATE UNIQUE INDEX` on a populated table with duplicates fails with `ERROR: could not create unique index ... duplicate key value violates unique constraint`, leaving `golang-migrate` in a dirty state (`schema_migrations.dirty = true`) and telling the operator nothing about which rows are at fault. The `DO $$ ... RAISE NOTICE ... RAISE EXCEPTION $$` block scans for duplicates first, prints every offending pair to the migration log, and only then attempts the index creation. The current cards table has no UI path that creates duplicates, so the pre-check is expected to pass on every existing environment; it is forward defense for the day someone seeds a database via raw SQL.
- **Explicit `BEGIN/COMMIT` envelope in both directions**: golang-migrate's pgx/v5 driver does **not** auto-wrap migration files in a transaction. Without explicit `BEGIN/COMMIT` the pre-check and the index creation could succeed independently, leaving the schema half-applied if an unrelated SQL error fired between the two statements. The down migration carries the same envelope so a partial apply is impossible by construction.
- **`UpsertManyTx` pre-fills missing IDs via UUID v7**: the `RETURNING` clause needs every row to carry an `id` so the per-row classification covers the entire batch. Letting Postgres generate the id is incompatible with the multi-row INSERT shape used here. UUID v7 is the project-wide convention; a `uuid.NewV7` failure surfaces as an eris-wrapped error mapped to `gqlerr.Internal`.
- **Empty-input is a silent no-op at every layer**: `UpsertManyTx(ctx, tx, nil)` short-circuits to a zero-valued result without issuing SQL. The usecase mirrors the pattern: a payload that parses to zero words after dedup short-circuits before opening a transaction, returning the parser's per-line diagnostics in `Errors` so the operator still sees why the upsert was a no-op without a DB connection being borrowed.
- **Per-payload `front` dedup (Postgres SQLSTATE 21000)**: a single `INSERT ... ON CONFLICT` that names the same conflict key twice fails with `cardinality_violation` ("ON CONFLICT DO UPDATE command cannot affect row a second time"). The usecase therefore deduplicates parsed words by `front` before sending them to the repository, with last-occurrence-wins semantics. Earlier occurrences are dropped and surfaced as `Errors[*]{ Line, Message: "duplicate front in payload (later occurrence wins)" }` so the operator sees the silent drop rather than guessing why the inserted count is lower than expected.
- **Cancellation maps to typed CANCELLED, not INTERNAL**: both the `IsAdmin` call and the transaction-runner call short-circuit on `errors.Is(err, context.Canceled) || context.DeadlineExceeded` and return `gqlerr.Cancelled` (`extensions.code = "CANCELLED"`, WARN-level log) instead of `gqlerr.Internal`. Cancellation is a client-driven signal — surfacing it as INTERNAL would emit ERROR-level log lines and pages on every browser-tab close. This matches the convention used by `validateDictionary`.
- **5,000-row parsed cap, not just byte cap**: the usecase enforces `len(words) <= 5000` after parsing, complementing the parser's existing 1 MiB byte cap. The two limits stack — the byte cap protects the parser; the row cap protects the single-statement INSERT against parameter-list pathologies. The cap applies to parser *output* (post-error filter), so a payload of 6,000 lines that parses to 4,500 valid words is allowed.
- **Narrow `DictionaryCardRepository` interface**: the usecase declares its own one-method interface (`UpsertManyTx`-only), so the existing `mockCardRepository` fabric in `card_test.go` already satisfies it via method-set inclusion. No new repository double was added; tests share the existing mock.
- **`txRunner` abstraction**: production wires a `*gorm.DB` through `NewDictionaryUsecase(authSvc, cardRepo, db)`, which captures `db.WithContext(ctx).Transaction(fn)` as a closure. Test wiring uses `NewDictionaryUsecaseWithTx(...)` to inject a stub `txRunner` that just invokes `fn(nil)` without opening a real transaction — keeps tests off `gorm`'s real Begin/Commit and lets the mock repo run without a `*gorm.DB`.
- **Pagination test rewrite for unique fronts**: the existing `card_pagination_test.go` helper inserted N cards with a literal `"front"` constant; that worked before because nothing enforced uniqueness on `(cardgroup_id, front)`. Once the new index is in place those fixtures violate the constraint and the entire pagination suite fails before any pagination assertion runs. Rewriting the helper to emit `front-0`, `front-1`, ..., `front-N-1` keeps the pagination semantics intact (timestamps still drive ordering) while satisfying the new invariant.
- **`MigrateStepsForTest` test helper**: migration-direction tests need to roll the index migration both up and down to assert the index is actually created and actually removed. The existing `database` package only exposed full up/down helpers; `MigrateStepsForTest(url, n int)` (positive `n` for up steps, negative for down) is test-only (`export_test.go`) so the public migration API stays intact while the migration-level test suite gets per-step control.
- **Frontend admin gate is intentionally transitional**: `app/admin/dictionary/page.tsx` only checks `supabase.auth.getUser()` and redirects unauthenticated callers to `/login`. The admin role is enforced by the server-side FORBIDDEN response on `validateDictionary` and `upsertDictionary`. The unified `frontend/src/app/admin/layout.tsx` that would gate every `/admin/*` page in one place is deferred to issue #60; until then the page-level JSDoc names the contract so a future reader knows the gate location is provisional.
- **`classifyError` translates FORBIDDEN to a user-facing string**: because the page renders for any authenticated user, the FORBIDDEN response from a non-admin caller must be readable rather than the generic "An unexpected error occurred." The classifier walks `CombinedGraphQLErrors.is(err)` first for a typed match on `extensions.code === "FORBIDDEN"` ("Admin role required."), then falls back to `getBackendErrorBanner(err)`. This shape mirrors how the resolver layer routes typed gqlerrors and keeps the error envelope semantics consistent across the stack.
- **Stale validate-result invalidation via `useEffect`**: editing the payload or switching cardgroup must clear the prior validate result, otherwise a user who validates payload A, then pastes payload B over it, can still hit Import (the Import button binds to `validationResult.valid`). The `useEffect([payloadText, cardgroupId])` resets validation, import, and banner state in a single trigger; the inline `biome-ignore` doc-comment names the intentional trigger-only dependency shape so a future linter sweep does not silently drop the deps array.
- **`encodePayload` uses `btoa(unescape(encodeURIComponent(...)))`**: raw `btoa` rejects non-Latin-1 input (Japanese definitions throw `InvalidCharacterError`). The triple-step encode escapes the UTF-8 bytes through `encodeURIComponent`, unescapes them into a byte string, then base64-encodes — the standard browser-compatible workaround. The server expects standard base64 with padding (matching `base64.StdEncoding`), and this wrapper produces exactly that.

## Changes

### Schema additions

- `schema/schema.graphql`: adds `input UpsertDictionaryInput { cardgroupId: ID!, payload: String! }`, `type UpsertDictionaryPayload { inserted: Int!, updated: Int!, errors: [DictionaryValidationError!]! }`, and `Mutation.upsertDictionary(input): UpsertDictionaryPayload!`. The mutation doc-comment names the admin-only requirement, the 5,000-row payload cap, the conflict key `(cardgroup_id, front)`, and the `ON CONFLICT DO UPDATE` semantics so a typed-client generator carries the contract into every consumer. `DictionaryValidationError` is reused from the `validateDictionary` surface — the wire shape stays consistent between validate and import.

### Migration

- `backend/internal/database/migrations/20260503000000_add_cards_upsert_index.up.sql` (new): runs the duplicate pre-check inside a `DO $$ ... $$` block — `RAISE NOTICE` emits one line per offending `(cardgroup_id, front)` pair before `RAISE EXCEPTION` aborts the migration with the duplicate count, and only on a clean table does it run `CREATE UNIQUE INDEX IF NOT EXISTS uq_cards_cardgroup_front ON public.cards (cardgroup_id, front)`. Wrapped in explicit `BEGIN/COMMIT`.
- `backend/internal/database/migrations/20260503000000_add_cards_upsert_index.down.sql` (new): bare `DROP INDEX IF EXISTS public.uq_cards_cardgroup_front`, also wrapped in `BEGIN/COMMIT`. The pre-check in the up direction is read-only, so the down direction has nothing to restore.

### Repository

- `backend/internal/repository/card.go`: `CardRepository` gains `UpsertManyTx(ctx, tx, cards) (UpsertManyTxResult, error)` with `UpsertManyTxResult { Inserted, Updated int64 }`. Implementation builds a single multi-row `INSERT ... VALUES ...` with `ON CONFLICT (cardgroup_id, front) DO UPDATE SET back = EXCLUDED.back, updated_at = now() RETURNING (xmax = 0) AS inserted`, scans the boolean per row, and counts inserts vs updates. Pre-fills any missing card ID via `uuid.NewV7` so every row contributes to the RETURNING set. Empty input short-circuits to a zero-valued result without issuing SQL. Strictly transaction-scoped — the implementation operates on the supplied `tx` only and never reaches `r.db`.
- `backend/internal/loader/user_test.go`: `countingCardRepo` (the in-test mock satisfying `CardRepository`) gains an `UpsertManyTx` stub that panics with `"countingCardRepo.UpsertManyTx not configured"`, matching the existing pattern for unconfigured methods.

### Usecase

- `backend/internal/usecase/dictionary.go` (new, 219 lines): `DictionaryUsecase` interface with the single `Upsert(ctx, UpsertDictionaryInput) (UpsertDictionaryOutput, error)` method. Implementation enforces the guard order `auth.UserFrom` (UNAUTHENTICATED) → `IsAdmin` (FORBIDDEN, with cancellation forwarded as CANCELLED) → empty `cardgroupId` (BAD_USER_INPUT) → empty payload (BAD_USER_INPUT) → base64 decode (BAD_USER_INPUT) → `textdic.Process` → 5,000-row cap (BAD_USER_INPUT) → per-front dedup (last-occurrence-wins) → empty-output short-circuit → `tx(ctx, fn)` wrapping a single `UpsertManyTx` call. Declares its own narrow `DictionaryCardRepository` and `AdminChecker` interfaces. `NewDictionaryUsecase(authSvc, cardRepo, db *gorm.DB)` is the production constructor; `NewDictionaryUsecaseWithTx(authSvc, cardRepo, txRunner)` is the test-only constructor that injects an explicit transaction runner.

### Resolver wiring

- `backend/graph/resolver/resolver.go`: `Resolver` gains a `DictionaryUC` field and `NewResolver(...)` adds a corresponding parameter so the production wiring compile-fails on a missing dependency.
- `backend/cmd/server/main.go`: `run` constructs the dictionary usecase (`usecase.NewDictionaryUsecase(authSvc, cardRepo, db)`) and passes it into `NewResolver(...)` alongside the existing usecases.
- `backend/graph/resolver/schema.resolvers.go`: `UpsertDictionary` resolver decodes the input model, calls `r.DictionaryUC.Upsert(ctx, ...)`, and reshapes `UpsertDictionaryOutput` into the gqlgen-generated `UpsertDictionaryPayload`. Errors propagate as-is — the typed gqlerrors raised by the usecase already carry the right `extensions.code`.

### Frontend admin import page

- `frontend/src/app/admin/dictionary/page.tsx` (new): Server Component that resolves the Supabase user, redirects unauthenticated callers to `/login`, and renders `DictionaryImportClient`. Page-level JSDoc names the transitional admin gate and the forward pointer to issue #60.
- `frontend/src/app/admin/dictionary/dictionary-client.tsx` (new, 323 lines): client component with cardgroup selector (reusing `MyCardgroupsQuery` from `app/cardgroups/queries.ts`), paste textarea, Validate and Import buttons, validation result table (parsed words + per-line errors), and import result banner. Tracks an in-flight banner string, the validate result, and the import result; clears all three when payload or cardgroup changes via a trigger-only `useEffect`. `classifyError` walks `CombinedGraphQLErrors.is(err)` for a typed FORBIDDEN match before falling back to `getBackendErrorBanner`. The "Import failed: no rows persisted" destructive banner fires when `inserted == 0 && updated == 0 && errors.length > 0` so a partial-failure outcome is visually distinct from a clean "nothing changed" outcome. Encodes the payload via `btoa(unescape(encodeURIComponent(...)))` so Japanese definitions encode to standard base64.
- `frontend/src/app/admin/dictionary/queries.ts` (new): `ValidateDictionaryQuery`, `UpsertDictionaryMutation`, and a re-export of `MyCardgroupsQuery as AdminDictionaryCardgroupsQuery` so the cardgroup selector shares the cache key with the main `/cardgroups` page.

### Tests

- `backend/internal/database/cards_upsert_index_test.go` (new, 157 lines): exercises both migration directions and the duplicate pre-check via the new `MigrateStepsForTest` helper. Confirms the index is created/dropped, the duplicate pre-check raises with the offending pairs in the migration log, and rollback forces the `schema_migrations` version cleanly.
- `backend/internal/database/export_test.go`: exports `MigrateStepsForTest(url, n int)` for test-external callers; uses `iofs.New(migrationsFS, "migrations")` against the same embedded FS the production `Run` uses.
- `backend/internal/repository/card_upsert_test.go` (new, 164 lines): four scenarios covering `UpsertManyTx` — all-inserts, mixed insert + update with the per-row split agreeing with the caller-supplied front list, empty input (no SQL issued), and cross-cardgroup uniqueness (same `front` under two different cardgroups inserts cleanly), confirming the unique constraint is per-cardgroup not global.
- `backend/internal/repository/card_pagination_test.go`: insertion helpers now emit unique `Front` values (`front-0`, `front-1`, ...) so the pagination suite continues to pass under the new unique index. Pagination semantics (`CreatedAt` staggering, `id DESC` tie-break) are unchanged.
- `backend/internal/usecase/dictionary_test.go` (new, 607 lines): full guard-order matrix plus per-payload-front dedup, parsed-row-cap, cancellation mapping (CANCELLED, not INTERNAL), and tx-failure paths. Uses `NewDictionaryUsecaseWithTx` to inject a stub `txRunner` that invokes `fn(nil)` so the mock repository receives the call without a real `*gorm.DB`.
- `backend/graph/resolver/dictionary_resolver_test.go`: extended with `UpsertDictionary` coverage on top of the existing `ValidateDictionary` matrix — happy path, FORBIDDEN propagation, BAD_USER_INPUT propagation. Uses dictionary-only resolver helpers so the per-test resolver only wires the usecases each test exercises.
- `backend/graph/resolver/{user_test,card_resolvers_test}.go`: rebased onto the widened `NewResolver` signature; existing tests keep their struct-literal partial construction shape.
- `frontend/__tests__/admin-dictionary.test.tsx` (new, 313 lines): end-to-end render coverage for the admin page. Exercises the cardgroup selector load, Validate flow (including the `__typename: "DictionaryValidationError"` shape required by the generated TypeScript types), the Import flow including the destructive "no rows persisted" banner path, and the stale-validation invalidation path (edit payload → Import disabled until re-Validate).

## Verification

After merge, the following should all hold:

- `grep -nE "input UpsertDictionaryInput|type UpsertDictionaryPayload|upsertDictionary\(input: UpsertDictionaryInput!\)" schema/schema.graphql` matches all three declarations.
- `grep -nE "uq_cards_cardgroup_front" backend/internal/database/migrations/20260503000000_add_cards_upsert_index.up.sql` matches once and the file contains the `DO $$ ... RAISE EXCEPTION ... $$` pre-check, the `CREATE UNIQUE INDEX IF NOT EXISTS` statement, all wrapped in `BEGIN; ... COMMIT;`.
- `grep -n "DROP INDEX IF EXISTS public.uq_cards_cardgroup_front" backend/internal/database/migrations/20260503000000_add_cards_upsert_index.down.sql` matches once, also wrapped in `BEGIN; ... COMMIT;`.
- `grep -nE "func \(r \*cardRepo\) UpsertManyTx" backend/internal/repository/card.go` matches once; the body contains `RETURNING (xmax = 0) AS inserted` and the `ON CONFLICT (cardgroup_id, front) DO UPDATE SET back = EXCLUDED.back, updated_at = now()` clause.
- `grep -nE "func NewDictionaryUsecase\(" backend/internal/usecase/dictionary.go` matches once and `grep -nE "func NewDictionaryUsecaseWithTx\(" backend/internal/usecase/dictionary.go` matches once. `grep -n "duplicate front in payload" backend/internal/usecase/dictionary.go` matches the dedup error message.
- `grep -n "DictionaryUC " backend/graph/resolver/resolver.go` shows the field on `Resolver` and `grep -n "resolver.NewResolver(" backend/cmd/server/main.go` includes the dictionary usecase argument.
- `grep -n "func (r \*mutationResolver) UpsertDictionary" backend/graph/resolver/schema.resolvers.go` matches once; the body calls `r.DictionaryUC.Upsert` and reshapes `UpsertDictionaryOutput` into `model.UpsertDictionaryPayload`.
- `grep -nE "btoa\(unescape\(encodeURIComponent" frontend/src/app/admin/dictionary/dictionary-client.tsx` matches once; `grep -n "FORBIDDEN" frontend/src/app/admin/dictionary/dictionary-client.tsx` matches inside `classifyError`; `grep -n "no rows persisted" frontend/src/app/admin/dictionary/dictionary-client.tsx` matches the destructive-import banner.
- gqlgen drift: `cd backend && go tool gqlgen generate && git diff --exit-code -- backend/graph/{generated,model}/` produces no diff. graphql-codegen drift: `cd frontend && pnpm codegen && git diff --exit-code -- frontend/src/generated/` produces no diff.
- Migration smoke against a populated DB: `make migrate-down && psql -c "INSERT INTO cards (...) VALUES (cg_id, 'dup-front', ...), (cg_id, 'dup-front', ...);" && make migrate-up` fails with the migration log containing `duplicate (cardgroup_id, front): cardgroup_id=... front=dup-front count=2` followed by `cards table has duplicate (cardgroup_id, front) rows`. Removing the duplicate row and re-running `make migrate-up` succeeds.

## Test plan

- [ ] `cd backend && go vet ./... && go build ./...` passes.
- [ ] `cd backend && go test -v -race -covermode=atomic -coverprofile=coverage.out ./...` passes; the new `internal/usecase/dictionary_test.go`, `internal/repository/card_upsert_test.go`, `internal/database/cards_upsert_index_test.go`, the regression-fixed `internal/repository/card_pagination_test.go`, and the extended `graph/resolver/dictionary_resolver_test.go` all run.
- [ ] `cd frontend && pnpm install && pnpm test` passes; `__tests__/admin-dictionary.test.tsx` covers the cardgroup load, Validate, Import (including destructive banner), and stale-validation invalidation paths.
- [ ] gqlgen drift: `cd backend && go tool gqlgen generate && git diff --exit-code -- backend/graph/{generated,model}/` is clean. graphql-codegen drift: `cd frontend && pnpm codegen && git diff --exit-code -- frontend/src/generated/` is clean.
- [ ] Migration round-trip on a clean DB: `make migrate-down && make migrate-up && make migrate-down && make migrate-up` — `schema_migrations` has no dirty row and the index is present after the final up.
- [ ] Migration on a duplicate-bearing DB: roll back, insert two rows with the same `(cardgroup_id, front)`, run `make migrate-up` — the migration aborts with the duplicate count and offending pair printed via `RAISE NOTICE`.
- [ ] Manual happy path: signed in as an admin, open `/admin/dictionary`, pick a cardgroup, paste a multi-line `front\tback` payload, Validate (preview table renders with line numbers and parsed entries), Import — banner reads `Import complete — N inserted, M updated`. Re-Import the same payload — `inserted = 0, updated = N` (every row updates because the conflict key matched).
- [ ] Manual non-admin path: signed in as a non-admin user, open `/admin/dictionary` — the page renders, but Validate and Import both surface the banner `Admin role required.` and no rows are created.
- [ ] Manual cancellation: while Import is in flight, close the browser tab — server logs do not show an INTERNAL error envelope; if the response arrives at all it carries `extensions.code = "CANCELLED"`.
- [ ] Manual stale-validation guard: Validate a payload, then paste a different payload — Import button disables until you re-Validate. Import button stays disabled with no cardgroup selected even after a successful Validate.
- [ ] Manual per-payload dedup: paste a payload with two lines sharing the same `front` value, Validate (parser reports both as ParsedWords), Import — the response shows `inserted` reflects the unique-front count and `errors` contains a `duplicate front in payload (later occurrence wins)` entry pointing at the earlier line number.
- [ ] Language-policy grep clean: `grep -rnP "[\x{3040}-\x{30ff}\x{4e00}-\x{9fff}]" --include="*.go" --include="*.ts" --include="*.tsx" --include="*.graphql" --include="*.sql" --include="*.md" docs backend/internal backend/cmd backend/graph frontend/src` returns nothing. `grep -rnE "PR[0-9]+" docs backend/internal backend/cmd backend/graph frontend/src` returns nothing.

## Out of scope (deferred to follow-up)

- **Unified admin route-segment gate** (issue #60): `/admin/dictionary/page.tsx` currently relies on the server-side FORBIDDEN response for non-admin callers. The unified `frontend/src/app/admin/layout.tsx` that gates every `/admin/*` page in one place is the right home for the role check; this PR keeps the page accessible to any authenticated user with the page-level JSDoc naming the contract.
