### PR TITLE
feat(frontend): localize login/auth-surface UI strings (en/ja)

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -39,5 +39,13 @@
   "Settings": {
     "heading": "Settings",
     "description": "Manage your preferences."
+  },
+  "Login": {
+    "heading": "Sign in",
+    "googleCta": "Sign in with your Google account to continue. New here? An account is created on first sign-in.",
+    "signInFailed": "Sign-in failed: {error}",
+    "googleButton": "Continue with Google",
+    "terms": "By signing in, you agree to our <terms>Terms of Service</terms> and <privacy>Privacy Policy</privacy>.",
+    "tagline": "Remember more, study less."
   }
 }

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -39,5 +39,13 @@
   "Settings": {
     "heading": "設定",
     "description": "環境設定を管理します。"
+  },
+  "Login": {
+    "heading": "ログイン",
+    "googleCta": "Google アカウントでログインして続行してください。初めての方は、初回ログイン時にアカウントが作成されます。",
+    "signInFailed": "ログインに失敗しました: {error}",
+    "googleButton": "Google で続行",
+    "terms": "ログインすることで、<terms>利用規約</terms>および<privacy>プライバシーポリシー</privacy>に同意したものとみなされます。",
+    "tagline": "少ない学習で、より多く記憶。"
   }
 }

