### PR TITLE
refactor(usecase): pass through context.Canceled in swipe.go and learn.go

### DIFF
--- a/.claude/rules/error-wrapping.md
+++ b/.claude/rules/error-wrapping.md
@@ -85,6 +85,7 @@ detection is grep-based today and pinned at single-file
 - [Classifier check must run before any pipeline step that appends to the classified slice](../../docs/backend/error-wrapping/classifier-check-ordering-before-pipeline-mutation.md)
 - [Redundant tests after alias-bridge deletion: cross-check existing table cases before retaining](../../docs/backend/error-wrapping/redundant-tests-after-alias-bridge-deletion.md)
 - [Error classifier helper: pass-through sentinels and typed errors, wrap infra errors with caller-supplied prefix](../../docs/backend/error-wrapping/error-classifier-helper-pass-through-with-caller-prefix.md)
+- [Pin unwrapped context error identity at the usecase boundary](../../docs/backend/error-wrapping/pin-unwrapped-context-error-with-identity-check.md)
 - [Application vs Presentation error responsibility split: usecase is consumer-agnostic; wire shape is a Presentation decision](../../docs/backend/error-wrapping/application-presentation-error-responsibility.md)
 - [Generic helper vs aggregate-specific wrap prefix: bare package name for cross-aggregate helpers, two-segment prefix for aggregate-scoped code](../../docs/backend/error-wrapping/generic-helper-vs-aggregate-prefix.md)
 

