### PR TITLE
feat(cards): duplicate-front overwrite flow with typed BAD_USER_INPUT

### DIFF
--- a/.claude/rules/error-wrapping.md
+++ b/.claude/rules/error-wrapping.md
@@ -48,9 +48,34 @@ The same shape applies when the DB rejects an `INSERT` or `UPDATE` for colliding
 
 **Anchor `ConstraintName` matches on the narrowest unambiguous fragment.** `strings.Contains(pgErr.ConstraintName, "roles")` would also match `user_roles_pkey` and route a join-table primary-key collision into `ErrRoleDuplicate`, which is wrong. The roles table emits its unique constraint on the `name` column, so the precise check is `strings.Contains(pgErr.ConstraintName, "name")`. The same rule extends to any future unique sentinel: pick the column or constraint suffix that no other constraint in the schema can collide with.
 
+**Add a negative integration test for any 23505 classification branch.** A positive test confirms that the target constraint maps to the sentinel; a negative test confirms that a *different* 23505 violation (e.g. a primary-key collision via `cards_pkey`) does **not** mis-route into the same sentinel. Without the negative test, widening the `strings.Contains` fragment in a future refactor silently routes unrelated unique violations through the wrong sentinel — the positive test stays green and the mis-classification ships undetected:
+
+```go
+// Force a 23505 on a different constraint (primary key) and assert the error
+// is NOT classified as the typed sentinel.
+second.ID = fixedID
+err := repo.Create(ctx, second)
+require.Error(t, err)
+require.False(t, errors.Is(err, repository.ErrCardDuplicateFront),
+    "cards_pkey violation must not be classified as ErrCardDuplicateFront; got %v", err)
+var pgErr *pgconn.PgError
+require.True(t, errors.As(err, &pgErr))
+require.Equal(t, "23505", pgErr.Code) // confirm we hit the intended path
+```
+
 ### Standalone sentinels: not every new sentinel joins `ErrNotFound`
 
 The layered-sentinel pattern (`errors.Join(specific, general)`) only works when the specific case is **semantically a refinement** of the general case. `ErrUserNotFound` and `ErrRoleNotFound` refine `ErrNotFound`, so joining is correct: a caller branching only on `ErrNotFound` still gets the right behaviour. But `ErrRoleDuplicate` is the inverse condition — the row was *found* and that is precisely the failure. Joining it with `ErrNotFound` would make `errors.Is(err, ErrNotFound)` true for a duplicate insert, which is a lie that any general-purpose 404 mapper would happily act on. Keep "found" sentinels (duplicate, conflict, already-exists) standalone; only "missing" sentinels get the `errors.Join` treatment.
