### PR TITLE
fix(playbooks): harden setup-prod/teardown-prod bring-up

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -393,7 +393,7 @@ ansible-playbook playbooks/teardown-prod.yml --tags <phase>   # single phase
 
 ### Mode flags
 
-- **`rescue=true`**: switches to advisory mode when `.setup-prod.state.yml` is missing (e.g. lost laptop or a different machine than the one used for bring-up). The operator must supply `vercel_project_id`, `render_service_id`, and `supabase_project_ref` via `-e` overrides on the `ansible-playbook` command line.
+- **`advisory_mode=true`**: switches to advisory mode when `.setup-prod.state.yml` is missing (e.g. lost laptop or a different machine than the one used for bring-up). The operator must supply `vercel_project_id`, `render_service_id`, and `supabase_project_ref` via `-e` overrides on the `ansible-playbook` command line.
 - **`confirm=true`**: bypasses the operator name-retype prompt. **Rejected at preflight unless `testing=true` is also set** — this is the hard barrier preventing CI from accidentally running a real teardown.
 
 ### The name-retype safety prompt
@@ -412,7 +412,7 @@ After a successful retype, the playbook also verifies that the bearer token's te
 | `resource_id` | Provider-assigned ID |
 | `name` | Resource name at time of deletion |
 | `team` | Team or org that owned the resource |
-| `teardown_mode` | `strict` (state file present) or `advisory` (rescue mode) |
+| `teardown_mode` | `strict` (state file present) or `advisory` (advisory_mode=true) |
 | `phase` | `vercel`, `render`, or `supabase` |
 | `delete_status` | `deleted`, `already_gone`, or `failed` |
 | `http_status` | HTTP status code returned by the provider |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -154,7 +154,7 @@ Four steps across the three providers. Allow about 30 minutes total; Supabase pr
 
 ### Step 1 — Supabase
 
-1. Create a new Supabase project (record region and DB password). Region matters for latency — keep it close to the Render region (the local default elsewhere in this repo is `ap-northeast-1`).
+1. Create a new Supabase project (record region and DB password). Region matters for latency — keep it close to the Render region (the repo-wide default is `ap-southeast-1`, Singapore, matching Render's `singapore` and Vercel's `sin1`).
 2. **Authentication → Sign In / Up**: enable Google OAuth. Paste the Client ID and secret from Manual prerequisites § 3.
 3. Capture the values that other providers need:
 
@@ -177,6 +177,7 @@ The structural config of the backend service lives in `render.yaml` at the repo 
 | Setting | Source |
 |---|---|
 | Root directory | `render.yaml` → `services[0].rootDir` (`backend`) |
+| Region | `render.yaml` → `services[0].region` (`singapore`) |
 | Build command | `render.yaml` → `services[0].buildCommand` (`go mod download && go tool gqlgen generate && go build -o main ./cmd/server`). The codegen step is required because `backend/graph/generated/` and `graph/model/models_gen.go` are gitignored; CI regenerates them the same way (see `.github/workflows/backend.yml`). |
 | Start command | `render.yaml` → `services[0].startCommand` (`./main`) |
 | Health check path | `render.yaml` → `services[0].healthCheckPath` (`/health`) |
@@ -234,7 +235,7 @@ Removing an email from `SUPER_USER_EMAILS` does **not** revoke a previously gran
 
 ### Step 3 — Vercel
 
-Import the repo with **Root Directory: `frontend`**, framework **Next.js**.
+Import the repo with **Root Directory: `frontend`**, framework **Next.js**. The function region is pinned to `sin1` (Singapore) by `frontend/vercel.json` → `regions` — no dashboard region step is required.
 
 Set these env vars (scopes given for the manual path; `make setup-prod` Phase 4 registers them via the Vercel API automatically — leave the wizard's Environment Variables section empty when running the automated path):
 

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "regions": ["sin1"]
+}

--- a/playbooks/setup-prod/postapply.yml
+++ b/playbooks/setup-prod/postapply.yml
@@ -7,17 +7,25 @@
 #
 # Flow:
 #   1. Load state and verify the keys this phase depends on.
-#   2. Pull RENDER_API_KEY and VERCEL_API_TOKEN from the environment.
+#   2. Pull RENDER_API_KEY and VERCEL_API_TOKEN from the environment, and
+#      validate that the required NOTION_* env vars are present in root .env.
 #   3. POST a deploy to Vercel (gitSource: main) so it rebuilds with the env
 #      vars Phase 4 registered. We don't poll Vercel: the build (~1-2 min) runs
 #      in parallel with the Render poll below, finishing well before the
 #      front-end HEAD probe.
-#   4. POST a deploy to Render and capture the deploy id.
-#   5. Poll the Render deploy until it reaches "live" (max 15 min, fast-fail
+#   4. Resolve the Notion owner UUID from NOTION_TARGET_OWNER_EMAIL against the
+#      production auth.users table. This runs AFTER the Vercel deploy on
+#      purpose: the email row only exists once the owner has signed in to the
+#      live frontend, so the deploy that enables sign-in must fire first. On a
+#      fresh bring-up the FIRST pass stops here (no row yet) -- sign in once,
+#      then re-run `make setup-prod-postapply` to complete in a second pass.
+#   5. Reconcile the dynamic Render env vars, then POST a deploy to Render and
+#      capture the deploy id.
+#   6. Poll the Render deploy until it reaches "live" (max 15 min, fast-fail
 #      on build_failed / update_failed / canceled / deactivated /
 #      pre_deploy_failed).