--- a/backend/internal/usecase/learn.go
+++ b/backend/internal/usecase/learn.go
@@ -111,6 +111,9 @@ func (u *LearnUsecase) NextDueCards(ctx context.Context, cardgroupID string, lim
 		if errors.Is(err, repository.ErrNotFound) {
 			return nil, ucerr.NewValidationError("cardgroupId", "cardgroup not found")
 		}
+		if isContextDone(err) {
+			return nil, err
+		}
 		return nil, eris.Wrap(err, "usecase: find cardgroup by id")
 	}
 	if !cg.IsOwnedBy(user.Sub) {
@@ -124,6 +127,9 @@ func (u *LearnUsecase) NextDueCards(ctx context.Context, cardgroupID string, lim
 	now := u.clock.Now().UTC()
 	due, err := u.cardRepo.FindDueCardsForUser(ctx, user.Sub, cardgroupID, now, n)
 	if err != nil {
+		if isContextDone(err) {
+			return nil, err
+		}
 		return nil, eris.Wrap(err, "usecase: learn: find due cards")
 	}
 	ordered := u.ordering.Apply(due, u.randSource())

--- a/backend/internal/usecase/learn_test.go
+++ b/backend/internal/usecase/learn_test.go
@@ -348,6 +348,7 @@ func TestLearnUsecase_NextDueCards_FindCardgroup_PropagatesCancelled(t *testing.
 	)
 	_, err := uc.NextDueCards(authedCtx("u-1"), "cg-1", nil)
 	assertCancelled(t, err)
+	require.Equal(t, context.Canceled, err, "expected unwrapped context.Canceled, got %v", err)
 }
 
 // TestLearnUsecase_NextDueCards_FindDueCards_PropagatesDeadlineExceeded verifies

--- a/backend/internal/usecase/learn_test.go
+++ b/backend/internal/usecase/learn_test.go
@@ -330,3 +330,43 @@ func learnCardIDs(cards []*domain.Card) []string {
 }
 
 func learnIntPtr(v int) *int { return &v }
+
+// TestLearnUsecase_NextDueCards_FindCardgroup_PropagatesCancelled verifies that
+// context.Canceled returned by the cardgroup repository is propagated unwrapped.
+func TestLearnUsecase_NextDueCards_FindCardgroup_PropagatesCancelled(t *testing.T) {
+	t.Parallel()
+	cgRepo := &mockLearnCardgroupRepo{err: context.Canceled}
+	uc := NewLearnUsecase(
+		&mockLearnCardRepo{},
+		cgRepo,
+		nil,
+		nil,
+		20,
+		100,
+		fixedClock{now: time.Now()},
+		newTestLogger(),
+	)
+	_, err := uc.NextDueCards(authedCtx("u-1"), "cg-1", nil)
+	assertCancelled(t, err)
+}
+
+// TestLearnUsecase_NextDueCards_FindDueCards_PropagatesDeadlineExceeded verifies
+// that context.DeadlineExceeded returned by the card repository is propagated
+// unwrapped after a successful cardgroup lookup.
+func TestLearnUsecase_NextDueCards_FindDueCards_PropagatesDeadlineExceeded(t *testing.T) {
+	t.Parallel()
+	cardRepo := &mockLearnCardRepo{err: context.DeadlineExceeded}
+	cgRepo := &mockLearnCardgroupRepo{cardgroup: &domain.Cardgroup{ID: "cg-1", OwnerID: "u-1"}}
+	uc := NewLearnUsecase(
+		cardRepo,
+		cgRepo,
+		nil,
+		nil,
+		20,
+		100,
+		fixedClock{now: time.Now()},
+		newTestLogger(),
+	)
+	_, err := uc.NextDueCards(authedCtx("u-1"), "cg-1", nil)
+	assertCancelled(t, err)
+}

--- a/backend/internal/usecase/swipe.go
+++ b/backend/internal/usecase/swipe.go
@@ -181,6 +181,9 @@ func (u *SwipeUsecase) HandleSwipe(ctx context.Context, in HandleSwipeInput) (Ha
 			if errors.Is(err, repository.ErrNotFound) {
 				return ucerr.NewValidationError("cardId", "card not found")
 			}
+			if isContextDone(err) {
+				return err
+			}
 			return eris.Wrap(err, "usecase: swipe: find card by id")
 		}
 		if !card.BelongsToCardgroup(in.CardgroupID) {
@@ -190,6 +193,9 @@ func (u *SwipeUsecase) HandleSwipe(ctx context.Context, in HandleSwipeInput) (Ha
 		now = time.Now().UTC()
 		byCardID, err := u.userFSRSRepo.FindByUserAndCardIDsTx(ctx, tx, user.Sub, []string{card.ID})
 		if err != nil {
+			if isContextDone(err) {
+				return err
+			}
 			return eris.Wrap(err, "usecase: swipe: find user-card fsrs")
 		}
 		current := byCardID[card.ID]
@@ -200,6 +206,9 @@ func (u *SwipeUsecase) HandleSwipe(ctx context.Context, in HandleSwipeInput) (Ha
 			return eris.Wrap(err, "usecase: swipe: apply rating")
 		}
 		if err := u.userFSRSRepo.UpsertTx(ctx, tx, current); err != nil {
+			if isContextDone(err) {
+				return err
+			}
 			return eris.Wrap(err, "usecase: swipe: upsert user-card fsrs")
 		}
 		sr, err := u.newSwipeRecord(user.Sub, card.ID, card.CardgroupID, rating, now, current.State)
@@ -207,10 +216,16 @@ func (u *SwipeUsecase) HandleSwipe(ctx context.Context, in HandleSwipeInput) (Ha
 			return eris.Wrap(err, "usecase: swipe: new swipe record")
 		}
 		if err := u.swipeRepo.CreateTx(ctx, tx, sr); err != nil {
+			if isContextDone(err) {
+				return err
+			}
 			return eris.Wrap(err, "usecase: swipe: insert swipe record")
 		}
 		due, err := u.cardRepo.FindDueCardsForUserTx(ctx, tx, user.Sub, in.CardgroupID, now, u.nextBatchSize)
 		if err != nil {
+			if isContextDone(err) {
+				return err
+			}
 			return eris.Wrap(err, "usecase: swipe: find due cards")
 		}
 		nextCards = u.ordering.Apply(due, u.randSource())
@@ -233,6 +248,9 @@ func (u *SwipeUsecase) HandleSwipe(ctx context.Context, in HandleSwipeInput) (Ha
 	}
 	recentSwipes, err := u.swipeRepo.ListRecentByUser(ctx, user.Sub, swipePerformanceSampleLimit)
 	if err != nil {
+		if isContextDone(err) {
+			return HandleSwipeOutcome{}, err
+		}
 		return HandleSwipeOutcome{}, eris.Wrap(err, "usecase: swipe: list recent swipes")
 	}
 	metrics := service.ComputeMetrics(swipeRecordsByValue(recentSwipes), now)

--- a/backend/internal/usecase/swipe_error_test.go
+++ b/backend/internal/usecase/swipe_error_test.go
@@ -297,6 +297,7 @@ func TestSwipeUsecase_HandleSwipe_FindCardByID_PropagatesCancelled(t *testing.T)
 	})
 
 	assertCancelled(t, err)
+	require.Equal(t, context.Canceled, err, "expected unwrapped context.Canceled, got %v", err)
 }
 
 // TestSwipeUsecase_HandleSwipe_FindUserCardFSRS_PropagatesCancelled verifies
