### PR TITLE
feat(#163): enforce outcome-union pattern with schema-lint and updateRole pilot

### DIFF
--- a/.claude/rules/error-wrapping.md
+++ b/.claude/rules/error-wrapping.md
@@ -68,6 +68,7 @@ detection is grep-based today and pinned at single-file
 ## Errors as data — detailed cases (on-demand)
 
 - [Result Union: "errors as data" pattern — when to use `CreateCardResult`-style unions over `BadUserInputWithExtensions`](../../docs/backend/error-wrapping/result-union-errors-as-data.md)
+- [Outcome-union enforcement: schema-lint gate forbidding new bare-object mutations that emit typed `ucerr.*` variants](../../docs/backend/error-wrapping/outcome-union-enforcement.md)
 
 ## Conversion boundaries — detailed cases (on-demand)
 

--- a/.claude/rules/frontend-rsc-error-handling.md
+++ b/.claude/rules/frontend-rsc-error-handling.md
@@ -79,3 +79,4 @@ Use `isUnauthenticatedGraphQLError` for all code paths — including simple redi
 - [GraphQL UNAUTHENTICATED must redirect to `/login`, not to an auth-required route](../../docs/frontend/rsc-error-handling/unauthenticated-redirect-target-must-be-login.md)
 - [Apollo `client.query()` is not cancelled on unmount — guard `setState` with `isMountedRef`](../../docs/frontend/rsc-error-handling/apollo-client-query-unmount-guard.md)
 - [`supabase.auth.getClaims()` has a three-way return — branch on `claimsData == null`](../../docs/frontend/rsc-error-handling/getclaims-three-way-return.md)
+- [`isUnauthenticatedGraphQLError` matches gqlFetch — not Apollo Client runtime errors](../../docs/frontend/rsc-error-handling/apollo-runtime-vs-gqlfetch-error-shape.md)

--- a/.claude/rules/go-library-gotchas.md
+++ b/.claude/rules/go-library-gotchas.md
@@ -98,3 +98,5 @@ This matters most in DataLoader batch functions, where an empty key slice is a n
 - [Migration down/up roundtrip test: prove the reverse path preserves data](../../docs/backend/library-gotchas/migration-down-up-roundtrip-test.md)
 - [RLS `INSERT-own` assertion on a PK-keyed table needs a fixture row that does not exist yet](../../docs/backend/library-gotchas/rls-insert-own-fresh-fixture-row.md)
 - [LSP stale-cache diagnostics during refactor — verify with `go build` before treating as real](../../docs/backend/library-gotchas/lsp-stale-cache-during-refactor.md)
+- [CI bash `rc=$?` is dead code under `set -e` — use `cmd || rc=$?`](../../docs/backend/library-gotchas/ci-bash-rc-capture-under-set-e.md)
+- [Walker / parser positive-discovery guards — silent zero disables enforcement](../../docs/backend/library-gotchas/walker-parser-positive-discovery-guards.md)

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -103,9 +103,11 @@ jobs:
       - name: Schema-lint outcome-union enforcement
         working-directory: backend
         run: |
-          if ! go run ./cmd/schema-lint; then
-            echo "::error::See docs/backend/error-wrapping/outcome-union-enforcement.md for the promotion guide."
-            exit 1
+          go run ./cmd/schema-lint
+          rc=$?
+          if [ $rc -ne 0 ]; then
+            echo "::error::Schema-lint failed with exit $rc. See docs/backend/error-wrapping/outcome-union-enforcement.md for the promotion guide (exit 1 = violation/drift; exit 2 = walker/config error)."
+            exit $rc
           fi
 
       - name: Build

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -103,11 +103,11 @@ jobs:
       - name: Schema-lint outcome-union enforcement
         working-directory: backend
         run: |
-          go run ./cmd/schema-lint
-          rc=$?
-          if [ $rc -ne 0 ]; then
+          rc=0
+          go run ./cmd/schema-lint || rc=$?
+          if [ "$rc" -ne 0 ]; then
             echo "::error::Schema-lint failed with exit $rc. See docs/backend/error-wrapping/outcome-union-enforcement.md for the promotion guide (exit 1 = violation/drift; exit 2 = walker/config error)."
-            exit $rc
+            exit "$rc"
           fi
 
       - name: Build

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -100,6 +100,14 @@ jobs:
             exit 1
           fi
 
+      - name: Schema-lint outcome-union enforcement
+        working-directory: backend
+        run: |
+          if ! go run ./cmd/schema-lint; then
+            echo "::error::See docs/backend/error-wrapping/outcome-union-enforcement.md for the promotion guide."
+            exit 1
+          fi
+
       - name: Build
         run: go build ./...
 

--- a/backend/cmd/schema-lint/README.md
+++ b/backend/cmd/schema-lint/README.md
@@ -1,0 +1,71 @@
+# schema-lint
+
+Enforces the outcome-union pattern for new GraphQL mutations that emit typed
+`ucerr.*` errors. A mutation whose return type is a bare object type AND whose
+usecase method emits `ucerr.NewValidationError`, `ucerr.NewForbiddenError`, or
+`ucerr.ErrUnauthenticated` is a violation. Existing violations are frozen via
+`allowlist.txt`; new mutations must use a `*Result` union from day one.
+
+See [docs/backend/error-wrapping/outcome-union-enforcement.md](../../../docs/backend/error-wrapping/outcome-union-enforcement.md) for the full
+promotion checklist and design rationale.
+
+## Usage
+
+Run from `backend/`:
+
+```
+go run ./cmd/schema-lint
+```
+
+### Flags
+
+| Flag | Default | Description |
+|---|---|---|
+| `-mode` | `error` | `error`: exit 1 on violations or drift. `warn`: print but exit 0. |
+| `-schema` | `../schema/schema.graphql` | Path to the GraphQL SDL file. |
+| `-resolver` | `graph/resolver/schema.resolvers.go` | Path to the generated resolver file. |
+| `-resolver-struct` | `graph/resolver/resolver.go` | Path to the `Resolver` struct declaration. |
+| `-usecase` | `internal/usecase` | Path to the usecase package directory (non-recursive). |
+| `-allowlist` | `cmd/schema-lint/allowlist.txt` | Path to the allowlist file. |
+
+### Exit codes
+
+| Code | Meaning |
+|---|---|
+| 0 | No violations and no drift (error mode), or `-mode=warn`. |
+| 1 | At least one violation or schema/resolver drift in error mode. |
+| 2 | Walker error: file not readable, schema parse error, or unknown `-mode`. |
+
+## Layout
+
+| File | Role |
+|---|---|
+| `schemawalk.go` | GraphQL SDL parser; classifies each mutation's return type as bare or not. |
+| `resolverwalk.go` | Go AST walker for `*mutationResolver` methods; extracts `r.<Field>.<Method>` calls. |
+| `usecasewalk.go` | Go AST walker for usecase methods; 1-bit `EmitsTypedError` detection. |
+| `classifier.go` | Joins the three walker outputs, applies the allowlist, reports violations and drifts. |
+| `main.go` | CLI wiring; hardcoded `InterfaceToImpl` map for interface-typed usecase fields. |
+| `allowlist.txt` | Frozen list of day-1 bare-emit mutations. |
+| `testdata/` | Fixture inputs for walker unit tests. |
+
+## Maintenance
+
+**Adding a new `ucerr.*` constructor** — extend the `switch` in
+`usecasewalk.go`'s `methodEmitsTypedError` function and add a fixture under
+`testdata/` to cover it.
+
+**Adding a new interface-typed usecase field to `Resolver`** — if the field
+type is an interface (not a `*usecase.XUsecase` concrete pointer), add a
+`"InterfaceName" -> "implName"` entry to the `interfaceToImpl` map in
+`main.go`. Concrete pointer fields are resolved automatically from the struct.
+
+**Allowlist rot** — when a mutation is promoted, the lint emits
+`allowlist-rot: <mutation> is allowlisted but no longer violates; remove the entry`.
+Delete the corresponding line from `allowlist.txt`.
+
+**Helper-delegated emissions** — the walker inspects only direct method bodies,
+not package-level helper functions called from those bodies. If a promoted
+mutation's usecase delegates all `ucerr.*` calls to a helper, the lint will
+not fire even without an allowlist entry. This is a known acceptable
+false-negative; extend the walker with same-file helper inlining if a real
+miss is detected.

--- a/backend/cmd/schema-lint/allowlist.txt
+++ b/backend/cmd/schema-lint/allowlist.txt
@@ -1,0 +1,21 @@
+# backend/cmd/schema-lint/allowlist.txt
+#
+# Mutations frozen as bare-type returns at issue #163's introduction.
+# Format: one mutation name per line, optional inline "#" comment with the
+# reason promotion is deferred. Blank lines and lines starting with "#" are
+# ignored.
+#
+# To promote a mutation: delete the line, change schema + usecase + resolver +
+# frontend in the same PR, then run `go run ./cmd/schema-lint` to verify.
+# See docs/backend/error-wrapping/outcome-union-enforcement.md for the full
+# 7-step promotion checklist.
+
+adminUpdateUser        # NewValidationError("id", "user not found")
+createCardgroup        # NewValidationError("name", ...): field-only payload
+handleSwipe            # NewValidationError("cardId", "card not found"): race; learn-UI broad
+revokeRole             # NewForbiddenError("cannot revoke own admin role")
+setLastViewedCardgroup # NewValidationError("cardgroupId", "cardgroup not found")
+updateCard             # NewValidationError(...): field-level validation
+updateCardgroup        # NewValidationError("name", ...): field-only payload
+updateProfile          # NewValidationError("displayName"/"bio", ...)
+upsertDictionary       # uses UpsertDictionaryPayload — different shape

--- a/backend/cmd/schema-lint/classifier.go
+++ b/backend/cmd/schema-lint/classifier.go
@@ -1,0 +1,397 @@
+package main
+
+import (
+	"bufio"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/rotisserie/eris"
+)
+
+// Violation represents one bare-emit mutation that is not allowlisted.
+type Violation struct {
+	// Mutation is the GraphQL field name, e.g. "updateRole".
+	Mutation string
+	// ReturnType is the GraphQL return type string, e.g. "Role!".
+	ReturnType string
+	// ResolverMethod is the PascalCase resolver method name, e.g. "UpdateRole".
+	ResolverMethod string
+	// UsecaseTarget is the resolved usecase receiver+method, e.g. "AdminRoleUC.Update".
+	UsecaseTarget string
+}
+
+// Drift represents a schema/resolver-Go drift: a mutation declared in
+// schema.graphql with no matching resolver method, or a resolver method
+// with no matching mutation field.
+type Drift struct {
+	// Mutation is the camelCase GraphQL mutation name. Empty if resolver-side drift.
+	Mutation string
+	// ResolverMethod is the PascalCase resolver method name. Empty if schema-side drift.
+	ResolverMethod string
+	// Description is a human-readable explanation of the drift.
+	Description string
+}
+
+// Allowlist is a set of mutation names that are exempt from the lint.
+// Loaded from backend/cmd/schema-lint/allowlist.txt.
+type Allowlist map[string]struct{}
+
+// ClassifierConfig carries optional interface-to-implementation mappings for
+// usecase types that are declared as interfaces in the resolver struct.
+type ClassifierConfig struct {
+	// InterfaceToImpl maps an interface type name to its unexported implementation
+	// type name, e.g. "AdminRoleUsecase" -> "adminRoleUsecase".
+	InterfaceToImpl map[string]string
+}
+
+// LoadAllowlist reads allowlist.txt and returns the set of allowlisted
+// mutation names. Blank lines and lines starting with "#" are ignored.
+// Inline comments after a "#" on a value line are also stripped.
+func LoadAllowlist(path string) (Allowlist, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, eris.Wrapf(err, "classifier: open allowlist %s", path)
+	}
+	defer f.Close()
+
+	al := make(Allowlist)
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		// Strip inline comments.
+		if idx := strings.Index(line, "#"); idx >= 0 {
+			line = line[:idx]
+		}
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		al[line] = struct{}{}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, eris.Wrapf(err, "classifier: scan allowlist %s", path)
+	}
+	return al, nil
+}
+
+// LoadResolverFieldMap parses the resolver struct file and returns a map from
+// resolver struct field name (e.g. "AdminRoleUC") to the underlying concrete
+// usecase type name (e.g. "adminRoleUsecase"). The value strips any leading "*"
+// and any "usecase." package prefix so callers can match directly against
+// UsecaseMethod.ReceiverType.
+func LoadResolverFieldMap(resolverPath string) (map[string]string, error) {
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, resolverPath, nil, 0)
+	if err != nil {
+		return nil, eris.Wrapf(err, "classifier: parse resolver struct %s", resolverPath)
+	}
+
+	result := make(map[string]string)
+	for _, decl := range f.Decls {
+		genDecl, ok := decl.(*ast.GenDecl)
+		if !ok {
+			continue
+		}
+		for _, spec := range genDecl.Specs {
+			typeSpec, ok := spec.(*ast.TypeSpec)
+			if !ok {
+				continue
+			}
+			if typeSpec.Name.Name != "Resolver" {
+				continue
+			}
+			structType, ok := typeSpec.Type.(*ast.StructType)
+			if !ok {
+				continue
+			}
+			for _, field := range structType.Fields.List {
+				if len(field.Names) == 0 {
+					continue
+				}
+				fieldName := field.Names[0].Name
+				typeName := extractTypeName(field.Type)
+				if typeName != "" {
+					result[fieldName] = typeName
+				}
+			}
+		}
+	}
+	return result, nil
+}
+
+// extractTypeName extracts the base type name from a field type expression,
+// stripping any leading "*" and any "usecase." package prefix.
+func extractTypeName(expr ast.Expr) string {
+	switch t := expr.(type) {
+	case *ast.StarExpr:
+		// Pointer type: *usecase.UserUsecase or *UserUsecase
+		return extractTypeName(t.X)
+	case *ast.SelectorExpr:
+		// Qualified name: usecase.DictionaryUsecase
+		// Return only the selector (type name), strip package prefix.
+		return t.Sel.Name
+	case *ast.Ident:
+		// Unqualified name: someLocalType
+		return t.Name
+	}
+	return ""
+}
+
+// Classify joins schema, resolver, and usecase walker outputs and applies
+// the allowlist. Returns violations and drifts in deterministic (sorted) order.
+//
+// resolverFieldToUsecaseType maps resolver struct field names to usecase type
+// names (as returned by LoadResolverFieldMap), e.g. {"AdminRoleUC": "AdminRoleUsecase"}.
+//
+// The cfg parameter carries optional InterfaceToImpl mappings for resolving
+// interface type names to concrete implementation names. A zero ClassifierConfig
+// is safe (all fields are nil-tolerant).
+func Classify(
+	schema []MutationReturn,
+	resolver ResolverWalkResult,
+	usecase []UsecaseMethod,
+	resolverFieldToUsecaseType map[string]string,
+	allowlist Allowlist,
+	cfg ClassifierConfig,
+) (violations []Violation, drifts []Drift) {
+	// Build a lookup: camelCase mutation name -> ResolverMapping.
+	resolverByMutation := make(map[string]ResolverMapping, len(resolver.Mappings))
+	for _, m := range resolver.Mappings {
+		resolverByMutation[m.MutationField] = m
+	}
+
+	// Build a lookup: camelCase mutation name from schema -> MutationReturn.
+	schemaByMutation := make(map[string]MutationReturn, len(schema))
+	for _, mr := range schema {
+		schemaByMutation[mr.Field] = mr
+	}
+
+	// Build a lookup: (receiverType, method) -> UsecaseMethod.
+	// Key is "ReceiverType:Method".
+	usecaseByKey := make(map[string]UsecaseMethod, len(usecase))
+	for _, um := range usecase {
+		key := um.ReceiverType + ":" + um.Method
+		usecaseByKey[key] = um
+		// Also index without leading "*" for pointer receivers.
+		stripped := strings.TrimPrefix(um.ReceiverType, "*")
+		if stripped != um.ReceiverType {
+			usecaseByKey[stripped+":"+um.Method] = um
+		}
+	}
+
+	// Drift detection — schema-side: mutations with no resolver method.
+	for _, mr := range schema {
+		if _, found := resolverByMutation[mr.Field]; !found {
+			drifts = append(drifts, Drift{
+				Mutation:    mr.Field,
+				Description: "mutation '" + mr.Field + "' has no resolver method",
+			})
+		}
+	}
+
+	// Drift detection — resolver-side: resolver methods with no mutation field.
+	for _, rm := range resolver.Mappings {
+		if _, found := schemaByMutation[rm.MutationField]; !found {
+			drifts = append(drifts, Drift{
+				ResolverMethod: rm.ResolverMethod,
+				Description:    "resolver method '" + rm.ResolverMethod + "' has no mutation field in schema",
+			})
+		}
+	}
+
+	// Violation detection — for each schema mutation, check if it is bare and emits.
+	for _, mr := range schema {
+		if !mr.IsBare {
+			continue
+		}
+		rm, found := resolverByMutation[mr.Field]
+		if !found {
+			// Already reported as drift above.
+			continue
+		}
+
+		// Gather all usecase calls: the primary call plus any additional calls.
+		type call struct{ Selector, Method string }
+		var calls []call
+		if rm.UsecaseSelector != "" && rm.UsecaseMethod != "" {
+			calls = append(calls, call{rm.UsecaseSelector, rm.UsecaseMethod})
+		}
+		for _, extra := range resolver.AdditionalCalls[rm.ResolverMethod] {
+			calls = append(calls, call{extra.Selector, extra.Method})
+		}
+
+		// OR-aggregate emission: if any reachable usecase method emits, mark true.
+		emits := false
+		usecaseTarget := ""
+		for _, c := range calls {
+			// Resolve the resolver field type.
+			fieldType, ok := resolverFieldToUsecaseType[c.Selector]
+			if !ok {
+				continue
+			}
+			// Resolve interface -> impl if applicable.
+			implType := resolveImplType(fieldType, cfg.InterfaceToImpl)
+
+			// Try matching usecase methods with both pointer and value receiver.
+			for _, candidate := range []string{"*" + implType, implType} {
+				key := candidate + ":" + c.Method
+				if um, found := usecaseByKey[key]; found {
+					if um.EmitsTypedError {
+						emits = true
+						if usecaseTarget == "" {
+							usecaseTarget = c.Selector + "." + c.Method
+						}
+					} else if usecaseTarget == "" {
+						usecaseTarget = c.Selector + "." + c.Method
+					}
+					break
+				}
+			}
+		}
+
+		if !emits {
+			continue
+		}
+
+		// Check the allowlist.
+		if _, allowlisted := allowlist[mr.Field]; allowlisted {
+			continue
+		}
+
+		if usecaseTarget == "" && len(calls) > 0 {
+			usecaseTarget = calls[0].Selector + "." + calls[0].Method
+		}
+
+		violations = append(violations, Violation{
+			Mutation:       mr.Field,
+			ReturnType:     mr.ReturnType,
+			ResolverMethod: rm.ResolverMethod,
+			UsecaseTarget:  usecaseTarget,
+		})
+	}
+
+	// Sort violations by mutation name for deterministic output.
+	sort.Slice(violations, func(i, j int) bool {
+		return violations[i].Mutation < violations[j].Mutation
+	})
+
+	// Sort drifts by a stable key (mutation name, then resolver method).
+	sort.Slice(drifts, func(i, j int) bool {
+		ki := drifts[i].Mutation + drifts[i].ResolverMethod
+		kj := drifts[j].Mutation + drifts[j].ResolverMethod
+		return ki < kj
+	})
+
+	return violations, drifts
+}
+
+// resolveImplType looks up an interface type name in the InterfaceToImpl map
+// and returns the concrete implementation name. If no mapping exists, the
+// input name is returned unchanged.
+func resolveImplType(typeName string, interfaceToImpl map[string]string) string {
+	if interfaceToImpl == nil {
+		return typeName
+	}
+	if impl, ok := interfaceToImpl[typeName]; ok {
+		return impl
+	}
+	return typeName
+}
+
+// AllowlistRotEntries returns the subset of allowlist entries that no longer
+// correspond to a bare-emit mutation. These are "rotten" entries that should
+// be removed.
+//
+// An entry rots when the mutation is no longer bare (returned a union, scalar,
+// list, or the mutation was removed from the schema), or when the usecase
+// no longer emits typed errors on the path the resolver calls.
+func AllowlistRotEntries(
+	schema []MutationReturn,
+	resolver ResolverWalkResult,
+	usecase []UsecaseMethod,
+	resolverFieldToUsecaseType map[string]string,
+	allowlist Allowlist,
+	cfg ClassifierConfig,
+) []string {
+	// Build schema lookup.
+	schemaByMutation := make(map[string]MutationReturn, len(schema))
+	for _, mr := range schema {
+		schemaByMutation[mr.Field] = mr
+	}
+
+	// Build resolver lookup.
+	resolverByMutation := make(map[string]ResolverMapping, len(resolver.Mappings))
+	for _, m := range resolver.Mappings {
+		resolverByMutation[m.MutationField] = m
+	}
+
+	// Build usecase lookup.
+	usecaseByKey := make(map[string]UsecaseMethod, len(usecase))
+	for _, um := range usecase {
+		key := um.ReceiverType + ":" + um.Method
+		usecaseByKey[key] = um
+		stripped := strings.TrimPrefix(um.ReceiverType, "*")
+		if stripped != um.ReceiverType {
+			usecaseByKey[stripped+":"+um.Method] = um
+		}
+	}
+
+	var rotten []string
+	for entry := range allowlist {
+		mr, inSchema := schemaByMutation[entry]
+		if !inSchema {
+			// Mutation was removed entirely.
+			rotten = append(rotten, entry)
+			continue
+		}
+		if !mr.IsBare {
+			// Mutation now returns a union/scalar/list.
+			rotten = append(rotten, entry)
+			continue
+		}
+		rm, inResolver := resolverByMutation[entry]
+		if !inResolver {
+			// Resolver method removed.
+			rotten = append(rotten, entry)
+			continue
+		}
+
+		// Check emission status.
+		type call struct{ Selector, Method string }
+		var calls []call
+		if rm.UsecaseSelector != "" && rm.UsecaseMethod != "" {
+			calls = append(calls, call{rm.UsecaseSelector, rm.UsecaseMethod})
+		}
+		for _, extra := range resolver.AdditionalCalls[rm.ResolverMethod] {
+			calls = append(calls, call{extra.Selector, extra.Method})
+		}
+
+		emits := false
+		for _, c := range calls {
+			fieldType, ok := resolverFieldToUsecaseType[c.Selector]
+			if !ok {
+				continue
+			}
+			implType := resolveImplType(fieldType, cfg.InterfaceToImpl)
+			for _, candidate := range []string{"*" + implType, implType} {
+				key := candidate + ":" + c.Method
+				if um, found := usecaseByKey[key]; found {
+					if um.EmitsTypedError {
+						emits = true
+					}
+					break
+				}
+			}
+		}
+		if !emits {
+			rotten = append(rotten, entry)
+		}
+	}
+
+	sort.Strings(rotten)
+	return rotten
+}

