### PR TITLE
fix(frontend): keep admin user row on one line on narrow screens

### DIFF
--- a/frontend/src/app/admin/users/admin-user-row.tsx
+++ b/frontend/src/app/admin/users/admin-user-row.tsx
@@ -40,8 +40,8 @@ export function AdminUserRow({ user, onEdit }: Props) {
       className="rounded-md border border-border transition-colors hover:bg-accent"
       data-testid={`admin-user-row-${user.id}`}
     >
-      <div className="flex flex-col gap-4 px-4 py-3 md:flex-row md:items-start">
-        <div className="flex min-w-0 flex-1 items-start gap-4">
+      <div className="flex items-center gap-4 px-4 py-3">
+        <div className="flex min-w-0 flex-1 items-center gap-4">
           {user.avatarUrl ? (
             <Image
               src={user.avatarUrl}
@@ -71,7 +71,7 @@ export function AdminUserRow({ user, onEdit }: Props) {
           type="button"
           variant="outline"
           size="sm"
-          className="self-start"
+          className="shrink-0"
           onClick={() => onEdit(user.id)}
           aria-label={`Edit ${user.displayName ?? "user"}`}
         >

--- a/frontend/src/app/cardgroups/[id]/cards/components/card-row.test.tsx
+++ b/frontend/src/app/cardgroups/[id]/cards/components/card-row.test.tsx
@@ -64,6 +64,20 @@ describe("<CardRow>", () => {
     expect(cls).toContain("motion-reduce:opacity-100");
   });
 
+  it("gates pointer-events on the same variants as opacity (hidden button is non-clickable)", () => {
+    // opacity:0 alone leaves the button clickable, so on a narrow viewport (sm:
+    // hover variant inactive) the invisible Delete button would steal a row tap
+    // and delete the card. pointer-events must track the exact opacity variants
+    // so "visible ⟺ clickable" holds at every breakpoint.
+    renderCardRow();
+
+    const cls = screen.getByTestId(`card-delete-${CARD.id}`).className;
+    expect(cls).toContain("pointer-events-none");
+    expect(cls).toContain("sm:group-hover:pointer-events-auto");
+    expect(cls).toContain("sm:group-focus-within:pointer-events-auto");
+    expect(cls).toContain("motion-reduce:pointer-events-auto");
+  });
+
   it("wraps the row content in SwipeableRow", () => {
     renderCardRow();
 

--- a/frontend/src/app/cardgroups/[id]/cards/components/card-row.tsx
+++ b/frontend/src/app/cardgroups/[id]/cards/components/card-row.tsx
@@ -72,7 +72,7 @@ export function CardRow({
             aria-label="Delete card"
             onClick={onDelete}
             data-testid={`card-delete-${card.id}`}
-            className="opacity-0 sm:group-hover:opacity-100 sm:group-focus-within:opacity-100 motion-reduce:opacity-100 transition-opacity"
+            className="pointer-events-none opacity-0 sm:group-hover:pointer-events-auto sm:group-hover:opacity-100 sm:group-focus-within:pointer-events-auto sm:group-focus-within:opacity-100 motion-reduce:pointer-events-auto motion-reduce:opacity-100 transition-opacity"
           >
             <Trash2 aria-hidden="true" className="h-4 w-4" />
           </Button>

--- a/frontend/src/app/cardgroups/[id]/cards/components/card-row.tsx
+++ b/frontend/src/app/cardgroups/[id]/cards/components/card-row.tsx
@@ -26,12 +26,12 @@ export function CardRow({
 }: CardRowProps) {
   return (
     <SwipeableRow ref={rowRef} onDelete={onDelete} disabled={disabled} ariaLabel="Delete card">
-      <div className="group flex items-start justify-between gap-4 px-4 py-3 hover:bg-accent active:bg-accent transition-colors">
+      <div className="group flex items-center justify-between gap-4 px-4 py-3 hover:bg-accent active:bg-accent transition-colors">
         {/* biome-ignore lint/a11y/noStaticElementInteractions: span is a click/keydown stopper, not an interactive element; the inner <input> is the actual control. */}
         <span
           onClick={(e) => e.stopPropagation()}
           onKeyDown={(e) => e.stopPropagation()}
-          className="mt-0.5 shrink-0"
+          className="shrink-0"
         >
           <input
             type="checkbox"

--- a/frontend/src/components/cardgroups/cardgroup-list-item.test.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-list-item.test.tsx
@@ -95,6 +95,23 @@ describe("<CardgroupListItem>", () => {
   });
 
   // -------------------------------------------------------------------------
+  // pointer-events must track opacity so the invisible button is never clickable
+  // -------------------------------------------------------------------------
+
+  it("gates pointer-events on the same variants as opacity (hidden button is non-clickable)", () => {
+    // The hover Delete affordance is opacity-0 by default. opacity:0 alone does
+    // not block clicks, so on a narrow viewport (sm: hover variant inactive) the
+    // invisible button would still steal a row click and delete the row. Pairing
+    // pointer-events-none/auto with the exact opacity variants keeps "visible ⟺
+    // clickable" true at every breakpoint.
+    renderItem({ id: "cg-1", name: "My Flashcards", updatedAt: fixedDate });
+    const deleteBtn = screen.getByRole("button", { name: /delete cardgroup my flashcards/i });
+    expect(deleteBtn.className).toContain("pointer-events-none");
+    expect(deleteBtn.className).toContain("sm:group-hover:pointer-events-auto");
+    expect(deleteBtn.className).toContain("motion-reduce:pointer-events-auto");
+  });
+
+  // -------------------------------------------------------------------------
   // prefers-reduced-motion: reduce — Trash icon remains visible and accessible
   // -------------------------------------------------------------------------
 

--- a/frontend/src/components/cardgroups/cardgroup-list-item.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-list-item.tsx
@@ -33,7 +33,7 @@ export function CardgroupListItem({
         <Button
           variant="outline"
           size="icon"
-          className="opacity-0 sm:group-hover:opacity-100 motion-reduce:opacity-100 transition-opacity"
+          className="pointer-events-none opacity-0 sm:group-hover:pointer-events-auto sm:group-hover:opacity-100 motion-reduce:pointer-events-auto motion-reduce:opacity-100 transition-opacity"
           onClick={requestDelete}
           disabled={busy}
           aria-label={deleteLabel}


### PR DESCRIPTION
> No related tracking issue — implemented directly from a screenshot report, not filed as a GitHub issue.

## Summary

Each row in the admin Users list (`/admin/users`) wrapped the Edit button onto a second line on narrow (mobile) screens. The row now stays on a single line at every width — avatar and name on the left, Edit button on the right.

## Background / Motivation

- `frontend/src/app/admin/users/admin-user-row.tsx` used `flex flex-col ... md:flex-row md:items-start`, so below the `md` breakpoint (on phones, including the installed iOS PWA) the Edit button stacked under the avatar/name as a second row.
- The Users list is primarily viewed on mobile, where the two-row layout wasted vertical space and looked broken.

## Changes

### Single-line admin user row

- The row container is now always `flex items-center gap-4` (dropped the `flex-col` / `md:flex-row` responsive switch), so avatar, name, and Edit sit on one line at every width.
- The avatar+name block is `items-center`; the name keeps `min-w-0 flex-1` so a long display name truncates with an ellipsis instead of forcing a wrap.
- The Edit button changed from `self-start` to `shrink-0`, so it holds its width and sits at the right edge.

## Verification

Open `/admin/users` on a narrow viewport (or the installed iOS PWA). Each row (`data-testid="admin-user-row-<id>"`) shows the avatar, name, and the Edit button (`aria-label="Edit <name>"`) on a single line; a long display name truncates rather than wrapping.

## Test plan

- [ ] `pnpm --filter frontend test admin-user-row` passes (identity render + onEdit click).
- [ ] On a narrow viewport, `/admin/users` rows show avatar + name + Edit on one line.
- [ ] A user with a long display name truncates the name instead of wrapping or pushing Edit to a second row.
