### PR TITLE
feat(frontend): auth-aware landing routes and admin-aware header

### DIFF
--- a/.claude/rules/frontend-rsc-error-handling.md
+++ b/.claude/rules/frontend-rsc-error-handling.md
@@ -1,0 +1,95 @@
+# Frontend RSC error handling
+
+> Applies to: `frontend/src/app/**/*.tsx` (React Server Components, layouts, route handlers) and `frontend/src/lib/apollo/server.ts` (the `gqlFetch` helper). Cross-cutting because every RSC that talks to Supabase + GraphQL has the same five failure modes — session-missing, session-expired, GraphQL `UNAUTHENTICATED`, GraphQL `FORBIDDEN`, and infrastructure 5xx — and they must be handled uniformly to avoid 500-ing the whole app.
+
+## `AuthSessionMissingError` is the "no session" signal — filter it, do not throw
+
+`createSupabaseServerClient().auth.getUser()` returns `{ data: { user: null }, error: AuthSessionMissingError }` for an anonymous request. This is the **happy path** for landing pages, the public Header, and any RSC that renders something for both signed-in and anonymous viewers. Treat any other error as a real failure:
+
+```ts
+const { data: { user }, error } = await supabase.auth.getUser();
+if (error && error.name !== "AuthSessionMissingError") {
+  console.error("[scope] getUser() failed:", error.name, error.message);
+  throw error;
+}
+// `user` is `User | null` here — branch on it.
+```
+
+The filter is keyed on `error.name` (string), not on `instanceof` — Supabase's class identity does not survive serialization across the SDK's internal boundaries reliably. Used today in `frontend/src/app/_components/header.tsx`, `frontend/src/app/page.tsx`, and `frontend/src/app/login/page.tsx`.
+
+## Header (root layout) MUST degrade on failure, never throw
+
+`Header` lives in `app/layout.tsx`, so anything it throws escapes every route segment's `error.tsx` and surfaces as `app/global-error.tsx` (or Next's default 500 page). Throwing for a failed `me` fetch turns one stale role lookup into a site-wide 500. The Header is the **display layer** and must:
+
+1. Render a degraded shell (logo only) when `getUser()` fails for a reason other than `AuthSessionMissingError`.
+2. Skip the GraphQL `me` call entirely when `user == null` — anonymous users do not have roles to load, and the call would spam `UNAUTHENTICATED` into the warn log (see "Skip auth-requiring GraphQL calls" below).
+3. On `me` failure, swallow `UNAUTHENTICATED` silently (Supabase session valid + GraphQL token rejected = expected race during clock skew or JWKS rotation), `console.warn` everything else, and fall back to `isAdmin = false`.
+
+The **authorization gate** is `app/admin/layout.tsx`, which redirects on failure. The two layers are deliberately asymmetric: Header is UI hint, admin layout is the enforcement boundary. A broken Header never grants access; an over-eager Header throw 500s the whole site.
+
+This is why `app/<route>/error.tsx` cannot rescue layout-level throws — the same constraint as the `Gotchas encountered` entry in `docs/frontend.md` ("`app/<route>/error.tsx` does not catch errors from `app/layout.tsx`").
+
+## Structurally parse GraphQL `extensions.code` — never substring-match the message
+
+`gqlFetch` (`frontend/src/lib/apollo/server.ts`) throws a single message-shaped error when the backend returns GraphQL errors:
+
+```
+Error("GraphQL errors: " + JSON.stringify(json.errors))
+```
+
+i.e. the literal prefix `GraphQL errors: ` followed by the JSON-stringified `errors` array as returned by the backend. Each entry has the standard `{ message, path, extensions: { code, ... } }` shape.
+
+Code that needs to branch on a specific code (e.g. swallowing `UNAUTHENTICATED` in the Header) MUST parse the JSON and read `extensions.code`, not substring-match the message. Substring matches conflate a real `UNAUTHENTICATED` extension with any error whose message text happens to contain the word, including user-supplied input echoed by the backend, future telemetry strings, or stack-trace fragments. The reference shape is `isUnauthenticatedGraphQLError` in `frontend/src/app/_components/header.tsx`:
+
+```ts
+function isUnauthenticatedGraphQLError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  const prefix = "GraphQL errors: ";
+  if (!err.message.startsWith(prefix)) return false;
+  try {
+    const parsed = JSON.parse(err.message.slice(prefix.length)) as Array<{
+      extensions?: { code?: string };
+    }>;
+    return Array.isArray(parsed) && parsed.some((e) => e?.extensions?.code === "UNAUTHENTICATED");
+  } catch {
+    return false;
+  }
+}
+```
+
+The existing `redirectIfUnauthenticated` helper (in `frontend/src/lib/apollo/server-redirect.ts`) is documented in `docs/frontend.md` as still using a substring match — that helper predates this rule and is acceptable for the redirect path because both sides converge on the same `/login` target. New code paths that need to branch finer (silent swallow vs. warn vs. redirect) MUST go structural.
+
+## `console.error("[scope] getUser() failed:", err.name, err.message)` before throwing in RSC
+
+Next.js may abbreviate or replace thrown errors in production (the App Router strips error.message in prod and renders a generic "Application error" page unless the error is a `NEXT_REDIRECT` or similar special). Operators triaging a failure see only the boundary log, not the underlying cause. RSCs that rethrow a real `getUser()` failure must log first:
+
+```ts
+if (error && error.name !== "AuthSessionMissingError") {
+  console.error("[home] getUser() failed:", error.name, error.message);
+  throw error;
+}
+```
+
+The `[scope]` prefix is the route or component name (`[home]`, `[login]`, `[header]`, `[healthz]`) so the log is greppable. Used today in `frontend/src/app/page.tsx`, `frontend/src/app/login/page.tsx`, `frontend/src/app/_components/header.tsx`, and `frontend/src/app/api/healthz/route.ts`.
+
+## Skip auth-requiring GraphQL calls when the client knows the user is anonymous
+
+When an RSC has already determined `user == null` from `supabase.auth.getUser()`, do not issue any GraphQL query that requires `Authorization`. The backend will return `UNAUTHENTICATED`, the call site has to special-case the error, and the warn log fills with expected-and-uninteresting noise. Gate the call:
+
+```ts
+let isAdmin = false;
+if (user) {
+  try {
+    const meData = await gqlFetch(HeaderMeQuery, { revalidate: 0 });
+    isAdmin = meData.me?.roles.some((r) => r.name === "admin") ?? false;
+  } catch (err) { /* ... */ }
+}
+```
+
+This is the inverse of the "fail-closed in `gqlFetch`" rule documented in `docs/frontend.md` § "Authorization forwarding in `gqlFetch`": `gqlFetch` itself throws on a session-fetch error rather than silently sending an anonymous request, but **callers** of `gqlFetch` are responsible for not invoking it in the first place when they already know the user is anonymous.
+
+## `revalidate: 0` for any RSC fetch that depends on the current user
+
+Any GraphQL query whose result depends on `Authorization` (role lookups, `me`, owned-resource queries, profile data) must pass `{ revalidate: 0 }` to `gqlFetch`. Caching auth-sensitive data either across users (via Next's data cache key, which does not include the access token) or across role changes (admin role revoked while the cached page is alive) is a correctness bug. Used today in `frontend/src/app/_components/header.tsx`, `frontend/src/app/admin/layout.tsx`, `frontend/src/app/profile/page.tsx`, and `frontend/src/app/api/healthz/route.ts` (the last one for probe freshness, not auth, but the constant is the same).
+
+The three `revalidate` states are documented in `docs/frontend.md` — `0` means no cache, `false` means cache forever, omitted means Next's default heuristic. Pick `0` for auth-sensitive; never collapse to a `number` default.

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -64,6 +64,23 @@ jobs:
       - name: Codegen (graphql-codegen)
         run: pnpm --filter frontend codegen
 
+      # `next-env.d.ts` and `.next/types/routes.d.ts` are gitignored
+      # (Next.js 16 toggles paths between dev/build — see
+      # docs/dev-setup.md §"Policy on generated files"). `next typegen`
+      # regenerates both faster than a full `next build` so the typecheck
+      # step below sees a valid type tree.
+      - name: Codegen (Next.js typegen)
+        run: pnpm --filter frontend exec next typegen
+
+      - name: Guard against re-tracking next-env.d.ts
+        run: |
+          if git ls-files --error-unmatch frontend/next-env.d.ts >/dev/null 2>&1; then
+            echo "::error::frontend/next-env.d.ts is tracked but must remain gitignored."
+            echo "Next.js 16 toggles its import path between 'next dev' and 'next build' — committing it produces a churn loop."
+            echo "Fix: git rm --cached frontend/next-env.d.ts (the file regenerates on every Next.js invocation)."
+            exit 1
+          fi
+
       - name: Biome check
         run: pnpm --filter frontend lint
 

--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,12 @@ backend/server
 /backend/graph/model/models_gen.go
 /frontend/src/generated/
 
+# Next.js auto-generated TypeScript shim. Toggles import paths between
+# `next dev` and `next build` runs (Next.js 16 `isolatedDevBuild`), so
+# committing it produces a churn loop. Regenerated on every Next.js
+# invocation; see docs/dev-setup.md §"Policy on generated files".
+/frontend/next-env.d.ts
+
 # Supabase CLI local state
 supabase/.branches/
 supabase/.temp/

--- a/README.md
+++ b/README.md
@@ -46,17 +46,30 @@ Sign in via `http://127.0.0.1:3000/login` (Google) → land on `/profile`. Use *
 
 Production runs across Supabase (Postgres + Auth), Render (Go backend), and Vercel (Next.js frontend), provisioned manually through each provider's dashboard. Full checklist in `docs/deployment.md`; `make setup-prod` wraps it with prerequisite checks and smoke tests.
 
+## Setup For Production
+
+`make setup-prod` is a guided wrapper around the manual `docs/deployment.md` runbook: it validates Supabase / Render / Vercel / GitHub tokens, hands off to the provider dashboards, and runs smoke tests once each service is up. Prerequisites (PATs, Google OAuth client, GitHub App installations) and the env var matrix live in `docs/deployment.md`.
+
+```bash
+make setup-prod-preflight   # validate tokens & GitHub App installations only (unattended)
+make setup-prod             # full guided bring-up
+make setup-prod-postapply   # re-run first Render deploy + smoke tests from .state.yml
+```
+
+`make teardown-prod` is the destructive inverse — only use it on environments created by `setup-prod`.
+
 ## Makefile reference
 
 | Target | What it does |
 |---|---|
-| `make setup` | One-shot first-time setup |
+| `make setup` | One-shot first-time local setup |
 | `make sync-env` | Idempotent env sync from `supabase status -o env` |
 | `make supabase-restart` | Re-boot Supabase to pick up `./.env` edits |
 | `make dev-backend` | Start the Go / Echo backend on port 1323 |
 | `make dev-frontend` | Start the Next.js 16 dev server on port 3000 |
 | `make codegen` | Regenerate GraphQL bindings on both sides from `schema/*.graphql` |
 | `make test` | Run backend Go tests (race + coverage) and frontend Vitest suite |
+| `make setup-prod` | Guided production bring-up across Supabase + Render + Vercel (see § "Setup For Production") |
 
 `make dev-backend` / `make dev-frontend` are foreground processes — run them in separate terminals. `make codegen` is required after editing `schema/*.graphql` (generated outputs are gitignored). `make test` mirrors CI.
 

--- a/README.md
+++ b/README.md
@@ -11,109 +11,54 @@
 
 ![Production architecture](docs/images/architecture.png)
 
-Diagram source: `docs/images/diagram.py` (rendered with the [diagrams](https://diagrams.mingrammer.com/) Python library + Graphviz). See `docs/images/README.md` for regeneration steps.
-
 ## Quick Start
-
-A first-time contributor should be able to go from a fresh clone to a logged-in local app in well under an hour by following the four phases below. Each phase has a single L2 doc as its source of truth — this section is the launchpad, not the manual.
 
 ### 1. Prerequisites
 
 | Tool | Why | How to install |
 |---|---|---|
-| **mise** | Pins Go, Node, pnpm, and the Supabase CLI to the versions in `.tool-versions` files (no global drift) | `curl https://mise.run \| sh` |
+| **mise** | Pins Go, Node, pnpm, and the Supabase CLI to the versions in `.tool-versions` files | `curl https://mise.run \| sh` |
 | **Docker** | Backs `supabase start` (Postgres + Auth running locally) | Docker Desktop / OrbStack / colima |
 
-Versions resolved by `mise install` at the repo root:
-
-- Go `1.26.2` — from `backend/.tool-versions`
-- Node `24.x`, pnpm `10.33.2`, Supabase CLI — from `./.tool-versions`
-
-Do not install pnpm via `npm i -g pnpm` or `brew install pnpm` — a PATH-level binary shadows the mise shim and silently breaks version pinning. If you previously installed it that way, uninstall it first.
-
-Verify after installation:
-
-```bash
-node --version    # v24.x.y
-pnpm --version    # 10.33.2 (from .tool-versions via mise)
-which pnpm        # ~/.local/share/mise/shims/pnpm
-```
-
-See `docs/dev-setup.md` § "Tools" for rationale (why mise-managed pnpm, mise hierarchy).
+Do not install pnpm via `npm i -g pnpm` or `brew install pnpm` — a PATH-level binary shadows the mise shim and silently breaks version pinning. See `docs/dev-setup.md` § "Tools".
 
 ### 2. Initial setup
 
-Once the prerequisites above are installed (and Docker is running), one command does everything reproducible:
+With Docker running:
 
 ```bash
 make setup
 # → check-docker → mise install → pnpm install → supabase start → sync-env → check-google-oauth
 ```
 
-The final `check-google-oauth` step inspects the root `./.env` (created from `.env.example` on the first run) and prints either:
-
-- a **green confirmation** if `SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID` / `_SECRET` are real values, or
-- a **red warning** with exactly which two lines to edit and the next command to run (`make supabase-restart`).
-
-The **only manual step** is editing `./.env` to add the Google OAuth client credentials. Everything else (frontend `.env.local`, backend `.env.local`, mise tool installs, Supabase boot, key derivation) is handled by `make setup`.
-
-> **Single source of truth.** The root `./.env` is the only file you hand-edit; `frontend/.env.local` and `backend/.env.local` are auto-generated and bear a `# managed-by: sync-env` marker on line 1. Re-running `make setup` is safe — managed files are regenerated, user-owned files (marker removed) are skipped with a notice. Full layout in `docs/dev-setup.md` § "Env file layout (single source of truth)".
-
-The Google OAuth procedure (Cloud Console steps, `127.0.0.1`-vs-`localhost` rule, JavaScript origin & redirect URI) lives in `docs/dev-setup.md` § "Supabase CLI" — start at the "Auth flow (read this first)" subsection.
-
-> Local and production each use a **separate Google OAuth client**. Local credentials live in the root `./.env`; production credentials are configured directly in the production Supabase Auth settings. See `docs/dev-setup.md` and `docs/deployment.md` section "Manual prerequisites" → Google OAuth client.
+The **only manual step** is editing `./.env` to add Google OAuth client credentials. `frontend/.env.local` and `backend/.env.local` are auto-generated and re-running `make setup` is safe. Full procedure (Cloud Console steps, `127.0.0.1`-vs-`localhost` rule) in `docs/dev-setup.md` § "Supabase CLI".
 
 ### 3. Run locally
-
-Two long-running processes; run them in separate terminals (Supabase is already up from step 2):
 
 ```bash
 make dev-backend     # Go server on http://127.0.0.1:1323
 make dev-frontend    # Next.js dev server on http://127.0.0.1:3000
 ```
 
-Sign in via `http://127.0.0.1:3000/login` (Google) → land on `/profile`. The profile page issues an authenticated GraphQL `me` query through the Next rewrite, exercising the full Frontend → Backend → Supabase chain.
-
-Use **`127.0.0.1`**, not `localhost`. Google OAuth treats them as distinct origins and will reject the redirect otherwise (`docs/dev-setup.md` § "Gotchas").
+Sign in via `http://127.0.0.1:3000/login` (Google) → land on `/profile`. Use **`127.0.0.1`**, not `localhost` — Google OAuth treats them as distinct origins.
 
 ### 4. Production deployment
 
-Production runs across three providers — Supabase (Postgres + Auth), Render (Go backend), Vercel (Next.js frontend) — and is provisioned manually through each provider's dashboard. The first-time bring-up walks through:
-
-1. Creating a Supabase project, capturing the project ref / API keys / DSN.
-2. Creating a Render web service against `backend/`, wiring its env vars.
-3. Creating a Vercel project against `frontend/`, wiring its env vars.
-4. Looping the Vercel domain back into Supabase Auth (Site URL + redirect allow list) and replacing the Google OAuth redirect URI placeholder.
-
-The full checklist with prerequisites (Supabase PAT, Render / Vercel API tokens, Google OAuth client credentials), env var matrices, and post-bring-up smoke tests lives in `docs/deployment.md`. For a guided run that wraps the manual procedure with prerequisite checks, value-derivation, GitHub Secret registration, and smoke tests, use `make setup-prod`.
+Production runs across Supabase (Postgres + Auth), Render (Go backend), and Vercel (Next.js frontend), provisioned manually through each provider's dashboard. Full checklist in `docs/deployment.md`; `make setup-prod` wraps it with prerequisite checks and smoke tests.
 
 ## Makefile reference
 
-The repo's Makefile is a thin convenience layer over `go`, `pnpm`, `gqlgen`, and an Ansible playbook (`playbooks/setup.yml`) that owns env-file generation and Supabase lifecycle. Running `make` with no argument prints the same table:
+| Target | What it does |
+|---|---|
+| `make setup` | One-shot first-time setup |
+| `make sync-env` | Idempotent env sync from `supabase status -o env` |
+| `make supabase-restart` | Re-boot Supabase to pick up `./.env` edits |
+| `make dev-backend` | Start the Go / Echo backend on port 1323 |
+| `make dev-frontend` | Start the Next.js 16 dev server on port 3000 |
+| `make codegen` | Regenerate GraphQL bindings on both sides from `schema/*.graphql` |
+| `make test` | Run backend Go tests (race + coverage) and frontend Vitest suite |
 
-```bash
-make                  # shows this help (DEFAULT_GOAL)
-```
-
-| Target | What it does | Underlying command |
-|---|---|---|
-| `make setup` | One-shot first-time setup (assumes prerequisites are installed) | `check-docker` → `mise install` → `ansible-playbook playbooks/setup.yml` |
-| `make sync-env` | Idempotent env sync: seed `./.env` from example, derive `frontend/.env.local` keys from `supabase status -o env`, seed `backend/.env.local` | `ansible-playbook ... --tags sync-env` |
-| `make check-google-oauth` | Verify root `./.env` has real Google OAuth credentials (warns if placeholder) | `ansible-playbook ... --tags google-check` |
-| `make supabase-restart` | Stop and re-boot Supabase so it picks up edits to `./.env` | `supabase stop && ansible-playbook ... --tags supabase` |
-| `make install` | Install all workspace dependencies | `ansible-playbook ... --tags pnpm` |
-| `make dev-backend` | Start the Go / Echo backend on port 1323 | `cd backend && go run ./cmd/server` |
-| `make dev-frontend` | Start the Next.js 16 dev server on port 3000 | `pnpm --filter frontend dev` |
-| `make codegen` | Regenerate GraphQL bindings on both sides from `schema/*.graphql` | `go tool gqlgen generate` (backend) + `pnpm --filter frontend codegen` |
-| `make test` | Run backend Go tests (with race + coverage) and frontend Vitest suite | `go test -race -covermode=atomic ./...` + `pnpm --filter frontend test` |
-
-Tips:
-
-- **`make dev-backend` and `make dev-frontend` are foreground processes.** Run them in separate terminals (or under `tmux` / your editor's tasks panel). They do not background themselves.
-- **`make codegen` is required after editing `schema/*.graphql`.** Generated outputs are gitignored on purpose — see `docs/dev-setup.md` § "Policy on generated files". CI regenerates and verifies on every push.
-- **`make test` mirrors CI.** If `make test` passes locally and CI fails, suspect environment drift (Go / Node / pnpm version, or a global pnpm shadowing the mise shim) before assuming a CI bug.
-- **The Makefile lives at the repo root.** Backend-only targets still `cd backend &&` internally so you can invoke `make` from anywhere in the tree.
-- **Direct invocation is fine.** `make dev-backend` is identical to `cd backend && go run ./cmd/server`. Use whichever you prefer; the Makefile is documentation, not a wrapper that adds behavior.
+`make dev-backend` / `make dev-frontend` are foreground processes — run them in separate terminals. `make codegen` is required after editing `schema/*.graphql` (generated outputs are gitignored). `make test` mirrors CI.
 
 ## Repository layout
 
@@ -122,26 +67,7 @@ backend/            Go / Echo backend (the only end-to-end-wired surface today)
 frontend/           Next.js 16 App Router frontend
 schema/             Shared GraphQL schema (source of truth for both codegen tools)
 docs/               L2 architecture & topic docs
-.claude/rules/      L3 cross-cutting conventions (language policy, etc.)
+.claude/rules/      L3 cross-cutting conventions
 ```
 
 Project-wide guidance for AI assistants lives in `CLAUDE.md`.
-
-## Further reading
-
-| Doc | Topic |
-|---|---|
-| `docs/dev-setup.md` | Local toolchain, Supabase CLI, Google OAuth for local, codegen policy |
-| `docs/backend.md` | Backend runtime, HTTP server, env vars, testing, logging |
-| `docs/backend-graphql.md` | GraphQL endpoint, gqlgen, resolvers, error helpers, DataLoader |
-| `docs/backend-auth.md` | Authentication, JWT, JWKS, role authz |
-| `docs/backend-db.md` | Database, migrations, RLS, GORM patterns |
-| `docs/frontend.md` | Frontend architecture, backend rewrite contract, Profile page |
-| `docs/observability.md` | Tracing, request-ID, APQ — backend ↔ frontend contract |
-| `docs/ci.md` | CI workflows and what each one verifies |
-| `docs/deployment.md` | Production bring-up across Supabase + Render + Vercel |
-| `docs/playbook-patterns.md` | Ansible idioms and migration recovery |
-| `.claude/rules/language-policy.md` | English-only rule for committed text, no PR-order references |
-| `.claude/rules/pagination.md` | Relay Connection conventions (cards-by-cardgroup) |
-| `.claude/rules/error-wrapping.md` | eris convention, `fmt.Errorf("%w")` ban |
-| `.claude/rules/go-library-gotchas.md` | Echo v5, GORM, JWT, slog, crypto/subtle quirks |

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -3,6 +3,12 @@ PORT=1323
 SHUTDOWN_TIMEOUT=25s
 SWIPE_NEXT_BATCH_SIZE=10
 
+# Internal /internal/ping bearer token (REQUIRED -- server fails to start if empty).
+# `make setup` / `make sync-env` auto-generates a 64-hex-char value when this is
+# empty in backend/.env.local; do not hand-edit unless you need a specific token.
+# Production uses a separately managed secret (see docs/deployment.md).
+PING_TOKEN=
+
 # Supabase Auth (JWT verification, see docs/backend.md §Authentication)
 # All three are REQUIRED — server fails to start if any is missing.
 SUPABASE_JWKS_URL=http://127.0.0.1:54321/auth/v1/.well-known/jwks.json

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -46,11 +46,25 @@ The two GraphQL codegen outputs are **gitignored**; the goyacc parser output is 
 |---|---|---|---|---|
 | gqlgen | `schema/*.graphql`, `backend/gqlgen.yml`, `backend/go.mod` (`tool` directive) | `backend/graph/generated/`, `backend/graph/model/models_gen.go` | gitignored | `cd backend && go tool gqlgen generate` |
 | graphql-codegen | `schema/*.graphql`, `frontend/codegen.ts`, `frontend/src/**/*.{ts,tsx}` | `frontend/src/generated/` | gitignored | `pnpm --filter frontend codegen` |
+| Next.js | (n/a — emitted by `next dev` / `next build`) | `frontend/next-env.d.ts` | gitignored | `pnpm --filter frontend dev` or `... build` |
 | goyacc | `backend/internal/textdic/grammar.y` | `backend/internal/textdic/parser.go` | **committed** | `make codegen-yacc` |
 
 For gqlgen / graphql-codegen, determinism relies on pinned tool versions (in `go.mod` and `package.json`) plus the committed schema. CI runs the backend regeneration before `go vet` and `go test` (`.github/workflows/backend.yml`). Frontend CI runs `pnpm --filter frontend codegen` before Biome check / typecheck / build (`.github/workflows/frontend.yml`), mirroring the backend contract. No `git diff --exit-code` step is needed because the outputs are not tracked.
 
 Rationale: keeps PR diffs to hand-written code only and removes the merge-conflict churn that committing thousand-line generated files causes. Applied symmetrically to both stacks for consistency.
+
+### `next-env.d.ts` is gitignored
+
+Next.js 16 rewrites the file's single `import` statement based on which command was just run:
+
+- After `next dev` (Turbopack default in Next 16): `import "./.next/dev/types/routes.d.ts";`
+- After `next build`: `import "./.next/types/routes.d.ts";`
+
+The toggle is intentional — it is the visible side-effect of the `experimental.isolatedDevBuild` feature (default `true` in Next.js 16) which keeps a running dev server's type cache from being clobbered by a concurrent `next build` (e.g. CI or AI agents validating the project alongside development). Upstream issues [vercel/next.js#85738](https://github.com/vercel/next.js/issues/85738) and [#86001](https://github.com/vercel/next.js/issues/86001) were both closed as working-as-intended, and the official [Next.js TypeScript docs](https://nextjs.org/docs/app/api-reference/config/typescript) now recommend adding `next-env.d.ts` to `.gitignore` (a reversal of the older "do not edit, do commit" guidance still embedded in the file's own comment).
+
+Frontend CI regenerates the file (and the matching `.next/types/routes.d.ts` it imports) via [`next typegen`](https://nextjs.org/docs/app/api-reference/cli/next) — introduced in Next.js 15.5, dedicated to type emission, and faster than running a full `next build` solely to refresh types. The step runs before Biome / typecheck / build in `.github/workflows/frontend.yml`, and a follow-up `git ls-files --error-unmatch` guard fails CI if anyone re-stages the file with `git add -f`.
+
+Do **not** reach for `experimental.isolatedDevBuild: false` to "fix" the toggle: it silences the churn but opts out of the dev/build isolation that Next.js 16 added on purpose, which matters in this monorepo (CI builds, dev server, and agents may run concurrently against the same checkout).
 
 `goyacc` (added via `go get -tool golang.org/x/tools/cmd/goyacc`, which appends to the `tool ( ... )` block in `go.mod`) is the exception: the generated `parser.go` is committed because the goyacc emitter is not byte-for-byte stable across Go and tool versions, and the test suite — not CI regeneration — is the contract that catches grammar drift. Edit `grammar.y` only; never hand-edit `parser.go`. After regenerating with `make codegen-yacc`, commit both files together.
 

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -101,7 +101,7 @@ Three env files exist for local development; **only the root `.env` is hand-edit
 |---|---|---|
 | **`./.env`** | **You** (Google OAuth credentials) | `SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID/SECRET`. Auto-exported into the shell by `mise.toml` so `supabase start` resolves the `env()` placeholders in `supabase/config.toml`. |
 | `frontend/.env.local` | `make sync-env` | `NEXT_PUBLIC_SUPABASE_URL` + `NEXT_PUBLIC_SUPABASE_ANON_KEY` derived from `supabase status -o env`. Regenerated on every sync while the marker is present. Loaded natively by Next.js from its own CWD. |
-| `backend/.env.local` | `make sync-env` (seeded once) | JWKS / JWT audience / issuer / pool tuning. Seeded from `backend/.env.example`; not regenerated after that. Loaded by `cmd/server/main.go` itself via `godotenv` — **not** auto-exported into the shell, so backend env names (`PORT`, `SUPABASE_*`) cannot leak into sibling processes such as `next dev`. |
+| `backend/.env.local` | `make sync-env` (seeded once) | JWKS / JWT audience / issuer / pool tuning. Seeded from `backend/.env.example`; not regenerated after that **except** for `PING_TOKEN`, which `make sync-env` auto-generates (64 hex chars via `openssl rand -hex 32`) when empty or missing — subsequent runs are a no-op. Loaded by `cmd/server/main.go` itself via `godotenv` — **not** auto-exported into the shell, so backend env names (`PORT`, `SUPABASE_*`) cannot leak into sibling processes such as `next dev`. |
 
 Removing the marker line from a managed file marks it as user-owned; subsequent `make sync-env` runs will skip it and warn that it may be stale.
 

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -131,6 +131,53 @@ Cache update pattern: read the Connection query via `cache.readQuery` → filter
 
 Early-return guard: the `update` callback must begin with `if (data?.deleteCards == null) return;`. Although Apollo Client normally skips `update` on network-layer rejection, a synchronous error inside the callback body will still fire `cache.evict + cache.gc` on whatever was already processed, causing cards to visually vanish while still present server-side. The guard defends against this: if the server response is absent or null the callback exits before touching the cache, so a transient failure followed by a retry leaves the UI consistent.
 
+## Routing topology
+
+`/cardgroups` is the canonical landing for any signed-in user. The app converges every entry path on it so the user never lands on a stale placeholder or a redirect loop:
+
+| Entry | Anonymous → | Signed-in → |
+|---|---|---|
+| `/` (`app/page.tsx`) | `/login` | `/cardgroups` |
+| `/login` (`app/login/page.tsx`) | render `LoginButton` | `/cardgroups` |
+| `/auth/callback?code=...` (`app/auth/callback/route.ts`) | n/a | `next` query value, defaulting to `/cardgroups` |
+| Header "Admin" link (admin only) | hidden | `/admin` (then `/admin/layout.tsx` gate → `/admin/page.tsx` → `redirect("/admin/users")`) |
+
+Loop prevention is delegated to the redirect chain itself, not to `next`-value inspection in `auth/callback`. A signed-in user landing on `/login` redirects once to `/cardgroups`; a signed-in user landing on `/` does the same. There is no `/cardgroups` self-redirect, so the chain always terminates in at most two hops.
+
+The legacy "render `/` with health check inline" pattern is replaced by `/api/healthz` — see "Route Handler conventions" below. External monitors that polled `/` must move to `/api/healthz`.
+
+The admin link in the global Header is the only UI affordance for entering `/admin`. It renders only when `gqlFetch(HeaderMeQuery)` returns a role named `"admin"`. See `.claude/rules/frontend-rsc-error-handling.md` for the failure-mode contract that lets the Header degrade silently when the role lookup fails.
+
+## Route Handler conventions
+
+Route Handlers under `frontend/src/app/api/**/route.ts` follow the same per-route layout as pages:
+
+- `route.ts` for the handler.
+- `queries.ts` (sibling) for any `graphql()` tagged template the handler uses. Mirror the page-level convention (`app/cardgroups/queries.ts`, `app/_components/queries.ts`); do **not** inline the document into `route.ts`. Shared queries live next to their consumer, not in a global `lib/` bag.
+- `route.test.ts` (sibling) for unit coverage.
+
+### Discriminated-union response shape
+
+Route Handlers that can fail typed (auth, validation, upstream-down) return a discriminated union so consumers narrow exhaustively on a tag field:
+
+```ts
+type HealthzResponse = { ok: true; backend: string } | { ok: false; error: string };
+
+const body: HealthzResponse = { ok: true, backend: data.health };
+return NextResponse.json(body);
+```
+
+The annotation on `body` is load-bearing — `NextResponse.json(...)` is generic over `unknown`, so without the explicit type the compiler accepts any object shape and a refactor that drops `ok` from one branch passes typecheck. Reference: `frontend/src/app/api/healthz/route.ts`.
+
+### `/api/healthz` JSON probe
+
+A public, JSON, cache-bypassing health endpoint. Conventions baked in:
+
+1. **Public** — no auth header required. The backend `health` resolver is whitelisted so no `UNAUTHENTICATED` ever returns. External uptime monitors can poll it without managing credentials.
+2. **`{ revalidate: 0 }`** on the upstream `gqlFetch` so a cached HTTP response cannot mask a live backend outage.
+3. **Status code, not body**: success is `200 + { ok: true, backend: <string> }`; failure is `503 + { ok: false, error: <string> }`. **Never** return `200` with `{ ok: false, ... }` embedded — generic monitors check status codes, not body parsers, and a 200-with-error silently passes every uptime check while the system is down.
+4. **Log before responding on failure**: `console.error("[healthz] backend health check failed:", err)` so an operator can correlate the 503 in logs with the cause.
+
 ## Auth (Supabase)
 
 The Supabase SSR client uses a 3-layer setup mirroring the official `@supabase/ssr` template. Each layer exists because cookie reading/writing differs between contexts:
@@ -552,6 +599,23 @@ render(await CardgroupDetailPage({ params: Promise.resolve({ id: "cg-1" }) }));
 Pre-15 patterns that pass `{ params: { id } }` directly will not type-check or will misbehave at runtime.
 
 `createSupabaseServerClient` is server-only, so RSC tests must stub it. The repo has no MSW; the canonical pattern is a per-test `vi.mock("@/lib/supabase/server", ...)` factory backed by the shared `mockSupabaseServerClient()` helper, with per-case `setMockSupabaseUser(...)` calls in `beforeEach`. The `server-only` import is also stubbed at the Vitest config level (`vitest.config.ts`) so any module that pulls it in transitively does not crash the test runner.
+
+### `vi.spyOn` requires `vi.restoreAllMocks()` in `afterEach`
+
+`vi.clearAllMocks()` resets call history but does **not** restore original implementations. Spies installed via `vi.spyOn(console, "warn")` (or any other property spy) accumulate across tests when only `clearAllMocks` runs in `beforeEach` — the second test sees a spy left behind by the first, and the third sees both. Symptoms are confusing: a `console.warn` spy installed in test A still records calls made by test B's setup, the `expect(spy).not.toHaveBeenCalled()` assertion in test B fails for reasons the test cannot explain.
+
+Pair them:
+
+```ts
+beforeEach(() => {
+  vi.clearAllMocks();    // wipes call history of all known mocks
+});
+afterEach(() => {
+  vi.restoreAllMocks();  // restores any spy installed via vi.spyOn back to the real impl
+});
+```
+
+Reference: `frontend/src/app/_components/header.test.tsx`. This applies to any test file that calls `vi.spyOn(...)` on a global (`console`, `Date`, `crypto`) or a module export.
 
 ### Apollo Client v4 testing migration gotchas
 

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,6 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/frontend/src/app/_components/header.test.tsx
+++ b/frontend/src/app/_components/header.test.tsx
@@ -1,0 +1,164 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  mockSupabaseServerClient,
+  resetMockSupabase,
+  setMockSupabaseUser,
+  setMockSupabaseUserError,
+} from "../../../__tests__/utils/mock-supabase";
+
+// Hoist vi.mock calls — Vitest processes these before any imports.
+
+vi.mock("@/lib/supabase/server", () => ({
+  createSupabaseServerClient: () => Promise.resolve(mockSupabaseServerClient()),
+}));
+
+vi.mock("@/lib/apollo/server", () => ({
+  gqlFetch: vi.fn(),
+}));
+
+vi.mock("./logout-button", () => ({
+  LogoutButton: () => <button type="button">Logout</button>,
+}));
+
+// Static mock for next/link — renders a plain <a> so href assertions work.
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    className,
+  }: {
+    href: string;
+    children: React.ReactNode;
+    className?: string;
+  }) => (
+    <a href={href} className={className}>
+      {children}
+    </a>
+  ),
+}));
+
+// Static mock for lucide-react ShieldCheck icon.
+vi.mock("lucide-react", () => ({
+  ShieldCheck: (props: React.SVGProps<SVGSVGElement>) => (
+    <svg data-testid="shield-check" {...props} />
+  ),
+}));
+
+import { gqlFetch } from "@/lib/apollo/server";
+import { Header } from "./header";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeRolesResponse(roleNames: string[]) {
+  return {
+    me: {
+      roles: roleNames.map((name) => ({ name })),
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  resetMockSupabase();
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("Header", () => {
+  // Branch 1: Anonymous user
+  it("anonymous: renders Sign in link and does NOT call gqlFetch", async () => {
+    setMockSupabaseUser(null);
+
+    render(await Header());
+
+    expect(screen.getByRole("link", { name: /sign in/i })).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /cardgroups/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /admin/i })).not.toBeInTheDocument();
+    expect(vi.mocked(gqlFetch)).not.toHaveBeenCalled();
+  });
+
+  // Branch 2: Logged-in non-admin user
+  it("logged-in non-admin: renders Cardgroups + email + Logout but no Admin link", async () => {
+    setMockSupabaseUser({ id: "u-1", email: "user@test.com" });
+    vi.mocked(gqlFetch).mockResolvedValue(makeRolesResponse(["user"]) as never);
+
+    render(await Header());
+
+    expect(screen.getByRole("link", { name: /cardgroups/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /user@test\.com/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /logout/i })).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /admin/i })).not.toBeInTheDocument();
+  });
+
+  // Branch 3: Logged-in admin user
+  it("logged-in admin: renders Admin link with href=/admin", async () => {
+    setMockSupabaseUser({ id: "u-2", email: "admin@test.com" });
+    vi.mocked(gqlFetch).mockResolvedValue(makeRolesResponse(["admin", "user"]) as never);
+
+    render(await Header());
+
+    expect(screen.getByRole("link", { name: /cardgroups/i })).toBeInTheDocument();
+    // Use exact text "Admin" to avoid matching the email address "admin@test.com".
+    const adminLink = screen.getByRole("link", { name: "Admin" });
+    expect(adminLink).toBeInTheDocument();
+    expect(adminLink).toHaveAttribute("href", "/admin");
+  });
+
+  // Branch 4: gqlFetch throws UNAUTHENTICATED
+  it("me throws UNAUTHENTICATED: Admin link hidden; console.warn NOT called", async () => {
+    setMockSupabaseUser({ id: "u-3", email: "race@test.com" });
+    vi.mocked(gqlFetch).mockRejectedValue(new Error("UNAUTHENTICATED: token rejected"));
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    render(await Header());
+
+    expect(screen.queryByRole("link", { name: /admin/i })).not.toBeInTheDocument();
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  // Branch 5: gqlFetch throws an unexpected error
+  it("me throws unexpected error: Admin link hidden; console.warn called with message and user id", async () => {
+    setMockSupabaseUser({ id: "u-4", email: "err@test.com" });
+    vi.mocked(gqlFetch).mockRejectedValue(new Error("503 service unavailable"));
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    render(await Header());
+
+    expect(screen.queryByRole("link", { name: /admin/i })).not.toBeInTheDocument();
+    expect(warnSpy).toHaveBeenCalledOnce();
+    expect(warnSpy).toHaveBeenCalledWith(
+      "[header] me query unexpectedly failed",
+      expect.objectContaining({
+        error_message: "503 service unavailable",
+        user_id: "u-4",
+      }),
+    );
+  });
+
+  // Branch 6: getUser returns a non-AuthSessionMissingError
+  it("getUser non-session error: renders only logo header; console.error called", async () => {
+    const networkError = new Error("boom");
+    networkError.name = "NetworkError";
+    setMockSupabaseUserError(networkError);
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    render(await Header());
+
+    // Only the logo link should be present — no nav, no sign-in link.
+    const logoLink = screen.getByRole("link", { name: /flamingo-armond/i });
+    expect(logoLink).toBeInTheDocument();
+    expect(screen.queryByRole("nav")).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /sign in/i })).not.toBeInTheDocument();
+    expect(errorSpy).toHaveBeenCalledWith("[header] getUser() failed:", "boom");
+  });
+});

--- a/frontend/src/app/_components/header.test.tsx
+++ b/frontend/src/app/_components/header.test.tsx
@@ -49,10 +49,6 @@ vi.mock("lucide-react", () => ({
 import { gqlFetch } from "@/lib/apollo/server";
 import { Header } from "./header";
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
 function makeRolesResponse(roleNames: string[]) {
   return {
     me: {
@@ -60,10 +56,6 @@ function makeRolesResponse(roleNames: string[]) {
     },
   };
 }
-
-// ---------------------------------------------------------------------------
-// Suite
-// ---------------------------------------------------------------------------
 
 beforeEach(() => {
   resetMockSupabase();
@@ -75,7 +67,6 @@ afterEach(() => {
 });
 
 describe("Header", () => {
-  // Branch 1: Anonymous user
   it("anonymous: renders Sign in link and does NOT call gqlFetch", async () => {
     setMockSupabaseUser(null);
 
@@ -87,7 +78,6 @@ describe("Header", () => {
     expect(vi.mocked(gqlFetch)).not.toHaveBeenCalled();
   });
 
-  // Branch 2: Logged-in non-admin user
   it("logged-in non-admin: renders Cardgroups + email + Logout but no Admin link", async () => {
     setMockSupabaseUser({ id: "u-1", email: "user@test.com" });
     vi.mocked(gqlFetch).mockResolvedValue(makeRolesResponse(["user"]) as never);
@@ -100,7 +90,6 @@ describe("Header", () => {
     expect(screen.queryByRole("link", { name: /admin/i })).not.toBeInTheDocument();
   });
 
-  // Branch 3: Logged-in admin user
   it("logged-in admin: renders Admin link with href=/admin", async () => {
     setMockSupabaseUser({ id: "u-2", email: "admin@test.com" });
     vi.mocked(gqlFetch).mockResolvedValue(makeRolesResponse(["admin", "user"]) as never);
@@ -114,7 +103,6 @@ describe("Header", () => {
     expect(adminLink).toHaveAttribute("href", "/admin");
   });
 
-  // Branch 4: gqlFetch throws UNAUTHENTICATED
   it("me throws UNAUTHENTICATED: Admin link hidden; console.warn NOT called", async () => {
     setMockSupabaseUser({ id: "u-3", email: "race@test.com" });
     vi.mocked(gqlFetch).mockRejectedValue(
@@ -133,7 +121,6 @@ describe("Header", () => {
     expect(warnSpy).not.toHaveBeenCalled();
   });
 
-  // Branch 5: gqlFetch throws an unexpected error
   it("me throws unexpected error: Admin link hidden; console.warn called with message and user id", async () => {
     setMockSupabaseUser({ id: "u-4", email: "err@test.com" });
     vi.mocked(gqlFetch).mockRejectedValue(new Error("503 service unavailable"));
@@ -152,7 +139,6 @@ describe("Header", () => {
     );
   });
 
-  // Branch 6: me resolves with null user
   it("me resolves with null user: Admin link hidden", async () => {
     setMockSupabaseUser({ id: "u-5", email: "ghost@test.com" });
     vi.mocked(gqlFetch).mockResolvedValue({ me: null } as never);
@@ -163,7 +149,6 @@ describe("Header", () => {
     expect(screen.getByRole("link", { name: /cardgroups/i })).toBeInTheDocument();
   });
 
-  // Branch 7: getUser returns a non-AuthSessionMissingError
   it("getUser non-session error: renders only logo header; console.error called", async () => {
     const networkError = new Error("boom");
     networkError.name = "NetworkError";

--- a/frontend/src/app/_components/header.test.tsx
+++ b/frontend/src/app/_components/header.test.tsx
@@ -117,7 +117,14 @@ describe("Header", () => {
   // Branch 4: gqlFetch throws UNAUTHENTICATED
   it("me throws UNAUTHENTICATED: Admin link hidden; console.warn NOT called", async () => {
     setMockSupabaseUser({ id: "u-3", email: "race@test.com" });
-    vi.mocked(gqlFetch).mockRejectedValue(new Error("UNAUTHENTICATED: token rejected"));
+    vi.mocked(gqlFetch).mockRejectedValue(
+      new Error(
+        "GraphQL errors: " +
+          JSON.stringify([
+            { message: "Not authenticated", extensions: { code: "UNAUTHENTICATED" } },
+          ]),
+      ),
+    );
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
     render(await Header());
@@ -145,7 +152,18 @@ describe("Header", () => {
     );
   });
 
-  // Branch 6: getUser returns a non-AuthSessionMissingError
+  // Branch 6: me resolves with null user
+  it("me resolves with null user: Admin link hidden", async () => {
+    setMockSupabaseUser({ id: "u-5", email: "ghost@test.com" });
+    vi.mocked(gqlFetch).mockResolvedValue({ me: null } as never);
+
+    render(await Header());
+
+    expect(screen.queryByRole("link", { name: /admin/i })).not.toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /cardgroups/i })).toBeInTheDocument();
+  });
+
+  // Branch 7: getUser returns a non-AuthSessionMissingError
   it("getUser non-session error: renders only logo header; console.error called", async () => {
     const networkError = new Error("boom");
     networkError.name = "NetworkError";

--- a/frontend/src/app/_components/header.tsx
+++ b/frontend/src/app/_components/header.tsx
@@ -5,6 +5,22 @@ import { createSupabaseServerClient } from "@/lib/supabase/server";
 import { LogoutButton } from "./logout-button";
 import { HeaderMeQuery } from "./queries";
 
+const ADMIN_ROLE = "admin" as const;
+
+function isUnauthenticatedGraphQLError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  const prefix = "GraphQL errors: ";
+  if (!err.message.startsWith(prefix)) return false;
+  try {
+    const parsed = JSON.parse(err.message.slice(prefix.length)) as Array<{
+      extensions?: { code?: string };
+    }>;
+    return Array.isArray(parsed) && parsed.some((e) => e?.extensions?.code === "UNAUTHENTICATED");
+  } catch {
+    return false;
+  }
+}
+
 export async function Header() {
   const supabase = await createSupabaseServerClient();
   const {
@@ -30,15 +46,15 @@ export async function Header() {
   if (user) {
     try {
       const meData = await gqlFetch(HeaderMeQuery, { revalidate: 0 });
-      isAdmin = meData.me?.roles.some((r) => r.name === "admin") ?? false;
+      isAdmin = meData.me?.roles.some((r) => r.name === ADMIN_ROLE) ?? false;
     } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      if (msg.includes("UNAUTHENTICATED")) {
-        // Expected race: Supabase session is valid but the GraphQL endpoint
-        // rejected the access token (clock skew, JWKS rotation gap, etc.).
-        // The admin layout will redirect on actual /admin navigation, so the
-        // header degrades silently here.
-      } else {
+      // Expected race: Supabase session is valid but the GraphQL endpoint
+      // rejected the access token (clock skew, JWKS rotation gap, etc.).
+      // The admin layout will redirect on actual /admin navigation, so the
+      // header degrades silently here.
+      const isUnauthenticated = isUnauthenticatedGraphQLError(err);
+      if (!isUnauthenticated) {
+        const msg = err instanceof Error ? err.message : String(err);
         console.warn("[header] me query unexpectedly failed", {
           error_message: msg,
           user_id: user.id,

--- a/frontend/src/app/_components/header.tsx
+++ b/frontend/src/app/_components/header.tsx
@@ -1,6 +1,9 @@
+import { ShieldCheck } from "lucide-react";
 import Link from "next/link";
+import { gqlFetch } from "@/lib/apollo/server";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 import { LogoutButton } from "./logout-button";
+import { HeaderMeQuery } from "./queries";
 
 export async function Header() {
   const supabase = await createSupabaseServerClient();
@@ -8,10 +11,7 @@ export async function Header() {
     data: { user },
     error,
   } = await supabase.auth.getUser();
-  // "AuthSessionMissingError" is the normal anonymous case — fall through to
-  // the "Sign in" branch below. Only a different auth-service error means we
-  // genuinely cannot tell the user's state, in which case we degrade by
-  // hiding both the email and the sign-in link to avoid misleading them.
+
   if (error && error.name !== "AuthSessionMissingError") {
     console.error("[header] getUser() failed:", error.message);
     return (
@@ -21,6 +21,30 @@ export async function Header() {
         </Link>
       </header>
     );
+  }
+
+  // Admin role check happens only when authenticated. Skipping the GraphQL
+  // call for anonymous users avoids unnecessary backend traffic and stops
+  // UNAUTHENTICATED noise from polluting the warn log.
+  let isAdmin = false;
+  if (user) {
+    try {
+      const meData = await gqlFetch(HeaderMeQuery, { revalidate: 0 });
+      isAdmin = meData.me?.roles.some((r) => r.name === "admin") ?? false;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (msg.includes("UNAUTHENTICATED")) {
+        // Expected race: Supabase session is valid but the GraphQL endpoint
+        // rejected the access token (clock skew, JWKS rotation gap, etc.).
+        // The admin layout will redirect on actual /admin navigation, so the
+        // header degrades silently here.
+      } else {
+        console.warn("[header] me query unexpectedly failed", {
+          error_message: msg,
+          user_id: user.id,
+        });
+      }
+    }
   }
 
   return (
@@ -37,6 +61,15 @@ export async function Header() {
             >
               Cardgroups
             </Link>
+            {isAdmin ? (
+              <Link
+                href="/admin"
+                className="flex items-center gap-1 text-muted-foreground underline-offset-4 hover:underline"
+              >
+                <ShieldCheck className="h-4 w-4" aria-hidden="true" />
+                Admin
+              </Link>
+            ) : null}
             <Link
               href="/profile"
               className="text-muted-foreground underline-offset-4 hover:underline"

--- a/frontend/src/app/_components/queries.ts
+++ b/frontend/src/app/_components/queries.ts
@@ -1,0 +1,13 @@
+import { graphql } from "@/generated";
+
+// Header queries
+
+export const HeaderMeQuery = graphql(`
+  query HeaderMe {
+    me {
+      roles {
+        name
+      }
+    }
+  }
+`);

--- a/frontend/src/app/_components/queries.ts
+++ b/frontend/src/app/_components/queries.ts
@@ -1,7 +1,5 @@
 import { graphql } from "@/generated";
 
-// Header queries
-
 export const HeaderMeQuery = graphql(`
   query HeaderMe {
     me {

--- a/frontend/src/app/admin/page.test.tsx
+++ b/frontend/src/app/admin/page.test.tsx
@@ -1,0 +1,16 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("next/navigation", () => ({
+  redirect: vi.fn((url: string) => {
+    throw new Error(`REDIRECT:${url}`);
+  }),
+}));
+
+import AdminIndexPage from "./page";
+
+describe("AdminIndexPage", () => {
+  it("redirects to /admin/users", () => {
+    expect(() => AdminIndexPage()).toThrow("REDIRECT:/admin/users");
+  });
+});

--- a/frontend/src/app/admin/page.tsx
+++ b/frontend/src/app/admin/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function AdminIndexPage() {
+  redirect("/admin/users");
+}

--- a/frontend/src/app/api/healthz/queries.ts
+++ b/frontend/src/app/api/healthz/queries.ts
@@ -1,0 +1,7 @@
+import { graphql } from "@/generated";
+
+export const HealthzQuery = graphql(`
+  query Healthz {
+    health
+  }
+`);

--- a/frontend/src/app/api/healthz/route.test.ts
+++ b/frontend/src/app/api/healthz/route.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { GET } from "./route";
+
+const mockGqlFetch = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/apollo/server", () => ({
+  gqlFetch: mockGqlFetch,
+}));
+
+describe("GET /api/healthz", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 200 with ok:true and backend value when gqlFetch resolves", async () => {
+    mockGqlFetch.mockResolvedValueOnce({ health: "ok" });
+
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ ok: true, backend: "ok" });
+  });
+
+  it("returns 503 with ok:false and error message when gqlFetch rejects", async () => {
+    mockGqlFetch.mockRejectedValueOnce(new Error("backend unavailable"));
+
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(body).toEqual({ ok: false, error: "backend unavailable" });
+  });
+});

