### PR TITLE
feat(ci): probe /api/ping for Vercel warm-up to get 200 instead of 307

### DIFF
--- a/.github/workflows/readiness-ping.yml
+++ b/.github/workflows/readiness-ping.yml
@@ -14,10 +14,12 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Ping Vercel frontend
+        env:
+          VERCEL_PING_URL: ${{ secrets.VERCEL_PING_URL }}
         run: |
           curl -fsS --retry 3 --retry-delay 5 --retry-all-errors --max-time 30 \
             -o /dev/null -w "frontend status=%{http_code} time=%{time_total}s\n" \
-            "${{ secrets.VERCEL_PING_URL }}"
+            "$VERCEL_PING_URL/api/ping"
       - name: Ping Render backend (writes to Supabase)
         run: |
           curl -fsS --retry 3 --retry-delay 5 --retry-all-errors --max-time 60 \

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -337,7 +337,7 @@ The workflow file `.github/workflows/readiness-ping.yml` triggers on a 15-minute
 
 | Secret | Purpose |
 |---|---|
-| `VERCEL_PING_URL` | Frontend base URL to warm; the workflow GETs this URL to prevent Vercel cold starts. |
+| `VERCEL_PING_URL` | Frontend base URL with scheme (e.g. `https://flamingo-armond.vercel.app`). The workflow appends `/api/ping` automatically — do **not** include the path in the secret value. |
 | `RENDER_PING_URL` | Backend base URL with scheme (e.g. `https://flamingo-backend.onrender.com`). The workflow appends `/internal/ping` automatically — do **not** include the path in the secret value. |
 | `PING_TOKEN` | Bearer token for the POST request; must match the `PING_TOKEN` env var on the Render service. |
 

--- a/docs/frontend/route-handler-conventions.md
+++ b/docs/frontend/route-handler-conventions.md
@@ -30,3 +30,11 @@ A public, JSON, cache-bypassing health endpoint. Conventions baked in:
 3. **Status code, not body**: success is `200 + { ok: true, backend: <string> }`; failure is `503 + { ok: false, error: <string> }`. **Never** return `200` with `{ ok: false, ... }` embedded — generic monitors check status codes, not body parsers, and a 200-with-error silently passes every uptime check while the system is down.
 4. **Log before responding on failure**: `console.error("[healthz] backend health check failed:", err)` so an operator can correlate the 503 in logs with the cause.
 
+### `/api/ping` liveness probe
+
+A sibling to `/api/healthz`, deliberately thinner. The `readiness-ping` GitHub Actions workflow pings this URL on a 15-minute cron to keep Vercel's edge warm; the warm-up job must succeed whenever the Vercel edge is reachable, even if the backend is briefly down. Conventions:
+
+1. **No upstream call** — the handler returns a constant `200 + { ok: true }`. Routing it through GraphQL would couple Vercel warm-up to Render's cold-start state and turn a transient backend hiccup into a ping failure that pages on call.
+2. **Public** — same reasoning as `/api/healthz`; matched by `frontend/src/middleware.ts`'s `/api` exclusion so auth redirects never intercept the probe.
+3. **Split of responsibility from `/api/healthz`** — `/api/healthz` answers "is the system serving requests end-to-end" (alerting target); `/api/ping` answers "is Vercel's edge live for this project" (warm-up target). Conflating them gives operators one probe that means two things, and the wrong one always pages.
+

--- a/docs/frontend/routing-topology.md
+++ b/docs/frontend/routing-topology.md
@@ -48,7 +48,7 @@ The URL `?cardgroup=<id>` is the **single source of truth** for the chip + form 
 
 `/login` (when hit by an already-signed-in user) follows the same single-decision-point rule: it redirects to `/`, never directly to `/cardgroups` or `/learn/...`, for the same reason the OAuth callback does.
 
-The legacy "render `/` with health check inline" pattern is replaced by `/api/healthz` — see "Route Handler conventions" below. External monitors that polled `/` must move to `/api/healthz`.
+The legacy "render `/` with health check inline" pattern is replaced by two distinct probes — see "Route Handler conventions" below. `/api/ping` is a thin liveness probe (Vercel edge reachability only, always 200) for warm-keep cron jobs; `/api/healthz` is a deep readiness probe (frontend → backend GraphQL `health`, 503 when the backend is down) for uptime monitors. External monitors that polled `/` must move to one of these — typically `/api/healthz` for alerting, `/api/ping` for warm-up that must not page on a backend outage.
 
 The admin entry surfaces (desktop rail admin items / `AdminPill`, mobile drawer admin section) are the only UI affordances for entering `/admin`. All render only when `gqlFetch(HeaderMeQuery)` returns a role named `"admin"`. The `/admin/layout.tsx` server-side gate is the enforcement boundary — nav visibility is a UI hint, not security. See `.claude/rules/frontend-rsc-error-handling.md` for the failure-mode contract that lets the shell degrade silently when the role lookup fails.
 

--- a/frontend/src/app/api/ping/route.test.ts
+++ b/frontend/src/app/api/ping/route.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { GET } from "./route";
+
+describe("GET /api/ping", () => {
+  it("returns 200 with ok:true", async () => {
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ ok: true });
+  });
+});

--- a/frontend/src/app/api/ping/route.ts
+++ b/frontend/src/app/api/ping/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from "next/server";
+
+type PingResponse = { ok: true };
+
+export async function GET() {
+  const body: PingResponse = { ok: true };
+  return NextResponse.json(body);
+}