--- a/frontend/src/app/login/login-button.test.tsx
+++ b/frontend/src/app/login/login-button.test.tsx
@@ -1,0 +1,21 @@
+// @vitest-environment jsdom
+import { screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { renderWithIntl } from "@/test/render-with-intl";
+import { LoginButton } from "./login-button";
+
+// The browser Supabase client is only constructed inside the click handler, but
+// mock the module so importing the component never reaches the real client.
+vi.mock("@/lib/supabase/client", () => ({
+  createSupabaseBrowserClient: vi.fn(),
+}));
+
+describe("<LoginButton>", () => {
+  it("renders the localized Google sign-in label", () => {
+    // renderWithIntl defaults to the en catalog, so `t("googleButton")` resolves
+    // to "Continue with Google" — this pins the Login.googleButton key.
+    renderWithIntl(<LoginButton />);
+
+    expect(screen.getByRole("button", { name: /continue with google/i })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/login/login-button.tsx
+++ b/frontend/src/app/login/login-button.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
 import { createSupabaseBrowserClient } from "@/lib/supabase/client";
 
@@ -30,6 +31,8 @@ function GoogleGLogo() {
 }
 
 export function LoginButton() {
+  const t = useTranslations("Login");
+
   async function handleSignIn() {
     const supabase = createSupabaseBrowserClient();
     const { error } = await supabase.auth.signInWithOAuth({
@@ -46,7 +49,7 @@ export function LoginButton() {
   return (
     <Button onClick={handleSignIn} type="button" variant="brand">
       <GoogleGLogo />
-      Continue with Google
+      {t("googleButton")}
     </Button>
   );
 }

--- a/frontend/src/app/login/page.test.tsx
+++ b/frontend/src/app/login/page.test.tsx
@@ -18,7 +18,19 @@ vi.mock("./login-button", () => ({
   LoginButton: () => <button type="button">Sign in</button>,
 }));
 
+// next-intl/server — the page resolves the Login namespace via getTranslations.
+// Back the mock with createTranslator + the real en catalog so t()/t.rich()
+// produce the original English copy (and rendered Terms/Privacy links), keeping
+// the existing English string assertions valid.
+vi.mock("next-intl/server", () => ({
+  getTranslations: vi.fn(async (namespace: "Login") =>
+    createTranslator({ locale: "en", messages: enMessages, namespace }),
+  ),
+}));
+
 import { headers } from "next/headers";
+import { createTranslator } from "next-intl";
+import enMessages from "../../../messages/en.json";
 import LoginPage from "./page";
 
 describe("LoginPage", () => {

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 import { getTranslations } from "next-intl/server";
+import type { ReactNode } from "react";
 import { FlamingoMark } from "@/components/brand/flamingo-mark";
 import { readAuthContext } from "@/lib/supabase/auth-status";
 import { LoginButton } from "./login-button";
@@ -17,6 +18,14 @@ export default async function LoginPage({ searchParams }: { searchParams: Search
 
   const t = await getTranslations("Login");
   const { error } = await searchParams;
+
+  // Both footer rich-text tags render the same styled link, differing only in href.
+  const footerLink = (href: string) => (chunks: ReactNode) => (
+    <a href={href} className="underline underline-offset-2 hover:text-foreground">
+      {chunks}
+    </a>
+  );
+
   return (
     <main data-testid="login-grid" className="relative grid h-svh lg:grid-cols-2">
       <div className="flex flex-col">
@@ -46,19 +55,8 @@ export default async function LoginPage({ searchParams }: { searchParams: Search
 
               <footer className="border-t pt-5 text-xs text-muted-foreground text-center">
                 {t.rich("terms", {
-                  terms: (chunks) => (
-                    <a href="/terms" className="underline underline-offset-2 hover:text-foreground">
-                      {chunks}
-                    </a>
-                  ),
-                  privacy: (chunks) => (
-                    <a
-                      href="/privacy"
-                      className="underline underline-offset-2 hover:text-foreground"
-                    >
-                      {chunks}
-                    </a>
-                  ),
+                  terms: footerLink("/terms"),
+                  privacy: footerLink("/privacy"),
                 })}
               </footer>
             </div>

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
+import { getTranslations } from "next-intl/server";
 import { FlamingoMark } from "@/components/brand/flamingo-mark";
 import { readAuthContext } from "@/lib/supabase/auth-status";
 import { LoginButton } from "./login-button";
@@ -14,6 +15,7 @@ export default async function LoginPage({ searchParams }: { searchParams: Search
   // identity via x-auth-status; stale / anonymous / error all render the page.
   if (readAuthContext(await headers()).status === "authenticated") redirect("/cardgroups");
 
+  const t = await getTranslations("Login");
   const { error } = await searchParams;
   return (
     <main data-testid="login-grid" className="relative grid h-svh lg:grid-cols-2">
@@ -30,31 +32,34 @@ export default async function LoginPage({ searchParams }: { searchParams: Search
           <div className="w-full max-w-sm">
             <div className="flex flex-col gap-6 rounded-2xl border bg-card p-8 shadow-[0_8px_40px_-12px_rgba(0,0,0,0.18)]">
               <div className="flex flex-col gap-2 text-start">
-                <h1 className="text-2xl font-semibold tracking-tight">Sign in</h1>
-                <p className="text-sm text-muted-foreground">
-                  Sign in with your Google account to continue. New here? An account is created on
-                  first sign-in.
-                </p>
+                <h1 className="text-2xl font-semibold tracking-tight">{t("heading")}</h1>
+                <p className="text-sm text-muted-foreground">{t("googleCta")}</p>
               </div>
 
               {error && (
                 <p role="alert" className="text-sm text-destructive">
-                  Sign-in failed: {error}
+                  {t("signInFailed", { error })}
                 </p>
               )}
 
               <LoginButton />
 
               <footer className="border-t pt-5 text-xs text-muted-foreground text-center">
-                By signing in, you agree to our{" "}
-                <a href="/terms" className="underline underline-offset-2 hover:text-foreground">
-                  Terms of Service
-                </a>{" "}
-                and{" "}
-                <a href="/privacy" className="underline underline-offset-2 hover:text-foreground">
-                  Privacy Policy
-                </a>
-                .
+                {t.rich("terms", {
+                  terms: (chunks) => (
+                    <a href="/terms" className="underline underline-offset-2 hover:text-foreground">
+                      {chunks}
+                    </a>
+                  ),
+                  privacy: (chunks) => (
+                    <a
+                      href="/privacy"
+                      className="underline underline-offset-2 hover:text-foreground"
+                    >
+                      {chunks}
+                    </a>
+                  ),
+                })}
               </footer>
             </div>
           </div>
@@ -80,7 +85,7 @@ export default async function LoginPage({ searchParams }: { searchParams: Search
               flamingo-armond
             </span>
             <span className="text-sm font-medium text-white/90 drop-shadow-[0_1px_6px_rgba(120,20,40,0.35)]">
-              Remember more, study less.
+              {t("tagline")}
             </span>
           </div>
         </div>


### PR DESCRIPTION
## Summary

Localize the login / auth-surface copy (`login/page.tsx`) to the `Login` message namespace. Public face of the app — the first thing anonymous visitors see — and because the foundation (#343) auto-detects `Accept-Language`, a Japanese browser with no cookie now lands on a Japanese login screen.

## Approach

- `login/page.tsx` is a server component, so it uses `const t = await getTranslations("Login")` (from `next-intl/server`).
- The Terms/Privacy footer mixes plain text with two `<a>` links, so it uses a single next-intl **rich-text** message (`t.rich`) with `<terms>` / `<privacy>` tags; the page supplies render functions that wrap the chunks in the original `<a href="/terms">` / `<a href="/privacy">` elements with unchanged hrefs and classNames. The rendered DOM is equivalent to the prior markup, so the existing footer link-role tests pass unchanged.
- The sign-in error line uses an ICU placeholder: `signInFailed` = `"Sign-in failed: {error}"`.
- The brand wordmark `flamingo-armond` stays a literal.

## Scope

- `messages/{en,ja}.json` — add the `Login` namespace (`heading`, `googleCta`, `signInFailed`, `googleButton`, `terms`, `tagline`; identical en/ja key sets).
- `src/app/login/page.tsx` — `getTranslations("Login")`; each literal → `t(...)` / `t.rich(...)`.
- `src/app/login/login-button.tsx` — "Continue with Google" → `t("googleButton")` via `useTranslations("Login")`.
- `src/app/login/page.test.tsx` — mock `next-intl/server` `getTranslations` with `createTranslator` + the real en catalog so `t()`/`t.rich()` render the original English copy; assertions unchanged.

## Out of scope

- Backend-originated messages stay English. Other screens' strings are separate per-area PRs.

## Test plan

- `pnpm --filter frontend typecheck` — green.
- `pnpm --filter frontend lint` — green.
- `pnpm --filter frontend test -- login` — 20 passed (1 file); full suite 1122 passed.
- `pnpm --filter frontend knip` — clean.
- en/ja `Login` key sets identical; CJK grep over `frontend/src` — clean.
- Manual contract: a `ja`-preferring browser with no cookie renders the login page in Japanese (auto-detect inherited from the foundation).

Closes #347
