### PR TITLE
refactor(domain): introduce Card.UpdateFront / Card.UpdateBack aggregate methods

### DIFF
--- a/.claude/rules/error-wrapping.md
+++ b/.claude/rules/error-wrapping.md
@@ -88,6 +88,7 @@ detection is grep-based today and pinned at single-file
 - [Pin unwrapped context error identity at the usecase boundary](../../docs/backend/error-wrapping/pin-unwrapped-context-error-with-identity-check.md)
 - [Application vs Presentation error responsibility split: usecase is consumer-agnostic; wire shape is a Presentation decision](../../docs/backend/error-wrapping/application-presentation-error-responsibility.md)
 - [Generic helper vs aggregate-specific wrap prefix: bare package name for cross-aggregate helpers, two-segment prefix for aggregate-scoped code](../../docs/backend/error-wrapping/generic-helper-vs-aggregate-prefix.md)
+- [Defense-in-depth aggregate-method errors classify as INTERNAL, not BAD_USER_INPUT](../../docs/backend/error-wrapping/defense-in-depth-classification-internal.md)
 
 ## Background
 

--- a/.claude/rules/go-library-gotchas.md
+++ b/.claude/rules/go-library-gotchas.md
@@ -114,6 +114,7 @@ This matters most in DataLoader batch functions, where an empty key slice is a n
 - [Dead context-done branch in pass-through helper — collapse to single return](../../docs/backend/library-gotchas/dead-context-check-in-pass-through-helper.md)
 - [GORM v1 round-trips underlying-string newtypes without Scanner/Valuer; reserving the `Value` accessor slot](../../docs/backend/library-gotchas/gorm-newtype-string-no-scanner-valuer.md)
 - [Defensive-copy tests assert pointer identity (`require.NotSame`), not variable rebind](../../docs/backend/library-gotchas/defensive-copy-test-pointer-identity.md)
+- [Mock-pointer fixture pitfalls: directionality tautology and parallel sub-test races](../../docs/backend/library-gotchas/mock-pointer-fixture-pitfalls.md)
 - [GORM embedded struct with `TableName()` silently breaks the outer scan target](../../docs/backend/library-gotchas/gorm-embedded-tablename-scan-confusion.md)
 - [Interleave trailing-append paths need a non-divisible fixture per direction](../../docs/backend/library-gotchas/interleave-trailing-append-test-fixture.md)
 - [Fat repository interface split: CRUD vs membership seam — when and how to split, wiring checklist, context pass-through in validation helpers](../../docs/backend/library-gotchas/fat-repository-interface-split.md)

--- a/backend/internal/domain/card.go
+++ b/backend/internal/domain/card.go
@@ -46,3 +46,28 @@ func (c *Card) Validate() error {
 	}
 	return nil
 }
+
+// UpdateFront updates the card's front text to the supplied value and returns an
+// error if the value is the zero CardText. The zero-value guard is defense-in-depth:
+// production callers parse the input through ParseCardText before reaching this
+// method, so structural invariants (length, non-empty) are enforced at VO construction
+// time. This method enforces only the aggregate-state invariant that c.Front must
+// never be the zero value. UpdatedAt is intentionally not modified here; persistence
+// is responsible for stamping the modification timestamp.
+func (c *Card) UpdateFront(front CardText) error {
+	if front == "" {
+		return ErrCardFrontRequired
+	}
+	c.Front = front
+	return nil
+}
+
+// UpdateBack mirrors UpdateFront for the back text; see UpdateFront for the
+// defense-in-depth rationale and the UpdatedAt non-stamping note.
+func (c *Card) UpdateBack(back CardText) error {
+	if back == "" {
+		return ErrCardBackRequired
+	}
+	c.Back = back
+	return nil
+}

--- a/backend/internal/domain/card_test.go
+++ b/backend/internal/domain/card_test.go
@@ -176,3 +176,101 @@ func TestRatingFromSwipeMode(t *testing.T) {
 		})
 	}
 }
+
+func TestCardUpdateFront(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		initial   Card
+		newFront  CardText
+		wantErr   error
+		wantFront CardText
+		wantBack  CardText
+	}{
+		{
+			name:      "empty CardText rejected with ErrCardFrontRequired",
+			initial:   Card{ID: "c", CardgroupID: "cg", Front: "front", Back: "back"},
+			newFront:  "",
+			wantErr:   ErrCardFrontRequired,
+			wantFront: "front", // unchanged on error
+			wantBack:  "back",
+		},
+		{
+			name:      "valid CardText updates Front and returns nil",
+			initial:   Card{ID: "c", CardgroupID: "cg", Front: "front", Back: "back"},
+			newFront:  "new front",
+			wantErr:   nil,
+			wantFront: "new front",
+			wantBack:  "back",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			card := tc.initial
+			err := card.UpdateFront(tc.newFront)
+
+			if tc.wantErr != nil {
+				require.Error(t, err)
+				require.True(t, errors.Is(err, tc.wantErr), "got %v", err)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, tc.wantFront, card.Front)
+			// Back must remain untouched regardless of outcome.
+			require.Equal(t, tc.wantBack, card.Back)
+		})
+	}
+}
+
+func TestCardUpdateBack(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		initial   Card
+		newBack   CardText
+		wantErr   error
+		wantFront CardText
+		wantBack  CardText
+	}{
+		{
+			name:      "empty CardText rejected with ErrCardBackRequired",
+			initial:   Card{ID: "c", CardgroupID: "cg", Front: "front", Back: "back"},
+			newBack:   "",
+			wantErr:   ErrCardBackRequired,
+			wantFront: "front",
+			wantBack:  "back", // unchanged on error
+		},
+		{
+			name:      "valid CardText updates Back and returns nil",
+			initial:   Card{ID: "c", CardgroupID: "cg", Front: "front", Back: "back"},
+			newBack:   "new back",
+			wantErr:   nil,
+			wantFront: "front",
+			wantBack:  "new back",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			card := tc.initial
+			err := card.UpdateBack(tc.newBack)
+
+			if tc.wantErr != nil {
+				require.Error(t, err)
+				require.True(t, errors.Is(err, tc.wantErr), "got %v", err)
+			} else {
+				require.NoError(t, err)
+			}
+			// Front must remain untouched regardless of outcome.
+			require.Equal(t, tc.wantFront, card.Front)
+			require.Equal(t, tc.wantBack, card.Back)
+		})
+	}
+}

