### PR TITLE
feat(frontend): show a branded loading/error splash on PWA launch

### DIFF
--- a/frontend/src/app/error.test.tsx
+++ b/frontend/src/app/error.test.tsx
@@ -1,0 +1,35 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import RootError from "./error";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("root <RootError>", () => {
+  it("renders the message and a retry affordance", () => {
+    render(<RootError error={new Error("boom")} reset={vi.fn()} />);
+
+    expect(screen.getByRole("heading", { name: /couldn't load the app/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /try again/i })).toBeInTheDocument();
+  });
+
+  it("calls reset when the retry button is clicked", () => {
+    const reset = vi.fn();
+    render(<RootError error={new Error("boom")} reset={reset} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /try again/i }));
+
+    expect(reset).toHaveBeenCalledTimes(1);
+  });
+
+  it("logs with the [error] scope prefix and redacts the raw message", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const error = Object.assign(new Error("secret-user-content"), { digest: "abc123" });
+
+    render(<RootError error={error} reset={vi.fn()} />);
+
+    expect(spy).toHaveBeenCalledWith("[error]", { name: "Error", digest: "abc123" });
+  });
+});

--- a/frontend/src/app/error.tsx
+++ b/frontend/src/app/error.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useEffect } from "react";
+import { BrandSplash } from "@/components/pwa/brand-splash";
+
+type RootErrorProps = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+/**
+ * Root error boundary for the page subtree.
+ *
+ * Catches errors thrown by any route segment without its own `error.tsx` — most
+ * importantly the root redirect's failed backend fetch when the backend is
+ * stopped or unreachable. It renders the same branded coral splash as the
+ * loading state (static mark) plus a retry control, so a backend outage degrades
+ * to a clean, on-brand screen rather than a blank/error page. `reset()` re-runs
+ * the failed segment, which re-enters the loading splash while the fetch retries.
+ *
+ * Errors thrown from the root layout itself are still handled by
+ * `global-error.tsx`.
+ */
+export default function RootError({ error, reset }: RootErrorProps) {
+  useEffect(() => {
+    // Scope prefix for log streams. Log the error name + digest only, never the
+    // message (which may carry user-supplied content) — mirrors the middleware
+    // and global-error boundaries.
+    console.error("[error]", { name: error.name, digest: error.digest });
+  }, [error]);
+
+  return (
+    <BrandSplash spin={false}>
+      <div className="space-y-2">
+        <h1 className="text-xl font-semibold tracking-tight">We couldn't load the app</h1>
+        <p className="mx-auto max-w-xs text-sm text-white/90">
+          This can happen when the server is starting up. Please try again in a moment.
+        </p>
+      </div>
+      <button
+        type="button"
+        onClick={reset}
+        className="rounded-lg bg-white px-8 py-3 text-sm font-medium text-brand-primary transition-colors hover:bg-white/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-brand-primary"
+      >
+        Try again
+      </button>
+    </BrandSplash>
+  );
+}

