### PR TITLE
fix(landing): point mobile menu links and final CTA at real targets

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -2110,6 +2110,7 @@
     const { useState } = React;
 
     const navItems = ['使い方', '英単語整理', '機能', '料金'];
+    const navHrefs = ['#review-flow', '#card-groups', '#features', '#pricing'];
 
     const logos = [
       'IELTS', 'TOEFL', 'Duolingo', 'Anki', '教室', 'Notion', 'Quizlet', 'Memrise', 'Teams'
@@ -2197,7 +2198,7 @@
             {navItems.map((item, index) => (
               <a
                 key={item}
-                href={['#review-flow', '#card-groups', '#features', '#pricing'][index]}
+                href={navHrefs[index]}
                 className="inline-flex h-9 items-center justify-center rounded-md px-[var(--fib-4)] py-2 text-[13px] font-medium text-gray-800 transition-colors hover:bg-gray-50"
               >
                 {item}
@@ -2222,8 +2223,8 @@
           {open && (
             <div className="mobile-menu-panel absolute left-4 right-4 top-16 z-50 rounded-3xl border border-gray-100 p-4 shadow-float md:hidden">
               <div className="grid gap-2">
-                {navItems.map((item) => (
-                  <a key={item} href="#" className="rounded-2xl px-4 py-3 text-sm font-semibold text-gray-800 hover:bg-gray-50">
+                {navItems.map((item, index) => (
+                  <a key={item} href={navHrefs[index]} onClick={() => setOpen(false)} className="rounded-2xl px-4 py-3 text-sm font-semibold text-gray-800 hover:bg-gray-50">
                     {item}
                   </a>
                 ))}
@@ -2567,7 +2568,7 @@
                 次に復習すべき単語は、Flamingo Armondがわかりやすく整理します。
               </p>
               <div className="mt-[var(--fib-6)] flex justify-center">
-                <Button href="#">無料で始める</Button>
+                <Button href="https://flamingo-armond-frontend.vercel.app/">無料で始める</Button>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary

- On the mobile landing page, the hamburger (☰) dropdown nav links did nothing — every item (使い方 / 英単語整理 / 機能 / 料金) was rendered with `href="#"`, so tapping one only scrolled to the top of the page instead of its section.
- Root cause was **desktop/mobile drift**: the desktop `<nav>` already mapped each item to its in-page anchor (`#review-flow` / `#card-groups` / `#features` / `#pricing`), but the mobile menu's separate `navItems.map(...)` was left at the placeholder `href="#"`. The two renders of the same nav had diverged.
- While fixing it, found the same defect on the **final CTA** ("無料で始める") at the bottom of the page — it used `href="#"` while every other CTA points at the app URL.
- The anchor list is now a single `navHrefs` constant shared by both nav renders, so the desktop and mobile menus can no longer drift apart.

No related issue — surfaced from a user mobile screenshot.

## Changes

### Mobile menu nav links (`site/index.html`)

- New `navHrefs = ['#review-flow', '#card-groups', '#features', '#pricing']` constant declared next to `navItems`, used as the single source of truth for both the desktop `<nav>` and the mobile dropdown.
- The desktop `<nav>` swaps its inline anchor array for `navHrefs[index]` (behavior unchanged — same anchors).
- The mobile dropdown `navItems.map(...)` now takes `index` and uses `href={navHrefs[index]}` instead of `href="#"`, and gains `onClick={() => setOpen(false)}` so the panel closes on tap (otherwise it would stay open over the section just jumped to).

### Final CTA target (`site/index.html`)

- The bottom `#cta` section's "無料で始める" `<Button>` swaps `href="#"` for `https://flamingo-armond-frontend.vercel.app/`, matching the header / hero / pricing CTAs.

## Verification

- Headless Chromium (Playwright, 390×780 mobile viewport): open ☰, tap each of the four links — `href` resolves to the expected anchor, `location.hash` updates to it, the target section node exists in the DOM, and the panel closes after the tap. No console errors.
- Final CTA: the `#cta` "無料で始める" anchor resolves to `https://flamingo-armond-frontend.vercel.app/`.
- The only remaining `href="#"` in the file is the logo (home → top of page), which is correct.

## Test plan

- [ ] Mobile (`< 768px`): open ☰, tap 使い方 / 英単語整理 / 機能 / 料金 — each scrolls to its section and the menu closes
- [ ] Desktop nav still jumps to the same four sections (no regression)
- [ ] Bottom "無料で始める" CTA opens the app (`flamingo-armond-frontend.vercel.app`)
- [ ] Logo still links to the top of the page
