### PR TITLE
ci(frontend): run Codecov upload from repo root so frontend flag is non-empty

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -85,13 +85,17 @@ jobs:
 
       - name: Upload coverage to Codecov
         id: codecov
+        # Run from the repo root (no `working-directory`) so the CLI's network
+        # discovery prepends `frontend/` to the `SF:src/...` entries emitted by
+        # vitest. With it set, uploaded paths stay `src/...` and the
+        # `flags.frontend.paths: frontend/` filter in codecov.yml drops every
+        # file, leaving the flag at 0% (badge renders as "unknown").
         uses: codecov/codecov-action@v6
         continue-on-error: true
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: frontend/coverage/lcov.info
           flags: frontend
-          working-directory: frontend
           fail_ci_if_error: true
 
       - name: Warn on Codecov upload failure


### PR DESCRIPTION
## Summary

Drops `working-directory: frontend` from the Codecov upload step in `.github/workflows/frontend.yml` so the CLI runs from the repo root and rewrites the LCOV `SF:src/...` entries (vitest's v8 reporter is project-relative) into `frontend/src/...`. Without this, every uploaded file fell outside the `flags.frontend.paths: frontend/` filter in `codecov.yml`, the `frontend` flag carried 0% coverage, and the Codecov frontend badge rendered as "unknown".

## Background / Motivation

- **`working-directory` made the CLI's network discovery think the repo root is `frontend/`.** Codecov's CLI walks up from the working directory to find the `.git` root, then uses that as the prefix base for LCOV path normalisation. With `working-directory: frontend`, the CLI still finds the same `.git` root but it has already swallowed the `frontend/` segment as part of its own cwd, so the `SF:src/...` entries get uploaded verbatim — no `frontend/` prefix is prepended.
- **`flags.frontend.paths: frontend/` then filters out every uploaded file.** The filter is applied **after** path normalisation; with no `frontend/` prefix, `src/app/page.tsx` does not match `frontend/`, the file is dropped, and the flag's totals stay at 0% / 0 lines. Carryforward keeps the badge alive but the per-PR diff has nothing to compare against.
- **Running from the repo root is the documented Codecov posture for monorepos.** Codecov's own monorepo guidance recommends invoking the CLI from the repo root and relying on `flags.<name>.paths` to scope the upload, not on `working-directory` to rewrite the LCOV paths. The `files: frontend/coverage/lcov.info` argument already names the report explicitly, so the working-directory was load-bearing only for the path-normalisation side effect that turned out to be the bug.

## Changes

- `.github/workflows/frontend.yml`: removes `working-directory: frontend` from the `codecov/codecov-action@v6` step. Adds a 5-line comment above the `uses:` line explaining why the absence of `working-directory` is load-bearing — the next contributor who tries to "tidy up" by re-adding `working-directory: frontend` will read the comment first. `files: frontend/coverage/lcov.info`, `flags: frontend`, and `fail_ci_if_error: true` are unchanged.

## Verification

After merge, the next push to `main` that touches `frontend/**` should produce a Codecov upload visible in the Actions log with rewritten paths. Concrete checks:

- In the "Upload coverage to Codecov" step log, the `Codecov CLI` lines should report `frontend/src/...` paths in the "files" section, not `src/...`.
- The Codecov dashboard's `frontend` flag should show a non-zero `lines` count and a coverage percentage matching the local `pnpm --filter frontend test --coverage` run.
- The `frontend` badge in `README.md` (or wherever the Codecov flag badge is embedded) should render the actual percentage rather than "unknown".
- `grep -n "working-directory: frontend" .github/workflows/frontend.yml` returns nothing (the only matched line on `main` was inside the codecov step).

## Test plan

- [ ] CI run on this PR: the "Upload coverage to Codecov" step succeeds and the uploaded report shows `frontend/src/...` paths (visible in the action log).
- [ ] After merge, observe the next `main` build: the Codecov frontend flag transitions from "unknown" / 0% to a real percentage on the Codecov project page.
- [ ] `grep -nE "working-directory: *frontend" .github/workflows/frontend.yml` returns nothing.
- [ ] No production code change — `git diff --stat main...HEAD -- frontend/src/ backend/internal/ backend/cmd/ schema/` reports nothing.
