### PR TITLE
refactor(usecase): promote User/Cardgroup/Card/Learn/Swipe to interfaces

### DIFF
--- a/.claude/rules/go-library-gotchas.md
+++ b/.claude/rules/go-library-gotchas.md
@@ -104,6 +104,7 @@ This matters most in DataLoader batch functions, where an empty key slice is a n
 - [CI bash `rc=$?` is dead code under `set -e` — use `cmd || rc=$?`](../../docs/backend/library-gotchas/ci-bash-rc-capture-under-set-e.md)
 - [Walker / parser positive-discovery guards — silent zero disables enforcement](../../docs/backend/library-gotchas/walker-parser-positive-discovery-guards.md)
 - [Resolver-injected usecase: interface field unlocks unit tests for outcome-union guards](../../docs/backend/library-gotchas/resolver-usecase-interface-vs-concrete-testability.md)
+- [Usecase interface promotion: three-part template, same-package type assertions, `WithTx` refactoring, pointer-to-interface anti-pattern](../../docs/backend/library-gotchas/usecase-interface-promotion-pattern.md)
 - [go-arch-lint v3: every `deps` entry must declare at least one permission flag (`anyVendorDeps: true` for leaf components)](../../docs/backend/library-gotchas/go-arch-lint-v3-anyvendordeps-required.md)
 - [go-arch-lint `commonComponents` is the only universal-import mechanism — cross-cutting packages still need explicit `mayDependOn`](../../docs/backend/library-gotchas/go-arch-lint-commoncomponents-not-universal.md)
 - [go-arch-lint violation output format and import-graph scope (binary vs. archfile version; what AST shapes it cannot enforce)](../../docs/backend/library-gotchas/go-arch-lint-violation-output-and-scope.md)

