### PR TITLE
refactor(frontend): model step-1 button spec as a discriminated union

### DIFF
--- a/frontend/src/components/cardgroups/cardgroup-batch-import-form.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-batch-import-form.tsx
@@ -54,17 +54,25 @@ type Step1ButtonState = {
   hasText: boolean;
   validating: boolean;
   result: ValidationResult | null;
-  /** True when the textarea was edited since the last successful validate. */
+  /**
+   * True when the textarea was edited since the last successful validate. Only
+   * inspected when `result?.valid === true`; it is ignored on every other
+   * branch, so `{ result: null, isStale: true }` is a meaningless but harmless
+   * input combination.
+   */
   isStale: boolean;
 };
 
 type Step1ButtonAction = "validate" | "continue";
 
-type Step1ButtonSpec = {
-  label: string;
-  action: Step1ButtonAction | null;
-  disabled: boolean;
-};
+/**
+ * Discriminated on `action`: a button with no action is always disabled, and a
+ * button with an action is always enabled. This makes the phantom
+ * `{ action: null, disabled: false }` state unrepresentable.
+ */
+type Step1ButtonSpec =
+  | { action: null; label: string; disabled: true }
+  | { action: Step1ButtonAction; label: string; disabled: false };
 
 /**
  * Pure state machine for the step-1 forward button. A string discriminant for


### PR DESCRIPTION
> Closes #270 — a deferred type-expression refactor split out of the stepper redesign (#271) to keep that change focused.

## Summary

Models `Step1ButtonSpec` in `cardgroup-batch-import-form.tsx` as a discriminated union keyed on `action`, so the phantom `{ action: null, disabled: false }` state becomes unrepresentable and `disabled` is provable from `action`. Type-expression only — `resolveStep1Button`, its consumers, and runtime behavior are unchanged.

## Background / Motivation

- The flat `{ label; action: Step1ButtonAction | null; disabled: boolean }` shape permitted combinations the function never produces — notably `{ action: null, disabled: false }` (no action yet not disabled).
- `disabled` was logically derivable from whether `action` is `null`, but the type did not encode that "no action ⟺ disabled" implication, leaving it to convention.
- `Step1ButtonState.isStale` is only meaningful when `result` is a valid result, so `{ result: null, isStale: true }` is a dead but undocumented combination.

## Changes

### `Step1ButtonSpec` discriminated union

- Replaced the flat object type with `{ action: null; label; disabled: true } | { action: Step1ButtonAction; label; disabled: false }`. The existing `resolveStep1Button` return shapes already satisfy both variants, so the function body is untouched; consumers (`buttonSpec.action`, `buttonSpec.disabled`) narrow correctly with no changes.

### `Step1ButtonState.isStale` documentation

- Kept `isStale` as a plain `boolean` field and documented that it is only inspected when `result?.valid === true`. The relationship is consumer-logic, not an intrinsic data invariant — the call site assembles the state from four independent `useState` values, so a union here would force a needless branch at the producer without expressing a real domain rule.

## Verification

```bash
pnpm --filter frontend typecheck             # tsc --noEmit, clean
pnpm --filter frontend lint                  # biome --error-on-warnings, no errors
pnpm --filter frontend test                  # 959 pass
```

## Test plan

- [x] `cardgroup-batch-import-form.test.tsx` — 20 pass / 0 fail (the 6 `resolveStep1Button` unit tests pass unchanged; `toEqual` compares runtime values, which are identical).
- [x] `tsc --noEmit` — the union narrows at both consumer sites with no errors.
- [x] No runtime behavior change — function body and all call sites are byte-identical aside from the type annotation.
