### PR TITLE
feat(frontend): per-page SEO metadata, Open Graph and Twitter Card tags

### DIFF
--- a/docs/frontend/env-vars.md
+++ b/docs/frontend/env-vars.md
@@ -7,4 +7,5 @@
 | `BACKEND_URL` | `frontend/src/env.ts` (server) | `http://localhost:1323` | Base URL for the `/api/graphql` rewrite in `next.config.ts`. |
 | `NEXT_PUBLIC_SUPABASE_URL` | `frontend/src/env.ts` (client) | `http://127.0.0.1:54321` | Supabase API base URL. Public — bundled into client. |
 | `NEXT_PUBLIC_SUPABASE_ANON_KEY` | `frontend/src/env.ts` (client) | `sb_publishable_...` (the **Publishable** value from `supabase start`; the env name keeps the legacy `_ANON_KEY` to match the Supabase JS SDK) | Public client key. RLS gates real access. |
+| `NEXT_PUBLIC_SITE_URL` | `frontend/src/env.ts` (client) | `http://localhost:3000` (optional — defaults when unset) | Canonical site origin for SEO metadata (`metadataBase`, Open Graph URLs). Set to the deployed origin in production. |
 

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -11,3 +11,8 @@ BACKEND_URL=http://localhost:1323
 # Supabase local dev -- these placeholders are overwritten by `make sync-env`.
 NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321
 NEXT_PUBLIC_SUPABASE_ANON_KEY=sb_publishable_replaced_by_sync_env
+
+# Canonical site origin for SEO metadata (metadataBase / Open Graph URLs).
+# Optional -- defaults to http://localhost:3000 when unset. Set to the
+# deployed origin (e.g. https://example.com) in production.
+NEXT_PUBLIC_SITE_URL=http://localhost:3000

--- a/frontend/src/app/admin/roles/page.tsx
+++ b/frontend/src/app/admin/roles/page.tsx
@@ -1,6 +1,13 @@
+import type { Metadata } from "next";
 import { graphql } from "@/generated";
 import { gqlFetch } from "@/lib/apollo/server";
 import { AdminRolesClient, type RoleItem } from "./admin-roles-client";
