### PR TITLE
docs: add AGENTS.md pointers for non-Claude agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# AGENTS.md
+
+Agent guidance for this repository lives in [`CLAUDE.md`](CLAUDE.md). The instructions there apply to any AI coding agent (Codex, Claude Code, Cursor, etc.) — not just Claude.
+
+The repo uses a hierarchical scheme: `backend/`, `frontend/`, `schema/`, and `docs/` each have their own `CLAUDE.md` (with a sibling `AGENTS.md` pointer) that auto-loads when working under that directory.

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -1,0 +1,3 @@
+# AGENTS.md
+
+Agent guidance for this directory lives in [`CLAUDE.md`](CLAUDE.md). The conventions there apply to any AI coding agent (Codex, Claude Code, Cursor, etc.).

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,3 @@
+# AGENTS.md
+
+Agent guidance for this directory lives in [`CLAUDE.md`](CLAUDE.md). The conventions there apply to any AI coding agent (Codex, Claude Code, Cursor, etc.).

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -1,0 +1,3 @@
+# AGENTS.md
+
+Agent guidance for this directory lives in [`CLAUDE.md`](CLAUDE.md). The conventions there apply to any AI coding agent (Codex, Claude Code, Cursor, etc.).

--- a/schema/AGENTS.md
+++ b/schema/AGENTS.md
@@ -1,0 +1,3 @@
+# AGENTS.md
+
+Agent guidance for this directory lives in [`CLAUDE.md`](CLAUDE.md). The conventions there apply to any AI coding agent (Codex, Claude Code, Cursor, etc.).


### PR DESCRIPTION
## Summary

Adds `AGENTS.md` at the repo root and at each top-level directory (`backend/`, `frontend/`, `schema/`, `docs/`) so that non-Claude coding agents — Codex, Cursor, and any future tool that follows the [`AGENTS.md` convention](https://agentsmd.net/) — discover the same guidance Claude Code already loads via its hierarchical `CLAUDE.md` scheme. Each `AGENTS.md` is a 1–4 line pointer to the sibling `CLAUDE.md`; no content is duplicated, so the two never drift. Diff is 17 / 0 lines across 5 new files.

No linked issue — this branch was scoped from a direct request; the change is too small to justify a tracking issue.

## Background / Motivation

- **`CLAUDE.md` is Claude-specific by filename.** The hierarchical scheme described in [`CLAUDE.md` § "Repo layout"](CLAUDE.md) (root + `backend/` + `frontend/` + `schema/` + `docs/`) is auto-loaded only by Claude Code. Codex, Cursor, and similar agents look for `AGENTS.md` at the working directory and walk upward — without one, they enter the repo blind to the conventions in [`.claude/rules/`](.claude/rules/) and the per-directory `CLAUDE.md` files.
- **Symlinks were rejected for portability.** A symlinked `AGENTS.md → CLAUDE.md` per directory would be zero-duplication, but symlinks break on Windows clones, on `git clone --no-symlinks`, and render as text-blobs (not file content) in GitHub's web UI. A 1–4 line pointer file is platform-neutral and renders normally.
- **A root-only `AGENTS.md` would defeat the hierarchical-load benefit.** Codex's directory-aware discovery is the whole point of the convention; pointing only from the root means subdirectory work loses the same per-area scoping that Claude Code gets from `backend/CLAUDE.md` etc.

## Changes

### Root pointer (with hierarchy explainer)

- `AGENTS.md` (new, 5 lines): points to [`CLAUDE.md`](CLAUDE.md) and additionally documents the hierarchical scheme — names the four subdirectories (`backend/`, `frontend/`, `schema/`, `docs/`) that each carry their own `CLAUDE.md` + `AGENTS.md` pair.

### Subdirectory pointers

- `backend/AGENTS.md`, `frontend/AGENTS.md`, `schema/AGENTS.md`, `docs/AGENTS.md` (new, 3 lines each): identical one-paragraph pointer to the same-directory `CLAUDE.md`. The pointer text names the audience explicitly ("Codex, Claude Code, Cursor, etc.") so a reader who lands on `AGENTS.md` first knows the file is intentional, not vestigial.

## Verification

```bash
# All five pointer files present at expected paths.
find . -maxdepth 3 -name AGENTS.md -not -path "./.claude/*" -not -path "./node_modules/*" | sort
# Expect: ./AGENTS.md ./backend/AGENTS.md ./docs/AGENTS.md ./frontend/AGENTS.md ./schema/AGENTS.md

# No content is duplicated from CLAUDE.md — each subdirectory pointer is <= 4 lines.
for f in backend/AGENTS.md frontend/AGENTS.md schema/AGENTS.md docs/AGENTS.md; do
  echo "$f: $(wc -l < "$f") lines"
done
# Expect: each <= 4 lines.

# Each pointer links to its sibling CLAUDE.md (not a stale path).
grep -nE 'CLAUDE\.md' AGENTS.md backend/AGENTS.md frontend/AGENTS.md schema/AGENTS.md docs/AGENTS.md
# Expect: one match per file.

# Language-policy check (per .claude/rules/language-policy.md) — no CJK in the new files.
grep -lP "[\x{3040}-\x{30ff}\x{4e00}-\x{9fff}]" \
  AGENTS.md backend/AGENTS.md frontend/AGENTS.md schema/AGENTS.md docs/AGENTS.md
# Expect: empty output.
```

## Test plan

- [x] `find` confirms 5 `AGENTS.md` files at the expected paths.
- [x] Each subdirectory pointer is 3 lines; root pointer is 5 lines. No CLAUDE.md prose is copied.
- [x] Each pointer links to the sibling `CLAUDE.md` via a relative Markdown link (no absolute paths, no stale targets).
- [x] Language-policy grep (`.claude/rules/language-policy.md`) prints nothing for the new files.
- [ ] Open the repo in Codex (or another `AGENTS.md`-aware agent) at the root and at `backend/`; confirm the agent surfaces `AGENTS.md` at the correct directory level and follows the pointer to `CLAUDE.md`.
