### PR TITLE
fix(login): detect in-app browsers and guide users to a real browser for Google sign-in

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -172,6 +172,10 @@
     "googleCta": "Sign in with your Google account to continue. New here? An account is created on first sign-in.",
     "signInFailed": "Sign-in failed: {error}",
     "googleButton": "Continue with Google",
+    "inAppBrowserWarning": "Google sign-in does not work inside in-app browsers. Open this page in your browser (Safari or Chrome) to sign in.",
+    "openInBrowser": "Open in browser",
+    "copyLink": "Copy page link",
+    "linkCopied": "Copied — paste into Safari or Chrome",
     "terms": "By signing in, you agree to our <terms>Terms of Service</terms> and <privacy>Privacy Policy</privacy>.",
     "tagline": "Remember more, study less."
   },

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -172,6 +172,10 @@
     "googleCta": "Google アカウントでログインして続行してください。初めての方は、初回ログイン時にアカウントが作成されます。",
     "signInFailed": "ログインに失敗しました: {error}",
     "googleButton": "Google で続行",
+    "inAppBrowserWarning": "アプリ内ブラウザでは Google ログインを利用できません。ログインするには、このページを標準ブラウザ（Safari または Chrome）で開いてください。",
+    "openInBrowser": "ブラウザで開く",
+    "copyLink": "ページのリンクをコピー",
+    "linkCopied": "コピーしました。Safari または Chrome に貼り付けてください",
     "terms": "ログインすることで、<terms>利用規約</terms>および<privacy>プライバシーポリシー</privacy>に同意したものとみなされます。",
     "tagline": "少ない学習で、より多く記憶。"
   },