+
+### Two-tier `gqlerr` API: generic open helper + domain-specific typed wrapper
+
+When a `BAD_USER_INPUT` error needs to carry a structured payload beyond the standard `{code, field}` envelope (e.g. an existing entity's ID and a preview field for the frontend to display), use two layers:
+
+1. **Generic open helper** — `BadUserInputWithExtensions(field, message string, extra map[string]any)` accepts any extension map. Use it for new one-off cases.
+2. **Domain-specific typed wrapper** — once a call site stabilises, wrap the generic helper in a named function (`BadUserInputCardDuplicateFront(existingCardID, existingBack string)`) so the call site is compile-checked and the extension keys are assembled in one place.
+3. **Typed reason constant** — pair the wrapper with a `BadUserInputReason` constant (e.g. `ReasonCardDuplicateFront = "CARD_DUPLICATE_FRONT"`) so the discriminator string the frontend branches on lives in exactly one place and is never stringly-typed at the call site.
+
+The frontend discriminates on `extensions.reason` (a sub-key), not on `extensions.code`. This keeps the top-level `code` as the coarse class (`BAD_USER_INPUT`) so existing `IsCode` matchers and field-error UI keep working without modification.
 
 ## Logging
 
@@ -61,6 +86,8 @@ All error sites that produce a structured log entry must attach the eris chain a
 - are a no-op when `err == nil`.
 
 Use `LogWarn` for any non-ERROR site that needs the `error_chain` attribute; do not hand-roll `slog.Warn(... eris.ToJSON ...)` calls.
+
+When a wrapper already forwards to a variadic helper (e.g. `logging.LogError(ctx, logger, msg, err, attrs...)`), expose the variadic slot at the wrapper rather than minting a sibling function. `gqlerr.Internal(ctx, err, attrs ...slog.Attr)` follows this shape: existing two-arg call sites keep compiling unchanged, and new sites can attach structured triage context (e.g. `slog.String("cardgroup_id", id)`) to the log line without a name-change cascade. The extra attrs appear only in the ERROR log — the wire response is always the same `{code: INTERNAL, message: "internal server error"}` envelope.
 
 Today's call sites:
 
@@ -104,6 +131,8 @@ if root != nil {
 ```
 
 Test stubs that produce errors must also use `eris.New(...)` (not `errors.New(...)`) so the assertion exercises the same code path production hits. Pattern in `backend/internal/auth/superuser_test.go` (`M7_IsAdminError`, `M8_AssignToUserError`).
+
+**A single `eris.New` stub is not enough to prove production's `eris.Wrap` is load-bearing.** A test where the stub always returns an eris-wrapped error passes the `error_chain.root.stack` assertion whether or not production wraps the error — because the stub's own eris chain provides the root. Add a sibling test that stubs the *actual* stdlib sentinel (e.g. `repository.ErrNotFound`, a plain `errors.New` value) and still asserts the rich shape. Only that test will fail if someone removes the production `eris.Wrap` call at the log site. Reference: `backend/internal/usecase/card_test.go` (`TestCardUsecase_Create_DuplicateLookupRace_RowVanished`) — the documented race where the duplicate row vanishes before the follow-up SELECT returns `repository.ErrNotFound`, and the test proves that the usecase's `eris.Wrap(lookupErr, ...)` is what makes the chain rich.
 
 ### Assert PII *absence* on log lines that carry `user_id`
 

--- a/.claude/rules/frontend-rsc-error-handling.md
+++ b/.claude/rules/frontend-rsc-error-handling.md
@@ -56,6 +56,61 @@ try {
 
 The older `redirectIfUnauthenticated` helper (in `frontend/src/lib/apollo/server-redirect.ts`) still uses a substring match and is grandfathered for legacy redirect-only sites where both sides converge on the same `/login` target. **New** code paths — silent swallow vs. warn vs. redirect, anything that branches finer than "redirect on auth failure" — MUST use the structural helper.
 
+### Use `CombinedGraphQLErrors.is(err)` — never `instanceof CombinedGraphQLErrors`
+
+Apollo Client ships `CombinedGraphQLErrors.is(err)` as the canonical check because `instanceof` is unreliable across module realm boundaries. In a Next.js build, the server bundle and the client bundle each have their own copy of `@apollo/client/errors`; a `CombinedGraphQLErrors` created in one realm does not pass `instanceof` in the other. The `.is()` static method uses a duck-type check (`err?.graphQLErrors != null`) that survives the realm split.
+
+Every helper in `frontend/src/lib/apollo/graphql-errors.ts` uses `.is()` already. Any new helper added to that file — or anywhere else that must detect a `CombinedGraphQLErrors` — must also use `.is()`:
+
+```ts
+// AVOID: fails silently when the error originates in a different bundle realm.
+if (err instanceof CombinedGraphQLErrors) { ... }
+
+// PREFER: duck-type check, realm-safe.
+if (CombinedGraphQLErrors.is(err)) { ... }
+```
+
+**How to apply:** grep for `instanceof CombinedGraphQLErrors` before any merge; every hit is a bug. The lint rule does not catch this automatically — it must be verified in code review. Reference: `frontend/src/lib/apollo/graphql-errors.ts` (`tryGetDuplicateCardInfo`).
+
+### `getBackendErrorBanner` deliberately skips field-level `BAD_USER_INPUT` — use `getBackendFieldErrors` first
+
+`getBackendErrorBanner` (`frontend/src/lib/apollo/errors.ts`) returns `undefined` for `BAD_USER_INPUT` errors that carry an `extensions.field`, because those errors are meant to be displayed inline next to the offending field, not in a generic banner. A call site that passes such an error to `getBackendErrorBanner` and displays the result will silently show nothing.
+
+Any UI flow that wants to surface a field-level error inline (instead of a generic banner) MUST explicitly call `getBackendFieldErrors(err)?.<field>` first, then fall back to `getBackendErrorBanner`, then to a generic copy string:
+
+```ts
+// correct: check field-level error first, then banner, then generic fallback
+const fieldErrors = getBackendFieldErrors(err);
+const banner = getBackendErrorBanner(err);
+setErrorMessage(
+  fieldErrors?.front ??    // field-level inline message
+  banner ??                // generic banner (skipped for field-level BAD_USER_INPUT)
+  "An unexpected error occurred",
+);
+```
+
+The three-way fallback ensures every typed error from the backend reaches the UI at the most specific level available, without duplicating the field-level message in a second banner. Reference: `frontend/src/app/cards/new/cards-new-client.tsx` `handleOverwrite`.
+
+### Structural error parsers must `console.warn` (not silently `continue`) when the shape narrows wrong
+
+A helper like `tryGetDuplicateCardInfo` iterates `err.errors` and skips entries whose extensions do not match the expected discriminator. When the discriminator (`extensions.reason === "CARD_DUPLICATE_FRONT"`) matches but the payload is missing required fields (`existingCardId`, `existingBack`), silently calling `continue` downgrades a partially-valid backend payload to a generic error path with no observable signal. Operators have no way to know a CARD_DUPLICATE_FRONT entry was received but discarded.
+
+Emit a `console.warn` with the raw `extensions` object when the discriminator matches but the shape is wrong:
+
+```ts
+if (!ext || ext.code !== "BAD_USER_INPUT" || ext.reason !== "CARD_DUPLICATE_FRONT") continue;
+// discriminator matched — now validate required fields
+if (typeof existingCardId !== "string" || existingCardId === "") {
+  console.warn(
+    "[graphql-errors] CARD_DUPLICATE_FRONT entry missing required extension fields",
+    { entry: { message: entry.message, extensions: ext } },
+  );
+  continue;
+}
+```
+
+**PII review gate:** new extension fields added to any backend error variant appear verbatim in this warn payload. Review every new field against the PII policy before landing — field names like `existingBack` (card content) may carry user-authored text, while `existingCardId` (a UUID) is safe. Reference: `frontend/src/lib/apollo/graphql-errors.ts` (`tryGetDuplicateCardInfo`).
+
 ## `console.error("[scope] getUser() failed:", err.name, err.message)` before throwing in RSC
 
 Next.js may abbreviate or replace thrown errors in production (the App Router strips error.message in prod and renders a generic "Application error" page unless the error is a `NEXT_REDIRECT` or similar special). Operators triaging a failure see only the boundary log, not the underlying cause. RSCs that rethrow a real `getUser()` failure must log first:

--- a/.claude/rules/frontend-typescript-conventions.md
+++ b/.claude/rules/frontend-typescript-conventions.md
@@ -40,7 +40,7 @@ If the project style evolves to allow branded types, replace the JSDoc with a no
 
 ## `expect.objectContaining({ message })` is not enough — add a discriminating key
 
-`Error.prototype.message` is an own (though non-enumerable) property on every `Error` instance. Vitest's `expect.objectContaining` uses `hasOwnProperty` for key checks. Therefore, asserting `expect.objectContaining({ message: expect.any(String) })` against a `console.error` second argument will pass whether the argument is the intended structured object `{ message, err }` OR a bare `Error` regression. The test is tautologically green and the regression ships silently.
+`Error.prototype.message` is an own (though non-enumerable) property on every `Error` instance. Vitest's `expect.objectContaining` uses `hasOwnProperty` for key checks. Therefore, asserting `expect.objectContaining({ message: expect.any(String) })` against a `console.error` or `console.warn` second argument will pass whether the argument is the intended structured object `{ message, err }` OR a bare `Error` regression. The test is tautologically green and the regression ships silently.
 
 The fix is to include a discriminating own-property key that exists in the structured object but NOT on `Error` instances — e.g. `err: expect.anything()`.
 
@@ -61,9 +61,9 @@ expect(consoleSpy).toHaveBeenCalledWith(
 );
 ```
 
-**Why:** structured log arguments (`{ message, err }`) are deliberately different from a raw `Error`. The assertion must verify the structure matches what was intentionally logged, not just that some string-ish property exists.
+**Why:** structured log arguments (`{ message, err }`) are deliberately different from a raw `Error`. The assertion must verify the structure matches what was intentionally logged, not just that some string-ish property exists. The rule applies equally to `console.error` and `console.warn` — both are used for structured payloads in this codebase (e.g. `tryGetDuplicateCardInfo` emits a `console.warn` with `{ entry }` rather than a bare string).
 
-**How to apply:** whenever a `console.error` / `console.warn` call passes a structured object as the second argument, pair the `message` matcher with at least one additional key that distinguishes the object from a bare `Error`. Reference: `frontend/src/app/cards/new/cards-new-client.test.tsx` `handleCreate` log assertion.
+**How to apply:** whenever a `console.error` / `console.warn` call passes a structured object as the second argument, pair the `message` matcher with at least one additional key that distinguishes the object from a bare `Error`. Reference: `frontend/src/app/cards/new/cards-new-client.test.tsx` `handleCreate` log assertion and `frontend/src/lib/apollo/graphql-errors.test.ts`.
 
 ## TanStack Form `_handleSubmit` re-throws — chain `.catch()` on `form.handleSubmit()`
 
@@ -104,6 +104,32 @@ onSubmit: async ({ value }) => {
 
 **How to apply:** every `useForm.onSubmit` that calls an external `submit` prop must re-throw after the catch/log. The re-throw is forward-safe even when the current caller wraps `submit` in its own `try/catch` — the rejection does not bubble past that boundary today. This rule pairs with the `.catch()` rule above; they must land together. Reference: `frontend/src/components/cardgroups/card-form.tsx`.
 
+## Radix `AlertDialogAction` closes the dialog synchronously — call `e.preventDefault()` to keep it open on failure
+
+Radix UI's `AlertDialogAction` calls `onOpenChange(false)` synchronously as soon as its `onClick` handler resolves, regardless of whether the action succeeded or failed. For a confirm action that may fail and must keep the dialog mounted (e.g. an overwrite mutation that returns a typed `BAD_USER_INPUT`), this means a failed action still closes the dialog and the user loses any inline error message.
+
+The fix: call `e.preventDefault()` at the start of the `onClick` handler and let the consuming component decide when to close the dialog based on the outcome of the operation.
+
+```tsx
+<AlertDialogAction
+  onClick={async (e) => {
+    e.preventDefault(); // prevent Radix from closing on click — we close on success only
+    try {
+      await onConfirm();
+      // caller closes the dialog (e.g. setDuplicate(null)) on success
+    } catch {
+      // dialog stays open; surface error inline
+    }
+  }}
+>
+  Confirm
+</AlertDialogAction>
+```
+
+The cancel path uses the standard `AlertDialogCancel` component, which closes correctly without `preventDefault`. The cancel path is the catch-all close path for any non-action close (backdrop click, Escape key, explicit cancel).
+
+**How to apply:** any `AlertDialogAction` whose `onClick` fires an async operation that can fail and must keep the dialog mounted MUST call `e.preventDefault()` at the top of the handler. Reference: `frontend/src/app/cards/new/cards-new-client.tsx` `DuplicateOverwriteDialog`.
+
 ## Discriminated union over flat DTO when consumers must branch on the variant
 
 A factory whose output has semantically distinct shapes — e.g. "navigate to a cardgroup form", "navigate to a card form with a pre-selected cardgroup id", "navigate to a generic card form" — has two encodings available: (a) a flat DTO with a string `href` plus runtime introspection (`href.startsWith("/cards/new")`), or (b) a discriminated union with a `kind` tag. The flat DTO erases an invariant the factory already knows; the union preserves it.
@@ -119,6 +145,8 @@ export type FabAction =
 **Why:** runtime-introspection (`startsWith`, `includes`, regex on the `href`) rots silently as new variants are added. A future `/cards/new/bulk` action would be silently picked up by `href.startsWith("/cards/new")` and routed through the wrong branch with no compile-time warning. The discriminant check forces every branching consumer to acknowledge the new variant during code review (see also "Positive allowlist over negative exclusion" below).
 
 **How to apply:** when a factory returns one of N semantically distinct shapes AND any consumer needs to branch on which shape was returned, model the output as `{ kind: "..." } & ...` and let consumers narrow on `kind`. Use literal-type fields (`href: "/cardgroups/new"`) where the value is an invariant of the variant — the type system will reject any factory branch that produces a different string. Reference: `frontend/src/components/nav/fab-action.ts` (`FabAction`) consumed by `frontend/src/components/nav/global-fab.tsx` and `frontend/src/components/nav/header-add-card-link.tsx`. This rule generalises the route-handler-specific § "Discriminated-union response shape" in `docs/frontend.md`.
+
+**Inverse case — do NOT use a discriminated union when only one "open" variant exists.** When a piece of state has exactly two shapes — "present with data" and "absent" — `T | null` is the right model. The `null` IS the second variant and TypeScript narrows it for free. A discriminated union shape `{ kind: "open"; data: T } | null` adds no type-safety value when no consumer ever branches on `kind` itself; it just adds boilerplate. Reference: `frontend/src/app/cards/new/cards-new-client.tsx` (`DuplicateState = { existingCardId, existingBack, ... } | null`). Reach for the union only when variants are semantically distinct and consumers branch on which one is active.
 
 ## Positive allowlist over negative exclusion in discriminated-union narrowing
 

--- a/.claude/rules/go-library-gotchas.md
+++ b/.claude/rules/go-library-gotchas.md
@@ -89,6 +89,36 @@ db.Where("name ILIKE ?", "%"+escapeLike(query)+"%")
 
 Order matters: escape `\` first, then `%` and `_`, otherwise the second pass re-escapes the backslash from the first pass. The same rule applies to `name ILIKE ? || '%'` (prefix match) and to any other `LIKE` predicate fed by user input.
 
+## GORM exact-match `FindBy*` helpers: callers own trimming, repos own nothing
+
+A `FindByXxx` method that uses `WHERE col = ?` performs byte-for-byte equality — no `TRIM`, no `LOWER`, no `LIKE`. The caller (usecase layer) is responsible for `strings.TrimSpace` before invoking the repo. The repo must not silently normalise input, because any future LIKE/LOWER "convenience" change would make the unique-index enforcement and the lookup disagree. Regression-guard the contract with a negative integration test:
+
+```go
+// Padded front must not match an exactly-stored value.
+_, err := repo.FindByCardgroupAndFront(ctx, cg.ID, " apple ")
+require.True(t, errors.Is(err, repository.ErrNotFound),
+    "padded front must not match exact-stored value; got %v", err)
+```
+
+This pairs with the GORM `LIKE` escape rule above: both rules block accidental broadening of match semantics on a column that backs a unique index.
+
+## Repository lookup methods scoped by tenant ID require a cross-tenant negative test
+
+Any `FindBy*` method that includes a `cardgroup_id = ?` (or other tenant-scoping) predicate must be regression-guarded by inserting the same discriminating value into **two** separate tenant rows and asserting the result is the tenant-scoped row, not the other one. Without this guard, dropping or accidentally omitting the predicate in a refactor silently leaks another tenant's row through duplicate-detection or query logic:
+
+```go
+cardA := newCard(cgA.ID, "apple", "back-A")
+cardB := newCard(cgB.ID, "apple", "back-B")
+require.NoError(t, repo.Create(ctx, cardA))
+require.NoError(t, repo.Create(ctx, cardB))
+
+got, err := repo.FindByCardgroupAndFront(ctx, cgB.ID, "apple")
+require.NoError(t, err)
+require.Equal(t, cardB.ID, got.ID, "must return cardgroup B's card, not cardgroup A's")
+```
+
+Apply this pattern to any repository method whose correctness depends on a tenant-scoping predicate.
+
 ## GORM rejects unconditional `Delete` — use `Where("1 = 1")` to opt out
 
 GORM v2+ refuses a `Delete` call that has no `WHERE` clause as a safety net against accidental full-table deletes. It returns an `ErrMissingWhereClause` error.
@@ -246,6 +276,8 @@ names the method, making the gap obvious without inspecting the stub.
 to the tests. Each scenario-level stub embeds it and overrides only the methods the
 scenario exercises. Do not share the base across packages — keep it local to the
 test file so the panic message stays readable.
+
+**Adding a method to an interface breaks test stubs in OTHER packages silently at the test level.** The production build (`go build ./...`) succeeds because production callers use the concrete implementation. But hand-rolled test doubles in packages such as `loader/` or `graph/resolver/` that embed the interface type stop compiling. Run `go build ./...` *before* `go test ./...` after any interface-method addition to surface the cascade before any test-run noise masks it. Panic-base stubs make the failure loud once the build passes: a missing override panics immediately rather than returning a silent zero-value that can mask a logic bug. Audit every hand-rolled stub for the new method on the same change.
 
 ## Extract startup helpers to make branch coverage testable without a live server
 

--- a/.claude/rules/language-policy.md
+++ b/.claude/rules/language-policy.md
@@ -41,3 +41,5 @@ grep -rlP "[\x{3040}-\x{30ff}\x{4e00}-\x{9fff}]" \
 # No PR-order references.
 grep -rnE "PR[0-9]+" docs backend/internal backend/cmd backend/graph frontend/src
 ```
+
+Run the CJK grep **before writing** any new UI string literals (JSX text, `placeholder`, `aria-label`, etc.), not after. Memory and convention assumptions about "matching existing UX text" are unreliable — grep is the canonical proof. A design-doc claim that "the text matches the rest of the app" was disproven by grep during the card-duplicate-overwrite implementation: the target component was the only file in `frontend/src/` carrying CJK content, requiring a full English rewrite. The grep takes under one second; discovering the violation in review wastes far more.

--- a/.claude/rules/pagination.md
+++ b/.claude/rules/pagination.md
@@ -103,6 +103,26 @@ Filter the edge out of the cached connection, decrement `totalCount` (clamped at
 
 Rely on Apollo cache normalization (entities with `id` are normalized by default). No manual `update` callback is needed; mutations that touch a normalised entity propagate to every cached query that reads it.
 
+### Do not reuse one mutation's Apollo-managed error state for a sibling mutation's failure surface
+
+`useMutation` returns a managed `error` field that clears automatically on the next call to the same mutation. If a component runs two independent mutations (e.g. `createCard` and `updateCard`), using `createError` from `useMutation(CreateCardMutation)` to display a failure message from `updateCard` causes the banner to vanish the moment the user retries `createCard` — even before the user dismisses the error. The clearing is silent; the user sees the banner disappear with no explanation.
+
+Use a sibling `useState<string | null>` for any error that belongs to a second mutation (or any flow not managed by the primary hook):
+
+```ts
+// correct: each mutation gets its own error surface
+const [createCard, { error: createError }] = useMutation(CreateCardMutation);
+const [updateCard] = useMutation(UpdateCardMutation);
+const [overwriteError, setOverwriteError] = useState<string | null>(null);
+
+// in the overwrite handler:
+updateCard({ ... }).catch((err) => {
+  setOverwriteError(getBackendErrorBanner(err) ?? "Overwrite failed");
+});
+```
+
+The `useState` error lives until the user explicitly dismisses it or the component unmounts — it does not clear on unrelated mutation interactions. Reference: `frontend/src/app/cards/new/cards-new-client.tsx` (`overwriteError` state alongside `createError`).
+
 ### Drop `optimisticResponse` for mutations that can fail with typed GraphQL errors
 
 `@apollo/client` v3.x rolls back optimistic writes on **network** errors but not consistently on typed GraphQL errors (`FORBIDDEN`, `BAD_USER_INPUT`, etc.). For a mutation that can plausibly return one of those — e.g. a role assignment that fails authorization, or a self-demotion blocked by a server-side guard — the optimistic write persists and the cache lies until the next mount. Two acceptable postures:

--- a/backend/graph/resolver/card_resolvers_test.go
+++ b/backend/graph/resolver/card_resolvers_test.go
@@ -44,6 +44,9 @@ func (m *cardMockRepo) FindPageByCardgroup(
 ) ([]*domain.Card, int64, error) {
 	return nil, 0, nil
 }
+func (m *cardMockRepo) FindByCardgroupAndFront(_ context.Context, _, _ string) (*domain.Card, error) {
+	return nil, nil
+}
 func (m *cardMockRepo) Create(_ context.Context, _ *domain.Card) error { return nil }
 func (m *cardMockRepo) Update(_ context.Context, _ string, _ repository.CardUpdate) (*domain.Card, error) {
 	return nil, nil

--- a/backend/internal/gqlerr/errors.go
+++ b/backend/internal/gqlerr/errors.go
@@ -20,6 +20,13 @@ const (
 	CodeCancelled       Code = "CANCELLED"
 )
 
+// BadUserInputReason is the sub-discriminator emitted under extensions.reason
+// for BAD_USER_INPUT errors that carry a typed payload. Frontend handlers branch
+// on the value of reason rather than the human-readable message.
+type BadUserInputReason string
+
+const ReasonCardDuplicateFront BadUserInputReason = "CARD_DUPLICATE_FRONT"
+
 func Unauthenticated() *gqlerror.Error {
 	return &gqlerror.Error{
 		Message: "unauthenticated",
@@ -42,6 +49,14 @@ func BadUserInput(field, message string) *gqlerror.Error {
 // BadUserInputWithExtensions returns a BAD_USER_INPUT error with additional
 // extensions merged into the standard {code, field} envelope. Reserved keys
 // (code, field) in extra are ignored to keep the envelope stable.
+//
+// The design places variant-specific data under an extensions.reason
+// sub-discriminator rather than a separate top-level code so that
+// IsCode(err, CodeBadUserInput) and existing field-error UI keep working without
+// modification. Reach for this helper — rather than BadUserInput — when the
+// payload needs to be structurally parsed by the frontend (e.g. to surface an
+// existing duplicate entity). For plain field validation messages, BadUserInput
+// is sufficient.
 func BadUserInputWithExtensions(field, message string, extra map[string]any) *gqlerror.Error {
 	ext := map[string]any{
 		"code":  string(CodeBadUserInput),
@@ -56,8 +71,27 @@ func BadUserInputWithExtensions(field, message string, extra map[string]any) *gq
 	return &gqlerror.Error{Message: message, Extensions: ext}
 }
 
-func Internal(ctx context.Context, err error) *gqlerror.Error {
-	logging.LogError(ctx, slog.Default(), "internal error", err)
+// BadUserInputCardDuplicateFront returns the BAD_USER_INPUT envelope used when
+// a card insert collides with the (cardgroup_id, front) unique index. The
+// frontend's tryGetDuplicateCardInfo helper parses the (reason, existingCardId,
+// existingBack) extension trio.
+func BadUserInputCardDuplicateFront(existingCardID, existingBack string) *gqlerror.Error {
+	return BadUserInputWithExtensions("front",
+		"card with same front exists in this cardgroup",
+		map[string]any{
+			"reason":         string(ReasonCardDuplicateFront),
+			"existingCardId": existingCardID,
+			"existingBack":   existingBack,
+		})
+}
+
+// Internal logs err at ERROR level and returns a generic INTERNAL gqlerror. The
+// optional attrs are attached to the log line only — the wire response is always
+// the same {code: INTERNAL, message: "internal server error"} shape. Use attrs
+// to attach triage-relevant context (e.g. entity IDs) that must not leak to the
+// client but helps operators distinguish a known race from a real regression.
+func Internal(ctx context.Context, err error, attrs ...slog.Attr) *gqlerror.Error {
+	logging.LogError(ctx, slog.Default(), "internal error", err, attrs...)
 	return &gqlerror.Error{
 		Message: "internal server error",
 		Extensions: map[string]any{

--- a/backend/internal/gqlerr/errors.go
+++ b/backend/internal/gqlerr/errors.go
@@ -39,6 +39,23 @@ func BadUserInput(field, message string) *gqlerror.Error {
 	}
 }
 
+// BadUserInputWithExtensions returns a BAD_USER_INPUT error with additional
+// extensions merged into the standard {code, field} envelope. Reserved keys
+// (code, field) in extra are ignored to keep the envelope stable.
+func BadUserInputWithExtensions(field, message string, extra map[string]any) *gqlerror.Error {
+	ext := map[string]any{
+		"code":  string(CodeBadUserInput),
+		"field": field,
+	}
+	for k, v := range extra {
+		if k == "code" || k == "field" {
+			continue
+		}
+		ext[k] = v
+	}
+	return &gqlerror.Error{Message: message, Extensions: ext}
+}
+
 func Internal(ctx context.Context, err error) *gqlerror.Error {
 	logging.LogError(ctx, slog.Default(), "internal error", err)
 	return &gqlerror.Error{

--- a/backend/internal/gqlerr/errors_test.go
+++ b/backend/internal/gqlerr/errors_test.go
@@ -214,6 +214,88 @@ func TestIsCode_Forbidden(t *testing.T) {
 	}
 }
 
+func TestBadUserInputCardDuplicateFront(t *testing.T) {
+	t.Parallel()
+
+	existingID := "card-uuid-123"
+	existingBack := "the answer"
+
+	got := gqlerr.BadUserInputCardDuplicateFront(existingID, existingBack)
+
+	want := gqlerr.BadUserInputWithExtensions("front",
+		"card with same front exists in this cardgroup",
+		map[string]any{
+			"reason":         string(gqlerr.ReasonCardDuplicateFront),
+			"existingCardId": existingID,
+			"existingBack":   existingBack,
+		})
+
+	if got.Message != want.Message {
+		t.Errorf("Message = %q, want %q", got.Message, want.Message)
+	}
+	if code := extString(t, got, "code"); code != "BAD_USER_INPUT" {
+		t.Errorf("Extensions[code] = %q, want %q", code, "BAD_USER_INPUT")
+	}
+	if field := extString(t, got, "field"); field != "front" {
+		t.Errorf("Extensions[field] = %q, want %q", field, "front")
+	}
+	if reason := extString(t, got, "reason"); reason != "CARD_DUPLICATE_FRONT" {
+		t.Errorf("Extensions[reason] = %q, want %q", reason, "CARD_DUPLICATE_FRONT")
+	}
+	if id := extString(t, got, "existingCardId"); id != existingID {
+		t.Errorf("Extensions[existingCardId] = %q, want %q", id, existingID)
+	}
+	if back := extString(t, got, "existingBack"); back != existingBack {
+		t.Errorf("Extensions[existingBack] = %q, want %q", back, existingBack)
+	}
+}
+
+func TestInternal_VariadicAttrs(t *testing.T) {
+	// Not parallel: mutates the global slog default.
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelError})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	got := gqlerr.Internal(
+		context.Background(),
+		eris.New("test error"),
+		slog.String("user_id", "u1"),
+		slog.String("cardgroup_id", "cg1"),
+	)
+
+	if got.Extensions["code"] != "INTERNAL" {
+		t.Errorf("Extensions[code] = %v, want %q", got.Extensions["code"], "INTERNAL")
+	}
+
+	var rec map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &rec); err != nil {
+		t.Fatalf("decode log record: %v (raw: %s)", err, buf.String())
+	}
+	if rec["user_id"] != "u1" {
+		t.Errorf("log record user_id = %v, want %q", rec["user_id"], "u1")
+	}
+	if rec["cardgroup_id"] != "cg1" {
+		t.Errorf("log record cardgroup_id = %v, want %q", rec["cardgroup_id"], "cg1")
+	}
+	if rec["level"] != "ERROR" {
+		t.Errorf("log record level = %v, want %q", rec["level"], "ERROR")
+	}
+	chain, ok := rec["error_chain"].(map[string]any)
+	if !ok {
+		t.Fatalf("error_chain is not a JSON object: %T", rec["error_chain"])
+	}
+	root, hasRoot := chain["root"].(map[string]any)
+	if !hasRoot {
+		t.Error("error_chain must have root entry (got external-only shape; stub may be using stdlib errors)")
+	}
+	if root != nil {
+		if stack, _ := root["stack"].([]any); len(stack) == 0 {
+			t.Error("error_chain.root.stack must contain at least one frame")
+		}
+	}
+}
+
 func TestCancelled(t *testing.T) {
 	t.Parallel()
 

--- a/backend/internal/gqlerr/errors_test.go
+++ b/backend/internal/gqlerr/errors_test.go
@@ -50,6 +50,56 @@ func TestBadUserInput(t *testing.T) {
 	}
 }
 
+func TestBadUserInputWithExtensions(t *testing.T) {
+	t.Parallel()
+
+	t.Run("merges extra keys", func(t *testing.T) {
+		t.Parallel()
+		got := gqlerr.BadUserInputWithExtensions("front", "duplicate card", map[string]any{
+			"reason":         "CARD_DUPLICATE_FRONT",
+			"existingCardId": "abc-123",
+		})
+
+		if got.Message != "duplicate card" {
+			t.Errorf("Message = %q, want %q", got.Message, "duplicate card")
+		}
+		if code := extString(t, got, "code"); code != "BAD_USER_INPUT" {
+			t.Errorf("Extensions[code] = %q, want %q", code, "BAD_USER_INPUT")
+		}
+		if field := extString(t, got, "field"); field != "front" {
+			t.Errorf("Extensions[field] = %q, want %q", field, "front")
+		}
+		if reason := extString(t, got, "reason"); reason != "CARD_DUPLICATE_FRONT" {
+			t.Errorf("Extensions[reason] = %q, want %q", reason, "CARD_DUPLICATE_FRONT")
+		}
+		if id := extString(t, got, "existingCardId"); id != "abc-123" {
+			t.Errorf("Extensions[existingCardId] = %q, want %q", id, "abc-123")
+		}
+	})
+
+	t.Run("ignores reserved code override", func(t *testing.T) {
+		t.Parallel()
+		got := gqlerr.BadUserInputWithExtensions("front", "duplicate card", map[string]any{
+			"code": "OVERRIDE",
+		})
+
+		if code := extString(t, got, "code"); code != "BAD_USER_INPUT" {
+			t.Errorf("Extensions[code] = %q, want %q (override must be ignored)", code, "BAD_USER_INPUT")
+		}
+	})
+
+	t.Run("ignores reserved field override", func(t *testing.T) {
+		t.Parallel()
+		got := gqlerr.BadUserInputWithExtensions("front", "duplicate card", map[string]any{
+			"field": "hijacked",
+		})
+
+		if field := extString(t, got, "field"); field != "front" {
+			t.Errorf("Extensions[field] = %q, want %q (override must be ignored)", field, "front")
+		}
+	})
+}
+
 func TestInternal_message(t *testing.T) {
 	t.Parallel()
 

--- a/backend/internal/loader/user_test.go
+++ b/backend/internal/loader/user_test.go
@@ -179,6 +179,9 @@ func (r *countingCardRepo) DeleteByIDsTx(_ context.Context, _ *gorm.DB, _ string
 func (r *countingCardRepo) UpsertManyTx(_ context.Context, _ *gorm.DB, _ []*domain.Card) (repository.UpsertManyTxResult, error) {
 	panic("countingCardRepo.UpsertManyTx not configured")
 }
+func (r *countingCardRepo) FindByCardgroupAndFront(_ context.Context, _, _ string) (*domain.Card, error) {
+	panic("countingCardRepo.FindByCardgroupAndFront not configured")
+}
 
 func emptyCardRepo() *countingCardRepo {
 	return &countingCardRepo{

--- a/backend/internal/repository/card.go
+++ b/backend/internal/repository/card.go
@@ -7,12 +7,18 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/rotisserie/eris"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 
 	"backend/internal/domain"
 )
+
+// ErrCardDuplicateFront is returned by Create when an INSERT collides with the
+// (cardgroup_id, front) unique index. Standalone — do NOT join with ErrNotFound;
+// the row was found, which is precisely the failure (see error-wrapping.md).
+var ErrCardDuplicateFront = errors.New("repository: card with same front exists in cardgroup")
 
 // CardOrderBy is the allowlist of fields that paginated card queries may sort by.
 // Lexicographic tuple order is always (orderField, id) so cursors stay deterministic
@@ -89,6 +95,10 @@ type CardRepository interface {
 	) (cards []*domain.Card, totalCount int64, err error)
 	FindDueCardsTx(ctx context.Context, tx *gorm.DB, cardgroupID string, now time.Time, limit int) ([]*domain.Card, error)
 	Create(ctx context.Context, card *domain.Card) error
+	// FindByCardgroupAndFront returns the card identified by the (cardgroup_id,
+	// front) unique key, or ErrNotFound when no such row exists. The front value
+	// is matched exactly; trimming is the caller's responsibility.
+	FindByCardgroupAndFront(ctx context.Context, cardgroupID, front string) (*domain.Card, error)
 	UpdateFSRSStateTx(ctx context.Context, tx *gorm.DB, id string, state domain.FSRSState) error
 	Update(ctx context.Context, id string, patch CardUpdate) (*domain.Card, error)
 	Delete(ctx context.Context, id string) error
@@ -329,9 +339,28 @@ func (r *cardRepo) FindDueCardsTx(ctx context.Context, tx *gorm.DB, cardgroupID 
 
 func (r *cardRepo) Create(ctx context.Context, card *domain.Card) error {
 	if err := r.db.WithContext(ctx).Create(cardToRow(card)).Error; err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" &&
+			strings.Contains(pgErr.ConstraintName, "uq_cards_cardgroup_front") {
+			return ErrCardDuplicateFront
+		}
 		return eris.Wrap(err, "repository: create card")
 	}
 	return nil
+}
+
+func (r *cardRepo) FindByCardgroupAndFront(ctx context.Context, cardgroupID, front string) (*domain.Card, error) {
+	var row gormCard
+	err := r.db.WithContext(ctx).
+		Where("cardgroup_id = ? AND front = ?", cardgroupID, front).
+		Take(&row).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrNotFound
+		}
+		return nil, eris.Wrap(err, "repository: find card by cardgroup and front")
+	}
+	return cardToDomain(row), nil
 }
 
 func (r *cardRepo) UpdateFSRSStateTx(ctx context.Context, tx *gorm.DB, id string, state domain.FSRSState) error {

--- a/backend/internal/repository/card_test.go
+++ b/backend/internal/repository/card_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/stretchr/testify/require"
 	"gorm.io/gorm"
 
@@ -278,4 +279,79 @@ func TestCardRepository_OnCardgroupDeleteCascade(t *testing.T) {
 
 	_, err := cardRepo.FindByID(ctx, card.ID)
 	require.True(t, errors.Is(err, repository.ErrNotFound), "got %v", err)
+}
+
+// TestCardRepo_FindByCardgroupAndFront_CardgroupScoped guards the
+// cardgroup_id predicate in FindByCardgroupAndFront: a card with the same
+// front value in a different cardgroup must not bleed through.
+func TestCardRepo_FindByCardgroupAndFront_CardgroupScoped(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	ownerID := insertAuthUser(t, ctx)
+	repo := repository.NewCardRepository(testDB.GORM)
+
+	cgA := insertCardgroup(t, ctx, ownerID)
+	cgB := insertCardgroup(t, ctx, ownerID)
+
+	cardA := newCard(cgA.ID, "apple", "back-A")
+	cardB := newCard(cgB.ID, "apple", "back-B")
+	require.NoError(t, repo.Create(ctx, cardA))
+	require.NoError(t, repo.Create(ctx, cardB))
+
+	got, err := repo.FindByCardgroupAndFront(ctx, cgB.ID, "apple")
+	require.NoError(t, err)
+	require.Equal(t, cardB.ID, got.ID, "must return cardgroup B's card, not cardgroup A's")
+}
+
+// TestCardRepo_FindByCardgroupAndFront_TrimSensitive guards the exact-match
+// contract: callers are responsible for trimming; the repo must not do TRIM /
+// LOWER / LIKE matching. A front with surrounding whitespace must not match a
+// stored value without it.
+func TestCardRepo_FindByCardgroupAndFront_TrimSensitive(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	ownerID := insertAuthUser(t, ctx)
+	cg := insertCardgroup(t, ctx, ownerID)
+	repo := repository.NewCardRepository(testDB.GORM)
+
+	card := newCard(cg.ID, "apple", "back")
+	require.NoError(t, repo.Create(ctx, card))
+
+	_, err := repo.FindByCardgroupAndFront(ctx, cg.ID, " apple ")
+	require.True(t, errors.Is(err, repository.ErrNotFound),
+		"padded front must not match exact-stored value; got %v", err)
+}
+
+// TestCardRepo_Create_OtherUniqueViolationNotMisclassified guards the
+// ConstraintName check in Create: a 23505 violation on a constraint other than
+// uq_cards_cardgroup_front (here: cards_pkey) must NOT be returned as
+// ErrCardDuplicateFront. It must still surface as a non-nil error.
+func TestCardRepo_Create_OtherUniqueViolationNotMisclassified(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	ownerID := insertAuthUser(t, ctx)
+	cgA := insertCardgroup(t, ctx, ownerID)
+	cgB := insertCardgroup(t, ctx, ownerID)
+	repo := repository.NewCardRepository(testDB.GORM)
+
+	fixedID := uuid.NewString()
+	first := newCard(cgA.ID, "front-pkey-1", "back-1")
+	first.ID = fixedID
+	require.NoError(t, repo.Create(ctx, first))
+
+	// Reuse the same id with a different cardgroup and front to hit cards_pkey,
+	// not uq_cards_cardgroup_front.
+	second := newCard(cgB.ID, "front-pkey-2", "back-2")
+	second.ID = fixedID
+	err := repo.Create(ctx, second)
+
+	require.Error(t, err, "duplicate primary key must return an error")
+	require.False(t, errors.Is(err, repository.ErrCardDuplicateFront),
+		"cards_pkey violation must not be classified as ErrCardDuplicateFront; got %v", err)
+
+	// Confirm the underlying Postgres error code is 23505 so the test
+	// exercises the intended code path.
+	var pgErr *pgconn.PgError
+	require.True(t, errors.As(err, &pgErr), "underlying error must be a pgconn.PgError; got %T %v", err, err)
+	require.Equal(t, "23505", pgErr.Code)
 }

--- a/backend/internal/repository/card_test.go
+++ b/backend/internal/repository/card_test.go
@@ -210,6 +210,60 @@ func TestCardRepository_FindDueCardsTx_OrderedAndScoped(t *testing.T) {
 	require.Equal(t, later.ID, due[1].ID)
 }
 
+func TestCardRepo_Create_DuplicateFront(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	ownerID := insertAuthUser(t, ctx)
+	cg := insertCardgroup(t, ctx, ownerID)
+	repo := repository.NewCardRepository(testDB.GORM)
+
+	first := newCard(cg.ID, "same-front", "back-one")
+	if err := repo.Create(ctx, first); err != nil {
+		t.Fatalf("Create (first): %v", err)
+	}
+
+	second := newCard(cg.ID, "same-front", "back-two")
+	err := repo.Create(ctx, second)
+	if !errors.Is(err, repository.ErrCardDuplicateFront) {
+		t.Fatalf("Create (duplicate): want ErrCardDuplicateFront, got %v", err)
+	}
+	// ErrCardDuplicateFront is a standalone "found" sentinel; must NOT match ErrNotFound.
+	if errors.Is(err, repository.ErrNotFound) {
+		t.Fatalf("ErrCardDuplicateFront must not match ErrNotFound, got %v", err)
+	}
+}
+
+func TestCardRepo_FindByCardgroupAndFront(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	ownerID := insertAuthUser(t, ctx)
+	cg := insertCardgroup(t, ctx, ownerID)
+	repo := repository.NewCardRepository(testDB.GORM)
+
+	card := newCard(cg.ID, "find-front", "find-back")
+	if err := repo.Create(ctx, card); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// Hit: existing (cardgroup_id, front) pair returns the card.
+	got, err := repo.FindByCardgroupAndFront(ctx, cg.ID, "find-front")
+	if err != nil {
+		t.Fatalf("FindByCardgroupAndFront (hit): %v", err)
+	}
+	if got.ID != card.ID {
+		t.Errorf("FindByCardgroupAndFront (hit): ID = %q, want %q", got.ID, card.ID)
+	}
+	if got.Back != "find-back" {
+		t.Errorf("FindByCardgroupAndFront (hit): Back = %q, want %q", got.Back, "find-back")
+	}
+
+	// Miss: unknown front value must return ErrNotFound.
+	_, err = repo.FindByCardgroupAndFront(ctx, cg.ID, "no-such-front")
+	if !errors.Is(err, repository.ErrNotFound) {
+		t.Fatalf("FindByCardgroupAndFront (miss): want ErrNotFound, got %v", err)
+	}
+}
+
 func TestCardRepository_OnCardgroupDeleteCascade(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/backend/internal/usecase/card.go
+++ b/backend/internal/usecase/card.go
@@ -208,20 +208,16 @@ func (u *CardUsecase) Create(ctx context.Context, in CreateCardInput) (*domain.C
 		if errors.Is(err, repository.ErrCardDuplicateFront) {
 			existing, lookupErr := u.cardRepo.FindByCardgroupAndFront(ctx, in.CardgroupID, front)
 			if lookupErr != nil {
-				// ErrNotFound here means the duplicate row vanished between the
-				// failed INSERT and this SELECT — a concurrent delete raced us.
-				// Treat it as an internal error; the client can retry.
-				return nil, gqlerr.Internal(ctx, eris.Wrap(lookupErr, "usecase: lookup duplicate card after 23505"))
+				// The lookup may race with a concurrent delete (the duplicate row vanished
+				// between the failed INSERT and this SELECT) or fail for an unrelated DB
+				// reason. Either way, surface as Internal so the client can retry; the
+				// duplicate is recoverable input, but a failed re-lookup is not.
+				return nil, gqlerr.Internal(ctx,
+					eris.Wrap(lookupErr, "usecase: lookup duplicate card after 23505"),
+					slog.String("cardgroup_id", in.CardgroupID),
+				)
 			}
-			return nil, gqlerr.BadUserInputWithExtensions(
-				"front",
-				"card with same front exists in this cardgroup",
-				map[string]any{
-					"reason":         "CARD_DUPLICATE_FRONT",
-					"existingCardId": existing.ID,
-					"existingBack":   existing.Back,
-				},
-			)
+			return nil, gqlerr.BadUserInputCardDuplicateFront(existing.ID, existing.Back)
 		}
 		return nil, gqlerr.Internal(ctx, err)
 	}

--- a/backend/internal/usecase/card.go
+++ b/backend/internal/usecase/card.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/rotisserie/eris"
 	"gorm.io/gorm"
 
 	"backend/internal/auth"
@@ -29,6 +30,7 @@ type CardRepository interface {
 		dir repository.SortOrder,
 	) ([]*domain.Card, int64, error)
 	Create(ctx context.Context, card *domain.Card) error
+	FindByCardgroupAndFront(ctx context.Context, cardgroupID, front string) (*domain.Card, error)
 	Update(ctx context.Context, id string, patch repository.CardUpdate) (*domain.Card, error)
 	Delete(ctx context.Context, id string) error
 	DeleteByIDsTx(ctx context.Context, tx *gorm.DB, ownerID string, ids []string) (int64, error)
@@ -203,6 +205,24 @@ func (u *CardUsecase) Create(ctx context.Context, in CreateCardInput) (*domain.C
 		return nil, translateCardErr(ctx, err)
 	}
 	if err := u.cardRepo.Create(ctx, card); err != nil {
+		if errors.Is(err, repository.ErrCardDuplicateFront) {
+			existing, lookupErr := u.cardRepo.FindByCardgroupAndFront(ctx, in.CardgroupID, front)
+			if lookupErr != nil {
+				// ErrNotFound here means the duplicate row vanished between the
+				// failed INSERT and this SELECT — a concurrent delete raced us.
+				// Treat it as an internal error; the client can retry.
+				return nil, gqlerr.Internal(ctx, eris.Wrap(lookupErr, "usecase: lookup duplicate card after 23505"))
+			}
+			return nil, gqlerr.BadUserInputWithExtensions(
+				"front",
+				"card with same front exists in this cardgroup",
+				map[string]any{
+					"reason":         "CARD_DUPLICATE_FRONT",
+					"existingCardId": existing.ID,
+					"existingBack":   existing.Back,
+				},
+			)
+		}
 		return nil, gqlerr.Internal(ctx, err)
 	}
 	return card, nil

--- a/backend/internal/usecase/card_test.go
+++ b/backend/internal/usecase/card_test.go
@@ -648,6 +648,11 @@ func TestCardUsecase_Create_Duplicate(t *testing.T) {
 	}
 }
 
+// Two race-path tests exist: TestCardUsecase_Create_DuplicateLookupRace tests the
+// "unrelated DB error" branch; TestCardUsecase_Create_DuplicateLookupRace_RowVanished
+// tests the actual documented race — the duplicate row vanished before the lookup
+// (repository.ErrNotFound, a stdlib sentinel). The latter proves that production's
+// eris.Wrap at the call site makes the error_chain rich even for stdlib sentinels.
 func TestCardUsecase_Create_DuplicateLookupRace(t *testing.T) {
 	// Not parallel: mutates the global slog default.
 	const wantCardgroupID = "cg-test-id"
@@ -689,6 +694,70 @@ func TestCardUsecase_Create_DuplicateLookupRace(t *testing.T) {
 	root, hasRoot := chain["root"].(map[string]any)
 	if !hasRoot {
 		t.Error("error_chain must have root entry (got external-only shape; stub may be using stdlib errors)")
+	}
+	if root != nil {
+		if stack, _ := root["stack"].([]any); len(stack) == 0 {
+			t.Error("error_chain.root.stack must contain at least one frame")
+		}
+	}
+
+	if rec0["cardgroup_id"] != wantCardgroupID {
+		t.Errorf("expected cardgroup_id=%q in ERROR log, got %v", wantCardgroupID, rec0["cardgroup_id"])
+	}
+	if _, hasFront := rec0["front"]; hasFront {
+		t.Error("ERROR log must not contain 'front' field (user-supplied content)")
+	}
+}
+
+// TestCardUsecase_Create_DuplicateLookupRace_RowVanished exercises the documented
+// race scenario: the duplicate row disappears between the failed INSERT and the
+// subsequent SELECT, causing FindByCardgroupAndFront to return repository.ErrNotFound
+// (a stdlib errors.New sentinel). The load-bearing assertion is that error_chain.root
+// is present with a non-empty stack — proving that production's eris.Wrap at the
+// call site constructs a rich chain even when the underlying error is a stdlib sentinel.
+func TestCardUsecase_Create_DuplicateLookupRace_RowVanished(t *testing.T) {
+	// Not parallel: mutates the global slog default.
+	const wantCardgroupID = "cg-vanished-id"
+
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	defer slog.SetDefault(prev)
+
+	cardRepo := &mockCardRepository{
+		createErr:                  repository.ErrCardDuplicateFront,
+		findByCardgroupAndFrontErr: repository.ErrNotFound,
+	}
+	cgRepo := &mockCardgroupRepoForCard{findResult: &domain.Cardgroup{ID: wantCardgroupID, OwnerID: "u1"}}
+	uc := NewCardUsecase(nil, cardRepo, cgRepo)
+
+	_, err := uc.Create(authedCtx("u1"), CreateCardInput{CardgroupID: wantCardgroupID, Front: "hello", Back: "world"})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !gqlerr.IsCode(err, gqlerr.CodeInternal) {
+		t.Fatalf("expected INTERNAL error, got %v", err)
+	}
+
+	records := decodeJSONRecords(t, buf.Bytes())
+	if len(records) == 0 {
+		t.Fatal("expected at least one ERROR log record, got none")
+	}
+	rec0 := records[0]
+
+	if rec0["level"] != "ERROR" {
+		t.Errorf("expected level=ERROR, got %v", rec0["level"])
+	}
+
+	// Load-bearing: eris.Wrap in production must produce a rich chain even when
+	// the wrapped error is a stdlib sentinel (no stack of its own).
+	chain, ok := rec0["error_chain"].(map[string]any)
+	if !ok {
+		t.Fatalf("error_chain is not a JSON object: %T", rec0["error_chain"])
+	}
+	root, hasRoot := chain["root"].(map[string]any)
+	if !hasRoot {
+		t.Error("error_chain must have root entry (got external-only shape; eris.Wrap may be missing at the call site)")
 	}
 	if root != nil {
 		if stack, _ := root["stack"].([]any); len(stack) == 0 {

--- a/backend/internal/usecase/card_test.go
+++ b/backend/internal/usecase/card_test.go
@@ -1,12 +1,16 @@
 package usecase
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"testing"
 	"time"
 
+	"github.com/rotisserie/eris"
 	"github.com/vektah/gqlparser/v2/gqlerror"
 	"gorm.io/gorm"
 
@@ -54,8 +58,10 @@ type mockCardRepository struct {
 		dir         repository.SortOrder
 	}
 
-	findByCardgroupAndFrontResult *domain.Card
-	findByCardgroupAndFrontErr    error
+	findByCardgroupAndFrontResult                *domain.Card
+	findByCardgroupAndFrontErr                   error
+	findByCardgroupAndFrontCalledWithCardgroupID string
+	findByCardgroupAndFrontCalledWithFront       string
 }
 
 func (m *mockCardRepository) FindByID(_ context.Context, _ string) (*domain.Card, error) {
@@ -80,7 +86,9 @@ func (m *mockCardRepository) Create(_ context.Context, card *domain.Card) error 
 	m.capturedCreate = card
 	return m.createErr
 }
-func (m *mockCardRepository) FindByCardgroupAndFront(_ context.Context, _ string, _ string) (*domain.Card, error) {
+func (m *mockCardRepository) FindByCardgroupAndFront(_ context.Context, cardgroupID string, front string) (*domain.Card, error) {
+	m.findByCardgroupAndFrontCalledWithCardgroupID = cardgroupID
+	m.findByCardgroupAndFrontCalledWithFront = front
 	return m.findByCardgroupAndFrontResult, m.findByCardgroupAndFrontErr
 }
 func (m *mockCardRepository) Update(_ context.Context, _ string, patch repository.CardUpdate) (*domain.Card, error) {
@@ -579,6 +587,23 @@ func TestCardUsecase_ListCardsByCardgroupConnection_ResolveCursorHydratesDueFiel
 	}
 }
 
+// decodeJSONRecords parses newline-delimited JSON log lines from buf.
+func decodeJSONRecords(t *testing.T, data []byte) []map[string]any {
+	t.Helper()
+	var records []map[string]any
+	for _, line := range bytes.Split(bytes.TrimSpace(data), []byte("\n")) {
+		if len(line) == 0 {
+			continue
+		}
+		var rec map[string]any
+		if err := json.Unmarshal(line, &rec); err != nil {
+			t.Fatalf("decode log line %q: %v", line, err)
+		}
+		records = append(records, rec)
+	}
+	return records
+}
+
 func TestCardUsecase_Create_Duplicate(t *testing.T) {
 	t.Parallel()
 
@@ -590,7 +615,8 @@ func TestCardUsecase_Create_Duplicate(t *testing.T) {
 	cgRepo := &mockCardgroupRepoForCard{findResult: &domain.Cardgroup{ID: "cg1", OwnerID: "u1"}}
 	uc := NewCardUsecase(nil, cardRepo, cgRepo)
 
-	_, err := uc.Create(authedCtx("u1"), CreateCardInput{CardgroupID: "cg1", Front: "hello", Back: "world"})
+	// Submit with surrounding whitespace to regression-guard the TrimSpace contract.
+	_, err := uc.Create(authedCtx("u1"), CreateCardInput{CardgroupID: "cg1", Front: "  hello  ", Back: "world"})
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -610,23 +636,70 @@ func TestCardUsecase_Create_Duplicate(t *testing.T) {
 	if got, _ := gqlErr.Extensions["existingBack"].(string); got != "fixture-back" {
 		t.Fatalf("expected extensions.existingBack=%q, got %q", "fixture-back", got)
 	}
+
+	// Verify FindByCardgroupAndFront was called with the trimmed front and correct cardgroupID.
+	if cardRepo.findByCardgroupAndFrontCalledWithCardgroupID != "cg1" {
+		t.Errorf("expected FindByCardgroupAndFront cardgroupID=%q, got %q",
+			"cg1", cardRepo.findByCardgroupAndFrontCalledWithCardgroupID)
+	}
+	if cardRepo.findByCardgroupAndFrontCalledWithFront != "hello" {
+		t.Errorf("expected FindByCardgroupAndFront front=%q (trimmed), got %q",
+			"hello", cardRepo.findByCardgroupAndFrontCalledWithFront)
+	}
 }
 
 func TestCardUsecase_Create_DuplicateLookupRace(t *testing.T) {
-	t.Parallel()
+	// Not parallel: mutates the global slog default.
+	const wantCardgroupID = "cg-test-id"
+
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	defer slog.SetDefault(prev)
 
 	cardRepo := &mockCardRepository{
 		createErr:                  repository.ErrCardDuplicateFront,
-		findByCardgroupAndFrontErr: repository.ErrNotFound,
+		findByCardgroupAndFrontErr: eris.New("db: connection reset"),
 	}
-	cgRepo := &mockCardgroupRepoForCard{findResult: &domain.Cardgroup{ID: "cg1", OwnerID: "u1"}}
+	cgRepo := &mockCardgroupRepoForCard{findResult: &domain.Cardgroup{ID: wantCardgroupID, OwnerID: "u1"}}
 	uc := NewCardUsecase(nil, cardRepo, cgRepo)
 
-	_, err := uc.Create(authedCtx("u1"), CreateCardInput{CardgroupID: "cg1", Front: "hello", Back: "world"})
+	_, err := uc.Create(authedCtx("u1"), CreateCardInput{CardgroupID: wantCardgroupID, Front: "hello", Back: "world"})
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
 	if !gqlerr.IsCode(err, gqlerr.CodeInternal) {
 		t.Fatalf("expected INTERNAL error, got %v", err)
+	}
+
+	records := decodeJSONRecords(t, buf.Bytes())
+	if len(records) == 0 {
+		t.Fatal("expected at least one ERROR log record, got none")
+	}
+	rec0 := records[0]
+
+	if rec0["level"] != "ERROR" {
+		t.Errorf("expected level=ERROR, got %v", rec0["level"])
+	}
+
+	chain, ok := rec0["error_chain"].(map[string]any)
+	if !ok {
+		t.Fatalf("error_chain is not a JSON object: %T", rec0["error_chain"])
+	}
+	root, hasRoot := chain["root"].(map[string]any)
+	if !hasRoot {
+		t.Error("error_chain must have root entry (got external-only shape; stub may be using stdlib errors)")
+	}
+	if root != nil {
+		if stack, _ := root["stack"].([]any); len(stack) == 0 {
+			t.Error("error_chain.root.stack must contain at least one frame")
+		}
+	}
+
+	if rec0["cardgroup_id"] != wantCardgroupID {
+		t.Errorf("expected cardgroup_id=%q in ERROR log, got %v", wantCardgroupID, rec0["cardgroup_id"])
+	}
+	if _, hasFront := rec0["front"]; hasFront {
+		t.Error("ERROR log must not contain 'front' field (user-supplied content)")
 	}
 }

--- a/backend/internal/usecase/card_test.go
+++ b/backend/internal/usecase/card_test.go
@@ -7,9 +7,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/vektah/gqlparser/v2/gqlerror"
 	"gorm.io/gorm"
 
 	"backend/internal/domain"
+	"backend/internal/gqlerr"
 	"backend/internal/repository"
 )
 
@@ -51,6 +53,9 @@ type mockCardRepository struct {
 		orderBy     repository.CardOrderBy
 		dir         repository.SortOrder
 	}
+
+	findByCardgroupAndFrontResult *domain.Card
+	findByCardgroupAndFrontErr    error
 }
 
 func (m *mockCardRepository) FindByID(_ context.Context, _ string) (*domain.Card, error) {
@@ -74,6 +79,9 @@ func (m *mockCardRepository) DeleteByIDsTx(_ context.Context, _ *gorm.DB, ownerI
 func (m *mockCardRepository) Create(_ context.Context, card *domain.Card) error {
 	m.capturedCreate = card
 	return m.createErr
+}
+func (m *mockCardRepository) FindByCardgroupAndFront(_ context.Context, _ string, _ string) (*domain.Card, error) {
+	return m.findByCardgroupAndFrontResult, m.findByCardgroupAndFrontErr
 }
 func (m *mockCardRepository) Update(_ context.Context, _ string, patch repository.CardUpdate) (*domain.Card, error) {
 	m.capturedPatch = patch
@@ -568,5 +576,57 @@ func TestCardUsecase_ListCardsByCardgroupConnection_ResolveCursorHydratesDueFiel
 			}
 			tc.assertFn(t, got)
 		})
+	}
+}
+
+func TestCardUsecase_Create_Duplicate(t *testing.T) {
+	t.Parallel()
+
+	fixture := &domain.Card{ID: "fixture-id", CardgroupID: "cg1", Front: "hello", Back: "fixture-back"}
+	cardRepo := &mockCardRepository{
+		createErr:                     repository.ErrCardDuplicateFront,
+		findByCardgroupAndFrontResult: fixture,
+	}
+	cgRepo := &mockCardgroupRepoForCard{findResult: &domain.Cardgroup{ID: "cg1", OwnerID: "u1"}}
+	uc := NewCardUsecase(nil, cardRepo, cgRepo)
+
+	_, err := uc.Create(authedCtx("u1"), CreateCardInput{CardgroupID: "cg1", Front: "hello", Back: "world"})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	assertGQLErr(t, err, string(gqlerr.CodeBadUserInput), "front")
+
+	gqlErr, ok := err.(*gqlerror.Error)
+	if !ok {
+		t.Fatalf("expected *gqlerror.Error, got %T", err)
+	}
+	if got, _ := gqlErr.Extensions["reason"].(string); got != "CARD_DUPLICATE_FRONT" {
+		t.Fatalf("expected extensions.reason=%q, got %q", "CARD_DUPLICATE_FRONT", got)
+	}
+	if got, _ := gqlErr.Extensions["existingCardId"].(string); got != "fixture-id" {
+		t.Fatalf("expected extensions.existingCardId=%q, got %q", "fixture-id", got)
+	}
+	if got, _ := gqlErr.Extensions["existingBack"].(string); got != "fixture-back" {
+		t.Fatalf("expected extensions.existingBack=%q, got %q", "fixture-back", got)
+	}
+}
+
+func TestCardUsecase_Create_DuplicateLookupRace(t *testing.T) {
+	t.Parallel()
+
+	cardRepo := &mockCardRepository{
+		createErr:                  repository.ErrCardDuplicateFront,
+		findByCardgroupAndFrontErr: repository.ErrNotFound,
+	}
+	cgRepo := &mockCardgroupRepoForCard{findResult: &domain.Cardgroup{ID: "cg1", OwnerID: "u1"}}
+	uc := NewCardUsecase(nil, cardRepo, cgRepo)
+
+	_, err := uc.Create(authedCtx("u1"), CreateCardInput{CardgroupID: "cg1", Front: "hello", Back: "world"})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !gqlerr.IsCode(err, gqlerr.CodeInternal) {
+		t.Fatalf("expected INTERNAL error, got %v", err)
 	}
 }

--- a/frontend/src/app/cards/new/cards-new-client.test.tsx
+++ b/frontend/src/app/cards/new/cards-new-client.test.tsx
@@ -554,7 +554,7 @@ describe("<CardsNewClient> — duplicate-front overwrite flow", () => {
     await fillAndSubmit("apple", "new back text");
 
     // Dialog title acts as the discriminator.
-    await screen.findByText("カードはすでに存在します");
+    await screen.findByText("Card already exists");
     // Both sides of the comparison must be visible to make the choice informed.
     expect(screen.getByText("existing back text")).toBeInTheDocument();
     expect(screen.getByText("new back text")).toBeInTheDocument();
@@ -599,7 +599,7 @@ describe("<CardsNewClient> — duplicate-front overwrite flow", () => {
     await fillAndSubmit("apple", "new back text");
 
     const user = userEvent.setup();
-    const confirmBtn = await screen.findByRole("button", { name: "上書き" });
+    const confirmBtn = await screen.findByRole("button", { name: "Overwrite" });
     await user.click(confirmBtn);
 
     // updateCard mock was consumed exactly once.
@@ -608,7 +608,7 @@ describe("<CardsNewClient> — duplicate-front overwrite flow", () => {
     });
     // Dialog closes.
     await waitFor(() => {
-      expect(screen.queryByText("カードはすでに存在します")).not.toBeInTheDocument();
+      expect(screen.queryByText("Card already exists")).not.toBeInTheDocument();
     });
     // Form is reset.
     expect((screen.getByLabelText(/front/i) as HTMLInputElement).value).toBe("");
@@ -637,12 +637,12 @@ describe("<CardsNewClient> — duplicate-front overwrite flow", () => {
     await fillAndSubmit("apple", "new back text");
 
     const user = userEvent.setup();
-    const cancelBtn = await screen.findByRole("button", { name: "キャンセル" });
+    const cancelBtn = await screen.findByRole("button", { name: "Cancel" });
     await user.click(cancelBtn);
 
     // Dialog closes.
     await waitFor(() => {
-      expect(screen.queryByText("カードはすでに存在します")).not.toBeInTheDocument();
+      expect(screen.queryByText("Card already exists")).not.toBeInTheDocument();
     });
     // Form values preserved so the user can edit `front` and resubmit.
     expect((screen.getByLabelText(/front/i) as HTMLInputElement).value).toBe("apple");
@@ -675,14 +675,14 @@ describe("<CardsNewClient> — duplicate-front overwrite flow", () => {
     await fillAndSubmit("apple", "new back text");
 
     const user = userEvent.setup();
-    const confirmBtn = await screen.findByRole("button", { name: "上書き" });
+    const confirmBtn = await screen.findByRole("button", { name: "Overwrite" });
     await user.click(confirmBtn);
 
     // Dialog stays mounted.
     await waitFor(() => {
       expect(screen.getByRole("alert")).toBeInTheDocument();
     });
-    expect(screen.getByText("カードはすでに存在します")).toBeInTheDocument();
+    expect(screen.getByText("Card already exists")).toBeInTheDocument();
     // Form is NOT reset.
     expect((screen.getByLabelText(/front/i) as HTMLInputElement).value).toBe("apple");
     expect((screen.getByLabelText(/back/i) as HTMLInputElement).value).toBe("new back text");
@@ -704,7 +704,7 @@ describe("<CardsNewClient> — duplicate-front overwrite flow", () => {
     // Two MockedResponse entries: the first triggers the duplicate dialog,
     // the second is consumed by the overwrite click and rejects with a
     // BAD_USER_INPUT error carrying field=back. The dialog must render the
-    // backend message verbatim instead of the generic JP fallback.
+    // backend message verbatim instead of the generic fallback.
     const backValidatorMessage = "back must be at most 4096 characters";
     renderClient({
       mocks: [
@@ -733,20 +733,18 @@ describe("<CardsNewClient> — duplicate-front overwrite flow", () => {
     await fillAndSubmit("apple", "new back text");
 
     const user = userEvent.setup();
-    const confirmBtn = await screen.findByRole("button", { name: "上書き" });
+    const confirmBtn = await screen.findByRole("button", { name: "Overwrite" });
     await user.click(confirmBtn);
 
     // Dialog stays open and the backend's field-level message replaces the
-    // generic JP fallback.
+    // generic fallback.
     await waitFor(() => {
       expect(screen.getByText(backValidatorMessage)).toBeInTheDocument();
     });
-    expect(screen.getByText("カードはすでに存在します")).toBeInTheDocument();
+    expect(screen.getByText("Card already exists")).toBeInTheDocument();
     // The generic fallback must NOT be shown when a field-level message is
     // available — that was the original bug.
-    expect(
-      screen.queryByText("上書きに失敗しました。もう一度お試しください。"),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText("Overwrite failed. Please try again.")).not.toBeInTheDocument();
   });
 });
 

--- a/frontend/src/app/cards/new/cards-new-client.test.tsx
+++ b/frontend/src/app/cards/new/cards-new-client.test.tsx
@@ -152,9 +152,10 @@ function makeUpdateMock(args: {
   cardgroupId?: string;
   front?: string;
   onCalled?: () => void;
+  errors?: GraphQLError[];
   networkError?: Error;
 }): MockedResponse {
-  const { id, back, cardgroupId = CG_ID, front = "apple", onCalled, networkError } = args;
+  const { id, back, cardgroupId = CG_ID, front = "apple", onCalled, errors, networkError } = args;
   if (networkError) {
     return {
       request: {
@@ -171,6 +172,9 @@ function makeUpdateMock(args: {
     },
     result: () => {
       onCalled?.();
+      if (errors) {
+        return { errors };
+      }
       return {
         data: {
           updateCard: {
@@ -556,6 +560,15 @@ describe("<CardsNewClient> — duplicate-front overwrite flow", () => {
     expect(screen.getByText("new back text")).toBeInTheDocument();
     // No success indicator for the failed create.
     expect(screen.queryByRole("status")).not.toBeInTheDocument();
+    // Duplicate-front is routine validation: the create-rejection log path must
+    // be skipped so operators are not paged for a normal collision.
+    expect(consoleErrorSpy).not.toHaveBeenCalledWith(
+      "[cards-new-client] create card rejection",
+      expect.anything(),
+    );
+    // Dialog itself does not surface an inline error banner unless updateCard
+    // fails; CardForm's banner is also empty for field-only BAD_USER_INPUT.
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
   });
 
   it("confirm overwrite calls updateCard and resets form", async () => {
@@ -685,6 +698,55 @@ describe("<CardsNewClient> — duplicate-front overwrite flow", () => {
         }),
       );
     });
+  });
+
+  it("shows field-level error from updateCard back validator inline in the dialog", async () => {
+    // Two MockedResponse entries: the first triggers the duplicate dialog,
+    // the second is consumed by the overwrite click and rejects with a
+    // BAD_USER_INPUT error carrying field=back. The dialog must render the
+    // backend message verbatim instead of the generic JP fallback.
+    const backValidatorMessage = "back must be at most 4096 characters";
+    renderClient({
+      mocks: [
+        makeCreateMock({
+          front: "apple",
+          back: "new back text",
+          errors: [
+            makeDuplicateFrontError({
+              existingCardId: "existing-id",
+              existingBack: "existing back text",
+            }),
+          ],
+        }),
+        makeUpdateMock({
+          id: "existing-id",
+          back: "new back text",
+          errors: [
+            new GraphQLError(backValidatorMessage, {
+              extensions: { code: "BAD_USER_INPUT", field: "back" },
+            }),
+          ],
+        }),
+      ],
+    });
+
+    await fillAndSubmit("apple", "new back text");
+
+    const user = userEvent.setup();
+    const confirmBtn = await screen.findByRole("button", { name: "上書き" });
+    await user.click(confirmBtn);
+
+    // Dialog stays open and the backend's field-level message replaces the
+    // generic JP fallback.
+    await waitFor(() => {
+      expect(screen.getByText(backValidatorMessage)).toBeInTheDocument();
+    });
+    expect(screen.getByText("カードはすでに存在します")).toBeInTheDocument();
+    // The generic fallback must NOT be shown when a field-level message is
+    // available — that was the original bug.
+    expect(
+      screen.queryByText("上書きに失敗しました。もう一度お試しください。"),
+    ).not.toBeInTheDocument();
   });
 });
 

--- a/frontend/src/app/cards/new/cards-new-client.test.tsx
+++ b/frontend/src/app/cards/new/cards-new-client.test.tsx
@@ -5,7 +5,11 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { GraphQLError } from "graphql";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { CreateCardDocument, SetLastViewedCardgroupDocument } from "@/generated/graphql";
+import {
+  CreateCardDocument,
+  SetLastViewedCardgroupDocument,
+  UpdateCardDocument,
+} from "@/generated/graphql";
 import { installApolloMockLeakSpy } from "../../../../__tests__/utils/mock-apollo-paginated";
 import CardsNewClient from "./cards-new-client";
 
@@ -120,6 +124,73 @@ function makeCreateMock(args: {
   };
 }
 
+/**
+ * Build a GraphQLError carrying the BAD_USER_INPUT + CARD_DUPLICATE_FRONT
+ * extensions shape that the backend returns when (cardgroup_id, front)
+ * collides on insert. MockedProvider serves this via the `errors:` field; the
+ * Apollo client wraps the resulting response into a CombinedGraphQLErrors
+ * rejection so `tryGetDuplicateCardInfo(err)` matches.
+ */
+function makeDuplicateFrontError(args: {
+  existingCardId: string;
+  existingBack: string;
+}): GraphQLError {
+  return new GraphQLError("card with same front exists in this cardgroup", {
+    extensions: {
+      code: "BAD_USER_INPUT",
+      field: "front",
+      reason: "CARD_DUPLICATE_FRONT",
+      existingCardId: args.existingCardId,
+      existingBack: args.existingBack,
+    },
+  });
+}
+
+function makeUpdateMock(args: {
+  id: string;
+  back: string;
+  cardgroupId?: string;
+  front?: string;
+  onCalled?: () => void;
+  networkError?: Error;
+}): MockedResponse {
+  const { id, back, cardgroupId = CG_ID, front = "apple", onCalled, networkError } = args;
+  if (networkError) {
+    return {
+      request: {
+        query: UpdateCardDocument,
+        variables: { id, input: { back } },
+      },
+      error: networkError,
+    };
+  }
+  return {
+    request: {
+      query: UpdateCardDocument,
+      variables: { id, input: { back } },
+    },
+    result: () => {
+      onCalled?.();
+      return {
+        data: {
+          updateCard: {
+            __typename: "UpdateCardPayload" as const,
+            card: {
+              __typename: "Card" as const,
+              id,
+              front,
+              back,
+              due: "2026-04-30T00:00:00Z",
+              state: 0,
+              cardgroupId,
+            },
+          },
+        },
+      };
+    },
+  };
+}
+
 function makePersistMock(
   args: {
     cardgroupId?: string;
@@ -210,7 +281,7 @@ beforeEach(() => {
   // Capture MockedProvider unmatched-mock leak warnings — assertNoLeaks() in
   // afterEach turns them into hard failures.
   leakSpy = installApolloMockLeakSpy({
-    operationNames: ["CreateCard", "SetLastViewedCardgroup"],
+    operationNames: ["CreateCard", "SetLastViewedCardgroup", "UpdateCard"],
   });
   // Track non-leak warnings so we can introspect [cards-new] persist failures.
   consoleWarnSpy = vi.spyOn(console, "warn");
@@ -456,6 +527,164 @@ describe("<CardsNewClient> — stay-on-page consecutive add", () => {
     // SuccessIndicator must display the name of cg-2, not cg-1.
     const indicator = await screen.findByRole("status");
     expect(indicator).toHaveTextContent(/✓ Card added to "French 101"/);
+  });
+});
+
+describe("<CardsNewClient> — duplicate-front overwrite flow", () => {
+  it("shows duplicate dialog with side-by-side comparison when create returns CARD_DUPLICATE_FRONT", async () => {
+    renderClient({
+      mocks: [
+        makeCreateMock({
+          front: "apple",
+          back: "new back text",
+          errors: [
+            makeDuplicateFrontError({
+              existingCardId: "existing-id",
+              existingBack: "existing back text",
+            }),
+          ],
+        }),
+      ],
+    });
+
+    await fillAndSubmit("apple", "new back text");
+
+    // Dialog title acts as the discriminator.
+    await screen.findByText("カードはすでに存在します");
+    // Both sides of the comparison must be visible to make the choice informed.
+    expect(screen.getByText("existing back text")).toBeInTheDocument();
+    expect(screen.getByText("new back text")).toBeInTheDocument();
+    // No success indicator for the failed create.
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+  });
+
+  it("confirm overwrite calls updateCard and resets form", async () => {
+    const updateCalled = vi.fn();
+    renderClient({
+      mocks: [
+        makeCreateMock({
+          front: "apple",
+          back: "new back text",
+          errors: [
+            makeDuplicateFrontError({
+              existingCardId: "existing-id",
+              existingBack: "existing back text",
+            }),
+          ],
+        }),
+        // Second MockedResponse entry consumed by the overwrite click.
+        makeUpdateMock({
+          id: "existing-id",
+          back: "new back text",
+          onCalled: updateCalled,
+        }),
+        // Mirror create-success path: setLastViewed fire-and-forget.
+        makePersistMock(),
+      ],
+    });
+
+    await fillAndSubmit("apple", "new back text");
+
+    const user = userEvent.setup();
+    const confirmBtn = await screen.findByRole("button", { name: "上書き" });
+    await user.click(confirmBtn);
+
+    // updateCard mock was consumed exactly once.
+    await waitFor(() => {
+      expect(updateCalled).toHaveBeenCalledTimes(1);
+    });
+    // Dialog closes.
+    await waitFor(() => {
+      expect(screen.queryByText("カードはすでに存在します")).not.toBeInTheDocument();
+    });
+    // Form is reset.
+    expect((screen.getByLabelText(/front/i) as HTMLInputElement).value).toBe("");
+    expect((screen.getByLabelText(/back/i) as HTMLInputElement).value).toBe("");
+    // Success indicator appears.
+    expect(screen.getByRole("status")).toBeInTheDocument();
+  });
+
+  it("cancel keeps form intact and does not call updateCard", async () => {
+    renderClient({
+      mocks: [
+        makeCreateMock({
+          front: "apple",
+          back: "new back text",
+          errors: [
+            makeDuplicateFrontError({
+              existingCardId: "existing-id",
+              existingBack: "existing back text",
+            }),
+          ],
+        }),
+        // No updateCard mock — the leak spy in afterEach would catch a stray call.
+      ],
+    });
+
+    await fillAndSubmit("apple", "new back text");
+
+    const user = userEvent.setup();
+    const cancelBtn = await screen.findByRole("button", { name: "キャンセル" });
+    await user.click(cancelBtn);
+
+    // Dialog closes.
+    await waitFor(() => {
+      expect(screen.queryByText("カードはすでに存在します")).not.toBeInTheDocument();
+    });
+    // Form values preserved so the user can edit `front` and resubmit.
+    expect((screen.getByLabelText(/front/i) as HTMLInputElement).value).toBe("apple");
+    expect((screen.getByLabelText(/back/i) as HTMLInputElement).value).toBe("new back text");
+    // No success indicator.
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+  });
+
+  it("overwrite mutation error keeps dialog open and surfaces inline error", async () => {
+    renderClient({
+      mocks: [
+        makeCreateMock({
+          front: "apple",
+          back: "new back text",
+          errors: [
+            makeDuplicateFrontError({
+              existingCardId: "existing-id",
+              existingBack: "existing back text",
+            }),
+          ],
+        }),
+        makeUpdateMock({
+          id: "existing-id",
+          back: "new back text",
+          networkError: new Error("network failure"),
+        }),
+      ],
+    });
+
+    await fillAndSubmit("apple", "new back text");
+
+    const user = userEvent.setup();
+    const confirmBtn = await screen.findByRole("button", { name: "上書き" });
+    await user.click(confirmBtn);
+
+    // Dialog stays mounted.
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+    });
+    expect(screen.getByText("カードはすでに存在します")).toBeInTheDocument();
+    // Form is NOT reset.
+    expect((screen.getByLabelText(/front/i) as HTMLInputElement).value).toBe("apple");
+    expect((screen.getByLabelText(/back/i) as HTMLInputElement).value).toBe("new back text");
+    // No success indicator.
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+    // The inline error log carries the structured shape.
+    await waitFor(() => {
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "[cards-new-client] overwrite card rejection",
+        expect.objectContaining({
+          message: expect.any(String),
+          err: expect.anything(),
+        }),
+      );
+    });
   });
 });
 

--- a/frontend/src/app/cards/new/cards-new-client.tsx
+++ b/frontend/src/app/cards/new/cards-new-client.tsx
@@ -4,11 +4,23 @@ import { useMutation } from "@apollo/client/react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { CreateCardMutation } from "@/app/cardgroups/queries";
+import { CreateCardMutation, UpdateCardMutation } from "@/app/cardgroups/queries";
 import { SetLastViewedCardgroupMutation } from "@/app/learn/queries";
 import { CardForm } from "@/components/cardgroups/card-form";
 import { CardgroupChip } from "@/components/cardgroups/cardgroup-chip";
 import CardgroupPickerSheet from "@/components/cardgroups/cardgroup-picker-sheet";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { getBackendErrorBanner } from "@/lib/apollo/errors";
+import { tryGetDuplicateCardInfo } from "@/lib/apollo/graphql-errors";
 
 type Cardgroup = {
   id: string;
@@ -23,6 +35,18 @@ type Props = {
   /** Cardgroups owned by the current user, seeded server-side. */
   myCardgroups: Cardgroup[];
 };
+
+/**
+ * Holds the duplicate-card payload returned by the backend plus the user's
+ * attempted submission, so the overwrite-confirm dialog can render a
+ * side-by-side comparison without re-reading from form state.
+ */
+type DuplicateState = {
+  existingCardId: string;
+  existingBack: string;
+  attemptedFront: string;
+  attemptedBack: string;
+} | null;
 
 /**
  * Transient banner that announces a successful card creation. Self-dismisses
@@ -43,6 +67,88 @@ function SuccessIndicator({ message, onTimeout }: { message: string; onTimeout: 
     >
       {message}
     </div>
+  );
+}
+
+/**
+ * Confirmation dialog for the duplicate-front overwrite flow. Renders a
+ * side-by-side comparison of the existing card's back and the user's new
+ * back so the choice is informed. User-facing strings are Japanese to match
+ * the rest of the UX text in this app.
+ */
+function DuplicateOverwriteDialog({
+  duplicate,
+  onConfirm,
+  onCancel,
+  loading,
+  error,
+}: {
+  duplicate: NonNullable<DuplicateState>;
+  onConfirm: () => void;
+  onCancel: () => void;
+  loading: boolean;
+  error: string | null;
+}) {
+  return (
+    <AlertDialog
+      open
+      onOpenChange={(open) => {
+        // Radix calls onOpenChange(false) for Escape, outside-click and (by
+        // default) for Action/Cancel button clicks. We suppress the Action
+        // auto-close via event.preventDefault() in onConfirm so the dialog
+        // can stay open if the overwrite mutation fails; everything else
+        // (Escape, outside-click, the Cancel button) routes to onCancel.
+        if (!open) onCancel();
+      }}
+    >
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>カードはすでに存在します</AlertDialogTitle>
+          <AlertDialogDescription>
+            「{duplicate.attemptedFront}
+            」というカードはすでにこのカードグループにあります。裏面を新しい内容で上書きしますか？学習履歴は維持されます。
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          <div className="space-y-1">
+            <div className="text-xs font-medium text-muted-foreground">既存の裏面</div>
+            <pre className="whitespace-pre-wrap break-words rounded-md border bg-muted/40 p-2 text-sm">
+              {duplicate.existingBack}
+            </pre>
+          </div>
+          <div className="space-y-1">
+            <div className="text-xs font-medium text-muted-foreground">新しい裏面</div>
+            <pre className="whitespace-pre-wrap break-words rounded-md border bg-muted/40 p-2 text-sm">
+              {duplicate.attemptedBack}
+            </pre>
+          </div>
+        </div>
+
+        {error ? (
+          <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive" role="alert">
+            {error}
+          </div>
+        ) : null}
+
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={loading}>キャンセル</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={(e) => {
+              // Suppress Radix's default close-on-action behaviour. Closing is
+              // driven by the parent clearing `duplicate` after a successful
+              // overwrite; on failure the dialog must stay mounted so the user
+              // can retry or cancel.
+              e.preventDefault();
+              onConfirm();
+            }}
+            disabled={loading}
+          >
+            {loading ? "上書き中…" : "上書き"}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
   );
 }
 
@@ -68,6 +174,10 @@ export default function CardsNewClient({
   // deleted between page render and submit) and Apollo v3.x does not roll back
   // optimistic writes on typed errors — see .claude/rules/pagination.md.
   const [setLastViewed] = useMutation(SetLastViewedCardgroupMutation);
+  // Overwrite path also drops `optimisticResponse`: updateCard can fail typed
+  // (UNAUTHENTICATED on session expiry, BAD_USER_INPUT from validators) and
+  // Apollo v3.x does not roll back optimistic writes on typed errors.
+  const [updateCard, { loading: overwriting }] = useMutation(UpdateCardMutation);
 
   const resetFormRef = useRef<(() => void) | null>(null);
   // `successKey` doubles as "is the indicator visible?" (null = hidden) and as
@@ -75,6 +185,11 @@ export default function CardsNewClient({
   // to remount and restart its 2 s timer.
   const [successKey, setSuccessKey] = useState<number | null>(null);
   const [lastAddedName, setLastAddedName] = useState<string | null>(null);
+  const [duplicate, setDuplicate] = useState<DuplicateState>(null);
+  // Inline error rendered inside DuplicateOverwriteDialog when updateCard fails.
+  // Sibling state (rather than reusing createError) so the dialog stays open
+  // and the message survives even after the create-mutation hook resets.
+  const [overwriteError, setOverwriteError] = useState<string | null>(null);
 
   // Stable callback identities so that CardForm's useEffect([form, onResetReady])
   // and SuccessIndicator's useEffect([onTimeout]) do not re-fire on every parent
@@ -103,11 +218,61 @@ export default function CardsNewClient({
       setLastAddedName(currentName);
       setSuccessKey(Date.now());
     } catch (err) {
+      // Duplicate-front is a routine validation outcome, not a failure: surface
+      // the overwrite dialog and skip both the generic error toast and the
+      // console.error log. Anything else falls through to the existing path.
+      const dupe = tryGetDuplicateCardInfo(err);
+      if (dupe) {
+        setDuplicate({
+          existingCardId: dupe.existingCardId,
+          existingBack: dupe.existingBack,
+          attemptedFront: values.front,
+          attemptedBack: values.back,
+        });
+        return;
+      }
       console.error("[cards-new-client] create card rejection", {
         message: err instanceof Error ? err.message : String(err),
         err,
       });
     }
+  }
+
+  async function handleOverwrite() {
+    if (!duplicate || !currentId) return;
+    setOverwriteError(null);
+    try {
+      await updateCard({
+        variables: {
+          id: duplicate.existingCardId,
+          input: { back: duplicate.attemptedBack },
+        },
+      });
+      setDuplicate(null);
+      // Mirror the create-success path: fire-and-forget the last-viewed hint,
+      // reset the form, and bump the success indicator.
+      void setLastViewed({ variables: { cardgroupId: currentId } }).catch((err) => {
+        console.warn("[cards-new] setLastViewedCardgroup failed", { cardgroupId: currentId, err });
+      });
+      resetFormRef.current?.();
+      setLastAddedName(currentName);
+      setSuccessKey(Date.now());
+    } catch (err) {
+      // Leave `duplicate` set so the dialog stays mounted; surface the failure
+      // inline. Use the same shape the form uses (getBackendErrorBanner) so the
+      // message is familiar to the user.
+      const banner = getBackendErrorBanner(err) ?? "上書きに失敗しました。もう一度お試しください。";
+      setOverwriteError(banner);
+      console.error("[cards-new-client] overwrite card rejection", {
+        message: err instanceof Error ? err.message : String(err),
+        err,
+      });
+    }
+  }
+
+  function handleCancelOverwrite() {
+    setDuplicate(null);
+    setOverwriteError(null);
   }
 
   function handlePickerSelect(newId: string) {
@@ -161,6 +326,16 @@ export default function CardsNewClient({
             Done
           </Link>
         </div>
+      )}
+
+      {duplicate !== null && (
+        <DuplicateOverwriteDialog
+          duplicate={duplicate}
+          onConfirm={handleOverwrite}
+          onCancel={handleCancelOverwrite}
+          loading={overwriting}
+          error={overwriteError}
+        />
       )}
     </div>
   );

--- a/frontend/src/app/cards/new/cards-new-client.tsx
+++ b/frontend/src/app/cards/new/cards-new-client.tsx
@@ -70,12 +70,6 @@ function SuccessIndicator({ message, onTimeout }: { message: string; onTimeout: 
   );
 }
 
-/**
- * Confirmation dialog for the duplicate-front overwrite flow. Renders a
- * side-by-side comparison of the existing card's back and the user's new
- * back so the choice is informed. User-facing strings are Japanese to match
- * the rest of the UX text in this app.
- */
 function DuplicateOverwriteDialog({
   duplicate,
   onConfirm,
@@ -103,22 +97,22 @@ function DuplicateOverwriteDialog({
     >
       <AlertDialogContent>
         <AlertDialogHeader>
-          <AlertDialogTitle>カードはすでに存在します</AlertDialogTitle>
+          <AlertDialogTitle>Card already exists</AlertDialogTitle>
           <AlertDialogDescription>
-            「{duplicate.attemptedFront}
-            」というカードはすでにこのカードグループにあります。裏面を新しい内容で上書きしますか？学習履歴は維持されます。
+            A card with the front &ldquo;{duplicate.attemptedFront}&rdquo; already exists in this
+            cardgroup. Overwrite its back with your new content? Learning history is preserved.
           </AlertDialogDescription>
         </AlertDialogHeader>
 
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
           <div className="space-y-1">
-            <div className="text-xs font-medium text-muted-foreground">既存の裏面</div>
+            <div className="text-xs font-medium text-muted-foreground">Existing back</div>
             <pre className="whitespace-pre-wrap break-words rounded-md border bg-muted/40 p-2 text-sm">
               {duplicate.existingBack}
             </pre>
           </div>
           <div className="space-y-1">
-            <div className="text-xs font-medium text-muted-foreground">新しい裏面</div>
+            <div className="text-xs font-medium text-muted-foreground">New back</div>
             <pre className="whitespace-pre-wrap break-words rounded-md border bg-muted/40 p-2 text-sm">
               {duplicate.attemptedBack}
             </pre>
@@ -132,7 +126,7 @@ function DuplicateOverwriteDialog({
         ) : null}
 
         <AlertDialogFooter>
-          <AlertDialogCancel disabled={loading}>キャンセル</AlertDialogCancel>
+          <AlertDialogCancel disabled={loading}>Cancel</AlertDialogCancel>
           <AlertDialogAction
             onClick={(e) => {
               // Suppress Radix's default close-on-action behaviour. Closing is
@@ -144,7 +138,7 @@ function DuplicateOverwriteDialog({
             }}
             disabled={loading}
           >
-            {loading ? "上書き中…" : "上書き"}
+            {loading ? "Overwriting…" : "Overwrite"}
           </AlertDialogAction>
         </AlertDialogFooter>
       </AlertDialogContent>
@@ -267,8 +261,7 @@ export default function CardsNewClient({
       // and would otherwise fall through to the generic JP fallback.
       const fieldErrors = getBackendFieldErrors(err);
       const banner = getBackendErrorBanner(err);
-      const message =
-        fieldErrors.back ?? banner ?? "上書きに失敗しました。もう一度お試しください。";
+      const message = fieldErrors.back ?? banner ?? "Overwrite failed. Please try again.";
       setOverwriteError(message);
       console.error("[cards-new-client] overwrite card rejection", {
         message: err instanceof Error ? err.message : String(err),

--- a/frontend/src/app/cards/new/cards-new-client.tsx
+++ b/frontend/src/app/cards/new/cards-new-client.tsx
@@ -19,7 +19,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
-import { getBackendErrorBanner } from "@/lib/apollo/errors";
+import { getBackendErrorBanner, getBackendFieldErrors } from "@/lib/apollo/errors";
 import { tryGetDuplicateCardInfo } from "@/lib/apollo/graphql-errors";
 
 type Cardgroup = {
@@ -174,9 +174,8 @@ export default function CardsNewClient({
   // deleted between page render and submit) and Apollo v3.x does not roll back
   // optimistic writes on typed errors — see .claude/rules/pagination.md.
   const [setLastViewed] = useMutation(SetLastViewedCardgroupMutation);
-  // Overwrite path also drops `optimisticResponse`: updateCard can fail typed
-  // (UNAUTHENTICATED on session expiry, BAD_USER_INPUT from validators) and
-  // Apollo v3.x does not roll back optimistic writes on typed errors.
+  // Same Apollo v3.x rollback caveat as createCard above (UNAUTHENTICATED on
+  // session expiry, BAD_USER_INPUT from validators).
   const [updateCard, { loading: overwriting }] = useMutation(UpdateCardMutation);
 
   const resetFormRef = useRef<(() => void) | null>(null);
@@ -218,9 +217,12 @@ export default function CardsNewClient({
       setLastAddedName(currentName);
       setSuccessKey(Date.now());
     } catch (err) {
-      // Duplicate-front is a routine validation outcome, not a failure: surface
-      // the overwrite dialog and skip both the generic error toast and the
-      // console.error log. Anything else falls through to the existing path.
+      // Duplicate-front is routine validation, not a failure operators should
+      // be paged for: open the overwrite dialog, set `duplicate` state, and skip
+      // the [cards-new-client] console.error log. CardForm's banner stays empty
+      // because the duplicate-front error is a field-level BAD_USER_INPUT and
+      // getBackendErrorBanner returns undefined for that shape; any inline
+      // front-field message is shadowed by the dialog that overlays the form.
       const dupe = tryGetDuplicateCardInfo(err);
       if (dupe) {
         setDuplicate({
@@ -259,10 +261,15 @@ export default function CardsNewClient({
       setSuccessKey(Date.now());
     } catch (err) {
       // Leave `duplicate` set so the dialog stays mounted; surface the failure
-      // inline. Use the same shape the form uses (getBackendErrorBanner) so the
-      // message is familiar to the user.
-      const banner = getBackendErrorBanner(err) ?? "上書きに失敗しました。もう一度お試しください。";
-      setOverwriteError(banner);
+      // inline. Field-level error on `back` is the only validation-failure shape
+      // updateCard can return today (the input only carries `back`); surface it
+      // directly since getBackendErrorBanner skips field-level BAD_USER_INPUT
+      // and would otherwise fall through to the generic JP fallback.
+      const fieldErrors = getBackendFieldErrors(err);
+      const banner = getBackendErrorBanner(err);
+      const message =
+        fieldErrors.back ?? banner ?? "上書きに失敗しました。もう一度お試しください。";
+      setOverwriteError(message);
       console.error("[cards-new-client] overwrite card rejection", {
         message: err instanceof Error ? err.message : String(err),
         err,

--- a/frontend/src/app/cards/new/cards-new-client.tsx
+++ b/frontend/src/app/cards/new/cards-new-client.tsx
@@ -193,6 +193,21 @@ export default function CardsNewClient({
 
   const handleSuccessTimeout = useCallback(() => setSuccessKey(null), []);
 
+  // Shared post-success tail for both the create and overwrite paths:
+  // fire-and-forget the last-viewed hint (must not block the UI; setLastViewed
+  // can fail typed when the cardgroup was deleted between page render and
+  // submit), reset the form, and bump the success indicator. See
+  // .claude/rules/pagination.md on dropping optimisticResponse for typed-fail mutations.
+  function markCreationSucceeded() {
+    if (!currentId) return;
+    void setLastViewed({ variables: { cardgroupId: currentId } }).catch((err) => {
+      console.warn("[cards-new] setLastViewedCardgroup failed", { cardgroupId: currentId, err });
+    });
+    resetFormRef.current?.();
+    setLastAddedName(currentName);
+    setSuccessKey(Date.now());
+  }
+
   async function handleCreate(values: { front: string; back: string }) {
     if (!currentId) return;
     try {
@@ -201,15 +216,7 @@ export default function CardsNewClient({
           input: { cardgroupId: currentId, front: values.front, back: values.back },
         },
       });
-      // Fire-and-forget: this is the 4-priority-chain hint for the next visit
-      // and must not block or fail the create flow. No `await` so a slow or
-      // erroring persist call cannot delay the form reset.
-      void setLastViewed({ variables: { cardgroupId: currentId } }).catch((err) => {
-        console.warn("[cards-new] setLastViewedCardgroup failed", { cardgroupId: currentId, err });
-      });
-      resetFormRef.current?.();
-      setLastAddedName(currentName);
-      setSuccessKey(Date.now());
+      markCreationSucceeded();
     } catch (err) {
       // Duplicate-front is routine validation, not a failure operators should
       // be paged for: open the overwrite dialog, set `duplicate` state, and skip
@@ -245,20 +252,13 @@ export default function CardsNewClient({
         },
       });
       setDuplicate(null);
-      // Mirror the create-success path: fire-and-forget the last-viewed hint,
-      // reset the form, and bump the success indicator.
-      void setLastViewed({ variables: { cardgroupId: currentId } }).catch((err) => {
-        console.warn("[cards-new] setLastViewedCardgroup failed", { cardgroupId: currentId, err });
-      });
-      resetFormRef.current?.();
-      setLastAddedName(currentName);
-      setSuccessKey(Date.now());
+      markCreationSucceeded();
     } catch (err) {
       // Leave `duplicate` set so the dialog stays mounted; surface the failure
       // inline. Field-level error on `back` is the only validation-failure shape
       // updateCard can return today (the input only carries `back`); surface it
       // directly since getBackendErrorBanner skips field-level BAD_USER_INPUT
-      // and would otherwise fall through to the generic JP fallback.
+      // and would otherwise fall through to the generic banner fallback.
       const fieldErrors = getBackendFieldErrors(err);
       const banner = getBackendErrorBanner(err);
       const message = fieldErrors.back ?? banner ?? "Overwrite failed. Please try again.";

--- a/frontend/src/lib/apollo/graphql-errors.test.ts
+++ b/frontend/src/lib/apollo/graphql-errors.test.ts
@@ -1,5 +1,5 @@
 import { CombinedGraphQLErrors } from "@apollo/client/errors";
-import { describe, expect, test } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { isUnauthenticatedGraphQLError, tryGetDuplicateCardInfo } from "./graphql-errors";
 
 const PREFIX = "GraphQL errors: ";
@@ -153,7 +153,7 @@ describe("tryGetDuplicateCardInfo", () => {
     expect(tryGetDuplicateCardInfo(err)).toBeNull();
   });
 
-  test("shape mismatch: empty-string existingBack returns null", () => {
+  test("valid match: empty-string existingBack is accepted (back field may be empty)", () => {
     const err = makeCombined([
       {
         message: "duplicate",
@@ -165,7 +165,108 @@ describe("tryGetDuplicateCardInfo", () => {
         },
       },
     ]);
-    expect(tryGetDuplicateCardInfo(err)).toBeNull();
+    expect(tryGetDuplicateCardInfo(err)).toEqual({
+      existingCardId: "abc-123",
+      existingBack: "",
+    });
+  });
+
+  describe("malformed payload: warns once when code+reason match but shape fails", () => {
+    let warnSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      warnSpy.mockRestore();
+    });
+
+    test("empty existingCardId triggers console.warn and returns null", () => {
+      const err = makeCombined([
+        {
+          message: "duplicate",
+          extensions: {
+            code: "BAD_USER_INPUT",
+            reason: "CARD_DUPLICATE_FRONT",
+            existingCardId: "",
+            existingBack: "some back",
+          },
+        },
+      ]);
+      const result = tryGetDuplicateCardInfo(err);
+      expect(result).toBeNull();
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy).toHaveBeenCalledWith(
+        "[graphql-errors] CARD_DUPLICATE_FRONT entry missing required extension fields",
+        expect.objectContaining({
+          entry: expect.objectContaining({
+            extensions: expect.objectContaining({ reason: "CARD_DUPLICATE_FRONT" }),
+          }),
+        }),
+      );
+    });
+
+    test("missing existingCardId triggers console.warn and returns null", () => {
+      const err = makeCombined([
+        {
+          message: "duplicate",
+          extensions: {
+            code: "BAD_USER_INPUT",
+            reason: "CARD_DUPLICATE_FRONT",
+            existingBack: "some back",
+          },
+        },
+      ]);
+      const result = tryGetDuplicateCardInfo(err);
+      expect(result).toBeNull();
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy).toHaveBeenCalledWith(
+        "[graphql-errors] CARD_DUPLICATE_FRONT entry missing required extension fields",
+        expect.objectContaining({
+          entry: expect.objectContaining({
+            extensions: expect.objectContaining({ reason: "CARD_DUPLICATE_FRONT" }),
+          }),
+        }),
+      );
+    });
+
+    test("non-string existingBack triggers console.warn and returns null", () => {
+      const err = makeCombined([
+        {
+          message: "duplicate",
+          extensions: {
+            code: "BAD_USER_INPUT",
+            reason: "CARD_DUPLICATE_FRONT",
+            existingCardId: "abc-123",
+            existingBack: 99,
+          },
+        },
+      ]);
+      const result = tryGetDuplicateCardInfo(err);
+      expect(result).toBeNull();
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy).toHaveBeenCalledWith(
+        "[graphql-errors] CARD_DUPLICATE_FRONT entry missing required extension fields",
+        expect.objectContaining({
+          entry: expect.objectContaining({
+            extensions: expect.objectContaining({ reason: "CARD_DUPLICATE_FRONT" }),
+          }),
+        }),
+      );
+    });
+
+    test("entries that do not match discriminator do not trigger console.warn", () => {
+      const err = makeCombined([
+        {
+          message: "bad input no reason",
+          extensions: { code: "BAD_USER_INPUT", existingCardId: "", existingBack: "" },
+        },
+      ]);
+      const result = tryGetDuplicateCardInfo(err);
+      expect(result).toBeNull();
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
   });
 
   test("multi-entry: only one entry matches, returns that entry's payload", () => {

--- a/frontend/src/lib/apollo/graphql-errors.test.ts
+++ b/frontend/src/lib/apollo/graphql-errors.test.ts
@@ -1,5 +1,6 @@
+import { CombinedGraphQLErrors } from "@apollo/client/errors";
 import { describe, expect, test } from "vitest";
-import { isUnauthenticatedGraphQLError } from "./graphql-errors";
+import { isUnauthenticatedGraphQLError, tryGetDuplicateCardInfo } from "./graphql-errors";
 
 const PREFIX = "GraphQL errors: ";
 
@@ -48,5 +49,149 @@ describe("isUnauthenticatedGraphQLError", () => {
       { message: "another error" },
     ]);
     expect(isUnauthenticatedGraphQLError(err)).toBe(true);
+  });
+});
+
+function makeCombined(
+  errors: Array<{ message?: string; extensions?: Record<string, unknown> }>,
+): CombinedGraphQLErrors {
+  return new CombinedGraphQLErrors({
+    errors: errors.map((e) => ({ message: e.message ?? "error", ...e })),
+  });
+}
+
+describe("tryGetDuplicateCardInfo", () => {
+  test("match: correct code, reason, and payload returns DuplicateCardInfo", () => {
+    const err = makeCombined([
+      {
+        message: "card with same front exists in this cardgroup",
+        extensions: {
+          code: "BAD_USER_INPUT",
+          field: "front",
+          reason: "CARD_DUPLICATE_FRONT",
+          existingCardId: "abc-123",
+          existingBack: "existing back text",
+        },
+      },
+    ]);
+    expect(tryGetDuplicateCardInfo(err)).toEqual({
+      existingCardId: "abc-123",
+      existingBack: "existing back text",
+    });
+  });
+
+  test("no match (wrong code): BAD_USER_INPUT without reason discriminator returns null", () => {
+    const err = makeCombined([
+      {
+        message: "some bad input",
+        extensions: { code: "BAD_USER_INPUT", field: "front" },
+      },
+    ]);
+    expect(tryGetDuplicateCardInfo(err)).toBeNull();
+  });
+
+  test("no match (wrong reason): BAD_USER_INPUT with a different reason returns null", () => {
+    const err = makeCombined([
+      {
+        message: "other validation error",
+        extensions: {
+          code: "BAD_USER_INPUT",
+          field: "front",
+          reason: "SOME_OTHER_REASON",
+          existingCardId: "abc-123",
+          existingBack: "existing back text",
+        },
+      },
+    ]);
+    expect(tryGetDuplicateCardInfo(err)).toBeNull();
+  });
+
+  test("no match (other error type): UNAUTHENTICATED entry returns null", () => {
+    const err = makeCombined([
+      {
+        message: "Not authenticated",
+        extensions: { code: "UNAUTHENTICATED" },
+      },
+    ]);
+    expect(tryGetDuplicateCardInfo(err)).toBeNull();
+  });
+
+  test("no match (non-Combined error): plain Error returns null", () => {
+    expect(tryGetDuplicateCardInfo(new Error("hi"))).toBeNull();
+  });
+
+  test("no match (non-Combined): null returns null", () => {
+    expect(tryGetDuplicateCardInfo(null)).toBeNull();
+  });
+
+  test("shape mismatch: missing existingBack returns null", () => {
+    const err = makeCombined([
+      {
+        message: "duplicate",
+        extensions: {
+          code: "BAD_USER_INPUT",
+          reason: "CARD_DUPLICATE_FRONT",
+          existingCardId: "abc-123",
+        },
+      },
+    ]);
+    expect(tryGetDuplicateCardInfo(err)).toBeNull();
+  });
+
+  test("shape mismatch: non-string existingCardId returns null", () => {
+    const err = makeCombined([
+      {
+        message: "duplicate",
+        extensions: {
+          code: "BAD_USER_INPUT",
+          reason: "CARD_DUPLICATE_FRONT",
+          existingCardId: 42,
+          existingBack: "some back",
+        },
+      },
+    ]);
+    expect(tryGetDuplicateCardInfo(err)).toBeNull();
+  });
+
+  test("shape mismatch: empty-string existingBack returns null", () => {
+    const err = makeCombined([
+      {
+        message: "duplicate",
+        extensions: {
+          code: "BAD_USER_INPUT",
+          reason: "CARD_DUPLICATE_FRONT",
+          existingCardId: "abc-123",
+          existingBack: "",
+        },
+      },
+    ]);
+    expect(tryGetDuplicateCardInfo(err)).toBeNull();
+  });
+
+  test("multi-entry: only one entry matches, returns that entry's payload", () => {
+    const err = makeCombined([
+      {
+        message: "session expired",
+        extensions: { code: "UNAUTHENTICATED" },
+      },
+      {
+        message: "card with same front exists in this cardgroup",
+        extensions: {
+          code: "BAD_USER_INPUT",
+          field: "front",
+          reason: "CARD_DUPLICATE_FRONT",
+          existingCardId: "xyz-789",
+          existingBack: "the matching back",
+        },
+      },
+      {
+        message: "other field error",
+        extensions: { code: "BAD_USER_INPUT", field: "back" },
+      },
+    ]);
+    expect(tryGetDuplicateCardInfo(err)).toEqual({
+      existingCardId: "xyz-789",
+      existingBack: "the matching back",
+    });
   });
 });

--- a/frontend/src/lib/apollo/graphql-errors.ts
+++ b/frontend/src/lib/apollo/graphql-errors.ts
@@ -43,16 +43,22 @@ export type DuplicateCardInfo = {
  * GraphQL `extensions.code`".
  */
 export function tryGetDuplicateCardInfo(err: unknown): DuplicateCardInfo | null {
-  if (!(err instanceof CombinedGraphQLErrors)) return null;
-  for (const ge of err.errors) {
-    const ext = ge.extensions as Record<string, unknown> | undefined;
-    if (!ext) continue;
-    if (ext.code !== "BAD_USER_INPUT") continue;
-    if (ext.reason !== "CARD_DUPLICATE_FRONT") continue;
-    const existingCardId = ext.existingCardId;
-    const existingBack = ext.existingBack;
-    if (typeof existingCardId !== "string" || existingCardId === "") continue;
-    if (typeof existingBack !== "string" || existingBack === "") continue;
+  if (!CombinedGraphQLErrors.is(err)) return null;
+  for (const entry of err.errors) {
+    const ext = entry?.extensions as Record<string, unknown> | undefined;
+    if (!ext || ext.code !== "BAD_USER_INPUT" || ext.reason !== "CARD_DUPLICATE_FRONT") continue;
+    const { existingCardId, existingBack } = ext;
+    if (
+      typeof existingCardId !== "string" ||
+      existingCardId === "" ||
+      typeof existingBack !== "string"
+    ) {
+      console.warn(
+        "[graphql-errors] CARD_DUPLICATE_FRONT entry missing required extension fields",
+        { entry: { message: entry.message, extensions: ext } },
+      );
+      continue;
+    }
     return { existingCardId, existingBack };
   }
   return null;

--- a/frontend/src/lib/apollo/graphql-errors.ts
+++ b/frontend/src/lib/apollo/graphql-errors.ts
@@ -1,3 +1,5 @@
+import { CombinedGraphQLErrors } from "@apollo/client/errors";
+
 /**
  * Returns true when `err` is the synthesized GraphQL error thrown by gqlFetch
  * (`server.ts`) and at least one entry in the parsed errors array carries
@@ -16,4 +18,42 @@ export function isUnauthenticatedGraphQLError(err: unknown): boolean {
   } catch {
     return false;
   }
+}
+
+/** Payload returned when the backend detects a duplicate `front` in the same cardgroup. */
+export type DuplicateCardInfo = {
+  existingCardId: string;
+  existingBack: string;
+};
+
+/**
+ * Inspects a `CombinedGraphQLErrors` from the Apollo client for a
+ * `BAD_USER_INPUT / CARD_DUPLICATE_FRONT` entry and returns the existing-card
+ * payload when found, or `null` on any other input.
+ *
+ * Structural parse rationale: substring-matching `err.message` for
+ * `"CARD_DUPLICATE_FRONT"` would conflate a genuine duplicate error with any
+ * error whose message text happens to include the discriminator (user-supplied
+ * content echoed by the backend, telemetry strings, etc.). This function
+ * iterates `err.errors`, reads `extensions.code` and `extensions.reason`
+ * directly, and returns `null` on any shape mismatch — missing key, wrong
+ * type, or empty string — so callers never receive a partially-filled object.
+ *
+ * See .claude/rules/frontend-rsc-error-handling.md § "Structurally parse
+ * GraphQL `extensions.code`".
+ */
+export function tryGetDuplicateCardInfo(err: unknown): DuplicateCardInfo | null {
+  if (!(err instanceof CombinedGraphQLErrors)) return null;
+  for (const ge of err.errors) {
+    const ext = ge.extensions as Record<string, unknown> | undefined;
+    if (!ext) continue;
+    if (ext["code"] !== "BAD_USER_INPUT") continue;
+    if (ext["reason"] !== "CARD_DUPLICATE_FRONT") continue;
+    const existingCardId = ext["existingCardId"];
+    const existingBack = ext["existingBack"];
+    if (typeof existingCardId !== "string" || existingCardId === "") continue;
+    if (typeof existingBack !== "string" || existingBack === "") continue;
+    return { existingCardId, existingBack };
+  }
+  return null;
 }

--- a/frontend/src/lib/apollo/graphql-errors.ts
+++ b/frontend/src/lib/apollo/graphql-errors.ts
@@ -47,10 +47,10 @@ export function tryGetDuplicateCardInfo(err: unknown): DuplicateCardInfo | null 
   for (const ge of err.errors) {
     const ext = ge.extensions as Record<string, unknown> | undefined;
     if (!ext) continue;
-    if (ext["code"] !== "BAD_USER_INPUT") continue;
-    if (ext["reason"] !== "CARD_DUPLICATE_FRONT") continue;
-    const existingCardId = ext["existingCardId"];
-    const existingBack = ext["existingBack"];
+    if (ext.code !== "BAD_USER_INPUT") continue;
+    if (ext.reason !== "CARD_DUPLICATE_FRONT") continue;
+    const existingCardId = ext.existingCardId;
+    const existingBack = ext.existingBack;
     if (typeof existingCardId !== "string" || existingCardId === "") continue;
     if (typeof existingBack !== "string" || existingBack === "") continue;
     return { existingCardId, existingBack };

--- a/frontend/src/lib/apollo/graphql-errors.ts
+++ b/frontend/src/lib/apollo/graphql-errors.ts
@@ -53,6 +53,7 @@ export function tryGetDuplicateCardInfo(err: unknown): DuplicateCardInfo | null 
       existingCardId === "" ||
       typeof existingBack !== "string"
     ) {
+      // New extension fields added to CARD_DUPLICATE_FRONT must be reviewed for PII before landing — they appear verbatim in this warn payload.
       console.warn(
         "[graphql-errors] CARD_DUPLICATE_FRONT entry missing required extension fields",
         { entry: { message: entry.message, extensions: ext } },


### PR DESCRIPTION
## Summary

Implements an end-to-end "duplicate front detected → confirm and overwrite" flow for `/cards/new`. When a `Create` mutation collides with the `(cardgroup_id, front)` unique index, the backend repository layer classifies the Postgres `23505` violation into a typed `ErrCardDuplicateFront` sentinel; the usecase re-fetches the existing row and returns a `BAD_USER_INPUT` envelope carrying `extensions.reason: "CARD_DUPLICATE_FRONT"` plus `existingCardId` and `existingBack`. The frontend's new `tryGetDuplicateCardInfo` structurally parses the payload, opens an `AlertDialog` showing the existing vs. attempted back side-by-side, and on confirm runs an `UpdateCard` mutation that overwrites the back while preserving learning history. Multiple review iterations are folded into `.claude/rules/` covering the two-tier `gqlerr` API (open helper + typed wrapper + reason constant), Postgres unique-violation classification with a negative-test guard, standalone "found" sentinels, `CombinedGraphQLErrors.is` over `instanceof` across bundle realms, the `e.preventDefault()` requirement on `AlertDialogAction` to keep the dialog mounted on failure, and the variadic `gqlerr.Internal` attrs slot for triage context.

## Background / Motivation

- **A naive `INSERT` → `gqlerr.Internal` mapping turned a routine "card already exists" into a 5xx alarm.** Without classification, the Postgres `23505` violation was indistinguishable from a real server bug at the operator level, and the user got a generic banner instead of an actionable choice.
- **Substring-matching error messages would conflate cases.** A frontend `err.message.includes("CARD_DUPLICATE_FRONT")` would match user-supplied `front` content echoed by the backend, telemetry strings, or any future error whose text happens to contain the discriminator. Reading `extensions.code` and `extensions.reason` directly is the canonical structural parse.
- **Apollo's `instanceof CombinedGraphQLErrors` is unreliable across Next.js server/client bundles.** Each bundle has its own copy of `@apollo/client/errors`; an error from one realm fails `instanceof` in the other. `.is()` uses a duck-type check that survives the realm split.
- **Radix `AlertDialogAction` closes synchronously on click.** Without `e.preventDefault()` at the top of the action handler, a failing overwrite mutation would unmount the dialog the moment `onClick` resolves and the user would lose the inline error message. The parent must drive close-on-success, not Radix.
- **Open-coded `extensions` maps are stringly-typed at three sites.** A hand-rolled `map[string]any{"reason": "CARD_DUPLICATE_FRONT", ...}` at the usecase site means the discriminator string lives in three places (server emit, frontend parse, runbook) with no compile-time link. The two-tier API (`BadUserInputWithExtensions` generic helper + `BadUserInputCardDuplicateFront` domain wrapper + `ReasonCardDuplicateFront` typed constant) collapses the discriminator to one definition.
- **Joining `ErrCardDuplicateFront` with `ErrNotFound` would be a lie.** The `errors.Join(specific, general)` pattern only works when the specific case refines the general case (`ErrUserNotFound` refines `ErrNotFound`). `ErrCardDuplicateFront` is the inverse — the row was *found*, which is precisely the failure. Joining would make any general 404 mapper happily route a duplicate insert through the wrong path. Standalone is correct.
- **Apollo `useMutation`-managed `error` clears on the next call to the same mutation.** Reusing `createError` for the overwrite failure surface would silently dismiss the banner the moment the user retries `createCard`. A sibling `useState<string | null>` for `overwriteError` is the only way to keep the message until the user explicitly dismisses it.
- **A subtle race exists between the failed `INSERT` and the follow-up `SELECT`.** The usecase catches the `23505`, then calls `FindByCardgroupAndFront` to populate the dialog payload. Between those two queries another transaction can delete the row. The lookup returns `ErrNotFound`; the usecase wraps it with `eris.Wrap(lookupErr, "usecase: lookup duplicate card after 23505")` and surfaces `gqlerr.Internal` with a `cardgroup_id` triage attr — the variadic `Internal` attrs slot lets that context attach to the log line without leaking to the wire.

## Changes

### Backend — typed `gqlerr` API and `ReasonCardDuplicateFront`

- `backend/internal/gqlerr/errors.go` — new `BadUserInputReason` string-typed enum with `ReasonCardDuplicateFront = "CARD_DUPLICATE_FRONT"`. New generic helper `BadUserInputWithExtensions(field, message, extra)` merges arbitrary extension keys onto the standard `{code, field}` envelope (reserved keys `code`/`field` cannot be overridden). New domain wrapper `BadUserInputCardDuplicateFront(existingCardID, existingBack)` assembles the `{reason, existingCardId, existingBack}` triple at one site so the discriminator string is never stringly-typed at the usecase layer.
- `backend/internal/gqlerr/errors.go` — `Internal(ctx, err, attrs ...slog.Attr)` gains a variadic attrs slot. Existing two-arg call sites compile unchanged; new sites attach triage context (e.g. `slog.String("cardgroup_id", id)`) that appears only on the ERROR log — the wire response stays `{code: INTERNAL, message: "internal server error"}`.

### Backend — repository `23505` classification and scoped lookup

- `backend/internal/repository/card.go` — new standalone sentinel `ErrCardDuplicateFront`. `Create` inspects `*pgconn.PgError` with `Code == "23505"` and matches `ConstraintName` against the narrowest unambiguous fragment `uq_cards_cardgroup_front`, so a future `cards_pkey` collision is *not* mis-routed into the same sentinel. New `FindByCardgroupAndFront(ctx, cardgroupID, front)` returns the row or `ErrNotFound`; exact-match (no trim, no `ILIKE`) — callers own normalisation.

### Backend — usecase branch and race-tolerant `Internal`

- `backend/internal/usecase/card.go` — `Create` branches on `errors.Is(err, repository.ErrCardDuplicateFront)`: re-fetches the existing card via `FindByCardgroupAndFront` and returns `gqlerr.BadUserInputCardDuplicateFront(existing.ID, existing.Back)`. If the lookup itself fails (concurrent delete race or unrelated DB error), surfaces `gqlerr.Internal(ctx, eris.Wrap(lookupErr, "usecase: lookup duplicate card after 23505"), slog.String("cardgroup_id", in.CardgroupID))` so the operator can distinguish the race from a real regression.

### Frontend — structural error parser and realm-safe Apollo detection

- `frontend/src/lib/apollo/graphql-errors.ts` — new `tryGetDuplicateCardInfo(err)` returns `{ existingCardId, existingBack } | null`. Uses `CombinedGraphQLErrors.is(err)` (not `instanceof`) so it works across Next.js server/client bundle realms. Iterates `err.errors`, reads `extensions.code === "BAD_USER_INPUT"` AND `extensions.reason === "CARD_DUPLICATE_FRONT"` directly, and emits a `console.warn` with the raw `extensions` payload when the discriminator matches but required fields are missing — operators get a signal rather than a silent skip.

### Frontend — overwrite confirm dialog and cards-new-client integration

- `frontend/src/app/cards/new/cards-new-client.tsx` — new `DuplicateOverwriteDialog` component (Radix `AlertDialog`) renders the existing-back vs. attempted-back side-by-side. The action `onClick` calls `e.preventDefault()` at the top so a failing overwrite mutation keeps the dialog mounted; closing on success is driven by the parent clearing `duplicate` state.
- New `handleOverwrite` runs `UpdateCard` with `{ id: existingCardId, input: { back: attemptedBack } }`. Success closes the dialog and calls the shared `markCreationSucceeded` tail. Failure routes through `getBackendFieldErrors(err)?.back ?? getBackendErrorBanner(err) ?? generic` into a sibling `overwriteError` state — separate from `createError` so the message does not vanish on a retry of `createCard`.
- New `markCreationSucceeded()` helper de-duplicates the post-success tail (fire-and-forget `setLastViewed`, reset form, bump `successKey`) shared by `handleCreate` and `handleOverwrite`.

### Tests

- `backend/internal/repository/card_test.go` — duplicate-front positive test, negative test that a `cards_pkey` 23505 (different constraint) is NOT mis-classified, sentinel-non-overlap test (must NOT match `ErrNotFound`), `FindByCardgroupAndFront` hit/miss/cardgroup-scoped/exact-trim contract tests.
- `backend/internal/usecase/card_test.go` — happy path, duplicate detected and routed to `BadUserInputCardDuplicateFront`, race path where the duplicate row vanishes between the failed `INSERT` and the `SELECT` (`ErrNotFound` from a stdlib `errors.New` stub) — the test asserts the `error_chain.root.stack` shape proves the usecase's `eris.Wrap` is load-bearing.
- `backend/internal/gqlerr/errors_test.go` — `BadUserInputWithExtensions` reserved-key behavior (`code`/`field` cannot be overridden), variadic `Internal` attrs flow into the log record.
- `frontend/src/lib/apollo/graphql-errors.test.ts` — happy path, missing `existingBack`, missing `existingCardId`, malformed `extensions`, and the `console.warn` shape on partial discriminator match.
- `frontend/src/app/cards/new/cards-new-client.test.tsx` — dialog renders on duplicate, `e.preventDefault()` keeps it mounted on overwrite failure, success path closes the dialog and runs the shared tail, cancel/Escape/outside-click route through the cancel handler, sibling `overwriteError` survives a `createCard` retry.

### Documentation — `.claude/rules/`

- `error-wrapping.md` — Postgres unique-violation classification (`23505`), standalone "found" sentinels (do not join with `ErrNotFound`), and the two-tier `gqlerr` API pattern (open helper + typed wrapper + reason constant).
- `frontend-rsc-error-handling.md` — `CombinedGraphQLErrors.is` over `instanceof`, `getBackendErrorBanner` skips field-level `BAD_USER_INPUT` (use `getBackendFieldErrors` first), and structural error parsers must `console.warn` (not silently `continue`) on a partial-discriminator shape narrow.
- `frontend-typescript-conventions.md` — Radix `AlertDialogAction` `e.preventDefault()` requirement, the inverse case for discriminated unions (`T | null` is right when no consumer branches on `kind`), and required `string | null` over optional for caller-deliberate props.
- `go-library-gotchas.md` — exact-match `FindBy*` helpers (callers own trimming, repos own nothing), repository tenant-scoped lookups require a cross-tenant negative test.
- `pagination.md` — sibling `useState` over reusing one mutation's Apollo-managed `error` for another mutation's failure surface.
- `language-policy.md` — run the CJK grep *before* writing any new UI string literal; "matches existing UX text" memory is unreliable.

## Verification

After merge, the following should hold in the repo state:

- `grep -n "ReasonCardDuplicateFront" backend/internal/gqlerr/errors.go` matches the constant definition.
- `grep -nE "BadUserInputCardDuplicateFront|BadUserInputWithExtensions" backend/internal/gqlerr/errors.go` matches both helpers.
- `grep -n "uq_cards_cardgroup_front" backend/internal/repository/card.go` matches the constraint anchor.
- `grep -n "ErrCardDuplicateFront" backend/internal/repository/card.go backend/internal/usecase/card.go` matches the sentinel definition and the usecase consumer.
- `grep -n "tryGetDuplicateCardInfo" frontend/src/lib/apollo/graphql-errors.ts frontend/src/app/cards/new/cards-new-client.tsx` matches the definition and the consumer.
- `grep -n "CombinedGraphQLErrors.is" frontend/src/lib/apollo/graphql-errors.ts` matches the realm-safe detection.
- `grep -nE "DuplicateOverwriteDialog|markCreationSucceeded" frontend/src/app/cards/new/cards-new-client.tsx` matches the dialog component and the extracted helper.
- `grep -rnP "[\x{3040}-\x{30ff}\x{4e00}-\x{9fff}]" --include="*.tsx" --include="*.ts" --include="*.go" --include="*.md" frontend/src backend/internal docs .claude/rules` returns nothing.

Then on the running dev server (`pnpm --filter frontend dev` plus `make dev-backend`):

- Sign in, navigate to `/cards/new`, submit a card whose `front` already exists in the cardgroup — `AlertDialog` opens with the existing back and the attempted back side-by-side. Click Overwrite → the dialog closes, the success indicator fires, the form resets. Refresh → the card now shows the new back content (`existingCardId` was preserved; learning history intact).
- Same flow but disable the network before clicking Overwrite — the dialog stays mounted, inline error renders. Re-enable network and click Overwrite again → succeeds.
- Click Cancel (or press Escape, or click outside) → the dialog closes, the form keeps the user's input, no mutation runs.
- Submit a unique front (no duplicate) → no dialog; creation proceeds as before.

## Test plan

- [ ] `cd backend && go vet ./... && go build ./...` exits 0.
- [ ] `cd backend && go test -race ./...` exits 0 (covers the new repo, usecase, and `gqlerr` tests).
- [ ] `cd frontend && pnpm typecheck` exits 0.
- [ ] `cd frontend && pnpm lint` (Biome) exits 0 with no fixes applied.
- [ ] `cd frontend && pnpm test --run` exits 0 (covers `graphql-errors.test.ts` and the new `cards-new-client.test.tsx` cases).
- [ ] Manual: duplicate front → `AlertDialog` opens with the side-by-side comparison; Overwrite → success indicator fires, form resets; refresh → new back persisted.
- [ ] Manual: duplicate front → `AlertDialog` opens; Cancel → dialog closes, no mutation, form retains values.
- [ ] Manual: duplicate front → `AlertDialog` opens; Escape and outside-click both close the dialog and run no mutation.
- [ ] Manual: duplicate front → `AlertDialog` opens; toggle DevTools to Offline → click Overwrite → dialog stays mounted, inline error renders; re-enable network → click Overwrite again → succeeds.
- [ ] Manual: unique front → no dialog; card creation proceeds normally.
- [ ] Negative: temporarily replace `e.preventDefault()` in `AlertDialogAction.onClick` with a no-op → the test "keeps the dialog mounted on overwrite failure" fails. Revert.
- [ ] Negative: temporarily change `extensions.reason !== "CARD_DUPLICATE_FRONT"` to a substring match on `entry.message` in `tryGetDuplicateCardInfo` → the malformed-payload tests fail. Revert.
- [ ] Negative: temporarily widen the `ConstraintName` match from `uq_cards_cardgroup_front` to `cards` → the `cards_pkey` negative test fails (a primary-key 23505 mis-routes into `ErrCardDuplicateFront`). Revert.
- [ ] Language-policy grep clean: `grep -rnP "[\x{3040}-\x{30ff}\x{4e00}-\x{9fff}]" --include="*.tsx" --include="*.ts" --include="*.go" --include="*.md" frontend/src backend/internal docs .claude/rules` returns nothing; `grep -rnE "PR[0-9]+" frontend/src backend/internal docs .claude/rules` returns nothing.
