### PR TITLE
feat(frontend): language switcher dropdown on /profile (en/ja)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,6 +29,7 @@
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-label": "^2.1.8",
+    "@radix-ui/react-select": "^2.3.0",
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-tooltip": "^1.2.8",
     "@react-spring/web": "^10.0.3",

--- a/frontend/src/app/profile/profile-page-client.test.tsx
+++ b/frontend/src/app/profile/profile-page-client.test.tsx
@@ -70,6 +70,19 @@ describe("<ProfilePageClient>", () => {
     expect(mockPush).toHaveBeenCalledWith("/profile?edit=self", { scroll: false });
   });
 
+  it("renders the Settings section with the language switcher", () => {
+    mockSearchParamsValue = "";
+
+    renderWithIntl(
+      <MockedProvider mocks={[]}>
+        <ProfilePageClient email="alice@example.com" initial={initial} />
+      </MockedProvider>,
+    );
+
+    expect(screen.getByRole("heading", { name: /settings/i })).toBeInTheDocument();
+    expect(screen.getByRole("combobox", { name: /language/i })).toBeInTheDocument();
+  });
+
   it("opens the sheet when ?edit=self (singleton sentinel) is present in the query", () => {
     mockSearchParamsValue = "edit=self";
 

--- a/frontend/src/app/profile/profile-page-client.test.tsx
+++ b/frontend/src/app/profile/profile-page-client.test.tsx
@@ -1,9 +1,10 @@
 // @vitest-environment jsdom
 import { MockedProvider } from "@apollo/client/testing/react";
-import { render, screen, waitFor } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { UpdateProfileDocument } from "@/generated/graphql";
+import { renderWithIntl } from "@/test/render-with-intl";
 import { ProfilePageClient } from "./profile-page-client";
 
 const mockPush = vi.fn();
@@ -58,7 +59,7 @@ describe("<ProfilePageClient>", () => {
     const user = userEvent.setup();
     mockSearchParamsValue = "";
 
-    render(
+    renderWithIntl(
       <MockedProvider mocks={[]}>
         <ProfilePageClient email="alice@example.com" initial={initial} />
       </MockedProvider>,
@@ -72,7 +73,7 @@ describe("<ProfilePageClient>", () => {
   it("opens the sheet when ?edit=self (singleton sentinel) is present in the query", () => {
     mockSearchParamsValue = "edit=self";
 
-    render(
+    renderWithIntl(
       <MockedProvider mocks={[]}>
         <ProfilePageClient email="alice@example.com" initial={initial} />
       </MockedProvider>,
@@ -86,7 +87,7 @@ describe("<ProfilePageClient>", () => {
     mockSearchParamsValue = "edit=self";
     const mocks = [makeUpdateProfileMock({ input: { displayName: "Alice", bio: "hello" } })];
 
-    render(
+    renderWithIntl(
       <MockedProvider mocks={mocks}>
         <ProfilePageClient email="alice@example.com" initial={initial} />
       </MockedProvider>,
@@ -104,7 +105,7 @@ describe("<ProfilePageClient>", () => {
     const user = userEvent.setup();
     mockSearchParamsValue = "edit=self";
 
-    render(
+    renderWithIntl(
       <MockedProvider mocks={[]}>
         <ProfilePageClient email="alice@example.com" initial={initial} />
       </MockedProvider>,
@@ -148,7 +149,7 @@ describe("<ProfilePageClient>", () => {
       },
     ];
 
-    render(
+    renderWithIntl(
       <MockedProvider mocks={mocks}>
         <ProfilePageClient email="alice@example.com" initial={initial} />
       </MockedProvider>,

--- a/frontend/src/app/profile/profile-page-client.tsx
+++ b/frontend/src/app/profile/profile-page-client.tsx
@@ -2,7 +2,9 @@
 
 import { Pencil } from "lucide-react";
 import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
 import { useCallback, useRef, useState } from "react";
+import { LanguageSwitcher } from "@/components/settings/language-switcher";
 import { Button } from "@/components/ui/button";
 import { FormSheet, useFormSheetClose } from "@/components/ui/form-sheet";
 import { useSheetSearchParam } from "@/lib/url/use-sheet-search-param";
@@ -52,6 +54,7 @@ function ProfileSheetBody({
 const PROFILE_SHEET_SENTINEL_ID = "self";
 
 export function ProfilePageClient({ email, initial }: Props) {
+  const tSettings = useTranslations("Settings");
   const router = useRouter();
   const sheet = useSheetSearchParam();
   const [dirty, setDirty] = useState(false);
@@ -127,6 +130,14 @@ export function ProfilePageClient({ email, initial }: Props) {
             <Pencil className="h-4 w-4" />
             Edit profile
           </Button>
+        </section>
+
+        <section className="space-y-4">
+          <div>
+            <h2 className="text-xl font-semibold">{tSettings("heading")}</h2>
+            <p className="text-sm text-muted-foreground">{tSettings("description")}</p>
+          </div>
+          <LanguageSwitcher />
         </section>
       </div>
 

--- a/frontend/src/components/settings/language-switcher.test.tsx
+++ b/frontend/src/components/settings/language-switcher.test.tsx
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import { renderWithIntl } from "@/test/render-with-intl";
+import enMessages from "../../../messages/en.json";
+import { LanguageSwitcher } from "./language-switcher";
+
+// Read the Japanese option label from the catalog rather than inlining a CJK
+// literal — the language policy forbids non-English string literals in source.
+const japaneseLabel = enMessages.Language.ja;
+
+const setUserLocale = vi.hoisted(() => vi.fn());
+
+vi.mock("@/i18n/locale-actions", () => ({
+  setUserLocale,
+}));
+
+// Radix Select drives its popup through pointer-capture and scroll APIs that
+// jsdom does not implement. Polyfill the no-ops so the listbox opens under a
+// real `userEvent.click` instead of forcing the test to bypass the component.
+beforeAll(() => {
+  if (!Element.prototype.hasPointerCapture) {
+    Element.prototype.hasPointerCapture = () => false;
+  }
+  if (!Element.prototype.setPointerCapture) {
+    Element.prototype.setPointerCapture = () => {};
+  }
+  if (!Element.prototype.releasePointerCapture) {
+    Element.prototype.releasePointerCapture = () => {};
+  }
+  if (!Element.prototype.scrollIntoView) {
+    Element.prototype.scrollIntoView = () => {};
+  }
+});
+
+describe("LanguageSwitcher", () => {
+  it("renders the Language label and the current locale value", () => {
+    renderWithIntl(<LanguageSwitcher />);
+
+    // The accessible name of the combobox comes from the associated label text.
+    expect(screen.getByText("Language")).toBeInTheDocument();
+    expect(screen.getByRole("combobox", { name: /language/i })).toBeInTheDocument();
+    // Default locale in renderWithIntl is `en`, so the trigger shows "English".
+    expect(screen.getByText("English")).toBeInTheDocument();
+  });
+
+  it("calls setUserLocale('ja') when the Japanese option is selected", async () => {
+    const user = userEvent.setup();
+    renderWithIntl(<LanguageSwitcher />);
+
+    await user.click(screen.getByRole("combobox", { name: /language/i }));
+
+    const japaneseOption = await screen.findByRole("option", { name: japaneseLabel });
+    await user.click(japaneseOption);
+
+    await waitFor(() => {
+      expect(setUserLocale).toHaveBeenCalledWith("ja");
+    });
+  });
+});

--- a/frontend/src/components/settings/language-switcher.tsx
+++ b/frontend/src/components/settings/language-switcher.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useLocale, useTranslations } from "next-intl";
+import { useId, useTransition } from "react";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { locales, toLocale } from "@/i18n/config";
+import { setUserLocale } from "@/i18n/locale-actions";
+
+/**
+ * Language picker backed by the `NEXT_LOCALE` cookie. Selecting a locale calls
+ * the `setUserLocale` Server Action inside a transition; `next-intl` re-resolves
+ * the active locale from the cookie on the next render. The control is disabled
+ * while the transition is pending so a second choice cannot race the first.
+ */
+export function LanguageSwitcher() {
+  const t = useTranslations("Language");
+  const currentLocale = useLocale();
+  const [isPending, startTransition] = useTransition();
+  const triggerId = useId();
+
+  function handleValueChange(value: string) {
+    const next = toLocale(value);
+    if (next === null) {
+      return;
+    }
+    startTransition(() => {
+      setUserLocale(next);
+    });
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <Label htmlFor={triggerId}>{t("label")}</Label>
+      <Select value={currentLocale} onValueChange={handleValueChange} disabled={isPending}>
+        <SelectTrigger id={triggerId} className="w-full sm:w-56">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {locales.map((locale) => (
+            <SelectItem key={locale} value={locale}>
+              {t(locale)}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}

--- a/frontend/src/components/settings/language-switcher.tsx
+++ b/frontend/src/components/settings/language-switcher.tsx
@@ -28,10 +28,22 @@ export function LanguageSwitcher() {
   function handleValueChange(value: string) {
     const next = toLocale(value);
     if (next === null) {
+      // Unreachable from the UI (every SelectItem value comes from `locales`),
+      // so a null here means a SelectItem drifted out of the canonical list.
+      // Warn rather than silently swallow so the programming error is visible.
+      console.warn("[LanguageSwitcher] ignoring unsupported locale value:", value);
       return;
     }
-    startTransition(() => {
-      setUserLocale(next);
+    // `await` the Server Action so `isPending` stays true across the server
+    // roundtrip (a synchronous fire-and-forget callback resolves immediately and
+    // the disabled guard never engages). The cookie write triggers Next.js to
+    // re-render the route with the new locale, so no explicit refresh is needed.
+    startTransition(async () => {
+      try {
+        await setUserLocale(next);
+      } catch (error) {
+        console.error("[LanguageSwitcher] setUserLocale failed:", error);
+      }
     });
   }
 

--- a/frontend/src/components/ui/select.tsx
+++ b/frontend/src/components/ui/select.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import * as SelectPrimitive from "@radix-ui/react-select";
+import { Check, ChevronDown, ChevronUp } from "lucide-react";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const Select = SelectPrimitive.Root;
+
+const SelectValue = SelectPrimitive.Value;
+
+const SelectTrigger = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "flex h-9 w-full items-center justify-between whitespace-nowrap rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
+      className,
+    )}
+    {...props}
+  >
+    {children}
+    <SelectPrimitive.Icon asChild>
+      <ChevronDown className="h-4 w-4 opacity-50" />
+    </SelectPrimitive.Icon>
+  </SelectPrimitive.Trigger>
+));
+SelectTrigger.displayName = SelectPrimitive.Trigger.displayName;
+
+const SelectScrollUpButton = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.ScrollUpButton>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollUpButton>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollUpButton
+    ref={ref}
+    className={cn("flex cursor-default items-center justify-center py-1", className)}
+    {...props}
+  >
+    <ChevronUp className="h-4 w-4" />
+  </SelectPrimitive.ScrollUpButton>
+));
+SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton.displayName;
+
+const SelectScrollDownButton = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.ScrollDownButton>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollDownButton>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollDownButton
+    ref={ref}
+    className={cn("flex cursor-default items-center justify-center py-1", className)}
+    {...props}
+  >
+    <ChevronDown className="h-4 w-4" />
+  </SelectPrimitive.ScrollDownButton>
+));
+SelectScrollDownButton.displayName = SelectPrimitive.ScrollDownButton.displayName;
+
+const SelectContent = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
+>(({ className, children, position = "popper", ...props }, ref) => (
+  <SelectPrimitive.Portal>
+    <SelectPrimitive.Content
+      ref={ref}
+      className={cn(
+        "relative z-50 max-h-[--radix-select-content-available-height] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-select-content-transform-origin]",
+        position === "popper" &&
+          "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+        className,
+      )}
+      position={position}
+      {...props}
+    >
+      <SelectScrollUpButton />
+      <SelectPrimitive.Viewport
+        className={cn(
+          "p-1",
+          position === "popper" &&
+            "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]",
+        )}
+      >
+        {children}
+      </SelectPrimitive.Viewport>
+      <SelectScrollDownButton />
+    </SelectPrimitive.Content>
+  </SelectPrimitive.Portal>
+));
+SelectContent.displayName = SelectPrimitive.Content.displayName;
+
+const SelectItem = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-2 pr-8 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className,
+    )}
+    {...props}
+  >
+    <span className="absolute right-2 flex h-3.5 w-3.5 items-center justify-center">
+      <SelectPrimitive.ItemIndicator>
+        <Check className="h-4 w-4" />
+      </SelectPrimitive.ItemIndicator>
+    </span>
+    <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+  </SelectPrimitive.Item>
+));
+SelectItem.displayName = SelectPrimitive.Item.displayName;
+
+export { Select, SelectContent, SelectItem, SelectTrigger, SelectValue };

--- a/frontend/src/i18n/config.ts
+++ b/frontend/src/i18n/config.ts
@@ -1,8 +1,7 @@
-// Supported UI locales. `en` is the default; `ja` is the added locale. Kept
-// module-private (the `Locale` type + `toLocale` are the public surface); a
-// consumer that needs to enumerate locales (e.g. a language switcher) promotes
-// this to an export when it wires the first use.
-const locales = ["en", "ja"] as const;
+// Supported UI locales. `en` is the default; `ja` is the added locale. Exported
+// so a consumer that enumerates locales (e.g. the language switcher) can map
+// over the canonical list rather than re-declaring it.
+export const locales = ["en", "ja"] as const;
 
 export type Locale = (typeof locales)[number];
 

--- a/frontend/src/i18n/locale-actions.test.ts
+++ b/frontend/src/i18n/locale-actions.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { Locale } from "./config";
+import { setUserLocale } from "./locale-actions";
+
+// Shared cookie-store spy captured by vi.hoisted so the mock factory can
+// reference it (mirrors the pattern in lib/supabase/server.test.ts).
+const mockCookieStore = vi.hoisted(() => ({
+  set: vi.fn(),
+}));
+
+vi.mock("next/headers", () => ({
+  cookies: vi.fn().mockResolvedValue(mockCookieStore),
+}));
+
+afterEach(() => {
+  mockCookieStore.set.mockReset();
+  vi.restoreAllMocks();
+});
+
+describe("setUserLocale", () => {
+  it("writes the NEXT_LOCALE cookie with the load-bearing attributes", async () => {
+    await setUserLocale("ja");
+
+    expect(mockCookieStore.set).toHaveBeenCalledTimes(1);
+    expect(mockCookieStore.set).toHaveBeenCalledWith(
+      "NEXT_LOCALE",
+      "ja",
+      // The cookie name, the one-year maxAge, the path, and SameSite=Lax are the
+      // integration contract with next-intl's request config + the persistence
+      // promise; pin them so a regression (e.g. maxAge dropping to one day, or
+      // SameSite drifting to "none") is caught.
+      expect.objectContaining({
+        path: "/",
+        maxAge: 60 * 60 * 24 * 365,
+        sameSite: "lax",
+      }),
+    );
+  });
+
+  it("persists English as well", async () => {
+    await setUserLocale("en");
+
+    expect(mockCookieStore.set).toHaveBeenCalledWith(
+      "NEXT_LOCALE",
+      "en",
+      expect.objectContaining({ path: "/", sameSite: "lax" }),
+    );
+  });
+
+  it("ignores an unsupported locale value (a network caller can bypass the compile-time type)", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await setUserLocale("fr" as Locale);
+
+    expect(mockCookieStore.set).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it("rethrows when the cookie write fails so the caller can surface it", async () => {
+    const boom = new Error("cookie store unavailable");
+    mockCookieStore.set.mockImplementation(() => {
+      throw boom;
+    });
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(setUserLocale("ja")).rejects.toThrow(boom);
+  });
+});

--- a/frontend/src/i18n/locale-actions.ts
+++ b/frontend/src/i18n/locale-actions.ts
@@ -1,0 +1,18 @@
+"use server";
+
+import { cookies } from "next/headers";
+import { LOCALE_COOKIE, type Locale } from "./config";
+
+/**
+ * Persists the user's explicit language choice in the `NEXT_LOCALE` cookie. The
+ * cookie is read by `next-intl`'s request config on the next render to resolve
+ * the active locale. A one-year `maxAge` keeps the choice across sessions; the
+ * `lax` SameSite policy keeps the cookie scoped to first-party navigations.
+ */
+export async function setUserLocale(locale: Locale): Promise<void> {
+  (await cookies()).set(LOCALE_COOKIE, locale, {
+    path: "/",
+    maxAge: 60 * 60 * 24 * 365,
+    sameSite: "lax",
+  });
+}

--- a/frontend/src/i18n/locale-actions.ts
+++ b/frontend/src/i18n/locale-actions.ts
@@ -1,18 +1,34 @@
 "use server";
 
 import { cookies } from "next/headers";
-import { LOCALE_COOKIE, type Locale } from "./config";
+import { LOCALE_COOKIE, type Locale, toLocale } from "./config";
 
 /**
  * Persists the user's explicit language choice in the `NEXT_LOCALE` cookie. The
  * cookie is read by `next-intl`'s request config on the next render to resolve
  * the active locale. A one-year `maxAge` keeps the choice across sessions; the
  * `lax` SameSite policy keeps the cookie scoped to first-party navigations.
+ *
+ * A `"use server"` action compiles to a network-reachable POST endpoint, so the
+ * compile-time `Locale` parameter is not a runtime guarantee — the value is
+ * re-narrowed via `toLocale` and an unsupported value is ignored rather than
+ * written verbatim into the cookie.
  */
 export async function setUserLocale(locale: Locale): Promise<void> {
-  (await cookies()).set(LOCALE_COOKIE, locale, {
-    path: "/",
-    maxAge: 60 * 60 * 24 * 365,
-    sameSite: "lax",
-  });
+  const safeLocale = toLocale(locale);
+  if (safeLocale === null) {
+    console.warn("[i18n] setUserLocale: ignoring unsupported locale value:", locale);
+    return;
+  }
+  try {
+    (await cookies()).set(LOCALE_COOKIE, safeLocale, {
+      path: "/",
+      maxAge: 60 * 60 * 24 * 365,
+      sameSite: "lax",
+      secure: process.env.NODE_ENV === "production",
+    });
+  } catch (error) {
+    console.error("[i18n] setUserLocale: failed to write NEXT_LOCALE cookie:", error);
+    throw error;
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       '@radix-ui/react-label':
         specifier: ^2.1.8
         version: 2.1.9(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-select':
+        specifier: ^2.3.0
+        version: 2.3.0(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@radix-ui/react-slot':
         specifier: ^1.2.4
         version: 1.2.5(@types/react@19.2.16)(react@19.2.7)
@@ -1486,6 +1489,9 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  '@radix-ui/number@1.1.2':
+    resolution: {integrity: sha512-ceTwaxc4I5IOi97DgCotl3pqiyRGvffcc0oOsE2dQYaJOFIDsDt4VWG6xEbg1QePv9QWausCEIppud/tJ1wNig==}
+
   '@radix-ui/primitive@1.1.4':
     resolution: {integrity: sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ==}
 
@@ -1729,6 +1735,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-select@2.3.0':
+    resolution: {integrity: sha512-mENc7WpJvJcW8hlMpzfFcHcEhTvYS5JMBmi9HVC1Q00uhBwML086MHYUV8QQdQv6lcu0Wg8dzd1RB8AFADcG/g==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-slot@1.2.5':
     resolution: {integrity: sha512-rCMO3QsIVKv5JTY5CVbo2MvO77SpEqqYc8AvRE7OWqRDOIqAKjsp+DrmnY9uc8NPdxB5E2z47HTYGeE2+NTptg==}
     peerDependencies:
@@ -1789,6 +1808,15 @@ packages:
 
   '@radix-ui/react-use-layout-effect@1.1.2':
     resolution: {integrity: sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-previous@1.1.2':
+    resolution: {integrity: sha512-IGBQPtRFdhN6MQ8dbegVmBq1LVZluya3F1jWY+puIcQC3MHctRwTDSBWCkL/3ZcnMJLTMJ++Z+ktmvg0F89iCw==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -5254,6 +5282,8 @@ snapshots:
     dependencies:
       playwright: 1.60.0
 
+  '@radix-ui/number@1.1.2': {}
+
   '@radix-ui/primitive@1.1.4': {}
 
   '@radix-ui/react-alert-dialog@1.1.16(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
@@ -5497,6 +5527,36 @@ snapshots:
       '@types/react': 19.2.16
       '@types/react-dom': 19.2.3(@types/react@19.2.16)
 
+  '@radix-ui/react-select@2.3.0(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/number': 1.1.2
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-collection': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.16)(react@19.2.7)
+      '@radix-ui/react-context': 1.1.4(@types/react@19.2.16)(react@19.2.7)
+      '@radix-ui/react-direction': 1.1.2(@types/react@19.2.16)(react@19.2.7)
+      '@radix-ui/react-dismissable-layer': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-focus-guards': 1.1.4(@types/react@19.2.16)(react@19.2.7)
+      '@radix-ui/react-focus-scope': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.2.16)(react@19.2.7)
+      '@radix-ui/react-popper': 1.3.0(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-portal': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-slot': 1.2.5(@types/react@19.2.16)(react@19.2.7)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.16)(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.16)(react@19.2.7)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.16)(react@19.2.7)
+      '@radix-ui/react-use-previous': 1.1.2(@types/react@19.2.16)(react@19.2.7)
+      '@radix-ui/react-visually-hidden': 1.2.5(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      aria-hidden: 1.2.6
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      react-remove-scroll: 2.7.2(@types/react@19.2.16)(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.16
+      '@types/react-dom': 19.2.3(@types/react@19.2.16)
+
   '@radix-ui/react-slot@1.2.5(@types/react@19.2.16)(react@19.2.7)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.16)(react@19.2.7)
@@ -5553,6 +5613,12 @@ snapshots:
       '@types/react': 19.2.16
 
   '@radix-ui/react-use-layout-effect@1.1.2(@types/react@19.2.16)(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.16
+
+  '@radix-ui/react-use-previous@1.1.2(@types/react@19.2.16)(react@19.2.7)':
     dependencies:
       react: 19.2.7
     optionalDependencies:


### PR DESCRIPTION
## Summary

Add the language-switcher dropdown to the settings area of `/profile`. Selecting a language persists the choice in the `NEXT_LOCALE` cookie via a Server Action and re-renders the app in the chosen locale. This is the headline feature of Wave 1 — the first user-facing control over the i18n foundation (#343).

## Approach

- **Cookie + Server Action persistence (no backend).** `src/i18n/locale-actions.ts` is the first Server Action in the repo: `setUserLocale(locale)` writes `NEXT_LOCALE` (`path:/`, 1-year `maxAge`, `sameSite: lax`). The foundation's `getRequestConfig` already reads that cookie, so the switcher only has to write it.
- **Placed outside the edit-profile form.** The switcher is a standalone control in a new "Settings" section below the read-only summary — it persists via cookie, not the `updateProfile` GraphQL mutation, so it is deliberately not a TanStack form field.
- **shadcn `Select` primitive added.** Only `dropdown-menu` existed before; `src/components/ui/select.tsx` adds the Radix-based `Select` (dependency `@radix-ui/react-select@^2.3.0`), hand-authored to match the repo's existing `forwardRef` + `displayName` + `cn` UI-wrapper style. The exported surface is trimmed to the five primitives the switcher consumes so `knip` stays clean.
- **`locales` promoted to an export** in `src/i18n/config.ts` (the foundation left a comment inviting exactly this) so the switcher can enumerate the supported locales.

## Scope

- `src/i18n/config.ts` — export `locales`.
- `src/components/ui/select.tsx` — shadcn Select primitive (+ `@radix-ui/react-select`).
- `src/i18n/locale-actions.ts` — `setUserLocale` Server Action.
- `src/components/settings/language-switcher.tsx` (+ test, TDD) — `useLocale()` / `useTranslations("Language")` / `useTransition`; `onValueChange` → `setUserLocale`.
- `src/app/profile/profile-page-client.tsx` — new "Settings" `<section>` rendering `<LanguageSwitcher />` (`useTranslations("Settings")` for heading/description).
- `profile-page-client.test.tsx` — renders wrapped in `renderWithIntl` (the client now uses next-intl hooks).

## Out of scope

- Translating the rest of the profile-page literals (Display name / Email / Bio / Edit profile) — the profile/onboarding string PR.
- Backend persistence of locale — cookie only.

## Test plan

- `pnpm --filter frontend typecheck` — green.
- `pnpm --filter frontend lint` — green.
- `pnpm --filter frontend test -- language-switcher` — 2 passed; `test -- profile` — 70 passed; full suite 1124 passed.
- `pnpm --filter frontend knip` — clean (Select export set trimmed to consumed primitives).
- CJK grep over `frontend/src` — clean (the Japanese option label is read from the en catalog, never inlined).

Closes #344
