### PR TITLE
fix(setup-prod): make Phase 3 & 4 idempotent on re-runs

### DIFF
--- a/playbooks/setup-prod/render.yml
+++ b/playbooks/setup-prod/render.yml
@@ -31,18 +31,25 @@
 - name: Load state file (Phase 3 reads Phase 2 outputs)
   ansible.builtin.include_vars:
     file: "{{ state_file }}"
+    name: existing_state
   when: _state_stat.stat.exists
+
+# Coerce to a mapping so `existing_state.<key>` access and `| default(...)`
+# behave consistently when the file is absent, empty, or YAML-null.
+- name: Ensure existing_state is a mapping
+  ansible.builtin.set_fact:
+    existing_state: "{{ existing_state if (existing_state is defined and existing_state is mapping) else {} }}"
 
 - name: Assert required Phase 2 keys are present
   ansible.builtin.assert:
     that:
       - _state_stat.stat.exists
-      - supabase_project_ref is defined and (supabase_project_ref | length) > 0
-      - supabase_url is defined and (supabase_url | length) > 0
-      - supabase_jwks_url is defined and (supabase_jwks_url | length) > 0
-      - supabase_jwt_issuer is defined and (supabase_jwt_issuer | length) > 0
-      - supabase_anon_key is defined and (supabase_anon_key | length) > 0
-      - supabase_db_url is defined and (supabase_db_url | length) > 0
+      - (existing_state.supabase_project_ref | default('') | length) > 0
+      - (existing_state.supabase_url | default('') | length) > 0
+      - (existing_state.supabase_jwks_url | default('') | length) > 0
+      - (existing_state.supabase_jwt_issuer | default('') | length) > 0
+      - (existing_state.supabase_anon_key | default('') | length) > 0
+      - (existing_state.supabase_db_url | default('') | length) > 0
     fail_msg: |
       Required state keys from Phase 2 (supabase) are missing or empty.
       Run Phase 2 first:
@@ -108,15 +115,18 @@
 
       Press Enter when the service is created and you have all three values ready.
 
-# --- Collect render_service_id ---
+# --- Collect render_service_id (empty input keeps existing) ---
 - name: Prompt for Render service ID
   ansible.builtin.pause:
-    prompt: "Render service ID (format: srv-<alphanumeric>)"
+    prompt: "Render service ID [current: {{ existing_state.render_service_id | default('(none)') }}] (format: srv-<alphanumeric>; press Enter to keep current)"
   register: _render_service_id_input
 
-- name: Store render_service_id fact
+- name: Resolve render_service_id (keep existing on empty input)
   ansible.builtin.set_fact:
-    render_service_id: "{{ _render_service_id_input.user_input | trim }}"
+    render_service_id: >-
+      {{ (_render_service_id_input.user_input | default('') | trim)
+         if (_render_service_id_input.user_input | default('') | trim | length) > 0
+         else existing_state.render_service_id | default('') }}
 
 - name: Validate render_service_id format
   ansible.builtin.assert:
@@ -126,15 +136,18 @@
       render_service_id '{{ render_service_id }}' does not match the expected
       pattern srv-<alphanumeric>. Find it in Render: Settings > General.
 
-# --- Collect backend_url ---
+# --- Collect backend_url (empty input keeps existing) ---
 - name: Prompt for Render backend URL
   ansible.builtin.pause:
-    prompt: "Render backend URL (https://...onrender.com, or custom domain starting with https://)"
+    prompt: "Render backend URL [current: {{ existing_state.backend_url | default('(none)') }}] (https://...; press Enter to keep current)"
   register: _backend_url_input
 
-- name: Store backend_url fact
+- name: Resolve backend_url (keep existing on empty input)
   ansible.builtin.set_fact:
-    backend_url: "{{ _backend_url_input.user_input | trim }}"
+    backend_url: >-
+      {{ (_backend_url_input.user_input | default('') | trim)
+         if (_backend_url_input.user_input | default('') | trim | length) > 0
+         else existing_state.backend_url | default('') }}
 
 - name: Validate backend_url format
   ansible.builtin.assert:
@@ -144,17 +157,48 @@
       backend_url '{{ backend_url }}' must start with https://.
       Custom domains are accepted; the URL does not have to end in .onrender.com.
 
-# --- Collect deploy hook URL (no_log) ---
+# --- Check whether RENDER_DEPLOY_HOOK_URL is already a GitHub Actions secret.
+# The deploy-hook URL itself is not stored in the state file (sensitive,
+# single-use registration sink), so we cannot show it back in the prompt. We
+# can, however, check whether the GH secret already exists and let the
+# operator skip re-prompt + re-registration on a re-run. `gh secret list`
+# only reveals names, not values, so this check is safe to log.
+- name: Check whether RENDER_DEPLOY_HOOK_URL secret already exists
+  ansible.builtin.shell:
+    cmd: gh secret list --repo {{ repo }} --json name -q '[.[] | select(.name == "RENDER_DEPLOY_HOOK_URL")] | length'
+  register: _gh_secret_check
+  changed_when: false
+  failed_when: false
+
+- name: Determine deploy-hook secret presence
+  ansible.builtin.set_fact:
+    deploy_hook_already_registered: "{{ (_gh_secret_check.rc == 0) and ((_gh_secret_check.stdout | default('0') | trim | int) > 0) }}"
+
+# --- Collect deploy hook URL (no_log; empty input keeps existing GH secret if registered) ---
 - name: Prompt for Render deploy hook URL
   ansible.builtin.pause:
-    prompt: "Render deploy hook URL (https://api.render.com/deploy/...)"
+    prompt: "Render deploy hook URL [current: {{ '(registered in GitHub; press Enter to keep)' if deploy_hook_already_registered else '(not registered yet)' }}] (https://api.render.com/deploy/...)"
   no_log: true
   register: _deploy_hook_input
 
-- name: Store deploy_hook_url fact
+- name: Store deploy_hook_url fact (empty if keeping existing GH secret)
   ansible.builtin.set_fact:
-    deploy_hook_url: "{{ _deploy_hook_input.user_input | trim }}"
+    deploy_hook_url: "{{ _deploy_hook_input.user_input | default('') | trim }}"
   no_log: true
+
+# Hard-fail only when the operator entered nothing AND the secret has never
+# been registered. Re-runs that intentionally keep the existing secret pass
+# this gate via deploy_hook_already_registered=true.
+- name: Require deploy hook URL on first run
+  ansible.builtin.fail:
+    msg: |
+      RENDER_DEPLOY_HOOK_URL is not yet registered in GitHub and no value was
+      provided. Copy the deploy hook URL from Render: Settings > Deploy Hook,
+      then re-run:
+        ansible-playbook -i playbooks/inventory.local playbooks/setup-prod.yml --tags render
+  when:
+    - (deploy_hook_url | length) == 0
+    - not deploy_hook_already_registered
 
 - name: Validate deploy hook URL format
   ansible.builtin.assert:
@@ -163,6 +207,7 @@
     fail_msg: |
       deploy_hook_url must start with https://api.render.com/deploy/.
       Copy it from Render: Settings > Deploy Hook.
+  when: (deploy_hook_url | length) > 0
   no_log: true
 
 # --- Register deploy hook as GitHub Actions secret ---
@@ -170,6 +215,8 @@
 # deploy-hook URL with a trailing `\n`, which makes the CI's
 # `curl -fsS -X POST "$RENDER_DEPLOY_HOOK_URL"` fail with code=000 and break
 # every push-triggered deploy until the secret is manually re-set.
+#
+# Skipped on re-runs that kept the existing secret (empty input above).
 - name: Register RENDER_DEPLOY_HOOK_URL as a GitHub Actions secret
   ansible.builtin.shell:
     cmd: gh secret set RENDER_DEPLOY_HOOK_URL --repo {{ repo }}