--- a/frontend/src/app/api/healthz/route.ts
+++ b/frontend/src/app/api/healthz/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from "next/server";
+import { graphql } from "@/generated";
+import { gqlFetch } from "@/lib/apollo/server";
+
+const HealthQuery = graphql(`
+  query Healthz {
+    health
+  }
+`);
+
+export async function GET() {
+  try {
+    const data = await gqlFetch(HealthQuery, { revalidate: 0 });
+    return NextResponse.json({ ok: true, backend: data.health });
+  } catch (err) {
+    return NextResponse.json(
+      { ok: false, error: err instanceof Error ? err.message : String(err) },
+      { status: 503 },
+    );
+  }
+}

--- a/frontend/src/app/api/healthz/route.ts
+++ b/frontend/src/app/api/healthz/route.ts
@@ -1,21 +1,20 @@
 import { NextResponse } from "next/server";
-import { graphql } from "@/generated";
 import { gqlFetch } from "@/lib/apollo/server";
+import { HealthzQuery } from "./queries";
 
-const HealthQuery = graphql(`
-  query Healthz {
-    health
-  }
-`);
+type HealthzResponse = { ok: true; backend: string } | { ok: false; error: string };
 
 export async function GET() {
   try {
-    const data = await gqlFetch(HealthQuery, { revalidate: 0 });
-    return NextResponse.json({ ok: true, backend: data.health });
+    const data = await gqlFetch(HealthzQuery, { revalidate: 0 });
+    const body: HealthzResponse = { ok: true, backend: data.health };
+    return NextResponse.json(body);
   } catch (err) {
-    return NextResponse.json(
-      { ok: false, error: err instanceof Error ? err.message : String(err) },
-      { status: 503 },
-    );
+    console.error("[healthz] backend health check failed:", err);
+    const body: HealthzResponse = {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+    return NextResponse.json(body, { status: 503 });
   }
 }

--- a/frontend/src/app/auth/callback/route.test.ts
+++ b/frontend/src/app/auth/callback/route.test.ts
@@ -26,14 +26,14 @@ describe("GET /auth/callback", () => {
     vi.clearAllMocks();
   });
 
-  it("exchanges valid code and redirects to /", async () => {
+  it("exchanges valid code and redirects to /cardgroups by default", async () => {
     mockExchangeCodeForSession.mockResolvedValueOnce({ error: null });
 
     const response = await GET(makeRequest("http://localhost/auth/callback?code=abc123"));
 
     expect(mockExchangeCodeForSession).toHaveBeenCalledWith("abc123");
     expect([301, 302, 307, 308]).toContain(response.status);
-    expect(response.headers.get("location")).toBe("http://localhost/");
+    expect(response.headers.get("location")).toBe("http://localhost/cardgroups");
   });
 
   it("redirects to /login?error=missing_code when code is absent", async () => {

--- a/frontend/src/app/auth/callback/route.ts
+++ b/frontend/src/app/auth/callback/route.ts
@@ -4,7 +4,7 @@ import { createSupabaseServerClient } from "@/lib/supabase/server";
 export async function GET(request: NextRequest) {
   const url = new URL(request.url);
   const code = url.searchParams.get("code");
-  const rawNext = url.searchParams.get("next") ?? "/";
+  const rawNext = url.searchParams.get("next") ?? "/cardgroups";
   const isSafeNext =
     rawNext.startsWith("/") && !rawNext.startsWith("//") && !rawNext.includes("\\");
   const safeNext = isSafeNext ? rawNext : "/";

--- a/frontend/src/app/login/page.test.tsx
+++ b/frontend/src/app/login/page.test.tsx
@@ -2,14 +2,13 @@
 import { render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-// Mock next/navigation before importing the page
+// `redirect` throws so the server component aborts the same way Next.js's server runtime does.
 vi.mock("next/navigation", () => ({
   redirect: vi.fn((url: string) => {
     throw new Error(`REDIRECT:${url}`);
   }),
 }));
 
-// Mock createSupabaseServerClient
 vi.mock("@/lib/supabase/server", () => ({
   createSupabaseServerClient: vi.fn(),
 }));

--- a/frontend/src/app/login/page.test.tsx
+++ b/frontend/src/app/login/page.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { render, screen } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // Mock next/navigation before importing the page
 vi.mock("next/navigation", () => ({
@@ -36,6 +36,11 @@ function makeSupabaseMock(user: { id: string; email?: string } | null, error: Er
 describe("LoginPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it("anonymous user: renders LoginButton and no error banner", async () => {
@@ -74,6 +79,11 @@ describe("LoginPage", () => {
     vi.mocked(createSupabaseServerClient).mockResolvedValue(makeSupabaseMock(null, boom) as never);
 
     await expect(LoginPage({ searchParams: Promise.resolve({}) })).rejects.toThrow(
+      "network failure",
+    );
+    expect(console.error).toHaveBeenCalledWith(
+      "[login] getUser() failed:",
+      "FetchError",
       "network failure",
     );
   });

--- a/frontend/src/app/login/page.test.tsx
+++ b/frontend/src/app/login/page.test.tsx
@@ -1,0 +1,93 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock next/navigation before importing the page
+vi.mock("next/navigation", () => ({
+  redirect: vi.fn((url: string) => {
+    throw new Error(`REDIRECT:${url}`);
+  }),
+}));
+
+// Mock createSupabaseServerClient
+vi.mock("@/lib/supabase/server", () => ({
+  createSupabaseServerClient: vi.fn(),
+}));
+
+// Mock LoginButton to avoid pulling in the Supabase browser client
+vi.mock("./login-button", () => ({
+  LoginButton: () => <button type="button">Sign in</button>,
+}));
+
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+import LoginPage from "./page";
+
+function makeSupabaseMock(user: { id: string; email?: string } | null, error: Error | null = null) {
+  return {
+    auth: {
+      getUser: vi.fn().mockResolvedValue({
+        data: { user },
+        error,
+      }),
+    },
+  };
+}
+
+describe("LoginPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("anonymous user: renders LoginButton and no error banner", async () => {
+    vi.mocked(createSupabaseServerClient).mockResolvedValue(makeSupabaseMock(null) as never);
+
+    const jsx = await LoginPage({ searchParams: Promise.resolve({}) });
+    render(jsx);
+
+    expect(screen.getByRole("button", { name: /sign in/i })).toBeInTheDocument();
+    expect(screen.queryByText(/sign-in failed/i)).not.toBeInTheDocument();
+  });
+
+  it("logged-in user: calls redirect to /cardgroups", async () => {
+    vi.mocked(createSupabaseServerClient).mockResolvedValue(
+      makeSupabaseMock({ id: "u-1", email: "user@example.com" }) as never,
+    );
+
+    await expect(LoginPage({ searchParams: Promise.resolve({}) })).rejects.toThrow(
+      "REDIRECT:/cardgroups",
+    );
+  });
+
+  it("searchParams.error set: displays sign-in failed banner", async () => {
+    vi.mocked(createSupabaseServerClient).mockResolvedValue(makeSupabaseMock(null) as never);
+
+    const jsx = await LoginPage({ searchParams: Promise.resolve({ error: "access_denied" }) });
+    render(jsx);
+
+    expect(screen.getByText(/sign-in failed: access_denied/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /sign in/i })).toBeInTheDocument();
+  });
+
+  it("non-AuthSessionMissingError is rethrown", async () => {
+    const boom = new Error("network failure");
+    boom.name = "FetchError";
+    vi.mocked(createSupabaseServerClient).mockResolvedValue(makeSupabaseMock(null, boom) as never);
+
+    await expect(LoginPage({ searchParams: Promise.resolve({}) })).rejects.toThrow(
+      "network failure",
+    );
+  });
+
+  it("AuthSessionMissingError is silenced and renders LoginButton", async () => {
+    const noSession = new Error("Auth session missing!");
+    noSession.name = "AuthSessionMissingError";
+    vi.mocked(createSupabaseServerClient).mockResolvedValue(
+      makeSupabaseMock(null, noSession) as never,
+    );
+
+    const jsx = await LoginPage({ searchParams: Promise.resolve({}) });
+    render(jsx);
+
+    expect(screen.getByRole("button", { name: /sign in/i })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -1,8 +1,18 @@
+import { redirect } from "next/navigation";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
 import { LoginButton } from "./login-button";
 
 type SearchParams = Promise<{ error?: string }>;
 
 export default async function LoginPage({ searchParams }: { searchParams: SearchParams }) {
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+    error: authErr,
+  } = await supabase.auth.getUser();
+  if (authErr && authErr.name !== "AuthSessionMissingError") throw authErr;
+  if (user) redirect("/cardgroups");
+
   const { error } = await searchParams;
   return (
     <main className="flex min-h-screen items-center justify-center p-8">

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -10,7 +10,10 @@ export default async function LoginPage({ searchParams }: { searchParams: Search
     data: { user },
     error: authErr,
   } = await supabase.auth.getUser();
-  if (authErr && authErr.name !== "AuthSessionMissingError") throw authErr;
+  if (authErr && authErr.name !== "AuthSessionMissingError") {
+    console.error("[login] getUser() failed:", authErr.name, authErr.message);
+    throw authErr;
+  }
   if (user) redirect("/cardgroups");
 
   const { error } = await searchParams;

--- a/frontend/src/app/page.test.tsx
+++ b/frontend/src/app/page.test.tsx
@@ -6,11 +6,8 @@ import {
   setMockSupabaseUserError,
 } from "../../__tests__/utils/mock-supabase";
 
-// ---------------------------------------------------------------------------
 // next/navigation mock — `redirect` throws so the server component aborts the
 // same way Next.js's server runtime does.
-// ---------------------------------------------------------------------------
-
 const REDIRECT_PREFIX = "REDIRECT:";
 
 vi.mock("next/navigation", () => ({
@@ -26,8 +23,6 @@ vi.mock("@/lib/supabase/server", () => ({
 import { redirect } from "next/navigation";
 import HomePage from "@/app/page";
 
-// ---------------------------------------------------------------------------
-
 let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
 
 beforeEach(() => {
@@ -39,8 +34,6 @@ beforeEach(() => {
 afterEach(() => {
   vi.restoreAllMocks();
 });
-
-// ---------------------------------------------------------------------------
 
 describe("HomePage (root redirect)", () => {
   test("anonymous user is redirected to /login", async () => {

--- a/frontend/src/app/page.test.tsx
+++ b/frontend/src/app/page.test.tsx
@@ -28,9 +28,12 @@ import HomePage from "@/app/page";
 
 // ---------------------------------------------------------------------------
 
+let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
 beforeEach(() => {
   vi.clearAllMocks();
   resetMockSupabase();
+  consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 });
 
 afterEach(() => {
@@ -61,5 +64,20 @@ describe("HomePage (root redirect)", () => {
 
     await expect(HomePage()).rejects.toBe(transportError);
     expect(redirect).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("[home]"),
+      transportError.name,
+      transportError.message,
+    );
+  });
+
+  test("AuthSessionMissingError is silenced and user is redirected to /login", async () => {
+    const noSession = new Error("Auth session missing!");
+    noSession.name = "AuthSessionMissingError";
+    setMockSupabaseUserError(noSession);
+
+    await expect(HomePage()).rejects.toThrow(`${REDIRECT_PREFIX}/login`);
+    expect(redirect).toHaveBeenCalledWith("/login");
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/app/page.test.tsx
+++ b/frontend/src/app/page.test.tsx
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+  mockSupabaseServerClient,
+  resetMockSupabase,
+  setMockSupabaseUser,
+  setMockSupabaseUserError,
+} from "../../__tests__/utils/mock-supabase";
+
+// ---------------------------------------------------------------------------
+// next/navigation mock — `redirect` throws so the server component aborts the
+// same way Next.js's server runtime does.
+// ---------------------------------------------------------------------------
+
+const REDIRECT_PREFIX = "REDIRECT:";
+
+vi.mock("next/navigation", () => ({
+  redirect: vi.fn((path: string) => {
+    throw new Error(`${REDIRECT_PREFIX}${path}`);
+  }),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createSupabaseServerClient: () => Promise.resolve(mockSupabaseServerClient()),
+}));
+
+import { redirect } from "next/navigation";
+import HomePage from "@/app/page";
+
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  resetMockSupabase();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+
+describe("HomePage (root redirect)", () => {
+  test("anonymous user is redirected to /login", async () => {
+    setMockSupabaseUser(null);
+
+    await expect(HomePage()).rejects.toThrow(`${REDIRECT_PREFIX}/login`);
+    expect(redirect).toHaveBeenCalledWith("/login");
+  });
+
+  test("logged-in user is redirected to /cardgroups", async () => {
+    setMockSupabaseUser({ id: "u-1", email: "user@test.com" });
+
+    await expect(HomePage()).rejects.toThrow(`${REDIRECT_PREFIX}/cardgroups`);
+    expect(redirect).toHaveBeenCalledWith("/cardgroups");
+  });
+
+  test("non-AuthSessionMissingError from getUser() is rethrown", async () => {
+    const transportError = new Error("network failure");
+    transportError.name = "FetchError";
+    setMockSupabaseUserError(transportError);
+
+    await expect(HomePage()).rejects.toBe(transportError);
+    expect(redirect).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -7,6 +7,9 @@ export default async function HomePage() {
     data: { user },
     error,
   } = await supabase.auth.getUser();
-  if (error && error.name !== "AuthSessionMissingError") throw error;
+  if (error && error.name !== "AuthSessionMissingError") {
+    console.error("[home] getUser() failed:", error.name, error.message);
+    throw error;
+  }
   redirect(user ? "/cardgroups" : "/login");
 }

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,19 +1,12 @@
-import { graphql } from "@/generated";
-import { gqlFetch } from "@/lib/apollo/server";
-
-const HealthQuery = graphql(`
-  query Health {
-    health
-  }
-`);
+import { redirect } from "next/navigation";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
 
 export default async function HomePage() {
-  const data = await gqlFetch(HealthQuery, { revalidate: 0 });
-  return (
-    <main className="flex min-h-screen items-center justify-center p-8">
-      <h1 className="text-4xl font-semibold tracking-tight">
-        Hello, flamingo-armond 🦩 — backend says: <code>{data.health}</code>
-      </h1>
-    </main>
-  );
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser();
+  if (error && error.name !== "AuthSessionMissingError") throw error;
+  redirect(user ? "/cardgroups" : "/login");
 }

--- a/playbooks/setup.yml
+++ b/playbooks/setup.yml
@@ -191,6 +191,46 @@
         - (item.src not in supabase_kv) or ((supabase_kv[item.src] | trim('"')) | length == 0)
       tags: [sync-env]
 
+    # --- Auto-generate PING_TOKEN if empty in backend/.env.local ---
+    # The /internal/ping bearer token has no upstream source (unlike the
+    # supabase-derived keys above). Generate a 64-hex-char value on first run
+    # and leave subsequent runs as a no-op. Skip user-owned files (no marker).
+    - name: Read backend/.env.local for PING_TOKEN inspection
+      ansible.builtin.slurp:
+        src: "{{ repo_root }}/backend/.env.local"
+      register: backend_env_raw
+      when: env_ownership[repo_root + '/backend/.env.local'] != 'user-owned'
+      tags: [sync-env]
+
+    - name: Compute current PING_TOKEN value
+      ansible.builtin.set_fact:
+        ping_token_current: "{{ ((backend_env_raw.content | b64decode).split('\n') | select('match', '^PING_TOKEN=') | map('regex_replace', '^PING_TOKEN=', '') | list | first | default('')) | trim('\"') }}"
+      when: env_ownership[repo_root + '/backend/.env.local'] != 'user-owned'
+      tags: [sync-env]
+
+    - name: Generate a fresh PING_TOKEN when missing or empty
+      ansible.builtin.command:
+        cmd: openssl rand -hex 32
+      register: ping_token_generated
+      changed_when: true
+      when:
+        - env_ownership[repo_root + '/backend/.env.local'] != 'user-owned'
+        - (ping_token_current | default('')) | length == 0
+      tags: [sync-env]
+
+    - name: Upsert generated PING_TOKEN into backend/.env.local
+      ansible.builtin.lineinfile:
+        path: "{{ repo_root }}/backend/.env.local"
+        regexp: "^PING_TOKEN="
+        line: "PING_TOKEN={{ ping_token_generated.stdout }}"
+        create: false
+        mode: "0600"
+      when:
+        - env_ownership[repo_root + '/backend/.env.local'] != 'user-owned'
+        - (ping_token_current | default('')) | length == 0
+        - ping_token_generated is succeeded
+      tags: [sync-env]
+
     # --- Google OAuth credentials check (root .env) ---
     # stat-then-slurp: a missing .env produces stat.exists=false (clean path),
     # and any slurp failure afterwards surfaces normally.


### PR DESCRIPTION
## Summary

Tightens the user navigation flow so the root, `/login`, and `/admin` routes redirect based on Supabase auth state instead of rendering a static landing page or 404, and the header now surfaces an `Admin` link only for users with the `admin` role. Adds a `/api/healthz` JSON probe endpoint and folds in two dev-tooling cleanups (gitignoring Next.js 16's `next-env.d.ts` and auto-generating `PING_TOKEN` on `make sync-env`) plus a README condense pass.

## Background / Motivation

- **Anonymous visitors landed on a useless `/`.** The root route was a static landing component that did not know whether the visitor was logged in. Logged-in users had to manually navigate to `/cardgroups`; anonymous users saw a page with no useful action and had to hunt for the Sign in link in the header. Making `/` an auth-aware redirect collapses the first-screen decision into one place.
- **`/login` rendered the sign-in button to already-authenticated users.** Anyone who hit `/login` directly (e.g. a stale bookmark) saw the OAuth button on top of an active session and could trigger a needless re-auth round-trip that clobbers the session cookie. The route now redirects logged-in users to `/cardgroups` before rendering anything.
- **`/admin` was a 404 even for admins.** The admin surface lives under `/admin/users`, `/admin/roles`, etc. Typing `/admin` directly produced a Next.js 404 because no page existed at that path. An index that redirects to `/admin/users` keeps the URL hygiene matching the natural mental model.
- **OAuth callback's default `next` was a redirect-loop seed.** `auth/callback/route.ts` defaulted `?next` to `/` — and now that `/` itself redirects, post-OAuth users would have bounced through `/ → /cardgroups`. Defaulting directly to `/cardgroups` makes the round-trip one hop instead of two.
- **Header's admin surface was hard to discover.** Admin users had to type `/admin/users` or follow a link from another admin page; there was no header affordance. A `ShieldCheck`-iconed `Admin` link gated on the `admin` role from a `me` GraphQL query makes the surface discoverable without exposing it to non-admins.
- **Header's UNAUTHENTICATED detection was substring-based.** The previous check matched the literal string `"UNAUTHENTICATED"` anywhere in the error message, which happens to work today but would silently break the day Apollo Client changes its error formatting. Parsing the JSON-formatted error and inspecting `extensions.code` directly is the structural fix.
- **`next-env.d.ts` produced a churn loop in Next.js 16.** Next.js 16's `experimental.isolatedDevBuild` (default `true`) rewrites `next-env.d.ts`'s single import path between `./.next/dev/types/routes.d.ts` (after `next dev`) and `./.next/types/routes.d.ts` (after `next build`), so committing the file produces a continuous diff every time a developer toggles between dev and build. The official Next.js docs now recommend gitignoring it; CI regenerates via the dedicated `next typegen` command (Next.js 15.5+).
- **`PING_TOKEN` was the only manual-edit step in `make setup`.** Every other env value is derived from `supabase status -o env`, but `PING_TOKEN` has no upstream source and required a hand-rolled `openssl rand` followed by editing `backend/.env.local`. Auto-generating it on first sync removes the last hand-edit between a fresh clone and a working backend.

## Changes

### Auth-aware landing routes

- `frontend/src/app/page.tsx`: replaced the static landing component with a server-side `getUser()` call. Logged-in users `redirect("/cardgroups")`, anonymous users `redirect("/login")`. `AuthSessionMissingError` (the legitimate "no session yet" case) is silenced; any other auth error is `console.error("[home] getUser() failed:", ...)`-logged and rethrown so the Next.js error boundary surfaces it.
- `frontend/src/app/login/page.tsx`: added the same `getUser()` guard at the top — logged-in users `redirect("/cardgroups")` before `<LoginButton />` ever renders. Same `AuthSessionMissingError` silencing and `[login]`-prefixed logging.
- `frontend/src/app/admin/page.tsx` (new, 5 lines): index server component that `redirect("/admin/users")` so `/admin` no longer 404s.
- `frontend/src/app/auth/callback/route.ts`: flips the default `next` cookie value from `/` to `/cardgroups` so the post-OAuth landing skips the redirect chain.

### Admin-aware header

- `frontend/src/app/_components/header.tsx`: after `getUser()` succeeds, runs a `HeaderMeQuery` against the backend; if `me.roles` contains `admin`, renders a `ShieldCheck`-iconed `Admin` `<Link>` next to the existing `Cardgroups` / `{user.email}` / `Logout` group. The `me` query is skipped entirely for anonymous users (saves a round-trip and avoids UNAUTHENTICATED noise in the warn log).
- New `isUnauthenticatedGraphQLError(err)`: parses the `"GraphQL errors: <json>"` message format and inspects each entry's `extensions.code === "UNAUTHENTICATED"`, replacing the previous substring match. Race-condition UNAUTHENTICATED responses (Supabase session valid but backend rejected the access token — clock skew, JWKS rotation gap) are silenced instead of warn-logged; any other failure logs `[header] me query unexpectedly failed`. The admin layout still redirects on actual `/admin` navigation, so the header degrades silently here.
- `frontend/src/app/_components/queries.ts` (new, 11 lines): extracted `HeaderMeQuery` into its own module so the same typed query can be shared across server components without duplicating the GraphQL string.

### `/api/healthz` JSON probe

- `frontend/src/app/api/healthz/route.ts` (new, 20 lines): GET handler that runs `gqlFetch(HealthzQuery, { revalidate: 0 })` and returns either `{ ok: true, backend: data.health }` (HTTP 200) or `{ ok: false, error: <message> }` (HTTP 503). The `HealthzResponse` discriminated union keeps consumers honest — a successful response carries `backend`, a failure carries `error`, never both.
- `frontend/src/app/api/healthz/queries.ts` (new): `HealthzQuery` extracted alongside the route so the typed return shape (`{ health: string }`) flows through generated types.
- `revalidate: 0` is load-bearing: a cached "backend is up" answer would mask a real outage from any external monitor reading this endpoint.

### Next.js 16 `next-env.d.ts` gitignore

- `.gitignore`: adds `/frontend/next-env.d.ts` with a four-line comment naming the `isolatedDevBuild` toggle.
- `frontend/next-env.d.ts`: removed from version control.
- `.github/workflows/frontend.yml`: adds two new steps before the Biome / typecheck / build pipeline:
  - **Codegen (Next.js typegen)** — runs `pnpm --filter frontend exec next typegen` so `next-env.d.ts` and `.next/types/routes.d.ts` exist before typecheck. Faster than a full `next build` because Next.js 15.5 split type emission into its own command.
  - **Guard against re-tracking next-env.d.ts** — `git ls-files --error-unmatch frontend/next-env.d.ts` fails the build with an explicit error message if anyone re-stages the file with `git add -f`.
- `docs/dev-setup.md` § "Policy on generated files": adds a `next-env.d.ts` row to the codegen table and a new subsection explaining the toggle, the upstream issues ([vercel/next.js#85738](https://github.com/vercel/next.js/issues/85738), [#86001](https://github.com/vercel/next.js/issues/86001)), and why `experimental.isolatedDevBuild: false` is not the right fix.

### `PING_TOKEN` auto-generation

- `playbooks/setup.yml`: adds four new tasks under the `sync-env` tag — slurp `backend/.env.local`, parse the current `PING_TOKEN=` line, generate a fresh `openssl rand -hex 32` value when the field is empty or missing, then `lineinfile`-upsert it back. All four tasks skip the file when its `# managed-by: sync-env` marker is absent (user-owned), so a developer who hand-customised the token is not overwritten.
- `backend/.env.example`: adds `PING_TOKEN=` with a four-line comment naming the auto-generation behaviour and the production override path.
- `docs/dev-setup.md` § "Env file layout": updates the `backend/.env.local` row to note that `PING_TOKEN` is the one auto-derived field on subsequent `sync-env` runs.

### README and `docs/dev-setup.md` polish

- `README.md`: condenses Quick Start (117 → ~67 lines) by collapsing per-step rationale paragraphs into single-line pointers to `docs/dev-setup.md`. Adds a new `## Setup For Production` section listing the three `make setup-prod*` targets (`-preflight` / full / `-postapply`) and the destructive `make teardown-prod` inverse. Tightens the Makefile reference table to one row per target. Drops the "Further reading" index (already covered by `docs/`'s own README).

### Tests

- `frontend/src/app/page.test.tsx` (new, 76 lines): logged-in user → `REDIRECT:/cardgroups`; anonymous user → `REDIRECT:/login`; `AuthSessionMissingError` silenced; non-session errors are logged and rethrown.
- `frontend/src/app/login/page.test.tsx` (new, 102 lines): logged-in user → `REDIRECT:/cardgroups`; anonymous user renders `<LoginButton />`; `searchParams.error` set → `Sign-in failed: …` banner; non-session errors are logged with `[login]` prefix; `AuthSessionMissingError` is silenced.
- `frontend/src/app/admin/page.test.tsx` (new, 16 lines): redirect target is asserted as `/admin/users`.
- `frontend/src/app/api/healthz/route.test.ts` (new, 34 lines): success → 200 + `{ ok: true, backend: "ok" }`; rejection → 503 + `{ ok: false, error: "..." }`.
- `frontend/src/app/_components/header.test.tsx` (new, 167 lines): admin user shows the `Admin` link; non-admin user does not; anonymous user sees only `Sign in`; `AuthSessionMissingError` silently produces the anonymous header; non-session `getUser` failures degrade gracefully without crashing; UNAUTHENTICATED errors from `gqlFetch` do not pollute `console.warn`; other GraphQL errors do.

## Verification

After merge, the following should hold:

- `grep -n 'redirect(user ? "/cardgroups" : "/login")' frontend/src/app/page.tsx` matches once.
- `grep -n 'if (user) redirect("/cardgroups")' frontend/src/app/login/page.tsx` matches once.
- `cat frontend/src/app/admin/page.tsx` shows a 5-line server component that `redirect("/admin/users")`.
- `grep -n 'rawNext = url.searchParams.get("next") ?? "/cardgroups"' frontend/src/app/auth/callback/route.ts` matches once.
- `grep -n 'extensions?.code === "UNAUTHENTICATED"' frontend/src/app/_components/header.tsx` matches once (structural check, not substring).
- `ls frontend/src/app/api/healthz/route.ts frontend/src/app/api/healthz/queries.ts frontend/src/app/_components/queries.ts frontend/src/app/admin/page.tsx` lists every new file.
- `git ls-files frontend/next-env.d.ts` returns nothing.
- `grep -n "Codegen (Next.js typegen)" .github/workflows/frontend.yml` matches once.
- `grep -nE "PING_TOKEN" backend/.env.example playbooks/setup.yml` matches the new placeholder and the four auto-gen tasks.

Then on the running site:

- Visiting `/` while logged in lands on `/cardgroups`; while anonymous lands on `/login`.
- Visiting `/login` while logged in lands on `/cardgroups` without flashing the OAuth button.
- Visiting `/admin` while logged in as an admin lands on `/admin/users`.
- For an admin user, the header shows a `ShieldCheck`-iconed `Admin` link to the right of `Cardgroups`; for a non-admin user, the link is absent.
- `curl -s http://localhost:3000/api/healthz` returns `{"ok":true,"backend":"ok"}` while the backend is up; with the backend down, returns HTTP 503 and `{"ok":false,"error":"..."}`.

## Test plan

- [ ] `pnpm --filter frontend test` passes locally (covers all five new test files above).
- [ ] `pnpm --filter frontend exec next typegen && pnpm --filter frontend lint && pnpm --filter frontend exec tsc --noEmit && pnpm --filter frontend build` (mirrors CI) succeeds.
- [ ] Manual: visit `/` while logged in → land on `/cardgroups`; sign out → visit `/` → land on `/login`.
- [ ] Manual: with an active session, visit `/login` → land on `/cardgroups` without seeing the OAuth button flash.
- [ ] Manual: with an active admin session, visit `/admin` → land on `/admin/users`.
- [ ] Manual: complete a Google OAuth round-trip with no `?next` query param → land on `/cardgroups` (not `/`).
- [ ] Manual: as an admin user, the header shows the `Admin` link with the shield icon; sign out → header shows only `Sign in`.
- [ ] Manual: as a non-admin user, the header shows `Cardgroups`, `{email}`, and `Logout` but no `Admin` link.
- [ ] Manual: hit `/api/healthz` with the backend up → JSON `{"ok":true,"backend":"ok"}` and HTTP 200; stop the backend → JSON `{"ok":false,"error":"..."}` and HTTP 503.
- [ ] `make setup` from a clean clone (or with `backend/.env.local` deleted) produces a `PING_TOKEN=<64 hex>` line in `backend/.env.local` automatically; running `make sync-env` again is a no-op for `PING_TOKEN`.
- [ ] After `pnpm --filter frontend dev` followed by `pnpm --filter frontend build`, `git status` shows `frontend/next-env.d.ts` as ignored (not modified). `git add -f frontend/next-env.d.ts && git commit` is rejected on CI by the new guard step.
- [ ] Language-policy grep clean: `grep -rnP "[\x{3040}-\x{30ff}\x{4e00}-\x{9fff}]" --include="*.tsx" --include="*.ts" --include="*.md" --include="*.yml" frontend/src docs README.md backend/.env.example .github/workflows playbooks/setup.yml` returns nothing. `grep -rnE "PR[0-9]+" frontend/src docs README.md` returns nothing.
