### PR TITLE
feat(frontend): add robots.ts and sitemap.ts route handlers

### DIFF
--- a/frontend/src/app/robots.test.ts
+++ b/frontend/src/app/robots.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "vitest";
+import robots from "@/app/robots";
+
+describe("robots()", () => {
+  const result = robots();
+
+  test("disallows /admin/ from crawlers", () => {
+    const { disallow } = result.rules as { disallow: string[] };
+    expect(disallow).toContain("/admin/");
+  });
+
+  test("disallows /api/ from crawlers", () => {
+    const { disallow } = result.rules as { disallow: string[] };
+    expect(disallow).toContain("/api/");
+  });
+
+  test("disallows /profile/ from crawlers", () => {
+    const { disallow } = result.rules as { disallow: string[] };
+    expect(disallow).toContain("/profile/");
+  });
+
+  test("disallows /learn/ from crawlers", () => {
+    const { disallow } = result.rules as { disallow: string[] };
+    expect(disallow).toContain("/learn/");
+  });
+
+  test("disallows /cardgroups/ from crawlers", () => {
+    const { disallow } = result.rules as { disallow: string[] };
+    expect(disallow).toContain("/cardgroups/");
+  });
+
+  test("disallows /auth/ from crawlers", () => {
+    const { disallow } = result.rules as { disallow: string[] };
+    expect(disallow).toContain("/auth/");
+  });
+
+  test("allows the root path", () => {
+    const { allow } = result.rules as { allow: string };
+    expect(allow).toBe("/");
+  });
+
+  test("applies rules to all user agents", () => {
+    const { userAgent } = result.rules as { userAgent: string };
+    expect(userAgent).toBe("*");
+  });
+
+  test("sitemap URL points to /sitemap.xml under the site origin", () => {
+    expect(result.sitemap).toMatch(/\/sitemap\.xml$/);
+    expect(result.sitemap).toMatch(/^https?:\/\//);
+  });
+});

--- a/frontend/src/app/robots.ts
+++ b/frontend/src/app/robots.ts
@@ -1,0 +1,14 @@
+import type { MetadataRoute } from "next";
+import { env } from "@/env";
+
+export default function robots(): MetadataRoute.Robots {
+  const siteUrl = env.NEXT_PUBLIC_SITE_URL;
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+      disallow: ["/api/", "/admin/", "/profile/", "/learn/", "/cardgroups/", "/auth/"],
+    },
+    sitemap: `${siteUrl}/sitemap.xml`,
+  };
+}

--- a/frontend/src/app/sitemap.test.ts
+++ b/frontend/src/app/sitemap.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "vitest";
+import sitemap from "@/app/sitemap";
+
+describe("sitemap()", () => {
+  const entries = sitemap();
+
+  test("contains exactly two entries: / and /login", () => {
+    const paths = entries.map((e) => new URL(e.url).pathname);
+    expect(paths).toHaveLength(2);
+    expect(paths).toContain("/");
+    expect(paths).toContain("/login");
+  });
+
+  test("does not include any dynamic segment (no [ or ] in URLs)", () => {
+    for (const entry of entries) {
+      expect(entry.url).not.toContain("[");
+      expect(entry.url).not.toContain("]");
+    }
+  });
+
+  test("does not include any private route prefix", () => {
+    const privatePatterns = ["/admin", "/profile", "/learn", "/cardgroups", "/api", "/auth"];
+    for (const entry of entries) {
+      const { pathname } = new URL(entry.url);
+      for (const prefix of privatePatterns) {
+        expect(pathname).not.toMatch(new RegExp(`^${prefix}`));
+      }
+    }
+  });
+
+  test("all URLs use the site origin and are absolute", () => {
+    for (const entry of entries) {
+      expect(entry.url).toMatch(/^https?:\/\//);
+    }
+  });
+
+  test("each entry carries lastModified, changeFrequency, and priority", () => {
+    for (const entry of entries) {
+      expect(entry.lastModified).toBeInstanceOf(Date);
+      expect(entry.changeFrequency).toBeDefined();
+      expect(entry.priority).toBeTypeOf("number");
+    }
+  });
+});

--- a/frontend/src/app/sitemap.ts
+++ b/frontend/src/app/sitemap.ts
@@ -1,0 +1,21 @@
+import type { MetadataRoute } from "next";
+import { env } from "@/env";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const siteUrl = env.NEXT_PUBLIC_SITE_URL;
+  const lastModified = new Date();
+  return [
+    {
+      url: `${siteUrl}/`,
+      lastModified,
+      changeFrequency: "weekly",
+      priority: 1.0,
+    },
+    {
+      url: `${siteUrl}/login`,
+      lastModified,
+      changeFrequency: "monthly",
+      priority: 0.5,
+    },
+  ];
+}


### PR DESCRIPTION
## Summary

Adds `robots.ts` and `sitemap.ts` route handlers. Crawlers get explicit directives: only the public landing surface (`/`, `/login`) is crawlable; per-user dynamic routes and API routes are disallowed.

**Stacked on #324** (consumes the `NEXT_PUBLIC_SITE_URL` it introduces). The base branch is `feat/324-seo-metadata-og`; retarget to `main` after #324 merges.

## Changes

- `frontend/src/app/robots.ts`: allow `/`; disallow `/api/`, `/admin/`, `/profile/`, `/learn/`, `/cardgroups/`, `/auth/`; `Sitemap:` line points at `${siteUrl}/sitemap.xml`.
- `frontend/src/app/sitemap.ts`: exactly two entries (`/` and `/login`) with `lastModified` / `changeFrequency` / `priority`.
- Co-located tests assert the disallow list covers `/admin/` and `/api/`, the sitemap lists only the two public routes, and no sitemap URL contains a dynamic segment or a private prefix.

## Test plan

- [x] `pnpm --filter frontend lint` / `typecheck` / `test` (106 files, 1088 tests) / `build` all green
- [x] `/robots.txt` and `/sitemap.xml` appear as static routes in the build output

Closes #325
