### PR TITLE
feat(backend): implement OrderingPolicy with tie-shuffle and 1:4 interleave

### DIFF
--- a/.claude/rules/ddd-patterns.md
+++ b/.claude/rules/ddd-patterns.md
@@ -122,6 +122,28 @@ repository site stays unaware of the VO. Same shape for `CardUpdate.Front` /
 
 [`docs/backend/ddd-patterns/patch-dto-primitive-not-vo.md`](../../docs/backend/ddd-patterns/patch-dto-primitive-not-vo.md)
 
+### View-level value in the domain package
+
+`DueCard` is a non-aggregate struct that bundles `*Card` with the viewer's
+FSRS `State` and `Due` timestamp. It lives in `domain/` because
+`OrderingPolicy.Apply` (a domain service) consumes it. The placement rule:
+when a domain service is the consumer, keep the read-model value in `domain/`
+rather than introducing a sibling `readmodel/` package whose only purpose
+is to feed the service its own input.
+
+[`docs/backend/ddd-patterns/view-level-value-in-domain-package.md`](../../docs/backend/ddd-patterns/view-level-value-in-domain-package.md)
+
+### Caller-truncate contract for domain services
+
+`OrderingPolicy.Apply` returns all cards it processed; each caller
+(`LearnUsecase.NextDueCards`, `SwipeUsecase.HandleSwipe`) truncates to its own
+per-session limit immediately after. The contract is documented on the
+service signature; the truncate is mirrored at every call site so a future
+ordering policy that emits more rows than it received cannot exceed the
+caller's cap.
+
+[`docs/backend/ddd-patterns/caller-truncate-contract.md`](../../docs/backend/ddd-patterns/caller-truncate-contract.md)
+
 ## Further reading (on-demand)
 
 - [Value object Parse pattern](../../docs/backend/ddd-patterns/value-object-parse-pattern.md)
@@ -136,3 +158,5 @@ repository site stays unaware of the VO. Same shape for `CardUpdate.Front` /
 - [Same-underlying-type pointer cast for VO bridging](../../docs/backend/ddd-patterns/same-underlying-type-pointer-cast.md)
 - [Boundary gate replaces domain re-check](../../docs/backend/ddd-patterns/boundary-gate-replaces-domain-recheck.md)
 - [Patch DTOs keep primitive types, not the VO](../../docs/backend/ddd-patterns/patch-dto-primitive-not-vo.md)
+- [View-level value in the domain package](../../docs/backend/ddd-patterns/view-level-value-in-domain-package.md)
+- [Caller-truncate contract for domain services](../../docs/backend/ddd-patterns/caller-truncate-contract.md)

--- a/.claude/rules/go-library-gotchas.md
+++ b/.claude/rules/go-library-gotchas.md
@@ -114,6 +114,8 @@ This matters most in DataLoader batch functions, where an empty key slice is a n
 - [Dead context-done branch in pass-through helper — collapse to single return](../../docs/backend/library-gotchas/dead-context-check-in-pass-through-helper.md)
 - [GORM v1 round-trips underlying-string newtypes without Scanner/Valuer; reserving the `Value` accessor slot](../../docs/backend/library-gotchas/gorm-newtype-string-no-scanner-valuer.md)
 - [Defensive-copy tests assert pointer identity (`require.NotSame`), not variable rebind](../../docs/backend/library-gotchas/defensive-copy-test-pointer-identity.md)
+- [GORM embedded struct with `TableName()` silently breaks the outer scan target](../../docs/backend/library-gotchas/gorm-embedded-tablename-scan-confusion.md)
+- [Interleave trailing-append paths need a non-divisible fixture per direction](../../docs/backend/library-gotchas/interleave-trailing-append-test-fixture.md)
 
 ## DDD patterns (on-demand)
 

