### PR TITLE
feat(frontend): add admin navigation skeletons gated to initial load

### DIFF
--- a/docs/frontend/csp.md
+++ b/docs/frontend/csp.md
@@ -11,7 +11,7 @@ The frontend ships an **enforcing** CSP for HTML responses, a **static offline-p
 [`frontend/src/lib/security/csp.ts`](../../frontend/src/lib/security/csp.ts) exports two public pieces:
 
 1. `serializeCsp(directives)` takes a directive map and turns it into a stable header string. It drops `null` / `undefined` / `false`, trims sources, removes duplicates, and emits directives in the configured order with any unknown directives sorted alphabetically after the known ones.
-2. `buildHtmlCsp({ nonce, supabaseUrl, reportUri?, reportTo?, speedInsightsOrigin? })` builds the policy used for HTML routes. It requires a non-empty nonce, derives the Supabase HTTPS origin plus the matching realtime WebSocket origin from `supabaseUrl`, and includes the default reporting endpoints.
+2. `buildHtmlCsp({ nonce, supabaseUrl, reportUri?, reportTo?, speedInsightsOrigin?, allowUnsafeEval? })` builds the policy used for HTML routes. It requires a non-empty nonce, derives the Supabase HTTPS origin plus the matching realtime WebSocket origin from `supabaseUrl`, and includes the default reporting endpoints. `allowUnsafeEval` defaults to `false`; when `true` it appends `'unsafe-eval'` to `script-src`.
 
 The HTML policy currently allows:
 
@@ -22,12 +22,14 @@ The HTML policy currently allows:
 - `form-action 'self'`
 - `img-src 'self' data: blob: https://lh3.googleusercontent.com`
 - `style-src 'self' 'unsafe-inline'`
-- `script-src 'self' 'nonce-<generated>'`
+- `script-src 'self' 'nonce-<generated>'` (plus `'unsafe-eval'` in development only — see below)
 - `connect-src 'self' <supabase https origin> <supabase wss origin> https://vitals.vercel-insights.com`
 - `report-uri /api/csp-report`
 - `report-to csp-endpoint`
 
 That is the current shipped policy shape. `style-src 'unsafe-inline'` remains because the existing animation and styling approach still depends on inline CSS. The Google avatar origin is intentionally whitelisted in `img-src`, and the Vercel Speed Insights origin is intentionally whitelisted in `connect-src`.
+
+The middleware passes `allowUnsafeEval: process.env.NODE_ENV !== "production"`, so `script-src` gains `'unsafe-eval'` in development only. Turbopack and React dev mode (HMR, React refresh) require the `'unsafe-eval'` source; without it the browser blocks dev tooling with an unsupported-environment error. Production builds never receive `'unsafe-eval'`.
 
 The shipped `/offline.html` CSP in [`frontend/next.config.ts`](../../frontend/next.config.ts) is:
 
@@ -87,6 +89,7 @@ These are the decisions currently shipped in code:
 
 - CSP is enforcing for HTML routes.
 - `style-src 'unsafe-inline'` is retained.
+- `script-src 'unsafe-eval'` is added in development only (`NODE_ENV !== "production"`) for Turbopack/React HMR; production omits it.
 - Supabase uses both its HTTPS origin and its WSS realtime origin in `connect-src`.
 - Vercel Speed Insights is allowed in `connect-src`.
 - Google avatar images from `https://lh3.googleusercontent.com` are allowed in `img-src`.

