### PR TITLE
fix(ci): make SchemaSpy output dir writable so er-chart can publish

### DIFF
--- a/.github/workflows/er-chart.yml
+++ b/.github/workflows/er-chart.yml
@@ -74,6 +74,12 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p erout
+          # The schemaspy/schemaspy image runs its process as a non-root user, so
+          # the bind-mounted /output (owned by the runner UID) is not writable by
+          # the container and SchemaSpy fails with "Unable to create directory
+          # /output/tables" (IOException, exit 7). Make the output dir writable by
+          # any UID so the container can create its subdirectories.
+          chmod 777 erout
           docker run --rm --network host -v "$PWD/erout:/output" \
             schemaspy/schemaspy:7.0.2 \
             -t pgsql11 -host localhost -port 5432 -db armond \


### PR DESCRIPTION
## Summary

The published SchemaSpy ER chart at
`https://yasuflatland-lf.github.io/flamingo-armond/er-chart/` returns 404 because
it has **never been published**: every `er-chart` workflow run has failed, so the
`gh-pages` branch was never created and GitHub Pages could not be enabled.

The failing step is `Generate ER docs with SchemaSpy`. DB connection and table
reads succeed, but generation aborts with:

```
ERROR - IOException
Unable to create directory /output/tables
##[error]Process completed with exit code 7.
```

## Root cause

`mkdir -p erout` creates the bind-mount source owned by the runner UID. The
`schemaspy/schemaspy:7.0.2` image runs its process as a **non-root user**, so it
cannot create `/output/tables` inside the mounted volume and fails with the
IOException above.

## Fix

`chmod 777 erout` before the `docker run`, so the container user can create its
subdirectories regardless of UID. One-line change, no behavioral change to the
generated output.

## Follow-up (operator action, not in this PR)

After this lands and the workflow succeeds for the first time, the `gh-pages`
branch is created automatically. GitHub Pages must then be enabled once:
**Settings → Pages → Source: "Deploy from a branch" → Branch: `gh-pages`, folder
`/ (root)`**. The site goes live only after that step. See
[`docs/ci.md` § "One-time operator setup"](../blob/main/docs/ci.md).

## Test plan

- [ ] Merge to `main` triggers `er-chart` (touches `.github/workflows/er-chart.yml`).
- [ ] The `Generate ER docs with SchemaSpy` step completes and `erout/index.html` exists.
- [ ] The `gh-pages` branch is created with the `er-chart/` subtree.
- [ ] After enabling Pages, the chart renders at the URL above.

This PR addresses no tracked issue.
