### PR TITLE
fix(frontend): recolor the PWA splash mark to loading.svg off-white (#f1f1f1)

### DIFF
--- a/frontend/src/components/pwa/brand-splash.test.tsx
+++ b/frontend/src/components/pwa/brand-splash.test.tsx
@@ -10,12 +10,12 @@ describe("<BrandSplash>", () => {
     expect(root).toHaveStyle({ backgroundColor: "#FF6F79" });
   });
 
-  it("paints the donut mark with the pinned near-black hex via inline style", () => {
-    // The mark color must be an inline style, not a Tailwind `fill-*` class, so
-    // it survives the first paint before the stylesheet loads (the cause of the
-    // mark rendering as default black on a real PWA launch).
+  it("paints the donut mark with the pinned off-white hex via inline style", () => {
+    // The mark color (from loading.svg) must be an inline style, not a Tailwind
+    // `fill-*` class, so it survives the first paint before the stylesheet loads
+    // (the cause of the mark rendering as default black on a real PWA launch).
     const { container } = render(<BrandSplash label="Loading" />);
-    expect(container.querySelector("svg")).toHaveStyle({ fill: "#1f1f1f" });
+    expect(container.querySelector("svg")).toHaveStyle({ fill: "#f1f1f1" });
   });
 
   it("exposes the accessible label as a status region", () => {

--- a/frontend/src/components/pwa/brand-splash.tsx
+++ b/frontend/src/components/pwa/brand-splash.tsx
@@ -6,14 +6,16 @@ import type { ReactNode } from "react";
 // not this exact hex, so the backdrop is pinned to the literal instead.
 const BRAND_CORAL = "#FF6F79";
 
-// The donut mark color. Like BRAND_CORAL it is pinned to a literal hex rather
-// than a design token, and it is applied as an inline style (not a Tailwind
-// `fill-*` utility) so it always paints with the first HTML chunk even before
-// the stylesheet loads — otherwise the SVG falls back to its default black fill.
-const MARK_COLOR = "#1f1f1f";
+// The donut mark color, taken from loading.svg (Streamline "Donut Large Fill").
+// Like BRAND_CORAL it is pinned to a literal hex rather than a design token, and
+// it is applied as an inline style (not a Tailwind `fill-*` utility) so it always
+// paints with the first HTML chunk even before the stylesheet loads — otherwise
+// the SVG falls back to its default black fill.
+const MARK_COLOR = "#f1f1f1";
 
-// Donut mark inlined as a path literal (Material "Donut Large") so the splash
-// needs no extra network request — it paints with the first HTML chunk.
+// Donut mark inlined as a path literal (from loading.svg, Streamline "Donut Large
+// Fill") so the splash needs no extra network request — it paints with the first
+// HTML chunk.
 const DONUT_PATH =
   "M11.2999 21.925c-2.63335 -0.2 -4.8375 -1.24585 -6.6125 -3.1375 -1.775 -1.8917 -2.6625 -4.1542 -2.6625 -6.7875 0 -2.63335 0.8875 -4.89585 2.6625 -6.7875 1.775 -1.89168 3.97915 -2.93751 6.6125 -3.13751v2.55c-1.91665 0.18333 -3.52085 0.97916 -4.8125 2.38751 -1.29165 1.4083 -1.929165 3.0708 -1.9125 4.9875 0.01667 1.91665 0.6625 3.57915 1.9375 4.9875 1.275 1.4083 2.87085 2.20415 4.7875 2.3875v2.55Zm1.5 0v-2.55c1.76665 -0.15 3.25835 -0.85 4.475 -2.1 1.21665 -1.25 1.93335 -2.75835 2.15 -4.525h2.55c-0.18335 2.4833 -1.1375 4.59165 -2.8625 6.325 -1.725 1.7333 -3.82915 2.6833 -6.3125 2.85Zm6.625 -10.675c-0.2 -1.7667 -0.9125 -3.275 -2.1375 -4.525 -1.225 -1.25 -2.72085 -1.958345 -4.4875 -2.12501v-2.55c2.46665 0.18333 4.56665 1.141665 6.3 2.875 1.73335 1.73331 2.69165 3.84166 2.875 6.32501h-2.55Z";
 


### PR DESCRIPTION
## Summary

Follow-up to #362. The PWA loading/error splash mark was pinned to `#1f1f1f`, which is **near-black** — so on a real PWA launch the mark still looked black (coral background + black mark). The intended color is the off-white `#f1f1f1` from `loading.svg` (the same Streamline "Donut Large Fill" icon already inlined as `DONUT_PATH`); `#1f1f1f` was a transposed-digit value.

This recolors the mark to `#f1f1f1`. The path is unchanged — it already matches `loading.svg` byte-for-byte — and the color stays an inline `style={{ fill }}` so it paints with the first HTML chunk before the stylesheet loads.

## Changes

- `frontend/src/components/pwa/brand-splash.tsx`: `MARK_COLOR` `#1f1f1f` to `#f1f1f1` (loading.svg's fill); update the comments to cite `loading.svg` as the source of both the path and the color.
- `frontend/src/components/pwa/brand-splash.test.tsx`: update the regression assertion to the off-white `#f1f1f1`.

## Test plan

- [x] `pnpm --filter frontend codegen` — green
- [x] `pnpm --filter frontend typecheck` — green
- [x] `pnpm --filter frontend lint` — clean (changed files)
- [x] `pnpm --filter frontend test brand-splash` — 6/6 green
- [x] `pnpm --filter frontend knip` — clean

No associated issue.
