### PR TITLE
fix: opaque mobile landing menu and batch import icon

### DIFF
--- a/frontend/src/components/cardgroups/cardgroup-header.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-header.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMutation } from "@apollo/client/react";
-import { MoreHorizontal, Pencil, Trash2 } from "lucide-react";
+import { Import, MoreHorizontal, Pencil, Trash2 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { useCallback, useState } from "react";
@@ -121,6 +121,7 @@ export function CardgroupHeader({ cardgroup, totalCount, onBatchImport }: Props)
                   {/* Batch import is shown here for mobile users;
                       the desktop split button (hidden md:inline-flex) covers desktop. */}
                   <DropdownMenuItem onSelect={onBatchImport} className="gap-2 md:hidden">
+                    <Import className="h-4 w-4" />
                     {t("batchImport")}
                   </DropdownMenuItem>
                 </>

--- a/site/index.html
+++ b/site/index.html
@@ -325,6 +325,13 @@
       box-shadow: 0 2px 10px rgba(255, 95, 79, 0.18);
     }
 
+    /* Mobile dropdown menu: force an opaque surface so page content never
+       bleeds through. Plain CSS (not the `bg-white` utility) so the fill is
+       independent of Tailwind's runtime JIT timing and opacity tokens. */
+    .mobile-menu-panel {
+      background-color: #fff;
+    }
+
   
     /* Senior spacing pass: golden-ratio / Fibonacci refinement */
     .hero-title-jp {
@@ -2213,7 +2220,7 @@
           </button>
 
           {open && (
-            <div className="absolute left-4 right-4 top-16 z-50 rounded-3xl border border-gray-100 bg-white p-4 shadow-float md:hidden">
+            <div className="mobile-menu-panel absolute left-4 right-4 top-16 z-50 rounded-3xl border border-gray-100 p-4 shadow-float md:hidden">
               <div className="grid gap-2">
                 {navItems.map((item) => (
                   <a key={item} href="#" className="rounded-2xl px-4 py-3 text-sm font-semibold text-gray-800 hover:bg-gray-50">


### PR DESCRIPTION
## Summary

- Two small mobile UI fixes — one on the static GitHub Pages landing page, one in the card app.
- **Landing dropdown was see-through.** On mobile, the hamburger menu panel let the hero copy and CTA buttons bleed through it. The panel relied on the Tailwind Play CDN `bg-white` utility, which can render translucent depending on runtime JIT timing / `--tw-bg-opacity` resolution; it now uses a plain-CSS opaque fill independent of Tailwind.
- **Batch-import menu item had no icon.** In the card group `...` options menu, "Rename" (`Pencil`) and "Delete" (`Trash2`) carried icons but "Batch import" did not, breaking the row's visual rhythm. Added the lucide `Import` glyph to match.

No related issue — both surfaced from user-reported mobile screenshots.

## Changes

### Opaque mobile landing menu (`site/index.html`)

- New plain-CSS rule `.mobile-menu-panel { background-color: #fff; }` in the `<style>` block.
- The mobile dropdown `<div>` swaps the `bg-white` utility for `mobile-menu-panel`, so the fill no longer depends on the Tailwind CDN's JIT timing or on `--tw-bg-opacity` inheritance from the `bg-white/95` header. No competing white-background rule exists, so CSS source order is irrelevant.

### Batch import menu icon (`frontend/src/components/cardgroups/cardgroup-header.tsx`)

- Import `Import` from `lucide-react` (verified present in the installed `1.17.0`).
- Render `<Import className="h-4 w-4" />` in the mobile `batchImport` `DropdownMenuItem`, matching the sibling `Pencil` / `Trash2` styling.
- The desktop split-button menu (`cardgroup-cards-section.tsx`) is intentionally left untouched — both of its items are iconless, so it is already internally consistent.

## Verification

- Landing: open the LP on a viewport < 768px and tap ☰ — the dropdown is solid white; hero copy/buttons no longer show through. DOM: the panel `<div>` carries `mobile-menu-panel` and no `bg-white`.
- Card app: open a card group on mobile, open the `...` menu — "Batch import" shows a lucide `Import` `<svg>` inside the `menuitem`, aligned with Rename/Delete.
- `pnpm --filter frontend typecheck` ✓ (full tree, 0 errors)
- `biome check --error-on-warnings` ✓ on the changed component (0 findings)
- `cardgroup-header.test.tsx` ✓ (11/11) — icon adds no accessible text, so the existing `getByRole("menuitem", { name: ... })` queries still resolve

## Test plan

- [ ] Landing: mobile ☰ menu renders an opaque panel with no content bleed-through
- [ ] Landing: `/er-chart/` and the desktop nav/header are unaffected
- [ ] Card app: mobile `...` menu shows an icon on "Batch import" matching Rename / Delete
- [ ] `pnpm --filter frontend typecheck && pnpm --filter frontend lint && pnpm --filter frontend test` all green
