### PR TITLE
fix(playbooks): skip empty env-var upserts to Render

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,3 +22,8 @@ SUPABASE_AUTH_EXTERNAL_GOOGLE_SECRET=YOUR_GOOGLE_SECRET_HERE
 SUPABASE_ACCESS_TOKEN=YOUR_SUPABASE_PAT_HERE
 RENDER_API_KEY=YOUR_RENDER_API_KEY_HERE
 VERCEL_API_TOKEN=YOUR_VERCEL_TOKEN_HERE
+
+# Comma-separated email addresses that receive admin role on login.
+# Consumed by `make setup-prod-postapply` to write the value to Render.
+# Leave blank if no super-users are needed.
+SUPER_USER_EMAILS=

--- a/playbooks/setup-prod/postapply.yml
+++ b/playbooks/setup-prod/postapply.yml
@@ -76,6 +76,7 @@
       and confirm `.env` (or your shell) exports a valid Render API key.
   when: (render_api_key | length) == 0
 
+
 - name: Read VERCEL_API_TOKEN from the environment
   ansible.builtin.set_fact:
     vercel_token: "{{ lookup('env', 'VERCEL_API_TOKEN') }}"
@@ -226,6 +227,7 @@
         status_code: [200]
       register: env_upsert
       no_log: true
+      when: (item.value | string | length) > 0
       loop:
         - key: SUPABASE_DB_URL
           value: "{{ supabase_db_url }}"


### PR DESCRIPTION
## Summary

Prevents the Render env-var upsert loop from making API calls for empty values, and documents `SUPER_USER_EMAILS` in `.env.example` so contributors know what to fill in before running `make setup-prod-postapply`.

## Background / Motivation

- **The Render env-var upsert loop called the API even when a value was empty.** PR #107 added `SUPER_USER_EMAILS` as an item in the per-key loop, but the loop did not guard against blank values. An operator who had not set `SUPER_USER_EMAILS` would trigger an API request that either silently set an empty string or returned a Render API error — both are unintended.
- **`SUPER_USER_EMAILS` was absent from `.env.example`.** A contributor cloning the repo and following the setup guide had no template entry to fill in, making the variable easy to overlook until the Render upsert failed or the SuperUserPromoter stayed in passthrough mode.

## Changes

### Render postapply playbook (`playbooks/setup-prod/postapply.yml`)

- Added `when: (item.value | string | length) > 0` to the `Upsert env var` task inside the per-key loop. Any loop item whose value resolves to an empty string is now skipped entirely, generating no API call to Render and no error output.

### Developer onboarding template (`.env.example`)

- Added `SUPER_USER_EMAILS=` entry with a three-line comment explaining the format (comma-separated emails), the consumer (`make setup-prod-postapply`), and the safe default (leave blank to disable admin promotion).

## Verification

After running `make setup-prod-postapply` with `SUPER_USER_EMAILS` unset (or empty):

```bash
# Confirm no SUPER_USER_EMAILS key was written to Render
curl -s -H "Authorization: Bearer $RENDER_API_KEY" \
  "https://api.render.com/v1/services/<id>/env-vars?limit=50" \
  | python3 -c "import json,sys; keys=[e['envVar']['key'] for e in json.load(sys.stdin)]; print('SUPER_USER_EMAILS present:', 'SUPER_USER_EMAILS' in keys)"
```

Expected: `SUPER_USER_EMAILS present: False` (or the existing non-empty value is left unchanged if set).

With `SUPER_USER_EMAILS=ops@example.com` exported:

```bash
# Confirm the value was upserted
curl -s -H "Authorization: Bearer $RENDER_API_KEY" \
  "https://api.render.com/v1/services/<id>/env-vars?limit=50" \
  | python3 -c "import json,sys; [print(e['envVar']['key'],'=',e['envVar']['value']) for e in json.load(sys.stdin) if e['envVar']['key']=='SUPER_USER_EMAILS']"
```

Expected: `SUPER_USER_EMAILS = ops@example.com`.

## Test plan

- [ ] `ansible-playbook --syntax-check -i playbooks/inventory.local playbooks/setup-prod.yml` exits 0.
- [ ] `make setup-prod-postapply` with `SUPER_USER_EMAILS=` unset → Ansible task `Upsert env var` is skipped for the `SUPER_USER_EMAILS` item; no Render API call for that key (confirm via `--check -v` output).
- [ ] `make setup-prod-postapply` with `SUPER_USER_EMAILS=ops@example.com` → upsert runs and the value appears on the Render service.
- [ ] Regression: other env vars (`SUPABASE_DB_URL`, `PING_TOKEN`, etc.) with non-empty values are still upserted normally.
- [ ] `.env.example` entry parses correctly: `grep SUPER_USER_EMAILS .env.example` shows the new key and comment.
- [ ] Language-policy: `grep -rnP "[\x{3040}-\x{30ff}\x{4e00}-\x{9fff}]" --include="*.yml" --include="*.example" playbooks .env.example` returns nothing.