--- a/backend/internal/domain/card_test.go
+++ b/backend/internal/domain/card_test.go
@@ -214,8 +214,7 @@ func TestCardUpdateFront(t *testing.T) {
 			err := card.UpdateFront(tc.newFront)
 
 			if tc.wantErr != nil {
-				require.Error(t, err)
-				require.True(t, errors.Is(err, tc.wantErr), "got %v", err)
+				require.ErrorIs(t, err, tc.wantErr)
 			} else {
 				require.NoError(t, err)
 			}
@@ -263,8 +262,7 @@ func TestCardUpdateBack(t *testing.T) {
 			err := card.UpdateBack(tc.newBack)
 
 			if tc.wantErr != nil {
-				require.Error(t, err)
-				require.True(t, errors.Is(err, tc.wantErr), "got %v", err)
+				require.ErrorIs(t, err, tc.wantErr)
 			} else {
 				require.NoError(t, err)
 			}

--- a/backend/internal/usecase/card.go
+++ b/backend/internal/usecase/card.go
@@ -311,7 +311,10 @@ func (u *CardUsecase) Update(ctx context.Context, id string, in UpdateCardInput)
 			}
 			return UpdateCardOutcome{Validation: info}, nil
 		}
-		s := front.String()
+		if err := existing.UpdateFront(front); err != nil {
+			return UpdateCardOutcome{}, eris.Wrap(err, "usecase: card: update front")
+		}
+		s := existing.Front.String()
 		patch.Front = &s
 	}
 	if in.Back != nil {
@@ -323,7 +326,10 @@ func (u *CardUsecase) Update(ctx context.Context, id string, in UpdateCardInput)
 			}
 			return UpdateCardOutcome{Validation: info}, nil
 		}
-		s := back.String()
+		if err := existing.UpdateBack(back); err != nil {
+			return UpdateCardOutcome{}, eris.Wrap(err, "usecase: card: update back")
+		}
+		s := existing.Back.String()
 		patch.Back = &s
 	}
 

--- a/backend/internal/usecase/card.go
+++ b/backend/internal/usecase/card.go
@@ -303,10 +303,12 @@ func (u *CardUsecase) Update(ctx context.Context, id string, in UpdateCardInput)
 
 	patch := repository.CardUpdate{}
 	// UpdateFront/UpdateBack errors below are routed through eris.Wrap, not
