### PR TITLE
feat(frontend): locale-aware date formatting (en/ja)

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -39,5 +39,8 @@
   "Settings": {
     "heading": "Settings",
     "description": "Manage your preferences."
+  },
+  "Cardgroups": {
+    "updatedAt": "Updated {date}"
   }
 }

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -39,5 +39,8 @@
   "Settings": {
     "heading": "設定",
     "description": "環境設定を管理します。"
+  },
+  "Cardgroups": {
+    "updatedAt": "{date}に更新"
   }
 }

--- a/frontend/src/app/cardgroups/cardgroups-client.test.tsx
+++ b/frontend/src/app/cardgroups/cardgroups-client.test.tsx
@@ -1,12 +1,13 @@
 // @vitest-environment jsdom
 import { InMemoryCache } from "@apollo/client";
 import { MockedProvider } from "@apollo/client/testing/react";
-import { act, render, screen, waitFor } from "@testing-library/react";
+import { act, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { GraphQLError } from "graphql";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { DeleteCardgroupDocument, MyCardgroupsConnectionDocument } from "@/generated/graphql";
 import { UndoDeleteProvider } from "@/lib/undo-delete";
+import { renderWithIntl } from "@/test/render-with-intl";
 import {
   type ApolloMockLeakSpyResult,
   installApolloMockLeakSpy,
@@ -164,7 +165,7 @@ function renderClient(
   initialConnection: ReturnType<typeof makeConnection> | null = null,
   cache?: InMemoryCache,
 ) {
-  render(
+  renderWithIntl(
     <MockedProvider mocks={mocks as never} cache={cache}>
       <UndoDeleteProvider>
         <CardgroupsClient initialConnection={initialConnection} />

--- a/frontend/src/components/cardgroups/cardgroup-list-item.test.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-list-item.test.tsx
@@ -1,7 +1,9 @@
 // @vitest-environment jsdom
 import { MockedProvider } from "@apollo/client/testing/react";
-import { render, screen } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
+import { renderWithIntl } from "@/test/render-with-intl";
+import jaMessages from "../../../messages/ja.json";
 import { CardgroupListItem } from "./cardgroup-list-item";
 
 // SwipeableRow uses useReducedMotion which reads matchMedia.
@@ -26,19 +28,23 @@ function stubMatchMedia(reducedMotion: boolean) {
 
 stubMatchMedia(false);
 
-function renderItem(props: {
-  id: string;
-  name: string;
-  updatedAt: string;
-  onDelete?: (id: string, name: string) => void;
-}) {
+function renderItem(
+  props: {
+    id: string;
+    name: string;
+    updatedAt: string;
+    onDelete?: (id: string, name: string) => void;
+  },
+  intl?: { locale: "en" | "ja"; messages: typeof jaMessages },
+) {
   const { onDelete = vi.fn(), ...rest } = props;
-  render(
+  renderWithIntl(
     <MockedProvider mocks={[]}>
       <ul>
         <CardgroupListItem {...rest} onDelete={onDelete} />
       </ul>
     </MockedProvider>,
+    intl,
   );
 }
 
@@ -59,9 +65,22 @@ describe("<CardgroupListItem>", () => {
 
   it("renders formatted date text", () => {
     renderItem({ id: "cg-1", name: "My Flashcards", updatedAt: fixedDate });
-    // Intl.DateTimeFormat en-US medium: "Jun 15, 2024"
+    // Default (en) catalog: "Updated <date>"; Intl medium en: "Jun 15, 2024".
     expect(screen.getByText(/Updated/)).toBeInTheDocument();
     expect(screen.getByText(/Jun 15, 2024/)).toBeInTheDocument();
+  });
+
+  it("renders the Japanese updated-at copy under the ja locale", () => {
+    renderItem(
+      { id: "cg-1", name: "My Flashcards", updatedAt: fixedDate },
+      { locale: "ja", messages: jaMessages },
+    );
+    // The ja "Cardgroups.updatedAt" message places the date before the verb, so
+    // the formatted date is year-first and the English "Updated " prefix is
+    // absent (proving the ja catalog + ja locale both took effect). Assert
+    // without a CJK literal per the language policy.
+    expect(screen.queryByText(/Updated/)).not.toBeInTheDocument();
+    expect(screen.getByText(/^2024/)).toBeInTheDocument();
   });
 
   it("renders a Delete button as a sibling of the name link (not nested inside it)", () => {

--- a/frontend/src/components/cardgroups/cardgroup-list-item.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-list-item.tsx
@@ -1,5 +1,8 @@
+"use client";
+
 import { Trash2 } from "lucide-react";
 import Link from "next/link";
+import { useLocale, useTranslations } from "next-intl";
 import { SwipeableRow } from "@/components/cardgroups/swipeable-row";
 import { Button } from "@/components/ui/button";
 import { formatMediumDate } from "@/lib/format";
@@ -19,6 +22,8 @@ export function CardgroupListItem({
   busy = false,
   onDelete,
 }: CardgroupListItemProps) {
+  const locale = useLocale();
+  const t = useTranslations("Cardgroups");
   const deleteLabel = `Delete cardgroup ${name}`;
   const requestDelete = () => onDelete(id, name);
   return (
@@ -27,7 +32,7 @@ export function CardgroupListItem({
         <Link href={`/cardgroups/${id}/edit`} className="flex min-w-0 flex-1 flex-col gap-1 p-4">
           <span className="truncate font-medium text-foreground">{name}</span>
           <span className="text-sm text-muted-foreground">
-            Updated {formatMediumDate(updatedAt)}
+            {t("updatedAt", { date: formatMediumDate(updatedAt, locale) })}
           </span>
         </Link>
         <Button

--- a/frontend/src/lib/format.test.ts
+++ b/frontend/src/lib/format.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { formatMediumDate } from "./format";
+
+describe("formatMediumDate", () => {
+  // Midday UTC keeps the calendar date stable across runner time zones.
+  const iso = "2026-06-11T12:00:00Z";
+
+  it("formats with the en-US locale (abbreviated month)", () => {
+    expect(formatMediumDate(iso, "en-US")).toMatch(/Jun/);
+  });
+
+  it("honors a Japanese locale (year-first, distinct from en-US)", () => {
+    const ja = formatMediumDate(iso, "ja-JP");
+    // ja medium is year-first (slash or year/month/day-suffixed form depending on
+    // the runtime's ICU data); en-US is month-first ("Jun 11, 2026"). Assert the
+    // locale arg is honored without pinning a CJK literal (kept out of source per
+    // the language policy) — the string starts with the year and differs from en.
+    expect(ja).toMatch(/^2026/);
+    expect(ja).not.toBe(formatMediumDate(iso, "en-US"));
+  });
+
+  it("defaults to en-US when no locale is passed", () => {
+    expect(formatMediumDate(iso)).toMatch(/Jun/);
+  });
+});

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -1,5 +1,3 @@
-const MEDIUM_DATE = new Intl.DateTimeFormat("en-US", { dateStyle: "medium" });
-
-export function formatMediumDate(iso: string): string {
-  return MEDIUM_DATE.format(new Date(iso));
+export function formatMediumDate(iso: string, locale = "en-US"): string {
+  return new Intl.DateTimeFormat(locale, { dateStyle: "medium" }).format(new Date(iso));
 }


### PR DESCRIPTION
## Summary

Make date formatting locale-aware. `src/lib/format.ts` hardcoded `Intl.DateTimeFormat("en-US")`, and `cardgroup-list-item.tsx` rendered `Updated {date}` as a string concatenation whose word order breaks in Japanese. This switches to a locale-parameterized formatter plus an ICU `{date}` message, on top of the i18n foundation (#343).

## Approach

- `formatMediumDate(iso, locale = "en-US")` now constructs `Intl.DateTimeFormat` per call so the locale argument is honored (the module-level singleton is dropped).
- **`formatMediumDate` is kept as the formatter and called from the component with the active locale** rather than switching the component to next-intl's `useFormatter()`. `formatMediumDate` has exactly one production caller, so moving the component off it would orphan the export and fail `knip`; keeping the component on it preserves a live caller.
- `cardgroup-list-item.tsx` reads `useLocale()` + `useTranslations("Cardgroups")` and renders `t("updatedAt", { date: formatMediumDate(updatedAt, locale) })`. The ICU message carries the word order: en `"Updated {date}"`, ja `"{date}に更新"`.

## Runtime note (worth a reviewer's attention)

The issue's acceptance criterion expected `ja-JP` medium dates to match `/年/`. Running the code in this Node/ICU build shows `Intl.DateTimeFormat("ja-JP", { dateStyle: "medium" })` renders the **slash** form (`2026/06/11`); the `年/月/日` form is `dateStyle: "long"`, not `medium`. Medium dates still differ from English by **field order** (year-first) and separators, so locale-awareness is real — only the `/年/` literal assumption was off. `format.test.ts` therefore asserts the en path via `/Jun/` and the ja path via year-first ordering + difference-from-en (CJK-free, timezone-stable via a midday-UTC fixture) instead of pinning `/年/`.

## Scope

- `src/lib/format.ts` — `formatMediumDate(iso, locale = "en-US")`.
- `src/lib/format.test.ts` (new) — en-US → `/Jun/`, default-arg → `/Jun/`, ja honored (year-first, differs from en).
- `src/components/cardgroups/cardgroup-list-item.tsx` — `"use client"`, `useLocale()` + `useTranslations("Cardgroups")`, ICU `updatedAt`.
- `messages/{en,ja}.json` — add `Cardgroups.updatedAt` (en `"Updated {date}"`, ja `"{date}に更新"`).
- Tests wrapped in `renderWithIntl`: `cardgroup-list-item.test.tsx` (+ a ja-locale render) and `cardgroups-client.test.tsx` (renders the real list item transitively).

## Out of scope

- Other cardgroup/card strings — the cardgroups/cards string PR.
- Number / currency formatting — none in the codebase.

## Test plan

- `pnpm --filter frontend typecheck` — green.
- `pnpm --filter frontend lint` — green.
- targeted `vitest run` of the 3 affected files — 30 passed; full suite 1126 passed.
- `pnpm --filter frontend knip` — clean (`formatMediumDate` retains a production caller).
- en/ja `Cardgroups.updatedAt` identical; CJK grep over `frontend/src` — clean.

Closes #348