-#   6. Smoke test backend /health, GraphQL /query, and the production URL HEAD.
-#   7. Print the three URLs and remind the operator that the /profile E2E
+#   7. Smoke test backend /health, GraphQL /query, and the production URL HEAD.
+#   8. Print the three URLs and remind the operator that the /profile E2E
 #      check is a manual step (Google sign-in required).
 #
 # Re-run safety: this phase has no state writes, so re-running is harmless --
@@ -135,78 +143,6 @@
   tags: [preflight, notion-preflight, notion, notion-secrets, postapply]
 
 # ---------------------------------------------------------------------------
-# Resolve NOTION_TARGET_OWNER_ID.
-#
-# Two paths are supported:
-#   1. NOTION_TARGET_OWNER_EMAIL (preferred) -- psql queries the production
-#      Supabase auth.users table using supabase_db_url from the state file,
-#      resolves the email to a UUID, and stores it as _notion_owner_id.
-#      The target account must have signed in to the production app at least
-#      once so the row exists.
-#   2. NOTION_TARGET_OWNER_ID (manual fallback) -- operator supplies the UUID
-#      directly in root .env; _notion_owner_id is set from that value.
-#
-# When NOTION_TARGET_OWNER_EMAIL is set it takes precedence; the fallback is
-# only used when the email key is absent or blank.
-# ---------------------------------------------------------------------------
-- name: Resolve NOTION_TARGET_OWNER_EMAIL to a UUID
-  when: (lookup('env', 'NOTION_TARGET_OWNER_EMAIL') | default('')) | trim | length > 0
-  tags: [notion, notion-secrets, postapply]
-  block:
-    - name: Validate NOTION_TARGET_OWNER_EMAIL format
-      ansible.builtin.fail:
-        msg: |
-          NOTION_TARGET_OWNER_EMAIL does not look like a valid email address:
-            {{ lookup('env', 'NOTION_TARGET_OWNER_EMAIL') | trim }}
-          Fix the value in root .env and re-run.
-      when: >-
-        not (lookup('env', 'NOTION_TARGET_OWNER_EMAIL') | trim
-             | regex_search('^[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}$'))
-
-    - name: Resolve NOTION_TARGET_OWNER_EMAIL to UUID in auth.users
-      # psql interpolates `:'var'` only for queries read from stdin or -f,
-      # never for queries passed via -c. Pipe the SQL through stdin so the
-      # email is bound as a quoted literal (psql escapes it) instead of being
-      # string-concatenated into the query.
-      ansible.builtin.command:
-        argv:
-          - psql
-          - "{{ supabase_db_url }}"
-          - -v
-          - "ON_ERROR_STOP=1"
-          - -v
-          - "email={{ lookup('env', 'NOTION_TARGET_OWNER_EMAIL') | trim }}"
-          - -t
-          - -A
-        stdin: "SELECT id FROM auth.users WHERE lower(email) = lower(:'email');"
-      register: _notion_owner_uuid_result
-      changed_when: false
-
-    - name: Fail if email not found in auth.users
-      ansible.builtin.fail:
-        msg: |
-          No auth.users row for {{ lookup('env', 'NOTION_TARGET_OWNER_EMAIL') }}.
-          The account must have signed in to the production app at least once before this step.
-      when: (_notion_owner_uuid_result.stdout | trim) | length == 0
-
-    - name: Fail if duplicate email rows found in auth.users
-      ansible.builtin.fail:
-        msg: |
-          Duplicate email in production auth.users; manual review required.
-          Email: {{ lookup('env', 'NOTION_TARGET_OWNER_EMAIL') }}
-      when: (_notion_owner_uuid_result.stdout | trim).split('\n') | length > 1
-
-    - name: Store resolved owner UUID from email
-      ansible.builtin.set_fact:
-        _notion_owner_id: "{{ _notion_owner_uuid_result.stdout | trim }}"
-
-- name: Use NOTION_TARGET_OWNER_ID when email resolution is skipped
-  ansible.builtin.set_fact:
-    _notion_owner_id: "{{ lookup('env', 'NOTION_TARGET_OWNER_ID') | default('') }}"
-  when: (lookup('env', 'NOTION_TARGET_OWNER_EMAIL') | default('')) | trim | length == 0
-  tags: [notion, notion-secrets, postapply]
-
-# ---------------------------------------------------------------------------
 # Precheck: Blueprint Manual Sync has been run for the current render.yaml.
 #
 # render.yaml is the source of truth for static env-var values (APP_ENV,
@@ -313,6 +249,95 @@
 - name: Show the Vercel deploy id (operator can cross-check the dashboard)
   ansible.builtin.debug:
     msg: "Vercel deploy kicked: {{ vercel_deploy_id }} (build runs in parallel with Render poll)"
