### PR TITLE
fix(frontend): pin the PWA splash mark to #1f1f1f via inline style

### DIFF
--- a/frontend/src/components/pwa/brand-splash.test.tsx
+++ b/frontend/src/components/pwa/brand-splash.test.tsx
@@ -10,6 +10,14 @@ describe("<BrandSplash>", () => {
     expect(root).toHaveStyle({ backgroundColor: "#FF6F79" });
   });
 
+  it("paints the donut mark with the pinned near-black hex via inline style", () => {
+    // The mark color must be an inline style, not a Tailwind `fill-*` class, so
+    // it survives the first paint before the stylesheet loads (the cause of the
+    // mark rendering as default black on a real PWA launch).
+    const { container } = render(<BrandSplash label="Loading" />);
+    expect(container.querySelector("svg")).toHaveStyle({ fill: "#1f1f1f" });
+  });
+
   it("exposes the accessible label as a status region", () => {
     render(<BrandSplash label="Loading" />);
     expect(screen.getByRole("status", { name: "Loading" })).toBeInTheDocument();

--- a/frontend/src/components/pwa/brand-splash.tsx
+++ b/frontend/src/components/pwa/brand-splash.tsx
@@ -6,6 +6,12 @@ import type { ReactNode } from "react";
 // not this exact hex, so the backdrop is pinned to the literal instead.
 const BRAND_CORAL = "#FF6F79";
 
+// The donut mark color. Like BRAND_CORAL it is pinned to a literal hex rather
+// than a design token, and it is applied as an inline style (not a Tailwind
+// `fill-*` utility) so it always paints with the first HTML chunk even before
+// the stylesheet loads — otherwise the SVG falls back to its default black fill.
+const MARK_COLOR = "#1f1f1f";
+
 // Donut mark inlined as a path literal (Material "Donut Large") so the splash
 // needs no extra network request — it paints with the first HTML chunk.
 const DONUT_PATH =
@@ -42,7 +48,8 @@ export function BrandSplash({ spin = true, label, children }: BrandSplashProps) 
       <svg
         viewBox="0 0 24 24"
         aria-hidden="true"
-        className={`size-14 fill-white${spin ? " motion-safe:animate-spin" : ""}`}
+        style={{ fill: MARK_COLOR }}
+        className={`size-14${spin ? " motion-safe:animate-spin" : ""}`}
       >
         <path d={DONUT_PATH} />
       </svg>


### PR DESCRIPTION
## Summary

On a real iOS PWA launch, the loading/error splash rendered its donut mark in **black** instead of the intended light mark (coral background + black mark). The mark color was set with the Tailwind `fill-white` utility class, which is not yet applied during the first paint before the stylesheet loads, so the inline SVG fell back to its default black `fill`. The coral backdrop was unaffected because it is set via an inline `style`, which is what produced the asymmetric "coral background + black mark" observed on launch.

This pins the mark to `#1f1f1f` via an inline `style={{ fill }}` — mirroring how `BRAND_CORAL` already pins the backdrop — so the mark paints with the first HTML chunk and no longer depends on the stylesheet being applied.

## Changes

- `frontend/src/components/pwa/brand-splash.tsx`: add a `MARK_COLOR = "#1f1f1f"` literal and apply it via inline `style={{ fill: MARK_COLOR }}`; drop the `fill-white` Tailwind class.
- `frontend/src/components/pwa/brand-splash.test.tsx`: assert the mark is painted with the pinned `#1f1f1f` inline fill — a regression guard against reverting to a class-based fill that black-falls-back on first paint.

## Test plan

- [x] `pnpm --filter frontend codegen` — green
- [x] `pnpm --filter frontend typecheck` — green
- [x] `pnpm --filter frontend lint` — clean (changed files; only the pre-existing biome `$schema` version info remains)
- [x] `pnpm --filter frontend test brand-splash` — 6/6 green
- [x] `pnpm --filter frontend knip` — clean

No associated issue.
