### PR TITLE
chore(backend): gate GET /playground behind the introspection flag

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -152,7 +152,14 @@ func newRouter(
 	)
 	q := e.Group("/query", authMW, promoter.Middleware(), loader.MiddlewareWithUserCardFSRS(userRepo, roleRepo, userRoleRepo, cardgroupRepo, cardRepo, userPreferenceRepo, swipeRecordRepo, userCardFSRSRepo))
 	q.POST("", echo.WrapHandler(otelGQLHandler))
-	e.GET("/playground", echo.WrapHandler(playground.Handler("GraphQL", "/query")))
+
+	// Gate the Playground UI on the same switch as introspection (main.go
+	// `extension.Introspection{}` gate): the UI is useless without
+	// introspection, so production (GRAPHQL_INTROSPECTION=off) does not serve
+	// it at all rather than serving a non-functional page.
+	if os.Getenv("GRAPHQL_INTROSPECTION") != "off" {
+		e.GET("/playground", echo.WrapHandler(playground.Handler("GraphQL", "/query")))
+	}
 
 	return e
 }

--- a/backend/cmd/server/main_test.go
+++ b/backend/cmd/server/main_test.go
@@ -870,6 +870,41 @@ func TestIntrospection_DefaultOn(t *testing.T) {
 	}
 }
 
+// getStatus issues a GET and returns only the HTTP status code. Used for
+// routes whose body is not JSON (the Playground UI serves HTML).
+func getStatus(t *testing.T, url string) int {
+	t.Helper()
+	res, err := http.Get(url)
+	if err != nil {
+		t.Fatalf("GET %s: %v", url, err)
+	}
+	defer res.Body.Close()
+	return res.StatusCode
+}
+
+// TestPlayground_GatedOff asserts that GRAPHQL_INTROSPECTION=off leaves the
+// /playground route unregistered (404). The Playground UI is useless without
+// introspection, so production (where introspection is off) does not serve it.
+func TestPlayground_GatedOff(t *testing.T) {
+	t.Setenv("GRAPHQL_INTROSPECTION", "off")
+	ts := newTestServer(t)
+
+	if got := getStatus(t, ts.URL+"/playground"); got != http.StatusNotFound {
+		t.Fatalf("GET /playground status = %d, want %d (route should be gated off)", got, http.StatusNotFound)
+	}
+}
+
+// TestPlayground_DefaultOn asserts that with introspection enabled (empty/unset
+// GRAPHQL_INTROSPECTION) the /playground route is registered and returns 200.
+func TestPlayground_DefaultOn(t *testing.T) {
+	t.Setenv("GRAPHQL_INTROSPECTION", "")
+	ts := newTestServer(t)
+
+	if got := getStatus(t, ts.URL+"/playground"); got != http.StatusOK {
+		t.Fatalf("GET /playground status = %d, want %d (route should be registered)", got, http.StatusOK)
+	}
+}
+
 // installInMemoryTracer wires a fresh in-memory exporter as the global
 // TracerProvider so individual tests can inspect emitted spans.
 // The returned flush function must be called before reading spans.

--- a/docs/backend-graphql.md
+++ b/docs/backend-graphql.md
@@ -73,7 +73,7 @@ gqlgen deletes `graph/model/models_gen.go` at the start of every run before rege
 
 ### Playground
 