+
+# ---------------------------------------------------------------------------
+# Resolve NOTION_TARGET_OWNER_ID.
+#
+# This runs AFTER the Vercel deploy on purpose. Path 1 below resolves the
+# owner email against the production auth.users table, and that row only
+# exists once the owner has signed in to the live frontend. The deploy that
+# makes sign-in possible must therefore fire first; placing this block before
+# the deploy would dead-lock a fresh bring-up (no app -> no sign-in -> no row
+# -> the resolution fails before the deploy that would have unblocked it).
+#
+# Two paths are supported:
+#   1. NOTION_TARGET_OWNER_EMAIL (preferred) -- psql queries the production
+#      Supabase auth.users table using supabase_db_url from the state file,
+#      resolves the email to a UUID, and stores it as _notion_owner_id.
+#      The target account must have signed in to the production app at least
+#      once so the row exists.
+#   2. NOTION_TARGET_OWNER_ID (manual fallback) -- operator supplies the UUID
+#      directly in root .env; _notion_owner_id is set from that value.
+#
+# When NOTION_TARGET_OWNER_EMAIL is set it takes precedence; the fallback is
+# only used when the email key is absent or blank.
+# ---------------------------------------------------------------------------
+- name: Resolve NOTION_TARGET_OWNER_EMAIL to a UUID
+  when: (lookup('env', 'NOTION_TARGET_OWNER_EMAIL') | default('')) | trim | length > 0
+  tags: [notion, notion-secrets, postapply]
+  block:
+    - name: Validate NOTION_TARGET_OWNER_EMAIL format
+      ansible.builtin.fail:
+        msg: |
+          NOTION_TARGET_OWNER_EMAIL does not look like a valid email address:
+            {{ lookup('env', 'NOTION_TARGET_OWNER_EMAIL') | trim }}
+          Fix the value in root .env and re-run.
+      when: >-
+        not (lookup('env', 'NOTION_TARGET_OWNER_EMAIL') | trim
+             | regex_search('^[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}$'))
+
+    - name: Resolve NOTION_TARGET_OWNER_EMAIL to UUID in auth.users
+      # psql interpolates `:'var'` only for queries read from stdin or -f,
+      # never for queries passed via -c. Pipe the SQL through stdin so the
+      # email is bound as a quoted literal (psql escapes it) instead of being
+      # string-concatenated into the query.
+      ansible.builtin.command:
+        argv:
+          - psql
+          - "{{ supabase_db_url }}"
+          - -v
+          - "ON_ERROR_STOP=1"
+          - -v
+          - "email={{ lookup('env', 'NOTION_TARGET_OWNER_EMAIL') | trim }}"
+          - -t
+          - -A
+        stdin: "SELECT id FROM auth.users WHERE lower(email) = lower(:'email');"
+      register: _notion_owner_uuid_result
+      changed_when: false
+
+    - name: Fail if email not found in auth.users
+      ansible.builtin.fail:
+        msg: |
+          No auth.users row for {{ lookup('env', 'NOTION_TARGET_OWNER_EMAIL') }}.
+
+          The Vercel production deploy has already been kicked above, so the
+          frontend is (or will shortly be) live at:
+            {{ production_url }}
+
+          This is the expected first-pass stop on a fresh bring-up:
+            1. Wait for the Vercel build to finish, then sign in once with
+               {{ lookup('env', 'NOTION_TARGET_OWNER_EMAIL') }} so Supabase
+               creates the auth.users row.
+            2. Re-run: make setup-prod-postapply
+          The second pass resolves the UUID and finishes Notion + Render wiring.
+      when: (_notion_owner_uuid_result.stdout | trim) | length == 0
+
+    - name: Fail if duplicate email rows found in auth.users
+      ansible.builtin.fail:
+        msg: |
+          Duplicate email in production auth.users; manual review required.
+          Email: {{ lookup('env', 'NOTION_TARGET_OWNER_EMAIL') }}
+      when: (_notion_owner_uuid_result.stdout | trim).split('\n') | length > 1
+
+    - name: Store resolved owner UUID from email
+      ansible.builtin.set_fact:
+        _notion_owner_id: "{{ _notion_owner_uuid_result.stdout | trim }}"
+
+- name: Use NOTION_TARGET_OWNER_ID when email resolution is skipped
+  ansible.builtin.set_fact:
+    _notion_owner_id: "{{ lookup('env', 'NOTION_TARGET_OWNER_ID') | default('') }}"
+  when: (lookup('env', 'NOTION_TARGET_OWNER_EMAIL') | default('')) | trim | length == 0
+  tags: [notion, notion-secrets, postapply]
 
 # ---------------------------------------------------------------------------
 # Reconcile the dynamic Render env vars from state before triggering deploy.

--- a/playbooks/setup-prod/postapply.yml
+++ b/playbooks/setup-prod/postapply.yml
@@ -23,9 +23,14 @@
 #      capture the deploy id.
 #   6. Poll the Render deploy until it reaches "live" (max 15 min, fast-fail
 #      on build_failed / update_failed / canceled / deactivated /
-#      pre_deploy_failed).
-#   7. Smoke test backend /health, GraphQL /query, and the production URL HEAD.
-#   8. Print the three URLs and remind the operator that the /profile E2E
+#      pre_deploy_failed). Reaching "live" implies database.Migrate ran on
+#      boot, so the schema (incl. the handle_new_user trigger) now exists.
+#   7. Backfill public.users for any auth.users created before the backend's
+#      first boot applied migrations. The first operator signs in before this
+#      phase can boot the backend, so their auth.users row predates the bridge
+#      trigger and has no public.users row; this heals the gap idempotently.
+#   8. Smoke test backend /health, GraphQL /query, and the production URL HEAD.
+#   9. Print the three URLs and remind the operator that the /profile E2E
 #      check is a manual step (Google sign-in required).
 #
 # Re-run safety: this phase has no state writes, so re-running is harmless --
@@ -739,6 +744,46 @@
 
           Fix the underlying issue, then re-run:
             make setup-prod-postapply
