### PR TITLE
feat(nav): in-place create/add drawers + FAB suppression

### DIFF
--- a/frontend/e2e/cardgroups-flow.spec.ts
+++ b/frontend/e2e/cardgroups-flow.spec.ts
@@ -48,11 +48,12 @@ test.describe
     });
 
     // ── Scenario 1 ──────────────────────────────────────────────────────────────
-    // Primary action on /cardgroups: with at least one cardgroup the "+ New
-    // cardgroup" link is visible in the page-shell header (primaryActions).
-    // Clicking it lands on /cardgroups/new with no returnTo, and the form is
-    // interactive.
-    test("primary action on /cardgroups leads to /cardgroups/new without returnTo", async ({
+    // Primary action on /cardgroups: with at least one cardgroup the "New
+    // cardgroup" button is visible in the page-shell header (primaryActions).
+    // Clicking it opens the create-cardgroup drawer (FormSheet) in place — no
+    // navigation. The full-page /cardgroups/new route is reserved for the
+    // onboarding (welcome) and picker returnTo flows (Scenario 3).
+    test("primary action on /cardgroups opens the create-cardgroup drawer in place", async ({
       context,
       page,
     }) => {
@@ -64,23 +65,26 @@ test.describe
       // The seeded cardgroup must be visible, confirming the non-empty branch renders.
       await expect(page.getByText(seededCardgroupName)).toBeVisible();
 
-      // The primary "+ New cardgroup" action in the page-shell header.
-      // After the listing-page-shell refactor it lives in primaryActions, not the footer.
-      const newCardgroupLink = page.getByRole("link", { name: /New cardgroup/ });
-      await expect(newCardgroupLink).toBeVisible();
-      await expect(newCardgroupLink).toHaveAttribute("href", "/cardgroups/new");
+      // The primary "New cardgroup" action is a button (not a link) — it opens
+      // the drawer in place rather than navigating. The desktop button carries
+      // `hidden md:inline-flex`; Playwright's Desktop Chrome viewport (1280px) is
+      // above the md breakpoint so the button is visible.
+      const newCardgroupButton = page.getByRole("button", { name: /New cardgroup/ });
+      await expect(newCardgroupButton).toBeVisible();
 
-      // Click it and verify we land on /cardgroups/new with the form interactive.
-      await newCardgroupLink.click();
-      await page.waitForURL("**/cardgroups/new", { timeout: 10_000 });
+      // Click it and verify the FormSheet opens in place with the form interactive.
+      await newCardgroupButton.click();
       await expect(page.getByRole("heading", { name: "New cardgroup" })).toBeVisible();
       await expect(page.getByLabel("Name")).toBeVisible();
       await expect(page.getByRole("button", { name: "Create" })).toBeVisible();
+
+      // The URL must NOT have navigated — the in-place drawer is the entire point.
+      expect(new URL(page.url()).pathname).toBe("/cardgroups");
     });
 
     // ── Scenario 2 ──────────────────────────────────────────────────────────────
     // Empty-state on /cardgroups: with zero cardgroups the "No cardgroups yet"
-    // copy is shown. The primary action link in the page-shell header is the
+    // copy is shown. The primary action button in the page-shell header is the
     // only "New cardgroup" affordance (the dashed empty-state CTA was removed).
     test("empty state on /cardgroups shows the empty-state copy and primary action", async ({
       context,
@@ -95,12 +99,14 @@ test.describe
       // After the listing-page-shell refactor the copy is "No cardgroups yet".
       await expect(page.getByText("No cardgroups yet")).toBeVisible();
 
-      // The primary action link is rendered in the page-shell header even in the empty state.
-      const newCardgroupLink = page.getByRole("link", { name: /New cardgroup/ });
-      await expect(newCardgroupLink).toBeVisible();
+      // The primary action button is rendered in the page-shell header even in
+      // the empty state. The mobile FAB carries a lowercase "Add new cardgroup"
+      // label, so the capital-N regex matches only this button.
+      const newCardgroupButton = page.getByRole("button", { name: /New cardgroup/ });
+      await expect(newCardgroupButton).toBeVisible();
 
-      // There is exactly one "New cardgroup" link (the dashed empty-state CTA was removed).
-      await expect(newCardgroupLink).toHaveCount(1);
+      // There is exactly one "New cardgroup" button (the dashed empty-state CTA was removed).
+      await expect(newCardgroupButton).toHaveCount(1);
     });
 
     // ── Scenario 3 ──────────────────────────────────────────────────────────────

--- a/frontend/src/app/admin/dictionary/dictionary-client.tsx
+++ b/frontend/src/app/admin/dictionary/dictionary-client.tsx
@@ -2,7 +2,6 @@
 
 import { CombinedGraphQLErrors } from "@apollo/client/errors";
 import { useLazyQuery, useMutation, useQuery } from "@apollo/client/react";
-import Link from "next/link";
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { getBackendErrorBanner } from "@/lib/apollo/errors";
@@ -136,11 +135,6 @@ export function DictionaryImportClient() {
 
   return (
     <main className="p-8">
-      <div className="mb-4">
-        <Link href="/cardgroups" className="text-sm text-muted-foreground hover:underline">
-          &larr; Back
-        </Link>
-      </div>
       <h1 className="mb-6 text-2xl font-semibold">Dictionary Import</h1>
 
       {cardgroupsErrorBanner && (

--- a/frontend/src/app/cardgroups/cardgroups-client.test.tsx
+++ b/frontend/src/app/cardgroups/cardgroups-client.test.tsx
@@ -200,9 +200,65 @@ describe("<CardgroupsClient>", () => {
 
     renderClient([initialMock], null, cache);
 
-    const link = await screen.findByRole("link", { name: /new cardgroup/i });
-    expect(link.className).toContain("hidden");
-    expect(link.className).toContain("md:inline-flex");
+    const button = await screen.findByRole("button", { name: /new cardgroup/i });
+    expect(button.className).toContain("hidden");
+    expect(button.className).toContain("md:inline-flex");
+  });
+
+  // The desktop "New cardgroup" button and the mobile FAB (via the
+  // flamingo:add-cardgroup event) both open the in-list create drawer instead
+  // of navigating to /cardgroups/new.
+  it("opens the create-cardgroup drawer when the desktop 'New cardgroup' button is clicked", async () => {
+    const user = userEvent.setup();
+    const cache = new InMemoryCache();
+    const emptyConn = makeConnection([]);
+    cache.writeQuery({
+      query: MyCardgroupsConnectionDocument,
+      variables: { first: CARDGROUPS_PAGE_SIZE, search: null },
+      data: { myCardgroupsConnection: emptyConn },
+    });
+    const initialMock = {
+      request: {
+        query: MyCardgroupsConnectionDocument,
+        variables: { first: CARDGROUPS_PAGE_SIZE, search: null },
+      },
+      result: { data: { myCardgroupsConnection: emptyConn } },
+    };
+
+    renderClient([initialMock], null, cache);
+
+    await user.click(await screen.findByRole("button", { name: /new cardgroup/i }));
+
+    expect(await screen.findByRole("textbox", { name: /name/i })).toBeInTheDocument();
+  });
+
+  it("opens the create-cardgroup drawer on the flamingo:add-cardgroup event (mobile FAB)", async () => {
+    const cache = new InMemoryCache();
+    const emptyConn = makeConnection([]);
+    cache.writeQuery({
+      query: MyCardgroupsConnectionDocument,
+      variables: { first: CARDGROUPS_PAGE_SIZE, search: null },
+      data: { myCardgroupsConnection: emptyConn },
+    });
+    const initialMock = {
+      request: {
+        query: MyCardgroupsConnectionDocument,
+        variables: { first: CARDGROUPS_PAGE_SIZE, search: null },
+      },
+      result: { data: { myCardgroupsConnection: emptyConn } },
+    };
+
+    renderClient([initialMock], null, cache);
+    // Let the initial query settle before dispatching the open event.
+    await screen.findByRole("button", { name: /new cardgroup/i });
+
+    const event = new CustomEvent("flamingo:add-cardgroup", { cancelable: true });
+    act(() => {
+      window.dispatchEvent(event);
+    });
+    // The listener cancels the FAB's fallback navigation.
+    expect(event.defaultPrevented).toBe(true);
+    expect(await screen.findByRole("textbox", { name: /name/i })).toBeInTheDocument();
   });
 
   // S1: empty state — no cardgroups, no active search

--- a/frontend/src/app/cardgroups/cardgroups-client.tsx
+++ b/frontend/src/app/cardgroups/cardgroups-client.tsx
@@ -5,10 +5,12 @@ import { useApolloClient, useMutation, useQuery } from "@apollo/client/react";
 import { Plus } from "lucide-react";
 import Link from "next/link";
 import { useCallback, useEffect, useEffectEvent, useRef, useState } from "react";
+import { CardgroupForm } from "@/components/cardgroups/cardgroup-form";
 import { CardgroupListItem } from "@/components/cardgroups/cardgroup-list-item";
 import { CardgroupsToolbar } from "@/components/cardgroups/cardgroups-toolbar";
 import { ListingPageShell } from "@/components/layout/listing-page-shell";
 import { Button } from "@/components/ui/button";
+import { FormSheet, useFormSheetClose } from "@/components/ui/form-sheet";
 import {
   MyCardgroupsConnectionDocument,
   type MyCardgroupsConnectionQuery,
@@ -17,11 +19,75 @@ import { getBackendErrorBanner } from "@/lib/apollo/errors";
 import type { FetchNextPageInput } from "@/lib/pagination/types";
 import { useUndoDelete } from "@/lib/undo-delete";
 import { CARDGROUPS_DEFAULT_VARS, DeleteCardgroupMutation } from "./queries";
+import { useCreateCardgroup } from "./use-create-cardgroup";
 
 type Connection = MyCardgroupsConnectionQuery["myCardgroupsConnection"];
 
 interface CardgroupsClientProps {
   initialConnection: Connection | null;
+}
+
+function CreateCardgroupSheetContent({
+  submit,
+  submitting,
+  validationError,
+  authError,
+  unexpectedError,
+  onDirty,
+}: {
+  submit: (values: { name: string }) => Promise<void>;
+  submitting: boolean;
+  validationError: { field: string; message: string } | null;
+  authError: "unauthenticated" | "forbidden" | null;
+  unexpectedError: string | null;
+  onDirty: () => void;
+}) {
+  const close = useFormSheetClose();
+
+  return (
+    <div onInput={onDirty} className="space-y-4">
+      {authError ? (
+        <div
+          role="alert"
+          data-testid="cardgroup-create-auth-error"
+          className="rounded-md bg-destructive/10 p-3 text-sm text-destructive"
+        >
+          <span>
+            {authError === "unauthenticated"
+              ? "Your session has expired. "
+              : "You do not have permission. "}
+          </span>
+          <Link href="/login" className="underline">
+            Sign in again
+          </Link>
+          .
+        </div>
+      ) : null}
+
+      {unexpectedError ? (
+        <div
+          role="alert"
+          data-testid="cardgroup-create-unexpected-error"
+          className="rounded-md bg-destructive/10 p-3 text-sm text-destructive"
+        >
+          {unexpectedError}
+        </div>
+      ) : null}
+
+      <CardgroupForm
+        mode="create"
+        defaultValues={{ name: "" }}
+        submit={submit}
+        submitting={submitting}
+        validationError={validationError}
+        secondarySlot={
+          <Button type="button" variant="outline" onClick={close}>
+            Cancel
+          </Button>
+        }
+      />
+    </div>
+  );
 }
 
 /**
@@ -47,6 +113,68 @@ export default function CardgroupsClient({ initialConnection }: CardgroupsClient
 
   const { scheduleDelete } = useUndoDelete();
   const [deleteCardgroup] = useMutation(DeleteCardgroupMutation);
+
+  // Create-cardgroup drawer (FormSheet → bottom drawer on mobile, right panel
+  // on desktop). Opened by the mobile FAB via the flamingo:add-cardgroup event
+  // and by the desktop "New cardgroup" button. The full-page /cardgroups/new
+  // route stays for the onboarding (welcome) and returnTo flows.
+  const { create: createCardgroup, loading: creating } = useCreateCardgroup();
+  const [addOpen, setAddOpen] = useState(false);
+  const [addDirty, setAddDirty] = useState(false);
+  const [addValidationError, setAddValidationError] = useState<{
+    field: string;
+    message: string;
+  } | null>(null);
+  const [addAuthError, setAddAuthError] = useState<"unauthenticated" | "forbidden" | null>(null);
+  const [addUnexpectedError, setAddUnexpectedError] = useState<string | null>(null);
+
+  const openAddSheet = useCallback(() => {
+    setAddValidationError(null);
+    setAddAuthError(null);
+    setAddUnexpectedError(null);
+    setAddDirty(false);
+    setAddOpen(true);
+  }, []);
+
+  useEffect(() => {
+    function handleAddCardgroupEvent(event: Event) {
+      // Cancel the FAB's fallback navigation to /cardgroups/new and open the
+      // drawer in place instead.
+      event.preventDefault();
+      openAddSheet();
+    }
+    window.addEventListener("flamingo:add-cardgroup", handleAddCardgroupEvent);
+    return () => window.removeEventListener("flamingo:add-cardgroup", handleAddCardgroupEvent);
+  }, [openAddSheet]);
+
+  async function handleCreateCardgroup(values: { name: string }) {
+    setAddValidationError(null);
+    setAddAuthError(null);
+    setAddUnexpectedError(null);
+
+    const outcome = await createCardgroup(values.name);
+
+    switch (outcome.status) {
+      case "validation":
+        setAddValidationError({ field: outcome.field, message: outcome.message });
+        return;
+      case "auth":
+        setAddAuthError(outcome.kind);
+        return;
+      case "unexpected":
+      case "rejected":
+        // The drawer is modal, so surface a banner for both an unparseable
+        // payload and a transport failure rather than failing silently.
+        setAddUnexpectedError("Something went wrong. Please try again.");
+        return;
+      case "success":
+        // The connection cache is updated inside useCreateCardgroup, so the new
+        // row appears in the list without a refetch. Just close the drawer.
+        setAddDirty(false);
+        setAddOpen(false);
+        return;
+    }
+  }
 
   const sentinelRef = useRef<HTMLDivElement | null>(null);
   // In-flight guard MUST be useRef<boolean>, not useState — see
@@ -239,11 +367,14 @@ export default function CardgroupsClient({ initialConnection }: CardgroupsClient
       title="My cardgroups"
       description="Browse and manage the cardgroups you have created."
       primaryActions={
-        <Button asChild variant="brand" className="hidden md:inline-flex">
-          <Link href="/cardgroups/new">
-            <span>New cardgroup</span>
-            <Plus aria-hidden="true" />
-          </Link>
+        <Button
+          type="button"
+          variant="brand"
+          className="hidden md:inline-flex"
+          onClick={openAddSheet}
+        >
+          <span>New cardgroup</span>
+          <Plus aria-hidden="true" />
         </Button>
       }
       toolbar={<CardgroupsToolbar searchInput={searchInput} onSearchInputChange={setSearchInput} />}
@@ -321,6 +452,33 @@ export default function CardgroupsClient({ initialConnection }: CardgroupsClient
           Loading more cardgroups...
         </p>
       )}
+
+      <FormSheet
+        title="New cardgroup"
+        open={addOpen}
+        onOpenChange={(nextOpen) => {
+          setAddOpen(nextOpen);
+          if (!nextOpen) {
+            setAddDirty(false);
+            setAddValidationError(null);
+            setAddAuthError(null);
+            setAddUnexpectedError(null);
+          }
+        }}
+        submitting={creating}
+        dirty={addDirty}
+        confirmOnDismiss
+        size="sm"
+      >
+        <CreateCardgroupSheetContent
+          submit={handleCreateCardgroup}
+          submitting={creating}
+          validationError={addValidationError}
+          authError={addAuthError}
+          unexpectedError={addUnexpectedError}
+          onDirty={() => setAddDirty(true)}
+        />
+      </FormSheet>
     </ListingPageShell>
   );
 }

--- a/frontend/src/app/cardgroups/new/new-cardgroup-client.tsx
+++ b/frontend/src/app/cardgroups/new/new-cardgroup-client.tsx
@@ -1,14 +1,11 @@
 "use client";
 
-import { useMutation } from "@apollo/client/react";
 import { Sparkles } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
-import { CARDGROUPS_DEFAULT_VARS, CreateCardgroupMutation } from "@/app/cardgroups/queries";
+import { useCreateCardgroup } from "@/app/cardgroups/use-create-cardgroup";
 import { CardgroupForm } from "@/components/cardgroups/cardgroup-form";
-import { MyCardgroupsConnectionDocument } from "@/generated/graphql";
-import { liftGraphQLCodes } from "@/lib/apollo/graphql-errors";
 
 interface NewCardgroupClientProps {
   showWelcome?: boolean;
@@ -39,118 +36,39 @@ export function NewCardgroupClient({ showWelcome = false, returnTo }: NewCardgro
   // <Link href="/login">, not redirect()".
   const [authError, setAuthError] = useState<"unauthenticated" | "forbidden" | null>(null);
 
-  // No optimisticResponse: typed errors (FORBIDDEN, InputValidationError for
-  // duplicate name) can fail the mutation, and Apollo does not consistently
-  // roll back optimistic writes for typed GraphQL errors. The user pays one
-  // round-trip of latency in exchange for a truthful cache.
-  const [createCardgroup, { loading }] = useMutation(CreateCardgroupMutation, {
-    update(cache, { data }) {
-      // Narrow on __typename before accessing .cardgroup so an InputValidationError
-      // or unknown variant does not silently mutate the cache.
-      if (data?.createCardgroup?.__typename !== "CreateCardgroupSuccess") return;
-      const created = data.createCardgroup.cardgroup;
-
-      // Update the Connection cache so the /cardgroups listing page
-      // shows the new entry without a refetch when the user returns there.
-      // cache.modify is forbidden — use readQuery + writeQuery so cold-cache
-      // entries are also handled correctly. See .claude/rules/pagination.md
-      // § "cache.modify skips non-existent fields".
-      // CARDGROUPS_DEFAULT_VARS keeps the cache key in sync with the SSR seed
-      // and the client useQuery — any mismatch makes this write invisible.
-      const existingConnection = cache.readQuery({
-        query: MyCardgroupsConnectionDocument,
-        variables: CARDGROUPS_DEFAULT_VARS,
-      });
-      const newEdge = {
-        __typename: "CardgroupEdge" as const,
-        cursor: created.id,
-        node: created,
-      };
-      const nextConnection = existingConnection
-        ? {
-            ...existingConnection.myCardgroupsConnection,
-            edges: [newEdge, ...existingConnection.myCardgroupsConnection.edges],
-            totalCount: existingConnection.myCardgroupsConnection.totalCount + 1,
-          }
-        : {
-            // Cold cache: build a minimal connection so the listing page can render
-            // the new edge immediately when the user lands there.
-            __typename: "CardgroupConnection" as const,
-            edges: [newEdge],
-            pageInfo: {
-              __typename: "PageInfo" as const,
-              hasNextPage: false,
-              hasPreviousPage: false,
-              startCursor: created.id,
-              endCursor: created.id,
-            },
-            totalCount: 1,
-          };
-      cache.writeQuery({
-        query: MyCardgroupsConnectionDocument,
-        variables: CARDGROUPS_DEFAULT_VARS,
-        data: { myCardgroupsConnection: nextConnection },
-      });
-    },
-  });
+  const { create, loading } = useCreateCardgroup();
 
   async function handleSubmit(values: { name: string }) {
     setValidationError(null);
     setUnexpectedPayloadError(null);
     setAuthError(null);
 
-    const result = await createCardgroup({
-      variables: { input: { name: values.name } },
-    }).catch((err) => {
-      const codes = liftGraphQLCodes(err);
-      if (codes.includes("UNAUTHENTICATED")) {
-        setAuthError("unauthenticated");
-        return null;
-      }
-      if (codes.includes("FORBIDDEN")) {
-        setAuthError("forbidden");
-        return null;
-      }
-      // err.message is omitted — backend messages may echo user input.
-      // codes is safe to log (fixed enum of GraphQL extension codes).
-      console.warn("[cardgroups-new] createCardgroup rejected", {
-        name: err instanceof Error ? err.name : "unknown",
-        codes,
-      });
-      return null;
-    });
+    const outcome = await create(values.name);
 
-    if (!result) return;
-
-    const payload = result.data?.createCardgroup;
-    // Capture typename before narrowing so the unknown-variant branch still
-    // has access to it (TypeScript narrows to `never` after the known cases).
-    const typename = payload?.__typename ?? null;
-
-    if (payload?.__typename === "InputValidationError") {
-      setValidationError({ field: payload.field, message: payload.message });
-      return;
-    }
-
-    if (payload?.__typename === "CreateCardgroupSuccess") {
-      const created = payload.cardgroup;
-      if (returnTo) {
-        const sep = returnTo.includes("?") ? "&" : "?";
-        router.push(`${returnTo}${sep}cardgroup=${created.id}`);
+    switch (outcome.status) {
+      case "validation":
+        setValidationError({ field: outcome.field, message: outcome.message });
         return;
-      }
-      router.push(`/cardgroups/${created.id}`);
-      router.refresh();
-      return;
+      case "auth":
+        setAuthError(outcome.kind);
+        return;
+      case "unexpected":
+        setUnexpectedPayloadError("Something went wrong. Please try again.");
+        return;
+      case "rejected":
+        // Transport/network failure: the hook already warned. Stay silent (no
+        // banner) to preserve the established full-page behavior.
+        return;
+      case "success":
+        if (returnTo) {
+          const sep = returnTo.includes("?") ? "&" : "?";
+          router.push(`${returnTo}${sep}cardgroup=${outcome.cardgroupId}`);
+          return;
+        }
+        router.push(`/cardgroups/${outcome.cardgroupId}`);
+        router.refresh();
+        return;
     }
-
-    // Unknown variant: null payload, partial-response null bubble, or a future
-    // union variant the client was not regenerated against. Warn loudly and
-    // show a degraded banner.
-    console.warn("[cardgroups-new] unexpected createCardgroup payload", {
-      typename,
-    });
-    setUnexpectedPayloadError("Something went wrong. Please try again.");
   }
 
   return (
@@ -173,12 +91,7 @@ export function NewCardgroupClient({ showWelcome = false, returnTo }: NewCardgro
           </div>
         </section>
       ) : (
-        <div className="mb-6 flex items-center gap-4">
-          <Link href="/cardgroups" className="text-sm text-muted-foreground hover:underline">
-            &larr; Back
-          </Link>
-          <h1 className="text-2xl font-semibold">New cardgroup</h1>
-        </div>
+        <h1 className="mb-6 text-2xl font-semibold">New cardgroup</h1>
       )}
 
       {authError ? (

--- a/frontend/src/app/cardgroups/new/page.test.tsx
+++ b/frontend/src/app/cardgroups/new/page.test.tsx
@@ -109,11 +109,12 @@ describe("<NewCardgroupPage> (client)", () => {
     expect(screen.getByRole("button", { name: /create/i })).toBeInTheDocument();
   });
 
-  it("renders page header and back link", () => {
+  it("renders page header without a back link", () => {
     renderPage();
     expect(screen.getByRole("heading", { name: /new cardgroup/i })).toBeInTheDocument();
-    const backLink = screen.getByRole("link");
-    expect(backLink).toHaveAttribute("href", "/cardgroups");
+    // The "← Back" link was removed; the drawer-based create flow and the app
+    // shell nav provide navigation instead.
+    expect(screen.queryByRole("link", { name: /back/i })).not.toBeInTheDocument();
   });
 
   it("welcome mode renders the welcome H1 and hides Back / 'New cardgroup'", () => {

--- a/frontend/src/app/cardgroups/use-create-cardgroup.ts
+++ b/frontend/src/app/cardgroups/use-create-cardgroup.ts
@@ -1,0 +1,121 @@
+"use client";
+
+import { useMutation } from "@apollo/client/react";
+import { useCallback } from "react";
+import { MyCardgroupsConnectionDocument } from "@/generated/graphql";
+import { liftGraphQLCodes } from "@/lib/apollo/graphql-errors";
+import { CARDGROUPS_DEFAULT_VARS, CreateCardgroupMutation } from "./queries";
+
+/**
+ * Discriminated outcome of a create-cardgroup attempt. Callers branch on
+ * `status`: the full-page route redirects on `success`; the in-list drawer
+ * closes. The connection cache is updated inside the hook (see the mutation
+ * `update` below), so neither caller needs to touch the cache.
+ */
+export type CreateCardgroupOutcome =
+  | { status: "success"; cardgroupId: string }
+  | { status: "validation"; field: string; message: string }
+  | { status: "auth"; kind: "unauthenticated" | "forbidden" }
+  // The mutation resolved with an unparseable payload (unknown __typename or a
+  // partial-response null bubble).
+  | { status: "unexpected" }
+  // The mutation threw a non-auth transport/network error.
+  | { status: "rejected" };
+
+/**
+ * Shared create-cardgroup mutation + Connection cache write. Used by both the
+ * full-page `/cardgroups/new` route (onboarding / returnTo flows) and the
+ * in-list FormSheet drawer so the cache-key handling and typed-error
+ * classification live in exactly one place.
+ *
+ * No `optimisticResponse`: typed errors (FORBIDDEN, InputValidationError for a
+ * duplicate name) can fail the mutation, and Apollo does not consistently roll
+ * back optimistic writes for typed GraphQL errors. See
+ * .claude/rules/pagination.md § "Drop optimisticResponse for mutations that can
+ * fail with typed GraphQL errors".
+ */
+export function useCreateCardgroup() {
+  const [createCardgroup, { loading }] = useMutation(CreateCardgroupMutation, {
+    update(cache, { data }) {
+      // Narrow on __typename before accessing .cardgroup so an InputValidationError
+      // or unknown variant does not silently mutate the cache.
+      if (data?.createCardgroup?.__typename !== "CreateCardgroupSuccess") return;
+      const created = data.createCardgroup.cardgroup;
+
+      // cache.modify is forbidden — use readQuery + writeQuery so cold-cache
+      // entries are also handled correctly. CARDGROUPS_DEFAULT_VARS keeps the
+      // cache key in sync with the SSR seed and the client useQuery — any
+      // mismatch makes this write invisible. See .claude/rules/pagination.md.
+      const existingConnection = cache.readQuery({
+        query: MyCardgroupsConnectionDocument,
+        variables: CARDGROUPS_DEFAULT_VARS,
+      });
+      const newEdge = {
+        __typename: "CardgroupEdge" as const,
+        cursor: created.id,
+        node: created,
+      };
+      const nextConnection = existingConnection
+        ? {
+            ...existingConnection.myCardgroupsConnection,
+            edges: [newEdge, ...existingConnection.myCardgroupsConnection.edges],
+            totalCount: existingConnection.myCardgroupsConnection.totalCount + 1,
+          }
+        : {
+            // Cold cache: build a minimal connection so the listing page can render
+            // the new edge immediately when the user lands there.
+            __typename: "CardgroupConnection" as const,
+            edges: [newEdge],
+            pageInfo: {
+              __typename: "PageInfo" as const,
+              hasNextPage: false,
+              hasPreviousPage: false,
+              startCursor: created.id,
+              endCursor: created.id,
+            },
+            totalCount: 1,
+          };
+      cache.writeQuery({
+        query: MyCardgroupsConnectionDocument,
+        variables: CARDGROUPS_DEFAULT_VARS,
+        data: { myCardgroupsConnection: nextConnection },
+      });
+    },
+  });
+
+  const create = useCallback(
+    async (name: string): Promise<CreateCardgroupOutcome> => {
+      try {
+        const result = await createCardgroup({ variables: { input: { name } } });
+        const payload = result.data?.createCardgroup;
+        // Capture typename before narrowing so the unknown-variant branch still
+        // has access to it (TypeScript narrows to `never` after the known cases).
+        const typename = payload?.__typename ?? null;
+        if (payload?.__typename === "InputValidationError") {
+          return { status: "validation", field: payload.field, message: payload.message };
+        }
+        if (payload?.__typename === "CreateCardgroupSuccess") {
+          return { status: "success", cardgroupId: payload.cardgroup.id };
+        }
+        // Null payload, partial-response null bubble, or a future union variant
+        // the client was not regenerated against.
+        console.warn("[useCreateCardgroup] unexpected createCardgroup payload", { typename });
+        return { status: "unexpected" };
+      } catch (err) {
+        const codes = liftGraphQLCodes(err);
+        if (codes.includes("UNAUTHENTICATED")) return { status: "auth", kind: "unauthenticated" };
+        if (codes.includes("FORBIDDEN")) return { status: "auth", kind: "forbidden" };
+        // err.message is omitted — backend messages may echo user input.
+        // codes is safe to log (fixed enum of GraphQL extension codes).
+        console.warn("[useCreateCardgroup] createCardgroup rejected", {
+          name: err instanceof Error ? err.name : "unknown",
+          codes,
+        });
+        return { status: "rejected" };
+      }
+    },
+    [createCardgroup],
+  );
+
+  return { create, loading };
+}

--- a/frontend/src/app/learn/[cardgroupId]/_components/learn-add-card-sheet.test.tsx
+++ b/frontend/src/app/learn/[cardgroupId]/_components/learn-add-card-sheet.test.tsx
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+import { MockedProvider } from "@apollo/client/testing/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { CreateCardDocument } from "@/generated/graphql";
+import { LearnAddCardSheet } from "./learn-add-card-sheet";
+
+const userCardState = (due: string, state: number) => ({
+  __typename: "UserCardState" as const,
+  due,
+  state,
+});
+
+function dispatchAddCard(cardgroupId: string) {
+  const event = new CustomEvent("flamingo:add-card", {
+    cancelable: true,
+    detail: { cardgroupId },
+  });
+  act(() => {
+    window.dispatchEvent(event);
+  });
+  return event;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("<LearnAddCardSheet>", () => {
+  it("opens the add-card drawer when the event targets this cardgroup", async () => {
+    render(
+      <MockedProvider mocks={[]}>
+        <LearnAddCardSheet cardgroupId="cg-1" />
+      </MockedProvider>,
+    );
+
+    const event = dispatchAddCard("cg-1");
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(await screen.findByRole("textbox", { name: /front/i })).toBeInTheDocument();
+    expect(screen.getByRole("textbox", { name: /back/i })).toBeInTheDocument();
+  });
+
+  it("ignores an add-card event for a different cardgroup", () => {
+    render(
+      <MockedProvider mocks={[]}>
+        <LearnAddCardSheet cardgroupId="cg-1" />
+      </MockedProvider>,
+    );
+
+    const event = dispatchAddCard("cg-2");
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(screen.queryByRole("textbox", { name: /front/i })).toBeNull();
+  });
+
+  it("creates a card and closes the drawer on success", async () => {
+    const user = userEvent.setup();
+    const createMock = {
+      request: {
+        query: CreateCardDocument,
+        variables: { input: { cardgroupId: "cg-1", front: "Hello", back: "World" } },
+      },
+      result: {
+        data: {
+          createCard: {
+            __typename: "CreateCardSuccess" as const,
+            card: {
+              __typename: "Card" as const,
+              id: "card-new",
+              front: "Hello",
+              back: "World",
+              userCardState: userCardState("2026-05-23T00:00:00Z", 0),
+              cardgroupId: "cg-1",
+            },
+          },
+        },
+      },
+    };
+
+    render(
+      <MockedProvider mocks={[createMock]}>
+        <LearnAddCardSheet cardgroupId="cg-1" />
+      </MockedProvider>,
+    );
+
+    dispatchAddCard("cg-1");
+
+    await user.type(await screen.findByRole("textbox", { name: /front/i }), "Hello");
+    await user.type(screen.getByRole("textbox", { name: /back/i }), "World");
+    await user.click(screen.getByRole("button", { name: /^add$/i }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole("textbox", { name: /front/i })).toBeNull();
+    });
+  });
+});

--- a/frontend/src/app/learn/[cardgroupId]/_components/learn-add-card-sheet.tsx
+++ b/frontend/src/app/learn/[cardgroupId]/_components/learn-add-card-sheet.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { useMutation } from "@apollo/client/react";
+import { useCallback, useEffect, useState } from "react";
+import { CreateCardMutation } from "@/app/cardgroups/queries";
+import { CardForm } from "@/components/cardgroups/card-form";
+import { FormSheet, useFormSheetClose } from "@/components/ui/form-sheet";
+
+function AddCardSheetContent({
+  submit,
+  submitting,
+  error,
+  validationError,
+  onDirty,
+}: {
+  submit: (values: { front: string; back: string }) => Promise<void>;
+  submitting: boolean;
+  error: unknown;
+  validationError: { field: string; message: string } | null;
+  onDirty: () => void;
+}) {
+  const close = useFormSheetClose();
+
+  return (
+    <div onInput={onDirty}>
+      <CardForm
+        mode="create"
+        idPrefix="learn-add-card-"
+        defaultValues={{ front: "", back: "" }}
+        submit={submit}
+        submitting={submitting}
+        error={error}
+        validationError={validationError}
+        onCancel={close}
+      />
+    </div>
+  );
+}
+
+/**
+ * In-context "add card" drawer for the Learn screen. Mounted independently of
+ * the swipe queue so the '+' works even when the queue is empty (AllCaughtUp).
+ *
+ * Opened by the `flamingo:add-card` event the LogoDrawer '+' button dispatches;
+ * the listener calls preventDefault so the dispatcher skips its fallback
+ * navigation. A created card is saved and the drawer closes — it surfaces in a
+ * later session via FSRS scheduling, leaving the current swipe queue untouched.
+ */
+export function LearnAddCardSheet({ cardgroupId }: { cardgroupId: string }) {
+  const [open, setOpen] = useState(false);
+  const [dirty, setDirty] = useState(false);
+  const [validationError, setValidationError] = useState<{
+    field: string;
+    message: string;
+  } | null>(null);
+
+  const [createCard, { loading: creating, error: createError, reset: resetCreateCard }] =
+    useMutation(CreateCardMutation);
+
+  const openSheet = useCallback(() => {
+    resetCreateCard();
+    setValidationError(null);
+    setDirty(false);
+    setOpen(true);
+  }, [resetCreateCard]);
+
+  useEffect(() => {
+    function handleAddCardEvent(event: Event) {
+      if (!(event instanceof CustomEvent)) return;
+      const detail = event.detail as { cardgroupId?: unknown } | null;
+      if (detail?.cardgroupId !== cardgroupId) return;
+
+      event.preventDefault();
+      openSheet();
+    }
+
+    window.addEventListener("flamingo:add-card", handleAddCardEvent);
+    return () => window.removeEventListener("flamingo:add-card", handleAddCardEvent);
+  }, [cardgroupId, openSheet]);
+
+  async function handleCreate(values: { front: string; back: string }) {
+    resetCreateCard();
+    setValidationError(null);
+    const result = await createCard({
+      variables: { input: { cardgroupId, front: values.front, back: values.back } },
+    }).catch((err) => {
+      // err.message is omitted — backend messages may echo user-authored content.
+      console.error("[LearnAddCardSheet] create rejection", {
+        name: err instanceof Error ? err.name : "unknown",
+        cardgroupId,
+      });
+      return null;
+    });
+    if (!result) return;
+
+    const payload = result.data?.createCard;
+    if (payload?.__typename === "CreateCardSuccess") {
+      setDirty(false);
+      setValidationError(null);
+      setOpen(false);
+    } else if (payload?.__typename === "CardDuplicateFrontError") {
+      setValidationError({ field: "front", message: payload.message });
+    } else {
+      const unknownPayload = payload as unknown as { __typename?: string } | null | undefined;
+      console.warn("[LearnAddCardSheet] unexpected createCard payload", {
+        typename: unknownPayload?.__typename ?? null,
+        cardgroupId,
+      });
+      setValidationError({ field: "front", message: "Add failed. Please try again." });
+    }
+  }
+
+  return (
+    <FormSheet
+      title="Add card"
+      open={open}
+      onOpenChange={(nextOpen) => {
+        setOpen(nextOpen);
+        if (!nextOpen) {
+          resetCreateCard();
+          setDirty(false);
+          setValidationError(null);
+        }
+      }}
+      submitting={creating}
+      dirty={dirty}
+      confirmOnDismiss
+    >
+      <AddCardSheetContent
+        submit={handleCreate}
+        submitting={creating}
+        error={createError}
+        validationError={validationError}
+        onDirty={() => setDirty(true)}
+      />
+    </FormSheet>
+  );
+}

--- a/frontend/src/app/learn/[cardgroupId]/page.tsx
+++ b/frontend/src/app/learn/[cardgroupId]/page.tsx
@@ -12,6 +12,7 @@ import { gqlFetch } from "@/lib/apollo/server";
 import { isIgnorableAuthError, isStaleSessionError } from "@/lib/supabase/auth-errors";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 import { LEARN_PAGE_LIMIT, LearnNextDueCardsQuery } from "../queries";
+import { LearnAddCardSheet } from "./_components/learn-add-card-sheet";
 import { LearnSkeleton } from "./_components/learn-skeleton";
 import { LearnClient } from "./learn-client";
 
@@ -40,6 +41,9 @@ export default async function LearnPage({ params }: { params: Promise<{ cardgrou
           <LearnContent cardgroupId={cardgroupId} />
         </Suspense>
       </div>
+      {/* Mounted outside the Suspense boundary so the '+' add-card drawer works
+          regardless of the queue state (including the AllCaughtUp empty state). */}
+      <LearnAddCardSheet cardgroupId={cardgroupId} />
     </main>
   );
 }

--- a/frontend/src/app/not-found.test.tsx
+++ b/frontend/src/app/not-found.test.tsx
@@ -1,11 +1,9 @@
 // @vitest-environment jsdom
 import { render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-const mockBack = vi.fn();
 vi.mock("next/navigation", () => ({
-  useRouter: () => ({ back: mockBack, push: vi.fn() }),
+  useRouter: () => ({ push: vi.fn() }),
   // Arbitrary unknown route: the FAB would otherwise resolve to the default
   // "Add new card" action and render.
   usePathname: () => "/this-route-does-not-exist",
@@ -20,22 +18,12 @@ afterEach(() => {
 });
 
 describe("<NotFound>", () => {
-  it("renders the 404 heading, message, and navigation actions", () => {
+  it("renders the 404 heading, message, and home link", () => {
     render(<NotFound />);
 
     expect(screen.getByText("404")).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: /page not found/i })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Go Back" })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /back to home/i })).toHaveAttribute("href", "/");
-  });
-
-  it("'Go Back' calls router.back()", async () => {
-    const user = userEvent.setup();
-    render(<NotFound />);
-
-    await user.click(screen.getByRole("button", { name: "Go Back" }));
-
-    expect(mockBack).toHaveBeenCalledTimes(1);
   });
 
   it("suppresses the global FAB while mounted", () => {

--- a/frontend/src/app/not-found.test.tsx
+++ b/frontend/src/app/not-found.test.tsx
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mockBack = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ back: mockBack, push: vi.fn() }),
+  // Arbitrary unknown route: the FAB would otherwise resolve to the default
+  // "Add new card" action and render.
+  usePathname: () => "/this-route-does-not-exist",
+}));
+
+import { FabSuppressionProvider } from "@/components/nav/fab-suppression";
+import { GlobalFAB } from "@/components/nav/global-fab";
+import NotFound from "./not-found";
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("<NotFound>", () => {
+  it("renders the 404 heading, message, and navigation actions", () => {
+    render(<NotFound />);
+
+    expect(screen.getByText("404")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /page not found/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Go Back" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /back to home/i })).toHaveAttribute("href", "/");
+  });
+
+  it("'Go Back' calls router.back()", async () => {
+    const user = userEvent.setup();
+    render(<NotFound />);
+
+    await user.click(screen.getByRole("button", { name: "Go Back" }));
+
+    expect(mockBack).toHaveBeenCalledTimes(1);
+  });
+
+  it("suppresses the global FAB while mounted", () => {
+    render(
+      <FabSuppressionProvider>
+        <NotFound />
+        <GlobalFAB />
+      </FabSuppressionProvider>,
+    );
+
+    expect(screen.queryByRole("button", { name: "Add new card" })).toBeNull();
+  });
+});

--- a/frontend/src/app/not-found.tsx
+++ b/frontend/src/app/not-found.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { FlamingoMark } from "@/components/brand/flamingo-mark";
+import { useSuppressFab } from "@/components/nav/fab-suppression";
+import { Button } from "@/components/ui/button";
+
+export default function NotFound() {
+  const router = useRouter();
+  // The global FAB has no meaningful "add" action on a 404; hide it while this
+  // page is shown. A 404 has an arbitrary path the FAB's pathname guard cannot
+  // match, so suppression is the explicit opt-out.
+  useSuppressFab();
+
+  return (
+    <main className="flex min-h-[calc(100dvh-3rem)] w-full flex-col items-center justify-center gap-6 p-8 text-center">
+      <FlamingoMark className="size-16" aria-hidden="true" />
+
+      <div className="space-y-2">
+        <p className="text-6xl font-bold tracking-tight text-brand-primary sm:text-7xl">404</p>
+        <h1 className="text-2xl font-semibold tracking-tight">Oops! Page Not Found!</h1>
+        <p className="mx-auto max-w-md text-sm text-muted-foreground">
+          It seems like the page you're looking for does not exist or might have been removed.
+        </p>
+      </div>
+
+      <div className="flex flex-wrap items-center justify-center gap-3">
+        <Button type="button" variant="outline" onClick={() => router.back()}>
+          Go Back
+        </Button>
+        <Button asChild variant="brand">
+          <Link href="/">Back to Home</Link>
+        </Button>
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/app/not-found.tsx
+++ b/frontend/src/app/not-found.tsx
@@ -1,13 +1,10 @@
 "use client";
 
 import Link from "next/link";
-import { useRouter } from "next/navigation";
-import { FlamingoMark } from "@/components/brand/flamingo-mark";
 import { useSuppressFab } from "@/components/nav/fab-suppression";
 import { Button } from "@/components/ui/button";
 
 export default function NotFound() {
-  const router = useRouter();
   // The global FAB has no meaningful "add" action on a 404; hide it while this
   // page is shown. A 404 has an arbitrary path the FAB's pathname guard cannot
   // match, so suppression is the explicit opt-out.
@@ -15,24 +12,17 @@ export default function NotFound() {
 
   return (
     <main className="flex min-h-[calc(100dvh-3rem)] w-full flex-col items-center justify-center gap-6 p-8 text-center">
-      <FlamingoMark className="size-16" aria-hidden="true" />
-
       <div className="space-y-2">
-        <p className="text-6xl font-bold tracking-tight text-brand-primary sm:text-7xl">404</p>
+        <p className="text-8xl font-bold tracking-tight text-brand-primary sm:text-9xl">404</p>
         <h1 className="text-2xl font-semibold tracking-tight">Oops! Page Not Found!</h1>
         <p className="mx-auto max-w-md text-sm text-muted-foreground">
           It seems like the page you're looking for does not exist or might have been removed.
         </p>
       </div>
 
-      <div className="flex flex-wrap items-center justify-center gap-3">
-        <Button type="button" variant="outline" onClick={() => router.back()}>
-          Go Back
-        </Button>
-        <Button asChild variant="brand">
-          <Link href="/">Back to Home</Link>
-        </Button>
-      </div>
+      <Button asChild variant="brand">
+        <Link href="/">Back to Home</Link>
+      </Button>
     </main>
   );
 }

--- a/frontend/src/app/providers.tsx
+++ b/frontend/src/app/providers.tsx
@@ -2,13 +2,16 @@
 
 import { ApolloNextAppProvider } from "@apollo/client-integration-nextjs";
 import type { ReactNode } from "react";
+import { FabSuppressionProvider } from "@/components/nav/fab-suppression";
 import { makeClient } from "@/lib/apollo/client";
 import { UndoDeleteProvider } from "@/lib/undo-delete";
 
 export function Providers({ children }: { children: ReactNode }) {
   return (
     <ApolloNextAppProvider makeClient={makeClient}>
-      <UndoDeleteProvider>{children}</UndoDeleteProvider>
+      <FabSuppressionProvider>
+        <UndoDeleteProvider>{children}</UndoDeleteProvider>
+      </FabSuppressionProvider>
     </ApolloNextAppProvider>
   );
 }

--- a/frontend/src/components/learn/learn-action-bar.test.tsx
+++ b/frontend/src/components/learn/learn-action-bar.test.tsx
@@ -5,7 +5,7 @@ import { describe, expect, it, vi } from "vitest";
 import { LearnActionBar } from "./learn-action-bar";
 
 describe("<LearnActionBar>", () => {
-  it("renders the three rating buttons with labels and shortcuts", () => {
+  it("renders the three rating buttons with accessible labels and shortcuts but no visible text labels", () => {
     render(<LearnActionBar onRate={vi.fn()} />);
 
     expect(screen.getByRole("button", { name: "Rate as Again" })).toHaveAttribute(
@@ -20,9 +20,11 @@ describe("<LearnActionBar>", () => {
       "aria-keyshortcuts",
       "ArrowRight",
     );
-    expect(screen.getByText("Again")).toBeInTheDocument();
-    expect(screen.getByText("Hard")).toBeInTheDocument();
-    expect(screen.getByText("Easy")).toBeInTheDocument();
+    // The visible "Again"/"Hard"/"Easy" text labels were removed; the rating is
+    // conveyed only via the button aria-label and color. The buttons remain.
+    expect(screen.queryByText("Again")).not.toBeInTheDocument();
+    expect(screen.queryByText("Hard")).not.toBeInTheDocument();
+    expect(screen.queryByText("Easy")).not.toBeInTheDocument();
   });
 
   it.each([

--- a/frontend/src/components/learn/learn-action-bar.tsx
+++ b/frontend/src/components/learn/learn-action-bar.tsx
@@ -41,24 +41,22 @@ export function LearnActionBar({ onRate, disabled = false }: Props) {
     <div className="pointer-events-none z-40 flex justify-center px-4 pt-3 pb-[calc(0.75rem+env(safe-area-inset-bottom))] md:pb-[calc(1.5rem+env(safe-area-inset-bottom))]">
       <div className="pointer-events-auto flex items-center gap-4">
         {DIRECTIONS.map(({ direction, label, Icon, shortcut, colorClass }) => (
-          <div key={direction} className="flex flex-col items-center gap-1">
-            <button
-              type="button"
-              aria-label={`Rate as ${label}`}
-              aria-keyshortcuts={shortcut}
-              disabled={disabled}
-              onClick={() => onRate(direction)}
-              className={cn(
-                "inline-flex h-14 w-14 items-center justify-center rounded-full border-2 bg-transparent transition active:scale-95",
-                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2",
-                "disabled:cursor-not-allowed disabled:opacity-50",
-                colorClass,
-              )}
-            >
-              <Icon className="h-6 w-6" aria-hidden="true" />
-            </button>
-            <span className="text-xs text-muted-foreground">{label}</span>
-          </div>
+          <button
+            key={direction}
+            type="button"
+            aria-label={`Rate as ${label}`}
+            aria-keyshortcuts={shortcut}
+            disabled={disabled}
+            onClick={() => onRate(direction)}
+            className={cn(
+              "inline-flex h-14 w-14 items-center justify-center rounded-full border-2 bg-transparent transition active:scale-95",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2",
+              "disabled:cursor-not-allowed disabled:opacity-50",
+              colorClass,
+            )}
+          >
+            <Icon className="h-6 w-6" aria-hidden="true" />
+          </button>
         ))}
       </div>
     </div>

--- a/frontend/src/components/nav/fab-suppression.tsx
+++ b/frontend/src/components/nav/fab-suppression.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { createContext, useContext, useEffect, useState } from "react";
+
+type FabSuppressionValue = {
+  suppressed: boolean;
+  setSuppressed: (value: boolean) => void;
+};
+
+const FabSuppressionContext = createContext<FabSuppressionValue | null>(null);
+
+/**
+ * Lets a page suppress the layout-level {@link GlobalFAB} while it is mounted.
+ * The FAB is rendered as a sibling of the route content in `app/layout.tsx`, so
+ * a page that has no meaningful "add" action (e.g. the global `not-found.tsx`)
+ * cannot hide it via the pathname-based guard — a 404 has an arbitrary path.
+ * This context is the explicit opt-out seam instead.
+ */
+export function FabSuppressionProvider({ children }: { children: React.ReactNode }) {
+  const [suppressed, setSuppressed] = useState(false);
+
+  return (
+    <FabSuppressionContext.Provider value={{ suppressed, setSuppressed }}>
+      {children}
+    </FabSuppressionContext.Provider>
+  );
+}
+
+/**
+ * Read whether the FAB is currently suppressed. Returns `false` outside a
+ * provider so the FAB renders normally (and its unit tests need no wrapper).
+ */
+export function useFabSuppressed(): boolean {
+  return useContext(FabSuppressionContext)?.suppressed ?? false;
+}
+
+/** Suppress the global FAB for as long as the calling component is mounted. */
+export function useSuppressFab(): void {
+  const ctx = useContext(FabSuppressionContext);
+  useEffect(() => {
+    if (!ctx) return;
+    ctx.setSuppressed(true);
+    return () => ctx.setSuppressed(false);
+  }, [ctx]);
+}

--- a/frontend/src/components/nav/global-fab.test.tsx
+++ b/frontend/src/components/nav/global-fab.test.tsx
@@ -37,6 +37,9 @@ describe("<GlobalFAB>", () => {
       ["/learn"],
       ["/learn/abc-123"],
       ["/learn/abc-123/"],
+      // "/" is a server-redirect-only hub (HomePage always redirects); the FAB
+      // there is only a transition flash during /learn -> "/" -> /learn.
+      ["/"],
     ])("renders nothing on %s", (path) => {
       vi.mocked(usePathname).mockReturnValue(path);
       const { container } = render(<GlobalFAB />);
@@ -56,7 +59,6 @@ describe("<GlobalFAB>", () => {
     it.each([
       ["/cardgroups/abc123/edit"],
       ["/cardgroups/abc123/edit/"],
-      ["/"],
     ])("renders 'Add new card' button on %s", (path) => {
       vi.mocked(usePathname).mockReturnValue(path);
       render(<GlobalFAB />);
@@ -113,11 +115,11 @@ describe("<GlobalFAB>", () => {
     window.removeEventListener("flamingo:add-card", listener);
   });
 
-  it("click on / navigates to /cards/new", async () => {
+  it("click on a cardgroup detail path navigates to /cards/new", async () => {
     const user = userEvent.setup();
     const router = makeRouter();
     vi.mocked(useRouter).mockReturnValue(router as never);
-    vi.mocked(usePathname).mockReturnValue("/");
+    vi.mocked(usePathname).mockReturnValue("/cardgroups/abc123");
 
     render(<GlobalFAB />);
     await user.click(screen.getByRole("button", { name: "Add new card" }));

--- a/frontend/src/components/nav/global-fab.test.tsx
+++ b/frontend/src/components/nav/global-fab.test.tsx
@@ -9,7 +9,13 @@ vi.mock("next/navigation", () => ({
 }));
 
 import { usePathname, useRouter } from "next/navigation";
+import { FabSuppressionProvider, useSuppressFab } from "./fab-suppression";
 import { GlobalFAB } from "./global-fab";
+
+function FabSuppressor() {
+  useSuppressFab();
+  return null;
+}
 
 function makeRouter() {
   return { push: vi.fn(), replace: vi.fn() };
@@ -66,16 +72,50 @@ describe("<GlobalFAB>", () => {
     });
   });
 
-  it("click on /cardgroups navigates to /cardgroups/new", async () => {
+  it("click on /cardgroups dispatches a cancelable add-cardgroup event and falls back to /cardgroups/new when unhandled", async () => {
     const user = userEvent.setup();
     const router = makeRouter();
+    const listener = vi.fn();
+    window.addEventListener("flamingo:add-cardgroup", listener);
     vi.mocked(useRouter).mockReturnValue(router as never);
     vi.mocked(usePathname).mockReturnValue("/cardgroups");
 
     render(<GlobalFAB />);
     await user.click(screen.getByRole("button", { name: "Add new cardgroup" }));
 
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect((listener.mock.calls[0]?.[0] as Event).cancelable).toBe(true);
     expect(router.push).toHaveBeenCalledWith("/cardgroups/new");
+
+    window.removeEventListener("flamingo:add-cardgroup", listener);
+  });
+
+  it("click on /cardgroups does not navigate when the add-cardgroup event is handled", async () => {
+    const user = userEvent.setup();
+    const router = makeRouter();
+    const listener = vi.fn((event: Event) => event.preventDefault());
+    window.addEventListener("flamingo:add-cardgroup", listener);
+    vi.mocked(useRouter).mockReturnValue(router as never);
+    vi.mocked(usePathname).mockReturnValue("/cardgroups");
+
+    render(<GlobalFAB />);
+    await user.click(screen.getByRole("button", { name: "Add new cardgroup" }));
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(router.push).not.toHaveBeenCalled();
+
+    window.removeEventListener("flamingo:add-cardgroup", listener);
+  });
+
+  it("renders nothing when a mounted component suppresses the FAB", () => {
+    vi.mocked(usePathname).mockReturnValue("/cardgroups");
+    render(
+      <FabSuppressionProvider>
+        <FabSuppressor />
+        <GlobalFAB />
+      </FabSuppressionProvider>,
+    );
+    expect(screen.queryByRole("button", { name: "Add new cardgroup" })).toBeNull();
   });
 
   it("click on /cardgroups/abc123/edit dispatches an in-context add-card event and falls back when unhandled", async () => {

--- a/frontend/src/components/nav/global-fab.tsx
+++ b/frontend/src/components/nav/global-fab.tsx
@@ -3,6 +3,7 @@
 import { Plus } from "lucide-react";
 import { usePathname, useRouter } from "next/navigation";
 import { resolveFabAction } from "./fab-action";
+import { useFabSuppressed } from "./fab-suppression";
 
 // Hidden on /login (anonymous-only), /admin (different audience),
 // /cards/new + /cardgroups/new (FAB target — would loop),
@@ -13,12 +14,15 @@ const HIDDEN_PATH_RE = /^\/(login|admin|cards\/new|cardgroups\/new|profile|learn
 export function GlobalFAB() {
   const pathname = usePathname();
   const router = useRouter();
+  // A page can opt out of the FAB while mounted (e.g. not-found.tsx, which has
+  // an arbitrary path that the pathname guard below cannot match).
+  const suppressed = useFabSuppressed();
 
   // "/" is a server-redirect-only hub — HomePage always redirects (to /learn,
   // /cardgroups, /login, or /onboarding) and never renders content. Rendering
   // the FAB there only produces a flash during transitions that pass through
   // it (e.g. tapping the logo from /learn routes /learn -> "/" -> /learn).
-  if (pathname === "/" || HIDDEN_PATH_RE.test(pathname)) {
+  if (suppressed || pathname === "/" || HIDDEN_PATH_RE.test(pathname)) {
     return null;
   }
 
@@ -34,6 +38,16 @@ export function GlobalFAB() {
         cancelable: true,
         detail: { cardgroupId: resolvedAction.cardgroupId },
       });
+      if (window.dispatchEvent(event)) {
+        router.push(resolvedAction.href);
+      }
+      return;
+    }
+
+    if (resolvedAction.kind === "cardgroup") {
+      // CardgroupsClient (mounted on /cardgroups) cancels this to open the
+      // create drawer in place; when unhandled we fall back to the full page.
+      const event = new CustomEvent("flamingo:add-cardgroup", { cancelable: true });
       if (window.dispatchEvent(event)) {
         router.push(resolvedAction.href);
       }

--- a/frontend/src/components/nav/global-fab.tsx
+++ b/frontend/src/components/nav/global-fab.tsx
@@ -14,7 +14,11 @@ export function GlobalFAB() {
   const pathname = usePathname();
   const router = useRouter();
 
-  if (HIDDEN_PATH_RE.test(pathname)) {
+  // "/" is a server-redirect-only hub — HomePage always redirects (to /learn,
+  // /cardgroups, /login, or /onboarding) and never renders content. Rendering
+  // the FAB there only produces a flash during transitions that pass through
+  // it (e.g. tapping the logo from /learn routes /learn -> "/" -> /learn).
+  if (pathname === "/" || HIDDEN_PATH_RE.test(pathname)) {
     return null;
   }
 

--- a/frontend/src/components/nav/logo-drawer.test.tsx
+++ b/frontend/src/components/nav/logo-drawer.test.tsx
@@ -6,8 +6,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 // usePathname is mocked per-test so anonymous Sign-in-link tests can set a
 // non-/login pathname (the link self-suppresses on /login).
 const mockUsePathname = vi.fn();
+// Stable router.push spy so the '+' button's fallback navigation is assertable.
+const mockPush = vi.fn();
 vi.mock("next/navigation", () => ({
-  useRouter: vi.fn(() => ({ push: vi.fn(), replace: vi.fn() })),
+  useRouter: () => ({ push: mockPush, replace: vi.fn() }),
   usePathname: () => mockUsePathname(),
 }));
 
@@ -27,6 +29,7 @@ const SIGNED_IN_USER = { email: "user@example.com" };
 beforeEach(() => {
   // Default to a non-/login path so HeaderSignInLink renders for anonymous tests.
   mockUsePathname.mockReturnValue("/cardgroups");
+  mockPush.mockClear();
 });
 
 afterEach(() => {
@@ -168,63 +171,97 @@ describe("<LogoDrawer>", () => {
     expect(screen.getByTestId("logout-button")).toBeInTheDocument();
   });
 
-  it("S-L1: on /learn/:id the '+' link exists with the right href", () => {
+  it("S-L1: on /learn/:id the '+' is a button that dispatches a cancelable add-card event and falls back to /cards/new when unhandled", async () => {
+    const user = userEvent.setup();
     mockUsePathname.mockReturnValue("/learn/abc-123");
+    const listener = vi.fn();
+    window.addEventListener("flamingo:add-card", listener);
     render(<LogoDrawer user={SIGNED_IN_USER} isAdmin={false} />);
-    const addLink = screen.getByRole("link", { name: /add a new card to this cardgroup/i });
-    expect(addLink).toHaveAttribute("href", "/cards/new?cardgroup=abc-123&return=/learn/abc-123");
+
+    await user.click(screen.getByRole("button", { name: /add a new card to this cardgroup/i }));
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    const event = listener.mock.calls[0]?.[0] as CustomEvent<{ cardgroupId: string }>;
+    expect(event.cancelable).toBe(true);
+    expect(event.detail).toEqual({ cardgroupId: "abc-123" });
+    expect(mockPush).toHaveBeenCalledWith("/cards/new?cardgroup=abc-123&return=/learn/abc-123");
+
+    window.removeEventListener("flamingo:add-card", listener);
   });
 
-  it("S-L2: on a non-learn route the '+' link is not rendered", () => {
+  it("S-L1b: on /learn/:id the '+' does not navigate when the add-card event is handled", async () => {
+    const user = userEvent.setup();
+    mockUsePathname.mockReturnValue("/learn/abc-123");
+    const listener = vi.fn((event: Event) => event.preventDefault());
+    window.addEventListener("flamingo:add-card", listener);
+    render(<LogoDrawer user={SIGNED_IN_USER} isAdmin={false} />);
+
+    await user.click(screen.getByRole("button", { name: /add a new card to this cardgroup/i }));
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(mockPush).not.toHaveBeenCalled();
+
+    window.removeEventListener("flamingo:add-card", listener);
+  });
+
+  it("S-L2: on a non-learn route the '+' button is not rendered", () => {
     mockUsePathname.mockReturnValue("/cardgroups");
     render(<LogoDrawer user={SIGNED_IN_USER} isAdmin={false} />);
-    expect(screen.queryByRole("link", { name: /add a new card to this cardgroup/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /add a new card to this cardgroup/i })).toBeNull();
   });
 
-  it("S-L3: on /learn/:id the '+' link receives keyboard focus before the menu trigger", async () => {
+  it("S-L3: on /learn/:id the '+' button receives keyboard focus before the menu trigger", async () => {
     const user = userEvent.setup();
     mockUsePathname.mockReturnValue("/learn/abc-123");
     render(<LogoDrawer user={SIGNED_IN_USER} isAdmin={false} />);
 
-    const addLink = screen.getByRole("link", { name: /add a new card to this cardgroup/i });
+    const addButton = screen.getByRole("button", { name: /add a new card to this cardgroup/i });
     const menuButton = screen.getByRole("button", { name: "Open menu" });
 
-    addLink.focus();
-    expect(addLink).toHaveFocus();
+    addButton.focus();
+    expect(addButton).toHaveFocus();
     await user.tab();
     expect(menuButton).toHaveFocus();
   });
 
-  it("S-L4: cardgroupId with special characters round-trips to single-encoded href", () => {
+  it("S-L4: cardgroupId with special characters — event carries the raw decoded id, fallback href is single-encoded", async () => {
     // usePathname returns the percent-encoded pathname as delivered by the browser.
-    // The component decodes the segment, then the JSX re-encodes once via
-    // encodeURIComponent so the final href is correctly single-encoded.
+    // The component decodes the segment for the event detail, then re-encodes once
+    // via encodeURIComponent so the fallback href is correctly single-encoded.
+    const user = userEvent.setup();
     mockUsePathname.mockReturnValue("/learn/abc%26evil");
+    const listener = vi.fn();
+    window.addEventListener("flamingo:add-card", listener);
     render(<LogoDrawer user={SIGNED_IN_USER} isAdmin={false} />);
-    const addLink = screen.getByRole("link", { name: /add a new card to this cardgroup/i });
-    expect(addLink).toHaveAttribute(
-      "href",
+
+    await user.click(screen.getByRole("button", { name: /add a new card to this cardgroup/i }));
+
+    const event = listener.mock.calls[0]?.[0] as CustomEvent<{ cardgroupId: string }>;
+    expect(event.detail).toEqual({ cardgroupId: "abc&evil" });
+    expect(mockPush).toHaveBeenCalledWith(
       "/cards/new?cardgroup=abc%26evil&return=/learn/abc%26evil",
     );
+
+    window.removeEventListener("flamingo:add-card", listener);
   });
 
-  it("S-L5: anonymous user on /learn/:id does not see the '+' link", () => {
+  it("S-L5: anonymous user on /learn/:id does not see the '+' button", () => {
     mockUsePathname.mockReturnValue("/learn/abc-123");
     render(<LogoDrawer user={null} isAdmin={false} />);
-    expect(screen.queryByRole("link", { name: /add a new card to this cardgroup/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /add a new card to this cardgroup/i })).toBeNull();
   });
 
-  it("S-L6: regex rejects /learn/:id sub-routes — '+' link is absent on /learn/abc-123/edit", () => {
+  it("S-L6: regex rejects /learn/:id sub-routes — '+' button is absent on /learn/abc-123/edit", () => {
     mockUsePathname.mockReturnValue("/learn/abc-123/edit");
     render(<LogoDrawer user={SIGNED_IN_USER} isAdmin={false} />);
-    expect(screen.queryByRole("link", { name: /add a new card to this cardgroup/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /add a new card to this cardgroup/i })).toBeNull();
   });
 
-  it("S-L7: malformed percent-escape in /learn/:id does not crash — '+' link is absent", () => {
+  it("S-L7: malformed percent-escape in /learn/:id does not crash — '+' button is absent", () => {
     // safeDecodePathSegment returns null for malformed %XX sequences; the conditional
-    // JSX skips the '+' link rather than throwing URIError and crashing the layout shell.
+    // JSX skips the '+' button rather than throwing URIError and crashing the layout shell.
     mockUsePathname.mockReturnValue("/learn/abc%XX");
     render(<LogoDrawer user={SIGNED_IN_USER} isAdmin={false} />);
-    expect(screen.queryByRole("link", { name: /add a new card to this cardgroup/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /add a new card to this cardgroup/i })).toBeNull();
   });
 });

--- a/frontend/src/components/nav/logo-drawer.tsx
+++ b/frontend/src/components/nav/logo-drawer.tsx
@@ -2,7 +2,7 @@
 
 import { BookOpen, Plus, User } from "lucide-react";
 import Link from "next/link";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import { LogoutButton } from "@/app/_components/logout-button";
 import { FlamingoMark } from "@/components/brand/flamingo-mark";
 import { MobileMenuTrigger } from "@/components/nav/mobile-menu-trigger";
@@ -23,11 +23,26 @@ const NAV_LINK_CLASS =
 
 export function LogoDrawer({ user, isAdmin }: LogoDrawerProps) {
   const pathname = usePathname();
+  const router = useRouter();
   const learnMatch = pathname.match(/^\/learn\/([^/]+)$/);
-  // null on malformed %XX — conditional JSX below skips the '+' link rather than
+  // null on malformed %XX — conditional JSX below skips the '+' button rather than
   // propagating a URIError that would escape layout.tsx's error boundary.
   const learnCardgroupId =
     user && learnMatch ? safeDecodePathSegment(learnMatch[1] as string) : null;
+
+  // The '+' opens the in-context add-card drawer (LearnAddCardSheet listens for
+  // this event and calls preventDefault). When no listener is mounted the event
+  // is uncancelled and we fall back to the full-page /cards/new route.
+  function handleAddCard(rawCardgroupId: string) {
+    const event = new CustomEvent("flamingo:add-card", {
+      cancelable: true,
+      detail: { cardgroupId: rawCardgroupId },
+    });
+    if (window.dispatchEvent(event)) {
+      const encodedId = encodeURIComponent(rawCardgroupId);
+      router.push(`/cards/new?cardgroup=${encodedId}&return=/learn/${encodedId}`);
+    }
+  }
 
   return (
     <Sheet>
@@ -40,13 +55,14 @@ export function LogoDrawer({ user, isAdmin }: LogoDrawerProps) {
       </Link>
       <div className="flex items-center gap-1">
         {learnCardgroupId && (
-          <Link
-            href={`/cards/new?cardgroup=${encodeURIComponent(learnCardgroupId)}&return=/learn/${encodeURIComponent(learnCardgroupId)}`}
+          <button
+            type="button"
+            onClick={() => handleAddCard(learnCardgroupId)}
             aria-label="Add a new card to this cardgroup"
             className="rounded-md p-2 hover:bg-accent focus:outline-none focus:ring-2 focus:ring-ring"
           >
             <Plus className="h-5 w-5" aria-hidden="true" />
-          </Link>
+          </button>
         )}
         <MobileMenuTrigger />
       </div>

--- a/frontend/src/components/nav/mobile-menu-trigger.tsx
+++ b/frontend/src/components/nav/mobile-menu-trigger.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Settings } from "lucide-react";
+import { Menu } from "lucide-react";
 import { SheetTrigger } from "@/components/ui/sheet";
 
 export function MobileMenuTrigger() {
@@ -11,7 +11,7 @@ export function MobileMenuTrigger() {
         aria-label="Open menu"
         className="rounded-md p-2 hover:bg-accent focus:outline-none focus:ring-2 focus:ring-ring"
       >
-        <Settings className="h-5 w-5" aria-hidden="true" />
+        <Menu className="h-5 w-5" aria-hidden="true" />
       </button>
     </SheetTrigger>
   );


### PR DESCRIPTION
## Summary

Converts the create-cardgroup and add-card actions from full-page navigations into in-place drawers, and suppresses the global FAB on pages where it has no meaningful action or would only flash during a transition. Quick create/add flows now open a drawer over the current screen instead of routing away, while the full-page routes stay for the onboarding / `returnTo` paths that still need them.

## Background / Motivation

- Tapping "add" on the cardgroups list or the Learn screen routed to a full page (`/cardgroups/new`, `/cards/new`), so a one-field create incurred a full navigation and lost the user's place in the list / swipe queue.
- The global FAB rendered on `"/"`, a server-redirect-only hub that never paints content. Transitions that pass through it (e.g. tapping the logo from `/learn` routes `/learn → "/" → /learn`) flashed the FAB mid-transition.
- A page with an arbitrary path — the global `not-found.tsx` — cannot opt out of the layout-level FAB via `GlobalFAB`'s pathname regex, so there was no seam to hide it on a 404.
- The repo had no branded 404 page; an unknown path fell through to Next's default.

## Changes

### FAB suppression context

- Add `FabSuppressionProvider` / `useSuppressFab` / `useFabSuppressed` (`components/nav/fab-suppression.tsx`) so a page can hide the layout-level `GlobalFAB` while mounted. The FAB is a sibling of the route content in `app/layout.tsx`, so a page with an arbitrary path cannot opt out via the pathname guard — this context is the explicit seam. Wired into `app/providers.tsx`.
- `GlobalFAB` now hides on `suppressed` and on `pathname === "/"` in addition to the existing `HIDDEN_PATH_RE`.

### In-place create-cardgroup drawer

- Extract the create-cardgroup mutation + Relay Connection cache write into a shared `useCreateCardgroup` hook (`app/cardgroups/use-create-cardgroup.ts`) returning a discriminated `CreateCardgroupOutcome`. Both `/cardgroups/new` (onboarding / `returnTo`) and the new in-list drawer consume it, so the `readQuery + writeQuery` cache handling and typed-error classification live in one place. No `optimisticResponse` — typed errors (FORBIDDEN, duplicate-name `InputValidationError`) can fail the mutation.
- `CardgroupsClient` opens a `FormSheet` drawer in place, triggered by the desktop "New cardgroup" button and by the mobile FAB via a cancelable `flamingo:add-cardgroup` event; the FAB falls back to the full page when no listener cancels it.

### In-context add-card drawer on Learn

- New `LearnAddCardSheet` (`app/learn/[cardgroupId]/_components/learn-add-card-sheet.tsx`), mounted outside the Suspense boundary so the '+' works regardless of queue state (including the AllCaughtUp empty state). It listens for a cancelable `flamingo:add-card` event the `LogoDrawer` '+' dispatches; the LogoDrawer falls back to `/cards/new` when uncancelled.

### 404 page + nav polish

- Add `app/not-found.tsx` — a branded 404 with Back / Home actions that calls `useSuppressFab`.
- Swap the mobile menu trigger icon from `Settings` to `Menu`; simplify the rating-button markup in the learn action bar.

## Verification

```bash
pnpm --filter frontend typecheck
pnpm --filter frontend exec vitest run \
  src/app/cardgroups/cardgroups-client.test.tsx \
  src/app/cardgroups/new/page.test.tsx \
  'src/app/learn/[cardgroupId]/_components/learn-add-card-sheet.test.tsx' \
  src/app/not-found.test.tsx \
  src/components/learn/learn-action-bar.test.tsx \
  src/components/nav/global-fab.test.tsx \
  src/components/nav/logo-drawer.test.tsx
```

Manual QA:

- FAB is hidden on `/`, `/login`, `/admin`, `/cards/new`, `/cardgroups/new`, and a 404 path; visible on `/cardgroups` and `/learn/<id>`.
- On `/cardgroups`, both the desktop "New cardgroup" button and the mobile FAB open the create drawer in place; a successful create appends the row without a refetch.
- On `/learn/<id>`, the LogoDrawer '+' opens the add-card drawer even when the swipe queue is empty (AllCaughtUp).

## Test plan

- [x] `pnpm --filter frontend typecheck`
- [x] Affected vitest suites — 99 passed
- [ ] Real-browser: FAB suppression, create-cardgroup drawer (desktop button + mobile FAB), and Learn '+' add-card drawer on an empty queue

This branch addresses no tracked issue.