+
+// Admin-only route — must not be indexed.
+export const metadata: Metadata = {
+  title: "Roles",
+  robots: { index: false, follow: false },
+};
 
 /**
  * Inline-fields query for the SSR seed (no fragment): useFragment is a React

--- a/frontend/src/app/admin/users/page.tsx
+++ b/frontend/src/app/admin/users/page.tsx
@@ -1,7 +1,14 @@
+import type { Metadata } from "next";
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 import { readAuthContext } from "@/lib/supabase/auth-status";
 import { AdminUsersClient } from "./admin-users-client";
+
+// Admin-only route — must not be indexed.
+export const metadata: Metadata = {
+  title: "Users",
+  robots: { index: false, follow: false },
+};
 
 export default async function AdminUsersPage() {
   // Defense-in-depth under the admin layout: redirect to / (not /login) for

--- a/frontend/src/app/cardgroups/[id]/cards/page.tsx
+++ b/frontend/src/app/cardgroups/[id]/cards/page.tsx
@@ -1,4 +1,8 @@
+import type { Metadata } from "next";
 import { redirect } from "next/navigation";
+
+// Per-user private route — must not be indexed.
+export const metadata: Metadata = { robots: { index: false, follow: false } };
 
 type Props = { params: Promise<{ id: string }> };
 

--- a/frontend/src/app/cardgroups/[id]/edit/page.tsx
+++ b/frontend/src/app/cardgroups/[id]/edit/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 import {
@@ -13,6 +14,9 @@ import { isUnauthenticatedGraphQLError } from "@/lib/apollo/graphql-errors";
 import { gqlFetch } from "@/lib/apollo/server";
 import { readAuthContext } from "@/lib/supabase/auth-status";
 import { CardgroupManagementClient } from "./cardgroup-management-client";
+
+// Per-user private route — must not be indexed.
+export const metadata: Metadata = { robots: { index: false, follow: false } };
 
 type Props = {
   params: Promise<{ id: string }>;

--- a/frontend/src/app/cardgroups/[id]/page.tsx
+++ b/frontend/src/app/cardgroups/[id]/page.tsx
@@ -1,4 +1,8 @@
+import type { Metadata } from "next";
 import { redirect } from "next/navigation";
+
+// Per-user private route — must not be indexed.
+export const metadata: Metadata = { robots: { index: false, follow: false } };
 
 type Props = { params: Promise<{ id: string }> };
 

--- a/frontend/src/app/cardgroups/page.tsx
+++ b/frontend/src/app/cardgroups/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 import { Suspense } from "react";
@@ -8,6 +9,8 @@ import { readAuthContext } from "@/lib/supabase/auth-status";
 import { CardgroupsSkeleton } from "./_components/cardgroups-skeleton";
 import CardgroupsClient from "./cardgroups-client";
 import { CARDGROUPS_DEFAULT_VARS, MyCardgroupsConnectionQuery } from "./queries";
+
+export const metadata: Metadata = { title: "Cardgroups" };
 
 export default async function CardgroupsPage() {
   // Auth check runs OUTSIDE the Suspense boundary so an unauthenticated request

--- a/frontend/src/app/cards/new/page.tsx
+++ b/frontend/src/app/cards/new/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 import { Suspense } from "react";
@@ -8,6 +9,8 @@ import { readAuthContext } from "@/lib/supabase/auth-status";
 import { CardsNewSkeleton } from "./_components/cards-new-skeleton";
 import CardsNewClient from "./cards-new-client";
 import { CardsNewBootstrapQuery } from "./queries";
+
+export const metadata: Metadata = { title: "New card" };
 
 interface CardsNewPageProps {
   searchParams: Promise<{ cardgroup?: string }>;

--- a/frontend/src/app/layout.test.tsx
+++ b/frontend/src/app/layout.test.tsx
@@ -57,7 +57,7 @@ vi.mock("@vercel/speed-insights/next", () => ({
 // Import after mocks are registered.
 // ---------------------------------------------------------------------------
 
-import RootLayout, { viewport } from "@/app/layout";
+import RootLayout, { metadata, viewport } from "@/app/layout";
 
 // ---------------------------------------------------------------------------
 // Helper: recursive element finder
@@ -239,6 +239,49 @@ describe("RootLayout — structural branch selection", () => {
     const providersEl = findElement(tree, byName("Providers"));
     expect(providersEl).not.toBeNull();
     expect(providersEl?.props?.nonce).toBeUndefined();
+  });
+});
+
+describe("root metadata", () => {
+  // Pins the SEO surface: metadataBase resolves relative OG/canonical URLs,
+  // the title template appends the site name to per-page titles, and the
+  // canonical alternate marks the public landing surface as the only
+  // canonical route of this auth-gated app.
+  test("resolves metadataBase from NEXT_PUBLIC_SITE_URL (localhost default in tests)", () => {
+    expect(metadata.metadataBase).toBeInstanceOf(URL);
+    expect(String(metadata.metadataBase)).toBe("http://localhost:3000/");
+  });
+
+  test("keeps the default title and appends the site name via the template", () => {
+    expect(metadata.title).toMatchObject({
+      default: "flamingo-armond",
+      template: "%s | flamingo-armond",
+    });
+  });
+
+  test("declares the canonical alternate for the public landing surface", () => {
+    expect(metadata.alternates?.canonical).toBe("/");
+  });
+
+  test("carries the Open Graph fields with the generated OG image", () => {
+    expect(metadata.openGraph).toMatchObject({
+      type: "website",
+      siteName: "flamingo-armond",
+      title: "flamingo-armond",
+      description: "Swiping flashcard app.",
+      url: "/",
+      locale: "en_US",
+      images: ["/opengraph-image"],
+    });
+  });
+
+  test("carries the Twitter Card fields with the generated OG image", () => {
+    expect(metadata.twitter).toMatchObject({
+      card: "summary_large_image",
+      title: "flamingo-armond",
+      description: "Swiping flashcard app.",
+      images: ["/opengraph-image"],
+    });
   });
 });
 

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -5,13 +5,35 @@ import type { ReactNode } from "react";
 import { AuthShell } from "@/components/auth-shell";
 import { AppleInstallHint } from "@/components/pwa/apple-install-hint";
 import { SwRegister } from "@/components/pwa/sw-register";
+import { env } from "@/env";
 import { readAuthContext } from "@/lib/supabase/auth-status";
 import { Providers } from "./providers";
 import "./globals.css";
 
+const siteTitle = "flamingo-armond";
+const siteDescription = "Swiping flashcard app.";
+
 export const metadata: Metadata = {
-  title: "flamingo-armond",
-  description: "Swiping flashcard app.",
+  metadataBase: new URL(env.NEXT_PUBLIC_SITE_URL),
+  title: { default: siteTitle, template: `%s | ${siteTitle}` },
+  description: siteDescription,
+  // The app is auth-gated; only the public landing surface is canonical.
+  alternates: { canonical: "/" },
+  openGraph: {
+    type: "website",
+    siteName: siteTitle,
+    title: siteTitle,
+    description: siteDescription,
+    url: "/",
+    locale: "en_US",
+    images: ["/opengraph-image"],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: siteTitle,
+    description: siteDescription,
+    images: ["/opengraph-image"],
+  },
   appleWebApp: {
     capable: true,
     statusBarStyle: "default",

--- a/frontend/src/app/learn/[cardgroupId]/page.tsx
+++ b/frontend/src/app/learn/[cardgroupId]/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 import { Suspense } from "react";
@@ -15,6 +16,12 @@ import { LEARN_PAGE_LIMIT, LearnNextDueCardsQuery } from "../queries";
 import { LearnAddCardSheet } from "./_components/learn-add-card-sheet";
 import { LearnSkeleton } from "./_components/learn-skeleton";
 import { LearnClient } from "./learn-client";
+
+// Per-user learning session — must not be indexed.
+export const metadata: Metadata = {
+  title: "Learn",
+  robots: { index: false, follow: false },
+};
 
 export default async function LearnPage({ params }: { params: Promise<{ cardgroupId: string }> }) {
   // Auth runs OUTSIDE the Suspense boundary so the redirect fires before any

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -1,8 +1,11 @@
+import type { Metadata } from "next";
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 import { FlamingoMark } from "@/components/brand/flamingo-mark";
 import { readAuthContext } from "@/lib/supabase/auth-status";
 import { LoginButton } from "./login-button";
+
+export const metadata: Metadata = { title: "Login" };
 
 type SearchParams = Promise<{ error?: string }>;
 

--- a/frontend/src/app/opengraph-image.tsx
+++ b/frontend/src/app/opengraph-image.tsx
@@ -1,0 +1,30 @@
+import { ImageResponse } from "next/og";
+
+// Generated Open Graph image (Next.js file convention). Pure code — the brand
+// color matches viewport.themeColor in app/layout.tsx; no design asset needed.
+
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+export const alt = "flamingo-armond — Remember more, study less.";
+
+export default function OpengraphImage() {
+  return new ImageResponse(
+    <div
+      style={{
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        gap: 24,
+        backgroundColor: "#FF6F79",
+        color: "#FFFFFF",
+      }}
+    >
+      <div style={{ fontSize: 96, fontWeight: 700, letterSpacing: -2 }}>flamingo-armond</div>
+      <div style={{ fontSize: 40, opacity: 0.9 }}>Remember more, study less.</div>
+    </div>,
+    { ...size },
+  );
+}

--- a/frontend/src/app/profile/change-email/page.tsx
+++ b/frontend/src/app/profile/change-email/page.tsx
@@ -1,7 +1,11 @@
+import type { Metadata } from "next";
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 import { readAuthContext } from "@/lib/supabase/auth-status";
 import { ChangeEmailClient } from "./change-email-client";
+
+// Per-user private route — must not be indexed.
+export const metadata: Metadata = { robots: { index: false, follow: false } };
 
 export default async function ChangeEmailPage() {
   const auth = readAuthContext(await headers());

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 import { graphql } from "@/generated";
@@ -6,6 +7,8 @@ import { isUnauthenticatedGraphQLError } from "@/lib/apollo/graphql-errors";
 import { gqlFetch } from "@/lib/apollo/server";
 import { readAuthContext } from "@/lib/supabase/auth-status";
 import { ProfilePageClient } from "./profile-page-client";
+
+export const metadata: Metadata = { title: "Profile" };
 
 const MeQuery = graphql(`
   query Me {

--- a/frontend/src/env.ts
+++ b/frontend/src/env.ts
@@ -13,11 +13,15 @@ export const env = createEnv({
   client: {
     NEXT_PUBLIC_SUPABASE_URL: z.string().url(),
     NEXT_PUBLIC_SUPABASE_ANON_KEY: z.string().min(20),
+    // Canonical site origin for SEO metadata (metadataBase, Open Graph URLs).
+    // Optional with a localhost default so local dev and tests work unset.
+    NEXT_PUBLIC_SITE_URL: z.string().url().default("http://localhost:3000"),
   },
   runtimeEnv: {
     BACKEND_URL: process.env.BACKEND_URL,
     NEXT_PUBLIC_SUPABASE_URL: process.env.NEXT_PUBLIC_SUPABASE_URL,
     NEXT_PUBLIC_SUPABASE_ANON_KEY: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+    NEXT_PUBLIC_SITE_URL: process.env.NEXT_PUBLIC_SITE_URL,
   },
   emptyStringAsUndefined: true,
 });


### PR DESCRIPTION
## Summary

Adds site-wide SEO/social metadata: `metadataBase` + canonical + Open Graph + Twitter Card on the root layout, a generated 1200x630 OG image via `next/og`, per-page titles for the static top-level routes, and `noindex` on all per-user/dynamic private routes. Introduces `NEXT_PUBLIC_SITE_URL` (validated in `frontend/src/env.ts`, defaulting to `http://localhost:3000` when unset).

## Changes

- `frontend/src/env.ts` / `frontend/.env.example` / `docs/frontend/env-vars.md`: new optional `NEXT_PUBLIC_SITE_URL` (defaults to `http://localhost:3000`); the env-vars doc table gains the matching row.
- `frontend/src/app/layout.tsx`: `metadataBase`, title template (`%s | flamingo-armond`), `alternates.canonical`, `openGraph`, `twitter`. The existing `appleWebApp` / `viewport` blocks are untouched.
- `frontend/src/app/opengraph-image.tsx`: generated 1200x630 `ImageResponse` on brand color `#FF6F79`; exports `size`, `contentType`, `alt`.
- Per-page `title` metadata: `login`, `profile`, `cardgroups`, `cards/new`, `admin/users` ("Users"), `admin/roles` ("Roles"), and `learn/[cardgroupId]` ("Learn" — there is no static `/learn` page; that directory only holds `queries.ts`).
- `robots: { index: false, follow: false }` on private/dynamic routes: `cardgroups/[id]` (+ `/cards`, `/edit`), `learn/[cardgroupId]`, `profile/change-email`, `admin/*`. All dynamic pages are Server Components with params-independent metadata, so static `metadata` consts sufficed (no `generateMetadata` needed).
- `frontend/src/app/layout.test.tsx`: extended to pin `openGraph`, `twitter`, and `alternates.canonical` on the root metadata object.

## Test plan

- [x] `pnpm --filter frontend lint` / `typecheck` / `test` (104 files, 1074 tests) / `build` all green
- [x] `/opengraph-image` prerendered as a static route at build time (proves the `ImageResponse` JSX renders under satori)
- [ ] After deploy: view-source on `/` shows `og:*`, `twitter:card`, and a canonical link; a private route emits `<meta name="robots" content="noindex">`

Closes #324
