### PR TITLE
feat(notion): resolve owner UUID from email and add notion-env-init

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,7 +31,14 @@ SUPER_USER_EMAILS=
 # Notion sync settings copied to Render for the backend service.
 NOTION_TOKEN=
 NOTION_PAGE_IDS=
-NOTION_TARGET_OWNER_ID=
+# Email of the Supabase account that owns the synced cardgroup.
+# make sync-notion-secrets resolves this to a UUID automatically via production
+# Supabase. The account must have signed in to the production app at least once.
+# If you prefer to supply the UUID directly, leave this blank and set
+# NOTION_TARGET_OWNER_ID instead.
+NOTION_TARGET_OWNER_EMAIL=
+# Fallback: set only when NOTION_TARGET_OWNER_EMAIL is blank.
+# NOTION_TARGET_OWNER_ID=
 NOTION_TARGET_CARDGROUP_NAME=
 NOTION_SYNC_TOKEN=
 NOTION_MAX_ATTEMPTS=5

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .DEFAULT_GOAL := help
 
-.PHONY: help setup notice-prereqs check-docker mise-install supabase-restart supabase-stop sync-env install supabase-start check-google-oauth dev dev-backend dev-frontend codegen codegen-yacc test clean clean-frontend clean-backend doctor db-reset setup-prod setup-prod-preflight setup-prod-postapply teardown-prod teardown-prod-preflight seed-admin sync-notion-secrets sync-notion-preflight notion-local-setup notion-local-run
+.PHONY: help setup notice-prereqs check-docker mise-install supabase-restart supabase-stop sync-env install supabase-start check-google-oauth dev dev-backend dev-frontend codegen codegen-yacc test clean clean-frontend clean-backend doctor db-reset setup-prod setup-prod-preflight setup-prod-postapply teardown-prod teardown-prod-preflight seed-admin sync-notion-secrets sync-notion-preflight notion-env-init notion-local-setup notion-local-run
 
 # Most env / Supabase targets dispatch to the playbook below; tags select the subset.
 ANSIBLE := ansible-playbook -i playbooks/inventory.local playbooks/setup.yml
@@ -112,6 +112,9 @@ sync-notion-secrets: mise-install ## Sync NOTION_* to Render env + GHA secrets (
 
 sync-notion-preflight: mise-install ## Verify root .env has all required NOTION_* without writing
 	@$(ANSIBLE_PROD) --tags notion-preflight
+
+notion-env-init: mise-install ## Seed NOTION_* production placeholders into root .env (safe to re-run; never overwrites existing values)
+	@$(ANSIBLE) --tags notion-env-init
 
 notion-local-setup: mise-install ## Write NOTION_* to backend/.env.local from root .env (run once, or after editing NOTION_LOCAL_*)
 	@$(ANSIBLE) --tags notion-local

--- a/docs/notion-sync.md
+++ b/docs/notion-sync.md
@@ -93,11 +93,14 @@ All NOTION_* values are stored in the root `.env` file (gitignored). The Makefil
 |---|---|---|
 | `NOTION_TOKEN` | yes | Notion integration token |
 | `NOTION_PAGE_IDS` | yes | Comma-separated page IDs |
-| `NOTION_TARGET_OWNER_ID` | yes | Supabase `auth.users.id` UUID for the destination owner |
+| `NOTION_TARGET_OWNER_EMAIL` | one of these two | Email of the destination account. `make sync-notion-secrets` resolves it to a UUID automatically via the production Supabase `auth.users` table. The account must have signed in to the production app at least once. |
+| `NOTION_TARGET_OWNER_ID` | one of these two | Manual fallback: UUID from `auth.users.id`. Set only when `NOTION_TARGET_OWNER_EMAIL` is blank. |
 | `NOTION_TARGET_CARDGROUP_NAME` | yes | Destination cardgroup name; created when absent |
 | `NOTION_SYNC_TOKEN` | yes | Shared bearer token — written to both Render env and the GHA secret (see note below) |
 | `NOTION_MAX_ATTEMPTS` | no | Defaults to `5` |
 | `NOTION_MAX_ELAPSED` | no | Defaults to `2m` |
