### PR TITLE
fix(landing): skip Vercel preview builds on gh-pages

### DIFF
--- a/.github/workflows/landing.yml
+++ b/.github/workflows/landing.yml
@@ -5,8 +5,11 @@ name: landing
 # so both coexist on the same Pages site:
 #   https://yasuflatland-lf.github.io/flamingo-armond/           <- landing (this workflow)
 #   https://yasuflatland-lf.github.io/flamingo-armond/er-chart/  <- ER chart
-# clean-exclude below preserves er-chart/ (and the legacy vercel.json) when this
-# workflow cleans the gh-pages root.
+# site/ is the single source of truth for the gh-pages root, including
+# site/vercel.json (ignoreCommand "exit 0"), which tells Vercel to skip building
+# the gh-pages branch (it carries only static Pages assets, not the Next.js app).
+# clean-exclude below preserves er-chart/ (owned by er-chart.yml, not by site/)
+# when this workflow cleans the gh-pages root.
 
 on:
   push:
@@ -51,4 +54,3 @@ jobs:
           clean: true
           clean-exclude: |
             er-chart
-            vercel.json

--- a/site/vercel.json
+++ b/site/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "ignoreCommand": "exit 0"
+}


### PR DESCRIPTION
## Summary

- Stops Vercel from creating (and failing) a Preview deployment on every push to the auto-generated `gh-pages` branch — that branch carries only the static Pages assets (`site/` content + `er-chart/`), not the Next.js app, so the build had nothing to build
- Root cause: the `gh-pages` `vercel.json` meant to skip those builds had its exit code inverted — `{ "ignoreCommand": "exit 1" }`. Per the [Vercel docs](https://vercel.com/docs/project-configuration/vercel-json#ignorecommand), `exit 1` means *continue the build* and `exit 0` means *ignore the build*, so the file told Vercel to **always** build `gh-pages`
- That `vercel.json` also lived only on the `gh-pages` branch (a "legacy" file preserved via `clean-exclude`), with no source-controlled origin on `main`
- Fix moves the file under source control in `site/` with the corrected `exit 0`, so the `landing` workflow deploys it to the `gh-pages` root as part of the normal publish flow

No related issue — fixes a deploy regression introduced alongside the GitHub Pages landing setup (#382).

## Changes

### Skip Vercel builds on gh-pages (`site/vercel.json`)

- New source-controlled `site/vercel.json` = `{ "ignoreCommand": "exit 0" }` — Vercel reads it from the pushed `gh-pages` commit and skips the build

### CI (`.github/workflows/landing.yml`)

- Drop `vercel.json` from `clean-exclude`; `site/` is now the single source of truth for the `gh-pages` root, so the deploy action syncs the corrected file rather than preserving the legacy one
- `clean-exclude` now lists only `er-chart/` (owned by `er-chart.yml`, never present in `site/`)
- Refresh the header comment to document that `site/vercel.json` controls the Vercel skip

## Verification

- After merge: the `landing` workflow runs (this PR touches `site/**` and `.github/workflows/landing.yml`, both trigger paths) and redeploys `site/` to the `gh-pages` root, so the next `gh-pages` commit carries `ignoreCommand: exit 0`
- The Preview deployment for that `gh-pages` commit shows **skipped/canceled**, not failed: `gh api repos/yasuflatland-lf/flamingo-armond/deployments --jq '.[] | select(.environment=="Preview")'` then check the latest status `state`
- `git show gh-pages:vercel.json` resolves to `{ "ignoreCommand": "exit 0" }` once the workflow has run

## Test plan

- [ ] `landing` workflow run is green on the merge commit
- [ ] The `gh-pages` Vercel Preview deployment after merge is skipped/canceled (no red ✕ on the Preview environment)
- [ ] `https://yasuflatland-lf.github.io/flamingo-armond/` still renders the landing page
- [ ] `https://yasuflatland-lf.github.io/flamingo-armond/er-chart/` is unchanged (clean-exclude still protects it)
