### PR TITLE
feat: add admin user list, edit, and role assignment end-to-end

### DIFF
--- a/.claude/rules/error-wrapping.md
+++ b/.claude/rules/error-wrapping.md
@@ -18,6 +18,30 @@ The backend uses [`github.com/rotisserie/eris`](https://github.com/rotisserie/er
 
 Sentinels used today: `repository.ErrNotFound`, and domain-level sentinels such as `domain.ErrCardgroupNameRequired` / `domain.ErrCardgroupNameTooLong`. New sentinels are allowed when (a) callers need to branch on identity, and (b) a string-equality match is fragile. Keep sentinels as plain `errors.New` so `errors.Is` works without going through eris's chain walk.
 
+### Layered sentinels via `errors.Join`
+
+When introducing a more specific sentinel alongside an existing general one (e.g. adding `ErrUserNotFound` while `ErrNotFound` is still in use across the repository), return `errors.Join(specific, general)` from the new call site. Callers that already match `errors.Is(err, ErrNotFound)` keep working; callers that want the finer split can branch on the specific sentinel first. This avoids a flag-day rename across every caller and lets the finer sentinel migrate in at its own pace. **Always check the more specific sentinel before the general one** — `errors.Is` returns true for both, so reversing the order silently routes user-not-found into a generic 404 path.
+
+### Postgres FK violation classification (`23503`)
+
+A "validate parent rows exist, then insert" pattern carries a TOCTOU race: between the SELECT and the INSERT, another transaction can delete the parent row, and the INSERT then fails with a Postgres foreign-key violation. Without classification, the usecase maps the raw GORM error to `gqlerr.Internal` and the operator gets a 5xx alarm for what is actually client-supplied stale input.
+
+Inspect the unwrapped driver error for `*pgconn.PgError` with `Code == "23503"` and read `ConstraintName` to decide which parent was missing — typical shape:
+
+```go
+var pgErr *pgconn.PgError
+if errors.As(err, &pgErr) && pgErr.Code == "23503" {
+    switch {
+    case strings.Contains(pgErr.ConstraintName, "user_id"):
+        return errors.Join(ErrUserNotFound, ErrNotFound)
+    case strings.Contains(pgErr.ConstraintName, "role_id"):
+        return errors.Join(ErrRoleNotFound, ErrNotFound)
+    }
+}
+```
+
+The usecase then translates the specific sentinel to `gqlerr.BadUserInput` on the offending field. A race-deleted parent is a client-fixable input, not a server bug — keep it out of the ERROR log.
+
 ## Logging
 
 All error sites that produce a structured log entry must attach the eris chain as the `error_chain` attribute (output of `eris.ToJSON(err, true)`). The `internal/logging` package exposes two sibling helpers — `LogError(ctx, logger, msg, err, attrs...)` and `LogWarn(ctx, logger, msg, err, attrs...)` — so ERROR and WARN sites share one shape. Both:

--- a/.claude/rules/go-library-gotchas.md
+++ b/.claude/rules/go-library-gotchas.md
@@ -72,6 +72,23 @@ GORM's `BeforeCreate` hook auto-generates a UUID when a primary key field is a `
 
 Peer models (`gormUser`, `gormCard`) avoid this by supplying the UUID in the application layer before calling `Create`. `gormPingRecord` is different: `Create` inserts a row without any caller-supplied ID, so the DB must generate it via `gen_random_uuid()`. The tag `gorm:"default:gen_random_uuid()"` is therefore load-bearing even though `AutoMigrate` is not used and the column default is already defined in the migration SQL.
 
+## GORM `LIKE` / `ILIKE` requires escaping `%`, `_`, `\` in user input
+
+A search box that runs `WHERE name ILIKE ? || '%'` with a user-supplied string becomes a pattern-injection surface: a user typing `100%` matches every row containing the literal string `100`, not just rows starting with `100%`. The three Postgres `LIKE` metacharacters are `%`, `_`, and `\` (the default escape). User-supplied search text must be escaped before being wrapped with `%...%`:
+
+```go
+func escapeLike(s string) string {
+    s = strings.ReplaceAll(s, `\`, `\\`)
+    s = strings.ReplaceAll(s, `%`, `\%`)
+    s = strings.ReplaceAll(s, `_`, `\_`)
+    return s
+}
+// ...
+db.Where("name ILIKE ?", "%"+escapeLike(query)+"%")
+```
+
+Order matters: escape `\` first, then `%` and `_`, otherwise the second pass re-escapes the backslash from the first pass. The same rule applies to `name ILIKE ? || '%'` (prefix match) and to any other `LIKE` predicate fed by user input.
+
 ## GORM rejects unconditional `Delete` — use `Where("1 = 1")` to opt out
 
 GORM v2+ refuses a `Delete` call that has no `WHERE` clause as a safety net against accidental full-table deletes. It returns an `ErrMissingWhereClause` error.

--- a/.claude/rules/pagination.md
+++ b/.claude/rules/pagination.md
@@ -45,6 +45,20 @@ Natural SQL "give me N rows before X" is awkward. The repository inverts the `OR
 
 A cursor pointing at a card in another cardgroup is treated as a malformed user-supplied parameter. Returning `UNAUTHENTICATED` would leak existence of cards in other cardgroups; `BAD_USER_INPUT` with `field = "after"` / `field = "before"` is the correct posture.
 
+### Reject mixed-direction argument combos at the usecase
+
+The repository trusts its inputs. Without explicit usecase-layer guards, malformed combinations silently re-interpret as a forward page-1 request and the client never learns why their cursor was ignored. Reject all five bad combos with `BAD_USER_INPUT` (with `extensions.field` naming the offending argument):
+
+| Combo | Why rejected |
+|---|---|
+| `after` + `before` | The two cursors disagree on direction. |
+| `first` + `before` | `first` implies forward, `before` implies backward. |
+| `last` + `after` | `last` implies backward, `after` implies forward. |
+| `before` alone (no `last`) | A backward cursor without a backward page size is ambiguous. |
+| `after` alone (no `first`) | A forward cursor without a forward page size is ambiguous. |
+
+A request with neither cursor and neither size is the legitimate "first page, server default" case and must still be accepted.
+
 ### Three layers of enums kept in sync
 
 - `model.CardOrderBy` — gqlgen-generated, schema strings.
@@ -88,6 +102,19 @@ Filter the edge out of the cached connection, decrement `totalCount` (clamped at
 ### Connection update (cache normalization)
 
 Rely on Apollo cache normalization (entities with `id` are normalized by default). No manual `update` callback is needed; mutations that touch a normalised entity propagate to every cached query that reads it.
+
+### Drop `optimisticResponse` for mutations that can fail with typed GraphQL errors
+
+`@apollo/client` v3.x rolls back optimistic writes on **network** errors but not consistently on typed GraphQL errors (`FORBIDDEN`, `BAD_USER_INPUT`, etc.). For a mutation that can plausibly return one of those — e.g. a role assignment that fails authorization, or a self-demotion blocked by a server-side guard — the optimistic write persists and the cache lies until the next mount. Two acceptable postures:
+
+1. **Drop optimistic** for mutations that can fail typed. The user pays a single round-trip of latency, but the cache stays truthful.
+2. **Manual rollback in the catch branch** — `cache.evict({ id: ... })` followed by `cache.gc()` to undo whatever the optimistic update wrote.
+
+Posture 1 is the default; reach for posture 2 only when the perceived latency cost is measurable. Never leave a typed-error-capable mutation with `optimisticResponse` and no rollback.
+
+### Pick one data-loading mode per component
+
+A component that accepts both an SSR-prop variant (`{ initial: T }`) and a query-id variant (`{ id: string; query }`) ends up with `useState(props.initial ?? "")` or similar — the state initializes once before the query resolves and stays at the empty default. The two modes are not interchangeable. Decide at the call site (RSC seed vs. client-driven fetch) and keep the component single-mode. If both modes are needed at different routes, write two thin wrappers around a shared presentational component instead of branching inside.
 
 ## Frontend pagination UX
 

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -200,8 +200,9 @@ func run(ctx context.Context, logger *slog.Logger) error {
 	cardUC := usecase.NewCardUsecase(db.GORM, cardRepo, cardgroupRepo)
 	swipeUC := usecase.NewSwipeUsecase(db.GORM, cardRepo, cardgroupRepo, swipeRecordRepo, service.NewFSRSScheduler(), swipeNextBatchSize(logger))
 	dictionaryUC := usecase.NewDictionaryUsecase(authSvc, cardRepo, db.GORM)
+	adminUserUC := usecase.NewAdminUser(userRepo, roleRepo, authSvc)
 
-	resolvers := resolver.NewResolver(userUC, cardgroupUC, cardUC, swipeUC, authSvc, dictionaryUC)
+	resolvers := resolver.NewResolver(userUC, cardgroupUC, cardUC, swipeUC, authSvc, dictionaryUC, adminUserUC)
 	pingHandler := ping.New(pingRecordRepo, pingToken)
 	// newRouter must be called after telemetry.Init: the otelhttp handler it
 	// constructs reads otel.GetTextMapPropagator() eagerly. See comment above

--- a/backend/cmd/server/main_test.go
+++ b/backend/cmd/server/main_test.go
@@ -141,7 +141,7 @@ func noopAuthMW(next echo.HandlerFunc) echo.HandlerFunc {
 
 func newTestServer(t *testing.T) *httptest.Server {
 	t.Helper()
-	ts := httptest.NewServer(newRouter(resolver.NewResolver(nil, nil, nil, nil, nil, nil), noopAuthMW, nil, nil, nil, nil, ping.New(nil, "test-token")))
+	ts := httptest.NewServer(newRouter(resolver.NewResolver(nil, nil, nil, nil, nil, nil, nil), noopAuthMW, nil, nil, nil, nil, ping.New(nil, "test-token")))
 	t.Cleanup(ts.Close)
 	return ts
 }
@@ -451,7 +451,7 @@ func newGraphQLTestServerWithUserRepo(t *testing.T, f *jwtFixture, userRepo repo
 	cardUC := usecase.NewCardUsecase(db.GORM, cardRepo, cardgroupRepo)
 	swipeUC := usecase.NewSwipeUsecase(db.GORM, cardRepo, cardgroupRepo, swipeRecordRepo, service.NewFSRSScheduler(), 10)
 	pingRecordRepo := repository.NewPingRecordRepository(db.GORM)
-	e := newRouter(resolver.NewResolver(userUC, cardgroupUC, cardUC, swipeUC, nil, nil), mw, userRepo, roleRepo, cardgroupRepo, cardRepo, ping.New(pingRecordRepo, "test-token"), swipeRecordRepo)
+	e := newRouter(resolver.NewResolver(userUC, cardgroupUC, cardUC, swipeUC, nil, nil, nil), mw, userRepo, roleRepo, cardgroupRepo, cardRepo, ping.New(pingRecordRepo, "test-token"), swipeRecordRepo)
 
 	ts := httptest.NewServer(e)
 	t.Cleanup(ts.Close)
@@ -485,6 +485,17 @@ func (c *countingUserRepo) FindByIDs(ctx context.Context, ids []string) (map[str
 
 func (c *countingUserRepo) Update(ctx context.Context, id string, patch repository.UserUpdate) (*domain.User, error) {
 	return c.inner.Update(ctx, id, patch)
+}
+
+// ListPage forwards to the inner repository so any future test that exercises
+// the cursor-paginated user list keeps working.
+func (c *countingUserRepo) ListPage(
+	ctx context.Context,
+	after, before *string,
+	first, last int,
+	search *string,
+) ([]*domain.User, int64, error) {
+	return c.inner.ListPage(ctx, after, before, first, last, search)
 }
 
 // insertAuthUser inserts a row into auth.users so the handle_new_user trigger
@@ -688,7 +699,7 @@ func TestComplexityLimit_Rejects(t *testing.T) {
 
 func newIntrospectionTestServer(t *testing.T) *httptest.Server {
 	t.Helper()
-	ts := httptest.NewServer(newGraphQLServer(resolver.NewResolver(nil, nil, nil, nil, nil, nil)))
+	ts := httptest.NewServer(newGraphQLServer(resolver.NewResolver(nil, nil, nil, nil, nil, nil, nil)))
 	t.Cleanup(ts.Close)
 	return ts
 }

--- a/backend/gqlgen.yml
+++ b/backend/gqlgen.yml
@@ -34,3 +34,7 @@ models:
     fields:
       cardgroup:
         resolver: true
+  User:
+    fields:
+      roles:
+        resolver: true

--- a/backend/graph/resolver/admin_user_resolver_test.go
+++ b/backend/graph/resolver/admin_user_resolver_test.go
@@ -10,6 +10,7 @@ import (
 
 	"backend/graph/generated"
 	"backend/graph/resolver"
+	"backend/internal/auth"
 	"backend/internal/domain"
 	"backend/internal/gqlerr"
 	"backend/internal/loader"
@@ -60,10 +61,14 @@ type mockRoleByUserIDRepo struct {
 	// byUserID maps user id → roles returned for that user.
 	byUserID      map[string][]*domain.Role
 	listCallCount int
+	// lastIDs holds the key slice from the most recent ListByUserIDs call so
+	// N+1 batch assertions can verify all expected user IDs were batched together.
+	lastIDs []string
 }
 
 func (m *mockRoleByUserIDRepo) ListByUserIDs(_ context.Context, ids []string) (map[string][]*domain.Role, error) {
 	m.listCallCount++
+	m.lastIDs = append([]string(nil), ids...)
 	out := make(map[string][]*domain.Role, len(ids))
 	for _, id := range ids {
 		if roles, ok := m.byUserID[id]; ok {
@@ -83,11 +88,30 @@ func newAdminUserSrv(adminUC usecase.AdminUserUsecase) *handler.Server {
 	return srv
 }
 
+// newAdminUserSrvWithAuth builds a server like newAdminUserSrv but also wires
+// an AuthSvc backed by the given UserRoleRepository. Tests that exercise the
+// User.roles admin gate need this because the resolver consults AuthSvc when
+// the caller is reading another user's roles.
+func newAdminUserSrvWithAuth(adminUC usecase.AdminUserUsecase, isAdmin bool) *handler.Server {
+	roleRepo := &mockUserRoleRepository{isAdmin: isAdmin}
+	r := resolver.NewResolver(nil, nil, nil, nil, auth.NewService(roleRepo), nil, adminUC)
+	srv := handler.New(generated.NewExecutableSchema(generated.Config{Resolvers: r}))
+	srv.AddTransport(transport.POST{})
+	return srv
+}
+
 // ctxWithRoles returns a context enriched with a loader.Loaders that has
 // RoleByUserID backed by rolesByUser. Other loaders are nil and must not be
 // invoked in the tests that use this helper.
 func ctxWithRoles(base context.Context, rolesByUser map[string][]*domain.Role) context.Context {
 	repo := &mockRoleByUserIDRepo{byUserID: rolesByUser}
+	return ctxWithRolesRepo(base, repo)
+}
+
+// ctxWithRolesRepo is like ctxWithRoles but accepts a pre-constructed
+// mockRoleByUserIDRepo so callers can inspect its listCallCount after the
+// GraphQL request resolves.
+func ctxWithRolesRepo(base context.Context, repo *mockRoleByUserIDRepo) context.Context {
 	loaders := &loader.Loaders{
 		RoleByUserID: dataloader.NewBatchedLoader(
 			func(ctx context.Context, keys []string) []*dataloader.Result[[]*domain.Role] {
@@ -233,6 +257,10 @@ const usersWithRolesQuery = `{"query":"{ users(first: 3) { edges { node { id rol
 // resolved through the RoleByUserID DataLoader (no N+1) and that the roles
 // shape is correct. The test injects a loader context carrying a fake
 // RoleByUserID DataLoader backed by an in-memory map.
+//
+// N+1 assertion (C3): three users are fetched; all three user IDs must reach
+// the batch function in exactly one call — the DataLoader must coalesce the
+// individual Load calls into a single ListByUserIDs invocation.
 func TestAdminUserResolver_Roles_ViaDataLoader(t *testing.T) {
 	t.Parallel()
 
@@ -252,14 +280,18 @@ func TestAdminUserResolver_Roles_ViaDataLoader(t *testing.T) {
 			TotalCount: 3,
 		},
 	}
-	srv := newAdminUserSrv(mock)
+	// Caller is admin (isAdmin=true) so the User.roles gate lets the
+	// DataLoader fan out to all three foreign user IDs.
+	srv := newAdminUserSrvWithAuth(mock, true)
 
 	rolesByUser := map[string][]*domain.Role{
 		"u1": {adminRole, generalRole},
 		"u2": {generalRole},
 		"u3": {},
 	}
-	ctx := ctxWithRoles(authedCtx("admin"), rolesByUser)
+	// Use the repo-exposing variant so we can assert on the batch call count.
+	roleRepo := &mockRoleByUserIDRepo{byUserID: rolesByUser}
+	ctx := ctxWithRolesRepo(authedCtx("admin"), roleRepo)
 	resp := gqlRequest(t, srv, ctx, usersWithRolesQuery)
 
 	if _, hasErrs := resp["errors"]; hasErrs {
@@ -294,6 +326,29 @@ func TestAdminUserResolver_Roles_ViaDataLoader(t *testing.T) {
 	u3roles, _ := u3["roles"].([]any)
 	if len(u3roles) != 0 {
 		t.Fatalf("expected u3 to have 0 roles, got %d", len(u3roles))
+	}
+
+	// N+1 assertion: all three user IDs must have been batched into exactly
+	// one ListByUserIDs call. More than one call indicates the DataLoader did
+	// not coalesce the individual Load() calls, i.e. an N+1 query per user.
+	if roleRepo.listCallCount != 1 {
+		t.Fatalf("expected exactly 1 batched DB call, got %d (N+1 regression)", roleRepo.listCallCount)
+	}
+	wantIDs := []string{"u1", "u2", "u3"}
+	for _, id := range wantIDs {
+		found := false
+		for _, got := range roleRepo.lastIDs {
+			if got == id {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("batch call missing user ID %q; got %v", id, roleRepo.lastIDs)
+		}
+	}
+	if len(roleRepo.lastIDs) != len(wantIDs) {
+		t.Fatalf("batch call received %d user IDs, want %d; got %v", len(roleRepo.lastIDs), len(wantIDs), roleRepo.lastIDs)
 	}
 }
 
@@ -349,5 +404,302 @@ func TestAdminUserResolver_Roles_Forbidden(t *testing.T) {
 	code := errCode(t, resp)
 	if code != string(gqlerr.CodeForbidden) {
 		t.Fatalf("expected FORBIDDEN, got %q", code)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// User.roles admin gate
+// ---------------------------------------------------------------------------
+
+// TestAdminUserResolver_Roles_NonAdminNonSelf_Forbidden verifies that a
+// non-admin caller querying another user's roles via adminUser.roles receives
+// a FORBIDDEN error and that no roles are returned in the payload. Returning
+// an empty slice silently would still leak the field's existence; the gate
+// surfaces the rejection explicitly.
+func TestAdminUserResolver_Roles_NonAdminNonSelf_Forbidden(t *testing.T) {
+	t.Parallel()
+
+	// adminUser query bypasses the AdminUserUsecase admin gate via the mock,
+	// so the resolver-level gate on User.roles is what we exercise here. The
+	// mock returns a target user whose ID differs from the caller's sub.
+	mock := &mockAdminUserUsecase{
+		getResult: &domain.User{ID: "u-target"},
+	}
+	// isAdmin=false models a non-admin caller.
+	srv := newAdminUserSrvWithAuth(mock, false)
+
+	rolesByUser := map[string][]*domain.Role{
+		"u-target": {{ID: "r-admin", Name: "admin"}},
+	}
+	ctx := ctxWithRoles(authedCtx("u-caller"), rolesByUser)
+	body := `{"query":"{ adminUser(id: \"u-target\") { id roles { id name } } }"}`
+	resp := gqlRequest(t, srv, ctx, body)
+
+	code := errCode(t, resp)
+	if code != string(gqlerr.CodeForbidden) {
+		t.Fatalf("expected FORBIDDEN, got %q; response: %v", code, resp)
+	}
+
+	// Payload must not surface a roles list — gqlgen sets data.adminUser to
+	// null when a non-nullable field errors. Either branch is acceptable: the
+	// FORBIDDEN code is what guards the leak.
+	data, _ := resp["data"].(map[string]any)
+	if data != nil {
+		if user, ok := data["adminUser"].(map[string]any); ok {
+			if _, hasRoles := user["roles"]; hasRoles {
+				t.Fatalf("expected no roles field in payload on FORBIDDEN, got %v", user)
+			}
+		}
+	}
+}
+
+// TestAdminUserResolver_Roles_SelfIntrospection_Allowed verifies that a
+// non-admin caller may read their own roles via me { roles } without a
+// FORBIDDEN. The User.roles resolver allows caller.Sub == obj.ID.
+func TestAdminUserResolver_Roles_SelfIntrospection_Allowed(t *testing.T) {
+	t.Parallel()
+
+	// Wire UserUsecase so me { ... } can resolve. The AdminUserUsecase is
+	// unused by this query; pass the mock to satisfy the resolver wiring.
+	displayName := "Alice"
+	userMock := &mockUserRepository{
+		findResult: &domain.User{ID: "u-self", DisplayName: &displayName},
+	}
+	uc := usecase.NewUserUsecase(userMock)
+	// isAdmin=false models a non-admin caller; the self-introspection branch
+	// must skip the IsAdmin check entirely.
+	roleRepo := &mockUserRoleRepository{isAdmin: false}
+	r := resolver.NewResolver(uc, nil, nil, nil, auth.NewService(roleRepo), nil, &mockAdminUserUsecase{})
+	srv := handler.New(generated.NewExecutableSchema(generated.Config{Resolvers: r}))
+	srv.AddTransport(transport.POST{})
+
+	rolesByUser := map[string][]*domain.Role{
+		"u-self": {{ID: "r-general", Name: "general"}},
+	}
+	ctx := ctxWithRoles(authedCtx("u-self"), rolesByUser)
+	body := `{"query":"{ me { id roles { id name } } }"}`
+	resp := gqlRequest(t, srv, ctx, body)
+
+	if errs, hasErrs := resp["errors"]; hasErrs {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	data, _ := resp["data"].(map[string]any)
+	me, _ := data["me"].(map[string]any)
+	if me == nil {
+		t.Fatalf("expected data.me, got nil; response: %v", resp)
+	}
+	roles, _ := me["roles"].([]any)
+	if len(roles) != 1 {
+		t.Fatalf("expected 1 role for self, got %d", len(roles))
+	}
+	first, _ := roles[0].(map[string]any)
+	if first["id"] != "r-general" || first["name"] != "general" {
+		t.Fatalf("roles[0] = %v, want {id:r-general name:general}", first)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Mutation.revokeRole tests (C6)
+// ---------------------------------------------------------------------------
+
+const revokeRoleMutation = `{"query":"mutation { revokeRole(userId: \"u1\", roleId: \"r1\") { id } }"}`
+const revokeRoleSelfMutation = `{"query":"mutation { revokeRole(userId: \"admin\", roleId: \"r-admin\") { id } }"}`
+
+// TestAdminUserResolver_RevokeRole_HappyPath verifies that an admin caller
+// revoking a role from another user gets the updated user back with no error.
+func TestAdminUserResolver_RevokeRole_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockAdminUserUsecase{
+		revokeResult: &domain.User{ID: "u1"},
+	}
+	srv := newAdminUserSrv(mock)
+	resp := gqlRequest(t, srv, authedCtx("admin"), revokeRoleMutation)
+
+	if _, hasErrs := resp["errors"]; hasErrs {
+		t.Fatalf("unexpected errors: %v", resp["errors"])
+	}
+	data, _ := resp["data"].(map[string]any)
+	user, _ := data["revokeRole"].(map[string]any)
+	if user == nil {
+		t.Fatalf("expected data.revokeRole, got nil; response: %v", resp)
+	}
+	if user["id"] != "u1" {
+		t.Fatalf("expected id=u1, got %v", user["id"])
+	}
+}
+
+// TestAdminUserResolver_RevokeRole_SelfDemotionForbidden verifies that an
+// admin caller attempting to revoke their own admin role receives FORBIDDEN.
+// This covers the self-demotion guard in the usecase.
+func TestAdminUserResolver_RevokeRole_SelfDemotionForbidden(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockAdminUserUsecase{
+		revokeErr: gqlerr.NewForbidden("cannot revoke own admin role"),
+	}
+	srv := newAdminUserSrv(mock)
+	resp := gqlRequest(t, srv, authedCtx("admin"), revokeRoleSelfMutation)
+
+	code := errCode(t, resp)
+	if code != string(gqlerr.CodeForbidden) {
+		t.Fatalf("expected FORBIDDEN, got %q; response: %v", code, resp)
+	}
+}
+
+// TestAdminUserResolver_RevokeRole_NonAdmin verifies that a non-admin caller
+// receives FORBIDDEN when attempting to revoke a role.
+func TestAdminUserResolver_RevokeRole_NonAdmin(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockAdminUserUsecase{
+		revokeErr: gqlerr.NewForbidden("admin only"),
+	}
+	srv := newAdminUserSrv(mock)
+	resp := gqlRequest(t, srv, authedCtx("non-admin"), revokeRoleMutation)
+
+	code := errCode(t, resp)
+	if code != string(gqlerr.CodeForbidden) {
+		t.Fatalf("expected FORBIDDEN, got %q; response: %v", code, resp)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Query.adminUser tests (I9)
+// ---------------------------------------------------------------------------
+
+// TestAdminUserResolver_AdminUser_HappyPath verifies that Query.adminUser
+// returns the user with id and displayName populated when the user exists.
+func TestAdminUserResolver_AdminUser_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	displayName := "Charlie"
+	mock := &mockAdminUserUsecase{
+		getResult: &domain.User{ID: "u-existing", DisplayName: &displayName},
+	}
+	srv := newAdminUserSrv(mock)
+	body := `{"query":"{ adminUser(id: \"u-existing\") { id displayName } }"}`
+	resp := gqlRequest(t, srv, authedCtx("admin"), body)
+
+	if _, hasErrs := resp["errors"]; hasErrs {
+		t.Fatalf("unexpected errors: %v", resp["errors"])
+	}
+	data, _ := resp["data"].(map[string]any)
+	user, _ := data["adminUser"].(map[string]any)
+	if user == nil {
+		t.Fatalf("expected data.adminUser, got nil; response: %v", resp)
+	}
+	if user["id"] != "u-existing" {
+		t.Fatalf("expected id=u-existing, got %v", user["id"])
+	}
+	if user["displayName"] != "Charlie" {
+		t.Fatalf("expected displayName=Charlie, got %v", user["displayName"])
+	}
+}
+
+// TestAdminUserResolver_AdminUser_NotFound_NullPayload verifies that
+// Query.adminUser returns data.adminUser == null with NO errors when the
+// user does not exist. This is the SSR redirect-to-list regression guard:
+// the resolver returns (nil, nil) from the usecase so gqlgen renders the
+// nullable field as null without setting errors[].
+func TestAdminUserResolver_AdminUser_NotFound_NullPayload(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockAdminUserUsecase{
+		// getResult == nil and getErr == nil: usecase found no user but
+		// returned no error (missing row maps to (nil, nil)).
+		getResult: nil,
+		getErr:    nil,
+	}
+	srv := newAdminUserSrv(mock)
+	body := `{"query":"{ adminUser(id: \"missing-id\") { id displayName } }"}`
+	resp := gqlRequest(t, srv, authedCtx("admin"), body)
+
+	if _, hasErrs := resp["errors"]; hasErrs {
+		t.Fatalf("expected no errors for missing user, got %v", resp["errors"])
+	}
+	data, _ := resp["data"].(map[string]any)
+	if data == nil {
+		t.Fatalf("expected data field, got nil; response: %v", resp)
+	}
+	// adminUser must be explicitly null, not missing.
+	if _, exists := data["adminUser"]; !exists {
+		t.Fatalf("expected data.adminUser key (null), got absent; response: %v", resp)
+	}
+	if data["adminUser"] != nil {
+		t.Fatalf("expected data.adminUser == null, got %v", data["adminUser"])
+	}
+}
+
+// TestAdminUserResolver_AdminUser_Forbidden verifies that a non-admin caller
+// receives FORBIDDEN when querying adminUser.
+func TestAdminUserResolver_AdminUser_Forbidden(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockAdminUserUsecase{
+		getErr: gqlerr.NewForbidden("admin only"),
+	}
+	srv := newAdminUserSrv(mock)
+	body := `{"query":"{ adminUser(id: \"u1\") { id } }"}`
+	resp := gqlRequest(t, srv, authedCtx("non-admin"), body)
+
+	code := errCode(t, resp)
+	if code != string(gqlerr.CodeForbidden) {
+		t.Fatalf("expected FORBIDDEN, got %q; response: %v", code, resp)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Mutation.adminUpdateUser tests (I9)
+// ---------------------------------------------------------------------------
+
+// TestAdminUserResolver_AdminUpdateUser_HappyPath verifies that an admin caller
+// updating displayName/bio gets the updated user back in the payload.
+func TestAdminUserResolver_AdminUpdateUser_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	newName := "Dana"
+	newBio := "A short bio."
+	mock := &mockAdminUserUsecase{
+		updateResult: &domain.User{ID: "u-target", DisplayName: &newName, Bio: &newBio},
+	}
+	srv := newAdminUserSrv(mock)
+	body := `{"query":"mutation { adminUpdateUser(id: \"u-target\", input: { displayName: \"Dana\", bio: \"A short bio.\" }) { id displayName bio } }"}`
+	resp := gqlRequest(t, srv, authedCtx("admin"), body)
+
+	if _, hasErrs := resp["errors"]; hasErrs {
+		t.Fatalf("unexpected errors: %v", resp["errors"])
+	}
+	data, _ := resp["data"].(map[string]any)
+	user, _ := data["adminUpdateUser"].(map[string]any)
+	if user == nil {
+		t.Fatalf("expected data.adminUpdateUser, got nil; response: %v", resp)
+	}
+	if user["id"] != "u-target" {
+		t.Fatalf("expected id=u-target, got %v", user["id"])
+	}
+	if user["displayName"] != "Dana" {
+		t.Fatalf("expected displayName=Dana, got %v", user["displayName"])
+	}
+	if user["bio"] != "A short bio." {
+		t.Fatalf("expected bio=%q, got %v", "A short bio.", user["bio"])
+	}
+}
+
+// TestAdminUserResolver_AdminUpdateUser_Forbidden verifies that a non-admin
+// caller attempting adminUpdateUser receives FORBIDDEN.
+func TestAdminUserResolver_AdminUpdateUser_Forbidden(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockAdminUserUsecase{
+		updateErr: gqlerr.NewForbidden("admin only"),
+	}
+	srv := newAdminUserSrv(mock)
+	body := `{"query":"mutation { adminUpdateUser(id: \"u1\", input: { displayName: \"Eve\" }) { id } }"}`
+	resp := gqlRequest(t, srv, authedCtx("non-admin"), body)
+
+	code := errCode(t, resp)
+	if code != string(gqlerr.CodeForbidden) {
+		t.Fatalf("expected FORBIDDEN, got %q; response: %v", code, resp)
 	}
 }

--- a/backend/graph/resolver/admin_user_resolver_test.go
+++ b/backend/graph/resolver/admin_user_resolver_test.go
@@ -1,0 +1,353 @@
+package resolver_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/99designs/gqlgen/graphql/handler"
+	"github.com/99designs/gqlgen/graphql/handler/transport"
+	"github.com/graph-gophers/dataloader/v7"
+
+	"backend/graph/generated"
+	"backend/graph/resolver"
+	"backend/internal/domain"
+	"backend/internal/gqlerr"
+	"backend/internal/loader"
+	"backend/internal/usecase"
+)
+
+// ---------------------------------------------------------------------------
+// mockAdminUserUsecase — stub for AdminUserUsecase
+// ---------------------------------------------------------------------------
+
+type mockAdminUserUsecase struct {
+	listResult      *usecase.AdminUserConnection
+	listErr         error
+	getResult       *domain.User
+	getErr          error
+	updateResult    *domain.User
+	updateErr       error
+	assignResult    *domain.User
+	assignErr       error
+	revokeResult    *domain.User
+	revokeErr       error
+	listRolesResult []*domain.Role
+	listRolesErr    error
+}
+
+func (m *mockAdminUserUsecase) List(_ context.Context, _, _ *int, _, _, _ *string) (*usecase.AdminUserConnection, error) {
+	return m.listResult, m.listErr
+}
+func (m *mockAdminUserUsecase) Get(_ context.Context, _ string) (*domain.User, error) {
+	return m.getResult, m.getErr
+}
+func (m *mockAdminUserUsecase) Update(_ context.Context, _ string, _ usecase.AdminUpdateUserInput) (*domain.User, error) {
+	return m.updateResult, m.updateErr
+}
+func (m *mockAdminUserUsecase) AssignRole(_ context.Context, _, _ string) (*domain.User, error) {
+	return m.assignResult, m.assignErr
+}
+func (m *mockAdminUserUsecase) RevokeRole(_ context.Context, _, _ string) (*domain.User, error) {
+	return m.revokeResult, m.revokeErr
+}
+func (m *mockAdminUserUsecase) ListRoles(_ context.Context) ([]*domain.Role, error) {
+	return m.listRolesResult, m.listRolesErr
+}
+
+// mockRoleByUserIDRepo satisfies the minimal interface needed to build the
+// RoleByUserID DataLoader.
+type mockRoleByUserIDRepo struct {
+	// byUserID maps user id → roles returned for that user.
+	byUserID      map[string][]*domain.Role
+	listCallCount int
+}
+
+func (m *mockRoleByUserIDRepo) ListByUserIDs(_ context.Context, ids []string) (map[string][]*domain.Role, error) {
+	m.listCallCount++
+	out := make(map[string][]*domain.Role, len(ids))
+	for _, id := range ids {
+		if roles, ok := m.byUserID[id]; ok {
+			out[id] = roles
+		}
+	}
+	return out, nil
+}
+
+// newAdminUserSrv builds a gqlgen handler.Server backed by a mock
+// AdminUserUsecase. Other usecase fields are nil — only admin-user resolvers
+// are exercised here.
+func newAdminUserSrv(adminUC usecase.AdminUserUsecase) *handler.Server {
+	r := resolver.NewResolver(nil, nil, nil, nil, nil, nil, adminUC)
+	srv := handler.New(generated.NewExecutableSchema(generated.Config{Resolvers: r}))
+	srv.AddTransport(transport.POST{})
+	return srv
+}
+
+// ctxWithRoles returns a context enriched with a loader.Loaders that has
+// RoleByUserID backed by rolesByUser. Other loaders are nil and must not be
+// invoked in the tests that use this helper.
+func ctxWithRoles(base context.Context, rolesByUser map[string][]*domain.Role) context.Context {
+	repo := &mockRoleByUserIDRepo{byUserID: rolesByUser}
+	loaders := &loader.Loaders{
+		RoleByUserID: dataloader.NewBatchedLoader(
+			func(ctx context.Context, keys []string) []*dataloader.Result[[]*domain.Role] {
+				out := make([]*dataloader.Result[[]*domain.Role], len(keys))
+				result, err := repo.ListByUserIDs(ctx, keys)
+				if err != nil {
+					for i := range keys {
+						out[i] = &dataloader.Result[[]*domain.Role]{Error: err}
+					}
+					return out
+				}
+				for i, k := range keys {
+					roles := result[k]
+					if roles == nil {
+						roles = []*domain.Role{}
+					}
+					out[i] = &dataloader.Result[[]*domain.Role]{Data: roles}
+				}
+				return out
+			},
+		),
+	}
+	return loader.WithContext(base, loaders)
+}
+
+// ---------------------------------------------------------------------------
+// Query.users tests
+// ---------------------------------------------------------------------------
+
+const usersQuery = `{"query":"{ users(first: 5) { edges { cursor node { id } } pageInfo { hasNextPage hasPreviousPage } totalCount } }"}`
+
+// TestAdminUserResolver_Users_NonAdmin verifies that a non-admin caller
+// (the mock usecase returns FORBIDDEN) gets errors[0].extensions.code ==
+// "FORBIDDEN" from the users query.
+func TestAdminUserResolver_Users_NonAdmin(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockAdminUserUsecase{
+		listErr: gqlerr.NewForbidden("admin only"),
+	}
+	srv := newAdminUserSrv(mock)
+	resp := gqlRequest(t, srv, authedCtx("non-admin"), usersQuery)
+
+	code := errCode(t, resp)
+	if code != string(gqlerr.CodeForbidden) {
+		t.Fatalf("expected FORBIDDEN, got %q", code)
+	}
+}
+
+// TestAdminUserResolver_Users_AdminHappyPath verifies that an admin caller
+// gets a UserConnection with populated edges and totalCount.
+func TestAdminUserResolver_Users_AdminHappyPath(t *testing.T) {
+	t.Parallel()
+
+	dn1, dn2 := "Alice", "Bob"
+	mock := &mockAdminUserUsecase{
+		listResult: &usecase.AdminUserConnection{
+			Edges: []usecase.AdminUserEdge{
+				{Cursor: "u1", Node: &domain.User{ID: "u1", DisplayName: &dn1}},
+				{Cursor: "u2", Node: &domain.User{ID: "u2", DisplayName: &dn2}},
+			},
+			PageInfo:   usecase.PageInfo{HasNextPage: false, HasPreviousPage: false},
+			TotalCount: 2,
+		},
+	}
+	srv := newAdminUserSrv(mock)
+	resp := gqlRequest(t, srv, authedCtx("admin"), usersQuery)
+
+	if _, hasErrs := resp["errors"]; hasErrs {
+		t.Fatalf("unexpected errors: %v", resp["errors"])
+	}
+	data, _ := resp["data"].(map[string]any)
+	conn, _ := data["users"].(map[string]any)
+	if conn == nil {
+		t.Fatalf("expected data.users, got nil; response: %v", resp)
+	}
+	edges, _ := conn["edges"].([]any)
+	if len(edges) != 2 {
+		t.Fatalf("expected 2 edges, got %d", len(edges))
+	}
+	total, _ := conn["totalCount"].(float64)
+	if int(total) != 2 {
+		t.Fatalf("expected totalCount=2, got %v", conn["totalCount"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Mutation.assignRole tests
+// ---------------------------------------------------------------------------
+
+const assignRoleMutation = `{"query":"mutation { assignRole(userId: \"u1\", roleId: \"r1\") { id } }"}`
+
+// TestAdminUserResolver_AssignRole_HappyPath verifies that assignRole returns
+// the updated user's ID when the usecase succeeds.
+func TestAdminUserResolver_AssignRole_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockAdminUserUsecase{
+		assignResult: &domain.User{ID: "u1"},
+	}
+	srv := newAdminUserSrv(mock)
+	resp := gqlRequest(t, srv, authedCtx("admin"), assignRoleMutation)
+
+	if _, hasErrs := resp["errors"]; hasErrs {
+		t.Fatalf("unexpected errors: %v", resp["errors"])
+	}
+	data, _ := resp["data"].(map[string]any)
+	user, _ := data["assignRole"].(map[string]any)
+	if user == nil {
+		t.Fatalf("expected data.assignRole, got nil; response: %v", resp)
+	}
+	if user["id"] != "u1" {
+		t.Fatalf("expected id=u1, got %v", user["id"])
+	}
+}
+
+// TestAdminUserResolver_AssignRole_Forbidden verifies that FORBIDDEN from the
+// usecase propagates unchanged to the caller.
+func TestAdminUserResolver_AssignRole_Forbidden(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockAdminUserUsecase{
+		assignErr: gqlerr.NewForbidden("admin only"),
+	}
+	srv := newAdminUserSrv(mock)
+	resp := gqlRequest(t, srv, authedCtx("non-admin"), assignRoleMutation)
+
+	code := errCode(t, resp)
+	if code != string(gqlerr.CodeForbidden) {
+		t.Fatalf("expected FORBIDDEN, got %q", code)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// User.roles DataLoader test
+// ---------------------------------------------------------------------------
+
+// usersWithRolesQuery requests the users list and resolves roles for each
+// user node.
+const usersWithRolesQuery = `{"query":"{ users(first: 3) { edges { node { id roles { id name } } } } }"}`
+
+// TestAdminUserResolver_Roles_ViaDataLoader verifies that User.roles is
+// resolved through the RoleByUserID DataLoader (no N+1) and that the roles
+// shape is correct. The test injects a loader context carrying a fake
+// RoleByUserID DataLoader backed by an in-memory map.
+func TestAdminUserResolver_Roles_ViaDataLoader(t *testing.T) {
+	t.Parallel()
+
+	adminRoleName := "admin"
+	generalRoleName := "general"
+	adminRole := &domain.Role{ID: "role-admin", Name: adminRoleName}
+	generalRole := &domain.Role{ID: "role-general", Name: generalRoleName}
+
+	mock := &mockAdminUserUsecase{
+		listResult: &usecase.AdminUserConnection{
+			Edges: []usecase.AdminUserEdge{
+				{Cursor: "u1", Node: &domain.User{ID: "u1"}},
+				{Cursor: "u2", Node: &domain.User{ID: "u2"}},
+				{Cursor: "u3", Node: &domain.User{ID: "u3"}},
+			},
+			PageInfo:   usecase.PageInfo{},
+			TotalCount: 3,
+		},
+	}
+	srv := newAdminUserSrv(mock)
+
+	rolesByUser := map[string][]*domain.Role{
+		"u1": {adminRole, generalRole},
+		"u2": {generalRole},
+		"u3": {},
+	}
+	ctx := ctxWithRoles(authedCtx("admin"), rolesByUser)
+	resp := gqlRequest(t, srv, ctx, usersWithRolesQuery)
+
+	if _, hasErrs := resp["errors"]; hasErrs {
+		t.Fatalf("unexpected errors: %v", resp["errors"])
+	}
+	data, _ := resp["data"].(map[string]any)
+	conn, _ := data["users"].(map[string]any)
+	if conn == nil {
+		t.Fatalf("expected data.users, got nil; response: %v", resp)
+	}
+	edges, _ := conn["edges"].([]any)
+	if len(edges) != 3 {
+		t.Fatalf("expected 3 edges, got %d", len(edges))
+	}
+
+	// u1 should have 2 roles.
+	u1, _ := edges[0].(map[string]any)["node"].(map[string]any)
+	u1roles, _ := u1["roles"].([]any)
+	if len(u1roles) != 2 {
+		t.Fatalf("expected u1 to have 2 roles, got %d", len(u1roles))
+	}
+
+	// u2 should have 1 role.
+	u2, _ := edges[1].(map[string]any)["node"].(map[string]any)
+	u2roles, _ := u2["roles"].([]any)
+	if len(u2roles) != 1 {
+		t.Fatalf("expected u2 to have 1 role, got %d", len(u2roles))
+	}
+
+	// u3 should have 0 roles.
+	u3, _ := edges[2].(map[string]any)["node"].(map[string]any)
+	u3roles, _ := u3["roles"].([]any)
+	if len(u3roles) != 0 {
+		t.Fatalf("expected u3 to have 0 roles, got %d", len(u3roles))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Query.roles tests
+// ---------------------------------------------------------------------------
+
+const rolesQuery = `{"query":"{ roles { id name } }"}`
+
+// TestAdminUserResolver_Roles_HappyPath verifies that Query.roles returns the
+// expected role list when the usecase succeeds.
+func TestAdminUserResolver_Roles_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockAdminUserUsecase{
+		listRolesResult: []*domain.Role{
+			{ID: "r-admin", Name: "admin"},
+			{ID: "r-general", Name: "general"},
+		},
+	}
+	srv := newAdminUserSrv(mock)
+	resp := gqlRequest(t, srv, authedCtx("admin"), rolesQuery)
+
+	if _, hasErrs := resp["errors"]; hasErrs {
+		t.Fatalf("unexpected errors: %v", resp["errors"])
+	}
+	data, _ := resp["data"].(map[string]any)
+	roles, _ := data["roles"].([]any)
+	if len(roles) != 2 {
+		t.Fatalf("expected 2 roles, got %d; response: %v", len(roles), resp)
+	}
+	first, _ := roles[0].(map[string]any)
+	if first["id"] != "r-admin" || first["name"] != "admin" {
+		t.Fatalf("roles[0] = %v, want {id:r-admin name:admin}", first)
+	}
+	second, _ := roles[1].(map[string]any)
+	if second["id"] != "r-general" || second["name"] != "general" {
+		t.Fatalf("roles[1] = %v, want {id:r-general name:general}", second)
+	}
+}
+
+// TestAdminUserResolver_Roles_Forbidden verifies that FORBIDDEN from the
+// usecase propagates unchanged.
+func TestAdminUserResolver_Roles_Forbidden(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockAdminUserUsecase{
+		listRolesErr: gqlerr.NewForbidden("admin only"),
+	}
+	srv := newAdminUserSrv(mock)
+	resp := gqlRequest(t, srv, authedCtx("non-admin"), rolesQuery)
+
+	code := errCode(t, resp)
+	if code != string(gqlerr.CodeForbidden) {
+		t.Fatalf("expected FORBIDDEN, got %q", code)
+	}
+}

--- a/backend/graph/resolver/card_resolvers_test.go
+++ b/backend/graph/resolver/card_resolvers_test.go
@@ -84,7 +84,7 @@ func newCardSrv(
 	tx func(context.Context, func(*gorm.DB) error) error,
 ) *handler.Server {
 	cardUC := usecase.NewCardUsecaseWithTx(cardRepo, cgRepo, tx)
-	r := resolver.NewResolver(nil, nil, cardUC, nil, nil, nil)
+	r := resolver.NewResolver(nil, nil, cardUC, nil, nil, nil, nil)
 	srv := handler.New(generated.NewExecutableSchema(generated.Config{Resolvers: r}))
 	srv.AddTransport(transport.POST{})
 	return srv

--- a/backend/graph/resolver/dictionary_resolver_test.go
+++ b/backend/graph/resolver/dictionary_resolver_test.go
@@ -30,7 +30,7 @@ func (m *mockUserRoleRepository) HasRole(_ context.Context, _, _ string) (bool, 
 // newDictOnlySrv builds a server with only AuthSvc wired; only the
 // validateDictionary resolver is exercised here.
 func newDictOnlySrv(roleRepo repository.UserRoleRepository) *handler.Server {
-	r := resolver.NewResolver(nil, nil, nil, nil, auth.NewService(roleRepo), nil)
+	r := resolver.NewResolver(nil, nil, nil, nil, auth.NewService(roleRepo), nil, nil)
 	srv := handler.New(generated.NewExecutableSchema(generated.Config{Resolvers: r}))
 	srv.AddTransport(transport.POST{})
 	return srv
@@ -216,7 +216,7 @@ func (m *mockDictionaryUsecase) Upsert(_ context.Context, _ usecase.UpsertDictio
 // wired. AuthSvc is not needed for the upsertDictionary resolver because the
 // usecase mock already encapsulates auth logic.
 func newUpsertDictSrv(dictUC usecase.DictionaryUsecase) *handler.Server {
-	r := resolver.NewResolver(nil, nil, nil, nil, nil, dictUC)
+	r := resolver.NewResolver(nil, nil, nil, nil, nil, dictUC, nil)
 	srv := handler.New(generated.NewExecutableSchema(generated.Config{Resolvers: r}))
 	srv.AddTransport(transport.POST{})
 	return srv

--- a/backend/graph/resolver/helpers.go
+++ b/backend/graph/resolver/helpers.go
@@ -132,6 +132,21 @@ func toCardConnectionModel(out *usecase.CardConnectionOutput) *model.CardConnect
 	}
 }
 
+func toRoleModel(r *domain.Role) *model.Role {
+	if r == nil {
+		return nil
+	}
+	return &model.Role{ID: r.ID, Name: r.Name}
+}
+
+func toRoleModels(roles []*domain.Role) []*model.Role {
+	out := make([]*model.Role, len(roles))
+	for i, r := range roles {
+		out[i] = toRoleModel(r)
+	}
+	return out
+}
+
 func nilIfEmpty(s string) *string {
 	if s == "" {
 		return nil

--- a/backend/graph/resolver/resolver.go
+++ b/backend/graph/resolver/resolver.go
@@ -6,12 +6,13 @@ import (
 )
 
 type Resolver struct {
-	User         *usecase.UserUsecase
+	UserUC       *usecase.UserUsecase
 	CardgroupUC  *usecase.CardgroupUsecase
 	CardUC       *usecase.CardUsecase
 	SwipeUC      *usecase.SwipeUsecase
 	AuthSvc      *auth.Service
 	DictionaryUC usecase.DictionaryUsecase
+	AdminUserUC  usecase.AdminUserUsecase
 }
 
 // NewResolver wires every Resolver dependency at construction time. Tests
@@ -24,13 +25,15 @@ func NewResolver(
 	swipeUC *usecase.SwipeUsecase,
 	authSvc *auth.Service,
 	dictionaryUC usecase.DictionaryUsecase,
+	adminUserUC usecase.AdminUserUsecase,
 ) *Resolver {
 	return &Resolver{
-		User:         user,
+		UserUC:       user,
 		CardgroupUC:  cardgroupUC,
 		CardUC:       cardUC,
 		SwipeUC:      swipeUC,
 		AuthSvc:      authSvc,
 		DictionaryUC: dictionaryUC,
+		AdminUserUC:  adminUserUC,
 	}
 }

--- a/backend/graph/resolver/schema.resolvers.go
+++ b/backend/graph/resolver/schema.resolvers.go
@@ -351,7 +351,32 @@ func (r *queryResolver) Roles(ctx context.Context) ([]*model.Role, error) {
 }
 
 // Roles is the resolver for the roles field.
+//
+// Admin gate: only the user themselves (self-introspection via me { roles })
+// or an admin caller may read another user's role membership. Returning an
+// empty slice for unauthorised callers would still leak the existence of the
+// field, so we surface FORBIDDEN explicitly.
 func (r *userResolver) Roles(ctx context.Context, obj *model.User) ([]*model.Role, error) {
+	caller := auth.UserFrom(ctx)
+	if caller == nil || caller.Sub == "" {
+		return nil, gqlerr.Unauthenticated()
+	}
+	if caller.Sub != obj.ID {
+		if r.AuthSvc == nil {
+			return nil, gqlerr.Internal(ctx, eris.New("resolver: user roles: AuthSvc not configured"))
+		}
+		isAdmin, err := r.AuthSvc.IsAdmin(ctx, caller.Sub)
+		if err != nil {
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return nil, gqlerr.Cancelled(ctx, err)
+			}
+			return nil, gqlerr.Internal(ctx, eris.Wrap(err, "resolver: user roles: check admin"))
+		}
+		if !isAdmin {
+			return nil, gqlerr.NewForbidden("admin only")
+		}
+	}
+
 	loaders := loader.For(ctx)
 	if loaders == nil {
 		return nil, gqlerr.Internal(ctx, eris.New("loader: middleware not installed for /query"))

--- a/backend/graph/resolver/schema.resolvers.go
+++ b/backend/graph/resolver/schema.resolvers.go
@@ -47,7 +47,7 @@ func (r *cardgroupResolver) Owner(ctx context.Context, obj *model.Cardgroup) (*m
 
 // UpdateProfile is the resolver for the updateProfile field.
 func (r *mutationResolver) UpdateProfile(ctx context.Context, input model.UpdateProfileInput) (*model.UpdateProfilePayload, error) {
-	user, err := r.User.UpdateUser(ctx, usecase.UpdateUserInput{
+	user, err := r.UserUC.UpdateUser(ctx, usecase.UpdateUserInput{
 		DisplayName: input.DisplayName,
 		Bio:         input.Bio,
 	})
@@ -162,6 +162,36 @@ func (r *mutationResolver) UpsertDictionary(ctx context.Context, input model.Ups
 	}, nil
 }
 
+// AdminUpdateUser is the resolver for the adminUpdateUser field.
+func (r *mutationResolver) AdminUpdateUser(ctx context.Context, id string, input model.AdminUpdateUserInput) (*model.User, error) {
+	user, err := r.AdminUserUC.Update(ctx, id, usecase.AdminUpdateUserInput{
+		DisplayName: input.DisplayName,
+		Bio:         input.Bio,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return toUserModel(user), nil
+}
+
+// AssignRole is the resolver for the assignRole field.
+func (r *mutationResolver) AssignRole(ctx context.Context, userID string, roleID string) (*model.User, error) {
+	user, err := r.AdminUserUC.AssignRole(ctx, userID, roleID)
+	if err != nil {
+		return nil, err
+	}
+	return toUserModel(user), nil
+}
+
+// RevokeRole is the resolver for the revokeRole field.
+func (r *mutationResolver) RevokeRole(ctx context.Context, userID string, roleID string) (*model.User, error) {
+	user, err := r.AdminUserUC.RevokeRole(ctx, userID, roleID)
+	if err != nil {
+		return nil, err
+	}
+	return toUserModel(user), nil
+}
+
 // Health is the resolver for the health field.
 func (r *queryResolver) Health(ctx context.Context) (string, error) {
 	return "ok", nil
@@ -169,7 +199,7 @@ func (r *queryResolver) Health(ctx context.Context) (string, error) {
 
 // Me is the resolver for the me field.
 func (r *queryResolver) Me(ctx context.Context) (*model.User, error) {
-	user, err := r.User.Me(ctx)
+	user, err := r.UserUC.Me(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -277,6 +307,65 @@ func (r *queryResolver) ValidateDictionary(ctx context.Context, input model.Vali
 	}, nil
 }
 
+// Users is the resolver for the users field.
+func (r *queryResolver) Users(ctx context.Context, first *int, after *string, last *int, before *string, search *string) (*model.UserConnection, error) {
+	uc, err := r.AdminUserUC.List(ctx, first, last, after, before, search)
+	if err != nil {
+		return nil, err
+	}
+	edges := make([]*model.UserEdge, len(uc.Edges))
+	for i, e := range uc.Edges {
+		edges[i] = &model.UserEdge{Cursor: e.Cursor, Node: toUserModel(e.Node)}
+	}
+	return &model.UserConnection{
+		Edges: edges,
+		PageInfo: &model.PageInfo{
+			HasNextPage:     uc.PageInfo.HasNextPage,
+			HasPreviousPage: uc.PageInfo.HasPreviousPage,
+			StartCursor:     uc.PageInfo.StartCursor,
+			EndCursor:       uc.PageInfo.EndCursor,
+		},
+		TotalCount: int(uc.TotalCount),
+	}, nil
+}
+
+// AdminUser is the resolver for the adminUser field.
+func (r *queryResolver) AdminUser(ctx context.Context, id string) (*model.User, error) {
+	user, err := r.AdminUserUC.Get(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if user == nil {
+		return nil, nil
+	}
+	return toUserModel(user), nil
+}
+
+// Roles is the resolver for the roles field.
+func (r *queryResolver) Roles(ctx context.Context) ([]*model.Role, error) {
+	roles, err := r.AdminUserUC.ListRoles(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return toRoleModels(roles), nil
+}
+
+// Roles is the resolver for the roles field.
+func (r *userResolver) Roles(ctx context.Context, obj *model.User) ([]*model.Role, error) {
+	loaders := loader.For(ctx)
+	if loaders == nil {
+		return nil, gqlerr.Internal(ctx, eris.New("loader: middleware not installed for /query"))
+	}
+	roles, err := loaders.RoleByUserID.Load(ctx, obj.ID)()
+	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return nil, gqlerr.Cancelled(ctx, err)
+		}
+		return nil, gqlerr.Internal(ctx, eris.Wrap(err, "resolver: user roles"))
+	}
+	return toRoleModels(roles), nil
+}
+
 // Card returns generated.CardResolver implementation.
 func (r *Resolver) Card() generated.CardResolver { return &cardResolver{r} }
 
@@ -289,7 +378,11 @@ func (r *Resolver) Mutation() generated.MutationResolver { return &mutationResol
 // Query returns generated.QueryResolver implementation.
 func (r *Resolver) Query() generated.QueryResolver { return &queryResolver{r} }
 
+// User returns generated.UserResolver implementation.
+func (r *Resolver) User() generated.UserResolver { return &userResolver{r} }
+
 type cardResolver struct{ *Resolver }
 type cardgroupResolver struct{ *Resolver }
 type mutationResolver struct{ *Resolver }
 type queryResolver struct{ *Resolver }
+type userResolver struct{ *Resolver }

--- a/backend/graph/resolver/user_test.go
+++ b/backend/graph/resolver/user_test.go
@@ -44,7 +44,7 @@ func ptr(s string) *string { return &s }
 // given mock repository.
 func newServer(mock *mockUserRepository) *handler.Server {
 	uc := usecase.NewUserUsecase(mock)
-	r := resolver.NewResolver(uc, nil, nil, nil, nil, nil)
+	r := resolver.NewResolver(uc, nil, nil, nil, nil, nil, nil)
 	srv := handler.New(generated.NewExecutableSchema(generated.Config{Resolvers: r}))
 	srv.AddTransport(transport.POST{})
 	return srv

--- a/backend/internal/loader/loader.go
+++ b/backend/internal/loader/loader.go
@@ -13,19 +13,21 @@ import (
 type contextKey struct{}
 
 type Loaders struct {
-	User        *dataloader.Loader[string, *domain.User]
-	Role        *dataloader.Loader[string, *domain.Role]
-	Cardgroup   *dataloader.Loader[string, *domain.Cardgroup]
-	Card        *dataloader.Loader[string, *domain.Card]
-	SwipeRecord *dataloader.Loader[string, *domain.SwipeRecord]
+	User         *dataloader.Loader[string, *domain.User]
+	Role         *dataloader.Loader[string, *domain.Role]
+	RoleByUserID *RoleByUserIDLoader
+	Cardgroup    *dataloader.Loader[string, *domain.Cardgroup]
+	Card         *dataloader.Loader[string, *domain.Card]
+	SwipeRecord  *dataloader.Loader[string, *domain.SwipeRecord]
 }
 
 func New(userRepo repository.UserRepository, roleRepo repository.RoleRepository, cardgroupRepo repository.CardgroupRepository, cardRepo repository.CardRepository, swipeRecordRepo ...repository.SwipeRecordRepository) *Loaders {
 	loaders := &Loaders{
-		User:      dataloader.NewBatchedLoader(userBatchFunc(userRepo)),
-		Role:      dataloader.NewBatchedLoader(roleBatchFunc(roleRepo)),
-		Cardgroup: dataloader.NewBatchedLoader(cardgroupBatchFunc(cardgroupRepo)),
-		Card:      dataloader.NewBatchedLoader(cardBatchFunc(cardRepo)),
+		User:         dataloader.NewBatchedLoader(userBatchFunc(userRepo)),
+		Role:         dataloader.NewBatchedLoader(roleBatchFunc(roleRepo)),
+		RoleByUserID: dataloader.NewBatchedLoader(roleByUserIDBatchFunc(roleRepo)),
+		Cardgroup:    dataloader.NewBatchedLoader(cardgroupBatchFunc(cardgroupRepo)),
+		Card:         dataloader.NewBatchedLoader(cardBatchFunc(cardRepo)),
 	}
 	if len(swipeRecordRepo) > 0 && swipeRecordRepo[0] != nil {
 		loaders.SwipeRecord = dataloader.NewBatchedLoader(swipeRecordBatchFunc(swipeRecordRepo[0]))
@@ -50,4 +52,10 @@ func Middleware(userRepo repository.UserRepository, roleRepo repository.RoleRepo
 func For(ctx context.Context) *Loaders {
 	l, _ := ctx.Value(contextKey{}).(*Loaders)
 	return l
+}
+
+// WithContext stores loaders in ctx and returns the enriched context. Use
+// this in tests to inject a Loaders without going through the Echo middleware.
+func WithContext(ctx context.Context, l *Loaders) context.Context {
+	return context.WithValue(ctx, contextKey{}, l)
 }

--- a/backend/internal/loader/role_by_user.go
+++ b/backend/internal/loader/role_by_user.go
@@ -1,0 +1,50 @@
+package loader
+
+import (
+	"context"
+
+	"github.com/graph-gophers/dataloader/v7"
+	"github.com/rotisserie/eris"
+
+	"backend/internal/domain"
+	"backend/internal/repository"
+)
+
+// RoleByUserIDLoader batches role lookups by user ID. Each key maps to the
+// ordered list of roles assigned to that user (empty slice when the user has
+// no roles, and also when the user ID is unknown — a missing user is not an
+// error at the loader layer).
+type RoleByUserIDLoader = dataloader.Loader[string, []*domain.Role]
+
+func roleByUserIDBatchFunc(repo repository.RoleRepository) dataloader.BatchFunc[string, []*domain.Role] {
+	return func(ctx context.Context, keys []string) []*dataloader.Result[[]*domain.Role] {
+		out := make([]*dataloader.Result[[]*domain.Role], len(keys))
+
+		// Defensive: dataloader normally never invokes the batch fn with an
+		// empty key slice, but the GORM "WHERE id IN ()" gotcha would turn
+		// such a call into a full-table scan. Short-circuit instead.
+		if len(keys) == 0 {
+			return out
+		}
+
+		byUser, err := repo.ListByUserIDs(ctx, keys)
+		if err != nil {
+			wrapped := eris.Wrap(err, "loader: list roles by user IDs")
+			for i := range keys {
+				out[i] = &dataloader.Result[[]*domain.Role]{Error: wrapped}
+			}
+			return out
+		}
+
+		for i, k := range keys {
+			roles, ok := byUser[k]
+			if !ok {
+				// Unknown or role-less user: return an explicit empty slice
+				// so resolvers can range over it without nil checks.
+				roles = []*domain.Role{}
+			}
+			out[i] = &dataloader.Result[[]*domain.Role]{Data: roles}
+		}
+		return out
+	}
+}

--- a/backend/internal/loader/role_by_user_test.go
+++ b/backend/internal/loader/role_by_user_test.go
@@ -1,0 +1,283 @@
+package loader_test
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"backend/internal/domain"
+	"backend/internal/loader"
+	"backend/internal/repository"
+)
+
+// roleBatchRepoStub satisfies repository.RoleRepository (which includes
+// ListByUserIDs). Methods unrelated to the RoleByUserID loader panic so
+// an unexpected call fails loudly.
+type roleBatchRepoStub struct {
+	listByUserIDs func(ctx context.Context, userIDs []string) (map[string][]*domain.Role, error)
+}
+
+func (s *roleBatchRepoStub) FindByName(_ context.Context, _ string) (*domain.Role, error) {
+	panic("roleBatchRepoStub.FindByName not configured")
+}
+
+func (s *roleBatchRepoStub) FindByIDs(_ context.Context, _ []string) (map[string]*domain.Role, error) {
+	// Return empty so the singular Role loader stays a no-op when invoked.
+	return map[string]*domain.Role{}, nil
+}
+
+// AssignToUser, RevokeFromUser, ListByUser satisfy the wider RoleRepository
+// interface. None of the RoleByUserID loader tests exercise these paths, so
+// they panic to surface accidental coupling.
+func (s *roleBatchRepoStub) AssignToUser(_ context.Context, _, _ string) error {
+	panic("roleBatchRepoStub.AssignToUser not configured")
+}
+
+func (s *roleBatchRepoStub) RevokeFromUser(_ context.Context, _, _ string) error {
+	panic("roleBatchRepoStub.RevokeFromUser not configured")
+}
+
+func (s *roleBatchRepoStub) ListByUser(_ context.Context, _ string) ([]*domain.Role, error) {
+	panic("roleBatchRepoStub.ListByUser not configured")
+}
+
+func (s *roleBatchRepoStub) ListByUserIDs(ctx context.Context, userIDs []string) (map[string][]*domain.Role, error) {
+	if s.listByUserIDs == nil {
+		panic("roleBatchRepoStub.ListByUserIDs not configured")
+	}
+	return s.listByUserIDs(ctx, userIDs)
+}
+
+func (s *roleBatchRepoStub) ListAll(_ context.Context) ([]*domain.Role, error) {
+	panic("roleBatchRepoStub.ListAll not configured")
+}
+
+// Compile-time assertion that the stub satisfies the unified interface.
+var _ repository.RoleRepository = (*roleBatchRepoStub)(nil)
+
+func newLoadersForRoleByUser(roleRepo repository.RoleRepository) *loader.Loaders {
+	return loader.New(
+		&countingRepo{
+			findByIDs: func(_ context.Context, _ []string) (map[string]*domain.User, error) {
+				return map[string]*domain.User{}, nil
+			},
+		},
+		roleRepo,
+		emptyCardgroupRepo(),
+		emptyCardRepo(),
+	)
+}
+
+func TestRoleByUserIDLoader_SingleUserMultipleRolesNameAsc(t *testing.T) {
+	t.Parallel()
+
+	roleA := &domain.Role{ID: "role-a", Name: "admin"}
+	roleB := &domain.Role{ID: "role-b", Name: "editor"}
+
+	repo := &roleBatchRepoStub{
+		listByUserIDs: func(_ context.Context, userIDs []string) (map[string][]*domain.Role, error) {
+			if len(userIDs) != 1 || userIDs[0] != "user-1" {
+				t.Fatalf("unexpected userIDs: %v", userIDs)
+			}
+			// Caller relies on the repository to sort by name ASC.
+			roles := []*domain.Role{roleA, roleB}
+			sort.Slice(roles, func(i, j int) bool { return roles[i].Name < roles[j].Name })
+			return map[string][]*domain.Role{"user-1": roles}, nil
+		},
+	}
+
+	l := newLoadersForRoleByUser(repo)
+	if l.RoleByUserID == nil {
+		t.Fatal("RoleByUserID loader was not wired")
+	}
+
+	got, err := l.RoleByUserID.Load(context.Background(), "user-1")()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len(roles) = %d, want 2", len(got))
+	}
+	if got[0].Name != "admin" || got[1].Name != "editor" {
+		t.Fatalf("name order = [%q,%q], want [admin,editor]", got[0].Name, got[1].Name)
+	}
+}
+
+func TestRoleByUserIDLoader_BatchesNCallsIntoOne(t *testing.T) {
+	t.Parallel()
+
+	var batchCalls atomic.Int32
+	var seenKeys [][]string
+	var mu sync.Mutex
+
+	repo := &roleBatchRepoStub{
+		listByUserIDs: func(_ context.Context, userIDs []string) (map[string][]*domain.Role, error) {
+			batchCalls.Add(1)
+			mu.Lock()
+			cp := append([]string(nil), userIDs...)
+			seenKeys = append(seenKeys, cp)
+			mu.Unlock()
+			out := make(map[string][]*domain.Role, len(userIDs))
+			for _, id := range userIDs {
+				out[id] = []*domain.Role{{ID: "role-for-" + id, Name: "n-" + id}}
+			}
+			return out, nil
+		},
+	}
+
+	l := newLoadersForRoleByUser(repo)
+	if l.RoleByUserID == nil {
+		t.Fatal("RoleByUserID loader was not wired")
+	}
+
+	ids := []string{"u1", "u2", "u3"}
+	results := make([][]*domain.Role, len(ids))
+	errs := make([]error, len(ids))
+
+	var wg sync.WaitGroup
+	for i, id := range ids {
+		wg.Add(1)
+		go func(i int, id string) {
+			defer wg.Done()
+			results[i], errs[i] = l.RoleByUserID.Load(context.Background(), id)()
+		}(i, id)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("load %d: %v", i, err)
+		}
+		if len(results[i]) != 1 || results[i][0].ID != "role-for-"+ids[i] {
+			t.Fatalf("load %d: unexpected roles %+v", i, results[i])
+		}
+	}
+	if got := batchCalls.Load(); got != 1 {
+		t.Fatalf("BatchFunc should run exactly once, ran %d times (keys seen: %v)", got, seenKeys)
+	}
+}
+
+func TestRoleByUserIDLoader_UserWithNoRolesReturnsEmptySlice(t *testing.T) {
+	t.Parallel()
+
+	repo := &roleBatchRepoStub{
+		listByUserIDs: func(_ context.Context, _ []string) (map[string][]*domain.Role, error) {
+			// Repository returns no entry for users with zero roles.
+			return map[string][]*domain.Role{}, nil
+		},
+	}
+
+	l := newLoadersForRoleByUser(repo)
+	got, err := l.RoleByUserID.Load(context.Background(), "user-without-roles")()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got == nil {
+		t.Fatal("got nil slice; want empty (non-nil) slice so resolvers can range without nil checks")
+	}
+	if len(got) != 0 {
+		t.Fatalf("len(roles) = %d, want 0", len(got))
+	}
+}
+
+func TestRoleByUserIDLoader_MixOfKnownAndUnknownUsers(t *testing.T) {
+	t.Parallel()
+
+	repo := &roleBatchRepoStub{
+		listByUserIDs: func(_ context.Context, userIDs []string) (map[string][]*domain.Role, error) {
+			out := map[string][]*domain.Role{}
+			for _, id := range userIDs {
+				if id == "ghost" {
+					continue
+				}
+				out[id] = []*domain.Role{{ID: "r-" + id, Name: "name-" + id}}
+			}
+			return out, nil
+		},
+	}
+
+	l := newLoadersForRoleByUser(repo)
+
+	ids := []string{"present", "ghost"}
+	results := make([][]*domain.Role, len(ids))
+	errs := make([]error, len(ids))
+
+	var wg sync.WaitGroup
+	for i, id := range ids {
+		wg.Add(1)
+		go func(i int, id string) {
+			defer wg.Done()
+			results[i], errs[i] = l.RoleByUserID.Load(context.Background(), id)()
+		}(i, id)
+	}
+	wg.Wait()
+
+	if errs[0] != nil {
+		t.Fatalf("present: unexpected error: %v", errs[0])
+	}
+	if len(results[0]) != 1 || results[0][0].ID != "r-present" {
+		t.Fatalf("present: unexpected roles %+v", results[0])
+	}
+	if errs[1] != nil {
+		t.Fatalf("ghost: want nil error (unknown user is not an error at the loader layer), got %v", errs[1])
+	}
+	if results[1] == nil {
+		t.Fatal("ghost: want empty slice, got nil")
+	}
+	if len(results[1]) != 0 {
+		t.Fatalf("ghost: want empty slice, got %+v", results[1])
+	}
+}
+
+func TestRoleByUserIDLoader_BatchFuncErrorWraps(t *testing.T) {
+	t.Parallel()
+
+	wantErr := errors.New("db blew up")
+	repo := &roleBatchRepoStub{
+		listByUserIDs: func(_ context.Context, _ []string) (map[string][]*domain.Role, error) {
+			return nil, wantErr
+		},
+	}
+
+	l := newLoadersForRoleByUser(repo)
+	_, err := l.RoleByUserID.Load(context.Background(), "u1")()
+	if err == nil {
+		t.Fatal("want error, got nil")
+	}
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("want errors.Is(err, wantErr) == true; got chain: %v", err)
+	}
+}
+
+// Defensive coverage for the empty-keys early return inside the batch fn.
+// The dataloader runtime never invokes the batch fn with an empty slice in
+// practice, so this exercises the guard directly via the package-level
+// helper that the loader uses internally. We approximate by asserting that
+// loading zero keys (i.e. issuing no Load calls) does not call the
+// repository — i.e. the loader stays cold. This is partly tautological but
+// pairs with the GORM empty-IN gotcha note in role_by_user.go.
+func TestRoleByUserIDLoader_NoLoadsLeavesRepositoryCold(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	repo := &roleBatchRepoStub{
+		listByUserIDs: func(_ context.Context, userIDs []string) (map[string][]*domain.Role, error) {
+			calls.Add(1)
+			if len(userIDs) == 0 {
+				t.Fatal("ListByUserIDs called with empty slice; the GORM empty-IN gotcha would scan the whole join table")
+			}
+			return map[string][]*domain.Role{}, nil
+		},
+	}
+
+	l := newLoadersForRoleByUser(repo)
+	if l.RoleByUserID == nil {
+		t.Fatal("RoleByUserID loader was not wired")
+	}
+	if got := calls.Load(); got != 0 {
+		t.Fatalf("repository called %d times before any Load; want 0", got)
+	}
+}

--- a/backend/internal/loader/user_test.go
+++ b/backend/internal/loader/user_test.go
@@ -45,6 +45,29 @@ func (r *countingRoleRepo) FindByIDs(ctx context.Context, ids []string) (map[str
 	return r.findByIDs(ctx, ids)
 }
 
+// AssignToUser, RevokeFromUser, ListByUser satisfy the wider RoleRepository
+// interface. The cardgroup/card/user loader tests never assign or revoke
+// roles, so these panic to surface accidental coupling.
+func (r *countingRoleRepo) AssignToUser(_ context.Context, _, _ string) error {
+	panic("countingRoleRepo.AssignToUser not configured")
+}
+
+func (r *countingRoleRepo) RevokeFromUser(_ context.Context, _, _ string) error {
+	panic("countingRoleRepo.RevokeFromUser not configured")
+}
+
+func (r *countingRoleRepo) ListByUser(_ context.Context, _ string) ([]*domain.Role, error) {
+	panic("countingRoleRepo.ListByUser not configured")
+}
+
+func (r *countingRoleRepo) ListByUserIDs(_ context.Context, _ []string) (map[string][]*domain.Role, error) {
+	panic("countingRoleRepo.ListByUserIDs not configured")
+}
+
+func (r *countingRoleRepo) ListAll(_ context.Context) ([]*domain.Role, error) {
+	panic("countingRoleRepo.ListAll not configured")
+}
+
 func emptyRoleRepo() *countingRoleRepo {
 	return &countingRoleRepo{
 		findByIDs: func(_ context.Context, _ []string) (map[string]*domain.Role, error) {
@@ -164,6 +187,18 @@ func (r *countingRepo) Update(ctx context.Context, id string, patch repository.U
 		panic("countingRepo.Update not configured")
 	}
 	return r.update(ctx, id, patch)
+}
+
+// ListPage satisfies repository.UserRepository. The loader-layer tests never
+// hit cursor pagination, so this fixture panics if called — surfacing any
+// accidental coupling instead of silently returning a fabricated empty page.
+func (r *countingRepo) ListPage(
+	_ context.Context,
+	_, _ *string,
+	_, _ int,
+	_ *string,
+) ([]*domain.User, int64, error) {
+	panic("countingRepo.ListPage not configured")
 }
 
 // loadAll concurrently loads all ids through l and returns aligned results/errors.

--- a/backend/internal/repository/role.go
+++ b/backend/internal/repository/role.go
@@ -3,7 +3,9 @@ package repository
 import (
 	"context"
 	"errors"
+	"strings"
 
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/rotisserie/eris"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
@@ -53,8 +55,10 @@ type RoleRepository interface {
 	// also satisfy errors.Is(_, ErrNotFound) for backward-compatible matching.
 	AssignToUser(ctx context.Context, userID, roleID string) error
 
-	// RevokeFromUser deletes the (user_id, role_id) row. Idempotent: if the row
-	// does not exist, returns nil without error.
+	// RevokeFromUser deletes the (user_id, role_id) row. Validates that the
+	// user and role exist; returns ErrUserNotFound / ErrRoleNotFound when
+	// either is missing. When both exist but no assignment link is present,
+	// returns nil without error (idempotent on the assignment row).
 	RevokeFromUser(ctx context.Context, userID, roleID string) error
 
 	// ListByUser returns all roles assigned to the given user, ordered by
@@ -107,6 +111,26 @@ func (r *roleRepo) FindByIDs(ctx context.Context, ids []string) (map[string]*dom
 	return out, nil
 }
 
+// classifyFKError inspects a Postgres FK violation (code 23503) and maps it
+// to ErrUserNotFound or ErrRoleNotFound based on which constraint was violated.
+// Returns nil when err is not a FK violation, so callers can use it as a
+// pre-filter before falling through to eris.Wrap. This helper exists so the
+// FK-classification logic can be unit-tested with a fabricated *pgconn.PgError
+// without needing a live DB race.
+func classifyFKError(err error) error {
+	var pgErr *pgconn.PgError
+	if !errors.As(err, &pgErr) || pgErr.Code != "23503" {
+		return nil
+	}
+	if strings.Contains(pgErr.ConstraintName, "user_id") {
+		return ErrUserNotFound
+	}
+	if strings.Contains(pgErr.ConstraintName, "role_id") {
+		return ErrRoleNotFound
+	}
+	return nil
+}
+
 // AssignToUser inserts a user_roles row. Idempotent via ON CONFLICT DO NOTHING.
 // Validates that both the user and role exist before inserting; returns
 // ErrUserNotFound when the user is missing and ErrRoleNotFound when the role
@@ -114,6 +138,11 @@ func (r *roleRepo) FindByIDs(ctx context.Context, ids []string) (map[string]*dom
 // callers that only branch on ErrNotFound keep working — new callers should
 // match the specific sentinel first to surface the correct field in
 // BAD_USER_INPUT responses.
+//
+// FK race: if the user or role is deleted between the existence check and the
+// INSERT (concurrent admin operation), the resulting Postgres FK violation
+// (23503) is classified by classifyFKError into the same sentinels, so the
+// caller still receives BAD_USER_INPUT rather than INTERNAL.
 func (r *roleRepo) AssignToUser(ctx context.Context, userID, roleID string) error {
 	// Validate user exists.
 	var userCount int64
@@ -143,14 +172,47 @@ func (r *roleRepo) AssignToUser(ctx context.Context, userID, roleID string) erro
 	if err := r.db.WithContext(ctx).
 		Clauses(clause.OnConflict{DoNothing: true}).
 		Create(&row).Error; err != nil {
+		// A concurrent delete between the existence check and the INSERT can
+		// produce a FK violation. Classify it into the appropriate sentinel
+		// so the caller sees BAD_USER_INPUT rather than INTERNAL.
+		if classified := classifyFKError(err); classified != nil {
+			return classified
+		}
 		return eris.Wrap(err, "repository: assign role to user")
 	}
 	return nil
 }
 
-// RevokeFromUser deletes the (user_id, role_id) row. Idempotent: no error when
-// the row does not exist.
+// RevokeFromUser deletes the (user_id, role_id) row. Validates that the user
+// and role both exist before attempting the delete; returns ErrUserNotFound
+// when the user is missing and ErrRoleNotFound when the role is missing. When
+// both exist but no assignment row is present, the operation is a silent
+// no-op (idempotent on the assignment link itself).
 func (r *roleRepo) RevokeFromUser(ctx context.Context, userID, roleID string) error {
+	// Validate user exists.
+	var userCount int64
+	if err := r.db.WithContext(ctx).
+		Table("users").
+		Where("id = ?", userID).
+		Count(&userCount).Error; err != nil {
+		return eris.Wrap(err, "repository: revoke role: check user")
+	}
+	if userCount == 0 {
+		return ErrUserNotFound
+	}
+
+	// Validate role exists.
+	var roleCount int64
+	if err := r.db.WithContext(ctx).
+		Table("roles").
+		Where("id = ?", roleID).
+		Count(&roleCount).Error; err != nil {
+		return eris.Wrap(err, "repository: revoke role: check role")
+	}
+	if roleCount == 0 {
+		return ErrRoleNotFound
+	}
+
 	if err := r.db.WithContext(ctx).
 		Where("user_id = ? AND role_id = ?", userID, roleID).
 		Delete(&gormUserRole{}).Error; err != nil {

--- a/backend/internal/repository/role.go
+++ b/backend/internal/repository/role.go
@@ -6,9 +6,18 @@ import (
 
 	"github.com/rotisserie/eris"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 
 	"backend/internal/domain"
 )
+
+// gormUserRoleJoinRow is the projected shape of the join between user_roles
+// and roles used by ListByUserIDs.
+type gormUserRoleJoinRow struct {
+	UserID string `gorm:"column:user_id"`
+	ID     string `gorm:"column:id"`
+	Name   string `gorm:"column:name"`
+}
 
 type gormRole struct {
 	ID   string `gorm:"column:id;primaryKey;type:uuid"`
@@ -20,6 +29,32 @@ func (gormRole) TableName() string { return "roles" }
 type RoleRepository interface {
 	FindByName(ctx context.Context, name string) (*domain.Role, error)
 	FindByIDs(ctx context.Context, ids []string) (map[string]*domain.Role, error)
+
+	// AssignToUser inserts a (user_id, role_id) row. Idempotent: if the row
+	// already exists, returns nil without error. Returns ErrNotFound if either
+	// the user or the role does not exist.
+	AssignToUser(ctx context.Context, userID, roleID string) error
+
+	// RevokeFromUser deletes the (user_id, role_id) row. Idempotent: if the row
+	// does not exist, returns nil without error.
+	RevokeFromUser(ctx context.Context, userID, roleID string) error
+
+	// ListByUser returns all roles assigned to the given user, ordered by
+	// role name ascending. Returns an empty slice (not nil, not an error) when
+	// the user has no roles.
+	ListByUser(ctx context.Context, userID string) ([]*domain.Role, error)
+
+	// ListByUserIDs returns the roles assigned to each user ID in a single
+	// query. The map key is the user ID; values are roles ordered by
+	// name ASC. Users with no roles are absent from the map (callers
+	// fill in an empty slice). An empty userIDs slice short-circuits to
+	// an empty map without issuing a query — see the GORM empty-IN gotcha
+	// in .claude/rules/go-library-gotchas.md.
+	ListByUserIDs(ctx context.Context, userIDs []string) (map[string][]*domain.Role, error)
+
+	// ListAll returns every role ordered by name ASC. Returns an empty
+	// slice (never nil) when no roles exist.
+	ListAll(ctx context.Context) ([]*domain.Role, error)
 }
 
 type roleRepo struct{ db *gorm.DB }
@@ -50,6 +85,116 @@ func (r *roleRepo) FindByIDs(ctx context.Context, ids []string) (map[string]*dom
 	for i := range rows {
 		role := roleToDomain(rows[i])
 		out[role.ID] = role
+	}
+	return out, nil
+}
+
+// AssignToUser inserts a user_roles row. Idempotent via ON CONFLICT DO NOTHING.
+// Validates that both the user and role exist before inserting; returns
+// ErrNotFound if either is absent.
+func (r *roleRepo) AssignToUser(ctx context.Context, userID, roleID string) error {
+	// Validate user exists.
+	var userCount int64
+	if err := r.db.WithContext(ctx).
+		Table("users").
+		Where("id = ?", userID).
+		Count(&userCount).Error; err != nil {
+		return eris.Wrap(err, "repository: assign role: check user")
+	}
+	if userCount == 0 {
+		return ErrNotFound
+	}
+
+	// Validate role exists.
+	var roleCount int64
+	if err := r.db.WithContext(ctx).
+		Table("roles").
+		Where("id = ?", roleID).
+		Count(&roleCount).Error; err != nil {
+		return eris.Wrap(err, "repository: assign role: check role")
+	}
+	if roleCount == 0 {
+		return ErrNotFound
+	}
+
+	row := gormUserRole{UserID: userID, RoleID: roleID}
+	if err := r.db.WithContext(ctx).
+		Clauses(clause.OnConflict{DoNothing: true}).
+		Create(&row).Error; err != nil {
+		return eris.Wrap(err, "repository: assign role to user")
+	}
+	return nil
+}
+
+// RevokeFromUser deletes the (user_id, role_id) row. Idempotent: no error when
+// the row does not exist.
+func (r *roleRepo) RevokeFromUser(ctx context.Context, userID, roleID string) error {
+	if err := r.db.WithContext(ctx).
+		Where("user_id = ? AND role_id = ?", userID, roleID).
+		Delete(&gormUserRole{}).Error; err != nil {
+		return eris.Wrap(err, "repository: revoke role from user")
+	}
+	return nil
+}
+
+// ListByUser returns all roles assigned to userID, ordered by name ascending.
+// Returns an empty slice (never nil) when the user has no roles.
+func (r *roleRepo) ListByUser(ctx context.Context, userID string) ([]*domain.Role, error) {
+	var rows []gormRole
+	if err := r.db.WithContext(ctx).
+		Table("roles").
+		Joins("JOIN user_roles ON user_roles.role_id = roles.id").
+		Where("user_roles.user_id = ?", userID).
+		Order("roles.name ASC").
+		Find(&rows).Error; err != nil {
+		return nil, eris.Wrap(err, "repository: list roles by user")
+	}
+	out := make([]*domain.Role, len(rows))
+	for i := range rows {
+		out[i] = roleToDomain(rows[i])
+	}
+	return out, nil
+}
+
+// ListByUserIDs returns the roles assigned to each user ID in a single query.
+// Returns an empty map (never nil) when userIDs is empty.
+func (r *roleRepo) ListByUserIDs(ctx context.Context, userIDs []string) (map[string][]*domain.Role, error) {
+	if len(userIDs) == 0 {
+		return map[string][]*domain.Role{}, nil
+	}
+
+	var rows []gormUserRoleJoinRow
+	err := r.db.WithContext(ctx).
+		Table("user_roles").
+		Select("user_roles.user_id AS user_id, roles.id AS id, roles.name AS name").
+		Joins("JOIN roles ON roles.id = user_roles.role_id").
+		Where("user_roles.user_id IN ?", userIDs).
+		Order("roles.name ASC").
+		Scan(&rows).Error
+	if err != nil {
+		return nil, eris.Wrap(err, "repository: list roles by user ids")
+	}
+
+	out := make(map[string][]*domain.Role, len(rows))
+	for i := range rows {
+		out[rows[i].UserID] = append(out[rows[i].UserID], &domain.Role{
+			ID:   rows[i].ID,
+			Name: rows[i].Name,
+		})
+	}
+	return out, nil
+}
+
+// ListAll returns every role ordered by name ASC. Returns an empty slice
+// (never nil) when the roles table is empty.
+func (r *roleRepo) ListAll(ctx context.Context) ([]*domain.Role, error) {
+	var rows []gormRole
+	if err := r.db.WithContext(ctx).Order("name ASC").Find(&rows).Error; err != nil {
+		return nil, eris.Wrap(err, "role repo: list all")
+	}
+	out := make([]*domain.Role, len(rows))
+	for i := range rows {
+		out[i] = roleToDomain(rows[i])
 	}
 	return out, nil
 }

--- a/backend/internal/repository/role.go
+++ b/backend/internal/repository/role.go
@@ -11,6 +11,23 @@ import (
 	"backend/internal/domain"
 )
 
+// ErrUserNotFound and ErrRoleNotFound are returned by AssignToUser to
+// distinguish which side of the (user, role) pair was missing. Both are
+// joined with ErrNotFound so callers that previously branched on the legacy
+// sentinel via errors.Is keep working; new callers can branch on the
+// specific cause to surface a more precise BAD_USER_INPUT field.
+//
+// Plain errors.New (not eris) so errors.Is walks identity directly.
+var (
+	errUserNotFoundBase = errors.New("repository: user not found")
+	errRoleNotFoundBase = errors.New("repository: role not found")
+
+	// ErrUserNotFound matches both itself and ErrNotFound.
+	ErrUserNotFound = errors.Join(errUserNotFoundBase, ErrNotFound)
+	// ErrRoleNotFound matches both itself and ErrNotFound.
+	ErrRoleNotFound = errors.Join(errRoleNotFoundBase, ErrNotFound)
+)
+
 // gormUserRoleJoinRow is the projected shape of the join between user_roles
 // and roles used by ListByUserIDs.
 type gormUserRoleJoinRow struct {
@@ -31,8 +48,9 @@ type RoleRepository interface {
 	FindByIDs(ctx context.Context, ids []string) (map[string]*domain.Role, error)
 
 	// AssignToUser inserts a (user_id, role_id) row. Idempotent: if the row
-	// already exists, returns nil without error. Returns ErrNotFound if either
-	// the user or the role does not exist.
+	// already exists, returns nil without error. Returns ErrUserNotFound when
+	// the user is missing and ErrRoleNotFound when the role is missing; both
+	// also satisfy errors.Is(_, ErrNotFound) for backward-compatible matching.
 	AssignToUser(ctx context.Context, userID, roleID string) error
 
 	// RevokeFromUser deletes the (user_id, role_id) row. Idempotent: if the row
@@ -91,7 +109,11 @@ func (r *roleRepo) FindByIDs(ctx context.Context, ids []string) (map[string]*dom
 
 // AssignToUser inserts a user_roles row. Idempotent via ON CONFLICT DO NOTHING.
 // Validates that both the user and role exist before inserting; returns
-// ErrNotFound if either is absent.
+// ErrUserNotFound when the user is missing and ErrRoleNotFound when the role
+// is missing. Both sentinels also satisfy errors.Is(_, ErrNotFound) so legacy
+// callers that only branch on ErrNotFound keep working — new callers should
+// match the specific sentinel first to surface the correct field in
+// BAD_USER_INPUT responses.
 func (r *roleRepo) AssignToUser(ctx context.Context, userID, roleID string) error {
 	// Validate user exists.
 	var userCount int64
@@ -102,7 +124,7 @@ func (r *roleRepo) AssignToUser(ctx context.Context, userID, roleID string) erro
 		return eris.Wrap(err, "repository: assign role: check user")
 	}
 	if userCount == 0 {
-		return ErrNotFound
+		return ErrUserNotFound
 	}
 
 	// Validate role exists.
@@ -114,7 +136,7 @@ func (r *roleRepo) AssignToUser(ctx context.Context, userID, roleID string) erro
 		return eris.Wrap(err, "repository: assign role: check role")
 	}
 	if roleCount == 0 {
-		return ErrNotFound
+		return ErrRoleNotFound
 	}
 
 	row := gormUserRole{UserID: userID, RoleID: roleID}

--- a/backend/internal/repository/role.go
+++ b/backend/internal/repository/role.go
@@ -131,6 +131,24 @@ func classifyFKError(err error) error {
 	return nil
 }
 
+// requireExists returns ErrUserNotFound / ErrRoleNotFound when no row matches
+// the given primary key. The wrap label feeds into the eris chain when the
+// underlying COUNT query itself fails. notFound is the sentinel returned for
+// the zero-count case.
+func (r *roleRepo) requireExists(ctx context.Context, table, id, wrap string, notFound error) error {
+	var count int64
+	if err := r.db.WithContext(ctx).
+		Table(table).
+		Where("id = ?", id).
+		Count(&count).Error; err != nil {
+		return eris.Wrap(err, wrap)
+	}
+	if count == 0 {
+		return notFound
+	}
+	return nil
+}
+
 // AssignToUser inserts a user_roles row. Idempotent via ON CONFLICT DO NOTHING.
 // Validates that both the user and role exist before inserting; returns
 // ErrUserNotFound when the user is missing and ErrRoleNotFound when the role
@@ -144,28 +162,11 @@ func classifyFKError(err error) error {
 // (23503) is classified by classifyFKError into the same sentinels, so the
 // caller still receives BAD_USER_INPUT rather than INTERNAL.
 func (r *roleRepo) AssignToUser(ctx context.Context, userID, roleID string) error {
-	// Validate user exists.
-	var userCount int64
-	if err := r.db.WithContext(ctx).
-		Table("users").
-		Where("id = ?", userID).
-		Count(&userCount).Error; err != nil {
-		return eris.Wrap(err, "repository: assign role: check user")
+	if err := r.requireExists(ctx, "users", userID, "repository: assign role: check user", ErrUserNotFound); err != nil {
+		return err
 	}
-	if userCount == 0 {
-		return ErrUserNotFound
-	}
-
-	// Validate role exists.
-	var roleCount int64
-	if err := r.db.WithContext(ctx).
-		Table("roles").
-		Where("id = ?", roleID).
-		Count(&roleCount).Error; err != nil {
-		return eris.Wrap(err, "repository: assign role: check role")
-	}
-	if roleCount == 0 {
-		return ErrRoleNotFound
+	if err := r.requireExists(ctx, "roles", roleID, "repository: assign role: check role", ErrRoleNotFound); err != nil {
+		return err
 	}
 
 	row := gormUserRole{UserID: userID, RoleID: roleID}
@@ -189,28 +190,11 @@ func (r *roleRepo) AssignToUser(ctx context.Context, userID, roleID string) erro
 // both exist but no assignment row is present, the operation is a silent
 // no-op (idempotent on the assignment link itself).
 func (r *roleRepo) RevokeFromUser(ctx context.Context, userID, roleID string) error {
-	// Validate user exists.
-	var userCount int64
-	if err := r.db.WithContext(ctx).
-		Table("users").
-		Where("id = ?", userID).
-		Count(&userCount).Error; err != nil {
-		return eris.Wrap(err, "repository: revoke role: check user")
+	if err := r.requireExists(ctx, "users", userID, "repository: revoke role: check user", ErrUserNotFound); err != nil {
+		return err
 	}
-	if userCount == 0 {
-		return ErrUserNotFound
-	}
-
-	// Validate role exists.
-	var roleCount int64
-	if err := r.db.WithContext(ctx).
-		Table("roles").
-		Where("id = ?", roleID).
-		Count(&roleCount).Error; err != nil {
-		return eris.Wrap(err, "repository: revoke role: check role")
-	}
-	if roleCount == 0 {
-		return ErrRoleNotFound
+	if err := r.requireExists(ctx, "roles", roleID, "repository: revoke role: check role", ErrRoleNotFound); err != nil {
+		return err
 	}
 
 	if err := r.db.WithContext(ctx).

--- a/backend/internal/repository/role_assign_test.go
+++ b/backend/internal/repository/role_assign_test.go
@@ -99,8 +99,13 @@ func TestRoleRepository_AssignToUser_UserNotFound(t *testing.T) {
 
 	missingUser := uuid.NewString()
 	err = repo.AssignToUser(ctx, missingUser, admin.ID)
+	if !errors.Is(err, repository.ErrUserNotFound) {
+		t.Fatalf("AssignToUser(missing user): want ErrUserNotFound, got %v", err)
+	}
+	// Backward-compat: legacy callers that match on ErrNotFound must still see
+	// the joined sentinel.
 	if !errors.Is(err, repository.ErrNotFound) {
-		t.Fatalf("AssignToUser(missing user): want ErrNotFound, got %v", err)
+		t.Fatalf("AssignToUser(missing user): want errors.Is(_, ErrNotFound) true, got %v", err)
 	}
 }
 
@@ -112,8 +117,30 @@ func TestRoleRepository_AssignToUser_RoleNotFound(t *testing.T) {
 
 	missingRole := uuid.NewString()
 	err := repo.AssignToUser(ctx, userID, missingRole)
+	if !errors.Is(err, repository.ErrRoleNotFound) {
+		t.Fatalf("AssignToUser(missing role): want ErrRoleNotFound, got %v", err)
+	}
 	if !errors.Is(err, repository.ErrNotFound) {
-		t.Fatalf("AssignToUser(missing role): want ErrNotFound, got %v", err)
+		t.Fatalf("AssignToUser(missing role): want errors.Is(_, ErrNotFound) true, got %v", err)
+	}
+}
+
+// TestRoleRepository_AssignToUser_RoleNotFoundDistinct asserts that the new
+// sentinels are distinct: a missing-role error must not match the
+// missing-user sentinel, and vice versa.
+func TestRoleRepository_AssignToUser_RoleNotFoundDistinct(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	userID := insertAuthUser(t, ctx)
+	repo := repository.NewRoleRepository(testDB.GORM)
+
+	missingRole := uuid.NewString()
+	err := repo.AssignToUser(ctx, userID, missingRole)
+	if !errors.Is(err, repository.ErrRoleNotFound) {
+		t.Fatalf("want ErrRoleNotFound, got %v", err)
+	}
+	if errors.Is(err, repository.ErrUserNotFound) {
+		t.Fatalf("missing-role error must not match ErrUserNotFound, got %v", err)
 	}
 }
 
@@ -272,5 +299,126 @@ func TestRoleRepository_ListAll_EmptySliceNotNil(t *testing.T) {
 	}
 	if roles == nil {
 		t.Fatal("ListAll returned nil; want non-nil slice (empty or populated)")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ListByUserIDs (C4)
+// ---------------------------------------------------------------------------
+
+// TestRoleRepository_ListByUserIDs_EmptySlice verifies the GORM empty-IN guard:
+// passing an empty userIDs slice must return an empty (non-nil) map and must
+// not issue any SQL query (the method short-circuits before touching the DB).
+func TestRoleRepository_ListByUserIDs_EmptySlice(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	repo := repository.NewRoleRepository(testDB.GORM)
+
+	result, err := repo.ListByUserIDs(ctx, []string{})
+	if err != nil {
+		t.Fatalf("ListByUserIDs(empty): unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("ListByUserIDs(empty): expected non-nil map, got nil")
+	}
+	if len(result) != 0 {
+		t.Fatalf("ListByUserIDs(empty): expected empty map, got %d entries", len(result))
+	}
+}
+
+// TestRoleRepository_ListByUserIDs_MultipleUsers_NameAsc creates three users
+// each with two roles assigned in varying insertion order, then verifies that
+// ListByUserIDs returns each user's roles sorted by name ASC.
+func TestRoleRepository_ListByUserIDs_MultipleUsers_NameAsc(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	repo := repository.NewRoleRepository(testDB.GORM)
+
+	userA := insertAuthUser(t, ctx)
+	userB := insertAuthUser(t, ctx)
+	userC := insertAuthUser(t, ctx)
+
+	// Ensure the three named roles exist (idempotent insert).
+	adminID := insertRole(t, ctx, "admin")
+	generalID := insertRole(t, ctx, "general")
+	reviewerID := insertRole(t, ctx, "reviewer")
+
+	// Assign in deliberate reverse-alphabetical order for each user.
+	for _, uid := range []string{userA, userB, userC} {
+		for _, rid := range []string{reviewerID, adminID} {
+			if err := repo.AssignToUser(ctx, uid, rid); err != nil {
+				t.Fatalf("AssignToUser(%s, %s): %v", uid, rid, err)
+			}
+		}
+	}
+	// userC also gets "general" to exercise a third distinct ordering.
+	if err := repo.AssignToUser(ctx, userC, generalID); err != nil {
+		t.Fatalf("AssignToUser(userC, general): %v", err)
+	}
+
+	result, err := repo.ListByUserIDs(ctx, []string{userA, userB, userC})
+	if err != nil {
+		t.Fatalf("ListByUserIDs: unexpected error: %v", err)
+	}
+
+	// userA: 2 roles — "admin", "reviewer" in name ASC.
+	rolesA := result[userA]
+	if len(rolesA) != 2 {
+		t.Fatalf("userA: expected 2 roles, got %d", len(rolesA))
+	}
+	if rolesA[0].Name != "admin" || rolesA[1].Name != "reviewer" {
+		t.Fatalf("userA roles not sorted ASC: %v", rolesA)
+	}
+
+	// userB: same 2 roles.
+	rolesB := result[userB]
+	if len(rolesB) != 2 {
+		t.Fatalf("userB: expected 2 roles, got %d", len(rolesB))
+	}
+	if rolesB[0].Name != "admin" || rolesB[1].Name != "reviewer" {
+		t.Fatalf("userB roles not sorted ASC: %v", rolesB)
+	}
+
+	// userC: 3 roles — "admin", "general", "reviewer" in name ASC.
+	rolesC := result[userC]
+	if len(rolesC) != 3 {
+		t.Fatalf("userC: expected 3 roles, got %d", len(rolesC))
+	}
+	if rolesC[0].Name != "admin" || rolesC[1].Name != "general" || rolesC[2].Name != "reviewer" {
+		t.Fatalf("userC roles not sorted ASC: %v", rolesC)
+	}
+}
+
+// TestRoleRepository_ListByUserIDs_UnknownUserAbsentFromMap verifies that
+// passing a mix of a known user and an unknown UUID returns only the known
+// user's entry in the map. The unknown UUID must not appear as a key and no
+// error is returned.
+func TestRoleRepository_ListByUserIDs_UnknownUserAbsentFromMap(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	repo := repository.NewRoleRepository(testDB.GORM)
+
+	knownUser := insertAuthUser(t, ctx)
+	unknownUser := uuid.NewString()
+
+	adminID := insertRole(t, ctx, "admin")
+	if err := repo.AssignToUser(ctx, knownUser, adminID); err != nil {
+		t.Fatalf("AssignToUser: %v", err)
+	}
+
+	result, err := repo.ListByUserIDs(ctx, []string{knownUser, unknownUser})
+	if err != nil {
+		t.Fatalf("ListByUserIDs: unexpected error: %v", err)
+	}
+
+	if _, present := result[unknownUser]; present {
+		t.Fatalf("unknown user %q must not appear in the result map", unknownUser)
+	}
+	rolesKnown := result[knownUser]
+	if len(rolesKnown) != 1 {
+		t.Fatalf("known user: expected 1 role, got %d", len(rolesKnown))
+	}
+	if rolesKnown[0].Name != "admin" {
+		t.Fatalf("known user role name = %q, want admin", rolesKnown[0].Name)
 	}
 }

--- a/backend/internal/repository/role_assign_test.go
+++ b/backend/internal/repository/role_assign_test.go
@@ -175,6 +175,9 @@ func TestRoleRepository_RevokeFromUser_HappyPath(t *testing.T) {
 	}
 }
 
+// TestRoleRepository_RevokeFromUser_Idempotent verifies that revoking a role
+// that was never assigned is a silent no-op when both the user and role exist.
+// This is the legitimate idempotency path: user + role exist, no assignment.
 func TestRoleRepository_RevokeFromUser_Idempotent(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
@@ -188,7 +191,69 @@ func TestRoleRepository_RevokeFromUser_Idempotent(t *testing.T) {
 
 	// Revoke a row that was never assigned — must not return an error.
 	if err := repo.RevokeFromUser(ctx, userID, admin.ID); err != nil {
-		t.Fatalf("RevokeFromUser on missing row: %v", err)
+		t.Fatalf("RevokeFromUser on missing assignment row: %v", err)
+	}
+}
+
+// TestRoleRepository_RevokeFromUser_AssignmentMissing is an explicit test for
+// the idempotent path: user and role both exist, but no (user_id, role_id)
+// assignment row is present. The operation must succeed without error.
+func TestRoleRepository_RevokeFromUser_AssignmentMissing(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	userID := insertAuthUser(t, ctx)
+	repo := repository.NewRoleRepository(testDB.GORM)
+
+	admin, err := repo.FindByName(ctx, "admin")
+	if err != nil {
+		t.Fatalf("FindByName(admin): %v", err)
+	}
+
+	// Ensure the assignment does not exist (user is freshly inserted, never assigned).
+	if err := repo.RevokeFromUser(ctx, userID, admin.ID); err != nil {
+		t.Fatalf("RevokeFromUser(user exists, role exists, no assignment): want nil, got %v", err)
+	}
+}
+
+// TestRoleRepository_RevokeFromUser_UserNotFound verifies that revoking a role
+// from a non-existent user returns ErrUserNotFound, not a silent no-op.
+func TestRoleRepository_RevokeFromUser_UserNotFound(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	repo := repository.NewRoleRepository(testDB.GORM)
+
+	admin, err := repo.FindByName(ctx, "admin")
+	if err != nil {
+		t.Fatalf("FindByName(admin): %v", err)
+	}
+
+	missingUser := uuid.NewString()
+	err = repo.RevokeFromUser(ctx, missingUser, admin.ID)
+	if !errors.Is(err, repository.ErrUserNotFound) {
+		t.Fatalf("RevokeFromUser(missing user): want ErrUserNotFound, got %v", err)
+	}
+	// Backward-compat: legacy callers that match on ErrNotFound must still see
+	// the joined sentinel.
+	if !errors.Is(err, repository.ErrNotFound) {
+		t.Fatalf("RevokeFromUser(missing user): want errors.Is(_, ErrNotFound) true, got %v", err)
+	}
+}
+
+// TestRoleRepository_RevokeFromUser_RoleNotFound verifies that revoking a
+// non-existent role from a real user returns ErrRoleNotFound.
+func TestRoleRepository_RevokeFromUser_RoleNotFound(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	userID := insertAuthUser(t, ctx)
+	repo := repository.NewRoleRepository(testDB.GORM)
+
+	missingRole := uuid.NewString()
+	err := repo.RevokeFromUser(ctx, userID, missingRole)
+	if !errors.Is(err, repository.ErrRoleNotFound) {
+		t.Fatalf("RevokeFromUser(missing role): want ErrRoleNotFound, got %v", err)
+	}
+	if !errors.Is(err, repository.ErrNotFound) {
+		t.Fatalf("RevokeFromUser(missing role): want errors.Is(_, ErrNotFound) true, got %v", err)
 	}
 }
 

--- a/backend/internal/repository/role_assign_test.go
+++ b/backend/internal/repository/role_assign_test.go
@@ -1,0 +1,276 @@
+package repository_test
+
+// TestMain, testDB, insertAuthUser, and sqlDBHandle are defined in user_test.go
+// and shared across this package.
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"backend/internal/repository"
+)
+
+// insertRole inserts a new role directly into the roles table and returns
+// the generated ID. Helper for tests that need roles beyond the seeded set.
+func insertRole(t *testing.T, ctx context.Context, name string) string {
+	t.Helper()
+	sqlDB := sqlDBHandle(t)
+	var id string
+	if err := sqlDB.QueryRowContext(ctx,
+		`INSERT INTO public.roles (name) VALUES ($1) ON CONFLICT (name) DO UPDATE SET name = EXCLUDED.name RETURNING id`,
+		name,
+	).Scan(&id); err != nil {
+		t.Fatalf("insertRole %q: %v", name, err)
+	}
+	return id
+}
+
+// ---------------------------------------------------------------------------
+// AssignToUser
+// ---------------------------------------------------------------------------
+
+func TestRoleRepository_AssignToUser_HappyPath(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	userID := insertAuthUser(t, ctx)
+	repo := repository.NewRoleRepository(testDB.GORM)
+
+	admin, err := repo.FindByName(ctx, "admin")
+	if err != nil {
+		t.Fatalf("FindByName(admin): %v", err)
+	}
+
+	if err := repo.AssignToUser(ctx, userID, admin.ID); err != nil {
+		t.Fatalf("AssignToUser: %v", err)
+	}
+
+	roles, err := repo.ListByUser(ctx, userID)
+	if err != nil {
+		t.Fatalf("ListByUser: %v", err)
+	}
+	if len(roles) != 1 {
+		t.Fatalf("ListByUser len = %d, want 1", len(roles))
+	}
+	if roles[0].ID != admin.ID {
+		t.Fatalf("role ID = %q, want %q", roles[0].ID, admin.ID)
+	}
+}
+
+func TestRoleRepository_AssignToUser_Idempotent(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	userID := insertAuthUser(t, ctx)
+	repo := repository.NewRoleRepository(testDB.GORM)
+
+	admin, err := repo.FindByName(ctx, "admin")
+	if err != nil {
+		t.Fatalf("FindByName(admin): %v", err)
+	}
+
+	if err := repo.AssignToUser(ctx, userID, admin.ID); err != nil {
+		t.Fatalf("AssignToUser (first): %v", err)
+	}
+	// Second call must not return an error.
+	if err := repo.AssignToUser(ctx, userID, admin.ID); err != nil {
+		t.Fatalf("AssignToUser (second, idempotent): %v", err)
+	}
+
+	roles, err := repo.ListByUser(ctx, userID)
+	if err != nil {
+		t.Fatalf("ListByUser: %v", err)
+	}
+	if len(roles) != 1 {
+		t.Fatalf("ListByUser len after double assign = %d, want 1", len(roles))
+	}
+}
+
+func TestRoleRepository_AssignToUser_UserNotFound(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	repo := repository.NewRoleRepository(testDB.GORM)
+
+	admin, err := repo.FindByName(ctx, "admin")
+	if err != nil {
+		t.Fatalf("FindByName(admin): %v", err)
+	}
+
+	missingUser := uuid.NewString()
+	err = repo.AssignToUser(ctx, missingUser, admin.ID)
+	if !errors.Is(err, repository.ErrNotFound) {
+		t.Fatalf("AssignToUser(missing user): want ErrNotFound, got %v", err)
+	}
+}
+
+func TestRoleRepository_AssignToUser_RoleNotFound(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	userID := insertAuthUser(t, ctx)
+	repo := repository.NewRoleRepository(testDB.GORM)
+
+	missingRole := uuid.NewString()
+	err := repo.AssignToUser(ctx, userID, missingRole)
+	if !errors.Is(err, repository.ErrNotFound) {
+		t.Fatalf("AssignToUser(missing role): want ErrNotFound, got %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// RevokeFromUser
+// ---------------------------------------------------------------------------
+
+func TestRoleRepository_RevokeFromUser_HappyPath(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	userID := insertAuthUser(t, ctx)
+	repo := repository.NewRoleRepository(testDB.GORM)
+
+	admin, err := repo.FindByName(ctx, "admin")
+	if err != nil {
+		t.Fatalf("FindByName(admin): %v", err)
+	}
+
+	if err := repo.AssignToUser(ctx, userID, admin.ID); err != nil {
+		t.Fatalf("AssignToUser: %v", err)
+	}
+	if err := repo.RevokeFromUser(ctx, userID, admin.ID); err != nil {
+		t.Fatalf("RevokeFromUser: %v", err)
+	}
+
+	roles, err := repo.ListByUser(ctx, userID)
+	if err != nil {
+		t.Fatalf("ListByUser after revoke: %v", err)
+	}
+	if len(roles) != 0 {
+		t.Fatalf("ListByUser len after revoke = %d, want 0", len(roles))
+	}
+}
+
+func TestRoleRepository_RevokeFromUser_Idempotent(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	userID := insertAuthUser(t, ctx)
+	repo := repository.NewRoleRepository(testDB.GORM)
+
+	admin, err := repo.FindByName(ctx, "admin")
+	if err != nil {
+		t.Fatalf("FindByName(admin): %v", err)
+	}
+
+	// Revoke a row that was never assigned — must not return an error.
+	if err := repo.RevokeFromUser(ctx, userID, admin.ID); err != nil {
+		t.Fatalf("RevokeFromUser on missing row: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ListByUser
+// ---------------------------------------------------------------------------
+
+func TestRoleRepository_ListByUser_NoRoles(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	userID := insertAuthUser(t, ctx)
+	repo := repository.NewRoleRepository(testDB.GORM)
+
+	roles, err := repo.ListByUser(ctx, userID)
+	if err != nil {
+		t.Fatalf("ListByUser: %v", err)
+	}
+	if roles == nil {
+		t.Fatal("ListByUser returned nil, want empty slice")
+	}
+	if len(roles) != 0 {
+		t.Fatalf("ListByUser len = %d, want 0", len(roles))
+	}
+}
+
+func TestRoleRepository_ListByUser_OrderedByNameAsc(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	userID := insertAuthUser(t, ctx)
+	repo := repository.NewRoleRepository(testDB.GORM)
+
+	// Seed three roles with names that should sort alphabetically.
+	adminID := insertRole(t, ctx, "admin")
+	generalID := insertRole(t, ctx, "general")
+	reviewerID := insertRole(t, ctx, "reviewer")
+
+	for _, roleID := range []string{reviewerID, adminID, generalID} {
+		if err := repo.AssignToUser(ctx, userID, roleID); err != nil {
+			t.Fatalf("AssignToUser(%s): %v", roleID, err)
+		}
+	}
+
+	roles, err := repo.ListByUser(ctx, userID)
+	if err != nil {
+		t.Fatalf("ListByUser: %v", err)
+	}
+	if len(roles) != 3 {
+		t.Fatalf("ListByUser len = %d, want 3", len(roles))
+	}
+
+	want := []string{"admin", "general", "reviewer"}
+	for i, r := range roles {
+		if r.Name != want[i] {
+			t.Errorf("roles[%d].Name = %q, want %q", i, r.Name, want[i])
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ListAll
+// ---------------------------------------------------------------------------
+
+// TestRoleRepository_ListAll_NameAscOrder inserts roles out of order and
+// verifies that ListAll returns them sorted by name ASC.
+func TestRoleRepository_ListAll_NameAscOrder(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	repo := repository.NewRoleRepository(testDB.GORM)
+
+	// Seed roles with names that should sort alphabetically. "admin" and
+	// "general" already exist in the test DB seed; add a unique one to
+	// verify sorting includes it.
+	_ = insertRole(t, ctx, "admin")
+	_ = insertRole(t, ctx, "general")
+	_ = insertRole(t, ctx, "zzz-test-sorter")
+
+	roles, err := repo.ListAll(ctx)
+	if err != nil {
+		t.Fatalf("ListAll: %v", err)
+	}
+	if roles == nil {
+		t.Fatal("ListAll returned nil, want non-nil slice")
+	}
+	// Verify the returned slice is non-empty and ordered.
+	if len(roles) < 2 {
+		t.Fatalf("ListAll len = %d, want >= 2", len(roles))
+	}
+	for i := 1; i < len(roles); i++ {
+		if roles[i].Name < roles[i-1].Name {
+			t.Errorf("ListAll not sorted ASC at [%d]: %q > %q", i, roles[i-1].Name, roles[i].Name)
+		}
+	}
+}
+
+// TestRoleRepository_ListAll_EmptySliceNotNil verifies that ListAll returns an
+// empty non-nil slice rather than nil when the roles table has no rows.
+// Because the shared test DB always has seed roles, this test works by
+// asserting the return type contract rather than a true empty-table scenario —
+// the important invariant is that the return is never nil regardless of row count.
+func TestRoleRepository_ListAll_EmptySliceNotNil(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	repo := repository.NewRoleRepository(testDB.GORM)
+
+	roles, err := repo.ListAll(ctx)
+	if err != nil {
+		t.Fatalf("ListAll: %v", err)
+	}
+	if roles == nil {
+		t.Fatal("ListAll returned nil; want non-nil slice (empty or populated)")
+	}
+}

--- a/backend/internal/repository/role_classify_fk_test.go
+++ b/backend/internal/repository/role_classify_fk_test.go
@@ -1,0 +1,80 @@
+package repository
+
+// White-box tests for classifyFKError. The function is unexported so the
+// tests must live in the same package. All assertions use fabricated
+// *pgconn.PgError values — no live DB is required.
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+func TestClassifyFKError_NotAFKViolation(t *testing.T) {
+	t.Parallel()
+	// A non-23503 Postgres error must not be classified.
+	pgErr := &pgconn.PgError{Code: "23505"} // unique_violation
+	if got := classifyFKError(pgErr); got != nil {
+		t.Fatalf("expected nil for non-FK error, got %v", got)
+	}
+}
+
+func TestClassifyFKError_NonPgError(t *testing.T) {
+	t.Parallel()
+	// A plain stdlib error must not be classified.
+	if got := classifyFKError(errors.New("some error")); got != nil {
+		t.Fatalf("expected nil for non-pg error, got %v", got)
+	}
+}
+
+func TestClassifyFKError_UserIDConstraint(t *testing.T) {
+	t.Parallel()
+	pgErr := &pgconn.PgError{
+		Code:           "23503",
+		ConstraintName: "user_roles_user_id_fkey",
+	}
+	got := classifyFKError(pgErr)
+	if !errors.Is(got, ErrUserNotFound) {
+		t.Fatalf("expected ErrUserNotFound for user_id FK, got %v", got)
+	}
+	// Must also satisfy the legacy sentinel.
+	if !errors.Is(got, ErrNotFound) {
+		t.Fatalf("expected errors.Is(_, ErrNotFound) true for user_id FK, got %v", got)
+	}
+}
+
+func TestClassifyFKError_RoleIDConstraint(t *testing.T) {
+	t.Parallel()
+	pgErr := &pgconn.PgError{
+		Code:           "23503",
+		ConstraintName: "user_roles_role_id_fkey",
+	}
+	got := classifyFKError(pgErr)
+	if !errors.Is(got, ErrRoleNotFound) {
+		t.Fatalf("expected ErrRoleNotFound for role_id FK, got %v", got)
+	}
+	if !errors.Is(got, ErrNotFound) {
+		t.Fatalf("expected errors.Is(_, ErrNotFound) true for role_id FK, got %v", got)
+	}
+}
+
+func TestClassifyFKError_UnknownConstraint(t *testing.T) {
+	t.Parallel()
+	// A FK violation on a constraint name that does not match user_id or role_id
+	// must return nil so the caller falls through to eris.Wrap.
+	pgErr := &pgconn.PgError{
+		Code:           "23503",
+		ConstraintName: "user_roles_other_fkey",
+	}
+	if got := classifyFKError(pgErr); got != nil {
+		t.Fatalf("expected nil for unknown FK constraint, got %v", got)
+	}
+}
+
+func TestClassifyFKError_NilError(t *testing.T) {
+	t.Parallel()
+	if got := classifyFKError(nil); got != nil {
+		t.Fatalf("expected nil for nil error, got %v", got)
+	}
+}

--- a/backend/internal/repository/user.go
+++ b/backend/internal/repository/user.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"context"
 	"errors"
+	"strings"
 	"time"
 
 	"github.com/rotisserie/eris"
@@ -28,6 +29,21 @@ func (gormUser) TableName() string { return "users" }
 // exist.
 var ErrNotFound = errors.New("repository: not found")
 
+// ErrCursorNotFound is returned by paginated queries when the supplied cursor
+// references a user that no longer exists (e.g. deleted between page fetches).
+// Plain errors.New so callers can branch with errors.Is without going through
+// eris's chain walk.
+var ErrCursorNotFound = errors.New("user pagination: cursor user not found")
+
+// User pagination caps. maxUserPageSize is the user-facing limit; userPageCap
+// is the repository limit set to maxUserPageSize+1 so the usecase's "+1 fetch"
+// trick can still detect another page when the caller asks for the documented
+// max.
+const (
+	maxUserPageSize = 100
+	userPageCap     = maxUserPageSize + 1
+)
+
 // UserUpdate carries patch fields. nil means "leave untouched"; a non-nil
 // pointer to "" is a request to clear the column.
 type UserUpdate struct {
@@ -40,6 +56,27 @@ type UserRepository interface {
 	FindByID(ctx context.Context, id string) (*domain.User, error)
 	FindByIDs(ctx context.Context, ids []string) (map[string]*domain.User, error)
 	Update(ctx context.Context, id string, patch UserUpdate) (*domain.User, error)
+	// ListPage returns a page of users ordered by created_at DESC with id ASC
+	// as a stable tiebreaker. The cursor is the user UUID. Forward paging uses
+	// `after` (exclusive); backward paging uses `before` (exclusive). `first`
+	// and `last` are mutually exclusive at the usecase layer; this method
+	// accepts both and lets the usecase enforce.
+	//
+	// search is a substring match on display_name (case-insensitive ILIKE).
+	// Whitespace-only input is treated as nil. `%` and `_` literals in the
+	// search term are escaped so they match literally.
+	//
+	// total is computed via a separate COUNT(*) scoped by the same search
+	// predicate as the page query (cursor predicate excluded).
+	//
+	// Repository caps page size at userPageCap so callers can use the
+	// usecase-level +1 fetch trick at the documented maximum.
+	ListPage(
+		ctx context.Context,
+		after, before *string,
+		first, last int,
+		search *string,
+	) (users []*domain.User, total int64, err error)
 }
 
 type userRepo struct{ db *gorm.DB }
@@ -100,6 +137,175 @@ func (r *userRepo) Update(ctx context.Context, id string, patch UserUpdate) (*do
 	}
 	// Re-fetch so callers see the trigger-refreshed updated_at.
 	return r.FindByID(ctx, id)
+}
+
+// ListPage implements the cursor-paginated user list. Order is fixed at
+// (created_at DESC, id ASC) so cursors stay deterministic even when multiple
+// users share a created_at. Backward paging inverts the direction, applies
+// LIMIT, then reverses the slice in memory so the caller sees the same display
+// order as forward paging.
+func (r *userRepo) ListPage(
+	ctx context.Context,
+	after, before *string,
+	first, last int,
+	search *string,
+) ([]*domain.User, int64, error) {
+	if first < 0 || last < 0 {
+		return nil, 0, eris.New("user repo: first/last must be >= 0")
+	}
+	first = clampUserPageSize(first)
+	last = clampUserPageSize(last)
+
+	// Normalise search: trim, treat blank as nil, escape ILIKE wildcards so
+	// "%" and "_" supplied by the caller match literally.
+	var searchPattern string
+	hasSearch := false
+	if search != nil {
+		trimmed := strings.TrimSpace(*search)
+		if trimmed != "" {
+			searchPattern = "%" + escapeLikePattern(trimmed) + "%"
+			hasSearch = true
+		}
+	}
+
+	// totalCount mirrors the page predicate (search only) but ignores the
+	// cursor predicate, so callers can compute "items after this point" /
+	// "page X of Y" without a second round-trip. Run before the zero-page
+	// short-circuit so callers asking only for totalCount still get a real
+	// value.
+	countQ := r.db.WithContext(ctx).Model(&gormUser{})
+	if hasSearch {
+		countQ = countQ.Where("display_name ILIKE ?", searchPattern)
+	}
+	var total int64
+	if err := countQ.Count(&total).Error; err != nil {
+		return nil, 0, eris.Wrap(err, "repository: count users")
+	}
+
+	if first == 0 && last == 0 {
+		return []*domain.User{}, total, nil
+	}
+
+	// Backward pagination: invert the SQL order, fetch, then reverse the
+	// slice so the caller still observes (created_at DESC, id ASC).
+	// Forward direction is (created_at DESC, id ASC); for backward we flip
+	// both axes.
+	createdAtAsc := false
+	idAsc := true
+	limit := first
+	cursorID := after
+	reverse := false
+	if last > 0 {
+		createdAtAsc = !createdAtAsc
+		idAsc = !idAsc
+		limit = last
+		cursorID = before
+		reverse = true
+	}
+
+	q := r.db.WithContext(ctx).Model(&gormUser{})
+	if hasSearch {
+		q = q.Where("display_name ILIKE ?", searchPattern)
+	}
+
+	if cursorID != nil {
+		// Hydrate the cursor user's created_at so we can build the tuple
+		// comparison. A missing user means the cursor row was deleted between
+		// fetches — surface as ErrCursorNotFound so callers can map to a
+		// BAD_USER_INPUT-shaped error.
+		var cursorRow gormUser
+		err := r.db.WithContext(ctx).Select("id", "created_at").
+			Where("id = ?", *cursorID).Take(&cursorRow).Error
+		if err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return nil, 0, ErrCursorNotFound
+			}
+			return nil, 0, eris.Wrap(err, "repository: hydrate user cursor")
+		}
+
+		clauseSQL, args := userCursorWhere(createdAtAsc, idAsc, cursorRow)
+		q = q.Where(clauseSQL, args...)
+	}
+
+	q = q.Order(userOrderClause(createdAtAsc, idAsc)).Limit(limit)
+
+	var rows []gormUser
+	if err := q.Find(&rows).Error; err != nil {
+		return nil, 0, eris.Wrap(err, "repository: list users page")
+	}
+
+	if reverse {
+		for i, j := 0, len(rows)-1; i < j; i, j = i+1, j-1 {
+			rows[i], rows[j] = rows[j], rows[i]
+		}
+	}
+
+	out := make([]*domain.User, len(rows))
+	for i := range rows {
+		out[i] = userToDomain(rows[i])
+	}
+	return out, total, nil
+}
+
+func clampUserPageSize(n int) int {
+	if n < 0 {
+		return 0
+	}
+	if n > userPageCap {
+		return userPageCap
+	}
+	return n
+}
+
+// userOrderClause renders the SQL ORDER BY tail for the configured axis
+// directions. The default forward order is (created_at DESC, id ASC).
+func userOrderClause(createdAtAsc, idAsc bool) string {
+	caDir := "DESC"
+	if createdAtAsc {
+		caDir = "ASC"
+	}
+	idDir := "ASC"
+	if !idAsc {
+		idDir = "DESC"
+	}
+	return "created_at " + caDir + ", id " + idDir
+}
+
+// userCursorWhere builds the tuple-comparison WHERE for (created_at, id)
+// against the supplied cursor row. The expanded form `field op ? OR (field = ?
+// AND id op ?)` is portable across SQL dialects (the row-constructor
+// `(a, b) > (?, ?)` is Postgres-only).
+//
+// For forward paging (created_at DESC, id ASC) we want rows strictly past the
+// cursor — so we emit:
+//
+//	created_at < cursor.created_at OR (created_at = cursor.created_at AND id > cursor.id)
+//
+// For backward paging the direction flips on both axes.
+func userCursorWhere(createdAtAsc, idAsc bool, cursor gormUser) (string, []any) {
+	caOp := "<"
+	if createdAtAsc {
+		caOp = ">"
+	}
+	idOp := ">"
+	if !idAsc {
+		idOp = "<"
+	}
+	clauseSQL := "(created_at " + caOp + " ? OR (created_at = ? AND id " + idOp + " ?))"
+	return clauseSQL, []any{cursor.CreatedAt, cursor.CreatedAt, cursor.ID}
+}
+
+// escapeLikePattern escapes the ILIKE meta-characters `%` and `_` so a
+// user-supplied search term containing them matches literally. The default
+// LIKE/ILIKE escape character is backslash; the backslash itself is escaped
+// first so we do not double-escape characters injected by this function.
+func escapeLikePattern(s string) string {
+	r := strings.NewReplacer(
+		`\`, `\\`,
+		`%`, `\%`,
+		`_`, `\_`,
+	)
+	return r.Replace(s)
 }
 
 func userToDomain(g gormUser) *domain.User {

--- a/backend/internal/repository/user_pagination_test.go
+++ b/backend/internal/repository/user_pagination_test.go
@@ -1,0 +1,430 @@
+package repository_test
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"backend/internal/domain"
+	"backend/internal/repository"
+)
+
+// insertUserWithName inserts a fresh auth user (the handle_new_user trigger
+// then creates the corresponding public.users row), backdates created_at via
+// direct SQL so test cases can control ordering, and stamps the supplied
+// display_name. Returns the seeded user id.
+//
+// The created_at update fires the BEFORE UPDATE trigger which refreshes
+// updated_at to now(); that is harmless for these tests because they never
+// assert on updated_at directly.
+func insertUserWithName(t *testing.T, ctx context.Context, displayName string, createdAt time.Time) string {
+	t.Helper()
+	id := insertAuthUser(t, ctx)
+	sqlDB := sqlDBHandle(t)
+	_, err := sqlDB.ExecContext(ctx,
+		`UPDATE public.users SET display_name = $1, created_at = $2 WHERE id = $3`,
+		displayName, createdAt, id,
+	)
+	require.NoError(t, err, "stamp display_name + created_at")
+	return id
+}
+
+// insertUserAt inserts an auth user and backdates created_at without touching
+// display_name. Use when display_name does not matter for the assertion.
+func insertUserAt(t *testing.T, ctx context.Context, createdAt time.Time) string {
+	t.Helper()
+	id := insertAuthUser(t, ctx)
+	sqlDB := sqlDBHandle(t)
+	_, err := sqlDB.ExecContext(ctx,
+		`UPDATE public.users SET created_at = $1 WHERE id = $2`,
+		createdAt, id,
+	)
+	require.NoError(t, err, "stamp created_at")
+	return id
+}
+
+// fetchUserCreatedAt re-fetches a user so the test observes the DB-rounded
+// timestamp; tuple comparisons must use that exact value.
+func fetchUser(t *testing.T, ctx context.Context, repo repository.UserRepository, id string) *domain.User {
+	t.Helper()
+	u, err := repo.FindByID(ctx, id)
+	require.NoError(t, err)
+	return u
+}
+
+// expectedListOrder sorts the supplied users by (created_at DESC, id ASC) and
+// returns their ids. Mirrors the SQL ORDER BY emitted by ListPage.
+func expectedListOrder(users []*domain.User) []string {
+	cp := make([]*domain.User, len(users))
+	copy(cp, users)
+	sort.SliceStable(cp, func(i, j int) bool {
+		if !cp[i].CreatedAt.Equal(cp[j].CreatedAt) {
+			return cp[i].CreatedAt.After(cp[j].CreatedAt)
+		}
+		return cp[i].ID < cp[j].ID
+	})
+	out := make([]string, len(cp))
+	for i, u := range cp {
+		out[i] = u.ID
+	}
+	return out
+}
+
+// TestUserPagination_EmptyTable verifies that ListPage on an empty result set
+// returns total=0 and an empty (but non-nil) slice. The empty-table semantics
+// also imply hasNextPage=false at the usecase layer because the +1 fetch
+// returns 0 rows.
+func TestUserPagination_EmptyTable(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	repo := repository.NewUserRepository(testDB.GORM)
+
+	// A unique nonsense search term ensures no other test's user matches.
+	q := "no-such-user-xyz-" + uuid.NewString()
+	users, total, err := repo.ListPage(ctx, nil, nil, 10, 0, &q)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), total)
+	require.NotNil(t, users)
+	require.Empty(t, users)
+}
+
+// TestUserPagination_ForwardPageOne verifies the no-cursor forward path
+// returns rows in (created_at DESC, id ASC) order.
+func TestUserPagination_ForwardPageOne(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	repo := repository.NewUserRepository(testDB.GORM)
+
+	tag := "fwd1-" + uuid.NewString()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	// 5 users: tag-0 oldest, tag-4 newest. Stagger by 1 hour.
+	ids := make([]string, 5)
+	for i := 0; i < 5; i++ {
+		ids[i] = insertUserWithName(t, ctx, tag+"-"+uuidShort(),
+			now.Add(time.Duration(i)*time.Hour))
+	}
+
+	// Re-fetch so we observe DB-rounded timestamps.
+	users := make([]*domain.User, 5)
+	for i, id := range ids {
+		users[i] = fetchUser(t, ctx, repo, id)
+	}
+	want := expectedListOrder(users)
+
+	got, total, err := repo.ListPage(ctx, nil, nil, 3, 0, ptrStr(tag))
+	require.NoError(t, err)
+	require.Equal(t, int64(5), total)
+	require.Len(t, got, 3)
+	require.Equal(t, want[0], got[0].ID)
+	require.Equal(t, want[1], got[1].ID)
+	require.Equal(t, want[2], got[2].ID)
+}
+
+// TestUserPagination_ForwardPageTwo verifies that the cursor is exclusive:
+// the cursor row itself does not appear in the next page.
+func TestUserPagination_ForwardPageTwo(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	repo := repository.NewUserRepository(testDB.GORM)
+
+	tag := "fwd2-" + uuid.NewString()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	ids := make([]string, 5)
+	for i := 0; i < 5; i++ {
+		ids[i] = insertUserWithName(t, ctx, tag+"-"+uuidShort(),
+			now.Add(time.Duration(i)*time.Hour))
+	}
+
+	users := make([]*domain.User, 5)
+	for i, id := range ids {
+		users[i] = fetchUser(t, ctx, repo, id)
+	}
+	want := expectedListOrder(users)
+
+	// Page 1: first=2 → want[0..1].
+	page1, _, err := repo.ListPage(ctx, nil, nil, 2, 0, ptrStr(tag))
+	require.NoError(t, err)
+	require.Len(t, page1, 2)
+	require.Equal(t, want[0], page1[0].ID)
+	require.Equal(t, want[1], page1[1].ID)
+
+	// Page 2: after = last cursor of page 1, first=2 → want[2..3].
+	cursor := page1[1].ID
+	page2, _, err := repo.ListPage(ctx, &cursor, nil, 2, 0, ptrStr(tag))
+	require.NoError(t, err)
+	require.Len(t, page2, 2)
+	require.Equal(t, want[2], page2[0].ID)
+	require.Equal(t, want[3], page2[1].ID)
+}
+
+// TestUserPagination_BackwardBeforeCursor verifies that backward pagination
+// returns the rows immediately preceding the cursor in the same display order
+// as forward pagination.
+func TestUserPagination_BackwardBeforeCursor(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	repo := repository.NewUserRepository(testDB.GORM)
+
+	tag := "bwd-" + uuid.NewString()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	ids := make([]string, 5)
+	for i := 0; i < 5; i++ {
+		ids[i] = insertUserWithName(t, ctx, tag+"-"+uuidShort(),
+			now.Add(time.Duration(i)*time.Hour))
+	}
+
+	users := make([]*domain.User, 5)
+	for i, id := range ids {
+		users[i] = fetchUser(t, ctx, repo, id)
+	}
+	want := expectedListOrder(users)
+	// want order: newest → oldest. want[0]=ids[4], want[4]=ids[0].
+
+	// last=2 before=want[3] should return want[1..2] — the page immediately
+	// before the cursor — in the same display order as forward.
+	cursor := want[3]
+	got, total, err := repo.ListPage(ctx, nil, &cursor, 0, 2, ptrStr(tag))
+	require.NoError(t, err)
+	require.Equal(t, int64(5), total)
+	require.Len(t, got, 2)
+	require.Equal(t, want[1], got[0].ID)
+	require.Equal(t, want[2], got[1].ID)
+}
+
+// TestUserPagination_SearchSubstring verifies that ILIKE substring match is
+// case-insensitive and that total reflects the filtered count.
+//
+// Layout: every row carries a unique per-test token chosen so it cannot
+// appear in any other test's display_names (a uuid-derived hex string). The
+// matching rows additionally contain a per-test "needle" letter sequence
+// inside the body — in mixed case, to exercise the case-insensitive ILIKE.
+// Rows that should not match leave the needle out.
+//
+// The search query is just the needle (no marker), so rows seeded by other
+// tests cannot satisfy the match. The total count therefore reflects exactly
+// the rows seeded here.
+func TestUserPagination_SearchSubstring(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	repo := repository.NewUserRepository(testDB.GORM)
+
+	// `needle` is the per-test substring to search for. Use only letters
+	// (no LIKE meta-chars) and append a uuid-hex tail so the substring is
+	// globally unique across tests.
+	needle := "Needle" + onlyHex(uuid.NewString())
+	// `tag` is the suffix appended to every row in this test, used solely
+	// to defend the assertions below if a future test happens to embed
+	// `needle` by accident.
+	tag := "Tag" + onlyHex(uuid.NewString())
+
+	type row struct {
+		body  string
+		match bool
+	}
+	rows := []row{
+		{"row1-" + needle + "-alice", true},             // contains needle
+		{"row2-" + flipCase(needle) + "-bob", true},     // case-insensitive match
+		{"row3-prefix" + needle + "suffix-carol", true}, // mid-string match
+		{"row4-bob", false},                             // no needle
+		{"row5-eve", false},                             // no needle
+	}
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	for i, r := range rows {
+		insertUserWithName(t, ctx, r.body+tag, now.Add(time.Duration(i)*time.Hour))
+	}
+
+	got, total, err := repo.ListPage(ctx, nil, nil, 10, 0, &needle)
+	require.NoError(t, err)
+	require.Equal(t, int64(3), total)
+	require.Len(t, got, 3)
+
+	gotNames := map[string]bool{}
+	for _, u := range got {
+		require.NotNil(t, u.DisplayName)
+		gotNames[*u.DisplayName] = true
+	}
+	for _, r := range rows {
+		full := r.body + tag
+		if r.match {
+			require.True(t, gotNames[full],
+				"expected %q in result", full)
+		} else {
+			require.False(t, gotNames[full],
+				"%q should be excluded", full)
+		}
+	}
+}
+
+// TestUserPagination_SearchEscapesPercentLiteral verifies that `%` in the
+// search input is treated as a literal character, not as an ILIKE wildcard.
+// Without escaping, the search "<marker>100%" would match every row whose
+// display_name starts with "<marker>100".
+func TestUserPagination_SearchEscapesPercentLiteral(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	repo := repository.NewUserRepository(testDB.GORM)
+
+	// Per-test marker has no LIKE meta-characters so the row prefix is
+	// matched verbatim; only the suffix differs across rows.
+	marker := "pctesc" + onlyHex(uuid.NewString())
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	insertUserWithName(t, ctx, marker+"100%legit", now)
+	insertUserWithName(t, ctx, marker+"99reasons", now.Add(time.Hour))
+	insertUserWithName(t, ctx, marker+"100reasons", now.Add(2*time.Hour))
+
+	// Search "<marker>100%": must match only "<marker>100%legit". If `%`
+	// were treated as a wildcard, "<marker>100reasons" would also match.
+	q := marker + "100%"
+	got, total, err := repo.ListPage(ctx, nil, nil, 10, 0, &q)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), total)
+	require.Len(t, got, 1)
+	require.NotNil(t, got[0].DisplayName)
+	require.Equal(t, marker+"100%legit", *got[0].DisplayName)
+}
+
+// TestUserPagination_CursorNotFound verifies that a cursor pointing at a uuid
+// that does not exist in the users table surfaces ErrCursorNotFound — not a
+// silent empty page or a wrapped DB error.
+func TestUserPagination_CursorNotFound(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	repo := repository.NewUserRepository(testDB.GORM)
+
+	missing := uuid.NewString()
+	_, _, err := repo.ListPage(ctx, &missing, nil, 5, 0, nil)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, repository.ErrCursorNotFound),
+		"expected ErrCursorNotFound, got %v", err)
+}
+
+// TestUserPagination_PageCapAllowsMaxPlusOne mirrors the cards-side test:
+// userPageCap == maxUserPageSize+1 (101) so first=101 is accepted, while
+// first=100 stays at the documented user-facing maximum.
+func TestUserPagination_PageCapAllowsMaxPlusOne(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	repo := repository.NewUserRepository(testDB.GORM)
+
+	tag := "_cap_" + uuid.NewString()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	for i := 0; i < 101; i++ {
+		insertUserWithName(t, ctx, "u"+tag, now.Add(time.Duration(i)*time.Second))
+	}
+
+	// first=101 must return all 101 rows because userPageCap == 101.
+	q := tag
+	cards101, total101, err := repo.ListPage(ctx, nil, nil, 101, 0, &q)
+	require.NoError(t, err)
+	require.Equal(t, int64(101), total101)
+	require.Len(t, cards101, 101)
+
+	// first=100 must be limited to 100 rows.
+	cards100, total100, err := repo.ListPage(ctx, nil, nil, 100, 0, &q)
+	require.NoError(t, err)
+	require.Equal(t, int64(101), total100)
+	require.Len(t, cards100, 100)
+}
+
+// TestUserPagination_ZeroPageReturnsTotal verifies that first==0 && last==0
+// short-circuits the row fetch but still returns a real totalCount from the
+// separate COUNT(*) query.
+func TestUserPagination_ZeroPageReturnsTotal(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	repo := repository.NewUserRepository(testDB.GORM)
+
+	tag := "_zero_" + uuid.NewString()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	for i := 0; i < 5; i++ {
+		insertUserWithName(t, ctx, "u"+tag, now.Add(time.Duration(i)*time.Second))
+	}
+
+	q := tag
+	users, total, err := repo.ListPage(ctx, nil, nil, 0, 0, &q)
+	require.NoError(t, err)
+	require.NotNil(t, users)
+	require.Empty(t, users)
+	require.Equal(t, int64(5), total)
+}
+
+// TestUserPagination_NegativeFirstOrLast verifies that negative page sizes are
+// rejected with an error rather than silently coerced to 0.
+func TestUserPagination_NegativeFirstOrLast(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	repo := repository.NewUserRepository(testDB.GORM)
+
+	_, _, err := repo.ListPage(ctx, nil, nil, -1, 0, nil)
+	require.Error(t, err)
+
+	_, _, err = repo.ListPage(ctx, nil, nil, 0, -1, nil)
+	require.Error(t, err)
+}
+
+// TestUserPagination_BlankSearchTreatedAsNoFilter verifies that whitespace-
+// only search input is treated the same as nil — total reflects the entire
+// users table, not zero.
+func TestUserPagination_BlankSearchTreatedAsNoFilter(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	repo := repository.NewUserRepository(testDB.GORM)
+
+	// Seed at least one user so total > 0 even if the table was empty.
+	insertUserAt(t, ctx, time.Now().UTC().Truncate(time.Microsecond))
+
+	blank := "   "
+	_, total, err := repo.ListPage(ctx, nil, nil, 1, 0, &blank)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, total, int64(1),
+		"blank search must not zero out totalCount")
+}
+
+// uuidShort returns the first 8 hex characters of a fresh uuid — used to
+// disambiguate display_name suffixes inside a single test without bloating
+// log output.
+func uuidShort() string {
+	return uuid.NewString()[:8]
+}
+
+// onlyHex strips dashes from a uuid string so the result contains no
+// LIKE/ILIKE meta-characters and no separators that could split a search
+// substring across non-matching characters.
+func onlyHex(s string) string {
+	out := make([]byte, 0, len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c != '-' {
+			out = append(out, c)
+		}
+	}
+	return string(out)
+}
+
+// flipCase swaps the case of every ASCII letter in s. Used to exercise the
+// case-insensitive ILIKE: passing flipCase(needle) produces a stored row in
+// the opposite case from the search term, so a successful match proves the
+// comparison ignores case.
+func flipCase(s string) string {
+	out := make([]byte, len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case c >= 'a' && c <= 'z':
+			out[i] = c - 32
+		case c >= 'A' && c <= 'Z':
+			out[i] = c + 32
+		default:
+			out[i] = c
+		}
+	}
+	return string(out)
+}
+
+// ptrStr is a one-line helper for &literal in test call sites.
+func ptrStr(s string) *string { return &s }

--- a/backend/internal/repository/user_pagination_test.go
+++ b/backend/internal/repository/user_pagination_test.go
@@ -288,6 +288,34 @@ func TestUserPagination_SearchEscapesPercentLiteral(t *testing.T) {
 	require.Equal(t, marker+"100%legit", *got[0].DisplayName)
 }
 
+// TestUserPagination_SearchEscapesUnderscoreLiteral verifies that `_` in the
+// search input is treated as a literal character, not as an ILIKE
+// single-character wildcard. Mirrors the percent-escape test so a future
+// refactor that drops `_` from the escape replacer is caught here.
+func TestUserPagination_SearchEscapesUnderscoreLiteral(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	repo := repository.NewUserRepository(testDB.GORM)
+
+	// Per-test marker has no LIKE meta-characters so the row prefix is
+	// matched verbatim; only the suffix (with/without underscore) differs.
+	marker := "uscesc" + onlyHex(uuid.NewString())
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	insertUserWithName(t, ctx, marker+"a_min", now)
+	insertUserWithName(t, ctx, marker+"admin", now.Add(time.Hour))
+
+	// Search "<marker>a_min": must match only "<marker>a_min". If `_` were
+	// treated as a single-character wildcard, "<marker>admin" would also
+	// match (the underscore covers any single character between "a" and "m").
+	q := marker + "a_min"
+	got, total, err := repo.ListPage(ctx, nil, nil, 10, 0, &q)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), total)
+	require.Len(t, got, 1)
+	require.NotNil(t, got[0].DisplayName)
+	require.Equal(t, marker+"a_min", *got[0].DisplayName)
+}
+
 // TestUserPagination_CursorNotFound verifies that a cursor pointing at a uuid
 // that does not exist in the users table surfaces ErrCursorNotFound — not a
 // silent empty page or a wrapped DB error.

--- a/backend/internal/usecase/admin_user.go
+++ b/backend/internal/usecase/admin_user.go
@@ -1,0 +1,400 @@
+package usecase
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/rotisserie/eris"
+
+	"backend/internal/auth"
+	"backend/internal/domain"
+	"backend/internal/gqlerr"
+	"backend/internal/repository"
+)
+
+// adminRoleName is the name of the role that grants admin privileges. It is
+// hardcoded here for the self-demotion guard in RevokeRole. Keeping the
+// literal in one place avoids drift from the same constant baked into
+// auth.Service.IsAdmin.
+const adminRoleName = "admin"
+
+// adminUserMaxPageSize is the user-facing cap on AdminUser.List page size.
+// Mirrors the repository-level maxUserPageSize (100). The asymmetry between
+// this value and userPageCap (101) at the repository layer enables the
+// usecase-level "+1 fetch" trick without truncating a maximum-sized page.
+const adminUserMaxPageSize = 100
+
+// AdminUserConnection is the usecase-level Relay-style page result for
+// AdminUser.List. The resolver wraps it into model.UserConnection.
+type AdminUserConnection struct {
+	Edges      []AdminUserEdge
+	PageInfo   PageInfo
+	TotalCount int64
+}
+
+// AdminUserEdge pairs a node with its opaque cursor (currently the user UUID).
+type AdminUserEdge struct {
+	Cursor string
+	Node   *domain.User
+}
+
+// PageInfo mirrors the GraphQL PageInfo type. The pointer-typed cursors
+// preserve "absent" semantics for the empty-page case.
+type PageInfo struct {
+	HasNextPage     bool
+	HasPreviousPage bool
+	StartCursor     *string
+	EndCursor       *string
+}
+
+// AdminUpdateUserInput captures the patch fields for AdminUser.Update. nil
+// means "leave unchanged"; non-nil with empty string means "explicit clear"
+// for Bio. DisplayName must be 1-50 grapheme clusters when non-nil — empty
+// strings are not accepted because there is no valid empty display name.
+type AdminUpdateUserInput struct {
+	DisplayName *string
+	Bio         *string
+}
+
+// AdminUserUsecase is the admin-only user management surface.
+type AdminUserUsecase interface {
+	List(
+		ctx context.Context,
+		first, last *int,
+		after, before, search *string,
+	) (*AdminUserConnection, error)
+	Get(ctx context.Context, id string) (*domain.User, error)
+	Update(ctx context.Context, id string, input AdminUpdateUserInput) (*domain.User, error)
+	AssignRole(ctx context.Context, userID, roleID string) (*domain.User, error)
+	RevokeRole(ctx context.Context, userID, roleID string) (*domain.User, error)
+	// ListRoles returns every existing role. Admin-only.
+	ListRoles(ctx context.Context) ([]*domain.Role, error)
+}
+
+// adminUserRepository is the subset of repository.UserRepository the
+// AdminUser usecase consumes. Declaring a narrow interface keeps the
+// usecase test scaffolding small.
+type adminUserRepository interface {
+	FindByID(ctx context.Context, id string) (*domain.User, error)
+	Update(ctx context.Context, id string, patch repository.UserUpdate) (*domain.User, error)
+	ListPage(
+		ctx context.Context,
+		after, before *string,
+		first, last int,
+		search *string,
+	) ([]*domain.User, int64, error)
+}
+
+// adminRoleRepository is the subset of repository.RoleRepository used by the
+// AdminUser usecase.
+type adminRoleRepository interface {
+	FindByIDs(ctx context.Context, ids []string) (map[string]*domain.Role, error)
+	AssignToUser(ctx context.Context, userID, roleID string) error
+	RevokeFromUser(ctx context.Context, userID, roleID string) error
+	ListAll(ctx context.Context) ([]*domain.Role, error)
+}
+
+// adminUserUsecase wires the auth service, the user repository, and the role
+// repository behind the admin-only management API.
+type adminUserUsecase struct {
+	users adminUserRepository
+	roles adminRoleRepository
+	auth  AdminChecker
+}
+
+// NewAdminUser constructs an AdminUserUsecase. Pass production
+// repository.UserRepository / repository.RoleRepository implementations;
+// tests may pass narrower stubs that satisfy the package-private
+// adminUserRepository / adminRoleRepository interfaces.
+func NewAdminUser(
+	users repository.UserRepository,
+	roles repository.RoleRepository,
+	authSvc *auth.Service,
+) AdminUserUsecase {
+	return &adminUserUsecase{users: users, roles: roles, auth: authSvc}
+}
+
+// NewAdminUserWithDeps is the test-time constructor that accepts the narrow
+// interface types. Production code must use NewAdminUser.
+func NewAdminUserWithDeps(
+	users adminUserRepository,
+	roles adminRoleRepository,
+	authSvc AdminChecker,
+) AdminUserUsecase {
+	return &adminUserUsecase{users: users, roles: roles, auth: authSvc}
+}
+
+// requireAdmin centralises the auth gate every method shares. It returns the
+// caller's user id alongside any error; callers use the id for the
+// self-demotion guard in RevokeRole.
+func (u *adminUserUsecase) requireAdmin(ctx context.Context) (string, error) {
+	caller := auth.UserFrom(ctx)
+	if caller == nil || caller.Sub == "" {
+		return "", gqlerr.Unauthenticated()
+	}
+	if u.auth == nil {
+		return "", gqlerr.Internal(ctx, eris.New("usecase: admin user: admin checker not configured"))
+	}
+	isAdmin, err := u.auth.IsAdmin(ctx, caller.Sub)
+	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return "", gqlerr.Cancelled(ctx, err)
+		}
+		return "", gqlerr.Internal(ctx, eris.Wrap(err, "usecase: admin user: check admin"))
+	}
+	if !isAdmin {
+		return "", gqlerr.NewForbidden("admin only")
+	}
+	return caller.Sub, nil
+}
+
+// List paginates the users table with Relay-style cursors. Forward paging
+// uses (first, after); backward uses (last, before). The two are mutually
+// exclusive. Default page size is adminUserMaxPageSize (100); the same
+// value is the absolute cap for either direction.
+func (u *adminUserUsecase) List(
+	ctx context.Context,
+	first, last *int,
+	after, before, search *string,
+) (*AdminUserConnection, error) {
+	if _, err := u.requireAdmin(ctx); err != nil {
+		return nil, err
+	}
+
+	wantFirst, wantLast, err := resolveAdminPageSize(first, last)
+	if err != nil {
+		return nil, err
+	}
+
+	// Request one extra row to detect whether another page exists. Trim the
+	// extra row before returning to the caller.
+	repoFirst := wantFirst
+	repoLast := wantLast
+	if repoFirst > 0 {
+		repoFirst++
+	}
+	if repoLast > 0 {
+		repoLast++
+	}
+
+	users, total, err := u.users.ListPage(ctx, after, before, repoFirst, repoLast, search)
+	if err != nil {
+		if errors.Is(err, repository.ErrCursorNotFound) {
+			field := "after"
+			if after == nil && before != nil {
+				field = "before"
+			}
+			return nil, gqlerr.BadUserInput(field, "cursor not found")
+		}
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return nil, gqlerr.Cancelled(ctx, err)
+		}
+		return nil, gqlerr.Internal(ctx, eris.Wrap(err, "usecase: admin user list"))
+	}
+
+	out := &AdminUserConnection{TotalCount: total}
+	switch {
+	case wantFirst > 0:
+		if len(users) > wantFirst {
+			out.PageInfo.HasNextPage = true
+			users = users[:wantFirst]
+		}
+		out.PageInfo.HasPreviousPage = after != nil
+	case wantLast > 0:
+		if len(users) > wantLast {
+			out.PageInfo.HasPreviousPage = true
+			// Backward paging fetched (last+1) leading rows in reversed
+			// SQL order; the repository already reversed them so the
+			// extra row is at the head of the slice.
+			users = users[len(users)-wantLast:]
+		}
+		out.PageInfo.HasNextPage = before != nil
+	}
+
+	out.Edges = make([]AdminUserEdge, len(users))
+	for i, user := range users {
+		out.Edges[i] = AdminUserEdge{Cursor: user.ID, Node: user}
+	}
+	if len(users) > 0 {
+		start := users[0].ID
+		end := users[len(users)-1].ID
+		out.PageInfo.StartCursor = &start
+		out.PageInfo.EndCursor = &end
+	}
+	return out, nil
+}
+
+// Get returns a single user by id. Missing rows resolve to (nil, nil) so the
+// resolver renders the GraphQL field as null without erroring.
+func (u *adminUserUsecase) Get(ctx context.Context, id string) (*domain.User, error) {
+	if _, err := u.requireAdmin(ctx); err != nil {
+		return nil, err
+	}
+	user, err := u.users.FindByID(ctx, id)
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return nil, nil
+		}
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return nil, gqlerr.Cancelled(ctx, err)
+		}
+		return nil, gqlerr.Internal(ctx, eris.Wrap(err, "usecase: admin user get"))
+	}
+	return user, nil
+}
+
+// Update applies the patch to the user identified by id. Validation mirrors
+// UserUsecase.UpdateUser: display_name must be 1-50 grapheme clusters when
+// non-nil, bio must be at most 500 grapheme clusters when non-nil, and an
+// explicit empty bio clears the column.
+func (u *adminUserUsecase) Update(ctx context.Context, id string, input AdminUpdateUserInput) (*domain.User, error) {
+	if _, err := u.requireAdmin(ctx); err != nil {
+		return nil, err
+	}
+
+	patch := repository.UserUpdate{}
+	if input.DisplayName != nil {
+		trimmed := strings.TrimSpace(*input.DisplayName)
+		if err := validateDisplayName(trimmed); err != nil {
+			return nil, err
+		}
+		patch.DisplayName = &trimmed
+	}
+	if input.Bio != nil {
+		if err := validateBio(input.Bio); err != nil {
+			return nil, err
+		}
+		patch.Bio = input.Bio
+	}
+
+	user, err := u.users.Update(ctx, id, patch)
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return nil, gqlerr.BadUserInput("id", "user not found")
+		}
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return nil, gqlerr.Cancelled(ctx, err)
+		}
+		return nil, gqlerr.Internal(ctx, eris.Wrap(err, "usecase: admin user update"))
+	}
+	return user, nil
+}
+
+// AssignRole grants roleID to userID. Idempotent at the repository layer:
+// calling twice with the same ids is a no-op the second time.
+func (u *adminUserUsecase) AssignRole(ctx context.Context, userID, roleID string) (*domain.User, error) {
+	if _, err := u.requireAdmin(ctx); err != nil {
+		return nil, err
+	}
+	if err := u.roles.AssignToUser(ctx, userID, roleID); err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return nil, gqlerr.BadUserInput("userId", "user or role not found")
+		}
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return nil, gqlerr.Cancelled(ctx, err)
+		}
+		return nil, gqlerr.Internal(ctx, eris.Wrap(err, "usecase: admin user assign role"))
+	}
+	return u.refetchUser(ctx, userID, "usecase: admin user assign role: refetch")
+}
+
+// RevokeRole removes roleID from userID. Self-demotion of the admin role is
+// rejected with FORBIDDEN to prevent locking the system out of admin
+// management. Idempotent at the repository layer otherwise.
+func (u *adminUserUsecase) RevokeRole(ctx context.Context, userID, roleID string) (*domain.User, error) {
+	callerID, err := u.requireAdmin(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Self-demotion guard: only blocks revoking the *admin* role from the
+	// caller themselves. Look up the role first so the check is deterministic
+	// even when the caller passes a stale roleID.
+	if userID == callerID {
+		roles, err := u.roles.FindByIDs(ctx, []string{roleID})
+		if err != nil {
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return nil, gqlerr.Cancelled(ctx, err)
+			}
+			return nil, gqlerr.Internal(ctx, eris.Wrap(err, "usecase: admin user revoke role: lookup role"))
+		}
+		if role, ok := roles[roleID]; ok && role.Name == adminRoleName {
+			return nil, gqlerr.NewForbidden("cannot revoke own admin role")
+		}
+	}
+
+	if err := u.roles.RevokeFromUser(ctx, userID, roleID); err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return nil, gqlerr.Cancelled(ctx, err)
+		}
+		return nil, gqlerr.Internal(ctx, eris.Wrap(err, "usecase: admin user revoke role"))
+	}
+	return u.refetchUser(ctx, userID, "usecase: admin user revoke role: refetch")
+}
+
+// ListRoles returns every role in the system ordered by name ASC. Admin-only.
+func (u *adminUserUsecase) ListRoles(ctx context.Context) ([]*domain.Role, error) {
+	if _, err := u.requireAdmin(ctx); err != nil {
+		return nil, err
+	}
+	roles, err := u.roles.ListAll(ctx)
+	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return nil, gqlerr.Cancelled(ctx, err)
+		}
+		return nil, gqlerr.Internal(ctx, eris.Wrap(err, "usecase: admin list roles"))
+	}
+	return roles, nil
+}
+
+// refetchUser loads the user after a mutation so callers see a fresh row
+// (e.g. with the trigger-refreshed updated_at). A missing row after a
+// successful mutation is unusual; surface it as INTERNAL with the supplied
+// context.
+func (u *adminUserUsecase) refetchUser(ctx context.Context, id, wrap string) (*domain.User, error) {
+	user, err := u.users.FindByID(ctx, id)
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return nil, gqlerr.Internal(ctx, eris.New(wrap+": user disappeared"))
+		}
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return nil, gqlerr.Cancelled(ctx, err)
+		}
+		return nil, gqlerr.Internal(ctx, eris.Wrap(err, wrap))
+	}
+	return user, nil
+}
+
+// resolveAdminPageSize enforces the (first XOR last) constraint and clamps
+// each value to [0, adminUserMaxPageSize]. When both are nil, defaults to
+// (adminUserMaxPageSize, 0) — the requirement to default forward paging at
+// the documented maximum keeps single-page admin queries simple.
+func resolveAdminPageSize(first, last *int) (int, int, error) {
+	if first != nil && last != nil {
+		return 0, 0, gqlerr.BadUserInput("first", "specify either first or last")
+	}
+	if first == nil && last == nil {
+		return adminUserMaxPageSize, 0, nil
+	}
+	check := func(field string, v int) error {
+		if v < 0 {
+			return gqlerr.BadUserInput(field, fmt.Sprintf("%s must be >= 0", field))
+		}
+		if v > adminUserMaxPageSize {
+			return gqlerr.BadUserInput(field, fmt.Sprintf("%s must be <= %d", field, adminUserMaxPageSize))
+		}
+		return nil
+	}
+	if first != nil {
+		if err := check("first", *first); err != nil {
+			return 0, 0, err
+		}
+		return *first, 0, nil
+	}
+	if err := check("last", *last); err != nil {
+		return 0, 0, err
+	}
+	return 0, *last, nil
+}

--- a/backend/internal/usecase/admin_user.go
+++ b/backend/internal/usecase/admin_user.go
@@ -178,6 +178,15 @@ func (u *adminUserUsecase) List(
 	if last != nil && *last > 0 && after != nil {
 		return nil, gqlerr.BadUserInput("after", "after requires first, not last")
 	}
+	// A cursor without its companion count is ambiguous: the server cannot
+	// determine page size or direction. Reject early so the repository is
+	// never called with an uninterpretable combination.
+	if before != nil && (first == nil || *first <= 0) && (last == nil || *last <= 0) {
+		return nil, gqlerr.BadUserInput("before", "before requires last")
+	}
+	if after != nil && (first == nil || *first <= 0) && (last == nil || *last <= 0) {
+		return nil, gqlerr.BadUserInput("after", "after requires first")
+	}
 
 	wantFirst, wantLast, err := resolveAdminPageSize(first, last)
 	if err != nil {
@@ -357,6 +366,17 @@ func (u *adminUserUsecase) RevokeRole(ctx context.Context, userID, roleID string
 	}
 
 	if err := u.roles.RevokeFromUser(ctx, userID, roleID); err != nil {
+		// Branch on the specific sentinels first; both also satisfy
+		// errors.Is(_, ErrNotFound), so order matters.
+		if errors.Is(err, repository.ErrUserNotFound) {
+			return nil, gqlerr.BadUserInput("userId", "user not found")
+		}
+		if errors.Is(err, repository.ErrRoleNotFound) {
+			return nil, gqlerr.BadUserInput("roleId", "role not found")
+		}
+		if errors.Is(err, repository.ErrNotFound) {
+			return nil, gqlerr.BadUserInput("userId", "user or role not found")
+		}
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			return nil, gqlerr.Cancelled(ctx, err)
 		}

--- a/backend/internal/usecase/admin_user.go
+++ b/backend/internal/usecase/admin_user.go
@@ -154,6 +154,12 @@ func (u *adminUserUsecase) requireAdmin(ctx context.Context) (string, error) {
 // uses (first, after); backward uses (last, before). The two are mutually
 // exclusive. Default page size is adminUserMaxPageSize (100); the same
 // value is the absolute cap for either direction.
+//
+// Cursor-direction cross-validation: per the Relay spec, after pairs with
+// first (forward) and before pairs with last (backward). Mixing them or
+// supplying both cursors at once is rejected with BAD_USER_INPUT before the
+// repository is touched, so callers never get a silently re-interpreted
+// page boundary.
 func (u *adminUserUsecase) List(
 	ctx context.Context,
 	first, last *int,
@@ -161,6 +167,16 @@ func (u *adminUserUsecase) List(
 ) (*AdminUserConnection, error) {
 	if _, err := u.requireAdmin(ctx); err != nil {
 		return nil, err
+	}
+
+	if after != nil && before != nil {
+		return nil, gqlerr.BadUserInput("after", "after and before are mutually exclusive")
+	}
+	if first != nil && *first > 0 && before != nil {
+		return nil, gqlerr.BadUserInput("before", "before requires last, not first")
+	}
+	if last != nil && *last > 0 && after != nil {
+		return nil, gqlerr.BadUserInput("after", "after requires first, not last")
 	}
 
 	wantFirst, wantLast, err := resolveAdminPageSize(first, last)
@@ -284,11 +300,26 @@ func (u *adminUserUsecase) Update(ctx context.Context, id string, input AdminUpd
 
 // AssignRole grants roleID to userID. Idempotent at the repository layer:
 // calling twice with the same ids is a no-op the second time.
+//
+// Error mapping: distinguishes user-missing from role-missing via the
+// repository's ErrUserNotFound / ErrRoleNotFound sentinels so the
+// BAD_USER_INPUT response carries the correct field for the frontend
+// banner-by-field machinery. The generic ErrNotFound branch is kept as a
+// fallback for any future repository implementation that surfaces only the
+// legacy sentinel.
 func (u *adminUserUsecase) AssignRole(ctx context.Context, userID, roleID string) (*domain.User, error) {
 	if _, err := u.requireAdmin(ctx); err != nil {
 		return nil, err
 	}
 	if err := u.roles.AssignToUser(ctx, userID, roleID); err != nil {
+		// Branch on the specific sentinels first; both also satisfy
+		// errors.Is(_, ErrNotFound), so order matters.
+		if errors.Is(err, repository.ErrUserNotFound) {
+			return nil, gqlerr.BadUserInput("userId", "user not found")
+		}
+		if errors.Is(err, repository.ErrRoleNotFound) {
+			return nil, gqlerr.BadUserInput("roleId", "role not found")
+		}
 		if errors.Is(err, repository.ErrNotFound) {
 			return nil, gqlerr.BadUserInput("userId", "user or role not found")
 		}
@@ -352,12 +383,14 @@ func (u *adminUserUsecase) ListRoles(ctx context.Context) ([]*domain.Role, error
 // refetchUser loads the user after a mutation so callers see a fresh row
 // (e.g. with the trigger-refreshed updated_at). A missing row after a
 // successful mutation is unusual; surface it as INTERNAL with the supplied
-// context.
+// context. The original ErrNotFound is wrapped (not replaced) so the chain
+// stays intact for errors.Is checks downstream and so the eris error_chain
+// log entry preserves the originating sentinel.
 func (u *adminUserUsecase) refetchUser(ctx context.Context, id, wrap string) (*domain.User, error) {
 	user, err := u.users.FindByID(ctx, id)
 	if err != nil {
 		if errors.Is(err, repository.ErrNotFound) {
-			return nil, gqlerr.Internal(ctx, eris.New(wrap+": user disappeared"))
+			return nil, gqlerr.Internal(ctx, eris.Wrap(err, wrap+": user disappeared"))
 		}
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			return nil, gqlerr.Cancelled(ctx, err)

--- a/backend/internal/usecase/admin_user.go
+++ b/backend/internal/usecase/admin_user.go
@@ -321,21 +321,7 @@ func (u *adminUserUsecase) AssignRole(ctx context.Context, userID, roleID string
 		return nil, err
 	}
 	if err := u.roles.AssignToUser(ctx, userID, roleID); err != nil {
-		// Branch on the specific sentinels first; both also satisfy
-		// errors.Is(_, ErrNotFound), so order matters.
-		if errors.Is(err, repository.ErrUserNotFound) {
-			return nil, gqlerr.BadUserInput("userId", "user not found")
-		}
-		if errors.Is(err, repository.ErrRoleNotFound) {
-			return nil, gqlerr.BadUserInput("roleId", "role not found")
-		}
-		if errors.Is(err, repository.ErrNotFound) {
-			return nil, gqlerr.BadUserInput("userId", "user or role not found")
-		}
-		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-			return nil, gqlerr.Cancelled(ctx, err)
-		}
-		return nil, gqlerr.Internal(ctx, eris.Wrap(err, "usecase: admin user assign role"))
+		return nil, mapRoleAssignmentError(ctx, err, "usecase: admin user assign role")
 	}
 	return u.refetchUser(ctx, userID, "usecase: admin user assign role: refetch")
 }
@@ -366,23 +352,29 @@ func (u *adminUserUsecase) RevokeRole(ctx context.Context, userID, roleID string
 	}
 
 	if err := u.roles.RevokeFromUser(ctx, userID, roleID); err != nil {
-		// Branch on the specific sentinels first; both also satisfy
-		// errors.Is(_, ErrNotFound), so order matters.
-		if errors.Is(err, repository.ErrUserNotFound) {
-			return nil, gqlerr.BadUserInput("userId", "user not found")
-		}
-		if errors.Is(err, repository.ErrRoleNotFound) {
-			return nil, gqlerr.BadUserInput("roleId", "role not found")
-		}
-		if errors.Is(err, repository.ErrNotFound) {
-			return nil, gqlerr.BadUserInput("userId", "user or role not found")
-		}
-		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-			return nil, gqlerr.Cancelled(ctx, err)
-		}
-		return nil, gqlerr.Internal(ctx, eris.Wrap(err, "usecase: admin user revoke role"))
+		return nil, mapRoleAssignmentError(ctx, err, "usecase: admin user revoke role")
 	}
 	return u.refetchUser(ctx, userID, "usecase: admin user revoke role: refetch")
+}
+
+// mapRoleAssignmentError translates the sentinel set returned by
+// roleRepo.AssignToUser / RevokeFromUser into the typed gqlerr surface used by
+// AssignRole and RevokeRole. Specific sentinels are matched before the legacy
+// ErrNotFound fallback because both ErrUserNotFound and ErrRoleNotFound also
+// satisfy errors.Is(_, ErrNotFound).
+func mapRoleAssignmentError(ctx context.Context, err error, wrap string) error {
+	switch {
+	case errors.Is(err, repository.ErrUserNotFound):
+		return gqlerr.BadUserInput("userId", "user not found")
+	case errors.Is(err, repository.ErrRoleNotFound):
+		return gqlerr.BadUserInput("roleId", "role not found")
+	case errors.Is(err, repository.ErrNotFound):
+		return gqlerr.BadUserInput("userId", "user or role not found")
+	case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+		return gqlerr.Cancelled(ctx, err)
+	default:
+		return gqlerr.Internal(ctx, eris.Wrap(err, wrap))
+	}
 }
 
 // ListRoles returns every role in the system ordered by name ASC. Admin-only.
@@ -409,13 +401,14 @@ func (u *adminUserUsecase) ListRoles(ctx context.Context) ([]*domain.Role, error
 func (u *adminUserUsecase) refetchUser(ctx context.Context, id, wrap string) (*domain.User, error) {
 	user, err := u.users.FindByID(ctx, id)
 	if err != nil {
-		if errors.Is(err, repository.ErrNotFound) {
-			return nil, gqlerr.Internal(ctx, eris.Wrap(err, wrap+": user disappeared"))
-		}
-		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		switch {
+		case errors.Is(err, repository.ErrNotFound):
+			return nil, gqlerr.Internal(ctx, eris.Wrapf(err, "%s: user disappeared", wrap))
+		case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
 			return nil, gqlerr.Cancelled(ctx, err)
+		default:
+			return nil, gqlerr.Internal(ctx, eris.Wrap(err, wrap))
 		}
-		return nil, gqlerr.Internal(ctx, eris.Wrap(err, wrap))
 	}
 	return user, nil
 }

--- a/backend/internal/usecase/admin_user_test.go
+++ b/backend/internal/usecase/admin_user_test.go
@@ -545,6 +545,44 @@ func TestAdminUser_List_LastWithAfter(t *testing.T) {
 	}
 }
 
+// TestAdminUser_List_BeforeWithoutLast rejects supplying a before cursor with
+// no companion last value. Without last, the server cannot determine page size
+// or direction, so the request is ambiguous and must be rejected.
+func TestAdminUser_List_BeforeWithoutLast(t *testing.T) {
+	t.Parallel()
+
+	users := &mockAdminUserRepository{}
+	authChk := &adminAuthChecker{admins: map[string]bool{"admin-1": true}}
+	uc, _, _ := buildAdminUC(users, nil, authChk)
+
+	before := "u-b"
+	// No first, no last — only before.
+	_, err := uc.List(adminCallerCtx("admin-1"), nil, nil, nil, &before, nil)
+	assertGQLErr(t, err, "BAD_USER_INPUT", "before")
+	if users.listCalls != 0 {
+		t.Fatalf("expected no repo call on before-without-last, got %d", users.listCalls)
+	}
+}
+
+// TestAdminUser_List_AfterWithoutFirst rejects supplying an after cursor with
+// no companion first value. Without first, the server cannot determine page
+// size or direction, so the request must be rejected.
+func TestAdminUser_List_AfterWithoutFirst(t *testing.T) {
+	t.Parallel()
+
+	users := &mockAdminUserRepository{}
+	authChk := &adminAuthChecker{admins: map[string]bool{"admin-1": true}}
+	uc, _, _ := buildAdminUC(users, nil, authChk)
+
+	after := "u-a"
+	// No first, no last — only after.
+	_, err := uc.List(adminCallerCtx("admin-1"), nil, nil, &after, nil, nil)
+	assertGQLErr(t, err, "BAD_USER_INPUT", "after")
+	if users.listCalls != 0 {
+		t.Fatalf("expected no repo call on after-without-first, got %d", users.listCalls)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Get
 // ---------------------------------------------------------------------------
@@ -843,6 +881,36 @@ func TestAdminUser_RevokeRole_SelfNonAdminAllowed(t *testing.T) {
 	if roles.revokeCalls != 1 {
 		t.Fatalf("expected 1 revoke call, got %d", roles.revokeCalls)
 	}
+}
+
+// TestAdminUser_RevokeRole_UserNotFound_FieldUserId asserts that a missing user
+// surfaces BAD_USER_INPUT keyed on userId — mirrors the AssignRole mapping for
+// the symmetric Revoke path.
+func TestAdminUser_RevokeRole_UserNotFound_FieldUserId(t *testing.T) {
+	t.Parallel()
+
+	users := &mockAdminUserRepository{}
+	roles := &mockAdminRoleRepository{revokeErr: repository.ErrUserNotFound}
+	authChk := &adminAuthChecker{admins: map[string]bool{"admin-1": true}}
+	uc, _, _ := buildAdminUC(users, roles, authChk)
+
+	_, err := uc.RevokeRole(adminCallerCtx("admin-1"), "missing-user", "r-some")
+	assertGQLErr(t, err, "BAD_USER_INPUT", "userId")
+}
+
+// TestAdminUser_RevokeRole_RoleNotFound_FieldRoleId asserts that a missing role
+// surfaces BAD_USER_INPUT keyed on roleId.
+func TestAdminUser_RevokeRole_RoleNotFound_FieldRoleId(t *testing.T) {
+	t.Parallel()
+
+	target := &domain.User{ID: "u-victim"}
+	users := &mockAdminUserRepository{users: map[string]*domain.User{"u-victim": target}}
+	roles := &mockAdminRoleRepository{revokeErr: repository.ErrRoleNotFound}
+	authChk := &adminAuthChecker{admins: map[string]bool{"admin-1": true}}
+	uc, _, _ := buildAdminUC(users, roles, authChk)
+
+	_, err := uc.RevokeRole(adminCallerCtx("admin-1"), "u-victim", "missing-role")
+	assertGQLErr(t, err, "BAD_USER_INPUT", "roleId")
 }
 
 // ---------------------------------------------------------------------------

--- a/backend/internal/usecase/admin_user_test.go
+++ b/backend/internal/usecase/admin_user_test.go
@@ -1,0 +1,910 @@
+package usecase
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"backend/internal/domain"
+	"backend/internal/repository"
+)
+
+// ---------------------------------------------------------------------------
+// Test doubles
+// ---------------------------------------------------------------------------
+
+// mockAdminUserRepository implements the narrow adminUserRepository surface.
+// Each method returns caller-controlled fixtures; the captured fields let the
+// tests assert what the usecase passed downstream.
+type mockAdminUserRepository struct {
+	// FindByID
+	users      map[string]*domain.User
+	findErr    error
+	findCalls  int
+	lastFindID string
+
+	// Update
+	updateResult  *domain.User
+	updateErr     error
+	capturedPatch repository.UserUpdate
+	updateCalls   int
+	lastUpdateID  string
+
+	// ListPage
+	listResult     []*domain.User
+	listTotal      int64
+	listErr        error
+	listCalls      int
+	lastListAfter  *string
+	lastListBefore *string
+	lastListFirst  int
+	lastListLast   int
+	lastListSearch *string
+}
+
+func (m *mockAdminUserRepository) FindByID(_ context.Context, id string) (*domain.User, error) {
+	m.findCalls++
+	m.lastFindID = id
+	if m.findErr != nil {
+		return nil, m.findErr
+	}
+	if u, ok := m.users[id]; ok {
+		return u, nil
+	}
+	return nil, repository.ErrNotFound
+}
+
+func (m *mockAdminUserRepository) Update(_ context.Context, id string, patch repository.UserUpdate) (*domain.User, error) {
+	m.updateCalls++
+	m.lastUpdateID = id
+	m.capturedPatch = patch
+	if m.updateErr != nil {
+		return nil, m.updateErr
+	}
+	if m.updateResult != nil {
+		return m.updateResult, nil
+	}
+	// Default behaviour: return the seeded user (when present) so refetch-style
+	// flows downstream get a non-nil row.
+	if u, ok := m.users[id]; ok {
+		return u, nil
+	}
+	return nil, repository.ErrNotFound
+}
+
+func (m *mockAdminUserRepository) ListPage(
+	_ context.Context,
+	after, before *string,
+	first, last int,
+	search *string,
+) ([]*domain.User, int64, error) {
+	m.listCalls++
+	m.lastListAfter = after
+	m.lastListBefore = before
+	m.lastListFirst = first
+	m.lastListLast = last
+	m.lastListSearch = search
+	if m.listErr != nil {
+		return nil, 0, m.listErr
+	}
+	return m.listResult, m.listTotal, nil
+}
+
+// mockAdminRoleRepository implements the narrow adminRoleRepository surface.
+type mockAdminRoleRepository struct {
+	// FindByIDs
+	roles       map[string]*domain.Role
+	findErr     error
+	findCalls   int
+	lastFindIDs []string
+
+	// AssignToUser
+	assignErr     error
+	assignCalls   int
+	lastAssignUID string
+	lastAssignRID string
+
+	// RevokeFromUser
+	revokeErr     error
+	revokeCalls   int
+	lastRevokeUID string
+	lastRevokeRID string
+
+	// ListAll
+	allRoles   []*domain.Role
+	listAllErr error
+}
+
+func (m *mockAdminRoleRepository) FindByIDs(_ context.Context, ids []string) (map[string]*domain.Role, error) {
+	m.findCalls++
+	m.lastFindIDs = append([]string(nil), ids...)
+	if m.findErr != nil {
+		return nil, m.findErr
+	}
+	out := make(map[string]*domain.Role, len(ids))
+	for _, id := range ids {
+		if r, ok := m.roles[id]; ok {
+			out[id] = r
+		}
+	}
+	return out, nil
+}
+
+func (m *mockAdminRoleRepository) AssignToUser(_ context.Context, userID, roleID string) error {
+	m.assignCalls++
+	m.lastAssignUID = userID
+	m.lastAssignRID = roleID
+	return m.assignErr
+}
+
+func (m *mockAdminRoleRepository) RevokeFromUser(_ context.Context, userID, roleID string) error {
+	m.revokeCalls++
+	m.lastRevokeUID = userID
+	m.lastRevokeRID = roleID
+	return m.revokeErr
+}
+
+func (m *mockAdminRoleRepository) ListAll(_ context.Context) ([]*domain.Role, error) {
+	if m.listAllErr != nil {
+		return nil, m.listAllErr
+	}
+	return m.allRoles, nil
+}
+
+// adminAuthChecker is a stand-alone admin checker for AdminUser tests. It
+// reuses the same shape as mockAdminChecker but is keyed on userID so the
+// self-demotion test can return true for one caller and false for another.
+type adminAuthChecker struct {
+	admins map[string]bool
+	err    error
+	calls  int
+}
+
+func (a *adminAuthChecker) IsAdmin(_ context.Context, userID string) (bool, error) {
+	a.calls++
+	if a.err != nil {
+		return false, a.err
+	}
+	return a.admins[userID], nil
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// buildAdminUC wires a usecase with the supplied stubs. nil arguments are
+// replaced with empty defaults so individual tests need only specify what
+// they exercise.
+func buildAdminUC(
+	users *mockAdminUserRepository,
+	roles *mockAdminRoleRepository,
+	authChk AdminChecker,
+) (AdminUserUsecase, *mockAdminUserRepository, *mockAdminRoleRepository) {
+	if users == nil {
+		users = &mockAdminUserRepository{}
+	}
+	if roles == nil {
+		roles = &mockAdminRoleRepository{}
+	}
+	if authChk == nil {
+		authChk = &adminAuthChecker{}
+	}
+	uc := NewAdminUserWithDeps(users, roles, authChk)
+	return uc, users, roles
+}
+
+// adminCallerCtx returns a context whose AuthUser sub matches a caller marked
+// as admin in the supplied checker.
+func adminCallerCtx(uid string) context.Context {
+	return authedCtx(uid)
+}
+
+// ---------------------------------------------------------------------------
+// FORBIDDEN gate: every method rejects non-admins
+// ---------------------------------------------------------------------------
+
+// TestAdminUser_NonAdminForbidden exercises the auth gate on every entry
+// point. A non-admin caller must receive FORBIDDEN before any repository
+// call is made.
+func TestAdminUser_NonAdminForbidden(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		call func(uc AdminUserUsecase) error
+	}{
+		{
+			name: "List",
+			call: func(uc AdminUserUsecase) error {
+				_, err := uc.List(adminCallerCtx("u1"), nil, nil, nil, nil, nil)
+				return err
+			},
+		},
+		{
+			name: "Get",
+			call: func(uc AdminUserUsecase) error {
+				_, err := uc.Get(adminCallerCtx("u1"), "any")
+				return err
+			},
+		},
+		{
+			name: "Update",
+			call: func(uc AdminUserUsecase) error {
+				_, err := uc.Update(adminCallerCtx("u1"), "any", AdminUpdateUserInput{})
+				return err
+			},
+		},
+		{
+			name: "AssignRole",
+			call: func(uc AdminUserUsecase) error {
+				_, err := uc.AssignRole(adminCallerCtx("u1"), "u2", "r1")
+				return err
+			},
+		},
+		{
+			name: "RevokeRole",
+			call: func(uc AdminUserUsecase) error {
+				_, err := uc.RevokeRole(adminCallerCtx("u1"), "u2", "r1")
+				return err
+			},
+		},
+		{
+			name: "ListRoles",
+			call: func(uc AdminUserUsecase) error {
+				_, err := uc.ListRoles(adminCallerCtx("u1"))
+				return err
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			authChk := &adminAuthChecker{admins: map[string]bool{}} // u1 is not admin
+			users := &mockAdminUserRepository{}
+			roles := &mockAdminRoleRepository{}
+			uc, _, _ := buildAdminUC(users, roles, authChk)
+
+			err := tc.call(uc)
+			assertGQLErr(t, err, "FORBIDDEN", "")
+
+			if users.findCalls+users.updateCalls+users.listCalls != 0 {
+				t.Fatalf("expected no user repo calls, got find=%d update=%d list=%d",
+					users.findCalls, users.updateCalls, users.listCalls)
+			}
+			if roles.assignCalls+roles.revokeCalls != 0 {
+				t.Fatalf("expected no role repo writes, got assign=%d revoke=%d",
+					roles.assignCalls, roles.revokeCalls)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// List
+// ---------------------------------------------------------------------------
+
+// TestAdminUser_List_Page1 covers the default forward page-1 case: no cursor,
+// no overflow, exactly N rows returned with no next page.
+func TestAdminUser_List_Page1(t *testing.T) {
+	t.Parallel()
+
+	page := []*domain.User{
+		{ID: "u-aaa"},
+		{ID: "u-bbb"},
+		{ID: "u-ccc"},
+	}
+	users := &mockAdminUserRepository{listResult: page, listTotal: 3}
+	authChk := &adminAuthChecker{admins: map[string]bool{"admin-1": true}}
+	uc, _, _ := buildAdminUC(users, nil, authChk)
+
+	out, err := uc.List(adminCallerCtx("admin-1"), nil, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.TotalCount != 3 {
+		t.Fatalf("TotalCount = %d, want 3", out.TotalCount)
+	}
+	if len(out.Edges) != 3 {
+		t.Fatalf("len(Edges) = %d, want 3", len(out.Edges))
+	}
+	for i, edge := range out.Edges {
+		if edge.Cursor != page[i].ID {
+			t.Fatalf("edge[%d].Cursor = %q, want %q", i, edge.Cursor, page[i].ID)
+		}
+		if edge.Node != page[i] {
+			t.Fatalf("edge[%d].Node mismatch", i)
+		}
+	}
+	if out.PageInfo.HasNextPage {
+		t.Fatal("HasNextPage = true, want false (under-fill page)")
+	}
+	if out.PageInfo.HasPreviousPage {
+		t.Fatal("HasPreviousPage = true, want false (no after cursor)")
+	}
+	if out.PageInfo.StartCursor == nil || *out.PageInfo.StartCursor != "u-aaa" {
+		t.Fatalf("StartCursor = %v, want u-aaa", out.PageInfo.StartCursor)
+	}
+	if out.PageInfo.EndCursor == nil || *out.PageInfo.EndCursor != "u-ccc" {
+		t.Fatalf("EndCursor = %v, want u-ccc", out.PageInfo.EndCursor)
+	}
+	// Default page size: usecase asks repo for 100+1=101 rows.
+	if users.lastListFirst != adminUserMaxPageSize+1 {
+		t.Fatalf("repo first arg = %d, want %d", users.lastListFirst, adminUserMaxPageSize+1)
+	}
+	if users.lastListLast != 0 {
+		t.Fatalf("repo last arg = %d, want 0", users.lastListLast)
+	}
+}
+
+// TestAdminUser_List_ForwardPage2 covers a forward (after) page that came
+// back over-filled (first+1 rows). The trailing extra row drives
+// HasNextPage=true and is trimmed; HasPreviousPage=true because an after
+// cursor was supplied.
+func TestAdminUser_List_ForwardPage2(t *testing.T) {
+	t.Parallel()
+
+	// first=2 → repo asked for 3; repo returns 3 rows so the trailing one
+	// is trimmed and HasNextPage flips on.
+	page := []*domain.User{
+		{ID: "u-2"},
+		{ID: "u-3"},
+		{ID: "u-4"},
+	}
+	users := &mockAdminUserRepository{listResult: page, listTotal: 10}
+	authChk := &adminAuthChecker{admins: map[string]bool{"admin-1": true}}
+	uc, _, _ := buildAdminUC(users, nil, authChk)
+
+	after := "u-1"
+	out, err := uc.List(adminCallerCtx("admin-1"), intPtr(2), nil, &after, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(out.Edges) != 2 {
+		t.Fatalf("len(Edges) = %d, want 2 (trailing row trimmed)", len(out.Edges))
+	}
+	if out.Edges[0].Cursor != "u-2" || out.Edges[1].Cursor != "u-3" {
+		t.Fatalf("edges = %v, want [u-2, u-3]", out.Edges)
+	}
+	if !out.PageInfo.HasNextPage {
+		t.Fatal("HasNextPage = false, want true (extra row present)")
+	}
+	if !out.PageInfo.HasPreviousPage {
+		t.Fatal("HasPreviousPage = false, want true (after cursor supplied)")
+	}
+	if users.lastListFirst != 3 {
+		t.Fatalf("repo first arg = %d, want 3 (2+1)", users.lastListFirst)
+	}
+	if users.lastListAfter == nil || *users.lastListAfter != "u-1" {
+		t.Fatalf("repo after arg = %v, want u-1", users.lastListAfter)
+	}
+}
+
+// TestAdminUser_List_Backward covers a backward (last+before) page in display
+// order. The repository returns rows already reversed; the usecase trims the
+// extra leading row and flips HasPreviousPage.
+func TestAdminUser_List_Backward(t *testing.T) {
+	t.Parallel()
+
+	// last=2 → repo asked for 3; repo returns 3 rows in display order.
+	// The leading extra row is trimmed and HasPreviousPage flips on.
+	page := []*domain.User{
+		{ID: "u-prev"}, // extra leading row, will be trimmed
+		{ID: "u-x"},
+		{ID: "u-y"},
+	}
+	users := &mockAdminUserRepository{listResult: page, listTotal: 10}
+	authChk := &adminAuthChecker{admins: map[string]bool{"admin-1": true}}
+	uc, _, _ := buildAdminUC(users, nil, authChk)
+
+	before := "u-z"
+	out, err := uc.List(adminCallerCtx("admin-1"), nil, intPtr(2), nil, &before, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(out.Edges) != 2 {
+		t.Fatalf("len(Edges) = %d, want 2 (leading row trimmed)", len(out.Edges))
+	}
+	if out.Edges[0].Cursor != "u-x" || out.Edges[1].Cursor != "u-y" {
+		t.Fatalf("edges = %v, want [u-x, u-y]", out.Edges)
+	}
+	if !out.PageInfo.HasPreviousPage {
+		t.Fatal("HasPreviousPage = false, want true (extra leading row)")
+	}
+	if !out.PageInfo.HasNextPage {
+		t.Fatal("HasNextPage = false, want true (before cursor supplied)")
+	}
+	if users.lastListLast != 3 {
+		t.Fatalf("repo last arg = %d, want 3 (2+1)", users.lastListLast)
+	}
+	if users.lastListBefore == nil || *users.lastListBefore != "u-z" {
+		t.Fatalf("repo before arg = %v, want u-z", users.lastListBefore)
+	}
+}
+
+// TestAdminUser_List_BadCursor_After covers the cursor-not-found branch: the
+// repository surfaces ErrCursorNotFound which the usecase translates to
+// BAD_USER_INPUT keyed on the cursor field that was supplied.
+func TestAdminUser_List_BadCursor_After(t *testing.T) {
+	t.Parallel()
+
+	users := &mockAdminUserRepository{listErr: repository.ErrCursorNotFound}
+	authChk := &adminAuthChecker{admins: map[string]bool{"admin-1": true}}
+	uc, _, _ := buildAdminUC(users, nil, authChk)
+
+	stale := "00000000-0000-0000-0000-000000000000"
+	_, err := uc.List(adminCallerCtx("admin-1"), nil, nil, &stale, nil, nil)
+	assertGQLErr(t, err, "BAD_USER_INPUT", "after")
+}
+
+// TestAdminUser_List_BadCursor_Before mirrors the after case but for the
+// backward-paging cursor field.
+func TestAdminUser_List_BadCursor_Before(t *testing.T) {
+	t.Parallel()
+
+	users := &mockAdminUserRepository{listErr: repository.ErrCursorNotFound}
+	authChk := &adminAuthChecker{admins: map[string]bool{"admin-1": true}}
+	uc, _, _ := buildAdminUC(users, nil, authChk)
+
+	stale := "00000000-0000-0000-0000-000000000000"
+	_, err := uc.List(adminCallerCtx("admin-1"), nil, intPtr(5), nil, &stale, nil)
+	assertGQLErr(t, err, "BAD_USER_INPUT", "before")
+}
+
+// TestAdminUser_List_BothFirstAndLast covers the mutual-exclusion check on
+// pagination args. Supplying both first and last is BAD_USER_INPUT.
+func TestAdminUser_List_BothFirstAndLast(t *testing.T) {
+	t.Parallel()
+
+	users := &mockAdminUserRepository{}
+	authChk := &adminAuthChecker{admins: map[string]bool{"admin-1": true}}
+	uc, _, _ := buildAdminUC(users, nil, authChk)
+
+	_, err := uc.List(adminCallerCtx("admin-1"), intPtr(5), intPtr(5), nil, nil, nil)
+	assertGQLErr(t, err, "BAD_USER_INPUT", "first")
+	if users.listCalls != 0 {
+		t.Fatalf("expected no repo call, got %d", users.listCalls)
+	}
+}
+
+// TestAdminUser_List_FirstNegative rejects negative first/last per the
+// resolveAdminPageSize contract.
+func TestAdminUser_List_FirstNegative(t *testing.T) {
+	t.Parallel()
+
+	users := &mockAdminUserRepository{}
+	authChk := &adminAuthChecker{admins: map[string]bool{"admin-1": true}}
+	uc, _, _ := buildAdminUC(users, nil, authChk)
+
+	_, err := uc.List(adminCallerCtx("admin-1"), intPtr(-1), nil, nil, nil, nil)
+	assertGQLErr(t, err, "BAD_USER_INPUT", "first")
+}
+
+// TestAdminUser_List_FirstOverCap rejects values above the documented cap.
+func TestAdminUser_List_FirstOverCap(t *testing.T) {
+	t.Parallel()
+
+	users := &mockAdminUserRepository{}
+	authChk := &adminAuthChecker{admins: map[string]bool{"admin-1": true}}
+	uc, _, _ := buildAdminUC(users, nil, authChk)
+
+	_, err := uc.List(adminCallerCtx("admin-1"), intPtr(adminUserMaxPageSize+1), nil, nil, nil, nil)
+	assertGQLErr(t, err, "BAD_USER_INPUT", "first")
+}
+
+// ---------------------------------------------------------------------------
+// Get
+// ---------------------------------------------------------------------------
+
+// TestAdminUser_Get_Found returns the row when the repo finds it.
+func TestAdminUser_Get_Found(t *testing.T) {
+	t.Parallel()
+
+	want := &domain.User{ID: "u-target"}
+	users := &mockAdminUserRepository{users: map[string]*domain.User{"u-target": want}}
+	authChk := &adminAuthChecker{admins: map[string]bool{"admin-1": true}}
+	uc, _, _ := buildAdminUC(users, nil, authChk)
+
+	got, err := uc.Get(adminCallerCtx("admin-1"), "u-target")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != want {
+		t.Fatalf("got = %p, want %p", got, want)
+	}
+}
+
+// TestAdminUser_Get_Missing maps ErrNotFound to (nil, nil) so the resolver
+// renders the GraphQL field as null.
+func TestAdminUser_Get_Missing(t *testing.T) {
+	t.Parallel()
+
+	users := &mockAdminUserRepository{users: map[string]*domain.User{}}
+	authChk := &adminAuthChecker{admins: map[string]bool{"admin-1": true}}
+	uc, _, _ := buildAdminUC(users, nil, authChk)
+
+	got, err := uc.Get(adminCallerCtx("admin-1"), "missing")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected nil user, got %+v", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Update
+// ---------------------------------------------------------------------------
+
+// TestAdminUser_Update_DisplayName persists the patched display name (with
+// surrounding whitespace trimmed) and returns the refreshed user.
+func TestAdminUser_Update_DisplayName(t *testing.T) {
+	t.Parallel()
+
+	updated := &domain.User{ID: "u-target", DisplayName: ptr("Bob")}
+	users := &mockAdminUserRepository{updateResult: updated}
+	authChk := &adminAuthChecker{admins: map[string]bool{"admin-1": true}}
+	uc, _, _ := buildAdminUC(users, nil, authChk)
+
+	got, err := uc.Update(adminCallerCtx("admin-1"), "u-target", AdminUpdateUserInput{
+		DisplayName: ptr("  Bob  "),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != updated {
+		t.Fatalf("got = %p, want %p", got, updated)
+	}
+	if users.capturedPatch.DisplayName == nil || *users.capturedPatch.DisplayName != "Bob" {
+		t.Fatalf("repo patch DisplayName = %v, want Bob", users.capturedPatch.DisplayName)
+	}
+	if users.capturedPatch.Bio != nil {
+		t.Fatalf("repo patch Bio = %v, want nil", users.capturedPatch.Bio)
+	}
+}
+
+// TestAdminUser_Update_BioClear covers the explicit-clear branch: bio == &""
+// is forwarded as a non-nil pointer to "".
+func TestAdminUser_Update_BioClear(t *testing.T) {
+	t.Parallel()
+
+	updated := &domain.User{ID: "u-target"}
+	users := &mockAdminUserRepository{updateResult: updated}
+	authChk := &adminAuthChecker{admins: map[string]bool{"admin-1": true}}
+	uc, _, _ := buildAdminUC(users, nil, authChk)
+
+	_, err := uc.Update(adminCallerCtx("admin-1"), "u-target", AdminUpdateUserInput{
+		Bio: ptr(""),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if users.capturedPatch.Bio == nil {
+		t.Fatal("expected non-nil Bio in patch (explicit clear), got nil")
+	}
+	if *users.capturedPatch.Bio != "" {
+		t.Fatalf("Bio = %q, want \"\"", *users.capturedPatch.Bio)
+	}
+}
+
+// TestAdminUser_Update_DisplayNameEmpty rejects an empty (post-trim) display
+// name with BAD_USER_INPUT.
+func TestAdminUser_Update_DisplayNameEmpty(t *testing.T) {
+	t.Parallel()
+
+	users := &mockAdminUserRepository{}
+	authChk := &adminAuthChecker{admins: map[string]bool{"admin-1": true}}
+	uc, _, _ := buildAdminUC(users, nil, authChk)
+
+	_, err := uc.Update(adminCallerCtx("admin-1"), "u-target", AdminUpdateUserInput{
+		DisplayName: ptr("   "),
+	})
+	assertGQLErr(t, err, "BAD_USER_INPUT", "displayName")
+	if users.updateCalls != 0 {
+		t.Fatalf("expected no repo update on validation failure, got %d", users.updateCalls)
+	}
+}
+
+// TestAdminUser_Update_DisplayNameOverMax rejects a 51-char display name.
+func TestAdminUser_Update_DisplayNameOverMax(t *testing.T) {
+	t.Parallel()
+
+	users := &mockAdminUserRepository{}
+	authChk := &adminAuthChecker{admins: map[string]bool{"admin-1": true}}
+	uc, _, _ := buildAdminUC(users, nil, authChk)
+
+	overMax := strings.Repeat("a", displayNameMax+1)
+	_, err := uc.Update(adminCallerCtx("admin-1"), "u-target", AdminUpdateUserInput{
+		DisplayName: ptr(overMax),
+	})
+	assertGQLErr(t, err, "BAD_USER_INPUT", "displayName")
+	if users.updateCalls != 0 {
+		t.Fatalf("expected no repo update on validation failure, got %d", users.updateCalls)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// AssignRole
+// ---------------------------------------------------------------------------
+
+// TestAdminUser_AssignRole_Idempotent calls AssignRole twice with the same
+// (userID, roleID) pair and asserts that the usecase issues two repo calls
+// (the repo handles ON CONFLICT DO NOTHING internally) without surfacing an
+// error to the caller.
+func TestAdminUser_AssignRole_Idempotent(t *testing.T) {
+	t.Parallel()
+
+	target := &domain.User{ID: "u-target", DisplayName: ptr("Carol")}
+	users := &mockAdminUserRepository{users: map[string]*domain.User{"u-target": target}}
+	roles := &mockAdminRoleRepository{}
+	authChk := &adminAuthChecker{admins: map[string]bool{"admin-1": true}}
+	uc, _, _ := buildAdminUC(users, roles, authChk)
+
+	for i := 0; i < 2; i++ {
+		got, err := uc.AssignRole(adminCallerCtx("admin-1"), "u-target", "r-admin")
+		if err != nil {
+			t.Fatalf("call %d: unexpected error: %v", i, err)
+		}
+		if got != target {
+			t.Fatalf("call %d: got = %p, want %p", i, got, target)
+		}
+	}
+	if roles.assignCalls != 2 {
+		t.Fatalf("expected 2 assign calls, got %d", roles.assignCalls)
+	}
+	if roles.lastAssignUID != "u-target" || roles.lastAssignRID != "r-admin" {
+		t.Fatalf("repo assign args = (%q,%q), want (u-target, r-admin)",
+			roles.lastAssignUID, roles.lastAssignRID)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// RevokeRole
+// ---------------------------------------------------------------------------
+
+// TestAdminUser_RevokeRole_Happy covers a clean revoke: caller is an admin,
+// target is someone else, role lookup is skipped, refetched user is returned.
+func TestAdminUser_RevokeRole_Happy(t *testing.T) {
+	t.Parallel()
+
+	target := &domain.User{ID: "u-victim"}
+	users := &mockAdminUserRepository{users: map[string]*domain.User{"u-victim": target}}
+	roles := &mockAdminRoleRepository{}
+	authChk := &adminAuthChecker{admins: map[string]bool{"admin-1": true}}
+	uc, _, _ := buildAdminUC(users, roles, authChk)
+
+	got, err := uc.RevokeRole(adminCallerCtx("admin-1"), "u-victim", "r-some")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != target {
+		t.Fatalf("got = %p, want %p", got, target)
+	}
+	if roles.revokeCalls != 1 {
+		t.Fatalf("expected 1 revoke call, got %d", roles.revokeCalls)
+	}
+	// Self-demotion guard does not fire when caller != target, so the role
+	// lookup must not have been issued.
+	if roles.findCalls != 0 {
+		t.Fatalf("expected 0 role lookups for non-self target, got %d", roles.findCalls)
+	}
+}
+
+// TestAdminUser_RevokeRole_SelfAdminForbidden covers the self-demotion guard:
+// an admin cannot revoke their own admin role. The role lookup must classify
+// the role as the admin role (by name) before the FORBIDDEN is returned.
+func TestAdminUser_RevokeRole_SelfAdminForbidden(t *testing.T) {
+	t.Parallel()
+
+	users := &mockAdminUserRepository{users: map[string]*domain.User{
+		"admin-1": {ID: "admin-1"},
+	}}
+	roles := &mockAdminRoleRepository{
+		roles: map[string]*domain.Role{
+			"r-admin": {ID: "r-admin", Name: "admin"},
+		},
+	}
+	authChk := &adminAuthChecker{admins: map[string]bool{"admin-1": true}}
+	uc, _, _ := buildAdminUC(users, roles, authChk)
+
+	_, err := uc.RevokeRole(adminCallerCtx("admin-1"), "admin-1", "r-admin")
+	assertGQLErr(t, err, "FORBIDDEN", "")
+	if roles.revokeCalls != 0 {
+		t.Fatalf("expected 0 revoke calls on self-demotion, got %d", roles.revokeCalls)
+	}
+	if roles.findCalls != 1 {
+		t.Fatalf("expected 1 role lookup for self-demotion check, got %d", roles.findCalls)
+	}
+}
+
+// TestAdminUser_RevokeRole_SelfNonAdminAllowed covers the "self-revoke is
+// allowed when the role isn't admin" branch: the self-demotion guard names
+// the admin role specifically, so revoking a different role from yourself
+// must succeed.
+func TestAdminUser_RevokeRole_SelfNonAdminAllowed(t *testing.T) {
+	t.Parallel()
+
+	caller := &domain.User{ID: "admin-1"}
+	users := &mockAdminUserRepository{users: map[string]*domain.User{"admin-1": caller}}
+	roles := &mockAdminRoleRepository{
+		roles: map[string]*domain.Role{
+			"r-other": {ID: "r-other", Name: "moderator"},
+		},
+	}
+	authChk := &adminAuthChecker{admins: map[string]bool{"admin-1": true}}
+	uc, _, _ := buildAdminUC(users, roles, authChk)
+
+	got, err := uc.RevokeRole(adminCallerCtx("admin-1"), "admin-1", "r-other")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != caller {
+		t.Fatalf("got = %p, want %p", got, caller)
+	}
+	if roles.revokeCalls != 1 {
+		t.Fatalf("expected 1 revoke call, got %d", roles.revokeCalls)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Context cancellation
+// ---------------------------------------------------------------------------
+
+// TestAdminUser_List_CancelledFromAdminCheck covers the ctx-cancellation
+// propagation path through the auth gate. A canceled context must surface
+// CANCELLED, not INTERNAL.
+func TestAdminUser_List_CancelledFromAdminCheck(t *testing.T) {
+	t.Parallel()
+
+	authChk := &adminAuthChecker{err: context.Canceled}
+	users := &mockAdminUserRepository{}
+	uc, _, _ := buildAdminUC(users, nil, authChk)
+
+	_, err := uc.List(adminCallerCtx("admin-1"), nil, nil, nil, nil, nil)
+	assertGQLErr(t, err, "CANCELLED", "")
+	if users.listCalls != 0 {
+		t.Fatalf("expected no repo call after cancellation, got %d", users.listCalls)
+	}
+}
+
+// TestAdminUser_List_CancelledFromRepo covers the cancellation path through
+// the repository call (after admin check passes).
+func TestAdminUser_List_CancelledFromRepo(t *testing.T) {
+	t.Parallel()
+
+	users := &mockAdminUserRepository{listErr: context.DeadlineExceeded}
+	authChk := &adminAuthChecker{admins: map[string]bool{"admin-1": true}}
+	uc, _, _ := buildAdminUC(users, nil, authChk)
+
+	_, err := uc.List(adminCallerCtx("admin-1"), nil, nil, nil, nil, nil)
+	assertGQLErr(t, err, "CANCELLED", "")
+}
+
+// TestAdminUser_Update_CancelledFromRepo covers cancellation surfacing through
+// the Update repo call.
+func TestAdminUser_Update_CancelledFromRepo(t *testing.T) {
+	t.Parallel()
+
+	users := &mockAdminUserRepository{updateErr: context.Canceled}
+	authChk := &adminAuthChecker{admins: map[string]bool{"admin-1": true}}
+	uc, _, _ := buildAdminUC(users, nil, authChk)
+
+	_, err := uc.Update(adminCallerCtx("admin-1"), "u-target", AdminUpdateUserInput{
+		DisplayName: ptr("Alice"),
+	})
+	assertGQLErr(t, err, "CANCELLED", "")
+}
+
+// ---------------------------------------------------------------------------
+// Auth gate edge cases
+// ---------------------------------------------------------------------------
+
+// TestAdminUser_AnonymousUnauthenticated covers the no-AuthUser-in-context
+// branch. Anonymous callers receive UNAUTHENTICATED; the IsAdmin checker is
+// never consulted.
+func TestAdminUser_AnonymousUnauthenticated(t *testing.T) {
+	t.Parallel()
+
+	authChk := &adminAuthChecker{admins: map[string]bool{"admin-1": true}}
+	users := &mockAdminUserRepository{}
+	uc, _, _ := buildAdminUC(users, nil, authChk)
+
+	_, err := uc.List(anonCtx(), nil, nil, nil, nil, nil)
+	assertGQLErr(t, err, "UNAUTHENTICATED", "")
+	if authChk.calls != 0 {
+		t.Fatalf("expected 0 IsAdmin calls for anonymous caller, got %d", authChk.calls)
+	}
+}
+
+// TestAdminUser_IsAdminInternalError covers the IsAdmin-returns-non-cancellation-
+// error branch. A DB-level error from the role check surfaces as INTERNAL.
+func TestAdminUser_IsAdminInternalError(t *testing.T) {
+	t.Parallel()
+
+	authChk := &adminAuthChecker{err: errors.New("db down")}
+	users := &mockAdminUserRepository{}
+	uc, _, _ := buildAdminUC(users, nil, authChk)
+
+	_, err := uc.List(adminCallerCtx("admin-1"), nil, nil, nil, nil, nil)
+	assertGQLErr(t, err, "INTERNAL", "")
+}
+
+// ---------------------------------------------------------------------------
+// ListRoles
+// ---------------------------------------------------------------------------
+
+// TestAdminUser_ListRoles_NonAdmin verifies that a non-admin caller receives
+// FORBIDDEN and the repository is never reached.
+func TestAdminUser_ListRoles_NonAdmin(t *testing.T) {
+	t.Parallel()
+
+	authChk := &adminAuthChecker{admins: map[string]bool{}} // no admins
+	roles := &mockAdminRoleRepository{}
+	uc, _, _ := buildAdminUC(nil, roles, authChk)
+
+	_, err := uc.ListRoles(adminCallerCtx("non-admin"))
+	assertGQLErr(t, err, "FORBIDDEN", "")
+}
+
+// TestAdminUser_ListRoles_Admin_Empty verifies that an admin caller receives
+// an empty (non-nil) slice when no roles exist.
+func TestAdminUser_ListRoles_Admin_Empty(t *testing.T) {
+	t.Parallel()
+
+	authChk := &adminAuthChecker{admins: map[string]bool{"admin-1": true}}
+	roles := &mockAdminRoleRepository{allRoles: []*domain.Role{}}
+	uc, _, _ := buildAdminUC(nil, roles, authChk)
+
+	got, err := uc.ListRoles(adminCallerCtx("admin-1"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected non-nil empty slice, got nil")
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected 0 roles, got %d", len(got))
+	}
+}
+
+// TestAdminUser_ListRoles_Admin_Multiple verifies that roles are passed through
+// from the repository in name ASC order (the repo owns ordering).
+func TestAdminUser_ListRoles_Admin_Multiple(t *testing.T) {
+	t.Parallel()
+
+	want := []*domain.Role{
+		{ID: "r-admin", Name: "admin"},
+		{ID: "r-general", Name: "general"},
+		{ID: "r-reviewer", Name: "reviewer"},
+	}
+	authChk := &adminAuthChecker{admins: map[string]bool{"admin-1": true}}
+	roles := &mockAdminRoleRepository{allRoles: want}
+	uc, _, _ := buildAdminUC(nil, roles, authChk)
+
+	got, err := uc.ListRoles(adminCallerCtx("admin-1"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != len(want) {
+		t.Fatalf("len(roles) = %d, want %d", len(got), len(want))
+	}
+	for i, r := range got {
+		if r.ID != want[i].ID || r.Name != want[i].Name {
+			t.Errorf("roles[%d] = {%q,%q}, want {%q,%q}", i, r.ID, r.Name, want[i].ID, want[i].Name)
+		}
+	}
+}
+
+// TestAdminUser_ListRoles_Cancelled verifies that a cancelled context
+// propagates as CANCELLED rather than INTERNAL.
+func TestAdminUser_ListRoles_Cancelled(t *testing.T) {
+	t.Parallel()
+
+	authChk := &adminAuthChecker{admins: map[string]bool{"admin-1": true}}
+	roles := &mockAdminRoleRepository{listAllErr: context.Canceled}
+	uc, _, _ := buildAdminUC(nil, roles, authChk)
+
+	_, err := uc.ListRoles(adminCallerCtx("admin-1"))
+	assertGQLErr(t, err, "CANCELLED", "")
+}

--- a/backend/internal/usecase/admin_user_test.go
+++ b/backend/internal/usecase/admin_user_test.go
@@ -493,6 +493,58 @@ func TestAdminUser_List_FirstOverCap(t *testing.T) {
 	assertGQLErr(t, err, "BAD_USER_INPUT", "first")
 }
 
+// TestAdminUser_List_AfterAndBeforeMutuallyExclusive verifies that supplying
+// both cursor sides is rejected before the repository is reached.
+func TestAdminUser_List_AfterAndBeforeMutuallyExclusive(t *testing.T) {
+	t.Parallel()
+
+	users := &mockAdminUserRepository{}
+	authChk := &adminAuthChecker{admins: map[string]bool{"admin-1": true}}
+	uc, _, _ := buildAdminUC(users, nil, authChk)
+
+	after := "u-a"
+	before := "u-b"
+	_, err := uc.List(adminCallerCtx("admin-1"), nil, nil, &after, &before, nil)
+	assertGQLErr(t, err, "BAD_USER_INPUT", "after")
+	if users.listCalls != 0 {
+		t.Fatalf("expected no repo call on cross-cursor rejection, got %d", users.listCalls)
+	}
+}
+
+// TestAdminUser_List_FirstWithBefore rejects pairing forward count with the
+// backward cursor — the page boundary would otherwise be ambiguous.
+func TestAdminUser_List_FirstWithBefore(t *testing.T) {
+	t.Parallel()
+
+	users := &mockAdminUserRepository{}
+	authChk := &adminAuthChecker{admins: map[string]bool{"admin-1": true}}
+	uc, _, _ := buildAdminUC(users, nil, authChk)
+
+	before := "u-b"
+	_, err := uc.List(adminCallerCtx("admin-1"), intPtr(5), nil, nil, &before, nil)
+	assertGQLErr(t, err, "BAD_USER_INPUT", "before")
+	if users.listCalls != 0 {
+		t.Fatalf("expected no repo call, got %d", users.listCalls)
+	}
+}
+
+// TestAdminUser_List_LastWithAfter rejects pairing backward count with the
+// forward cursor.
+func TestAdminUser_List_LastWithAfter(t *testing.T) {
+	t.Parallel()
+
+	users := &mockAdminUserRepository{}
+	authChk := &adminAuthChecker{admins: map[string]bool{"admin-1": true}}
+	uc, _, _ := buildAdminUC(users, nil, authChk)
+
+	after := "u-a"
+	_, err := uc.List(adminCallerCtx("admin-1"), nil, intPtr(5), &after, nil, nil)
+	assertGQLErr(t, err, "BAD_USER_INPUT", "after")
+	if users.listCalls != 0 {
+		t.Fatalf("expected no repo call, got %d", users.listCalls)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Get
 // ---------------------------------------------------------------------------
@@ -657,6 +709,52 @@ func TestAdminUser_AssignRole_Idempotent(t *testing.T) {
 		t.Fatalf("repo assign args = (%q,%q), want (u-target, r-admin)",
 			roles.lastAssignUID, roles.lastAssignRID)
 	}
+}
+
+// TestAdminUser_AssignRole_UserNotFound_FieldUserId asserts that a missing
+// user surfaces a BAD_USER_INPUT keyed on userId — not on roleId. The
+// repository must emit ErrUserNotFound for this branch to trigger.
+func TestAdminUser_AssignRole_UserNotFound_FieldUserId(t *testing.T) {
+	t.Parallel()
+
+	users := &mockAdminUserRepository{}
+	roles := &mockAdminRoleRepository{assignErr: repository.ErrUserNotFound}
+	authChk := &adminAuthChecker{admins: map[string]bool{"admin-1": true}}
+	uc, _, _ := buildAdminUC(users, roles, authChk)
+
+	_, err := uc.AssignRole(adminCallerCtx("admin-1"), "missing-user", "r-admin")
+	assertGQLErr(t, err, "BAD_USER_INPUT", "userId")
+}
+
+// TestAdminUser_AssignRole_RoleNotFound_FieldRoleId asserts that a missing
+// role surfaces BAD_USER_INPUT keyed on roleId — the previous behaviour
+// blamed userId for both cases, which broke the frontend banner-by-field.
+func TestAdminUser_AssignRole_RoleNotFound_FieldRoleId(t *testing.T) {
+	t.Parallel()
+
+	users := &mockAdminUserRepository{}
+	roles := &mockAdminRoleRepository{assignErr: repository.ErrRoleNotFound}
+	authChk := &adminAuthChecker{admins: map[string]bool{"admin-1": true}}
+	uc, _, _ := buildAdminUC(users, roles, authChk)
+
+	_, err := uc.AssignRole(adminCallerCtx("admin-1"), "u-target", "missing-role")
+	assertGQLErr(t, err, "BAD_USER_INPUT", "roleId")
+}
+
+// TestAdminUser_AssignRole_LegacyErrNotFound_FieldUserId covers the fallback
+// branch: a repository that surfaces only the legacy ErrNotFound (e.g. a
+// stub that has not been migrated) keeps the existing userId field so older
+// callers do not regress to INTERNAL.
+func TestAdminUser_AssignRole_LegacyErrNotFound_FieldUserId(t *testing.T) {
+	t.Parallel()
+
+	users := &mockAdminUserRepository{}
+	roles := &mockAdminRoleRepository{assignErr: repository.ErrNotFound}
+	authChk := &adminAuthChecker{admins: map[string]bool{"admin-1": true}}
+	uc, _, _ := buildAdminUC(users, roles, authChk)
+
+	_, err := uc.AssignRole(adminCallerCtx("admin-1"), "u-target", "r-admin")
+	assertGQLErr(t, err, "BAD_USER_INPUT", "userId")
 }
 
 // ---------------------------------------------------------------------------
@@ -906,5 +1004,58 @@ func TestAdminUser_ListRoles_Cancelled(t *testing.T) {
 	uc, _, _ := buildAdminUC(nil, roles, authChk)
 
 	_, err := uc.ListRoles(adminCallerCtx("admin-1"))
+	assertGQLErr(t, err, "CANCELLED", "")
+}
+
+// ---------------------------------------------------------------------------
+// Update edge cases (I8)
+// ---------------------------------------------------------------------------
+
+// TestAdminUser_Update_NotFound verifies that when the user repository returns
+// ErrNotFound from Update, the usecase translates it to BAD_USER_INPUT with
+// field == "id". The caller supplied an unknown user ID.
+func TestAdminUser_Update_NotFound(t *testing.T) {
+	t.Parallel()
+
+	users := &mockAdminUserRepository{updateErr: repository.ErrNotFound}
+	authChk := &adminAuthChecker{admins: map[string]bool{"admin-1": true}}
+	uc, _, _ := buildAdminUC(users, nil, authChk)
+
+	_, err := uc.Update(adminCallerCtx("admin-1"), "missing-user", AdminUpdateUserInput{
+		DisplayName: ptr("Valid Name"),
+	})
+	assertGQLErr(t, err, "BAD_USER_INPUT", "id")
+}
+
+// TestAdminUser_Update_BioOverMax verifies that a bio of 501 grapheme clusters
+// is rejected with BAD_USER_INPUT keyed on "bio" before the repository is
+// reached.
+func TestAdminUser_Update_BioOverMax(t *testing.T) {
+	t.Parallel()
+
+	users := &mockAdminUserRepository{}
+	authChk := &adminAuthChecker{admins: map[string]bool{"admin-1": true}}
+	uc, _, _ := buildAdminUC(users, nil, authChk)
+
+	overMax := strings.Repeat("b", bioMax+1)
+	_, err := uc.Update(adminCallerCtx("admin-1"), "u-target", AdminUpdateUserInput{
+		Bio: ptr(overMax),
+	})
+	assertGQLErr(t, err, "BAD_USER_INPUT", "bio")
+	if users.updateCalls != 0 {
+		t.Fatalf("expected no repo update on validation failure, got %d", users.updateCalls)
+	}
+}
+
+// TestAdminUser_Get_Cancelled verifies that a cancelled context from the
+// repository FindByID call propagates as CANCELLED rather than INTERNAL.
+func TestAdminUser_Get_Cancelled(t *testing.T) {
+	t.Parallel()
+
+	users := &mockAdminUserRepository{findErr: context.Canceled}
+	authChk := &adminAuthChecker{admins: map[string]bool{"admin-1": true}}
+	uc, _, _ := buildAdminUC(users, nil, authChk)
+
+	_, err := uc.Get(adminCallerCtx("admin-1"), "u-target")
 	assertGQLErr(t, err, "CANCELLED", "")
 }

--- a/docs/backend-auth.md
+++ b/docs/backend-auth.md
@@ -77,6 +77,45 @@ See also the general env-vars table above.
 
 All three are required. `ConfigFromEnv()` returns an error and the server fails to start if any is missing or empty — silent misconfiguration is not allowed.
 
+### Authorization gates: object-level vs. field-level
+
+A `@hasRole(ADMIN)`-style gate on a top-level query (e.g. `Query.users`) does **not** protect fields on the returned type that any other resolver might also expose. `User.roles` is reachable from `me`, `cardgroup.owner`, and any future resolver that returns a `User` — the admin-only gate on `Query.users` covers exactly one of those entry points.
+
+Field-level resolvers that expose privileged data must perform their own admin-or-self check inside the field resolver itself:
+
+```go
+func (r *userResolver) Roles(ctx context.Context, obj *model.User) ([]*model.Role, error) {
+    caller := auth.UserFrom(ctx)
+    if caller == nil {
+        return nil, gqlerr.Unauthenticated()
+    }
+    if caller.Sub != obj.ID {
+        isAdmin, err := r.AuthSvc.IsAdmin(ctx, caller.Sub)
+        if err != nil { /* propagate context.Canceled, else gqlerr.Internal */ }
+        if !isAdmin {
+            return nil, gqlerr.NewForbidden("forbidden")
+        }
+    }
+    // ...
+}
+```
+
+The "self or admin" check is the right granularity for fields where the owning user has a legitimate read interest in their own data; pure admin-only fields drop the `caller.Sub != obj.ID` branch.
+
+### Self-demotion guard
+
+A user who is allowed to assign and revoke roles can also revoke their own admin role and lock the system out of admin operations. The usecase layer must reject "the caller is removing the admin role from themselves" before the DB write:
+
+1. Compare `callerID == targetUserID`.
+2. Look up the role being revoked and check whether its name is `"admin"`.
+3. If both, return `gqlerr.NewForbidden("cannot remove your own admin role")`.
+
+This guard belongs in the usecase, not in the UI: the UI is one of N possible callers, and a CLI / API consumer / Apollo Studio request can hit the resolver directly. The role-name lookup is mandatory — comparing role IDs would couple the guard to seed data that varies between environments. The hardcoded `"admin"` matches `auth.Service.IsAdmin`'s same hardcoded literal; both move together when a second privileged role is introduced.
+
+### Multi-layer security test coverage
+
+Authorization rules implemented at the usecase level need tests at **both** the usecase layer and the resolver layer. Usecase tests confirm the rule (right sentinel returned, right error code mapped) but cannot catch wire-format regressions: an `extensions.code` typo, a resolver that swallows the usecase error and returns `nil`, or a gqlgen codec change that drops the `field` extension. Resolver-level wire tests built against `handler.NewServer` (see `docs/backend.md` § "Resolver-level wire tests") are the only layer that exercises the full request envelope. Apply this dual-layer rule to every guard whose failure mode is "user gains access they should not have" — privilege checks, owner checks, self-demotion, and role-mutation paths.
+
 ### Echo v5 + gqlgen error propagation
 
 `echo.WrapHandler` (v5) converts a `http.Handler` into an `echo.HandlerFunc` that always returns `nil`. gqlgen's `handler.Server` is an `http.Handler`: it writes GraphQL errors into the response body as `{"errors":[...]}` with HTTP 200, and only ever writes a 5xx for catastrophic transport failures. Because `WrapHandler` returns `nil`, Echo's central error pipeline never sees these, which is fine: the GraphQL error is already transported in-band. Do **not** wrap gqlgen with a custom adapter that translates non-2xx into `echo.NewHTTPError` — that would cause a double write on the already-committed `ResponseWriter`.

--- a/docs/backend-graphql.md
+++ b/docs/backend-graphql.md
@@ -102,6 +102,17 @@ Both operations require an authenticated caller. When `auth.UserFrom(ctx)` retur
 
 This three-state pointer distinction is preserved end-to-end: schema (`bio: String`) → gqlgen model (`Bio *string`) → `usecase.UpdateUserInput.Bio *string` → `repository.UserUpdate.Bio *string`. Never collapse it to a plain `string` default.
 
+### Per-field "null vs. empty" semantics on partial-update inputs
+
+A single uniform statement on the input type ("null = unchanged, empty = clear") lies the moment the input mixes optional clearable fields with optional required-when-present fields. `AdminUpdateUserInput` is the canonical example:
+
+| Field | `nil` (omitted) | `""` (present, empty) |
+|---|---|---|
+| `bio` | leave unchanged | explicit clear |
+| `displayName` | leave unchanged | rejected as `BAD_USER_INPUT` (the field has a 1-char minimum) |
+
+The schema docstring on each `*string` field must state which of the two empty-string semantics applies. Clients reading a generic "null = unchanged, empty = clear" rule will write `displayName: ""` to mean "clear" and the mutation will fail at runtime with a confusing validation error. State the per-field contract on the field, not on the input type.
+
 ### Layering rule
 
 ```
@@ -298,7 +309,12 @@ as the input keys. dataloader/v7 enforces this 1:1 invariant at runtime.
 4. Initialise it in `loader.New(...)` and pass its repository through `loader.Middleware(...)`.
 5. Add the new repository parameter to `newGraphQLTestServer` (and any test-server variants) in `cmd/server/main_test.go`.
 
-**Loader test contract:** A loader test must verify both (a) the batch function was called exactly once (dedup working) AND (b) it received the expected number of distinct keys. Without (b), key collisions or dedup bugs can go undetected.
+**Loader test contract:** A loader test must verify both (a) the batch function was called exactly once (dedup working) AND (b) it received the expected number of distinct keys. Without (b), key collisions or dedup bugs can go undetected. The mock must also **record the actual batch keys it received** (not just a call counter); a loader test that asserts only "called once" cannot distinguish a correct batch of N from a bug that fans out N single-key calls when the underlying batcher coincidentally collapses them.
+
+**Key → slice loaders for one-to-many.** A user-to-roles relation has many roles per user, so the loader signature is `dataloader.Loader[string, []*domain.Role]` — the value type is a **slice**, not a pointer-to-entity. Two non-obvious rules follow:
+
+1. **Return `[]*domain.Role{}` (empty slice) — not `nil` — for a key with zero children.** A `nil` slice marshals to JSON `null`, while a non-nullable list field (`roles: [Role!]!`) requires `[]`. Returning `nil` produces a `null` payload that the gqlgen runtime then rejects as a non-nullable violation, surfaced as `INTERNAL` rather than the empty list the schema actually expects.
+2. **Drive the batch with one SQL JOIN, not N individual lookups.** The `FindByUserIDs` repository method runs `SELECT ... FROM user_roles JOIN roles ... WHERE user_id IN (?)` and groups results into `map[userID][]*Role` in Go. A naive batch function that loops `for _, id := range ids { repo.FindByUserID(id) }` defeats the entire point of DataLoader — it produces N round-trips per request despite the loader interface looking correct from the outside.
 
 **Loader error wrapping:** Every resolver that calls `loaders.X.Load(ctx, key)()` must wrap the returned error via `gqlerr.Internal(ctx, err)` (or another typed gqlerr) before returning. Bare loader errors have no `extensions.code` and leak internal details.
 

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -191,6 +191,26 @@ try {
 
 The helper string-matches `UNAUTHENTICATED` in the error message and calls `redirect(target)`; all other errors are rethrown to the nearest error boundary. Two redirect targets are in use: `/login` for session-expired or no-session cases (checked before `gqlFetch` via `supabase.auth.getUser()`), and `/cardgroups` for cross-user-access on inner pages. See [Backend error-code contract](#backend-error-code-contract) for why these two cases both surface as `UNAUTHENTICATED`.
 
+### RSC FORBIDDEN redirect pattern
+
+Admin-only pages (e.g. `/admin/users`, `/admin/users/[id]`) must explicitly handle the `FORBIDDEN` code in their RSC `try/catch`. Unlike `UNAUTHENTICATED` (where `redirectIfUnauthenticated` covers it), an unhandled `FORBIDDEN` rethrows to the nearest error boundary and Next.js renders a 500 — wrong UX for "you are signed in but lack the role". RSC pages call `redirect("/")` (or `/admin` if the user might still belong somewhere) on `FORBIDDEN`:
+
+```ts
+try {
+  data = await gqlFetch(AdminUsersQuery, { variables, revalidate: 0 });
+} catch (err) {
+  redirectIfUnauthenticated(err, "/login");
+  if (isForbidden(err)) redirect("/");
+  throw err;
+}
+```
+
+Pair the SSR redirect with a **client-side classifier** for mid-session role revocation: a user who lands on the page as admin and then has the role revoked while the page is open will see the next mutation fail with `FORBIDDEN`. A discriminated-union classifier (`classifyQueryError(err): { kind: "forbidden" | "unauthenticated" | "internal" | ... }`) lets the client component branch into a banner or a redirect without inlining string-matches at every call site.
+
+### Mutations that can return `FORBIDDEN` should not use `optimisticResponse`
+
+When a mutation can plausibly return `FORBIDDEN` or `BAD_USER_INPUT` (admin role assignment, self-demotion, etc.), drop `optimisticResponse` entirely. Apollo v3.x rolls back optimistic writes on network errors but not consistently on typed GraphQL errors, so the cache holds the optimistic write while the server has rejected the change. See `.claude/rules/pagination.md` § "Drop `optimisticResponse` for mutations that can fail with typed GraphQL errors" for the full rule.
+
 ### Zod schema convention
 
 Validation schemas live in `frontend/src/schemas/*.ts` and mirror their corresponding GraphQL `Input` types. Example: `frontend/src/schemas/profile.ts` mirrors `UpdateProfileInput`.

--- a/frontend/__tests__/admin-users-list.test.tsx
+++ b/frontend/__tests__/admin-users-list.test.tsx
@@ -1,0 +1,564 @@
+// @vitest-environment jsdom
+import { InMemoryCache, NetworkStatus } from "@apollo/client";
+import { MockedProvider } from "@apollo/client/testing/react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { AdminUsersClient } from "@/app/admin/users/AdminUsersClient";
+import { AdminUsersDocument } from "@/generated/graphql";
+import { ADMIN_USERS_PAGE_SIZE } from "@/app/admin/users/queries";
+
+// ---------------------------------------------------------------------------
+// Next.js stubs
+// ---------------------------------------------------------------------------
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    ...rest
+  }: {
+    href: string;
+    children: React.ReactNode;
+    [key: string]: unknown;
+  }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("next/image", () => ({
+  default: ({
+    src,
+    alt,
+    width,
+    height,
+    ...rest
+  }: {
+    src: string;
+    alt: string;
+    width: number;
+    height: number;
+    [key: string]: unknown;
+  }) => (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img src={src} alt={alt} width={width} height={height} {...rest} />
+  ),
+}));
+
+// ---------------------------------------------------------------------------
+// Data fixtures
+// ---------------------------------------------------------------------------
+
+type UserNode = {
+  __typename: "User";
+  id: string;
+  displayName: string;
+  bio: null;
+  avatarUrl: null;
+  roles: Array<{ __typename: "Role"; id: string; name: string }>;
+};
+
+type UserEdge = {
+  __typename: "UserEdge";
+  cursor: string;
+  node: UserNode;
+};
+
+function makeUser(i: number): UserNode {
+  return {
+    __typename: "User",
+    id: `user-${i}`,
+    displayName: `User ${i}`,
+    bio: null,
+    avatarUrl: null,
+    roles: [{ __typename: "Role", id: `role-general`, name: "general" }],
+  };
+}
+
+function makeEdge(user: UserNode): UserEdge {
+  return {
+    __typename: "UserEdge",
+    cursor: user.id,
+    node: user,
+  };
+}
+
+function makeConnection(
+  users: UserNode[],
+  hasNextPage: boolean,
+): {
+  __typename: "UserConnection";
+  edges: UserEdge[];
+  pageInfo: {
+    __typename: "PageInfo";
+    hasNextPage: boolean;
+    hasPreviousPage: boolean;
+    startCursor: string | null;
+    endCursor: string | null;
+  };
+  totalCount: number;
+} {
+  return {
+    __typename: "UserConnection",
+    edges: users.map(makeEdge),
+    pageInfo: {
+      __typename: "PageInfo",
+      hasNextPage,
+      hasPreviousPage: false,
+      startCursor: users[0]?.id ?? null,
+      endCursor: users[users.length - 1]?.id ?? null,
+    },
+    totalCount: users.length,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// IntersectionObserver mock (mirrors cards-pagination.test.tsx verbatim)
+// ---------------------------------------------------------------------------
+
+let ioCallbacks: IntersectionObserverCallback[] = [];
+
+class FakeIntersectionObserver {
+  callback: IntersectionObserverCallback;
+  constructor(cb: IntersectionObserverCallback) {
+    this.callback = cb;
+    ioCallbacks.push(cb);
+  }
+  observe() {}
+  unobserve() {}
+  disconnect() {
+    ioCallbacks = ioCallbacks.filter((cb) => cb !== this.callback);
+  }
+  takeRecords(): IntersectionObserverEntry[] {
+    return [];
+  }
+}
+
+function fireIntersect() {
+  const cb = ioCallbacks[ioCallbacks.length - 1];
+  if (!cb) return;
+  cb(
+    [{ isIntersecting: true } as IntersectionObserverEntry],
+    {} as IntersectionObserver,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// console spy helpers
+// ---------------------------------------------------------------------------
+
+let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
+let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  ioCallbacks = [];
+  vi.stubGlobal("IntersectionObserver", FakeIntersectionObserver);
+  consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("AdminUsersClient", () => {
+  // T1: Initial render — edges, display names, role badges, and totalCount shown.
+  test("renders edges with display name and role badges and shows totalCount", async () => {
+    const users = Array.from({ length: 3 }, (_, i) => makeUser(i + 1));
+    const connection = makeConnection(users, false);
+
+    const mocks = [
+      {
+        request: {
+          query: AdminUsersDocument,
+          variables: { first: ADMIN_USERS_PAGE_SIZE, search: null },
+        },
+        result: { data: { users: connection } },
+      },
+    ];
+
+    const cache = new InMemoryCache();
+    cache.writeQuery({
+      query: AdminUsersDocument,
+      variables: { first: ADMIN_USERS_PAGE_SIZE, search: null },
+      data: { users: connection },
+    });
+
+    render(
+      <MockedProvider mocks={mocks as never} cache={cache}>
+        <AdminUsersClient />
+      </MockedProvider>,
+    );
+
+    // Display names visible.
+    expect(await screen.findByText("User 1")).toBeInTheDocument();
+    expect(screen.getByText("User 2")).toBeInTheDocument();
+    expect(screen.getByText("User 3")).toBeInTheDocument();
+
+    // Role badges visible for each user.
+    const roleBadges = screen.getAllByText("general");
+    expect(roleBadges.length).toBe(3);
+
+    // totalCount shown (3 in parens).
+    expect(screen.getByText("(3)")).toBeInTheDocument();
+  });
+
+  // T2: Debounced search — typing "ali" issues ONE query with search:"ali" after 300ms.
+  test('debounced search issues AdminUsersDocument exactly once with search "ali" after 300ms', async () => {
+    const user = userEvent.setup({ delay: null });
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+
+    const initialUsers = Array.from({ length: 2 }, (_, i) => makeUser(i + 1));
+    const searchUsers = [
+      {
+        __typename: "User" as const,
+        id: "user-ali",
+        displayName: "Alice",
+        bio: null,
+        avatarUrl: null,
+        roles: [{ __typename: "Role" as const, id: "role-general", name: "general" }],
+      },
+    ];
+
+    let searchQueryCalls = 0;
+    const searchResult = vi.fn(() => {
+      searchQueryCalls += 1;
+      return { data: { users: makeConnection(searchUsers, false) } };
+    });
+
+    const mocks = [
+      {
+        request: {
+          query: AdminUsersDocument,
+          variables: { first: ADMIN_USERS_PAGE_SIZE, search: null },
+        },
+        result: { data: { users: makeConnection(initialUsers, false) } },
+      },
+      {
+        request: {
+          query: AdminUsersDocument,
+          variables: { first: ADMIN_USERS_PAGE_SIZE, search: "ali" },
+        },
+        result: searchResult,
+      },
+    ];
+
+    const cache = new InMemoryCache();
+    cache.writeQuery({
+      query: AdminUsersDocument,
+      variables: { first: ADMIN_USERS_PAGE_SIZE, search: null },
+      data: { users: makeConnection(initialUsers, false) },
+    });
+
+    render(
+      <MockedProvider mocks={mocks as never} cache={cache}>
+        <AdminUsersClient />
+      </MockedProvider>,
+    );
+
+    // Initial render present.
+    expect(await screen.findByText("User 1")).toBeInTheDocument();
+
+    const searchInput = screen.getByRole("searchbox", { name: /search users/i });
+
+    // Type "ali" — three keystrokes, each resets the debounce timer.
+    await user.type(searchInput, "ali");
+
+    // Advance past the debounce window.
+    vi.advanceTimersByTime(300);
+
+    // Restore real timers before waiting for DOM updates.
+    vi.useRealTimers();
+
+    await waitFor(() => {
+      expect(screen.getByText("Alice")).toBeInTheDocument();
+    });
+
+    // The query must have fired exactly once — not once per keystroke.
+    expect(searchQueryCalls).toBe(1);
+  });
+
+  // T3: In-flight guard — two observer firings in the same frame produce one fetchMore.
+  test("IntersectionObserver fires fetchMore exactly once when triggered twice in-flight", async () => {
+    const firstBatch = Array.from({ length: 20 }, (_, i) => makeUser(i + 1));
+    const secondBatch = Array.from({ length: 20 }, (_, i) => makeUser(i + 21));
+
+    let nextPageCalls = 0;
+    const nextPageResult = vi.fn(() => {
+      nextPageCalls += 1;
+      return { data: { users: makeConnection(secondBatch, false) } };
+    });
+
+    const mocks = [
+      {
+        request: {
+          query: AdminUsersDocument,
+          variables: { first: ADMIN_USERS_PAGE_SIZE, search: null },
+        },
+        result: { data: { users: makeConnection(firstBatch, true) } },
+      },
+      {
+        request: {
+          query: AdminUsersDocument,
+          variables: {
+            first: ADMIN_USERS_PAGE_SIZE,
+            after: `user-${firstBatch.length}`,
+            search: null,
+          },
+        },
+        delay: 50,
+        result: nextPageResult,
+      },
+    ];
+
+    const cache = new InMemoryCache();
+    cache.writeQuery({
+      query: AdminUsersDocument,
+      variables: { first: ADMIN_USERS_PAGE_SIZE, search: null },
+      data: { users: makeConnection(firstBatch, true) },
+    });
+
+    render(
+      <MockedProvider mocks={mocks as never} cache={cache}>
+        <AdminUsersClient />
+      </MockedProvider>,
+    );
+
+    expect(await screen.findByText("User 1")).toBeInTheDocument();
+
+    // Synchronously fire the observer twice — only the first must reach fetchMore.
+    fireIntersect();
+    fireIntersect();
+
+    await waitFor(() => {
+      expect(screen.getByText("User 21")).toBeInTheDocument();
+    });
+
+    expect(nextPageCalls).toBe(1);
+  });
+
+  // T4: fetchMoreError halts the IO loop; Retry clears the banner and re-issues.
+  test("fetchMoreError stops the IO loop and Retry re-issues the request", async () => {
+    const user = userEvent.setup({ delay: null });
+    const firstBatch = Array.from({ length: 20 }, (_, i) => makeUser(i + 1));
+    const secondBatch = Array.from({ length: 20 }, (_, i) => makeUser(i + 21));
+    const endCursor = `user-${firstBatch.length}`;
+
+    let fetchMoreCallCount = 0;
+
+    const failResult = vi.fn(() => {
+      fetchMoreCallCount += 1;
+      return {
+        errors: [{ message: "Could not load more users. Please try again." }],
+      };
+    });
+
+    const successResult = vi.fn(() => {
+      fetchMoreCallCount += 1;
+      return { data: { users: makeConnection(secondBatch, false) } };
+    });
+
+    const fetchMoreVars = {
+      first: ADMIN_USERS_PAGE_SIZE,
+      after: endCursor,
+      search: null,
+    };
+
+    const mocks = [
+      {
+        request: {
+          query: AdminUsersDocument,
+          variables: { first: ADMIN_USERS_PAGE_SIZE, search: null },
+        },
+        result: { data: { users: makeConnection(firstBatch, true) } },
+      },
+      // First fetchMore fails.
+      {
+        request: {
+          query: AdminUsersDocument,
+          variables: fetchMoreVars,
+        },
+        result: failResult,
+      },
+      // After Retry, the next fetchMore succeeds.
+      {
+        request: {
+          query: AdminUsersDocument,
+          variables: fetchMoreVars,
+        },
+        result: successResult,
+      },
+    ];
+
+    const cache = new InMemoryCache();
+    cache.writeQuery({
+      query: AdminUsersDocument,
+      variables: { first: ADMIN_USERS_PAGE_SIZE, search: null },
+      data: { users: makeConnection(firstBatch, true) },
+    });
+
+    render(
+      <MockedProvider mocks={mocks as never} cache={cache}>
+        <AdminUsersClient />
+      </MockedProvider>,
+    );
+
+    expect(await screen.findByText("User 1")).toBeInTheDocument();
+
+    // Trigger the observer — first fetchMore fails.
+    fireIntersect();
+
+    const banner = await screen.findByTestId("admin-users-fetch-more-error");
+    expect(banner).toBeInTheDocument();
+    expect(fetchMoreCallCount).toBe(1);
+
+    // While the error banner is present, firing the observer again must NOT issue fetchMore.
+    fireIntersect();
+    fireIntersect();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(fetchMoreCallCount).toBe(1);
+
+    // Click Retry — the banner clears and the second request (success) fires.
+    await user.click(screen.getByRole("button", { name: /retry/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("User 21")).toBeInTheDocument();
+    });
+
+    expect(screen.queryByTestId("admin-users-fetch-more-error")).not.toBeInTheDocument();
+    // fetchMoreCallCount is now 2 (1 fail + 1 success via Retry).
+    expect(fetchMoreCallCount).toBe(2);
+  });
+
+  // T5: MockedProvider leak detection — no "No more mocked responses" warning fires.
+  test("no MockedProvider leak warning fires for AdminUsers after one fetchMore", async () => {
+    const firstBatch = Array.from({ length: 20 }, (_, i) => makeUser(i + 1));
+    const secondBatch = Array.from({ length: 20 }, (_, i) => makeUser(i + 21));
+    const endCursor = `user-${firstBatch.length}`;
+
+    const mocks = [
+      {
+        request: {
+          query: AdminUsersDocument,
+          variables: { first: ADMIN_USERS_PAGE_SIZE, search: null },
+        },
+        result: { data: { users: makeConnection(firstBatch, true) } },
+      },
+      {
+        request: {
+          query: AdminUsersDocument,
+          variables: {
+            first: ADMIN_USERS_PAGE_SIZE,
+            after: endCursor,
+            search: null,
+          },
+        },
+        result: { data: { users: makeConnection(secondBatch, false) } },
+      },
+    ];
+
+    const cache = new InMemoryCache();
+    cache.writeQuery({
+      query: AdminUsersDocument,
+      variables: { first: ADMIN_USERS_PAGE_SIZE, search: null },
+      data: { users: makeConnection(firstBatch, true) },
+    });
+
+    render(
+      <MockedProvider mocks={mocks as never} cache={cache}>
+        <AdminUsersClient />
+      </MockedProvider>,
+    );
+
+    expect(await screen.findByText("User 1")).toBeInTheDocument();
+
+    fireIntersect();
+
+    await waitFor(() => {
+      expect(screen.getByText("User 21")).toBeInTheDocument();
+    });
+
+    // No "No more mocked responses for the query AdminUsers" warning should have fired.
+    const adminUsersLeakWarnings = consoleWarnSpy.mock.calls.filter((args: unknown[]) =>
+      args.some(
+        (arg: unknown) => typeof arg === "string" && arg.includes("AdminUsers"),
+      ),
+    );
+    expect(adminUsersLeakWarnings).toEqual([]);
+  });
+
+  // T6: NetworkStatus.fetchMore indicator — "Loading more" shown while in-flight, cleared on resolve.
+  // Uses the named NetworkStatus.fetchMore enum (value 3) rather than a magic number.
+  test("shows loading-more indicator while fetchMore is in flight using named NetworkStatus.fetchMore", async () => {
+    const firstBatch = Array.from({ length: 20 }, (_, i) => makeUser(i + 1));
+    const secondBatch = Array.from({ length: 20 }, (_, i) => makeUser(i + 21));
+    const endCursor = `user-${firstBatch.length}`;
+
+    // Explicit assertion that the named enum matches the expected value —
+    // guards against magic-number drift without coupling to the number itself.
+    expect(NetworkStatus.fetchMore).toBe(3);
+
+    const mocks = [
+      {
+        request: {
+          query: AdminUsersDocument,
+          variables: { first: ADMIN_USERS_PAGE_SIZE, search: null },
+        },
+        result: { data: { users: makeConnection(firstBatch, true) } },
+      },
+      // A 200ms delay keeps the fetchMore in-flight long enough for the indicator check.
+      {
+        request: {
+          query: AdminUsersDocument,
+          variables: {
+            first: ADMIN_USERS_PAGE_SIZE,
+            after: endCursor,
+            search: null,
+          },
+        },
+        delay: 200,
+        result: { data: { users: makeConnection(secondBatch, false) } },
+      },
+    ];
+
+    const cache = new InMemoryCache();
+    cache.writeQuery({
+      query: AdminUsersDocument,
+      variables: { first: ADMIN_USERS_PAGE_SIZE, search: null },
+      data: { users: makeConnection(firstBatch, true) },
+    });
+
+    render(
+      <MockedProvider mocks={mocks as never} cache={cache}>
+        <AdminUsersClient />
+      </MockedProvider>,
+    );
+
+    expect(await screen.findByText("User 1")).toBeInTheDocument();
+
+    // Trigger the observer — fetchMore is now in-flight (delayed 200ms).
+    fireIntersect();
+
+    // The "Loading more users..." indicator must appear while the request is in-flight.
+    const indicator = await screen.findByTestId("admin-users-loading-more");
+    expect(indicator).toBeInTheDocument();
+
+    // After the delay resolves, the indicator must disappear and the second batch renders.
+    await waitFor(
+      () => {
+        expect(screen.queryByTestId("admin-users-loading-more")).not.toBeInTheDocument();
+      },
+      { timeout: 1000 },
+    );
+
+    expect(screen.getByText("User 21")).toBeInTheDocument();
+  });
+});

--- a/frontend/__tests__/admin-users-list.test.tsx
+++ b/frontend/__tests__/admin-users-list.test.tsx
@@ -3,14 +3,19 @@ import { InMemoryCache, NetworkStatus } from "@apollo/client";
 import { MockedProvider } from "@apollo/client/testing/react";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { GraphQLError } from "graphql";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { AdminUsersClient } from "@/app/admin/users/AdminUsersClient";
-import { AdminUsersDocument } from "@/generated/graphql";
 import { ADMIN_USERS_PAGE_SIZE } from "@/app/admin/users/queries";
+import { AdminUsersDocument } from "@/generated/graphql";
 
 // ---------------------------------------------------------------------------
 // Next.js stubs
 // ---------------------------------------------------------------------------
+
+vi.mock("next/navigation", () => ({
+  redirect: vi.fn(),
+}));
 
 vi.mock("next/link", () => ({
   default: ({
@@ -139,10 +144,7 @@ class FakeIntersectionObserver {
 function fireIntersect() {
   const cb = ioCallbacks[ioCallbacks.length - 1];
   if (!cb) return;
-  cb(
-    [{ isIntersecting: true } as IntersectionObserverEntry],
-    {} as IntersectionObserver,
-  );
+  cb([{ isIntersecting: true } as IntersectionObserverEntry], {} as IntersectionObserver);
 }
 
 // ---------------------------------------------------------------------------
@@ -343,6 +345,19 @@ describe("AdminUsersClient", () => {
     });
 
     expect(nextPageCalls).toBe(1);
+
+    // If the ref-guard were replaced with useState, a second fetchMore would leak
+    // into MockedProvider and emit a "No more mocked responses" console.warn.
+    // Assert that no such warning fired for the AdminUsers query.
+    const adminUsersWarn = consoleWarnSpy.mock.calls.flatMap((args: unknown[]) =>
+      args.filter(
+        (a): a is string =>
+          typeof a === "string" &&
+          a.includes("No more mocked responses") &&
+          a.includes("AdminUsers"),
+      ),
+    );
+    expect(adminUsersWarn).toEqual([]);
   });
 
   // T4: fetchMoreError halts the IO loop; Retry clears the banner and re-issues.
@@ -488,9 +503,7 @@ describe("AdminUsersClient", () => {
 
     // No "No more mocked responses for the query AdminUsers" warning should have fired.
     const adminUsersLeakWarnings = consoleWarnSpy.mock.calls.filter((args: unknown[]) =>
-      args.some(
-        (arg: unknown) => typeof arg === "string" && arg.includes("AdminUsers"),
-      ),
+      args.some((arg: unknown) => typeof arg === "string" && arg.includes("AdminUsers")),
     );
     expect(adminUsersLeakWarnings).toEqual([]);
   });
@@ -560,5 +573,38 @@ describe("AdminUsersClient", () => {
     );
 
     expect(screen.getByText("User 21")).toBeInTheDocument();
+  });
+
+  // T7: FORBIDDEN query error — non-retry permission banner; no Retry button.
+  test("renders permission-denied banner without Retry when AdminUsers returns FORBIDDEN", async () => {
+    const mocks = [
+      {
+        request: {
+          query: AdminUsersDocument,
+          variables: { first: ADMIN_USERS_PAGE_SIZE, search: null },
+        },
+        result: {
+          errors: [
+            new GraphQLError("admin role required", {
+              extensions: { code: "FORBIDDEN" },
+            }),
+          ],
+        },
+      },
+    ];
+
+    render(
+      <MockedProvider mocks={mocks as never}>
+        <AdminUsersClient />
+      </MockedProvider>,
+    );
+
+    // The permission-denied banner must appear.
+    const banner = await screen.findByTestId("admin-users-query-error");
+    expect(banner).toBeInTheDocument();
+    expect(banner).toHaveTextContent("You do not have permission to view this page.");
+
+    // No Retry button — re-issuing the same query would fail again.
+    expect(screen.queryByRole("button", { name: /retry/i })).not.toBeInTheDocument();
   });
 });

--- a/frontend/__tests__/admin-users-roles.test.tsx
+++ b/frontend/__tests__/admin-users-roles.test.tsx
@@ -4,70 +4,43 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { GraphQLError } from "graphql";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { RoleOption, UserForEdit } from "@/app/admin/users/[id]/edit/AdminUserEditClient";
 import { AdminUserEditClient } from "@/app/admin/users/[id]/edit/AdminUserEditClient";
-import {
-  AdminAssignRoleDocument,
-  AdminRevokeRoleDocument,
-  AdminRolesDocument,
-  AdminUserDocument,
-} from "@/generated/graphql";
+import { AdminAssignRoleDocument, AdminRevokeRoleDocument } from "@/generated/graphql";
 
 // ---------------------------------------------------------------------------
 // Fixture IDs
 // ---------------------------------------------------------------------------
 
 const USER_ID = "user-1";
-const CALLER_ID = "caller-99";
 const SELF_ADMIN_USER_ID = "admin-self-1";
 
 const ROLE_GENERAL_ID = "role-general";
 const ROLE_ADMIN_ID = "role-admin";
 
 // ---------------------------------------------------------------------------
-// Shared mock fragments
+// Shared fixture data
 // ---------------------------------------------------------------------------
 
-const ALL_ROLES_MOCK = {
-  request: {
-    query: AdminRolesDocument,
-    variables: {},
-  },
-  result: {
-    data: {
-      roles: [
-        { __typename: "Role", id: ROLE_GENERAL_ID, name: "general" },
-        { __typename: "Role", id: ROLE_ADMIN_ID, name: "admin" },
-      ],
-    },
-  },
-};
+const ALL_ROLES: RoleOption[] = [
+  { id: ROLE_GENERAL_ID, name: "general" },
+  { id: ROLE_ADMIN_ID, name: "admin" },
+];
 
-function makeAdminUserMock(userId: string, roleNames: string[]) {
+function makeUser(userId: string, roleNames: string[]): UserForEdit {
   const roleMap: Record<string, string> = {
     general: ROLE_GENERAL_ID,
     admin: ROLE_ADMIN_ID,
   };
   return {
-    request: {
-      query: AdminUserDocument,
-      variables: { id: userId },
-    },
-    result: {
-      data: {
-        adminUser: {
-          __typename: "User",
-          id: userId,
-          displayName: `User ${userId}`,
-          bio: null,
-          avatarUrl: null,
-          roles: roleNames.map((n) => ({
-            __typename: "Role",
-            id: roleMap[n] ?? `role-${n}`,
-            name: n,
-          })),
-        },
-      },
-    },
+    id: userId,
+    displayName: `User ${userId}`,
+    bio: null,
+    avatarUrl: null,
+    roles: roleNames.map((n) => ({
+      id: roleMap[n] ?? `role-${n}`,
+      name: n,
+    })),
   };
 }
 
@@ -89,13 +62,13 @@ afterEach(() => {
 });
 
 // ---------------------------------------------------------------------------
-// Helper renderer
+// Helper renderer — SSR-props mode (no AdminUserQuery / AdminRolesQuery needed)
 // ---------------------------------------------------------------------------
 
-function renderEdit(mocks: object[], userId: string, callerId?: string) {
+function renderEdit(mocks: object[], user: UserForEdit, allRoles: RoleOption[] = ALL_ROLES) {
   render(
     <MockedProvider mocks={mocks as never}>
-      <AdminUserEditClient userId={userId} callerId={callerId} />
+      <AdminUserEditClient user={user} allRoles={allRoles} />
     </MockedProvider>,
   );
 }
@@ -107,14 +80,9 @@ function renderEdit(mocks: object[], userId: string, callerId?: string) {
 describe("AdminUserEditClient — role assign / revoke flow", () => {
   // T1: Initial render — user has ["general"] role
   it("renders general checkbox checked and admin checkbox unchecked for a user with only general role", async () => {
-    renderEdit(
-      [makeAdminUserMock(USER_ID, ["general"]), ALL_ROLES_MOCK],
-      USER_ID,
-      CALLER_ID,
-    );
+    renderEdit([], makeUser(USER_ID, ["general"]));
 
-    // Wait for async data to load
-    const generalCheckbox = await screen.findByRole("checkbox", { name: /general/i });
+    const generalCheckbox = screen.getByRole("checkbox", { name: /general/i });
     const adminCheckbox = screen.getByRole("checkbox", { name: /admin/i });
 
     expect(generalCheckbox).toBeChecked();
@@ -153,14 +121,9 @@ describe("AdminUserEditClient — role assign / revoke flow", () => {
       result: assignResult,
     };
 
-    renderEdit(
-      [makeAdminUserMock(USER_ID, ["general"]), ALL_ROLES_MOCK, assignMock],
-      USER_ID,
-      CALLER_ID,
-    );
+    renderEdit([assignMock], makeUser(USER_ID, ["general"]));
 
-    // Wait for initial render
-    const adminCheckbox = await screen.findByRole("checkbox", { name: /admin/i });
+    const adminCheckbox = screen.getByRole("checkbox", { name: /admin/i });
     expect(adminCheckbox).not.toBeChecked();
 
     // Click to assign admin role
@@ -169,7 +132,7 @@ describe("AdminUserEditClient — role assign / revoke flow", () => {
     // Mutation should have fired exactly once
     await waitFor(() => expect(assignCalls).toBe(1));
 
-    // After optimistic response / mutation resolution, admin checkbox is checked
+    // After mutation resolution, admin checkbox is checked (from server-truth response)
     await waitFor(() => {
       expect(screen.getByRole("checkbox", { name: /admin/i })).toBeChecked();
     });
@@ -190,9 +153,7 @@ describe("AdminUserEditClient — role assign / revoke flow", () => {
             displayName: `User ${USER_ID}`,
             bio: null,
             avatarUrl: null,
-            roles: [
-              { __typename: "Role", id: ROLE_ADMIN_ID, name: "admin" },
-            ],
+            roles: [{ __typename: "Role", id: ROLE_ADMIN_ID, name: "admin" }],
           },
         },
       };
@@ -206,14 +167,10 @@ describe("AdminUserEditClient — role assign / revoke flow", () => {
       result: revokeResult,
     };
 
-    renderEdit(
-      [makeAdminUserMock(USER_ID, ["general", "admin"]), ALL_ROLES_MOCK, revokeMock],
-      USER_ID,
-      CALLER_ID,
-    );
+    renderEdit([revokeMock], makeUser(USER_ID, ["general", "admin"]));
 
-    // Wait for initial render — both checkboxes should be checked
-    const generalCheckbox = await screen.findByRole("checkbox", { name: /general/i });
+    // Both checkboxes should be checked
+    const generalCheckbox = screen.getByRole("checkbox", { name: /general/i });
     expect(generalCheckbox).toBeChecked();
     expect(screen.getByRole("checkbox", { name: /admin/i })).toBeChecked();
 
@@ -223,13 +180,15 @@ describe("AdminUserEditClient — role assign / revoke flow", () => {
     // Mutation should have fired exactly once
     await waitFor(() => expect(revokeCalls).toBe(1));
 
-    // After optimistic response / mutation resolution, general checkbox is unchecked
+    // After mutation resolution, general checkbox is unchecked (server-truth response)
     await waitFor(() => {
       expect(screen.getByRole("checkbox", { name: /general/i })).not.toBeChecked();
     });
   });
 
-  // T4: Self-demotion guard — FORBIDDEN error keeps checkbox checked, shows banner
+  // T4: Self-demotion guard — FORBIDDEN error keeps checkbox checked (server truth),
+  //     shows banner. Because there is no optimistic response, the checkbox never flips;
+  //     its state after the error matches the server-truth initial state (checked).
   it("shows FORBIDDEN banner and keeps admin checkbox checked when revoking own admin role", async () => {
     const user = userEvent.setup({ delay: null });
 
@@ -247,18 +206,10 @@ describe("AdminUserEditClient — role assign / revoke flow", () => {
       },
     };
 
-    renderEdit(
-      [
-        makeAdminUserMock(SELF_ADMIN_USER_ID, ["admin"]),
-        ALL_ROLES_MOCK,
-        selfDemotionRevokeMock,
-      ],
-      SELF_ADMIN_USER_ID,
-      SELF_ADMIN_USER_ID, // callerId === userId → same user
-    );
+    renderEdit([selfDemotionRevokeMock], makeUser(SELF_ADMIN_USER_ID, ["admin"]));
 
-    // Wait for initial render — admin checkbox should be checked
-    const adminCheckbox = await screen.findByRole("checkbox", { name: /admin/i });
+    // Admin checkbox should be checked initially
+    const adminCheckbox = screen.getByRole("checkbox", { name: /admin/i });
     expect(adminCheckbox).toBeChecked();
 
     // Attempt to uncheck (revoke own admin role)
@@ -268,7 +219,7 @@ describe("AdminUserEditClient — role assign / revoke flow", () => {
     const banner = await screen.findByRole("alert");
     expect(banner).toHaveTextContent("cannot revoke own admin role");
 
-    // Checkbox must remain checked (optimistic write rolled back)
+    // Checkbox must still be checked — server truth was never changed (no optimistic write)
     await waitFor(() => {
       expect(screen.getByRole("checkbox", { name: /admin/i })).toBeChecked();
     });
@@ -276,7 +227,7 @@ describe("AdminUserEditClient — role assign / revoke flow", () => {
 
   // T5: MockedProvider leak — no "no more mocked responses" warning for admin mutations
   it("does not produce MockedProvider leak warnings for admin role mutations across all test interactions", async () => {
-    // This test fires one assign and one revoke and verifies no duplicate-request warnings.
+    // This test fires one assign and verifies no duplicate-request warnings.
     const user = userEvent.setup({ delay: null });
 
     const assignMock = {
@@ -301,14 +252,9 @@ describe("AdminUserEditClient — role assign / revoke flow", () => {
       },
     };
 
-    renderEdit(
-      [makeAdminUserMock(USER_ID, ["general"]), ALL_ROLES_MOCK, assignMock],
-      USER_ID,
-      CALLER_ID,
-    );
+    renderEdit([assignMock], makeUser(USER_ID, ["general"]));
 
-    // Wait for initial render and click assign once
-    const adminCheckbox = await screen.findByRole("checkbox", { name: /admin/i });
+    const adminCheckbox = screen.getByRole("checkbox", { name: /admin/i });
     await user.click(adminCheckbox);
 
     // Allow all async work to settle
@@ -317,13 +263,12 @@ describe("AdminUserEditClient — role assign / revoke flow", () => {
     });
 
     // Verify no "No more mocked responses" warnings were emitted for the admin mutations
-    const adminMutationLeakWarnings = consoleWarnSpy.mock.calls.filter(
-      (args: unknown[]) =>
-        args.some(
-          (arg: unknown) =>
-            typeof arg === "string" &&
-            (arg.includes("AdminAssignRole") || arg.includes("AdminRevokeRole")),
-        ),
+    const adminMutationLeakWarnings = consoleWarnSpy.mock.calls.filter((args: unknown[]) =>
+      args.some(
+        (arg: unknown) =>
+          typeof arg === "string" &&
+          (arg.includes("AdminAssignRole") || arg.includes("AdminRevokeRole")),
+      ),
     );
     expect(adminMutationLeakWarnings).toEqual([]);
   });

--- a/frontend/__tests__/admin-users-roles.test.tsx
+++ b/frontend/__tests__/admin-users-roles.test.tsx
@@ -1,0 +1,330 @@
+// @vitest-environment jsdom
+import { MockedProvider } from "@apollo/client/testing/react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { GraphQLError } from "graphql";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AdminUserEditClient } from "@/app/admin/users/[id]/edit/AdminUserEditClient";
+import {
+  AdminAssignRoleDocument,
+  AdminRevokeRoleDocument,
+  AdminRolesDocument,
+  AdminUserDocument,
+} from "@/generated/graphql";
+
+// ---------------------------------------------------------------------------
+// Fixture IDs
+// ---------------------------------------------------------------------------
+
+const USER_ID = "user-1";
+const CALLER_ID = "caller-99";
+const SELF_ADMIN_USER_ID = "admin-self-1";
+
+const ROLE_GENERAL_ID = "role-general";
+const ROLE_ADMIN_ID = "role-admin";
+
+// ---------------------------------------------------------------------------
+// Shared mock fragments
+// ---------------------------------------------------------------------------
+
+const ALL_ROLES_MOCK = {
+  request: {
+    query: AdminRolesDocument,
+    variables: {},
+  },
+  result: {
+    data: {
+      roles: [
+        { __typename: "Role", id: ROLE_GENERAL_ID, name: "general" },
+        { __typename: "Role", id: ROLE_ADMIN_ID, name: "admin" },
+      ],
+    },
+  },
+};
+
+function makeAdminUserMock(userId: string, roleNames: string[]) {
+  const roleMap: Record<string, string> = {
+    general: ROLE_GENERAL_ID,
+    admin: ROLE_ADMIN_ID,
+  };
+  return {
+    request: {
+      query: AdminUserDocument,
+      variables: { id: userId },
+    },
+    result: {
+      data: {
+        adminUser: {
+          __typename: "User",
+          id: userId,
+          displayName: `User ${userId}`,
+          bio: null,
+          avatarUrl: null,
+          roles: roleNames.map((n) => ({
+            __typename: "Role",
+            id: roleMap[n] ?? `role-${n}`,
+            name: n,
+          })),
+        },
+      },
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// console spy helpers — mirror admin-dictionary.test.tsx scaffolding
+// ---------------------------------------------------------------------------
+
+let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
+let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  consoleWarnSpy.mockRestore();
+  consoleErrorSpy.mockRestore();
+});
+
+// ---------------------------------------------------------------------------
+// Helper renderer
+// ---------------------------------------------------------------------------
+
+function renderEdit(mocks: object[], userId: string, callerId?: string) {
+  render(
+    <MockedProvider mocks={mocks as never}>
+      <AdminUserEditClient userId={userId} callerId={callerId} />
+    </MockedProvider>,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("AdminUserEditClient — role assign / revoke flow", () => {
+  // T1: Initial render — user has ["general"] role
+  it("renders general checkbox checked and admin checkbox unchecked for a user with only general role", async () => {
+    renderEdit(
+      [makeAdminUserMock(USER_ID, ["general"]), ALL_ROLES_MOCK],
+      USER_ID,
+      CALLER_ID,
+    );
+
+    // Wait for async data to load
+    const generalCheckbox = await screen.findByRole("checkbox", { name: /general/i });
+    const adminCheckbox = screen.getByRole("checkbox", { name: /admin/i });
+
+    expect(generalCheckbox).toBeChecked();
+    expect(adminCheckbox).not.toBeChecked();
+  });
+
+  // T2: Assign — click unchecked admin checkbox → AdminAssignRoleMutation called once
+  it("calls AdminAssignRoleMutation once and renders admin checkbox as checked after assign", async () => {
+    const user = userEvent.setup({ delay: null });
+
+    let assignCalls = 0;
+    const assignResult = vi.fn(() => {
+      assignCalls += 1;
+      return {
+        data: {
+          assignRole: {
+            __typename: "User",
+            id: USER_ID,
+            displayName: `User ${USER_ID}`,
+            bio: null,
+            avatarUrl: null,
+            roles: [
+              { __typename: "Role", id: ROLE_GENERAL_ID, name: "general" },
+              { __typename: "Role", id: ROLE_ADMIN_ID, name: "admin" },
+            ],
+          },
+        },
+      };
+    });
+
+    const assignMock = {
+      request: {
+        query: AdminAssignRoleDocument,
+        variables: { userId: USER_ID, roleId: ROLE_ADMIN_ID },
+      },
+      result: assignResult,
+    };
+
+    renderEdit(
+      [makeAdminUserMock(USER_ID, ["general"]), ALL_ROLES_MOCK, assignMock],
+      USER_ID,
+      CALLER_ID,
+    );
+
+    // Wait for initial render
+    const adminCheckbox = await screen.findByRole("checkbox", { name: /admin/i });
+    expect(adminCheckbox).not.toBeChecked();
+
+    // Click to assign admin role
+    await user.click(adminCheckbox);
+
+    // Mutation should have fired exactly once
+    await waitFor(() => expect(assignCalls).toBe(1));
+
+    // After optimistic response / mutation resolution, admin checkbox is checked
+    await waitFor(() => {
+      expect(screen.getByRole("checkbox", { name: /admin/i })).toBeChecked();
+    });
+  });
+
+  // T3: Revoke — user starts with ["general", "admin"], click general to revoke it
+  it("calls AdminRevokeRoleMutation once and renders general checkbox as unchecked after revoke", async () => {
+    const user = userEvent.setup({ delay: null });
+
+    let revokeCalls = 0;
+    const revokeResult = vi.fn(() => {
+      revokeCalls += 1;
+      return {
+        data: {
+          revokeRole: {
+            __typename: "User",
+            id: USER_ID,
+            displayName: `User ${USER_ID}`,
+            bio: null,
+            avatarUrl: null,
+            roles: [
+              { __typename: "Role", id: ROLE_ADMIN_ID, name: "admin" },
+            ],
+          },
+        },
+      };
+    });
+
+    const revokeMock = {
+      request: {
+        query: AdminRevokeRoleDocument,
+        variables: { userId: USER_ID, roleId: ROLE_GENERAL_ID },
+      },
+      result: revokeResult,
+    };
+
+    renderEdit(
+      [makeAdminUserMock(USER_ID, ["general", "admin"]), ALL_ROLES_MOCK, revokeMock],
+      USER_ID,
+      CALLER_ID,
+    );
+
+    // Wait for initial render — both checkboxes should be checked
+    const generalCheckbox = await screen.findByRole("checkbox", { name: /general/i });
+    expect(generalCheckbox).toBeChecked();
+    expect(screen.getByRole("checkbox", { name: /admin/i })).toBeChecked();
+
+    // Click to revoke general role
+    await user.click(generalCheckbox);
+
+    // Mutation should have fired exactly once
+    await waitFor(() => expect(revokeCalls).toBe(1));
+
+    // After optimistic response / mutation resolution, general checkbox is unchecked
+    await waitFor(() => {
+      expect(screen.getByRole("checkbox", { name: /general/i })).not.toBeChecked();
+    });
+  });
+
+  // T4: Self-demotion guard — FORBIDDEN error keeps checkbox checked, shows banner
+  it("shows FORBIDDEN banner and keeps admin checkbox checked when revoking own admin role", async () => {
+    const user = userEvent.setup({ delay: null });
+
+    const selfDemotionRevokeMock = {
+      request: {
+        query: AdminRevokeRoleDocument,
+        variables: { userId: SELF_ADMIN_USER_ID, roleId: ROLE_ADMIN_ID },
+      },
+      result: {
+        errors: [
+          new GraphQLError("cannot revoke own admin role", {
+            extensions: { code: "FORBIDDEN" },
+          }),
+        ],
+      },
+    };
+
+    renderEdit(
+      [
+        makeAdminUserMock(SELF_ADMIN_USER_ID, ["admin"]),
+        ALL_ROLES_MOCK,
+        selfDemotionRevokeMock,
+      ],
+      SELF_ADMIN_USER_ID,
+      SELF_ADMIN_USER_ID, // callerId === userId → same user
+    );
+
+    // Wait for initial render — admin checkbox should be checked
+    const adminCheckbox = await screen.findByRole("checkbox", { name: /admin/i });
+    expect(adminCheckbox).toBeChecked();
+
+    // Attempt to uncheck (revoke own admin role)
+    await user.click(adminCheckbox);
+
+    // Banner with FORBIDDEN message must appear
+    const banner = await screen.findByRole("alert");
+    expect(banner).toHaveTextContent("cannot revoke own admin role");
+
+    // Checkbox must remain checked (optimistic write rolled back)
+    await waitFor(() => {
+      expect(screen.getByRole("checkbox", { name: /admin/i })).toBeChecked();
+    });
+  });
+
+  // T5: MockedProvider leak — no "no more mocked responses" warning for admin mutations
+  it("does not produce MockedProvider leak warnings for admin role mutations across all test interactions", async () => {
+    // This test fires one assign and one revoke and verifies no duplicate-request warnings.
+    const user = userEvent.setup({ delay: null });
+
+    const assignMock = {
+      request: {
+        query: AdminAssignRoleDocument,
+        variables: { userId: USER_ID, roleId: ROLE_ADMIN_ID },
+      },
+      result: {
+        data: {
+          assignRole: {
+            __typename: "User",
+            id: USER_ID,
+            displayName: `User ${USER_ID}`,
+            bio: null,
+            avatarUrl: null,
+            roles: [
+              { __typename: "Role", id: ROLE_GENERAL_ID, name: "general" },
+              { __typename: "Role", id: ROLE_ADMIN_ID, name: "admin" },
+            ],
+          },
+        },
+      },
+    };
+
+    renderEdit(
+      [makeAdminUserMock(USER_ID, ["general"]), ALL_ROLES_MOCK, assignMock],
+      USER_ID,
+      CALLER_ID,
+    );
+
+    // Wait for initial render and click assign once
+    const adminCheckbox = await screen.findByRole("checkbox", { name: /admin/i });
+    await user.click(adminCheckbox);
+
+    // Allow all async work to settle
+    await waitFor(() => {
+      expect(screen.getByRole("checkbox", { name: /admin/i })).toBeChecked();
+    });
+
+    // Verify no "No more mocked responses" warnings were emitted for the admin mutations
+    const adminMutationLeakWarnings = consoleWarnSpy.mock.calls.filter(
+      (args: unknown[]) =>
+        args.some(
+          (arg: unknown) =>
+            typeof arg === "string" &&
+            (arg.includes("AdminAssignRole") || arg.includes("AdminRevokeRole")),
+        ),
+    );
+    expect(adminMutationLeakWarnings).toEqual([]);
+  });
+});

--- a/frontend/src/app/admin/users/AdminUsersClient.tsx
+++ b/frontend/src/app/admin/users/AdminUsersClient.tsx
@@ -1,0 +1,265 @@
+"use client";
+
+import { NetworkStatus } from "@apollo/client";
+import { useQuery } from "@apollo/client/react";
+import Image from "next/image";
+import Link from "next/link";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useFragment } from "@/generated/fragment-masking";
+import { AdminUsersDocument, type AdminUsersQuery } from "@/generated/graphql";
+import { getBackendErrorBanner } from "@/lib/apollo/errors";
+import { ADMIN_USERS_PAGE_SIZE, AdminRoleFieldsFragment, AdminUserFieldsFragment } from "./queries";
+
+type Connection = AdminUsersQuery["users"];
+type Edge = Connection["edges"][number];
+type PageInfo = Connection["pageInfo"];
+
+function UserRow({ edge }: { edge: Edge }) {
+  const user = useFragment(AdminUserFieldsFragment, edge.node);
+  const roles = useFragment(AdminRoleFieldsFragment, edge.node.roles);
+
+  return (
+    <li
+      key={user.id}
+      className="flex items-start gap-4 rounded-md border border-border px-4 py-3"
+      data-testid={`admin-user-row-${user.id}`}
+    >
+      {/* Avatar */}
+      {user.avatarUrl ? (
+        <Image
+          src={user.avatarUrl}
+          alt={user.displayName ?? "User avatar"}
+          width={40}
+          height={40}
+          className="h-10 w-10 shrink-0 rounded-full object-cover"
+        />
+      ) : (
+        <div
+          className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-muted text-sm font-medium text-muted-foreground"
+          aria-hidden="true"
+        >
+          {(user.displayName ?? "?").charAt(0).toUpperCase()}
+        </div>
+      )}
+
+      {/* Name, bio, roles */}
+      <div className="min-w-0 flex-1 space-y-1">
+        <p className="text-sm font-medium">
+          {user.displayName ?? <span className="italic text-muted-foreground">No name</span>}
+        </p>
+        {user.bio && <p className="truncate text-sm text-muted-foreground">{user.bio}</p>}
+        {roles.length > 0 && (
+          <div className="flex flex-wrap gap-1">
+            {roles.map((role) => (
+              <span
+                key={role.id}
+                className="inline-flex items-center rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary"
+              >
+                {role.name}
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Edit link */}
+      <Link
+        href={`/admin/users/${user.id}/edit`}
+        className="shrink-0 text-sm text-muted-foreground hover:underline"
+      >
+        Edit
+      </Link>
+    </li>
+  );
+}
+
+export function AdminUsersClient() {
+  const [searchInput, setSearchInput] = useState("");
+  const [searchQuery, setSearchQuery] = useState<string | null>(null);
+  const [fetchMoreError, setFetchMoreError] = useState<string | null>(null);
+
+  // Debounce: update searchQuery 300ms after the last keystroke.
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setSearchQuery(searchInput.trim() || null);
+      // Reset pagination error when the search changes.
+      setFetchMoreError(null);
+    }, 300);
+    return () => clearTimeout(timer);
+  }, [searchInput]);
+
+  const {
+    data,
+    fetchMore,
+    loading,
+    networkStatus,
+    error: queryError,
+    refetch,
+  } = useQuery(AdminUsersDocument, {
+    variables: { first: ADMIN_USERS_PAGE_SIZE, search: searchQuery },
+    fetchPolicy: "cache-first",
+    notifyOnNetworkStatusChange: true,
+  });
+
+  const queryBannerError = getBackendErrorBanner(queryError);
+
+  const connection = data?.users;
+  const edges: Edge[] = connection?.edges ?? [];
+  const pageInfo: PageInfo = connection?.pageInfo ?? {
+    hasNextPage: false,
+    hasPreviousPage: false,
+    startCursor: null,
+    endCursor: null,
+  };
+  const totalCount = connection?.totalCount ?? 0;
+
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
+  const fetchingRef = useRef(false);
+
+  const requestNextPage = useCallback(() => {
+    if (fetchingRef.current) return;
+    if (!pageInfo.hasNextPage) return;
+
+    fetchingRef.current = true;
+    fetchMore({
+      variables: {
+        first: ADMIN_USERS_PAGE_SIZE,
+        after: pageInfo.endCursor,
+        search: searchQuery,
+      },
+      updateQuery: (prev, { fetchMoreResult }) => {
+        if (!fetchMoreResult) return prev;
+        return {
+          users: {
+            ...fetchMoreResult.users,
+            edges: [...prev.users.edges, ...fetchMoreResult.users.edges],
+          },
+        };
+      },
+    })
+      .then(() => {
+        setFetchMoreError(null);
+      })
+      .catch((err) => {
+        const banner = getBackendErrorBanner(err) ?? "Could not load more users. Please try again.";
+        setFetchMoreError(banner);
+      })
+      .finally(() => {
+        fetchingRef.current = false;
+      });
+  }, [fetchMore, pageInfo.endCursor, pageInfo.hasNextPage, searchQuery]);
+
+  useEffect(() => {
+    if (!pageInfo.hasNextPage) return;
+    // Halt the observer loop while a previous fetch failed; user must click Retry to resume.
+    if (fetchMoreError != null) return;
+    const node = sentinelRef.current;
+    if (!node) return;
+
+    const observer = new IntersectionObserver((entries) => {
+      const entry = entries[0];
+      if (!entry?.isIntersecting) return;
+      if (fetchingRef.current) return;
+      if (!pageInfo.hasNextPage) return;
+      requestNextPage();
+    });
+
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [pageInfo.hasNextPage, fetchMoreError, requestNextPage]);
+
+  const fetchingMore = networkStatus === NetworkStatus.fetchMore || (loading && edges.length > 0);
+  const initialLoading = loading && edges.length === 0 && networkStatus !== NetworkStatus.fetchMore;
+
+  return (
+    <main className="mx-auto max-w-3xl p-8">
+      <div className="mb-6 flex items-center gap-4">
+        <h1 className="text-2xl font-semibold">Users</h1>
+        <span className="text-sm text-muted-foreground">({totalCount})</span>
+      </div>
+
+      {/* Search input */}
+      <div className="mb-6">
+        <input
+          type="search"
+          placeholder="Search users..."
+          value={searchInput}
+          onChange={(e) => setSearchInput(e.target.value)}
+          className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          aria-label="Search users"
+        />
+      </div>
+
+      {/* Query error banner */}
+      {queryBannerError && (
+        <div
+          className="mb-4 rounded-md bg-destructive/10 p-3 text-sm text-destructive"
+          role="alert"
+          data-testid="admin-users-query-error"
+        >
+          <span>{queryBannerError}</span>
+          <button type="button" className="ml-3 underline" onClick={() => refetch()}>
+            Retry
+          </button>
+        </div>
+      )}
+
+      {/* Loading state */}
+      {initialLoading && (
+        <p className="text-sm text-muted-foreground" data-testid="admin-users-loading">
+          Loading...
+        </p>
+      )}
+
+      {/* Empty state */}
+      {!initialLoading && !queryBannerError && edges.length === 0 && (
+        <p className="text-sm text-muted-foreground" data-testid="admin-users-empty">
+          No users found.
+        </p>
+      )}
+
+      {/* User list */}
+      {edges.length > 0 && (
+        <ul className="space-y-3" data-testid="admin-users-list">
+          {edges.map((edge) => (
+            <UserRow key={edge.cursor} edge={edge} />
+          ))}
+        </ul>
+      )}
+
+      {/* Intersection sentinel for infinite scroll */}
+      <div ref={sentinelRef} aria-hidden="true" data-testid="admin-users-sentinel" />
+
+      {/* fetchMore error banner with Retry */}
+      {fetchMoreError && (
+        <div
+          className="mt-3 flex flex-col items-center gap-2 rounded-md bg-destructive/10 p-3 text-sm text-destructive"
+          role="alert"
+          data-testid="admin-users-fetch-more-error"
+        >
+          <span>{fetchMoreError}</span>
+          <button
+            type="button"
+            className="rounded-md border border-destructive/40 px-3 py-1 text-xs hover:bg-destructive/10"
+            onClick={() => {
+              setFetchMoreError(null);
+              requestNextPage();
+            }}
+          >
+            Retry
+          </button>
+        </div>
+      )}
+
+      {/* Loading more indicator */}
+      {!fetchMoreError && fetchingMore && pageInfo.hasNextPage && (
+        <p
+          className="mt-3 text-center text-xs text-muted-foreground"
+          data-testid="admin-users-loading-more"
+        >
+          Loading more users...
+        </p>
+      )}
+    </main>
+  );
+}

--- a/frontend/src/app/admin/users/AdminUsersClient.tsx
+++ b/frontend/src/app/admin/users/AdminUsersClient.tsx
@@ -13,7 +13,6 @@ import { ADMIN_USERS_PAGE_SIZE, AdminRoleFieldsFragment, AdminUserFieldsFragment
 
 type Connection = AdminUsersQuery["users"];
 type Edge = Connection["edges"][number];
-type PageInfo = Connection["pageInfo"];
 
 function UserRow({ edge }: { edge: Edge }) {
   const user = useFragment(AdminUserFieldsFragment, edge.node);
@@ -115,12 +114,8 @@ export function AdminUsersClient() {
 
   const connection = data?.users;
   const edges: Edge[] = connection?.edges ?? [];
-  const pageInfo: PageInfo = connection?.pageInfo ?? {
-    hasNextPage: false,
-    hasPreviousPage: false,
-    startCursor: null,
-    endCursor: null,
-  };
+  const hasNextPage = connection?.pageInfo.hasNextPage ?? false;
+  const endCursor = connection?.pageInfo.endCursor ?? null;
   const totalCount = connection?.totalCount ?? 0;
 
   const sentinelRef = useRef<HTMLDivElement | null>(null);
@@ -128,13 +123,13 @@ export function AdminUsersClient() {
 
   const requestNextPage = useCallback(() => {
     if (fetchingRef.current) return;
-    if (!pageInfo.hasNextPage) return;
+    if (!hasNextPage) return;
 
     fetchingRef.current = true;
     fetchMore({
       variables: {
         first: ADMIN_USERS_PAGE_SIZE,
-        after: pageInfo.endCursor,
+        after: endCursor,
         search: searchQuery,
       },
       updateQuery: (prev, { fetchMoreResult }) => {
@@ -157,10 +152,10 @@ export function AdminUsersClient() {
       .finally(() => {
         fetchingRef.current = false;
       });
-  }, [fetchMore, pageInfo.endCursor, pageInfo.hasNextPage, searchQuery]);
+  }, [fetchMore, endCursor, hasNextPage, searchQuery]);
 
   useEffect(() => {
-    if (!pageInfo.hasNextPage) return;
+    if (!hasNextPage) return;
     // Halt the observer loop while a previous fetch failed; user must click Retry to resume.
     if (fetchMoreError != null) return;
     const node = sentinelRef.current;
@@ -170,13 +165,12 @@ export function AdminUsersClient() {
       const entry = entries[0];
       if (!entry?.isIntersecting) return;
       if (fetchingRef.current) return;
-      if (!pageInfo.hasNextPage) return;
       requestNextPage();
     });
 
     observer.observe(node);
     return () => observer.disconnect();
-  }, [pageInfo.hasNextPage, fetchMoreError, requestNextPage]);
+  }, [hasNextPage, fetchMoreError, requestNextPage]);
 
   const fetchingMore = networkStatus === NetworkStatus.fetchMore || (loading && edges.length > 0);
   const initialLoading = loading && edges.length === 0 && networkStatus !== NetworkStatus.fetchMore;
@@ -273,7 +267,7 @@ export function AdminUsersClient() {
       )}
 
       {/* Loading more indicator */}
-      {!fetchMoreError && fetchingMore && pageInfo.hasNextPage && (
+      {!fetchMoreError && fetchingMore && hasNextPage && (
         <p
           className="mt-3 text-center text-xs text-muted-foreground"
           data-testid="admin-users-loading-more"

--- a/frontend/src/app/admin/users/AdminUsersClient.tsx
+++ b/frontend/src/app/admin/users/AdminUsersClient.tsx
@@ -4,10 +4,11 @@ import { NetworkStatus } from "@apollo/client";
 import { useQuery } from "@apollo/client/react";
 import Image from "next/image";
 import Link from "next/link";
+import { redirect } from "next/navigation";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useFragment } from "@/generated/fragment-masking";
 import { AdminUsersDocument, type AdminUsersQuery } from "@/generated/graphql";
-import { getBackendErrorBanner } from "@/lib/apollo/errors";
+import { classifyQueryError, getBackendErrorBanner } from "@/lib/apollo/errors";
 import { ADMIN_USERS_PAGE_SIZE, AdminRoleFieldsFragment, AdminUserFieldsFragment } from "./queries";
 
 type Connection = AdminUsersQuery["users"];
@@ -101,7 +102,16 @@ export function AdminUsersClient() {
     notifyOnNetworkStatusChange: true,
   });
 
-  const queryBannerError = getBackendErrorBanner(queryError);
+  const queryErrorKind = classifyQueryError(queryError);
+
+  // UNAUTHENTICATED post-mount means the session expired while the page was open.
+  // The server-side gate in page.tsx already blocks the initial load, so this
+  // handles the mid-session case. Redirect to "/" where the app will re-auth.
+  if (queryErrorKind?.kind === "unauthenticated") {
+    redirect("/");
+  }
+
+  const queryBannerError = queryErrorKind?.kind === "banner" ? queryErrorKind.message : undefined;
 
   const connection = data?.users;
   const edges: Edge[] = connection?.edges ?? [];
@@ -190,7 +200,18 @@ export function AdminUsersClient() {
         />
       </div>
 
-      {/* Query error banner */}
+      {/* FORBIDDEN error banner — no Retry since re-issuing the query would fail again */}
+      {queryErrorKind?.kind === "forbidden" && (
+        <div
+          className="mb-4 rounded-md bg-destructive/10 p-3 text-sm text-destructive"
+          role="alert"
+          data-testid="admin-users-query-error"
+        >
+          You do not have permission to view this page.
+        </div>
+      )}
+
+      {/* Generic query error banner with Retry */}
       {queryBannerError && (
         <div
           className="mb-4 rounded-md bg-destructive/10 p-3 text-sm text-destructive"
@@ -212,7 +233,7 @@ export function AdminUsersClient() {
       )}
 
       {/* Empty state */}
-      {!initialLoading && !queryBannerError && edges.length === 0 && (
+      {!initialLoading && !queryErrorKind && edges.length === 0 && (
         <p className="text-sm text-muted-foreground" data-testid="admin-users-empty">
           No users found.
         </p>

--- a/frontend/src/app/admin/users/[id]/edit/AdminUserEditClient.tsx
+++ b/frontend/src/app/admin/users/[id]/edit/AdminUserEditClient.tsx
@@ -1,0 +1,351 @@
+"use client";
+
+import { CombinedGraphQLErrors } from "@apollo/client/errors";
+import { useMutation, useQuery } from "@apollo/client/react";
+import Link from "next/link";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { useFragment } from "@/generated/fragment-masking";
+import type {
+  AdminRolesQuery as AdminRolesQueryType,
+  AdminUserQuery as AdminUserQueryType,
+} from "@/generated/graphql";
+import { AdminRoleFieldsFragmentDoc, AdminUserFieldsFragmentDoc } from "@/generated/graphql";
+import { getBackendErrorBanner } from "@/lib/apollo/errors";
+import {
+  AdminAssignRoleMutation,
+  AdminRevokeRoleMutation,
+  AdminRolesQuery,
+  AdminUpdateUserMutation,
+  AdminUserQuery,
+} from "../../queries";
+
+/** Plain serializable types matching the runtime JSON shape from gqlFetch. */
+export type UserForEdit = {
+  id: string;
+  displayName?: string | null;
+  bio?: string | null;
+  avatarUrl?: string | null;
+  roles: Array<{ id: string; name: string }>;
+};
+
+export type RoleOption = {
+  id: string;
+  name: string;
+};
+
+/**
+ * Props for AdminUserEditClient.
+ *
+ * Two usage modes:
+ *  - SSR mode: pass `user` and `allRoles` from a server component (no client queries fired).
+ *  - Client mode: pass `userId` and the component fetches its own data (used in tests).
+ */
+type Props =
+  | {
+      /** Pre-fetched user from the server component. */
+      user: UserForEdit;
+      /** Pre-fetched roles list from the server component. */
+      allRoles: RoleOption[];
+      userId?: never;
+      callerId?: string;
+    }
+  | {
+      /** User ID; the component fetches AdminUserQuery and AdminRolesQuery itself. */
+      userId: string;
+      user?: never;
+      allRoles?: never;
+      callerId?: string;
+    };
+
+/** Maximum grapheme clusters for displayName (mirrors usecase/user.go displayNameMax). */
+const DISPLAY_NAME_MAX = 50;
+
+/** Maximum grapheme clusters for bio (mirrors usecase/user.go bioMax). */
+const BIO_MAX = 500;
+
+/**
+ * Classify a raw Apollo error into a user-facing banner string.
+ * FORBIDDEN errors surface the server message verbatim (e.g. self-demotion guard).
+ */
+function classifyError(err: unknown): string {
+  if (!err) return "";
+  if (CombinedGraphQLErrors.is(err)) {
+    for (const ge of err.errors) {
+      if (ge.extensions?.code === "FORBIDDEN") {
+        return ge.message;
+      }
+    }
+  }
+  return getBackendErrorBanner(err) ?? "An unexpected error occurred. Please try again.";
+}
+
+export function AdminUserEditClient(props: Props) {
+  const isClientMode = "userId" in props && props.userId !== undefined;
+
+  // Client-side queries — only active in client mode (skip when SSR props provided).
+  const { data: queriedUserData, loading: userLoading } = useQuery(AdminUserQuery, {
+    variables: { id: isClientMode ? props.userId : "" },
+    skip: !isClientMode,
+  });
+  const { data: queriedRolesData, loading: rolesLoading } = useQuery(AdminRolesQuery, {
+    skip: !isClientMode,
+  });
+
+  // Resolve user data: prefer SSR prop, fall back to query result.
+  const rawUser = isClientMode
+    ? queriedUserData?.adminUser
+    : (props.user as unknown as NonNullable<AdminUserQueryType["adminUser"]>);
+  const userFields = useFragment(AdminUserFieldsFragmentDoc, rawUser);
+
+  const rawAllRoles = isClientMode
+    ? (queriedRolesData?.roles ?? [])
+    : ((props.allRoles ?? []) as unknown as AdminRolesQueryType["roles"]);
+  const allRoles = useFragment(AdminRoleFieldsFragmentDoc, rawAllRoles);
+
+  const rawUserRoles = rawUser?.roles ?? [];
+  const userRoles = useFragment(AdminRoleFieldsFragmentDoc, rawUserRoles);
+
+  const resolvedUserId = userFields?.id ?? (isClientMode ? props.userId : "");
+
+  const [displayName, setDisplayName] = useState(userFields?.displayName ?? "");
+  const [bio, setBio] = useState(userFields?.bio ?? "");
+  const [saveError, setSaveError] = useState("");
+  const [saveBanner, setSaveBanner] = useState("");
+
+  // Per-role error banners (keyed by role id).
+  const [roleBanners, setRoleBanners] = useState<Record<string, string>>({});
+  // Per-role in-flight guard so consecutive clicks cannot double-fire.
+  const [roleInflight, setRoleInflight] = useState<Record<string, boolean>>({});
+
+  const [runUpdate, { loading: saving }] = useMutation(AdminUpdateUserMutation);
+  const [runAssign] = useMutation(AdminAssignRoleMutation);
+  const [runRevoke] = useMutation(AdminRevokeRoleMutation);
+
+  // Derive assigned role ids. Apollo entity normalization propagates
+  // assign/revoke mutation results back into the cache automatically.
+  const userRoleIds = new Set(userRoles.map((r) => r.id));
+
+  /** Client-side validation mirror of server-side constraints. Returns error or "". */
+  function validate(): string {
+    const trimmed = displayName.trim();
+    if (trimmed.length < 1) return "Display name is required.";
+    if (trimmed.length > DISPLAY_NAME_MAX)
+      return `Display name must be at most ${DISPLAY_NAME_MAX} characters.`;
+    if (bio.length > BIO_MAX) return `Bio must be at most ${BIO_MAX} characters.`;
+    return "";
+  }
+
+  async function handleSave() {
+    const validationError = validate();
+    if (validationError) {
+      setSaveError(validationError);
+      return;
+    }
+    setSaveError("");
+    setSaveBanner("");
+
+    try {
+      await runUpdate({
+        variables: {
+          id: resolvedUserId,
+          input: {
+            displayName: displayName.trim(),
+            bio: bio || null,
+          },
+        },
+      });
+      setSaveBanner("Changes saved.");
+    } catch (err) {
+      setSaveError(classifyError(err));
+    }
+  }
+
+  async function handleRoleToggle(roleId: string, currentlyAssigned: boolean) {
+    setRoleInflight((prev) => ({ ...prev, [roleId]: true }));
+    setRoleBanners((prev) => ({ ...prev, [roleId]: "" }));
+
+    // Build the optimistic roles list so the checkbox flips immediately.
+    const optimisticRoles = currentlyAssigned
+      ? userRoles
+          .filter((r) => r.id !== roleId)
+          .map((r) => ({ __typename: "Role" as const, id: r.id, name: r.name }))
+      : [
+          ...userRoles.map((r) => ({
+            __typename: "Role" as const,
+            id: r.id,
+            name: r.name,
+          })),
+          {
+            __typename: "Role" as const,
+            id: roleId,
+            name: allRoles.find((r) => r.id === roleId)?.name ?? "",
+          },
+        ];
+
+    const optimisticUser = {
+      __typename: "User" as const,
+      id: resolvedUserId,
+      displayName: userFields?.displayName ?? null,
+      bio: userFields?.bio ?? null,
+      avatarUrl: userFields?.avatarUrl ?? null,
+      roles: optimisticRoles,
+    };
+
+    try {
+      if (currentlyAssigned) {
+        await runRevoke({
+          variables: { userId: resolvedUserId, roleId },
+          optimisticResponse: { revokeRole: optimisticUser },
+        });
+      } else {
+        await runAssign({
+          variables: { userId: resolvedUserId, roleId },
+          optimisticResponse: { assignRole: optimisticUser },
+        });
+      }
+    } catch (err) {
+      setRoleBanners((prev) => ({
+        ...prev,
+        [roleId]: classifyError(err),
+      }));
+    } finally {
+      setRoleInflight((prev) => ({ ...prev, [roleId]: false }));
+    }
+  }
+
+  if (isClientMode && (userLoading || rolesLoading)) {
+    return <div>Loading...</div>;
+  }
+
+  if (!userFields && !isClientMode) {
+    return <div role="alert">User not found.</div>;
+  }
+
+  return (
+    <main className="mx-auto max-w-2xl p-8">
+      {/* Navigation */}
+      <div className="mb-6 flex items-center gap-4">
+        <Link href="/admin/users" className="text-sm text-muted-foreground hover:underline">
+          &larr; Back to users
+        </Link>
+        <h1 className="text-2xl font-semibold">Edit User</h1>
+      </div>
+
+      {/* Save success banner */}
+      {saveBanner && !saveError && (
+        <div className="mb-4 rounded-md bg-green-50 p-3 text-sm text-green-800" role="status">
+          {saveBanner}
+        </div>
+      )}
+
+      {/* Save error banner */}
+      {saveError && (
+        <div
+          className="mb-4 rounded-md bg-destructive/10 p-3 text-sm text-destructive"
+          role="alert"
+        >
+          {saveError}
+        </div>
+      )}
+
+      <div className="space-y-6">
+        {/* Display name */}
+        <div className="space-y-2">
+          <label htmlFor="display-name" className="block text-sm font-medium">
+            Display name
+          </label>
+          <input
+            id="display-name"
+            type="text"
+            value={displayName}
+            onChange={(e) => {
+              setDisplayName(e.target.value);
+              setSaveError("");
+              setSaveBanner("");
+            }}
+            maxLength={DISPLAY_NAME_MAX}
+            className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          />
+          <p className="text-xs text-muted-foreground">
+            {displayName.trim().length}/{DISPLAY_NAME_MAX}
+          </p>
+        </div>
+
+        {/* Bio */}
+        <div className="space-y-2">
+          <label htmlFor="bio" className="block text-sm font-medium">
+            Bio
+          </label>
+          <textarea
+            id="bio"
+            value={bio}
+            onChange={(e) => {
+              setBio(e.target.value);
+              setSaveError("");
+              setSaveBanner("");
+            }}
+            rows={4}
+            maxLength={BIO_MAX}
+            className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            placeholder="Optional bio"
+          />
+          <p className="text-xs text-muted-foreground">
+            {bio.length}/{BIO_MAX}
+          </p>
+        </div>
+
+        {/* Save button */}
+        <Button type="button" onClick={handleSave} disabled={saving}>
+          {saving ? "Saving..." : "Save changes"}
+        </Button>
+
+        {/* Role multi-select */}
+        <section className="space-y-3">
+          <h2 className="text-sm font-medium">Roles</h2>
+          {allRoles.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No roles available.</p>
+          ) : (
+            <ul className="space-y-2">
+              {allRoles.map((role) => {
+                const isAssigned = userRoleIds.has(role.id);
+                const isInflight = roleInflight[role.id] ?? false;
+                const roleBanner = roleBanners[role.id];
+                const checkboxId = `role-checkbox-${role.id}`;
+                return (
+                  <li key={role.id}>
+                    <div className="flex items-center gap-3">
+                      <input
+                        id={checkboxId}
+                        type="checkbox"
+                        checked={isAssigned}
+                        disabled={isInflight}
+                        onChange={() => handleRoleToggle(role.id, isAssigned)}
+                        className="h-4 w-4 rounded border-input accent-primary"
+                        aria-label={role.name}
+                      />
+                      <label htmlFor={checkboxId} className="cursor-pointer text-sm">
+                        {role.name}
+                      </label>
+                      {isInflight && (
+                        <span className="text-xs text-muted-foreground">Updating...</span>
+                      )}
+                    </div>
+                    {roleBanner && (
+                      <div
+                        className="mt-1 rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive"
+                        role="alert"
+                      >
+                        {roleBanner}
+                      </div>
+                    )}
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/app/admin/users/[id]/edit/AdminUserEditClient.tsx
+++ b/frontend/src/app/admin/users/[id]/edit/AdminUserEditClient.tsx
@@ -1,23 +1,16 @@
 "use client";
 
 import { CombinedGraphQLErrors } from "@apollo/client/errors";
-import { useMutation, useQuery } from "@apollo/client/react";
+import { useMutation } from "@apollo/client/react";
 import Link from "next/link";
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
-import { useFragment } from "@/generated/fragment-masking";
-import type {
-  AdminRolesQuery as AdminRolesQueryType,
-  AdminUserQuery as AdminUserQueryType,
-} from "@/generated/graphql";
-import { AdminRoleFieldsFragmentDoc, AdminUserFieldsFragmentDoc } from "@/generated/graphql";
+import type { AdminRoleFieldsFragment } from "@/generated/graphql";
 import { getBackendErrorBanner } from "@/lib/apollo/errors";
 import {
   AdminAssignRoleMutation,
   AdminRevokeRoleMutation,
-  AdminRolesQuery,
   AdminUpdateUserMutation,
-  AdminUserQuery,
 } from "../../queries";
 
 /** Plain serializable types matching the runtime JSON shape from gqlFetch. */
@@ -36,27 +29,14 @@ export type RoleOption = {
 
 /**
  * Props for AdminUserEditClient.
- *
- * Two usage modes:
- *  - SSR mode: pass `user` and `allRoles` from a server component (no client queries fired).
- *  - Client mode: pass `userId` and the component fetches its own data (used in tests).
+ * Data is always pre-fetched by the server component; no client-side queries.
  */
-type Props =
-  | {
-      /** Pre-fetched user from the server component. */
-      user: UserForEdit;
-      /** Pre-fetched roles list from the server component. */
-      allRoles: RoleOption[];
-      userId?: never;
-      callerId?: string;
-    }
-  | {
-      /** User ID; the component fetches AdminUserQuery and AdminRolesQuery itself. */
-      userId: string;
-      user?: never;
-      allRoles?: never;
-      callerId?: string;
-    };
+type Props = {
+  /** Pre-fetched user from the server component. */
+  user: UserForEdit;
+  /** Pre-fetched roles list from the server component. */
+  allRoles: RoleOption[];
+};
 
 /** Maximum grapheme clusters for displayName (mirrors usecase/user.go displayNameMax). */
 const DISPLAY_NAME_MAX = 50;
@@ -80,36 +60,9 @@ function classifyError(err: unknown): string {
   return getBackendErrorBanner(err) ?? "An unexpected error occurred. Please try again.";
 }
 
-export function AdminUserEditClient(props: Props) {
-  const isClientMode = "userId" in props && props.userId !== undefined;
-
-  // Client-side queries — only active in client mode (skip when SSR props provided).
-  const { data: queriedUserData, loading: userLoading } = useQuery(AdminUserQuery, {
-    variables: { id: isClientMode ? props.userId : "" },
-    skip: !isClientMode,
-  });
-  const { data: queriedRolesData, loading: rolesLoading } = useQuery(AdminRolesQuery, {
-    skip: !isClientMode,
-  });
-
-  // Resolve user data: prefer SSR prop, fall back to query result.
-  const rawUser = isClientMode
-    ? queriedUserData?.adminUser
-    : (props.user as unknown as NonNullable<AdminUserQueryType["adminUser"]>);
-  const userFields = useFragment(AdminUserFieldsFragmentDoc, rawUser);
-
-  const rawAllRoles = isClientMode
-    ? (queriedRolesData?.roles ?? [])
-    : ((props.allRoles ?? []) as unknown as AdminRolesQueryType["roles"]);
-  const allRoles = useFragment(AdminRoleFieldsFragmentDoc, rawAllRoles);
-
-  const rawUserRoles = rawUser?.roles ?? [];
-  const userRoles = useFragment(AdminRoleFieldsFragmentDoc, rawUserRoles);
-
-  const resolvedUserId = userFields?.id ?? (isClientMode ? props.userId : "");
-
-  const [displayName, setDisplayName] = useState(userFields?.displayName ?? "");
-  const [bio, setBio] = useState(userFields?.bio ?? "");
+export function AdminUserEditClient({ user, allRoles }: Props) {
+  const [displayName, setDisplayName] = useState(user.displayName ?? "");
+  const [bio, setBio] = useState(user.bio ?? "");
   const [saveError, setSaveError] = useState("");
   const [saveBanner, setSaveBanner] = useState("");
 
@@ -117,14 +70,14 @@ export function AdminUserEditClient(props: Props) {
   const [roleBanners, setRoleBanners] = useState<Record<string, string>>({});
   // Per-role in-flight guard so consecutive clicks cannot double-fire.
   const [roleInflight, setRoleInflight] = useState<Record<string, boolean>>({});
+  // Server-truth role ids — initialised from SSR props; updated on mutation success.
+  const [userRoleIds, setUserRoleIds] = useState<Set<string>>(
+    () => new Set(user.roles.map((r) => r.id)),
+  );
 
   const [runUpdate, { loading: saving }] = useMutation(AdminUpdateUserMutation);
   const [runAssign] = useMutation(AdminAssignRoleMutation);
   const [runRevoke] = useMutation(AdminRevokeRoleMutation);
-
-  // Derive assigned role ids. Apollo entity normalization propagates
-  // assign/revoke mutation results back into the cache automatically.
-  const userRoleIds = new Set(userRoles.map((r) => r.id));
 
   /** Client-side validation mirror of server-side constraints. Returns error or "". */
   function validate(): string {
@@ -148,7 +101,7 @@ export function AdminUserEditClient(props: Props) {
     try {
       await runUpdate({
         variables: {
-          id: resolvedUserId,
+          id: user.id,
           input: {
             displayName: displayName.trim(),
             bio: bio || null,
@@ -165,46 +118,31 @@ export function AdminUserEditClient(props: Props) {
     setRoleInflight((prev) => ({ ...prev, [roleId]: true }));
     setRoleBanners((prev) => ({ ...prev, [roleId]: "" }));
 
-    // Build the optimistic roles list so the checkbox flips immediately.
-    const optimisticRoles = currentlyAssigned
-      ? userRoles
-          .filter((r) => r.id !== roleId)
-          .map((r) => ({ __typename: "Role" as const, id: r.id, name: r.name }))
-      : [
-          ...userRoles.map((r) => ({
-            __typename: "Role" as const,
-            id: r.id,
-            name: r.name,
-          })),
-          {
-            __typename: "Role" as const,
-            id: roleId,
-            name: allRoles.find((r) => r.id === roleId)?.name ?? "",
-          },
-        ];
-
-    const optimisticUser = {
-      __typename: "User" as const,
-      id: resolvedUserId,
-      displayName: userFields?.displayName ?? null,
-      bio: userFields?.bio ?? null,
-      avatarUrl: userFields?.avatarUrl ?? null,
-      roles: optimisticRoles,
-    };
-
     try {
       if (currentlyAssigned) {
-        await runRevoke({
-          variables: { userId: resolvedUserId, roleId },
-          optimisticResponse: { revokeRole: optimisticUser },
+        const result = await runRevoke({
+          variables: { userId: user.id, roleId },
         });
+        // Update local role state from server-truth response.
+        // Fragment masking is compile-time only; at runtime the shape is the plain object.
+        const serverRoles = result.data?.revokeRole?.roles as AdminRoleFieldsFragment[] | undefined;
+        if (serverRoles) {
+          setUserRoleIds(new Set(serverRoles.map((r) => r.id)));
+        }
       } else {
-        await runAssign({
-          variables: { userId: resolvedUserId, roleId },
-          optimisticResponse: { assignRole: optimisticUser },
+        const result = await runAssign({
+          variables: { userId: user.id, roleId },
         });
+        // Update local role state from server-truth response.
+        // Fragment masking is compile-time only; at runtime the shape is the plain object.
+        const serverRoles = result.data?.assignRole?.roles as AdminRoleFieldsFragment[] | undefined;
+        if (serverRoles) {
+          setUserRoleIds(new Set(serverRoles.map((r) => r.id)));
+        }
       }
     } catch (err) {
+      // On failure (including FORBIDDEN), surface the banner.
+      // No optimistic writes were made, so local state already reflects server truth.
       setRoleBanners((prev) => ({
         ...prev,
         [roleId]: classifyError(err),
@@ -214,11 +152,7 @@ export function AdminUserEditClient(props: Props) {
     }
   }
 
-  if (isClientMode && (userLoading || rolesLoading)) {
-    return <div>Loading...</div>;
-  }
-
-  if (!userFields && !isClientMode) {
+  if (!user) {
     return <div role="alert">User not found.</div>;
   }
 

--- a/frontend/src/app/admin/users/[id]/edit/AdminUserEditClient.tsx
+++ b/frontend/src/app/admin/users/[id]/edit/AdminUserEditClient.tsx
@@ -66,9 +66,9 @@ export function AdminUserEditClient({ user, allRoles }: Props) {
   const [saveError, setSaveError] = useState("");
   const [saveBanner, setSaveBanner] = useState("");
 
-  // Per-role error banners (keyed by role id).
+  // Per-role error banners (keyed by role id) and in-flight guard so consecutive
+  // clicks on the same role cannot double-fire.
   const [roleBanners, setRoleBanners] = useState<Record<string, string>>({});
-  // Per-role in-flight guard so consecutive clicks cannot double-fire.
   const [roleInflight, setRoleInflight] = useState<Record<string, boolean>>({});
   // Server-truth role ids — initialised from SSR props; updated on mutation success.
   const [userRoleIds, setUserRoleIds] = useState<Set<string>>(
@@ -78,6 +78,11 @@ export function AdminUserEditClient({ user, allRoles }: Props) {
   const [runUpdate, { loading: saving }] = useMutation(AdminUpdateUserMutation);
   const [runAssign] = useMutation(AdminAssignRoleMutation);
   const [runRevoke] = useMutation(AdminRevokeRoleMutation);
+
+  function clearSaveStatus(): void {
+    setSaveError("");
+    setSaveBanner("");
+  }
 
   /** Client-side validation mirror of server-side constraints. Returns error or "". */
   function validate(): string {
@@ -95,8 +100,7 @@ export function AdminUserEditClient({ user, allRoles }: Props) {
       setSaveError(validationError);
       return;
     }
-    setSaveError("");
-    setSaveBanner("");
+    clearSaveStatus();
 
     try {
       await runUpdate({
@@ -119,26 +123,16 @@ export function AdminUserEditClient({ user, allRoles }: Props) {
     setRoleBanners((prev) => ({ ...prev, [roleId]: "" }));
 
     try {
-      if (currentlyAssigned) {
-        const result = await runRevoke({
-          variables: { userId: user.id, roleId },
-        });
-        // Update local role state from server-truth response.
-        // Fragment masking is compile-time only; at runtime the shape is the plain object.
-        const serverRoles = result.data?.revokeRole?.roles as AdminRoleFieldsFragment[] | undefined;
-        if (serverRoles) {
-          setUserRoleIds(new Set(serverRoles.map((r) => r.id)));
-        }
-      } else {
-        const result = await runAssign({
-          variables: { userId: user.id, roleId },
-        });
-        // Update local role state from server-truth response.
-        // Fragment masking is compile-time only; at runtime the shape is the plain object.
-        const serverRoles = result.data?.assignRole?.roles as AdminRoleFieldsFragment[] | undefined;
-        if (serverRoles) {
-          setUserRoleIds(new Set(serverRoles.map((r) => r.id)));
-        }
+      const variables = { userId: user.id, roleId };
+      // Update local role state from the server-truth response. Fragment masking
+      // is compile-time only; at runtime the shape is the plain object.
+      const serverRoles = (
+        currentlyAssigned
+          ? (await runRevoke({ variables })).data?.revokeRole?.roles
+          : (await runAssign({ variables })).data?.assignRole?.roles
+      ) as AdminRoleFieldsFragment[] | undefined;
+      if (serverRoles) {
+        setUserRoleIds(new Set(serverRoles.map((r) => r.id)));
       }
     } catch (err) {
       // On failure (including FORBIDDEN), surface the banner.
@@ -150,10 +144,6 @@ export function AdminUserEditClient({ user, allRoles }: Props) {
     } finally {
       setRoleInflight((prev) => ({ ...prev, [roleId]: false }));
     }
-  }
-
-  if (!user) {
-    return <div role="alert">User not found.</div>;
   }
 
   return (
@@ -195,8 +185,7 @@ export function AdminUserEditClient({ user, allRoles }: Props) {
             value={displayName}
             onChange={(e) => {
               setDisplayName(e.target.value);
-              setSaveError("");
-              setSaveBanner("");
+              clearSaveStatus();
             }}
             maxLength={DISPLAY_NAME_MAX}
             className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
@@ -216,8 +205,7 @@ export function AdminUserEditClient({ user, allRoles }: Props) {
             value={bio}
             onChange={(e) => {
               setBio(e.target.value);
-              setSaveError("");
-              setSaveBanner("");
+              clearSaveStatus();
             }}
             rows={4}
             maxLength={BIO_MAX}

--- a/frontend/src/app/admin/users/[id]/edit/page.tsx
+++ b/frontend/src/app/admin/users/[id]/edit/page.tsx
@@ -9,15 +9,13 @@ import { AdminRolesQuery, AdminUserQuery } from "../../queries";
 import { AdminUserEditClient, type RoleOption, type UserForEdit } from "./AdminUserEditClient";
 
 /**
- * Redirect if the error carries an UNAUTHENTICATED or FORBIDDEN GraphQL code.
- * UNAUTHENTICATED → user must log in again.
- * FORBIDDEN → user is authenticated but not admin; send to home.
- * Any other error is rethrown to the error boundary.
+ * Redirect to "/" when the error carries an UNAUTHENTICATED (session expired)
+ * or FORBIDDEN (not admin) GraphQL code. Any other error is rethrown to the
+ * error boundary.
  */
 function redirectOnAuthError(err: unknown): never {
   const msg = err instanceof Error ? err.message : String(err);
-  if (msg.includes("UNAUTHENTICATED")) redirect("/");
-  if (msg.includes("FORBIDDEN")) redirect("/");
+  if (msg.includes("UNAUTHENTICATED") || msg.includes("FORBIDDEN")) redirect("/");
   throw err;
 }
 

--- a/frontend/src/app/admin/users/[id]/edit/page.tsx
+++ b/frontend/src/app/admin/users/[id]/edit/page.tsx
@@ -4,10 +4,22 @@ import type {
   AdminUserQuery as AdminUserQueryType,
 } from "@/generated/graphql";
 import { gqlFetch } from "@/lib/apollo/server";
-import { redirectIfUnauthenticated } from "@/lib/apollo/server-redirect";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 import { AdminRolesQuery, AdminUserQuery } from "../../queries";
 import { AdminUserEditClient, type RoleOption, type UserForEdit } from "./AdminUserEditClient";
+
+/**
+ * Redirect if the error carries an UNAUTHENTICATED or FORBIDDEN GraphQL code.
+ * UNAUTHENTICATED → user must log in again.
+ * FORBIDDEN → user is authenticated but not admin; send to home.
+ * Any other error is rethrown to the error boundary.
+ */
+function redirectOnAuthError(err: unknown): never {
+  const msg = err instanceof Error ? err.message : String(err);
+  if (msg.includes("UNAUTHENTICATED")) redirect("/");
+  if (msg.includes("FORBIDDEN")) redirect("/");
+  throw err;
+}
 
 export default async function AdminUserEditPage({ params }: { params: Promise<{ id: string }> }) {
   const supabase = await createSupabaseServerClient();
@@ -29,7 +41,7 @@ export default async function AdminUserEditPage({ params }: { params: Promise<{ 
       gqlFetch(AdminRolesQuery, { revalidate: 0 }),
     ]);
   } catch (err) {
-    redirectIfUnauthenticated(err, "/");
+    redirectOnAuthError(err);
   }
 
   if (!userData?.adminUser) redirect("/admin/users");

--- a/frontend/src/app/admin/users/[id]/edit/page.tsx
+++ b/frontend/src/app/admin/users/[id]/edit/page.tsx
@@ -1,0 +1,43 @@
+import { redirect } from "next/navigation";
+import type {
+  AdminRolesQuery as AdminRolesQueryType,
+  AdminUserQuery as AdminUserQueryType,
+} from "@/generated/graphql";
+import { gqlFetch } from "@/lib/apollo/server";
+import { redirectIfUnauthenticated } from "@/lib/apollo/server-redirect";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+import { AdminRolesQuery, AdminUserQuery } from "../../queries";
+import { AdminUserEditClient, type RoleOption, type UserForEdit } from "./AdminUserEditClient";
+
+export default async function AdminUserEditPage({ params }: { params: Promise<{ id: string }> }) {
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+    error: authErr,
+  } = await supabase.auth.getUser();
+  if (authErr) throw authErr;
+  if (!user) redirect("/login");
+
+  const { id } = await params;
+
+  let userData: AdminUserQueryType | null = null;
+  let rolesData: AdminRolesQueryType | null = null;
+
+  try {
+    [userData, rolesData] = await Promise.all([
+      gqlFetch(AdminUserQuery, { variables: { id }, revalidate: 0 }),
+      gqlFetch(AdminRolesQuery, { revalidate: 0 }),
+    ]);
+  } catch (err) {
+    redirectIfUnauthenticated(err, "/");
+  }
+
+  if (!userData?.adminUser) redirect("/admin/users");
+
+  // The fragment-masked types carry the actual field values at runtime. Cast to
+  // the plain serializable props the client component expects.
+  const userForEdit = userData.adminUser as unknown as UserForEdit;
+  const allRoles = (rolesData?.roles ?? []) as unknown as RoleOption[];
+
+  return <AdminUserEditClient user={userForEdit} allRoles={allRoles} />;
+}

--- a/frontend/src/app/admin/users/page.tsx
+++ b/frontend/src/app/admin/users/page.tsx
@@ -1,0 +1,15 @@
+import { redirect } from "next/navigation";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+import { AdminUsersClient } from "./AdminUsersClient";
+
+export default async function AdminUsersPage() {
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+    error: authErr,
+  } = await supabase.auth.getUser();
+  if (authErr) throw authErr;
+  if (!user) redirect("/");
+
+  return <AdminUsersClient />;
+}

--- a/frontend/src/app/admin/users/queries.ts
+++ b/frontend/src/app/admin/users/queries.ts
@@ -1,0 +1,101 @@
+import { graphql } from "@/generated";
+
+/** Default page size for the admin users connection. Must stay in sync between SSR seed and client useQuery/cache reads. */
+export const ADMIN_USERS_PAGE_SIZE = 20;
+
+export const AdminUserFieldsFragment = graphql(`
+  fragment AdminUserFields on User {
+    id
+    displayName
+    bio
+    avatarUrl
+  }
+`);
+
+export const AdminRoleFieldsFragment = graphql(`
+  fragment AdminRoleFields on Role {
+    id
+    name
+  }
+`);
+
+export const AdminUsersQuery = graphql(`
+  query AdminUsers(
+    $first: Int
+    $after: ID
+    $last: Int
+    $before: ID
+    $search: String
+  ) {
+    users(first: $first, after: $after, last: $last, before: $before, search: $search) {
+      edges {
+        cursor
+        node {
+          ...AdminUserFields
+          roles {
+            ...AdminRoleFields
+          }
+        }
+      }
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+    }
+  }
+`);
+
+export const AdminUserQuery = graphql(`
+  query AdminUser($id: ID!) {
+    adminUser(id: $id) {
+      ...AdminUserFields
+      roles {
+        ...AdminRoleFields
+      }
+    }
+  }
+`);
+
+export const AdminRolesQuery = graphql(`
+  query AdminRoles {
+    roles {
+      ...AdminRoleFields
+    }
+  }
+`);
+
+export const AdminUpdateUserMutation = graphql(`
+  mutation AdminUpdateUser($id: ID!, $input: AdminUpdateUserInput!) {
+    adminUpdateUser(id: $id, input: $input) {
+      ...AdminUserFields
+      roles {
+        ...AdminRoleFields
+      }
+    }
+  }
+`);
+
+export const AdminAssignRoleMutation = graphql(`
+  mutation AdminAssignRole($userId: ID!, $roleId: ID!) {
+    assignRole(userId: $userId, roleId: $roleId) {
+      ...AdminUserFields
+      roles {
+        ...AdminRoleFields
+      }
+    }
+  }
+`);
+
+export const AdminRevokeRoleMutation = graphql(`
+  mutation AdminRevokeRole($userId: ID!, $roleId: ID!) {
+    revokeRole(userId: $userId, roleId: $roleId) {
+      ...AdminUserFields
+      roles {
+        ...AdminRoleFields
+      }
+    }
+  }
+`);

--- a/frontend/src/lib/apollo/errors.ts
+++ b/frontend/src/lib/apollo/errors.ts
@@ -7,6 +7,8 @@
  *  - getBackendErrorBanner:  Returns a user-facing banner string for non-field
  *    errors.  Priority: INTERNAL > UNAUTHENTICATED > first non-field GQL error.
  *    Network / non-CombinedGraphQLErrors → generic network message.
+ *  - classifyQueryError:  Classifies a query-level error into a typed result so
+ *    callers can branch on FORBIDDEN / UNAUTHENTICATED without retrying.
  */
 
 import { CombinedGraphQLErrors } from "@apollo/client/errors";
@@ -60,4 +62,38 @@ export function getBackendErrorBanner(err: unknown): string | undefined {
     }
   }
   return internalMsg ?? authMsg ?? firstNonFieldMsg;
+}
+
+/**
+ * Typed result of classifying a query-level Apollo error.
+ *
+ * - `forbidden`:       FORBIDDEN code — user lacks the required role.
+ * - `unauthenticated`: UNAUTHENTICATED code — session expired.
+ * - `banner`:          Any other error; `message` carries the user-facing string.
+ */
+export type QueryErrorKind =
+  | { kind: "forbidden" }
+  | { kind: "unauthenticated" }
+  | { kind: "banner"; message: string };
+
+/**
+ * Classify a query-level Apollo error for callers that need to branch on
+ * FORBIDDEN (no retry, permission copy) or UNAUTHENTICATED (redirect/re-login)
+ * separately from generic errors that warrant a Retry banner.
+ *
+ * Returns `null` when `err` is falsy.
+ */
+export function classifyQueryError(err: unknown): QueryErrorKind | null {
+  if (!err) return null;
+  if (CombinedGraphQLErrors.is(err)) {
+    for (const ge of err.errors) {
+      const code = extensionString(ge.extensions, "code");
+      if (code === "FORBIDDEN") return { kind: "forbidden" };
+      if (code === "UNAUTHENTICATED") return { kind: "unauthenticated" };
+    }
+  }
+  return {
+    kind: "banner",
+    message: getBackendErrorBanner(err) ?? "An unexpected error occurred. Please try again.",
+  };
 }

--- a/frontend/src/lib/apollo/errors.ts
+++ b/frontend/src/lib/apollo/errors.ts
@@ -55,9 +55,8 @@ export function getBackendErrorBanner(err: unknown): string | undefined {
       internalMsg ??= ge.message;
     } else if (code === "UNAUTHENTICATED") {
       authMsg ??= "Your session expired. Please sign in again.";
-    } else if (code === "BAD_USER_INPUT" && field) {
-      // field-level error — skip for banner
-    } else {
+    } else if (code !== "BAD_USER_INPUT" || !field) {
+      // Skip field-level BAD_USER_INPUT; everything else is banner-worthy.
       firstNonFieldMsg ??= ge.message;
     }
   }

--- a/schema/schema.graphql
+++ b/schema/schema.graphql
@@ -369,9 +369,11 @@ extend type Query {
   roles: [Role!]!
 }
 
-"""Input for admin-edited user fields. null/omitted leaves the field unchanged; empty-string explicitly clears."""
+"""Input for admin-edited user fields."""
 input AdminUpdateUserInput {
+  """null/omitted = unchanged. Non-null = set; must be 1-50 grapheme clusters after trim. Empty string is rejected with BAD_USER_INPUT."""
   displayName: String
+  """null/omitted = unchanged. Empty string clears the field. Non-empty must be <= 500 grapheme clusters."""
   bio: String
 }
 

--- a/schema/schema.graphql
+++ b/schema/schema.graphql
@@ -333,3 +333,53 @@ extend type Mutation {
   """
   upsertDictionary(input: UpsertDictionaryInput!): UpsertDictionaryPayload!
 }
+
+"""A named permission role. Names are stored lowercase (e.g., "admin", "general")."""
+type Role {
+  id: ID!
+  name: String!
+}
+
+extend type User {
+  """Roles assigned to this user. Resolved via the per-request RoleByUserID DataLoader."""
+  roles: [Role!]!
+}
+
+"""One element in a UserConnection."""
+type UserEdge {
+  """Opaque cursor for this position. Currently equal to node.id."""
+  cursor: ID!
+  node: User!
+}
+
+"""Paginated list of Users (Relay Connection)."""
+type UserConnection {
+  edges: [UserEdge!]!
+  pageInfo: PageInfo!
+  """Total users matching the filter, regardless of page window."""
+  totalCount: Int!
+}
+
+extend type Query {
+  """Admin-only. Paginated user list. Non-admin callers receive FORBIDDEN."""
+  users(first: Int, after: ID, last: Int, before: ID, search: String): UserConnection!
+  """Admin-only. Single user with roles populated. Non-admin callers receive FORBIDDEN."""
+  adminUser(id: ID!): User
+  """Admin-only. List all roles (used by admin role-assignment UI). Non-admin callers receive FORBIDDEN."""
+  roles: [Role!]!
+}
+
+"""Input for admin-edited user fields. null/omitted leaves the field unchanged; empty-string explicitly clears."""
+input AdminUpdateUserInput {
+  displayName: String
+  bio: String
+}
+
+extend type Mutation {
+  """Admin-only. Edit display_name / bio of any user."""
+  adminUpdateUser(id: ID!, input: AdminUpdateUserInput!): User!
+  """Admin-only. Assign a role to a user. Idempotent."""
+  assignRole(userId: ID!, roleId: ID!): User!
+  """Admin-only. Revoke a role from a user. Self-demotion of admin role is rejected with FORBIDDEN."""
+  revokeRole(userId: ID!, roleId: ID!): User!
+}


### PR DESCRIPTION
Closes #58

## Summary

Lands the admin user surface end-to-end. The new `User.roles` field, `Query.users / adminUser / roles`, and the `Mutation.adminUpdateUser / assignRole / revokeRole` triple ride on top of a cursor-paginated `UserRepository.ListPage` (with `display_name ILIKE` search), an extended `RoleRepository` (`AssignToUser` / `RevokeFromUser` / `ListByUser` / `ListByUserIDs` / `ListAll`), a per-request `RoleByUserID` DataLoader that batches role lookups for `User.roles`, and an `AdminUserUsecase` that gates every method through `auth.Service.IsAdmin` while rejecting an admin's attempt to revoke their own admin role with FORBIDDEN. The frontend `/admin/users` list (debounced search, IO-driven infinite scroll, FORBIDDEN/UNAUTHENTICATED routing via `classifyQueryError`) and `/admin/users/[id]/edit` page (display-name + bio form plus a role checkbox grid that drives `assignRole` / `revokeRole` with per-row in-flight guards and FORBIDDEN-aware banners) consume the new schema verbatim.

## Background / Motivation

- **Self-demotion guard lives in the usecase, not the repository**: the only system-wide invariant that must hold is "at least one admin remains reachable through the admin UI." Pushing the guard into `RevokeFromUser` would force every future caller (e.g. a bulk-cleanup tool) to re-derive the same caller-equality check, and any caller forgetting it could silently lock the system out of admin management. The usecase enforces `userID == callerID && role.Name == "admin"` → FORBIDDEN with the message `"cannot revoke own admin role"`. The role name is hydrated via `roles.FindByIDs([roleID])` so a stale `roleID` cannot bypass the guard by accident. The literal `"admin"` is hoisted into a package-level `adminRoleName` constant so it stays in sync with the same string baked into `auth.Service.IsAdmin`.
- **`RoleByUserID` DataLoader, not per-row repository call**: `User.roles` runs once per row in any query that fans `User` out (e.g. `Query.users` returning 20 rows). A direct `RoleRepository.ListByUser` call per row produces 20 round-trips; the project convention (see `loader/role.go`, `loader/cardgroup.go`) is to wrap the per-row read in a per-request batched DataLoader. `RoleByUserIDLoader` keys on user id and resolves to `[]*domain.Role`, with the batch-fn explicitly short-circuiting on an empty key slice — the GORM `WHERE id IN ()` gotcha (`.claude/rules/go-library-gotchas.md`) would otherwise turn an empty batch into a full-table scan.
- **`User.roles` is admin-or-self gated, never bare**: returning roles for any caller would leak admin/role membership for arbitrary users. Returning an empty slice for unauthorised callers would still leak the existence of the field for self-introspection. The resolver gates explicitly: `caller.Sub == obj.ID` (self) or `auth.Service.IsAdmin(caller.Sub)` (admin) — anything else returns FORBIDDEN. Cancellation in the `IsAdmin` round-trip surfaces as `gqlerr.Cancelled`, not `gqlerr.Internal`, matching the convention used by `ValidateDictionary` and the dictionary usecase.
- **Distinct `ErrUserNotFound` / `ErrRoleNotFound` sentinels via `errors.Join`**: `AssignToUser` and `RevokeFromUser` need to tell the caller *which* side of the `(user, role)` pair was missing so the GraphQL response carries the right `extensions.field` (`userId` vs `roleId`) and the frontend banner-by-field machinery picks the right input. Both new sentinels are joined with the legacy `ErrNotFound` via `errors.Join`, so existing `errors.Is(err, ErrNotFound)` callers keep working while new callers can branch on the precise cause. `mapRoleAssignmentError` in the usecase matches the specific sentinels first, then falls back to `ErrNotFound`, then to context-cancellation, then to `gqlerr.Internal` — the order matters because both joined sentinels also satisfy `errors.Is(_, ErrNotFound)`.
- **Forward-paging defaults to the documented maximum, not a small hand-picked default**: when neither `first` nor `last` is supplied, the usecase defaults to `(adminUserMaxPageSize, 0)` — i.e. `first = 100`. The admin UI consumes this paged list, and its IO-loop infinite-scroll requires deterministic boundaries; defaulting to a smaller page (e.g. 20) would force every caller to know to pass a default explicitly, which is the foot-gun the constant exists to prevent. The repository-level `userPageCap = maxUserPageSize + 1 = 101` mirrors the cards repository so the usecase's `+1` fetch trick still detects another page when the caller asks for the documented maximum.
- **Cursor-direction cross-validation rejects mixed pairs at the usecase**: the Relay spec pairs `after` with `first` (forward) and `before` with `last` (backward). Mixing them or supplying both cursors at once is rejected with BAD_USER_INPUT before the repository is touched, so callers never get a silently re-interpreted page boundary. A cursor without its companion count is also rejected — the server cannot determine page size or direction, and silently picking a default would produce wrong-but-valid SQL.
- **`COUNT(*)` runs before the `(first == 0 && last == 0)` short-circuit**: callers asking only for `totalCount` (e.g. an admin overview widget that does not render the rows) still get a real value, matching the cards-pagination pattern documented in `.claude/rules/pagination.md`. The count predicate mirrors the page predicate (search filter only — cursor predicate excluded) so "items after this point" is comparable across pages.
- **`display_name ILIKE` with explicit wildcard escaping**: `escapeLikePattern` escapes `\`, `%`, and `_` (in that order, so the backslash injected by the function does not get double-escaped) before wrapping the term as `%term%`. Without this, a user-supplied search containing a literal `%` would match every row. The fixed `\` escape character is the Postgres ILIKE default; no `ESCAPE` clause is required. The `pg_trgm` index swap for larger user counts is deferred — the issue calls it out as out of scope.
- **Backward pagination via direction-flip + reverse, mirroring `cards`**: natural SQL "give me N rows before X" is awkward; the repository inverts both axes (`created_at DESC, id ASC` → `ASC, DESC`), applies `LIMIT N+1`, then reverses the slice in memory so the caller still observes the canonical forward order. The usecase mirrors the trim logic on the leading edge so the page boundary stays at the head. Pattern is identical to `card.go` and shares the test conventions in `card_pagination_test.go`.
- **`ErrCursorNotFound` distinguishes "cursor row deleted" from "no rows match the predicate"**: a cursor pointing at a user that has since been deleted is a malformed user-supplied parameter, not a server bug. The repository hydrates the cursor user's `created_at` before composing the tuple-comparison WHERE; on `gorm.ErrRecordNotFound` it returns the new `ErrCursorNotFound` sentinel which the usecase maps to `gqlerr.BadUserInput("after"|"before", "cursor not found")` with the field chosen by which cursor was supplied.
- **`gqlgen.yml` re-binds `User`, `Role`, `UserConnection`, and `UserEdge`**: gqlgen's default scaffold generates a `model.User` with `Roles []*model.Role` baked in, which would drive a third trip through codegen every time the `User.roles` resolver was edited. Pinning the model bindings to existing Go types in `gqlgen.yml` lets the resolver layer stay the only place the `roles` field is materialised. The same binding makes `helpers.go::toUserModel` continue to leave `Roles` nil so `userResolver.Roles` populates it lazily via `RoleByUserID`, mirroring the `cardResolver.Cardgroup` / `cardgroupResolver.Owner` lazy-via-DataLoader pattern.
- **Frontend: `classifyQueryError` for query-level error routing**: a list-page Apollo `useQuery` can fail with FORBIDDEN (mid-session role removal), UNAUTHENTICATED (session expired), or any number of generic banner-worthy errors. Branching directly on `extensions.code` at every call site is repetitive and easy to miss; `classifyQueryError` returns a typed `{ kind: "forbidden" | "unauthenticated" | "banner" }` that callers `switch` on. `AdminUsersClient` redirects to `/` on UNAUTHENTICATED post-mount (the SSR gate already handles cold-start) and to `/` on FORBIDDEN; everything else lands as a Retry banner.
- **Edit page is server-rendered with two parallel `gqlFetch` calls**: `AdminUserEditPage` fetches `adminUser(id)` and `roles` in parallel via `Promise.all` and passes both as plain serialised props into the client component. Pre-fetching server-side keeps the form's first paint stable (no loading spinner on either query) and pushes auth failures to a single `redirectOnAuthError` helper that string-matches `UNAUTHENTICATED` / `FORBIDDEN` and redirects to `/`. Other errors propagate to the error boundary unchanged.
- **Role checkbox grid uses per-row in-flight guards, not optimistic writes**: an optimistic toggle on `assignRole` / `revokeRole` would have to roll back on failure (e.g. self-demotion FORBIDDEN), which doubles the surface area for race conditions. The grid instead disables the checkbox while the mutation is in flight (`roleInflight[roleId]`), reads `serverRoles` from the response, and rebuilds `userRoleIds` from server truth — no rollback path because no optimistic state was ever written. FORBIDDEN responses on `revokeRole` (self-demotion) surface in a per-row banner (`roleBanners[roleId]`) without disturbing other rows.
- **Pagination test fixtures use `time.Now().Add(-i * minute)` to stagger `created_at`**: without the per-row offset, all fixture rows would share `created_at`, defeating the `(created_at DESC, id ASC)` order's primary axis and making cursor tie-break logic untestable. The minute-spaced fixtures keep both axes exercised, mirroring the cards-pagination test setup.
- **`admin_user_test.go` covers cancellation mapping (CANCELLED, not INTERNAL)**: every usecase method that calls `IsAdmin`, the role repo, or the user repo must short-circuit `context.Canceled` / `context.DeadlineExceeded` to `gqlerr.Cancelled` instead of wrapping into INTERNAL. The dedicated cancellation matrix tests pin this behaviour against future refactors that might forget the short-circuit at one site (e.g. forgetting it inside `RevokeRole`'s self-demotion lookup branch produces an INTERNAL log line on every cancelled tab close).

## Changes

### Schema

- `schema/schema.graphql`: adds `type Role { id, name }`, `extend type User { roles: [Role!]! }`, `type UserEdge { cursor, node }`, `type UserConnection { edges, pageInfo, totalCount }`, `input AdminUpdateUserInput { displayName, bio }`, `Query.users(first, after, last, before, search)`, `Query.adminUser(id)`, `Query.roles`, `Mutation.adminUpdateUser(id, input)`, `Mutation.assignRole(userId, roleId)`, and `Mutation.revokeRole(userId, roleId)`. Each new query / mutation doc-comment names the admin-only requirement; `User.roles` doc-comment names the `RoleByUserID` DataLoader so a typed-client generator carries the contract into every consumer.

### gqlgen wiring

- `backend/gqlgen.yml`: pins the `User`, `Role`, `UserConnection`, and `UserEdge` model bindings to existing types so codegen does not generate parallel scaffolds. Keeps `User.Roles` off the model (resolver field) so `userResolver.Roles` is the single materialisation site.

### Repository

- `backend/internal/repository/user.go`: adds `ListPage(ctx, after, before, first, last, search) ([]*domain.User, int64, error)` with `(created_at DESC, id ASC)` ordering, tuple-comparison WHERE for cursor-bounded pages, COUNT(*) before the zero-page short-circuit, and `display_name ILIKE` search with `\` / `%` / `_` escaping. Introduces `ErrCursorNotFound` for the cursor-row-deleted case, `maxUserPageSize = 100`, and `userPageCap = 101`.
- `backend/internal/repository/role.go`: extends `RoleRepository` with `AssignToUser`, `RevokeFromUser`, `ListByUser`, `ListByUserIDs`, and `ListAll`. Introduces `ErrUserNotFound` and `ErrRoleNotFound` joined with the legacy `ErrNotFound` via `errors.Join` so existing `errors.Is(err, ErrNotFound)` callers keep working. `ListByUserIDs` returns a `map[userID][]*Role` keyed by user id with users-without-roles absent from the map (loader fills in `[]`). `RevokeFromUser` validates user and role existence first so a missing pair surfaces the precise sentinel instead of a silent no-op.

### DataLoader

- `backend/internal/loader/role_by_user.go` (new, 50 lines): `RoleByUserIDLoader` typedef plus `roleByUserIDBatchFunc(repo)` that calls `RoleRepository.ListByUserIDs` once per request and resolves each key to `[]*domain.Role` (empty slice for users with no roles). Empty-key short-circuit guards against the GORM `WHERE id IN ()` full-scan gotcha.
- `backend/internal/loader/loader.go`: `Loaders` struct gains `RoleByUserID *RoleByUserIDLoader` and `New(...)` instantiates it via `roleByUserIDBatchFunc(roleRepo)`.

### Usecase

- `backend/internal/usecase/admin_user.go` (new, 446 lines): `AdminUserUsecase` interface (`List`, `Get`, `Update`, `AssignRole`, `RevokeRole`, `ListRoles`) plus `AdminUpdateUserInput`, `AdminUserConnection`, `AdminUserEdge`, and `PageInfo`. `requireAdmin` centralises the `auth.UserFrom` → `IsAdmin` gate and returns the caller id for the self-demotion check. `RevokeRole` performs the self-demotion lookup via `roles.FindByIDs([roleID])` so a stale `roleID` cannot bypass the guard. `mapRoleAssignmentError` matches `ErrUserNotFound` / `ErrRoleNotFound` before the legacy `ErrNotFound` fallback. `NewAdminUser` is the production constructor; `NewAdminUserWithDeps` is a test-only constructor over the narrow interface types.

### Resolver

- `backend/graph/resolver/resolver.go`: `Resolver` gains `AdminUserUC usecase.AdminUserUsecase` field; `NewResolver(...)` widens to accept it so a missing wire-up becomes a compile error in production.
- `backend/graph/resolver/schema.resolvers.go`: adds `AdminUpdateUser`, `AssignRole`, `RevokeRole` (mutation resolvers thin-wrapping the usecase), `Users`, `AdminUser`, `Roles` (query resolvers), and `userResolver.Roles` which gates self-vs-admin and dispatches via `loaders.RoleByUserID`. Cancellation in the admin gate maps to `gqlerr.Cancelled`.
- `backend/graph/resolver/helpers.go`: adds `toRoleModel` / `toRoleModels`.
- `backend/cmd/server/main.go`: constructs `usecase.NewAdminUser(userRepo, roleRepo, authSvc)` and passes it as the seventh argument to `resolver.NewResolver(...)`.

### Frontend

- `frontend/src/app/admin/users/page.tsx` (new): Server Component that resolves the Supabase user, redirects unauthenticated callers to `/`, and renders `AdminUsersClient`. Server-side admin-role enforcement is delegated to the FORBIDDEN response on `Query.users` (the unified `/admin` layout gate is deferred per #60).
- `frontend/src/app/admin/users/AdminUsersClient.tsx` (new, 280 lines): client component with debounced search (300ms), `useQuery(AdminUsersDocument)` with `cache-first`, `IntersectionObserver`-driven infinite scroll, `fetchMoreError` halt-gate, and `classifyQueryError` routing (FORBIDDEN → banner with retry, UNAUTHENTICATED → `redirect("/")`).
- `frontend/src/app/admin/users/[id]/edit/page.tsx` (new): Server Component fetching `adminUser(id)` and `roles` in parallel via `Promise.all`, with `redirectOnAuthError` mapping UNAUTHENTICATED / FORBIDDEN to `redirect("/")` and rethrowing other errors to the error boundary. Missing user redirects to `/admin/users`.
- `frontend/src/app/admin/users/[id]/edit/AdminUserEditClient.tsx` (new, 273 lines): display-name + bio form with grapheme-cluster mirrored validation (`DISPLAY_NAME_MAX = 50`, `BIO_MAX = 500`), and a role checkbox grid where each row owns its in-flight guard (`roleInflight[roleId]`) and per-row banner (`roleBanners[roleId]`). Mutation responses drive `userRoleIds` from server truth — no optimistic writes. `classifyError` walks `CombinedGraphQLErrors.is(err)` for FORBIDDEN before falling back to `getBackendErrorBanner`.
- `frontend/src/app/admin/users/queries.ts` (new): `AdminUserFieldsFragment`, `AdminRoleFieldsFragment`, `AdminUsersQuery`, `AdminUserQuery`, `AdminRolesQuery`, `AdminUpdateUserMutation`, `AdminAssignRoleMutation`, `AdminRevokeRoleMutation`, plus `ADMIN_USERS_PAGE_SIZE = 20` exported for the SSR seed / client cache parity rule (`.claude/rules/pagination.md`).
- `frontend/src/lib/apollo/errors.ts`: extracts `classifyQueryError` returning a typed `QueryErrorKind` (`{ kind: "forbidden" } | { kind: "unauthenticated" } | { kind: "banner"; message }`). Used by `AdminUsersClient` and reusable for any future admin list page.

### Tests

- `backend/internal/repository/user_pagination_test.go` (new, 458 lines): forward + backward pagination, search filter, ILIKE wildcard escaping, `ErrCursorNotFound` on cursor-row delete, total count behaviour, and the `(created_at DESC, id ASC)` tie-break under same-timestamp fixtures.
- `backend/internal/repository/role_assign_test.go` (new, 489 lines): `AssignToUser` idempotency + `ErrUserNotFound` / `ErrRoleNotFound` precision, `RevokeFromUser` idempotency on missing assignment row, `ListByUser`, `ListByUserIDs` with empty-key short-circuit, and `ListAll`.
- `backend/internal/repository/role_classify_fk_test.go` (new, 80 lines): pins the FK-violation classification in role mutations so a future `pgconn.PgError` change cannot silently downgrade `ErrUserNotFound` to a generic eris-wrapped error.
- `backend/internal/loader/role_by_user_test.go` (new, 283 lines): batch coalescing, empty-key short-circuit, error fan-out across keys, and users-with-no-roles → empty slice (not nil).
- `backend/internal/loader/user_test.go`: extended with admin-user mock surface (`countingUserRepo` gains `ListPage`).
- `backend/internal/usecase/admin_user_test.go` (new, 1129 lines): full guard-order matrix per method (UNAUTHENTICATED → FORBIDDEN → BAD_USER_INPUT → INTERNAL), self-demotion FORBIDDEN, cursor-direction cross-validation, page-size clamping, role-error sentinel mapping, cancellation → CANCELLED, and the role-not-found fallback when the legacy sentinel is the only one returned.
- `backend/graph/resolver/admin_user_resolver_test.go` (new, 705 lines): resolver-level guard-order matrix for every new field, FORBIDDEN propagation through `User.roles` for non-self-non-admin, and an explicit `RoleByUserID` N+1 assertion (`countingRoleRepo.ListByUserIDs` invocation count must be 1 across a 3-edge `Query.users` page even with `User.roles` selected on every edge).
- `backend/graph/resolver/{card_resolvers_test.go,dictionary_resolver_test.go,user_test.go}`: rebased onto the widened `NewResolver` signature.
- `frontend/__tests__/admin-users-list.test.tsx` (new, 610 lines): list page render, search debounce, infinite-scroll IO loop, `fetchMoreError` halt + Retry, FORBIDDEN banner, UNAUTHENTICATED `redirect("/")`, and a `console.warn` MockedProvider leak spy for the `"No more mocked responses"` regression (`.claude/rules/pagination.md` § "Spy on `console.warn` for MockedProvider leaks").
- `frontend/__tests__/admin-users-roles.test.tsx` (new, 275 lines): role checkbox toggle assign / revoke, in-flight disabled state, FORBIDDEN per-row banner (self-demotion), and the no-optimistic-write contract (server-truth role ids drive `userRoleIds`).

## Verification

After merge, the following should all hold:

- `grep -nE "type Role \{|extend type User \{[^}]*roles: \[Role!\]!|type UserConnection|type UserEdge|input AdminUpdateUserInput|users\(first: Int, after: ID|adminUser\(id: ID!\): User|roles: \[Role!\]!|adminUpdateUser\(id|assignRole\(userId|revokeRole\(userId" schema/schema.graphql` matches every new declaration.
- `grep -nE "func \(r \*userRepo\) ListPage\(" backend/internal/repository/user.go` matches once and the body shows `(created_at DESC, id ASC)` ordering, tuple-comparison WHERE, and the `escapeLikePattern` call. `grep -n "ErrCursorNotFound" backend/internal/repository/user.go` matches the `errors.New` declaration.
- `grep -nE "ErrUserNotFound\s*=\s*errors\.Join|ErrRoleNotFound\s*=\s*errors\.Join" backend/internal/repository/role.go` matches both joins with `ErrNotFound`. `grep -nE "func \(r \*roleRepo\) (AssignToUser|RevokeFromUser|ListByUser|ListByUserIDs|ListAll)\(" backend/internal/repository/role.go` matches all five methods.
- `grep -n "RoleByUserID" backend/internal/loader/loader.go` shows the field and constructor wiring. `grep -n "len(keys) == 0" backend/internal/loader/role_by_user.go` matches the empty-key short-circuit.
- `grep -nE "func NewAdminUser\(|func NewAdminUserWithDeps\(" backend/internal/usecase/admin_user.go` matches both constructors. `grep -n "cannot revoke own admin role" backend/internal/usecase/admin_user.go` matches the self-demotion FORBIDDEN message. `grep -n "adminRoleName" backend/internal/usecase/admin_user.go` matches the package-level constant.
- `grep -n "AdminUserUC " backend/graph/resolver/resolver.go` shows the field on `Resolver`; `grep -nE "resolver\.NewResolver\(" backend/cmd/server/main.go` includes the `adminUserUC` argument.
- `grep -nE "func \(r \*queryResolver\) (Users|AdminUser|Roles)\(|func \(r \*mutationResolver\) (AdminUpdateUser|AssignRole|RevokeRole)\(|func \(r \*userResolver\) Roles\(" backend/graph/resolver/schema.resolvers.go` matches every new resolver. The `userResolver.Roles` body contains the self-vs-admin gate and dispatches via `loaders.RoleByUserID.Load(ctx, obj.ID)`.
- `grep -n "classifyQueryError" frontend/src/lib/apollo/errors.ts` matches the helper; `grep -n "classifyQueryError" frontend/src/app/admin/users/AdminUsersClient.tsx` matches the call site. `grep -n "ADMIN_USERS_PAGE_SIZE" frontend/src/app/admin/users/queries.ts` matches the page-size export.
- `grep -n "redirectOnAuthError" frontend/src/app/admin/users/\[id\]/edit/page.tsx` matches the helper. `grep -n "userRoleIds" frontend/src/app/admin/users/\[id\]/edit/AdminUserEditClient.tsx` matches the no-optimistic-write contract and `grep -n "FORBIDDEN" frontend/src/app/admin/users/\[id\]/edit/AdminUserEditClient.tsx` matches the FORBIDDEN classifier.
- gqlgen drift: `cd backend && go tool gqlgen generate && git diff --exit-code -- backend/graph/{generated,model}/` produces no diff. graphql-codegen drift: `cd frontend && pnpm codegen && git diff --exit-code -- frontend/src/generated/` produces no diff.

## Test plan

- [ ] `cd backend && go vet ./... && go build ./...` passes.
- [ ] `cd backend && go test -v -race -covermode=atomic -coverprofile=coverage.out ./...` passes; `internal/repository/user_pagination_test.go`, `internal/repository/role_assign_test.go`, `internal/repository/role_classify_fk_test.go`, `internal/loader/role_by_user_test.go`, `internal/usecase/admin_user_test.go`, and `graph/resolver/admin_user_resolver_test.go` all run.
- [ ] `cd frontend && pnpm install && pnpm lint && pnpm typecheck && pnpm build && pnpm test` passes; `__tests__/admin-users-list.test.tsx` and `__tests__/admin-users-roles.test.tsx` cover the IO-loop, search debounce, and role-toggle paths.
- [ ] N+1 regression: `graph/resolver/admin_user_resolver_test.go` asserts `countingRoleRepo.ListByUserIDs` was invoked exactly once across a 3-edge `Query.users` page even with `User.roles` selected on every edge.
- [ ] gqlgen + graphql-codegen drift: both regen targets are clean (`git diff --exit-code -- backend/graph/{generated,model}/` and `git diff --exit-code -- frontend/src/generated/`).
- [ ] Manual happy path: signed in as admin, open `/admin/users`. List paginates via infinite scroll; search box filters by `display_name` after a 300ms debounce. Click Edit on a row, change display-name + bio, save — banner reads `Changes saved.` and the row in the list reflects the new name on next refetch.
- [ ] Manual role toggle: on `/admin/users/<id>/edit`, toggle a non-admin role checkbox — server response refreshes `userRoleIds` and the checkbox stays checked. Toggle the admin role on a second user — same.
- [ ] Manual self-demotion FORBIDDEN: on `/admin/users/<own-id>/edit`, attempt to uncheck the admin role — request returns FORBIDDEN, the per-row banner reads `cannot revoke own admin role`, and the checkbox remains checked.
- [ ] Manual non-admin path: signed in as a non-admin user, open `/admin/users` — `Query.users` returns FORBIDDEN, the page surfaces the banner; UNAUTHENTICATED on session expiry redirects to `/`.
- [ ] Manual `User.roles` admin/self gate: signed in as a non-admin, `me { roles { id } }` returns the caller's own roles; `users { edges { node { roles { id } } } }` returns FORBIDDEN.
- [ ] Manual cancellation: while `users` or `revokeRole` is in flight, close the browser tab — server logs do not show an INTERNAL error envelope; if the response arrives at all it carries `extensions.code = "CANCELLED"`.
- [ ] Language-policy grep clean: `grep -rnP "[\x{3040}-\x{30ff}\x{4e00}-\x{9fff}]" --include="*.go" --include="*.ts" --include="*.tsx" --include="*.graphql" --include="*.sql" --include="*.md" docs backend/internal backend/cmd backend/graph frontend/src` returns nothing. `grep -rnE "PR[0-9]+" docs backend/internal backend/cmd backend/graph frontend/src` returns nothing.

## Out of scope (deferred to follow-up)

- **Unified `/admin` route-segment gate** (#60): `/admin/users/page.tsx` and `/admin/users/[id]/edit/page.tsx` rely on the server-side FORBIDDEN response from `Query.users` / `Query.adminUser` to gate non-admin callers. The unified `frontend/src/app/admin/layout.tsx` that gates every `/admin/*` page in one place is the right home for the role check; this PR keeps the pages accessible to any authenticated user with the page-level handlers covering FORBIDDEN.
- **User deletion**: requires a cascade strategy across cardgroups / cards / swipe_records and is out of scope per the issue.
- **Sorting columns and `pg_trgm` search index**: list defaults to `created_at DESC, id ASC`; search is `display_name ILIKE '%q%'`. Both are sufficient for current user counts; revisit when the table grows.
