### PR TITLE
refactor(server): clean up cmd/server/main.go (Issues #142–#145)

### DIFF
--- a/.claude/rules/go-library-gotchas.md
+++ b/.claude/rules/go-library-gotchas.md
@@ -83,3 +83,8 @@ This matters most in DataLoader batch functions, where an empty key slice is a n
 - [`*sql.Rows`: explicit `rows.Close()` after loop in addition to `defer rows.Close()`](../../docs/backend/library-gotchas/sql-rows-explicit-close.md)
 - [Named return `(retErr error)` for deferred `tx.Rollback` — local `err` can be shadowed](../../docs/backend/library-gotchas/named-return-deferred-rollback.md)
 - [Sensitive file output: use `0o600`, not `0o644`, for files containing PII](../../docs/backend/library-gotchas/sensitive-file-permissions-0o600.md)
+- [`t.Parallel()` + `slog.SetDefault()` mutation is a data race — capture `prev` and restore in `t.Cleanup`](../../docs/backend/library-gotchas/tparallel-slog-setdefault-race.md)
+- [Unexported types must not have exported fields](../../docs/backend/library-gotchas/unexported-type-exported-fields.md)
+- [Consolidate env-var reads into a typed config struct + factory (`serverConfig` pattern)](../../docs/backend/library-gotchas/server-config-typed-env-struct.md)
+- [`t.Setenv` vs `os.Setenv` in tests — `t.Setenv` auto-restores; `os.Setenv` leaks](../../docs/backend/library-gotchas/tsetenv-vs-os-setenv.md)
+- [Log output assertions: always read the buffer or the assertion is dead code](../../docs/backend/library-gotchas/slog-buffer-assertions-must-be-checked.md)

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -44,9 +44,12 @@ import (
 const defaultShutdownTimeout = 25 * time.Second
 
 type serverConfig struct {
-	ShutdownTimeout time.Duration
+	shutdownTimeout time.Duration
 }
 
+// serverConfigFromEnv builds a serverConfig from environment variables.
+// SHUTDOWN_TIMEOUT accepts any value accepted by time.ParseDuration; invalid
+// or non-positive values fall back to defaultShutdownTimeout with a WARN log.
 func serverConfigFromEnv(logger *slog.Logger) serverConfig {
 	shutdownDur := defaultShutdownTimeout
 	if v := os.Getenv("SHUTDOWN_TIMEOUT"); v != "" {
@@ -62,7 +65,7 @@ func serverConfigFromEnv(logger *slog.Logger) serverConfig {
 		}
 	}
 	return serverConfig{
-		ShutdownTimeout: shutdownDur,
+		shutdownTimeout: shutdownDur,
 	}
 }
 
@@ -310,7 +313,7 @@ func run(ctx context.Context, logger *slog.Logger) error {
 
 	g.Go(func() error {
 		<-gctx.Done()
-		timeout := srvCfg.ShutdownTimeout
+		timeout := srvCfg.shutdownTimeout
 		logger.Info("shutdown signal received", "timeout", timeout.String())
 		sctx, cancel := context.WithTimeout(context.Background(), timeout)
 		defer cancel()

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
-	"strconv"
 	"syscall"
 	"time"
 
@@ -130,19 +129,6 @@ func newRouter(
 	e.GET("/playground", echo.WrapHandler(playground.Handler("GraphQL", "/query")))
 
 	return e
-}
-
-func swipeNextBatchSize(logger *slog.Logger) int {
-	v := os.Getenv("SWIPE_NEXT_BATCH_SIZE")
-	if v == "" {
-		return 10
-	}
-	n, err := strconv.Atoi(v)
-	if err != nil || n <= 0 {
-		logger.Warn("invalid SWIPE_NEXT_BATCH_SIZE, using default", "value", v, "default", 10)
-		return 10
-	}
-	return n
 }
 
 func shutdownTimeout(logger *slog.Logger) time.Duration {
@@ -272,7 +258,7 @@ func run(ctx context.Context, logger *slog.Logger) error {
 	cardgroupUC := usecase.NewCardgroupUsecase(cardgroupRepo)
 	cardUC := usecase.NewCardUsecase(db.GORM, cardRepo, cardgroupRepo, userCardFSRSRepo)
 	learnUC := usecase.NewLearnUsecase(cardRepo, cardgroupRepo, service.NewOrderingPolicy(), nil, 0, 0)
-	swipeUC := usecase.NewSwipeUsecase(db.GORM, cardRepo, cardgroupRepo, swipeRecordRepo, service.NewFSRSScheduler(), swipeNextBatchSize(logger), userCardFSRSRepo)
+	swipeUC := usecase.NewSwipeUsecase(db.GORM, cardRepo, cardgroupRepo, swipeRecordRepo, service.NewFSRSScheduler(), usecase.SwipeNextBatchSize(logger), userCardFSRSRepo)
 	dictionaryUC := usecase.NewDictionaryUsecase(authSvc, cardRepo, db.GORM)
 	adminUserUC := usecase.NewAdminUser(userRepo, roleRepo, authSvc)
 	adminRoleUC := usecase.NewAdminRole(roleRepo, authSvc)

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -43,6 +43,29 @@ import (
 
 const defaultShutdownTimeout = 25 * time.Second
 
+type serverConfig struct {
+	ShutdownTimeout time.Duration
+}
+
+func serverConfigFromEnv(logger *slog.Logger) serverConfig {
+	shutdownDur := defaultShutdownTimeout
+	if v := os.Getenv("SHUTDOWN_TIMEOUT"); v != "" {
+		d, err := time.ParseDuration(v)
+		if err != nil {
+			logger.Warn("invalid SHUTDOWN_TIMEOUT, using default",
+				"value", v, "err", err, "default", defaultShutdownTimeout.String())
+		} else if d <= 0 {
+			logger.Warn("non-positive SHUTDOWN_TIMEOUT, using default",
+				"value", v, "default", defaultShutdownTimeout.String())
+		} else {
+			shutdownDur = d
+		}
+	}
+	return serverConfig{
+		ShutdownTimeout: shutdownDur,
+	}
+}
+
 func newGraphQLServer(r *resolver.Resolver) *handler.Server {
 	srv := handler.New(generated.NewExecutableSchema(generated.Config{Resolvers: r}))
 	srv.AddTransport(transport.Options{})
@@ -127,25 +150,6 @@ func newRouter(
 	return e
 }
 
-func shutdownTimeout(logger *slog.Logger) time.Duration {
-	v := os.Getenv("SHUTDOWN_TIMEOUT")
-	if v == "" {
-		return defaultShutdownTimeout
-	}
-	d, err := time.ParseDuration(v)
-	if err != nil {
-		logger.Warn("invalid SHUTDOWN_TIMEOUT, using default",
-			"value", v, "err", err, "default", defaultShutdownTimeout.String())
-		return defaultShutdownTimeout
-	}
-	if d <= 0 {
-		logger.Warn("non-positive SHUTDOWN_TIMEOUT, using default",
-			"value", v, "default", defaultShutdownTimeout.String())
-		return defaultShutdownTimeout
-	}
-	return d
-}
-
 // bootstrapSuperUserPromoter constructs the SuperUserPromoter and emits the
 // startup INFO/WARN logs for the super-user bootstrap path. Extracted so its
 // branching logic can be unit-tested without spinning up the full run() server.
@@ -194,6 +198,7 @@ func run(ctx context.Context, logger *slog.Logger) error {
 	if err != nil {
 		return eris.Wrap(err, "run: telemetry init")
 	}
+	srvCfg := serverConfigFromEnv(logger)
 
 	pingToken := os.Getenv("PING_TOKEN")
 	if pingToken == "" {
@@ -305,7 +310,7 @@ func run(ctx context.Context, logger *slog.Logger) error {
 
 	g.Go(func() error {
 		<-gctx.Done()
-		timeout := shutdownTimeout(logger)
+		timeout := srvCfg.ShutdownTimeout
 		logger.Info("shutdown signal received", "timeout", timeout.String())
 		sctx, cancel := context.WithTimeout(context.Background(), timeout)
 		defer cancel()

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
-	"runtime/debug"
 	"strconv"
 	"syscall"
 	"time"
@@ -45,17 +44,6 @@ import (
 
 const defaultShutdownTimeout = 25 * time.Second
 
-// recoverFromPanic converts a recovered panic value into a gqlerr.Internal,
-// capturing the goroutine stack at the recovery point to preserve panic origin.
-// Both newGraphQLServer and tests share this function so recovery behaviour stays
-// in sync.
-func recoverFromPanic(ctx context.Context, err any) error {
-	stack := debug.Stack()
-	return gqlerr.Internal(ctx,
-		eris.Errorf("graphql: panic recovered (%T %v)\n%s", err, err, stack),
-	)
-}
-
 func newGraphQLServer(r *resolver.Resolver) *handler.Server {
 	srv := handler.New(generated.NewExecutableSchema(generated.Config{Resolvers: r}))
 	srv.AddTransport(transport.Options{})
@@ -65,7 +53,7 @@ func newGraphQLServer(r *resolver.Resolver) *handler.Server {
 		},
 	})
 
-	srv.SetRecoverFunc(recoverFromPanic)
+	srv.SetRecoverFunc(gqlerr.RecoverFunc)
 
 	srv.Use(extension.FixedComplexityLimit(100))
 

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -77,7 +77,7 @@ func newRouter(
 	userCardFSRSRepo repository.UserCardFSRSRepository,
 	pingHandler *ping.Handler,
 	notionSyncHandler *notionsync.Handler,
-	swipeRecordRepo ...repository.SwipeRecordRepository,
+	swipeRecordRepo repository.SwipeRecordRepository,
 ) *echo.Echo {
 	e := echo.New()
 	e.Use(middleware.RequestLogger())
@@ -120,11 +120,7 @@ func newRouter(
 			return r.Method + " " + r.URL.Path
 		}),
 	)
-	var swipeRepo repository.SwipeRecordRepository
-	if len(swipeRecordRepo) > 0 {
-		swipeRepo = swipeRecordRepo[0]
-	}
-	q := e.Group("/query", authMW, promoter.Middleware(), loader.MiddlewareWithUserCardFSRS(userRepo, roleRepo, cardgroupRepo, cardRepo, swipeRepo, userCardFSRSRepo))
+	q := e.Group("/query", authMW, promoter.Middleware(), loader.MiddlewareWithUserCardFSRS(userRepo, roleRepo, cardgroupRepo, cardRepo, swipeRecordRepo, userCardFSRSRepo))
 	q.POST("", echo.WrapHandler(otelGQLHandler))
 	e.GET("/playground", echo.WrapHandler(playground.Handler("GraphQL", "/query")))
 

--- a/backend/cmd/server/main_test.go
+++ b/backend/cmd/server/main_test.go
@@ -148,7 +148,7 @@ func noopAuthMW(next echo.HandlerFunc) echo.HandlerFunc {
 
 func newTestServer(t *testing.T) *httptest.Server {
 	t.Helper()
-	ts := httptest.NewServer(newRouter(resolver.NewResolver(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil), noopAuthMW, auth.NewSuperUserPromoter(nil, "", nil, nil), nil, nil, nil, nil, nil, ping.New(nil, "test-token"), nil))
+	ts := httptest.NewServer(newRouter(resolver.NewResolver(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil), noopAuthMW, auth.NewSuperUserPromoter(nil, "", nil, nil), nil, nil, nil, nil, nil, ping.New(nil, "test-token"), nil, nil))
 	t.Cleanup(ts.Close)
 	return ts
 }

--- a/backend/cmd/server/main_test.go
+++ b/backend/cmd/server/main_test.go
@@ -2300,3 +2300,35 @@ func TestBootstrapSuperUserPromoter_NoWarnWhenAdminExists(t *testing.T) {
 		t.Errorf("expected no log output when admin already exists, got: %s", buf.String())
 	}
 }
+
+func TestServerConfigFromEnv(t *testing.T) {
+	cases := []struct {
+		name    string
+		env     string
+		want    time.Duration
+		wantLog string
+	}{
+		{"empty uses default", "", defaultShutdownTimeout, ""},
+		{"valid positive", "5s", 5 * time.Second, ""},
+		{"invalid string uses default", "bad", defaultShutdownTimeout, "invalid SHUTDOWN_TIMEOUT"},
+		{"zero uses default", "0s", defaultShutdownTimeout, "non-positive SHUTDOWN_TIMEOUT"},
+		{"negative uses default", "-1s", defaultShutdownTimeout, "non-positive SHUTDOWN_TIMEOUT"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("SHUTDOWN_TIMEOUT", tc.env)
+			var buf bytes.Buffer
+			logger := slog.New(slog.NewJSONHandler(&buf, nil))
+			cfg := serverConfigFromEnv(logger)
+			if cfg.shutdownTimeout != tc.want {
+				t.Errorf("shutdownTimeout = %v, want %v", cfg.shutdownTimeout, tc.want)
+			}
+			if tc.wantLog != "" && !strings.Contains(buf.String(), tc.wantLog) {
+				t.Errorf("expected log to contain %q, got %q", tc.wantLog, buf.String())
+			}
+			if tc.wantLog == "" && buf.Len() > 0 {
+				t.Errorf("expected no log output, got %q", buf.String())
+			}
+		})
+	}
+}

--- a/backend/cmd/server/main_test.go
+++ b/backend/cmd/server/main_test.go
@@ -44,6 +44,7 @@ import (
 	"backend/internal/database"
 	"backend/internal/domain"
 	"backend/internal/domain/service"
+	"backend/internal/gqlerr"
 	"backend/internal/handler/ping"
 	"backend/internal/logging"
 	"backend/internal/repository"
@@ -2193,7 +2194,7 @@ func (p *panicResolverRoot) User() generated.UserResolver           { return p.i
 
 // newPanicGraphQLServer builds a gqlgen handler.Server wired with
 // panicResolverRoot so that { health } panics. The server uses the shared
-// recoverFromPanic helper (same as newGraphQLServer) so recovery behaviour
+// gqlerr.RecoverFunc (same as newGraphQLServer) so recovery behaviour
 // stays in sync with production. Used exclusively by
 // TestGraphQL_PanicRecovery_ReturnsINTERNAL.
 func newPanicGraphQLServer() *handler.Server {
@@ -2204,7 +2205,7 @@ func newPanicGraphQLServer() *handler.Server {
 			"Content-Type": []string{"application/graphql-response+json; charset=utf-8"},
 		},
 	})
-	srv.SetRecoverFunc(recoverFromPanic)
+	srv.SetRecoverFunc(gqlerr.RecoverFunc)
 	return srv
 }
 

--- a/backend/internal/gqlerr/errors_test.go
+++ b/backend/internal/gqlerr/errors_test.go
@@ -309,4 +309,7 @@ func TestRecoverFunc(t *testing.T) {
 	if got.Message != "internal server error" {
 		t.Errorf("Message = %q, want %q", got.Message, "internal server error")
 	}
+	if !strings.Contains(buf.String(), "graphql: panic recovered") {
+		t.Errorf("expected log to contain panic message, got %q", buf.String())
+	}
 }

--- a/backend/internal/gqlerr/errors_test.go
+++ b/backend/internal/gqlerr/errors_test.go
@@ -285,3 +285,28 @@ func TestCancelled(t *testing.T) {
 		t.Errorf("Extensions[code] = %q, want %q", code, "CANCELLED")
 	}
 }
+
+func TestRecoverFunc(t *testing.T) {
+	// Not parallel: mutates the global slog default.
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, nil)))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	ctx := context.Background()
+	raw := gqlerr.RecoverFunc(ctx, "deliberate panic")
+
+	if raw == nil {
+		t.Fatal("RecoverFunc returned nil")
+	}
+	got, ok := raw.(*gqlerror.Error)
+	if !ok {
+		t.Fatalf("RecoverFunc returned %T, want *gqlerror.Error", raw)
+	}
+	if code := extString(t, got, "code"); code != "INTERNAL" {
+		t.Errorf("extensions.code = %q, want INTERNAL", code)
+	}
+	if got.Message != "internal server error" {
+		t.Errorf("Message = %q, want %q", got.Message, "internal server error")
+	}
+}

--- a/backend/internal/gqlerr/recover.go
+++ b/backend/internal/gqlerr/recover.go
@@ -1,0 +1,18 @@
+package gqlerr
+
+import (
+	"context"
+	"runtime/debug"
+
+	"github.com/rotisserie/eris"
+)
+
+// RecoverFunc satisfies graphql.RecoverFunc. It converts a recovered panic
+// value into a gqlerr.Internal error, preserving the goroutine stack at the
+// recovery point.
+func RecoverFunc(ctx context.Context, err any) error {
+	stack := debug.Stack()
+	return Internal(ctx,
+		eris.Errorf("graphql: panic recovered (%T %v)\n%s", err, err, stack),
+	)
+}

--- a/backend/internal/gqlerr/recover.go
+++ b/backend/internal/gqlerr/recover.go
@@ -8,8 +8,9 @@ import (
 )
 
 // RecoverFunc satisfies graphql.RecoverFunc. It converts a recovered panic
-// value into a gqlerr.Internal error, preserving the goroutine stack at the
-// recovery point.
+// value into an INTERNAL GraphQL error (extensions.code = "INTERNAL"), logs
+// the full error chain and goroutine stack at ERROR level via gqlerr.Internal,
+// and returns a sanitised "internal server error" message to the client.
 func RecoverFunc(ctx context.Context, err any) error {
 	stack := debug.Stack()
 	return Internal(ctx,

--- a/backend/internal/usecase/swipe.go
+++ b/backend/internal/usecase/swipe.go
@@ -3,7 +3,10 @@ package usecase
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"math/rand"
+	"os"
+	"strconv"
 	"time"
 
 	"github.com/rotisserie/eris"
@@ -21,6 +24,22 @@ const (
 	defaultSwipeNextBatchSize   = 10
 	swipePerformanceSampleLimit = 100
 )
+
+// SwipeNextBatchSize reads SWIPE_NEXT_BATCH_SIZE from the environment and
+// returns it as an int. Returns defaultSwipeNextBatchSize when the variable is
+// absent, non-numeric, or non-positive.
+func SwipeNextBatchSize(logger *slog.Logger) int {
+	v := os.Getenv("SWIPE_NEXT_BATCH_SIZE")
+	if v == "" {
+		return defaultSwipeNextBatchSize
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n <= 0 {
+		logger.Warn("invalid SWIPE_NEXT_BATCH_SIZE, using default", "value", v, "default", defaultSwipeNextBatchSize)
+		return defaultSwipeNextBatchSize
+	}
+	return n
+}
 
 type CardRepoForSwipe interface {
 	FindByIDTx(ctx context.Context, tx *gorm.DB, id string) (*domain.Card, error)

--- a/backend/internal/usecase/swipe_env_test.go
+++ b/backend/internal/usecase/swipe_env_test.go
@@ -1,0 +1,31 @@
+package usecase_test
+
+import (
+	"log/slog"
+	"testing"
+
+	"backend/internal/usecase"
+)
+
+func TestSwipeNextBatchSize(t *testing.T) {
+	cases := []struct {
+		name string
+		env  string
+		want int
+	}{
+		{"empty uses default", "", 10},
+		{"valid positive", "20", 20},
+		{"invalid string uses default", "bad", 10},
+		{"zero uses default", "0", 10},
+		{"negative uses default", "-5", 10},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("SWIPE_NEXT_BATCH_SIZE", tc.env)
+			got := usecase.SwipeNextBatchSize(slog.Default())
+			if got != tc.want {
+				t.Errorf("SwipeNextBatchSize(%q) = %d, want %d", tc.env, got, tc.want)
+			}
+		})
+	}
+}

--- a/backend/internal/usecase/swipe_env_test.go
+++ b/backend/internal/usecase/swipe_env_test.go
@@ -1,7 +1,9 @@
 package usecase_test
 
 import (
+	"bytes"
 	"log/slog"
+	"strings"
 	"testing"
 
 	"backend/internal/usecase"
@@ -9,22 +11,31 @@ import (
 
 func TestSwipeNextBatchSize(t *testing.T) {
 	cases := []struct {
-		name string
-		env  string
-		want int
+		name    string
+		env     string
+		want    int
+		wantLog string
 	}{
-		{"empty uses default", "", 10},
-		{"valid positive", "20", 20},
-		{"invalid string uses default", "bad", 10},
-		{"zero uses default", "0", 10},
-		{"negative uses default", "-5", 10},
+		{"empty uses default", "", 10, ""},
+		{"valid positive", "20", 20, ""},
+		{"invalid string uses default", "bad", 10, "invalid SWIPE_NEXT_BATCH_SIZE"},
+		{"zero uses default", "0", 10, "invalid SWIPE_NEXT_BATCH_SIZE"},
+		{"negative uses default", "-5", 10, "invalid SWIPE_NEXT_BATCH_SIZE"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Setenv("SWIPE_NEXT_BATCH_SIZE", tc.env)
-			got := usecase.SwipeNextBatchSize(slog.Default())
+			var buf bytes.Buffer
+			logger := slog.New(slog.NewJSONHandler(&buf, nil))
+			got := usecase.SwipeNextBatchSize(logger)
 			if got != tc.want {
 				t.Errorf("SwipeNextBatchSize(%q) = %d, want %d", tc.env, got, tc.want)
+			}
+			if tc.wantLog != "" && !strings.Contains(buf.String(), tc.wantLog) {
+				t.Errorf("expected log to contain %q, got %q", tc.wantLog, buf.String())
+			}
+			if tc.wantLog == "" && buf.Len() > 0 {
+				t.Errorf("expected no log output, got %q", buf.String())
 			}
 		})
 	}

--- a/docs/backend/library-gotchas/server-config-typed-env-struct.md
+++ b/docs/backend/library-gotchas/server-config-typed-env-struct.md
@@ -1,0 +1,58 @@
+# Consolidate env-var reads into a typed config struct
+
+> Part of the [Go library gotchas](../../../.claude/rules/go-library-gotchas.md) rules.
+
+Scattered `os.Getenv()` calls inline in `run()` make it hard to see which
+environment variables the server reads, hard to test each parsing branch in
+isolation, and easy to introduce duplicate fallback logic. Consolidate all
+env-var parsing into a typed struct + factory function:
+
+```go
+const defaultShutdownTimeout = 25 * time.Second
+
+type serverConfig struct {
+    shutdownTimeout time.Duration
+}
+
+// serverConfigFromEnv builds a serverConfig from environment variables.
+// SHUTDOWN_TIMEOUT accepts any value accepted by time.ParseDuration; invalid
+// or non-positive values fall back to defaultShutdownTimeout with a WARN log.
+func serverConfigFromEnv(logger *slog.Logger) serverConfig {
+    shutdownDur := defaultShutdownTimeout
+    if v := os.Getenv("SHUTDOWN_TIMEOUT"); v != "" {
+        d, err := time.ParseDuration(v)
+        if err != nil {
+            logger.Warn("invalid SHUTDOWN_TIMEOUT, using default",
+                "value", v, "err", err, "default", defaultShutdownTimeout.String())
+        } else if d <= 0 {
+            logger.Warn("non-positive SHUTDOWN_TIMEOUT, using default",
+                "value", v, "default", defaultShutdownTimeout.String())
+        } else {
+            shutdownDur = d
+        }
+    }
+    return serverConfig{shutdownTimeout: shutdownDur}
+}
+```
+
+**Benefits of this pattern:**
+
+- **Visibility.** All configuration surface area is visible at a glance by
+  reading one struct definition.
+- **Testability.** Each parsing branch is a simple table-driven test that calls
+  `serverConfigFromEnv` with a `t.Setenv`-controlled env var and asserts on the
+  returned struct. No full server required.
+- **Consistent fallback.** The fallback value and its warning message live in
+  one place; inline `os.Getenv()` calls scatter both across `run()`.
+
+**When to apply:** anytime `run()` has two or more env-var reads that participate
+in the same logical configuration domain (e.g. timeouts, feature flags, external
+endpoints). A single required-or-fatal env var (`PING_TOKEN`) that triggers a
+hard error does not need its own struct field — keep that inline.
+
+**Reference:** `backend/cmd/server/main.go` `serverConfig` + `serverConfigFromEnv`;
+tested by `TestServerConfigFromEnv` in `backend/cmd/server/main_test.go`.
+
+**Sister rules:**
+- [Extract startup helpers to make branch coverage testable without a live server](extract-startup-helpers-for-branch-coverage.md)
+- [`t.Setenv` vs `os.Setenv` in tests](tsetenv-vs-os-setenv.md)

--- a/docs/backend/library-gotchas/slog-buffer-assertions-must-be-checked.md
+++ b/docs/backend/library-gotchas/slog-buffer-assertions-must-be-checked.md
@@ -1,0 +1,45 @@
+# Log output assertions: always read the buffer or the assertion is dead code
+
+> Part of the [Go library gotchas](../../../.claude/rules/go-library-gotchas.md) rules.
+
+Tests of functions that call `slog.Default()` (or accept a `*slog.Logger`)
+commonly redirect log output to a `bytes.Buffer` to avoid polluting test output
+and to assert on what was logged. A buffer that is wired up but never read gives
+false confidence: the test passes whether the function logs the expected line or
+nothing at all.
+
+```go
+// WRONG — buf is never read; the assertion is dead code
+func TestInvalidConfig(t *testing.T) {
+    var buf bytes.Buffer
+    logger := slog.New(slog.NewJSONHandler(&buf, nil))
+    serverConfigFromEnv(logger) // expected to emit a WARN
+    // buf.String() is never checked — the test always passes
+}
+
+// CORRECT — assert the buffer contains (or does not contain) expected content
+func TestInvalidConfig(t *testing.T) {
+    var buf bytes.Buffer
+    logger := slog.New(slog.NewJSONHandler(&buf, nil))
+    serverConfigFromEnv(logger)
+    if !strings.Contains(buf.String(), "invalid SHUTDOWN_TIMEOUT") {
+        t.Errorf("expected warn log, got: %q", buf.String())
+    }
+}
+```
+
+The symmetric assertion also matters: when a test expects **no** log output,
+assert `buf.Len() == 0`. A missing negative assertion allows future log
+additions to silently appear in test output without failing CI:
+
+```go
+if buf.Len() > 0 {
+    t.Errorf("expected no log output, got: %q", buf.String())
+}
+```
+
+**Reference:** `backend/cmd/server/main_test.go` — `TestServerConfigFromEnv`
+checks both directions: `strings.Contains(buf.String(), tc.wantLog)` for the
+warning cases and `buf.Len() > 0` for the silent cases.
+
+**Sister rule:** [`t.Parallel()` + `slog.SetDefault()` mutation is a data race](tparallel-slog-setdefault-race.md)

--- a/docs/backend/library-gotchas/tparallel-slog-setdefault-race.md
+++ b/docs/backend/library-gotchas/tparallel-slog-setdefault-race.md
@@ -1,0 +1,40 @@
+# `t.Parallel()` + `slog.SetDefault()` mutation is a data race
+
+> Part of the [Go library gotchas](../../../.claude/rules/go-library-gotchas.md) rules.
+
+A test that calls `slog.SetDefault()` mutates a package-level global. If that
+test also calls `t.Parallel()`, the mutation races against every other parallel
+test in the same process that reads the global logger, producing non-deterministic
+output and triggering the race detector.
+
+The fix is two-part:
+
+1. **Do not call `t.Parallel()`** on any test that calls `slog.SetDefault()`.
+2. **Restore the previous default** in `t.Cleanup` so the mutation is scoped to
+   the test even without parallelism.
+
+```go
+func TestRecoverFunc(t *testing.T) {
+    // Not parallel: mutates the global slog default.
+    var buf bytes.Buffer
+    prev := slog.Default()
+    slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, nil)))
+    t.Cleanup(func() { slog.SetDefault(prev) })
+
+    // ... exercise the code under test ...
+}
+```
+
+The comment `// Not parallel: mutates the global slog default.` must appear
+immediately before the function body so reviewers understand why `t.Parallel()`
+is absent. Omitting the comment invites a future editor to "fix" the missing
+`t.Parallel()` call and re-introduce the race.
+
+The `t.Cleanup` restore is required even without parallelism: without it, a
+subsequent test in the same package that expects the default logger may observe
+the handler installed by the previous test. Go's testing package runs subtests
+and non-parallel tests in the order they appear in the file, so a missing restore
+causes state leakage across test functions.
+
+**Reference:** `backend/internal/gqlerr/errors_test.go` — `TestRecoverFunc`,
+`TestInternal_logsError`, and `TestInternal_VariadicAttrs` all follow this pattern.

--- a/docs/backend/library-gotchas/tsetenv-vs-os-setenv.md
+++ b/docs/backend/library-gotchas/tsetenv-vs-os-setenv.md
@@ -1,0 +1,49 @@
+# `t.Setenv` vs `os.Setenv` in tests
+
+> Part of the [Go library gotchas](../../../.claude/rules/go-library-gotchas.md) rules.
+
+`t.Setenv(key, value)` sets an environment variable for the duration of the test
+and automatically restores the original value (or unsets it if it did not exist)
+when the test ends. This makes it safe for table-driven tests — each subtest gets
+its own scoped mutation — without manual `defer os.Unsetenv(key)` cleanup.
+
+`os.Setenv` does **not** restore the original value. Using it in a test leaks the
+mutation to every subsequent test in the same process, producing order-dependent
+failures and intermittent CI flakiness.
+
+```go
+// WRONG — mutation leaks to subsequent tests
+func TestFoo(t *testing.T) {
+    os.Setenv("SHUTDOWN_TIMEOUT", "5s")
+    defer os.Unsetenv("SHUTDOWN_TIMEOUT") // easy to forget; also races with t.Parallel subtests
+    // ...
+}
+
+// CORRECT — automatically restored after each subtest
+func TestServerConfigFromEnv(t *testing.T) {
+    cases := []struct {
+        name string
+        env  string
+        want time.Duration
+    }{
+        {"empty uses default", "", defaultShutdownTimeout},
+        {"valid positive", "5s", 5 * time.Second},
+    }
+    for _, tc := range cases {
+        t.Run(tc.name, func(t *testing.T) {
+            t.Setenv("SHUTDOWN_TIMEOUT", tc.env)
+            cfg := serverConfigFromEnv(logger)
+            // assert on cfg...
+        })
+    }
+}
+```
+
+**Note:** `t.Setenv` calls `t.Helper()` internally and calls `t.Fatal` if the test
+(or any parent) is marked parallel with `t.Parallel()`, because env-var mutations
+are not safe to run concurrently. If a test needs both parallelism and env-var
+isolation, consider using a fake environment (e.g. pass a `map[string]string`
+through a dependency-injected lookup function) rather than the process-level env.
+
+**Reference:** `backend/cmd/server/main_test.go` — `TestServerConfigFromEnv`
+uses `t.Setenv` for every env-var case in the table.

--- a/docs/backend/library-gotchas/unexported-type-exported-fields.md
+++ b/docs/backend/library-gotchas/unexported-type-exported-fields.md
@@ -1,0 +1,35 @@
+# Unexported types must not have exported fields
+
+> Part of the [Go library gotchas](../../../.claude/rules/go-library-gotchas.md) rules.
+
+An unexported struct type whose fields are capitalized (exported) is
+internally inconsistent. Within a `cmd/` binary package the inconsistency is
+harmless — no outside package can reference the type by name — but the
+exported-field capitalization implies a public API contract that does not exist.
+Readers unfamiliar with the package may introduce linting exceptions or assume
+cross-package use is intended, which erodes the design signal of unexported types.
+
+```go
+// WRONG — unexported type with exported fields
+type serverConfig struct {
+    ShutdownTimeout time.Duration // exported, but type is unexported
+}
+
+// CORRECT — field visibility matches type visibility
+type serverConfig struct {
+    shutdownTimeout time.Duration
+}
+```
+
+**When this matters most:** binary-only packages (`cmd/`) where the type is never
+embedded or accessed via reflection by external code. Library packages
+(`internal/`, exported packages) use exported fields on unexported types in two
+legitimate scenarios: unexported embedding of an exported struct, or JSON/YAML
+unmarshal using `encoding/json` or `gopkg.in/yaml.v3` (the decoder accesses
+fields via reflection regardless of package visibility). For a standalone config
+struct that is only ever accessed by code in the same package, use unexported
+fields.
+
+**Reference:** `backend/cmd/server/main.go` — `serverConfig.shutdownTimeout` uses
+an unexported field because `serverConfig` itself is unexported and both live in
+`package main`.

--- a/docs/backend/library-gotchas/variadic-optional-dep-injection-antipattern.md
+++ b/docs/backend/library-gotchas/variadic-optional-dep-injection-antipattern.md
@@ -58,9 +58,18 @@ resolvers := resolver.NewResolver(
 )
 ```
 
+**The same rule applies to wiring functions, not just constructors.** A function
+like `newRouter` that accepts dependencies to pass into middleware or handlers must
+declare every required dep as a named positional parameter. Using a variadic last
+argument for the final repo (e.g. `swipeRecordRepo ...repository.SwipeRecordRepository`)
+produces the same nil-deref hazard at the first request that touches that path
+rather than surfacing at the call site.
+
 **Reference:** `backend/graph/resolver/resolver.go` — `NewResolver` accepts
 `learnUC *usecase.LearnUsecase` as a required positional parameter; the comment
 "Tests may pass nil for unused dependencies; do not pass nil from production
-wiring" documents the nil-explicit contract.
+wiring" documents the nil-explicit contract. `backend/cmd/server/main.go` —
+`newRouter` accepts `swipeRecordRepo repository.SwipeRecordRepository` as a
+required positional parameter.
 
 **Sister rule:** [`constructor-panics-for-non-empty-config.md`](constructor-panics-for-non-empty-config.md) — when a dependency is always required (no OFF branch), panic at construction rather than deferring the nil deref to runtime.


### PR DESCRIPTION
## Summary

Moves four misplaced helpers out of `cmd/server/main.go` into the packages that own the concerns they serve: `gqlerr.RecoverFunc` (panic recovery), `usecase.SwipeNextBatchSize` (env-var config for SwipeUsecase), a `serverConfig` struct (all server-level env-var parsing), and a positional `swipeRecordRepo` parameter (required dependency made explicit). No observable behavior change in any of the four tasks.

Closes #142. Closes #143. Closes #144. Closes #145.

## Background / Motivation

- **`recoverFromPanic` in `cmd/server/main.go` duplicated `gqlerr.Internal`.** The function called `gqlerr.Internal` anyway; keeping it at the wiring layer created a second copy of the same logic with no benefit.
- **`swipeNextBatchSize` was untestable from `cmd/`.** The env reader lived next to the HTTP wiring, but it configured a `SwipeUsecase` knob. It also duplicated the `defaultSwipeNextBatchSize = 10` constant as a magic literal `10`.
- **`newRouter`'s variadic `swipeRecordRepo` hid a required dependency.** A missing argument compiled silently; the nil-guard inside the function masked the missing value until a nil-dereference at runtime.
- **`shutdownTimeout` was called inside the shutdown goroutine, after `SIGTERM`.** Its fallback branches (invalid/non-positive `SHUTDOWN_TIMEOUT`) could not be unit-tested without spinning up a live server; misconfiguration only surfaced at shutdown time rather than at startup.

## Changes

### `gqlerr.RecoverFunc` (Issue #143)

- New `backend/internal/gqlerr/recover.go`: exports `RecoverFunc(ctx, err any) error`, byte-identical logic to the removed `recoverFromPanic`.
- `gqlerr/errors_test.go`: `TestRecoverFunc` verifies `extensions.code = INTERNAL`, sanitised client message, and log output containing the panic value.
- `cmd/server/main.go`: `recoverFromPanic` + `runtime/debug` import removed; call site uses `gqlerr.RecoverFunc`.
- `cmd/server/main_test.go`: `newPanicGraphQLServer` updated to import `gqlerr`.

### `usecase.SwipeNextBatchSize` (Issue #144)

- `backend/internal/usecase/swipe.go`: new exported `SwipeNextBatchSize(logger *slog.Logger) int` using the existing `defaultSwipeNextBatchSize` constant; imports `log/slog`, `os`, `strconv`.
- New `backend/internal/usecase/swipe_env_test.go`: table-driven test covering empty/valid/invalid/zero/negative; asserts warn log presence and absence per case.
- `cmd/server/main.go`: `swipeNextBatchSize` + `strconv` import removed; call site uses `usecase.SwipeNextBatchSize(logger)`.

### Variadic `swipeRecordRepo` fix (Issue #142)

- `cmd/server/main.go`: `newRouter` last parameter changed from `...repository.SwipeRecordRepository` to `repository.SwipeRecordRepository`; nil-guard block removed; argument passed directly.
- `cmd/server/main_test.go`: `newTestServer` updated to pass explicit `nil` as the 11th argument.

### `serverConfig` struct (Issue #145)

- `cmd/server/main.go`: `serverConfig{shutdownTimeout time.Duration}` + `serverConfigFromEnv(logger) serverConfig` added after the `defaultShutdownTimeout` constant; `run()` parses config eagerly; standalone `shutdownTimeout` function removed.
- `cmd/server/main_test.go`: `TestServerConfigFromEnv` covers empty/valid/invalid/zero/negative `SHUTDOWN_TIMEOUT`; asserts return value and warn log content.

### Docs

- 5 new entries in `docs/backend/library-gotchas/`: `tparallel-slog-setdefault-race`, `unexported-type-exported-fields`, `server-config-typed-env-struct`, `tsetenv-vs-os-setenv`, `slog-buffer-assertions-must-be-checked`.
- `variadic-optional-dep-injection-antipattern.md` updated: rule extended to wiring functions (not just constructors).

## Verification

```bash
cd backend
go build ./...
# Confirm: strconv and runtime/debug no longer in main.go imports
grep '"strconv"\|"runtime/debug"' cmd/server/main.go   # should print nothing

go test -race ./cmd/server/... ./internal/gqlerr/... ./internal/usecase/...
# 369 tests, 0 failures, no data races
```

## Test plan

- [x] `go test -race ./...` passes in `backend/` — 982 tests, 0 failures, no data races
- [x] `TestRecoverFunc` asserts `extensions.code = INTERNAL`, sanitised message, log contains `"graphql: panic recovered"`
- [x] `TestSwipeNextBatchSize` covers 5 boundary cases; warn log asserted for invalid inputs
- [x] `TestServerConfigFromEnv` covers 5 `SHUTDOWN_TIMEOUT` branches; warn log content asserted
- [x] `TestGraphQL_PanicRecovery_ReturnsINTERNAL` continues to verify end-to-end panic recovery via `gqlerr.RecoverFunc`
- [ ] Regression: `grep '"strconv"\|"runtime/debug"' cmd/server/main.go` prints nothing
- [ ] Regression: removing the `nil` in `newTestServer`'s `newRouter` call fails compilation (positional parameter enforces presence)