+
+# ---------------------------------------------------------------------------
+# Backfill public.users rows for auth.users that predate the handle_new_user
+# trigger.
+#
+# Migrations -- which create public.users and the auth.users -> public.users
+# bridge trigger -- run only on backend boot (database.Migrate). On a fresh
+# bring-up the first operator MUST sign in before this phase completes: the
+# Notion owner step above gates on their auth.users row, and the backend
+# cannot boot (so cannot migrate) until this phase wires its env and triggers
+# the Render deploy. So the first operator's auth.users row is created before
+# the trigger exists, and no public.users bridge row is made. The Render
+# deploy verified live above has now booted the backend and applied
+# migrations, so the table and trigger exist; this task self-heals that gap
+# idempotently. Later signups are provisioned by the trigger directly.
+#
+# Without the bridge row, updateProfile (onboarding) fails with INTERNAL
+# (the UPDATE matches 0 rows -> ErrNotFound), and seed-admin-prod fails on the
+# user_roles -> public.users foreign key.
+# ---------------------------------------------------------------------------
+- name: Backfill public.users for auth.users created before the trigger existed
+  ansible.builtin.command:
+    argv:
+      - psql
+      - "{{ supabase_db_url }}"
+      - -v
+      - "ON_ERROR_STOP=1"
+      - -c
+      - >-
+        INSERT INTO public.users (id)
+        SELECT u.id FROM auth.users u
+        LEFT JOIN public.users p ON p.id = u.id
+        WHERE p.id IS NULL
+        ON CONFLICT (id) DO NOTHING;
+  register: _backfill_users_result
+  changed_when: "'INSERT 0 0' not in (_backfill_users_result.stdout | default(''))"
+
+- name: Report public.users backfill outcome
+  ansible.builtin.debug:
+    msg: "public.users backfill: {{ _backfill_users_result.stdout | default('(no output)') | trim }}"
 
 - name: Smoke 1 - backend /health returns 200
   block:

--- a/playbooks/setup-prod/postapply.yml
+++ b/playbooks/setup-prod/postapply.yml
@@ -3,7 +3,8 @@
 #
 # Reads:  state file (render_service_id, backend_url, production_url,
 #                     vercel_project_id, vercel_repo_id).
-# Writes: nothing (state is read-only here).
+# Writes: no state-file changes. DB writes: idempotent backfill of
+#         public.users and admin grant to public.user_roles (steps 7-8).
 #
 # Flow:
 #   1. Load state and verify the keys this phase depends on.
@@ -29,12 +30,16 @@
 #      first boot applied migrations. The first operator signs in before this
 #      phase can boot the backend, so their auth.users row predates the bridge
 #      trigger and has no public.users row; this heals the gap idempotently.
-#   8. Smoke test backend /health, GraphQL /query, and the production URL HEAD.
-#   9. Print the three URLs and remind the operator that the /profile E2E
+#   8. Grant the admin role to SUPER_USER_EMAILS now that the bridge row exists
+#      (idempotent). Addresses not yet in auth.users are skipped; the same step
+#      is also available standalone via `make seed-admin-prod`.
+#   9. Smoke test backend /health, GraphQL /query, and the production URL HEAD.
+#  10. Print the three URLs and remind the operator that the /profile E2E
 #      check is a manual step (Google sign-in required).
 #
-# Re-run safety: this phase has no state writes, so re-running is harmless --
-# every invocation triggers a fresh Vercel + Render deploy.
+# Re-run safety: this phase makes no state-file writes; its DB writes (steps
+# 7-8) are idempotent, so re-running is harmless -- every invocation triggers
+# a fresh Vercel + Render deploy.
 
 # Postapply cannot run before Phases 3 + 4 have written state, so a
 # missing file is itself a misuse. Stat first so a missing file vs.
@@ -784,6 +789,23 @@
 - name: Report public.users backfill outcome
   ansible.builtin.debug:
     msg: "public.users backfill: {{ _backfill_users_result.stdout | default('(no output)') | trim }}"
+
+# ---------------------------------------------------------------------------
+# Grant the admin role to SUPER_USER_EMAILS now that the bootstrap gap is
+# healed. The Notion owner gate above already blocked the bring-up until the
+# first operator signed in, and the backfill above guarantees the public.users
+# bridge row exists, so the user_roles -> public.users FK can no longer fail.
+# The grant is idempotent and silently skips any address not yet in auth.users,
+# preserving this phase's re-run safety.
+#
+# These tasks also remain available standalone via `make seed-admin-prod`, for
+# granting additional admins who sign in after this phase completes. The two
+# import sites are tag-isolated: this one inherits the `postapply` tag, while
+# the standalone import in setup-prod.yml carries `seed-admin-prod, never`, so
+# no invocation runs the grant twice.
+# ---------------------------------------------------------------------------
+- name: Seed admin role from SUPER_USER_EMAILS (postapply)
+  ansible.builtin.import_tasks: seed-admin-prod.yml
 
 - name: Smoke 1 - backend /health returns 200
   block:

--- a/playbooks/setup-prod/render.yml
+++ b/playbooks/setup-prod/render.yml
@@ -20,19 +20,24 @@
       backend_url in {{ state_file }} and skip Phase 3 entirely with --skip-tags render.
   when: confirm | bool
 
-# Stat first so YAML parse errors fail loudly instead of being masked by
-# `failed_when: false` on include_vars and surfacing as confusing
-# "missing keys" later in the assert.
+# Stat first so an absent state file produces the clear assert below,
+# distinct from a corrupt-YAML parse error raised by from_yaml when the
+# file is present but malformed.
 - name: Stat state file (Phase 3)
   ansible.builtin.stat:
     path: "{{ state_file }}"
   register: _state_stat
 
