### PR TITLE
perf(frontend): gate learn-page LCP on a single GraphQL fetch

### DIFF
--- a/frontend/src/app/learn/[cardgroupId]/learn-client.test.tsx
+++ b/frontend/src/app/learn/[cardgroupId]/learn-client.test.tsx
@@ -213,6 +213,34 @@ function makeDefaultPrefetchMocks(count = 4) {
   }));
 }
 
+/**
+ * Default `SetLastViewedCardgroup` no-op success mock.
+ *
+ * The persist-last-viewed effect fires unconditionally on mount (the page no
+ * longer fetches a last-viewed value to short-circuit it), so every render of
+ * `LearnClient` issues one `SetLastViewedCardgroup` mutation. Without a matching
+ * mock the file-wide leak spy (which includes `SetLastViewedCardgroup` in
+ * `operationNames`) records an unmatched-request warning. Tests in the dedicated
+ * persist-last-viewed describe supply their own mocks instead.
+ */
+function makeDefaultPersistMock() {
+  return {
+    request: { query: SetLastViewedCardgroupDocument, variables: { cardgroupId: CG_ID } },
+    result: {
+      data: {
+        setLastViewedCardgroup: {
+          __typename: "SetLastViewedCardgroupSuccess" as const,
+          user: {
+            __typename: "User" as const,
+            id: "u-default",
+            lastViewedCardgroup: { __typename: "Cardgroup" as const, id: CG_ID },
+          },
+        },
+      },
+    },
+  };
+}
+
 type RenderLearnClientOptions = {
   /**
    * When `true`, do NOT append default `LearnNextDueCards` no-op mocks. Used
@@ -228,19 +256,18 @@ function renderLearnClient(
   initialCards = [CARD_1],
   options: RenderLearnClientOptions = {},
 ) {
-  // Pass `lastViewedCardgroupId === CG_ID` so the persist-last-viewed effect
-  // short-circuits before issuing a mutation; that mutation is exercised in
-  // its own test below and would otherwise need a mock entry in every case.
-  //
-  // Append default no-op `LearnNextDueCards` mocks so the prefetch effect is
-  // satisfied for any test whose initial queue length is 1..PREFETCH_THRESHOLD.
-  // See `makeDefaultPrefetchMocks` JSDoc for rationale.
+  // The persist-last-viewed effect fires unconditionally on mount, so append a
+  // no-op `SetLastViewedCardgroup` mock to satisfy it; that mutation's behaviour
+  // is exercised in its own describe below. Append default no-op
+  // `LearnNextDueCards` mocks so the prefetch effect is satisfied for any test
+  // whose initial queue length is 1..PREFETCH_THRESHOLD. See the
+  // `makeDefaultPersistMock` / `makeDefaultPrefetchMocks` JSDoc for rationale.
   const mergedMocks = options.skipDefaultPrefetchMocks
-    ? mocks
-    : [...mocks, ...makeDefaultPrefetchMocks()];
+    ? [...mocks, makeDefaultPersistMock()]
+    : [...mocks, makeDefaultPersistMock(), ...makeDefaultPrefetchMocks()];
   render(
     <MockedProvider mocks={mergedMocks as never}>
-      <LearnClient cardgroupId={CG_ID} initialCards={initialCards} lastViewedCardgroupId={CG_ID} />
+      <LearnClient cardgroupId={CG_ID} initialCards={initialCards} />
     </MockedProvider>,
   );
 }
@@ -564,7 +591,7 @@ describe("<LearnClient>", () => {
     // to pass a LearnClient-compatible card with a non-null level without fighting
     // that inference — the same pattern used by the persist-last-viewed tests.
     render(
-      <MockedProvider mocks={makeDefaultPrefetchMocks()}>
+      <MockedProvider mocks={[makeDefaultPersistMock(), ...makeDefaultPrefetchMocks()]}>
         <LearnClient
           cardgroupId={CG_ID}
           initialCards={[
@@ -578,7 +605,6 @@ describe("<LearnClient>", () => {
               cardgroupId: CG_ID,
             },
           ]}
-          lastViewedCardgroupId={CG_ID}
         />
       </MockedProvider>,
     );
@@ -641,13 +667,13 @@ describe("<LearnClient> persist-last-viewed path", () => {
     consoleWarnSpy.mockRestore();
   });
 
-  it("fires SetLastViewedCardgroup mutation when ids differ", async () => {
+  it("fires SetLastViewedCardgroup mutation on mount", async () => {
     const mutationCalled = vi.fn();
     render(
       <MockedProvider
         mocks={[makePersistMock(CG_ID, mutationCalled), ...makeDefaultPrefetchMocks()]}
       >
-        <LearnClient cardgroupId={CG_ID} initialCards={[CARD_1]} lastViewedCardgroupId="cg-other" />
+        <LearnClient cardgroupId={CG_ID} initialCards={[CARD_1]} />
       </MockedProvider>,
     );
 
@@ -661,7 +687,7 @@ describe("<LearnClient> persist-last-viewed path", () => {
 
     render(
       <MockedProvider mocks={[makePersistMock(CG_ID), ...makeDefaultPrefetchMocks()]} cache={cache}>
-        <LearnClient cardgroupId={CG_ID} initialCards={[CARD_1]} lastViewedCardgroupId="cg-other" />
+        <LearnClient cardgroupId={CG_ID} initialCards={[CARD_1]} />
       </MockedProvider>,
     );
 
@@ -707,7 +733,7 @@ describe("<LearnClient> persist-last-viewed path", () => {
 
     render(
       <MockedProvider mocks={[validationMock, ...makeDefaultPrefetchMocks()]} cache={cache}>
-        <LearnClient cardgroupId={CG_ID} initialCards={[CARD_1]} lastViewedCardgroupId="cg-other" />
+        <LearnClient cardgroupId={CG_ID} initialCards={[CARD_1]} />
       </MockedProvider>,
     );
 
@@ -757,7 +783,7 @@ describe("<LearnClient> persist-last-viewed path", () => {
   ] as const)("swallows %s from the persist mutation without throwing", async (_, mockEntry) => {
     render(
       <MockedProvider mocks={[mockEntry, ...makeDefaultPrefetchMocks()]}>
-        <LearnClient cardgroupId={CG_ID} initialCards={[CARD_1]} lastViewedCardgroupId="cg-other" />
+        <LearnClient cardgroupId={CG_ID} initialCards={[CARD_1]} />
       </MockedProvider>,
     );
 
@@ -944,12 +970,8 @@ describe("<LearnClient> onSwipe identity stability", () => {
     };
 
     render(
-      <MockedProvider mocks={[swipeMock, ...makeDefaultPrefetchMocks()]}>
-        <LearnClient
-          cardgroupId={CG_ID}
-          initialCards={[CARD_1, CARD_2]}
-          lastViewedCardgroupId={CG_ID}
-        />
+      <MockedProvider mocks={[swipeMock, makeDefaultPersistMock(), ...makeDefaultPrefetchMocks()]}>
+        <LearnClient cardgroupId={CG_ID} initialCards={[CARD_1, CARD_2]} />
       </MockedProvider>,
     );
 

--- a/frontend/src/app/learn/[cardgroupId]/learn-client.tsx
+++ b/frontend/src/app/learn/[cardgroupId]/learn-client.tsx
@@ -41,11 +41,9 @@ function modeFromDirection(direction: SwipeDirection): 1 | 2 | 4 {
 type Props = {
   cardgroupId: string;
   initialCards: LearnCard[];
-  /** The id of the user's `lastViewedCardgroup` at server-render time. */
-  lastViewedCardgroupId: string | null;
 };
 
