### PR TITLE
docs(readme): add codecov logo to coverage badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![backend CI](https://github.com/yasuflatland-lf/flamingo-armond/actions/workflows/backend.yml/badge.svg?branch=main)](https://github.com/yasuflatland-lf/flamingo-armond/actions/workflows/backend.yml)
 [![frontend CI](https://github.com/yasuflatland-lf/flamingo-armond/actions/workflows/frontend.yml/badge.svg?branch=main)](https://github.com/yasuflatland-lf/flamingo-armond/actions/workflows/frontend.yml)
-[![backend coverage](https://img.shields.io/codecov/c/github/yasuflatland-lf/flamingo-armond?flag=backend&label=backend%20coverage)](https://codecov.io/gh/yasuflatland-lf/flamingo-armond)
-[![frontend coverage](https://img.shields.io/codecov/c/github/yasuflatland-lf/flamingo-armond?flag=frontend&label=frontend%20coverage)](https://codecov.io/gh/yasuflatland-lf/flamingo-armond)
+[![backend coverage](https://img.shields.io/codecov/c/github/yasuflatland-lf/flamingo-armond?flag=backend&label=backend%20coverage&logo=codecov&logoColor=white)](https://codecov.io/gh/yasuflatland-lf/flamingo-armond)
+[![frontend coverage](https://img.shields.io/codecov/c/github/yasuflatland-lf/flamingo-armond?flag=frontend&label=frontend%20coverage&logo=codecov&logoColor=white)](https://codecov.io/gh/yasuflatland-lf/flamingo-armond)
 
 🦩 Swiping Flashcard app (installable PWA) — a Go (Echo) backend, a Next.js 16 frontend, and a shared GraphQL schema, with Supabase for Postgres + Auth, and optional Notion page sync that imports cards from Notion pages on a 6-hourly schedule.
 


### PR DESCRIPTION
No associated issue — small documentation/presentation tweak to the README coverage badges. Documentation only; no application code, GraphQL schema, or runtime behaviour change.

## Summary

The two Codecov coverage badges rendered as plain text labels with no icon, so they read flat next to the GitHub Actions CI badges. This adds the Codecov umbrella logo to the `backend coverage` and `frontend coverage` shields.io badges so each badge carries a recognizable Codecov mark on its left edge.

## Background / Motivation

- The coverage badges used the bare `img.shields.io/codecov/c/...` endpoint with only a `label`, so they showed no Codecov icon and were visually indistinguishable from any other shields.io badge.
- shields.io supports a `logo` parameter that renders a SimpleIcons mark inline; the Codecov badge endpoint did not opt into it.

## Changes

- `README.md` — append `&logo=codecov&logoColor=white` to both coverage badge URLs (`backend coverage`, `frontend coverage`). shields.io now draws the white Codecov umbrella logo to the left of each label/value.

## Verification

- Render the README on GitHub (or open the raw badge URL) and confirm the Codecov umbrella icon appears on both coverage badges. shields.io may cache for a few minutes after the first hit.
- `grep -n 'logo=codecov' README.md` returns both coverage badge lines.

## Test plan

- [ ] `grep -n 'logo=codecov&logoColor=white' README.md` prints both coverage badge lines
- [ ] GitHub-rendered README shows the Codecov umbrella icon on `backend coverage` and `frontend coverage`
- [ ] CI / coverage badge links still resolve to `https://codecov.io/gh/yasuflatland-lf/flamingo-armond`