--- a/backend/graph/resolver/card_resolvers_test.go
+++ b/backend/graph/resolver/card_resolvers_test.go
@@ -26,7 +26,7 @@ import (
 type cardMockRepo struct {
 	deleteByIDsResult int64
 	deleteByIDsErr    error
-	findDueRows       []*domain.Card
+	findDueRows       []domain.DueCard
 	findDueErr        error
 	findDueLimit      int
 
@@ -43,7 +43,7 @@ func (m *cardMockRepo) FindByID(_ context.Context, _ string) (*domain.Card, erro
 func (m *cardMockRepo) FindByIDs(_ context.Context, _ []string) (map[string]*domain.Card, error) {
 	return nil, nil
 }
-func (m *cardMockRepo) FindDueCardsForUser(_ context.Context, _ string, _ string, _ time.Time, limit int) ([]*domain.Card, error) {
+func (m *cardMockRepo) FindDueCardsForUser(_ context.Context, _ string, _ string, _ time.Time, limit int) ([]domain.DueCard, error) {
 	m.findDueLimit = limit
 	return m.findDueRows, m.findDueErr
 }
@@ -212,14 +212,15 @@ func TestResolver_DeleteCards_Anonymous(t *testing.T) {
 func TestResolver_LearnNextDueCards_ReturnsDueCards(t *testing.T) {
 	t.Parallel()
 
+	c1 := &domain.Card{
+		ID:          "c1",
+		CardgroupID: "cg1",
+		Front:       "front",
+		Back:        "back",
+	}
 	cardRepo := &cardMockRepo{
-		findDueRows: []*domain.Card{
-			{
-				ID:          "c1",
-				CardgroupID: "cg1",
-				Front:       "front",
-				Back:        "back",
-			},
+		findDueRows: []domain.DueCard{
+			{Card: c1, State: domain.FSRSStateNew, Due: c1.CreatedAt},
 		},
 	}
 	srv := newLearnSrv(
@@ -265,7 +266,7 @@ func TestResolver_LearnNextDueCards_EmptyListIsNormal(t *testing.T) {
 	t.Parallel()
 
 	srv := newLearnSrv(
-		&cardMockRepo{findDueRows: []*domain.Card{}},
+		&cardMockRepo{findDueRows: []domain.DueCard{}},
 		&cardMockCGRepo{findResult: &domain.Cardgroup{ID: "cg1", OwnerID: "u1"}},
 	)
 

--- a/backend/graph/resolver/swipe_resolver_test.go
+++ b/backend/graph/resolver/swipe_resolver_test.go
@@ -25,7 +25,7 @@ import (
 type swipeCardRepo struct {
 	findByIDTxResult         *domain.Card
 	findByIDTxErr            error
-	findDueCardsForUserTxRes []*domain.Card
+	findDueCardsForUserTxRes []domain.DueCard
 	findDueCardsForUserTxErr error
 }
 
@@ -33,7 +33,7 @@ func (m *swipeCardRepo) FindByIDTx(_ context.Context, _ *gorm.DB, _ string) (*do
 	return m.findByIDTxResult, m.findByIDTxErr
 }
 
-func (m *swipeCardRepo) FindDueCardsForUserTx(_ context.Context, _ *gorm.DB, _, _ string, _ time.Time, _ int) ([]*domain.Card, error) {
+func (m *swipeCardRepo) FindDueCardsForUserTx(_ context.Context, _ *gorm.DB, _, _ string, _ time.Time, _ int) ([]domain.DueCard, error) {
 	return m.findDueCardsForUserTxRes, m.findDueCardsForUserTxErr
 }
 
@@ -160,8 +160,10 @@ func TestResolver_HandleSwipe_HappyPath(t *testing.T) {
 	nextCard := &domain.Card{ID: "c-2", CardgroupID: "cg-1", Front: "Q2", Back: "A2"}
 
 	cardRepo := &swipeCardRepo{
-		findByIDTxResult:         card,
-		findDueCardsForUserTxRes: []*domain.Card{nextCard},
+		findByIDTxResult: card,
+		findDueCardsForUserTxRes: []domain.DueCard{
+			{Card: nextCard, State: domain.FSRSStateNew, Due: nextCard.CreatedAt},
+		},
 	}
 	cgRepo := &swipeCGRepo{
 		findByIDResult: &domain.Cardgroup{ID: "cg-1", OwnerID: "u-1"},

--- a/backend/internal/domain/due_card.go
+++ b/backend/internal/domain/due_card.go
@@ -10,6 +10,11 @@ import "time"
 // DueCard is not an aggregate; it is a view-level value shared between the
 // repository and OrderingPolicy. It lives in the domain package because the
 // ordering policy is domain logic and DueCard is its input.
+//
+// Card must not be nil; downstream consumers (OrderingPolicy.Apply) dereference
+// it unconditionally. The State invariant (FSRSStateNew ↔ Due == Card.CreatedAt)
+// is established by the repository and is not enforced at the domain layer
+// today; new construction sites must reproduce it.
 type DueCard struct {
 	Card  *Card
 	State FSRSCardState

--- a/backend/internal/domain/due_card.go
+++ b/backend/internal/domain/due_card.go
@@ -1,0 +1,17 @@
+package domain
+
+import "time"
+
+// DueCard is a Card paired with the viewer's FSRS state for queueing decisions.
+//
+// State is FSRSStateNew when the viewer has no user_card_fsrs row for the card,
+// in which case Due is the card's created_at as a stable substitute.
+//
+// DueCard is not an aggregate; it is a view-level value shared between the
+// repository and OrderingPolicy. It lives in the domain package because the
+// ordering policy is domain logic and DueCard is its input.
+type DueCard struct {
+	Card  *Card
+	State FSRSCardState
+	Due   time.Time
+}

--- a/backend/internal/domain/service/due_card_ordering.go
+++ b/backend/internal/domain/service/due_card_ordering.go
@@ -1,14 +1,15 @@
 package service
 
 import (
+	"fmt"
 	"math/rand"
 
 	"backend/internal/domain"
 )
 
 // NewCardRatio and ReviewCardRatio define the new/review interleave ratio.
-// Today fixed at 1:4 (one new per four reviews) per the 2026-05 product
-// decision; revisit if data shows the queue ballooning or starving.
+// Fixed at 1:4 (one new per four reviews). Revisit if session queues
+// consistently balloon (too few news) or starve (too few reviews).
 const (
 	NewCardRatio    = 1
 	ReviewCardRatio = 4
@@ -32,14 +33,19 @@ func NewOrderingPolicy() *OrderingPolicy { return &OrderingPolicy{} }
 //     cards from the other bucket are appended in their post-shuffle order.
 //
 // The caller is responsible for truncating to a per-session limit. Apply
-// returns every Card supplied in due so the caller can decide whether to
-// keep more than the originally requested limit for tomorrow's queue.
+// returns all cards from due without imposing a length cap; the input slice
+// is not modified, as partition produces fresh slices before shuffling.
 //
 // rng must be non-nil. Tests inject a seeded *rand.Rand for deterministic
 // order; production constructs one per session.
 func (p *OrderingPolicy) Apply(due []domain.DueCard, rng *rand.Rand) []*domain.Card {
 	if rng == nil {
 		panic("domain/service: OrderingPolicy.Apply requires non-nil rng")
+	}
+	for _, d := range due {
+		if d.Card == nil {
+			panic("domain/service: OrderingPolicy.Apply: DueCard.Card must not be nil")
+		}
 	}
 	newCards, reviewCards := partition(due)
 	shuffleSameDue(newCards, rng)
@@ -65,6 +71,8 @@ func partition(due []domain.DueCard) (newC, reviewC []domain.DueCard) {
 // Single-card runs are untouched.
 func shuffleSameDue(cards []domain.DueCard, rng *rand.Rand) {
 	start := 0
+	// Loop runs through len(cards) inclusive so the trailing run is flushed
+	// without a tail handler.
 	for i := 1; i <= len(cards); i++ {
 		if i == len(cards) || !cards[i].Due.Equal(cards[start].Due) {
 			if i-start > 1 {
@@ -80,6 +88,9 @@ func shuffleSameDue(cards []domain.DueCard, rng *rand.Rand) {
 // one bucket empties, then appends the remaining bucket in its current order.
 // Returns the flattened []*Card extracted from DueCard.Card.
 func interleave(newC, reviewC []domain.DueCard, nRatio, rRatio int) []*domain.Card {
+	if nRatio <= 0 || rRatio <= 0 {
+		panic(fmt.Sprintf("domain/service: interleave requires positive ratios, got nRatio=%d rRatio=%d", nRatio, rRatio))
+	}
 	out := make([]*domain.Card, 0, len(newC)+len(reviewC))
 	i, j := 0, 0
 	for i < len(newC) && j < len(reviewC) {

--- a/backend/internal/domain/service/due_card_ordering.go
+++ b/backend/internal/domain/service/due_card_ordering.go
@@ -6,13 +6,97 @@ import (
 	"backend/internal/domain"
 )
 
-// OrderingPolicy preserves repository ordering for the learning queue.
-// Per-user due ordering now lives in SQL so the domain Card does not carry
-// viewer-specific FSRS state. Apply is pure: it never mutates the input slice.
+// NewCardRatio and ReviewCardRatio define the new/review interleave ratio.
+// Today fixed at 1:4 (one new per four reviews) per the 2026-05 product
+// decision; revisit if data shows the queue ballooning or starving.
+const (
+	NewCardRatio    = 1
+	ReviewCardRatio = 4
+)
+
+// OrderingPolicy applies session-local ordering to due cards.
+//
+// The zero value is ready to use; the constructor is provided for symmetry
+// with other domain services.
 type OrderingPolicy struct{}
 
 func NewOrderingPolicy() *OrderingPolicy { return &OrderingPolicy{} }
 
-func (p *OrderingPolicy) Apply(cards []*domain.Card, _ *rand.Rand) []*domain.Card {
-	return append([]*domain.Card(nil), cards...)
+// Apply orders due cards with a two-step policy:
+//
+//  1. Within each partition (new / review), cards sharing the same Due
+//     timestamp are shuffled using rng so consecutive sessions do not see
+//     the same first-N order.
+//  2. New and review cards are interleaved at NewCardRatio:ReviewCardRatio
+//     with review-first emission. When one bucket empties, the remaining
+//     cards from the other bucket are appended in their post-shuffle order.
+//
+// The caller is responsible for truncating to a per-session limit. Apply
+// returns every Card supplied in due so the caller can decide whether to
+// keep more than the originally requested limit for tomorrow's queue.
+//
+// rng must be non-nil. Tests inject a seeded *rand.Rand for deterministic
+// order; production constructs one per session.
+func (p *OrderingPolicy) Apply(due []domain.DueCard, rng *rand.Rand) []*domain.Card {
+	if rng == nil {
+		panic("domain/service: OrderingPolicy.Apply requires non-nil rng")
+	}
+	newCards, reviewCards := partition(due)
+	shuffleSameDue(newCards, rng)
+	shuffleSameDue(reviewCards, rng)
+	return interleave(newCards, reviewCards, NewCardRatio, ReviewCardRatio)
+}
+
+// partition splits due into new (FSRSStateNew) vs review (everything else),
+// preserving the input order. The repository pre-sorts by Due ASC, id ASC.
+func partition(due []domain.DueCard) (newC, reviewC []domain.DueCard) {
+	for _, d := range due {
+		if d.State == domain.FSRSStateNew {
+			newC = append(newC, d)
+		} else {
+			reviewC = append(reviewC, d)
+		}
+	}
+	return
+}
+
+// shuffleSameDue shuffles contiguous same-Due runs in place using rng.
+// Inputs are pre-sorted by Due ASC so a single linear pass detects each run.
+// Single-card runs are untouched.
+func shuffleSameDue(cards []domain.DueCard, rng *rand.Rand) {
+	start := 0
+	for i := 1; i <= len(cards); i++ {
+		if i == len(cards) || !cards[i].Due.Equal(cards[start].Due) {
+			if i-start > 1 {
+				run := cards[start:i]
+				rng.Shuffle(len(run), func(a, b int) { run[a], run[b] = run[b], run[a] })
+			}
+			start = i
+		}
+	}
+}
+
+// interleave emits rRatio review cards then nRatio new cards in a loop until
+// one bucket empties, then appends the remaining bucket in its current order.
+// Returns the flattened []*Card extracted from DueCard.Card.
+func interleave(newC, reviewC []domain.DueCard, nRatio, rRatio int) []*domain.Card {
+	out := make([]*domain.Card, 0, len(newC)+len(reviewC))
+	i, j := 0, 0
+	for i < len(newC) && j < len(reviewC) {
+		for k := 0; k < rRatio && j < len(reviewC); k++ {
+			out = append(out, reviewC[j].Card)
+			j++
+		}
+		for k := 0; k < nRatio && i < len(newC); k++ {
+			out = append(out, newC[i].Card)
+			i++
+		}
+	}
+	for ; j < len(reviewC); j++ {
+		out = append(out, reviewC[j].Card)
+	}
+	for ; i < len(newC); i++ {
+		out = append(out, newC[i].Card)
+	}
+	return out
 }

--- a/backend/internal/domain/service/due_card_ordering_test.go
+++ b/backend/internal/domain/service/due_card_ordering_test.go
@@ -180,24 +180,19 @@ func TestOrderingPolicy_Apply_PanicsOnNilRng(t *testing.T) {
 	)
 }
 
-// TestOrderingPolicy_Apply_MixedInterleaveRatio_TrailingAppend exercises the
-// trailing-append paths in interleave when the review bucket exhausts before the
-// new bucket (2 new + 7 review). All Due timestamps are distinct so shuffleSameDue
-// is a no-op and the output order is fully deterministic.
+// TestOrderingPolicy_Apply_TrailingReviewAppend exercises the trailing-review
+// append path in interleave. Fixture: 1 new + 7 review, all with distinct Due
+// timestamps so shuffleSameDue is a no-op.
 //
-// With ReviewCardRatio=4 and NewCardRatio=1 the loop produces:
-//
-//	rev-0, rev-1, rev-2, rev-3, new-0  (first cycle)
-//	rev-4, rev-5, rev-6, new-1          (second cycle: only 3 reviews remain)
-//
-// That exhausts the review bucket mid-cycle before the new bucket empties, so
-// the trailing `for ; i < len(newC); i++` path appends new-1 and the remaining
-// review tail is emitted by `for ; j < len(reviewC); j++`.
-func TestOrderingPolicy_Apply_MixedInterleaveRatio_TrailingAppend(t *testing.T) {
+// With ReviewCardRatio=4 and NewCardRatio=1 the outer loop runs one full cycle:
+// emit rev-0..rev-3 then new-0. After that cycle i=1 == len(newC)=1, so the
+// outer loop exits. The trailing-review append path ("for ; j < len(reviewC)")
+// then appends rev-4, rev-5, rev-6.
+func TestOrderingPolicy_Apply_TrailingReviewAppend(t *testing.T) {
 	t.Parallel()
 
 	base := time.Date(2026, 5, 20, 9, 0, 0, 0, time.UTC)
-	in := make([]domain.DueCard, 0, 9)
+	in := make([]domain.DueCard, 0, 8)
 	for i := 0; i < 7; i++ {
 		in = append(in, dueCard(
 			fmt.Sprintf("rev-%d", i),
@@ -205,7 +200,45 @@ func TestOrderingPolicy_Apply_MixedInterleaveRatio_TrailingAppend(t *testing.T) 
 			base.Add(time.Duration(i)*time.Minute),
 		))
 	}
-	for i := 0; i < 2; i++ {
+	in = append(in, dueCard(
+		"new-0",
+		domain.FSRSStateNew,
+		base.Add(100*time.Minute),
+	))
+
+	got := NewOrderingPolicy().Apply(in, rand.New(rand.NewSource(42)))
+
+	// One full cycle emits rev-0..rev-3 + new-0; new bucket exhausts and the
+	// trailing-review append path emits rev-4, rev-5, rev-6.
+	want := []string{
+		"rev-0", "rev-1", "rev-2", "rev-3", "new-0",
+		"rev-4", "rev-5", "rev-6",
+	}
+	require.Len(t, got, 8)
+	require.Equal(t, want, cardIDs(got))
+}
+
+// TestOrderingPolicy_Apply_TrailingNewAppend exercises the trailing-new append
+// path in interleave. Fixture: 5 new + 3 review, all with distinct Due
+// timestamps so shuffleSameDue is a no-op.
+//
+// With ReviewCardRatio=4 and NewCardRatio=1 the k-loop guard "j < len(reviewC)"
+// exits after emitting rev-0, rev-1, rev-2 (only 3 reviews exist), then new-0
+// is emitted. After that j=3 == len(reviewC)=3, so the outer loop exits. The
+// trailing-new append path ("for ; i < len(newC)") then appends new-1..new-4.
+func TestOrderingPolicy_Apply_TrailingNewAppend(t *testing.T) {
+	t.Parallel()
+
+	base := time.Date(2026, 5, 20, 9, 0, 0, 0, time.UTC)
+	in := make([]domain.DueCard, 0, 8)
+	for i := 0; i < 3; i++ {
+		in = append(in, dueCard(
+			fmt.Sprintf("rev-%d", i),
+			domain.FSRSStateReview,
+			base.Add(time.Duration(i)*time.Minute),
+		))
+	}
+	for i := 0; i < 5; i++ {
 		in = append(in, dueCard(
 			fmt.Sprintf("new-%d", i),
 			domain.FSRSStateNew,
@@ -215,14 +248,15 @@ func TestOrderingPolicy_Apply_MixedInterleaveRatio_TrailingAppend(t *testing.T) 
 
 	got := NewOrderingPolicy().Apply(in, rand.New(rand.NewSource(42)))
 
-	// Probed output from the interleave algorithm with the above input.
-	// rev-0..rev-3 + new-0 (first full cycle), then rev-4..rev-6 + new-1
-	// (second cycle where review exhausts after 3, then new-1 trails).
+	// The k-loop emits rev-0, rev-1, rev-2 then exits early (review bucket
+	// exhausted inside the k-loop guard); new-0 is emitted next. The review
+	// bucket is now empty so the outer loop exits. The trailing-new append
+	// path emits new-1, new-2, new-3, new-4.
 	want := []string{
-		"rev-0", "rev-1", "rev-2", "rev-3", "new-0",
-		"rev-4", "rev-5", "rev-6", "new-1",
+		"rev-0", "rev-1", "rev-2", "new-0",
+		"new-1", "new-2", "new-3", "new-4",
 	}
-	require.Len(t, got, 9)
+	require.Len(t, got, 8)
 	require.Equal(t, want, cardIDs(got))
 }
 

--- a/backend/internal/domain/service/due_card_ordering_test.go
+++ b/backend/internal/domain/service/due_card_ordering_test.go
@@ -121,8 +121,7 @@ func TestOrderingPolicy_Apply_SameDueShuffled(t *testing.T) {
 
 	// All four cards share the same Due, so shuffleSameDue MUST permute the
 	// run. With rand.NewSource(42), four identical-Due cards [a, b, c, d]
-	// shuffle to [c, d, a, b] — see the comment in the file documenting the
-	// seed.
+	// shuffle to [c, d, a, b].
 	due := time.Date(2026, 5, 20, 9, 0, 0, 0, time.UTC)
 	in := []domain.DueCard{
 		dueCard("a", domain.FSRSStateReview, due),
@@ -179,4 +178,97 @@ func TestOrderingPolicy_Apply_PanicsOnNilRng(t *testing.T) {
 			_ = NewOrderingPolicy().Apply(nil, nil)
 		},
 	)
+}
+
+// TestOrderingPolicy_Apply_MixedInterleaveRatio_TrailingAppend exercises the
+// trailing-append paths in interleave when the review bucket exhausts before the
+// new bucket (2 new + 7 review). All Due timestamps are distinct so shuffleSameDue
+// is a no-op and the output order is fully deterministic.
+//
+// With ReviewCardRatio=4 and NewCardRatio=1 the loop produces:
+//
+//	rev-0, rev-1, rev-2, rev-3, new-0  (first cycle)
+//	rev-4, rev-5, rev-6, new-1          (second cycle: only 3 reviews remain)
+//
+// That exhausts the review bucket mid-cycle before the new bucket empties, so
+// the trailing `for ; i < len(newC); i++` path appends new-1 and the remaining
+// review tail is emitted by `for ; j < len(reviewC); j++`.
+func TestOrderingPolicy_Apply_MixedInterleaveRatio_TrailingAppend(t *testing.T) {
+	t.Parallel()
+
+	base := time.Date(2026, 5, 20, 9, 0, 0, 0, time.UTC)
+	in := make([]domain.DueCard, 0, 9)
+	for i := 0; i < 7; i++ {
+		in = append(in, dueCard(
+			fmt.Sprintf("rev-%d", i),
+			domain.FSRSStateReview,
+			base.Add(time.Duration(i)*time.Minute),
+		))
+	}
+	for i := 0; i < 2; i++ {
+		in = append(in, dueCard(
+			fmt.Sprintf("new-%d", i),
+			domain.FSRSStateNew,
+			base.Add(time.Duration(100+i)*time.Minute),
+		))
+	}
+
+	got := NewOrderingPolicy().Apply(in, rand.New(rand.NewSource(42)))
+
+	// Probed output from the interleave algorithm with the above input.
+	// rev-0..rev-3 + new-0 (first full cycle), then rev-4..rev-6 + new-1
+	// (second cycle where review exhausts after 3, then new-1 trails).
+	want := []string{
+		"rev-0", "rev-1", "rev-2", "rev-3", "new-0",
+		"rev-4", "rev-5", "rev-6", "new-1",
+	}
+	require.Len(t, got, 9)
+	require.Equal(t, want, cardIDs(got))
+}
+
+// TestOrderingPolicy_Apply_MultipleSameDueRuns verifies that two disjoint
+// same-Due runs are each shuffled independently and that run-1 (earlier Due)
+// is emitted entirely before run-2 (later Due).
+//
+// Fixture: run-1 has two review cards at T1; run-2 has two review cards at T2
+// where T1 < T2. With rand.NewSource(42) the shuffle produces a deterministic
+// permutation within each run; the inter-run order is unchanged (T1 before T2).
+func TestOrderingPolicy_Apply_MultipleSameDueRuns(t *testing.T) {
+	t.Parallel()
+
+	T1 := time.Date(2026, 5, 20, 9, 0, 0, 0, time.UTC)
+	T2 := T1.Add(time.Hour)
+
+	in := []domain.DueCard{
+		dueCard("r1a", domain.FSRSStateReview, T1),
+		dueCard("r1b", domain.FSRSStateReview, T1),
+		dueCard("r2a", domain.FSRSStateReview, T2),
+		dueCard("r2b", domain.FSRSStateReview, T2),
+	}
+
+	got := NewOrderingPolicy().Apply(in, rand.New(rand.NewSource(42)))
+	ids := cardIDs(got)
+
+	require.Len(t, ids, 4)
+
+	// Both run-1 cards appear before both run-2 cards (inter-run order preserved).
+	run1Set := map[string]bool{"r1a": true, "r1b": true}
+	run2Set := map[string]bool{"r2a": true, "r2b": true}
+	lastRun1Idx := -1
+	firstRun2Idx := len(ids)
+	for i, id := range ids {
+		if run1Set[id] {
+			lastRun1Idx = i
+		}
+		if run2Set[id] && i < firstRun2Idx {
+			firstRun2Idx = i
+		}
+	}
+	require.Less(t, lastRun1Idx, firstRun2Idx,
+		"all run-1 cards must appear before all run-2 cards")
+
+	// With rand.NewSource(42) each 2-card run is shuffled deterministically.
+	// Probed result: run-1 permutes to [r1b, r1a]; run-2 permutes to [r2b, r2a].
+	require.Equal(t, []string{"r1b", "r1a", "r2b", "r2a"}, ids,
+		"deterministic shuffle order for seed 42")
 }

--- a/backend/internal/domain/service/due_card_ordering_test.go
+++ b/backend/internal/domain/service/due_card_ordering_test.go
@@ -1,48 +1,22 @@
 package service
 
 import (
+	"fmt"
 	"math/rand"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
 	"backend/internal/domain"
 )
 
-func TestOrderingPolicyApplyPreservesRepositoryOrder(t *testing.T) {
-	t.Parallel()
-
-	cards := []*domain.Card{
-		testOrderingCard("repo-first"),
-		testOrderingCard("repo-second"),
-		testOrderingCard("repo-third"),
-	}
-	before := append([]*domain.Card(nil), cards...)
-
-	got := NewOrderingPolicy().Apply(cards, rand.New(rand.NewSource(42)))
-
-	require.Equal(t, []string{"repo-first", "repo-second", "repo-third"}, cardIDs(got))
-	require.Equal(t, before, cards, "Apply must not mutate the input slice")
-}
-
-func TestOrderingPolicyApplyReturnsIndependentSlice(t *testing.T) {
-	t.Parallel()
-
-	cards := []*domain.Card{
-		testOrderingCard("a"),
-		testOrderingCard("b"),
-	}
-
-	got := NewOrderingPolicy().Apply(cards, nil)
-	got[0], got[1] = got[1], got[0]
-
-	require.Equal(t, []string{"a", "b"}, cardIDs(cards))
-	require.Equal(t, []string{"b", "a"}, cardIDs(got))
-}
-
-func testOrderingCard(id string) *domain.Card {
-	return &domain.Card{
-		ID: id,
+// dueCard builds a DueCard fixture with a Card carrying the given ID.
+func dueCard(id string, state domain.FSRSCardState, due time.Time) domain.DueCard {
+	return domain.DueCard{
+		Card:  &domain.Card{ID: id},
+		State: state,
+		Due:   due,
 	}
 }
 
@@ -52,4 +26,157 @@ func cardIDs(cards []*domain.Card) []string {
 		out[i] = card.ID
 	}
 	return out
+}
+
+func TestOrderingPolicy_Apply_Empty(t *testing.T) {
+	t.Parallel()
+
+	got := NewOrderingPolicy().Apply(nil, rand.New(rand.NewSource(42)))
+	require.Empty(t, got)
+
+	got = NewOrderingPolicy().Apply([]domain.DueCard{}, rand.New(rand.NewSource(42)))
+	require.Empty(t, got)
+}
+
+func TestOrderingPolicy_Apply_OnlyNew(t *testing.T) {
+	t.Parallel()
+
+	// All distinct Due timestamps so shuffleSameDue is a no-op and the
+	// post-partition order is identical to the input order.
+	base := time.Date(2026, 5, 20, 9, 0, 0, 0, time.UTC)
+	in := []domain.DueCard{
+		dueCard("n1", domain.FSRSStateNew, base),
+		dueCard("n2", domain.FSRSStateNew, base.Add(time.Minute)),
+		dueCard("n3", domain.FSRSStateNew, base.Add(2*time.Minute)),
+	}
+
+	got := NewOrderingPolicy().Apply(in, rand.New(rand.NewSource(42)))
+
+	require.Equal(t, []string{"n1", "n2", "n3"}, cardIDs(got))
+}
+
+func TestOrderingPolicy_Apply_OnlyReview(t *testing.T) {
+	t.Parallel()
+
+	base := time.Date(2026, 5, 20, 9, 0, 0, 0, time.UTC)
+	in := []domain.DueCard{
+		dueCard("r1", domain.FSRSStateReview, base),
+		dueCard("r2", domain.FSRSStateLearning, base.Add(time.Minute)),
+		dueCard("r3", domain.FSRSStateRelearning, base.Add(2*time.Minute)),
+	}
+
+	got := NewOrderingPolicy().Apply(in, rand.New(rand.NewSource(42)))
+
+	require.Equal(t, []string{"r1", "r2", "r3"}, cardIDs(got))
+}
+
+func TestOrderingPolicy_Apply_MixedInterleaveRatio(t *testing.T) {
+	t.Parallel()
+
+	// 5 new + 20 review, all with distinct Due timestamps so the shuffle
+	// step is a no-op and we can assert the deterministic interleave order.
+	// Expected pattern: review-first, ReviewCardRatio (4) reviews then
+	// NewCardRatio (1) new, repeating until both buckets empty.
+	base := time.Date(2026, 5, 20, 9, 0, 0, 0, time.UTC)
+	in := make([]domain.DueCard, 0, 25)
+	for i := 0; i < 20; i++ {
+		in = append(in, dueCard(
+			fmt.Sprintf("rev-%d", i),
+			domain.FSRSStateReview,
+			base.Add(time.Duration(i)*time.Minute),
+		))
+	}
+	for i := 0; i < 5; i++ {
+		in = append(in, dueCard(
+			fmt.Sprintf("new-%d", i),
+			domain.FSRSStateNew,
+			base.Add(time.Duration(100+i)*time.Minute),
+		))
+	}
+
+	got := NewOrderingPolicy().Apply(in, rand.New(rand.NewSource(42)))
+
+	require.Len(t, got, 25)
+
+	// Assert first 10 cards exactly: 4 reviews, 1 new, 4 reviews, 1 new.
+	wantFirst10 := []string{
+		"rev-0", "rev-1", "rev-2", "rev-3", "new-0",
+		"rev-4", "rev-5", "rev-6", "rev-7", "new-1",
+	}
+	require.Equal(t, wantFirst10, cardIDs(got)[:10])
+
+	// Full expected order documents the policy end-to-end:
+	wantAll := []string{
+		"rev-0", "rev-1", "rev-2", "rev-3", "new-0",
+		"rev-4", "rev-5", "rev-6", "rev-7", "new-1",
+		"rev-8", "rev-9", "rev-10", "rev-11", "new-2",
+		"rev-12", "rev-13", "rev-14", "rev-15", "new-3",
+		"rev-16", "rev-17", "rev-18", "rev-19", "new-4",
+	}
+	require.Equal(t, wantAll, cardIDs(got))
+}
+
+func TestOrderingPolicy_Apply_SameDueShuffled(t *testing.T) {
+	t.Parallel()
+
+	// All four cards share the same Due, so shuffleSameDue MUST permute the
+	// run. With rand.NewSource(42), four identical-Due cards [a, b, c, d]
+	// shuffle to [c, d, a, b] — see the comment in the file documenting the
+	// seed.
+	due := time.Date(2026, 5, 20, 9, 0, 0, 0, time.UTC)
+	in := []domain.DueCard{
+		dueCard("a", domain.FSRSStateReview, due),
+		dueCard("b", domain.FSRSStateReview, due),
+		dueCard("c", domain.FSRSStateReview, due),
+		dueCard("d", domain.FSRSStateReview, due),
+	}
+
+	got := NewOrderingPolicy().Apply(in, rand.New(rand.NewSource(42)))
+
+	gotIDs := cardIDs(got)
+	require.Len(t, gotIDs, 4)
+	require.NotEqual(t, []string{"a", "b", "c", "d"}, gotIDs,
+		"same-Due run must be shuffled, not left in input order")
+	require.Equal(t, []string{"c", "d", "a", "b"}, gotIDs,
+		"deterministic shuffle order for seed 42")
+}
+
+func TestOrderingPolicy_Apply_SetEquality(t *testing.T) {
+	t.Parallel()
+
+	base := time.Date(2026, 5, 20, 9, 0, 0, 0, time.UTC)
+	in := []domain.DueCard{
+		dueCard("n1", domain.FSRSStateNew, base),
+		dueCard("n2", domain.FSRSStateNew, base.Add(time.Minute)),
+		dueCard("r1", domain.FSRSStateReview, base),
+		dueCard("r2", domain.FSRSStateReview, base),
+		dueCard("r3", domain.FSRSStateLearning, base.Add(2*time.Minute)),
+		dueCard("r4", domain.FSRSStateRelearning, base.Add(3*time.Minute)),
+	}
+
+	got := NewOrderingPolicy().Apply(in, rand.New(rand.NewSource(42)))
+
+	require.Len(t, got, len(in), "no cards dropped or duplicated")
+
+	wantPtrs := make(map[*domain.Card]struct{}, len(in))
+	for _, d := range in {
+		wantPtrs[d.Card] = struct{}{}
+	}
+	gotPtrs := make(map[*domain.Card]struct{}, len(got))
+	for _, c := range got {
+		gotPtrs[c] = struct{}{}
+	}
+	require.Equal(t, wantPtrs, gotPtrs,
+		"output Card pointer set must equal input Card pointer set")
+}
+
+func TestOrderingPolicy_Apply_PanicsOnNilRng(t *testing.T) {
+	t.Parallel()
+
+	require.PanicsWithValue(t,
+		"domain/service: OrderingPolicy.Apply requires non-nil rng",
+		func() {
+			_ = NewOrderingPolicy().Apply(nil, nil)
+		},
+	)
 }

--- a/backend/internal/repository/card.go
+++ b/backend/internal/repository/card.go
@@ -98,8 +98,8 @@ type CardPageRepository interface {
 		dir SortOrder,
 		search *string,
 	) (cards []*domain.Card, totalCount int64, err error)
-	FindDueCardsForUser(ctx context.Context, userID, cardgroupID string, now time.Time, limit int) ([]*domain.Card, error)
-	FindDueCardsForUserTx(ctx context.Context, tx *gorm.DB, userID, cardgroupID string, now time.Time, limit int) ([]*domain.Card, error)
+	FindDueCardsForUser(ctx context.Context, userID, cardgroupID string, now time.Time, limit int) ([]domain.DueCard, error)
+	FindDueCardsForUserTx(ctx context.Context, tx *gorm.DB, userID, cardgroupID string, now time.Time, limit int) ([]domain.DueCard, error)
 }
 
 type CardWriteRepository interface {
@@ -364,33 +364,68 @@ func cursorFieldValue(orderBy CardOrderBy, c *CardCursor) (any, error) {
 	return nil, eris.Errorf("cursor missing %s column", orderBy)
 }
 
-func (r *cardRepo) FindDueCardsForUser(ctx context.Context, userID, cardgroupID string, now time.Time, limit int) ([]*domain.Card, error) {
+func (r *cardRepo) FindDueCardsForUser(ctx context.Context, userID, cardgroupID string, now time.Time, limit int) ([]domain.DueCard, error) {
 	return findDueCardsOn(r.db.WithContext(ctx), userID, cardgroupID, now, limit)
 }
 
-func (r *cardRepo) FindDueCardsForUserTx(ctx context.Context, tx *gorm.DB, userID, cardgroupID string, now time.Time, limit int) ([]*domain.Card, error) {
+func (r *cardRepo) FindDueCardsForUserTx(ctx context.Context, tx *gorm.DB, userID, cardgroupID string, now time.Time, limit int) ([]domain.DueCard, error) {
 	return findDueCardsOn(tx.WithContext(ctx), userID, cardgroupID, now, limit)
 }
 
-func findDueCardsOn(db *gorm.DB, userID, cardgroupID string, now time.Time, limit int) ([]*domain.Card, error) {
+// dueCardRow is the raw scan target for findDueCardsOn. It holds all cards.*
+// columns as flat fields plus nullable FSRS columns from the LEFT JOIN.
+// Embedding gormCard is intentionally avoided: gormCard carries a TableName()
+// method that confuses GORM's embedded-struct schema parser when the outer
+// scan target is a different type.
+type dueCardRow struct {
+	ID          string     `gorm:"column:id"`
+	CardgroupID string     `gorm:"column:cardgroup_id"`
+	Front       string     `gorm:"column:front"`
+	Back        string     `gorm:"column:back"`
+	CreatedAt   time.Time  `gorm:"column:created_at"`
+	UpdatedAt   time.Time  `gorm:"column:updated_at"`
+	State       *int       `gorm:"column:state"`
+	Due         *time.Time `gorm:"column:due"`
+}
+
+func findDueCardsOn(db *gorm.DB, userID, cardgroupID string, now time.Time, limit int) ([]domain.DueCard, error) {
 	userID = coalesceUserIDForJoin(userID)
 	if limit <= 0 {
-		return []*domain.Card{}, nil
+		return []domain.DueCard{}, nil
 	}
-	var rows []gormCard
+	var rows []dueCardRow
 	if err := db.
-		Model(&gormCard{}).
-		Select("cards.*").
+		Table("cards").
+		Select("cards.id, cards.cardgroup_id, cards.front, cards.back, cards.created_at, cards.updated_at, ucs.state, ucs.due").
 		Joins("LEFT JOIN user_card_fsrs ucs ON ucs.user_id = ? AND ucs.card_id = cards.id", userID).
 		Where("cards.cardgroup_id = ? AND (ucs.due IS NULL OR ucs.due <= ?)", cardgroupID, now).
 		Order("COALESCE(ucs.due, cards.created_at) ASC, cards.id ASC").
 		Limit(limit).
 		Find(&rows).Error; err != nil {
-		return nil, eris.Wrap(err, "repository: find due cards")
+		return nil, eris.Wrap(err, "repository: card: find due cards")
 	}
-	out := make([]*domain.Card, len(rows))
-	for i := range rows {
-		out[i] = cardToDomain(rows[i])
+	out := make([]domain.DueCard, len(rows))
+	for i, r := range rows {
+		c := &domain.Card{
+			ID:          r.ID,
+			CardgroupID: r.CardgroupID,
+			Front:       domain.CardText(r.Front),
+			Back:        domain.CardText(r.Back),
+			CreatedAt:   r.CreatedAt,
+			UpdatedAt:   r.UpdatedAt,
+		}
+		dc := domain.DueCard{Card: c, State: domain.FSRSStateNew, Due: r.CreatedAt}
+		if r.State != nil {
+			s := domain.FSRSCardState(*r.State)
+			if !s.IsValid() {
+				return nil, eris.Errorf("repository: card: invalid FSRSCardState %d", *r.State)
+			}
+			dc.State = s
+		}
+		if r.Due != nil {
+			dc.Due = *r.Due
+		}
+		out[i] = dc
 	}
 	return out, nil
 }

--- a/backend/internal/repository/card_test.go
+++ b/backend/internal/repository/card_test.go
@@ -364,7 +364,7 @@ func TestCardRepository_FindDueCards_InvalidState(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = repo.FindDueCardsForUser(ctx, ownerID, cg.ID, now, 10)
-	require.Error(t, err, "expected error for invalid FSRSCardState 99")
+	require.ErrorContains(t, err, "repository: card: invalid FSRSCardState 99")
 }
 
 func TestCardRepo_Create_DuplicateFront(t *testing.T) {

--- a/backend/internal/repository/card_test.go
+++ b/backend/internal/repository/card_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func newCard(cardgroupID, front, back string) *domain.Card {
-	now := time.Now().UTC()
+	now := time.Now().UTC().Truncate(time.Microsecond)
 	return &domain.Card{
 		ID:          uuid.NewString(),
 		CardgroupID: cardgroupID,

--- a/backend/internal/repository/card_test.go
+++ b/backend/internal/repository/card_test.go
@@ -199,7 +199,7 @@ func TestCardRepository_FindDueCardsTx_OrderedAndScoped(t *testing.T) {
 		return nil
 	}))
 
-	var due []*domain.Card
+	var due []domain.DueCard
 	err := testDB.GORM.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		var err error
 		due, err = repo.FindDueCardsForUserTx(ctx, tx, ownerID, cg1.ID, now, 10)
@@ -207,8 +207,8 @@ func TestCardRepository_FindDueCardsTx_OrderedAndScoped(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Len(t, due, 2)
-	require.Equal(t, earlier.ID, due[0].ID)
-	require.Equal(t, later.ID, due[1].ID)
+	require.Equal(t, earlier.ID, due[0].Card.ID)
+	require.Equal(t, later.ID, due[1].Card.ID)
 }
 
 func TestCardRepository_FindDueCards_OrderedScopedAndLimited(t *testing.T) {
@@ -260,6 +260,113 @@ func TestCardRepository_FindDueCards_OrderedScopedAndLimited(t *testing.T) {
 	require.Empty(t, empty)
 }
 
+// TestCardRepository_FindDueCards_NoFSRSRow verifies that a card with no
+// user_card_fsrs row is returned with State == FSRSStateNew and Due ==
+// card.CreatedAt (the stable fallback).
+func TestCardRepository_FindDueCards_NoFSRSRow(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	ownerID := insertAuthUser(t, ctx)
+	cg := insertCardgroup(t, ctx, ownerID)
+	repo := repository.NewCardRepository(testDB.GORM)
+	now := time.Now().UTC().Add(time.Hour) // far future so the card is "due"
+
+	card := newCard(cg.ID, "no-fsrs", "back")
+	require.NoError(t, repo.Create(ctx, card))
+
+	got, err := repo.FindDueCardsForUser(ctx, ownerID, cg.ID, now, 10)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	require.Equal(t, card.ID, got[0].Card.ID)
+	require.Equal(t, domain.FSRSStateNew, got[0].State)
+	require.True(t, got[0].Due.Equal(card.CreatedAt), "Due should fall back to card.CreatedAt when no FSRS row exists")
+}
+
+// TestCardRepository_FindDueCards_FSRSStateMapping verifies that existing
+// FSRS rows with Learning, Review, and Relearning states are mapped correctly
+// to the corresponding domain.FSRSCardState values.
+func TestCardRepository_FindDueCards_FSRSStateMapping(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	ownerID := insertAuthUser(t, ctx)
+	cg := insertCardgroup(t, ctx, ownerID)
+	repo := repository.NewCardRepository(testDB.GORM)
+	ucsRepo := repository.NewUserCardFSRSRepository(testDB.GORM)
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	cases := []struct {
+		front string
+		state domain.FSRSCardState
+	}{
+		{"learning-card", domain.FSRSStateLearning},
+		{"review-card", domain.FSRSStateReview},
+		{"relearning-card", domain.FSRSStateRelearning},
+	}
+
+	cards := make([]*domain.Card, len(cases))
+	for i, tc := range cases {
+		c := newCard(cg.ID, tc.front, "back")
+		require.NoError(t, repo.Create(ctx, c))
+		cards[i] = c
+	}
+
+	require.NoError(t, testDB.GORM.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		for i, tc := range cases {
+			ucs := domain.NewUserCardFSRSForNewCard(ownerID, cards[i].ID, now)
+			ucs.State.State = tc.state
+			ucs.State.Due = now.Add(-time.Minute) // ensure it is due
+			if err := ucsRepo.UpsertTx(ctx, tx, ucs); err != nil {
+				return err
+			}
+		}
+		return nil
+	}))
+
+	got, err := repo.FindDueCardsForUser(ctx, ownerID, cg.ID, now, 10)
+	require.NoError(t, err)
+	require.Len(t, got, len(cases))
+
+	byID := make(map[string]domain.DueCard, len(got))
+	for _, dc := range got {
+		byID[dc.Card.ID] = dc
+	}
+	for i, tc := range cases {
+		dc, ok := byID[cards[i].ID]
+		require.True(t, ok, "missing card for case %q", tc.front)
+		require.Equal(t, tc.state, dc.State, "state mismatch for case %q", tc.front)
+	}
+}
+
+// TestCardRepository_FindDueCards_InvalidState verifies that an out-of-range
+// state value stored in user_card_fsrs causes FindDueCardsForUser to return an
+// error rather than silently producing a zero-value FSRSCardState.
+func TestCardRepository_FindDueCards_InvalidState(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	ownerID := insertAuthUser(t, ctx)
+	cg := insertCardgroup(t, ctx, ownerID)
+	repo := repository.NewCardRepository(testDB.GORM)
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	card := newCard(cg.ID, "invalid-state", "back")
+	require.NoError(t, repo.Create(ctx, card))
+
+	// Insert a user_card_fsrs row directly with an invalid state value (99) so
+	// that the IsValid gate in findDueCardsOn is exercised.
+	sqlDB, err := testDB.GORM.DB()
+	require.NoError(t, err)
+	_, err = sqlDB.ExecContext(ctx,
+		`INSERT INTO user_card_fsrs
+		 (user_id, card_id, state, due, stability, difficulty, reps, lapses, last_review, elapsed_days, scheduled_days, created_at, updated_at)
+		 VALUES ($1, $2, $3, $4, 0, 5.0, 0, 0, $4, 0, 0, now(), now())`,
+		ownerID, card.ID, 99, now.Add(-time.Minute),
+	)
+	require.NoError(t, err)
+
+	_, err = repo.FindDueCardsForUser(ctx, ownerID, cg.ID, now, 10)
+	require.Error(t, err, "expected error for invalid FSRSCardState 99")
+}
+
 func TestCardRepo_Create_DuplicateFront(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
@@ -283,10 +390,10 @@ func TestCardRepo_Create_DuplicateFront(t *testing.T) {
 	}
 }
 
-func repoCardIDs(cards []*domain.Card) []string {
+func repoCardIDs(cards []domain.DueCard) []string {
 	out := make([]string, len(cards))
-	for i, card := range cards {
-		out[i] = card.ID
+	for i, dc := range cards {
+		out[i] = dc.Card.ID
 	}
 	return out
 }

--- a/backend/internal/usecase/card_test.go
+++ b/backend/internal/usecase/card_test.go
@@ -38,7 +38,7 @@ type mockCardRepository struct {
 	findPageRows  []*domain.Card
 	findPageTotal int64
 	findPageErr   error
-	findDueRows   []*domain.Card
+	findDueRows   []domain.DueCard
 	findDueErr    error
 	// captured arguments from the most recent FindPageByCardgroup call.
 	capturedFindPage struct {
@@ -87,7 +87,7 @@ func (m *mockCardRepository) Delete(_ context.Context, _ string) error {
 	m.deleteCalled = true
 	return m.deleteErr
 }
-func (m *mockCardRepository) FindDueCardsForUserTx(_ context.Context, _ *gorm.DB, _ string, _ string, _ time.Time, _ int) ([]*domain.Card, error) {
+func (m *mockCardRepository) FindDueCardsForUserTx(_ context.Context, _ *gorm.DB, _ string, _ string, _ time.Time, _ int) ([]domain.DueCard, error) {
 	return m.findDueRows, m.findDueErr
 }
 func (m *mockCardRepository) FindPageByCardgroupForUser(

--- a/backend/internal/usecase/learn.go
+++ b/backend/internal/usecase/learn.go
@@ -61,6 +61,12 @@ func NewLearnUsecase(
 	if logger == nil {
 		panic("usecase: learn: logger is required")
 	}
+	if cardRepo == nil {
+		panic("usecase: learn: cardRepo must not be nil")
+	}
+	if cardgroupRepo == nil {
+		panic("usecase: learn: cardgroupRepo must not be nil")
+	}
 	if ordering == nil {
 		ordering = service.NewOrderingPolicy()
 	}
@@ -78,14 +84,8 @@ func NewLearnUsecase(
 	if maxLimit <= 0 {
 		maxLimit = maxLearnNextDueLimit
 	}
-	if cardRepo == nil {
-		panic("LearnUsecase: cardRepo must not be nil")
-	}
-	if cardgroupRepo == nil {
-		panic("LearnUsecase: cardgroupRepo must not be nil")
-	}
 	if defaultLimit > maxLimit {
-		panic(fmt.Sprintf("LearnUsecase: defaultLimit (%d) must not exceed maxLimit (%d)", defaultLimit, maxLimit))
+		panic(fmt.Sprintf("usecase: learn: defaultLimit (%d) must not exceed maxLimit (%d)", defaultLimit, maxLimit))
 	}
 	return &LearnUsecase{
 		cardRepo:      cardRepo,

--- a/backend/internal/usecase/learn.go
+++ b/backend/internal/usecase/learn.go
@@ -23,7 +23,7 @@ const (
 )
 
 type CardRepoForLearn interface {
-	FindDueCardsForUser(ctx context.Context, userID, cardgroupID string, now time.Time, limit int) ([]*domain.Card, error)
+	FindDueCardsForUser(ctx context.Context, userID, cardgroupID string, now time.Time, limit int) ([]domain.DueCard, error)
 }
 
 type CardgroupRepoForLearn interface {
@@ -122,11 +122,15 @@ func (u *LearnUsecase) NextDueCards(ctx context.Context, cardgroupID string, lim
 	}
 	n = u.clampLimit(n)
 	now := u.clock.Now().UTC()
-	cards, err := u.cardRepo.FindDueCardsForUser(ctx, user.Sub, cardgroupID, now, n)
+	due, err := u.cardRepo.FindDueCardsForUser(ctx, user.Sub, cardgroupID, now, n)
 	if err != nil {
-		return nil, eris.Wrap(err, "usecase: find due cards for user")
+		return nil, eris.Wrap(err, "usecase: learn: find due cards")
 	}
-	return u.ordering.Apply(cards, u.randSource()), nil
+	ordered := u.ordering.Apply(due, u.randSource())
+	if len(ordered) > n {
+		ordered = ordered[:n]
+	}
+	return ordered, nil
 }
 
 func (u *LearnUsecase) clampLimit(limit int) int {

--- a/backend/internal/usecase/learn_test.go
+++ b/backend/internal/usecase/learn_test.go
@@ -237,16 +237,18 @@ func TestNewLearnUsecase_PanicsOnInvalidDeps(t *testing.T) {
 	})
 }
 
-// TestLearnUsecaseNextDueCards_TruncatesToDueLimit verifies that when
-// OrderingPolicy.Apply returns more cards than the requested limit (because new
-// and review interleaving can produce a larger set), NextDueCards truncates the
-// result to the originally requested limit.
+// TestLearnUsecaseNextDueCards_TruncatesToDueLimit verifies that NextDueCards
+// truncates the ordered result to the requested limit when the mock repository
+// returns more rows than requested, exercising the guard at the usecase layer.
 func TestLearnUsecaseNextDueCards_TruncatesToDueLimit(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, 5, 13, 9, 0, 0, 0, time.UTC)
-	// Mix of 3 new and 3 review cards. The interleave policy emits all 6.
-	// Request limit=3; expect exactly 3 cards back.
+	// 3 new + 3 review cards, all with distinct Due timestamps so shuffleSameDue
+	// is a no-op and the interleave order is fully deterministic.
+	// With ReviewCardRatio=4 and 3 reviews, all reviews emit before any new card:
+	// rev-1, rev-2, rev-3, new-1, new-2, new-3.  Truncating at limit=3 yields
+	// the first three review cards in their Due-sorted order.
 	rows := []domain.DueCard{
 		learnDueCard("new-1", now.Add(-3*time.Hour), domain.FSRSStateNew),
 		learnDueCard("new-2", now.Add(-2*time.Hour), domain.FSRSStateNew),
@@ -271,6 +273,8 @@ func TestLearnUsecaseNextDueCards_TruncatesToDueLimit(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Len(t, got, 3, "result must be truncated to the requested limit")
+	require.Equal(t, []string{"rev-1", "rev-2", "rev-3"}, learnCardIDs(got),
+		"truncated result must contain the first three cards from the ordered set")
 }
 
 // TestLearnUsecaseNextDueCards_HappyPathReviewOnly verifies the simple path

--- a/backend/internal/usecase/learn_test.go
+++ b/backend/internal/usecase/learn_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 type mockLearnCardRepo struct {
-	rows []*domain.Card
+	rows []domain.DueCard
 	err  error
 
 	cardgroupID string
@@ -25,7 +25,7 @@ type mockLearnCardRepo struct {
 	calls       int
 }
 
-func (m *mockLearnCardRepo) FindDueCardsForUser(_ context.Context, userID, cardgroupID string, now time.Time, limit int) ([]*domain.Card, error) {
+func (m *mockLearnCardRepo) FindDueCardsForUser(_ context.Context, userID, cardgroupID string, now time.Time, limit int) ([]domain.DueCard, error) {
 	m.calls++
 	m.userID = userID
 	m.cardgroupID = cardgroupID
@@ -51,9 +51,10 @@ func TestLearnUsecaseNextDueCards(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, 5, 13, 9, 0, 0, 0, time.UTC)
-	first := learnCard("repo-first", now.Add(time.Hour))
-	second := learnCard("repo-second", now.Add(-time.Hour))
-	cardRepo := &mockLearnCardRepo{rows: []*domain.Card{first, second}}
+	// Two review cards with distinct Due times so shuffleSameDue leaves order stable.
+	first := learnDueCard("repo-first", now.Add(-2*time.Hour), domain.FSRSStateReview)
+	second := learnDueCard("repo-second", now.Add(-time.Hour), domain.FSRSStateReview)
+	cardRepo := &mockLearnCardRepo{rows: []domain.DueCard{first, second}}
 	uc := NewLearnUsecase(
 		cardRepo,
 		&mockLearnCardgroupRepo{cardgroup: &domain.Cardgroup{ID: "cg-1", OwnerID: "u-1"}},
@@ -150,7 +151,7 @@ func TestLearnUsecaseNextDueCardsLimitClampAndEmpty(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			cardRepo := &mockLearnCardRepo{rows: []*domain.Card{}}
+			cardRepo := &mockLearnCardRepo{rows: []domain.DueCard{}}
 			uc := NewLearnUsecase(
 				cardRepo,
 				&mockLearnCardgroupRepo{cardgroup: &domain.Cardgroup{ID: "cg-1", OwnerID: "u-1"}},
@@ -189,7 +190,7 @@ func TestLearnUsecaseNextDueCardsRepoError(t *testing.T) {
 
 	_, err := uc.NextDueCards(authedCtx("u-1"), "cg-1", learnIntPtr(5))
 
-	assertInternalChain(t, err, "usecase: find due cards for user")
+	assertInternalChain(t, err, "usecase: learn: find due cards")
 }
 
 func TestLearnUsecaseNextDueCardsCardgroupRepoInternalError(t *testing.T) {
@@ -236,9 +237,83 @@ func TestNewLearnUsecase_PanicsOnInvalidDeps(t *testing.T) {
 	})
 }
 
-func learnCard(id string, _ time.Time) *domain.Card {
-	return &domain.Card{
-		ID: id,
+// TestLearnUsecaseNextDueCards_TruncatesToDueLimit verifies that when
+// OrderingPolicy.Apply returns more cards than the requested limit (because new
+// and review interleaving can produce a larger set), NextDueCards truncates the
+// result to the originally requested limit.
+func TestLearnUsecaseNextDueCards_TruncatesToDueLimit(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 5, 13, 9, 0, 0, 0, time.UTC)
+	// Mix of 3 new and 3 review cards. The interleave policy emits all 6.
+	// Request limit=3; expect exactly 3 cards back.
+	rows := []domain.DueCard{
+		learnDueCard("new-1", now.Add(-3*time.Hour), domain.FSRSStateNew),
+		learnDueCard("new-2", now.Add(-2*time.Hour), domain.FSRSStateNew),
+		learnDueCard("new-3", now.Add(-time.Hour), domain.FSRSStateNew),
+		learnDueCard("rev-1", now.Add(-6*time.Hour), domain.FSRSStateReview),
+		learnDueCard("rev-2", now.Add(-5*time.Hour), domain.FSRSStateReview),
+		learnDueCard("rev-3", now.Add(-4*time.Hour), domain.FSRSStateReview),
+	}
+	cardRepo := &mockLearnCardRepo{rows: rows}
+	uc := NewLearnUsecase(
+		cardRepo,
+		&mockLearnCardgroupRepo{cardgroup: &domain.Cardgroup{ID: "cg-1", OwnerID: "u-1"}},
+		service.NewOrderingPolicy(),
+		func() *rand.Rand { return rand.New(rand.NewSource(42)) },
+		20,
+		100,
+		fixedClock{now: now},
+		newTestLogger(),
+	)
+
+	got, err := uc.NextDueCards(authedCtx("u-1"), "cg-1", learnIntPtr(3))
+
+	require.NoError(t, err)
+	require.Len(t, got, 3, "result must be truncated to the requested limit")
+}
+
+// TestLearnUsecaseNextDueCards_HappyPathReviewOnly verifies the simple path
+// where the repository returns only review cards and the limit is lower than
+// the number returned, so the result is truncated.
+func TestLearnUsecaseNextDueCards_HappyPathReviewOnly(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 5, 13, 9, 0, 0, 0, time.UTC)
+	// 5 review cards; request limit=3 → expect 3 back.
+	rows := []domain.DueCard{
+		learnDueCard("rev-1", now.Add(-5*time.Hour), domain.FSRSStateReview),
+		learnDueCard("rev-2", now.Add(-4*time.Hour), domain.FSRSStateReview),
+		learnDueCard("rev-3", now.Add(-3*time.Hour), domain.FSRSStateReview),
+		learnDueCard("rev-4", now.Add(-2*time.Hour), domain.FSRSStateReview),
+		learnDueCard("rev-5", now.Add(-time.Hour), domain.FSRSStateReview),
+	}
+	cardRepo := &mockLearnCardRepo{rows: rows}
+	uc := NewLearnUsecase(
+		cardRepo,
+		&mockLearnCardgroupRepo{cardgroup: &domain.Cardgroup{ID: "cg-1", OwnerID: "u-1"}},
+		service.NewOrderingPolicy(),
+		func() *rand.Rand { return rand.New(rand.NewSource(7)) },
+		20,
+		100,
+		fixedClock{now: now},
+		newTestLogger(),
+	)
+
+	got, err := uc.NextDueCards(authedCtx("u-1"), "cg-1", learnIntPtr(3))
+
+	require.NoError(t, err)
+	require.Len(t, got, 3, "result must contain exactly the requested limit")
+}
+
+// learnDueCard constructs a DueCard for use in learn tests.
+// state controls the partition (FSRSStateNew vs review).
+// due sets the DueCard.Due timestamp so shuffleSameDue groups cards correctly.
+func learnDueCard(id string, due time.Time, state domain.FSRSCardState) domain.DueCard {
+	return domain.DueCard{
+		Card:  &domain.Card{ID: id},
+		State: state,
+		Due:   due,
 	}
 }
 

--- a/backend/internal/usecase/swipe.go
+++ b/backend/internal/usecase/swipe.go
@@ -24,7 +24,7 @@ const (
 
 type CardRepoForSwipe interface {
 	FindByIDTx(ctx context.Context, tx *gorm.DB, id string) (*domain.Card, error)
-	FindDueCardsForUserTx(ctx context.Context, tx *gorm.DB, userID, cardgroupID string, now time.Time, limit int) ([]*domain.Card, error)
+	FindDueCardsForUserTx(ctx context.Context, tx *gorm.DB, userID, cardgroupID string, now time.Time, limit int) ([]domain.DueCard, error)
 }
 
 type CardgroupRepoForSwipe interface {
@@ -203,11 +203,11 @@ func (u *SwipeUsecase) HandleSwipe(ctx context.Context, in HandleSwipeInput) (Ha
 		if err := u.swipeRepo.CreateTx(ctx, tx, sr); err != nil {
 			return err
 		}
-		nextCards, err = u.cardRepo.FindDueCardsForUserTx(ctx, tx, user.Sub, in.CardgroupID, now, u.nextBatchSize)
+		due, err := u.cardRepo.FindDueCardsForUserTx(ctx, tx, user.Sub, in.CardgroupID, now, u.nextBatchSize)
 		if err != nil {
-			return err
+			return eris.Wrap(err, "usecase: swipe: find due cards")
 		}
-		nextCards = u.ordering.Apply(nextCards, u.randSource())
+		nextCards = u.ordering.Apply(due, u.randSource())
 		return nil
 	})
 	if err != nil {

--- a/backend/internal/usecase/swipe.go
+++ b/backend/internal/usecase/swipe.go
@@ -175,7 +175,7 @@ func (u *SwipeUsecase) HandleSwipe(ctx context.Context, in HandleSwipeInput) (Ha
 			if errors.Is(err, repository.ErrNotFound) {
 				return ucerr.NewValidationError("cardId", "card not found")
 			}
-			return err
+			return eris.Wrap(err, "usecase: swipe: find card by id")
 		}
 		if !card.BelongsToCardgroup(in.CardgroupID) {
 			return ucerr.NewValidationError("cardId", "card not found")
@@ -184,7 +184,7 @@ func (u *SwipeUsecase) HandleSwipe(ctx context.Context, in HandleSwipeInput) (Ha
 		now = time.Now().UTC()
 		byCardID, err := u.userFSRSRepo.FindByUserAndCardIDsTx(ctx, tx, user.Sub, []string{card.ID})
 		if err != nil {
-			return err
+			return eris.Wrap(err, "usecase: swipe: find user-card fsrs")
 		}
 		current := byCardID[card.ID]
 		if current == nil {
@@ -194,20 +194,23 @@ func (u *SwipeUsecase) HandleSwipe(ctx context.Context, in HandleSwipeInput) (Ha
 			return eris.Wrap(err, "usecase: swipe: apply rating")
 		}
 		if err := u.userFSRSRepo.UpsertTx(ctx, tx, current); err != nil {
-			return err
+			return eris.Wrap(err, "usecase: swipe: upsert user-card fsrs")
 		}
 		sr, err := domain.NewSwipeRecord(user.Sub, card.ID, rating, now, current.State)
 		if err != nil {
-			return err
+			return eris.Wrap(err, "usecase: swipe: new swipe record")
 		}
 		if err := u.swipeRepo.CreateTx(ctx, tx, sr); err != nil {
-			return err
+			return eris.Wrap(err, "usecase: swipe: insert swipe record")
 		}
 		due, err := u.cardRepo.FindDueCardsForUserTx(ctx, tx, user.Sub, in.CardgroupID, now, u.nextBatchSize)
 		if err != nil {
 			return eris.Wrap(err, "usecase: swipe: find due cards")
 		}
 		nextCards = u.ordering.Apply(due, u.randSource())
+		if len(nextCards) > u.nextBatchSize {
+			nextCards = nextCards[:u.nextBatchSize]
+		}
 		return nil
 	})
 	if err != nil {

--- a/backend/internal/usecase/swipe_error_test.go
+++ b/backend/internal/usecase/swipe_error_test.go
@@ -1,0 +1,141 @@
+package usecase
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/rotisserie/eris"
+
+	"backend/internal/domain"
+	"backend/internal/domain/service"
+)
+
+// TestSwipeUsecase_HandleSwipe_FindCardByIDError_PinsChain verifies that an
+// infrastructure error from FindByIDTx is wrapped with the canonical
+// "usecase: swipe: find card by id" prefix so the error_chain log attribute
+// points at the correct operation.  repository.ErrNotFound is NOT used here;
+// that sentinel travels to the Validation outcome variant and is covered by
+// TestSwipeUsecase_HandleSwipe_CardNotFound_ValidationVariant.
+func TestSwipeUsecase_HandleSwipe_FindCardByIDError_PinsChain(t *testing.T) {
+	t.Parallel()
+
+	infraErr := eris.New("storage: simulated find-card infra failure")
+	cardRepo := &mockCardRepository{
+		findErr: infraErr,
+	}
+	cardgroupRepo := &mockCardgroupRepoForCard{
+		findResult: &domain.Cardgroup{ID: "cg-1", OwnerID: "user-1"},
+	}
+	tx, _ := fakeTxRunner()
+	uc := NewSwipeUsecaseWithTx(
+		cardRepo,
+		cardgroupRepo,
+		&mockSwipeRecordRepoForSwipe{},
+		service.NewFSRSScheduler(),
+		10,
+		tx,
+		&mockUserCardFSRSRepository{byCardID: map[string]*domain.UserCardFSRS{}},
+		newTestLogger(),
+	)
+
+	_, err := uc.HandleSwipe(authedCtx("user-1"), HandleSwipeInput{
+		CardID:      "card-1",
+		CardgroupID: "cg-1",
+		Mode:        int(domain.RatingEasy),
+	})
+
+	assertInternalChain(t, err, "usecase: swipe: find card by id")
+	if !errors.Is(err, infraErr) {
+		t.Fatalf("error chain should preserve injected root sentinel; got: %v", err)
+	}
+}
+
+// TestSwipeUsecase_HandleSwipe_FindUserCardFSRSError_PinsChain verifies that an
+// infrastructure error from FindByUserAndCardIDsTx is wrapped with the canonical
+// "usecase: swipe: find user-card fsrs" prefix.
+func TestSwipeUsecase_HandleSwipe_FindUserCardFSRSError_PinsChain(t *testing.T) {
+	t.Parallel()
+
+	infraErr := eris.New("storage: simulated find-user-card-fsrs infra failure")
+	cardRepo := &mockCardRepository{
+		findResult: &domain.Card{
+			ID:          "card-1",
+			CardgroupID: "cg-1",
+		},
+	}
+	cardgroupRepo := &mockCardgroupRepoForCard{
+		findResult: &domain.Cardgroup{ID: "cg-1", OwnerID: "user-1"},
+	}
+	userFSRSRepo := &mockUserCardFSRSRepository{
+		byCardID: map[string]*domain.UserCardFSRS{},
+		findErr:  infraErr,
+	}
+	tx, _ := fakeTxRunner()
+	uc := NewSwipeUsecaseWithTx(
+		cardRepo,
+		cardgroupRepo,
+		&mockSwipeRecordRepoForSwipe{},
+		service.NewFSRSScheduler(),
+		10,
+		tx,
+		userFSRSRepo,
+		newTestLogger(),
+	)
+
+	_, err := uc.HandleSwipe(authedCtx("user-1"), HandleSwipeInput{
+		CardID:      "card-1",
+		CardgroupID: "cg-1",
+		Mode:        int(domain.RatingEasy),
+	})
+
+	assertInternalChain(t, err, "usecase: swipe: find user-card fsrs")
+	if !errors.Is(err, infraErr) {
+		t.Fatalf("error chain should preserve injected root sentinel; got: %v", err)
+	}
+}
+
+// TestSwipeUsecase_HandleSwipe_FindDueCardsError_PinsChain verifies that an
+// infrastructure error from FindDueCardsForUserTx (the final step that fetches
+// the next batch of due cards) is wrapped with the canonical
+// "usecase: swipe: find due cards" prefix.  This is the central new path
+// introduced by the ordering-policy refactor.
+func TestSwipeUsecase_HandleSwipe_FindDueCardsError_PinsChain(t *testing.T) {
+	t.Parallel()
+
+	infraErr := eris.New("storage: simulated find-due-cards infra failure")
+	cardRepo := &mockCardRepository{
+		findResult: &domain.Card{
+			ID:          "card-1",
+			CardgroupID: "cg-1",
+		},
+		findDueErr: infraErr,
+	}
+	cardgroupRepo := &mockCardgroupRepoForCard{
+		findResult: &domain.Cardgroup{ID: "cg-1", OwnerID: "user-1"},
+	}
+	userFSRSRepo := &mockUserCardFSRSRepository{
+		byCardID: map[string]*domain.UserCardFSRS{},
+	}
+	tx, _ := fakeTxRunner()
+	uc := NewSwipeUsecaseWithTx(
+		cardRepo,
+		cardgroupRepo,
+		&mockSwipeRecordRepoForSwipe{},
+		service.NewFSRSScheduler(),
+		10,
+		tx,
+		userFSRSRepo,
+		newTestLogger(),
+	)
+
+	_, err := uc.HandleSwipe(authedCtx("user-1"), HandleSwipeInput{
+		CardID:      "card-1",
+		CardgroupID: "cg-1",
+		Mode:        int(domain.RatingEasy),
+	})
+
+	assertInternalChain(t, err, "usecase: swipe: find due cards")
+	if !errors.Is(err, infraErr) {
+		t.Fatalf("error chain should preserve injected root sentinel; got: %v", err)
+	}
+}

--- a/backend/internal/usecase/swipe_error_test.go
+++ b/backend/internal/usecase/swipe_error_test.go
@@ -1,10 +1,10 @@
 package usecase
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/rotisserie/eris"
+	"github.com/stretchr/testify/require"
 
 	"backend/internal/domain"
 	"backend/internal/domain/service"
@@ -45,9 +45,7 @@ func TestSwipeUsecase_HandleSwipe_FindCardByIDError_PinsChain(t *testing.T) {
 	})
 
 	assertInternalChain(t, err, "usecase: swipe: find card by id")
-	if !errors.Is(err, infraErr) {
-		t.Fatalf("error chain should preserve injected root sentinel; got: %v", err)
-	}
+	require.ErrorIs(t, err, infraErr, "error chain must preserve injected root sentinel")
 }
 
 // TestSwipeUsecase_HandleSwipe_FindUserCardFSRSError_PinsChain verifies that an
@@ -89,9 +87,7 @@ func TestSwipeUsecase_HandleSwipe_FindUserCardFSRSError_PinsChain(t *testing.T) 
 	})
 
 	assertInternalChain(t, err, "usecase: swipe: find user-card fsrs")
-	if !errors.Is(err, infraErr) {
-		t.Fatalf("error chain should preserve injected root sentinel; got: %v", err)
-	}
+	require.ErrorIs(t, err, infraErr, "error chain must preserve injected root sentinel")
 }
 
 // TestSwipeUsecase_HandleSwipe_FindDueCardsError_PinsChain verifies that an
@@ -135,7 +131,5 @@ func TestSwipeUsecase_HandleSwipe_FindDueCardsError_PinsChain(t *testing.T) {
 	})
 
 	assertInternalChain(t, err, "usecase: swipe: find due cards")
-	if !errors.Is(err, infraErr) {
-		t.Fatalf("error chain should preserve injected root sentinel; got: %v", err)
-	}
+	require.ErrorIs(t, err, infraErr, "error chain must preserve injected root sentinel")
 }

--- a/backend/internal/usecase/swipe_performance_test.go
+++ b/backend/internal/usecase/swipe_performance_test.go
@@ -76,7 +76,7 @@ func TestSwipeUsecase_HandleSwipePerformanceMode(t *testing.T) {
 					ID:          "card-1",
 					CardgroupID: "cg-1",
 				},
-				findDueRows: []*domain.Card{{ID: "next-1", CardgroupID: "cg-1"}},
+				findDueRows: []domain.DueCard{{Card: &domain.Card{ID: "next-1", CardgroupID: "cg-1"}}},
 			}
 			cardgroupRepo := &mockCardgroupRepoForCard{
 				findResult: &domain.Cardgroup{ID: "cg-1", OwnerID: "user-1"},
@@ -141,7 +141,7 @@ func TestSwipeUsecase_HandleSwipeCreatesUserFSRSStateForFirstSwipe(t *testing.T)
 			ID:          "card-1",
 			CardgroupID: "cg-1",
 		},
-		findDueRows: []*domain.Card{{ID: "next-1", CardgroupID: "cg-1"}},
+		findDueRows: []domain.DueCard{{Card: &domain.Card{ID: "next-1", CardgroupID: "cg-1"}}},
 	}
 	cardgroupRepo := &mockCardgroupRepoForCard{
 		findResult: &domain.Cardgroup{ID: "cg-1", OwnerID: "user-1"},
@@ -256,7 +256,7 @@ func TestSwipeUsecase_HandleSwipe_PropagatesUpsertError(t *testing.T) {
 			ID:          "card-1",
 			CardgroupID: "cg-1",
 		},
-		findDueRows: []*domain.Card{},
+		findDueRows: []domain.DueCard{},
 	}
 	cardgroupRepo := &mockCardgroupRepoForCard{
 		findResult: &domain.Cardgroup{ID: "cg-1", OwnerID: "user-1"},

--- a/backend/internal/usecase/swipe_performance_test.go
+++ b/backend/internal/usecase/swipe_performance_test.go
@@ -76,7 +76,8 @@ func TestSwipeUsecase_HandleSwipePerformanceMode(t *testing.T) {
 					ID:          "card-1",
 					CardgroupID: "cg-1",
 				},
-				findDueRows: []domain.DueCard{{Card: &domain.Card{ID: "next-1", CardgroupID: "cg-1"}}},
+				// State: FSRSStateReview exercises the review-bucket path in OrderingPolicy.Apply.
+				findDueRows: []domain.DueCard{{Card: &domain.Card{ID: "next-1", CardgroupID: "cg-1"}, State: domain.FSRSStateReview}},
 			}
 			cardgroupRepo := &mockCardgroupRepoForCard{
 				findResult: &domain.Cardgroup{ID: "cg-1", OwnerID: "user-1"},
@@ -141,7 +142,8 @@ func TestSwipeUsecase_HandleSwipeCreatesUserFSRSStateForFirstSwipe(t *testing.T)
 			ID:          "card-1",
 			CardgroupID: "cg-1",
 		},
-		findDueRows: []domain.DueCard{{Card: &domain.Card{ID: "next-1", CardgroupID: "cg-1"}}},
+		// State: FSRSStateReview exercises the review-bucket path in OrderingPolicy.Apply.
+		findDueRows: []domain.DueCard{{Card: &domain.Card{ID: "next-1", CardgroupID: "cg-1"}, State: domain.FSRSStateReview}},
 	}
 	cardgroupRepo := &mockCardgroupRepoForCard{
 		findResult: &domain.Cardgroup{ID: "cg-1", OwnerID: "user-1"},

--- a/docs/backend-graphql.md
+++ b/docs/backend-graphql.md
@@ -382,7 +382,7 @@ as the input keys. dataloader/v7 enforces this 1:1 invariant at runtime.
 
 **Loader error wrapping:** Every resolver that calls `loaders.X.Load(ctx, key)()` must wrap the returned error via `gqlerr.Internal(ctx, err)` (or another typed gqlerr) before returning. Bare loader errors have no `extensions.code` and leak internal details.
 
-**Transactional usecases must not call DataLoader:** DataLoaders are request-scoped and use the normal repository DB handle, not the `*gorm.DB` transaction handle passed into `db.Transaction(...)`. A usecase that needs read-your-writes consistency must call transaction-aware repository methods such as `FindByIDTx`, `UpdateFSRSStateTx`, or `FindDueCardsTx` directly with the `tx` argument. Keep `loader.For(ctx)` out of `internal/usecase/*` files.
+**Transactional usecases must not call DataLoader:** DataLoaders are request-scoped and use the normal repository DB handle, not the `*gorm.DB` transaction handle passed into `db.Transaction(...)`. A usecase that needs read-your-writes consistency must call transaction-aware repository methods such as `FindByIDTx`, `UpdateFSRSStateTx`, or `FindDueCardsForUserTx` directly with the `tx` argument. Keep `loader.For(ctx)` out of `internal/usecase/*` files.
 
 ### Error helpers (`backend/internal/gqlerr`)
 

--- a/docs/backend/ddd-patterns/caller-truncate-contract.md
+++ b/docs/backend/ddd-patterns/caller-truncate-contract.md
@@ -1,0 +1,87 @@
+# Caller-truncate contract: domain service returns all, callers cap
+
+> Part of the [DDD patterns](../../../.claude/rules/ddd-patterns.md) rules.
+
+## Why
+
+A domain service that applies session-local ordering (shuffle, interleave,
+priority weighting) operates on a slice of candidate cards already filtered
+and capped at the repository boundary. The service does not know the
+per-session limit a particular caller wants to enforce — different transports
+(`learnNextDueCards` query, `handleSwipe` mutation) may want different caps,
+or the same transport may pass a user-supplied `limit` that is lower than the
+repository's request size.
+
+Two valid placements:
+
+1. **Service truncates** — the domain service takes a `limit` argument and
+   returns at most `limit` cards.
+2. **Caller truncates** — the domain service returns all cards it processed;
+   each caller slices the result down to its own limit.
+
+The codebase picks (2) because the ordering policy's intermediate shape is
+pure (no length cap), and the limit is a presentation/usecase concern that
+varies across call sites. The trade-off is that every caller must remember
+to truncate.
+
+## What
+
+`OrderingPolicy.Apply` returns all cards it received, in the new
+order:
+
+```go
+// The caller is responsible for truncating to a per-session limit. Apply
+// returns all cards from due without imposing a length cap; the input slice
+// is not modified, as partition produces fresh slices before shuffling.
+func (p *OrderingPolicy) Apply(due []domain.DueCard, rng *rand.Rand) []*domain.Card { ... }
+```
+
+Every caller truncates with the same shape immediately after:
+
+```go
+// backend/internal/usecase/learn.go
+ordered := u.ordering.Apply(due, u.randSource())
+if len(ordered) > n {
+    ordered = ordered[:n]
+}
+
+// backend/internal/usecase/swipe.go
+nextCards = u.ordering.Apply(due, u.randSource())
+if len(nextCards) > u.nextBatchSize {
+    nextCards = nextCards[:u.nextBatchSize]
+}
+```
+
+## Failure mode and mitigations
+
+The risk is a third caller forgetting the truncate, in which case the
+service returns more rows than the caller's contract allows. Three things
+keep that from drifting:
+
+1. **The docstring on `Apply` names the responsibility explicitly.** A
+   reviewer reading the call site can grep the service signature and see
+   "the caller is responsible for truncating".
+2. **The repository already caps at the caller-requested limit.** The
+   service therefore receives at most `limit` rows; the truncate after
+   `Apply` is a redundant guard for the case where the ordering policy
+   would otherwise emit a longer slice (it does not today, but the guard
+   future-proofs against changes that interleave additional sources).
+3. **Direct unit tests cover the post-truncate shape.** Each caller's
+   tests assert the final slice length, so a missing truncate surfaces at
+   review time, not in production.
+
+If a future ordering policy can legitimately emit more cards than it
+received (e.g. interleaving a separate "boosted" bucket), the truncate
+becomes load-bearing and the contract is unchanged: caller still owns the
+cap. If every call site grows to do the same truncate immediately and the
+limit becomes a session-wide config, only then is the contract a candidate
+to flip to service-truncates.
+
+## Reference
+
+- `backend/internal/domain/service/due_card_ordering.go` — `Apply`
+  docstring states the caller-truncate contract.
+- `backend/internal/usecase/learn.go` and `backend/internal/usecase/swipe.go`
+  — both callers truncate after `Apply`. A grep for `ordering.Apply` returns
+  exactly these two sites today; either one missing the truncate is a
+  review-time defect.

--- a/docs/backend/ddd-patterns/view-level-value-in-domain-package.md
+++ b/docs/backend/ddd-patterns/view-level-value-in-domain-package.md
@@ -1,0 +1,89 @@
+# View-level value lives in the domain package when domain logic consumes it
+
+> Part of the [DDD patterns](../../../.claude/rules/ddd-patterns.md) rules.
+
+## Why
+
+Not every type in `domain/` is an aggregate. A *view-level value* is a
+non-aggregate struct that bundles existing aggregate references with
+projection-only fields needed by domain logic. The placement question is
+whether the type belongs in the domain package or in a separate
+`readmodel`/`view` package.
+
+The deciding signal is *who consumes the type*. When the consumer is a domain
+service that already lives in `domain/service/`, hoisting the type to a
+separate package introduces an import path for no behaviour change — the
+domain service would import a sibling package solely to receive its own
+input. Keep the type in `domain/` and document the read-model intent on the
+struct.
+
+## What
+
+`DueCard` is the read-model input to `OrderingPolicy.Apply`. It carries a
+`*Card` plus the viewer's FSRS `State` and `Due` timestamp:
+
+```go
+// backend/internal/domain/due_card.go
+package domain
+
+// DueCard is a Card paired with the viewer's FSRS state for queueing decisions.
+//
+// State is FSRSStateNew when the viewer has no user_card_fsrs row for the card,
+// in which case Due is the card's created_at as a stable substitute.
+//
+// DueCard is not an aggregate; it is a view-level value shared between the
+// repository and OrderingPolicy. It lives in the domain package because the
+// ordering policy is domain logic and DueCard is its input.
+//
+// Card must not be nil; downstream consumers (OrderingPolicy.Apply) dereference
+// it unconditionally. The State invariant (FSRSStateNew ↔ Due == Card.CreatedAt)
+// is established by the repository and is not enforced at the domain layer
+// today; new construction sites must reproduce it.
+type DueCard struct {
+    Card  *Card
+    State FSRSCardState
+    Due   time.Time
+}
+```
+
+`OrderingPolicy.Apply` accepts `[]DueCard` and returns `[]*Card` — the
+read-model is the *input* type, the aggregate is the *output*. The
+repository builds `DueCard` values from a LEFT JOIN of `cards` and
+`user_card_fsrs`; the domain service consumes them; no other layer needs to
+construct them.
+
+## When to keep in `domain/` vs. extract
+
+| Signal | Verdict |
+|---|---|
+| Type is consumed by a domain service (`domain/service/*.go`) | Keep in `domain/` |
+| Type is consumed only by adapters (repository, GraphQL resolver) | Extract to `readmodel/` or keep in `repository/` |
+| Type carries domain-level invariants (e.g. `State ↔ Due` coupling) | Keep in `domain/` so the invariant comment is co-located |
+| Type is a thin projection with no domain semantics | Adapter-side DTO is fine |
+
+The first row applies here: `OrderingPolicy.Apply` is the consumer and lives
+in `domain/service/`. The Go import graph then has
+`repository → domain` (constructs `DueCard`) and `service → domain`
+(consumes `DueCard`), with no extra package introduced. The
+go-arch-lint layer model in [`backend-layering.md`](../../../.claude/rules/backend-layering.md)
+admits both arrows.
+
+## Caveat — invariants are documented, not enforced
+
+`DueCard` does not have a `ParseDueCard` constructor: the State/Due
+relationship is established by the repository's LEFT JOIN logic, not by a
+domain-side validator. The docstring is the load-bearing contract. New
+construction sites (typically test fixtures and any future migration paths)
+must read the docstring and reproduce the invariant. This is the same
+discipline as [zero-value docstring on string newtypes](zero-value-docstring-on-string-newtypes.md),
+applied to a struct value: a comment, not a compiler check, because no
+single trust-boundary parse exists for the read-model.
+
+## Reference
+
+- `backend/internal/domain/due_card.go` — `DueCard` declaration with the
+  read-model docstring.
+- `backend/internal/domain/service/due_card_ordering.go` — `OrderingPolicy.Apply`
+  consumes `[]DueCard`.
+- `backend/internal/repository/card.go` — `findDueCardsOn` constructs
+  `DueCard` from the LEFT JOIN result.

--- a/docs/backend/library-gotchas/constructor-relationship-invariant-panic.md
+++ b/docs/backend/library-gotchas/constructor-relationship-invariant-panic.md
@@ -19,33 +19,49 @@ func NewLearnUsecase(
     ordering      *service.OrderingPolicy,
     randSource    func() *rand.Rand,
     defaultLimit, maxLimit int,
+    clock Clock,
+    logger *slog.Logger,
 ) *LearnUsecase {
-    // nil guards first
+    // nil guards for required deps (panic)
+    if logger == nil {
+        panic("usecase: learn: logger is required")
+    }
     if cardRepo == nil {
-        panic("LearnUsecase: cardRepo must not be nil")
+        panic("usecase: learn: cardRepo must not be nil")
     }
     if cardgroupRepo == nil {
-        panic("LearnUsecase: cardgroupRepo must not be nil")
+        panic("usecase: learn: cardgroupRepo must not be nil")
+    }
+    // optional deps fall back to a default rather than panicking
+    if ordering == nil {
+        ordering = service.NewOrderingPolicy()
+    }
+    if randSource == nil {
+        randSource = func() *rand.Rand {
+            return rand.New(rand.NewSource(time.Now().UnixNano()))
+        }
     }
 
     // relationship invariant: defaultLimit may never exceed maxLimit
     if defaultLimit > maxLimit {
         panic(fmt.Sprintf(
-            "LearnUsecase: defaultLimit (%d) must not exceed maxLimit (%d)",
+            "usecase: learn: defaultLimit (%d) must not exceed maxLimit (%d)",
             defaultLimit, maxLimit,
         ))
     }
 
-    return &LearnUsecase{
-        cardRepo:      cardRepo,
-        cardgroupRepo: cardgroupRepo,
-        ordering:      ordering,
-        randSource:    randSource,
-        defaultLimit:  defaultLimit,
-        maxLimit:      maxLimit,
-    }
+    return &LearnUsecase{ /* fields */ }
 }
 ```
+
+**Optional vs. required dep split.** `cardRepo`, `cardgroupRepo`, and `logger`
+are required: nil indicates a wiring bug and must panic at boot. `ordering`
+and `randSource` are optional: a missing value is recoverable because the
+constructor knows the canonical default (`NewOrderingPolicy()` is stateless,
+`rand.New(rand.NewSource(time.Now().UnixNano()))` is the production seed).
+The fallback is intentional, not lenient: it lets tests omit deps they do not
+exercise without forcing every test to construct a `service.OrderingPolicy`
+just to satisfy the nil check.
 
 Without the relationship panic, passing `defaultLimit=50, maxLimit=20` constructs a
 `LearnUsecase` whose `clampLimit` helper will always clamp to 20, silently ignoring

--- a/docs/backend/library-gotchas/consumer-defined-narrow-repo-interface.md
+++ b/docs/backend/library-gotchas/consumer-defined-narrow-repo-interface.md
@@ -17,7 +17,7 @@ any change to the concrete repository:
 // CardRepoForLearn is the minimal card-repository surface that LearnUsecase needs.
 // The concrete *repository.cardRepo satisfies it automatically.
 type CardRepoForLearn interface {
-    FindDueCards(ctx context.Context, cardgroupID string, now time.Time, limit int) ([]*domain.Card, error)
+    FindDueCardsForUser(ctx context.Context, userID, cardgroupID string, now time.Time, limit int) ([]domain.DueCard, error)
 }
 
 // CardgroupRepoForLearn is the minimal cardgroup-repository surface.
@@ -27,8 +27,8 @@ type CardgroupRepoForLearn interface {
 ```
 
 The shared `CardRepository` in `backend/internal/repository/card.go` keeps its full
-surface (`FindByID`, `FindByIDs`, `FindPageByCardgroup`, `FindDueCards`,
-`FindDueCardsTx`, `Create`, `Update`, `Delete`, …). The `LearnUsecase` sees only
+surface (`FindByID`, `FindByIDs`, `FindPageByCardgroup`, `FindDueCardsForUser`,
+`FindDueCardsForUserTx`, `Create`, `Update`, `Delete`, …). The `LearnUsecase` sees only
 the two methods it calls, so:
 
 - Test stubs for `LearnUsecase` need only two methods, not the full fourteen-method
@@ -38,13 +38,28 @@ the two methods it calls, so:
 - Grepping `CardRepoForLearn` immediately shows the complete data-access footprint
   of `LearnUsecase`, which the shared interface cannot provide.
 
-**Antipattern:** adding `FindDueCards` to the shared `CardRepository` interface and
+**Antipattern:** adding `FindDueCardsForUser` to the shared `CardRepository` interface and
 passing the concrete repository everywhere. This works until the test setup for a
-`CardUsecase` test must implement `FindDueCards` even though that test exercises only
+`CardUsecase` test must implement `FindDueCardsForUser` even though that test exercises only
 card-create logic. Over time each new cross-cutting method increases stub boilerplate
 for every existing test suite.
 
-**Reference:** `backend/internal/usecase/learn.go:21–28` — `CardRepoForLearn` and
+### Return-type widening ripples through every narrow interface
+
+When the concrete repository method's return type changes — for example
+`[]*domain.Card` widening to `[]domain.DueCard` to carry per-user state — every
+narrow interface that names the method (`CardRepoForLearn`, `CardRepoForSwipe`,
+resolver test mocks) must be updated in lockstep. The Go compiler catches the
+mismatch at every site, but a parallel-agent migration that fans out per file
+without first pinning the new signature upstream produces a temporary build
+break across every consumer site. Pin the interface contract first (in one
+agent), then propagate to consumers (in fanned-out agents). The mechanical-
+migration discipline in [`.claude/rules/subagent-dispatch.md` § "Symbol moves
+must be atomic"](../../../.claude/rules/subagent-dispatch.md#symbol-moves-must-be-atomic-----one-agent-owns-both-delete-and-add)
+applies to interface-shape changes for the same reason — a type rename split
+across agents leaves an unbuildable intermediate state.
+
+**Reference:** `backend/internal/usecase/learn.go` — `CardRepoForLearn` and
 `CardgroupRepoForLearn` as local interfaces satisfied by the concrete repository.
 The same pattern appears in `internal/usecase/admin_role.go` as `adminRoleRepoForCRUD`
 (documented in `docs/backend-graphql.md` § "Admin usecase split").

--- a/docs/backend/library-gotchas/gorm-embedded-tablename-scan-confusion.md
+++ b/docs/backend/library-gotchas/gorm-embedded-tablename-scan-confusion.md
@@ -1,0 +1,73 @@
+# GORM embedded struct with `TableName()` silently breaks the outer scan
+
+> Part of the [Go library gotchas](../../../.claude/rules/go-library-gotchas.md) rules.
+
+A scan target that embeds another row struct inherits the embedded type's
+`TableName()` method via Go's method promotion. GORM's schema parser then
+resolves the embedded type's schema (its columns, its `TableName`) instead of
+the outer struct's, and column-to-field mapping silently breaks. The outer
+struct's own non-overlapping fields (extra columns from a JOIN, for example)
+either never populate or scan into the embedded fields by accident.
+
+The failure mode is silent: no scan error, no log line. Affected fields land
+with the Go zero value. For string primary keys this means `id == ""` for
+every row — easy to miss in tests that only inspect the joined columns.
+
+```go
+// Anti-pattern: dueCardRow embeds gormCard, which carries TableName()
+type dueCardRow struct {
+    gormCard            // TableName() returns "cards"
+    State *int       `gorm:"column:state"` // from LEFT JOIN
+    Due   *time.Time `gorm:"column:due"`
+}
+
+// rows[i].ID is empty string after Find; the outer struct's id mapping
+// got displaced by the embedded schema lookup.
+```
+
+The fix is to **flatten the scan target** so no embedded type carries a
+`TableName()`, and call `Table("cards").Select(...)` to set the table and
+column projection explicitly:
+
+```go
+// Correct: flat struct, no embedded TableName() method
+type dueCardRow struct {
+    ID          string     `gorm:"column:id"`
+    CardgroupID string     `gorm:"column:cardgroup_id"`
+    Front       string     `gorm:"column:front"`
+    Back        string     `gorm:"column:back"`
+    CreatedAt   time.Time  `gorm:"column:created_at"`
+    UpdatedAt   time.Time  `gorm:"column:updated_at"`
+    State       *int       `gorm:"column:state"`
+    Due         *time.Time `gorm:"column:due"`
+}
+
+err := db.
+    Table("cards").
+    Select("cards.id, cards.cardgroup_id, cards.front, cards.back, cards.created_at, cards.updated_at, ucs.state, ucs.due").
+    Joins("LEFT JOIN user_card_fsrs ucs ON ucs.user_id = ? AND ucs.card_id = cards.id", userID).
+    Where("cards.cardgroup_id = ? AND (ucs.due IS NULL OR ucs.due <= ?)", cardgroupID, now).
+    Order("COALESCE(ucs.due, cards.created_at) ASC, cards.id ASC").
+    Limit(limit).
+    Find(&rows).Error
+```
+
+A struct comment at the declaration site documents the constraint so a future
+reader does not re-embed `gormCard` for convenience:
+
+```go
+// dueCardRow is the raw scan target for findDueCardsOn. It holds all cards.*
+// columns as flat fields plus nullable FSRS columns from the LEFT JOIN.
+// Embedding gormCard is intentionally avoided: gormCard carries a TableName()
+// method that confuses GORM's embedded-struct schema parser when the outer
+// scan target is a different type.
+```
+
+**Why not `db.Model(&gormCard{}).Select(...).Find(&rows)`:** `Model` sets the
+table but leaves the embedded-schema confusion intact when `rows` itself
+embeds a typed row. The flat scan target + explicit `Table` is the smallest
+fix that survives future column additions.
+
+**Reference:** `backend/internal/repository/card.go` — `dueCardRow` (flat) and
+`findDueCardsOn`. The same flat-scan pattern applies to any LEFT JOIN whose
+right side contributes nullable columns to the projection.

--- a/docs/backend/library-gotchas/inject-rand-rand-for-deterministic-test.md
+++ b/docs/backend/library-gotchas/inject-rand-rand-for-deterministic-test.md
@@ -10,30 +10,19 @@ pass a fixed seed and can assert an exact output order.
 ```go
 // backend/internal/domain/service/due_card_ordering.go
 
-// Apply returns cards ordered by due ASC, with same-due ties shuffled by r.
-// Passing r == nil skips the shuffle (stable sort only).
-// Apply is pure: it never mutates the input slice.
-func (p *OrderingPolicy) Apply(cards []*domain.Card, r *rand.Rand) []*domain.Card {
-    out := append([]*domain.Card(nil), cards...) // copy, never mutate input
-    sort.SliceStable(out, func(i, j int) bool {
-        return out[i].FSRS.Due.Before(out[j].FSRS.Due)
-    })
-    if r == nil {
-        return out
+// Apply orders due cards with a two-step policy:
+//
+//  1. Within each partition (new / review), cards sharing the same Due
+//     timestamp are shuffled using rng.
+//  2. New and review cards are interleaved at NewCardRatio:ReviewCardRatio.
+//
+// rng must be non-nil. Tests inject a seeded *rand.Rand for deterministic
+// order; production constructs one per session.
+func (p *OrderingPolicy) Apply(due []domain.DueCard, rng *rand.Rand) []*domain.Card {
+    if rng == nil {
+        panic("domain/service: OrderingPolicy.Apply requires non-nil rng")
     }
-    // shuffle runs of cards sharing the same due timestamp
-    for start := 0; start < len(out); {
-        end := start + 1
-        for end < len(out) && out[end].FSRS.Due.Equal(out[start].FSRS.Due) {
-            end++
-        }
-        if end-start > 1 {
-            run := out[start:end]
-            r.Shuffle(len(run), func(i, j int) { run[i], run[j] = run[j], run[i] })
-        }
-        start = end
-    }
-    return out
+    // ... partition, shuffleSameDue, interleave ...
 }
 ```
 
@@ -56,14 +45,18 @@ randSource: func() *rand.Rand {
 and cannot be seeded from Go tests, making ordering assertions impossible.
 Pulling the shuffle into application code with an injected source keeps the
 database responsible only for fetching rows in stable due-date order
-(`ORDER BY due ASC, id ASC`); the application layer applies the within-tie
-shuffle on top.
+(`ORDER BY COALESCE(ucs.due, cards.created_at) ASC, cards.id ASC`); the
+application layer applies the within-tie shuffle on top.
 
-**Passing `nil` skips the shuffle:** when the caller does not care about
-tie-breaking order (integration tests asserting only which cards appear, not
-their sequence within a tie), passing `r = nil` returns a stable sort and
-removes the non-determinism without requiring a seeded source.
+**Non-nil rng is enforced at the entry point.** Earlier iterations of the
+policy used `rng == nil` to mean "stable sort only". The current contract
+panics on `nil` because every production wiring (and every test fixture
+written since the interleave step landed) supplies a seeded source — silently
+returning a stable order on `nil` would mask a wiring bug. Tests that want
+deterministic output pass `rand.NewSource(42)`; tests that only assert set
+equality still pass a seeded source.
 
-**Reference:** `backend/internal/domain/service/due_card_ordering.go` — `OrderingPolicy.Apply`;
-`backend/internal/usecase/learn.go` — `randSource func() *rand.Rand` field and
-`NewLearnUsecase` factory injection.
+**Reference:** `backend/internal/domain/service/due_card_ordering.go` — `OrderingPolicy.Apply`
+panics on nil rng; `backend/internal/usecase/learn.go` — `randSource func() *rand.Rand`
+field, factory pattern documented under
+[constructor-relationship-invariant-panic](constructor-relationship-invariant-panic.md).

--- a/docs/backend/library-gotchas/interleave-trailing-append-test-fixture.md
+++ b/docs/backend/library-gotchas/interleave-trailing-append-test-fixture.md
@@ -1,0 +1,79 @@
+# Interleave trailing-append paths need a non-divisible fixture per direction
+
+> Part of the [Go library gotchas](../../../.claude/rules/go-library-gotchas.md) rules.
+
+A ratio-based interleave like `OrderingPolicy.Apply` (1 new per 4 review,
+review-first) has two trailing-append paths that the outer `for i < len(newC)
+&& j < len(reviewC)` loop never executes — one for each bucket that runs
+empty first. Both paths must be exercised by fixtures whose bucket sizes do
+NOT split evenly across the ratio cycle.
+
+```go
+// production: interleave emits rRatio reviews then nRatio news per cycle,
+// then drains whichever bucket has cards left.
+for i < len(newC) && j < len(reviewC) {
+    for k := 0; k < rRatio && j < len(reviewC); k++ {
+        out = append(out, reviewC[j].Card); j++
+    }
+    for k := 0; k < nRatio && i < len(newC); k++ {
+        out = append(out, newC[i].Card); i++
+    }
+}
+// trailing-review path: only executes when newC empties first
+for ; j < len(reviewC); j++ { out = append(out, reviewC[j].Card) }
+// trailing-new path: only executes when reviewC empties first
+for ; i < len(newC); i++ { out = append(out, newC[i].Card) }
+```
+
+A fixture that splits evenly — e.g. 5 new + 20 review at ratio 1:4 — drains
+both buckets simultaneously on the last cycle. Neither trailing loop runs.
+A test built around that fixture proves the ratio pattern but does NOT prove
+that either trailing-append path emits cards in their post-shuffle order.
+
+### Two fixtures per interleave
+
+To cover both trailing paths, two distinct fixtures are required:
+
+| Fixture | Cards | Path exercised |
+|---|---|---|
+| `1 new + 7 review` | new bucket empties mid-loop, review bucket has trailing surplus | trailing-review append |
+| `5 new + 3 review` | review bucket empties inside the k-loop guard, then new bucket has trailing surplus | trailing-new append |
+
+```go
+// Trailing-review: 1N + 7R → first cycle emits rev-0..rev-3 + new-0,
+// outer loop exits when i==1==len(newC), trailing emits rev-4..rev-6.
+in := []domain.DueCard{
+    dueCard("rev-0", ..., t0), ..., dueCard("rev-6", ..., t6),
+    dueCard("new-0", ..., t100),
+}
+
+// Trailing-new: 5N + 3R → k-loop emits rev-0..rev-2 then exits via the
+// "j < len(reviewC)" guard, new-0 emitted, outer loop exits when
+// j==3==len(reviewC), trailing emits new-1..new-4.
+in := []domain.DueCard{
+    dueCard("rev-0", ..., t0), ..., dueCard("rev-2", ..., t2),
+    dueCard("new-0", ..., t100), ..., dueCard("new-4", ..., t104),
+}
+```
+
+### State zero-value collapses the partition
+
+A separate but related pitfall: `domain.DueCard{Card: c}` leaves
+`State` at its zero value (`FSRSStateNew`). A test built only from
+zero-value fixtures exercises ONLY the new-bucket branch of `partition` —
+the review-bucket branch is never entered, and no interleave path runs at
+all because the review bucket is empty. Any fixture intended to exercise
+the review-bucket path or the interleave loop MUST set
+`State: FSRSStateReview` (or `Learning` / `Relearning`) explicitly:
+
+```go
+// Exercises review-bucket: required for interleave coverage.
+domain.DueCard{Card: &domain.Card{ID: "next-1"}, State: domain.FSRSStateReview}
+```
+
+**Reference:** `backend/internal/domain/service/due_card_ordering_test.go` —
+`TestOrderingPolicy_Apply_TrailingReviewAppend` (1N+7R fixture) and
+`TestOrderingPolicy_Apply_TrailingNewAppend` (5N+3R fixture) cover the two
+trailing paths. `backend/internal/usecase/swipe_performance_test.go` carries
+the inline comment `State: FSRSStateReview exercises the review-bucket path`
+at every `findDueRows` fixture that needs the review bucket populated.

--- a/docs/backend/library-gotchas/repo-tx-and-nontx-share-private-helper.md
+++ b/docs/backend/library-gotchas/repo-tx-and-nontx-share-private-helper.md
@@ -9,47 +9,47 @@ accepts `*gorm.DB` directly and call it from both public methods:
 ```go
 // backend/internal/repository/card.go
 
-// FindDueCards is the standalone version — uses the repo's default DB handle.
-func (r *cardRepo) FindDueCards(
+// FindDueCardsForUser is the standalone version — uses the repo's default DB handle.
+func (r *cardRepo) FindDueCardsForUser(
     ctx context.Context,
-    cardgroupID string,
+    userID, cardgroupID string,
     now time.Time,
     limit int,
-) ([]*domain.Card, error) {
-    return findDueCardsOn(r.db.WithContext(ctx), cardgroupID, now, limit)
+) ([]domain.DueCard, error) {
+    return findDueCardsOn(r.db.WithContext(ctx), userID, cardgroupID, now, limit)
 }
 
-// FindDueCardsTx is the transaction-aware version — operates on the caller's tx.
-func (r *cardRepo) FindDueCardsTx(
+// FindDueCardsForUserTx is the transaction-aware version — operates on the caller's tx.
+func (r *cardRepo) FindDueCardsForUserTx(
     ctx context.Context,
     tx *gorm.DB,
-    cardgroupID string,
+    userID, cardgroupID string,
     now time.Time,
     limit int,
-) ([]*domain.Card, error) {
-    return findDueCardsOn(tx.WithContext(ctx), cardgroupID, now, limit)
+) ([]domain.DueCard, error) {
+    return findDueCardsOn(tx.WithContext(ctx), userID, cardgroupID, now, limit)
 }
 
 // findDueCardsOn holds the shared implementation.
-// db is either the default handle (from FindDueCards) or a transaction handle
-// (from FindDueCardsTx).
-func findDueCardsOn(db *gorm.DB, cardgroupID string, now time.Time, limit int) ([]*domain.Card, error) {
+// db is either the default handle (from FindDueCardsForUser) or a transaction handle
+// (from FindDueCardsForUserTx).
+func findDueCardsOn(db *gorm.DB, userID, cardgroupID string, now time.Time, limit int) ([]domain.DueCard, error) {
+    userID = coalesceUserIDForJoin(userID)
     if limit <= 0 {
-        return []*domain.Card{}, nil
+        return []domain.DueCard{}, nil
     }
-    var rows []gormCard
+    var rows []dueCardRow
     if err := db.
-        Where("cardgroup_id = ? AND due <= ?", cardgroupID, now).
-        Order("due ASC, id ASC").
+        Table("cards").
+        Select("cards.id, cards.cardgroup_id, cards.front, cards.back, cards.created_at, cards.updated_at, ucs.state, ucs.due").
+        Joins("LEFT JOIN user_card_fsrs ucs ON ucs.user_id = ? AND ucs.card_id = cards.id", userID).
+        Where("cards.cardgroup_id = ? AND (ucs.due IS NULL OR ucs.due <= ?)", cardgroupID, now).
+        Order("COALESCE(ucs.due, cards.created_at) ASC, cards.id ASC").
         Limit(limit).
         Find(&rows).Error; err != nil {
-        return nil, eris.Wrap(err, "repository: find due cards")
+        return nil, eris.Wrap(err, "repository: card: find due cards")
     }
-    out := make([]*domain.Card, len(rows))
-    for i := range rows {
-        out[i] = cardToDomain(rows[i])
-    }
-    return out, nil
+    // ... build []domain.DueCard from rows ...
 }
 ```
 
@@ -63,6 +63,17 @@ suffix, accepting `*gorm.DB` as its first argument. This pattern is consistent
 with the existing `findCardByID(ctx, db, id)` helper used by `FindByID` and
 `FindByIDTx`.
 
-**Reference:** `backend/internal/repository/card.go` — `FindDueCards`,
-`FindDueCardsTx`, and `findDueCardsOn`. The same `On`-suffix pattern is used by
+**Per-user variant naming:** when the query takes a `userID` because it joins
+against a per-user table (here `user_card_fsrs`), the public methods carry a
+`ForUser` segment between the operation and the `Tx` suffix
+(`FindDueCardsForUser` / `FindDueCardsForUserTx`). The private helper drops the
+`ForUser` segment and treats `userID` as a positional argument — the
+shared-helper name describes the operation; the per-user variant lives only on
+the public surface that callers grep against. Note also that
+[GORM scan targets with embedded TableName methods](gorm-embedded-tablename-scan-confusion.md)
+can silently break LEFT JOIN projection, so the private helper uses a flat
+scan target (`dueCardRow`) rather than embedding `gormCard`.
+
+**Reference:** `backend/internal/repository/card.go` — `FindDueCardsForUser`,
+`FindDueCardsForUserTx`, and `findDueCardsOn`. The same `On`-suffix pattern is used by
 `findCardByID` for `FindByID` / `FindByIDTx`.


### PR DESCRIPTION
## Summary

Closes #200. Wires up the `OrderingPolicy` domain service — previously a no-op stub — with real tie-shuffle and 1:4 review-first interleave logic, and widens the `FindDueCardsForUser` repository return type to supply the data ordering needs. Production diff is 237 lines (well under the 800-line ceiling in [`.claude/rules/pr-sizing.md`](.claude/rules/pr-sizing.md)).

## Background / Motivation

- **`OrderingPolicy.Apply` was a no-op defensive copy.** The stub accepted a `*rand.Rand` (per the [`inject-rand-rand-for-deterministic-test.md`](docs/backend/library-gotchas/inject-rand-rand-for-deterministic-test.md) convention) but ignored it. Both call sites passed cards through without rearrangement, making the injection point dead code.
- **`FindDueCardsForUser` already ran a `LEFT JOIN` on `user_card_fsrs`.** Only `cards.*` was projected; the FSRS state and `due` timestamp were computed in the JOIN but discarded before returning. Widening the projection to `DueCard` is a pure `SELECT`-list change with no schema impact.
- **Tie-breaking randomization.** Cards sharing the same `due` timestamp (common after a long absence or a fresh seed of `user_card_fsrs`) produce a deterministic first-N order every session. Shuffling tied runs with a session-local `*rand.Rand` breaks the lockstep without harming test determinism.
- **1:4 new/review interleave.** Pure `due ASC` ordering surfaces overdue review cards ahead of every new card on re-entry. A review-first 1:4 interleave prioritises backlog recovery while rate-limiting new-card injection to avoid queue ballooning.

## Changes

### Item #1 — `domain.DueCard` + repository widening

- New `backend/internal/domain/due_card.go`: `type DueCard struct { Card *Card; State FSRSCardState; Due time.Time }`. Not an aggregate — a view-level projection shared between repository and `OrderingPolicy`.
- `repository/card.go` (`FindDueCardsForUser` + `FindDueCardsForUserTx`): inner `row` struct now projects `ucs.state` and `ucs.due`; absent FSRS row → `State = FSRSStateNew`, `Due = card.CreatedAt`. Invalid `state` value rejected via `s.IsValid()`.
- All call sites (`usecase/learn.go`, `usecase/swipe.go`, fixture files) updated to consume `[]domain.DueCard`.

### Item #2 — `OrderingPolicy.Apply` implementation

- `domain/service/due_card_ordering.go`: exports `NewCardRatio = 1` / `ReviewCardRatio = 4`. `Apply(due []domain.DueCard, rng *rand.Rand) []*domain.Card` panics on nil `rng`, partitions into new/review, calls `shuffleSameDue` on each partition, then `interleave`.
- `shuffleSameDue` does one linear pass over a pre-sorted (`Due ASC`) slice, detects contiguous same-`Due` runs, and calls `rng.Shuffle` on each run.
- `interleave` emits `ReviewCardRatio` review cards then `NewCardRatio` new cards in a loop; appends remainder when one bucket empties.

### Item #3 — Call-site updates and fixes

- `usecase/learn.go` and `usecase/swipe.go`: `FindDueCardsForUser` result typed as `[]domain.DueCard`; passed to `u.ordering.Apply(due, u.randSource())`; output truncated to `dueLimit` after ordering. Truncation happens at the usecase, not the repository.
- Nil-Card and zero-ratio guards added to `OrderingPolicy.Apply` defensive paths.
- Swipe and learn error-wrap prefixes aligned to `"usecase: swipe: ..."` / `"usecase: learn: ..."` per the [error-wrapping rule](docs/backend/error-wrapping/from-usecase-error-conversion-site.md).

### Tests

- `domain/service/due_card_ordering_test.go`: trailing-append, multi-run shuffle, truncate ordering, same-`Due` shuffle determinism, nil-rng panic, empty/single-partition edge cases; all deterministic via `rand.New(rand.NewSource(42))`.
- `usecase/swipe_performance_test.go` and `learn_test.go` updated to inject `[]domain.DueCard` fixtures.

### Docs

- New L3 learnings in `.claude/rules/go-library-gotchas.md` and `docs/backend/library-gotchas/` capture the `DueCard` view-level projection pattern, `shuffleSameDue` linear-pass contract, and truncate-after-ordering placement.

## Verification

```bash
cd backend
go build ./...
go vet ./...
go test -race -count=1 ./...                   # 1289 tests pass in 23 packages
go tool go-arch-lint check --project-path .    # OK — no warnings found

# Item #1 acceptance: no []*domain.Card consumers of FindDueCardsForUser remain.
grep -rn 'FindDueCardsForUser' backend/ --include='*.go' | grep -v 'DueCard'
# Expect: empty (all callers now use []domain.DueCard).

# Item #2 acceptance: OrderingPolicy.Apply is non-trivial.
grep -n 'shuffleSameDue\|interleave\|partition' backend/internal/domain/service/due_card_ordering.go
# Expect: hits on all three helpers.

# Item #3 acceptance: truncation lives at the usecase, not the repository.
grep -n 'ordered\[:dueLimit\]\|ordered = ordered\[:' backend/internal/usecase/learn.go backend/internal/usecase/swipe.go
# Expect: one match per file.

# PR-sizing rule.
git diff --stat main..HEAD -- '*.go' ':!*_test.go' | tail -1
# Expect: 198 insertions(+), 39 deletions(-) — well under the 800-line ceiling.

# Language-policy: no CJK, no PR-order references.
grep -rlP "[\x{3040}-\x{30ff}\x{4e00}-\x{9fff}]" \
  --include="*.go" --include="*.graphql" --include="*.sql" --include="*.md" \
  docs backend/internal backend/cmd backend/graph
grep -rnE "PR[0-9]+" docs backend/internal backend/cmd backend/graph
# Expect: empty output for both.
```

## Test plan

- [x] `cd backend && go build ./...`
- [x] `cd backend && go vet ./...`
- [x] `cd backend && go test -race -count=1 ./...` — 1289 tests pass in 23 packages
- [x] `cd backend && go tool go-arch-lint check --project-path .` exits 0
- [x] `domain/service` retains `mayDependOn: [domain]` — no new outbound deps
- [x] No GraphQL schema or wire-format change
- [x] Production diff under the 800-line ceiling (237 lines)
- [x] All acceptance greps in the Verification block return expected results
- [ ] CI green on this branch

Closes #200
