### PR TITLE
feat: delete user account with cascade (admin + self-service)

### DIFF
--- a/backend/cmd/server/main_test.go
+++ b/backend/cmd/server/main_test.go
@@ -643,6 +643,10 @@ func (c *countingUserRepo) ListPage(
 	return c.inner.ListPage(ctx, after, before, first, last, search)
 }
 
+func (c *countingUserRepo) DeleteAuthUser(ctx context.Context, id string) error {
+	return c.inner.DeleteAuthUser(ctx, id)
+}
+
 // insertAuthUser inserts a row into auth.users so the handle_new_user trigger
 // creates the matching public.users row. Returns the generated user id.
 func insertAuthUser(t *testing.T, ctx context.Context) string {

--- a/backend/graph/resolver/admin.resolvers.go
+++ b/backend/graph/resolver/admin.resolvers.go
@@ -106,6 +106,14 @@ func (r *mutationResolver) DeleteRole(ctx context.Context, id string) (bool, err
 	return true, nil
 }
 
+// AdminDeleteUser is the resolver for the adminDeleteUser field.
+func (r *mutationResolver) AdminDeleteUser(ctx context.Context, id string) (bool, error) {
+	if err := r.AdminUserUC.DeleteUser(ctx, id); err != nil {
+		return false, gqlerr.FromUsecaseError(ctx, err)
+	}
+	return true, nil
+}
+
 // Users is the resolver for the users field.
 func (r *queryResolver) Users(ctx context.Context, first *int, after *string, last *int, before *string, search *string) (*model.UserConnection, error) {
 	uc, err := r.AdminUserUC.List(ctx, first, last, after, before, search)

--- a/backend/graph/resolver/admin_user_resolver_test.go
+++ b/backend/graph/resolver/admin_user_resolver_test.go
@@ -32,6 +32,10 @@ type mockAdminUserUsecase struct {
 	editErr       error
 	lastEditID    string
 	lastEditInput usecase.AdminEditUserInput
+
+	deleteErr    error
+	lastDeleteID string
+	deleteCalls  int
 }
 
 func (m *mockAdminUserUsecase) List(_ context.Context, _, _ *int, _, _, _ *string) (*usecase.AdminUserConnection, error) {
@@ -47,6 +51,12 @@ func (m *mockAdminUserUsecase) EditUser(_ context.Context, id string, input usec
 	return m.editOutcome, m.editErr
 }
 
+func (m *mockAdminUserUsecase) DeleteUser(_ context.Context, id string) error {
+	m.deleteCalls++
+	m.lastDeleteID = id
+	return m.deleteErr
+}
+
 // mockRoleByUserIDRepo satisfies the minimal interface needed to build the
 // RoleByUserID DataLoader.
 type mockRoleByUserIDRepo struct {
@@ -57,6 +67,8 @@ type mockRoleByUserIDRepo struct {
 	// lastIDs holds the key slice from the most recent ListByUserIDs call so
 	// N+1 batch assertions can verify all expected user IDs were batched together.
 	lastIDs []string
+	// adminCount is returned by CountAdmins; used by DeleteMyAccount tests.
+	adminCount int64
 }
 
 func (m *mockRoleByUserIDRepo) ListByUserIDs(_ context.Context, ids []string) (map[string][]*domain.Role, error) {
@@ -85,6 +97,10 @@ func (m *mockRoleByUserIDRepo) ListByUser(_ context.Context, userID string) ([]*
 		return []*domain.Role{}, nil
 	}
 	return roles, nil
+}
+
+func (m *mockRoleByUserIDRepo) CountAdmins(_ context.Context) (int64, error) {
+	return m.adminCount, nil
 }
 
 // newAdminUserSrv builds a gqlgen handler.Server backed by a mock
@@ -673,5 +689,65 @@ func TestAdminUserResolver_AdminEditUser_XORInvariantViolation(t *testing.T) {
 	code := errCode(t, resp)
 	if code != string(gqlerr.CodeInternal) {
 		t.Fatalf("expected INTERNAL_SERVER_ERROR, got %q; response: %v", code, resp)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Mutation.adminDeleteUser tests
+// ---------------------------------------------------------------------------
+
+const adminDeleteUserMutation = `{"query":"mutation { adminDeleteUser(id: \"u-target\") }"}`
+
+// TestAdminUserResolver_AdminDeleteUser_Success verifies adminDeleteUser returns
+// true and delegates to the usecase with the requested id when the usecase
+// succeeds.
+func TestAdminUserResolver_AdminDeleteUser_Success(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockAdminUserUsecase{}
+	srv := newAdminUserSrv(mock)
+	resp := gqlRequest(t, srv, authedCtx("admin"), adminDeleteUserMutation)
+
+	if _, hasErrs := resp["errors"]; hasErrs {
+		t.Fatalf("unexpected errors: %v", resp["errors"])
+	}
+	data, _ := resp["data"].(map[string]any)
+	if deleted, _ := data["adminDeleteUser"].(bool); !deleted {
+		t.Fatalf("expected data.adminDeleteUser == true, got %v", data["adminDeleteUser"])
+	}
+	if mock.deleteCalls != 1 || mock.lastDeleteID != "u-target" {
+		t.Fatalf("usecase.DeleteUser: calls=%d id=%q, want 1 and \"u-target\"", mock.deleteCalls, mock.lastDeleteID)
+	}
+}
+
+// TestAdminUserResolver_AdminDeleteUser_Forbidden verifies a usecase forbidden
+// error (self-deletion or last-admin guard) surfaces as FORBIDDEN.
+func TestAdminUserResolver_AdminDeleteUser_Forbidden(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockAdminUserUsecase{
+		deleteErr: ucerr.NewForbiddenError("cannot delete the last admin account"),
+	}
+	srv := newAdminUserSrv(mock)
+	resp := gqlRequest(t, srv, authedCtx("admin"), adminDeleteUserMutation)
+
+	if code := errCode(t, resp); code != string(gqlerr.CodeForbidden) {
+		t.Fatalf("expected FORBIDDEN, got %q; response: %v", code, resp)
+	}
+}
+
+// TestAdminUserResolver_AdminDeleteUser_NotFound verifies a usecase validation
+// error (missing target) surfaces as BAD_USER_INPUT.
+func TestAdminUserResolver_AdminDeleteUser_NotFound(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockAdminUserUsecase{
+		deleteErr: ucerr.NewValidationError("id", "user not found"),
+	}
+	srv := newAdminUserSrv(mock)
+	resp := gqlRequest(t, srv, authedCtx("admin"), adminDeleteUserMutation)
+
+	if code := errCode(t, resp); code != string(gqlerr.CodeBadUserInput) {
+		t.Fatalf("expected BAD_USER_INPUT, got %q; response: %v", code, resp)
 	}
 }

--- a/backend/graph/resolver/user.resolvers.go
+++ b/backend/graph/resolver/user.resolvers.go
@@ -42,6 +42,14 @@ func (r *mutationResolver) UpdateProfile(ctx context.Context, input model.Update
 	return model.UpdateProfileSuccess{User: toUserModel(outcome.User)}, nil
 }
 
+// DeleteMyAccount is the resolver for the deleteMyAccount field.
+func (r *mutationResolver) DeleteMyAccount(ctx context.Context) (bool, error) {
+	if err := r.UserUC.DeleteMyAccount(ctx); err != nil {
+		return false, gqlerr.FromUsecaseError(ctx, err)
+	}
+	return true, nil
+}
+
 // Me is the resolver for the me field.
 func (r *queryResolver) Me(ctx context.Context) (*model.User, error) {
 	user, err := r.UserUC.Me(ctx)

--- a/backend/graph/resolver/user_test.go
+++ b/backend/graph/resolver/user_test.go
@@ -26,6 +26,7 @@ type mockUserRepository struct {
 	updateResult  *domain.User
 	updateErr     error
 	capturedPatch repository.UserUpdate
+	deleteAuthErr error
 }
 
 func (m *mockUserRepository) FindByID(_ context.Context, _ string) (*domain.User, error) {
@@ -35,6 +36,10 @@ func (m *mockUserRepository) FindByID(_ context.Context, _ string) (*domain.User
 func (m *mockUserRepository) Update(_ context.Context, _ string, patch repository.UserUpdate) (*domain.User, error) {
 	m.capturedPatch = patch
 	return m.updateResult, m.updateErr
+}
+
+func (m *mockUserRepository) DeleteAuthUser(_ context.Context, _ string) error {
+	return m.deleteAuthErr
 }
 
 // ptr returns a pointer to s.
@@ -332,5 +337,64 @@ func TestResolver_UpdateProfile_NilVariant_ReturnsInternal(t *testing.T) {
 	code := errCode(t, resp)
 	if code != "INTERNAL" {
 		t.Fatalf("expected INTERNAL, got %q; response: %v", code, resp)
+	}
+}
+
+// newDeleteMyAccountSrv builds a server whose UserUsecase is wired with the
+// admin-guard dependencies DeleteMyAccount needs: an AuthSvc reporting isAdmin
+// for the caller and a roles repo reporting the global admin count.
+func newDeleteMyAccountSrv(repo *mockUserRepository, isAdmin bool, adminCount int64) *handler.Server {
+	authSvc := auth.NewService(&mockUserRoleRepository{isAdmin: isAdmin})
+	uc := usecase.NewUserUsecase(repo, &mockRoleByUserIDRepo{adminCount: adminCount}, authSvc, newDiscardLogger())
+	r := resolver.NewResolver(uc, nil, nil, nil, authSvc, nil, nil, nil, nil, nil, nil)
+	srv := handler.New(generated.NewExecutableSchema(generated.Config{Resolvers: r}))
+	srv.AddTransport(transport.POST{})
+	return srv
+}
+
+const deleteMyAccountMutation = `{"query":"mutation { deleteMyAccount }"}`
+
+// TestUserResolver_DeleteMyAccount_Success verifies the mutation returns true
+// when the usecase deletes the caller's account.
+func TestUserResolver_DeleteMyAccount_Success(t *testing.T) {
+	t.Parallel()
+
+	repo := &mockUserRepository{}
+	srv := newDeleteMyAccountSrv(repo, false, 0)
+	resp := gqlRequest(t, srv, authedCtx("u1"), deleteMyAccountMutation)
+
+	if _, hasErrs := resp["errors"]; hasErrs {
+		t.Fatalf("unexpected errors: %v", resp["errors"])
+	}
+	data, _ := resp["data"].(map[string]any)
+	if deleted, _ := data["deleteMyAccount"].(bool); !deleted {
+		t.Fatalf("expected data.deleteMyAccount == true, got %v", data["deleteMyAccount"])
+	}
+}
+
+// TestUserResolver_DeleteMyAccount_Unauthenticated verifies an anonymous caller
+// receives UNAUTHENTICATED.
+func TestUserResolver_DeleteMyAccount_Unauthenticated(t *testing.T) {
+	t.Parallel()
+
+	srv := newDeleteMyAccountSrv(&mockUserRepository{}, false, 0)
+	resp := gqlRequest(t, srv, context.Background(), deleteMyAccountMutation)
+
+	if code := errCode(t, resp); code != "UNAUTHENTICATED" {
+		t.Fatalf("expected UNAUTHENTICATED, got %q; response: %v", code, resp)
+	}
+}
+
+// TestUserResolver_DeleteMyAccount_LastAdminForbidden verifies the sole admin
+// cannot delete their own account via the self-service path.
+func TestUserResolver_DeleteMyAccount_LastAdminForbidden(t *testing.T) {
+	t.Parallel()
+
+	// Caller is an admin and is the only admin (count == 1) → forbidden.
+	srv := newDeleteMyAccountSrv(&mockUserRepository{}, true, 1)
+	resp := gqlRequest(t, srv, authedCtx("u1"), deleteMyAccountMutation)
+
+	if code := errCode(t, resp); code != "FORBIDDEN" {
+		t.Fatalf("expected FORBIDDEN, got %q; response: %v", code, resp)
 	}
 }

--- a/backend/internal/loader/user_test.go
+++ b/backend/internal/loader/user_test.go
@@ -275,6 +275,12 @@ func (r *countingRepo) ListPage(
 	panic("countingRepo.ListPage not configured")
 }
 
+// DeleteAuthUser satisfies repository.UserRepository. Loader-layer tests never
+// invoke account deletion; panic if called so accidental coupling is surfaced.
+func (r *countingRepo) DeleteAuthUser(_ context.Context, _ string) error {
+	panic("countingRepo.DeleteAuthUser not configured")
+}
+
 // SetLastViewedCardgroup satisfies repository.UserRepository. Loader-layer
 // tests never invoke this path; panic if called so accidental coupling is
 // surfaced rather than silently no-oped.

--- a/backend/internal/repository/user.go
+++ b/backend/internal/repository/user.go
@@ -86,6 +86,20 @@ type UserRepository interface {
 		first, last int,
 		search *string,
 	) (users []*domain.User, total int64, err error)
+
+	// DeleteAuthUser deletes the auth.users row identified by id. The public.users
+	// row and every cascade-linked row (user_roles, cardgroups → cards →
+	// swipe_records / user_card_fsrs, user_preferences) are removed automatically
+	// by the existing ON DELETE CASCADE foreign keys — no application-level
+	// multi-step delete is needed. Returns ErrNotFound when no auth.users row
+	// matches id (RowsAffected == 0).
+	//
+	// The operation requires the connection role to have DELETE privilege on
+	// auth.users; the production DSN connects as the postgres role, which has it
+	// (the same statement is exercised by the repository integration tests). This
+	// is the single isolation point for auth-account deletion: swapping to the
+	// Supabase Admin REST API is a change to this method body alone.
+	DeleteAuthUser(ctx context.Context, id string) error
 }
 
 type userRepo struct{ db *gorm.DB }
@@ -178,6 +192,20 @@ func (r *userRepo) UpdateTxVersioned(ctx context.Context, tx *gorm.DB, id string
 		return eris.Wrap(err, "repository: update user tx versioned: probe user")
 	}
 	return ErrConcurrentUpdate
+}
+
+// DeleteAuthUser deletes the auth.users row, cascading to public.users and all
+// child data via the schema's ON DELETE CASCADE foreign keys. See the interface
+// doc for the privilege and isolation rationale.
+func (r *userRepo) DeleteAuthUser(ctx context.Context, id string) error {
+	res := r.db.WithContext(ctx).Exec("DELETE FROM auth.users WHERE id = ?", id)
+	if res.Error != nil {
+		return eris.Wrap(res.Error, "repository: delete auth user")
+	}
+	if res.RowsAffected == 0 {
+		return ErrNotFound
+	}
+	return nil
 }
 
 func userUpdates(patch UserUpdate) map[string]any {

--- a/backend/internal/repository/user_test.go
+++ b/backend/internal/repository/user_test.go
@@ -351,6 +351,63 @@ func TestUser_OnDeleteCascade(t *testing.T) {
 	}
 }
 
+func TestDeleteAuthUser_Success(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	id := insertAuthUser(t, ctx)
+	repo := repository.NewUserRepository(testDB.GORM)
+
+	if _, err := repo.FindByID(ctx, id); err != nil {
+		t.Fatalf("precondition FindByID: %v", err)
+	}
+	if err := repo.DeleteAuthUser(ctx, id); err != nil {
+		t.Fatalf("DeleteAuthUser: %v", err)
+	}
+	if _, err := repo.FindByID(ctx, id); !errors.Is(err, repository.ErrNotFound) {
+		t.Fatalf("want ErrNotFound after delete, got %v", err)
+	}
+}
+
+func TestDeleteAuthUser_NotFound(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	repo := repository.NewUserRepository(testDB.GORM)
+
+	if err := repo.DeleteAuthUser(ctx, uuid.NewString()); !errors.Is(err, repository.ErrNotFound) {
+		t.Fatalf("want ErrNotFound for missing auth user, got %v", err)
+	}
+}
+
+// TestDeleteAuthUser_CascadesOwnedCardgroup proves DeleteAuthUser (not a raw
+// SQL statement) drives the ON DELETE CASCADE chain down to a user-owned
+// cardgroup row.
+func TestDeleteAuthUser_CascadesOwnedCardgroup(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	id := insertAuthUser(t, ctx)
+	repo := repository.NewUserRepository(testDB.GORM)
+	sqlDB := sqlDBHandle(t)
+
+	cgID := uuid.NewString()
+	if _, err := sqlDB.ExecContext(ctx,
+		`INSERT INTO cardgroups (id, owner_id, name) VALUES ($1, $2, $3)`,
+		cgID, id, "to-be-cascaded"); err != nil {
+		t.Fatalf("insert cardgroup: %v", err)
+	}
+
+	if err := repo.DeleteAuthUser(ctx, id); err != nil {
+		t.Fatalf("DeleteAuthUser: %v", err)
+	}
+
+	var count int
+	if err := sqlDB.QueryRowContext(ctx, `SELECT count(*) FROM cardgroups WHERE id = $1`, cgID).Scan(&count); err != nil {
+		t.Fatalf("count cardgroups: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("cardgroup row should be cascade-deleted, got count=%d", count)
+	}
+}
+
 func TestUpdate_EmptyPatchReturnsCurrentRow(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/backend/internal/usecase/admin_user.go
+++ b/backend/internal/usecase/admin_user.go
@@ -101,6 +101,10 @@ type AdminUserUsecase interface {
 	) (*AdminUserConnection, error)
 	Get(ctx context.Context, id string) (*domain.User, error)
 	EditUser(ctx context.Context, id string, input AdminEditUserInput) (AdminEditUserOutcome, error)
+	// DeleteUser permanently deletes the user identified by id and all associated
+	// data. Returns a forbidden error when the caller targets their own id or the
+	// target is the last admin, and a validation error when the user is not found.
+	DeleteUser(ctx context.Context, id string) error
 }
 
 // adminUserRepository is the subset of repository.UserRepository the
@@ -115,6 +119,9 @@ type adminUserRepository interface {
 		first, last int,
 		search *string,
 	) ([]*domain.User, int64, error)
+	// DeleteAuthUser deletes the target's auth.users row, cascading to all
+	// associated data. See repository.UserRepository.DeleteAuthUser for details.
+	DeleteAuthUser(ctx context.Context, id string) error
 }
 
 // adminRoleRepository is the subset of repository.RoleRepository used by the
@@ -126,9 +133,16 @@ type adminRoleRepository interface {
 }
 
 // adminUserRoleRepository is the subset of repository.UserRoleRepository used
-// by the AdminUser usecase (atomic membership replacement).
+// by the AdminUser usecase: atomic membership replacement (EditUser) and the
+// last-admin / target-is-admin checks (DeleteUser).
 type adminUserRoleRepository interface {
 	SetUserRolesTx(ctx context.Context, tx *gorm.DB, userID string, roleIDs []string) error
+	// HasRole reports whether the user holds the named role. Used by DeleteUser
+	// to decide whether the last-admin guard applies to the target.
+	HasRole(ctx context.Context, userID string, roleName domain.RoleName) (bool, error)
+	// CountAdmins returns the number of users holding the admin role. Used by
+	// DeleteUser's last-admin guard.
+	CountAdmins(ctx context.Context) (int64, error)
 }
 
 // adminUserUsecase wires the admin gate, the user repository, the role
@@ -421,6 +435,63 @@ func (u *adminUserUsecase) EditUser(ctx context.Context, id string, input AdminE
 		return AdminEditUserOutcome{}, err
 	}
 	return AdminEditUserOutcome{User: user}, nil
+}
+
+// DeleteUser permanently deletes the user identified by id and all associated
+// data. The delete cascades through public.users and every child row via the
+// schema's ON DELETE CASCADE foreign keys; no application-level multi-step
+// delete is needed.
+//
+// Guard order:
+//  1. Admin gate: non-admin / unauthenticated callers are rejected.
+//  2. Self-deletion block: an admin cannot delete their own account from the
+//     admin surface (they must use DeleteMyAccount), preventing an accidental
+//     lockout.
+//  3. Last-admin guard: when the target holds the admin role and is the only
+//     admin, the deletion is refused so the system is never left without an
+//     admin. Best-effort (no row lock) — see DeleteMyAccount for the TOCTOU note.
+//
+// A missing target maps to a validation error on "id" (BAD_USER_INPUT).
+func (u *adminUserUsecase) DeleteUser(ctx context.Context, id string) error {
+	callerID, err := u.adminGate.Require(ctx, "usecase: admin user: check admin")
+	if err != nil {
+		return err
+	}
+	if callerID == id {
+		return ucerr.NewForbiddenError("cannot delete your own account from the admin panel; use deleteMyAccount")
+	}
+
+	// Only consult the global admin count when the target is itself an admin.
+	isAdmin, err := u.userRoles.HasRole(ctx, id, domain.AdminRoleName)
+	if err != nil {
+		if isContextDone(err) {
+			return err
+		}
+		return eris.Wrap(err, "usecase: admin user: delete: check admin role")
+	}
+	if isAdmin {
+		n, err := u.userRoles.CountAdmins(ctx)
+		if err != nil {
+			if isContextDone(err) {
+				return err
+			}
+			return eris.Wrap(err, "usecase: admin user: delete: count admins")
+		}
+		if n <= 1 {
+			return ucerr.NewForbiddenError("cannot delete the last admin account")
+		}
+	}
+
+	if err := u.users.DeleteAuthUser(ctx, id); err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return ucerr.NewValidationError("id", "user not found")
+		}
+		if isContextDone(err) {
+			return err
+		}
+		return eris.Wrap(err, "usecase: admin user: delete")
+	}
+	return nil
 }
 
 func mapAdminEditMutationError(err error) (*InputValidationInfo, error) {

--- a/backend/internal/usecase/admin_user_test.go
+++ b/backend/internal/usecase/admin_user_test.go
@@ -42,6 +42,11 @@ type mockAdminUserRepository struct {
 	lastListFirst  int
 	lastListLast   int
 	lastListSearch *string
+
+	// DeleteAuthUser
+	deleteAuthErr    error
+	deleteAuthCalls  int
+	lastDeleteAuthID string
 }
 
 func (m *mockAdminUserRepository) FindByID(_ context.Context, id string) (*domain.User, error) {
@@ -88,6 +93,12 @@ func (m *mockAdminUserRepository) ListPage(
 	return m.listResult, m.listTotal, nil
 }
 
+func (m *mockAdminUserRepository) DeleteAuthUser(_ context.Context, id string) error {
+	m.deleteAuthCalls++
+	m.lastDeleteAuthID = id
+	return m.deleteAuthErr
+}
+
 // mockAdminRoleRepository implements the narrow adminRoleRepository surface.
 // The lookup is the tx-scoped, row-locking FindByIDsTx; the fake tx runner
 // passes a non-nil *gorm.DB into the callback so the stub is reached on the
@@ -122,6 +133,16 @@ type mockAdminUserRoleRepository struct {
 	setCalls       int
 	lastSetUID     string
 	lastSetRoleIDs []string
+
+	// HasRole — keyed by userID so DeleteUser tests can mark a specific target
+	// as an admin (or not).
+	hasRoleByUser map[string]bool
+	hasRoleErr    error
+	hasRoleCalls  int
+
+	// CountAdmins
+	adminCount int64
+	countErr   error
 }
 
 func (m *mockAdminUserRoleRepository) SetUserRolesTx(_ context.Context, _ *gorm.DB, userID string, roleIDs []string) error {
@@ -129,6 +150,18 @@ func (m *mockAdminUserRoleRepository) SetUserRolesTx(_ context.Context, _ *gorm.
 	m.lastSetUID = userID
 	m.lastSetRoleIDs = append([]string(nil), roleIDs...)
 	return m.setErr
+}
+
+func (m *mockAdminUserRoleRepository) HasRole(_ context.Context, userID string, _ domain.RoleName) (bool, error) {
+	m.hasRoleCalls++
+	if m.hasRoleErr != nil {
+		return false, m.hasRoleErr
+	}
+	return m.hasRoleByUser[userID], nil
+}
+
+func (m *mockAdminUserRoleRepository) CountAdmins(_ context.Context) (int64, error) {
+	return m.adminCount, m.countErr
 }
 
 // adminAuthChecker is a stand-alone AdminChecker stub for AdminUser tests. It
@@ -244,6 +277,12 @@ func TestAdminUser_NonAdminForbidden(t *testing.T) {
 				return err
 			},
 		},
+		{
+			name: "DeleteUser",
+			call: func(uc AdminUserUsecase) error {
+				return uc.DeleteUser(adminCallerCtx("u1"), "any")
+			},
+		},
 	}
 
 	for _, tc := range cases {
@@ -266,6 +305,122 @@ func TestAdminUser_NonAdminForbidden(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestAdminUserUsecase_DeleteUser exercises the DeleteUser guard chain and the
+// happy path. The non-admin gate is covered by TestAdminUser_NonAdminForbidden;
+// the cases here all use an admin caller.
+func TestAdminUserUsecase_DeleteUser(t *testing.T) {
+	t.Parallel()
+
+	const caller = "admin-1"
+	adminCaller := func() *adminAuthChecker {
+		return &adminAuthChecker{admins: map[string]bool{caller: true}}
+	}
+
+	t.Run("self-deletion is forbidden", func(t *testing.T) {
+		t.Parallel()
+		users := &mockAdminUserRepository{}
+		userRoles := &mockAdminUserRoleRepository{}
+		uc, _, _, _ := buildAdminUC(users, nil, userRoles, adminCaller())
+
+		err := uc.DeleteUser(adminCallerCtx(caller), caller)
+
+		assertForbidden(t, err, "cannot delete your own account from the admin panel; use deleteMyAccount")
+		if users.deleteAuthCalls != 0 {
+			t.Fatalf("DeleteAuthUser must not run on self-deletion, got %d calls", users.deleteAuthCalls)
+		}
+		if userRoles.hasRoleCalls != 0 {
+			t.Fatalf("HasRole must not run on self-deletion, got %d calls", userRoles.hasRoleCalls)
+		}
+	})
+
+	t.Run("last admin is forbidden", func(t *testing.T) {
+		t.Parallel()
+		users := &mockAdminUserRepository{}
+		userRoles := &mockAdminUserRoleRepository{
+			hasRoleByUser: map[string]bool{"target": true},
+			adminCount:    1,
+		}
+		uc, _, _, _ := buildAdminUC(users, nil, userRoles, adminCaller())
+
+		err := uc.DeleteUser(adminCallerCtx(caller), "target")
+
+		assertForbidden(t, err, "cannot delete the last admin account")
+		if users.deleteAuthCalls != 0 {
+			t.Fatalf("DeleteAuthUser must not run when the target is the last admin, got %d calls", users.deleteAuthCalls)
+		}
+	})
+
+	t.Run("non-admin target is deleted without consulting the admin count", func(t *testing.T) {
+		t.Parallel()
+		users := &mockAdminUserRepository{}
+		// "target" is absent from hasRoleByUser → not an admin. adminCount is set
+		// to a blocking value to prove the count is never consulted for non-admins.
+		userRoles := &mockAdminUserRoleRepository{adminCount: 1}
+		uc, _, _, _ := buildAdminUC(users, nil, userRoles, adminCaller())
+
+		err := uc.DeleteUser(adminCallerCtx(caller), "target")
+
+		if err != nil {
+			t.Fatalf("DeleteUser: unexpected error: %v", err)
+		}
+		if users.deleteAuthCalls != 1 || users.lastDeleteAuthID != "target" {
+			t.Fatalf("DeleteAuthUser: calls=%d id=%q, want 1 and \"target\"", users.deleteAuthCalls, users.lastDeleteAuthID)
+		}
+	})
+
+	t.Run("admin target that is not the last admin is deleted", func(t *testing.T) {
+		t.Parallel()
+		users := &mockAdminUserRepository{}
+		userRoles := &mockAdminUserRoleRepository{
+			hasRoleByUser: map[string]bool{"target": true},
+			adminCount:    2,
+		}
+		uc, _, _, _ := buildAdminUC(users, nil, userRoles, adminCaller())
+
+		err := uc.DeleteUser(adminCallerCtx(caller), "target")
+
+		if err != nil {
+			t.Fatalf("DeleteUser: unexpected error: %v", err)
+		}
+		if users.deleteAuthCalls != 1 {
+			t.Fatalf("DeleteAuthUser: calls=%d, want 1", users.deleteAuthCalls)
+		}
+	})
+
+	t.Run("missing user maps to validation error", func(t *testing.T) {
+		t.Parallel()
+		users := &mockAdminUserRepository{deleteAuthErr: repository.ErrNotFound}
+		userRoles := &mockAdminUserRoleRepository{}
+		uc, _, _, _ := buildAdminUC(users, nil, userRoles, adminCaller())
+
+		err := uc.DeleteUser(adminCallerCtx(caller), "ghost")
+
+		assertValidationError(t, err, "id", "user not found")
+	})
+
+	t.Run("infrastructure error wraps as internal chain", func(t *testing.T) {
+		t.Parallel()
+		users := &mockAdminUserRepository{deleteAuthErr: errors.New("boom")}
+		userRoles := &mockAdminUserRoleRepository{}
+		uc, _, _, _ := buildAdminUC(users, nil, userRoles, adminCaller())
+
+		err := uc.DeleteUser(adminCallerCtx(caller), "target")
+
+		assertInternalChain(t, err, "usecase: admin user: delete")
+	})
+
+	t.Run("context cancellation propagates", func(t *testing.T) {
+		t.Parallel()
+		users := &mockAdminUserRepository{}
+		userRoles := &mockAdminUserRoleRepository{hasRoleErr: context.Canceled}
+		uc, _, _, _ := buildAdminUC(users, nil, userRoles, adminCaller())
+
+		err := uc.DeleteUser(adminCallerCtx(caller), "target")
+
+		assertCancelled(t, err)
+	})
 }
 
 // ---------------------------------------------------------------------------

--- a/backend/internal/usecase/user.go
+++ b/backend/internal/usecase/user.go
@@ -20,10 +20,16 @@ import (
 type UserRepository interface {
 	FindByID(ctx context.Context, id string) (*domain.User, error)
 	Update(ctx context.Context, id string, patch repository.UserUpdate) (*domain.User, error)
+	// DeleteAuthUser deletes the caller's auth.users row, cascading to all
+	// associated data. See repository.UserRepository.DeleteAuthUser for details.
+	DeleteAuthUser(ctx context.Context, id string) error
 }
 
 type UserRolesRepository interface {
 	ListByUser(ctx context.Context, userID string) ([]*domain.Role, error)
+	// CountAdmins returns the number of users holding the admin role. Used by
+	// DeleteMyAccount's last-admin guard.
+	CountAdmins(ctx context.Context) (int64, error)
 }
 
 // UserUsecase is the authenticated user profile and role-query surface.
@@ -31,6 +37,10 @@ type UserUsecase interface {
 	Me(ctx context.Context) (*domain.User, error)
 	RolesFor(ctx context.Context, targetID string) ([]*domain.Role, error)
 	UpdateUser(ctx context.Context, in UpdateUserInput) (UpdateProfileOutcome, error)
+	// DeleteMyAccount deletes the authenticated caller's own account and all
+	// associated data. Returns ucerr.ErrUnauthenticated when no caller is on the
+	// context, and a forbidden error when the caller is the last admin.
+	DeleteMyAccount(ctx context.Context) error
 }
 
 type userUsecase struct {
@@ -153,4 +163,60 @@ func (u *userUsecase) UpdateUser(ctx context.Context, in UpdateUserInput) (Updat
 		return UpdateProfileOutcome{}, eris.Wrap(err, "usecase: UpdateUser: update user")
 	}
 	return UpdateProfileOutcome{User: appUser}, nil
+}
+
+// DeleteMyAccount permanently deletes the authenticated caller's own account.
+// The delete cascades through public.users and every child row via the schema's
+// ON DELETE CASCADE foreign keys; no application-level multi-step delete is
+// needed.
+//
+// Guard order:
+//  1. Authentication: no caller on the context returns ucerr.ErrUnauthenticated.
+//  2. Last-admin guard: if the caller holds the admin role and is the only admin,
+//     return a forbidden error so the system is never left without an admin.
+//     This is best-effort (no row lock): a concurrent admin deletion could race
+//     past the count. At this app's scale the TOCTOU window is acceptable; a
+//     Postgres advisory lock is the upgrade path if it ever matters.
+//
+// A missing auth.users row at delete time is treated as idempotent success — the
+// account is already gone from the system's perspective.
+func (u *userUsecase) DeleteMyAccount(ctx context.Context) error {
+	caller := auth.UserFrom(ctx)
+	if err := requireCallerSub(caller); err != nil {
+		return err
+	}
+
+	if u.auth == nil || u.roles == nil {
+		return eris.New("usecase: user: delete my account: admin guard deps not configured")
+	}
+	isAdmin, err := u.auth.IsAdmin(ctx, caller.Sub)
+	if err != nil {
+		if isContextDone(err) {
+			return err
+		}
+		return eris.Wrap(err, "usecase: user: delete my account: check admin")
+	}
+	if isAdmin {
+		n, err := u.roles.CountAdmins(ctx)
+		if err != nil {
+			if isContextDone(err) {
+				return err
+			}
+			return eris.Wrap(err, "usecase: user: delete my account: count admins")
+		}
+		if n <= 1 {
+			return ucerr.NewForbiddenError("cannot delete the last admin account; promote another admin first")
+		}
+	}
+
+	if err := u.repo.DeleteAuthUser(ctx, caller.Sub); err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return nil
+		}
+		if isContextDone(err) {
+			return err
+		}
+		return eris.Wrap(err, "usecase: user: delete my account")
+	}
+	return nil
 }

--- a/backend/internal/usecase/user_test.go
+++ b/backend/internal/usecase/user_test.go
@@ -18,6 +18,10 @@ type mockUserRepository struct {
 	updateResult  *domain.User
 	updateErr     error
 	capturedPatch repository.UserUpdate
+
+	deleteAuthErr    error
+	deleteAuthCalls  int
+	lastDeleteAuthID string
 }
 
 func (m *mockUserRepository) FindByID(_ context.Context, _ string) (*domain.User, error) {
@@ -29,17 +33,30 @@ func (m *mockUserRepository) Update(_ context.Context, _ string, patch repositor
 	return m.updateResult, m.updateErr
 }
 
+func (m *mockUserRepository) DeleteAuthUser(_ context.Context, id string) error {
+	m.deleteAuthCalls++
+	m.lastDeleteAuthID = id
+	return m.deleteAuthErr
+}
+
 type mockUserRolesRepository struct {
 	roles  []*domain.Role
 	err    error
 	calls  int
 	userID string
+
+	adminCount     int64
+	countAdminsErr error
 }
 
 func (m *mockUserRolesRepository) ListByUser(_ context.Context, userID string) ([]*domain.Role, error) {
 	m.calls++
 	m.userID = userID
 	return m.roles, m.err
+}
+
+func (m *mockUserRolesRepository) CountAdmins(_ context.Context) (int64, error) {
+	return m.adminCount, m.countAdminsErr
 }
 
 func authedCtx(sub string) context.Context {
@@ -536,4 +553,98 @@ func TestUserUsecase_UpdateUser_RepoError_InfraChannel(t *testing.T) {
 		t.Fatal("expected error from repo, got nil")
 	}
 	assertInternalChain(t, err, "usecase: UpdateUser: update user")
+}
+
+// TestUserUsecase_DeleteMyAccount exercises the self-service account-deletion
+// guard chain and the happy path.
+func TestUserUsecase_DeleteMyAccount(t *testing.T) {
+	t.Parallel()
+
+	const caller = "user-1"
+
+	t.Run("unauthenticated", func(t *testing.T) {
+		t.Parallel()
+		uc := NewUserUsecase(&mockUserRepository{}, &mockUserRolesRepository{}, &mockAdminChecker{}, newTestLogger())
+		assertUnauthenticated(t, uc.DeleteMyAccount(anonCtx()))
+	})
+
+	t.Run("non-admin caller is deleted without consulting the admin count", func(t *testing.T) {
+		t.Parallel()
+		repo := &mockUserRepository{}
+		// adminCount is a blocking value to prove it is never consulted for non-admins.
+		roles := &mockUserRolesRepository{adminCount: 1}
+		uc := NewUserUsecase(repo, roles, &mockAdminChecker{isAdmin: false}, newTestLogger())
+
+		if err := uc.DeleteMyAccount(authedCtx(caller)); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if repo.deleteAuthCalls != 1 || repo.lastDeleteAuthID != caller {
+			t.Fatalf("DeleteAuthUser: calls=%d id=%q, want 1 and %q", repo.deleteAuthCalls, repo.lastDeleteAuthID, caller)
+		}
+	})
+
+	t.Run("admin caller that is not the last admin is deleted", func(t *testing.T) {
+		t.Parallel()
+		repo := &mockUserRepository{}
+		roles := &mockUserRolesRepository{adminCount: 2}
+		uc := NewUserUsecase(repo, roles, &mockAdminChecker{isAdmin: true}, newTestLogger())
+
+		if err := uc.DeleteMyAccount(authedCtx(caller)); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if repo.deleteAuthCalls != 1 {
+			t.Fatalf("DeleteAuthUser calls=%d, want 1", repo.deleteAuthCalls)
+		}
+	})
+
+	t.Run("last admin is forbidden", func(t *testing.T) {
+		t.Parallel()
+		repo := &mockUserRepository{}
+		roles := &mockUserRolesRepository{adminCount: 1}
+		uc := NewUserUsecase(repo, roles, &mockAdminChecker{isAdmin: true}, newTestLogger())
+
+		err := uc.DeleteMyAccount(authedCtx(caller))
+
+		assertForbidden(t, err, "cannot delete the last admin account; promote another admin first")
+		if repo.deleteAuthCalls != 0 {
+			t.Fatalf("DeleteAuthUser must not run for the last admin, got %d calls", repo.deleteAuthCalls)
+		}
+	})
+
+	t.Run("missing account is idempotent success", func(t *testing.T) {
+		t.Parallel()
+		repo := &mockUserRepository{deleteAuthErr: repository.ErrNotFound}
+		roles := &mockUserRolesRepository{}
+		uc := NewUserUsecase(repo, roles, &mockAdminChecker{isAdmin: false}, newTestLogger())
+
+		if err := uc.DeleteMyAccount(authedCtx(caller)); err != nil {
+			t.Fatalf("expected nil (idempotent), got %v", err)
+		}
+	})
+
+	t.Run("infrastructure error wraps as internal chain", func(t *testing.T) {
+		t.Parallel()
+		repo := &mockUserRepository{deleteAuthErr: errors.New("boom")}
+		roles := &mockUserRolesRepository{}
+		uc := NewUserUsecase(repo, roles, &mockAdminChecker{isAdmin: false}, newTestLogger())
+
+		assertInternalChain(t, uc.DeleteMyAccount(authedCtx(caller)), "usecase: user: delete my account")
+	})
+
+	t.Run("context cancellation propagates", func(t *testing.T) {
+		t.Parallel()
+		uc := NewUserUsecase(&mockUserRepository{}, &mockUserRolesRepository{}, &mockAdminChecker{err: context.Canceled}, newTestLogger())
+		assertCancelled(t, uc.DeleteMyAccount(authedCtx(caller)))
+	})
+
+	t.Run("missing guard deps fail safe", func(t *testing.T) {
+		t.Parallel()
+		repo := &mockUserRepository{}
+		uc := NewUserUsecase(repo, nil, &mockAdminChecker{}, newTestLogger())
+
+		assertInternalChain(t, uc.DeleteMyAccount(authedCtx(caller)), "admin guard deps not configured")
+		if repo.deleteAuthCalls != 0 {
+			t.Fatalf("DeleteAuthUser must not run when guard deps are missing, got %d calls", repo.deleteAuthCalls)
+		}
+	})
 }

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -208,7 +208,20 @@
     "emailRateLimited": "Too many requests. Please wait a moment and try again.",
     "emailAlreadyInUse": "That email address is already in use.",
     "emailCouldNotSend": "Could not send confirmation link. Please try again.",
-    "emailNetworkError": "Network error. Please check your connection and try again."
+    "emailNetworkError": "Network error. Please check your connection and try again.",
+    "dangerZoneHeading": "Danger zone",
+    "dangerZoneDescription": "These actions are permanent and cannot be undone.",
+    "deleteAccountButton": "Delete my account",
+    "deleteAccountDialogTitle": "Delete your account?",
+    "deleteAccountDialogDescription": "This permanently deletes your account and all your cardgroups, cards, and learning history. You will be signed out immediately. This cannot be undone.",
+    "deleteAccountConfirmPhrase": "delete my account",
+    "deleteAccountTypeToConfirm": "Type \"{phrase}\" to confirm:",
+    "deleteAccountConfirmInputLabel": "Type the confirmation phrase to delete your account",
+    "deleteAccountConfirmButton": "Delete my account",
+    "deleteAccountDeleting": "Deleting...",
+    "deleteAccountFailed": "Could not delete your account. Please try again.",
+    "deleteAccountForbidden": "You cannot delete your account while you are the last admin. Promote another admin first.",
+    "deleteAccountSessionExpired": "Your session has expired. Please sign in again."
   },
   "Onboarding": {
     "welcome": "Welcome to Flamingo Armond",
@@ -257,6 +270,16 @@
     "deleteAuthFailed": "Your session has expired. Please sign in again.",
     "systemRole": "System role",
     "roleNameLabel": "Name",
-    "roleNamePlaceholder": "new-role-name"
+    "roleNamePlaceholder": "new-role-name",
+    "deleteUserButton": "Delete user",
+    "deleteUserHeading": "Danger zone",
+    "deleteUserDescription": "Permanently delete this user and all their data.",
+    "deleteUserDialogTitle": "Delete this user?",
+    "deleteUserDialogDescription": "This permanently deletes the user account and all their cardgroups, cards, and learning history. This cannot be undone.",
+    "deleteUserConfirmButton": "Delete user",
+    "deleteUserDeleting": "Deleting...",
+    "deleteUserSuccess": "User deleted.",
+    "deleteUserFailed": "Could not delete the user. Please try again.",
+    "deleteUserForbidden": "This user cannot be deleted. You cannot delete your own account here, and the last admin cannot be removed."
   }
 }

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -208,7 +208,20 @@
     "emailRateLimited": "リクエストが多すぎます。少し待ってからもう一度お試しください。",
     "emailAlreadyInUse": "そのメールアドレスは既に使用されています。",
     "emailCouldNotSend": "確認リンクを送信できませんでした。もう一度お試しください。",
-    "emailNetworkError": "ネットワークエラーです。接続を確認してもう一度お試しください。"
+    "emailNetworkError": "ネットワークエラーです。接続を確認してもう一度お試しください。",
+    "dangerZoneHeading": "危険な操作",
+    "dangerZoneDescription": "これらの操作は永続的で、元に戻せません。",
+    "deleteAccountButton": "アカウントを削除",
+    "deleteAccountDialogTitle": "アカウントを削除しますか？",
+    "deleteAccountDialogDescription": "アカウントと、すべてのカードグループ・カード・学習履歴が完全に削除されます。直ちにログアウトされます。この操作は元に戻せません。",
+    "deleteAccountConfirmPhrase": "アカウントを削除する",
+    "deleteAccountTypeToConfirm": "確認のため「{phrase}」と入力してください：",
+    "deleteAccountConfirmInputLabel": "アカウントを削除するには確認フレーズを入力してください",
+    "deleteAccountConfirmButton": "アカウントを削除",
+    "deleteAccountDeleting": "削除中...",
+    "deleteAccountFailed": "アカウントを削除できませんでした。もう一度お試しください。",
+    "deleteAccountForbidden": "最後の管理者であるため、アカウントを削除できません。先に他のユーザーを管理者にしてください。",
+    "deleteAccountSessionExpired": "セッションの有効期限が切れました。再度ログインしてください。"
   },
   "Onboarding": {
     "welcome": "Flamingo Armond へようこそ",
@@ -257,6 +270,16 @@
     "deleteAuthFailed": "セッションの有効期限が切れました。再度ログインしてください。",
     "systemRole": "システムロール",
     "roleNameLabel": "名前",
-    "roleNamePlaceholder": "new-role-name"
+    "roleNamePlaceholder": "new-role-name",
+    "deleteUserButton": "ユーザーを削除",
+    "deleteUserHeading": "危険な操作",
+    "deleteUserDescription": "このユーザーとすべてのデータを完全に削除します。",
+    "deleteUserDialogTitle": "このユーザーを削除しますか？",
+    "deleteUserDialogDescription": "このユーザーアカウントと、そのすべてのカードグループ・カード・学習履歴が完全に削除されます。この操作は元に戻せません。",
+    "deleteUserConfirmButton": "ユーザーを削除",
+    "deleteUserDeleting": "削除中...",
+    "deleteUserSuccess": "ユーザーを削除しました。",
+    "deleteUserFailed": "ユーザーを削除できませんでした。もう一度お試しください。",
+    "deleteUserForbidden": "このユーザーは削除できません。自分自身のアカウントはここでは削除できず、最後の管理者も削除できません。"
   }
 }

--- a/frontend/src/app/admin/users/admin-user-profile-sheet.test.tsx
+++ b/frontend/src/app/admin/users/admin-user-profile-sheet.test.tsx
@@ -604,9 +604,7 @@ describe("AdminUserProfileSheet", () => {
     await user.click(screen.getByTestId("admin-delete-user-confirm"));
 
     await waitFor(() => {
-      expect(screen.getByTestId("admin-delete-user-error")).toHaveTextContent(
-        /cannot be deleted/i,
-      );
+      expect(screen.getByTestId("admin-delete-user-error")).toHaveTextContent(/cannot be deleted/i);
     });
     // The confirm button is still present — the dialog did not auto-close.
     expect(screen.getByTestId("admin-delete-user-confirm")).toBeInTheDocument();

--- a/frontend/src/app/admin/users/admin-user-profile-sheet.test.tsx
+++ b/frontend/src/app/admin/users/admin-user-profile-sheet.test.tsx
@@ -60,6 +60,7 @@ function renderSheet({
   onDismiss = vi.fn(),
   onSaved = vi.fn(),
   onReloadRequested = vi.fn(),
+  onDelete,
 }: {
   user?: AdminUserListItem | null;
   allRoles?: AdminUserRole[];
@@ -67,6 +68,7 @@ function renderSheet({
   onDismiss?: () => void;
   onSaved?: () => void;
   onReloadRequested?: () => void;
+  onDelete?: (id: string) => Promise<void>;
 } = {}) {
   renderWithIntl(
     <MockedProvider mocks={mocks}>
@@ -79,6 +81,7 @@ function renderSheet({
         onDismiss={onDismiss}
         onSaved={onSaved}
         onReloadRequested={onReloadRequested}
+        onDelete={onDelete}
       />
     </MockedProvider>,
   );
@@ -564,5 +567,52 @@ describe("AdminUserProfileSheet", () => {
 
     expect(start).toBeGreaterThanOrEqual(0);
     expect(source.slice(start, end)).not.toContain("optimisticResponse");
+  });
+
+  it("omits the danger-zone delete button when onDelete is not provided", () => {
+    renderSheet();
+    expect(screen.queryByTestId("admin-delete-user-trigger")).not.toBeInTheDocument();
+  });
+
+  it("renders the danger-zone delete button when onDelete is provided", () => {
+    renderSheet({ onDelete: vi.fn() });
+    expect(screen.getByTestId("admin-delete-user-trigger")).toBeInTheDocument();
+  });
+
+  it("confirms deletion and calls onDelete with the user id", async () => {
+    const user = userEvent.setup();
+    const onDelete = vi.fn<(id: string) => Promise<void>>().mockResolvedValue(undefined);
+    renderSheet({ onDelete });
+
+    await user.click(screen.getByTestId("admin-delete-user-trigger"));
+    await user.click(screen.getByTestId("admin-delete-user-confirm"));
+
+    await waitFor(() => {
+      expect(onDelete).toHaveBeenCalledWith("u-1");
+    });
+  });
+
+  it("shows the forbidden copy and keeps the dialog open when onDelete rejects with FORBIDDEN", async () => {
+    const user = userEvent.setup();
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const onDelete = vi
+      .fn<(id: string) => Promise<void>>()
+      .mockRejectedValue(makeCodedError("FORBIDDEN"));
+    renderSheet({ onDelete });
+
+    await user.click(screen.getByTestId("admin-delete-user-trigger"));
+    await user.click(screen.getByTestId("admin-delete-user-confirm"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("admin-delete-user-error")).toHaveTextContent(
+        /cannot be deleted/i,
+      );
+    });
+    // The confirm button is still present — the dialog did not auto-close.
+    expect(screen.getByTestId("admin-delete-user-confirm")).toBeInTheDocument();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("adminDeleteUser rejected"),
+      expect.objectContaining({ codes: ["FORBIDDEN"] }),
+    );
   });
 });

--- a/frontend/src/app/admin/users/admin-user-profile-sheet.tsx
+++ b/frontend/src/app/admin/users/admin-user-profile-sheet.tsx
@@ -3,6 +3,16 @@
 import { useMutation } from "@apollo/client/react";
 import { useTranslations } from "next-intl";
 import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 import { FormSheet, useFormSheetClose } from "@/components/ui/form-sheet";
 import { liftGraphQLCodes } from "@/lib/apollo/graphql-errors";
@@ -18,6 +28,12 @@ type Props = {
   onDismiss: () => void;
   onSaved: () => void;
   onReloadRequested?: () => void;
+  /**
+   * Deletes the user by id. Resolves on success (the parent closes the sheet and
+   * surfaces a toast); rejects with a GraphQL error on failure so the danger
+   * zone can render the reason. Absent when deletion is not available.
+   */
+  onDelete?: (id: string) => Promise<void>;
 };
 
 const DISPLAY_NAME_MAX = 50;
@@ -40,6 +56,7 @@ export function AdminUserProfileSheet({
   onDismiss,
   onSaved,
   onReloadRequested,
+  onDelete,
 }: Props) {
   const t = useTranslations("Admin");
   const tCommon = useTranslations("Common");
@@ -206,6 +223,7 @@ export function AdminUserProfileSheet({
         }}
         onRoleToggle={toggleRole}
         onSave={handleSave}
+        onDelete={onDelete}
       />
     </FormSheet>
   );
@@ -226,6 +244,7 @@ function AdminUserProfileSheetBody({
   onDisplayNameChange,
   onRoleToggle,
   onSave,
+  onDelete,
 }: {
   allRoles: AdminUserRole[];
   bio: string;
@@ -241,11 +260,40 @@ function AdminUserProfileSheetBody({
   onDisplayNameChange: (displayName: string) => void;
   onRoleToggle: (roleId: string) => void;
   onSave: () => void;
+  onDelete?: (id: string) => Promise<void>;
 }) {
   const t = useTranslations("Admin");
   const tNav = useTranslations("Nav");
   const tCommon = useTranslations("Common");
   const close = useFormSheetClose();
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [deleteError, setDeleteError] = useState("");
+
+  async function handleConfirmDelete() {
+    if (!user || !onDelete) return;
+    setDeleteError("");
+    setDeleting(true);
+    try {
+      await onDelete(user.id);
+      // Success: the parent closes the sheet and shows a toast; this component
+      // unmounts, so no further state updates are needed here.
+    } catch (err) {
+      const codes = liftGraphQLCodes(err);
+      console.warn("[admin/users] adminDeleteUser rejected", {
+        userId: user.id,
+        codes,
+      });
+      setDeleteError(
+        codes.includes("FORBIDDEN")
+          ? t("deleteUserForbidden")
+          : codes.includes("UNAUTHENTICATED")
+            ? t("unauthenticated")
+            : t("deleteUserFailed"),
+      );
+      setDeleting(false);
+    }
+  }
 
   return (
     <div className="space-y-6">
@@ -351,6 +399,63 @@ function AdminUserProfileSheetBody({
               {tCommon("cancel")}
             </Button>
           </div>
+
+          {onDelete && (
+            <div className="space-y-3 border-t border-destructive/30 pt-6">
+              <div>
+                <h3 className="text-sm font-semibold text-destructive">{t("deleteUserHeading")}</h3>
+                <p className="text-xs text-muted-foreground">{t("deleteUserDescription")}</p>
+              </div>
+
+              {deleteError && (
+                <div
+                  className="rounded-md bg-destructive/10 p-3 text-sm text-destructive"
+                  role="alert"
+                  data-testid="admin-delete-user-error"
+                >
+                  {deleteError}
+                </div>
+              )}
+
+              <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
+                <AlertDialogTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="destructive"
+                    data-testid="admin-delete-user-trigger"
+                  >
+                    {t("deleteUserButton")}
+                  </Button>
+                </AlertDialogTrigger>
+                <AlertDialogContent>
+                  <AlertDialogHeader>
+                    <AlertDialogTitle>{t("deleteUserDialogTitle")}</AlertDialogTitle>
+                    <AlertDialogDescription>
+                      {t("deleteUserDialogDescription")}
+                    </AlertDialogDescription>
+                  </AlertDialogHeader>
+                  <AlertDialogFooter>
+                    <AlertDialogCancel disabled={deleting}>{tCommon("cancel")}</AlertDialogCancel>
+                    {/*
+                      A plain destructive Button (not AlertDialogAction) drives the
+                      confirm so the dialog stays open during the async mutation and
+                      while a FORBIDDEN error is shown. AlertDialogAction auto-closes
+                      the dialog on click, which would hide the in-progress / error UI.
+                    */}
+                    <Button
+                      type="button"
+                      variant="destructive"
+                      onClick={handleConfirmDelete}
+                      disabled={deleting}
+                      data-testid="admin-delete-user-confirm"
+                    >
+                      {deleting ? t("deleteUserDeleting") : t("deleteUserConfirmButton")}
+                    </Button>
+                  </AlertDialogFooter>
+                </AlertDialogContent>
+              </AlertDialog>
+            </div>
+          )}
         </>
       )}
     </div>

--- a/frontend/src/app/admin/users/admin-users-client.test.tsx
+++ b/frontend/src/app/admin/users/admin-users-client.test.tsx
@@ -1,5 +1,7 @@
 // @vitest-environment jsdom
 
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { InMemoryCache } from "@apollo/client";
 import { MockedProvider } from "@apollo/client/testing/react";
 import { screen, waitFor } from "@testing-library/react";
@@ -7,6 +9,7 @@ import userEvent from "@testing-library/user-event";
 import { GraphQLError } from "graphql";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  AdminDeleteUserDocument,
   AdminEditUserDocument,
   AdminRolesDocument,
   AdminUserDocument,
@@ -35,6 +38,11 @@ vi.mock("next/navigation", () => ({
     replace: mockReplace,
   }),
   useSearchParams: () => new URLSearchParams(mockSearchParamsValue),
+}));
+
+const toastSuccessMock = vi.fn();
+vi.mock("sonner", () => ({
+  toast: { success: (...args: unknown[]) => toastSuccessMock(...args) },
 }));
 
 vi.mock("next/link", () => ({
@@ -155,6 +163,7 @@ beforeEach(() => {
   mockPush.mockReset();
   mockReplace.mockReset();
   mockRefresh.mockReset();
+  toastSuccessMock.mockReset();
   mockPathname = "/admin/users";
   mockSearchParamsValue = "";
   vi.stubGlobal("IntersectionObserver", FakeIntersectionObserver);
@@ -473,5 +482,93 @@ describe("<AdminUsersClient> fetchMore catch", () => {
     expect(warnCall?.[1]).not.toHaveProperty("message");
 
     consoleWarnSpy.mockRestore();
+  });
+});
+
+describe("<AdminUsersClient> delete", () => {
+  it("deletes a user, drops the row from the cached connection, and toasts", async () => {
+    const user = userEvent.setup();
+    mockSearchParamsValue = "edit=u-1";
+    leakSpy.teardown();
+    leakSpy = installApolloMockLeakSpy({
+      operationNames: ["AdminUsers", "AdminRoles", "AdminUser", "AdminDeleteUser"],
+    });
+
+    const cache = new InMemoryCache();
+    const initialVars = { first: ADMIN_USERS_PAGE_SIZE, search: null };
+    const conn = makeConnection([USER_1, USER_2], false, 2);
+    cache.writeQuery({
+      query: AdminUsersDocument,
+      variables: initialVars,
+      data: { users: conn },
+    });
+
+    const mocks = [
+      {
+        request: { query: AdminUsersDocument, variables: initialVars },
+        result: { data: { users: conn } },
+      },
+      makeRolesMock(),
+      {
+        request: { query: AdminUserDocument, variables: { id: "u-1" } },
+        result: { data: { adminUser: USER_1 } },
+      },
+      {
+        request: { query: AdminDeleteUserDocument, variables: { id: "u-1" } },
+        result: { data: { adminDeleteUser: true } },
+      },
+      // Evicting User:u-1 makes the still-open sheet's network-only lazy query
+      // re-observe and re-fetch (a test artifact — in production sheet.close()
+      // drops ?edit so editUserId becomes null and the query unmounts). The user
+      // is gone, so this absorbing response returns null.
+      {
+        request: { query: AdminUserDocument, variables: { id: "u-1" } },
+        result: { data: { adminUser: null } },
+      },
+    ];
+
+    renderWithIntl(
+      <MockedProvider mocks={mocks} cache={cache}>
+        <AdminUsersClient />
+      </MockedProvider>,
+    );
+
+    // The sheet opens for u-1, exposing its danger-zone delete trigger.
+    await screen.findByTestId("admin-delete-user-trigger");
+    expect(screen.getByTestId("admin-user-row-u-1")).toBeInTheDocument();
+    expect(screen.getByTestId("admin-user-row-u-2")).toBeInTheDocument();
+
+    await user.click(screen.getByTestId("admin-delete-user-trigger"));
+    await user.click(screen.getByTestId("admin-delete-user-confirm"));
+
+    // cache.modify removes the u-1 edge from the live connection; the list
+    // re-renders without that row while u-2 stays.
+    await waitFor(() => {
+      expect(screen.queryByTestId("admin-user-row-u-1")).not.toBeInTheDocument();
+    });
+    expect(screen.getByTestId("admin-user-row-u-2")).toBeInTheDocument();
+    expect(toastSuccessMock).toHaveBeenCalledWith("User deleted.");
+
+    // The cached connection reflects the removal and the decremented totalCount,
+    // and the normalized User entity was evicted.
+    const after = cache.readQuery<{ users: typeof conn }>({
+      query: AdminUsersDocument,
+      variables: initialVars,
+    });
+    expect(after?.users.edges.map((edge) => edge.cursor)).toEqual(["u-2"]);
+    expect(after?.users.totalCount).toBe(1);
+    expect(cache.extract()["User:u-1"]).toBeUndefined();
+  });
+
+  it("does not configure optimisticResponse for adminDeleteUser", () => {
+    const source = readFileSync(
+      join(process.cwd(), "src/app/admin/users/admin-users-client.tsx"),
+      "utf8",
+    );
+    const start = source.indexOf("runDeleteUser({");
+    const end = source.indexOf("});", start);
+
+    expect(start).toBeGreaterThanOrEqual(0);
+    expect(source.slice(start, end)).not.toContain("optimisticResponse");
   });
 });

--- a/frontend/src/app/admin/users/admin-users-client.tsx
+++ b/frontend/src/app/admin/users/admin-users-client.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import { NetworkStatus } from "@apollo/client";
-import { useLazyQuery, useQuery } from "@apollo/client/react";
+import { useApolloClient, useLazyQuery, useMutation, useQuery } from "@apollo/client/react";
 import Link from "next/link";
 import { useTranslations } from "next-intl";
 import { useCallback, useEffect, useEffectEvent, useMemo, useRef, useState } from "react";
+import { toast } from "sonner";
 import { useFragment } from "@/generated/fragment-masking";
 import type { AdminUsersQuery as AdminUsersQueryResult } from "@/generated/graphql";
 import {
@@ -19,6 +20,7 @@ import { type AdminUserListItem, AdminUserRow } from "./admin-user-row";
 import { AdminUsersSkeleton } from "./admin-users-skeleton";
 import {
   ADMIN_USERS_PAGE_SIZE,
+  AdminDeleteUserMutation,
   AdminRoleFieldsFragment,
   AdminRolesQuery,
   AdminUserFieldsFragment,
@@ -176,6 +178,50 @@ export function AdminUsersClient() {
     if (!editUserId) return;
     void loadAdminUser({ variables: { id: editUserId } });
   }, [editUserId, loadAdminUser, refetch]);
+
+  const apolloClient = useApolloClient();
+  const [runDeleteUser] = useMutation(AdminDeleteUserMutation);
+
+  // Deletes a user, updates the cache, toasts, and closes the sheet. Rejects on
+  // failure (e.g. FORBIDDEN) so the sheet's danger zone can render the reason.
+  const handleDeleteUser = useCallback(
+    async (id: string) => {
+      const result = await runDeleteUser({ variables: { id } });
+      if (!result.data?.adminDeleteUser) {
+        throw new Error("adminDeleteUser returned false");
+      }
+      // Drop the deleted user from every cached `users` connection variant (each
+      // search / pagination combo is a separate field entry). The edge cursor
+      // equals the user id by schema contract, so filter on cursor and avoid
+      // unmasking the node fragment. Then evict the now-orphaned entity.
+      apolloClient.cache.modify({
+        fields: {
+          users(existing) {
+            const connection = existing as {
+              edges?: ReadonlyArray<{ cursor: string }>;
+              totalCount?: number;
+            };
+            if (!connection.edges) return existing;
+            const edges = connection.edges.filter((edge) => edge.cursor !== id);
+            if (edges.length === connection.edges.length) return existing;
+            return {
+              ...connection,
+              edges,
+              totalCount: Math.max(0, (connection.totalCount ?? 0) - 1),
+            };
+          },
+        },
+      });
+      const cacheId = apolloClient.cache.identify({ __typename: "User", id });
+      if (cacheId) {
+        apolloClient.cache.evict({ id: cacheId });
+        apolloClient.cache.gc();
+      }
+      toast.success(t("deleteUserSuccess"));
+      sheet.close();
+    },
+    [apolloClient, runDeleteUser, sheet, t],
+  );
 
   const fetchNextPage = useCallback(
     ({ hasNextPage, endCursor, searchQuery }: FetchNextPageInput) => {
@@ -391,6 +437,7 @@ export function AdminUsersClient() {
         onDismiss={() => sheet.close()}
         onSaved={() => sheet.close({ refresh: true })}
         onReloadRequested={reloadEditedUser}
+        onDelete={handleDeleteUser}
       />
     </main>
   );

--- a/frontend/src/app/admin/users/queries.ts
+++ b/frontend/src/app/admin/users/queries.ts
@@ -116,3 +116,9 @@ export const AdminEditUserMutation = graphql(`
     }
   }
 `);
+
+export const AdminDeleteUserMutation = graphql(`
+  mutation AdminDeleteUser($id: ID!) {
+    adminDeleteUser(id: $id)
+  }
+`);

--- a/frontend/src/app/profile/delete-account-section.test.tsx
+++ b/frontend/src/app/profile/delete-account-section.test.tsx
@@ -1,0 +1,152 @@
+// @vitest-environment jsdom
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { CombinedGraphQLErrors } from "@apollo/client/errors";
+import { MockedProvider } from "@apollo/client/testing/react";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DeleteMyAccountDocument } from "@/generated/graphql";
+import { renderWithIntl } from "@/test/render-with-intl";
+
+const mockReplace = vi.fn();
+const mockRefresh = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: mockReplace, refresh: mockRefresh }),
+}));
+
+const mockSignOut = vi.fn();
+vi.mock("@/lib/supabase/client", () => ({
+  createSupabaseBrowserClient: () => ({
+    auth: { signOut: () => mockSignOut() },
+  }),
+}));
+
+import { DeleteAccountSection } from "./delete-account-section";
+
+const CONFIRM_PHRASE = "delete my account";
+
+function makeCodedError(code: string): CombinedGraphQLErrors {
+  return new CombinedGraphQLErrors({
+    errors: [{ message: "transport", extensions: { code } }],
+  });
+}
+
+function successMock() {
+  return {
+    request: { query: DeleteMyAccountDocument },
+    result: { data: { deleteMyAccount: true } },
+  };
+}
+
+function errorMock(code: string) {
+  return {
+    request: { query: DeleteMyAccountDocument },
+    error: makeCodedError(code),
+  };
+}
+
+function renderSection(mocks: React.ComponentProps<typeof MockedProvider>["mocks"] = []) {
+  renderWithIntl(
+    <MockedProvider mocks={mocks}>
+      <DeleteAccountSection />
+    </MockedProvider>,
+  );
+}
+
+beforeEach(() => {
+  mockReplace.mockReset();
+  mockRefresh.mockReset();
+  mockSignOut.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("<DeleteAccountSection>", () => {
+  it("renders the danger zone with a delete trigger", () => {
+    renderSection();
+    expect(screen.getByRole("heading", { name: /danger zone/i })).toBeInTheDocument();
+    expect(screen.getByTestId("delete-account-trigger")).toBeInTheDocument();
+  });
+
+  it("gates the confirm button on typing the exact phrase", async () => {
+    const user = userEvent.setup();
+    renderSection();
+
+    await user.click(screen.getByTestId("delete-account-trigger"));
+    expect(screen.getByTestId("delete-account-confirm")).toBeDisabled();
+
+    await user.type(screen.getByTestId("delete-account-confirm-input"), "delete");
+    expect(screen.getByTestId("delete-account-confirm")).toBeDisabled();
+
+    await user.clear(screen.getByTestId("delete-account-confirm-input"));
+    await user.type(screen.getByTestId("delete-account-confirm-input"), CONFIRM_PHRASE);
+    expect(screen.getByTestId("delete-account-confirm")).toBeEnabled();
+  });
+
+  it("on success signs out and redirects to /login", async () => {
+    const user = userEvent.setup();
+    mockSignOut.mockResolvedValue({ error: null });
+    renderSection([successMock()]);
+
+    await user.click(screen.getByTestId("delete-account-trigger"));
+    await user.type(screen.getByTestId("delete-account-confirm-input"), CONFIRM_PHRASE);
+    await user.click(screen.getByTestId("delete-account-confirm"));
+
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith("/login");
+    });
+    expect(mockSignOut).toHaveBeenCalledTimes(1);
+    expect(mockRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("still redirects when signOut fails (non-fatal)", async () => {
+    const user = userEvent.setup();
+    mockSignOut.mockResolvedValue({ error: { message: "network" } });
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    renderSection([successMock()]);
+
+    await user.click(screen.getByTestId("delete-account-trigger"));
+    await user.type(screen.getByTestId("delete-account-confirm-input"), CONFIRM_PHRASE);
+    await user.click(screen.getByTestId("delete-account-confirm"));
+
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith("/login");
+    });
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("signOut after deleteMyAccount failed"),
+      "network",
+    );
+  });
+
+  it("shows the last-admin copy and does not redirect on FORBIDDEN", async () => {
+    const user = userEvent.setup();
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    renderSection([errorMock("FORBIDDEN")]);
+
+    await user.click(screen.getByTestId("delete-account-trigger"));
+    await user.type(screen.getByTestId("delete-account-confirm-input"), CONFIRM_PHRASE);
+    await user.click(screen.getByTestId("delete-account-confirm"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("delete-account-error")).toHaveTextContent(/last admin/i);
+    });
+    expect(mockReplace).not.toHaveBeenCalled();
+    expect(mockSignOut).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(
+      "[profile] deleteMyAccount rejected",
+      expect.objectContaining({ codes: ["FORBIDDEN"] }),
+    );
+  });
+
+  it("does not configure optimisticResponse for deleteMyAccount", () => {
+    const source = readFileSync(
+      join(process.cwd(), "src/app/profile/delete-account-section.tsx"),
+      "utf8",
+    );
+    expect(source).not.toContain("optimisticResponse");
+  });
+});

--- a/frontend/src/app/profile/delete-account-section.test.tsx
+++ b/frontend/src/app/profile/delete-account-section.test.tsx
@@ -103,9 +103,11 @@ describe("<DeleteAccountSection>", () => {
     expect(mockRefresh).toHaveBeenCalledTimes(1);
   });
 
-  it("still redirects when signOut fails (non-fatal)", async () => {
+  it("still redirects when signOut fails (non-fatal) without leaking the error message", async () => {
     const user = userEvent.setup();
-    mockSignOut.mockResolvedValue({ error: { message: "network" } });
+    mockSignOut.mockResolvedValue({
+      error: Object.assign(new Error("network"), { name: "AuthApiError" }),
+    });
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     renderSection([successMock()]);
 
@@ -116,9 +118,14 @@ describe("<DeleteAccountSection>", () => {
     await waitFor(() => {
       expect(mockReplace).toHaveBeenCalledWith("/login");
     });
+    // The warn logs the stable error name, never error.message (redact rule).
     expect(warnSpy).toHaveBeenCalledWith(
       expect.stringContaining("signOut after deleteMyAccount failed"),
-      "network",
+      expect.objectContaining({ name: "AuthApiError" }),
+    );
+    expect(warnSpy).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ message: expect.anything() }),
     );
   });
 
@@ -139,6 +146,26 @@ describe("<DeleteAccountSection>", () => {
     expect(warnSpy).toHaveBeenCalledWith(
       "[profile] deleteMyAccount rejected",
       expect.objectContaining({ codes: ["FORBIDDEN"] }),
+    );
+  });
+
+  it("shows the session-expired copy and does not redirect on UNAUTHENTICATED", async () => {
+    const user = userEvent.setup();
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    renderSection([errorMock("UNAUTHENTICATED")]);
+
+    await user.click(screen.getByTestId("delete-account-trigger"));
+    await user.type(screen.getByTestId("delete-account-confirm-input"), CONFIRM_PHRASE);
+    await user.click(screen.getByTestId("delete-account-confirm"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("delete-account-error")).toHaveTextContent(/session has expired/i);
+    });
+    expect(mockReplace).not.toHaveBeenCalled();
+    expect(mockSignOut).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(
+      "[profile] deleteMyAccount rejected",
+      expect.objectContaining({ codes: ["UNAUTHENTICATED"] }),
     );
   });
 

--- a/frontend/src/app/profile/delete-account-section.tsx
+++ b/frontend/src/app/profile/delete-account-section.tsx
@@ -64,7 +64,12 @@ export function DeleteAccountSection() {
       const supabase = createSupabaseBrowserClient();
       const { error } = await supabase.auth.signOut();
       if (error) {
-        console.warn("[profile] signOut after deleteMyAccount failed:", error.message);
+        // Redact error.message — Supabase auth errors can carry user-identifying
+        // content (see .claude/rules/frontend-rsc-error-handling.md). Log the
+        // stable error name only.
+        console.warn("[profile] signOut after deleteMyAccount failed", {
+          name: error instanceof Error ? error.name : "unknown",
+        });
       }
       router.replace("/login");
       router.refresh();

--- a/frontend/src/app/profile/delete-account-section.tsx
+++ b/frontend/src/app/profile/delete-account-section.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import { useMutation } from "@apollo/client/react";
+import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
+import { useState } from "react";
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import { liftGraphQLCodes } from "@/lib/apollo/graphql-errors";
+import { createSupabaseBrowserClient } from "@/lib/supabase/client";
+import { DeleteMyAccountMutation } from "./mutations";
+
+/**
+ * Danger zone on `/profile`: lets the signed-in user permanently delete their
+ * own account. A type-to-confirm input gates the irreversible action. On
+ * success the local Supabase session is cleared and the user is redirected to
+ * `/login`.
+ */
+export function DeleteAccountSection() {
+  const t = useTranslations("Profile");
+  const tCommon = useTranslations("Common");
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [confirmInput, setConfirmInput] = useState("");
+  const [deleting, setDeleting] = useState(false);
+  const [deleteError, setDeleteError] = useState("");
+  const [runDelete] = useMutation(DeleteMyAccountMutation);
+
+  const confirmPhrase = t("deleteAccountConfirmPhrase");
+  const confirmed = confirmInput.trim() === confirmPhrase;
+
+  function handleOpenChange(next: boolean) {
+    setOpen(next);
+    if (!next) {
+      setConfirmInput("");
+      setDeleteError("");
+    }
+  }
+
+  async function handleConfirmDelete() {
+    if (!confirmed || deleting) return;
+    setDeleteError("");
+    setDeleting(true);
+    try {
+      const result = await runDelete();
+      if (!result.data?.deleteMyAccount) {
+        setDeleteError(t("deleteAccountFailed"));
+        setDeleting(false);
+        return;
+      }
+      // The account no longer exists; clear the Supabase session and leave the
+      // app. A signOut failure is non-fatal — the account is gone regardless, so
+      // log it and redirect anyway (the middleware treats the next request as
+      // anonymous once the cookie is cleared or the user row is missing).
+      const supabase = createSupabaseBrowserClient();
+      const { error } = await supabase.auth.signOut();
+      if (error) {
+        console.warn("[profile] signOut after deleteMyAccount failed:", error.message);
+      }
+      router.replace("/login");
+      router.refresh();
+      // No further state updates — this component unmounts on navigation.
+    } catch (err) {
+      const codes = liftGraphQLCodes(err);
+      console.warn("[profile] deleteMyAccount rejected", { codes });
+      setDeleteError(
+        codes.includes("FORBIDDEN")
+          ? t("deleteAccountForbidden")
+          : codes.includes("UNAUTHENTICATED")
+            ? t("deleteAccountSessionExpired")
+            : t("deleteAccountFailed"),
+      );
+      setDeleting(false);
+    }
+  }
+
+  return (
+    <section
+      className="space-y-4 border-t border-destructive/30 pt-6"
+      aria-labelledby="profile-danger-zone-heading"
+    >
+      <div>
+        <h2 id="profile-danger-zone-heading" className="text-xl font-semibold text-destructive">
+          {t("dangerZoneHeading")}
+        </h2>
+        <p className="text-sm text-muted-foreground">{t("dangerZoneDescription")}</p>
+      </div>
+
+      <AlertDialog open={open} onOpenChange={handleOpenChange}>
+        <AlertDialogTrigger asChild>
+          <Button type="button" variant="destructive" data-testid="delete-account-trigger">
+            {t("deleteAccountButton")}
+          </Button>
+        </AlertDialogTrigger>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t("deleteAccountDialogTitle")}</AlertDialogTitle>
+            <AlertDialogDescription>{t("deleteAccountDialogDescription")}</AlertDialogDescription>
+          </AlertDialogHeader>
+
+          <div className="space-y-2">
+            <label htmlFor="delete-account-confirm" className="block text-sm">
+              {t("deleteAccountTypeToConfirm", { phrase: confirmPhrase })}
+            </label>
+            <input
+              id="delete-account-confirm"
+              type="text"
+              value={confirmInput}
+              onChange={(event) => setConfirmInput(event.target.value)}
+              placeholder={confirmPhrase}
+              autoComplete="off"
+              className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              data-testid="delete-account-confirm-input"
+              aria-label={t("deleteAccountConfirmInputLabel")}
+            />
+          </div>
+
+          {deleteError && (
+            <div
+              className="rounded-md bg-destructive/10 p-3 text-sm text-destructive"
+              role="alert"
+              data-testid="delete-account-error"
+            >
+              {deleteError}
+            </div>
+          )}
+
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={deleting}>{tCommon("cancel")}</AlertDialogCancel>
+            {/*
+              A plain destructive Button (not AlertDialogAction) drives the
+              confirm so the dialog stays open during the async mutation and while
+              a FORBIDDEN (last-admin) error is shown.
+            */}
+            <Button
+              type="button"
+              variant="destructive"
+              onClick={handleConfirmDelete}
+              disabled={!confirmed || deleting}
+              data-testid="delete-account-confirm"
+            >
+              {deleting ? t("deleteAccountDeleting") : t("deleteAccountConfirmButton")}
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </section>
+  );
+}

--- a/frontend/src/app/profile/mutations.ts
+++ b/frontend/src/app/profile/mutations.ts
@@ -1,0 +1,7 @@
+import { graphql } from "@/generated";
+
+export const DeleteMyAccountMutation = graphql(`
+  mutation DeleteMyAccount {
+    deleteMyAccount
+  }
+`);

--- a/frontend/src/app/profile/profile-page-client.tsx
+++ b/frontend/src/app/profile/profile-page-client.tsx
@@ -8,6 +8,7 @@ import { LanguageSwitcher } from "@/components/settings/language-switcher";
 import { Button } from "@/components/ui/button";
 import { FormSheet, useFormSheetClose } from "@/components/ui/form-sheet";
 import { useSheetSearchParam } from "@/lib/url/use-sheet-search-param";
+import { DeleteAccountSection } from "./delete-account-section";
 import { ProfileForm } from "./profile-form";
 
 type Props = {
@@ -140,6 +141,8 @@ export function ProfilePageClient({ email, initial }: Props) {
           </div>
           <LanguageSwitcher />
         </section>
+
+        <DeleteAccountSection />
       </div>
 
       <FormSheet

--- a/schema/admin.graphql
+++ b/schema/admin.graphql
@@ -137,4 +137,14 @@ extend type Mutation {
   updateRole(id: ID!, name: String!): UpdateRoleResult!
   """Admin-only. Delete a role. The system role "admin" cannot be deleted (FORBIDDEN). Returns true on success."""
   deleteRole(id: ID!): Boolean!
+  """
+  Admin-only. Permanently delete a user account and all associated data
+  (cardgroups, cards, learning history, preferences, role assignments) via
+  database cascade. Returns true on success.
+
+  FORBIDDEN when the caller targets their own id (an admin must use
+  `deleteMyAccount` to leave) or when the target is the last remaining admin.
+  Non-admin callers receive FORBIDDEN.
+  """
+  adminDeleteUser(id: ID!): Boolean!
 }

--- a/schema/user.graphql
+++ b/schema/user.graphql
@@ -42,4 +42,14 @@ type Mutation {
   Unauthenticated callers receive an error with `extensions.code = "UNAUTHENTICATED"`.
   """
   updateProfile(input: UpdateProfileInput!): UpdateProfileResult!
+  """
+  Permanently deletes the authenticated caller's own account and all associated
+  data (cardgroups, cards, learning history, preferences, role assignments) via
+  database cascade. Returns true on success.
+
+  Unauthenticated callers receive an error with `extensions.code = "UNAUTHENTICATED"`.
+  FORBIDDEN when the caller is the last remaining admin (promote another admin
+  first).
+  """
+  deleteMyAccount: Boolean!
 }


### PR DESCRIPTION
## Summary

- Adds the ability to **permanently delete a user account and cascade-delete all of their data** (cardgroups, cards, learning history / FSRS state, swipe records, preferences, role assignments).
- Two GraphQL mutations: **`adminDeleteUser(id)`** — admin-only, from the admin user-management screen — and **`deleteMyAccount`** — self-service account deletion from `/profile`.
- **The cascade is database-enforced.** A single `DELETE FROM auth.users WHERE id = ?` cascades through the entire user-owned graph via the schema's existing `ON DELETE CASCADE` foreign keys (`public.users` -> `user_roles` / `cardgroups` -> `cards` -> `swipe_records` / `user_card_fsrs` / `user_preferences`). No application-level multi-step delete is needed. Deleting `auth.users` (not just `public.users`) is required so the account cannot resurrect via the `handle_new_user` trigger on next login.
- **The `auth.users` delete is isolated behind one repository method** (`UserRepository.DeleteAuthUser`) so a future swap to the Supabase Admin REST API would be a single-method change.
- **Safety guards:** `adminDeleteUser` blocks self-deletion (an admin must use `deleteMyAccount` to leave) and blocks deleting the last remaining admin; `deleteMyAccount` blocks the last admin from removing themselves. All guard violations surface as `FORBIDDEN`.

No related issue — direct feature request.

**Production privilege verified.** Hosted Supabase restricts the `auth.users` table to owner `supabase_auth_admin`, but `has_table_privilege('postgres','auth.users','DELETE')` returns `true` on the production DB — and `postgres` is the role the backend connects as via `SUPABASE_DB_URL`. So the raw-SQL approach works in production as-is; no Admin-API swap is required.

## Changes

### Schema (`schema/admin.graphql`, `schema/user.graphql`)

- `adminDeleteUser(id: ID!): Boolean!` and `deleteMyAccount: Boolean!`. Both return `Boolean!` and surface guard violations as top-level `FORBIDDEN` errors, mirroring the existing `deleteRole` / `deleteCardgroup` shape.

### Repository (`backend/internal/repository/user.go`)

- New `DeleteAuthUser(ctx, id)` runs `DELETE FROM auth.users WHERE id = ?` (parameterised) and maps `RowsAffected == 0` to `ErrNotFound`. This is the single isolation point for auth-account deletion.

### Usecase (`backend/internal/usecase/admin_user.go`, `user.go`)

- `adminUserUsecase.DeleteUser`: admin gate -> self-deletion block -> last-admin guard (`HasRole` + `CountAdmins`) -> delete. Missing target maps to a `BAD_USER_INPUT` validation error.
- `userUsecase.DeleteMyAccount`: auth check -> last-admin guard (reuses the injected `AdminChecker.IsAdmin` + `CountAdmins`) -> delete. A missing row is treated as idempotent success.
- Wiring is unchanged in `cmd/server/main.go` — the narrow consumer interfaces were widened and the production repositories already satisfy them, so no constructor signatures changed.

### Resolver (`backend/graph/resolver/{admin,user}.resolvers.go`)

- Thin delegates that wrap every usecase error via `gqlerr.FromUsecaseError`, matching the existing `deleteRole` resolver.

### Frontend — admin delete (`frontend/src/app/admin/users/*`)

- A **Danger Zone** in the admin user sheet (`admin-user-profile-sheet.tsx`) with a confirm `AlertDialog`. On confirm it calls an `onDelete(id)` prop and renders the `FORBIDDEN` reason inline (the dialog stays open on error).
- The parent `admin-users-client.tsx` owns the `AdminDeleteUserMutation` and the Apollo cache update: `cache.modify` filters the deleted edge out of **every** cached `users` connection variant (keyed on `edge.cursor`, which equals the user id), decrements `totalCount` (clamped at 0), then `cache.evict` + `cache.gc`. No `optimisticResponse` (typed-error-capable mutation), enforced by a static-source regression test.

### Frontend — self-service deletion (`frontend/src/app/profile/*`)

- New `delete-account-section.tsx`: a type-to-confirm `AlertDialog` on `/profile`. On success it clears the Supabase session (`auth.signOut()`, non-fatal) and redirects to `/login`. The signOut-error log redacts `error.message` per the PII-redaction rule.

### i18n (`frontend/messages/{en,ja}.json`)

- New `Admin.*` and `Profile.*` keys for the delete buttons, dialogs, confirm copy, and toasts (Japanese strings confined to the catalogs, per the English-only-source rule).

## Verification

- **Backend:** `go build ./...` ✓ · `go vet ./...` ✓ · `go test ./internal/usecase/... ./graph/resolver/... ./internal/loader/...` ✓ (**614 unit tests**) · `go tool go-arch-lint check` ✓ (no layer violations) · `gofmt` clean
- **Backend gates:** no `fmt.Errorf("%w")` in `internal/`/`cmd/`; no CJK in Go source
- **Frontend:** `typecheck` ✓ · `test` ✓ (**1191 tests / 123 files**) · `knip` ✓ · `build` ✓ · CJK source check ✓ (Japanese confined to `messages/*.json`)
- **Production DB:** `has_table_privilege('postgres','auth.users','DELETE')` = `true` (verified against prod)
- Backend repository integration tests (the `auth.users` cascade) compile (`go vet`) and run in **CI** via testcontainers — they are not run locally (Docker unavailable in the dev environment).

## Test plan

- [ ] As an admin, delete another user from `/admin/users` -> the row disappears, the count decrements, and a success toast shows; the user's cardgroups/cards/learning data are gone.
- [ ] As an admin, attempt to delete your own account from the admin sheet -> `FORBIDDEN` reason shown, dialog stays open.
- [ ] As the only admin, attempt to delete the last admin (self or other) -> `FORBIDDEN`.
- [ ] Self-service: on `/profile`, type the confirm phrase and delete -> signed out and redirected to `/login`; logging back in starts a fresh account.
- [ ] As the only admin, attempt self-service deletion -> `FORBIDDEN` ("promote another admin first").
- [ ] CI: the backend repository integration tests (testcontainers cascade) pass.
