### PR TITLE
feat(backend): reserved-name blocklist for displayName to block impersonation

### DIFF
--- a/backend/internal/domain/display_name.go
+++ b/backend/internal/domain/display_name.go
@@ -12,14 +12,42 @@ const DisplayNameMax = 50
 var (
 	ErrDisplayNameRequired = eris.New("user: display name is required")
 	ErrDisplayNameTooLong  = eris.Errorf("user: display name exceeds %d characters", DisplayNameMax)
+	ErrDisplayNameReserved = eris.New("user: display name is reserved")
 )
+
+// reservedDisplayNames is the set of lowercased display names that users may not
+// claim, to prevent impersonation of the platform or staff. Exact normalized
+// equality only — no substring matching.
+var reservedDisplayNames = func() map[string]struct{} {
+	entries := []string{
+		"admin",
+		"administrator",
+		"root",
+		"system",
+		"support",
+		"moderator",
+		"mod",
+		"staff",
+		"official",
+		"flamingo",
+		"flamingo-armond",
+		strings.ToLower(string(AdminRoleName)),
+		strings.ToLower(string(GeneralRoleName)),
+	}
+	m := make(map[string]struct{}, len(entries))
+	for _, e := range entries {
+		m[e] = struct{}{}
+	}
+	return m
+}()
 
 // DisplayName is the user-chosen profile display name, trimmed, 1..DisplayNameMax graphemes.
 // The zero value (DisplayName("")) is invalid; use ParseDisplayName to construct.
 type DisplayName string
 
 // ParseDisplayName trims surrounding whitespace from s, counts grapheme clusters,
-// and returns a validated DisplayName or a sentinel error.
+// checks against the reserved-name blocklist, and returns a validated DisplayName
+// or a sentinel error.
 func ParseDisplayName(s string) (DisplayName, error) {
 	trimmed := strings.TrimSpace(s)
 	n := uniseg.GraphemeClusterCount(trimmed)
@@ -28,6 +56,9 @@ func ParseDisplayName(s string) (DisplayName, error) {
 	}
 	if n > DisplayNameMax {
 		return "", ErrDisplayNameTooLong
+	}
+	if _, reserved := reservedDisplayNames[strings.ToLower(trimmed)]; reserved {
+		return "", ErrDisplayNameReserved
 	}
 	return DisplayName(trimmed), nil
 }

--- a/backend/internal/domain/display_name_test.go
+++ b/backend/internal/domain/display_name_test.go
@@ -53,6 +53,45 @@ func TestParseDisplayName(t *testing.T) {
 			input:       strings.Repeat(zwjEmoji, 51),
 			sentinelErr: ErrDisplayNameTooLong,
 		},
