### PR TITLE
feat(dictionary): add front/back to DictionaryValidationError

### DIFF
--- a/.claude/rules/go-library-gotchas.md
+++ b/.claude/rules/go-library-gotchas.md
@@ -54,6 +54,7 @@ This matters most in DataLoader batch functions, where an empty key slice is a n
 - [Constructor panics are the right tool for "non-empty config requires non-nil deps"](../../docs/backend/library-gotchas/constructor-panics-for-non-empty-config.md)
 - [Go `map` is a reference type — copy in the constructor when accepting one](../../docs/backend/library-gotchas/go-map-reference-copy-in-constructor.md)
 - [`json:",omitempty"` controls marshal output, never the decode path](../../docs/backend/library-gotchas/json-omitempty-marshal-only.md)
+- [Extending a JSON-marshaled struct: tag all fields, not just the new ones](../../docs/backend/library-gotchas/json-tag-asymmetry-on-struct-extension.md)
 - [Echo middleware factory: build the no-op decision once, not per-request](../../docs/backend/library-gotchas/echo-middleware-factory-once-at-construction.md)
 - [Derived flags drift; read the source of truth instead](../../docs/backend/library-gotchas/derived-flags-drift.md)
 - [`slog.NewJSONHandler` renders attrs as JSON keys, not `key=value` pairs](../../docs/backend/library-gotchas/slog-jsonhandler-shape.md)

--- a/backend/graph/resolver/dictionary_resolver_test.go
+++ b/backend/graph/resolver/dictionary_resolver_test.go
@@ -225,8 +225,10 @@ func newUpsertDictSrv(dictUC usecase.DictionaryUsecase) *handler.Server {
 // upsertDictionaryMutation returns a JSON-encoded GraphQL mutation body for
 // upsertDictionary. Both arguments are embedded literally so the caller must
 // escape them if needed; for test use the values are always safe ASCII/base64.
+// The errors selection set includes front and back so resolver mapping of those
+// optional fields can be asserted.
 func upsertDictionaryMutation(cardgroupID, payload string) string {
-	return `{"query":"mutation { upsertDictionary(input: { cardgroupId: \"` + cardgroupID + `\", payload: \"` + payload + `\" }) { inserted updated errors { line message } } }"}`
+	return `{"query":"mutation { upsertDictionary(input: { cardgroupId: \"` + cardgroupID + `\", payload: \"` + payload + `\" }) { inserted updated errors { line message front back } } }"}`
 }
 
 // TestUpsertDictionary_ResolverHappyPath drives the full GraphQL transport with
@@ -277,6 +279,67 @@ func TestUpsertDictionary_ResolverHappyPath(t *testing.T) {
 	}
 	if msg, _ := firstErr["message"].(string); msg != "duplicate" {
 		t.Fatalf("expected errors[0].message=%q, got %q", "duplicate", msg)
+	}
+	// A syntax-level error has no parsed front/back — the resolver must leave
+	// both fields as null (i.e. the key is absent or nil in the JSON map).
+	if v, present := firstErr["front"]; present && v != nil {
+		t.Fatalf("expected errors[0].front=null for syntax error, got %v", v)
+	}
+	if v, present := firstErr["back"]; present && v != nil {
+		t.Fatalf("expected errors[0].back=null for syntax error, got %v", v)
+	}
+}
+
+// TestUpsertDictionary_ResolverMapsValidationErrorFrontBack verifies that when
+// the DictionaryUsecase returns a DictionaryValidationError with non-empty
+// Front and Back (the duplicate-front dedup path), the resolver maps them to
+// non-nil *string pointers and the GraphQL response carries the values.
+func TestUpsertDictionary_ResolverMapsValidationErrorFrontBack(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockDictionaryUsecase{
+		returnOut: usecase.UpsertDictionaryOutput{
+			Inserted: 0,
+			Updated:  1,
+			Errors: []usecase.DictionaryValidationError{
+				{
+					Line:    3,
+					Message: "duplicate front in payload (later occurrence wins)",
+					Front:   "apple",
+					Back:    "fruit",
+				},
+			},
+		},
+	}
+	srv := newUpsertDictSrv(mock)
+	payload := base64.StdEncoding.EncodeToString([]byte("apple fruit"))
+	resp := gqlRequest(t, srv, authedCtx("u1"), upsertDictionaryMutation("cg-1", payload))
+
+	if _, hasErrs := resp["errors"]; hasErrs {
+		t.Fatalf("unexpected top-level errors: %v", resp["errors"])
+	}
+	data, _ := resp["data"].(map[string]any)
+	result, _ := data["upsertDictionary"].(map[string]any)
+	if result == nil {
+		t.Fatalf("expected data.upsertDictionary, got nil; response: %v", resp)
+	}
+
+	errs, _ := result["errors"].([]any)
+	if len(errs) != 1 {
+		t.Fatalf("expected 1 error entry, got %d: %v", len(errs), errs)
+	}
+	entry, _ := errs[0].(map[string]any)
+	if line, _ := entry["line"].(float64); int(line) != 3 {
+		t.Fatalf("expected errors[0].line=3, got %v", entry["line"])
+	}
+	// front and back must be present and non-nil for a parsed duplicate row.
+	front, _ := entry["front"].(string)
+	if front != "apple" {
+		t.Fatalf("expected errors[0].front=%q, got %v", "apple", entry["front"])
+	}
+	back, _ := entry["back"].(string)
+	if back != "fruit" {
+		t.Fatalf("expected errors[0].back=%q, got %v", "fruit", entry["back"])
 	}
 }
 

