### PR TITLE
feat(frontend): stay-on-page consecutive card creation at /cards/new

### DIFF
--- a/.claude/rules/frontend-typescript-conventions.md
+++ b/.claude/rules/frontend-typescript-conventions.md
@@ -1,0 +1,39 @@
+# Frontend TypeScript conventions
+
+> Applies to: `frontend/src/**/*.{ts,tsx}`. Cross-cutting type-design rules that affect correctness, security, or testability and are non-obvious from the TypeScript docs alone.
+
+## Required `string | null` over optional `?: string | null` for security-relevant or caller-deliberate props
+
+`prop?: string | null` and `prop: string | null` are not interchangeable. The optional form (`?`) collapses three distinct caller states into two observable outcomes — callers may omit the prop entirely, which is indistinguishable at runtime from an explicit `null` and means the type system does not force the caller to acknowledge the prop's existence. When a prop has security implications (e.g. a redirect destination, a sanitized user-supplied value) or when the calling component must make an explicit choice (pass a value or acknowledge absence), use the required form:
+
+```ts
+// AVOID: callers can omit entirely; the prop's existence is unacknowledged.
+interface Props { returnTo?: string | null; }
+
+// PREFER: callers must pass something, even if it is null.
+interface Props { returnTo: string | null; }
+```
+
+The required form surfaces callers that forgot to wire the prop (compile error: "returnTo is missing") rather than silently defaulting to `undefined`. Reference: `frontend/src/app/cardgroups/new/new-cardgroup-client.tsx` (`returnTo: string | null`) after a review finding that the optional form allowed callers to skip the prop and lose the sanitized redirect value without any error.
+
+## JSDoc as the enforcer of "pre-sanitized" invariants when branded types are not used
+
+When a function or component accepts a value that must have crossed a security boundary before being passed (e.g. "this path has been validated as an internal path"), and the project style does not use branded/nominal types, a load-bearing JSDoc comment is the only compile-time signal available. The comment must:
+
+1. State what the caller is responsible for (e.g. "must be a pre-sanitized internal path").
+2. State what the receiving side does defensively (e.g. "the receiving page also calls `sanitizeReturnTo`").
+3. State what callers must NOT pass (e.g. "do not pass arbitrary user input here").
+
+```ts
+/**
+ * Path to return to after creating a new cardgroup. Must be a **pre-sanitized
+ * internal path** (e.g. `/cards/new`). The receiving page applies
+ * `sanitizeReturnTo` defensively, but callers are responsible for not passing
+ * arbitrary user input here.
+ */
+createReturnTo: string;
+```
+
+The JSDoc documents a two-layer defence: the caller sanitizes before passing, the receiver sanitizes again on arrival. Both layers are intentional — the "defensive" layer in the receiver is the last-resort guard against a future caller that skips pre-sanitization. Reference: `frontend/src/components/cardgroups/cardgroup-picker-sheet.tsx` (`createReturnTo` prop).
+
+If the project style evolves to allow branded types, replace the JSDoc with a nominal type (e.g. `type InternalPath = string & { readonly __brand: "InternalPath" }`) and a constructor function that calls `sanitizeReturnTo`. Until then, treat the JSDoc as load-bearing — do not remove it during refactoring without adding the branded type.

--- a/.claude/rules/pagination.md
+++ b/.claude/rules/pagination.md
@@ -152,3 +152,12 @@ Always import the named `NetworkStatus` enum from `@apollo/client`. Magic number
 ### Capture `console.warn` for MockedProvider leaks, then assert in teardown
 
 The assertion `nextPageCalls === 1` is partially tautological — `MockedProvider` matches per-entry, single-use, keyed on `(query, variables)`, so a leaked second `fetchMore` does not throw. It prints `"No more mocked responses for the query"` to `console.warn` and the `useQuery` hook resolves with `undefined` `data`; tests that depend on the second-page data thus silently pass on stale or missing data. The contract is **capture-then-explicit-assert**, not auto-fail-on-warn: `installApolloMockLeakSpy({ operationNames })` in `frontend/__tests__/utils/mock-apollo-paginated.ts` records every matching warning, and a `assertNoLeaks()` call in `afterEach` converts the captured set into a hard test failure. Restore the spy in the same `afterEach`. Without this, double-fetch regressions pass the call-count assertion silently.
