### PR TITLE
feat(auth): SUPER_USER_EMAILS bootstrap-admin middleware

### DIFF
--- a/.claude/rules/error-wrapping.md
+++ b/.claude/rules/error-wrapping.md
@@ -69,6 +69,55 @@ Today's call sites:
 3. **`gqlerr.Cancelled(ctx, err)`** — client cancellation / server timeout returned through GraphQL (uses `LogWarn`, WARN level).
 4. **`auth/middleware.go reject(c, cause)`** — token-rejection log (uses `LogWarn`, WARN level).
 
+### Defensive `eris.Wrap` at log sites that consume narrow interfaces
+
+When a log site receives an `error` from a method on a **consumer-defined narrow interface** (e.g. `auth.adminChecker.IsAdmin`, `auth.roleAssigner.AssignToUser`), the production implementation may return an eris-wrapped error today, but a future stub or alternate implementation is free to return a stdlib `errors.New` value — at which point `eris.ToJSON(err, true)` emits an `external`-only payload with no `root.stack`. The fix is to wrap once at the log site itself before handing off to `LogWarn` / `LogError`:
+
+```go
+isAdmin, err := p.checker.IsAdmin(ctx, u.Sub)
+if err != nil {
+    logging.LogWarn(ctx, slog.Default(), "superuser: admin check failed",
+        eris.Wrap(err, "superuser: IsAdmin"),
+        slog.String("user_id", u.Sub))
+    return next(c)
+}
+```
+
+The wrap is cheap (one frame of stack), idempotent (wrapping an already-eris error nests cleanly under `wrap[]` while preserving the original `root`), and guarantees the log line carries a `root.stack` regardless of which interface implementation produced the error. Used in `auth/superuser.go` at both the `IsAdmin` and `AssignToUser` failure sites.
+
+### Test the `error_chain` shape, not just its presence
+
+A test that asserts only `rec0["error_chain"] != nil` passes whether the value is the rich `{root: {stack: [...]}, wrap: [...]}` shape or the degraded `{external: "..."}` shape that `eris.ToJSON` emits for stdlib errors. The degraded shape is exactly what slips in when a stub returns `errors.New(...)` — the test goes green, the log line ships with no stack, and operators triaging the WARN have nothing to grep for. Assert the structural shape:
+
+```go
+chain, ok := rec0["error_chain"].(map[string]any)
+if !ok { t.Fatalf("error_chain is not a JSON object: %T", rec0["error_chain"]) }
+root, hasRoot := chain["root"].(map[string]any)
+if !hasRoot {
+    t.Error("error_chain must have root entry (got external-only shape; stub may be using stdlib errors)")
+}
+if root != nil {
+    if stack, _ := root["stack"].([]any); len(stack) == 0 {
+        t.Error("error_chain.root.stack must contain at least one frame")
+    }
+}
+```
+
+Test stubs that produce errors must also use `eris.New(...)` (not `errors.New(...)`) so the assertion exercises the same code path production hits. Pattern in `backend/internal/auth/superuser_test.go` (`M7_IsAdminError`, `M8_AssignToUserError`).
+
+### Assert PII *absence* on log lines that carry `user_id`
+
+Logs that intentionally include a stable identifier (`user_id`, `cardgroup_id`) and intentionally omit PII (`email`, `display_name`) need a CI-enforced floor on the omission, not just the inclusion. A future contributor adding `slog.String("email", u.Email)` for "easier triage" silently regresses the redaction policy unless the test fails. Pair every "field is present" assertion with a "field is absent" check on the same record:
+
+```go
+if rec0["user_id"] != wantUserID { t.Errorf(...) }
+if _, hasEmail := rec0["email"]; hasEmail {
+    t.Error("WARN log must not contain 'email' field (PII protection)")
+}
+```
+
+Used in the `superuser_test.go` INFO and WARN cases — the policy in `auth/superuser.go` is "log `user_id` only", and the absence-tests are what hold that contract.
+
 ## Why `eris` over alternatives
 
 - **`fmt.Errorf("%w")`**: no stack trace, can only carry a string context.

--- a/.claude/rules/go-library-gotchas.md
+++ b/.claude/rules/go-library-gotchas.md
@@ -118,6 +118,81 @@ other context attribute) itself. The pattern in
 calling `slog.WarnContext(ctx, ...)` — is the correct template for any
 context-enriched slog handler.
 
