### PR TITLE
refactor(schema-lint): remove dead ResolverWalk wrapper

### DIFF
--- a/backend/cmd/schema-lint/resolverwalk.go
+++ b/backend/cmd/schema-lint/resolverwalk.go
@@ -38,13 +38,6 @@ type ResolverWalkResult struct {
 	Mappings []ResolverMapping
 }
 
-// ResolverWalk parses the Go source file at resolverPath and extracts every
-// method on *mutationResolver (or mutationResolver) together with the
-// usecase call(s) found in its body.
-func ResolverWalk(resolverPath string) (ResolverWalkResult, error) {
-	return ResolverWalkFiles([]string{resolverPath})
-}
-
 // ResolverWalkFiles parses one or more Go source files and extracts every
 // method on *mutationResolver (or mutationResolver) together with the usecase
 // call(s) found in its body. Mappings are appended in the order paths are

--- a/backend/cmd/schema-lint/resolverwalk_test.go
+++ b/backend/cmd/schema-lint/resolverwalk_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-func TestResolverWalk(t *testing.T) {
+func TestResolverWalkFiles_PerFile(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -78,18 +78,18 @@ func TestResolverWalk(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			got, err := ResolverWalk(tc.file)
+			got, err := ResolverWalkFiles([]string{tc.file})
 			if tc.wantErr {
 				if err == nil {
-					t.Fatal("ResolverWalk: expected error, got nil")
+					t.Fatal("ResolverWalkFiles: expected error, got nil")
 				}
 				return
 			}
 			if err != nil {
-				t.Fatalf("ResolverWalk: unexpected error: %v", err)
+				t.Fatalf("ResolverWalkFiles: unexpected error: %v", err)
 			}
 			if diff := cmp.Diff(tc.wantMappings, got.Mappings); diff != "" {
-				t.Errorf("ResolverWalk Mappings mismatch (-want +got):\n%s", diff)
+				t.Errorf("ResolverWalkFiles Mappings mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/backend/cmd/schema-lint/schema_lint_integration_test.go
+++ b/backend/cmd/schema-lint/schema_lint_integration_test.go
@@ -67,7 +67,7 @@ func runLivePipeline(t *testing.T, al Allowlist) ([]Violation, []Drift) {
 	}
 	resolverResult, err := ResolverWalkFiles(resolverPaths)
 	if err != nil {
-		t.Fatalf("ResolverWalk: %v", err)
+		t.Fatalf("ResolverWalkFiles: %v", err)
 	}
 	usecaseMethods, err := UsecaseWalk(usecaseDir)
 	if err != nil {
@@ -163,7 +163,7 @@ func TestIntegration_LiveTree_NoAllowlistRot(t *testing.T) {
 	}
 	resolverResult, err := ResolverWalkFiles(resolverPaths)
 	if err != nil {
-		t.Fatalf("ResolverWalk: %v", err)
+		t.Fatalf("ResolverWalkFiles: %v", err)
 	}
 	usecaseMethods, err := UsecaseWalk(usecaseDir)
 	if err != nil {


### PR DESCRIPTION
## Summary

Removes the dead `ResolverWalk` single-file convenience wrapper from `cmd/schema-lint/resolverwalk.go` — flagged as genuine dead code by a `deadcode` sweep. The production entry point already calls `ResolverWalkFiles` directly, making `ResolverWalk` reachable only from its test. No behaviour change; all five single-file test scenarios and all integration tests are preserved by repointing the call site.

## Background / Motivation

- A `deadcode ./...` sweep from `backend/` against the three `main` packages flagged 17 unreachable functions. 16 were classified as intentional (test-injection seams, documented public API, generated code). `ResolverWalk` was the one genuine dead-code finding.
- `ResolverWalk(path)` is a thin shim that immediately calls `ResolverWalkFiles([]string{path})`; `cmd/schema-lint/main.go` calls `ResolverWalkFiles` directly, so the shim is never reached in production.
- Keeping a dead exported function sends a false signal that a second call-form is supported, and suppresses future `deadcode` alerts.

## Changes

### Production: delete the shim (`resolverwalk.go`)

- Remove the `ResolverWalk` function and its 6-line docblock; `ResolverWalkFiles` and the private `resolverWalkFile` are unchanged.

### Tests: repoint the single-file table test (`resolverwalk_test.go`)

- Rename `TestResolverWalk` → `TestResolverWalkFiles_PerFile` so the test name no longer references the deleted symbol.
- Switch the call site from `ResolverWalk(tc.file)` to `ResolverWalkFiles([]string{tc.file})`; `got.Mappings` is identical, so all five scenarios keep their coverage.
- Refresh three message labels (`"ResolverWalk: ..."` → `"ResolverWalkFiles: ..."`).

### Tests: refresh stale labels (`schema_lint_integration_test.go`)

- Lines 70 and 166 carried `t.Fatalf("ResolverWalk: %v", err)` labels even though the actual call on each line was already `ResolverWalkFiles`. Updated both to `"ResolverWalkFiles: %v"`.

## Verification

```bash
# From backend/
go build ./...
go vet ./...
go test ./cmd/schema-lint/...

# Bare identifier must be gone — expect no output
grep -rn '\bResolverWalk\b' backend/ | grep -v 'ResolverWalkFiles\|resolverWalkFile'
```

## Test plan

- [ ] `go build ./...` — clean
- [ ] `go vet ./...` — clean
- [ ] `go test ./cmd/schema-lint/...` — all tests green, including `TestResolverWalkFiles_PerFile` and all four integration tests
- [ ] `grep -rn '\bResolverWalk\b' backend/ | grep -v 'ResolverWalkFiles\|resolverWalkFile'` — no output

Closes #255
