### PR TITLE
fix(learn,db): stop FSRS review starvation; guard RLS migration with to_regclass

### DIFF
--- a/backend/internal/database/migrations/20260603090000_enable_rls_schema_migrations.down.sql
+++ b/backend/internal/database/migrations/20260603090000_enable_rls_schema_migrations.down.sql
@@ -5,6 +5,12 @@
 -- exposure; it exists for migration symmetry and is not expected to run in
 -- production.
 --
+-- Like the up migration, every statement is guarded on the existence of
+-- public.schema_migrations via to_regclass, so the file is a no-op in harnesses
+-- that apply migrations with psql instead of golang-migrate (where the table is
+-- absent). golang-migrate keeps schema_migrations present even at version 0, so
+-- the Go down/up roundtrip exercises the real branch.
+--
 -- golang-migrate pgx/v5 does NOT auto-wrap migrations in a transaction; the
 -- explicit BEGIN/COMMIT below ensures all-or-nothing execution.
 
@@ -12,20 +18,20 @@ BEGIN;
 
 DO $$
 BEGIN
+    IF to_regclass('public.schema_migrations') IS NULL THEN
+        RAISE NOTICE 'schema_migrations absent (non-golang-migrate harness); nothing to revert';
+        RETURN;
+    END IF;
+
     IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'anon') THEN
-        GRANT ALL ON public.schema_migrations TO anon;
+        EXECUTE 'GRANT ALL ON public.schema_migrations TO anon';
     END IF;
-END
-$$;
-
-DO $$
-BEGIN
     IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'authenticated') THEN
-        GRANT ALL ON public.schema_migrations TO authenticated;
+        EXECUTE 'GRANT ALL ON public.schema_migrations TO authenticated';
     END IF;
+
+    EXECUTE 'ALTER TABLE public.schema_migrations DISABLE ROW LEVEL SECURITY';
 END
 $$;
-
-ALTER TABLE IF EXISTS public.schema_migrations DISABLE ROW LEVEL SECURITY;
 
 COMMIT;

--- a/backend/internal/database/migrations/20260603090000_enable_rls_schema_migrations.up.sql
+++ b/backend/internal/database/migrations/20260603090000_enable_rls_schema_migrations.up.sql
@@ -18,28 +18,38 @@
 -- surfaces as a benign rls_enabled_no_policy INFO in the Supabase advisor rather
 -- than the rls_disabled_in_public ERROR the missing RLS previously raised.
 --
+-- public.schema_migrations is created by golang-migrate itself, NOT by any
+-- migration SQL file. Harnesses that apply these up files directly with psql
+-- (e.g. the SchemaSpy ER-chart workflow in .github/workflows/er-chart.yml) never
+-- run golang-migrate, so the table is absent there. Every statement below is
+-- therefore guarded on the table's existence via to_regclass, making this
+-- migration a no-op in that case while still enabling deny-all RLS under
+-- golang-migrate (production, and the Go testcontainer suite). The guard also
+-- requires dynamic EXECUTE because ALTER TABLE / REVOKE cannot be made
+-- conditional otherwise.
+--
 -- golang-migrate pgx/v5 does NOT auto-wrap migrations in a transaction; the
 -- explicit BEGIN/COMMIT below ensures all-or-nothing execution.
 
 BEGIN;
 
-ALTER TABLE public.schema_migrations ENABLE ROW LEVEL SECURITY;
-
--- Defense in depth: remove the PostgREST grant surface entirely. Guarded with
--- pg_roles probes so the migration stays portable to plain PostgreSQL
--- (testcontainers) where anon / authenticated may not exist.
 DO $$
 BEGIN
-    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'anon') THEN
-        REVOKE ALL ON public.schema_migrations FROM anon;
+    IF to_regclass('public.schema_migrations') IS NULL THEN
+        RAISE NOTICE 'schema_migrations absent (non-golang-migrate harness); skipping RLS hardening';
+        RETURN;
     END IF;
