### PR TITLE
refactor(backend/domain): Tier 3 — promote anemic-domain behaviour to domain layer (#182)

### DIFF
--- a/.claude/rules/backend-layering.md
+++ b/.claude/rules/backend-layering.md
@@ -35,6 +35,8 @@ The backend follows a DDD/layered architecture. The dependency arrow always poin
 
 **`internal/gqlerr`** sits inside `internal/` but belongs to the Presentation layer — it is a wire-format constructor, not a domain or application primitive. The fact that it lives under `internal/` does not make it available to domain or application code; the `go-arch-lint` config enforces its actual layer membership.
 
+**`internal/auth` lists `domain` in `mayDependOn`** — this is intentional and correct. `auth.Service.IsAdmin` compares a role membership query result against `domain.AdminRoleName`, a domain-owned constant that defines the canonical admin role name. Role membership is a domain concern; coupling the auth adapter to the canonical constant rather than a local string literal keeps the two in sync and prevents drift. The dependency arrow (`auth → domain`) is infrastructure importing domain, which is the normal inward direction.
+
 ## What `go-arch-lint` covers vs. doesn't
 
 `go-arch-lint` operates at the **import-graph level only**. Even with `deepScan: true` it does not classify function-call, struct-literal, or string-literal shapes. The CI grep gates in [`.github/workflows/backend.yml`](../../.github/workflows/backend.yml) are evaluated against that capability:

--- a/.claude/rules/ddd-patterns.md
+++ b/.claude/rules/ddd-patterns.md
@@ -1,0 +1,90 @@
+# DDD patterns
+
+> Applies to: `backend/internal/domain/` and adjacent usecase + service layers.
+> Learnings captured from issue #182 (Tier 3 — promote anemic-domain behaviour).
+
+This file collects the domain-driven design patterns introduced when promoting
+logic from anemic usecases into domain aggregates and value objects. For error
+wrapping conventions see [`.claude/rules/error-wrapping.md`](error-wrapping.md);
+for layer-graph invariants see [`.claude/rules/backend-layering.md`](backend-layering.md).
+
+## Patterns
+
+### Parse constructor for value objects
+
+`Parse<Type>(s string) (<Type>, error)` is the canonical VO constructor. Trim,
+validate bounds, return either the typed value or a domain sentinel. Callers at
+the usecase layer translate sentinels via `translate<Type>Err` helpers.
+
+[`docs/backend/ddd-patterns/value-object-parse-pattern.md`](../../docs/backend/ddd-patterns/value-object-parse-pattern.md)
+
+### Caller-supplied sentinels in a field-agnostic parser
+
+When a VO is shared by multiple fields with distinct sentinels, pass the sentinels
+as parameters to keep the VO field-agnostic. The aggregate calls the parser with
+the right sentinel for each field. Nil sentinels panic at the construction boundary.
+
+[`docs/backend/ddd-patterns/caller-supplied-sentinels-in-parser.md`](../../docs/backend/ddd-patterns/caller-supplied-sentinels-in-parser.md)
+
+### Trinary value object for optional profile fields
+
+`Bio` encodes "no change" / "explicit clear" / "set" in a struct with a private
+`*string`. `IsSet()` and `Value()` expose the trinary without an out-of-band flag.
+`ParseBio(nil)` returns the no-change case; whitespace-only inputs collapse to
+explicit-clear after trimming.
+
+[`docs/backend/ddd-patterns/trinary-value-object.md`](../../docs/backend/ddd-patterns/trinary-value-object.md)
+
+### Consumer-defined interface across package boundaries
+
+`domain.FSRSScheduler` is declared inside `domain/user_card_fsrs.go` and satisfied
+implicitly by `*service.FSRSScheduler`. This keeps the dependency arrow correct
+(`service → domain`, not `domain → service`) while letting the aggregate call back
+to the scheduler without a forbidden import. Related to the usecase → repository
+variant in `docs/backend/library-gotchas/consumer-defined-narrow-repo-interface.md`.
+
+[`docs/backend/ddd-patterns/consumer-defined-interface-cross-package.md`](../../docs/backend/ddd-patterns/consumer-defined-interface-cross-package.md)
+
+### Aggregate behaviour methods (promoting anemic-domain logic)
+
+`Role.IsSystem()`, `Rating.IsValid()`, and `UserCardFSRS.ApplyRating()` replace
+usecase-side validators and inline upserts. Each method enforces its own invariant
+in one place; all callers get the same check automatically.
+
+[`docs/backend/ddd-patterns/aggregate-behaviour-method.md`](../../docs/backend/ddd-patterns/aggregate-behaviour-method.md)
+
+### Zero-value docstring on string newtypes
+
+`type RoleName string` allows `RoleName("")` at any caller — Go cannot seal string
+newtypes. A one-line docstring ("The zero value is invalid; use `ParseRoleName` to
+construct") surfaces the gap at review time and in IDE hover. Applies to
+`RoleName`, `DisplayName`, and `CardText`.
+
+[`docs/backend/ddd-patterns/zero-value-docstring-on-string-newtypes.md`](../../docs/backend/ddd-patterns/zero-value-docstring-on-string-newtypes.md)
+
+### Exported bound constants prevent message drift
+
+`RoleNameMax`, `DisplayNameMax`, `BioMax` are exported so usecase `translate*Err`
+helpers can reference the constant instead of hardcoding the literal. Updating the
+cap automatically propagates to the user-facing error message.
+
+[`docs/backend/ddd-patterns/exported-bound-constants-prevent-message-drift.md`](../../docs/backend/ddd-patterns/exported-bound-constants-prevent-message-drift.md)
+
+### Helpers introduced but not wired must be deleted
+
+A speculative domain method with zero production callers at PR completion time must
+be removed in the same PR. Post-flight grep confirms zero callers; a zero count means
+delete, not "keep for later". Application of the existing scope-discipline rule.
+
+[`docs/backend/ddd-patterns/helpers-introduced-but-not-wired-must-be-deleted.md`](../../docs/backend/ddd-patterns/helpers-introduced-but-not-wired-must-be-deleted.md)
+
+## Further reading (on-demand)
+
+- [Value object Parse pattern](../../docs/backend/ddd-patterns/value-object-parse-pattern.md)
+- [Caller-supplied sentinels in a field-agnostic parser](../../docs/backend/ddd-patterns/caller-supplied-sentinels-in-parser.md)
+- [Trinary value object for optional profile fields](../../docs/backend/ddd-patterns/trinary-value-object.md)
+- [Consumer-defined interface across package boundaries](../../docs/backend/ddd-patterns/consumer-defined-interface-cross-package.md)
+- [Aggregate behaviour methods](../../docs/backend/ddd-patterns/aggregate-behaviour-method.md)
+- [Zero-value docstring on string newtypes](../../docs/backend/ddd-patterns/zero-value-docstring-on-string-newtypes.md)
+- [Exported bound constants prevent message drift](../../docs/backend/ddd-patterns/exported-bound-constants-prevent-message-drift.md)
+- [Helpers introduced but not wired must be deleted](../../docs/backend/ddd-patterns/helpers-introduced-but-not-wired-must-be-deleted.md)

--- a/.claude/rules/go-library-gotchas.md
+++ b/.claude/rules/go-library-gotchas.md
@@ -49,7 +49,7 @@ This matters most in DataLoader batch functions, where an empty key slice is a n
 - [Repository lookup methods scoped by tenant ID require a cross-tenant negative test](../../docs/backend/library-gotchas/repository-cross-tenant-negative-test.md)
 - [GORM rejects unconditional `Delete` — use `Where("1 = 1")` to opt out](../../docs/backend/library-gotchas/gorm-rejects-unconditional-delete.md)
 - [Tx and non-Tx repository methods share a private helper to avoid drift](../../docs/backend/library-gotchas/repo-tx-and-nontx-share-private-helper.md)
-- [Consumer-defined narrow repository interface per usecase](../../docs/backend/library-gotchas/consumer-defined-narrow-repo-interface.md)
+- [Consumer-defined narrow repository interface per usecase](../../docs/backend/library-gotchas/consumer-defined-narrow-repo-interface.md) — for the domain→service variant (same technique, architecture-enforced boundary) see [`docs/backend/ddd-patterns/consumer-defined-interface-cross-package.md`](../../docs/backend/ddd-patterns/consumer-defined-interface-cross-package.md)
 - [Inject `*rand.Rand` into pure functions to keep tests deterministic](../../docs/backend/library-gotchas/inject-rand-rand-for-deterministic-test.md)
 - [Postgres advisory lock for race-safe ensure-by-name when no UNIQUE constraint exists](../../docs/backend/library-gotchas/postgres-advisory-lock-for-ensure-by-name.md)
 - [`subtle.ConstantTimeCompare` leaks token length — pair with a rate limiter](../../docs/backend/library-gotchas/subtle-constanttimecompare-length-leak.md)
@@ -111,3 +111,10 @@ This matters most in DataLoader batch functions, where an empty key slice is a n
 - [Bool flag vs two-function split: ubiquitous language signals (`authorizeCardgroup*`)](../../docs/backend/library-gotchas/bool-flag-vs-two-function-ubiquitous-language.md)
 - [Direct unit tests for shared helpers + directionality assertion](../../docs/backend/library-gotchas/direct-unit-test-for-shared-helper.md)
 - [Dead context-done branch in pass-through helper — collapse to single return](../../docs/backend/library-gotchas/dead-context-check-in-pass-through-helper.md)
+
+## DDD patterns (on-demand)
+
+For domain-layer design patterns — value object constructors, aggregate behaviour
+methods, trinary VOs, exported bound constants, and speculative-helper deletion —
+see [`.claude/rules/ddd-patterns.md`](ddd-patterns.md) and the full chapter
+index under `docs/backend/ddd-patterns/`.

--- a/backend/.go-arch-lint.yml
+++ b/backend/.go-arch-lint.yml
@@ -43,7 +43,7 @@ commonComponents:
   - graph_model
 
 deps:
-  auth:               { mayDependOn: [logging, repository] }
+  auth:               { mayDependOn: [domain, logging, repository] }
   cursor:             { anyVendorDeps: true }           # leaf: vendor-only deps (eris, std)
   database:           { anyVendorDeps: true }           # leaf: vendor-only deps (gorm, pgx, migrate, eris)
   domain:             { anyVendorDeps: true }           # leaf: vendor-only deps (uuid, uniseg, eris)

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -29,6 +29,7 @@ import (
 	"backend/graph/resolver"
 	"backend/internal/auth"
 	"backend/internal/database"
+	"backend/internal/domain"
 	"backend/internal/domain/service"
 	"backend/internal/gqlerr"
 	"backend/internal/handler/notionsync"
@@ -190,7 +191,7 @@ func bootstrapSuperUserPromoter(
 ) (*auth.SuperUserPromoter, error) {
 	superUserEmails := auth.ParseSuperUserSet(emailsEnv)
 	if len(superUserEmails) > 0 {
-		adminRole, err := roleRepo.FindByName(ctx, "admin")
+		adminRole, err := roleRepo.FindByName(ctx, domain.AdminRoleName)
 		if err != nil {
 			return nil, eris.Wrap(err, "run: lookup admin role for super-user bootstrap")
 		}

--- a/backend/internal/auth/role.go
+++ b/backend/internal/auth/role.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/rotisserie/eris"
 
+	"backend/internal/domain"
 	"backend/internal/repository"
 )
 
@@ -21,10 +22,10 @@ func NewService(userRoles repository.UserRoleRepository) *Service {
 	return &Service{userRoles: userRoles}
 }
 
-// IsAdmin reports whether userID holds the "admin" role. The role name is
-// hardcoded to keep usecases from drifting to bespoke names.
+// IsAdmin reports whether userID holds the admin role (domain.AdminRoleName).
+// The role name is defined in the domain package to keep usecases from drifting to bespoke names.
 func (s *Service) IsAdmin(ctx context.Context, userID string) (bool, error) {
-	ok, err := s.userRoles.HasRole(ctx, userID, "admin")
+	ok, err := s.userRoles.HasRole(ctx, userID, domain.AdminRoleName)
 	if err != nil {
 		return false, eris.Wrap(err, "auth: check admin role")
 	}

--- a/backend/internal/domain/bio.go
+++ b/backend/internal/domain/bio.go
@@ -7,10 +7,10 @@ import (
 	"github.com/rotisserie/eris"
 )
 
-const bioMax = 500
+const BioMax = 500
 
-// ErrBioTooLong is returned when the trimmed bio exceeds bioMax graphemes.
-var ErrBioTooLong = eris.Errorf("user: bio exceeds %d characters", bioMax)
+// ErrBioTooLong is returned when the trimmed bio exceeds BioMax graphemes.
+var ErrBioTooLong = eris.Errorf("user: bio exceeds %d characters", BioMax)
 
 // Bio is the user profile bio, supporting a trinary: nil (no change),
 // pointer-to-"" (explicit clear), or pointer-to-non-empty (set).
@@ -20,22 +20,29 @@ type Bio struct {
 
 // ParseBio validates and trims s, preserving the trinary contract:
 // nil means "no change"; a pointer to "" means "explicit clear"; a pointer to
-// a non-empty string means "set". Returns ErrBioTooLong if the trimmed value
-// exceeds bioMax graphemes.
+// a non-empty string means "set". Surrounding whitespace is trimmed;
+// whitespace-only inputs collapse to the explicit-clear case (Value() returns
+// a pointer to ""). Returns ErrBioTooLong if the trimmed value exceeds BioMax graphemes.
 func ParseBio(s *string) (Bio, error) {
 	if s == nil {
 		return Bio{value: nil}, nil
 	}
 	trimmed := strings.TrimSpace(*s)
-	if uniseg.GraphemeClusterCount(trimmed) > bioMax {
+	if uniseg.GraphemeClusterCount(trimmed) > BioMax {
 		return Bio{}, ErrBioTooLong
 	}
 	return Bio{value: &trimmed}, nil
 }
 
-// Value returns the persistence-ready pointer: nil for "no change",
+// Value returns a copy of the persistence-ready pointer: nil for "no change",
 // pointer-to-"" for explicit clear, pointer-to-non-empty for set.
-func (b Bio) Value() *string { return b.value }
+func (b Bio) Value() *string {
+	if b.value == nil {
+		return nil
+	}
+	s := *b.value
+	return &s
+}
 
 // IsSet reports whether the caller supplied a value (including an explicit clear).
 // Returns false only when the Bio was constructed from a nil input.

--- a/backend/internal/domain/bio.go
+++ b/backend/internal/domain/bio.go
@@ -25,7 +25,7 @@ type Bio struct {
 // a pointer to ""). Returns ErrBioTooLong if the trimmed value exceeds BioMax graphemes.
 func ParseBio(s *string) (Bio, error) {
 	if s == nil {
-		return Bio{value: nil}, nil
+		return Bio{}, nil
 	}
 	trimmed := strings.TrimSpace(*s)
 	if uniseg.GraphemeClusterCount(trimmed) > BioMax {

--- a/backend/internal/domain/bio.go
+++ b/backend/internal/domain/bio.go
@@ -1,0 +1,42 @@
+package domain
+
+import (
+	"strings"
+
+	"github.com/rivo/uniseg"
+	"github.com/rotisserie/eris"
+)
+
+const bioMax = 500
+
+// ErrBioTooLong is returned when the trimmed bio exceeds bioMax graphemes.
+var ErrBioTooLong = eris.Errorf("user: bio exceeds %d characters", bioMax)
+
+// Bio is the user profile bio, supporting a trinary: nil (no change),
+// pointer-to-"" (explicit clear), or pointer-to-non-empty (set).
+type Bio struct {
+	value *string
+}
+
+// ParseBio validates and trims s, preserving the trinary contract:
+// nil means "no change"; a pointer to "" means "explicit clear"; a pointer to
+// a non-empty string means "set". Returns ErrBioTooLong if the trimmed value
+// exceeds bioMax graphemes.
+func ParseBio(s *string) (Bio, error) {
+	if s == nil {
+		return Bio{value: nil}, nil
+	}
+	trimmed := strings.TrimSpace(*s)
+	if uniseg.GraphemeClusterCount(trimmed) > bioMax {
+		return Bio{}, ErrBioTooLong
+	}
+	return Bio{value: &trimmed}, nil
+}
+
+// Value returns the persistence-ready pointer: nil for "no change",
+// pointer-to-"" for explicit clear, pointer-to-non-empty for set.
+func (b Bio) Value() *string { return b.value }
+
+// IsSet reports whether the caller supplied a value (including an explicit clear).
+// Returns false only when the Bio was constructed from a nil input.
+func (b Bio) IsSet() bool { return b.value != nil }

--- a/backend/internal/domain/bio_test.go
+++ b/backend/internal/domain/bio_test.go
@@ -69,7 +69,6 @@ func TestParseBio(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/backend/internal/domain/bio_test.go
+++ b/backend/internal/domain/bio_test.go
@@ -1,0 +1,94 @@
+package domain
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseBio(t *testing.T) {
+	t.Parallel()
+
+	const zwjEmoji = "👨‍👩‍👧‍👦"
+
+	cases := []struct {
+		name        string
+		input       *string
+		wantIsSet   bool
+		wantValue   *string
+		sentinelErr error
+	}{
+		{
+			name:      "nil input — no change",
+			input:     nil,
+			wantIsSet: false,
+			wantValue: nil,
+		},
+		{
+			name:      "empty pointer — explicit clear",
+			input:     strPtr(""),
+			wantIsSet: true,
+			wantValue: strPtr(""),
+		},
+		{
+			name:      "whitespace only — trimmed to explicit clear",
+			input:     strPtr("   "),
+			wantIsSet: true,
+			wantValue: strPtr(""),
+		},
+		{
+			name:      "normal string",
+			input:     strPtr("Hello world"),
+			wantIsSet: true,
+			wantValue: strPtr("Hello world"),
+		},
+		{
+			name:      "surrounding whitespace trimmed",
+			input:     strPtr("  hello  "),
+			wantIsSet: true,
+			wantValue: strPtr("hello"),
+		},
+		{
+			name:      "exactly 500 graphemes — ok",
+			input:     strPtr(strings.Repeat("a", 500)),
+			wantIsSet: true,
+			wantValue: strPtr(strings.Repeat("a", 500)),
+		},
+		{
+			name:        "501 ASCII chars — too long",
+			input:       strPtr(strings.Repeat("a", 501)),
+			sentinelErr: ErrBioTooLong,
+		},
+		{
+			name:        "501 ZWJ emojis — grapheme count, not bytes",
+			input:       strPtr(strings.Repeat(zwjEmoji, 501)),
+			sentinelErr: ErrBioTooLong,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := ParseBio(tc.input)
+			if tc.sentinelErr != nil {
+				require.Error(t, err)
+				require.True(t, errors.Is(err, tc.sentinelErr), "got %v", err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.wantIsSet, got.IsSet())
+			if tc.wantValue == nil {
+				require.Nil(t, got.Value())
+			} else {
+				require.NotNil(t, got.Value())
+				require.Equal(t, *tc.wantValue, *got.Value())
+			}
+		})
+	}
+}
+
+func strPtr(s string) *string { return &s }

--- a/backend/internal/domain/card.go
+++ b/backend/internal/domain/card.go
@@ -4,7 +4,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/rivo/uniseg"
 	"github.com/rotisserie/eris"
 )
 
@@ -33,27 +32,11 @@ func (c *Card) Validate() error {
 	if strings.TrimSpace(c.CardgroupID) == "" {
 		return ErrCardCardgroupIDRequired
 	}
-	if err := validateCardText("front", c.Front); err != nil {
+	if _, err := ParseCardText(c.Front, ErrCardFrontRequired, ErrCardFrontTooLong); err != nil {
 		return err
 	}
-	if err := validateCardText("back", c.Back); err != nil {
+	if _, err := ParseCardText(c.Back, ErrCardBackRequired, ErrCardBackTooLong); err != nil {
 		return err
 	}
 	return nil
-}
-
-func validateCardText(field, value string) error {
-	n := uniseg.GraphemeClusterCount(strings.TrimSpace(value))
-	switch {
-	case n < 1 && field == "front":
-		return ErrCardFrontRequired
-	case n < 1:
-		return ErrCardBackRequired
-	case n > CardTextMax && field == "front":
-		return ErrCardFrontTooLong
-	case n > CardTextMax:
-		return ErrCardBackTooLong
-	default:
-		return nil
-	}
 }

--- a/backend/internal/domain/card_test.go
+++ b/backend/internal/domain/card_test.go
@@ -14,14 +14,14 @@ import (
 func TestCardShape(t *testing.T) {
 	t.Parallel()
 
-	cardType := reflect.TypeOf(Card{})
+	cardType := reflect.TypeFor[Card]()
 	want := map[string]reflect.Type{
-		"ID":          reflect.TypeOf(""),
-		"CardgroupID": reflect.TypeOf(""),
-		"Front":       reflect.TypeOf(""),
-		"Back":        reflect.TypeOf(""),
-		"CreatedAt":   reflect.TypeOf(time.Time{}),
-		"UpdatedAt":   reflect.TypeOf(time.Time{}),
+		"ID":          reflect.TypeFor[string](),
+		"CardgroupID": reflect.TypeFor[string](),
+		"Front":       reflect.TypeFor[string](),
+		"Back":        reflect.TypeFor[string](),
+		"CreatedAt":   reflect.TypeFor[time.Time](),
+		"UpdatedAt":   reflect.TypeFor[time.Time](),
 	}
 	for name, typ := range want {
 		field, ok := cardType.FieldByName(name)
@@ -79,7 +79,6 @@ func TestCardValidate(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -127,7 +126,6 @@ func TestRatingFromSwipeMode(t *testing.T) {
 		{mode: 5, wantErr: true},
 	}
 	for _, tc := range cases {
-		tc := tc
 		t.Run(fmt.Sprintf("mode_%d", tc.mode), func(t *testing.T) {
 			t.Parallel()
 			got, err := RatingFromSwipeMode(tc.mode)

--- a/backend/internal/domain/card_test.go
+++ b/backend/internal/domain/card_test.go
@@ -53,6 +53,11 @@ func TestCardValidate(t *testing.T) {
 			sentinelErr: ErrCardFrontRequired,
 		},
 		{
+			name:        "front whitespace only treated as required",
+			card:        Card{CardgroupID: "cg", Front: "   ", Back: "back"},
+			sentinelErr: ErrCardFrontRequired,
+		},
+		{
 			name:        "back required",
 			card:        Card{CardgroupID: "cg", Front: "front", Back: "  "},
 			sentinelErr: ErrCardBackRequired,

--- a/backend/internal/domain/card_text.go
+++ b/backend/internal/domain/card_text.go
@@ -8,7 +8,8 @@ import (
 
 // CardText is the trimmed, grapheme-bounded text used for both Card.Front and
 // Card.Back. Caller passes its own field-specific sentinels — VO stays
-// field-agnostic.
+// field-agnostic (1..CardTextMax graphemes).
+// The zero value (CardText("")) is invalid; use ParseCardText to construct.
 type CardText string
 
 // String returns the underlying string value.
@@ -18,6 +19,9 @@ func (c CardText) String() string { return string(c) }
 // CardText. It returns requiredErr when the trimmed input is empty and
 // tooLongErr when it exceeds CardTextMax clusters.
 func ParseCardText(s string, requiredErr, tooLongErr error) (CardText, error) {
+	if requiredErr == nil || tooLongErr == nil {
+		panic("domain: ParseCardText requires non-nil requiredErr and tooLongErr sentinels")
+	}
 	trimmed := strings.TrimSpace(s)
 	n := uniseg.GraphemeClusterCount(trimmed)
 	if n < 1 {

--- a/backend/internal/domain/card_text.go
+++ b/backend/internal/domain/card_text.go
@@ -1,0 +1,30 @@
+package domain
+
+import (
+	"strings"
+
+	"github.com/rivo/uniseg"
+)
+
+// CardText is the trimmed, grapheme-bounded text used for both Card.Front and
+// Card.Back. Caller passes its own field-specific sentinels — VO stays
+// field-agnostic.
+type CardText string
+
+// String returns the underlying string value.
+func (c CardText) String() string { return string(c) }
+
+// ParseCardText trims s, counts grapheme clusters, and returns a validated
+// CardText. It returns requiredErr when the trimmed input is empty and
+// tooLongErr when it exceeds CardTextMax clusters.
+func ParseCardText(s string, requiredErr, tooLongErr error) (CardText, error) {
+	trimmed := strings.TrimSpace(s)
+	n := uniseg.GraphemeClusterCount(trimmed)
+	if n < 1 {
+		return "", requiredErr
+	}
+	if n > CardTextMax {
+		return "", tooLongErr
+	}
+	return CardText(trimmed), nil
+}

--- a/backend/internal/domain/card_text_test.go
+++ b/backend/internal/domain/card_text_test.go
@@ -70,7 +70,6 @@ func TestParseCardText(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			got, err := ParseCardText(tc.input, errReq, errLong)

--- a/backend/internal/domain/card_text_test.go
+++ b/backend/internal/domain/card_text_test.go
@@ -1,0 +1,86 @@
+package domain
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseCardText(t *testing.T) {
+	t.Parallel()
+
+	errReq := errors.New("required-sentinel")
+	errLong := errors.New("toolong-sentinel")
+
+	const zwjEmoji = "👨‍👩‍👧‍👦"
+
+	cases := []struct {
+		name    string
+		input   string
+		wantVal CardText
+		wantErr error
+	}{
+		{
+			name:    "happy ascii",
+			input:   "hello",
+			wantVal: CardText("hello"),
+		},
+		{
+			name:    "happy trims whitespace",
+			input:   "  hello  ",
+			wantVal: CardText("hello"),
+		},
+		{
+			name:    "happy exactly CardTextMax grapheme clusters",
+			input:   strings.Repeat(zwjEmoji, CardTextMax),
+			wantVal: CardText(strings.Repeat(zwjEmoji, CardTextMax)),
+		},
+		{
+			name:    "empty string returns requiredErr",
+			input:   "",
+			wantErr: errReq,
+		},
+		{
+			name:    "whitespace only returns requiredErr",
+			input:   "   ",
+			wantErr: errReq,
+		},
+		{
+			name:    "501 ascii chars returns tooLongErr",
+			input:   strings.Repeat("a", CardTextMax+1),
+			wantErr: errLong,
+		},
+		{
+			name:    "501 ZWJ emojis returns tooLongErr",
+			input:   strings.Repeat(zwjEmoji, CardTextMax+1),
+			wantErr: errLong,
+		},
+		{
+			name:    "sentinel propagation required branch",
+			input:   "",
+			wantErr: errReq,
+		},
+		{
+			name:    "sentinel propagation toolong branch",
+			input:   strings.Repeat("b", CardTextMax+1),
+			wantErr: errLong,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := ParseCardText(tc.input, errReq, errLong)
+			if tc.wantErr != nil {
+				require.True(t, errors.Is(err, tc.wantErr), "got %v, want %v", err, tc.wantErr)
+				require.Empty(t, got)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.wantVal, got)
+		})
+	}
+}

--- a/backend/internal/domain/display_name.go
+++ b/backend/internal/domain/display_name.go
@@ -7,14 +7,15 @@ import (
 	"github.com/rotisserie/eris"
 )
 
-const displayNameMax = 50
+const DisplayNameMax = 50
 
 var (
 	ErrDisplayNameRequired = eris.New("user: display name is required")
-	ErrDisplayNameTooLong  = eris.Errorf("user: display name exceeds %d characters", displayNameMax)
+	ErrDisplayNameTooLong  = eris.Errorf("user: display name exceeds %d characters", DisplayNameMax)
 )
 
-// DisplayName is the user-chosen profile display name, trimmed, 1..50 graphemes.
+// DisplayName is the user-chosen profile display name, trimmed, 1..DisplayNameMax graphemes.
+// The zero value (DisplayName("")) is invalid; use ParseDisplayName to construct.
 type DisplayName string
 
 // ParseDisplayName trims surrounding whitespace from s, counts grapheme clusters,
@@ -25,7 +26,7 @@ func ParseDisplayName(s string) (DisplayName, error) {
 	if n < 1 {
 		return "", ErrDisplayNameRequired
 	}
-	if n > displayNameMax {
+	if n > DisplayNameMax {
 		return "", ErrDisplayNameTooLong
 	}
 	return DisplayName(trimmed), nil

--- a/backend/internal/domain/display_name.go
+++ b/backend/internal/domain/display_name.go
@@ -1,0 +1,32 @@
+package domain
+
+import (
+	"strings"
+
+	"github.com/rivo/uniseg"
+	"github.com/rotisserie/eris"
+)
+
+const displayNameMax = 50
+
+var (
+	ErrDisplayNameRequired = eris.New("user: display name is required")
+	ErrDisplayNameTooLong  = eris.Errorf("user: display name exceeds %d characters", displayNameMax)
+)
+
+// DisplayName is the user-chosen profile display name, trimmed, 1..50 graphemes.
+type DisplayName string
+
+// ParseDisplayName trims surrounding whitespace from s, counts grapheme clusters,
+// and returns a validated DisplayName or a sentinel error.
+func ParseDisplayName(s string) (DisplayName, error) {
+	trimmed := strings.TrimSpace(s)
+	n := uniseg.GraphemeClusterCount(trimmed)
+	if n < 1 {
+		return "", ErrDisplayNameRequired
+	}
+	if n > displayNameMax {
+		return "", ErrDisplayNameTooLong
+	}
+	return DisplayName(trimmed), nil
+}

--- a/backend/internal/domain/display_name_test.go
+++ b/backend/internal/domain/display_name_test.go
@@ -56,7 +56,6 @@ func TestParseDisplayName(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/backend/internal/domain/display_name_test.go
+++ b/backend/internal/domain/display_name_test.go
@@ -1,0 +1,73 @@
+package domain
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseDisplayName(t *testing.T) {
+	t.Parallel()
+
+	const zwjEmoji = "👨‍👩‍👧‍👦"
+	cases := []struct {
+		name        string
+		input       string
+		wantValue   DisplayName
+		sentinelErr error
+	}{
+		{
+			name:      "happy short name",
+			input:     "Alice",
+			wantValue: DisplayName("Alice"),
+		},
+		{
+			name:      "happy with surrounding whitespace",
+			input:     "  Alice  ",
+			wantValue: DisplayName("Alice"),
+		},
+		{
+			name:      "happy at exactly 50 graphemes",
+			input:     strings.Repeat(zwjEmoji, 50),
+			wantValue: DisplayName(strings.Repeat(zwjEmoji, 50)),
+		},
+		{
+			name:        "empty string",
+			input:       "",
+			sentinelErr: ErrDisplayNameRequired,
+		},
+		{
+			name:        "whitespace only",
+			input:       "   ",
+			sentinelErr: ErrDisplayNameRequired,
+		},
+		{
+			name:        "51 ASCII chars",
+			input:       strings.Repeat("a", 51),
+			sentinelErr: ErrDisplayNameTooLong,
+		},
+		{
+			name:        "51 ZWJ emojis",
+			input:       strings.Repeat(zwjEmoji, 51),
+			sentinelErr: ErrDisplayNameTooLong,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := ParseDisplayName(tc.input)
+			if tc.sentinelErr == nil {
+				require.NoError(t, err)
+				require.Equal(t, tc.wantValue, got)
+				return
+			}
+			require.Error(t, err)
+			require.True(t, errors.Is(err, tc.sentinelErr), "got %v", err)
+		})
+	}
+}

--- a/backend/internal/domain/rating.go
+++ b/backend/internal/domain/rating.go
@@ -13,6 +13,11 @@ const (
 	RatingEasy  Rating = 4
 )
 
+// IsValid reports whether the rating is in the recognised FSRS range.
+func (r Rating) IsValid() bool {
+	return r >= RatingAgain && r <= RatingEasy
+}
+
 // RatingFromSwipeMode maps the legacy 3-step swipe UI to FSRS ratings. The UI
 // emits 1=Again, 2=Hard, and 4=Easy; it intentionally does not emit 3=Good.
 func RatingFromSwipeMode(mode int) (Rating, error) {

--- a/backend/internal/domain/rating_test.go
+++ b/backend/internal/domain/rating_test.go
@@ -1,0 +1,31 @@
+package domain
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRatingIsValid(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input Rating
+		want  bool
+	}{
+		{"RatingAgain", RatingAgain, true},
+		{"RatingHard", RatingHard, true},
+		{"RatingGood", RatingGood, true},
+		{"RatingEasy", RatingEasy, true},
+		{"zero", Rating(0), false},
+		{"five", Rating(5), false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, tc.input.IsValid())
+		})
+	}
+}

--- a/backend/internal/domain/role.go
+++ b/backend/internal/domain/role.go
@@ -6,3 +6,21 @@ type Role struct {
 	ID   string
 	Name string
 }
+
+// AdminRoleName and GeneralRoleName are the two built-in system role names.
+const (
+	AdminRoleName   = "admin"
+	GeneralRoleName = "general"
+)
+
+// systemRoleNames is the set of role names that are owned by the system.
+var systemRoleNames = map[string]struct{}{
+	AdminRoleName:   {},
+	GeneralRoleName: {},
+}
+
+// IsSystem reports whether r is one of the built-in system roles.
+func (r Role) IsSystem() bool {
+	_, ok := systemRoleNames[r.Name]
+	return ok
+}

--- a/backend/internal/domain/role_name.go
+++ b/backend/internal/domain/role_name.go
@@ -7,22 +7,23 @@ import (
 	"github.com/rotisserie/eris"
 )
 
-// roleNameMax is the maximum byte length of a normalized role name. Because the
+// RoleNameMax is the maximum byte length of a normalized role name. Because the
 // pattern restricts input to ASCII, byte length equals grapheme count.
-const roleNameMax = 50
+const RoleNameMax = 50
 
 // roleNamePattern allows lowercase letters, digits, underscores, and hyphens.
 var roleNamePattern = regexp.MustCompile(`^[a-z0-9_-]+$`)
 
 var (
 	ErrRoleNameRequired = eris.New("role: name is required")
-	ErrRoleNameTooLong  = eris.Errorf("role: name exceeds %d characters", roleNameMax)
+	ErrRoleNameTooLong  = eris.Errorf("role: name exceeds %d characters", RoleNameMax)
 	ErrRoleNameInvalid  = eris.New("role: name must contain only lowercase letters, digits, '_', or '-'")
 )
 
 // RoleName is the canonical, lowercase, slug-like identifier for an application
 // role. It is the normalized form of the user-supplied name string, validated
-// against a strict character set and length limit.
+// against a strict character set and length limit (1..RoleNameMax bytes).
+// The zero value (RoleName("")) is invalid; use ParseRoleName to construct.
 type RoleName string
 
 // ParseRoleName normalizes s (trim whitespace, lowercase) and validates it.
@@ -33,7 +34,7 @@ func ParseRoleName(s string) (RoleName, error) {
 	if normalized == "" {
 		return "", ErrRoleNameRequired
 	}
-	if len(normalized) > roleNameMax {
+	if len(normalized) > RoleNameMax {
 		return "", ErrRoleNameTooLong
 	}
 	if !roleNamePattern.MatchString(normalized) {

--- a/backend/internal/domain/role_name.go
+++ b/backend/internal/domain/role_name.go
@@ -9,7 +9,7 @@ import (
 
 // roleNameMax is the maximum byte length of a normalized role name. Because the
 // pattern restricts input to ASCII, byte length equals grapheme count.
-const roleNameMax = 30
+const roleNameMax = 50
 
 // roleNamePattern allows lowercase letters, digits, underscores, and hyphens.
 var roleNamePattern = regexp.MustCompile(`^[a-z0-9_-]+$`)

--- a/backend/internal/domain/role_name.go
+++ b/backend/internal/domain/role_name.go
@@ -1,0 +1,43 @@
+package domain
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/rotisserie/eris"
+)
+
+// roleNameMax is the maximum byte length of a normalized role name. Because the
+// pattern restricts input to ASCII, byte length equals grapheme count.
+const roleNameMax = 30
+
+// roleNamePattern allows lowercase letters, digits, underscores, and hyphens.
+var roleNamePattern = regexp.MustCompile(`^[a-z0-9_-]+$`)
+
+var (
+	ErrRoleNameRequired = eris.New("role: name is required")
+	ErrRoleNameTooLong  = eris.Errorf("role: name exceeds %d characters", roleNameMax)
+	ErrRoleNameInvalid  = eris.New("role: name must contain only lowercase letters, digits, '_', or '-'")
+)
+
+// RoleName is the canonical, lowercase, slug-like identifier for an application
+// role. It is the normalized form of the user-supplied name string, validated
+// against a strict character set and length limit.
+type RoleName string
+
+// ParseRoleName normalizes s (trim whitespace, lowercase) and validates it.
+// It returns ErrRoleNameRequired, ErrRoleNameTooLong, or ErrRoleNameInvalid on
+// failure, or the validated RoleName on success.
+func ParseRoleName(s string) (RoleName, error) {
+	normalized := strings.ToLower(strings.TrimSpace(s))
+	if normalized == "" {
+		return "", ErrRoleNameRequired
+	}
+	if len(normalized) > roleNameMax {
+		return "", ErrRoleNameTooLong
+	}
+	if !roleNamePattern.MatchString(normalized) {
+		return "", ErrRoleNameInvalid
+	}
+	return RoleName(normalized), nil
+}

--- a/backend/internal/domain/role_name_test.go
+++ b/backend/internal/domain/role_name_test.go
@@ -1,0 +1,87 @@
+package domain
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseRoleName(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name        string
+		input       string
+		wantValue   RoleName
+		sentinelErr error
+	}{
+		{
+			name:      "admin lowercase",
+			input:     "admin",
+			wantValue: "admin",
+		},
+		{
+			name:      "general lowercase",
+			input:     "general",
+			wantValue: "general",
+		},
+		{
+			name:      "uppercase normalized",
+			input:     "ADMIN",
+			wantValue: "admin",
+		},
+		{
+			name:      "whitespace trimmed",
+			input:     "  admin  ",
+			wantValue: "admin",
+		},
+		{
+			name:        "empty string",
+			input:       "",
+			sentinelErr: ErrRoleNameRequired,
+		},
+		{
+			name:        "whitespace only",
+			input:       "   ",
+			sentinelErr: ErrRoleNameRequired,
+		},
+		{
+			name:        "too long",
+			input:       strings.Repeat("a", 31),
+			sentinelErr: ErrRoleNameTooLong,
+		},
+		{
+			name:        "invalid character exclamation",
+			input:       "admin!",
+			sentinelErr: ErrRoleNameInvalid,
+		},
+		{
+			name:        "space not allowed after normalization",
+			input:       "Admin Smith",
+			sentinelErr: ErrRoleNameInvalid,
+		},
+		{
+			name:        "at-sign not allowed",
+			input:       "admin@example",
+			sentinelErr: ErrRoleNameInvalid,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := ParseRoleName(tc.input)
+			if tc.sentinelErr == nil {
+				require.NoError(t, err)
+				require.Equal(t, tc.wantValue, got)
+				return
+			}
+			require.Error(t, err)
+			require.True(t, errors.Is(err, tc.sentinelErr), "got %v", err)
+		})
+	}
+}

--- a/backend/internal/domain/role_name_test.go
+++ b/backend/internal/domain/role_name_test.go
@@ -70,7 +70,6 @@ func TestParseRoleName(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/backend/internal/domain/role_name_test.go
+++ b/backend/internal/domain/role_name_test.go
@@ -49,7 +49,7 @@ func TestParseRoleName(t *testing.T) {
 		},
 		{
 			name:        "too long",
-			input:       strings.Repeat("a", 31),
+			input:       strings.Repeat("a", 51),
 			sentinelErr: ErrRoleNameTooLong,
 		},
 		{

--- a/backend/internal/domain/role_test.go
+++ b/backend/internal/domain/role_test.go
@@ -3,6 +3,8 @@ package domain
 import (
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestRoleShape(t *testing.T) {
@@ -25,5 +27,29 @@ func TestRoleShape(t *testing.T) {
 		if len(field.Tag) != 0 {
 			t.Fatalf("Role.%s should not have struct tags, got %q", name, field.Tag)
 		}
+	}
+}
+
+func TestRoleIsSystem(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		role Role
+		want bool
+	}{
+		{name: "admin", role: Role{Name: AdminRoleName}, want: true},
+		{name: "general", role: Role{Name: GeneralRoleName}, want: true},
+		{name: "empty", role: Role{Name: ""}, want: false},
+		{name: "unknown", role: Role{Name: "unknown"}, want: false},
+		{name: "case-sensitive Admin", role: Role{Name: "Admin"}, want: false},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, tc.role.IsSystem())
+		})
 	}
 }

--- a/backend/internal/domain/role_test.go
+++ b/backend/internal/domain/role_test.go
@@ -10,10 +10,10 @@ import (
 func TestRoleShape(t *testing.T) {
 	t.Parallel()
 
-	roleType := reflect.TypeOf(Role{})
+	roleType := reflect.TypeFor[Role]()
 	want := map[string]reflect.Type{
-		"ID":   reflect.TypeOf(""),
-		"Name": reflect.TypeOf(""),
+		"ID":   reflect.TypeFor[string](),
+		"Name": reflect.TypeFor[string](),
 	}
 
 	for name, typ := range want {
@@ -46,7 +46,6 @@ func TestRoleIsSystem(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			require.Equal(t, tc.want, tc.role.IsSystem())

--- a/backend/internal/domain/user.go
+++ b/backend/internal/domain/user.go
@@ -11,3 +11,17 @@ type User struct {
 	CreatedAt   time.Time
 	UpdatedAt   time.Time
 }
+
+// UpdateProfile applies a parsed profile patch.
+//
+// DisplayName is always set (the VO contract guarantees 1..50 graphemes).
+// Bio follows trinary semantics: when bio.IsSet() is false the field is left
+// unchanged; otherwise bio.Value() (which may point at "") is written, allowing
+// an explicit clear.
+func (u *User) UpdateProfile(displayName DisplayName, bio Bio) {
+	s := string(displayName)
+	u.DisplayName = &s
+	if bio.IsSet() {
+		u.Bio = bio.Value()
+	}
+}

--- a/backend/internal/domain/user.go
+++ b/backend/internal/domain/user.go
@@ -11,17 +11,3 @@ type User struct {
 	CreatedAt   time.Time
 	UpdatedAt   time.Time
 }
-
-// UpdateProfile applies a parsed profile patch.
-//
-// DisplayName is always set (the VO contract guarantees 1..50 graphemes).
-// Bio follows trinary semantics: when bio.IsSet() is false the field is left
-// unchanged; otherwise bio.Value() (which may point at "") is written, allowing
-// an explicit clear.
-func (u *User) UpdateProfile(displayName DisplayName, bio Bio) {
-	s := string(displayName)
-	u.DisplayName = &s
-	if bio.IsSet() {
-		u.Bio = bio.Value()
-	}
-}

--- a/backend/internal/domain/user_card_fsrs.go
+++ b/backend/internal/domain/user_card_fsrs.go
@@ -1,6 +1,10 @@
 package domain
 
-import "time"
+import (
+	"time"
+
+	"github.com/rotisserie/eris"
+)
 
 // UserCardFSRS is the per-user scheduling aggregate for a card.
 type UserCardFSRS struct {
@@ -9,6 +13,12 @@ type UserCardFSRS struct {
 	State     FSRSState
 	CreatedAt time.Time
 	UpdatedAt time.Time
+}
+
+// FSRSScheduler is the consumer-defined interface for the FSRS scheduler.
+// *service.FSRSScheduler satisfies it implicitly.
+type FSRSScheduler interface {
+	Apply(state FSRSState, rating Rating, now time.Time) FSRSState
 }
 
 func NewUserCardFSRSForNewCard(userID, cardID string, now time.Time) *UserCardFSRS {
@@ -22,4 +32,16 @@ func NewUserCardFSRSForNewCard(userID, cardID string, now time.Time) *UserCardFS
 		CreatedAt: now,
 		UpdatedAt: now,
 	}
+}
+
+// ApplyRating recomputes the scheduling state via the provided scheduler and
+// stamps UpdatedAt with now. An invalid rating leaves the aggregate
+// unchanged and returns an error.
+func (u *UserCardFSRS) ApplyRating(scheduler FSRSScheduler, rating Rating, now time.Time) error {
+	if !rating.IsValid() {
+		return eris.Errorf("user_card_fsrs: invalid rating %d", rating)
+	}
+	u.State = scheduler.Apply(u.State, rating, now)
+	u.UpdatedAt = now
+	return nil
 }

--- a/backend/internal/domain/user_card_fsrs_test.go
+++ b/backend/internal/domain/user_card_fsrs_test.go
@@ -63,7 +63,6 @@ func TestUserCardFSRS_ApplyRating_InvalidRating(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/backend/internal/domain/user_card_fsrs_test.go
+++ b/backend/internal/domain/user_card_fsrs_test.go
@@ -1,0 +1,83 @@
+package domain
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+type stubScheduler struct {
+	gotState  FSRSState
+	gotRating Rating
+	gotNow    time.Time
+	out       FSRSState
+	called    int
+}
+
+func (s *stubScheduler) Apply(state FSRSState, rating Rating, now time.Time) FSRSState {
+	s.gotState = state
+	s.gotRating = rating
+	s.gotNow = now
+	s.called++
+	return s.out
+}
+
+func TestUserCardFSRS_ApplyRating_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	t0 := time.Date(2026, 4, 26, 0, 0, 0, 0, time.UTC)
+	t1 := t0.Add(time.Hour)
+
+	outState := FSRSState{
+		Reps:       1,
+		Stability:  3.0,
+		Difficulty: 4.5,
+		State:      FSRSStateLearning,
+		LastReview: t1,
+	}
+	stub := &stubScheduler{out: outState}
+
+	u := NewUserCardFSRSForNewCard("u1", "c1", t0)
+	err := u.ApplyRating(stub, RatingGood, t1)
+
+	require.NoError(t, err)
+	require.Equal(t, outState, u.State)
+	require.Equal(t, t1, u.UpdatedAt)
+	require.Equal(t, RatingGood, stub.gotRating)
+	require.Equal(t, t1, stub.gotNow)
+}
+
+func TestUserCardFSRS_ApplyRating_InvalidRating(t *testing.T) {
+	t.Parallel()
+
+	t0 := time.Date(2026, 4, 26, 0, 0, 0, 0, time.UTC)
+	t1 := t0.Add(time.Hour)
+
+	cases := []struct {
+		name   string
+		rating Rating
+	}{
+		{name: "zero", rating: Rating(0)},
+		{name: "too_high", rating: Rating(5)},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			stub := &stubScheduler{}
+			u := NewUserCardFSRSForNewCard("u1", "c1", t0)
+			snapshotState := u.State
+			snapshotUpdatedAt := u.UpdatedAt
+
+			err := u.ApplyRating(stub, tc.rating, t1)
+
+			require.Error(t, err)
+			require.Equal(t, snapshotState, u.State)
+			require.Equal(t, snapshotUpdatedAt, u.UpdatedAt)
+			require.Equal(t, 0, stub.called)
+		})
+	}
+}

--- a/backend/internal/domain/user_test.go
+++ b/backend/internal/domain/user_test.go
@@ -4,8 +4,6 @@ import (
 	"reflect"
 	"testing"
 	"time"
-
-	"github.com/stretchr/testify/require"
 )
 
 func TestUserShape(t *testing.T) {
@@ -33,56 +31,4 @@ func TestUserShape(t *testing.T) {
 			t.Fatalf("User.%s should not have struct tags, got %q", name, field.Tag)
 		}
 	}
-}
-
-func TestUserUpdateProfile(t *testing.T) {
-	t.Parallel()
-
-	ptr := func(s string) *string { return &s }
-
-	t.Run("sets display name and bio", func(t *testing.T) {
-		t.Parallel()
-		u := User{ID: "u1"}
-		dn, err := ParseDisplayName("Alice")
-		require.NoError(t, err)
-		s := "hello"
-		bio, err := ParseBio(&s)
-		require.NoError(t, err)
-
-		u.UpdateProfile(dn, bio)
-
-		require.NotNil(t, u.DisplayName)
-		require.Equal(t, "Alice", *u.DisplayName)
-		require.NotNil(t, u.Bio)
-		require.Equal(t, "hello", *u.Bio)
-	})
-
-	t.Run("bio nil leaves existing bio untouched", func(t *testing.T) {
-		t.Parallel()
-		u := User{ID: "u1", Bio: ptr("existing")}
-		dn, err := ParseDisplayName("Bob")
-		require.NoError(t, err)
-		bio, err := ParseBio(nil)
-		require.NoError(t, err)
-
-		u.UpdateProfile(dn, bio)
-
-		require.Equal(t, "Bob", *u.DisplayName)
-		require.Equal(t, "existing", *u.Bio)
-	})
-
-	t.Run("bio explicit empty clears bio", func(t *testing.T) {
-		t.Parallel()
-		u := User{ID: "u1", Bio: ptr("existing")}
-		dn, err := ParseDisplayName("Carol")
-		require.NoError(t, err)
-		s := ""
-		bio, err := ParseBio(&s)
-		require.NoError(t, err)
-
-		u.UpdateProfile(dn, bio)
-
-		require.NotNil(t, u.Bio)
-		require.Equal(t, "", *u.Bio)
-	})
 }

--- a/backend/internal/domain/user_test.go
+++ b/backend/internal/domain/user_test.go
@@ -4,6 +4,8 @@ import (
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestUserShape(t *testing.T) {
@@ -31,4 +33,56 @@ func TestUserShape(t *testing.T) {
 			t.Fatalf("User.%s should not have struct tags, got %q", name, field.Tag)
 		}
 	}
+}
+
+func TestUserUpdateProfile(t *testing.T) {
+	t.Parallel()
+
+	ptr := func(s string) *string { return &s }
+
+	t.Run("sets display name and bio", func(t *testing.T) {
+		t.Parallel()
+		u := User{ID: "u1"}
+		dn, err := ParseDisplayName("Alice")
+		require.NoError(t, err)
+		s := "hello"
+		bio, err := ParseBio(&s)
+		require.NoError(t, err)
+
+		u.UpdateProfile(dn, bio)
+
+		require.NotNil(t, u.DisplayName)
+		require.Equal(t, "Alice", *u.DisplayName)
+		require.NotNil(t, u.Bio)
+		require.Equal(t, "hello", *u.Bio)
+	})
+
+	t.Run("bio nil leaves existing bio untouched", func(t *testing.T) {
+		t.Parallel()
+		u := User{ID: "u1", Bio: ptr("existing")}
+		dn, err := ParseDisplayName("Bob")
+		require.NoError(t, err)
+		bio, err := ParseBio(nil)
+		require.NoError(t, err)
+
+		u.UpdateProfile(dn, bio)
+
+		require.Equal(t, "Bob", *u.DisplayName)
+		require.Equal(t, "existing", *u.Bio)
+	})
+
+	t.Run("bio explicit empty clears bio", func(t *testing.T) {
+		t.Parallel()
+		u := User{ID: "u1", Bio: ptr("existing")}
+		dn, err := ParseDisplayName("Carol")
+		require.NoError(t, err)
+		s := ""
+		bio, err := ParseBio(&s)
+		require.NoError(t, err)
+
+		u.UpdateProfile(dn, bio)
+
+		require.NotNil(t, u.Bio)
+		require.Equal(t, "", *u.Bio)
+	})
 }

--- a/backend/internal/repository/role.go
+++ b/backend/internal/repository/role.go
@@ -370,7 +370,7 @@ func (r *roleRepo) CountAdminUsers(ctx context.Context) (int64, error) {
 	err := r.db.WithContext(ctx).
 		Table("user_roles").
 		Joins("JOIN roles ON roles.id = user_roles.role_id").
-		Where("roles.name = ?", "admin").
+		Where("roles.name = ?", domain.AdminRoleName).
 		Count(&n).Error
 	if err != nil {
 		return 0, eris.Wrap(err, "repository: count admin users")

--- a/backend/internal/usecase/admin_role.go
+++ b/backend/internal/usecase/admin_role.go
@@ -246,7 +246,7 @@ func translateRoleNameErr(err error) error {
 	case errors.Is(err, domain.ErrRoleNameRequired):
 		return ucerr.NewValidationError("name", "name is required")
 	case errors.Is(err, domain.ErrRoleNameTooLong):
-		return ucerr.NewValidationError("name", "name must be at most 50 characters")
+		return ucerr.NewValidationError("name", fmt.Sprintf("name must be at most %d characters", domain.RoleNameMax))
 	case errors.Is(err, domain.ErrRoleNameInvalid):
 		return ucerr.NewValidationError("name", "name must contain only lowercase letters, digits, '_' or '-'")
 	default:

--- a/backend/internal/usecase/admin_role.go
+++ b/backend/internal/usecase/admin_role.go
@@ -5,10 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"regexp"
-	"strings"
 
-	"github.com/rivo/uniseg"
 	"github.com/rotisserie/eris"
 
 	"backend/internal/auth"
@@ -16,20 +13,6 @@ import (
 	"backend/internal/repository"
 	"backend/internal/usecase/ucerr"
 )
-
-// roleNameMin / roleNameMax bound the post-normalisation grapheme-cluster
-// length of a role name. The lower bound rejects whitespace-only input that
-// collapses to "" after TrimSpace; the upper bound matches the column constraint.
-const (
-	roleNameMin = 1
-	roleNameMax = 50
-)
-
-// roleNamePattern restricts the post-normalisation role name to lowercase
-// ASCII letters, digits, underscore, and hyphen. The set is deliberately narrow
-// so role names round-trip cleanly through URLs, log lines, and the frontend
-// without escaping.
-var roleNamePattern = regexp.MustCompile(`^[a-z0-9_-]+$`)
 
 // AdminRoleUsecase is the admin-only role CRUD surface. Kept separate from
 // AdminUserUsecase: the two share an auth gate but no business state.
@@ -87,24 +70,6 @@ func NewAdminRoleWithDeps(roles adminRoleRepoForCRUD, authSvc AdminChecker, logg
 	return &adminRoleUsecase{roles: roles, auth: authSvc, logger: logger}
 }
 
-// validateRoleName trims, lowercases, and validates a user-supplied role name.
-// Returns the canonical form on success so the caller passes a consistent value
-// to the repository (defence-in-depth — the repository also normalises).
-func validateRoleName(name string) (string, error) {
-	normalized := strings.ToLower(strings.TrimSpace(name))
-	n := uniseg.GraphemeClusterCount(normalized)
-	if n < roleNameMin {
-		return "", ucerr.NewValidationError("name", "name is required")
-	}
-	if n > roleNameMax {
-		return "", ucerr.NewValidationError("name", fmt.Sprintf("name must be at most %d characters", roleNameMax))
-	}
-	if !roleNamePattern.MatchString(normalized) {
-		return "", ucerr.NewValidationError("name", "name must contain only lowercase letters, digits, '_' or '-'")
-	}
-	return normalized, nil
-}
-
 // List returns every role in the system. Admin-only.
 func (u *adminRoleUsecase) List(ctx context.Context) ([]*domain.Role, error) {
 	if _, err := requireAdmin(ctx, u.auth); err != nil {
@@ -151,13 +116,15 @@ func (u *adminRoleUsecase) Create(ctx context.Context, name string) (CreateRoleO
 	if _, err := requireAdmin(ctx, u.auth); err != nil {
 		return CreateRoleOutcome{}, wrapAdminGateError(err, "usecase: admin role: check admin")
 	}
-	normalized, info, err := normalizeAndValidateRoleName(name)
+	parsed, err := domain.ParseRoleName(name)
 	if err != nil {
-		return CreateRoleOutcome{}, err
-	}
-	if info != nil {
+		info, perr := liftValidationErr(translateRoleNameErr(err))
+		if perr != nil {
+			return CreateRoleOutcome{}, perr
+		}
 		return CreateRoleOutcome{Validation: info}, nil
 	}
+	normalized := string(parsed)
 	role, err := u.roles.Create(ctx, normalized)
 	if err != nil {
 		info, perr := mapAdminRoleError(err, "name", "usecase: admin role create")
@@ -167,24 +134,6 @@ func (u *adminRoleUsecase) Create(ctx context.Context, name string) (CreateRoleO
 		return CreateRoleOutcome{Validation: info}, nil
 	}
 	return CreateRoleOutcome{Role: role}, nil
-}
-
-// normalizeAndValidateRoleName wraps validateRoleName for outcome-bearing
-// callers: it returns the canonical name on success, or an
-// InputValidationInfo (with empty canonical name) on a validation failure.
-// Non-validation errors are not expected from validateRoleName today; if
-// one ever appears, it propagates via the error return so the caller can
-// surface it as INTERNAL.
-func normalizeAndValidateRoleName(name string) (string, *InputValidationInfo, error) {
-	normalized, err := validateRoleName(name)
-	if err != nil {
-		info, perr := liftValidationErr(err)
-		if perr != nil {
-			return "", nil, perr
-		}
-		return "", info, nil
-	}
-	return normalized, nil, nil
 }
 
 // UpdateRoleOutcome is the result of admin_role.Update. Exactly one of Role
@@ -234,16 +183,17 @@ func (u *adminRoleUsecase) Update(ctx context.Context, id, name string) (UpdateR
 	if _, err := requireAdmin(ctx, u.auth); err != nil {
 		return UpdateRoleOutcome{}, wrapAdminGateError(err, "usecase: admin role: check admin")
 	}
-	normalized, err := validateRoleName(name)
+	parsed, err := domain.ParseRoleName(name)
 	if err != nil {
-		return UpdateRoleOutcome{}, err
+		return UpdateRoleOutcome{}, translateRoleNameErr(err)
 	}
+	normalized := string(parsed)
 
 	existing, err := u.roles.FindByID(ctx, id)
 	if err != nil {
 		return UpdateRoleOutcome{}, lowerValidationInfo(mapAdminRoleError(err, "id", "usecase: admin role update: find"))
 	}
-	if isSystemRole(existing.Name) {
+	if existing.IsSystem() {
 		return UpdateRoleOutcome{SystemRoleConflict: &SystemRoleConflictInfo{
 			ID:   existing.ID,
 			Name: existing.Name,
@@ -276,7 +226,7 @@ func (u *adminRoleUsecase) Delete(ctx context.Context, id string) error {
 	if err != nil {
 		return lowerValidationInfo(mapAdminRoleError(err, "id", "usecase: admin role delete: find"))
 	}
-	if isSystemRole(existing.Name) {
+	if existing.IsSystem() {
 		return ucerr.NewForbiddenError(fmt.Sprintf("cannot delete system role %q", existing.Name))
 	}
 
@@ -284,6 +234,24 @@ func (u *adminRoleUsecase) Delete(ctx context.Context, id string) error {
 		return lowerValidationInfo(mapAdminRoleError(err, "id", "usecase: admin role delete"))
 	}
 	return nil
+}
+
+// translateRoleNameErr maps domain RoleName sentinels into usecase-layer typed
+// errors. Unexpected errors are wrapped with eris. Returns nil when err is nil.
+func translateRoleNameErr(err error) error {
+	if err == nil {
+		return nil
+	}
+	switch {
+	case errors.Is(err, domain.ErrRoleNameRequired):
+		return ucerr.NewValidationError("name", "name is required")
+	case errors.Is(err, domain.ErrRoleNameTooLong):
+		return ucerr.NewValidationError("name", "name must be at most 50 characters")
+	case errors.Is(err, domain.ErrRoleNameInvalid):
+		return ucerr.NewValidationError("name", "name must contain only lowercase letters, digits, '_' or '-'")
+	default:
+		return eris.Wrap(err, "usecase: translate role name error")
+	}
 }
 
 // mapAdminRoleError classifies the role-repository sentinel set into either

--- a/backend/internal/usecase/admin_role_test.go
+++ b/backend/internal/usecase/admin_role_test.go
@@ -341,7 +341,7 @@ func TestAdminRole_Create_Validation_TooLong(t *testing.T) {
 	authChk := &adminAuthChecker{admins: map[string]bool{"admin-1": true}}
 	uc, _ := buildAdminRoleUC(roles, authChk)
 
-	overMax := strings.Repeat("a", roleNameMax+1)
+	overMax := strings.Repeat("a", 51)
 	outcome, err := uc.Create(authedCtx("admin-1"), overMax)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/backend/internal/usecase/admin_role_test.go
+++ b/backend/internal/usecase/admin_role_test.go
@@ -668,6 +668,43 @@ func TestAdminRole_Update_EmptyName(t *testing.T) {
 	}
 }
 
+// TestAdminRole_Update_Validation_TooLong rejects a 51-character name before
+// FindByID is reached. The error surfaces via the error channel as a
+// *ucerr.ValidationError with Field: "name".
+func TestAdminRole_Update_Validation_TooLong(t *testing.T) {
+	t.Parallel()
+
+	roles := &mockAdminRoleRepoForCRUD{}
+	authChk := &adminAuthChecker{admins: map[string]bool{"admin-1": true}}
+	uc, _ := buildAdminRoleUC(roles, authChk)
+
+	overMax := strings.Repeat("a", 51)
+	_, err := uc.Update(authedCtx("admin-1"), "r-1", overMax)
+	assertValidationError(t, err, "name", "")
+	if roles.findCalls != 0 || roles.updateCalls != 0 {
+		t.Fatalf("expected 0 repo calls on validation failure, got find=%d update=%d",
+			roles.findCalls, roles.updateCalls)
+	}
+}
+
+// TestAdminRole_Update_Validation_InvalidChars rejects names whose
+// post-normalisation form contains characters outside [a-z0-9_-]. The error
+// surfaces via the error channel as a *ucerr.ValidationError with Field: "name".
+func TestAdminRole_Update_Validation_InvalidChars(t *testing.T) {
+	t.Parallel()
+
+	roles := &mockAdminRoleRepoForCRUD{}
+	authChk := &adminAuthChecker{admins: map[string]bool{"admin-1": true}}
+	uc, _ := buildAdminRoleUC(roles, authChk)
+
+	_, err := uc.Update(authedCtx("admin-1"), "r-1", "INVALID!")
+	assertValidationError(t, err, "name", "")
+	if roles.findCalls != 0 || roles.updateCalls != 0 {
+		t.Fatalf("expected 0 repo calls on validation failure, got find=%d update=%d",
+			roles.findCalls, roles.updateCalls)
+	}
+}
+
 // TestAdminRole_Update_TOCTOUNotFound covers the race where FindByID succeeds
 // (role existed at lookup time) but the subsequent Update returns
 // ErrRoleNotFound because another admin deleted the row in between. This must
@@ -815,7 +852,7 @@ func TestAdminRole_Delete_RepoInternalError(t *testing.T) {
 // TestAdminRole_Update_RepoInternalError surfaces a generic repository error
 // from the roles.Update call (anything other than the classified sentinels) as
 // INTERNAL with the eris chain attached. The pattern mirrors
-// TestAdminRole_Delete_RepoInternalError: requireAdmin OK, validateRoleName OK,
+// TestAdminRole_Delete_RepoInternalError: requireAdmin OK, domain.ParseRoleName OK,
 // FindByID returns a non-system role, roles.Update returns a non-sentinel error.
 func TestAdminRole_Update_RepoInternalError(t *testing.T) {
 	t.Parallel()

--- a/backend/internal/usecase/admin_user.go
+++ b/backend/internal/usecase/admin_user.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"strings"
 
 	"github.com/rotisserie/eris"
 
@@ -14,33 +13,6 @@ import (
 	"backend/internal/repository"
 	"backend/internal/usecase/ucerr"
 )
-
-// adminRoleName is the name of the role that grants admin privileges. It is
-// hardcoded here for the self-demotion guard in RevokeRole. Keeping the
-// literal in one place avoids drift from the same constant baked into
-// auth.Service.IsAdmin.
-const adminRoleName = "admin"
-
-// generalRoleName is the name of the default end-user role seeded alongside
-// "admin". Treated as a system role by AdminRole.Update / AdminRole.Delete:
-// renaming or deleting it is blocked because deployments may rely on the
-// literal name being present.
-const generalRoleName = "general"
-
-// systemRoleNames enumerates the role names that are protected from rename
-// and delete by the AdminRole usecase. The set is closed at compile time so
-// any future system role must be added here explicitly.
-var systemRoleNames = map[string]struct{}{
-	adminRoleName:   {},
-	generalRoleName: {},
-}
-
-// isSystemRole reports whether a role name is in the protected set. Used by
-// AdminRole.Update and AdminRole.Delete to gate the system-role guard.
-func isSystemRole(name string) bool {
-	_, ok := systemRoleNames[name]
-	return ok
-}
 
 // adminUserMaxPageSize is the user-facing cap on AdminUser.List page size.
 // Mirrors the repository-level maxUserPageSize (100). The asymmetry between
@@ -323,25 +295,27 @@ func (u *adminUserUsecase) Update(ctx context.Context, id string, input AdminUpd
 
 	patch := repository.UserUpdate{}
 	if input.DisplayName != nil {
-		trimmed := strings.TrimSpace(*input.DisplayName)
-		info, err := liftValidationErr(validateDisplayName(trimmed))
+		dn, err := domain.ParseDisplayName(*input.DisplayName)
 		if err != nil {
-			return AdminUpdateUserOutcome{}, err
-		}
-		if info != nil {
+			info, perr := liftValidationErr(translateDisplayNameErr(err))
+			if perr != nil {
+				return AdminUpdateUserOutcome{}, perr
+			}
 			return AdminUpdateUserOutcome{Validation: info}, nil
 		}
-		patch.DisplayName = &trimmed
+		s := string(dn)
+		patch.DisplayName = &s
 	}
 	if input.Bio != nil {
-		info, err := liftValidationErr(validateBio(input.Bio))
+		bio, err := domain.ParseBio(input.Bio)
 		if err != nil {
-			return AdminUpdateUserOutcome{}, err
-		}
-		if info != nil {
+			info, perr := liftValidationErr(translateBioErr(err))
+			if perr != nil {
+				return AdminUpdateUserOutcome{}, perr
+			}
 			return AdminUpdateUserOutcome{Validation: info}, nil
 		}
-		patch.Bio = input.Bio
+		patch.Bio = bio.Value()
 	}
 
 	user, err := u.users.Update(ctx, id, patch)
@@ -409,7 +383,7 @@ func (u *adminUserUsecase) RevokeRole(ctx context.Context, userID, roleID string
 			}
 			return RevokeRoleOutcome{}, eris.Wrap(err, "usecase: admin user revoke role: lookup role")
 		}
-		if role, ok := roles[roleID]; ok && role.Name == adminRoleName {
+		if role, ok := roles[roleID]; ok && role.Name == domain.AdminRoleName {
 			return RevokeRoleOutcome{CannotRevokeOwnAdmin: true}, nil
 		}
 	}
@@ -464,6 +438,35 @@ func liftValidationErr(err error) (*InputValidationInfo, error) {
 		return NewInputValidationInfo(ve.Field, ve.Message), nil
 	}
 	return nil, err
+}
+
+// translateDisplayNameErr maps domain DisplayName sentinels into usecase-layer
+// typed errors. Unexpected errors are wrapped with eris. Returns nil when err
+// is nil.
+func translateDisplayNameErr(err error) error {
+	if err == nil {
+		return nil
+	}
+	switch {
+	case errors.Is(err, domain.ErrDisplayNameRequired):
+		return ucerr.NewValidationError("displayName", "displayName is required")
+	case errors.Is(err, domain.ErrDisplayNameTooLong):
+		return ucerr.NewValidationError("displayName", "displayName must be at most 50 characters")
+	default:
+		return eris.Wrap(err, "usecase: translate display name error")
+	}
+}
+
+// translateBioErr maps domain Bio sentinels into usecase-layer typed errors.
+// Unexpected errors are wrapped with eris. Returns nil when err is nil.
+func translateBioErr(err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, domain.ErrBioTooLong) {
+		return ucerr.NewValidationError("bio", "bio must be at most 500 characters")
+	}
+	return eris.Wrap(err, "usecase: translate bio error")
 }
 
 // refetchUser loads the user after a mutation so callers see a fresh row

--- a/backend/internal/usecase/admin_user.go
+++ b/backend/internal/usecase/admin_user.go
@@ -451,7 +451,7 @@ func translateDisplayNameErr(err error) error {
 	case errors.Is(err, domain.ErrDisplayNameRequired):
 		return ucerr.NewValidationError("displayName", "displayName is required")
 	case errors.Is(err, domain.ErrDisplayNameTooLong):
-		return ucerr.NewValidationError("displayName", "displayName must be at most 50 characters")
+		return ucerr.NewValidationError("displayName", fmt.Sprintf("displayName must be at most %d characters", domain.DisplayNameMax))
 	default:
 		return eris.Wrap(err, "usecase: translate display name error")
 	}
@@ -464,7 +464,7 @@ func translateBioErr(err error) error {
 		return nil
 	}
 	if errors.Is(err, domain.ErrBioTooLong) {
-		return ucerr.NewValidationError("bio", "bio must be at most 500 characters")
+		return ucerr.NewValidationError("bio", fmt.Sprintf("bio must be at most %d characters", domain.BioMax))
 	}
 	return eris.Wrap(err, "usecase: translate bio error")
 }

--- a/backend/internal/usecase/admin_user_test.go
+++ b/backend/internal/usecase/admin_user_test.go
@@ -700,7 +700,7 @@ func TestAdminUser_Update_Validation_DisplayNameOverMax(t *testing.T) {
 	authChk := &adminAuthChecker{admins: map[string]bool{"admin-1": true}}
 	uc, _, _ := buildAdminUC(users, nil, authChk)
 
-	overMax := strings.Repeat("a", displayNameMax+1)
+	overMax := strings.Repeat("a", 51)
 	outcome, err := uc.Update(adminCallerCtx("admin-1"), "u-target", AdminUpdateUserInput{
 		DisplayName: ptr(overMax),
 	})
@@ -1079,7 +1079,7 @@ func TestAdminUser_Update_Validation_BioOverMax(t *testing.T) {
 	authChk := &adminAuthChecker{admins: map[string]bool{"admin-1": true}}
 	uc, _, _ := buildAdminUC(users, nil, authChk)
 
-	overMax := strings.Repeat("b", bioMax+1)
+	overMax := strings.Repeat("b", 501)
 	outcome, err := uc.Update(adminCallerCtx("admin-1"), "u-target", AdminUpdateUserInput{
 		Bio: ptr(overMax),
 	})

--- a/backend/internal/usecase/card.go
+++ b/backend/internal/usecase/card.go
@@ -225,24 +225,28 @@ func (u *CardUsecase) Create(ctx context.Context, in CreateCardInput) (CreateCar
 		return CreateCardOutcome{}, err
 	}
 
-	front := strings.TrimSpace(in.Front)
-	back := strings.TrimSpace(in.Back)
+	frontVO, err := domain.ParseCardText(in.Front, domain.ErrCardFrontRequired, domain.ErrCardFrontTooLong)
+	if err != nil {
+		return CreateCardOutcome{}, translateCardErr(err)
+	}
+	backVO, err := domain.ParseCardText(in.Back, domain.ErrCardBackRequired, domain.ErrCardBackTooLong)
+	if err != nil {
+		return CreateCardOutcome{}, translateCardErr(err)
+	}
 	now := time.Now().UTC()
 	id, err := uuidV7()
 	if err != nil {
 		return CreateCardOutcome{}, eris.Wrap(err, "usecase: create card: generate id")
 	}
 
+	front := frontVO.String()
 	card := &domain.Card{
 		ID:          id,
 		CardgroupID: in.CardgroupID,
 		Front:       front,
-		Back:        back,
+		Back:        backVO.String(),
 		CreatedAt:   now,
 		UpdatedAt:   now,
-	}
-	if err := card.Validate(); err != nil {
-		return CreateCardOutcome{}, translateCardErr(err)
 	}
 	if err := u.cardRepo.Create(ctx, card); err != nil {
 		if errors.Is(err, repository.ErrCardDuplicateFront) {
@@ -299,21 +303,30 @@ func (u *CardUsecase) Update(ctx context.Context, id string, in UpdateCardInput)
 	patch := repository.CardUpdate{}
 	candidate := *existing
 	if in.Front != nil {
-		front := strings.TrimSpace(*in.Front)
-		patch.Front = &front
-		candidate.Front = front
+		front, err := domain.ParseCardText(*in.Front, domain.ErrCardFrontRequired, domain.ErrCardFrontTooLong)
+		if err != nil {
+			info, perr := liftValidationErr(translateCardErr(err))
+			if perr != nil {
+				return UpdateCardOutcome{}, perr
+			}
+			return UpdateCardOutcome{Validation: info}, nil
+		}
+		s := front.String()
+		patch.Front = &s
+		candidate.Front = s
 	}
 	if in.Back != nil {
-		back := strings.TrimSpace(*in.Back)
-		patch.Back = &back
-		candidate.Back = back
-	}
-	info, err := liftValidationErr(translateCardErr(candidate.Validate()))
-	if err != nil {
-		return UpdateCardOutcome{}, err
-	}
-	if info != nil {
-		return UpdateCardOutcome{Validation: info}, nil
+		back, err := domain.ParseCardText(*in.Back, domain.ErrCardBackRequired, domain.ErrCardBackTooLong)
+		if err != nil {
+			info, perr := liftValidationErr(translateCardErr(err))
+			if perr != nil {
+				return UpdateCardOutcome{}, perr
+			}
+			return UpdateCardOutcome{Validation: info}, nil
+		}
+		s := back.String()
+		patch.Back = &s
+		candidate.Back = s
 	}
 
 	updated, err := u.cardRepo.Update(ctx, id, patch)

--- a/backend/internal/usecase/card.go
+++ b/backend/internal/usecase/card.go
@@ -301,7 +301,6 @@ func (u *CardUsecase) Update(ctx context.Context, id string, in UpdateCardInput)
 	}
 
 	patch := repository.CardUpdate{}
-	candidate := *existing
 	if in.Front != nil {
 		front, err := domain.ParseCardText(*in.Front, domain.ErrCardFrontRequired, domain.ErrCardFrontTooLong)
 		if err != nil {
@@ -313,7 +312,6 @@ func (u *CardUsecase) Update(ctx context.Context, id string, in UpdateCardInput)
 		}
 		s := front.String()
 		patch.Front = &s
-		candidate.Front = s
 	}
 	if in.Back != nil {
 		back, err := domain.ParseCardText(*in.Back, domain.ErrCardBackRequired, domain.ErrCardBackTooLong)
@@ -326,7 +324,6 @@ func (u *CardUsecase) Update(ctx context.Context, id string, in UpdateCardInput)
 		}
 		s := back.String()
 		patch.Back = &s
-		candidate.Back = s
 	}
 
 	updated, err := u.cardRepo.Update(ctx, id, patch)

--- a/backend/internal/usecase/card_test.go
+++ b/backend/internal/usecase/card_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -262,6 +263,36 @@ func TestCardUsecase_Create(t *testing.T) {
 	}
 }
 
+func TestCardUsecase_Create_FrontTooLong(t *testing.T) {
+	t.Parallel()
+
+	cardRepo := &mockCardRepository{}
+	cgRepo := &mockCardgroupRepoForCard{findResult: &domain.Cardgroup{ID: "cg1", OwnerID: "u1"}}
+	uc := NewCardUsecase(nil, cardRepo, cgRepo, nil, newTestLogger())
+
+	_, err := uc.Create(authedCtx("u1"), CreateCardInput{
+		CardgroupID: "cg1",
+		Front:       strings.Repeat("a", 501),
+		Back:        "back",
+	})
+	assertValidationError(t, err, "front", "")
+}
+
+func TestCardUsecase_Create_BackTooLong(t *testing.T) {
+	t.Parallel()
+
+	cardRepo := &mockCardRepository{}
+	cgRepo := &mockCardgroupRepoForCard{findResult: &domain.Cardgroup{ID: "cg1", OwnerID: "u1"}}
+	uc := NewCardUsecase(nil, cardRepo, cgRepo, nil, newTestLogger())
+
+	_, err := uc.Create(authedCtx("u1"), CreateCardInput{
+		CardgroupID: "cg1",
+		Front:       "front",
+		Back:        strings.Repeat("a", 501),
+	})
+	assertValidationError(t, err, "back", "")
+}
+
 func TestCardUsecase_Update_NonOwnerAndPatch(t *testing.T) {
 	t.Parallel()
 
@@ -346,6 +377,64 @@ func TestCardUsecase_Update_EmptyFront_ValidationVariant(t *testing.T) {
 	}
 	if cardRepo.capturedPatch.Front != nil {
 		t.Fatal("repository.Update must not be called on validation failure")
+	}
+}
+
+func TestCardUsecase_Update_FrontTooLong(t *testing.T) {
+	t.Parallel()
+
+	existing := &domain.Card{
+		ID:          "card1",
+		CardgroupID: "cg1",
+		Front:       "old front",
+		Back:        "old back",
+	}
+	cardRepo := &mockCardRepository{findResult: existing}
+	uc := NewCardUsecase(nil, cardRepo,
+		&mockCardgroupRepoForCard{findResult: &domain.Cardgroup{ID: "cg1", OwnerID: "u1"}},
+		nil, newTestLogger(),
+	)
+
+	overMax := strings.Repeat("a", 501)
+	outcome, err := uc.Update(authedCtx("u1"), "card1", UpdateCardInput{Front: &overMax})
+
+	if err != nil {
+		t.Fatalf("expected nil error (validation goes to outcome), got: %v", err)
+	}
+	if outcome.Card != nil {
+		t.Fatal("expected nil Card on validation failure")
+	}
+	if outcome.Validation == nil || outcome.Validation.Field != "front" {
+		t.Fatalf("outcome.Validation = %+v, want field=front", outcome.Validation)
+	}
+}
+
+func TestCardUsecase_Update_BackTooLong(t *testing.T) {
+	t.Parallel()
+
+	existing := &domain.Card{
+		ID:          "card1",
+		CardgroupID: "cg1",
+		Front:       "old front",
+		Back:        "old back",
+	}
+	cardRepo := &mockCardRepository{findResult: existing}
+	uc := NewCardUsecase(nil, cardRepo,
+		&mockCardgroupRepoForCard{findResult: &domain.Cardgroup{ID: "cg1", OwnerID: "u1"}},
+		nil, newTestLogger(),
+	)
+
+	overMax := strings.Repeat("a", 501)
+	outcome, err := uc.Update(authedCtx("u1"), "card1", UpdateCardInput{Back: &overMax})
+
+	if err != nil {
+		t.Fatalf("expected nil error (validation goes to outcome), got: %v", err)
+	}
+	if outcome.Card != nil {
+		t.Fatal("expected nil Card on validation failure")
+	}
+	if outcome.Validation == nil || outcome.Validation.Field != "back" {
+		t.Fatalf("outcome.Validation = %+v, want field=back", outcome.Validation)
 	}
 }
 

--- a/backend/internal/usecase/swipe.go
+++ b/backend/internal/usecase/swipe.go
@@ -190,17 +190,13 @@ func (u *SwipeUsecase) HandleSwipe(ctx context.Context, in HandleSwipeInput) (Ha
 		if current == nil {
 			current = domain.NewUserCardFSRSForNewCard(user.Sub, card.ID, now)
 		}
-		newState := u.scheduler.Apply(current.State, rating, now)
-		if err := u.userFSRSRepo.UpsertTx(ctx, tx, &domain.UserCardFSRS{
-			UserID:    user.Sub,
-			CardID:    card.ID,
-			State:     newState,
-			CreatedAt: current.CreatedAt,
-			UpdatedAt: now,
-		}); err != nil {
+		if err := current.ApplyRating(u.scheduler, rating, now); err != nil {
+			return eris.Wrap(err, "usecase: swipe: apply rating")
+		}
+		if err := u.userFSRSRepo.UpsertTx(ctx, tx, current); err != nil {
 			return err
 		}
-		sr, err := domain.NewSwipeRecord(user.Sub, card.ID, rating, now, newState)
+		sr, err := domain.NewSwipeRecord(user.Sub, card.ID, rating, now, current.State)
 		if err != nil {
 			return err
 		}

--- a/backend/internal/usecase/user.go
+++ b/backend/internal/usecase/user.go
@@ -5,23 +5,14 @@ package usecase
 import (
 	"context"
 	"errors"
-	"fmt"
 	"log/slog"
-	"strings"
 
-	"github.com/rivo/uniseg"
 	"github.com/rotisserie/eris"
 
 	"backend/internal/auth"
 	"backend/internal/domain"
 	"backend/internal/repository"
 	"backend/internal/usecase/ucerr"
-)
-
-const (
-	displayNameMin = 1
-	displayNameMax = 50
-	bioMax         = 500
 )
 
 // UserRepository is the consumer-driven interface used by UserUsecase.
@@ -87,51 +78,31 @@ func (u *UserUsecase) UpdateUser(ctx context.Context, in UpdateUserInput) (Updat
 		return UpdateProfileOutcome{}, ucerr.ErrUnauthenticated
 	}
 
-	name := strings.TrimSpace(in.DisplayName)
-	info, err := liftValidationErr(validateDisplayName(name))
+	dn, err := domain.ParseDisplayName(in.DisplayName)
 	if err != nil {
-		return UpdateProfileOutcome{}, err
-	}
-	if info != nil {
+		info, perr := liftValidationErr(translateDisplayNameErr(err))
+		if perr != nil {
+			return UpdateProfileOutcome{}, perr
+		}
 		return UpdateProfileOutcome{Validation: info}, nil
 	}
 
-	info, err = liftValidationErr(validateBio(in.Bio))
+	bio, err := domain.ParseBio(in.Bio)
 	if err != nil {
-		return UpdateProfileOutcome{}, err
-	}
-	if info != nil {
+		info, perr := liftValidationErr(translateBioErr(err))
+		if perr != nil {
+			return UpdateProfileOutcome{}, perr
+		}
 		return UpdateProfileOutcome{Validation: info}, nil
 	}
 
+	name := string(dn)
 	appUser, err := u.repo.Update(ctx, user.Sub, repository.UserUpdate{
 		DisplayName: &name,
-		Bio:         in.Bio,
+		Bio:         bio.Value(),
 	})
 	if err != nil {
 		return UpdateProfileOutcome{}, eris.Wrap(err, "usecase: UpdateUser: update user")
 	}
 	return UpdateProfileOutcome{User: appUser}, nil
-}
-
-func validateDisplayName(v string) error {
-	n := uniseg.GraphemeClusterCount(v)
-	if n < displayNameMin {
-		return ucerr.NewValidationError("displayName", "displayName is required")
-	}
-	if n > displayNameMax {
-		return ucerr.NewValidationError("displayName", fmt.Sprintf("displayName must be at most %d characters", displayNameMax))
-	}
-	return nil
-}
-
-func validateBio(v *string) error {
-	if v == nil {
-		return nil
-	}
-	n := uniseg.GraphemeClusterCount(*v)
-	if n > bioMax {
-		return ucerr.NewValidationError("bio", fmt.Sprintf("bio must be at most %d characters", bioMax))
-	}
-	return nil
 }

--- a/backend/internal/usecase/user.go
+++ b/backend/internal/usecase/user.go
@@ -54,7 +54,7 @@ func (u *UserUsecase) Me(ctx context.Context) (*domain.User, error) {
 
 type UpdateUserInput struct {
 	DisplayName string
-	Bio         *string // nil = unchanged, "" = explicit clear
+	Bio         *string // nil = unchanged, "" or whitespace-only = explicit clear (trimmed); surrounding whitespace is stripped
 }
 
 // UpdateProfileOutcome is the result of UserUsecase.UpdateUser. Exactly one
@@ -87,20 +87,22 @@ func (u *UserUsecase) UpdateUser(ctx context.Context, in UpdateUserInput) (Updat
 		return UpdateProfileOutcome{Validation: info}, nil
 	}
 
-	bio, err := domain.ParseBio(in.Bio)
-	if err != nil {
-		info, perr := liftValidationErr(translateBioErr(err))
-		if perr != nil {
-			return UpdateProfileOutcome{}, perr
-		}
-		return UpdateProfileOutcome{Validation: info}, nil
-	}
-
 	name := string(dn)
-	appUser, err := u.repo.Update(ctx, user.Sub, repository.UserUpdate{
+	patch := repository.UserUpdate{
 		DisplayName: &name,
-		Bio:         bio.Value(),
-	})
+	}
+	if in.Bio != nil {
+		bio, err := domain.ParseBio(in.Bio)
+		if err != nil {
+			info, perr := liftValidationErr(translateBioErr(err))
+			if perr != nil {
+				return UpdateProfileOutcome{}, perr
+			}
+			return UpdateProfileOutcome{Validation: info}, nil
+		}
+		patch.Bio = bio.Value()
+	}
+	appUser, err := u.repo.Update(ctx, user.Sub, patch)
 	if err != nil {
 		return UpdateProfileOutcome{}, eris.Wrap(err, "usecase: UpdateUser: update user")
 	}

--- a/docs/backend-graphql.md
+++ b/docs/backend-graphql.md
@@ -406,9 +406,9 @@ Usage in the usecase layer:
 if user == nil {
     return nil, gqlerr.Unauthenticated()
 }
-if n > displayNameMax {
+if n > domain.DisplayNameMax {
     return nil, gqlerr.BadUserInput("displayName",
-        fmt.Sprintf("displayName must be at most %d characters", displayNameMax))
+        fmt.Sprintf("displayName must be at most %d characters", domain.DisplayNameMax))
 }
 if err := repo.Update(ctx, id, patch); err != nil {
     return nil, gqlerr.Internal(ctx, err)

--- a/docs/backend-graphql.md
+++ b/docs/backend-graphql.md
@@ -192,7 +192,7 @@ The `auth` package exposes two distinct types with different lifetimes and data 
 
 The split is deliberate: the JWT does not carry roles in this project, so every role check goes through the DB. `auth.Service` is constructed once at boot in `run()` against the `UserRoleRepository` and injected into resolvers/usecases that need to gate on role membership.
 
-`auth.Service.IsAdmin(ctx, userID)` hardcodes the literal `"admin"` role name in the method body — callers cannot pass a role string. This prevents drift to bespoke role names; add a new dedicated method (e.g. `IsModerator`) when a second role is needed rather than parameterising `IsAdmin`. The same `"admin"` literal is exposed to the role-CRUD usecase as `adminRoleName` (see `internal/usecase/admin_role.go`) so the system-role rename / delete guards stay in lockstep with the auth-side check; both move together when a second privileged role is introduced.
+`auth.Service.IsAdmin(ctx, userID)` hardcodes the literal `"admin"` role name in the method body — callers cannot pass a role string. This prevents drift to bespoke role names; add a new dedicated method (e.g. `IsModerator`) when a second role is needed rather than parameterising `IsAdmin`. The same `"admin"` literal is exposed to the role-CRUD usecase as `domain.AdminRoleName` (see `internal/domain/role.go`) so the system-role rename / delete guards stay in lockstep with the auth-side check; both move together when a second privileged role is introduced.
 
 The DB side of the same check is `public.is_admin(uid uuid) RETURNS boolean`, defined in migration `20260502000000_add_rbac_helpers`. See `docs/backend-db.md` § "SECURITY DEFINER helper recipe" for the function shape RLS policies and future RBAC helpers must replicate.
 
@@ -209,7 +209,7 @@ The DB side of the same check is `public.is_admin(uid uuid) RETURNS boolean`, de
 
 ### System-role guard reads the persisted name, not the input
 
-`AdminRoleUsecase.Update` rejects renaming the system `"admin"` role. The check is `existing.Name == adminRoleName` against the row just loaded by `FindByID`, not against the post-normalisation new name. The reasoning is asymmetric:
+`AdminRoleUsecase.Update` rejects renaming the system `"admin"` role. The check is `existing.IsSystem()` against the row just loaded by `FindByID`, not against the post-normalisation new name. The reasoning is asymmetric:
 
 - "Renaming admin away" is what the guard must block — the persisted name is what tells you whether this row is admin.
 - "Renaming something else *to* admin" is also blocked, but by the unique-name guard at the repository layer (`ErrRoleDuplicate` on `name`) — admin always exists, so the new-name collision is automatic.
@@ -223,7 +223,7 @@ Reading the input name instead would force the guard to also know that admin exi
 ### Validation rules in `usecase.UpdateUser`
 
 - `displayName` is `strings.TrimSpace`-ed, then validated as 1–50 grapheme clusters via `rivo/uniseg`.
-- `bio` accepts up to 500 grapheme clusters (no trim; whitespace is preserved).
+- `bio` accepts up to 500 grapheme clusters (trimmed; whitespace-only collapses to explicit clear).
 - Out-of-bounds returns `gqlerr.BadUserInput("displayName", ...)` (extensions.code = "BAD_USER_INPUT", field = "displayName"). See [Validation (grapheme clusters)](#validation-grapheme-clusters) for the WHY.
 
 ### Card bulk delete + FSRS override

--- a/docs/backend/ddd-patterns/aggregate-behaviour-method.md
+++ b/docs/backend/ddd-patterns/aggregate-behaviour-method.md
@@ -1,0 +1,83 @@
+# Aggregate behaviour methods: promoting anemic-domain logic
+
+> Part of the [DDD patterns](./../../../.claude/rules/ddd-patterns.md) rules.
+
+## Why
+
+An "anemic domain" puts all logic in usecases: the domain model is a data carrier
+(structs with no methods), and every caller reimplements the same invariant. The
+costs:
+
+- **Duplication.** An invariant checked in three usecases is three places to break
+  independently.
+- **Coupling.** Callers accumulate knowledge of internal domain rules they should not
+  need to understand.
+- **Testability.** Unit tests for the invariant live in the usecase test file instead
+  of in a focused domain test.
+
+Behaviour methods let the type enforce its own invariants and expose the validated
+state via a single API surface.
+
+## What (three promotions in issue #182)
+
+### `Role.IsSystem()` (issue #182 item #14, #15)
+
+Before: `usecase/admin_role.go` contained a local `isSystemRole(name string) bool`
+check comparing the string against hardcoded `"admin"` and `"general"` literals.
+
+After: `domain/role.go` owns the set and the method:
+
+```go
+var systemRoleNames = map[string]struct{}{
+    AdminRoleName:   {},
+    GeneralRoleName: {},
+}
+
+func (r Role) IsSystem() bool {
+    _, ok := systemRoleNames[r.Name]
+    return ok
+}
+```
+
+Any usecase that receives a `*domain.Role` calls `role.IsSystem()` — the check is
+not repeated per-caller.
+
+### `Rating.IsValid()` (issue #182 item #16)
+
+Before: rating bounds were checked inline in the swipe usecase via an ad-hoc range
+comparison.
+
+After: `domain/rating.go` owns the boundary:
+
+```go
+func (r Rating) IsValid() bool {
+    return r >= RatingAgain && r <= RatingEasy
+}
+```
+
+`UserCardFSRS.ApplyRating` calls `rating.IsValid()` before delegating to the
+scheduler, so an invalid rating is caught at the aggregate boundary rather than
+reaching the service layer.
+
+### `UserCardFSRS.ApplyRating()` (issue #182 item #18)
+
+Before: `usecase/swipe.go` built a `UserCardFSRS{...}` struct literal and called
+`scheduler.Apply` inline, producing a partial aggregate state that could diverge
+from the constructor invariants if any field was missed.
+
+After: the aggregate owns the state-transition logic:
+
+```go
+func (u *UserCardFSRS) ApplyRating(scheduler FSRSScheduler, rating Rating, now time.Time) error {
+    if !rating.IsValid() {
+        return eris.Errorf("user_card_fsrs: invalid rating %d", rating)
+    }
+    u.State = scheduler.Apply(u.State, rating, now)
+    u.UpdatedAt = now
+    return nil
+}
+```
+
+The usecase passes the concrete scheduler; the aggregate updates its own fields.
+`UpdatedAt` is always stamped, and the aggregate's invariants are maintained in
+one place.

--- a/docs/backend/ddd-patterns/caller-supplied-sentinels-in-parser.md
+++ b/docs/backend/ddd-patterns/caller-supplied-sentinels-in-parser.md
@@ -1,0 +1,68 @@
+# Caller-supplied sentinels in a field-agnostic parser
+
+> Part of the [DDD patterns](./../../../.claude/rules/ddd-patterns.md) rules.
+
+## Why
+
+`Card` has two text fields — `Front` and `Back` — with identical validation rules
+but different domain sentinels (`ErrCardFrontRequired` vs `ErrCardBackRequired`).
+Before this PR, `usecase/card.go` contained a `validateCardText(field, value string)`
+function that dispatched on a `field == "front"` string comparison. The problems:
+
+- The discrimination is fragile: a misspelling compiles without complaint.
+- Each field's validation is not symmetric — a new field requires a new branch.
+- The VO (`CardText`) knew nothing about which sentinel to return, so the field
+  identity lived outside the VO and had to be kept in sync manually.
+
+## What
+
+`ParseCardText` accepts the two sentinels as parameters:
+
+```go
+// domain/card_text.go
+
+func ParseCardText(s string, requiredErr, tooLongErr error) (CardText, error) {
+    if requiredErr == nil || tooLongErr == nil {
+        panic("domain: ParseCardText requires non-nil requiredErr and tooLongErr sentinels")
+    }
+    trimmed := strings.TrimSpace(s)
+    n := uniseg.GraphemeClusterCount(trimmed)
+    if n < 1 {
+        return "", requiredErr
+    }
+    if n > CardTextMax {
+        return "", tooLongErr
+    }
+    return CardText(trimmed), nil
+}
+```
+
+The VO stays field-agnostic. The aggregate (`Card.Validate`) picks the right
+sentinel for each field:
+
+```go
+// domain/card.go
+
+func (c *Card) Validate() error {
+    // ...
+    if _, err := ParseCardText(c.Front, ErrCardFrontRequired, ErrCardFrontTooLong); err != nil {
+        return err
+    }
+    if _, err := ParseCardText(c.Back, ErrCardBackRequired, ErrCardBackTooLong); err != nil {
+        return err
+    }
+    return nil
+}
+```
+
+The sentinels themselves (`ErrCardFrontRequired`, etc.) are declared at the `domain`
+level and are available to the usecase layer's `translate*Err` helpers.
+
+## Panic on nil sentinels
+
+`ParseCardText` panics when either sentinel is `nil`. This is a programmer-error
+guard: nil sentinels cause the function to return `nil` errors on validation
+failure, which the caller interprets as "valid" — a silent correctness bug. A panic
+surfaces the mistake immediately in tests. This mirrors the `ucerr.NewValidationError`
+convention documented in
+[`docs/backend/error-wrapping/input-validation-info-empty-field-panic.md`](../error-wrapping/input-validation-info-empty-field-panic.md).

--- a/docs/backend/ddd-patterns/consumer-defined-interface-cross-package.md
+++ b/docs/backend/ddd-patterns/consumer-defined-interface-cross-package.md
@@ -1,0 +1,64 @@
+# Consumer-defined interface across package boundaries (domain → service)
+
+> Part of the [DDD patterns](./../../../.claude/rules/ddd-patterns.md) rules.
+> For the usecase → repository variant see
+> [`docs/backend/library-gotchas/consumer-defined-narrow-repo-interface.md`](../library-gotchas/consumer-defined-narrow-repo-interface.md).
+
+## Why
+
+The `go-arch-lint` invariant forbids `domain → domain/service` imports
+(see [`backend/.go-arch-lint.yml`](../../../backend/.go-arch-lint.yml) and
+[`.claude/rules/backend-layering.md`](../../../.claude/rules/backend-layering.md)).
+`domain/service` depends on `domain`, not the other way around. Yet
+`UserCardFSRS.ApplyRating` needs to call a scheduler — a calculation that lives in
+`domain/service`.
+
+Putting `ApplyRating`'s logic inline in the aggregate would duplicate the
+FSRS algorithm. Calling `service.FSRSScheduler` directly would create a forbidden
+import cycle. A global function pointer would be implicit and untestable.
+
+## What
+
+The aggregate declares a minimal interface in its own file:
+
+```go
+// domain/user_card_fsrs.go
+
+// FSRSScheduler is the consumer-defined interface for the FSRS scheduler.
+// *service.FSRSScheduler satisfies it implicitly.
+type FSRSScheduler interface {
+    Apply(state FSRSState, rating Rating, now time.Time) FSRSState
+}
+
+func (u *UserCardFSRS) ApplyRating(scheduler FSRSScheduler, rating Rating, now time.Time) error {
+    if !rating.IsValid() {
+        return eris.Errorf("user_card_fsrs: invalid rating %d", rating)
+    }
+    u.State = scheduler.Apply(u.State, rating, now)
+    u.UpdatedAt = now
+    return nil
+}
+```
+
+`*service.FSRSScheduler` has an `Apply` method with the matching signature and
+satisfies `domain.FSRSScheduler` implicitly — Go's structural typing requires no
+change to the service package. The dependency arrow stays correct: `service`
+depends on `domain`; `domain` has no import of `service`.
+
+The caller (usecase layer) passes the concrete `*service.FSRSScheduler` at the
+call site:
+
+```go
+// usecase/swipe.go (simplified)
+if err := uc.Apply(scheduler, rating, now); err != nil { ... }
+```
+
+## Relationship to the usecase→repository variant
+
+The [`consumer-defined-narrow-repo-interface`](../library-gotchas/consumer-defined-narrow-repo-interface.md)
+pattern (usecase level) and this pattern (domain level) are the same technique
+applied at different layers. In both cases the consumer declares the minimal
+interface it needs; the concrete implementation satisfies it without importing back.
+The domain-level variant is stricter because the forbidden import (`domain →
+domain/service`) is architecturally enforced by `go-arch-lint`, not just a
+best-practice guideline.

--- a/docs/backend/ddd-patterns/exported-bound-constants-prevent-message-drift.md
+++ b/docs/backend/ddd-patterns/exported-bound-constants-prevent-message-drift.md
@@ -1,0 +1,78 @@
+# Exported bound constants prevent message drift
+
+> Part of the [DDD patterns](./../../../.claude/rules/ddd-patterns.md) rules.
+
+## Why
+
+If the validation cap is an unexported constant inside the domain package and the
+usecase error message hardcodes the literal (`"50 characters"`), the cap and the
+message can drift independently:
+
+- Changing `roleNameMax` from 50 to 100 inside `domain` still compiles.
+- The usecase message still says "50 characters" until someone remembers to
+  update it — and they usually do not.
+
+The mismatch is invisible in tests unless the test pins the exact message string.
+
+## What
+
+Export the constant even though only the domain layer enforces the bound:
+
+```go
+// domain/role_name.go
+const RoleNameMax = 50
+
+// domain/display_name.go
+const DisplayNameMax = 50
+
+// domain/bio.go
+const BioMax = 500
+```
+
+The usecase `translate*Err` helper references the constant when formatting the
+message:
+
+```go
+// usecase/admin_role.go
+
+func translateRoleNameErr(err error) error {
+    // ...
+    case errors.Is(err, domain.ErrRoleNameTooLong):
+        return ucerr.NewValidationError("name",
+            fmt.Sprintf("name must be at most %d characters", domain.RoleNameMax))
+    // ...
+}
+```
+
+```go
+// usecase/admin_user.go
+
+func translateDisplayNameErr(err error) error {
+    // ...
+    case errors.Is(err, domain.ErrDisplayNameTooLong):
+        return ucerr.NewValidationError("displayName",
+            fmt.Sprintf("displayName must be at most %d characters", domain.DisplayNameMax))
+    // ...
+}
+
+func translateBioErr(err error) error {
+    // ...
+    if errors.Is(err, domain.ErrBioTooLong) {
+        return ucerr.NewValidationError("bio",
+            fmt.Sprintf("bio must be at most %d characters", domain.BioMax))
+    }
+    // ...
+}
+```
+
+The cap lives in one place (`domain/*.go`); the message is derived from it at the
+`translate*Err` call site. Updating the cap automatically propagates to the
+user-facing message.
+
+## Rule of thumb
+
+Any constant that appears in a domain sentinel's message text (e.g. `eris.Errorf("role:
+name exceeds %d characters", RoleNameMax)`) must be exported. If the constant is
+used only in unexported sentinel formatting inside the domain package, it could stay
+unexported — but the sentinel's presence on the wire (via `translate*Err`) makes the
+cap effectively public, and exporting the symbol makes that fact explicit.

--- a/docs/backend/ddd-patterns/helpers-introduced-but-not-wired-must-be-deleted.md
+++ b/docs/backend/ddd-patterns/helpers-introduced-but-not-wired-must-be-deleted.md
@@ -1,0 +1,54 @@
+# Helpers introduced but not wired must be deleted
+
+> Part of the [DDD patterns](./../../../.claude/rules/ddd-patterns.md) rules.
+> Application of the existing rule in
+> [`.claude/rules/scope-discipline.md` § "Post-flight grep: helpers introduced but never wired"](../../../.claude/rules/scope-discipline.md#post-flight-grep-helpers-introduced-but-never-wired).
+
+## Why
+
+`User.UpdateProfile(DisplayName, Bio)` was introduced in Phase 1 of this PR
+alongside the new domain VOs. The intent was to provide a single aggregate method
+that encapsulated profile-update logic. However, both `usecase/user.go` and
+`usecase/admin_user.go` retained the patch-based `repository.UserUpdate` flow and
+never called `UpdateProfile`. The method had zero production callers at PR-completion
+time.
+
+A speculative API that ships with zero callers becomes dead exported surface. A
+future contributor who finds `User.UpdateProfile` may:
+
+- Route a new feature through it rather than the established `repository.UserUpdate`
+  path, bypassing tests pinned to the per-file behavior.
+- Assume the method is "the right way" without realizing no existing code uses it,
+  leading to behavioral divergence.
+
+The root cause was scope expansion: the VO introduction phase added a convenience
+aggregator before the callers were ready to use it. The correct fix is to introduce
+the aggregator in the same commit that wires the first caller.
+
+## What
+
+`User.UpdateProfile` was deleted in commit `234519d` in the same PR. The post-flight
+check that caught this was:
+
+```bash
+grep -rn "UpdateProfile" backend/ --include='*.go' | grep -v _test.go | grep -v domain/user.go
+```
+
+Zero results confirmed the method had no production callers outside its own file.
+The existing test in `domain/user_test.go` was also removed, leaving no dead test
+coverage.
+
+## The rule
+
+After any route-through PR that introduces a domain or aggregate helper alongside
+a refactor, run the post-flight grep:
+
+```bash
+grep -rn <NewSymbol> backend/ --include='*.go' | grep -v _test.go | grep -v <declaring-file>
+```
+
+A count of `0` means delete the helper in the same PR. "Keep for later" produces
+the exact surface-rot described above.
+
+See [`.claude/rules/scope-discipline.md`](../../../.claude/rules/scope-discipline.md)
+for the general rule and the analogous example from issue #181 (`ResolvePageSize`).

--- a/docs/backend/ddd-patterns/trinary-value-object.md
+++ b/docs/backend/ddd-patterns/trinary-value-object.md
@@ -1,0 +1,68 @@
+# Trinary value object for optional profile fields
+
+> Part of the [DDD patterns](./../../../.claude/rules/ddd-patterns.md) rules.
+
+## Why
+
+A profile update mutation may send three distinct intents for an optional field:
+
+| Intent | Meaning |
+|---|---|
+| Field absent from input | Leave the stored value unchanged |
+| Field present, value `""` | Explicitly clear the stored value |
+| Field present, value `"x"` | Set the stored value to `"x"` |
+
+A bare `*string` cannot distinguish "leave alone" (no pointer) from the Go zero
+value for the pointee. Using a separate `bool` flag alongside the pointer drifts
+independently — the flag can say "set" while the pointer says `nil`, or vice versa.
+
+## What
+
+`Bio` encodes the trinary as a struct with a private `*string`:
+
+```go
+// domain/bio.go
+
+type Bio struct {
+    value *string
+}
+
+func ParseBio(s *string) (Bio, error) {
+    if s == nil {
+        return Bio{}, nil        // no change
+    }
+    trimmed := strings.TrimSpace(*s)
+    if uniseg.GraphemeClusterCount(trimmed) > BioMax {
+        return Bio{}, ErrBioTooLong
+    }
+    return Bio{value: &trimmed}, nil
+}
+
+func (b Bio) IsSet() bool    { return b.value != nil }
+
+func (b Bio) Value() *string {
+    if b.value == nil {
+        return nil
+    }
+    s := *b.value
+    return &s    // copy to prevent aliasing mutation
+}
+```
+
+- `ParseBio(nil)` → `Bio{}` (no change): `IsSet()` returns `false`.
+- `ParseBio(&"")` or `ParseBio(&"   ")` → explicit clear: `IsSet()` returns `true`,
+  `Value()` returns a pointer to `""`. Whitespace-only inputs are collapsed to the
+  explicit-clear case after trimming.
+- `ParseBio(&"hello")` → set: `IsSet()` returns `true`, `Value()` returns a pointer
+  to `"hello"`.
+
+`Value()` returns a copy of the pointer's target so external mutation of the
+returned pointer does not alter the `Bio`'s internal state.
+
+## Usecase guard
+
+The `if in.Bio != nil` check in `usecase/user.go` and `usecase/admin_user.go` mirrors
+the `ParseBio(nil)` no-change case in Go guard-clause form. It is a defense against
+future semantic changes to `ParseBio` (e.g. a version that validates a nil input
+differently) rather than a correction for a current bug. Both the guard and the `nil`
+pass-through inside `ParseBio` produce the same outcome today.

--- a/docs/backend/ddd-patterns/value-object-parse-pattern.md
+++ b/docs/backend/ddd-patterns/value-object-parse-pattern.md
@@ -1,0 +1,79 @@
+# Value object Parse pattern
+
+> Part of the [DDD patterns](./../../../.claude/rules/ddd-patterns.md) rules.
+
+## Why
+
+Validation failures in a domain VO are expected business outcomes, not exceptional
+conditions. A constructor that panics (or silently truncates) hides the failure
+from the caller. An explicit `error` return forces the caller to handle it at the
+trust boundary — the point where raw user input meets the domain model.
+
+## What
+
+The canonical VO constructor signature is:
+
+```go
+Parse<Type>(s string) (<Type>, error)
+```
+
+Applied in `backend/internal/domain/` for `RoleName`, `CardText`, `DisplayName`,
+and `Bio`. Each `Parse*` function:
+
+1. Trims surrounding whitespace.
+2. Validates a lower bound (non-empty after trim).
+3. Validates an upper bound (byte count or grapheme cluster count, depending on
+   whether the field is ASCII-restricted or multi-script).
+4. Returns either the typed value or a domain-owned sentinel error.
+
+### RoleName example (`domain/role_name.go`)
+
+```go
+const RoleNameMax = 50
+
+func ParseRoleName(s string) (RoleName, error) {
+    normalized := strings.ToLower(strings.TrimSpace(s))
+    if normalized == "" {
+        return "", ErrRoleNameRequired
+    }
+    if len(normalized) > RoleNameMax {
+        return "", ErrRoleNameTooLong
+    }
+    if !roleNamePattern.MatchString(normalized) {
+        return "", ErrRoleNameInvalid
+    }
+    return RoleName(normalized), nil
+}
+```
+
+`RoleName` is ASCII-restricted (the pattern enforces `[a-z0-9_-]`), so byte
+length equals grapheme count and `len()` is correct.
+
+### DisplayName example (`domain/display_name.go`)
+
+```go
+const DisplayNameMax = 50
+
+func ParseDisplayName(s string) (DisplayName, error) {
+    trimmed := strings.TrimSpace(s)
+    n := uniseg.GraphemeClusterCount(trimmed)
+    if n < 1 {
+        return "", ErrDisplayNameRequired
+    }
+    if n > DisplayNameMax {
+        return "", ErrDisplayNameTooLong
+    }
+    return DisplayName(trimmed), nil
+}
+```
+
+Multi-script display names use `uniseg.GraphemeClusterCount` because a single
+visible character can be multiple UTF-8 bytes. Byte-counting would impose a
+different effective cap depending on the script.
+
+## Caller responsibility
+
+Callers at the usecase layer translate domain sentinels into wire-typed errors via a
+`translate<Type>Err` helper (see
+[`docs/backend/ddd-patterns/exported-bound-constants-prevent-message-drift.md`](exported-bound-constants-prevent-message-drift.md)).
+The domain layer owns the cap; the usecase layer owns the user-facing message.

--- a/docs/backend/ddd-patterns/zero-value-docstring-on-string-newtypes.md
+++ b/docs/backend/ddd-patterns/zero-value-docstring-on-string-newtypes.md
@@ -1,0 +1,51 @@
+# Zero-value docstring on string newtypes
+
+> Part of the [DDD patterns](./../../../.claude/rules/ddd-patterns.md) rules.
+
+## Why
+
+Go cannot seal a string newtype the way a struct type can be sealed via unexported
+fields. Any caller can write `RoleName("")` or `CardText("")` and obtain the zero
+value without going through `Parse*`. The zero value is always invalid — an empty
+`RoleName` that bypasses `ParseRoleName` skips the length and pattern checks and
+silently enters the system.
+
+A docstring does not prevent the bypass, but it surfaces the gap:
+
+- Code review sees the intent before approving a raw cast.
+- IDE hover shows the warning before a developer writes the bypass.
+- `go doc` and generated API references carry the constraint.
+
+## What
+
+Each string-newtype VO declares the zero-value invalidity on the type:
+
+```go
+// domain/role_name.go
+
+// RoleName is the canonical, lowercase, slug-like identifier for an application
+// role. ...
+// The zero value (RoleName("")) is invalid; use ParseRoleName to construct.
+type RoleName string
+```
+
+The same pattern appears in `domain/display_name.go`:
+
+```go
+// The zero value (DisplayName("")) is invalid; use ParseDisplayName to construct.
+type DisplayName string
+```
+
+And in `domain/card_text.go`:
+
+```go
+// The zero value (CardText("")) is invalid; use ParseCardText to construct.
+type CardText string
+```
+
+## Relationship to future compile-time enforcement
+
+The docstring is a documentation pattern, not a runtime safeguard. Stronger
+enforcement options — a struct wrapper with an unexported field, a linter rule that
+forbids raw string conversion for these types — are tracked separately (see issue
+#193). Until then, the docstring is the review-time and IDE-time checkpoint.

--- a/docs/backend/error-wrapping/input-validation-info-empty-field-panic.md
+++ b/docs/backend/error-wrapping/input-validation-info-empty-field-panic.md
@@ -68,5 +68,5 @@ production code.
   tests legitimately construct invalid shapes to verify classifier coverage.
 - Reference: `backend/internal/usecase/admin_user.go` (`NewInputValidationInfo`,
   `liftValidationErr`, `mapRoleAssignmentError`) and `backend/internal/usecase/admin_role.go`
-  (`mapAdminRoleError`, `normalizeAndValidateRoleName`) — all production
+  (`mapAdminRoleError`, `translateRoleNameErr`) — all production
   construction sites flow through the constructor.

--- a/docs/backend/error-wrapping/inverse-helper-for-partial-promotion.md
+++ b/docs/backend/error-wrapping/inverse-helper-for-partial-promotion.md
@@ -139,6 +139,6 @@ This bounds the promotion's diff to the mutation being promoted plus a single
 one-line wrap at each non-routing caller — well inside the 800-line ceiling in
 [`.claude/rules/pr-sizing.md`](../../../.claude/rules/pr-sizing.md). Reference:
 `backend/internal/usecase/admin_role.go` (`mapAdminRoleError`, `lowerValidationInfo`,
-`normalizeAndValidateRoleName`) and `backend/internal/usecase/admin_user.go`
+`translateRoleNameErr`) and `backend/internal/usecase/admin_user.go`
 (`mapRoleAssignmentError`, `liftValidationErr`) — both pairs were introduced
 for the four-mutation outcome promotion in [#171].

--- a/docs/backend/error-wrapping/outcome-union-enforcement.md
+++ b/docs/backend/error-wrapping/outcome-union-enforcement.md
@@ -67,7 +67,7 @@ extraction produces a real miss.
 and `adminRoleUsecase.Create` were never on the allowlist before [#171] even though
 both ultimately surfaced typed `ucerr.NewValidationError` values to the resolver.
 The classifier missed them because both methods routed validation through helper
-functions (`mapRoleAssignmentError`, `mapAdminRoleError`, `validateRoleName`)
+functions (`mapRoleAssignmentError`, `mapAdminRoleError`, `domain.ParseRoleName`)
 that themselves called `ucerr.New*` — the helpers lived outside the methods'
 function bodies, so the body-only `ast.Inspect` saw zero direct constructor
 references and treated `emitsTypedError = false`. The promotion still landed


### PR DESCRIPTION
## Summary

Tier 3 of the DDD promotion (issue #182): promote anemic-domain behaviour from the usecase layer into the `internal/domain` package.

- New value objects: `RoleName`, `CardText`, `DisplayName`, `Bio` (`backend/internal/domain/*.go`). Each exposes a `Parse...` constructor that trims and validates against grapheme-cluster bounds. The trinary `Bio` struct encodes the "no change / explicit clear / set" semantics in the type itself.
- New behaviour methods: `Role.IsSystem`, `Rating.IsValid`, `UserCardFSRS.ApplyRating`, plus a consumer-defined `domain.FSRSScheduler` interface that keeps the `domain → service` import forbidden while letting the aggregate call back to the scheduler.
- Usecase call sites in `admin_role.go`, `admin_user.go`, `user.go`, `card.go`, `swipe.go` rewritten to delegate trim/validate/system-role detection to the new domain symbols. The legacy `validateRoleName`, `validateDisplayName`, `validateBio`, `isSystemRole`, `adminRoleName` / `generalRoleName` constants are removed.
- `auth/role.go`, `repository/role.go`, `cmd/server/main.go` swap remaining `"admin"` string literals for `domain.AdminRoleName`. `.go-arch-lint.yml` adds the `auth → domain` edge.
- Defensive improvements: exported bound constants (`RoleNameMax`, `DisplayNameMax`, `BioMax`) referenced from the usecase `translateXxxErr` helpers so the validation cap and the error message string cannot drift; `ParseCardText` panics on nil sentinels; `Bio.Value()` returns a copy.
- Field-level retyping (e.g. `Card.Front` typed as `CardText`) is intentionally out of scope and tracked as Tier 4 in #193.
- Documentation: `docs/backend/ddd-patterns/` adds 8 L3 chapters; `.claude/rules/ddd-patterns.md` indexes them; `.claude/rules/backend-layering.md` records the new `auth → domain` edge.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race -covermode=atomic -timeout 300s ./...` — 1237 passed in 23 packages
- [x] `go tool go-arch-lint check --project-path .`
- [x] Acceptance grep checks #14, #15, #17, #18, #19, #20 (zero hits in production)
- [x] Three-round PR review (`/pr-review-toolkit:review-pr`); all in-scope Critical/Important items resolved

Closes #182

Related: #193 (Tier 4 — promote VO field types across aggregates and signatures)
