### PR TITLE
feat(frontend): localize profile/onboarding/change-email UI strings (en/ja)

### DIFF
--- a/frontend/e2e/display-name-onboarding.spec.ts
+++ b/frontend/e2e/display-name-onboarding.spec.ts
@@ -34,12 +34,15 @@ test.describe
       await page.goto("/");
       await page.waitForURL("**/onboarding", { timeout: 10_000 });
 
-      // 2. Onboarding form is visible.
-      await expect(page.getByLabel("Display name")).toBeVisible();
+      // 2. Onboarding form is visible. The suite runs in the ja-JP locale, so
+      // target the display-name input and submit button by locale-independent
+      // attributes (input id / data-testid) rather than translated copy.
+      const displayNameInput = page.locator("#displayName");
+      await expect(displayNameInput).toBeVisible();
 
       // 3. Fill in the display name and submit.
-      await page.getByLabel("Display name").fill("E2E Onboarder");
-      await page.getByRole("button", { name: "Continue" }).click();
+      await displayNameInput.fill("E2E Onboarder");
+      await page.getByTestId("onboarding-submit").click();
 
       // 4. On success, the form's onCompleted callback pushes /cardgroups/new?welcome=1.
       await page.waitForURL("**/cardgroups/new?welcome=1", { timeout: 15_000 });

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -65,5 +65,37 @@
     "googleButton": "Continue with Google",
     "terms": "By signing in, you agree to our <terms>Terms of Service</terms> and <privacy>Privacy Policy</privacy>.",
     "tagline": "Remember more, study less."
+  },
+  "Profile": {
+    "title": "Profile",
+    "readOnlySummary": "Read-only summary",
+    "displayName": "Display name",
+    "email": "Email",
+    "bio": "Bio",
+    "notSet": "Not set",
+    "noEmail": "No email on this account",
+    "editProfile": "Edit profile",
+    "changeEmail": "Change email",
+    "clearBio": "Clear bio",
+    "sessionExpired": "Your session expired. Please sign in again.",
+    "couldntLoad": "Couldn't load your profile",
+    "loadError": "Something went wrong while loading your profile. Please try again in a moment.",
+    "currentEmail": "Current email",
+    "newEmail": "New email",
+    "sendConfirmationLink": "Send confirmation link",
+    "sending": "Sending...",
+    "confirmationSent": "Confirmation link sent to <strong>{email}</strong>. Open the link in your email to finish the change.",
+    "backToProfile": "Back to profile",
+    "emailRateLimited": "Too many requests. Please wait a moment and try again.",
+    "emailAlreadyInUse": "That email address is already in use.",
+    "emailCouldNotSend": "Could not send confirmation link. Please try again.",
+    "emailNetworkError": "Network error. Please check your connection and try again."
+  },
+  "Onboarding": {
+    "welcome": "Welcome to Flamingo Armond",
+    "displayName": "Display name",
+    "displayNameHint": "1–50 characters; visible to other users.",
+    "continue": "Continue",
+    "sessionExpired": "Your session expired. Please sign in again."
   }
 }

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -65,5 +65,37 @@
     "googleButton": "Google で続行",
     "terms": "ログインすることで、<terms>利用規約</terms>および<privacy>プライバシーポリシー</privacy>に同意したものとみなされます。",
     "tagline": "少ない学習で、より多く記憶。"
+  },
+  "Profile": {
+    "title": "プロフィール",
+    "readOnlySummary": "読み取り専用の概要",
+    "displayName": "表示名",
+    "email": "メールアドレス",
+    "bio": "自己紹介",
+    "notSet": "未設定",
+    "noEmail": "このアカウントにはメールアドレスがありません",
+    "editProfile": "プロフィールを編集",
+    "changeEmail": "メールアドレスを変更",
+    "clearBio": "自己紹介をクリア",
+    "sessionExpired": "セッションの有効期限が切れました。もう一度ログインしてください。",
+    "couldntLoad": "プロフィールを読み込めませんでした",
+    "loadError": "プロフィールの読み込み中に問題が発生しました。しばらくしてからもう一度お試しください。",
+    "currentEmail": "現在のメールアドレス",
+    "newEmail": "新しいメールアドレス",
+    "sendConfirmationLink": "確認リンクを送信",
+    "sending": "送信中...",
+    "confirmationSent": "<strong>{email}</strong> に確認リンクを送信しました。メール内のリンクを開いて変更を完了してください。",
+    "backToProfile": "プロフィールに戻る",
+    "emailRateLimited": "リクエストが多すぎます。少し待ってからもう一度お試しください。",
+    "emailAlreadyInUse": "そのメールアドレスは既に使用されています。",
+    "emailCouldNotSend": "確認リンクを送信できませんでした。もう一度お試しください。",
+    "emailNetworkError": "ネットワークエラーです。接続を確認してもう一度お試しください。"
+  },
+  "Onboarding": {
+    "welcome": "Flamingo Armond へようこそ",
+    "displayName": "表示名",
+    "displayNameHint": "1〜50文字。他のユーザーに表示されます。",
+    "continue": "続ける",
+    "sessionExpired": "セッションの有効期限が切れました。もう一度ログインしてください。"
   }
 }