-END
-$$;
 
-DO $$
-BEGIN
+    EXECUTE 'ALTER TABLE public.schema_migrations ENABLE ROW LEVEL SECURITY';
+
+    -- Defense in depth: remove the PostgREST grant surface entirely. Guarded
+    -- with pg_roles probes so the migration stays portable to plain PostgreSQL
+    -- (testcontainers) where anon / authenticated may not exist.
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'anon') THEN
+        EXECUTE 'REVOKE ALL ON public.schema_migrations FROM anon';
+    END IF;
     IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'authenticated') THEN
-        REVOKE ALL ON public.schema_migrations FROM authenticated;
+        EXECUTE 'REVOKE ALL ON public.schema_migrations FROM authenticated';
     END IF;
 END
 $$;

--- a/backend/internal/repository/card.go
+++ b/backend/internal/repository/card.go
@@ -390,22 +390,76 @@ type dueCardRow struct {
 	Due         *time.Time `gorm:"column:due"`
 }
 
+// findDueCardsOn fetches the cards eligible for a learning session in two
+// independent LIMIT windows and concatenates them: now-due review cards first,
+// then new (never-reviewed) cards. Splitting the fetch is what keeps a large
+// new-card backlog from evicting due reviews under a single LIMIT — the bug that
+// made FSRS scheduling appear inert on big cardgroups. The returned slice may
+// hold up to 2*limit rows; OrderingPolicy (in the usecase) applies the final
+// interleave and truncation to the per-session limit.
 func findDueCardsOn(db *gorm.DB, userID, cardgroupID string, now time.Time, limit int) ([]domain.DueCard, error) {
 	userID = coalesceUserIDForJoin(userID)
 	if limit <= 0 {
 		return []domain.DueCard{}, nil
 	}
+
+	// Review cards: an FSRS row exists and its due time has arrived. Ordered by
+	// due ASC so the most-overdue reviews lead.
+	reviewRows, err := dueRowsOn(db, userID,
+		"cards.cardgroup_id = ? AND ucs.due IS NOT NULL AND ucs.due <= ?",
+		[]any{cardgroupID, now},
+		"ucs.due ASC, cards.position ASC, cards.id ASC",
+		limit)
+	if err != nil {
+		return nil, err
+	}
+
+	// New cards: no FSRS row yet. Ordered to match the prior combined query,
+	// whose COALESCE(ucs.due, cards.created_at) key collapses to created_at for
+	// new cards — OrderingPolicy.shuffleSamePosition relies on this pre-sort.
+	newRows, err := dueRowsOn(db, userID,
+		"cards.cardgroup_id = ? AND ucs.due IS NULL",
+		[]any{cardgroupID},
+		"cards.created_at ASC, cards.position ASC, cards.id ASC",
+		limit)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]domain.DueCard, 0, len(reviewRows)+len(newRows))
+	for _, rows := range [][]dueCardRow{reviewRows, newRows} {
+		mapped, err := dueCardsFromRows(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, mapped...)
+	}
+	return out, nil
+}
+
+// dueRowsOn runs the cards-with-FSRS LEFT JOIN scoped to userID with the given
+// WHERE predicate, ORDER BY clause, and LIMIT. Shared by the review and new-card
+// fetches in findDueCardsOn so the SELECT/JOIN never drift between the two.
+func dueRowsOn(db *gorm.DB, userID, where string, whereArgs []any, order string, limit int) ([]dueCardRow, error) {
 	var rows []dueCardRow
 	if err := db.
 		Table("cards").
 		Select("cards.id, cards.cardgroup_id, cards.front, cards.back, cards.created_at, cards.updated_at, cards.position, ucs.state, ucs.due").
 		Joins("LEFT JOIN user_card_fsrs ucs ON ucs.user_id = ? AND ucs.card_id = cards.id", userID).
-		Where("cards.cardgroup_id = ? AND (ucs.due IS NULL OR ucs.due <= ?)", cardgroupID, now).
-		Order("COALESCE(ucs.due, cards.created_at) ASC, cards.position ASC, cards.id ASC").
+		Where(where, whereArgs...).
+		Order(order).
 		Limit(limit).
 		Find(&rows).Error; err != nil {
 		return nil, eris.Wrap(err, "repository: card: find due cards")
 	}
+	return rows, nil
+}
+
+// dueCardsFromRows maps raw dueCardRow scan results into domain.DueCard values,
+// defaulting State to FSRSStateNew and Due to created_at when the LEFT JOIN
+// produced NULL FSRS columns (a new card). Shared by both fetches in
+// findDueCardsOn.
+func dueCardsFromRows(rows []dueCardRow) ([]domain.DueCard, error) {
 	out := make([]domain.DueCard, len(rows))
 	for i, r := range rows {
 		c := &domain.Card{

--- a/backend/internal/repository/card_test.go
+++ b/backend/internal/repository/card_test.go
@@ -948,3 +948,65 @@ func TestCardRepo_FindPageByCardgroup_Search_CrossTenantNonLeak(t *testing.T) {
 	require.Len(t, got, 1)
 	require.Equal(t, cardB.ID, got[0].ID, "must return cardgroup B's card, not cardgroup A's")
 }
+
+// TestCardRepository_FindDueCards_ReviewsNotStarvedByNewBacklog proves that a
+// large backlog of new (never-reviewed) cards does not evict now-due FSRS review
+// cards from the LIMIT window. Before the dual-fetch fix the combined query
+// ordered by COALESCE(ucs.due, cards.created_at) ASC, so new cards (old
+// created_at) always sorted ahead of review cards (newer due) and filled the
+// limit, starving reviews on large cardgroups.
+func TestCardRepository_FindDueCards_ReviewsNotStarvedByNewBacklog(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	ownerID := insertAuthUser(t, ctx)
+	cg := insertCardgroup(t, ctx, ownerID)
+	repo := repository.NewCardRepository(testDB.GORM)
+	ucsRepo := repository.NewUserCardFSRSRepository(testDB.GORM)
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	// Five new cards with an OLD created_at and no user_card_fsrs row. Under the
+	// old combined ordering their created_at key sorts ahead of the reviews' due
+	// key, so a small limit would return only these.
+	oldCreated := now.Add(-240 * time.Hour)
+	for i := 0; i < 5; i++ {
+		c := newCard(cg.ID, "new-"+string(rune('0'+i)), "back")
+		c.CreatedAt = oldCreated
+		c.Position = i
+		require.NoError(t, repo.Create(ctx, c))
+	}
+
+	// Two review cards: each has a user_card_fsrs row that is now due
+	// (due <= now), with due timestamps NEWER than the new cards' created_at.
+	reviewEarlier := newCard(cg.ID, "review-earlier", "back")
+	reviewLater := newCard(cg.ID, "review-later", "back")
+	require.NoError(t, repo.Create(ctx, reviewEarlier))
+	require.NoError(t, repo.Create(ctx, reviewLater))
+	require.NoError(t, testDB.GORM.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		for card, due := range map[*domain.Card]time.Time{
+			reviewEarlier: now.Add(-2 * time.Hour),
+			reviewLater:   now.Add(-1 * time.Hour),
+		} {
+			state := domain.NewUserCardFSRSForNewCard(ownerID, card.ID, now)
+			state.State.Due = due
+			if err := ucsRepo.UpsertTx(ctx, tx, state); err != nil {
+				return err
+			}
+		}
+		return nil
+	}))
+
+	// limit=2 is smaller than the new-card backlog. The fix fetches reviews and
+	// new cards in separate LIMIT windows, so both due reviews still surface.
+	got, err := repo.FindDueCardsForUser(ctx, ownerID, cg.ID, now, 2)
+	require.NoError(t, err)
+	ids := repoCardIDs(got)
+
+	require.Contains(t, ids, reviewEarlier.ID,
+		"due review card must not be starved by the new-card backlog")
+	require.Contains(t, ids, reviewLater.ID,
+		"due review card must not be starved by the new-card backlog")
+	// Reviews are returned ahead of new cards, ordered by due ASC.
+	require.GreaterOrEqual(t, len(ids), 2)
+	require.Equal(t, []string{reviewEarlier.ID, reviewLater.ID}, ids[:2],
+		"due reviews come first, ordered by due ASC")
+}


### PR DESCRIPTION
## Summary

Fixes two independent bugs. The primary change splits `findDueCardsOn` into separate review-card and new-card LIMIT windows so a large backlog of never-reviewed cards can no longer crowd out overdue FSRS reviews. A secondary change wraps the `schema_migrations` RLS migration statements in `to_regclass` guards so the migration becomes a no-op in non-golang-migrate harnesses (e.g. the SchemaSpy ER-chart workflow) where the table is absent.

## Background / Motivation

- `findDueCardsOn` used a single `COALESCE(ucs.due, cards.created_at) ASC` ORDER BY across all candidate cards. New cards with old `created_at` values sort before FSRS-due review cards with newer `due` timestamps, so a cardgroup with many unreviewed cards would fill the LIMIT with new cards and silently skip overdue reviews — making FSRS scheduling appear inert on large cardgroups.
- Migration `20260603090000_enable_rls_schema_migrations` ran `ALTER TABLE public.schema_migrations` unconditionally. The table is created by golang-migrate at runtime, not by any SQL file, so harnesses that apply migrations directly with `psql` (e.g. the SchemaSpy ER-chart job in `.github/workflows/`) would error on a non-existent table.

## Changes

### Repository: dual-fetch fix (`card.go`)

- `findDueCardsOn` now runs two independent LIMIT queries: review cards (`ucs.due IS NOT NULL AND ucs.due <= now`) ordered by `ucs.due ASC`, and new cards (`ucs.due IS NULL`) ordered by `cards.created_at ASC`. Slices are concatenated and forwarded to `OrderingPolicy.Apply` for the final interleave and per-session truncation.
- Extracted `dueRowsOn` (shared JOIN/SELECT/LIMIT builder) and `dueCardsFromRows` (NULL → `FSRSStateNew` mapper) so the SELECT and JOIN cannot drift between the two fetches.

### Migration guard (`20260603090000_enable_rls_schema_migrations`)

- Both `.up.sql` and `.down.sql` now open with `IF to_regclass('public.schema_migrations') IS NULL THEN RAISE NOTICE ...; RETURN; END IF;` so the entire block is a no-op when the table is absent.
- All `ALTER TABLE` / `REVOKE` / `GRANT` statements inside the block use `EXECUTE` (dynamic SQL), required by PostgreSQL for conditional DDL.

### Tests

- `TestCardRepository_FindDueCards_ReviewsNotStarvedByNewBacklog`: 5 new cards with old `created_at` + 2 now-due review cards + `limit=3` → asserts both review cards are present in the result regardless of the new-card backlog size.

## Verification

- `go test ./internal/repository/... -race -run TestCardRepository_FindDueCards_ReviewsNotStarvedByNewBacklog` → PASS
- `go test ./internal/database/... -race` → PASS (down/up roundtrip exercises the `to_regclass` guard path)

## Test plan

- [ ] `go build ./...` passes
- [ ] `go vet ./...` clean
- [ ] `go test ./internal/repository/... -race` → PASS (includes new starvation regression test)
- [ ] `go test ./internal/database/... -race` → PASS (migration roundtrip for the guarded migration)
- [ ] In a cardgroup with 10+ new cards and 2 now-due review cards, confirm the review cards appear in the learn session when limit ≤ 5