@@ -179,6 +226,7 @@
   no_log: true
   failed_when: false
   changed_when: _gh_secret_result.rc == 0
+  when: (deploy_hook_url | length) > 0
 
 - name: Fail with remediation if gh secret set failed
   ansible.builtin.fail:
@@ -196,22 +244,29 @@
         - `repo` var is wrong / repo not found. Verify {{ repo }} is correct.
 
       Then retry: ansible-playbook -i playbooks/inventory.local playbooks/setup-prod.yml --tags render
-  when: _gh_secret_result.rc != 0
+  when:
+    - (deploy_hook_url | length) > 0
+    - _gh_secret_result.rc | default(0) != 0
 
 - name: Confirm GitHub secret registered
   ansible.builtin.debug:
-    msg: "RENDER_DEPLOY_HOOK_URL registered as a GitHub Actions secret in {{ repo }}."
+    msg: >-
+      {{ 'RENDER_DEPLOY_HOOK_URL registered as a GitHub Actions secret in ' ~ repo ~ '.'
+         if (deploy_hook_url | length) > 0
+         else 'RENDER_DEPLOY_HOOK_URL kept as-is (existing GitHub Actions secret in ' ~ repo ~ ').' }}
 
-# --- Generate PING_TOKEN if not already in state ---
+# --- Reuse PING_TOKEN from state, or generate if missing ---
 # The token is auto-generated (no external source); generating it here, in
 # Phase 3, means it is available in the state file before Phase 6 needs to
-# push it to Render via the API. Idempotent: if the state file already
+# push it to Render via the API. Idempotent: when the state file already
 # carries a non-empty ping_token (re-run of Phase 3), the existing value is
-# loaded by include_vars above and the generation task is skipped.
-- name: Generate PING_TOKEN if not already in state
+# kept; otherwise a fresh token is generated.
+- name: Reuse or generate PING_TOKEN
   ansible.builtin.set_fact:
-    ping_token: "{{ lookup('pipe', 'openssl rand -hex 32') }}"
-  when: ping_token is not defined or (ping_token | string | length) == 0
+    ping_token: >-
+      {{ existing_state.ping_token
+         if ((existing_state.ping_token | default('') | string | trim | length) > 0)
+         else lookup('pipe', 'openssl rand -hex 32') }}
   no_log: true
 
 # --- Persist render_service_id, backend_url, and ping_token into state file ---

--- a/playbooks/setup-prod/vercel.yml
+++ b/playbooks/setup-prod/vercel.yml
@@ -35,18 +35,25 @@
     path: "{{ state_file }}"
   register: _state_stat
 
-- name: Load state file (Phase 4)
+- name: Load state file (Phase 4 reads Phase 2/3 outputs)
   ansible.builtin.include_vars:
     file: "{{ state_file }}"
+    name: existing_state
   when: _state_stat.stat.exists
+
+# Coerce to a mapping so `existing_state.<key>` access and `| default(...)`
+# behave consistently when the file is absent, empty, or YAML-null.
+- name: Ensure existing_state is a mapping
+  ansible.builtin.set_fact:
+    existing_state: "{{ existing_state if (existing_state is defined and existing_state is mapping) else {} }}"
 
 - name: Assert Phase 2 (supabase) and Phase 3 (render) have run
   ansible.builtin.assert:
     that:
       - _state_stat.stat.exists
-      - backend_url is defined
-      - supabase_url is defined
-      - supabase_anon_key is defined
+      - (existing_state.backend_url | default('') | length) > 0
+      - (existing_state.supabase_url | default('') | length) > 0
+      - (existing_state.supabase_anon_key | default('') | length) > 0
     fail_msg: >-
       Required state values from earlier phases are missing.
 
@@ -56,6 +63,15 @@
       - The state file is corrupt or was hand-edited.
         Restore from the most recent backup:
           cp "$(ls -1t {{ state_file }}.*~ 2>/dev/null | head -1)" {{ state_file }}
