### PR TITLE
fix(mise): drop supabase latest override so .tool-versions pin wins

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -16,7 +16,6 @@
 [tools]
 rust = "latest"
 "cargo:mprocs" = "latest"
-supabase = "latest"
 
 [env]
 _.file = [".env"]


### PR DESCRIPTION
## Summary

- `supabase` was pinned twice with conflicting versions: `./.tool-versions` set `supabase 2.90.0` (exact), while `./mise.toml` `[tools]` set `supabase = "latest"`.
- mise resolves `mise.toml` ahead of `.tool-versions`, so the `latest` entry won and the exact pin was dead — `mise current supabase` resolved to `2.100.0`, not `2.90.0`.
- This violated `docs/dev-setup.md`, which requires the Supabase CLI to stay on an exact version because `supabase latest` breaks `supabase/config.toml` across major upgrades.
- Drops the `supabase = "latest"` line so `.tool-versions` is the single source of truth again; the `[tools]` block now matches the file's own comment ("dev runtime tooling (Rust + mprocs) lives here").

No related issue — surfaced while reviewing the `mise.toml` / `.tool-versions` split.

## Changes

### `mise.toml`

- Removed `supabase = "latest"` from `[tools]`. `rust` and `cargo:mprocs` stay — they ride here alongside `[env]` because the cargo backend needs a Rust toolchain, and `.tool-versions` remains the canonical place for the rest of the pins.

## Verification

```
$ mise current supabase
2.90.0
$ mise ls supabase
supabase  2.90.0  .../.tool-versions  2.90.0   # active, sourced from .tool-versions
supabase  2.100.0
```

Before this change `mise current supabase` resolved to `2.100.0` (mise.toml `latest` overriding the pin).

## Test plan

- [ ] `mise current supabase` → `2.90.0` (was `2.100.0`)
- [ ] `mise ls supabase` shows the active version sourced from `.tool-versions`, not `mise.toml`
- [ ] `mise install` from a clean checkout still provisions Rust + mprocs (no regression in `[tools]`)
