### PR TITLE
feat(frontend): localize error/not-found/toast/PWA UI strings (en/ja)

### DIFF
--- a/frontend/__tests__/admin-roles-crud.test.tsx
+++ b/frontend/__tests__/admin-roles-crud.test.tsx
@@ -18,10 +18,12 @@ import { MockedProvider } from "@apollo/client/testing/react";
 import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { GraphQLError } from "graphql";
+import { NextIntlClientProvider } from "next-intl";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AdminRolesClient } from "@/app/admin/roles/admin-roles-client";
 import { AdminDeleteRoleDocument } from "@/generated/graphql";
 import { UndoDeleteProvider } from "@/lib/undo-delete";
+import enMessages from "../messages/en.json";
 
 // ---------------------------------------------------------------------------
 // Module mocks
@@ -79,9 +81,11 @@ afterEach(() => {
 function renderClient(initialRoles: RoleItem[], mocks: object[]) {
   return render(
     <MockedProvider mocks={mocks as never}>
-      <UndoDeleteProvider>
-        <AdminRolesClient initialRoles={initialRoles} />
-      </UndoDeleteProvider>
+      <NextIntlClientProvider locale="en" messages={enMessages} timeZone="UTC">
+        <UndoDeleteProvider>
+          <AdminRolesClient initialRoles={initialRoles} />
+        </UndoDeleteProvider>
+      </NextIntlClientProvider>
     </MockedProvider>,
   );
 }

--- a/frontend/__tests__/cardgroup-edit.test.tsx
+++ b/frontend/__tests__/cardgroup-edit.test.tsx
@@ -69,10 +69,12 @@ vi.mock("@/lib/apollo/server", () => ({
 
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
+import { NextIntlClientProvider } from "next-intl";
 import { cardsDefaultVars } from "@/app/cardgroups/[id]/cards/queries";
 import EditCardgroupPage from "@/app/cardgroups/[id]/edit/page";
 import { gqlFetch } from "@/lib/apollo/server";
 import { UndoDeleteProvider } from "@/lib/undo-delete";
+import enMessages from "../messages/en.json";
 
 class FakeIntersectionObserver {
   observe() {}
@@ -117,7 +119,9 @@ async function renderPage(
 
   render(
     <MockedProvider mocks={[]} cache={cache}>
-      <UndoDeleteProvider>{jsx as React.ReactElement}</UndoDeleteProvider>
+      <NextIntlClientProvider locale="en" messages={enMessages} timeZone="UTC">
+        <UndoDeleteProvider>{jsx as React.ReactElement}</UndoDeleteProvider>
+      </NextIntlClientProvider>
     </MockedProvider>,
   );
 }

--- a/frontend/__tests__/cards-bulk-delete.test.tsx
+++ b/frontend/__tests__/cards-bulk-delete.test.tsx
@@ -28,9 +28,11 @@ vi.mock("next/link", () => ({
   ),
 }));
 
+import { NextIntlClientProvider } from "next-intl";
 import { CardsClient } from "@/app/cardgroups/[id]/cards/cards-client";
 import { CardsByCardgroupConnectionDocument, DeleteCardsDocument } from "@/generated/graphql";
 import { UndoDeleteProvider } from "@/lib/undo-delete";
+import enMessages from "../messages/en.json";
 
 const CG_ID = "cg-bulk-1";
 const PAGE_SIZE = 20;
@@ -119,15 +121,17 @@ function renderCardsClient(cards: Card[], mocks: object[]) {
 
   render(
     <MockedProvider mocks={mocks as never} cache={cache}>
-      <UndoDeleteProvider>
-        <CardsClient
-          cardgroupId={CG_ID}
-          cardgroupName="Test Cardgroup"
-          initialEdges={connection.edges}
-          initialPageInfo={connection.pageInfo}
-          initialTotalCount={connection.totalCount}
-        />
-      </UndoDeleteProvider>
+      <NextIntlClientProvider locale="en" messages={enMessages} timeZone="UTC">
+        <UndoDeleteProvider>
+          <CardsClient
+            cardgroupId={CG_ID}
+            cardgroupName="Test Cardgroup"
+            initialEdges={connection.edges}
+            initialPageInfo={connection.pageInfo}
+            initialTotalCount={connection.totalCount}
+          />
+        </UndoDeleteProvider>
+      </NextIntlClientProvider>
     </MockedProvider>,
   );
 }
@@ -274,15 +278,17 @@ describe("CardsClient — bulk delete", () => {
 
     render(
       <MockedProvider mocks={mocks as never} cache={cache}>
-        <UndoDeleteProvider>
-          <CardsClient
-            cardgroupId={CG_ID}
-            cardgroupName="Test Cardgroup"
-            initialEdges={connection.edges}
-            initialPageInfo={connection.pageInfo}
-            initialTotalCount={connection.totalCount}
-          />
-        </UndoDeleteProvider>
+        <NextIntlClientProvider locale="en" messages={enMessages} timeZone="UTC">
+          <UndoDeleteProvider>
+            <CardsClient
+              cardgroupId={CG_ID}
+              cardgroupName="Test Cardgroup"
+              initialEdges={connection.edges}
+              initialPageInfo={connection.pageInfo}
+              initialTotalCount={connection.totalCount}
+            />
+          </UndoDeleteProvider>
+        </NextIntlClientProvider>
       </MockedProvider>,
     );
 
@@ -334,15 +340,17 @@ describe("CardsClient — bulk delete", () => {
     let caughtError: unknown = null;
     render(
       <MockedProvider mocks={mocks as never} cache={cache}>
-        <UndoDeleteProvider>
-          <CardsClient
-            cardgroupId={CG_ID}
-            cardgroupName="Test Cardgroup"
-            initialEdges={connection.edges}
-            initialPageInfo={connection.pageInfo}
-            initialTotalCount={connection.totalCount}
-          />
-        </UndoDeleteProvider>
+        <NextIntlClientProvider locale="en" messages={enMessages} timeZone="UTC">
+          <UndoDeleteProvider>
+            <CardsClient
+              cardgroupId={CG_ID}
+              cardgroupName="Test Cardgroup"
+              initialEdges={connection.edges}
+              initialPageInfo={connection.pageInfo}
+              initialTotalCount={connection.totalCount}
+            />
+          </UndoDeleteProvider>
+        </NextIntlClientProvider>
       </MockedProvider>,
     );
 

--- a/frontend/__tests__/cards-pagination.test.tsx
+++ b/frontend/__tests__/cards-pagination.test.tsx
@@ -28,9 +28,11 @@ vi.mock("next/link", () => ({
   ),
 }));
 
+import { NextIntlClientProvider } from "next-intl";
 import { CardsClient } from "@/app/cardgroups/[id]/cards/cards-client";
 import { CardsByCardgroupConnectionDocument } from "@/generated/graphql";
 import { UndoDeleteProvider } from "@/lib/undo-delete";
+import enMessages from "../messages/en.json";
 
 const CG_ID = "cg-1";
 const PAGE_SIZE = 20;
@@ -199,15 +201,17 @@ describe("CardsClient pagination via IntersectionObserver", () => {
 
     render(
       <MockedProvider mocks={mocks as never} cache={cache}>
-        <UndoDeleteProvider>
-          <CardsClient
-            cardgroupId={CG_ID}
-            cardgroupName="Test Cardgroup"
-            initialEdges={initialEdges}
-            initialPageInfo={initialPageInfo}
-            initialTotalCount={initialTotalCount}
-          />
-        </UndoDeleteProvider>
+        <NextIntlClientProvider locale="en" messages={enMessages} timeZone="UTC">
+          <UndoDeleteProvider>
+            <CardsClient
+              cardgroupId={CG_ID}
+              cardgroupName="Test Cardgroup"
+              initialEdges={initialEdges}
+              initialPageInfo={initialPageInfo}
+              initialTotalCount={initialTotalCount}
+            />
+          </UndoDeleteProvider>
+        </NextIntlClientProvider>
       </MockedProvider>,
     );
 
@@ -289,15 +293,17 @@ describe("CardsClient pagination via IntersectionObserver", () => {
 
     render(
       <MockedProvider mocks={mocks as never} cache={cache}>
-        <UndoDeleteProvider>
-          <CardsClient
-            cardgroupId={CG_ID}
-            cardgroupName="Test Cardgroup"
-            initialEdges={initialEdges}
-            initialPageInfo={initialPageInfo}
-            initialTotalCount={initialTotalCount}
-          />
-        </UndoDeleteProvider>
+        <NextIntlClientProvider locale="en" messages={enMessages} timeZone="UTC">
+          <UndoDeleteProvider>
+            <CardsClient
+              cardgroupId={CG_ID}
+              cardgroupName="Test Cardgroup"
+              initialEdges={initialEdges}
+              initialPageInfo={initialPageInfo}
+              initialTotalCount={initialTotalCount}
+            />
+          </UndoDeleteProvider>
+        </NextIntlClientProvider>
       </MockedProvider>,
     );
 
@@ -383,15 +389,17 @@ describe("CardsClient pagination via IntersectionObserver", () => {
 
     render(
       <MockedProvider mocks={mocks as never} cache={cache}>
-        <UndoDeleteProvider>
-          <CardsClient
-            cardgroupId={CG_ID}
-            cardgroupName="Test Cardgroup"
-            initialEdges={initialEdges}
-            initialPageInfo={initialPageInfo}
-            initialTotalCount={initialTotalCount}
-          />
-        </UndoDeleteProvider>
+        <NextIntlClientProvider locale="en" messages={enMessages} timeZone="UTC">
+          <UndoDeleteProvider>
+            <CardsClient
+              cardgroupId={CG_ID}
+              cardgroupName="Test Cardgroup"
+              initialEdges={initialEdges}
+              initialPageInfo={initialPageInfo}
+              initialTotalCount={initialTotalCount}
+            />
+          </UndoDeleteProvider>
+        </NextIntlClientProvider>
       </MockedProvider>,
     );
 
@@ -467,15 +475,17 @@ describe("CardsClient pagination via IntersectionObserver", () => {
 
     render(
       <MockedProvider mocks={mocks as never} cache={cache}>
-        <UndoDeleteProvider>
-          <CardsClient
-            cardgroupId={CG_ID}
-            cardgroupName="Test Cardgroup"
-            initialEdges={initialEdges}
-            initialPageInfo={initialPageInfo}
-            initialTotalCount={initialTotalCount}
-          />
-        </UndoDeleteProvider>
+        <NextIntlClientProvider locale="en" messages={enMessages} timeZone="UTC">
+          <UndoDeleteProvider>
+            <CardsClient
+              cardgroupId={CG_ID}
+              cardgroupName="Test Cardgroup"
+              initialEdges={initialEdges}
+              initialPageInfo={initialPageInfo}
+              initialTotalCount={initialTotalCount}
+            />
+          </UndoDeleteProvider>
+        </NextIntlClientProvider>
       </MockedProvider>,
     );
 
@@ -548,15 +558,17 @@ describe("CardsClient pagination via IntersectionObserver", () => {
 
     render(
       <MockedProvider mocks={mocks as never} cache={cache}>
-        <UndoDeleteProvider>
-          <CardsClient
-            cardgroupId={CG_ID}
-            cardgroupName="Test Cardgroup"
-            initialEdges={initialEdges}
-            initialPageInfo={initialPageInfo}
-            initialTotalCount={initialTotalCount}
-          />
-        </UndoDeleteProvider>
+        <NextIntlClientProvider locale="en" messages={enMessages} timeZone="UTC">
+          <UndoDeleteProvider>
+            <CardsClient
+              cardgroupId={CG_ID}
+              cardgroupName="Test Cardgroup"
+              initialEdges={initialEdges}
+              initialPageInfo={initialPageInfo}
+              initialTotalCount={initialTotalCount}
+            />
+          </UndoDeleteProvider>
+        </NextIntlClientProvider>
       </MockedProvider>,
     );
 

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -65,5 +65,11 @@
     "googleButton": "Continue with Google",
     "terms": "By signing in, you agree to our <terms>Terms of Service</terms> and <privacy>Privacy Policy</privacy>.",
     "tagline": "Remember more, study less."
+  },
+  "Pwa": {
+    "installHeading": "Install {brand}",
+    "installInstruction": "Tap the Share button, then “Add to Home Screen”.",
+    "hintLabel": "Install hint",
+    "dismissLabel": "Dismiss install hint"
   }
 }

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -65,5 +65,11 @@
     "googleButton": "Google で続行",
     "terms": "ログインすることで、<terms>利用規約</terms>および<privacy>プライバシーポリシー</privacy>に同意したものとみなされます。",
     "tagline": "少ない学習で、より多く記憶。"
+  },
+  "Pwa": {
+    "installHeading": "{brand}をインストール",
+    "installInstruction": "共有ボタンをタップして、「ホーム画面に追加」を選択してください。",
+    "hintLabel": "インストールのヒント",
+    "dismissLabel": "インストールのヒントを閉じる"
   }
 }

--- a/frontend/src/app/admin/roles/admin-roles-client.test.tsx
+++ b/frontend/src/app/admin/roles/admin-roles-client.test.tsx
@@ -5,8 +5,8 @@ import { MockedProvider } from "@apollo/client/testing/react";
 import { act, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { GraphQLError } from "graphql";
+import { NextIntlClientProvider } from "next-intl";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-
 import {
   AdminCreateRoleDocument,
   AdminDeleteRoleDocument,
@@ -14,6 +14,7 @@ import {
   AdminUpdateRoleDocument,
 } from "@/generated/graphql";
 import { UndoDeleteProvider } from "@/lib/undo-delete";
+import enMessages from "../../../../messages/en.json";
 import { AdminRolesClient, type RoleItem } from "./admin-roles-client";
 
 // ---------------------------------------------------------------------------
@@ -80,9 +81,11 @@ const ADMIN_ROLE: RoleItem = { id: "r-admin", name: "admin" };
 function renderRoles(roles: RoleItem[], mocks: unknown[] = []) {
   render(
     <MockedProvider mocks={mocks as never}>
-      <UndoDeleteProvider>
-        <AdminRolesClient initialRoles={roles} />
-      </UndoDeleteProvider>
+      <NextIntlClientProvider locale="en" messages={enMessages} timeZone="UTC">
+        <UndoDeleteProvider>
+          <AdminRolesClient initialRoles={roles} />
+        </UndoDeleteProvider>
+      </NextIntlClientProvider>
     </MockedProvider>,
   );
 }
@@ -117,9 +120,11 @@ describe("AdminRolesClient", () => {
   it("wires the ListingPageShell with title, description, and New role CTA", () => {
     render(
       <MockedProvider mocks={[]}>
-        <UndoDeleteProvider>
-          <AdminRolesClient initialRoles={[]} />
-        </UndoDeleteProvider>
+        <NextIntlClientProvider locale="en" messages={enMessages} timeZone="UTC">
+          <UndoDeleteProvider>
+            <AdminRolesClient initialRoles={[]} />
+          </UndoDeleteProvider>
+        </NextIntlClientProvider>
       </MockedProvider>,
     );
 

--- a/frontend/src/app/cardgroups/[id]/cards/cards-client.test.tsx
+++ b/frontend/src/app/cardgroups/[id]/cards/cards-client.test.tsx
@@ -4,6 +4,7 @@ import { MockedProvider } from "@apollo/client/testing/react";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { GraphQLError } from "graphql";
+import { NextIntlClientProvider } from "next-intl";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   CardsByCardgroupConnectionDocument,
@@ -17,6 +18,7 @@ import {
   type ApolloMockLeakSpyResult,
   installApolloMockLeakSpy,
 } from "../../../../../__tests__/utils/mock-apollo-paginated";
+import enMessages from "../../../../../messages/en.json";
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -247,16 +249,18 @@ function renderClient(
 
   render(
     <MockedProvider mocks={mocks as never} cache={cache}>
-      <UndoDeleteProvider>
-        <CardsClient
-          cardgroupId={CG_ID}
-          cardgroupName="Test Cardgroup"
-          initialEdges={initialConn.edges}
-          initialPageInfo={initialConn.pageInfo}
-          initialTotalCount={initialConn.totalCount}
-          sectionHeader={options.sectionHeader}
-        />
-      </UndoDeleteProvider>
+      <NextIntlClientProvider locale="en" messages={enMessages} timeZone="UTC">
+        <UndoDeleteProvider>
+          <CardsClient
+            cardgroupId={CG_ID}
+            cardgroupName="Test Cardgroup"
+            initialEdges={initialConn.edges}
+            initialPageInfo={initialConn.pageInfo}
+            initialTotalCount={initialConn.totalCount}
+            sectionHeader={options.sectionHeader}
+          />
+        </UndoDeleteProvider>
+      </NextIntlClientProvider>
     </MockedProvider>,
   );
 }
@@ -822,9 +826,11 @@ describe("<CardsClient>", () => {
 
     const { rerender } = render(
       <MockedProvider mocks={[deleteMock] as never} cache={cache}>
-        <UndoDeleteProvider>
-          <Harness />
-        </UndoDeleteProvider>
+        <NextIntlClientProvider locale="en" messages={enMessages} timeZone="UTC">
+          <UndoDeleteProvider>
+            <Harness />
+          </UndoDeleteProvider>
+        </NextIntlClientProvider>
       </MockedProvider>,
     );
 
@@ -842,9 +848,11 @@ describe("<CardsClient>", () => {
     mockUsePathname.mockReturnValue("/cardgroups");
     rerender(
       <MockedProvider mocks={[deleteMock] as never} cache={cache}>
-        <UndoDeleteProvider>
-          <Harness />
-        </UndoDeleteProvider>
+        <NextIntlClientProvider locale="en" messages={enMessages} timeZone="UTC">
+          <UndoDeleteProvider>
+            <Harness />
+          </UndoDeleteProvider>
+        </NextIntlClientProvider>
       </MockedProvider>,
     );
 

--- a/frontend/src/app/global-error.tsx
+++ b/frontend/src/app/global-error.tsx
@@ -21,8 +21,21 @@ export default function GlobalError({ error, reset }: GlobalErrorProps) {
     });
   }, [error]);
 
+  // This component renders outside NextIntlClientProvider (it replaces the root
+  // layout on unrecoverable errors), so it cannot call useTranslations — the
+  // copy stays English. Only <html lang> reflects the persisted locale, read
+  // directly from the NEXT_LOCALE cookie client-side.
+  const lang =
+    typeof document !== "undefined" &&
+    document.cookie
+      .split("; ")
+      .find((c) => c.startsWith("NEXT_LOCALE="))
+      ?.split("=")[1] === "ja"
+      ? "ja"
+      : "en";
+
   return (
-    <html lang="en">
+    <html lang={lang}>
       <body>
         <main className="flex min-h-dvh w-full flex-col items-center justify-center gap-6 p-8 text-center">
           <div className="space-y-2">

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -167,10 +167,13 @@ export default async function RootLayout({ children }: { children: ReactNode }) 
               {children}
             </AuthShell>
           </Providers>
+          {/* AppleInstallHint calls useTranslations("Pwa"), so it MUST render
+              inside NextIntlClientProvider — outside it throws a no-intl-context
+              error during SSR on every request. */}
+          <AppleInstallHint />
         </NextIntlClientProvider>
         <SpeedInsights />
         <SwRegister />
-        <AppleInstallHint />
       </body>
     </html>
   );

--- a/frontend/src/app/not-found.test.tsx
+++ b/frontend/src/app/not-found.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
-import { render, screen } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { renderWithIntl } from "@/test/render-with-intl";
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: vi.fn() }),
@@ -15,7 +16,7 @@ afterEach(() => {
 
 describe("<NotFound>", () => {
   it("renders the 404 heading, message, and home link", () => {
-    render(<NotFound />);
+    renderWithIntl(<NotFound />);
 
     expect(screen.getByText("404")).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: /page not found/i })).toBeInTheDocument();

--- a/frontend/src/app/not-found.tsx
+++ b/frontend/src/app/not-found.tsx
@@ -1,17 +1,18 @@
 "use client";
 
 import Link from "next/link";
+import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
 
 export default function NotFound() {
+  const t = useTranslations("NotFound");
+
   return (
     <main className="flex min-h-[calc(100dvh-3rem)] w-full flex-col items-center justify-center gap-6 p-8 text-center">
       <div className="space-y-2">
         <p className="text-8xl font-bold tracking-tight text-brand-primary sm:text-9xl">404</p>
-        <h1 className="text-2xl font-semibold tracking-tight">Oops! Page Not Found!</h1>
-        <p className="mx-auto max-w-md text-sm text-muted-foreground">
-          It seems like the page you're looking for does not exist or might have been removed.
-        </p>
+        <h1 className="text-2xl font-semibold tracking-tight">{t("heading")}</h1>
+        <p className="mx-auto max-w-md text-sm text-muted-foreground">{t("message")}</p>
       </div>
 
       <Button asChild variant="brand">

--- a/frontend/src/components/pwa/apple-install-hint.test.tsx
+++ b/frontend/src/components/pwa/apple-install-hint.test.tsx
@@ -1,8 +1,9 @@
 // @vitest-environment jsdom
-import { render, screen } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { renderWithIntl } from "@/test/render-with-intl";
 import { AppleInstallHint } from "./apple-install-hint";
 
 const DISMISSED_KEY = "pwa-ios-install-hint-dismissed";
@@ -57,7 +58,7 @@ describe("<AppleInstallHint>", () => {
     });
 
     it("renders the install banner with 'Add to Home Screen' copy", async () => {
-      render(<AppleInstallHint />);
+      renderWithIntl(<AppleInstallHint />);
       // The banner is revealed by a useEffect; wait for the state update.
       const hint = await screen.findByLabelText("Install hint");
       expect(hint).toBeInTheDocument();
@@ -65,12 +66,12 @@ describe("<AppleInstallHint>", () => {
     });
 
     it("renders the 'Install flamingo' heading", async () => {
-      render(<AppleInstallHint />);
+      renderWithIntl(<AppleInstallHint />);
       await screen.findByText("Install flamingo");
     });
 
     it("renders a dismiss button", async () => {
-      render(<AppleInstallHint />);
+      renderWithIntl(<AppleInstallHint />);
       const btn = await screen.findByRole("button", {
         name: "Dismiss install hint",
       });
@@ -79,7 +80,7 @@ describe("<AppleInstallHint>", () => {
 
     it("hides the banner and sets localStorage when dismiss is clicked", async () => {
       const user = userEvent.setup();
-      render(<AppleInstallHint />);
+      renderWithIntl(<AppleInstallHint />);
 
       const btn = await screen.findByRole("button", {
         name: "Dismiss install hint",
@@ -104,7 +105,7 @@ describe("<AppleInstallHint>", () => {
     });
 
     it("does not render the install banner", async () => {
-      render(<AppleInstallHint />);
+      renderWithIntl(<AppleInstallHint />);
       // Give effects time to run, then assert nothing appeared.
       await new Promise((r) => setTimeout(r, 0));
       expect(screen.queryByLabelText("Install hint")).not.toBeInTheDocument();
@@ -122,7 +123,7 @@ describe("<AppleInstallHint>", () => {
     });
 
     it("does not render the install banner", async () => {
-      render(<AppleInstallHint />);
+      renderWithIntl(<AppleInstallHint />);
       await new Promise((r) => setTimeout(r, 0));
       expect(screen.queryByLabelText("Install hint")).not.toBeInTheDocument();
     });
@@ -145,7 +146,7 @@ describe("<AppleInstallHint>", () => {
     });
 
     it("does not render the install banner", async () => {
-      render(<AppleInstallHint />);
+      renderWithIntl(<AppleInstallHint />);
       await new Promise((r) => setTimeout(r, 0));
       expect(screen.queryByLabelText("Install hint")).not.toBeInTheDocument();
     });
@@ -161,7 +162,7 @@ describe("<AppleInstallHint>", () => {
     });
 
     it("does not render the install banner", async () => {
-      render(<AppleInstallHint />);
+      renderWithIntl(<AppleInstallHint />);
       await new Promise((r) => setTimeout(r, 0));
       expect(screen.queryByLabelText("Install hint")).not.toBeInTheDocument();
     });

--- a/frontend/src/components/pwa/apple-install-hint.tsx
+++ b/frontend/src/components/pwa/apple-install-hint.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { useEffect, useState } from "react";
 
 // localStorage key used to remember that the user dismissed the banner.
@@ -32,6 +33,7 @@ function shouldShowHint(): boolean {
 }
 
 export function AppleInstallHint() {
+  const t = useTranslations("Pwa");
   // Start hidden to avoid a hydration mismatch — the server never knows
   // whether the client is an iOS device or has already dismissed the hint.
   const [visible, setVisible] = useState<boolean>(false);
@@ -53,21 +55,21 @@ export function AppleInstallHint() {
 
   return (
     <section
-      aria-label="Install hint"
+      aria-label={t("hintLabel")}
       className="fixed inset-x-0 bottom-0 z-50 mx-auto max-w-md rounded-t-2xl bg-brand-primary px-4 pb-[env(safe-area-inset-bottom,1rem)] pt-4 shadow-lg"
     >
       <div className="flex items-start justify-between gap-3 pb-4">
         <div className="flex flex-col gap-1">
           <p className="font-semibold text-brand-primary-foreground text-sm leading-snug">
-            Install flamingo
+            {t("installHeading", { brand: "flamingo" })}
           </p>
           <p className="text-brand-primary-foreground text-xs opacity-90">
-            Tap the Share button, then &ldquo;Add to Home Screen&rdquo;.
+            {t("installInstruction")}
           </p>
         </div>
         <button
           type="button"
-          aria-label="Dismiss install hint"
+          aria-label={t("dismissLabel")}
           onClick={handleDismiss}
           className="mt-0.5 flex-shrink-0 rounded-full p-1 text-brand-primary-foreground opacity-80 hover:opacity-100 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-primary-foreground"
         >

--- a/frontend/src/lib/undo-delete.test.tsx
+++ b/frontend/src/lib/undo-delete.test.tsx
@@ -9,8 +9,10 @@
  */
 
 import { act, renderHook } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import enMessages from "../../messages/en.json";
 import { UndoDeleteProvider, useUndoDelete } from "./undo-delete";
 
 // ---------------------------------------------------------------------------
@@ -46,7 +48,13 @@ vi.mock("sonner", () => {
 // ---------------------------------------------------------------------------
 
 function wrapper({ children }: { children: ReactNode }) {
-  return <UndoDeleteProvider>{children}</UndoDeleteProvider>;
+  // UndoDeleteProvider now calls useTranslations("Common") for the toast's
+  // "Undo" action label, so it must render inside NextIntlClientProvider.
+  return (
+    <NextIntlClientProvider locale="en" messages={enMessages} timeZone="UTC">
+      <UndoDeleteProvider>{children}</UndoDeleteProvider>
+    </NextIntlClientProvider>
+  );
 }
 
 function makeOpts(

--- a/frontend/src/lib/undo-delete.tsx
+++ b/frontend/src/lib/undo-delete.tsx
@@ -23,6 +23,7 @@
  */
 
 import { usePathname } from "next/navigation";
+import { useTranslations } from "next-intl";
 import {
   createContext,
   type ReactNode,
@@ -85,6 +86,11 @@ export function UndoDeleteProvider({ children }: { children: ReactNode }) {
   const pendingRef = useRef<Map<string, PendingDelete>>(new Map());
   const pathname = usePathname();
   const previousPathnameRef = useRef(pathname);
+  // The toast's "Undo" action label is Provider-owned UI chrome (the toast
+  // title `label` is caller-supplied content). Resolve it here so every caller
+  // gets the localized label without threading it through scheduleDelete.
+  const t = useTranslations("Common");
+  const undoLabel = t("undo");
 
   const flushPendingDeletes = useCallback(async (): Promise<void> => {
     // Snapshot then clear so a concurrent flush cannot double-commit the same entry.
@@ -178,7 +184,7 @@ export function UndoDeleteProvider({ children }: { children: ReactNode }) {
       const toastId = toast(label, {
         duration: UNDO_DELAY_MS,
         action: {
-          label: "Undo",
+          label: undoLabel,
           onClick: () => handle.undo(),
         },
       });
@@ -194,7 +200,7 @@ export function UndoDeleteProvider({ children }: { children: ReactNode }) {
 
       return handle;
     },
-    [cancelPending],
+    [cancelPending, undoLabel],
   );
 
   // Returns a point-in-time snapshot. Not reactive — the value does not trigger


### PR DESCRIPTION
## Summary

Localize the cross-cutting feedback surfaces — not-found page, undo toast, and the iOS PWA install hint — to the `NotFound` / `Pwa` / `Common` message namespaces, on top of the i18n foundation (#343). `global-error.tsx` stays English (it renders outside the next-intl provider) but now reflects the persisted locale in `<html lang>`.

## Approach

- `NotFound` keys were already seeded by the foundation, so the not-found page maps `heading` / `message` to existing catalog keys with no copy change. The "Back to Home" CTA stays English (no seeded key; outside the issue's stated heading/message scope).
- `global-error.tsx` MUST NOT call `useTranslations` — it replaces the root layout on unrecoverable errors and renders outside `NextIntlClientProvider`. Copy stays English; `<html lang>` is derived from the `NEXT_LOCALE` cookie client-side, keeping the error path dependency-free.
- The undo toast's **"Undo" action label is Provider-owned UI chrome**, so `UndoDeleteProvider` resolves it via `useTranslations("Common")` → `undo` once — every caller gets the localized label without threading it through `scheduleDelete`. The toast *title* (`label`) stays caller-supplied content.
- `AppleInstallHint` reads `useTranslations("Pwa")`; the `flamingo` brand stays a literal, interpolated via `t("installHeading", { brand: "flamingo" })`.
- New `Pwa` namespace added to both catalogs; en/ja key sets stay identical. `Common.undo` already existed.

## Scope

- `src/app/not-found.tsx` — heading/message → `NotFound.*`.
- `src/app/global-error.tsx` — dynamic `<html lang>` from `NEXT_LOCALE` cookie; copy stays English, no `useTranslations`.
- `src/lib/undo-delete.tsx` — toast "Undo" action label → `Common.undo` (resolved in the Provider).
- `src/components/pwa/apple-install-hint.tsx` — hint copy / heading / aria-labels → `Pwa.*`; brand interpolated.
- `messages/{en,ja}.json` — add the `Pwa` namespace.
- Tests wrapped in `renderWithIntl` / `NextIntlClientProvider`: `not-found`, `apple-install-hint`, `undo-delete`, plus every test that mounts the real `UndoDeleteProvider` (`admin-roles-client`, `cards-client`, `cardgroup-edit`, `cards-bulk-delete`, `cards-pagination`, `admin-roles-crud`) — required because the Provider now calls `useTranslations`.

## Out of scope

- Backend-originated banner copy (`getBackendErrorBanner`, `lib/apollo/errors.ts`) stays English.
- The undo-toast caller components (cardgroups / cards / admin) are not localized here — only the shared Provider label is. Their own strings land in their per-area PRs.

## Test plan

- `pnpm --filter frontend typecheck` — green.
- `pnpm --filter frontend lint` — green.
- `pnpm --filter frontend test` — 117 files / 1135 tests pass.
- `pnpm --filter frontend knip` — clean.
- `pnpm --filter frontend build` — green.
- en/ja key sets identical; CJK grep over `frontend/src` (`.ts`/`.tsx`/`.graphql`/`.sql`/`.md`) — clean.

Closes #350