### PR DESCRIPTION
## Summary

Introduces `/api/ping`, a thin Next.js Route Handler that returns a constant `200 { ok: true }`, and rewires the `readiness-ping` GitHub Actions cron to probe it instead of the Vercel base URL. The cron previously hit `${VERCEL_PING_URL}/` and received a 307 redirect from the auth middleware to `/login`; the new path bypasses middleware (matched by the existing `/api` exclusion) and returns 200 directly. Vercel warm-up is now separated by responsibility from the existing `/api/healthz` readiness probe, so a backend outage no longer turns the warm-up cron red.

This branch addresses no GitHub issue — it ships from an ad-hoc observation that the Vercel ping step was always returning 307.

## Background / Motivation

- **`readiness-ping` was probing the Vercel root URL and getting redirected.** Every 15 minutes the workflow ran `curl -fsS "${{ secrets.VERCEL_PING_URL }}"`. The base URL hits `app/page.tsx`, which redirects anonymous users to `/login` via `app/middleware.ts`. `curl -fsS` accepts 3xx as success, so the workflow never failed — but the probe was structurally a redirect check, not a liveness check.
- **`/api/healthz` is a readiness probe, not a liveness probe.** It calls `gqlFetch(HealthzQuery)` and returns `503 + { ok: false, error }` when the backend is unreachable (see `docs/frontend/route-handler-conventions.md`). Pointing the warm-up cron at it would couple Vercel edge warm-up to Render cold-start state — a brief backend hiccup would turn the warm-up job red and page on call, even though the Vercel edge is fine.
- **`VERCEL_PING_URL` is already a base URL — no secret-value change required.** `playbooks/setup-prod/postapply.yml:486-490` injects `production_url` from the state file (validated against `^https://.+` in Phase 4 of `make setup-prod`), with no trailing path. This matches the `RENDER_PING_URL` convention (workflow appends `/internal/ping`), so the asymmetry was purely in the workflow YAML, not in operational data.
- **`secrets.*` was inlined into the shell command.** `security_reminder_hook.py` (a pre-tool hook in this repo) flags `${{ secrets.X }}` substituted directly into a `run:` block as a shell-injection antipattern; passing the secret through an `env:` block routes it via `$VAR` which the shell parser handles safely.

## Changes

### Liveness probe (`frontend/src/app/api/ping/`)

- `route.ts` (new, 8 lines): exports a `GET` handler that returns `NextResponse.json({ ok: true } satisfies PingResponse)`. No upstream call, no `gqlFetch`, no auth — the `/api` matcher exclusion in `src/middleware.ts:10` keeps the auth middleware off this path.
- `route.test.ts` (new, 12 lines): vitest verifying `response.status === 200` and `body === { ok: true }`. No mocks needed (no upstream dependency).

### Workflow wiring (`.github/workflows/readiness-ping.yml`)

- Vercel curl URL changes from `"${{ secrets.VERCEL_PING_URL }}"` to `"$VERCEL_PING_URL/api/ping"` — same base URL, new path appended.
- The Vercel step gains an `env:` block exporting `VERCEL_PING_URL: ${{ secrets.VERCEL_PING_URL }}`, so the secret reaches `curl` via a shell variable rather than direct interpolation. The Render step is intentionally left as-is (out of scope for this PR; could be aligned in a follow-up).

### Docs (`docs/`)

- `docs/deployment.md`: rewrite the `VERCEL_PING_URL` row in the secrets table to match the `RENDER_PING_URL` wording — "Frontend base URL with scheme … the workflow appends `/api/ping` automatically — do **not** include the path in the secret value."
- `docs/frontend/routing-topology.md`: replace the single "external monitors that polled `/` must move to `/api/healthz`" sentence with an explicit two-probe split — `/api/ping` for warm-up cron (always 200), `/api/healthz` for uptime alerting (503 on backend outage).
- `docs/frontend/route-handler-conventions.md`: append a new `### /api/ping liveness probe` section listing the three conventions baked in: no upstream call, public (middleware-excluded), and split-of-responsibility from `/api/healthz`.

## Verification

```bash
# Local
cd frontend
npm run typecheck                          # 0 errors
npm exec -- vitest run src/app/api/ping    # 1/1 PASS
npm exec -- biome check src/app/api/ping   # clean
```

After merge, manually trigger the workflow and inspect the log line:

```bash
gh workflow run readiness-ping.yml
gh run list --workflow=readiness-ping.yml --limit 1
gh run view <run-id> --log | grep "frontend status="
# Expect: frontend status=200 time=<small>s     (was: 307)
```

The `backend status=200` line (Render probe) should continue to appear unchanged with cold-start timing in the 20–50 s range.

## Test plan

- [x] `npm run typecheck` in `frontend/` — passes
- [x] `vitest run src/app/api/ping` — 1/1 passes
- [x] `biome check src/app/api/ping` — clean
- [ ] After merge: `gh workflow run readiness-ping.yml`, then `gh run view <id> --log | grep frontend` — expect `frontend status=200`
- [ ] Hit `https://<vercel-prod-host>/api/ping` directly with `curl -i` — expect `HTTP/2 200` and `{"ok":true}` body, no `Set-Cookie` header from Supabase middleware
- [ ] Regression: `gh run view <id> --log | grep backend` — expect `backend status=200` (Render probe unchanged)
- [ ] Regression: anonymous user hitting `/` still redirects to `/login` (probe path change must not have leaked into the `/api` matcher exclusion logic)
