### PR TITLE
fix(ci): assert HTTP 200 and strip trailing slashes in readiness pings

### DIFF
--- a/.github/workflows/readiness-ping.yml
+++ b/.github/workflows/readiness-ping.yml
@@ -13,17 +13,38 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      # Both steps strip a trailing slash from the base-URL secret before
+      # joining the path: a secret stored as "https://host/" would otherwise
+      # produce "https://host//api/ping", which Vercel's edge answers with a
+      # 308 redirect before the route handler runs. curl -f treats 3xx as
+      # success, so each step also asserts the final status is exactly 200.
       - name: Ping Vercel frontend
         env:
           VERCEL_PING_URL: ${{ secrets.VERCEL_PING_URL }}
         run: |
-          curl -fsS --retry 3 --retry-delay 5 --retry-all-errors --max-time 30 \
-            -o /dev/null -w "frontend status=%{http_code} time=%{time_total}s\n" \
-            "$VERCEL_PING_URL/api/ping"
+          meta=$(curl -fsS --retry 3 --retry-delay 5 --retry-all-errors --max-time 30 \
+            -o /tmp/ping-body -w "%{http_code} %{time_total}" \
+            "${VERCEL_PING_URL%/}/api/ping")
+          cat /tmp/ping-body; echo
+          status="${meta%% *}"
+          echo "frontend status=$status time=${meta#* }s"
+          if [ "$status" != "200" ]; then
+            echo "::error::Vercel ping returned HTTP $status (expected 200); the /api/ping handler was not reached."
+            exit 1
+          fi
       - name: Ping Render backend (writes to Supabase)
+        env:
+          RENDER_PING_URL: ${{ secrets.RENDER_PING_URL }}
         run: |
-          curl -fsS --retry 3 --retry-delay 5 --retry-all-errors --max-time 60 \
+          meta=$(curl -fsS --retry 3 --retry-delay 5 --retry-all-errors --max-time 60 \
             -X POST \
             -H "Authorization: Bearer ${{ secrets.PING_TOKEN }}" \
-            -w "backend status=%{http_code} time=%{time_total}s\n" \
-            "${{ secrets.RENDER_PING_URL }}/internal/ping"
+            -o /tmp/ping-body -w "%{http_code} %{time_total}" \
+            "${RENDER_PING_URL%/}/internal/ping")
+          cat /tmp/ping-body; echo
+          status="${meta%% *}"
+          echo "backend status=$status time=${meta#* }s"
+          if [ "$status" != "200" ]; then
+            echo "::error::Render ping returned HTTP $status (expected 200)."
+            exit 1
+          fi

--- a/playbooks/setup-prod/postapply.yml
+++ b/playbooks/setup-prod/postapply.yml
@@ -448,6 +448,10 @@
 #                       Guaranteed to have a scheme because Phase 4 asserts it
 #                       starts with https://.
 #
+# Trailing slashes are stripped from both URL secrets: the workflow joins
+# paths as "$URL/api/ping", and a stored trailing slash yields "//api/ping",
+# which Vercel answers with a 308 redirect that never reaches the handler.
+#
 # Mirror the RENDER_DEPLOY_HOOK_URL pattern from render.yml:
 #   - shell: + stdin: (never argv) to keep secret off ps / audit logs.
 #   - stdin_add_newline: false to prevent a trailing \n in the stored value.
@@ -489,7 +493,7 @@
 - name: Register RENDER_PING_URL as GitHub Actions secret
   ansible.builtin.shell:
     cmd: gh secret set RENDER_PING_URL --repo {{ repo }}
-    stdin: "{{ backend_url }}"
+    stdin: "{{ backend_url | regex_replace('/+$', '') }}"
     stdin_add_newline: false
   register: _gh_render_ping_url_result
   no_log: true
@@ -521,7 +525,7 @@
 - name: Register VERCEL_PING_URL as GitHub Actions secret
   ansible.builtin.shell:
     cmd: gh secret set VERCEL_PING_URL --repo {{ repo }}
-    stdin: "{{ production_url }}"
+    stdin: "{{ production_url | regex_replace('/+$', '') }}"
     stdin_add_newline: false
   register: _gh_vercel_ping_url_result
   no_log: true
@@ -562,7 +566,7 @@
 - name: Register NOTION_SYNC_URL as GitHub Actions secret
   ansible.builtin.shell:
     cmd: gh secret set NOTION_SYNC_URL --repo {{ repo }}
