### PR TITLE
feat(frontend): localize navigation UI strings (en/ja)

### DIFF
--- a/frontend/src/app/_components/logout-button.test.tsx
+++ b/frontend/src/app/_components/logout-button.test.tsx
@@ -1,8 +1,9 @@
 // @vitest-environment jsdom
 
-import { render, screen } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { renderWithIntl } from "@/test/render-with-intl";
 
 const mockReplace = vi.fn();
 const mockRefresh = vi.fn();
@@ -36,7 +37,7 @@ describe("<LogoutButton>", () => {
     mockReplace.mockImplementation((path: string) => callOrder.push(`replace:${path}`));
     mockRefresh.mockImplementation(() => callOrder.push("refresh"));
 
-    render(<LogoutButton />);
+    renderWithIntl(<LogoutButton />);
     await userEvent.click(screen.getByRole("button", { name: /logout/i }));
 
     // replace must precede refresh: refreshing on the old (protected) URL is
@@ -49,7 +50,7 @@ describe("<LogoutButton>", () => {
     mockSignOut.mockResolvedValue({ error: { message: "boom" } });
     const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
-    render(<LogoutButton />);
+    renderWithIntl(<LogoutButton />);
     await userEvent.click(screen.getByRole("button", { name: /logout/i }));
 
     expect(mockReplace).not.toHaveBeenCalled();

--- a/frontend/src/app/_components/logout-button.tsx
+++ b/frontend/src/app/_components/logout-button.tsx
@@ -1,10 +1,12 @@
 "use client";
 
 import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
 import { createSupabaseBrowserClient } from "@/lib/supabase/client";
 
 export function LogoutButton() {
+  const t = useTranslations("Nav");
   const router = useRouter();
 
   async function handleLogout() {
@@ -24,7 +26,7 @@ export function LogoutButton() {
 
   return (
     <Button onClick={handleLogout} type="button" variant="outline" size="sm">
-      Logout
+      {t("logout")}
     </Button>
   );
 }

--- a/frontend/src/components/nav/app-shell.test.tsx
+++ b/frontend/src/components/nav/app-shell.test.tsx
@@ -1,7 +1,8 @@
 // @vitest-environment jsdom
-import { render, screen, within } from "@testing-library/react";
+import { screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { renderWithIntl } from "@/test/render-with-intl";
 
 // Mock next/link so it renders a plain <a> in jsdom.
 vi.mock("next/link", () => ({
@@ -65,7 +66,7 @@ afterEach(() => {
 describe("<AppShell>", () => {
   describe("S1 — responsive containers are both present in the DOM", () => {
     it("rail container has the hidden-on-mobile class and mobile header has the hidden-on-desktop class", () => {
-      render(
+      renderWithIntl(
         <AppShell user={SIGNED_IN_USER} isAdmin={false}>
           <div />
         </AppShell>,
@@ -85,7 +86,7 @@ describe("<AppShell>", () => {
 
   describe("S2 — mobile menu trigger is present with the Settings icon", () => {
     it("contains a button with aria-label 'Open menu' (the Settings icon trigger)", () => {
-      render(
+      renderWithIntl(
         <AppShell user={SIGNED_IN_USER} isAdmin={false}>
           <div />
         </AppShell>,
@@ -99,7 +100,7 @@ describe("<AppShell>", () => {
 
   describe("S3 — does not render the email in the mobile header", () => {
     it("does not render the signed-in user's email inside the mobile header", () => {
-      render(
+      renderWithIntl(
         <AppShell user={SIGNED_IN_USER} isAdmin={false}>
           <div />
         </AppShell>,
@@ -115,7 +116,7 @@ describe("<AppShell>", () => {
   describe("S4 — anonymous user", () => {
     it("renders no email in the mobile header, no rail nav items, and a Sign in link when user is null", () => {
       mockUsePathname.mockReturnValue("/cardgroups");
-      render(
+      renderWithIntl(
         <AppShell user={null} isAdmin={false}>
           <div />
         </AppShell>,
@@ -139,7 +140,7 @@ describe("<AppShell>", () => {
   describe("S4b — anonymous on /login: no Sign in links", () => {
     it("anonymous on /login: zero Sign in links across both surfaces", () => {
       mockUsePathname.mockReturnValue("/login");
-      render(
+      renderWithIntl(
         <AppShell user={null} isAdmin={false}>
           <div />
         </AppShell>,
@@ -153,7 +154,7 @@ describe("<AppShell>", () => {
 
   describe("S5 — children render inside main content area", () => {
     it("a sentinel child passed via the children prop is present in the document", () => {
-      render(
+      renderWithIntl(
         <AppShell user={SIGNED_IN_USER} isAdmin={false}>
           <div data-testid="content">hello</div>
         </AppShell>,
@@ -167,7 +168,7 @@ describe("<AppShell>", () => {
   describe("S6 — isAdmin=true: Admin sub-links appear in both rail and drawer", () => {
     it("the rail body contains the admin sub-links (Users, Roles) when isAdmin=true", () => {
       mockUsePathname.mockReturnValue("/");
-      render(
+      renderWithIntl(
         <AppShell user={SIGNED_IN_USER} isAdmin={true}>
           <div />
         </AppShell>,
@@ -182,7 +183,7 @@ describe("<AppShell>", () => {
     it("the drawer body contains the admin sub-links (Users, Roles) when isAdmin=true", async () => {
       const user = userEvent.setup();
       mockUsePathname.mockReturnValue("/");
-      render(
+      renderWithIntl(
         <AppShell user={SIGNED_IN_USER} isAdmin={true}>
           <div />
         </AppShell>,

--- a/frontend/src/components/nav/global-rail.test.tsx
+++ b/frontend/src/components/nav/global-rail.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
-import { act, fireEvent, render, screen, within } from "@testing-library/react";
+import { act, fireEvent, screen, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { renderWithIntl } from "@/test/render-with-intl";
 
 // Mock next/link so it renders a plain <a> in jsdom.
 vi.mock("next/link", () => ({
@@ -61,7 +62,7 @@ function renderRail(
   props: React.ComponentProps<typeof GlobalRail>,
   options?: { defaultOpen?: boolean },
 ) {
-  return render(
+  return renderWithIntl(
     <SidebarProvider defaultOpen={options?.defaultOpen}>
       <GlobalRail {...props} />
     </SidebarProvider>,

--- a/frontend/src/components/nav/global-rail.tsx
+++ b/frontend/src/components/nav/global-rail.tsx
@@ -3,6 +3,7 @@
 import { BookOpen, User } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { useTranslations } from "next-intl";
 import { useEffect, useRef } from "react";
 import { LogoutButton } from "@/app/_components/logout-button";
 import { FlamingoMark } from "@/components/brand/flamingo-mark";
@@ -63,6 +64,7 @@ function resolveActiveItem(pathname: string): ActiveItem {
 }
 
 export function GlobalRail({ user, isAdmin }: GlobalRailProps) {
+  const t = useTranslations("Nav");
   const pathname = usePathname();
   const { state, setOpen, isMobile } = useSidebar();
 
@@ -127,7 +129,7 @@ export function GlobalRail({ user, isAdmin }: GlobalRailProps) {
     >
       <SidebarHeader>
         <div className="flex size-8 items-center justify-center">
-          <Link href="/" aria-label="Flamingo home" className="shrink-0 leading-none">
+          <Link href="/" aria-label={t("flamingoHome")} className="shrink-0 leading-none">
             <FlamingoMark className="size-7" aria-hidden="true" />
           </Link>
         </div>
@@ -142,14 +144,14 @@ export function GlobalRail({ user, isAdmin }: GlobalRailProps) {
                   <SidebarMenuButton
                     asChild
                     isActive={active === "cardgroups"}
-                    tooltip="Cardgroups"
+                    tooltip={t("cardgroups")}
                   >
                     <Link
                       href="/cardgroups"
                       aria-current={active === "cardgroups" ? "page" : undefined}
                     >
                       <BookOpen aria-hidden="true" />
-                      <span>Cardgroups</span>
+                      <span>{t("cardgroups")}</span>
                     </Link>
                   </SidebarMenuButton>
                 </SidebarMenuItem>
@@ -162,10 +164,14 @@ export function GlobalRail({ user, isAdmin }: GlobalRailProps) {
                     const Icon = item.icon;
                     return (
                       <SidebarMenuItem key={item.href}>
-                        <SidebarMenuButton asChild isActive={isItemActive} tooltip={item.label}>
+                        <SidebarMenuButton
+                          asChild
+                          isActive={isItemActive}
+                          tooltip={t(item.labelKey)}
+                        >
                           <Link href={item.href} aria-current={isItemActive ? "page" : undefined}>
                             <Icon aria-hidden="true" />
-                            <span>{item.label}</span>
+                            <span>{t(item.labelKey)}</span>
                           </Link>
                         </SidebarMenuButton>
                       </SidebarMenuItem>
@@ -181,10 +187,10 @@ export function GlobalRail({ user, isAdmin }: GlobalRailProps) {
         <SidebarFooter>
           <SidebarMenu>
             <SidebarMenuItem>
-              <SidebarMenuButton asChild isActive={profileActive} tooltip="Profile">
+              <SidebarMenuButton asChild isActive={profileActive} tooltip={t("profile")}>
                 <Link href="/profile" aria-current={profileActive ? "page" : undefined}>
                   <User aria-hidden="true" />
-                  <span>Profile</span>
+                  <span>{t("profile")}</span>
                 </Link>
               </SidebarMenuButton>
             </SidebarMenuItem>
@@ -206,7 +212,7 @@ export function GlobalRail({ user, isAdmin }: GlobalRailProps) {
         <SidebarFooter>
           <SidebarMenu>
             <SidebarMenuItem>
-              <SidebarMenuButton asChild tooltip="Sign in">
+              <SidebarMenuButton asChild tooltip={t("signIn")}>
                 <HeaderSignInLink />
               </SidebarMenuButton>
             </SidebarMenuItem>

--- a/frontend/src/components/nav/header-sign-in-link.test.tsx
+++ b/frontend/src/components/nav/header-sign-in-link.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
-import { render, screen } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { renderWithIntl } from "@/test/render-with-intl";
 
 vi.mock("next/link", () => ({
   default: ({
@@ -29,7 +30,7 @@ describe("<HeaderSignInLink>", () => {
     });
 
     it("renders nothing", () => {
-      const { container } = render(<HeaderSignInLink className="foo" />);
+      const { container } = renderWithIntl(<HeaderSignInLink className="foo" />);
       expect(container.firstChild).toBeNull();
       expect(screen.queryByRole("link")).not.toBeInTheDocument();
     });
@@ -41,12 +42,12 @@ describe("<HeaderSignInLink>", () => {
     });
 
     it("renders a link to /login", () => {
-      render(<HeaderSignInLink />);
+      renderWithIntl(<HeaderSignInLink />);
       expect(screen.getByRole("link", { name: /sign in/i })).toHaveAttribute("href", "/login");
     });
 
     it("forwards className to the link", () => {
-      render(<HeaderSignInLink className="text-sm underline md:hidden" />);
+      renderWithIntl(<HeaderSignInLink className="text-sm underline md:hidden" />);
       expect(screen.getByRole("link", { name: /sign in/i })).toHaveClass(
         "text-sm",
         "underline",

--- a/frontend/src/components/nav/header-sign-in-link.tsx
+++ b/frontend/src/components/nav/header-sign-in-link.tsx
@@ -2,17 +2,19 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { useTranslations } from "next-intl";
 
 type Props = { className?: string };
 
 // Suppresses itself on /login so the header does not render a self-referential
 // "Sign in" link while the user is already on the sign-in page.
 export function HeaderSignInLink({ className }: Props) {
+  const t = useTranslations("Nav");
   const pathname = usePathname();
   if (pathname === "/login") return null;
   return (
     <Link href="/login" className={className}>
-      Sign in
+      {t("signIn")}
     </Link>
   );
 }

--- a/frontend/src/components/nav/logo-drawer.test.tsx
+++ b/frontend/src/components/nav/logo-drawer.test.tsx
@@ -1,7 +1,8 @@
 // @vitest-environment jsdom
-import { render, screen, within } from "@testing-library/react";
+import { screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { renderWithIntl } from "@/test/render-with-intl";
 
 // usePathname is mocked per-test so anonymous Sign-in-link tests can set a
 // non-/login pathname (the link self-suppresses on /login).
@@ -43,7 +44,7 @@ afterEach(() => {
 describe("<LogoDrawer>", () => {
   it("logo trigger opens the drawer and shows the Cardgroups link", async () => {
     const user = userEvent.setup();
-    render(<LogoDrawer user={SIGNED_IN_USER} isAdmin={false} />);
+    renderWithIntl(<LogoDrawer user={SIGNED_IN_USER} isAdmin={false} />);
 
     await user.click(screen.getByRole("button", { name: "Open menu" }));
 
@@ -51,7 +52,7 @@ describe("<LogoDrawer>", () => {
   });
 
   it("logo is a home link with aria-label='Flamingo home' and href='/'", () => {
-    render(<LogoDrawer user={SIGNED_IN_USER} isAdmin={false} />);
+    renderWithIntl(<LogoDrawer user={SIGNED_IN_USER} isAdmin={false} />);
 
     const logoLink = screen.getByRole("link", { name: /flamingo home/i });
     expect(logoLink).toBeInTheDocument();
@@ -59,14 +60,14 @@ describe("<LogoDrawer>", () => {
   });
 
   it("the drawer trigger button is labeled 'Open menu' (was 'Open navigation menu')", () => {
-    render(<LogoDrawer user={SIGNED_IN_USER} isAdmin={false} />);
+    renderWithIntl(<LogoDrawer user={SIGNED_IN_USER} isAdmin={false} />);
     expect(screen.getByRole("button", { name: "Open menu" })).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /open navigation menu/i })).toBeNull();
   });
 
   it("Settings link is not rendered in the drawer body", async () => {
     const user = userEvent.setup();
-    render(<LogoDrawer user={SIGNED_IN_USER} isAdmin={false} />);
+    renderWithIntl(<LogoDrawer user={SIGNED_IN_USER} isAdmin={false} />);
 
     await user.click(screen.getByRole("button", { name: "Open menu" }));
 
@@ -75,7 +76,7 @@ describe("<LogoDrawer>", () => {
 
   it("isAdmin=false does not render any admin nav links", async () => {
     const user = userEvent.setup();
-    render(<LogoDrawer user={SIGNED_IN_USER} isAdmin={false} />);
+    renderWithIntl(<LogoDrawer user={SIGNED_IN_USER} isAdmin={false} />);
 
     await user.click(screen.getByRole("button", { name: "Open menu" }));
 
@@ -85,7 +86,7 @@ describe("<LogoDrawer>", () => {
 
   it("isAdmin=true renders the admin nav links with correct hrefs", async () => {
     const user = userEvent.setup();
-    render(<LogoDrawer user={SIGNED_IN_USER} isAdmin={true} />);
+    renderWithIntl(<LogoDrawer user={SIGNED_IN_USER} isAdmin={true} />);
 
     await user.click(screen.getByRole("button", { name: "Open menu" }));
 
@@ -100,7 +101,7 @@ describe("<LogoDrawer>", () => {
 
   it("Profile link in the bottom block has href=/profile and is present for signed-in users", async () => {
     const user = userEvent.setup();
-    render(<LogoDrawer user={SIGNED_IN_USER} isAdmin={false} />);
+    renderWithIntl(<LogoDrawer user={SIGNED_IN_USER} isAdmin={false} />);
 
     await user.click(screen.getByRole("button", { name: "Open menu" }));
 
@@ -112,7 +113,7 @@ describe("<LogoDrawer>", () => {
 
   it("anonymous user (user === null): drawer body shows a Sign in link but no nav items and no email", async () => {
     const user = userEvent.setup();
-    render(<LogoDrawer user={null} isAdmin={false} />);
+    renderWithIntl(<LogoDrawer user={null} isAdmin={false} />);
 
     await user.click(screen.getByRole("button", { name: "Open menu" }));
 
@@ -124,7 +125,7 @@ describe("<LogoDrawer>", () => {
 
   it("anonymous user (user === null): no LogoutButton in the drawer body", async () => {
     const user = userEvent.setup();
-    render(<LogoDrawer user={null} isAdmin={false} />);
+    renderWithIntl(<LogoDrawer user={null} isAdmin={false} />);
 
     await user.click(screen.getByRole("button", { name: "Open menu" }));
 
@@ -134,7 +135,7 @@ describe("<LogoDrawer>", () => {
   it("anonymous user on /login: Sign in link is suppressed (self-suppression behavior)", async () => {
     const user = userEvent.setup();
     mockUsePathname.mockReturnValue("/login");
-    render(<LogoDrawer user={null} isAdmin={false} />);
+    renderWithIntl(<LogoDrawer user={null} isAdmin={false} />);
 
     await user.click(screen.getByRole("button", { name: "Open menu" }));
 
@@ -143,7 +144,7 @@ describe("<LogoDrawer>", () => {
 
   it("signed-in user: email address is not shown in the drawer body", async () => {
     const user = userEvent.setup();
-    render(<LogoDrawer user={SIGNED_IN_USER} isAdmin={false} />);
+    renderWithIntl(<LogoDrawer user={SIGNED_IN_USER} isAdmin={false} />);
 
     await user.click(screen.getByRole("button", { name: "Open menu" }));
 
@@ -152,7 +153,7 @@ describe("<LogoDrawer>", () => {
 
   it("signed-in user: LogoutButton is visible in the drawer body", async () => {
     const user = userEvent.setup();
-    render(<LogoDrawer user={SIGNED_IN_USER} isAdmin={false} />);
+    renderWithIntl(<LogoDrawer user={SIGNED_IN_USER} isAdmin={false} />);
 
     await user.click(screen.getByRole("button", { name: "Open menu" }));
 
@@ -161,7 +162,7 @@ describe("<LogoDrawer>", () => {
 
   it("signed-in user with null email: drawer shows nav items but no email text", async () => {
     const user = userEvent.setup();
-    render(<LogoDrawer user={{ email: null }} isAdmin={false} />);
+    renderWithIntl(<LogoDrawer user={{ email: null }} isAdmin={false} />);
 
     await user.click(screen.getByRole("button", { name: "Open menu" }));
 
@@ -175,7 +176,7 @@ describe("<LogoDrawer>", () => {
     mockUsePathname.mockReturnValue("/cardgroups");
     const listener = vi.fn();
     window.addEventListener("flamingo:add-cardgroup", listener);
-    render(<LogoDrawer user={SIGNED_IN_USER} isAdmin={false} />);
+    renderWithIntl(<LogoDrawer user={SIGNED_IN_USER} isAdmin={false} />);
 
     await user.click(screen.getByRole("button", { name: /add new cardgroup/i }));
 
@@ -193,7 +194,7 @@ describe("<LogoDrawer>", () => {
     mockUsePathname.mockReturnValue("/cardgroups");
     const listener = vi.fn((event: Event) => event.preventDefault());
     window.addEventListener("flamingo:add-cardgroup", listener);
-    render(<LogoDrawer user={SIGNED_IN_USER} isAdmin={false} />);
+    renderWithIntl(<LogoDrawer user={SIGNED_IN_USER} isAdmin={false} />);
 
     await user.click(screen.getByRole("button", { name: /add new cardgroup/i }));
 
@@ -208,7 +209,7 @@ describe("<LogoDrawer>", () => {
     mockUsePathname.mockReturnValue("/cardgroups/abc-123/edit");
     const listener = vi.fn();
     window.addEventListener("flamingo:add-card", listener);
-    render(<LogoDrawer user={SIGNED_IN_USER} isAdmin={false} />);
+    renderWithIntl(<LogoDrawer user={SIGNED_IN_USER} isAdmin={false} />);
 
     await user.click(screen.getByRole("button", { name: /add new card/i }));
 
@@ -226,7 +227,7 @@ describe("<LogoDrawer>", () => {
     mockUsePathname.mockReturnValue("/cardgroups/abc-123/edit");
     const listener = vi.fn((event: Event) => event.preventDefault());
     window.addEventListener("flamingo:add-card", listener);
-    render(<LogoDrawer user={SIGNED_IN_USER} isAdmin={false} />);
+    renderWithIntl(<LogoDrawer user={SIGNED_IN_USER} isAdmin={false} />);
 
     await user.click(screen.getByRole("button", { name: /add new card/i }));
 
@@ -242,7 +243,7 @@ describe("<LogoDrawer>", () => {
     mockUsePathname.mockReturnValue("/cardgroups/abc%26evil/edit");
     const listener = vi.fn();
     window.addEventListener("flamingo:add-card", listener);
-    render(<LogoDrawer user={SIGNED_IN_USER} isAdmin={false} />);
+    renderWithIntl(<LogoDrawer user={SIGNED_IN_USER} isAdmin={false} />);
 
     await user.click(screen.getByRole("button", { name: /add new card/i }));
 
@@ -259,7 +260,7 @@ describe("<LogoDrawer>", () => {
   it("malformed edit path: '+' button is not rendered when the segment is a malformed percent-escape", () => {
     // safeDecodePathSegment returns null for %ZZ -> resolver returns null -> no '+' rendered.
     mockUsePathname.mockReturnValue("/cardgroups/abc%ZZ/edit");
-    render(<LogoDrawer user={SIGNED_IN_USER} isAdmin={false} />);
+    renderWithIntl(<LogoDrawer user={SIGNED_IN_USER} isAdmin={false} />);
     expect(screen.queryByRole("button", { name: /add new/i })).toBeNull();
   });
 
@@ -268,7 +269,7 @@ describe("<LogoDrawer>", () => {
     mockUsePathname.mockReturnValue("/learn/abc-123");
     const listener = vi.fn();
     window.addEventListener("flamingo:add-card", listener);
-    render(<LogoDrawer user={SIGNED_IN_USER} isAdmin={false} />);
+    renderWithIntl(<LogoDrawer user={SIGNED_IN_USER} isAdmin={false} />);
 
     await user.click(screen.getByRole("button", { name: /add new card/i }));
 
@@ -286,7 +287,7 @@ describe("<LogoDrawer>", () => {
     mockUsePathname.mockReturnValue("/learn/abc-123");
     const listener = vi.fn((event: Event) => event.preventDefault());
     window.addEventListener("flamingo:add-card", listener);
-    render(<LogoDrawer user={SIGNED_IN_USER} isAdmin={false} />);
+    renderWithIntl(<LogoDrawer user={SIGNED_IN_USER} isAdmin={false} />);
 
     await user.click(screen.getByRole("button", { name: /add new card/i }));
 
@@ -299,7 +300,7 @@ describe("<LogoDrawer>", () => {
   it("S-R1: on /admin/roles the '+' (Add new role) opens the create sheet by writing ?new=true to the URL", async () => {
     const user = userEvent.setup();
     mockUsePathname.mockReturnValue("/admin/roles");
-    render(<LogoDrawer user={SIGNED_IN_USER} isAdmin={true} />);
+    renderWithIntl(<LogoDrawer user={SIGNED_IN_USER} isAdmin={true} />);
 
     await user.click(screen.getByRole("button", { name: /add new role/i }));
 
@@ -310,20 +311,20 @@ describe("<LogoDrawer>", () => {
 
   it("S-G1: on an unknown route (/profile) the '+' button is not rendered", () => {
     mockUsePathname.mockReturnValue("/profile");
-    render(<LogoDrawer user={SIGNED_IN_USER} isAdmin={false} />);
+    renderWithIntl(<LogoDrawer user={SIGNED_IN_USER} isAdmin={false} />);
     expect(screen.queryByRole("button", { name: /add new/i })).toBeNull();
   });
 
   it("S-G2: anonymous user (user === null) sees no '+' button on any create route", () => {
     mockUsePathname.mockReturnValue("/cardgroups");
-    render(<LogoDrawer user={null} isAdmin={false} />);
+    renderWithIntl(<LogoDrawer user={null} isAdmin={false} />);
     expect(screen.queryByRole("button", { name: /add new/i })).toBeNull();
   });
 
   it("S-G3: the '+' button receives keyboard focus before the menu trigger (order: logo · + · menu)", async () => {
     const user = userEvent.setup();
     mockUsePathname.mockReturnValue("/cardgroups");
-    render(<LogoDrawer user={SIGNED_IN_USER} isAdmin={false} />);
+    renderWithIntl(<LogoDrawer user={SIGNED_IN_USER} isAdmin={false} />);
 
     const addButton = screen.getByRole("button", { name: /add new cardgroup/i });
     const menuButton = screen.getByRole("button", { name: "Open menu" });
@@ -336,7 +337,7 @@ describe("<LogoDrawer>", () => {
 
   it("S-G4: the menu trigger renders alongside the '+' on create routes", () => {
     mockUsePathname.mockReturnValue("/cardgroups");
-    render(<LogoDrawer user={SIGNED_IN_USER} isAdmin={false} />);
+    renderWithIntl(<LogoDrawer user={SIGNED_IN_USER} isAdmin={false} />);
     expect(screen.getByRole("button", { name: /add new cardgroup/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Open menu" })).toBeInTheDocument();
   });

--- a/frontend/src/components/nav/logo-drawer.tsx
+++ b/frontend/src/components/nav/logo-drawer.tsx
@@ -3,6 +3,7 @@
 import { BookOpen, Plus, User } from "lucide-react";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
 import { LogoutButton } from "@/app/_components/logout-button";
 import { FlamingoMark } from "@/components/brand/flamingo-mark";
 import { MobileMenuTrigger } from "@/components/nav/mobile-menu-trigger";
@@ -23,6 +24,7 @@ const NAV_LINK_CLASS =
   "flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium hover:bg-accent hover:text-accent-foreground active:bg-accent active:text-accent-foreground";
 
 export function LogoDrawer({ user, isAdmin }: LogoDrawerProps) {
+  const t = useTranslations("Nav");
   const pathname = usePathname();
   const router = useRouter();
   // Hooks must run unconditionally (Rules of Hooks); only `open(...)` is called
@@ -73,7 +75,7 @@ export function LogoDrawer({ user, isAdmin }: LogoDrawerProps) {
     <Sheet>
       <Link
         href="/"
-        aria-label="Flamingo home"
+        aria-label={t("flamingoHome")}
         className="rounded-md p-2 hover:bg-accent font-semibold"
       >
         <FlamingoMark className="size-7" aria-hidden="true" />
@@ -94,7 +96,7 @@ export function LogoDrawer({ user, isAdmin }: LogoDrawerProps) {
 
       <SheetContent side="left" className="flex flex-col">
         <SheetHeader>
-          <SheetTitle className="sr-only">Navigation menu</SheetTitle>
+          <SheetTitle className="sr-only">{t("navigationMenu")}</SheetTitle>
         </SheetHeader>
 
         {user === null && pathname !== "/login" && (
@@ -111,7 +113,7 @@ export function LogoDrawer({ user, isAdmin }: LogoDrawerProps) {
               <SheetClose asChild>
                 <Link href="/cardgroups" className={NAV_LINK_CLASS}>
                   <BookOpen className="h-4 w-4 shrink-0" aria-hidden="true" />
-                  Cardgroups
+                  {t("cardgroups")}
                 </Link>
               </SheetClose>
 
@@ -122,7 +124,7 @@ export function LogoDrawer({ user, isAdmin }: LogoDrawerProps) {
                     <SheetClose key={item.href} asChild>
                       <Link href={item.href} className={NAV_LINK_CLASS}>
                         <Icon className="h-4 w-4 shrink-0" aria-hidden="true" />
-                        {item.label}
+                        {t(item.labelKey)}
                       </Link>
                     </SheetClose>
                   );
@@ -135,7 +137,7 @@ export function LogoDrawer({ user, isAdmin }: LogoDrawerProps) {
               <SheetClose asChild>
                 <Link href="/profile" className={NAV_LINK_CLASS}>
                   <User className="h-4 w-4 shrink-0" aria-hidden="true" />
-                  Profile
+                  {t("profile")}
                 </Link>
               </SheetClose>
 

--- a/frontend/src/components/nav/nav-items.ts
+++ b/frontend/src/components/nav/nav-items.ts
@@ -3,11 +3,12 @@ import type { ComponentType } from "react";
 
 export type AdminNavItem = {
   href: "/admin/users" | "/admin/roles";
-  label: "Users" | "Roles";
+  /** Key into the `Nav` message namespace — resolved via `useTranslations("Nav")`. */
+  labelKey: "users" | "roles";
   icon: ComponentType<{ className?: string }>;
 };
 
 export const ADMIN_NAV_ITEMS: readonly AdminNavItem[] = [
-  { href: "/admin/users", label: "Users", icon: Users },
-  { href: "/admin/roles", label: "Roles", icon: ShieldCheck },
+  { href: "/admin/users", labelKey: "users", icon: Users },
+  { href: "/admin/roles", labelKey: "roles", icon: ShieldCheck },
 ] as const;


### PR DESCRIPTION
## Summary

Localize the navigation UI strings (sidebar rail, mobile drawer, logout button, sign-in link) to the `Nav` message namespace. Highest-visibility surface — present on every authenticated page — with a small, mechanical change on top of the i18n foundation (#343).

## Approach

- The `Nav` namespace was already seeded by the foundation, so **no catalog change was needed** — every string maps to an existing key (`cardgroups`, `profile`, `signIn`, `logout`, `users`, `roles`, `flamingoHome`, `navigationMenu`). en/ja key sets stay identical.
- Admin nav items now carry a `labelKey` (`"users" | "roles"`) instead of a hardcoded `label`, so the rendered text is resolved through `t(item.labelKey)` rather than embedded English.
- Each client component reads `const t = useTranslations("Nav")`; component tests now render via `renderWithIntl`, so the existing English string assertions stay green.

## Scope

- `src/components/nav/nav-items.ts` — `AdminNavItem.label` → `labelKey`; both `ADMIN_NAV_ITEMS` entries updated.
- `src/components/nav/global-rail.tsx` — Cardgroups / Flamingo home / admin items / Profile / Sign in → `Nav.*`.
- `src/components/nav/logo-drawer.tsx` — Flamingo home / Navigation menu / Cardgroups / admin items / Profile → `Nav.*`.
- `src/app/_components/logout-button.tsx` — `Logout` → `t("logout")`.
- `src/components/nav/header-sign-in-link.tsx` — `Sign in` → `t("signIn")`.
- Tests wrapped in `renderWithIntl`: `global-rail`, `logo-drawer`, `app-shell`, `header-sign-in-link`, `logout-button`.

## Out of scope

- Backend-originated messages stay English. Other screens' strings are separate per-area PRs.

## Test plan

- `pnpm --filter frontend typecheck` — green.
- `pnpm --filter frontend lint` — green.
- `pnpm --filter frontend test -- nav` (78) / `test -- app-shell` (8) / `test -- logout-button` (2) — all pass; full suite 1122 passed.
- `pnpm --filter frontend knip` — clean.
- No stale `item.label` reference remains; CJK grep over `frontend/src` — clean.

Closes #345