+
+`NOTION_TARGET_OWNER_EMAIL` is preferred over `NOTION_TARGET_OWNER_ID` because it eliminates the manual UUID lookup step. When both are set, `NOTION_TARGET_OWNER_EMAIL` takes precedence and the UUID is resolved fresh each run.
 
 `NOTION_SYNC_TOKEN` is deliberately written to **two destinations with the same value**: the Render service env and the `NOTION_SYNC_TOKEN` GitHub Actions secret. This is what guarantees bearer-auth integrity — the backend validates the token in the incoming `Authorization: Bearer` header, and the GHA workflow supplies it as that same secret. If the two values drift, every sync request returns `401`.
 

--- a/playbooks/ansible.cfg
+++ b/playbooks/ansible.cfg
@@ -7,3 +7,8 @@ inventory          = ./inventory.local
 retry_files_enabled = false
 host_key_checking  = false
 interpreter_python = auto_silent
+
+[colors]
+; "FAILED - RETRYING" is emitted with COLOR_DEBUG (default: dark gray), which
+; renders as near-black on dark terminals. Override to bright gray for legibility.
+debug = bright gray

--- a/playbooks/setup-prod/postapply.yml
+++ b/playbooks/setup-prod/postapply.yml
@@ -106,7 +106,6 @@
   loop:
     - NOTION_TOKEN
     - NOTION_PAGE_IDS
-    - NOTION_TARGET_OWNER_ID
     - NOTION_TARGET_CARDGROUP_NAME
     - NOTION_SYNC_TOKEN
   tags: [preflight, notion-preflight, notion, notion-secrets, postapply]
@@ -120,6 +119,92 @@
       Set all of the above in the root .env file and re-run.
   when: (_missing_notion_keys | default([])) | length > 0
   tags: [preflight, notion-preflight, notion, notion-secrets, postapply]
+
+- name: Fail if neither NOTION_TARGET_OWNER_EMAIL nor NOTION_TARGET_OWNER_ID is set
+  ansible.builtin.fail:
+    msg: |
+      At least one of these must be set in root .env:
+        NOTION_TARGET_OWNER_EMAIL  (preferred) -- email of the destination account;
+                                                  resolved to UUID via production Supabase.
+        NOTION_TARGET_OWNER_ID     (fallback)  -- UUID from auth.users.id, set manually.
+
+      Set one of the above in root .env and re-run.
+  when: >-
+    ((lookup('env', 'NOTION_TARGET_OWNER_EMAIL') | default('')) | trim | length == 0) and
+    ((lookup('env', 'NOTION_TARGET_OWNER_ID')    | default('')) | trim | length == 0)
+  tags: [preflight, notion-preflight, notion, notion-secrets, postapply]
+
+# ---------------------------------------------------------------------------
+# Resolve NOTION_TARGET_OWNER_ID.
+#
+# Two paths are supported:
+#   1. NOTION_TARGET_OWNER_EMAIL (preferred) -- psql queries the production
+#      Supabase auth.users table using supabase_db_url from the state file,
+#      resolves the email to a UUID, and stores it as _notion_owner_id.
+#      The target account must have signed in to the production app at least
+#      once so the row exists.
+#   2. NOTION_TARGET_OWNER_ID (manual fallback) -- operator supplies the UUID
+#      directly in root .env; _notion_owner_id is set from that value.
+#
+# When NOTION_TARGET_OWNER_EMAIL is set it takes precedence; the fallback is
+# only used when the email key is absent or blank.
+# ---------------------------------------------------------------------------
+- name: Resolve NOTION_TARGET_OWNER_EMAIL to a UUID
+  when: (lookup('env', 'NOTION_TARGET_OWNER_EMAIL') | default('')) | trim | length > 0
+  tags: [notion, notion-secrets, postapply]
+  block:
+    - name: Validate NOTION_TARGET_OWNER_EMAIL format
+      ansible.builtin.fail:
+        msg: |
+          NOTION_TARGET_OWNER_EMAIL does not look like a valid email address:
+            {{ lookup('env', 'NOTION_TARGET_OWNER_EMAIL') | trim }}
+          Fix the value in root .env and re-run.
+      when: >-
+        not (lookup('env', 'NOTION_TARGET_OWNER_EMAIL') | trim
+             | regex_search('^[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}$'))
+
+    - name: Resolve NOTION_TARGET_OWNER_EMAIL to UUID in auth.users
+      # psql interpolates `:'var'` only for queries read from stdin or -f,
+      # never for queries passed via -c. Pipe the SQL through stdin so the
+      # email is bound as a quoted literal (psql escapes it) instead of being
+      # string-concatenated into the query.
+      ansible.builtin.command:
+        argv:
+          - psql
+          - "{{ supabase_db_url }}"
+          - -v
+          - "ON_ERROR_STOP=1"
+          - -v
+          - "email={{ lookup('env', 'NOTION_TARGET_OWNER_EMAIL') | trim }}"
+          - -t
+          - -A
+        stdin: "SELECT id FROM auth.users WHERE lower(email) = lower(:'email');"
+      register: _notion_owner_uuid_result
+      changed_when: false
+
+    - name: Fail if email not found in auth.users
+      ansible.builtin.fail:
+        msg: |
+          No auth.users row for {{ lookup('env', 'NOTION_TARGET_OWNER_EMAIL') }}.
+          The account must have signed in to the production app at least once before this step.
+      when: (_notion_owner_uuid_result.stdout | trim) | length == 0
+
+    - name: Fail if duplicate email rows found in auth.users
+      ansible.builtin.fail:
+        msg: |
+          Duplicate email in production auth.users; manual review required.
+          Email: {{ lookup('env', 'NOTION_TARGET_OWNER_EMAIL') }}
+      when: (_notion_owner_uuid_result.stdout | trim).split('\n') | length > 1
+
+    - name: Store resolved owner UUID from email
+      ansible.builtin.set_fact:
+        _notion_owner_id: "{{ _notion_owner_uuid_result.stdout | trim }}"
+
+- name: Use NOTION_TARGET_OWNER_ID when email resolution is skipped
+  ansible.builtin.set_fact:
+    _notion_owner_id: "{{ lookup('env', 'NOTION_TARGET_OWNER_ID') | default('') }}"
+  when: (lookup('env', 'NOTION_TARGET_OWNER_EMAIL') | default('')) | trim | length == 0
+  tags: [notion, notion-secrets, postapply]
 
 # ---------------------------------------------------------------------------
 # Precheck: Blueprint Manual Sync has been run for the current render.yaml.
