### PR TITLE
feat(frontend): context-aware FAB and header CTA via resolveFabAction

### DIFF
--- a/.claude/rules/frontend-typescript-conventions.md
+++ b/.claude/rules/frontend-typescript-conventions.md
@@ -103,3 +103,75 @@ onSubmit: async ({ value }) => {
 **Why:** `_handleSubmit` gates `formState.isSubmitSuccessful` on whether `onSubmit` resolves or rejects. A swallowed rejection makes the form believe the submission succeeded, which can unblock navigation, clear state, or show a success banner while the mutation actually failed.
 
 **How to apply:** every `useForm.onSubmit` that calls an external `submit` prop must re-throw after the catch/log. The re-throw is forward-safe even when the current caller wraps `submit` in its own `try/catch` — the rejection does not bubble past that boundary today. This rule pairs with the `.catch()` rule above; they must land together. Reference: `frontend/src/components/cardgroups/card-form.tsx`.
+
+## Discriminated union over flat DTO when consumers must branch on the variant
+
+A factory whose output has semantically distinct shapes — e.g. "navigate to a cardgroup form", "navigate to a card form with a pre-selected cardgroup id", "navigate to a generic card form" — has two encodings available: (a) a flat DTO with a string `href` plus runtime introspection (`href.startsWith("/cards/new")`), or (b) a discriminated union with a `kind` tag. The flat DTO erases an invariant the factory already knows; the union preserves it.
+
+```ts
+// frontend/src/components/nav/fab-action.ts
+export type FabAction =
+  | { kind: "cardgroup"; href: "/cardgroups/new"; label: "Add new cardgroup" }
+  | { kind: "card-with-group"; href: string; label: "Add new card"; cardgroupId: string }
+  | { kind: "card"; href: "/cards/new"; label: "Add new card" };
+```
+
+**Why:** runtime-introspection (`startsWith`, `includes`, regex on the `href`) rots silently as new variants are added. A future `/cards/new/bulk` action would be silently picked up by `href.startsWith("/cards/new")` and routed through the wrong branch with no compile-time warning. The discriminant check forces every branching consumer to acknowledge the new variant during code review (see also "Positive allowlist over negative exclusion" below).
+
+**How to apply:** when a factory returns one of N semantically distinct shapes AND any consumer needs to branch on which shape was returned, model the output as `{ kind: "..." } & ...` and let consumers narrow on `kind`. Use literal-type fields (`href: "/cardgroups/new"`) where the value is an invariant of the variant — the type system will reject any factory branch that produces a different string. Reference: `frontend/src/components/nav/fab-action.ts` (`FabAction`) consumed by `frontend/src/components/nav/global-fab.tsx` and `frontend/src/components/nav/header-add-card-link.tsx`. This rule generalises the route-handler-specific § "Discriminated-union response shape" in `docs/frontend.md`.
+
+## Positive allowlist over negative exclusion in discriminated-union narrowing
+
+Given a discriminated union with `kind` tags, two narrowing styles are syntactically valid but semantically opposite:
+
+```tsx
+// AVOID: open-ended — every future variant silently passes through.
+const href = action !== null && action.kind !== "cardgroup" ? action.href : "/cards/new";
+
+// PREFER: closed — every future variant must be explicitly added or falls to the default.
+// frontend/src/components/nav/header-add-card-link.tsx
+const href =
+  action !== null && (action.kind === "card-with-group" || action.kind === "card")
+    ? action.href
+    : "/cards/new";
+```
+
+**Why:** extension-by-default is rarely what consumer code intends. A new variant added to the union (e.g. a future `kind: "bulk-card"`) silently slips through the negative-exclusion form because `action.kind !== "cardgroup"` is true for the new variant too. The positive-allowlist form forces the addition to surface as a compile decision: either the new variant belongs in this consumer's allow list (add it) or it does not (the default branch handles it). This is the consumer-side mirror of the type-design analyzer's exhaustiveness pattern.
+
+**How to apply:** any consumer that branches on a discriminated union's `kind` should enumerate the variants it actually wants — never the variants it does not want. The single exception is when the consumer is the type-system-enforced exhaustive switch (e.g. a `never`-defaulted `switch (action.kind)`); there, every variant is named and the compiler enforces totality. Reference: `frontend/src/components/nav/header-add-card-link.tsx` after a review finding that `action.kind !== "cardgroup"` allowed any future variant to be silently treated as a card-form destination.
+
+## `as string` cast on regex captures under `noUncheckedIndexedAccess`
+
+The frontend tsconfig enables `noUncheckedIndexedAccess`, which widens `RegExpExecArray[number]` to `string | undefined`. For a capture group the regex makes mandatory (i.e. the regex cannot match without producing that capture), the soundest pattern is `const id = match[1] as string;` paired with a comment naming the invariant the cast relies on:
+
+```ts
+// frontend/src/components/nav/fab-action.ts
+const cardsMatch = CARDGROUP_CARDS_RE.exec(pathname);
+if (cardsMatch) {
+  // cardsMatch[1] is always defined when the regex matched (capture group 1 is required)
+  const id = cardsMatch[1] as string;
+  return { kind: "card-with-group", href: `/cards/new?cardgroup=${id}`, /* ... */ };
+}
+```
+
+Avoid `String(match[1] ?? "")` — that turns `undefined` into the literal string `"undefined"`, which silently corrupts downstream URLs. Avoid the bare non-null assertion `match[1]!` because it offers no docstring anchor for the invariant: a future contributor reading `match[1]!` cannot tell whether the assertion is sound or a leftover from a refactor.
+
+**Why:** `noUncheckedIndexedAccess` is a project-wide flag that future contributors may not be aware of. Without the comment, the `as string` cast looks superfluous and is a candidate for "cleanup" by anyone reading the code in isolation. The comment names the invariant (capture group N is required by this regex) so the cast survives review.
+
+**How to apply:** for every regex-capture access where the capture is required by the regex, use `as string` with a one-line comment naming the required capture group. The comment is load-bearing — do not delete it during refactoring. The same pattern applies to other `noUncheckedIndexedAccess`-affected accesses (e.g. `Object.keys(o)[0]`); the rule is "explain the invariant, not just satisfy the compiler." Reference: `frontend/src/components/nav/fab-action.ts` (`cardsMatch[1] as string`, `detailMatch[1] as string`).
+
+## Cross-module constant references in test descriptions are silent-rot coupling
+
+A test description that names a sibling module's constant by its identifier — e.g. `"shadowed by HIDDEN_PATH_RE in global-fab.tsx"` — couples the test to that constant's exact name. A rename of the constant (or its replacement by a different mechanism, e.g. a `Set` lookup or a different regex name) leaves the test description misleading with no compile-time signal. Prefer module-relative wording that names the responsibility, not the symbol:
+
+```ts
+// AVOID: rots the moment the constant is renamed.
+describe("is shadowed externally by HIDDEN_PATH_RE in global-fab.tsx", () => { ... });
+
+// PREFER: frontend/src/components/nav/fab-action.test.ts
+describe("is shadowed externally by GlobalFAB's hidden-path guard for /cardgroups/new", () => { ... });
+```
+
+**Why:** linters do not check English prose. A `grep` for the renamed constant will not find the stale test description; reviewers checking the test diff against the production diff will not flag a description that still reads naturally. The misalignment is invisible until a future reader is confused enough to investigate.
+
+**How to apply:** when a test description must reference a sibling module's behaviour, name the **module's responsibility** (e.g. "GlobalFAB's hidden-path guard") rather than the **constant's identifier** (e.g. `HIDDEN_PATH_RE`). The same rule extends to source comments that justify a piece of code by referencing a sibling module. Reference: `frontend/src/components/nav/fab-action.test.ts` and `frontend/src/components/nav/header-add-card-link.test.tsx` after a review finding that referring to `HIDDEN_PATH_RE` by name in test prose would rot the moment the constant was replaced.

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -191,6 +191,17 @@ When two surfaces would render the same primary CTA at the same time (here: the 
 
 When a primary CTA's destination is the page the user is already on, do not hide it (the layout would jump and the user loses orientation) and do not disable it as a `<button>` (it is a `<Link>`, not a button). Apply `aria-current="page"` for screen-reader semantics and pair with `pointer-events-none opacity-60` to make the same `<Link>` visually subdued and unclickable. Drop the hover variant on the same branch — a hover-color flash on a non-interactive element is dishonest. `HeaderAddCardLink` is the reference implementation.
 
+#### Two-layer hide pattern: static-path regex + dynamic-segment helper
+
+The FAB's "do not show this control" rule has two distinct flavours: (a) static path patterns where the decision depends only on the literal pathname (`/login`, `/learn/*`, `/admin/*`, `/cards/new`, `/cardgroups/new`, `/profile`), and (b) dynamic-segment patterns where the decision depends on parsing the segment (`/cardgroups/<id>/edit` — the FAB has nothing meaningful to add on an edit form). Encoding both in one regex makes the regex grow monotonically with every new edit-shaped path; encoding both in `resolveFabAction` mixes "what should the FAB do here" with "should the FAB exist here". The cleaner split is:
+
+- `HIDDEN_PATH_RE` in `frontend/src/components/nav/global-fab.tsx` — static-path allowlist of *paths to hide* (regex over the literal pathname).
+- `resolveFabAction(pathname)` in `frontend/src/components/nav/fab-action.ts` — returns `null` for dynamic patterns where no FAB action makes sense (today: the cardgroup-edit shape).
+
+`GlobalFAB` short-circuits on `HIDDEN_PATH_RE.test(pathname)` first, then on `resolveFabAction(pathname) === null`.
+
+**Cross-layer interaction must be tested explicitly.** A path that is suppressed by ONE layer but produces a non-null/non-suppressed value at the OTHER layer is the failure mode this split introduces. Today's example: `/cardgroups/new` is hidden by `HIDDEN_PATH_RE` but `resolveFabAction("/cardgroups/new")` returns `{ kind: "card-with-group", cardgroupId: "new" }` — the literal `"new"` is treated as a cardgroup id by `CARDGROUP_DETAIL_RE`. Without an explicit cross-layer test, a future contributor "consolidating" both layers into one might inadvertently expose the FAB on the new-cardgroup form. The test in `frontend/src/components/nav/fab-action.test.ts` (`is shadowed externally by GlobalFAB's hidden-path guard for /cardgroups/new`) documents that responsibility-split — it is the only place the split is explicit; production code looks consistent either way.
+
 ### Cardgroup chip + picker primitives
 
 `CardgroupChip` (client) and `CardgroupPickerSheet` (client) live under `frontend/src/components/cardgroups/`. The chip is a short pill with the current cardgroup name + `ChevronDown`; tapping it opens the picker. The picker is a shadcn `Sheet` rendered with `side="bottom"` on all viewport sizes (the original plan considered a desktop `Dialog` variant via `useMediaQuery`, but a bottom sheet works on both and avoids dragging in a media-query hook just for one component). It is backed by `MyCardgroupsQuery` via `useQuery`. Two consumers exist today: `/cards/new` (chip + form pair, single source of truth in URL) and any future page that needs cardgroup-scoped writes from a non-cardgroup-scoped route.
@@ -240,7 +251,7 @@ const body: HealthzResponse = { ok: true, backend: data.health };
 return NextResponse.json(body);
 ```
 
-The annotation on `body` is load-bearing — `NextResponse.json(...)` is generic over `unknown`, so without the explicit type the compiler accepts any object shape and a refactor that drops `ok` from one branch passes typecheck. Reference: `frontend/src/app/api/healthz/route.ts`.
+The annotation on `body` is load-bearing — `NextResponse.json(...)` is generic over `unknown`, so without the explicit type the compiler accepts any object shape and a refactor that drops `ok` from one branch passes typecheck. Reference: `frontend/src/app/api/healthz/route.ts`. The general "discriminated union over flat DTO" rule (covering factory output beyond Route Handler responses) lives in [`.claude/rules/frontend-typescript-conventions.md` § "Discriminated union over flat DTO when consumers must branch on the variant"](../.claude/rules/frontend-typescript-conventions.md#discriminated-union-over-flat-dto-when-consumers-must-branch-on-the-variant).
 
 ### `/api/healthz` JSON probe
 
@@ -753,3 +764,35 @@ Test code copy-pasted from v3 examples will fail typecheck against v4:
 ### TypeScript strict array indexing in fixtures
 
 With `noUncheckedIndexedAccess` on, `arr[i]` is typed as `T | undefined`, so `cardsFixture[0].front` does not type-check. Resolve at the access site with a non-null assertion plus a Biome-ignore comment justifying the literal-array safety (`cardsFixture[0]!.front`), or shape the fixture as a tuple via `as const` so the type system knows the length statically. The non-null-assertion route is preferred for variable-length fixtures.
+
+### Extract pure logic out of client components for `@vitest-environment node` tests
+
+When a client component contains a pure mapping function — e.g. a pathname → action lookup, a route → label lookup, a state → CSS-class lookup — lifting that function into a sibling module enables testing it under `// @vitest-environment node`. The node environment skips jsdom setup, React mock plumbing, and `next/navigation` mocks; the test runs as a plain function-call assertion against a string input.
+
+```ts
+// frontend/src/components/nav/fab-action.ts — pure helper, no React, no next/navigation imports.
+export function resolveFabAction(pathname: string): FabAction | null { /* ... */ }
+
+// frontend/src/components/nav/fab-action.test.ts
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+import { resolveFabAction } from "./fab-action";
+
+describe("resolveFabAction", () => {
+  it("returns Add new cardgroup href for exact /cardgroups", () => {
+    expect(resolveFabAction("/cardgroups")).toEqual({ kind: "cardgroup", /* ... */ });
+  });
+});
+```
+
+The component then becomes a thin shell that calls the helper:
+
+```tsx
+// frontend/src/components/nav/global-fab.tsx
+const action = resolveFabAction(pathname);
+if (action === null) return null;
+```
+
+**Why:** pure logic + jsdom is wasted overhead — every test pays for the DOM environment to assert a string-in-string-out result. Node tests are faster (no jsdom bootstrap), clearer (no `vi.mock` of `next/navigation`), and the production code gets a forcing function to keep the helper React-free. The same testability-extraction principle is documented for the backend in `.claude/rules/go-library-gotchas.md` § "Extract startup helpers to make branch coverage testable without a live server".
+
+**How to apply:** when a client component's render function or hook callback contains branching logic that depends only on its arguments (not on React state, refs, or router objects), lift that logic into a sibling `.ts` file with no React or Next.js imports, and write its tests under `// @vitest-environment node`. The component imports the helper and calls it. Reference: `frontend/src/components/nav/fab-action.ts` consumed by `global-fab.tsx` and `header-add-card-link.tsx`; the test file `fab-action.test.ts` runs under the node environment while the component tests stay on jsdom.

--- a/frontend/e2e/new-user-onboarding.spec.ts
+++ b/frontend/e2e/new-user-onboarding.spec.ts
@@ -38,7 +38,7 @@ test.describe
       });
     });
 