--- a/backend/graph/resolver/card_resolvers_test.go
+++ b/backend/graph/resolver/card_resolvers_test.go
@@ -21,8 +21,9 @@ import (
 
 // --- mock repositories used only by the card resolver tests ---
 
-// cardMockRepo satisfies usecase.CardRepository. FindByID and Update are
-// configurable via struct fields; the remaining methods are no-op stubs.
+// cardMockRepo satisfies usecase.CardRepository and usecase.CardRepoForLearn.
+// FindByID, Update, and FindDueCardsForUser are configurable via struct fields;
+// the remaining methods are no-op stubs.
 type cardMockRepo struct {
 	deleteByIDsResult int64
 	deleteByIDsErr    error
@@ -40,23 +41,9 @@ type cardMockRepo struct {
 func (m *cardMockRepo) FindByID(_ context.Context, _ string) (*domain.Card, error) {
 	return m.findByIDResult, m.findByIDErr
 }
-func (m *cardMockRepo) FindByIDs(_ context.Context, _ []string) (map[string]*domain.Card, error) {
-	return nil, nil
-}
 func (m *cardMockRepo) FindDueCardsForUser(_ context.Context, _ string, _ string, _ time.Time, limit int) ([]domain.DueCard, error) {
 	m.findDueLimit = limit
 	return m.findDueRows, m.findDueErr
-}
-func (m *cardMockRepo) FindPageByCardgroup(
-	_ context.Context,
-	_ string,
-	_, _ *repository.CardCursor,
-	_, _ int,
-	_ repository.CardOrderBy,
-	_ repository.SortOrder,
-	_ *string,
-) ([]*domain.Card, int64, error) {
-	return nil, 0, nil
 }
 func (m *cardMockRepo) FindPageByCardgroupForUser(
 	_ context.Context,

--- a/backend/graph/resolver/resolver.go
+++ b/backend/graph/resolver/resolver.go
@@ -6,11 +6,11 @@ import (
 )
 
 type Resolver struct {
-	UserUC                *usecase.UserUsecase
-	CardgroupUC           *usecase.CardgroupUsecase
-	CardUC                *usecase.CardUsecase
-	LearnUC               *usecase.LearnUsecase
-	SwipeUC               *usecase.SwipeUsecase
+	UserUC                usecase.UserUsecase
+	CardgroupUC           usecase.CardgroupUsecase
+	CardUC                usecase.CardUsecase
+	LearnUC               usecase.LearnUsecase
+	SwipeUC               usecase.SwipeUsecase
 	AuthSvc               *auth.Service
 	DictionaryUC          usecase.DictionaryUsecase
 	AdminUserUC           usecase.AdminUserUsecase
@@ -21,16 +21,16 @@ type Resolver struct {
 // NewResolver wires every Resolver dependency. Tests may pass nil for unused
 // dependencies; do not pass nil from production wiring.
 func NewResolver(
-	user *usecase.UserUsecase,
-	cardgroupUC *usecase.CardgroupUsecase,
-	cardUC *usecase.CardUsecase,
-	swipeUC *usecase.SwipeUsecase,
+	user usecase.UserUsecase,
+	cardgroupUC usecase.CardgroupUsecase,
+	cardUC usecase.CardUsecase,
+	swipeUC usecase.SwipeUsecase,
 	authSvc *auth.Service,
 	dictionaryUC usecase.DictionaryUsecase,
 	adminUserUC usecase.AdminUserUsecase,
 	adminRoleUC usecase.AdminRoleUsecase,
 	lastViewedCardgroupUC usecase.LastViewedCardgroupUsecase,
-	learnUC *usecase.LearnUsecase,
+	learnUC usecase.LearnUsecase,
 ) *Resolver {
 	return &Resolver{
 		UserUC:                user,

--- a/backend/internal/usecase/card.go
+++ b/backend/internal/usecase/card.go
@@ -61,7 +61,17 @@ func normalizeCardObserver(observer CardObserver) CardObserver {
 	return observer
 }
 
-type CardUsecase struct {
+// CardUsecase is the application interface for card-related operations.
+type CardUsecase interface {
+	Card(ctx context.Context, id string) (*domain.Card, error)
+	Create(ctx context.Context, in CreateCardInput) (CreateCardOutcome, error)
+	Update(ctx context.Context, id string, in UpdateCardInput) (UpdateCardOutcome, error)
+	Delete(ctx context.Context, id string) error
+	ListCardsByCardgroupConnection(ctx context.Context, in CardConnectionInput) (*CardConnectionOutput, error)
+	BulkDelete(ctx context.Context, ids []string) (int64, error)
+}
+
+type cardUsecase struct {
 	cardRepo      CardRepository
 	cardgroupRepo CardgroupRepositoryForCard
 	userFSRSRepo  UserCardFSRSRepositoryForCard
@@ -77,11 +87,11 @@ func NewCardUsecase(
 	userCardFSRSRepo UserCardFSRSRepositoryForCard,
 	observer CardObserver,
 	logger *slog.Logger,
-) *CardUsecase {
+) CardUsecase {
 	if logger == nil {
 		panic("usecase: card: logger is required")
 	}
-	uc := &CardUsecase{
+	uc := &cardUsecase{
 		cardRepo:      cardRepo,
 		cardgroupRepo: cardgroupRepo,
 		userFSRSRepo:  userCardFSRSRepo,
@@ -106,11 +116,11 @@ func NewCardUsecaseWithTx(
 	userCardFSRSRepo UserCardFSRSRepositoryForCard,
 	observer CardObserver,
 	logger *slog.Logger,
-) *CardUsecase {
+) CardUsecase {
 	if logger == nil {
 		panic("usecase: card: logger is required")
 	}
-	return &CardUsecase{
+	return &cardUsecase{
 		cardRepo:      cardRepo,
 		cardgroupRepo: cardgroupRepo,
 		tx:            tx,
@@ -210,7 +220,7 @@ const (
 	maxBulkDelete   = 100
 )
 
-func (u *CardUsecase) Card(ctx context.Context, id string) (*domain.Card, error) {
+func (u *cardUsecase) Card(ctx context.Context, id string) (*domain.Card, error) {
 	user := auth.UserFrom(ctx)
 	if user == nil {
 		return nil, ucerr.ErrUnauthenticated
@@ -233,7 +243,7 @@ func (u *CardUsecase) Card(ctx context.Context, id string) (*domain.Card, error)
 // Real failures — unauthenticated caller, validation, infrastructure — are still
 // returned as the second return value so the resolver can wrap them via
 // gqlerr.FromUsecaseError into the wire-format GraphQL error.
-func (u *CardUsecase) Create(ctx context.Context, in CreateCardInput) (CreateCardOutcome, error) {
+func (u *cardUsecase) Create(ctx context.Context, in CreateCardInput) (CreateCardOutcome, error) {
 	user := auth.UserFrom(ctx)
 	if user == nil {
 		return CreateCardOutcome{}, ucerr.ErrUnauthenticated
@@ -285,7 +295,7 @@ func (u *CardUsecase) Create(ctx context.Context, in CreateCardInput) (CreateCar
 	return CreateCardOutcome{Card: card}, nil
 }
 
-func (u *CardUsecase) Update(ctx context.Context, id string, in UpdateCardInput) (UpdateCardOutcome, error) {
+func (u *cardUsecase) Update(ctx context.Context, id string, in UpdateCardInput) (UpdateCardOutcome, error) {
 	user := auth.UserFrom(ctx)
 	if user == nil {
 		return UpdateCardOutcome{}, ucerr.ErrUnauthenticated
@@ -348,7 +358,7 @@ func (u *CardUsecase) Update(ctx context.Context, id string, in UpdateCardInput)
 	return UpdateCardOutcome{Card: updated}, nil
 }
 
-func (u *CardUsecase) Delete(ctx context.Context, id string) error {
+func (u *cardUsecase) Delete(ctx context.Context, id string) error {
 	user := auth.UserFrom(ctx)
 	if user == nil {
 		return ucerr.ErrUnauthenticated
@@ -371,7 +381,7 @@ func (u *CardUsecase) Delete(ctx context.Context, id string) error {
 
 // ListCardsByCardgroupConnection paginates a cardgroup's cards using
 // Relay-style forward (first/after) or backward (last/before) cursors.
-func (u *CardUsecase) ListCardsByCardgroupConnection(
+func (u *cardUsecase) ListCardsByCardgroupConnection(
 	ctx context.Context, in CardConnectionInput,
 ) (*CardConnectionOutput, error) {
 	user := auth.UserFrom(ctx)
@@ -512,7 +522,7 @@ func resolvePageSize(first, last *int) (int, int, error) {
 // the backward-compatibility window. Returns BAD_USER_INPUT when the cursor
 // cannot be decoded, the card cannot be found, or the card belongs to a
 // different cardgroup.
-func (u *CardUsecase) resolveCursor(
+func (u *cardUsecase) resolveCursor(
 	ctx context.Context,
 	cursorStr *string,
 	cardgroupID string,
@@ -571,7 +581,7 @@ func (u *CardUsecase) resolveCursor(
 // foreign-owned ids are silently skipped at the SQL layer. Returns the number
 // of rows actually deleted. At most maxBulkDelete ids may be supplied per call;
 // exceeding the cap returns BAD_USER_INPUT.
-func (u *CardUsecase) BulkDelete(ctx context.Context, ids []string) (int64, error) {
+func (u *cardUsecase) BulkDelete(ctx context.Context, ids []string) (int64, error) {
 	user := auth.UserFrom(ctx)
 	if user == nil {
 		return 0, ucerr.ErrUnauthenticated

--- a/backend/internal/usecase/card.go
+++ b/backend/internal/usecase/card.go
@@ -61,7 +61,7 @@ func normalizeCardObserver(observer CardObserver) CardObserver {
 	return observer
 }
 
-// CardUsecase is the application interface for card-related operations.
+// CardUsecase is the card CRUD and paginated-list surface.
 type CardUsecase interface {
 	Card(ctx context.Context, id string) (*domain.Card, error)
 	Create(ctx context.Context, in CreateCardInput) (CreateCardOutcome, error)

--- a/backend/internal/usecase/card_bulk_delete_test.go
+++ b/backend/internal/usecase/card_bulk_delete_test.go
@@ -24,7 +24,7 @@ func TestCardUsecase_BulkDelete_EmptyIDs(t *testing.T) {
 	cardRepo := &mockCardRepository{}
 	cgRepo := &mockCardgroupRepoForCard{}
 	tx, calls := fakeTxRunner()
-	uc := &CardUsecase{cardRepo: cardRepo, cardgroupRepo: cgRepo, tx: tx, logger: newTestLogger()}
+	uc := &cardUsecase{cardRepo: cardRepo, cardgroupRepo: cgRepo, tx: tx, logger: newTestLogger()}
 
 	n, err := uc.BulkDelete(authedCtx("u1"), nil)
 	if err != nil {
@@ -46,7 +46,7 @@ func TestCardUsecase_BulkDelete_Anonymous(t *testing.T) {
 	cardRepo := &mockCardRepository{}
 	cgRepo := &mockCardgroupRepoForCard{}
 	tx, _ := fakeTxRunner()
-	uc := &CardUsecase{cardRepo: cardRepo, cardgroupRepo: cgRepo, tx: tx, logger: newTestLogger()}
+	uc := &cardUsecase{cardRepo: cardRepo, cardgroupRepo: cgRepo, tx: tx, logger: newTestLogger()}
 
 	_, err := uc.BulkDelete(anonCtx(), []string{"c1", "c2"})
 	assertUnauthenticated(t, err)
@@ -58,7 +58,7 @@ func TestCardUsecase_BulkDelete_Anonymous(t *testing.T) {
 func TestCardUsecase_BulkDelete_AnonymousWithEmptyIDs(t *testing.T) {
 	// Auth check fires before the empty-ids short-circuit.
 	t.Parallel()
-	uc := &CardUsecase{cardRepo: &mockCardRepository{}, cardgroupRepo: &mockCardgroupRepoForCard{}, logger: newTestLogger()}
+	uc := &cardUsecase{cardRepo: &mockCardRepository{}, cardgroupRepo: &mockCardgroupRepoForCard{}, logger: newTestLogger()}
 	_, err := uc.BulkDelete(anonCtx(), nil)
 	assertUnauthenticated(t, err)
 }
@@ -70,7 +70,7 @@ func TestCardUsecase_BulkDelete_AllOwn(t *testing.T) {
 	}
 	cgRepo := &mockCardgroupRepoForCard{}
 	tx, calls := fakeTxRunner()
-	uc := &CardUsecase{cardRepo: cardRepo, cardgroupRepo: cgRepo, tx: tx, logger: newTestLogger()}
+	uc := &cardUsecase{cardRepo: cardRepo, cardgroupRepo: cgRepo, tx: tx, logger: newTestLogger()}
 
 	n, err := uc.BulkDelete(authedCtx("u1"), []string{"c1", "c2", "c3"})
 	if err != nil {
@@ -101,7 +101,7 @@ func TestCardUsecase_BulkDelete_SilentlySkipsForeign(t *testing.T) {
 	cardRepo := &mockCardRepository{deleteByIDsResult: 1}
 	cgRepo := &mockCardgroupRepoForCard{}
 	tx, calls := fakeTxRunner()
-	uc := &CardUsecase{cardRepo: cardRepo, cardgroupRepo: cgRepo, tx: tx, logger: newTestLogger()}
+	uc := &cardUsecase{cardRepo: cardRepo, cardgroupRepo: cgRepo, tx: tx, logger: newTestLogger()}
 
 	n, err := uc.BulkDelete(authedCtx("u1"), []string{"c1", "foreign"})
 	if err != nil {
@@ -132,7 +132,7 @@ func TestCardUsecase_BulkDelete_PartialMatchSucceeds(t *testing.T) {
 	cardRepo := &mockCardRepository{deleteByIDsResult: 2}
 	cgRepo := &mockCardgroupRepoForCard{}
 	tx, calls := fakeTxRunner()
-	uc := &CardUsecase{cardRepo: cardRepo, cardgroupRepo: cgRepo, tx: tx, logger: newTestLogger()}
+	uc := &cardUsecase{cardRepo: cardRepo, cardgroupRepo: cgRepo, tx: tx, logger: newTestLogger()}
 
 	ids := []string{"own1", "own2", "foreign1", "foreign2", "foreign3"}
 	n, err := uc.BulkDelete(authedCtx("u1"), ids)
@@ -158,7 +158,7 @@ func TestCardUsecase_BulkDelete_RejectsTooManyIDs(t *testing.T) {
 	cardRepo := &mockCardRepository{}
 	cgRepo := &mockCardgroupRepoForCard{}
 	tx, calls := fakeTxRunner()
-	uc := &CardUsecase{cardRepo: cardRepo, cardgroupRepo: cgRepo, tx: tx, logger: newTestLogger()}
+	uc := &cardUsecase{cardRepo: cardRepo, cardgroupRepo: cgRepo, tx: tx, logger: newTestLogger()}
 
 	_, err := uc.BulkDelete(authedCtx("u1"), ids)
 	assertValidationError(t, err, "ids", "")

--- a/backend/internal/usecase/card_test.go
+++ b/backend/internal/usecase/card_test.go
@@ -834,7 +834,7 @@ func TestCardUsecase_ResolveCursor_MalformedV1_ReturnsBadUserInput(t *testing.T)
 		nil, nil, newTestLogger(),
 	)
 	malformed := "v1:!!!not-base64!!!"
-	_, err := uc.resolveCursor(
+	_, err := uc.(*cardUsecase).resolveCursor(
 		context.Background(),
 		&malformed, "cg1", repository.CardOrderByID, "after",
 	)
@@ -853,7 +853,7 @@ func TestCardUsecase_ResolveCursor_V1EncodedID(t *testing.T) {
 	)
 	// "v1:" + base64.RawURLEncoding.EncodeToString([]byte("card-abc")) == "v1:Y2FyZC1hYmM"
 	encoded := "v1:Y2FyZC1hYmM"
-	c, err := uc.resolveCursor(
+	c, err := uc.(*cardUsecase).resolveCursor(
 		context.Background(),
 		&encoded, "cg1", repository.CardOrderByID, "after",
 	)

--- a/backend/internal/usecase/cardgroup.go
+++ b/backend/internal/usecase/cardgroup.go
@@ -71,24 +71,32 @@ type CardgroupConnectionOutput struct {
 	EndCur     string
 }
 
-// CardgroupUsecase implements the cardgroup application logic.
-type CardgroupUsecase struct {
+// CardgroupUsecase is the application interface for cardgroup-related operations.
+type CardgroupUsecase interface {
+	Cardgroup(ctx context.Context, id string) (*domain.Cardgroup, error)
+	Create(ctx context.Context, in CreateCardgroupInput) (CreateCardgroupOutcome, error)
+	Update(ctx context.Context, id string, in UpdateCardgroupInput) (UpdateCardgroupOutcome, error)
+	Delete(ctx context.Context, id string) error
+	ListCardgroupsByOwnerConnection(ctx context.Context, in CardgroupConnectionInput) (*CardgroupConnectionOutput, error)
+}
+
+type cardgroupUsecase struct {
 	repo   CardgroupRepository
 	logger *slog.Logger
 }
 
 // NewCardgroupUsecase constructs a CardgroupUsecase backed by the given repository.
-func NewCardgroupUsecase(repo CardgroupRepository, logger *slog.Logger) *CardgroupUsecase {
+func NewCardgroupUsecase(repo CardgroupRepository, logger *slog.Logger) CardgroupUsecase {
 	if logger == nil {
 		panic("usecase: cardgroup: logger is required")
 	}
-	return &CardgroupUsecase{repo: repo, logger: logger}
+	return &cardgroupUsecase{repo: repo, logger: logger}
 }
 
 // Cardgroup returns a single cardgroup by id. Non-owners receive UNAUTHENTICATED
 // rather than NOT_FOUND so the caller cannot probe existence via ID enumeration.
 // A missing row returns (nil, nil) so the nullable GraphQL field resolves to null.
-func (u *CardgroupUsecase) Cardgroup(ctx context.Context, id string) (*domain.Cardgroup, error) {
+func (u *cardgroupUsecase) Cardgroup(ctx context.Context, id string) (*domain.Cardgroup, error) {
 	user := auth.UserFrom(ctx)
 	if user == nil {
 		return nil, ucerr.ErrUnauthenticated
@@ -120,7 +128,7 @@ type CreateCardgroupOutcome struct {
 }
 
 // Create creates a new cardgroup owned by the authenticated caller.
-func (u *CardgroupUsecase) Create(ctx context.Context, in CreateCardgroupInput) (CreateCardgroupOutcome, error) {
+func (u *cardgroupUsecase) Create(ctx context.Context, in CreateCardgroupInput) (CreateCardgroupOutcome, error) {
 	user := auth.UserFrom(ctx)
 	if user == nil {
 		return CreateCardgroupOutcome{}, ucerr.ErrUnauthenticated
@@ -172,7 +180,7 @@ type UpdateCardgroupOutcome struct {
 // Non-owners and missing rows both return UNAUTHENTICATED to prevent ID enumeration.
 // A nil Name field is treated as an empty patch: the existing row is returned
 // without any database write.
-func (u *CardgroupUsecase) Update(ctx context.Context, id string, in UpdateCardgroupInput) (UpdateCardgroupOutcome, error) {
+func (u *cardgroupUsecase) Update(ctx context.Context, id string, in UpdateCardgroupInput) (UpdateCardgroupOutcome, error) {
 	user := auth.UserFrom(ctx)
 	if user == nil {
 		return UpdateCardgroupOutcome{}, ucerr.ErrUnauthenticated
@@ -217,7 +225,7 @@ func (u *CardgroupUsecase) Update(ctx context.Context, id string, in UpdateCardg
 
 // Delete removes the cardgroup identified by id.
 // Non-owners and missing rows both return UNAUTHENTICATED to prevent ID enumeration.
-func (u *CardgroupUsecase) Delete(ctx context.Context, id string) error {
+func (u *cardgroupUsecase) Delete(ctx context.Context, id string) error {
 	user := auth.UserFrom(ctx)
 	if user == nil {
 		return ucerr.ErrUnauthenticated
@@ -248,7 +256,7 @@ func (u *CardgroupUsecase) Delete(ctx context.Context, id string) error {
 // reference a cardgroup belonging to another owner are also rejected as
 // BAD_USER_INPUT (returning UNAUTHENTICATED would leak existence of other
 // users' cardgroups).
-func (u *CardgroupUsecase) ListCardgroupsByOwnerConnection(
+func (u *cardgroupUsecase) ListCardgroupsByOwnerConnection(
 	ctx context.Context, in CardgroupConnectionInput,
 ) (*CardgroupConnectionOutput, error) {
 	user := auth.UserFrom(ctx)
@@ -419,7 +427,7 @@ func resolveCardgroupPageSize(first, last *int) (int, int, error) {
 // hydrate). Without it, an attacker could probe for the existence of foreign
 // cardgroups by paging past a guessed cursor and observing whether any rows
 // come back.
-func (u *CardgroupUsecase) resolveCardgroupCursor(
+func (u *cardgroupUsecase) resolveCardgroupCursor(
 	ctx context.Context,
 	cursorStr *string,
 	ownerID string,

--- a/backend/internal/usecase/cardgroup.go
+++ b/backend/internal/usecase/cardgroup.go
@@ -71,7 +71,7 @@ type CardgroupConnectionOutput struct {
 	EndCur     string
 }
 
-// CardgroupUsecase is the application interface for cardgroup-related operations.
+// CardgroupUsecase is the cardgroup CRUD and paginated-list surface.
 type CardgroupUsecase interface {
 	Cardgroup(ctx context.Context, id string) (*domain.Cardgroup, error)
 	Create(ctx context.Context, in CreateCardgroupInput) (CreateCardgroupOutcome, error)

--- a/backend/internal/usecase/cardgroup_test.go
+++ b/backend/internal/usecase/cardgroup_test.go
@@ -1406,7 +1406,7 @@ func TestResolveCardgroupCursor_NilCursor(t *testing.T) {
 	repo := &mockCardgroupRepository{}
 	uc := NewCardgroupUsecase(repo, newTestLogger())
 
-	c, err := uc.resolveCardgroupCursor(
+	c, err := uc.(*cardgroupUsecase).resolveCardgroupCursor(
 		context.Background(),
 		nil, "u1", repository.CardgroupOrderByName, "after",
 	)
@@ -1418,7 +1418,7 @@ func TestResolveCardgroupCursor_NilCursor(t *testing.T) {
 	}
 
 	empty := ""
-	c, err = uc.resolveCardgroupCursor(
+	c, err = uc.(*cardgroupUsecase).resolveCardgroupCursor(
 		context.Background(),
 		&empty, "u1", repository.CardgroupOrderByName, "after",
 	)
@@ -1440,7 +1440,7 @@ func TestResolveCardgroupCursor_OtherOwner_NonIDOrderBy(t *testing.T) {
 	uc := NewCardgroupUsecase(repo, newTestLogger())
 
 	id := "cg-x"
-	_, err := uc.resolveCardgroupCursor(
+	_, err := uc.(*cardgroupUsecase).resolveCardgroupCursor(
 		context.Background(),
 		&id, "owner-b", repository.CardgroupOrderByName, "after",
 	)
@@ -1459,7 +1459,7 @@ func TestResolveCardgroupCursor_UnknownOrderBy(t *testing.T) {
 	uc := NewCardgroupUsecase(repo, newTestLogger())
 
 	id := "cg-cursor"
-	_, err := uc.resolveCardgroupCursor(
+	_, err := uc.(*cardgroupUsecase).resolveCardgroupCursor(
 		context.Background(),
 		&id, "u1", repository.CardgroupOrderBy("not_a_real_column"), "after",
 	)
@@ -1486,7 +1486,7 @@ func TestResolveCardgroupCursor_MalformedV1_ReturnsBadUserInput(t *testing.T) {
 	uc := NewCardgroupUsecase(repo, newTestLogger())
 
 	malformed := "v1:!!!not-base64!!!"
-	_, err := uc.resolveCardgroupCursor(
+	_, err := uc.(*cardgroupUsecase).resolveCardgroupCursor(
 		context.Background(),
 		&malformed, "u1", repository.CardgroupOrderByID, "after",
 	)
@@ -1504,7 +1504,7 @@ func TestResolveCardgroupCursor_V1EncodedID(t *testing.T) {
 
 	// Encode the raw ID into the v1 envelope the way the resolver would.
 	encoded := "v1:Y2ctY3Vyc29y" // base64.RawURLEncoding.EncodeToString([]byte("cg-cursor"))
-	c, err := uc.resolveCardgroupCursor(
+	c, err := uc.(*cardgroupUsecase).resolveCardgroupCursor(
 		context.Background(),
 		&encoded, "u1", repository.CardgroupOrderByID, "after",
 	)

--- a/backend/internal/usecase/learn.go
+++ b/backend/internal/usecase/learn.go
@@ -30,7 +30,12 @@ type CardgroupRepoForLearn interface {
 	FindByID(ctx context.Context, id string) (*domain.Cardgroup, error)
 }
 
-type LearnUsecase struct {
+// LearnUsecase is the application interface for learning session operations.
+type LearnUsecase interface {
+	NextDueCards(ctx context.Context, cardgroupID string, limit *int) ([]*domain.Card, error)
+}
+
+type learnUsecase struct {
 	cardRepo      CardRepoForLearn
 	cardgroupRepo CardgroupRepoForLearn
 	ordering      *service.OrderingPolicy
@@ -57,7 +62,7 @@ func NewLearnUsecase(
 	defaultLimit, maxLimit int,
 	clock Clock,
 	logger *slog.Logger,
-) *LearnUsecase {
+) LearnUsecase {
 	if logger == nil {
 		panic("usecase: learn: logger is required")
 	}
@@ -87,7 +92,7 @@ func NewLearnUsecase(
 	if defaultLimit > maxLimit {
 		panic(fmt.Sprintf("usecase: learn: defaultLimit (%d) must not exceed maxLimit (%d)", defaultLimit, maxLimit))
 	}
-	return &LearnUsecase{
+	return &learnUsecase{
 		cardRepo:      cardRepo,
 		cardgroupRepo: cardgroupRepo,
 		ordering:      ordering,
@@ -101,7 +106,7 @@ func NewLearnUsecase(
 
 // NextDueCards returns up to limit due cards (clamped to [1, maxLimit]).
 // Returns Unauthenticated when the caller does not own the cardgroup, BadUserInput when the cardgroup is missing.
-func (u *LearnUsecase) NextDueCards(ctx context.Context, cardgroupID string, limit *int) ([]*domain.Card, error) {
+func (u *learnUsecase) NextDueCards(ctx context.Context, cardgroupID string, limit *int) ([]*domain.Card, error) {
 	user := auth.UserFrom(ctx)
 	if user == nil {
 		return nil, ucerr.ErrUnauthenticated
@@ -139,7 +144,7 @@ func (u *LearnUsecase) NextDueCards(ctx context.Context, cardgroupID string, lim
 	return ordered, nil
 }
 
-func (u *LearnUsecase) clampLimit(limit int) int {
+func (u *learnUsecase) clampLimit(limit int) int {
 	if limit <= 0 {
 		return u.defaultLimit
 	}

--- a/backend/internal/usecase/learn.go
+++ b/backend/internal/usecase/learn.go
@@ -30,7 +30,7 @@ type CardgroupRepoForLearn interface {
 	FindByID(ctx context.Context, id string) (*domain.Cardgroup, error)
 }
 
-// LearnUsecase is the application interface for learning session operations.
+// LearnUsecase surfaces due-card retrieval for a learning session.
 type LearnUsecase interface {
 	NextDueCards(ctx context.Context, cardgroupID string, limit *int) ([]*domain.Card, error)
 }

--- a/backend/internal/usecase/swipe.go
+++ b/backend/internal/usecase/swipe.go
@@ -140,33 +140,9 @@ func NewSwipeUsecaseWithTx(
 	userCardFSRSRepo UserCardFSRSRepoForSwipe,
 	logger *slog.Logger,
 ) SwipeUsecase {
-	if logger == nil {
-		panic("usecase: swipe: logger is required")
-	}
-	if scheduler == nil {
-		scheduler = service.NewFSRSScheduler()
-	}
-	if nextBatchSize <= 0 {
-		nextBatchSize = defaultSwipeNextBatchSize
-	}
-	return &swipeUsecase{
-		cardRepo:      cardRepo,
-		cardgroupRepo: cardgroupRepo,
-		swipeRepo:     swipeRepo,
-		userFSRSRepo:  userCardFSRSRepo,
-		scheduler:     scheduler,
-		ordering:      service.NewOrderingPolicy(),
-		randSource: func() *rand.Rand {
-			return rand.New(rand.NewSource(time.Now().UnixNano()))
-		},
-		applyRating: func(current *domain.UserCardFSRS, scheduler domain.FSRSScheduler, rating domain.Rating, now time.Time) error {
-			return current.ApplyRating(scheduler, rating, now)
-		},
-		newSwipeRecord: domain.NewSwipeRecord,
-		nextBatchSize:  nextBatchSize,
-		tx:             tx,
-		logger:         logger,
-	}
+	uc := NewSwipeUsecase(nil, cardRepo, cardgroupRepo, swipeRepo, scheduler, nextBatchSize, userCardFSRSRepo, logger).(*swipeUsecase)
+	uc.tx = tx
+	return uc
 }
 
 func (u *swipeUsecase) HandleSwipe(ctx context.Context, in HandleSwipeInput) (HandleSwipeOutcome, error) {

--- a/backend/internal/usecase/swipe.go
+++ b/backend/internal/usecase/swipe.go
@@ -42,7 +42,7 @@ type UserCardFSRSRepoForSwipe interface {
 	FindByUserAndCardIDsTx(ctx context.Context, tx *gorm.DB, userID string, cardIDs []string) (map[string]*domain.UserCardFSRS, error)
 }
 
-// SwipeUsecase is the application interface for swipe session operations.
+// SwipeUsecase processes a single card swipe and advances the FSRS schedule.
 type SwipeUsecase interface {
 	HandleSwipe(ctx context.Context, in HandleSwipeInput) (HandleSwipeOutcome, error)
 }

--- a/backend/internal/usecase/swipe.go
+++ b/backend/internal/usecase/swipe.go
@@ -42,7 +42,12 @@ type UserCardFSRSRepoForSwipe interface {
 	FindByUserAndCardIDsTx(ctx context.Context, tx *gorm.DB, userID string, cardIDs []string) (map[string]*domain.UserCardFSRS, error)
 }
 
-type SwipeUsecase struct {
+// SwipeUsecase is the application interface for swipe session operations.
+type SwipeUsecase interface {
+	HandleSwipe(ctx context.Context, in HandleSwipeInput) (HandleSwipeOutcome, error)
+}
+
+type swipeUsecase struct {
 	cardRepo       CardRepoForSwipe
 	cardgroupRepo  CardgroupRepoForSwipe
 	swipeRepo      SwipeRecordRepoForSwipe
@@ -90,7 +95,7 @@ func NewSwipeUsecase(
 	nextBatchSize int,
 	userCardFSRSRepo UserCardFSRSRepoForSwipe,
 	logger *slog.Logger,
-) *SwipeUsecase {
+) SwipeUsecase {
 	if logger == nil {
 		panic("usecase: swipe: logger is required")
 	}
@@ -100,7 +105,7 @@ func NewSwipeUsecase(
 	if nextBatchSize <= 0 {
 		nextBatchSize = defaultSwipeNextBatchSize
 	}
-	uc := &SwipeUsecase{
+	uc := &swipeUsecase{
 		cardRepo:      cardRepo,
 		cardgroupRepo: cardgroupRepo,
 		swipeRepo:     swipeRepo,
@@ -134,16 +139,37 @@ func NewSwipeUsecaseWithTx(
 	tx txRunner,
 	userCardFSRSRepo UserCardFSRSRepoForSwipe,
 	logger *slog.Logger,
-) *SwipeUsecase {
+) SwipeUsecase {
 	if logger == nil {
 		panic("usecase: swipe: logger is required")
 	}
-	uc := NewSwipeUsecase(nil, cardRepo, cardgroupRepo, swipeRepo, scheduler, nextBatchSize, userCardFSRSRepo, logger)
-	uc.tx = tx
-	return uc
+	if scheduler == nil {
+		scheduler = service.NewFSRSScheduler()
+	}
+	if nextBatchSize <= 0 {
+		nextBatchSize = defaultSwipeNextBatchSize
+	}
+	return &swipeUsecase{
+		cardRepo:      cardRepo,
+		cardgroupRepo: cardgroupRepo,
+		swipeRepo:     swipeRepo,
+		userFSRSRepo:  userCardFSRSRepo,
+		scheduler:     scheduler,
+		ordering:      service.NewOrderingPolicy(),
+		randSource: func() *rand.Rand {
+			return rand.New(rand.NewSource(time.Now().UnixNano()))
+		},
+		applyRating: func(current *domain.UserCardFSRS, scheduler domain.FSRSScheduler, rating domain.Rating, now time.Time) error {
+			return current.ApplyRating(scheduler, rating, now)
+		},
+		newSwipeRecord: domain.NewSwipeRecord,
+		nextBatchSize:  nextBatchSize,
+		tx:             tx,
+		logger:         logger,
+	}
 }
 
-func (u *SwipeUsecase) HandleSwipe(ctx context.Context, in HandleSwipeInput) (HandleSwipeOutcome, error) {
+func (u *swipeUsecase) HandleSwipe(ctx context.Context, in HandleSwipeInput) (HandleSwipeOutcome, error) {
 	user := auth.UserFrom(ctx)
 	if user == nil {
 		return HandleSwipeOutcome{}, ucerr.ErrUnauthenticated

--- a/backend/internal/usecase/swipe_error_test.go
+++ b/backend/internal/usecase/swipe_error_test.go
@@ -122,7 +122,7 @@ func TestSwipeUsecase_HandleSwipe_ApplyRatingError_PinsChain(t *testing.T) {
 		userFSRSRepo,
 		newTestLogger(),
 	)
-	uc.applyRating = func(_ *domain.UserCardFSRS, _ domain.FSRSScheduler, _ domain.Rating, _ time.Time) error {
+	uc.(*swipeUsecase).applyRating = func(_ *domain.UserCardFSRS, _ domain.FSRSScheduler, _ domain.Rating, _ time.Time) error {
 		return infraErr
 	}
 
@@ -210,7 +210,7 @@ func TestSwipeUsecase_HandleSwipe_NewSwipeRecordError_PinsChain(t *testing.T) {
 		userFSRSRepo,
 		newTestLogger(),
 	)
-	uc.newSwipeRecord = func(_, _, _ string, _ domain.Rating, _ time.Time, _ domain.FSRSState) (*domain.SwipeRecord, error) {
+	uc.(*swipeUsecase).newSwipeRecord = func(_, _, _ string, _ domain.Rating, _ time.Time, _ domain.FSRSState) (*domain.SwipeRecord, error) {
 		return nil, infraErr
 	}
 

--- a/backend/internal/usecase/user.go
+++ b/backend/internal/usecase/user.go
@@ -26,7 +26,7 @@ type UserRolesRepository interface {
 	ListByUser(ctx context.Context, userID string) ([]*domain.Role, error)
 }
 
-// UserUsecase is the application interface for user-related operations.
+// UserUsecase is the authenticated user profile and role-query surface.
 type UserUsecase interface {
 	Me(ctx context.Context) (*domain.User, error)
 	RolesFor(ctx context.Context, targetID string) ([]*domain.Role, error)

--- a/backend/internal/usecase/user.go
+++ b/backend/internal/usecase/user.go
@@ -26,21 +26,28 @@ type UserRolesRepository interface {
 	ListByUser(ctx context.Context, userID string) ([]*domain.Role, error)
 }
 
-type UserUsecase struct {
+// UserUsecase is the application interface for user-related operations.
+type UserUsecase interface {
+	Me(ctx context.Context) (*domain.User, error)
+	RolesFor(ctx context.Context, targetID string) ([]*domain.Role, error)
+	UpdateUser(ctx context.Context, in UpdateUserInput) (UpdateProfileOutcome, error)
+}
+
+type userUsecase struct {
 	repo   UserRepository
 	roles  UserRolesRepository
 	auth   AdminChecker
 	logger *slog.Logger
 }
 
-func NewUserUsecase(repo UserRepository, roles UserRolesRepository, authSvc AdminChecker, logger *slog.Logger) *UserUsecase {
+func NewUserUsecase(repo UserRepository, roles UserRolesRepository, authSvc AdminChecker, logger *slog.Logger) UserUsecase {
 	if logger == nil {
 		panic("usecase: user: logger is required")
 	}
-	return &UserUsecase{repo: repo, roles: roles, auth: authSvc, logger: logger}
+	return &userUsecase{repo: repo, roles: roles, auth: authSvc, logger: logger}
 }
 
-func (u *UserUsecase) Me(ctx context.Context) (*domain.User, error) {
+func (u *userUsecase) Me(ctx context.Context) (*domain.User, error) {
 	user := auth.UserFrom(ctx)
 	if user == nil {
 		return nil, ucerr.ErrUnauthenticated
@@ -58,7 +65,7 @@ func (u *UserUsecase) Me(ctx context.Context) (*domain.User, error) {
 	return nil, eris.Wrap(err, "usecase: Me: find user by ID")
 }
 
-func (u *UserUsecase) RolesFor(ctx context.Context, targetID string) ([]*domain.Role, error) {
+func (u *userUsecase) RolesFor(ctx context.Context, targetID string) ([]*domain.Role, error) {
 	caller := auth.UserFrom(ctx)
 	if caller == nil || caller.Sub == "" {
 		return nil, ucerr.ErrUnauthenticated
@@ -111,7 +118,7 @@ type UpdateProfileOutcome struct {
 // bio is optional (nil = unchanged, "" = explicit clear) and capped at 500
 // graphemes. Validation failures are returned via the outcome's Validation
 // field, not on the error channel.
-func (u *UserUsecase) UpdateUser(ctx context.Context, in UpdateUserInput) (UpdateProfileOutcome, error) {
+func (u *userUsecase) UpdateUser(ctx context.Context, in UpdateUserInput) (UpdateProfileOutcome, error) {
 	user := auth.UserFrom(ctx)
 	if user == nil {
 		return UpdateProfileOutcome{}, ucerr.ErrUnauthenticated

--- a/docs/backend/library-gotchas/resolver-usecase-interface-vs-concrete-testability.md
+++ b/docs/backend/library-gotchas/resolver-usecase-interface-vs-concrete-testability.md
@@ -124,6 +124,10 @@ every production call site that constructs a Resolver. Out of scope for an
 outcome-union promotion PR — the 800-line ceiling in
 [`.claude/rules/pr-sizing.md`](../../../.claude/rules/pr-sizing.md) excludes
 unrelated shape changes.
+For the step-by-step mechanics of that promotion — the interface + unexported struct template,
+type assertions for private access in same-package tests, `WithTx` constructor refactoring,
+and the pointer-to-interface anti-pattern — see
+[`usecase-interface-promotion-pattern.md`](usecase-interface-promotion-pattern.md).
 
 ## References
 

--- a/docs/backend/library-gotchas/usecase-interface-promotion-pattern.md
+++ b/docs/backend/library-gotchas/usecase-interface-promotion-pattern.md
@@ -1,0 +1,159 @@
+# Usecase interface promotion pattern
+
+When a usecase starts as a concrete struct (`type CardgroupUsecase struct`) and is later
+promoted to an interface, four concerns arise: the mechanics of promotion, test access to
+private methods, `WithTx`-style constructor refactoring, and the pointer-to-interface
+anti-pattern that surfaces during the change.
+
+## Three-part template
+
+Every promoted usecase follows this template (using `CardgroupUsecase` as the example):
+
+```go
+// Declared interface — lists only the methods the resolver calls.
+type CardgroupUsecase interface {
+    Cardgroup(ctx context.Context, id string) (*domain.Cardgroup, error)
+    Create(ctx context.Context, in CreateCardgroupInput) (CreateCardgroupOutcome, error)
+    Update(ctx context.Context, id string, in UpdateCardgroupInput) (UpdateCardgroupOutcome, error)
+    Delete(ctx context.Context, id string) error
+    ListCardgroupsByOwnerConnection(ctx context.Context, in CardgroupConnectionInput) (*CardgroupConnectionOutput, error)
+}
+
+// Unexported concrete struct — holds narrow repository interfaces and logger.
+type cardgroupUsecase struct {
+    repo   CardgroupRepository
+    logger *slog.Logger
+}
+
+// Constructor returns the interface, not a pointer to the struct.
+func NewCardgroupUsecase(repo CardgroupRepository, logger *slog.Logger) CardgroupUsecase {
+    if logger == nil {
+        panic("usecase: cardgroup: logger is required")
+    }
+    return &cardgroupUsecase{repo: repo, logger: logger}
+}
+```
+
+The invariants:
+- The interface name is public (`CardgroupUsecase`); the struct is unexported (`cardgroupUsecase`).
+- Private methods on the struct (`resolveCardgroupCursor`, `resolveCursor`, `clampLimit`) are
+  excluded from the interface — Go's visibility rules enforce this: unexported methods cannot
+  appear on a named interface in another package, and same-package code does not need them on
+  the interface.
+- `NewCardgroupUsecase` panics on nil dependencies. The panic is in the constructor, not in
+  the methods, because the invariant must be enforced before the struct can be used at all.
+  See [`constructor-panics-for-non-empty-config.md`](constructor-panics-for-non-empty-config.md).
+- `cmd/server` wires the concrete `*gormCardgroupRepository` to the `CardgroupRepository`
+  parameter and calls `NewCardgroupUsecase(...)`. The returned `CardgroupUsecase` interface
+  value is passed directly to `resolver.NewResolver(...)`. No cast is needed; the concrete
+  struct satisfies the interface implicitly.
+
+The `Resolver` struct field is the interface type without a pointer prefix:
+
+```go
+type Resolver struct {
+    CardgroupUC usecase.CardgroupUsecase   // interface, no *
+    // ...
+}
+```
+
+`NewResolver` accepts the same interface type for each usecase parameter. Taking `*usecase.CardgroupUsecase`
+(a pointer to an interface) is almost always a bug — see the anti-pattern section below.
+
+## Type assertion for private access in same-package tests
+
+Tests in `package usecase` are in the same package as the implementation. After promotion,
+the constructor returns `CardgroupUsecase` (an interface), not `*cardgroupUsecase`. But
+test code sometimes needs to call a private method or set a private field directly — for
+example, to unit-test `resolveCardgroupCursor` in isolation.
+
+The correct pattern is a type assertion back to the concrete struct:
+
+```go
+// In cardgroup_test.go (package usecase):
+uc := NewCardgroupUsecase(repo, slog.Default())
+got, err := uc.(*cardgroupUsecase).resolveCardgroupCursor(after, before)
+```
+
+This is valid because:
+1. The test is in `package usecase` — the same package as `cardgroupUsecase`. Go allows
+   access to unexported fields and methods from within the same package, regardless of
+   whether the access path goes through an interface value.
+2. `NewCardgroupUsecase` always returns `*cardgroupUsecase` wrapped in the interface. The
+   assertion will never panic in practice, but a failing assertion would surface as a test
+   panic rather than a compile error.
+
+The same pattern applies to field mutation in tests:
+
+```go
+// In swipe_error_test.go (package usecase):
+uc := NewSwipeUsecaseWithTx(...)
+uc.(*swipeUsecase).applyRating = func(...) error { return infraErr }
+```
+
+Do not add a `concrete()` or `inner()` accessor to the interface just to give tests access
+to private members. The type assertion within the same package is the idiomatic alternative.
+
+## `WithTx` constructor after interface promotion
+
+Some usecases have a `WithTx`-style constructor that accepts a transaction runner so tests
+can inject a controllable tx. Before promotion, the pattern was:
+
+```go
+// Pre-promotion: uc is *SwipeUsecase, so field assignment works.
+func NewSwipeUsecaseWithTx(..., tx txRunner, ...) *SwipeUsecase {
+    uc := NewSwipeUsecase(nil, ...)   // nil db — no real tx wired
+    uc.tx = tx                        // direct field assignment
+    return uc
+}
+```
+
+After promotion `NewSwipeUsecase` returns `SwipeUsecase` (interface). Direct field
+assignment on an interface value is not valid. Restore the pattern with a type assertion:
+
+```go
+// Post-promotion: assert to concrete struct, set field, return interface.
+func NewSwipeUsecaseWithTx(..., tx txRunner, ...) SwipeUsecase {
+    uc := NewSwipeUsecase(nil, ...).(*swipeUsecase)  // type-assert to get concrete ptr
+    uc.tx = tx
+    return uc
+}
+```
+
+This works because the type assertion is in `package usecase` (same package as the
+private struct). Production code outside the package cannot replicate this — which is
+the correct boundary.
+
+The alternative — duplicating the full constructor body in `NewSwipeUsecaseWithTx` — is
+tempting but costly: any future change to the production constructor's default initialization
+logic (e.g., changing `ordering` or `randSource` defaults) must be mirrored in the `WithTx`
+variant, and the drift is invisible until a test relies on the differing behavior.
+
+## Pointer-to-interface anti-pattern
+
+`*usecase.CardgroupUsecase` is a pointer to an interface. This is almost always a bug.
+
+An interface value in Go is already a two-word fat pointer (type descriptor + data pointer).
+Taking a pointer to it adds a third layer of indirection. The practical consequences:
+
+- An interface field in the `Resolver` struct declared as `*usecase.CardgroupUsecase` will
+  not satisfy the `usecase.CardgroupUsecase` interface at assignment sites — the two types
+  are different and the compiler rejects the assignment.
+- A test that constructs `Resolver{CardgroupUC: &cgUC}` where `cgUC` is already of type
+  `usecase.CardgroupUsecase` will fail with a "pointer to interface, not interface" error.
+- Calling methods through `*usecase.CardgroupUsecase` requires double-dereference
+  (`(*r.CardgroupUC).Create(...)`) and is not idiomatic.
+
+The rule: a struct field whose type is a usecase interface must be declared without a `*`
+prefix. The field holds the interface value (two words), not a pointer to the interface.
+
+```go
+// Correct:
+CardgroupUC usecase.CardgroupUsecase
+
+// Wrong — pointer to interface, not interface:
+CardgroupUC *usecase.CardgroupUsecase
+```
+
+See [`resolver-usecase-interface-vs-concrete-testability.md`](resolver-usecase-interface-vs-concrete-testability.md)
+for the testability rationale behind using interface fields in `Resolver`.

--- a/docs/backend/library-gotchas/variadic-optional-dep-injection-antipattern.md
+++ b/docs/backend/library-gotchas/variadic-optional-dep-injection-antipattern.md
@@ -12,7 +12,7 @@ to the first request that exercises the code path rather than surfacing at boot.
 // WRONG — variadic silently admits nil
 func NewResolver(
     user *usecase.UserUsecase,
-    learnUC ...*usecase.LearnUsecase, // ← caller can omit, leaving r.LearnUC == nil
+    learnUC ...usecase.LearnUsecase, // ← caller can omit, leaving r.LearnUC == nil
 ) *Resolver {
     r := &Resolver{UserUC: user}
     if len(learnUC) > 0 {
@@ -36,7 +36,7 @@ call site rather than hiding it behind variadic omission:
 func NewResolver(
     user *usecase.UserUsecase,
     // ... other deps ...
-    learnUC *usecase.LearnUsecase, // ← tests that skip this feature pass nil
+    learnUC usecase.LearnUsecase, // ← tests that skip this feature pass nil
 ) *Resolver {
     return &Resolver{
         UserUC:  user,
@@ -66,7 +66,7 @@ produces the same nil-deref hazard at the first request that touches that path
 rather than surfacing at the call site.
 
 **Reference:** `backend/graph/resolver/resolver.go` — `NewResolver` accepts
-`learnUC *usecase.LearnUsecase` as a required positional parameter; the comment
+`learnUC usecase.LearnUsecase` as a required positional parameter; the comment
 "Tests may pass nil for unused dependencies; do not pass nil from production
 wiring" documents the nil-explicit contract. `backend/cmd/server/main.go` —
 `newRouter` accepts `swipeRecordRepo repository.SwipeRecordRepository` as a


### PR DESCRIPTION
## Summary

Closes #214. Promotes `UserUsecase`, `CardgroupUsecase`, `CardUsecase`, `LearnUsecase`, and `SwipeUsecase` from concrete struct pointers (`*usecase.XxxUsecase`) to interfaces (`usecase.XxxUsecase`), matching the pattern already established for `AdminUserUsecase`, `AdminRoleUsecase`, `DictionaryUsecase`, and `LastViewedCardgroupUsecase`. All ten usecase-typed `Resolver` fields are now interfaces; resolver tests can substitute stubs without an integration setup. Production diff (excluding `*_test.go`) is under the 800-line ceiling in [`.claude/rules/pr-sizing.md`](.claude/rules/pr-sizing.md).

## Background / Motivation

- **Inconsistent testing surface.** The four already-promoted usecases enabled resolver-layer unit tests with stubs. The five concrete-struct usecases forced resolver tests into integration-style setups, creating a "why is this one mockable but not the other" friction every time a new resolver test was written.
- **Concrete pointers in `Resolver` blocked interface substitution.** `Resolver.CardUC *usecase.CardUsecase` required passing the concrete `*CardUsecase`; no stub satisfying a subset of the interface could be assigned. The interface form (`usecase.CardUsecase`) accepts any conforming value.
- **The split was historical, not principled.** The four promoted usecases were migrated during the typed-error migration for outcome-union unit tests. The five concrete usecases were not reached by that migration; this PR completes the uniform pattern across all ten resolver fields.

## Changes

### Interface + unexported struct promotion — `backend/internal/usecase/` (commit `605f4b9`)

For each of the five files (`user.go`, `cardgroup.go`, `card.go`, `learn.go`, `swipe.go`):

- Added exported `type XxxUsecase interface { ... }` listing all public methods.
- Renamed `type XxxUsecase struct` → `type xxxUsecase struct` (unexported).
- Changed all method receivers from `(u *XxxUsecase)` to `(u *xxxUsecase)`.
- Changed constructor return types: `NewXxxUsecase(...) XxxUsecase` (was `*XxxUsecase`).

`NewSwipeUsecaseWithTx` previously called `NewSwipeUsecase(nil, ...)` then mutated `uc.tx = tx` on the concrete pointer. After promotion the type assertion `uc := NewSwipeUsecase(nil, ...).(*swipeUsecase)` restores field access (commit `6784d91`).

### Resolver wiring — `backend/graph/resolver/resolver.go` (commit `0267ed7`)

- Changed five `Resolver` struct fields from `*usecase.XxxUsecase` to `usecase.XxxUsecase`.
- Changed the corresponding `NewResolver` parameters to match.
- `cmd/server/main.go` required no changes — the constructors already return interface values.

### Test fixes — `backend/internal/usecase/` (commit `2166f0a`)

Same-package tests that accessed private methods or struct fields through the interface needed type assertions:

- `card_bulk_delete_test.go`: `&CardUsecase{...}` → `&cardUsecase{...}` (unexported struct literal).
- `card_test.go`: `uc.resolveCursor(...)` → `uc.(*cardUsecase).resolveCursor(...)`.
- `cardgroup_test.go`: `uc.resolveCardgroupCursor(...)` → `uc.(*cardgroupUsecase).resolveCardgroupCursor(...)`.
- `swipe_error_test.go`: `uc.applyRating = ...` → `uc.(*swipeUsecase).applyRating = ...`.

### Cleanup (commit `5d4c877`)

- Interface docstrings aligned to the `admin_user.go` style (e.g. "is the card CRUD and paginated-list surface" rather than "is the application interface for card-related operations").
- Removed dead `FindByIDs` and `FindPageByCardgroup` stubs from `cardMockRepo` in `card_resolvers_test.go`; `FindDueCardsForUser` kept as it satisfies `CardRepoForLearn` for the learn tests.

### Documentation (commit `9e8b6dd`)

- Added [`docs/backend/library-gotchas/usecase-interface-promotion-pattern.md`](docs/backend/library-gotchas/usecase-interface-promotion-pattern.md) documenting the three-part template, same-package type-assertion pattern, `WithTx` refactoring after promotion, and the pointer-to-interface anti-pattern.
- Added cross-reference in `resolver-usecase-interface-vs-concrete-testability.md` pointing to the new file.
- Fixed stale `*usecase.LearnUsecase` (concrete pointer) references in `variadic-optional-dep-injection-antipattern.md` to `usecase.LearnUsecase` (interface, no `*`).

## Test plan

- [ ] `grep -nE '^\tUserUC|^\tCardgroupUC|^\tCardUC|^\tLearnUC|^\tSwipeUC' backend/graph/resolver/resolver.go` shows no leading `*` on any of the five fields
- [ ] `go build ./...` passes
- [ ] `go test -race ./...` — 1338 tests pass in 23 packages
- [ ] `grep -rn 'type.*Usecase interface' backend/internal/usecase/*_test.go` — no matches (interfaces live in `*.go`, not `*_test.go`)
