### PR TITLE
feat(i18n): verification gates, parity script, e2e round-trip, and straggler sweep

### DIFF
--- a/docs/frontend/i18n.md
+++ b/docs/frontend/i18n.md
@@ -104,3 +104,31 @@ Field-level validation messages from the Go backend (`InputValidationError.messa
 ## `global-error.tsx` renders outside the provider
 
 `app/global-error.tsx` replaces the root layout on unrecoverable errors, so it has **no** `NextIntlClientProvider` and must not call `useTranslations` (it would throw). Keep its copy English; read the `NEXT_LOCALE` cookie client-side only to set `<html lang>`. This mirrors the layout-throw constraint in [`.claude/rules/frontend-rsc-error-handling.md`](../../.claude/rules/frontend-rsc-error-handling.md).
+
+## Catalog parity check
+
+`frontend/scripts/i18n-parity.mjs` asserts that `en.json` and `ja.json` carry exactly the same flattened key set. Run it locally whenever you add or remove keys:
+
+```bash
+pnpm --filter frontend i18n:parity
+```
+
+Exit 0 = keys match. Exit 1 = prints which keys are missing from which catalog, keyed by dotted namespace path (e.g. `Cardgroups.filterPlaceholder`). Fix by adding the missing key to the deficient catalog before merging.
+
+The script is intentionally dependency-free (Node built-ins only) and runs in under one second on the full catalog.
+
+## Language round-trip e2e
+
+`frontend/e2e/i18n-language-switch.spec.ts` covers the full locale-switch flow end-to-end:
+
+1. Sign in as a seeded user.
+2. Navigate to `/profile`.
+3. Select Japanese via the language switcher.
+4. Assert `<html lang="ja">` and that the Cardgroups nav link renders as `カードグループ`.
+5. Switch back to English and assert `<html lang="en">` and `Cardgroups`.
+
+Run with: `pnpm --filter frontend e2e -- --grep "language round-trip"`.
+
+## Skeleton aria-labels (known constraint)
+
+Skeleton components used as Suspense fallbacks (`LearnSkeleton`, `CardgroupsSkeleton`, `AdminUsersSkeleton`, `AdminRolesSkeleton`, `CardsNewSkeleton`) retain English `aria-label` values. The reason: a Suspense `fallback` must render synchronously, so the skeleton cannot call `await getTranslations()` — that would turn the fallback into an async component and break the Suspense contract. These labels are low-visibility (screen-reader-only loading states) and acceptable as English.

--- a/frontend/e2e/cardgroup-import.spec.ts
+++ b/frontend/e2e/cardgroup-import.spec.ts
@@ -29,8 +29,8 @@ async function openBatchImport(page: Page) {
   expect(response?.ok(), `goto returned status ${response?.status()}`).toBe(true);
   await expect(page.getByRole("heading", { level: 1, name: cardgroup.name })).toBeVisible();
 
-  await page.getByRole("button", { name: "More add options" }).click();
-  await page.getByRole("menuitem", { name: "Batch import" }).click();
+  await page.getByTestId("cardgroup-add-more-options").click();
+  await page.getByTestId("cardgroup-batch-import-menuitem").click();
   // Use data-testid to avoid locale-dependent label matching (Playwright runs with ja-JP).
   await expect(page.getByTestId("batch-import-payload")).toBeVisible();
 }

--- a/frontend/e2e/cardgroups-flow.spec.ts
+++ b/frontend/e2e/cardgroups-flow.spec.ts
@@ -77,7 +77,7 @@ test.describe
       // Check the Name input (CardgroupForm label — not yet localized) rather than
       // the translated sheet heading.
       await newCardgroupButton.click();
-      await expect(page.getByLabel("Name")).toBeVisible();
+      await expect(page.locator('input[name="name"]')).toBeVisible();
       await expect(page.getByRole("button", { name: "Create" })).toBeVisible();
 
       // The URL must NOT have navigated — the in-place drawer is the entire point.
@@ -142,11 +142,13 @@ test.describe
       // chip are not in the accessibility tree until the picker closes.
       // Assert the dialog first; the underlying page is verified below after
       // navigation back to /cards/new with ?cardgroup=<newId>.
-      const dialog = page.getByRole("dialog", { name: "Select cardgroup" });
+      // Use data-testid to avoid locale-dependent dialog name (Playwright runs ja-JP).
+      const dialog = page.getByTestId("cardgroup-picker-dialog");
       await expect(dialog).toBeVisible();
 
       // The "Create new cardgroup…" inline link must be present inside the sheet.
-      const createLink = dialog.getByRole("link", { name: /Create new cardgroup/ });
+      // Use href to avoid locale-dependent link text.
+      const createLink = dialog.locator('a[href*="/cardgroups/new"]');
       await expect(createLink).toBeVisible();
 
       // Clicking the link navigates to /cardgroups/new?returnTo=%2Fcards%2Fnew.
@@ -157,7 +159,8 @@ test.describe
 
       // Fill and submit the new cardgroup form.
       const newCgName = `E2E picker-return ${runId}`;
-      await page.getByLabel("Name").fill(newCgName);
+      // Use name attribute to avoid locale-dependent label text (Playwright runs ja-JP).
+      await page.locator('input[name="name"]').fill(newCgName);
       await page.getByRole("button", { name: "Create" }).click();
 
       // After successful creation the router pushes /cards/new?cardgroup=<newId>.
@@ -169,8 +172,9 @@ test.describe
       expect(newCgId).toMatch(UUID_RE);
 
       // The card form heading and the Name field must now be interactive.
-      await expect(page.getByRole("heading", { name: "New card" })).toBeVisible();
-      await expect(page.getByLabel("Front")).toBeVisible();
+      // Use data-testid / name attribute to avoid locale-dependent text (Playwright runs ja-JP).
+      await expect(page.getByTestId("cards-new-page-heading")).toBeVisible();
+      await expect(page.locator('input[name="front"]')).toBeVisible();
 
       // The chip must reflect the newly created cardgroup.
       await expect(
@@ -197,7 +201,7 @@ test.describe
       await expect(page.getByTestId("new-cardgroup-page-heading")).toBeVisible();
 
       const name4a = `E2E redirect-a ${runId}`;
-      await page.getByLabel("Name").fill(name4a);
+      await page.locator('input[name="name"]').fill(name4a);
       await page.getByRole("button", { name: "Create" }).click();
 
       // Must land on /cardgroups/<uuid>, never on evil.com or /cards/new.
@@ -214,7 +218,7 @@ test.describe
       await expect(page.getByTestId("new-cardgroup-page-heading")).toBeVisible();
 
       const name4b = `E2E redirect-b ${runId}`;
-      await page.getByLabel("Name").fill(name4b);
+      await page.locator('input[name="name"]').fill(name4b);
       await page.getByRole("button", { name: "Create" }).click();
 
       await page.waitForURL(/\/cardgroups\/[0-9a-f-]{36}$/, { timeout: 15_000 });

--- a/frontend/e2e/i18n-language-switch.spec.ts
+++ b/frontend/e2e/i18n-language-switch.spec.ts
@@ -1,0 +1,65 @@
+import { randomUUID } from "node:crypto";
+import { expect, test } from "@playwright/test";
+import { loginAs, seedUser } from "./_auth";
+
+/**
+ * Language round-trip: sign in → /profile → assert ja initial state →
+ * switch to English → assert lang=en + English nav → switch back to Japanese →
+ * assert lang=ja + Japanese nav.
+ *
+ * The LanguageSwitcher is a Radix UI Select (role=combobox) on /profile.
+ * The suite's Playwright locale is ja-JP, so the page starts in Japanese.
+ */
+
+const runId = randomUUID().slice(0, 8);
+const user = {
+  email: `i18n-switch-${runId}@example.test`,
+  password: "e2e-password",
+};
+
+test.describe.serial("language round-trip", () => {
+  test.beforeAll(async () => {
+    await seedUser({
+      email: user.email,
+      password: user.password,
+      role: "general",
+      displayName: `I18n Switch ${runId}`,
+    });
+  });
+
+  test("Japanese initial state, switch to English and back", async ({ context, page }) => {
+    await loginAs(context, user);
+    await page.goto("/profile");
+    await page.waitForURL("**/profile", { timeout: 15_000 });
+
+    // ── Assert initial Japanese state ───────────────────────────────────────
+    // Playwright locale ja-JP → Accept-Language: ja → resolveLocale → "ja"
+    await expect(page.locator("html")).toHaveAttribute("lang", "ja", { timeout: 10_000 });
+    await expect(page.getByRole("link", { name: "カードグループ" })).toBeVisible();
+
+    // ── Switch to English ───────────────────────────────────────────────────
+    // The LanguageSwitcher <SelectTrigger> renders as role=combobox.
+    // There is exactly one combobox on /profile (the language picker).
+    const langTrigger = page.getByRole("combobox");
+    await expect(langTrigger).toBeVisible();
+    await langTrigger.click();
+
+    // SelectContent renders options as role=option in a portal.
+    const englishOption = page.getByRole("option", { name: "English" });
+    await expect(englishOption).toBeVisible({ timeout: 5_000 });
+    await englishOption.click();
+
+    // setUserLocale server action sets the NEXT_LOCALE cookie; Next.js re-renders.
+    await expect(page.locator("html")).toHaveAttribute("lang", "en", { timeout: 15_000 });
+    await expect(page.getByRole("link", { name: "Cardgroups" })).toBeVisible();
+
+    // ── Switch back to Japanese ─────────────────────────────────────────────
+    await langTrigger.click();
+    const jaOption = page.getByRole("option", { name: "日本語" });
+    await expect(jaOption).toBeVisible({ timeout: 5_000 });
+    await jaOption.click();
+
+    await expect(page.locator("html")).toHaveAttribute("lang", "ja", { timeout: 15_000 });
+    await expect(page.getByRole("link", { name: "カードグループ" })).toBeVisible();
+  });
+});

--- a/frontend/e2e/i18n-language-switch.spec.ts
+++ b/frontend/e2e/i18n-language-switch.spec.ts
@@ -17,49 +17,50 @@ const user = {
   password: "e2e-password",
 };
 
-test.describe.serial("language round-trip", () => {
-  test.beforeAll(async () => {
-    await seedUser({
-      email: user.email,
-      password: user.password,
-      role: "general",
-      displayName: `I18n Switch ${runId}`,
+test.describe
+  .serial("language round-trip", () => {
+    test.beforeAll(async () => {
+      await seedUser({
+        email: user.email,
+        password: user.password,
+        role: "general",
+        displayName: `I18n Switch ${runId}`,
+      });
+    });
+
+    test("Japanese initial state, switch to English and back", async ({ context, page }) => {
+      await loginAs(context, user);
+      await page.goto("/profile");
+      await page.waitForURL("**/profile", { timeout: 15_000 });
+
+      // ── Assert initial Japanese state ───────────────────────────────────────
+      // Playwright locale ja-JP → Accept-Language: ja → resolveLocale → "ja"
+      await expect(page.locator("html")).toHaveAttribute("lang", "ja", { timeout: 10_000 });
+      await expect(page.getByRole("link", { name: "カードグループ" })).toBeVisible();
+
+      // ── Switch to English ───────────────────────────────────────────────────
+      // The LanguageSwitcher <SelectTrigger> renders as role=combobox.
+      // There is exactly one combobox on /profile (the language picker).
+      const langTrigger = page.getByRole("combobox");
+      await expect(langTrigger).toBeVisible();
+      await langTrigger.click();
+
+      // SelectContent renders options as role=option in a portal.
+      const englishOption = page.getByRole("option", { name: "English" });
+      await expect(englishOption).toBeVisible({ timeout: 5_000 });
+      await englishOption.click();
+
+      // setUserLocale server action sets the NEXT_LOCALE cookie; Next.js re-renders.
+      await expect(page.locator("html")).toHaveAttribute("lang", "en", { timeout: 15_000 });
+      await expect(page.getByRole("link", { name: "Cardgroups" })).toBeVisible();
+
+      // ── Switch back to Japanese ─────────────────────────────────────────────
+      await langTrigger.click();
+      const jaOption = page.getByRole("option", { name: "日本語" });
+      await expect(jaOption).toBeVisible({ timeout: 5_000 });
+      await jaOption.click();
+
+      await expect(page.locator("html")).toHaveAttribute("lang", "ja", { timeout: 15_000 });
+      await expect(page.getByRole("link", { name: "カードグループ" })).toBeVisible();
     });
   });
-
-  test("Japanese initial state, switch to English and back", async ({ context, page }) => {
-    await loginAs(context, user);
-    await page.goto("/profile");
-    await page.waitForURL("**/profile", { timeout: 15_000 });
-
-    // ── Assert initial Japanese state ───────────────────────────────────────
-    // Playwright locale ja-JP → Accept-Language: ja → resolveLocale → "ja"
-    await expect(page.locator("html")).toHaveAttribute("lang", "ja", { timeout: 10_000 });
-    await expect(page.getByRole("link", { name: "カードグループ" })).toBeVisible();
-
-    // ── Switch to English ───────────────────────────────────────────────────
-    // The LanguageSwitcher <SelectTrigger> renders as role=combobox.
-    // There is exactly one combobox on /profile (the language picker).
-    const langTrigger = page.getByRole("combobox");
-    await expect(langTrigger).toBeVisible();
-    await langTrigger.click();
-
-    // SelectContent renders options as role=option in a portal.
-    const englishOption = page.getByRole("option", { name: "English" });
-    await expect(englishOption).toBeVisible({ timeout: 5_000 });
-    await englishOption.click();
-
-    // setUserLocale server action sets the NEXT_LOCALE cookie; Next.js re-renders.
-    await expect(page.locator("html")).toHaveAttribute("lang", "en", { timeout: 15_000 });
-    await expect(page.getByRole("link", { name: "Cardgroups" })).toBeVisible();
-
-    // ── Switch back to Japanese ─────────────────────────────────────────────
-    await langTrigger.click();
-    const jaOption = page.getByRole("option", { name: "日本語" });
-    await expect(jaOption).toBeVisible({ timeout: 5_000 });
-    await jaOption.click();
-
-    await expect(page.locator("html")).toHaveAttribute("lang", "ja", { timeout: 15_000 });
-    await expect(page.getByRole("link", { name: "カードグループ" })).toBeVisible();
-  });
-});

--- a/frontend/e2e/new-user-onboarding.spec.ts
+++ b/frontend/e2e/new-user-onboarding.spec.ts
@@ -53,7 +53,8 @@ test.describe
       // 2. Submit the create-cardgroup form. onCompleted pushes /cardgroups/<newId>,
       // which redirects server-side to /cardgroups/<newId>/edit. Wait for the
       // /edit form so we can capture the new id from the URL.
-      await page.getByLabel("Name").fill(cardgroupName);
+      // Use name attribute to avoid locale-dependent label text (Playwright runs ja-JP).
+      await page.locator('input[name="name"]').fill(cardgroupName);
       await page.getByRole("button", { name: "Create" }).click();
       await page.waitForURL(/\/cardgroups\/[0-9a-f-]{36}\/edit$/, { timeout: 15_000 });
       const newCardgroupId = page.url().split("/").slice(-2, -1)[0] ?? "";
@@ -70,7 +71,8 @@ test.describe
       // 4. FormSheet opens inline. On mobile (390x844, below md=768) FormSheet
       // renders as a vaul Drawer. Verify the form is interactive via the Front
       // field — a stronger locale-independent signal than the translated sheet title.
-      await expect(page.getByLabel("Front")).toBeVisible();
+      // Use name attribute to avoid locale-dependent label text (Playwright runs ja-JP).
+      await expect(page.locator('input[name="front"]')).toBeVisible();
 
       // URL must NOT have navigated to /cards/new — the inline-sheet path is
       // the entire point of the FormSheet migration. Stay on /edit.

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -8,7 +8,12 @@
     "undo": "Undo",
     "edit": "Edit",
     "delete": "Delete",
-    "somethingWentWrong": "Something went wrong. Please try again."
+    "somethingWentWrong": "Something went wrong. Please try again.",
+    "discardChanges": "Discard your changes?",
+    "keepEditing": "Keep editing",
+    "discard": "Discard",
+    "cannotBeUndone": "This action cannot be undone.",
+    "deleteSelected": "Delete selected"
   },
   "Nav": {
     "cardgroups": "Cardgroups",
@@ -18,7 +23,9 @@
     "users": "Users",
     "roles": "Roles",
     "flamingoHome": "Flamingo home",
-    "navigationMenu": "Navigation menu"
+    "navigationMenu": "Navigation menu",
+    "openMenu": "Open menu",
+    "primaryNavigation": "Primary navigation"
   },
   "Language": {
     "label": "Language",
@@ -53,7 +60,11 @@
     "practiceEmptyHeading": "No cards practiced today yet",
     "practiceEmptyMessage": "Review some cards in a learning session first, then come back to practice them.",
     "practiceCompleteHeading": "Practice complete",
-    "practiceCompleteMessage": "You finished this practice round. Study again for another pass — your progress is never affected."
+    "practiceCompleteMessage": "You finished this practice round. Study again for another pass — your progress is never affected.",
+    "sessionComplete": "Session complete",
+    "sessionCompleteMessage": "There are no due cards left in this batch.",
+    "reviewedCount": "{count, plural, one {You reviewed # card in this batch.} other {You reviewed # cards in this batch.}}",
+    "refreshCards": "Refresh cards"
   },
   "Cardgroups": {
     "updatedAt": "Updated {date}",
@@ -71,7 +82,24 @@
     "deleteAriaLabel": "Delete cardgroup {name}",
     "backLink": "← Cardgroups",
     "welcomeHeading": "Welcome! Let's create your first cardgroup.",
-    "welcomeDesc": "A cardgroup holds the cards you study together — you can add more anytime."
+    "welcomeDesc": "A cardgroup holds the cards you study together — you can add more anytime.",
+    "filterPlaceholder": "Filter cardgroups...",
+    "filterAriaLabel": "Filter cardgroups",
+    "cardgroupOptions": "Cardgroup options",
+    "rename": "Rename",
+    "renameCardgroupTitle": "Rename cardgroup",
+    "deleteCardgroupTitle": "Delete cardgroup",
+    "deleteCardgroupDesc": "This will permanently delete \"{name}\" and all its cards. This cannot be undone.",
+    "pickerTitle": "Select cardgroup",
+    "pickerLoading": "Loading…",
+    "pickerFailed": "Failed to load cardgroups",
+    "pickerNoCardgroups": "You don't have any cardgroups yet.",
+    "createNewCardgroup": "Create new cardgroup…",
+    "addMoreOptions": "More add options",
+    "addCardButton": "Add card +",
+    "addACard": "Add a card",
+    "batchImport": "Batch import",
+    "nameLabel": "Name"
   },
   "Cards": {
     "addSomeCards": "Add some new cards to get started.",
@@ -99,7 +127,14 @@
     "overwriting": "Overwriting…",
     "overwriteFailed": "Overwrite failed. Please try again.",
     "selectCardgroupPrompt": "Select a cardgroup above to add a card.",
-    "cardgroupLabel": "Cardgroup"
+    "cardgroupLabel": "Cardgroup",
+    "frontLabel": "Front",
+    "backLabel": "Back",
+    "newCardTitle": "New card",
+    "addCardSheetTitle": "Add card",
+    "selectedCount": "{count} selected",
+    "deleteCardsTitle": "Delete {count} cards?",
+    "deleteConfirmCount": "Delete {count}"
   },
   "BatchImport": {
     "cardsToImport": "Cards to import",
@@ -215,6 +250,9 @@
     "rolesDescription": "Manage roles available to assign to users.",
     "editRoleTitle": "Edit role",
     "createRole": "Create",
-    "deleteAuthFailed": "Your session has expired. Please sign in again."
+    "deleteAuthFailed": "Your session has expired. Please sign in again.",
+    "systemRole": "System role",
+    "roleNameLabel": "Name",
+    "roleNamePlaceholder": "new-role-name"
   }
 }

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -8,7 +8,12 @@
     "undo": "元に戻す",
     "edit": "編集",
     "delete": "削除",
-    "somethingWentWrong": "エラーが発生しました。もう一度お試しください。"
+    "somethingWentWrong": "エラーが発生しました。もう一度お試しください。",
+    "discardChanges": "変更を破棄しますか？",
+    "keepEditing": "編集を続ける",
+    "discard": "破棄",
+    "cannotBeUndone": "この操作は元に戻せません。",
+    "deleteSelected": "選択を削除"
   },
   "Nav": {
     "cardgroups": "カードグループ",
@@ -18,7 +23,9 @@
     "users": "ユーザー",
     "roles": "ロール",
     "flamingoHome": "Flamingo ホーム",
-    "navigationMenu": "ナビゲーションメニュー"
+    "navigationMenu": "ナビゲーションメニュー",
+    "openMenu": "メニューを開く",
+    "primaryNavigation": "メインナビゲーション"
   },
   "Language": {
     "label": "言語",
@@ -53,7 +60,11 @@
     "practiceEmptyHeading": "今日はまだ練習したカードがありません",
     "practiceEmptyMessage": "まず学習セッションでカードを復習してから、練習しに戻ってきてください。",
     "practiceCompleteHeading": "練習完了",
-    "practiceCompleteMessage": "この練習ラウンドを終えました。もう一周したい場合はもう一度学習してください。進捗には影響しません。"
+    "practiceCompleteMessage": "この練習ラウンドを終えました。もう一周したい場合はもう一度学習してください。進捗には影響しません。",
+    "sessionComplete": "セッション完了",
+    "sessionCompleteMessage": "このバッチに期限切れのカードはありません。",
+    "reviewedCount": "{count, plural, other {このバッチで#枚のカードを復習しました。}}",
+    "refreshCards": "カードを更新"
   },
   "Cardgroups": {
     "updatedAt": "{date}に更新",
@@ -71,7 +82,24 @@
     "deleteAriaLabel": "カードグループ「{name}」を削除",
     "backLink": "← カードグループ",
     "welcomeHeading": "ようこそ！最初のカードグループを作成しましょう。",
-    "welcomeDesc": "カードグループには一緒に学習するカードをまとめます。いつでも追加できます。"
+    "welcomeDesc": "カードグループには一緒に学習するカードをまとめます。いつでも追加できます。",
+    "filterPlaceholder": "カードグループを絞り込む...",
+    "filterAriaLabel": "カードグループを絞り込む",
+    "cardgroupOptions": "カードグループのオプション",
+    "rename": "名前を変更",
+    "renameCardgroupTitle": "カードグループ名を変更",
+    "deleteCardgroupTitle": "カードグループを削除",
+    "deleteCardgroupDesc": "「{name}」とそのすべてのカードが完全に削除されます。この操作は元に戻せません。",
+    "pickerTitle": "カードグループを選択",
+    "pickerLoading": "読み込み中…",
+    "pickerFailed": "カードグループを読み込めませんでした",
+    "pickerNoCardgroups": "カードグループがまだありません。",
+    "createNewCardgroup": "新規カードグループを作成…",
+    "addMoreOptions": "追加オプション",
+    "addCardButton": "カードを追加 +",
+    "addACard": "カードを追加",
+    "batchImport": "一括インポート",
+    "nameLabel": "名前"
   },
   "Cards": {
     "addSomeCards": "新しいカードを追加して始めましょう。",
@@ -99,7 +127,14 @@
     "overwriting": "上書き中…",
     "overwriteFailed": "上書きに失敗しました。もう一度お試しください。",
     "selectCardgroupPrompt": "カードを追加するには上でカードグループを選択してください。",
-    "cardgroupLabel": "カードグループ"
+    "cardgroupLabel": "カードグループ",
+    "frontLabel": "表面",
+    "backLabel": "裏面",
+    "newCardTitle": "新しいカード",
+    "addCardSheetTitle": "カードを追加",
+    "selectedCount": "{count}件選択中",
+    "deleteCardsTitle": "{count}件のカードを削除しますか？",
+    "deleteConfirmCount": "{count}件を削除"
   },
   "BatchImport": {
     "cardsToImport": "インポートするカード",
@@ -215,6 +250,9 @@
     "rolesDescription": "ユーザーに割り当て可能なロールを管理します。",
     "editRoleTitle": "ロールを編集",
     "createRole": "作成",
-    "deleteAuthFailed": "セッションの有効期限が切れました。再度ログインしてください。"
+    "deleteAuthFailed": "セッションの有効期限が切れました。再度ログインしてください。",
+    "systemRole": "システムロール",
+    "roleNameLabel": "名前",
+    "roleNamePlaceholder": "new-role-name"
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "format": "biome format --write .",
     "typecheck": "tsc --noEmit",
     "knip": "knip",
+    "i18n:parity": "node scripts/i18n-parity.mjs",
     "codegen": "graphql-codegen --config codegen.ts",
     "codegen:watch": "graphql-codegen --config codegen.ts --watch",
     "prebuild": "pnpm codegen && node scripts/stamp-sw-version.mjs",

--- a/frontend/scripts/i18n-parity.mjs
+++ b/frontend/scripts/i18n-parity.mjs
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+/**
+ * Asserts that en.json and ja.json have exactly the same flattened key set.
+ * Exits 0 when they match; exits 1 and prints diffs when they diverge.
+ * Run: node scripts/i18n-parity.mjs
+ */
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const messagesDir = join(__dirname, "../messages");
+
+function flatten(obj, prefix = "") {
+  const out = [];
+  for (const [k, v] of Object.entries(obj)) {
+    const key = prefix ? `${prefix}.${k}` : k;
+    if (v !== null && typeof v === "object" && !Array.isArray(v)) {
+      out.push(...flatten(v, key));
+    } else {
+      out.push(key);
+    }
+  }
+  return out.sort();
+}
+
+const en = JSON.parse(readFileSync(join(messagesDir, "en.json"), "utf8"));
+const ja = JSON.parse(readFileSync(join(messagesDir, "ja.json"), "utf8"));
+
+const enKeys = new Set(flatten(en));
+const jaKeys = new Set(flatten(ja));
+
+const onlyEn = [...enKeys].filter((k) => !jaKeys.has(k));
+const onlyJa = [...jaKeys].filter((k) => !enKeys.has(k));
+
+let ok = true;
+
+if (onlyEn.length > 0) {
+  ok = false;
+  console.error("Keys in en.json but missing from ja.json:");
+  for (const k of onlyEn) console.error(`  - ${k}`);
+}
+
+if (onlyJa.length > 0) {
+  ok = false;
+  console.error("Keys in ja.json but missing from en.json:");
+  for (const k of onlyJa) console.error(`  + ${k}`);
+}
+
+if (ok) {
+  console.log(`Parity OK — ${enKeys.size} keys in both catalogs.`);
+  process.exit(0);
+} else {
+  process.exit(1);
+}

--- a/frontend/scripts/i18n-parity.mjs
+++ b/frontend/scripts/i18n-parity.mjs
@@ -5,8 +5,8 @@
  * Run: node scripts/i18n-parity.mjs
  */
 import { readFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const messagesDir = join(__dirname, "../messages");

--- a/frontend/src/app/cardgroups/[id]/cards/components/bulk-action-bar.tsx
+++ b/frontend/src/app/cardgroups/[id]/cards/components/bulk-action-bar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useTranslations } from "next-intl";
 import { Trash2, X } from "lucide-react";
+import { useTranslations } from "next-intl";
 import {
   AlertDialog,
   AlertDialogAction,

--- a/frontend/src/app/cardgroups/[id]/cards/components/bulk-action-bar.tsx
+++ b/frontend/src/app/cardgroups/[id]/cards/components/bulk-action-bar.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { Trash2, X } from "lucide-react";
 import {
   AlertDialog,
@@ -22,12 +23,15 @@ export type BulkActionBarProps = {
 };
 
 export function BulkActionBar({ count, busy, onConfirm, onClear }: BulkActionBarProps) {
+  const t = useTranslations("Cards");
+  const tCommon = useTranslations("Common");
+
   return (
     <div
       className="mb-3 flex items-center gap-3 rounded-md border border-border bg-muted/50 px-4 py-2"
       data-testid="cards-bulk-action-bar"
     >
-      <span className="flex-1 text-sm font-medium">{count} selected</span>
+      <span className="flex-1 text-sm font-medium">{t("selectedCount", { count })}</span>
       <AlertDialog>
         <AlertDialogTrigger asChild>
           <Button
@@ -36,25 +40,25 @@ export function BulkActionBar({ count, busy, onConfirm, onClear }: BulkActionBar
             disabled={busy}
             data-testid="cards-bulk-delete-button"
           >
-            Delete selected
+            {tCommon("deleteSelected")}
             <Trash2 aria-hidden="true" className="ml-1.5 h-4 w-4" />
           </Button>
         </AlertDialogTrigger>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>Delete {count} cards?</AlertDialogTitle>
-            <AlertDialogDescription>This action cannot be undone.</AlertDialogDescription>
+            <AlertDialogTitle>{t("deleteCardsTitle", { count })}</AlertDialogTitle>
+            <AlertDialogDescription>{tCommon("cannotBeUndone")}</AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogCancel>{tCommon("cancel")}</AlertDialogCancel>
             <AlertDialogAction data-testid="cards-bulk-confirm" onClick={onConfirm}>
-              Delete {count}
+              {t("deleteConfirmCount", { count })}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
       <Button variant="outline" size="sm" onClick={onClear}>
-        Cancel
+        {tCommon("cancel")}
         <X aria-hidden="true" className="ml-1.5 h-4 w-4" />
       </Button>
     </div>

--- a/frontend/src/app/cards/new/page.test.tsx
+++ b/frontend/src/app/cards/new/page.test.tsx
@@ -23,8 +23,9 @@ vi.mock("@/lib/apollo/server", () => ({
 vi.mock("next-intl/server", async () => {
   const enMessages = (await import("../../../../messages/en.json")).default;
   return {
-    getTranslations: vi.fn(async (namespace: string) =>
-      (key: string) => (enMessages as Record<string, Record<string, string>>)[namespace]?.[key] ?? key,
+    getTranslations: vi.fn(
+      async (namespace: string) => (key: string) =>
+        (enMessages as Record<string, Record<string, string>>)[namespace]?.[key] ?? key,
     ),
   };
 });

--- a/frontend/src/app/cards/new/page.test.tsx
+++ b/frontend/src/app/cards/new/page.test.tsx
@@ -19,6 +19,16 @@ vi.mock("@/lib/apollo/server", () => ({
   gqlFetch: vi.fn(),
 }));
 
+// next-intl/server — the page resolves the Cards namespace via getTranslations.
+vi.mock("next-intl/server", async () => {
+  const enMessages = (await import("../../../../messages/en.json")).default;
+  return {
+    getTranslations: vi.fn(async (namespace: string) =>
+      (key: string) => (enMessages as Record<string, Record<string, string>>)[namespace]?.[key] ?? key,
+    ),
+  };
+});
+
 // Stub CardsNewClient — it is a "use client" component that requires an
 // ApolloProvider. The RSC page test only needs to verify props are forwarded
 // correctly; the client component has its own dedicated test file.

--- a/frontend/src/app/cards/new/page.tsx
+++ b/frontend/src/app/cards/new/page.tsx
@@ -29,7 +29,9 @@ export default async function CardsNewPage({ searchParams }: CardsNewPageProps) 
 
   return (
     <main className="p-8">
-      <h1 className="mb-6 text-2xl font-semibold">{t("newCardTitle")}</h1>
+      <h1 className="mb-6 text-2xl font-semibold" data-testid="cards-new-page-heading">
+        {t("newCardTitle")}
+      </h1>
       <Suspense fallback={<CardsNewSkeleton />}>
         <CardsNewContent cardgroupParam={cardgroupParam} />
       </Suspense>

--- a/frontend/src/app/cards/new/page.tsx
+++ b/frontend/src/app/cards/new/page.tsx
@@ -1,8 +1,8 @@
 import type { Metadata } from "next";
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
-import { Suspense } from "react";
 import { getTranslations } from "next-intl/server";
+import { Suspense } from "react";
 import type { CardsNewBootstrapQuery as CardsNewBootstrapQueryType } from "@/generated/graphql";
 import { isUnauthenticatedGraphQLError } from "@/lib/apollo/graphql-errors";
 import { gqlFetch } from "@/lib/apollo/server";

--- a/frontend/src/app/cards/new/page.tsx
+++ b/frontend/src/app/cards/new/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 import { Suspense } from "react";
+import { getTranslations } from "next-intl/server";
 import type { CardsNewBootstrapQuery as CardsNewBootstrapQueryType } from "@/generated/graphql";
 import { isUnauthenticatedGraphQLError } from "@/lib/apollo/graphql-errors";
 import { gqlFetch } from "@/lib/apollo/server";
@@ -23,11 +24,12 @@ export default async function CardsNewPage({ searchParams }: CardsNewPageProps) 
   // "anonymous" so a dropped header never leaks an authenticated view.
   if (readAuthContext(await headers()).status !== "authenticated") redirect("/login");
 
+  const t = await getTranslations("Cards");
   const { cardgroup: cardgroupParam } = await searchParams;
 
   return (
     <main className="p-8">
-      <h1 className="mb-6 text-2xl font-semibold">New card</h1>
+      <h1 className="mb-6 text-2xl font-semibold">{t("newCardTitle")}</h1>
       <Suspense fallback={<CardsNewSkeleton />}>
         <CardsNewContent cardgroupParam={cardgroupParam} />
       </Suspense>

--- a/frontend/src/app/learn/[cardgroupId]/_components/learn-add-card-sheet.test.tsx
+++ b/frontend/src/app/learn/[cardgroupId]/_components/learn-add-card-sheet.test.tsx
@@ -3,8 +3,8 @@ import { MockedProvider } from "@apollo/client/testing/react";
 import { act, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { renderWithIntl } from "@/test/render-with-intl";
 import { CreateCardDocument } from "@/generated/graphql";
+import { renderWithIntl } from "@/test/render-with-intl";
 import { LearnAddCardSheet } from "./learn-add-card-sheet";
 
 const userCardState = (due: string, state: number) => ({

--- a/frontend/src/app/learn/[cardgroupId]/_components/learn-add-card-sheet.test.tsx
+++ b/frontend/src/app/learn/[cardgroupId]/_components/learn-add-card-sheet.test.tsx
@@ -1,8 +1,9 @@
 // @vitest-environment jsdom
 import { MockedProvider } from "@apollo/client/testing/react";
-import { act, render, screen, waitFor } from "@testing-library/react";
+import { act, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { renderWithIntl } from "@/test/render-with-intl";
 import { CreateCardDocument } from "@/generated/graphql";
 import { LearnAddCardSheet } from "./learn-add-card-sheet";
 
@@ -29,7 +30,7 @@ afterEach(() => {
 
 describe("<LearnAddCardSheet>", () => {
   it("opens the add-card drawer when the event targets this cardgroup", async () => {
-    render(
+    renderWithIntl(
       <MockedProvider mocks={[]}>
         <LearnAddCardSheet cardgroupId="cg-1" />
       </MockedProvider>,
@@ -43,7 +44,7 @@ describe("<LearnAddCardSheet>", () => {
   });
 
   it("ignores an add-card event for a different cardgroup", () => {
-    render(
+    renderWithIntl(
       <MockedProvider mocks={[]}>
         <LearnAddCardSheet cardgroupId="cg-1" />
       </MockedProvider>,
@@ -79,7 +80,7 @@ describe("<LearnAddCardSheet>", () => {
       },
     };
 
-    render(
+    renderWithIntl(
       <MockedProvider mocks={[createMock]}>
         <LearnAddCardSheet cardgroupId="cg-1" />
       </MockedProvider>,

--- a/frontend/src/app/learn/[cardgroupId]/_components/learn-add-card-sheet.tsx
+++ b/frontend/src/app/learn/[cardgroupId]/_components/learn-add-card-sheet.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { useMutation } from "@apollo/client/react";
-import { useCallback, useEffect, useState } from "react";
 import { useTranslations } from "next-intl";
+import { useCallback, useEffect, useState } from "react";
 import { CreateCardMutation } from "@/app/cardgroups/queries";
 import { CardForm } from "@/components/cardgroups/card-form";
 import { FormSheet, useFormSheetClose } from "@/components/ui/form-sheet";

--- a/frontend/src/app/learn/[cardgroupId]/_components/learn-add-card-sheet.tsx
+++ b/frontend/src/app/learn/[cardgroupId]/_components/learn-add-card-sheet.tsx
@@ -2,6 +2,7 @@
 
 import { useMutation } from "@apollo/client/react";
 import { useCallback, useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
 import { CreateCardMutation } from "@/app/cardgroups/queries";
 import { CardForm } from "@/components/cardgroups/card-form";
 import { FormSheet, useFormSheetClose } from "@/components/ui/form-sheet";
@@ -47,6 +48,7 @@ function AddCardSheetContent({
  * later session via FSRS scheduling, leaving the current swipe queue untouched.
  */
 export function LearnAddCardSheet({ cardgroupId }: { cardgroupId: string }) {
+  const t = useTranslations("Cards");
   const [open, setOpen] = useState(false);
   const [dirty, setDirty] = useState(false);
   const [validationError, setValidationError] = useState<{
@@ -112,7 +114,7 @@ export function LearnAddCardSheet({ cardgroupId }: { cardgroupId: string }) {
 
   return (
     <FormSheet
-      title="Add card"
+      title={t("addCardSheetTitle")}
       open={open}
       onOpenChange={(nextOpen) => {
         setOpen(nextOpen);

--- a/frontend/src/components/admin/role-form.tsx
+++ b/frontend/src/components/admin/role-form.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useForm } from "@tanstack/react-form";
+import { useTranslations } from "next-intl";
 import { useEffect, useMemo } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -49,6 +50,7 @@ export function RoleForm({
   onCancel,
   onDirtyChange,
 }: RoleFormProps) {
+  const t = useTranslations("Admin");
   const nameSchema = roleSchema.shape.name;
 
   const fieldErrors = useMemo(() => getBackendFieldErrors(error), [error]);
@@ -93,7 +95,7 @@ export function RoleForm({
       <form.Field name="name" validators={{ onChange: nameSchema, onBlur: nameSchema }}>
         {(field) => (
           <div className="space-y-2">
-            <Label htmlFor={field.name}>Name</Label>
+            <Label htmlFor={field.name}>{t("roleNameLabel")}</Label>
             <Input
               id={field.name}
               name={field.name}
@@ -101,7 +103,7 @@ export function RoleForm({
               onBlur={field.handleBlur}
               onChange={(e) => field.handleChange(e.target.value)}
               disabled={readOnly}
-              placeholder="new-role-name"
+              placeholder={t("roleNamePlaceholder")}
             />
             <FieldError zodErrors={field.state.meta.errors} backendError={fieldErrors.name} />
           </div>

--- a/frontend/src/components/admin/role-list-item.tsx
+++ b/frontend/src/components/admin/role-list-item.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Trash2 } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { SwipeableRow } from "@/components/cardgroups/swipeable-row";
 import { Button } from "@/components/ui/button";
 
@@ -26,6 +27,7 @@ export type RoleListItemProps = {
  * frontend/src/components/cardgroups/cardgroup-list-item.tsx.
  */
 export function RoleListItem({ id, name, isSystem, busy, onEdit, onDelete }: RoleListItemProps) {
+  const t = useTranslations("Admin");
   if (isSystem) {
     return (
       <li
@@ -36,7 +38,7 @@ export function RoleListItem({ id, name, isSystem, busy, onEdit, onDelete }: Rol
           <span className="truncate font-medium text-foreground" data-testid="admin-role-name">
             {name}
           </span>
-          <span className="text-xs text-muted-foreground">System role</span>
+          <span className="text-xs text-muted-foreground">{t("systemRole")}</span>
         </div>
       </li>
     );

--- a/frontend/src/components/cardgroups/card-form.test.tsx
+++ b/frontend/src/components/cardgroups/card-form.test.tsx
@@ -1,15 +1,16 @@
 // @vitest-environment jsdom
 import { CombinedGraphQLErrors } from "@apollo/client/errors";
 import { MockedProvider } from "@apollo/client/testing/react";
-import { render, screen, waitFor } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { GraphQLError } from "graphql";
 import { describe, expect, it, vi } from "vitest";
+import { renderWithIntl } from "@/test/render-with-intl";
 import { CardForm } from "./card-form";
 
 function renderForm(props: Partial<Parameters<typeof CardForm>[0]> = {}) {
   const submit = vi.fn().mockResolvedValue(undefined);
-  render(
+  renderWithIntl(
     <MockedProvider mocks={[]}>
       <CardForm
         mode={props.mode ?? "create"}

--- a/frontend/src/components/cardgroups/card-form.tsx
+++ b/frontend/src/components/cardgroups/card-form.tsx
@@ -3,8 +3,8 @@
 // cardgroupId injection happens in the parent's submit callback, not inside this component.
 
 import { useForm } from "@tanstack/react-form";
-import { useMemo } from "react";
 import { useTranslations } from "next-intl";
+import { useMemo } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";

--- a/frontend/src/components/cardgroups/card-form.tsx
+++ b/frontend/src/components/cardgroups/card-form.tsx
@@ -4,6 +4,7 @@
 
 import { useForm } from "@tanstack/react-form";
 import { useMemo } from "react";
+import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -43,6 +44,7 @@ export function CardForm({
   validationError,
   onCancel,
 }: CardFormProps) {
+  const t = useTranslations("Cards");
   const resolvedLabel = submitLabel ?? (mode === "create" ? "Add" : "Save");
   const schema = mode === "create" ? newCardSchema.omit({ cardgroupId: true }) : updateCardSchema;
   const frontSchema = schema.shape.front;
@@ -85,7 +87,7 @@ export function CardForm({
           const inputId = `${idPrefix}${field.name}-field`;
           return (
             <div className="space-y-1">
-              <Label htmlFor={inputId}>Front</Label>
+              <Label htmlFor={inputId}>{t("frontLabel")}</Label>
               <Input
                 id={inputId}
                 name={field.name}
@@ -109,7 +111,7 @@ export function CardForm({
           const inputId = `${idPrefix}${field.name}-field`;
           return (
             <div className="space-y-1">
-              <Label htmlFor={inputId}>Back</Label>
+              <Label htmlFor={inputId}>{t("backLabel")}</Label>
               <Input
                 id={inputId}
                 name={field.name}

--- a/frontend/src/components/cardgroups/cardgroup-cards-section.test.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-cards-section.test.tsx
@@ -1,9 +1,10 @@
 // @vitest-environment jsdom
 
-import { render, screen } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { renderWithIntl } from "@/test/render-with-intl";
 import { CardgroupCardsSection } from "./cardgroup-cards-section";
 
 const onAddCard = vi.fn();
@@ -44,7 +45,7 @@ function renderSection(
   initialTotalCount = 7,
   renderPageHeader?: (args: { totalCount: number; onBatchImport: () => void }) => ReactNode,
 ) {
-  render(
+  renderWithIntl(
     <CardgroupCardsSection
       cardgroupId={cardgroupId}
       cardgroupName="Test Cardgroup"

--- a/frontend/src/components/cardgroups/cardgroup-cards-section.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-cards-section.tsx
@@ -83,13 +83,14 @@ export function CardgroupCardsSection({
                 size="sm"
                 className="rounded-l-none border-l px-2"
                 aria-label={t("addMoreOptions")}
+                data-testid="cardgroup-add-more-options"
               >
                 <ChevronDown aria-hidden="true" className="h-4 w-4" />
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
               <DropdownMenuItem onSelect={onAddCard}>{t("addACard")}</DropdownMenuItem>
-              <DropdownMenuItem onSelect={onBatchImport}>{t("batchImport")}</DropdownMenuItem>
+              <DropdownMenuItem onSelect={onBatchImport} data-testid="cardgroup-batch-import-menuitem">{t("batchImport")}</DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
         </div>

--- a/frontend/src/components/cardgroups/cardgroup-cards-section.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-cards-section.tsx
@@ -2,6 +2,7 @@
 
 import { ChevronDown, Play } from "lucide-react";
 import Link from "next/link";
+import { useTranslations } from "next-intl";
 import type { ReactNode } from "react";
 import {
   type CardConnectionPageInfo,
@@ -15,7 +16,6 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { useTranslations } from "next-intl";
 
 type Props = {
   cardgroupId: string;

--- a/frontend/src/components/cardgroups/cardgroup-cards-section.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-cards-section.tsx
@@ -90,7 +90,12 @@ export function CardgroupCardsSection({
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
               <DropdownMenuItem onSelect={onAddCard}>{t("addACard")}</DropdownMenuItem>
-              <DropdownMenuItem onSelect={onBatchImport} data-testid="cardgroup-batch-import-menuitem">{t("batchImport")}</DropdownMenuItem>
+              <DropdownMenuItem
+                onSelect={onBatchImport}
+                data-testid="cardgroup-batch-import-menuitem"
+              >
+                {t("batchImport")}
+              </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
         </div>

--- a/frontend/src/components/cardgroups/cardgroup-cards-section.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-cards-section.tsx
@@ -15,6 +15,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { useTranslations } from "next-intl";
 
 type Props = {
   cardgroupId: string;
@@ -40,6 +41,7 @@ export function CardgroupCardsSection({
   renderPageHeader,
 }: Props) {
   const learnHref = `/learn/${encodeURIComponent(cardgroupId)}`;
+  const t = useTranslations("Cardgroups");
 
   // The render-prop form lets CardsClient pass its live totalCount (read from
   // Apollo cache, kept in sync with delete/bulk-delete/fetchMore) into the
@@ -71,7 +73,7 @@ export function CardgroupCardsSection({
             className="rounded-r-none"
             onClick={onAddCard}
           >
-            Add card +
+            {t("addCardButton")}
           </Button>
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
@@ -80,14 +82,14 @@ export function CardgroupCardsSection({
                 variant="brand"
                 size="sm"
                 className="rounded-l-none border-l px-2"
-                aria-label="More add options"
+                aria-label={t("addMoreOptions")}
               >
                 <ChevronDown aria-hidden="true" className="h-4 w-4" />
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
-              <DropdownMenuItem onSelect={onAddCard}>Add a card</DropdownMenuItem>
-              <DropdownMenuItem onSelect={onBatchImport}>Batch import</DropdownMenuItem>
+              <DropdownMenuItem onSelect={onAddCard}>{t("addACard")}</DropdownMenuItem>
+              <DropdownMenuItem onSelect={onBatchImport}>{t("batchImport")}</DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
         </div>

--- a/frontend/src/components/cardgroups/cardgroup-form.test.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-form.test.tsx
@@ -2,10 +2,11 @@
 import { CombinedGraphQLErrors } from "@apollo/client/errors";
 import { MockedProvider } from "@apollo/client/testing/react";
 import { useForm } from "@tanstack/react-form";
-import { render, screen, waitFor } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { GraphQLError } from "graphql";
 import { describe, expect, it, vi } from "vitest";
+import { renderWithIntl } from "@/test/render-with-intl";
 import { CardgroupForm } from "./cardgroup-form";
 
 /**
@@ -55,7 +56,7 @@ function CardgroupFormWithStatus({
 // The form itself does not run a mutation, but the parent's submit might.
 function renderForm(props: Partial<Parameters<typeof CardgroupForm>[0]> = {}) {
   const submit = vi.fn().mockResolvedValue(undefined);
-  render(
+  renderWithIntl(
     <MockedProvider mocks={[]}>
       <CardgroupForm
         mode={props.mode ?? "create"}
@@ -235,7 +236,7 @@ describe("<CardgroupForm>", () => {
     const user = userEvent.setup();
     const submit = vi.fn().mockRejectedValue(new Error("network down"));
 
-    render(
+    renderWithIntl(
       <MockedProvider mocks={[]}>
         <CardgroupFormWithStatus submit={submit} />
       </MockedProvider>,

--- a/frontend/src/components/cardgroups/cardgroup-form.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-form.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useForm } from "@tanstack/react-form";
+import { useTranslations } from "next-intl";
 import type React from "react";
 import { useMemo } from "react";
 import { Button } from "@/components/ui/button";
@@ -9,7 +10,6 @@ import { Label } from "@/components/ui/label";
 import { getBackendErrorBanner, getBackendFieldErrors } from "@/lib/apollo/errors";
 import { FieldError } from "@/lib/forms/field-error";
 import { newCardgroupSchema, updateCardgroupSchema } from "@/schemas/cardgroup";
-import { useTranslations } from "next-intl";
 
 type Mode = "create" | "edit";
 

--- a/frontend/src/components/cardgroups/cardgroup-form.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-form.tsx
@@ -9,6 +9,7 @@ import { Label } from "@/components/ui/label";
 import { getBackendErrorBanner, getBackendFieldErrors } from "@/lib/apollo/errors";
 import { FieldError } from "@/lib/forms/field-error";
 import { newCardgroupSchema, updateCardgroupSchema } from "@/schemas/cardgroup";
+import { useTranslations } from "next-intl";
 
 type Mode = "create" | "edit";
 
@@ -43,6 +44,7 @@ export function CardgroupForm({
   validationError,
   secondarySlot,
 }: CardgroupFormProps) {
+  const t = useTranslations("Cardgroups");
   const resolvedLabel = submitLabel ?? (mode === "create" ? "Create" : "Save");
 
   const schema = mode === "create" ? newCardgroupSchema : updateCardgroupSchema;
@@ -85,7 +87,7 @@ export function CardgroupForm({
       <form.Field name="name" validators={{ onChange: nameSchema, onBlur: nameSchema }}>
         {(field) => (
           <div className="space-y-2">
-            <Label htmlFor={field.name}>Name</Label>
+            <Label htmlFor={field.name}>{t("nameLabel")}</Label>
             <Input
               id={field.name}
               name={field.name}

--- a/frontend/src/components/cardgroups/cardgroup-header.test.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-header.test.tsx
@@ -5,8 +5,8 @@ import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { GraphQLError } from "graphql";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { renderWithIntl } from "@/test/render-with-intl";
 import { DeleteCardgroupDocument, UpdateCardgroupDocument } from "@/generated/graphql";
+import { renderWithIntl } from "@/test/render-with-intl";
 import { CardgroupHeader } from "./cardgroup-header";
 
 const mockPush = vi.fn();

--- a/frontend/src/components/cardgroups/cardgroup-header.test.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-header.test.tsx
@@ -1,10 +1,11 @@
 // @vitest-environment jsdom
 import type { MockedResponse } from "@apollo/client/testing";
 import { MockedProvider } from "@apollo/client/testing/react";
-import { render, screen, waitFor } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { GraphQLError } from "graphql";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { renderWithIntl } from "@/test/render-with-intl";
 import { DeleteCardgroupDocument, UpdateCardgroupDocument } from "@/generated/graphql";
 import { CardgroupHeader } from "./cardgroup-header";
 
@@ -33,7 +34,7 @@ function makeUpdateMock(
 }
 
 function renderHeader(mocks: MockedResponse[] = [], totalCount = 5) {
-  render(
+  renderWithIntl(
     <MockedProvider mocks={mocks}>
       <CardgroupHeader cardgroup={CARDGROUP} totalCount={totalCount} />
     </MockedProvider>,

--- a/frontend/src/components/cardgroups/cardgroup-header.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-header.tsx
@@ -28,6 +28,7 @@ import {
 import { FormSheet } from "@/components/ui/form-sheet";
 import { MyCardgroupsConnectionDocument } from "@/generated/graphql";
 import { getBackendErrorBanner } from "@/lib/apollo/errors";
+import { useTranslations } from "next-intl";
 
 type Props = {
   cardgroup: { id: string; name: string };
@@ -46,6 +47,9 @@ export function CardgroupHeader({ cardgroup, totalCount, onBatchImport }: Props)
     useMutation(DeleteCardgroupMutation);
 
   const deleteBannerError = getBackendErrorBanner(deleteError);
+
+  const t = useTranslations("Cardgroups");
+  const tCommon = useTranslations("Common");
 
   const handleRenameSubmittingChange = useCallback((submitting: boolean) => {
     setRenaming(submitting);
@@ -102,14 +106,14 @@ export function CardgroupHeader({ cardgroup, totalCount, onBatchImport }: Props)
         <div className="ml-auto">
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <Button variant="ghost" size="icon" aria-label="Cardgroup options">
+              <Button variant="ghost" size="icon" aria-label={t("cardgroupOptions")}>
                 <MoreHorizontal className="h-4 w-4" />
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
               <DropdownMenuItem onSelect={() => setRenameOpen(true)} className="gap-2">
                 <Pencil className="h-4 w-4" />
-                Rename
+                {t("rename")}
               </DropdownMenuItem>
               {onBatchImport && (
                 <>
@@ -117,7 +121,7 @@ export function CardgroupHeader({ cardgroup, totalCount, onBatchImport }: Props)
                   {/* Batch import is shown here for mobile users;
                       the desktop split button (hidden md:inline-flex) covers desktop. */}
                   <DropdownMenuItem onSelect={onBatchImport} className="gap-2 md:hidden">
-                    Batch import
+                    {t("batchImport")}
                   </DropdownMenuItem>
                 </>
               )}
@@ -132,7 +136,7 @@ export function CardgroupHeader({ cardgroup, totalCount, onBatchImport }: Props)
                 className="gap-2 text-destructive focus:text-destructive"
               >
                 <Trash2 className="h-4 w-4" />
-                Delete cardgroup
+                {t("deleteCardgroupTitle")}
               </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
@@ -142,7 +146,7 @@ export function CardgroupHeader({ cardgroup, totalCount, onBatchImport }: Props)
       <FormSheet
         open={renameOpen}
         onOpenChange={setRenameOpen}
-        title="Rename cardgroup"
+        title={t("renameCardgroupTitle")}
         confirmOnDismiss={false}
         submitting={renaming}
         size="sm"
@@ -160,9 +164,9 @@ export function CardgroupHeader({ cardgroup, totalCount, onBatchImport }: Props)
       <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>Delete cardgroup</AlertDialogTitle>
+            <AlertDialogTitle>{t("deleteCardgroupTitle")}</AlertDialogTitle>
             <AlertDialogDescription>
-              {`This will permanently delete "${cardgroup.name}" and all its cards. This cannot be undone.`}
+              {t("deleteCardgroupDesc", { name: cardgroup.name })}
             </AlertDialogDescription>
           </AlertDialogHeader>
           {deleteBannerError && (
@@ -171,7 +175,7 @@ export function CardgroupHeader({ cardgroup, totalCount, onBatchImport }: Props)
             </div>
           )}
           <AlertDialogFooter>
-            <AlertDialogCancel disabled={deleting}>Cancel</AlertDialogCancel>
+            <AlertDialogCancel disabled={deleting}>{tCommon("cancel")}</AlertDialogCancel>
             <AlertDialogAction
               className="bg-destructive text-destructive-foreground"
               disabled={deleting}
@@ -180,7 +184,7 @@ export function CardgroupHeader({ cardgroup, totalCount, onBatchImport }: Props)
                 void handleDelete();
               }}
             >
-              Delete
+              {tCommon("delete")}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/frontend/src/components/cardgroups/cardgroup-header.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-header.tsx
@@ -3,6 +3,7 @@
 import { useMutation } from "@apollo/client/react";
 import { MoreHorizontal, Pencil, Trash2 } from "lucide-react";
 import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
 import { useCallback, useState } from "react";
 import { CARDGROUPS_DEFAULT_VARS, DeleteCardgroupMutation } from "@/app/cardgroups/queries";
 import { CardgroupRenameForm } from "@/components/cardgroups/cardgroup-rename-form";
@@ -28,7 +29,6 @@ import {
 import { FormSheet } from "@/components/ui/form-sheet";
 import { MyCardgroupsConnectionDocument } from "@/generated/graphql";
 import { getBackendErrorBanner } from "@/lib/apollo/errors";
-import { useTranslations } from "next-intl";
 
 type Props = {
   cardgroup: { id: string; name: string };

--- a/frontend/src/components/cardgroups/cardgroup-picker-sheet.test.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-picker-sheet.test.tsx
@@ -14,15 +14,15 @@
 import type { MockedResponse } from "@apollo/client/testing";
 import { MockedProvider } from "@apollo/client/testing/react";
 import { render, screen, waitFor } from "@testing-library/react";
-import { NextIntlClientProvider } from "next-intl";
-import enMessages from "../../../messages/en.json";
 import userEvent from "@testing-library/user-event";
+import { NextIntlClientProvider } from "next-intl";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MyCardgroupsConnectionDocument } from "@/generated/graphql";
 import {
   type ApolloMockLeakSpyResult,
   installApolloMockLeakSpy,
 } from "../../../__tests__/utils/mock-apollo-paginated";
+import enMessages from "../../../messages/en.json";
 import CardgroupPickerSheet from "./cardgroup-picker-sheet";
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/components/cardgroups/cardgroup-picker-sheet.test.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-picker-sheet.test.tsx
@@ -14,6 +14,8 @@
 import type { MockedResponse } from "@apollo/client/testing";
 import { MockedProvider } from "@apollo/client/testing/react";
 import { render, screen, waitFor } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import enMessages from "../../../messages/en.json";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MyCardgroupsConnectionDocument } from "@/generated/graphql";
@@ -107,15 +109,17 @@ function renderSheet({
   const onSelect = vi.fn();
 
   render(
-    <MockedProvider mocks={mocks}>
-      <CardgroupPickerSheet
-        open={open}
-        onOpenChange={onOpenChange}
-        selectedId={selectedId}
-        onSelect={onSelect}
-        createReturnTo={createReturnTo}
-      />
-    </MockedProvider>,
+    <NextIntlClientProvider locale="en" messages={enMessages} timeZone="UTC">
+      <MockedProvider mocks={mocks}>
+        <CardgroupPickerSheet
+          open={open}
+          onOpenChange={onOpenChange}
+          selectedId={selectedId}
+          onSelect={onSelect}
+          createReturnTo={createReturnTo}
+        />
+      </MockedProvider>
+    </NextIntlClientProvider>,
   );
 
   return { onOpenChange, onSelect };

--- a/frontend/src/components/cardgroups/cardgroup-picker-sheet.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-picker-sheet.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/components/ui/sheet";
 import { MyCardgroupsConnectionDocument } from "@/generated/graphql";
 import { cn } from "@/lib/utils";
+import { useTranslations } from "next-intl";
 
 type Props = {
   open: boolean;
@@ -51,6 +52,9 @@ export default function CardgroupPickerSheet({
     fetchPolicy: "cache-and-network",
   });
 
+  const t = useTranslations("Cardgroups");
+  const tCommon = useTranslations("Common");
+
   const rawConnection = data?.myCardgroupsConnection;
   if (data && rawConnection === null) {
     console.warn(
@@ -71,17 +75,17 @@ export default function CardgroupPickerSheet({
         className="mx-auto max-h-[70vh] w-full max-w-lg overflow-y-auto rounded-t-xl pb-safe"
       >
         <SheetHeader className="mb-4">
-          <SheetTitle>Select cardgroup</SheetTitle>
+          <SheetTitle>{t("pickerTitle")}</SheetTitle>
           <SheetDescription className="sr-only">
             Choose the cardgroup for this card.
           </SheetDescription>
         </SheetHeader>
 
-        {loading && <p className="py-6 text-center text-sm text-muted-foreground">Loading…</p>}
+        {loading && <p className="py-6 text-center text-sm text-muted-foreground">{t("pickerLoading")}</p>}
 
         {!loading && error && (
           <div className="flex flex-col items-center gap-3 py-6 text-center">
-            <p className="text-sm text-destructive">Failed to load cardgroups</p>
+            <p className="text-sm text-destructive">{t("pickerFailed")}</p>
             <Button
               variant="outline"
               size="sm"
@@ -94,7 +98,7 @@ export default function CardgroupPickerSheet({
                 });
               }}
             >
-              Retry
+              {tCommon("retry")}
             </Button>
           </div>
         )}
@@ -103,7 +107,7 @@ export default function CardgroupPickerSheet({
           <>
             {cardgroups.length === 0 ? (
               <p className="py-6 text-center text-sm text-muted-foreground">
-                You don&apos;t have any cardgroups yet.
+                {t("pickerNoCardgroups")}
               </p>
             ) : (
               <ul className="space-y-1">
@@ -145,7 +149,7 @@ export default function CardgroupPickerSheet({
                 className="flex w-full items-center gap-2 rounded-md px-3 py-3 text-sm text-brand-primary hover:bg-accent active:bg-accent transition-colors"
               >
                 <Plus className="h-4 w-4" aria-hidden="true" />
-                Create new cardgroup…
+                {t("createNewCardgroup")}
               </Link>
             </div>
           </>

--- a/frontend/src/components/cardgroups/cardgroup-picker-sheet.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-picker-sheet.tsx
@@ -3,6 +3,7 @@
 import { useQuery } from "@apollo/client/react";
 import { Check, Plus } from "lucide-react";
 import Link from "next/link";
+import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
 import {
   Sheet,
@@ -13,7 +14,6 @@ import {
 } from "@/components/ui/sheet";
 import { MyCardgroupsConnectionDocument } from "@/generated/graphql";
 import { cn } from "@/lib/utils";
-import { useTranslations } from "next-intl";
 
 type Props = {
   open: boolean;
@@ -81,7 +81,9 @@ export default function CardgroupPickerSheet({
           </SheetDescription>
         </SheetHeader>
 
-        {loading && <p className="py-6 text-center text-sm text-muted-foreground">{t("pickerLoading")}</p>}
+        {loading && (
+          <p className="py-6 text-center text-sm text-muted-foreground">{t("pickerLoading")}</p>
+        )}
 
         {!loading && error && (
           <div className="flex flex-col items-center gap-3 py-6 text-center">

--- a/frontend/src/components/cardgroups/cardgroup-picker-sheet.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-picker-sheet.tsx
@@ -73,6 +73,7 @@ export default function CardgroupPickerSheet({
       <SheetContent
         side="bottom"
         className="mx-auto max-h-[70vh] w-full max-w-lg overflow-y-auto rounded-t-xl pb-safe"
+        data-testid="cardgroup-picker-dialog"
       >
         <SheetHeader className="mb-4">
           <SheetTitle>{t("pickerTitle")}</SheetTitle>

--- a/frontend/src/components/cardgroups/cardgroup-rename-form.test.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-rename-form.test.tsx
@@ -4,8 +4,8 @@ import { MockedProvider } from "@apollo/client/testing/react";
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { renderWithIntl } from "@/test/render-with-intl";
 import { UpdateCardgroupDocument } from "@/generated/graphql";
+import { renderWithIntl } from "@/test/render-with-intl";
 import { CardgroupRenameForm } from "./cardgroup-rename-form";
 
 const mockRefresh = vi.fn();

--- a/frontend/src/components/cardgroups/cardgroup-rename-form.test.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-rename-form.test.tsx
@@ -1,9 +1,10 @@
 // @vitest-environment jsdom
 import type { MockedResponse } from "@apollo/client/testing";
 import { MockedProvider } from "@apollo/client/testing/react";
-import { render, screen, waitFor } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { renderWithIntl } from "@/test/render-with-intl";
 import { UpdateCardgroupDocument } from "@/generated/graphql";
 import { CardgroupRenameForm } from "./cardgroup-rename-form";
 
@@ -24,7 +25,7 @@ function makeUpdateMock(
 
 function renderForm(mocks: MockedResponse[] = []) {
   const onSaved = vi.fn();
-  render(
+  renderWithIntl(
     <MockedProvider mocks={mocks}>
       <CardgroupRenameForm cardgroup={CARDGROUP} onSaved={onSaved} />
     </MockedProvider>,

--- a/frontend/src/components/cardgroups/cardgroups-toolbar.tsx
+++ b/frontend/src/components/cardgroups/cardgroups-toolbar.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useTranslations } from "next-intl";
+
 interface CardgroupsToolbarProps {
   searchInput: string;
   onSearchInputChange: (value: string) => void;
@@ -10,15 +12,17 @@ interface CardgroupsToolbarProps {
  * Renders a search input that filters cardgroups by name (case-insensitive).
  */
 export function CardgroupsToolbar({ searchInput, onSearchInputChange }: CardgroupsToolbarProps) {
+  const t = useTranslations("Cardgroups");
+
   return (
     <div className="mb-6">
       <input
         type="search"
-        placeholder="Filter cardgroups..."
+        placeholder={t("filterPlaceholder")}
         value={searchInput}
         onChange={(e) => onSearchInputChange(e.target.value)}
         className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-        aria-label="Filter cardgroups"
+        aria-label={t("filterAriaLabel")}
       />
     </div>
   );

--- a/frontend/src/components/learn/swipe-card-stack.test.tsx
+++ b/frontend/src/components/learn/swipe-card-stack.test.tsx
@@ -1,8 +1,8 @@
 // @vitest-environment jsdom
 import { act, fireEvent, screen } from "@testing-library/react";
-import { renderWithIntl } from "@/test/render-with-intl";
 import { createRef } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { renderWithIntl } from "@/test/render-with-intl";
 import type { SwipeCardData } from "./swipe-card";
 import type { SwipeCardStackHandle } from "./swipe-card-stack";
 import { SwipeCardStack } from "./swipe-card-stack";

--- a/frontend/src/components/learn/swipe-card-stack.test.tsx
+++ b/frontend/src/components/learn/swipe-card-stack.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
-import { act, fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, screen } from "@testing-library/react";
+import { renderWithIntl } from "@/test/render-with-intl";
 import { createRef } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { SwipeCardData } from "./swipe-card";
@@ -132,25 +133,25 @@ describe("SwipeCardStack — Session-complete count line", () => {
   };
 
   it("renders Session-complete heading and no count line when completedCount is undefined", () => {
-    render(<SwipeCardStack {...baseProps} />);
+    renderWithIntl(<SwipeCardStack {...baseProps} />);
     expect(screen.getByRole("heading", { name: "Session complete" })).toBeInTheDocument();
     expect(screen.queryByText(/You reviewed/)).not.toBeInTheDocument();
   });
 
   it("renders Session-complete heading and no count line when completedCount is 0", () => {
-    render(<SwipeCardStack {...baseProps} completedCount={0} />);
+    renderWithIntl(<SwipeCardStack {...baseProps} completedCount={0} />);
     expect(screen.getByRole("heading", { name: "Session complete" })).toBeInTheDocument();
     expect(screen.queryByText(/You reviewed/)).not.toBeInTheDocument();
   });
 
   it("renders singular count line when completedCount is 1", () => {
-    render(<SwipeCardStack {...baseProps} completedCount={1} />);
+    renderWithIntl(<SwipeCardStack {...baseProps} completedCount={1} />);
     expect(screen.getByRole("heading", { name: "Session complete" })).toBeInTheDocument();
     expect(screen.getByText("You reviewed 1 card in this batch.")).toBeInTheDocument();
   });
 
   it("renders plural count line when completedCount is 2", () => {
-    render(<SwipeCardStack {...baseProps} completedCount={2} />);
+    renderWithIntl(<SwipeCardStack {...baseProps} completedCount={2} />);
     expect(screen.getByRole("heading", { name: "Session complete" })).toBeInTheDocument();
     expect(screen.getByText("You reviewed 2 cards in this batch.")).toBeInTheDocument();
   });
@@ -166,7 +167,7 @@ describe("SwipeCardStack — keydown listener stability (activeCardRef)", () => 
     const removeSpy = vi.spyOn(window, "removeEventListener");
 
     const onCardSwiped = vi.fn();
-    const { rerender, unmount } = render(
+    const { rerender, unmount } = renderWithIntl(
       <SwipeCardStack cards={[cardA, cardB]} onCardSwiped={onCardSwiped} />,
     );
 
@@ -191,7 +192,7 @@ describe("SwipeCardStack — keydown listener stability (activeCardRef)", () => 
 
   it("fires onCardSwiped with the correct card after activeCard advances", () => {
     const onCardSwiped = vi.fn();
-    const { rerender } = render(
+    const { rerender } = renderWithIntl(
       <SwipeCardStack cards={[cardA, cardB]} onCardSwiped={onCardSwiped} />,
     );
 
@@ -227,7 +228,7 @@ describe("SwipeCardStack — triggerSwipe via imperative ref", () => {
     const onCardSwiped = vi.fn();
     const ref = createRef<SwipeCardStackHandle | null>();
 
-    render(<SwipeCardStack cards={[cardA, cardB]} onCardSwiped={onCardSwiped} ref={ref} />);
+    renderWithIntl(<SwipeCardStack cards={[cardA, cardB]} onCardSwiped={onCardSwiped} ref={ref} />);
 
     act(() => {
       ref.current?.triggerSwipe("right");
@@ -246,7 +247,7 @@ describe("SwipeCardStack — triggerSwipe via imperative ref", () => {
     const onCardSwiped = vi.fn();
     const ref = createRef<SwipeCardStackHandle | null>();
 
-    render(<SwipeCardStack cards={[cardA]} onCardSwiped={onCardSwiped} ref={ref} />);
+    renderWithIntl(<SwipeCardStack cards={[cardA]} onCardSwiped={onCardSwiped} ref={ref} />);
 
     act(() => {
       ref.current?.triggerSwipe("right");
@@ -263,7 +264,7 @@ describe("SwipeCardStack — triggerSwipe via imperative ref", () => {
     const onCardSwiped = vi.fn();
     const ref = createRef<SwipeCardStackHandle | null>();
 
-    const { unmount } = render(
+    const { unmount } = renderWithIntl(
       <SwipeCardStack cards={[cardA]} onCardSwiped={onCardSwiped} ref={ref} />,
     );
 
@@ -289,7 +290,7 @@ describe("SwipeCardStack — triggerSwipe via imperative ref", () => {
     const onCardSwiped = vi.fn();
     const ref = createRef<SwipeCardStackHandle | null>();
 
-    render(<SwipeCardStack cards={[cardA]} onCardSwiped={onCardSwiped} ref={ref} />);
+    renderWithIntl(<SwipeCardStack cards={[cardA]} onCardSwiped={onCardSwiped} ref={ref} />);
 
     act(() => {
       ref.current?.triggerSwipe("right");
@@ -310,7 +311,7 @@ describe("SwipeCardStack — triggerSwipe via imperative ref", () => {
     const onCardSwiped = vi.fn();
     const ref = createRef<SwipeCardStackHandle | null>();
 
-    render(<SwipeCardStack cards={[cardA]} onCardSwiped={onCardSwiped} ref={ref} />);
+    renderWithIntl(<SwipeCardStack cards={[cardA]} onCardSwiped={onCardSwiped} ref={ref} />);
 
     act(() => {
       ref.current?.triggerSwipe("left");
@@ -329,7 +330,7 @@ describe("SwipeCardStack — triggerSwipe via imperative ref", () => {
     const onCardSwiped = vi.fn();
     const ref = createRef<SwipeCardStackHandle | null>();
 
-    render(<SwipeCardStack cards={[cardA]} onCardSwiped={onCardSwiped} ref={ref} />);
+    renderWithIntl(<SwipeCardStack cards={[cardA]} onCardSwiped={onCardSwiped} ref={ref} />);
 
     act(() => {
       ref.current?.triggerSwipe("down");
@@ -348,7 +349,7 @@ describe("SwipeCardStack — triggerSwipe via imperative ref", () => {
     const onCardSwiped = vi.fn();
     const ref = createRef<SwipeCardStackHandle | null>();
 
-    render(<SwipeCardStack cards={[cardA]} onCardSwiped={onCardSwiped} ref={ref} />);
+    renderWithIntl(<SwipeCardStack cards={[cardA]} onCardSwiped={onCardSwiped} ref={ref} />);
 
     const stub = screen.getByTestId("swipe-card-stub");
 
@@ -376,7 +377,7 @@ describe("SwipeCardStack — triggerSwipe via imperative ref", () => {
     const onCardSwiped = vi.fn();
     const ref = createRef<SwipeCardStackHandle | null>();
 
-    render(<SwipeCardStack cards={[]} onCardSwiped={onCardSwiped} ref={ref} />);
+    renderWithIntl(<SwipeCardStack cards={[]} onCardSwiped={onCardSwiped} ref={ref} />);
 
     act(() => {
       // Must not throw even when the deck is empty.
@@ -397,7 +398,7 @@ describe("SwipeCardStack — triggerSwipe via imperative ref", () => {
     const onCardSwiped = vi.fn();
     const ref = createRef<SwipeCardStackHandle | null>();
 
-    render(<SwipeCardStack cards={[cardA]} onCardSwiped={onCardSwiped} ref={ref} />);
+    renderWithIntl(<SwipeCardStack cards={[cardA]} onCardSwiped={onCardSwiped} ref={ref} />);
 
     act(() => {
       ref.current?.triggerSwipe("right");
@@ -425,7 +426,7 @@ describe("SwipeCardStack — gesture-driven overlay via SwipeCard callbacks", ()
   it("shows the overlay when onSwipeProgress fires right/0.5 (pointer-down), hides it when progress resets", () => {
     const onCardSwiped = vi.fn();
 
-    render(<SwipeCardStack cards={[cardA]} onCardSwiped={onCardSwiped} />);
+    renderWithIntl(<SwipeCardStack cards={[cardA]} onCardSwiped={onCardSwiped} />);
 
     const stub = screen.getByTestId("swipe-card-stub");
 
@@ -469,7 +470,7 @@ describe("SwipeCardStack — triggerSwipe with reduced motion", () => {
     const onCardSwiped = vi.fn();
     const ref = createRef<SwipeCardStackHandle | null>();
 
-    render(<SwipeCardStack cards={[cardA]} onCardSwiped={onCardSwiped} ref={ref} />);
+    renderWithIntl(<SwipeCardStack cards={[cardA]} onCardSwiped={onCardSwiped} ref={ref} />);
 
     act(() => {
       ref.current?.triggerSwipe("left");
@@ -501,7 +502,7 @@ describe("SwipeCardStack — keyboard triggers all three directions", () => {
   ] as const)("commits onCardSwiped with direction '%s' → '%s' on spring rest after the key is pressed", (key, expectedDirection) => {
     const onCardSwiped = vi.fn();
 
-    render(<SwipeCardStack cards={[cardA]} onCardSwiped={onCardSwiped} />);
+    renderWithIntl(<SwipeCardStack cards={[cardA]} onCardSwiped={onCardSwiped} />);
 
     fireEvent.keyDown(document, { key });
     // Commit is deferred to the fly-off spring rest — not yet fired.
@@ -524,7 +525,7 @@ describe("SwipeCardStack — overlay state resets on active card change", () => 
     const onCardSwiped = vi.fn();
     const ref = createRef<SwipeCardStackHandle | null>();
 
-    const { rerender } = render(
+    const { rerender } = renderWithIntl(
       <SwipeCardStack cards={[cardA, cardB]} onCardSwiped={onCardSwiped} ref={ref} />,
     );
 

--- a/frontend/src/components/learn/swipe-card-stack.tsx
+++ b/frontend/src/components/learn/swipe-card-stack.tsx
@@ -1,8 +1,8 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import type { RefObject } from "react";
 import { useCallback, useEffect, useImperativeHandle, useRef, useState } from "react";
-import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
 import { useReducedMotion } from "@/lib/use-reduced-motion";
 import { type AnimatedCardHandle, SwipeCard, type SwipeCardData } from "./swipe-card";
@@ -172,9 +172,7 @@ export function SwipeCardStack<TCard extends SwipeCardData>({
     return (
       <div className="flex w-full max-w-xl flex-col items-center rounded-lg border border-dashed border-border p-8 text-center">
         <h1 className="mb-2 text-xl font-semibold">{t("sessionComplete")}</h1>
-        <p className="mb-6 text-sm text-muted-foreground">
-          {t("sessionCompleteMessage")}
-        </p>
+        <p className="mb-6 text-sm text-muted-foreground">{t("sessionCompleteMessage")}</p>
         {completedCount != null && completedCount > 0 && (
           <p className="mb-6 text-sm text-muted-foreground">
             {t("reviewedCount", { count: completedCount })}

--- a/frontend/src/components/learn/swipe-card-stack.tsx
+++ b/frontend/src/components/learn/swipe-card-stack.tsx
@@ -2,6 +2,7 @@
 
 import type { RefObject } from "react";
 import { useCallback, useEffect, useImperativeHandle, useRef, useState } from "react";
+import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
 import { useReducedMotion } from "@/lib/use-reduced-motion";
 import { type AnimatedCardHandle, SwipeCard, type SwipeCardData } from "./swipe-card";
@@ -36,6 +37,7 @@ export function SwipeCardStack<TCard extends SwipeCardData>({
   completedCount,
   ref,
 }: Props<TCard>) {
+  const t = useTranslations("Learn");
   const activeCard = cards[0];
 
   // Drag-progress state ownership stays inside the stack, so the parent
@@ -169,17 +171,17 @@ export function SwipeCardStack<TCard extends SwipeCardData>({
   if (!activeCard) {
     return (
       <div className="flex w-full max-w-xl flex-col items-center rounded-lg border border-dashed border-border p-8 text-center">
-        <h1 className="mb-2 text-xl font-semibold">Session complete</h1>
+        <h1 className="mb-2 text-xl font-semibold">{t("sessionComplete")}</h1>
         <p className="mb-6 text-sm text-muted-foreground">
-          There are no due cards left in this batch.
+          {t("sessionCompleteMessage")}
         </p>
         {completedCount != null && completedCount > 0 && (
           <p className="mb-6 text-sm text-muted-foreground">
-            You reviewed {completedCount} {completedCount === 1 ? "card" : "cards"} in this batch.
+            {t("reviewedCount", { count: completedCount })}
           </p>
         )}
         <Button type="button" variant="outline" onClick={() => window.location.reload()}>
-          Refresh cards
+          {t("refreshCards")}
         </Button>
       </div>
     );

--- a/frontend/src/components/nav/app-shell.tsx
+++ b/frontend/src/components/nav/app-shell.tsx
@@ -1,4 +1,3 @@
-import { getTranslations } from "next-intl/server";
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
 import { GlobalRail } from "./global-rail";
 import { LogoDrawer } from "./logo-drawer";
@@ -22,8 +21,7 @@ interface AppShellProps {
  * added to AppShell itself must remain server-side, so keep the "use client"
  * directive off this file.
  */
-export async function AppShell({ user, isAdmin, children }: AppShellProps) {
-  const t = await getTranslations("Nav");
+export function AppShell({ user, isAdmin, children }: AppShellProps) {
   return (
     <SidebarProvider>
       {/* PC layout (md+): GlobalRail is a direct child of SidebarProvider so the
@@ -33,7 +31,7 @@ export async function AppShell({ user, isAdmin, children }: AppShellProps) {
       <aside
         data-testid="rail-container"
         className="hidden md:flex"
-        aria-label={t("primaryNavigation")}
+        aria-label="Primary navigation"
       >
         <GlobalRail user={user} isAdmin={isAdmin} />
       </aside>

--- a/frontend/src/components/nav/app-shell.tsx
+++ b/frontend/src/components/nav/app-shell.tsx
@@ -1,3 +1,4 @@
+import { getTranslations } from "next-intl/server";
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
 import { GlobalRail } from "./global-rail";
 import { LogoDrawer } from "./logo-drawer";
@@ -21,7 +22,8 @@ interface AppShellProps {
  * added to AppShell itself must remain server-side, so keep the "use client"
  * directive off this file.
  */
-export function AppShell({ user, isAdmin, children }: AppShellProps) {
+export async function AppShell({ user, isAdmin, children }: AppShellProps) {
+  const t = await getTranslations("Nav");
   return (
     <SidebarProvider>
       {/* PC layout (md+): GlobalRail is a direct child of SidebarProvider so the
@@ -31,7 +33,7 @@ export function AppShell({ user, isAdmin, children }: AppShellProps) {
       <aside
         data-testid="rail-container"
         className="hidden md:flex"
-        aria-label="Primary navigation"
+        aria-label={t("primaryNavigation")}
       >
         <GlobalRail user={user} isAdmin={isAdmin} />
       </aside>

--- a/frontend/src/components/nav/mobile-menu-trigger.test.tsx
+++ b/frontend/src/components/nav/mobile-menu-trigger.test.tsx
@@ -1,12 +1,13 @@
 // @vitest-environment jsdom
-import { render, screen } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
+import { renderWithIntl } from "@/test/render-with-intl";
 import { Sheet } from "@/components/ui/sheet";
 import { MobileMenuTrigger } from "./mobile-menu-trigger";
 
 describe("<MobileMenuTrigger>", () => {
   it("S-M1: button has aria-label 'Open menu'", () => {
-    render(
+    renderWithIntl(
       <Sheet>
         <MobileMenuTrigger />
       </Sheet>,
@@ -15,7 +16,7 @@ describe("<MobileMenuTrigger>", () => {
   });
 
   it("S-M2: icon svg is hidden from assistive technology", () => {
-    const { container } = render(
+    const { container } = renderWithIntl(
       <Sheet>
         <MobileMenuTrigger />
       </Sheet>,

--- a/frontend/src/components/nav/mobile-menu-trigger.test.tsx
+++ b/frontend/src/components/nav/mobile-menu-trigger.test.tsx
@@ -1,8 +1,8 @@
 // @vitest-environment jsdom
 import { screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import { renderWithIntl } from "@/test/render-with-intl";
 import { Sheet } from "@/components/ui/sheet";
+import { renderWithIntl } from "@/test/render-with-intl";
 import { MobileMenuTrigger } from "./mobile-menu-trigger";
 
 describe("<MobileMenuTrigger>", () => {

--- a/frontend/src/components/nav/mobile-menu-trigger.tsx
+++ b/frontend/src/components/nav/mobile-menu-trigger.tsx
@@ -1,14 +1,16 @@
 "use client";
 
 import { Menu } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { SheetTrigger } from "@/components/ui/sheet";
 
 export function MobileMenuTrigger() {
+  const t = useTranslations("Nav");
   return (
     <SheetTrigger asChild>
       <button
         type="button"
-        aria-label="Open menu"
+        aria-label={t("openMenu")}
         className="rounded-md p-2 hover:bg-accent focus:outline-none focus:ring-2 focus:ring-ring"
       >
         <Menu className="h-5 w-5" aria-hidden="true" />

--- a/frontend/src/components/ui/form-sheet.test.tsx
+++ b/frontend/src/components/ui/form-sheet.test.tsx
@@ -1,9 +1,10 @@
 // @vitest-environment jsdom
 
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useIsMobile } from "@/hooks/use-mobile";
+import { renderWithIntl } from "@/test/render-with-intl";
 import { FormSheet, useFormSheetClose } from "./form-sheet";
 
 vi.mock("@/hooks/use-mobile", () => ({
@@ -40,7 +41,7 @@ describe("<FormSheet>", () => {
   });
 
   it("renders a desktop right sheet when useIsMobile returns false", () => {
-    render(
+    renderWithIntl(
       <FormSheet open onOpenChange={vi.fn()} title="Edit card">
         <p>Form body</p>
       </FormSheet>,
@@ -58,7 +59,7 @@ describe("<FormSheet>", () => {
     ["md", "sm:max-w-lg"],
     ["lg", "sm:max-w-2xl"],
   ] as const)("applies the size=%s width to the desktop sheet", (size, expectedClass) => {
-    render(
+    renderWithIntl(
       <FormSheet open onOpenChange={vi.fn()} title="Edit card" size={size}>
         <p>Form body</p>
       </FormSheet>,
@@ -68,7 +69,7 @@ describe("<FormSheet>", () => {
   });
 
   it("defaults to the medium width when size is not provided", () => {
-    render(
+    renderWithIntl(
       <FormSheet open onOpenChange={vi.fn()} title="Edit card">
         <p>Form body</p>
       </FormSheet>,
@@ -78,7 +79,7 @@ describe("<FormSheet>", () => {
   });
 
   it("constrains the desktop sheet body so tall forms can scroll", () => {
-    render(
+    renderWithIntl(
       <FormSheet open onOpenChange={vi.fn()} title="Edit card">
         <div style={{ height: 2000 }}>Tall form</div>
       </FormSheet>,
@@ -90,7 +91,7 @@ describe("<FormSheet>", () => {
   it("renders a mobile drawer dialog when useIsMobile returns true", () => {
     vi.mocked(useIsMobile).mockReturnValue(true);
 
-    render(
+    renderWithIntl(
       <FormSheet open onOpenChange={vi.fn()} title="Add card">
         <p>Mobile body</p>
       </FormSheet>,
@@ -105,7 +106,7 @@ describe("<FormSheet>", () => {
     const user = userEvent.setup();
     const onOpenChange = vi.fn();
 
-    render(
+    renderWithIntl(
       <FormSheet open onOpenChange={onOpenChange} title="Edit card">
         <ContextCancelButton />
       </FormSheet>,
@@ -120,7 +121,7 @@ describe("<FormSheet>", () => {
     const user = userEvent.setup();
     const onOpenChange = vi.fn();
 
-    render(
+    renderWithIntl(
       <FormSheet open onOpenChange={onOpenChange} title="Edit card">
         <p>Form body</p>
       </FormSheet>,
@@ -135,7 +136,7 @@ describe("<FormSheet>", () => {
     const user = userEvent.setup();
     const onOpenChange = vi.fn();
 
-    render(
+    renderWithIntl(
       <FormSheet open onOpenChange={onOpenChange} title="Edit card">
         <p>Form body</p>
       </FormSheet>,
@@ -150,7 +151,7 @@ describe("<FormSheet>", () => {
     const user = userEvent.setup();
     const onOpenChange = vi.fn();
 
-    render(
+    renderWithIntl(
       <FormSheet open onOpenChange={onOpenChange} title="Edit card">
         <p>Form body</p>
       </FormSheet>,
@@ -166,7 +167,7 @@ describe("<FormSheet>", () => {
     const onOpenChange = vi.fn();
     vi.mocked(useIsMobile).mockReturnValue(true);
 
-    render(
+    renderWithIntl(
       <FormSheet open onOpenChange={onOpenChange} title="Add card">
         <p>Mobile body</p>
       </FormSheet>,
@@ -181,7 +182,7 @@ describe("<FormSheet>", () => {
     const onOpenChange = vi.fn();
     vi.mocked(useIsMobile).mockReturnValue(true);
 
-    render(
+    renderWithIntl(
       <FormSheet open onOpenChange={onOpenChange} title="Add card">
         <p>Mobile body</p>
       </FormSheet>,
@@ -231,7 +232,7 @@ describe("<FormSheet>", () => {
     const user = userEvent.setup();
     const onOpenChange = vi.fn();
 
-    render(
+    renderWithIntl(
       <FormSheet open onOpenChange={onOpenChange} title="Edit card" confirmOnDismiss>
         <ContextCancelButton />
       </FormSheet>,
@@ -247,7 +248,7 @@ describe("<FormSheet>", () => {
     const user = userEvent.setup();
     const onOpenChange = vi.fn();
 
-    render(
+    renderWithIntl(
       <FormSheet open onOpenChange={onOpenChange} title="Add card" dirty confirmOnDismiss>
         <ContextCancelButton />
       </FormSheet>,
@@ -264,7 +265,7 @@ describe("<FormSheet>", () => {
     const user = userEvent.setup();
     const onOpenChange = vi.fn();
 
-    render(
+    renderWithIntl(
       <FormSheet open onOpenChange={onOpenChange} title="Add card" dirty confirmOnDismiss>
         <ContextCancelButton />
       </FormSheet>,
@@ -284,7 +285,7 @@ describe("<FormSheet>", () => {
     const user = userEvent.setup();
     const onOpenChange = vi.fn();
 
-    render(
+    renderWithIntl(
       <FormSheet open onOpenChange={onOpenChange} title="Add card" dirty confirmOnDismiss>
         <ContextCancelButton />
       </FormSheet>,
@@ -300,7 +301,7 @@ describe("<FormSheet>", () => {
     const user = userEvent.setup();
     const onOpenChange = vi.fn();
 
-    const { rerender } = render(
+    const { rerender } = renderWithIntl(
       <FormSheet open onOpenChange={onOpenChange} title="Add card" dirty confirmOnDismiss>
         <ContextCancelButton />
       </FormSheet>,
@@ -331,7 +332,7 @@ describe("<FormSheet>", () => {
     const user = userEvent.setup();
     const onOpenChange = vi.fn();
 
-    const { rerender } = render(
+    const { rerender } = renderWithIntl(
       <FormSheet open onOpenChange={onOpenChange} title="Add card" dirty confirmOnDismiss>
         <ContextCancelButton />
       </FormSheet>,
@@ -355,7 +356,7 @@ describe("<FormSheet>", () => {
     const user = userEvent.setup();
     const onOpenChange = vi.fn();
 
-    render(
+    renderWithIntl(
       <FormSheet open onOpenChange={onOpenChange} title="Edit card" submitting>
         <ContextCancelButton />
       </FormSheet>,
@@ -370,7 +371,7 @@ describe("<FormSheet>", () => {
   it("constrains the mobile drawer body so tall forms can scroll", () => {
     vi.mocked(useIsMobile).mockReturnValue(true);
 
-    render(
+    renderWithIntl(
       <FormSheet open onOpenChange={vi.fn()} title="Add card">
         <div style={{ height: 2000 }}>Tall form</div>
       </FormSheet>,
@@ -383,7 +384,7 @@ describe("<FormSheet>", () => {
   });
 
   it("renders a string-title desktop sheet with accessible description '<title> form'", () => {
-    render(
+    renderWithIntl(
       <FormSheet open onOpenChange={vi.fn()} title="Edit card">
         <p>Body</p>
       </FormSheet>,
@@ -401,7 +402,7 @@ describe("<FormSheet>", () => {
 
     it("exposes both verb and destination in the heading textContent", () => {
       const cardgroupName = "Yasu Cardgroup";
-      render(
+      renderWithIntl(
         <FormSheet
           open
           onOpenChange={vi.fn()}
@@ -431,7 +432,7 @@ describe("<FormSheet>", () => {
 
     it("title span carries truncation classes and tooltip attribute", () => {
       const cardgroupName = "A Very Long Cardgroup Name That Should Truncate";
-      render(
+      renderWithIntl(
         <FormSheet
           open
           onOpenChange={vi.fn()}
@@ -457,7 +458,7 @@ describe("<FormSheet>", () => {
     });
 
     it("a11yDescription falls back to 'Form' when title is a ReactNode and no description is provided", () => {
-      render(
+      renderWithIntl(
         <FormSheet open onOpenChange={vi.fn()} title={<span>Some ReactNode title</span>}>
           <p>Body</p>
         </FormSheet>,

--- a/frontend/src/components/ui/form-sheet.tsx
+++ b/frontend/src/components/ui/form-sheet.tsx
@@ -25,6 +25,7 @@ import {
   SheetHeader,
   SheetTitle,
 } from "@/components/ui/sheet";
+import { useTranslations } from "next-intl";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { cn } from "@/lib/utils";
 
@@ -73,6 +74,7 @@ function FormSheet({
   size = "md",
   children,
 }: FormSheetProps) {
+  const t = useTranslations("Common");
   const a11yDescription = description ?? (typeof title === "string" ? `${title} form` : "Form");
   const isMobile = useIsMobile();
   const [confirmOpen, setConfirmOpen] = React.useState(false);
@@ -160,13 +162,13 @@ function FormSheet({
       <AlertDialog open={confirmOpen} onOpenChange={setConfirmOpen}>
         <AlertDialogContent className="z-[60]">
           <AlertDialogHeader>
-            <AlertDialogTitle>Discard your changes?</AlertDialogTitle>
+            <AlertDialogTitle>{t("discardChanges")}</AlertDialogTitle>
             <AlertDialogDescription>{confirmMessage}</AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel>Keep editing</AlertDialogCancel>
+            <AlertDialogCancel>{t("keepEditing")}</AlertDialogCancel>
             <AlertDialogAction disabled={submitting} onClick={discard}>
-              Discard
+              {t("discard")}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/frontend/src/components/ui/form-sheet.tsx
+++ b/frontend/src/components/ui/form-sheet.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import * as React from "react";
 import {
   AlertDialog,
@@ -25,7 +26,6 @@ import {
   SheetHeader,
   SheetTitle,
 } from "@/components/ui/sheet";
-import { useTranslations } from "next-intl";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { cn } from "@/lib/utils";
 


### PR DESCRIPTION
## Summary

Wave 4 (final) of the frontend i18n work — verification gates and straggler extraction.

- **Straggler sweep**: extracts remaining hard-coded UI strings across `Common`, `Cardgroups`, `Cards`, `Learn`, `Admin`, and `Nav` namespaces (toolbar, picker sheet, header, cards section, card form, role form, swipe stack, nav triggers)
- **Catalog parity script**: adds `frontend/scripts/i18n-parity.mjs` + `pnpm --filter frontend i18n:parity` to assert `en.json` / `ja.json` carry identical flattened key sets (224 keys, exits 0)
- **e2e language round-trip**: `frontend/e2e/i18n-language-switch.spec.ts` — login → `/profile` → select Japanese → assert `lang=ja` + `カードグループ` nav → switch back → `lang=en` + `Cardgroups`
- **Docs**: extends `docs/frontend/i18n.md` with parity-script usage, e2e spec reference, and the Suspense-fallback skeleton constraint

## Verification

- `pnpm --filter frontend typecheck` ✓ (no errors)
- `pnpm --filter frontend lint` ✓ (no errors)
- `pnpm --filter frontend test` ✓ (1135/1135)
- CJK grep → `CLEAN`
- `node frontend/scripts/i18n-parity.mjs` → `Parity OK — 224 keys in both catalogs.`

## Known exceptions (documented in i18n.md)

- `global-error.tsx` — outside `NextIntlClientProvider` (renders in place of root layout)
- Skeleton `aria-label` values — Suspense `fallback` must render synchronously
- `app-shell.tsx` `aria-label="Primary navigation"` — async RSC → same Suspense constraint
- `opengraph-image.tsx` — OG brand voice, English by design
- `sidebar.tsx` / `flamingo-mark.tsx` — shadcn/ui internals / brand name

Closes #353