-    test("welcome page → create cardgroup → FAB → picker → chip pre-select", async ({
+    test("welcome page → create cardgroup → FAB lands on /cards/new with chip pre-selected", async ({
       context,
       page,
     }) => {
@@ -61,35 +61,23 @@ test.describe
       expect(newCardgroupId).toMatch(UUID_RE);
       await expect(page.getByRole("heading", { name: cardgroupName })).toBeVisible();
 
-      // 3. Click the global "+ Card" FAB to open /cards/new.
-      // The FAB renders at the root layout level and is hidden on a few paths
-      // (/learn/*, /admin/*, /cards/new, /cardgroups/new); /cardgroups/<id> is
+      // 3. Click the global "+ Card" FAB. On a /cardgroups/<id> page,
+      // resolveFabAction returns kind: "card-with-group" so the FAB href is
+      // /cards/new?cardgroup=<id> — no picker dialog, the chip is pre-selected
+      // from the URL. The FAB renders at the root layout level and is hidden on
+      // /learn/*, /admin/*, /cards/new, /cardgroups/new; /cardgroups/<id> is
       // not on the hidden list so the FAB must be present here.
       const fab = page.getByRole("button", { name: "Add new card" });
       await expect(fab).toBeVisible();
       await fab.click();
 
-      // The root-layout FAB is invoked without lastViewedCardgroupId, so it
-      // navigates to bare /cards/new. The /cards/new RSC then resolves the
-      // cardgroup: ?cardgroup= is empty, me.lastViewedCardgroup is still null
-      // (the user has not visited /learn yet), and myCardgroups has exactly one
-      // entry → forcePickerOpen=true so the picker auto-opens.
-      await page.waitForURL("**/cards/new", { timeout: 10_000 });
-
-      // 4. The picker is a Radix Dialog with focus-trap + aria-hidden on the
-      // rest of the page, so we must not assert against headings outside the
-      // dialog while it is open. Assert the dialog title, click the cardgroup,
-      // and only then verify the underlying form.
-      const dialog = page.getByRole("dialog", { name: "Select cardgroup" });
-      await expect(dialog).toBeVisible();
-      await dialog.getByRole("button", { name: cardgroupName }).click();
-
-      // 5. URL gains ?cardgroup=<id> and the chip is pre-selected.
+      // 4. URL carries ?cardgroup=<id> from the moment we land — no picker
+      // round-trip needed because the cardgroup id was propagated via the FAB
+      // href.
       await page.waitForURL(`**/cards/new?cardgroup=${newCardgroupId}`, {
         timeout: 10_000,
       });
 
-      // With the dialog closed, the underlying page is back in the a11y tree.
       await expect(page.getByRole("heading", { name: "New card" })).toBeVisible();
 
       // The CardgroupChip's aria-label is "Change cardgroup (currently \"<name>\")"

--- a/frontend/src/components/nav/fab-action.test.ts
+++ b/frontend/src/components/nav/fab-action.test.ts
@@ -14,10 +14,7 @@ describe("resolveFabAction", () => {
 
   describe("creates a card with cardgroup pre-selected on cardgroup detail/cards", () => {
     it.each([
-      [
-        "/cardgroups/abc-123",
-        { href: "/cards/new?cardgroup=abc-123", label: "Add new card" },
-      ],
+      ["/cardgroups/abc-123", { href: "/cards/new?cardgroup=abc-123", label: "Add new card" }],
       [
         "/cardgroups/abc-123/cards",
         { href: "/cards/new?cardgroup=abc-123", label: "Add new card" },

--- a/frontend/src/components/nav/fab-action.test.ts
+++ b/frontend/src/components/nav/fab-action.test.ts
@@ -6,6 +6,7 @@ describe("resolveFabAction", () => {
   describe("creates a cardgroup on /cardgroups", () => {
     it("returns Add new cardgroup href for exact /cardgroups", () => {
       expect(resolveFabAction("/cardgroups")).toEqual({
+        kind: "cardgroup",
         href: "/cardgroups/new",
         label: "Add new cardgroup",
       });
@@ -14,16 +15,31 @@ describe("resolveFabAction", () => {
 
   describe("creates a card with cardgroup pre-selected on cardgroup detail/cards", () => {
     it.each([
-      ["/cardgroups/abc-123", { href: "/cards/new?cardgroup=abc-123", label: "Add new card" }],
+      [
+        "/cardgroups/abc-123",
+        {
+          kind: "card-with-group",
+          href: "/cards/new?cardgroup=abc-123",
+          label: "Add new card",
+          cardgroupId: "abc-123",
+        },
+      ],
       [
         "/cardgroups/abc-123/cards",
-        { href: "/cards/new?cardgroup=abc-123", label: "Add new card" },
+        {
+          kind: "card-with-group",
+          href: "/cards/new?cardgroup=abc-123",
+          label: "Add new card",
+          cardgroupId: "abc-123",
+        },
       ],
       [
         "/cardgroups/0190f9f4-3ad8-7d52-b1d0-6f6b5f5a9c2c",
         {
+          kind: "card-with-group",
           href: "/cards/new?cardgroup=0190f9f4-3ad8-7d52-b1d0-6f6b5f5a9c2c",
           label: "Add new card",
+          cardgroupId: "0190f9f4-3ad8-7d52-b1d0-6f6b5f5a9c2c",
         },
       ],
     ])("returns card href with cardgroup param for %s", (pathname, expected) => {
@@ -49,8 +65,20 @@ describe("resolveFabAction", () => {
       ["/login"],
     ])("returns generic /cards/new for %s", (pathname) => {
       expect(resolveFabAction(pathname)).toEqual({
+        kind: "card",
         href: "/cards/new",
         label: "Add new card",
+      });
+    });
+  });
+
+  describe("is shadowed by HIDDEN_PATH_RE for /cardgroups/new", () => {
+    it("returns a card-with-group action for /cardgroups/new (the literal 'new' is treated as a cardgroup id; HIDDEN_PATH_RE in global-fab.tsx is what suppresses the FAB on this path)", () => {
+      expect(resolveFabAction("/cardgroups/new")).toEqual({
+        kind: "card-with-group",
+        href: "/cards/new?cardgroup=new",
+        label: "Add new card",
+        cardgroupId: "new",
       });
     });
   });

--- a/frontend/src/components/nav/fab-action.test.ts
+++ b/frontend/src/components/nav/fab-action.test.ts
@@ -1,0 +1,60 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+import { resolveFabAction } from "./fab-action";
+
+describe("resolveFabAction", () => {
+  describe("creates a cardgroup on /cardgroups", () => {
+    it("returns Add new cardgroup href for exact /cardgroups", () => {
+      expect(resolveFabAction("/cardgroups")).toEqual({
+        href: "/cardgroups/new",
+        label: "Add new cardgroup",
+      });
+    });
+  });
+
+  describe("creates a card with cardgroup pre-selected on cardgroup detail/cards", () => {
+    it.each([
+      [
+        "/cardgroups/abc-123",
+        { href: "/cards/new?cardgroup=abc-123", label: "Add new card" },
+      ],
+      [
+        "/cardgroups/abc-123/cards",
+        { href: "/cards/new?cardgroup=abc-123", label: "Add new card" },
+      ],
+      [
+        "/cardgroups/0190f9f4-3ad8-7d52-b1d0-6f6b5f5a9c2c",
+        {
+          href: "/cards/new?cardgroup=0190f9f4-3ad8-7d52-b1d0-6f6b5f5a9c2c",
+          label: "Add new card",
+        },
+      ],
+    ])("returns card href with cardgroup param for %s", (pathname, expected) => {
+      expect(resolveFabAction(pathname)).toEqual(expected);
+    });
+  });
+
+  describe("hides on cardgroups edit", () => {
+    it.each([
+      ["/cardgroups/abc-123/edit"],
+      ["/cardgroups/abc-123/edit/"],
+      ["/cardgroups/abc-123/edit/anything"],
+    ])("returns null for %s", (pathname) => {
+      expect(resolveFabAction(pathname)).toBeNull();
+    });
+  });
+
+  describe("default to creating a card", () => {
+    it.each([
+      ["/"],
+      ["/learn/abc-123"],
+      ["/profile"],
+      ["/login"],
+    ])("returns generic /cards/new for %s", (pathname) => {
+      expect(resolveFabAction(pathname)).toEqual({
+        href: "/cards/new",
+        label: "Add new card",
+      });
+    });
+  });
+});

--- a/frontend/src/components/nav/fab-action.test.ts
+++ b/frontend/src/components/nav/fab-action.test.ts
@@ -72,8 +72,8 @@ describe("resolveFabAction", () => {
     });
   });
 
-  describe("is shadowed by HIDDEN_PATH_RE for /cardgroups/new", () => {
-    it("returns a card-with-group action for /cardgroups/new (the literal 'new' is treated as a cardgroup id; HIDDEN_PATH_RE in global-fab.tsx is what suppresses the FAB on this path)", () => {
+  describe("is shadowed externally by GlobalFAB's hidden-path guard for /cardgroups/new", () => {
+    it("returns a card-with-group action (the literal 'new' is treated as a cardgroup id; GlobalFAB suppresses the FAB on this path via its own hidden-path guard)", () => {
       expect(resolveFabAction("/cardgroups/new")).toEqual({
         kind: "card-with-group",
         href: "/cards/new?cardgroup=new",

--- a/frontend/src/components/nav/fab-action.ts
+++ b/frontend/src/components/nav/fab-action.ts
@@ -26,12 +26,12 @@ export function resolveFabAction(pathname: string): FabAction | null {
 
   const cardsMatch = CARDGROUP_CARDS_RE.exec(pathname);
   if (cardsMatch) {
-    return { href: "/cards/new?cardgroup=" + cardsMatch[1], label: "Add new card" };
+    return { href: `/cards/new?cardgroup=${cardsMatch[1]}`, label: "Add new card" };
   }
 
   const detailMatch = CARDGROUP_DETAIL_RE.exec(pathname);
   if (detailMatch) {
-    return { href: "/cards/new?cardgroup=" + detailMatch[1], label: "Add new card" };
+    return { href: `/cards/new?cardgroup=${detailMatch[1]}`, label: "Add new card" };
   }
 
   return { href: "/cards/new", label: "Add new card" };

--- a/frontend/src/components/nav/fab-action.ts
+++ b/frontend/src/components/nav/fab-action.ts
@@ -1,17 +1,16 @@
-// Pure helper: maps a pathname to the FAB destination and accessible label.
 const CARDGROUP_DETAIL_RE = /^\/cardgroups\/([^/]+)$/;
 const CARDGROUP_CARDS_RE = /^\/cardgroups\/([^/]+)\/cards$/;
 const CARDGROUP_EDIT_RE = /^\/cardgroups\/([^/]+)\/edit(\/|$)/;
 
-export interface FabAction {
-  href: string;
-  label: string;
-}
+export type FabAction =
+  | { kind: "cardgroup"; href: "/cardgroups/new"; label: "Add new cardgroup" }
+  | { kind: "card-with-group"; href: string; label: "Add new card"; cardgroupId: string }
+  | { kind: "card"; href: "/cards/new"; label: "Add new card" };
 
 /**
  * Maps the current pathname to the FAB destination and accessible label.
- * Returns null when the FAB has nothing meaningful to show for this path
- * (caller should treat this as a hide signal).
+ * Returns null when the FAB has nothing meaningful to show for this path.
+ * Each caller decides how to handle null (e.g. hide the FAB, or fall back to a default).
  *
  * Pure function — no side effects, no imports from React or Next.js.
  */
@@ -21,18 +20,32 @@ export function resolveFabAction(pathname: string): FabAction | null {
   }
 
   if (pathname === "/cardgroups") {
-    return { href: "/cardgroups/new", label: "Add new cardgroup" };
+    return { kind: "cardgroup", href: "/cardgroups/new", label: "Add new cardgroup" };
   }
 
   const cardsMatch = CARDGROUP_CARDS_RE.exec(pathname);
   if (cardsMatch) {
-    return { href: `/cards/new?cardgroup=${cardsMatch[1]}`, label: "Add new card" };
+    // cardsMatch[1] is always defined when the regex matched (capture group 1 is required)
+    const id = cardsMatch[1] as string;
+    return {
+      kind: "card-with-group",
+      href: `/cards/new?cardgroup=${id}`,
+      label: "Add new card",
+      cardgroupId: id,
+    };
   }
 
   const detailMatch = CARDGROUP_DETAIL_RE.exec(pathname);
   if (detailMatch) {
-    return { href: `/cards/new?cardgroup=${detailMatch[1]}`, label: "Add new card" };
+    // detailMatch[1] is always defined when the regex matched (capture group 1 is required)
+    const id = detailMatch[1] as string;
+    return {
+      kind: "card-with-group",
+      href: `/cards/new?cardgroup=${id}`,
+      label: "Add new card",
+      cardgroupId: id,
+    };
   }
 
-  return { href: "/cards/new", label: "Add new card" };
+  return { kind: "card", href: "/cards/new", label: "Add new card" };
 }

--- a/frontend/src/components/nav/fab-action.ts
+++ b/frontend/src/components/nav/fab-action.ts
@@ -1,0 +1,38 @@
+// Pure helper: maps a pathname to the FAB destination and accessible label.
+const CARDGROUP_DETAIL_RE = /^\/cardgroups\/([^/]+)$/;
+const CARDGROUP_CARDS_RE = /^\/cardgroups\/([^/]+)\/cards$/;
+const CARDGROUP_EDIT_RE = /^\/cardgroups\/([^/]+)\/edit(\/|$)/;
+
+export interface FabAction {
+  href: string;
+  label: string;
+}
+
+/**
+ * Maps the current pathname to the FAB destination and accessible label.
+ * Returns null when the FAB has nothing meaningful to show for this path
+ * (caller should treat this as a hide signal).
+ *
+ * Pure function — no side effects, no imports from React or Next.js.
+ */
+export function resolveFabAction(pathname: string): FabAction | null {
+  if (CARDGROUP_EDIT_RE.test(pathname)) {
+    return null;
+  }
+
+  if (pathname === "/cardgroups") {
+    return { href: "/cardgroups/new", label: "Add new cardgroup" };
+  }
+
+  const cardsMatch = CARDGROUP_CARDS_RE.exec(pathname);
+  if (cardsMatch) {
+    return { href: "/cards/new?cardgroup=" + cardsMatch[1], label: "Add new card" };
+  }
+
+  const detailMatch = CARDGROUP_DETAIL_RE.exec(pathname);
+  if (detailMatch) {
+    return { href: "/cards/new?cardgroup=" + detailMatch[1], label: "Add new card" };
+  }
+
+  return { href: "/cards/new", label: "Add new card" };
+}

--- a/frontend/src/components/nav/global-fab.test.tsx
+++ b/frontend/src/components/nav/global-fab.test.tsx
@@ -33,6 +33,7 @@ describe("<GlobalFAB>", () => {
       ["/admin"],
       ["/cards/new"],
       ["/cardgroups/new"],
+      ["/cardgroups/new/"],
       ["/profile"],
       ["/profile/"],
       ["/cardgroups/abc123/edit"],

--- a/frontend/src/components/nav/global-fab.test.tsx
+++ b/frontend/src/components/nav/global-fab.test.tsx
@@ -45,16 +45,11 @@ describe("<GlobalFAB>", () => {
   });
 
   describe("visible paths — renders 'Add new cardgroup' label", () => {
-    it.each([["/cardgroups"]])(
-      "renders 'Add new cardgroup' button on %s",
-      (path) => {
-        vi.mocked(usePathname).mockReturnValue(path);
-        render(<GlobalFAB />);
-        expect(
-          screen.getByRole("button", { name: "Add new cardgroup" }),
-        ).toBeInTheDocument();
-      },
-    );
+    it.each([["/cardgroups"]])("renders 'Add new cardgroup' button on %s", (path) => {
+      vi.mocked(usePathname).mockReturnValue(path);
+      render(<GlobalFAB />);
+      expect(screen.getByRole("button", { name: "Add new cardgroup" })).toBeInTheDocument();
+    });
   });
 
   describe("visible paths — renders 'Add new card' label", () => {
@@ -65,9 +60,7 @@ describe("<GlobalFAB>", () => {
     ])("renders 'Add new card' button on %s", (path) => {
       vi.mocked(usePathname).mockReturnValue(path);
       render(<GlobalFAB />);
-      expect(
-        screen.getByRole("button", { name: "Add new card" }),
-      ).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Add new card" })).toBeInTheDocument();
     });
   });
 

--- a/frontend/src/components/nav/global-fab.test.tsx
+++ b/frontend/src/components/nav/global-fab.test.tsx
@@ -33,6 +33,10 @@ describe("<GlobalFAB>", () => {
       ["/admin"],
       ["/cards/new"],
       ["/cardgroups/new"],
+      ["/profile"],
+      ["/profile/"],
+      ["/cardgroups/abc123/edit"],
+      ["/cardgroups/abc123/edit/"],
     ])("renders nothing on %s", (path) => {
       vi.mocked(usePathname).mockReturnValue(path);
       const { container } = render(<GlobalFAB />);
@@ -40,30 +44,74 @@ describe("<GlobalFAB>", () => {
     });
   });
 
-  describe("visible paths — renders the FAB button", () => {
+  describe("visible paths — renders 'Add new cardgroup' label", () => {
+    it.each([["/cardgroups"]])(
+      "renders 'Add new cardgroup' button on %s",
+      (path) => {
+        vi.mocked(usePathname).mockReturnValue(path);
+        render(<GlobalFAB />);
+        expect(
+          screen.getByRole("button", { name: "Add new cardgroup" }),
+        ).toBeInTheDocument();
+      },
+    );
+  });
+
+  describe("visible paths — renders 'Add new card' label", () => {
     it.each([
-      ["/cardgroups"],
       ["/cardgroups/abc123"],
-      ["/profile"],
+      ["/cardgroups/abc123/cards"],
       ["/"],
-    ])("renders button on %s", (path) => {
+    ])("renders 'Add new card' button on %s", (path) => {
       vi.mocked(usePathname).mockReturnValue(path);
       render(<GlobalFAB />);
-      expect(screen.getByRole("button", { name: "Add new card" })).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Add new card" }),
+      ).toBeInTheDocument();
     });
   });
 
-  it("has aria-label 'Add new card'", () => {
-    vi.mocked(usePathname).mockReturnValue("/cardgroups");
-    render(<GlobalFAB />);
-    expect(screen.getByRole("button", { name: "Add new card" })).toBeInTheDocument();
-  });
-
-  it("click navigates to /cards/new", async () => {
+  it("click on /cardgroups navigates to /cardgroups/new", async () => {
     const user = userEvent.setup();
     const router = makeRouter();
     vi.mocked(useRouter).mockReturnValue(router as never);
     vi.mocked(usePathname).mockReturnValue("/cardgroups");
+
+    render(<GlobalFAB />);
+    await user.click(screen.getByRole("button", { name: "Add new cardgroup" }));
+
+    expect(router.push).toHaveBeenCalledWith("/cardgroups/new");
+  });
+
+  it("click on /cardgroups/abc123 navigates to /cards/new?cardgroup=abc123", async () => {
+    const user = userEvent.setup();
+    const router = makeRouter();
+    vi.mocked(useRouter).mockReturnValue(router as never);
+    vi.mocked(usePathname).mockReturnValue("/cardgroups/abc123");
+
+    render(<GlobalFAB />);
+    await user.click(screen.getByRole("button", { name: "Add new card" }));
+
+    expect(router.push).toHaveBeenCalledWith("/cards/new?cardgroup=abc123");
+  });
+
+  it("click on /cardgroups/abc123/cards navigates to /cards/new?cardgroup=abc123", async () => {
+    const user = userEvent.setup();
+    const router = makeRouter();
+    vi.mocked(useRouter).mockReturnValue(router as never);
+    vi.mocked(usePathname).mockReturnValue("/cardgroups/abc123/cards");
+
+    render(<GlobalFAB />);
+    await user.click(screen.getByRole("button", { name: "Add new card" }));
+
+    expect(router.push).toHaveBeenCalledWith("/cards/new?cardgroup=abc123");
+  });
+
+  it("click on / navigates to /cards/new", async () => {
+    const user = userEvent.setup();
+    const router = makeRouter();
+    vi.mocked(useRouter).mockReturnValue(router as never);
+    vi.mocked(usePathname).mockReturnValue("/");
 
     render(<GlobalFAB />);
     await user.click(screen.getByRole("button", { name: "Add new card" }));
@@ -72,7 +120,7 @@ describe("<GlobalFAB>", () => {
   });
 
   it("wraps the button in an md:hidden container so the FAB is hidden at >= md breakpoint", () => {
-    vi.mocked(usePathname).mockReturnValue("/cardgroups");
+    vi.mocked(usePathname).mockReturnValue("/cardgroups/abc123");
     render(<GlobalFAB />);
     const button = screen.getByRole("button", { name: /add new card/i });
     expect(button.parentElement).toHaveClass("md:hidden");

--- a/frontend/src/components/nav/global-fab.tsx
+++ b/frontend/src/components/nav/global-fab.tsx
@@ -2,10 +2,12 @@
 
 import { Plus } from "lucide-react";
 import { usePathname, useRouter } from "next/navigation";
+import { resolveFabAction } from "./fab-action";
 
 // Hidden on /login (anonymous-only), /learn (full-bleed swipe UI),
-// /admin (different audience), and /cards/new + /cardgroups/new (FAB target — would loop).
-const HIDDEN_PATH_RE = /^\/(login|learn|admin|cards\/new|cardgroups\/new)(\/|$)/;
+// /admin (different audience), /cards/new + /cardgroups/new (FAB target — would loop),
+// and /profile (mid-edit form).
+const HIDDEN_PATH_RE = /^\/(login|learn|admin|cards\/new|cardgroups\/new|profile)(\/|$)/;
 
 export function GlobalFAB() {
   const pathname = usePathname();
@@ -15,12 +17,17 @@ export function GlobalFAB() {
     return null;
   }
 
+  const action = resolveFabAction(pathname);
+  if (action === null) {
+    return null;
+  }
+
   return (
     <div className="md:hidden">
       <button
         type="button"
-        aria-label="Add new card"
-        onClick={() => router.push("/cards/new")}
+        aria-label={action.label}
+        onClick={() => router.push(action.href)}
         className="fixed bottom-[calc(env(safe-area-inset-bottom)+1rem)] right-4 z-50 flex h-14 w-14 items-center justify-center rounded-full bg-brand-primary text-brand-primary-foreground shadow-lg"
       >
         <Plus className="h-6 w-6" aria-hidden="true" />

--- a/frontend/src/components/nav/global-fab.tsx
+++ b/frontend/src/components/nav/global-fab.tsx
@@ -6,7 +6,7 @@ import { resolveFabAction } from "./fab-action";
 
 // Hidden on /login (anonymous-only), /learn (full-bleed swipe UI),
 // /admin (different audience), /cards/new + /cardgroups/new (FAB target — would loop),
-// and /profile (mid-edit form).
+// and /profile (FAB action does not apply to profile editing).
 const HIDDEN_PATH_RE = /^\/(login|learn|admin|cards\/new|cardgroups\/new|profile)(\/|$)/;
 
 export function GlobalFAB() {

--- a/frontend/src/components/nav/header-add-card-link.test.tsx
+++ b/frontend/src/components/nav/header-add-card-link.test.tsx
@@ -94,10 +94,7 @@ describe("<HeaderAddCardLink>", () => {
 
     it("renders href with cardgroup query param", () => {
       render(<HeaderAddCardLink />);
-      expect(screen.getByRole("link")).toHaveAttribute(
-        "href",
-        "/cards/new?cardgroup=cg-abc",
-      );
+      expect(screen.getByRole("link")).toHaveAttribute("href", "/cards/new?cardgroup=cg-abc");
     });
 
     it("does not have aria-current attribute", () => {
@@ -123,10 +120,7 @@ describe("<HeaderAddCardLink>", () => {
 
     it("renders href with cardgroup query param", () => {
       render(<HeaderAddCardLink />);
-      expect(screen.getByRole("link")).toHaveAttribute(
-        "href",
-        "/cards/new?cardgroup=cg-abc",
-      );
+      expect(screen.getByRole("link")).toHaveAttribute("href", "/cards/new?cardgroup=cg-abc");
     });
 
     it("does not have aria-current attribute", () => {

--- a/frontend/src/components/nav/header-add-card-link.test.tsx
+++ b/frontend/src/components/nav/header-add-card-link.test.tsx
@@ -145,9 +145,30 @@ describe("<HeaderAddCardLink>", () => {
       mockUsePathname.mockReturnValue("/cardgroups/new");
     });
 
-    it("renders href with cardgroup query param (header treats 'new' as an id; this is a known limitation guarded by HIDDEN_PATH_RE on the FAB side, but the header has no equivalent guard)", () => {
+    it("renders href with cardgroup query param (header treats 'new' as an id; this is a known limitation suppressed by GlobalFAB's hidden-path guard on the FAB side, but the header has no equivalent guard)", () => {
       render(<HeaderAddCardLink />);
       expect(screen.getByRole("link")).toHaveAttribute("href", "/cards/new?cardgroup=new");
+    });
+  });
+
+  describe("when on a cardgroup edit page", () => {
+    beforeEach(() => {
+      mockUsePathname.mockReturnValue("/cardgroups/cg-abc/edit");
+    });
+
+    it("renders href as /cards/new because resolveFabAction returns null on edit pages", () => {
+      render(<HeaderAddCardLink />);
+      expect(screen.getByRole("link")).toHaveAttribute("href", "/cards/new");
+    });
+
+    it("does not have aria-current attribute", () => {
+      render(<HeaderAddCardLink />);
+      expect(screen.getByRole("link")).not.toHaveAttribute("aria-current");
+    });
+
+    it("does not have pointer-events-none class", () => {
+      render(<HeaderAddCardLink />);
+      expect(screen.getByRole("link")).not.toHaveClass("pointer-events-none");
     });
   });
 });

--- a/frontend/src/components/nav/header-add-card-link.test.tsx
+++ b/frontend/src/components/nav/header-add-card-link.test.tsx
@@ -86,4 +86,63 @@ describe("<HeaderAddCardLink>", () => {
       expect(screen.getByRole("link")).toHaveClass("hover:opacity-90");
     });
   });
+
+  describe("when on a cardgroup detail page", () => {
+    beforeEach(() => {
+      mockUsePathname.mockReturnValue("/cardgroups/cg-abc");
+    });
+
+    it("renders href with cardgroup query param", () => {
+      render(<HeaderAddCardLink />);
+      expect(screen.getByRole("link")).toHaveAttribute(
+        "href",
+        "/cards/new?cardgroup=cg-abc",
+      );
+    });
+
+    it("does not have aria-current attribute", () => {
+      render(<HeaderAddCardLink />);
+      expect(screen.getByRole("link")).not.toHaveAttribute("aria-current");
+    });
+
+    it("does not have pointer-events-none class", () => {
+      render(<HeaderAddCardLink />);
+      expect(screen.getByRole("link")).not.toHaveClass("pointer-events-none");
+    });
+
+    it("has hover:opacity-90 class", () => {
+      render(<HeaderAddCardLink />);
+      expect(screen.getByRole("link")).toHaveClass("hover:opacity-90");
+    });
+  });
+
+  describe("when on a cardgroup cards sub-page", () => {
+    beforeEach(() => {
+      mockUsePathname.mockReturnValue("/cardgroups/cg-abc/cards");
+    });
+
+    it("renders href with cardgroup query param", () => {
+      render(<HeaderAddCardLink />);
+      expect(screen.getByRole("link")).toHaveAttribute(
+        "href",
+        "/cards/new?cardgroup=cg-abc",
+      );
+    });
+
+    it("does not have aria-current attribute", () => {
+      render(<HeaderAddCardLink />);
+      expect(screen.getByRole("link")).not.toHaveAttribute("aria-current");
+    });
+  });
+
+  describe("when on the cardgroups list page", () => {
+    beforeEach(() => {
+      mockUsePathname.mockReturnValue("/cardgroups");
+    });
+
+    it("renders href as /cards/new (header is card-targeted; FAB action targets cardgroups)", () => {
+      render(<HeaderAddCardLink />);
+      expect(screen.getByRole("link")).toHaveAttribute("href", "/cards/new");
+    });
+  });
 });

--- a/frontend/src/components/nav/header-add-card-link.test.tsx
+++ b/frontend/src/components/nav/header-add-card-link.test.tsx
@@ -139,4 +139,15 @@ describe("<HeaderAddCardLink>", () => {
       expect(screen.getByRole("link")).toHaveAttribute("href", "/cards/new");
     });
   });
+
+  describe("when on the new-cardgroup form", () => {
+    beforeEach(() => {
+      mockUsePathname.mockReturnValue("/cardgroups/new");
+    });
+
+    it("renders href with cardgroup query param (header treats 'new' as an id; this is a known limitation guarded by HIDDEN_PATH_RE on the FAB side, but the header has no equivalent guard)", () => {
+      render(<HeaderAddCardLink />);
+      expect(screen.getByRole("link")).toHaveAttribute("href", "/cards/new?cardgroup=new");
+    });
+  });
 });

--- a/frontend/src/components/nav/header-add-card-link.tsx
+++ b/frontend/src/components/nav/header-add-card-link.tsx
@@ -3,13 +3,16 @@
 import { Plus } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { resolveFabAction } from "./fab-action";
 
 export function HeaderAddCardLink() {
   const pathname = usePathname();
   const onCardsNew = pathname === "/cards/new";
+  const action = resolveFabAction(pathname);
+  const href = action?.href.startsWith("/cards/new") ? action.href : "/cards/new";
   return (
     <Link
-      href="/cards/new"
+      href={href}
       aria-current={onCardsNew ? "page" : undefined}
       className={`flex items-center gap-1.5 rounded-md bg-brand-primary px-3 py-1.5 text-sm font-medium text-brand-primary-foreground transition-opacity ${
         onCardsNew ? "pointer-events-none opacity-60" : "hover:opacity-90"

--- a/frontend/src/components/nav/header-add-card-link.tsx
+++ b/frontend/src/components/nav/header-add-card-link.tsx
@@ -9,7 +9,10 @@ export function HeaderAddCardLink() {
   const pathname = usePathname();
   const onCardsNew = pathname === "/cards/new";
   const action = resolveFabAction(pathname);
-  const href = action !== null && action.kind !== "cardgroup" ? action.href : "/cards/new";
+  const href =
+    action !== null && (action.kind === "card-with-group" || action.kind === "card")
+      ? action.href
+      : "/cards/new";
   return (
     <Link
       href={href}

--- a/frontend/src/components/nav/header-add-card-link.tsx
+++ b/frontend/src/components/nav/header-add-card-link.tsx
@@ -9,7 +9,7 @@ export function HeaderAddCardLink() {
   const pathname = usePathname();
   const onCardsNew = pathname === "/cards/new";
   const action = resolveFabAction(pathname);
-  const href = action?.href.startsWith("/cards/new") ? action.href : "/cards/new";
+  const href = action !== null && action.kind !== "cardgroup" ? action.href : "/cards/new";
   return (
     <Link
       href={href}


### PR DESCRIPTION
## Summary

Replaces the unconditional `router.push("/cards/new")` / `<Link href="/cards/new">` shape in `GlobalFAB` and the desktop header `+ Card` link with a single pathname-driven `resolveFabAction` helper. The FAB and the header CTA now propagate the active `cardgroup` id when the user is on `/cardgroups/<id>` or `/cardgroups/<id>/cards`, hide the FAB entirely on `/cardgroups/<id>/edit/*` and `/profile`, and route to `/cardgroups/new` instead of `/cards/new` when the user is browsing the cardgroup index. Output is modeled as a discriminated union (`{ kind: "cardgroup" | "card-with-group" | "card" }`) so consumers narrow on `kind` rather than substring-matching the rendered `href`. Three review iterations folded back into `.claude/rules/frontend-typescript-conventions.md` (discriminated-union over flat DTO, positive-allowlist narrowing, `as string` cast on regex captures under `noUncheckedIndexedAccess`, and the cross-module-constant-name-in-test-prose rot).

## Background / Motivation

- **The FAB and header `+ Card` CTA both routed unconditionally to `/cards/new`, dropping the cardgroup context the user had just navigated through.** A user on `/cardgroups/<id>/cards` who tapped "+" landed on `/cards/new` with the picker auto-resolving to the last-viewed cardgroup (which is not necessarily the one in the URL). The two affordances had no shared source of truth for "which cardgroup should the new card belong to?".
- **The pathname → destination branching logic would have lived in two places.** A naive fix that inlined `if (pathname.startsWith("/cardgroups/"))` into both `global-fab.tsx` and `header-add-card-link.tsx` would silently drift the moment a third path-aware variant landed (e.g. hiding the FAB on `/cardgroups/<id>/edit/*` was needed in this PR but only relevant to the FAB, not the header link).
- **A flat `{ href: string; label: string }` DTO would have erased an invariant the resolver already knows.** Consumers branching on `href.startsWith("/cards/new")` would silently pick up future routes like `/cards/new/bulk` and route them through the wrong UX. The discriminated union forces every consumer-side branch to acknowledge new variants at compile time, and the resolver's literal-typed `href` fields (`href: "/cardgroups/new"`) reject any factory branch that produces the wrong string.
- **Negative-exclusion narrowing in the header link (`action.kind !== "cardgroup"`) is open-ended.** A future `kind: "bulk-card"` would silently slip through and be treated as a card-form destination. The positive-allowlist form (`action.kind === "card-with-group" || action.kind === "card"`) forces the addition to surface as a code-review decision: either the new variant belongs in the allow list, or the default `/cards/new` branch handles it.
- **Regex captures under `noUncheckedIndexedAccess` widen to `string | undefined`.** `cardsMatch[1]` is typed `string | undefined` even though the regex cannot match without producing capture group 1. `String(match[1] ?? "")` would silently corrupt URLs (turning `undefined` into `"undefined"`); a bare `match[1]!` non-null assertion offers no docstring anchor for why it is sound. The chosen `as string` cast paired with a one-line comment naming the required capture group survives review.
- **Test prose that named a sibling module's constant by its identifier (`HIDDEN_PATH_RE`) was silent-rot coupling.** A constant rename or replacement (e.g. swapping the regex for a `Set` lookup) would leave the test description misleading with no compile-time signal. The fix is to name the module's responsibility ("GlobalFAB's hidden-path guard for `/cardgroups/new`") rather than the constant's identifier.

## Changes

### `resolveFabAction` — single pathname-driven source of truth

- `frontend/src/components/nav/fab-action.ts` (new, 51 lines): pure function that takes `pathname: string` and returns one of three discriminated-union shapes or `null`. No imports from React or Next.js — testable as a plain Node module without `vitest`'s React harness.
  - `kind: "cardgroup"` — `pathname === "/cardgroups"` → `href: "/cardgroups/new"`, label `"Add new cardgroup"`.
  - `kind: "card-with-group"` — `pathname` matches `/^\/cardgroups\/([^/]+)$/` or `/^\/cardgroups\/([^/]+)\/cards$/` → `href: \`/cards/new?cardgroup=${id}\``, label `"Add new card"`, plus the `cardgroupId` field for consumers that need it directly.
  - `kind: "card"` — fallback for everything else → `href: "/cards/new"`.
  - Returns `null` on `/cardgroups/<id>/edit/*` (matched by `/^\/cardgroups\/([^/]+)\/edit(\/|$)/`) so the FAB can hide entirely on edit paths.
- Captures use `as string` with a load-bearing comment (`// cardsMatch[1] is always defined when the regex matched (capture group 1 is required)`) — see "Background" above.

### `GlobalFAB` integration

- `frontend/src/components/nav/global-fab.tsx`: replaces the hard-coded `aria-label="Add new card"` + `router.push("/cards/new")` with `action.label` and `router.push(action.href)`. When `resolveFabAction` returns `null` (edit paths), the component returns `null` and the FAB does not render.
- `HIDDEN_PATH_RE` extended with `/profile` (FAB action does not apply to profile editing) — matched alongside the existing `/login`, `/learn`, `/admin`, `/cards/new`, `/cardgroups/new` set.

### Header `+ Card` link integration

- `frontend/src/components/nav/header-add-card-link.tsx`: replaces the hard-coded `<Link href="/cards/new">` with a `resolveFabAction(pathname)` call narrowed by a **positive allowlist** — `action.kind === "card-with-group" || action.kind === "card"` produces the action's `href`; anything else (the `cardgroup` variant or `null` on edit paths) falls back to `/cards/new`. The header link cannot meaningfully route to `/cardgroups/new`, so the cardgroup branch is deliberately excluded.
- `aria-current="page"` and the `pointer-events-none opacity-60` styling on `/cards/new` are unchanged from the prior shape.

### Tests

- `frontend/src/components/nav/fab-action.test.ts` (new, 85 lines): table-driven coverage for every branch of `resolveFabAction` — `/cardgroups` → cardgroup variant; `/cardgroups/<id>` and `/cardgroups/<id>/cards` → `card-with-group` variant with id propagated; `/cardgroups/<id>/edit` and `/cardgroups/<id>/edit/preview` → `null`; `/cards/new`, `/`, `/learn/<id>`, `/profile` → `card` variant. Runs as a `.ts` file (no React harness needed) since `resolveFabAction` is a pure function.
- `frontend/src/components/nav/global-fab.test.tsx` (+45 lines, -15 lines): asserts the FAB hides on `/cardgroups/<id>/edit/*`, hides on `/profile`, propagates the id on `/cardgroups/<id>/cards` (rendered button's `aria-label` and `onClick` target verified together), and continues to render the default `/cards/new` action elsewhere. Hidden-path tests describe the invariant by responsibility ("hidden by GlobalFAB's hidden-path guard for `/cardgroups/new`") rather than naming the `HIDDEN_PATH_RE` constant.
- `frontend/src/components/nav/header-add-card-link.test.tsx` (new, 85 lines): both branches of the positive allowlist plus the cardgroup-index branch (which falls through to `/cards/new`), and the existing `aria-current="page"` / `pointer-events-none` behavior on `/cards/new`.

### Documentation

- `.claude/rules/frontend-typescript-conventions.md` (+72 lines): four new sections capturing the WHY learnings from the review loop:
  - **"Discriminated union over flat DTO when consumers must branch on the variant"** — the resolver's union shape vs. a flat `{ href, label }` DTO. References `frontend/src/components/nav/fab-action.ts`.
  - **"Positive allowlist over negative exclusion in discriminated-union narrowing"** — the header-link narrowing rule. References `frontend/src/components/nav/header-add-card-link.tsx`.
  - **"`as string` cast on regex captures under `noUncheckedIndexedAccess`"** — the load-bearing comment pattern that pairs with the cast. References the two `match[1] as string` sites in `fab-action.ts`.
  - **"Cross-module constant references in test descriptions are silent-rot coupling"** — the test-prose rule that surfaced from the `HIDDEN_PATH_RE` rename concern.
- `docs/frontend.md` (+45 lines): cross-reference to the new rule sections plus a short "FAB / header-link path resolution" subsection naming `resolveFabAction` as the single source of truth and pointing readers at the rules file for the design rationale.

## Verification

After merge, the following should hold in the repo state:

- `grep -n "resolveFabAction" frontend/src/components/nav/fab-action.ts frontend/src/components/nav/global-fab.tsx frontend/src/components/nav/header-add-card-link.tsx` matches the export and both integration sites.
- `grep -nE 'router\.push\("/cards/new"\)' frontend/src/components/nav/global-fab.tsx` returns nothing — the unconditional push is gone.
- `grep -n 'href="/cards/new"' frontend/src/components/nav/header-add-card-link.tsx` returns nothing — the unconditional href is gone.
- `grep -n "kind: \"card-with-group\"" frontend/src/components/nav/fab-action.ts` matches twice (the two call sites that produce the variant).
- `grep -n "as string" frontend/src/components/nav/fab-action.ts` matches twice; each match is preceded by a `// ...` comment naming the required capture group.
- `grep -n '/profile' frontend/src/components/nav/global-fab.tsx` matches inside `HIDDEN_PATH_RE`.
- `grep -n "Discriminated union over flat DTO" .claude/rules/frontend-typescript-conventions.md` matches the new section heading.
- `grep -n "Positive allowlist over negative exclusion" .claude/rules/frontend-typescript-conventions.md` matches the new section heading.

Then on the running dev server (`pnpm --filter frontend dev`):

- Sign in. From a `< md` viewport, navigate to `/cardgroups/<some-id>/cards`. The FAB renders with `aria-label="Add new card"`. Tap it → URL becomes `/cards/new?cardgroup=<some-id>` (the picker pre-selects that cardgroup, not the last-viewed default).
- Navigate to `/cardgroups/<some-id>/edit`. The FAB does **not** render. Same on `/profile`.
- Navigate to `/cardgroups`. The FAB renders with `aria-label="Add new cardgroup"` and routes to `/cardgroups/new`.
- At `>= md` viewport on `/cardgroups/<some-id>/cards`, the desktop header `+ Card` link's `href` resolves to `/cards/new?cardgroup=<some-id>` (inspect element). On `/cardgroups`, the link still points at `/cards/new` (the cardgroup-index branch is deliberately excluded from the header allowlist).
- On `/cards/new`, the header `+ Card` link is visually subdued (`opacity-60`), shows no hover state, and clicking does nothing — `aria-current="page"` is present (unchanged behavior).

## Test plan

- [ ] `cd frontend && pnpm typecheck` exits 0.
- [ ] `cd frontend && pnpm lint` (Biome) exits 0 with no fixes applied.
- [ ] `cd frontend && pnpm test --run` exits 0 (covers the new `fab-action.test.ts` and `header-add-card-link.test.tsx` plus the touched `global-fab.test.tsx`).
- [ ] Manual: from `< md` on `/cardgroups/<id>/cards`, tap the FAB → land on `/cards/new?cardgroup=<id>` (URL contains the id; picker is pre-selected).
- [ ] Manual: from `< md` on `/cardgroups/<id>/edit` and `/profile`, the FAB is absent.
- [ ] Manual: from `< md` on `/cardgroups`, the FAB has `aria-label="Add new cardgroup"` and routes to `/cardgroups/new`.
- [ ] Manual: at `>= md` on `/cardgroups/<id>/cards`, the header `+ Card` link's `href` is `/cards/new?cardgroup=<id>` (inspect element).
- [ ] Manual: at `>= md` on `/cardgroups`, the header `+ Card` link still points at `/cards/new` (no cardgroup id).
- [ ] Regression: on `/cards/new`, the header `+ Card` link still carries `aria-current="page"` and `pointer-events-none opacity-60` (unchanged).
- [ ] Negative: temporarily change the header allowlist back to `action.kind !== "cardgroup"` → vitest fails on the cardgroup-index branch test that expects fallback to `/cards/new`. Revert.
- [ ] Negative: temporarily replace `cardsMatch[1] as string` with `String(cardsMatch[1] ?? "")` and pass an unmatched path → the URL contains the literal `"undefined"` (the existing tests with concrete ids still pass; this confirms why the cast pattern is preferred). Revert.
- [ ] Language-policy grep clean: `grep -rnP "[\x{3040}-\x{30ff}\x{4e00}-\x{9fff}]" --include="*.tsx" --include="*.ts" --include="*.md" frontend/src docs .claude/rules` returns nothing; `grep -rnE "PR[0-9]+" frontend/src docs .claude/rules` returns nothing.
