### PR TITLE
feat(seed): add dump and import CLI subcommands

### DIFF
--- a/.claude/rules/go-library-gotchas.md
+++ b/.claude/rules/go-library-gotchas.md
@@ -79,3 +79,7 @@ This matters most in DataLoader batch functions, where an empty key slice is a n
 - [Transactional read-modify-write must use the `tx` handle, not `r.db`](../../docs/backend/library-gotchas/gorm-tx-read-modify-write.md)
 - [Int-typed domain enums need `IsValid()` on DB reconstitution](../../docs/backend/library-gotchas/gorm-enum-cast-isvalid.md)
 - [GraphQL resolver: synthesized domain values must be deterministic](../../docs/backend/library-gotchas/graphql-resolver-stable-synthesis.md)
+- [Raw SQL CLI: `sql.Open("pgx", dbURL)` + pgx stdlib, not GORM; validate DSN before Open; auth.users needs superuser DSN](../../docs/backend/library-gotchas/raw-sql-cli-pgx-stdlib.md)
+- [`*sql.Rows`: explicit `rows.Close()` after loop in addition to `defer rows.Close()`](../../docs/backend/library-gotchas/sql-rows-explicit-close.md)
+- [Named return `(retErr error)` for deferred `tx.Rollback` — local `err` can be shadowed](../../docs/backend/library-gotchas/named-return-deferred-rollback.md)
+- [Sensitive file output: use `0o600`, not `0o644`, for files containing PII](../../docs/backend/library-gotchas/sensitive-file-permissions-0o600.md)

--- a/Makefile
+++ b/Makefile
@@ -58,10 +58,12 @@ dev-frontend: ## Run the frontend Next.js dev server
 	pnpm --filter frontend dev
 
 dump-data: ## Dump cardgroups/cards/user_card_fsrs to JSON (DB_URL=  DUMP_OUT=dump.json)
-	cd backend && go run ./cmd/seed dump --db-url "$(DB_URL)" --out "$(DUMP_OUT)"
+	@if [ -z "$(DB_URL)" ]; then echo "ERROR: DB_URL is required, e.g. make dump-data DB_URL=postgres://..."; exit 1; fi
+	cd backend && go run ./cmd/seed dump --db-url "$(DB_URL)" $(if $(DUMP_OUT),--out "$(DUMP_OUT)")
 
 import-data: ## Import from JSON dump (DB_URL=  DUMP_IN=dump.json)
-	cd backend && go run ./cmd/seed import --db-url "$(DB_URL)" --in "$(DUMP_IN)"
+	@if [ -z "$(DB_URL)" ]; then echo "ERROR: DB_URL is required, e.g. make import-data DB_URL=postgres://..."; exit 1; fi
+	cd backend && go run ./cmd/seed import --db-url "$(DB_URL)" $(if $(DUMP_IN),--in "$(DUMP_IN)")
 
 ##@ Local Supabase
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .DEFAULT_GOAL := help
 
-.PHONY: help setup notice-prereqs check-docker mise-install supabase-restart supabase-stop sync-env install supabase-start check-google-oauth dev dev-backend dev-frontend codegen codegen-yacc test clean clean-frontend clean-backend doctor db-reset setup-prod setup-prod-preflight setup-prod-postapply teardown-prod teardown-prod-preflight seed-admin seed-admin-prod sync-notion-secrets sync-notion-preflight notion-env-init notion-local-setup notion-local-run
+.PHONY: help setup notice-prereqs check-docker mise-install supabase-restart supabase-stop sync-env install supabase-start check-google-oauth dev dev-backend dev-frontend dump-data import-data codegen codegen-yacc test clean clean-frontend clean-backend doctor db-reset setup-prod setup-prod-preflight setup-prod-postapply teardown-prod teardown-prod-preflight seed-admin seed-admin-prod sync-notion-secrets sync-notion-preflight notion-env-init notion-local-setup notion-local-run
 
 # Ensure every ansible-playbook invocation picks up playbooks/ansible.cfg.
 # Ansible does not search the inventory directory for ansible.cfg — it walks
@@ -56,6 +56,12 @@ dev-backend: ## Run the backend dev server on port 1323
 
 dev-frontend: ## Run the frontend Next.js dev server
 	pnpm --filter frontend dev
+
+dump-data: ## Dump cardgroups/cards/user_card_fsrs to JSON (DB_URL=  DUMP_OUT=dump.json)
+	cd backend && go run ./cmd/seed dump --db-url "$(DB_URL)" --out "$(DUMP_OUT)"
+
+import-data: ## Import from JSON dump (DB_URL=  DUMP_IN=dump.json)
+	cd backend && go run ./cmd/seed import --db-url "$(DB_URL)" --in "$(DUMP_IN)"
 
 ##@ Local Supabase
 

--- a/backend/cmd/seed/main.go
+++ b/backend/cmd/seed/main.go
@@ -71,8 +71,7 @@ func main() {
 	importIn := importCmd.String("in", "dump.json", "input file path")
 
 	if len(os.Args) < 2 {
-		fmt.Fprintln(os.Stderr, "usage: seed <dump|import> [flags]")
-		os.Exit(1)
+		log.Fatal("usage: seed <dump|import> [flags]")
 	}
 
 	switch os.Args[1] {
@@ -91,8 +90,7 @@ func main() {
 			log.Fatal(eris.ToString(err, true))
 		}
 	default:
-		fmt.Fprintf(os.Stderr, "unknown subcommand %q\n", os.Args[1])
-		os.Exit(1)
+		log.Fatalf("unknown subcommand %q", os.Args[1])
 	}
 }
 
@@ -203,7 +201,7 @@ func runDump(dbURL, outPath string) error {
 	return nil
 }
 