-	// translateCardErr: ParseCardText above already guarantees a non-zero VO
-	// reaches the method, so any error here signals an invariant violation
-	// (programmer error), not bad user input. INTERNAL is the honest
-	// classification — surfacing as BAD_USER_INPUT would mislead the client.
+	// translateCardErr: ParseCardText (called immediately inside each guard)
+	// already returns the sentinel for empty/zero input on the validation
+	// channel. If UpdateFront/UpdateBack still rejects the parsed VO, the
+	// invariant has been violated by a programmer error, not bad user input.
+	// INTERNAL is the honest classification — surfacing as BAD_USER_INPUT
+	// would mislead the client.
 	if in.Front != nil {
 		front, err := domain.ParseCardText(*in.Front, domain.ErrCardFrontRequired, domain.ErrCardFrontTooLong)
 		if err != nil {

--- a/backend/internal/usecase/card.go
+++ b/backend/internal/usecase/card.go
@@ -302,6 +302,11 @@ func (u *CardUsecase) Update(ctx context.Context, id string, in UpdateCardInput)
 	}
 
 	patch := repository.CardUpdate{}
+	// UpdateFront/UpdateBack errors below are routed through eris.Wrap, not
+	// translateCardErr: ParseCardText above already guarantees a non-zero VO
+	// reaches the method, so any error here signals an invariant violation
+	// (programmer error), not bad user input. INTERNAL is the honest
+	// classification — surfacing as BAD_USER_INPUT would mislead the client.
 	if in.Front != nil {
 		front, err := domain.ParseCardText(*in.Front, domain.ErrCardFrontRequired, domain.ErrCardFrontTooLong)
 		if err != nil {

--- a/backend/internal/usecase/card_test.go
+++ b/backend/internal/usecase/card_test.go
@@ -320,14 +320,57 @@ func TestCardUsecase_Update_NonOwnerAndPatch(t *testing.T) {
 		if cardRepo.capturedPatch.Front == nil || *cardRepo.capturedPatch.Front != newFront {
 			t.Fatalf("unexpected patch: %+v", cardRepo.capturedPatch)
 		}
-		// Route-through assertion: the patch is derived from the mutated aggregate,
-		// so *patch.Front must equal existing.Front.String() after UpdateFront ran.
-		if *cardRepo.capturedPatch.Front != existing.Front.String() {
-			t.Fatalf("patch.Front %q != existing.Front %q: aggregate mutation did not propagate to patch",
-				*cardRepo.capturedPatch.Front, existing.Front.String())
+		// Route-through guard: UpdateFront must have mutated the aggregate before
+		// patch derivation. A regression that bypassed UpdateFront would leave
+		// existing.Front at its initial value.
+		if existing.Front != domain.CardText(newFront) {
+			t.Fatalf("aggregate not mutated: existing.Front = %q, want %q", existing.Front, newFront)
 		}
 		if cardRepo.capturedPatch.Back != nil {
 			t.Fatalf("back should be unchanged: %+v", cardRepo.capturedPatch)
+		}
+	})
+
+	t.Run("valid partial update back", func(t *testing.T) {
+		t.Parallel()
+		newBack := "new back"
+		existingBack := &domain.Card{
+			ID:          "card1",
+			CardgroupID: "cg1",
+			Front:       domain.CardText("old front"),
+			Back:        domain.CardText("old back"),
+		}
+		cardRepo := &mockCardRepository{
+			findResult:   existingBack,
+			updateResult: &domain.Card{ID: "card1", CardgroupID: "cg1", Front: "old front", Back: domain.CardText(newBack)},
+		}
+		uc := NewCardUsecase(nil, cardRepo,
+			&mockCardgroupRepoForCard{findResult: &domain.Cardgroup{ID: "cg1", OwnerID: "u1"}},
+			nil, nil, newTestLogger(),
+		)
+		outcome, err := uc.Update(authedCtx("u1"), "card1", UpdateCardInput{Back: ptr(" new back ")})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if outcome.Card == nil {
+			t.Fatal("expected non-nil Card on success")
+		}
+		if outcome.Card.Back != domain.CardText(newBack) {
+			t.Fatalf("back = %q, want %q", outcome.Card.Back, newBack)
+		}
+		if outcome.Validation != nil {
+			t.Fatalf("expected nil Validation on success, got %+v", outcome.Validation)
+		}
+		if cardRepo.capturedPatch.Back == nil || *cardRepo.capturedPatch.Back != newBack {
+			t.Fatalf("unexpected patch: %+v", cardRepo.capturedPatch)
+		}
+		// Route-through guard: UpdateBack must have mutated the aggregate before
+		// patch derivation.
+		if existingBack.Back != domain.CardText(newBack) {
+			t.Fatalf("aggregate not mutated: existing.Back = %q, want %q", existingBack.Back, newBack)
+		}
+		if cardRepo.capturedPatch.Front != nil {
+			t.Fatalf("front should be unchanged: %+v", cardRepo.capturedPatch)
 		}
 	})
 }

--- a/backend/internal/usecase/card_test.go
+++ b/backend/internal/usecase/card_test.go
@@ -320,6 +320,12 @@ func TestCardUsecase_Update_NonOwnerAndPatch(t *testing.T) {
 		if cardRepo.capturedPatch.Front == nil || *cardRepo.capturedPatch.Front != newFront {
 			t.Fatalf("unexpected patch: %+v", cardRepo.capturedPatch)
 		}
+		// Route-through assertion: the patch is derived from the mutated aggregate,
+		// so *patch.Front must equal existing.Front.String() after UpdateFront ran.
+		if *cardRepo.capturedPatch.Front != existing.Front.String() {
+			t.Fatalf("patch.Front %q != existing.Front %q: aggregate mutation did not propagate to patch",
+				*cardRepo.capturedPatch.Front, existing.Front.String())
+		}
 		if cardRepo.capturedPatch.Back != nil {
 			t.Fatalf("back should be unchanged: %+v", cardRepo.capturedPatch)
 		}

--- a/backend/internal/usecase/card_test.go
+++ b/backend/internal/usecase/card_test.go
@@ -296,8 +296,17 @@ func TestCardUsecase_Update_NonOwnerAndPatch(t *testing.T) {
 	t.Run("valid partial update", func(t *testing.T) {
 		t.Parallel()
 		newFront := "new front"
+		// Isolated fixture: a parallel sibling sub-test ("non owner") also
+		// receives the outer `existing` via its mock, so writing through that
+		// shared pointer would race under -race.
+		existingFront := &domain.Card{
+			ID:          "card1",
+			CardgroupID: "cg1",
+			Front:       domain.CardText("old front"),
+			Back:        domain.CardText("old back"),
+		}
 		cardRepo := &mockCardRepository{
-			findResult:   existing,
+			findResult:   existingFront,
 			updateResult: &domain.Card{ID: "card1", CardgroupID: "cg1", Front: domain.CardText(newFront), Back: "old back"},
 		}
 		uc := NewCardUsecase(nil, cardRepo,
@@ -322,9 +331,9 @@ func TestCardUsecase_Update_NonOwnerAndPatch(t *testing.T) {
 		}
 		// Route-through guard: UpdateFront must have mutated the aggregate before
 		// patch derivation. A regression that bypassed UpdateFront would leave
-		// existing.Front at its initial value.
-		if existing.Front != domain.CardText(newFront) {
-			t.Fatalf("aggregate not mutated: existing.Front = %q, want %q", existing.Front, newFront)
+		// existingFront.Front at its initial value.
+		if existingFront.Front != domain.CardText(newFront) {
+			t.Fatalf("aggregate not mutated: existingFront.Front = %q, want %q", existingFront.Front, newFront)
 		}
 		if cardRepo.capturedPatch.Back != nil {
 			t.Fatalf("back should be unchanged: %+v", cardRepo.capturedPatch)

--- a/docs/backend/ddd-patterns/aggregate-behaviour-method.md
+++ b/docs/backend/ddd-patterns/aggregate-behaviour-method.md
@@ -81,3 +81,85 @@ func (u *UserCardFSRS) ApplyRating(scheduler FSRSScheduler, rating Rating, now t
 The usecase passes the concrete scheduler; the aggregate updates its own fields.
 `UpdatedAt` is always stamped, and the aggregate's invariants are maintained in
 one place.
+
+### Single-field aggregate mutation (`Cardgroup.Rename`, `Card.UpdateFront`/`UpdateBack`) (issues #212, #213)
+
+**Before**: `CardgroupUsecase.Update` and `CardUsecase.Update` mutated the
+persistence patch directly from a parsed VO:
+
+```go
+// old shape — patch derived from the local VO, aggregate never mutated
+nameStr := name.String()
+updated, err := u.repo.Update(ctx, id, repository.CardgroupUpdate{Name: &nameStr})
+```
+
+The aggregate (`*domain.Cardgroup`, `*domain.Card`) was loaded via `repo.FindByID`
+but never mutated through a behaviour method. A future invariant spanning two
+fields — say, `UpdatedAt >= CreatedAt` — would have had no obvious home.
+
+**After**: each aggregate exposes a behaviour method that enforces the
+aggregate-state invariant (the field must never become the zero VO). The usecase
+mutates `existing` via the method, then derives the persistence patch from the
+*mutated aggregate*:
+
+```go
+// Cardgroup.Rename — usecase route-through
+if err := existing.Rename(name); err != nil {
+    return UpdateCardgroupOutcome{}, eris.Wrap(err, "usecase: cardgroup: rename")
+}
+nameStr := existing.Name.String()
+updated, err := u.repo.Update(ctx, id, repository.CardgroupUpdate{Name: &nameStr})
+```
+
+```go
+// Card.UpdateFront — usecase route-through; UpdateBack is symmetric
+if err := existing.UpdateFront(front); err != nil {
+    return UpdateCardOutcome{}, eris.Wrap(err, "usecase: card: update front")
+}
+s := existing.Front.String()
+patch.Front = &s
+```
+
+The two-step "behaviour method → patch derivation" decouples invariant enforcement
+from persistence shape; the repository patch DTO never knows about aggregate methods.
+
+**Single-field vs combined method.** For per-field mutation — where the patch DTO
+has a `*string` per field that may independently be `nil` — two single-field methods
+beat one combined `UpdateText(front, back *CardText)` method. Reasons:
+
+1. The patch's `nil = no change` semantics belong to the usecase layer; the
+   aggregate should not interpret per-field nullability.
+2. Each single-field method encodes exactly one invariant; combined methods
+   accumulate tri-state pointer handling that obscures the per-field invariant.
+3. Symmetric methods (`UpdateFront` / `UpdateBack`) document parity and let unit
+   tests use a single shape.
+
+**Defense-in-depth zero-value guard.** Each method's body is structurally identical:
+
+```go
+func (c *Card) UpdateFront(front CardText) error {
+    if front == "" {
+        return ErrCardFrontRequired
+    }
+    c.Front = front
+    return nil
+}
+```
+
+The guard is defense-in-depth: production callers parse the input through
+`ParseCardText` before reaching the method. The guard fires only if a future caller
+bypasses the parser, which is a programmer error that classifies as `INTERNAL`, not
+`BAD_USER_INPUT`. See
+[`docs/backend/error-wrapping/defense-in-depth-classification-internal.md`](../error-wrapping/defense-in-depth-classification-internal.md).
+
+`Cardgroup.Rename` follows the identical shape using `CardgroupName` and
+`ErrCardgroupNameRequired`.
+
+**`UpdatedAt` is intentionally not stamped by the aggregate methods.** Persistence
+(GORM `AutoUpdateTime` on the `UpdatedAt` field) is the canonical source of the
+modification timestamp. Stamping `c.UpdatedAt = time.Now()` inside a behaviour
+method would couple the aggregate to a clock seam and introduce a second
+source-of-truth for the timestamp. Compare `UserCardFSRS.ApplyRating` above, which
+does stamp `UpdatedAt` — that case owns the full state-transition including the
+timestamp because the FSRS algorithm dictates the exact moment the card state
+changes; the simpler rename/field-update cases have no such requirement.

--- a/docs/backend/error-wrapping/defense-in-depth-classification-internal.md
+++ b/docs/backend/error-wrapping/defense-in-depth-classification-internal.md
@@ -1,0 +1,126 @@
+# Defense-in-depth aggregate-method errors classify as INTERNAL, not BAD_USER_INPUT
+
+> Part of the [error-wrapping conventions](../../../.claude/rules/error-wrapping.md) rules.
+
+## Why
+
+A field-validation sentinel can appear on two paths in the same usecase:
+
+1. **Validation channel** (the user-input boundary): `domain.ParseX(in)` returns
+   the sentinel because the user supplied a bad value. The usecase translates it
+   via `liftValidationErr(translateXErr(err))` to `ucerr.NewValidationError(...)`,
+   surfacing on the wire as `BAD_USER_INPUT` with the field name.
+2. **Defense-in-depth path** (the aggregate behaviour method): `aggregate.UpdateX(parsedVO)`
+   returns the same sentinel because the parsed VO turned out to be the zero value.
+   By construction this is unreachable in production — `ParseX` upstream rejects
+   the zero value first. If the path *does* fire, a programmer has bypassed the
+   upstream gate.
+
+The temptation is to route both paths through `translateXErr` "for consistency".
+This is wrong: the two paths represent different failure modes and must classify
+differently.
+
+- **Validation channel** — the user gave bad input. The client receives
+  `BAD_USER_INPUT` and the user can correct it.
+- **Defense-in-depth path** — a programmer caller violated the aggregate's
+  invariant after the gate. The client receives `INTERNAL` because the situation
+  is a server-side bug, not a user-input problem. The Application layer logs the
+  wrapped error chain so the bug can be diagnosed.
+
+Collapsing both into `BAD_USER_INPUT` lies to the user: they cannot fix the input
+because the input was already valid. Collapsing both into `INTERNAL` hides genuine
+validation errors that the user could fix. The classification must match the
+failure mode, not the sentinel identity.
+
+## What
+
+The usecase wraps a defense-in-depth aggregate-method return with `eris.Wrap`,
+not with the validation classifier:
+
+```go
+// backend/internal/usecase/card.go — CardUsecase.Update (excerpt)
+
+// UpdateFront/UpdateBack errors below are routed through eris.Wrap, not
+// translateCardErr: ParseCardText (called immediately inside each guard)
+// already returns the sentinel for empty/zero input on the validation
+// channel. If UpdateFront/UpdateBack still rejects the parsed VO, the
+// invariant has been violated by a programmer error, not bad user input.
+// INTERNAL is the honest classification — surfacing as BAD_USER_INPUT
+// would mislead the client.
+if in.Front != nil {
+    front, err := domain.ParseCardText(*in.Front, domain.ErrCardFrontRequired, domain.ErrCardFrontTooLong)
+    if err != nil {
+        // Validation channel: surfaces as BAD_USER_INPUT.
+        info, perr := liftValidationErr(translateCardErr(err))
+        if perr != nil {
+            return UpdateCardOutcome{}, perr
+        }
+        return UpdateCardOutcome{Validation: info}, nil
+    }
+    // Defense-in-depth: surfaces as INTERNAL.
+    if err := existing.UpdateFront(front); err != nil {
+        return UpdateCardOutcome{}, eris.Wrap(err, "usecase: card: update front")
+    }
+    s := existing.Front.String()
+    patch.Front = &s
+}
+```
+
+The two-segment wrap prefix `usecase: card: update front` follows the canonical
+layer prefix convention (see [`.claude/rules/error-wrapping.md`](../../../.claude/rules/error-wrapping.md#canonical-layer-prefix)).
+
+## How to recognise the pattern at review time
+
+A defense-in-depth path is identifiable by three structural cues, **all of which
+must hold**:
+
+1. The aggregate method has a non-nil error signature returning the same sentinel
+   as the upstream parser.
+2. The usecase calls the parser first and the aggregate method second, on the same
+   input.
+3. The aggregate method's docstring explicitly describes itself as defense-in-depth
+   (e.g. "The zero-value guard is defense-in-depth: production callers parse the
+   input through `ParseX` before reaching this method").
+
+If a method satisfies all three, its error path should classify as `INTERNAL` via
+`eris.Wrap`. If only some hold (e.g. an aggregate method that takes a raw string
+and is the *only* validation site), the aggregate-method path is the validation
+channel and should route through the classifier.
+
+## Comparison with the boundary-gate pattern
+
+A related but distinct pattern is documented in
+[`boundary-gate-replaces-domain-recheck.md`](../ddd-patterns/boundary-gate-replaces-domain-recheck.md):
+when an invariant has a boundary gate, the aggregate's `Validate()` can drop the
+re-check entirely. That pattern *removes* the redundant invariant. The
+defense-in-depth pattern *keeps* the redundant invariant but classifies the
+redundant path as `INTERNAL`.
+
+The choice between them:
+
+- **Drop the re-check** when the invariant has no defensive value (e.g.
+  `Card.CardgroupID` is a user-input field gated at the boundary; an unreachable
+  re-check has zero security weight).
+- **Keep the re-check as defense-in-depth** when the invariant is an
+  *aggregate-state* invariant the type enforces structurally (e.g. `Card.Front`
+  must never be the zero `CardText`). A zero-value `Card.Front` corrupts the
+  aggregate; the re-check stops the corruption from being committed even if the
+  upstream parser is bypassed.
+
+The two patterns are not in conflict — they apply to invariants of different
+shapes.
+
+## Reference
+
+- `backend/internal/domain/card.go` — `UpdateFront`/`UpdateBack` with
+  defense-in-depth zero-value guard.
+- `backend/internal/usecase/card.go` — `CardUsecase.Update` wraps the
+  defense-in-depth path with `eris.Wrap` and the validation channel with
+  `translateCardErr`.
+- Issue #213 — introduced this pattern for `Card.Front` / `Card.Back`.
+- [`docs/backend/ddd-patterns/boundary-gate-replaces-domain-recheck.md`](../ddd-patterns/boundary-gate-replaces-domain-recheck.md) —
+  the complementary pattern that drops the re-check.
+- [`docs/backend/error-wrapping/application-presentation-error-responsibility.md`](application-presentation-error-responsibility.md) —
+  the usecase is consumer-agnostic; the presentation layer maps errors to wire
+  format. The classification choice belongs to the usecase, not the presentation
+  layer.

--- a/docs/backend/library-gotchas/mock-pointer-fixture-pitfalls.md
+++ b/docs/backend/library-gotchas/mock-pointer-fixture-pitfalls.md
@@ -1,0 +1,180 @@
+# Mock-pointer fixture pitfalls: directionality tautology and parallel sub-test races
+
+> Part of the [Go library gotchas](../../../.claude/rules/go-library-gotchas.md) rules.
+
+Two test-fixture hazards arise together whenever a mock returns a `*domain.X`
+by value (the same pointer the test's outer scope holds) and the production
+code mutates that struct in place. The tautology trap makes an assertion
+silently dead; the parallel race turns it into undefined behaviour.
+
+## The shared-pointer directionality tautology
+
+### Why the assertion is dead code
+
+When a test mock's `findResult` field holds the same `*domain.Card` pointer
+that the outer scope uses as its fixture, and the production code mutates
+that struct in place (e.g. via `card.UpdateFront(newValue)`), an assertion
+of the form
+
+```go
+if *cardRepo.capturedPatch.Front != existingCard.Front.String() { /* fail */ }
+```
+
+is tautologically true. The execution sequence is:
+
+1. The mock returns the outer-scope pointer.
+2. The production code calls `existingCard.UpdateFront(newValue)`, writing
+   `newValue` into `existingCard.Front` through that pointer.
+3. The repository captures `existingCard.Front.String()` as `capturedPatch.Front`.
+4. The assertion compares `*capturedPatch.Front` against `existingCard.Front.String()`.
+
+Both sides were written by the same mutation in step 2. The assertion passes
+whether or not the route-through actually ran. A regression that bypassed
+`UpdateFront` and derived the patch value by some other path would leave
+`existingCard.Front` at its initial value — but then `capturedPatch.Front`
+would also reflect that unchanged value, so the comparison still holds. The
+test cannot distinguish the regression it claims to catch.
+
+### The fix — mutation guard against the initial known value
+
+Snapshot the initial value before the call (or hard-code it as a literal),
+then assert that the aggregate field changed *to the expected new value*. A
+regression that skipped the aggregate-mutation step leaves the field at its
+initial value, and the guard trips.
+
+```go
+existingFront := &domain.Card{
+    ID:          "card1",
+    CardgroupID: "cg1",
+    Front:       domain.CardText("old front"),
+    Back:        domain.CardText("old back"),
+}
+cardRepo := &mockCardRepository{findResult: existingFront, updateResult: existingFront}
+uc := NewCardUsecase(nil, cardRepo, nil, nil)
+
+newFront := " new front "
+_, _ = uc.Update(ctx, "card1", UpdateCardInput{Front: &newFront})
+
+// Tautology (do not use) — both sides equal "new front" because the mock
+// returned existingFront and the usecase mutated it in place.
+//   if *cardRepo.capturedPatch.Front != existingFront.Front.String() { ... }  // DEAD CODE
+
+// Mutation guard (load-bearing) — a bypass-the-route-through regression
+// leaves existingFront.Front at "old front" and fails this assertion.
+if existingFront.Front != domain.CardText("new front") {
+    t.Fatalf("aggregate not mutated: Front = %q, want %q",
+        existingFront.Front, "new front")
+}
+```
+
+The initial value `"old front"` is the anchor. If the production code ever
+stops calling `card.UpdateFront` and drives the patch a different way, the
+aggregate field stays at `"old front"` and the assertion fails — which is
+exactly the regression the test exists to catch.
+
+The shape generalises: any test that uses a mutable pointer as both mock
+state and assertion subject must compare against the *initial known value*
+(or a snapshot taken before the call under test), not against another value
+produced by the same mutation.
+
+## Parallel sub-test fixture isolation
+
+### Why the race is silent
+
+`t.Parallel()` schedules sibling sub-tests on goroutines that the runtime
+may interleave. When two sub-tests share a `*domain.Card` pointer via an
+outer-scope variable and both pass it as `mockCardRepository{findResult: ...}`,
+any sub-test whose call path mutates that pointer races with any concurrent
+reader.
+
+The danger is silent for two reasons:
+
+1. One sibling may return early on an auth check before reaching the mutation,
+   keeping the race window narrow. The race detector may not fire under low
+   contention.
+2. Tests pass consistently on a local laptop but exhibit undefined behaviour
+   under a different scheduler or heavier load.
+
+The acceptance criterion `go test -race ./...` is supposed to catch this, but
+race detection is probabilistic per run.
+
+### The fix — each parallel sub-test owns its own fixture pointer
+
+Declare a fresh `*domain.Card` inside the sub-test that mutates it. The
+outer-scope fixture may remain shared if and only if all readers are read-only.
+
+```go
+func TestCardUsecase_Update_NonOwnerAndPatch(t *testing.T) {
+    t.Parallel()
+
+    // outer fixture — used read-only by the "non owner" sub-test below.
+    existing := &domain.Card{
+        ID:          "card1",
+        CardgroupID: "cg1",
+        Front:       domain.CardText("front"),
+        Back:        domain.CardText("back"),
+    }
+
+    t.Run("non owner", func(t *testing.T) {
+        t.Parallel()
+        // Reads existing only; no mutation through this pointer.
+        uc := NewCardUsecase(nil,
+            &mockCardRepository{findResult: existing},
+            nil, nil)
+        _, err := uc.Update(ctx, "card1", UpdateCardInput{})
+        assertUnauthenticated(t, err)
+    })
+
+    t.Run("valid partial update", func(t *testing.T) {
+        t.Parallel()
+        // Isolated fixture: sharing `existing` with the sibling above and
+        // mutating through it would be a data race under -race.
+        existingFront := &domain.Card{
+            ID:          "card1",
+            CardgroupID: "cg1",
+            Front:       domain.CardText("old front"),
+            Back:        domain.CardText("old back"),
+        }
+        cardRepo := &mockCardRepository{
+            findResult:   existingFront,
+            updateResult: existingFront,
+        }
+        uc := NewCardUsecase(nil, cardRepo, nil, nil)
+
+        newFront := " new front "
+        _, _ = uc.Update(ctx, "card1", UpdateCardInput{Front: &newFront})
+
+        if existingFront.Front != domain.CardText("new front") {
+            t.Fatalf("aggregate not mutated: Front = %q", existingFront.Front)
+        }
+    })
+}
+```
+
+The same rule applies to `t.Run` siblings nested under any parallel parent,
+not only top-level test functions.
+
+## How to spot both pitfalls in review
+
+- A sub-test uses `findResult: existing` where `existing` is declared in an
+  outer scope AND the production call path mutates the returned aggregate in
+  place — this is the trigger for both pitfalls simultaneously.
+- An assertion of the form `*capturedPatch.X == existing.X.String()` after
+  that call is the dead-code shape (directionality tautology).
+- Two or more `t.Parallel()` sub-tests sharing that same outer-scope pointer
+  is the race shape.
+
+The fix is usually both corrections together:
+
+1. Move the fixture inside the mutating sub-test (isolation).
+2. Rewrite the assertion as a mutation guard against the literal initial value
+   (directionality).
+
+## Reference
+
+- `backend/internal/usecase/card_test.go` — `TestCardUsecase_Update_NonOwnerAndPatch`.
+  Both `"valid partial update"` and `"valid partial update back"` sub-tests use
+  isolated fixtures; each mutation guard reads
+  `existingFront.Front != domain.CardText(newFront)`.
+- Issue #213 — `Card.UpdateFront` / `Card.UpdateBack` route-through that
+  introduced the in-place mutation and surfaced both pitfalls.


### PR DESCRIPTION
## Summary

Closes #213. Adds `domain.Card.UpdateFront(CardText) error` and `domain.Card.UpdateBack(CardText) error`, then routes `CardUsecase.Update` through them. Mirrors the `Cardgroup.Rename` shape introduced in #212. The aggregate-state invariant (Front/Back must never be the zero `CardText`) now lives on the aggregate; the patch DTO is derived from the *mutated* aggregate, not from the parsed VO directly. Production diff is ~40 lines (excluding tests) — well under the 800-line ceiling in [`.claude/rules/pr-sizing.md`](.claude/rules/pr-sizing.md).

## Background / Motivation

- **Anemic update flow.** Before this change, `CardUsecase.Update` (`backend/internal/usecase/card.go:288-336`) loaded the aggregate via `repo.FindByID` and built the patch directly from the parsed VOs: `s := front.String(); patch.Front = &s`. The aggregate was fetched but never mutated through a behaviour method. Adding any cross-field invariant would have had no obvious home.
- **Aggregate behaviour method pattern.** Documented in [`.claude/rules/ddd-patterns.md`](.claude/rules/ddd-patterns.md) and [`docs/backend/ddd-patterns/aggregate-behaviour-method.md`](docs/backend/ddd-patterns/aggregate-behaviour-method.md). Existing aggregates (`Role.IsSystem`, `Rating.IsValid`, `UserCardFSRS.ApplyRating`, `Cardgroup.Rename`) follow this pattern; `Card` lacked an `Update`-side behaviour method.
- **Two single-field methods over one combined `UpdateText`.** The issue's "Open question" landed on two methods per the recommendation: the patch's `nil = no change` semantics belong to the usecase layer; the aggregate should not interpret per-field nullability. Each single-field method encodes exactly one invariant.
- **Patch DTO retained, not replaced.** Per [`docs/backend/ddd-patterns/patch-dto-primitive-not-vo.md`](docs/backend/ddd-patterns/patch-dto-primitive-not-vo.md), the `repository.CardUpdate{Front: *string, Back: *string}` shape stays as-is. The change is the two-step `behaviour method → patch derivation` seam.

## Changes

### `domain/card.go` — new `UpdateFront` / `UpdateBack` methods (commit `a1db67a`)

```go
// UpdateFront updates the card's front text to the supplied value and returns an
// error if the value is the zero CardText. The zero-value guard is defense-in-depth:
// production callers parse the input through ParseCardText before reaching this
// method, so structural invariants (length, non-empty) are enforced at VO construction
// time. This method enforces only the aggregate-state invariant that c.Front must
// never be the zero value. UpdatedAt is intentionally not modified here; persistence
// is responsible for stamping the modification timestamp.
func (c *Card) UpdateFront(front CardText) error {
    if front == "" {
        return ErrCardFrontRequired
    }
    c.Front = front
    return nil
}
```

`UpdateBack` mirrors the same shape with `ErrCardBackRequired`. Direct unit tests in `domain/card_test.go` cover: zero VO rejected via `require.ErrorIs(err, ErrCard*Required)`, valid VO mutates the targeted field, and the sibling field is NOT mutated.

### `usecase/card.go` — route `Update` through aggregate methods (commit `ecf0181`)

`CardUsecase.Update` now calls `existing.UpdateFront(front)` / `existing.UpdateBack(back)` after the parse/lift validation block and derives the patch strings from the *mutated aggregate*:

```go
if err := existing.UpdateFront(front); err != nil {
    return UpdateCardOutcome{}, eris.Wrap(err, "usecase: card: update front")
}
s := existing.Front.String()
patch.Front = &s
```

Wrap prefix `usecase: card: update front` follows the canonical two-segment form per [`.claude/rules/error-wrapping.md`](.claude/rules/error-wrapping.md).

### `usecase/card_test.go` — load-bearing directionality + race fix (commits `6ca00f8`, `7800581`)

- Replaced a tautological assertion (`*capturedPatch.Front == existing.Front.String()`) with a mutation guard (`existingFront.Front != domain.CardText(newFront)`) that catches a regression bypassing `UpdateFront`. The shared-pointer trap is documented in [`docs/backend/library-gotchas/mock-pointer-fixture-pitfalls.md`](docs/backend/library-gotchas/mock-pointer-fixture-pitfalls.md).
- Added a symmetric `"valid partial update back"` sub-test with its own `existingBack` fixture.
- Isolated the front sub-test's fixture (`existingFront`) so the route-through write does not race a parallel sibling sub-test reading the outer `existing` pointer under `t.Parallel()`.

### `usecase/card.go` — comment block documenting the INTERNAL classification choice (commit `7800581`)

A 7-line comment block precedes the `if in.Front != nil` block explaining that `UpdateFront`/`UpdateBack` errors route through `eris.Wrap` (→ INTERNAL), not through `translateCardErr` (→ BAD_USER_INPUT). The defense-in-depth path firing signals a programmer error (the upstream `ParseCardText` gate was bypassed), not bad user input — collapsing the two would mislead the client. See [`docs/backend/error-wrapping/defense-in-depth-classification-internal.md`](docs/backend/error-wrapping/defense-in-depth-classification-internal.md).

### `domain/card_test.go` — `require.ErrorIs` idiom (commit `3e6cb7b`)

Collapsed `require.Error + errors.Is` into `require.ErrorIs` to match the project's established test style.

### Docs (commit `a462cf1`)

Two new L3 docs and one updated:

- **New**: [`docs/backend/library-gotchas/mock-pointer-fixture-pitfalls.md`](docs/backend/library-gotchas/mock-pointer-fixture-pitfalls.md) — shared-pointer directionality tautology + parallel sub-test fixture isolation.
- **New**: [`docs/backend/error-wrapping/defense-in-depth-classification-internal.md`](docs/backend/error-wrapping/defense-in-depth-classification-internal.md) — why defense-in-depth aggregate-method errors classify as INTERNAL, not BAD_USER_INPUT.
- **Updated**: [`docs/backend/ddd-patterns/aggregate-behaviour-method.md`](docs/backend/ddd-patterns/aggregate-behaviour-method.md) — appended a "Single-field aggregate mutation" section covering `Cardgroup.Rename`, `Card.UpdateFront`, and `Card.UpdateBack`.

Both new docs indexed in [`.claude/rules/go-library-gotchas.md`](.claude/rules/go-library-gotchas.md) and [`.claude/rules/error-wrapping.md`](.claude/rules/error-wrapping.md).

## Verification

```bash
cd backend
go build ./...
go vet ./...
go test -race -count=1 ./...    # 1,323 tests pass across 23 packages

# Aggregate methods exist and are wired
grep -n 'func (c \*Card) Update' backend/internal/domain/card.go
grep -n 'existing.Update' backend/internal/usecase/card.go

# Two-segment wrap prefix
grep -nE 'eris\.Wrap\(err, "usecase: card: update (front|back)"\)' backend/internal/usecase/card.go

# Language-policy: no CJK, no PR-order references
grep -rlP "[\x{3040}-\x{30ff}\x{4e00}-\x{9fff}]" \
  --include="*.go" --include="*.md" \
  docs backend/internal backend/cmd backend/graph
grep -rnE "PR[0-9]+" docs backend/internal backend/cmd backend/graph
# Expect: empty for both
```

## Test plan

- [x] `cd backend && go build ./...` succeeds
- [x] `cd backend && go vet ./...` clean
- [x] `cd backend && go test -race -count=1 ./...` — 1,323 tests pass
- [x] `TestCardUpdateFront` / `TestCardUpdateBack` cover zero VO rejection, mutation, and non-mutation of sibling fields
- [x] `TestCardUsecase_Update_NonOwnerAndPatch` covers both Front and Back route-through with load-bearing mutation guards and isolated parallel-safe fixtures
- [x] Production diff under 800 lines (~40 lines excl. tests)
- [ ] CI green on this branch

Closes #213