--- a/frontend/src/app/loading.test.tsx
+++ b/frontend/src/app/loading.test.tsx
@@ -1,0 +1,11 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import Loading from "./loading";
+
+describe("root <Loading>", () => {
+  it("renders the branded loading splash with an accessible status region", () => {
+    render(<Loading />);
+    expect(screen.getByRole("status", { name: /loading/i })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/loading.tsx
+++ b/frontend/src/app/loading.tsx
@@ -1,0 +1,20 @@
+import { BrandSplash } from "@/components/pwa/brand-splash";
+
+/**
+ * Root-level streaming/navigation fallback.
+ *
+ * The root redirect (`app/page.tsx`) blocks on a GraphQL fetch to the backend
+ * before it can choose a destination. When the backend is cold-starting or
+ * stopped that wait can last tens of seconds, and there is no page UI to stream
+ * during it. This Suspense fallback is rendered entirely by the frontend host
+ * with no backend dependency, so the branded spinner appears immediately — the
+ * PWA launch experience the OS/manifest splash hands off to — instead of a blank
+ * or black screen.
+ *
+ * It also backs any descendant route that lacks its own `loading.tsx`; routes
+ * that ship a skeleton (cardgroups, learn, admin, cards/new) keep theirs, since
+ * the nearest boundary wins.
+ */
+export default function Loading() {
+  return <BrandSplash label="Loading" />;
+}

--- a/frontend/src/components/pwa/brand-splash.test.tsx
+++ b/frontend/src/components/pwa/brand-splash.test.tsx
@@ -1,0 +1,35 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { BrandSplash } from "./brand-splash";
+
+describe("<BrandSplash>", () => {
+  it("pins the coral backdrop to the literal manifest hex for a seamless OS hand-off", () => {
+    const { container } = render(<BrandSplash label="Loading" />);
+    const root = container.firstElementChild as HTMLElement;
+    expect(root).toHaveStyle({ backgroundColor: "#FF6F79" });
+  });
+
+  it("exposes the accessible label as a status region", () => {
+    render(<BrandSplash label="Loading" />);
+    expect(screen.getByRole("status", { name: "Loading" })).toBeInTheDocument();
+  });
+
+  it("omits the status role when no label is given so caller semantics own the region", () => {
+    render(
+      <BrandSplash>
+        <p>content</p>
+      </BrandSplash>,
+    );
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+    expect(screen.getByText("content")).toBeInTheDocument();
+  });
+
+  it("spins the mark by default and holds it static when spin is false", () => {
+    const { container, rerender } = render(<BrandSplash label="Loading" />);
+    expect(container.querySelector("svg")).toHaveClass("motion-safe:animate-spin");
+
+    rerender(<BrandSplash label="Loading" spin={false} />);
+    expect(container.querySelector("svg")).not.toHaveClass("motion-safe:animate-spin");
+  });
+});

--- a/frontend/src/components/pwa/brand-splash.tsx
+++ b/frontend/src/components/pwa/brand-splash.tsx
@@ -1,0 +1,52 @@
+import type { ReactNode } from "react";
+
+// Match the manifest `background_color` and the OS/apple-touch startup images
+// byte-for-byte so the hand-off from the OS launch splash to this in-app splash
+// is seamless. The `--brand-primary` design token is an oklch near-equivalent,
+// not this exact hex, so the backdrop is pinned to the literal instead.
+const BRAND_CORAL = "#FF6F79";
+
+// Donut mark inlined from the source `loading.svg` so the splash needs no extra
+// network request — it paints with the first HTML chunk.
+const DONUT_PATH =
+  "M11.2999 21.925c-2.63335 -0.2 -4.8375 -1.24585 -6.6125 -3.1375 -1.775 -1.8917 -2.6625 -4.1542 -2.6625 -6.7875 0 -2.63335 0.8875 -4.89585 2.6625 -6.7875 1.775 -1.89168 3.97915 -2.93751 6.6125 -3.13751v2.55c-1.91665 0.18333 -3.52085 0.97916 -4.8125 2.38751 -1.29165 1.4083 -1.929165 3.0708 -1.9125 4.9875 0.01667 1.91665 0.6625 3.57915 1.9375 4.9875 1.275 1.4083 2.87085 2.20415 4.7875 2.3875v2.55Zm1.5 0v-2.55c1.76665 -0.15 3.25835 -0.85 4.475 -2.1 1.21665 -1.25 1.93335 -2.75835 2.15 -4.525h2.55c-0.18335 2.4833 -1.1375 4.59165 -2.8625 6.325 -1.725 1.7333 -3.82915 2.6833 -6.3125 2.85Zm6.625 -10.675c-0.2 -1.7667 -0.9125 -3.275 -2.1375 -4.525 -1.225 -1.25 -2.72085 -1.958345 -4.4875 -2.12501v-2.55c2.46665 0.18333 4.56665 1.141665 6.3 2.875 1.73335 1.73331 2.69165 3.84166 2.875 6.32501h-2.55Z";
+
+type BrandSplashProps = {
+  /** Rotate the mark (loading) or hold it static (a terminal/error state). */
+  spin?: boolean;
+  /**
+   * Accessible name for the splash. When provided, the container is announced as
+   * a `status` region (used for the loading state). Omit for content that
+   * carries its own semantics (e.g. an error heading + retry button).
+   */
+  label?: string;
+  /** Content rendered under the mark — a message, a retry control, etc. */
+  children?: ReactNode;
+};
+
+/**
+ * Full-viewport coral splash with the flamingo donut mark.
+ *
+ * Pure markup (no hooks, no client state), so it renders in both a server
+ * boundary (`app/loading.tsx`) and a client boundary (`app/error.tsx`) and ships
+ * zero client JavaScript when used from a server component. The mark spins with a
+ * CSS-only animation that respects `prefers-reduced-motion`.
+ */
+export function BrandSplash({ spin = true, label, children }: BrandSplashProps) {
+  return (
+    <div
+      {...(label ? { role: "status", "aria-label": label } : {})}
+      style={{ backgroundColor: BRAND_CORAL }}
+      className="fixed inset-0 z-50 flex flex-col items-center justify-center gap-6 px-6 text-center text-white"
+    >
+      <svg
+        viewBox="0 0 24 24"
+        aria-hidden="true"
+        className={`size-14 fill-white${spin ? " motion-safe:animate-spin" : ""}`}
+      >
+        <path d={DONUT_PATH} />
+      </svg>
+      {children}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

The PWA `start_url` is `/`, and the root redirect (`app/page.tsx`) blocks on a GraphQL fetch to the backend before it can choose a destination. That root page had **no Suspense fallback** (every other data-fetching route ships a `loading.tsx` skeleton — only the root did not). When the backend is cold-starting or stopped — the free tier spins down after ~15 minutes and takes up to a minute to cold-start — the `await` streams no page UI for tens of seconds, so the launch shows a blank/black screen.

This closes that last gap (the OS startup-image and the layout de-block already cover the earlier launch intervals):

- A root **`app/loading.tsx`** renders a branded coral spinner as the Suspense fallback. It is produced entirely by the frontend host with **no backend dependency**, so it appears immediately while the root redirect waits on the backend — even when the backend is fully stopped.
- A root **`app/error.tsx`** degrades a confirmed backend outage (the root fetch ultimately failing) to the same on-brand splash plus a **Try again** control, instead of bubbling to the generic `global-error` screen.

## Changes

- `frontend/src/components/pwa/brand-splash.tsx`: new shared presentational splash. Full-viewport coral backdrop pinned to the literal `#FF6F79` (matching the manifest `background_color` and the OS/apple-touch startup images byte-for-byte, so the OS→app hand-off is seamless — the `--brand-primary` token is an oklch near-equivalent, not this exact hex). The donut mark is inlined from `loading.svg` (no extra network request) and spins with a CSS-only `motion-safe:animate-spin` that respects `prefers-reduced-motion`. Hook-free, so it renders in both a server boundary (`loading.tsx`) and a client boundary (`error.tsx`) and ships zero client JS from the server side. Props: optional `label` (announces a `status` region), `spin`, `children`.
- `frontend/src/app/loading.tsx`: root streaming/navigation fallback (`<BrandSplash label="Loading" />`, spinning). Also backs any descendant route without its own `loading.tsx`; skeleton-bearing routes (cardgroups, learn, admin, cards/new) keep theirs since the nearest boundary wins.
- `frontend/src/app/error.tsx`: root error boundary (`"use client"`). Renders the static-mark splash + a retry button; `reset()` re-runs the failed segment, which re-enters the loading splash while the fetch retries. Logs `[error]` with the error name + digest only — never the message, which may carry user content (mirrors the middleware / `global-error` boundaries). Root-layout errors are still handled by `global-error.tsx`.
- Tests: `brand-splash.test.tsx` (coral hex, `status` role, spin toggle, children), `loading.test.tsx` (status region), `error.test.tsx` (message, retry → `reset`, redacted log payload).

**Scope note:** `app/error.tsx` is the error boundary for the whole page subtree, so routes without their own `error.tsx` now degrade to this branded retry instead of bubbling to `global-error.tsx` — an on-brand, layout-aware improvement. `global-error.tsx` continues to handle root-layout errors.

UI strings are English; localization (en/ja) of error/PWA strings is tracked by #350 and out of scope here.

## Test plan

- [x] `pnpm --filter frontend typecheck` — green
- [x] `pnpm --filter frontend lint` — green (the only output is a benign `biome.json` `$schema` version info, unrelated to this change)
- [x] `pnpm --filter frontend test` — full suite green (110 files / 1107 tests), including the 3 new files / 8 new tests
- [ ] After deploy: install the PWA, then cold-start or stop the backend and confirm the coral spinner shows on launch instead of a black screen, and that the retry screen appears and recovers once the backend returns (service-worker runtime behavior needs a real HTTPS deployment)

No associated issue.
