### PR TITLE
fix(playbook): drop item ref from looped task name to silence warning

### DIFF
--- a/playbooks/setup-prod/postapply.yml
+++ b/playbooks/setup-prod/postapply.yml
@@ -338,7 +338,7 @@
 - name: Reconcile dynamic Render env vars from state
   tags: [notion, notion-secrets, postapply]
   block:
-    - name: "PUT /v1/services/{{ render_service_id }}/env-vars/{{ item.key }}"
+    - name: "PUT dynamic env var to Render service {{ render_service_id }}"
       ansible.builtin.uri:
         url: "https://api.render.com/v1/services/{{ render_service_id }}/env-vars/{{ item.key }}"
         method: PUT


### PR DESCRIPTION
No related tracking issue — this fix addresses an Ansible runtime warning observed during a `postapply` run, not filed as a GitHub issue.

## Summary

The looped task that upserts dynamic Render env vars named itself after `{{ item.key }}`, a loop variable that is unbound at the point Ansible renders the task name. Ansible warns on every run that the name references an undefined variable. The task name is now a static `PUT dynamic env var to Render service {{ render_service_id }}` — `render_service_id` is a normal play var that is always bound — so the warning is gone while the name stays descriptive.

## Background / Motivation

- The task name `PUT /v1/services/{{ render_service_id }}/env-vars/{{ item.key }}` interpolated `item.key`, but `item` only exists per-iteration inside the `loop`; Ansible renders the `name` once, before the loop binds `item`, so it logs a "referenced variable in task name" warning each run.
- The warning is pure noise — it does not affect the upsert behaviour — but it clutters every `postapply` log and trains operators to ignore Ansible warnings.

## Changes

### Static loop-task name

- `playbooks/setup-prod/postapply.yml`: drop the `{{ item.key }}` reference from the looped task's `name`, leaving the always-bound `render_service_id`. The `url` field still interpolates `{{ item.key }}` (correct there — it is rendered per-iteration); only the `name` is made static.

## Verification

```bash
ansible-lint playbooks/setup-prod/postapply.yml
ansible-playbook --syntax-check playbooks/setup-prod/postapply.yml
```

- Run the `postapply` play and confirm no "referenced variable in task name" warning is emitted for the dynamic-env-var reconcile task.
- Confirm each `SUPABASE_*` env var is still upserted per-key against the Render API (the per-iteration `url` still carries `item.key`).

## Test plan

- [ ] `ansible-playbook --syntax-check playbooks/setup-prod/postapply.yml` passes.
- [ ] `postapply` run emits no loop-variable-in-name warning.
- [ ] Each dynamic env var (`SUPABASE_DB_URL`, `SUPABASE_JWKS_URL`, …) is still PUT to the correct per-key Render endpoint.