+
+#### Spy stacking: install order is outer-first, teardown is LIFO
+
+When a test file installs the leak spy AND a second `vi.spyOn(console, "warn")` (e.g. to assert that a non-Apollo `console.warn("[scope] ...")` call also fires), the second `spyOn` becomes the **outer** spy: every `console.warn(...)` call hits it first, and only forwards to the leak spy if the outer spy's `mockImplementation` does so. Two consequences:
+
+1. **Do not call `outer.mockImplementation(() => {})` on the outer spy** — it swallows every warning before the leak spy records it, and `assertNoLeaks()` becomes a no-op while real leaks ship to production unnoticed. The `cards-new-client.test.tsx` regression that exposed this rule: a `mockImplementation(() => {})` was added to silence persist-failure warnings in a single test, and the leak spy stopped catching unmatched mocks for every test in the file.
+2. **Restore in LIFO order**: outer spy first (so `console.warn` is back to the leak spy's mock), then the leak spy (so `console.warn` is back to the real implementation). Reversing leaves the leak spy's mock installed permanently.
+
+If a single test needs to suppress a specific `console.warn` call, prefer asserting it explicitly via `expect(consoleWarnSpy).toHaveBeenCalledWith(...)` — the assertion documents intent and the call still flows through to the leak spy. The leak spy itself defaults to `silent: true` (`installApolloMockLeakSpy` swallows the formatted leak warning to keep CI output clean), so the outer spy does not need its own silencer.

--- a/.claude/rules/pagination.md
+++ b/.claude/rules/pagination.md
@@ -161,3 +161,16 @@ When a test file installs the leak spy AND a second `vi.spyOn(console, "warn")` 
 2. **Restore in LIFO order**: outer spy first (so `console.warn` is back to the leak spy's mock), then the leak spy (so `console.warn` is back to the real implementation). Reversing leaves the leak spy's mock installed permanently.
 
 If a single test needs to suppress a specific `console.warn` call, prefer asserting it explicitly via `expect(consoleWarnSpy).toHaveBeenCalledWith(...)` — the assertion documents intent and the call still flows through to the leak spy. The leak spy itself defaults to `silent: true` (`installApolloMockLeakSpy` swallows the formatted leak warning to keep CI output clean), so the outer spy does not need its own silencer.
+
+### Provide two `MockedResponse` entries to test a Retry-after-error path
+
+`MockedProvider` serves entries in order, single-use. A test that mounts with only one `{ request, error }` mock can assert that the error UI appears, but clicking Retry fires `refetch()` — which consumes a second entry. With only one entry, `MockedProvider` prints `"No more mocked responses for the query"` to `console.warn` and the `useQuery` hook resolves with `undefined` data; the refetch path is never exercised in a way that can assert the success state. Supply two matching entries:
+
+```ts
+const retryMocks: MockedResponse[] = [
+  { request: { query: MyQuery }, error: new Error("network failure") },
+  { request: { query: MyQuery }, result: { data: { ... } } },
+];
+```
+
+The first entry drives the initial error state; the second entry is consumed by `refetch()`. A single-entry test for the same scenario passes tautologically — the leak spy records the unmatched warn and `assertNoLeaks()` in `afterEach` converts it to a hard failure. Reference: `frontend/src/components/cardgroups/cardgroup-picker-sheet.test.tsx` tests S12 and S13.

--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,4 @@ supabase/.temp/
 
 # Teardown event records from production bring-up.
 /.setup-prod-archive/
+.playwright-mcp/

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![backend CI](https://github.com/yasuflatland-lf/flamingo-armond/actions/workflows/backend.yml/badge.svg?branch=main)](https://github.com/yasuflatland-lf/flamingo-armond/actions/workflows/backend.yml)
 [![frontend CI](https://github.com/yasuflatland-lf/flamingo-armond/actions/workflows/frontend.yml/badge.svg?branch=main)](https://github.com/yasuflatland-lf/flamingo-armond/actions/workflows/frontend.yml)
-[![codecov backend](https://img.shields.io/codecov/c/github/yasuflatland-lf/flamingo-armond/main?flag=backend&label=backend&logo=codecov&logoColor=white)](https://codecov.io/gh/yasuflatland-lf/flamingo-armond)
-[![codecov frontend](https://img.shields.io/codecov/c/github/yasuflatland-lf/flamingo-armond/main?flag=frontend&label=frontend&logo=codecov&logoColor=white)](https://codecov.io/gh/yasuflatland-lf/flamingo-armond)
+[![codecov backend](https://codecov.io/gh/yasuflatland-lf/flamingo-armond/branch/main/graph/badge.svg?flag=backend)](https://codecov.io/gh/yasuflatland-lf/flamingo-armond)
+[![codecov frontend](https://codecov.io/gh/yasuflatland-lf/flamingo-armond/branch/main/graph/badge.svg?flag=frontend)](https://codecov.io/gh/yasuflatland-lf/flamingo-armond)
 
 🦩 Swiping Flashcard app — a Go (Echo) backend, a Next.js 16 frontend, and a shared GraphQL schema, with Supabase for Postgres + Auth.
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,16 @@
 
 ![Production architecture](docs/images/architecture.png)
 
+## Pre-conditions
+
+Production deployment uses three external services. Create accounts before running `make setup-prod` — free tiers cover everything this repo provisions:
+
+- **Supabase** — managed Postgres + Auth: https://supabase.com
+- **Render** — hosts the Go backend: https://render.com
+- **Vercel** — hosts the Next.js frontend: https://vercel.com
+
+Local development does not require any of these — `make setup` boots a local Supabase via Docker. Provider tokens and the env-var matrix live in `docs/deployment.md`.
+
 ## Quick Start
 
 ### 1. Prerequisites

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,5 @@
 coverage:
+  range: "50...70"
   status:
     project:
       backend:

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -177,10 +177,19 @@ The admin entry surfaces (desktop `AdminPill`, mobile hamburger admin section) a
 Three components live under `frontend/src/components/nav/` and compose into the root layout:
 
 - `GlobalHeader` — RSC; rendered from `app/layout.tsx`. Mobile shows hamburger + logo + truncated email; desktop shows logo + nav links + `+ Card` CTA + `AdminPill` (when admin) + `LogoutButton`. Header MUST degrade silently on `getUser()` or `me`-query failure — see the rule.
-- `GlobalFAB` — Client; floats bottom-right with the coral `--brand-primary` background. Hidden on `/login`, `/learn/*`, `/admin/*`, `/cards/new`, `/cardgroups/new` — i.e. routes that are anonymous-only, full-bleed UI, a different audience, or the FAB's own destination (would loop). Hide list lives in one regex (`HIDDEN_PATH_RE`) inside `global-fab.tsx`; there is no allow-list. The FAB does NOT pre-pend `?cardgroup=...` — `/cards/new` owns the 4-priority resolution; passing the id from the FAB would create two truths.
+- `GlobalFAB` — Client; floats bottom-right with the coral `--brand-primary` background. Hidden on `/login`, `/learn/*`, `/admin/*`, `/cards/new`, `/cardgroups/new` — i.e. routes that are anonymous-only, full-bleed UI, a different audience, or the FAB's own destination (would loop). Hide list lives in one regex (`HIDDEN_PATH_RE`) inside `global-fab.tsx`; there is no allow-list. The FAB also wraps its button in an `md:hidden` container so the desktop header `+ Card` CTA is the **single** add-card affordance at `>= md` — see "Breakpoint-exclusive primary action" below. The FAB does NOT pre-pend `?cardgroup=...` — `/cards/new` owns the 4-priority resolution; passing the id from the FAB would create two truths.
+- `HeaderAddCardLink` — Client; the desktop `+ Card` CTA. Lives in `frontend/src/components/nav/header-add-card-link.tsx` so the surrounding `GlobalHeader` can stay an RSC. Reads `usePathname()` and applies the "current location CTA" pattern below when on `/cards/new`.
 - `HamburgerDrawer` — Client; mobile-only. Three visually-divided groups separated by `<hr>`: (1) primary nav (Cardgroups, Profile), (2) admin entry tinted with `bg-brand-tint` + `border-brand-tint-border` when `isAdmin`, (3) sign-out. The admin tint is the **only** non-CTA use of the brand palette — see "Design tokens" below.
 
 `AdminPill` is a server component rendered inline in the desktop header when `isAdmin === true`. Its tint comes from the same `--brand-tint*` family as the hamburger admin section so the two surfaces are visually linked.
+
+#### Breakpoint-exclusive primary action
+
+When two surfaces would render the same primary CTA at the same time (here: the desktop header `+ Card` button and the mobile `GlobalFAB`), make them **mutually exclusive by Tailwind class** (`md:hidden` on the FAB, `hidden md:flex` would go on a desktop-only nav element) rather than by a JS `useMediaQuery` hook. Two reasons: (1) SSR and CSR render the same markup, so there is no hydration flash where both affordances briefly appear; (2) no React re-render fires on viewport change — the browser handles the transition in CSS. Reach for `useMediaQuery` only when the *content* (not just visibility) differs across breakpoints, which is rare.
+
+#### Current-location CTA — `aria-current="page"` plus disabled styling
+
+When a primary CTA's destination is the page the user is already on, do not hide it (the layout would jump and the user loses orientation) and do not disable it as a `<button>` (it is a `<Link>`, not a button). Apply `aria-current="page"` for screen-reader semantics and pair with `pointer-events-none opacity-60` to make the same `<Link>` visually subdued and unclickable. Drop the hover variant on the same branch — a hover-color flash on a non-interactive element is dishonest. `HeaderAddCardLink` is the reference implementation.
 
 ### Cardgroup chip + picker primitives
 
@@ -462,6 +471,16 @@ if (result?.data?.updateCardgroup?.cardgroup) {
 
 **Form remount via React `key` to reset fields:** After a successful create-mutation, bump a numeric `key` state variable passed to the form component (`<CardForm key={createFormKey} ...>`). React unmounts and remounts the component, resetting all TanStack Form field state without manual `form.reset()` calls.
 
+**Stay-on-page consecutive add:** A create flow may deliberately *not* navigate after success — the user expects to add several items in a row without leaving the page. Three pieces compose:
+
+1. The submit handler does NOT call `router.push(...)` on success. Instead it (a) clears the form, (b) shows a transient success indicator, and (c) leaves the user with an explicit "Done" link to the natural next page (e.g. `/cardgroups/<id>/cards`). The "Done" link is the only navigation-out affordance, so back-button history stays clean — every add is one history entry on the same URL, not N entries on the destination page.
+2. The success indicator is a separate component keyed on a `useState<number | null>` whose value is bumped (`setSuccessKey(Date.now())`) on each successful submit. Because React unmounts-and-remounts on key change, the indicator's `setTimeout(..., 2000)` cleanup runs and a fresh timer starts — two rapid submits get two full 2 s windows, not one extended one. A boolean "isVisible" flag with a single timer would silently extend the previous timer when the second submit lands inside the first's window.
+3. Pin "we did not navigate" in a regression-guard test: `expect(mockPush).not.toHaveBeenCalled()` after a successful submit. Without the inverse assertion, a refactor that re-introduces `router.push(...)` passes the happy-path tests (form clears, indicator renders) and silently breaks the consecutive-add UX. Reference: `frontend/src/app/cards/new/cards-new-client.test.tsx`.
+
+**`onResetReady?: (resetFn: () => void) => void` — callback inversion to expose `form.reset()` to the parent without giving up `useForm` ownership:** The form's parent (e.g. `CardsNewClient`) needs to call `form.reset()` after the parent's submit-handler succeeds, but `useForm()` must live inside the form component because field validators depend on its identity. `forwardRef + useImperativeHandle` works but pulls the parent into the ref dance for one method. The lighter pattern: the form component accepts an optional `onResetReady` callback and runs `useEffect(() => onResetReady?.(() => form.reset({...})), [form, onResetReady])` once after mount, handing the parent a closure over the live `form`. The parent stores the closure in a `useRef<(() => void) | null>` and calls it from its submit handler. This keeps `useForm` lifecycle inside the child and makes the wiring trivially testable (the parent test does not touch the form's internal state). Reference: `frontend/src/components/cardgroups/card-form.tsx` (`onResetReady`) consumed by `frontend/src/app/cards/new/cards-new-client.tsx`.
+
+**Stable callback identity for child effect deps:** When a child component lists a parent-supplied callback in its `useEffect` dependency array (e.g. `useEffect(() => onResetReady?.(...), [form, onResetReady])`, or a self-dismissing indicator's `useEffect(..., [onTimeout])`), passing an inline arrow (`<Child onX={() => ...} />`) makes the dep change identity on every parent re-render and re-fires the effect. For a `setTimeout`-based dismiss this manifests as the timer never firing — each parent re-render restarts it. Wrap the parent-supplied callback in `useCallback(..., [...])` so the identity is stable across renders that do not change the captured closure. The bug surfaced concretely in `cards-new-client.tsx` where a fire-and-forget `setLastViewedCardgroup` mutation settling caused a parent re-render that reset the success indicator's 2 s timer on every animation frame. This is a React fundamentals issue, not a library quirk — but the failure mode is silent (component does not throw, timers just never elapse).
+
 **Validate-then-mutate flows must invalidate the validation result on input edit.** When a UI splits a server-side check (`validateDictionary`) from a destructive mutation (`upsertDictionary`) and gates the mutation button on the validation result, the validation state goes stale the instant the user edits any input feeding into it. Without explicit invalidation, the user can validate text A, edit to text B, and then submit B against a "valid" gate. The pattern is a `useEffect(() => setValidation(null), [<all input deps>])` whose callback only resets state — the deps array is trigger-only, which Biome flags as `lint/correctness/useExhaustiveDependencies`. Suppress with the inline `biome-ignore` comment as in `frontend/src/app/admin/dictionary/dictionary-client.tsx`.
 
 #### Bio explicit clear UX
@@ -669,6 +688,22 @@ afterEach(() => {
 ```
 
 Reference: `frontend/src/components/nav/global-header.test.tsx`. This applies to any test file that calls `vi.spyOn(...)` on a global (`console`, `Date`, `crypto`) or a module export.
+
+### `vi.useRealTimers()` in `afterEach` is a defensive guard for fake-timer leaks
+
+A single test that calls `vi.useFakeTimers()` and then `throw`s — or simply forgets to call `vi.useRealTimers()` at the end — leaks fake timers into every subsequent test in the same file. Symptoms: `userEvent` interactions hang because their internal `setTimeout(0)` never fires, and `MockedProvider`'s async resolution never settles because the microtask runner is paused. The whole suite then times out with no useful stack pointing at the offending test. Pin a defensive `vi.useRealTimers()` in `afterEach` in any file that touches fake timers (or *might* touch them via a refactor):
+
+```ts
+afterEach(() => {
+  vi.useRealTimers();
+  // ...other teardown
+});
+```
+
+Two corollaries:
+
+1. **Real timers + `waitFor` is usually the right tool for `setTimeout`-based UI** (e.g. a 2 s self-dismissing banner). Switching to fake timers `AFTER` the `setTimeout` is already pending does not migrate the existing real-timer handle into the fake queue — the timer keeps running on real time while `vi.advanceTimersByTime(...)` does nothing. Either install fake timers before the component mounts, or stay on real timers and `waitFor(..., { timeout: 3000 })`.
+2. **Avoid `mockImplementation(() => {})` on outer console spies that wrap an Apollo leak spy.** The leak spy from `installApolloMockLeakSpy` is itself a `console.warn` spy with `mockImplementation`; installing a second `vi.spyOn(console, "warn")` afterwards makes the second spy *outer* (it intercepts first), and an `outer.mockImplementation(() => {})` call swallows every warning before it ever reaches the inner leak spy — the inner spy then records nothing and `assertNoLeaks()` becomes a no-op. Track non-leak warnings via `expect(consoleWarnSpy).toHaveBeenCalledWith(...)` instead, and keep the outer spy in pass-through (call-recording) mode. Restore the outer spy first in `afterEach`, then the leak spy — LIFO order matches the install order. See the rule in `.claude/rules/pagination.md` § "Capture `console.warn` for MockedProvider leaks" for the full chain.
 
 ### Apollo Client v4 testing migration gotchas
 

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -197,6 +197,17 @@ When a primary CTA's destination is the page the user is already on, do not hide
 
 The chip truncates names to `max-w-[12ch] sm:max-w-[20ch]`; long names show as ellipsis-on-mobile and the full name appears in the picker. There is no tooltip — tapping the chip already reveals the full list.
 
+### Cardgroup creation flow — two entry points
+
+Cardgroup creation entry points are intentionally asymmetric because card and cardgroup creation frequencies are roughly 95:5. Two surfaces initiate cardgroup creation:
+
+1. **From `/cardgroups` list** (low-weight footer link): When the user owns ≥1 cardgroup, a thin "+ New cardgroup" link appears at the bottom of the list. Clicking it navigates to `/cardgroups/new` without a `returnTo` query, and the completion page is `/cardgroups/{newId}` — the new cardgroup's detail page.
+2. **From `/cards/new` picker** (always-visible inline link): The `CardgroupPickerSheet` always displays a "+ Create new cardgroup…" link at the bottom, even when cardgroups exist. Clicking it navigates to `/cardgroups/new?returnTo=/cards/new`, embedding the return destination into the query parameter. After creation, the page redirects to `/cards/new?cardgroup={newId}` with the new cardgroup pre-selected in the form, keeping the user in the card creation flow without a detour.
+
+**Open-redirect guard**: The `returnTo` query is sanitized server-side in `frontend/src/app/cardgroups/new/page.tsx` via the `sanitizeReturnTo` function. Only paths starting with `/` (and not `//` or `/\`) are accepted; everything else is rejected and defaults to `/cardgroups/{newId}`. The `/\` rejection blocks the browser-normalised backslash bypass — Chrome and Firefox rewrite `/\evil.com` to `//evil.com` and follow the protocol-relative URL off-domain.
+
+The asymmetry reflects the information hierarchy: the header "+ Card" button and mobile FAB remain the global, frequent path; cardgroup creation is a setup-level operation accessible only when creating a card (picker) or managing the cardgroup list (/cardgroups). This surfaces the card → cardgroup parent-child relationship in the interaction flow.
+
 ### Design tokens — brand palette usage rules
 
 `globals.css` defines five brand tokens (`--brand-primary`, `--brand-primary-foreground`, `--brand-tint`, `--brand-tint-border`, `--brand-tint-foreground`). The product palette is intentionally narrow:

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -469,6 +469,19 @@ await mutate({ variables }).catch(console.error);
 
 Do not swallow the rejection silently with an empty `.catch(() => {})` — that hides unexpected errors (network failures, etc.).
 
+**`void refetch()` swallows `useQuery` refetch rejections.** Unlike `useMutation` where the `error` state captures GraphQL errors, a `refetch()` call from `useQuery` also returns a promise that can reject on network failure. Writing `void refetch()` (or `onClick={() => void refetch()}`) drops that rejection silently — the error never reaches the operator log. Call `.catch` explicitly with a scoped warn:
+
+```ts
+refetch().catch((err) => {
+  console.warn("[scope] refetch failed", {
+    message: err instanceof Error ? err.message : String(err),
+    err,
+  });
+});
+```
+
+This is distinct from the `useMutation` unhandled-rejection rule: `useQuery`'s `error` state does update after a failed `refetch`, so the UI error branch still renders — but without the `.catch`, no log record exists for operator triage. Reference: `frontend/src/components/cardgroups/cardgroup-picker-sheet.tsx` Retry button.
+
 **Stale-closure trap with `useMutation` `error` state:** The `error` state from `useMutation` is updated on the next render. Reading it inside the same async handler right after `await mutate(...)` reads the previous closure's stale value. Gate navigation and dialog-close on the `FetchResult` returned by the `await` instead:
 
 ```ts
@@ -519,6 +532,17 @@ field to `""` so the next submit clears the column.
 **Inverse navigation assertion in failure-path tests:** Use `expect(mockPush).not.toHaveBeenCalled()` in error-path tests to pin down "navigate-on-failure" regressions. Without this assertion, a handler that navigates unconditionally passes happy-path tests but silently breaks on errors.
 
 **`__typename` in `MockedProvider` mocks must match the generated schema type name.** Apollo's normalization layer keys cache entries on `__typename` + identifying fields, and inline-included children are also keyed by their `__typename`. A made-up name (e.g. `"ValidationError"` instead of the schema's `DictionaryValidationError`) is silently degrading: the mock still resolves, but the cache stores a malformed entry and the next lookup misses. Copy the type name from `frontend/src/generated/graphql.ts` rather than guessing.
+
+**`vi.mock` factory props must be typed with `React.ComponentProps<typeof import(...)>`, not `Record<string, unknown>`.** A `vi.mock` factory that types the captured props as `Record<string, unknown>` defeats TypeScript entirely: a future rename of any prop in the real component passes type-check silently because `Record<string, unknown>` accepts any key. Use `React.ComponentProps<typeof import("@/path/to/component").default>` instead — the import path resolves at type-check time, so a renamed prop becomes a compile error in the test. Note: the factory function body itself must also use the same type, not just the capture variable. Reference: `frontend/src/app/cards/new/cards-new-client.test.tsx` (`PickerSheetProps` and the `vi.mock` factory for `cardgroup-picker-sheet`).
+
+**E2E locators using `.last()` are positional and fragile.** Playwright's `.last()` silently picks the wrong element when DOM order changes — a new component variant, a different render branch, or a reorder of sibling nodes is enough to flip which element `.last()` resolves to, and the test still passes green while asserting the wrong thing. Instead, scope to the container that is unique to the branch you want:
+
+```ts
+const footerScope = page.locator(".mt-6.border-t.pt-4");
+const footerLink = footerScope.getByRole("link", { name: /New cardgroup/ });
+```
+
+The container CSS class is stable (it comes from the layout, not from dynamic data), so the locator stays correct even when sibling branches add or remove elements. Reference: `frontend/e2e/cardgroups-flow.spec.ts`.
 
 ## shadcn/ui
 
@@ -578,6 +602,8 @@ Being first in the chain ensures the ID is present for every subsequent link and
 **`app/<route>/error.tsx` does not catch errors from `app/layout.tsx`.** Next.js error boundaries scoped to a route segment only catch errors thrown by that segment's RSCs and components. Errors thrown inside `app/layout.tsx` (e.g. the `Header`) escape to `app/global-error.tsx`, or to Next's default crash page if `global-error.tsx` is absent. Keep shared layout components defensive — render degraded states rather than throwing.
 
 **`useRef(false)` is the correct guard for one-shot effects in error boundaries.** When an error boundary needs to call `router.replace()` exactly once, use `const hasRedirected = useRef(false)` to gate the call inside `useEffect`. Using `useState` instead would re-trigger the effect on every re-render. `useRef` mutations do not schedule a re-render and therefore cannot form a feedback loop.
+
+**`router.refresh()` after `router.push()` refreshes the source route, not the destination.** `router.refresh()` re-renders the RSC subtree for whatever page is current at call time. Calling it immediately after `router.push("/other")` targets the *current* page before the navigation settles — the destination route does not receive the refresh. `router.refresh()` is only useful when staying on the same route (e.g. after a mutation that does not navigate). When navigating to a different route, skip `router.refresh()` entirely — the destination page is a fresh server render, so there is nothing stale to clear. Reference: `frontend/src/app/cardgroups/new/new-cardgroup-client.tsx` calls `router.refresh()` only in the no-`returnTo` branch that navigates to `/cardgroups/{id}` (a same-domain refresh of the newly-pushed page is idempotent), and skips it in the `returnTo` branch where the destination is a fully fresh render.
 
 **Next 16 deprecates `middleware.ts` in favour of `proxy.ts`.** The build emits a deprecation warning (not an error) when `src/middleware.ts` exists. We intentionally stay on `middleware.ts` because `@supabase/ssr` templates and ecosystem docs still reference the old name. When the ecosystem catches up and Next removes the old name, rename `src/middleware.ts` → `src/proxy.ts` (and `src/lib/supabase/middleware.ts` → `src/lib/supabase/proxy.ts` for consistency).
 

--- a/frontend/e2e/cardgroups-flow.spec.ts
+++ b/frontend/e2e/cardgroups-flow.spec.ts
@@ -1,0 +1,214 @@
+import { randomUUID } from "node:crypto";
+import { expect, test } from "@playwright/test";
+import { loginAs, seedCardgroup, seedUser } from "./_auth";
+
+// Covers the cardgroup-creation navigation refactor:
+//   - Footer link on /cardgroups (with at least one cardgroup)
+//   - Empty-state CTA on /cardgroups (zero cardgroups)
+//   - Picker-driven create flow from /cards/new
+//   - Open-redirect rejection for external returnTo values
+
+const runId = randomUUID().slice(0, 8);
+const UUID_RE = /^[0-9a-f-]{36}$/;
+
+const withCardgroup = {
+  email: `cg-flow-${runId}@example.test`,
+  password: "e2e-password",
+};
+
+let seededCardgroupName: string;
+
+const emptyUser = {
+  email: `cg-empty-${runId}@example.test`,
+  password: "e2e-password",
+};
+
+test.describe.serial("cardgroups flow", () => {
+  test.beforeAll(async () => {
+    // Seed the "with cardgroup" user and one cardgroup.
+    const user = await seedUser({
+      email: withCardgroup.email,
+      password: withCardgroup.password,
+      role: "general",
+      displayName: "E2E CG Flow",
+    });
+    const cg = await seedCardgroup({
+      ownerId: user.id,
+      name: `E2E cardgroup ${runId}`,
+    });
+    seededCardgroupName = cg.name;
+
+    // Seed the "empty" user with no cardgroups.
+    await seedUser({
+      email: emptyUser.email,
+      password: emptyUser.password,
+      role: "general",
+      displayName: "E2E CG Empty",
+    });
+  });
+
+  // ── Scenario 1 ──────────────────────────────────────────────────────────────
+  // Footer-link path on /cardgroups: with at least one cardgroup the footer
+  // "New cardgroup" link is visible at the bottom of the list. Clicking it
+  // lands on /cardgroups/new with no returnTo, and the form is interactive.
+  test("footer link on /cardgroups leads to /cardgroups/new without returnTo", async ({
+    context,
+    page,
+  }) => {
+    await loginAs(context, withCardgroup);
+
+    const response = await page.goto("/cardgroups");
+    expect(response?.ok(), `goto /cardgroups returned ${response?.status()}`).toBe(true);
+
+    // The seeded cardgroup must be visible, confirming the non-empty branch renders.
+    await expect(page.getByText(seededCardgroupName)).toBeVisible();
+
+    // The large dashed-border CTA must NOT be present in the non-empty branch.
+    await expect(
+      page.getByRole("link", { name: "New cardgroup" }).filter({ hasText: "New cardgroup" }).first(),
+    ).toBeVisible();
+
+    // Locate the footer link specifically — it lives inside the border-t container
+    // after the list, not the empty-state CTA. Both branches use the same link
+    // text so we scope to the one rendered in the non-empty branch (no dashed
+    // wrapper) by checking its href points to /cardgroups/new without a returnTo.
+    const footerLink = page.getByRole("link", { name: /New cardgroup/ }).last();
+    await expect(footerLink).toBeVisible();
+    await expect(footerLink).toHaveAttribute("href", "/cardgroups/new");
+
+    // Click it and verify we land on /cardgroups/new with the form interactive.
+    await footerLink.click();
+    await page.waitForURL("**/cardgroups/new", { timeout: 10_000 });
+    await expect(page.getByRole("heading", { name: "New cardgroup" })).toBeVisible();
+    await expect(page.getByLabel("Name")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Create" })).toBeVisible();
+  });
+
+  // ── Scenario 2 ──────────────────────────────────────────────────────────────
+  // Empty-state on /cardgroups: with zero cardgroups the dashed-border large CTA
+  // is the only "New cardgroup" affordance; the footer link is not present.
+  test("empty state on /cardgroups shows only the dashed CTA, not the footer link", async ({
+    context,
+    page,
+  }) => {
+    await loginAs(context, emptyUser);
+
+    const response = await page.goto("/cardgroups");
+    expect(response?.ok(), `goto /cardgroups returned ${response?.status()}`).toBe(true);
+
+    // The empty-state description text confirms we are in the zero-cardgroup branch.
+    await expect(
+      page.getByText("You haven't created any cardgroups yet."),
+    ).toBeVisible();
+
+    // The dashed-border CTA link must be visible.
+    const ctaLink = page.getByRole("link", { name: "New cardgroup" });
+    await expect(ctaLink).toBeVisible();
+
+    // There must be exactly ONE "New cardgroup" link — the footer link is absent
+    // in the empty-state branch.
+    await expect(ctaLink).toHaveCount(1);
+  });
+
+  // ── Scenario 3 ──────────────────────────────────────────────────────────────
+  // Picker-driven create flow: /cards/new → open picker → "Create new cardgroup…"
+  // → /cardgroups/new?returnTo=%2Fcards%2Fnew → fill name → submit →
+  // /cards/new?cardgroup=<newId> with the form interactive and chip pre-selected.
+  test("picker 'Create new cardgroup…' link returns to /cards/new with new cardgroup pre-selected", async ({
+    context,
+    page,
+  }) => {
+    await loginAs(context, withCardgroup);
+
+    const response = await page.goto("/cards/new");
+    expect(response?.ok(), `goto /cards/new returned ${response?.status()}`).toBe(true);
+    await expect(page.getByRole("heading", { name: "New card" })).toBeVisible();
+
+    // Open the cardgroup picker by clicking the chip.
+    const chip = page.getByRole("button", { name: /Select cardgroup|Change cardgroup/ });
+    await expect(chip).toBeVisible();
+    await chip.click();
+
+    // The picker renders as a bottom Sheet (role="dialog", title "Select cardgroup").
+    const dialog = page.getByRole("dialog", { name: "Select cardgroup" });
+    await expect(dialog).toBeVisible();
+
+    // The "Create new cardgroup…" inline link must be present inside the sheet.
+    const createLink = dialog.getByRole("link", { name: /Create new cardgroup/ });
+    await expect(createLink).toBeVisible();
+
+    // Clicking the link navigates to /cardgroups/new?returnTo=%2Fcards%2Fnew.
+    await createLink.click();
+    await page.waitForURL("**/cardgroups/new?returnTo=%2Fcards%2Fnew", { timeout: 10_000 });
+    await expect(page.getByRole("heading", { name: "New cardgroup" })).toBeVisible();
+
+    // Fill and submit the new cardgroup form.
+    const newCgName = `E2E picker-return ${runId}`;
+    await page.getByLabel("Name").fill(newCgName);
+    await page.getByRole("button", { name: "Create" }).click();
+
+    // After successful creation the router pushes /cards/new?cardgroup=<newId>.
+    await page.waitForURL(/\/cards\/new\?cardgroup=[0-9a-f-]{36}/, { timeout: 15_000 });
+
+    // Verify the cardgroup id is a valid UUID.
+    const url = new URL(page.url());
+    const newCgId = url.searchParams.get("cardgroup") ?? "";
+    expect(newCgId).toMatch(UUID_RE);
+
+    // The card form heading and the Name field must now be interactive.
+    await expect(page.getByRole("heading", { name: "New card" })).toBeVisible();
+    await expect(page.getByLabel("Front")).toBeVisible();
+
+    // The chip must reflect the newly created cardgroup.
+    await expect(
+      page.getByRole("button", {
+        name: `Change cardgroup (currently "${newCgName}")`,
+      }),
+    ).toBeVisible();
+  });
+
+  // ── Scenario 4 ──────────────────────────────────────────────────────────────
+  // Open-redirect rejection: a protocol-relative ("//evil.com") or absolute
+  // ("https://evil.com") returnTo is silently stripped by sanitizeReturnTo.
+  // After creation the router falls back to /cardgroups/<newId> — NOT to an
+  // external origin and NOT to /cards/new.
+  test("open-redirect: external returnTo is rejected and falls back to /cardgroups/<id>", async ({
+    context,
+    page,
+  }) => {
+    await loginAs(context, withCardgroup);
+
+    // ── 4a: protocol-relative URL ──────────────────────────────────────────────
+    const response4a = await page.goto("/cardgroups/new?returnTo=//evil.com");
+    expect(response4a?.ok(), `goto returned ${response4a?.status()}`).toBe(true);
+    await expect(page.getByRole("heading", { name: "New cardgroup" })).toBeVisible();
+
+    const name4a = `E2E redirect-a ${runId}`;
+    await page.getByLabel("Name").fill(name4a);
+    await page.getByRole("button", { name: "Create" }).click();
+
+    // Must land on /cardgroups/<uuid>, never on evil.com or /cards/new.
+    await page.waitForURL(/\/cardgroups\/[0-9a-f-]{36}$/, { timeout: 15_000 });
+    const finalUrl4a = page.url();
+    expect(finalUrl4a).not.toContain("evil.com");
+    expect(finalUrl4a).not.toMatch(/\/cards\/new/);
+    const createdId4a = finalUrl4a.split("/").pop() ?? "";
+    expect(createdId4a).toMatch(UUID_RE);
+
+    // ── 4b: absolute https URL ─────────────────────────────────────────────────
+    const response4b = await page.goto("/cardgroups/new?returnTo=https://evil.com");
+    expect(response4b?.ok(), `goto returned ${response4b?.status()}`).toBe(true);
+    await expect(page.getByRole("heading", { name: "New cardgroup" })).toBeVisible();
+
+    const name4b = `E2E redirect-b ${runId}`;
+    await page.getByLabel("Name").fill(name4b);
+    await page.getByRole("button", { name: "Create" }).click();
+
+    await page.waitForURL(/\/cardgroups\/[0-9a-f-]{36}$/, { timeout: 15_000 });
+    const finalUrl4b = page.url();
+    expect(finalUrl4b).not.toContain("evil.com");
+    expect(finalUrl4b).not.toMatch(/\/cards\/new/);
+    const createdId4b = finalUrl4b.split("/").pop() ?? "";
+    expect(createdId4b).toMatch(UUID_RE);
+  });
+});

--- a/frontend/e2e/cardgroups-flow.spec.ts
+++ b/frontend/e2e/cardgroups-flow.spec.ts
@@ -70,9 +70,9 @@ test.describe.serial("cardgroups flow", () => {
 
     // Locate the footer link specifically — it lives inside the border-t container
     // after the list, not the empty-state CTA. Both branches use the same link
-    // text so we scope to the one rendered in the non-empty branch (no dashed
-    // wrapper) by checking its href points to /cardgroups/new without a returnTo.
-    const footerLink = page.getByRole("link", { name: /New cardgroup/ }).last();
+    // text so we scope to the wrapper that renders only in the non-empty branch.
+    const footerScope = page.locator(".mt-6.border-t.pt-4");
+    const footerLink = footerScope.getByRole("link", { name: /New cardgroup/ });
     await expect(footerLink).toBeVisible();
     await expect(footerLink).toHaveAttribute("href", "/cardgroups/new");
 

--- a/frontend/e2e/cardgroups-flow.spec.ts
+++ b/frontend/e2e/cardgroups-flow.spec.ts
@@ -23,192 +23,194 @@ const emptyUser = {
   password: "e2e-password",
 };
 
-test.describe.serial("cardgroups flow", () => {
-  test.beforeAll(async () => {
-    // Seed the "with cardgroup" user and one cardgroup.
-    const user = await seedUser({
-      email: withCardgroup.email,
-      password: withCardgroup.password,
-      role: "general",
-      displayName: "E2E CG Flow",
+test.describe
+  .serial("cardgroups flow", () => {
+    test.beforeAll(async () => {
+      // Seed the "with cardgroup" user and one cardgroup.
+      const user = await seedUser({
+        email: withCardgroup.email,
+        password: withCardgroup.password,
+        role: "general",
+        displayName: "E2E CG Flow",
+      });
+      const cg = await seedCardgroup({
+        ownerId: user.id,
+        name: `E2E cardgroup ${runId}`,
+      });
+      seededCardgroupName = cg.name;
+
+      // Seed the "empty" user with no cardgroups.
+      await seedUser({
+        email: emptyUser.email,
+        password: emptyUser.password,
+        role: "general",
+        displayName: "E2E CG Empty",
+      });
     });
-    const cg = await seedCardgroup({
-      ownerId: user.id,
-      name: `E2E cardgroup ${runId}`,
+
+    // ── Scenario 1 ──────────────────────────────────────────────────────────────
+    // Footer-link path on /cardgroups: with at least one cardgroup the footer
+    // "New cardgroup" link is visible at the bottom of the list. Clicking it
+    // lands on /cardgroups/new with no returnTo, and the form is interactive.
+    test("footer link on /cardgroups leads to /cardgroups/new without returnTo", async ({
+      context,
+      page,
+    }) => {
+      await loginAs(context, withCardgroup);
+
+      const response = await page.goto("/cardgroups");
+      expect(response?.ok(), `goto /cardgroups returned ${response?.status()}`).toBe(true);
+
+      // The seeded cardgroup must be visible, confirming the non-empty branch renders.
+      await expect(page.getByText(seededCardgroupName)).toBeVisible();
+
+      // The large dashed-border CTA must NOT be present in the non-empty branch.
+      await expect(
+        page
+          .getByRole("link", { name: "New cardgroup" })
+          .filter({ hasText: "New cardgroup" })
+          .first(),
+      ).toBeVisible();
+
+      // Locate the footer link specifically — it lives inside the border-t container
+      // after the list, not the empty-state CTA. Both branches use the same link
+      // text so we scope to the wrapper that renders only in the non-empty branch.
+      const footerScope = page.locator(".mt-6.border-t.pt-4");
+      const footerLink = footerScope.getByRole("link", { name: /New cardgroup/ });
+      await expect(footerLink).toBeVisible();
+      await expect(footerLink).toHaveAttribute("href", "/cardgroups/new");
+
+      // Click it and verify we land on /cardgroups/new with the form interactive.
+      await footerLink.click();
+      await page.waitForURL("**/cardgroups/new", { timeout: 10_000 });
+      await expect(page.getByRole("heading", { name: "New cardgroup" })).toBeVisible();
+      await expect(page.getByLabel("Name")).toBeVisible();
+      await expect(page.getByRole("button", { name: "Create" })).toBeVisible();
     });
-    seededCardgroupName = cg.name;
 
-    // Seed the "empty" user with no cardgroups.
-    await seedUser({
-      email: emptyUser.email,
-      password: emptyUser.password,
-      role: "general",
-      displayName: "E2E CG Empty",
+    // ── Scenario 2 ──────────────────────────────────────────────────────────────
+    // Empty-state on /cardgroups: with zero cardgroups the dashed-border large CTA
+    // is the only "New cardgroup" affordance; the footer link is not present.
+    test("empty state on /cardgroups shows only the dashed CTA, not the footer link", async ({
+      context,
+      page,
+    }) => {
+      await loginAs(context, emptyUser);
+
+      const response = await page.goto("/cardgroups");
+      expect(response?.ok(), `goto /cardgroups returned ${response?.status()}`).toBe(true);
+
+      // The empty-state description text confirms we are in the zero-cardgroup branch.
+      await expect(page.getByText("You haven't created any cardgroups yet.")).toBeVisible();
+
+      // The dashed-border CTA link must be visible.
+      const ctaLink = page.getByRole("link", { name: "New cardgroup" });
+      await expect(ctaLink).toBeVisible();
+
+      // There must be exactly ONE "New cardgroup" link — the footer link is absent
+      // in the empty-state branch.
+      await expect(ctaLink).toHaveCount(1);
+    });
+
+    // ── Scenario 3 ──────────────────────────────────────────────────────────────
+    // Picker-driven create flow: /cards/new → open picker → "Create new cardgroup…"
+    // → /cardgroups/new?returnTo=%2Fcards%2Fnew → fill name → submit →
+    // /cards/new?cardgroup=<newId> with the form interactive and chip pre-selected.
+    test("picker 'Create new cardgroup…' link returns to /cards/new with new cardgroup pre-selected", async ({
+      context,
+      page,
+    }) => {
+      await loginAs(context, withCardgroup);
+
+      const response = await page.goto("/cards/new");
+      expect(response?.ok(), `goto /cards/new returned ${response?.status()}`).toBe(true);
+      await expect(page.getByRole("heading", { name: "New card" })).toBeVisible();
+
+      // Open the cardgroup picker by clicking the chip.
+      const chip = page.getByRole("button", { name: /Select cardgroup|Change cardgroup/ });
+      await expect(chip).toBeVisible();
+      await chip.click();
+
+      // The picker renders as a bottom Sheet (role="dialog", title "Select cardgroup").
+      const dialog = page.getByRole("dialog", { name: "Select cardgroup" });
+      await expect(dialog).toBeVisible();
+
+      // The "Create new cardgroup…" inline link must be present inside the sheet.
+      const createLink = dialog.getByRole("link", { name: /Create new cardgroup/ });
+      await expect(createLink).toBeVisible();
+
+      // Clicking the link navigates to /cardgroups/new?returnTo=%2Fcards%2Fnew.
+      await createLink.click();
+      await page.waitForURL("**/cardgroups/new?returnTo=%2Fcards%2Fnew", { timeout: 10_000 });
+      await expect(page.getByRole("heading", { name: "New cardgroup" })).toBeVisible();
+
+      // Fill and submit the new cardgroup form.
+      const newCgName = `E2E picker-return ${runId}`;
+      await page.getByLabel("Name").fill(newCgName);
+      await page.getByRole("button", { name: "Create" }).click();
+
+      // After successful creation the router pushes /cards/new?cardgroup=<newId>.
+      await page.waitForURL(/\/cards\/new\?cardgroup=[0-9a-f-]{36}/, { timeout: 15_000 });
+
+      // Verify the cardgroup id is a valid UUID.
+      const url = new URL(page.url());
+      const newCgId = url.searchParams.get("cardgroup") ?? "";
+      expect(newCgId).toMatch(UUID_RE);
+
+      // The card form heading and the Name field must now be interactive.
+      await expect(page.getByRole("heading", { name: "New card" })).toBeVisible();
+      await expect(page.getByLabel("Front")).toBeVisible();
+
+      // The chip must reflect the newly created cardgroup.
+      await expect(
+        page.getByRole("button", {
+          name: `Change cardgroup (currently "${newCgName}")`,
+        }),
+      ).toBeVisible();
+    });
+
+    // ── Scenario 4 ──────────────────────────────────────────────────────────────
+    // Open-redirect rejection: a protocol-relative ("//evil.com") or absolute
+    // ("https://evil.com") returnTo is silently stripped by sanitizeReturnTo.
+    // After creation the router falls back to /cardgroups/<newId> — NOT to an
+    // external origin and NOT to /cards/new.
+    test("open-redirect: external returnTo is rejected and falls back to /cardgroups/<id>", async ({
+      context,
+      page,
+    }) => {
+      await loginAs(context, withCardgroup);
+
+      // ── 4a: protocol-relative URL ──────────────────────────────────────────────
+      const response4a = await page.goto("/cardgroups/new?returnTo=//evil.com");
+      expect(response4a?.ok(), `goto returned ${response4a?.status()}`).toBe(true);
+      await expect(page.getByRole("heading", { name: "New cardgroup" })).toBeVisible();
+
+      const name4a = `E2E redirect-a ${runId}`;
+      await page.getByLabel("Name").fill(name4a);
+      await page.getByRole("button", { name: "Create" }).click();
+
+      // Must land on /cardgroups/<uuid>, never on evil.com or /cards/new.
+      await page.waitForURL(/\/cardgroups\/[0-9a-f-]{36}$/, { timeout: 15_000 });
+      const finalUrl4a = page.url();
+      expect(finalUrl4a).not.toContain("evil.com");
+      expect(finalUrl4a).not.toMatch(/\/cards\/new/);
+      const createdId4a = finalUrl4a.split("/").pop() ?? "";
+      expect(createdId4a).toMatch(UUID_RE);
+
+      // ── 4b: absolute https URL ─────────────────────────────────────────────────
+      const response4b = await page.goto("/cardgroups/new?returnTo=https://evil.com");
+      expect(response4b?.ok(), `goto returned ${response4b?.status()}`).toBe(true);
+      await expect(page.getByRole("heading", { name: "New cardgroup" })).toBeVisible();
+
+      const name4b = `E2E redirect-b ${runId}`;
+      await page.getByLabel("Name").fill(name4b);
+      await page.getByRole("button", { name: "Create" }).click();
+
+      await page.waitForURL(/\/cardgroups\/[0-9a-f-]{36}$/, { timeout: 15_000 });
+      const finalUrl4b = page.url();
+      expect(finalUrl4b).not.toContain("evil.com");
+      expect(finalUrl4b).not.toMatch(/\/cards\/new/);
+      const createdId4b = finalUrl4b.split("/").pop() ?? "";
+      expect(createdId4b).toMatch(UUID_RE);
     });
   });
-
-  // ── Scenario 1 ──────────────────────────────────────────────────────────────
-  // Footer-link path on /cardgroups: with at least one cardgroup the footer
-  // "New cardgroup" link is visible at the bottom of the list. Clicking it
-  // lands on /cardgroups/new with no returnTo, and the form is interactive.
-  test("footer link on /cardgroups leads to /cardgroups/new without returnTo", async ({
-    context,
-    page,
-  }) => {
-    await loginAs(context, withCardgroup);
-
-    const response = await page.goto("/cardgroups");
-    expect(response?.ok(), `goto /cardgroups returned ${response?.status()}`).toBe(true);
-
-    // The seeded cardgroup must be visible, confirming the non-empty branch renders.
-    await expect(page.getByText(seededCardgroupName)).toBeVisible();
-
-    // The large dashed-border CTA must NOT be present in the non-empty branch.
-    await expect(
-      page.getByRole("link", { name: "New cardgroup" }).filter({ hasText: "New cardgroup" }).first(),
-    ).toBeVisible();
-
-    // Locate the footer link specifically — it lives inside the border-t container
-    // after the list, not the empty-state CTA. Both branches use the same link
-    // text so we scope to the wrapper that renders only in the non-empty branch.
-    const footerScope = page.locator(".mt-6.border-t.pt-4");
-    const footerLink = footerScope.getByRole("link", { name: /New cardgroup/ });
-    await expect(footerLink).toBeVisible();
-    await expect(footerLink).toHaveAttribute("href", "/cardgroups/new");
-
-    // Click it and verify we land on /cardgroups/new with the form interactive.
-    await footerLink.click();
-    await page.waitForURL("**/cardgroups/new", { timeout: 10_000 });
-    await expect(page.getByRole("heading", { name: "New cardgroup" })).toBeVisible();
-    await expect(page.getByLabel("Name")).toBeVisible();
-    await expect(page.getByRole("button", { name: "Create" })).toBeVisible();
-  });
-
-  // ── Scenario 2 ──────────────────────────────────────────────────────────────
-  // Empty-state on /cardgroups: with zero cardgroups the dashed-border large CTA
-  // is the only "New cardgroup" affordance; the footer link is not present.
-  test("empty state on /cardgroups shows only the dashed CTA, not the footer link", async ({
-    context,
-    page,
-  }) => {
-    await loginAs(context, emptyUser);
-
-    const response = await page.goto("/cardgroups");
-    expect(response?.ok(), `goto /cardgroups returned ${response?.status()}`).toBe(true);
-
-    // The empty-state description text confirms we are in the zero-cardgroup branch.
-    await expect(
-      page.getByText("You haven't created any cardgroups yet."),
-    ).toBeVisible();
-
-    // The dashed-border CTA link must be visible.
-    const ctaLink = page.getByRole("link", { name: "New cardgroup" });
-    await expect(ctaLink).toBeVisible();
-
-    // There must be exactly ONE "New cardgroup" link — the footer link is absent
-    // in the empty-state branch.
-    await expect(ctaLink).toHaveCount(1);
-  });
-
-  // ── Scenario 3 ──────────────────────────────────────────────────────────────
-  // Picker-driven create flow: /cards/new → open picker → "Create new cardgroup…"
-  // → /cardgroups/new?returnTo=%2Fcards%2Fnew → fill name → submit →
-  // /cards/new?cardgroup=<newId> with the form interactive and chip pre-selected.
-  test("picker 'Create new cardgroup…' link returns to /cards/new with new cardgroup pre-selected", async ({
-    context,
-    page,
-  }) => {
-    await loginAs(context, withCardgroup);
-
-    const response = await page.goto("/cards/new");
-    expect(response?.ok(), `goto /cards/new returned ${response?.status()}`).toBe(true);
-    await expect(page.getByRole("heading", { name: "New card" })).toBeVisible();
-
-    // Open the cardgroup picker by clicking the chip.
-    const chip = page.getByRole("button", { name: /Select cardgroup|Change cardgroup/ });
-    await expect(chip).toBeVisible();
-    await chip.click();
-
-    // The picker renders as a bottom Sheet (role="dialog", title "Select cardgroup").
-    const dialog = page.getByRole("dialog", { name: "Select cardgroup" });
-    await expect(dialog).toBeVisible();
-
-    // The "Create new cardgroup…" inline link must be present inside the sheet.
-    const createLink = dialog.getByRole("link", { name: /Create new cardgroup/ });
-    await expect(createLink).toBeVisible();
-
-    // Clicking the link navigates to /cardgroups/new?returnTo=%2Fcards%2Fnew.
-    await createLink.click();
-    await page.waitForURL("**/cardgroups/new?returnTo=%2Fcards%2Fnew", { timeout: 10_000 });
-    await expect(page.getByRole("heading", { name: "New cardgroup" })).toBeVisible();
-
-    // Fill and submit the new cardgroup form.
-    const newCgName = `E2E picker-return ${runId}`;
-    await page.getByLabel("Name").fill(newCgName);
-    await page.getByRole("button", { name: "Create" }).click();
-
-    // After successful creation the router pushes /cards/new?cardgroup=<newId>.
-    await page.waitForURL(/\/cards\/new\?cardgroup=[0-9a-f-]{36}/, { timeout: 15_000 });
-
-    // Verify the cardgroup id is a valid UUID.
-    const url = new URL(page.url());
-    const newCgId = url.searchParams.get("cardgroup") ?? "";
-    expect(newCgId).toMatch(UUID_RE);
-
-    // The card form heading and the Name field must now be interactive.
-    await expect(page.getByRole("heading", { name: "New card" })).toBeVisible();
-    await expect(page.getByLabel("Front")).toBeVisible();
-
-    // The chip must reflect the newly created cardgroup.
-    await expect(
-      page.getByRole("button", {
-        name: `Change cardgroup (currently "${newCgName}")`,
-      }),
-    ).toBeVisible();
-  });
-
-  // ── Scenario 4 ──────────────────────────────────────────────────────────────
-  // Open-redirect rejection: a protocol-relative ("//evil.com") or absolute
-  // ("https://evil.com") returnTo is silently stripped by sanitizeReturnTo.
-  // After creation the router falls back to /cardgroups/<newId> — NOT to an
-  // external origin and NOT to /cards/new.
-  test("open-redirect: external returnTo is rejected and falls back to /cardgroups/<id>", async ({
-    context,
-    page,
-  }) => {
-    await loginAs(context, withCardgroup);
-
-    // ── 4a: protocol-relative URL ──────────────────────────────────────────────
-    const response4a = await page.goto("/cardgroups/new?returnTo=//evil.com");
-    expect(response4a?.ok(), `goto returned ${response4a?.status()}`).toBe(true);
-    await expect(page.getByRole("heading", { name: "New cardgroup" })).toBeVisible();
-
-    const name4a = `E2E redirect-a ${runId}`;
-    await page.getByLabel("Name").fill(name4a);
-    await page.getByRole("button", { name: "Create" }).click();
-
-    // Must land on /cardgroups/<uuid>, never on evil.com or /cards/new.
-    await page.waitForURL(/\/cardgroups\/[0-9a-f-]{36}$/, { timeout: 15_000 });
-    const finalUrl4a = page.url();
-    expect(finalUrl4a).not.toContain("evil.com");
-    expect(finalUrl4a).not.toMatch(/\/cards\/new/);
-    const createdId4a = finalUrl4a.split("/").pop() ?? "";
-    expect(createdId4a).toMatch(UUID_RE);
-
-    // ── 4b: absolute https URL ─────────────────────────────────────────────────
-    const response4b = await page.goto("/cardgroups/new?returnTo=https://evil.com");
-    expect(response4b?.ok(), `goto returned ${response4b?.status()}`).toBe(true);
-    await expect(page.getByRole("heading", { name: "New cardgroup" })).toBeVisible();
-
-    const name4b = `E2E redirect-b ${runId}`;
-    await page.getByLabel("Name").fill(name4b);
-    await page.getByRole("button", { name: "Create" }).click();
-
-    await page.waitForURL(/\/cardgroups\/[0-9a-f-]{36}$/, { timeout: 15_000 });
-    const finalUrl4b = page.url();
-    expect(finalUrl4b).not.toContain("evil.com");
-    expect(finalUrl4b).not.toMatch(/\/cards\/new/);
-    const createdId4b = finalUrl4b.split("/").pop() ?? "";
-    expect(createdId4b).toMatch(UUID_RE);
-  });
-});

--- a/frontend/e2e/cardgroups-flow.spec.ts
+++ b/frontend/e2e/cardgroups-flow.spec.ts
@@ -113,8 +113,10 @@ test.describe
     });
 
     // ── Scenario 3 ──────────────────────────────────────────────────────────────
-    // Picker-driven create flow: /cards/new → open picker → "Create new cardgroup…"
-    // → /cardgroups/new?returnTo=%2Fcards%2Fnew → fill name → submit →
+    // Picker-driven create flow: /cards/new auto-opens the picker (user has one
+    // cardgroup but no lastViewed → forcePickerOpen=true Priority 3 in
+    // app/cards/new/page.tsx) → "Create new cardgroup…" link →
+    // /cardgroups/new?returnTo=%2Fcards%2Fnew → fill name → submit →
     // /cards/new?cardgroup=<newId> with the form interactive and chip pre-selected.
     test("picker 'Create new cardgroup…' link returns to /cards/new with new cardgroup pre-selected", async ({
       context,
@@ -124,14 +126,12 @@ test.describe
 
       const response = await page.goto("/cards/new");
       expect(response?.ok(), `goto /cards/new returned ${response?.status()}`).toBe(true);
-      await expect(page.getByRole("heading", { name: "New card" })).toBeVisible();
 
-      // Open the cardgroup picker by clicking the chip.
-      const chip = page.getByRole("button", { name: /Select cardgroup|Change cardgroup/ });
-      await expect(chip).toBeVisible();
-      await chip.click();
-
-      // The picker renders as a bottom Sheet (role="dialog", title "Select cardgroup").
+      // The picker auto-opens (Radix Dialog with focus-trap + aria-hidden on
+      // the rest of the page), so the "New card" heading and the underlying
+      // chip are not in the accessibility tree until the picker closes.
+      // Assert the dialog first; the underlying page is verified below after
+      // navigation back to /cards/new with ?cardgroup=<newId>.
       const dialog = page.getByRole("dialog", { name: "Select cardgroup" });
       await expect(dialog).toBeVisible();
 

--- a/frontend/e2e/new-user-onboarding.spec.ts
+++ b/frontend/e2e/new-user-onboarding.spec.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { expect, test } from "@playwright/test";
+import { devices, expect, test } from "@playwright/test";
 import { loginAs, seedUser } from "./_auth";
 
 // Scenario: a brand-new user (zero cardgroups, no last_viewed) is funnelled
@@ -17,6 +17,13 @@ const UUID_RE = /^[0-9a-f-]{36}$/;
 
 test.describe
   .serial("new user onboarding", () => {
+    // The global FAB is intentionally hidden at >= md (`md:hidden` in
+    // GlobalFAB) because desktop users get the same affordance via the
+    // header "Add card" link. This scenario is specifically the FAB path,
+    // so override the project default Desktop Chrome viewport with a
+    // mobile device for this describe block only.
+    test.use({ ...devices["iPhone 14"] });
+
     test.beforeAll(async () => {
       // Seed only the auth user + role; deliberately NO cardgroup so the home
       // RSC routes to /cardgroups/new?welcome=1 on first login.

--- a/frontend/e2e/new-user-onboarding.spec.ts
+++ b/frontend/e2e/new-user-onboarding.spec.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { devices, expect, test } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 import { loginAs, seedUser } from "./_auth";
 
 // Scenario: a brand-new user (zero cardgroups, no last_viewed) is funnelled
@@ -20,9 +20,12 @@ test.describe
     // The global FAB is intentionally hidden at >= md (`md:hidden` in
     // GlobalFAB) because desktop users get the same affordance via the
     // header "Add card" link. This scenario is specifically the FAB path,
-    // so override the project default Desktop Chrome viewport with a
-    // mobile device for this describe block only.
-    test.use({ ...devices["iPhone 14"] });
+    // so shrink the viewport below the md breakpoint (768px). We only
+    // override viewport here — spreading a full devices[...] descriptor
+    // includes defaultBrowserType, which Playwright forbids inside a
+    // describe group ("forces a new worker") and would also require a
+    // matching project entry, neither of which we want here.
+    test.use({ viewport: { width: 390, height: 844 } });
 
     test.beforeAll(async () => {
       // Seed only the auth user + role; deliberately NO cardgroup so the home

--- a/frontend/src/app/_components/logout-button.test.tsx
+++ b/frontend/src/app/_components/logout-button.test.tsx
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockReplace = vi.fn();
+const mockRefresh = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: mockReplace, refresh: mockRefresh }),
+}));
+
+const mockSignOut = vi.fn();
+vi.mock("@/lib/supabase/client", () => ({
+  createSupabaseBrowserClient: () => ({
+    auth: { signOut: () => mockSignOut() },
+  }),
+}));
+
+import { LogoutButton } from "./logout-button";
+
+beforeEach(() => {
+  mockReplace.mockReset();
+  mockRefresh.mockReset();
+  mockSignOut.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("<LogoutButton>", () => {
+  it("on success navigates to /login before refreshing the route", async () => {
+    mockSignOut.mockResolvedValue({ error: null });
+    const callOrder: string[] = [];
+    mockReplace.mockImplementation((path: string) => callOrder.push(`replace:${path}`));
+    mockRefresh.mockImplementation(() => callOrder.push("refresh"));
+
+    render(<LogoutButton />);
+    await userEvent.click(screen.getByRole("button", { name: /logout/i }));
+
+    // replace must precede refresh: refreshing on the old (protected) URL is
+    // what causes the anonymous Header to flash a "Sign in" link before the
+    // page-level redirect kicks in.
+    expect(callOrder).toEqual(["replace:/login", "refresh"]);
+  });
+
+  it("does not navigate or refresh when signOut errors", async () => {
+    mockSignOut.mockResolvedValue({ error: { message: "boom" } });
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    render(<LogoutButton />);
+    await userEvent.click(screen.getByRole("button", { name: /logout/i }));
+
+    expect(mockReplace).not.toHaveBeenCalled();
+    expect(mockRefresh).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).toHaveBeenCalledWith("[logout] signOut failed:", "boom");
+  });
+});

--- a/frontend/src/app/_components/logout-button.tsx
+++ b/frontend/src/app/_components/logout-button.tsx
@@ -14,6 +14,11 @@ export function LogoutButton() {
       console.error("[logout] signOut failed:", error.message);
       return;
     }
+    // Navigate to /login first so the layout re-renders for that URL — the
+    // HeaderSignInLink suppresses itself on /login, avoiding the brief
+    // "Sign in" flash that occurs when refresh() re-renders the protected
+    // page's anonymous header before its server-side redirect kicks in.
+    router.replace("/login");
     router.refresh();
   }
 

--- a/frontend/src/app/cardgroups/new/new-cardgroup-client.tsx
+++ b/frontend/src/app/cardgroups/new/new-cardgroup-client.tsx
@@ -9,9 +9,10 @@ import { MyCardgroupsDocument } from "@/generated/graphql";
 
 interface NewCardgroupClientProps {
   showWelcome?: boolean;
+  returnTo?: string | null;
 }
 
-export function NewCardgroupClient({ showWelcome = false }: NewCardgroupClientProps) {
+export function NewCardgroupClient({ showWelcome = false, returnTo }: NewCardgroupClientProps) {
   const router = useRouter();
 
   const [createCardgroup, { loading, error }] = useMutation(CreateCardgroupMutation, {
@@ -26,8 +27,14 @@ export function NewCardgroupClient({ showWelcome = false }: NewCardgroupClientPr
       });
     },
     onCompleted(data) {
-      if (!data?.createCardgroup?.cardgroup?.id) return;
-      router.push(`/cardgroups/${data.createCardgroup.cardgroup.id}`);
+      const created = data?.createCardgroup?.cardgroup;
+      if (!created?.id) return;
+      if (returnTo) {
+        const sep = returnTo.includes("?") ? "&" : "?";
+        router.push(`${returnTo}${sep}cardgroup=${created.id}`);
+      } else {
+        router.push(`/cardgroups/${created.id}`);
+      }
       router.refresh();
     },
   });

--- a/frontend/src/app/cardgroups/new/new-cardgroup-client.tsx
+++ b/frontend/src/app/cardgroups/new/new-cardgroup-client.tsx
@@ -9,7 +9,8 @@ import { MyCardgroupsDocument } from "@/generated/graphql";
 
 interface NewCardgroupClientProps {
   showWelcome?: boolean;
-  returnTo?: string | null;
+  /** Sanitized internal path to return to after creation, or null for the default redirect. */
+  returnTo: string | null;
 }
 
 export function NewCardgroupClient({ showWelcome = false, returnTo }: NewCardgroupClientProps) {
@@ -34,8 +35,8 @@ export function NewCardgroupClient({ showWelcome = false, returnTo }: NewCardgro
         router.push(`${returnTo}${sep}cardgroup=${created.id}`);
       } else {
         router.push(`/cardgroups/${created.id}`);
+        router.refresh();
       }
-      router.refresh();
     },
   });
 
@@ -43,7 +44,10 @@ export function NewCardgroupClient({ showWelcome = false, returnTo }: NewCardgro
     await createCardgroup({
       variables: { input: { name: values.name } },
     }).catch((err) => {
-      console.error("[NewCardgroupClient] mutation rejection", err);
+      console.error("[cardgroups-new] mutation rejection", {
+        message: err instanceof Error ? err.message : String(err),
+        err,
+      });
     });
   }
 

--- a/frontend/src/app/cardgroups/new/page.test.tsx
+++ b/frontend/src/app/cardgroups/new/page.test.tsx
@@ -6,19 +6,21 @@ import { MockedProvider } from "@apollo/client/testing/react";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { GraphQLError } from "graphql";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { CreateCardgroupDocument, MyCardgroupsDocument } from "@/generated/graphql";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
 import { NewCardgroupClient } from "./new-cardgroup-client";
-import { sanitizeReturnTo } from "./page";
+import NewCardgroupPage, { sanitizeReturnTo } from "./page";
 
 // Stub next/navigation so the client component can render outside Next.js.
 const mockPush = vi.fn();
 const mockRefresh = vi.fn();
+const mockRedirect = vi.fn((path: string) => {
+  throw new Error(`REDIRECT:${path}`);
+});
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: mockPush, refresh: mockRefresh }),
-  redirect: vi.fn((path: string) => {
-    throw new Error(`REDIRECT:${path}`);
-  }),
+  redirect: (path: string) => mockRedirect(path),
 }));
 
 // Stub next/link so it renders an anchor without Next.js router context.
@@ -32,14 +34,16 @@ vi.mock("next/link", () => ({
 
 // Stub the Supabase server client — required because page.tsx imports it at
 // module-evaluation time (the import itself triggers the module graph).
+// Using vi.fn() so individual tests can override with mockResolvedValueOnce.
 vi.mock("@/lib/supabase/server", () => ({
-  createSupabaseServerClient: () =>
+  createSupabaseServerClient: vi.fn(() =>
     Promise.resolve({
       auth: {
         getUser: () =>
           Promise.resolve({ data: { user: { id: "u-1" } }, error: null }),
       },
     }),
+  ),
 }));
 
 const CREATED_CARDGROUP = {
@@ -73,7 +77,7 @@ function renderPage(
   mocks: MockedResponse[] = [],
   errorPolicy?: "all" | "none" | "ignore",
   cache?: InMemoryCache,
-  returnTo?: string | null,
+  returnTo: string | null = null,
 ) {
   const defaultOptions = errorPolicy ? { mutate: { errorPolicy } } : undefined;
   render(
@@ -218,7 +222,7 @@ describe("<NewCardgroupPage> (client)", () => {
     expect(screen.getByRole("alert")).toBeInTheDocument();
   });
 
-  it("on success with returnTo navigates to returnTo?cardgroup=<id>", async () => {
+  it("on success with returnTo navigates to returnTo?cardgroup=<id> and does not refresh", async () => {
     const user = userEvent.setup();
     mockPush.mockClear();
     mockRefresh.mockClear();
@@ -231,7 +235,7 @@ describe("<NewCardgroupPage> (client)", () => {
     await waitFor(() => {
       expect(mockPush).toHaveBeenCalledWith(`/cards/new?cardgroup=${CREATED_CARDGROUP.id}`);
     });
-    expect(mockRefresh).toHaveBeenCalledOnce();
+    expect(mockRefresh).not.toHaveBeenCalled();
   });
 
   it("on success with returnTo containing query string uses & separator", async () => {
@@ -260,6 +264,59 @@ describe("<NewCardgroupPage> (client)", () => {
     await waitFor(() => {
       expect(mockPush).toHaveBeenCalledWith(`/cardgroups/${CREATED_CARDGROUP.id}`);
     });
+  });
+});
+
+describe("authentication boundary", () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    mockRedirect.mockClear();
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("redirects to /login when getUser returns no user (AuthSessionMissingError)", async () => {
+    vi.mocked(createSupabaseServerClient).mockResolvedValueOnce({
+      auth: {
+        getUser: () =>
+          Promise.resolve({
+            data: { user: null },
+            error: { name: "AuthSessionMissingError", message: "Auth session missing!" },
+          }),
+      },
+    } as Awaited<ReturnType<typeof createSupabaseServerClient>>);
+
+    await expect(
+      NewCardgroupPage({ searchParams: Promise.resolve({}) }),
+    ).rejects.toThrow("REDIRECT:/login");
+
+    expect(mockRedirect).toHaveBeenCalledWith("/login");
+  });
+
+  it("console.errors and rethrows on a non-AuthSessionMissingError getUser failure", async () => {
+    vi.mocked(createSupabaseServerClient).mockResolvedValueOnce({
+      auth: {
+        getUser: () =>
+          Promise.resolve({
+            data: { user: null },
+            error: { name: "SomeOtherError", message: "boom" },
+          }),
+      },
+    } as Awaited<ReturnType<typeof createSupabaseServerClient>>);
+
+    await expect(
+      NewCardgroupPage({ searchParams: Promise.resolve({}) }),
+    ).rejects.toMatchObject({ name: "SomeOtherError", message: "boom" });
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "[cardgroups-new] getUser() failed:",
+      "SomeOtherError",
+      "boom",
+    );
   });
 });
 

--- a/frontend/src/app/cardgroups/new/page.test.tsx
+++ b/frontend/src/app/cardgroups/new/page.test.tsx
@@ -39,8 +39,7 @@ vi.mock("@/lib/supabase/server", () => ({
   createSupabaseServerClient: vi.fn(() =>
     Promise.resolve({
       auth: {
-        getUser: () =>
-          Promise.resolve({ data: { user: { id: "u-1" } }, error: null }),
+        getUser: () => Promise.resolve({ data: { user: { id: "u-1" } }, error: null }),
       },
     }),
   ),
@@ -290,9 +289,9 @@ describe("authentication boundary", () => {
       },
     } as Awaited<ReturnType<typeof createSupabaseServerClient>>);
 
-    await expect(
-      NewCardgroupPage({ searchParams: Promise.resolve({}) }),
-    ).rejects.toThrow("REDIRECT:/login");
+    await expect(NewCardgroupPage({ searchParams: Promise.resolve({}) })).rejects.toThrow(
+      "REDIRECT:/login",
+    );
 
     expect(mockRedirect).toHaveBeenCalledWith("/login");
   });
@@ -308,9 +307,10 @@ describe("authentication boundary", () => {
       },
     } as Awaited<ReturnType<typeof createSupabaseServerClient>>);
 
-    await expect(
-      NewCardgroupPage({ searchParams: Promise.resolve({}) }),
-    ).rejects.toMatchObject({ name: "SomeOtherError", message: "boom" });
+    await expect(NewCardgroupPage({ searchParams: Promise.resolve({}) })).rejects.toMatchObject({
+      name: "SomeOtherError",
+      message: "boom",
+    });
 
     expect(consoleErrorSpy).toHaveBeenCalledWith(
       "[cardgroups-new] getUser() failed:",

--- a/frontend/src/app/cardgroups/new/page.test.tsx
+++ b/frontend/src/app/cardgroups/new/page.test.tsx
@@ -9,12 +9,16 @@ import { GraphQLError } from "graphql";
 import { describe, expect, it, vi } from "vitest";
 import { CreateCardgroupDocument, MyCardgroupsDocument } from "@/generated/graphql";
 import { NewCardgroupClient } from "./new-cardgroup-client";
+import { sanitizeReturnTo } from "./page";
 
 // Stub next/navigation so the client component can render outside Next.js.
 const mockPush = vi.fn();
 const mockRefresh = vi.fn();
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: mockPush, refresh: mockRefresh }),
+  redirect: vi.fn((path: string) => {
+    throw new Error(`REDIRECT:${path}`);
+  }),
 }));
 
 // Stub next/link so it renders an anchor without Next.js router context.
@@ -24,6 +28,18 @@ vi.mock("next/link", () => ({
       {children}
     </a>
   ),
+}));
+
+// Stub the Supabase server client — required because page.tsx imports it at
+// module-evaluation time (the import itself triggers the module graph).
+vi.mock("@/lib/supabase/server", () => ({
+  createSupabaseServerClient: () =>
+    Promise.resolve({
+      auth: {
+        getUser: () =>
+          Promise.resolve({ data: { user: { id: "u-1" } }, error: null }),
+      },
+    }),
 }));
 
 const CREATED_CARDGROUP = {
@@ -57,11 +73,12 @@ function renderPage(
   mocks: MockedResponse[] = [],
   errorPolicy?: "all" | "none" | "ignore",
   cache?: InMemoryCache,
+  returnTo?: string | null,
 ) {
   const defaultOptions = errorPolicy ? { mutate: { errorPolicy } } : undefined;
   render(
     <MockedProvider mocks={mocks} defaultOptions={defaultOptions} cache={cache}>
-      <NewCardgroupClient />
+      <NewCardgroupClient returnTo={returnTo} />
     </MockedProvider>,
   );
 }
@@ -199,5 +216,89 @@ describe("<NewCardgroupPage> (client)", () => {
       expect(screen.getByText("Your session expired. Please sign in again.")).toBeInTheDocument();
     });
     expect(screen.getByRole("alert")).toBeInTheDocument();
+  });
+
+  it("on success with returnTo navigates to returnTo?cardgroup=<id>", async () => {
+    const user = userEvent.setup();
+    mockPush.mockClear();
+    mockRefresh.mockClear();
+
+    renderPage([makeCreateMock("My New Group")], undefined, undefined, "/cards/new");
+
+    await user.type(screen.getByRole("textbox"), "My New Group");
+    await user.click(screen.getByRole("button", { name: /create/i }));
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith(`/cards/new?cardgroup=${CREATED_CARDGROUP.id}`);
+    });
+    expect(mockRefresh).toHaveBeenCalledOnce();
+  });
+
+  it("on success with returnTo containing query string uses & separator", async () => {
+    const user = userEvent.setup();
+    mockPush.mockClear();
+
+    renderPage([makeCreateMock("My New Group")], undefined, undefined, "/foo?bar=1");
+
+    await user.type(screen.getByRole("textbox"), "My New Group");
+    await user.click(screen.getByRole("button", { name: /create/i }));
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith(`/foo?bar=1&cardgroup=${CREATED_CARDGROUP.id}`);
+    });
+  });
+
+  it("on success with null returnTo falls back to /cardgroups/<id>", async () => {
+    const user = userEvent.setup();
+    mockPush.mockClear();
+
+    renderPage([makeCreateMock("My New Group")], undefined, undefined, null);
+
+    await user.type(screen.getByRole("textbox"), "My New Group");
+    await user.click(screen.getByRole("button", { name: /create/i }));
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith(`/cardgroups/${CREATED_CARDGROUP.id}`);
+    });
+  });
+});
+
+describe("sanitizeReturnTo", () => {
+  it("allows internal paths starting with /", () => {
+    expect(sanitizeReturnTo("/cards/new")).toBe("/cards/new");
+  });
+
+  it("allows internal paths with query string", () => {
+    expect(sanitizeReturnTo("/cards/new?foo=1")).toBe("/cards/new?foo=1");
+  });
+
+  it("rejects protocol-relative URLs starting with //", () => {
+    expect(sanitizeReturnTo("//evil.com")).toBeNull();
+  });
+
+  it("rejects https:// URLs", () => {
+    expect(sanitizeReturnTo("https://evil.com")).toBeNull();
+  });
+
+  it("rejects bare hostnames without leading slash", () => {
+    expect(sanitizeReturnTo("evil.com")).toBeNull();
+  });
+
+  it("rejects undefined", () => {
+    expect(sanitizeReturnTo(undefined)).toBeNull();
+  });
+
+  it("rejects empty string", () => {
+    expect(sanitizeReturnTo("")).toBeNull();
+  });
+
+  it("rejects backslash-bypass /\\evil.com", () => {
+    expect(sanitizeReturnTo("/\\evil.com")).toBeNull();
+  });
+
+  it("rejects backslash-bypass /\\\\evil.com", () => {
+    // double-escaped to land "/\\evil.com" as the runtime string -- verify the helper
+    // when called with the raw form a browser may emit
+    expect(sanitizeReturnTo("/\\\\evil.com")).toBeNull();
   });
 });

--- a/frontend/src/app/cardgroups/new/page.tsx
+++ b/frontend/src/app/cardgroups/new/page.tsx
@@ -3,7 +3,7 @@ import { createSupabaseServerClient } from "@/lib/supabase/server";
 import { NewCardgroupClient } from "./new-cardgroup-client";
 
 interface NewCardgroupPageProps {
-  searchParams: Promise<{ welcome?: string }>;
+  searchParams: Promise<{ welcome?: string; returnTo?: string }>;
 }
 
 export default async function NewCardgroupPage({ searchParams }: NewCardgroupPageProps) {
@@ -18,8 +18,21 @@ export default async function NewCardgroupPage({ searchParams }: NewCardgroupPag
   }
   if (!user) redirect("/login");
 
-  const { welcome } = await searchParams;
+  const { welcome, returnTo } = await searchParams;
   const showWelcome = welcome === "1";
+  const safeReturnTo = sanitizeReturnTo(returnTo);
 
-  return <NewCardgroupClient showWelcome={showWelcome} />;
+  return <NewCardgroupClient showWelcome={showWelcome} returnTo={safeReturnTo} />;
+}
+
+/**
+ * Open-redirect guard: allow only internal paths (must start with "/" but not
+ * "//"). Rejects missing values, protocol-relative URLs ("//evil.com"), and
+ * any scheme-bearing URLs ("https://...").
+ */
+export function sanitizeReturnTo(value: string | undefined): string | null {
+  if (!value) return null;
+  // reject "//" and "/\" -- both normalise to protocol-relative in browsers
+  if (!value.startsWith("/") || value[1] === "/" || value[1] === "\\") return null;
+  return value;
 }

--- a/frontend/src/app/cardgroups/page.test.tsx
+++ b/frontend/src/app/cardgroups/page.test.tsx
@@ -96,9 +96,7 @@ describe("CardgroupsPage", () => {
 
   it("renders footer-style New cardgroup link when cardgroups list is non-empty", async () => {
     vi.mocked(gqlFetch).mockResolvedValue({
-      myCardgroups: [
-        { id: "cg-1", name: "Spanish Vocab", updatedAt: "2024-06-15T10:00:00.000Z" },
-      ],
+      myCardgroups: [{ id: "cg-1", name: "Spanish Vocab", updatedAt: "2024-06-15T10:00:00.000Z" }],
     } as never);
 
     const jsx = await CardgroupsPage();
@@ -112,9 +110,7 @@ describe("CardgroupsPage", () => {
 
   it("does not render the top-right New cardgroup button when cardgroups exist", async () => {
     vi.mocked(gqlFetch).mockResolvedValue({
-      myCardgroups: [
-        { id: "cg-1", name: "Spanish Vocab", updatedAt: "2024-06-15T10:00:00.000Z" },
-      ],
+      myCardgroups: [{ id: "cg-1", name: "Spanish Vocab", updatedAt: "2024-06-15T10:00:00.000Z" }],
     } as never);
 
     const jsx = await CardgroupsPage();

--- a/frontend/src/app/cardgroups/page.test.tsx
+++ b/frontend/src/app/cardgroups/page.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // Mock next/navigation before importing the page
 vi.mock("next/navigation", () => ({
@@ -35,6 +35,12 @@ function makeSupabaseMock(user: { id: string } | null) {
 }
 
 describe("CardgroupsPage", () => {
+  beforeEach(() => {
+    vi.mocked(createSupabaseServerClient).mockResolvedValue(
+      makeSupabaseMock({ id: "user-1" }) as never,
+    );
+  });
+
   it("redirects to /login when no user is authenticated", async () => {
     vi.mocked(createSupabaseServerClient).mockResolvedValue(makeSupabaseMock(null) as never);
 
@@ -42,9 +48,6 @@ describe("CardgroupsPage", () => {
   });
 
   it("renders empty state when myCardgroups is empty", async () => {
-    vi.mocked(createSupabaseServerClient).mockResolvedValue(
-      makeSupabaseMock({ id: "user-1" }) as never,
-    );
     vi.mocked(gqlFetch).mockResolvedValue({ myCardgroups: [] } as never);
 
     const jsx = await CardgroupsPage();
@@ -58,9 +61,6 @@ describe("CardgroupsPage", () => {
   });
 
   it("does not render footer link when cardgroups list is empty", async () => {
-    vi.mocked(createSupabaseServerClient).mockResolvedValue(
-      makeSupabaseMock({ id: "user-1" }) as never,
-    );
     vi.mocked(gqlFetch).mockResolvedValue({ myCardgroups: [] } as never);
 
     const jsx = await CardgroupsPage();
@@ -74,9 +74,6 @@ describe("CardgroupsPage", () => {
   });
 
   it("renders one list item per cardgroup", async () => {
-    vi.mocked(createSupabaseServerClient).mockResolvedValue(
-      makeSupabaseMock({ id: "user-1" }) as never,
-    );
     vi.mocked(gqlFetch).mockResolvedValue({
       myCardgroups: [
         { id: "cg-1", name: "Spanish Vocab", updatedAt: "2024-06-15T10:00:00.000Z" },
@@ -98,9 +95,6 @@ describe("CardgroupsPage", () => {
   });
 
   it("renders footer-style New cardgroup link when cardgroups list is non-empty", async () => {
-    vi.mocked(createSupabaseServerClient).mockResolvedValue(
-      makeSupabaseMock({ id: "user-1" }) as never,
-    );
     vi.mocked(gqlFetch).mockResolvedValue({
       myCardgroups: [
         { id: "cg-1", name: "Spanish Vocab", updatedAt: "2024-06-15T10:00:00.000Z" },
@@ -117,9 +111,6 @@ describe("CardgroupsPage", () => {
   });
 
   it("does not render the top-right New cardgroup button when cardgroups exist", async () => {
-    vi.mocked(createSupabaseServerClient).mockResolvedValue(
-      makeSupabaseMock({ id: "user-1" }) as never,
-    );
     vi.mocked(gqlFetch).mockResolvedValue({
       myCardgroups: [
         { id: "cg-1", name: "Spanish Vocab", updatedAt: "2024-06-15T10:00:00.000Z" },
@@ -135,18 +126,12 @@ describe("CardgroupsPage", () => {
   });
 
   it("redirects to /login when MyCardgroupsQuery returns UNAUTHENTICATED", async () => {
-    vi.mocked(createSupabaseServerClient).mockResolvedValue(
-      makeSupabaseMock({ id: "user-1" }) as never,
-    );
     vi.mocked(gqlFetch).mockRejectedValue(new Error("GraphQL errors: UNAUTHENTICATED"));
 
     await expect(CardgroupsPage()).rejects.toThrow("REDIRECT:/login");
   });
 
   it("rethrows non-auth errors so the error boundary handles them", async () => {
-    vi.mocked(createSupabaseServerClient).mockResolvedValue(
-      makeSupabaseMock({ id: "user-1" }) as never,
-    );
     vi.mocked(gqlFetch).mockRejectedValue(new Error("Network unreachable"));
 
     await expect(CardgroupsPage()).rejects.toThrow("Network unreachable");

--- a/frontend/src/app/cardgroups/page.test.tsx
+++ b/frontend/src/app/cardgroups/page.test.tsx
@@ -51,9 +51,26 @@ describe("CardgroupsPage", () => {
     render(jsx);
 
     expect(screen.getByText("You haven't created any cardgroups yet.")).toBeInTheDocument();
-    // Both CTA links should be present (header + empty state)
+    // Empty state CTA link should be present
+    const ctaLink = screen.getByRole("link", { name: /new cardgroup/i });
+    expect(ctaLink).toBeInTheDocument();
+    expect(ctaLink).toHaveAttribute("href", "/cardgroups/new");
+  });
+
+  it("does not render footer link when cardgroups list is empty", async () => {
+    vi.mocked(createSupabaseServerClient).mockResolvedValue(
+      makeSupabaseMock({ id: "user-1" }) as never,
+    );
+    vi.mocked(gqlFetch).mockResolvedValue({ myCardgroups: [] } as never);
+
+    const jsx = await CardgroupsPage();
+    render(jsx);
+
+    // Only one "New cardgroup" link: the empty-state CTA (no footer link when empty)
     const links = screen.getAllByRole("link", { name: /new cardgroup/i });
-    expect(links.length).toBeGreaterThanOrEqual(1);
+    expect(links).toHaveLength(1);
+    // The single link is the empty-state CTA, not a footer-style link
+    expect(links[0]).toHaveAttribute("href", "/cardgroups/new");
   });
 
   it("renders one list item per cardgroup", async () => {
@@ -78,6 +95,43 @@ describe("CardgroupsPage", () => {
 
     const mathLink = screen.getByRole("link", { name: /math formulas/i });
     expect(mathLink).toHaveAttribute("href", "/cardgroups/cg-2");
+  });
+
+  it("renders footer-style New cardgroup link when cardgroups list is non-empty", async () => {
+    vi.mocked(createSupabaseServerClient).mockResolvedValue(
+      makeSupabaseMock({ id: "user-1" }) as never,
+    );
+    vi.mocked(gqlFetch).mockResolvedValue({
+      myCardgroups: [
+        { id: "cg-1", name: "Spanish Vocab", updatedAt: "2024-06-15T10:00:00.000Z" },
+      ],
+    } as never);
+
+    const jsx = await CardgroupsPage();
+    render(jsx);
+
+    // Footer link should be present
+    const footerLink = screen.getByRole("link", { name: /new cardgroup/i });
+    expect(footerLink).toBeInTheDocument();
+    expect(footerLink).toHaveAttribute("href", "/cardgroups/new");
+  });
+
+  it("does not render the top-right New cardgroup button when cardgroups exist", async () => {
+    vi.mocked(createSupabaseServerClient).mockResolvedValue(
+      makeSupabaseMock({ id: "user-1" }) as never,
+    );
+    vi.mocked(gqlFetch).mockResolvedValue({
+      myCardgroups: [
+        { id: "cg-1", name: "Spanish Vocab", updatedAt: "2024-06-15T10:00:00.000Z" },
+      ],
+    } as never);
+
+    const jsx = await CardgroupsPage();
+    render(jsx);
+
+    // Exactly one "New cardgroup" link: the footer link only (no top-right button)
+    const links = screen.getAllByRole("link", { name: /new cardgroup/i });
+    expect(links).toHaveLength(1);
   });
 
   it("redirects to /login when MyCardgroupsQuery returns UNAUTHENTICATED", async () => {

--- a/frontend/src/app/cardgroups/page.tsx
+++ b/frontend/src/app/cardgroups/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { redirect } from "next/navigation";
+import { Plus } from "lucide-react";
 import { CardgroupListItem } from "@/components/cardgroups/cardgroup-list-item";
 import type { MyCardgroupsQuery as MyCardgroupsQueryType } from "@/generated/graphql";
 import { gqlFetch } from "@/lib/apollo/server";
@@ -31,14 +32,8 @@ export default async function CardgroupsPage() {
 
   return (
     <main className="mx-auto max-w-2xl p-8">
-      <div className="mb-6 flex items-center justify-between">
+      <div className="mb-6">
         <h1 className="text-2xl font-semibold">My Cardgroups</h1>
-        <Link
-          href="/cardgroups/new"
-          className="rounded-md bg-brand-primary px-4 py-2 text-sm font-medium text-brand-primary-foreground hover:opacity-90 transition-opacity"
-        >
-          New cardgroup
-        </Link>
       </div>
 
       {cardgroups.length === 0 ? (
@@ -52,11 +47,22 @@ export default async function CardgroupsPage() {
           </Link>
         </div>
       ) : (
-        <ul className="space-y-2">
-          {cardgroups.map((cg) => (
-            <CardgroupListItem key={cg.id} id={cg.id} name={cg.name} updatedAt={cg.updatedAt} />
-          ))}
-        </ul>
+        <>
+          <ul className="space-y-2">
+            {cardgroups.map((cg) => (
+              <CardgroupListItem key={cg.id} id={cg.id} name={cg.name} updatedAt={cg.updatedAt} />
+            ))}
+          </ul>
+          <div className="mt-6 border-t pt-4 text-center">
+            <Link
+              href="/cardgroups/new"
+              className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground hover:underline"
+            >
+              <Plus className="h-3.5 w-3.5" aria-hidden="true" />
+              New cardgroup
+            </Link>
+          </div>
+        </>
       )}
     </main>
   );

--- a/frontend/src/app/cardgroups/page.tsx
+++ b/frontend/src/app/cardgroups/page.tsx
@@ -1,6 +1,6 @@
+import { Plus } from "lucide-react";
 import Link from "next/link";
 import { redirect } from "next/navigation";
-import { Plus } from "lucide-react";
 import { CardgroupListItem } from "@/components/cardgroups/cardgroup-list-item";
 import type { MyCardgroupsQuery as MyCardgroupsQueryType } from "@/generated/graphql";
 import { gqlFetch } from "@/lib/apollo/server";

--- a/frontend/src/app/cards/new/cards-new-client.test.tsx
+++ b/frontend/src/app/cards/new/cards-new-client.test.tsx
@@ -52,17 +52,26 @@ const myCardgroups = [
 function makeCreateMock(args: {
   front: string;
   back: string;
+  cardgroupId?: string;
   cardId?: string;
   onCalled?: () => void;
   errors?: GraphQLError[];
   networkError?: Error;
 }): MockedResponse {
-  const { front, back, cardId = "card-new-1", onCalled, errors, networkError } = args;
+  const {
+    front,
+    back,
+    cardgroupId = CG_ID,
+    cardId = "card-new-1",
+    onCalled,
+    errors,
+    networkError,
+  } = args;
   if (networkError) {
     return {
       request: {
         query: CreateCardDocument,
-        variables: { input: { cardgroupId: CG_ID, front, back } },
+        variables: { input: { cardgroupId, front, back } },
       },
       error: networkError,
     };
@@ -70,7 +79,7 @@ function makeCreateMock(args: {
   return {
     request: {
       query: CreateCardDocument,
-      variables: { input: { cardgroupId: CG_ID, front, back } },
+      variables: { input: { cardgroupId, front, back } },
     },
     result: () => {
       onCalled?.();
@@ -88,7 +97,7 @@ function makeCreateMock(args: {
               back,
               due: "2026-04-30T00:00:00Z",
               state: 0,
-              cardgroupId: CG_ID,
+              cardgroupId,
             },
           },
         },
@@ -255,7 +264,7 @@ describe("<CardsNewClient> — stay-on-page consecutive add", () => {
 
     const indicator = await screen.findByRole("status");
     expect(indicator).toHaveAttribute("aria-live", "polite");
-    expect(indicator).toHaveTextContent(`Card added to "${CG_NAME}"`);
+    expect(indicator).toHaveTextContent(/✓ Card added to "Spanish 101"/);
   });
 
   it("does NOT call router.push after a successful submit (regression guard)", async () => {
@@ -400,5 +409,35 @@ describe("<CardsNewClient> — stay-on-page consecutive add", () => {
     });
 
     expect(screen.queryByRole("link", { name: /done/i })).not.toBeInTheDocument();
+  });
+
+  it("uses URL cardgroup id (not initialCardgroupId) for setLastViewed and SuccessIndicator after picker switch", async () => {
+    // Simulate the router having already written cg-2 into the URL (e.g. the
+    // user picked "French 101" via the picker and the URL reflects that).
+    // initialCardgroupId is still cg-1 (server-resolved before the client switch).
+    mockSearchParamsValue = "cardgroup=cg-2";
+
+    const persistCalled = vi.fn();
+    renderClient({
+      initialCardgroupId: CG_ID,
+      mocks: [
+        makeCreateMock({ cardgroupId: "cg-2", front: "Bonjour", back: "Hello", cardId: "c-fr-1" }),
+        makePersistMock({ cardgroupId: "cg-2", onCalled: persistCalled }),
+      ],
+    });
+
+    // The component should show the French 101 chip because the URL wins.
+    expect(screen.getByText("French 101")).toBeInTheDocument();
+
+    await fillAndSubmit("Bonjour", "Hello");
+
+    // SetLastViewedCardgroup must be called with cg-2 (the URL-driven id).
+    await waitFor(() => {
+      expect(persistCalled).toHaveBeenCalledTimes(1);
+    });
+
+    // SuccessIndicator must display the name of cg-2, not cg-1.
+    const indicator = await screen.findByRole("status");
+    expect(indicator).toHaveTextContent(/✓ Card added to "French 101"/);
   });
 });

--- a/frontend/src/app/cards/new/cards-new-client.test.tsx
+++ b/frontend/src/app/cards/new/cards-new-client.test.tsx
@@ -210,8 +210,11 @@ afterEach(() => {
   // every userEvent / Apollo mutation would silently hang.
   vi.useRealTimers();
   leakSpy.assertNoLeaks();
-  leakSpy.teardown();
+  // Restore outer spy first so console.warn is back to leakSpy's mock, then
+  // restore leakSpy so console.warn is back to the real implementation.
+  // Reversing the order would leave leakSpy's mock installed permanently.
   consoleWarnSpy.mockRestore();
+  leakSpy.teardown();
   consoleErrorSpy.mockRestore();
 });
 
@@ -334,7 +337,10 @@ describe("<CardsNewClient> — stay-on-page consecutive add", () => {
   });
 
   it("logs [cards-new] warning and still resets/shows indicator when setLastViewed rejects", async () => {
-    consoleWarnSpy.mockImplementation(() => {});
+    // leakSpy (inner spy, silent=true) already swallows console output, so no
+    // extra mockImplementation is needed here. Calling mockImplementation on the
+    // outer consoleWarnSpy would break the call chain into leakSpy and silence
+    // Apollo unmatched-mock leak detection for the rest of this test.
     renderClient({
       mocks: [
         makeCreateMock({ front: "Hello", back: "Hola" }),

--- a/frontend/src/app/cards/new/cards-new-client.test.tsx
+++ b/frontend/src/app/cards/new/cards-new-client.test.tsx
@@ -1,0 +1,404 @@
+// @vitest-environment jsdom
+import type { MockedResponse } from "@apollo/client/testing";
+import { MockedProvider } from "@apollo/client/testing/react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { GraphQLError } from "graphql";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { installApolloMockLeakSpy } from "../../../../__tests__/utils/mock-apollo-paginated";
+import { CreateCardDocument, SetLastViewedCardgroupDocument } from "@/generated/graphql";
+import CardsNewClient from "./cards-new-client";
+
+// ---------------------------------------------------------------------------
+// next/navigation + next/link stubs
+// ---------------------------------------------------------------------------
+
+const mockPush = vi.fn();
+const mockReplace = vi.fn();
+let mockSearchParamsValue = "";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush, replace: mockReplace }),
+  useSearchParams: () => new URLSearchParams(mockSearchParamsValue),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    ...rest
+  }: {
+    href: string;
+    children: React.ReactNode;
+  }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const CG_ID = "cg-1";
+const CG_NAME = "Spanish 101";
+
+const myCardgroups = [
+  { id: CG_ID, name: CG_NAME },
+  { id: "cg-2", name: "French 101" },
+];
+
+function makeCreateMock(args: {
+  front: string;
+  back: string;
+  cardId?: string;
+  onCalled?: () => void;
+  errors?: GraphQLError[];
+  networkError?: Error;
+}): MockedResponse {
+  const { front, back, cardId = "card-new-1", onCalled, errors, networkError } = args;
+  if (networkError) {
+    return {
+      request: {
+        query: CreateCardDocument,
+        variables: { input: { cardgroupId: CG_ID, front, back } },
+      },
+      error: networkError,
+    };
+  }
+  return {
+    request: {
+      query: CreateCardDocument,
+      variables: { input: { cardgroupId: CG_ID, front, back } },
+    },
+    result: () => {
+      onCalled?.();
+      if (errors) {
+        return { errors };
+      }
+      return {
+        data: {
+          createCard: {
+            __typename: "CreateCardPayload" as const,
+            card: {
+              __typename: "Card" as const,
+              id: cardId,
+              front,
+              back,
+              due: "2026-04-30T00:00:00Z",
+              state: 0,
+              cardgroupId: CG_ID,
+            },
+          },
+        },
+      };
+    },
+  };
+}
+
+function makePersistMock(args: {
+  cardgroupId?: string;
+  onCalled?: () => void;
+  errors?: GraphQLError[];
+  networkError?: Error;
+} = {}): MockedResponse {
+  const { cardgroupId = CG_ID, onCalled, errors, networkError } = args;
+  if (networkError) {
+    return {
+      request: {
+        query: SetLastViewedCardgroupDocument,
+        variables: { cardgroupId },
+      },
+      error: networkError,
+    };
+  }
+  return {
+    request: {
+      query: SetLastViewedCardgroupDocument,
+      variables: { cardgroupId },
+    },
+    result: () => {
+      onCalled?.();
+      if (errors) {
+        return { errors };
+      }
+      return {
+        data: {
+          setLastViewedCardgroup: {
+            __typename: "User" as const,
+            id: "u-1",
+            lastViewedCardgroup: {
+              __typename: "Cardgroup" as const,
+              id: cardgroupId,
+            },
+          },
+        },
+      };
+    },
+  };
+}
+
+function renderClient(
+  opts: {
+    initialCardgroupId?: string | null;
+    forcePickerOpen?: boolean;
+    mocks?: MockedResponse[];
+  } = {},
+) {
+  const {
+    initialCardgroupId = CG_ID,
+    forcePickerOpen = false,
+    mocks = [],
+  } = opts;
+  return render(
+    <MockedProvider mocks={mocks}>
+      <CardsNewClient
+        initialCardgroupId={initialCardgroupId}
+        forcePickerOpen={forcePickerOpen}
+        myCardgroups={myCardgroups}
+      />
+    </MockedProvider>,
+  );
+}
+
+async function fillAndSubmit(front: string, back: string) {
+  const user = userEvent.setup();
+  const frontInput = screen.getByLabelText(/front/i);
+  const backInput = screen.getByLabelText(/back/i);
+  await user.clear(frontInput);
+  await user.type(frontInput, front);
+  await user.clear(backInput);
+  await user.type(backInput, back);
+  await user.click(screen.getByRole("button", { name: /add card/i }));
+}
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+let leakSpy: ReturnType<typeof installApolloMockLeakSpy>;
+let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
+let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  mockPush.mockClear();
+  mockReplace.mockClear();
+  mockSearchParamsValue = "";
+  // Capture MockedProvider unmatched-mock leak warnings — assertNoLeaks() in
+  // afterEach turns them into hard failures.
+  leakSpy = installApolloMockLeakSpy({
+    operationNames: ["CreateCard", "SetLastViewedCardgroup"],
+  });
+  // Track non-leak warnings so we can introspect [cards-new] persist failures.
+  consoleWarnSpy = vi.spyOn(console, "warn");
+  consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  // Always reset to real timers — a test that throws while fake timers are
+  // installed would otherwise leak fake timers into subsequent tests and
+  // every userEvent / Apollo mutation would silently hang.
+  vi.useRealTimers();
+  leakSpy.assertNoLeaks();
+  leakSpy.teardown();
+  consoleWarnSpy.mockRestore();
+  consoleErrorSpy.mockRestore();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("<CardsNewClient> — stay-on-page consecutive add", () => {
+  it("clears the front/back inputs after a successful submit", async () => {
+    renderClient({
+      mocks: [
+        makeCreateMock({ front: "Hello", back: "Hola" }),
+        makePersistMock(),
+      ],
+    });
+
+    await fillAndSubmit("Hello", "Hola");
+
+    await waitFor(() => {
+      expect((screen.getByLabelText(/front/i) as HTMLInputElement).value).toBe("");
+    });
+    expect((screen.getByLabelText(/back/i) as HTMLInputElement).value).toBe("");
+  });
+
+  it("fires SetLastViewedCardgroup exactly once with the current cardgroup id", async () => {
+    const persistCalled = vi.fn();
+    renderClient({
+      mocks: [
+        makeCreateMock({ front: "Hello", back: "Hola" }),
+        makePersistMock({ onCalled: persistCalled }),
+      ],
+    });
+
+    await fillAndSubmit("Hello", "Hola");
+
+    await waitFor(() => {
+      expect(persistCalled).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("renders the SuccessIndicator with role=status, aria-live=polite, and the cardgroup name", async () => {
+    renderClient({
+      mocks: [
+        makeCreateMock({ front: "Hello", back: "Hola" }),
+        makePersistMock(),
+      ],
+    });
+
+    await fillAndSubmit("Hello", "Hola");
+
+    const indicator = await screen.findByRole("status");
+    expect(indicator).toHaveAttribute("aria-live", "polite");
+    expect(indicator).toHaveTextContent(`Card added to "${CG_NAME}"`);
+  });
+
+  it("does NOT call router.push after a successful submit (regression guard)", async () => {
+    renderClient({
+      mocks: [
+        makeCreateMock({ front: "Hello", back: "Hola" }),
+        makePersistMock(),
+      ],
+    });
+
+    await fillAndSubmit("Hello", "Hola");
+
+    // Wait for the success indicator so we know the submit chain ran.
+    await screen.findByRole("status");
+
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it("dismisses the SuccessIndicator after 2 s", async () => {
+    // Real timers throughout: userEvent and Apollo MockedProvider both rely
+    // on real timer/microtask scheduling, and switching to fake timers AFTER
+    // the SuccessIndicator's setTimeout is already pending does not migrate
+    // the existing real-timer handle into the fake-timer queue. So we wait
+    // the wall-clock 2 s with a generous test-level timeout instead.
+    renderClient({
+      mocks: [
+        makeCreateMock({ front: "Hello", back: "Hola" }),
+        makePersistMock(),
+      ],
+    });
+
+    await fillAndSubmit("Hello", "Hola");
+    const indicator = await screen.findByRole("status");
+    expect(indicator).toBeInTheDocument();
+
+    // Real-time wait for the indicator's 2 s setTimeout; cap at 3 s.
+    await waitFor(
+      () => {
+        expect(screen.queryByRole("status")).not.toBeInTheDocument();
+      },
+      { timeout: 3000, interval: 100 },
+    );
+  }, 10000);
+
+  it("two consecutive submits each render a fresh SuccessIndicator", async () => {
+    renderClient({
+      mocks: [
+        makeCreateMock({ front: "Hello", back: "Hola", cardId: "c-1" }),
+        makePersistMock(),
+        makeCreateMock({ front: "Bye", back: "Adios", cardId: "c-2" }),
+        makePersistMock(),
+      ],
+    });
+
+    // First submit.
+    await fillAndSubmit("Hello", "Hola");
+    const firstIndicator = await screen.findByRole("status");
+    expect(firstIndicator).toBeInTheDocument();
+
+    // Second submit — the form should be clear, fill again.
+    await fillAndSubmit("Bye", "Adios");
+
+    // The indicator should still be visible (key bumped → remount, restarts timer).
+    await waitFor(() => {
+      expect(screen.queryByRole("status")).toBeInTheDocument();
+    });
+  });
+
+  it("logs [cards-new] warning and still resets/shows indicator when setLastViewed rejects", async () => {
+    consoleWarnSpy.mockImplementation(() => {});
+    renderClient({
+      mocks: [
+        makeCreateMock({ front: "Hello", back: "Hola" }),
+        makePersistMock({
+          errors: [
+            new GraphQLError("forbidden", {
+              extensions: { code: "BAD_USER_INPUT" },
+            }),
+          ],
+        }),
+      ],
+    });
+
+    await fillAndSubmit("Hello", "Hola");
+
+    await waitFor(() => {
+      expect((screen.getByLabelText(/front/i) as HTMLInputElement).value).toBe("");
+    });
+    expect(screen.getByRole("status")).toBeInTheDocument();
+    // No alert banner from createCard (which succeeded).
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        "[cards-new] setLastViewedCardgroup failed",
+        expect.objectContaining({ cardgroupId: CG_ID }),
+      );
+    });
+  });
+
+  it("does NOT reset the form and does NOT show indicator when createCard rejects; surfaces error banner", async () => {
+    renderClient({
+      mocks: [
+        makeCreateMock({
+          front: "Hello",
+          back: "Hola",
+          errors: [
+            new GraphQLError("backend exploded", {
+              extensions: { code: "INTERNAL_SERVER_ERROR" },
+            }),
+          ],
+        }),
+      ],
+    });
+
+    await fillAndSubmit("Hello", "Hola");
+
+    // Banner from CardForm's getBackendErrorBanner.
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+    });
+    // Form values are preserved so the user can retry.
+    expect((screen.getByLabelText(/front/i) as HTMLInputElement).value).toBe("Hello");
+    expect((screen.getByLabelText(/back/i) as HTMLInputElement).value).toBe("Hola");
+    // No success indicator.
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+  });
+
+  it('renders a "Done" link to /cardgroups/<currentId>/cards when currentId is set', () => {
+    renderClient({ initialCardgroupId: CG_ID });
+
+    const done = screen.getByRole("link", { name: /done/i });
+    expect(done).toHaveAttribute("href", `/cardgroups/${CG_ID}/cards`);
+  });
+
+  it('does NOT render the "Done" link when currentId is null', () => {
+    renderClient({
+      initialCardgroupId: null,
+      // forcePickerOpen would render the picker which queries MyCardgroups; keep
+      // it closed here so MockedProvider does not need an extra mock.
+      forcePickerOpen: false,
+    });
+
+    expect(screen.queryByRole("link", { name: /done/i })).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/cards/new/cards-new-client.test.tsx
+++ b/frontend/src/app/cards/new/cards-new-client.test.tsx
@@ -5,8 +5,8 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { GraphQLError } from "graphql";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { installApolloMockLeakSpy } from "../../../../__tests__/utils/mock-apollo-paginated";
 import { CreateCardDocument, SetLastViewedCardgroupDocument } from "@/generated/graphql";
+import { installApolloMockLeakSpy } from "../../../../__tests__/utils/mock-apollo-paginated";
 import CardsNewClient from "./cards-new-client";
 
 // ---------------------------------------------------------------------------
@@ -23,14 +23,7 @@ vi.mock("next/navigation", () => ({
 }));
 
 vi.mock("next/link", () => ({
-  default: ({
-    href,
-    children,
-    ...rest
-  }: {
-    href: string;
-    children: React.ReactNode;
-  }) => (
+  default: ({ href, children, ...rest }: { href: string; children: React.ReactNode }) => (
     <a href={href} {...rest}>
       {children}
     </a>
@@ -106,12 +99,14 @@ function makeCreateMock(args: {
   };
 }
 
-function makePersistMock(args: {
-  cardgroupId?: string;
-  onCalled?: () => void;
-  errors?: GraphQLError[];
-  networkError?: Error;
-} = {}): MockedResponse {
+function makePersistMock(
+  args: {
+    cardgroupId?: string;
+    onCalled?: () => void;
+    errors?: GraphQLError[];
+    networkError?: Error;
+  } = {},
+): MockedResponse {
   const { cardgroupId = CG_ID, onCalled, errors, networkError } = args;
   if (networkError) {
     return {
@@ -155,11 +150,7 @@ function renderClient(
     mocks?: MockedResponse[];
   } = {},
 ) {
-  const {
-    initialCardgroupId = CG_ID,
-    forcePickerOpen = false,
-    mocks = [],
-  } = opts;
+  const { initialCardgroupId = CG_ID, forcePickerOpen = false, mocks = [] } = opts;
   return render(
     <MockedProvider mocks={mocks}>
       <CardsNewClient
@@ -225,10 +216,7 @@ afterEach(() => {
 describe("<CardsNewClient> — stay-on-page consecutive add", () => {
   it("clears the front/back inputs after a successful submit", async () => {
     renderClient({
-      mocks: [
-        makeCreateMock({ front: "Hello", back: "Hola" }),
-        makePersistMock(),
-      ],
+      mocks: [makeCreateMock({ front: "Hello", back: "Hola" }), makePersistMock()],
     });
 
     await fillAndSubmit("Hello", "Hola");
@@ -257,10 +245,7 @@ describe("<CardsNewClient> — stay-on-page consecutive add", () => {
 
   it("renders the SuccessIndicator with role=status, aria-live=polite, and the cardgroup name", async () => {
     renderClient({
-      mocks: [
-        makeCreateMock({ front: "Hello", back: "Hola" }),
-        makePersistMock(),
-      ],
+      mocks: [makeCreateMock({ front: "Hello", back: "Hola" }), makePersistMock()],
     });
 
     await fillAndSubmit("Hello", "Hola");
@@ -272,10 +257,7 @@ describe("<CardsNewClient> — stay-on-page consecutive add", () => {
 
   it("does NOT call router.push after a successful submit (regression guard)", async () => {
     renderClient({
-      mocks: [
-        makeCreateMock({ front: "Hello", back: "Hola" }),
-        makePersistMock(),
-      ],
+      mocks: [makeCreateMock({ front: "Hello", back: "Hola" }), makePersistMock()],
     });
 
     await fillAndSubmit("Hello", "Hola");
@@ -293,10 +275,7 @@ describe("<CardsNewClient> — stay-on-page consecutive add", () => {
     // the existing real-timer handle into the fake-timer queue. So we wait
     // the wall-clock 2 s with a generous test-level timeout instead.
     renderClient({
-      mocks: [
-        makeCreateMock({ front: "Hello", back: "Hola" }),
-        makePersistMock(),
-      ],
+      mocks: [makeCreateMock({ front: "Hello", back: "Hola" }), makePersistMock()],
     });
 
     await fillAndSubmit("Hello", "Hola");

--- a/frontend/src/app/cards/new/cards-new-client.test.tsx
+++ b/frontend/src/app/cards/new/cards-new-client.test.tsx
@@ -14,10 +14,17 @@ import CardsNewClient from "./cards-new-client";
 // Only used by the prop-wiring describe block; the consecutive-add tests do
 // not use this mock (they rely on the real component with the picker closed).
 // ---------------------------------------------------------------------------
-let capturedPickerProps: Record<string, unknown> | null = null;
+type PickerSheetProps = React.ComponentProps<
+  typeof import("@/components/cardgroups/cardgroup-picker-sheet").default
+>;
+let capturedPickerProps: PickerSheetProps | null = null;
 
 vi.mock("@/components/cardgroups/cardgroup-picker-sheet", () => ({
-  default: (props: Record<string, unknown>) => {
+  default: (
+    props: React.ComponentProps<
+      typeof import("@/components/cardgroups/cardgroup-picker-sheet").default
+    >,
+  ) => {
     capturedPickerProps = props;
     return null;
   },

--- a/frontend/src/app/cards/new/cards-new-client.test.tsx
+++ b/frontend/src/app/cards/new/cards-new-client.test.tsx
@@ -10,6 +10,20 @@ import { installApolloMockLeakSpy } from "../../../../__tests__/utils/mock-apoll
 import CardsNewClient from "./cards-new-client";
 
 // ---------------------------------------------------------------------------
+// Captured picker props — populated by the CardgroupPickerSheet mock below.
+// Only used by the prop-wiring describe block; the consecutive-add tests do
+// not use this mock (they rely on the real component with the picker closed).
+// ---------------------------------------------------------------------------
+let capturedPickerProps: Record<string, unknown> | null = null;
+
+vi.mock("@/components/cardgroups/cardgroup-picker-sheet", () => ({
+  default: (props: Record<string, unknown>) => {
+    capturedPickerProps = props;
+    return null;
+  },
+}));
+
+// ---------------------------------------------------------------------------
 // next/navigation + next/link stubs
 // ---------------------------------------------------------------------------
 
@@ -185,6 +199,7 @@ beforeEach(() => {
   mockPush.mockClear();
   mockReplace.mockClear();
   mockSearchParamsValue = "";
+  capturedPickerProps = null;
   // Capture MockedProvider unmatched-mock leak warnings — assertNoLeaks() in
   // afterEach turns them into hard failures.
   leakSpy = installApolloMockLeakSpy({
@@ -424,5 +439,18 @@ describe("<CardsNewClient> — stay-on-page consecutive add", () => {
     // SuccessIndicator must display the name of cg-2, not cg-1.
     const indicator = await screen.findByRole("status");
     expect(indicator).toHaveTextContent(/✓ Card added to "French 101"/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CardgroupPickerSheet prop wiring
+// ---------------------------------------------------------------------------
+
+describe("<CardsNewClient> — CardgroupPickerSheet prop wiring", () => {
+  it('passes createReturnTo="/cards/new" to CardgroupPickerSheet', () => {
+    renderClient({ initialCardgroupId: CG_ID });
+
+    expect(capturedPickerProps).not.toBeNull();
+    expect(capturedPickerProps?.createReturnTo).toBe("/cards/new");
   });
 });

--- a/frontend/src/app/cards/new/cards-new-client.tsx
+++ b/frontend/src/app/cards/new/cards-new-client.tsx
@@ -123,6 +123,7 @@ export default function CardsNewClient({
         onOpenChange={setPickerOpen}
         selectedId={currentId}
         onSelect={handlePickerSelect}
+        createReturnTo="/cards/new"
       />
 
       {successKey !== null && lastAddedName && (

--- a/frontend/src/app/cards/new/cards-new-client.tsx
+++ b/frontend/src/app/cards/new/cards-new-client.tsx
@@ -3,7 +3,7 @@
 import { useMutation } from "@apollo/client/react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { SetLastViewedCardgroupMutation } from "@/app/learn/queries";
 import { CreateCardMutation } from "@/app/cardgroups/queries";
 import { CardForm } from "@/components/cardgroups/card-form";
@@ -84,6 +84,15 @@ export default function CardsNewClient({
   const [successKey, setSuccessKey] = useState<number | null>(null);
   const [lastAddedName, setLastAddedName] = useState<string | null>(null);
 
+  // Stable callback identities so that CardForm's useEffect([form, onResetReady])
+  // and SuccessIndicator's useEffect([onTimeout]) do not re-fire on every parent
+  // re-render (e.g. after the fire-and-forget setLastViewed mutation settles).
+  const handleResetReady = useCallback((fn: () => void) => {
+    resetFormRef.current = fn;
+  }, []);
+
+  const handleSuccessTimeout = useCallback(() => setSuccessKey(null), []);
+
   async function handleCreate(values: { front: string; back: string }) {
     if (!currentId) return;
     try {
@@ -128,7 +137,7 @@ export default function CardsNewClient({
         <SuccessIndicator
           key={successKey}
           message={`✓ Card added to "${lastAddedName}"`}
-          onTimeout={() => setSuccessKey(null)}
+          onTimeout={handleSuccessTimeout}
         />
       )}
 
@@ -141,9 +150,7 @@ export default function CardsNewClient({
           submitLabel="Add card"
           submitting={creating}
           error={createError}
-          onResetReady={(fn) => {
-            resetFormRef.current = fn;
-          }}
+          onResetReady={handleResetReady}
         />
       ) : (
         <p className="text-sm text-muted-foreground">Select a cardgroup above to add a card.</p>

--- a/frontend/src/app/cards/new/cards-new-client.tsx
+++ b/frontend/src/app/cards/new/cards-new-client.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import { useMutation } from "@apollo/client/react";
+import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
+import { SetLastViewedCardgroupMutation } from "@/app/learn/queries";
 import { CreateCardMutation } from "@/app/cardgroups/queries";
 import { CardForm } from "@/components/cardgroups/card-form";
 import { CardgroupChip } from "@/components/cardgroups/cardgroup-chip";
@@ -22,6 +24,34 @@ type Props = {
   myCardgroups: Cardgroup[];
 };
 
+/**
+ * Transient banner that announces a successful card creation. Self-dismisses
+ * after 2 s. The parent assigns a fresh `key` on every successful submit so
+ * consecutive adds remount this component and restart the timer instead of
+ * silently extending the previous one.
+ */
+function SuccessIndicator({
+  message,
+  onTimeout,
+}: {
+  message: string;
+  onTimeout: () => void;
+}) {
+  useEffect(() => {
+    const t = setTimeout(onTimeout, 2000);
+    return () => clearTimeout(t);
+  }, [onTimeout]);
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm text-emerald-900"
+    >
+      {message}
+    </div>
+  );
+}
+
 export default function CardsNewClient({
   initialCardgroupId,
   forcePickerOpen,
@@ -40,6 +70,19 @@ export default function CardsNewClient({
     currentId != null ? (myCardgroups.find((cg) => cg.id === currentId)?.name ?? null) : null;
 
   const [createCard, { loading: creating, error: createError }] = useMutation(CreateCardMutation);
+  // Stay-on-page consecutive-add: do not carry an `optimisticResponse` for either
+  // mutation. setLastViewed can fail typed (BAD_USER_INPUT when the cardgroup was
+  // deleted between page render and submit) and Apollo v3.x does not roll back
+  // optimistic writes on typed errors — see .claude/rules/pagination.md.
+  const [setLastViewed] = useMutation(SetLastViewedCardgroupMutation);
+
+  // Form-reset callback handed up by <CardForm> via onResetReady.
+  const resetFormRef = useRef<(() => void) | null>(null);
+  // `successKey` doubles as "is the indicator visible?" (null = hidden) and as
+  // a remount key — bumping it on each successful submit forces SuccessIndicator
+  // to remount and restart its 2 s timer.
+  const [successKey, setSuccessKey] = useState<number | null>(null);
+  const [lastAddedName, setLastAddedName] = useState<string | null>(null);
 
   async function handleCreate(values: { front: string; back: string }) {
     if (!currentId) return;
@@ -49,7 +92,15 @@ export default function CardsNewClient({
           input: { cardgroupId: currentId, front: values.front, back: values.back },
         },
       });
-      router.push(`/cardgroups/${currentId}/cards`);
+      // Fire-and-forget: this is the 4-priority-chain hint for the next visit
+      // and must not block or fail the create flow. No `await` so a slow or
+      // erroring persist call cannot delay the form reset.
+      void setLastViewed({ variables: { cardgroupId: currentId } }).catch((err) => {
+        console.warn("[cards-new] setLastViewedCardgroup failed", { cardgroupId: currentId, err });
+      });
+      resetFormRef.current?.();
+      setLastAddedName(currentName);
+      setSuccessKey(Date.now());
     } catch (err) {
       console.error("[cards-new-client] create card rejection", err);
     }
@@ -73,6 +124,14 @@ export default function CardsNewClient({
         onSelect={handlePickerSelect}
       />
 
+      {successKey !== null && lastAddedName && (
+        <SuccessIndicator
+          key={successKey}
+          message={`✓ Card added to "${lastAddedName}"`}
+          onTimeout={() => setSuccessKey(null)}
+        />
+      )}
+
       {currentId != null ? (
         <CardForm
           mode="create"
@@ -82,9 +141,23 @@ export default function CardsNewClient({
           submitLabel="Add card"
           submitting={creating}
           error={createError}
+          onResetReady={(fn) => {
+            resetFormRef.current = fn;
+          }}
         />
       ) : (
         <p className="text-sm text-muted-foreground">Select a cardgroup above to add a card.</p>
+      )}
+
+      {currentId != null && (
+        <div className="flex justify-end pt-4 border-t">
+          <Link
+            href={`/cardgroups/${currentId}/cards`}
+            className="text-sm text-muted-foreground hover:underline"
+          >
+            Done
+          </Link>
+        </div>
       )}
     </div>
   );

--- a/frontend/src/app/cards/new/cards-new-client.tsx
+++ b/frontend/src/app/cards/new/cards-new-client.tsx
@@ -4,8 +4,8 @@ import { useMutation } from "@apollo/client/react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { SetLastViewedCardgroupMutation } from "@/app/learn/queries";
 import { CreateCardMutation } from "@/app/cardgroups/queries";
+import { SetLastViewedCardgroupMutation } from "@/app/learn/queries";
 import { CardForm } from "@/components/cardgroups/card-form";
 import { CardgroupChip } from "@/components/cardgroups/cardgroup-chip";
 import CardgroupPickerSheet from "@/components/cardgroups/cardgroup-picker-sheet";
@@ -30,13 +30,7 @@ type Props = {
  * consecutive adds remount this component and restart the timer instead of
  * silently extending the previous one.
  */
-function SuccessIndicator({
-  message,
-  onTimeout,
-}: {
-  message: string;
-  onTimeout: () => void;
-}) {
+function SuccessIndicator({ message, onTimeout }: { message: string; onTimeout: () => void }) {
   useEffect(() => {
     const t = setTimeout(onTimeout, 2000);
     return () => clearTimeout(t);
@@ -65,7 +59,6 @@ export default function CardsNewClient({
   const urlCardgroupId = searchParams.get("cardgroup");
   const currentId = urlCardgroupId ?? initialCardgroupId;
 
-  // Derive the display name from the server-seeded list.
   const currentName =
     currentId != null ? (myCardgroups.find((cg) => cg.id === currentId)?.name ?? null) : null;
 
@@ -76,7 +69,6 @@ export default function CardsNewClient({
   // optimistic writes on typed errors — see .claude/rules/pagination.md.
   const [setLastViewed] = useMutation(SetLastViewedCardgroupMutation);
 
-  // Form-reset callback handed up by <CardForm> via onResetReady.
   const resetFormRef = useRef<(() => void) | null>(null);
   // `successKey` doubles as "is the indicator visible?" (null = hidden) and as
   // a remount key — bumping it on each successful submit forces SuccessIndicator

--- a/frontend/src/app/login/login-button.tsx
+++ b/frontend/src/app/login/login-button.tsx
@@ -3,6 +3,32 @@
 import { Button } from "@/components/ui/button";
 import { createSupabaseBrowserClient } from "@/lib/supabase/client";
 
+// Official Google "G" mark. Per Google's branding guidelines
+// (https://developers.google.com/identity/branding-guidelines) the multicolor
+// fills must not be modified — do not replace with currentColor or a tint.
+function GoogleGLogo() {
+  return (
+    <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+      <path
+        d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
+        fill="#4285F4"
+      />
+      <path
+        d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+        fill="#34A853"
+      />
+      <path
+        d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+        fill="#FBBC05"
+      />
+      <path
+        d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+        fill="#EA4335"
+      />
+    </svg>
+  );
+}
+
 export function LoginButton() {
   async function handleSignIn() {
     const supabase = createSupabaseBrowserClient();
@@ -19,6 +45,7 @@ export function LoginButton() {
 
   return (
     <Button onClick={handleSignIn} type="button">
+      <GoogleGLogo />
       Continue with Google
     </Button>
   );

--- a/frontend/src/components/cardgroups/card-form.tsx
+++ b/frontend/src/components/cardgroups/card-form.tsx
@@ -121,7 +121,7 @@ export function CardForm({
       </form.Field>
 
       <div className="flex items-center gap-2">
-        <Button type="submit" disabled={submitting}>
+        <Button type="submit" variant="brand" disabled={submitting}>
           {submitting ? "Saving..." : resolvedLabel}
         </Button>
         {onCancel && (

--- a/frontend/src/components/cardgroups/card-form.tsx
+++ b/frontend/src/components/cardgroups/card-form.tsx
@@ -3,7 +3,7 @@
 // cardgroupId injection happens in the parent's submit callback, not inside this component.
 
 import { useForm } from "@tanstack/react-form";
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -23,6 +23,13 @@ export type CardFormProps = {
   submitting?: boolean;
   error?: unknown;
   onCancel?: () => void;
+  /**
+   * Optional callback invoked once after mount with a function the parent can
+   * call to reset the form to empty values. Used by stay-on-page consecutive-add
+   * flows (e.g. /cards/new) where the parent owns "submit succeeded → clear inputs"
+   * and never unmounts the form between submissions.
+   */
+  onResetReady?: (resetFn: () => void) => void;
 };
 
 export function CardForm({
@@ -34,6 +41,7 @@ export function CardForm({
   submitting = false,
   error,
   onCancel,
+  onResetReady,
 }: CardFormProps) {
   const resolvedLabel = submitLabel ?? (mode === "create" ? "Add" : "Save");
   const schema = mode === "create" ? newCardSchema.omit({ cardgroupId: true }) : updateCardSchema;
@@ -51,6 +59,13 @@ export function CardForm({
       });
     },
   });
+
+  // Hand the parent a stable resetter so it can clear the form after a successful
+  // submit without unmounting. The dependency on `onResetReady` keeps the wiring
+  // up to date if the parent ever swaps callback identity.
+  useEffect(() => {
+    onResetReady?.(() => form.reset({ front: "", back: "" }));
+  }, [form, onResetReady]);
 
   return (
     <form

--- a/frontend/src/components/cardgroups/cardgroup-picker-sheet.test.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-picker-sheet.test.tsx
@@ -159,6 +159,85 @@ describe("<CardgroupPickerSheet>", () => {
     expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
   });
 
+  // S12: clicking Retry triggers a refetch — error UI replaced by loaded list.
+  it("clicking Retry triggers a refetch and shows the cardgroup list on success", async () => {
+    const user = userEvent.setup();
+
+    // Two mock entries for the same query: first errors, second succeeds.
+    // MockedProvider consumes entries in order; the refetch consumes the second.
+    const retryMocks: MockedResponse[] = [
+      {
+        request: { query: MyCardgroupsDocument },
+        error: new Error("network failure"),
+      },
+      {
+        request: { query: MyCardgroupsDocument },
+        result: { data: { myCardgroups: [CG_1, CG_2] } },
+      },
+    ];
+
+    renderSheet({ mocks: retryMocks });
+
+    // Wait for the error state to appear.
+    expect(await screen.findByText(/failed to load cardgroups/i)).toBeInTheDocument();
+
+    const retryButton = screen.getByRole("button", { name: /retry/i });
+
+    // Click Retry — this fires refetch(), consuming the second mock.
+    await user.click(retryButton);
+
+    // After the refetch resolves, the cardgroup list must be rendered.
+    expect(await screen.findByText("Spanish Vocab")).toBeInTheDocument();
+    expect(screen.getByText("Japanese Kanji")).toBeInTheDocument();
+  });
+
+  // S13: Retry that fails again warns once — rejection is caught and logged.
+  it("S13: Retry that fails again warns once", async () => {
+    const user = userEvent.setup();
+
+    // Two mock entries that both error: initial load fails, refetch also fails.
+    const doubleErrorMocks: MockedResponse[] = [
+      {
+        request: { query: MyCardgroupsDocument },
+        error: new Error("network failure"),
+      },
+      {
+        request: { query: MyCardgroupsDocument },
+        error: new Error("still down"),
+      },
+    ];
+
+    // Outer spy layered AFTER the leak spy (LIFO restore: outer first, then leak).
+    // No mockImplementation — calls flow through to the leak spy.
+    const consoleWarnSpy = vi.spyOn(console, "warn");
+
+    try {
+      renderSheet({ mocks: doubleErrorMocks });
+
+      // Wait for the initial error state.
+      expect(await screen.findByText(/failed to load cardgroups/i)).toBeInTheDocument();
+
+      // Click Retry — refetch fires and also errors.
+      await user.click(screen.getByRole("button", { name: /retry/i }));
+
+      // The .catch handler must have logged a warn with our scope tag.
+      await waitFor(() => {
+        expect(consoleWarnSpy).toHaveBeenCalledWith(
+          "[cardgroup-picker-sheet] refetch failed",
+          expect.objectContaining({
+            message: expect.any(String),
+          }),
+        );
+      });
+
+      // Error UI is still visible after the second failure.
+      expect(screen.getByText(/failed to load cardgroups/i)).toBeInTheDocument();
+    } finally {
+      // Restore outer spy first (LIFO), then leak spy teardown happens in afterEach.
+      consoleWarnSpy.mockRestore();
+    }
+  });
+
   // S4: success state renders the list of cardgroup names.
   it("renders all cardgroup names on successful load", async () => {
     renderSheet({ mocks: baseMocks([CG_1, CG_2, CG_3]) });

--- a/frontend/src/components/cardgroups/cardgroup-picker-sheet.test.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-picker-sheet.test.tsx
@@ -73,12 +73,14 @@ type SheetProps = {
   open?: boolean;
   selectedId?: string | null;
   mocks?: MockedResponse[];
+  createReturnTo?: string;
 };
 
 function renderSheet({
   open = true,
   selectedId = null,
   mocks = baseMocks([CG_1, CG_2]),
+  createReturnTo = "/cards/new",
 }: SheetProps = {}) {
   const onOpenChange = vi.fn();
   const onSelect = vi.fn();
@@ -90,6 +92,7 @@ function renderSheet({
         onOpenChange={onOpenChange}
         selectedId={selectedId}
         onSelect={onSelect}
+        createReturnTo={createReturnTo}
       />
     </MockedProvider>,
   );
@@ -195,14 +198,14 @@ describe("<CardgroupPickerSheet>", () => {
     expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 
-  // S7: empty state — no cardgroups shows empty message and a link to /cardgroups/new.
-  it("shows empty-state copy and a link to /cardgroups/new when myCardgroups is empty", async () => {
+  // S7: empty state — no cardgroups shows friendly text; the standalone CTA is gone.
+  it("shows empty-state copy and the inline create link when myCardgroups is empty", async () => {
     renderSheet({ mocks: baseMocks([]) });
 
     expect(await screen.findByText(/don't have any cardgroups yet/i)).toBeInTheDocument();
 
-    const link = screen.getByRole("link", { name: /create cardgroup/i });
-    expect(link).toHaveAttribute("href", "/cardgroups/new");
+    // The inline "Create new cardgroup…" link must also be present.
+    expect(screen.getByRole("link", { name: /create new cardgroup/i })).toBeInTheDocument();
   });
 
   // S8: sheet title is rendered (accessibility sanity check for aria-labelledby).
@@ -213,5 +216,41 @@ describe("<CardgroupPickerSheet>", () => {
     await waitFor(() => {
       expect(screen.getByText("Select cardgroup")).toBeInTheDocument();
     });
+  });
+
+  // S9: "Create new cardgroup…" link is present even when there are existing cardgroups.
+  it("shows the inline create link when myCardgroups is non-empty", async () => {
+    renderSheet({ mocks: baseMocks([CG_1, CG_2]) });
+
+    await screen.findByText("Spanish Vocab");
+
+    expect(screen.getByRole("link", { name: /create new cardgroup/i })).toBeInTheDocument();
+  });
+
+  // S10: the inline create link's href encodes createReturnTo as the returnTo query parameter.
+  it("builds the create link href with the encoded createReturnTo value", async () => {
+    renderSheet({ mocks: baseMocks([CG_1]), createReturnTo: "/cards/new" });
+
+    await screen.findByText("Spanish Vocab");
+
+    const link = screen.getByRole("link", { name: /create new cardgroup/i });
+    expect(link).toHaveAttribute(
+      "href",
+      `/cardgroups/new?returnTo=${encodeURIComponent("/cards/new")}`,
+    );
+    // Explicit suffix check per spec: createReturnTo="/cards/new" → %2Fcards%2Fnew
+    expect(link.getAttribute("href")).toContain("%2Fcards%2Fnew");
+  });
+
+  // S11: clicking the inline create link calls onOpenChange(false).
+  it("calls onOpenChange(false) when the inline create link is clicked", async () => {
+    const user = userEvent.setup();
+    const { onOpenChange } = renderSheet({ mocks: baseMocks([CG_1]) });
+
+    await screen.findByText("Spanish Vocab");
+
+    await user.click(screen.getByRole("link", { name: /create new cardgroup/i }));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 });

--- a/frontend/src/components/cardgroups/cardgroup-picker-sheet.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-picker-sheet.tsx
@@ -19,7 +19,12 @@ type Props = {
   onOpenChange: (open: boolean) => void;
   selectedId?: string | null;
   onSelect: (cardgroupId: string) => void;
-  /** Path to return to after creating a new cardgroup (encoded into the returnTo query). */
+  /**
+   * Path to return to after creating a new cardgroup. Must be a **pre-sanitized
+   * internal path** (e.g. `/cards/new`). The receiving page applies
+   * `sanitizeReturnTo` defensively, but callers are responsible for not passing
+   * arbitrary user input here.
+   */
   createReturnTo: string;
 };
 
@@ -68,7 +73,18 @@ export default function CardgroupPickerSheet({
         {!loading && error && (
           <div className="flex flex-col items-center gap-3 py-6 text-center">
             <p className="text-sm text-destructive">Failed to load cardgroups</p>
-            <Button variant="outline" size="sm" onClick={() => void refetch()}>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => {
+                refetch().catch((err) => {
+                  console.warn("[cardgroup-picker-sheet] refetch failed", {
+                    message: err instanceof Error ? err.message : String(err),
+                    err,
+                  });
+                });
+              }}
+            >
               Retry
             </Button>
           </div>

--- a/frontend/src/components/cardgroups/cardgroup-picker-sheet.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-picker-sheet.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useQuery } from "@apollo/client/react";
-import { Check } from "lucide-react";
+import { Check, Plus } from "lucide-react";
 import Link from "next/link";
 import { MyCardgroupsQuery } from "@/app/cardgroups/queries";
 import { Button } from "@/components/ui/button";
@@ -19,6 +19,8 @@ type Props = {
   onOpenChange: (open: boolean) => void;
   selectedId?: string | null;
   onSelect: (cardgroupId: string) => void;
+  /** Path to return to after creating a new cardgroup (encoded into the returnTo query). */
+  createReturnTo: string;
 };
 
 /**
@@ -36,6 +38,7 @@ export default function CardgroupPickerSheet({
   onOpenChange,
   selectedId,
   onSelect,
+  createReturnTo,
 }: Props): React.ReactElement {
   const { data, loading, error, refetch } = useQuery(MyCardgroupsQuery, {
     skip: !open,
@@ -71,53 +74,57 @@ export default function CardgroupPickerSheet({
           </div>
         )}
 
-        {!loading &&
-          !error &&
-          data &&
-          (data.myCardgroups.length === 0 ? (
-            <div className="flex flex-col items-center gap-3 py-6 text-center">
-              <p className="text-sm text-muted-foreground">
+        {!loading && !error && data && (
+          <>
+            {data.myCardgroups.length === 0 ? (
+              <p className="py-6 text-center text-sm text-muted-foreground">
                 You don&apos;t have any cardgroups yet.
               </p>
+            ) : (
+              <ul className="space-y-1">
+                {data.myCardgroups.map((cg) => {
+                  const isSelected = cg.id === selectedId;
+                  return (
+                    <li key={cg.id}>
+                      <button
+                        type="button"
+                        onClick={() => handleSelect(cg.id)}
+                        className={cn(
+                          "flex w-full items-center justify-between rounded-md px-3 py-3 text-left text-sm",
+                          "transition-colors hover:bg-accent hover:text-accent-foreground",
+                          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+                          isSelected && "font-medium",
+                        )}
+                        aria-pressed={isSelected}
+                      >
+                        <span className="truncate">{cg.name}</span>
+                        {isSelected && (
+                          <Check
+                            size={16}
+                            className="ml-2 flex-shrink-0 text-primary"
+                            aria-hidden="true"
+                          />
+                        )}
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+
+            {/* Inline create link — always visible when data is loaded */}
+            <div className="mt-3 border-t pt-3">
               <Link
-                href="/cardgroups/new"
-                className="rounded-md bg-brand-primary px-4 py-2 text-sm font-medium text-brand-primary-foreground hover:opacity-90 transition-opacity"
+                href={`/cardgroups/new?returnTo=${encodeURIComponent(createReturnTo)}`}
                 onClick={() => onOpenChange(false)}
+                className="flex w-full items-center gap-2 rounded-md px-3 py-3 text-sm text-brand-primary hover:bg-accent transition-colors"
               >
-                Create cardgroup
+                <Plus className="h-4 w-4" aria-hidden="true" />
+                Create new cardgroup…
               </Link>
             </div>
-          ) : (
-            <ul className="space-y-1">
-              {data.myCardgroups.map((cg) => {
-                const isSelected = cg.id === selectedId;
-                return (
-                  <li key={cg.id}>
-                    <button
-                      type="button"
-                      onClick={() => handleSelect(cg.id)}
-                      className={cn(
-                        "flex w-full items-center justify-between rounded-md px-3 py-3 text-left text-sm",
-                        "transition-colors hover:bg-accent hover:text-accent-foreground",
-                        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
-                        isSelected && "font-medium",
-                      )}
-                      aria-pressed={isSelected}
-                    >
-                      <span className="truncate">{cg.name}</span>
-                      {isSelected && (
-                        <Check
-                          size={16}
-                          className="ml-2 flex-shrink-0 text-primary"
-                          aria-hidden="true"
-                        />
-                      )}
-                    </button>
-                  </li>
-                );
-              })}
-            </ul>
-          ))}
+          </>
+        )}
       </SheetContent>
     </Sheet>
   );

--- a/frontend/src/components/nav/global-fab.test.tsx
+++ b/frontend/src/components/nav/global-fab.test.tsx
@@ -70,4 +70,11 @@ describe("<GlobalFAB>", () => {
 
     expect(router.push).toHaveBeenCalledWith("/cards/new");
   });
+
+  it("wraps the button in an md:hidden container so the FAB is hidden at >= md breakpoint", () => {
+    vi.mocked(usePathname).mockReturnValue("/cardgroups");
+    render(<GlobalFAB />);
+    const button = screen.getByRole("button", { name: /add new card/i });
+    expect(button.parentElement).toHaveClass("md:hidden");
+  });
 });

--- a/frontend/src/components/nav/global-fab.tsx
+++ b/frontend/src/components/nav/global-fab.tsx
@@ -16,13 +16,15 @@ export function GlobalFAB() {
   }
 
   return (
-    <button
-      type="button"
-      aria-label="Add new card"
-      onClick={() => router.push("/cards/new")}
-      className="fixed bottom-[calc(env(safe-area-inset-bottom)+1rem)] right-4 z-50 flex h-14 w-14 items-center justify-center rounded-full bg-brand-primary text-brand-primary-foreground shadow-lg"
-    >
-      <Plus className="h-6 w-6" aria-hidden="true" />
-    </button>
+    <div className="md:hidden">
+      <button
+        type="button"
+        aria-label="Add new card"
+        onClick={() => router.push("/cards/new")}
+        className="fixed bottom-[calc(env(safe-area-inset-bottom)+1rem)] right-4 z-50 flex h-14 w-14 items-center justify-center rounded-full bg-brand-primary text-brand-primary-foreground shadow-lg"
+      >
+        <Plus className="h-6 w-6" aria-hidden="true" />
+      </button>
+    </div>
   );
 }

--- a/frontend/src/components/nav/global-header.test.tsx
+++ b/frontend/src/components/nav/global-header.test.tsx
@@ -50,6 +50,15 @@ vi.mock("./header-add-card-link", () => ({
   ),
 }));
 
+// HeaderSignInLink is "use client" and uses usePathname for the same reason.
+vi.mock("./header-sign-in-link", () => ({
+  HeaderSignInLink: ({ className }: { className?: string }) => (
+    <a href="/login" className={className} data-testid="header-sign-in-link">
+      Sign in
+    </a>
+  ),
+}));
+
 // AdminPill default export
 vi.mock("./admin-pill", () => ({
   default: () => (

--- a/frontend/src/components/nav/global-header.test.tsx
+++ b/frontend/src/components/nav/global-header.test.tsx
@@ -40,6 +40,16 @@ vi.mock("./hamburger-drawer", () => ({
   ),
 }));
 
+// HeaderAddCardLink is "use client" and uses usePathname — mock it so the
+// RSC test does not need next/navigation to be fully set up.
+vi.mock("./header-add-card-link", () => ({
+  HeaderAddCardLink: () => (
+    <a href="/cards/new" data-testid="header-add-card-link">
+      Card
+    </a>
+  ),
+}));
+
 // AdminPill default export
 vi.mock("./admin-pill", () => ({
   default: () => (

--- a/frontend/src/components/nav/global-header.tsx
+++ b/frontend/src/components/nav/global-header.tsx
@@ -1,4 +1,4 @@
-import { BookOpen, Plus } from "lucide-react";
+import { BookOpen } from "lucide-react";
 import Link from "next/link";
 import { LogoutButton } from "@/app/_components/logout-button";
 import { HeaderMeQuery } from "@/app/_components/queries";
@@ -7,6 +7,7 @@ import { gqlFetch } from "@/lib/apollo/server";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 import AdminPill from "./admin-pill";
 import { HamburgerDrawer } from "./hamburger-drawer";
+import { HeaderAddCardLink } from "./header-add-card-link";
 
 export async function GlobalHeader() {
   const supabase = await createSupabaseServerClient();
@@ -88,13 +89,7 @@ export async function GlobalHeader() {
                 Cardgroups
               </Link>
 
-              <Link
-                href="/cards/new"
-                className="flex items-center gap-1.5 rounded-md bg-brand-primary px-3 py-1.5 text-sm font-medium text-brand-primary-foreground hover:opacity-90 transition-opacity"
-              >
-                <Plus className="h-4 w-4" aria-hidden="true" />
-                Card
-              </Link>
+              <HeaderAddCardLink />
             </nav>
 
             <div className="flex items-center gap-3 text-sm ml-auto">

--- a/frontend/src/components/nav/global-header.tsx
+++ b/frontend/src/components/nav/global-header.tsx
@@ -8,6 +8,7 @@ import { createSupabaseServerClient } from "@/lib/supabase/server";
 import AdminPill from "./admin-pill";
 import { HamburgerDrawer } from "./hamburger-drawer";
 import { HeaderAddCardLink } from "./header-add-card-link";
+import { HeaderSignInLink } from "./header-sign-in-link";
 
 export async function GlobalHeader() {
   const supabase = await createSupabaseServerClient();
@@ -66,11 +67,7 @@ export async function GlobalHeader() {
       )}
 
       {/* Mobile: sign-in link when anonymous */}
-      {!user && (
-        <Link href="/login" className="text-sm underline md:hidden">
-          Sign in
-        </Link>
-      )}
+      {!user && <HeaderSignInLink className="text-sm underline md:hidden" />}
 
       {/* ── Desktop layout (≥ md) ─────────────────────────────────── */}
       <div className="hidden md:flex md:items-center md:gap-4 md:w-full">
@@ -105,9 +102,7 @@ export async function GlobalHeader() {
           </>
         ) : (
           <div className="ml-auto">
-            <Link href="/login" className="text-sm underline">
-              Sign in
-            </Link>
+            <HeaderSignInLink className="text-sm underline" />
           </div>
         )}
       </div>

--- a/frontend/src/components/nav/header-add-card-link.test.tsx
+++ b/frontend/src/components/nav/header-add-card-link.test.tsx
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock next/link so it renders a plain <a> in jsdom.
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    ...rest
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { children?: React.ReactNode }) => (
+    <a {...rest}>{children}</a>
+  ),
+}));
+
+// usePathname is mocked per-test via vi.mocked().mockReturnValue.
+const mockUsePathname = vi.fn();
+vi.mock("next/navigation", () => ({
+  usePathname: () => mockUsePathname(),
+}));
+
+import { HeaderAddCardLink } from "./header-add-card-link";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("<HeaderAddCardLink>", () => {
+  describe("when on /cards/new", () => {
+    beforeEach(() => {
+      mockUsePathname.mockReturnValue("/cards/new");
+    });
+
+    it("renders a link to /cards/new", () => {
+      render(<HeaderAddCardLink />);
+      expect(screen.getByRole("link")).toHaveAttribute("href", "/cards/new");
+    });
+
+    it("has aria-current='page'", () => {
+      render(<HeaderAddCardLink />);
+      expect(screen.getByRole("link")).toHaveAttribute("aria-current", "page");
+    });
+
+    it("has pointer-events-none class", () => {
+      render(<HeaderAddCardLink />);
+      expect(screen.getByRole("link")).toHaveClass("pointer-events-none");
+    });
+
+    it("has opacity-60 class", () => {
+      render(<HeaderAddCardLink />);
+      expect(screen.getByRole("link")).toHaveClass("opacity-60");
+    });
+
+    it("does not have hover:opacity-90 class", () => {
+      render(<HeaderAddCardLink />);
+      expect(screen.getByRole("link")).not.toHaveClass("hover:opacity-90");
+    });
+  });
+
+  describe("when on a different path", () => {
+    beforeEach(() => {
+      mockUsePathname.mockReturnValue("/cardgroups");
+    });
+
+    it("renders a link to /cards/new", () => {
+      render(<HeaderAddCardLink />);
+      expect(screen.getByRole("link")).toHaveAttribute("href", "/cards/new");
+    });
+
+    it("does not have aria-current attribute", () => {
+      render(<HeaderAddCardLink />);
+      expect(screen.getByRole("link")).not.toHaveAttribute("aria-current");
+    });
+
+    it("does not have pointer-events-none class", () => {
+      render(<HeaderAddCardLink />);
+      expect(screen.getByRole("link")).not.toHaveClass("pointer-events-none");
+    });
+
+    it("does not have opacity-60 class", () => {
+      render(<HeaderAddCardLink />);
+      expect(screen.getByRole("link")).not.toHaveClass("opacity-60");
+    });
+
+    it("has hover:opacity-90 class", () => {
+      render(<HeaderAddCardLink />);
+      expect(screen.getByRole("link")).toHaveClass("hover:opacity-90");
+    });
+  });
+});

--- a/frontend/src/components/nav/header-add-card-link.tsx
+++ b/frontend/src/components/nav/header-add-card-link.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { Plus } from "lucide-react";
+
+export function HeaderAddCardLink() {
+  const pathname = usePathname();
+  const onCardsNew = pathname === "/cards/new";
+  return (
+    <Link
+      href="/cards/new"
+      aria-current={onCardsNew ? "page" : undefined}
+      className={`flex items-center gap-1.5 rounded-md bg-brand-primary px-3 py-1.5 text-sm font-medium text-brand-primary-foreground transition-opacity ${
+        onCardsNew ? "pointer-events-none opacity-60" : "hover:opacity-90"
+      }`}
+    >
+      <Plus className="h-4 w-4" aria-hidden="true" />
+      Card
+    </Link>
+  );
+}

--- a/frontend/src/components/nav/header-add-card-link.tsx
+++ b/frontend/src/components/nav/header-add-card-link.tsx
@@ -1,8 +1,8 @@
 "use client";
 
+import { Plus } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { Plus } from "lucide-react";
 
 export function HeaderAddCardLink() {
   const pathname = usePathname();

--- a/frontend/src/components/nav/header-sign-in-link.test.tsx
+++ b/frontend/src/components/nav/header-sign-in-link.test.tsx
@@ -1,0 +1,57 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    ...rest
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { children?: React.ReactNode }) => (
+    <a {...rest}>{children}</a>
+  ),
+}));
+
+const mockUsePathname = vi.fn();
+vi.mock("next/navigation", () => ({
+  usePathname: () => mockUsePathname(),
+}));
+
+import { HeaderSignInLink } from "./header-sign-in-link";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("<HeaderSignInLink>", () => {
+  describe("when on /login", () => {
+    beforeEach(() => {
+      mockUsePathname.mockReturnValue("/login");
+    });
+
+    it("renders nothing", () => {
+      const { container } = render(<HeaderSignInLink className="foo" />);
+      expect(container.firstChild).toBeNull();
+      expect(screen.queryByRole("link")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("when on another path", () => {
+    beforeEach(() => {
+      mockUsePathname.mockReturnValue("/cardgroups");
+    });
+
+    it("renders a link to /login", () => {
+      render(<HeaderSignInLink />);
+      expect(screen.getByRole("link", { name: /sign in/i })).toHaveAttribute("href", "/login");
+    });
+
+    it("forwards className to the link", () => {
+      render(<HeaderSignInLink className="text-sm underline md:hidden" />);
+      expect(screen.getByRole("link", { name: /sign in/i })).toHaveClass(
+        "text-sm",
+        "underline",
+        "md:hidden",
+      );
+    });
+  });
+});

--- a/frontend/src/components/nav/header-sign-in-link.tsx
+++ b/frontend/src/components/nav/header-sign-in-link.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+type Props = { className?: string };
+
+// Suppresses itself on /login so the header does not render a self-referential
+// "Sign in" link while the user is already on the sign-in page.
+export function HeaderSignInLink({ className }: Props) {
+  const pathname = usePathname();
+  if (pathname === "/login") return null;
+  return (
+    <Link href="/login" className={className}>
+      Sign in
+    </Link>
+  );
+}


### PR DESCRIPTION
## Summary

Replaces the "submit → navigate to `/cardgroups/<id>/cards`" pattern at `/cards/new` with a stay-on-page consecutive-add flow: the form clears in place, a transient success banner announces each addition, and an explicit `Done` link is the only navigation-out affordance. The desktop header `+ Card` CTA is extracted into a client component that marks itself as the current page (`aria-current="page"` plus `pointer-events-none opacity-60`) when the user is already on `/cards/new`, and the mobile floating-action button is wrapped in `md:hidden` so the two affordances are mutually exclusive by Tailwind class — eliminating the duplicate add-card target at `>= md` without a `useMediaQuery` hydration flash.

## Background / Motivation

- **Adding several cards in a row required N round-trips through `/cardgroups/<id>/cards`.** The previous flow at `/cards/new` redirected immediately after a successful create, and re-navigating back through the FAB / header CTA reset the cardgroup chip to the last-viewed default. A user adding five cards generated five history entries on the destination page and five round-trips through the cardgroup pre-selection logic.
- **The desktop header and the mobile FAB rendered the same `+ Card` CTA at the same time on `>= md`.** Two affordances pointing at `/cards/new`, both visible, both clickable — the FAB partially overlapped the form on small desktop windows and the visual hierarchy implied two distinct actions. There was no breakpoint coordination between the header `+ Card` link in `global-header.tsx` and the floating button in `global-fab.tsx`.
- **The header `+ Card` link stayed clickable while the user was on `/cards/new`.** Tapping it triggered a no-op route push that reset the cardgroup chip pre-selection to the last-viewed default and discarded any in-progress form input. There was no visual or screen-reader cue that the link was the current page.
- **`onSubmit` → `form.reset()` requires the parent to own the form's lifecycle**, but `useForm()` must live inside the form component because field validators close over its identity. `forwardRef + useImperativeHandle` would pull every form consumer into the ref dance; a callback-inversion pattern (`onResetReady?: (resetFn) => void`) keeps the wiring trivial and testable.
- **Codecov badges rendered orange-yellow even when backend coverage was well above 70%.** The previous `img.shields.io/codecov/c/...` proxy URL ignored Codecov's per-project range; Codecov's native badge URL honors `coverage.range` in `codecov.yml`, which now declares `"50...70"` (red below 50, yellow 50–70, green at 70+).
- **The README listed no required external service accounts.** A new contributor following Quick Start hit `make setup-prod` without the three SaaS dependencies provisioned. The pre-conditions section names Supabase / Render / Vercel up-front and clarifies that local `make setup` requires none of them.

## Changes

### Stay-on-page consecutive add at `/cards/new`

- `frontend/src/app/cards/new/cards-new-client.tsx`:
  - Remove the post-success `router.push(...)`. Submit now clears the form, fires `setLastViewedCardgroup` as fire-and-forget (no `await`, no `optimisticResponse` — the mutation can return typed `BAD_USER_INPUT` and Apollo v3.x does not roll back optimistic writes on typed errors, see `.claude/rules/pagination.md`), and bumps a `successKey` state to force the banner to remount.
  - New `SuccessIndicator` sub-component — `useEffect` self-dismiss after 2000 ms; the parent assigns `key={successKey}` so two rapid submits get two independent 2 s windows instead of the second submit silently extending the first's timer.
  - New `Done` link at the bottom of the form pointing at `/cardgroups/<currentId>/cards` — the single navigation-out affordance, preserved so the user can leave the consecutive-add flow when ready.
  - `useCallback` wrappers around `handleResetReady` and `handleSuccessTimeout` so child `useEffect` dependency arrays do not re-fire on every parent re-render (e.g. when the fire-and-forget `setLastViewedCardgroup` mutation settles). The pre-`useCallback` shape silently broke the success banner's 2 s timer because every parent re-render restarted it on the next animation frame.
- `frontend/src/components/cardgroups/card-form.tsx`:
  - New optional `onResetReady?: (resetFn: () => void) => void` prop. A `useEffect(() => onResetReady?.(() => form.reset({...})), [form, onResetReady])` once after mount hands the parent a closure over the live `form` instance. The parent stores it in `useRef<(() => void) | null>` and invokes it from its submit handler — `useForm` lifecycle stays inside the child, no ref-and-imperative-handle dance.

### Breakpoint-exclusive add-card CTA

- `frontend/src/components/nav/global-fab.tsx`: wrap the existing `<button>` in `<div className="md:hidden">`. The FAB now renders only at `< md`. The decision is made by Tailwind / CSS — no `useMediaQuery` hook — so SSR and CSR produce identical markup and there is no hydration flash where both the header CTA and the FAB are briefly visible.
- `frontend/src/components/nav/global-header.tsx`: replace the inline `<Link href="/cards/new">...+ Card</Link>` with `<HeaderAddCardLink />`. The header itself stays an RSC; only the new client component touches `usePathname`.
- `frontend/src/components/nav/header-add-card-link.tsx` (new): client component that reads `usePathname()`. When `pathname === "/cards/new"`, the rendered `<Link>` carries `aria-current="page"` plus `pointer-events-none opacity-60` so it is screen-reader-correctly marked as the current page and visually subdued + unclickable. The `hover:opacity-90` variant is dropped on the same branch — a hover-color flash on a non-interactive element is dishonest.

### Codecov badges and README pre-conditions

- `codecov.yml`: add `coverage.range: "50...70"` so the native Codecov badge applies the red → yellow → green gradient with green starting at 70 %.
- `README.md`:
  - Swap both badge URLs from `img.shields.io/codecov/c/...?flag=...` (a proxy that ignores `codecov.yml`) to `codecov.io/.../graph/badge.svg?flag=...` (honors `coverage.range`).
  - Add a `## Pre-conditions` section listing Supabase / Render / Vercel as required service accounts for `make setup-prod`, with a note that local `make setup` requires none of them.

### Tests

- `frontend/src/app/cards/new/cards-new-client.test.tsx` (new, ~428 lines): covers the consecutive-add happy path (form clears, banner renders, banner self-dismisses), the regression-guard `expect(mockPush).not.toHaveBeenCalled()` (without the inverse assertion, a refactor that re-introduces `router.push` would silently break the UX while passing happy-path tests), the two-rapid-submits / two-independent-timers behavior (verified via `key`-based remount), the fire-and-forget `setLastViewedCardgroup` failure case (`console.warn` fires but the create still succeeds), and the Apollo mock leak-spy interaction (no `mockImplementation(() => {})` on the outer `console.warn` spy — see the spy-stacking entry in `.claude/rules/pagination.md`).
- `frontend/src/components/nav/header-add-card-link.test.tsx` (new, ~89 lines): both branches of the `pathname === "/cards/new"` check — `aria-current="page"` + `pointer-events-none opacity-60` on `/cards/new`, plain hover-enabled link elsewhere.
- `frontend/src/components/nav/global-fab.test.tsx`: assert the rendered button is wrapped by `md:hidden` (regression guard for accidental removal).
- `frontend/src/components/nav/global-header.test.tsx`: assert the header now renders `HeaderAddCardLink` rather than its previous inline shape.

### Documentation

- `docs/frontend.md` (`+37` lines):
  - **"Stay-on-page consecutive add"** — three-piece composition (no router push, key-based indicator remount, regression-guard inverse assertion).
  - **"`onResetReady?: (resetFn: () => void) => void` — callback inversion"** — the form-reset wiring pattern in `card-form.tsx`.
  - **"Stable callback identity for child effect deps"** — the `useCallback` rule that fixed the success-banner-timer bug.
  - **"Breakpoint-exclusive primary action"** — the `md:hidden` Tailwind-class rule (vs. `useMediaQuery`).
  - **"Current-location CTA — `aria-current="page"` plus disabled styling"** — the `HeaderAddCardLink` reference pattern.
  - **"`vi.useRealTimers()` in `afterEach` is a defensive guard for fake-timer leaks"** — surfaced while writing the success-banner timer tests.
- `.claude/rules/pagination.md` (`+9` lines): **"Spy stacking: install order is outer-first, teardown is LIFO"** — the `installApolloMockLeakSpy` + secondary `vi.spyOn(console, "warn")` interaction that bit `cards-new-client.test.tsx`.

## Verification

After merge, the following should hold in the repo state:

- `grep -n "router.push" frontend/src/app/cards/new/cards-new-client.tsx` returns nothing — the post-success navigation is gone.
- `grep -n "onResetReady" frontend/src/components/cardgroups/card-form.tsx frontend/src/app/cards/new/cards-new-client.tsx` matches both the prop declaration in the form and the parent ref wiring in the page client.
- `grep -n "md:hidden" frontend/src/components/nav/global-fab.tsx` matches the wrapper `<div>`.
- `grep -n "HeaderAddCardLink" frontend/src/components/nav/global-header.tsx frontend/src/components/nav/header-add-card-link.tsx frontend/src/components/nav/header-add-card-link.test.tsx` matches all three files.
- `grep -n 'aria-current="page"' frontend/src/components/nav/header-add-card-link.tsx` matches once.
- `grep -n "range:" codecov.yml` matches `range: "50...70"`.
- `grep -n "Pre-conditions" README.md` matches once; `grep -n "img.shields.io/codecov" README.md` returns nothing (proxy badges replaced by native).

Then on the running dev server (`pnpm --filter frontend dev`):

- Sign in, open `/cards/new` from the mobile FAB on a phone-sized viewport. Submit a card. The page does **not** navigate. The form clears. A green "Card added to <name>" banner appears for 2 s and disappears. Submit again — a second banner appears for a full 2 s independently. After three submits, click `Done` — land on `/cardgroups/<id>/cards` with all three cards visible.
- Resize the viewport to `>= md` (≥768 px). The FAB is no longer rendered; the desktop header `+ Card` link is the only add-card affordance.
- On `/cards/new`, the desktop header `+ Card` link is visually subdued (`opacity-60`), shows no hover state, and clicking does nothing. Inspect element — `aria-current="page"` is present.
- The README badges on `main` render with Codecov's red → yellow → green gradient and turn green when coverage is ≥ 70 %.

## Test plan

- [ ] `cd frontend && pnpm typecheck` exits 0.
- [ ] `cd frontend && pnpm lint` (Biome) exits 0 with no fixes applied.
- [ ] `cd frontend && pnpm test --run` exits 0 (covers the new `cards-new-client.test.tsx` and `header-add-card-link.test.tsx` suites and the touched `global-fab.test.tsx` / `global-header.test.tsx`).
- [ ] Manual: from a `< md` viewport, tap the FAB → land on `/cards/new` → submit a card → form clears, banner appears, no navigation. Submit again within 1 s → second banner appears and runs the full 2 s.
- [ ] Manual: at `>= md` viewport, the FAB is absent; the header `+ Card` is the only add-card affordance.
- [ ] Manual: on `/cards/new` at any viewport, the header `+ Card` link is visually subdued and unclickable; `aria-current="page"` is present in the DOM.
- [ ] Manual: from `/cards/new`, click `Done` → land on `/cardgroups/<id>/cards`.
- [ ] Regression: each successful submit fires exactly one `CreateCard` POST plus one fire-and-forget `setLastViewedCardgroup` POST in the Network tab — no extra round-trip and no rollback churn.
- [ ] Negative: stub `setLastViewedCardgroup` to reject (or return `BAD_USER_INPUT`) — `console.warn("[cards-new] setLastViewedCardgroup failed", ...)` fires but the create still succeeds and the form clears.
- [ ] Visual: `main` README badges render with the red → yellow → green Codecov gradient (green at ≥ 70 %).
- [ ] Language-policy grep clean: `grep -rnP "[\x{3040}-\x{30ff}\x{4e00}-\x{9fff}]" --include="*.tsx" --include="*.ts" --include="*.md" frontend/src docs .claude/rules` returns nothing; `grep -rnE "PR[0-9]+" frontend/src docs .claude/rules` returns nothing.
