### PR TITLE
feat(backend): answer HEAD on /health for free-tier keep-warm pings

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -124,11 +124,19 @@ func newRouter(
 		})
 	})
 
-	e.GET("/health", func(c *echo.Context) error {
+	// /health answers both GET and HEAD. GET serves Render's deploy/liveness
+	// health checks; HEAD serves free-tier keep-warm pings from external uptime
+	// monitors that only issue HEAD requests. Echo does not auto-serve HEAD for
+	// a GET route (the router resolves HEAD to its own slot with no GET
+	// fallback), so a HEAD-only registration gap returns 405; register both
+	// methods explicitly. The HEAD response body is dropped by net/http, so the
+	// shared handler returns the same 200 payload for both.
+	healthz := func(c *echo.Context) error {
 		return c.JSON(http.StatusOK, map[string]string{
 			"status": "ok",
 		})
-	})
+	}
+	e.Match([]string{http.MethodGet, http.MethodHead}, "/health", healthz)
 
 	e.POST("/internal/ping", pingHandler.Handle, pingHandler.RateLimiter())
 	if notionSyncHandler != nil {

--- a/backend/cmd/server/main_test.go
+++ b/backend/cmd/server/main_test.go
@@ -206,6 +206,33 @@ func TestHealthEndpoint(t *testing.T) {
 	}
 }
 
+func TestHealthEndpoint_Head(t *testing.T) {
+	t.Parallel()
+	ts := newTestServer(t)
+
+	res, err := http.Head(ts.URL + "/health")
+	if err != nil {
+		t.Fatalf("HEAD %s/health: %v", ts.URL, err)
+	}
+	defer res.Body.Close()
+
+	// HEAD must succeed (not 405) so external uptime monitors that only issue
+	// HEAD requests classify the service as up while still resetting Render's
+	// free-tier idle timer.
+	if res.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want %d", res.StatusCode, http.StatusOK)
+	}
+
+	// Per HTTP semantics net/http strips the body from a HEAD response.
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	if len(body) != 0 {
+		t.Errorf("HEAD response body = %q, want empty", body)
+	}
+}
+
 func TestRootEndpoint(t *testing.T) {
 	t.Parallel()
 	ts := newTestServer(t)


### PR DESCRIPTION
## Summary

`/health` now answers both `GET` and `HEAD`. Render's free tier spins down a web service after 15 minutes without inbound traffic and takes ~1 minute to cold-start on the next request, which lands on the first visitor as a multi-second first paint. An external uptime monitor pinging the backend on a short interval keeps it warm, but UptimeRobot's free plan only issues `HEAD` requests — and Echo v5 does not auto-serve `HEAD` for a `GET` route, so `HEAD /health` previously returned `405`.

A `405` still resets Render's idle timer (the request reaches the service either way), so keep-warm technically worked, but the monitor classified the service as **down** and alerted on every check. Returning `200` to `HEAD` makes the monitor read **up** while keeping the timer reset.

`GET /health` is unchanged, so Render's own deploy/liveness health check (which uses `GET`) is unaffected.

## Changes

- `backend/cmd/server/main.go`: register `/health` for `GET` + `HEAD` via `e.Match` (was `GET`-only). Echo v5's router resolves `HEAD` to its own slot with no `GET` fallback, so the method must be registered explicitly. `net/http` strips the body from a `HEAD` response, so the shared handler returns the same `200 {"status":"ok"}` payload for both methods.
- `backend/cmd/server/main_test.go`: add `TestHealthEndpoint_Head` asserting `HEAD /health` returns `200` with an empty body.

No `go.mod` / `go.sum` change — the diff adds no new dependency (stdlib + the already-imported Echo router).

## Test plan

- [x] `go build ./cmd/server/` and `go vet ./cmd/server/` green
- [x] `go test ./cmd/server/ -run 'TestHealthEndpoint|TestRootEndpoint'` — GET, HEAD, and root all pass; the request log confirms `method=HEAD uri=/health status=200`
- Full `go test ./...` hits the same pre-existing missing-`go.sum`-entry local toolchain errors present on `main` (identical behavior); CI runs the full suite on a fresh environment.

## Operator note

Point the uptime monitor at the **real** backend public URL (the Render dashboard service URL, i.e. the Vercel `BACKEND_URL` env) — not a guessed `*.onrender.com` host. Ping `/health` at an interval comfortably under 15 minutes (UptimeRobot free = 5 min). Keeping one free service warm 24/7 consumes ~730 of the 750 free instance-hours per month, so this fits only if it is the workspace's sole free web service; otherwise upgrade the Render plan to remove spin-down entirely.

No associated issue.
