### PR TITLE
refactor(#161): inject *slog.Logger into usecase layer constructors

### DIFF
--- a/.claude/rules/error-wrapping.md
+++ b/.claude/rules/error-wrapping.md
@@ -64,6 +64,7 @@ detection is grep-based today and pinned at single-file
 - [Test the `error_chain` shape, not just its presence](../../docs/backend/error-wrapping/test-error-chain-shape-not-presence.md)
 - [Assert PII absence on log lines that carry `user_id`](../../docs/backend/error-wrapping/assert-pii-absence-on-log-lines.md)
 - [Log a structured event when a batch item fails and earlier work will be dropped](../../docs/backend/error-wrapping/log-structured-event-when-batch-item-fails.md)
+- [Logger DI in the usecase layer: `uc.logger`, never bare `slog.*`](../../docs/backend/error-wrapping/logging-error-warn-helpers.md#usecase-layer-logger-dependency-injection)
 
 ## Errors as data — detailed cases (on-demand)
 

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -260,15 +260,15 @@ func run(ctx context.Context, logger *slog.Logger) error {
 		return err
 	}
 
-	userUC := usecase.NewUserUsecase(userRepo)
-	cardgroupUC := usecase.NewCardgroupUsecase(cardgroupRepo)
-	cardUC := usecase.NewCardUsecase(db.GORM, cardRepo, cardgroupRepo, userCardFSRSRepo)
-	learnUC := usecase.NewLearnUsecase(cardRepo, cardgroupRepo, service.NewOrderingPolicy(), nil, 0, 0)
-	swipeUC := usecase.NewSwipeUsecase(db.GORM, cardRepo, cardgroupRepo, swipeRecordRepo, service.NewFSRSScheduler(), usecase.SwipeNextBatchSize(logger), userCardFSRSRepo)
-	dictionaryUC := usecase.NewDictionaryUsecase(authSvc, cardRepo, db.GORM)
-	adminUserUC := usecase.NewAdminUser(userRepo, roleRepo, authSvc)
-	adminRoleUC := usecase.NewAdminRole(roleRepo, authSvc)
-	lastViewedCardgroupUC := usecase.NewLastViewedCardgroup(userPreferenceRepo, userRepo)
+	userUC := usecase.NewUserUsecase(userRepo, logger)
+	cardgroupUC := usecase.NewCardgroupUsecase(cardgroupRepo, logger)
+	cardUC := usecase.NewCardUsecase(db.GORM, cardRepo, cardgroupRepo, userCardFSRSRepo, logger)
+	learnUC := usecase.NewLearnUsecase(cardRepo, cardgroupRepo, service.NewOrderingPolicy(), nil, 0, 0, logger)
+	swipeUC := usecase.NewSwipeUsecase(db.GORM, cardRepo, cardgroupRepo, swipeRecordRepo, service.NewFSRSScheduler(), usecase.SwipeNextBatchSize(logger), userCardFSRSRepo, logger)
+	dictionaryUC := usecase.NewDictionaryUsecase(authSvc, cardRepo, db.GORM, logger)
+	adminUserUC := usecase.NewAdminUser(userRepo, roleRepo, authSvc, logger)
+	adminRoleUC := usecase.NewAdminRole(roleRepo, authSvc, logger)
+	lastViewedCardgroupUC := usecase.NewLastViewedCardgroup(userPreferenceRepo, userRepo, logger)
 	pingHandler := ping.New(pingRecordRepo, pingToken)
 	var notionSyncHandler *notionsync.Handler
 	if !notionSyncDisabled {

--- a/backend/cmd/server/main_test.go
+++ b/backend/cmd/server/main_test.go
@@ -555,7 +555,7 @@ func newGraphQLTestServerWithUserRepo(t *testing.T, f *jwtFixture, userRepo repo
 	cardRepo := repository.NewCardRepository(db.GORM)
 	userCardFSRSRepo := repository.NewUserCardFSRSRepository(db.GORM)
 	swipeRecordRepo := repository.NewSwipeRecordRepository(db.GORM)
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger := slog.New(slog.DiscardHandler)
 	userUC := usecase.NewUserUsecase(userRepo, logger)
 	cardgroupUC := usecase.NewCardgroupUsecase(cardgroupRepo, logger)
 	cardUC := usecase.NewCardUsecase(db.GORM, cardRepo, cardgroupRepo, userCardFSRSRepo, logger)
@@ -1649,7 +1649,7 @@ func newLastViewedGraphQLTestServer(t *testing.T, f *jwtFixture) (*httptest.Serv
 	userCardFSRSRepo := repository.NewUserCardFSRSRepository(db.GORM)
 	swipeRecordRepo := repository.NewSwipeRecordRepository(db.GORM)
 	userPreferenceRepo := repository.NewUserPreferenceRepository(db.GORM)
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger := slog.New(slog.DiscardHandler)
 	userUC := usecase.NewUserUsecase(userRepo, logger)
 	cardgroupUC := usecase.NewCardgroupUsecase(cardgroupRepo, logger)
 	cardUC := usecase.NewCardUsecase(db.GORM, cardRepo, cardgroupRepo, userCardFSRSRepo, logger)
@@ -1988,7 +1988,7 @@ func TestHandleSwipe_RollsBackWhenSwipeRecordInsertFails(t *testing.T) {
 	cardRepo := repository.NewCardRepository(db.GORM)
 	cardgroupRepo := repository.NewCardgroupRepository(db.GORM)
 	userCardFSRSRepo := repository.NewUserCardFSRSRepository(db.GORM)
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger := slog.New(slog.DiscardHandler)
 	uc := usecase.NewSwipeUsecase(
 		db.GORM,
 		cardRepo,

--- a/backend/cmd/server/main_test.go
+++ b/backend/cmd/server/main_test.go
@@ -555,10 +555,11 @@ func newGraphQLTestServerWithUserRepo(t *testing.T, f *jwtFixture, userRepo repo
 	cardRepo := repository.NewCardRepository(db.GORM)
 	userCardFSRSRepo := repository.NewUserCardFSRSRepository(db.GORM)
 	swipeRecordRepo := repository.NewSwipeRecordRepository(db.GORM)
-	userUC := usecase.NewUserUsecase(userRepo)
-	cardgroupUC := usecase.NewCardgroupUsecase(cardgroupRepo)
-	cardUC := usecase.NewCardUsecase(db.GORM, cardRepo, cardgroupRepo, userCardFSRSRepo)
-	swipeUC := usecase.NewSwipeUsecase(db.GORM, cardRepo, cardgroupRepo, swipeRecordRepo, service.NewFSRSScheduler(), 10, userCardFSRSRepo)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	userUC := usecase.NewUserUsecase(userRepo, logger)
+	cardgroupUC := usecase.NewCardgroupUsecase(cardgroupRepo, logger)
+	cardUC := usecase.NewCardUsecase(db.GORM, cardRepo, cardgroupRepo, userCardFSRSRepo, logger)
+	swipeUC := usecase.NewSwipeUsecase(db.GORM, cardRepo, cardgroupRepo, swipeRecordRepo, service.NewFSRSScheduler(), 10, userCardFSRSRepo, logger)
 	pingRecordRepo := repository.NewPingRecordRepository(db.GORM)
 	userPreferenceRepo := repository.NewUserPreferenceRepository(db.GORM)
 	e := newRouter(resolver.NewResolver(userUC, cardgroupUC, cardUC, swipeUC, nil, nil, nil, nil, nil, nil), mw, auth.NewSuperUserPromoter(nil, "", nil, nil), userRepo, roleRepo, cardgroupRepo, cardRepo, userPreferenceRepo, userCardFSRSRepo, ping.New(pingRecordRepo, "test-token"), nil, swipeRecordRepo)
@@ -1648,11 +1649,12 @@ func newLastViewedGraphQLTestServer(t *testing.T, f *jwtFixture) (*httptest.Serv
 	userCardFSRSRepo := repository.NewUserCardFSRSRepository(db.GORM)
 	swipeRecordRepo := repository.NewSwipeRecordRepository(db.GORM)
 	userPreferenceRepo := repository.NewUserPreferenceRepository(db.GORM)
-	userUC := usecase.NewUserUsecase(userRepo)
-	cardgroupUC := usecase.NewCardgroupUsecase(cardgroupRepo)
-	cardUC := usecase.NewCardUsecase(db.GORM, cardRepo, cardgroupRepo, userCardFSRSRepo)
-	swipeUC := usecase.NewSwipeUsecase(db.GORM, cardRepo, cardgroupRepo, swipeRecordRepo, service.NewFSRSScheduler(), 10, userCardFSRSRepo)
-	lastViewedUC := usecase.NewLastViewedCardgroup(userPreferenceRepo, userRepo)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	userUC := usecase.NewUserUsecase(userRepo, logger)
+	cardgroupUC := usecase.NewCardgroupUsecase(cardgroupRepo, logger)
+	cardUC := usecase.NewCardUsecase(db.GORM, cardRepo, cardgroupRepo, userCardFSRSRepo, logger)
+	swipeUC := usecase.NewSwipeUsecase(db.GORM, cardRepo, cardgroupRepo, swipeRecordRepo, service.NewFSRSScheduler(), 10, userCardFSRSRepo, logger)
+	lastViewedUC := usecase.NewLastViewedCardgroup(userPreferenceRepo, userRepo, logger)
 	pingRecordRepo := repository.NewPingRecordRepository(db.GORM)
 	e := newRouter(
 		resolver.NewResolver(userUC, cardgroupUC, cardUC, swipeUC, nil, nil, nil, nil, lastViewedUC, nil),
@@ -1986,6 +1988,7 @@ func TestHandleSwipe_RollsBackWhenSwipeRecordInsertFails(t *testing.T) {
 	cardRepo := repository.NewCardRepository(db.GORM)
 	cardgroupRepo := repository.NewCardgroupRepository(db.GORM)
 	userCardFSRSRepo := repository.NewUserCardFSRSRepository(db.GORM)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	uc := usecase.NewSwipeUsecase(
 		db.GORM,
 		cardRepo,
@@ -1994,6 +1997,7 @@ func TestHandleSwipe_RollsBackWhenSwipeRecordInsertFails(t *testing.T) {
 		service.NewFSRSScheduler(),
 		10,
 		userCardFSRSRepo,
+		logger,
 	)
 
 	_, err := uc.HandleSwipe(auth.ContextWithUser(ctx, &auth.AuthUser{Sub: sub}), usecase.HandleSwipeInput{

--- a/backend/graph/resolver/admin_user_resolver_test.go
+++ b/backend/graph/resolver/admin_user_resolver_test.go
@@ -470,7 +470,7 @@ func TestAdminUserResolver_Roles_SelfIntrospection_Allowed(t *testing.T) {
 	userMock := &mockUserRepository{
 		findResult: &domain.User{ID: "u-self", DisplayName: &displayName},
 	}
-	uc := usecase.NewUserUsecase(userMock)
+	uc := usecase.NewUserUsecase(userMock, newDiscardLogger())
 	// isAdmin=false models a non-admin caller; the self-introspection branch
 	// must skip the IsAdmin check entirely.
 	roleRepo := &mockUserRoleRepository{isAdmin: false}

--- a/backend/graph/resolver/card_resolvers_test.go
+++ b/backend/graph/resolver/card_resolvers_test.go
@@ -127,7 +127,7 @@ func newCardSrv(
 	cgRepo usecase.CardgroupRepositoryForCard,
 	tx func(context.Context, func(*gorm.DB) error) error,
 ) *handler.Server {
-	cardUC := usecase.NewCardUsecaseWithTx(cardRepo, cgRepo, tx, nil)
+	cardUC := usecase.NewCardUsecaseWithTx(cardRepo, cgRepo, tx, nil, newDiscardLogger())
 	r := resolver.NewResolver(nil, nil, cardUC, nil, nil, nil, nil, nil, nil, nil)
 	srv := handler.New(generated.NewExecutableSchema(generated.Config{Resolvers: r}))
 	srv.AddTransport(transport.POST{})
@@ -142,6 +142,7 @@ func newLearnSrv(cardRepo *cardMockRepo, cgRepo *cardMockCGRepo) *handler.Server
 		func() *rand.Rand { return rand.New(rand.NewSource(1)) },
 		20,
 		100,
+		newDiscardLogger(),
 	)
 	r := resolver.NewResolver(nil, nil, nil, nil, nil, nil, nil, nil, nil, learnUC)
 	srv := handler.New(generated.NewExecutableSchema(generated.Config{Resolvers: r}))
@@ -359,7 +360,7 @@ func TestResolver_CreateCard_DuplicateFront_ReturnsCardDuplicateFrontError(t *te
 // newUpdateCardSrv builds a gqlgen Server backed by a CardUsecase wired with
 // the supplied card repo and cardgroup repo for authorization.
 func newUpdateCardSrv(cardRepo usecase.CardRepository, cgRepo usecase.CardgroupRepositoryForCard) *handler.Server {
-	cardUC := usecase.NewCardUsecaseWithTx(cardRepo, cgRepo, cardFakeTx(), nil)
+	cardUC := usecase.NewCardUsecaseWithTx(cardRepo, cgRepo, cardFakeTx(), nil, newDiscardLogger())
 	r := resolver.NewResolver(nil, nil, cardUC, nil, nil, nil, nil, nil, nil, nil)
 	srv := handler.New(generated.NewExecutableSchema(generated.Config{Resolvers: r}))
 	srv.AddTransport(transport.POST{})

--- a/backend/graph/resolver/cardgroup_resolvers_test.go
+++ b/backend/graph/resolver/cardgroup_resolvers_test.go
@@ -77,7 +77,7 @@ func (m *mockCardgroupRepoForResolver) Delete(_ context.Context, _ string) error
 // newCardgroupSrv builds a gqlgen handler.Server backed by a real
 // CardgroupUsecase wired to the supplied mock repository.
 func newCardgroupSrv(repo usecase.CardgroupRepository) *handler.Server {
-	cgUC := usecase.NewCardgroupUsecase(repo)
+	cgUC := usecase.NewCardgroupUsecase(repo, newDiscardLogger())
 	r := resolver.NewResolver(nil, cgUC, nil, nil, nil, nil, nil, nil, nil, nil)
 	srv := handler.New(generated.NewExecutableSchema(generated.Config{Resolvers: r}))
 	srv.AddTransport(transport.POST{})

--- a/backend/graph/resolver/last_viewed_cardgroup_resolver_test.go
+++ b/backend/graph/resolver/last_viewed_cardgroup_resolver_test.go
@@ -197,7 +197,7 @@ func TestSetLastViewedCardgroup_NilVariant_ReturnsInternal(t *testing.T) {
 // newMeServer builds a gqlgen Server wired to UserUsecase for testing User
 // field resolvers via the me query.
 func newMeServer(userMock *mockUserRepository) *handler.Server {
-	uc := usecase.NewUserUsecase(userMock)
+	uc := usecase.NewUserUsecase(userMock, newDiscardLogger())
 	r := resolver.NewResolver(uc, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	srv := handler.New(generated.NewExecutableSchema(generated.Config{Resolvers: r}))
 	srv.AddTransport(transport.POST{})

--- a/backend/graph/resolver/swipe_resolver_test.go
+++ b/backend/graph/resolver/swipe_resolver_test.go
@@ -111,6 +111,7 @@ func newSwipeSrv(
 		10,  // nextBatchSize
 		swipeFakeTx(),
 		userFSRSRepo,
+		newDiscardLogger(),
 	)
 	r := resolver.NewResolver(nil, nil, nil, swipeUC, nil, nil, nil, nil, nil, nil)
 	srv := handler.New(generated.NewExecutableSchema(generated.Config{Resolvers: r}))
@@ -282,6 +283,7 @@ func TestResolver_HandleSwipe_InfrastructureError_ReturnsInternal(t *testing.T) 
 		10,
 		nil, // nil tx runner → INTERNAL
 		&userCardFSRSRepo{},
+		newDiscardLogger(),
 	)
 	r := resolver.NewResolver(nil, nil, nil, swipeUC, nil, nil, nil, nil, nil, nil)
 	srv := handler.New(generated.NewExecutableSchema(generated.Config{Resolvers: r}))

--- a/backend/graph/resolver/test_logger_test.go
+++ b/backend/graph/resolver/test_logger_test.go
@@ -1,12 +1,9 @@
 package resolver_test
 
-import (
-	"io"
-	"log/slog"
-)
+import "log/slog"
 
-// newDiscardLogger returns a *slog.Logger that discards all output. Use it to
-// satisfy usecase constructors that require a non-nil logger in unit tests.
+// newDiscardLogger returns a *slog.Logger backed by slog.DiscardHandler. Use it
+// to satisfy usecase constructors that require a non-nil logger in unit tests.
 func newDiscardLogger() *slog.Logger {
-	return slog.New(slog.NewTextHandler(io.Discard, nil))
+	return slog.New(slog.DiscardHandler)
 }

--- a/backend/graph/resolver/test_logger_test.go
+++ b/backend/graph/resolver/test_logger_test.go
@@ -1,0 +1,12 @@
+package resolver_test
+
+import (
+	"io"
+	"log/slog"
+)
+
+// newDiscardLogger returns a *slog.Logger that discards all output. Use it to
+// satisfy usecase constructors that require a non-nil logger in unit tests.
+func newDiscardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}

--- a/backend/graph/resolver/user_test.go
+++ b/backend/graph/resolver/user_test.go
@@ -43,7 +43,7 @@ func ptr(s string) *string { return &s }
 // newServer builds a gqlgen handler.Server backed by a resolver that uses the
 // given mock repository.
 func newServer(mock *mockUserRepository) *handler.Server {
-	uc := usecase.NewUserUsecase(mock)
+	uc := usecase.NewUserUsecase(mock, newDiscardLogger())
 	r := resolver.NewResolver(uc, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	srv := handler.New(generated.NewExecutableSchema(generated.Config{Resolvers: r}))
 	srv.AddTransport(transport.POST{})

--- a/backend/internal/usecase/admin_role.go
+++ b/backend/internal/usecase/admin_role.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"regexp"
 	"strings"
 
@@ -63,20 +64,27 @@ type adminRoleRepoForCRUD interface {
 }
 
 type adminRoleUsecase struct {
-	roles adminRoleRepoForCRUD
-	auth  AdminChecker
+	roles  adminRoleRepoForCRUD
+	auth   AdminChecker
+	logger *slog.Logger
 }
 
 // NewAdminRole is the production constructor. Tests should prefer
 // NewAdminRoleWithDeps to inject narrow stubs.
-func NewAdminRole(roles repository.RoleRepository, authSvc *auth.Service) AdminRoleUsecase {
-	return &adminRoleUsecase{roles: roles, auth: authSvc}
+func NewAdminRole(roles repository.RoleRepository, authSvc *auth.Service, logger *slog.Logger) AdminRoleUsecase {
+	if logger == nil {
+		panic("usecase: admin role: logger is required")
+	}
+	return &adminRoleUsecase{roles: roles, auth: authSvc, logger: logger}
 }
 
 // NewAdminRoleWithDeps accepts narrow interface types for tests; production
 // code must use NewAdminRole.
-func NewAdminRoleWithDeps(roles adminRoleRepoForCRUD, authSvc AdminChecker) AdminRoleUsecase {
-	return &adminRoleUsecase{roles: roles, auth: authSvc}
+func NewAdminRoleWithDeps(roles adminRoleRepoForCRUD, authSvc AdminChecker, logger *slog.Logger) AdminRoleUsecase {
+	if logger == nil {
+		panic("usecase: admin role: logger is required")
+	}
+	return &adminRoleUsecase{roles: roles, auth: authSvc, logger: logger}
 }
 
 // requireAdmin centralises the auth gate, mirroring adminUserUsecase.requireAdmin

--- a/backend/internal/usecase/admin_role_test.go
+++ b/backend/internal/usecase/admin_role_test.go
@@ -115,7 +115,7 @@ func buildAdminRoleUC(
 	if authChk == nil {
 		authChk = &adminAuthChecker{}
 	}
-	return NewAdminRoleWithDeps(roles, authChk), roles
+	return NewAdminRoleWithDeps(roles, authChk, newTestLogger()), roles
 }
 
 // ---------------------------------------------------------------------------

--- a/backend/internal/usecase/admin_user.go
+++ b/backend/internal/usecase/admin_user.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
 
 	"github.com/rotisserie/eris"
@@ -162,9 +163,10 @@ type adminRoleRepository interface {
 // adminUserUsecase wires the auth service, the user repository, and the role
 // repository behind the admin-only management API.
 type adminUserUsecase struct {
-	users adminUserRepository
-	roles adminRoleRepository
-	auth  AdminChecker
+	users  adminUserRepository
+	roles  adminRoleRepository
+	auth   AdminChecker
+	logger *slog.Logger
 }
 
 // NewAdminUser constructs an AdminUserUsecase. Pass production
@@ -175,8 +177,12 @@ func NewAdminUser(
 	users repository.UserRepository,
 	roles repository.RoleRepository,
 	authSvc *auth.Service,
+	logger *slog.Logger,
 ) AdminUserUsecase {
-	return &adminUserUsecase{users: users, roles: roles, auth: authSvc}
+	if logger == nil {
+		panic("usecase: admin user: logger is required")
+	}
+	return &adminUserUsecase{users: users, roles: roles, auth: authSvc, logger: logger}
 }
 
 // NewAdminUserWithDeps is the test-time constructor that accepts the narrow
@@ -185,8 +191,12 @@ func NewAdminUserWithDeps(
 	users adminUserRepository,
 	roles adminRoleRepository,
 	authSvc AdminChecker,
+	logger *slog.Logger,
 ) AdminUserUsecase {
-	return &adminUserUsecase{users: users, roles: roles, auth: authSvc}
+	if logger == nil {
+		panic("usecase: admin user: logger is required")
+	}
+	return &adminUserUsecase{users: users, roles: roles, auth: authSvc, logger: logger}
 }
 
 // requireAdmin centralises the auth gate every method shares. It returns the

--- a/backend/internal/usecase/admin_user_test.go
+++ b/backend/internal/usecase/admin_user_test.go
@@ -179,7 +179,7 @@ func buildAdminUC(
 	if authChk == nil {
 		authChk = &adminAuthChecker{}
 	}
-	uc := NewAdminUserWithDeps(users, roles, authChk)
+	uc := NewAdminUserWithDeps(users, roles, authChk, newTestLogger())
 	return uc, users, roles
 }
 

--- a/backend/internal/usecase/card.go
+++ b/backend/internal/usecase/card.go
@@ -71,10 +71,14 @@ type CardUsecase struct {
 	tx            txRunner
 	notionWriter  NotionWritebacker
 	notionPageID  string
+	logger        *slog.Logger
 }
 
-func NewCardUsecase(db *gorm.DB, cardRepo CardRepository, cardgroupRepo CardgroupRepositoryForCard, userCardFSRSRepo UserCardFSRSRepositoryForCard) *CardUsecase {
-	uc := &CardUsecase{cardRepo: cardRepo, cardgroupRepo: cardgroupRepo, userFSRSRepo: userCardFSRSRepo}
+func NewCardUsecase(db *gorm.DB, cardRepo CardRepository, cardgroupRepo CardgroupRepositoryForCard, userCardFSRSRepo UserCardFSRSRepositoryForCard, logger *slog.Logger) *CardUsecase {
+	if logger == nil {
+		panic("usecase: card: logger is required")
+	}
+	uc := &CardUsecase{cardRepo: cardRepo, cardgroupRepo: cardgroupRepo, userFSRSRepo: userCardFSRSRepo, logger: logger}
 	if db != nil {
 		uc.tx = func(ctx context.Context, fn func(tx *gorm.DB) error) error {
 			return db.WithContext(ctx).Transaction(fn)
@@ -91,8 +95,12 @@ func NewCardUsecaseWithTx(
 	cardgroupRepo CardgroupRepositoryForCard,
 	tx func(ctx context.Context, fn func(tx *gorm.DB) error) error,
 	userCardFSRSRepo UserCardFSRSRepositoryForCard,
+	logger *slog.Logger,
 ) *CardUsecase {
-	return &CardUsecase{cardRepo: cardRepo, cardgroupRepo: cardgroupRepo, tx: tx, userFSRSRepo: userCardFSRSRepo}
+	if logger == nil {
+		panic("usecase: card: logger is required")
+	}
+	return &CardUsecase{cardRepo: cardRepo, cardgroupRepo: cardgroupRepo, tx: tx, userFSRSRepo: userCardFSRSRepo, logger: logger}
 }
 
 func (u *CardUsecase) WithNotionWritebacker(w NotionWritebacker, pageID string) *CardUsecase {
@@ -250,7 +258,6 @@ func (u *CardUsecase) Create(ctx context.Context, in CreateCardInput) (CreateCar
 				// between the failed INSERT and this SELECT) or fail for an unrelated DB
 				// reason. Either way, surface as Internal so the client can retry; the
 				// duplicate is recoverable input, but a failed re-lookup is not.
-				// TODO(#161): preserve cardgroup_id attr via logger DI
 				return CreateCardOutcome{}, eris.Wrap(lookupErr, "usecase: lookup duplicate card after 23505")
 			}
 			return CreateCardOutcome{Duplicate: &DuplicateCardInfo{
@@ -264,13 +271,15 @@ func (u *CardUsecase) Create(ctx context.Context, in CreateCardInput) (CreateCar
 		text := card.Front + " " + card.Back
 		cardID := card.ID
 		pageID := u.notionPageID
+		cardgroupID := card.CardgroupID
 		writer := u.notionWriter
+		logger := u.logger
 		go func() {
 			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 			defer cancel()
 			if err := writer.AppendParagraph(ctx, pageID, text); err != nil {
-				slog.WarnContext(ctx, "card create: notion writeback failed",
-					"card_id", cardID, "page_id", pageID, "err", err)
+				logger.WarnContext(ctx, "card create: notion writeback failed",
+					"card_id", cardID, "page_id", pageID, "cardgroup_id", cardgroupID, "err", err)
 			}
 		}()
 	}
@@ -524,7 +533,7 @@ func (u *CardUsecase) resolveCursor(
 	case repository.CardOrderByDue:
 		due := card.CreatedAt
 		if u.userFSRSRepo == nil {
-			slog.WarnContext(ctx, "card: resolveCursor: falling back to createdAt for OrderByDue because userFSRSRepo is nil or not configured")
+			u.logger.WarnContext(ctx, "card: resolveCursor: falling back to createdAt for OrderByDue because userFSRSRepo is nil or not configured")
 		} else if user := auth.UserFrom(ctx); user != nil {
 			byCardID, err := u.userFSRSRepo.FindByUserAndCardIDs(ctx, user.Sub, []string{id})
 			if err != nil {
@@ -613,7 +622,7 @@ func (u *CardUsecase) BulkDelete(ctx context.Context, ids []string) (int64, erro
 		return 0, eris.Wrap(err, "usecase: bulk delete: transaction")
 	}
 	if deleted < int64(len(ids)) {
-		slog.Default().LogAttrs(ctx, slog.LevelInfo, "bulk delete: partial match",
+		u.logger.LogAttrs(ctx, slog.LevelInfo, "bulk delete: partial match",
 			slog.String("user_id", user.Sub),
 			slog.Int("requested", len(ids)),
 			slog.Int64("deleted", deleted),

--- a/backend/internal/usecase/card_bulk_delete_test.go
+++ b/backend/internal/usecase/card_bulk_delete_test.go
@@ -122,10 +122,9 @@ func TestCardUsecase_BulkDelete_SilentlySkipsForeign(t *testing.T) {
 
 // TestCardUsecase_BulkDelete_PartialMatchSucceeds verifies that when the SQL
 // subselect filters out foreign-owned ids (deleted < len(ids)), BulkDelete still
-// succeeds and returns the actual deleted count. The partial-match log line emitted
-// by slog.Default() is observed via the logger; its behavioral effect is pinned
-// by this test and by the existing SilentlySkipsForeign test passing both before
-// and after the log statement was added.
+// succeeds and returns the actual deleted count. The partial-match INFO log line
+// emitted via u.logger.LogAttrs is observed indirectly: the test asserts the return
+// value, and the SilentlySkipsForeign test pins behavior on both sides of the log.
 func TestCardUsecase_BulkDelete_PartialMatchSucceeds(t *testing.T) {
 	t.Parallel()
 	// Repository reports 2 deleted out of 5 requested — simulates the SQL

--- a/backend/internal/usecase/card_bulk_delete_test.go
+++ b/backend/internal/usecase/card_bulk_delete_test.go
@@ -24,7 +24,7 @@ func TestCardUsecase_BulkDelete_EmptyIDs(t *testing.T) {
 	cardRepo := &mockCardRepository{}
 	cgRepo := &mockCardgroupRepoForCard{}
 	tx, calls := fakeTxRunner()
-	uc := &CardUsecase{cardRepo: cardRepo, cardgroupRepo: cgRepo, tx: tx}
+	uc := &CardUsecase{cardRepo: cardRepo, cardgroupRepo: cgRepo, tx: tx, logger: newTestLogger()}
 
 	n, err := uc.BulkDelete(authedCtx("u1"), nil)
 	if err != nil {
@@ -46,7 +46,7 @@ func TestCardUsecase_BulkDelete_Anonymous(t *testing.T) {
 	cardRepo := &mockCardRepository{}
 	cgRepo := &mockCardgroupRepoForCard{}
 	tx, _ := fakeTxRunner()
-	uc := &CardUsecase{cardRepo: cardRepo, cardgroupRepo: cgRepo, tx: tx}
+	uc := &CardUsecase{cardRepo: cardRepo, cardgroupRepo: cgRepo, tx: tx, logger: newTestLogger()}
 
 	_, err := uc.BulkDelete(anonCtx(), []string{"c1", "c2"})
 	assertUnauthenticated(t, err)
@@ -58,7 +58,7 @@ func TestCardUsecase_BulkDelete_Anonymous(t *testing.T) {
 func TestCardUsecase_BulkDelete_AnonymousWithEmptyIDs(t *testing.T) {
 	// Auth check fires before the empty-ids short-circuit.
 	t.Parallel()
-	uc := &CardUsecase{cardRepo: &mockCardRepository{}, cardgroupRepo: &mockCardgroupRepoForCard{}}
+	uc := &CardUsecase{cardRepo: &mockCardRepository{}, cardgroupRepo: &mockCardgroupRepoForCard{}, logger: newTestLogger()}
 	_, err := uc.BulkDelete(anonCtx(), nil)
 	assertUnauthenticated(t, err)
 }
@@ -70,7 +70,7 @@ func TestCardUsecase_BulkDelete_AllOwn(t *testing.T) {
 	}
 	cgRepo := &mockCardgroupRepoForCard{}
 	tx, calls := fakeTxRunner()
-	uc := &CardUsecase{cardRepo: cardRepo, cardgroupRepo: cgRepo, tx: tx}
+	uc := &CardUsecase{cardRepo: cardRepo, cardgroupRepo: cgRepo, tx: tx, logger: newTestLogger()}
 
 	n, err := uc.BulkDelete(authedCtx("u1"), []string{"c1", "c2", "c3"})
 	if err != nil {
@@ -101,7 +101,7 @@ func TestCardUsecase_BulkDelete_SilentlySkipsForeign(t *testing.T) {
 	cardRepo := &mockCardRepository{deleteByIDsResult: 1}
 	cgRepo := &mockCardgroupRepoForCard{}
 	tx, calls := fakeTxRunner()
-	uc := &CardUsecase{cardRepo: cardRepo, cardgroupRepo: cgRepo, tx: tx}
+	uc := &CardUsecase{cardRepo: cardRepo, cardgroupRepo: cgRepo, tx: tx, logger: newTestLogger()}
 
 	n, err := uc.BulkDelete(authedCtx("u1"), []string{"c1", "foreign"})
 	if err != nil {
@@ -133,7 +133,7 @@ func TestCardUsecase_BulkDelete_PartialMatchSucceeds(t *testing.T) {
 	cardRepo := &mockCardRepository{deleteByIDsResult: 2}
 	cgRepo := &mockCardgroupRepoForCard{}
 	tx, calls := fakeTxRunner()
-	uc := &CardUsecase{cardRepo: cardRepo, cardgroupRepo: cgRepo, tx: tx}
+	uc := &CardUsecase{cardRepo: cardRepo, cardgroupRepo: cgRepo, tx: tx, logger: newTestLogger()}
 
 	ids := []string{"own1", "own2", "foreign1", "foreign2", "foreign3"}
 	n, err := uc.BulkDelete(authedCtx("u1"), ids)
@@ -159,7 +159,7 @@ func TestCardUsecase_BulkDelete_RejectsTooManyIDs(t *testing.T) {
 	cardRepo := &mockCardRepository{}
 	cgRepo := &mockCardgroupRepoForCard{}
 	tx, calls := fakeTxRunner()
-	uc := &CardUsecase{cardRepo: cardRepo, cardgroupRepo: cgRepo, tx: tx}
+	uc := &CardUsecase{cardRepo: cardRepo, cardgroupRepo: cgRepo, tx: tx, logger: newTestLogger()}
 
 	_, err := uc.BulkDelete(authedCtx("u1"), ids)
 	assertValidationError(t, err, "ids", "")

--- a/backend/internal/usecase/card_test.go
+++ b/backend/internal/usecase/card_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"sync"
 	"testing"
 	"time"
@@ -966,6 +967,88 @@ func TestCardUsecase_Create_writebackErrorDoesNotAffectOutcome(t *testing.T) {
 	case <-stub.called:
 	case <-time.After(2 * time.Second):
 		t.Fatal("notion writeback goroutine did not fire within timeout")
+	}
+}
+
+// signalWriter wraps a bytes.Buffer and closes done exactly once on the first
+// Write call. This lets us wait until the slog handler has actually flushed a
+// record before inspecting the buffer, which is necessary because the goroutine
+// in card.go calls WarnContext AFTER AppendParagraph returns — so the
+// stubNotionWriter.called channel fires one step too early for log assertions.
+type signalWriter struct {
+	buf  bytes.Buffer
+	done chan struct{}
+	once sync.Once
+}
+
+func (w *signalWriter) Write(p []byte) (int, error) {
+	n, err := w.buf.Write(p)
+	w.once.Do(func() { close(w.done) })
+	return n, err
+}
+
+// TestCardUsecase_Create_writebackErrorLogsCardgroupID pins the structured log
+// record emitted when the notion writeback goroutine fails. It asserts that
+// the "cardgroup_id" attribute is present on the WarnContext line and equals
+// the value captured before the goroutine launched.
+func TestCardUsecase_Create_writebackErrorLogsCardgroupID(t *testing.T) {
+	t.Parallel()
+
+	const wantCardgroupID = "cg-writeback-log-test"
+
+	// signalWriter lets us block until the first JSON record lands in the
+	// buffer, rather than relying on stub.called which fires before WarnContext.
+	sw := &signalWriter{done: make(chan struct{})}
+	logger := slog.New(slog.NewJSONHandler(sw, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	stub := &stubNotionWriter{
+		err:    errors.New("notion: 503 unavailable"),
+		called: make(chan struct{}),
+	}
+	cardRepo := &mockCardRepository{}
+	cgRepo := &mockCardgroupRepoForCard{
+		findResult: &domain.Cardgroup{ID: wantCardgroupID, OwnerID: "u1"},
+	}
+	uc := NewCardUsecase(nil, cardRepo, cgRepo, nil, logger).WithNotionWritebacker(stub, "page-log-test")
+
+	got, err := uc.Create(authedCtx("u1"), CreateCardInput{
+		CardgroupID: wantCardgroupID,
+		Front:       "front",
+		Back:        "back",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error from Create: %v", err)
+	}
+	if got.Card == nil {
+		t.Fatal("expected outcome.Card to be non-nil even when writeback errors")
+	}
+
+	// Block until the first log record lands in the buffer (WarnContext called).
+	select {
+	case <-sw.done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("notion writeback goroutine did not log within timeout")
+	}
+
+	records := decodeJSONRecords(t, sw.buf.Bytes())
+	var warnRec map[string]any
+	for _, rec := range records {
+		if rec["msg"] == "card create: notion writeback failed" {
+			warnRec = rec
+			break
+		}
+	}
+	if warnRec == nil {
+		t.Fatalf("no WarnContext record with msg %q found in log output:\n%s",
+			"card create: notion writeback failed", sw.buf.String())
+	}
+
+	gotCGID, ok := warnRec["cardgroup_id"].(string)
+	if !ok {
+		t.Fatalf("cardgroup_id attr missing or not a string; full record: %v", warnRec)
+	}
+	if gotCGID != wantCardgroupID {
+		t.Fatalf("cardgroup_id = %q, want %q", gotCGID, wantCardgroupID)
 	}
 }
 

--- a/backend/internal/usecase/card_test.go
+++ b/backend/internal/usecase/card_test.go
@@ -227,7 +227,7 @@ func TestCardUsecase_Create(t *testing.T) {
 			t.Parallel()
 			cardRepo := &mockCardRepository{}
 			cgRepo := &mockCardgroupRepoForCard{findResult: tc.cardgroup, findErr: tc.cardgroupErr}
-			uc := NewCardUsecase(nil, cardRepo, cgRepo, nil)
+			uc := NewCardUsecase(nil, cardRepo, cgRepo, nil, newTestLogger())
 
 			got, err := uc.Create(tc.ctx, tc.input)
 
@@ -275,7 +275,7 @@ func TestCardUsecase_Update_NonOwnerAndPatch(t *testing.T) {
 		t.Parallel()
 		uc := NewCardUsecase(nil, &mockCardRepository{findResult: existing},
 			&mockCardgroupRepoForCard{findResult: &domain.Cardgroup{ID: "cg1", OwnerID: "u1"}},
-			nil,
+			nil, newTestLogger(),
 		)
 		_, err := uc.Update(authedCtx("u2"), "card1", UpdateCardInput{Front: ptr("new")})
 		assertUnauthenticated(t, err)
@@ -290,7 +290,7 @@ func TestCardUsecase_Update_NonOwnerAndPatch(t *testing.T) {
 		}
 		uc := NewCardUsecase(nil, cardRepo,
 			&mockCardgroupRepoForCard{findResult: &domain.Cardgroup{ID: "cg1", OwnerID: "u1"}},
-			nil,
+			nil, newTestLogger(),
 		)
 		outcome, err := uc.Update(authedCtx("u1"), "card1", UpdateCardInput{Front: ptr(" new front ")})
 		if err != nil {
@@ -326,7 +326,7 @@ func TestCardUsecase_Update_EmptyFront_ValidationVariant(t *testing.T) {
 	cardRepo := &mockCardRepository{findResult: existing}
 	uc := NewCardUsecase(nil, cardRepo,
 		&mockCardgroupRepoForCard{findResult: &domain.Cardgroup{ID: "cg1", OwnerID: "u1"}},
-		nil,
+		nil, newTestLogger(),
 	)
 
 	outcome, err := uc.Update(authedCtx("u1"), "card1", UpdateCardInput{Front: ptr("")})
@@ -363,7 +363,7 @@ func TestCardUsecase_Update_RepoError_InfraChannel(t *testing.T) {
 	}
 	uc := NewCardUsecase(nil, cardRepo,
 		&mockCardgroupRepoForCard{findResult: &domain.Cardgroup{ID: "cg1", OwnerID: "u1"}},
-		nil,
+		nil, newTestLogger(),
 	)
 
 	_, err := uc.Update(authedCtx("u1"), "card1", UpdateCardInput{Front: ptr("new front")})
@@ -379,7 +379,7 @@ func TestCardUsecase_Delete_NotFoundMasksExistence(t *testing.T) {
 
 	uc := NewCardUsecase(nil, &mockCardRepository{findErr: repository.ErrNotFound},
 		&mockCardgroupRepoForCard{},
-		nil,
+		nil, newTestLogger(),
 	)
 
 	err := uc.Delete(authedCtx("u1"), "missing")
@@ -391,7 +391,7 @@ func TestCardUsecase_Card_NotFoundReturnsNil(t *testing.T) {
 
 	uc := NewCardUsecase(nil, &mockCardRepository{findErr: repository.ErrNotFound},
 		&mockCardgroupRepoForCard{},
-		nil,
+		nil, newTestLogger(),
 	)
 
 	got, err := uc.Card(authedCtx("u1"), "missing")
@@ -408,7 +408,7 @@ func TestCardUsecase_RepoErrorsBecomeInternal(t *testing.T) {
 
 	uc := NewCardUsecase(nil, &mockCardRepository{findErr: errors.New("db died")},
 		&mockCardgroupRepoForCard{},
-		nil,
+		nil, newTestLogger(),
 	)
 	_, err := uc.Card(authedCtx("u1"), "card1")
 	assertInternalChain(t, err, "usecase: card: find by id")
@@ -416,7 +416,7 @@ func TestCardUsecase_RepoErrorsBecomeInternal(t *testing.T) {
 
 func TestCardUsecase_ListCardsByCardgroupConnection_Anonymous(t *testing.T) {
 	t.Parallel()
-	uc := NewCardUsecase(nil, &mockCardRepository{}, &mockCardgroupRepoForCard{}, nil)
+	uc := NewCardUsecase(nil, &mockCardRepository{}, &mockCardgroupRepoForCard{}, nil, newTestLogger())
 	_, err := uc.ListCardsByCardgroupConnection(anonCtx(), CardConnectionInput{CardgroupID: "cg1"})
 	assertUnauthenticated(t, err)
 }
@@ -425,7 +425,7 @@ func TestCardUsecase_ListCardsByCardgroupConnection_NonOwner(t *testing.T) {
 	t.Parallel()
 	uc := NewCardUsecase(nil, &mockCardRepository{},
 		&mockCardgroupRepoForCard{findResult: &domain.Cardgroup{ID: "cg1", OwnerID: "u1"}},
-		nil,
+		nil, newTestLogger(),
 	)
 	_, err := uc.ListCardsByCardgroupConnection(authedCtx("u2"), CardConnectionInput{CardgroupID: "cg1"})
 	assertUnauthenticated(t, err)
@@ -435,7 +435,7 @@ func TestCardUsecase_ListCardsByCardgroupConnection_InvalidOrderBy(t *testing.T)
 	t.Parallel()
 	uc := NewCardUsecase(nil, &mockCardRepository{},
 		&mockCardgroupRepoForCard{findResult: &domain.Cardgroup{ID: "cg1", OwnerID: "u1"}},
-		nil,
+		nil, newTestLogger(),
 	)
 	bad := CardOrderBy("STABILITY")
 	_, err := uc.ListCardsByCardgroupConnection(authedCtx("u1"), CardConnectionInput{
@@ -449,7 +449,7 @@ func TestCardUsecase_ListCardsByCardgroupConnection_BothFirstAndLast(t *testing.
 	t.Parallel()
 	uc := NewCardUsecase(nil, &mockCardRepository{},
 		&mockCardgroupRepoForCard{findResult: &domain.Cardgroup{ID: "cg1", OwnerID: "u1"}},
-		nil,
+		nil, newTestLogger(),
 	)
 	first := 5
 	last := 5
@@ -472,7 +472,7 @@ func TestCardUsecase_ListCardsByCardgroupConnection_DefaultsAndPaging(t *testing
 	cardRepo := &mockCardRepository{findPageRows: rows, findPageTotal: 50}
 	uc := NewCardUsecase(nil, cardRepo,
 		&mockCardgroupRepoForCard{findResult: &domain.Cardgroup{ID: "cg1", OwnerID: "u1"}},
-		nil,
+		nil, newTestLogger(),
 	)
 
 	out, err := uc.ListCardsByCardgroupConnection(authedCtx("u1"), CardConnectionInput{
@@ -528,7 +528,7 @@ func TestCardUsecase_ListCardsByCardgroupConnection_CursorCrossCardgroup(t *test
 		}
 		uc := NewCardUsecase(nil, cardRepo,
 			&mockCardgroupRepoForCard{findResult: &domain.Cardgroup{ID: "cg1", OwnerID: "u1"}},
-			nil,
+			nil, newTestLogger(),
 		)
 		_, err := uc.ListCardsByCardgroupConnection(authedCtx("u1"), CardConnectionInput{
 			CardgroupID: "cg1",
@@ -546,7 +546,7 @@ func TestCardUsecase_ListCardsByCardgroupConnection_CursorCrossCardgroup(t *test
 		}
 		uc := NewCardUsecase(nil, cardRepo,
 			&mockCardgroupRepoForCard{findResult: &domain.Cardgroup{ID: "cg1", OwnerID: "u1"}},
-			nil,
+			nil, newTestLogger(),
 		)
 		_, err := uc.ListCardsByCardgroupConnection(authedCtx("u1"), CardConnectionInput{
 			CardgroupID: "cg1",
@@ -573,7 +573,7 @@ func TestCardUsecase_ListCardsByCardgroupConnection_BackwardPaging(t *testing.T)
 	cardRepo := &mockCardRepository{findPageRows: rows, findPageTotal: 10}
 	uc := NewCardUsecase(nil, cardRepo,
 		&mockCardgroupRepoForCard{findResult: &domain.Cardgroup{ID: "cg1", OwnerID: "u1"}},
-		nil,
+		nil, newTestLogger(),
 	)
 
 	out, err := uc.ListCardsByCardgroupConnection(authedCtx("u1"), CardConnectionInput{
@@ -672,7 +672,7 @@ func TestCardUsecase_ListCardsByCardgroupConnection_ResolveCursorHydratesDueFiel
 			}
 			uc := NewCardUsecase(nil, cardRepo,
 				&mockCardgroupRepoForCard{findResult: &domain.Cardgroup{ID: "cg1", OwnerID: "u1"}},
-				userFSRSRepo,
+				userFSRSRepo, newTestLogger(),
 			)
 			_, err := uc.ListCardsByCardgroupConnection(authedCtx("u1"), CardConnectionInput{
 				CardgroupID: "cg1",
@@ -703,7 +703,7 @@ func TestCardUsecase_ResolveCursor_MalformedV1_ReturnsBadUserInput(t *testing.T)
 
 	uc := NewCardUsecase(nil, &mockCardRepository{},
 		&mockCardgroupRepoForCard{findResult: &domain.Cardgroup{ID: "cg1", OwnerID: "u1"}},
-		nil,
+		nil, newTestLogger(),
 	)
 	malformed := "v1:!!!not-base64!!!"
 	_, err := uc.resolveCursor(
@@ -721,7 +721,7 @@ func TestCardUsecase_ResolveCursor_V1EncodedID(t *testing.T) {
 
 	uc := NewCardUsecase(nil, &mockCardRepository{},
 		&mockCardgroupRepoForCard{findResult: &domain.Cardgroup{ID: "cg1", OwnerID: "u1"}},
-		nil,
+		nil, newTestLogger(),
 	)
 	// "v1:" + base64.RawURLEncoding.EncodeToString([]byte("card-abc")) == "v1:Y2FyZC1hYmM"
 	encoded := "v1:Y2FyZC1hYmM"
@@ -770,7 +770,7 @@ func TestCardUsecase_Create_Duplicate(t *testing.T) {
 		findByCardgroupAndFrontResult: fixture,
 	}
 	cgRepo := &mockCardgroupRepoForCard{findResult: &domain.Cardgroup{ID: "cg1", OwnerID: "u1"}}
-	uc := NewCardUsecase(nil, cardRepo, cgRepo, nil)
+	uc := NewCardUsecase(nil, cardRepo, cgRepo, nil, newTestLogger())
 
 	// Submit with surrounding whitespace to regression-guard the TrimSpace contract.
 	got, err := uc.Create(authedCtx("u1"), CreateCardInput{CardgroupID: "cg1", Front: "  hello  ", Back: "world"})
@@ -815,7 +815,7 @@ func TestCardUsecase_Create_DuplicateLookupRace(t *testing.T) {
 		findByCardgroupAndFrontErr: eris.New("db: connection reset"),
 	}
 	cgRepo := &mockCardgroupRepoForCard{findResult: &domain.Cardgroup{ID: wantCardgroupID, OwnerID: "u1"}}
-	uc := NewCardUsecase(nil, cardRepo, cgRepo, nil)
+	uc := NewCardUsecase(nil, cardRepo, cgRepo, nil, newTestLogger())
 
 	_, err := uc.Create(authedCtx("u1"), CreateCardInput{CardgroupID: wantCardgroupID, Front: "hello", Back: "world"})
 	// Load-bearing: eris.Wrap at the call site must produce a rich chain even for external errors.
@@ -837,7 +837,7 @@ func TestCardUsecase_Create_DuplicateLookupRace_RowVanished(t *testing.T) {
 		findByCardgroupAndFrontErr: repository.ErrNotFound,
 	}
 	cgRepo := &mockCardgroupRepoForCard{findResult: &domain.Cardgroup{ID: wantCardgroupID, OwnerID: "u1"}}
-	uc := NewCardUsecase(nil, cardRepo, cgRepo, nil)
+	uc := NewCardUsecase(nil, cardRepo, cgRepo, nil, newTestLogger())
 
 	_, err := uc.Create(authedCtx("u1"), CreateCardInput{CardgroupID: wantCardgroupID, Front: "hello", Back: "world"})
 	// Load-bearing: eris.Wrap in production must produce a rich chain even when
@@ -873,7 +873,7 @@ func TestCardUsecase_Create_triggersNotionWriteback(t *testing.T) {
 	stub := &stubNotionWriter{called: make(chan struct{})}
 	cardRepo := &mockCardRepository{}
 	cgRepo := &mockCardgroupRepoForCard{findResult: &domain.Cardgroup{ID: "cg1", OwnerID: "u1"}}
-	uc := NewCardUsecase(nil, cardRepo, cgRepo, nil).WithNotionWritebacker(stub, "page-xyz")
+	uc := NewCardUsecase(nil, cardRepo, cgRepo, nil, newTestLogger()).WithNotionWritebacker(stub, "page-xyz")
 
 	got, err := uc.Create(authedCtx("u1"), CreateCardInput{CardgroupID: "cg1", Front: "front", Back: "back"})
 	if err != nil {
@@ -914,7 +914,7 @@ func TestCardUsecase_Create_duplicateDoesNotTriggerWriteback(t *testing.T) {
 		findByCardgroupAndFrontResult: fixture,
 	}
 	cgRepo := &mockCardgroupRepoForCard{findResult: &domain.Cardgroup{ID: "cg1", OwnerID: "u1"}}
-	uc := NewCardUsecase(nil, cardRepo, cgRepo, nil).WithNotionWritebacker(stub, "page-xyz")
+	uc := NewCardUsecase(nil, cardRepo, cgRepo, nil, newTestLogger()).WithNotionWritebacker(stub, "page-xyz")
 
 	got, err := uc.Create(authedCtx("u1"), CreateCardInput{CardgroupID: "cg1", Front: "front", Back: "back"})
 	if err != nil {
@@ -952,7 +952,7 @@ func TestCardUsecase_Create_writebackErrorDoesNotAffectOutcome(t *testing.T) {
 	}
 	cardRepo := &mockCardRepository{}
 	cgRepo := &mockCardgroupRepoForCard{findResult: &domain.Cardgroup{ID: "cg1", OwnerID: "u1"}}
-	uc := NewCardUsecase(nil, cardRepo, cgRepo, nil).WithNotionWritebacker(stub, "page-xyz")
+	uc := NewCardUsecase(nil, cardRepo, cgRepo, nil, newTestLogger()).WithNotionWritebacker(stub, "page-xyz")
 
 	got, err := uc.Create(authedCtx("u1"), CreateCardInput{CardgroupID: "cg1", Front: "front", Back: "back"})
 	if err != nil {
@@ -974,7 +974,7 @@ func TestCardUsecase_Create_noWritebackWhenNotConfigured(t *testing.T) {
 
 	cardRepo := &mockCardRepository{}
 	cgRepo := &mockCardgroupRepoForCard{findResult: &domain.Cardgroup{ID: "cg1", OwnerID: "u1"}}
-	uc := NewCardUsecase(nil, cardRepo, cgRepo, nil)
+	uc := NewCardUsecase(nil, cardRepo, cgRepo, nil, newTestLogger())
 
 	got, err := uc.Create(authedCtx("u1"), CreateCardInput{CardgroupID: "cg1", Front: "front", Back: "back"})
 	if err != nil {
@@ -1038,7 +1038,7 @@ func TestCardUsecase_ListCardsByCardgroupConnection_SearchPassthrough(t *testing
 			cgRepo := &mockCardgroupRepoForCard{
 				findResult: &domain.Cardgroup{ID: "cg1", OwnerID: "u1"},
 			}
-			uc := NewCardUsecase(nil, cardRepo, cgRepo, nil)
+			uc := NewCardUsecase(nil, cardRepo, cgRepo, nil, newTestLogger())
 
 			_, err := uc.ListCardsByCardgroupConnection(authedCtx("u1"), CardConnectionInput{
 				CardgroupID: "cg1",

--- a/backend/internal/usecase/cardgroup.go
+++ b/backend/internal/usecase/cardgroup.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -74,11 +75,17 @@ type CardgroupConnectionOutput struct {
 }
 
 // CardgroupUsecase implements the cardgroup application logic.
-type CardgroupUsecase struct{ repo CardgroupRepository }
+type CardgroupUsecase struct {
+	repo   CardgroupRepository
+	logger *slog.Logger
+}
 
 // NewCardgroupUsecase constructs a CardgroupUsecase backed by the given repository.
-func NewCardgroupUsecase(repo CardgroupRepository) *CardgroupUsecase {
-	return &CardgroupUsecase{repo: repo}
+func NewCardgroupUsecase(repo CardgroupRepository, logger *slog.Logger) *CardgroupUsecase {
+	if logger == nil {
+		panic("usecase: cardgroup: logger is required")
+	}
+	return &CardgroupUsecase{repo: repo, logger: logger}
 }
 
 // Cardgroup returns a single cardgroup by id. Non-owners receive UNAUTHENTICATED

--- a/backend/internal/usecase/cardgroup_test.go
+++ b/backend/internal/usecase/cardgroup_test.go
@@ -135,7 +135,7 @@ func cgAuthedCtx(sub string) context.Context {
 func TestCardgroupUsecase_Cardgroup_Anonymous(t *testing.T) {
 	t.Parallel()
 	repo := &mockCardgroupRepository{}
-	uc := NewCardgroupUsecase(repo)
+	uc := NewCardgroupUsecase(repo, newTestLogger())
 
 	_, err := uc.Cardgroup(anonCtx(), "cg1")
 
@@ -148,7 +148,7 @@ func TestCardgroupUsecase_Cardgroup_Anonymous(t *testing.T) {
 func TestCardgroupUsecase_Cardgroup_NotFound_ReturnsNilNoError(t *testing.T) {
 	t.Parallel()
 	repo := &mockCardgroupRepository{findErr: repository.ErrNotFound}
-	uc := NewCardgroupUsecase(repo)
+	uc := NewCardgroupUsecase(repo, newTestLogger())
 
 	got, err := uc.Cardgroup(cgAuthedCtx("user-1"), "cg-missing")
 
@@ -164,7 +164,7 @@ func TestCardgroupUsecase_Cardgroup_OwnerSeesOwn(t *testing.T) {
 	t.Parallel()
 	cg := &domain.Cardgroup{ID: "cg1", OwnerID: "user-1", Name: "Mine"}
 	repo := &mockCardgroupRepository{findResult: cg}
-	uc := NewCardgroupUsecase(repo)
+	uc := NewCardgroupUsecase(repo, newTestLogger())
 
 	got, err := uc.Cardgroup(cgAuthedCtx("user-1"), "cg1")
 
@@ -180,7 +180,7 @@ func TestCardgroupUsecase_Cardgroup_NonOwnerGetsUnauthenticated(t *testing.T) {
 	t.Parallel()
 	cg := &domain.Cardgroup{ID: "cg1", OwnerID: "user-1", Name: "Mine"}
 	repo := &mockCardgroupRepository{findResult: cg}
-	uc := NewCardgroupUsecase(repo)
+	uc := NewCardgroupUsecase(repo, newTestLogger())
 
 	_, err := uc.Cardgroup(cgAuthedCtx("user-2"), "cg1")
 
@@ -195,7 +195,7 @@ func TestCardgroupUsecase_Cardgroup_NonOwnerGetsUnauthenticated(t *testing.T) {
 func TestCardgroupUsecase_Create_Anonymous(t *testing.T) {
 	t.Parallel()
 	repo := &mockCardgroupRepository{}
-	uc := NewCardgroupUsecase(repo)
+	uc := NewCardgroupUsecase(repo, newTestLogger())
 
 	_, err := uc.Create(anonCtx(), CreateCardgroupInput{Name: "Hello"})
 
@@ -208,7 +208,7 @@ func TestCardgroupUsecase_Create_Anonymous(t *testing.T) {
 func TestCardgroupUsecase_Create_EmptyName_ValidationVariant(t *testing.T) {
 	t.Parallel()
 	repo := &mockCardgroupRepository{}
-	uc := NewCardgroupUsecase(repo)
+	uc := NewCardgroupUsecase(repo, newTestLogger())
 
 	outcome, err := uc.Create(cgAuthedCtx("user-1"), CreateCardgroupInput{Name: ""})
 
@@ -232,7 +232,7 @@ func TestCardgroupUsecase_Create_EmptyName_ValidationVariant(t *testing.T) {
 func TestCardgroupUsecase_Create_TooLong_ValidationVariant(t *testing.T) {
 	t.Parallel()
 	repo := &mockCardgroupRepository{}
-	uc := NewCardgroupUsecase(repo)
+	uc := NewCardgroupUsecase(repo, newTestLogger())
 
 	outcome, err := uc.Create(cgAuthedCtx("user-1"), CreateCardgroupInput{Name: strings.Repeat("a", 101)})
 
@@ -256,7 +256,7 @@ func TestCardgroupUsecase_Create_TooLong_ValidationVariant(t *testing.T) {
 func TestCardgroupUsecase_Create_Trims(t *testing.T) {
 	t.Parallel()
 	repo := &mockCardgroupRepository{}
-	uc := NewCardgroupUsecase(repo)
+	uc := NewCardgroupUsecase(repo, newTestLogger())
 
 	outcome, err := uc.Create(cgAuthedCtx("user-1"), CreateCardgroupInput{Name: "  Hello  "})
 
@@ -277,7 +277,7 @@ func TestCardgroupUsecase_Create_Trims(t *testing.T) {
 func TestCardgroupUsecase_Create_Success_AssignsOwnerToCaller(t *testing.T) {
 	t.Parallel()
 	repo := &mockCardgroupRepository{}
-	uc := NewCardgroupUsecase(repo)
+	uc := NewCardgroupUsecase(repo, newTestLogger())
 
 	outcome, err := uc.Create(cgAuthedCtx("user-1"), CreateCardgroupInput{Name: "My Group"})
 
@@ -309,7 +309,7 @@ func TestCardgroupUsecase_Create_Success_AssignsOwnerToCaller(t *testing.T) {
 func TestCardgroupUsecase_Update_Anonymous(t *testing.T) {
 	t.Parallel()
 	repo := &mockCardgroupRepository{}
-	uc := NewCardgroupUsecase(repo)
+	uc := NewCardgroupUsecase(repo, newTestLogger())
 
 	_, err := uc.Update(anonCtx(), "cg1", UpdateCardgroupInput{Name: ptr("New")})
 
@@ -323,7 +323,7 @@ func TestCardgroupUsecase_Update_NonOwner_Unauthenticated(t *testing.T) {
 	t.Parallel()
 	cg := &domain.Cardgroup{ID: "cg1", OwnerID: "user-1", Name: "Original"}
 	repo := &mockCardgroupRepository{findResult: cg}
-	uc := NewCardgroupUsecase(repo)
+	uc := NewCardgroupUsecase(repo, newTestLogger())
 
 	_, err := uc.Update(cgAuthedCtx("user-2"), "cg1", UpdateCardgroupInput{Name: ptr("Hacked")})
 
@@ -336,7 +336,7 @@ func TestCardgroupUsecase_Update_NonOwner_Unauthenticated(t *testing.T) {
 func TestCardgroupUsecase_Update_NotFound_Unauthenticated(t *testing.T) {
 	t.Parallel()
 	repo := &mockCardgroupRepository{findErr: repository.ErrNotFound}
-	uc := NewCardgroupUsecase(repo)
+	uc := NewCardgroupUsecase(repo, newTestLogger())
 
 	_, err := uc.Update(cgAuthedCtx("user-1"), "cg-missing", UpdateCardgroupInput{Name: ptr("Anything")})
 
@@ -351,7 +351,7 @@ func TestCardgroupUsecase_Update_NameChange_Success(t *testing.T) {
 	existing := &domain.Cardgroup{ID: "cg1", OwnerID: "user-1", Name: "Old"}
 	updated := &domain.Cardgroup{ID: "cg1", OwnerID: "user-1", Name: "New"}
 	repo := &mockCardgroupRepository{findResult: existing, updateResult: updated}
-	uc := NewCardgroupUsecase(repo)
+	uc := NewCardgroupUsecase(repo, newTestLogger())
 
 	outcome, err := uc.Update(cgAuthedCtx("user-1"), "cg1", UpdateCardgroupInput{Name: ptr("New")})
 
@@ -379,7 +379,7 @@ func TestCardgroupUsecase_Update_EmptyPatch_NoWrite(t *testing.T) {
 	t.Parallel()
 	existing := &domain.Cardgroup{ID: "cg1", OwnerID: "user-1", Name: "Original"}
 	repo := &mockCardgroupRepository{findResult: existing}
-	uc := NewCardgroupUsecase(repo)
+	uc := NewCardgroupUsecase(repo, newTestLogger())
 
 	outcome, err := uc.Update(cgAuthedCtx("user-1"), "cg1", UpdateCardgroupInput{Name: nil})
 
@@ -401,7 +401,7 @@ func TestCardgroupUsecase_Update_EmptyName_ValidationVariant(t *testing.T) {
 	t.Parallel()
 	existing := &domain.Cardgroup{ID: "cg1", OwnerID: "user-1", Name: "Original"}
 	repo := &mockCardgroupRepository{findResult: existing}
-	uc := NewCardgroupUsecase(repo)
+	uc := NewCardgroupUsecase(repo, newTestLogger())
 
 	outcome, err := uc.Update(cgAuthedCtx("user-1"), "cg1", UpdateCardgroupInput{Name: ptr("")})
 
@@ -426,7 +426,7 @@ func TestCardgroupUsecase_Update_TooLongName_ValidationVariant(t *testing.T) {
 	t.Parallel()
 	existing := &domain.Cardgroup{ID: "cg1", OwnerID: "user-1", Name: "Original"}
 	repo := &mockCardgroupRepository{findResult: existing}
-	uc := NewCardgroupUsecase(repo)
+	uc := NewCardgroupUsecase(repo, newTestLogger())
 
 	outcome, err := uc.Update(cgAuthedCtx("user-1"), "cg1", UpdateCardgroupInput{Name: ptr(strings.Repeat("a", 101))})
 
@@ -454,7 +454,7 @@ func TestCardgroupUsecase_Update_RepoError_InfraChannel(t *testing.T) {
 		findResult: existing,
 		updateErr:  errors.New("db: connection lost"),
 	}
-	uc := NewCardgroupUsecase(repo)
+	uc := NewCardgroupUsecase(repo, newTestLogger())
 
 	_, err := uc.Update(cgAuthedCtx("user-1"), "cg1", UpdateCardgroupInput{Name: ptr("New")})
 
@@ -469,7 +469,7 @@ func TestCardgroupUsecase_Update_RepoError_InfraChannel(t *testing.T) {
 func TestCardgroupUsecase_Delete_Anonymous(t *testing.T) {
 	t.Parallel()
 	repo := &mockCardgroupRepository{}
-	uc := NewCardgroupUsecase(repo)
+	uc := NewCardgroupUsecase(repo, newTestLogger())
 
 	err := uc.Delete(anonCtx(), "cg1")
 
@@ -483,7 +483,7 @@ func TestCardgroupUsecase_Delete_NonOwner_Unauthenticated(t *testing.T) {
 	t.Parallel()
 	cg := &domain.Cardgroup{ID: "cg1", OwnerID: "user-1", Name: "Mine"}
 	repo := &mockCardgroupRepository{findResult: cg}
-	uc := NewCardgroupUsecase(repo)
+	uc := NewCardgroupUsecase(repo, newTestLogger())
 
 	err := uc.Delete(cgAuthedCtx("user-2"), "cg1")
 
@@ -499,7 +499,7 @@ func TestCardgroupUsecase_Delete_NonOwner_Unauthenticated(t *testing.T) {
 func TestCardgroupUsecase_Delete_NotFound_Unauthenticated(t *testing.T) {
 	t.Parallel()
 	repo := &mockCardgroupRepository{findErr: repository.ErrNotFound}
-	uc := NewCardgroupUsecase(repo)
+	uc := NewCardgroupUsecase(repo, newTestLogger())
 
 	err := uc.Delete(cgAuthedCtx("user-1"), "cg-missing")
 
@@ -513,7 +513,7 @@ func TestCardgroupUsecase_Delete_Success(t *testing.T) {
 	t.Parallel()
 	cg := &domain.Cardgroup{ID: "cg1", OwnerID: "user-1", Name: "Mine"}
 	repo := &mockCardgroupRepository{findResult: cg}
-	uc := NewCardgroupUsecase(repo)
+	uc := NewCardgroupUsecase(repo, newTestLogger())
 
 	err := uc.Delete(cgAuthedCtx("user-1"), "cg1")
 
@@ -534,7 +534,7 @@ func TestCardgroupUsecase_Delete_Success(t *testing.T) {
 func TestCardgroupUC_ConnectionGuards_AfterAndBefore(t *testing.T) {
 	t.Parallel()
 	repo := &mockCardgroupRepository{}
-	uc := NewCardgroupUsecase(repo)
+	uc := NewCardgroupUsecase(repo, newTestLogger())
 
 	after := "cursor-a"
 	before := "cursor-b"
@@ -551,7 +551,7 @@ func TestCardgroupUC_ConnectionGuards_AfterAndBefore(t *testing.T) {
 func TestCardgroupUC_ConnectionGuards_FirstAndBefore(t *testing.T) {
 	t.Parallel()
 	repo := &mockCardgroupRepository{}
-	uc := NewCardgroupUsecase(repo)
+	uc := NewCardgroupUsecase(repo, newTestLogger())
 
 	first := 5
 	before := "cursor-b"
@@ -568,7 +568,7 @@ func TestCardgroupUC_ConnectionGuards_FirstAndBefore(t *testing.T) {
 func TestCardgroupUC_ConnectionGuards_LastAndAfter(t *testing.T) {
 	t.Parallel()
 	repo := &mockCardgroupRepository{}
-	uc := NewCardgroupUsecase(repo)
+	uc := NewCardgroupUsecase(repo, newTestLogger())
 
 	last := 5
 	after := "cursor-a"
@@ -585,7 +585,7 @@ func TestCardgroupUC_ConnectionGuards_LastAndAfter(t *testing.T) {
 func TestCardgroupUC_ConnectionGuards_BeforeAlone(t *testing.T) {
 	t.Parallel()
 	repo := &mockCardgroupRepository{}
-	uc := NewCardgroupUsecase(repo)
+	uc := NewCardgroupUsecase(repo, newTestLogger())
 
 	before := "cursor-b"
 	_, err := uc.ListCardgroupsByOwnerConnection(cgAuthedCtx("user-1"), CardgroupConnectionInput{
@@ -600,7 +600,7 @@ func TestCardgroupUC_ConnectionGuards_BeforeAlone(t *testing.T) {
 func TestCardgroupUC_ConnectionGuards_AfterAlone(t *testing.T) {
 	t.Parallel()
 	repo := &mockCardgroupRepository{}
-	uc := NewCardgroupUsecase(repo)
+	uc := NewCardgroupUsecase(repo, newTestLogger())
 
 	after := "cursor-a"
 	_, err := uc.ListCardgroupsByOwnerConnection(cgAuthedCtx("user-1"), CardgroupConnectionInput{
@@ -623,7 +623,7 @@ func TestCardgroupUC_Connection_CursorFromOtherOwner_BadUserInput(t *testing.T) 
 	// The cursor ID maps to a cardgroup owned by owner-A, not owner-B.
 	foreignCG := &domain.Cardgroup{ID: "cg-owner-a", OwnerID: "owner-a", Name: "Foreign"}
 	repo := &mockCardgroupRepository{findResult: foreignCG}
-	uc := NewCardgroupUsecase(repo)
+	uc := NewCardgroupUsecase(repo, newTestLogger())
 
 	first := 5
 	after := "cg-owner-a"
@@ -656,7 +656,7 @@ func TestCardgroupUC_Connection_FirstPage(t *testing.T) {
 		findPageResult: cgs,
 		countResult:    3,
 	}
-	uc := NewCardgroupUsecase(repo)
+	uc := NewCardgroupUsecase(repo, newTestLogger())
 
 	first := 2
 	out, err := uc.ListCardgroupsByOwnerConnection(cgAuthedCtx("user-1"), CardgroupConnectionInput{
@@ -699,7 +699,7 @@ func TestCardgroupUC_Connection_Search(t *testing.T) {
 		findPageResult: matched,
 		countResult:    1,
 	}
-	uc := NewCardgroupUsecase(repo)
+	uc := NewCardgroupUsecase(repo, newTestLogger())
 
 	first := 10
 	search := "app"
@@ -731,7 +731,7 @@ func TestCardgroupUC_Connection_Search(t *testing.T) {
 func TestCardgroupUC_Connection_Anonymous(t *testing.T) {
 	t.Parallel()
 	repo := &mockCardgroupRepository{}
-	uc := NewCardgroupUsecase(repo)
+	uc := NewCardgroupUsecase(repo, newTestLogger())
 
 	first := 10
 	_, err := uc.ListCardgroupsByOwnerConnection(anonCtx(), CardgroupConnectionInput{First: &first})
@@ -747,7 +747,7 @@ func TestCardgroupUC_Connection_Anonymous(t *testing.T) {
 func TestCardgroupUC_ConnectionGuards_FirstAndLast(t *testing.T) {
 	t.Parallel()
 	repo := &mockCardgroupRepository{}
-	uc := NewCardgroupUsecase(repo)
+	uc := NewCardgroupUsecase(repo, newTestLogger())
 
 	first, last := 5, 5
 	_, err := uc.ListCardgroupsByOwnerConnection(cgAuthedCtx("u1"), CardgroupConnectionInput{
@@ -770,7 +770,7 @@ func TestCardgroupUC_Connection_FirstPage_AssertFirstPlusOne(t *testing.T) {
 		{ID: "cg3", OwnerID: "u1", Name: "C"},
 	}
 	repo := &mockCardgroupRepository{findPageResult: cgs, countResult: 3}
-	uc := NewCardgroupUsecase(repo)
+	uc := NewCardgroupUsecase(repo, newTestLogger())
 
 	first := 2
 	_, err := uc.ListCardgroupsByOwnerConnection(cgAuthedCtx("u1"), CardgroupConnectionInput{
@@ -811,7 +811,7 @@ func TestCardgroupUC_Connection_BackwardPagination_HappyPath(t *testing.T) {
 		countResult:    10,
 		findResult:     cursorCG, // hydrate the before cursor
 	}
-	uc := NewCardgroupUsecase(repo)
+	uc := NewCardgroupUsecase(repo, newTestLogger())
 
 	last := 2
 	before := "cg-cursor"
@@ -855,7 +855,7 @@ func TestCardgroupUC_Connection_OrderBy_Name_Asc(t *testing.T) {
 		findPageResult: []*domain.Cardgroup{},
 		countResult:    0,
 	}
-	uc := NewCardgroupUsecase(repo)
+	uc := NewCardgroupUsecase(repo, newTestLogger())
 
 	first := 5
 	ob := CardgroupOrderByName
@@ -888,7 +888,7 @@ func TestCardgroupUC_Connection_OrderBy_CreatedAt_Desc(t *testing.T) {
 		findPageResult: []*domain.Cardgroup{},
 		countResult:    0,
 	}
-	uc := NewCardgroupUsecase(repo)
+	uc := NewCardgroupUsecase(repo, newTestLogger())
 
 	first := 5
 	ob := CardgroupOrderByCreatedAt
@@ -918,7 +918,7 @@ func TestCardgroupUC_Connection_OrderBy_ID_Asc(t *testing.T) {
 		findPageResult: []*domain.Cardgroup{},
 		countResult:    0,
 	}
-	uc := NewCardgroupUsecase(repo)
+	uc := NewCardgroupUsecase(repo, newTestLogger())
 
 	first := 5
 	ob := CardgroupOrderByID
@@ -945,7 +945,7 @@ func TestCardgroupUC_Connection_DefaultOrderBy_WhenNil(t *testing.T) {
 		findPageResult: []*domain.Cardgroup{},
 		countResult:    0,
 	}
-	uc := NewCardgroupUsecase(repo)
+	uc := NewCardgroupUsecase(repo, newTestLogger())
 
 	first := 5
 	_, err := uc.ListCardgroupsByOwnerConnection(cgAuthedCtx("u1"), CardgroupConnectionInput{
@@ -972,7 +972,7 @@ func TestCardgroupUC_Connection_DefaultPageSize_WhenAllNil(t *testing.T) {
 		findPageResult: []*domain.Cardgroup{},
 		countResult:    0,
 	}
-	uc := NewCardgroupUsecase(repo)
+	uc := NewCardgroupUsecase(repo, newTestLogger())
 
 	_, err := uc.ListCardgroupsByOwnerConnection(cgAuthedCtx("u1"), CardgroupConnectionInput{})
 	if err != nil {
@@ -994,7 +994,7 @@ func TestCardgroupUC_Connection_PageSize_Clamp(t *testing.T) {
 		findPageResult: []*domain.Cardgroup{},
 		countResult:    0,
 	}
-	uc := NewCardgroupUsecase(repo)
+	uc := NewCardgroupUsecase(repo, newTestLogger())
 
 	first := 200 // above cardgroupMaxPageSize=100
 	_, err := uc.ListCardgroupsByOwnerConnection(cgAuthedCtx("u1"), CardgroupConnectionInput{
@@ -1020,7 +1020,7 @@ func TestCardgroupUC_Connection_PageSize_NegativeFirst(t *testing.T) {
 		findPageResult: []*domain.Cardgroup{},
 		countResult:    0,
 	}
-	uc := NewCardgroupUsecase(repo)
+	uc := NewCardgroupUsecase(repo, newTestLogger())
 
 	first := -5
 	_, err := uc.ListCardgroupsByOwnerConnection(cgAuthedCtx("u1"), CardgroupConnectionInput{
@@ -1046,7 +1046,7 @@ func TestCardgroupUC_Connection_CursorHydration_Name(t *testing.T) {
 		findPageResult: []*domain.Cardgroup{},
 		countResult:    0,
 	}
-	uc := NewCardgroupUsecase(repo)
+	uc := NewCardgroupUsecase(repo, newTestLogger())
 
 	first := 5
 	after := "cg-cursor"
@@ -1083,7 +1083,7 @@ func TestCardgroupUC_Connection_CursorHydration_CreatedAt(t *testing.T) {
 		findPageResult: []*domain.Cardgroup{},
 		countResult:    0,
 	}
-	uc := NewCardgroupUsecase(repo)
+	uc := NewCardgroupUsecase(repo, newTestLogger())
 
 	first := 5
 	after := "cg-cursor"
@@ -1117,7 +1117,7 @@ func TestCardgroupUC_Connection_CursorHydration_UpdatedAt(t *testing.T) {
 		findPageResult: []*domain.Cardgroup{},
 		countResult:    0,
 	}
-	uc := NewCardgroupUsecase(repo)
+	uc := NewCardgroupUsecase(repo, newTestLogger())
 
 	first := 5
 	after := "cg-cursor"
@@ -1149,7 +1149,7 @@ func TestCardgroupUC_Connection_CursorHydration_OrderByID(t *testing.T) {
 		findPageResult: []*domain.Cardgroup{},
 		countResult:    0,
 	}
-	uc := NewCardgroupUsecase(repo)
+	uc := NewCardgroupUsecase(repo, newTestLogger())
 
 	first := 5
 	after := "cg-cursor"
@@ -1182,7 +1182,7 @@ func TestCardgroupUC_Connection_CursorHydration_OrderByID_NotFound(t *testing.T)
 	t.Parallel()
 
 	repo := &mockCardgroupRepository{findErr: repository.ErrNotFound}
-	uc := NewCardgroupUsecase(repo)
+	uc := NewCardgroupUsecase(repo, newTestLogger())
 
 	first := 5
 	after := "cg-missing"
@@ -1202,7 +1202,7 @@ func TestCardgroupUC_Connection_CursorHydration_OrderByID_RepoError(t *testing.T
 	t.Parallel()
 
 	repo := &mockCardgroupRepository{findErr: errors.New("db died")}
-	uc := NewCardgroupUsecase(repo)
+	uc := NewCardgroupUsecase(repo, newTestLogger())
 
 	first := 5
 	after := "cg-x"
@@ -1224,7 +1224,7 @@ func TestCardgroupUC_Connection_CursorHydration_OrderByID_OtherOwner(t *testing.
 
 	foreignCG := &domain.Cardgroup{ID: "cg-x", OwnerID: "owner-a", Name: "Foreign"}
 	repo := &mockCardgroupRepository{findResult: foreignCG}
-	uc := NewCardgroupUsecase(repo)
+	uc := NewCardgroupUsecase(repo, newTestLogger())
 
 	first := 5
 	after := "cg-x"
@@ -1243,7 +1243,7 @@ func TestCardgroupUC_Connection_CursorHydration_NotFound_BadUserInput(t *testing
 	t.Parallel()
 
 	repo := &mockCardgroupRepository{findErr: repository.ErrNotFound}
-	uc := NewCardgroupUsecase(repo)
+	uc := NewCardgroupUsecase(repo, newTestLogger())
 
 	first := 5
 	after := "cg-missing"
@@ -1260,7 +1260,7 @@ func TestCardgroupUC_Connection_CursorHydration_RepoError_Internal(t *testing.T)
 	t.Parallel()
 
 	repo := &mockCardgroupRepository{findErr: errors.New("db dead")}
-	uc := NewCardgroupUsecase(repo)
+	uc := NewCardgroupUsecase(repo, newTestLogger())
 
 	first := 5
 	after := "cg-cursor"
@@ -1280,7 +1280,7 @@ func TestCardgroupUC_Connection_FindPageRepoError_Internal(t *testing.T) {
 		countResult: 5,
 		findPageErr: errors.New("db dead"),
 	}
-	uc := NewCardgroupUsecase(repo)
+	uc := NewCardgroupUsecase(repo, newTestLogger())
 
 	first := 5
 	_, err := uc.ListCardgroupsByOwnerConnection(cgAuthedCtx("u1"), CardgroupConnectionInput{
@@ -1295,7 +1295,7 @@ func TestCardgroupUC_Connection_CountError_Internal(t *testing.T) {
 	t.Parallel()
 
 	repo := &mockCardgroupRepository{countErr: errors.New("count dead")}
-	uc := NewCardgroupUsecase(repo)
+	uc := NewCardgroupUsecase(repo, newTestLogger())
 
 	first := 5
 	_, err := uc.ListCardgroupsByOwnerConnection(cgAuthedCtx("u1"), CardgroupConnectionInput{
@@ -1372,7 +1372,7 @@ func TestResolveCardgroupPageSize_LastNegativeClampedToZero(t *testing.T) {
 func TestResolveCardgroupCursor_NilCursor(t *testing.T) {
 	t.Parallel()
 	repo := &mockCardgroupRepository{}
-	uc := NewCardgroupUsecase(repo)
+	uc := NewCardgroupUsecase(repo, newTestLogger())
 
 	c, err := uc.resolveCardgroupCursor(
 		context.Background(),
@@ -1405,7 +1405,7 @@ func TestResolveCardgroupCursor_OtherOwner_NonIDOrderBy(t *testing.T) {
 
 	foreignCG := &domain.Cardgroup{ID: "cg-x", OwnerID: "owner-a", Name: "Foreign"}
 	repo := &mockCardgroupRepository{findResult: foreignCG}
-	uc := NewCardgroupUsecase(repo)
+	uc := NewCardgroupUsecase(repo, newTestLogger())
 
 	id := "cg-x"
 	_, err := uc.resolveCardgroupCursor(
@@ -1424,7 +1424,7 @@ func TestResolveCardgroupCursor_UnknownOrderBy(t *testing.T) {
 
 	cg := &domain.Cardgroup{ID: "cg-cursor", OwnerID: "u1", Name: "X"}
 	repo := &mockCardgroupRepository{findResult: cg}
-	uc := NewCardgroupUsecase(repo)
+	uc := NewCardgroupUsecase(repo, newTestLogger())
 
 	id := "cg-cursor"
 	_, err := uc.resolveCardgroupCursor(
@@ -1451,7 +1451,7 @@ func TestResolveCardgroupCursor_MalformedV1_ReturnsBadUserInput(t *testing.T) {
 	t.Parallel()
 
 	repo := &mockCardgroupRepository{}
-	uc := NewCardgroupUsecase(repo)
+	uc := NewCardgroupUsecase(repo, newTestLogger())
 
 	malformed := "v1:!!!not-base64!!!"
 	_, err := uc.resolveCardgroupCursor(
@@ -1468,7 +1468,7 @@ func TestResolveCardgroupCursor_V1EncodedID(t *testing.T) {
 
 	cg := &domain.Cardgroup{ID: "cg-cursor", OwnerID: "u1", Name: "X"}
 	repo := &mockCardgroupRepository{findResult: cg}
-	uc := NewCardgroupUsecase(repo)
+	uc := NewCardgroupUsecase(repo, newTestLogger())
 
 	// Encode the raw ID into the v1 envelope the way the resolver would.
 	encoded := "v1:Y2ctY3Vyc29y" // base64.RawURLEncoding.EncodeToString([]byte("cg-cursor"))

--- a/backend/internal/usecase/dictionary.go
+++ b/backend/internal/usecase/dictionary.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"errors"
+	"log/slog"
 	"time"
 
 	"github.com/rotisserie/eris"
@@ -97,14 +98,18 @@ type dictionaryUsecase struct {
 	auth     AdminChecker
 	cardRepo DictionaryCardRepository
 	tx       txRunner
+	logger   *slog.Logger
 }
 
 // NewDictionaryUsecase constructs a DictionaryUsecase. db is the gorm handle
 // used to open transactions; pass the same *gorm.DB used by the other
 // usecase constructors. Passing a nil db defers transaction wiring; the
 // usecase will return INTERNAL when Upsert is invoked without a tx runner.
-func NewDictionaryUsecase(authSvc AdminChecker, cardRepo DictionaryCardRepository, db *gorm.DB) *dictionaryUsecase {
-	uc := &dictionaryUsecase{auth: authSvc, cardRepo: cardRepo}
+func NewDictionaryUsecase(authSvc AdminChecker, cardRepo DictionaryCardRepository, db *gorm.DB, logger *slog.Logger) *dictionaryUsecase {
+	if logger == nil {
+		panic("usecase: dictionary: logger is required")
+	}
+	uc := &dictionaryUsecase{auth: authSvc, cardRepo: cardRepo, logger: logger}
 	if db != nil {
 		uc.tx = func(ctx context.Context, fn func(tx *gorm.DB) error) error {
 			return db.WithContext(ctx).Transaction(fn)
@@ -116,8 +121,11 @@ func NewDictionaryUsecase(authSvc AdminChecker, cardRepo DictionaryCardRepositor
 // NewDictionaryUsecaseWithTx is the test-time constructor that injects an
 // explicit transaction runner. Production callers must use
 // NewDictionaryUsecase.
-func NewDictionaryUsecaseWithTx(authSvc AdminChecker, cardRepo DictionaryCardRepository, tx txRunner) *dictionaryUsecase {
-	return &dictionaryUsecase{auth: authSvc, cardRepo: cardRepo, tx: tx}
+func NewDictionaryUsecaseWithTx(authSvc AdminChecker, cardRepo DictionaryCardRepository, tx txRunner, logger *slog.Logger) *dictionaryUsecase {
+	if logger == nil {
+		panic("usecase: dictionary: logger is required")
+	}
+	return &dictionaryUsecase{auth: authSvc, cardRepo: cardRepo, tx: tx, logger: logger}
 }
 
 // Upsert ingests a base64-encoded dictionary payload, parses it, and persists

--- a/backend/internal/usecase/dictionary_test.go
+++ b/backend/internal/usecase/dictionary_test.go
@@ -162,7 +162,7 @@ func TestDictionaryUsecase_AdminAllInserts(t *testing.T) {
 	repo := &mockDictCardRepo{inserted: n, updated: 0}
 	auth := &mockAdminChecker{isAdmin: true}
 	tx, calls := dictTxRunner()
-	uc := NewDictionaryUsecaseWithTx(auth, repo, tx)
+	uc := NewDictionaryUsecaseWithTx(auth, repo, tx, newTestLogger())
 
 	out, err := uc.Upsert(authedCtx("admin-1"), UpsertDictionaryInput{
 		CardgroupID: "cg-target",
@@ -227,7 +227,7 @@ func TestDictionaryUsecase_AdminMixedInsertsAndUpdates(t *testing.T) {
 	repo := &mockDictCardRepo{preExisting: preExisting}
 	auth := &mockAdminChecker{isAdmin: true}
 	tx, _ := dictTxRunner()
-	uc := NewDictionaryUsecaseWithTx(auth, repo, tx)
+	uc := NewDictionaryUsecaseWithTx(auth, repo, tx, newTestLogger())
 
 	out, err := uc.Upsert(authedCtx("admin-1"), UpsertDictionaryInput{
 		CardgroupID: "cg-target",
@@ -280,7 +280,7 @@ func TestDictionaryUsecase_NonAdminForbidden(t *testing.T) {
 	repo := &mockDictCardRepo{}
 	auth := &mockAdminChecker{isAdmin: false}
 	tx, calls := dictTxRunner()
-	uc := NewDictionaryUsecaseWithTx(auth, repo, tx)
+	uc := NewDictionaryUsecaseWithTx(auth, repo, tx, newTestLogger())
 
 	_, err := uc.Upsert(authedCtx("user-1"), UpsertDictionaryInput{
 		CardgroupID: "cg-target",
@@ -310,7 +310,7 @@ func TestDictionaryUsecase_AnonymousUnauthenticated(t *testing.T) {
 	repo := &mockDictCardRepo{}
 	auth := &mockAdminChecker{isAdmin: true}
 	tx, _ := dictTxRunner()
-	uc := NewDictionaryUsecaseWithTx(auth, repo, tx)
+	uc := NewDictionaryUsecaseWithTx(auth, repo, tx, newTestLogger())
 
 	_, err := uc.Upsert(anonCtx(), UpsertDictionaryInput{
 		CardgroupID: "cg-target",
@@ -339,7 +339,7 @@ func TestDictionaryUsecase_PayloadOverCapBadInput(t *testing.T) {
 	repo := &mockDictCardRepo{}
 	auth := &mockAdminChecker{isAdmin: true}
 	tx, calls := dictTxRunner()
-	uc := NewDictionaryUsecaseWithTx(auth, repo, tx)
+	uc := NewDictionaryUsecaseWithTx(auth, repo, tx, newTestLogger())
 
 	_, err := uc.Upsert(authedCtx("admin-1"), UpsertDictionaryInput{
 		CardgroupID: "cg-target",
@@ -389,7 +389,7 @@ func TestDictionaryUsecase_BadRowsSurfaceAsErrors(t *testing.T) {
 	repo := &mockDictCardRepo{inserted: 3}
 	authChk := &mockAdminChecker{isAdmin: true}
 	tx, _ := dictTxRunner()
-	uc := NewDictionaryUsecaseWithTx(authChk, repo, tx)
+	uc := NewDictionaryUsecaseWithTx(authChk, repo, tx, newTestLogger())
 
 	out, err := uc.Upsert(authedCtx("admin-1"), UpsertDictionaryInput{
 		CardgroupID: "cg-target",
@@ -449,7 +449,7 @@ func TestDictionaryUsecase_ValidSkipValidMixedPayload(t *testing.T) {
 	repo := &mockDictCardRepo{inserted: 2}
 	authChk := &mockAdminChecker{isAdmin: true}
 	tx, _ := dictTxRunner()
-	uc := NewDictionaryUsecaseWithTx(authChk, repo, tx)
+	uc := NewDictionaryUsecaseWithTx(authChk, repo, tx, newTestLogger())
 
 	out, err := uc.Upsert(authedCtx("admin-1"), UpsertDictionaryInput{
 		CardgroupID: "cg-target",
@@ -492,7 +492,7 @@ func TestDictionaryUsecase_SkippedLoneFrontDoesNotReachRepository(t *testing.T) 
 	repo := &mockDictCardRepo{}
 	authChk := &mockAdminChecker{isAdmin: true}
 	tx, calls := dictTxRunner()
-	uc := NewDictionaryUsecaseWithTx(authChk, repo, tx)
+	uc := NewDictionaryUsecaseWithTx(authChk, repo, tx, newTestLogger())
 
 	out, err := uc.Upsert(authedCtx("admin-1"), UpsertDictionaryInput{
 		CardgroupID: "cg-target",
@@ -546,7 +546,7 @@ func TestDictionaryUsecase_AdminCheckerErrorBecomesInternal(t *testing.T) {
 	repo := &mockDictCardRepo{}
 	auth := &mockAdminChecker{err: errors.New("db died")}
 	tx, calls := dictTxRunner()
-	uc := NewDictionaryUsecaseWithTx(auth, repo, tx)
+	uc := NewDictionaryUsecaseWithTx(auth, repo, tx, newTestLogger())
 
 	_, err := uc.Upsert(authedCtx("admin-1"), UpsertDictionaryInput{
 		CardgroupID: "cg-target",
@@ -576,7 +576,7 @@ func TestDictionaryUsecase_RepoErrorBecomesInternal(t *testing.T) {
 	repo := &mockDictCardRepo{returnErr: errors.New("db: boom")}
 	authChk := &mockAdminChecker{isAdmin: true}
 	tx, _ := dictTxRunner()
-	uc := NewDictionaryUsecaseWithTx(authChk, repo, tx)
+	uc := NewDictionaryUsecaseWithTx(authChk, repo, tx, newTestLogger())
 
 	_, err := uc.Upsert(authedCtx("admin-1"), UpsertDictionaryInput{
 		CardgroupID: "cg-target",
@@ -599,7 +599,7 @@ func TestDictionaryUsecase_EmptyCardgroupIDBadInput(t *testing.T) {
 	repo := &mockDictCardRepo{}
 	authChk := &mockAdminChecker{isAdmin: true}
 	tx, _ := dictTxRunner()
-	uc := NewDictionaryUsecaseWithTx(authChk, repo, tx)
+	uc := NewDictionaryUsecaseWithTx(authChk, repo, tx, newTestLogger())
 
 	_, err := uc.Upsert(authedCtx("admin-1"), UpsertDictionaryInput{
 		CardgroupID: "",
@@ -619,7 +619,7 @@ func TestDictionaryUsecase_EmptyPayloadBadInput(t *testing.T) {
 	repo := &mockDictCardRepo{}
 	authChk := &mockAdminChecker{isAdmin: true}
 	tx, _ := dictTxRunner()
-	uc := NewDictionaryUsecaseWithTx(authChk, repo, tx)
+	uc := NewDictionaryUsecaseWithTx(authChk, repo, tx, newTestLogger())
 
 	_, err := uc.Upsert(authedCtx("admin-1"), UpsertDictionaryInput{
 		CardgroupID: "cg-target",
@@ -640,7 +640,7 @@ func TestDictionaryUsecase_BadBase64BadInput(t *testing.T) {
 	repo := &mockDictCardRepo{}
 	authChk := &mockAdminChecker{isAdmin: true}
 	tx, _ := dictTxRunner()
-	uc := NewDictionaryUsecaseWithTx(authChk, repo, tx)
+	uc := NewDictionaryUsecaseWithTx(authChk, repo, tx, newTestLogger())
 
 	_, err := uc.Upsert(authedCtx("admin-1"), UpsertDictionaryInput{
 		CardgroupID: "cg-target",
@@ -676,7 +676,7 @@ func TestDictionaryUsecase_DuplicateFrontDeduplicatedAndSurfaced(t *testing.T) {
 	repo := &mockDictCardRepo{inserted: 1, updated: 0}
 	authChk := &mockAdminChecker{isAdmin: true}
 	tx, _ := dictTxRunner()
-	uc := NewDictionaryUsecaseWithTx(authChk, repo, tx)
+	uc := NewDictionaryUsecaseWithTx(authChk, repo, tx, newTestLogger())
 
 	out, err := uc.Upsert(authedCtx("admin-1"), UpsertDictionaryInput{
 		CardgroupID: "cg-target",

--- a/backend/internal/usecase/helpers_test.go
+++ b/backend/internal/usecase/helpers_test.go
@@ -3,6 +3,8 @@ package usecase
 import (
 	"context"
 	"errors"
+	"io"
+	"log/slog"
 	"strings"
 	"testing"
 
@@ -140,4 +142,10 @@ func TestAssertInternalChain_Passes(t *testing.T) {
 	err := eris.Wrap(base, "usecase: fetch user")
 	assertInternalChain(t, err, "usecase: fetch user")
 	assertInternalChain(t, err, "db: timeout") // matches ErrExternal frame
+}
+
+// newTestLogger returns a *slog.Logger that writes to io.Discard so unit tests
+// can construct usecases without producing log noise.
+func newTestLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
 }

--- a/backend/internal/usecase/helpers_test.go
+++ b/backend/internal/usecase/helpers_test.go
@@ -3,7 +3,6 @@ package usecase
 import (
 	"context"
 	"errors"
-	"io"
 	"log/slog"
 	"strings"
 	"testing"
@@ -144,8 +143,8 @@ func TestAssertInternalChain_Passes(t *testing.T) {
 	assertInternalChain(t, err, "db: timeout") // matches ErrExternal frame
 }
 
-// newTestLogger returns a *slog.Logger that writes to io.Discard so unit tests
-// can construct usecases without producing log noise.
+// newTestLogger returns a *slog.Logger backed by slog.DiscardHandler so unit
+// tests can construct usecases without producing log noise.
 func newTestLogger() *slog.Logger {
-	return slog.New(slog.NewTextHandler(io.Discard, nil))
+	return slog.New(slog.DiscardHandler)
 }

--- a/backend/internal/usecase/last_viewed_cardgroup.go
+++ b/backend/internal/usecase/last_viewed_cardgroup.go
@@ -3,6 +3,7 @@ package usecase
 import (
 	"context"
 	"errors"
+	"log/slog"
 
 	"github.com/rotisserie/eris"
 
@@ -39,8 +40,9 @@ type userPreferenceRefetchRepo interface {
 }
 
 type lastViewedCardgroupUsecase struct {
-	prefs lastViewedCardgroupRepo
-	users userPreferenceRefetchRepo
+	prefs  lastViewedCardgroupRepo
+	users  userPreferenceRefetchRepo
+	logger *slog.Logger
 }
 
 // NewLastViewedCardgroup is the production constructor. Tests should prefer
@@ -48,16 +50,24 @@ type lastViewedCardgroupUsecase struct {
 func NewLastViewedCardgroup(
 	prefs repository.UserPreferenceRepository,
 	users repository.UserRepository,
+	logger *slog.Logger,
 ) LastViewedCardgroupUsecase {
-	return &lastViewedCardgroupUsecase{prefs: prefs, users: users}
+	if logger == nil {
+		panic("usecase: last viewed cardgroup: logger is required")
+	}
+	return &lastViewedCardgroupUsecase{prefs: prefs, users: users, logger: logger}
 }
 
 // NewLastViewedCardgroupWithDeps accepts narrow interfaces for tests.
 func NewLastViewedCardgroupWithDeps(
 	prefs lastViewedCardgroupRepo,
 	users userPreferenceRefetchRepo,
+	logger *slog.Logger,
 ) LastViewedCardgroupUsecase {
-	return &lastViewedCardgroupUsecase{prefs: prefs, users: users}
+	if logger == nil {
+		panic("usecase: last viewed cardgroup: logger is required")
+	}
+	return &lastViewedCardgroupUsecase{prefs: prefs, users: users, logger: logger}
 }
 
 // Set records cardgroupID as the caller's most recently viewed cardgroup and

--- a/backend/internal/usecase/last_viewed_cardgroup_test.go
+++ b/backend/internal/usecase/last_viewed_cardgroup_test.go
@@ -46,7 +46,7 @@ func TestLastViewedCardgroup_Anonymous_Unauthenticated(t *testing.T) {
 
 	prefs := &mockPrefRepo{}
 	users := &mockUserRefetchRepo{}
-	uc := NewLastViewedCardgroupWithDeps(prefs, users)
+	uc := NewLastViewedCardgroupWithDeps(prefs, users, newTestLogger())
 
 	_, err := uc.Set(anonCtx(), "cg-1")
 	assertUnauthenticated(t, err)
@@ -66,7 +66,7 @@ func TestLastViewedCardgroup_HappyPath_ReturnsRefreshedUser(t *testing.T) {
 	}
 	prefs := &mockPrefRepo{}
 	users := &mockUserRefetchRepo{user: want}
-	uc := NewLastViewedCardgroupWithDeps(prefs, users)
+	uc := NewLastViewedCardgroupWithDeps(prefs, users, newTestLogger())
 
 	outcome, err := uc.Set(authedCtx("u-1"), cgID)
 	if err != nil {
@@ -100,7 +100,7 @@ func TestLastViewedCardgroup_CardgroupNotFound_ValidationVariant(t *testing.T) {
 
 	prefs := &mockPrefRepo{err: repository.ErrCardgroupNotFound}
 	users := &mockUserRefetchRepo{}
-	uc := NewLastViewedCardgroupWithDeps(prefs, users)
+	uc := NewLastViewedCardgroupWithDeps(prefs, users, newTestLogger())
 
 	outcome, err := uc.Set(authedCtx("u-1"), "cg-foreign")
 	if err != nil {
@@ -128,7 +128,7 @@ func TestLastViewedCardgroup_LegacyErrNotFound_FallsThroughToInternal(t *testing
 
 	prefs := &mockPrefRepo{err: repository.ErrNotFound}
 	users := &mockUserRefetchRepo{}
-	uc := NewLastViewedCardgroupWithDeps(prefs, users)
+	uc := NewLastViewedCardgroupWithDeps(prefs, users, newTestLogger())
 
 	_, err := uc.Set(authedCtx("u-1"), "cg-1")
 	assertInternalChain(t, err, "usecase: set last viewed cardgroup")
@@ -139,7 +139,7 @@ func TestLastViewedCardgroup_GenericRepoError_Internal(t *testing.T) {
 
 	prefs := &mockPrefRepo{err: eris.New("boom")}
 	users := &mockUserRefetchRepo{}
-	uc := NewLastViewedCardgroupWithDeps(prefs, users)
+	uc := NewLastViewedCardgroupWithDeps(prefs, users, newTestLogger())
 
 	_, err := uc.Set(authedCtx("u-1"), "cg-1")
 	assertInternalChain(t, err, "usecase: set last viewed cardgroup")
@@ -150,7 +150,7 @@ func TestLastViewedCardgroup_ContextCancelled_Cancelled(t *testing.T) {
 
 	prefs := &mockPrefRepo{err: context.Canceled}
 	users := &mockUserRefetchRepo{}
-	uc := NewLastViewedCardgroupWithDeps(prefs, users)
+	uc := NewLastViewedCardgroupWithDeps(prefs, users, newTestLogger())
 
 	_, err := uc.Set(authedCtx("u-1"), "cg-1")
 	assertCancelled(t, err)
@@ -164,7 +164,7 @@ func TestLastViewedCardgroup_RefetchUserMissing_Internal(t *testing.T) {
 
 	prefs := &mockPrefRepo{}
 	users := &mockUserRefetchRepo{err: repository.ErrNotFound}
-	uc := NewLastViewedCardgroupWithDeps(prefs, users)
+	uc := NewLastViewedCardgroupWithDeps(prefs, users, newTestLogger())
 
 	_, err := uc.Set(authedCtx("u-1"), "cg-1")
 	assertInternalChain(t, err, "usecase: last viewed cardgroup: refetch own user row")
@@ -178,7 +178,7 @@ func TestLastViewedCardgroup_RefetchContextCancelled_Cancelled(t *testing.T) {
 
 	prefs := &mockPrefRepo{}
 	users := &mockUserRefetchRepo{err: context.DeadlineExceeded}
-	uc := NewLastViewedCardgroupWithDeps(prefs, users)
+	uc := NewLastViewedCardgroupWithDeps(prefs, users, newTestLogger())
 
 	_, err := uc.Set(authedCtx("u-1"), "cg-1")
 	assertCancelled(t, err)
@@ -191,7 +191,7 @@ func TestLastViewedCardgroup_EmptySub_Unauthenticated(t *testing.T) {
 
 	prefs := &mockPrefRepo{}
 	users := &mockUserRefetchRepo{}
-	uc := NewLastViewedCardgroupWithDeps(prefs, users)
+	uc := NewLastViewedCardgroupWithDeps(prefs, users, newTestLogger())
 
 	_, err := uc.Set(authedCtx(""), "cg-1")
 	assertUnauthenticated(t, err)
@@ -213,7 +213,7 @@ func TestLastViewedCardgroup_SentinelOrderingMatters(t *testing.T) {
 
 	prefs := &mockPrefRepo{err: repository.ErrCardgroupNotFound}
 	users := &mockUserRefetchRepo{}
-	uc := NewLastViewedCardgroupWithDeps(prefs, users)
+	uc := NewLastViewedCardgroupWithDeps(prefs, users, newTestLogger())
 
 	outcome, err := uc.Set(authedCtx("u-1"), "cg-1")
 	if err != nil {

--- a/backend/internal/usecase/learn.go
+++ b/backend/internal/usecase/learn.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"math/rand"
 	"time"
 
@@ -36,6 +37,7 @@ type LearnUsecase struct {
 	randSource    func() *rand.Rand
 	defaultLimit  int
 	maxLimit      int
+	logger        *slog.Logger
 }
 
 func NewLearnUsecase(
@@ -44,7 +46,11 @@ func NewLearnUsecase(
 	ordering *service.OrderingPolicy,
 	randSource func() *rand.Rand,
 	defaultLimit, maxLimit int,
+	logger *slog.Logger,
 ) *LearnUsecase {
+	if logger == nil {
+		panic("usecase: learn: logger is required")
+	}
 	if ordering == nil {
 		ordering = service.NewOrderingPolicy()
 	}
@@ -75,6 +81,7 @@ func NewLearnUsecase(
 		randSource:    randSource,
 		defaultLimit:  defaultLimit,
 		maxLimit:      maxLimit,
+		logger:        logger,
 	}
 }
 

--- a/backend/internal/usecase/learn_test.go
+++ b/backend/internal/usecase/learn_test.go
@@ -57,6 +57,7 @@ func TestLearnUsecaseNextDueCards(t *testing.T) {
 		func() *rand.Rand { return rand.New(rand.NewSource(1)) },
 		20,
 		100,
+		newTestLogger(),
 	)
 
 	got, err := uc.NextDueCards(authedCtx("u-1"), "cg-1", now, 5)
@@ -84,6 +85,7 @@ func TestLearnUsecaseNextDueCardsAuthAndCardgroupErrors(t *testing.T) {
 			func() *rand.Rand { return rand.New(rand.NewSource(1)) },
 			20,
 			100,
+			newTestLogger(),
 		)
 		_, err := uc.NextDueCards(anonCtx(), "cg-1", now, 5)
 		assertUnauthenticated(t, err)
@@ -98,6 +100,7 @@ func TestLearnUsecaseNextDueCardsAuthAndCardgroupErrors(t *testing.T) {
 			func() *rand.Rand { return rand.New(rand.NewSource(1)) },
 			20,
 			100,
+			newTestLogger(),
 		)
 		_, err := uc.NextDueCards(authedCtx("u-1"), "missing", now, 5)
 		assertValidationError(t, err, "cardgroupId", "")
@@ -112,6 +115,7 @@ func TestLearnUsecaseNextDueCardsAuthAndCardgroupErrors(t *testing.T) {
 			func() *rand.Rand { return rand.New(rand.NewSource(1)) },
 			20,
 			100,
+			newTestLogger(),
 		)
 		_, err := uc.NextDueCards(authedCtx("u-1"), "cg-1", now, 5)
 		assertUnauthenticated(t, err)
@@ -145,6 +149,7 @@ func TestLearnUsecaseNextDueCardsLimitClampAndEmpty(t *testing.T) {
 				func() *rand.Rand { return rand.New(rand.NewSource(1)) },
 				20,
 				100,
+				newTestLogger(),
 			)
 
 			got, err := uc.NextDueCards(authedCtx("u-1"), "cg-1", now, tc.in)
@@ -167,6 +172,7 @@ func TestLearnUsecaseNextDueCardsRepoError(t *testing.T) {
 		func() *rand.Rand { return rand.New(rand.NewSource(1)) },
 		20,
 		100,
+		newTestLogger(),
 	)
 
 	_, err := uc.NextDueCards(authedCtx("u-1"), "cg-1", now, 5)
@@ -185,6 +191,7 @@ func TestLearnUsecaseNextDueCardsCardgroupRepoInternalError(t *testing.T) {
 		func() *rand.Rand { return rand.New(rand.NewSource(1)) },
 		20,
 		100,
+		newTestLogger(),
 	)
 
 	_, err := uc.NextDueCards(authedCtx("u-1"), "cg-1", now, 5)
@@ -199,19 +206,19 @@ func TestNewLearnUsecase_PanicsOnInvalidDeps(t *testing.T) {
 	t.Run("nil cardRepo", func(t *testing.T) {
 		t.Parallel()
 		require.Panics(t, func() {
-			NewLearnUsecase(nil, cgRepo, nil, nil, 20, 100)
+			NewLearnUsecase(nil, cgRepo, nil, nil, 20, 100, newTestLogger())
 		})
 	})
 	t.Run("nil cardgroupRepo", func(t *testing.T) {
 		t.Parallel()
 		require.Panics(t, func() {
-			NewLearnUsecase(cardRepo, nil, nil, nil, 20, 100)
+			NewLearnUsecase(cardRepo, nil, nil, nil, 20, 100, newTestLogger())
 		})
 	})
 	t.Run("defaultLimit greater than maxLimit", func(t *testing.T) {
 		t.Parallel()
 		require.Panics(t, func() {
-			NewLearnUsecase(cardRepo, cgRepo, nil, nil, 30, 20)
+			NewLearnUsecase(cardRepo, cgRepo, nil, nil, 30, 20, newTestLogger())
 		})
 	})
 }

--- a/backend/internal/usecase/notion_sync.go
+++ b/backend/internal/usecase/notion_sync.go
@@ -71,6 +71,9 @@ func NewNotionSyncUsecase(
 	db *gorm.DB,
 	logger *slog.Logger,
 ) *NotionSyncUsecase {
+	if logger == nil {
+		panic("usecase: notion sync: logger is required")
+	}
 	uc := &NotionSyncUsecase{
 		fetcher:       fetcher,
 		cardgroupRepo: cardgroupRepo,
@@ -92,6 +95,9 @@ func NewNotionSyncUsecaseWithTx(
 	tx txRunner,
 	logger *slog.Logger,
 ) *NotionSyncUsecase {
+	if logger == nil {
+		panic("usecase: notion sync: logger is required")
+	}
 	return &NotionSyncUsecase{
 		fetcher:       fetcher,
 		cardgroupRepo: cardgroupRepo,
@@ -137,24 +143,20 @@ func (u *NotionSyncUsecase) Sync(ctx context.Context, input SyncFromNotionInput)
 	// happens to also have duplicates added later in the pipeline.
 	if len(rows) == 0 && len(parseErrs) > 0 {
 		if allDictionaryErrorsSkipped(parseErrs) {
-			if u.logger != nil {
-				u.logger.InfoContext(ctx, "notion sync: skip-only payload, no persistence",
-					"skipped_count", len(parseErrs),
-					"first_line", parseErrs[0].Line,
-					"first_kind", parseErrs[0].Kind,
-					"first_snippet", parseErrs[0].Snippet,
-				)
-			}
+			u.logger.InfoContext(ctx, "notion sync: skip-only payload, no persistence",
+				"skipped_count", len(parseErrs),
+				"first_line", parseErrs[0].Line,
+				"first_kind", parseErrs[0].Kind,
+				"first_snippet", parseErrs[0].Snippet,
+			)
 			return SyncFromNotionOutput{ParseErrors: parseErrs}, nil
 		}
-		if u.logger != nil {
-			u.logger.WarnContext(ctx, "notion sync: all rows failed to parse",
-				"parse_error_count", len(parseErrs),
-				"first_error_line", parseErrs[0].Line,
-				"first_error_kind", parseErrs[0].Kind,
-				"first_error_snippet", parseErrs[0].Snippet,
-			)
-		}
+		u.logger.WarnContext(ctx, "notion sync: all rows failed to parse",
+			"parse_error_count", len(parseErrs),
+			"first_error_line", parseErrs[0].Line,
+			"first_error_kind", parseErrs[0].Kind,
+			"first_error_snippet", parseErrs[0].Snippet,
+		)
 		return SyncFromNotionOutput{}, eris.Wrap(ErrNotionSyncParse, "all rows failed to parse")
 	}
 	if len(rows) > dictionaryParsedRowCap {
@@ -201,15 +203,13 @@ func (u *NotionSyncUsecase) Sync(ctx context.Context, input SyncFromNotionInput)
 		return SyncFromNotionOutput{}, eris.Wrap(errors.Join(ErrNotionSyncPersist, err), "persist cards")
 	}
 
-	if u.logger != nil {
-		u.logger.InfoContext(ctx, "notion sync complete",
-			"cardgroup_id", out.CardgroupID,
-			"inserted", out.Inserted,
-			"updated", out.Updated,
-			"deleted", out.Deleted,
-			"parse_errors_count", len(out.ParseErrors),
-		)
-	}
+	u.logger.InfoContext(ctx, "notion sync complete",
+		"cardgroup_id", out.CardgroupID,
+		"inserted", out.Inserted,
+		"updated", out.Updated,
+		"deleted", out.Deleted,
+		"parse_errors_count", len(out.ParseErrors),
+	)
 	return out, nil
 }
 
@@ -260,14 +260,12 @@ func parseNotionPages(ctx context.Context, logger *slog.Logger, pages []notion.P
 			// side (the function returns nil rows). Log the failing page so
 			// operators can locate the breakage; the caller maps err into
 			// ErrNotionSyncParse.
-			if logger != nil {
-				logger.ErrorContext(ctx, "notion sync: page parse failed",
-					"page_index", i,
-					"page_id", page.ID,
-					"error_name", reflect.TypeOf(err).String(),
-					"error", err.Error(),
-				)
-			}
+			logger.ErrorContext(ctx, "notion sync: page parse failed",
+				"page_index", i,
+				"page_id", page.ID,
+				"error_name", reflect.TypeOf(err).String(),
+				"error", err.Error(),
+			)
 			return nil, nil, err
 		}
 		for _, word := range words {

--- a/backend/internal/usecase/notion_sync_test.go
+++ b/backend/internal/usecase/notion_sync_test.go
@@ -114,7 +114,7 @@ func TestNotionSyncUsecase_DiffMerge(t *testing.T) {
 		upsertResult:   repository.UpsertManyTxResult{Inserted: 1, Updated: 1},
 	}
 	tx, txCalls := dictTxRunner()
-	uc := NewNotionSyncUsecaseWithTx(fetcher, cardgroups, cards, tx, nil)
+	uc := NewNotionSyncUsecaseWithTx(fetcher, cardgroups, cards, tx, newTestLogger())
 
 	out, err := uc.Sync(context.Background(), SyncFromNotionInput{
 		PageIDs:       []string{" page-1 ", "page-1"},
@@ -163,7 +163,7 @@ func TestNotionSyncUsecase_DuplicateFrontLastWins(t *testing.T) {
 	cardgroups := &mockNotionCardgroupRepo{cg: &domain.Cardgroup{ID: "cg-target"}}
 	cards := &mockNotionCardRepo{upsertResult: repository.UpsertManyTxResult{Inserted: 1}}
 	tx, txCalls := dictTxRunner()
-	uc := NewNotionSyncUsecaseWithTx(fetcher, cardgroups, cards, tx, nil)
+	uc := NewNotionSyncUsecaseWithTx(fetcher, cardgroups, cards, tx, newTestLogger())
 
 	out, err := uc.Sync(context.Background(), SyncFromNotionInput{
 		PageIDs:       []string{"page-1", "page-2"},
@@ -216,7 +216,7 @@ func TestNotionSyncUsecase_DuplicateFrontSamePageLastWins(t *testing.T) {
 	cardgroups := &mockNotionCardgroupRepo{cg: &domain.Cardgroup{ID: "cg-target"}}
 	cards := &mockNotionCardRepo{upsertResult: repository.UpsertManyTxResult{Inserted: 1}}
 	tx, txCalls := dictTxRunner()
-	uc := NewNotionSyncUsecaseWithTx(fetcher, cardgroups, cards, tx, nil)
+	uc := NewNotionSyncUsecaseWithTx(fetcher, cardgroups, cards, tx, newTestLogger())
 
 	out, err := uc.Sync(context.Background(), SyncFromNotionInput{
 		PageIDs:       []string{"page-1"},
@@ -312,7 +312,7 @@ func newValidationUsecase() *NotionSyncUsecase {
 		&mockNotionCardgroupRepo{},
 		&mockNotionCardRepo{},
 		tx,
-		nil,
+		newTestLogger(),
 	)
 }
 
@@ -329,7 +329,7 @@ func TestNotionSyncUsecase_SoftParseFailure(t *testing.T) {
 	cardgroups := &mockNotionCardgroupRepo{}
 	cards := &mockNotionCardRepo{}
 	tx, txCalls := dictTxRunner()
-	uc := NewNotionSyncUsecaseWithTx(fetcher, cardgroups, cards, tx, nil)
+	uc := NewNotionSyncUsecaseWithTx(fetcher, cardgroups, cards, tx, newTestLogger())
 
 	_, err := uc.Sync(context.Background(), SyncFromNotionInput{
 		PageIDs:       []string{"page-1"},
@@ -361,7 +361,7 @@ func TestNotionSyncUsecase_MixedSkipAndLexerErrorIsNotSkipOnly(t *testing.T) {
 	cardgroups := &mockNotionCardgroupRepo{}
 	cards := &mockNotionCardRepo{}
 	tx, txCalls := dictTxRunner()
-	uc := NewNotionSyncUsecaseWithTx(fetcher, cardgroups, cards, tx, nil)
+	uc := NewNotionSyncUsecaseWithTx(fetcher, cardgroups, cards, tx, newTestLogger())
 
 	_, err := uc.Sync(context.Background(), SyncFromNotionInput{
 		PageIDs:       []string{"page-1"},
@@ -394,7 +394,7 @@ func TestNotionSyncUsecase_LoneFrontDoesNotOverwriteExistingBack(t *testing.T) {
 	cardgroups := &mockNotionCardgroupRepo{cg: &domain.Cardgroup{ID: "cg-target"}}
 	cards := &mockNotionCardRepo{existingFronts: []string{"apple"}}
 	tx, txCalls := dictTxRunner()
-	uc := NewNotionSyncUsecaseWithTx(fetcher, cardgroups, cards, tx, nil)
+	uc := NewNotionSyncUsecaseWithTx(fetcher, cardgroups, cards, tx, newTestLogger())
 
 	out, err := uc.Sync(context.Background(), SyncFromNotionInput{
 		PageIDs:       []string{"page-1"},
@@ -433,7 +433,7 @@ func TestNotionSyncUsecase_FetchErrorSkipsPersistence(t *testing.T) {
 	cardgroups := &mockNotionCardgroupRepo{}
 	cards := &mockNotionCardRepo{}
 	tx, txCalls := dictTxRunner()
-	uc := NewNotionSyncUsecaseWithTx(fetcher, cardgroups, cards, tx, nil)
+	uc := NewNotionSyncUsecaseWithTx(fetcher, cardgroups, cards, tx, newTestLogger())
 
 	_, err := uc.Sync(context.Background(), SyncFromNotionInput{
 		PageIDs:       []string{"page-1"},
@@ -456,7 +456,7 @@ func TestNotionSyncUsecase_PersistError(t *testing.T) {
 	cardgroups := &mockNotionCardgroupRepo{cg: &domain.Cardgroup{ID: "cg-target"}}
 	cards := &mockNotionCardRepo{upsertErr: boom}
 	tx, _ := dictTxRunner()
-	uc := NewNotionSyncUsecaseWithTx(fetcher, cardgroups, cards, tx, nil)
+	uc := NewNotionSyncUsecaseWithTx(fetcher, cardgroups, cards, tx, newTestLogger())
 
 	_, err := uc.Sync(context.Background(), SyncFromNotionInput{
 		PageIDs:       []string{"page-1"},
@@ -481,7 +481,7 @@ func TestNotionSyncUsecase_CardgroupEnsureError(t *testing.T) {
 	cardgroups := &mockNotionCardgroupRepo{err: dbErr}
 	cards := &mockNotionCardRepo{}
 	tx, txCalls := dictTxRunner()
-	uc := NewNotionSyncUsecaseWithTx(fetcher, cardgroups, cards, tx, nil)
+	uc := NewNotionSyncUsecaseWithTx(fetcher, cardgroups, cards, tx, newTestLogger())
 
 	_, err := uc.Sync(context.Background(), SyncFromNotionInput{
 		PageIDs:       []string{"page-1"},
@@ -520,7 +520,7 @@ func TestNotionSyncUsecase_ListFrontsError(t *testing.T) {
 	cardgroups := &mockNotionCardgroupRepo{cg: &domain.Cardgroup{ID: "cg-target"}}
 	cards := &mockNotionCardRepo{listErr: listErr}
 	tx, txCalls := dictTxRunner()
-	uc := NewNotionSyncUsecaseWithTx(fetcher, cardgroups, cards, tx, nil)
+	uc := NewNotionSyncUsecaseWithTx(fetcher, cardgroups, cards, tx, newTestLogger())
 
 	_, err := uc.Sync(context.Background(), SyncFromNotionInput{
 		PageIDs:       []string{"page-1"},

--- a/backend/internal/usecase/swipe.go
+++ b/backend/internal/usecase/swipe.go
@@ -70,6 +70,7 @@ type SwipeUsecase struct {
 	randSource    func() *rand.Rand
 	tx            txRunner
 	nextBatchSize int
+	logger        *slog.Logger
 }
 
 type HandleSwipeInput struct {
@@ -104,7 +105,11 @@ func NewSwipeUsecase(
 	scheduler *service.FSRSScheduler,
 	nextBatchSize int,
 	userCardFSRSRepo UserCardFSRSRepoForSwipe,
+	logger *slog.Logger,
 ) *SwipeUsecase {
+	if logger == nil {
+		panic("usecase: swipe: logger is required")
+	}
 	if scheduler == nil {
 		scheduler = service.NewFSRSScheduler()
 	}
@@ -122,6 +127,7 @@ func NewSwipeUsecase(
 			return rand.New(rand.NewSource(time.Now().UnixNano()))
 		},
 		nextBatchSize: nextBatchSize,
+		logger:        logger,
 	}
 	if db != nil {
 		uc.tx = func(ctx context.Context, fn func(tx *gorm.DB) error) error {
@@ -139,8 +145,12 @@ func NewSwipeUsecaseWithTx(
 	nextBatchSize int,
 	tx txRunner,
 	userCardFSRSRepo UserCardFSRSRepoForSwipe,
+	logger *slog.Logger,
 ) *SwipeUsecase {
-	uc := NewSwipeUsecase(nil, cardRepo, cardgroupRepo, swipeRepo, scheduler, nextBatchSize, userCardFSRSRepo)
+	if logger == nil {
+		panic("usecase: swipe: logger is required")
+	}
+	uc := NewSwipeUsecase(nil, cardRepo, cardgroupRepo, swipeRepo, scheduler, nextBatchSize, userCardFSRSRepo, logger)
 	uc.tx = tx
 	return uc
 }

--- a/backend/internal/usecase/swipe_performance_test.go
+++ b/backend/internal/usecase/swipe_performance_test.go
@@ -96,6 +96,7 @@ func TestSwipeUsecase_HandleSwipePerformanceMode(t *testing.T) {
 				10,
 				tx,
 				userFSRSRepo,
+				newTestLogger(),
 			)
 
 			outcome, err := uc.HandleSwipe(authedCtx("user-1"), HandleSwipeInput{
@@ -156,6 +157,7 @@ func TestSwipeUsecase_HandleSwipeCreatesUserFSRSStateForFirstSwipe(t *testing.T)
 		10,
 		tx,
 		userFSRSRepo,
+		newTestLogger(),
 	)
 
 	outcome, err := uc.HandleSwipe(authedCtx("user-1"), HandleSwipeInput{
@@ -207,6 +209,7 @@ func TestSwipeUsecase_HandleSwipe_NonOwner_Unauthenticated(t *testing.T) {
 		10,
 		tx,
 		&mockUserCardFSRSRepository{byCardID: map[string]*domain.UserCardFSRS{}},
+		newTestLogger(),
 	)
 
 	_, err := uc.HandleSwipe(authedCtx("user-1"), HandleSwipeInput{
@@ -273,6 +276,7 @@ func TestSwipeUsecase_HandleSwipe_PropagatesUpsertError(t *testing.T) {
 		10,
 		tx,
 		userFSRSRepo,
+		newTestLogger(),
 	)
 
 	_, err := uc.HandleSwipe(authedCtx("user-1"), HandleSwipeInput{
@@ -306,6 +310,7 @@ func TestSwipeUsecase_HandleSwipe_InvalidMode_ValidationVariant(t *testing.T) {
 		10,
 		tx,
 		&mockUserCardFSRSRepository{byCardID: map[string]*domain.UserCardFSRS{}},
+		newTestLogger(),
 	)
 
 	outcome, err := uc.HandleSwipe(authedCtx("user-1"), HandleSwipeInput{
@@ -352,6 +357,7 @@ func TestSwipeUsecase_HandleSwipe_CardNotFound_ValidationVariant(t *testing.T) {
 		10,
 		tx,
 		&mockUserCardFSRSRepository{byCardID: map[string]*domain.UserCardFSRS{}},
+		newTestLogger(),
 	)
 
 	outcome, err := uc.HandleSwipe(authedCtx("user-1"), HandleSwipeInput{
@@ -395,6 +401,7 @@ func TestSwipeUsecase_HandleSwipe_CardgroupNotFound_ValidationVariant(t *testing
 		10,
 		tx,
 		&mockUserCardFSRSRepository{byCardID: map[string]*domain.UserCardFSRS{}},
+		newTestLogger(),
 	)
 
 	outcome, err := uc.HandleSwipe(authedCtx("user-1"), HandleSwipeInput{
@@ -447,6 +454,7 @@ func TestSwipeUsecase_HandleSwipe_CardCrossCardgroup_ValidationVariant(t *testin
 		10,
 		tx,
 		&mockUserCardFSRSRepository{byCardID: map[string]*domain.UserCardFSRS{}},
+		newTestLogger(),
 	)
 
 	outcome, err := uc.HandleSwipe(authedCtx("user-1"), HandleSwipeInput{

--- a/backend/internal/usecase/user.go
+++ b/backend/internal/usecase/user.go
@@ -32,11 +32,15 @@ type UserRepository interface {
 }
 
 type UserUsecase struct {
-	repo UserRepository
+	repo   UserRepository
+	logger *slog.Logger
 }
 
-func NewUserUsecase(repo UserRepository) *UserUsecase {
-	return &UserUsecase{repo: repo}
+func NewUserUsecase(repo UserRepository, logger *slog.Logger) *UserUsecase {
+	if logger == nil {
+		panic("usecase: user: logger is required")
+	}
+	return &UserUsecase{repo: repo, logger: logger}
 }
 
 func (u *UserUsecase) Me(ctx context.Context) (*domain.User, error) {
@@ -50,7 +54,7 @@ func (u *UserUsecase) Me(ctx context.Context) (*domain.User, error) {
 	}
 	if errors.Is(err, repository.ErrNotFound) {
 		// handle_new_user trigger should have provisioned the row; degrade gracefully.
-		slog.Warn("user row missing for authenticated user; returning empty user",
+		u.logger.WarnContext(ctx, "user row missing for authenticated user; returning empty user",
 			"user_id", user.Sub)
 		return &domain.User{ID: user.Sub}, nil
 	}

--- a/backend/internal/usecase/user_test.go
+++ b/backend/internal/usecase/user_test.go
@@ -82,7 +82,7 @@ func TestUserUsecase_Me(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			repo := &mockUserRepository{findResult: tc.findResult, findErr: tc.findErr}
-			uc := NewUserUsecase(repo)
+			uc := NewUserUsecase(repo, newTestLogger())
 
 			p, err := uc.Me(tc.ctx)
 
@@ -261,7 +261,7 @@ func TestUserUsecase_UpdateUser(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			repo := &mockUserRepository{updateResult: tc.repoResult, updateErr: tc.repoErr}
-			uc := NewUserUsecase(repo)
+			uc := NewUserUsecase(repo, newTestLogger())
 
 			outcome, err := uc.UpdateUser(tc.ctx, tc.input)
 
@@ -335,7 +335,7 @@ func TestUserUsecase_UpdateUser_SuccessVariant(t *testing.T) {
 
 	returned := &domain.User{ID: "u1", DisplayName: ptr("Alice")}
 	repo := &mockUserRepository{updateResult: returned}
-	uc := NewUserUsecase(repo)
+	uc := NewUserUsecase(repo, newTestLogger())
 
 	outcome, err := uc.UpdateUser(authedCtx("u1"), UpdateUserInput{DisplayName: "Alice"})
 
@@ -354,7 +354,7 @@ func TestUserUsecase_UpdateUser_ValidationVariant_DisplayName(t *testing.T) {
 	t.Parallel()
 
 	repo := &mockUserRepository{}
-	uc := NewUserUsecase(repo)
+	uc := NewUserUsecase(repo, newTestLogger())
 
 	outcome, err := uc.UpdateUser(authedCtx("u1"), UpdateUserInput{DisplayName: ""})
 
@@ -379,7 +379,7 @@ func TestUserUsecase_UpdateUser_ValidationVariant_Bio(t *testing.T) {
 	t.Parallel()
 
 	repo := &mockUserRepository{}
-	uc := NewUserUsecase(repo)
+	uc := NewUserUsecase(repo, newTestLogger())
 
 	outcome, err := uc.UpdateUser(authedCtx("u1"), UpdateUserInput{
 		DisplayName: "Alice",
@@ -407,7 +407,7 @@ func TestUserUsecase_UpdateUser_RepoError_InfraChannel(t *testing.T) {
 	t.Parallel()
 
 	repo := &mockUserRepository{updateErr: errors.New("db: storage failure")}
-	uc := NewUserUsecase(repo)
+	uc := NewUserUsecase(repo, newTestLogger())
 
 	_, err := uc.UpdateUser(authedCtx("u1"), UpdateUserInput{DisplayName: "Alice"})
 

--- a/docs/backend/error-wrapping/logging-error-warn-helpers.md
+++ b/docs/backend/error-wrapping/logging-error-warn-helpers.md
@@ -40,3 +40,18 @@ Today's call sites:
 2. **`cmd/server/main.go main()`** — terminal error before `os.Exit(1)` (uses `LogError`, ERROR level).
 3. **`gqlerr.Cancelled(ctx, err)`** — client cancellation / server timeout returned through GraphQL (uses `LogWarn`, WARN level).
 4. **`auth/middleware.go reject(c, cause)`** — token-rejection log (uses `LogWarn`, WARN level).
+
+### Usecase-layer logger dependency injection
+
+Production code under `backend/internal/usecase/` MUST log through an injected `uc.logger *slog.Logger` field — never via the bare package-level `slog.Warn` / `slog.WarnContext` / `slog.Info` / `slog.InfoContext` / `slog.Error` / `slog.ErrorContext` / `slog.Default()` / `slog.LogAttrs` calls. Every usecase struct carries a logger field set via constructor; the constructor panics if the logger is nil (matches the [`constructor-panics-for-non-empty-config`](../library-gotchas/constructor-panics-for-non-empty-config.md) rule). The composition root in `cmd/server/main.go` plumbs the application's `*slog.Logger` into every `usecase.NewXxx(...)` call as the trailing positional argument.
+
+The `gqlerr.Internal` / `gqlerr.Cancelled` constructors in `backend/internal/gqlerr/` are deliberately exempt — the transport layer is the correct seam for the process-default logger because it has no upstream caller to inject from. Usecase code does not have that excuse.
+
+Acceptance check (run from the repo root):
+
+```bash
+grep -rnE 'slog\.(Default|SetDefault|Warn|WarnContext|Info|InfoContext|Error|ErrorContext|LogAttrs)\(' \
+    backend/internal/usecase/ --include='*.go' | grep -v '_test.go'
+```
+
+Expected: empty. Any match is a regression.

--- a/docs/backend/library-gotchas/tparallel-slog-setdefault-race.md
+++ b/docs/backend/library-gotchas/tparallel-slog-setdefault-race.md
@@ -39,4 +39,4 @@ causes state leakage across test functions.
 **Reference:** `backend/internal/gqlerr/errors_test.go` — `TestRecoverFunc`,
 `TestInternal_logsError`, and `TestInternal_VariadicAttrs` all follow this pattern.
 
-**Scope after issue #161 landed.** This gotcha applies to handler, auth, and gqlerr tests only — the usecase layer no longer touches `slog.SetDefault`. Every usecase constructor takes an injected `*slog.Logger`; tests pass a discard logger via the `newTestLogger()` helper in `backend/internal/usecase/helpers_test.go` and run unrestricted under `t.Parallel()`.
+**Scope.** This gotcha applies to handler, auth, and gqlerr tests where `slog.SetDefault` is the only seam available. The usecase layer is exempt: every usecase constructor takes an injected `*slog.Logger`, and tests pass a discard logger via the `newTestLogger()` helper in `backend/internal/usecase/helpers_test.go`, so usecase tests run unrestricted under `t.Parallel()`. See [#161] for the design rationale.

--- a/docs/backend/library-gotchas/tparallel-slog-setdefault-race.md
+++ b/docs/backend/library-gotchas/tparallel-slog-setdefault-race.md
@@ -38,3 +38,5 @@ causes state leakage across test functions.
 
 **Reference:** `backend/internal/gqlerr/errors_test.go` — `TestRecoverFunc`,
 `TestInternal_logsError`, and `TestInternal_VariadicAttrs` all follow this pattern.
+
+**Scope after issue #161 landed.** This gotcha applies to handler, auth, and gqlerr tests only — the usecase layer no longer touches `slog.SetDefault`. Every usecase constructor takes an injected `*slog.Logger`; tests pass a discard logger via the `newTestLogger()` helper in `backend/internal/usecase/helpers_test.go` and run unrestricted under `t.Parallel()`.


### PR DESCRIPTION
## Summary

Injects `*slog.Logger` into every usecase struct in `backend/internal/usecase/` via constructor, replacing the bare package-level `slog.*` / `slog.Default()` calls that tied the application layer to the process-default logger. After this change the usecase layer is transport-and-process-default-agnostic — tests construct usecases with a discard logger and can run unrestricted under `t.Parallel()` without the `slog.SetDefault` race guarded by [`tparallel-slog-setdefault-race.md`](../../docs/backend/library-gotchas/tparallel-slog-setdefault-race.md). Implements Option A from #161.

Closes #161.

## Background / Motivation

- **`slog.Default()` made the usecase layer implicitly transport-coupled.** After #154 / #158 decoupled `usecase` from `gqlerr`, the layer still reached for `slog.Default()` for warn-and-continue paths (notion writeback failure, cursor fallback, bulk-delete partial match). The process-default logger is a transport-layer concern; the application layer should not depend on it.
- **`slog.SetDefault` in tests forbids `t.Parallel()` across the whole subtree.** The pre-#161 usecase tests had to swap `slog.Default()` in `t.Cleanup` (per [`tparallel-slog-setdefault-race.md`](../../docs/backend/library-gotchas/tparallel-slog-setdefault-race.md)). Concurrent mutation of a process global racing with sibling tests' reads of the default logger meant the usecase test directory could not run in parallel — the slowest test in the package dictated the wall-clock time for the whole suite.
- **`gqlerr.Internal` / `gqlerr.Cancelled` stay on `slog.Default()` by design.** The transport layer is the right place for the process-default logger because it has no upstream caller to inject from. Out-of-scope per #161 § "Out of Scope".

## Changes

### Usecase constructors take a trailing `*slog.Logger`

- `backend/internal/usecase/{card,cardgroup,user,learn,swipe,dictionary,admin_user,admin_role,last_viewed_cardgroup,notion_sync}.go`: every `NewXxxUsecase(...)` constructor accepts `*slog.Logger` as the trailing positional argument and stores it in a `logger *slog.Logger` field. Each constructor panics with `"usecase: <name>: logger is required"` on a nil logger — matches the [`constructor-panics-for-non-empty-config`](../../docs/backend/library-gotchas/constructor-panics-for-non-empty-config.md) rule.
- `backend/internal/usecase/card.go`: `NewCardUsecaseWithTx` (the test-only constructor that takes an explicit `tx` function) gets the same trailing `logger` argument and panic guard.

### Bare `slog.*` call sites rewritten to `uc.logger`

- `backend/internal/usecase/card.go`: notion-writeback goroutine in `Create` (captures `u.logger` into a local before the `go func()` to detach from the request lifecycle, per [`fire-and-forget-goroutine-detached-context`](../../docs/backend/library-gotchas/fire-and-forget-goroutine-detached-context.md)), `resolveCursor` userFSRSRepo-nil warn, and `BulkDelete` partial-match info log all switch to `u.logger`. The notion-writeback log gains `cardgroup_id` as a structured attribute — the previous code had a `TODO(#161)` for it because `slog.Default()` lacked the context plumbing.
- `backend/internal/usecase/{cardgroup,user,learn,swipe,dictionary,admin_user,admin_role,last_viewed_cardgroup,notion_sync}.go`: every remaining `slog.WarnContext` / `slog.InfoContext` / `slog.ErrorContext` / `slog.LogAttrs` call site routes through `uc.logger`.

### Composition root wires the application logger

- `backend/cmd/server/main.go`: `run(ctx, logger)` already has the application's `*slog.Logger` in scope from #154's logger bootstrap. Every `usecase.NewXxx(...)` call passes `logger` as the trailing argument. `usecase.SwipeNextBatchSize(logger)` (an option func that already took the logger) keeps its current shape — only the trailing constructor arg is new.

### Tests inject a discard logger and run unrestricted

- `backend/internal/usecase/helpers_test.go`: adds `newTestLogger()` returning `slog.New(slog.DiscardHandler)`. Every usecase test (`card_test.go`, `cardgroup_test.go`, `user_test.go`, `learn_test.go`, `swipe_performance_test.go`, `dictionary_test.go`, `admin_user_test.go`, `admin_role_test.go`, `last_viewed_cardgroup_test.go`, `notion_sync_test.go`, `card_bulk_delete_test.go`) constructs usecases via the helper and drops the previous `slog.SetDefault` / `t.Cleanup` swap. `slog.DiscardHandler` (Go 1.24+) is preferred over `slog.NewTextHandler(io.Discard, nil)` because it skips attribute formatting entirely.
- `backend/graph/resolver/test_logger_test.go` (new): adds `newDiscardLogger()` so resolver tests can satisfy the new constructor signature without producing log noise. Adopted by `admin_user_resolver_test.go`, `card_resolvers_test.go`, `cardgroup_resolvers_test.go`, `last_viewed_cardgroup_resolver_test.go`, `swipe_resolver_test.go`, `user_test.go`.
- `backend/cmd/server/main_test.go`: integration-test usecase construction passes the test logger through.

### Docs / rules

- `docs/backend/error-wrapping/logging-error-warn-helpers.md` (new sub-section "Usecase-layer logger dependency injection"): documents the convention — `uc.logger` only, never bare `slog.*` in production usecase code — and pins a grep-based acceptance check.
- `docs/backend/library-gotchas/tparallel-slog-setdefault-race.md`: adds a "Scope" note that the gotcha does not apply to the usecase layer post-#161; usecase tests run with `t.Parallel()` enabled.
- `.claude/rules/error-wrapping.md`: one-line index entry for the new logger-DI sub-section under § "Logging — detailed cases (on-demand)".

## Verification

```bash
cd backend
go vet ./...
go build ./...
go test -race -count=1 ./...

# No bare slog.* calls in usecase production code (the grep gate documented in
# docs/backend/error-wrapping/logging-error-warn-helpers.md § "Usecase-layer
# logger dependency injection"). Expect: empty output.
grep -rnE 'slog\.(Default|SetDefault|Warn|WarnContext|Info|InfoContext|Error|ErrorContext|LogAttrs)\(' \
    backend/internal/usecase/ --include='*.go' | grep -v '_test.go'

# Smoke that a usecase test runs under t.Parallel() repeatedly without racing.
go test -race -count=10 ./backend/internal/usecase/...

# Language-policy and PR-order checks (per .claude/rules/language-policy.md).
grep -rlP "[\x{3040}-\x{30ff}\x{4e00}-\x{9fff}]" \
  --include="*.go" --include="*.ts" --include="*.tsx" \
  --include="*.graphql" --include="*.sql" --include="*.md" \
  docs backend/internal backend/cmd backend/graph frontend/src
grep -rnE "PR[0-9]+" docs backend/internal backend/cmd backend/graph frontend/src
# Expect: empty output for both.
```

## Test plan

- [x] `go vet ./... && go build ./... && go test -race -count=1 ./...` passes in `backend/`.
- [x] Grep gate from `logging-error-warn-helpers.md` § "Usecase-layer logger dependency injection" returns empty against `backend/internal/usecase/*.go` (production only).
- [x] Usecase tests run with `t.Parallel()` enabled and pass under `go test -race -count=10 ./internal/usecase/...`.
- [ ] Regression: constructing any usecase with a nil `*slog.Logger` panics with `usecase: <name>: logger is required` (covered by the constructor panic; verified by a unit test in `card_test.go`).
- [ ] Regression: re-introducing a bare `slog.WarnContext(...)` in any `backend/internal/usecase/*.go` production file is caught by the grep gate.
- [ ] Notion writeback failure surfaces `card_id`, `page_id`, `cardgroup_id`, `err` as structured attrs on the warn line (the `TODO(#161)` is resolved by the new attribute set).
- [ ] Language-policy and PR-order greps from `.claude/rules/language-policy.md` print nothing.
