### PR TITLE
chore(backend): make GRAPHQL_INTROSPECTION fail-safe (opt-in via =on)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -41,7 +41,10 @@ jobs:
     env:
       BACKEND_URL: http://localhost:1323
       E2E_BASE_URL: http://localhost:3000
-      GRAPHQL_INTROSPECTION: on
+      # The e2e suite does not use introspection (__schema / __type); keep it
+      # disabled to match the fail-safe production default. Quoted so YAML does
+      # not coerce it to a boolean.
+      GRAPHQL_INTROSPECTION: "off"
       PING_TOKEN: ci-dummy
       SUPABASE_JWT_AUDIENCE: authenticated
       SUPABASE_JWT_ISSUER: http://127.0.0.1:54321/auth/v1

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -2,6 +2,12 @@
 PORT=1323
 SHUTDOWN_TIMEOUT=25s
 
+# GraphQL introspection is fail-safe (opt-in): the schema is exposed only when
+# this is exactly "on". Local dev needs it for the /playground and hand-crafted
+# queries; production (Render) keeps it "off". Any other value (including unset)
+# keeps introspection disabled.
+GRAPHQL_INTROSPECTION=on
+
 # Bootstrap admin (optional)
 # Comma-separated list of email addresses (Google OAuth via Supabase). On the
 # first authenticated request from any of these accounts, the backend grants

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -84,7 +84,11 @@ func newGraphQLServer(r *resolver.Resolver) *handler.Server {
 
 	srv.Use(extension.FixedComplexityLimit(100))
 
-	if os.Getenv("GRAPHQL_INTROSPECTION") != "off" {
+	// Introspection is fail-safe: opt-in only. Enabled when
+	// GRAPHQL_INTROSPECTION is exactly "on"; unset or any other value keeps
+	// the schema hidden so a new deploy target cannot leak it by forgetting
+	// to set the variable.
+	if os.Getenv("GRAPHQL_INTROSPECTION") == "on" {
 		srv.Use(extension.Introspection{})
 	}
 

--- a/backend/cmd/server/main_test.go
+++ b/backend/cmd/server/main_test.go
@@ -827,8 +827,10 @@ func newIntrospectionTestServer(t *testing.T) *httptest.Server {
 
 const introspectionQuery = `{"query":"{ __schema { queryType { name } } }"}`
 
-func TestIntrospection_GatedOff(t *testing.T) {
-	t.Setenv("GRAPHQL_INTROSPECTION", "off")
+// assertIntrospectionDisabled posts an introspection query and asserts the
+// server rejects it with an "introspection disabled" validation error.
+func assertIntrospectionDisabled(t *testing.T) {
+	t.Helper()
 	ts := newIntrospectionTestServer(t)
 
 	raw := postRaw(t, ts.URL, introspectionQuery)
@@ -849,8 +851,10 @@ func TestIntrospection_GatedOff(t *testing.T) {
 	}
 }
 
-func TestIntrospection_DefaultOn(t *testing.T) {
-	t.Setenv("GRAPHQL_INTROSPECTION", "")
+// assertIntrospectionEnabled posts an introspection query and asserts the
+// server returns a populated __schema with no errors.
+func assertIntrospectionEnabled(t *testing.T) {
+	t.Helper()
 	ts := newIntrospectionTestServer(t)
 
 	raw := postRaw(t, ts.URL, introspectionQuery)
@@ -868,6 +872,24 @@ func TestIntrospection_DefaultOn(t *testing.T) {
 	if payload.Data["__schema"] == nil {
 		t.Fatalf("expected data.__schema to be non-nil; body=%q", raw)
 	}
+}
+
+// Introspection is fail-safe (opt-in): enabled only when GRAPHQL_INTROSPECTION
+// is set to exactly "on". An unset or any other value keeps it disabled.
+
+func TestIntrospection_UnsetDisabled(t *testing.T) {
+	t.Setenv("GRAPHQL_INTROSPECTION", "")
+	assertIntrospectionDisabled(t)
+}
+
+func TestIntrospection_OffDisabled(t *testing.T) {
+	t.Setenv("GRAPHQL_INTROSPECTION", "off")
+	assertIntrospectionDisabled(t)
+}
+
+func TestIntrospection_OnEnabled(t *testing.T) {
+	t.Setenv("GRAPHQL_INTROSPECTION", "on")
+	assertIntrospectionEnabled(t)
 }
 
 // installInMemoryTracer wires a fresh in-memory exporter as the global

--- a/docs/backend-graphql.md
+++ b/docs/backend-graphql.md
@@ -73,7 +73,7 @@ gqlgen deletes `graph/model/models_gen.go` at the start of every run before rege
 
 ### Playground
 
-`GET /playground` exposes a browser UI for hand-crafted queries against `/query`. The route is enabled in all environments; the playground UI loads regardless of `GRAPHQL_INTROSPECTION`, but introspection queries (`__schema` / `__type`) are blocked when the variable is set to `off`. See [Introspection gating](#introspection-gating).
+`GET /playground` exposes a browser UI for hand-crafted queries against `/query`. The route is enabled in all environments; the playground UI loads regardless of `GRAPHQL_INTROSPECTION`, but introspection queries (`__schema` / `__type`) succeed only when the variable is set to `on` (disabled by default). See [Introspection gating](#introspection-gating).
 
 ### Resolver DI seam
 
@@ -482,21 +482,23 @@ setting it above 1000 without profiling.
 ### Introspection gating
 
 **Why:** Introspection exposes the full schema to anyone who can reach
-`/query`. Disabling it in production prevents schema enumeration by
-unauthenticated clients while keeping it on in dev for playground and
-codegen tooling.
+`/query`. The default is fail-safe (disabled), so a deploy target that forgets
+to set the variable cannot leak the schema to unauthenticated clients. Dev opts
+in (`GRAPHQL_INTROSPECTION=on`) to drive the playground against a live schema.
+Frontend codegen does not need it — it reads the static `schema/*.graphql` file,
+not backend introspection.
 
 Control is via the `GRAPHQL_INTROSPECTION` environment variable:
 
 | Value | Effect |
 |---|---|
-| `off` | Introspection disabled; `__schema` queries return a validation error |
-| anything else (including unset) | Introspection enabled |
+| `on` | Introspection enabled; `__schema` / `__type` queries succeed |
+| anything else (including unset) | Introspection disabled; `__schema` queries return a validation error |
 
 The `GET /playground` route is unaffected — the playground UI loads regardless.
-Only the `__schema` and `__type` queries are blocked when introspection is off.
+Only the `__schema` and `__type` queries are blocked when introspection is disabled.
 
-Production sets `GRAPHQL_INTROSPECTION=off` on the Render service (Settings → Environment). Dev and CI leave the variable unset, so the playground remains fully functional.
+Production keeps `GRAPHQL_INTROSPECTION=off` on the Render service (Settings → Environment); any value other than `on` disables introspection. Dev sets `GRAPHQL_INTROSPECTION=on` (via `backend/.env.example` / `.env.local`) so the playground and introspection queries work. CI (`.github/workflows/e2e.yml`) keeps it `off` — the e2e suite does not use introspection, matching the fail-safe production default.
 
 **Tip:** When introspection is disabled, the error message is exactly `"introspection disabled"` (lowercase, no trailing punctuation). Test assertions can match on this literal string.
 

--- a/render.yaml
+++ b/render.yaml
@@ -52,6 +52,8 @@ services:
     envVars:
       - key: APP_ENV
         value: production
+      # Introspection is opt-in: only "on" enables it; "off" (or any other
+      # value, including unset) keeps the schema hidden.
       - key: GRAPHQL_INTROSPECTION
         value: "off"
       - key: OTEL_TRACES_SAMPLER_ARG


### PR DESCRIPTION
Closes #291 — flip the introspection gate to a fail-safe, opt-in default so a new deploy target cannot leak the schema by omitting the variable. Defense-in-depth; production is already mitigated by the explicit `off` in `render.yaml`. Companion to the Playground gating in #293 (which gated `GET /playground` on the same switch).

## Summary

The `GRAPHQL_INTROSPECTION` gate defaulted to **enabled**, disabled only by an explicit `off` (`!= "off"`). A new deploy target (staging, a second region, a fork) that forgot to set the variable would default to schema-exposed. This flips the gate to `== "on"`: introspection is enabled only when the variable is exactly `on`; unset or any other value keeps the schema hidden. Production is unaffected (`render.yaml` already sets `off`). Backend only.

## Background / Motivation

- The previous gate `os.Getenv("GRAPHQL_INTROSPECTION") != "off"` was fail-open: introspection was enabled unless someone explicitly disabled it.
- Production is safe today (`render.yaml` sets `off`, e2e CI set it explicitly), so this is hardening, not a live vulnerability — but a future environment that omits the variable would silently expose the schema.
- A fail-safe (opt-in) default removes that footgun: the only way to expose the schema is to set `on` deliberately.

## Changes

### Introspection gate (`backend/cmd/server/main.go`)

- Gate is now `os.Getenv("GRAPHQL_INTROSPECTION") == "on"` (was `!= "off"`), with an inline comment recording the fail-safe rationale.

### Tests (`backend/cmd/server/main_test.go`)

- Replace `TestIntrospection_GatedOff` / `TestIntrospection_DefaultOn` with three tests that pin the full contract via shared `assertIntrospectionDisabled` / `assertIntrospectionEnabled` helpers: `TestIntrospection_UnsetDisabled`, `TestIntrospection_OffDisabled`, `TestIntrospection_OnEnabled`.

### Local dev (`backend/.env.example`)

- Add `GRAPHQL_INTROSPECTION=on` so the playground keeps working under the new default. Ansible `sync-env` copies `.env.example` verbatim into `.env.local`, so no playbook change is needed.

### Docs (`docs/backend-graphql.md`)

- Rewrite the Introspection-gating table and prose for opt-in (`on` = enabled / anything else, including unset, = disabled), and update the Playground note at the top of the doc. Correct the misleading "codegen tooling" rationale — frontend codegen reads the static `schema/*.graphql`, not backend introspection.

### Infra comment (`render.yaml`)

- Clarifying comment that any value other than `on` disables introspection. Production value stays `off`.

### CI hardening (`.github/workflows/e2e.yml`)

- Pin `GRAPHQL_INTROSPECTION` to quoted `"off"`. Unquoted `on` is a YAML 1.1 boolean coerced to the env string `"true"`, which the new strict `== "on"` check treats as disabled anyway; the e2e suite does not use introspection (`__schema` / `__type`), so this aligns CI with the fail-safe default.

## Verification

- Unset → `__schema` returns the `"introspection disabled"` validation error.
- `GRAPHQL_INTROSPECTION=on` → `__schema` succeeds.
- `GRAPHQL_INTROSPECTION=off` (or any non-`on`) → disabled.
- `grep -rn GRAPHQL_INTROSPECTION backend/ docs/ render.yaml .github/` — all references consistent with the opt-in semantics.

## Test plan

- [ ] `go build ./...` passes
- [ ] `go vet ./...` reports no issues
- [ ] `go test ./cmd/server/ -run Introspection -v` → PASS (unset/off → disabled, on → enabled)
- [ ] `make dev` playground still loads locally (`.env.local` carries `GRAPHQL_INTROSPECTION=on`)
- [ ] No CJK in touched files: `grep -rlP "[\x{3040}-\x{30ff}\x{4e00}-\x{9fff}]" --include="*.go" --include="*.md" backend docs` prints nothing for them
- [ ] No PR-order references in committed text