--- a/frontend/src/app/onboarding/onboarding-form.test.tsx
+++ b/frontend/src/app/onboarding/onboarding-form.test.tsx
@@ -1,9 +1,10 @@
 // @vitest-environment jsdom
 import { MockedProvider } from "@apollo/client/testing/react";
-import { render, screen, waitFor } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import { UpdateProfileDocument } from "@/generated/graphql";
+import { renderWithIntl } from "@/test/render-with-intl";
 import { OnboardingForm } from "./onboarding-form";
 
 // Stub next/navigation so OnboardingForm can render outside Next.js.
@@ -54,7 +55,7 @@ describe("<OnboardingForm>", () => {
   it("empty submit is blocked — validation error displayed", async () => {
     const user = userEvent.setup();
 
-    render(
+    renderWithIntl(
       <MockedProvider mocks={[]}>
         <OnboardingForm />
       </MockedProvider>,
@@ -76,7 +77,7 @@ describe("<OnboardingForm>", () => {
 
     const mocks = [makeUpdateProfileMock({ input: { displayName: "Alice" } }, mutationCalled)];
 
-    render(
+    renderWithIntl(
       <MockedProvider mocks={mocks}>
         <OnboardingForm />
       </MockedProvider>,
@@ -97,7 +98,7 @@ describe("<OnboardingForm>", () => {
 
     const mocks = [makeUpdateProfileMock({ input: { displayName: "Alice" } })];
 
-    render(
+    renderWithIntl(
       <MockedProvider mocks={mocks}>
         <OnboardingForm />
       </MockedProvider>,
@@ -134,7 +135,7 @@ describe("<OnboardingForm>", () => {
       },
     ];
 
-    render(
+    renderWithIntl(
       <MockedProvider mocks={mocks}>
         <OnboardingForm />
       </MockedProvider>,
@@ -168,7 +169,7 @@ describe("<OnboardingForm>", () => {
       },
     ];
 
-    render(
+    renderWithIntl(
       <MockedProvider mocks={mocks}>
         <OnboardingForm />
       </MockedProvider>,
@@ -201,7 +202,7 @@ describe("<OnboardingForm>", () => {
       },
     ];
 
-    render(
+    renderWithIntl(
       <MockedProvider mocks={mocks}>
         <OnboardingForm />
       </MockedProvider>,

--- a/frontend/src/app/onboarding/onboarding-form.tsx
+++ b/frontend/src/app/onboarding/onboarding-form.tsx
@@ -3,6 +3,7 @@
 import { useMutation } from "@apollo/client/react";
 import { useForm } from "@tanstack/react-form";
 import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -35,6 +36,8 @@ const UpdateProfileMutation = graphql(`
 
 export function OnboardingForm() {
   const router = useRouter();
+  const t = useTranslations("Onboarding");
+  const tCommon = useTranslations("Common");
 
   // Typed InputValidationError variant — field-level validation failure
   // surfaced by the server via the outcome union. Cleared on each new submission.
@@ -67,10 +70,10 @@ export function OnboardingForm() {
       }).catch((err) => {
         const codes = liftGraphQLCodes(err);
         if (codes.includes("UNAUTHENTICATED")) {
-          setBannerMessage("Your session expired. Please sign in again.");
+          setBannerMessage(t("sessionExpired"));
           return null;
         }
-        const banner = getBackendErrorBanner(err) ?? "Something went wrong. Please try again.";
+        const banner = getBackendErrorBanner(err) ?? tCommon("somethingWentWrong");
         setBannerMessage(banner);
         console.error("[OnboardingForm] mutation rejection", err);
         throw err; // keep formState.isSubmitSuccessful correct
@@ -96,7 +99,7 @@ export function OnboardingForm() {
       console.warn("[OnboardingForm] unexpected updateProfile payload", {
         typename: unknownPayload?.__typename ?? null,
       });
-      setBannerMessage("Something went wrong. Please try again.");
+      setBannerMessage(tCommon("somethingWentWrong"));
     },
   });
 
@@ -118,7 +121,7 @@ export function OnboardingForm() {
       }}
       className="space-y-4"
     >
-      <h1 className="mb-6 text-2xl font-semibold">Welcome to Flamingo Armond</h1>
+      <h1 className="mb-6 text-2xl font-semibold">{t("welcome")}</h1>
 
       {bannerMessage ? (
         <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive" role="alert">
@@ -132,7 +135,7 @@ export function OnboardingForm() {
       >
         {(field) => (
           <div className="space-y-2">
-            <Label htmlFor={field.name}>Display name</Label>
+            <Label htmlFor={field.name}>{t("displayName")}</Label>
             <Input
               id={field.name}
               name={field.name}
@@ -140,9 +143,7 @@ export function OnboardingForm() {
               onBlur={field.handleBlur}
               onChange={(e) => field.handleChange(e.target.value)}
             />
-            <p className="text-sm text-muted-foreground">
-              1–50 characters; visible to other users.
-            </p>
+            <p className="text-sm text-muted-foreground">{t("displayNameHint")}</p>
             <FieldError
               zodErrors={field.state.meta.errors}
               backendError={fieldErrors.displayName}
@@ -151,8 +152,8 @@ export function OnboardingForm() {
         )}
       </form.Field>
 
-      <Button type="submit" variant="brand" disabled={loading}>
-        {loading ? "Saving..." : "Continue"}
+      <Button type="submit" variant="brand" disabled={loading} data-testid="onboarding-submit">
+        {loading ? tCommon("saving") : t("continue")}
       </Button>
 
       {/* Hidden sentinel used by tests to observe formState.isSubmitSuccessful */}

--- a/frontend/src/app/profile/change-email/change-email-client.test.tsx
+++ b/frontend/src/app/profile/change-email/change-email-client.test.tsx
@@ -1,8 +1,9 @@
 // @vitest-environment jsdom
 
-import { render, screen, waitFor } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { renderWithIntl } from "@/test/render-with-intl";
 
 const mockUpdateUser = vi.fn();
 vi.mock("@/lib/supabase/client", () => ({
@@ -21,7 +22,7 @@ afterEach(() => {
 
 describe("<ChangeEmailClient>", () => {
   it("S1 renders the current email and a new email input", () => {
-    render(<ChangeEmailClient currentEmail="alice@example.com" />);
+    renderWithIntl(<ChangeEmailClient currentEmail="alice@example.com" />);
 
     expect(screen.getByText("alice@example.com")).toBeInTheDocument();
     expect(screen.getByLabelText(/new email/i)).toBeInTheDocument();
@@ -31,7 +32,7 @@ describe("<ChangeEmailClient>", () => {
     const user = userEvent.setup();
     mockUpdateUser.mockResolvedValue({ data: { user: {} }, error: null });
 
-    render(<ChangeEmailClient currentEmail="alice@example.com" />);
+    renderWithIntl(<ChangeEmailClient currentEmail="alice@example.com" />);
 
     const input = screen.getByLabelText(/new email/i);
     await user.type(input, "bob@example.com");
@@ -57,7 +58,7 @@ describe("<ChangeEmailClient>", () => {
       error: { name: "AuthApiError", message: "Email rate limit exceeded" },
     });
 
-    render(<ChangeEmailClient currentEmail="alice@example.com" />);
+    renderWithIntl(<ChangeEmailClient currentEmail="alice@example.com" />);
 
     const input = screen.getByLabelText(/new email/i);
     await user.type(input, "bob@example.com");
@@ -83,7 +84,7 @@ describe("<ChangeEmailClient>", () => {
       error: { name: "AuthApiError", message: "User already registered" },
     });
 
-    render(<ChangeEmailClient currentEmail="alice@example.com" />);
+    renderWithIntl(<ChangeEmailClient currentEmail="alice@example.com" />);
 
     const input = screen.getByLabelText(/new email/i);
     await user.type(input, "bob@example.com");
@@ -106,7 +107,7 @@ describe("<ChangeEmailClient>", () => {
       error: { name: "AuthApiError", message: "some unmapped error xyz" },
     });
 
-    render(<ChangeEmailClient currentEmail="alice@example.com" />);
+    renderWithIntl(<ChangeEmailClient currentEmail="alice@example.com" />);
 
     const input = screen.getByLabelText(/new email/i);
     await user.type(input, "bob@example.com");
@@ -131,7 +132,7 @@ describe("<ChangeEmailClient>", () => {
     const transportError = Object.assign(new Error("network down"), { name: "FetchError" });
     mockUpdateUser.mockRejectedValue(transportError);
 
-    render(<ChangeEmailClient currentEmail="alice@example.com" />);
+    renderWithIntl(<ChangeEmailClient currentEmail="alice@example.com" />);
 
     const input = screen.getByLabelText(/new email/i);
     await user.type(input, "bob@example.com");
@@ -152,7 +153,7 @@ describe("<ChangeEmailClient>", () => {
     // Never-resolving promise keeps loading=true for the duration of the assertion.
     mockUpdateUser.mockReturnValue(new Promise<never>(() => {}));
 
-    render(<ChangeEmailClient currentEmail="alice@example.com" />);
+    renderWithIntl(<ChangeEmailClient currentEmail="alice@example.com" />);
 
     const input = screen.getByLabelText(/new email/i);
     await user.type(input, "bob@example.com");
@@ -167,7 +168,7 @@ describe("<ChangeEmailClient>", () => {
   });
 
   it("S4 Cancel button links to /profile", () => {
-    render(<ChangeEmailClient currentEmail="alice@example.com" />);
+    renderWithIntl(<ChangeEmailClient currentEmail="alice@example.com" />);
 
     const cancelLink = screen.getByRole("link", { name: /cancel/i });
     expect(cancelLink).toHaveAttribute("href", "/profile");

--- a/frontend/src/app/profile/change-email/change-email-client.tsx
+++ b/frontend/src/app/profile/change-email/change-email-client.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import { useTranslations } from "next-intl";
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -17,20 +18,25 @@ type Props = {
   currentEmail: string | null;
 };
 
-// Returns the mapped user-facing message, or null when the Supabase message is
-// unmapped — null lets the caller log the raw message and show generic copy.
-function classifyUpdateUserError(message: string): string | null {
+// Returns the translation key for the mapped user-facing message, or null when
+// the Supabase message is unmapped — null lets the caller log the raw message
+// and show generic copy.
+function classifyUpdateUserError(
+  message: string,
+): "emailRateLimited" | "emailAlreadyInUse" | null {
   const lower = message.toLowerCase();
   if (lower.includes("rate limit")) {
-    return "Too many requests. Please wait a moment and try again.";
+    return "emailRateLimited";
   }
   if (lower.includes("already registered")) {
-    return "That email address is already in use.";
+    return "emailAlreadyInUse";
   }
   return null;
 }
 
 export function ChangeEmailClient({ currentEmail }: Props) {
+  const t = useTranslations("Profile");
+  const tCommon = useTranslations("Common");
   const [newEmail, setNewEmail] = useState("");
   const [loading, setLoading] = useState(false);
   const [success, setSuccess] = useState(false);
@@ -45,11 +51,11 @@ export function ChangeEmailClient({ currentEmail }: Props) {
       const supabase = createSupabaseBrowserClient();
       const { error: updateErr } = await supabase.auth.updateUser({ email: newEmail });
       if (updateErr) {
-        const classified = classifyUpdateUserError(updateErr.message);
-        if (classified !== null) {
+        const classifiedKey = classifyUpdateUserError(updateErr.message);
+        if (classifiedKey !== null) {
           // Classified: operators know what happened from the user copy + error.name; no raw needed.
           console.warn("[change-email] updateUser failed:", updateErr.name);
-          setError(classified);
+          setError(t(classifiedKey));
         } else {
           // Unmapped: log the raw Supabase message so operators can extend classifyUpdateUserError.
           // Supabase API error messages are server-generated and do not echo user-typed input,
@@ -59,7 +65,7 @@ export function ChangeEmailClient({ currentEmail }: Props) {
             updateErr.name,
             updateErr.message,
           );
-          setError("Could not send confirmation link. Please try again.");
+          setError(t("emailCouldNotSend"));
         }
         return;
       }
@@ -68,7 +74,7 @@ export function ChangeEmailClient({ currentEmail }: Props) {
       // Transport-level failure (network, timeout). The API-shaped failure goes via updateErr above.
       // Do NOT log err.message — Supabase exception messages can include the email the user typed.
       console.warn("[change-email] updateUser threw:", err instanceof Error ? err.name : "unknown");
-      setError("Network error. Please check your connection and try again.");
+      setError(t("emailNetworkError"));
     } finally {
       setLoading(false);
     }
@@ -78,11 +84,13 @@ export function ChangeEmailClient({ currentEmail }: Props) {
     return (
       <div className="space-y-4">
         <p>
-          Confirmation link sent to <strong>{newEmail}</strong>. Open the link in your email to
-          finish the change.
+          {t.rich("confirmationSent", {
+            email: newEmail,
+            strong: (chunks) => <strong>{chunks}</strong>,
+          })}
         </p>
         <Button asChild>
-          <Link href="/profile">Back to profile</Link>
+          <Link href="/profile">{t("backToProfile")}</Link>
         </Button>
       </div>
     );
@@ -97,16 +105,16 @@ export function ChangeEmailClient({ currentEmail }: Props) {
       ) : null}
 
       <div className="space-y-2">
-        <Label>Current email</Label>
+        <Label>{t("currentEmail")}</Label>
         {currentEmail !== null ? (
           <p>{currentEmail}</p>
         ) : (
-          <p className="italic">No email on this account</p>
+          <p className="italic">{t("noEmail")}</p>
         )}
       </div>
 
       <div className="space-y-2">
-        <Label htmlFor="new-email">New email</Label>
+        <Label htmlFor="new-email">{t("newEmail")}</Label>
         <Input
           id="new-email"
           name="new-email"
@@ -119,10 +127,10 @@ export function ChangeEmailClient({ currentEmail }: Props) {
 
       <div className="flex gap-2">
         <Button type="submit" disabled={loading}>
-          {loading ? "Sending..." : "Send confirmation link"}
+          {loading ? t("sending") : t("sendConfirmationLink")}
         </Button>
         <Button asChild variant="outline">
-          <Link href="/profile">Cancel</Link>
+          <Link href="/profile">{tCommon("cancel")}</Link>
         </Button>
       </div>
     </form>

--- a/frontend/src/app/profile/change-email/change-email-client.tsx
+++ b/frontend/src/app/profile/change-email/change-email-client.tsx
@@ -21,9 +21,7 @@ type Props = {
 // Returns the translation key for the mapped user-facing message, or null when
 // the Supabase message is unmapped — null lets the caller log the raw message
 // and show generic copy.
-function classifyUpdateUserError(
-  message: string,
-): "emailRateLimited" | "emailAlreadyInUse" | null {
+function classifyUpdateUserError(message: string): "emailRateLimited" | "emailAlreadyInUse" | null {
   const lower = message.toLowerCase();
   if (lower.includes("rate limit")) {
     return "emailRateLimited";
@@ -106,11 +104,7 @@ export function ChangeEmailClient({ currentEmail }: Props) {
 
       <div className="space-y-2">
         <Label>{t("currentEmail")}</Label>
-        {currentEmail !== null ? (
-          <p>{currentEmail}</p>
-        ) : (
-          <p className="italic">{t("noEmail")}</p>
-        )}
+        {currentEmail !== null ? <p>{currentEmail}</p> : <p className="italic">{t("noEmail")}</p>}
       </div>
 
       <div className="space-y-2">

--- a/frontend/src/app/profile/change-email/page.test.tsx
+++ b/frontend/src/app/profile/change-email/page.test.tsx
@@ -27,7 +27,18 @@ vi.mock("./change-email-client", () => ({
   ),
 }));
 
+// next-intl/server — the page resolves the Profile namespace via getTranslations.
+// Back the mock with createTranslator + the real en catalog so t() produces the
+// original English heading copy, keeping any string assertions valid.
+vi.mock("next-intl/server", () => ({
+  getTranslations: vi.fn(async (namespace: "Profile") =>
+    createTranslator({ locale: "en", messages: enMessages, namespace }),
+  ),
+}));
+
 import { headers } from "next/headers";
+import { createTranslator } from "next-intl";
+import enMessages from "../../../../messages/en.json";
 import ChangeEmailPage from "./page";
 
 describe("ChangeEmailPage — auth gate", () => {

--- a/frontend/src/app/profile/change-email/page.tsx
+++ b/frontend/src/app/profile/change-email/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
+import { getTranslations } from "next-intl/server";
 import { readAuthContext } from "@/lib/supabase/auth-status";
 import { ChangeEmailClient } from "./change-email-client";
 
@@ -11,9 +12,11 @@ export default async function ChangeEmailPage() {
   const auth = readAuthContext(await headers());
   if (auth.status !== "authenticated") redirect("/login");
 
+  const t = await getTranslations("Profile");
+
   return (
     <main className="p-8">
-      <h1 className="mb-6 text-2xl font-semibold">Change email</h1>
+      <h1 className="mb-6 text-2xl font-semibold">{t("changeEmail")}</h1>
       <ChangeEmailClient currentEmail={auth.email} />
     </main>
   );

--- a/frontend/src/app/profile/error.test.tsx
+++ b/frontend/src/app/profile/error.test.tsx
@@ -1,7 +1,8 @@
 // @vitest-environment jsdom
-import { render, screen } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { renderWithIntl } from "@/test/render-with-intl";
 import ProfileError from "./error";
 
 describe("<ProfileError>", () => {
@@ -10,7 +11,7 @@ describe("<ProfileError>", () => {
   });
 
   it("renders heading and Retry button for any error", () => {
-    render(
+    renderWithIntl(
       <ProfileError
         error={Object.assign(new Error("Network error"), { digest: undefined })}
         reset={vi.fn()}
@@ -25,7 +26,7 @@ describe("<ProfileError>", () => {
     const user = userEvent.setup();
     const reset = vi.fn();
 
-    render(
+    renderWithIntl(
       <ProfileError
         error={Object.assign(new Error("Network error"), { digest: undefined })}
         reset={reset}
@@ -40,7 +41,7 @@ describe("<ProfileError>", () => {
   it("logs error with digest to console.error", () => {
     const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
-    render(
+    renderWithIntl(
       <ProfileError
         error={Object.assign(new Error("Something broke"), { digest: "abc123" })}
         reset={vi.fn()}

--- a/frontend/src/app/profile/error.tsx
+++ b/frontend/src/app/profile/error.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { useEffect } from "react";
 import { Button } from "@/components/ui/button";
 
@@ -9,6 +10,9 @@ type ErrorPageProps = {
 };
 
 export default function ProfileError({ error, reset }: ErrorPageProps) {
+  const t = useTranslations("Profile");
+  const tCommon = useTranslations("Common");
+
   useEffect(() => {
     // Initial-load UNAUTHENTICATED is intercepted in page.tsx and redirects
     // to /login before this boundary is reached. This boundary handles the
@@ -22,12 +26,10 @@ export default function ProfileError({ error, reset }: ErrorPageProps) {
 
   return (
     <main className="p-8">
-      <h1 className="mb-3 text-2xl font-semibold">Couldn&apos;t load your profile</h1>
-      <p className="mb-6 text-sm text-muted-foreground">
-        Something went wrong while loading your profile. Please try again in a moment.
-      </p>
+      <h1 className="mb-3 text-2xl font-semibold">{t("couldntLoad")}</h1>
+      <p className="mb-6 text-sm text-muted-foreground">{t("loadError")}</p>
       <Button onClick={reset} variant="outline">
-        Retry
+        {tCommon("retry")}
       </Button>
     </main>
   );

--- a/frontend/src/app/profile/profile-form.test.tsx
+++ b/frontend/src/app/profile/profile-form.test.tsx
@@ -1,11 +1,12 @@
 // @vitest-environment jsdom
 import { MockedProvider } from "@apollo/client/testing/react";
-import { render, screen, waitFor } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { GraphQLError } from "graphql";
 import { describe, expect, it, vi } from "vitest";
 import { FormSheet, useFormSheetClose } from "@/components/ui/form-sheet";
 import { UpdateProfileDocument } from "@/generated/graphql";
+import { renderWithIntl } from "@/test/render-with-intl";
 import { ProfileForm } from "./profile-form";
 
 // Stub next/navigation so ProfileForm can render outside Next.js.
@@ -61,7 +62,7 @@ function makeMutationMock(
 
 describe("<ProfileForm>", () => {
   it("renders defaults", () => {
-    render(
+    renderWithIntl(
       <MockedProvider mocks={[]}>
         <ProfileForm email="alice@example.com" initial={{ displayName: "Alice", bio: "hi" }} />
       </MockedProvider>,
@@ -72,7 +73,7 @@ describe("<ProfileForm>", () => {
   });
 
   it("renders email as read-only text and a Change email link", () => {
-    render(
+    renderWithIntl(
       <MockedProvider mocks={[]}>
         <ProfileForm email="alice@example.com" initial={{ displayName: "Alice", bio: "hi" }} />
       </MockedProvider>,
@@ -87,7 +88,7 @@ describe("<ProfileForm>", () => {
     const user = userEvent.setup();
     const onOpenChange = vi.fn();
 
-    render(
+    renderWithIntl(
       <MockedProvider mocks={[]}>
         <FormSheet open onOpenChange={onOpenChange} title="Edit profile" size="md">
           <ProfileFormSheetHarness
@@ -104,7 +105,7 @@ describe("<ProfileForm>", () => {
   });
 
   it("renders fallback text when email is null", () => {
-    render(
+    renderWithIntl(
       <MockedProvider mocks={[]}>
         <ProfileForm email={null} initial={{ displayName: "Alice", bio: "hi" }} />
       </MockedProvider>,
@@ -116,7 +117,7 @@ describe("<ProfileForm>", () => {
   it("displayName empty triggers Zod error before submit", async () => {
     const user = userEvent.setup();
 
-    render(
+    renderWithIntl(
       <MockedProvider mocks={[]}>
         <ProfileForm email="alice@example.com" initial={{ displayName: "Alice", bio: "" }} />
       </MockedProvider>,
@@ -134,7 +135,7 @@ describe("<ProfileForm>", () => {
   it("displayName 51 graphemes triggers Zod error", async () => {
     const user = userEvent.setup();
 
-    render(
+    renderWithIntl(
       <MockedProvider mocks={[]}>
         <ProfileForm email="alice@example.com" initial={{ displayName: "", bio: "" }} />
       </MockedProvider>,
@@ -156,7 +157,7 @@ describe("<ProfileForm>", () => {
   it("bio over 500 triggers Zod error", async () => {
     const user = userEvent.setup();
 
-    render(
+    renderWithIntl(
       <MockedProvider mocks={[]}>
         <ProfileForm email="alice@example.com" initial={{ displayName: "Alice", bio: "" }} />
       </MockedProvider>,
@@ -180,7 +181,7 @@ describe("<ProfileForm>", () => {
     // bio="" in mutation variables means explicit clear
     const mocks = [makeMutationMock({ input: { displayName: "Alice", bio: "" } }, mutationCalled)];
 
-    render(
+    renderWithIntl(
       <MockedProvider mocks={mocks}>
         <ProfileForm email="alice@example.com" initial={{ displayName: "Alice", bio: "hi" }} />
       </MockedProvider>,
@@ -208,7 +209,7 @@ describe("<ProfileForm>", () => {
       makeMutationMock({ input: { displayName: "Alice", bio: "hello" } }, mutationCalled),
     ];
 
-    render(
+    renderWithIntl(
       <MockedProvider mocks={mocks}>
         <ProfileForm email="alice@example.com" initial={{ displayName: "Alice", bio: "hello" }} />
       </MockedProvider>,
@@ -242,7 +243,7 @@ describe("<ProfileForm>", () => {
       },
     ];
 
-    render(
+    renderWithIntl(
       <MockedProvider mocks={mocks}>
         <ProfileForm email="alice@example.com" initial={{ displayName: "Alice", bio: "hi" }} />
       </MockedProvider>,
@@ -277,7 +278,7 @@ describe("<ProfileForm>", () => {
       },
     ];
 
-    render(
+    renderWithIntl(
       <MockedProvider mocks={mocks}>
         <ProfileForm email="alice@example.com" initial={{ displayName: "Alice", bio: "hi" }} />
       </MockedProvider>,
@@ -311,7 +312,7 @@ describe("<ProfileForm>", () => {
       },
     ];
 
-    render(
+    renderWithIntl(
       <MockedProvider mocks={mocks}>
         <ProfileForm email="alice@example.com" initial={{ displayName: "Alice", bio: "hi" }} />
       </MockedProvider>,
@@ -337,7 +338,7 @@ describe("<ProfileForm>", () => {
       },
     ];
 
-    render(
+    renderWithIntl(
       <MockedProvider mocks={mocks}>
         <ProfileForm email="alice@example.com" initial={{ displayName: "Alice", bio: "hi" }} />
       </MockedProvider>,
@@ -366,7 +367,7 @@ describe("<ProfileForm>", () => {
       },
     ];
 
-    render(
+    renderWithIntl(
       <MockedProvider mocks={mocks}>
         <ProfileForm email="alice@example.com" initial={{ displayName: "Alice", bio: "hi" }} />
       </MockedProvider>,
@@ -414,7 +415,7 @@ describe("<ProfileForm>", () => {
       },
     ];
 
-    render(
+    renderWithIntl(
       <MockedProvider mocks={mocks}>
         <ProfileForm
           email="alice@example.com"

--- a/frontend/src/app/profile/profile-form.tsx
+++ b/frontend/src/app/profile/profile-form.tsx
@@ -3,6 +3,7 @@
 import { useMutation } from "@apollo/client/react";
 import { useForm } from "@tanstack/react-form";
 import Link from "next/link";
+import { useTranslations } from "next-intl";
 import { useCallback, useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -70,6 +71,9 @@ export function ProfileForm({
   onSaved,
   onSubmittingChange,
 }: Props) {
+  const t = useTranslations("Profile");
+  const tCommon = useTranslations("Common");
+
   // Typed InputValidationError variant — field-level validation failure
   // surfaced by the server via the outcome union. Cleared on each new submission.
   const [validationError, setValidationError] = useState<{
@@ -118,10 +122,10 @@ export function ProfileForm({
       }).catch((err) => {
         const codes = liftGraphQLCodes(err);
         if (codes.includes("UNAUTHENTICATED")) {
-          setBannerMessage("Your session expired. Please sign in again.");
+          setBannerMessage(t("sessionExpired"));
           return null;
         }
-        const banner = getBackendErrorBanner(err) ?? "Something went wrong. Please try again.";
+        const banner = getBackendErrorBanner(err) ?? tCommon("somethingWentWrong");
         setBannerMessage(banner);
         console.error("[ProfileForm] mutation rejection", err);
         throw err; // keep formState.isSubmitSuccessful correct
@@ -147,7 +151,7 @@ export function ProfileForm({
       console.warn("[ProfileForm] unexpected updateProfile payload", {
         typename: unknownPayload?.__typename ?? null,
       });
-      setBannerMessage("Something went wrong. Please try again.");
+      setBannerMessage(tCommon("somethingWentWrong"));
     },
   });
 
@@ -176,8 +180,8 @@ export function ProfileForm({
       ) : null}
 
       <div className="mb-4 space-y-2">
-        <Label>Email</Label>
-        {email !== null ? <p>{email}</p> : <p className="italic">No email on this account</p>}
+        <Label>{t("email")}</Label>
+        {email !== null ? <p>{email}</p> : <p className="italic">{t("noEmail")}</p>}
         <Link
           href="/profile/change-email"
           className="text-sm underline"
@@ -187,7 +191,7 @@ export function ProfileForm({
             onChangeEmail();
           }}
         >
-          Change email
+          {t("changeEmail")}
         </Link>
       </div>
 
@@ -197,7 +201,7 @@ export function ProfileForm({
       >
         {(field) => (
           <div className="space-y-2">
-            <Label htmlFor={field.name}>Display name</Label>
+            <Label htmlFor={field.name}>{t("displayName")}</Label>
             <Input
               id={field.name}
               name={field.name}
@@ -216,7 +220,7 @@ export function ProfileForm({
       <form.Field name="bio" validators={{ onChange: bioSchema, onBlur: bioSchema }}>
         {(field) => (
           <div className="space-y-2">
-            <Label htmlFor={field.name}>Bio</Label>
+            <Label htmlFor={field.name}>{t("bio")}</Label>
             <Textarea
               id={field.name}
               name={field.name}
@@ -231,7 +235,7 @@ export function ProfileForm({
                 size="sm"
                 onClick={() => field.handleChange("")}
               >
-                Clear bio
+                {t("clearBio")}
               </Button>
             ) : null}
             <FieldError zodErrors={field.state.meta.errors} backendError={fieldErrors.bio} />
@@ -241,11 +245,11 @@ export function ProfileForm({
 
       <div className="flex items-center gap-2">
         <Button type="submit" variant="brand" disabled={loading}>
-          {loading ? "Saving..." : "Save"}
+          {loading ? tCommon("saving") : tCommon("save")}
         </Button>
         {onCancel ? (
           <Button type="button" variant="outline" onClick={onCancel}>
-            Cancel
+            {tCommon("cancel")}
           </Button>
         ) : null}
       </div>

--- a/frontend/src/app/profile/profile-page-client.tsx
+++ b/frontend/src/app/profile/profile-page-client.tsx
@@ -54,6 +54,7 @@ function ProfileSheetBody({
 const PROFILE_SHEET_SENTINEL_ID = "self";
 
 export function ProfilePageClient({ email, initial }: Props) {
+  const t = useTranslations("Profile");
   const tSettings = useTranslations("Settings");
   const router = useRouter();
   const sheet = useSheetSearchParam();
@@ -102,23 +103,23 @@ export function ProfilePageClient({ email, initial }: Props) {
         <section className="flex flex-wrap items-start gap-4 border-b pb-6">
           <div className="min-w-0 flex-1 space-y-3">
             <div>
-              <h1 className="text-2xl font-semibold">Profile</h1>
-              <p className="text-sm text-muted-foreground">Read-only summary</p>
+              <h1 className="text-2xl font-semibold">{t("title")}</h1>
+              <p className="text-sm text-muted-foreground">{t("readOnlySummary")}</p>
             </div>
             <dl className="grid gap-4 sm:grid-cols-3">
               <div className="space-y-1">
-                <dt className="text-sm font-medium text-muted-foreground">Display name</dt>
-                <dd className="break-words text-sm">{initial.displayName || "Not set"}</dd>
+                <dt className="text-sm font-medium text-muted-foreground">{t("displayName")}</dt>
+                <dd className="break-words text-sm">{initial.displayName || t("notSet")}</dd>
               </div>
               <div className="space-y-1">
-                <dt className="text-sm font-medium text-muted-foreground">Email</dt>
+                <dt className="text-sm font-medium text-muted-foreground">{t("email")}</dt>
                 <dd className="break-words text-sm">
-                  {email ?? <span className="italic">No email on this account</span>}
+                  {email ?? <span className="italic">{t("noEmail")}</span>}
                 </dd>
               </div>
               <div className="space-y-1">
-                <dt className="text-sm font-medium text-muted-foreground">Bio</dt>
-                <dd className="break-words text-sm">{initial.bio || "Not set"}</dd>
+                <dt className="text-sm font-medium text-muted-foreground">{t("bio")}</dt>
+                <dd className="break-words text-sm">{initial.bio || t("notSet")}</dd>
               </div>
             </dl>
           </div>
@@ -128,7 +129,7 @@ export function ProfilePageClient({ email, initial }: Props) {
             onClick={() => sheet.open({ mode: "edit", id: PROFILE_SHEET_SENTINEL_ID })}
           >
             <Pencil className="h-4 w-4" />
-            Edit profile
+            {t("editProfile")}
           </Button>
         </section>
 
@@ -144,7 +145,7 @@ export function ProfilePageClient({ email, initial }: Props) {
       <FormSheet
         open={open}
         onOpenChange={handleSheetOpenChange}
-        title="Edit profile"
+        title={t("editProfile")}
         dirty={dirty}
         submitting={submitting}
         size="md"


### PR DESCRIPTION
## Summary

Localize the profile, onboarding, and change-email screens to the `Profile` / `Onboarding` message namespaces (reusing `Common` for Save/Cancel/Saving/somethingWentWrong). This is the settings home where the language switcher lives, built on the i18n foundation (#343) and sequenced after the language-switcher PR (#344) — the `<LanguageSwitcher />` section in `profile-page-client.tsx` is left intact.

## Approach

- Client components read `useTranslations("Profile")` / `useTranslations("Onboarding")`, plus `useTranslations("Common")` for the shared verbs. `renderWithIntl` (English catalog) keeps every existing string assertion valid.
- **`change-email-client.tsx`** — `classifyUpdateUserError` is refactored to return a translation **key** (`"emailRateLimited"` / `"emailAlreadyInUse"` / `null`) instead of English copy, so it stays a pure module-level function; the component maps the key through `t(...)`. The success line uses a next-intl **rich-text** message (`t.rich("confirmationSent", { email, strong })`) so `<strong>{email}</strong>` renders the same DOM as before. The raw Supabase `updateErr.message` and the `console.warn` calls stay English.
- **`change-email/page.tsx`** — the `<h1>Change email</h1>` heading lives in the server component, so it is localized via `getTranslations("Profile")` (the same server pattern as `login/page.tsx` in #347). Without this, the page title would be the only English text left on an otherwise-Japanese change-email screen — a deliberate, consistent extension of the issue's stated goal ("localize the change-email screen").
- **`onboarding-form.tsx`** — "Welcome to Flamingo Armond" keeps the brand wordmark literal inside the translated phrase (en `"Welcome to Flamingo Armond"`, ja `"Flamingo Armond へようこそ"`).
- **e2e** — the suite runs in the `ja-JP` locale, so `display-name-onboarding.spec.ts` could no longer select the now-localized onboarding form by English copy. It switches to locale-independent selectors: the input by `#displayName` and the submit button by a new `data-testid="onboarding-submit"`. (vitest renders the English catalog and would not have caught this; only ja-locale Playwright does.)
- Backend-originated banners (`getBackendErrorBanner(...)`, `payload.message`) stay English.

## Scope

- `messages/{en,ja}.json` — add the `Profile` (24 keys) and `Onboarding` (5 keys) namespaces; identical en/ja key sets; `Common.save/cancel/saving/somethingWentWrong` reused.
- `src/app/profile/profile-form.tsx`, `profile-page-client.tsx`, `error.tsx` — literals → `t(...)`.
- `src/app/profile/change-email/change-email-client.tsx` (+ `page.tsx` heading) — literals → `t(...)` / `t.rich(...)`; key-returning classifier.
- `src/app/onboarding/onboarding-form.tsx` — literals → `t(...)`; `data-testid` on submit.
- Tests wrapped in `renderWithIntl` (`profile-form`, `error`, `onboarding-form`, `change-email-client`); `change-email/page.test.tsx` mocks `next-intl/server` `getTranslations` with `createTranslator` + the real en catalog.
- `e2e/display-name-onboarding.spec.ts` — locale-independent selectors.

## Out of scope

- Backend validation/error message text stays English.
- The language switcher itself (#344).
- The browser-tab `metadata.title` (separate `generateMetadata` pattern, not established here).

## Test plan

- `pnpm --filter frontend typecheck` — green.
- `pnpm --filter frontend lint` — green (only the pre-existing `biome.json` schema-version info, unrelated to this change).
- targeted `vitest run` of the 8 affected test files — 59 passed; full suite 1135 passed.
- `pnpm --filter frontend knip` — clean.
- `pnpm --filter frontend build` — green.
- en/ja key sets identical (75 total); CJK grep over `frontend/src` — clean.

Closes #349
