### PR TITLE
fix(landing): stack mobile header above page so dropdown stops bleeding through

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -2190,7 +2190,7 @@
       const [open, setOpen] = useState(false);
 
       return (
-        <header className="page-shell flex h-[56px] items-center justify-between bg-white/95 backdrop-blur">
+        <header className="page-shell relative z-50 flex h-[56px] items-center justify-between bg-white/95 backdrop-blur">
           <Logo />
 
           <nav className="hidden items-center gap-x-[var(--fib-1)] lg:flex">


### PR DESCRIPTION
## Summary

- The mobile landing dropdown still let the hero copy and CTA buttons bleed through it, even after the prior opaque-fill fix (#386).
- Root cause was **not** the panel's background color — it was already `background-color: #fff`, `opacity: 1` — but **stacking order**. `<header>` is `position: static` with `backdrop-filter: blur(8px)`, while `<main className="page-shell isolate">` (`isolation: isolate`) forms a sibling stacking context later in the DOM. Both paint at the non-positioned layer, so the later `main` (the hero) painted on top of the whole header — including its `z-50` menu panel.
- Fix promotes the header's stacking context above page content by making it positioned (`relative z-50`). The header is already at the top of the flow, so `position: relative` adds no layout shift; it only raises the paint layer.

No related issue — surfaced from a user mobile screenshot. This is the real fix for the bleed-through that #386 only masked: the opaque fill was necessary but insufficient on its own.

## Changes

### Stacking fix (`site/index.html`)

- The `<header>` className gains `relative z-50`. It already forms a stacking context via `backdrop-filter`, but as a non-positioned (`static`) box it painted in DOM order beneath `<main className="page-shell isolate">`. Making it positioned with a positive `z-index` promotes the whole header — and the `z-50` mobile dropdown inside it — above `main`/the hero.
- The existing `.mobile-menu-panel { background-color: #fff; }` rule (from #386) is intentionally kept. Once the panel paints above `main`, it still needs an opaque fill so the hero does not show through the panel's own bounds. Background color and z-index are two halves of the same fix.

## Verification

- Open `site/index.html` at a viewport `< 768px` and tap ☰ — the dropdown is solid white and nothing behind it shows through.
- Stacking check with the menu open: `document.elementFromPoint(x, y)` at a point inside `.mobile-menu-panel` returns a menu node (the `<a>` link or the button row `div`), **not** a `.hero-title-word` span. Before the fix it returned the hero title.
- Confirmed via headless Chromium (Playwright, mobile viewport): panel computes `background-color: rgb(255, 255, 255)`, `opacity: 1`, and all three probe points inside the panel resolve to menu descendants.

## Test plan

- [ ] Mobile (`< 768px`) ☰ menu renders an opaque panel; hero copy / CTA no longer bleed through
- [ ] Desktop header and nav are unaffected (header renders in place; `relative z-50` adds no layout shift)
- [ ] `/er-chart/` and the rest of the landing page render unchanged
- [ ] With the menu open, `elementFromPoint` inside the panel returns a menu node, not the hero title
