### PR TITLE
refactor(backend): Tier 3 follow-up — promote VO field types across aggregates (#193)

### DIFF
--- a/.claude/rules/ddd-patterns.md
+++ b/.claude/rules/ddd-patterns.md
@@ -29,7 +29,7 @@ the right sentinel for each field. Nil sentinels panic at the construction bound
 ### Trinary value object for optional profile fields
 
 `Bio` encodes "no change" / "explicit clear" / "set" in a struct with a private
-`*string`. `IsSet()` and `Value()` expose the trinary without an out-of-band flag.
+`*string`. `IsSet()` and `Ptr()` expose the trinary without an out-of-band flag.
 `ParseBio(nil)` returns the no-change case; whitespace-only inputs collapse to
 explicit-clear after trimming.
 

--- a/.claude/rules/ddd-patterns.md
+++ b/.claude/rules/ddd-patterns.md
@@ -74,9 +74,53 @@ cap automatically propagates to the user-facing error message.
 
 A speculative domain method with zero production callers at PR completion time must
 be removed in the same PR. Post-flight grep confirms zero callers; a zero count means
-delete, not "keep for later". Application of the existing scope-discipline rule.
+delete, not "keep for later". Application of the existing scope-discipline rule. The
+rule keys on wired-ness per symbol, not on category: a single PR introducing several
+helpers of the same kind applies the grep verdict independently to each.
 
 [`docs/backend/ddd-patterns/helpers-introduced-but-not-wired-must-be-deleted.md`](../../docs/backend/ddd-patterns/helpers-introduced-but-not-wired-must-be-deleted.md)
+
+### Context-neutral docstrings on shared-context value objects
+
+When a struct VO is consumed from both a patch-context (DTO input) and a
+read-context (DB column) — e.g. `Bio` carrying `nil` / `&""` / `&"x"` in
+both — the accessor docstrings must enumerate both interpretations. A
+docstring that bakes in one context misleads readers arriving from the other.
+Context-specific helpers (`ParseBio` for patch input, `BioFromPtr` for DB
+reads) carry context-specific docstrings.
+
+[`docs/backend/ddd-patterns/context-neutral-vo-docstrings.md`](../../docs/backend/ddd-patterns/context-neutral-vo-docstrings.md)
+
+### Same-underlying-type pointer cast for VO bridging
+
+When a repository row stores `*string` and the domain field is
+`*<DomainStringNewtype>`, `(*domain.DisplayName)(g.DisplayName)` is a direct
+pointer conversion legal under Go's same-underlying-type rule. No helper, no
+nil-check needed. Does not apply to struct VOs (e.g. `Bio`), which require a
+boundary helper.
+
+[`docs/backend/ddd-patterns/same-underlying-type-pointer-cast.md`](../../docs/backend/ddd-patterns/same-underlying-type-pointer-cast.md)
+
+### Boundary gate replaces domain re-check
+
+A field that originates in user input and is gated at the usecase boundary
+should not be re-checked in the domain aggregate. `Card.CardgroupID` is gated
+by `authorizeCardgroupOrBadInput` before any `Card` is constructed; the domain
+side's `Validate()` skips the presence check. The remaining `Front`/`Back`
+checks survive because no boundary gate enforces them.
+
+[`docs/backend/ddd-patterns/boundary-gate-replaces-domain-recheck.md`](../../docs/backend/ddd-patterns/boundary-gate-replaces-domain-recheck.md)
+
+### Patch DTOs keep primitive types, not the VO
+
+`repository.UserUpdate.Bio` stays `*string`, even though `User.Bio` is the
+struct VO `Bio`. The patch contract (`nil = no change`) is about
+presence/absence, which the primitive expresses literally. The usecase
+translates `Bio.Ptr()` to `*string` at the DTO construction site; the
+repository site stays unaware of the VO. Same shape for `CardUpdate.Front` /
+`CardUpdate.Back` via `CardText.String()`.
+
+[`docs/backend/ddd-patterns/patch-dto-primitive-not-vo.md`](../../docs/backend/ddd-patterns/patch-dto-primitive-not-vo.md)
 
 ## Further reading (on-demand)
 
@@ -88,3 +132,7 @@ delete, not "keep for later". Application of the existing scope-discipline rule.
 - [Zero-value docstring on string newtypes](../../docs/backend/ddd-patterns/zero-value-docstring-on-string-newtypes.md)
 - [Exported bound constants prevent message drift](../../docs/backend/ddd-patterns/exported-bound-constants-prevent-message-drift.md)
 - [Helpers introduced but not wired must be deleted](../../docs/backend/ddd-patterns/helpers-introduced-but-not-wired-must-be-deleted.md)
+- [Context-neutral docstrings on shared-context value objects](../../docs/backend/ddd-patterns/context-neutral-vo-docstrings.md)
+- [Same-underlying-type pointer cast for VO bridging](../../docs/backend/ddd-patterns/same-underlying-type-pointer-cast.md)
+- [Boundary gate replaces domain re-check](../../docs/backend/ddd-patterns/boundary-gate-replaces-domain-recheck.md)
+- [Patch DTOs keep primitive types, not the VO](../../docs/backend/ddd-patterns/patch-dto-primitive-not-vo.md)

--- a/.claude/rules/go-library-gotchas.md
+++ b/.claude/rules/go-library-gotchas.md
@@ -111,6 +111,8 @@ This matters most in DataLoader batch functions, where an empty key slice is a n
 - [Bool flag vs two-function split: ubiquitous language signals (`authorizeCardgroup*`)](../../docs/backend/library-gotchas/bool-flag-vs-two-function-ubiquitous-language.md)
 - [Direct unit tests for shared helpers + directionality assertion](../../docs/backend/library-gotchas/direct-unit-test-for-shared-helper.md)
 - [Dead context-done branch in pass-through helper — collapse to single return](../../docs/backend/library-gotchas/dead-context-check-in-pass-through-helper.md)
+- [GORM v1 round-trips underlying-string newtypes without Scanner/Valuer; reserving the `Value` accessor slot](../../docs/backend/library-gotchas/gorm-newtype-string-no-scanner-valuer.md)
+- [Defensive-copy tests assert pointer identity (`require.NotSame`), not variable rebind](../../docs/backend/library-gotchas/defensive-copy-test-pointer-identity.md)
 
 ## DDD patterns (on-demand)
 

--- a/backend/cmd/server/main_test.go
+++ b/backend/cmd/server/main_test.go
@@ -2032,7 +2032,7 @@ type panicRoleRepo struct{}
 func (panicRoleRepo) FindByID(_ context.Context, _ string) (*domain.Role, error) {
 	panic("not used in this test")
 }
-func (panicRoleRepo) FindByName(_ context.Context, _ string) (*domain.Role, error) {
+func (panicRoleRepo) FindByName(_ context.Context, _ domain.RoleName) (*domain.Role, error) {
 	panic("not used in this test")
 }
 func (panicRoleRepo) FindByIDs(_ context.Context, _ []string) (map[string]*domain.Role, error) {
@@ -2087,7 +2087,7 @@ type findByNameRepo struct {
 	err  error
 }
 
-func (f findByNameRepo) FindByName(_ context.Context, _ string) (*domain.Role, error) {
+func (f findByNameRepo) FindByName(_ context.Context, _ domain.RoleName) (*domain.Role, error) {
 	return f.role, f.err
 }
 
@@ -2268,7 +2268,7 @@ func TestBootstrapSuperUserPromoter_WarnOnCountError(t *testing.T) {
 // need to verify promoter construction, not per-request role checks.
 type userRoleStub struct{}
 
-func (userRoleStub) HasRole(_ context.Context, _, _ string) (bool, error) {
+func (userRoleStub) HasRole(_ context.Context, _ string, _ domain.RoleName) (bool, error) {
 	return false, nil
 }
 

--- a/backend/graph/resolver/admin_user_resolver_test.go
+++ b/backend/graph/resolver/admin_user_resolver_test.go
@@ -162,12 +162,11 @@ func TestAdminUserResolver_Users_NonAdmin(t *testing.T) {
 func TestAdminUserResolver_Users_AdminHappyPath(t *testing.T) {
 	t.Parallel()
 
-	dn1, dn2 := "Alice", "Bob"
 	mock := &mockAdminUserUsecase{
 		listResult: &usecase.AdminUserConnection{
 			Edges: []usecase.AdminUserEdge{
-				{Cursor: "u1", Node: &domain.User{ID: "u1", DisplayName: &dn1}},
-				{Cursor: "u2", Node: &domain.User{ID: "u2", DisplayName: &dn2}},
+				{Cursor: "u1", Node: &domain.User{ID: "u1", DisplayName: dnPtr("Alice")}},
+				{Cursor: "u2", Node: &domain.User{ID: "u2", DisplayName: dnPtr("Bob")}},
 			},
 			PageInfo:   usecase.PageInfo{HasNextPage: false, HasPreviousPage: false},
 			TotalCount: 2,
@@ -466,9 +465,8 @@ func TestAdminUserResolver_Roles_SelfIntrospection_Allowed(t *testing.T) {
 
 	// Wire UserUsecase so me { ... } can resolve. The AdminUserUsecase is
 	// unused by this query; pass the mock to satisfy the resolver wiring.
-	displayName := "Alice"
 	userMock := &mockUserRepository{
-		findResult: &domain.User{ID: "u-self", DisplayName: &displayName},
+		findResult: &domain.User{ID: "u-self", DisplayName: dnPtr("Alice")},
 	}
 	uc := usecase.NewUserUsecase(userMock, newDiscardLogger())
 	// isAdmin=false models a non-admin caller; the self-introspection branch
@@ -675,9 +673,8 @@ func TestAdminUserResolver_RevokeRole_XORInvariantViolation(t *testing.T) {
 func TestAdminUserResolver_AdminUser_HappyPath(t *testing.T) {
 	t.Parallel()
 
-	displayName := "Charlie"
 	mock := &mockAdminUserUsecase{
-		getResult: &domain.User{ID: "u-existing", DisplayName: &displayName},
+		getResult: &domain.User{ID: "u-existing", DisplayName: dnPtr("Charlie")},
 	}
 	srv := newAdminUserSrv(mock)
 	body := `{"query":"{ adminUser(id: \"u-existing\") { id displayName } }"}`
@@ -771,11 +768,13 @@ const adminUpdateUserForbiddenMutation = `{"query":"mutation { adminUpdateUser(i
 func TestAdminUserResolver_AdminUpdateUser_HappyPath(t *testing.T) {
 	t.Parallel()
 
-	newName := "Dana"
-	newBio := "A short bio."
 	mock := &mockAdminUserUsecase{
 		updateOutcome: usecase.AdminUpdateUserOutcome{
-			User: &domain.User{ID: "u-target", DisplayName: &newName, Bio: &newBio},
+			User: &domain.User{
+				ID:          "u-target",
+				DisplayName: dnPtr("Dana"),
+				Bio:         domain.BioFromPtr(ptr("A short bio.")),
+			},
 		},
 	}
 	srv := newAdminUserSrv(mock)

--- a/backend/graph/resolver/admin_user_resolver_test.go
+++ b/backend/graph/resolver/admin_user_resolver_test.go
@@ -324,8 +324,8 @@ const usersWithRolesQuery = `{"query":"{ users(first: 3) { edges { node { id rol
 func TestAdminUserResolver_Roles_ViaDataLoader(t *testing.T) {
 	t.Parallel()
 
-	adminRoleName := "admin"
-	generalRoleName := "general"
+	adminRoleName := domain.RoleName("admin")
+	generalRoleName := domain.RoleName("general")
 	adminRole := &domain.Role{ID: "role-admin", Name: adminRoleName}
 	generalRole := &domain.Role{ID: "role-general", Name: generalRoleName}
 

--- a/backend/graph/resolver/dictionary_resolver_test.go
+++ b/backend/graph/resolver/dictionary_resolver_test.go
@@ -12,6 +12,7 @@ import (
 	"backend/graph/generated"
 	"backend/graph/resolver"
 	"backend/internal/auth"
+	"backend/internal/domain"
 	"backend/internal/gqlerr"
 	"backend/internal/repository"
 	"backend/internal/usecase"
@@ -24,7 +25,7 @@ type mockUserRoleRepository struct {
 	err     error
 }
 
-func (m *mockUserRoleRepository) HasRole(_ context.Context, _, _ string) (bool, error) {
+func (m *mockUserRoleRepository) HasRole(_ context.Context, _ string, _ domain.RoleName) (bool, error) {
 	return m.isAdmin, m.err
 }
 

--- a/backend/graph/resolver/helpers.go
+++ b/backend/graph/resolver/helpers.go
@@ -208,7 +208,7 @@ func toRoleModel(r *domain.Role) *model.Role {
 	if r == nil {
 		return nil
 	}
-	return &model.Role{ID: r.ID, Name: r.Name}
+	return &model.Role{ID: r.ID, Name: string(r.Name)}
 }
 
 func toRoleModels(ctx context.Context, roles []*domain.Role) []*model.Role {

--- a/backend/graph/resolver/helpers.go
+++ b/backend/graph/resolver/helpers.go
@@ -23,10 +23,15 @@ func toUserModel(user *domain.User) *model.User {
 	// LastViewedCardgroup is intentionally left nil here. The
 	// userResolver.LastViewedCardgroup field resolver hydrates it lazily via
 	// UserPreferenceLoader + CardgroupLoader when the client selects the field.
+	//
+	// DisplayName is a *DisplayName (typed-string pointer) and converts back
+	// to the GraphQL *string via the same-underlying-type pointer cast.
+	// Bio is the trinary VO; Ptr() returns the defensive-copy *string the
+	// model field expects (nil → null on the wire).
 	return &model.User{
 		ID:          user.ID,
-		DisplayName: user.DisplayName,
-		Bio:         user.Bio,
+		DisplayName: (*string)(user.DisplayName),
+		Bio:         user.Bio.Ptr(),
 		AvatarURL:   user.AvatarURL,
 	}
 }

--- a/backend/graph/resolver/helpers.go
+++ b/backend/graph/resolver/helpers.go
@@ -54,8 +54,8 @@ func toCardModel(card *domain.Card) *model.Card {
 	}
 	return &model.Card{
 		ID:          card.ID,
-		Front:       card.Front,
-		Back:        card.Back,
+		Front:       string(card.Front),
+		Back:        string(card.Back),
 		CardgroupID: card.CardgroupID,
 		CreatedAt:   card.CreatedAt,
 		UpdatedAt:   card.UpdatedAt,

--- a/backend/graph/resolver/last_viewed_cardgroup_resolver_test.go
+++ b/backend/graph/resolver/last_viewed_cardgroup_resolver_test.go
@@ -211,7 +211,7 @@ func TestUserLastViewedCardgroup_NoPreferenceRowReturnsNull(t *testing.T) {
 
 	dn := "Alice"
 	userMock := &mockUserRepository{
-		findResult: &domain.User{ID: "u-1", DisplayName: &dn},
+		findResult: &domain.User{ID: "u-1", DisplayName: dnPtr(dn)},
 	}
 	srv := newMeServer(userMock)
 
@@ -247,7 +247,7 @@ func TestUserLastViewedCardgroup_NilCardgroupIDReturnsNull(t *testing.T) {
 
 	dn := "Alice"
 	userMock := &mockUserRepository{
-		findResult: &domain.User{ID: "u-1", DisplayName: &dn},
+		findResult: &domain.User{ID: "u-1", DisplayName: dnPtr(dn)},
 	}
 	srv := newMeServer(userMock)
 
@@ -284,7 +284,7 @@ func TestUserLastViewedCardgroup_PopulatedResolvesViaDataLoader(t *testing.T) {
 	cgID := "cg-1"
 	dn := "Alice"
 	userMock := &mockUserRepository{
-		findResult: &domain.User{ID: "u-1", DisplayName: &dn},
+		findResult: &domain.User{ID: "u-1", DisplayName: dnPtr(dn)},
 	}
 	srv := newMeServer(userMock)
 
@@ -327,7 +327,7 @@ func TestUserLastViewedCardgroup_DanglingIDResolvesNull(t *testing.T) {
 	cgID := "cg-deleted"
 	dn := "Alice"
 	userMock := &mockUserRepository{
-		findResult: &domain.User{ID: "u-1", DisplayName: &dn},
+		findResult: &domain.User{ID: "u-1", DisplayName: dnPtr(dn)},
 	}
 	srv := newMeServer(userMock)
 
@@ -360,7 +360,7 @@ func TestUserLastViewedCardgroup_LoadersNilReturnsInternal(t *testing.T) {
 
 	dn := "Alice"
 	userMock := &mockUserRepository{
-		findResult: &domain.User{ID: "u-1", DisplayName: &dn},
+		findResult: &domain.User{ID: "u-1", DisplayName: dnPtr(dn)},
 	}
 	srv := newMeServer(userMock)
 
@@ -380,7 +380,7 @@ func TestUserLastViewedCardgroup_ContextCancelledReturnsCancelled(t *testing.T) 
 
 	dn := "Alice"
 	userMock := &mockUserRepository{
-		findResult: &domain.User{ID: "u-1", DisplayName: &dn},
+		findResult: &domain.User{ID: "u-1", DisplayName: dnPtr(dn)},
 	}
 	srv := newMeServer(userMock)
 
@@ -422,7 +422,7 @@ func TestUserLastViewedCardgroup_GenericLoaderErrorReturnsInternal(t *testing.T)
 
 	dn := "Alice"
 	userMock := &mockUserRepository{
-		findResult: &domain.User{ID: "u-1", DisplayName: &dn},
+		findResult: &domain.User{ID: "u-1", DisplayName: dnPtr(dn)},
 	}
 	srv := newMeServer(userMock)
 

--- a/backend/graph/resolver/last_viewed_cardgroup_resolver_test.go
+++ b/backend/graph/resolver/last_viewed_cardgroup_resolver_test.go
@@ -209,9 +209,8 @@ func newMeServer(userMock *mockUserRepository) *handler.Server {
 func TestUserLastViewedCardgroup_NoPreferenceRowReturnsNull(t *testing.T) {
 	t.Parallel()
 
-	dn := "Alice"
 	userMock := &mockUserRepository{
-		findResult: &domain.User{ID: "u-1", DisplayName: dnPtr(dn)},
+		findResult: &domain.User{ID: "u-1", DisplayName: dnPtr("Alice")},
 	}
 	srv := newMeServer(userMock)
 
@@ -245,9 +244,8 @@ func TestUserLastViewedCardgroup_NoPreferenceRowReturnsNull(t *testing.T) {
 func TestUserLastViewedCardgroup_NilCardgroupIDReturnsNull(t *testing.T) {
 	t.Parallel()
 
-	dn := "Alice"
 	userMock := &mockUserRepository{
-		findResult: &domain.User{ID: "u-1", DisplayName: dnPtr(dn)},
+		findResult: &domain.User{ID: "u-1", DisplayName: dnPtr("Alice")},
 	}
 	srv := newMeServer(userMock)
 
@@ -282,9 +280,8 @@ func TestUserLastViewedCardgroup_PopulatedResolvesViaDataLoader(t *testing.T) {
 	t.Parallel()
 
 	cgID := "cg-1"
-	dn := "Alice"
 	userMock := &mockUserRepository{
-		findResult: &domain.User{ID: "u-1", DisplayName: dnPtr(dn)},
+		findResult: &domain.User{ID: "u-1", DisplayName: dnPtr("Alice")},
 	}
 	srv := newMeServer(userMock)
 
@@ -325,9 +322,8 @@ func TestUserLastViewedCardgroup_DanglingIDResolvesNull(t *testing.T) {
 	t.Parallel()
 
 	cgID := "cg-deleted"
-	dn := "Alice"
 	userMock := &mockUserRepository{
-		findResult: &domain.User{ID: "u-1", DisplayName: dnPtr(dn)},
+		findResult: &domain.User{ID: "u-1", DisplayName: dnPtr("Alice")},
 	}
 	srv := newMeServer(userMock)
 
@@ -358,9 +354,8 @@ func TestUserLastViewedCardgroup_DanglingIDResolvesNull(t *testing.T) {
 func TestUserLastViewedCardgroup_LoadersNilReturnsInternal(t *testing.T) {
 	t.Parallel()
 
-	dn := "Alice"
 	userMock := &mockUserRepository{
-		findResult: &domain.User{ID: "u-1", DisplayName: dnPtr(dn)},
+		findResult: &domain.User{ID: "u-1", DisplayName: dnPtr("Alice")},
 	}
 	srv := newMeServer(userMock)
 
@@ -378,9 +373,8 @@ func TestUserLastViewedCardgroup_LoadersNilReturnsInternal(t *testing.T) {
 func TestUserLastViewedCardgroup_ContextCancelledReturnsCancelled(t *testing.T) {
 	t.Parallel()
 
-	dn := "Alice"
 	userMock := &mockUserRepository{
-		findResult: &domain.User{ID: "u-1", DisplayName: dnPtr(dn)},
+		findResult: &domain.User{ID: "u-1", DisplayName: dnPtr("Alice")},
 	}
 	srv := newMeServer(userMock)
 
@@ -420,9 +414,8 @@ func TestUserLastViewedCardgroup_ContextCancelledReturnsCancelled(t *testing.T) 
 func TestUserLastViewedCardgroup_GenericLoaderErrorReturnsInternal(t *testing.T) {
 	t.Parallel()
 
-	dn := "Alice"
 	userMock := &mockUserRepository{
-		findResult: &domain.User{ID: "u-1", DisplayName: dnPtr(dn)},
+		findResult: &domain.User{ID: "u-1", DisplayName: dnPtr("Alice")},
 	}
 	srv := newMeServer(userMock)
 

--- a/backend/graph/resolver/user_test.go
+++ b/backend/graph/resolver/user_test.go
@@ -40,9 +40,9 @@ func (m *mockUserRepository) Update(_ context.Context, _ string, patch repositor
 // ptr returns a pointer to s.
 func ptr(s string) *string { return &s }
 
-// dnPtr returns a *domain.DisplayName for the supplied string. Used to build
-// User fixtures after the field type changed from *string to *DisplayName in
-// Phase 3.
+// dnPtr returns a *domain.DisplayName for the supplied string. Used by User
+// fixture builders because Go does not allow taking the address of a conversion
+// expression like &domain.DisplayName(s).
 func dnPtr(s string) *domain.DisplayName {
 	d := domain.DisplayName(s)
 	return &d

--- a/backend/graph/resolver/user_test.go
+++ b/backend/graph/resolver/user_test.go
@@ -40,6 +40,14 @@ func (m *mockUserRepository) Update(_ context.Context, _ string, patch repositor
 // ptr returns a pointer to s.
 func ptr(s string) *string { return &s }
 
+// dnPtr returns a *domain.DisplayName for the supplied string. Used to build
+// User fixtures after the field type changed from *string to *DisplayName in
+// Phase 3.
+func dnPtr(s string) *domain.DisplayName {
+	d := domain.DisplayName(s)
+	return &d
+}
+
 // newServer builds a gqlgen handler.Server backed by a resolver that uses the
 // given mock repository.
 func newServer(mock *mockUserRepository) *handler.Server {
@@ -90,9 +98,8 @@ const meQuery = `{"query":"{ me { id displayName bio avatarUrl } }"}`
 // user returns the expected User shape.
 func TestResolver_Me_Authenticated(t *testing.T) {
 	t.Parallel()
-	displayName := "Alice"
 	mock := &mockUserRepository{
-		findResult: &domain.User{ID: "u1", DisplayName: &displayName},
+		findResult: &domain.User{ID: "u1", DisplayName: dnPtr("Alice")},
 	}
 	srv := newServer(mock)
 	resp := gqlRequest(t, srv, authedCtx("u1"), meQuery)
@@ -160,7 +167,7 @@ func updateProfileMutation(displayName string, bio *string) string {
 func TestResolver_UpdateProfile_BioVariants(t *testing.T) {
 	t.Parallel()
 
-	returned := &domain.User{ID: "u1", DisplayName: ptr("Alice")}
+	returned := &domain.User{ID: "u1", DisplayName: dnPtr("Alice")}
 
 	cases := []struct {
 		name          string
@@ -232,7 +239,7 @@ func TestResolver_UpdateProfile_BioVariants(t *testing.T) {
 func TestResolver_UpdateProfile_HappyPath(t *testing.T) {
 	t.Parallel()
 
-	returned := &domain.User{ID: "u1", DisplayName: ptr("Alice")}
+	returned := &domain.User{ID: "u1", DisplayName: dnPtr("Alice")}
 	mock := &mockUserRepository{updateResult: returned}
 	srv := newServer(mock)
 

--- a/backend/internal/auth/role_test.go
+++ b/backend/internal/auth/role_test.go
@@ -6,16 +6,17 @@ import (
 	"testing"
 
 	"backend/internal/auth"
+	"backend/internal/domain"
 )
 
 type stubUserRoles struct {
 	hasRole bool
 	err     error
 	gotUID  string
-	gotRole string
+	gotRole domain.RoleName
 }
 
-func (s *stubUserRoles) HasRole(_ context.Context, userID, roleName string) (bool, error) {
+func (s *stubUserRoles) HasRole(_ context.Context, userID string, roleName domain.RoleName) (bool, error) {
 	s.gotUID = userID
 	s.gotRole = roleName
 	return s.hasRole, s.err
@@ -51,7 +52,7 @@ func TestServiceIsAdmin(t *testing.T) {
 				if tc.stub.gotUID != "user-1" {
 					t.Errorf("uid passed through: got %q", tc.stub.gotUID)
 				}
-				if tc.stub.gotRole != "admin" {
+				if tc.stub.gotRole != domain.AdminRoleName {
 					t.Errorf("role passed through: got %q", tc.stub.gotRole)
 				}
 			}

--- a/backend/internal/domain/bio.go
+++ b/backend/internal/domain/bio.go
@@ -34,11 +34,11 @@ func ParseBio(s *string) (Bio, error) {
 	return Bio{value: &trimmed}, nil
 }
 
-// BioFromPtr lifts a database-shaped *string into the Bio trinary VO.
-// A nil pointer maps to Bio{} (IsSet=false, "no change"); a non-nil pointer —
-// including pointer-to-empty — maps to a set Bio whose Ptr() returns the
-// same string contents. Used by repository readers to bridge a nullable text
-// column into the typed domain field.
+// BioFromPtr maps a nullable text column to a Bio: nil → Bio{} (IsSet()=false,
+// NULL column); a non-nil pointer — including pointer-to-empty — maps to a set
+// Bio whose Ptr() returns a defensive copy with the same string value.
+// Used by repository readers to bridge a nullable text column into the typed
+// domain field.
 func BioFromPtr(p *string) Bio {
 	if p == nil {
 		return Bio{}

--- a/backend/internal/domain/bio.go
+++ b/backend/internal/domain/bio.go
@@ -1,6 +1,7 @@
 package domain
 
 import (
+	"database/sql/driver"
 	"strings"
 
 	"github.com/rivo/uniseg"
@@ -21,7 +22,7 @@ type Bio struct {
 // ParseBio validates and trims s, preserving the trinary contract:
 // nil means "no change"; a pointer to "" means "explicit clear"; a pointer to
 // a non-empty string means "set". Surrounding whitespace is trimmed;
-// whitespace-only inputs collapse to the explicit-clear case (Value() returns
+// whitespace-only inputs collapse to the explicit-clear case (Ptr() returns
 // a pointer to ""). Returns ErrBioTooLong if the trimmed value exceeds BioMax graphemes.
 func ParseBio(s *string) (Bio, error) {
 	if s == nil {
@@ -34,9 +35,24 @@ func ParseBio(s *string) (Bio, error) {
 	return Bio{value: &trimmed}, nil
 }
 
-// Value returns a copy of the persistence-ready pointer: nil for "no change",
-// pointer-to-"" for explicit clear, pointer-to-non-empty for set.
-func (b Bio) Value() *string {
+// BioFromPtr lifts a database-shaped *string into the Bio trinary VO.
+// A nil pointer maps to Bio{} (IsSet=false, "no change"); a non-nil pointer —
+// including pointer-to-empty — maps to a set Bio whose Ptr() returns the
+// same string contents. Used by repository readers to bridge a nullable text
+// column into the typed domain field.
+func BioFromPtr(p *string) Bio {
+	if p == nil {
+		return Bio{}
+	}
+	s := *p
+	return Bio{value: &s}
+}
+
+// Ptr returns a copy of the persistence-ready pointer: nil for "no change",
+// pointer-to-"" for explicit clear, pointer-to-non-empty for set. Use this
+// accessor for non-database call sites (usecase patches, GraphQL output).
+// The driver.Valuer Value method below is reserved for sql/driver consumers.
+func (b Bio) Ptr() *string {
 	if b.value == nil {
 		return nil
 	}
@@ -47,3 +63,35 @@ func (b Bio) Value() *string {
 // IsSet reports whether the caller supplied a value (including an explicit clear).
 // Returns false only when the Bio was constructed from a nil input.
 func (b Bio) IsSet() bool { return b.value != nil }
+
+// Scan implements sql.Scanner so GORM can read a Bio column directly.
+// Semantics mirror BioFromPtr — null source maps to Bio{} (IsSet=false,
+// "no change"); a text source maps to a set Bio (IsSet=true, including the
+// empty-string explicit-clear case).
+func (b *Bio) Scan(src any) error {
+	if src == nil {
+		*b = Bio{}
+		return nil
+	}
+	switch v := src.(type) {
+	case string:
+		s := v
+		*b = Bio{value: &s}
+	case []byte:
+		s := string(v)
+		*b = Bio{value: &s}
+	default:
+		return eris.Errorf("domain: bio: unsupported scan type %T", src)
+	}
+	return nil
+}
+
+// Value implements driver.Valuer so GORM writes the trinary back to a
+// nullable text column: Bio{value: nil} → SQL NULL; Bio{value: &s} → the
+// string s (including the empty-string explicit-clear case).
+func (b Bio) Value() (driver.Value, error) {
+	if b.value == nil {
+		return nil, nil
+	}
+	return *b.value, nil
+}

--- a/backend/internal/domain/bio.go
+++ b/backend/internal/domain/bio.go
@@ -1,7 +1,6 @@
 package domain
 
 import (
-	"database/sql/driver"
 	"strings"
 
 	"github.com/rivo/uniseg"
@@ -49,9 +48,7 @@ func BioFromPtr(p *string) Bio {
 }
 
 // Ptr returns a copy of the persistence-ready pointer: nil for "no change",
-// pointer-to-"" for explicit clear, pointer-to-non-empty for set. Use this
-// accessor for non-database call sites (usecase patches, GraphQL output).
-// The driver.Valuer Value method below is reserved for sql/driver consumers.
+// pointer-to-"" for explicit clear, pointer-to-non-empty for set.
 func (b Bio) Ptr() *string {
 	if b.value == nil {
 		return nil
@@ -61,37 +58,6 @@ func (b Bio) Ptr() *string {
 }
 
 // IsSet reports whether the caller supplied a value (including an explicit clear).
-// Returns false only when the Bio was constructed from a nil input.
+// Returns false when the Bio was constructed from a nil input or is the zero
+// value (Bio{}); returns true for explicit-clear and set cases.
 func (b Bio) IsSet() bool { return b.value != nil }
-
-// Scan implements sql.Scanner so GORM can read a Bio column directly.
-// Semantics mirror BioFromPtr — null source maps to Bio{} (IsSet=false,
-// "no change"); a text source maps to a set Bio (IsSet=true, including the
-// empty-string explicit-clear case).
-func (b *Bio) Scan(src any) error {
-	if src == nil {
-		*b = Bio{}
-		return nil
-	}
-	switch v := src.(type) {
-	case string:
-		s := v
-		*b = Bio{value: &s}
-	case []byte:
-		s := string(v)
-		*b = Bio{value: &s}
-	default:
-		return eris.Errorf("domain: bio: unsupported scan type %T", src)
-	}
-	return nil
-}
-
-// Value implements driver.Valuer so GORM writes the trinary back to a
-// nullable text column: Bio{value: nil} → SQL NULL; Bio{value: &s} → the
-// string s (including the empty-string explicit-clear case).
-func (b Bio) Value() (driver.Value, error) {
-	if b.value == nil {
-		return nil, nil
-	}
-	return *b.value, nil
-}

--- a/backend/internal/domain/bio.go
+++ b/backend/internal/domain/bio.go
@@ -47,8 +47,13 @@ func BioFromPtr(p *string) Bio {
 	return Bio{value: &s}
 }
 
-// Ptr returns a copy of the persistence-ready pointer: nil for "no change",
-// pointer-to-"" for explicit clear, pointer-to-non-empty for set.
+// Ptr returns a fresh copy of the internal pointer:
+//   - nil — the Bio holds no value (constructed via ParseBio(nil) or BioFromPtr(nil));
+//   - non-nil pointer to empty string — the Bio holds an empty value;
+//   - non-nil pointer to non-empty string — the Bio holds a populated value.
+//
+// Patch-context callers map nil → "no change", &"" → "explicit clear", &"x" → "set".
+// Read-context callers map nil → NULL column, &"" → empty stored, &"x" → populated stored.
 func (b Bio) Ptr() *string {
 	if b.value == nil {
 		return nil
@@ -57,7 +62,8 @@ func (b Bio) Ptr() *string {
 	return &s
 }
 
-// IsSet reports whether the caller supplied a value (including an explicit clear).
-// Returns false when the Bio was constructed from a nil input or is the zero
-// value (Bio{}); returns true for explicit-clear and set cases.
+// IsSet reports whether the Bio carries a value (its internal pointer is non-nil).
+// Returns false for ParseBio(nil) (patch-context: no change) and for BioFromPtr(nil)
+// (read-context: NULL column / zero value Bio{}). Returns true for any other
+// construction, including an explicit empty string.
 func (b Bio) IsSet() bool { return b.value != nil }

--- a/backend/internal/domain/bio_test.go
+++ b/backend/internal/domain/bio_test.go
@@ -14,7 +14,7 @@ import (
 func TestBioFromPtr(t *testing.T) {
 	t.Parallel()
 
-	t.Run("nil pointer maps to no-change Bio", func(t *testing.T) {
+	t.Run("nil pointer maps to unset Bio", func(t *testing.T) {
 		t.Parallel()
 		b := BioFromPtr(nil)
 		require.False(t, b.IsSet())
@@ -30,7 +30,7 @@ func TestBioFromPtr(t *testing.T) {
 		require.Equal(t, "hello", *b.Ptr())
 	})
 
-	t.Run("pointer to empty string maps to explicit-clear Bio", func(t *testing.T) {
+	t.Run("pointer to empty string maps to set Bio holding empty string", func(t *testing.T) {
 		t.Parallel()
 		s := ""
 		b := BioFromPtr(&s)

--- a/backend/internal/domain/bio_test.go
+++ b/backend/internal/domain/bio_test.go
@@ -8,60 +8,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestBio_ScanValuerRoundTrip exercises sql.Scanner and driver.Valuer so a
-// nullable bio column round-trips through GORM with the trinary contract
-// intact: null DB → Bio{} (IsSet=false), text DB → set Bio (IsSet=true),
-// including the explicit-clear empty-string case.
-func TestBio_ScanValuerRoundTrip(t *testing.T) {
-	t.Parallel()
-
-	cases := []struct {
-		name      string
-		src       any
-		wantIsSet bool
-		wantPtr   *string
-	}{
-		{name: "nil source → no-change Bio", src: nil, wantIsSet: false, wantPtr: nil},
-		{name: "string source set", src: "hello", wantIsSet: true, wantPtr: strPtr("hello")},
-		{name: "empty string source → explicit clear", src: "", wantIsSet: true, wantPtr: strPtr("")},
-		{name: "[]byte source set", src: []byte("from bytes"), wantIsSet: true, wantPtr: strPtr("from bytes")},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			var b Bio
-			require.NoError(t, b.Scan(tc.src))
-			require.Equal(t, tc.wantIsSet, b.IsSet())
-			if tc.wantPtr == nil {
-				require.Nil(t, b.Ptr())
-			} else {
-				require.NotNil(t, b.Ptr())
-				require.Equal(t, *tc.wantPtr, *b.Ptr())
-			}
-
-			v, err := b.Value()
-			require.NoError(t, err)
-			if tc.wantPtr == nil {
-				require.Nil(t, v)
-			} else {
-				require.Equal(t, *tc.wantPtr, v)
-			}
-		})
-	}
-}
-
-// TestBio_ScanUnsupportedType verifies that an unexpected source type
-// surfaces as an eris-wrapped error rather than panicking.
-func TestBio_ScanUnsupportedType(t *testing.T) {
-	t.Parallel()
-
-	var b Bio
-	err := b.Scan(123)
-	require.Error(t, err)
-}
-
 // TestBioFromPtr verifies the helper that bridges a *string repository read
 // into the trinary VO. nil → Bio{} (IsSet=false); non-nil pointer copies the
 // underlying string and exposes it via Ptr() in defensive-copy fashion.
@@ -93,12 +39,12 @@ func TestBioFromPtr(t *testing.T) {
 		require.Equal(t, "", *b.Ptr())
 	})
 
-	t.Run("input pointer mutation does not affect VO", func(t *testing.T) {
+	t.Run("Ptr returns a fresh pointer, not the caller's", func(t *testing.T) {
 		t.Parallel()
 		s := "original"
 		b := BioFromPtr(&s)
-		s = "mutated"
-		require.Equal(t, "original", *b.Ptr())
+		p := b.Ptr()
+		require.NotSame(t, &s, p, "Ptr() must return a fresh pointer; mutating *Ptr() must not affect the caller's s")
 	})
 }
 

--- a/backend/internal/domain/bio_test.go
+++ b/backend/internal/domain/bio_test.go
@@ -8,6 +8,100 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestBio_ScanValuerRoundTrip exercises sql.Scanner and driver.Valuer so a
+// nullable bio column round-trips through GORM with the trinary contract
+// intact: null DB → Bio{} (IsSet=false), text DB → set Bio (IsSet=true),
+// including the explicit-clear empty-string case.
+func TestBio_ScanValuerRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		src       any
+		wantIsSet bool
+		wantPtr   *string
+	}{
+		{name: "nil source → no-change Bio", src: nil, wantIsSet: false, wantPtr: nil},
+		{name: "string source set", src: "hello", wantIsSet: true, wantPtr: strPtr("hello")},
+		{name: "empty string source → explicit clear", src: "", wantIsSet: true, wantPtr: strPtr("")},
+		{name: "[]byte source set", src: []byte("from bytes"), wantIsSet: true, wantPtr: strPtr("from bytes")},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var b Bio
+			require.NoError(t, b.Scan(tc.src))
+			require.Equal(t, tc.wantIsSet, b.IsSet())
+			if tc.wantPtr == nil {
+				require.Nil(t, b.Ptr())
+			} else {
+				require.NotNil(t, b.Ptr())
+				require.Equal(t, *tc.wantPtr, *b.Ptr())
+			}
+
+			v, err := b.Value()
+			require.NoError(t, err)
+			if tc.wantPtr == nil {
+				require.Nil(t, v)
+			} else {
+				require.Equal(t, *tc.wantPtr, v)
+			}
+		})
+	}
+}
+
+// TestBio_ScanUnsupportedType verifies that an unexpected source type
+// surfaces as an eris-wrapped error rather than panicking.
+func TestBio_ScanUnsupportedType(t *testing.T) {
+	t.Parallel()
+
+	var b Bio
+	err := b.Scan(123)
+	require.Error(t, err)
+}
+
+// TestBioFromPtr verifies the helper that bridges a *string repository read
+// into the trinary VO. nil → Bio{} (IsSet=false); non-nil pointer copies the
+// underlying string and exposes it via Ptr() in defensive-copy fashion.
+func TestBioFromPtr(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil pointer maps to no-change Bio", func(t *testing.T) {
+		t.Parallel()
+		b := BioFromPtr(nil)
+		require.False(t, b.IsSet())
+		require.Nil(t, b.Ptr())
+	})
+
+	t.Run("pointer to non-empty string maps to set Bio", func(t *testing.T) {
+		t.Parallel()
+		s := "hello"
+		b := BioFromPtr(&s)
+		require.True(t, b.IsSet())
+		require.NotNil(t, b.Ptr())
+		require.Equal(t, "hello", *b.Ptr())
+	})
+
+	t.Run("pointer to empty string maps to explicit-clear Bio", func(t *testing.T) {
+		t.Parallel()
+		s := ""
+		b := BioFromPtr(&s)
+		require.True(t, b.IsSet())
+		require.NotNil(t, b.Ptr())
+		require.Equal(t, "", *b.Ptr())
+	})
+
+	t.Run("input pointer mutation does not affect VO", func(t *testing.T) {
+		t.Parallel()
+		s := "original"
+		b := BioFromPtr(&s)
+		s = "mutated"
+		require.Equal(t, "original", *b.Ptr())
+	})
+}
+
 func TestParseBio(t *testing.T) {
 	t.Parallel()
 
@@ -81,10 +175,10 @@ func TestParseBio(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, tc.wantIsSet, got.IsSet())
 			if tc.wantValue == nil {
-				require.Nil(t, got.Value())
+				require.Nil(t, got.Ptr())
 			} else {
-				require.NotNil(t, got.Value())
-				require.Equal(t, *tc.wantValue, *got.Value())
+				require.NotNil(t, got.Ptr())
+				require.Equal(t, *tc.wantValue, *got.Ptr())
 			}
 		})
 	}

--- a/backend/internal/domain/bio_test.go
+++ b/backend/internal/domain/bio_test.go
@@ -39,12 +39,13 @@ func TestBioFromPtr(t *testing.T) {
 		require.Equal(t, "", *b.Ptr())
 	})
 
-	t.Run("Ptr returns a fresh pointer, not the caller's", func(t *testing.T) {
+	t.Run("Ptr returns a fresh pointer on each call", func(t *testing.T) {
 		t.Parallel()
 		s := "original"
 		b := BioFromPtr(&s)
-		p := b.Ptr()
-		require.NotSame(t, &s, p, "Ptr() must return a fresh pointer; mutating *Ptr() must not affect the caller's s")
+		p1, p2 := b.Ptr(), b.Ptr()
+		require.NotSame(t, p1, p2, "each Ptr() call must allocate a fresh pointer")
+		require.Equal(t, *p1, *p2, "but the values must be equal")
 	})
 }
 

--- a/backend/internal/domain/card.go
+++ b/backend/internal/domain/card.go
@@ -22,8 +22,8 @@ var (
 type Card struct {
 	ID          string
 	CardgroupID string
-	Front       string
-	Back        string
+	Front       CardText
+	Back        CardText
 	CreatedAt   time.Time
 	UpdatedAt   time.Time
 }
@@ -32,10 +32,10 @@ func (c *Card) Validate() error {
 	if strings.TrimSpace(c.CardgroupID) == "" {
 		return ErrCardCardgroupIDRequired
 	}
-	if _, err := ParseCardText(c.Front, ErrCardFrontRequired, ErrCardFrontTooLong); err != nil {
+	if _, err := ParseCardText(string(c.Front), ErrCardFrontRequired, ErrCardFrontTooLong); err != nil {
 		return err
 	}
-	if _, err := ParseCardText(c.Back, ErrCardBackRequired, ErrCardBackTooLong); err != nil {
+	if _, err := ParseCardText(string(c.Back), ErrCardBackRequired, ErrCardBackTooLong); err != nil {
 		return err
 	}
 	return nil

--- a/backend/internal/domain/card.go
+++ b/backend/internal/domain/card.go
@@ -1,7 +1,6 @@
 package domain
 
 import (
-	"strings"
 	"time"
 
 	"github.com/rotisserie/eris"
@@ -10,15 +9,18 @@ import (
 const CardTextMax = 500
 
 var (
-	ErrCardCardgroupIDRequired = eris.New("card: cardgroup id is required")
-	ErrCardFrontRequired       = eris.New("card: front is required")
-	ErrCardFrontTooLong        = eris.Errorf("card: front exceeds %d characters", CardTextMax)
-	ErrCardBackRequired        = eris.New("card: back is required")
-	ErrCardBackTooLong         = eris.Errorf("card: back exceeds %d characters", CardTextMax)
+	ErrCardFrontRequired = eris.New("card: front is required")
+	ErrCardFrontTooLong  = eris.Errorf("card: front exceeds %d characters", CardTextMax)
+	ErrCardBackRequired  = eris.New("card: back is required")
+	ErrCardBackTooLong   = eris.Errorf("card: back exceeds %d characters", CardTextMax)
 )
 
 // Card is an aggregate root. It references Cardgroup by ID only; GraphQL
 // resolves the cross-aggregate object through a DataLoader.
+//
+// CardgroupID ownership is enforced at the usecase boundary via
+// authorizeCardgroupOrBadInput before a Card is constructed; the domain
+// aggregate therefore does not re-check CardgroupID presence in Validate.
 type Card struct {
 	ID          string
 	CardgroupID string
@@ -29,9 +31,6 @@ type Card struct {
 }
 
 func (c *Card) Validate() error {
-	if strings.TrimSpace(c.CardgroupID) == "" {
-		return ErrCardCardgroupIDRequired
-	}
 	if _, err := ParseCardText(string(c.Front), ErrCardFrontRequired, ErrCardFrontTooLong); err != nil {
 		return err
 	}

--- a/backend/internal/domain/card_test.go
+++ b/backend/internal/domain/card_test.go
@@ -43,11 +43,6 @@ func TestCardValidate(t *testing.T) {
 		sentinelErr error
 	}{
 		{
-			name:        "cardgroup id required",
-			card:        Card{Front: "front", Back: "back"},
-			sentinelErr: ErrCardCardgroupIDRequired,
-		},
-		{
 			name:        "front required",
 			card:        Card{CardgroupID: "cg", Front: "", Back: "back"},
 			sentinelErr: ErrCardFrontRequired,

--- a/backend/internal/domain/card_test.go
+++ b/backend/internal/domain/card_test.go
@@ -18,8 +18,8 @@ func TestCardShape(t *testing.T) {
 	want := map[string]reflect.Type{
 		"ID":          reflect.TypeFor[string](),
 		"CardgroupID": reflect.TypeFor[string](),
-		"Front":       reflect.TypeFor[string](),
-		"Back":        reflect.TypeFor[string](),
+		"Front":       reflect.TypeFor[CardText](),
+		"Back":        reflect.TypeFor[CardText](),
 		"CreatedAt":   reflect.TypeFor[time.Time](),
 		"UpdatedAt":   reflect.TypeFor[time.Time](),
 	}
@@ -64,17 +64,17 @@ func TestCardValidate(t *testing.T) {
 		},
 		{
 			name:        "front too long",
-			card:        Card{CardgroupID: "cg", Front: strings.Repeat("a", 501), Back: "back"},
+			card:        Card{CardgroupID: "cg", Front: CardText(strings.Repeat("a", 501)), Back: "back"},
 			sentinelErr: ErrCardFrontTooLong,
 		},
 		{
 			name:        "back too long with graphemes",
-			card:        Card{CardgroupID: "cg", Front: "front", Back: strings.Repeat(zwjEmoji, 501)},
+			card:        Card{CardgroupID: "cg", Front: "front", Back: CardText(strings.Repeat(zwjEmoji, 501))},
 			sentinelErr: ErrCardBackTooLong,
 		},
 		{
 			name: "valid at max grapheme length",
-			card: Card{CardgroupID: "cg", Front: strings.Repeat(zwjEmoji, 500), Back: strings.Repeat("b", 500)},
+			card: Card{CardgroupID: "cg", Front: CardText(strings.Repeat(zwjEmoji, 500)), Back: CardText(strings.Repeat("b", 500))},
 		},
 	}
 

--- a/backend/internal/domain/card_text.go
+++ b/backend/internal/domain/card_text.go
@@ -1,9 +1,11 @@
 package domain
 
 import (
+	"database/sql/driver"
 	"strings"
 
 	"github.com/rivo/uniseg"
+	"github.com/rotisserie/eris"
 )
 
 // CardText is the trimmed, grapheme-bounded text used for both Card.Front and
@@ -14,6 +16,29 @@ type CardText string
 
 // String returns the underlying string value.
 func (c CardText) String() string { return string(c) }
+
+// Scan implements sql.Scanner so GORM can read a CardText column from the
+// database without calling ParseCardText. The DB is trusted on reads;
+// bound-checks are a write-side concern.
+func (c *CardText) Scan(src any) error {
+	if src == nil {
+		*c = ""
+		return nil
+	}
+	switch v := src.(type) {
+	case string:
+		*c = CardText(v)
+	case []byte:
+		*c = CardText(v)
+	default:
+		return eris.Errorf("domain: card text: unsupported scan type %T", src)
+	}
+	return nil
+}
+
+// Value implements driver.Valuer so GORM writes the underlying string to the
+// database column.
+func (c CardText) Value() (driver.Value, error) { return string(c), nil }
 
 // ParseCardText trims s, counts grapheme clusters, and returns a validated
 // CardText. It returns requiredErr when the trimmed input is empty and

--- a/backend/internal/domain/card_text.go
+++ b/backend/internal/domain/card_text.go
@@ -1,11 +1,9 @@
 package domain
 
 import (
-	"database/sql/driver"
 	"strings"
 
 	"github.com/rivo/uniseg"
-	"github.com/rotisserie/eris"
 )
 
 // CardText is the trimmed, grapheme-bounded text used for both Card.Front and
@@ -16,29 +14,6 @@ type CardText string
 
 // String returns the underlying string value.
 func (c CardText) String() string { return string(c) }
-
-// Scan implements sql.Scanner so GORM can read a CardText column from the
-// database without calling ParseCardText. The DB is trusted on reads;
-// bound-checks are a write-side concern.
-func (c *CardText) Scan(src any) error {
-	if src == nil {
-		*c = ""
-		return nil
-	}
-	switch v := src.(type) {
-	case string:
-		*c = CardText(v)
-	case []byte:
-		*c = CardText(v)
-	default:
-		return eris.Errorf("domain: card text: unsupported scan type %T", src)
-	}
-	return nil
-}
-
-// Value implements driver.Valuer so GORM writes the underlying string to the
-// database column.
-func (c CardText) Value() (driver.Value, error) { return string(c), nil }
 
 // ParseCardText trims s, counts grapheme clusters, and returns a validated
 // CardText. It returns requiredErr when the trimmed input is empty and

--- a/backend/internal/domain/display_name.go
+++ b/backend/internal/domain/display_name.go
@@ -1,6 +1,7 @@
 package domain
 
 import (
+	"database/sql/driver"
 	"strings"
 
 	"github.com/rivo/uniseg"
@@ -17,6 +18,34 @@ var (
 // DisplayName is the user-chosen profile display name, trimmed, 1..DisplayNameMax graphemes.
 // The zero value (DisplayName("")) is invalid; use ParseDisplayName to construct.
 type DisplayName string
+
+// String returns the underlying string value.
+func (d DisplayName) String() string { return string(d) }
+
+// Scan implements sql.Scanner so GORM can read a DisplayName column from the
+// database without calling ParseDisplayName. The DB is trusted on reads;
+// bound-checks are a write-side concern. For a nullable column the field is
+// typed *DisplayName at the row struct, so Scan is only invoked for the
+// non-nil case; nil source still maps to the empty string for safety.
+func (d *DisplayName) Scan(src any) error {
+	if src == nil {
+		*d = ""
+		return nil
+	}
+	switch v := src.(type) {
+	case string:
+		*d = DisplayName(v)
+	case []byte:
+		*d = DisplayName(v)
+	default:
+		return eris.Errorf("domain: display name: unsupported scan type %T", src)
+	}
+	return nil
+}
+
+// Value implements driver.Valuer so GORM writes the underlying string to the
+// database column.
+func (d DisplayName) Value() (driver.Value, error) { return string(d), nil }
 
 // ParseDisplayName trims surrounding whitespace from s, counts grapheme clusters,
 // and returns a validated DisplayName or a sentinel error.

--- a/backend/internal/domain/display_name.go
+++ b/backend/internal/domain/display_name.go
@@ -18,9 +18,6 @@ var (
 // The zero value (DisplayName("")) is invalid; use ParseDisplayName to construct.
 type DisplayName string
 
-// String returns the underlying string value.
-func (d DisplayName) String() string { return string(d) }
-
 // ParseDisplayName trims surrounding whitespace from s, counts grapheme clusters,
 // and returns a validated DisplayName or a sentinel error.
 func ParseDisplayName(s string) (DisplayName, error) {

--- a/backend/internal/domain/display_name.go
+++ b/backend/internal/domain/display_name.go
@@ -1,7 +1,6 @@
 package domain
 
 import (
-	"database/sql/driver"
 	"strings"
 
 	"github.com/rivo/uniseg"
@@ -21,31 +20,6 @@ type DisplayName string
 
 // String returns the underlying string value.
 func (d DisplayName) String() string { return string(d) }
-
-// Scan implements sql.Scanner so GORM can read a DisplayName column from the
-// database without calling ParseDisplayName. The DB is trusted on reads;
-// bound-checks are a write-side concern. For a nullable column the field is
-// typed *DisplayName at the row struct, so Scan is only invoked for the
-// non-nil case; nil source still maps to the empty string for safety.
-func (d *DisplayName) Scan(src any) error {
-	if src == nil {
-		*d = ""
-		return nil
-	}
-	switch v := src.(type) {
-	case string:
-		*d = DisplayName(v)
-	case []byte:
-		*d = DisplayName(v)
-	default:
-		return eris.Errorf("domain: display name: unsupported scan type %T", src)
-	}
-	return nil
-}
-
-// Value implements driver.Valuer so GORM writes the underlying string to the
-// database column.
-func (d DisplayName) Value() (driver.Value, error) { return string(d), nil }
 
 // ParseDisplayName trims surrounding whitespace from s, counts grapheme clusters,
 // and returns a validated DisplayName or a sentinel error.

--- a/backend/internal/domain/display_name_test.go
+++ b/backend/internal/domain/display_name_test.go
@@ -1,6 +1,7 @@
 package domain
 
 import (
+	"database/sql/driver"
 	"errors"
 	"strings"
 	"testing"
@@ -69,4 +70,48 @@ func TestParseDisplayName(t *testing.T) {
 			require.True(t, errors.Is(err, tc.sentinelErr), "got %v", err)
 		})
 	}
+}
+
+// TestDisplayName_ScanValueRoundTrip exercises the sql.Scanner and
+// driver.Valuer methods so a nullable display_name column round-trips through
+// GORM without losing fidelity. nil source maps to "" (the empty newtype
+// value); string and []byte sources both populate the field; Value emits the
+// underlying string.
+func TestDisplayName_ScanValueRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		src  any
+		want DisplayName
+	}{
+		{name: "nil source maps to empty newtype", src: nil, want: ""},
+		{name: "string source", src: "Alice", want: DisplayName("Alice")},
+		{name: "[]byte source", src: []byte("Bob"), want: DisplayName("Bob")},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var d DisplayName
+			require.NoError(t, d.Scan(tc.src))
+			require.Equal(t, tc.want, d)
+
+			v, err := d.Value()
+			require.NoError(t, err)
+			require.Equal(t, driver.Value(string(tc.want)), v)
+		})
+	}
+}
+
+// TestDisplayName_ScanUnsupportedType verifies that an unexpected source type
+// surfaces as an eris-wrapped error rather than panicking or silently
+// truncating.
+func TestDisplayName_ScanUnsupportedType(t *testing.T) {
+	t.Parallel()
+
+	var d DisplayName
+	err := d.Scan(123)
+	require.Error(t, err)
 }

--- a/backend/internal/domain/display_name_test.go
+++ b/backend/internal/domain/display_name_test.go
@@ -1,7 +1,6 @@
 package domain
 
 import (
-	"database/sql/driver"
 	"errors"
 	"strings"
 	"testing"
@@ -70,48 +69,4 @@ func TestParseDisplayName(t *testing.T) {
 			require.True(t, errors.Is(err, tc.sentinelErr), "got %v", err)
 		})
 	}
-}
-
-// TestDisplayName_ScanValueRoundTrip exercises the sql.Scanner and
-// driver.Valuer methods so a nullable display_name column round-trips through
-// GORM without losing fidelity. nil source maps to "" (the empty newtype
-// value); string and []byte sources both populate the field; Value emits the
-// underlying string.
-func TestDisplayName_ScanValueRoundTrip(t *testing.T) {
-	t.Parallel()
-
-	cases := []struct {
-		name string
-		src  any
-		want DisplayName
-	}{
-		{name: "nil source maps to empty newtype", src: nil, want: ""},
-		{name: "string source", src: "Alice", want: DisplayName("Alice")},
-		{name: "[]byte source", src: []byte("Bob"), want: DisplayName("Bob")},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			var d DisplayName
-			require.NoError(t, d.Scan(tc.src))
-			require.Equal(t, tc.want, d)
-
-			v, err := d.Value()
-			require.NoError(t, err)
-			require.Equal(t, driver.Value(string(tc.want)), v)
-		})
-	}
-}
-
-// TestDisplayName_ScanUnsupportedType verifies that an unexpected source type
-// surfaces as an eris-wrapped error rather than panicking or silently
-// truncating.
-func TestDisplayName_ScanUnsupportedType(t *testing.T) {
-	t.Parallel()
-
-	var d DisplayName
-	err := d.Scan(123)
-	require.Error(t, err)
 }

--- a/backend/internal/domain/role.go
+++ b/backend/internal/domain/role.go
@@ -4,17 +4,17 @@ package domain
 // model and is queried through the repository layer.
 type Role struct {
 	ID   string
-	Name string
+	Name RoleName
 }
 
 // AdminRoleName and GeneralRoleName are the two built-in system role names.
 const (
-	AdminRoleName   = "admin"
-	GeneralRoleName = "general"
+	AdminRoleName   RoleName = "admin"
+	GeneralRoleName RoleName = "general"
 )
 
 // systemRoleNames is the set of role names that are owned by the system.
-var systemRoleNames = map[string]struct{}{
+var systemRoleNames = map[RoleName]struct{}{
 	AdminRoleName:   {},
 	GeneralRoleName: {},
 }

--- a/backend/internal/domain/role_test.go
+++ b/backend/internal/domain/role_test.go
@@ -13,7 +13,7 @@ func TestRoleShape(t *testing.T) {
 	roleType := reflect.TypeFor[Role]()
 	want := map[string]reflect.Type{
 		"ID":   reflect.TypeFor[string](),
-		"Name": reflect.TypeFor[string](),
+		"Name": reflect.TypeFor[RoleName](),
 	}
 
 	for name, typ := range want {

--- a/backend/internal/domain/user.go
+++ b/backend/internal/domain/user.go
@@ -5,9 +5,10 @@ import "time"
 // User is the application-owned row keyed by auth.users.id.
 //
 // DisplayName is *DisplayName so a NULL column round-trips as a nil pointer
-// (no display name set). Bio is the trinary VO Bio (by value): the zero value
-// Bio{} encodes "no change" / NULL via IsSet()=false, while a set Bio encodes
-// either an explicit clear (empty string) or a non-empty value.
+// (no display name set). Bio is the trinary VO Bio (by value). The zero value
+// Bio{} represents a NULL bio column (IsSet()=false); a set Bio carries either
+// an explicit empty-string value or non-empty text. The trinary's "no change"
+// meaning applies in the UpdateProfileInput patch context, not here.
 type User struct {
 	ID          string
 	DisplayName *DisplayName

--- a/backend/internal/domain/user.go
+++ b/backend/internal/domain/user.go
@@ -3,10 +3,15 @@ package domain
 import "time"
 
 // User is the application-owned row keyed by auth.users.id.
+//
+// DisplayName is *DisplayName so a NULL column round-trips as a nil pointer
+// (no display name set). Bio is the trinary VO Bio (by value): the zero value
+// Bio{} encodes "no change" / NULL via IsSet()=false, while a set Bio encodes
+// either an explicit clear (empty string) or a non-empty value.
 type User struct {
 	ID          string
-	DisplayName *string
-	Bio         *string
+	DisplayName *DisplayName
+	Bio         Bio
 	AvatarURL   *string
 	CreatedAt   time.Time
 	UpdatedAt   time.Time

--- a/backend/internal/domain/user_test.go
+++ b/backend/internal/domain/user_test.go
@@ -12,8 +12,8 @@ func TestUserShape(t *testing.T) {
 	userType := reflect.TypeOf(User{})
 	want := map[string]reflect.Type{
 		"ID":          reflect.TypeOf(""),
-		"DisplayName": reflect.TypeOf((*string)(nil)),
-		"Bio":         reflect.TypeOf((*string)(nil)),
+		"DisplayName": reflect.TypeOf((*DisplayName)(nil)),
+		"Bio":         reflect.TypeOf(Bio{}),
 		"AvatarURL":   reflect.TypeOf((*string)(nil)),
 		"CreatedAt":   reflect.TypeOf(time.Time{}),
 		"UpdatedAt":   reflect.TypeOf(time.Time{}),

--- a/backend/internal/loader/role_by_user_test.go
+++ b/backend/internal/loader/role_by_user_test.go
@@ -24,7 +24,7 @@ func (s *roleBatchRepoStub) FindByID(_ context.Context, _ string) (*domain.Role,
 	panic("roleBatchRepoStub.FindByID not configured")
 }
 
-func (s *roleBatchRepoStub) FindByName(_ context.Context, _ string) (*domain.Role, error) {
+func (s *roleBatchRepoStub) FindByName(_ context.Context, _ domain.RoleName) (*domain.Role, error) {
 	panic("roleBatchRepoStub.FindByName not configured")
 }
 
@@ -143,7 +143,7 @@ func TestRoleByUserIDLoader_BatchesNCallsIntoOne(t *testing.T) {
 			mu.Unlock()
 			out := make(map[string][]*domain.Role, len(userIDs))
 			for _, id := range userIDs {
-				out[id] = []*domain.Role{{ID: "role-for-" + id, Name: "n-" + id}}
+				out[id] = []*domain.Role{{ID: "role-for-" + id, Name: domain.RoleName("n-" + id)}}
 			}
 			return out, nil
 		},
@@ -214,7 +214,7 @@ func TestRoleByUserIDLoader_MixOfKnownAndUnknownUsers(t *testing.T) {
 				if id == "ghost" {
 					continue
 				}
-				out[id] = []*domain.Role{{ID: "r-" + id, Name: "name-" + id}}
+				out[id] = []*domain.Role{{ID: "r-" + id, Name: domain.RoleName("name-" + id)}}
 			}
 			return out, nil
 		},

--- a/backend/internal/loader/user_test.go
+++ b/backend/internal/loader/user_test.go
@@ -27,7 +27,7 @@ type countingRepo struct {
 }
 
 type countingRoleRepo struct {
-	findByName func(ctx context.Context, name string) (*domain.Role, error)
+	findByName func(ctx context.Context, name domain.RoleName) (*domain.Role, error)
 	findByIDs  func(ctx context.Context, ids []string) (map[string]*domain.Role, error)
 }
 
@@ -35,7 +35,7 @@ func (r *countingRoleRepo) FindByID(_ context.Context, _ string) (*domain.Role, 
 	panic("countingRoleRepo.FindByID not configured")
 }
 
-func (r *countingRoleRepo) FindByName(ctx context.Context, name string) (*domain.Role, error) {
+func (r *countingRoleRepo) FindByName(ctx context.Context, name domain.RoleName) (*domain.Role, error) {
 	if r.findByName == nil {
 		panic("countingRoleRepo.FindByName not configured")
 	}
@@ -418,7 +418,7 @@ func TestRoleLoader_BatchesNCallsIntoOne(t *testing.T) {
 			batchCalls.Add(1)
 			out := make(map[string]*domain.Role, len(ids))
 			for _, id := range ids {
-				out[id] = &domain.Role{ID: id, Name: "role-" + id}
+				out[id] = &domain.Role{ID: id, Name: domain.RoleName("role-" + id)}
 			}
 			return out, nil
 		},

--- a/backend/internal/repository/card.go
+++ b/backend/internal/repository/card.go
@@ -579,8 +579,8 @@ func cardToRow(card *domain.Card) *gormCard {
 	return &gormCard{
 		ID:          card.ID,
 		CardgroupID: card.CardgroupID,
-		Front:       card.Front,
-		Back:        card.Back,
+		Front:       string(card.Front),
+		Back:        string(card.Back),
 		CreatedAt:   card.CreatedAt,
 		UpdatedAt:   card.UpdatedAt,
 	}
@@ -590,8 +590,8 @@ func cardToDomain(row gormCard) *domain.Card {
 	return &domain.Card{
 		ID:          row.ID,
 		CardgroupID: row.CardgroupID,
-		Front:       row.Front,
-		Back:        row.Back,
+		Front:       domain.CardText(row.Front),
+		Back:        domain.CardText(row.Back),
 		CreatedAt:   row.CreatedAt,
 		UpdatedAt:   row.UpdatedAt,
 	}

--- a/backend/internal/repository/card_test.go
+++ b/backend/internal/repository/card_test.go
@@ -20,8 +20,8 @@ func newCard(cardgroupID, front, back string) *domain.Card {
 	return &domain.Card{
 		ID:          uuid.NewString(),
 		CardgroupID: cardgroupID,
-		Front:       front,
-		Back:        back,
+		Front:       domain.CardText(front),
+		Back:        domain.CardText(back),
 		CreatedAt:   now,
 		UpdatedAt:   now,
 	}
@@ -49,15 +49,15 @@ func TestCardRepository_CRUD(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, card.ID, got.ID)
 	require.Equal(t, cg.ID, got.CardgroupID)
-	require.Equal(t, "front", got.Front)
-	require.Equal(t, "back", got.Back)
+	require.Equal(t, domain.CardText("front"), got.Front)
+	require.Equal(t, domain.CardText("back"), got.Back)
 
 	time.Sleep(5 * time.Millisecond)
 	front := "updated front"
 	updated, err := repo.Update(ctx, card.ID, repository.CardUpdate{Front: &front})
 	require.NoError(t, err)
-	require.Equal(t, front, updated.Front)
-	require.Equal(t, "back", updated.Back)
+	require.Equal(t, domain.CardText(front), updated.Front)
+	require.Equal(t, domain.CardText("back"), updated.Back)
 	require.True(t, updated.UpdatedAt.After(got.UpdatedAt))
 
 	require.NoError(t, repo.Delete(ctx, card.ID))
@@ -312,7 +312,7 @@ func TestCardRepo_FindByCardgroupAndFront(t *testing.T) {
 		t.Errorf("FindByCardgroupAndFront (hit): ID = %q, want %q", got.ID, card.ID)
 	}
 	if got.Back != "find-back" {
-		t.Errorf("FindByCardgroupAndFront (hit): Back = %q, want %q", got.Back, "find-back")
+		t.Errorf("FindByCardgroupAndFront (hit): Back = %q, want %q", string(got.Back), "find-back")
 	}
 
 	// Miss: unknown front value must return ErrNotFound.

--- a/backend/internal/repository/card_upsert_test.go
+++ b/backend/internal/repository/card_upsert_test.go
@@ -152,13 +152,13 @@ func TestCardRepository_UpsertManyTx(t *testing.T) {
 		storedA, err := repo.FindByCardgroup(ctx, cgA.ID)
 		require.NoError(t, err)
 		require.Len(t, storedA, 1)
-		require.Equal(t, "hello", storedA[0].Front)
-		require.Equal(t, "back-A", storedA[0].Back)
+		require.Equal(t, domain.CardText("hello"), storedA[0].Front)
+		require.Equal(t, domain.CardText("back-A"), storedA[0].Back)
 
 		storedB, err := repo.FindByCardgroup(ctx, cgB.ID)
 		require.NoError(t, err)
 		require.Len(t, storedB, 1)
-		require.Equal(t, "hello", storedB[0].Front)
-		require.Equal(t, "back-B", storedB[0].Back)
+		require.Equal(t, domain.CardText("hello"), storedB[0].Front)
+		require.Equal(t, domain.CardText("back-B"), storedB[0].Back)
 	})
 }

--- a/backend/internal/repository/role.go
+++ b/backend/internal/repository/role.go
@@ -50,7 +50,7 @@ type RoleRepository interface {
 	// (which also satisfies ErrNotFound) when no matching row exists.
 	FindByID(ctx context.Context, id string) (*domain.Role, error)
 
-	FindByName(ctx context.Context, name string) (*domain.Role, error)
+	FindByName(ctx context.Context, name domain.RoleName) (*domain.Role, error)
 	FindByIDs(ctx context.Context, ids []string) (map[string]*domain.Role, error)
 
 	// Create inserts a new role with the given name. The name is normalised
@@ -121,7 +121,7 @@ func (r *roleRepo) FindByID(ctx context.Context, id string) (*domain.Role, error
 	return roleToDomain(row), nil
 }
 
-func (r *roleRepo) FindByName(ctx context.Context, name string) (*domain.Role, error) {
+func (r *roleRepo) FindByName(ctx context.Context, name domain.RoleName) (*domain.Role, error) {
 	var row gormRole
 	err := r.db.WithContext(ctx).Where("name = ?", name).Take(&row).Error
 	if err != nil {
@@ -347,7 +347,7 @@ func (r *roleRepo) ListByUserIDs(ctx context.Context, userIDs []string) (map[str
 	for i := range rows {
 		out[rows[i].UserID] = append(out[rows[i].UserID], &domain.Role{
 			ID:   rows[i].ID,
-			Name: rows[i].Name,
+			Name: domain.RoleName(rows[i].Name),
 		})
 	}
 	return out, nil
@@ -381,6 +381,6 @@ func (r *roleRepo) CountAdminUsers(ctx context.Context) (int64, error) {
 func roleToDomain(g gormRole) *domain.Role {
 	return &domain.Role{
 		ID:   g.ID,
-		Name: g.Name,
+		Name: domain.RoleName(g.Name),
 	}
 }

--- a/backend/internal/repository/role_assign_test.go
+++ b/backend/internal/repository/role_assign_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"backend/internal/domain"
 	"backend/internal/repository"
 )
 
@@ -304,7 +305,7 @@ func TestRoleRepository_ListByUser_OrderedByNameAsc(t *testing.T) {
 		t.Fatalf("ListByUser len = %d, want 3", len(roles))
 	}
 
-	want := []string{"admin", "general", "reviewer"}
+	want := []domain.RoleName{"admin", "general", "reviewer"}
 	for i, r := range roles {
 		if r.Name != want[i] {
 			t.Errorf("roles[%d].Name = %q, want %q", i, r.Name, want[i])

--- a/backend/internal/repository/role_crud_test.go
+++ b/backend/internal/repository/role_crud_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"backend/internal/domain"
 	"backend/internal/repository"
 )
 
@@ -78,7 +79,7 @@ func TestRoleRepository_Create_Success(t *testing.T) {
 	if role.ID == "" {
 		t.Error("Create returned role with empty ID")
 	}
-	if role.Name != name {
+	if role.Name != domain.RoleName(name) {
 		t.Errorf("Create.Name = %q, want %q", role.Name, name)
 	}
 
@@ -87,7 +88,7 @@ func TestRoleRepository_Create_Success(t *testing.T) {
 	if err != nil {
 		t.Fatalf("FindByID after Create: %v", err)
 	}
-	if fetched.Name != name {
+	if fetched.Name != domain.RoleName(name) {
 		t.Errorf("FindByID.Name = %q, want %q", fetched.Name, name)
 	}
 }
@@ -105,7 +106,7 @@ func TestRoleRepository_Create_NormalizesName(t *testing.T) {
 	}
 
 	want := strings.ToLower(strings.TrimSpace(raw))
-	if role.Name != want {
+	if role.Name != domain.RoleName(want) {
 		t.Errorf("Create.Name = %q, want %q (normalised)", role.Name, want)
 	}
 }
@@ -153,7 +154,7 @@ func TestRoleRepository_Update_Success(t *testing.T) {
 	if updated.ID != created.ID {
 		t.Errorf("Update.ID = %q, want %q", updated.ID, created.ID)
 	}
-	if updated.Name != newName {
+	if updated.Name != domain.RoleName(newName) {
 		t.Errorf("Update.Name = %q, want %q", updated.Name, newName)
 	}
 
@@ -162,7 +163,7 @@ func TestRoleRepository_Update_Success(t *testing.T) {
 	if err != nil {
 		t.Fatalf("FindByID after Update: %v", err)
 	}
-	if fetched.Name != newName {
+	if fetched.Name != domain.RoleName(newName) {
 		t.Errorf("FindByID.Name = %q after Update, want %q", fetched.Name, newName)
 	}
 }
@@ -185,7 +186,7 @@ func TestRoleRepository_Update_NormalizesName(t *testing.T) {
 	}
 
 	want := strings.ToLower(strings.TrimSpace(raw))
-	if updated.Name != want {
+	if updated.Name != domain.RoleName(want) {
 		t.Errorf("Update.Name = %q, want %q (normalised)", updated.Name, want)
 	}
 }

--- a/backend/internal/repository/user.go
+++ b/backend/internal/repository/user.go
@@ -275,10 +275,15 @@ func userCursorWhere(createdAtAsc, idAsc bool, cursor gormUser) (string, []any) 
 }
 
 func userToDomain(g gormUser) *domain.User {
+	// The gormUser DisplayName field is *string (DB column type); the domain
+	// DisplayName is a string newtype, so (*domain.DisplayName)(g.DisplayName)
+	// is a straight pointer cast across the same underlying type. Bio is the
+	// trinary VO; BioFromPtr maps a NULL column to Bio{} (IsSet=false) and a
+	// text column to a set Bio whose Ptr() returns the same string.
 	return &domain.User{
 		ID:          g.ID,
-		DisplayName: g.DisplayName,
-		Bio:         g.Bio,
+		DisplayName: (*domain.DisplayName)(g.DisplayName),
+		Bio:         domain.BioFromPtr(g.Bio),
 		AvatarURL:   g.AvatarURL,
 		CreatedAt:   g.CreatedAt,
 		UpdatedAt:   g.UpdatedAt,

--- a/backend/internal/repository/user.go
+++ b/backend/internal/repository/user.go
@@ -279,7 +279,7 @@ func userToDomain(g gormUser) *domain.User {
 	// DisplayName is a string newtype, so (*domain.DisplayName)(g.DisplayName)
 	// is a straight pointer cast across the same underlying type. Bio is the
 	// trinary VO; BioFromPtr maps a NULL column to Bio{} (IsSet=false) and a
-	// text column to a set Bio whose Ptr() returns the same string.
+	// text column to a set Bio whose Ptr() returns a defensive copy with the same string value.
 	return &domain.User{
 		ID:          g.ID,
 		DisplayName: (*domain.DisplayName)(g.DisplayName),

--- a/backend/internal/repository/user_pagination_test.go
+++ b/backend/internal/repository/user_pagination_test.go
@@ -246,7 +246,7 @@ func TestUserPagination_SearchSubstring(t *testing.T) {
 	gotNames := map[string]bool{}
 	for _, u := range got {
 		require.NotNil(t, u.DisplayName)
-		gotNames[*u.DisplayName] = true
+		gotNames[string(*u.DisplayName)] = true
 	}
 	for _, r := range rows {
 		full := r.body + tag
@@ -285,7 +285,7 @@ func TestUserPagination_SearchEscapesPercentLiteral(t *testing.T) {
 	require.Equal(t, int64(1), total)
 	require.Len(t, got, 1)
 	require.NotNil(t, got[0].DisplayName)
-	require.Equal(t, marker+"100%legit", *got[0].DisplayName)
+	require.Equal(t, marker+"100%legit", string(*got[0].DisplayName))
 }
 
 // TestUserPagination_SearchEscapesUnderscoreLiteral verifies that `_` in the
@@ -313,7 +313,7 @@ func TestUserPagination_SearchEscapesUnderscoreLiteral(t *testing.T) {
 	require.Equal(t, int64(1), total)
 	require.Len(t, got, 1)
 	require.NotNil(t, got[0].DisplayName)
-	require.Equal(t, marker+"a_min", *got[0].DisplayName)
+	require.Equal(t, marker+"a_min", string(*got[0].DisplayName))
 }
 
 // TestUserPagination_CursorNotFound verifies that a cursor pointing at a uuid

--- a/backend/internal/repository/user_role.go
+++ b/backend/internal/repository/user_role.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/rotisserie/eris"
 	"gorm.io/gorm"
+
+	"backend/internal/domain"
 )
 
 type gormUserRole struct {
@@ -19,7 +21,7 @@ type UserRoleRepository interface {
 	// HasRole reports whether userID holds the named role.
 	// Returns (false, nil) when the user has no rows or the role name does not exist.
 	// Only DB errors return a non-nil error. Role lookup is by name (case-sensitive).
-	HasRole(ctx context.Context, userID, roleName string) (bool, error)
+	HasRole(ctx context.Context, userID string, roleName domain.RoleName) (bool, error)
 }
 
 type userRoleRepo struct{ db *gorm.DB }
@@ -28,7 +30,7 @@ func NewUserRoleRepository(db *gorm.DB) UserRoleRepository {
 	return &userRoleRepo{db: db}
 }
 
-func (r *userRoleRepo) HasRole(ctx context.Context, userID, roleName string) (bool, error) {
+func (r *userRoleRepo) HasRole(ctx context.Context, userID string, roleName domain.RoleName) (bool, error) {
 	var count int64
 	err := r.db.WithContext(ctx).
 		Table("user_roles").

--- a/backend/internal/repository/user_test.go
+++ b/backend/internal/repository/user_test.go
@@ -160,8 +160,8 @@ func TestFindByID_Success(t *testing.T) {
 	if got.DisplayName != nil {
 		t.Fatalf("DisplayName: want nil, got %v", *got.DisplayName)
 	}
-	if got.Bio != nil {
-		t.Fatalf("Bio: want nil, got %v", *got.Bio)
+	if got.Bio.IsSet() {
+		t.Fatalf("Bio: want IsSet=false, got Ptr=%v", got.Bio.Ptr())
 	}
 	if got.AvatarURL != nil {
 		t.Fatalf("AvatarURL: want nil, got %v", *got.AvatarURL)
@@ -252,11 +252,11 @@ func TestUpdate_Success_DisplayNameOnly(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Update: %v", err)
 	}
-	if got.DisplayName == nil || *got.DisplayName != name {
+	if got.DisplayName == nil || string(*got.DisplayName) != name {
 		t.Fatalf("DisplayName: got %v, want %q", got.DisplayName, name)
 	}
-	if got.Bio != nil {
-		t.Fatalf("Bio should remain nil, got %v", *got.Bio)
+	if got.Bio.IsSet() {
+		t.Fatalf("Bio should remain IsSet=false, got Ptr=%v", got.Bio.Ptr())
 	}
 	if got.AvatarURL != nil {
 		t.Fatalf("AvatarURL should remain nil, got %v", *got.AvatarURL)
@@ -285,10 +285,10 @@ func TestUpdate_PartialBioOnly(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Update: %v", err)
 	}
-	if got.Bio == nil || *got.Bio != bio {
-		t.Fatalf("Bio: got %v, want %q", got.Bio, bio)
+	if !got.Bio.IsSet() || got.Bio.Ptr() == nil || *got.Bio.Ptr() != bio {
+		t.Fatalf("Bio: got Ptr=%v, want %q", got.Bio.Ptr(), bio)
 	}
-	if got.DisplayName == nil || *got.DisplayName != name {
+	if got.DisplayName == nil || string(*got.DisplayName) != name {
 		t.Fatalf("DisplayName should remain %q, got %v", name, got.DisplayName)
 	}
 }
@@ -325,7 +325,7 @@ func TestUpdate_EmptyStringClearsField(t *testing.T) {
 	if got.DisplayName == nil {
 		t.Fatalf("DisplayName should be non-nil empty string, got nil")
 	}
-	if *got.DisplayName != "" {
+	if string(*got.DisplayName) != "" {
 		t.Fatalf("DisplayName: got %q, want empty", *got.DisplayName)
 	}
 }

--- a/backend/internal/usecase/admin_role.go
+++ b/backend/internal/usecase/admin_role.go
@@ -196,7 +196,7 @@ func (u *adminRoleUsecase) Update(ctx context.Context, id, name string) (UpdateR
 	if existing.IsSystem() {
 		return UpdateRoleOutcome{SystemRoleConflict: &SystemRoleConflictInfo{
 			ID:   existing.ID,
-			Name: existing.Name,
+			Name: string(existing.Name),
 		}}, nil
 	}
 

--- a/backend/internal/usecase/admin_role_test.go
+++ b/backend/internal/usecase/admin_role_test.go
@@ -68,7 +68,7 @@ func (m *mockAdminRoleRepoForCRUD) Create(_ context.Context, name string) (*doma
 		return m.createResult, nil
 	}
 	// Echo the normalised name so callers see what reached the repo.
-	return &domain.Role{ID: "r-new", Name: name}, nil
+	return &domain.Role{ID: "r-new", Name: domain.RoleName(name)}, nil
 }
 
 func (m *mockAdminRoleRepoForCRUD) Update(_ context.Context, id, name string) (*domain.Role, error) {
@@ -81,7 +81,7 @@ func (m *mockAdminRoleRepoForCRUD) Update(_ context.Context, id, name string) (*
 	if m.updateResult != nil {
 		return m.updateResult, nil
 	}
-	return &domain.Role{ID: id, Name: name}, nil
+	return &domain.Role{ID: id, Name: domain.RoleName(name)}, nil
 }
 
 func (m *mockAdminRoleRepoForCRUD) Delete(_ context.Context, id string) error {
@@ -461,7 +461,7 @@ func TestAdminRole_Create_NormalizesBeforeUniqueCheck(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			roles := &mockAdminRoleRepoForCRUD{
-				createResult: &domain.Role{ID: "r-new", Name: tc.wantRepo},
+				createResult: &domain.Role{ID: "r-new", Name: domain.RoleName(tc.wantRepo)},
 			}
 			authChk := &adminAuthChecker{admins: map[string]bool{"admin-1": true}}
 			uc, _ := buildAdminRoleUC(roles, authChk)
@@ -471,7 +471,7 @@ func TestAdminRole_Create_NormalizesBeforeUniqueCheck(t *testing.T) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 			assertCreateRoleOutcomeXOR(t, outcome)
-			if outcome.Role == nil || outcome.Role.Name != tc.wantRepo {
+			if outcome.Role == nil || outcome.Role.Name != domain.RoleName(tc.wantRepo) {
 				t.Fatalf("outcome.Role = %+v, want role with name=%s", outcome.Role, tc.wantRepo)
 			}
 			if roles.lastCreateName != tc.wantRepo {
@@ -573,7 +573,7 @@ func TestAdminRole_Update_RenameSystemRoleConflict(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			roles := &mockAdminRoleRepoForCRUD{
-				findResult: &domain.Role{ID: "r-x", Name: tc.roleName},
+				findResult: &domain.Role{ID: "r-x", Name: domain.RoleName(tc.roleName)},
 			}
 			authChk := &adminAuthChecker{admins: map[string]bool{"admin-1": true}}
 			uc, _ := buildAdminRoleUC(roles, authChk)
@@ -772,7 +772,7 @@ func TestAdminRole_Delete_SystemRoleForbidden(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			roles := &mockAdminRoleRepoForCRUD{
-				findResult: &domain.Role{ID: "r-x", Name: tc.roleName},
+				findResult: &domain.Role{ID: "r-x", Name: domain.RoleName(tc.roleName)},
 			}
 			authChk := &adminAuthChecker{admins: map[string]bool{"admin-1": true}}
 			uc, _ := buildAdminRoleUC(roles, authChk)

--- a/backend/internal/usecase/admin_user.go
+++ b/backend/internal/usecase/admin_user.go
@@ -315,7 +315,7 @@ func (u *adminUserUsecase) Update(ctx context.Context, id string, input AdminUpd
 			}
 			return AdminUpdateUserOutcome{Validation: info}, nil
 		}
-		patch.Bio = bio.Value()
+		patch.Bio = bio.Ptr()
 	}
 
 	user, err := u.users.Update(ctx, id, patch)

--- a/backend/internal/usecase/admin_user_test.go
+++ b/backend/internal/usecase/admin_user_test.go
@@ -615,7 +615,7 @@ func TestAdminUser_Get_Missing(t *testing.T) {
 func TestAdminUser_Update_DisplayName(t *testing.T) {
 	t.Parallel()
 
-	updated := &domain.User{ID: "u-target", DisplayName: ptr("Bob")}
+	updated := &domain.User{ID: "u-target", DisplayName: dnPtr("Bob")}
 	users := &mockAdminUserRepository{updateResult: updated}
 	authChk := &adminAuthChecker{admins: map[string]bool{"admin-1": true}}
 	uc, _, _ := buildAdminUC(users, nil, authChk)
@@ -728,7 +728,7 @@ func TestAdminUser_Update_Validation_DisplayNameOverMax(t *testing.T) {
 func TestAdminUser_AssignRole_Idempotent(t *testing.T) {
 	t.Parallel()
 
-	target := &domain.User{ID: "u-target", DisplayName: ptr("Carol")}
+	target := &domain.User{ID: "u-target", DisplayName: dnPtr("Carol")}
 	users := &mockAdminUserRepository{users: map[string]*domain.User{"u-target": target}}
 	roles := &mockAdminRoleRepository{}
 	authChk := &adminAuthChecker{admins: map[string]bool{"admin-1": true}}

--- a/backend/internal/usecase/card.go
+++ b/backend/internal/usecase/card.go
@@ -239,18 +239,17 @@ func (u *CardUsecase) Create(ctx context.Context, in CreateCardInput) (CreateCar
 		return CreateCardOutcome{}, eris.Wrap(err, "usecase: create card: generate id")
 	}
 
-	front := frontVO.String()
 	card := &domain.Card{
 		ID:          id,
 		CardgroupID: in.CardgroupID,
-		Front:       front,
-		Back:        backVO.String(),
+		Front:       frontVO,
+		Back:        backVO,
 		CreatedAt:   now,
 		UpdatedAt:   now,
 	}
 	if err := u.cardRepo.Create(ctx, card); err != nil {
 		if errors.Is(err, repository.ErrCardDuplicateFront) {
-			existing, lookupErr := u.cardRepo.FindByCardgroupAndFront(ctx, in.CardgroupID, front)
+			existing, lookupErr := u.cardRepo.FindByCardgroupAndFront(ctx, in.CardgroupID, string(card.Front))
 			if lookupErr != nil {
 				// The lookup may race with a concurrent delete (the duplicate row vanished
 				// between the failed INSERT and this SELECT) or fail for an unrelated DB
@@ -260,13 +259,13 @@ func (u *CardUsecase) Create(ctx context.Context, in CreateCardInput) (CreateCar
 			}
 			return CreateCardOutcome{Duplicate: &DuplicateCardInfo{
 				ExistingID:   existing.ID,
-				ExistingBack: existing.Back,
+				ExistingBack: string(existing.Back),
 			}}, nil
 		}
 		return CreateCardOutcome{}, eris.Wrap(err, "usecase: create card: repo create")
 	}
 	if u.notionWriter != nil && u.notionPageID != "" {
-		text := card.Front + " " + card.Back
+		text := string(card.Front) + " " + string(card.Back)
 		cardID := card.ID
 		pageID := u.notionPageID
 		cardgroupID := card.CardgroupID

--- a/backend/internal/usecase/card.go
+++ b/backend/internal/usecase/card.go
@@ -551,8 +551,6 @@ func (u *CardUsecase) resolveCursor(
 
 func translateCardErr(err error) error {
 	switch {
-	case errors.Is(err, domain.ErrCardCardgroupIDRequired):
-		return ucerr.NewValidationError("cardgroupId", "cardgroupId is required")
 	case errors.Is(err, domain.ErrCardFrontRequired):
 		return ucerr.NewValidationError("front", "front is required")
 	case errors.Is(err, domain.ErrCardFrontTooLong):

--- a/backend/internal/usecase/card_test.go
+++ b/backend/internal/usecase/card_test.go
@@ -256,7 +256,7 @@ func TestCardUsecase_Create(t *testing.T) {
 			if cardRepo.capturedCreate == nil {
 				t.Fatal("expected repo.Create call")
 			}
-			if got.Card.Front != "front" || got.Card.Back != "back" {
+			if got.Card.Front != domain.CardText("front") || got.Card.Back != domain.CardText("back") {
 				t.Fatalf("expected trimmed text, got front=%q back=%q", got.Card.Front, got.Card.Back)
 			}
 		})
@@ -299,8 +299,8 @@ func TestCardUsecase_Update_NonOwnerAndPatch(t *testing.T) {
 	existing := &domain.Card{
 		ID:          "card1",
 		CardgroupID: "cg1",
-		Front:       "old front",
-		Back:        "old back",
+		Front:       domain.CardText("old front"),
+		Back:        domain.CardText("old back"),
 	}
 
 	t.Run("non owner", func(t *testing.T) {
@@ -318,7 +318,7 @@ func TestCardUsecase_Update_NonOwnerAndPatch(t *testing.T) {
 		newFront := "new front"
 		cardRepo := &mockCardRepository{
 			findResult:   existing,
-			updateResult: &domain.Card{ID: "card1", CardgroupID: "cg1", Front: newFront, Back: "old back"},
+			updateResult: &domain.Card{ID: "card1", CardgroupID: "cg1", Front: domain.CardText(newFront), Back: "old back"},
 		}
 		uc := NewCardUsecase(nil, cardRepo,
 			&mockCardgroupRepoForCard{findResult: &domain.Cardgroup{ID: "cg1", OwnerID: "u1"}},
@@ -331,7 +331,7 @@ func TestCardUsecase_Update_NonOwnerAndPatch(t *testing.T) {
 		if outcome.Card == nil {
 			t.Fatal("expected non-nil Card on success")
 		}
-		if outcome.Card.Front != newFront {
+		if outcome.Card.Front != domain.CardText(newFront) {
 			t.Fatalf("front = %q, want %q", outcome.Card.Front, newFront)
 		}
 		if outcome.Validation != nil {
@@ -352,8 +352,8 @@ func TestCardUsecase_Update_EmptyFront_ValidationVariant(t *testing.T) {
 	existing := &domain.Card{
 		ID:          "card1",
 		CardgroupID: "cg1",
-		Front:       "old front",
-		Back:        "old back",
+		Front:       domain.CardText("old front"),
+		Back:        domain.CardText("old back"),
 	}
 	cardRepo := &mockCardRepository{findResult: existing}
 	uc := NewCardUsecase(nil, cardRepo,
@@ -386,8 +386,8 @@ func TestCardUsecase_Update_FrontTooLong(t *testing.T) {
 	existing := &domain.Card{
 		ID:          "card1",
 		CardgroupID: "cg1",
-		Front:       "old front",
-		Back:        "old back",
+		Front:       domain.CardText("old front"),
+		Back:        domain.CardText("old back"),
 	}
 	cardRepo := &mockCardRepository{findResult: existing}
 	uc := NewCardUsecase(nil, cardRepo,
@@ -415,8 +415,8 @@ func TestCardUsecase_Update_BackTooLong(t *testing.T) {
 	existing := &domain.Card{
 		ID:          "card1",
 		CardgroupID: "cg1",
-		Front:       "old front",
-		Back:        "old back",
+		Front:       domain.CardText("old front"),
+		Back:        domain.CardText("old back"),
 	}
 	cardRepo := &mockCardRepository{findResult: existing}
 	uc := NewCardUsecase(nil, cardRepo,
@@ -444,8 +444,8 @@ func TestCardUsecase_Update_RepoError_InfraChannel(t *testing.T) {
 	existing := &domain.Card{
 		ID:          "card1",
 		CardgroupID: "cg1",
-		Front:       "old front",
-		Back:        "old back",
+		Front:       domain.CardText("old front"),
+		Back:        domain.CardText("old back"),
 	}
 	cardRepo := &mockCardRepository{
 		findResult: existing,
@@ -854,7 +854,7 @@ func decodeJSONRecords(t *testing.T, data []byte) []map[string]any {
 func TestCardUsecase_Create_Duplicate(t *testing.T) {
 	t.Parallel()
 
-	fixture := &domain.Card{ID: "fixture-id", CardgroupID: "cg1", Front: "hello", Back: "fixture-back"}
+	fixture := &domain.Card{ID: "fixture-id", CardgroupID: "cg1", Front: domain.CardText("hello"), Back: domain.CardText("fixture-back")}
 	cardRepo := &mockCardRepository{
 		createErr:                     repository.ErrCardDuplicateFront,
 		findByCardgroupAndFrontResult: fixture,
@@ -997,7 +997,7 @@ func TestCardUsecase_Create_triggersNotionWriteback(t *testing.T) {
 func TestCardUsecase_Create_duplicateDoesNotTriggerWriteback(t *testing.T) {
 	t.Parallel()
 
-	fixture := &domain.Card{ID: "existing-id", CardgroupID: "cg1", Front: "front", Back: "existing-back"}
+	fixture := &domain.Card{ID: "existing-id", CardgroupID: "cg1", Front: domain.CardText("front"), Back: domain.CardText("existing-back")}
 	stub := &stubNotionWriter{called: make(chan struct{})}
 	cardRepo := &mockCardRepository{
 		createErr:                     repository.ErrCardDuplicateFront,

--- a/backend/internal/usecase/dictionary.go
+++ b/backend/internal/usecase/dictionary.go
@@ -197,8 +197,8 @@ func (u *dictionaryUsecase) Upsert(ctx context.Context, input UpsertDictionaryIn
 	for _, w := range words {
 		c := &domain.Card{
 			CardgroupID: input.CardgroupID,
-			Front:       w.Front,
-			Back:        w.Back,
+			Front:       domain.CardText(w.Front),
+			Back:        domain.CardText(w.Back),
 			CreatedAt:   now,
 			UpdatedAt:   now,
 		}

--- a/backend/internal/usecase/dictionary_test.go
+++ b/backend/internal/usecase/dictionary_test.go
@@ -67,7 +67,7 @@ func (m *mockDictCardRepo) UpsertManyTx(_ context.Context, _ *gorm.DB, cards []*
 	if m.preExisting != nil {
 		var ins, upd int64
 		for _, c := range cards {
-			if _, ok := m.preExisting[c.Front]; ok {
+			if _, ok := m.preExisting[string(c.Front)]; ok {
 				upd++
 			} else {
 				ins++
@@ -256,8 +256,8 @@ func TestDictionaryUsecase_AdminMixedInsertsAndUpdates(t *testing.T) {
 	wantBack := uniqueBack(probeIdx + 1000)
 	var found bool
 	for _, c := range repo.captured {
-		if c.Front == wantFront {
-			if c.Back != wantBack {
+		if string(c.Front) == wantFront {
+			if string(c.Back) != wantBack {
 				t.Fatalf("captured shared front=%q has Back=%q, want %q", wantFront, c.Back, wantBack)
 			}
 			found = true
@@ -708,7 +708,7 @@ func TestDictionaryUsecase_DuplicateFrontDeduplicatedAndSurfaced(t *testing.T) {
 	if len(repo.captured) != 1 {
 		t.Fatalf("expected 1 card sent to repo, got %d", len(repo.captured))
 	}
-	if repo.captured[0].Back != rubbishBack {
+	if string(repo.captured[0].Back) != rubbishBack {
 		t.Fatalf("expected repo card Back=%q (last occurrence wins), got %q", rubbishBack, repo.captured[0].Back)
 	}
 }

--- a/backend/internal/usecase/last_viewed_cardgroup_test.go
+++ b/backend/internal/usecase/last_viewed_cardgroup_test.go
@@ -58,11 +58,10 @@ func TestLastViewedCardgroup_Anonymous_Unauthenticated(t *testing.T) {
 func TestLastViewedCardgroup_HappyPath_ReturnsRefreshedUser(t *testing.T) {
 	t.Parallel()
 
-	dn := "Alice"
 	cgID := "cg-123"
 	want := &domain.User{
 		ID:          "u-1",
-		DisplayName: &dn,
+		DisplayName: dnPtr("Alice"),
 	}
 	prefs := &mockPrefRepo{}
 	users := &mockUserRefetchRepo{user: want}

--- a/backend/internal/usecase/notion_sync.go
+++ b/backend/internal/usecase/notion_sync.go
@@ -316,8 +316,8 @@ func cardsFromParsedRows(cardgroupID string, rows []ParsedRow) []*domain.Card {
 	for _, row := range rows {
 		cards = append(cards, &domain.Card{
 			CardgroupID: cardgroupID,
-			Front:       row.Front,
-			Back:        row.Back,
+			Front:       domain.CardText(row.Front),
+			Back:        domain.CardText(row.Back),
 			CreatedAt:   now,
 			UpdatedAt:   now,
 		})

--- a/backend/internal/usecase/notion_sync_test.go
+++ b/backend/internal/usecase/notion_sync_test.go
@@ -189,7 +189,7 @@ func TestNotionSyncUsecase_DuplicateFrontLastWins(t *testing.T) {
 	if pe.Back != uniqueBack(1) {
 		t.Fatalf("ParseErrors[0].Back = %q, want %q (the dropped row's back)", pe.Back, uniqueBack(1))
 	}
-	if len(cards.upserted) != 1 || cards.upserted[0].Back != uniqueBack(2) {
+	if len(cards.upserted) != 1 || string(cards.upserted[0].Back) != uniqueBack(2) {
 		t.Fatalf("upserted = %+v, want latest back", cards.upserted)
 	}
 	// Partial success (rows>0, parseErrs>0): persistence must still run.

--- a/backend/internal/usecase/user.go
+++ b/backend/internal/usecase/user.go
@@ -100,7 +100,7 @@ func (u *UserUsecase) UpdateUser(ctx context.Context, in UpdateUserInput) (Updat
 			}
 			return UpdateProfileOutcome{Validation: info}, nil
 		}
-		patch.Bio = bio.Value()
+		patch.Bio = bio.Ptr()
 	}
 	appUser, err := u.repo.Update(ctx, user.Sub, patch)
 	if err != nil {

--- a/backend/internal/usecase/user_test.go
+++ b/backend/internal/usecase/user_test.go
@@ -39,9 +39,9 @@ func anonCtx() context.Context {
 
 func ptr(s string) *string { return &s }
 
-// dnPtr returns a *domain.DisplayName for the supplied string. Used to build
-// User fixtures after the field type changed from *string to *DisplayName in
-// Phase 3.
+// dnPtr returns a *domain.DisplayName for the supplied string. Used by User
+// fixture builders because Go does not allow taking the address of a conversion
+// expression like &domain.DisplayName(s).
 func dnPtr(s string) *domain.DisplayName {
 	d := domain.DisplayName(s)
 	return &d

--- a/backend/internal/usecase/user_test.go
+++ b/backend/internal/usecase/user_test.go
@@ -39,12 +39,20 @@ func anonCtx() context.Context {
 
 func ptr(s string) *string { return &s }
 
+// dnPtr returns a *domain.DisplayName for the supplied string. Used to build
+// User fixtures after the field type changed from *string to *DisplayName in
+// Phase 3.
+func dnPtr(s string) *domain.DisplayName {
+	d := domain.DisplayName(s)
+	return &d
+}
+
 // --- Me tests ---
 
 func TestUserUsecase_Me(t *testing.T) {
 	t.Parallel()
 
-	alice := ptr("Alice")
+	alice := dnPtr("Alice")
 	cases := []struct {
 		name       string
 		ctx        context.Context
@@ -118,7 +126,7 @@ func TestUserUsecase_Me(t *testing.T) {
 func TestUserUsecase_UpdateUser(t *testing.T) {
 	t.Parallel()
 
-	returned := &domain.User{ID: "u1", DisplayName: ptr("Alice")}
+	returned := &domain.User{ID: "u1", DisplayName: dnPtr("Alice")}
 
 	// familyEmoji is a ZWJ sequence that counts as 1 grapheme cluster.
 	familyEmoji := "👨‍👩‍👧‍👦"
@@ -333,7 +341,7 @@ func TestUserUsecase_UpdateUser(t *testing.T) {
 func TestUserUsecase_UpdateUser_SuccessVariant(t *testing.T) {
 	t.Parallel()
 
-	returned := &domain.User{ID: "u1", DisplayName: ptr("Alice")}
+	returned := &domain.User{ID: "u1", DisplayName: dnPtr("Alice")}
 	repo := &mockUserRepository{updateResult: returned}
 	uc := NewUserUsecase(repo, newTestLogger())
 

--- a/docs/backend/ddd-patterns/boundary-gate-replaces-domain-recheck.md
+++ b/docs/backend/ddd-patterns/boundary-gate-replaces-domain-recheck.md
@@ -1,0 +1,104 @@
+# Boundary gate replaces domain re-check
+
+> Part of the [DDD patterns](./../../../.claude/rules/ddd-patterns.md) rules.
+
+## Why
+
+A domain aggregate's `Validate()` method is the temptation to centralise every
+invariant in one place: "validate everything every time, then it is impossible
+to forget". The problem with double-checking an invariant that the usecase
+boundary already enforces is twofold:
+
+- **Dead code.** If the only callers of the aggregate constructor flow through
+  the boundary gate, the domain-side check never fires for any non-malicious
+  input. It is exercised only by domain unit tests that construct invalid
+  shapes deliberately.
+- **Drift risk.** The boundary gate and the domain re-check express the same
+  invariant in two languages (e.g. `ucerr.NewValidationError("cardgroupId", ...)`
+  at the boundary, `eris.New("card: cardgroup id is required")` in the domain).
+  When the message text on one side changes, the other drifts unnoticed.
+
+The right shape is: the boundary enforces caller-input invariants; the
+aggregate enforces internal-state invariants. A field that originates in
+user-supplied input and is gated at the boundary should not be re-checked in
+the domain.
+
+## What — `Card.CardgroupID`
+
+`Card.CardgroupID` originates exclusively from caller input (a GraphQL mutation
+argument). Every usecase entry point that mutates a `Card` runs
+`authorizeCardgroupOrBadInput` before constructing the aggregate:
+
+```go
+// backend/internal/usecase/card.go — CardUsecase.Create
+if err := authorizeCardgroupOrBadInput(ctx, u.cardgroupRepo, in.CardgroupID, user.Sub); err != nil {
+    return CreateCardOutcome{}, err
+}
+// ... Card is constructed only after the gate has passed.
+```
+
+```go
+// backend/internal/usecase/ownership.go
+func authorizeCardgroupOrBadInput(ctx context.Context, repo CardgroupOwnershipFinder, id, userID string) error {
+    cg, err := repo.FindByID(ctx, id)
+    if err != nil {
+        if errors.Is(err, repository.ErrNotFound) {
+            return ucerr.NewValidationError("cardgroupId", "cardgroup not found")
+        }
+        return eris.Wrap(err, "usecase: authorize cardgroup: find by id")
+    }
+    if !cg.IsOwnedBy(userID) {
+        return ucerr.ErrUnauthenticated
+    }
+    return nil
+}
+```
+
+An empty `CardgroupID` reaches `repo.FindByID`, which returns `ErrNotFound`,
+which the gate translates into `BAD_USER_INPUT(field=cardgroupId)`. The
+GraphQL caller sees a typed validation error before any `Card` is constructed.
+
+A domain-side `if c.CardgroupID == ""` check inside `Card.Validate()` would
+have been unreachable for every production caller. The check was removed
+along with its `ErrCardCardgroupIDRequired` sentinel; the aggregate's
+docstring documents the boundary contract instead:
+
+```go
+// backend/internal/domain/card.go
+// Card is an aggregate root. ...
+//
+// CardgroupID ownership is enforced at the usecase boundary via
+// authorizeCardgroupOrBadInput before a Card is constructed; the domain
+// aggregate therefore does not re-check CardgroupID presence in Validate.
+type Card struct { ... }
+```
+
+## The other Card.Validate fields stayed
+
+`Card.Validate()` retains `ParseCardText` calls for `Front` and `Back`. Those
+fields are not gated at the usecase boundary; `ParseCardText` is the
+single source of truth for the grapheme-bound + non-empty invariants. The
+aggregate's `Validate()` method is still load-bearing for any caller that
+constructs a `Card` outside the usecase's `Create`/`Update` paths (today: no
+such callers in production, but the contract is the right shape for future
+seed/migration paths).
+
+The pattern is: each invariant has a single enforcement site. If the
+boundary enforces it, the domain skips it. If the domain owns it (because
+no boundary gate has it), the domain enforces it.
+
+## When the pattern does NOT apply
+
+- **Cross-aggregate invariants** that span fields with different origins.
+  Example: a `Card.UpdatedAt` that must not be earlier than `Card.CreatedAt`
+  is a domain-internal consistency check; no caller-facing boundary owns it.
+- **Defense in depth for sensitive operations** (authorization, money,
+  cryptographic state) where a redundant check is cheap insurance against
+  a future caller bypassing the gate. The `Card.CardgroupID` case is plain
+  user input with no security weight beyond what the gate already provides.
+
+## Reference
+
+- `backend/internal/domain/card.go` — `Card.Validate` minus the `CardgroupID` check; docstring notes the boundary contract.
+- `backend/internal/usecase/ownership.go` — `authorizeCardgroupOrBadInput`, the gate that owns the invariant.
+- `backend/internal/usecase/card.go` — `Create` / `Update` call the gate before constructing the aggregate.

--- a/docs/backend/ddd-patterns/context-neutral-vo-docstrings.md
+++ b/docs/backend/ddd-patterns/context-neutral-vo-docstrings.md
@@ -1,0 +1,125 @@
+# Context-neutral docstrings on shared-context value objects
+
+> Part of the [DDD patterns](./../../../.claude/rules/ddd-patterns.md) rules.
+
+## Why
+
+When the same value object encodes a trinary state that is consumed from
+multiple contexts, a docstring that bakes in one context's meaning misleads
+readers in the other. The `Bio` VO carries the same wire shape (`nil` /
+pointer-to-`""` / pointer-to-non-empty) but the meaning diverges:
+
+| Wire shape | Patch-context meaning (`UpdateProfileInput`) | Read-context meaning (DB column) |
+|---|---|---|
+| `nil` pointer | "leave the stored value unchanged" | "the column is NULL" |
+| pointer to `""` | "explicitly clear the stored value" | "the column stores the empty string" |
+| pointer to `"x"` | "set the stored value to `\"x\"`" | "the column stores `\"x\"`" |
+
+A reader who finds `Bio` via the read path and sees a patch-context docstring
+("`nil` means no change") will interpret a `BioFromPtr(nil)` result as "this
+field was not part of the patch", which is wrong — the field is `NULL` in the
+database. The reverse failure is just as bad: a patch-context caller who reads
+"`nil` means NULL column" will not understand why omitting `Bio` from the input
+preserves the existing value.
+
+## What
+
+Docstrings on the VO type, the constructors, and the accessors enumerate
+**both** contexts. The aggregate or the consumer-specific helper carries the
+context-specific intent.
+
+### Bio (`backend/internal/domain/bio.go`)
+
+```go
+// Bio is the user profile bio, supporting a trinary: nil (no change),
+// pointer-to-"" (explicit clear), or pointer-to-non-empty (set).
+type Bio struct {
+    value *string
+}
+
+// Ptr returns a fresh copy of the internal pointer:
+//   - nil — the Bio holds no value (constructed via ParseBio(nil) or BioFromPtr(nil));
+//   - non-nil pointer to empty string — the Bio holds an empty value;
+//   - non-nil pointer to non-empty string — the Bio holds a populated value.
+//
+// Patch-context callers map nil → "no change", &"" → "explicit clear", &"x" → "set".
+// Read-context callers map nil → NULL column, &"" → empty stored, &"x" → populated stored.
+func (b Bio) Ptr() *string { ... }
+
+// IsSet reports whether the Bio carries a value (its internal pointer is non-nil).
+// Returns false for ParseBio(nil) (patch-context: no change) and for BioFromPtr(nil)
+// (read-context: NULL column / zero value Bio{}). Returns true for any other
+// construction, including an explicit empty string.
+func (b Bio) IsSet() bool { return b.value != nil }
+```
+
+The accessor docstrings list the wire shape mapping (the "what") and then
+enumerate the per-context interpretation (the "why this shape"). The reader
+arriving from either context sees their own meaning without having to follow
+the implementation trail to the call site.
+
+### Context-specific helpers carry context-specific docstrings
+
+`ParseBio` is patch-context: it takes user input and may surface
+`ErrBioTooLong`. Its docstring talks about the patch contract.
+
+`BioFromPtr` is read-context: it takes a database column value and never
+errors. Its docstring talks about NULL columns and defensive copying.
+
+```go
+// ParseBio validates and trims s, preserving the trinary contract:
+// nil means "no change"; a pointer to "" means "explicit clear"; a pointer to
+// a non-empty string means "set". ...
+func ParseBio(s *string) (Bio, error) { ... }
+
+// BioFromPtr maps a nullable text column to a Bio: nil → Bio{} (IsSet()=false,
+// NULL column); a non-nil pointer — including pointer-to-empty — maps to a set
+// Bio whose Ptr() returns a defensive copy with the same string value.
+// Used by repository readers to bridge a nullable text column into the typed
+// domain field.
+func BioFromPtr(p *string) Bio { ... }
+```
+
+The constructor that *receives* user input owns the validation contract; the
+constructor that *receives* DB data trusts the DB and never validates. Two
+constructors with one struct VO keeps the per-context concerns separated
+while the VO itself stays single-source.
+
+## The aggregate carries the context-shared posture
+
+The `User` aggregate's field docstring touches all three contexts where `Bio`
+appears (patch-context, read-context, and the in-memory aggregate state) and
+explicitly disclaims the patch-context "no change" interpretation:
+
+```go
+// User is the application-owned row keyed by auth.users.id.
+//
+// DisplayName is *DisplayName so a NULL column round-trips as a nil pointer
+// (no display name set). Bio is the trinary VO Bio (by value). The zero value
+// Bio{} represents a NULL bio column (IsSet()=false); a set Bio carries either
+// an explicit empty-string value or non-empty text. The trinary's "no change"
+// meaning applies in the UpdateProfileInput patch context, not here.
+type User struct {
+    ID          string
+    DisplayName *DisplayName
+    Bio         Bio
+    // ...
+}
+```
+
+The "applies in the UpdateProfileInput patch context, not here" sentence is the
+disambiguator: a reader who arrives via `User.Bio` is told that the trinary
+they remember from the VO docstring is not the meaning in this read-context
+field.
+
+## When this matters
+
+This pattern applies whenever a struct VO is shared by:
+
+- An input DTO that uses a `nil` field to signal "absent".
+- A repository row that uses a `nil` column to signal "NULL".
+
+The trinary VO docstring chapter
+([`docs/backend/ddd-patterns/trinary-value-object.md`](trinary-value-object.md))
+covers the underlying VO design; this chapter covers the docstring discipline
+that keeps the design legible from both ends.

--- a/docs/backend/ddd-patterns/helpers-introduced-but-not-wired-must-be-deleted.md
+++ b/docs/backend/ddd-patterns/helpers-introduced-but-not-wired-must-be-deleted.md
@@ -50,5 +50,40 @@ grep -rn <NewSymbol> backend/ --include='*.go' | grep -v _test.go | grep -v <dec
 A count of `0` means delete the helper in the same PR. "Keep for later" produces
 the exact surface-rot described above.
 
-See [`.claude/rules/scope-discipline.md`](../../../.claude/rules/scope-discipline.md)
-for the general rule and the analogous example from issue #181 (`ResolvePageSize`).
+## The rule applies per symbol, not per category — keyed on wired-ness
+
+A single PR can introduce several helpers of the same category (e.g. a
+boundary helper, a `Scan` method, a `Value` method, a `String` accessor) at
+the same time. The rule applies to each helper *independently*: the
+post-flight grep keys on wired-ness, not on what kind of method it is. The
+current backend VOs illustrate the per-symbol verdict:
+
+| Symbol | Caller count outside declaration | Verdict |
+|---|---|---|
+| `domain.BioFromPtr` | 1 (`repository/user.go:userToDomain`) + 1 test fixture | Keep — load-bearing read-path bridge. |
+| Hypothetical `(Bio).Scan` / `(Bio).Value` (gorm row stores `*string`, never reaches the VO) | 0 | Delete in the same PR if introduced. |
+| `(CardText).String` | 2 (`usecase/card.go` patch construction) | Keep — wired by the patch DTO boundary. |
+| Hypothetical `(DisplayName).String` (no caller wired) | 0 | Delete in the same PR if introduced. |
+
+A reviewer's "no tests" finding is not by itself a signal to delete. The
+right next step is to grep for production callers:
+
+- Zero callers → delete (the test gap is consistent with the call-site gap).
+- One or more callers → keep, and either add the missing test or accept that
+  the call-site behavioural tests cover the helper transitively.
+
+The shorthand "untested means dead" elides the second case and recommends
+deleting helpers that production code actually depends on. The reverse —
+"wired means keep" — is also asymmetric: a helper with one production caller
+and no direct unit test is fine if the caller's behavioural tests exercise
+the helper's path; the helper is greppably reachable from a tested call site.
+
+## Reference
+
+- See [`.claude/rules/scope-discipline.md`](../../../.claude/rules/scope-discipline.md)
+  for the general rule and the analogous example from issue #181 (`ResolvePageSize`).
+- `backend/internal/domain/bio.go` — `BioFromPtr` (kept; wired by repository
+  read path) is co-located with `Bio.Ptr()` / `Bio.IsSet()` (kept; wired by
+  patch construction).
+- `backend/internal/usecase/card.go` — `front.String()` / `back.String()` are
+  the live callers that keep `CardText.String()` from being deleted.

--- a/docs/backend/ddd-patterns/patch-dto-primitive-not-vo.md
+++ b/docs/backend/ddd-patterns/patch-dto-primitive-not-vo.md
@@ -1,0 +1,120 @@
+# Patch DTOs keep primitive types, not the VO
+
+> Part of the [DDD patterns](./../../../.claude/rules/ddd-patterns.md) rules.
+
+## Why
+
+A patch DTO (e.g. `repository.UserUpdate`, `repository.CardUpdate`) is a thin
+data carrier between the usecase and the repository's `Updates(map)` call.
+Each field expresses the patch contract directly:
+
+| DTO field shape | Meaning |
+|---|---|
+| `nil` pointer | "leave the stored value unchanged" |
+| pointer to `""` | "clear the column" |
+| pointer to `"x"` | "set the column to `\"x\"`" |
+
+The primitive `*string` expresses this contract literally — `nil` is the
+absence of a patch, anything non-`nil` is a write. Retyping the field to a
+struct VO (e.g. `Bio` instead of `*string`) does not add safety here:
+
+- The patch contract is **about presence/absence**, not about the validated
+  shape of the value. The struct VO's invariants (length cap, etc.) were
+  already enforced by the upstream `Parse*` call in the usecase.
+- The repository's `Updates(map)` site takes `any` values and writes them
+  verbatim. A struct VO would have to be translated back to `*string` at
+  this site (`if bio.IsSet() { updates["bio"] = *bio.Ptr() }`), adding two
+  lines per field for no semantic gain.
+- The DTO retains its role as a *data carrier* — it does not validate, it
+  does not enforce, it just describes the patch.
+
+The boundary between "value object" and "patch DTO" is the usecase function:
+the VO lives on the way in (validated user input), the DTO lives on the way
+out (write request to the repository).
+
+## What — `UserUpdate.Bio`
+
+`repository.UserUpdate.Bio` is `*string`, even though the domain field
+`User.Bio` is the struct VO `Bio`. The usecase translates the validated `Bio`
+back to `*string` at the patch construction site:
+
+```go
+// backend/internal/usecase/user.go — UpdateUser
+patch := repository.UserUpdate{
+    DisplayName: &name,
+}
+if in.Bio != nil {
+    bio, err := domain.ParseBio(in.Bio)
+    if err != nil {
+        // ... liftValidationErr / translateBioErr branch
+        return UpdateProfileOutcome{Validation: info}, nil
+    }
+    patch.Bio = bio.Ptr()   // <- VO → primitive at the DTO boundary
+}
+```
+
+The `if in.Bio != nil` guard is the patch contract's "field absent" branch:
+the input field is a `*string` because the input itself is a patch (the GraphQL
+mutation `UpdateProfileInput.Bio` is `*string`). Keeping the same shape on the
+DTO side keeps the translation trivial.
+
+If `UserUpdate.Bio` were retyped to `Bio`, the repository site would have to
+demote it back:
+
+```go
+// HYPOTHETICAL — what the retyping would force at the repository.
+if patch.Bio.IsSet() {
+    updates["bio"] = *patch.Bio.Ptr()
+}
+```
+
+…with no validation, no extra safety, just a per-field demote. The primitive
+shape keeps the repository unaware of the VO.
+
+## What — `CardUpdate.Front` / `CardUpdate.Back`
+
+The same shape applies to `repository.CardUpdate`: `Front` and `Back` are
+`*string`, even though `Card.Front` / `Card.Back` are `CardText`. The usecase
+validates via `ParseCardText` and translates to `*string` at the DTO
+construction site:
+
+```go
+// backend/internal/usecase/card.go — CardUsecase.Update
+if in.Front != nil {
+    front, err := domain.ParseCardText(*in.Front, domain.ErrCardFrontRequired, domain.ErrCardFrontTooLong)
+    if err != nil { /* ... validation branch */ }
+    s := front.String()      // <- VO → primitive at the DTO boundary
+    patch.Front = &s
+}
+```
+
+The `.String()` method is what makes the cast explicit at the call site. It is
+the only place the `CardText.String()` accessor is wired today (two callers
+in `card.go`), but it is load-bearing — without it the patch construction
+would have to use `(*string)(&front)` casts or convert via intermediate
+variables, both of which read worse than the named accessor.
+
+## When the pattern does NOT apply
+
+- **Constructor DTOs** (`CreateUserInput`) — these are inputs, not patches.
+  The "no change" semantics do not exist; every field has a definite value.
+  Retyping to the VO (`DisplayName string` → `DisplayName DisplayName`) is
+  legitimate and arguably preferable, though this codebase keeps the
+  primitives at the input boundary and validates inside the usecase.
+- **Single-field patches** that already use a typed enum or boolean —
+  `RoleUpdate.Name string` becomes `RoleName RoleName` because the field's
+  only valid values are the validated newtype; the primitive shape adds no
+  information.
+
+The rule is: keep the DTO shape aligned with the contract the DTO encodes.
+For three-way patch DTOs, `*<primitive>` matches the contract. For
+two-way constructor DTOs, the VO matches the contract.
+
+## Reference
+
+- `backend/internal/repository/user.go` — `UserUpdate` (`*string` for `DisplayName`/`Bio`/`AvatarURL`).
+- `backend/internal/repository/card.go` — `CardUpdate` (`*string` for `Front`/`Back`).
+- `backend/internal/usecase/user.go` — `UpdateUser` translates `Bio.Ptr()` to `patch.Bio *string`.
+- `backend/internal/usecase/card.go` — `CardUsecase.Update` translates `CardText.String()` to `patch.Front/Back *string`.
+- [`docs/backend/ddd-patterns/trinary-value-object.md`](trinary-value-object.md) — the `Bio` VO's own contract.
+- [`docs/backend/ddd-patterns/context-neutral-vo-docstrings.md`](context-neutral-vo-docstrings.md) — the patch-vs-read context split for shared VOs.

--- a/docs/backend/ddd-patterns/same-underlying-type-pointer-cast.md
+++ b/docs/backend/ddd-patterns/same-underlying-type-pointer-cast.md
@@ -1,0 +1,68 @@
+# Same-underlying-type pointer cast for VO bridging
+
+> Part of the [DDD patterns](./../../../.claude/rules/ddd-patterns.md) rules.
+
+## Why
+
+A repository row struct stores nullable string columns as `*string` (so that
+NULL columns round-trip as a Go nil pointer). The domain field carrying the
+same value is `*<DomainStringNewtype>` — the domain side wants the type
+discipline of `DisplayName`, but the wire-shape contract (NULL → nil) is the
+same as for the raw pointer.
+
+The two types are not identical (one is `*string`, the other is `*domain.DisplayName`),
+but their **underlying types** are identical (`*string`). Go's conversion
+rules permit a direct pointer conversion between named pointer types whose
+underlying types are identical, without an intermediate string copy and
+without a nil check at the boundary:
+
+```go
+// backend/internal/repository/user.go — userToDomain
+return &domain.User{
+    ID:          g.ID,
+    DisplayName: (*domain.DisplayName)(g.DisplayName),   // <- straight cast
+    Bio:         domain.BioFromPtr(g.Bio),
+    AvatarURL:   g.AvatarURL,
+    // ...
+}
+```
+
+The alternatives are strictly worse:
+
+- **Helper function (`displayNameFromPtr`)**: introduces a function call, an
+  extra symbol to find and read, and a nil-check that the cast does not need.
+  Zero behavioural benefit because the conversion has no validation step.
+- **Inline if-nil-else dereference**:
+  ```go
+  var dn *domain.DisplayName
+  if g.DisplayName != nil {
+      v := domain.DisplayName(*g.DisplayName)
+      dn = &v
+  }
+  ```
+  Five lines of stutter for the same outcome, and the `domain.DisplayName(*g.DisplayName)`
+  step allocates a new string-header (technically harmless given immutable
+  strings, but visually noisy).
+
+The same cast applies in the other direction (`(*string)(domainPtr)`) if a
+repository write path ever needs to thread the domain pointer back out
+through a primitive field. Today the repository writes via a primitive-typed
+`UserUpdate.DisplayName *string`, so the reverse cast does not appear.
+
+## When the cast does NOT apply
+
+The pointer cast is legal only when both sides have the **same underlying
+type**. Two situations where it does not apply:
+
+- **Struct VO (`Bio`)** — `Bio` is `struct { value *string }`, not a string
+  newtype. There is no `(*Bio)(someStringPtr)` conversion; the bridging
+  helper (`BioFromPtr`) is mandatory.
+- **Underlying-type mismatch** — `type UserID uint64` cannot be cast from
+  `*string` even if the on-the-wire shape is the same. The cast is a Go
+  type-system operation, not a semantic equivalence.
+
+## Reference
+
+- `backend/internal/repository/user.go` — `userToDomain` uses the cast for `DisplayName` and falls back to `BioFromPtr` for `Bio`.
+- `backend/internal/domain/display_name.go` — `type DisplayName string` (the underlying-type match that legalises the cast).
+- `backend/internal/domain/bio.go` — `type Bio struct { value *string }` (the struct VO that requires the helper).

--- a/docs/backend/ddd-patterns/trinary-value-object.md
+++ b/docs/backend/ddd-patterns/trinary-value-object.md
@@ -38,9 +38,9 @@ func ParseBio(s *string) (Bio, error) {
     return Bio{value: &trimmed}, nil
 }
 
-func (b Bio) IsSet() bool    { return b.value != nil }
+func (b Bio) IsSet() bool   { return b.value != nil }
 
-func (b Bio) Value() *string {
+func (b Bio) Ptr() *string {
     if b.value == nil {
         return nil
     }
@@ -51,12 +51,12 @@ func (b Bio) Value() *string {
 
 - `ParseBio(nil)` → `Bio{}` (no change): `IsSet()` returns `false`.
 - `ParseBio(&"")` or `ParseBio(&"   ")` → explicit clear: `IsSet()` returns `true`,
-  `Value()` returns a pointer to `""`. Whitespace-only inputs are collapsed to the
+  `Ptr()` returns a pointer to `""`. Whitespace-only inputs are collapsed to the
   explicit-clear case after trimming.
-- `ParseBio(&"hello")` → set: `IsSet()` returns `true`, `Value()` returns a pointer
+- `ParseBio(&"hello")` → set: `IsSet()` returns `true`, `Ptr()` returns a pointer
   to `"hello"`.
 
-`Value()` returns a copy of the pointer's target so external mutation of the
+`Ptr()` returns a copy of the pointer's target so external mutation of the
 returned pointer does not alter the `Bio`'s internal state.
 
 ## Usecase guard

--- a/docs/backend/library-gotchas/defensive-copy-test-pointer-identity.md
+++ b/docs/backend/library-gotchas/defensive-copy-test-pointer-identity.md
@@ -1,0 +1,78 @@
+# Defensive-copy tests assert pointer identity, not variable rebind
+
+> Part of the [Go library gotchas](../../../.claude/rules/go-library-gotchas.md) rules.
+
+## The trap
+
+A naive test for a defensive-copy accessor reaches for variable mutation to
+prove the copy survived:
+
+```go
+// WRONG — proves nothing about defensive copying.
+func TestBio_DefensiveCopy_WRONG(t *testing.T) {
+    s := "original"
+    b := BioFromPtr(&s)
+    s = "mutated"                              // <- rebinds local, doesn't mutate the original string
+    require.Equal(t, "original", *b.Ptr())     // passes whether or not Bio defensively copies
+}
+```
+
+This test passes regardless of whether `BioFromPtr` defensively copies, because
+Go strings are immutable. `s = "mutated"` does not write into the existing
+string header that `&s` once pointed at; it allocates a new string and rebinds
+the local `s` to that new value. The original string the `Bio` captured was
+never mutable, so a non-defensive `Bio` would still report `"original"`.
+
+A defensive-copy invariant exists for *external aliasing*: another caller
+holding the same `*string` could swap out the pointer's referent. But Go
+strings are immutable, so swapping is the only way to "mutate" them — and the
+test above does not swap, it rebinds.
+
+## The fix — assert pointer identity
+
+The defensive-copy property to test is: each `Ptr()` call hands the caller a
+fresh `*string`, so two consecutive calls return non-identical pointers:
+
+```go
+// CORRECT — proves each call allocates a fresh pointer.
+t.Run("Ptr returns a fresh pointer on each call", func(t *testing.T) {
+    s := "original"
+    b := BioFromPtr(&s)
+    p1, p2 := b.Ptr(), b.Ptr()
+    require.NotSame(t, p1, p2, "each Ptr() call must allocate a fresh pointer")
+    require.Equal(t, *p1, *p2, "but the values must be equal")
+})
+```
+
+`require.NotSame` compares the `*string` addresses. Two fresh allocations have
+different addresses; a shared pointer would return the same address twice and
+fail the assertion. The companion `require.Equal(t, *p1, *p2)` confirms the
+values still agree, so the test does not accidentally pass on a broken
+implementation that returns a fresh pointer pointing at unrelated data.
+
+The same assertion shape catches the failure mode the rebind test misses:
+if `BioFromPtr` were changed to store the caller's pointer verbatim (no
+internal copy), `b.Ptr()` would return that exact pointer on every call, and
+`require.NotSame(p1, p2)` would fail.
+
+## Why this happens
+
+The trap is that the word "mutation" is overloaded in Go:
+
+- **Local variable rebind** (`s = "x"`) — changes which value the local
+  identifier refers to. Does not write into any pre-existing memory.
+- **Pointee mutation** through an exclusive pointer (`*p = "x"`) — also legal
+  for strings, but again allocates a new string and rebinds the location `p`
+  refers to.
+- **Slice-element or struct-field mutation** through a shared pointer — the
+  case that defensive copies actually defend against, but not what string
+  immutability allows.
+
+A defensive-copy accessor's contract is "the value I return is not aliased
+to the value I stored". The right test exercises the aliasing axis (pointer
+identity), not the rebind axis.
+
+## Reference
+
+- `backend/internal/domain/bio_test.go` — `TestBioFromPtr` / `"Ptr returns a fresh pointer on each call"`.
+- `backend/internal/domain/bio.go` — `Bio.Ptr()` allocates a fresh `*string` on every call.

--- a/docs/backend/library-gotchas/gorm-newtype-string-no-scanner-valuer.md
+++ b/docs/backend/library-gotchas/gorm-newtype-string-no-scanner-valuer.md
@@ -1,0 +1,123 @@
+# GORM v1 round-trips underlying-string newtypes without Scanner/Valuer
+
+> Part of the [Go library gotchas](../../../.claude/rules/go-library-gotchas.md) rules.
+
+## The reflective fallback
+
+`database/sql` resolves a value to be sent to the driver in two steps:
+
+1. Check whether the value implements `driver.Valuer`. If yes, call `Value()`.
+2. Fall back to a reflective converter (`database/sql/driver.DefaultParameterConverter`).
+   For any type whose `reflect.Kind` is `String`, the converter returns the
+   underlying string verbatim. Likewise for `Scan`: a `*string` target accepts
+   the column's text value via the reflective path.
+
+Consequently, a Go newtype defined as `type RoleName string` (or `type CardText string`,
+`type DisplayName string`) round-trips through a GORM v1 query against a `text`
+column **without** an explicit `Scanner`/`Valuer` pair — provided the GORM row
+struct types the column as the underlying primitive (`string`), not as the newtype.
+
+In this repository the gorm row structs intentionally use primitives at the
+column boundary:
+
+```go
+// backend/internal/repository/role.go
+type gormRole struct {
+    ID   string `gorm:"column:id;primaryKey;type:uuid"`
+    Name string `gorm:"column:name"`     // <- string, not RoleName
+}
+
+// backend/internal/repository/card.go
+type gormCard struct {
+    ID          string    `gorm:"column:id;primaryKey;type:uuid"`
+    CardgroupID string    `gorm:"column:cardgroup_id"`
+    Front       string    `gorm:"column:front"`   // <- string, not CardText
+    Back        string    `gorm:"column:back"`
+    CreatedAt   time.Time `gorm:"column:created_at"`
+    UpdatedAt   time.Time `gorm:"column:updated_at"`
+}
+```
+
+The VO conversion happens at the boundary in the `*ToDomain` helper:
+
+```go
+// backend/internal/repository/card.go — cardToDomain
+return &domain.Card{
+    ID:          row.ID,
+    CardgroupID: row.CardgroupID,
+    Front:       domain.CardText(row.Front),   // <- straight cast at boundary
+    Back:        domain.CardText(row.Back),
+    // ...
+}
+```
+
+## When Scanner/Valuer are dead code
+
+If the gorm row struct already types the column as a primitive (`string`,
+`*string`), adding `Scan`/`Value` methods to the newtype produces dead code:
+the reflective converter never reaches the newtype because the row struct's
+field is the primitive, and the conversion to the newtype happens *after* the
+DB round-trip.
+
+A Scanner/Valuer pair on the newtype is only load-bearing when the gorm row
+struct types the column with the VO directly (e.g. `Name RoleName \`gorm:"column:name"\``).
+That introduces a different design trade-off (the gorm row becomes
+domain-typed) and is not the pattern this repository uses.
+
+## The Bio counter-example — boundary helper, not Scanner/Valuer
+
+`Bio` is a struct VO (`type Bio struct { value *string }`), not a string newtype.
+A struct VO does not benefit from the reflective fallback, so the conversion
+needs an explicit boundary helper. The repository writes the underlying `*string`
+verbatim into the gorm row's `*string` column field, and reads back via
+`domain.BioFromPtr(g.Bio)`:
+
+```go
+// backend/internal/repository/user.go — userToDomain
+return &domain.User{
+    // ...
+    Bio: domain.BioFromPtr(g.Bio),
+    // ...
+}
+```
+
+`BioFromPtr` is wired by the repository read path; it is the load-bearing
+counterpart to the dead Scanner/Valuer pair. The dead-code rule (delete unwired
+helpers; see [`docs/backend/ddd-patterns/helpers-introduced-but-not-wired-must-be-deleted.md`](../ddd-patterns/helpers-introduced-but-not-wired-must-be-deleted.md))
+is keyed on wired-ness, not symbol kind: `BioFromPtr` and the never-wired
+`Scan`/`Value` methods were introduced together; only the former survived.
+
+## Method-name collision when reserving the `Value` slot
+
+`Bio.Value() *string` was the original accessor for the underlying pointer. To
+support a future `driver.Valuer` interface (`Value() (driver.Value, error)`),
+the accessor would have to be renamed — Go does not allow two methods with the
+same name and different signatures on the same receiver.
+
+The accessor was renamed to `Ptr()` and the `Value` slot was left free:
+
+```go
+// backend/internal/domain/bio.go
+func (b Bio) Ptr() *string { ... }
+func (b Bio) IsSet() bool  { return b.value != nil }
+```
+
+The lesson: when designing a struct VO whose underlying value is a pointer
+or interface that future code may want to expose via a `database/sql` or
+`json` interface (`Value`, `MarshalJSON`, `UnmarshalJSON`), avoid naming the
+accessor `Value` up front. `Ptr`, `Get`, `Unwrap`, or the field name itself
+(`BioText`, `BioPtr`) all keep the interface slots free. The same applies to
+`Scan` (avoid an accessor named `Scan`).
+
+This is a soft constraint: when the future interface actually arrives the
+rename is a mechanical refactor. The cost is the cascade of call-site updates
+(here: ~10 call sites across repo + tests + resolver) and any docs/comments
+that name the old method. Pay the cost eagerly if the interface is anticipated;
+otherwise rename when the need is concrete.
+
+## Reference
+
+- `backend/internal/repository/role.go` — `gormRole.Name string` + `domain.RoleName(g.Name)` at the boundary.
+- `backend/internal/repository/card.go` — `gormCard.Front/Back string` + `domain.CardText(row.Front)` in `cardToDomain`.
+- `backend/internal/repository/user.go` — `gormUser.DisplayName/Bio *string` + `(*domain.DisplayName)(g.DisplayName)` and `domain.BioFromPtr(g.Bio)` in `userToDomain`.
+- `backend/internal/domain/bio.go` — `Bio.Ptr()` accessor with the `Value` slot reserved for future `driver.Valuer`.


### PR DESCRIPTION
## Summary

Closes #193. Tier 3 follow-up to #182: promote three value-object field types from primitives to typed VOs across the `Role`, `Card`, and `User` aggregates, with cascading changes through `repository/`, `graph/resolver/`, `usecase/`, and test fixtures. Four review rounds, one simplifier pass, and a learnings-capture pass land alongside the core retype as separate commits.

## Background / Motivation

- **`AdminRoleName` / `GeneralRoleName` were untyped string constants.** `HasRole(ctx, userID, roleName string)` accepted positionally-swappable `string` args, so `HasRole(ctx, "admin", "user-1")` would compile and silently look up the wrong role. The constants existed but provided no compile-time safety.
- **`Card.Front` / `Card.Back` were `string`-typed fields** even after #182 introduced `domain.CardText`. `ParseCardText` ran at the usecase boundary, but the validated value was immediately discarded into a `string` field — any direct struct assignment `Card{Front: rawInput}` bypassed validation entirely. The VO was acting as a "validated-then-discarded" gate.
- **`User.DisplayName *string` and `User.Bio *string` carried the trinary pointer-shape contract by convention.** A reader had no compile-time hint that `nil` meant "no value" vs "no change" vs "explicit clear" depending on context. The struct VO `domain.Bio` already encoded the trinary at the type level but was confined to validation-only flow.
- **`Card.Validate()` had a `CardgroupID != ""` check that became dead code.** Every production caller routed through `usecase/ownership.go`'s `authorizeCardgroupOrBadInput` first, which maps empty `CardgroupID` to `BAD_USER_INPUT` via a `FindByID` not-found. The domain-level recheck was unreachable.

## Changes

### Item A — `RoleName` retyping (`e77c650`, 15 files)

- `domain.AdminRoleName` / `GeneralRoleName` retyped from untyped string constants to `domain.RoleName` constants.
- `domain.Role.Name` field retyped to `RoleName`; `systemRoleNames` map keyed by `RoleName`.
- `repository.UserRolesRepository.HasRole` and `repository.RoleRepository.FindByName` accept `domain.RoleName` instead of `string`.
- Resolver `toRoleModel` and `usecase.SystemRoleConflictInfo.Name` retain `string` at outbound layer boundaries via one-line `string(...)` conversions.
- No Scanner/Valuer added — GORM v1's reflective default converter round-trips `type RoleName string` transparently (see [`docs/backend/library-gotchas/gorm-newtype-string-no-scanner-valuer.md`](docs/backend/library-gotchas/gorm-newtype-string-no-scanner-valuer.md)).

### Item B — `CardText` retyping (`c4f744e`, 13 files)

- `domain.Card.Front` / `domain.Card.Back` retyped from `string` to `domain.CardText`.
- `usecase/card.go` constructs `Card{Front: frontVO, Back: backVO}` directly from `ParseCardText` results — the prior `.String()` round-trip is gone.
- `usecase/dictionary.go` and `usecase/notion_sync.go` use direct `domain.CardText(...)` casts; both paths consume already-validated text from the textdic parser (internal-data trust path).
- `repository/card.go`'s `cardToDomain` / `gormCard` mapping converts between `string` (column) and `CardText` (domain) at the row boundary. `CardUpdate` DTO stays `*string` since callers convert via `.String()` and the repository writes the raw string directly to a `map[string]any`.
- Resolver `toCardModel` casts `CardText → string` for the GraphQL `String` scalar.

### Item C — `DisplayName` / `Bio` retyping (`6cdb9c7`, 18 files)

- `domain.User.DisplayName` retyped from `*string` to `*domain.DisplayName`.
- `domain.User.Bio` retyped from `*string` to `domain.Bio` (by value, struct VO). The trinary "no change / explicit clear / set" contract now lives entirely inside the value type.
- New `domain.BioFromPtr(p *string) Bio` constructor bridges the nullable `gormUser.Bio *string` column into the struct VO at the row boundary.
- Repository `userToDomain` uses the same-underlying-type pointer cast `(*domain.DisplayName)(g.DisplayName)` for the typed-string pointer (see [`docs/backend/ddd-patterns/same-underlying-type-pointer-cast.md`](docs/backend/ddd-patterns/same-underlying-type-pointer-cast.md)).
- `UserUpdate` DTO kept as `*string` for the patch contract (`nil = no change`); the boundary conversion `bio.Ptr()` happens in `usecase/user.go` and `usecase/admin_user.go` (see [`docs/backend/ddd-patterns/patch-dto-primitive-not-vo.md`](docs/backend/ddd-patterns/patch-dto-primitive-not-vo.md)).

### Phase 4 — boundary-gate cleanup (`49c6c6c`, 3 files)

- Removed `domain.ErrCardCardgroupIDRequired` sentinel, its branch in `usecase.translateCardErr`, and the `CardgroupID == ""` check from `Card.Validate()`. `Card.Validate()` had zero production callers; `authorizeCardgroupOrBadInput` is the single enforcement site (see [`docs/backend/ddd-patterns/boundary-gate-replaces-domain-recheck.md`](docs/backend/ddd-patterns/boundary-gate-replaces-domain-recheck.md)).
- `ParseCardText` calls in `Validate()` are retained as defense against `CardText("")` zero-value bypass at direct-construction sites.

### Review rounds 1–3 (`df8c836`, `10d8ee3`, `66880e9`)

- Round 1: deleted dead `Scan` / `Value` methods on `Bio`, `CardText`, `DisplayName`. The gorm row structs still hold `string` / `*string`, so the Scanner/Valuer were never invoked in production. Renamed `Bio.Value() *string` → `Bio.Ptr() *string` to free the `Value()` slot (originally claimed by `driver.Valuer`); kept the rename even after deletion as `Ptr()` reads more clearly. Replaced weak `BioFromPtr` defensive-copy test (variable rebind) with a pointer-identity `require.NotSame` assertion (see [`docs/backend/library-gotchas/defensive-copy-test-pointer-identity.md`](docs/backend/library-gotchas/defensive-copy-test-pointer-identity.md)). Refreshed `dnPtr`/`Bio.IsSet`/`User` docstrings; updated `docs/backend/ddd-patterns/trinary-value-object.md` for the rename.
- Round 2: deleted unwired `DisplayName.String()` (zero callers); kept `CardText.String()` (two callers in `usecase/card.go`). Tightened `BioFromPtr` docstring to read-context framing and the defensive-copy test to assert each `Ptr()` call returns a fresh pointer.
- Round 3: context-neutralized `Bio.Ptr()` and `Bio.IsSet()` docstrings so the patch-context and read-context interpretations are both surfaced (see [`docs/backend/ddd-patterns/context-neutral-vo-docstrings.md`](docs/backend/ddd-patterns/context-neutral-vo-docstrings.md)). Renamed two `bio_test.go` sub-tests to drop patch-context vocabulary. Fixed stale `Value()` reference in `.claude/rules/ddd-patterns.md`.

### Simplifier pass (`613d45e`)

- Inlined 7 single-use `dn := "Alice"` locals in `last_viewed_cardgroup_resolver_test.go` since `dnPtr(string)` no longer requires an addressable variable. Matches the pattern already established in three sibling files.

### Docs (`5b772ef`)

- Six new L3 chapters (4 DDD patterns + 2 library gotchas) capture Why/What learnings from this PR. Indexed from `.claude/rules/ddd-patterns.md` and `.claude/rules/go-library-gotchas.md`. Existing `helpers-introduced-but-not-wired-must-be-deleted.md` extended with a "per-symbol, keyed on wired-ness" section.

## Verification

```bash
cd backend
go build ./...
go vet ./...
go test -race -count=1 ./...                   # 1241 tests pass in 23 packages
go tool go-arch-lint check --project-path .

# Item A acceptance: AdminRoleName / GeneralRoleName are typed RoleName.
grep -nE 'AdminRoleName\s+RoleName|GeneralRoleName\s+RoleName' backend/internal/domain/role.go
# Expect: two matches.

# Item B acceptance: Card.Front / Card.Back are CardText in the aggregate.
grep -nE 'Front\s+CardText|Back\s+CardText' backend/internal/domain/card.go
# Expect: two matches.

# Item C acceptance: User.DisplayName is *DisplayName, User.Bio is Bio.
grep -nE 'DisplayName\s+\*DisplayName|Bio\s+Bio$' backend/internal/domain/user.go
# Expect: two matches.

# Phase 4 cleanup: sentinel fully purged.
grep -rn 'ErrCardCardgroupIDRequired' backend --include='*.go'
# Expect: empty output.

# Round 1 deletion: no Scanner/Valuer remains on the three VOs.
grep -rnE 'func \(.*(Bio|CardText|DisplayName)\) (Scan|Value)\(' backend/internal/domain/
# Expect: empty output.

# Round 2 deletion: DisplayName.String removed; CardText.String kept (two callers).
grep -rnE 'func \(.*DisplayName\) String\(' backend/internal/domain/
# Expect: empty output.
grep -rn 'CardText\) String()' backend/internal/domain/
# Expect: one match in card_text.go.

# Language-policy (per .claude/rules/language-policy.md): no CJK, no PR-order references.
grep -rlP "[\x{3040}-\x{30ff}\x{4e00}-\x{9fff}]" \
  --include="*.go" --include="*.ts" --include="*.tsx" \
  --include="*.graphql" --include="*.sql" --include="*.md" \
  docs backend/internal backend/cmd backend/graph frontend/src
grep -rnE "PR[0-9]+" docs backend/internal backend/cmd backend/graph frontend/src
# Expect: empty output for both.
```

Production diff is 91 / 57 across 15 `*.go` files, well under the 800-line ceiling in [`.claude/rules/pr-sizing.md`](.claude/rules/pr-sizing.md). Test diff: 168 / 122 across 25 `*_test.go` files. Docs diff: 721 / 9 across 10 Markdown files (6 new L3 chapters + 4 index/chapter updates). Total: 980 / 188.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race -count=1 ./...` — 1241 tests pass in 23 packages (testcontainers-backed Postgres integration tests included)
- [x] `go tool go-arch-lint check --project-path .`
- [x] Acceptance greps in Verification block all return zero hits (or the expected count) at branch tip
- [x] Per-phase build/vet/test green at each of the nine commits (incremental landing, not a single mega-commit)
- [x] `/pr-review-toolkit:review-pr` four-round loop converged at "READY TO MERGE" (no in-scope Critical / Important findings remain)
- [x] `/pr-review-toolkit:code-simplifier` pass landed (no production-code simplifications worth applying; one test-fixture inlining)
- [x] Six new L3 doc chapters indexed from the corresponding `.claude/rules/*.md` rule files

Closes #193