--- a/frontend/src/app/login/in-app-browser-notice.test.tsx
+++ b/frontend/src/app/login/in-app-browser-notice.test.tsx
@@ -1,0 +1,57 @@
+// @vitest-environment jsdom
+import { fireEvent, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { renderWithIntl } from "@/test/render-with-intl";
+import { InAppBrowserNotice } from "./in-app-browser-notice";
+
+const REAL_UA = navigator.userAgent;
+
+function setUserAgent(ua: string) {
+  Object.defineProperty(navigator, "userAgent", { value: ua, configurable: true });
+}
+
+const LINE_UA =
+  "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 Safari/604.1 Line/14.5.0";
+const INSTAGRAM_UA =
+  "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 Instagram 333.0.0.0";
+const SAFARI_UA =
+  "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1";
+
+afterEach(() => {
+  setUserAgent(REAL_UA);
+  vi.restoreAllMocks();
+});
+
+describe("<InAppBrowserNotice>", () => {
+  it("renders nothing in a standalone browser", () => {
+    setUserAgent(SAFARI_UA);
+    renderWithIntl(<InAppBrowserNotice />);
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("warns and offers the external-browser action inside LINE", () => {
+    setUserAgent(LINE_UA);
+    renderWithIntl(<InAppBrowserNotice />);
+
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+    // LINE gets the one-tap escape hatch, not the copy-link fallback.
+    expect(screen.getByRole("button", { name: /open in browser/i })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /copy page link/i })).not.toBeInTheDocument();
+  });
+
+  it("warns and offers a copy-link fallback inside other in-app browsers", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", { value: { writeText }, configurable: true });
+    setUserAgent(INSTAGRAM_UA);
+    renderWithIntl(<InAppBrowserNotice />);
+
+    const copyButton = screen.getByRole("button", { name: /copy page link/i });
+    expect(copyButton).toBeInTheDocument();
+
+    fireEvent.click(copyButton);
+
+    expect(writeText).toHaveBeenCalledWith(window.location.href);
+    // After a successful copy the label confirms the action.
+    expect(await screen.findByText(/paste into safari or chrome/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/login/in-app-browser-notice.tsx
+++ b/frontend/src/app/login/in-app-browser-notice.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { detectInAppBrowser, type InAppBrowser } from "@/lib/in-app-browser";
+
+// LINE honours this query param by reopening the URL in the OS default browser.
+// https://developers.line.biz/en/docs/line-login/using-line-url-scheme/
+const LINE_EXTERNAL_BROWSER_PARAM = "openExternalBrowser";
+
+/**
+ * Advisory banner shown only when the visitor is inside an in-app browser
+ * (LINE, Instagram, Facebook, …), where Google blocks OAuth sign-in with
+ * `Error 403: disallowed_useragent`. It guides the user into the system
+ * browser instead of letting them hit the opaque Google error after tapping
+ * the sign-in button. The sign-in button itself stays enabled so a false
+ * positive never locks anyone out.
+ */
+export function InAppBrowserNotice() {
+  const t = useTranslations("Login");
+  // Start hidden: the server cannot read the user-agent, so detection runs only
+  // after mount. Rendering nothing on the server also avoids a hydration mismatch.
+  const [browser, setBrowser] = useState<InAppBrowser | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    setBrowser(detectInAppBrowser(navigator.userAgent));
+  }, []);
+
+  if (!browser) return null;
+
+  function openInExternalBrowser() {
+    // LINE re-opens the page in the external browser when the flag is present.
+    const url = new URL(window.location.href);
+    url.searchParams.set(LINE_EXTERNAL_BROWSER_PARAM, "1");
+    window.location.href = url.toString();
+  }
+
+  async function copyPageLink() {
+    try {
+      await navigator.clipboard.writeText(window.location.href);
+      setCopied(true);
+    } catch {
+      // Clipboard API may be unavailable (insecure context / denied permission).
+      // The banner text already tells the user how to proceed manually.
+      setCopied(false);
+    }
+  }
+
+  return (
+    <div
+      role="alert"
+      className="flex flex-col gap-3 rounded-lg border border-amber-300 bg-amber-50 p-4 text-sm text-amber-900"
+    >
+      <p className="font-medium leading-snug">{t("inAppBrowserWarning")}</p>
+      {browser === "line" ? (
+        <Button type="button" variant="outline" size="sm" onClick={openInExternalBrowser}>
+          {t("openInBrowser")}
+        </Button>
+      ) : (
+        <Button type="button" variant="outline" size="sm" onClick={copyPageLink}>
+          {copied ? t("linkCopied") : t("copyLink")}
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/app/login/page.test.tsx
+++ b/frontend/src/app/login/page.test.tsx
@@ -18,6 +18,13 @@ vi.mock("./login-button", () => ({
   LoginButton: () => <button type="button">Sign in</button>,
 }));
 
+// InAppBrowserNotice is a client component (useTranslations) that renders
+// nothing in a standalone browser; the broad page test has no NextIntlClient
+// provider, so mock it to null to mirror the standalone-browser DOM.
+vi.mock("./in-app-browser-notice", () => ({
+  InAppBrowserNotice: () => null,
+}));
+
 // next-intl/server — the page resolves the Login namespace via getTranslations.
 // Back the mock with createTranslator + the real en catalog so t()/t.rich()
 // produce the original English copy (and rendered Terms/Privacy links), keeping

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -5,6 +5,7 @@ import { getTranslations } from "next-intl/server";
 import type { ReactNode } from "react";
 import { FlamingoMark } from "@/components/brand/flamingo-mark";
 import { readAuthContext } from "@/lib/supabase/auth-status";
+import { InAppBrowserNotice } from "./in-app-browser-notice";
 import { LoginButton } from "./login-button";
 
 export const metadata: Metadata = { title: "Login" };
@@ -50,6 +51,8 @@ export default async function LoginPage({ searchParams }: { searchParams: Search
                   {t("signInFailed", { error })}
                 </p>
               )}
+
+              <InAppBrowserNotice />
 
               <LoginButton />
 

--- a/frontend/src/lib/in-app-browser.test.ts
+++ b/frontend/src/lib/in-app-browser.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { detectInAppBrowser } from "./in-app-browser";
+
+// Representative user-agent strings captured from real devices. The exact
+// version numbers are irrelevant — only the app-identifying tokens matter.
+const IN_APP: ReadonlyArray<readonly [string, ReturnType<typeof detectInAppBrowser>]> = [
+  [
+    "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 Safari/604.1 Line/14.5.0",
+    "line",
+  ],
+  [
+    "Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/125.0.0.0 Mobile Safari/537.36 Line/14.5.0/IAB",
+    "line",
+  ],
+  [
+    "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 [FBAN/FBIOS;FBAV/468.0.0;FBBV/1]",
+    "facebook",
+  ],
+  [
+    "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 Instagram 333.0.0.0",
+    "instagram",
+  ],
+  [
+    "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 Twitter for iPhone",
+    "twitter",
+  ],
+  [
+    "Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/125.0.0.0 Mobile Safari/537.36 musical_ly_2023 TikTok",
+    "tiktok",
+  ],
+  [
+    "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 MicroMessenger/8.0.44",
+    "wechat",
+  ],
+  [
+    "Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/125.0.0.0 Mobile Safari/537.36 KAKAOTALK 10.4.5",
+    "kakaotalk",
+  ],
+  [
+    "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 Snapchat/12.0",
+    "snapchat",
+  ],
+  [
+    "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 [Pinterest/iOS]",
+    "pinterest",
+  ],
+  [
+    // Generic Android System WebView (no app-specific token) — the `; wv)` marker.
+    "Mozilla/5.0 (Linux; Android 14; Pixel 8 Build/UP1A; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/125.0.0.0 Mobile Safari/537.36",
+    "webview",
+  ],
+];
+
+// Standalone browsers must NOT be flagged — a false positive would nag a user
+// for whom Google sign-in works fine.
+const STANDALONE: readonly string[] = [
+  // Mobile Safari (iOS) — the canonical browser that DOES allow OAuth.
+  "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1",
+  // Chrome on Android (no `wv` token).
+  "Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Mobile Safari/537.36",
+  // Desktop Chrome.
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36",
+  // Desktop Firefox.
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:127.0) Gecko/20100101 Firefox/127.0",
+];
+
+describe("detectInAppBrowser", () => {
+  it.each(IN_APP)("flags %s as %s", (ua, expected) => {
+    expect(detectInAppBrowser(ua)).toBe(expected);
+  });
+
+  it.each(STANDALONE)("returns null for standalone browser %s", (ua) => {
+    expect(detectInAppBrowser(ua)).toBeNull();
+  });
+
+  it("returns null for an empty user-agent", () => {
+    expect(detectInAppBrowser("")).toBeNull();
+  });
+});

--- a/frontend/src/lib/in-app-browser.ts
+++ b/frontend/src/lib/in-app-browser.ts
@@ -1,0 +1,55 @@
+/**
+ * Best-effort detection of embedded in-app browsers (WebViews) shipped inside
+ * native apps such as LINE, Instagram, or Facebook.
+ *
+ * Google blocks OAuth 2.0 sign-in from embedded user-agents with
+ * `Error 403: disallowed_useragent` — see Google's "Use secure browsers"
+ * policy (https://developers.google.com/identity/protocols/oauth2/policies).
+ * The platform deliberately refuses these requests, so the only viable remedy
+ * is to detect the in-app browser and steer the user into the system browser
+ * (Safari / Chrome), which the login page does.
+ *
+ * Detection is intentionally NOT used to hard-block the sign-in button: a false
+ * positive only adds an advisory banner rather than locking a legitimate
+ * visitor out.
+ */
+export type InAppBrowser =
+  | "line"
+  | "facebook"
+  | "instagram"
+  | "twitter"
+  | "tiktok"
+  | "wechat"
+  | "kakaotalk"
+  | "snapchat"
+  | "pinterest"
+  | "webview";
+
+// Ordered so app-specific markers win over the generic Android WebView token:
+// an Instagram WebView UA also carries `; wv)`, but "instagram" is the useful
+// label and is what unlocks any app-specific escape hatch.
+const SIGNATURES: ReadonlyArray<readonly [InAppBrowser, RegExp]> = [
+  ["line", /\bLine\//i],
+  ["facebook", /\bFB(?:AN|AV|_IAB|IOS|SS)\b/],
+  ["instagram", /\bInstagram\b/i],
+  ["twitter", /\bTwitter(?:Android)?\b/i],
+  ["tiktok", /\b(?:musical_ly|BytedanceWebview|TikTok|Trill)\b/i],
+  ["wechat", /\bMicroMessenger\b/i],
+  ["kakaotalk", /\bKAKAOTALK\b/i],
+  ["snapchat", /\bSnapchat\b/i],
+  ["pinterest", /\bPinterest\b/i],
+  // Standard Android System WebView marker. Real Chrome / Custom Tabs omit it.
+  ["webview", /;\s?wv[);]/],
+];
+
+/**
+ * Returns the recognised in-app browser for a user-agent string, or `null` when
+ * the UA looks like a normal standalone browser. The first matching signature
+ * wins, so app-specific labels take precedence over the generic WebView token.
+ */
+export function detectInAppBrowser(userAgent: string): InAppBrowser | null {
+  for (const [kind, pattern] of SIGNATURES) {
+    if (pattern.test(userAgent)) return kind;
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary

- On mobile, opening the app from inside an **in-app browser** (LINE / Instagram / X / Facebook WebViews) and tapping **「Google で続行」** fails with Google's opaque `Error 403: disallowed_useragent`.
- Root cause is a **Google policy**, not a config bug: Google blocks OAuth from embedded user-agents — "a developer must not direct a Google OAuth 2.0 authorization request to an embedded user-agent" ([Google OAuth 2.0 Policies](https://developers.google.com/identity/protocols/oauth2/policies)). OAuth cannot succeed inside a WebView; the only remedy is to move the user into the system browser.
- The login flow had **no in-app-browser detection** — `signInWithOAuth({ provider: "google" })` fired unconditionally, so the user only discovered the problem after tapping the button and landing on the Google error page.
- This PR detects the in-app browser on the login page and shows an advisory banner that steers the user into Safari / Chrome. The sign-in button stays enabled, so a false-positive detection never locks anyone out.

No related issue — surfaced from a user mobile screenshot (`Error 403: disallowed_useragent` on `accounts.google.com`).

## Changes

### In-app browser detection (`frontend/src/lib/in-app-browser.ts`, new)

- Pure `detectInAppBrowser(userAgent)` returns the recognised app (`line` / `facebook` / `instagram` / `twitter` / `tiktok` / `wechat` / `kakaotalk` / `snapchat` / `pinterest`), the generic Android System WebView marker (`webview`, matched on `; wv)`), or `null` for a standalone browser.
- App-specific signatures are ordered before the generic WebView token so the useful label wins and unlocks any app-specific escape hatch.

### Advisory banner (`frontend/src/app/login/in-app-browser-notice.tsx`, new)

- Client component detected only after mount (the server cannot read the UA), so it renders nothing on the server — no hydration mismatch — and nothing in a standalone browser.
- **LINE** gets a one-tap escape: it navigates to the same URL with `openExternalBrowser=1`, which LINE honours by reopening in the OS default browser.
- All other in-app browsers get a **copy-page-link** fallback whose label flips to a "paste into Safari or Chrome" confirmation on success.
- Mounted directly above `<LoginButton />` in `frontend/src/app/login/page.tsx`.

### i18n copy (`frontend/messages/{en,ja}.json`)

- New `Login.inAppBrowserWarning` / `openInBrowser` / `copyLink` / `linkCopied` keys in both catalogs (the Japanese strings live only in the catalogs, per the English-only-source rule).

### Tests

- `in-app-browser.test.ts`: a UA detection table — real device UAs for each supported app, the Android `; wv)` marker, plus standalone Safari / Chrome / Firefox and empty-UA negatives.
- `in-app-browser-notice.test.tsx`: standalone → renders nothing; LINE → external-browser action (no copy button); other in-app → copy-link fallback that calls `clipboard.writeText(location.href)` and flips the label on success.
- `page.test.tsx`: mocks `./in-app-browser-notice` to `null`, mirroring the existing `./login-button` mock, so the broad page test stays provider-free and its DOM assertions are unchanged.

## Verification

- `pnpm --filter frontend typecheck` ✓ (full tree, 0 errors)
- `biome check --error-on-warnings` ✓
- `pnpm --filter frontend knip` ✓ — no unused exports (the speculative `isInAppBrowser` predicate was dropped; it had zero production callers)
- `pnpm --filter frontend test` ✓ — **122 files / 1178 tests**
- `pnpm --filter frontend build` ✓
- CJK source check ✓ — new `.ts` / `.tsx` are English-only; Japanese copy is confined to `messages/*.json`

## Test plan

- [ ] Open the site inside the **LINE** in-app browser → banner appears; "Open in browser" reopens the page in Safari/Chrome; Google sign-in then succeeds
- [ ] Open inside **Instagram / X / Facebook** in-app browser → banner appears with "Copy page link"; paste into Safari/Chrome → sign-in succeeds
- [ ] Open in **mobile Safari / Chrome** directly → no banner; sign-in works as before (regression check)
- [ ] Switch to the Japanese locale → the banner renders the translated copy
