### PR TITLE
docs(backend-auth): record the bearer-only / CORS-allowlist CSRF invariant

### DIFF
--- a/.claude/rules/backend-layering.md
+++ b/.claude/rules/backend-layering.md
@@ -37,6 +37,8 @@ The backend follows a DDD/layered architecture. The dependency arrow always poin
 
 **`internal/auth` lists `domain` in `mayDependOn`** — this is intentional and correct. `auth.Service.IsAdmin` compares a role membership query result against `domain.AdminRoleName`, a domain-owned constant that defines the canonical admin role name. Role membership is a domain concern; coupling the auth adapter to the canonical constant rather than a local string literal keeps the two in sync and prevents drift. The dependency arrow (`auth → domain`) is infrastructure importing domain, which is the normal inward direction.
 
+**The CSRF posture is a transport/presentation-layer invariant.** The bearer-only credential rule (no cookie/session auth read in `internal/auth`), the explicit CORS allowlist requirement, and the JSON-only gqlgen POST transport together make the API structurally CSRF-immune. Adding CORS middleware or a cookie credential touches that contract — see [`docs/backend-auth.md` § "CSRF posture: bearer-only credential and CORS allowlist invariant"](../../docs/backend-auth.md#csrf-posture-bearer-only-credential-and-cors-allowlist-invariant).
+
 ## What `go-arch-lint` covers vs. doesn't
 
 `go-arch-lint` operates at the **import-graph level only**. Even with `deepScan: true` it does not classify function-call, struct-literal, or string-literal shapes. The CI grep gates in [`.github/workflows/backend.yml`](../../.github/workflows/backend.yml) are evaluated against that capability:

--- a/docs/backend-auth.md
+++ b/docs/backend-auth.md
@@ -56,6 +56,15 @@ Accepted algorithms: ES256, RS256. A 30-second leeway is applied to `exp` to tol
 
 All 401 responses carry `WWW-Authenticate: Bearer realm="api"`. The header deliberately omits `error` and `error_description` parameters (RFC 6750 §3.1) to minimize information disclosure — callers learn only that a valid Bearer token is required, not why verification failed.
 
+### CSRF posture: bearer-only credential and CORS allowlist invariant
+
+The API is structurally immune to CSRF because authentication never reads a credential the browser attaches automatically. This immunity is **implicit** — it rests on the *absence* of cookie auth and the *absence* of permissive CORS — so a future change can silently lose it. The following four properties are standing invariants; preserve all of them.
+
+1. **Bearer-only credential.** The API authenticates **exclusively** via the `Authorization: Bearer <JWT>` header (`AuthMiddleware` in `backend/internal/auth/middleware.go`). The backend MUST NOT read any cookie, session, or other browser-auto-attached credential server-side. A header that the browser does not attach on its own for cross-origin requests is precisely what makes the API structurally CSRF-immune.
+2. **Explicit CORS allowlist only.** No CORS middleware is configured, so the browser same-origin policy already blocks cross-origin custom-header requests. If CORS is ever added, it MUST use an explicit origin allowlist. Never combine `Access-Control-Allow-Origin: *` with credentials, and never reflect the request `Origin` header back into the response.
+3. **Cookies break the immunity.** If any cookie-based credential is ever introduced, the CSRF immunity is lost. Explicit CSRF defenses then become mandatory: `SameSite=Lax|Strict` on the credential cookie plus either an anti-CSRF token or an `Origin` / `Sec-Fetch-Site` check on every state-changing route.
+4. **JSON-only POST transport.** The GraphQL POST transport accepts only `application/json` (gqlgen `transport.POST` in `backend/cmd/server/main.go`). Do not register `transport.GET` or any form transport for mutation-capable operations — both are reachable cross-origin without a CORS preflight and would reopen the CSRF surface.
+
 ### JWKS lifecycle
 
 `NewJWKSKeyfunc` wraps `MicahParks/keyfunc/v3` with `NoErrorReturnFirstHTTPReq: false`. This means:

--- a/docs/backend-graphql.md
+++ b/docs/backend-graphql.md
@@ -6,6 +6,8 @@
 
 `POST /query` is served by gqlgen. The schema lives under `schema/*.graphql` at the repo root and is consumed by `backend/gqlgen.yml` via a relative glob (`../schema/*.graphql`), so both backend (gqlgen) and frontend (graphql-codegen) see the same source of truth.
 
+The transport accepts only `application/json` and registers no `transport.GET` — a deliberate part of the API's CSRF posture. See [`docs/backend-auth.md` § "CSRF posture: bearer-only credential and CORS allowlist invariant"](backend-auth.md#csrf-posture-bearer-only-credential-and-cors-allowlist-invariant) before adding a form transport or `transport.GET`.
+
 ### Schema extension rules
 
 - `extend type Query { ... }` works without ceremony — gqlgen merges all `extend type Query` blocks automatically. Use it freely when adding fields to the root query type.


### PR DESCRIPTION
Closes #292 — record the backend's structural CSRF immunity as a standing invariant. Documentation only; no application code, GraphQL schema, or runtime behaviour change. Companion to the CSRF / SQL-injection security audit hardening also tracked in #290.

## Summary

The backend is structurally immune to CSRF, but the property is **implicit**: it rests on the *absence* of cookie auth and the *absence* of permissive CORS. A future change that adds a cookie credential or permissive CORS could silently break it with no obvious signal. This change writes the invariant down in `docs/backend-auth.md` as four standing statements and cross-links it from the layering rule and the GraphQL transport doc so the property is defended against regression.

## Background / Motivation

- The CSRF immunity depends on facts that are easy to undo by accident: auth reads only the `Authorization: Bearer` header, no CORS middleware is configured, and the gqlgen POST transport accepts only `application/json` with no `transport.GET`.
- None of those facts were recorded as a contributor/operator contract, so a later PR adding CORS or a cookie session would not be flagged by review or by any existing doc.
- The audit that surfaced this also produced the Playground route gating (#290); recording the invariant is the documentation half of the same audit.

## Changes

### CSRF invariant subsection (`docs/backend-auth.md`)

- New `### CSRF posture: bearer-only credential and CORS allowlist invariant`, inserted after `### WWW-Authenticate policy`, stating four standing invariants:
  1. **Bearer-only credential** — auth reads `Authorization: Bearer <JWT>` only; the backend never reads a cookie/session/browser-auto-attached credential.
  2. **Explicit CORS allowlist only** — if CORS is added, no `Access-Control-Allow-Origin: *` with credentials and no `Origin` reflection.
  3. **Cookies break the immunity** — a cookie credential makes `SameSite=Lax|Strict` plus an anti-CSRF token or `Origin` / `Sec-Fetch-Site` check mandatory.
  4. **JSON-only POST transport** — `application/json` only; do not register `transport.GET` or a form transport for mutation-capable operations.

### Cross-references

- `.claude/rules/backend-layering.md` — one paragraph in the presentation/auth-boundary section pointing at the new subsection via an anchor link, framing the CSRF posture as a transport/presentation-layer invariant.
- `docs/backend-graphql.md` — anchor-link reference next to the `POST /query` transport description, to be consulted before adding a form transport or `transport.GET`.

## Verification

- The new subsection renders under `## Authentication` in `docs/backend-auth.md`; the heading slug is `csrf-posture-bearer-only-credential-and-cors-allowlist-invariant`.
- Both cross-links resolve to that heading (anchor links, not bare text):
  - `grep -rn "csrf-posture-bearer-only-credential-and-cors-allowlist-invariant" docs/backend-auth.md docs/backend-graphql.md .claude/rules/backend-layering.md` returns the heading plus two inbound links.

## Test plan

- [ ] `docs/backend-auth.md` contains the new subsection with all four invariants as standing statements.
- [ ] At least one cross-reference links to it via an anchor link (two are present).
- [ ] No CJK: `grep -rlP "[\x{3040}-\x{30ff}\x{4e00}-\x{9fff}]" --include="*.md" docs | grep backend-auth` prints nothing.
- [ ] No PR-order references: `grep -rnE "PR[0-9]+" docs/backend-auth.md` prints nothing.