+
+# Rebind upstream values to top-level facts so downstream tasks (`Show env
+# vars`, `Define desired env vars`, etc.) keep their existing references.
+# The assert above guarantees these keys are present and non-empty.
+- name: Rebind Phase 2/3 values from existing_state
+  ansible.builtin.set_fact:
+    backend_url: "{{ existing_state.backend_url }}"
+    supabase_url: "{{ existing_state.supabase_url }}"
+    supabase_anon_key: "{{ existing_state.supabase_anon_key }}"
 
 # ---------------------------------------------------------------------------
 # Show env vars the operator can verify after the API registers them.
@@ -90,16 +106,19 @@
       Press Enter once the project has been created.
   when: not confirm
 
-- name: Prompt for Vercel project ID
+- name: Prompt for Vercel project ID (empty input keeps existing)
   ansible.builtin.pause:
-    prompt: "Vercel project ID (Settings -> General -> Project ID; starts with prj_)"
+    prompt: "Vercel project ID [current: {{ existing_state.vercel_project_id | default('(none)') }}] (Settings -> General -> Project ID; starts with prj_; press Enter to keep current)"
     echo: true
   register: vercel_project_id_prompt
   when: not confirm
 
-- name: Resolve vercel_project_id
+- name: Resolve vercel_project_id (keep existing on empty input)
   ansible.builtin.set_fact:
-    vercel_project_id: "{{ vercel_project_id_prompt.user_input | default('') | trim }}"
+    vercel_project_id: >-
+      {{ (vercel_project_id_prompt.user_input | default('') | trim)
+         if (vercel_project_id_prompt.user_input | default('') | trim | length) > 0
+         else existing_state.vercel_project_id | default('') }}
 
 - name: Validate vercel_project_id shape
   ansible.builtin.assert:
@@ -108,7 +127,8 @@
     fail_msg: >-
       vercel_project_id must start with 'prj_' followed by alphanumeric
       characters. Got: '{{ vercel_project_id }}'.
-      Copy the value from Vercel -> Settings -> General -> Project ID.
+      Copy the value from Vercel -> Settings -> General -> Project ID,
+      or re-run and press Enter to reuse the value already in {{ state_file }}.
 
 # ---------------------------------------------------------------------------
 # Read VERCEL_API_TOKEN from the environment (Phase 1 already verified it
@@ -343,16 +363,19 @@
   ansible.builtin.debug:
     msg: "Reconciled {{ vercel_desired_env | length }} env vars on Vercel project {{ vercel_project_id }} (PATCH existing, POST new)."
 
-- name: Prompt for Vercel production URL
+- name: Prompt for Vercel production URL (empty input keeps existing)
   ansible.builtin.pause:
-    prompt: "Vercel production URL (e.g. https://flamingo-armond.vercel.app or custom domain)"
+    prompt: "Vercel production URL [current: {{ existing_state.production_url | default('(none)') }}] (e.g. https://flamingo-armond.vercel.app or custom domain; press Enter to keep current)"
     echo: true
   register: production_url_prompt
   when: not confirm
 
-- name: Resolve production_url
+- name: Resolve production_url (keep existing on empty input)
   ansible.builtin.set_fact:
-    production_url: "{{ production_url_prompt.user_input | default('') | trim }}"
+    production_url: >-
+      {{ (production_url_prompt.user_input | default('') | trim)
+         if (production_url_prompt.user_input | default('') | trim | length) > 0
+         else existing_state.production_url | default('') }}
 
 - name: Validate production_url shape
   ansible.builtin.assert:
@@ -360,7 +383,8 @@
       - production_url is match('^https://.+')
     fail_msg: >-
       production_url must begin with 'https://'. Got: '{{ production_url }}'.
-      Enter the full URL shown in Vercel -> Settings -> Domains.
+      Enter the full URL shown in Vercel -> Settings -> Domains,
+      or re-run and press Enter to reuse the value already in {{ state_file }}.
 
 # State file is known to exist at this point (assert above would have failed
 # otherwise), so re-reading via lookup is safe without errors='ignore'.


### PR DESCRIPTION
## Summary

