### PR TITLE
feat(frontend): redesign login with framed form card and brand lockup

### DIFF
--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -33,49 +33,63 @@ export default async function LoginPage({ searchParams }: { searchParams: Search
           <span className="text-base font-medium">flamingo-armond</span>
         </div>
 
-        <div className="flex flex-1 items-center justify-center p-8">
-          <div className="w-full max-w-sm flex flex-col gap-6">
-            <div className="flex flex-col gap-2 text-start">
-              <h1 className="text-2xl font-semibold tracking-tight">Sign in</h1>
-              <p className="text-sm text-muted-foreground">
-                Sign in with your Google account to continue. New here? An account is created on
-                first sign-in.
-              </p>
+        <div className="flex flex-1 items-center justify-center p-6 sm:p-8">
+          <div className="w-full max-w-sm">
+            <div className="flex flex-col gap-6 rounded-2xl border bg-card p-8 shadow-[0_8px_40px_-12px_rgba(0,0,0,0.18)]">
+              <div className="flex flex-col gap-2 text-start">
+                <h1 className="text-2xl font-semibold tracking-tight">Sign in</h1>
+                <p className="text-sm text-muted-foreground">
+                  Sign in with your Google account to continue. New here? An account is created on
+                  first sign-in.
+                </p>
+              </div>
+
+              {error && (
+                <p role="alert" className="text-sm text-destructive">
+                  Sign-in failed: {error}
+                </p>
+              )}
+
+              <LoginButton />
+
+              <footer className="border-t pt-5 text-xs text-muted-foreground text-center">
+                By signing in, you agree to our{" "}
+                <a href="/terms" className="underline underline-offset-2 hover:text-foreground">
+                  Terms of Service
+                </a>{" "}
+                and{" "}
+                <a href="/privacy" className="underline underline-offset-2 hover:text-foreground">
+                  Privacy Policy
+                </a>
+                .
+              </footer>
             </div>
-
-            {error && (
-              <p role="alert" className="text-sm text-destructive">
-                Sign-in failed: {error}
-              </p>
-            )}
-
-            <LoginButton />
-
-            <footer className="text-xs text-muted-foreground text-center">
-              By signing in, you agree to our{" "}
-              <a href="/terms" className="underline underline-offset-2 hover:text-foreground">
-                Terms of Service
-              </a>{" "}
-              and{" "}
-              <a href="/privacy" className="underline underline-offset-2 hover:text-foreground">
-                Privacy Policy
-              </a>
-              .
-            </footer>
           </div>
         </div>
       </div>
 
       <div
         data-testid="brand-panel"
-        className="max-lg:hidden relative flex flex-col items-center justify-center gap-4 overflow-hidden bg-gradient-to-br from-brand-tint via-brand-tint to-brand-tint/70"
+        className="max-lg:hidden relative flex items-center justify-center overflow-hidden bg-gradient-to-br from-[oklch(83%_0.11_22)] via-[oklch(72%_0.185_18.45)] to-[oklch(60%_0.2_13)]"
       >
-        <FlamingoMark className="size-28 drop-shadow-sm" />
-        <div className="flex flex-col items-center gap-1 text-center">
-          <span className="text-3xl font-semibold tracking-tight text-brand-tint-foreground">
-            flamingo-armond
-          </span>
-          <span className="text-sm text-brand-tint-foreground/80">Remember more, study less.</span>
+        {/* Soft radial glows give the flat coral gradient depth and atmosphere. */}
+        <div className="pointer-events-none absolute -top-24 -left-16 size-96 rounded-full bg-white/20 blur-3xl" />
+        <div className="pointer-events-none absolute -right-12 -bottom-32 size-[30rem] rounded-full bg-[rgba(150,25,60,0.45)] blur-3xl" />
+
+        {/* Horizontal brand lockup: white-framed logo beside the wordmark. The
+            mark is itself coral, so a white badge lifts it off the pink ground. */}
+        <div className="relative flex items-center gap-5">
+          <div className="rounded-[1.3rem] bg-white p-2.5 shadow-xl shadow-rose-950/20">
+            <FlamingoMark className="size-16" />
+          </div>
+          <div className="flex flex-col gap-1.5">
+            <span className="text-4xl font-semibold tracking-tight text-white drop-shadow-[0_2px_10px_rgba(120,20,40,0.45)]">
+              flamingo-armond
+            </span>
+            <span className="text-sm font-medium text-white/90 drop-shadow-[0_1px_6px_rgba(120,20,40,0.35)]">
+              Remember more, study less.
+            </span>
+          </div>
         </div>
       </div>
     </main>


### PR DESCRIPTION
## Summary

Restyles the `/login` split-screen so the sign-in form reads as an elevated card and the brand panel becomes a horizontal logo + wordmark lockup over a flamingo-pink gradient. The change is presentation-only — the auth flow, redirect logic, and the `data-testid` / viewport-visibility contract the page tests pin are untouched.

## Background / Motivation

- The sign-in form floated as bare centered text with no container, so it read as loose copy rather than a deliberate panel against the empty left column.
- The brand panel stacked a large logo above the wordmark and sat on a near-white `brand-tint` gradient, so the "flamingo" identity barely registered — the panel looked washed out next to the coral app icon.
- The coral `FlamingoMark` placed directly on any pink ground would blend into the background and lose its edges.

## Changes

### Sign-in form card

- Wrap the form column content in `rounded-2xl border bg-card` with a soft custom drop shadow (`shadow-[0_8px_40px_-12px_rgba(0,0,0,0.18)]`) so it presents as a raised card.
- Give the Terms/Privacy footer a `border-t pt-5` separator to echo the sectioned card layout.

### Brand panel lockup

- Recompose the panel from a vertical stack into a horizontal `flex items-center gap-5` lockup: white-framed logo beside a wordmark + tagline block.
- Frame the coral mark in a white badge (`rounded-[1.3rem] bg-white p-2.5 shadow-xl shadow-rose-950/20`) so it lifts off the pink ground; the wordmark switches to white text with a rose-toned `drop-shadow` for legibility.

### Flamingo-pink gradient background

- Replace the `from-brand-tint via-brand-tint to-brand-tint/70` near-white gradient with a saturated diagonal `from-[oklch(83%_0.11_22)] via-[oklch(72%_0.185_18.45)] to-[oklch(60%_0.2_13)]`.
- Add two blurred radial-glow layers (`pointer-events-none` highlights, top-left white + bottom-right deep rose) for depth.

## Verification

```bash
# Form card wrapper and footer separator present
grep -n 'rounded-2xl border bg-card' frontend/src/app/login/page.tsx
grep -n 'border-t pt-5' frontend/src/app/login/page.tsx

# Brand panel: flamingo-pink gradient + white logo badge
grep -n 'from-\[oklch' frontend/src/app/login/page.tsx
grep -n 'rounded-\[1.3rem\] bg-white' frontend/src/app/login/page.tsx

# Visibility contract preserved (brand panel lg-only, mobile header sub-lg)
grep -n 'max-lg:hidden' frontend/src/app/login/page.tsx
```

Manual QA:

- `/login` at `lg`+ width → two columns: card-wrapped form on the left, pink-gradient brand lockup (logo beside `flamingo-armond`) on the right.
- `/login` below `lg` → pink panel hidden, top brand header + card-wrapped form only.

## Test plan

- [x] `pnpm --filter frontend typecheck`
- [x] `pnpm --filter frontend exec biome check` on the login page
- [x] `pnpm --filter frontend exec vitest run src/app/login/page.test.tsx` — 19 passed (testid + visibility contract intact)
- [x] Real-browser screenshot at desktop (1280×800) and mobile (390×844) viewports