@@ -283,7 +368,7 @@
         - key: NOTION_PAGE_IDS
           value: "{{ lookup('env', 'NOTION_PAGE_IDS') | default('') }}"
         - key: NOTION_TARGET_OWNER_ID
-          value: "{{ lookup('env', 'NOTION_TARGET_OWNER_ID') | default('') }}"
+          value: "{{ _notion_owner_id }}"
         - key: NOTION_TARGET_CARDGROUP_NAME
           value: "{{ lookup('env', 'NOTION_TARGET_CARDGROUP_NAME') | default('') }}"
         - key: NOTION_SYNC_TOKEN

--- a/playbooks/setup.yml
+++ b/playbooks/setup.yml
@@ -433,13 +433,12 @@
       tags: [notion-env-init, never]
 
     - name: Seed NOTION_* production placeholders into root .env (skips existing keys)
-      ansible.builtin.lineinfile:
-        path: "{{ repo_root }}/.env"
-        regexp: "^{{ item.key }}="
-        line: "{{ item.key }}={{ item.val }}"
-        insertafter: EOF
-        create: false
-        mode: "0600"
+      # grep -qE exits 0 when the key already exists (any value), so the append
+      # branch never runs for pre-existing keys, preserving operator-set values.
+      ansible.builtin.shell:
+        cmd: >-
+          grep -qE '^{{ item.key }}=' '{{ repo_root }}/.env' ||
+          echo '{{ item.key }}={{ item.val }}' >> '{{ repo_root }}/.env'
       loop:
         - { key: NOTION_TOKEN,                val: "" }
         - { key: NOTION_PAGE_IDS,             val: "" }
@@ -450,6 +449,7 @@
         - { key: NOTION_MAX_ELAPSED,          val: "2m" }
       loop_control:
         label: "{{ item.key }}"
+      changed_when: false
       tags: [notion-env-init, never]
 
     - name: Confirm notion-env-init complete