--- a/backend/cmd/schema-lint/classifier.go
+++ b/backend/cmd/schema-lint/classifier.go
@@ -253,10 +253,8 @@ func Classify(
 				if um, found := usecaseByKey[key]; found {
 					if um.EmitsTypedError {
 						emits = true
-						if usecaseTarget == "" {
-							usecaseTarget = c.Selector + "." + c.Method
-						}
-					} else if usecaseTarget == "" {
+					}
+					if usecaseTarget == "" {
 						usecaseTarget = c.Selector + "." + c.Method
 					}
 					break

--- a/backend/cmd/schema-lint/classifier.go
+++ b/backend/cmd/schema-lint/classifier.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"fmt"
 	"go/ast"
 	"go/parser"
 	"go/token"
@@ -203,6 +204,26 @@ func Classify(
 		}
 	}
 
+	// Drift detection — resolver method has a usecase selector whose
+	// resolver-struct field type is not resolvable (neither directly in the
+	// field-map nor via InterfaceToImpl). A new interface-typed Resolver field
+	// without a corresponding interfaceToImpl entry would silently disable
+	// emission detection otherwise.
+	for _, rm := range resolver.Mappings {
+		for _, c := range rm.UsecaseCalls {
+			if isSelectorResolvable(c.Selector, resolverFieldToUsecaseType, cfg.InterfaceToImpl) {
+				continue
+			}
+			drifts = append(drifts, Drift{
+				ResolverMethod: rm.ResolverMethod,
+				Description: fmt.Sprintf(
+					"classifier: resolver method '%s' has usecase selector 'r.%s.%s' but no corresponding usecase type found (add to interfaceToImpl map?)",
+					rm.ResolverMethod, c.Selector, c.Method,
+				),
+			})
+		}
+	}
+
 	// Violation detection — for each schema mutation, check if it is bare and emits.
 	for _, mr := range schema {
 		if !mr.IsBare {
@@ -214,20 +235,10 @@ func Classify(
 			continue
 		}
 
-		// Gather all usecase calls: the primary call plus any additional calls.
-		type call struct{ Selector, Method string }
-		var calls []call
-		if rm.UsecaseSelector != "" && rm.UsecaseMethod != "" {
-			calls = append(calls, call{rm.UsecaseSelector, rm.UsecaseMethod})
-		}
-		for _, extra := range resolver.AdditionalCalls[rm.ResolverMethod] {
-			calls = append(calls, call{extra.Selector, extra.Method})
-		}
-
 		// OR-aggregate emission: if any reachable usecase method emits, mark true.
 		emits := false
 		usecaseTarget := ""
-		for _, c := range calls {
+		for _, c := range rm.UsecaseCalls {
 			// Resolve the resolver field type.
 			fieldType, ok := resolverFieldToUsecaseType[c.Selector]
 			if !ok {
@@ -262,8 +273,8 @@ func Classify(
 			continue
 		}
 
-		if usecaseTarget == "" && len(calls) > 0 {
-			usecaseTarget = calls[0].Selector + "." + calls[0].Method
+		if usecaseTarget == "" && len(rm.UsecaseCalls) > 0 {
+			usecaseTarget = rm.UsecaseCalls[0].Selector + "." + rm.UsecaseCalls[0].Method
 		}
 
 		violations = append(violations, Violation{
@@ -300,6 +311,28 @@ func resolveImplType(typeName string, interfaceToImpl map[string]string) string 
 		return impl
 	}
 	return typeName
+}
+
+// isSelectorResolvable returns true when the resolver-struct field selector
+// is present in resolverFieldToUsecaseType. The selector resolves to a
+// type name; whether that type name eventually matches a concrete usecase
+// receiver is a separate concern handled by emission detection.
+func isSelectorResolvable(selector string, resolverFieldToUsecaseType, interfaceToImpl map[string]string) bool {
+	_, ok := resolverFieldToUsecaseType[selector]
+	if ok {
+		return true
+	}
+	// As a defensive fallback, if the selector is itself a known interface name
+	// in InterfaceToImpl, treat it as resolvable. In practice the selector is
+	// a field name (e.g. "AdminRoleUC"), not a type name, so this branch is
+	// rarely exercised — but it keeps the lint quiet when an operator adds an
+	// interfaceToImpl entry that happens to share a name with a field.
+	if interfaceToImpl != nil {
+		if _, ok := interfaceToImpl[selector]; ok {
+			return true
+		}
+	}
+	return false
 }
 
 // AllowlistRotEntries returns the subset of allowlist entries that no longer
@@ -360,18 +393,9 @@ func AllowlistRotEntries(
 			continue
 		}
 
-		// Check emission status.
-		type call struct{ Selector, Method string }
-		var calls []call
-		if rm.UsecaseSelector != "" && rm.UsecaseMethod != "" {
-			calls = append(calls, call{rm.UsecaseSelector, rm.UsecaseMethod})
-		}
-		for _, extra := range resolver.AdditionalCalls[rm.ResolverMethod] {
-			calls = append(calls, call{extra.Selector, extra.Method})
-		}
-
+		// Check emission status across every usecase call in the resolver method.
 		emits := false
-		for _, c := range calls {
+		for _, c := range rm.UsecaseCalls {
 			fieldType, ok := resolverFieldToUsecaseType[c.Selector]
 			if !ok {
 				continue

--- a/backend/cmd/schema-lint/classifier_test.go
+++ b/backend/cmd/schema-lint/classifier_test.go
@@ -1,0 +1,628 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// helper returns a zero-value ClassifierConfig (no interface-to-impl mappings).
+func noIfaceConfig() ClassifierConfig { return ClassifierConfig{} }
+
+// makeAllowlist constructs an Allowlist from a slice of mutation names.
+func makeAllowlist(names ...string) Allowlist {
+	al := make(Allowlist, len(names))
+	for _, n := range names {
+		al[n] = struct{}{}
+	}
+	return al
+}
+
+// --- Classify tests ----------------------------------------------------------
+
+func TestClassify_SingleBareEmit_NoAllowlist_OneViolation(t *testing.T) {
+	t.Parallel()
+
+	schema := []MutationReturn{
+		{Field: "updateRole", ReturnType: "Role!", IsBare: true},
+	}
+	resolver := ResolverWalkResult{
+		Mappings: []ResolverMapping{
+			{
+				MutationField:   "updateRole",
+				ResolverMethod:  "UpdateRole",
+				UsecaseSelector: "AdminRoleUC",
+				UsecaseMethod:   "Update",
+			},
+		},
+		AdditionalCalls: map[string][]struct{ Selector, Method string }{},
+	}
+	usecase := []UsecaseMethod{
+		{ReceiverType: "*adminRoleUsecase", Method: "Update", EmitsTypedError: true},
+	}
+	fieldMap := map[string]string{
+		"AdminRoleUC": "adminRoleUsecase",
+	}
+	allowlist := makeAllowlist()
+
+	violations, drifts := Classify(schema, resolver, usecase, fieldMap, allowlist, noIfaceConfig())
+
+	if len(drifts) != 0 {
+		t.Errorf("expected 0 drifts, got %d: %v", len(drifts), drifts)
+	}
+	want := []Violation{
+		{
+			Mutation:       "updateRole",
+			ReturnType:     "Role!",
+			ResolverMethod: "UpdateRole",
+			UsecaseTarget:  "AdminRoleUC.Update",
+		},
+	}
+	if diff := cmp.Diff(want, violations); diff != "" {
+		t.Errorf("violations mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestClassify_SingleBareEmit_InAllowlist_ZeroViolations(t *testing.T) {
+	t.Parallel()
+
+	schema := []MutationReturn{
+		{Field: "updateRole", ReturnType: "Role!", IsBare: true},
+	}
+	resolver := ResolverWalkResult{
+		Mappings: []ResolverMapping{
+			{
+				MutationField:   "updateRole",
+				ResolverMethod:  "UpdateRole",
+				UsecaseSelector: "AdminRoleUC",
+				UsecaseMethod:   "Update",
+			},
+		},
+		AdditionalCalls: map[string][]struct{ Selector, Method string }{},
+	}
+	usecase := []UsecaseMethod{
+		{ReceiverType: "*adminRoleUsecase", Method: "Update", EmitsTypedError: true},
+	}
+	fieldMap := map[string]string{"AdminRoleUC": "adminRoleUsecase"}
+	allowlist := makeAllowlist("updateRole")
+
+	violations, drifts := Classify(schema, resolver, usecase, fieldMap, allowlist, noIfaceConfig())
+
+	if len(drifts) != 0 {
+		t.Errorf("expected 0 drifts, got %d", len(drifts))
+	}
+	if len(violations) != 0 {
+		t.Errorf("expected 0 violations (allowlisted), got %d: %v", len(violations), violations)
+	}
+}
+
+func TestClassify_UnionReturn_ZeroViolations(t *testing.T) {
+	t.Parallel()
+
+	schema := []MutationReturn{
+		{Field: "createCard", ReturnType: "CreateCardResult!", IsBare: false},
+	}
+	resolver := ResolverWalkResult{
+		Mappings: []ResolverMapping{
+			{
+				MutationField:   "createCard",
+				ResolverMethod:  "CreateCard",
+				UsecaseSelector: "CardUC",
+				UsecaseMethod:   "Create",
+			},
+		},
+		AdditionalCalls: map[string][]struct{ Selector, Method string }{},
+	}
+	usecase := []UsecaseMethod{
+		{ReceiverType: "*cardUsecase", Method: "Create", EmitsTypedError: true},
+	}
+	fieldMap := map[string]string{"CardUC": "cardUsecase"}
+	allowlist := makeAllowlist()
+
+	violations, drifts := Classify(schema, resolver, usecase, fieldMap, allowlist, noIfaceConfig())
+
+	if len(drifts) != 0 {
+		t.Errorf("expected 0 drifts, got %d", len(drifts))
+	}
+	if len(violations) != 0 {
+		t.Errorf("expected 0 violations for union return, got %d: %v", len(violations), violations)
+	}
+}
+
+func TestClassify_ListReturn_ZeroViolations(t *testing.T) {
+	t.Parallel()
+
+	schema := []MutationReturn{
+		{Field: "bulkCreateCards", ReturnType: "[Card!]!", IsBare: false},
+	}
+	resolver := ResolverWalkResult{
+		Mappings: []ResolverMapping{
+			{
+				MutationField:   "bulkCreateCards",
+				ResolverMethod:  "BulkCreateCards",
+				UsecaseSelector: "CardUC",
+				UsecaseMethod:   "BulkCreate",
+			},
+		},
+		AdditionalCalls: map[string][]struct{ Selector, Method string }{},
+	}
+	usecase := []UsecaseMethod{
+		{ReceiverType: "*cardUsecase", Method: "BulkCreate", EmitsTypedError: true},
+	}
+	fieldMap := map[string]string{"CardUC": "cardUsecase"}
+	allowlist := makeAllowlist()
+
+	violations, drifts := Classify(schema, resolver, usecase, fieldMap, allowlist, noIfaceConfig())
+
+	if len(drifts) != 0 {
+		t.Errorf("expected 0 drifts, got %d", len(drifts))
+	}
+	if len(violations) != 0 {
+		t.Errorf("expected 0 violations for list return, got %d: %v", len(violations), violations)
+	}
+}
+
+func TestClassify_ScalarReturn_ZeroViolations(t *testing.T) {
+	t.Parallel()
+
+	schema := []MutationReturn{
+		{Field: "deleteRole", ReturnType: "Boolean!", IsBare: false},
+	}
+	resolver := ResolverWalkResult{
+		Mappings: []ResolverMapping{
+			{
+				MutationField:   "deleteRole",
+				ResolverMethod:  "DeleteRole",
+				UsecaseSelector: "AdminRoleUC",
+				UsecaseMethod:   "Delete",
+			},
+		},
+		AdditionalCalls: map[string][]struct{ Selector, Method string }{},
+	}
+	usecase := []UsecaseMethod{
+		{ReceiverType: "*adminRoleUsecase", Method: "Delete", EmitsTypedError: true},
+	}
+	fieldMap := map[string]string{"AdminRoleUC": "adminRoleUsecase"}
+	allowlist := makeAllowlist()
+
+	violations, drifts := Classify(schema, resolver, usecase, fieldMap, allowlist, noIfaceConfig())
+
+	if len(drifts) != 0 {
+		t.Errorf("expected 0 drifts, got %d", len(drifts))
+	}
+	if len(violations) != 0 {
+		t.Errorf("expected 0 violations for scalar return, got %d: %v", len(violations), violations)
+	}
+}
+
+func TestClassify_BareReturn_NoEmission_ZeroViolations(t *testing.T) {
+	t.Parallel()
+
+	schema := []MutationReturn{
+		{Field: "updateRole", ReturnType: "Role!", IsBare: true},
+	}
+	resolver := ResolverWalkResult{
+		Mappings: []ResolverMapping{
+			{
+				MutationField:   "updateRole",
+				ResolverMethod:  "UpdateRole",
+				UsecaseSelector: "AdminRoleUC",
+				UsecaseMethod:   "Update",
+			},
+		},
+		AdditionalCalls: map[string][]struct{ Selector, Method string }{},
+	}
+	usecase := []UsecaseMethod{
+		{ReceiverType: "*adminRoleUsecase", Method: "Update", EmitsTypedError: false},
+	}
+	fieldMap := map[string]string{"AdminRoleUC": "adminRoleUsecase"}
+	allowlist := makeAllowlist()
+
+	violations, drifts := Classify(schema, resolver, usecase, fieldMap, allowlist, noIfaceConfig())
+
+	if len(drifts) != 0 {
+		t.Errorf("expected 0 drifts, got %d", len(drifts))
+	}
+	if len(violations) != 0 {
+		t.Errorf("expected 0 violations when usecase does not emit, got %d: %v", len(violations), violations)
+	}
+}
+
+func TestClassify_SchemaSideDrift_NoResolverMethod(t *testing.T) {
+	t.Parallel()
+
+	schema := []MutationReturn{
+		{Field: "updateRole", ReturnType: "Role!", IsBare: true},
+	}
+	resolver := ResolverWalkResult{
+		Mappings:        []ResolverMapping{}, // no matching resolver
+		AdditionalCalls: map[string][]struct{ Selector, Method string }{},
+	}
+	usecase := []UsecaseMethod{}
+	fieldMap := map[string]string{}
+	allowlist := makeAllowlist()
+
+	violations, drifts := Classify(schema, resolver, usecase, fieldMap, allowlist, noIfaceConfig())
+
+	if len(violations) != 0 {
+		t.Errorf("expected 0 violations for drift-only scenario, got %d", len(violations))
+	}
+	if len(drifts) != 1 {
+		t.Fatalf("expected 1 drift, got %d: %v", len(drifts), drifts)
+	}
+	if drifts[0].Mutation != "updateRole" {
+		t.Errorf("drift.Mutation = %q, want %q", drifts[0].Mutation, "updateRole")
+	}
+	if drifts[0].ResolverMethod != "" {
+		t.Errorf("drift.ResolverMethod = %q, want empty for schema-side drift", drifts[0].ResolverMethod)
+	}
+}
+
+func TestClassify_ResolverSideDrift_NoMutationField(t *testing.T) {
+	t.Parallel()
+
+	schema := []MutationReturn{} // no mutation declared
+	resolver := ResolverWalkResult{
+		Mappings: []ResolverMapping{
+			{
+				MutationField:   "updateRole",
+				ResolverMethod:  "UpdateRole",
+				UsecaseSelector: "AdminRoleUC",
+				UsecaseMethod:   "Update",
+			},
+		},
+		AdditionalCalls: map[string][]struct{ Selector, Method string }{},
+	}
+	usecase := []UsecaseMethod{}
+	fieldMap := map[string]string{}
+	allowlist := makeAllowlist()
+
+	violations, drifts := Classify(schema, resolver, usecase, fieldMap, allowlist, noIfaceConfig())
+
+	if len(violations) != 0 {
+		t.Errorf("expected 0 violations for drift-only scenario, got %d", len(violations))
+	}
+	if len(drifts) != 1 {
+		t.Fatalf("expected 1 drift, got %d: %v", len(drifts), drifts)
+	}
+	if drifts[0].ResolverMethod != "UpdateRole" {
+		t.Errorf("drift.ResolverMethod = %q, want %q", drifts[0].ResolverMethod, "UpdateRole")
+	}
+	if drifts[0].Mutation != "" {
+		t.Errorf("drift.Mutation = %q, want empty for resolver-side drift", drifts[0].Mutation)
+	}
+}
+
+func TestClassify_MultiCallResolver_EmissionORAggregation(t *testing.T) {
+	t.Parallel()
+
+	// First call does NOT emit; second call DOES emit.
+	schema := []MutationReturn{
+		{Field: "handleSwipe", ReturnType: "Card!", IsBare: true},
+	}
+	resolver := ResolverWalkResult{
+		Mappings: []ResolverMapping{
+			{
+				MutationField:   "handleSwipe",
+				ResolverMethod:  "HandleSwipe",
+				UsecaseSelector: "CardgroupUC",
+				UsecaseMethod:   "Get",
+			},
+		},
+		AdditionalCalls: map[string][]struct{ Selector, Method string }{
+			"HandleSwipe": {
+				{Selector: "CardUC", Method: "Create"},
+			},
+		},
+	}
+	usecase := []UsecaseMethod{
+		{ReceiverType: "*cardgroupUsecase", Method: "Get", EmitsTypedError: false},
+		{ReceiverType: "*cardUsecase", Method: "Create", EmitsTypedError: true},
+	}
+	fieldMap := map[string]string{
+		"CardgroupUC": "cardgroupUsecase",
+		"CardUC":      "cardUsecase",
+	}
+	allowlist := makeAllowlist()
+
+	violations, drifts := Classify(schema, resolver, usecase, fieldMap, allowlist, noIfaceConfig())
+
+	if len(drifts) != 0 {
+		t.Errorf("expected 0 drifts, got %d", len(drifts))
+	}
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation from OR-aggregation, got %d: %v", len(violations), violations)
+	}
+	if violations[0].Mutation != "handleSwipe" {
+		t.Errorf("violation.Mutation = %q, want %q", violations[0].Mutation, "handleSwipe")
+	}
+}
+
+func TestClassify_InterfaceToImplResolution(t *testing.T) {
+	t.Parallel()
+
+	// AdminRoleUC is declared as interface type AdminRoleUsecase in the resolver
+	// struct. The impl is adminRoleUsecase.
+	schema := []MutationReturn{
+		{Field: "updateRole", ReturnType: "Role!", IsBare: true},
+	}
+	resolver := ResolverWalkResult{
+		Mappings: []ResolverMapping{
+			{
+				MutationField:   "updateRole",
+				ResolverMethod:  "UpdateRole",
+				UsecaseSelector: "AdminRoleUC",
+				UsecaseMethod:   "Update",
+			},
+		},
+		AdditionalCalls: map[string][]struct{ Selector, Method string }{},
+	}
+	// LoadResolverFieldMap returns the interface name; impl differs.
+	fieldMap := map[string]string{
+		"AdminRoleUC": "AdminRoleUsecase", // interface name from resolver.go
+	}
+	usecase := []UsecaseMethod{
+		// The method is on the *impl*, not the interface.
+		{ReceiverType: "*adminRoleUsecase", Method: "Update", EmitsTypedError: true},
+	}
+	allowlist := makeAllowlist()
+	cfg := ClassifierConfig{
+		InterfaceToImpl: map[string]string{
+			"AdminRoleUsecase": "adminRoleUsecase",
+		},
+	}
+
+	violations, drifts := Classify(schema, resolver, usecase, fieldMap, allowlist, cfg)
+
+	if len(drifts) != 0 {
+		t.Errorf("expected 0 drifts, got %d", len(drifts))
+	}
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation via interface->impl resolution, got %d: %v", len(violations), violations)
+	}
+	if violations[0].Mutation != "updateRole" {
+		t.Errorf("violation.Mutation = %q, want %q", violations[0].Mutation, "updateRole")
+	}
+}
+
+func TestClassify_SortedOutput_Deterministic(t *testing.T) {
+	t.Parallel()
+
+	schema := []MutationReturn{
+		{Field: "updateRole", ReturnType: "Role!", IsBare: true},
+		{Field: "createRole", ReturnType: "Role!", IsBare: true},
+	}
+	resolver := ResolverWalkResult{
+		Mappings: []ResolverMapping{
+			{
+				MutationField:   "updateRole",
+				ResolverMethod:  "UpdateRole",
+				UsecaseSelector: "AdminRoleUC",
+				UsecaseMethod:   "Update",
+			},
+			{
+				MutationField:   "createRole",
+				ResolverMethod:  "CreateRole",
+				UsecaseSelector: "AdminRoleUC",
+				UsecaseMethod:   "Create",
+			},
+		},
+		AdditionalCalls: map[string][]struct{ Selector, Method string }{},
+	}
+	usecase := []UsecaseMethod{
+		{ReceiverType: "*adminRoleUsecase", Method: "Update", EmitsTypedError: true},
+		{ReceiverType: "*adminRoleUsecase", Method: "Create", EmitsTypedError: true},
+	}
+	fieldMap := map[string]string{"AdminRoleUC": "adminRoleUsecase"}
+	allowlist := makeAllowlist()
+
+	violations, _ := Classify(schema, resolver, usecase, fieldMap, allowlist, noIfaceConfig())
+
+	if len(violations) != 2 {
+		t.Fatalf("expected 2 violations, got %d", len(violations))
+	}
+	// Must be sorted: createRole < updateRole.
+	if violations[0].Mutation != "createRole" || violations[1].Mutation != "updateRole" {
+		t.Errorf("violations not sorted: got [%s, %s]", violations[0].Mutation, violations[1].Mutation)
+	}
+}
+
+// --- LoadAllowlist tests -----------------------------------------------------
+
+func TestLoadAllowlist_BlankLinesAndComments(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "allowlist.txt")
+	content := `# This is a comment line
+# Another comment
+
+updateRole    # inline comment
+createRole
+
+# section header
+assignRole
+`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+
+	al, err := LoadAllowlist(path)
+	if err != nil {
+		t.Fatalf("LoadAllowlist: %v", err)
+	}
+
+	want := makeAllowlist("updateRole", "createRole", "assignRole")
+	if diff := cmp.Diff(want, al); diff != "" {
+		t.Errorf("allowlist mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestLoadAllowlist_EmptyFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "allowlist.txt")
+	if err := os.WriteFile(path, []byte(""), 0o644); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+
+	al, err := LoadAllowlist(path)
+	if err != nil {
+		t.Fatalf("LoadAllowlist: %v", err)
+	}
+	if len(al) != 0 {
+		t.Errorf("expected empty allowlist, got %d entries", len(al))
+	}
+}
+
+func TestLoadAllowlist_OnlyComments(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "allowlist.txt")
+	content := "# comment one\n# comment two\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+
+	al, err := LoadAllowlist(path)
+	if err != nil {
+		t.Fatalf("LoadAllowlist: %v", err)
+	}
+	if len(al) != 0 {
+		t.Errorf("expected empty allowlist for comment-only file, got %d entries", len(al))
+	}
+}
+
+func TestLoadAllowlist_InlineComment(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "allowlist.txt")
+	content := "updateRole   # promoted later\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+
+	al, err := LoadAllowlist(path)
+	if err != nil {
+		t.Fatalf("LoadAllowlist: %v", err)
+	}
+	if _, ok := al["updateRole"]; !ok {
+		t.Errorf("expected 'updateRole' in allowlist after stripping inline comment")
+	}
+	if len(al) != 1 {
+		t.Errorf("expected 1 entry, got %d", len(al))
+	}
+}
+
+func TestLoadAllowlist_NonExistentFile(t *testing.T) {
+	t.Parallel()
+
+	_, err := LoadAllowlist(filepath.Join(t.TempDir(), "does-not-exist.txt"))
+	if err == nil {
+		t.Fatal("LoadAllowlist: expected error for missing file, got nil")
+	}
+}
+
+// --- LoadResolverFieldMap tests ----------------------------------------------
+
+func TestLoadResolverFieldMap(t *testing.T) {
+	t.Parallel()
+
+	// Write a minimal resolver.go fixture to a temp file.
+	dir := t.TempDir()
+	resolverSrc := `package resolver
+
+import "backend/internal/usecase"
+
+type Resolver struct {
+	CardUC      *usecase.CardUsecase
+	AdminRoleUC usecase.AdminRoleUsecase
+}
+`
+	path := filepath.Join(dir, "resolver.go")
+	if err := os.WriteFile(path, []byte(resolverSrc), 0o644); err != nil {
+		t.Fatalf("write resolver fixture: %v", err)
+	}
+
+	got, err := LoadResolverFieldMap(path)
+	if err != nil {
+		t.Fatalf("LoadResolverFieldMap: %v", err)
+	}
+
+	want := map[string]string{
+		"CardUC":      "CardUsecase",      // *usecase.CardUsecase -> "CardUsecase"
+		"AdminRoleUC": "AdminRoleUsecase", // usecase.AdminRoleUsecase -> "AdminRoleUsecase"
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("field map mismatch (-want +got):\n%s", diff)
+	}
+}
+
+// --- AllowlistRotEntries tests -----------------------------------------------
+
+func TestAllowlistRotEntries_PromotedMutation_IsRotten(t *testing.T) {
+	t.Parallel()
+
+	// The mutation now returns a union (IsBare=false) but is still in allowlist.
+	schema := []MutationReturn{
+		{Field: "updateRole", ReturnType: "UpdateRoleResult!", IsBare: false},
+	}
+	resolver := ResolverWalkResult{
+		Mappings: []ResolverMapping{
+			{
+				MutationField:   "updateRole",
+				ResolverMethod:  "UpdateRole",
+				UsecaseSelector: "AdminRoleUC",
+				UsecaseMethod:   "Update",
+			},
+		},
+		AdditionalCalls: map[string][]struct{ Selector, Method string }{},
+	}
+	usecase := []UsecaseMethod{
+		{ReceiverType: "*adminRoleUsecase", Method: "Update", EmitsTypedError: true},
+	}
+	fieldMap := map[string]string{"AdminRoleUC": "adminRoleUsecase"}
+	allowlist := makeAllowlist("updateRole")
+
+	rotten := AllowlistRotEntries(schema, resolver, usecase, fieldMap, allowlist, noIfaceConfig())
+
+	if len(rotten) != 1 || rotten[0] != "updateRole" {
+		t.Errorf("expected [\"updateRole\"] as rotten, got %v", rotten)
+	}
+}
+
+func TestAllowlistRotEntries_StillViolating_NotRotten(t *testing.T) {
+	t.Parallel()
+
+	// The mutation is still bare and still emits — it should NOT appear as rotten.
+	schema := []MutationReturn{
+		{Field: "updateRole", ReturnType: "Role!", IsBare: true},
+	}
+	resolver := ResolverWalkResult{
+		Mappings: []ResolverMapping{
+			{
+				MutationField:   "updateRole",
+				ResolverMethod:  "UpdateRole",
+				UsecaseSelector: "AdminRoleUC",
+				UsecaseMethod:   "Update",
+			},
+		},
+		AdditionalCalls: map[string][]struct{ Selector, Method string }{},
+	}
+	usecase := []UsecaseMethod{
+		{ReceiverType: "*adminRoleUsecase", Method: "Update", EmitsTypedError: true},
+	}
+	fieldMap := map[string]string{"AdminRoleUC": "adminRoleUsecase"}
+	allowlist := makeAllowlist("updateRole")
+
+	rotten := AllowlistRotEntries(schema, resolver, usecase, fieldMap, allowlist, noIfaceConfig())
+
+	if len(rotten) != 0 {
+		t.Errorf("expected no rotten entries, got %v", rotten)
+	}
+}

--- a/backend/cmd/schema-lint/classifier_test.go
+++ b/backend/cmd/schema-lint/classifier_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -31,13 +32,13 @@ func TestClassify_SingleBareEmit_NoAllowlist_OneViolation(t *testing.T) {
 	resolver := ResolverWalkResult{
 		Mappings: []ResolverMapping{
 			{
-				MutationField:   "updateRole",
-				ResolverMethod:  "UpdateRole",
-				UsecaseSelector: "AdminRoleUC",
-				UsecaseMethod:   "Update",
+				MutationField:  "updateRole",
+				ResolverMethod: "UpdateRole",
+				UsecaseCalls: []UsecaseCall{
+					{Selector: "AdminRoleUC", Method: "Update"},
+				},
 			},
 		},
-		AdditionalCalls: map[string][]struct{ Selector, Method string }{},
 	}
 	usecase := []UsecaseMethod{
 		{ReceiverType: "*adminRoleUsecase", Method: "Update", EmitsTypedError: true},
@@ -74,13 +75,13 @@ func TestClassify_SingleBareEmit_InAllowlist_ZeroViolations(t *testing.T) {
 	resolver := ResolverWalkResult{
 		Mappings: []ResolverMapping{
 			{
-				MutationField:   "updateRole",
-				ResolverMethod:  "UpdateRole",
-				UsecaseSelector: "AdminRoleUC",
-				UsecaseMethod:   "Update",
+				MutationField:  "updateRole",
+				ResolverMethod: "UpdateRole",
+				UsecaseCalls: []UsecaseCall{
+					{Selector: "AdminRoleUC", Method: "Update"},
+				},
 			},
 		},
-		AdditionalCalls: map[string][]struct{ Selector, Method string }{},
 	}
 	usecase := []UsecaseMethod{
 		{ReceiverType: "*adminRoleUsecase", Method: "Update", EmitsTypedError: true},
@@ -107,13 +108,13 @@ func TestClassify_UnionReturn_ZeroViolations(t *testing.T) {
 	resolver := ResolverWalkResult{
 		Mappings: []ResolverMapping{
 			{
-				MutationField:   "createCard",
-				ResolverMethod:  "CreateCard",
-				UsecaseSelector: "CardUC",
-				UsecaseMethod:   "Create",
+				MutationField:  "createCard",
+				ResolverMethod: "CreateCard",
+				UsecaseCalls: []UsecaseCall{
+					{Selector: "CardUC", Method: "Create"},
+				},
 			},
 		},
-		AdditionalCalls: map[string][]struct{ Selector, Method string }{},
 	}
 	usecase := []UsecaseMethod{
 		{ReceiverType: "*cardUsecase", Method: "Create", EmitsTypedError: true},
@@ -140,13 +141,13 @@ func TestClassify_ListReturn_ZeroViolations(t *testing.T) {
 	resolver := ResolverWalkResult{
 		Mappings: []ResolverMapping{
 			{
-				MutationField:   "bulkCreateCards",
-				ResolverMethod:  "BulkCreateCards",
-				UsecaseSelector: "CardUC",
-				UsecaseMethod:   "BulkCreate",
+				MutationField:  "bulkCreateCards",
+				ResolverMethod: "BulkCreateCards",
+				UsecaseCalls: []UsecaseCall{
+					{Selector: "CardUC", Method: "BulkCreate"},
+				},
 			},
 		},
-		AdditionalCalls: map[string][]struct{ Selector, Method string }{},
 	}
 	usecase := []UsecaseMethod{
 		{ReceiverType: "*cardUsecase", Method: "BulkCreate", EmitsTypedError: true},
@@ -173,13 +174,13 @@ func TestClassify_ScalarReturn_ZeroViolations(t *testing.T) {
 	resolver := ResolverWalkResult{
 		Mappings: []ResolverMapping{
 			{
-				MutationField:   "deleteRole",
-				ResolverMethod:  "DeleteRole",
-				UsecaseSelector: "AdminRoleUC",
-				UsecaseMethod:   "Delete",
+				MutationField:  "deleteRole",
+				ResolverMethod: "DeleteRole",
+				UsecaseCalls: []UsecaseCall{
+					{Selector: "AdminRoleUC", Method: "Delete"},
+				},
 			},
 		},
-		AdditionalCalls: map[string][]struct{ Selector, Method string }{},
 	}
 	usecase := []UsecaseMethod{
 		{ReceiverType: "*adminRoleUsecase", Method: "Delete", EmitsTypedError: true},
@@ -206,13 +207,13 @@ func TestClassify_BareReturn_NoEmission_ZeroViolations(t *testing.T) {
 	resolver := ResolverWalkResult{
 		Mappings: []ResolverMapping{
 			{
-				MutationField:   "updateRole",
-				ResolverMethod:  "UpdateRole",
-				UsecaseSelector: "AdminRoleUC",
-				UsecaseMethod:   "Update",
+				MutationField:  "updateRole",
+				ResolverMethod: "UpdateRole",
+				UsecaseCalls: []UsecaseCall{
+					{Selector: "AdminRoleUC", Method: "Update"},
+				},
 			},
 		},
-		AdditionalCalls: map[string][]struct{ Selector, Method string }{},
 	}
 	usecase := []UsecaseMethod{
 		{ReceiverType: "*adminRoleUsecase", Method: "Update", EmitsTypedError: false},
@@ -237,8 +238,7 @@ func TestClassify_SchemaSideDrift_NoResolverMethod(t *testing.T) {
 		{Field: "updateRole", ReturnType: "Role!", IsBare: true},
 	}
 	resolver := ResolverWalkResult{
-		Mappings:        []ResolverMapping{}, // no matching resolver
-		AdditionalCalls: map[string][]struct{ Selector, Method string }{},
+		Mappings: []ResolverMapping{}, // no matching resolver
 	}
 	usecase := []UsecaseMethod{}
 	fieldMap := map[string]string{}
@@ -267,16 +267,16 @@ func TestClassify_ResolverSideDrift_NoMutationField(t *testing.T) {
 	resolver := ResolverWalkResult{
 		Mappings: []ResolverMapping{
 			{
-				MutationField:   "updateRole",
-				ResolverMethod:  "UpdateRole",
-				UsecaseSelector: "AdminRoleUC",
-				UsecaseMethod:   "Update",
+				MutationField:  "updateRole",
+				ResolverMethod: "UpdateRole",
+				UsecaseCalls: []UsecaseCall{
+					{Selector: "AdminRoleUC", Method: "Update"},
+				},
 			},
 		},
-		AdditionalCalls: map[string][]struct{ Selector, Method string }{},
 	}
 	usecase := []UsecaseMethod{}
-	fieldMap := map[string]string{}
+	fieldMap := map[string]string{"AdminRoleUC": "adminRoleUsecase"}
 	allowlist := makeAllowlist()
 
 	violations, drifts := Classify(schema, resolver, usecase, fieldMap, allowlist, noIfaceConfig())
@@ -305,15 +305,12 @@ func TestClassify_MultiCallResolver_EmissionORAggregation(t *testing.T) {
 	resolver := ResolverWalkResult{
 		Mappings: []ResolverMapping{
 			{
-				MutationField:   "handleSwipe",
-				ResolverMethod:  "HandleSwipe",
-				UsecaseSelector: "CardgroupUC",
-				UsecaseMethod:   "Get",
-			},
-		},
-		AdditionalCalls: map[string][]struct{ Selector, Method string }{
-			"HandleSwipe": {
-				{Selector: "CardUC", Method: "Create"},
+				MutationField:  "handleSwipe",
+				ResolverMethod: "HandleSwipe",
+				UsecaseCalls: []UsecaseCall{
+					{Selector: "CardgroupUC", Method: "Get"},
+					{Selector: "CardUC", Method: "Create"},
+				},
 			},
 		},
 	}
@@ -324,6 +321,50 @@ func TestClassify_MultiCallResolver_EmissionORAggregation(t *testing.T) {
 	fieldMap := map[string]string{
 		"CardgroupUC": "cardgroupUsecase",
 		"CardUC":      "cardUsecase",
+	}
+	allowlist := makeAllowlist()
+
+	violations, drifts := Classify(schema, resolver, usecase, fieldMap, allowlist, noIfaceConfig())
+
+	if len(drifts) != 0 {
+		t.Errorf("expected 0 drifts, got %d", len(drifts))
+	}
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation from OR-aggregation, got %d: %v", len(violations), violations)
+	}
+	if violations[0].Mutation != "handleSwipe" {
+		t.Errorf("violation.Mutation = %q, want %q", violations[0].Mutation, "handleSwipe")
+	}
+}
+
+// TestClassify_MultiCallResolver_EmissionORAggregation_ReverseDirection asserts
+// the symmetric case: first call DOES emit, second call does NOT. The result
+// must still be a single violation, proving OR semantics are not order-dependent.
+func TestClassify_MultiCallResolver_EmissionORAggregation_ReverseDirection(t *testing.T) {
+	t.Parallel()
+
+	schema := []MutationReturn{
+		{Field: "handleSwipe", ReturnType: "Card!", IsBare: true},
+	}
+	resolver := ResolverWalkResult{
+		Mappings: []ResolverMapping{
+			{
+				MutationField:  "handleSwipe",
+				ResolverMethod: "HandleSwipe",
+				UsecaseCalls: []UsecaseCall{
+					{Selector: "CardUC", Method: "Create"},   // emits
+					{Selector: "CardgroupUC", Method: "Get"}, // does not emit
+				},
+			},
+		},
+	}
+	usecase := []UsecaseMethod{
+		{ReceiverType: "*cardUsecase", Method: "Create", EmitsTypedError: true},
+		{ReceiverType: "*cardgroupUsecase", Method: "Get", EmitsTypedError: false},
+	}
+	fieldMap := map[string]string{
+		"CardUC":      "cardUsecase",
+		"CardgroupUC": "cardgroupUsecase",
 	}
 	allowlist := makeAllowlist()
 
@@ -351,13 +392,13 @@ func TestClassify_InterfaceToImplResolution(t *testing.T) {
 	resolver := ResolverWalkResult{
 		Mappings: []ResolverMapping{
 			{
-				MutationField:   "updateRole",
-				ResolverMethod:  "UpdateRole",
-				UsecaseSelector: "AdminRoleUC",
-				UsecaseMethod:   "Update",
+				MutationField:  "updateRole",
+				ResolverMethod: "UpdateRole",
+				UsecaseCalls: []UsecaseCall{
+					{Selector: "AdminRoleUC", Method: "Update"},
+				},
 			},
 		},
-		AdditionalCalls: map[string][]struct{ Selector, Method string }{},
 	}
 	// LoadResolverFieldMap returns the interface name; impl differs.
 	fieldMap := map[string]string{
@@ -387,6 +428,89 @@ func TestClassify_InterfaceToImplResolution(t *testing.T) {
 	}
 }
 
+// TestClassify_UnresolvableSelector_EmitsDrift asserts that a resolver method
+// whose usecase selector cannot be resolved via the field map (and is also
+// not present in InterfaceToImpl) produces a classifier drift. This prevents
+// the silent failure mode where a new interface-typed Resolver field is
+// added but the hardcoded interfaceToImpl map is not extended.
+func TestClassify_UnresolvableSelector_EmitsDrift(t *testing.T) {
+	t.Parallel()
+
+	schema := []MutationReturn{
+		{Field: "frobnicate", ReturnType: "Role!", IsBare: true},
+	}
+	resolver := ResolverWalkResult{
+		Mappings: []ResolverMapping{
+			{
+				MutationField:  "frobnicate",
+				ResolverMethod: "Frobnicate",
+				UsecaseCalls: []UsecaseCall{
+					{Selector: "MysteryUC", Method: "DoIt"},
+				},
+			},
+		},
+	}
+	usecase := []UsecaseMethod{}
+	// Field map deliberately omits MysteryUC.
+	fieldMap := map[string]string{}
+	allowlist := makeAllowlist()
+
+	_, drifts := Classify(schema, resolver, usecase, fieldMap, allowlist, noIfaceConfig())
+
+	if len(drifts) == 0 {
+		t.Fatalf("expected at least one drift for unresolvable selector, got 0")
+	}
+	found := false
+	for _, d := range drifts {
+		if d.ResolverMethod == "Frobnicate" && strings.Contains(d.Description, "no corresponding usecase type found") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected a drift mentioning the unresolved selector; got drifts: %v", drifts)
+	}
+}
+
+// TestClassify_ResolvableSelectorButMissingMethod_NoDrift asserts that when
+// the selector resolves but the method does not match any UsecaseMethod entry
+// (e.g. the method does not exist on that receiver), the classifier does NOT
+// emit a drift for that case — that is a separate "method not in usecase scope"
+// concern, not the silent-disable failure the unresolvable-selector drift
+// guards against.
+func TestClassify_ResolvableSelectorButMissingMethod_NoDrift(t *testing.T) {
+	t.Parallel()
+
+	schema := []MutationReturn{
+		{Field: "updateRole", ReturnType: "Role!", IsBare: true},
+	}
+	resolver := ResolverWalkResult{
+		Mappings: []ResolverMapping{
+			{
+				MutationField:  "updateRole",
+				ResolverMethod: "UpdateRole",
+				UsecaseCalls: []UsecaseCall{
+					{Selector: "AdminRoleUC", Method: "MethodThatDoesNotExist"},
+				},
+			},
+		},
+	}
+	usecase := []UsecaseMethod{
+		// Different method name; the call's method is not represented.
+		{ReceiverType: "*adminRoleUsecase", Method: "Update", EmitsTypedError: true},
+	}
+	fieldMap := map[string]string{"AdminRoleUC": "adminRoleUsecase"}
+	allowlist := makeAllowlist()
+
+	_, drifts := Classify(schema, resolver, usecase, fieldMap, allowlist, noIfaceConfig())
+
+	for _, d := range drifts {
+		if d.ResolverMethod == "UpdateRole" && strings.Contains(d.Description, "no corresponding usecase type found") {
+			t.Errorf("did not expect an unresolvable-selector drift for a method-not-found case; got: %v", d)
+		}
+	}
+}
+
 func TestClassify_SortedOutput_Deterministic(t *testing.T) {
 	t.Parallel()
 
@@ -397,19 +521,20 @@ func TestClassify_SortedOutput_Deterministic(t *testing.T) {
 	resolver := ResolverWalkResult{
 		Mappings: []ResolverMapping{
 			{
-				MutationField:   "updateRole",
-				ResolverMethod:  "UpdateRole",
-				UsecaseSelector: "AdminRoleUC",
-				UsecaseMethod:   "Update",
+				MutationField:  "updateRole",
+				ResolverMethod: "UpdateRole",
+				UsecaseCalls: []UsecaseCall{
+					{Selector: "AdminRoleUC", Method: "Update"},
+				},
 			},
 			{
-				MutationField:   "createRole",
-				ResolverMethod:  "CreateRole",
-				UsecaseSelector: "AdminRoleUC",
-				UsecaseMethod:   "Create",
+				MutationField:  "createRole",
+				ResolverMethod: "CreateRole",
+				UsecaseCalls: []UsecaseCall{
+					{Selector: "AdminRoleUC", Method: "Create"},
+				},
 			},
 		},
-		AdditionalCalls: map[string][]struct{ Selector, Method string }{},
 	}
 	usecase := []UsecaseMethod{
 		{ReceiverType: "*adminRoleUsecase", Method: "Update", EmitsTypedError: true},
@@ -575,13 +700,13 @@ func TestAllowlistRotEntries_PromotedMutation_IsRotten(t *testing.T) {
 	resolver := ResolverWalkResult{
 		Mappings: []ResolverMapping{
 			{
-				MutationField:   "updateRole",
-				ResolverMethod:  "UpdateRole",
-				UsecaseSelector: "AdminRoleUC",
-				UsecaseMethod:   "Update",
+				MutationField:  "updateRole",
+				ResolverMethod: "UpdateRole",
+				UsecaseCalls: []UsecaseCall{
+					{Selector: "AdminRoleUC", Method: "Update"},
+				},
 			},
 		},
-		AdditionalCalls: map[string][]struct{ Selector, Method string }{},
 	}
 	usecase := []UsecaseMethod{
 		{ReceiverType: "*adminRoleUsecase", Method: "Update", EmitsTypedError: true},
@@ -606,13 +731,13 @@ func TestAllowlistRotEntries_StillViolating_NotRotten(t *testing.T) {
 	resolver := ResolverWalkResult{
 		Mappings: []ResolverMapping{
 			{
-				MutationField:   "updateRole",
-				ResolverMethod:  "UpdateRole",
-				UsecaseSelector: "AdminRoleUC",
-				UsecaseMethod:   "Update",
+				MutationField:  "updateRole",
+				ResolverMethod: "UpdateRole",
+				UsecaseCalls: []UsecaseCall{
+					{Selector: "AdminRoleUC", Method: "Update"},
+				},
 			},
 		},
-		AdditionalCalls: map[string][]struct{ Selector, Method string }{},
 	}
 	usecase := []UsecaseMethod{
 		{ReceiverType: "*adminRoleUsecase", Method: "Update", EmitsTypedError: true},
@@ -624,5 +749,107 @@ func TestAllowlistRotEntries_StillViolating_NotRotten(t *testing.T) {
 
 	if len(rotten) != 0 {
 		t.Errorf("expected no rotten entries, got %v", rotten)
+	}
+}
+
+// Test 2: AllowlistRotEntries branch coverage for missing-mutation branch.
+// The allowlist has "oldMutation" but the schema slice does NOT contain it.
+// AllowlistRotEntries must report "oldMutation" as a rot entry with no further
+// context required — the mutation has been removed from the schema entirely.
+func TestAllowlistRotEntries_MutationRemovedFromSchema_IsRotten(t *testing.T) {
+	t.Parallel()
+
+	schema := []MutationReturn{
+		// "oldMutation" is absent; only an unrelated mutation is present.
+		{Field: "keepMe", ReturnType: "Thing!", IsBare: true},
+	}
+	resolver := ResolverWalkResult{
+		Mappings: []ResolverMapping{
+			{
+				MutationField:  "keepMe",
+				ResolverMethod: "KeepMe",
+				UsecaseCalls:   nil,
+			},
+		},
+	}
+	usecase := []UsecaseMethod{}
+	fieldMap := map[string]string{}
+	allowlist := makeAllowlist("oldMutation")
+
+	rotten := AllowlistRotEntries(schema, resolver, usecase, fieldMap, allowlist, noIfaceConfig())
+
+	if len(rotten) != 1 {
+		t.Fatalf("expected 1 rotten entry, got %d: %v", len(rotten), rotten)
+	}
+	if rotten[0] != "oldMutation" {
+		t.Errorf("expected rotten entry %q, got %q", "oldMutation", rotten[0])
+	}
+}
+
+// Test 2: AllowlistRotEntries branch coverage for missing-resolver branch.
+// The allowlist has "mut"; schema has "mut" as a bare return; but the resolver
+// mapping slice contains no method whose camelCase name matches "mut".
+// AllowlistRotEntries must report "mut" as a rot entry.
+func TestAllowlistRotEntries_ResolverMethodRemoved_IsRotten(t *testing.T) {
+	t.Parallel()
+
+	schema := []MutationReturn{
+		{Field: "orphanedMut", ReturnType: "Role!", IsBare: true},
+	}
+	// Resolver has no mapping for "orphanedMut".
+	resolver := ResolverWalkResult{
+		Mappings: []ResolverMapping{},
+	}
+	usecase := []UsecaseMethod{
+		{ReceiverType: "*adminRoleUsecase", Method: "Update", EmitsTypedError: true},
+	}
+	fieldMap := map[string]string{"AdminRoleUC": "adminRoleUsecase"}
+	allowlist := makeAllowlist("orphanedMut")
+
+	rotten := AllowlistRotEntries(schema, resolver, usecase, fieldMap, allowlist, noIfaceConfig())
+
+	if len(rotten) != 1 {
+		t.Fatalf("expected 1 rotten entry, got %d: %v", len(rotten), rotten)
+	}
+	if rotten[0] != "orphanedMut" {
+		t.Errorf("expected rotten entry %q, got %q", "orphanedMut", rotten[0])
+	}
+}
+
+// Test 2: AllowlistRotEntries branch coverage for no-longer-emits branch.
+// The allowlist has "silentMut"; schema has "silentMut" as a bare return;
+// resolver matches; but the usecase method now has EmitsTypedError = false.
+// AllowlistRotEntries must report "silentMut" as a rot entry.
+func TestAllowlistRotEntries_UsecaseNoLongerEmits_IsRotten(t *testing.T) {
+	t.Parallel()
+
+	schema := []MutationReturn{
+		{Field: "silentMut", ReturnType: "Role!", IsBare: true},
+	}
+	resolver := ResolverWalkResult{
+		Mappings: []ResolverMapping{
+			{
+				MutationField:  "silentMut",
+				ResolverMethod: "SilentMut",
+				UsecaseCalls: []UsecaseCall{
+					{Selector: "AdminRoleUC", Method: "Update"},
+				},
+			},
+		},
+	}
+	// Usecase method now has EmitsTypedError = false.
+	usecase := []UsecaseMethod{
+		{ReceiverType: "*adminRoleUsecase", Method: "Update", EmitsTypedError: false},
+	}
+	fieldMap := map[string]string{"AdminRoleUC": "adminRoleUsecase"}
+	allowlist := makeAllowlist("silentMut")
+
+	rotten := AllowlistRotEntries(schema, resolver, usecase, fieldMap, allowlist, noIfaceConfig())
+
+	if len(rotten) != 1 {
+		t.Fatalf("expected 1 rotten entry, got %d: %v", len(rotten), rotten)
+	}
+	if rotten[0] != "silentMut" {
+		t.Errorf("expected rotten entry %q, got %q", "silentMut", rotten[0])
 	}
 }

--- a/backend/cmd/schema-lint/main.go
+++ b/backend/cmd/schema-lint/main.go
@@ -28,13 +28,17 @@ import (
 	"os"
 )
 
-// interfaceToImpl is the hardcoded mapping from resolver-struct interface type
-// names to their concrete implementation type names.
+// interfaceToImpl maps each Resolver field whose type is a usecase
+// interface to the concrete impl type's lowercase identifier (the
+// receiver type used by methods on that impl). For example:
 //
-// Maintenance: when a new interface-based usecase is added to the Resolver
-// struct in backend/graph/resolver/resolver.go, add the corresponding
-// "InterfaceName" -> "implName" entry here. See the README for the
-// full maintenance guide.
+//	"AdminUserUsecase": "adminUserUsecase"
+//
+// The value must be the receiver-type identifier exactly as it appears
+// in the usecase impl files. Maintenance: add an entry for each new
+// interface-typed field added to Resolver.
+//
+// See backend/cmd/schema-lint/README.md § "Maintenance" for guidance.
 var interfaceToImpl = map[string]string{
 	"AdminUserUsecase":           "adminUserUsecase",
 	"AdminRoleUsecase":           "adminRoleUsecase",

--- a/backend/cmd/schema-lint/main.go
+++ b/backend/cmd/schema-lint/main.go
@@ -1,0 +1,146 @@
+// Package main is the schema-lint CLI that enforces the outcome-union pattern
+// for new error-returning GraphQL mutations.
+//
+// Usage (run from backend/):
+//
+//	go run ./cmd/schema-lint [flags]
+//
+// Flags:
+//
+//	-mode={error,warn}        Exit non-zero on violations (default: error).
+//	-schema=path              Path to schema.graphql (default: ../schema/schema.graphql).
+//	-resolver=path            Path to schema.resolvers.go (default: graph/resolver/schema.resolvers.go).
+//	-resolver-struct=path     Path to resolver.go struct file (default: graph/resolver/resolver.go).
+//	-usecase=dir              Path to usecase directory (default: internal/usecase).
+//	-allowlist=path           Path to allowlist.txt (default: cmd/schema-lint/allowlist.txt).
+//
+// Exit codes:
+//
+//	0   No violations and no drifts (or -mode=warn).
+//	1   At least one violation or drift in -mode=error.
+//	2   Walker or configuration error.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+)
+
+// interfaceToImpl is the hardcoded mapping from resolver-struct interface type
+// names to their concrete implementation type names.
+//
+// Maintenance: when a new interface-based usecase is added to the Resolver
+// struct in backend/graph/resolver/resolver.go, add the corresponding
+// "InterfaceName" -> "implName" entry here. See the README for the
+// full maintenance guide.
+var interfaceToImpl = map[string]string{
+	"AdminUserUsecase":           "adminUserUsecase",
+	"AdminRoleUsecase":           "adminRoleUsecase",
+	"DictionaryUsecase":          "dictionaryUsecase",
+	"LastViewedCardgroupUsecase": "lastViewedCardgroupUsecase",
+}
+
+func main() {
+	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr))
+}
+
+// run is the testable entry point. It accepts the CLI args slice and explicit
+// stdout/stderr writers so integration tests can invoke it without exec'ing
+// the binary.
+//
+// Returns the desired exit code (0, 1, or 2).
+func run(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("schema-lint", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+
+	mode := fs.String("mode", "error", "lint mode: 'error' (exit 1 on violations) or 'warn' (print but exit 0)")
+	schemaPath := fs.String("schema", "../schema/schema.graphql", "path to schema.graphql")
+	resolverPath := fs.String("resolver", "graph/resolver/schema.resolvers.go", "path to schema.resolvers.go")
+	resolverStructPath := fs.String("resolver-struct", "graph/resolver/resolver.go", "path to resolver.go struct file")
+	usecaseDir := fs.String("usecase", "internal/usecase", "path to usecase directory")
+	allowlistPath := fs.String("allowlist", "cmd/schema-lint/allowlist.txt", "path to allowlist.txt")
+
+	if err := fs.Parse(args); err != nil {
+		// flag.ContinueOnError already printed the error.
+		return 2
+	}
+
+	if *mode != "error" && *mode != "warn" {
+		fmt.Fprintf(stderr, "schema-lint: -mode must be 'error' or 'warn', got %q\n", *mode)
+		return 2
+	}
+
+	// --- Walk schema ---
+	schemaMutations, err := SchemaWalk([]string{*schemaPath})
+	if err != nil {
+		fmt.Fprintf(stderr, "schema-lint: schema walk failed: %v\n", err)
+		return 2
+	}
+
+	// --- Walk resolver ---
+	resolverResult, err := ResolverWalk(*resolverPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "schema-lint: resolver walk failed: %v\n", err)
+		return 2
+	}
+
+	// --- Walk usecase ---
+	usecaseMethods, err := UsecaseWalk(*usecaseDir)
+	if err != nil {
+		fmt.Fprintf(stderr, "schema-lint: usecase walk failed: %v\n", err)
+		return 2
+	}
+
+	// --- Load resolver field map ---
+	fieldMap, err := LoadResolverFieldMap(*resolverStructPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "schema-lint: resolver struct parse failed: %v\n", err)
+		return 2
+	}
+
+	// --- Load allowlist ---
+	allowlist, err := LoadAllowlist(*allowlistPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "schema-lint: allowlist load failed: %v\n", err)
+		return 2
+	}
+
+	cfg := ClassifierConfig{InterfaceToImpl: interfaceToImpl}
+
+	// --- Allowlist rot check (informational, does not affect exit code) ---
+	rotten := AllowlistRotEntries(schemaMutations, resolverResult, usecaseMethods, fieldMap, allowlist, cfg)
+	for _, entry := range rotten {
+		fmt.Fprintf(stderr, "allowlist-rot: %s is allowlisted but no longer violates; remove the entry\n", entry)
+	}
+
+	// --- Classify ---
+	violations, drifts := Classify(schemaMutations, resolverResult, usecaseMethods, fieldMap, allowlist, cfg)
+
+	// --- Print drifts ---
+	for _, d := range drifts {
+		fmt.Fprintf(stderr, "drift: %s\n", d.Description)
+	}
+
+	// --- Print violations ---
+	for _, v := range violations {
+		fmt.Fprintf(stderr,
+			"violation: %s returns bare '%s' but '%s' emits typed ucerr.* errors; "+
+				"add to allowlist.txt or promote to a *Result union "+
+				"(see docs/backend/error-wrapping/outcome-union-enforcement.md)\n",
+			v.Mutation, v.ReturnType, v.UsecaseTarget,
+		)
+	}
+
+	if *mode == "warn" {
+		return 0
+	}
+
+	// error mode: exit 1 if any violation or drift.
+	if len(violations) > 0 || len(drifts) > 0 {
+		return 1
+	}
+	fmt.Fprintf(stdout, "schema-lint: 0 violations, 0 drifts\n")
+	return 0
+}

--- a/backend/cmd/schema-lint/main_test.go
+++ b/backend/cmd/schema-lint/main_test.go
@@ -1,0 +1,290 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// liveArgsForRun builds the explicit flag slice that points run() at the live
+// working-tree paths. It mirrors liveInputs() from schema_lint_integration_test.go
+// but returns the run() args slice directly.
+func liveArgsForRun(t *testing.T, extraArgs ...string) []string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	// file is .../backend/cmd/schema-lint/main_test.go
+	// Up three levels: schema-lint/ -> cmd/ -> backend/ -> repo root.
+	root := filepath.Clean(filepath.Join(filepath.Dir(file), "..", "..", ".."))
+	backend := filepath.Join(root, "backend")
+
+	args := []string{
+		"-schema=" + filepath.Join(root, "schema", "schema.graphql"),
+		"-resolver=" + filepath.Join(backend, "graph", "resolver", "schema.resolvers.go"),
+		"-resolver-struct=" + filepath.Join(backend, "graph", "resolver", "resolver.go"),
+		"-usecase=" + filepath.Join(backend, "internal", "usecase"),
+		"-allowlist=" + filepath.Join(backend, "cmd", "schema-lint", "allowlist.txt"),
+	}
+	return append(args, extraArgs...)
+}
+
+// syntheticFixtures writes the minimal set of files needed for one violation
+// into dir and returns the paths expected by run().
+//
+// Schema: bareRole mutation returns Role! (bare object → IsBare=true).
+// Resolver: calls r.RoleUC.Manage(...).
+// Resolver struct: RoleUC field typed as *roleUsecase.
+// Usecase: Manage method emits ucerr.NewValidationError → EmitsTypedError=true.
+// Allowlist: empty.
+//
+// This combination produces exactly one violation in -mode=error.
+func syntheticFixtures(t *testing.T, dir string) (schemaPath, resolverPath, resolverStructPath, usecaseDir, allowlistPath string) {
+	t.Helper()
+
+	// schema.graphql — bare return type
+	schemaContent := `type Query { health: String! }
+type Role { id: ID! name: String! }
+type Mutation { bareRole(id: ID!): Role! }
+`
+	schemaPath = filepath.Join(dir, "schema.graphql")
+	if err := os.WriteFile(schemaPath, []byte(schemaContent), 0o644); err != nil {
+		t.Fatalf("write schema: %v", err)
+	}
+
+	// schema.resolvers.go — three-segment usecase call r.RoleUC.Manage(...)
+	resolverContent := `package resolver
+import "context"
+type mutationResolver struct { RoleUC roleUsecaseIface }
+type roleUsecaseIface interface { Manage(ctx context.Context, id string) (interface{}, error) }
+func (r *mutationResolver) BareRole(ctx context.Context, id string) (interface{}, error) {
+	return r.RoleUC.Manage(ctx, id)
+}
+`
+	resolverPath = filepath.Join(dir, "schema.resolvers.go")
+	if err := os.WriteFile(resolverPath, []byte(resolverContent), 0o644); err != nil {
+		t.Fatalf("write resolver: %v", err)
+	}
+
+	// resolver.go — Resolver struct with RoleUC field
+	resolverStructContent := `package resolver
+type Resolver struct { RoleUC *roleUsecase }
+`
+	resolverStructPath = filepath.Join(dir, "resolver.go")
+	if err := os.WriteFile(resolverStructPath, []byte(resolverStructContent), 0o644); err != nil {
+		t.Fatalf("write resolver struct: %v", err)
+	}
+
+	// usecase dir with one .go file
+	usecaseDir = filepath.Join(dir, "usecase")
+	if err := os.MkdirAll(usecaseDir, 0o755); err != nil {
+		t.Fatalf("mkdir usecase: %v", err)
+	}
+	usecaseContent := `package usecase
+import (
+	"context"
+	"backend/internal/usecase/ucerr"
+)
+type roleUsecase struct{}
+func (u *roleUsecase) Manage(ctx context.Context, id string) (interface{}, error) {
+	if id == "" { return nil, ucerr.NewValidationError("id", "required") }
+	return nil, nil
+}
+`
+	if err := os.WriteFile(filepath.Join(usecaseDir, "role.go"), []byte(usecaseContent), 0o644); err != nil {
+		t.Fatalf("write usecase: %v", err)
+	}
+
+	// empty allowlist
+	allowlistPath = filepath.Join(dir, "allowlist.txt")
+	if err := os.WriteFile(allowlistPath, []byte(""), 0o644); err != nil {
+		t.Fatalf("write allowlist: %v", err)
+	}
+
+	return
+}
+
+// buildSyntheticArgs assembles the -flag=value slice for run() from synthetic fixture paths.
+func buildSyntheticArgs(mode, schemaPath, resolverPath, resolverStructPath, usecaseDir, allowlistPath string) []string {
+	return []string{
+		"-mode=" + mode,
+		"-schema=" + schemaPath,
+		"-resolver=" + resolverPath,
+		"-resolver-struct=" + resolverStructPath,
+		"-usecase=" + usecaseDir,
+		"-allowlist=" + allowlistPath,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: run() orchestrator tests
+// ---------------------------------------------------------------------------
+
+// TestRun_DefaultFlags_LiveTree_ExitsZero calls run with explicit live-tree
+// paths (mirroring the defaults but resolved to absolute paths so the test
+// binary's working directory does not matter). The live tree is lint-clean, so
+// the exit code must be 0 and stdout must contain "0 violations, 0 drifts".
+func TestRun_DefaultFlags_LiveTree_ExitsZero(t *testing.T) {
+	// Not parallel: reads the live working tree; no mutation.
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	args := liveArgsForRun(t)
+	code := run(args, stdout, stderr)
+	if code != 0 {
+		t.Fatalf("run with live-tree flags: want exit 0, got %d\nstdout: %s\nstderr: %s",
+			code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "0 violations, 0 drifts") {
+		t.Errorf("stdout does not contain '0 violations, 0 drifts':\n%s", stdout.String())
+	}
+}
+
+// TestRun_WarnMode_SyntheticViolation_ExitsZero verifies that -mode=warn
+// exits 0 even when there is one violation, and that the violation is printed
+// to stderr with the "violation:" prefix.
+func TestRun_WarnMode_SyntheticViolation_ExitsZero(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	schemaPath, resolverPath, resolverStructPath, usecaseDir, allowlistPath := syntheticFixtures(t, dir)
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	args := buildSyntheticArgs("warn", schemaPath, resolverPath, resolverStructPath, usecaseDir, allowlistPath)
+	code := run(args, stdout, stderr)
+
+	if code != 0 {
+		t.Fatalf("run -mode=warn with violation: want exit 0, got %d\nstdout: %s\nstderr: %s",
+			code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "violation:") {
+		t.Errorf("stderr does not contain 'violation:' prefix:\n%s", stderr.String())
+	}
+}
+
+// TestRun_ErrorMode_SyntheticViolation_ExitsOne verifies that -mode=error
+// exits 1 when there is at least one violation.
+func TestRun_ErrorMode_SyntheticViolation_ExitsOne(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	schemaPath, resolverPath, resolverStructPath, usecaseDir, allowlistPath := syntheticFixtures(t, dir)
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	args := buildSyntheticArgs("error", schemaPath, resolverPath, resolverStructPath, usecaseDir, allowlistPath)
+	code := run(args, stdout, stderr)
+
+	if code != 1 {
+		t.Fatalf("run -mode=error with violation: want exit 1, got %d\nstdout: %s\nstderr: %s",
+			code, stdout.String(), stderr.String())
+	}
+}
+
+// TestRun_BadFlag_ExitsTwo verifies that an unknown flag produces exit code 2.
+func TestRun_BadFlag_ExitsTwo(t *testing.T) {
+	t.Parallel()
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	code := run([]string{"-not-a-real-flag"}, stdout, stderr)
+	if code != 2 {
+		t.Fatalf("run with bad flag: want exit 2, got %d\nstderr: %s", code, stderr.String())
+	}
+}
+
+// TestRun_MissingSchemaFile_ExitsTwo verifies that pointing -schema= at a
+// non-existent path produces exit code 2 and an error message on stderr.
+func TestRun_MissingSchemaFile_ExitsTwo(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	nonExistent := filepath.Join(dir, "no-such-schema.graphql")
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	code := run([]string{"-schema=" + nonExistent}, stdout, stderr)
+	if code != 2 {
+		t.Fatalf("run with missing schema: want exit 2, got %d\nstderr: %s", code, stderr.String())
+	}
+	if stderr.Len() == 0 {
+		t.Error("expected non-empty stderr on missing schema file")
+	}
+}
+
+// TestRun_DriftOnly_ErrorMode_ExitsOne verifies that a mutation present in the
+// schema but with no corresponding resolver method (drift only, no violation)
+// still produces exit code 1 in -mode=error. This confirms that drift alone is
+// sufficient to fail CI.
+func TestRun_DriftOnly_ErrorMode_ExitsOne(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	// Schema declares "ghostMutation"; resolver has no such method.
+	schemaContent := `type Query { health: String! }
+type Ghost { id: ID! }
+type Mutation { ghostMutation(id: ID!): Ghost! }
+`
+	schemaPath := filepath.Join(dir, "schema.graphql")
+	if err := os.WriteFile(schemaPath, []byte(schemaContent), 0o644); err != nil {
+		t.Fatalf("write schema: %v", err)
+	}
+
+	// Resolver file that declares a mutationResolver with no methods at all.
+	resolverContent := `package resolver
+type mutationResolver struct{}
+`
+	resolverPath := filepath.Join(dir, "schema.resolvers.go")
+	if err := os.WriteFile(resolverPath, []byte(resolverContent), 0o644); err != nil {
+		t.Fatalf("write resolver: %v", err)
+	}
+
+	resolverStructContent := `package resolver
+type Resolver struct{}
+`
+	resolverStructPath := filepath.Join(dir, "resolver.go")
+	if err := os.WriteFile(resolverStructPath, []byte(resolverStructContent), 0o644); err != nil {
+		t.Fatalf("write resolver struct: %v", err)
+	}
+
+	usecaseDir := filepath.Join(dir, "usecase")
+	if err := os.MkdirAll(usecaseDir, 0o755); err != nil {
+		t.Fatalf("mkdir usecase: %v", err)
+	}
+	usecaseContent := `package usecase
+type stubUsecase struct{}
+func (u *stubUsecase) Noop() {}
+`
+	if err := os.WriteFile(filepath.Join(usecaseDir, "stub.go"), []byte(usecaseContent), 0o644); err != nil {
+		t.Fatalf("write usecase: %v", err)
+	}
+
+	allowlistPath := filepath.Join(dir, "allowlist.txt")
+	if err := os.WriteFile(allowlistPath, []byte(""), 0o644); err != nil {
+		t.Fatalf("write allowlist: %v", err)
+	}
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	args := buildSyntheticArgs("error", schemaPath, resolverPath, resolverStructPath, usecaseDir, allowlistPath)
+	code := run(args, stdout, stderr)
+
+	if code != 1 {
+		t.Fatalf("drift-only run -mode=error: want exit 1, got %d\nstdout: %s\nstderr: %s",
+			code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "drift:") {
+		t.Errorf("stderr does not contain 'drift:' prefix:\n%s", stderr.String())
+	}
+}

--- a/backend/cmd/schema-lint/main_test.go
+++ b/backend/cmd/schema-lint/main_test.go
@@ -284,7 +284,11 @@ func (u *stubUsecase) Noop() {}
 		t.Fatalf("drift-only run -mode=error: want exit 1, got %d\nstdout: %s\nstderr: %s",
 			code, stdout.String(), stderr.String())
 	}
-	if !strings.Contains(stderr.String(), "drift:") {
-		t.Errorf("stderr does not contain 'drift:' prefix:\n%s", stderr.String())
+	stderrStr := stderr.String()
+	if strings.Contains(stderrStr, "violation:") {
+		t.Errorf("expected drift-only stderr without 'violation:' prefix, got: %s", stderrStr)
+	}
+	if !strings.Contains(stderrStr, "drift:") {
+		t.Errorf("expected drift-only stderr to contain 'drift:' prefix, got: %s", stderrStr)
 	}
 }

--- a/backend/cmd/schema-lint/resolverwalk.go
+++ b/backend/cmd/schema-lint/resolverwalk.go
@@ -10,37 +10,32 @@ import (
 	"github.com/rotisserie/eris"
 )
 
-// ResolverMapping maps a single GraphQL mutation field to the usecase call
-// made in its resolver method.
+// UsecaseCall captures a single r.<Selector>.<Method>(...) call expression
+// inside a resolver method body.
+type UsecaseCall struct {
+	// Selector is the field name on the resolver struct, e.g. "AdminRoleUC".
+	Selector string
+	// Method is the method invoked on the usecase, e.g. "Update".
+	Method string
+}
+
+// ResolverMapping maps a single GraphQL mutation field to the usecase
+// call(s) made in its resolver method.
 type ResolverMapping struct {
 	// MutationField is the camelCase GraphQL field name, e.g. "updateRole".
 	MutationField string
 	// ResolverMethod is the PascalCase method name on *mutationResolver, e.g. "UpdateRole".
 	ResolverMethod string
-	// UsecaseSelector is the field name on the resolver struct, e.g. "AdminRoleUC".
-	// Empty when no usecase call was found in the method body.
-	UsecaseSelector string
-	// UsecaseMethod is the method invoked on the usecase, e.g. "Update".
-	// Empty when no usecase call was found in the method body.
-	UsecaseMethod string
-}
-
-// usecaseCall captures a single r.<Selector>.<Method> call expression.
-type usecaseCall struct {
-	Selector string
-	Method   string
+	// UsecaseCalls is every r.<Selector>.<Method>(...) call found in the
+	// resolver method body, in source order. len(UsecaseCalls) == 0 when the
+	// resolver method makes no usecase call at all.
+	UsecaseCalls []UsecaseCall
 }
 
 // ResolverWalkResult holds all mappings extracted from the resolver file.
 type ResolverWalkResult struct {
 	// Mappings contains one ResolverMapping per method on *mutationResolver.
-	// When a method has multiple usecase calls, the first call is reflected
-	// here; the rest appear in AdditionalCalls.
 	Mappings []ResolverMapping
-
-	// AdditionalCalls maps a ResolverMethod name to any usecase calls beyond
-	// the first. Only populated for methods with two or more calls.
-	AdditionalCalls map[string][]struct{ Selector, Method string }
 }
 
 // ResolverWalk parses the Go source file at resolverPath and extracts every
@@ -53,9 +48,7 @@ func ResolverWalk(resolverPath string) (ResolverWalkResult, error) {
 		return ResolverWalkResult{}, eris.Wrapf(err, "resolverwalk: parse %s", resolverPath)
 	}
 
-	result := ResolverWalkResult{
-		AdditionalCalls: make(map[string][]struct{ Selector, Method string }),
-	}
+	var result ResolverWalkResult
 
 	for _, decl := range f.Decls {
 		fn, ok := decl.(*ast.FuncDecl)
@@ -69,22 +62,10 @@ func ResolverWalk(resolverPath string) (ResolverWalkResult, error) {
 		}
 
 		methodName := fn.Name.Name
-		calls := collectUsecaseCalls(fn.Body, recvName)
-
 		mapping := ResolverMapping{
 			MutationField:  toCamelCase(methodName),
 			ResolverMethod: methodName,
-		}
-		if len(calls) >= 1 {
-			mapping.UsecaseSelector = calls[0].Selector
-			mapping.UsecaseMethod = calls[0].Method
-		}
-		if len(calls) > 1 {
-			extra := make([]struct{ Selector, Method string }, 0, len(calls)-1)
-			for _, c := range calls[1:] {
-				extra = append(extra, struct{ Selector, Method string }{c.Selector, c.Method})
-			}
-			result.AdditionalCalls[methodName] = extra
+			UsecaseCalls:   collectUsecaseCalls(fn.Body, recvName),
 		}
 
 		result.Mappings = append(result.Mappings, mapping)
@@ -111,12 +92,13 @@ func extractReceiver(field *ast.Field) (varName, typeName string) {
 }
 
 // collectUsecaseCalls walks the function body and returns every call of the
-// form <recv>.<Selector>.<Method>(...), in source order.
-func collectUsecaseCalls(body *ast.BlockStmt, recvVarName string) []usecaseCall {
+// form <recv>.<Selector>.<Method>(...), in source order. Returns nil when the
+// body has no such call (so an empty slice is preserved as nil for cmp.Diff).
+func collectUsecaseCalls(body *ast.BlockStmt, recvVarName string) []UsecaseCall {
 	if body == nil {
 		return nil
 	}
-	var calls []usecaseCall
+	var calls []UsecaseCall
 	ast.Inspect(body, func(n ast.Node) bool {
 		call, ok := n.(*ast.CallExpr)
 		if !ok {
@@ -140,7 +122,7 @@ func collectUsecaseCalls(body *ast.BlockStmt, recvVarName string) []usecaseCall 
 		if !ok || recvIdent.Name != recvVarName {
 			return true
 		}
-		calls = append(calls, usecaseCall{
+		calls = append(calls, UsecaseCall{
 			Selector: inner.Sel.Name,
 			Method:   outer.Sel.Name,
 		})

--- a/backend/cmd/schema-lint/resolverwalk.go
+++ b/backend/cmd/schema-lint/resolverwalk.go
@@ -1,0 +1,163 @@
+package main
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/rotisserie/eris"
+)
+
+// ResolverMapping maps a single GraphQL mutation field to the usecase call
+// made in its resolver method.
+type ResolverMapping struct {
+	// MutationField is the camelCase GraphQL field name, e.g. "updateRole".
+	MutationField string
+	// ResolverMethod is the PascalCase method name on *mutationResolver, e.g. "UpdateRole".
+	ResolverMethod string
+	// UsecaseSelector is the field name on the resolver struct, e.g. "AdminRoleUC".
+	// Empty when no usecase call was found in the method body.
+	UsecaseSelector string
+	// UsecaseMethod is the method invoked on the usecase, e.g. "Update".
+	// Empty when no usecase call was found in the method body.
+	UsecaseMethod string
+}
+
+// usecaseCall captures a single r.<Selector>.<Method> call expression.
+type usecaseCall struct {
+	Selector string
+	Method   string
+}
+
+// ResolverWalkResult holds all mappings extracted from the resolver file.
+type ResolverWalkResult struct {
+	// Mappings contains one ResolverMapping per method on *mutationResolver.
+	// When a method has multiple usecase calls, the first call is reflected
+	// here; the rest appear in AdditionalCalls.
+	Mappings []ResolverMapping
+
+	// AdditionalCalls maps a ResolverMethod name to any usecase calls beyond
+	// the first. Only populated for methods with two or more calls.
+	AdditionalCalls map[string][]struct{ Selector, Method string }
+}
+
+// ResolverWalk parses the Go source file at resolverPath and extracts every
+// method on *mutationResolver (or mutationResolver) together with the
+// usecase call(s) found in its body.
+func ResolverWalk(resolverPath string) (ResolverWalkResult, error) {
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, resolverPath, nil, 0)
+	if err != nil {
+		return ResolverWalkResult{}, eris.Wrapf(err, "resolverwalk: parse %s", resolverPath)
+	}
+
+	result := ResolverWalkResult{
+		AdditionalCalls: make(map[string][]struct{ Selector, Method string }),
+	}
+
+	for _, decl := range f.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Recv == nil || len(fn.Recv.List) == 0 {
+			continue
+		}
+
+		recvName, recvType := extractReceiver(fn.Recv.List[0])
+		if recvType != "mutationResolver" {
+			continue
+		}
+
+		methodName := fn.Name.Name
+		calls := collectUsecaseCalls(fn.Body, recvName)
+
+		mapping := ResolverMapping{
+			MutationField:  toCamelCase(methodName),
+			ResolverMethod: methodName,
+		}
+		if len(calls) >= 1 {
+			mapping.UsecaseSelector = calls[0].Selector
+			mapping.UsecaseMethod = calls[0].Method
+		}
+		if len(calls) > 1 {
+			extra := make([]struct{ Selector, Method string }, 0, len(calls)-1)
+			for _, c := range calls[1:] {
+				extra = append(extra, struct{ Selector, Method string }{c.Selector, c.Method})
+			}
+			result.AdditionalCalls[methodName] = extra
+		}
+
+		result.Mappings = append(result.Mappings, mapping)
+	}
+
+	return result, nil
+}
+
+// extractReceiver returns the receiver variable name and the receiver type
+// name (with any pointer star stripped) from a receiver field.
+func extractReceiver(field *ast.Field) (varName, typeName string) {
+	if len(field.Names) > 0 {
+		varName = field.Names[0].Name
+	}
+	switch t := field.Type.(type) {
+	case *ast.StarExpr:
+		if ident, ok := t.X.(*ast.Ident); ok {
+			typeName = ident.Name
+		}
+	case *ast.Ident:
+		typeName = t.Name
+	}
+	return
+}
+
+// collectUsecaseCalls walks the function body and returns every call of the
+// form <recv>.<Selector>.<Method>(...), in source order.
+func collectUsecaseCalls(body *ast.BlockStmt, recvVarName string) []usecaseCall {
+	if body == nil {
+		return nil
+	}
+	var calls []usecaseCall
+	ast.Inspect(body, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		// We are looking for <recv>.<Selector>.<Method>(...)
+		// which parses as:
+		//   CallExpr.Fun = SelectorExpr{
+		//     X:   SelectorExpr{ X: Ident(recv), Sel: Ident(Selector) },
+		//     Sel: Ident(Method),
+		//   }
+		outer, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		inner, ok := outer.X.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		recvIdent, ok := inner.X.(*ast.Ident)
+		if !ok || recvIdent.Name != recvVarName {
+			return true
+		}
+		calls = append(calls, usecaseCall{
+			Selector: inner.Sel.Name,
+			Method:   outer.Sel.Name,
+		})
+		return true
+	})
+	return calls
+}
+
+// toCamelCase lowercases the first Unicode rune of s, leaving the rest intact.
+// "UpdateRole" → "updateRole", "HandleSwipe" → "handleSwipe".
+func toCamelCase(s string) string {
+	if s == "" {
+		return s
+	}
+	r, size := utf8.DecodeRuneInString(s)
+	if r == utf8.RuneError {
+		return s
+	}
+	return string(unicode.ToLower(r)) + s[size:]
+}

--- a/backend/cmd/schema-lint/resolverwalk_test.go
+++ b/backend/cmd/schema-lint/resolverwalk_test.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestResolverWalk(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		file           string
+		wantMappings   []ResolverMapping
+		wantAdditional map[string][]struct{ Selector, Method string }
+		wantErr        bool
+	}{
+		{
+			name: "single usecase call extracted correctly",
+			file: filepath.Join("testdata", "resolverwalk", "one-call.go"),
+			wantMappings: []ResolverMapping{
+				{
+					MutationField:   "updateRole",
+					ResolverMethod:  "UpdateRole",
+					UsecaseSelector: "AdminRoleUC",
+					UsecaseMethod:   "Update",
+				},
+			},
+			wantAdditional: map[string][]struct{ Selector, Method string }{},
+		},
+		{
+			name: "method with no usecase call yields empty selector and method",
+			file: filepath.Join("testdata", "resolverwalk", "no-call.go"),
+			wantMappings: []ResolverMapping{
+				{
+					MutationField:   "deleteRole",
+					ResolverMethod:  "DeleteRole",
+					UsecaseSelector: "",
+					UsecaseMethod:   "",
+				},
+			},
+			wantAdditional: map[string][]struct{ Selector, Method string }{},
+		},
+		{
+			name: "method with multiple calls puts first in mapping and rest in AdditionalCalls",
+			file: filepath.Join("testdata", "resolverwalk", "multi-call.go"),
+			wantMappings: []ResolverMapping{
+				{
+					MutationField:   "handleSwipe",
+					ResolverMethod:  "HandleSwipe",
+					UsecaseSelector: "CardgroupUC",
+					UsecaseMethod:   "Get",
+				},
+			},
+			wantAdditional: map[string][]struct{ Selector, Method string }{
+				"HandleSwipe": {
+					{Selector: "CardUC", Method: "Create"},
+				},
+			},
+		},
+		{
+			name:    "non-existent file returns error",
+			file:    filepath.Join("testdata", "resolverwalk", "does-not-exist.go"),
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := ResolverWalk(tc.file)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("ResolverWalk: expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ResolverWalk: unexpected error: %v", err)
+			}
+			if diff := cmp.Diff(tc.wantMappings, got.Mappings); diff != "" {
+				t.Errorf("ResolverWalk Mappings mismatch (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(tc.wantAdditional, got.AdditionalCalls); diff != "" {
+				t.Errorf("ResolverWalk AdditionalCalls mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestToCamelCase(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"UpdateRole", "updateRole"},
+		{"HandleSwipe", "handleSwipe"},
+		{"CreateCard", "createCard"},
+		{"AdminUpdateUser", "adminUpdateUser"},
+		{"SetLastViewedCardgroup", "setLastViewedCardgroup"},
+		{"", ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			t.Parallel()
+			got := toCamelCase(tc.input)
+			if got != tc.want {
+				t.Errorf("toCamelCase(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}

--- a/backend/cmd/schema-lint/resolverwalk_test.go
+++ b/backend/cmd/schema-lint/resolverwalk_test.go
@@ -11,52 +11,46 @@ func TestResolverWalk(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name           string
-		file           string
-		wantMappings   []ResolverMapping
-		wantAdditional map[string][]struct{ Selector, Method string }
-		wantErr        bool
+		name         string
+		file         string
+		wantMappings []ResolverMapping
+		wantErr      bool
 	}{
 		{
 			name: "single usecase call extracted correctly",
 			file: filepath.Join("testdata", "resolverwalk", "one-call.go"),
 			wantMappings: []ResolverMapping{
 				{
-					MutationField:   "updateRole",
-					ResolverMethod:  "UpdateRole",
-					UsecaseSelector: "AdminRoleUC",
-					UsecaseMethod:   "Update",
+					MutationField:  "updateRole",
+					ResolverMethod: "UpdateRole",
+					UsecaseCalls: []UsecaseCall{
+						{Selector: "AdminRoleUC", Method: "Update"},
+					},
 				},
 			},
-			wantAdditional: map[string][]struct{ Selector, Method string }{},
 		},
 		{
-			name: "method with no usecase call yields empty selector and method",
+			name: "method with no usecase call yields empty UsecaseCalls",
 			file: filepath.Join("testdata", "resolverwalk", "no-call.go"),
 			wantMappings: []ResolverMapping{
 				{
-					MutationField:   "deleteRole",
-					ResolverMethod:  "DeleteRole",
-					UsecaseSelector: "",
-					UsecaseMethod:   "",
+					MutationField:  "deleteRole",
+					ResolverMethod: "DeleteRole",
+					UsecaseCalls:   nil,
 				},
 			},
-			wantAdditional: map[string][]struct{ Selector, Method string }{},
 		},
 		{
-			name: "method with multiple calls puts first in mapping and rest in AdditionalCalls",
+			name: "method with multiple calls captures every call in source order",
 			file: filepath.Join("testdata", "resolverwalk", "multi-call.go"),
 			wantMappings: []ResolverMapping{
 				{
-					MutationField:   "handleSwipe",
-					ResolverMethod:  "HandleSwipe",
-					UsecaseSelector: "CardgroupUC",
-					UsecaseMethod:   "Get",
-				},
-			},
-			wantAdditional: map[string][]struct{ Selector, Method string }{
-				"HandleSwipe": {
-					{Selector: "CardUC", Method: "Create"},
+					MutationField:  "handleSwipe",
+					ResolverMethod: "HandleSwipe",
+					UsecaseCalls: []UsecaseCall{
+						{Selector: "CardgroupUC", Method: "Get"},
+						{Selector: "CardUC", Method: "Create"},
+					},
 				},
 			},
 		},
@@ -64,6 +58,20 @@ func TestResolverWalk(t *testing.T) {
 			name:    "non-existent file returns error",
 			file:    filepath.Join("testdata", "resolverwalk", "does-not-exist.go"),
 			wantErr: true,
+		},
+		// Test 5 (negative case): chains that are NOT three segments must NOT
+		// appear in UsecaseCalls. The fixture has two-segment and four-segment
+		// call chains; neither matches the r.<Selector>.<Method>() form.
+		{
+			name: "non-three-segment chains produce empty UsecaseCalls",
+			file: filepath.Join("testdata", "resolverwalk", "non-three-segment.go"),
+			wantMappings: []ResolverMapping{
+				{
+					MutationField:  "fakeMutation",
+					ResolverMethod: "FakeMutation",
+					UsecaseCalls:   nil,
+				},
+			},
 		},
 	}
 
@@ -82,9 +90,6 @@ func TestResolverWalk(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.wantMappings, got.Mappings); diff != "" {
 				t.Errorf("ResolverWalk Mappings mismatch (-want +got):\n%s", diff)
-			}
-			if diff := cmp.Diff(tc.wantAdditional, got.AdditionalCalls); diff != "" {
-				t.Errorf("ResolverWalk AdditionalCalls mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/backend/cmd/schema-lint/schema_lint_integration_test.go
+++ b/backend/cmd/schema-lint/schema_lint_integration_test.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// repoRoot walks up from the directory of this source file to find the
+// repository root (the directory that contains go.mod for the backend module).
+// It uses runtime.Caller so the path is evaluated at compile time relative
+// to the source file, which is reliable regardless of the working directory
+// the test binary is run from.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	// file is .../backend/cmd/schema-lint/schema_lint_integration_test.go
+	// Go up three levels: schema-lint/ -> cmd/ -> backend/ -> repo root
+	root := filepath.Join(filepath.Dir(file), "..", "..", "..")
+	root = filepath.Clean(root)
+	// Sanity check: schema/schema.graphql should exist at the root.
+	if _, err := os.Stat(filepath.Join(root, "schema", "schema.graphql")); err != nil {
+		t.Fatalf("repoRoot: schema/schema.graphql not found under %s: %v", root, err)
+	}
+	return root
+}
+
+// liveInputs resolves the canonical live-tree paths for all walkers.
+func liveInputs(t *testing.T) (schemaPath, resolverPath, resolverStructPath, usecaseDir, allowlistPath string) {
+	t.Helper()
+	root := repoRoot(t)
+	backend := filepath.Join(root, "backend")
+	schemaPath = filepath.Join(root, "schema", "schema.graphql")
+	resolverPath = filepath.Join(backend, "graph", "resolver", "schema.resolvers.go")
+	resolverStructPath = filepath.Join(backend, "graph", "resolver", "resolver.go")
+	usecaseDir = filepath.Join(backend, "internal", "usecase")
+	allowlistPath = filepath.Join(backend, "cmd", "schema-lint", "allowlist.txt")
+	return
+}
+
+// runLivePipeline runs all walkers + classifier against the live tree and
+// returns violations, drifts, and the loaded allowlist (or a fatal).
+func runLivePipeline(t *testing.T, al Allowlist) ([]Violation, []Drift) {
+	t.Helper()
+	schemaPath, resolverPath, resolverStructPath, usecaseDir, _ := liveInputs(t)
+
+	schemaMutations, err := SchemaWalk([]string{schemaPath})
+	if err != nil {
+		t.Fatalf("SchemaWalk: %v", err)
+	}
+	resolverResult, err := ResolverWalk(resolverPath)
+	if err != nil {
+		t.Fatalf("ResolverWalk: %v", err)
+	}
+	usecaseMethods, err := UsecaseWalk(usecaseDir)
+	if err != nil {
+		t.Fatalf("UsecaseWalk: %v", err)
+	}
+	fieldMap, err := LoadResolverFieldMap(resolverStructPath)
+	if err != nil {
+		t.Fatalf("LoadResolverFieldMap: %v", err)
+	}
+
+	cfg := ClassifierConfig{InterfaceToImpl: interfaceToImpl}
+	return Classify(schemaMutations, resolverResult, usecaseMethods, fieldMap, al, cfg)
+}
+
+// TestIntegration_LiveTree_NoViolations asserts that the full lint pipeline
+// reports zero violations and zero drifts against the current working tree
+// when the production allowlist is applied.
+func TestIntegration_LiveTree_NoViolations(t *testing.T) {
+	_, _, _, _, allowlistPath := liveInputs(t)
+
+	al, err := LoadAllowlist(allowlistPath)
+	if err != nil {
+		t.Fatalf("LoadAllowlist: %v", err)
+	}
+
+	violations, drifts := runLivePipeline(t, al)
+
+	if diff := cmp.Diff([]Violation(nil), violations); diff != "" {
+		t.Errorf("unexpected violations (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff([]Drift(nil), drifts); diff != "" {
+		t.Errorf("unexpected drifts (-want +got):\n%s", diff)
+	}
+}
+
+// TestIntegration_AllowlistReleaseValve confirms that removing a known
+// bare-emit entry from the allowlist causes the classifier to report a
+// violation for that mutation. The test operates on an in-memory copy of the
+// allowlist, leaving the on-disk file untouched.
+func TestIntegration_AllowlistReleaseValve(t *testing.T) {
+	_, _, _, _, allowlistPath := liveInputs(t)
+
+	al, err := LoadAllowlist(allowlistPath)
+	if err != nil {
+		t.Fatalf("LoadAllowlist: %v", err)
+	}
+
+	// "updateProfile" is a known bare-emit mutation frozen in the allowlist.
+	// Remove it from the in-memory copy to simulate a line deletion.
+	const targetMutation = "updateProfile"
+	if _, present := al[targetMutation]; !present {
+		t.Fatalf("test precondition failed: %q not found in allowlist; update the test if the mutation was promoted", targetMutation)
+	}
+	delete(al, targetMutation)
+
+	violations, _ := runLivePipeline(t, al)
+
+	found := false
+	for _, v := range violations {
+		if v.Mutation == targetMutation {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected a violation for %q after removing it from the allowlist, but none was reported; violations: %v", targetMutation, violations)
+	}
+}
+
+// TestIntegration_UpdateRole_NotInAllowlist_NotViolation verifies that the
+// pilot promotion (updateRole -> UpdateRoleResult) is reflected correctly:
+//   - "updateRole" must NOT appear in the on-disk allowlist.
+//   - Running the classifier with the production allowlist must NOT produce a
+//     violation for "updateRole" (because its return type is now a union).
+func TestIntegration_UpdateRole_NotInAllowlist_NotViolation(t *testing.T) {
+	_, _, _, _, allowlistPath := liveInputs(t)
+
+	al, err := LoadAllowlist(allowlistPath)
+	if err != nil {
+		t.Fatalf("LoadAllowlist: %v", err)
+	}
+
+	// updateRole must not be in the allowlist.
+	if _, present := al["updateRole"]; present {
+		t.Error("updateRole is in the allowlist but should have been promoted; remove it from allowlist.txt")
+	}
+
+	violations, _ := runLivePipeline(t, al)
+
+	for _, v := range violations {
+		if v.Mutation == "updateRole" {
+			t.Errorf("unexpected violation for updateRole: %+v (pilot promotion should have eliminated the bare return type)", v)
+		}
+	}
+}

--- a/backend/cmd/schema-lint/schema_lint_integration_test.go
+++ b/backend/cmd/schema-lint/schema_lint_integration_test.go
@@ -126,6 +126,43 @@ func TestIntegration_AllowlistReleaseValve(t *testing.T) {
 	}
 }
 
+// TestIntegration_LiveTree_NoAllowlistRot is a tripwire that asserts every
+// entry in the on-disk allowlist still corresponds to a bare-emit mutation in
+// the live tree. A future PR that promotes a mutation without removing the
+// allowlist entry will fail this test.
+func TestIntegration_LiveTree_NoAllowlistRot(t *testing.T) {
+	schemaPath, resolverPath, resolverStructPath, usecaseDir, allowlistPath := liveInputs(t)
+
+	al, err := LoadAllowlist(allowlistPath)
+	if err != nil {
+		t.Fatalf("LoadAllowlist: %v", err)
+	}
+
+	schemaMutations, err := SchemaWalk([]string{schemaPath})
+	if err != nil {
+		t.Fatalf("SchemaWalk: %v", err)
+	}
+	resolverResult, err := ResolverWalk(resolverPath)
+	if err != nil {
+		t.Fatalf("ResolverWalk: %v", err)
+	}
+	usecaseMethods, err := UsecaseWalk(usecaseDir)
+	if err != nil {
+		t.Fatalf("UsecaseWalk: %v", err)
+	}
+	fieldMap, err := LoadResolverFieldMap(resolverStructPath)
+	if err != nil {
+		t.Fatalf("LoadResolverFieldMap: %v", err)
+	}
+
+	cfg := ClassifierConfig{InterfaceToImpl: interfaceToImpl}
+	rotten := AllowlistRotEntries(schemaMutations, resolverResult, usecaseMethods, fieldMap, al, cfg)
+
+	if len(rotten) != 0 {
+		t.Errorf("allowlist rot detected; remove these stale entries from allowlist.txt: %v", rotten)
+	}
+}
+
 // TestIntegration_UpdateRole_NotInAllowlist_NotViolation verifies that the
 // pilot promotion (updateRole -> UpdateRoleResult) is reflected correctly:
 //   - "updateRole" must NOT appear in the on-disk allowlist.

--- a/backend/cmd/schema-lint/schemawalk.go
+++ b/backend/cmd/schema-lint/schemawalk.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"os"
+
+	"github.com/rotisserie/eris"
+	"github.com/vektah/gqlparser/v2"
+	"github.com/vektah/gqlparser/v2/ast"
+)
+
+// MutationReturn describes the return type of a single mutation field.
+type MutationReturn struct {
+	// Field is the camelCase GraphQL mutation field name, e.g. "updateRole".
+	Field string
+	// ReturnType is the full GraphQL type signature, e.g. "Role!", "[Card!]!".
+	ReturnType string
+	// IsBare is true when the underlying named type is an Object or Interface.
+	// Unions, scalars, enums, and list-wrapped types set IsBare = false.
+	IsBare bool
+}
+
+// SchemaWalk parses one or more GraphQL SDL files and returns one MutationReturn
+// per mutation field found on the Mutation type (including extend blocks).
+// If no Mutation type is defined, it returns an empty slice with no error.
+func SchemaWalk(schemaPaths []string) ([]MutationReturn, error) {
+	sources := make([]*ast.Source, 0, len(schemaPaths))
+	for _, p := range schemaPaths {
+		raw, err := os.ReadFile(p)
+		if err != nil {
+			return nil, eris.Wrapf(err, "schemawalk: read %s", p)
+		}
+		sources = append(sources, &ast.Source{Name: p, Input: string(raw)})
+	}
+
+	schema, err := gqlparser.LoadSchema(sources...)
+	if err != nil {
+		return nil, eris.Wrap(err, "schemawalk: parse schema")
+	}
+
+	mutation := schema.Mutation
+	if mutation == nil {
+		return nil, nil
+	}
+
+	results := make([]MutationReturn, 0, len(mutation.Fields))
+	for _, field := range mutation.Fields {
+		mr := MutationReturn{
+			Field:      field.Name,
+			ReturnType: field.Type.String(),
+			IsBare:     classifyBare(schema, field.Type),
+		}
+		results = append(results, mr)
+	}
+	return results, nil
+}
+
+// classifyBare returns true when the field type, after stripping non-null
+// markers and list wrappers, resolves to an Object or Interface named type.
+func classifyBare(schema *ast.Schema, t *ast.Type) bool {
+	// List-wrapped types are never bare, regardless of element kind.
+	if t.Elem != nil {
+		return false
+	}
+	// t.NamedType is the underlying name (e.g. "Role", "Boolean", "CreateCardResult").
+	named := t.NamedType
+	if named == "" {
+		// Defensive: should not happen for a valid schema field type.
+		return false
+	}
+	def, ok := schema.Types[named]
+	if !ok {
+		// Unknown type — treat as not bare.
+		return false
+	}
+	switch def.Kind {
+	case ast.Object:
+		return true
+	case ast.Interface:
+		return true
+	default:
+		// Union, Scalar, Enum, InputObject — not bare.
+		return false
+	}
+}

--- a/backend/cmd/schema-lint/schemawalk.go
+++ b/backend/cmd/schema-lint/schemawalk.go
@@ -21,7 +21,9 @@ type MutationReturn struct {
 
 // SchemaWalk parses one or more GraphQL SDL files and returns one MutationReturn
 // per mutation field found on the Mutation type (including extend blocks).
-// If no Mutation type is defined, it returns an empty slice with no error.
+// If no Mutation type is defined, it returns an error: a schema with no
+// Mutation type is treated as degenerate (likely a truncated file or a wrong
+// -schema= flag) to prevent the lint from silently passing.
 func SchemaWalk(schemaPaths []string) ([]MutationReturn, error) {
 	sources := make([]*ast.Source, 0, len(schemaPaths))
 	for _, p := range schemaPaths {
@@ -39,7 +41,7 @@ func SchemaWalk(schemaPaths []string) ([]MutationReturn, error) {
 
 	mutation := schema.Mutation
 	if mutation == nil {
-		return nil, nil
+		return nil, eris.New("schemawalk: schema has no Mutation type (likely wrong schema path or truncated file)")
 	}
 
 	results := make([]MutationReturn, 0, len(mutation.Fields))

--- a/backend/cmd/schema-lint/schemawalk_test.go
+++ b/backend/cmd/schema-lint/schemawalk_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestSchemaWalk(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		files   []string
+		want    []MutationReturn
+		wantErr bool
+	}{
+		{
+			name:  "bare object returns IsBare true",
+			files: []string{filepath.Join("testdata", "schemawalk", "bare-object.graphql")},
+			want: []MutationReturn{
+				{Field: "updateRole", ReturnType: "Role!", IsBare: true},
+			},
+		},
+		{
+			name:  "union return sets IsBare false",
+			files: []string{filepath.Join("testdata", "schemawalk", "union-return.graphql")},
+			want: []MutationReturn{
+				{Field: "createCard", ReturnType: "CreateCardResult!", IsBare: false},
+			},
+		},
+		{
+			name:  "list return sets IsBare false",
+			files: []string{filepath.Join("testdata", "schemawalk", "list-return.graphql")},
+			want: []MutationReturn{
+				{Field: "bulkCreateCards", ReturnType: "[Card!]!", IsBare: false},
+			},
+		},
+		{
+			name:  "scalar Boolean return sets IsBare false",
+			files: []string{filepath.Join("testdata", "schemawalk", "scalar-return.graphql")},
+			want: []MutationReturn{
+				{Field: "deleteRole", ReturnType: "Boolean!", IsBare: false},
+			},
+		},
+		{
+			name:  "extend type Mutation merges fields with base Mutation",
+			files: []string{filepath.Join("testdata", "schemawalk", "extend-mutation.graphql")},
+			want: []MutationReturn{
+				{Field: "createRole", ReturnType: "Role!", IsBare: true},
+				{Field: "updateRole", ReturnType: "UpdateRoleResult!", IsBare: false},
+			},
+		},
+		{
+			name:    "non-existent file returns error",
+			files:   []string{filepath.Join("testdata", "schemawalk", "does-not-exist.graphql")},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := SchemaWalk(tc.files)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("SchemaWalk: expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("SchemaWalk: unexpected error: %v", err)
+			}
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("SchemaWalk mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/backend/cmd/schema-lint/schemawalk_test.go
+++ b/backend/cmd/schema-lint/schemawalk_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -11,10 +12,11 @@ func TestSchemaWalk(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name    string
-		files   []string
-		want    []MutationReturn
-		wantErr bool
+		name        string
+		files       []string
+		want        []MutationReturn
+		wantErr     bool
+		wantErrSubs string
 	}{
 		{
 			name:  "bare object returns IsBare true",
@@ -57,6 +59,12 @@ func TestSchemaWalk(t *testing.T) {
 			files:   []string{filepath.Join("testdata", "schemawalk", "does-not-exist.graphql")},
 			wantErr: true,
 		},
+		{
+			name:        "schema with no Mutation type returns error",
+			files:       []string{filepath.Join("testdata", "schemawalk", "no-mutation.graphql")},
+			wantErr:     true,
+			wantErrSubs: "no Mutation type",
+		},
 	}
 
 	for _, tc := range tests {
@@ -66,6 +74,9 @@ func TestSchemaWalk(t *testing.T) {
 			if tc.wantErr {
 				if err == nil {
 					t.Fatal("SchemaWalk: expected error, got nil")
+				}
+				if tc.wantErrSubs != "" && !strings.Contains(err.Error(), tc.wantErrSubs) {
+					t.Errorf("SchemaWalk: error %q does not contain %q", err.Error(), tc.wantErrSubs)
 				}
 				return
 			}

--- a/backend/cmd/schema-lint/testdata/resolverwalk/multi-call.go
+++ b/backend/cmd/schema-lint/testdata/resolverwalk/multi-call.go
@@ -1,0 +1,30 @@
+package resolver
+
+import "context"
+
+type mutationResolver struct {
+	CardUC      cardUsecase
+	CardgroupUC cardgroupUsecase
+}
+
+type cardUsecase interface {
+	Create(ctx context.Context, front string) (interface{}, error)
+}
+
+type cardgroupUsecase interface {
+	Get(ctx context.Context, id string) (interface{}, error)
+}
+
+// HandleSwipe demonstrates a resolver that calls two distinct usecase fields.
+func (r *mutationResolver) HandleSwipe(ctx context.Context, cardgroupID string, front string) (interface{}, error) {
+	cg, err := r.CardgroupUC.Get(ctx, cardgroupID)
+	if err != nil {
+		return nil, err
+	}
+	_ = cg
+	result, err := r.CardUC.Create(ctx, front)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}

--- a/backend/cmd/schema-lint/testdata/resolverwalk/no-call.go
+++ b/backend/cmd/schema-lint/testdata/resolverwalk/no-call.go
@@ -1,0 +1,12 @@
+package resolver
+
+import "context"
+
+type mutationResolver struct{}
+
+func (r *mutationResolver) DeleteRole(ctx context.Context, id string) (bool, error) {
+	// No usecase call — resolver handles the logic inline.
+	_ = ctx
+	_ = id
+	return true, nil
+}

--- a/backend/cmd/schema-lint/testdata/resolverwalk/non-three-segment.go
+++ b/backend/cmd/schema-lint/testdata/resolverwalk/non-three-segment.go
@@ -1,0 +1,33 @@
+package resolver
+
+import "context"
+
+type fakeResolver struct{}
+
+type mutationResolver struct{ *fakeResolver }
+
+// FakeMutation contains call chains that do NOT match the three-segment
+// <recv>.<Selector>.<Method>() pattern the walker looks for:
+//
+//   - r.Logger(): two-segment (method directly on recv), no third segment.
+//   - r.A.B.C(): four-segment chain; inner.X is a SelectorExpr, not an Ident,
+//     so the recvIdent check rejects it.
+//   - localVar.Field.Method(): three-segment but recvIdent.Name != "r".
+//
+// None should appear in UsecaseCalls.
+func (r *mutationResolver) FakeMutation(ctx context.Context) error {
+	// Two-segment: direct method on receiver — the outer SelectorExpr's X is
+	// already the recv Ident, so there is no inner SelectorExpr.
+	_ = r.Enabled()
+
+	// Four-segment: r.Sub.Child.DeepCall() — inner.X is SelectorExpr{X:r, Sel:Sub},
+	// not a plain Ident, so the recvIdent assertion fails.
+	r.Sub.Child.DeepCall()
+
+	// Three-segment but the base is a local variable, not the receiver.
+	// The recvIdent.Name check rejects it because "localVar" != "r".
+	localVar := &struct{ Field interface{ Act() } }{}
+	localVar.Field.Act()
+
+	return nil
+}

--- a/backend/cmd/schema-lint/testdata/resolverwalk/one-call.go
+++ b/backend/cmd/schema-lint/testdata/resolverwalk/one-call.go
@@ -1,0 +1,19 @@
+package resolver
+
+import "context"
+
+type mutationResolver struct {
+	AdminRoleUC adminRoleUsecase
+}
+
+type adminRoleUsecase interface {
+	Update(ctx context.Context, id, name string) (interface{}, error)
+}
+
+func (r *mutationResolver) UpdateRole(ctx context.Context, id string, name string) (interface{}, error) {
+	result, err := r.AdminRoleUC.Update(ctx, id, name)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}

--- a/backend/cmd/schema-lint/testdata/schemawalk/bare-object.graphql
+++ b/backend/cmd/schema-lint/testdata/schemawalk/bare-object.graphql
@@ -1,0 +1,12 @@
+type Query {
+  health: String!
+}
+
+type Role {
+  id: ID!
+  name: String!
+}
+
+type Mutation {
+  updateRole(id: ID!, name: String!): Role!
+}

--- a/backend/cmd/schema-lint/testdata/schemawalk/extend-mutation.graphql
+++ b/backend/cmd/schema-lint/testdata/schemawalk/extend-mutation.graphql
@@ -1,0 +1,26 @@
+type Query {
+  health: String!
+}
+
+type Role {
+  id: ID!
+  name: String!
+}
+
+type CreateRoleSuccess {
+  role: Role!
+}
+
+type CannotRenameSystemRole {
+  message: String!
+}
+
+union UpdateRoleResult = Role | CannotRenameSystemRole
+
+type Mutation {
+  createRole(name: String!): Role!
+}
+
+extend type Mutation {
+  updateRole(id: ID!, name: String!): UpdateRoleResult!
+}

--- a/backend/cmd/schema-lint/testdata/schemawalk/list-return.graphql
+++ b/backend/cmd/schema-lint/testdata/schemawalk/list-return.graphql
@@ -1,0 +1,12 @@
+type Query {
+  health: String!
+}
+
+type Card {
+  id: ID!
+  front: String!
+}
+
+type Mutation {
+  bulkCreateCards(fronts: [String!]!): [Card!]!
+}

--- a/backend/cmd/schema-lint/testdata/schemawalk/no-mutation.graphql
+++ b/backend/cmd/schema-lint/testdata/schemawalk/no-mutation.graphql
@@ -1,0 +1,3 @@
+type Query {
+  health: String!
+}

--- a/backend/cmd/schema-lint/testdata/schemawalk/scalar-return.graphql
+++ b/backend/cmd/schema-lint/testdata/schemawalk/scalar-return.graphql
@@ -1,0 +1,7 @@
+type Query {
+  health: String!
+}
+
+type Mutation {
+  deleteRole(id: ID!): Boolean!
+}

--- a/backend/cmd/schema-lint/testdata/schemawalk/union-return.graphql
+++ b/backend/cmd/schema-lint/testdata/schemawalk/union-return.graphql
@@ -1,0 +1,17 @@
+type Query {
+  health: String!
+}
+
+type CreateCardSuccess {
+  cardId: ID!
+}
+
+type CardDuplicateFrontError {
+  message: String!
+}
+
+union CreateCardResult = CreateCardSuccess | CardDuplicateFrontError
+
+type Mutation {
+  createCard(front: String!, back: String!): CreateCardResult!
+}

--- a/backend/cmd/schema-lint/testdata/usecasewalk/emits-forbidden.go
+++ b/backend/cmd/schema-lint/testdata/usecasewalk/emits-forbidden.go
@@ -1,0 +1,16 @@
+package usecase
+
+import (
+	"context"
+
+	"backend/internal/usecase/ucerr"
+)
+
+type adminRoleUsecase struct{}
+
+func (u *adminRoleUsecase) Delete(ctx context.Context, id string) error {
+	if id == "system" {
+		return ucerr.NewForbiddenError("cannot delete system role")
+	}
+	return nil
+}

--- a/backend/cmd/schema-lint/testdata/usecasewalk/emits-unauth.go
+++ b/backend/cmd/schema-lint/testdata/usecasewalk/emits-unauth.go
@@ -1,0 +1,14 @@
+package usecase
+
+import (
+	"context"
+
+	"backend/internal/usecase/ucerr"
+)
+
+type userUsecase struct{}
+
+func (u *userUsecase) Me(ctx context.Context) (interface{}, error) {
+	// Simulate an unauthenticated path by referencing the sentinel.
+	return nil, ucerr.ErrUnauthenticated
+}

--- a/backend/cmd/schema-lint/testdata/usecasewalk/emits-validation.go
+++ b/backend/cmd/schema-lint/testdata/usecasewalk/emits-validation.go
@@ -1,0 +1,16 @@
+package usecase
+
+import (
+	"context"
+
+	"backend/internal/usecase/ucerr"
+)
+
+type cardUsecase struct{}
+
+func (u *cardUsecase) Create(ctx context.Context, front string) (interface{}, error) {
+	if front == "" {
+		return nil, ucerr.NewValidationError("front", "must not be empty")
+	}
+	return struct{ Front string }{Front: front}, nil
+}

--- a/backend/cmd/schema-lint/testdata/usecasewalk/no-emit-foreign-package-newvalidation.go
+++ b/backend/cmd/schema-lint/testdata/usecasewalk/no-emit-foreign-package-newvalidation.go
@@ -1,0 +1,16 @@
+package usecase
+
+import (
+	"context"
+
+	foreign "backend/internal/repository"
+)
+
+type auditUsecase struct{}
+
+// Save calls foreign.NewValidationError where the package alias is NOT ucerr.
+// The walker must NOT treat this as an emit signal and must set
+// EmitsTypedError = false.
+func (u *auditUsecase) Save(ctx context.Context) error {
+	return foreign.NewValidationError(nil)
+}

--- a/backend/cmd/schema-lint/testdata/usecasewalk/no-emit-unrelated-ucerr-call.go
+++ b/backend/cmd/schema-lint/testdata/usecasewalk/no-emit-unrelated-ucerr-call.go
@@ -1,0 +1,16 @@
+package usecase
+
+import (
+	"context"
+
+	"backend/internal/usecase/ucerr"
+)
+
+type reportUsecase struct{}
+
+// Generate references ucerr.Classify, which is NOT one of the three matched
+// emit signals (NewValidationError, NewForbiddenError, ErrUnauthenticated).
+// The walker must set EmitsTypedError = false for this method.
+func (u *reportUsecase) Generate(ctx context.Context) error {
+	return ucerr.Classify(nil)
+}

--- a/backend/cmd/schema-lint/testdata/usecasewalk/no-emit.go
+++ b/backend/cmd/schema-lint/testdata/usecasewalk/no-emit.go
@@ -1,0 +1,16 @@
+package usecase
+
+import (
+	"context"
+
+	"github.com/rotisserie/eris"
+)
+
+type learnUsecase struct{}
+
+func (u *learnUsecase) NextDueCards(ctx context.Context, cardgroupID string) ([]string, error) {
+	if cardgroupID == "" {
+		return nil, eris.New("usecasewalk: cardgroupID must not be empty")
+	}
+	return []string{}, nil
+}

--- a/backend/cmd/schema-lint/usecasewalk.go
+++ b/backend/cmd/schema-lint/usecasewalk.go
@@ -5,6 +5,7 @@ import (
 	"go/parser"
 	"go/token"
 	"io/fs"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -31,7 +32,18 @@ type UsecaseMethod struct {
 // UsecaseWalk parses every non-test *.go file in usecaseDir (non-recursive:
 // sub-packages such as ucerr/ are intentionally skipped) and returns one
 // UsecaseMethod per declared method.
+//
+// Returns an error when:
+//   - usecaseDir cannot be stat'd (missing, permission denied, etc.) — a
+//     missing directory silently disables enforcement otherwise, because
+//     parser.ParseDir returns (nil, nil) in that case.
+//   - usecaseDir contains no Go packages — likely a wrong path, since the
+//     real usecase directory always has at least one non-test .go file.
 func UsecaseWalk(usecaseDir string) ([]UsecaseMethod, error) {
+	if _, err := os.Stat(usecaseDir); err != nil {
+		return nil, eris.Wrap(err, "usecasewalk: usecase dir")
+	}
+
 	fset := token.NewFileSet()
 	// Parse only the immediate directory; do not recurse into sub-packages.
 	pkgs, err := parser.ParseDir(fset, usecaseDir, func(info fs.FileInfo) bool {
@@ -40,6 +52,9 @@ func UsecaseWalk(usecaseDir string) ([]UsecaseMethod, error) {
 	}, 0)
 	if err != nil {
 		return nil, eris.Wrapf(err, "usecasewalk: parse dir %s", usecaseDir)
+	}
+	if len(pkgs) == 0 {
+		return nil, eris.Errorf("usecasewalk: no Go packages found in %q (likely wrong dir path)", usecaseDir)
 	}
 
 	var results []UsecaseMethod

--- a/backend/cmd/schema-lint/usecasewalk.go
+++ b/backend/cmd/schema-lint/usecasewalk.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"strings"
+
+	"github.com/rotisserie/eris"
+)
+
+// UsecaseMethod describes a single method on a usecase type and whether it
+// emits any typed ucerr value in its body.
+type UsecaseMethod struct {
+	// File is the base filename, e.g. "admin_role.go".
+	File string
+	// ReceiverType is the source-form receiver type, e.g. "*adminRoleUsecase"
+	// or "adminRoleUsecase".
+	ReceiverType string
+	// Method is the declared method name, e.g. "Update".
+	Method string
+	// EmitsTypedError is true when the function body contains at least one of:
+	//   - ucerr.NewValidationError(...)
+	//   - ucerr.NewForbiddenError(...)
+	//   - ucerr.ErrUnauthenticated (identifier reference)
+	EmitsTypedError bool
+}
+
+// UsecaseWalk parses every non-test *.go file in usecaseDir (non-recursive:
+// sub-packages such as ucerr/ are intentionally skipped) and returns one
+// UsecaseMethod per declared method.
+func UsecaseWalk(usecaseDir string) ([]UsecaseMethod, error) {
+	fset := token.NewFileSet()
+	// Parse only the immediate directory; do not recurse into sub-packages.
+	pkgs, err := parser.ParseDir(fset, usecaseDir, func(info fs.FileInfo) bool {
+		name := info.Name()
+		return strings.HasSuffix(name, ".go") && !strings.HasSuffix(name, "_test.go")
+	}, 0)
+	if err != nil {
+		return nil, eris.Wrapf(err, "usecasewalk: parse dir %s", usecaseDir)
+	}
+
+	var results []UsecaseMethod
+	for _, pkg := range pkgs {
+		for filePath, f := range pkg.Files {
+			baseName := filepath.Base(filePath)
+			for _, decl := range f.Decls {
+				fn, ok := decl.(*ast.FuncDecl)
+				if !ok || fn.Recv == nil || len(fn.Recv.List) == 0 {
+					continue
+				}
+				recvType := formatReceiverType(fn.Recv.List[0])
+				um := UsecaseMethod{
+					File:            baseName,
+					ReceiverType:    recvType,
+					Method:          fn.Name.Name,
+					EmitsTypedError: methodEmitsTypedError(fn.Body),
+				}
+				results = append(results, um)
+			}
+		}
+	}
+	return results, nil
+}
+
+// formatReceiverType formats the receiver type as a source-form string.
+// *ast.StarExpr over *ast.Ident → "*Name"; bare *ast.Ident → "Name".
+func formatReceiverType(field *ast.Field) string {
+	switch t := field.Type.(type) {
+	case *ast.StarExpr:
+		if ident, ok := t.X.(*ast.Ident); ok {
+			return "*" + ident.Name
+		}
+	case *ast.Ident:
+		return t.Name
+	}
+	return ""
+}
+
+// methodEmitsTypedError returns true if the function body contains any of:
+//   - a call to ucerr.NewValidationError or ucerr.NewForbiddenError
+//   - a reference to ucerr.ErrUnauthenticated (SelectorExpr, not necessarily a call)
+func methodEmitsTypedError(body *ast.BlockStmt) bool {
+	if body == nil {
+		return false
+	}
+	emits := false
+	ast.Inspect(body, func(n ast.Node) bool {
+		if emits {
+			return false // short-circuit once found
+		}
+		sel, ok := n.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		xIdent, ok := sel.X.(*ast.Ident)
+		if !ok || xIdent.Name != "ucerr" {
+			return true
+		}
+		switch sel.Sel.Name {
+		case "NewValidationError", "NewForbiddenError", "ErrUnauthenticated":
+			emits = true
+		}
+		return true
+	})
+	return emits
+}

--- a/backend/cmd/schema-lint/usecasewalk_test.go
+++ b/backend/cmd/schema-lint/usecasewalk_test.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+func TestUsecaseWalk(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		dir     string
+		want    []UsecaseMethod
+		wantErr bool
+	}{
+		{
+			name: "detects ucerr.NewValidationError",
+			dir:  filepath.Join("testdata", "usecasewalk"),
+			// We test the whole directory together; sub-tests below isolate each file.
+		},
+	}
+	_ = tests // directory-level test is covered by file-level sub-tests below.
+
+	// File-level sub-tests: parse a single-file directory equivalent by
+	// pointing UsecaseWalk at the testdata/usecasewalk directory and
+	// filtering results by filename.
+	dir := filepath.Join("testdata", "usecasewalk")
+	all, err := UsecaseWalk(dir)
+	if err != nil {
+		t.Fatalf("UsecaseWalk(%q): unexpected error: %v", dir, err)
+	}
+
+	byFile := make(map[string][]UsecaseMethod)
+	for _, m := range all {
+		byFile[m.File] = append(byFile[m.File], m)
+	}
+
+	t.Run("emits-validation.go", func(t *testing.T) {
+		t.Parallel()
+		want := []UsecaseMethod{
+			{
+				File:            "emits-validation.go",
+				ReceiverType:    "*cardUsecase",
+				Method:          "Create",
+				EmitsTypedError: true,
+			},
+		}
+		got := byFile["emits-validation.go"]
+		if diff := cmp.Diff(want, got, cmpopts.SortSlices(func(a, b UsecaseMethod) bool {
+			return a.Method < b.Method
+		})); diff != "" {
+			t.Errorf("emits-validation.go mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("emits-forbidden.go", func(t *testing.T) {
+		t.Parallel()
+		want := []UsecaseMethod{
+			{
+				File:            "emits-forbidden.go",
+				ReceiverType:    "*adminRoleUsecase",
+				Method:          "Delete",
+				EmitsTypedError: true,
+			},
+		}
+		got := byFile["emits-forbidden.go"]
+		if diff := cmp.Diff(want, got, cmpopts.SortSlices(func(a, b UsecaseMethod) bool {
+			return a.Method < b.Method
+		})); diff != "" {
+			t.Errorf("emits-forbidden.go mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("emits-unauth.go", func(t *testing.T) {
+		t.Parallel()
+		want := []UsecaseMethod{
+			{
+				File:            "emits-unauth.go",
+				ReceiverType:    "*userUsecase",
+				Method:          "Me",
+				EmitsTypedError: true,
+			},
+		}
+		got := byFile["emits-unauth.go"]
+		if diff := cmp.Diff(want, got, cmpopts.SortSlices(func(a, b UsecaseMethod) bool {
+			return a.Method < b.Method
+		})); diff != "" {
+			t.Errorf("emits-unauth.go mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("no-emit.go", func(t *testing.T) {
+		t.Parallel()
+		want := []UsecaseMethod{
+			{
+				File:            "no-emit.go",
+				ReceiverType:    "*learnUsecase",
+				Method:          "NextDueCards",
+				EmitsTypedError: false,
+			},
+		}
+		got := byFile["no-emit.go"]
+		if diff := cmp.Diff(want, got, cmpopts.SortSlices(func(a, b UsecaseMethod) bool {
+			return a.Method < b.Method
+		})); diff != "" {
+			t.Errorf("no-emit.go mismatch (-want +got):\n%s", diff)
+		}
+	})
+}
+
+func TestUsecaseWalkNonExistentDir(t *testing.T) {
+	t.Parallel()
+	_, err := UsecaseWalk(filepath.Join("testdata", "usecasewalk", "does-not-exist"))
+	if err == nil {
+		t.Fatal("UsecaseWalk: expected error for non-existent directory, got nil")
+	}
+}

--- a/backend/cmd/schema-lint/usecasewalk_test.go
+++ b/backend/cmd/schema-lint/usecasewalk_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -10,20 +11,6 @@ import (
 
 func TestUsecaseWalk(t *testing.T) {
 	t.Parallel()
-
-	tests := []struct {
-		name    string
-		dir     string
-		want    []UsecaseMethod
-		wantErr bool
-	}{
-		{
-			name: "detects ucerr.NewValidationError",
-			dir:  filepath.Join("testdata", "usecasewalk"),
-			// We test the whole directory together; sub-tests below isolate each file.
-		},
-	}
-	_ = tests // directory-level test is covered by file-level sub-tests below.
 
 	// File-level sub-tests: parse a single-file directory equivalent by
 	// pointing UsecaseWalk at the testdata/usecasewalk directory and
@@ -110,12 +97,78 @@ func TestUsecaseWalk(t *testing.T) {
 			t.Errorf("no-emit.go mismatch (-want +got):\n%s", diff)
 		}
 	})
+
+	// Test 4 (negative cases): false-positive avoidance
+
+	// no-emit-unrelated-ucerr-call.go: method references ucerr.Classify (an
+	// exported ucerr symbol that is NOT one of the three matched names). The
+	// matcher must not over-fire on any ucerr.X reference.
+	t.Run("no-emit-unrelated-ucerr-call.go", func(t *testing.T) {
+		t.Parallel()
+		got := byFile["no-emit-unrelated-ucerr-call.go"]
+		if len(got) == 0 {
+			t.Fatal("expected at least one UsecaseMethod for no-emit-unrelated-ucerr-call.go, got none")
+		}
+		for _, m := range got {
+			if m.EmitsTypedError {
+				t.Errorf("no-emit-unrelated-ucerr-call.go: method %s: EmitsTypedError = true, want false (matcher must not fire on ucerr.Classify)", m.Method)
+			}
+		}
+	})
+
+	// no-emit-foreign-package-newvalidation.go: method body calls
+	// foreign.NewValidationError where the package alias is NOT ucerr. The
+	// matcher must pin on the "ucerr" package qualifier specifically.
+	t.Run("no-emit-foreign-package-newvalidation.go", func(t *testing.T) {
+		t.Parallel()
+		got := byFile["no-emit-foreign-package-newvalidation.go"]
+		if len(got) == 0 {
+			t.Fatal("expected at least one UsecaseMethod for no-emit-foreign-package-newvalidation.go, got none")
+		}
+		for _, m := range got {
+			if m.EmitsTypedError {
+				t.Errorf("no-emit-foreign-package-newvalidation.go: method %s: EmitsTypedError = true, want false (matcher must pin on ucerr qualifier)", m.Method)
+			}
+		}
+	})
 }
 
 func TestUsecaseWalkNonExistentDir(t *testing.T) {
 	t.Parallel()
-	_, err := UsecaseWalk(filepath.Join("testdata", "usecasewalk", "does-not-exist"))
+
+	t.Run("relative path under testdata", func(t *testing.T) {
+		t.Parallel()
+		_, err := UsecaseWalk(filepath.Join("testdata", "usecasewalk", "does-not-exist"))
+		if err == nil {
+			t.Fatal("UsecaseWalk: expected error for non-existent directory, got nil")
+		}
+		if !strings.Contains(err.Error(), "usecasewalk: usecase dir") {
+			t.Errorf("UsecaseWalk: error %q does not contain expected layer prefix", err.Error())
+		}
+	})
+
+	t.Run("bare nonexistent name", func(t *testing.T) {
+		t.Parallel()
+		_, err := UsecaseWalk("nonexistent")
+		if err == nil {
+			t.Fatal("UsecaseWalk: expected error for non-existent directory, got nil")
+		}
+		if !strings.Contains(err.Error(), "usecasewalk: usecase dir") {
+			t.Errorf("UsecaseWalk: error %q does not contain expected layer prefix", err.Error())
+		}
+	})
+}
+
+func TestUsecaseWalkEmptyDir(t *testing.T) {
+	t.Parallel()
+
+	// A directory that exists but has no .go files should also error.
+	emptyDir := t.TempDir()
+	_, err := UsecaseWalk(emptyDir)
 	if err == nil {
-		t.Fatal("UsecaseWalk: expected error for non-existent directory, got nil")
+		t.Fatal("UsecaseWalk: expected error for empty directory, got nil")
+	}
+	if !strings.Contains(err.Error(), "no Go packages found") {
+		t.Errorf("UsecaseWalk: error %q does not contain expected substring", err.Error())
 	}
 }

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/MicahParks/keyfunc/v3 v3.8.0
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/golang-migrate/migrate/v4 v4.19.1
+	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/graph-gophers/dataloader/v7 v7.1.3
 	github.com/jackc/pgx/v5 v5.9.2

--- a/backend/graph/resolver/admin_role_resolver_test.go
+++ b/backend/graph/resolver/admin_role_resolver_test.go
@@ -20,15 +20,15 @@ import (
 // ---------------------------------------------------------------------------
 
 type mockAdminRoleUsecase struct {
-	listResult   []*domain.Role
-	listErr      error
-	getResult    *domain.Role
-	getErr       error
-	createResult *domain.Role
-	createErr    error
-	updateResult *domain.Role
-	updateErr    error
-	deleteErr    error
+	listResult    []*domain.Role
+	listErr       error
+	getResult     *domain.Role
+	getErr        error
+	createResult  *domain.Role
+	createErr     error
+	updateOutcome usecase.UpdateRoleOutcome
+	updateErr     error
+	deleteErr     error
 }
 
 func (m *mockAdminRoleUsecase) List(_ context.Context) ([]*domain.Role, error) {
@@ -40,8 +40,8 @@ func (m *mockAdminRoleUsecase) Get(_ context.Context, _ string) (*domain.Role, e
 func (m *mockAdminRoleUsecase) Create(_ context.Context, _ string) (*domain.Role, error) {
 	return m.createResult, m.createErr
 }
-func (m *mockAdminRoleUsecase) Update(_ context.Context, _, _ string) (*domain.Role, error) {
-	return m.updateResult, m.updateErr
+func (m *mockAdminRoleUsecase) Update(_ context.Context, _, _ string) (usecase.UpdateRoleOutcome, error) {
+	return m.updateOutcome, m.updateErr
 }
 func (m *mockAdminRoleUsecase) Delete(_ context.Context, _ string) error {
 	return m.deleteErr
@@ -111,6 +111,80 @@ func TestResolver_CreateRole_Forbidden(t *testing.T) {
 // Mutation.updateRole tests
 // ---------------------------------------------------------------------------
 
+// updateRoleMutation queries every variant of the UpdateRoleResult union so a
+// single mutation body covers both the success and system-role-conflict cases.
+const updateRoleMutation = `{"query":"mutation { updateRole(id: \"r1\", name: \"reviewer\") { __typename ... on UpdateRoleSuccess { role { id name } } ... on CannotModifySystemRoleError { message roleId roleName } } }"}`
+
+// TestResolver_UpdateRole_Success verifies that the happy-path outcome maps to
+// the UpdateRoleSuccess union variant carrying the renamed role.
+func TestResolver_UpdateRole_Success(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockAdminRoleUsecase{
+		updateOutcome: usecase.UpdateRoleOutcome{
+			Role: &domain.Role{ID: "r1", Name: "reviewer"},
+		},
+	}
+	srv := newAdminRoleSrv(mock)
+	resp := gqlRequest(t, srv, authedCtx("admin"), updateRoleMutation)
+
+	if _, hasErrs := resp["errors"]; hasErrs {
+		t.Fatalf("unexpected errors: %v", resp["errors"])
+	}
+	data, _ := resp["data"].(map[string]any)
+	payload, _ := data["updateRole"].(map[string]any)
+	if payload == nil {
+		t.Fatalf("expected data.updateRole, got nil; response: %v", resp)
+	}
+	if payload["__typename"] != "UpdateRoleSuccess" {
+		t.Fatalf("expected __typename=UpdateRoleSuccess, got %v", payload["__typename"])
+	}
+	role, _ := payload["role"].(map[string]any)
+	if role == nil || role["id"] != "r1" || role["name"] != "reviewer" {
+		t.Fatalf("expected role={id:r1 name:reviewer}, got %v", role)
+	}
+}
+
+// TestResolver_UpdateRole_SystemRoleConflict verifies that the system-role
+// refusal outcome maps to the CannotModifySystemRoleError union variant
+// (data, not an error) with the offending role's identity attached.
+func TestResolver_UpdateRole_SystemRoleConflict(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockAdminRoleUsecase{
+		updateOutcome: usecase.UpdateRoleOutcome{
+			SystemRoleConflict: &usecase.SystemRoleConflictInfo{
+				ID:   "r-admin",
+				Name: "admin",
+			},
+		},
+	}
+	srv := newAdminRoleSrv(mock)
+	resp := gqlRequest(t, srv, authedCtx("admin"), updateRoleMutation)
+
+	if _, hasErrs := resp["errors"]; hasErrs {
+		t.Fatalf("unexpected errors: %v", resp["errors"])
+	}
+	data, _ := resp["data"].(map[string]any)
+	payload, _ := data["updateRole"].(map[string]any)
+	if payload == nil {
+		t.Fatalf("expected data.updateRole, got nil; response: %v", resp)
+	}
+	if payload["__typename"] != "CannotModifySystemRoleError" {
+		t.Fatalf("expected __typename=CannotModifySystemRoleError, got %v", payload["__typename"])
+	}
+	if payload["roleId"] != "r-admin" {
+		t.Fatalf("expected roleId=r-admin, got %v", payload["roleId"])
+	}
+	if payload["roleName"] != "admin" {
+		t.Fatalf("expected roleName=admin, got %v", payload["roleName"])
+	}
+	msg, _ := payload["message"].(string)
+	if msg == "" {
+		t.Fatalf("expected non-empty message, got %q", msg)
+	}
+}
+
 // TestResolver_UpdateRole_BadInput verifies that BAD_USER_INPUT with
 // extensions.field="name" from the usecase propagates unchanged.
 func TestResolver_UpdateRole_BadInput(t *testing.T) {
@@ -120,7 +194,7 @@ func TestResolver_UpdateRole_BadInput(t *testing.T) {
 		updateErr: &ucerr.ValidationError{Field: "name", Message: "name must contain only lowercase letters, digits, '_' or '-'"},
 	}
 	srv := newAdminRoleSrv(mock)
-	body := `{"query":"mutation { updateRole(id: \"r1\", name: \"INVALID NAME\") { id name } }"}`
+	body := `{"query":"mutation { updateRole(id: \"r1\", name: \"INVALID NAME\") { __typename ... on UpdateRoleSuccess { role { id name } } ... on CannotModifySystemRoleError { message roleId roleName } } }"}`
 	resp := gqlRequest(t, srv, authedCtx("admin"), body)
 
 	code := errCode(t, resp)
@@ -133,6 +207,25 @@ func TestResolver_UpdateRole_BadInput(t *testing.T) {
 	field, _ := ext["field"].(string)
 	if field != "name" {
 		t.Fatalf("expected extensions.field=name, got %q; ext: %v", field, ext)
+	}
+}
+
+// TestResolver_UpdateRole_XORInvariantViolation covers the defensive guard
+// where the usecase returns an UpdateRoleOutcome with neither variant set.
+// This must surface as INTERNAL — the resolver refuses to render an
+// unselectable union value.
+func TestResolver_UpdateRole_XORInvariantViolation(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockAdminRoleUsecase{
+		updateOutcome: usecase.UpdateRoleOutcome{}, // both variants nil
+	}
+	srv := newAdminRoleSrv(mock)
+	resp := gqlRequest(t, srv, authedCtx("admin"), updateRoleMutation)
+
+	code := errCode(t, resp)
+	if code != string(gqlerr.CodeInternal) {
+		t.Fatalf("expected INTERNAL_SERVER_ERROR, got %q; response: %v", code, resp)
 	}
 }
 

--- a/backend/graph/resolver/schema.resolvers.go
+++ b/backend/graph/resolver/schema.resolvers.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"encoding/base64"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/rotisserie/eris"
@@ -244,12 +245,28 @@ func (r *mutationResolver) CreateRole(ctx context.Context, name string) (*model.
 }
 
 // UpdateRole is the resolver for the updateRole field.
-func (r *mutationResolver) UpdateRole(ctx context.Context, id string, name string) (*model.Role, error) {
-	role, err := r.AdminRoleUC.Update(ctx, id, name)
+//
+// Returns a union: `model.UpdateRoleSuccess` on the happy path, or
+// `model.CannotModifySystemRoleError` when the target role is a system role
+// ("admin", "general"). The system-role case is "errors as data" — the second
+// return value is reserved for real errors (auth, validation, internal).
+func (r *mutationResolver) UpdateRole(ctx context.Context, id string, name string) (model.UpdateRoleResult, error) {
+	outcome, err := r.AdminRoleUC.Update(ctx, id, name)
 	if err != nil {
 		return nil, gqlerr.FromUsecaseError(ctx, err)
 	}
-	return toRoleModel(role), nil
+	if outcome.SystemRoleConflict != nil {
+		return model.CannotModifySystemRoleError{
+			Message:  fmt.Sprintf("cannot rename system role %q", outcome.SystemRoleConflict.Name),
+			RoleID:   outcome.SystemRoleConflict.ID,
+			RoleName: outcome.SystemRoleConflict.Name,
+		}, nil
+	}
+	if outcome.Role == nil {
+		return nil, gqlerr.Internal(ctx,
+			eris.New("resolver: UpdateRoleOutcome has no variant set"))
+	}
+	return model.UpdateRoleSuccess{Role: toRoleModel(outcome.Role)}, nil
 }
 
 // DeleteRole is the resolver for the deleteRole field.

--- a/backend/internal/usecase/admin_role.go
+++ b/backend/internal/usecase/admin_role.go
@@ -36,7 +36,7 @@ type AdminRoleUsecase interface {
 	List(ctx context.Context) ([]*domain.Role, error)
 	Get(ctx context.Context, id string) (*domain.Role, error)
 	Create(ctx context.Context, name string) (*domain.Role, error)
-	Update(ctx context.Context, id, name string) (*domain.Role, error)
+	Update(ctx context.Context, id, name string) (UpdateRoleOutcome, error)
 	Delete(ctx context.Context, id string) error
 }
 
@@ -164,7 +164,40 @@ func (u *adminRoleUsecase) Create(ctx context.Context, name string) (*domain.Rol
 	return role, nil
 }
 
-// Update renames an existing role. System roles ("admin", "general") are
+// UpdateRoleOutcome is the result of admin_role.Update. Exactly one of Role
+// or SystemRoleConflict is non-nil: a successful rename returns the updated
+// Role, while a refusal to rename a system role ("admin", "general") returns
+// a populated SystemRoleConflict and a nil error.
+//
+// The system-role guard is a domain invariant of the Role aggregate, not an
+// authorisation failure: even an admin caller cannot rename "admin". Surfacing
+// the refusal as data (rather than as an error) lets the resolver map it to
+// the model.CannotModifySystemRoleError union variant, which carries the
+// offending role's id and name for client-side rendering without a second
+// fetch.
+//
+// Validation failures, unauthenticated callers, and repository errors stay in
+// the second return value (error) so the resolver wraps them via
+// gqlerr.FromUsecaseError into the wire-format GraphQL error.
+type UpdateRoleOutcome struct {
+	// Role is the renamed role on the happy path. Non-nil iff
+	// SystemRoleConflict is nil.
+	Role *domain.Role
+	// SystemRoleConflict carries the offending system role's identity when
+	// the rename was refused by the system-role guard. Non-nil iff Role is nil.
+	SystemRoleConflict *SystemRoleConflictInfo
+}
+
+// SystemRoleConflictInfo identifies the system role that an Update call
+// refused to rename.
+type SystemRoleConflictInfo struct {
+	ID   string
+	Name string
+}
+
+// Update renames an existing role and returns an UpdateRoleOutcome that
+// signals the system-role refusal as data (via outcome.SystemRoleConflict)
+// rather than as an error. System roles ("admin", "general") are
 // renaming-locked: renaming "admin" would break the auth.Service.IsAdmin
 // lookup that hardcodes the literal string, and renaming "general" would
 // break any deployment that relies on the literal name being present.
@@ -172,28 +205,31 @@ func (u *adminRoleUsecase) Create(ctx context.Context, name string) (*domain.Rol
 // TOCTOU: between FindByID and roles.Update another admin can delete the row;
 // the resulting ErrRoleNotFound is mapped back to BAD_USER_INPUT(field=id)
 // rather than INTERNAL.
-func (u *adminRoleUsecase) Update(ctx context.Context, id, name string) (*domain.Role, error) {
+func (u *adminRoleUsecase) Update(ctx context.Context, id, name string) (UpdateRoleOutcome, error) {
 	if err := u.requireAdmin(ctx); err != nil {
-		return nil, err
+		return UpdateRoleOutcome{}, err
 	}
 	normalized, err := validateRoleName(name)
 	if err != nil {
-		return nil, err
+		return UpdateRoleOutcome{}, err
 	}
 
 	existing, err := u.roles.FindByID(ctx, id)
 	if err != nil {
-		return nil, mapAdminRoleError(err, "id", "usecase: admin role update: find")
+		return UpdateRoleOutcome{}, mapAdminRoleError(err, "id", "usecase: admin role update: find")
 	}
 	if isSystemRole(existing.Name) {
-		return nil, ucerr.NewForbiddenError(fmt.Sprintf("cannot rename system role %q", existing.Name))
+		return UpdateRoleOutcome{SystemRoleConflict: &SystemRoleConflictInfo{
+			ID:   existing.ID,
+			Name: existing.Name,
+		}}, nil
 	}
 
 	role, err := u.roles.Update(ctx, id, normalized)
 	if err != nil {
-		return nil, mapAdminRoleError(err, "id", "usecase: admin role update")
+		return UpdateRoleOutcome{}, mapAdminRoleError(err, "id", "usecase: admin role update")
 	}
-	return role, nil
+	return UpdateRoleOutcome{Role: role}, nil
 }
 
 // Delete removes a role by id. System roles ("admin", "general") are

--- a/backend/internal/usecase/admin_role_test.go
+++ b/backend/internal/usecase/admin_role_test.go
@@ -751,6 +751,32 @@ func TestAdminRole_Delete_RepoInternalError(t *testing.T) {
 	assertInternalChain(t, err, "usecase: admin role delete")
 }
 
+// Test 3: Update default-branch chain assertion.
+// TestAdminRole_Update_RepoInternalError surfaces a generic repository error
+// from the roles.Update call (anything other than the classified sentinels) as
+// INTERNAL with the eris chain attached. The pattern mirrors
+// TestAdminRole_Delete_RepoInternalError: requireAdmin OK, validateRoleName OK,
+// FindByID returns a non-system role, roles.Update returns a non-sentinel error.
+func TestAdminRole_Update_RepoInternalError(t *testing.T) {
+	t.Parallel()
+
+	roles := &mockAdminRoleRepoForCRUD{
+		findResult: &domain.Role{ID: "r-1", Name: "moderator"}, // non-system role
+		updateErr:  errors.New("boom: db blew up"),
+	}
+	authChk := &adminAuthChecker{admins: map[string]bool{"admin-1": true}}
+	uc, _ := buildAdminRoleUC(roles, authChk)
+
+	outcome, err := uc.Update(authedCtx("admin-1"), "r-1", "reviewer")
+
+	// The outcome struct must be zero-value (no Role, no SystemRoleConflict).
+	if outcome.Role != nil || outcome.SystemRoleConflict != nil {
+		t.Fatalf("expected zero-value outcome, got %+v", outcome)
+	}
+	// The error must be non-nil and carry the "usecase: admin role update" wrap.
+	assertInternalChain(t, err, "usecase: admin role update")
+}
+
 // ---------------------------------------------------------------------------
 // Get
 // ---------------------------------------------------------------------------

--- a/backend/internal/usecase/admin_role_test.go
+++ b/backend/internal/usecase/admin_role_test.go
@@ -458,7 +458,8 @@ func TestAdminRole_Create_DuplicateMatchesAfterNormalization(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 // TestAdminRole_Update_Success looks the role up, confirms it is not the
-// system admin role, and pushes the normalised new name to the repo.
+// system admin role, and pushes the normalised new name to the repo. The
+// happy-path outcome carries the renamed Role and a nil SystemRoleConflict.
 func TestAdminRole_Update_Success(t *testing.T) {
 	t.Parallel()
 
@@ -469,12 +470,16 @@ func TestAdminRole_Update_Success(t *testing.T) {
 	authChk := &adminAuthChecker{admins: map[string]bool{"admin-1": true}}
 	uc, _ := buildAdminRoleUC(roles, authChk)
 
-	got, err := uc.Update(authedCtx("admin-1"), "r-1", "Reviewer")
+	outcome, err := uc.Update(authedCtx("admin-1"), "r-1", "Reviewer")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if got == nil || got.Name != "reviewer" {
-		t.Fatalf("got = %+v, want role with name=reviewer", got)
+	if outcome.SystemRoleConflict != nil {
+		t.Fatalf("expected SystemRoleConflict==nil on happy path, got %+v",
+			outcome.SystemRoleConflict)
+	}
+	if outcome.Role == nil || outcome.Role.Name != "reviewer" {
+		t.Fatalf("outcome.Role = %+v, want role with name=reviewer", outcome.Role)
 	}
 	if roles.lastUpdateID != "r-1" || roles.lastUpdateName != "reviewer" {
 		t.Fatalf("repo update args = (%q,%q), want (r-1, reviewer)",
@@ -482,25 +487,26 @@ func TestAdminRole_Update_Success(t *testing.T) {
 	}
 }
 
-// TestAdminRole_Update_RenameSystemRoleForbidden enforces the system-role
-// guard for every name in the protected set. Renaming any of them must be
-// rejected with FORBIDDEN, and the repo Update must not be called. A
-// negative case (a non-system role with a similar-looking name) is included
-// so a future widening of the guard cannot silently route a custom role
-// through the system branch.
-func TestAdminRole_Update_RenameSystemRoleForbidden(t *testing.T) {
+// TestAdminRole_Update_RenameSystemRoleConflict enforces the system-role
+// guard for every name in the protected set. Renaming any of them must
+// return UpdateRoleOutcome{SystemRoleConflict: ...} with a nil error (the
+// refusal is surfaced as data, not as an error), and the repo Update must
+// not be called. A negative case (a non-system role with a similar-looking
+// name) is included so a future widening of the guard cannot silently route
+// a custom role through the system branch.
+func TestAdminRole_Update_RenameSystemRoleConflict(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
-		name     string
-		roleName string
-		want     string
+		name       string
+		roleName   string
+		wantSystem bool
 	}{
-		{name: "admin", roleName: "admin", want: "FORBIDDEN"},
-		{name: "general", roleName: "general", want: "FORBIDDEN"},
+		{name: "admin", roleName: "admin", wantSystem: true},
+		{name: "general", roleName: "general", wantSystem: true},
 		// Negative: a non-system role with a confusable prefix must NOT be
 		// rejected by the system-role guard. It still hits the repo Update.
-		{name: "non-system 'general-2'", roleName: "general-2", want: ""},
+		{name: "non-system 'general-2'", roleName: "general-2", wantSystem: false},
 	}
 
 	for _, tc := range cases {
@@ -512,9 +518,22 @@ func TestAdminRole_Update_RenameSystemRoleForbidden(t *testing.T) {
 			authChk := &adminAuthChecker{admins: map[string]bool{"admin-1": true}}
 			uc, _ := buildAdminRoleUC(roles, authChk)
 
-			_, err := uc.Update(authedCtx("admin-1"), "r-x", "renamed")
-			if tc.want == "FORBIDDEN" {
-				assertForbidden(t, err, "")
+			outcome, err := uc.Update(authedCtx("admin-1"), "r-x", "renamed")
+			if tc.wantSystem {
+				if err != nil {
+					t.Fatalf("expected nil error on system-role refusal, got %v", err)
+				}
+				if outcome.SystemRoleConflict == nil {
+					t.Fatalf("expected SystemRoleConflict, got nil; outcome=%+v", outcome)
+				}
+				if outcome.SystemRoleConflict.ID != "r-x" ||
+					outcome.SystemRoleConflict.Name != tc.roleName {
+					t.Fatalf("SystemRoleConflict = %+v, want {ID:r-x Name:%s}",
+						outcome.SystemRoleConflict, tc.roleName)
+				}
+				if outcome.Role != nil {
+					t.Fatalf("expected Role==nil on system-role refusal, got %+v", outcome.Role)
+				}
 				if roles.updateCalls != 0 {
 					t.Fatalf("expected 0 repo update calls on system-role guard, got %d",
 						roles.updateCalls)
@@ -523,6 +542,13 @@ func TestAdminRole_Update_RenameSystemRoleForbidden(t *testing.T) {
 			}
 			if err != nil {
 				t.Fatalf("unexpected error for non-system role: %v", err)
+			}
+			if outcome.Role == nil {
+				t.Fatalf("expected outcome.Role for non-system role, got nil")
+			}
+			if outcome.SystemRoleConflict != nil {
+				t.Fatalf("expected SystemRoleConflict==nil for non-system role, got %+v",
+					outcome.SystemRoleConflict)
 			}
 			if roles.updateCalls != 1 {
 				t.Fatalf("expected 1 repo update call for non-system role, got %d",

--- a/docs/backend/error-wrapping/outcome-union-enforcement.md
+++ b/docs/backend/error-wrapping/outcome-union-enforcement.md
@@ -1,0 +1,161 @@
+# Outcome-union enforcement lint
+
+> Part of the [error wrapping convention](../../../.claude/rules/error-wrapping.md) rules.
+> Closely related to [`docs/backend/error-wrapping/result-union-errors-as-data.md`](result-union-errors-as-data.md).
+
+## Overview
+
+The schema-lint program at `backend/cmd/schema-lint/` detects mutations that
+return a bare object type while their backing usecase method emits at least one
+typed `ucerr.*` variant. Such mutations are promotion candidates for the
+outcome-union pattern described in
+[`docs/backend/error-wrapping/result-union-errors-as-data.md`](result-union-errors-as-data.md).
+
+"Bare" means the mutation's return type is a single named object or interface —
+not wrapped in a `union`. A bare return type forces the resolver to route
+typed business failures through the `error` channel, where they lose schema
+structure and reach the client as opaque `extensions.code` strings. Wrapping
+the return type in a union instead lets codegen produce typed variants the
+client can switch on safely.
+
+The lint runs in `.github/workflows/backend.yml` alongside the existing four
+error-handling gates (see [`.claude/rules/error-wrapping.md`](../../../.claude/rules/error-wrapping.md)).
+It is a stop-the-bleeding gate: existing mutations that predate the rule are
+frozen in an allowlist so the gate's introduction does not blast-radius across
+the codebase. New mutations that match both conditions fail immediately.
+
+## What the lint flags
+
+The classifier joins three independent walkers:
+
+- `schemawalk` — reads `schema/schema.graphql` via `vektah/gqlparser`; produces
+  `{mutation, returnType, isBare}` for every mutation field.
+- `resolverwalk` — reads `backend/graph/resolver/schema.resolvers.go` as a Go
+  AST; produces the mutation → usecase call mapping.
+- `usecasewalk` — reads `backend/internal/usecase/*.go`; produces a 1-bit
+  `emitsTypedError` flag per usecase method.
+
+A violation is raised when `isBare AND emitsTypedError AND NOT in allowlist`.
+
+### Return-type classification (`schemawalk`)
+
+| Return type | Lint subject? | Reason |
+|---|---|---|
+| Object type (`Card!`, `User!`, `Role!`) | yes | Promotion candidate |
+| Union (`CreateCardResult!`) | no | Already outcome-union |
+| List (`[Card!]!`) | no | Bulk/list — different pattern |
+| Scalar (`Boolean!`, `Int!`) | no | A success-only scalar variant (`type DeleteSuccess { deleted: Boolean }`) adds no value |
+| Interface | yes | Defensive — does not occur today but logically equivalent to a bare object |
+
+"Bare" = isolated object or interface return type that is not wrapped in a union.
+
+### Typed-error emission detection (`usecasewalk`)
+
+A usecase method is flagged `emitsTypedError = true` when its function body
+contains any of:
+
+- `ucerr.NewValidationError(...)` call expression
+- `ucerr.NewForbiddenError(...)` call expression
+- `ucerr.ErrUnauthenticated` identifier reference
+
+Detection uses `ast.Inspect` on the function body only. Helper-delegated
+emission outside the same function body is a known false-negative; its profile
+is low today (verified via grep). Extend the walker if a future helper
+extraction produces a real miss.
+
+## Why allowlist (stop-the-bleeding philosophy)
+
+The allowlist at `backend/cmd/schema-lint/allowlist.txt` follows the same
+philosophy as `rubocop --auto-gen-config` and `mypy --baseline`: existing
+violations are named and frozen at a known point; every new violation fails
+immediately. This lets the gate ship in `-mode=error` on day one without
+requiring a bulk promotion of all 17 pre-existing bare-return mutations.
+
+Each promotion is one allowlist-line deletion paired with the full schema +
+usecase + resolver + frontend + regenerate change. Because promotion PRs touch
+exactly one mutation, they stay well inside the 800-line production-diff ceiling
+in [`.claude/rules/pr-sizing.md`](../../../.claude/rules/pr-sizing.md).
+
+Allowlist format: one mutation name per line. Lines starting with `#` and blank
+lines are ignored. Inline `# reason` comments record why promotion is deferred.
+
+```text
+# backend/cmd/schema-lint/allowlist.txt
+updateProfile          # NewValidationError("displayName"/"bio", ...): field-only payload
+createCardgroup        # NewValidationError("name", ...): field-only payload
+```
+
+## Promotion checklist
+
+Follow these steps in order to promote one mutation from the allowlist to a
+full outcome-union. Each step is a single atomic unit; commit after step 4 and
+after step 7 pass their respective verifications.
+
+1. **Edit `schema/schema.graphql`**: add `TypeSuccess`, `TypeError1`,
+   `TypeError2` types (error types implement `UserError` to gain `message:
+   String!`), declare `union <Op>Result = TypeSuccess | TypeError1 | ...`, and
+   change the mutation field's return type from the bare object to `<Op>Result!`.
+
+2. **Refactor the usecase**: introduce an `<Op>Outcome` struct with one pointer
+   per variant; change the method signature to `(<Op>Outcome, error)`. The XOR
+   invariant — exactly one non-nil pointer per returned outcome — is enforced by
+   the exhaustiveness guard in the resolver (step 3). Domain-invariant violations
+   return `(<Op>Outcome{VariantField: &info}, nil)`; all other failures remain in
+   the `error` channel.
+
+3. **Refactor the resolver**: branch on `outcome.<Variant> != nil` and return
+   the corresponding `model.<Variant>` value; guard "no variant set" with
+   `gqlerr.Internal(ctx, eris.New("resolver: <Op>Outcome has no variant set"))`.
+   Wrap all usecase errors via `gqlerr.FromUsecaseError(ctx, err)` per the
+   mandatory resolver-side wrap rule.
+
+4. **Regenerate**: run `go tool gqlgen generate` from `backend/`; commit the
+   resulting `backend/graph/generated/` and `backend/graph/model/` diff. Verify
+   `go build ./...` and `go vet ./...` pass before continuing.
+
+5. **Update the frontend mutation**: discriminate on `__typename` with inline
+   fragments per variant in the `.graphql` document; regenerate types via
+   `pnpm --filter frontend codegen`; commit the `frontend/src/generated/` diff
+   and the updated mutation handler.
+
+6. **Delete the mutation name from `backend/cmd/schema-lint/allowlist.txt`**:
+   remove the line (and its inline comment) for the promoted mutation.
+
+7. **Verify the lint exits cleanly**: run `go run ./cmd/schema-lint` from
+   `backend/`; assert it exits 0 with no violations reported for the promoted
+   mutation or any other.
+
+## Maintaining the lint
+
+### Naming drift handling
+
+When gqlgen renames a resolver method (e.g. after a schema field rename),
+`resolverwalk` can no longer pair the schema mutation with its resolver body.
+The lint emits `schema/resolver drift: mutation <X> has no resolver method` and
+fails with a non-zero exit code — independent of any outcome-union concern. This
+surfaces gqlgen naming drift in CI on the first run after the change, before
+any real violation analysis runs.
+
+### Adding a new `ucerr.*` constructor
+
+If a new constructor is added to `backend/internal/usecase/ucerr/` (e.g.
+`ucerr.NewConflictError`), extend `backend/cmd/schema-lint/usecasewalk.go`'s
+string-match list with the new constructor name and add a fixture test in
+`backend/cmd/schema-lint/testdata/` to cover the true and false cases. The
+fixture test runs without access to the project-wide source tree; keep it
+self-contained.
+
+### False-positive recovery
+
+If the lint flags a mutation that should not be a violation (e.g. a resolver
+that emits `ucerr.NewValidationError` only in an unreachable legacy path), add
+the mutation name to `backend/cmd/schema-lint/allowlist.txt` with a `# reason`
+comment explaining why. File a follow-up issue to investigate whether the
+emission is intentional or a refactor leak; link the issue in the comment.
+Never leave an unexplained allowlist entry.
+
+## Back-links
+
+- [`result-union-errors-as-data.md`](result-union-errors-as-data.md) — pattern reference; `createCard` and `updateRole` are the canonical worked examples.
+- [`.claude/rules/error-wrapping.md` § "Errors as data — detailed cases"](../../../.claude/rules/error-wrapping.md#errors-as-data--detailed-cases-on-demand) — rule layer this doc supports.
+- [`.claude/rules/scope-discipline.md`](../../../.claude/rules/scope-discipline.md) — allowlist-as-baseline rationale; per-mutation promotion as opportunistic follow-up.

--- a/docs/backend/error-wrapping/outcome-union-enforcement.md
+++ b/docs/backend/error-wrapping/outcome-union-enforcement.md
@@ -18,7 +18,7 @@ structure and reach the client as opaque `extensions.code` strings. Wrapping
 the return type in a union instead lets codegen produce typed variants the
 client can switch on safely.
 
-The lint runs in `.github/workflows/backend.yml` alongside the existing four
+The lint runs in `.github/workflows/backend.yml` alongside the existing
 error-handling gates (see [`.claude/rules/error-wrapping.md`](../../../.claude/rules/error-wrapping.md)).
 It is a stop-the-bleeding gate: existing mutations that predate the rule are
 frozen in an allowlist so the gate's introduction does not blast-radius across
@@ -69,7 +69,8 @@ The allowlist at `backend/cmd/schema-lint/allowlist.txt` follows the same
 philosophy as `rubocop --auto-gen-config` and `mypy --baseline`: existing
 violations are named and frozen at a known point; every new violation fails
 immediately. This lets the gate ship in `-mode=error` on day one without
-requiring a bulk promotion of all 17 pre-existing bare-return mutations.
+requiring a bulk promotion of the pre-existing bare-emit mutations frozen in
+the allowlist.
 
 Each promotion is one allowlist-line deletion paired with the full schema +
 usecase + resolver + frontend + regenerate change. Because promotion PRs touch
@@ -156,6 +157,6 @@ Never leave an unexplained allowlist entry.
 
 ## Back-links
 
-- [`result-union-errors-as-data.md`](result-union-errors-as-data.md) — pattern reference; `createCard` and `updateRole` are the canonical worked examples.
+- [`result-union-errors-as-data.md`](result-union-errors-as-data.md) — pattern reference; `createCard` is the canonical worked example; `updateRole` is a second precedent that follows the same shape.
 - [`.claude/rules/error-wrapping.md` § "Errors as data — detailed cases"](../../../.claude/rules/error-wrapping.md#errors-as-data--detailed-cases-on-demand) — rule layer this doc supports.
 - [`.claude/rules/scope-discipline.md`](../../../.claude/rules/scope-discipline.md) — allowlist-as-baseline rationale; per-mutation promotion as opportunistic follow-up.

--- a/docs/backend/error-wrapping/outcome-union-enforcement.md
+++ b/docs/backend/error-wrapping/outcome-union-enforcement.md
@@ -155,6 +155,22 @@ comment explaining why. File a follow-up issue to investigate whether the
 emission is intentional or a refactor leak; link the issue in the comment.
 Never leave an unexplained allowlist entry.
 
+### Allowlist rot detection is informational, not exit-code-affecting
+
+When an allowlist entry no longer corresponds to a bare-emit mutation — because
+the mutation was promoted to a union, deleted, renamed, or its usecase stopped
+emitting typed errors — the lint prints `allowlist-rot: <mutation> is allowlisted
+but no longer violates; remove from allowlist.txt` to stderr. **The rot check is
+deliberately informational and does not affect the exit code.** A rotted entry
+is harmless to enforcement (it forgives a violation that no longer exists), so
+treating it as a hard CI failure would block unrelated PRs over a cleanup task.
+Maintainers periodically delete rotted entries; the stderr noise is the prompt,
+not a blocker. The implementation in `backend/cmd/schema-lint/main.go` prints
+the rot warnings before the violation check and continues regardless. If a
+future change wants to enforce zero rot in CI, that is a separate flag — do
+not flip the existing behavior, because pre-existing rot blocks the next
+unrelated PR until it is cleaned up.
+
 ## Back-links
 
 - [`result-union-errors-as-data.md`](result-union-errors-as-data.md) — pattern reference; `createCard` is the canonical worked example; `updateRole` is a second precedent that follows the same shape.

--- a/docs/backend/error-wrapping/outcome-union-enforcement.md
+++ b/docs/backend/error-wrapping/outcome-union-enforcement.md
@@ -140,11 +140,11 @@ any real violation analysis runs.
 ### Adding a new `ucerr.*` constructor
 
 If a new constructor is added to `backend/internal/usecase/ucerr/` (e.g.
-`ucerr.NewConflictError`), extend `backend/cmd/schema-lint/usecasewalk.go`'s
-string-match list with the new constructor name and add a fixture test in
-`backend/cmd/schema-lint/testdata/` to cover the true and false cases. The
-fixture test runs without access to the project-wide source tree; keep it
-self-contained.
+`ucerr.NewConflictError`), extend the constructor switch in
+`methodEmitsTypedError` (`backend/cmd/schema-lint/usecasewalk.go`) with one
+new case and add a fixture test in `backend/cmd/schema-lint/testdata/` to cover
+the true and false cases. The fixture test runs without access to the
+project-wide source tree; keep it self-contained.
 
 ### False-positive recovery
 

--- a/docs/backend/error-wrapping/result-union-errors-as-data.md
+++ b/docs/backend/error-wrapping/result-union-errors-as-data.md
@@ -151,3 +151,23 @@ type safety those helpers tried to recover by hand.
 Prefer Result Union when the variant set is small and schema-driven. Fall back
 to `BadUserInputWithExtensions` when a full union type would be disproportionate
 (e.g. a single optional extra field on an otherwise uniform validation error).
+
+## Enforcement
+
+The outcome-union pattern is enforced by a Go lint program at
+`backend/cmd/schema-lint/` that runs as part of the CI backend workflow. The
+lint flags any mutation whose return type is a bare object (not wrapped in a
+union) while its backing usecase method emits at least one typed `ucerr.*`
+variant (`ucerr.NewValidationError`, `ucerr.NewForbiddenError`, or
+`ucerr.ErrUnauthenticated`).
+
+An allowlist at `backend/cmd/schema-lint/allowlist.txt` freezes the existing 17
+bare-emit mutations so the gate ships without a bulk migration; any new mutation
+that matches both conditions fails CI immediately. `createCard` and `updateRole`
+are the two canonical precedents that have been promoted to the full outcome-union
+shape — both follow the same XOR-invariant outcome struct pattern described
+above, where exactly one pointer field in the outcome struct is non-nil per
+returned result.
+
+See [outcome-union-enforcement.md](outcome-union-enforcement.md) for the full
+promotion checklist and lint internals.

--- a/docs/backend/error-wrapping/result-union-errors-as-data.md
+++ b/docs/backend/error-wrapping/result-union-errors-as-data.md
@@ -20,9 +20,9 @@ produces typed variants the client can switch on safely.
 
 ## Schema-side conventions
 
-Declare the error type with `implements UserError` (the existing schema interface
-at `schema/schema.graphql:316`) so all business-error types share a `message:
-String!` field:
+Declare the error type with `implements UserError` (the existing `UserError`
+interface declared in `schema/schema.graphql`) so all business-error types
+share a `message: String!` field:
 
 ```graphql
 interface UserError {
@@ -161,13 +161,13 @@ union) while its backing usecase method emits at least one typed `ucerr.*`
 variant (`ucerr.NewValidationError`, `ucerr.NewForbiddenError`, or
 `ucerr.ErrUnauthenticated`).
 
-An allowlist at `backend/cmd/schema-lint/allowlist.txt` freezes the existing 17
-bare-emit mutations so the gate ships without a bulk migration; any new mutation
-that matches both conditions fails CI immediately. `createCard` and `updateRole`
-are the two canonical precedents that have been promoted to the full outcome-union
-shape — both follow the same XOR-invariant outcome struct pattern described
-above, where exactly one pointer field in the outcome struct is non-nil per
-returned result.
+An allowlist at `backend/cmd/schema-lint/allowlist.txt` freezes the
+pre-existing bare-emit mutations so the gate ships without a bulk migration;
+any new mutation that matches both conditions fails CI immediately. `createCard`
+is the canonical worked example that has been promoted to the full outcome-union
+shape; `updateRole` is a second precedent that follows the same XOR-invariant
+outcome struct pattern, where exactly one pointer field in the outcome struct is
+non-nil per returned result.
 
 See [outcome-union-enforcement.md](outcome-union-enforcement.md) for the full
 promotion checklist and lint internals.

--- a/docs/backend/library-gotchas/ci-bash-rc-capture-under-set-e.md
+++ b/docs/backend/library-gotchas/ci-bash-rc-capture-under-set-e.md
@@ -1,0 +1,31 @@
+# CI bash `rc=$?` is dead code under `set -e` — use `cmd || rc=$?`
+
+> Part of the [Go library gotchas](../../../.claude/rules/go-library-gotchas.md) rules.
+
+GitHub Actions runs `run:` blocks under the default shell `bash --noprofile --norc -eo pipefail {0}`. The `-e` flag aborts the script on the first non-zero exit, *before* the next line runs. A common pattern lifted from non-CI shell scripts therefore behaves wrong in CI:
+
+```bash
+# BROKEN under `set -e`: the script never reaches the `if`.
+go run ./cmd/schema-lint
+rc=$?
+if [ "$rc" -ne 0 ]; then
+  echo "::error::lint failed with exit $rc"
+  exit "$rc"
+fi
+```
+
+When `go run ./cmd/schema-lint` exits non-zero, `set -e` aborts at that line. The next two lines never execute, `rc` is never assigned, and the job fails without the `::error::` annotation the maintainer expected to surface in the CI summary. Worse, if a later refactor inserts a guaranteed-success command between the call and `rc=$?`, the script silently swallows the failure exit code.
+
+**The fix is the tested-compound form `cmd || rc=$?`.** `set -e` is documented to *not* abort when the failing command is the left-hand side of a `||` (or `&&`, or the condition of `if`/`while`/`until`, or a member of a pipeline that is not the last). The branch is reached only when `cmd` fails, so initialize `rc=0` first:
+
+```bash
+# CORRECT: `set -e` skips the abort because `go run` is the LHS of `||`.
+rc=0
+go run ./cmd/schema-lint || rc=$?
+if [ "$rc" -ne 0 ]; then
+  echo "::error::lint failed with exit $rc"
+  exit "$rc"
+fi
+```
+
+**How to apply:** any CI `run:` block that wants to inspect a non-zero exit code from a tool — to emit `::error::` annotations, route to different remediation messages by exit code (e.g. exit 1 = lint violation, exit 2 = config error), or chain conditional cleanup — must use the `|| rc=$?` form. The naked `cmd; rc=$?` pattern is a porting hazard from local shell scripts that ran without `set -e`. The same gotcha applies to any `run:` block in `.github/workflows/*.yml` since the default shell flags are inherited workflow-wide unless explicitly overridden by `shell:` or `defaults.run.shell:`.

--- a/docs/backend/library-gotchas/walker-parser-positive-discovery-guards.md
+++ b/docs/backend/library-gotchas/walker-parser-positive-discovery-guards.md
@@ -1,0 +1,38 @@
+# Walker / parser positive-discovery guards — silent zero disables enforcement
+
+> Part of the [Go library gotchas](../../../.claude/rules/go-library-gotchas.md) rules.
+
+Two libraries used by the `backend/cmd/schema-lint/` program return "silent zero" when their input is missing or degenerate, and either failure mode quietly disables downstream enforcement when the walker is plumbed into a CI gate:
+
+- `go/parser.ParseDir(fset, dir, ...)` returns `(nil, nil)` — empty map, no error — for a directory that does not exist or contains no Go files matching the filter. Callers that range over the result simply produce zero `UsecaseMethod` entries and the classifier reports zero violations.
+- `vektah/gqlparser/v2`'s `schema.Mutation` is `nil` when the parsed schema declares no `type Mutation`. `range mutation.Fields` over a `nil` pointer panics; defensively guarding with `if mutation == nil { return nil, nil }` produces the same silent-zero failure as above.
+
+Both failure modes look like "the lint correctly found nothing to flag" from CI's vantage point. The wrong `-schema=` flag, a truncated file, or a typo in a directory path all produce a green CI run with no signal that the walker never inspected the source it was supposed to inspect.
+
+**The rule:** guard every walker with **positive discovery** — fail loud when the input is missing or degenerate, rather than returning an empty result. The two patterns from `schemawalk.go` and `usecasewalk.go`:
+
+```go
+// schemawalk: an empty Mutation type means the schema was not what we expected.
+if mutation == nil {
+    return nil, eris.New(
+        "schemawalk: schema has no Mutation type " +
+        "(likely wrong schema path or truncated file)",
+    )
+}
+
+// usecasewalk: stat the directory before parser.ParseDir; check for zero packages after.
+if _, err := os.Stat(usecaseDir); err != nil {
+    return nil, eris.Wrap(err, "usecasewalk: usecase dir")
+}
+// ... parser.ParseDir ...
+if len(pkgs) == 0 {
+    return nil, eris.Errorf(
+        "usecasewalk: no Go packages found in %q (likely wrong dir path)",
+        usecaseDir,
+    )
+}
+```
+
+**How to apply:** when adding a new walker that backs a CI gate, ask "what does this return for a missing or empty input?" If the answer is "empty slice, no error", insert a positive-discovery guard that fails fast with an actionable message (mention the wrong-flag / truncated-file hypothesis explicitly — the reader is debugging a CI failure and benefits from the most likely cause being named). The walker's unit tests must include a missing-input case that asserts the error is raised, not absorbed.
+
+The same pattern applies anywhere else a library returns silent zero for a missing input: `os.ReadDir` returns an error and is safe; `filepath.Glob` returns `(nil, nil)` for "no matches" and is **not** safe and must be guarded the same way.

--- a/docs/frontend/rsc-error-handling/apollo-runtime-vs-gqlfetch-error-shape.md
+++ b/docs/frontend/rsc-error-handling/apollo-runtime-vs-gqlfetch-error-shape.md
@@ -1,0 +1,47 @@
+# `isUnauthenticatedGraphQLError` matches gqlFetch — not Apollo Client runtime errors
+
+> Part of the [frontend RSC error handling](../../../.claude/rules/frontend-rsc-error-handling.md) rules.
+
+`isUnauthenticatedGraphQLError` and `isForbiddenGraphQLError` in `frontend/src/lib/apollo/graphql-errors.ts` look like universal helpers but they are not. Each delegates to `parseGqlErrors`, which begins:
+
+```ts
+const prefix = "GraphQL errors: ";
+if (!err.message.startsWith(prefix)) return null;
+const parsed = JSON.parse(err.message.slice(prefix.length));
+```
+
+The `"GraphQL errors: "` prefix is the SSR shape that `gqlFetch` (`frontend/src/lib/apollo/server.ts`) constructs when the GraphQL response carries `errors` and `data == null`. **Apollo Client at runtime does not produce that string.** When a `useMutation` rejection or an in-browser `client.query()` failure surfaces as a `CombinedGraphQLErrors` (or any Apollo error subclass), the typed errors live on `err.graphQLErrors: GraphQLError[]` and the message is the human-readable Apollo aggregate, not the JSON-stringified array. Passing such an error to `isUnauthenticatedGraphQLError` returns `false` — silently — and the typed-error branch never fires.
+
+This divergence is non-obvious because the helper names omit the transport assumption. RSC pages, route handlers, and any code path that consumes `gqlFetch` use the helpers correctly. Client components that consume `useMutation` / `useQuery` results must read `err.graphQLErrors[*].extensions.code` directly.
+
+**How to apply:** in a client component that needs typed-error discrimination after a mutation, lift the extension codes off `err.graphQLErrors` instead of calling the SSR helpers:
+
+```ts
+function liftGraphQLCodes(err: unknown): string[] {
+  if (err == null || typeof err !== "object") return [];
+  const maybe = (err as { graphQLErrors?: unknown }).graphQLErrors;
+  if (!Array.isArray(maybe)) return [];
+  const codes: string[] = [];
+  for (const entry of maybe) {
+    const code = (entry as { extensions?: { code?: unknown } } | null | undefined)
+      ?.extensions?.code;
+    if (typeof code === "string") codes.push(code);
+  }
+  return codes;
+}
+
+const result = await mutate({ variables }).catch((err) => {
+  const codes = liftGraphQLCodes(err);
+  if (codes.includes("UNAUTHENTICATED")) { setAuthBanner("expired"); return null; }
+  if (codes.includes("FORBIDDEN"))       { setAuthBanner("forbidden"); return null; }
+  // safe to log: codes is a fixed enum; err.message may echo user input.
+  console.warn("[scope] mutation rejected", { codes });
+  return null;
+});
+```
+
+The `codes` payload is safe to log; the raw `err.message` may carry user-supplied content echoed by the backend (see [`redact-err-message-from-console-payloads.md`](redact-err-message-from-console-payloads.md)) and must stay out of the structured payload.
+
+Reference: the `liftGraphQLCodes` helper in `frontend/src/app/admin/roles/[id]/edit/edit-role-client.tsx` is the canonical worked example. Its top-of-file comment ("We deliberately do not reuse `parseGqlErrors` here") exists specifically to flag this divergence for the next reader.
+
+Related: [`Use CombinedGraphQLErrors.is(err)`](combinedgraphqlerrors-is-over-instanceof.md) covers a different concern — realm-safe detection of `CombinedGraphQLErrors`. This rule is about extension-code extraction, which works regardless of whether the runtime error is a `CombinedGraphQLErrors` or any other Error whose shape exposes `graphQLErrors`.

--- a/frontend/src/app/admin/roles/[id]/edit/edit-role-client.test.tsx
+++ b/frontend/src/app/admin/roles/[id]/edit/edit-role-client.test.tsx
@@ -36,7 +36,7 @@ describe("EditRoleClient", () => {
     expect(screen.getByRole("link", { name: /cancel/i })).toHaveAttribute("href", "/admin/roles");
   });
 
-  it("submits update mutation and navigates on success", async () => {
+  it("UpdateRoleSuccess response — navigates and refreshes", async () => {
     const user = userEvent.setup();
     mockPush.mockClear();
     mockRefresh.mockClear();
@@ -54,7 +54,10 @@ describe("EditRoleClient", () => {
           mutationCalled();
           return {
             data: {
-              updateRole: { __typename: "Role" as const, id: CUSTOM_ROLE.id, name: "reviewer" },
+              updateRole: {
+                __typename: "UpdateRoleSuccess" as const,
+                role: { __typename: "Role" as const, id: CUSTOM_ROLE.id, name: "reviewer" },
+              },
             },
           };
         },
@@ -77,6 +80,52 @@ describe("EditRoleClient", () => {
     });
     expect(mockPush).toHaveBeenCalledWith("/admin/roles");
     expect(mockRefresh).toHaveBeenCalledOnce();
+  });
+
+  it("CannotModifySystemRoleError response — shows banner, no navigation, no cache mutation", async () => {
+    const user = userEvent.setup();
+    mockPush.mockClear();
+    mockRefresh.mockClear();
+
+    const mocks = [
+      {
+        request: {
+          query: AdminUpdateRoleDocument,
+          variables: { id: CUSTOM_ROLE.id, name: "reviewer" },
+        },
+        result: () => ({
+          data: {
+            updateRole: {
+              __typename: "CannotModifySystemRoleError" as const,
+              message: 'cannot rename system role "admin"',
+              roleId: CUSTOM_ROLE.id,
+              roleName: "admin",
+            },
+          },
+        }),
+      },
+    ];
+
+    render(
+      <MockedProvider mocks={mocks}>
+        <EditRoleClient role={CUSTOM_ROLE} />
+      </MockedProvider>,
+    );
+
+    const input = screen.getByRole("textbox");
+    await user.clear(input);
+    await user.type(input, "Reviewer");
+    await user.click(screen.getByRole("button", { name: /save/i }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("admin-role-edit-system-role-error")).toBeInTheDocument();
+    });
+    expect(screen.getByTestId("admin-role-edit-system-role-error")).toHaveTextContent(
+      'cannot rename system role "admin"',
+    );
+    // No navigation: the error variant is data, not a success.
+    expect(mockPush).not.toHaveBeenCalled();
+    expect(mockRefresh).not.toHaveBeenCalled();
   });
 
   it("renders the system-role banner and disables submit when role is admin", () => {

--- a/frontend/src/app/admin/roles/[id]/edit/edit-role-client.test.tsx
+++ b/frontend/src/app/admin/roles/[id]/edit/edit-role-client.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import { MockedProvider } from "@apollo/client/testing/react";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
@@ -175,9 +175,13 @@ describe("EditRoleClient", () => {
       expect(mockPush).not.toHaveBeenCalled();
       expect(mockRefresh).not.toHaveBeenCalled();
 
-      // No typed-error banner.
+      // No typed-error banner, no auth banner, no unexpected-payload banner.
       expect(
         screen.queryByTestId("admin-role-edit-system-role-error"),
+      ).not.toBeInTheDocument();
+      expect(screen.queryByTestId("admin-role-edit-auth-error")).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId("admin-role-edit-unexpected-payload-error"),
       ).not.toBeInTheDocument();
 
       // Warn payload MUST NOT include err.message — backend messages may echo user input.
@@ -187,10 +191,118 @@ describe("EditRoleClient", () => {
         expect.objectContaining({ message: expect.anything() }),
       );
       // Warn payload MUST include err.name — proves production code logs name, not message.
+      // Per fix I19, it MUST also include a `codes` array (empty for a network-only
+      // failure with no GraphQL errors attached).
       expect(warnSpy).toHaveBeenCalledWith(
         expect.any(String),
-        expect.objectContaining({ name: "Error" }),
+        expect.objectContaining({ name: "Error", codes: [] }),
       );
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("unauthenticated transport rejection — shows login link banner, no navigation", async () => {
+    const user = userEvent.setup();
+    mockPush.mockClear();
+    mockRefresh.mockClear();
+
+    // Match the Apollo runtime shape: an Error with a graphQLErrors array
+    // carrying the extension code. liftGraphQLCodes reads err.graphQLErrors
+    // directly — it does NOT use the "GraphQL errors: " prefix that gqlFetch
+    // produces, which is the SSR-only shape. Using the runtime shape here
+    // ensures the test exercises the production code path for useMutation.
+    const authError = Object.assign(new Error("transport"), {
+      graphQLErrors: [{ extensions: { code: "UNAUTHENTICATED" } }],
+    });
+    const mocks = [
+      {
+        request: {
+          query: AdminUpdateRoleDocument,
+          variables: { id: CUSTOM_ROLE.id, name: "reviewer" },
+        },
+        error: authError,
+      },
+    ];
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      render(
+        <MockedProvider mocks={mocks}>
+          <EditRoleClient role={CUSTOM_ROLE} />
+        </MockedProvider>,
+      );
+
+      const input = screen.getByRole("textbox");
+      await user.clear(input);
+      await user.type(input, "Reviewer");
+      await user.click(screen.getByRole("button", { name: /save/i }));
+
+      await waitFor(() => {
+        expect(screen.getByTestId("admin-role-edit-auth-error")).toBeInTheDocument();
+      });
+
+      const banner = screen.getByTestId("admin-role-edit-auth-error");
+      expect(banner).toHaveTextContent(/session has expired/i);
+      // Banner contains a sign-in link pointing at /login (the next/link mock
+      // renders it as a plain <a>).
+      const signIn = within(banner).getByRole("link", { name: /sign in again/i });
+      expect(signIn).toHaveAttribute("href", "/login");
+
+      // No router navigation: this is a mid-session degraded banner, not a redirect.
+      expect(mockPush).not.toHaveBeenCalled();
+      expect(mockRefresh).not.toHaveBeenCalled();
+      // Generic transport-rejection warn must NOT fire — the auth branch returns early.
+      expect(warnSpy).not.toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("forbidden transport rejection — shows login link banner, no navigation", async () => {
+    const user = userEvent.setup();
+    mockPush.mockClear();
+    mockRefresh.mockClear();
+
+    // Apollo runtime shape — same reasoning as the UNAUTHENTICATED test above.
+    const forbiddenError = Object.assign(new Error("transport"), {
+      graphQLErrors: [{ extensions: { code: "FORBIDDEN" } }],
+    });
+    const mocks = [
+      {
+        request: {
+          query: AdminUpdateRoleDocument,
+          variables: { id: CUSTOM_ROLE.id, name: "reviewer" },
+        },
+        error: forbiddenError,
+      },
+    ];
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      render(
+        <MockedProvider mocks={mocks}>
+          <EditRoleClient role={CUSTOM_ROLE} />
+        </MockedProvider>,
+      );
+
+      const input = screen.getByRole("textbox");
+      await user.clear(input);
+      await user.type(input, "Reviewer");
+      await user.click(screen.getByRole("button", { name: /save/i }));
+
+      await waitFor(() => {
+        expect(screen.getByTestId("admin-role-edit-auth-error")).toBeInTheDocument();
+      });
+
+      const banner = screen.getByTestId("admin-role-edit-auth-error");
+      expect(banner).toHaveTextContent(/do not have permission/i);
+      const signIn = within(banner).getByRole("link", { name: /sign in again/i });
+      expect(signIn).toHaveAttribute("href", "/login");
+
+      expect(mockPush).not.toHaveBeenCalled();
+      expect(mockRefresh).not.toHaveBeenCalled();
+      expect(warnSpy).not.toHaveBeenCalled();
     } finally {
       warnSpy.mockRestore();
     }
@@ -232,11 +344,19 @@ describe("EditRoleClient", () => {
 
       await waitFor(() => expect(warnSpy).toHaveBeenCalled());
 
-      // Degraded banner is shown.
-      expect(screen.getByTestId("admin-role-edit-system-role-error")).toBeInTheDocument();
-      expect(screen.getByTestId("admin-role-edit-system-role-error")).toHaveTextContent(
-        /something went wrong/i,
-      );
+      // Degraded banner is shown on the dedicated unexpected-payload state,
+      // NOT on the typed-error state (which is reserved for
+      // CannotModifySystemRoleError per fix I18).
+      expect(
+        screen.getByTestId("admin-role-edit-unexpected-payload-error"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByTestId("admin-role-edit-unexpected-payload-error"),
+      ).toHaveTextContent(/something went wrong/i);
+      // Typed-error banner MUST NOT fire for an unknown __typename.
+      expect(
+        screen.queryByTestId("admin-role-edit-system-role-error"),
+      ).not.toBeInTheDocument();
 
       // No navigation — this is not a success variant.
       expect(mockPush).not.toHaveBeenCalled();
@@ -284,11 +404,17 @@ describe("EditRoleClient", () => {
 
       await waitFor(() => expect(warnSpy).toHaveBeenCalled());
 
-      // Degraded banner is shown.
-      expect(screen.getByTestId("admin-role-edit-system-role-error")).toBeInTheDocument();
-      expect(screen.getByTestId("admin-role-edit-system-role-error")).toHaveTextContent(
-        /something went wrong/i,
-      );
+      // Degraded banner is shown on the dedicated unexpected-payload state
+      // per fix I18 — typed-error state stays clean.
+      expect(
+        screen.getByTestId("admin-role-edit-unexpected-payload-error"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByTestId("admin-role-edit-unexpected-payload-error"),
+      ).toHaveTextContent(/something went wrong/i);
+      expect(
+        screen.queryByTestId("admin-role-edit-system-role-error"),
+      ).not.toBeInTheDocument();
 
       // No navigation.
       expect(mockPush).not.toHaveBeenCalled();

--- a/frontend/src/app/admin/roles/[id]/edit/edit-role-client.test.tsx
+++ b/frontend/src/app/admin/roles/[id]/edit/edit-role-client.test.tsx
@@ -186,6 +186,119 @@ describe("EditRoleClient", () => {
         expect.anything(),
         expect.objectContaining({ message: expect.anything() }),
       );
+      // Warn payload MUST include err.name — proves production code logs name, not message.
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ name: "Error" }),
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("unexpected __typename — warns and shows degraded banner, no navigation", async () => {
+    const user = userEvent.setup();
+    mockPush.mockClear();
+    mockRefresh.mockClear();
+
+    const mocks = [
+      {
+        request: {
+          query: AdminUpdateRoleDocument,
+          variables: { id: CUSTOM_ROLE.id, name: "reviewer" },
+        },
+        result: () => ({
+          data: {
+            updateRole: {
+              __typename: "FutureVariantClientDidNotKnowAbout",
+            } as never,
+          },
+        }),
+      },
+    ];
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      render(
+        <MockedProvider mocks={mocks}>
+          <EditRoleClient role={CUSTOM_ROLE} />
+        </MockedProvider>,
+      );
+
+      const input = screen.getByRole("textbox");
+      await user.clear(input);
+      await user.type(input, "Reviewer");
+      await user.click(screen.getByRole("button", { name: /save/i }));
+
+      await waitFor(() => expect(warnSpy).toHaveBeenCalled());
+
+      // Degraded banner is shown.
+      expect(screen.getByTestId("admin-role-edit-system-role-error")).toBeInTheDocument();
+      expect(screen.getByTestId("admin-role-edit-system-role-error")).toHaveTextContent(
+        /something went wrong/i,
+      );
+
+      // No navigation — this is not a success variant.
+      expect(mockPush).not.toHaveBeenCalled();
+      expect(mockRefresh).not.toHaveBeenCalled();
+
+      // Warn payload includes the unexpected typename.
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("unexpected updateRole payload"),
+        expect.objectContaining({ typename: "FutureVariantClientDidNotKnowAbout" }),
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("null updateRole payload (partial-response null bubble) — warns and shows banner", async () => {
+    const user = userEvent.setup();
+    mockPush.mockClear();
+    mockRefresh.mockClear();
+
+    const mocks = [
+      {
+        request: {
+          query: AdminUpdateRoleDocument,
+          variables: { id: CUSTOM_ROLE.id, name: "reviewer" },
+        },
+        result: () => ({
+          data: { updateRole: null as never },
+        }),
+      },
+    ];
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      render(
+        <MockedProvider mocks={mocks}>
+          <EditRoleClient role={CUSTOM_ROLE} />
+        </MockedProvider>,
+      );
+
+      const input = screen.getByRole("textbox");
+      await user.clear(input);
+      await user.type(input, "Reviewer");
+      await user.click(screen.getByRole("button", { name: /save/i }));
+
+      await waitFor(() => expect(warnSpy).toHaveBeenCalled());
+
+      // Degraded banner is shown.
+      expect(screen.getByTestId("admin-role-edit-system-role-error")).toBeInTheDocument();
+      expect(screen.getByTestId("admin-role-edit-system-role-error")).toHaveTextContent(
+        /something went wrong/i,
+      );
+
+      // No navigation.
+      expect(mockPush).not.toHaveBeenCalled();
+      expect(mockRefresh).not.toHaveBeenCalled();
+
+      // typename is null in the warn payload for a null bubble.
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("unexpected updateRole payload"),
+        expect.objectContaining({ typename: null }),
+      );
     } finally {
       warnSpy.mockRestore();
     }

--- a/frontend/src/app/admin/roles/[id]/edit/edit-role-client.test.tsx
+++ b/frontend/src/app/admin/roles/[id]/edit/edit-role-client.test.tsx
@@ -176,9 +176,7 @@ describe("EditRoleClient", () => {
       expect(mockRefresh).not.toHaveBeenCalled();
 
       // No typed-error banner, no auth banner, no unexpected-payload banner.
-      expect(
-        screen.queryByTestId("admin-role-edit-system-role-error"),
-      ).not.toBeInTheDocument();
+      expect(screen.queryByTestId("admin-role-edit-system-role-error")).not.toBeInTheDocument();
       expect(screen.queryByTestId("admin-role-edit-auth-error")).not.toBeInTheDocument();
       expect(
         screen.queryByTestId("admin-role-edit-unexpected-payload-error"),
@@ -347,16 +345,12 @@ describe("EditRoleClient", () => {
       // Degraded banner is shown on the dedicated unexpected-payload state,
       // NOT on the typed-error state (which is reserved for
       // CannotModifySystemRoleError per fix I18).
-      expect(
-        screen.getByTestId("admin-role-edit-unexpected-payload-error"),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByTestId("admin-role-edit-unexpected-payload-error"),
-      ).toHaveTextContent(/something went wrong/i);
+      expect(screen.getByTestId("admin-role-edit-unexpected-payload-error")).toBeInTheDocument();
+      expect(screen.getByTestId("admin-role-edit-unexpected-payload-error")).toHaveTextContent(
+        /something went wrong/i,
+      );
       // Typed-error banner MUST NOT fire for an unknown __typename.
-      expect(
-        screen.queryByTestId("admin-role-edit-system-role-error"),
-      ).not.toBeInTheDocument();
+      expect(screen.queryByTestId("admin-role-edit-system-role-error")).not.toBeInTheDocument();
 
       // No navigation — this is not a success variant.
       expect(mockPush).not.toHaveBeenCalled();
@@ -406,15 +400,11 @@ describe("EditRoleClient", () => {
 
       // Degraded banner is shown on the dedicated unexpected-payload state
       // per fix I18 — typed-error state stays clean.
-      expect(
-        screen.getByTestId("admin-role-edit-unexpected-payload-error"),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByTestId("admin-role-edit-unexpected-payload-error"),
-      ).toHaveTextContent(/something went wrong/i);
-      expect(
-        screen.queryByTestId("admin-role-edit-system-role-error"),
-      ).not.toBeInTheDocument();
+      expect(screen.getByTestId("admin-role-edit-unexpected-payload-error")).toBeInTheDocument();
+      expect(screen.getByTestId("admin-role-edit-unexpected-payload-error")).toHaveTextContent(
+        /something went wrong/i,
+      );
+      expect(screen.queryByTestId("admin-role-edit-system-role-error")).not.toBeInTheDocument();
 
       // No navigation.
       expect(mockPush).not.toHaveBeenCalled();

--- a/frontend/src/app/admin/roles/[id]/edit/edit-role-client.test.tsx
+++ b/frontend/src/app/admin/roles/[id]/edit/edit-role-client.test.tsx
@@ -140,6 +140,57 @@ describe("EditRoleClient", () => {
     expect(screen.getByRole("button", { name: /save/i })).toBeDisabled();
   });
 
+  it("transport rejection — no banner, no navigation, console.warn omits err.message", async () => {
+    const user = userEvent.setup();
+    mockPush.mockClear();
+    mockRefresh.mockClear();
+
+    const networkError = new Error("network down");
+    const mocks = [
+      {
+        request: {
+          query: AdminUpdateRoleDocument,
+          variables: { id: CUSTOM_ROLE.id, name: "reviewer" },
+        },
+        error: networkError,
+      },
+    ];
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      render(
+        <MockedProvider mocks={mocks}>
+          <EditRoleClient role={CUSTOM_ROLE} />
+        </MockedProvider>,
+      );
+
+      const input = screen.getByRole("textbox");
+      await user.clear(input);
+      await user.type(input, "Reviewer");
+      await user.click(screen.getByRole("button", { name: /save/i }));
+
+      await waitFor(() => expect(warnSpy).toHaveBeenCalled());
+
+      // No navigation on transport failure.
+      expect(mockPush).not.toHaveBeenCalled();
+      expect(mockRefresh).not.toHaveBeenCalled();
+
+      // No typed-error banner.
+      expect(
+        screen.queryByTestId("admin-role-edit-system-role-error"),
+      ).not.toBeInTheDocument();
+
+      // Warn payload MUST NOT include err.message — backend messages may echo user input.
+      // Per .claude/rules/frontend-rsc-error-handling.md § "Redact err.message from structured console payloads".
+      expect(warnSpy).not.toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ message: expect.anything() }),
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
   it("renders the system-role banner for the general role", () => {
     render(
       <MockedProvider mocks={[]}>

--- a/frontend/src/app/admin/roles/[id]/edit/edit-role-client.tsx
+++ b/frontend/src/app/admin/roles/[id]/edit/edit-role-client.tsx
@@ -14,6 +14,27 @@ type Props = {
   role: RoleForEdit;
 };
 
+// Lift GraphQL extension codes from an arbitrary Apollo / network error for
+// the warn payload. We do NOT trust err.message — backend messages may echo
+// user input — but extensions.code is a fixed enum from the server's
+// resolver layer and safe to log. The shape check is permissive: if the
+// underlying transport surfaces graphQLErrors as a property on the Error,
+// pluck them; otherwise return an empty list. We deliberately do not
+// reuse parseGqlErrors here — that helper is keyed on the literal
+// "GraphQL errors: " message prefix, which not every transport produces.
+function liftGraphQLCodes(err: unknown): string[] {
+  if (err == null || typeof err !== "object") return [];
+  const maybe = (err as { graphQLErrors?: unknown }).graphQLErrors;
+  if (!Array.isArray(maybe)) return [];
+  const codes: string[] = [];
+  for (const entry of maybe) {
+    const code = (entry as { extensions?: { code?: unknown } } | null | undefined)
+      ?.extensions?.code;
+    if (typeof code === "string") codes.push(code);
+  }
+  return codes;
+}
+
 export function EditRoleClient({ role }: Props) {
   const router = useRouter();
   const readOnly = SYSTEM_ROLE_NAMES.has(role.name);
@@ -22,6 +43,20 @@ export function EditRoleClient({ role }: Props) {
   // Cleared on each new submission attempt.
   const [systemRoleError, setSystemRoleError] = useState<string | null>(null);
 
+  // Semantically distinct from systemRoleError: this surfaces a degraded
+  // "Something went wrong" banner when the server returns a __typename the
+  // client was not regenerated against, or null payload from a partial-
+  // response null bubble. Separating these states keeps the typed-error
+  // banner pinned to the actual typed error.
+  const [unexpectedPayloadError, setUnexpectedPayloadError] = useState<string | null>(null);
+
+  // Mid-session auth failures. Cleared on each new submission attempt so a
+  // retry after re-login does not show a stale banner.
+  // Per .claude/rules/frontend-rsc-error-handling.md § "Mid-session
+  // UNAUTHENTICATED in a client component: degraded banner with
+  // <Link href=\"/login\">, not redirect()".
+  const [authError, setAuthError] = useState<"unauthenticated" | "forbidden" | null>(null);
+
   // No optimisticResponse: CannotModifySystemRoleError is a typed union variant
   // and Apollo v3.x does not roll back optimistic writes on typed GraphQL errors
   // — see docs/pagination/drop-optimistic-response-typed-errors.md.
@@ -29,15 +64,28 @@ export function EditRoleClient({ role }: Props) {
 
   async function handleSubmit(values: { name: string }) {
     setSystemRoleError(null);
+    setUnexpectedPayloadError(null);
+    setAuthError(null);
     // Mirror the backend `validateRoleName` normalization — see new-role-client.tsx.
     const name = values.name.trim().toLowerCase();
-    // Mid-session auth failures surface via RoleForm's banner; no redirect, per
-    // .claude/rules/frontend-rsc-error-handling.md § "Mid-session UNAUTHENTICATED in a client component".
+    // Mid-session auth failures surface via a dedicated banner with a
+    // sign-in link; no redirect, per the rule referenced above.
     const result = await updateRole({ variables: { id: role.id, name } }).catch((err) => {
+      const codes = liftGraphQLCodes(err);
+      if (codes.includes("UNAUTHENTICATED")) {
+        setAuthError("unauthenticated");
+        return null;
+      }
+      if (codes.includes("FORBIDDEN")) {
+        setAuthError("forbidden");
+        return null;
+      }
       // err.message is omitted — backend messages may echo user input.
+      // codes is safe to log (fixed enum of GraphQL extension codes).
       console.warn("[admin/roles/:id/edit] updateRole rejected", {
         roleId: role.id,
         name: err instanceof Error ? err.name : "unknown",
+        codes,
       });
       return null;
     });
@@ -59,11 +107,12 @@ export function EditRoleClient({ role }: Props) {
     }
     // Unknown variant: null payload, partial-response null bubble, or a future union
     // variant the client was not regenerated against. Warn loudly and show a degraded
-    // banner — do not silently fall through into success-path code.
+    // banner — do not silently fall through into success-path code. Routed through a
+    // distinct state from setSystemRoleError so the typed-error banner stays semantic.
     console.warn("[admin/roles/:id/edit] unexpected updateRole payload", {
       typename,
     });
-    setSystemRoleError("Something went wrong. Please try again.");
+    setUnexpectedPayloadError("Something went wrong. Please try again.");
   }
 
   return (
@@ -80,6 +129,24 @@ export function EditRoleClient({ role }: Props) {
         </div>
       ) : null}
 
+      {authError ? (
+        <div
+          role="alert"
+          data-testid="admin-role-edit-auth-error"
+          className="mb-4 rounded-md bg-destructive/10 p-3 text-sm text-destructive"
+        >
+          <span>
+            {authError === "unauthenticated"
+              ? "Your session has expired. "
+              : "You do not have permission. "}
+          </span>
+          <Link href="/login" className="underline">
+            Sign in again
+          </Link>
+          .
+        </div>
+      ) : null}
+
       {systemRoleError ? (
         <div
           role="alert"
@@ -87,6 +154,16 @@ export function EditRoleClient({ role }: Props) {
           className="mb-4 rounded-md bg-destructive/10 p-3 text-sm text-destructive"
         >
           {systemRoleError}
+        </div>
+      ) : null}
+
+      {unexpectedPayloadError ? (
+        <div
+          role="alert"
+          data-testid="admin-role-edit-unexpected-payload-error"
+          className="mb-4 rounded-md bg-destructive/10 p-3 text-sm text-destructive"
+        >
+          {unexpectedPayloadError}
         </div>
       ) : null}
 

--- a/frontend/src/app/admin/roles/[id]/edit/edit-role-client.tsx
+++ b/frontend/src/app/admin/roles/[id]/edit/edit-role-client.tsx
@@ -28,8 +28,8 @@ function liftGraphQLCodes(err: unknown): string[] {
   if (!Array.isArray(maybe)) return [];
   const codes: string[] = [];
   for (const entry of maybe) {
-    const code = (entry as { extensions?: { code?: unknown } } | null | undefined)
-      ?.extensions?.code;
+    const code = (entry as { extensions?: { code?: unknown } } | null | undefined)?.extensions
+      ?.code;
     if (typeof code === "string") codes.push(code);
   }
   return codes;

--- a/frontend/src/app/admin/roles/[id]/edit/edit-role-client.tsx
+++ b/frontend/src/app/admin/roles/[id]/edit/edit-role-client.tsx
@@ -43,17 +43,27 @@ export function EditRoleClient({ role }: Props) {
     });
     if (!result) return;
     const payload = result.data?.updateRole;
+    // Capture __typename before the narrowing chain so the else branch can read
+    // it without TypeScript narrowing the type to `never` at that point.
+    const typename = (payload as { __typename?: string } | null | undefined)?.__typename ?? null;
     if (payload?.__typename === "CannotModifySystemRoleError") {
       // Domain invariant: system roles are immutable. Surface as a banner;
       // do not navigate and do not mutate the Apollo cache.
       setSystemRoleError(payload.message);
       return;
     }
-    // payload.__typename === "UpdateRoleSuccess"
     if (payload?.__typename === "UpdateRoleSuccess") {
       router.push("/admin/roles");
       router.refresh();
+      return;
     }
+    // Unknown variant: null payload, partial-response null bubble, or a future union
+    // variant the client was not regenerated against. Warn loudly and show a degraded
+    // banner — do not silently fall through into success-path code.
+    console.warn("[admin/roles/:id/edit] unexpected updateRole payload", {
+      typename,
+    });
+    setSystemRoleError("Something went wrong. Please try again.");
   }
 
   return (

--- a/frontend/src/app/admin/roles/[id]/edit/edit-role-client.tsx
+++ b/frontend/src/app/admin/roles/[id]/edit/edit-role-client.tsx
@@ -3,6 +3,7 @@
 import { useMutation } from "@apollo/client/react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
+import { useState } from "react";
 import { RoleForm } from "@/components/admin/role-form";
 import { Button } from "@/components/ui/button";
 import { AdminUpdateRoleMutation, SYSTEM_ROLE_NAMES } from "../../queries";
@@ -17,24 +18,40 @@ export function EditRoleClient({ role }: Props) {
   const router = useRouter();
   const readOnly = SYSTEM_ROLE_NAMES.has(role.name);
 
-  const [updateRole, { loading, error }] = useMutation(AdminUpdateRoleMutation, {
-    onCompleted(data) {
-      if (!data?.updateRole) return;
-      router.push("/admin/roles");
-      router.refresh();
-    },
-  });
+  // Typed error from the CannotModifySystemRoleError union variant.
+  // Cleared on each new submission attempt.
+  const [systemRoleError, setSystemRoleError] = useState<string | null>(null);
+
+  // No optimisticResponse: CannotModifySystemRoleError is a typed union variant
+  // and Apollo v3.x does not roll back optimistic writes on typed GraphQL errors
+  // — see docs/pagination/drop-optimistic-response-typed-errors.md.
+  const [updateRole, { loading, error }] = useMutation(AdminUpdateRoleMutation);
 
   async function handleSubmit(values: { name: string }) {
+    setSystemRoleError(null);
     // Mirror the backend `validateRoleName` normalization — see new-role-client.tsx.
     const name = values.name.trim().toLowerCase();
-    await updateRole({ variables: { id: role.id, name } }).catch((err) => {
+    const result = await updateRole({ variables: { id: role.id, name } }).catch((err) => {
       // err.message is omitted — backend messages may echo user input.
       console.warn("[admin/roles/:id/edit] updateRole rejected", {
         roleId: role.id,
         name: err instanceof Error ? err.name : "unknown",
       });
+      return null;
     });
+    if (!result) return;
+    const payload = result.data?.updateRole;
+    if (payload?.__typename === "CannotModifySystemRoleError") {
+      // Domain invariant: system roles are immutable. Surface as a banner;
+      // do not navigate and do not mutate the Apollo cache.
+      setSystemRoleError(payload.message);
+      return;
+    }
+    // payload.__typename === "UpdateRoleSuccess"
+    if (payload?.__typename === "UpdateRoleSuccess") {
+      router.push("/admin/roles");
+      router.refresh();
+    }
   }
 
   return (
@@ -48,6 +65,16 @@ export function EditRoleClient({ role }: Props) {
           className="mb-4 rounded-md border border-border bg-muted/30 p-3 text-sm text-muted-foreground"
         >
           This is a system role. Its name cannot be changed.
+        </div>
+      ) : null}
+
+      {systemRoleError ? (
+        <div
+          role="alert"
+          data-testid="admin-role-edit-system-role-error"
+          className="mb-4 rounded-md bg-destructive/10 p-3 text-sm text-destructive"
+        >
+          {systemRoleError}
         </div>
       ) : null}
 

--- a/frontend/src/app/admin/roles/[id]/edit/edit-role-client.tsx
+++ b/frontend/src/app/admin/roles/[id]/edit/edit-role-client.tsx
@@ -31,6 +31,8 @@ export function EditRoleClient({ role }: Props) {
     setSystemRoleError(null);
     // Mirror the backend `validateRoleName` normalization — see new-role-client.tsx.
     const name = values.name.trim().toLowerCase();
+    // Mid-session auth failures surface via RoleForm's banner; no redirect, per
+    // .claude/rules/frontend-rsc-error-handling.md § "Mid-session UNAUTHENTICATED in a client component".
     const result = await updateRole({ variables: { id: role.id, name } }).catch((err) => {
       // err.message is omitted — backend messages may echo user input.
       console.warn("[admin/roles/:id/edit] updateRole rejected", {

--- a/frontend/src/app/admin/roles/[id]/edit/edit-role-client.tsx
+++ b/frontend/src/app/admin/roles/[id]/edit/edit-role-client.tsx
@@ -91,9 +91,7 @@ export function EditRoleClient({ role }: Props) {
     });
     if (!result) return;
     const payload = result.data?.updateRole;
-    // Capture __typename before the narrowing chain so the else branch can read
-    // it without TypeScript narrowing the type to `never` at that point.
-    const typename = (payload as { __typename?: string } | null | undefined)?.__typename ?? null;
+    const typename = payload?.__typename ?? null;
     if (payload?.__typename === "CannotModifySystemRoleError") {
       // Domain invariant: system roles are immutable. Surface as a banner;
       // do not navigate and do not mutate the Apollo cache.

--- a/frontend/src/app/admin/roles/queries.ts
+++ b/frontend/src/app/admin/roles/queries.ts
@@ -25,7 +25,17 @@ export const AdminCreateRoleMutation = graphql(`
 export const AdminUpdateRoleMutation = graphql(`
   mutation AdminUpdateRole($id: ID!, $name: String!) {
     updateRole(id: $id, name: $name) {
-      ...AdminRoleFields
+      __typename
+      ... on UpdateRoleSuccess {
+        role {
+          ...AdminRoleFields
+        }
+      }
+      ... on CannotModifySystemRoleError {
+        message
+        roleId
+        roleName
+      }
     }
   }
 `);

--- a/schema/schema.graphql
+++ b/schema/schema.graphql
@@ -470,8 +470,7 @@ type CannotModifySystemRoleError implements UserError {
 
 """
 Result of `updateRole`. Either the updated role, or a typed
-CannotModifySystemRoleError describing the system-role guard. See
-docs/backend/error-wrapping/result-union-errors-as-data.md.
+CannotModifySystemRoleError describing the system-role guard.
 """
 union UpdateRoleResult = UpdateRoleSuccess | CannotModifySystemRoleError
 
@@ -532,8 +531,8 @@ extend type Mutation {
   """
   Rename a role. System roles are immutable — the call returns
   CannotModifySystemRoleError as a typed union variant in that case.
-  Validation failures (empty name, duplicate name) continue to surface as
-  InputValidationError via extensions.code = "BAD_USER_INPUT".
+  Validation failures (empty name, duplicate name) continue to surface
+  as a top-level GraphQL error with extensions.code = "BAD_USER_INPUT".
   """
   updateRole(id: ID!, name: String!): UpdateRoleResult!
   """Admin-only. Delete a role. The system role "admin" cannot be deleted (FORBIDDEN). Returns true on success."""

--- a/schema/schema.graphql
+++ b/schema/schema.graphql
@@ -449,6 +449,32 @@ type Role {
   name: String!
 }
 
+"""Success result of `updateRole`. Returned when the role rename succeeded."""
+type UpdateRoleSuccess {
+  role: Role!
+}
+
+"""
+Returned by `updateRole` when the target role is a system role
+("admin", "general"). System roles are immutable by domain invariant — the
+backend refuses the rename regardless of caller privilege.
+
+The variant carries the offending role's identity so the client can render
+"system role 'admin' cannot be renamed" without re-fetching.
+"""
+type CannotModifySystemRoleError implements UserError {
+  message: String!
+  roleId: ID!
+  roleName: String!
+}
+
+"""
+Result of `updateRole`. Either the updated role, or a typed
+CannotModifySystemRoleError describing the system-role guard. See
+docs/backend/error-wrapping/result-union-errors-as-data.md.
+"""
+union UpdateRoleResult = UpdateRoleSuccess | CannotModifySystemRoleError
+
 extend type User {
   """Roles assigned to this user. Resolved via the per-request RoleByUserID DataLoader."""
   roles: [Role!]!
@@ -503,8 +529,13 @@ extend type Mutation {
   revokeRole(userId: ID!, roleId: ID!): User!
   """Admin-only. Create a new role. Names are normalized to lowercase. Duplicates are rejected with BAD_USER_INPUT."""
   createRole(name: String!): Role!
-  """Admin-only. Rename a role. The system role "admin" cannot be renamed (FORBIDDEN). Duplicates are rejected with BAD_USER_INPUT."""
-  updateRole(id: ID!, name: String!): Role!
+  """
+  Rename a role. System roles are immutable — the call returns
+  CannotModifySystemRoleError as a typed union variant in that case.
+  Validation failures (empty name, duplicate name) continue to surface as
+  InputValidationError via extensions.code = "BAD_USER_INPUT".
+  """
+  updateRole(id: ID!, name: String!): UpdateRoleResult!
   """Admin-only. Delete a role. The system role "admin" cannot be deleted (FORBIDDEN). Returns true on success."""
   deleteRole(id: ID!): Boolean!
 }


### PR DESCRIPTION
## Summary

Implements schema-lint enforcement for the outcome-union pattern and promotes `updateRole` end-to-end as the first worked example. A new Go program (`backend/cmd/schema-lint/`) detects mutations that return a bare object type while their usecase emits typed `ucerr.*` errors; it runs in CI with an allowlist covering the 9 existing bare-emit mutations so the gate stays green until each is individually promoted.

Closes #163.

## Background / Motivation

- **The outcome-union pattern had no toolchain enforcement.** `CreateCardResult = CreateCardSuccess | CardDuplicateFrontError` was the codebase precedent, but new mutations that returned bare types while emitting typed `ucerr` errors compiled and shipped without a gate. The gap was called out in #158's Out-of-Scope section; this PR is the named follow-up.
- **A Go AST lint fits the rule better than `@graphql-eslint`.** The lint must cross two artifacts — the schema (return type shape) and the usecase source (typed-error call sites) — to avoid false positives on CRUD mutations that have no business-state error path. An `@graphql-eslint` rule sees only the schema side. A small Go program using `vektah/gqlparser` (already a transitive dep via `gqlgen`) covers both.
- **`updateRole` was the clearest pilot.** The system-role guard in `AdminRoleUC.UpdateRole` already returned a `ucerr.ForbiddenError`, making it an exact match for the lint's detection rule. Promoting it provides the migration shape the promotion checklist documents.
- **Exit-code loss under `bash set -e` required an explicit fix.** `go run ./cmd/schema-lint` exits non-zero on violations, but a CI step with `set -eo pipefail` that redirects output through `tee` or pipes loses the exit code. The `|| rc=$?` capture pattern preserves it without disabling `set -e`.

## Changes

### Schema-lint program (`backend/cmd/schema-lint/`)

- `main.go`: orchestrates schema walk → usecase walk → resolver walk → classifier. Accepts `--schema`, `--usecase-dir`, `--resolver`, `--allowlist` flags; exits non-zero on violations or drift (allowlisted mutations that no longer match).
- `schemawalk.go` / `schemawalk_test.go`: parses `schema/schema.graphql` via `vektah/gqlparser` and returns every `Mutation` field whose return type is a bare object (not a union, not a list, not a scalar).
- `usecasewalk.go` / `usecasewalk_test.go`: walks `backend/internal/usecase/*.go` AST, records which usecase method names call `ucerr.NewValidationError`, `ucerr.NewForbiddenError`, or `ucerr.ErrUnauthenticated`. Uses positive-discovery guards so walker stages that find nothing produce a clear error rather than a silent false-negative.
- `resolverwalk.go` / `resolverwalk_test.go`: finds `schema.resolvers.go` → mutation → usecase method binding by identifying `<uc>.<Method>(` patterns on resolver-method bodies.
- `classifier.go` / `classifier_test.go`: joins schema walk, usecase walk, and resolver walk results; checks each bare-type mutation against the allowlist; emits violation or allowlist-drift messages.
- `allowlist.txt`: 9 existing bare-emit mutations exempted until individually promoted.
- `schema_lint_integration_test.go`: integration test against the live schema, usecase tree, and resolver to confirm 0 violations and 0 drifts.
- `testdata/`: per-walker `.go` and `.graphql` fixtures covering positive and negative cases.
- `README.md`: operation, flag reference, and promotion checklist.

### Schema — `UpdateRoleResult` union

- `schema/schema.graphql`: adds `UpdateRoleSuccess { role: Role! }`, `CannotModifySystemRoleError implements UserError { message: String! }`, and `union UpdateRoleResult = UpdateRoleSuccess | CannotModifySystemRoleError`. Changes `updateRole` return from `Role!` to `UpdateRoleResult!`. Updates the gqlgen model directives accordingly.

### Usecase — system-role guard becomes data, not error

- `backend/internal/usecase/admin_role.go`: `UpdateRole` returns `(UpdateRoleResult, error)` where `UpdateRoleResult` is an XOR-invariant outcome struct. The system-role guard returns a `CannotModifySystemRoleError` data variant instead of a `ucerr.ForbiddenError` transport error.
- `backend/internal/usecase/admin_role_test.go`: extends table to cover the `CannotModifySystemRoleError` path.

### Resolver + resolver tests

- `backend/graph/resolver/schema.resolvers.go`: `updateRole` resolver branches on the outcome struct and maps to `model.UpdateRoleSuccess` or `model.CannotModifySystemRoleError`.
- `backend/graph/resolver/admin_role_resolver_test.go`: updates stub and assertions for the new union shape.

### Frontend — `edit-role-client.tsx` and queries

- `frontend/src/app/admin/roles/queries.ts`: updates `UPDATE_ROLE_MUTATION` to select `__typename ... on UpdateRoleSuccess { role { ... } } ... on CannotModifySystemRoleError { message }`.
- `frontend/src/app/admin/roles/[id]/edit/edit-role-client.tsx`: adds `__typename` dispatch for the union; renders a degraded banner for `CannotModifySystemRoleError` instead of throwing; handles transport-rejection (`gqlFetch` throws) and unknown payload shapes separately.
- `frontend/src/app/admin/roles/[id]/edit/edit-role-client.test.tsx`: adds coverage for the `CannotModifySystemRoleError` path, the transport-rejection path, and the unknown-payload warn path.

### CI

- `.github/workflows/backend.yml`: new `Schema-lint outcome-union enforcement` step using `|| rc=$?` exit-code capture, runs on `schema/**` and `backend/internal/usecase/**` path filters.

### Docs

- `docs/backend/error-wrapping/outcome-union-enforcement.md` (new): promotion checklist (6-step schema → usecase → resolver → frontend → schema-lint) with mutation-to-usecase naming convention.
- `docs/backend/error-wrapping/result-union-errors-as-data.md`: updated to reference the new enforcement mechanism.
- `docs/backend/library-gotchas/ci-bash-rc-capture-under-set-e.md` (new): `|| rc=$?` pattern for preserving exit codes under `set -eo pipefail`.
- `docs/backend/library-gotchas/walker-parser-positive-discovery-guards.md` (new): AST walker stages must assert they found at least one target; silent empty results are silent false-negatives.
- `docs/frontend/rsc-error-handling/apollo-runtime-vs-gqlfetch-error-shape.md` (new): `gqlFetch` throws a stringified `json.errors` array; Apollo runtime wraps errors differently — never assume the two shapes are identical.
- `.claude/rules/error-wrapping.md`, `.claude/rules/go-library-gotchas.md`, `.claude/rules/frontend-rsc-error-handling.md`: index entries for the new on-demand docs.

## Verification

```bash
cd backend
go vet ./...
go build ./...
go test -race -count=1 ./...

# Schema-lint exits 0 on this branch (0 violations, 0 drifts).
go run ./cmd/schema-lint

# Language-policy and PR-order checks (per .claude/rules/language-policy.md).
grep -rlP "[\x{3040}-\x{30ff}\x{4e00}-\x{9fff}]" \
  --include="*.go" --include="*.ts" --include="*.tsx" \
  --include="*.graphql" --include="*.sql" --include="*.md" \
  docs backend/internal backend/cmd backend/graph frontend/src
grep -rnE "PR[0-9]+" docs backend/internal backend/cmd backend/graph frontend/src
# Expect: empty output for both.

cd ..
pnpm --filter frontend typecheck
pnpm --filter frontend test --run
```

## Test plan

- [x] `go vet ./... && go build ./... && go test -race -count=1 ./...` passes in `backend/` — 23 packages, 1096 tests.
- [x] `go run ./cmd/schema-lint` exits 0 — 0 violations, 0 drifts.
- [x] `pnpm --filter frontend typecheck` clean.
- [x] `pnpm --filter frontend test --run` — 84 files, 731 tests pass.
- [x] CI exit-code preservation verified locally: `bash -c 'set -eo pipefail; rc=0; bash -c "exit 7" || rc=$?; echo "rc=$rc"'` prints `rc=7`.
- [ ] CI: `Schema-lint outcome-union enforcement` step green on this PR.
- [ ] Regression: adding a new mutation returning a bare type with a `ucerr.NewValidationError` call site trips the schema-lint on a throwaway branch.
- [ ] Regression: removing a mutation from `allowlist.txt` that still returns a bare type trips the drift check.
- [ ] Language-policy and PR-order greps from `.claude/rules/language-policy.md` print nothing.
