### PR TITLE
fix(pwa): stop dark-mode iOS launch black flash

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@
 
 🦩 Swiping Flashcard app — a Go (Echo) backend, a Next.js 16 frontend, and a shared GraphQL schema, with Supabase for Postgres + Auth, and optional Notion page sync that imports cards from Notion pages on a 6-hourly schedule.
 
+## Why Flamingo Armond?
+
+When my child was about one year old, we were playing make-believe, and they handed me a pretend drink. I asked, "What is this drink called?" and without missing a beat, she answered, "Flamingo Armond." The name stuck. It came up again during bath time and kept popping up in our play over the next few years. I loved how it sounded, and I promised myself that if I ever built my own app, I would use that name. This is that app.
+
 ## Architecture
 
 ![Production architecture](docs/images/architecture.png)

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 [![backend CI](https://github.com/yasuflatland-lf/flamingo-armond/actions/workflows/backend.yml/badge.svg?branch=main)](https://github.com/yasuflatland-lf/flamingo-armond/actions/workflows/backend.yml)
 [![frontend CI](https://github.com/yasuflatland-lf/flamingo-armond/actions/workflows/frontend.yml/badge.svg?branch=main)](https://github.com/yasuflatland-lf/flamingo-armond/actions/workflows/frontend.yml)
-[![codecov backend](https://codecov.io/gh/yasuflatland-lf/flamingo-armond/branch/main/graph/badge.svg?flag=backend)](https://codecov.io/gh/yasuflatland-lf/flamingo-armond)
-[![codecov frontend](https://codecov.io/gh/yasuflatland-lf/flamingo-armond/branch/main/graph/badge.svg?flag=frontend)](https://codecov.io/gh/yasuflatland-lf/flamingo-armond)
+[![backend coverage](https://img.shields.io/codecov/c/github/yasuflatland-lf/flamingo-armond?flag=backend&label=backend%20coverage)](https://codecov.io/gh/yasuflatland-lf/flamingo-armond)
+[![frontend coverage](https://img.shields.io/codecov/c/github/yasuflatland-lf/flamingo-armond?flag=frontend&label=frontend%20coverage)](https://codecov.io/gh/yasuflatland-lf/flamingo-armond)
 
-🦩 Swiping Flashcard app — a Go (Echo) backend, a Next.js 16 frontend, and a shared GraphQL schema, with Supabase for Postgres + Auth, and optional Notion page sync that imports cards from Notion pages on a 6-hourly schedule.
+🦩 Swiping Flashcard app (installable PWA) — a Go (Echo) backend, a Next.js 16 frontend, and a shared GraphQL schema, with Supabase for Postgres + Auth, and optional Notion page sync that imports cards from Notion pages on a 6-hourly schedule.
 
 ## Why Flamingo Armond?
 

--- a/docs/frontend/pwa.md
+++ b/docs/frontend/pwa.md
@@ -70,13 +70,13 @@ Unit and component tests cover the registration guard, the production gate, and 
 
 ### Root cause
 
-The app ships a single light theme (no `ThemeProvider` is mounted, so `.dark` is never added and `--background` stays `oklch(1 0 0)`). But the document declared no `color-scheme`. On an iOS standalone PWA whose device is in **dark mode**, Safari applies the system dark appearance to the UA *canvas* — the backdrop painted before `<body>`'s `bg-background` white (and the coral `BootSplash`) reach the screen. The result is a black flash on every launch, even though every painted surface is light or coral.
+The app currently renders light-only — no `ThemeProvider` or `prefers-color-scheme` toggle is wired, so the dormant `.dark` block in `globals.css` is never activated and `--background` stays `oklch(1 0 0)`. But the document declared no `color-scheme`. On an iOS standalone PWA whose device is in **dark mode**, Safari applies the system dark appearance to the UA *canvas* — the backdrop painted before `<body>`'s `bg-background` white (and the coral `BootSplash`) reach the screen. The result is a black flash on every launch, even though every painted surface is light or coral.
 
 ### Fix
 
 Declare the scheme as light in two places, both correct for a light-only app:
 
-- `frontend/src/app/layout.tsx` — `viewport.colorScheme = "light"`, which emits `<meta name="color-scheme" content="light">`. The meta is parsed in `<head>` before first paint, so it governs the pre-paint canvas appearance — the exact interval where the black flash occurs.
+- `frontend/src/app/layout.tsx` — sets `colorScheme: "light"` in the `viewport` export, which emits `<meta name="color-scheme" content="light">`. The meta is parsed in `<head>` before first paint, so it governs the pre-paint canvas appearance — the exact interval where the black flash occurs.
 - `frontend/src/app/globals.css` — `:root { color-scheme: light; }`, the CSS-level declaration that keeps the canvas, scrollbars, and form controls light once styles apply.
 
 This is correct precisely because the app is light-only; it never wants the dark canvas. `frontend/src/app/layout.test.tsx` pins `viewport.colorScheme === "light"` so the meta cannot silently regress.

--- a/docs/frontend/pwa.md
+++ b/docs/frontend/pwa.md
@@ -66,6 +66,25 @@ The Supabase auth middleware matcher in `frontend/src/middleware.ts` excludes `s
 
 Unit and component tests cover the registration guard, the production gate, and the dev-cleanup path (`frontend/src/components/pwa/sw-register.test.tsx`), as well as the install-hint logic (`frontend/src/components/pwa/apple-install-hint.test.tsx`). The service worker's *runtime* behaviour — offline-fallback rendering, install-time precache population, the actual install flow — cannot be exercised in the test environment because service workers require a secure context. Validating that path requires a real HTTPS device or a deployment.
 
+## PWA black-flash on dark-mode iOS — `color-scheme: light`
+
+### Root cause
+
+The app ships a single light theme (no `ThemeProvider` is mounted, so `.dark` is never added and `--background` stays `oklch(1 0 0)`). But the document declared no `color-scheme`. On an iOS standalone PWA whose device is in **dark mode**, Safari applies the system dark appearance to the UA *canvas* — the backdrop painted before `<body>`'s `bg-background` white (and the coral `BootSplash`) reach the screen. The result is a black flash on every launch, even though every painted surface is light or coral.
+
+### Fix
+
+Declare the scheme as light in two places, both correct for a light-only app:
+
+- `frontend/src/app/layout.tsx` — `viewport.colorScheme = "light"`, which emits `<meta name="color-scheme" content="light">`. The meta is parsed in `<head>` before first paint, so it governs the pre-paint canvas appearance — the exact interval where the black flash occurs.
+- `frontend/src/app/globals.css` — `:root { color-scheme: light; }`, the CSS-level declaration that keeps the canvas, scrollbars, and form controls light once styles apply.
+
+This is correct precisely because the app is light-only; it never wants the dark canvas. `frontend/src/app/layout.test.tsx` pins `viewport.colorScheme === "light"` so the meta cannot silently regress.
+
+### Why not the apple-touch-startup-image
+
+A mismatched `apple-touch-startup-image` produces a *sustained* black launch screen, not a brief flash. The observed symptom was a brief black flash that resolved into the app — the canvas-appearance issue above, not startup-image coverage. The startup images remain a separate concern (see the Interval A section).
+
 ## PWA white-screen fix: de-blocking the root layout (Interval B)
 
 ### Root cause

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -4,6 +4,9 @@
 @custom-variant dark (&:is(.dark *));
 
 :root {
+  /* Light-only app: keep the UA canvas light so an iOS standalone PWA on a
+     dark-mode device does not flash a black backdrop before the page paints. */
+  color-scheme: light;
   --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);
   --card: oklch(1 0 0);

--- a/frontend/src/app/layout.test.tsx
+++ b/frontend/src/app/layout.test.tsx
@@ -56,7 +56,7 @@ vi.mock("@vercel/speed-insights/next", () => ({
 // Import after mocks are registered.
 // ---------------------------------------------------------------------------
 
-import RootLayout from "@/app/layout";
+import RootLayout, { viewport } from "@/app/layout";
 
 // ---------------------------------------------------------------------------
 // Helper: recursive element finder
@@ -188,5 +188,17 @@ describe("RootLayout — structural branch selection", () => {
 
     const suspenseEl = findElement(tree, isSuspense);
     expect(suspenseEl).toBeNull();
+  });
+});
+
+describe("viewport metadata", () => {
+  // Pins the iOS dark-mode black-flash fix: a light-only app must declare
+  // color-scheme: light so the standalone PWA canvas stays light on dark devices.
+  test("pins the scheme to light so a dark-mode iOS PWA does not flash a black canvas", () => {
+    expect(viewport.colorScheme).toBe("light");
+  });
+
+  test("keeps the brand theme color", () => {
+    expect(viewport.themeColor).toBe("#FF6F79");
   });
 });

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -80,6 +80,10 @@ export const metadata: Metadata = {
 
 export const viewport: Viewport = {
   themeColor: "#FF6F79",
+  // The app ships a single light theme. Without this, an iOS standalone PWA on a
+  // device in dark mode paints the UA canvas dark, producing a black flash before
+  // the body/BootSplash paint. Pinning the scheme to light keeps the canvas light.
+  colorScheme: "light",
 };
 
 export default async function RootLayout({ children }: { children: ReactNode }) {


### PR DESCRIPTION
> No related tracking issue — implemented directly from a PWA-launch report, not filed as a GitHub issue.

## Summary

Launching the installed PWA on a dark-mode iOS device flashed a black screen on every launch, because the light-only app declared no `color-scheme` and Safari painted the standalone canvas in the system dark appearance before the page painted. This pins the scheme to light, and refreshes the README (name-origin story, per-target coverage-badge labels, and a PWA note).

## Background / Motivation

- The app ships a single light theme (no `ThemeProvider` is mounted, so `.dark` is never applied and `--background` stays `oklch(1 0 0)`), yet the document declared no `color-scheme`. On an iOS standalone PWA whose device is in dark mode, Safari renders the UA canvas — the backdrop shown before `<body>`'s `bg-background` and the coral `BootSplash` paint — in dark appearance, i.e. black.
- The symptom is a brief black flash that resolves into the app — the canvas-appearance issue above, not an `apple-touch-startup-image` mismatch (that produces a sustained black launch screen).
- The two codecov badges both rendered the label "codecov" because codecov's `badge.svg` ignores a custom `&label=`, so backend vs frontend coverage was indistinguishable at a glance.
- The README had no record of where the project name came from, and did not state that the app is an installable PWA.

## Changes

### Dark-mode iOS black-flash fix

- `frontend/src/app/layout.tsx`: `viewport.colorScheme = "light"` — emits `<meta name="color-scheme" content="light">`, parsed in `<head>` before first paint, so it governs the pre-paint canvas appearance where the black flash occurs.
- `frontend/src/app/globals.css`: `:root { color-scheme: light; }` — keeps the canvas, scrollbars, and form controls light once styles apply.

### README

- New "Why Flamingo Armond?" section telling the origin of the project name.
- Replaced the two identical "codecov" badges with shields.io codecov badges labeled `backend coverage` and `frontend coverage` via `&flag=` + `&label=`.
- Tagline now notes the app is an installable PWA.

### Tests

- `frontend/src/app/layout.test.tsx`: a `viewport metadata` block pins `viewport.colorScheme === "light"` (and the brand `themeColor`) so the meta cannot silently regress.

### Docs

- `docs/frontend/pwa.md`: a "black-flash on dark-mode iOS" section documenting the root cause, the two-part `color-scheme: light` fix, and why it is not the `apple-touch-startup-image`.

## Verification

```bash
pnpm --filter frontend typecheck
pnpm --filter frontend test layout
```

## Test plan

- [ ] `pnpm --filter frontend typecheck` passes.
- [ ] `pnpm --filter frontend test layout` passes, including the `viewport.colorScheme === "light"` regression test.
- [ ] On a dark-mode iPhone, relaunch the installed PWA from the home screen and confirm there is no black flash on launch (cannot be unit-tested — standalone canvas behavior needs a real device).
- [ ] On the rendered GitHub README, confirm the two coverage badges read "backend coverage" and "frontend coverage".
