### PR TITLE
refactor(layout): liquid layout sitewide; fix Tailwind v4 sidebar CSS vars

### DIFF
--- a/frontend/src/app/admin/dictionary/dictionary-client.tsx
+++ b/frontend/src/app/admin/dictionary/dictionary-client.tsx
@@ -131,7 +131,7 @@ export function DictionaryImportClient() {
     validationResult?.valid === true && validationResult.parsedWords.length > 0 && !!cardgroupId;
 
   return (
-    <main className="mx-auto max-w-3xl p-8">
+    <main className="p-8">
       <div className="mb-6 flex items-center gap-4">
         <Link href="/cardgroups" className="text-sm text-muted-foreground hover:underline">
           &larr; Back

--- a/frontend/src/app/admin/roles/AdminRolesClient.tsx
+++ b/frontend/src/app/admin/roles/AdminRolesClient.tsx
@@ -133,7 +133,7 @@ export function AdminRolesClient({ initialRoles }: Props) {
   }
 
   return (
-    <div className="mx-auto max-w-2xl space-y-4 p-8">
+    <div className="space-y-4 p-8">
       <h1 className="text-2xl font-semibold">Roles</h1>
 
       {error && (

--- a/frontend/src/app/admin/users/AdminUsersClient.tsx
+++ b/frontend/src/app/admin/users/AdminUsersClient.tsx
@@ -176,7 +176,7 @@ export function AdminUsersClient() {
   const initialLoading = loading && edges.length === 0 && networkStatus !== NetworkStatus.fetchMore;
 
   return (
-    <main className="mx-auto max-w-3xl p-8">
+    <main className="p-8">
       <div className="mb-6 flex items-center gap-4">
         <h1 className="text-2xl font-semibold">Users</h1>
         <span className="text-sm text-muted-foreground">({totalCount})</span>

--- a/frontend/src/app/admin/users/[id]/edit/AdminUserEditClient.tsx
+++ b/frontend/src/app/admin/users/[id]/edit/AdminUserEditClient.tsx
@@ -147,7 +147,7 @@ export function AdminUserEditClient({ user, allRoles }: Props) {
   }
 
   return (
-    <main className="mx-auto max-w-2xl p-8">
+    <main className="p-8">
       {/* Navigation */}
       <div className="mb-6 flex items-center gap-4">
         <Link href="/admin/users" className="text-sm text-muted-foreground hover:underline">

--- a/frontend/src/app/cardgroups/[id]/cards/page.tsx
+++ b/frontend/src/app/cardgroups/[id]/cards/page.tsx
@@ -56,7 +56,7 @@ export default async function CardsPage({ params }: { params: Promise<{ id: stri
   const initialTotalCount = connectionData?.cardsByCardgroupConnection.totalCount ?? 0;
 
   return (
-    <main className="mx-auto max-w-2xl p-8">
+    <main className="p-8">
       <div className="mb-3 flex items-center gap-4">
         <Link href={`/cardgroups/${id}`} className="text-sm text-muted-foreground hover:underline">
           &larr; Back

--- a/frontend/src/app/cardgroups/[id]/edit/edit-cardgroup-client.tsx
+++ b/frontend/src/app/cardgroups/[id]/edit/edit-cardgroup-client.tsx
@@ -102,7 +102,7 @@ export function EditCardgroupClient({ cardgroup }: Props) {
   );
 
   return (
-    <main className="mx-auto max-w-xl p-8">
+    <main className="p-8">
       <div className="mb-6 flex items-center gap-4">
         <Link
           href={`/cardgroups/${cardgroup.id}`}

--- a/frontend/src/app/cardgroups/[id]/page.tsx
+++ b/frontend/src/app/cardgroups/[id]/page.tsx
@@ -51,7 +51,7 @@ export default async function CardgroupDetailPage({ params }: { params: Promise<
   const previewCards = cards.slice(0, 5);
 
   return (
-    <main className="mx-auto max-w-2xl p-8">
+    <main className="p-8">
       <h1 className="mb-2 text-2xl font-semibold">{cardgroup.name}</h1>
       <p className="mb-6 text-sm text-muted-foreground">
         Updated {formatMediumDate(cardgroup.updatedAt as string)}

--- a/frontend/src/app/cardgroups/new/new-cardgroup-client.tsx
+++ b/frontend/src/app/cardgroups/new/new-cardgroup-client.tsx
@@ -52,7 +52,7 @@ export function NewCardgroupClient({ showWelcome = false, returnTo }: NewCardgro
   }
 
   return (
-    <main className="mx-auto max-w-xl p-8">
+    <main className="p-8">
       {showWelcome && (
         <div className="mb-8 rounded-lg border border-border bg-card p-6">
           <h2 className="mb-2 text-lg font-semibold">

--- a/frontend/src/app/cardgroups/page.tsx
+++ b/frontend/src/app/cardgroups/page.tsx
@@ -31,7 +31,7 @@ export default async function CardgroupsPage() {
   const cardgroups = data.myCardgroups;
 
   return (
-    <main className="mx-auto max-w-2xl p-8">
+    <main className="p-8">
       <div className="mb-6">
         <h1 className="text-2xl font-semibold">My Cardgroups</h1>
       </div>

--- a/frontend/src/app/cards/new/page.tsx
+++ b/frontend/src/app/cards/new/page.tsx
@@ -67,7 +67,7 @@ export default async function CardsNewPage({ searchParams }: CardsNewPageProps) 
   }
 
   return (
-    <main className="mx-auto max-w-2xl p-8">
+    <main className="p-8">
       <h1 className="mb-6 text-2xl font-semibold">New card</h1>
       <CardsNewClient
         initialCardgroupId={resolvedCardgroupId}

--- a/frontend/src/app/layout.test.tsx
+++ b/frontend/src/app/layout.test.tsx
@@ -42,6 +42,14 @@ vi.mock("next/navigation", () => ({
   usePathname: vi.fn(() => "/"),
 }));
 
+// next/headers — middleware forwards the request pathname via x-pathname so
+// the server component can decide whether to mount AppShell. Tests override
+// the return value for the /login bypass case.
+const mockGetHeader = vi.fn<(name: string) => string | null>(() => null);
+vi.mock("next/headers", () => ({
+  headers: vi.fn(() => Promise.resolve({ get: mockGetHeader })),
+}));
+
 // ---------------------------------------------------------------------------
 // Import after mocks are registered.
 // ---------------------------------------------------------------------------
@@ -130,6 +138,9 @@ let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
 beforeEach(() => {
   vi.clearAllMocks();
   resetMockSupabase();
+  // Default: x-pathname is absent, so layout falls through to the AppShell
+  // branch. The /login test overrides this per-case.
+  mockGetHeader.mockReturnValue(null);
   consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
   consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 });
@@ -300,5 +311,22 @@ describe("RootLayout — error handling and AppShell prop wiring", () => {
     expect(consoleWarnSpy).not.toHaveBeenCalled();
     expect(props.user).toBeNull();
     expect(props.isAdmin).toBe(false);
+  });
+
+  // Case 9: /login route bypasses AppShell entirely. The layout must NOT call
+  // Supabase getUser() (the auth page handles its own session check) and the
+  // returned tree must NOT contain an AppShell element. The supabase server
+  // client mock would still be invocable, but the layout must short-circuit
+  // before reaching it.
+  test("/login: layout renders bare children without AppShell, no Supabase or gqlFetch calls", async () => {
+    mockGetHeader.mockImplementation((name) => (name === "x-pathname" ? "/login" : null));
+
+    const tree = await RootLayout({ children: <div data-testid="login-children" /> });
+    const appShellProps = findElementProps(tree, "AppShell");
+
+    expect(appShellProps).toBeNull();
+    expect(gqlFetch).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { headers } from "next/headers";
 import type { ReactNode } from "react";
 import { AppShell } from "@/components/nav/app-shell";
 import { GlobalFAB } from "@/components/nav/global-fab";
@@ -15,6 +16,22 @@ export const metadata: Metadata = {
 };
 
 export default async function RootLayout({ children }: { children: ReactNode }) {
+  // Read the pathname forwarded by middleware so this server component can
+  // decide whether to mount the navigation shell. /login renders bare so the
+  // sign-in screen owns the entire viewport.
+  const headersList = await headers();
+  const pathname = headersList.get("x-pathname") ?? "/";
+
+  if (pathname === "/login") {
+    return (
+      <html lang="en">
+        <body suppressHydrationWarning>
+          <Providers>{children}</Providers>
+        </body>
+      </html>
+    );
+  }
+
   const supabase = await createSupabaseServerClient();
   const {
     data: { user },

--- a/frontend/src/app/login/login-button.tsx
+++ b/frontend/src/app/login/login-button.tsx
@@ -44,7 +44,7 @@ export function LoginButton() {
   }
 
   return (
-    <Button onClick={handleSignIn} type="button">
+    <Button onClick={handleSignIn} type="button" variant="brand">
       <GoogleGLogo />
       Continue with Google
     </Button>

--- a/frontend/src/app/profile/change-email/page.tsx
+++ b/frontend/src/app/profile/change-email/page.tsx
@@ -17,7 +17,7 @@ export default async function ChangeEmailPage() {
   if (!user) redirect("/login");
 
   return (
-    <main className="mx-auto max-w-xl p-8">
+    <main className="p-8">
       <h1 className="mb-6 text-2xl font-semibold">Change email</h1>
       <ChangeEmailClient currentEmail={user.email ?? null} />
     </main>

--- a/frontend/src/app/profile/error.tsx
+++ b/frontend/src/app/profile/error.tsx
@@ -29,7 +29,7 @@ export default function ProfileError({ error, reset }: ErrorPageProps) {
   }, [error, router]);
 
   return (
-    <main className="mx-auto max-w-xl p-8">
+    <main className="p-8">
       <h1 className="mb-3 text-2xl font-semibold">Couldn&apos;t load your profile</h1>
       <p className="mb-6 text-sm text-muted-foreground">
         Something went wrong while loading your profile. Please try again in a moment.

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -35,7 +35,7 @@ export default async function ProfilePage() {
   }
 
   return (
-    <main className="mx-auto max-w-xl p-8">
+    <main className="p-8">
       <h1 className="mb-6 text-2xl font-semibold">Edit profile</h1>
       <ProfileForm
         email={user.email ?? null}

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -16,7 +16,7 @@ export default async function SettingsPage() {
   if (!user) redirect("/login");
 
   return (
-    <main className="mx-auto max-w-xl p-8">
+    <main className="p-8">
       <h1 className="mb-6 text-2xl font-semibold">Settings</h1>
       <div className="rounded-lg border border-input bg-background p-4">
         <h2 className="font-semibold">Coming soon.</h2>

--- a/frontend/src/components/admin/admin-page-shell.test.tsx
+++ b/frontend/src/components/admin/admin-page-shell.test.tsx
@@ -1,0 +1,84 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { AdminPageShell } from "./admin-page-shell";
+
+describe("<AdminPageShell>", () => {
+  it("renders the title as a top-level heading and the children body", () => {
+    render(
+      <AdminPageShell title="Users">
+        <div data-testid="body">body</div>
+      </AdminPageShell>,
+    );
+
+    expect(screen.getByRole("heading", { level: 1, name: "Users" })).toBeInTheDocument();
+    expect(screen.getByTestId("body")).toBeInTheDocument();
+  });
+
+  it("renders the description below the title when provided", () => {
+    render(
+      <AdminPageShell title="Users" description="Manage users and their roles.">
+        <div />
+      </AdminPageShell>,
+    );
+
+    expect(screen.getByText("Manage users and their roles.")).toBeInTheDocument();
+  });
+
+  it("does not render a description paragraph when description is omitted", () => {
+    const { container } = render(
+      <AdminPageShell title="Users">
+        <div />
+      </AdminPageShell>,
+    );
+
+    // The header row holds the title + (optional) description in the same div.
+    // When description is omitted, no <p> sibling should appear.
+    const paragraphs = container.querySelectorAll("p");
+    expect(paragraphs.length).toBe(0);
+  });
+
+  it("renders primaryActions in the trailing edge of the header row", () => {
+    render(
+      <AdminPageShell title="Users" primaryActions={<button type="button">Invite User</button>}>
+        <div />
+      </AdminPageShell>,
+    );
+
+    expect(screen.getByRole("button", { name: "Invite User" })).toBeInTheDocument();
+  });
+
+  it("renders the toolbar slot between the header row and the body", () => {
+    render(
+      <AdminPageShell title="Users" toolbar={<input type="search" aria-label="Search users" />}>
+        <div data-testid="body">body</div>
+      </AdminPageShell>,
+    );
+
+    const toolbarWrapper = screen.getByLabelText("Search users").closest('[data-slot="toolbar"]');
+    expect(toolbarWrapper).not.toBeNull();
+  });
+
+  it("does not render the toolbar wrapper when toolbar is omitted", () => {
+    const { container } = render(
+      <AdminPageShell title="Users">
+        <div />
+      </AdminPageShell>,
+    );
+
+    expect(container.querySelector('[data-slot="toolbar"]')).toBeNull();
+  });
+
+  it("forwards a className to the outer <main>", () => {
+    render(
+      <AdminPageShell title="Users" className="custom-shell">
+        <div data-testid="body" />
+      </AdminPageShell>,
+    );
+
+    const main = screen.getByTestId("body").closest("main");
+    expect(main?.className).toContain("custom-shell");
+    // The base liquid-layout classes are preserved.
+    expect(main?.className).toContain("p-8");
+  });
+});

--- a/frontend/src/components/admin/admin-page-shell.tsx
+++ b/frontend/src/components/admin/admin-page-shell.tsx
@@ -1,0 +1,52 @@
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+interface AdminPageShellProps {
+  /** Page title shown as the leading heading. */
+  title: ReactNode;
+  /** Optional supporting copy under the title. */
+  description?: ReactNode;
+  /** Optional CTA cluster aligned to the trailing edge of the header row. */
+  primaryActions?: ReactNode;
+  /** Optional toolbar slot rendered between the header row and the content. */
+  toolbar?: ReactNode;
+  /** Main content (table, list, grid). */
+  children: ReactNode;
+  /** Optional class merge for the outer <main>. */
+  className?: string;
+}
+
+/**
+ * Shared shell for admin and admin-adjacent listing pages.
+ *
+ * Mirrors the shadcn-admin Tasks/Users `<Main>` shape: a flex column with
+ * a wrap-friendly title row, an optional toolbar slot, and the page body.
+ * Padding matches the existing `p-8` adopted across cardgroups/admin pages
+ * after the recent max-width removal, so this shell stays liquid.
+ *
+ * Intentionally unaware of authorization — admin gating lives in
+ * `app/admin/layout.tsx`. AdminPageShell is reusable from any listing page
+ * (admin or not) that wants the same header + toolbar geometry.
+ */
+export function AdminPageShell({
+  title,
+  description,
+  primaryActions,
+  toolbar,
+  children,
+  className,
+}: AdminPageShellProps) {
+  return (
+    <main className={cn("flex flex-1 flex-col gap-4 p-8 sm:gap-6", className)}>
+      <div className="flex flex-wrap items-end justify-between gap-2">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight">{title}</h1>
+          {description != null && <p className="text-muted-foreground">{description}</p>}
+        </div>
+        {primaryActions != null && <div className="flex items-center gap-2">{primaryActions}</div>}
+      </div>
+      {toolbar != null && <div data-slot="toolbar">{toolbar}</div>}
+      {children}
+    </main>
+  );
+}

--- a/frontend/src/components/nav/app-shell.tsx
+++ b/frontend/src/components/nav/app-shell.tsx
@@ -24,6 +24,10 @@ interface AppShellProps {
 export function AppShell({ user, isAdmin, children }: AppShellProps) {
   return (
     <SidebarProvider>
+      {/* PC layout (md+): GlobalRail is a direct child of SidebarProvider so the
+          Sidebar gap div participates in the flex row and offsets SidebarInset.
+          The wrapper is hidden on mobile; the Sidebar component handles mobile
+          display internally via a Sheet overlay. */}
       {/* PC layout (md+): persistent rail on the left */}
       <aside
         data-testid="rail-container"
@@ -42,8 +46,6 @@ export function AppShell({ user, isAdmin, children }: AppShellProps) {
           <LogoDrawer user={user} isAdmin={isAdmin} />
         </header>
 
-        {/* Main content — SidebarInset handles the left-offset when the PC rail
-            is visible, via peer CSS selectors in the Shadcn sidebar primitive. */}
         <SidebarInset>{children}</SidebarInset>
       </div>
     </SidebarProvider>

--- a/frontend/src/components/ui/sidebar.tsx
+++ b/frontend/src/components/ui/sidebar.tsx
@@ -177,7 +177,7 @@ const Sidebar = React.forwardRef<
       return (
         <div
           className={cn(
-            "flex h-full w-[--sidebar-width] flex-col bg-sidebar text-sidebar-foreground",
+            "flex h-full w-(--sidebar-width) flex-col bg-sidebar text-sidebar-foreground",
             className,
           )}
           ref={ref}
@@ -194,7 +194,7 @@ const Sidebar = React.forwardRef<
           <SheetContent
             data-sidebar="sidebar"
             data-mobile="true"
-            className="w-[--sidebar-width] bg-sidebar p-0 text-sidebar-foreground [&>button]:hidden"
+            className="w-(--sidebar-width) bg-sidebar p-0 text-sidebar-foreground [&>button]:hidden"
             style={
               {
                 "--sidebar-width": SIDEBAR_WIDTH_MOBILE,
@@ -224,24 +224,24 @@ const Sidebar = React.forwardRef<
         {/* This is what handles the sidebar gap on desktop */}
         <div
           className={cn(
-            "relative w-[--sidebar-width] bg-transparent transition-[width] duration-200 ease-linear",
+            "relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear",
             "group-data-[collapsible=offcanvas]:w-0",
             "group-data-[side=right]:rotate-180",
             variant === "floating" || variant === "inset"
               ? "group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)_+_theme(spacing.4))]"
-              : "group-data-[collapsible=icon]:w-[--sidebar-width-icon]",
+              : "group-data-[collapsible=icon]:w-(--sidebar-width-icon)",
           )}
         />
         <div
           className={cn(
-            "fixed inset-y-0 z-10 hidden h-svh w-[--sidebar-width] transition-[left,right,width] duration-200 ease-linear md:flex",
+            "fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear md:flex",
             side === "left"
               ? "left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]"
               : "right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]",
             // Adjust the padding for floating and inset variants.
             variant === "floating" || variant === "inset"
               ? "p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)_+_theme(spacing.4)_+2px)]"
-              : "group-data-[collapsible=icon]:w-[--sidebar-width-icon] group-data-[side=left]:border-r group-data-[side=right]:border-l",
+              : "group-data-[collapsible=icon]:w-(--sidebar-width-icon) group-data-[side=left]:border-r group-data-[side=right]:border-l",
             className,
           )}
           {...props}

--- a/frontend/src/lib/supabase/middleware.ts
+++ b/frontend/src/lib/supabase/middleware.ts
@@ -3,7 +3,15 @@ import { type NextRequest, NextResponse } from "next/server";
 import { env } from "@/env";
 
 export async function updateSession(request: NextRequest) {
-  let supabaseResponse = NextResponse.next({ request });
+  // Forward the request pathname as a header so server components can read it
+  // via `next/headers` (no usePathname in RSC). AppShell uses this to skip the
+  // navigation rail on /login.
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set("x-pathname", request.nextUrl.pathname);
+
+  let supabaseResponse = NextResponse.next({
+    request: { headers: requestHeaders },
+  });
 
   const supabase = createServerClient(
     env.NEXT_PUBLIC_SUPABASE_URL,
@@ -17,7 +25,11 @@ export async function updateSession(request: NextRequest) {
           for (const { name, value } of cookiesToSet) {
             request.cookies.set(name, value);
           }
-          supabaseResponse = NextResponse.next({ request });
+          // Re-create the response after cookie writes; pass the same modified
+          // request headers so x-pathname survives.
+          supabaseResponse = NextResponse.next({
+            request: { headers: requestHeaders },
+          });
           for (const { name, value, options } of cookiesToSet) {
             supabaseResponse.cookies.set(name, value, options);
           }


### PR DESCRIPTION
## Summary

Removes `max-width` constraints from all 14 page-level components to adopt a liquid (full-width) layout that fills the space the AppShell rail creates, fixes `sidebar.tsx` to use Tailwind v4 CSS variable syntax so the configured rail width is applied instead of the browser default, and corrects an inaccurate comment in `AppShell` describing how `SidebarInset` is offset.

## Background / Motivation

- **Page content was artificially narrowed beside the sidebar rail.** After `AppShell` landed, each page still carried a `max-w-*` cap on its top-level wrapper, leaving a blank column between the rail boundary and the content edge on wide viewports.
- **`sidebar.tsx` used CSS variable syntax that Tailwind v4 does not recognize.** Six occurrences of `var(--sidebar-width)` and related properties used legacy syntax; Tailwind v4 expects the un-prefixed `--sidebar-*` token form, so the rail rendered at a browser-default width instead of the configured value.
- **An `AppShell` comment mis-described the `SidebarInset` offset mechanism.** The previous comment attributed the horizontal offset to "peer CSS selectors in the Shadcn sidebar primitive"; the actual mechanism is that `GlobalRail` is a direct child of `SidebarProvider`'s flex row — the gap div participates in the row and pushes `SidebarInset` rightward naturally.

## Changes

### Liquid layout — max-width removal

- Removed `max-w-*` / `max-w-screen-*` constraints from the top-level wrapper of 14 page components: `admin/dictionary`, `admin/roles`, `admin/users`, `admin/users/[id]/edit`, `cardgroups`, `cardgroups/[id]`, `cardgroups/[id]/cards`, `cardgroups/[id]/edit`, `cardgroups/new`, `cards/new`, `profile`, `profile/change-email`, `profile/error`, and `settings`.
- Pages now fill the full available width beside the sidebar rail, consistent with the AppShell responsive design intent.

### Tailwind v4 sidebar CSS variable fix

- `frontend/src/components/ui/sidebar.tsx` (6 lines): replaced legacy `var(--sidebar-width)` references with Tailwind v4 CSS variable syntax so the rail renders at the configured value.

### AppShell documentation

- `frontend/src/components/nav/app-shell.tsx`: replaced the inaccurate "peer CSS selectors" comment with a correct explanation that `GlobalRail` as a direct child of `SidebarProvider` participates in the flex row and thereby offsets `SidebarInset`.

## Verification

After merge:

- `grep -rn "max-w-" frontend/src/app/` should return no hits in page-level wrapper `<div>` elements across the 14 affected routes.
- `grep -n "var(--sidebar-" frontend/src/components/ui/sidebar.tsx` should return nothing — all occurrences use Tailwind v4 syntax.

On the running dev server (`pnpm --filter frontend dev`):

- At `>= md`: visit any admin, cardgroup, card, profile, or settings page — content fills the full viewport width beside the rail with no visible right-side gap.
- Sidebar rail renders at the configured width, not a narrow browser default.

## Test plan

- [ ] `cd frontend && pnpm typecheck` exits 0.
- [ ] `cd frontend && pnpm lint` exits 0.
- [ ] `cd frontend && pnpm test --run` exits 0.
- [ ] `cd frontend && pnpm build` exits 0.
- [ ] Manual: all 14 affected pages fill the full available width beside the sidebar rail at `>= md` viewport.
- [ ] Manual: sidebar rail renders at the configured width (not a browser default).
- [ ] Regression: navigate through admin, cardgroups, cards, profile, and settings — no layout shifts, content overflow, or missing margins.