-    stdin: "{{ backend_url }}/internal/notion-sync"
+    stdin: "{{ backend_url | regex_replace('/+$', '') }}/internal/notion-sync"
     stdin_add_newline: false
   register: _gh_notion_url_result
   no_log: true

--- a/playbooks/setup-prod/vercel.yml
+++ b/playbooks/setup-prod/vercel.yml
@@ -378,12 +378,16 @@
   register: production_url_prompt
   when: not confirm
 
+# Trailing slashes are stripped because downstream consumers join paths as
+# "{{ production_url }}/api/ping"; a trailing slash yields "//api/ping",
+# which Vercel answers with a 308 redirect that never reaches the handler.
 - name: Resolve production_url (keep existing on empty input)
   ansible.builtin.set_fact:
     production_url: >-
-      {{ (production_url_prompt.user_input | default('') | trim)
-         if (production_url_prompt.user_input | default('') | trim | length) > 0
-         else existing_state.production_url | default('') }}
+      {{ ((production_url_prompt.user_input | default('') | trim)
+          if (production_url_prompt.user_input | default('') | trim | length) > 0
+          else existing_state.production_url | default(''))
+         | regex_replace('/+$', '') }}
 
 - name: Validate production_url shape
   ansible.builtin.assert:


### PR DESCRIPTION
## Summary

The scheduled readiness-ping workflow reported green while its Vercel ping never reached the `/api/ping` route handler: the `VERCEL_PING_URL` secret carried a trailing slash, the workflow's path join produced `//api/ping`, and Vercel's edge answered with a 308 redirect that `curl -f` counts as success. Both ping steps now strip the trailing slash and assert the final HTTP status is exactly 200, and the setup-prod playbooks trim trailing slashes at every site where a base URL enters a GitHub Actions secret.

## Background / Motivation

- Every `readiness-ping` run logged `frontend status=308 time=0.16s` — the Vercel edge returned `location: /api/ping` without invoking the route handler, so the frontend keepalive exercised nothing. `curl -f` fails only on 4xx/5xx, so the 308 kept the workflow green.
- The slash entered via the Phase-4 operator prompt in `playbooks/setup-prod/vercel.yml`: `production_url` was stored with a trailing slash in the state file and pushed verbatim into the `VERCEL_PING_URL` secret by `postapply.yml`.
- The Render ping and the Notion sync URL share the same path-join shape (`$BASE_URL/<path>`), so the same latent failure existed for `RENDER_PING_URL` and `NOTION_SYNC_URL`.

## Changes

### Workflow status assertion (`.github/workflows/readiness-ping.yml`)

- Both ping steps join paths as `${VERCEL_PING_URL%/}/api/ping` / `${RENDER_PING_URL%/}/internal/ping`, so a stored trailing slash can no longer produce a `//` URL.
- Each step captures `%{http_code}` and fails the job unless it is exactly 200 — a 3xx now turns the run red instead of silently passing.
- Response bodies are echoed to the log (`{"ok":true}` / `{"action":"created","count":1}`) so the Supabase write performed by the backend ping stays visible.

### Playbook URL trimming (`playbooks/setup-prod/`)

- `vercel.yml`: `production_url` resolution strips trailing slashes from the operator prompt input — the root cause; the slash came from manual entry.
- `postapply.yml`: the `RENDER_PING_URL`, `VERCEL_PING_URL`, and `NOTION_SYNC_URL` secret registrations apply `regex_replace('/+$', '')` before `gh secret set`.

## Verification

- The `VERCEL_PING_URL` secret has been re-set without the trailing slash; a manual `workflow_dispatch` run now logs `frontend status=200 time=0.65s` (previously `status=308 time=0.16s`) and `backend status=200`: https://github.com/yasuflatland-lf/flamingo-armond/actions/runs/27047665460
- Direct probe: `curl -s https://flamingo-armond-frontend.vercel.app/api/ping` returns `{"ok":true}`, while the double-slash form returns `308` with `location: /api/ping`.

## Test plan

- [ ] `gh workflow run readiness-ping.yml` after merge — both steps log `status=200` and the run is green
- [ ] Negative case: pointing the ping at a redirecting URL fails the job with `::error::Vercel ping returned HTTP 308` instead of passing
- [ ] `make setup-prod-postapply` re-registers all three URL secrets without trailing slashes

No tracked issue — this fixes an operational defect found by inspecting the readiness-ping run logs.
