### PR TITLE
chore: add .worktreeinclude for worktree env file sync

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,12 @@
+# Files copied from the main repo into a new worktree on creation.
+# Used by the /worktree slash command (see ~/.claude/commands/worktree.md).
+# One path per line, relative to the repo root. Lines starting with # are ignored.
+
+# Root env — Google OAuth and shared secrets consumed by the local Supabase auth server
+.env
+
+# Frontend env — Supabase URL + anon key overlaid by `make sync-env`
+frontend/.env.local
+
+# Backend env — DB connection and server config overlaid by `make sync-env`
+backend/.env.local


### PR DESCRIPTION
## Summary

Adds `.worktreeinclude` so the `/worktree` slash command knows which secret env files to copy from the main repo into a freshly-created worktree. Without this file the command falls back to a glob that misses `backend/.env.local` and copies `frontend/.env.local` with placeholder values only.

- `.env` (root) — Google OAuth credentials consumed by the local Supabase auth server
- `frontend/.env.local` — Supabase URL + anon key; worktree previously had `replaced_by_sync_env` placeholders
- `backend/.env.local` — DB connection string and server config; absent from worktrees entirely

## Test plan

- [ ] Run `/worktree <branch>` and confirm `.env`, `frontend/.env.local`, and `backend/.env.local` are present in the new worktree with real values (not placeholder strings)
- [ ] Confirm `.worktreeinclude` is **not** gitignored and shows up in `git ls-files .worktreeinclude`