+# Read via set_fact (not include_vars) so the load survives a full-sequence
+# `make setup-prod` run. An earlier phase set `existing_state = {}` via
+# set_fact, which outranks include_vars (set_fact > include_vars in Ansible
+# precedence) and would shadow a `include_vars name: existing_state` here,
+# leaving this phase with an empty dict. set_fact + lookup overwrites it.
 - name: Load state file (Phase 3 reads Phase 2 outputs)
-  ansible.builtin.include_vars:
-    file: "{{ state_file }}"
-    name: existing_state
-  when: _state_stat.stat.exists
+  ansible.builtin.set_fact:
+    existing_state: >-
+      {{ (lookup('file', state_file) | from_yaml)
+         if _state_stat.stat.exists else {} }}
 
 # Coerce to a mapping so `existing_state.<key>` access and `| default(...)`
 # behave consistently when the file is absent, empty, or YAML-null.
@@ -79,16 +84,27 @@
 
       First-time setup:
         1. New > Blueprint, point at {{ repo }} on branch `main`.
-        2. Render reads render.yaml and creates the service
-           `flamingo-backend` with all structural config.
-        3. The static env vars (APP_ENV, GRAPHQL_INTROSPECTION,
+        2. Set Blueprint Name to `flamingo-armond`; leave Blueprint
+           Path blank (it defaults to render.yaml at the repo root).
+        3. Render reads render.yaml and creates the service
+           `flamingo-backend` with all structural config. The static
+           env vars (APP_ENV, GRAPHQL_INTROSPECTION,
            OTEL_TRACES_SAMPLER_ARG, SUPABASE_JWT_AUDIENCE) get their
            values from the Blueprint automatically.
-        4. The dashboard prompts for the `sync: false` placeholders
-           (SUPABASE_DB_URL, SUPABASE_JWKS_URL, SUPABASE_JWT_ISSUER,
-           OTEL_EXPORTER_OTLP_ENDPOINT). Leave them BLANK and click
-           Save - Phase 6 (postapply) writes the Supabase-derived
-           values via the Render API.
+        4. Under "Specified configurations", leave EVERY env-var Value
+           field BLANK - they are all `sync: false` placeholders. Then
+           click "Deploy Blueprint". Phase 6 (postapply) writes the
+           dynamic values (SUPABASE_DB_URL / SUPABASE_JWKS_URL /
+           SUPABASE_JWT_ISSUER, PING_TOKEN, SUPER_USER_EMAILS, NOTION_*)
+           via the Render API; OTEL_EXPORTER_OTLP_ENDPOINT stays empty
+           unless you opt into tracing.
+
+      If the Blueprint Name shows "Name already in use":
+        A `flamingo-armond` Blueprint already exists (a prior setup or
+        an incomplete teardown). Do NOT create a second one. Cancel this
+        form, open Blueprints -> flamingo-armond, confirm the
+        `flamingo-backend` service is present, and reuse it - collect
+        the service ID / URL / deploy hook from that existing service.
 
       Re-applying after render.yaml changes:
         Blueprints -> flamingo-armond -> Manual Sync.
@@ -103,22 +119,39 @@
     prompt: |
 
       Action required in the Render dashboard:
-        1. Apply the Blueprint as described above. Because
+        1. Apply the Blueprint as described above. This CREATES the
+           `flamingo-backend` service: set Blueprint Name to
+           `flamingo-armond`, leave EVERY env-var Value field BLANK,
+           then click "Deploy Blueprint". Because
            `autoDeployTrigger: "off"` is set in render.yaml, no deploy
-           will run yet - Phase 6 (postapply) triggers the first deploy
-           via the Render API. The next steps below do NOT require a
-           completed deploy.
-        2. Copy the service ID (srv-...) from Settings > General.
+           runs yet - Phase 6 (postapply) triggers the first deploy via
+           the Render API, so the steps below do NOT require a completed
+           deploy.
+
+           If "Name already in use" appears, the Blueprint already
+           exists: cancel, open Blueprints -> flamingo-armond, and reuse
+           its `flamingo-backend` service for the values below.
+        2. Copy the service ID (srv-...) from the service's
+           Settings > General.
         3. Copy the service URL (https://....onrender.com) from the top
-           of the page.
+           of the service page.
         4. Copy the deploy hook URL from Settings > Deploy Hook.
 
-      Press Enter when the service is created and you have all three values ready.
+      Press Enter when the service exists and you have all three values ready.
 
 # --- Collect render_service_id (empty input keeps existing) ---
 - name: Prompt for Render service ID
   ansible.builtin.pause:
-    prompt: "Render service ID [current: {{ existing_state.render_service_id | default('(none)') }}] (format: srv-<alphanumeric>; press Enter to keep current)"
+    prompt: |-
+      Render service ID (format: srv-<alphanumeric>).
+      Look on the `flamingo-backend` SERVICE page - NOT the Blueprint page:
+        Blueprints > flamingo-armond > Resources > open `flamingo-backend`
+        > Settings > General > "Service ID".
+      Shortcut: it is the srv-... in the service page URL
+        https://dashboard.render.com/web/srv-...
+      Do NOT paste the Blueprint ID (exs-...) or the Blueprint "Sync Hook".
+
+      Service ID [current: {{ existing_state.render_service_id | default('(none)') }}] (press Enter to keep current)
   register: _render_service_id_input
 
 - name: Resolve render_service_id (keep existing on empty input)
@@ -139,7 +172,13 @@
 # --- Collect backend_url (empty input keeps existing) ---
 - name: Prompt for Render backend URL
   ansible.builtin.pause:
-    prompt: "Render backend URL [current: {{ existing_state.backend_url | default('(none)') }}] (https://...; press Enter to keep current)"
+    prompt: |-
+      Render backend URL (https://...).
+      On the `flamingo-backend` SERVICE page, copy the URL shown at the top
+      of the page, e.g. https://flamingo-backend.onrender.com.
+      A custom domain is fine; it need not end in .onrender.com.
+
+      Backend URL [current: {{ existing_state.backend_url | default('(none)') }}] (press Enter to keep current)
   register: _backend_url_input
 
 - name: Resolve backend_url (keep existing on empty input)
@@ -177,7 +216,14 @@
 # --- Collect deploy hook URL (no_log; empty input keeps existing GH secret if registered) ---
 - name: Prompt for Render deploy hook URL
   ansible.builtin.pause:
-    prompt: "Render deploy hook URL [current: {{ '(registered in GitHub; press Enter to keep)' if deploy_hook_already_registered else '(not registered yet)' }}] (https://api.render.com/deploy/...)"
+    prompt: |-
+      Render deploy hook URL (https://api.render.com/deploy/...).
+      On the `flamingo-backend` SERVICE page: Settings > Deploy Hook.
+      This is the SERVICE deploy hook - NOT the Blueprint "Sync Hook"
+      on the Blueprint settings page (that one starts differently and
+      will be rejected by the format check below).
+
+      Deploy hook URL [current: {{ '(registered in GitHub; press Enter to keep)' if deploy_hook_already_registered else '(not registered yet)' }}]
   no_log: true
   register: _deploy_hook_input
 

--- a/playbooks/setup-prod/supabase.yml
+++ b/playbooks/setup-prod/supabase.yml
@@ -133,7 +133,27 @@
 
     - name: Prompt for Supabase session-pooler DSN
       ansible.builtin.pause:
-        prompt: "Supabase DB URL (Connect -> Session pooler tab; postgres://...?sslmode=require)"
+        prompt: |
+          Supabase DB URL - session-pooler connection string
+          ---------------------------------------------------
+          Where to get it:
+            1. Click the green "Connect" button (top of the dashboard).
+            2. Open the "Direct / Connection string" tab.
+            3. Set Connection Method to "Session pooler"
+               (NOT "Direct connection", NOT "Transaction pooler").
+            4. Copy the string. It looks like:
+               postgres://postgres.<ref>:[YOUR-PASSWORD]@aws-0-<region>.pooler.supabase.com:5432/postgres
+
+          Before pasting, fix two things:
+            - Replace [YOUR-PASSWORD] with the DB password you set at
+              project creation (shown only once; from your password manager).
+            - Append ?sslmode=require to the end.
+
+          The DSN must contain "pooler" and port :5432 (session pooler).
+          Port :6543 is the transaction pooler and will be rejected -
+          golang-migrate's advisory locks need a real session.
+
+          Paste the final DSN here (input is hidden):
         echo: false
       register: db_url_prompt
       no_log: true

--- a/playbooks/setup-prod/supabase.yml
+++ b/playbooks/setup-prod/supabase.yml
@@ -71,7 +71,7 @@
           --------------------------------
           1. Open https://supabase.com/dashboard and create a new project.
              Record the region (keep it close to the Render region; the
-             repo-wide default is ap-northeast-1) and the DB password.
+             repo-wide default is ap-southeast-1, Singapore) and the DB password.
              Store the DB password in your password manager - it is only
              shown once and is not retrievable from the dashboard later.
           2. In the new project, open Authentication -> Sign In / Up and

--- a/playbooks/setup-prod/vercel.yml
+++ b/playbooks/setup-prod/vercel.yml
@@ -28,18 +28,24 @@
       production_url in {{ state_file }} and skip Phase 4 entirely with --skip-tags vercel.
   when: confirm | bool
 
-# Stat first so YAML parse errors fail loudly instead of being masked by
-# `failed_when: false` and surfacing as confusing "missing keys" later.
+# Stat first so an absent state file produces the clear assert below,
+# distinct from a corrupt-YAML parse error raised by from_yaml when the
+# file is present but malformed.
 - name: Stat state file (Phase 4)
   ansible.builtin.stat:
     path: "{{ state_file }}"
   register: _state_stat
 
+# Read via set_fact (not include_vars) so the load survives a full-sequence
+# `make setup-prod` run. An earlier phase set `existing_state = {}` via
+# set_fact, which outranks include_vars (set_fact > include_vars in Ansible
+# precedence) and would shadow a `include_vars name: existing_state` here,
+# leaving this phase with an empty dict. set_fact + lookup overwrites it.
 - name: Load state file (Phase 4 reads Phase 2/3 outputs)
-  ansible.builtin.include_vars:
-    file: "{{ state_file }}"
-    name: existing_state
-  when: _state_stat.stat.exists
+  ansible.builtin.set_fact:
+    existing_state: >-
+      {{ (lookup('file', state_file) | from_yaml)
+         if _state_stat.stat.exists else {} }}
 
 # Coerce to a mapping so `existing_state.<key>` access and `| default(...)`
 # behave consistently when the file is absent, empty, or YAML-null.

--- a/playbooks/setup-prod/vercel.yml
+++ b/playbooks/setup-prod/vercel.yml
@@ -102,6 +102,8 @@
       1. Open https://vercel.com/new and import this repository.
       2. Set Framework Preset to: Next.js
       3. Set Root Directory to: frontend
+         The function region is pinned to sin1 (Singapore) by
+         frontend/vercel.json -- no dashboard region step is needed.
       4. SKIP the Environment Variables section -- leave it empty.
          The playbook registers the three required env vars via the Vercel
          API as soon as you provide the project ID below.

--- a/playbooks/teardown-prod.yml
+++ b/playbooks/teardown-prod.yml
@@ -23,8 +23,8 @@
 #   postapply  -> Phase 5  (archive state file, summary)
 #
 # Mode flags:
-#   rescue=true   switches to advisory mode when the state file is absent;
-#                 requires operator to supply IDs via -e overrides.
+#   advisory_mode=true  switches to advisory mode when the state file is absent;
+#                       requires operator to supply IDs via -e overrides.
 #   confirm=true  suppresses the interactive name-retype prompt (CI use only).
 #                 confirm=true is REJECTED at preflight unless testing=true is
 #                 also set; this prevents CI from running a real teardown.
@@ -40,7 +40,7 @@
     repo: yasuflatland-lf/flamingo-armond
     state_file: "{{ playbook_dir }}/../.setup-prod.state.yml"
     archive_dir: "{{ playbook_dir }}/../.setup-prod-archive"
-    rescue: false
+    advisory_mode: false
     confirm: false
 
   tasks:

--- a/playbooks/teardown-prod/_lib/verify_identity.yml
+++ b/playbooks/teardown-prod/_lib/verify_identity.yml
@@ -111,6 +111,7 @@
           Owner    : {{ verified_identity.owner_email }}
 
           Retype the resource name exactly as shown above (case-sensitive)
+          Example — type exactly:  {{ verified_identity.name }}
           Resource name to confirm
         echo: true
       register: _retype_prompt

--- a/playbooks/teardown-prod/preflight.yml
+++ b/playbooks/teardown-prod/preflight.yml
@@ -7,7 +7,7 @@
 #
 # Inputs (play vars, all defaulted in teardown-prod.yml):
 #   state_file   - path to .setup-prod.state.yml
-#   rescue       - bool; true switches to advisory mode when state file absent
+#   advisory_mode - bool; true switches to advisory mode when state file absent
 #   confirm      - bool; true suppresses the operator name-retype prompt
 #   testing      - bool; CI test sentinel; required when confirm=true
 #
@@ -69,15 +69,15 @@
         teardown_mode: strict
         original_state: "{{ lookup('file', state_file) | from_yaml }}"
 
-- name: "preflight | advisory mode: set teardown_mode=advisory when rescue=true"
+- name: "preflight | advisory mode: set teardown_mode=advisory when advisory_mode=true"
   ansible.builtin.set_fact:
     teardown_mode: advisory
     original_state: null
   when:
     - not _state_stat.stat.exists
-    - rescue | default(false) | bool
+    - advisory_mode | default(false) | bool
 
-- name: "preflight | fail: state file absent and rescue=false"
+- name: "preflight | fail: state file absent and advisory_mode=false"
   ansible.builtin.fail:
     msg: |
       State file not found: {{ state_file }}
@@ -86,10 +86,10 @@
       setup-prod and records the IDs of every provisioned resource.
 
       If the state file was lost but you know the resource IDs, activate
-      rescue mode and supply each in-scope ID as a -e override:
+      advisory mode and supply each in-scope ID as a -e override:
 
         ansible-playbook playbooks/teardown-prod.yml \
-          -e rescue=true \
+          -e advisory_mode=true \
           -e vercel_project_id=<id> \
           -e render_service_id=<id> \
           -e supabase_project_ref=<ref>
@@ -97,7 +97,7 @@
       Omit overrides for providers you are not targeting with --tags.
   when:
     - not _state_stat.stat.exists
-    - not (rescue | default(false) | bool)
+    - not (advisory_mode | default(false) | bool)
 
 # ── 3. Determine phases in scope from ansible_run_tags ─────────────────────────
 #

--- a/playbooks/teardown-prod/supabase.yml
+++ b/playbooks/teardown-prod/supabase.yml
@@ -108,16 +108,15 @@
 
     - name: "supabase teardown | verify identity before deletion"
       ansible.builtin.include_tasks: _lib/verify_identity.yml
+      # identity_name/team/owner_email/created_at and token_team_id are already
+      # set_fact'd above into play scope, satisfying verify_identity.yml's input
+      # contract. Re-passing them here as same-named include vars makes each var
+      # reference itself and trips ansible-core's recursive-loop detector.
       vars:
         provider: supabase
         resource_id: "{{ supabase_project_ref }}"
         api_url: "https://api.supabase.com/v1/projects/{{ supabase_project_ref }}"
         token: "{{ supabase_token }}"
-        identity_name: "{{ identity_name }}"
-        identity_team: "{{ identity_team }}"
-        identity_owner_email: "{{ identity_owner_email }}"
-        identity_created_at: "{{ identity_created_at }}"
-        token_team_id: "{{ token_team_id }}"
 
     - name: "supabase teardown | delete and archive (with rescue for failure)"
       block:

--- a/playbooks/teardown-prod/vercel.yml
+++ b/playbooks/teardown-prod/vercel.yml
@@ -98,16 +98,15 @@
 
     - name: "vercel teardown | verify identity before deletion"
       ansible.builtin.include_tasks: _lib/verify_identity.yml
+      # identity_name/team/owner_email/created_at and token_team_id are already
+      # set_fact'd above into play scope, satisfying verify_identity.yml's input
+      # contract. Re-passing them here as same-named include vars makes each var
+      # reference itself and trips ansible-core's recursive-loop detector.
       vars:
         provider: vercel
         resource_id: "{{ vercel_project_id }}"
         api_url: "https://api.vercel.com/v9/projects/{{ vercel_project_id }}"
         token: "{{ vercel_token }}"
-        identity_name: "{{ identity_name }}"
-        identity_team: "{{ identity_team }}"
-        identity_owner_email: "{{ identity_owner_email }}"
-        identity_created_at: "{{ identity_created_at }}"
-        token_team_id: "{{ token_team_id }}"
 
     - name: "vercel teardown | delete and archive (with rescue for failure)"
       block:

--- a/playbooks/teardown-prod/vercel.yml
+++ b/playbooks/teardown-prod/vercel.yml
@@ -71,8 +71,8 @@
       ansible.builtin.set_fact:
         identity_created_at: >-
           {{
-            ((_vercel_pre_get.json.createdAt | default(0)) / 1000) | int
-            | strftime('%Y-%m-%dT%H:%M:%SZ')
+            '%Y-%m-%dT%H:%M:%SZ'
+            | strftime(((_vercel_pre_get.json.createdAt | default(0)) / 1000) | int, utc=true)
           }}
 
     - name: "vercel teardown | GET /v2/teams/{{ identity_team }} (token scope check)"

--- a/render.yaml
+++ b/render.yaml
@@ -37,7 +37,7 @@ services:
   - type: web
     name: flamingo-backend
     runtime: go
-    region: oregon
+    region: singapore
     plan: free
     rootDir: backend
     # `go tool gqlgen generate` runs because backend/graph/generated/ and


### PR DESCRIPTION
> No related tracking issue — these fixes address Ansible runtime ordering, region, and state-loading problems observed during `setup-prod` / `teardown-prod` runs.

## Summary

Hardens the production bring-up and teardown Ansible playbooks. The headline fix reorders the Notion owner-UUID resolution to run *after* the Vercel deploy, so a fresh bring-up no longer dead-locks on an `auth.users` row that cannot exist until the frontend is live. Also pins every provider to the Singapore region and clears up several setup/teardown state-loading and naming defects.

## Background / Motivation

- The `NOTION_TARGET_OWNER_EMAIL → UUID` resolution queries the production `auth.users` table, but that row only exists once the owner has signed in to the live frontend. Placing the resolution before the Vercel deploy dead-locked a fresh bring-up: no app → no sign-in → no row → resolution fails before the deploy that would have unblocked it.
- Providers were not consistently pinned to a single region, risking cross-region latency between Render, Vercel, and Supabase.
- `setup-prod` loaded `existing_state` via `include_vars`, which does not behave as a per-play fact the later tasks expect.
- Teardown carried a self-referential `include_vars` in the `verify_identity` calls, a misleading `rescue` variable name, and swapped `strftime` arguments in the Vercel playbook.

## Changes

### Notion owner resolution ordering (`setup-prod/postapply.yml`)

- Moved the `Resolve NOTION_TARGET_OWNER_EMAIL to a UUID` block to run after the Vercel deploy. The header comment now documents the dead-lock rationale, and the "email not found" failure message guides the operator through the expected two-pass first-run flow: sign in once after the deploy, then re-run `make setup-prod-postapply`.

### Singapore region pinning

- `render.yaml`, `frontend/vercel.json`, `playbooks/setup-prod/supabase.yml`, and `playbooks/setup-prod/vercel.yml` pin Render, Vercel, and Supabase to Singapore. `docs/deployment.md` updated to match.

### setup-prod state loading

- `setup-prod/render.yml` and `setup-prod/vercel.yml`: load `existing_state` via `set_fact` instead of `include_vars` so downstream tasks see it as a play fact.

### teardown-prod fixes

- `teardown-prod/supabase.yml`, `teardown-prod/vercel.yml`: drop the self-referential `include_vars` from the `verify_identity` calls.
- `teardown-prod.yml`, `teardown-prod/preflight.yml`: rename the rescue variable to `advisory_mode` for clarity (`docs/deployment.md` updated).
- `teardown-prod/vercel.yml`: correct the swapped `strftime` arguments.

### Docs / operator prompts

- `docs/playbooks` prose clarifies the operator prompts for both setup and teardown.

## Verification

```bash
ansible-playbook --syntax-check playbooks/setup-prod/postapply.yml
ansible-playbook --syntax-check playbooks/teardown-prod.yml
ansible-lint playbooks/setup-prod/postapply.yml
```

- On a fresh bring-up, confirm `make setup-prod-postapply` kicks the Vercel deploy first, then stops at the "email not found" message; sign in once and re-run to complete Notion + Render wiring.
- Confirm Render / Vercel / Supabase resources report the Singapore region.

## Test plan

- [ ] `ansible-playbook --syntax-check` passes for both `setup-prod/postapply.yml` and `teardown-prod.yml`.
- [ ] First-pass `make setup-prod-postapply` deploys Vercel, then halts with the two-pass guidance when no `auth.users` row exists.
- [ ] Second-pass run (after sign-in) resolves the owner UUID and completes Render + Notion wiring.
- [ ] `make teardown-prod` runs without the self-referential include-vars error and prints correct timestamps.