--- a/playbooks/setup.yml
+++ b/playbooks/setup.yml
@@ -413,6 +413,53 @@
           then run `make notion-local-run`.
       tags: [notion-local, never]
 
+    # --- Notion production env seed ---
+    # Adds NOTION_* production keys as blank placeholders to root .env when
+    # absent; never overwrites existing values. Run once before configuring
+    # production Notion sync for the first time (or after adding new NOTION_*
+    # keys to .env.example).
+    - name: Stat root .env for notion-env-init
+      ansible.builtin.stat:
+        path: "{{ repo_root }}/.env"
+      register: _notion_env_init_stat
+      tags: [notion-env-init, never]
+
+    - name: Fail if root .env is missing for notion-env-init
+      ansible.builtin.fail:
+        msg: |
+          notion-env-init: root .env not found at {{ repo_root }}/.env.
+          Run `make setup` first to seed it, then retry `make notion-env-init`.
+      when: not _notion_env_init_stat.stat.exists
+      tags: [notion-env-init, never]
+
+    - name: Seed NOTION_* production placeholders into root .env (skips existing keys)
+      ansible.builtin.lineinfile:
+        path: "{{ repo_root }}/.env"
+        regexp: "^{{ item.key }}="
+        line: "{{ item.key }}={{ item.val }}"
+        insertafter: EOF
+        create: false
+        mode: "0600"
+      loop:
+        - { key: NOTION_TOKEN,                val: "" }
+        - { key: NOTION_PAGE_IDS,             val: "" }
+        - { key: NOTION_TARGET_OWNER_EMAIL,   val: "" }
+        - { key: NOTION_TARGET_CARDGROUP_NAME, val: "" }
+        - { key: NOTION_SYNC_TOKEN,           val: "" }
+        - { key: NOTION_MAX_ATTEMPTS,         val: "5" }
+        - { key: NOTION_MAX_ELAPSED,          val: "2m" }
+      loop_control:
+        label: "{{ item.key }}"
+      tags: [notion-env-init, never]
+
+    - name: Confirm notion-env-init complete
+      ansible.builtin.debug:
+        msg: >-
+          Seeded NOTION_* placeholders into .env.
+          Open .env and fill in: NOTION_TOKEN, NOTION_PAGE_IDS,
+          NOTION_TARGET_OWNER_EMAIL, NOTION_TARGET_CARDGROUP_NAME, NOTION_SYNC_TOKEN.
+      tags: [notion-env-init, never]
+
     # --- Google OAuth credentials check (root .env) ---
     # stat-then-slurp: a missing .env produces stat.exists=false (clean path),
     # and any slurp failure afterwards surfaces normally.


### PR DESCRIPTION
## Summary

Adds email-to-UUID resolution for the Notion sync owner: operators can now set `NOTION_TARGET_OWNER_EMAIL` in root `.env` and `make sync-notion-secrets` will query production Supabase `auth.users` to resolve it to a UUID automatically, eliminating the manual UUID lookup step. Also introduces `make notion-env-init`, a safe idempotent command that seeds all `NOTION_*` production keys as blank placeholders into root `.env` without overwriting existing values.

## Background / Motivation

- **Looking up a UUID from production Supabase `auth.users` was a manual, error-prone step.** The old flow required the operator to open a psql shell, find the target account's `id` column, and paste it as `NOTION_TARGET_OWNER_ID` in root `.env`. Any typo or stale value silently misconfigured the sync destination.
- **`NOTION_TARGET_OWNER_ID` appearing as a bare required field gave no hint that an email alternative exists.** New operators following the setup flow had no discovery path for the email-based resolution.
- **There was no safe first-time seeding command for `NOTION_*` keys.** Operators had to copy placeholders from `.env.example` by hand, risking accidentally overwriting already-set values or missing newly added keys when the list changes.

## Changes

### Email-to-UUID resolution (`postapply.yml`)