--- a/backend/graph/resolver/schema.resolvers.go
+++ b/backend/graph/resolver/schema.resolvers.go
@@ -151,10 +151,19 @@ func (r *mutationResolver) UpsertDictionary(ctx context.Context, input model.Ups
 	}
 	errs := make([]*model.DictionaryValidationError, 0, len(out.Errors))
 	for _, e := range out.Errors {
-		errs = append(errs, &model.DictionaryValidationError{
+		me := &model.DictionaryValidationError{
 			Line:    e.Line,
 			Message: e.Message,
-		})
+		}
+		if e.Front != "" {
+			f := e.Front
+			me.Front = &f
+		}
+		if e.Back != "" {
+			b := e.Back
+			me.Back = &b
+		}
+		errs = append(errs, me)
 	}
 	return &model.UpsertDictionaryPayload{
 		Inserted: int(out.Inserted),

--- a/backend/graph/resolver/schema.resolvers.go
+++ b/backend/graph/resolver/schema.resolvers.go
@@ -151,19 +151,12 @@ func (r *mutationResolver) UpsertDictionary(ctx context.Context, input model.Ups
 	}
 	errs := make([]*model.DictionaryValidationError, 0, len(out.Errors))
 	for _, e := range out.Errors {
-		me := &model.DictionaryValidationError{
+		errs = append(errs, &model.DictionaryValidationError{
 			Line:    e.Line,
 			Message: e.Message,
-		}
-		if e.Front != "" {
-			f := e.Front
-			me.Front = &f
-		}
-		if e.Back != "" {
-			b := e.Back
-			me.Back = &b
-		}
-		errs = append(errs, me)
+			Front:   nilIfEmpty(e.Front),
+			Back:    nilIfEmpty(e.Back),
+		})
 	}
 	return &model.UpsertDictionaryPayload{
 		Inserted: int(out.Inserted),

--- a/backend/internal/handler/notionsync/handler_test.go
+++ b/backend/internal/handler/notionsync/handler_test.go
@@ -146,6 +146,76 @@ func TestHandlerSuccess(t *testing.T) {
 	}
 }
 
+func TestHandlerSuccess_ParseErrorsJSONShape(t *testing.T) {
+	t.Parallel()
+
+	uc := &stubSyncUsecase{out: usecase.SyncFromNotionOutput{
+		CardgroupID: "cg-1",
+		ParseErrors: []usecase.DictionaryValidationError{
+			{Line: 2, Message: "duplicate front in Notion pages (later occurrence wins)", Front: "apple", Back: "fruit"},
+			{Line: 3, Message: "syntax error: unexpected ..."},
+		},
+	}}
+	h := New(uc, Config{Token: "secret"})
+	req := httptest.NewRequest(http.MethodPost, "/internal/notion-sync", nil)
+	req.Header.Set("Authorization", "Bearer secret")
+	rec := httptest.NewRecorder()
+	e := echo.New()
+	c := e.NewContext(req, rec)
+
+	if err := h.Handle(c); err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+
+	var body map[string]json.RawMessage
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+
+	rawErrs, ok := body["parseErrors"]
+	if !ok {
+		t.Fatal("parseErrors key missing from response body")
+	}
+
+	var parseErrors []map[string]any
+	if err := json.Unmarshal(rawErrs, &parseErrors); err != nil {
+		t.Fatalf("decode parseErrors: %v", err)
+	}
+	if len(parseErrors) != 2 {
+		t.Fatalf("parseErrors len = %d, want 2", len(parseErrors))
+	}
+
+	// Entry 0: all four fields must be present with correct values.
+	e0 := parseErrors[0]
+	if e0["line"] != float64(2) {
+		t.Fatalf("parseErrors[0].line = %v, want 2", e0["line"])
+	}
+	if e0["message"] != "duplicate front in Notion pages (later occurrence wins)" {
+		t.Fatalf("parseErrors[0].message = %v", e0["message"])
+	}
+	if e0["front"] != "apple" {
+		t.Fatalf("parseErrors[0].front = %v, want apple", e0["front"])
+	}
+	if e0["back"] != "fruit" {
+		t.Fatalf("parseErrors[0].back = %v, want fruit", e0["back"])
+	}
+
+	// Entry 1: front and back must be absent (omitempty drops zero-value strings).
+	e1 := parseErrors[1]
+	if e1["line"] != float64(3) {
+		t.Fatalf("parseErrors[1].line = %v, want 3", e1["line"])
+	}
+	if _, ok := e1["front"]; ok {
+		t.Fatal("parseErrors[1] must not have front key (omitempty), but it is present")
+	}
+	if _, ok := e1["back"]; ok {
+		t.Fatal("parseErrors[1] must not have back key (omitempty), but it is present")
+	}
+}
+
 func TestHandlerErrorMapping(t *testing.T) {
 	t.Parallel()
 

--- a/backend/internal/usecase/dictionary.go
+++ b/backend/internal/usecase/dictionary.go
@@ -167,6 +167,8 @@ func (u *dictionaryUsecase) Upsert(ctx context.Context, input UpsertDictionaryIn
 			mappedErrs = append(mappedErrs, DictionaryValidationError{
 				Line:    w.Line,
 				Message: "duplicate front in payload (later occurrence wins)",
+				Front:   w.Front,
+				Back:    w.Back,
 			})
 			continue
 		}

--- a/backend/internal/usecase/dictionary.go
+++ b/backend/internal/usecase/dictionary.go
@@ -47,8 +47,10 @@ type UpsertDictionaryInput struct {
 // resolver layer can reshape it into the GraphQL model without importing the
 // textdic package directly.
 type DictionaryValidationError struct {
-	Line    int
-	Message string
+	Line    int    `json:"line"`
+	Message string `json:"message"`
+	Front   string `json:"front,omitempty"`
+	Back    string `json:"back,omitempty"`
 }
 
 // UpsertDictionaryOutput is the result returned to the caller. Inserted +

--- a/backend/internal/usecase/dictionary_test.go
+++ b/backend/internal/usecase/dictionary_test.go
@@ -425,6 +425,18 @@ func TestDictionaryUsecase_BadRowsSurfaceAsErrors(t *testing.T) {
 	if len(out.Errors) != 2 {
 		t.Fatalf("expected exactly 2 parse errors, got %d: %+v", len(out.Errors), out.Errors)
 	}
+	// Syntax-error entries must NOT carry Front or Back — the textdic parser
+	// does not emit field values for malformed rows, and the usecase must not
+	// populate them either. This locks in the contract that powers the
+	// omitempty / nil-pointer behaviour downstream in the resolver layer.
+	for i, e := range out.Errors {
+		if e.Front != "" {
+			t.Fatalf("syntax-error Errors[%d].Front = %q, want empty", i, e.Front)
+		}
+		if e.Back != "" {
+			t.Fatalf("syntax-error Errors[%d].Back = %q, want empty", i, e.Back)
+		}
+	}
 	// The repo must have been called exactly once with the 1 surviving card.
 	if repo.upsertCalls != 1 {
 		t.Fatalf("expected 1 UpsertManyTx call, got %d", repo.upsertCalls)

--- a/backend/internal/usecase/dictionary_test.go
+++ b/backend/internal/usecase/dictionary_test.go
@@ -592,6 +592,12 @@ func TestDictionaryUsecase_DuplicateFrontDeduplicatedAndSurfaced(t *testing.T) {
 	if len(out.Errors) != 1 {
 		t.Fatalf("expected exactly 1 duplicate error, got %d: %+v", len(out.Errors), out.Errors)
 	}
+	if got := out.Errors[0].Front; got != "apple" {
+		t.Fatalf("Errors[0].Front = %q, want %q (the duplicate row's front)", got, "apple")
+	}
+	if got := out.Errors[0].Back; got != fruitBack {
+		t.Fatalf("Errors[0].Back = %q, want %q (the dropped row's back)", got, fruitBack)
+	}
 	if len(repo.captured) != 1 {
 		t.Fatalf("expected 1 card sent to repo, got %d", len(repo.captured))
 	}

--- a/backend/internal/usecase/notion_sync.go
+++ b/backend/internal/usecase/notion_sync.go
@@ -245,6 +245,8 @@ func dedupeParsedRows(rows []ParsedRow, errs []DictionaryValidationError) ([]Par
 			errs = append(errs, DictionaryValidationError{
 				Line:    row.Line,
 				Message: "duplicate front in Notion pages (later occurrence wins)",
+				Front:   row.Front,
+				Back:    row.Back,
 			})
 			continue
 		}

--- a/backend/internal/usecase/notion_sync_test.go
+++ b/backend/internal/usecase/notion_sync_test.go
@@ -180,6 +180,13 @@ func TestNotionSyncUsecase_DuplicateFrontLastWins(t *testing.T) {
 	if len(out.ParseErrors) != 1 {
 		t.Fatalf("ParseErrors len = %d, want duplicate warning", len(out.ParseErrors))
 	}
+	pe := out.ParseErrors[0]
+	if pe.Front != "apple" {
+		t.Fatalf("ParseErrors[0].Front = %q, want %q", pe.Front, "apple")
+	}
+	if pe.Back != uniqueBack(1) {
+		t.Fatalf("ParseErrors[0].Back = %q, want %q (the dropped row's back)", pe.Back, uniqueBack(1))
+	}
 	if len(cards.upserted) != 1 || cards.upserted[0].Back != uniqueBack(2) {
 		t.Fatalf("upserted = %+v, want latest back", cards.upserted)
 	}
@@ -230,6 +237,13 @@ func TestNotionSyncUsecase_DuplicateFrontSamePageLastWins(t *testing.T) {
 	// dedupeParsedRows MUST anchor the error to the *discarded* row's line.
 	if out.ParseErrors[0].Line != 1 {
 		t.Fatalf("ParseErrors[0].Line = %d, want 1 (the discarded row's line)", out.ParseErrors[0].Line)
+	}
+	pe2 := out.ParseErrors[0]
+	if pe2.Front != "apple" {
+		t.Fatalf("ParseErrors[0].Front = %q, want %q", pe2.Front, "apple")
+	}
+	if pe2.Back != uniqueBack(1) {
+		t.Fatalf("ParseErrors[0].Back = %q, want %q (the dropped row's back)", pe2.Back, uniqueBack(1))
 	}
 	// Partial success (rows>0, parseErrs>0): persistence must still run.
 	if cardgroups.calls != 1 {

--- a/docs/backend-graphql.md
+++ b/docs/backend-graphql.md
@@ -294,6 +294,12 @@ The admin check sits **before** base64 validation deliberately: a non-admin call
 
 **`DictionaryValidationResult` is a resolver-enforced product type.** The schema returns `valid` + `parsedWords` + `errors` as a flat product. The `validateDictionary` resolver enforces the invariant `valid = (len(errors) == 0 && len(parsedWords) > 0)` — conflicting states (e.g. `valid: true` with non-empty `errors`) are representable in the type but never emitted. Any new producer of this result must compute `Valid` the same way; do not let callers set `Valid: true` directly.
 
+**Empty-string → nil-pointer mapping at the resolver boundary.** When a usecase struct field is `Front string` (zero value `""`) and the GraphQL model is `Front *string` (nullable in schema), the resolver must map `e.Front == ""` to `nil` rather than `&e.Front`. Use the existing `nilIfEmpty(s string) *string` helper in `backend/graph/resolver/helpers.go` (already used for `StartCursor`/`EndCursor`) — do not inline the pointer-copy pattern at each mapping site. The struct-literal form with `nilIfEmpty` is shorter, avoids per-iteration variable shadowing, and reads consistently with the other resolver sites that use the same helper.
+
+**Schema docstrings describe result semantics, not parser mechanics.** A docstring like `"""Null when the parser rejected the line before extracting front/back"""` ties the documentation to a specific implementation path. Prefer result-oriented phrasing: `"""Absent (null) for syntax errors, where front/back were never extracted"""`. Result-oriented docstrings stay accurate when the implementation evolves; mechanism-oriented docstrings rot as soon as the code path changes.
+
+**Dedupe is asymmetric: `upsertDictionary` dedupes, `validateDictionary` does not.** `upsertDictionary` runs dedup and surfaces dropped rows as `DictionaryValidationError` entries with `Front`/`Back` populated. `validateDictionary` runs `textdic.Process` directly and surfaces only parser-level syntax errors — those entries never carry `Front`/`Back`. The resolver mapping site for `validateDictionary` (in `backend/graph/resolver/schema.resolvers.go`) therefore deliberately omits `nilIfEmpty(e.Front)` calls; there is nothing to map. If a future change adds dedup to `validateDictionary`, the resolver mapping site must be updated symmetrically with `upsertDictionary`.
+
 ## Backend hardening
 
 Five operational guardrails surround the `/query` endpoint: DataLoader

--- a/docs/backend/library-gotchas/json-tag-asymmetry-on-struct-extension.md
+++ b/docs/backend/library-gotchas/json-tag-asymmetry-on-struct-extension.md
@@ -1,0 +1,29 @@
+# Extending a JSON-marshaled struct: tag all fields, not just the new ones
+
+> Part of the [Go library gotchas](../../../.claude/rules/go-library-gotchas.md) rules.
+
+When a new field is added to a struct that is already serialized via `c.JSON` (or any `encoding/json.Marshal` call), tagging only the new field while leaving existing fields untagged produces a mixed-case wire shape: the untagged fields render as their Go field names (e.g. `"Line"`, `"Message"`) while the new tagged fields render as lowercase (`"front"`, `"back"`). Consumers that expect all lowercase keys — an external cron, a REST client, a monitoring script — silently receive the wrong shape for the existing fields and may misparse or drop them.
+
+Go's `encoding/json` uses the struct field name verbatim when no `json:` tag is present. Adding tags to some fields but not others is valid Go; the encoder applies the override only to the tagged fields, leaving the rest capitalized. The result is an inconsistent wire shape that is invisible to the GraphQL path (gqlgen has its own marshaler and ignores `json:` tags on resolver types) but breaks REST-over-JSON consumers immediately.
+
+The fix is to tag every field when any field needs a tag, normalizing all keys to lowercase camelCase:
+
+```go
+// Before (mixed casing on the wire when this struct is c.JSON'd)
+type DictionaryValidationError struct {
+    Line    int    // -> "Line"
+    Message string // -> "Message"
+    Front   string `json:"front,omitempty"` // -> "front"
+    Back    string `json:"back,omitempty"`  // -> "back"
+}
+
+// After
+type DictionaryValidationError struct {
+    Line    int    `json:"line"`
+    Message string `json:"message"`
+    Front   string `json:"front,omitempty"`
+    Back    string `json:"back,omitempty"`
+}
+```
+
+Pair the fix with a wire-shape test whenever the struct flows through `c.JSON`. The test should decode the response body into `map[string]json.RawMessage` and assert key presence and absence — this catches both the tag-renaming and the `omitempty` branch in one pass. See `backend/internal/handler/notionsync/handler_test.go` `TestHandlerSuccess_ParseErrorsJSONShape` for the asserted example: it verifies that `"line"` and `"message"` are present and that `"front"` and `"back"` are absent when the error carries no card text. Without this test, a future edit that drops a tag goes undetected — the GraphQL path is unaffected, so only the REST consumers see the breakage.

--- a/schema/schema.graphql
+++ b/schema/schema.graphql
@@ -316,9 +316,9 @@ type DictionaryValidationError {
   line: Int!
   """Human-readable, English error message."""
   message: String!
-  """Front of the row when the error refers to a parsed row (e.g. duplicate front). Null when the parser rejected the line before extracting front/back."""
+  """Front term of the row, present only when the error refers to a fully parsed row (e.g. a duplicate front). Absent (null) for syntax errors, where front/back were never extracted."""
   front: String
-  """Back of the row, populated under the same conditions as `front`."""
+  """Back definition of the row. Null for syntax errors; non-null whenever `front` is non-null."""
   back: String
 }
 

--- a/schema/schema.graphql
+++ b/schema/schema.graphql
@@ -316,6 +316,10 @@ type DictionaryValidationError {
   line: Int!
   """Human-readable, English error message."""
   message: String!
+  """Front of the row when the error refers to a parsed row (e.g. duplicate front). Null when the parser rejected the line before extracting front/back."""
+  front: String
+  """Back of the row, populated under the same conditions as `front`."""
+  back: String
 }
 
 """


### PR DESCRIPTION
Closes #119 

## Summary

Extends the shared `DictionaryValidationError` (used by `upsertDictionary`, `validateDictionary`, and `POST /internal/notion-sync`) with optional `front` and `back` fields, populated whenever the parser has already extracted a row (i.e. duplicate-front errors) and absent for textdic syntax errors that rejected the line before extraction. This gives operators the offending row inline in the error response instead of forcing a manual re-parse of the source payload to find the colliding key.

Closes #119.

## Background / Motivation

- **Duplicate-front errors named the line but not the row.** `parseErrors[i]` carried only `{line, message}`, so an operator investigating `"duplicate front in payload (later occurrence wins)"` had to re-fetch the source pages (Notion) or the original CSV (`upsertDictionary`) and re-parse them by hand to identify which front collided.
- **The information was already in scope at the emit site.** `dictionaryUsecase.Upsert` had `w.Front` / `w.Back` available in the dedupe loop, and `dedupeParsedRows` (notion-sync) had `row.Front` / `row.Back` — the call sites simply discarded both fields when constructing the error.
- **A prior exploratory branch forked the type.** An earlier draft on `feature/make_setup_for_notion_sync` introduced a parallel `NotionSyncParseError` struct to scope the change to notion-sync only. Forking the type would have left the GraphQL Dictionary mutations returning only `{line, message}` while notion-sync returned the richer shape, breaking symmetry across the two entry points and guaranteeing a follow-up "now do the same for GraphQL" PR. Extending the shared type once keeps a single concept.
- **Syntax errors must remain unannotated.** The textdic parser does not surface front/back for rows it rejected lexically; populating these fields with empty strings on syntax errors would mask the distinction at the wire layer. `omitempty` on the Go struct + `String` (nullable) in the schema preserves "this row was parsed enough to know what collided" vs "the parser never got that far" as a structural signal.

## Changes

### Schema (`schema/schema.graphql`)

- `type DictionaryValidationError` gains two optional fields:
  - `front: String` — present only when the error refers to a fully parsed row (e.g. duplicate front). Null for syntax errors where front/back were never extracted.
  - `back: String` — null for syntax errors; non-null whenever `front` is non-null.
- The docstrings spell out the **same-conditions** invariant ("`back` is non-null whenever `front` is non-null") so future field consumers can rely on a paired-presence guarantee at the contract layer rather than re-deriving it from the implementation.

### Usecase struct (`backend/internal/usecase/dictionary.go`)

- `DictionaryValidationError` gains `Front string` and `Back string` with `json:"front,omitempty"` / `json:"back,omitempty"` tags. The pre-existing `Line` and `Message` fields are tagged explicitly as well so the JSON wire shape is fully declared rather than relying on the default field-name lowercasing.
- `Upsert` populates `Front: w.Front` / `Back: w.Back` on the existing duplicate-front branch (the same branch that emits `"duplicate front in payload (later occurrence wins)"`).

### Notion-sync usecase (`backend/internal/usecase/notion_sync.go`)

- `dedupeParsedRows` populates `Front: row.Front` / `Back: row.Back` on the duplicate-front branch that emits `"duplicate front in Notion pages (later occurrence wins)"`. `SyncFromNotionOutput.ParseErrors` continues to use the shared `[]DictionaryValidationError` type — no parallel struct introduced.

### Resolver mapping (`backend/graph/resolver/schema.resolvers.go`)

- `UpsertDictionary` resolver maps `usecase.DictionaryValidationError` → `model.DictionaryValidationError`, copying `Front` / `Back` through as `*string`. Empty strings on the usecase side are mapped to `nil` pointers so the GraphQL `null` semantics line up with the schema's "absent when not parsed" contract.

### Tests

- `backend/internal/usecase/dictionary_test.go`:
  - `BadRowsSurfaceAsErrors` now asserts that **syntax-error** entries leave `Front` / `Back` empty — locks in the contract that powers the `omitempty` / nil-pointer behaviour downstream.
  - `DuplicateFrontDeduplicatedAndSurfaced` asserts the **duplicate-front** entry carries `Front="apple"` and `Back=<the dropped row's back>`.
- `backend/internal/usecase/notion_sync_test.go`:
  - `DuplicateFrontLastWins` and `DuplicateFrontSamePageLastWins` assert `ParseErrors[0].Front` / `Back` carry the discarded row's values (matching the "later occurrence wins" semantics — the dropped row is the *earlier* one whose front/back are surfaced as diagnostics).
- `backend/internal/handler/notionsync/handler_test.go`:
  - New `TestHandlerSuccess_ParseErrorsJSONShape` decodes the response body as `map[string]json.RawMessage` and asserts both wire-shape branches: a duplicate-front entry carries `front` + `back` keys with the expected values, while a syntax-error entry has neither key present (proving `omitempty` drops zero-value strings rather than serialising them as empty strings).
- `backend/graph/resolver/dictionary_resolver_test.go`:
  - `upsertDictionaryMutation` selection set extended to `errors { line message front back }` so GraphQL transport-layer assertions can read the new fields.
  - `ResolverHappyPath` (syntax-error path) now asserts both fields come back as JSON `null` (absent or nil in the decoded map).
  - New `ResolverMapsValidationErrorFrontBack` drives the duplicate-front branch through the full GraphQL transport with a stub usecase and asserts `front="apple"`, `back="fruit"` round-trip end to end.

## Verification

After deploy:

- Hit `POST /internal/notion-sync` with a Notion source that has two rows sharing the same front. The response `parseErrors[]` entry for that pair carries `"front": "<the duplicate>"` and `"back": "<the discarded row's back>"`. Add a row with a textdic syntax error (e.g. drop the `back` column) and confirm its `parseErrors[]` entry has **no** `front` or `back` keys at all (not empty strings).
- Run the GraphQL `upsertDictionary` mutation with a payload containing two rows sharing a front:
  ```graphql
  mutation { upsertDictionary(input: { cardgroupId: "cg-1", payload: "<base64>" }) { errors { line message front back } } }
  ```
  The duplicate-front error entry has non-null `front` / `back`; syntax-error entries return `null` for both.
- `grep -rn "NotionSyncParseError" backend/` returns nothing (the exploratory fork from the prior branch is not present in this PR).
- `grep -n "front,omitempty" backend/internal/usecase/dictionary.go` returns the `Front` / `Back` field declarations.

## Test plan

- [ ] `cd backend && go vet ./... && go build ./...` passes (CI eris-grep gate stays clean).
- [ ] `cd backend && go test -v -race -covermode=atomic -coverprofile=coverage.out ./...` passes.
- [ ] Happy path (notion-sync): seed two Notion rows sharing front `"apple"`; `POST /internal/notion-sync` returns `200`; `parseErrors[0]` carries `front="apple"` and `back` equal to the discarded row's back.
- [ ] Happy path (upsertDictionary): submit a payload with two rows sharing front `"apple"`; GraphQL response `errors[0]` carries non-null `front` and `back`.
- [ ] Regression: notion-sync row with textdic syntax error — `parseErrors[i]` has no `front` or `back` keys in the JSON body (assert via `map[string]json.RawMessage` decode, not just string-match).
- [ ] Regression: `upsertDictionary` row with syntax error — GraphQL response `errors[i].front` and `errors[i].back` are JSON `null` (absent or nil in the decoded map).
- [ ] Regression: existing usecase tests (`BadRowsSurfaceAsErrors`, `DuplicateFrontDeduplicatedAndSurfaced`, `DuplicateFrontLastWins`, `DuplicateFrontSamePageLastWins`) still pass — no behavioural shift on the line/message fields.
- [ ] Language-policy grep: `grep -rlP "[\x{3040}-\x{30ff}\x{4e00}-\x{9fff}]" --include="*.go" --include="*.ts" --include="*.tsx" --include="*.graphql" --include="*.sql" --include="*.md" docs backend/internal backend/cmd backend/graph` returns nothing.
- [ ] PR-order grep: `grep -rnE "PR[0-9]+" docs backend/internal backend/cmd backend/graph` returns nothing.