+
+		// Reserved-name cases.
+		{
+			name:        "reserved exact lowercase admin",
+			input:       "admin",
+			sentinelErr: ErrDisplayNameReserved,
+		},
+		{
+			name:        "reserved mixed-case Admin",
+			input:       "Admin",
+			sentinelErr: ErrDisplayNameReserved,
+		},
+		{
+			name:        "reserved all-uppercase ADMIN",
+			input:       "ADMIN",
+			sentinelErr: ErrDisplayNameReserved,
+		},
+		{
+			name:        "reserved with surrounding whitespace",
+			input:       "  admin  ",
+			sentinelErr: ErrDisplayNameReserved,
+		},
+		{
+			name:        "reserved flamingo",
+			input:       "flamingo",
+			sentinelErr: ErrDisplayNameReserved,
+		},
+		{
+			name:        "reserved system",
+			input:       "system",
+			sentinelErr: ErrDisplayNameReserved,
+		},
+
+		// Near-miss: must be accepted (substring match is NOT applied).
+		{
+			name:      "near-miss Adminah is accepted",
+			input:     "Adminah",
+			wantValue: DisplayName("Adminah"),
+		},
 	}
 
 	for _, tc := range cases {

--- a/backend/internal/usecase/validators.go
+++ b/backend/internal/usecase/validators.go
@@ -95,6 +95,8 @@ func translateDisplayNameErr(err error) error {
 		return ucerr.NewValidationError("displayName", "displayName is required")
 	case errors.Is(err, domain.ErrDisplayNameTooLong):
 		return ucerr.NewValidationError("displayName", fmt.Sprintf("displayName must be at most %d characters", domain.DisplayNameMax))
+	case errors.Is(err, domain.ErrDisplayNameReserved):
+		return ucerr.NewValidationError("displayName", "displayName is reserved")
 	default:
 		return eris.Wrap(err, "usecase: translate display name error")
 	}

--- a/backend/internal/usecase/validators_test.go
+++ b/backend/internal/usecase/validators_test.go
@@ -1,9 +1,12 @@
 package usecase
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"backend/internal/domain"
 )
 
 func TestValidateRelayArgs(t *testing.T) {
@@ -102,6 +105,63 @@ func TestValidateRelayArgs(t *testing.T) {
 			if tc.wantField == "" {
 				require.NoError(t, err)
 			} else {
+				require.Error(t, err)
+				assertValidationError(t, err, tc.wantField, tc.wantMsg)
+			}
+		})
+	}
+}
+
+func TestTranslateDisplayNameErr(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		input     error
+		wantField string // non-empty when a ValidationError is expected
+		wantMsg   string // exact message when a ValidationError is expected
+		wantChain string // non-empty when an internal-chain wrap is expected
+	}{
+		{
+			name:  "nil passes through",
+			input: nil,
+		},
+		{
+			name:      "required sentinel",
+			input:     domain.ErrDisplayNameRequired,
+			wantField: "displayName",
+			wantMsg:   "displayName is required",
+		},
+		{
+			name:      "too-long sentinel",
+			input:     domain.ErrDisplayNameTooLong,
+			wantField: "displayName",
+		},
+		{
+			name:      "reserved sentinel",
+			input:     domain.ErrDisplayNameReserved,
+			wantField: "displayName",
+			wantMsg:   "displayName is reserved",
+		},
+		{
+			name:      "unexpected error wraps as internal",
+			input:     errors.New("surprise"),
+			wantChain: "usecase: translate display name error",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := translateDisplayNameErr(tc.input)
+
+			switch {
+			case tc.input == nil:
+				require.NoError(t, err)
+			case tc.wantChain != "":
+				assertInternalChain(t, err, tc.wantChain)
+			default:
 				require.Error(t, err)
 				assertValidationError(t, err, tc.wantField, tc.wantMsg)
 			}


### PR DESCRIPTION
## Summary

Adds a reserved-name blocklist to `domain.ParseDisplayName` so users cannot pick display names that impersonate the platform or staff (`admin`, `support`, `flamingo-armond`, ...). The comparison is exact normalized equality (trim + lowercase) — no substring matching, so legitimate names like "Adminah" stay accepted.

## Changes

- `backend/internal/domain/display_name.go`: new sentinel `ErrDisplayNameReserved` (`eris.New`, matching the file's existing sentinel style); unexported `reservedDisplayNames` set built from 11 literals plus `AdminRoleName` / `GeneralRoleName` (referencing the constants, not re-typed literals, to avoid drift); `ParseDisplayName` checks the set after the length checks.
- `backend/internal/usecase/validators.go`: `translateDisplayNameErr` gains the `ErrDisplayNameReserved` case returning `ucerr.NewValidationError("displayName", "displayName is reserved")`.
- Tests: table cases for exact / mixed-case / whitespace-padded reserved names and the "Adminah" near-miss negative; new `TestTranslateDisplayNameErr` covering nil pass-through, both length sentinels, the reserved sentinel, and the default arm.

No frontend change required — the existing `getBackendFieldErrors` path renders the field-level `BAD_USER_INPUT` on the profile/onboarding form.

## Test plan

- [x] `go vet` / `go build` (domain + usecase) green; `go test ./internal/domain/... ./internal/usecase/...` — 642 tests pass
- [x] Full `go test ./...`: 959 passed; 7 packages fail to build locally with pre-existing missing-go.sum-entry errors (identical on `main`, local toolchain issue) — CI runs the full suite

Closes #327