Makes Phase 3 (`render`) and Phase 4 (`vercel`) of the `setup-prod` Ansible playbook safely re-runnable. State written by an earlier successful run is now reused on re-prompts: each interactive `pause` shows the current value in the prompt and accepts an empty input to keep it. The sensitive deploy-hook URL — which is intentionally **not** stored in `.setup-prod.state.yml` — is detected via `gh secret list` (names only, never values) so re-runs that keep the existing GitHub secret skip both the prompt-driven re-registration and the validation step. Both phases now load state into a namespaced `existing_state` mapping so the assert + default-chain access behaves uniformly when the file is absent, empty, or YAML-null.

## Background / Motivation

- **Re-running `--tags render` or `--tags vercel` after a successful first run forced a full re-entry of every value.** The operator had to retype `srv-...`, `https://...onrender.com`, `prj_...`, the production URL, and (for `render`) the deploy-hook URL on every iteration. There was no way to say "use what's already in the state file" — pressing Enter at any prompt produced an empty string that downstream `assert` tasks then rejected.
- **The deploy-hook URL is single-use, sensitive, and intentionally not persisted.** It registers as `RENDER_DEPLOY_HOOK_URL` in GitHub Actions and never lands in `.setup-prod.state.yml` (the state file is operator-readable; the hook URL grants unauthenticated POST-to-deploy on the production service). Without a way to *detect* whether the secret is already registered, every re-run had to re-prompt for it and re-`gh secret set`, which is friction and risks the trailing-newline bug that `1eae012` already fixed once.
- **`include_vars` without `name:` leaks loaded keys into the global play namespace.** That is fine when every key is set, but the assert step's `var is defined and (var | length) > 0` check disagrees with how downstream tasks read the value when the state file is YAML-null or empty (`var is defined` becomes `True` with `var == None`, and `None | length` errors out before the assert can even fail-msg). Loading into a namespaced mapping plus an explicit `is mapping` coercion makes `(existing_state.var | default('') | length) > 0` correct in all three states (absent file, empty file, YAML-null file).
- **`PING_TOKEN` regeneration on re-runs would invalidate the registered Render env var.** The token is generated locally in Phase 3 and pushed to Render's environment in Phase 6; re-running `--tags render` after a successful Phase 6 must reuse the existing token, not mint a fresh one that no longer matches the deployed service's expected value.
- **Phase 4 (`vercel`) had a parallel re-run friction.** `vercel_project_id` and `production_url` were re-prompted unconditionally even though the state file already carried both. The Vercel side does **not** need a `gh secret list`-style detection because Vercel env vars are reconciled via the Vercel API in an idempotent PATCH-existing / POST-new loop — so once `vercel_project_id` is recovered, the existing reconciler handles re-runs without modification.

## Changes

### Namespaced state load + mapping coercion (both phases)

- `playbooks/setup-prod/render.yml` and `playbooks/setup-prod/vercel.yml` — `include_vars` now loads into `existing_state` via the `name:` parameter instead of polluting the global namespace.
- A follow-up `set_fact` coerces `existing_state` to an empty mapping when the file is absent, empty, or YAML-null (`existing_state if (... is mapping) else {}`), so every later `existing_state.<key> | default('') | length` chain evaluates safely. Comment in both files names the three failure modes the coercion guards against.
- The Phase 2 / Phase 2+3 dependency `assert` blocks now read `(existing_state.<key> | default('') | length) > 0` instead of `<key> is defined and (<key> | length) > 0`. The new check correctly rejects keys that are present-but-empty or YAML-null, which the old `is defined` form silently accepted.

### Re-prompt with current-value display + empty-keeps-existing (both phases)

- `render.yml` — `render_service_id` and `backend_url` prompts now show `[current: <value>]` (or `(none)` on a fresh run) and explicitly invite `press Enter to keep current`. The `Resolve <field>` `set_fact` picks the trimmed user input when non-empty, otherwise falls back to `existing_state.<field> | default('')`.
- `vercel.yml` — same pattern for `vercel_project_id` and `production_url`. Validation `fail_msg` strings on both fields now mention the `or re-run and press Enter to reuse the value already in {{ state_file }}` recovery path so an operator who fat-fingers a fresh value gets a self-documenting next step.

