### PR TITLE
fix(frontend): logout crash filter and brand color CTAs

### DIFF
--- a/.claude/rules/frontend-rsc-error-handling.md
+++ b/.claude/rules/frontend-rsc-error-handling.md
@@ -15,7 +15,7 @@ if (error && error.name !== "AuthSessionMissingError") {
 // `user` is `User | null` here — branch on it.
 ```
 
-The filter is keyed on `error.name` (string), not on `instanceof` — Supabase's class identity does not survive serialization across the SDK's internal boundaries reliably. Used today in `frontend/src/components/nav/global-header.tsx`, `frontend/src/app/page.tsx`, `frontend/src/app/login/page.tsx`, `frontend/src/app/cards/new/page.tsx`, and `frontend/src/app/cardgroups/new/page.tsx`.
+The filter is keyed on `error.name` (string), not on `instanceof` — Supabase's class identity does not survive serialization across the SDK's internal boundaries reliably. The pattern applies to every RSC, layout, route handler, or server action that calls `supabase.auth.getUser()`. To find all current call sites: `grep -rn "auth.getUser\|auth.getSession\|auth.getClaims" frontend/src/`. Any new file added to those results must include the filter — there is no per-file list to maintain because the list rotted before this entry was rewritten.
 
 ## Header (root layout) MUST degrade on failure, never throw
 

--- a/frontend/src/app/admin/dictionary/page.tsx
+++ b/frontend/src/app/admin/dictionary/page.tsx
@@ -19,7 +19,12 @@ export default async function AdminDictionaryPage() {
     data: { user },
     error: authErr,
   } = await supabase.auth.getUser();
-  if (authErr) throw authErr;
+  // AuthSessionMissingError is the "no session" signal — fall through to the
+  // !user redirect below. Any other auth error is a real failure.
+  if (authErr && authErr.name !== "AuthSessionMissingError") {
+    console.error("[admin/dictionary] getUser() failed:", authErr.name, authErr.message);
+    throw authErr;
+  }
   if (!user) redirect("/login");
 
   return <DictionaryImportClient />;

--- a/frontend/src/app/admin/users/[id]/edit/page.tsx
+++ b/frontend/src/app/admin/users/[id]/edit/page.tsx
@@ -25,7 +25,12 @@ export default async function AdminUserEditPage({ params }: { params: Promise<{ 
     data: { user },
     error: authErr,
   } = await supabase.auth.getUser();
-  if (authErr) throw authErr;
+  // AuthSessionMissingError is the "no session" signal — fall through to the
+  // !user redirect below. Any other auth error is a real failure.
+  if (authErr && authErr.name !== "AuthSessionMissingError") {
+    console.error("[admin/users/:id/edit] getUser() failed:", authErr.name, authErr.message);
+    throw authErr;
+  }
   if (!user) redirect("/login");
 
   const { id } = await params;

--- a/frontend/src/app/admin/users/page.tsx
+++ b/frontend/src/app/admin/users/page.tsx
@@ -8,7 +8,12 @@ export default async function AdminUsersPage() {
     data: { user },
     error: authErr,
   } = await supabase.auth.getUser();
-  if (authErr) throw authErr;
+  // AuthSessionMissingError is the "no session" signal — fall through to the
+  // !user redirect below. Any other auth error is a real failure.
+  if (authErr && authErr.name !== "AuthSessionMissingError") {
+    console.error("[admin/users] getUser() failed:", authErr.name, authErr.message);
+    throw authErr;
+  }
   if (!user) redirect("/");
 
   return <AdminUsersClient />;

--- a/frontend/src/app/cardgroups/[id]/cards/page.tsx
+++ b/frontend/src/app/cardgroups/[id]/cards/page.tsx
@@ -17,7 +17,12 @@ export default async function CardsPage({ params }: { params: Promise<{ id: stri
     data: { user },
     error: authErr,
   } = await supabase.auth.getUser();
-  if (authErr) throw authErr;
+  // AuthSessionMissingError is the "no session" signal — fall through to the
+  // !user redirect below. Any other auth error is a real failure.
+  if (authErr && authErr.name !== "AuthSessionMissingError") {
+    console.error("[cardgroups/:id/cards] getUser() failed:", authErr.name, authErr.message);
+    throw authErr;
+  }
   if (!user) redirect("/login");
 
   const { id } = await params;

--- a/frontend/src/app/cardgroups/[id]/edit/page.tsx
+++ b/frontend/src/app/cardgroups/[id]/edit/page.tsx
@@ -17,7 +17,12 @@ export default async function EditCardgroupPage({ params }: Props) {
     data: { user },
     error: authErr,
   } = await supabase.auth.getUser();
-  if (authErr) throw authErr;
+  // AuthSessionMissingError is the "no session" signal — fall through to the
+  // !user redirect below. Any other auth error is a real failure.
+  if (authErr && authErr.name !== "AuthSessionMissingError") {
+    console.error("[cardgroups/:id/edit] getUser() failed:", authErr.name, authErr.message);
+    throw authErr;
+  }
   if (!user) redirect("/login");
 
   let data: { cardgroup?: { id: string; name: string; updatedAt: unknown } | null };

--- a/frontend/src/app/cardgroups/[id]/page.tsx
+++ b/frontend/src/app/cardgroups/[id]/page.tsx
@@ -22,7 +22,12 @@ export default async function CardgroupDetailPage({ params }: { params: Promise<
     data: { user },
     error: authErr,
   } = await supabase.auth.getUser();
-  if (authErr) throw authErr;
+  // AuthSessionMissingError is the "no session" signal — fall through to the
+  // !user redirect below. Any other auth error is a real failure.
+  if (authErr && authErr.name !== "AuthSessionMissingError") {
+    console.error("[cardgroups/:id] getUser() failed:", authErr.name, authErr.message);
+    throw authErr;
+  }
   if (!user) redirect("/login");
 
   const { id } = await params;

--- a/frontend/src/app/cardgroups/[id]/page.tsx
+++ b/frontend/src/app/cardgroups/[id]/page.tsx
@@ -60,7 +60,7 @@ export default async function CardgroupDetailPage({ params }: { params: Promise<
       {cards.length === 0 ? (
         <div className="mb-8 rounded-lg border border-dashed border-border p-6 text-center">
           <p className="mb-4 text-muted-foreground">No cards yet. Add some to get started.</p>
-          <Button asChild>
+          <Button asChild variant="brand">
             <Link href={`/cardgroups/${id}/cards`}>Add card</Link>
           </Button>
         </div>
@@ -86,7 +86,7 @@ export default async function CardgroupDetailPage({ params }: { params: Promise<
       )}
 
       <div className="flex flex-wrap gap-3">
-        <Button asChild>
+        <Button asChild variant="brand">
           <Link href={`/learn/${id}`}>Start learning</Link>
         </Button>
         <Button asChild variant="outline">

--- a/frontend/src/app/cardgroups/page.tsx
+++ b/frontend/src/app/cardgroups/page.tsx
@@ -35,7 +35,7 @@ export default async function CardgroupsPage() {
         <h1 className="text-2xl font-semibold">My Cardgroups</h1>
         <Link
           href="/cardgroups/new"
-          className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+          className="rounded-md bg-brand-primary px-4 py-2 text-sm font-medium text-brand-primary-foreground hover:opacity-90 transition-opacity"
         >
           New cardgroup
         </Link>
@@ -46,7 +46,7 @@ export default async function CardgroupsPage() {
           <p className="mb-4 text-muted-foreground">You haven&apos;t created any cardgroups yet.</p>
           <Link
             href="/cardgroups/new"
-            className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+            className="rounded-md bg-brand-primary px-4 py-2 text-sm font-medium text-brand-primary-foreground hover:opacity-90 transition-opacity"
           >
             New cardgroup
           </Link>

--- a/frontend/src/app/cardgroups/page.tsx
+++ b/frontend/src/app/cardgroups/page.tsx
@@ -13,7 +13,12 @@ export default async function CardgroupsPage() {
     data: { user },
     error: authErr,
   } = await supabase.auth.getUser();
-  if (authErr) throw authErr;
+  // AuthSessionMissingError is the "no session" signal — fall through to the
+  // !user redirect below. Any other auth error is a real failure.
+  if (authErr && authErr.name !== "AuthSessionMissingError") {
+    console.error("[cardgroups] getUser() failed:", authErr.name, authErr.message);
+    throw authErr;
+  }
   if (!user) redirect("/login");
 
   let data: MyCardgroupsQueryType;

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -21,7 +21,12 @@ export default async function ProfilePage() {
     data: { user },
     error: authErr,
   } = await supabase.auth.getUser();
-  if (authErr) throw authErr;
+  // AuthSessionMissingError is the "no session" signal — fall through to the
+  // !user redirect below. Any other auth error is a real failure.
+  if (authErr && authErr.name !== "AuthSessionMissingError") {
+    console.error("[profile] getUser() failed:", authErr.name, authErr.message);
+    throw authErr;
+  }
   if (!user) redirect("/login");
 
   const data = await gqlFetch(MeQuery, { revalidate: 0 });

--- a/frontend/src/components/cardgroups/cardgroup-form.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-form.tsx
@@ -86,7 +86,7 @@ export function CardgroupForm({
       </form.Field>
 
       <div className="flex items-center gap-2">
-        <Button type="submit" disabled={submitting}>
+        <Button type="submit" variant="brand" disabled={submitting}>
           {submitting ? "Saving..." : resolvedLabel}
         </Button>
         {secondarySlot}

--- a/frontend/src/components/cardgroups/cardgroup-picker-sheet.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-picker-sheet.tsx
@@ -52,10 +52,9 @@ export default function CardgroupPickerSheet({
       <SheetContent
         side="bottom"
         className="mx-auto max-h-[70vh] w-full max-w-lg overflow-y-auto rounded-t-xl pb-safe"
-        aria-labelledby="cardgroup-picker-title"
       >
         <SheetHeader className="mb-4">
-          <SheetTitle id="cardgroup-picker-title">Select cardgroup</SheetTitle>
+          <SheetTitle>Select cardgroup</SheetTitle>
           <SheetDescription className="sr-only">
             Choose the cardgroup for this card.
           </SheetDescription>

--- a/frontend/src/components/cardgroups/cardgroup-picker-sheet.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-picker-sheet.tsx
@@ -82,7 +82,7 @@ export default function CardgroupPickerSheet({
               </p>
               <Link
                 href="/cardgroups/new"
-                className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+                className="rounded-md bg-brand-primary px-4 py-2 text-sm font-medium text-brand-primary-foreground hover:opacity-90 transition-opacity"
                 onClick={() => onOpenChange(false)}
               >
                 Create cardgroup

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -10,6 +10,7 @@ const buttonVariants = cva(
     variants: {
       variant: {
         default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        brand: "bg-brand-primary text-brand-primary-foreground hover:bg-brand-primary/90",
         destructive: "bg-destructive text-destructive-foreground hover:bg-destructive/90",
         outline: "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
         secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",


### PR DESCRIPTION
## Summary

Bundles three interaction-layer fixes uncovered while exercising the post-merge UX of `/learn` and `/cardgroups`. (1) Logging out from any of eight auth-required RSCs (`/cardgroups`, `/cardgroups/[id]`, `/cardgroups/[id]/cards`, `/cardgroups/[id]/edit`, `/admin/users`, `/admin/dictionary`, `/admin/users/[id]/edit`, `/profile`) crashed with `Runtime AuthSessionMissingError: Auth session missing!` because each page threw the bare `getUser()` error instead of filtering it by `error.name`. (2) Five primary CTA buttons (Start learning / Add card / Create / New cardgroup ×2 / Create cardgroup in the picker empty state) rendered in the shadcn `bg-primary` neutral black instead of the brand coral defined as `--brand-primary` and already in use by the header "+ Card" pill, the FAB "+", and the Admin pill. The fix adds a `brand` variant to the shared `<Button>` so the next CTA does not have to choose between `bg-primary` (wrong) and inline brand class names (drift-prone). (3) The cardgroup picker sheet on `/cards/new` triggered a Radix Dialog accessibility warning on every open because a custom `id` on `<SheetTitle>` clashed with Radix's auto-generated `titleId`; removing the redundant id lets Radix wire `aria-labelledby` itself. The PR also retires the rule's stale "compliant call sites" allowlist that had already rotted twice.

## Background / Motivation

- **Supabase returns `AuthSessionMissingError`; it does not throw it.** `createSupabaseServerClient().auth.getUser()` resolves with `{ data: { user: null }, error: AuthSessionMissingError }` for any request without valid Supabase cookies. Eight RSCs treated **any** non-nil `error` as fatal (`if (authErr) throw authErr;`), which converted the documented happy-path-for-anonymous-requests into a 500 the moment the user logged out and `router.refresh()` re-rendered the page. The `if (!user) redirect("/login");` line below was structurally unreachable on logout because the unfiltered throw fired first.
- **Next.js 16's dev overlay surfaces server thrown errors aggressively.** The runtime overlay screenshotted on the bug report shows the throw originating inside `node_modules/.../GoTrueClient.ts` because the in-RSC throw site is ignore-listed by default; without the rule's filter, every protected route is one logout away from this overlay.
- **The rule's "Used today in" allowlist had already gone stale once.** `.claude/rules/frontend-rsc-error-handling.md` listed `frontend/src/app/profile/page.tsx` as a compliant filter site, but `profile/page.tsx:24` was throwing the bare error. A static list of compliant files implicitly tells the next contributor "if it's not on this list, you don't have to apply the pattern" — exactly the inverse of what the rule wants.
- **Brand color tokens existed but only three components consumed them.** `frontend/src/app/globals.css:27-87` defines `--brand-primary` / `--brand-primary-foreground` and exposes them as Tailwind utilities `bg-brand-primary` / `text-brand-primary-foreground`. Only the GlobalHeader "+ Card" pill, the GlobalFAB, and the AdminPill consume them today. Every primary action button on the rest of the app rendered through shadcn's `default` variant (`bg-primary`, neutral black) so the brand identity was visually limited to the chrome and absent from the actual call-to-action surfaces.
- **Two divergent ways of expressing brand color invited drift.** Components built around `<Button>` reach for `variant=...`; raw `<Link>` ones reach for inline className. With no `brand` variant in the shadcn `Button` and no shared "branded link" component, the next contributor has to either rewrite the button component or paste a long className string from the header pill — both routes are how the inconsistency landed in the first place.

## Changes

### `AuthSessionMissingError` filter applied to 8 RSCs

- The bare `if (authErr) throw authErr;` (one line) is replaced by the rule's canonical 5-line block in each file: a 2-line explanatory comment, then `if (authErr && authErr.name !== "AuthSessionMissingError")` guarding a scope-prefixed `console.error` and the original `throw authErr`. The existing `if (!user) redirect("/login");` immediately below is preserved unchanged.
- Per-route `[scope]` log prefixes (lifted from the existing `[home]`, `[login]`, `[cards-new]` convention used by the reference implementation in `frontend/src/app/page.tsx`):
  - `frontend/src/app/cardgroups/page.tsx` — `[cardgroups]`
  - `frontend/src/app/cardgroups/[id]/page.tsx` — `[cardgroups/:id]`
  - `frontend/src/app/cardgroups/[id]/cards/page.tsx` — `[cardgroups/:id/cards]`
  - `frontend/src/app/cardgroups/[id]/edit/page.tsx` — `[cardgroups/:id/edit]`
  - `frontend/src/app/admin/users/page.tsx` — `[admin/users]`
  - `frontend/src/app/admin/dictionary/page.tsx` — `[admin/dictionary]`
  - `frontend/src/app/admin/users/[id]/edit/page.tsx` — `[admin/users/:id/edit]`
  - `frontend/src/app/profile/page.tsx` — `[profile]`
- Reference implementation: `frontend/src/app/page.tsx:11-22` was the unchanged template; the eight edits clone its shape verbatim except for the per-route scope prefix.
- `admin/users/page.tsx` keeps its existing `redirect("/")` (rather than `/login`) when `!user` — that route's redirect target predates this PR and is intentionally untouched. Only the auth-error filter is added.

### Rule self-treatment in `.claude/rules/frontend-rsc-error-handling.md`

- The trailing sentence of the "AuthSessionMissingError is the 'no session' signal" section previously enumerated five compliant files by path. That list was already wrong about `profile/page.tsx` and missing the eight pages this PR fixes. Replaced with a standing instruction: the pattern applies to every RSC, layout, route handler, or server action that calls `supabase.auth.getUser()`, and the canonical way to find current call sites is `grep -rn "auth.getUser\|auth.getSession\|auth.getClaims" frontend/src/`. Phrased as "there is no per-file list to maintain because the list rotted before this entry was rewritten" so the rationale travels with the fix.

### `Button` gains a `brand` variant

- `frontend/src/components/ui/button.tsx:13` adds a new `brand` entry to the shadcn `cva` variant map: `brand: "bg-brand-primary text-brand-primary-foreground hover:bg-brand-primary/90"`. Slots between the `default` (neutral black) and `destructive` (red) variants so the visual hierarchy in the variant list mirrors the visual hierarchy in usage. The hover token follows the convention used by `default` (`bg-primary/90`) rather than the `hover:opacity-90` shape used by raw-Link brand sites — `<Button>` consumers expect `cva`-typed variants, so the variant interior should match the `default` shape.

### Primary CTA buttons switched to brand coral

- `frontend/src/app/cardgroups/[id]/page.tsx:63` "Add card" — `<Button asChild>` → `<Button asChild variant="brand">`.
- `frontend/src/app/cardgroups/[id]/page.tsx:89` "Start learning" — same shape.
- `frontend/src/components/cardgroups/cardgroup-form.tsx:89` "Create" / "Save" submit — `<Button type="submit" disabled={submitting}>` → `<Button type="submit" variant="brand" disabled={submitting}>`. Used by both create and edit flows so the entire cardgroup form pipeline reads brand.
- `frontend/src/app/cardgroups/page.tsx:38, 49` "New cardgroup" — both raw `<Link>` instances swap their color classes from `bg-primary ... text-primary-foreground hover:bg-primary/90 transition-colors` to `bg-brand-primary ... text-brand-primary-foreground hover:opacity-90 transition-opacity`, matching the header "+ Card" pill convention verbatim.
- `frontend/src/components/cardgroups/cardgroup-picker-sheet.tsx:85` "Create cardgroup" (empty-state link in the picker) — same color-class swap as above.

### Sheet a11y warning silenced (`CardgroupPickerSheet`)

- `frontend/src/components/cardgroups/cardgroup-picker-sheet.tsx` — removed the redundant `id="cardgroup-picker-title"` on `<SheetTitle>` and the matching `aria-labelledby="cardgroup-picker-title"` on `<SheetContent>`. Radix `Dialog.Content` warns `DialogContent requires a DialogTitle for the component to be accessible for screen reader users` whenever its mount-time check `document.getElementById(context.titleId)` cannot find an element with the auto-generated `titleId` from Radix context. With `@radix-ui/react-dialog@1.1.15` the user-supplied `id` props on `Dialog.Title` (line `<Primitive.h2 id={context.titleId} {...props} />`) override the auto `titleId`, leaving Radix's lookup empty even though a `<DialogTitle>` IS rendered in the subtree. Removing the custom override lets Radix wire `aria-labelledby` automatically.

## Verification

After merge, the following should all hold in the repo state:

- `grep -rn "if (authErr) throw authErr" frontend/src/` returns nothing — every bare-throw call site is fixed.
- `grep -rc 'authErr.name !== "AuthSessionMissingError"' frontend/src/app/cardgroups/page.tsx 'frontend/src/app/cardgroups/[id]/page.tsx' 'frontend/src/app/cardgroups/[id]/cards/page.tsx' 'frontend/src/app/cardgroups/[id]/edit/page.tsx' frontend/src/app/admin/users/page.tsx frontend/src/app/admin/dictionary/page.tsx 'frontend/src/app/admin/users/[id]/edit/page.tsx' frontend/src/app/profile/page.tsx` reports `1` for each of the eight files.
- `grep -n "Used today in" .claude/rules/frontend-rsc-error-handling.md` returns nothing.
- `grep -n 'brand: "bg-brand-primary' frontend/src/components/ui/button.tsx` matches once.
- `grep -rn 'bg-primary\b' frontend/src/ --include="*.tsx"` returns only `frontend/src/components/ui/button.tsx:12` (the `default` variant definition itself) and `frontend/src/app/admin/users/AdminUsersClient.tsx:56` (a Badge using `bg-primary/10`, intentionally neutral).

Then on the running dev server (`pnpm --filter frontend dev`):

- Sign in with any account, navigate to any of the eight previously-broken routes, click **Logout** in the header. The browser redirects to `/login` in one round-trip; no Next.js dev overlay appears.
- The "Start learning", "Add card", "Create", "New cardgroup" (×2), and "Create cardgroup" (picker empty state) buttons all render in the brand coral matching the header "+ Card" pill and the FAB.
- An *intentional* failure case still surfaces: temporarily replace `await supabase.auth.getUser()` in any one of the fixed files with `Promise.resolve({ data: { user: null }, error: { name: "NetworkError", message: "fetch failed" } })`. Reload the page → the dev overlay returns, the server logs `[<scope>] getUser() failed: NetworkError fetch failed`, and the throw propagates as before. Revert.

## Test plan

- [ ] `cd frontend && pnpm typecheck` exits 0.
- [ ] `cd frontend && pnpm lint` (Biome) exits 0 with no fixes applied.
- [ ] `cd frontend && pnpm test --run` exits 0 (393 tests across 52 files).
- [ ] Manual logout from `/cardgroups` while signed in — redirect to `/login`, no dev overlay.
- [ ] Manual logout from `/cardgroups/<id>` — same expectation.
- [ ] Manual logout from `/cardgroups/<id>/cards` — same expectation.
- [ ] Manual logout from `/cardgroups/<id>/edit` — same expectation.
- [ ] Manual logout from `/profile` — same expectation.
- [ ] Manual logout from `/admin/users` (as admin) — same expectation.
- [ ] Manual logout from `/admin/dictionary` (as admin) — same expectation.
- [ ] Manual logout from `/admin/users/<id>/edit` (as admin) — same expectation.
- [ ] Visual: `/cardgroups/[id]` — "Start learning" and "Add card" buttons render in brand coral matching the header "+ Card" pill.
- [ ] Visual: `/cardgroups` — both "New cardgroup" buttons (page-header right edge and empty-state) render in brand coral.
- [ ] Visual: `/cardgroups/new` — "Create" submit button renders in brand coral.
- [ ] Visual: open the cardgroup picker on `/learn/<id>` or `/cards/new` while owning zero cardgroups — the "Create cardgroup" empty-state link renders in brand coral.
- [ ] Regression: the existing happy paths (signed-in user navigating between protected routes, signed-out user visiting `/`, `/login`, `/cards/new`, `/cardgroups/new`, `/learn/<id>`) still work — none of those files were touched, so the existing `app/page.tsx`-style filter remains the source of truth.
- [ ] Negative test: induce a non-`AuthSessionMissingError` failure (see Verification above) — the dev overlay returns and the server log carries `[<scope>] getUser() failed: <error.name> <error.message>`.
- [ ] Sheet a11y: navigate to `/cards/new` while owning zero cardgroups (so `forcePickerOpen=true`); the picker opens automatically; the dev-server console shows no `DialogContent requires a DialogTitle` warning.
- [ ] Language-policy grep clean: `grep -rnP "[\x{3040}-\x{30ff}\x{4e00}-\x{9fff}]" --include="*.tsx" --include="*.ts" --include="*.md" frontend/src .claude/rules` returns nothing; `grep -rnE "PR[0-9]+" frontend/src .claude/rules` returns nothing.