-export function LearnClient({ cardgroupId, initialCards, lastViewedCardgroupId }: Props) {
+export function LearnClient({ cardgroupId, initialCards }: Props) {
   const [queue, setQueue] = useState<LearnCard[]>(initialCards);
   const [completed, setCompleted] = useState(0);
   const [localError, setLocalError] = useState<string | null>(null);
@@ -60,9 +58,12 @@ export function LearnClient({ cardgroupId, initialCards, lastViewedCardgroupId }
   const visibleError = localError ?? backendError;
 
   // Persist this cardgroup as the user's last-viewed cardgroup so the HomePage
-  // RSC can land them here on next visit. Frontend skips the network call when
-  // the server already reports this cardgroup as last-viewed; the server has
-  // no throttle (YAGNI). Errors are non-fatal — learning continues.
+  // RSC can land them here on next visit. The sync runs once per mount and is
+  // fire-and-forget: the page deliberately does NOT fetch the current
+  // last-viewed value (that would put an extra query on the LCP critical path),
+  // so the mutation always fires even when the value is already current. The
+  // server has no throttle (YAGNI) and the redundant write is harmless. Errors
+  // are non-fatal — learning continues.
   //
   // The mutation is fired via the imperative client API rather than useMutation
   // so the cache update can run regardless of caller render state, and so we
@@ -79,7 +80,6 @@ export function LearnClient({ cardgroupId, initialCards, lastViewedCardgroupId }
   const client = useApolloClient();
   const lastDispatchedRef = useRef<string | null>(null);
   useEffect(() => {
-    if (lastViewedCardgroupId === cardgroupId) return;
     if (lastDispatchedRef.current === cardgroupId) return;
     lastDispatchedRef.current = cardgroupId;
     client
@@ -130,7 +130,7 @@ export function LearnClient({ cardgroupId, initialCards, lastViewedCardgroupId }
           codes: liftGraphQLCodes(err),
         });
       });
-  }, [cardgroupId, lastViewedCardgroupId, client]);
+  }, [cardgroupId, client]);
 
   // Background prefetch: the ONLY mechanism that refills the queue.
   //

