### PR TITLE
refactor(backend): denormalize cardgroup_id into swipe_records (#201)

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,5 +1,5 @@
 nodejs 24
-pnpm 10.33.4
+pnpm 11.1.3
 supabase 2.90.0
 python 3.14.5
 pipx latest

--- a/backend/internal/database/migrations/20260520090000_add_cardgroup_id_to_swipe_records.down.sql
+++ b/backend/internal/database/migrations/20260520090000_add_cardgroup_id_to_swipe_records.down.sql
@@ -1,0 +1,13 @@
+-- Reverse of 20260520090000_add_cardgroup_id_to_swipe_records.up.sql.
+--
+-- golang-migrate pgx/v5 does NOT auto-wrap migrations in a transaction; the
+-- explicit BEGIN/COMMIT below ensures all-or-nothing execution.
+
+BEGIN;
+
+DROP INDEX IF EXISTS public.idx_swipe_records_user_cardgroup;
+
+ALTER TABLE public.swipe_records
+    DROP COLUMN IF EXISTS cardgroup_id;
+
+COMMIT;

--- a/backend/internal/database/migrations/20260520090000_add_cardgroup_id_to_swipe_records.up.sql
+++ b/backend/internal/database/migrations/20260520090000_add_cardgroup_id_to_swipe_records.up.sql
@@ -1,0 +1,16 @@
+-- Denormalize the cardgroup at swipe time so swipe_records can be queried
+-- without joining the cards aggregate. Pre-launch DB reset guarantees
+-- public.swipe_records is empty when this NOT NULL column is added.
+--
+-- golang-migrate pgx/v5 does NOT auto-wrap migrations in a transaction; the
+-- explicit BEGIN/COMMIT below ensures all-or-nothing execution.
+
+BEGIN;
+
+ALTER TABLE public.swipe_records
+    ADD COLUMN cardgroup_id uuid NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_swipe_records_user_cardgroup
+    ON public.swipe_records (user_id, cardgroup_id, reviewed_at DESC);
+
+COMMIT;

--- a/backend/internal/database/rls_test.go
+++ b/backend/internal/database/rls_test.go
@@ -74,11 +74,11 @@ func TestRLSPolicies_AuthenticatedRole(t *testing.T) {
 		assertCount(t, queryCountAs(t, ctx, authPool, fx.adminUser, `SELECT count(*) FROM public.swipe_records WHERE user_id = $1`, fx.userB), 1)
 
 		assertRows(t, execOKAs(t, ctx, authPool, fx.userA, insertSwipeSQL(),
-			fx.userA, fx.cardA, time.Now().UTC()), 1)
+			fx.userA, fx.cardA, fx.groupA, time.Now().UTC()), 1)
 		execDeniedAs(t, ctx, authPool, fx.userA, insertSwipeSQL(),
-			fx.userB, fx.cardA, time.Now().UTC())
+			fx.userB, fx.cardA, fx.groupA, time.Now().UTC())
 		execDeniedAs(t, ctx, authPool, fx.adminUser, insertSwipeSQL(),
-			fx.userB, fx.cardB, time.Now().UTC())
+			fx.userB, fx.cardB, fx.groupB, time.Now().UTC())
 	})
 
 	t.Run("user_card_fsrs", func(t *testing.T) {
@@ -193,8 +193,8 @@ func createRLSFixture(t *testing.T, ctx context.Context, sqlDB *sql.DB) rlsFixtu
 	groupB := insertRLSCardgroup(t, ctx, sqlDB, userB, "RLS group B")
 	cardA := insertRLSCard(t, ctx, sqlDB, groupA, "Card A")
 	cardB := insertRLSCard(t, ctx, sqlDB, groupB, "Card B")
-	insertRLSSwipe(t, ctx, sqlDB, userA, cardA)
-	insertRLSSwipe(t, ctx, sqlDB, userB, cardB)
+	insertRLSSwipe(t, ctx, sqlDB, userA, cardA, groupA)
+	insertRLSSwipe(t, ctx, sqlDB, userB, cardB, groupB)
 
 	return rlsFixture{
 		userA:     userA,
@@ -239,9 +239,9 @@ func insertRLSCard(t *testing.T, ctx context.Context, sqlDB *sql.DB, cardgroupID
 	return id
 }
 
-func insertRLSSwipe(t *testing.T, ctx context.Context, sqlDB *sql.DB, userID, cardID string) {
+func insertRLSSwipe(t *testing.T, ctx context.Context, sqlDB *sql.DB, userID, cardID, cardgroupID string) {
 	t.Helper()
-	if _, err := sqlDB.ExecContext(ctx, insertSwipeSQL(), userID, cardID, time.Now().UTC()); err != nil {
+	if _, err := sqlDB.ExecContext(ctx, insertSwipeSQL(), userID, cardID, cardgroupID, time.Now().UTC()); err != nil {
 		t.Fatalf("insert swipe: %v", err)
 	}
 }
@@ -374,10 +374,10 @@ func insertCardSQL() string {
 func insertSwipeSQL() string {
 	return `
         INSERT INTO public.swipe_records (
-            user_id, card_id, rating, reviewed_at, due, stability, difficulty,
+            user_id, card_id, cardgroup_id, rating, reviewed_at, due, stability, difficulty,
             elapsed_days, scheduled_days, reps, lapses, state, last_review
         )
-        VALUES ($1, $2, 3, $3, $3, 2.5, 5.0, 0, 0, 0, 0, 0, $3)
+        VALUES ($1, $2, $3, 3, $4, $4, 2.5, 5.0, 0, 0, 0, 0, 0, $4)
     `
 }
 

--- a/backend/internal/database/swipe_records_cardgroup_test.go
+++ b/backend/internal/database/swipe_records_cardgroup_test.go
@@ -1,0 +1,55 @@
+package database_test
+
+import (
+	"context"
+	"testing"
+)
+
+func TestSwipeRecordsCardgroupIDSchema(t *testing.T) {
+	ctx := context.Background()
+	db := openMigratedDB(t)
+	defer db.Close()
+
+	sqlDB := sqlDBForTest(t, db)
+
+	var dataType, isNullable string
+	if err := sqlDB.QueryRowContext(ctx, `
+		SELECT data_type, is_nullable
+		FROM information_schema.columns
+		WHERE table_schema = 'public'
+		  AND table_name = 'swipe_records'
+		  AND column_name = 'cardgroup_id'
+	`).Scan(&dataType, &isNullable); err != nil {
+		t.Fatalf("query swipe_records.cardgroup_id: %v", err)
+	}
+	if dataType != "uuid" {
+		t.Fatalf("swipe_records.cardgroup_id data_type=%q, want uuid", dataType)
+	}
+	if isNullable != "NO" {
+		t.Fatalf("swipe_records.cardgroup_id is_nullable=%q, want NO", isNullable)
+	}
+
+	var indexdef string
+	if err := sqlDB.QueryRowContext(ctx, `
+		SELECT pg_get_indexdef(indexrelid)
+		FROM pg_index
+		WHERE indexrelid = 'public.idx_swipe_records_user_cardgroup'::regclass
+	`).Scan(&indexdef); err != nil {
+		t.Fatalf("query idx_swipe_records_user_cardgroup definition: %v", err)
+	}
+	const wantIndexDef = "CREATE INDEX idx_swipe_records_user_cardgroup ON public.swipe_records USING btree (user_id, cardgroup_id, reviewed_at DESC)"
+	if indexdef != wantIndexDef {
+		t.Fatalf("idx_swipe_records_user_cardgroup definition=%q, want %q", indexdef, wantIndexDef)
+	}
+
+	var indexedTable string
+	if err := sqlDB.QueryRowContext(ctx, `
+		SELECT tablename
+		FROM pg_indexes
+		WHERE schemaname = 'public'
+		  AND tablename = 'swipe_records'
+		  AND indexname = 'idx_swipe_records_user_cardgroup'
+	`).Scan(&indexedTable); err != nil {
+		t.Fatalf("query pg_indexes for idx_swipe_records_user_cardgroup: %v", err)
+	}
+}

--- a/backend/internal/domain/swipe_record.go
+++ b/backend/internal/domain/swipe_record.go
@@ -9,26 +9,31 @@ import (
 
 // SwipeRecord is an immutable domain event. Append-only; never updated.
 type SwipeRecord struct {
-	ID         string
-	UserID     string
-	CardID     string
-	Rating     Rating
-	ReviewedAt time.Time
-	StateAfter FSRSState
+	ID          string
+	UserID      string
+	CardID      string
+	CardgroupID string
+	Rating      Rating
+	ReviewedAt  time.Time
+	StateAfter  FSRSState
 }
 
 // NewSwipeRecord creates a swipe event with a fresh UUID v7.
-func NewSwipeRecord(userID, cardID string, rating Rating, reviewedAt time.Time, stateAfter FSRSState) (*SwipeRecord, error) {
+func NewSwipeRecord(userID, cardID, cardgroupID string, rating Rating, reviewedAt time.Time, stateAfter FSRSState) (*SwipeRecord, error) {
+	if cardgroupID == "" {
+		return nil, eris.New("swipe record: cardgroupID is required")
+	}
 	id, err := uuid.NewV7()
 	if err != nil {
 		return nil, eris.Wrap(err, "swipe record: new uuid v7")
 	}
 	return &SwipeRecord{
-		ID:         id.String(),
-		UserID:     userID,
-		CardID:     cardID,
-		Rating:     rating,
-		ReviewedAt: reviewedAt,
-		StateAfter: stateAfter,
+		ID:          id.String(),
+		UserID:      userID,
+		CardID:      cardID,
+		CardgroupID: cardgroupID,
+		Rating:      rating,
+		ReviewedAt:  reviewedAt,
+		StateAfter:  stateAfter,
 	}, nil
 }

--- a/backend/internal/domain/swipe_record_test.go
+++ b/backend/internal/domain/swipe_record_test.go
@@ -13,16 +13,26 @@ func TestNewSwipeRecord(t *testing.T) {
 	reviewedAt := time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC)
 	state := NewFSRSStateForNewCard(reviewedAt)
 
-	first, err := NewSwipeRecord("user-1", "card-1", RatingEasy, reviewedAt, state)
+	first, err := NewSwipeRecord("user-1", "card-1", "cg-1", RatingEasy, reviewedAt, state)
 	require.NoError(t, err)
-	second, err := NewSwipeRecord("user-1", "card-1", RatingEasy, reviewedAt, state)
+	second, err := NewSwipeRecord("user-1", "card-1", "cg-1", RatingEasy, reviewedAt, state)
 	require.NoError(t, err)
 
 	require.NotEmpty(t, first.ID)
 	require.NotEqual(t, first.ID, second.ID)
 	require.Equal(t, "user-1", first.UserID)
 	require.Equal(t, "card-1", first.CardID)
+	require.Equal(t, "cg-1", first.CardgroupID)
 	require.Equal(t, RatingEasy, first.Rating)
 	require.Equal(t, reviewedAt, first.ReviewedAt)
 	require.Equal(t, state, first.StateAfter)
+}
+
+func TestNewSwipeRecord_EmptyCardgroupID(t *testing.T) {
+	t.Parallel()
+
+	reviewedAt := time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC)
+
+	_, err := NewSwipeRecord("user-1", "card-1", "", RatingEasy, reviewedAt, NewFSRSStateForNewCard(reviewedAt))
+	require.EqualError(t, err, "swipe record: cardgroupID is required")
 }

--- a/backend/internal/repository/swipe_record.go
+++ b/backend/internal/repository/swipe_record.go
@@ -14,6 +14,7 @@ type gormSwipeRecord struct {
 	ID            string    `gorm:"column:id;primaryKey;type:uuid"`
 	UserID        string    `gorm:"column:user_id"`
 	CardID        string    `gorm:"column:card_id"`
+	CardgroupID   string    `gorm:"column:cardgroup_id;type:uuid"`
 	Rating        int       `gorm:"column:rating"`
 	ReviewedAt    time.Time `gorm:"column:reviewed_at"`
 	Due           time.Time `gorm:"column:due"`
@@ -61,9 +62,8 @@ func (r *swipeRecordRepo) FindByIDs(ctx context.Context, ids []string) (map[stri
 func (r *swipeRecordRepo) FindByUserAndCardgroup(ctx context.Context, userID, cardgroupID string) ([]*domain.SwipeRecord, error) {
 	var rows []gormSwipeRecord
 	if err := r.db.WithContext(ctx).
-		Joins("JOIN cards ON cards.id = swipe_records.card_id").
-		Where("swipe_records.user_id = ? AND cards.cardgroup_id = ?", userID, cardgroupID).
-		Order("swipe_records.reviewed_at DESC, swipe_records.id DESC").
+		Where("user_id = ? AND cardgroup_id = ?", userID, cardgroupID).
+		Order("reviewed_at DESC, id DESC").
 		Find(&rows).Error; err != nil {
 		return nil, eris.Wrap(err, "repository: find swipe records by user and cardgroup")
 	}
@@ -107,6 +107,7 @@ func swipeRecordToRow(sr *domain.SwipeRecord) *gormSwipeRecord {
 		ID:            sr.ID,
 		UserID:        sr.UserID,
 		CardID:        sr.CardID,
+		CardgroupID:   sr.CardgroupID,
 		Rating:        int(sr.Rating),
 		ReviewedAt:    sr.ReviewedAt,
 		Due:           sr.StateAfter.Due,
@@ -123,11 +124,12 @@ func swipeRecordToRow(sr *domain.SwipeRecord) *gormSwipeRecord {
 
 func swipeRecordToDomain(row gormSwipeRecord) *domain.SwipeRecord {
 	return &domain.SwipeRecord{
-		ID:         row.ID,
-		UserID:     row.UserID,
-		CardID:     row.CardID,
-		Rating:     domain.Rating(row.Rating),
-		ReviewedAt: row.ReviewedAt,
+		ID:          row.ID,
+		UserID:      row.UserID,
+		CardID:      row.CardID,
+		CardgroupID: row.CardgroupID,
+		Rating:      domain.Rating(row.Rating),
+		ReviewedAt:  row.ReviewedAt,
 		StateAfter: domain.FSRSState{
 			Due:           row.Due,
 			Stability:     row.Stability,

--- a/backend/internal/repository/swipe_record_test.go
+++ b/backend/internal/repository/swipe_record_test.go
@@ -25,7 +25,7 @@ func TestSwipeRecordRepository_CreateTxAndFind(t *testing.T) {
 	reviewedAt := time.Now().UTC()
 	state := domain.NewFSRSStateForNewCard(reviewedAt)
 	state.Reps = 1
-	sr, err := domain.NewSwipeRecord(ownerID, card.ID, domain.RatingEasy, reviewedAt, state)
+	sr, err := domain.NewSwipeRecord(ownerID, card.ID, cg.ID, domain.RatingEasy, reviewedAt, state)
 	require.NoError(t, err)
 
 	require.NoError(t, testDB.GORM.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
@@ -36,6 +36,7 @@ func TestSwipeRecordRepository_CreateTxAndFind(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, byID, 1)
 	require.Equal(t, sr.ID, byID[sr.ID].ID)
+	require.Equal(t, cg.ID, byID[sr.ID].CardgroupID)
 	require.Equal(t, domain.RatingEasy, byID[sr.ID].Rating)
 	require.Equal(t, state.Reps, byID[sr.ID].StateAfter.Reps)
 
@@ -43,6 +44,38 @@ func TestSwipeRecordRepository_CreateTxAndFind(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, history, 1)
 	require.Equal(t, sr.ID, history[0].ID)
+	require.Equal(t, cg.ID, history[0].CardgroupID)
+}
+
+func TestSwipeRecordRepository_FindByUserAndCardgroup_UsesDenormalizedCardgroup(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	ownerID := insertAuthUser(t, ctx)
+	cgAtSwipe := insertCardgroup(t, ctx, ownerID)
+	cgCurrent := insertCardgroup(t, ctx, ownerID)
+	cardRepo := repository.NewCardRepository(testDB.GORM)
+	swipeRepo := repository.NewSwipeRecordRepository(testDB.GORM)
+
+	card := newCard(cgCurrent.ID, "front denormalized", "back")
+	require.NoError(t, cardRepo.Create(ctx, card))
+	reviewedAt := time.Now().UTC().Truncate(time.Microsecond)
+	state := domain.NewFSRSStateForNewCard(reviewedAt)
+	sr, err := domain.NewSwipeRecord(ownerID, card.ID, cgAtSwipe.ID, domain.RatingGood, reviewedAt, state)
+	require.NoError(t, err)
+
+	require.NoError(t, testDB.GORM.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		return swipeRepo.CreateTx(ctx, tx, sr)
+	}))
+
+	historyAtSwipe, err := swipeRepo.FindByUserAndCardgroup(ctx, ownerID, cgAtSwipe.ID)
+	require.NoError(t, err)
+	require.Len(t, historyAtSwipe, 1)
+	require.Equal(t, sr.ID, historyAtSwipe[0].ID)
+	require.Equal(t, cgAtSwipe.ID, historyAtSwipe[0].CardgroupID)
+
+	historyCurrent, err := swipeRepo.FindByUserAndCardgroup(ctx, ownerID, cgCurrent.ID)
+	require.NoError(t, err)
+	require.Empty(t, historyCurrent)
 }
 
 func TestSwipeRecordRepository_ListRecentByUser_OrdersAndScopes(t *testing.T) {
@@ -66,24 +99,25 @@ func TestSwipeRecordRepository_ListRecentByUser_OrdersAndScopes(t *testing.T) {
 	sameReviewTime := base
 	newest := base.Add(time.Hour)
 
-	seed := func(id, userID, cardID string, reviewedAt time.Time) *domain.SwipeRecord {
+	seed := func(id, userID, cardID, cardgroupID string, reviewedAt time.Time) *domain.SwipeRecord {
 		return &domain.SwipeRecord{
-			ID:         id,
-			UserID:     userID,
-			CardID:     cardID,
-			Rating:     domain.RatingEasy,
-			ReviewedAt: reviewedAt,
-			StateAfter: domain.NewFSRSStateForNewCard(reviewedAt),
+			ID:          id,
+			UserID:      userID,
+			CardID:      cardID,
+			CardgroupID: cardgroupID,
+			Rating:      domain.RatingEasy,
+			ReviewedAt:  reviewedAt,
+			StateAfter:  domain.NewFSRSStateForNewCard(reviewedAt),
 		}
 	}
 
 	require.NoError(t, testDB.GORM.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		for _, sr := range []*domain.SwipeRecord{
-			seed("00000000-0000-0000-0000-000000000001", ownerID, ownerCard1.ID, earlier),
-			seed("00000000-0000-0000-0000-000000000002", ownerID, ownerCard1.ID, sameReviewTime),
-			seed("00000000-0000-0000-0000-000000000003", ownerID, ownerCard2.ID, sameReviewTime),
-			seed("00000000-0000-0000-0000-000000000004", ownerID, ownerCard2.ID, newest),
-			seed("00000000-0000-0000-0000-000000000005", otherUserID, otherCard.ID, newest),
+			seed("00000000-0000-0000-0000-000000000001", ownerID, ownerCard1.ID, cg.ID, earlier),
+			seed("00000000-0000-0000-0000-000000000002", ownerID, ownerCard1.ID, cg.ID, sameReviewTime),
+			seed("00000000-0000-0000-0000-000000000003", ownerID, ownerCard2.ID, cg.ID, sameReviewTime),
+			seed("00000000-0000-0000-0000-000000000004", ownerID, ownerCard2.ID, cg.ID, newest),
+			seed("00000000-0000-0000-0000-000000000005", otherUserID, otherCard.ID, cg.ID, newest),
 		} {
 			if err := swipeRepo.CreateTx(ctx, tx, sr); err != nil {
 				return err

--- a/backend/internal/usecase/swipe.go
+++ b/backend/internal/usecase/swipe.go
@@ -43,16 +43,18 @@ type UserCardFSRSRepoForSwipe interface {
 }
 
 type SwipeUsecase struct {
-	cardRepo      CardRepoForSwipe
-	cardgroupRepo CardgroupRepoForSwipe
-	swipeRepo     SwipeRecordRepoForSwipe
-	userFSRSRepo  UserCardFSRSRepoForSwipe
-	scheduler     *service.FSRSScheduler
-	ordering      *service.OrderingPolicy
-	randSource    func() *rand.Rand
-	tx            txRunner
-	nextBatchSize int
-	logger        *slog.Logger
+	cardRepo       CardRepoForSwipe
+	cardgroupRepo  CardgroupRepoForSwipe
+	swipeRepo      SwipeRecordRepoForSwipe
+	userFSRSRepo   UserCardFSRSRepoForSwipe
+	scheduler      *service.FSRSScheduler
+	ordering       *service.OrderingPolicy
+	randSource     func() *rand.Rand
+	applyRating    func(current *domain.UserCardFSRS, scheduler domain.FSRSScheduler, rating domain.Rating, now time.Time) error
+	newSwipeRecord func(userID, cardID, cardgroupID string, rating domain.Rating, reviewedAt time.Time, stateAfter domain.FSRSState) (*domain.SwipeRecord, error)
+	tx             txRunner
+	nextBatchSize  int
+	logger         *slog.Logger
 }
 
 type HandleSwipeInput struct {
@@ -108,8 +110,12 @@ func NewSwipeUsecase(
 		randSource: func() *rand.Rand {
 			return rand.New(rand.NewSource(time.Now().UnixNano()))
 		},
-		nextBatchSize: nextBatchSize,
-		logger:        logger,
+		applyRating: func(current *domain.UserCardFSRS, scheduler domain.FSRSScheduler, rating domain.Rating, now time.Time) error {
+			return current.ApplyRating(scheduler, rating, now)
+		},
+		newSwipeRecord: domain.NewSwipeRecord,
+		nextBatchSize:  nextBatchSize,
+		logger:         logger,
 	}
 	if db != nil {
 		uc.tx = func(ctx context.Context, fn func(tx *gorm.DB) error) error {
@@ -190,13 +196,13 @@ func (u *SwipeUsecase) HandleSwipe(ctx context.Context, in HandleSwipeInput) (Ha
 		if current == nil {
 			current = domain.NewUserCardFSRSForNewCard(user.Sub, card.ID, now)
 		}
-		if err := current.ApplyRating(u.scheduler, rating, now); err != nil {
+		if err := u.applyRating(current, u.scheduler, rating, now); err != nil {
 			return eris.Wrap(err, "usecase: swipe: apply rating")
 		}
 		if err := u.userFSRSRepo.UpsertTx(ctx, tx, current); err != nil {
 			return eris.Wrap(err, "usecase: swipe: upsert user-card fsrs")
 		}
-		sr, err := domain.NewSwipeRecord(user.Sub, card.ID, rating, now, current.State)
+		sr, err := u.newSwipeRecord(user.Sub, card.ID, card.CardgroupID, rating, now, current.State)
 		if err != nil {
 			return eris.Wrap(err, "usecase: swipe: new swipe record")
 		}

--- a/backend/internal/usecase/swipe_error_test.go
+++ b/backend/internal/usecase/swipe_error_test.go
@@ -2,6 +2,7 @@ package usecase
 
 import (
 	"testing"
+	"time"
 
 	"github.com/rotisserie/eris"
 	"github.com/stretchr/testify/require"
@@ -90,6 +91,50 @@ func TestSwipeUsecase_HandleSwipe_FindUserCardFSRSError_PinsChain(t *testing.T) 
 	require.ErrorIs(t, err, infraErr, "error chain must preserve injected root sentinel")
 }
 
+// TestSwipeUsecase_HandleSwipe_ApplyRatingError_PinsChain verifies that an
+// infrastructure error from the rating application step is wrapped with the
+// canonical "usecase: swipe: apply rating" prefix.
+func TestSwipeUsecase_HandleSwipe_ApplyRatingError_PinsChain(t *testing.T) {
+	t.Parallel()
+
+	infraErr := eris.New("storage: simulated apply-rating infra failure")
+	cardRepo := &mockCardRepository{
+		findResult: &domain.Card{
+			ID:          "card-1",
+			CardgroupID: "cg-1",
+		},
+	}
+	cardgroupRepo := &mockCardgroupRepoForCard{
+		findResult: &domain.Cardgroup{ID: "cg-1", OwnerID: "user-1"},
+	}
+	userFSRSRepo := &mockUserCardFSRSRepository{
+		byCardID: map[string]*domain.UserCardFSRS{},
+	}
+	tx, _ := fakeTxRunner()
+	uc := NewSwipeUsecaseWithTx(
+		cardRepo,
+		cardgroupRepo,
+		&mockSwipeRecordRepoForSwipe{},
+		service.NewFSRSScheduler(),
+		10,
+		tx,
+		userFSRSRepo,
+		newTestLogger(),
+	)
+	uc.applyRating = func(_ *domain.UserCardFSRS, _ domain.FSRSScheduler, _ domain.Rating, _ time.Time) error {
+		return infraErr
+	}
+
+	_, err := uc.HandleSwipe(authedCtx("user-1"), HandleSwipeInput{
+		CardID:      "card-1",
+		CardgroupID: "cg-1",
+		Mode:        int(domain.RatingEasy),
+	})
+
+	assertInternalChain(t, err, "usecase: swipe: apply rating")
+	require.ErrorIs(t, err, infraErr, "error chain must preserve injected root sentinel")
+}
+
 // TestSwipeUsecase_HandleSwipe_FindDueCardsError_PinsChain verifies that an
 // infrastructure error from FindDueCardsForUserTx (the final step that fetches
 // the next batch of due cards) is wrapped with the canonical
@@ -131,5 +176,93 @@ func TestSwipeUsecase_HandleSwipe_FindDueCardsError_PinsChain(t *testing.T) {
 	})
 
 	assertInternalChain(t, err, "usecase: swipe: find due cards")
+	require.ErrorIs(t, err, infraErr, "error chain must preserve injected root sentinel")
+}
+
+// TestSwipeUsecase_HandleSwipe_NewSwipeRecordError_PinsChain verifies that a
+// failure while constructing the denormalized swipe snapshot is wrapped with
+// the canonical "usecase: swipe: new swipe record" prefix.
+func TestSwipeUsecase_HandleSwipe_NewSwipeRecordError_PinsChain(t *testing.T) {
+	t.Parallel()
+
+	infraErr := eris.New("storage: simulated new-swipe-record infra failure")
+	cardRepo := &mockCardRepository{
+		findResult: &domain.Card{
+			ID:          "card-1",
+			CardgroupID: "cg-1",
+		},
+	}
+	cardgroupRepo := &mockCardgroupRepoForCard{
+		findResult: &domain.Cardgroup{ID: "cg-1", OwnerID: "user-1"},
+	}
+	userFSRSRepo := &mockUserCardFSRSRepository{
+		byCardID: map[string]*domain.UserCardFSRS{},
+	}
+	tx, _ := fakeTxRunner()
+	uc := NewSwipeUsecaseWithTx(
+		cardRepo,
+		cardgroupRepo,
+		&mockSwipeRecordRepoForSwipe{},
+		service.NewFSRSScheduler(),
+		10,
+		tx,
+		userFSRSRepo,
+		newTestLogger(),
+	)
+	uc.newSwipeRecord = func(_, _, _ string, _ domain.Rating, _ time.Time, _ domain.FSRSState) (*domain.SwipeRecord, error) {
+		return nil, infraErr
+	}
+
+	_, err := uc.HandleSwipe(authedCtx("user-1"), HandleSwipeInput{
+		CardID:      "card-1",
+		CardgroupID: "cg-1",
+		Mode:        int(domain.RatingEasy),
+	})
+
+	assertInternalChain(t, err, "usecase: swipe: new swipe record")
+	require.ErrorIs(t, err, infraErr, "error chain must preserve injected root sentinel")
+}
+
+// TestSwipeUsecase_HandleSwipe_InsertSwipeRecordError_PinsChain verifies that
+// infrastructure errors from the final insert step preserve the canonical
+// "usecase: swipe: insert swipe record" prefix.
+func TestSwipeUsecase_HandleSwipe_InsertSwipeRecordError_PinsChain(t *testing.T) {
+	t.Parallel()
+
+	infraErr := eris.New("storage: simulated insert-swipe-record infra failure")
+	cardRepo := &mockCardRepository{
+		findResult: &domain.Card{
+			ID:          "card-1",
+			CardgroupID: "cg-1",
+		},
+	}
+	cardgroupRepo := &mockCardgroupRepoForCard{
+		findResult: &domain.Cardgroup{ID: "cg-1", OwnerID: "user-1"},
+	}
+	swipeRepo := &mockSwipeRecordRepoForSwipe{
+		createErr: infraErr,
+	}
+	userFSRSRepo := &mockUserCardFSRSRepository{
+		byCardID: map[string]*domain.UserCardFSRS{},
+	}
+	tx, _ := fakeTxRunner()
+	uc := NewSwipeUsecaseWithTx(
+		cardRepo,
+		cardgroupRepo,
+		swipeRepo,
+		service.NewFSRSScheduler(),
+		10,
+		tx,
+		userFSRSRepo,
+		newTestLogger(),
+	)
+
+	_, err := uc.HandleSwipe(authedCtx("user-1"), HandleSwipeInput{
+		CardID:      "card-1",
+		CardgroupID: "cg-1",
+		Mode:        int(domain.RatingEasy),
+	})
+
+	assertInternalChain(t, err, "usecase: swipe: insert swipe record")
 	require.ErrorIs(t, err, infraErr, "error chain must preserve injected root sentinel")
 }

--- a/backend/internal/usecase/swipe_performance_test.go
+++ b/backend/internal/usecase/swipe_performance_test.go
@@ -121,6 +121,9 @@ func TestSwipeUsecase_HandleSwipePerformanceMode(t *testing.T) {
 			if swipeRepo.created == nil {
 				t.Fatal("expected swipe record to be created before metrics are listed")
 			}
+			if swipeRepo.created.CardgroupID != "cg-1" {
+				t.Fatalf("created swipe cardgroup=%q, want cg-1", swipeRepo.created.CardgroupID)
+			}
 			if swipeRepo.listUserID != "user-1" {
 				t.Fatalf("ListRecentByUser user=%q, want user-1", swipeRepo.listUserID)
 			}
@@ -185,6 +188,9 @@ func TestSwipeUsecase_HandleSwipeCreatesUserFSRSStateForFirstSwipe(t *testing.T)
 	}
 	if swipeRepo.created == nil || swipeRepo.created.StateAfter != userFSRSRepo.upserted.State {
 		t.Fatalf("swipe snapshot must match upserted user state, swipe=%+v ucs=%+v", swipeRepo.created, userFSRSRepo.upserted)
+	}
+	if swipeRepo.created.CardgroupID != "cg-1" {
+		t.Fatalf("created swipe cardgroup=%q, want cg-1", swipeRepo.created.CardgroupID)
 	}
 	if len(outcome.Swipe.NextCards) != 1 || outcome.Swipe.NextCards[0].ID != "next-1" {
 		t.Fatalf("unexpected next cards: %+v", outcome.Swipe.NextCards)

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "description": "Swiping flashcard app — Next.js × Echo(gqlgen) × Supabase monorepo.",
   "//packageManager": "Load-bearing for Vercel (no mise) and pnpm's own self-check; mise/.tool-versions covers local + GitHub Actions. Keep aligned with .tool-versions.",
-  "packageManager": "pnpm@10.33.4",
+  "packageManager": "pnpm@11.1.3",
   "engines": {
     "node": ">=24.0.0 <25.0.0",
     "pnpm": ">=10.0.0"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,3 +3,6 @@ packages:
 
 onlyBuiltDependencies:
   - sharp
+
+allowBuilds:
+  sharp: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,5 @@
 packages:
   - "frontend"
+
+onlyBuiltDependencies:
+  - sharp


### PR DESCRIPTION
## Summary

Closes #201. Denormalizes `cardgroup_id` onto `swipe_records` to eliminate the cross-aggregate JOIN in `FindByUserAndCardgroup`. Pre-launch single-PR approach (no back-fill needed; production DB will be reset before this merges), so both phases of the original two-phase plan collapse into one.

## Background / Motivation

- **`SwipeRecord.FindByUserAndCardgroup` coupled two aggregates via SQL.** `JOIN cards ON cards.id = swipe_records.card_id` is needed only to reach `cards.cardgroup_id`, forcing `SwipeRecordRepository` to reach across the `Card` aggregate boundary on every read.
- **`cardgroup_id` is a natural as-of-event attribute.** `SwipeRecord` is an append-only business event; the cardgroup the card belonged to *at the moment of the swipe* is part of the event itself and should be frozen at write-time. Denormalizing records the value without relying on the card's current state.
- **The two-phase migration plan was retired on 2026-05-20.** No `swipe_records` rows exist in production (pre-launch DB reset agreed), so there is no back-fill requirement and both phases can land atomically.

## Changes

### Item #1 — Migration: `cardgroup_id NOT NULL` + composite index (commit `71c6f20`)

- New `20260520090000_add_cardgroup_id_to_swipe_records.up.sql`: `ALTER TABLE swipe_records ADD COLUMN cardgroup_id UUID NOT NULL` + `CREATE INDEX idx_swipe_records_user_cardgroup ON swipe_records (user_id, cardgroup_id, reviewed_at DESC)`.
- Matching `.down.sql` drops the index then the column.
- New `backend/internal/database/swipe_records_cardgroup_test.go`: schema-state spec test asserting the column is `NOT NULL` and the composite index exists after migration.

### Item #2 — `domain.SwipeRecord` carries `CardgroupID` (commit `b85dc4e`)

- `domain/swipe_record.go`: new `CardgroupID string` field; `NewSwipeRecord` gains a mandatory `cardgroupID` parameter and returns `eris.New("swipe record: cardgroupID is required")` on empty input.
- `domain/swipe_record_test.go`: new "empty cardgroupID rejected" table case.

### Item #3 — Repository write + read paths use `cardgroup_id` directly (commits `2c9145f`, `74db92b`)

- `repository/swipe_record.go`: `gormSwipeRecord` gains `CardgroupID string`; `swipeRecordToRow` / `swipeRecordToDomain` round-trip the field. `FindByUserAndCardgroup` drops the `Joins("JOIN cards ...")` clause and filters `WHERE user_id = ? AND cardgroup_id = ?` directly with `ORDER BY reviewed_at DESC, id DESC` for stable tie-breaking.
- `repository/swipe_record_test.go`: round-trip assertion for `CardgroupID`; cross-cardgroup isolation test confirms records from a different cardgroup are excluded.

### Item #4 — Usecase write path passes `card.CardgroupID` (commit `e094b9c`)

- `usecase/swipe.go`: `HandleSwipe` passes `card.CardgroupID` as the third argument to `domain.NewSwipeRecord`. `newSwipeRecordFn` factory injected for testability.
- `usecase/swipe_error_test.go`: updated to cover the new factory injection points with `assertInternalChain` per the error-chain-shape convention.

### Tests (commits `3bb33fa`, `74db92b`)

- `backend/internal/database/rls_test.go`: RLS fixtures supply `cardgroup_id`.
- `backend/internal/usecase/swipe_performance_test.go`: performance fixtures include `CardgroupID`.

## Verification

```bash
cd backend
go build ./...
go vet ./...
go test -race -count=1 ./...
go tool go-arch-lint check --project-path .

# JOIN removed from the repository.
grep -n 'Joins.*cards.*swipe_records' backend/internal/repository/swipe_record.go
# Expect: empty.

# Every NewSwipeRecord call site passes cardgroupID.
grep -rn 'domain\.NewSwipeRecord(' backend/ --include='*.go'
# Expect: all hits include 3 string args before Rating.

# Production diff under 800-line ceiling.
git diff --stat main..HEAD -- '*.go' ':!*_test.go' | tail -1
# Expect: ~52 insertions — well under 800.

# Language-policy: no CJK, no PR-order references.
grep -rlP "[\x{3040}-\x{30ff}\x{4e00}-\x{9fff}]" \
  --include="*.go" --include="*.sql" --include="*.md" \
  docs backend/internal backend/cmd backend/graph
grep -rnE "PR[0-9]+" docs backend/internal backend/cmd backend/graph
# Expect: empty for both.
```

## Test plan

- [ ] `cd backend && go build ./...` succeeds.
- [ ] `cd backend && go vet ./...` succeeds.
- [ ] `cd backend && go test -race -count=1 ./...` all green.
- [ ] `cd backend && go tool go-arch-lint check --project-path .` exits 0.
- [ ] `supabase db reset --local` applies cleanly; `\d swipe_records` shows `cardgroup_id uuid not null`.
- [ ] Migration down → up roundtrip test passes.
- [ ] `grep -n 'Joins.*cards' backend/internal/repository/swipe_record.go` returns empty.
- [ ] Production diff under the 800-line ceiling (~52 lines production, well under).
- [ ] CI green on this branch.

Closes #201
