### PR TITLE
fix(ui): add active:bg-accent tap feedback to list items on mobile

### DIFF
--- a/docs/frontend/tailwind-4-notes.md
+++ b/docs/frontend/tailwind-4-notes.md
@@ -7,3 +7,31 @@
 - Tokens map into the Tailwind namespace via an **`@theme inline`** block in `globals.css` (`inline` matters — without it Tailwind emits duplicate variables). `tw-animate-css` is pulled in with `@import "tw-animate-css"` (it is a CSS package, not a JS plugin).
 - When new shadcn components are added, extend the `@theme` block with the additional `--color-*` tokens the components reference.
 
+## `hover:` on touch devices — pair with `active:` for tap feedback
+
+Tailwind v4's `hover:` variant compiles to `@media (hover: hover)` and does not fire reliably on touch devices. A list-item-style element styled with only `hover:bg-accent transition-colors` gives no feedback when a mobile user taps it — the row appears unresponsive even when the navigation works. Pair `hover:` with `active:` so the row flashes on touch:
+
+```tsx
+// Correct — desktop hover and touch tap both highlight.
+<li className="... hover:bg-accent active:bg-accent transition-colors">
+
+// Wrong — silent on mobile.
+<li className="... hover:bg-accent transition-colors">
+```
+
+When the existing string carries both `hover:bg-X` and `hover:text-X`, pair both with their `active:` counterparts. Group the hover-pair before the active-pair, matching the precedent in `frontend/src/components/ui/sidebar.tsx:370`:
+
+```tsx
+// Correct — hover-pair first, active-pair second.
+"hover:bg-accent hover:text-accent-foreground active:bg-accent active:text-accent-foreground"
+
+// Wrong — interleaved.
+"hover:bg-accent active:bg-accent hover:text-accent-foreground active:text-accent-foreground"
+```
+
+Tailwind class order has no cascade effect (the utilities target disjoint property/state pairs), so the rule is purely a readability convention — consistency matters for grep-ability when refactoring class strings across files.
+
+Applies to list rows, picker-sheet items, nav-drawer links, and any other element where `hover:bg-*` is the primary affordance signal. Buttons (`components/ui/button.tsx` variants) and icon-only nav triggers are out of scope — they carry their own pressed-state conventions through the shared `Button` component, and adding `active:` there would force a wide cross-cutting change with no incremental benefit.
+
+A static-grep regression-guard test for the presence of `active:bg-*` is deliberately NOT added — see [`typescript-conventions/static-grep-regression-guard-test.md`](typescript-conventions/static-grep-regression-guard-test.md). A missing tap highlight is a visually obvious regression caught by QA on a touch device; pinning the granular Tailwind variant choice would force test churn on any future design-token rename with no bug-catching value. The guard pattern is reserved for invisible load-bearing attributes like `optimisticResponse` absence.
+