### Deploy-hook detection via `gh secret list` (render-only)

- `render.yml` adds a `gh secret list --repo {{ repo }} --json name -q '[.[] | select(.name == "RENDER_DEPLOY_HOOK_URL")] | length'` shell call before the deploy-hook prompt. The query exposes secret **names** only (no values), so the task is safe to log without `no_log`.
- A `deploy_hook_already_registered` fact captures the boolean (`rc == 0` AND `stdout > 0`). The deploy-hook prompt then renders `(registered in GitHub; press Enter to keep)` vs. `(not registered yet)` based on this fact.
- A new `Require deploy hook URL on first run` `fail` task hard-stops the playbook only when the operator entered nothing **and** the GitHub secret has never been registered; the message names the exact `--tags render` re-run command. Re-runs that intentionally keep the existing secret pass this gate via `deploy_hook_already_registered=true`.
- The `Validate deploy hook URL format`, `Register RENDER_DEPLOY_HOOK_URL as a GitHub Actions secret`, and `Fail with remediation if gh secret set failed` tasks all gate on `(deploy_hook_url | length) > 0` so the `keep existing secret` re-run path skips them entirely. The `Confirm GitHub secret registered` debug message branches on the same flag and emits either `registered as a GitHub Actions secret` or `kept as-is (existing GitHub Actions secret)`.

### `PING_TOKEN` reuse over regenerate (render-only)

- The `Generate PING_TOKEN if not already in state` task collapses into a single `Reuse or generate PING_TOKEN` `set_fact` that picks `existing_state.ping_token` when present and non-blank, otherwise calls `lookup('pipe', 'openssl rand -hex 32')`. The `when:` guard is gone — the conditional now lives inline in the value expression — and the comment block explicitly calls out the Phase-6 contract: regenerating on a re-run would invalidate the token already pushed to the Render service.

### Fact rebind for downstream-task compatibility (vercel-only)

- `vercel.yml` adds a `Rebind Phase 2/3 values from existing_state` `set_fact` immediately after the assert. It copies `backend_url`, `supabase_url`, and `supabase_anon_key` from `existing_state` back to top-level facts so the existing `Show env vars`, `Define desired env vars`, and reconciliation tasks keep working with no rewrites. The assert above guarantees the keys are present and non-empty, so the rebind is safe without further default-chains.
- This pattern is intentionally absent from `render.yml` because Phase 3's downstream tasks (`gh secret set`, `Persist render_service_id, backend_url, and ping_token into state file`) reference values produced *within* Phase 3 itself (`render_service_id`, `backend_url`, `ping_token`, `deploy_hook_url`) — those facts are set by the new resolve-or-keep `set_fact` blocks and do not need rebinding from `existing_state`.

## Verification

After merge, the following should hold in the repo state:

- `grep -n "name: existing_state" playbooks/setup-prod/render.yml playbooks/setup-prod/vercel.yml` matches once in each file (the `include_vars` line).
- `grep -n "Ensure existing_state is a mapping" playbooks/setup-prod/render.yml playbooks/setup-prod/vercel.yml` matches once in each file.
- `grep -n "press Enter to keep current" playbooks/setup-prod/render.yml playbooks/setup-prod/vercel.yml` matches twice in each file (two re-promptable fields per phase).
- `grep -n "deploy_hook_already_registered" playbooks/setup-prod/render.yml` matches the fact-set, the prompt branch, the require-on-first-run guard's neighborhood, and the `Confirm GitHub secret registered` branch.
- `grep -n "Rebind Phase 2/3 values from existing_state" playbooks/setup-prod/vercel.yml` matches once.
- `grep -n "Reuse or generate PING_TOKEN" playbooks/setup-prod/render.yml` matches once; `grep -n "Generate PING_TOKEN if not already in state" playbooks/setup-prod/render.yml` returns nothing (old task name removed).
- `grep -rnE "PR[0-9]+" playbooks/setup-prod/` returns nothing.