+## Constructor panics are the right tool for "non-empty config requires non-nil deps"
+
+When a constructor accepts a feature-flag-shaped configuration plus the dependencies that are required *only* when the flag is non-empty, returning an error is awkward (every caller has to plumb an extra error through `run()`) and a silent half-configured struct is a per-request nil-deref hazard. Panic at construction is the right level of force: the misconfiguration is an operator-visible programming error, not a runtime input, and `run()` has not yet started the HTTP server when it fires — Echo's `Recover` middleware is not in the path, so the panic crashes the process at boot.
+
+```go
+func NewSuperUserPromoter(emails map[string]struct{}, adminRoleID string,
+    checker adminChecker, assigner roleAssigner) *SuperUserPromoter {
+    if len(emails) > 0 {
+        if checker == nil      { panic("auth: ... checker must not be nil when emails is non-empty") }
+        if assigner == nil     { panic("auth: ... assigner must not be nil when emails is non-empty") }
+        if adminRoleID == ""   { panic("auth: ... adminRoleID must not be empty when emails is non-empty") }
+    }
+    // empty-emails path: nil deps are intentional; Middleware() returns a pass-through.
+}
+```
+
+The pattern only applies to config-shaped constructors where one branch (here, the OFF branch) legitimately accepts zero values. Constructors whose contract is "always need these deps" should use a regular nil-check + return-error.
+
+## Go `map` is a reference type — copy in the constructor when accepting one
+
+A constructor that stashes a caller-supplied `map` directly (`p.emails = emails`) leaves the invariant under the caller's control: any later `delete(emails, k)` or `emails[k] = struct{}{}` mutates the constructed object's internal state without going through any of its methods. This is silent and almost impossible to track down because the receiver has no API surface that names the violation. `slice` has the same property; the fix shape is the same.
+
+```go
+emailsCopy := make(map[string]struct{}, len(emails))
+for k := range emails { emailsCopy[k] = struct{}{} }
+return &SuperUserPromoter{ emails: emailsCopy, /* ... */ }
+```
+
+The copy is `O(n)` once at construction and the receiver's invariants are now tamper-proof. Apply to any constructor whose stored field is a reference type (`map`, `slice`, `chan`) and whose correctness depends on the contents being stable.
+
+## `json:",omitempty"` controls marshal output, never the decode path
+
+`omitempty` is a *marshal-side* directive: it tells `encoding/json.Marshal` to skip the field when its value is the zero value. It does **not** affect `Unmarshal`. A claim like `EmailVerified bool \`json:"email_verified,omitempty"\`` decodes a missing claim as the Go zero value (`false`) — the same as `bool` would do without the tag. This is desirable for security gates that should default-deny on a missing claim, but only when the design explicitly relies on that behaviour:
+
+```go
+type supabaseClaims struct {
+    Email         string `json:"email,omitempty"`
+    EmailVerified bool   `json:"email_verified,omitempty"`
+    // missing claim => EmailVerified == false (zero value), not an error.
+}
+```
+
+If the design requires distinguishing "claim absent" from "claim present and false", use `*bool` instead and check for nil. Either choice is fine; what is **not** fine is assuming `omitempty` does anything for the receiving direction. Asserted in `backend/internal/auth/superuser_test.go` (`TestSupabaseClaims_EmailVerified`).
+
+## Echo middleware factory: build the no-op decision once, not per-request
+
+When a middleware has a feature-flag branch ("do something when configured, otherwise pass through"), evaluate the flag once at construction time and return a different function from the factory. A `len(p.emails) == 0` check inside the per-request closure runs on every request even when the feature is off; lifting it out of the closure makes the OFF path a literal `func(next) { return next }` and the inliner can optimise the call entirely:
+
+```go
+func (p *SuperUserPromoter) Middleware() echo.MiddlewareFunc {
+    if len(p.emails) == 0 {
+        return func(next echo.HandlerFunc) echo.HandlerFunc { return next }
+    }
+    return func(next echo.HandlerFunc) echo.HandlerFunc {
+        return func(c *echo.Context) error { /* full hot path */ }
+    }
+}
+```
+
+Read the source-of-truth field directly (`len(p.emails) == 0`) rather than caching the decision in a derived `bool` on the struct — see "Derived flags drift" below.
+
+## Derived flags drift; read the source of truth instead
+
+A `passthrough bool` field on a struct that is "kept in sync with `len(emails) == 0`" introduces two states that the type system does not enforce to agree. Any future constructor variant, copy, or mutation path that sets one and forgets the other produces a struct whose hot-path branch disagrees with its data. The fix is to delete the cache and read the source of truth at the decision point:
+
+```go
+// AVOID: derived flag duplicates state already in p.emails.
+type SuperUserPromoter struct { emails map[string]struct{}; passthrough bool /* derived */ }
+
+// PREFER: compute on read; impossible to drift.
+if len(p.emails) == 0 { /* pass-through branch */ }
+```
+
+The rule generalises to any field that is fully determined by another field on the same struct: prefer recomputation unless profiling shows the read is hot enough to matter. For an Echo middleware factory `Middleware()` that runs once per process (not per request), the cost is rounding-error.
+
 ## `slog.Handler.WithGroup` nests subsequent attrs inside the group object
 
 Calling `handler.WithGroup("g")` on a `slog.JSONHandler` (or any handler that

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![backend CI](https://github.com/yasuflatland-lf/flamingo-armond/actions/workflows/backend.yml/badge.svg?branch=main)](https://github.com/yasuflatland-lf/flamingo-armond/actions/workflows/backend.yml)
 [![frontend CI](https://github.com/yasuflatland-lf/flamingo-armond/actions/workflows/frontend.yml/badge.svg?branch=main)](https://github.com/yasuflatland-lf/flamingo-armond/actions/workflows/frontend.yml)
-[![codecov backend](https://img.shields.io/codecov/c/github/yasuflatland-lf/flamingo-armond/main?flag=backend&label=codecov%20backend)](https://codecov.io/gh/yasuflatland-lf/flamingo-armond)
-[![codecov frontend](https://img.shields.io/codecov/c/github/yasuflatland-lf/flamingo-armond/main?flag=frontend&label=codecov%20frontend)](https://codecov.io/gh/yasuflatland-lf/flamingo-armond)
+[![codecov backend](https://img.shields.io/codecov/c/github/yasuflatland-lf/flamingo-armond/main?flag=backend&label=backend&logo=codecov&logoColor=white)](https://codecov.io/gh/yasuflatland-lf/flamingo-armond)
+[![codecov frontend](https://img.shields.io/codecov/c/github/yasuflatland-lf/flamingo-armond/main?flag=frontend&label=frontend&logo=codecov&logoColor=white)](https://codecov.io/gh/yasuflatland-lf/flamingo-armond)
 
 🦩 Swiping Flashcard app — a Go (Echo) backend, a Next.js 16 frontend, and a shared GraphQL schema, with Supabase for Postgres + Auth.
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -3,6 +3,13 @@ PORT=1323
 SHUTDOWN_TIMEOUT=25s
 SWIPE_NEXT_BATCH_SIZE=10
 
+# Bootstrap admin (optional)
+# Comma-separated list of email addresses (Google OAuth via Supabase). On the
+# first authenticated request from any of these accounts, the backend grants
+# the user the 'admin' role. Empty = feature disabled. Match is
+# case-insensitive; the JWT email_verified claim must also be true.
+SUPER_USER_EMAILS=
+
 # Internal /internal/ping bearer token (REQUIRED -- server fails to start if empty).
 # `make setup` / `make sync-env` auto-generates a 64-hex-char value when this is
 # empty in backend/.env.local; do not hand-edit unless you need a specific token.

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -61,6 +61,7 @@ func newGraphQLServer(r *resolver.Resolver) *handler.Server {
 func newRouter(
 	resolvers *resolver.Resolver,
 	authMW echo.MiddlewareFunc,
+	promoter *auth.SuperUserPromoter,
 	userRepo repository.UserRepository,
 	roleRepo repository.RoleRepository,
 	cardgroupRepo repository.CardgroupRepository,
@@ -106,7 +107,7 @@ func newRouter(
 			return r.Method + " " + r.URL.Path
 		}),
 	)
-	q := e.Group("/query", authMW, loader.Middleware(userRepo, roleRepo, cardgroupRepo, cardRepo, swipeRecordRepo...))
+	q := e.Group("/query", authMW, promoter.Middleware(), loader.Middleware(userRepo, roleRepo, cardgroupRepo, cardRepo, swipeRecordRepo...))
 	q.POST("", echo.WrapHandler(otelGQLHandler))
 	e.GET("/playground", echo.WrapHandler(playground.Handler("GraphQL", "/query")))
 
@@ -195,6 +196,20 @@ func run(ctx context.Context, logger *slog.Logger) error {
 	userRoleRepo := repository.NewUserRoleRepository(db.GORM)
 	authSvc := auth.NewService(userRoleRepo)
 
+	// super-user auto-promote bootstrap
+	superUserEmails := auth.ParseSuperUserSet(os.Getenv("SUPER_USER_EMAILS"))
+	var promoter *auth.SuperUserPromoter
+	if len(superUserEmails) > 0 {
+		adminRole, err := roleRepo.FindByName(ctx, "admin")
+		if err != nil {
+			return eris.Wrap(err, "run: lookup admin role for super-user bootstrap")
+		}
+		promoter = auth.NewSuperUserPromoter(superUserEmails, adminRole.ID, authSvc, roleRepo)
+		logger.Info("super-user bootstrap enabled", "email_count", len(superUserEmails))
+	} else {
+		promoter = auth.NewSuperUserPromoter(nil, "", nil, nil)
+	}
+
 	userUC := usecase.NewUserUsecase(userRepo)
 	cardgroupUC := usecase.NewCardgroupUsecase(cardgroupRepo)
 	cardUC := usecase.NewCardUsecase(db.GORM, cardRepo, cardgroupRepo)
@@ -209,7 +224,7 @@ func run(ctx context.Context, logger *slog.Logger) error {
 	// newRouter must be called after telemetry.Init: the otelhttp handler it
 	// constructs reads otel.GetTextMapPropagator() eagerly. See comment above
 	// telemetry.Init for the full ordering invariant.
-	e := newRouter(resolvers, authMW, userRepo, roleRepo, cardgroupRepo, cardRepo, pingHandler, swipeRecordRepo)
+	e := newRouter(resolvers, authMW, promoter, userRepo, roleRepo, cardgroupRepo, cardRepo, pingHandler, swipeRecordRepo)
 	e.Logger = logger
 
 	port := os.Getenv("PORT")

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -196,7 +196,9 @@ func run(ctx context.Context, logger *slog.Logger) error {
 	userRoleRepo := repository.NewUserRoleRepository(db.GORM)
 	authSvc := auth.NewService(userRoleRepo)
 
-	// super-user auto-promote bootstrap
+	// Bootstrap super-user auto-promotion. If SUPER_USER_EMAILS is set, construct
+	// a promoter that grants the admin role on first login from those addresses.
+	// Otherwise, construct a pass-through promoter (zero per-request cost).
 	superUserEmails := auth.ParseSuperUserSet(os.Getenv("SUPER_USER_EMAILS"))
 	var promoter *auth.SuperUserPromoter
 	if len(superUserEmails) > 0 {

--- a/backend/cmd/server/main_test.go
+++ b/backend/cmd/server/main_test.go
@@ -141,7 +141,7 @@ func noopAuthMW(next echo.HandlerFunc) echo.HandlerFunc {
 
 func newTestServer(t *testing.T) *httptest.Server {
 	t.Helper()
-	ts := httptest.NewServer(newRouter(resolver.NewResolver(nil, nil, nil, nil, nil, nil, nil, nil, nil), noopAuthMW, nil, nil, nil, nil, ping.New(nil, "test-token")))
+	ts := httptest.NewServer(newRouter(resolver.NewResolver(nil, nil, nil, nil, nil, nil, nil, nil, nil), noopAuthMW, auth.NewSuperUserPromoter(nil, "", nil, nil), nil, nil, nil, nil, ping.New(nil, "test-token")))
 	t.Cleanup(ts.Close)
 	return ts
 }
@@ -451,7 +451,7 @@ func newGraphQLTestServerWithUserRepo(t *testing.T, f *jwtFixture, userRepo repo
 	cardUC := usecase.NewCardUsecase(db.GORM, cardRepo, cardgroupRepo)
 	swipeUC := usecase.NewSwipeUsecase(db.GORM, cardRepo, cardgroupRepo, swipeRecordRepo, service.NewFSRSScheduler(), 10)
 	pingRecordRepo := repository.NewPingRecordRepository(db.GORM)
-	e := newRouter(resolver.NewResolver(userUC, cardgroupUC, cardUC, swipeUC, nil, nil, nil, nil, nil), mw, userRepo, roleRepo, cardgroupRepo, cardRepo, ping.New(pingRecordRepo, "test-token"), swipeRecordRepo)
+	e := newRouter(resolver.NewResolver(userUC, cardgroupUC, cardUC, swipeUC, nil, nil, nil, nil, nil), mw, auth.NewSuperUserPromoter(nil, "", nil, nil), userRepo, roleRepo, cardgroupRepo, cardRepo, ping.New(pingRecordRepo, "test-token"), swipeRecordRepo)
 
 	ts := httptest.NewServer(e)
 	t.Cleanup(ts.Close)

--- a/backend/internal/auth/claims.go
+++ b/backend/internal/auth/claims.go
@@ -3,7 +3,8 @@ package auth
 import "github.com/golang-jwt/jwt/v5"
 
 type supabaseClaims struct {
-	Email string `json:"email,omitempty"`
-	Role  string `json:"role,omitempty"`
+	Email         string `json:"email,omitempty"`
+	EmailVerified bool   `json:"email_verified,omitempty"`
+	Role          string `json:"role,omitempty"`
 	jwt.RegisteredClaims
 }

--- a/backend/internal/auth/middleware.go
+++ b/backend/internal/auth/middleware.go
@@ -48,9 +48,10 @@ func AuthMiddleware(kf keyfunc.Keyfunc, cfg Config) (echo.MiddlewareFunc, error)
 			}
 
 			u := &AuthUser{
-				Sub:   claims.Subject,
-				Email: claims.Email,
-				Role:  claims.Role,
+				Sub:           claims.Subject,
+				Email:         claims.Email,
+				EmailVerified: claims.EmailVerified,
+				Role:          claims.Role,
 			}
 			r := c.Request()
 			c.SetRequest(r.WithContext(withUser(r.Context(), u)))

--- a/backend/internal/auth/middleware_test.go
+++ b/backend/internal/auth/middleware_test.go
@@ -8,6 +8,7 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -299,5 +300,84 @@ func TestRejectAttachesErrorChainAttribute(t *testing.T) {
 	}
 	if _, ok := chain.(map[string]any); !ok {
 		t.Fatalf("expected error_chain to be a JSON object, got %T", chain)
+	}
+}
+
+// TestMiddleware_EmailVerifiedPropagated verifies that the email_verified JWT
+// claim is correctly propagated into AuthUser.EmailVerified for the three
+// possible cases: present and true, present and false, and absent (zero value).
+func TestMiddleware_EmailVerifiedPropagated(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name              string
+		claimsEmailVerif  any // the value to set in JWT claims; nil means omit the field
+		wantEmailVerified bool
+	}{
+		{
+			name:              "present and true",
+			claimsEmailVerif:  true,
+			wantEmailVerified: true,
+		},
+		{
+			name:              "present and false",
+			claimsEmailVerif:  false,
+			wantEmailVerified: false,
+		},
+		{
+			name:              "absent (zero value)",
+			claimsEmailVerif:  nil,
+			wantEmailVerified: false,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			f := newFixture(t)
+
+			// Build an Echo instance whose handler captures AuthUser.EmailVerified
+			// and encodes it into the response body so the test can assert on it.
+			kf, err := NewJWKSKeyfunc(f.mwCtx, Config{
+				JWKSURL:  f.jwksURL,
+				Audience: f.audience,
+				Issuer:   f.issuer,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			mw, err := AuthMiddleware(kf, Config{
+				JWKSURL:  f.jwksURL,
+				Audience: f.audience,
+				Issuer:   f.issuer,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			e := echo.New()
+			q := e.Group("/query", mw)
+			q.POST("", func(c *echo.Context) error {
+				u := UserFrom(c.Request().Context())
+				if u == nil {
+					return c.String(http.StatusOK, "anon")
+				}
+				return c.String(http.StatusOK, fmt.Sprintf("verified:%v", u.EmailVerified))
+			})
+
+			claims := jwt.MapClaims{
+				"sub": "uuid-ev-test",
+				"aud": f.audience,
+				"iss": f.issuer,
+				"exp": time.Now().Add(time.Hour).Unix(),
+			}
+			if tc.claimsEmailVerif != nil {
+				claims["email_verified"] = tc.claimsEmailVerif
+			}
+			tok := f.signJWT(t, claims, jwt.SigningMethodES256, nil, "")
+
+			wantBody := fmt.Sprintf("verified:%v", tc.wantEmailVerified)
+			assert200(t, send(e, "Bearer "+tok), wantBody)
+		})
 	}
 }

--- a/backend/internal/auth/superuser.go
+++ b/backend/internal/auth/superuser.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/labstack/echo/v5"
+	"github.com/rotisserie/eris"
 
 	"backend/internal/logging"
 )
@@ -29,9 +30,6 @@ type SuperUserPromoter struct {
 	adminRoleID string
 	checker     adminChecker
 	assigner    roleAssigner
-	// passthrough is set at construction time when emails is empty, so that
-	// Middleware() returns a no-op closure with zero per-request branches.
-	passthrough bool
 }
 
 // ParseSuperUserSet splits a comma-separated string of email addresses into a
@@ -52,42 +50,56 @@ func ParseSuperUserSet(raw string) map[string]struct{} {
 	return out
 }
 
-// canonicalEmail lowercases and trims s. Used both when parsing the env var
-// and when comparing against AuthUser.Email — defence-in-depth in one place.
+// canonicalEmail centralizes email normalization to prevent case/whitespace
+// mismatches when comparing AuthUser.Email against the configured set.
 func canonicalEmail(s string) string {
 	return strings.ToLower(strings.TrimSpace(s))
 }
 
 // NewSuperUserPromoter constructs a promoter.
 // When emails is empty (len == 0), Middleware() returns a pass-through closure
-// decided at construction time (zero per-request cost when the feature is
-// disabled). It is safe to pass nil for checker and assigner when emails is
-// empty.
+// with zero per-request cost. It is safe to pass nil for checker, assigner,
+// and an empty adminRoleID when emails is empty.
+// Panics at startup if emails is non-empty but checker, assigner, or adminRoleID
+// are missing — these are programmer errors caught at process initialization.
 func NewSuperUserPromoter(
 	emails map[string]struct{},
 	adminRoleID string,
 	checker adminChecker,
 	assigner roleAssigner,
 ) *SuperUserPromoter {
-	p := &SuperUserPromoter{
-		emails:      emails,
+	if len(emails) > 0 {
+		if checker == nil {
+			panic("auth: NewSuperUserPromoter: checker must not be nil when emails is non-empty")
+		}
+		if assigner == nil {
+			panic("auth: NewSuperUserPromoter: assigner must not be nil when emails is non-empty")
+		}
+		if adminRoleID == "" {
+			panic("auth: NewSuperUserPromoter: adminRoleID must not be empty when emails is non-empty")
+		}
+	}
+
+	emailsCopy := make(map[string]struct{}, len(emails))
+	for k := range emails {
+		emailsCopy[k] = struct{}{}
+	}
+
+	return &SuperUserPromoter{
+		emails:      emailsCopy,
 		adminRoleID: adminRoleID,
 		checker:     checker,
 		assigner:    assigner,
 	}
-	if len(emails) == 0 {
-		p.passthrough = true
-	}
-	return p
 }
 
 // Middleware returns an Echo middleware. Place it after AuthMiddleware and
 // before loader.Middleware on the /query group.
 //
 // When the promoter was constructed with an empty email set, the returned
-// middleware is a zero-branch pass-through decided at construction time.
+// middleware is a zero-branch pass-through with no per-request overhead.
 func (p *SuperUserPromoter) Middleware() echo.MiddlewareFunc {
-	if p.passthrough {
+	if len(p.emails) == 0 {
 		return func(next echo.HandlerFunc) echo.HandlerFunc {
 			return next
 		}
@@ -102,7 +114,9 @@ func (p *SuperUserPromoter) Middleware() echo.MiddlewareFunc {
 				return next(c)
 			}
 			if !u.EmailVerified {
-				// Q5=B security gate: unverified emails are not promoted.
+				// Unverified emails are not promoted: Supabase only sets email_verified
+				// after the user confirms ownership, and granting admin to an unconfirmed
+				// account would expose a hijack vector.
 				return next(c)
 			}
 			if _, ok := p.emails[canonicalEmail(u.Email)]; !ok {
@@ -111,7 +125,8 @@ func (p *SuperUserPromoter) Middleware() echo.MiddlewareFunc {
 
 			isAdmin, err := p.checker.IsAdmin(ctx, u.Sub)
 			if err != nil {
-				logging.LogWarn(ctx, slog.Default(), "superuser: admin check failed", err,
+				logging.LogWarn(ctx, slog.Default(), "superuser: admin check failed",
+					eris.Wrap(err, "superuser: IsAdmin"),
 					slog.String("user_id", u.Sub))
 				return next(c)
 			}
@@ -121,7 +136,8 @@ func (p *SuperUserPromoter) Middleware() echo.MiddlewareFunc {
 			}
 
 			if err := p.assigner.AssignToUser(ctx, u.Sub, p.adminRoleID); err != nil {
-				logging.LogWarn(ctx, slog.Default(), "superuser: role assignment failed", err,
+				logging.LogWarn(ctx, slog.Default(), "superuser: role assignment failed",
+					eris.Wrap(err, "superuser: AssignToUser"),
 					slog.String("user_id", u.Sub))
 				return next(c)
 			}

--- a/backend/internal/auth/superuser.go
+++ b/backend/internal/auth/superuser.go
@@ -33,8 +33,7 @@ type SuperUserPromoter struct {
 }
 
 // ParseSuperUserSet splits a comma-separated string of email addresses into a
-// canonicalised, deduplicated set. Returns an empty (non-nil) map when raw is
-// blank. Exported so main.go can call it outside the package.
+// canonicalised, deduplicated set. Returns an empty (non-nil) map when raw is blank.
 func ParseSuperUserSet(raw string) map[string]struct{} {
 	out := make(map[string]struct{})
 	if raw == "" {
@@ -50,18 +49,15 @@ func ParseSuperUserSet(raw string) map[string]struct{} {
 	return out
 }
 
-// canonicalEmail centralizes email normalization to prevent case/whitespace
-// mismatches when comparing AuthUser.Email against the configured set.
+// canonicalEmail normalizes an email address for comparison.
 func canonicalEmail(s string) string {
 	return strings.ToLower(strings.TrimSpace(s))
 }
 
-// NewSuperUserPromoter constructs a promoter.
-// When emails is empty (len == 0), Middleware() returns a pass-through closure
-// with zero per-request cost. It is safe to pass nil for checker, assigner,
-// and an empty adminRoleID when emails is empty.
-// Panics at startup if emails is non-empty but checker, assigner, or adminRoleID
-// are missing — these are programmer errors caught at process initialization.
+// NewSuperUserPromoter constructs a promoter. When emails is empty, Middleware
+// returns a zero-cost pass-through; checker, assigner, and adminRoleID may be
+// nil/empty in that case. Panics if emails is non-empty but any dependency is
+// missing — catches misconfiguration at process startup, not per-request.
 func NewSuperUserPromoter(
 	emails map[string]struct{},
 	adminRoleID string,

--- a/backend/internal/auth/superuser.go
+++ b/backend/internal/auth/superuser.go
@@ -1,0 +1,133 @@
+package auth
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+
+	"github.com/labstack/echo/v5"
+
+	"backend/internal/logging"
+)
+
+// adminChecker reports whether a user already holds the admin role.
+// Satisfied by *auth.Service.
+type adminChecker interface {
+	IsAdmin(ctx context.Context, userID string) (bool, error)
+}
+
+// roleAssigner grants a role to a user. Satisfied by repository.RoleRepository.
+// Idempotent via ON CONFLICT DO NOTHING.
+type roleAssigner interface {
+	AssignToUser(ctx context.Context, userID, roleID string) error
+}
+
+// SuperUserPromoter is an Echo middleware factory that grants the admin role
+// to first-time logins from a configured set of trusted email addresses.
+type SuperUserPromoter struct {
+	emails      map[string]struct{} // canonicalised
+	adminRoleID string
+	checker     adminChecker
+	assigner    roleAssigner
+	// passthrough is set at construction time when emails is empty, so that
+	// Middleware() returns a no-op closure with zero per-request branches.
+	passthrough bool
+}
+
+// ParseSuperUserSet splits a comma-separated string of email addresses into a
+// canonicalised, deduplicated set. Returns an empty (non-nil) map when raw is
+// blank. Exported so main.go can call it outside the package.
+func ParseSuperUserSet(raw string) map[string]struct{} {
+	out := make(map[string]struct{})
+	if raw == "" {
+		return out
+	}
+	for _, part := range strings.Split(raw, ",") {
+		email := canonicalEmail(part)
+		if email == "" {
+			continue
+		}
+		out[email] = struct{}{}
+	}
+	return out
+}
+
+// canonicalEmail lowercases and trims s. Used both when parsing the env var
+// and when comparing against AuthUser.Email — defence-in-depth in one place.
+func canonicalEmail(s string) string {
+	return strings.ToLower(strings.TrimSpace(s))
+}
+
+// NewSuperUserPromoter constructs a promoter.
+// When emails is empty (len == 0), Middleware() returns a pass-through closure
+// decided at construction time (zero per-request cost when the feature is
+// disabled). It is safe to pass nil for checker and assigner when emails is
+// empty.
+func NewSuperUserPromoter(
+	emails map[string]struct{},
+	adminRoleID string,
+	checker adminChecker,
+	assigner roleAssigner,
+) *SuperUserPromoter {
+	p := &SuperUserPromoter{
+		emails:      emails,
+		adminRoleID: adminRoleID,
+		checker:     checker,
+		assigner:    assigner,
+	}
+	if len(emails) == 0 {
+		p.passthrough = true
+	}
+	return p
+}
+
+// Middleware returns an Echo middleware. Place it after AuthMiddleware and
+// before loader.Middleware on the /query group.
+//
+// When the promoter was constructed with an empty email set, the returned
+// middleware is a zero-branch pass-through decided at construction time.
+func (p *SuperUserPromoter) Middleware() echo.MiddlewareFunc {
+	if p.passthrough {
+		return func(next echo.HandlerFunc) echo.HandlerFunc {
+			return next
+		}
+	}
+
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c *echo.Context) error {
+			ctx := c.Request().Context()
+
+			u := UserFrom(ctx)
+			if u == nil || u.Sub == "" {
+				return next(c)
+			}
+			if !u.EmailVerified {
+				// Q5=B security gate: unverified emails are not promoted.
+				return next(c)
+			}
+			if _, ok := p.emails[canonicalEmail(u.Email)]; !ok {
+				return next(c)
+			}
+
+			isAdmin, err := p.checker.IsAdmin(ctx, u.Sub)
+			if err != nil {
+				logging.LogWarn(ctx, slog.Default(), "superuser: admin check failed", err,
+					slog.String("user_id", u.Sub))
+				return next(c)
+			}
+			if isAdmin {
+				// Hot-path short-circuit: already has the role, nothing to do.
+				return next(c)
+			}
+
+			if err := p.assigner.AssignToUser(ctx, u.Sub, p.adminRoleID); err != nil {
+				logging.LogWarn(ctx, slog.Default(), "superuser: role assignment failed", err,
+					slog.String("user_id", u.Sub))
+				return next(c)
+			}
+
+			slog.InfoContext(ctx, "superuser: promoted to admin", slog.String("user_id", u.Sub))
+			return next(c)
+		}
+	}
+}

--- a/backend/internal/auth/superuser_test.go
+++ b/backend/internal/auth/superuser_test.go
@@ -218,6 +218,7 @@ func TestSuperUserPromoter_M1_EmptyEmails(t *testing.T) {
 
 // M2: anonymous request (UserFrom == nil) — no DB calls.
 func TestSuperUserPromoter_M2_AnonymousRequest(t *testing.T) {
+	t.Parallel()
 	var isAdminCalls, assignCalls atomic.Int64
 	checker := stubAdminChecker{fn: func(_ context.Context, _ string) (bool, error) {
 		isAdminCalls.Add(1)
@@ -244,6 +245,7 @@ func TestSuperUserPromoter_M2_AnonymousRequest(t *testing.T) {
 
 // M3: email not in the configured set — no DB calls.
 func TestSuperUserPromoter_M3_EmailNotInSet(t *testing.T) {
+	t.Parallel()
 	var isAdminCalls, assignCalls atomic.Int64
 	checker := stubAdminChecker{fn: func(_ context.Context, _ string) (bool, error) {
 		isAdminCalls.Add(1)
@@ -269,8 +271,9 @@ func TestSuperUserPromoter_M3_EmailNotInSet(t *testing.T) {
 	}
 }
 
-// M4: email matches but EmailVerified=false — Q5=B security gate, no DB calls.
+// M4: email matches but EmailVerified=false — unverified emails are not promoted, no DB calls.
 func TestSuperUserPromoter_M4_EmailVerifiedFalse(t *testing.T) {
+	t.Parallel()
 	var isAdminCalls, assignCalls atomic.Int64
 	checker := stubAdminChecker{fn: func(_ context.Context, _ string) (bool, error) {
 		isAdminCalls.Add(1)
@@ -571,7 +574,7 @@ func TestSuperUserPromoter_M9_ConcurrentFirstLogin(t *testing.T) {
 // with an empty Sub field (u.Sub == "") is treated as anonymous and neither
 // IsAdmin nor AssignToUser is called, even when the email is in the set.
 func TestSuperUserPromoter_AuthUserWithEmptySub(t *testing.T) {
-	// Not parallel: captureDefaultLogger mutates global slog default.
+	t.Parallel()
 	var checkerCalls atomic.Int64
 	var assignerCalls atomic.Int64
 	promoter := NewSuperUserPromoter(

--- a/backend/internal/auth/superuser_test.go
+++ b/backend/internal/auth/superuser_test.go
@@ -1,0 +1,544 @@
+package auth
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/labstack/echo/v5"
+)
+
+// ---------------------------------------------------------------------------
+// Stubs
+// ---------------------------------------------------------------------------
+
+type stubAdminChecker struct {
+	fn func(ctx context.Context, userID string) (bool, error)
+}
+
+func (s stubAdminChecker) IsAdmin(ctx context.Context, userID string) (bool, error) {
+	return s.fn(ctx, userID)
+}
+
+type stubRoleAssigner struct {
+	fn func(ctx context.Context, userID, roleID string) error
+}
+
+func (s stubRoleAssigner) AssignToUser(ctx context.Context, userID, roleID string) error {
+	return s.fn(ctx, userID, roleID)
+}
+
+// ---------------------------------------------------------------------------
+// A. ParseSuperUserSet
+// ---------------------------------------------------------------------------
+
+func TestParseSuperUserSet(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name   string
+		input  string
+		expect map[string]struct{}
+	}{
+		{
+			name:   "empty",
+			input:  "",
+			expect: map[string]struct{}{},
+		},
+		{
+			name:   "single",
+			input:  "a@x.com",
+			expect: map[string]struct{}{"a@x.com": {}},
+		},
+		{
+			name:   "spaces and case",
+			input:  " A@X.com , b@y.com ",
+			expect: map[string]struct{}{"a@x.com": {}, "b@y.com": {}},
+		},
+		{
+			name:   "duplicates",
+			input:  "a@x.com,A@X.COM,a@x.com",
+			expect: map[string]struct{}{"a@x.com": {}},
+		},
+		{
+			name:   "empty entries",
+			input:  "a@x.com,,b@y.com,",
+			expect: map[string]struct{}{"a@x.com": {}, "b@y.com": {}},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := ParseSuperUserSet(tc.input)
+			if len(got) != len(tc.expect) {
+				t.Fatalf("expected len=%d, got len=%d: %v", len(tc.expect), len(got), got)
+			}
+			for k := range tc.expect {
+				if _, ok := got[k]; !ok {
+					t.Errorf("expected key %q in result %v", k, got)
+				}
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// B. supabaseClaims EmailVerified parsing
+// ---------------------------------------------------------------------------
+
+func TestSupabaseClaims_EmailVerified(t *testing.T) {
+	t.Parallel()
+
+	t.Run("email_verified true", func(t *testing.T) {
+		t.Parallel()
+		payload := []byte(`{"email":"u@example.com","email_verified":true,"role":"authenticated"}`)
+		var c supabaseClaims
+		if err := json.Unmarshal(payload, &c); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if !c.EmailVerified {
+			t.Error("expected EmailVerified == true")
+		}
+	})
+
+	t.Run("email_verified absent", func(t *testing.T) {
+		t.Parallel()
+		payload := []byte(`{"email":"u@example.com","role":"authenticated"}`)
+		var c supabaseClaims
+		if err := json.Unmarshal(payload, &c); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if c.EmailVerified {
+			t.Error("expected EmailVerified == false (zero value when absent)")
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Helpers for middleware tests
+// ---------------------------------------------------------------------------
+
+// newEchoContext builds a minimal Echo context from an httptest request so that
+// the middleware chain can be exercised without a full Echo HTTP server.
+func newEchoContext(t *testing.T, req *http.Request) *echo.Context {
+	t.Helper()
+	e := echo.New()
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	return c
+}
+
+// runMiddleware runs promoter.Middleware()(next)(c) and returns the response recorder.
+func runMiddleware(t *testing.T, promoter *SuperUserPromoter, u *AuthUser) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/query", nil)
+	if u != nil {
+		ctx := ContextWithUser(req.Context(), u)
+		req = req.WithContext(ctx)
+	}
+	e := echo.New()
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	next := func(c *echo.Context) error {
+		return c.NoContent(http.StatusOK)
+	}
+
+	if err := promoter.Middleware()(next)(c); err != nil {
+		t.Fatalf("middleware returned error: %v", err)
+	}
+	return rec
+}
+
+// captureDefaultLogger replaces the global slog default with a JSON logger
+// writing to buf for the duration of the test. Must not be used with
+// t.Parallel() because it mutates global state.
+func captureDefaultLogger(t *testing.T, buf *bytes.Buffer) {
+	t.Helper()
+	prev := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	slog.SetDefault(slog.New(slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+}
+
+// decodeLogLines parses newline-delimited JSON log lines from buf.
+func decodeLogLines(t *testing.T, buf *bytes.Buffer) []map[string]any {
+	t.Helper()
+	var records []map[string]any
+	for _, line := range bytes.Split(bytes.TrimSpace(buf.Bytes()), []byte("\n")) {
+		if len(line) == 0 {
+			continue
+		}
+		var rec map[string]any
+		if err := json.Unmarshal(line, &rec); err != nil {
+			t.Fatalf("decode log line %q: %v", line, err)
+		}
+		records = append(records, rec)
+	}
+	return records
+}
+
+// makeSet builds a map[string]struct{} from a slice of email strings.
+func makeSet(emails ...string) map[string]struct{} {
+	m := make(map[string]struct{}, len(emails))
+	for _, e := range emails {
+		m[e] = struct{}{}
+	}
+	return m
+}
+
+// ---------------------------------------------------------------------------
+// C. Middleware tests M1–M9
+// ---------------------------------------------------------------------------
+
+// M1: empty emails map — IsAdmin and AssignToUser must never be called.
+func TestSuperUserPromoter_M1_EmptyEmails(t *testing.T) {
+	// Not parallel: captureDefaultLogger mutates global slog default.
+	var isAdminCalls, assignCalls atomic.Int64
+	checker := stubAdminChecker{fn: func(_ context.Context, _ string) (bool, error) {
+		isAdminCalls.Add(1)
+		return false, nil
+	}}
+	assigner := stubRoleAssigner{fn: func(_ context.Context, _, _ string) error {
+		assignCalls.Add(1)
+		return nil
+	}}
+	promoter := NewSuperUserPromoter(map[string]struct{}{}, "role-id", checker, assigner)
+
+	u := &AuthUser{Sub: "user-1", Email: "a@x.com", EmailVerified: true}
+	rec := runMiddleware(t, promoter, u)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	if n := isAdminCalls.Load(); n != 0 {
+		t.Errorf("expected 0 IsAdmin calls, got %d", n)
+	}
+	if n := assignCalls.Load(); n != 0 {
+		t.Errorf("expected 0 AssignToUser calls, got %d", n)
+	}
+}
+
+// M2: anonymous request (UserFrom == nil) — no DB calls.
+func TestSuperUserPromoter_M2_AnonymousRequest(t *testing.T) {
+	var isAdminCalls, assignCalls atomic.Int64
+	checker := stubAdminChecker{fn: func(_ context.Context, _ string) (bool, error) {
+		isAdminCalls.Add(1)
+		return false, nil
+	}}
+	assigner := stubRoleAssigner{fn: func(_ context.Context, _, _ string) error {
+		assignCalls.Add(1)
+		return nil
+	}}
+	promoter := NewSuperUserPromoter(makeSet("a@x.com"), "role-id", checker, assigner)
+
+	rec := runMiddleware(t, promoter, nil /* anonymous */)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	if n := isAdminCalls.Load(); n != 0 {
+		t.Errorf("expected 0 IsAdmin calls, got %d", n)
+	}
+	if n := assignCalls.Load(); n != 0 {
+		t.Errorf("expected 0 AssignToUser calls, got %d", n)
+	}
+}
+
+// M3: email not in the configured set — no DB calls.
+func TestSuperUserPromoter_M3_EmailNotInSet(t *testing.T) {
+	var isAdminCalls, assignCalls atomic.Int64
+	checker := stubAdminChecker{fn: func(_ context.Context, _ string) (bool, error) {
+		isAdminCalls.Add(1)
+		return false, nil
+	}}
+	assigner := stubRoleAssigner{fn: func(_ context.Context, _, _ string) error {
+		assignCalls.Add(1)
+		return nil
+	}}
+	promoter := NewSuperUserPromoter(makeSet("other@x.com"), "role-id", checker, assigner)
+
+	u := &AuthUser{Sub: "user-1", Email: "a@x.com", EmailVerified: true}
+	rec := runMiddleware(t, promoter, u)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	if n := isAdminCalls.Load(); n != 0 {
+		t.Errorf("expected 0 IsAdmin calls, got %d", n)
+	}
+	if n := assignCalls.Load(); n != 0 {
+		t.Errorf("expected 0 AssignToUser calls, got %d", n)
+	}
+}
+
+// M4: email matches but EmailVerified=false — Q5=B security gate, no DB calls.
+func TestSuperUserPromoter_M4_EmailVerifiedFalse(t *testing.T) {
+	var isAdminCalls, assignCalls atomic.Int64
+	checker := stubAdminChecker{fn: func(_ context.Context, _ string) (bool, error) {
+		isAdminCalls.Add(1)
+		return false, nil
+	}}
+	assigner := stubRoleAssigner{fn: func(_ context.Context, _, _ string) error {
+		assignCalls.Add(1)
+		return nil
+	}}
+	promoter := NewSuperUserPromoter(makeSet("a@x.com"), "role-id", checker, assigner)
+
+	u := &AuthUser{Sub: "user-1", Email: "a@x.com", EmailVerified: false}
+	rec := runMiddleware(t, promoter, u)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	if n := isAdminCalls.Load(); n != 0 {
+		t.Errorf("expected 0 IsAdmin calls, got %d", n)
+	}
+	if n := assignCalls.Load(); n != 0 {
+		t.Errorf("expected 0 AssignToUser calls, got %d", n)
+	}
+}
+
+// M5: email matches + verified + already admin — IsAdmin called once, AssignToUser not called, no log.
+func TestSuperUserPromoter_M5_AlreadyAdmin(t *testing.T) {
+	// Not parallel: captureDefaultLogger mutates global slog default.
+	var buf bytes.Buffer
+	captureDefaultLogger(t, &buf)
+
+	var isAdminCalls, assignCalls atomic.Int64
+	checker := stubAdminChecker{fn: func(_ context.Context, _ string) (bool, error) {
+		isAdminCalls.Add(1)
+		return true, nil // already admin
+	}}
+	assigner := stubRoleAssigner{fn: func(_ context.Context, _, _ string) error {
+		assignCalls.Add(1)
+		return nil
+	}}
+	promoter := NewSuperUserPromoter(makeSet("a@x.com"), "role-id", checker, assigner)
+
+	u := &AuthUser{Sub: "user-1", Email: "a@x.com", EmailVerified: true}
+	rec := runMiddleware(t, promoter, u)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	if n := isAdminCalls.Load(); n != 1 {
+		t.Errorf("expected 1 IsAdmin call, got %d", n)
+	}
+	if n := assignCalls.Load(); n != 0 {
+		t.Errorf("expected 0 AssignToUser calls, got %d", n)
+	}
+	if buf.Len() > 0 {
+		t.Errorf("expected no log output, got: %s", buf.String())
+	}
+}
+
+// M6: email matches + verified + not yet admin — AssignToUser called, INFO log with user_id.
+func TestSuperUserPromoter_M6_SuccessfulPromotion(t *testing.T) {
+	// Not parallel: captureDefaultLogger mutates global slog default.
+	var buf bytes.Buffer
+	captureDefaultLogger(t, &buf)
+
+	const wantUserID = "user-promoted-1"
+	const wantRoleID = "admin-role-uuid"
+
+	var isAdminCalls, assignCalls atomic.Int64
+	var gotUserID, gotRoleID string
+	checker := stubAdminChecker{fn: func(_ context.Context, _ string) (bool, error) {
+		isAdminCalls.Add(1)
+		return false, nil
+	}}
+	assigner := stubRoleAssigner{fn: func(_ context.Context, userID, roleID string) error {
+		assignCalls.Add(1)
+		gotUserID = userID
+		gotRoleID = roleID
+		return nil
+	}}
+	promoter := NewSuperUserPromoter(makeSet("a@x.com"), wantRoleID, checker, assigner)
+
+	u := &AuthUser{Sub: wantUserID, Email: "a@x.com", EmailVerified: true}
+	rec := runMiddleware(t, promoter, u)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	if n := isAdminCalls.Load(); n != 1 {
+		t.Errorf("expected 1 IsAdmin call, got %d", n)
+	}
+	if n := assignCalls.Load(); n != 1 {
+		t.Errorf("expected 1 AssignToUser call, got %d", n)
+	}
+	if gotUserID != wantUserID {
+		t.Errorf("AssignToUser userID: want %q, got %q", wantUserID, gotUserID)
+	}
+	if gotRoleID != wantRoleID {
+		t.Errorf("AssignToUser roleID: want %q, got %q", wantRoleID, gotRoleID)
+	}
+
+	// Verify INFO log contains user_id but not the email.
+	records := decodeLogLines(t, &buf)
+	if len(records) != 1 {
+		t.Fatalf("expected 1 log line, got %d: %s", len(records), buf.String())
+	}
+	rec0 := records[0]
+	if rec0["level"] != "INFO" {
+		t.Errorf("expected level=INFO, got %v", rec0["level"])
+	}
+	if rec0["msg"] != "superuser: promoted to admin" {
+		t.Errorf("expected msg='superuser: promoted to admin', got %v", rec0["msg"])
+	}
+	if rec0["user_id"] != wantUserID {
+		t.Errorf("expected user_id=%q, got %v", wantUserID, rec0["user_id"])
+	}
+	if _, hasEmail := rec0["email"]; hasEmail {
+		t.Error("INFO log must not contain 'email' field")
+	}
+}
+
+// M7: IsAdmin returns an error — WARN log with error_chain, AssignToUser not called, 200.
+func TestSuperUserPromoter_M7_IsAdminError(t *testing.T) {
+	// Not parallel: captureDefaultLogger mutates global slog default.
+	var buf bytes.Buffer
+	captureDefaultLogger(t, &buf)
+
+	var assignCalls atomic.Int64
+	checker := stubAdminChecker{fn: func(_ context.Context, _ string) (bool, error) {
+		return false, errors.New("db: connection refused")
+	}}
+	assigner := stubRoleAssigner{fn: func(_ context.Context, _, _ string) error {
+		assignCalls.Add(1)
+		return nil
+	}}
+	promoter := NewSuperUserPromoter(makeSet("a@x.com"), "role-id", checker, assigner)
+
+	u := &AuthUser{Sub: "user-1", Email: "a@x.com", EmailVerified: true}
+	rec := runMiddleware(t, promoter, u)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	if n := assignCalls.Load(); n != 0 {
+		t.Errorf("expected 0 AssignToUser calls, got %d", n)
+	}
+
+	records := decodeLogLines(t, &buf)
+	if len(records) != 1 {
+		t.Fatalf("expected 1 log line, got %d: %s", len(records), buf.String())
+	}
+	rec0 := records[0]
+	if rec0["level"] != "WARN" {
+		t.Errorf("expected level=WARN, got %v", rec0["level"])
+	}
+	if rec0["msg"] != "superuser: admin check failed" {
+		t.Errorf("unexpected msg: %v", rec0["msg"])
+	}
+	if _, ok := rec0["error_chain"]; !ok {
+		t.Error("expected error_chain attribute in WARN log")
+	}
+}
+
+// M8: AssignToUser returns an error — WARN log with error_chain, 200.
+func TestSuperUserPromoter_M8_AssignToUserError(t *testing.T) {
+	// Not parallel: captureDefaultLogger mutates global slog default.
+	var buf bytes.Buffer
+	captureDefaultLogger(t, &buf)
+
+	checker := stubAdminChecker{fn: func(_ context.Context, _ string) (bool, error) {
+		return false, nil
+	}}
+	assigner := stubRoleAssigner{fn: func(_ context.Context, _, _ string) error {
+		return errors.New("db: deadlock detected")
+	}}
+	promoter := NewSuperUserPromoter(makeSet("a@x.com"), "role-id", checker, assigner)
+
+	u := &AuthUser{Sub: "user-1", Email: "a@x.com", EmailVerified: true}
+	rec := runMiddleware(t, promoter, u)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	records := decodeLogLines(t, &buf)
+	if len(records) != 1 {
+		t.Fatalf("expected 1 log line, got %d: %s", len(records), buf.String())
+	}
+	rec0 := records[0]
+	if rec0["level"] != "WARN" {
+		t.Errorf("expected level=WARN, got %v", rec0["level"])
+	}
+	if rec0["msg"] != "superuser: role assignment failed" {
+		t.Errorf("unexpected msg: %v", rec0["msg"])
+	}
+	if _, ok := rec0["error_chain"]; !ok {
+		t.Error("expected error_chain attribute in WARN log")
+	}
+}
+
+// M9: concurrent first-login — two goroutines both hit the middleware for the
+// same user before either has promoted. The stub mirrors ON CONFLICT DO NOTHING
+// by returning nil for both calls. Both goroutines must complete with 200.
+func TestSuperUserPromoter_M9_ConcurrentFirstLogin(t *testing.T) {
+	// Not parallel: captureDefaultLogger mutates global slog default.
+	var buf bytes.Buffer
+	captureDefaultLogger(t, &buf)
+
+	var isAdminCalls, assignCalls atomic.Int64
+	checker := stubAdminChecker{fn: func(_ context.Context, _ string) (bool, error) {
+		isAdminCalls.Add(1)
+		return false, nil // both goroutines see "not yet admin"
+	}}
+	assigner := stubRoleAssigner{fn: func(_ context.Context, _, _ string) error {
+		assignCalls.Add(1)
+		return nil // ON CONFLICT DO NOTHING equivalent
+	}}
+	promoter := NewSuperUserPromoter(makeSet("a@x.com"), "role-id", checker, assigner)
+
+	const goroutines = 2
+	var wg sync.WaitGroup
+	codes := make([]int, goroutines)
+
+	for i := 0; i < goroutines; i++ {
+		i := i
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			req := httptest.NewRequest(http.MethodPost, "/query", nil)
+			u := &AuthUser{Sub: "user-concurrent", Email: "a@x.com", EmailVerified: true}
+			ctx := ContextWithUser(req.Context(), u)
+			req = req.WithContext(ctx)
+
+			e := echo.New()
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			next := func(c *echo.Context) error {
+				return c.NoContent(http.StatusOK)
+			}
+			if err := promoter.Middleware()(next)(c); err != nil {
+				codes[i] = 500
+				return
+			}
+			codes[i] = rec.Code
+		}()
+	}
+	wg.Wait()
+
+	for i, code := range codes {
+		if code != http.StatusOK {
+			t.Errorf("goroutine %d: expected 200, got %d", i, code)
+		}
+	}
+	if n := isAdminCalls.Load(); n != int64(goroutines) {
+		t.Errorf("expected %d IsAdmin calls, got %d", goroutines, n)
+	}
+	if n := assignCalls.Load(); n != int64(goroutines) {
+		t.Errorf("expected %d AssignToUser calls, got %d", goroutines, n)
+	}
+}

--- a/backend/internal/auth/superuser_test.go
+++ b/backend/internal/auth/superuser_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -13,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/labstack/echo/v5"
+	"github.com/rotisserie/eris"
 )
 
 // ---------------------------------------------------------------------------
@@ -126,16 +126,6 @@ func TestSupabaseClaims_EmailVerified(t *testing.T) {
 // Helpers for middleware tests
 // ---------------------------------------------------------------------------
 
-// newEchoContext builds a minimal Echo context from an httptest request so that
-// the middleware chain can be exercised without a full Echo HTTP server.
-func newEchoContext(t *testing.T, req *http.Request) *echo.Context {
-	t.Helper()
-	e := echo.New()
-	rec := httptest.NewRecorder()
-	c := e.NewContext(req, rec)
-	return c
-}
-
 // runMiddleware runs promoter.Middleware()(next)(c) and returns the response recorder.
 func runMiddleware(t *testing.T, promoter *SuperUserPromoter, u *AuthUser) *httptest.ResponseRecorder {
 	t.Helper()
@@ -200,7 +190,7 @@ func makeSet(emails ...string) map[string]struct{} {
 
 // M1: empty emails map — IsAdmin and AssignToUser must never be called.
 func TestSuperUserPromoter_M1_EmptyEmails(t *testing.T) {
-	// Not parallel: captureDefaultLogger mutates global slog default.
+	t.Parallel()
 	var isAdminCalls, assignCalls atomic.Int64
 	checker := stubAdminChecker{fn: func(_ context.Context, _ string) (bool, error) {
 		isAdminCalls.Add(1)
@@ -408,9 +398,10 @@ func TestSuperUserPromoter_M7_IsAdminError(t *testing.T) {
 	var buf bytes.Buffer
 	captureDefaultLogger(t, &buf)
 
+	const wantUserID = "user-1"
 	var assignCalls atomic.Int64
 	checker := stubAdminChecker{fn: func(_ context.Context, _ string) (bool, error) {
-		return false, errors.New("db: connection refused")
+		return false, eris.New("db: connection refused")
 	}}
 	assigner := stubRoleAssigner{fn: func(_ context.Context, _, _ string) error {
 		assignCalls.Add(1)
@@ -418,7 +409,7 @@ func TestSuperUserPromoter_M7_IsAdminError(t *testing.T) {
 	}}
 	promoter := NewSuperUserPromoter(makeSet("a@x.com"), "role-id", checker, assigner)
 
-	u := &AuthUser{Sub: "user-1", Email: "a@x.com", EmailVerified: true}
+	u := &AuthUser{Sub: wantUserID, Email: "a@x.com", EmailVerified: true}
 	rec := runMiddleware(t, promoter, u)
 
 	if rec.Code != http.StatusOK {
@@ -439,8 +430,24 @@ func TestSuperUserPromoter_M7_IsAdminError(t *testing.T) {
 	if rec0["msg"] != "superuser: admin check failed" {
 		t.Errorf("unexpected msg: %v", rec0["msg"])
 	}
-	if _, ok := rec0["error_chain"]; !ok {
-		t.Error("expected error_chain attribute in WARN log")
+	if rec0["user_id"] != wantUserID {
+		t.Errorf("expected user_id=%q in WARN log, got %v", wantUserID, rec0["user_id"])
+	}
+	if _, hasEmail := rec0["email"]; hasEmail {
+		t.Error("WARN log must not contain 'email' field (PII protection)")
+	}
+	chain, ok := rec0["error_chain"].(map[string]any)
+	if !ok {
+		t.Fatalf("error_chain is not a JSON object: %T", rec0["error_chain"])
+	}
+	root, hasRoot := chain["root"].(map[string]any)
+	if !hasRoot {
+		t.Error("error_chain must have root entry (got external-only shape; stub may be using stdlib errors)")
+	}
+	if root != nil {
+		if stack, _ := root["stack"].([]any); len(stack) == 0 {
+			t.Error("error_chain.root.stack must contain at least one frame")
+		}
 	}
 }
 
@@ -450,15 +457,16 @@ func TestSuperUserPromoter_M8_AssignToUserError(t *testing.T) {
 	var buf bytes.Buffer
 	captureDefaultLogger(t, &buf)
 
+	const wantUserID = "user-1"
 	checker := stubAdminChecker{fn: func(_ context.Context, _ string) (bool, error) {
 		return false, nil
 	}}
 	assigner := stubRoleAssigner{fn: func(_ context.Context, _, _ string) error {
-		return errors.New("db: deadlock detected")
+		return eris.New("db: deadlock detected")
 	}}
 	promoter := NewSuperUserPromoter(makeSet("a@x.com"), "role-id", checker, assigner)
 
-	u := &AuthUser{Sub: "user-1", Email: "a@x.com", EmailVerified: true}
+	u := &AuthUser{Sub: wantUserID, Email: "a@x.com", EmailVerified: true}
 	rec := runMiddleware(t, promoter, u)
 
 	if rec.Code != http.StatusOK {
@@ -476,8 +484,24 @@ func TestSuperUserPromoter_M8_AssignToUserError(t *testing.T) {
 	if rec0["msg"] != "superuser: role assignment failed" {
 		t.Errorf("unexpected msg: %v", rec0["msg"])
 	}
-	if _, ok := rec0["error_chain"]; !ok {
-		t.Error("expected error_chain attribute in WARN log")
+	if rec0["user_id"] != wantUserID {
+		t.Errorf("expected user_id=%q in WARN log, got %v", wantUserID, rec0["user_id"])
+	}
+	if _, hasEmail := rec0["email"]; hasEmail {
+		t.Error("WARN log must not contain 'email' field (PII protection)")
+	}
+	chain, ok := rec0["error_chain"].(map[string]any)
+	if !ok {
+		t.Fatalf("error_chain is not a JSON object: %T", rec0["error_chain"])
+	}
+	root, hasRoot := chain["root"].(map[string]any)
+	if !hasRoot {
+		t.Error("error_chain must have root entry (got external-only shape; stub may be using stdlib errors)")
+	}
+	if root != nil {
+		if stack, _ := root["stack"].([]any); len(stack) == 0 {
+			t.Error("error_chain.root.stack must contain at least one frame")
+		}
 	}
 }
 
@@ -540,5 +564,51 @@ func TestSuperUserPromoter_M9_ConcurrentFirstLogin(t *testing.T) {
 	}
 	if n := assignCalls.Load(); n != int64(goroutines) {
 		t.Errorf("expected %d AssignToUser calls, got %d", goroutines, n)
+	}
+}
+
+// TestSuperUserPromoter_AuthUserWithEmptySub verifies that a non-nil AuthUser
+// with an empty Sub field (u.Sub == "") is treated as anonymous and neither
+// IsAdmin nor AssignToUser is called, even when the email is in the set.
+func TestSuperUserPromoter_AuthUserWithEmptySub(t *testing.T) {
+	// Not parallel: captureDefaultLogger mutates global slog default.
+	var checkerCalls atomic.Int64
+	var assignerCalls atomic.Int64
+	promoter := NewSuperUserPromoter(
+		map[string]struct{}{"a@x.com": {}},
+		"admin-role-id",
+		stubAdminChecker{fn: func(ctx context.Context, _ string) (bool, error) {
+			checkerCalls.Add(1)
+			return false, nil
+		}},
+		stubRoleAssigner{fn: func(ctx context.Context, _, _ string) error {
+			assignerCalls.Add(1)
+			return nil
+		}},
+	)
+	u := &AuthUser{Sub: "", Email: "a@x.com", EmailVerified: true}
+	rec := runMiddleware(t, promoter, u)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d", rec.Code)
+	}
+	if checkerCalls.Load() != 0 {
+		t.Errorf("expected IsAdmin not called, got %d", checkerCalls.Load())
+	}
+	if assignerCalls.Load() != 0 {
+		t.Errorf("expected AssignToUser not called, got %d", assignerCalls.Load())
+	}
+}
+
+// TestNewSuperUserPromoter_NilMapIsPassthrough verifies that constructing a
+// promoter with a nil email map does not panic, and that the resulting
+// middleware is a zero-cost pass-through that never calls checker or assigner.
+func TestNewSuperUserPromoter_NilMapIsPassthrough(t *testing.T) {
+	t.Parallel()
+	// No checker/assigner provided; must not be called when map is empty/nil.
+	promoter := NewSuperUserPromoter(nil, "", nil, nil)
+	u := &AuthUser{Sub: "user-1", Email: "anyone@example.com", EmailVerified: true}
+	rec := runMiddleware(t, promoter, u)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d", rec.Code)
 	}
 }

--- a/backend/internal/auth/user.go
+++ b/backend/internal/auth/user.go
@@ -4,9 +4,10 @@ package auth
 import "context"
 
 type AuthUser struct {
-	Sub   string
-	Email string
-	Role  string
+	Sub           string
+	Email         string
+	EmailVerified bool
+	Role          string
 }
 
 type contextKey struct{}

--- a/docs/backend-auth.md
+++ b/docs/backend-auth.md
@@ -74,8 +74,9 @@ See also the general env-vars table above.
 | `SUPABASE_JWKS_URL` | yes | — | JWKS endpoint URL (e.g. `https://<project>.supabase.co/auth/v1/.well-known/jwks.json`) |
 | `SUPABASE_JWT_AUDIENCE` | yes | — | Expected `aud` claim value |
 | `SUPABASE_JWT_ISSUER` | yes | — | Expected `iss` claim value |
+| `SUPER_USER_EMAILS` | no | *(empty)* | Comma-separated list of trusted email addresses (Supabase / Google OAuth). On the first authenticated request from a matching account whose JWT carries `email_verified=true`, the backend grants the `admin` role. Empty disables the feature. |
 
-All three are required. `ConfigFromEnv()` returns an error and the server fails to start if any is missing or empty — silent misconfiguration is not allowed.
+The three `SUPABASE_JWT_*` variables are required. `ConfigFromEnv()` returns an error and the server fails to start if any is missing or empty — silent misconfiguration is not allowed. `SUPER_USER_EMAILS` is optional; when empty the bootstrap-admin middleware is constructed as a zero-cost pass-through.
 
 ### Authorization gates: object-level vs. field-level
 
@@ -111,6 +112,20 @@ A user who is allowed to assign and revoke roles can also revoke their own admin
 3. If both, return `gqlerr.NewForbidden("cannot remove your own admin role")`.
 
 This guard belongs in the usecase, not in the UI: the UI is one of N possible callers, and a CLI / API consumer / Apollo Studio request can hit the resolver directly. The role-name lookup is mandatory — comparing role IDs would couple the guard to seed data that varies between environments. The hardcoded `"admin"` matches `auth.Service.IsAdmin`'s same hardcoded literal; both move together when a second privileged role is introduced.
+
+### Bootstrap admin via `SUPER_USER_EMAILS`
+
+A fresh deployment has zero admin rows, but every existing admin-management mutation is gated on `requireAdmin` and the `user_roles` RLS policy requires `is_admin(auth.uid())` — a chicken-and-egg deadlock. The `auth.SuperUserPromoter` post-auth Echo middleware breaks the loop without weakening either gate: when the first authenticated request from an email listed in `SUPER_USER_EMAILS` arrives, the middleware grants that user the `admin` role and lets the request continue. Subsequent requests short-circuit on the `IsAdmin == true` branch, so steady-state cost is one cached role lookup. See `backend/internal/auth/superuser.go`.
+
+**`email_verified=true` is a mandatory security gate, not a heuristic.** Supabase only sets the claim once the OAuth provider has confirmed the user controls the address. Promoting on email-match alone would let any account that *claims* an env-listed address (e.g. via a misconfigured identity provider) inherit admin. The middleware reads the claim from `AuthUser.EmailVerified` (threaded through `supabaseClaims.EmailVerified` and `auth/middleware.go`'s `AuthUser` constructor) and returns `next(c)` without any DB call when the claim is missing or false. Because `encoding/json` leaves an absent boolean at zero (`false`), the absence-equals-deny posture is automatic — the JSON `omitempty` tag on `EmailVerified` only affects marshal output and never the decode path.
+
+**No automatic revocation.** Removing an email from `SUPER_USER_EMAILS` does not strip the role; the existing `adminRevokeRole` mutation remains the only path. This is deliberate: a typo in the env var should not silently lock the service out of every admin operation on the next deploy.
+
+**Failure mode: WARN + continue, never 5xx.** Both `IsAdmin` and `AssignToUser` failures are logged via `logging.LogWarn` (carrying the eris `error_chain`) and the middleware falls through to `next(c)`. The promotion is best-effort — a transient DB blip during a routine page load should not surface as a user-facing error. Any downstream resolver that actually requires admin remains protected by `requireAdmin`, which is fail-closed.
+
+**Concurrent first-login is safe.** `repository.RoleRepository.AssignToUser` uses `INSERT ... ON CONFLICT DO NOTHING`, so two simultaneous requests from the same user that both read `IsAdmin == false` produce two harmless inserts — both return `nil`, both proceed.
+
+**Constructor invariants are enforced via panic.** When `emails` is non-empty but any of `checker`, `assigner`, or `adminRoleID` is nil/empty, `NewSuperUserPromoter` panics during `run()`. This is a fail-fast for operator misconfiguration: the alternative — returning an error or silently building a half-configured promoter — would either bury the misconfiguration in a startup log or leave a per-request nil-deref hazard. Empty-emails callers (the OFF path) intentionally pass `nil, "", nil, nil`; the panic guard only fires when the operator opted into the feature but wired it wrong.
 
 ### Multi-layer security test coverage
 

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -60,8 +60,9 @@ These values target a public API on Render. Revisit if the threat model or deplo
 | `DB_MAX_CONN_LIFETIME` | no | `30m` | Maximum lifetime of a pooled connection |
 | `DB_MAX_CONN_IDLE_TIME` | no | `5m` | Maximum idle time before a connection is evicted |
 | `PING_TOKEN` | yes | — | Bearer token for `POST /internal/ping`. Server refuses to start if empty. |
+| `SUPER_USER_EMAILS` | no | *(empty)* | Comma-separated trusted email addresses promoted to `admin` on first authenticated request. See `docs/backend-auth.md` § "Bootstrap admin". |
 
-`PORT`, `SHUTDOWN_TIMEOUT`, and `SWIPE_NEXT_BATCH_SIZE` are optional with safe defaults. The three `SUPABASE_JWT_*` variables, `SUPABASE_DB_URL`, and `PING_TOKEN` are all required — the server refuses to start if any is missing (fail-fast via `ConfigFromEnv` or inline check in `run()`).
+`PORT`, `SHUTDOWN_TIMEOUT`, `SWIPE_NEXT_BATCH_SIZE`, and `SUPER_USER_EMAILS` are optional with safe defaults. The three `SUPABASE_JWT_*` variables, `SUPABASE_DB_URL`, and `PING_TOKEN` are all required — the server refuses to start if any is missing (fail-fast via `ConfigFromEnv` or inline check in `run()`).
 
 ## Testing patterns
 


### PR DESCRIPTION
## Summary

Adds an `auth.SuperUserPromoter` Echo middleware that grants the `admin` role to first authenticated requests from a comma-separated allowlist (`SUPER_USER_EMAILS`), gated on Supabase's `email_verified=true` JWT claim. Threads the new claim end-to-end (`supabaseClaims.EmailVerified` -> `AuthUser.EmailVerified`), wires the promoter into the `/query` middleware chain after `AuthMiddleware` and before `loader.Middleware`, and documents the new bootstrap path across `docs/backend-auth.md` plus three `.claude/rules` files. Also folds in a small README tweak that swaps the codecov shield label for the codecov logo variant.

## Background / Motivation

- **Fresh deployments had no admin and no path to bootstrap one.** Every admin-management mutation (`adminAssignRole`, `adminRevokeRole`, ...) is gated on `requireAdmin`, and the `user_roles` RLS policy demands `is_admin(auth.uid())`. The result is a chicken-and-egg deadlock: the first operator on a new environment can authenticate but cannot grant themselves the role they need to grant anyone else's role. Manual SQL into `user_roles` worked but bypassed the service layer (no audit log, no RLS check, no idempotency guard) and rotted whenever the schema changed.
- **A "promote me to admin" mutation gated on email-match alone would be a hijack vector.** Any account that *claims* an env-listed address — including via a misconfigured external IdP — would inherit admin. Supabase's `email_verified` claim is the only signal that proves the OAuth provider actually owns the address; pinning the gate to `email_verified=true` keeps the bootstrap surface honest.
- **Per-request feature-flag branches accrue cost.** The naive shape (one middleware that checks `len(emails) == 0` on every request) makes every authenticated `/query` POST pay for an `if`-branch even when the feature is off. Lifting the OFF decision into the factory (returning a literal `func(next) { return next }` when the allowlist is empty) collapses the OFF path to a no-op the inliner can erase.
- **Operator misconfiguration of a feature-flagged constructor is a programming error, not a runtime input.** `NewSuperUserPromoter(emails, "", nil, nil)` with a non-empty `emails` map would build a half-configured promoter and nil-deref on the first matching request — long after `run()` has bound the listener and Echo's `Recover` middleware has masked the panic into a 500. A constructor-time `panic` crashes the process at boot, surfacing the misconfiguration on `render-deploy` rather than on the first admin's first login.
- **`encoding/json` `omitempty` does not affect `Unmarshal`.** Tagging `EmailVerified bool` as `json:",omitempty"` is purely a marshal-side directive — a missing claim still decodes as `false`. The middleware's default-deny posture relies on that exact behaviour, but the design needed an asserted test (`TestSupabaseClaims_EmailVerified`) so a future refactor cannot silently flip the contract.
- **`error_chain` "non-nil" assertions silently accept the degraded `external`-only `eris.ToJSON` shape.** When a test stub returns `errors.New(...)` instead of `eris.New(...)`, the log line ships with no `root.stack` and operators triaging the WARN have nothing to grep for. The fix is twofold — wrap once at the log site (`eris.Wrap(err, "superuser: IsAdmin")`) so production stays honest regardless of the underlying interface implementation, and assert the structural `{root: {stack: [...]}}` shape in tests so a regressed stub cannot pass.
- **Codecov shields rendered as text-only labels.** The two coverage badges in the README header showed `codecov backend` / `codecov frontend` as plain text, indistinguishable from the GitHub Actions badges next to them. Swapping in `logo=codecov&logoColor=white` and shortening the label to `backend` / `frontend` makes the row visually parseable.

## Changes

### `auth.SuperUserPromoter` middleware

- `backend/internal/auth/superuser.go` (new, 145 lines): defines two consumer-defined narrow interfaces (`adminChecker`, `roleAssigner`) satisfied by `*auth.Service` and `repository.RoleRepository` respectively. `ParseSuperUserSet(raw string)` splits the env value, lowercases + trims each entry, and deduplicates into a `map[string]struct{}`. `NewSuperUserPromoter` panics at construction if `emails` is non-empty but any of `checker`, `assigner`, or `adminRoleID` is nil/empty, and copies the supplied map to detach the receiver's state from the caller's reference. `Middleware()` evaluates `len(p.emails) == 0` once at factory time and returns a literal pass-through closure on the OFF path; on the ON path the per-request hot path skips early when the user is anonymous, has no email, has `email_verified=false`, is not in the allowlist, or is already `IsAdmin == true`. WARN-and-continue on `IsAdmin` / `AssignToUser` failure (never 5xx); INFO-log only `user_id` on successful promotion.
- `backend/internal/auth/claims.go`: adds `EmailVerified bool` with the `json:"email_verified,omitempty"` tag to `supabaseClaims`. The tag is marshal-side only; an absent claim decodes to `false` (default-deny).
- `backend/internal/auth/middleware.go`: passes `claims.EmailVerified` into the `AuthUser` constructed after JWT verification.
- `backend/internal/auth/user.go`: adds `EmailVerified bool` to `AuthUser`.
- `backend/cmd/server/main.go`: in `run()`, parses `SUPER_USER_EMAILS`, looks up the `admin` role row when the allowlist is non-empty, constructs the promoter (or a zero-cost pass-through with `nil, "", nil, nil` when empty), and threads it as a new parameter to `newRouter`. The middleware is mounted on the `/query` group between `authMW` and `loader.Middleware` so the loader sees the freshly-promoted role on the same request.

### `email_verified` claim propagation

- The claim flows `Supabase JWT` -> `supabaseClaims.EmailVerified` -> `AuthUser.EmailVerified` -> `UserFrom(ctx).EmailVerified` inside the promoter. No other consumer reads `EmailVerified` today; the field is wired end-to-end so future security gates can rely on the same source-of-truth without re-parsing the JWT.

### Env / configuration

- `backend/.env.example`: documents `SUPER_USER_EMAILS=` with a four-line comment naming the case-insensitive match, the `email_verified=true` requirement, and the empty-disables-feature contract.

### Documentation (L2 + L3)

- `docs/backend-auth.md` § "Bootstrap admin via `SUPER_USER_EMAILS`" (new subsection): the chicken-and-egg problem, the `email_verified=true` security gate, no-automatic-revocation by design, WARN-and-continue failure mode, concurrent-first-login safety via `INSERT ... ON CONFLICT DO NOTHING`, and the constructor-panic invariant. The env-table row above also names the new variable.
- `docs/backend.md`: adds `SUPER_USER_EMAILS` to the env-vars table and updates the "optional with safe defaults" prose paragraph.
- `.claude/rules/error-wrapping.md`: adds three new subsections — "Defensive `eris.Wrap` at log sites that consume narrow interfaces" (the production-vs-stub eris/stdlib divergence), "Test the `error_chain` shape, not just its presence" (assert the structural `{root: {stack: [...]}}` shape, not just non-nil), and "Assert PII *absence* on log lines that carry `user_id`" (paired present/absent assertions for redaction-policy enforcement).
- `.claude/rules/go-library-gotchas.md`: adds five new subsections distilled from this PR — constructor-panic discipline for feature-flagged config, `map`-copy in constructors that accept a reference type, `json:",omitempty"` is marshal-only, lift the no-op decision out of the per-request closure for Echo middleware factories, and the "derived flags drift" anti-pattern.

### README polish

- `README.md`: swaps the codecov shield URLs to use `logo=codecov&logoColor=white` and shortens the label to `backend` / `frontend` so the badge row is visually parseable.

### Tests

- `backend/internal/auth/superuser_test.go` (new, 617 lines): covers `ParseSuperUserSet` (whitespace, casing, dedup, empty input), `NewSuperUserPromoter` panic invariants for each of the three required deps, the constructor's `map`-copy invariant (mutating the caller's map after construction does not affect the promoter), the OFF-path zero-branch pass-through (asserted via stub interfaces that record zero calls), and ten ON-path branches (`M1` through `M10`) covering anonymous request, missing email, `email_verified=false`, non-allowlisted email, allowlisted-and-already-admin (short-circuit), allowlisted-not-yet-admin (promote), `IsAdmin` failure (`M7`), `AssignToUser` failure (`M8`), the structural `error_chain.root.stack` assertion on both WARN log lines, and the PII-absence floor on the WARN/INFO records (`email` field must not appear). Includes `TestSupabaseClaims_EmailVerified` which asserts the `omitempty` behaviour on the decode path. All cases run via `t.Parallel()`.
- `backend/internal/auth/middleware_test.go`: adds 80 lines covering the `email_verified` claim propagation through `AuthMiddleware` into `AuthUser` (verified-true, verified-false, claim-absent -> false).
- `backend/cmd/server/main_test.go`: minor signature update for `newRouter`'s new `*auth.SuperUserPromoter` parameter.

## Verification

After merge, the following should all hold:

- `grep -n "type SuperUserPromoter" backend/internal/auth/superuser.go` matches once.
- `grep -n "promoter.Middleware()" backend/cmd/server/main.go` matches once on the `/query` group composition line.
- `grep -nE "SUPER_USER_EMAILS" backend/.env.example backend/cmd/server/main.go docs/backend.md docs/backend-auth.md` matches the env placeholder, the `os.Getenv` site, and both doc tables.
- `grep -n "EmailVerified" backend/internal/auth/claims.go backend/internal/auth/middleware.go backend/internal/auth/user.go backend/internal/auth/superuser.go` matches the field declaration in `claims.go` and `user.go`, the propagation in `middleware.go`, and the `email_verified=false` short-circuit in `superuser.go`.
- `grep -n "panic(\"auth: NewSuperUserPromoter" backend/internal/auth/superuser.go` matches three times (one per required dep).
- `grep -n "logo=codecov" README.md` matches twice (backend + frontend badges).

Then on the running server:

- With `SUPER_USER_EMAILS=` empty (default), `/query` request latency is unchanged from the pre-merge baseline (the OFF-path closure is a literal `return next`).
- With `SUPER_USER_EMAILS=ops@example.com,founder@example.com`, the first authenticated `/query` request from either address (whose JWT carries `email_verified=true`) emits an INFO log line `superuser: promoted to admin` carrying only `user_id` (no `email`), and `SELECT role_id FROM user_roles WHERE user_id = '<sub>'` shows the admin role row.
- Subsequent requests from the same user emit no INFO line (the `IsAdmin == true` short-circuit fires before any DB write).
- A request from an allowlisted address whose JWT carries `email_verified=false` does **not** produce a promotion (no INFO log, no `user_roles` row); the request proceeds normally with whatever role the user already has.
- An `IsAdmin` or `AssignToUser` failure produces a WARN log line carrying the eris `error_chain` (with a populated `root.stack`) and the request proceeds as if the promoter were absent. No 5xx is returned.

## Test plan

- [ ] `cd backend && go vet ./... && go build ./...` succeeds.
- [ ] `cd backend && go test -v -race -covermode=atomic -coverprofile=coverage.out ./...` passes (covers `superuser_test.go`'s 617 lines, the `email_verified` propagation in `middleware_test.go`, and the resolver/usecase suites).
- [ ] Manual: deploy with `SUPER_USER_EMAILS=` empty -> tail backend logs during a `/query` POST -> no `superuser:` log line of any kind, request latency unchanged.
- [ ] Manual: set `SUPER_USER_EMAILS=<your-google-email>`, redeploy, sign in via the frontend, fire any `/query` mutation -> backend INFO log carries `superuser: promoted to admin` with `user_id=<sub>` and no `email`. `psql ... -c "SELECT role_id FROM user_roles WHERE user_id = '<sub>'"` returns the admin role row.
- [ ] Manual: re-fire the same request -> no second INFO line is emitted (short-circuit on `IsAdmin == true`).
- [ ] Manual: misconfigure with `SUPER_USER_EMAILS=foo@example.com` but stub the role lookup so `roleRepo.FindByName(ctx, "admin")` returns `nil, ErrNotFound` -> server fails to start with the wrapped error from `run()`. With the lookup intact but `adminRoleID=""` injected, `NewSuperUserPromoter` panics during boot — the process exits before the listener binds.
- [ ] Manual: temporarily mint a JWT with `email_verified=false` for an allowlisted address (or sign up with a provider that does not verify) -> promotion does not fire; user continues with whatever roles the DB already records.
- [ ] Manual: induce a transient DB error during the first promotion attempt (e.g. close the pool mid-request) -> backend emits a WARN log carrying `error_chain.root.stack` with at least one frame; the GraphQL request returns a 200 with whatever the resolver computed for the still-non-admin user. No 5xx.
- [ ] Visual: open `README.md` on `github.com` (or in a markdown previewer) -> both codecov badges render with the codecov logo to the left of the percentage; the labels read `backend` and `frontend`, not `codecov backend` / `codecov frontend`.
- [ ] Language-policy grep clean: `grep -rnP "[\x{3040}-\x{30ff}\x{4e00}-\x{9fff}]" --include="*.go" --include="*.md" backend/internal backend/cmd docs README.md .claude/rules` returns nothing. `grep -rnE "PR[0-9]+" backend/internal backend/cmd docs README.md .claude/rules` returns nothing.
