### PR TITLE
fix(learn): drop nextCards from SwipeResponse to fix swipe reshuffle (#229)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .DEFAULT_GOAL := help
 
-.PHONY: help setup notice-prereqs check-docker mise-install supabase-restart supabase-stop sync-env install supabase-start check-google-oauth dev dev-backend dev-frontend dump-data import-data codegen codegen-yacc test clean clean-frontend clean-backend doctor db-reset setup-prod setup-prod-preflight setup-prod-postapply teardown-prod teardown-prod-preflight seed-admin seed-admin-prod sync-notion-secrets sync-notion-preflight notion-env-init notion-local-setup notion-local-run
+.PHONY: help setup notice-prereqs check-docker mise-install supabase-restart supabase-stop sync-env install supabase-start check-google-oauth dev dev-backend dev-frontend dump-data import-data codegen codegen-yacc test clean clean-frontend clean-backend doctor db-reset setup-prod setup-prod-preflight setup-prod-postapply supabase-hooks teardown-prod teardown-prod-preflight seed-admin seed-admin-prod sync-notion-secrets sync-notion-preflight notion-env-init notion-local-setup notion-local-run
 
 # Ensure every ansible-playbook invocation picks up playbooks/ansible.cfg.
 # Ansible does not search the inventory directory for ansible.cfg — it walks
@@ -129,6 +129,9 @@ setup-prod-preflight: mise-install ## Verify tokens and GitHub App installations
 
 setup-prod-postapply: mise-install ## Trigger first Render deploy + smoke tests (re-runnable from .state.yml)
 	@$(ANSIBLE_PROD) --tags postapply
+
+supabase-hooks: mise-install ## Enable Supabase custom_access_token hook in production (idempotent; re-runnable)
+	@$(ANSIBLE_PROD) --tags supabase-hooks
 
 seed-admin-prod: mise-install ## Grant admin role to SUPER_USER_EMAILS in production DB (idempotent; re-runnable)
 	@$(ANSIBLE_PROD) --tags seed-admin-prod

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -15,18 +15,19 @@ The stack splits across three providers, each owning a distinct concern:
 A thin Ansible-driven layer wraps this manual runbook with prerequisite checks, value-derivation, GitHub Secret registration, deploy-trigger, and smoke tests. It does **not** replace the dashboard work below — operators still create the Supabase project, the Render web service, and the Vercel project by hand. The remainder of this document is the authoritative manual procedure; refer to it for what each phase is doing under the hood.
 
 ```bash
-make setup-prod              # full guided run: preflight + 4 dashboard steps + smoke
+make setup-prod              # full guided run: preflight + 4 dashboard steps + smoke + hook
 make setup-prod-preflight    # ~10s scanner: tokens + auth + manual-prereq reminders
 make setup-prod-postapply    # re-runnable: kick first Render deploy + smoke tests
+make supabase-hooks          # re-runnable: enable custom_access_token hook (standalone)
 ```
 
 ### Why guided, not fully automated
 
 The earlier Terraform implementation was deleted **as an intentional IaC-abandonment decision**, not as tech-debt cleanup — the bring-up runs once per environment per lifetime, so the ROI of full API automation is low and the maintenance cost of mirroring three providers' APIs in a stateful tool is high. The playbook re-introduces the layer where humans actually make mistakes (token expiry, missed GitHub App installs, copy-paste of derived URLs, forgetting to register the deploy-hook secret) without re-introducing IaC. Reach for `--tags <phase>` or hand-runs of the manual procedure when you need to deviate; the playbook is a convenience, not a contract.
 
-### Three Make targets, six phases
+### Make targets and phases
 
-The Makefile exposes only `setup-prod`, `setup-prod-preflight`, and `setup-prod-postapply` because the four dashboard phases (`supabase`, `render`, `vercel`, `loopback`) must run in order and giving each its own target invites order-of-operation mistakes. When intentional partial runs are needed, drive them via `--tags` directly:
+The Makefile exposes `setup-prod`, `setup-prod-preflight`, `setup-prod-postapply`, and `supabase-hooks`. The four dashboard phases (`supabase`, `render`, `vercel`, `loopback`) must run in order; giving each its own target invites order-of-operation mistakes, so partial runs are driven via `--tags` directly:
 
 ```bash
 ansible-playbook playbooks/setup-prod.yml --tags <phase>
@@ -40,6 +41,7 @@ ansible-playbook playbooks/setup-prod.yml --tags <phase>
 | `vercel` | 4 | Step 3 — Vercel project import |
 | `loopback` | 5 | Step 4 — Supabase loopback |
 | `postapply` | 6 | Post-bring-up + smoke |
+| `supabase-hooks` | 7 | Enable custom_access_token hook via Management API |
 
 `supabase.yml` is imported twice from the entry playbook with different `step` vars (`create` vs `loopback`), gated by `when: step == ...` blocks inside the file. This keeps the tag → step mapping 1:1 (`--tags supabase` runs only Step 1, `--tags loopback` only Step 4) while avoiding two near-duplicate task files.
 
@@ -165,6 +167,8 @@ Four steps across the three providers. Allow about 30 minutes total; Supabase pr
    | Backend `SUPABASE_JWT_AUDIENCE` | `authenticated` | Supabase default. |
 
 4. **Connect** (top of any page) → **Session pooler** tab → copy the `postgres://...?sslmode=require` DSN → backend `SUPABASE_DB_URL`. Use session pooler, not transaction pooler — `golang-migrate` issues advisory locks that need a real session.
+
+The `custom_access_token_hook` (the Postgres function that injects `app_metadata.role` into the JWT so the frontend can show the Admin nav) is enabled automatically by Phase 7 (`supabase-hooks`) of `make setup-prod`, after the first Render deploy lands and migrations have run. No manual dashboard step is required. To enable it on an existing environment, run `make supabase-hooks`.
 
 ### Step 2 — Render
 

--- a/frontend/src/components/learn/animated-card.tsx
+++ b/frontend/src/components/learn/animated-card.tsx
@@ -3,9 +3,16 @@
 import { animated, useSpring } from "@react-spring/web";
 import { useDrag } from "@use-gesture/react";
 import { useCallback } from "react";
+import { evaluateSwipeGesture } from "./gesture-evaluation";
 import type { SwipeCardData } from "./swipe-card";
 import { CardContent } from "./swipe-card";
 import type { SwipeDirection } from "./types";
+
+// Minimum movement (px) before `@use-gesture` considers the pointer to be in a
+// drag. Raised above the previous 4px to stop a steady-finger pointer-down
+// from registering a drag — the old threshold combined with the immediate
+// scale jump (1 → 1.02) made the card visibly jitter on touch.
+const USE_GESTURE_THRESHOLD = 12;
 
 type Props = {
   card: SwipeCardData;
@@ -53,37 +60,31 @@ export function AnimatedCard({ card, isActive, onSwipe, onSwipeProgress }: Props
     ({ active, movement: [mx, my], direction: [, yDir], velocity: [vx, vy] }) => {
       if (!isActive) return;
 
-      const xAbs = Math.abs(mx);
-      const yAbs = Math.abs(my);
-      let direction: SwipeDirection | null = null;
-      let progress = 0;
-
-      if (xAbs >= yAbs && xAbs > 8) {
-        direction = mx < 0 ? "left" : "right";
-        progress = Math.min(xAbs / 120, 1);
-      } else if (my > 8) {
-        direction = "down";
-        progress = Math.min(yAbs / 96, 1);
-      }
+      const { direction, progress, shouldSwipe } = evaluateSwipeGesture({
+        active,
+        mx,
+        my,
+        vx,
+        vy,
+        yDir,
+      });
       onSwipeProgress?.(active ? direction : null, active ? progress : 0);
-
-      const shouldSwipe =
-        !active &&
-        direction &&
-        ((direction === "down" && (yAbs > 96 || vy > 0.35 || yDir > 0.9)) ||
-          (direction !== "down" && (xAbs > 120 || vx > 0.45)));
 
       if (shouldSwipe && direction) {
         completeSwipe(direction);
         return;
       }
 
+      // `immediate` is restricted to transform-axis keys (x/y/rotate) so the
+      // card tracks the pointer with no spring lag, while `scale` always
+      // animates through the spring — that prevents the 1 → 1.02 jump on
+      // drag-start which used to look like the card was "twitching".
       api.start({
         x: active ? mx : 0,
         y: active ? Math.max(my, -40) : 0,
         rotate: active ? mx / 16 : 0,
         scale: active ? 1.02 : 1,
-        immediate: active,
+        immediate: (key) => active && key !== "scale",
       });
     },
     {
@@ -91,7 +92,7 @@ export function AnimatedCard({ card, isActive, onSwipe, onSwipeProgress }: Props
       filterTaps: true,
       pointer: { capture: false },
       rubberband: true,
-      threshold: 4,
+      threshold: USE_GESTURE_THRESHOLD,
     },
   );
 

--- a/frontend/src/components/learn/gesture-evaluation.test.ts
+++ b/frontend/src/components/learn/gesture-evaluation.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from "vitest";
+import {
+  DIRECTION_LOCK_PX,
+  evaluateSwipeGesture,
+  HORIZONTAL_COMMIT_PX,
+  HORIZONTAL_COMMIT_VX,
+  HORIZONTAL_FLICK_MIN_PX,
+} from "./gesture-evaluation";
+
+const base = {
+  active: true,
+  mx: 0,
+  my: 0,
+  vx: 0,
+  vy: 0,
+  yDir: 0,
+};
+
+describe("evaluateSwipeGesture — direction locking (jitter suppression)", () => {
+  it("does not lock a direction for sub-threshold horizontal movement (5px)", () => {
+    const r = evaluateSwipeGesture({ ...base, mx: 5 });
+    expect(r.direction).toBeNull();
+    expect(r.progress).toBe(0);
+  });
+
+  it("does not lock a direction at the legacy 8px threshold", () => {
+    const r = evaluateSwipeGesture({ ...base, mx: 10 });
+    expect(r.direction).toBeNull();
+    expect(r.progress).toBe(0);
+  });
+
+  it("locks 'right' once movement exceeds DIRECTION_LOCK_PX", () => {
+    const r = evaluateSwipeGesture({ ...base, mx: DIRECTION_LOCK_PX + 2 });
+    expect(r.direction).toBe("right");
+    expect(r.progress).toBeGreaterThan(0);
+  });
+
+  it("locks 'left' for negative mx above the lock threshold", () => {
+    const r = evaluateSwipeGesture({ ...base, mx: -(DIRECTION_LOCK_PX + 2) });
+    expect(r.direction).toBe("left");
+  });
+
+  it("locks 'down' for positive my above the lock threshold", () => {
+    const r = evaluateSwipeGesture({ ...base, my: DIRECTION_LOCK_PX + 2 });
+    expect(r.direction).toBe("down");
+  });
+
+  it("does not lock 'down' for sub-threshold my", () => {
+    const r = evaluateSwipeGesture({ ...base, my: 10 });
+    expect(r.direction).toBeNull();
+  });
+
+  it("DIRECTION_LOCK_PX is at least 12 (jitter suppression)", () => {
+    expect(DIRECTION_LOCK_PX).toBeGreaterThanOrEqual(12);
+  });
+});
+
+describe("evaluateSwipeGesture — horizontal commit threshold (premature commit suppression)", () => {
+  it("does NOT commit a horizontal swipe at 100px with low velocity", () => {
+    const r = evaluateSwipeGesture({ ...base, active: false, mx: 100, vx: 0.2 });
+    expect(r.shouldSwipe).toBe(false);
+  });
+
+  it("does NOT commit a horizontal swipe at 100px with the legacy velocity (0.5)", () => {
+    // Previously vx > 0.45 was enough to commit at any distance — this is the
+    // accidental-flick failure mode the user reported.
+    const r = evaluateSwipeGesture({ ...base, active: false, mx: 100, vx: 0.5 });
+    expect(r.shouldSwipe).toBe(false);
+  });
+
+  it("does NOT commit a horizontal swipe at the legacy 120px distance threshold", () => {
+    const r = evaluateSwipeGesture({ ...base, active: false, mx: 120, vx: 0 });
+    expect(r.shouldSwipe).toBe(false);
+  });
+
+  it("commits a horizontal swipe at HORIZONTAL_COMMIT_PX", () => {
+    const r = evaluateSwipeGesture({
+      ...base,
+      active: false,
+      mx: HORIZONTAL_COMMIT_PX + 1,
+      vx: 0,
+    });
+    expect(r.shouldSwipe).toBe(true);
+    expect(r.direction).toBe("right");
+  });
+
+  it("commits a left swipe at -HORIZONTAL_COMMIT_PX", () => {
+    const r = evaluateSwipeGesture({
+      ...base,
+      active: false,
+      mx: -(HORIZONTAL_COMMIT_PX + 1),
+      vx: 0,
+    });
+    expect(r.shouldSwipe).toBe(true);
+    expect(r.direction).toBe("left");
+  });
+
+  it("HORIZONTAL_COMMIT_PX is at least 150 (longer swipe required)", () => {
+    expect(HORIZONTAL_COMMIT_PX).toBeGreaterThanOrEqual(150);
+  });
+
+  it("HORIZONTAL_COMMIT_VX is at least 0.8 (no accidental light-flick commits)", () => {
+    expect(HORIZONTAL_COMMIT_VX).toBeGreaterThanOrEqual(0.8);
+  });
+});
+
+describe("evaluateSwipeGesture — flick path (high velocity, mid distance)", () => {
+  it("commits via flick when distance >= HORIZONTAL_FLICK_MIN_PX AND vx > HORIZONTAL_COMMIT_VX", () => {
+    const r = evaluateSwipeGesture({
+      ...base,
+      active: false,
+      mx: HORIZONTAL_FLICK_MIN_PX + 5,
+      vx: HORIZONTAL_COMMIT_VX + 0.1,
+    });
+    expect(r.shouldSwipe).toBe(true);
+  });
+
+  it("does NOT commit via flick when distance is below HORIZONTAL_FLICK_MIN_PX even at very high velocity", () => {
+    // A 20px move with a 2.0 px/ms velocity is the "twitch" case — almost no
+    // travel, just a fast finger jiggle. Must not commit.
+    const r = evaluateSwipeGesture({
+      ...base,
+      active: false,
+      mx: HORIZONTAL_FLICK_MIN_PX - 10,
+      vx: 2.0,
+    });
+    expect(r.shouldSwipe).toBe(false);
+  });
+
+  it("HORIZONTAL_FLICK_MIN_PX is at least 30 (no twitch commits)", () => {
+    expect(HORIZONTAL_FLICK_MIN_PX).toBeGreaterThanOrEqual(30);
+  });
+});
+
+describe("evaluateSwipeGesture — vertical (down) commit unchanged", () => {
+  it("commits a down swipe at the legacy 96px distance threshold", () => {
+    const r = evaluateSwipeGesture({ ...base, active: false, my: 100, vy: 0 });
+    expect(r.shouldSwipe).toBe(true);
+    expect(r.direction).toBe("down");
+  });
+
+  it("commits a down swipe via the velocity path", () => {
+    const r = evaluateSwipeGesture({ ...base, active: false, my: 60, vy: 0.5 });
+    expect(r.shouldSwipe).toBe(true);
+    expect(r.direction).toBe("down");
+  });
+
+  it("does not commit a down swipe with insufficient motion", () => {
+    const r = evaluateSwipeGesture({ ...base, active: false, my: 30, vy: 0.1 });
+    expect(r.shouldSwipe).toBe(false);
+  });
+});
+
+describe("evaluateSwipeGesture — shouldSwipe is false while active (mid-drag)", () => {
+  it("never commits while the gesture is still active, even past commit distance", () => {
+    const r = evaluateSwipeGesture({
+      ...base,
+      active: true,
+      mx: HORIZONTAL_COMMIT_PX + 100,
+      vx: 5,
+    });
+    expect(r.shouldSwipe).toBe(false);
+    // …but direction/progress are still reported so the overlay paints.
+    expect(r.direction).toBe("right");
+    expect(r.progress).toBeGreaterThan(0);
+  });
+});

--- a/frontend/src/components/learn/gesture-evaluation.ts
+++ b/frontend/src/components/learn/gesture-evaluation.ts
@@ -16,9 +16,9 @@ export const HORIZONTAL_FLICK_MIN_PX = 40;
 
 // Vertical (down) commit thresholds — unchanged from the original tuning.
 // "Hard" / unsure-of-answer gesture stays forgiving on purpose.
-export const DOWN_COMMIT_PY = 96;
-export const DOWN_COMMIT_VY = 0.35;
-export const DOWN_COMMIT_YDIR = 0.9;
+const DOWN_COMMIT_PY = 96;
+const DOWN_COMMIT_VY = 0.35;
+const DOWN_COMMIT_YDIR = 0.9;
 
 export type GestureInput = {
   active: boolean;

--- a/frontend/src/components/learn/gesture-evaluation.ts
+++ b/frontend/src/components/learn/gesture-evaluation.ts
@@ -1,0 +1,70 @@
+import type { SwipeDirection } from "./types";
+
+// Direction-lock threshold. Movement under this many pixels is treated as
+// pre-drag jitter and reports no direction / zero progress so the overlay
+// does not paint and `scale` does not jump on micro-movements.
+export const DIRECTION_LOCK_PX = 14;
+
+// A horizontal swipe commits when EITHER:
+//   - travel distance exceeds HORIZONTAL_COMMIT_PX (slow but committed swipe), or
+//   - travel >= HORIZONTAL_FLICK_MIN_PX AND velocity > HORIZONTAL_COMMIT_VX (flick).
+// The flick minimum distance prevents a fast finger twitch (~20px at high
+// velocity) from registering as an intentional swipe.
+export const HORIZONTAL_COMMIT_PX = 160;
+export const HORIZONTAL_COMMIT_VX = 0.9;
+export const HORIZONTAL_FLICK_MIN_PX = 40;
+
+// Vertical (down) commit thresholds — unchanged from the original tuning.
+// "Hard" / unsure-of-answer gesture stays forgiving on purpose.
+export const DOWN_COMMIT_PY = 96;
+export const DOWN_COMMIT_VY = 0.35;
+export const DOWN_COMMIT_YDIR = 0.9;
+
+export type GestureInput = {
+  active: boolean;
+  mx: number;
+  my: number;
+  vx: number;
+  vy: number;
+  yDir: number;
+};
+
+export type GestureEvaluation = {
+  direction: SwipeDirection | null;
+  progress: number;
+  shouldSwipe: boolean;
+};
+
+export function evaluateSwipeGesture({
+  active,
+  mx,
+  my,
+  vx,
+  vy,
+  yDir,
+}: GestureInput): GestureEvaluation {
+  const xAbs = Math.abs(mx);
+  const yAbs = Math.abs(my);
+
+  let direction: SwipeDirection | null = null;
+  let progress = 0;
+
+  if (xAbs >= yAbs && xAbs > DIRECTION_LOCK_PX) {
+    direction = mx < 0 ? "left" : "right";
+    progress = Math.min(xAbs / HORIZONTAL_COMMIT_PX, 1);
+  } else if (my > DIRECTION_LOCK_PX) {
+    direction = "down";
+    progress = Math.min(yAbs / DOWN_COMMIT_PY, 1);
+  }
+
+  const shouldSwipe =
+    !active &&
+    direction !== null &&
+    ((direction === "down" &&
+      (yAbs > DOWN_COMMIT_PY || vy > DOWN_COMMIT_VY || yDir > DOWN_COMMIT_YDIR)) ||
+      (direction !== "down" &&
+        (xAbs > HORIZONTAL_COMMIT_PX ||
+          (xAbs > HORIZONTAL_FLICK_MIN_PX && vx > HORIZONTAL_COMMIT_VX))));
+
+  return { direction, progress, shouldSwipe };
+}

--- a/playbooks/setup-prod.yml
+++ b/playbooks/setup-prod.yml
@@ -20,6 +20,7 @@
 #   vercel          -> Phase 4  (runbook Step 3: Vercel project import)
 #   loopback        -> Phase 5  (runbook Step 4: Supabase loopback env wiring)
 #   postapply       -> Phase 6  (post-bring-up deploy kick + smoke)
+#   supabase-hooks  -> Phase 7  (enable custom_access_token hook via Management API)
 #   seed-admin-prod -> one-shot admin promotion from SUPER_USER_EMAILS (re-runnable)
 #
 # supabase.yml is imported twice with different `step` vars so that
@@ -65,6 +66,10 @@
     - name: Phase 6 - Render deploy kick + smoke
       ansible.builtin.import_tasks: setup-prod/postapply.yml
       tags: [postapply]
+
+    - name: Phase 7 - Enable Supabase custom access token hook
+      ansible.builtin.import_tasks: setup-prod/supabase-hook.yml
+      tags: [supabase-hooks]
 
     - name: Seed admin role from SUPER_USER_EMAILS in production DB
       ansible.builtin.import_tasks: setup-prod/seed-admin-prod.yml

--- a/playbooks/setup-prod/supabase-hook.yml
+++ b/playbooks/setup-prod/supabase-hook.yml
@@ -1,0 +1,79 @@
+---
+# Enable the custom_access_token hook on the production Supabase project via
+# the Management API. Invoked automatically as Phase 7 of `make setup-prod`
+# (after postapply confirms the Render service is live and migrations have run),
+# and standalone via `make supabase-hooks`.
+#
+# Reads:  .setup-prod.state.yml (supabase_project_ref)
+#         SUPABASE_ACCESS_TOKEN environment variable
+# Writes: Supabase project auth config (idempotent PATCH)
+#
+# Safe to re-run at any time. The PATCH is idempotent — re-enabling an already-
+# enabled hook is a no-op on the Supabase side.
+#
+# Why this step matters: the frontend reads app_metadata.role from the JWT to
+# gate the Admin nav item. The hook is the only path that injects that claim;
+# without it every user degrades to isAdmin=false regardless of user_roles state.
+
+- name: Stat state file (supabase-hooks)
+  ansible.builtin.stat:
+    path: "{{ state_file }}"
+  register: _hook_state_stat
+
+- name: Load state file (supabase-hooks)
+  ansible.builtin.include_vars:
+    file: "{{ state_file }}"
+  when: _hook_state_stat.stat.exists
+
+- name: Assert supabase_project_ref is present (supabase-hooks)
+  ansible.builtin.assert:
+    that:
+      - _hook_state_stat.stat.exists
+      - supabase_project_ref is defined and (supabase_project_ref | length) > 0
+    fail_msg: |
+      State file is missing or lacks supabase_project_ref.
+      Run the Supabase phase first:
+        ansible-playbook -i playbooks/inventory.local playbooks/setup-prod.yml --tags supabase
+
+- name: Read SUPABASE_ACCESS_TOKEN from environment (supabase-hooks)
+  ansible.builtin.set_fact:
+    _hook_supabase_pat: "{{ lookup('env', 'SUPABASE_ACCESS_TOKEN') }}"
+  no_log: true
+
+- name: Assert SUPABASE_ACCESS_TOKEN is set (supabase-hooks)
+  ansible.builtin.assert:
+    that:
+      - _hook_supabase_pat | length > 0
+    fail_msg: |
+      SUPABASE_ACCESS_TOKEN is not set in the environment.
+      Export it before running:
+        export SUPABASE_ACCESS_TOKEN=<from https://supabase.com/dashboard/account/tokens>
+
+- name: Enable custom_access_token hook via Supabase Management API
+  ansible.builtin.uri:
+    url: "https://api.supabase.com/v1/projects/{{ supabase_project_ref }}/config/auth"
+    method: PATCH
+    headers:
+      Authorization: "Bearer {{ _hook_supabase_pat }}"
+      Content-Type: "application/json"
+    body_format: json
+    body:
+      hook_custom_access_token_enabled: true
+      hook_custom_access_token_uri: "pg-functions://postgres/public/custom_access_token_hook"
+    status_code: [200]
+  register: _hook_patch_result
+  no_log: true
+  changed_when: true
+
+- name: Verify hook is enabled in PATCH response
+  ansible.builtin.assert:
+    that:
+      - _hook_patch_result.json.hook_custom_access_token_enabled == true
+      - _hook_patch_result.json.hook_custom_access_token_uri == "pg-functions://postgres/public/custom_access_token_hook"
+    fail_msg: |
+      Supabase Management API accepted the PATCH but the response does not confirm
+      the hook is enabled. Check Authentication -> Hooks in the Supabase dashboard.
+
+- name: Report hook enabled
+  ansible.builtin.debug:
+    msg: "custom_access_token hook enabled at pg-functions://postgres/public/custom_access_token_hook"

--- a/playbooks/setup.yml
+++ b/playbooks/setup.yml
@@ -570,6 +570,10 @@
           - "ON_ERROR_STOP=1"
           - -c
           - >-
+            INSERT INTO public.users (id)
+            SELECT u.id FROM auth.users u
+            WHERE u.email = '{{ item | replace("'", "''") }}'
+            ON CONFLICT (id) DO NOTHING;
             INSERT INTO public.user_roles (user_id, role_id)
             SELECT u.id, r.id FROM auth.users u, public.roles r
             WHERE u.email = '{{ item | replace("'", "''") }}' AND r.name = 'admin'
@@ -631,6 +635,10 @@
           - "ON_ERROR_STOP=1"
           - -c
           - >-
+            INSERT INTO public.users (id)
+            SELECT u.id FROM auth.users u
+            WHERE u.email = '{{ admin_email | replace("'", "''") }}'
+            ON CONFLICT (id) DO NOTHING;
             INSERT INTO public.user_roles (user_id, role_id)
             SELECT u.id, r.id FROM auth.users u, public.roles r
             WHERE u.email = '{{ admin_email | replace("'", "''") }}' AND r.name = 'admin'


### PR DESCRIPTION
## Summary

Fixes #229 (approach A1): drops `nextCards` from `SwipeResponse`. The frontend's existing `learnNextDueCards` prefetch becomes the single source of queue refills, and the optimistic delete becomes the single queue-advance step. This eliminates the dual-source-of-truth that caused "swipe one card → multiple cards appear consumed" by removing the server's per-mutation freshly-shuffled queue snapshot.

## Background / Motivation

`SwipeUsecase.HandleSwipe` previously returned a freshly-shuffled `nextCards` slice on every swipe. The frontend merged that server snapshot into its local queue, but the server shuffle ran independently of the client-side order — so swiping one card could silently advance the queue by two or more positions, dropping cards the user had not yet seen. The root cause is a mutation-response anti-pattern: a mutation response must not carry a client-managed collection. This is documented in the new `docs/backend/patterns/mutation-response-must-not-carry-client-managed-collection.md`.

## Changes

### Schema — `schema/swipe.graphql` (commit `121ce4c`)

`SwipeResponse` retains only `performanceMode` and `metrics`; the `nextCards` field is removed.

### Backend — `backend/internal/usecase/swipe.go`, `backend/graph/resolver/`, `backend/cmd/server/main.go` (commits `2f31c97`, `e0e858a`, `ca8e8a1`)

- `SwipeUsecase.HandleSwipe` no longer fetches due cards or invokes `OrderingPolicy.Apply`; `SwipeOutput.NextCards` field removed.
- Constructor signature loses `nextBatchSize` and `randSource`; all call-sites (22 sites across `swipe.go`, `main.go`, and test harnesses) migrated.
- `CardRepoForSwipe` interface narrows — `FindRecentByUser`-related methods removed.
- `OrderingPolicy` is preserved; `LearnUsecase` still relies on it.
- `toSwipeResponseModel` unused `ctx` parameter dropped from the resolver mapper.

### Frontend — `frontend/src/app/learn/[cardgroupId]/learn-client.tsx`, `queries.ts` (commits `9843226`, `141f9be`, `04ccdba`)

- `handleSwipe` mutation no longer selects `nextCards`; `setQueue(payload.response.nextCards)` removed.
- `optimisticResponse` dropped — typed-error-capable mutation per the pagination rule (`.claude/rules/pagination.md`).
- `onSwipe` payload chain refactored to guard clauses, removing a nested conditional layer.

### Tests (commits `44aa0bc`, `141f9be`)

- `backend/internal/usecase/swipe_error_test.go`: constructor calls updated; `swipe_performance_test.go` stale `ordering`/`randSource` fixture code removed.
- `backend/graph/resolver/swipe_resolver_test.go`: adds `ListRecentByUser` chain-shape test, cancelled-context test, and a schema regression test asserting the `nextCards` field is rejected by the server.
- `frontend/src/app/learn/[cardgroupId]/learn-client.test.tsx`: adds a queue-order-stability regression test and a static-source guard asserting no `optimisticResponse` key appears in `handleSwipe`.

### Docs (commits `614998e`, `1a313e2`, `27feb20`)

- New: `docs/backend/patterns/mutation-response-must-not-carry-client-managed-collection.md` — the anti-pattern and A1/A2/A3 remediation options.
- New: `docs/backend/library-gotchas/codegen-two-pass-schema-field-drop.md` — two-pass codegen sequence when dropping a schema field.
- New: `docs/backend/library-gotchas/inject-rand-rand-for-deterministic-test.md` — deterministic random injection for usecase tests.
- New: `docs/backend/library-gotchas/static-grep-regression-guard-test.md` — static grep assertions as lightweight regression guards.
- Rule refinements with worked examples in `scope-discipline.md`, `subagent-dispatch.md`, `pagination.md`, `ddd-patterns.md`, and `go-library-gotchas.md`.

## Verification

```bash
cd backend
go build ./...
go vet ./...
go test -race -count=1 ./...
go tool go-arch-lint check --project-path .

cd ../frontend
pnpm typecheck
pnpm lint
pnpm test
```

## Test plan

- [ ] `cd backend && go build ./... && go vet ./...` — clean
- [ ] `cd backend && go test -race -count=1 ./...` — clean; schema regression test confirms `nextCards` is rejected
- [ ] `cd backend && go tool go-arch-lint check --project-path .` — exits 0
- [ ] `pnpm --filter frontend typecheck && pnpm --filter frontend lint && pnpm --filter frontend test` — clean; queue-order-stability test and `optimisticResponse` guard pass
- [ ] Manual: open `/learn` for a cardgroup with ≥ 4 due cards; swipe one card; confirm the next visible card is the one that was previously second in the queue (no reshuffled position).
- [ ] Regression: reproduce the issue #229 scenario; symptom (multiple cards appearing consumed per swipe) should be gone.

Closes #229
