### PR TITLE
feat(playbooks): idempotent admin seeding from SUPER_USER_EMAILS

### DIFF
--- a/playbooks/setup-prod/postapply.yml
+++ b/playbooks/setup-prod/postapply.yml
@@ -235,6 +235,8 @@
           value: "{{ supabase_jwt_issuer }}"
         - key: PING_TOKEN
           value: "{{ ping_token }}"
+        - key: SUPER_USER_EMAILS
+          value: "{{ lookup('env', 'SUPER_USER_EMAILS') | default('') }}"
       loop_control:
         label: "{{ item.key }}"
   rescue:

--- a/playbooks/setup.yml
+++ b/playbooks/setup.yml
@@ -293,6 +293,83 @@
       when: google_configured
       tags: [google-check]
 
+    # --- Auto seed-admin from SUPER_USER_EMAILS (runs on every make setup / make sync-env) ---
+    # Reads SUPER_USER_EMAILS from backend/.env.local and grants the admin role to each
+    # address that already has an auth.users row. Idempotent: ON CONFLICT DO NOTHING.
+    # Addresses not yet signed in are silently skipped; re-running after first login grants
+    # the role without further operator action.
+    - name: Read backend/.env.local for SUPER_USER_EMAILS
+      ansible.builtin.slurp:
+        src: "{{ repo_root }}/backend/.env.local"
+      register: _backend_env_for_seed
+      when: env_ownership[repo_root + '/backend/.env.local'] != 'user-owned'
+      tags: [sync-env]
+
+    - name: Parse SUPER_USER_EMAILS from backend/.env.local
+      ansible.builtin.set_fact:
+        _super_user_emails: >-
+          {{ (_backend_env_for_seed.content | b64decode).split('\n')
+             | select('match', '^SUPER_USER_EMAILS=')
+             | map('regex_replace', '^SUPER_USER_EMAILS=', '')
+             | list | first | default('')
+             | split(',')
+             | map('trim')
+             | map('trim', '"')
+             | reject('equalto', '')
+             | list }}
+      when: _backend_env_for_seed is not skipped
+      tags: [sync-env]
+
+    - name: Skip seed-admin-from-env when SUPER_USER_EMAILS is empty
+      ansible.builtin.debug:
+        msg: "seed-admin-from-env: SUPER_USER_EMAILS is not set -- skipping."
+      when: _backend_env_for_seed is not skipped and (_super_user_emails | default([]) | length) == 0
+      tags: [sync-env]
+
+    - name: Resolve local Supabase DB URL for seed-admin-from-env
+      ansible.builtin.shell: |
+        set -o pipefail
+        supabase status --output json | python3 -c 'import json,sys; print(json.load(sys.stdin)["DB_URL"])'
+      args:
+        executable: /bin/bash
+      register: _seed_db_url
+      changed_when: false
+      when: _backend_env_for_seed is not skipped and (_super_user_emails | length) > 0
+      tags: [sync-env]
+
+    - name: Grant admin role to each SUPER_USER_EMAILS address (idempotent)
+      ansible.builtin.command:
+        argv:
+          - psql
+          - "{{ _seed_db_url.stdout | trim }}"
+          - -v
+          - "ON_ERROR_STOP=1"
+          - -c
+          - >-
+            INSERT INTO public.user_roles (user_id, role_id)
+            SELECT u.id, r.id FROM auth.users u, public.roles r
+            WHERE u.email = '{{ item | replace("'", "''") }}' AND r.name = 'admin'
+            ON CONFLICT DO NOTHING;
+      register: _seed_results
+      changed_when: "'INSERT 0 1' in _seed_results.stdout"
+      loop: "{{ _super_user_emails }}"
+      loop_control:
+        label: "{{ item }}"
+      when: _backend_env_for_seed is not skipped and (_super_user_emails | length) > 0
+      tags: [sync-env]
+
+    - name: Report seed-admin-from-env outcome per address
+      ansible.builtin.debug:
+        msg: >-
+          {{ 'granted admin to ' + item.item
+             if 'INSERT 0 1' in (item.stdout | default(''))
+             else 'no-op (not yet signed in or already admin): ' + item.item }}
+      loop: "{{ _seed_results.results | default([]) }}"
+      loop_control:
+        label: "{{ item.item }}"
+      when: _backend_env_for_seed is not skipped and (_super_user_emails | length) > 0
+      tags: [sync-env]
+
     # --- One-shot admin promotion via SQL (local Supabase only) ---
     # Inserts a (user_id, admin_role_id) row by joining auth.users on email and
     # public.roles on name='admin'. Idempotent via ON CONFLICT DO NOTHING.