--- a/frontend/src/app/learn/[cardgroupId]/page.test.tsx
+++ b/frontend/src/app/learn/[cardgroupId]/page.test.tsx
@@ -21,14 +21,12 @@ vi.mock("./learn-client", () => ({
   LearnClient: ({
     cardgroupId,
     initialCards,
-    lastViewedCardgroupId,
   }: {
     cardgroupId: string;
     initialCards: unknown[];
-    lastViewedCardgroupId: string | null;
   }) => (
     <div data-testid="learn-client">
-      {cardgroupId}:{initialCards.length}:{lastViewedCardgroupId ?? "null"}
+      {cardgroupId}:{initialCards.length}
     </div>
   ),
 }));
@@ -105,7 +103,7 @@ describe("LearnPage — LearnContent gqlFetch error branches", () => {
 
       // PII-redacted payload: only `name` is logged, never `message`.
       expect(consoleErrorSpy).toHaveBeenCalledWith(
-        "[learn] gqlFetch batch failed:",
+        "[learn] gqlFetch failed:",
         expect.objectContaining({ name: expect.any(String) }),
       );
       // Assert that `message` (which may carry user-supplied content) is absent.
@@ -165,7 +163,7 @@ describe("LearnPage", () => {
     expect(gqlFetch).not.toHaveBeenCalled();
   });
 
-  it("redirects to /login when the GraphQL batch returns UNAUTHENTICATED", async () => {
+  it("redirects to /login when LearnNextDueCards returns UNAUTHENTICATED", async () => {
     vi.mocked(gqlFetch).mockRejectedValue(
       new Error(`GraphQL errors: ${JSON.stringify([{ extensions: { code: "UNAUTHENTICATED" } }])}`),
     );
@@ -176,14 +174,17 @@ describe("LearnPage", () => {
     await expect(childType(childProps)).rejects.toThrow("REDIRECT:/login");
   });
 
-  it("redirects to /cardgroups when the cardgroup is not found", async () => {
-    vi.mocked(gqlFetch)
-      .mockResolvedValueOnce({ cardgroup: null } as never)
-      .mockResolvedValueOnce({ learnNextDueCards: [] } as never)
-      .mockResolvedValueOnce({
-        me: { id: "user-1", lastViewedCardgroup: null },
-        myCardgroupsConnection: { __typename: "CardgroupConnection", totalCount: 0 },
-      } as never);
+  it("redirects to /cardgroups when LearnNextDueCards returns BAD_USER_INPUT (missing cardgroup)", async () => {
+    // The usecase authorizes the cardgroup inside the cards query, so a missing
+    // cardgroup surfaces as BAD_USER_INPUT — the surviving form of the old
+    // CardgroupQuery existence guard.
+    vi.mocked(gqlFetch).mockRejectedValue(
+      new Error(
+        `GraphQL errors: ${JSON.stringify([
+          { extensions: { code: "BAD_USER_INPUT", field: "cardgroupId" } },
+        ])}`,
+      ),
+    );
 
     const jsx = await LearnPage({ params: Promise.resolve({ cardgroupId: "cg-1" }) });
     const { childType, childProps } = getSuspenseChild(jsx);
@@ -192,56 +193,40 @@ describe("LearnPage", () => {
   });
 
   it("server-renders the first card batch into LearnClient", async () => {
-    vi.mocked(gqlFetch)
-      .mockResolvedValueOnce({
-        cardgroup: { id: "cg-1", name: "Spanish", updatedAt: "2026-04-30T00:00:00Z" },
-      } as never)
-      .mockResolvedValueOnce({
-        learnNextDueCards: [
-          {
-            id: "c-1",
-            front: "Hello",
-            back: "Hola",
-            userCardState: {
-              due: "2026-04-30T00:00:00Z",
-              state: 0,
-            },
-            cardgroupId: "cg-1",
+    vi.mocked(gqlFetch).mockResolvedValueOnce({
+      learnNextDueCards: [
+        {
+          id: "c-1",
+          front: "Hello",
+          back: "Hola",
+          userCardState: {
+            due: "2026-04-30T00:00:00Z",
+            state: 0,
           },
-        ],
-      } as never)
-      .mockResolvedValueOnce({
-        me: { id: "user-1", lastViewedCardgroup: { id: "cg-old" } },
-        myCardgroupsConnection: { __typename: "CardgroupConnection", totalCount: 0 },
-      } as never);
+          cardgroupId: "cg-1",
+        },
+      ],
+    } as never);
 
     const jsx = await LearnPage({ params: Promise.resolve({ cardgroupId: "cg-1" }) });
     const { childType, childProps } = getSuspenseChild(jsx);
     const inner = await childType(childProps);
     render(inner as React.ReactElement);
 
-    // Format: cardgroupId:initialCards.length:lastViewedCardgroupId
-    expect(screen.getByTestId("learn-client")).toHaveTextContent("cg-1:1:cg-old");
+    // Format: cardgroupId:initialCards.length
+    expect(screen.getByTestId("learn-client")).toHaveTextContent("cg-1:1");
   });
 
   it("server-renders an empty due batch into LearnClient", async () => {
-    vi.mocked(gqlFetch)
-      .mockResolvedValueOnce({
-        cardgroup: { id: "cg-1", name: "Spanish", updatedAt: "2026-04-30T00:00:00Z" },
-      } as never)
-      .mockResolvedValueOnce({
-        learnNextDueCards: [],
-      } as never)
-      .mockResolvedValueOnce({
-        me: { id: "user-1", lastViewedCardgroup: null },
-        myCardgroupsConnection: { __typename: "CardgroupConnection", totalCount: 0 },
-      } as never);
+    vi.mocked(gqlFetch).mockResolvedValueOnce({
+      learnNextDueCards: [],
+    } as never);
 
     const jsx = await LearnPage({ params: Promise.resolve({ cardgroupId: "cg-1" }) });
     const { childType, childProps } = getSuspenseChild(jsx);
     const inner = await childType(childProps);
     render(inner as React.ReactElement);
 
-    expect(screen.getByTestId("learn-client")).toHaveTextContent("cg-1:0:null");
+    expect(screen.getByTestId("learn-client")).toHaveTextContent("cg-1:0");
   });
 });

--- a/frontend/src/app/learn/[cardgroupId]/page.tsx
+++ b/frontend/src/app/learn/[cardgroupId]/page.tsx
@@ -2,14 +2,11 @@ import type { Metadata } from "next";
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 import { Suspense } from "react";
-import { CardgroupQuery } from "@/app/cardgroups/queries";
-import { MeWithLastViewedQuery } from "@/app/queries";
-import type {
-  CardgroupQuery as CardgroupQueryType,
-  LearnNextDueCardsQuery as LearnNextDueCardsQueryType,
-  MeWithLastViewedQuery as MeWithLastViewedQueryType,
-} from "@/generated/graphql";
-import { isUnauthenticatedGraphQLError } from "@/lib/apollo/graphql-errors";
+import type { LearnNextDueCardsQuery as LearnNextDueCardsQueryType } from "@/generated/graphql";
+import {
+  isBadUserInputGraphQLError,
+  isUnauthenticatedGraphQLError,
+} from "@/lib/apollo/graphql-errors";
 import { gqlFetch } from "@/lib/apollo/server";
 import { readAuthContext } from "@/lib/supabase/auth-status";
 import { LEARN_PAGE_LIMIT, LearnNextDueCardsQuery } from "../queries";
@@ -46,44 +43,42 @@ export default async function LearnPage({ params }: { params: Promise<{ cardgrou
 
 /**
  * Data-dependent subtree streamed inside the `<Suspense>` boundary. Auth has
- * already passed at this point; this component only loads the data needed to
- * hydrate `<LearnClient>` and handles the post-auth redirect cases (missing
- * cardgroup, GraphQL UNAUTHENTICATED).
+ * already passed at this point.
+ *
+ * The LCP element is the card text, which depends ONLY on `LearnNextDueCards`.
+ * That query is therefore the single fetch on the LCP critical path — the
+ * cardgroup-existence check and the last-viewed sync are deliberately NOT
+ * fetched here, so they cannot hold the card paint hostage (see the learn-page
+ * LCP investigation). Both concerns are recovered without an extra blocking
+ * fetch: `LearnNextDueCards` already authorizes the cardgroup in the usecase
+ * layer (`authorizeCardgroupForLearn`), so a missing cardgroup surfaces as a
+ * `BAD_USER_INPUT` rejection (-> `/cardgroups`, mirroring the prior
+ * CardgroupQuery guard) and a non-owned one as `UNAUTHENTICATED` (-> `/login`);
+ * the last-viewed sync runs client-side in `<LearnClient>`.
  */
 async function LearnContent({ cardgroupId }: { cardgroupId: string }) {
-  let cardgroupData: CardgroupQueryType;
   let cardsData: LearnNextDueCardsQueryType;
-  let meData: MeWithLastViewedQueryType;
 
   try {
-    [cardgroupData, cardsData, meData] = await Promise.all([
-      gqlFetch(CardgroupQuery, { variables: { id: cardgroupId }, revalidate: 0 }),
-      gqlFetch(LearnNextDueCardsQuery, {
-        variables: { cardgroupId, limit: LEARN_PAGE_LIMIT },
-        revalidate: 0,
-      }),
-      gqlFetch(MeWithLastViewedQuery, { revalidate: 0 }),
-    ]);
+    cardsData = await gqlFetch(LearnNextDueCardsQuery, {
+      variables: { cardgroupId, limit: LEARN_PAGE_LIMIT },
+      revalidate: 0,
+    });
   } catch (err) {
     if (isUnauthenticatedGraphQLError(err)) {
       redirect("/login");
     }
-    console.error("[learn] gqlFetch batch failed:", {
+    // `LearnNextDueCards` only returns BAD_USER_INPUT for a missing cardgroup
+    // (usecase `authorizeCardgroupForLearn` -> `NewValidationError("cardgroupId")`),
+    // so this branch is the surviving form of the old cardgroup-existence guard.
+    if (isBadUserInputGraphQLError(err)) {
+      redirect("/cardgroups");
+    }
+    console.error("[learn] gqlFetch failed:", {
       name: err instanceof Error ? err.name : "unknown",
     });
     throw err;
   }
 
-  if (!cardgroupData.cardgroup) redirect("/cardgroups");
-
-  const cards = cardsData.learnNextDueCards;
-  const lastViewedCardgroupId = meData.me?.lastViewedCardgroup?.id ?? null;
-
-  return (
-    <LearnClient
-      cardgroupId={cardgroupId}
-      initialCards={cards}
-      lastViewedCardgroupId={lastViewedCardgroupId}
-    />
-  );
+  return <LearnClient cardgroupId={cardgroupId} initialCards={cardsData.learnNextDueCards} />;
 }

--- a/frontend/src/lib/apollo/graphql-errors.test.ts
+++ b/frontend/src/lib/apollo/graphql-errors.test.ts
@@ -1,6 +1,7 @@
 import { CombinedGraphQLErrors } from "@apollo/client/errors";
 import { describe, expect, test, vi } from "vitest";
 import {
+  isBadUserInputGraphQLError,
   isForbiddenGraphQLError,
   isUnauthenticatedGraphQLError,
   liftGraphQLCodes,
@@ -183,5 +184,42 @@ describe("isForbiddenGraphQLError", () => {
       { extensions: { code: "FORBIDDEN" } },
     ]);
     expect(isForbiddenGraphQLError(err)).toBe(true);
+  });
+});
+
+describe("isBadUserInputGraphQLError", () => {
+  test("non-Error value returns false", () => {
+    expect(isBadUserInputGraphQLError(null)).toBe(false);
+    expect(isBadUserInputGraphQLError("some string")).toBe(false);
+  });
+
+  test("Error with wrong prefix returns false", () => {
+    expect(isBadUserInputGraphQLError(new Error("BAD_USER_INPUT"))).toBe(false);
+  });
+
+  test("Error with correct prefix but malformed JSON returns false", () => {
+    expect(isBadUserInputGraphQLError(new Error(`${PREFIX}not-json`))).toBe(false);
+  });
+
+  test("correct prefix + non-array JSON payload returns false", () => {
+    expect(isBadUserInputGraphQLError(new Error(`${PREFIX}{}`))).toBe(false);
+  });
+
+  test("Error with UNAUTHENTICATED code (not BAD_USER_INPUT) returns false", () => {
+    const err = makeErr([{ extensions: { code: "UNAUTHENTICATED" } }]);
+    expect(isBadUserInputGraphQLError(err)).toBe(false);
+  });
+
+  test("Error with BAD_USER_INPUT code returns true", () => {
+    const err = makeErr([{ extensions: { code: "BAD_USER_INPUT" } }]);
+    expect(isBadUserInputGraphQLError(err)).toBe(true);
+  });
+
+  test("mixed errors array with at least one BAD_USER_INPUT returns true", () => {
+    const err = makeErr([
+      { extensions: { code: "UNAUTHENTICATED" } },
+      { extensions: { code: "BAD_USER_INPUT", field: "cardgroupId" } },
+    ]);
+    expect(isBadUserInputGraphQLError(err)).toBe(true);
   });
 });

--- a/frontend/src/lib/apollo/graphql-errors.ts
+++ b/frontend/src/lib/apollo/graphql-errors.ts
@@ -46,3 +46,7 @@ export function isUnauthenticatedGraphQLError(err: unknown): boolean {
 export function isForbiddenGraphQLError(err: unknown): boolean {
   return parseGqlErrors(err)?.some((e) => e?.extensions?.code === "FORBIDDEN") ?? false;
 }
+
+export function isBadUserInputGraphQLError(err: unknown): boolean {
+  return parseGqlErrors(err)?.some((e) => e?.extensions?.code === "BAD_USER_INPUT") ?? false;
+}


### PR DESCRIPTION
## Summary

Cuts the learn-page LCP critical path from three server-side GraphQL fetches to one. Production Lighthouse on `/learn/[cardgroupId]` measured LCP 3.7s (mobile) as TTFB 11ms + elementRenderDelay 2535ms: the shell flushed instantly, but the swipe card (the LCP element, an SSR `<p>`) only streamed after `LearnContent` awaited a `Promise.all` of `CardgroupQuery` + `LearnNextDueCards` + `MeWithLastViewedQuery` inside `<Suspense>`. The card text depends only on `LearnNextDueCards`, so the other two queries held the paint hostage; `LearnContent` now awaits that single query.

## Changes

- `frontend/src/app/learn/[cardgroupId]/page.tsx`: `LearnContent` fetches only `LearnNextDueCards`. On that one rejection: `UNAUTHENTICATED` → `/login` (unchanged), `BAD_USER_INPUT` → `/cardgroups`, else PII-redacted `console.error` + rethrow. The `CardgroupQuery` and `MeWithLastViewedQuery` fetches and their imports are removed.
- `frontend/src/lib/apollo/graphql-errors.ts`: new `isBadUserInputGraphQLError`, mirroring the existing `isUnauthenticatedGraphQLError` / `isForbiddenGraphQLError` predicates (structural `extensions.code` check, no message substring matching).
- `frontend/src/app/learn/[cardgroupId]/learn-client.tsx`: remove the `lastViewedCardgroupId` prop and its skip-when-equal optimization. The `setLastViewedCardgroup` sync now fires once per mount (deduped against StrictMode double-mount by `lastDispatchedRef`), staying fire-and-forget and off the LCP path.
- Tests: `graphql-errors.test.ts` adds `isBadUserInputGraphQLError` cases; `page.test.tsx` moves to the single-fetch shape and asserts `BAD_USER_INPUT → /cardgroups`; `learn-client.test.tsx` drops the prop and appends a default no-op `SetLastViewedCardgroup` mock (the mutation now always fires).

Redirect UX is unchanged: the cardgroup-existence guard now rides the cards query's own authorization — the backend usecase `authorizeCardgroupForLearn` already returns `BAD_USER_INPUT(field: cardgroupId)` for a missing cardgroup and `UNAUTHENTICATED` for a non-owned one — so the old `!cardgroup → /cardgroups` check is preserved without a separate query. `setLastViewedCardgroup` keeps no `optimisticResponse`; the static regression-guard test still pins this.

## Test plan

- [x] `pnpm --filter frontend lint` / `typecheck` / `test` (107 files, 1099 tests) / `build` all green
- [ ] After deploy: re-run Lighthouse on `/learn/[cardgroupId]` and confirm LCP drops (card no longer waits on the cardgroup/me fetches)

Backend latency of the surviving `LearnNextDueCards` fetch (~2s server-side) is out of scope. No associated issue.