@@ -502,4 +503,5 @@ func TestSwipeUsecase_HandleSwipe_ListRecentSwipes_PropagatesDeadlineExceeded(t 
 	})
 
 	assertCancelled(t, err)
+	require.Equal(t, context.DeadlineExceeded, err, "expected unwrapped context.DeadlineExceeded, got %v", err)
 }

--- a/backend/internal/usecase/swipe_error_test.go
+++ b/backend/internal/usecase/swipe_error_test.go
@@ -1,6 +1,7 @@
 package usecase
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -265,4 +266,240 @@ func TestSwipeUsecase_HandleSwipe_InsertSwipeRecordError_PinsChain(t *testing.T)
 
 	assertInternalChain(t, err, "usecase: swipe: insert swipe record")
 	require.ErrorIs(t, err, infraErr, "error chain must preserve injected root sentinel")
+}
+
+// TestSwipeUsecase_HandleSwipe_FindCardByID_PropagatesCancelled verifies that
+// context.Canceled returned from FindByIDTx passes through unwrapped so the
+// caller can distinguish a cancellation from an infrastructure failure.
+func TestSwipeUsecase_HandleSwipe_FindCardByID_PropagatesCancelled(t *testing.T) {
+	t.Parallel()
+
+	cardRepo := &mockCardRepository{findErr: context.Canceled}
+	cardgroupRepo := &mockCardgroupRepoForCard{
+		findResult: &domain.Cardgroup{ID: "cg-1", OwnerID: "user-1"},
+	}
+	tx, _ := fakeTxRunner()
+	uc := NewSwipeUsecaseWithTx(
+		cardRepo,
+		cardgroupRepo,
+		&mockSwipeRecordRepoForSwipe{},
+		service.NewFSRSScheduler(),
+		10,
+		tx,
+		&mockUserCardFSRSRepository{byCardID: map[string]*domain.UserCardFSRS{}},
+		newTestLogger(),
+	)
+
+	_, err := uc.HandleSwipe(authedCtx("user-1"), HandleSwipeInput{
+		CardID:      "card-1",
+		CardgroupID: "cg-1",
+		Mode:        int(domain.RatingEasy),
+	})
+
+	assertCancelled(t, err)
+}
+
+// TestSwipeUsecase_HandleSwipe_FindUserCardFSRS_PropagatesCancelled verifies
+// that context.Canceled returned from FindByUserAndCardIDsTx passes through
+// unwrapped after FindByIDTx succeeds.
+func TestSwipeUsecase_HandleSwipe_FindUserCardFSRS_PropagatesCancelled(t *testing.T) {
+	t.Parallel()
+
+	cardRepo := &mockCardRepository{
+		findResult: &domain.Card{
+			ID:          "card-1",
+			CardgroupID: "cg-1",
+		},
+	}
+	cardgroupRepo := &mockCardgroupRepoForCard{
+		findResult: &domain.Cardgroup{ID: "cg-1", OwnerID: "user-1"},
+	}
+	userFSRSRepo := &mockUserCardFSRSRepository{
+		byCardID: map[string]*domain.UserCardFSRS{},
+		findErr:  context.Canceled,
+	}
+	tx, _ := fakeTxRunner()
+	uc := NewSwipeUsecaseWithTx(
+		cardRepo,
+		cardgroupRepo,
+		&mockSwipeRecordRepoForSwipe{},
+		service.NewFSRSScheduler(),
+		10,
+		tx,
+		userFSRSRepo,
+		newTestLogger(),
+	)
+
+	_, err := uc.HandleSwipe(authedCtx("user-1"), HandleSwipeInput{
+		CardID:      "card-1",
+		CardgroupID: "cg-1",
+		Mode:        int(domain.RatingEasy),
+	})
+
+	assertCancelled(t, err)
+}
+
+// TestSwipeUsecase_HandleSwipe_UpsertUserCardFSRS_PropagatesCancelled verifies
+// that context.Canceled returned from UpsertTx passes through unwrapped after
+// the preceding find steps succeed.
+func TestSwipeUsecase_HandleSwipe_UpsertUserCardFSRS_PropagatesCancelled(t *testing.T) {
+	t.Parallel()
+
+	cardRepo := &mockCardRepository{
+		findResult: &domain.Card{
+			ID:          "card-1",
+			CardgroupID: "cg-1",
+		},
+	}
+	cardgroupRepo := &mockCardgroupRepoForCard{
+		findResult: &domain.Cardgroup{ID: "cg-1", OwnerID: "user-1"},
+	}
+	userFSRSRepo := &mockUserCardFSRSRepository{
+		byCardID:  map[string]*domain.UserCardFSRS{},
+		upsertErr: context.Canceled,
+	}
+	tx, _ := fakeTxRunner()
+	uc := NewSwipeUsecaseWithTx(
+		cardRepo,
+		cardgroupRepo,
+		&mockSwipeRecordRepoForSwipe{},
+		service.NewFSRSScheduler(),
+		10,
+		tx,
+		userFSRSRepo,
+		newTestLogger(),
+	)
+
+	_, err := uc.HandleSwipe(authedCtx("user-1"), HandleSwipeInput{
+		CardID:      "card-1",
+		CardgroupID: "cg-1",
+		Mode:        int(domain.RatingEasy),
+	})
+
+	assertCancelled(t, err)
+}
+
+// TestSwipeUsecase_HandleSwipe_InsertSwipeRecord_PropagatesCancelled verifies
+// that context.Canceled returned from CreateTx passes through unwrapped after
+// the upsert step succeeds.
+func TestSwipeUsecase_HandleSwipe_InsertSwipeRecord_PropagatesCancelled(t *testing.T) {
+	t.Parallel()
+
+	cardRepo := &mockCardRepository{
+		findResult: &domain.Card{
+			ID:          "card-1",
+			CardgroupID: "cg-1",
+		},
+	}
+	cardgroupRepo := &mockCardgroupRepoForCard{
+		findResult: &domain.Cardgroup{ID: "cg-1", OwnerID: "user-1"},
+	}
+	swipeRepo := &mockSwipeRecordRepoForSwipe{
+		createErr: context.Canceled,
+	}
+	userFSRSRepo := &mockUserCardFSRSRepository{
+		byCardID: map[string]*domain.UserCardFSRS{},
+	}
+	tx, _ := fakeTxRunner()
+	uc := NewSwipeUsecaseWithTx(
+		cardRepo,
+		cardgroupRepo,
+		swipeRepo,
+		service.NewFSRSScheduler(),
+		10,
+		tx,
+		userFSRSRepo,
+		newTestLogger(),
+	)
+
+	_, err := uc.HandleSwipe(authedCtx("user-1"), HandleSwipeInput{
+		CardID:      "card-1",
+		CardgroupID: "cg-1",
+		Mode:        int(domain.RatingEasy),
+	})
+
+	assertCancelled(t, err)
+}
+
+// TestSwipeUsecase_HandleSwipe_FindDueCards_PropagatesCancelled verifies that
+// context.Canceled returned from FindDueCardsForUserTx passes through unwrapped
+// after the insert step succeeds.
+func TestSwipeUsecase_HandleSwipe_FindDueCards_PropagatesCancelled(t *testing.T) {
+	t.Parallel()
+
+	cardRepo := &mockCardRepository{
+		findResult: &domain.Card{
+			ID:          "card-1",
+			CardgroupID: "cg-1",
+		},
+		findDueErr: context.Canceled,
+	}
+	cardgroupRepo := &mockCardgroupRepoForCard{
+		findResult: &domain.Cardgroup{ID: "cg-1", OwnerID: "user-1"},
+	}
+	userFSRSRepo := &mockUserCardFSRSRepository{
+		byCardID: map[string]*domain.UserCardFSRS{},
+	}
+	tx, _ := fakeTxRunner()
+	uc := NewSwipeUsecaseWithTx(
+		cardRepo,
+		cardgroupRepo,
+		&mockSwipeRecordRepoForSwipe{},
+		service.NewFSRSScheduler(),
+		10,
+		tx,
+		userFSRSRepo,
+		newTestLogger(),
+	)
+
+	_, err := uc.HandleSwipe(authedCtx("user-1"), HandleSwipeInput{
+		CardID:      "card-1",
+		CardgroupID: "cg-1",
+		Mode:        int(domain.RatingEasy),
+	})
+
+	assertCancelled(t, err)
+}
+
+// TestSwipeUsecase_HandleSwipe_ListRecentSwipes_PropagatesDeadlineExceeded
+// verifies that context.DeadlineExceeded returned from ListRecentByUser passes
+// through unwrapped after the transaction commits successfully.
+func TestSwipeUsecase_HandleSwipe_ListRecentSwipes_PropagatesDeadlineExceeded(t *testing.T) {
+	t.Parallel()
+
+	cardRepo := &mockCardRepository{
+		findResult: &domain.Card{
+			ID:          "card-1",
+			CardgroupID: "cg-1",
+		},
+		findDueRows: []domain.DueCard{},
+	}
+	cardgroupRepo := &mockCardgroupRepoForCard{
+		findResult: &domain.Cardgroup{ID: "cg-1", OwnerID: "user-1"},
+	}
+	swipeRepo := &mockSwipeRecordRepoForSwipe{
+		listErr: context.DeadlineExceeded,
+	}
+	userFSRSRepo := &mockUserCardFSRSRepository{
+		byCardID: map[string]*domain.UserCardFSRS{},
+	}
+	tx, _ := fakeTxRunner()
+	uc := NewSwipeUsecaseWithTx(
+		cardRepo,
+		cardgroupRepo,
+		swipeRepo,
+		service.NewFSRSScheduler(),
+		10,
+		tx,
+		userFSRSRepo,
+		newTestLogger(),
+	)
+
+	_, err := uc.HandleSwipe(authedCtx("user-1"), HandleSwipeInput{
+		CardID:      "card-1",
+		CardgroupID: "cg-1",
+		Mode:        int(domain.RatingEasy),
+	})
+
+	assertCancelled(t, err)
 }