Then on a clone with a populated `.setup-prod.state.yml` from an earlier successful bring-up:

- `ansible-playbook -i playbooks/inventory.local playbooks/setup-prod.yml --tags render` → each prompt shows `[current: <value>]`. Pressing Enter at every prompt keeps the existing values; the deploy-hook section emits `RENDER_DEPLOY_HOOK_URL kept as-is`; the `gh secret set` shell task is skipped; the state file is rewritten with the same values (idempotent).
- Same flow but enter a fresh `srv-...` at the `render_service_id` prompt → the new value is stored; other prompts stay defaulted; state file shows the updated `render_service_id` and unchanged other fields.
- `ansible-playbook -i playbooks/inventory.local playbooks/setup-prod.yml --tags vercel` → `vercel_project_id` and `production_url` prompts show `[current: <value>]` and accept Enter; the `Show env vars` debug output reflects the rebound `backend_url` / `supabase_url` / `supabase_anon_key`; downstream env-reconciliation runs against the kept project ID.

Negative-path runtime checks:

- Fresh checkout (no `.setup-prod.state.yml`) and no GH secret → `--tags render` fails at `Require deploy hook URL on first run` with the remediation message naming the `--tags render` re-run command.
- State file present but YAML-null (`echo '' > .setup-prod.state.yml`) → both phases fail-fast at the assert with `Required state values from earlier phases are missing`, not at a downstream task with a confusing `Could not find <key>` error.

## Test plan

- [ ] `ansible-lint playbooks/setup-prod/render.yml playbooks/setup-prod/vercel.yml` exits 0.
- [ ] `yamllint playbooks/setup-prod/render.yml playbooks/setup-prod/vercel.yml` exits 0.
- [ ] Manual: with a populated state file, `ansible-playbook ... --tags render` → press Enter at every prompt → all values preserved, GH secret untouched, state file rewrite is a no-op (mtime updates but content unchanged).
- [ ] Manual: with a populated state file, `ansible-playbook ... --tags render` → enter a fresh `srv-...` at the first prompt, Enter for the rest → `render_service_id` updated in state, other values preserved.
- [ ] Manual: with a populated state file, `ansible-playbook ... --tags vercel` → press Enter at every prompt → `vercel_project_id` and `production_url` preserved; Vercel API reconciliation runs idempotently.
- [ ] Manual: fresh state (`rm .setup-prod.state.yml*`), no `RENDER_DEPLOY_HOOK_URL` GH secret → `--tags render` → fails at `Require deploy hook URL on first run` with the documented remediation message.
- [ ] Manual: fresh state, GH secret already registered, empty input at deploy-hook prompt → playbook completes; `Confirm GitHub secret registered` debug emits `kept as-is`; `gh secret set` shell task is skipped (visible in `-v` output as a `skipping:` line).
- [ ] Manual: state file replaced with `''` (YAML-null) → `--tags render` and `--tags vercel` both fail-fast at the assert with the `Required state values ... are missing` message; no downstream task runs.
- [ ] Negative: temporarily delete the `Ensure existing_state is a mapping` `set_fact` block from either file → run with a YAML-null state file → assert fails with `'NoneType' has no attribute 'supabase_project_ref'` (or similar), confirming the coercion is load-bearing. Revert.
- [ ] Negative: temporarily change the `Reuse or generate PING_TOKEN` value expression to always call `lookup('pipe', ...)` → re-run `--tags render` against a populated state → state file shows a fresh `ping_token`, breaking the Phase-6 contract. Revert.
- [ ] Language-policy: `grep -rnP "[\x{3040}-\x{30ff}\x{4e00}-\x{9fff}]" playbooks/setup-prod/` returns nothing; `grep -rnE "PR[0-9]+" playbooks/setup-prod/` returns nothing.
