### PR TITLE
chore(frontend): correct PWA splash comments and harden its tests

### DIFF
--- a/frontend/src/app/error.test.tsx
+++ b/frontend/src/app/error.test.tsx
@@ -31,5 +31,9 @@ describe("root <RootError>", () => {
     render(<RootError error={error} reset={vi.fn()} />);
 
     expect(spy).toHaveBeenCalledWith("[error]", { name: "Error", digest: "abc123" });
+    // Assert the raw message is absent explicitly, so a future switch to a
+    // partial matcher (e.g. objectContaining) cannot silently let it through.
+    expect(JSON.stringify(spy.mock.calls[0]?.[1])).not.toContain("secret-user-content");
+    expect(spy).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/app/error.tsx
+++ b/frontend/src/app/error.tsx
@@ -23,9 +23,10 @@ type RootErrorProps = {
  */
 export default function RootError({ error, reset }: RootErrorProps) {
   useEffect(() => {
-    // Scope prefix for log streams. Log the error name + digest only, never the
-    // message (which may carry user-supplied content) — mirrors the middleware
-    // and global-error boundaries.
+    // Scope prefix for log streams. Log the error name + digest only — never the
+    // message, which may carry user-supplied content (the middleware redacts the
+    // message the same way). The digest correlates to the server-side log that
+    // does carry the full message.
     console.error("[error]", { name: error.name, digest: error.digest });
   }, [error]);
 

--- a/frontend/src/app/loading.tsx
+++ b/frontend/src/app/loading.tsx
@@ -12,8 +12,7 @@ import { BrandSplash } from "@/components/pwa/brand-splash";
  * or black screen.
  *
  * It also backs any descendant route that lacks its own `loading.tsx`; routes
- * that ship a skeleton (cardgroups, learn, admin, cards/new) keep theirs, since
- * the nearest boundary wins.
+ * that ship their own skeleton keep theirs, since the nearest boundary wins.
  */
 export default function Loading() {
   return <BrandSplash label="Loading" />;

--- a/frontend/src/components/pwa/brand-splash.test.tsx
+++ b/frontend/src/components/pwa/brand-splash.test.tsx
@@ -32,4 +32,11 @@ describe("<BrandSplash>", () => {
     rerender(<BrandSplash label="Loading" spin={false} />);
     expect(container.querySelector("svg")).not.toHaveClass("motion-safe:animate-spin");
   });
+
+  it("marks the donut decorative with aria-hidden so it is not announced", () => {
+    const { container } = render(<BrandSplash label="Loading" />);
+    // The status region already names the splash "Loading"; the mark must stay
+    // out of the accessibility tree to avoid double-announcing.
+    expect(container.querySelector("svg")).toHaveAttribute("aria-hidden", "true");
+  });
 });

--- a/frontend/src/components/pwa/brand-splash.tsx
+++ b/frontend/src/components/pwa/brand-splash.tsx
@@ -6,8 +6,8 @@ import type { ReactNode } from "react";
 // not this exact hex, so the backdrop is pinned to the literal instead.
 const BRAND_CORAL = "#FF6F79";
 
-// Donut mark inlined from the source `loading.svg` so the splash needs no extra
-// network request — it paints with the first HTML chunk.
+// Donut mark inlined as a path literal (Material "Donut Large") so the splash
+// needs no extra network request — it paints with the first HTML chunk.
 const DONUT_PATH =
   "M11.2999 21.925c-2.63335 -0.2 -4.8375 -1.24585 -6.6125 -3.1375 -1.775 -1.8917 -2.6625 -4.1542 -2.6625 -6.7875 0 -2.63335 0.8875 -4.89585 2.6625 -6.7875 1.775 -1.89168 3.97915 -2.93751 6.6125 -3.13751v2.55c-1.91665 0.18333 -3.52085 0.97916 -4.8125 2.38751 -1.29165 1.4083 -1.929165 3.0708 -1.9125 4.9875 0.01667 1.91665 0.6625 3.57915 1.9375 4.9875 1.275 1.4083 2.87085 2.20415 4.7875 2.3875v2.55Zm1.5 0v-2.55c1.76665 -0.15 3.25835 -0.85 4.475 -2.1 1.21665 -1.25 1.93335 -2.75835 2.15 -4.525h2.55c-0.18335 2.4833 -1.1375 4.59165 -2.8625 6.325 -1.725 1.7333 -3.82915 2.6833 -6.3125 2.85Zm6.625 -10.675c-0.2 -1.7667 -0.9125 -3.275 -2.1375 -4.525 -1.225 -1.25 -2.72085 -1.958345 -4.4875 -2.12501v-2.55c2.46665 0.18333 4.56665 1.141665 6.3 2.875 1.73335 1.73331 2.69165 3.84166 2.875 6.32501h-2.55Z";
 


### PR DESCRIPTION
## Summary

Follow-up quality fixes for the PWA loading/error splash, surfaced by a multi-aspect code review (code / tests / comments / errors / types). **No runtime behavior changes** — comment accuracy and test hardening only.

## Changes

- `frontend/src/app/error.tsx`: fix an inaccurate comment. It claimed the `[error]` log "mirrors the middleware **and global-error** boundaries", but `global-error.tsx` logs `error.message` — the very thing this boundary deliberately redacts. Reworded to reference only the middleware's matching message-redaction, and to note that the logged `digest` correlates to the server-side log that does carry the full message (so dropping the message client-side stays diagnosable).
- `frontend/src/components/pwa/brand-splash.tsx`: the donut-path comment referenced a `loading.svg` that does not exist anywhere in the repo (it was the external source asset). Reworded to describe the inlined path literal (Material "Donut Large") without pointing at a non-existent file a future maintainer would grep for.
- `frontend/src/app/loading.tsx`: drop the hardcoded skeleton-route enumeration (`cardgroups, learn, admin, cards/new`) from the doc comment — it rots as route-level `loading.tsx` files are added/removed and was already imprecise (`admin` has no top-level skeleton, only `admin/roles` and `admin/users`). Kept the durable "nearest boundary wins" rule.
- `frontend/src/components/pwa/brand-splash.test.tsx`: assert the decorative donut carries `aria-hidden="true"` — the accessibility contract that keeps the mark out of the a11y tree so it is not double-announced alongside the `status` region.
- `frontend/src/app/error.test.tsx`: harden the log-redaction test — explicitly assert the raw message string is absent from the logged payload (so a future switch to a partial matcher like `objectContaining` cannot silently let it through), and pin the single-log call count.

The reviewer's type-design suggestion (make `BrandSplashProps.label` a required nullable, or split the two splash modes into a discriminated union) was considered and intentionally deferred — it is a convention-alignment refactor with call-site churn, out of scope for this comment/test-only pass.

## Test plan

- [x] `pnpm --filter frontend typecheck` — green
- [x] `pnpm --filter frontend lint` (changed files) — clean
- [x] `pnpm --filter frontend test` for the affected files — `brand-splash` / `loading` / `error` (3 files, 9 tests) green

No associated issue.
