### PR TITLE
test(swipe): replace broken schema-rejection test with schema introspection

### DIFF
--- a/backend/graph/resolver/swipe_resolver_test.go
+++ b/backend/graph/resolver/swipe_resolver_test.go
@@ -3,7 +3,6 @@ package resolver_test
 import (
 	"context"
 	"encoding/json"
-	"strings"
 	"testing"
 
 	"github.com/99designs/gqlgen/graphql/handler"
@@ -279,61 +278,31 @@ func TestResolver_HandleSwipe_InfrastructureError_ReturnsInternal(t *testing.T) 
 	}
 }
 
-// TestResolver_HandleSwipe_SchemaRejectsNextCardsSelection verifies that the
-// schema no longer exposes a nextCards field on SwipeResponse. A mutation that
-// selects nextCards must be rejected at schema-validation time so that any
-// future reintroduction of the field is caught on the wire, not just at
-// gqlgen compile time.
-func TestResolver_HandleSwipe_SchemaRejectsNextCardsSelection(t *testing.T) {
+// TestSwipeResponseSchema_DoesNotExposeNextCards is a regression guard for
+// issue #229. The fix dropped the `nextCards` field from `SwipeResponse`
+// because the field carried a freshly-shuffled queue snapshot that the
+// client also tracked, creating a dual-source-of-truth bug. If a future
+// change re-introduces the field on the SwipeResponse type, this test
+// fails immediately at unit-test time.
+//
+// The test uses gqlgen's parsed schema (not a runtime mutation) because:
+//   - The parsed schema is the canonical wire contract.
+//   - A runtime mutation requires resolver + repository mocks; if the
+//     resolver panics on incomplete mocks, the recovered error masks
+//     the schema-level rejection signal.
+//   - Schema introspection runs in microseconds and is dependency-free.
+func TestSwipeResponseSchema_DoesNotExposeNextCards(t *testing.T) {
 	t.Parallel()
 
-	// Repos are not reached — schema validation fires before any resolver call.
-	srv := newSwipeSrv(
-		&swipeCardRepo{},
-		&swipeCGRepo{},
-		&swipeRecordRepo{},
-		&userCardFSRSRepo{},
-	)
-
-	b, _ := json.Marshal(map[string]any{
-		"query": `mutation($input: HandleSwipeInput!) {
-			handleSwipe(input: $input) {
-				__typename
-				... on HandleSwipeSuccess {
-					response {
-						nextCards { id }
-					}
-				}
-			}
-		}`,
-		"variables": map[string]any{
-			"input": map[string]any{
-				"cardId":      "c-1",
-				"cardgroupId": "cg-1",
-				"mode":        1,
-			},
-		},
-	})
-
-	resp := gqlRequest(t, srv, authedCtx("u-1"), string(b))
-
-	errs, hasErrs := resp["errors"].([]any)
-	if !hasErrs || len(errs) == 0 {
-		t.Fatalf("expected schema validation error for nextCards selection, got resp: %v", resp)
+	schema := generated.NewExecutableSchema(generated.Config{}).Schema()
+	swipeResponse, ok := schema.Types["SwipeResponse"]
+	if !ok {
+		t.Fatal("SwipeResponse type missing from schema")
 	}
-	// The error must reference nextCards or SwipeResponse to confirm the rejection
-	// is for the non-existent field, not an unrelated error.
-	found := false
-	for _, e := range errs {
-		em, _ := e.(map[string]any)
-		msg, _ := em["message"].(string)
-		if strings.Contains(msg, "nextCards") || strings.Contains(msg, "SwipeResponse") {
-			found = true
-			break
+	for _, field := range swipeResponse.Fields {
+		if field.Name == "nextCards" {
+			t.Fatalf("SwipeResponse must not expose `nextCards` field (issue #229 regression); current fields: %v", swipeResponse.Fields)
 		}
-	}
-	if !found {
-		t.Fatalf("expected error mentioning nextCards or SwipeResponse, got errors: %v", errs)
 	}
 }
 


### PR DESCRIPTION
## Summary

Replace the `TestResolver_HandleSwipe_SchemaRejectsNextCardsSelection` test with a schema-introspection guard. The original test (added in PR #231 for issue #229) assumed gqlgen rejects unknown field selections at schema-validation time before resolver invocation; in practice gqlgen runs the resolver, which panics on incomplete mocks, masking the intended rejection signal.

## Background / Motivation

- PR #231 landed a regression guard that fails on `origin/main`: `expected error mentioning nextCards or SwipeResponse, got errors: [map[message:internal system error path:[handleSwipe]]]`.
- Root cause traced via stack: gqlgen invokes the resolver → `authorizeCardgroupOrBadInput` → `swipeCGRepo.FindByID` (zero-value stub returns `(nil, nil)`) → `cg.IsOwnedBy()` nil-deref → recovered to `"internal system error"`.
- The test's intent (catch any future re-introduction of `nextCards` in `SwipeResponse`) is correct; the wire-level execution path was the wrong assertion harness.

## Changes

### Test

- Delete `TestResolver_HandleSwipe_SchemaRejectsNextCardsSelection` and replace with `TestSwipeResponseSchema_DoesNotExposeNextCards` in `backend/graph/resolver/swipe_resolver_test.go`.
- New test introspects the gqlgen-parsed schema (`generated.NewExecutableSchema(generated.Config{}).Schema()`) and asserts `SwipeResponse.Fields` does not contain `nextCards`.
- Runs in microseconds; no resolver, no mocks, no DB.

## Verification

- `go test -count=1 -run TestSwipeResponseSchema_DoesNotExposeNextCards ./graph/resolver/...` — PASS
- `go test -count=1 -race ./graph/resolver/...` — full resolver package PASS (111 tests)
- A regression check (manually re-add `nextCards` to `schema/swipe.graphql` + regen) fails the new test immediately.

## Test plan

- [ ] `cd backend && go vet ./... && go test -race -count=1 ./...`
- [ ] Confirm the failing test on main (`TestResolver_HandleSwipe_SchemaRejectsNextCardsSelection`) is replaced by the new passing test.

Related: #229
