### PR TITLE
chore(frontend): make biome lint fail on warnings via --error-on-warnings

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "biome check .",
+    "lint": "biome check --error-on-warnings .",
     "lint:fix": "biome check --write .",
     "format": "biome format --write .",
     "typecheck": "tsc --noEmit",


### PR DESCRIPTION
## Summary

Promotes Biome warn-severity diagnostics to CI failures by adding `--error-on-warnings` to the `frontend/` `lint` script. The current tree has zero warn-level diagnostics (`pnpm --filter frontend lint` reports `Checked 238 files. No fixes applied.`), so this lands as a no-op for the existing tree while preventing future warn-rule regressions from passing CI silently.

Closes #152.

## Background / Motivation

- **`biome check` exits zero on warnings by default.** Biome's recommended `correctness` rules — `noUnusedVariables`, `noUnusedImports`, `noUnusedFunctionParameters` — fire at the default `warn` severity. Without `--error-on-warnings`, the process exits zero even when those rules report findings, so the `Biome check` step in `.github/workflows/frontend.yml` passes regardless of warn-level deadness.
- **The window to enforce-by-default is now.** Today's diagnostic count is zero on `main`; flipping the switch is a no-op on the current tree. Delaying the change lets warn-level findings accumulate, after which the same flip becomes a cleanup PR rather than a one-line policy change.
- **`lint:fix` deliberately stays unchanged.** `biome check --write --error-on-warnings` would fail on the very warnings it just fixed, defeating the purpose of the auto-fix loop. Only the read-only `lint` script needs the flag.
- **knip remains the orthogonal cross-file analyzer.** Biome covers in-file unused symbols; knip (already wired into CI) covers unused files / exports / dependencies. The two are complementary; this PR is scoped strictly to Biome.

## Changes

### `frontend/package.json`

- `lint` script: `biome check .` → `biome check --error-on-warnings .`. CI's `Biome check` step (`pnpm --filter frontend lint`) now exits non-zero on warn-level diagnostics.
- `lint:fix` left unchanged (`biome check --write .`), per the rationale above.

## Verification

```bash
cd frontend
pnpm install
pnpm --filter frontend lint
# Expect: "Checked 238 files in <N>ms. No fixes applied." and exit 0
```

After CI lands, any future PR introducing an unused variable / import / function parameter (or any other Biome warn-severity rule) will fail the `Biome check` step in `.github/workflows/frontend.yml` rather than silently passing.

## Test plan

- [ ] `pnpm --filter frontend lint` exits 0 on this branch (zero diagnostics, baseline preserved)
- [ ] CI: the `Biome check` step in `.github/workflows/frontend.yml` is green on this branch
- [ ] Regression: induce a synthetic unused import (e.g. `import { unused } from "react"` in any `frontend/src/` file) on a throwaway branch and confirm `pnpm --filter frontend lint` exits non-zero, and the `Biome check` CI step fails
- [ ] `pnpm --filter frontend lint:fix` still works as an auto-fix loop (does NOT fail on warnings it would otherwise resolve)