-func runImport(dbURL, inPath string) error {
+func runImport(dbURL, inPath string) (retErr error) {
 	data, err := os.ReadFile(inPath)
 	if err != nil {
 		return eris.Wrapf(err, "seed: read dump file %s", inPath)
@@ -263,10 +261,10 @@ func runImport(dbURL, inPath string) error {
 
 	tx, err := db.Begin()
 	if err != nil {
-		return eris.Wrap(err, "seed: begin transaction")
+		return eris.Wrap(err, "seed: begin tx")
 	}
 	defer func() {
-		if err != nil {
+		if retErr != nil {
 			_ = tx.Rollback()
 		}
 	}()

--- a/backend/cmd/seed/main.go
+++ b/backend/cmd/seed/main.go
@@ -1,0 +1,367 @@
+package main
+
+import (
+	"database/sql"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"github.com/rotisserie/eris"
+
+	_ "github.com/jackc/pgx/v5/stdlib"
+)
+
+type DumpFile struct {
+	Version      int         `json:"version"`
+	DumpedAt     time.Time   `json:"dumped_at"`
+	UserMap      []UserEntry `json:"user_map"`
+	Cardgroups   []CGEntry   `json:"cardgroups"`
+	Cards        []CardEntry `json:"cards"`
+	UserCardFSRS []FSRSEntry `json:"user_card_fsrs"`
+}
+
+type UserEntry struct {
+	SourceUUID string `json:"source_uuid"`
+	Email      string `json:"email"`
+}
+
+type CGEntry struct {
+	ID        string    `json:"id"`
+	OwnerID   string    `json:"owner_id"`
+	Name      string    `json:"name"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+type CardEntry struct {
+	ID          string    `json:"id"`
+	CardgroupID string    `json:"cardgroup_id"`
+	Front       string    `json:"front"`
+	Back        string    `json:"back"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+}
+
+type FSRSEntry struct {
+	UserID        string    `json:"user_id"`
+	CardID        string    `json:"card_id"`
+	State         int       `json:"state"`
+	Due           time.Time `json:"due"`
+	Stability     float64   `json:"stability"`
+	Difficulty    float64   `json:"difficulty"`
+	Reps          int       `json:"reps"`
+	Lapses        int       `json:"lapses"`
+	LastReview    time.Time `json:"last_review"`
+	ElapsedDays   int       `json:"elapsed_days"`
+	ScheduledDays int       `json:"scheduled_days"`
+	CreatedAt     time.Time `json:"created_at"`
+	UpdatedAt     time.Time `json:"updated_at"`
+}
+
+func main() {
+	dumpCmd := flag.NewFlagSet("dump", flag.ExitOnError)
+	dumpDBURL := dumpCmd.String("db-url", "", "database connection URL")
+	dumpOut := dumpCmd.String("out", "dump.json", "output file path")
+
+	importCmd := flag.NewFlagSet("import", flag.ExitOnError)
+	importDBURL := importCmd.String("db-url", "", "database connection URL")
+	importIn := importCmd.String("in", "dump.json", "input file path")
+
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: seed <dump|import> [flags]")
+		os.Exit(1)
+	}
+
+	switch os.Args[1] {
+	case "dump":
+		if err := dumpCmd.Parse(os.Args[2:]); err != nil {
+			log.Fatal(eris.ToString(eris.Wrap(err, "seed: parse dump flags"), true))
+		}
+		if err := runDump(*dumpDBURL, *dumpOut); err != nil {
+			log.Fatal(eris.ToString(err, true))
+		}
+	case "import":
+		if err := importCmd.Parse(os.Args[2:]); err != nil {
+			log.Fatal(eris.ToString(eris.Wrap(err, "seed: parse import flags"), true))
+		}
+		if err := runImport(*importDBURL, *importIn); err != nil {
+			log.Fatal(eris.ToString(err, true))
+		}
+	default:
+		fmt.Fprintf(os.Stderr, "unknown subcommand %q\n", os.Args[1])
+		os.Exit(1)
+	}
+}
+
+func runDump(dbURL, outPath string) error {
+	db, err := sql.Open("pgx", dbURL)
+	if err != nil {
+		return eris.Wrap(err, "seed: open db")
+	}
+	defer db.Close()
+
+	if err := db.Ping(); err != nil {
+		return eris.Wrap(err, "seed: ping db")
+	}
+
+	var cardgroups []CGEntry
+	cgRows, err := db.Query(`SELECT id, owner_id, name, created_at, updated_at FROM public.cardgroups`)
+	if err != nil {
+		return eris.Wrap(err, "seed: query cardgroups")
+	}
+	defer cgRows.Close()
+	for cgRows.Next() {
+		var cg CGEntry
+		if err := cgRows.Scan(&cg.ID, &cg.OwnerID, &cg.Name, &cg.CreatedAt, &cg.UpdatedAt); err != nil {
+			return eris.Wrap(err, "seed: scan cardgroup row")
+		}
+		cardgroups = append(cardgroups, cg)
+	}
+	if err := cgRows.Err(); err != nil {
+		return eris.Wrap(err, "seed: iterate cardgroup rows")
+	}
+
+	var cards []CardEntry
+	cardRows, err := db.Query(`SELECT id, cardgroup_id, front, back, created_at, updated_at FROM public.cards`)
+	if err != nil {
+		return eris.Wrap(err, "seed: query cards")
+	}
+	defer cardRows.Close()
+	for cardRows.Next() {
+		var c CardEntry
+		if err := cardRows.Scan(&c.ID, &c.CardgroupID, &c.Front, &c.Back, &c.CreatedAt, &c.UpdatedAt); err != nil {
+			return eris.Wrap(err, "seed: scan card row")
+		}
+		cards = append(cards, c)
+	}
+	if err := cardRows.Err(); err != nil {
+		return eris.Wrap(err, "seed: iterate card rows")
+	}
+
+	var fsrsEntries []FSRSEntry
+	fsrsRows, err := db.Query(`SELECT user_id, card_id, state, due, stability, difficulty, reps, lapses, last_review, elapsed_days, scheduled_days, created_at, updated_at FROM public.user_card_fsrs`)
+	if err != nil {
+		return eris.Wrap(err, "seed: query user_card_fsrs")
+	}
+	defer fsrsRows.Close()
+	for fsrsRows.Next() {
+		var f FSRSEntry
+		if err := fsrsRows.Scan(&f.UserID, &f.CardID, &f.State, &f.Due, &f.Stability, &f.Difficulty, &f.Reps, &f.Lapses, &f.LastReview, &f.ElapsedDays, &f.ScheduledDays, &f.CreatedAt, &f.UpdatedAt); err != nil {
+			return eris.Wrap(err, "seed: scan user_card_fsrs row")
+		}
+		fsrsEntries = append(fsrsEntries, f)
+	}
+	if err := fsrsRows.Err(); err != nil {
+		return eris.Wrap(err, "seed: iterate user_card_fsrs rows")
+	}
+
+	uuidSet := make(map[string]struct{})
+	for _, cg := range cardgroups {
+		uuidSet[cg.OwnerID] = struct{}{}
+	}
+	for _, f := range fsrsEntries {
+		uuidSet[f.UserID] = struct{}{}
+	}
+
+	var userMap []UserEntry
+	for uuid := range uuidSet {
+		var email string
+		err := db.QueryRow(`SELECT email FROM auth.users WHERE id = $1`, uuid).Scan(&email)
+		if err == sql.ErrNoRows {
+			log.Printf("seed: no auth.users row for uuid %s, skipping", uuid)
+			continue
+		}
+		if err != nil {
+			return eris.Wrapf(err, "seed: query auth.users for uuid %s", uuid)
+		}
+		userMap = append(userMap, UserEntry{SourceUUID: uuid, Email: email})
+	}
+
+	df := DumpFile{
+		Version:      1,
+		DumpedAt:     time.Now().UTC(),
+		UserMap:      userMap,
+		Cardgroups:   cardgroups,
+		Cards:        cards,
+		UserCardFSRS: fsrsEntries,
+	}
+
+	data, err := json.MarshalIndent(df, "", "  ")
+	if err != nil {
+		return eris.Wrap(err, "seed: marshal dump file")
+	}
+
+	if err := os.WriteFile(outPath, data, 0o644); err != nil {
+		return eris.Wrapf(err, "seed: write dump file %s", outPath)
+	}
+
+	fmt.Printf("dump complete: %d cardgroups, %d cards, %d fsrs rows, %d users -> %s\n",
+		len(cardgroups), len(cards), len(fsrsEntries), len(userMap), outPath)
+	return nil
+}
+
+func runImport(dbURL, inPath string) error {
+	data, err := os.ReadFile(inPath)
+	if err != nil {
+		return eris.Wrapf(err, "seed: read dump file %s", inPath)
+	}
+
+	var df DumpFile
+	if err := json.Unmarshal(data, &df); err != nil {
+		return eris.Wrap(err, "seed: unmarshal dump file")
+	}
+
+	if df.Version != 1 {
+		return eris.Errorf("seed: unsupported dump version %d (expected 1)", df.Version)
+	}
+
+	db, err := sql.Open("pgx", dbURL)
+	if err != nil {
+		return eris.Wrap(err, "seed: open db")
+	}
+	defer db.Close()
+
+	if err := db.Ping(); err != nil {
+		return eris.Wrap(err, "seed: ping db")
+	}
+
+	uuidMap := make(map[string]string)
+	skipped := make(map[string]struct{})
+	var skippedEmails []string
+
+	for _, u := range df.UserMap {
+		var targetID string
+		err := db.QueryRow(`SELECT id FROM auth.users WHERE email = $1`, u.Email).Scan(&targetID)
+		if err == sql.ErrNoRows {
+			log.Printf("seed: user not found for email %s (source uuid %s), skipping", u.Email, u.SourceUUID)
+			skipped[u.SourceUUID] = struct{}{}
+			skippedEmails = append(skippedEmails, u.Email)
+			continue
+		}
+		if err != nil {
+			return eris.Wrapf(err, "seed: query auth.users for email %s", u.Email)
+		}
+		uuidMap[u.SourceUUID] = targetID
+	}
+
+	skippedCGs := make(map[string]struct{})
+	for _, cg := range df.Cardgroups {
+		if _, skip := skipped[cg.OwnerID]; skip {
+			skippedCGs[cg.ID] = struct{}{}
+		}
+	}
+
+	skippedCards := make(map[string]struct{})
+	for _, c := range df.Cards {
+		if _, skip := skippedCGs[c.CardgroupID]; skip {
+			skippedCards[c.ID] = struct{}{}
+		}
+	}
+
+	tx, err := db.Begin()
+	if err != nil {
+		return eris.Wrap(err, "seed: begin transaction")
+	}
+	defer func() {
+		if err != nil {
+			_ = tx.Rollback()
+		}
+	}()
+
+	cgInserted := 0
+	for _, cg := range df.Cardgroups {
+		if _, skip := skippedCGs[cg.ID]; skip {
+			continue
+		}
+		targetOwnerID, ok := uuidMap[cg.OwnerID]
+		if !ok {
+			targetOwnerID = cg.OwnerID
+		}
+		_, err = tx.Exec(`
+			INSERT INTO public.cardgroups (id, owner_id, name, created_at, updated_at)
+			VALUES ($1, $2, $3, $4, $5)
+			ON CONFLICT (id) DO UPDATE
+			  SET owner_id   = EXCLUDED.owner_id,
+			      name       = EXCLUDED.name,
+			      updated_at = EXCLUDED.updated_at`,
+			cg.ID, targetOwnerID, cg.Name, cg.CreatedAt, cg.UpdatedAt,
+		)
+		if err != nil {
+			return eris.Wrapf(err, "seed: upsert cardgroup %s", cg.ID)
+		}
+		cgInserted++
+	}
+
+	cardInserted := 0
+	for _, c := range df.Cards {
+		if _, skip := skippedCards[c.ID]; skip {
+			continue
+		}
+		if _, skip := skippedCGs[c.CardgroupID]; skip {
+			continue
+		}
+		_, err = tx.Exec(`
+			INSERT INTO public.cards (id, cardgroup_id, front, back, created_at, updated_at)
+			VALUES ($1, $2, $3, $4, $5, $6)
+			ON CONFLICT (id) DO UPDATE
+			  SET cardgroup_id = EXCLUDED.cardgroup_id,
+			      front        = EXCLUDED.front,
+			      back         = EXCLUDED.back,
+			      updated_at   = EXCLUDED.updated_at`,
+			c.ID, c.CardgroupID, c.Front, c.Back, c.CreatedAt, c.UpdatedAt,
+		)
+		if err != nil {
+			return eris.Wrapf(err, "seed: upsert card %s", c.ID)
+		}
+		cardInserted++
+	}
+
+	fsrsInserted := 0
+	for _, f := range df.UserCardFSRS {
+		if _, skip := skipped[f.UserID]; skip {
+			continue
+		}
+		targetUserID, ok := uuidMap[f.UserID]
+		if !ok {
+			targetUserID = f.UserID
+		}
+		_, err = tx.Exec(`
+			INSERT INTO public.user_card_fsrs
+			  (user_id, card_id, state, due, stability, difficulty, reps, lapses,
+			   last_review, elapsed_days, scheduled_days, created_at, updated_at)
+			VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13)
+			ON CONFLICT (user_id, card_id) DO UPDATE
+			  SET state          = EXCLUDED.state,
+			      due            = EXCLUDED.due,
+			      stability      = EXCLUDED.stability,
+			      difficulty     = EXCLUDED.difficulty,
+			      reps           = EXCLUDED.reps,
+			      lapses         = EXCLUDED.lapses,
+			      last_review    = EXCLUDED.last_review,
+			      elapsed_days   = EXCLUDED.elapsed_days,
+			      scheduled_days = EXCLUDED.scheduled_days,
+			      updated_at     = EXCLUDED.updated_at`,
+			targetUserID, f.CardID, f.State, f.Due, f.Stability, f.Difficulty,
+			f.Reps, f.Lapses, f.LastReview, f.ElapsedDays, f.ScheduledDays,
+			f.CreatedAt, f.UpdatedAt,
+		)
+		if err != nil {
+			return eris.Wrapf(err, "seed: upsert user_card_fsrs user=%s card=%s", f.UserID, f.CardID)
+		}
+		fsrsInserted++
+	}
+
+	if err = tx.Commit(); err != nil {
+		return eris.Wrap(err, "seed: commit transaction")
+	}
+
+	fmt.Printf("import complete: %d cardgroups, %d cards, %d fsrs rows inserted/updated\n",
+		cgInserted, cardInserted, fsrsInserted)
+	if len(skippedEmails) > 0 {
+		fmt.Printf("skipped users (not found in target db): %v\n", skippedEmails)
+	}
+	return nil
+}

--- a/backend/cmd/seed/main.go
+++ b/backend/cmd/seed/main.go
@@ -245,7 +245,7 @@ func runImport(dbURL, inPath string) (retErr error) {
 
 	uuidMap := make(map[string]string)
 	skipped := make(map[string]struct{})
-	var skippedEmails []string
+	skippedUserCount := 0
 
 	for _, u := range df.UserMap {
 		var targetID string
@@ -253,7 +253,7 @@ func runImport(dbURL, inPath string) (retErr error) {
 		if err == sql.ErrNoRows {
 			log.Printf("seed: user not found for email <redacted> (source uuid %s), skipping", u.SourceUUID)
 			skipped[u.SourceUUID] = struct{}{}
-			skippedEmails = append(skippedEmails, u.Email)
+			skippedUserCount++
 			continue
 		}
 		if err != nil {
@@ -383,8 +383,8 @@ func runImport(dbURL, inPath string) (retErr error) {
 
 	fmt.Printf("import complete: %d cardgroups, %d cards, %d fsrs rows inserted/updated\n",
 		cgInserted, cardInserted, fsrsInserted)
-	if len(skippedEmails) > 0 {
-		fmt.Printf("skipped %d users not found in target db\n", len(skippedEmails))
+	if skippedUserCount > 0 {
+		fmt.Printf("skipped %d users not found in target db\n", skippedUserCount)
 	}
 	return nil
 }

--- a/backend/cmd/seed/main.go
+++ b/backend/cmd/seed/main.go
@@ -384,7 +384,7 @@ func runImport(dbURL, inPath string) (retErr error) {
 	fmt.Printf("import complete: %d cardgroups, %d cards, %d fsrs rows inserted/updated\n",
 		cgInserted, cardInserted, fsrsInserted)
 	if len(skippedEmails) > 0 {
-		fmt.Printf("skipped users (not found in target db): %v\n", skippedEmails)
+		fmt.Printf("skipped %d users not found in target db\n", len(skippedEmails))
 	}
 	return nil
 }

--- a/backend/cmd/seed/main.go
+++ b/backend/cmd/seed/main.go
@@ -95,11 +95,18 @@ func main() {
 }
 
 func runDump(dbURL, outPath string) error {
+	if dbURL == "" {
+		return eris.New("seed: --db-url is required")
+	}
 	db, err := sql.Open("pgx", dbURL)
 	if err != nil {
 		return eris.Wrap(err, "seed: open db")
 	}
-	defer db.Close()
+	defer func() {
+		if err := db.Close(); err != nil {
+			log.Printf("seed: db.Close: %v", err)
+		}
+	}()
 
 	if err := db.Ping(); err != nil {
 		return eris.Wrap(err, "seed: ping db")
@@ -121,6 +128,7 @@ func runDump(dbURL, outPath string) error {
 	if err := cgRows.Err(); err != nil {
 		return eris.Wrap(err, "seed: iterate cardgroup rows")
 	}
+	cgRows.Close()
 
 	var cards []CardEntry
 	cardRows, err := db.Query(`SELECT id, cardgroup_id, front, back, created_at, updated_at FROM public.cards`)
@@ -138,6 +146,7 @@ func runDump(dbURL, outPath string) error {
 	if err := cardRows.Err(); err != nil {
 		return eris.Wrap(err, "seed: iterate card rows")
 	}
+	cardRows.Close()
 
 	var fsrsEntries []FSRSEntry
 	fsrsRows, err := db.Query(`SELECT user_id, card_id, state, due, stability, difficulty, reps, lapses, last_review, elapsed_days, scheduled_days, created_at, updated_at FROM public.user_card_fsrs`)
@@ -155,6 +164,7 @@ func runDump(dbURL, outPath string) error {
 	if err := fsrsRows.Err(); err != nil {
 		return eris.Wrap(err, "seed: iterate user_card_fsrs rows")
 	}
+	fsrsRows.Close()
 
 	uuidSet := make(map[string]struct{})
 	for _, cg := range cardgroups {
@@ -192,7 +202,7 @@ func runDump(dbURL, outPath string) error {
 		return eris.Wrap(err, "seed: marshal dump file")
 	}
 
-	if err := os.WriteFile(outPath, data, 0o644); err != nil {
+	if err := os.WriteFile(outPath, data, 0o600); err != nil {
 		return eris.Wrapf(err, "seed: write dump file %s", outPath)
 	}
 
@@ -216,11 +226,18 @@ func runImport(dbURL, inPath string) (retErr error) {
 		return eris.Errorf("seed: unsupported dump version %d (expected 1)", df.Version)
 	}
 
+	if dbURL == "" {
+		return eris.New("seed: --db-url is required")
+	}
 	db, err := sql.Open("pgx", dbURL)
 	if err != nil {
 		return eris.Wrap(err, "seed: open db")
 	}
-	defer db.Close()
+	defer func() {
+		if err := db.Close(); err != nil {
+			log.Printf("seed: db.Close: %v", err)
+		}
+	}()
 
 	if err := db.Ping(); err != nil {
 		return eris.Wrap(err, "seed: ping db")
@@ -234,13 +251,13 @@ func runImport(dbURL, inPath string) (retErr error) {
 		var targetID string
 		err := db.QueryRow(`SELECT id FROM auth.users WHERE email = $1`, u.Email).Scan(&targetID)
 		if err == sql.ErrNoRows {
-			log.Printf("seed: user not found for email %s (source uuid %s), skipping", u.Email, u.SourceUUID)
+			log.Printf("seed: user not found for email <redacted> (source uuid %s), skipping", u.SourceUUID)
 			skipped[u.SourceUUID] = struct{}{}
 			skippedEmails = append(skippedEmails, u.Email)
 			continue
 		}
 		if err != nil {
-			return eris.Wrapf(err, "seed: query auth.users for email %s", u.Email)
+			return eris.Wrapf(err, "seed: query auth.users for uuid %s", u.SourceUUID)
 		}
 		uuidMap[u.SourceUUID] = targetID
 	}
@@ -265,7 +282,9 @@ func runImport(dbURL, inPath string) (retErr error) {
 	}
 	defer func() {
 		if retErr != nil {
-			_ = tx.Rollback()
+			if rbErr := tx.Rollback(); rbErr != nil {
+				log.Printf("seed: tx.Rollback failed: %v (original error: %v)", rbErr, retErr)
+			}
 		}
 	}()
 
@@ -276,7 +295,9 @@ func runImport(dbURL, inPath string) (retErr error) {
 		}
 		targetOwnerID, ok := uuidMap[cg.OwnerID]
 		if !ok {
-			targetOwnerID = cg.OwnerID
+			log.Printf("seed: cardgroup %s has owner_id %s not in uuidMap; skipping", cg.ID, cg.OwnerID)
+			skippedCGs[cg.ID] = struct{}{}
+			continue
 		}
 		_, err = tx.Exec(`
 			INSERT INTO public.cardgroups (id, owner_id, name, created_at, updated_at)
@@ -322,9 +343,13 @@ func runImport(dbURL, inPath string) (retErr error) {
 		if _, skip := skipped[f.UserID]; skip {
 			continue
 		}
+		if _, skip := skippedCards[f.CardID]; skip {
+			continue
+		}
 		targetUserID, ok := uuidMap[f.UserID]
 		if !ok {
-			targetUserID = f.UserID
+			log.Printf("seed: fsrs entry user_id %s not in uuidMap; skipping", f.UserID)
+			continue
 		}
 		_, err = tx.Exec(`
 			INSERT INTO public.user_card_fsrs

--- a/backend/cmd/seed/main_test.go
+++ b/backend/cmd/seed/main_test.go
@@ -130,6 +130,15 @@ func cleanTables(t *testing.T, pool *pgxpool.Pool) {
 	require.NoError(t, err)
 }
 
+func countRows(t *testing.T, pool *pgxpool.Pool, table string) int {
+	t.Helper()
+	var n int
+	err := pool.QueryRow(context.Background(),
+		`SELECT COUNT(*) FROM `+table).Scan(&n)
+	require.NoError(t, err)
+	return n
+}
+
 func TestDump_WritesValidJSON(t *testing.T) {
 	pool := openPool(t)
 	cleanTables(t, pool)
@@ -215,13 +224,9 @@ func TestImport_Idempotent(t *testing.T) {
 	err = runImport(testDBURL, tmpFile)
 	require.NoError(t, err)
 
-	var cgCount, cardCount, fsrsCount int
-	err = pool.QueryRow(ctx, `SELECT COUNT(*) FROM public.cardgroups`).Scan(&cgCount)
-	require.NoError(t, err)
-	err = pool.QueryRow(ctx, `SELECT COUNT(*) FROM public.cards`).Scan(&cardCount)
-	require.NoError(t, err)
-	err = pool.QueryRow(ctx, `SELECT COUNT(*) FROM public.user_card_fsrs`).Scan(&fsrsCount)
-	require.NoError(t, err)
+	cgCount := countRows(t, pool, "public.cardgroups")
+	cardCount := countRows(t, pool, "public.cards")
+	fsrsCount := countRows(t, pool, "public.user_card_fsrs")
 
 	assert.Equal(t, 1, cgCount)
 	assert.Equal(t, 1, cardCount)
@@ -230,17 +235,9 @@ func TestImport_Idempotent(t *testing.T) {
 	err = runImport(testDBURL, tmpFile)
 	require.NoError(t, err)
 
-	var cgCount2, cardCount2, fsrsCount2 int
-	err = pool.QueryRow(ctx, `SELECT COUNT(*) FROM public.cardgroups`).Scan(&cgCount2)
-	require.NoError(t, err)
-	err = pool.QueryRow(ctx, `SELECT COUNT(*) FROM public.cards`).Scan(&cardCount2)
-	require.NoError(t, err)
-	err = pool.QueryRow(ctx, `SELECT COUNT(*) FROM public.user_card_fsrs`).Scan(&fsrsCount2)
-	require.NoError(t, err)
-
-	assert.Equal(t, cgCount, cgCount2)
-	assert.Equal(t, cardCount, cardCount2)
-	assert.Equal(t, fsrsCount, fsrsCount2)
+	assert.Equal(t, cgCount, countRows(t, pool, "public.cardgroups"))
+	assert.Equal(t, cardCount, countRows(t, pool, "public.cards"))
+	assert.Equal(t, fsrsCount, countRows(t, pool, "public.user_card_fsrs"))
 }
 
 func TestImport_SkipsUnknownEmail(t *testing.T) {
@@ -472,20 +469,7 @@ func TestImport_SkipsCascade(t *testing.T) {
 	err = runImport(testDBURL, tmpFile)
 	require.NoError(t, err)
 
-	ctx := context.Background()
-
-	var cgCount int
-	err = pool.QueryRow(ctx, `SELECT COUNT(*) FROM public.cardgroups`).Scan(&cgCount)
-	require.NoError(t, err)
-	assert.Equal(t, 0, cgCount, "cardgroup owned by unknown user should be skipped")
-
-	var cardCount int
-	err = pool.QueryRow(ctx, `SELECT COUNT(*) FROM public.cards`).Scan(&cardCount)
-	require.NoError(t, err)
-	assert.Equal(t, 0, cardCount, "card in skipped cardgroup should be cascaded-skipped")
-
-	var fsrsCount int
-	err = pool.QueryRow(ctx, `SELECT COUNT(*) FROM public.user_card_fsrs`).Scan(&fsrsCount)
-	require.NoError(t, err)
-	assert.Equal(t, 0, fsrsCount, "fsrs row for unknown user skipped by user guard; fsrs row for known user skipped by skippedCards guard (card never inserted)")
+	assert.Equal(t, 0, countRows(t, pool, "public.cardgroups"), "cardgroup owned by unknown user should be skipped")
+	assert.Equal(t, 0, countRows(t, pool, "public.cards"), "card in skipped cardgroup should be cascaded-skipped")
+	assert.Equal(t, 0, countRows(t, pool, "public.user_card_fsrs"), "fsrs row for unknown user skipped by user guard; fsrs row for known user skipped by skippedCards guard (card never inserted)")
 }

--- a/backend/cmd/seed/main_test.go
+++ b/backend/cmd/seed/main_test.go
@@ -1,0 +1,343 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
+
+	"backend/internal/database"
+	_ "github.com/jackc/pgx/v5/stdlib"
+)
+
+var testDBURL string
+
+func TestMain(m *testing.M) {
+	os.Exit(runTests(m))
+}
+
+func runTests(m *testing.M) int {
+	ctx := context.Background()
+	container, err := tcpostgres.Run(ctx,
+		"postgres:15-alpine",
+		tcpostgres.WithDatabase("flamingo_test"),
+		tcpostgres.WithUsername("test"),
+		tcpostgres.WithPassword("test"),
+		tcpostgres.BasicWaitStrategies(),
+	)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "tcpostgres run: %v\n", err)
+		return 1
+	}
+	defer func() {
+		if err := testcontainers.TerminateContainer(container); err != nil {
+			fmt.Fprintf(os.Stderr, "terminate container: %v\n", err)
+		}
+	}()
+
+	dsn, err := container.ConnectionString(ctx, "sslmode=disable")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "conn string: %v\n", err)
+		return 1
+	}
+	if err := bootstrapAuthSchema(ctx, dsn); err != nil {
+		fmt.Fprintf(os.Stderr, "bootstrap: %v\n", err)
+		return 1
+	}
+	if err := database.Migrate(dsn); err != nil {
+		fmt.Fprintf(os.Stderr, "migrate: %v\n", err)
+		return 1
+	}
+	testDBURL = dsn
+	return m.Run()
+}
+
+func bootstrapAuthSchema(ctx context.Context, dsn string) error {
+	cfg, err := pgxpool.ParseConfig(dsn)
+	if err != nil {
+		return err
+	}
+	pool, err := pgxpool.NewWithConfig(ctx, cfg)
+	if err != nil {
+		return err
+	}
+	defer pool.Close()
+	_, err = pool.Exec(ctx, `
+        DO $$
+        BEGIN
+            IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'authenticated') THEN
+                CREATE ROLE authenticated LOGIN PASSWORD 'test';
+            END IF;
+        END
+        $$;
+        CREATE SCHEMA IF NOT EXISTS auth;
+        CREATE TABLE IF NOT EXISTS auth.users (
+            id uuid PRIMARY KEY,
+            email text
+        );
+        CREATE OR REPLACE FUNCTION auth.uid()
+        RETURNS uuid
+        LANGUAGE sql
+        STABLE
+        AS $$
+            SELECT COALESCE(
+                NULLIF(current_setting('request.jwt.claim.sub', true), ''),
+                NULLIF(current_setting('request.jwt.claims', true), '')::jsonb ->> 'sub'
+            )::uuid
+        $$;
+        GRANT USAGE ON SCHEMA auth TO authenticated;
+        GRANT EXECUTE ON FUNCTION auth.uid() TO authenticated;
+        GRANT USAGE ON SCHEMA public TO authenticated;
+        ALTER DEFAULT PRIVILEGES IN SCHEMA public
+            GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO authenticated;
+        ALTER DEFAULT PRIVILEGES IN SCHEMA public
+            GRANT USAGE, SELECT ON SEQUENCES TO authenticated;
+    `)
+	return err
+}
+
+func openPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	cfg, err := pgxpool.ParseConfig(testDBURL)
+	require.NoError(t, err)
+	pool, err := pgxpool.NewWithConfig(context.Background(), cfg)
+	require.NoError(t, err)
+	t.Cleanup(pool.Close)
+	return pool
+}
+
+func insertAuthUser(t *testing.T, pool *pgxpool.Pool, id, email string) {
+	t.Helper()
+	_, err := pool.Exec(context.Background(),
+		`INSERT INTO auth.users(id, email) VALUES ($1, $2)`,
+		id, email)
+	require.NoError(t, err)
+}
+
+func cleanTables(t *testing.T, pool *pgxpool.Pool) {
+	t.Helper()
+	_, err := pool.Exec(context.Background(),
+		`TRUNCATE public.user_card_fsrs, public.cards, public.cardgroups, auth.users CASCADE`)
+	require.NoError(t, err)
+}
+
+func TestDump_WritesValidJSON(t *testing.T) {
+	pool := openPool(t)
+	cleanTables(t, pool)
+
+	ctx := context.Background()
+	userID := uuid.New().String()
+	email := "dump@example.com"
+	insertAuthUser(t, pool, userID, email)
+
+	cgID := uuid.New().String()
+	_, err := pool.Exec(ctx,
+		`INSERT INTO public.cardgroups (id, owner_id, name, created_at, updated_at)
+		 VALUES ($1, $2, $3, now(), now())`,
+		cgID, userID, "Test Group")
+	require.NoError(t, err)
+
+	cardID := uuid.New().String()
+	_, err = pool.Exec(ctx,
+		`INSERT INTO public.cards (id, cardgroup_id, front, back, created_at, updated_at)
+		 VALUES ($1, $2, $3, $4, now(), now())`,
+		cardID, cgID, "Front text", "Back text")
+	require.NoError(t, err)
+
+	_, err = pool.Exec(ctx, `
+		INSERT INTO public.user_card_fsrs
+		(user_id, card_id, state, due, stability, difficulty, reps, lapses, last_review, elapsed_days, scheduled_days)
+		VALUES ($1, $2, 0, now(), 1.0, 5.0, 0, 0, now(), 0, 0)`,
+		userID, cardID)
+	require.NoError(t, err)
+
+	tmpFile := t.TempDir() + "/dump.json"
+	err = runDump(testDBURL, tmpFile)
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(tmpFile)
+	require.NoError(t, err)
+
+	var df DumpFile
+	err = json.Unmarshal(data, &df)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, df.Version)
+	assert.Len(t, df.Cardgroups, 1)
+	assert.Len(t, df.Cards, 1)
+	assert.Len(t, df.UserCardFSRS, 1)
+	require.Len(t, df.UserMap, 1)
+	assert.Equal(t, email, df.UserMap[0].Email)
+}
+
+func TestImport_Idempotent(t *testing.T) {
+	pool := openPool(t)
+	cleanTables(t, pool)
+
+	ctx := context.Background()
+	userID := uuid.New().String()
+	insertAuthUser(t, pool, userID, "idempotent@example.com")
+
+	cgID := uuid.New().String()
+	_, err := pool.Exec(ctx,
+		`INSERT INTO public.cardgroups (id, owner_id, name, created_at, updated_at)
+		 VALUES ($1, $2, $3, now(), now())`,
+		cgID, userID, "Idempotent Group")
+	require.NoError(t, err)
+
+	cardID := uuid.New().String()
+	_, err = pool.Exec(ctx,
+		`INSERT INTO public.cards (id, cardgroup_id, front, back, created_at, updated_at)
+		 VALUES ($1, $2, $3, $4, now(), now())`,
+		cardID, cgID, "Front", "Back")
+	require.NoError(t, err)
+
+	_, err = pool.Exec(ctx, `
+		INSERT INTO public.user_card_fsrs
+		(user_id, card_id, state, due, stability, difficulty, reps, lapses, last_review, elapsed_days, scheduled_days)
+		VALUES ($1, $2, 0, now(), 1.0, 5.0, 0, 0, now(), 0, 0)`,
+		userID, cardID)
+	require.NoError(t, err)
+
+	tmpFile := t.TempDir() + "/dump.json"
+	err = runDump(testDBURL, tmpFile)
+	require.NoError(t, err)
+
+	err = runImport(testDBURL, tmpFile)
+	require.NoError(t, err)
+
+	var cgCount, cardCount, fsrsCount int
+	err = pool.QueryRow(ctx, `SELECT COUNT(*) FROM public.cardgroups`).Scan(&cgCount)
+	require.NoError(t, err)
+	err = pool.QueryRow(ctx, `SELECT COUNT(*) FROM public.cards`).Scan(&cardCount)
+	require.NoError(t, err)
+	err = pool.QueryRow(ctx, `SELECT COUNT(*) FROM public.user_card_fsrs`).Scan(&fsrsCount)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, cgCount)
+	assert.Equal(t, 1, cardCount)
+	assert.Equal(t, 1, fsrsCount)
+
+	err = runImport(testDBURL, tmpFile)
+	require.NoError(t, err)
+
+	var cgCount2, cardCount2, fsrsCount2 int
+	err = pool.QueryRow(ctx, `SELECT COUNT(*) FROM public.cardgroups`).Scan(&cgCount2)
+	require.NoError(t, err)
+	err = pool.QueryRow(ctx, `SELECT COUNT(*) FROM public.cards`).Scan(&cardCount2)
+	require.NoError(t, err)
+	err = pool.QueryRow(ctx, `SELECT COUNT(*) FROM public.user_card_fsrs`).Scan(&fsrsCount2)
+	require.NoError(t, err)
+
+	assert.Equal(t, cgCount, cgCount2)
+	assert.Equal(t, cardCount, cardCount2)
+	assert.Equal(t, fsrsCount, fsrsCount2)
+}
+
+func TestImport_SkipsUnknownEmail(t *testing.T) {
+	pool := openPool(t)
+	cleanTables(t, pool)
+
+	unknownUserID := uuid.New().String()
+	cgID := uuid.New().String()
+	now := time.Now().UTC()
+
+	df := DumpFile{
+		Version:  1,
+		DumpedAt: now,
+		UserMap: []UserEntry{
+			{SourceUUID: unknownUserID, Email: "unknown@example.com"},
+		},
+		Cardgroups: []CGEntry{
+			{
+				ID:        cgID,
+				OwnerID:   unknownUserID,
+				Name:      "Should be skipped",
+				CreatedAt: now,
+				UpdatedAt: now,
+			},
+		},
+		Cards:        []CardEntry{},
+		UserCardFSRS: []FSRSEntry{},
+	}
+
+	data, err := json.MarshalIndent(df, "", "  ")
+	require.NoError(t, err)
+
+	tmpFile := t.TempDir() + "/dump.json"
+	err = os.WriteFile(tmpFile, data, 0o644)
+	require.NoError(t, err)
+
+	err = runImport(testDBURL, tmpFile)
+	require.NoError(t, err)
+
+	var count int
+	err = pool.QueryRow(context.Background(), `SELECT COUNT(*) FROM public.cardgroups`).Scan(&count)
+	require.NoError(t, err)
+	assert.Equal(t, 0, count)
+}
+
+func TestImport_RemapsOwnerID(t *testing.T) {
+	pool := openPool(t)
+	cleanTables(t, pool)
+
+	ctx := context.Background()
+
+	// Build the dump file directly without writing to the live DB, so we avoid
+	// truncate cascades that would also remove public.users rows (because
+	// public.users.last_viewed_cardgroup_id references public.cardgroups, so
+	// TRUNCATE public.cardgroups CASCADE transitively truncates public.users).
+	sourceID := uuid.New().String()
+	cgID := uuid.New().String()
+	now := time.Now().UTC()
+
+	df := DumpFile{
+		Version:  1,
+		DumpedAt: now,
+		UserMap: []UserEntry{
+			{SourceUUID: sourceID, Email: "remap@example.com"},
+		},
+		Cardgroups: []CGEntry{
+			{
+				ID:        cgID,
+				OwnerID:   sourceID,
+				Name:      "Remap Group",
+				CreatedAt: now,
+				UpdatedAt: now,
+			},
+		},
+		Cards:        []CardEntry{},
+		UserCardFSRS: []FSRSEntry{},
+	}
+
+	data, err := json.MarshalIndent(df, "", "  ")
+	require.NoError(t, err)
+
+	tmpFile := t.TempDir() + "/dump.json"
+	err = os.WriteFile(tmpFile, data, 0o644)
+	require.NoError(t, err)
+
+	// Insert the target user (different UUID, same email as the dump's source user).
+	targetID := uuid.New().String()
+	insertAuthUser(t, pool, targetID, "remap@example.com")
+
+	err = runImport(testDBURL, tmpFile)
+	require.NoError(t, err)
+
+	var ownerID string
+	err = pool.QueryRow(ctx,
+		`SELECT owner_id FROM public.cardgroups WHERE id = $1`, cgID).Scan(&ownerID)
+	require.NoError(t, err, "cardgroup should have been inserted")
+
+	assert.Equal(t, targetID, ownerID, "owner_id should be remapped to the target UUID")
+	assert.NotEqual(t, sourceID, ownerID, "owner_id must not remain as the source UUID")
+}

--- a/backend/cmd/seed/main_test.go
+++ b/backend/cmd/seed/main_test.go
@@ -487,5 +487,5 @@ func TestImport_SkipsCascade(t *testing.T) {
 	var fsrsCount int
 	err = pool.QueryRow(ctx, `SELECT COUNT(*) FROM public.user_card_fsrs`).Scan(&fsrsCount)
 	require.NoError(t, err)
-	assert.Equal(t, 0, fsrsCount, "fsrs rows should be skipped (card not inserted + user skipped)")
+	assert.Equal(t, 0, fsrsCount, "fsrs row for unknown user skipped by user guard; fsrs row for known user skipped by skippedCards guard (card never inserted)")
 }

--- a/backend/cmd/seed/main_test.go
+++ b/backend/cmd/seed/main_test.go
@@ -341,3 +341,151 @@ func TestImport_RemapsOwnerID(t *testing.T) {
 	assert.Equal(t, targetID, ownerID, "owner_id should be remapped to the target UUID")
 	assert.NotEqual(t, sourceID, ownerID, "owner_id must not remain as the source UUID")
 }
+
+func TestImport_InvalidJSON(t *testing.T) {
+	tmpFile := t.TempDir() + "/dump.json"
+	err := os.WriteFile(tmpFile, []byte("{not valid json"), 0o644)
+	require.NoError(t, err)
+
+	err = runImport(testDBURL, tmpFile)
+	require.Error(t, err)
+}
+
+func TestImport_VersionMismatch(t *testing.T) {
+	for _, version := range []int{0, 2, 99} {
+		df := DumpFile{Version: version, DumpedAt: time.Now().UTC()}
+		data, err := json.MarshalIndent(df, "", "  ")
+		require.NoError(t, err)
+
+		tmpFile := t.TempDir() + "/dump.json"
+		err = os.WriteFile(tmpFile, data, 0o644)
+		require.NoError(t, err)
+
+		err = runImport(testDBURL, tmpFile)
+		require.Error(t, err)
+	}
+}
+
+func TestImport_RemapsFSRSUserID(t *testing.T) {
+	pool := openPool(t)
+	cleanTables(t, pool)
+
+	ctx := context.Background()
+	sourceID := uuid.New().String()
+	targetID := uuid.New().String()
+	cgID := uuid.New().String()
+	cardID := uuid.New().String()
+	now := time.Now().UTC()
+
+	insertAuthUser(t, pool, targetID, "fsrs-remap@example.com")
+
+	df := DumpFile{
+		Version:  1,
+		DumpedAt: now,
+		UserMap:  []UserEntry{{SourceUUID: sourceID, Email: "fsrs-remap@example.com"}},
+		Cardgroups: []CGEntry{{
+			ID: cgID, OwnerID: sourceID, Name: "FSRS Remap Group",
+			CreatedAt: now, UpdatedAt: now,
+		}},
+		Cards: []CardEntry{{
+			ID: cardID, CardgroupID: cgID, Front: "Q", Back: "A",
+			CreatedAt: now, UpdatedAt: now,
+		}},
+		UserCardFSRS: []FSRSEntry{{
+			UserID: sourceID, CardID: cardID, State: 0,
+			Due: now, Stability: 1.0, Difficulty: 5.0,
+			Reps: 0, Lapses: 0, LastReview: now,
+			ElapsedDays: 0, ScheduledDays: 0,
+			CreatedAt: now, UpdatedAt: now,
+		}},
+	}
+
+	data, err := json.MarshalIndent(df, "", "  ")
+	require.NoError(t, err)
+	tmpFile := t.TempDir() + "/dump.json"
+	err = os.WriteFile(tmpFile, data, 0o644)
+	require.NoError(t, err)
+
+	err = runImport(testDBURL, tmpFile)
+	require.NoError(t, err)
+
+	var fsrsUserID string
+	err = pool.QueryRow(ctx,
+		`SELECT user_id FROM public.user_card_fsrs WHERE card_id = $1`, cardID).Scan(&fsrsUserID)
+	require.NoError(t, err, "fsrs row should have been inserted")
+	assert.Equal(t, targetID, fsrsUserID, "user_id should be remapped to target UUID")
+	assert.NotEqual(t, sourceID, fsrsUserID)
+}
+
+func TestImport_SkipsCascade(t *testing.T) {
+	pool := openPool(t)
+	cleanTables(t, pool)
+
+	unknownUserID := uuid.New().String()
+	knownUserID := uuid.New().String()
+	knownTargetID := uuid.New().String()
+	cgID := uuid.New().String()
+	cardID := uuid.New().String()
+	now := time.Now().UTC()
+
+	insertAuthUser(t, pool, knownTargetID, "known@example.com")
+
+	df := DumpFile{
+		Version:  1,
+		DumpedAt: now,
+		UserMap: []UserEntry{
+			{SourceUUID: unknownUserID, Email: "unknown@example.com"},
+			{SourceUUID: knownUserID, Email: "known@example.com"},
+		},
+		Cardgroups: []CGEntry{{
+			ID: cgID, OwnerID: unknownUserID, Name: "Skipped Group",
+			CreatedAt: now, UpdatedAt: now,
+		}},
+		Cards: []CardEntry{{
+			ID: cardID, CardgroupID: cgID, Front: "Q", Back: "A",
+			CreatedAt: now, UpdatedAt: now,
+		}},
+		UserCardFSRS: []FSRSEntry{
+			{
+				UserID: unknownUserID, CardID: cardID, State: 0,
+				Due: now, Stability: 1.0, Difficulty: 5.0,
+				Reps: 0, Lapses: 0, LastReview: now,
+				ElapsedDays: 0, ScheduledDays: 0,
+				CreatedAt: now, UpdatedAt: now,
+			},
+			{
+				UserID: knownUserID, CardID: cardID, State: 0,
+				Due: now, Stability: 1.0, Difficulty: 5.0,
+				Reps: 0, Lapses: 0, LastReview: now,
+				ElapsedDays: 0, ScheduledDays: 0,
+				CreatedAt: now, UpdatedAt: now,
+			},
+		},
+	}
+
+	data, err := json.MarshalIndent(df, "", "  ")
+	require.NoError(t, err)
+	tmpFile := t.TempDir() + "/dump.json"
+	err = os.WriteFile(tmpFile, data, 0o644)
+	require.NoError(t, err)
+
+	err = runImport(testDBURL, tmpFile)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	var cgCount int
+	err = pool.QueryRow(ctx, `SELECT COUNT(*) FROM public.cardgroups`).Scan(&cgCount)
+	require.NoError(t, err)
+	assert.Equal(t, 0, cgCount, "cardgroup owned by unknown user should be skipped")
+
+	var cardCount int
+	err = pool.QueryRow(ctx, `SELECT COUNT(*) FROM public.cards`).Scan(&cardCount)
+	require.NoError(t, err)
+	assert.Equal(t, 0, cardCount, "card in skipped cardgroup should be cascaded-skipped")
+
+	var fsrsCount int
+	err = pool.QueryRow(ctx, `SELECT COUNT(*) FROM public.user_card_fsrs`).Scan(&fsrsCount)
+	require.NoError(t, err)
+	assert.Equal(t, 0, fsrsCount, "fsrs rows should be skipped (card not inserted + user skipped)")
+}

--- a/docs/backend/error-wrapping/assert-pii-absence-on-log-lines.md
+++ b/docs/backend/error-wrapping/assert-pii-absence-on-log-lines.md
@@ -12,3 +12,20 @@ if _, hasEmail := rec0["email"]; hasEmail {
 ```
 
 Used in the `superuser_test.go` INFO and WARN cases — the policy in `auth/superuser.go` is "log `user_id` only", and the absence-tests are what hold that contract.
+
+## CLI output: extend the same rule to unstructured stdout/stderr
+
+The slog-scoped rule above targets structured JSON fields in the application server. The same intent applies to unstructured output from CLI tools:
+
+- Email addresses must not appear in `log.Printf` lines from CLI tools. Use `<redacted>` as the placeholder literal when an identifier must appear for diagnostic purposes.
+- Summary lines that indicate skipped or failed items must print counts, not the actual email values:
+  ```go
+  // CORRECT
+  log.Printf("skipped %d users (already seeded)", skippedCount)
+
+  // WRONG — exposes PII in terminal output and log files
+  log.Printf("skipped users: %v", emailList)
+  ```
+- `fmt.Printf` progress output follows the same rule: print row counts or UUID prefixes, never full email addresses.
+
+This is a separate concern from the structured-field absence test above — both rules must be satisfied independently. A CLI that omits email from its slog JSON but prints it via `log.Printf` still violates the redaction policy.

--- a/docs/backend/library-gotchas/named-return-deferred-rollback.md
+++ b/docs/backend/library-gotchas/named-return-deferred-rollback.md
@@ -1,0 +1,83 @@
+# Named return `(retErr error)` for deferred `tx.Rollback` — local `err` can be shadowed
+
+> Part of the [Go library gotchas](./../../../.claude/rules/go-library-gotchas.md) rules.
+
+## Pattern
+
+Functions that defer `tx.Rollback()` must use a named return value `(retErr error)`, not a local variable `err`.
+
+```go
+// CORRECT
+func doWork(db *sql.DB) (retErr error) {
+    tx, err := db.Begin()
+    if err != nil {
+        return eris.Wrap(err, "begin tx")
+    }
+    defer func() {
+        if retErr != nil {
+            if rbErr := tx.Rollback(); rbErr != nil {
+                log.Printf("tx.Rollback failed: %v (original: %v)", rbErr, retErr)
+            }
+        }
+    }()
+
+    if err := someQuery(tx); err != nil {
+        return eris.Wrap(err, "some query") // sets retErr, defer sees it
+    }
+
+    return tx.Commit()
+}
+```
+
+```go
+// FRAGILE — do not use
+func doWork(db *sql.DB) error {
+    tx, err := db.Begin()
+    if err != nil {
+        return err
+    }
+    defer func() {
+        if err != nil { // captures the *outer* err
+            _ = tx.Rollback()
+        }
+    }()
+
+    if err := someQuery(tx); err != nil { // shadows outer err with :=
+        return err // outer err is still nil; defer rolls back nothing
+    }
+
+    return tx.Commit()
+}
+```
+
+## Why local `err` is fragile
+
+A `defer` closure captures variables by reference. When the deferred function checks `err != nil`, it reads the variable from the enclosing scope at the moment the defer runs — which is after the function returns.
+
+The fragile pattern breaks when a `:=` inside a nested block introduces a new `err` variable that shadows the outer one:
+
+```go
+if err := someQuery(tx); err != nil {
+    return err
+}
+```
+
+The `err` on the left of `:=` is a new variable. The outer `err` (captured by the defer) remains `nil`. When `someQuery` fails and the function returns, the defer sees `err == nil` and skips the rollback, leaving the transaction open until the connection is recycled.
+
+Named returns cannot be shadowed in this way. A `return err` inside a nested block assigns to the named return value (`retErr`), which the deferred closure reads correctly.
+
+## Log rollback errors, do not swallow them
+
+A failed rollback during a network partition leaves the database in an ambiguous state. Log the rollback error as a side channel so the operator knows both the original failure and the rollback failure:
+
+```go
+defer func() {
+    if retErr != nil {
+        if rbErr := tx.Rollback(); rbErr != nil {
+            log.Printf("tx.Rollback failed: %v (original error: %v)", rbErr, retErr)
+        }
+    }
+}()
+```
+
+Using `_ = tx.Rollback()` silently discards this diagnostic information.

--- a/docs/backend/library-gotchas/raw-sql-cli-pgx-stdlib.md
+++ b/docs/backend/library-gotchas/raw-sql-cli-pgx-stdlib.md
@@ -1,0 +1,63 @@
+# Raw SQL CLI: `sql.Open("pgx", dbURL)` + pgx stdlib, not GORM
+
+> Part of the [Go library gotchas](./../../../.claude/rules/go-library-gotchas.md) rules.
+
+## Pattern
+
+Single-purpose CLI tools connect to Postgres using `database/sql` with the pgx stdlib driver, not GORM.
+
+```go
+import (
+    "database/sql"
+    _ "github.com/jackc/pgx/v5/stdlib"
+)
+
+db, err := sql.Open("pgx", dbURL)
+if err != nil {
+    return eris.Wrap(err, "open db")
+}
+defer db.Close()
+
+if err := db.Ping(); err != nil {
+    return eris.Wrap(err, "ping db")
+}
+```
+
+## Why not GORM
+
+GORM is the right tool for the application server, where model-layer features (auto-migrations, associations, soft-delete, hooks) earn their overhead. For a one-shot CLI tool:
+
+- GORM's connection pool and model registry are initialized even if only one query runs.
+- GORM wraps raw SQL results in reflection-heavy scanning that adds no value when the CLI is already writing its own query strings.
+- A plain `*sql.DB` lifecycle is straightforward to reason about: open, ping, query, close. No `gorm.DB` state leaks between calls.
+
+## Validate the DSN before calling `sql.Open`
+
+`sql.Open("pgx", "")` succeeds — the driver defers connection establishment. The first observable failure is `db.Ping()`, which returns a pgx-level error such as:
+
+```
+failed to connect to `host=localhost user=postgres database=`: dial error
+```
+
+This error message does not make it obvious that the DSN was never provided. Always validate the flag value before calling `sql.Open`:
+
+```go
+if dbURL == "" {
+    return eris.New("--db-url is required")
+}
+db, err := sql.Open("pgx", dbURL)
+```
+
+## `auth.users` requires the superuser DSN
+
+The Supabase `auth` schema is owned by the `supabase_auth_admin` role and is not readable by the normal application role (e.g. `anon`, `authenticated`, or a custom app role). A CLI that queries `auth.users` directly — for example to look up emails from UUIDs — must connect with the postgres/superuser DSN, not the application DSN.
+
+Concretely, if the tool accepts both a `--db-url` (application DSN) and a `--admin-db-url` (superuser DSN), the `auth.users` query must use the admin connection:
+
+```go
+adminDB, err := sql.Open("pgx", adminDBURL)
+// ...
+rows, err := adminDB.Query(`SELECT id, email FROM auth.users WHERE id = ANY($1)`, pq.Array(ids))
+```
+
+Attempting the same query over the application DSN returns `ERROR: permission denied for schema auth` — not a confusing query result, but the error is only visible at runtime, so the DSN choice must be explicit in the code.

--- a/docs/backend/library-gotchas/sensitive-file-permissions-0o600.md
+++ b/docs/backend/library-gotchas/sensitive-file-permissions-0o600.md
@@ -1,0 +1,43 @@
+# Sensitive file output: use `0o600`, not `0o644`, for files containing PII
+
+> Part of the [Go library gotchas](./../../../.claude/rules/go-library-gotchas.md) rules.
+
+## Rule
+
+Files written by CLI tools that contain PII must use permission mode `0o600` (owner-read-write only). Using `0o644` (owner-read-write, group-read, other-read) makes the file readable by any process or user on the same system.
+
+```go
+// CORRECT
+if err := os.WriteFile(outPath, data, 0o600); err != nil {
+    return eris.Wrapf(err, "write output file %s", outPath)
+}
+
+// WRONG — world-readable
+if err := os.WriteFile(outPath, data, 0o644); err != nil { ... }
+```
+
+## What counts as PII in this codebase
+
+- Email addresses (from `auth.users` or any user-facing table).
+- `auth.users` UUIDs (they are stable identifiers that can be correlated across data sets).
+- Dump files produced by the seed CLI (they combine both of the above).
+- API tokens, secret keys, or any credential value written to disk.
+
+## Why `0o644` is a real risk
+
+On a shared CI runner or a developer machine with multiple accounts, a file written with `0o644` is readable by every other user on the system. Even on a single-user machine, `0o644` is world-readable by any process that can traverse the parent directory. A dump file that contains user emails sitting in `/tmp` or a project subdirectory with `0o644` violates the Supabase RLS intent — data that the database protects behind row-level policies is exposed in plaintext on the filesystem.
+
+## Creating parent directories
+
+When the output path may not exist yet, create the parent directory with `0o700` before writing the file:
+
+```go
+if err := os.MkdirAll(filepath.Dir(outPath), 0o700); err != nil {
+    return eris.Wrapf(err, "create output directory")
+}
+if err := os.WriteFile(outPath, data, 0o600); err != nil {
+    return eris.Wrapf(err, "write output file %s", outPath)
+}
+```
+
+Using `0o700` for the directory (owner-execute only) prevents other users from listing directory contents even if they can guess the path.

--- a/docs/backend/library-gotchas/sql-rows-explicit-close.md
+++ b/docs/backend/library-gotchas/sql-rows-explicit-close.md
@@ -1,0 +1,41 @@
+# `*sql.Rows`: explicit `rows.Close()` after loop in addition to `defer rows.Close()`
+
+> Part of the [Go library gotchas](./../../../.claude/rules/go-library-gotchas.md) rules.
+
+## Pattern
+
+After iterating `*sql.Rows`, call `rows.Close()` explicitly after the `rows.Err()` check, in addition to the safety-net `defer rows.Close()`.
+
+```go
+rows, err := db.QueryContext(ctx, `SELECT id, email FROM auth.users WHERE id = ANY($1)`, pq.Array(ids))
+if err != nil {
+    return eris.Wrap(err, "query users")
+}
+defer rows.Close() // safety net if an early return fires
+
+for rows.Next() {
+    var id, email string
+    if err := rows.Scan(&id, &email); err != nil {
+        return eris.Wrap(err, "scan user row")
+    }
+    // process row
+}
+if err := rows.Err(); err != nil {
+    return eris.Wrap(err, "rows iteration")
+}
+rows.Close() // release cursor immediately; double-close is safe
+```
+
+## Why two closes
+
+`defer rows.Close()` holds the server-side cursor open until the enclosing function returns. When the function performs non-trivial work after the iteration loop — JSON marshaling, file I/O, additional DB queries — all cursors deferred until that point remain open and occupy connection-pool slots. Under connection-pool pressure, a second query inside the same function can deadlock waiting for a slot that the first query's deferred close has not yet released.
+
+Calling `rows.Close()` explicitly after `rows.Err()` releases the cursor and the connection slot immediately, before the post-iteration work begins.
+
+## Double-close is safe
+
+`(*sql.Rows).Close()` is idempotent per the `database/sql` contract. The second call (from `defer`) is a no-op. There is no need to track whether the explicit close already ran.
+
+## The safety net `defer` is still required
+
+The explicit close only fires on the straight-line path through the loop. If `rows.Scan` returns an error and the function returns early, the cursor is still open. The `defer rows.Close()` at the top covers every early-return path and must remain in place.


### PR DESCRIPTION
## Summary

Introduces `seed dump` and `seed import` subcommands to `backend/cmd/seed`, enabling operators to export cardgroups, cards, and per-user FSRS state from one Postgres database to a JSON file and re-import it into another. This is the primary tool for migrating production or staging data across environments — for example, seeding a fresh Supabase instance with an existing user's card history. Two Makefile targets (`dump-data`, `import-data`) wrap the subcommands with `DB_URL` validation.

This branch addresses no GitHub issue — it ships from an operational need to move data between environments.

## Background / Motivation

- **No operator-level data migration path existed.** There was no supported way to move cardgroups, cards, and per-user FSRS scheduling state between two separate Postgres instances (e.g. from a local Supabase to a hosted one).
- **User UUID remapping is required across environments.** Supabase assigns new UUIDs to `auth.users` rows on each install; the importer must remap source UUIDs to matching target UUIDs by email before inserting any rows.
- **Cascade correctness requires explicit skip tracking.** Cardgroups owned by an unmapped user, cards in skipped cardgroups, and FSRS entries for skipped users or skipped cards must all be silently dropped rather than failing the import with a foreign-key violation.
- **PII in log output was a risk.** Earlier revisions logged the email address of every skipped user in plaintext; `skipped N users not found in target db` with a count replaces that pattern.
- **File permissions and error hygiene needed hardening.** The initial implementation wrote the dump file at `0o644` and silently discarded `db.Close()` / `tx.Rollback()` errors.

## Changes

### CLI (`backend/cmd/seed/main.go`)

- `runDump(dbURL, outPath)`: queries `cardgroups`, `cards`, and `user_card_fsrs` in sequence, closes each `sql.Rows` explicitly, collects referenced user UUIDs into a `UserMap`, and writes the serialized `DumpFile` to `outPath` at permission `0o600`.
- `runImport(dbURL, inPath)`: reads the dump file, resolves source-to-target UUID mappings by matching `auth.users.email`, tracks skipped UUIDs in three sets (`skipped`, `skippedCGs`, `skippedCards`) to cascade skips across dependent tables, and inserts all surviving rows inside a single transaction using a named return for rollback-on-error.
- `--db-url` validated before opening any connection; `db.Close()` wrapped to log errors rather than silently discard them; `log.Fatal` used for usage and unknown-subcommand errors instead of `fmt.Fprintln` + `os.Exit(1)`.
- Skipped-user summary prints a count only — email addresses never appear in stdout or stderr.

### Integration tests (`backend/cmd/seed/main_test.go`)

- Spins up an ephemeral `postgres:15-alpine` container via testcontainers, applies the full GORM migration set, then exercises round-trip dump → import correctness, cascade skip behavior (unmapped owner drops its cardgroup and its cards), and FSRS-entry orphan handling.

### Makefile

- `dump-data`: validates `DB_URL`, delegates to `go run ./cmd/seed dump`; accepts optional `DUMP_OUT` for the output path.
- `import-data`: validates `DB_URL`, delegates to `go run ./cmd/seed import`; accepts optional `DUMP_IN` for the input path.

## Verification

```bash
# Dump from local Supabase
make dump-data DB_URL=postgres://postgres:postgres@localhost:54322/postgres DUMP_OUT=/tmp/dump.json
# Expect: "dumped N cardgroups, M cards, K fsrs entries" printed; /tmp/dump.json created at mode 0600

# Import to a different DB
make import-data DB_URL=postgres://... DUMP_IN=/tmp/dump.json
# Expect: "imported N cardgroups, M cards, K fsrs entries" with any skipped-user count printed
```

## Test plan

- [ ] `go test -race ./cmd/seed/...` passes in `backend/` with no data-race reports
- [ ] `make dump-data DB_URL=<local-supabase-url>` produces a valid JSON file; `jq .cardgroups dump.json` returns a non-empty array
- [ ] Dump file is created with mode `0600`: `stat -f "%Lp" dump.json` → `600`
- [ ] `make import-data DB_URL=<target-db-url>` inserts all rows into the target DB; `SELECT COUNT(*) FROM public.cardgroups` matches the dump count
- [ ] A user email absent from the target `auth.users` table causes its cardgroup to be silently skipped; the importer prints `skipped N users not found in target db` with no email in the output
- [ ] A skipped cardgroup causes its cards to be skipped (no FK violation on `cardgroups.id`)
- [ ] A skipped card causes its `user_card_fsrs` rows to be skipped (no FK violation on `cards.id`)
- [ ] `make dump-data` without `DB_URL` prints `ERROR: DB_URL is required` and exits non-zero
- [ ] Regression: existing `seed-admin` and `seed-admin-prod` Makefile targets are unaffected