--- a/frontend/src/app/admin/users/admin-users-client.tsx
+++ b/frontend/src/app/admin/users/admin-users-client.tsx
@@ -26,7 +26,7 @@ function UserRow({ edge }: { edge: Edge }) {
   return (
     <li
       key={user.id}
-      className="flex rounded-md border border-border hover:bg-accent transition-colors"
+      className="flex rounded-md border border-border hover:bg-accent active:bg-accent transition-colors"
       data-testid={`admin-user-row-${user.id}`}
     >
       <Link

--- a/frontend/src/app/cardgroups/[id]/cards/components/card-row.tsx
+++ b/frontend/src/app/cardgroups/[id]/cards/components/card-row.tsx
@@ -26,7 +26,7 @@ export function CardRow({
 }: CardRowProps) {
   return (
     <SwipeableRow ref={rowRef} onDelete={onDelete} disabled={disabled} ariaLabel="Delete card">
-      <div className="group flex items-start justify-between gap-4 px-4 py-3 hover:bg-accent transition-colors">
+      <div className="group flex items-start justify-between gap-4 px-4 py-3 hover:bg-accent active:bg-accent transition-colors">
         {/* biome-ignore lint/a11y/noStaticElementInteractions: span is a click/keydown stopper, not an interactive element; the inner <input> is the actual control. */}
         <span
           onClick={(e) => e.stopPropagation()}

--- a/frontend/src/components/admin/role-list-item.tsx
+++ b/frontend/src/components/admin/role-list-item.tsx
@@ -27,7 +27,7 @@ export type RoleListItemProps = {
 export function RoleListItem({ id, name, isSystem, busy, onDelete }: RoleListItemProps) {
   const wrapperClasses = isSystem
     ? "flex items-center gap-2 rounded-lg border border-border pr-2 opacity-60"
-    : "flex items-center gap-2 rounded-lg border border-border pr-2 hover:bg-accent transition-colors";
+    : "flex items-center gap-2 rounded-lg border border-border pr-2 hover:bg-accent active:bg-accent transition-colors";
 
   return (
     <li className={wrapperClasses} data-testid={`admin-role-row-${id}`}>

--- a/frontend/src/components/cardgroups/cardgroup-list-item.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-list-item.tsx
@@ -10,7 +10,7 @@ export type CardgroupListItemProps = {
 
 export function CardgroupListItem({ id, name, updatedAt }: CardgroupListItemProps) {
   return (
-    <li className="flex items-center gap-2 rounded-lg border border-border pr-2 hover:bg-accent transition-colors">
+    <li className="flex items-center gap-2 rounded-lg border border-border pr-2 hover:bg-accent active:bg-accent transition-colors">
       <Link href={`/cardgroups/${id}/edit`} className="flex min-w-0 flex-1 flex-col gap-1 p-4">
         <span className="truncate font-medium text-foreground">{name}</span>
         <span className="text-sm text-muted-foreground">Updated {formatMediumDate(updatedAt)}</span>

--- a/frontend/src/components/cardgroups/cardgroup-picker-sheet.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-picker-sheet.tsx
@@ -116,7 +116,7 @@ export default function CardgroupPickerSheet({
                         onClick={() => handleSelect(cg.id)}
                         className={cn(
                           "flex w-full items-center justify-between rounded-md px-3 py-3 text-left text-sm",
-                          "transition-colors hover:bg-accent active:bg-accent hover:text-accent-foreground active:text-accent-foreground",
+                          "transition-colors hover:bg-accent hover:text-accent-foreground active:bg-accent active:text-accent-foreground",
                           "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
                           isSelected && "font-medium",
                         )}

--- a/frontend/src/components/cardgroups/cardgroup-picker-sheet.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-picker-sheet.tsx
@@ -116,7 +116,7 @@ export default function CardgroupPickerSheet({
                         onClick={() => handleSelect(cg.id)}
                         className={cn(
                           "flex w-full items-center justify-between rounded-md px-3 py-3 text-left text-sm",
-                          "transition-colors hover:bg-accent hover:text-accent-foreground",
+                          "transition-colors hover:bg-accent active:bg-accent hover:text-accent-foreground active:text-accent-foreground",
                           "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
                           isSelected && "font-medium",
                         )}
@@ -142,7 +142,7 @@ export default function CardgroupPickerSheet({
               <Link
                 href={`/cardgroups/new?returnTo=${encodeURIComponent(createReturnTo)}`}
                 onClick={() => onOpenChange(false)}
-                className="flex w-full items-center gap-2 rounded-md px-3 py-3 text-sm text-brand-primary hover:bg-accent transition-colors"
+                className="flex w-full items-center gap-2 rounded-md px-3 py-3 text-sm text-brand-primary hover:bg-accent active:bg-accent transition-colors"
               >
                 <Plus className="h-4 w-4" aria-hidden="true" />
                 Create new cardgroup…

--- a/frontend/src/components/nav/logo-drawer.tsx
+++ b/frontend/src/components/nav/logo-drawer.tsx
@@ -18,7 +18,7 @@ interface LogoDrawerProps {
 }
 
 const NAV_LINK_CLASS =
-  "flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium hover:bg-accent hover:text-accent-foreground";
+  "flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium hover:bg-accent active:bg-accent hover:text-accent-foreground active:text-accent-foreground";
 
 export function LogoDrawer({ user, isAdmin }: LogoDrawerProps) {
   const pathname = usePathname();

--- a/frontend/src/components/nav/logo-drawer.tsx
+++ b/frontend/src/components/nav/logo-drawer.tsx
@@ -18,7 +18,7 @@ interface LogoDrawerProps {
 }
 
 const NAV_LINK_CLASS =
-  "flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium hover:bg-accent active:bg-accent hover:text-accent-foreground active:text-accent-foreground";
+  "flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium hover:bg-accent hover:text-accent-foreground active:bg-accent active:text-accent-foreground";
 
 export function LogoDrawer({ user, isAdmin }: LogoDrawerProps) {
   const pathname = usePathname();


### PR DESCRIPTION
## Summary

Pair Tailwind's `active:bg-accent` with the existing `hover:bg-accent` on every list-item-style tap target in Card Groups, Users, Roles, the mobile cardgroup picker, the Card row, and the mobile nav drawer. Mobile users tapping these rows previously got no visual feedback because Tailwind v4's `hover:` variant compiles to `@media (hover: hover)` and does not fire on touch. No related issue exists; the regression was surfaced by manual touch QA on the listing pages.

## Background / Motivation

- Tailwind v4 gates the `hover:` variant behind `@media (hover: hover)`, so a list row styled with only `hover:bg-accent transition-colors` renders no background change on a touch device. The row appeared unresponsive even when navigation worked.
- The repo already had a precedent for the fix at `frontend/src/components/ui/sidebar.tsx:370`, which pairs `hover:bg-sidebar-accent hover:text-sidebar-accent-foreground` with `active:bg-sidebar-accent active:text-sidebar-accent-foreground`. The user-facing list components had not adopted the idiom.
- Class-string ordering was inconsistent on two newly-touched sites — `hover:bg active:bg hover:text active:text` interleaving instead of the sidebar's `hover-pair → active-pair` grouping. A separate `style(ui)` commit unifies the order so a grep across the codebase returns predictable string boundaries.

## Changes

### List items — `frontend/src/components/cardgroups/`, `frontend/src/components/admin/`, `frontend/src/app/admin/users/`, `frontend/src/app/cardgroups/[id]/cards/components/` (commit `b48f736`)

- `cardgroup-list-item.tsx:13` — Card Groups row gains `active:bg-accent`.
- `role-list-item.tsx:30` — Roles editable branch gains `active:bg-accent`. The `isSystem` branch (line 29) stays untouched because system rows are non-interactive and visually telegraphed via `opacity-60`.
- `admin-users-client.tsx:29` — Users row (`UserRow` component) gains `active:bg-accent`.
- `cardgroup-picker-sheet.tsx:119, 145` — Mobile picker selection button gains `active:bg-accent active:text-accent-foreground`; the "Create new cardgroup" link gains `active:bg-accent`.
- `card-row.tsx:29` — Card row in the cardgroup edit view gains `active:bg-accent`.

### Mobile nav drawer — `frontend/src/components/nav/logo-drawer.tsx` (commit `27a13d7`)

- `NAV_LINK_CLASS` constant gains `active:bg-accent active:text-accent-foreground` so the Cardgroups / Profile / admin links in the mobile drawer flash on touch. The icon-only logo (line 36) and Plus (line 45) buttons in the same file are out of scope — they carry their own pressed-state conventions through the shared `Button` component, and pulling them in would force a wide cross-cutting change with no incremental benefit.

### Class-string ordering — `cardgroup-picker-sheet.tsx`, `logo-drawer.tsx` (commit `93e1b88`)

- Two sites that initially landed with interleaved `hover:bg active:bg hover:text active:text` reordered to `hover:bg hover:text active:bg active:text`, matching `sidebar.tsx:370`. Tailwind class order has no cascade effect (the utilities target disjoint property/state pairs); this is purely a grep-friendliness convention.

### Docs — `docs/frontend/tailwind-4-notes.md` (commit `bf86a62`)

- New section documents the `@media (hover: hover)` gotcha, the `hover:` + `active:` pairing rule, the hover-pair-before-active-pair grouping convention, and the rationale for NOT adding a static-grep regression-guard test (a missing tap highlight is visually obvious; the guard is reserved for invisible load-bearing attributes per `docs/frontend/typescript-conventions/static-grep-regression-guard-test.md`).

## Verification

```bash
# Every touched site has the new active:bg-accent variant
grep -rn 'active:bg-accent' \
  frontend/src/components/cardgroups/cardgroup-list-item.tsx \
  frontend/src/components/admin/role-list-item.tsx \
  frontend/src/app/admin/users/admin-users-client.tsx \
  frontend/src/components/cardgroups/cardgroup-picker-sheet.tsx \
  "frontend/src/app/cardgroups/[id]/cards/components/card-row.tsx" \
  frontend/src/components/nav/logo-drawer.tsx
# Expect: 7 matches across 6 files

# Class-ordering convention: hover-pair appears before active-pair in every reordered string
grep -n 'hover:bg-accent hover:text-accent-foreground active:bg-accent active:text-accent-foreground' \
  frontend/src/components/cardgroups/cardgroup-picker-sheet.tsx \
  frontend/src/components/nav/logo-drawer.tsx
# Expect: 2 matches (one per file)

# Role-list-item isSystem branch was deliberately not touched
grep -n 'opacity-60' frontend/src/components/admin/role-list-item.tsx
# Expect: 1 match, no active:bg-accent on the same wrapper string
```

## Test plan

- [x] `pnpm --filter frontend lint` — clean (Biome, 252 files)
- [x] `pnpm --filter frontend typecheck` — clean (`tsc --noEmit`)
- [x] `pnpm --filter frontend test` — 845 / 845 pass (90 files, ~5.9 s)
- [ ] CI green on this branch
- [ ] Manual QA on a touch device (iOS Safari + Android Chrome): tap a row in each list type — Card Groups index, Users index (`/admin/users`), Roles index (`/admin/roles`), the mobile cardgroup picker sheet, the Card row in a cardgroup edit page, and the mobile nav drawer links — and confirm the row flashes the accent background on touch-down. The DOM class to look for in DevTools is `active:bg-accent`; the visible change is the `--color-accent` token painting the row background while the finger is down.