--- a/frontend/src/app/admin/dictionary/admin-dictionary-skeleton.tsx
+++ b/frontend/src/app/admin/dictionary/admin-dictionary-skeleton.tsx
@@ -1,0 +1,34 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+/**
+ * Loading placeholder for the /admin/dictionary route. Mirrors the resolved
+ * page layout to prevent CLS while the server component runs auth checks.
+ */
+export function AdminDictionarySkeleton() {
+  return (
+    <main className="p-8">
+      <Skeleton className="mb-6 h-8 w-56" />
+
+      <div className="space-y-6">
+        {/* Cardgroup selector */}
+        <div className="space-y-2">
+          <Skeleton className="h-4 w-36" />
+          <Skeleton className="h-10 w-full max-w-sm" />
+        </div>
+
+        {/* Payload textarea */}
+        <div className="space-y-2">
+          <Skeleton className="h-4 w-40" />
+          <Skeleton className="h-3 w-72" />
+          <Skeleton className="h-40 w-full" />
+        </div>
+
+        {/* Action buttons */}
+        <div className="flex gap-3">
+          <Skeleton className="h-10 w-24" />
+          <Skeleton className="h-10 w-20" />
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/app/admin/dictionary/loading.tsx
+++ b/frontend/src/app/admin/dictionary/loading.tsx
@@ -1,0 +1,10 @@
+import { AdminDictionarySkeleton } from "./admin-dictionary-skeleton";
+
+/**
+ * Route-segment navigation fallback. Rendered by Next.js while the server
+ * component tree for /admin/dictionary is being prepared (the RSC performs
+ * an auth check before streaming the client component).
+ */
+export default function Loading() {
+  return <AdminDictionarySkeleton />;
+}

--- a/frontend/src/app/admin/roles/admin-roles-skeleton.tsx
+++ b/frontend/src/app/admin/roles/admin-roles-skeleton.tsx
@@ -1,0 +1,41 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+/**
+ * Loading placeholder for the /admin/roles listing route. Mirrors the resolved
+ * page layout to prevent CLS while the server component fetches the roles list.
+ *
+ * Reproduces the ListingPageShell geometry manually to avoid wrapping a <Skeleton>
+ * block element inside <h1> (which ListingPageShell would do via its title slot).
+ */
+export function AdminRolesSkeleton() {
+  return (
+    <main className="flex flex-1 flex-col gap-4 p-8 sm:gap-6">
+      <div className="flex flex-wrap items-end justify-between gap-2">
+        <div>
+          <Skeleton className="h-8 w-24" />
+          <Skeleton className="mt-2 h-4 w-64" />
+        </div>
+        <div className="flex items-center gap-2">
+          <Skeleton className="hidden h-10 w-28 md:inline-flex" />
+        </div>
+      </div>
+
+      <ul
+        className="space-y-3"
+        aria-busy="true"
+        aria-label="Loading roles"
+        data-testid="admin-roles-skeleton"
+      >
+        {Array.from({ length: 3 }).map((_, i) => (
+          // biome-ignore lint/suspicious/noArrayIndexKey: static placeholder rows have no stable id.
+          <li key={i} className="rounded-md border border-border px-4 py-3">
+            <div className="flex items-center justify-between">
+              <Skeleton className="h-5 w-32" />
+              <Skeleton className="h-8 w-16" />
+            </div>
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/frontend/src/app/admin/roles/loading.tsx
+++ b/frontend/src/app/admin/roles/loading.tsx
@@ -1,0 +1,10 @@
+import { AdminRolesSkeleton } from "./admin-roles-skeleton";
+
+/**
+ * Route-segment navigation fallback. Rendered by Next.js while the server
+ * component tree for /admin/roles is being prepared (the RSC performs a
+ * gqlFetch to seed the initial roles list before streaming the client).
+ */
+export default function Loading() {
+  return <AdminRolesSkeleton />;
+}

--- a/frontend/src/app/admin/users/admin-users-client.test.tsx
+++ b/frontend/src/app/admin/users/admin-users-client.test.tsx
@@ -166,6 +166,27 @@ afterEach(() => {
   leakSpy.teardown();
 });
 
+describe("<AdminUsersClient> initial loading", () => {
+  it("renders the skeleton immediately on first render then hides it once data arrives", async () => {
+    render(
+      <MockedProvider mocks={[makeUsersMock(), makeRolesMock()]}>
+        <AdminUsersClient />
+      </MockedProvider>,
+    );
+
+    // Synchronous assertion: Apollo starts with networkStatus === loading (1) and
+    // no data, so initialLoading is true and the skeleton must be in the DOM
+    // before any microtask resolves the mock response.
+    expect(screen.getByTestId("admin-users-skeleton")).toBeInTheDocument();
+
+    // Wait for the mock to resolve and the list to appear.
+    expect(await screen.findByTestId("admin-users-list")).toBeInTheDocument();
+
+    // Once data has arrived the skeleton must be gone.
+    expect(screen.queryByTestId("admin-users-skeleton")).not.toBeInTheDocument();
+  });
+});
+
 describe("<AdminUsersClient> sheet", () => {
   it("pushes ?edit=<id> when the row Edit affordance is clicked", async () => {
     const user = userEvent.setup();

--- a/frontend/src/app/admin/users/admin-users-client.tsx
+++ b/frontend/src/app/admin/users/admin-users-client.tsx
@@ -15,6 +15,7 @@ import type { FetchNextPageInput } from "@/lib/pagination/types";
 import { useSheetSearchParam } from "@/lib/url/use-sheet-search-param";
 import { AdminUserProfileSheet } from "./admin-user-profile-sheet";
 import { type AdminUserListItem, AdminUserRow } from "./admin-user-row";
+import { AdminUsersSkeleton } from "./admin-users-skeleton";
 import {
   ADMIN_USERS_PAGE_SIZE,
   AdminRoleFieldsFragment,
@@ -229,7 +230,14 @@ export function AdminUsersClient() {
   }, [hasNextPage, fetchMoreError]);
 
   const fetchingMore = networkStatus === NetworkStatus.fetchMore || (loading && edges.length > 0);
-  const initialLoading = loading && edges.length === 0 && networkStatus !== NetworkStatus.fetchMore;
+  // Show the full-page skeleton only on the very first load (NetworkStatus.loading = 1).
+  // Refetch and setVariables must not re-trigger the skeleton — a refetch mid-session
+  // (e.g. after ConcurrentUpdateError) would unmount the open sheet and lose any banner.
+  const initialLoading = networkStatus === NetworkStatus.loading && edges.length === 0;
+
+  if (initialLoading) {
+    return <AdminUsersSkeleton />;
+  }
 
   return (
     <main className="p-8">
@@ -304,13 +312,6 @@ export function AdminUsersClient() {
         >
           {rolesBannerError}
         </div>
-      )}
-
-      {/* Loading state */}
-      {initialLoading && (
-        <p className="text-sm text-muted-foreground" data-testid="admin-users-loading">
-          Loading...
-        </p>
       )}
 
       {/* Empty state */}

--- a/frontend/src/app/admin/users/admin-users-skeleton.tsx
+++ b/frontend/src/app/admin/users/admin-users-skeleton.tsx
@@ -1,0 +1,44 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+/**
+ * Loading placeholder for the /admin/users listing route. Mirrors the resolved
+ * page layout to prevent CLS while the server component runs auth checks and
+ * while the Apollo initial query resolves.
+ */
+export function AdminUsersSkeleton() {
+  return (
+    <main className="p-8">
+      <div className="mb-6 flex items-center gap-4">
+        <Skeleton className="h-8 w-24" />
+        <Skeleton className="h-4 w-8" />
+      </div>
+
+      <div className="mb-6">
+        <Skeleton className="h-10 w-full" />
+      </div>
+
+      <ul
+        className="space-y-3"
+        aria-busy="true"
+        aria-label="Loading users"
+        data-testid="admin-users-skeleton"
+      >
+        {Array.from({ length: 5 }).map((_, i) => (
+          // biome-ignore lint/suspicious/noArrayIndexKey: static placeholder rows have no stable id.
+          <li key={i} className="rounded-md border border-border">
+            <div className="flex flex-col gap-4 px-4 py-3 md:flex-row md:items-start">
+              <div className="flex min-w-0 flex-1 items-start gap-4">
+                <Skeleton className="h-10 w-10 shrink-0 rounded-full" />
+                <div className="min-w-0 flex-1 space-y-1">
+                  <Skeleton className="h-4 w-40" />
+                  <Skeleton className="h-3 w-64" />
+                </div>
+              </div>
+              <Skeleton className="h-8 w-16 self-start" />
+            </div>
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/frontend/src/app/admin/users/loading.tsx
+++ b/frontend/src/app/admin/users/loading.tsx
@@ -1,0 +1,10 @@
+import { AdminUsersSkeleton } from "./admin-users-skeleton";
+
+/**
+ * Route-segment navigation fallback. Rendered by Next.js while the server
+ * component tree for /admin/users is being prepared (the RSC performs an
+ * auth check before streaming the client component).
+ */
+export default function Loading() {
+  return <AdminUsersSkeleton />;
+}

--- a/frontend/src/components/learn/swipe-card-stack.tsx
+++ b/frontend/src/components/learn/swipe-card-stack.tsx
@@ -186,7 +186,7 @@ export function SwipeCardStack<TCard extends SwipeCardData>({
   }
 
   return (
-    <div className="relative h-full max-h-[420px] w-full max-w-xl sm:max-h-[480px]">
+    <div className="relative h-full w-full max-w-xl">
       {cards.slice(0, 3).map((card, index) => (
         <div
           key={card.id}

--- a/frontend/src/lib/security/csp.test.ts
+++ b/frontend/src/lib/security/csp.test.ts
@@ -65,6 +65,26 @@ describe("buildHtmlCsp", () => {
     expect(policy).toContain("report-to csp-endpoint");
   });
 
+  it("omits 'unsafe-eval' from script-src by default (production-safe)", () => {
+    const policy = buildHtmlCsp({
+      nonce: "abc123",
+      supabaseUrl: "https://project-ref.supabase.co",
+    });
+
+    expect(policy).toContain("script-src 'self' 'nonce-abc123'");
+    expect(policy).not.toContain("'unsafe-eval'");
+  });
+
+  it("adds 'unsafe-eval' to script-src when allowUnsafeEval is true (dev only)", () => {
+    const policy = buildHtmlCsp({
+      nonce: "abc123",
+      supabaseUrl: "https://project-ref.supabase.co",
+      allowUnsafeEval: true,
+    });
+
+    expect(policy).toContain("script-src 'self' 'nonce-abc123' 'unsafe-eval'");
+  });
+
   it("throws when nonce is empty", () => {
     expect(() =>
       buildHtmlCsp({ nonce: "", supabaseUrl: "https://project-ref.supabase.co" }),

--- a/frontend/src/lib/security/csp.ts
+++ b/frontend/src/lib/security/csp.ts
@@ -8,6 +8,8 @@ export type HtmlCspOptions = {
   reportUri?: string;
   reportTo?: string;
   speedInsightsOrigin?: string;
+  // Turbopack/React dev mode needs the 'unsafe-eval' source for HMR and React refresh; production never does.
+  allowUnsafeEval?: boolean;
 };
 
 const DEFAULT_REPORT_URI = "/api/csp-report";
@@ -112,6 +114,7 @@ export function buildHtmlCsp({
   reportUri = DEFAULT_REPORT_URI,
   reportTo = DEFAULT_REPORT_TO,
   speedInsightsOrigin = DEFAULT_SPEED_INSIGHTS_ORIGIN,
+  allowUnsafeEval = false,
 }: HtmlCspOptions): string {
   if (nonce.trim().length === 0) {
     throw new Error("nonce is required");
@@ -128,7 +131,7 @@ export function buildHtmlCsp({
     "form-action": ["'self'"],
     "img-src": ["'self'", "data:", "blob:", "https://lh3.googleusercontent.com"],
     "style-src": ["'self'", "'unsafe-inline'"],
-    "script-src": ["'self'", `'nonce-${nonce}'`],
+    "script-src": ["'self'", `'nonce-${nonce}'`, allowUnsafeEval && "'unsafe-eval'"],
     "connect-src": ["'self'", supabaseOrigin, supabaseRealtimeOrigin, speedInsightsOrigin],
     "report-uri": [reportUri],
     "report-to": [reportTo],

--- a/frontend/src/lib/supabase/middleware.ts
+++ b/frontend/src/lib/supabase/middleware.ts
@@ -34,6 +34,7 @@ export async function updateSession(request: NextRequest) {
     cspPolicy = buildHtmlCsp({
       nonce,
       supabaseUrl: env.NEXT_PUBLIC_SUPABASE_URL,
+      allowUnsafeEval: process.env.NODE_ENV !== "production",
     });
   } catch (err) {
     console.error(


### PR DESCRIPTION
## Summary

Adds full-page navigation skeletons to the three admin pages (users, roles, dictionary) so the initial route load shows a structural placeholder instead of a bare "Loading..." line. The skeleton is gated to the very first load only (`NetworkStatus.loading`), so a mid-session refetch never unmounts open UI. Also fixes a flashcard sizing issue on the learn screen and adds a dev-only `'unsafe-eval'` CSP allowance for Turbopack HMR.

## Background / Motivation

- The admin users page rendered a plain `Loading...` text node on first load while the other admin pages had nothing — an inconsistent, jarring first paint.
- The previous `initialLoading` predicate (`loading && edges.length === 0 && networkStatus !== NetworkStatus.fetchMore`) also matched `refetch` and `setVariables`. A mid-session refetch (e.g. after a `ConcurrentUpdateError`) would re-trigger the loading branch, unmount the open sheet, and lose any error banner. Keying strictly on `NetworkStatus.loading` confines the skeleton to the first load.
- Under enforcing CSP, Turbopack/React dev mode needs `'unsafe-eval'` in `script-src` for HMR and React refresh; production never does. This was previously missing, breaking the dev HMR loop under the enforcing policy.
- The swipe card stack had a hardcoded `max-h-[420px]`/`sm:max-h-[480px]` cap that left excess whitespace and prevented the flashcard from filling the available height.

## Changes

### Admin navigation skeletons

- New `admin-users-skeleton.tsx`, `admin-roles-skeleton.tsx`, `admin-dictionary-skeleton.tsx` rendering structural placeholders that match each page's layout.
- New `loading.tsx` route segments for users, roles, and dictionary so the App Router shows the skeleton during RSC streaming.
- `admin-users-client.tsx`: `initialLoading` now keys on `networkStatus === NetworkStatus.loading && edges.length === 0`; early-returns `<AdminUsersSkeleton />`. Removed the old inline `Loading...` text node.

### CSP dev HMR allowance

- `csp.ts`: new `allowUnsafeEval?: boolean` option on `HtmlCspOptions`; when set, `'unsafe-eval'` is appended to `script-src`.
- `middleware.ts`: passes `allowUnsafeEval: process.env.NODE_ENV !== "production"` so the allowance is dev-only.
- `docs/frontend/csp.md`: documents the dev-only `'unsafe-eval'` allowance.

### Learn screen flashcard sizing

- `swipe-card-stack.tsx`: drops the `max-h-[420px]`/`sm:max-h-[480px]` cap so the flashcard fills the available height of the card stack.

### Tests

- `admin-users-client.test.tsx`: asserts the skeleton shows on initial load and hides once data resolves.
- `csp.test.ts`: covers the `allowUnsafeEval` branch (present in dev, absent in prod).

## Verification

```bash
pnpm --filter frontend typecheck
pnpm --filter frontend lint
pnpm --filter frontend test
pnpm --filter frontend build
```

- Admin users/roles/dictionary pages show a structural skeleton on first load, then the real content.
- A mid-session refetch on the users page does not unmount the open sheet or clear a banner.
- Dev HMR works under the enforcing CSP; production CSP carries no `'unsafe-eval'`.
- Learn screen flashcard fills the card-stack height with no excess whitespace.

## Test plan

- [ ] `pnpm --filter frontend test` green.
- [ ] `pnpm --filter frontend build` clean.
- [ ] Admin users/roles/dictionary: skeleton on first load, content after.
- [ ] Users page: trigger a refetch mid-session, confirm open sheet/banner survive.
- [ ] Dev: HMR loop works with no CSP `'unsafe-eval'` violation.
- [ ] Prod build: `script-src` has no `'unsafe-eval'`.
- [ ] Learn screen: flashcard fills available height.

This branch addresses no tracked issue.