- Preflight now accepts **either** `NOTION_TARGET_OWNER_EMAIL` or `NOTION_TARGET_OWNER_ID`; the task fails early with an actionable message when both are blank, removing `NOTION_TARGET_OWNER_ID` from the always-required list.
- New `Resolve NOTION_TARGET_OWNER_EMAIL to a UUID` block: validates the email format via regex, runs `SELECT id FROM auth.users WHERE lower(email) = lower(:'email')` via psql stdin binding (prevents SQL injection and avoids `-c` quoting issues), and fails with a named error for no-row or duplicate-row results. The resolved UUID is stored as `_notion_owner_id`.
- Falls back to `NOTION_TARGET_OWNER_ID` as `_notion_owner_id` when `NOTION_TARGET_OWNER_EMAIL` is blank.
- The `NOTION_TARGET_OWNER_ID` Render env write now uses `_notion_owner_id` (the resolved value) instead of a raw env lookup, so both resolution paths write the same key.

### `make notion-env-init` command

- `playbooks/setup.yml` — new `notion-env-init` / `never`-tagged task group: stats root `.env` (fails early if missing), then for each `NOTION_*` production key runs `grep -qE '^KEY=' .env || echo 'KEY=val' >> .env`. The grep exit-code guard makes the command fully idempotent — existing values are never overwritten.
- `Makefile` — new `notion-env-init` target dispatching `--tags notion-env-init`, added to `.PHONY`.
- Keys seeded: `NOTION_TOKEN`, `NOTION_PAGE_IDS`, `NOTION_TARGET_OWNER_EMAIL`, `NOTION_TARGET_CARDGROUP_NAME`, `NOTION_SYNC_TOKEN`, `NOTION_MAX_ATTEMPTS` (default `5`), `NOTION_MAX_ELAPSED` (default `2m`).

### Env and docs updates

- `.env.example` — replaces the bare `NOTION_TARGET_OWNER_ID=` line with `NOTION_TARGET_OWNER_EMAIL=` (with an explanatory comment) and moves `NOTION_TARGET_OWNER_ID` to a commented-out fallback line.
- `docs/notion-sync.md` — env-var table updated to show both keys as "one of these two", with a prose note that email is preferred and takes precedence when both are set.

## Verification

```bash
# Confirm the preflight rejects blank email + blank ID
unset NOTION_TARGET_OWNER_EMAIL NOTION_TARGET_OWNER_ID
make sync-notion-preflight   # must fail: "At least one of these must be set in root .env"

# Confirm notion-env-init is idempotent
cp .env .env.bak
make notion-env-init         # seeds missing NOTION_* keys
diff .env .env.bak           # only absent keys appear; existing values unchanged
make notion-env-init         # second run: diff produces no output
mv .env.bak .env
```

After a full `make setup-prod-postapply` with `NOTION_TARGET_OWNER_EMAIL` set, inspect the Render service dashboard → environment variables and confirm `NOTION_TARGET_OWNER_ID` holds the UUID (not the email string).

## Test plan

- [ ] `NOTION_TARGET_OWNER_EMAIL` set, account exists in production `auth.users` → `make sync-notion-secrets` resolves the UUID and writes it as `NOTION_TARGET_OWNER_ID` in Render env.
- [ ] `NOTION_TARGET_OWNER_EMAIL` set, email not found in `auth.users` → playbook fails with "No auth.users row for ..." message.
- [ ] `NOTION_TARGET_OWNER_EMAIL` set, value is not a valid email (e.g. `notanemail`) → playbook fails at format-validation before touching the database.
- [ ] Both `NOTION_TARGET_OWNER_EMAIL` and `NOTION_TARGET_OWNER_ID` blank → preflight fails with "At least one of these must be set" message.
- [ ] `NOTION_TARGET_OWNER_EMAIL` blank, `NOTION_TARGET_OWNER_ID` set → UUID used directly; no psql query runs.
- [ ] `make notion-env-init` on a fresh `.env` without any `NOTION_*` keys → all seven keys seeded as blank (or default) placeholders.
- [ ] `make notion-env-init` on an `.env` where some `NOTION_*` keys are already set → existing values preserved; only absent keys are appended.
- [ ] `make notion-env-init` when root `.env` does not exist → playbook fails with "root .env not found; run \`make setup\` first" message.
- [ ] Regression: `make notion-local-setup`, `make notion-local-run`, `make sync-notion-preflight` behave identically to before (unrelated tags unaffected).