-`GET /playground` exposes a browser UI for hand-crafted queries against `/query`. The route is enabled in all environments; the playground UI loads regardless of `GRAPHQL_INTROSPECTION`, but introspection queries (`__schema` / `__type`) are blocked when the variable is set to `off`. See [Introspection gating](#introspection-gating).
+`GET /playground` exposes a browser UI for hand-crafted queries against `/query`. The route is registered only when introspection is enabled (it shares the `GRAPHQL_INTROSPECTION` switch): with `GRAPHQL_INTROSPECTION=off` the route is not registered and returns `404`, so production does not serve the developer UI. With the variable unset or any non-`off` value the route is registered and the playground loads. The UI is gated together with introspection because it is non-functional without `__schema` / `__type`. See [Introspection gating](#introspection-gating).
 
 ### Resolver DI seam
 
@@ -493,10 +493,9 @@ Control is via the `GRAPHQL_INTROSPECTION` environment variable:
 | `off` | Introspection disabled; `__schema` queries return a validation error |
 | anything else (including unset) | Introspection enabled |
 
-The `GET /playground` route is unaffected — the playground UI loads regardless.
-Only the `__schema` and `__type` queries are blocked when introspection is off.
+The `GET /playground` route shares this switch: when introspection is off the route is not registered and `GET /playground` returns `404`; when introspection is on the route is registered and serves the UI. (Beyond route registration, the `__schema` / `__type` queries are themselves blocked when introspection is off.)
 
-Production sets `GRAPHQL_INTROSPECTION=off` on the Render service (Settings → Environment). Dev and CI leave the variable unset, so the playground remains fully functional.
+Production sets `GRAPHQL_INTROSPECTION=off` on the Render service (Settings → Environment), so neither introspection nor the playground UI is served. Dev and CI leave the variable unset, so the playground remains fully functional.
 
 **Tip:** When introspection is disabled, the error message is exactly `"introspection disabled"` (lowercase, no trailing punctuation). Test assertions can match on this literal string.
 


### PR DESCRIPTION
Closes #290 — gate the GraphQL Playground UI route behind the existing introspection switch. Defense-in-depth hardening surfaced by the CSRF / SQL-injection security audit; not a vulnerability, and no GraphQL schema or `/query` behaviour change.

## Summary

`GET /playground` was registered in every environment. It is now registered only when introspection is enabled (`GRAPHQL_INTROSPECTION != "off"`), so production — which sets `GRAPHQL_INTROSPECTION=off` in `render.yaml` — returns `404` for `/playground` and no longer serves the developer UI. The Playground UI is non-functional without introspection, so the route shares one switch with the `extension.Introspection{}` gate rather than introducing a new flag. Backend only.

## Background / Motivation

- The Playground UI route was registered unconditionally (`e.GET("/playground", ...)`), so the developer query UI was served in production even though `GRAPHQL_INTROSPECTION=off` already blocks `__schema` / `__type` there.
- The residual exposure is the served HTML/JS UI itself, not an auth bypass — the playground's queries still hit the bearer-protected `/query`. This is hardening from the CSRF / SQLi audit, not a vulnerability.
- The UI cannot load the schema once introspection is off, so gating it on the same switch removes dead surface in production at zero new-config cost.

## Changes

### Route gating (`backend/cmd/server/main.go`)

- Wrap the `GET /playground` registration in `if os.Getenv("GRAPHQL_INTROSPECTION") != "off"`, mirroring the existing `extension.Introspection{}` gate idiom (inline `os.Getenv`). Production (`off`) skips registration → `404`; unset or any non-`off` value registers the route → `200`.

### Tests (`backend/cmd/server/main_test.go`)

- `TestPlayground_GatedOff` — `GRAPHQL_INTROSPECTION=off` → `GET /playground` returns `404`.
- `TestPlayground_DefaultOn` — empty/unset → `GET /playground` returns `200`.
- `getStatus` helper for routes whose body is not JSON (the Playground serves HTML).

### Docs (`docs/backend-graphql.md`)

- Rewrite the Playground section and the Introspection-gating section: the route is registered only when introspection is enabled; with `off` it is unregistered and returns `404`, so production serves neither introspection nor the playground UI.

## Verification

- With `GRAPHQL_INTROSPECTION=off`: `curl -s -o /dev/null -w '%{http_code}' http://localhost:1323/playground` → `404`.
- With the variable unset: the same curl → `200` and the playground HTML loads.
- `/query` is unaffected in both cases.

## Test plan

- [ ] `go build ./...` passes
- [ ] `go vet ./cmd/server/` reports no issues
- [ ] `go test ./cmd/server/ -run 'TestPlayground_|TestIntrospection_' -v` → PASS (off → 404, on → 200)
- [ ] Existing `TestIntrospection_GatedOff` / `TestIntrospection_DefaultOn` still pass (no regression in the shared switch)