--- a/docs/backend/error-wrapping/pin-unwrapped-context-error-with-identity-check.md
+++ b/docs/backend/error-wrapping/pin-unwrapped-context-error-with-identity-check.md
@@ -1,0 +1,87 @@
+# Pin unwrapped context error identity at the usecase boundary
+
+> Part of the [error wrapping convention](../../../.claude/rules/error-wrapping.md) rules.
+> Related: [Legacy primitives (resolver-only)](../../../.claude/rules/error-wrapping.md#legacy-primitives-resolver-only),
+> [Test the `error_chain` shape, not just its presence](test-error-chain-shape-not-presence.md),
+> [Dead context-done branch in pass-through helper](../library-gotchas/dead-context-check-in-pass-through-helper.md).
+
+The usecase contract says `context.Canceled` and `context.DeadlineExceeded`
+pass through **unwrapped** so the resolver's `gqlerr.FromUsecaseError` can route
+them to `Cancelled(ctx, err)` via `errors.Is`. Tests that only call
+`assertCancelled(t, err)` verify the weaker chain-shape contract — they pass
+whether the error is the bare sentinel or `eris.Wrap(context.Canceled, "...")`.
+A future refactor that adds a wrap on top would not break those tests, but
+would silently change the wire-format classification at the resolver.
+
+## Why `assertCancelled` alone is too weak
+
+`assertCancelled` (`backend/internal/usecase/helpers_test.go`) is
+`errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)`.
+`errors.Is` walks the eris chain, so the assertion succeeds for any error whose
+chain contains a context sentinel anywhere — including wrapped variants:
+
+```go
+// Both pass assertCancelled, but only the first is contract-compliant
+// at the usecase boundary.
+err1 := context.Canceled
+err2 := eris.Wrap(context.Canceled, "usecase: swipe: find card")
+```
+
+The pass-through contract is identity-level: the resolver expects the value it
+receives to **be** the context sentinel, not merely to wrap one. A wrap would
+still classify correctly today (`gqlerr.FromUsecaseError` uses `errors.Is`),
+but the contract documented in the error-wrapping rules is the stronger
+identity form, and downstream code that compares via `==` rather than
+`errors.Is` (e.g. a future logger that suppresses bare context errors) breaks
+silently if the wrap leaks in.
+
+## The dual assertion
+
+Representative tests use `assertCancelled` for the chain check **and**
+`require.Equal` for the identity check:
+
+```go
+// backend/internal/usecase/swipe_error_test.go
+_, err := uc.HandleSwipe(authedCtx("user-1"), HandleSwipeInput{...})
+
+assertCancelled(t, err)
+require.Equal(t, context.Canceled, err,
+    "expected unwrapped context.Canceled, got %v", err)
+```
+
+`assertCancelled` keeps the canonical narrowing-failure message ("expected
+context.Canceled or context.DeadlineExceeded in chain"); `require.Equal` adds
+the identity pin. The two together fail loudly in both directions: a missing
+chain match and a snuck-in wrap.
+
+## Why not strengthen `assertCancelled` itself
+
+`assertCancelled` is a generic helper used across the usecase test suite,
+including paths where a wrap is legitimate (e.g. an infrastructure-class error
+that happens to carry a cancelled context in its chain). Strengthening the
+helper to `require.Equal` would over-constrain those call sites. The
+layer-specific strength — usecase-boundary returns are identity-level, deeper
+layers are chain-level — belongs at the test level, not the helper level.
+
+## Choosing representative tests
+
+The `require.Equal` pin lives on a small number of structurally distinct
+representative tests, not every cancellation test:
+
+| Test | Pinned shape | Why it is representative |
+|---|---|---|
+| `TestSwipeUsecase_HandleSwipe_FindCardByID_PropagatesCancelled` (`swipe_error_test.go`) | In-tx path | Error originates inside the `txRunner` closure |
+| `TestSwipeUsecase_HandleSwipe_ListRecentSwipes_PropagatesDeadlineExceeded` (`swipe_error_test.go`) | Post-tx path | Error originates after the tx commits |
+| `TestLearnUsecase_NextDueCards_FindCardgroup_PropagatesCancelled` (`learn_test.go`) | Separate usecase | Confirms the contract holds across usecase boundaries, not just one |
+
+Each test exercises a structurally distinct code path that could regress
+independently. Pinning identity on all cancellation tests would be redundant
+without strengthening coverage; pinning on these three covers the orthogonal
+seams where a wrap could plausibly leak in.
+
+## Self-check
+
+Before merging a cancellation test, complete this sentence: "If a future
+refactor wraps the context error with `eris.Wrap`, this test will ___." If
+the answer is "still pass", and the test exercises a usecase boundary, add
+the `require.Equal` identity pin.


### PR DESCRIPTION
## Summary

Closes #206. Converts 8 infrastructure call sites in `swipe.go` (6 guards) and `learn.go` (2 guards) to pass `context.Canceled` and `context.DeadlineExceeded` through unwrapped, so the resolver's `errors.Is`-based classification routes them to the `Cancelled` wire shape rather than `Internal`. Production diff is well under the 800-line ceiling in [`.claude/rules/pr-sizing.md`](.claude/rules/pr-sizing.md).

## Background / Motivation

- **`eris.Wrap` on a context sentinel breaks `errors.Is`.** `eris.Wrap(context.Canceled, "usecase: swipe: ...")` creates a new error chain; the resolver's `errors.Is(err, context.Canceled)` check returns `false`, so mid-flight cancellations were silently promoted to `gqlerr.Internal` responses visible to clients. An explicit early-return guard before the `eris.Wrap` site restores the bare-sentinel identity.
- **Convention was already applied across `admin_user.go`, `user.go`, `last_viewed_cardgroup.go`, `dictionary.go`, and others;** `swipe.go` and `learn.go` were the remaining gaps. The requirement is in [`.claude/rules/error-wrapping.md`](.claude/rules/error-wrapping.md#legacy-primitives-resolver-only).
- **`error_chain` mis-attribution.** Although `gqlerr.FromUsecaseError` uses `errors.Is` (chain-walking) so the wire shape was incidentally correct, the `error_chain` log attribute carried a misleading `"usecase: swipe: ..."` prefix on cancellation paths. Any future `==` comparison would also have failed silently.
- **Identity check complements chain check.** `assertCancelled` walks the chain via `errors.Is`; the new `require.Equal(t, context.Canceled, err)` cases assert pointer identity, proving no wrapper struct is allocated before the return.

## Changes

### `swipe.go` — 6 pass-through guards

Added `isContextDone(err)` early-return before the corresponding `eris.Wrap` site at:
- `FindByIDTx` (find card by id)
- `FindByUserAndCardIDsTx` (find user-card fsrs)
- `UpsertTx` (upsert user-card fsrs)
- `CreateTx` (insert swipe record)
- `FindDueCardsForUserTx` (find due cards)
- `ListRecentByUser` (list recent swipes)

### `learn.go` — 2 pass-through guards

Added `isContextDone(err)` early-return before the corresponding `eris.Wrap` site at:
- `cardgroupRepo.FindByID` (find cardgroup by id)
- `cardRepo.FindDueCardsForUser` (find due cards)

### Tests

- `usecase/swipe_error_test.go`: 6 new `context.Canceled` propagation tests, one per modified site.
- `usecase/learn_test.go`: 2 new `context.Canceled` propagation tests.
- 3 of the 8 new cases also assert `require.Equal(t, context.Canceled, err)` to pin pointer identity at structurally distinct boundary positions (in-tx, post-tx, separate usecase).

### Docs

- New L3 doc `docs/backend/error-wrapping/pin-unwrapped-context-error-with-identity-check.md` explains the dual-assertion design (chain check + identity check) and the `isContextDone` helper convention.
- Added bullet link to the new L3 doc in `.claude/rules/error-wrapping.md`.

## Verification

```bash
cd backend
go build ./...
go vet ./...
go test -race -count=1 ./...                # 1303 tests pass
go tool go-arch-lint check --project-path . # no warnings

# Guards are in place at every modified site.
grep -n 'isContextDone' backend/internal/usecase/swipe.go backend/internal/usecase/learn.go
# Expect: 6 hits in swipe.go, 2 hits in learn.go.

# No eris.Wrap immediately after a context-done guard (guard must precede wrap).
grep -A2 'isContextDone' backend/internal/usecase/swipe.go | grep 'eris.Wrap'
# Expect: empty (the return is the immediate next line).

# Production diff under the 800-line ceiling.
git diff --stat main..HEAD -- '*.go' ':!*_test.go' | tail -1
# Expect: 24 insertions, 0 deletions — well under 800.

# Language-policy: no CJK, no PR-order references.
grep -rlP "[\x{3040}-\x{30ff}\x{4e00}-\x{9fff}]" \
  --include="*.go" --include="*.md" \
  docs backend/internal backend/cmd backend/graph
grep -rnE "PR[0-9]+" docs backend/internal backend/cmd backend/graph
# Expect: empty for both.
```

## Test plan

- [x] `cd backend && go build ./...` succeeds
- [x] `cd backend && go vet ./...` clean
- [x] `cd backend && go test -race -count=1 ./...` — 1303 tests pass
- [x] `cd backend && go tool go-arch-lint check --project-path .` exits 0
- [x] Existing `*_PinsChain` regression tests still pin the non-cancellation `eris.Wrap` prefix (no regression on the wrapped-error path)
- [x] Production diff under the 800-line ceiling (24 lines production)
- [ ] CI green on this branch

## Out of scope

- `backend/internal/usecase/ownership.go` (`authorizeCardgroupOrBadInput`, `authorizeCardgroupOrUnauthenticated`) — same pass-through pattern needed in shared ownership helpers; tracked in #208.
- The pre-existing one-segment wrap prefix `"usecase: find cardgroup by id"` in `learn.go` (canonical form is two-segment per [`.claude/rules/error-wrapping.md`](.claude/rules/error-wrapping.md#canonical-layer-prefix)); left untouched to keep this diff minimal per `.claude/rules/scope-discipline.md`.

## References

- [`.claude/rules/error-wrapping.md` — context sentinel pass-through rule](.claude/rules/error-wrapping.md#legacy-primitives-resolver-only)
- [`docs/backend/error-wrapping/pin-unwrapped-context-error-with-identity-check.md`](docs/backend/error-wrapping/pin-unwrapped-context-error-with-identity-check.md) — new L3 doc for the identity-check pattern
- Follow-up: #208 (ownership helpers)

Closes #206
