### PR TITLE
refactor(usecase): extract validateRelayArgs and requireCallerSub helpers

### DIFF
--- a/backend/internal/usecase/admin_gate.go
+++ b/backend/internal/usecase/admin_gate.go
@@ -60,8 +60,8 @@ func NewAdminGate(checker AdminChecker) *AdminGate {
 // errors.Is / errors.AsType and an additional wrap would defeat that.
 func (g *AdminGate) Require(ctx context.Context, callerPrefix string) (callerID string, err error) {
 	caller := auth.UserFrom(ctx)
-	if caller == nil || caller.Sub == "" {
-		return "", ucerr.ErrUnauthenticated
+	if err := requireCallerSub(caller); err != nil {
+		return "", err
 	}
 	isAdmin, err := g.checker.IsAdmin(ctx, caller.Sub)
 	if err != nil {

--- a/backend/internal/usecase/admin_user.go
+++ b/backend/internal/usecase/admin_user.go
@@ -203,23 +203,11 @@ func (u *adminUserUsecase) List(
 		return nil, err
 	}
 
-	if after != nil && before != nil {
-		return nil, ucerr.NewValidationError("after", "after and before are mutually exclusive")
-	}
-	if first != nil && *first > 0 && before != nil {
-		return nil, ucerr.NewValidationError("before", "before requires last, not first")
-	}
-	if last != nil && *last > 0 && after != nil {
-		return nil, ucerr.NewValidationError("after", "after requires first, not last")
-	}
-	// A cursor without its companion count is ambiguous: the server cannot
-	// determine page size or direction. Reject early so the repository is
-	// never called with an uninterpretable combination.
-	if before != nil && (first == nil || *first <= 0) && (last == nil || *last <= 0) {
-		return nil, ucerr.NewValidationError("before", "before requires last")
-	}
-	if after != nil && (first == nil || *first <= 0) && (last == nil || *last <= 0) {
-		return nil, ucerr.NewValidationError("after", "after requires first")
+	// Relay argument coherence: after pairs with first (forward) and before
+	// pairs with last (backward). A cursor without its companion count is also
+	// rejected — page size and direction would be unresolvable.
+	if err := validateRelayArgs(first, last, after, before); err != nil {
+		return nil, err
 	}
 
 	wantFirst, wantLast, err := resolveAdminPageSize(first, last)

--- a/backend/internal/usecase/admin_user.go
+++ b/backend/internal/usecase/admin_user.go
@@ -256,10 +256,8 @@ func (u *adminUserUsecase) List(
 		out.Edges[i] = AdminUserEdge{Cursor: user.ID, Node: user}
 	}
 	if len(users) > 0 {
-		start := users[0].ID
-		end := users[len(users)-1].ID
-		out.PageInfo.StartCursor = &start
-		out.PageInfo.EndCursor = &end
+		out.PageInfo.StartCursor = &users[0].ID
+		out.PageInfo.EndCursor = &users[len(users)-1].ID
 	}
 	return out, nil
 }

--- a/backend/internal/usecase/auth_helpers.go
+++ b/backend/internal/usecase/auth_helpers.go
@@ -1,6 +1,3 @@
-// Package usecase — authentication guard helpers.
-// requireCallerSub centralises the nil-or-empty-Sub check so every usecase
-// method can share the same guard without repeating the two-condition predicate.
 package usecase
 
 import (
@@ -8,13 +5,11 @@ import (
 	"backend/internal/usecase/ucerr"
 )
 
-// requireCallerSub returns ucerr.ErrUnauthenticated if caller is nil or has an
-// empty Sub claim. Call sites should return their own zero values alongside the
-// returned error, for example:
-//
-//	if err := requireCallerSub(caller); err != nil {
-//	    return nil, err
-//	}
+// requireCallerSub returns ucerr.ErrUnauthenticated bare when caller is nil or
+// has an empty Sub claim. Callers MUST NOT wrap the returned error before
+// returning it: gqlerr.FromUsecaseError uses errors.Is to detect the sentinel,
+// and any eris.Wrap around it causes the resolver to emit INTERNAL instead of
+// UNAUTHENTICATED.
 func requireCallerSub(caller *auth.AuthUser) error {
 	if caller == nil || caller.Sub == "" {
 		return ucerr.ErrUnauthenticated

--- a/backend/internal/usecase/auth_helpers.go
+++ b/backend/internal/usecase/auth_helpers.go
@@ -1,0 +1,23 @@
+// Package usecase — authentication guard helpers.
+// requireCallerSub centralises the nil-or-empty-Sub check so every usecase
+// method can share the same guard without repeating the two-condition predicate.
+package usecase
+
+import (
+	"backend/internal/auth"
+	"backend/internal/usecase/ucerr"
+)
+
+// requireCallerSub returns ucerr.ErrUnauthenticated if caller is nil or has an
+// empty Sub claim. Call sites should return their own zero values alongside the
+// returned error, for example:
+//
+//	if err := requireCallerSub(caller); err != nil {
+//	    return nil, err
+//	}
+func requireCallerSub(caller *auth.AuthUser) error {
+	if caller == nil || caller.Sub == "" {
+		return ucerr.ErrUnauthenticated
+	}
+	return nil
+}

--- a/backend/internal/usecase/auth_helpers_test.go
+++ b/backend/internal/usecase/auth_helpers_test.go
@@ -1,0 +1,50 @@
+package usecase
+
+import (
+	"errors"
+	"testing"
+
+	"backend/internal/auth"
+	"backend/internal/usecase/ucerr"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRequireCallerSub(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		caller  *auth.AuthUser
+		wantErr error
+	}{
+		{
+			name:    "nil caller returns ErrUnauthenticated",
+			caller:  nil,
+			wantErr: ucerr.ErrUnauthenticated,
+		},
+		{
+			name:    "empty Sub returns ErrUnauthenticated",
+			caller:  &auth.AuthUser{Sub: ""},
+			wantErr: ucerr.ErrUnauthenticated,
+		},
+		{
+			name:    "valid Sub returns nil",
+			caller:  &auth.AuthUser{Sub: "user-123"},
+			wantErr: nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := requireCallerSub(tc.caller)
+			if tc.wantErr == nil {
+				require.NoError(t, err)
+			} else {
+				require.True(t, errors.Is(err, tc.wantErr),
+					"expected %v, got %v", tc.wantErr, err)
+			}
+		})
+	}
+}

--- a/backend/internal/usecase/cardgroup.go
+++ b/backend/internal/usecase/cardgroup.go
@@ -264,24 +264,12 @@ func (u *cardgroupUsecase) ListCardgroupsByOwnerConnection(
 		return nil, ucerr.ErrUnauthenticated
 	}
 
-	// Five mixed-direction guards. The Relay spec pairs after with first
-	// (forward) and before with last (backward); any other combination is
-	// either contradictory or ambiguous. Reject before the repo is touched
-	// so the failure mode is observable rather than a silent page-1 reset.
-	if in.After != nil && in.Before != nil {
-		return nil, ucerr.NewValidationError("after", "after and before are mutually exclusive")
-	}
-	if in.First != nil && *in.First > 0 && in.Before != nil {
-		return nil, ucerr.NewValidationError("before", "last must be > 0 when before is set (received first, not last)")
-	}
-	if in.Last != nil && *in.Last > 0 && in.After != nil {
-		return nil, ucerr.NewValidationError("after", "first must be > 0 when after is set (received last, not first)")
-	}
-	if in.Before != nil && (in.First == nil || *in.First <= 0) && (in.Last == nil || *in.Last <= 0) {
-		return nil, ucerr.NewValidationError("before", "last must be > 0 when before is set")
-	}
-	if in.After != nil && (in.First == nil || *in.First <= 0) && (in.Last == nil || *in.Last <= 0) {
-		return nil, ucerr.NewValidationError("after", "first must be > 0 when after is set")
+	// Relay argument coherence: after pairs with first (forward) and before
+	// pairs with last (backward). Reject any other combination before the repo
+	// is touched so the failure mode is observable rather than a silent
+	// page-1 reset.
+	if err := validateRelayArgs(in.First, in.Last, in.After, in.Before); err != nil {
+		return nil, err
 	}
 
 	orderBy, dir, err := resolveCardgroupOrderBy(in.OrderBy, in.OrderDirection)

--- a/backend/internal/usecase/last_viewed_cardgroup.go
+++ b/backend/internal/usecase/last_viewed_cardgroup.go
@@ -10,7 +10,6 @@ import (
 	"backend/internal/auth"
 	"backend/internal/domain"
 	"backend/internal/repository"
-	"backend/internal/usecase/ucerr"
 )
 
 // SetLastViewedCardgroupOutcome is the result of LastViewedCardgroupUsecase.Set.
@@ -85,8 +84,8 @@ func NewLastViewedCardgroupWithDeps(
 // than an error.
 func (u *lastViewedCardgroupUsecase) Set(ctx context.Context, cardgroupID string) (SetLastViewedCardgroupOutcome, error) {
 	caller := auth.UserFrom(ctx)
-	if caller == nil || caller.Sub == "" {
-		return SetLastViewedCardgroupOutcome{}, ucerr.ErrUnauthenticated
+	if err := requireCallerSub(caller); err != nil {
+		return SetLastViewedCardgroupOutcome{}, err
 	}
 
 	if err := u.prefs.UpsertLastViewedCardgroup(ctx, caller.Sub, cardgroupID); err != nil {

--- a/backend/internal/usecase/user.go
+++ b/backend/internal/usecase/user.go
@@ -67,8 +67,8 @@ func (u *userUsecase) Me(ctx context.Context) (*domain.User, error) {
 
 func (u *userUsecase) RolesFor(ctx context.Context, targetID string) ([]*domain.Role, error) {
 	caller := auth.UserFrom(ctx)
-	if caller == nil || caller.Sub == "" {
-		return nil, ucerr.ErrUnauthenticated
+	if err := requireCallerSub(caller); err != nil {
+		return nil, err
 	}
 	if caller.Sub != targetID {
 		if u.auth == nil {

--- a/backend/internal/usecase/validators.go
+++ b/backend/internal/usecase/validators.go
@@ -13,6 +13,36 @@ import (
 	"backend/internal/usecase/ucerr"
 )
 
+// validateRelayArgs enforces Relay pagination argument coherence.
+// The Relay spec pairs after with first (forward direction) and before with
+// last (backward direction). The five guards below reject every other
+// combination before any repository call is made, so callers never receive a
+// silently re-interpreted page boundary.
+//
+// Returns a *ucerr.ValidationError on violation; nil otherwise.
+func validateRelayArgs(first, last *int, after, before *string) error {
+	// Mutual exclusion: cursors from opposite directions cannot coexist.
+	if after != nil && before != nil {
+		return ucerr.NewValidationError("after", "after and before are mutually exclusive")
+	}
+	// Direction mismatch: first (forward count) paired with before (backward cursor).
+	if first != nil && *first > 0 && before != nil {
+		return ucerr.NewValidationError("before", "before requires last, not first")
+	}
+	// Direction mismatch: last (backward count) paired with after (forward cursor).
+	if last != nil && *last > 0 && after != nil {
+		return ucerr.NewValidationError("after", "after requires first, not last")
+	}
+	// Cursor without companion count: page size and direction are unresolvable.
+	if before != nil && (first == nil || *first <= 0) && (last == nil || *last <= 0) {
+		return ucerr.NewValidationError("before", "before requires last")
+	}
+	if after != nil && (first == nil || *first <= 0) && (last == nil || *last <= 0) {
+		return ucerr.NewValidationError("after", "after requires first")
+	}
+	return nil
+}
+
 // translateBioErr maps domain Bio sentinels into usecase-layer typed errors.
 // Unexpected errors are wrapped with eris. Returns nil when err is nil.
 func translateBioErr(err error) error {

--- a/backend/internal/usecase/validators.go
+++ b/backend/internal/usecase/validators.go
@@ -1,6 +1,3 @@
-// Package usecase — validator helpers.
-// translateErr functions consolidate domain-sentinel-to-ucerr translation in
-// one file so the mapping logic is easy to audit and update in one place.
 package usecase
 
 import (
@@ -16,24 +13,21 @@ import (
 // validateRelayArgs enforces Relay pagination argument coherence.
 // The Relay spec pairs after with first (forward direction) and before with
 // last (backward direction). The five guards below reject every other
-// combination before any repository call is made, so callers never receive a
-// silently re-interpreted page boundary.
+// combination so callers never receive a silently re-interpreted page boundary.
+// Callers should invoke this before any repository call so invalid arguments
+// are rejected early.
 //
 // Returns a *ucerr.ValidationError on violation; nil otherwise.
 func validateRelayArgs(first, last *int, after, before *string) error {
-	// Mutual exclusion: cursors from opposite directions cannot coexist.
 	if after != nil && before != nil {
 		return ucerr.NewValidationError("after", "after and before are mutually exclusive")
 	}
-	// Direction mismatch: first (forward count) paired with before (backward cursor).
 	if first != nil && *first > 0 && before != nil {
 		return ucerr.NewValidationError("before", "before requires last, not first")
 	}
-	// Direction mismatch: last (backward count) paired with after (forward cursor).
 	if last != nil && *last > 0 && after != nil {
 		return ucerr.NewValidationError("after", "after requires first, not last")
 	}
-	// Cursor without companion count: page size and direction are unresolvable.
 	if before != nil && (first == nil || *first <= 0) && (last == nil || *last <= 0) {
 		return ucerr.NewValidationError("before", "before requires last")
 	}

--- a/backend/internal/usecase/validators_test.go
+++ b/backend/internal/usecase/validators_test.go
@@ -1,0 +1,116 @@
+package usecase
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestValidateRelayArgs covers every rejection branch and the happy paths.
+// strPtr and intPtr are defined in card_test.go (same package).
+func TestValidateRelayArgs(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		first     *int
+		last      *int
+		after     *string
+		before    *string
+		wantField string // non-empty when a ValidationError is expected
+	}{
+		// --- Rejection branches ---
+
+		{
+			// after and before are mutually exclusive cursor directions.
+			name:      "after_and_before_mutually_exclusive",
+			after:     strPtr("cursor-a"),
+			before:    strPtr("cursor-b"),
+			wantField: "after",
+		},
+		{
+			// first (forward count) cannot pair with before (backward cursor).
+			name:      "first_with_before",
+			first:     intPtr(5),
+			before:    strPtr("cursor-b"),
+			wantField: "before",
+		},
+		{
+			// last (backward count) cannot pair with after (forward cursor).
+			name:      "last_with_after",
+			last:      intPtr(5),
+			after:     strPtr("cursor-a"),
+			wantField: "after",
+		},
+		{
+			// before without any companion count is ambiguous.
+			name:      "before_without_count",
+			before:    strPtr("cursor-b"),
+			wantField: "before",
+		},
+		{
+			// before with first=0 is also without a usable count.
+			name:      "before_with_first_zero",
+			first:     intPtr(0),
+			before:    strPtr("cursor-b"),
+			wantField: "before",
+		},
+		{
+			// after without any companion count is ambiguous.
+			name:      "after_without_count",
+			after:     strPtr("cursor-a"),
+			wantField: "after",
+		},
+		{
+			// after with last=0 is also without a usable count.
+			name:      "after_with_last_zero",
+			last:      intPtr(0),
+			after:     strPtr("cursor-a"),
+			wantField: "after",
+		},
+
+		// --- Happy paths (no error expected) ---
+
+		{
+			// Forward page: first + after.
+			name:  "forward_first_and_after",
+			first: intPtr(10),
+			after: strPtr("cursor-a"),
+		},
+		{
+			// Backward page: last + before.
+			name:   "backward_last_and_before",
+			last:   intPtr(10),
+			before: strPtr("cursor-b"),
+		},
+		{
+			// Initial forward page: first only, no cursor.
+			name:  "first_only",
+			first: intPtr(10),
+		},
+		{
+			// Initial backward page: last only, no cursor.
+			name: "last_only",
+			last: intPtr(10),
+		},
+		{
+			// No arguments at all — caller uses its own default.
+			name: "all_nil",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := validateRelayArgs(tc.first, tc.last, tc.after, tc.before)
+
+			if tc.wantField == "" {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				assertValidationError(t, err, tc.wantField, "")
+			}
+		})
+	}
+}

--- a/backend/internal/usecase/validators_test.go
+++ b/backend/internal/usecase/validators_test.go
@@ -6,8 +6,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestValidateRelayArgs covers every rejection branch and the happy paths.
-// strPtr and intPtr are defined in card_test.go (same package).
 func TestValidateRelayArgs(t *testing.T) {
 	t.Parallel()
 
@@ -18,83 +16,79 @@ func TestValidateRelayArgs(t *testing.T) {
 		after     *string
 		before    *string
 		wantField string // non-empty when a ValidationError is expected
+		wantMsg   string // exact message string produced by the failing branch
 	}{
 		// --- Rejection branches ---
 
 		{
-			// after and before are mutually exclusive cursor directions.
 			name:      "after_and_before_mutually_exclusive",
 			after:     strPtr("cursor-a"),
 			before:    strPtr("cursor-b"),
 			wantField: "after",
+			wantMsg:   "after and before are mutually exclusive",
 		},
 		{
-			// first (forward count) cannot pair with before (backward cursor).
 			name:      "first_with_before",
 			first:     intPtr(5),
 			before:    strPtr("cursor-b"),
 			wantField: "before",
+			wantMsg:   "before requires last, not first",
 		},
 		{
-			// last (backward count) cannot pair with after (forward cursor).
 			name:      "last_with_after",
 			last:      intPtr(5),
 			after:     strPtr("cursor-a"),
 			wantField: "after",
+			wantMsg:   "after requires first, not last",
 		},
 		{
-			// before without any companion count is ambiguous.
 			name:      "before_without_count",
 			before:    strPtr("cursor-b"),
 			wantField: "before",
+			wantMsg:   "before requires last",
 		},
 		{
-			// before with first=0 is also without a usable count.
 			name:      "before_with_first_zero",
 			first:     intPtr(0),
 			before:    strPtr("cursor-b"),
 			wantField: "before",
+			wantMsg:   "before requires last",
 		},
 		{
-			// after without any companion count is ambiguous.
 			name:      "after_without_count",
 			after:     strPtr("cursor-a"),
 			wantField: "after",
+			wantMsg:   "after requires first",
 		},
 		{
-			// after with last=0 is also without a usable count.
 			name:      "after_with_last_zero",
 			last:      intPtr(0),
 			after:     strPtr("cursor-a"),
 			wantField: "after",
+			wantMsg:   "after requires first",
 		},
 
 		// --- Happy paths (no error expected) ---
 
 		{
-			// Forward page: first + after.
 			name:  "forward_first_and_after",
 			first: intPtr(10),
 			after: strPtr("cursor-a"),
 		},
 		{
-			// Backward page: last + before.
 			name:   "backward_last_and_before",
 			last:   intPtr(10),
 			before: strPtr("cursor-b"),
 		},
 		{
-			// Initial forward page: first only, no cursor.
 			name:  "first_only",
 			first: intPtr(10),
 		},
 		{
-			// Initial backward page: last only, no cursor.
 			name: "last_only",
 			last: intPtr(10),
 		},
 		{
-			// No arguments at all — caller uses its own default.
 			name: "all_nil",
 		},
 	}
@@ -109,7 +103,7 @@ func TestValidateRelayArgs(t *testing.T) {
 				require.NoError(t, err)
 			} else {
 				require.Error(t, err)
-				assertValidationError(t, err, tc.wantField, "")
+				assertValidationError(t, err, tc.wantField, tc.wantMsg)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Extracts two shared helpers and drops redundant intermediate string copies to remove inline duplication across the usecase layer. Production diff is under the 800-line ceiling in [`.claude/rules/pr-sizing.md`](.claude/rules/pr-sizing.md). No related issue exists for this work — this is a solo-developer complexity-minimization pass.

## Background / Motivation

- **`validateRelayArgs` was inlined independently in `admin_user.go` and `cardgroup.go`**, with error-message wording that had drifted between the two sites. Neither site had direct unit tests for the validation logic.
- **`requireCallerSub` was inlined in three files** (`admin_gate.go`, `user.go`, `last_viewed_cardgroup.go`) as an `if caller == nil || caller.Sub == ""` early-return. The no-wrap contract for `ucerr.ErrUnauthenticated` was implicit and undocumented at every site.
- Both extractions follow the pattern established by `AdminGate.Require` in PR #222: collapse a repeated guard into one named helper with a documented contract, then add direct unit tests so the contract is machine-checked.

## Changes

### Relay-pagination validation — `backend/internal/usecase/validators.go` (commit `9387793`)

- New `validateRelayArgs(first, last *int, after, before *string) error` helper enforces the five Relay-spec coherence rules: mutual exclusion of `after`/`before`, direction–count pairing (`first`+`after`, `last`+`before`), and cursor-without-count rejection.
- `admin_user.go` and `cardgroup.go` inline guard blocks (15 lines each) replaced by a single `validateRelayArgs(...)` call.
- Pre-merge grep confirmed zero consumers of the old `cardgroup.go`-specific error string text across backend, frontend, and docs — the message wording unification had no downstream impact.

### Auth caller guard — `backend/internal/usecase/auth_helpers.go` (commit `bf06ff9`)

- New `requireCallerSub(caller *auth.AuthUser) error` helper returns `ucerr.ErrUnauthenticated` bare when `caller` is nil or has an empty `Sub` claim.
- Docblock explicitly documents the no-wrap contract: callers must not wrap the returned error, because `gqlerr.FromUsecaseError` uses `errors.Is` to detect the sentinel, and any `eris.Wrap` around it causes the resolver to emit `INTERNAL` instead of `UNAUTHENTICATED`.
- Three inline guards in `admin_gate.go`, `user.go`, and `last_viewed_cardgroup.go` replaced by a single call.

### Cursor pointer cleanup in `admin_user.go` (commit `e319416`)

- `start := users[0].ID` / `end := users[len-1].ID` intermediate copies dropped; `PageInfo.StartCursor` and `PageInfo.EndCursor` reference the slice element fields inline.

### Tests (commits `9387793`, `bf06ff9`, `7fa0b78`)

- `TestValidateRelayArgs` — 12 table-driven sub-tests (7 rejection branches, 5 happy paths) pinning both the `Field` and message text of each `*ucerr.ValidationError`.
- `TestRequireCallerSub` — 3 sub-tests (nil caller, empty Sub, valid Sub) asserting sentinel identity via `errors.Is(err, ucerr.ErrUnauthenticated)`.

## Verification

```bash
cd backend

# Helpers are wired at every call site
grep -rn 'validateRelayArgs' internal/usecase/ | grep -v _test.go
# Expect: validators.go (declaration) + admin_user.go + cardgroup.go

grep -rn 'requireCallerSub' internal/usecase/ | grep -v _test.go
# Expect: auth_helpers.go (declaration) + admin_gate.go + user.go + last_viewed_cardgroup.go

# Old inline patterns are gone
grep -rn 'after != nil && before != nil' internal/usecase/ | grep -v _test.go
# Expect: 1 hit — only validators.go

grep -rn 'caller == nil || caller.Sub == ""' internal/usecase/ | grep -v _test.go
# Expect: 1 hit — only auth_helpers.go

# Language-policy: no CJK, no PR-order references
grep -rlP "[\x{3040}-\x{30ff}\x{4e00}-\x{9fff}]" \
  --include="*.go" --include="*.md" \
  docs backend/internal backend/cmd backend/graph
grep -rnE "PR[0-9]+" docs backend/internal backend/cmd backend/graph
# Expect: empty for both
```

## Test plan

- [x] `cd backend && go build ./...` — clean
- [x] `cd backend && go vet ./...` — clean
- [x] `cd backend && go test -race -count=1 ./...` — 1355 / 1355 tests pass
- [x] `cd backend && go tool go-arch-lint check --project-path .` — exits 0
- [x] CI grep gates (`fmt.Errorf %w`, struct-literal `ucerr`, raw resolver error, hardcoded `extensions.code`) — all clean
- [x] Schema-lint clean
- [ ] CI green on this branch
