### PR TITLE
feat(frontend): localize learn-session UI strings (en/ja)

### DIFF
--- a/frontend/e2e/learn-flow.spec.ts
+++ b/frontend/e2e/learn-flow.spec.ts
@@ -47,7 +47,11 @@ test("swipes easy cards and advances through the deck", async ({ page }) => {
 
   // The rating buttons moved out of the swipe card into LearnActionBar
   // (sticky bar below the deck), so click at page scope, not inside activeCard.
-  const easyButton = page.getByRole("button", { name: "Rate as Easy" });
+  // Select by the stable `aria-keyshortcuts` attribute rather than the accessible
+  // name: the rating label is now localized and Playwright runs with
+  // `locale: "ja-JP"`, so the rendered name is Japanese. The ArrowRight shortcut
+  // (the "Easy" rating) is locale-independent.
+  const easyButton = page.locator('button[aria-keyshortcuts="ArrowRight"]');
 
   const seen: string[] = [];
   for (let i = 0; i < 3; i += 1) {

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -39,5 +39,20 @@
   "Settings": {
     "heading": "Settings",
     "description": "Manage your preferences."
+  },
+  "Learn": {
+    "completeHeading": "Today's learning is complete",
+    "completeMessage": "All cards for this group have been reviewed. Come back when the next review is due.",
+    "studyAgain": "Study again",
+    "backToCardgroups": "Back to cardgroups",
+    "rateAs": "Rate as {label}",
+    "again": "Again",
+    "hard": "Hard",
+    "easy": "Easy",
+    "practiceBanner": "Practice — swipes aren't recorded",
+    "practiceEmptyHeading": "No cards practiced today yet",
+    "practiceEmptyMessage": "Review some cards in a learning session first, then come back to practice them.",
+    "practiceCompleteHeading": "Practice complete",
+    "practiceCompleteMessage": "You finished this practice round. Study again for another pass — your progress is never affected."
   }
 }

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -39,5 +39,20 @@
   "Settings": {
     "heading": "設定",
     "description": "環境設定を管理します。"
+  },
+  "Learn": {
+    "completeHeading": "本日の学習が完了しました",
+    "completeMessage": "このグループのすべてのカードを復習しました。次の復習時期になったらまたお越しください。",
+    "studyAgain": "もう一度学習",
+    "backToCardgroups": "カードグループに戻る",
+    "rateAs": "{label}と評価",
+    "again": "もう一度",
+    "hard": "むずかしい",
+    "easy": "かんたん",
+    "practiceBanner": "練習 — スワイプは記録されません",
+    "practiceEmptyHeading": "今日はまだ練習したカードがありません",
+    "practiceEmptyMessage": "まず学習セッションでカードを復習してから、練習しに戻ってきてください。",
+    "practiceCompleteHeading": "練習完了",
+    "practiceCompleteMessage": "この練習ラウンドを終えました。もう一周したい場合はもう一度学習してください。進捗には影響しません。"
   }
 }

--- a/frontend/src/app/learn/[cardgroupId]/learn-client.test.tsx
+++ b/frontend/src/app/learn/[cardgroupId]/learn-client.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { gql, InMemoryCache } from "@apollo/client";
 import { MockedProvider } from "@apollo/client/testing/react";
-import { act, render, screen, waitFor } from "@testing-library/react";
+import { act, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { GraphQLError } from "graphql";
 import { type RefObject, useImperativeHandle, useRef } from "react";
@@ -14,6 +14,7 @@ import {
   LearnNextDueCardsDocument,
   SetLastViewedCardgroupDocument,
 } from "@/generated/graphql";
+import { renderWithIntl } from "@/test/render-with-intl";
 import {
   type ApolloMockLeakSpyResult,
   installApolloMockLeakSpy,
@@ -265,7 +266,7 @@ function renderLearnClient(
   const mergedMocks = options.skipDefaultPrefetchMocks
     ? [...mocks, makeDefaultPersistMock()]
     : [...mocks, makeDefaultPersistMock(), ...makeDefaultPrefetchMocks()];
-  render(
+  renderWithIntl(
     <MockedProvider mocks={mergedMocks as never}>
       <LearnClient cardgroupId={CG_ID} initialCards={initialCards} />
     </MockedProvider>,
@@ -590,7 +591,7 @@ describe("<LearnClient>", () => {
     // default `[CARD_1]`, which narrows `cefrLevel` to `null`. Inline the render
     // to pass a LearnClient-compatible card with a non-null level without fighting
     // that inference — the same pattern used by the persist-last-viewed tests.
-    render(
+    renderWithIntl(
       <MockedProvider mocks={[makeDefaultPersistMock(), ...makeDefaultPrefetchMocks()]}>
         <LearnClient
           cardgroupId={CG_ID}
@@ -669,7 +670,7 @@ describe("<LearnClient> persist-last-viewed path", () => {
 
   it("fires SetLastViewedCardgroup mutation on mount", async () => {
     const mutationCalled = vi.fn();
-    render(
+    renderWithIntl(
       <MockedProvider
         mocks={[makePersistMock(CG_ID, mutationCalled), ...makeDefaultPrefetchMocks()]}
       >
@@ -685,7 +686,7 @@ describe("<LearnClient> persist-last-viewed path", () => {
   it("writes lastViewedCardgroup into the Apollo cache after mutation resolves", async () => {
     const cache = new InMemoryCache();
 
-    render(
+    renderWithIntl(
       <MockedProvider mocks={[makePersistMock(CG_ID), ...makeDefaultPrefetchMocks()]} cache={cache}>
         <LearnClient cardgroupId={CG_ID} initialCards={[CARD_1]} />
       </MockedProvider>,
@@ -731,7 +732,7 @@ describe("<LearnClient> persist-last-viewed path", () => {
       }),
     };
 
-    render(
+    renderWithIntl(
       <MockedProvider mocks={[validationMock, ...makeDefaultPrefetchMocks()]} cache={cache}>
         <LearnClient cardgroupId={CG_ID} initialCards={[CARD_1]} />
       </MockedProvider>,
@@ -781,7 +782,7 @@ describe("<LearnClient> persist-last-viewed path", () => {
       },
     ],
   ] as const)("swallows %s from the persist mutation without throwing", async (_, mockEntry) => {
-    render(
+    renderWithIntl(
       <MockedProvider mocks={[mockEntry, ...makeDefaultPrefetchMocks()]}>
         <LearnClient cardgroupId={CG_ID} initialCards={[CARD_1]} />
       </MockedProvider>,
@@ -969,7 +970,7 @@ describe("<LearnClient> onSwipe identity stability", () => {
       },
     };
 
-    render(
+    renderWithIntl(
       <MockedProvider mocks={[swipeMock, makeDefaultPersistMock(), ...makeDefaultPrefetchMocks()]}>
         <LearnClient cardgroupId={CG_ID} initialCards={[CARD_1, CARD_2]} />
       </MockedProvider>,

--- a/frontend/src/app/learn/[cardgroupId]/practice-client.test.tsx
+++ b/frontend/src/app/learn/[cardgroupId]/practice-client.test.tsx
@@ -2,7 +2,7 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { MockedProvider } from "@apollo/client/testing/react";
-import { render, screen, waitFor } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { GraphQLError } from "graphql";
 import { type RefObject, useImperativeHandle, useRef } from "react";
@@ -10,6 +10,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { CardContent, type SwipeCardData } from "@/components/learn/swipe-card";
 import type { SwipeCardStackHandle } from "@/components/learn/swipe-card-stack";
 import { PracticeTodaysCardsDocument } from "@/generated/graphql";
+import { renderWithIntl } from "@/test/render-with-intl";
 import {
   type ApolloMockLeakSpyResult,
   installApolloMockLeakSpy,
@@ -169,7 +170,7 @@ function makePracticeFieldErrorMock() {
 }
 
 function renderPractice(mocks: unknown[]) {
-  render(
+  renderWithIntl(
     <MockedProvider mocks={mocks as never}>
       <PracticeClient cardgroupId={CG_ID} />
     </MockedProvider>,

--- a/frontend/src/app/learn/[cardgroupId]/practice-client.tsx
+++ b/frontend/src/app/learn/[cardgroupId]/practice-client.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useQuery } from "@apollo/client/react";
+import { useTranslations } from "next-intl";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { PracticeTodaysCardsQuery as PracticeTodaysCardsDocument } from "@/app/learn/queries";
 import { AllCaughtUp } from "@/components/learn/all-caught-up";
@@ -17,12 +18,9 @@ import { advancePracticeQueue, outcomeFromDirection } from "./practice-queue";
 
 type PracticeCard = PracticeTodaysCardsQuery["practiceTodaysCards"][number];
 
-/**
- * Persistent banner shown the whole time practice mode is active. Reminds the
- * learner that practice is FSRS-safe: swipes are not recorded and have no
- * impact on the card's review schedule.
- */
-const PRACTICE_BANNER = "Practice — swipes aren't recorded";
+// A persistent banner (Learn.practiceBanner) is shown the whole time practice
+// mode is active. It reminds the learner that practice is FSRS-safe: swipes are
+// not recorded and have no impact on the card's review schedule.
 
 /**
  * FSRS-safe practice mode.
@@ -45,6 +43,7 @@ const PRACTICE_BANNER = "Practice — swipes aren't recorded";
  * screen, so the button never looks like a no-op.
  */
 export function PracticeClient({ cardgroupId }: { cardgroupId: string }) {
+  const t = useTranslations("Learn");
   const { data, loading, error, refetch } = useQuery(PracticeTodaysCardsDocument, {
     variables: { cardgroupId },
     fetchPolicy: "network-only",
@@ -166,12 +165,7 @@ export function PracticeClient({ cardgroupId }: { cardgroupId: string }) {
   // nothing to practice. Terminal state — no "Study again" (a refetch would
   // return the same empty pool).
   if ((pool?.length ?? 0) === 0) {
-    return (
-      <AllCaughtUp
-        heading="No cards practiced today yet"
-        message="Review some cards in a learning session first, then come back to practice them."
-      />
-    );
+    return <AllCaughtUp heading={t("practiceEmptyHeading")} message={t("practiceEmptyMessage")} />;
   }
 
   // Round complete: the pool was non-empty but every card has been retired
@@ -179,8 +173,8 @@ export function PracticeClient({ cardgroupId }: { cardgroupId: string }) {
   if (queue.length === 0) {
     return (
       <AllCaughtUp
-        heading="Practice complete"
-        message="You finished this practice round. Study again for another pass — your progress is never affected."
+        heading={t("practiceCompleteHeading")}
+        message={t("practiceCompleteMessage")}
         onStudyAgain={studyAgain}
       />
     );
@@ -192,7 +186,7 @@ export function PracticeClient({ cardgroupId }: { cardgroupId: string }) {
         className="mx-auto w-full max-w-xl rounded-md border border-border bg-muted/30 p-3 text-sm text-muted-foreground"
         role="status"
       >
-        {PRACTICE_BANNER}
+        {t("practiceBanner")}
       </div>
 
       <div className="relative flex min-h-0 items-center justify-center overflow-hidden">

--- a/frontend/src/components/learn/all-caught-up.test.tsx
+++ b/frontend/src/components/learn/all-caught-up.test.tsx
@@ -1,12 +1,13 @@
 // @vitest-environment jsdom
-import { render, screen } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
+import { renderWithIntl } from "@/test/render-with-intl";
 import { AllCaughtUp } from "./all-caught-up";
 
 describe("<AllCaughtUp>", () => {
   it("renders the caught-up message and cardgroups link", () => {
-    render(<AllCaughtUp />);
+    renderWithIntl(<AllCaughtUp />);
 
     expect(
       screen.getByRole("heading", { name: "Today's learning is complete" }),
@@ -19,12 +20,12 @@ describe("<AllCaughtUp>", () => {
   });
 
   it("does not render a Study again button by default", () => {
-    render(<AllCaughtUp />);
+    renderWithIntl(<AllCaughtUp />);
     expect(screen.queryByRole("button", { name: "Study again" })).not.toBeInTheDocument();
   });
 
   it("renders custom heading and message when provided", () => {
-    render(<AllCaughtUp heading="Practice complete" message="Another round awaits." />);
+    renderWithIntl(<AllCaughtUp heading="Practice complete" message="Another round awaits." />);
 
     expect(screen.getByRole("heading", { name: "Practice complete" })).toBeInTheDocument();
     expect(screen.getByText("Another round awaits.")).toBeInTheDocument();
@@ -36,14 +37,14 @@ describe("<AllCaughtUp>", () => {
   });
 
   it("renders a Study again button only when onStudyAgain is provided", () => {
-    render(<AllCaughtUp onStudyAgain={() => {}} />);
+    renderWithIntl(<AllCaughtUp onStudyAgain={() => {}} />);
     expect(screen.getByRole("button", { name: "Study again" })).toBeInTheDocument();
   });
 
   it("fires onStudyAgain when the Study again button is clicked", async () => {
     const user = userEvent.setup();
     const onStudyAgain = vi.fn();
-    render(<AllCaughtUp onStudyAgain={onStudyAgain} />);
+    renderWithIntl(<AllCaughtUp onStudyAgain={onStudyAgain} />);
 
     await user.click(screen.getByRole("button", { name: "Study again" }));
 

--- a/frontend/src/components/learn/all-caught-up.tsx
+++ b/frontend/src/components/learn/all-caught-up.tsx
@@ -1,9 +1,8 @@
-import Link from "next/link";
-import { Button } from "@/components/ui/button";
+"use client";
 
-const DEFAULT_HEADING = "Today's learning is complete";
-const DEFAULT_MESSAGE =
-  "All cards for this group have been reviewed. Come back when the next review is due.";
+import Link from "next/link";
+import { useTranslations } from "next-intl";
+import { Button } from "@/components/ui/button";
 
 type Props = {
   /** Heading copy. Defaults to the end-of-daily-learn message. */
@@ -18,24 +17,21 @@ type Props = {
   onStudyAgain?: () => void;
 };
 
-export function AllCaughtUp({
-  heading = DEFAULT_HEADING,
-  message = DEFAULT_MESSAGE,
-  onStudyAgain,
-}: Props) {
+export function AllCaughtUp({ heading, message, onStudyAgain }: Props) {
+  const t = useTranslations("Learn");
   return (
     <section className="flex flex-1 items-center justify-center">
       <div className="w-full max-w-md rounded-lg border border-dashed border-border p-8 text-center">
-        <h1 className="mb-2 text-xl font-semibold">{heading}</h1>
-        <p className="mb-6 text-sm text-muted-foreground">{message}</p>
+        <h1 className="mb-2 text-xl font-semibold">{heading ?? t("completeHeading")}</h1>
+        <p className="mb-6 text-sm text-muted-foreground">{message ?? t("completeMessage")}</p>
         <div className="flex flex-col items-center gap-3">
           {onStudyAgain ? (
             <Button type="button" variant="brand" onClick={onStudyAgain}>
-              Study again
+              {t("studyAgain")}
             </Button>
           ) : null}
           <Button asChild variant={onStudyAgain ? "outline" : "brand"}>
-            <Link href="/cardgroups">Back to cardgroups</Link>
+            <Link href="/cardgroups">{t("backToCardgroups")}</Link>
           </Button>
         </div>
       </div>

--- a/frontend/src/components/learn/all-caught-up.tsx
+++ b/frontend/src/components/learn/all-caught-up.tsx
@@ -5,9 +5,9 @@ import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
 
 type Props = {
-  /** Heading copy. Defaults to the end-of-daily-learn message. */
+  /** Heading copy. Falls back to the `Learn.completeHeading` message when omitted. */
   heading?: string;
-  /** Body copy. Defaults to the end-of-daily-learn message. */
+  /** Body copy. Falls back to the `Learn.completeMessage` message when omitted. */
   message?: string;
   /**
    * When provided, render a primary "Study again" button above the always-present

--- a/frontend/src/components/learn/learn-action-bar.test.tsx
+++ b/frontend/src/components/learn/learn-action-bar.test.tsx
@@ -1,12 +1,13 @@
 // @vitest-environment jsdom
-import { render, screen } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
+import { renderWithIntl } from "@/test/render-with-intl";
 import { LearnActionBar } from "./learn-action-bar";
 
 describe("<LearnActionBar>", () => {
   it("renders the three rating buttons with accessible labels and shortcuts but no visible text labels", () => {
-    render(<LearnActionBar onRate={vi.fn()} />);
+    renderWithIntl(<LearnActionBar onRate={vi.fn()} />);
 
     expect(screen.getByRole("button", { name: "Rate as Again" })).toHaveAttribute(
       "aria-keyshortcuts",
@@ -34,7 +35,7 @@ describe("<LearnActionBar>", () => {
   ] as const)("calls onRate with %s direction", async (name, direction) => {
     const user = userEvent.setup();
     const onRate = vi.fn();
-    render(<LearnActionBar onRate={onRate} />);
+    renderWithIntl(<LearnActionBar onRate={onRate} />);
 
     await user.click(screen.getByRole("button", { name }));
 
@@ -44,7 +45,7 @@ describe("<LearnActionBar>", () => {
   it("disables all rating buttons and ignores clicks while disabled", async () => {
     const user = userEvent.setup();
     const onRate = vi.fn();
-    render(<LearnActionBar onRate={onRate} disabled />);
+    renderWithIntl(<LearnActionBar onRate={onRate} disabled />);
 
     const again = screen.getByRole("button", { name: "Rate as Again" });
     const hard = screen.getByRole("button", { name: "Rate as Hard" });
@@ -63,7 +64,7 @@ describe("<LearnActionBar>", () => {
 
   it("keeps tab order as Again, Hard, Easy", async () => {
     const user = userEvent.setup();
-    render(<LearnActionBar onRate={vi.fn()} />);
+    renderWithIntl(<LearnActionBar onRate={vi.fn()} />);
 
     await user.tab();
     expect(screen.getByRole("button", { name: "Rate as Again" })).toHaveFocus();

--- a/frontend/src/components/learn/learn-action-bar.tsx
+++ b/frontend/src/components/learn/learn-action-bar.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { RotateCcw, Smile, Zap } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { cn } from "@/lib/utils";
 import type { SwipeDirection } from "./types";
 
@@ -12,7 +13,7 @@ type Props = {
 const DIRECTIONS = [
   {
     direction: "left",
-    label: "Again",
+    labelKey: "again",
     Icon: RotateCcw,
     shortcut: "ArrowLeft",
     colorClass:
@@ -20,7 +21,7 @@ const DIRECTIONS = [
   },
   {
     direction: "down",
-    label: "Hard",
+    labelKey: "hard",
     Icon: Zap,
     shortcut: "ArrowDown",
     colorClass:
@@ -28,7 +29,7 @@ const DIRECTIONS = [
   },
   {
     direction: "right",
-    label: "Easy",
+    labelKey: "easy",
     Icon: Smile,
     shortcut: "ArrowRight",
     colorClass:
@@ -37,14 +38,15 @@ const DIRECTIONS = [
 ] as const;
 
 export function LearnActionBar({ onRate, disabled = false }: Props) {
+  const t = useTranslations("Learn");
   return (
     <div className="pointer-events-none z-40 flex justify-center px-4 pt-3 pb-[calc(0.75rem+env(safe-area-inset-bottom))] md:pb-[calc(1.5rem+env(safe-area-inset-bottom))]">
       <div className="pointer-events-auto flex items-center gap-4">
-        {DIRECTIONS.map(({ direction, label, Icon, shortcut, colorClass }) => (
+        {DIRECTIONS.map(({ direction, labelKey, Icon, shortcut, colorClass }) => (
           <button
             key={direction}
             type="button"
-            aria-label={`Rate as ${label}`}
+            aria-label={t("rateAs", { label: t(labelKey) })}
             aria-keyshortcuts={shortcut}
             disabled={disabled}
             onClick={() => onRate(direction)}


### PR DESCRIPTION
## Summary

Localize the learn-session UI (completion screen, rating buttons, practice banner, and the practice-mode empty/complete screens) to the `Learn` message namespace. Shown during every study session — core vocabulary of the app — built on the i18n foundation (#343).

## Approach

- New `Learn` namespace in both catalogs (13 keys, identical en/ja sets). Rating labels use an ICU message: `rateAs` = `"Rate as {label}"` with `label` resolved from `again`/`hard`/`easy`, so under the en catalog the `aria-label` still reads "Rate as Again" and existing test queries stay green.
- `AllCaughtUp` becomes a client component and falls back to `t("completeHeading")` / `t("completeMessage")` when no copy props are passed; callers can still override.
- The rating bar's `DIRECTIONS` entries carry a `labelKey` instead of a hardcoded `label`.
- **Practice-mode screens included.** Beyond the documented `practiceBanner`, the practice empty-pool and round-complete screens (`AllCaughtUp` headings/messages) are also localized via four `practice*` keys. They live on the same `/learn` route, so leaving them English would show a mixed-language session — a deliberate, consistent extension of the issue's stated goal ("localize the learn-session UI").
- FSRS-safe invariant preserved: no swipe-mutation import added; the practice-client static-source guard test still passes.

## Scope

- `messages/{en,ja}.json` — add the `Learn` namespace.
- `src/components/learn/all-caught-up.tsx` — `"use client"`, `useTranslations("Learn")`, `t`-defaulted copy + buttons.
- `src/components/learn/learn-action-bar.tsx` — `labelKey` + `t("rateAs", { label: t(labelKey) })`.
- `src/app/learn/[cardgroupId]/practice-client.tsx` — `practiceBanner` + the four `practice*` `AllCaughtUp` props.
- Tests (`all-caught-up`, `learn-action-bar`, `learn-client`, `practice-client`) wrapped in `renderWithIntl`.

`learn-client.tsx` needed no change — it renders `<AllCaughtUp />` with no copy props, so the localized defaults apply automatically.

## Out of scope

- Backend-originated messages stay English. The two learn/practice **error-banner** literals (`"Could not save that swipe…"`, `"Could not load today's practice cards…"`) are not in the documented `Learn` key set and one is asserted verbatim in a test — left for a follow-up error-message-family PR.

## Test plan

- `pnpm --filter frontend typecheck` — green.
- `pnpm --filter frontend lint` — green.
- `pnpm --filter frontend test -- learn` / `test -- practice` / `test -- all-caught-up` — all pass (177 targeted); FSRS-safe static guards pass.
- `pnpm --filter frontend knip` — clean.
- en/ja `Learn` key sets identical (13 keys); CJK grep over `frontend/src` — clean.

Closes #346