### PR DESCRIPTION
## Summary

Adds idempotent admin seeding to both local and production setup flows. `make setup` (and `make sync-env`) now reads `SUPER_USER_EMAILS` from `backend/.env.local` and grants the admin role to each address that has already signed in — with no manual `make seed-admin` invocation required. `make setup-prod` now reconciles `SUPER_USER_EMAILS` to the Render service so the SuperUserPromoter middleware can elevate the operator on first login.

## Background / Motivation

- **Admin promotion required a manual step after `make setup`.** `make setup` started the stack and populated env vars, but granting admin access required a separate `make seed-admin EMAIL=...` invocation that was easy to miss.
- **`SUPER_USER_EMAILS` was not wired to Render in `make setup-prod`.** The env-var key existed in `render.yaml` with `sync: false` but was never populated by the postapply playbook, leaving the SuperUserPromoter middleware in passthrough mode on production.
- **Both gaps made the first-run operator experience error-prone.** A developer starting from scratch had to know about two separate commands in the right order to get admin access on either environment.

## Changes

### Local setup (`playbooks/setup.yml`)

- New task block tagged `[sync-env]` (runs on every `make setup` and `make sync-env`) that:
  - Slurps `backend/.env.local` — guarded by the same `env_ownership` check as the existing PING_TOKEN slurp so it is safe when the file is absent.
  - Parses `SUPER_USER_EMAILS` by splitting on `,`, stripping whitespace, and trimming surrounding double-quotes (handles both `a@b.com` and `"a@b.com"` forms).
  - Short-circuits with a debug no-op when the list is empty.
  - Resolves the local Supabase DB URL via `supabase status --output json | python3`.
  - Runs a per-address `INSERT INTO public.user_roles ... ON CONFLICT DO NOTHING` loop; `changed_when` tracks real inserts vs. no-ops.
  - Emits a per-address outcome message (`granted admin to <email>` or `no-op (not yet signed in or already admin): <email>`).

### Production setup (`playbooks/setup-prod/postapply.yml`)

- Added `SUPER_USER_EMAILS` as a 5th entry in the Render per-key env-var upsert loop. Value comes from `lookup('env', 'SUPER_USER_EMAILS') | default('')` — an empty string disables admin promotion without error.

## Verification

After running `make setup` with `SUPER_USER_EMAILS=<your-email>` in `backend/.env.local` and signing in:

```bash
# Confirm the role was granted (local Supabase)
supabase db query "SELECT u.email, r.name FROM auth.users u
  JOIN public.user_roles ur ON u.id = ur.user_id
  JOIN public.roles r ON ur.role_id = r.id
  WHERE u.email = '<your-email>';"
```

Expected: one row with `role_name = admin`.

For production, after `make setup-prod`:

```bash
# Confirm SUPER_USER_EMAILS is set on the Render service
curl -s -H "Authorization: Bearer $RENDER_API_KEY" \
  "https://api.render.com/v1/services/<id>/env-vars?limit=50" \
  | python3 -c "import json,sys; [print(e['envVar']['key'],'=',e['envVar']['value']) for e in json.load(sys.stdin) if e['envVar']['key']=='SUPER_USER_EMAILS']"
```

Expected: `SUPER_USER_EMAILS = <email>`.

## Test plan

- [ ] `ansible-playbook --syntax-check -i playbooks/inventory.local playbooks/setup.yml` exits 0.
- [ ] `ansible-playbook --syntax-check -i playbooks/inventory.local playbooks/setup-prod.yml` exits 0.
- [ ] `ansible-playbook -i playbooks/inventory.local playbooks/setup.yml --tags sync-env --list-tasks 2>&1 | grep -i "seed\|SUPER"` — all six new tasks appear.
- [ ] `make sync-env` with `SUPER_USER_EMAILS=` empty → plays task "Skip seed-admin-from-env" and does NOT attempt psql.
- [ ] `make sync-env` with `SUPER_USER_EMAILS=<signed-in-email>` → plays "Grant admin role" and reports "granted admin to <email>" or "no-op" on re-run.
- [ ] `make sync-env` with `SUPER_USER_EMAILS="a@b.com"` (double-quoted value) → strips quotes correctly, inserts `a@b.com` not `"a@b.com"`.
- [ ] `make sync-env` when `backend/.env.local` is absent → slurp task is skipped, no playbook abort.
- [ ] Regression: `make setup` on a fresh clone still completes without errors.
- [ ] Language-policy: `grep -rnP "[\x{3040}-\x{30ff}\x{4e00}-\x{9fff}]" --include="*.yml" playbooks` returns nothing.
