### PR TITLE
feat(notion): repoint sync to master tables

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -22,12 +22,12 @@ SUPER_USER_EMAILS=
 PING_TOKEN=
 
 # Notion page -> card sync (REQUIRED -- server fails to start if any required
-# value is empty). NOTION_TARGET_OWNER_ID is the public.users/auth.users UUID
-# that owns the destination cardgroup.
+# value is empty). The sync writes into the admin-only master_* catalog tables.
+# NOTION_MASTER_CARDGROUP_NAME identifies the owner-less master cardgroup by
+# name; the backend creates it when absent.
 NOTION_TOKEN=
 NOTION_PAGE_IDS=
-NOTION_TARGET_OWNER_ID=
-NOTION_TARGET_CARDGROUP_NAME=
+NOTION_MASTER_CARDGROUP_NAME=
 NOTION_SYNC_TOKEN=
 NOTION_MAX_ATTEMPTS=5
 NOTION_MAX_ELAPSED=2m

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -304,7 +304,9 @@ func run(ctx context.Context, logger *slog.Logger) error {
 		notionFetcher := notion.NewFetcher(notionEnv.NotionToken, retryCfg)
 		notionWriter := notion.NewWriter(notionEnv.NotionToken, retryCfg)
 		cardObserver = notion.NewCardWritebacker(notionWriter, notionEnv.HandlerConfig.PageIDs[0], logger)
-		notionSyncUC := usecase.NewNotionSyncUsecase(notionFetcher, cardgroupRepo, cardRepo, db.GORM, logger)
+		masterCardgroupRepo := repository.NewMasterCardgroupRepository(db.GORM)
+		masterCardRepo := repository.NewMasterCardRepository(db.GORM)
+		notionSyncUC := usecase.NewMasterNotionSyncUsecase(notionFetcher, masterCardgroupRepo, masterCardRepo, db.GORM, logger)
 		notionSyncHandler = notionsync.New(notionSyncUC, notionEnv.HandlerConfig)
 	}
 	cardUC := usecase.NewCardUsecase(db.GORM, cardRepo, cardgroupRepo, userCardFSRSRepo, cardObserver, logger)
@@ -378,7 +380,7 @@ func main() {
 
 	// Load .env.local for local dev. Overload (not Load) so .env.local wins
 	// over inherited shell env: mise auto-exports the root .env (production
-	// template, with empty placeholders for keys like NOTION_TARGET_OWNER_ID),
+	// template, with empty placeholders for keys like NOTION_MASTER_CARDGROUP_NAME),
 	// which would otherwise mask the local-dev values written by
 	// `make notion-local-setup`. Production (Render) is unaffected because
 	// .env.local is gitignored and never deployed.

--- a/backend/cmd/server/main_test.go
+++ b/backend/cmd/server/main_test.go
@@ -157,19 +157,17 @@ func setNotionSyncEnv(t *testing.T) {
 	t.Helper()
 	t.Setenv("NOTION_TOKEN", "notion-test-token")
 	t.Setenv("NOTION_PAGE_IDS", "page-1,page-2")
-	t.Setenv("NOTION_TARGET_OWNER_ID", uuid.NewString())
-	t.Setenv("NOTION_TARGET_CARDGROUP_NAME", "English")
+	t.Setenv("NOTION_MASTER_CARDGROUP_NAME", "English")
 	t.Setenv("NOTION_SYNC_TOKEN", "sync-test-token")
 }
 
-// unsetNotionSyncEnv blanks all five NOTION_* vars so that run() treats
+// unsetNotionSyncEnv blanks all four NOTION_* vars so that run() treats
 // notion-sync as disabled and skips registering /internal/notion-sync.
 func unsetNotionSyncEnv(t *testing.T) {
 	t.Helper()
 	t.Setenv("NOTION_TOKEN", "")
 	t.Setenv("NOTION_PAGE_IDS", "")
-	t.Setenv("NOTION_TARGET_OWNER_ID", "")
-	t.Setenv("NOTION_TARGET_CARDGROUP_NAME", "")
+	t.Setenv("NOTION_MASTER_CARDGROUP_NAME", "")
 	t.Setenv("NOTION_SYNC_TOKEN", "")
 }
 

--- a/backend/internal/handler/notionsync/config.go
+++ b/backend/internal/handler/notionsync/config.go
@@ -15,7 +15,7 @@ type EnvConfig struct {
 	HandlerConfig Config
 }
 
-// varOrder defines the deterministic iteration order for the five required
+// varOrder defines the deterministic iteration order for the four required
 // NOTION_* env vars. The order is fixed so that OptionalConfigFromEnv returns
 // a stable missing slice regardless of map-iteration randomness, and so that
 // ConfigFromEnv always reports the first missing var in the same predictable
@@ -23,12 +23,11 @@ type EnvConfig struct {
 var varOrder = []string{
 	"NOTION_TOKEN",
 	"NOTION_PAGE_IDS",
-	"NOTION_TARGET_OWNER_ID",
-	"NOTION_TARGET_CARDGROUP_NAME",
+	"NOTION_MASTER_CARDGROUP_NAME",
 	"NOTION_SYNC_TOKEN",
 }
 
-// OptionalConfigFromEnv reads the five NOTION_* env vars and reports which (if
+// OptionalConfigFromEnv reads the four NOTION_* env vars and reports which (if
 // any) are missing or whitespace-only. When missing is empty, the returned
 // EnvConfig is fully populated and the handler should be wired up. When
 // missing is non-empty, the handler should be skipped and the caller should
@@ -57,15 +56,14 @@ func OptionalConfigFromEnv() (cfg EnvConfig, missing []string, err error) {
 	return EnvConfig{
 		NotionToken: vals["NOTION_TOKEN"],
 		HandlerConfig: Config{
-			Token:         vals["NOTION_SYNC_TOKEN"],
-			PageIDs:       pageIDs,
-			OwnerID:       vals["NOTION_TARGET_OWNER_ID"],
-			CardgroupName: vals["NOTION_TARGET_CARDGROUP_NAME"],
+			Token:               vals["NOTION_SYNC_TOKEN"],
+			PageIDs:             pageIDs,
+			MasterCardgroupName: vals["NOTION_MASTER_CARDGROUP_NAME"],
 		},
 	}, nil, nil
 }
 
-// ConfigFromEnv reads the five required NOTION_* env vars and returns an
+// ConfigFromEnv reads the four required NOTION_* env vars and returns an
 // EnvConfig. All values are required; whitespace-only is treated as missing.
 // This is the strict variant: any missing var produces an error. Callers that
 // want to skip Notion sync gracefully when env is incomplete should use

--- a/backend/internal/handler/notionsync/config_test.go
+++ b/backend/internal/handler/notionsync/config_test.go
@@ -9,12 +9,11 @@ import (
 var notionEnvAllVars = map[string]string{
 	"NOTION_TOKEN":                 "tok-123",
 	"NOTION_PAGE_IDS":              "page-1,page-2,page-3",
-	"NOTION_TARGET_OWNER_ID":       "owner-abc",
-	"NOTION_TARGET_CARDGROUP_NAME": "My Cards",
+	"NOTION_MASTER_CARDGROUP_NAME": "My Cards",
 	"NOTION_SYNC_TOKEN":            "sync-tok",
 }
 
-// setNotionEnv populates the five NOTION_* env vars from notionEnvAllVars,
+// setNotionEnv populates the four NOTION_* env vars from notionEnvAllVars,
 // applying any overrides supplied by the test. Values are unset via
 // t.Setenv(k, "") rather than os.Unsetenv so that t.Cleanup restores the
 // prior process state automatically.
@@ -53,11 +52,8 @@ func TestConfigFromEnv(t *testing.T) {
 				t.Errorf("PageIDs[%d] = %q, want %q", i, cfg.HandlerConfig.PageIDs[i], want)
 			}
 		}
-		if cfg.HandlerConfig.OwnerID != "owner-abc" {
-			t.Errorf("OwnerID = %q, want %q", cfg.HandlerConfig.OwnerID, "owner-abc")
-		}
-		if cfg.HandlerConfig.CardgroupName != "My Cards" {
-			t.Errorf("CardgroupName = %q, want %q", cfg.HandlerConfig.CardgroupName, "My Cards")
+		if cfg.HandlerConfig.MasterCardgroupName != "My Cards" {
+			t.Errorf("MasterCardgroupName = %q, want %q", cfg.HandlerConfig.MasterCardgroupName, "My Cards")
 		}
 	})
 
@@ -67,8 +63,7 @@ func TestConfigFromEnv(t *testing.T) {
 	}{
 		{"missing NOTION_TOKEN", "NOTION_TOKEN"},
 		{"missing NOTION_PAGE_IDS", "NOTION_PAGE_IDS"},
-		{"missing NOTION_TARGET_OWNER_ID", "NOTION_TARGET_OWNER_ID"},
-		{"missing NOTION_TARGET_CARDGROUP_NAME", "NOTION_TARGET_CARDGROUP_NAME"},
+		{"missing NOTION_MASTER_CARDGROUP_NAME", "NOTION_MASTER_CARDGROUP_NAME"},
 		{"missing NOTION_SYNC_TOKEN", "NOTION_SYNC_TOKEN"},
 	}
 	for _, tc := range missingVarCases {
@@ -109,14 +104,14 @@ func TestConfigFromEnv(t *testing.T) {
 		}
 	})
 
-	t.Run("NOTION_TARGET_OWNER_ID with whitespace is trimmed", func(t *testing.T) {
-		setNotionEnv(t, map[string]string{"NOTION_TARGET_OWNER_ID": "  owner-xyz  "})
+	t.Run("NOTION_MASTER_CARDGROUP_NAME with whitespace is trimmed", func(t *testing.T) {
+		setNotionEnv(t, map[string]string{"NOTION_MASTER_CARDGROUP_NAME": "  Master Deck  "})
 		cfg, err := ConfigFromEnv()
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if cfg.HandlerConfig.OwnerID != "owner-xyz" {
-			t.Errorf("OwnerID = %q, want %q", cfg.HandlerConfig.OwnerID, "owner-xyz")
+		if cfg.HandlerConfig.MasterCardgroupName != "Master Deck" {
+			t.Errorf("MasterCardgroupName = %q, want %q", cfg.HandlerConfig.MasterCardgroupName, "Master Deck")
 		}
 	})
 }
@@ -137,11 +132,8 @@ func TestOptionalConfigFromEnv(t *testing.T) {
 		if cfg.HandlerConfig.Token != "sync-tok" {
 			t.Errorf("HandlerConfig.Token = %q, want %q", cfg.HandlerConfig.Token, "sync-tok")
 		}
-		if cfg.HandlerConfig.OwnerID != "owner-abc" {
-			t.Errorf("OwnerID = %q, want %q", cfg.HandlerConfig.OwnerID, "owner-abc")
-		}
-		if cfg.HandlerConfig.CardgroupName != "My Cards" {
-			t.Errorf("CardgroupName = %q, want %q", cfg.HandlerConfig.CardgroupName, "My Cards")
+		if cfg.HandlerConfig.MasterCardgroupName != "My Cards" {
+			t.Errorf("MasterCardgroupName = %q, want %q", cfg.HandlerConfig.MasterCardgroupName, "My Cards")
 		}
 		wantPageIDs := []string{"page-1", "page-2", "page-3"}
 		if !reflect.DeepEqual(cfg.HandlerConfig.PageIDs, wantPageIDs) {
@@ -175,8 +167,7 @@ func TestOptionalConfigFromEnv(t *testing.T) {
 		want := []string{
 			"NOTION_TOKEN",
 			"NOTION_PAGE_IDS",
-			"NOTION_TARGET_OWNER_ID",
-			"NOTION_TARGET_CARDGROUP_NAME",
+			"NOTION_MASTER_CARDGROUP_NAME",
 			"NOTION_SYNC_TOKEN",
 		}
 		if !reflect.DeepEqual(missing, want) {
@@ -187,14 +178,14 @@ func TestOptionalConfigFromEnv(t *testing.T) {
 		}
 	})
 
-	t.Run("whitespace-only NOTION_TARGET_OWNER_ID treated as missing", func(t *testing.T) {
-		setNotionEnv(t, map[string]string{"NOTION_TARGET_OWNER_ID": "  "})
+	t.Run("whitespace-only NOTION_MASTER_CARDGROUP_NAME treated as missing", func(t *testing.T) {
+		setNotionEnv(t, map[string]string{"NOTION_MASTER_CARDGROUP_NAME": "  "})
 		_, missing, err := OptionalConfigFromEnv()
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if len(missing) != 1 || missing[0] != "NOTION_TARGET_OWNER_ID" {
-			t.Errorf("missing = %v, want [NOTION_TARGET_OWNER_ID]", missing)
+		if len(missing) != 1 || missing[0] != "NOTION_MASTER_CARDGROUP_NAME" {
+			t.Errorf("missing = %v, want [NOTION_MASTER_CARDGROUP_NAME]", missing)
 		}
 	})
 

--- a/backend/internal/handler/notionsync/handler.go
+++ b/backend/internal/handler/notionsync/handler.go
@@ -17,14 +17,13 @@ import (
 )
 
 type SyncUsecase interface {
-	Sync(ctx context.Context, input usecase.SyncFromNotionInput) (usecase.SyncFromNotionOutput, error)
+	Sync(ctx context.Context, input usecase.SyncToMasterInput) (usecase.SyncFromNotionOutput, error)
 }
 
 type Config struct {
-	Token         string
-	PageIDs       []string
-	OwnerID       string
-	CardgroupName string
+	Token               string
+	PageIDs             []string
+	MasterCardgroupName string
 }
 
 type Handler struct {
@@ -51,10 +50,9 @@ func (h *Handler) Handle(c *echo.Context) error {
 		return c.JSON(http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
 	}
 
-	out, err := h.uc.Sync(c.Request().Context(), usecase.SyncFromNotionInput{
+	out, err := h.uc.Sync(c.Request().Context(), usecase.SyncToMasterInput{
 		PageIDs:       h.config.PageIDs,
-		OwnerID:       h.config.OwnerID,
-		CardgroupName: h.config.CardgroupName,
+		CardgroupName: h.config.MasterCardgroupName,
 	})
 	if err != nil {
 		return h.handleError(c, err)

--- a/backend/internal/handler/notionsync/handler.go
+++ b/backend/internal/handler/notionsync/handler.go
@@ -17,7 +17,7 @@ import (
 )
 
 type SyncUsecase interface {
-	Sync(ctx context.Context, input usecase.SyncToMasterInput) (usecase.SyncFromNotionOutput, error)
+	Sync(ctx context.Context, input usecase.SyncToMasterInput) (usecase.MasterNotionSyncOutput, error)
 }
 
 type Config struct {
@@ -51,8 +51,8 @@ func (h *Handler) Handle(c *echo.Context) error {
 	}
 
 	out, err := h.uc.Sync(c.Request().Context(), usecase.SyncToMasterInput{
-		PageIDs:       h.config.PageIDs,
-		CardgroupName: h.config.MasterCardgroupName,
+		PageIDs:             h.config.PageIDs,
+		MasterCardgroupName: h.config.MasterCardgroupName,
 	})
 	if err != nil {
 		return h.handleError(c, err)

--- a/backend/internal/handler/notionsync/handler_test.go
+++ b/backend/internal/handler/notionsync/handler_test.go
@@ -19,17 +19,17 @@ import (
 )
 
 type stubSyncUsecase struct {
-	out   usecase.SyncFromNotionOutput
+	out   usecase.MasterNotionSyncOutput
 	err   error
 	calls int
 	in    usecase.SyncToMasterInput
 }
 
-func (s *stubSyncUsecase) Sync(_ context.Context, in usecase.SyncToMasterInput) (usecase.SyncFromNotionOutput, error) {
+func (s *stubSyncUsecase) Sync(_ context.Context, in usecase.SyncToMasterInput) (usecase.MasterNotionSyncOutput, error) {
 	s.calls++
 	s.in = in
 	if s.err != nil {
-		return usecase.SyncFromNotionOutput{}, s.err
+		return usecase.MasterNotionSyncOutput{}, s.err
 	}
 	return s.out, nil
 }
@@ -97,7 +97,7 @@ func TestHandlerUnauthorizedVariants(t *testing.T) {
 func TestHandlerSuccess(t *testing.T) {
 	t.Parallel()
 
-	uc := &stubSyncUsecase{out: usecase.SyncFromNotionOutput{
+	uc := &stubSyncUsecase{out: usecase.MasterNotionSyncOutput{
 		CardgroupID: "cg-1",
 		Inserted:    2,
 		Updated:     3,
@@ -123,7 +123,7 @@ func TestHandlerSuccess(t *testing.T) {
 	if uc.calls != 1 {
 		t.Fatalf("usecase calls = %d, want 1", uc.calls)
 	}
-	if uc.in.CardgroupName != "English" || len(uc.in.PageIDs) != 2 {
+	if uc.in.MasterCardgroupName != "English" || len(uc.in.PageIDs) != 2 {
 		t.Fatalf("input = %+v", uc.in)
 	}
 	var body map[string]any
@@ -150,7 +150,7 @@ func TestHandlerSuccess(t *testing.T) {
 func TestHandlerSuccess_ParseErrorsJSONShape(t *testing.T) {
 	t.Parallel()
 
-	uc := &stubSyncUsecase{out: usecase.SyncFromNotionOutput{
+	uc := &stubSyncUsecase{out: usecase.MasterNotionSyncOutput{
 		CardgroupID: "cg-1",
 		ParseErrors: []usecase.CardImportError{
 			{Line: 2, Message: "duplicate front in Notion pages (later occurrence wins)", Front: "apple", Back: "fruit"},

--- a/backend/internal/handler/notionsync/handler_test.go
+++ b/backend/internal/handler/notionsync/handler_test.go
@@ -22,10 +22,10 @@ type stubSyncUsecase struct {
 	out   usecase.SyncFromNotionOutput
 	err   error
 	calls int
-	in    usecase.SyncFromNotionInput
+	in    usecase.SyncToMasterInput
 }
 
-func (s *stubSyncUsecase) Sync(_ context.Context, in usecase.SyncFromNotionInput) (usecase.SyncFromNotionOutput, error) {
+func (s *stubSyncUsecase) Sync(_ context.Context, in usecase.SyncToMasterInput) (usecase.SyncFromNotionOutput, error) {
 	s.calls++
 	s.in = in
 	if s.err != nil {
@@ -104,10 +104,9 @@ func TestHandlerSuccess(t *testing.T) {
 		Deleted:     1,
 	}}
 	h := New(uc, Config{
-		Token:         "secret",
-		PageIDs:       []string{"p1", "p2"},
-		OwnerID:       "owner-1",
-		CardgroupName: "English",
+		Token:               "secret",
+		PageIDs:             []string{"p1", "p2"},
+		MasterCardgroupName: "English",
 	})
 	req := httptest.NewRequest(http.MethodPost, "/internal/notion-sync", nil)
 	req.Header.Set("Authorization", "Bearer secret")
@@ -124,7 +123,7 @@ func TestHandlerSuccess(t *testing.T) {
 	if uc.calls != 1 {
 		t.Fatalf("usecase calls = %d, want 1", uc.calls)
 	}
-	if uc.in.OwnerID != "owner-1" || uc.in.CardgroupName != "English" || len(uc.in.PageIDs) != 2 {
+	if uc.in.CardgroupName != "English" || len(uc.in.PageIDs) != 2 {
 		t.Fatalf("input = %+v", uc.in)
 	}
 	var body map[string]any

--- a/backend/internal/repository/card.go
+++ b/backend/internal/repository/card.go
@@ -124,7 +124,7 @@ type CardWriteRepository interface {
 	// DeleteByCardgroupAndFrontsTx hard-deletes cards by the scoped
 	// (cardgroup_id, front) natural key. Scoping is by cardgroup_id only —
 	// callers must verify the cardgroup is reachable by the calling owner
-	// before invoking this method (NotionSyncUsecase is the canonical caller).
+	// before invoking this method.
 	//
 	// Empty fronts short-circuits to (0, nil) without touching the DB. With an
 	// empty slice GORM v2 omits the `WHERE front IN (?)` clause altogether,

--- a/backend/internal/repository/cardgroup_test.go
+++ b/backend/internal/repository/cardgroup_test.go
@@ -339,9 +339,10 @@ func TestCardgroupRepository_EnsureByName_Create(t *testing.T) {
 // TestCardgroupRepository_EnsureByName_WhitespaceContract pins the current
 // contract that EnsureByName matches name verbatim: leading/trailing whitespace
 // produces a distinct row from the trimmed value. Trimming is the caller's
-// responsibility (the NotionSyncUsecase trims at its boundary). A future
-// caller that bypasses that trim must either trim itself or this contract
-// must change deliberately, not by accident.
+// responsibility (callers parse the name into a domain.CardgroupName, which
+// trims at its boundary, before invoking the repository). A future caller that
+// bypasses that trim must either trim itself or this contract must change
+// deliberately, not by accident.
 func TestCardgroupRepository_EnsureByName_WhitespaceContract(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/backend/internal/usecase/notion_sync.go
+++ b/backend/internal/usecase/notion_sync.go
@@ -54,10 +54,10 @@ type MasterNotionSyncUsecase struct {
 
 // SyncToMasterInput is the input for a master-targeted Notion sync. Unlike the
 // user-targeted variant it carries no OwnerID: master cardgroups are owner-less
-// and identified by CardgroupName alone.
+// and identified by MasterCardgroupName alone.
 type SyncToMasterInput struct {
-	PageIDs       []string
-	CardgroupName string
+	PageIDs             []string
+	MasterCardgroupName string
 }
 
 type ParsedRow struct {
@@ -67,7 +67,7 @@ type ParsedRow struct {
 	Line         int    `json:"line"`
 }
 
-type SyncFromNotionOutput struct {
+type MasterNotionSyncOutput struct {
 	CardgroupID string            `json:"cardgroupId"`
 	Inserted    int64             `json:"inserted"`
 	Updated     int64             `json:"updated"`
@@ -119,33 +119,33 @@ func NewMasterNotionSyncUsecaseWithTx(
 	}
 }
 
-func (u *MasterNotionSyncUsecase) Sync(ctx context.Context, input SyncToMasterInput) (SyncFromNotionOutput, error) {
+func (u *MasterNotionSyncUsecase) Sync(ctx context.Context, input SyncToMasterInput) (MasterNotionSyncOutput, error) {
 	pageIDs := normalizePageIDs(input.PageIDs)
 	if len(pageIDs) == 0 {
-		return SyncFromNotionOutput{}, eris.Wrap(ErrNotionSyncInvalidInput, "page ids are required")
+		return MasterNotionSyncOutput{}, eris.Wrap(ErrNotionSyncInvalidInput, "page ids are required")
 	}
-	cgName, cgNameErr := domain.ParseCardgroupName(input.CardgroupName)
+	cgName, cgNameErr := domain.ParseCardgroupName(input.MasterCardgroupName)
 	if cgNameErr != nil {
 		// The typed *ucerr.ValidationError is preserved in the chain for log-structured
 		// detail and any future GraphQL/CLI consumer; the REST handler intentionally
 		// collapses it to a generic 422 body.
-		return SyncFromNotionOutput{}, eris.Wrap(
+		return MasterNotionSyncOutput{}, eris.Wrap(
 			errors.Join(ErrNotionSyncInvalidInput, translateCardgroupNameErr(cgNameErr)),
 			"cardgroup name is invalid",
 		)
 	}
 	if u.fetcher == nil || u.masterCardgroupRepo == nil || u.masterCardRepo == nil || u.tx == nil {
-		return SyncFromNotionOutput{}, eris.Wrap(ErrNotionSyncInvalidInput, "dependencies are not configured")
+		return MasterNotionSyncOutput{}, eris.Wrap(ErrNotionSyncInvalidInput, "dependencies are not configured")
 	}
 
 	pages, err := u.fetcher.FetchPages(ctx, pageIDs)
 	if err != nil {
-		return SyncFromNotionOutput{}, eris.Wrap(errors.Join(ErrNotionSyncFetch, err), "fetch pages")
+		return MasterNotionSyncOutput{}, eris.Wrap(errors.Join(ErrNotionSyncFetch, err), "fetch pages")
 	}
 
 	rows, parseErrs, err := parseNotionPages(ctx, u.logger, pages)
 	if err != nil {
-		return SyncFromNotionOutput{}, eris.Wrap(errors.Join(ErrNotionSyncParse, err), "parse pages")
+		return MasterNotionSyncOutput{}, eris.Wrap(errors.Join(ErrNotionSyncParse, err), "parse pages")
 	}
 	// Soft skip-only input: every non-blank line was intentionally skipped by
 	// the grammar. Report the skipped rows, but do not persist an empty sync
@@ -163,7 +163,7 @@ func (u *MasterNotionSyncUsecase) Sync(ctx context.Context, input SyncToMasterIn
 				"first_kind", parseErrs[0].Kind,
 				"first_snippet", parseErrs[0].Snippet,
 			)
-			return SyncFromNotionOutput{ParseErrors: parseErrs}, nil
+			return MasterNotionSyncOutput{ParseErrors: parseErrs}, nil
 		}
 		u.logger.WarnContext(ctx, "notion sync: all rows failed to parse",
 			"parse_error_count", len(parseErrs),
@@ -171,15 +171,15 @@ func (u *MasterNotionSyncUsecase) Sync(ctx context.Context, input SyncToMasterIn
 			"first_error_kind", parseErrs[0].Kind,
 			"first_error_snippet", parseErrs[0].Snippet,
 		)
-		return SyncFromNotionOutput{}, eris.Wrap(ErrNotionSyncParse, "all rows failed to parse")
+		return MasterNotionSyncOutput{}, eris.Wrap(ErrNotionSyncParse, "all rows failed to parse")
 	}
 	if len(rows) > cardImportParsedRowCap {
-		return SyncFromNotionOutput{}, eris.Wrap(ErrNotionSyncInvalidInput, "parsed rows exceed cap")
+		return MasterNotionSyncOutput{}, eris.Wrap(ErrNotionSyncInvalidInput, "parsed rows exceed cap")
 	}
 
 	cardgroup, err := u.masterCardgroupRepo.EnsureByName(ctx, cgName.String())
 	if err != nil {
-		return SyncFromNotionOutput{}, eris.Wrap(errors.Join(ErrNotionSyncPersist, err), "ensure master cardgroup")
+		return MasterNotionSyncOutput{}, eris.Wrap(errors.Join(ErrNotionSyncPersist, err), "ensure master cardgroup")
 	}
 
 	rows, parseErrs = dedupeParsedRows(rows, parseErrs)
@@ -189,7 +189,7 @@ func (u *MasterNotionSyncUsecase) Sync(ctx context.Context, input SyncToMasterIn
 		notionFronts[row.Front] = struct{}{}
 	}
 
-	out := SyncFromNotionOutput{
+	out := MasterNotionSyncOutput{
 		CardgroupID: cardgroup.ID,
 		Parsed:      rows,
 		ParseErrors: parseErrs,
@@ -214,7 +214,7 @@ func (u *MasterNotionSyncUsecase) Sync(ctx context.Context, input SyncToMasterIn
 		return nil
 	})
 	if err != nil {
-		return SyncFromNotionOutput{}, eris.Wrap(errors.Join(ErrNotionSyncPersist, err), "persist master cards")
+		return MasterNotionSyncOutput{}, eris.Wrap(errors.Join(ErrNotionSyncPersist, err), "persist master cards")
 	}
 
 	u.logger.InfoContext(ctx, "notion sync complete",

--- a/backend/internal/usecase/notion_sync.go
+++ b/backend/internal/usecase/notion_sync.go
@@ -24,27 +24,39 @@ var (
 	ErrNotionSyncPersist      = errors.New("usecase: notion sync persist failed")
 )
 
-type NotionSyncCardRepository interface {
-	UpsertManyTx(ctx context.Context, tx *gorm.DB, cards []*domain.Card) (repository.UpsertManyTxResult, error)
-	ListFrontsByCardgroupTx(ctx context.Context, tx *gorm.DB, cardgroupID string) ([]string, error)
-	DeleteByCardgroupAndFrontsTx(ctx context.Context, tx *gorm.DB, cardgroupID string, fronts []string) (int64, error)
+// NotionSyncMasterCardgroupRepository is the narrow consumer interface the
+// master-targeted sync needs from the master cardgroup repository. Master
+// cardgroups are owner-less; EnsureByName looks up or creates the named
+// catalog template under a 'master' advisory-lock namespace.
+type NotionSyncMasterCardgroupRepository interface {
+	EnsureByName(ctx context.Context, name string) (*domain.MasterCardgroup, error)
 }
 
-type NotionSyncCardgroupRepository interface {
-	EnsureByName(ctx context.Context, ownerID, name string) (*domain.Cardgroup, error)
+// NotionSyncMasterCardRepository is the narrow consumer interface the
+// master-targeted sync needs from the master card repository: the bulk upsert
+// plus the diff-prune pair (list current fronts, delete the stale ones).
+type NotionSyncMasterCardRepository interface {
+	UpsertManyTx(ctx context.Context, tx *gorm.DB, cards []*domain.MasterCard) (repository.UpsertManyTxResult, error)
+	ListFrontsByMasterCardgroupTx(ctx context.Context, tx *gorm.DB, masterCardgroupID string) ([]string, error)
+	DeleteByMasterCardgroupAndFrontsTx(ctx context.Context, tx *gorm.DB, masterCardgroupID string, fronts []string) (int64, error)
 }
 
-type NotionSyncUsecase struct {
-	fetcher       notion.Fetcher
-	cardRepo      NotionSyncCardRepository
-	cardgroupRepo NotionSyncCardgroupRepository
-	tx            txRunner
-	logger        *slog.Logger
+// MasterNotionSyncUsecase syncs Notion pages into the admin-only master_*
+// catalog tables. The destination master cardgroup is identified by name only
+// (owner-less); EnsureByName resolves the name to an id under an advisory lock.
+type MasterNotionSyncUsecase struct {
+	fetcher             notion.Fetcher
+	masterCardgroupRepo NotionSyncMasterCardgroupRepository
+	masterCardRepo      NotionSyncMasterCardRepository
+	tx                  txRunner
+	logger              *slog.Logger
 }
 
-type SyncFromNotionInput struct {
+// SyncToMasterInput is the input for a master-targeted Notion sync. Unlike the
+// user-targeted variant it carries no OwnerID: master cardgroups are owner-less
+// and identified by CardgroupName alone.
+type SyncToMasterInput struct {
 	PageIDs       []string
-	OwnerID       string
 	CardgroupName string
 }
 
@@ -64,21 +76,21 @@ type SyncFromNotionOutput struct {
 	ParseErrors []CardImportError `json:"parseErrors"`
 }
 
-func NewNotionSyncUsecase(
+func NewMasterNotionSyncUsecase(
 	fetcher notion.Fetcher,
-	cardgroupRepo NotionSyncCardgroupRepository,
-	cardRepo NotionSyncCardRepository,
+	masterCardgroupRepo NotionSyncMasterCardgroupRepository,
+	masterCardRepo NotionSyncMasterCardRepository,
 	db *gorm.DB,
 	logger *slog.Logger,
-) *NotionSyncUsecase {
+) *MasterNotionSyncUsecase {
 	if logger == nil {
 		panic("usecase: notion sync: logger is required")
 	}
-	uc := &NotionSyncUsecase{
-		fetcher:       fetcher,
-		cardgroupRepo: cardgroupRepo,
-		cardRepo:      cardRepo,
-		logger:        logger,
+	uc := &MasterNotionSyncUsecase{
+		fetcher:             fetcher,
+		masterCardgroupRepo: masterCardgroupRepo,
+		masterCardRepo:      masterCardRepo,
+		logger:              logger,
 	}
 	if db != nil {
 		uc.tx = func(ctx context.Context, fn func(tx *gorm.DB) error) error {
@@ -88,33 +100,29 @@ func NewNotionSyncUsecase(
 	return uc
 }
 
-func NewNotionSyncUsecaseWithTx(
+func NewMasterNotionSyncUsecaseWithTx(
 	fetcher notion.Fetcher,
-	cardgroupRepo NotionSyncCardgroupRepository,
-	cardRepo NotionSyncCardRepository,
+	masterCardgroupRepo NotionSyncMasterCardgroupRepository,
+	masterCardRepo NotionSyncMasterCardRepository,
 	tx txRunner,
 	logger *slog.Logger,
-) *NotionSyncUsecase {
+) *MasterNotionSyncUsecase {
 	if logger == nil {
 		panic("usecase: notion sync: logger is required")
 	}
-	return &NotionSyncUsecase{
-		fetcher:       fetcher,
-		cardgroupRepo: cardgroupRepo,
-		cardRepo:      cardRepo,
-		tx:            tx,
-		logger:        logger,
+	return &MasterNotionSyncUsecase{
+		fetcher:             fetcher,
+		masterCardgroupRepo: masterCardgroupRepo,
+		masterCardRepo:      masterCardRepo,
+		tx:                  tx,
+		logger:              logger,
 	}
 }
 
-func (u *NotionSyncUsecase) Sync(ctx context.Context, input SyncFromNotionInput) (SyncFromNotionOutput, error) {
+func (u *MasterNotionSyncUsecase) Sync(ctx context.Context, input SyncToMasterInput) (SyncFromNotionOutput, error) {
 	pageIDs := normalizePageIDs(input.PageIDs)
-	ownerID := strings.TrimSpace(input.OwnerID)
 	if len(pageIDs) == 0 {
 		return SyncFromNotionOutput{}, eris.Wrap(ErrNotionSyncInvalidInput, "page ids are required")
-	}
-	if ownerID == "" {
-		return SyncFromNotionOutput{}, eris.Wrap(ErrNotionSyncInvalidInput, "owner id is required")
 	}
 	cgName, cgNameErr := domain.ParseCardgroupName(input.CardgroupName)
 	if cgNameErr != nil {
@@ -126,7 +134,7 @@ func (u *NotionSyncUsecase) Sync(ctx context.Context, input SyncFromNotionInput)
 			"cardgroup name is invalid",
 		)
 	}
-	if u.fetcher == nil || u.cardgroupRepo == nil || u.cardRepo == nil || u.tx == nil {
+	if u.fetcher == nil || u.masterCardgroupRepo == nil || u.masterCardRepo == nil || u.tx == nil {
 		return SyncFromNotionOutput{}, eris.Wrap(ErrNotionSyncInvalidInput, "dependencies are not configured")
 	}
 
@@ -141,7 +149,7 @@ func (u *NotionSyncUsecase) Sync(ctx context.Context, input SyncFromNotionInput)
 	}
 	// Soft skip-only input: every non-blank line was intentionally skipped by
 	// the grammar. Report the skipped rows, but do not persist an empty sync
-	// that would delete existing cards from the target cardgroup.
+	// that would delete existing cards from the target master cardgroup.
 	//
 	// This short-circuit MUST run before dedupeParsedRows: dedupe appends
 	// non-skip "duplicate front" warnings to parseErrs, which would make
@@ -169,13 +177,13 @@ func (u *NotionSyncUsecase) Sync(ctx context.Context, input SyncFromNotionInput)
 		return SyncFromNotionOutput{}, eris.Wrap(ErrNotionSyncInvalidInput, "parsed rows exceed cap")
 	}
 
-	cardgroup, err := u.cardgroupRepo.EnsureByName(ctx, ownerID, cgName.String())
+	cardgroup, err := u.masterCardgroupRepo.EnsureByName(ctx, cgName.String())
 	if err != nil {
-		return SyncFromNotionOutput{}, eris.Wrap(errors.Join(ErrNotionSyncPersist, err), "ensure cardgroup")
+		return SyncFromNotionOutput{}, eris.Wrap(errors.Join(ErrNotionSyncPersist, err), "ensure master cardgroup")
 	}
 
 	rows, parseErrs = dedupeParsedRows(rows, parseErrs)
-	cards := cardsFromParsedRows(cardgroup.ID, rows)
+	cards := masterCardsFromParsedRows(cardgroup.ID, rows)
 	notionFronts := make(map[string]struct{}, len(rows))
 	for _, row := range rows {
 		notionFronts[row.Front] = struct{}{}
@@ -187,18 +195,18 @@ func (u *NotionSyncUsecase) Sync(ctx context.Context, input SyncFromNotionInput)
 		ParseErrors: parseErrs,
 	}
 	err = u.tx(ctx, func(tx *gorm.DB) error {
-		upserted, err := u.cardRepo.UpsertManyTx(ctx, tx, cards)
+		upserted, err := u.masterCardRepo.UpsertManyTx(ctx, tx, cards)
 		if err != nil {
-			return eris.Wrap(err, "upsert cards")
+			return eris.Wrap(err, "upsert master cards")
 		}
-		currentFronts, err := u.cardRepo.ListFrontsByCardgroupTx(ctx, tx, cardgroup.ID)
+		currentFronts, err := u.masterCardRepo.ListFrontsByMasterCardgroupTx(ctx, tx, cardgroup.ID)
 		if err != nil {
 			return eris.Wrap(err, "list current fronts")
 		}
 		deleteFronts := frontsToDelete(currentFronts, notionFronts)
-		deleted, err := u.cardRepo.DeleteByCardgroupAndFrontsTx(ctx, tx, cardgroup.ID, deleteFronts)
+		deleted, err := u.masterCardRepo.DeleteByMasterCardgroupAndFrontsTx(ctx, tx, cardgroup.ID, deleteFronts)
 		if err != nil {
-			return eris.Wrap(err, "delete stale cards")
+			return eris.Wrap(err, "delete stale master cards")
 		}
 		out.Inserted = upserted.Inserted
 		out.Updated = upserted.Updated
@@ -206,7 +214,7 @@ func (u *NotionSyncUsecase) Sync(ctx context.Context, input SyncFromNotionInput)
 		return nil
 	})
 	if err != nil {
-		return SyncFromNotionOutput{}, eris.Wrap(errors.Join(ErrNotionSyncPersist, err), "persist cards")
+		return SyncFromNotionOutput{}, eris.Wrap(errors.Join(ErrNotionSyncPersist, err), "persist master cards")
 	}
 
 	u.logger.InfoContext(ctx, "notion sync complete",
@@ -316,19 +324,20 @@ func dedupeParsedRows(rows []ParsedRow, errs []CardImportError) ([]ParsedRow, []
 	return out, errs
 }
 
-func cardsFromParsedRows(cardgroupID string, rows []ParsedRow) []*domain.Card {
+// masterCardsFromParsedRows builds master cards from deduped, document-order
+// parsed rows. Position is the index in the deduped slice (0..n-1) so the
+// catalog reflects the original Notion document position.
+func masterCardsFromParsedRows(masterCardgroupID string, rows []ParsedRow) []*domain.MasterCard {
 	now := time.Now().UTC()
-	cards := make([]*domain.Card, 0, len(rows))
-	// Position is the index in the deduped document-order slice (0..n-1), so the
-	// learn query can order new cards by their original Notion document position.
+	cards := make([]*domain.MasterCard, 0, len(rows))
 	for i, row := range rows {
-		cards = append(cards, &domain.Card{
-			CardgroupID: cardgroupID,
-			Front:       domain.CardText(row.Front),
-			Back:        domain.CardText(row.Back),
-			Position:    i,
-			CreatedAt:   now,
-			UpdatedAt:   now,
+		cards = append(cards, &domain.MasterCard{
+			MasterCardgroupID: masterCardgroupID,
+			Front:             domain.CardText(row.Front),
+			Back:              domain.CardText(row.Back),
+			Position:          i,
+			CreatedAt:         now,
+			UpdatedAt:         now,
 		})
 	}
 	return cards

--- a/backend/internal/usecase/notion_sync_test.go
+++ b/backend/internal/usecase/notion_sync_test.go
@@ -33,35 +33,33 @@ func (s *stubNotionFetcher) FetchPages(_ context.Context, ids []string) ([]notio
 	return s.pages, nil
 }
 
-type mockNotionCardgroupRepo struct {
-	cg      *domain.Cardgroup
-	err     error
-	calls   int
-	ownerID string
-	name    string
+type mockMasterCardgroupRepo struct {
+	cg    *domain.MasterCardgroup
+	err   error
+	calls int
+	name  string
 }
 
-func (m *mockNotionCardgroupRepo) EnsureByName(_ context.Context, ownerID, name string) (*domain.Cardgroup, error) {
+func (m *mockMasterCardgroupRepo) EnsureByName(_ context.Context, name string) (*domain.MasterCardgroup, error) {
 	m.calls++
-	m.ownerID = ownerID
 	m.name = name
 	if m.err != nil {
 		return nil, m.err
 	}
 	if m.cg == nil {
-		m.cg = &domain.Cardgroup{ID: "cg-created", OwnerID: ownerID, Name: domain.CardgroupName(name)}
+		m.cg = &domain.MasterCardgroup{ID: "mcg-created", Name: domain.CardgroupName(name)}
 	}
 	return m.cg, nil
 }
 
-type mockNotionCardRepo struct {
+type mockMasterCardRepo struct {
 	existingFronts []string
 	upsertResult   repository.UpsertManyTxResult
 	upsertErr      error
 	listErr        error
 	deleteErr      error
 
-	upserted       []*domain.Card
+	upserted       []*domain.MasterCard
 	deletedFronts  []string
 	upsertCalls    int
 	listCalls      int
@@ -69,7 +67,7 @@ type mockNotionCardRepo struct {
 	deleteAffected int64
 }
 
-func (m *mockNotionCardRepo) UpsertManyTx(_ context.Context, _ *gorm.DB, cards []*domain.Card) (repository.UpsertManyTxResult, error) {
+func (m *mockMasterCardRepo) UpsertManyTx(_ context.Context, _ *gorm.DB, cards []*domain.MasterCard) (repository.UpsertManyTxResult, error) {
 	m.upsertCalls++
 	for _, card := range cards {
 		clone := *card
@@ -81,7 +79,7 @@ func (m *mockNotionCardRepo) UpsertManyTx(_ context.Context, _ *gorm.DB, cards [
 	return m.upsertResult, nil
 }
 
-func (m *mockNotionCardRepo) ListFrontsByCardgroupTx(_ context.Context, _ *gorm.DB, _ string) ([]string, error) {
+func (m *mockMasterCardRepo) ListFrontsByMasterCardgroupTx(_ context.Context, _ *gorm.DB, _ string) ([]string, error) {
 	m.listCalls++
 	if m.listErr != nil {
 		return nil, m.listErr
@@ -89,7 +87,7 @@ func (m *mockNotionCardRepo) ListFrontsByCardgroupTx(_ context.Context, _ *gorm.
 	return append([]string(nil), m.existingFronts...), nil
 }
 
-func (m *mockNotionCardRepo) DeleteByCardgroupAndFrontsTx(_ context.Context, _ *gorm.DB, _ string, fronts []string) (int64, error) {
+func (m *mockMasterCardRepo) DeleteByMasterCardgroupAndFrontsTx(_ context.Context, _ *gorm.DB, _ string, fronts []string) (int64, error) {
 	m.deleteCalls++
 	m.deletedFronts = append([]string(nil), fronts...)
 	if m.deleteErr != nil {
@@ -101,7 +99,7 @@ func (m *mockNotionCardRepo) DeleteByCardgroupAndFrontsTx(_ context.Context, _ *
 	return int64(len(fronts)), nil
 }
 
-func TestNotionSyncUsecase_DiffMerge(t *testing.T) {
+func TestMasterNotionSyncUsecase_DiffMerge(t *testing.T) {
 	t.Parallel()
 
 	fetcher := &stubNotionFetcher{pages: []notion.Page{
@@ -110,24 +108,23 @@ func TestNotionSyncUsecase_DiffMerge(t *testing.T) {
 			Text: "apple " + uniqueBack(1) + "\nbanana " + uniqueBack(2) + "\n",
 		},
 	}}
-	cardgroups := &mockNotionCardgroupRepo{cg: &domain.Cardgroup{ID: "cg-target"}}
-	cards := &mockNotionCardRepo{
+	cardgroups := &mockMasterCardgroupRepo{cg: &domain.MasterCardgroup{ID: "mcg-target"}}
+	cards := &mockMasterCardRepo{
 		existingFronts: []string{"apple", "banana", "stale"},
 		upsertResult:   repository.UpsertManyTxResult{Inserted: 1, Updated: 1},
 	}
 	tx, txCalls := dictTxRunner()
-	uc := NewNotionSyncUsecaseWithTx(fetcher, cardgroups, cards, tx, newTestLogger())
+	uc := NewMasterNotionSyncUsecaseWithTx(fetcher, cardgroups, cards, tx, newTestLogger())
 
-	out, err := uc.Sync(context.Background(), SyncFromNotionInput{
+	out, err := uc.Sync(context.Background(), SyncToMasterInput{
 		PageIDs:       []string{" page-1 ", "page-1"},
-		OwnerID:       "owner-1",
 		CardgroupName: "English",
 	})
 	if err != nil {
 		t.Fatalf("Sync: %v", err)
 	}
-	if out.CardgroupID != "cg-target" {
-		t.Fatalf("CardgroupID = %q, want cg-target", out.CardgroupID)
+	if out.CardgroupID != "mcg-target" {
+		t.Fatalf("CardgroupID = %q, want mcg-target", out.CardgroupID)
 	}
 	if out.Inserted != 1 || out.Updated != 1 || out.Deleted != 1 {
 		t.Fatalf("counts = (%d,%d,%d), want (1,1,1)", out.Inserted, out.Updated, out.Deleted)
@@ -135,8 +132,8 @@ func TestNotionSyncUsecase_DiffMerge(t *testing.T) {
 	if len(out.Parsed) != 2 {
 		t.Fatalf("Parsed len = %d, want 2", len(out.Parsed))
 	}
-	if cardgroups.ownerID != "owner-1" || cardgroups.name != "English" {
-		t.Fatalf("EnsureByName args = (%q,%q)", cardgroups.ownerID, cardgroups.name)
+	if cardgroups.name != "English" {
+		t.Fatalf("EnsureByName name = %q, want English", cardgroups.name)
 	}
 	if len(fetcher.ids) != 1 || fetcher.ids[0] != "page-1" {
 		t.Fatalf("fetch ids = %v, want [page-1]", fetcher.ids)
@@ -144,8 +141,9 @@ func TestNotionSyncUsecase_DiffMerge(t *testing.T) {
 	if len(cards.upserted) != 2 {
 		t.Fatalf("upserted len = %d, want 2", len(cards.upserted))
 	}
-	if cards.upserted[0].CardgroupID != "cg-target" {
-		t.Fatalf("upserted cardgroup = %q, want cg-target", cards.upserted[0].CardgroupID)
+	// Cards land via the master upsert path, scoped to the master cardgroup id.
+	if cards.upserted[0].MasterCardgroupID != "mcg-target" {
+		t.Fatalf("upserted master cardgroup = %q, want mcg-target", cards.upserted[0].MasterCardgroupID)
 	}
 	if len(cards.deletedFronts) != 1 || cards.deletedFronts[0] != "stale" {
 		t.Fatalf("deleted fronts = %v, want [stale]", cards.deletedFronts)
@@ -155,21 +153,20 @@ func TestNotionSyncUsecase_DiffMerge(t *testing.T) {
 	}
 }
 
-func TestNotionSyncUsecase_DuplicateFrontLastWins(t *testing.T) {
+func TestMasterNotionSyncUsecase_DuplicateFrontLastWins(t *testing.T) {
 	t.Parallel()
 
 	fetcher := &stubNotionFetcher{pages: []notion.Page{
 		{ID: "page-1", Text: "apple " + uniqueBack(1) + "\n"},
 		{ID: "page-2", Text: "apple " + uniqueBack(2) + "\n"},
 	}}
-	cardgroups := &mockNotionCardgroupRepo{cg: &domain.Cardgroup{ID: "cg-target"}}
-	cards := &mockNotionCardRepo{upsertResult: repository.UpsertManyTxResult{Inserted: 1}}
+	cardgroups := &mockMasterCardgroupRepo{cg: &domain.MasterCardgroup{ID: "mcg-target"}}
+	cards := &mockMasterCardRepo{upsertResult: repository.UpsertManyTxResult{Inserted: 1}}
 	tx, txCalls := dictTxRunner()
-	uc := NewNotionSyncUsecaseWithTx(fetcher, cardgroups, cards, tx, newTestLogger())
+	uc := NewMasterNotionSyncUsecaseWithTx(fetcher, cardgroups, cards, tx, newTestLogger())
 
-	out, err := uc.Sync(context.Background(), SyncFromNotionInput{
+	out, err := uc.Sync(context.Background(), SyncToMasterInput{
 		PageIDs:       []string{"page-1", "page-2"},
-		OwnerID:       "owner-1",
 		CardgroupName: "English",
 	})
 	if err != nil {
@@ -211,7 +208,7 @@ func TestNotionSyncUsecase_DuplicateFrontLastWins(t *testing.T) {
 	}
 }
 
-func TestNotionSyncUsecase_DuplicateFrontSamePageLastWins(t *testing.T) {
+func TestMasterNotionSyncUsecase_DuplicateFrontSamePageLastWins(t *testing.T) {
 	t.Parallel()
 
 	// Two duplicates inside a single page: the second occurrence wins, the
@@ -220,14 +217,13 @@ func TestNotionSyncUsecase_DuplicateFrontSamePageLastWins(t *testing.T) {
 	fetcher := &stubNotionFetcher{pages: []notion.Page{
 		{ID: "page-1", Text: "apple " + uniqueBack(1) + "\napple " + uniqueBack(2) + "\n"},
 	}}
-	cardgroups := &mockNotionCardgroupRepo{cg: &domain.Cardgroup{ID: "cg-target"}}
-	cards := &mockNotionCardRepo{upsertResult: repository.UpsertManyTxResult{Inserted: 1}}
+	cardgroups := &mockMasterCardgroupRepo{cg: &domain.MasterCardgroup{ID: "mcg-target"}}
+	cards := &mockMasterCardRepo{upsertResult: repository.UpsertManyTxResult{Inserted: 1}}
 	tx, txCalls := dictTxRunner()
-	uc := NewNotionSyncUsecaseWithTx(fetcher, cardgroups, cards, tx, newTestLogger())
+	uc := NewMasterNotionSyncUsecaseWithTx(fetcher, cardgroups, cards, tx, newTestLogger())
 
-	out, err := uc.Sync(context.Background(), SyncFromNotionInput{
+	out, err := uc.Sync(context.Background(), SyncToMasterInput{
 		PageIDs:       []string{"page-1"},
-		OwnerID:       "owner-1",
 		CardgroupName: "English",
 	})
 	if err != nil {
@@ -266,7 +262,7 @@ func TestNotionSyncUsecase_DuplicateFrontSamePageLastWins(t *testing.T) {
 	}
 }
 
-func TestNotionSyncUsecase_InputValidation(t *testing.T) {
+func TestMasterNotionSyncUsecase_InputValidation(t *testing.T) {
 	t.Parallel()
 
 	// Each case proves a specific failure branch in Sync's input-validation
@@ -274,23 +270,9 @@ func TestNotionSyncUsecase_InputValidation(t *testing.T) {
 	// can map them to a 4xx response.
 	t.Run("empty page ids", func(t *testing.T) {
 		t.Parallel()
-		uc := newValidationUsecase()
-		_, err := uc.Sync(context.Background(), SyncFromNotionInput{
+		uc := newMasterValidationUsecase()
+		_, err := uc.Sync(context.Background(), SyncToMasterInput{
 			PageIDs:       []string{"", "  "},
-			OwnerID:       "owner-1",
-			CardgroupName: "English",
-		})
-		if !errors.Is(err, ErrNotionSyncInvalidInput) {
-			t.Fatalf("err = %v, want ErrNotionSyncInvalidInput", err)
-		}
-	})
-
-	t.Run("empty owner", func(t *testing.T) {
-		t.Parallel()
-		uc := newValidationUsecase()
-		_, err := uc.Sync(context.Background(), SyncFromNotionInput{
-			PageIDs:       []string{"page-1"},
-			OwnerID:       "  ",
 			CardgroupName: "English",
 		})
 		if !errors.Is(err, ErrNotionSyncInvalidInput) {
@@ -300,10 +282,9 @@ func TestNotionSyncUsecase_InputValidation(t *testing.T) {
 
 	t.Run("empty cardgroup name", func(t *testing.T) {
 		t.Parallel()
-		uc := newValidationUsecase()
-		_, err := uc.Sync(context.Background(), SyncFromNotionInput{
+		uc := newMasterValidationUsecase()
+		_, err := uc.Sync(context.Background(), SyncToMasterInput{
 			PageIDs:       []string{"page-1"},
-			OwnerID:       "owner-1",
 			CardgroupName: " ",
 		})
 		if !errors.Is(err, ErrNotionSyncInvalidInput) {
@@ -323,11 +304,10 @@ func TestNotionSyncUsecase_InputValidation(t *testing.T) {
 
 	t.Run("over-cap cardgroup name", func(t *testing.T) {
 		t.Parallel()
-		uc := newValidationUsecase()
+		uc := newMasterValidationUsecase()
 		overCap := strings.Repeat("a", domain.CardgroupNameMax+1)
-		_, err := uc.Sync(context.Background(), SyncFromNotionInput{
+		_, err := uc.Sync(context.Background(), SyncToMasterInput{
 			PageIDs:       []string{"page-1"},
-			OwnerID:       "owner-1",
 			CardgroupName: overCap,
 		})
 		if !errors.Is(err, ErrNotionSyncInvalidInput) {
@@ -347,18 +327,18 @@ func TestNotionSyncUsecase_InputValidation(t *testing.T) {
 	})
 }
 
-func newValidationUsecase() *NotionSyncUsecase {
+func newMasterValidationUsecase() *MasterNotionSyncUsecase {
 	tx, _ := dictTxRunner()
-	return NewNotionSyncUsecaseWithTx(
+	return NewMasterNotionSyncUsecaseWithTx(
 		&stubNotionFetcher{},
-		&mockNotionCardgroupRepo{},
-		&mockNotionCardRepo{},
+		&mockMasterCardgroupRepo{},
+		&mockMasterCardRepo{},
 		tx,
 		newTestLogger(),
 	)
 }
 
-func TestNotionSyncUsecase_SoftParseFailure(t *testing.T) {
+func TestMasterNotionSyncUsecase_SoftParseFailure(t *testing.T) {
 	t.Parallel()
 
 	// Page text where every line is a lexer-level failure. textdic.Process
@@ -368,14 +348,13 @@ func TestNotionSyncUsecase_SoftParseFailure(t *testing.T) {
 	fetcher := &stubNotionFetcher{pages: []notion.Page{
 		{ID: "page-1", Text: "@\n"},
 	}}
-	cardgroups := &mockNotionCardgroupRepo{}
-	cards := &mockNotionCardRepo{}
+	cardgroups := &mockMasterCardgroupRepo{}
+	cards := &mockMasterCardRepo{}
 	tx, txCalls := dictTxRunner()
-	uc := NewNotionSyncUsecaseWithTx(fetcher, cardgroups, cards, tx, newTestLogger())
+	uc := NewMasterNotionSyncUsecaseWithTx(fetcher, cardgroups, cards, tx, newTestLogger())
 
-	_, err := uc.Sync(context.Background(), SyncFromNotionInput{
+	_, err := uc.Sync(context.Background(), SyncToMasterInput{
 		PageIDs:       []string{"page-1"},
-		OwnerID:       "owner-1",
 		CardgroupName: "English",
 	})
 	if !errors.Is(err, ErrNotionSyncParse) {
@@ -390,7 +369,7 @@ func TestNotionSyncUsecase_SoftParseFailure(t *testing.T) {
 	}
 }
 
-func TestNotionSyncUsecase_MixedSkipAndLexerErrorIsNotSkipOnly(t *testing.T) {
+func TestMasterNotionSyncUsecase_MixedSkipAndLexerErrorIsNotSkipOnly(t *testing.T) {
 	t.Parallel()
 
 	// "orphan\n@\n" produces zero parsed rows, one skip (line 1: lone front),
@@ -400,21 +379,20 @@ func TestNotionSyncUsecase_MixedSkipAndLexerErrorIsNotSkipOnly(t *testing.T) {
 	fetcher := &stubNotionFetcher{pages: []notion.Page{
 		{ID: "page-1", Text: "orphan\n@\n"},
 	}}
-	cardgroups := &mockNotionCardgroupRepo{}
-	cards := &mockNotionCardRepo{}
+	cardgroups := &mockMasterCardgroupRepo{}
+	cards := &mockMasterCardRepo{}
 	tx, txCalls := dictTxRunner()
-	uc := NewNotionSyncUsecaseWithTx(fetcher, cardgroups, cards, tx, newTestLogger())
+	uc := NewMasterNotionSyncUsecaseWithTx(fetcher, cardgroups, cards, tx, newTestLogger())
 
-	_, err := uc.Sync(context.Background(), SyncFromNotionInput{
+	_, err := uc.Sync(context.Background(), SyncToMasterInput{
 		PageIDs:       []string{"page-1"},
-		OwnerID:       "owner-1",
 		CardgroupName: "English",
 	})
 	if !errors.Is(err, ErrNotionSyncParse) {
 		t.Fatalf("err = %v, want ErrNotionSyncParse (mixed skip + lexer error is not skip-only)", err)
 	}
-	// Persistence must be skipped entirely: no cardgroup creation, no repo
-	// calls, no tx open.
+	// Persistence must be skipped entirely: no master cardgroup creation, no
+	// repo calls, no tx open.
 	if cardgroups.calls != 0 {
 		t.Fatalf("EnsureByName calls = %d, want 0 (persistence must be skipped)", cardgroups.calls)
 	}
@@ -427,20 +405,19 @@ func TestNotionSyncUsecase_MixedSkipAndLexerErrorIsNotSkipOnly(t *testing.T) {
 	}
 }
 
-func TestNotionSyncUsecase_LoneFrontDoesNotOverwriteExistingBack(t *testing.T) {
+func TestMasterNotionSyncUsecase_LoneFrontDoesNotOverwriteExistingBack(t *testing.T) {
 	t.Parallel()
 
 	fetcher := &stubNotionFetcher{pages: []notion.Page{
 		{ID: "page-1", Text: "apple\n"},
 	}}
-	cardgroups := &mockNotionCardgroupRepo{cg: &domain.Cardgroup{ID: "cg-target"}}
-	cards := &mockNotionCardRepo{existingFronts: []string{"apple"}}
+	cardgroups := &mockMasterCardgroupRepo{cg: &domain.MasterCardgroup{ID: "mcg-target"}}
+	cards := &mockMasterCardRepo{existingFronts: []string{"apple"}}
 	tx, txCalls := dictTxRunner()
-	uc := NewNotionSyncUsecaseWithTx(fetcher, cardgroups, cards, tx, newTestLogger())
+	uc := NewMasterNotionSyncUsecaseWithTx(fetcher, cardgroups, cards, tx, newTestLogger())
 
-	out, err := uc.Sync(context.Background(), SyncFromNotionInput{
+	out, err := uc.Sync(context.Background(), SyncToMasterInput{
 		PageIDs:       []string{"page-1"},
-		OwnerID:       "owner-1",
 		CardgroupName: "English",
 	})
 	if err != nil {
@@ -467,19 +444,18 @@ func TestNotionSyncUsecase_LoneFrontDoesNotOverwriteExistingBack(t *testing.T) {
 	}
 }
 
-func TestNotionSyncUsecase_FetchErrorSkipsPersistence(t *testing.T) {
+func TestMasterNotionSyncUsecase_FetchErrorSkipsPersistence(t *testing.T) {
 	t.Parallel()
 
 	boom := errors.New("notion down")
 	fetcher := &stubNotionFetcher{err: boom}
-	cardgroups := &mockNotionCardgroupRepo{}
-	cards := &mockNotionCardRepo{}
+	cardgroups := &mockMasterCardgroupRepo{}
+	cards := &mockMasterCardRepo{}
 	tx, txCalls := dictTxRunner()
-	uc := NewNotionSyncUsecaseWithTx(fetcher, cardgroups, cards, tx, newTestLogger())
+	uc := NewMasterNotionSyncUsecaseWithTx(fetcher, cardgroups, cards, tx, newTestLogger())
 
-	_, err := uc.Sync(context.Background(), SyncFromNotionInput{
+	_, err := uc.Sync(context.Background(), SyncToMasterInput{
 		PageIDs:       []string{"page-1"},
-		OwnerID:       "owner-1",
 		CardgroupName: "English",
 	})
 	if !errors.Is(err, ErrNotionSyncFetch) || !errors.Is(err, boom) {
@@ -490,19 +466,18 @@ func TestNotionSyncUsecase_FetchErrorSkipsPersistence(t *testing.T) {
 	}
 }
 
-func TestNotionSyncUsecase_PersistError(t *testing.T) {
+func TestMasterNotionSyncUsecase_PersistError(t *testing.T) {
 	t.Parallel()
 
 	boom := errors.New("db down")
 	fetcher := &stubNotionFetcher{pages: []notion.Page{{ID: "page-1", Text: "apple " + uniqueBack(1) + "\n"}}}
-	cardgroups := &mockNotionCardgroupRepo{cg: &domain.Cardgroup{ID: "cg-target"}}
-	cards := &mockNotionCardRepo{upsertErr: boom}
+	cardgroups := &mockMasterCardgroupRepo{cg: &domain.MasterCardgroup{ID: "mcg-target"}}
+	cards := &mockMasterCardRepo{upsertErr: boom}
 	tx, _ := dictTxRunner()
-	uc := NewNotionSyncUsecaseWithTx(fetcher, cardgroups, cards, tx, newTestLogger())
+	uc := NewMasterNotionSyncUsecaseWithTx(fetcher, cardgroups, cards, tx, newTestLogger())
 
-	_, err := uc.Sync(context.Background(), SyncFromNotionInput{
+	_, err := uc.Sync(context.Background(), SyncToMasterInput{
 		PageIDs:       []string{"page-1"},
-		OwnerID:       "owner-1",
 		CardgroupName: "English",
 	})
 	if !errors.Is(err, ErrNotionSyncPersist) || !errors.Is(err, boom) {
@@ -510,7 +485,7 @@ func TestNotionSyncUsecase_PersistError(t *testing.T) {
 	}
 }
 
-func TestNotionSyncUsecase_CardgroupEnsureError(t *testing.T) {
+func TestMasterNotionSyncUsecase_CardgroupEnsureError(t *testing.T) {
 	t.Parallel()
 
 	// EnsureByName fails before the transaction is opened. Sync must surface
@@ -520,14 +495,13 @@ func TestNotionSyncUsecase_CardgroupEnsureError(t *testing.T) {
 	fetcher := &stubNotionFetcher{pages: []notion.Page{
 		{ID: "page-1", Text: "apple " + uniqueBack(1) + "\n"},
 	}}
-	cardgroups := &mockNotionCardgroupRepo{err: dbErr}
-	cards := &mockNotionCardRepo{}
+	cardgroups := &mockMasterCardgroupRepo{err: dbErr}
+	cards := &mockMasterCardRepo{}
 	tx, txCalls := dictTxRunner()
-	uc := NewNotionSyncUsecaseWithTx(fetcher, cardgroups, cards, tx, newTestLogger())
+	uc := NewMasterNotionSyncUsecaseWithTx(fetcher, cardgroups, cards, tx, newTestLogger())
 
-	_, err := uc.Sync(context.Background(), SyncFromNotionInput{
+	_, err := uc.Sync(context.Background(), SyncToMasterInput{
 		PageIDs:       []string{"page-1"},
-		OwnerID:       "owner-1",
 		CardgroupName: "English",
 	})
 	if !errors.Is(err, ErrNotionSyncPersist) {
@@ -549,24 +523,23 @@ func TestNotionSyncUsecase_CardgroupEnsureError(t *testing.T) {
 	}
 }
 
-func TestNotionSyncUsecase_ListFrontsError(t *testing.T) {
+func TestMasterNotionSyncUsecase_ListFrontsError(t *testing.T) {
 	t.Parallel()
 
-	// ListFrontsByCardgroupTx fails inside the transaction. Sync must surface
-	// ErrNotionSyncPersist and the underlying list error so the caller can
-	// distinguish a persistence failure from a fetch or parse failure.
+	// ListFrontsByMasterCardgroupTx fails inside the transaction. Sync must
+	// surface ErrNotionSyncPersist and the underlying list error so the caller
+	// can distinguish a persistence failure from a fetch or parse failure.
 	listErr := errors.New("list error")
 	fetcher := &stubNotionFetcher{pages: []notion.Page{
 		{ID: "page-1", Text: "apple " + uniqueBack(1) + "\n"},
 	}}
-	cardgroups := &mockNotionCardgroupRepo{cg: &domain.Cardgroup{ID: "cg-target"}}
-	cards := &mockNotionCardRepo{listErr: listErr}
+	cardgroups := &mockMasterCardgroupRepo{cg: &domain.MasterCardgroup{ID: "mcg-target"}}
+	cards := &mockMasterCardRepo{listErr: listErr}
 	tx, txCalls := dictTxRunner()
-	uc := NewNotionSyncUsecaseWithTx(fetcher, cardgroups, cards, tx, newTestLogger())
+	uc := NewMasterNotionSyncUsecaseWithTx(fetcher, cardgroups, cards, tx, newTestLogger())
 
-	_, err := uc.Sync(context.Background(), SyncFromNotionInput{
+	_, err := uc.Sync(context.Background(), SyncToMasterInput{
 		PageIDs:       []string{"page-1"},
-		OwnerID:       "owner-1",
 		CardgroupName: "English",
 	})
 	if !errors.Is(err, ErrNotionSyncPersist) {
@@ -582,7 +555,7 @@ func TestNotionSyncUsecase_ListFrontsError(t *testing.T) {
 	if *txCalls != 1 {
 		t.Fatalf("tx calls = %d, want 1", *txCalls)
 	}
-	// UpsertManyTx runs before ListFrontsByCardgroupTx; it must have been called.
+	// UpsertManyTx runs before ListFrontsByMasterCardgroupTx; it must have been called.
 	if cards.upsertCalls != 1 {
 		t.Fatalf("upsert calls = %d, want 1", cards.upsertCalls)
 	}
@@ -592,28 +565,27 @@ func TestNotionSyncUsecase_ListFrontsError(t *testing.T) {
 	}
 }
 
-// TestNotionSyncUsecase_SkipOnlyLogFields verifies that the skip-only branch
-// emits an InfoContext log record whose structured fields include first_line,
-// first_kind, and first_snippet, pinned to the known values for a lone-front
-// input ("apple\n" → line 1, kind "FRONT_ONLY", snippet "apple").
+// TestMasterNotionSyncUsecase_SkipOnlyLogFields verifies that the skip-only
+// branch emits an InfoContext log record whose structured fields include
+// first_line, first_kind, and first_snippet, pinned to the known values for a
+// lone-front input ("apple\n" → line 1, kind "FRONT_ONLY", snippet "apple").
 //
 // Not parallel: injects a logger directly into the usecase, so it does not
 // mutate the global slog default.
-func TestNotionSyncUsecase_SkipOnlyLogFields(t *testing.T) {
+func TestMasterNotionSyncUsecase_SkipOnlyLogFields(t *testing.T) {
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
 
 	fetcher := &stubNotionFetcher{pages: []notion.Page{
 		{ID: "page-1", Text: "apple\n"},
 	}}
-	cardgroups := &mockNotionCardgroupRepo{}
-	cards := &mockNotionCardRepo{}
+	cardgroups := &mockMasterCardgroupRepo{}
+	cards := &mockMasterCardRepo{}
 	tx, txCalls := dictTxRunner()
-	uc := NewNotionSyncUsecaseWithTx(fetcher, cardgroups, cards, tx, logger)
+	uc := NewMasterNotionSyncUsecaseWithTx(fetcher, cardgroups, cards, tx, logger)
 
-	out, err := uc.Sync(context.Background(), SyncFromNotionInput{
+	out, err := uc.Sync(context.Background(), SyncToMasterInput{
 		PageIDs:       []string{"page-1"},
-		OwnerID:       "owner-1",
 		CardgroupName: "English",
 	})
 	if err != nil {
@@ -716,7 +688,7 @@ func TestAllCardImportErrorsSkipped(t *testing.T) {
 	}
 }
 
-// TestNotionSyncUsecase_WarnBranchLogFields verifies that the warn branch
+// TestMasterNotionSyncUsecase_WarnBranchLogFields verifies that the warn branch
 // (rows == 0, parseErrs > 0, not skip-only) emits a WarnContext log record
 // with structured fields anchored to the first error.
 //
@@ -725,21 +697,20 @@ func TestAllCardImportErrorsSkipped(t *testing.T) {
 //
 // Not parallel: injects a logger directly into the usecase, so it does not
 // mutate the global slog default.
-func TestNotionSyncUsecase_WarnBranchLogFields(t *testing.T) {
+func TestMasterNotionSyncUsecase_WarnBranchLogFields(t *testing.T) {
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
 
 	fetcher := &stubNotionFetcher{pages: []notion.Page{
 		{ID: "page-1", Text: "@broken\n"},
 	}}
-	cardgroups := &mockNotionCardgroupRepo{}
-	cards := &mockNotionCardRepo{}
+	cardgroups := &mockMasterCardgroupRepo{}
+	cards := &mockMasterCardRepo{}
 	tx, txCalls := dictTxRunner()
-	uc := NewNotionSyncUsecaseWithTx(fetcher, cardgroups, cards, tx, logger)
+	uc := NewMasterNotionSyncUsecaseWithTx(fetcher, cardgroups, cards, tx, logger)
 
-	_, err := uc.Sync(context.Background(), SyncFromNotionInput{
+	_, err := uc.Sync(context.Background(), SyncToMasterInput{
 		PageIDs:       []string{"page-1"},
-		OwnerID:       "owner-1",
 		CardgroupName: "English",
 	})
 	if !errors.Is(err, ErrNotionSyncParse) {
@@ -779,10 +750,11 @@ func TestNotionSyncUsecase_WarnBranchLogFields(t *testing.T) {
 	}
 }
 
-// TestCardsFromParsedRows_AssignsContiguousPositions verifies that each card
-// receives a Position equal to its index (0..n-1) in the deduped document-order
-// slice, including rows that originate from more than one source page.
-func TestCardsFromParsedRows_AssignsContiguousPositions(t *testing.T) {
+// TestMasterCardsFromParsedRows_AssignsContiguousPositions verifies that each
+// master card receives a Position equal to its index (0..n-1) in the deduped
+// document-order slice, including rows that originate from more than one source
+// page.
+func TestMasterCardsFromParsedRows_AssignsContiguousPositions(t *testing.T) {
 	t.Parallel()
 	// Rows come from two different source pages, simulating a multi-page Notion
 	// sync.  After dedupe (already done before this call) these are the survivors.
@@ -793,8 +765,8 @@ func TestCardsFromParsedRows_AssignsContiguousPositions(t *testing.T) {
 		{Front: "daikon", Back: "vegetable", SourcePageID: "page-2", Line: 2},
 	}
 
-	const cardgroupID = "cg-test"
-	cards := cardsFromParsedRows(cardgroupID, rows)
+	const masterCardgroupID = "mcg-test"
+	cards := masterCardsFromParsedRows(masterCardgroupID, rows)
 
 	if len(cards) != len(rows) {
 		t.Fatalf("len(cards) = %d, want %d", len(cards), len(rows))
@@ -809,9 +781,9 @@ func TestCardsFromParsedRows_AssignsContiguousPositions(t *testing.T) {
 		if string(card.Front) != rows[i].Front {
 			t.Errorf("cards[%d].Front = %q, want %q", i, card.Front, rows[i].Front)
 		}
-		// CardgroupID must be propagated.
-		if card.CardgroupID != cardgroupID {
-			t.Errorf("cards[%d].CardgroupID = %q, want %q", i, card.CardgroupID, cardgroupID)
+		// MasterCardgroupID must be propagated.
+		if card.MasterCardgroupID != masterCardgroupID {
+			t.Errorf("cards[%d].MasterCardgroupID = %q, want %q", i, card.MasterCardgroupID, masterCardgroupID)
 		}
 	}
 }

--- a/backend/internal/usecase/notion_sync_test.go
+++ b/backend/internal/usecase/notion_sync_test.go
@@ -845,7 +845,7 @@ func TestMasterNotionSyncUsecase_OverCapRejected(t *testing.T) {
 
 	const n = cardImportParsedRowCap + 1
 	var b strings.Builder
-	for i := 0; i < n; i++ {
+	for i := range n {
 		b.WriteString(stringFront("front", i))
 		b.WriteString(" ")
 		b.WriteString(uniqueBack(i))

--- a/backend/internal/usecase/notion_sync_test.go
+++ b/backend/internal/usecase/notion_sync_test.go
@@ -117,8 +117,8 @@ func TestMasterNotionSyncUsecase_DiffMerge(t *testing.T) {
 	uc := NewMasterNotionSyncUsecaseWithTx(fetcher, cardgroups, cards, tx, newTestLogger())
 
 	out, err := uc.Sync(context.Background(), SyncToMasterInput{
-		PageIDs:       []string{" page-1 ", "page-1"},
-		CardgroupName: "English",
+		PageIDs:             []string{" page-1 ", "page-1"},
+		MasterCardgroupName: "English",
 	})
 	if err != nil {
 		t.Fatalf("Sync: %v", err)
@@ -166,8 +166,8 @@ func TestMasterNotionSyncUsecase_DuplicateFrontLastWins(t *testing.T) {
 	uc := NewMasterNotionSyncUsecaseWithTx(fetcher, cardgroups, cards, tx, newTestLogger())
 
 	out, err := uc.Sync(context.Background(), SyncToMasterInput{
-		PageIDs:       []string{"page-1", "page-2"},
-		CardgroupName: "English",
+		PageIDs:             []string{"page-1", "page-2"},
+		MasterCardgroupName: "English",
 	})
 	if err != nil {
 		t.Fatalf("Sync: %v", err)
@@ -223,8 +223,8 @@ func TestMasterNotionSyncUsecase_DuplicateFrontSamePageLastWins(t *testing.T) {
 	uc := NewMasterNotionSyncUsecaseWithTx(fetcher, cardgroups, cards, tx, newTestLogger())
 
 	out, err := uc.Sync(context.Background(), SyncToMasterInput{
-		PageIDs:       []string{"page-1"},
-		CardgroupName: "English",
+		PageIDs:             []string{"page-1"},
+		MasterCardgroupName: "English",
 	})
 	if err != nil {
 		t.Fatalf("Sync: %v", err)
@@ -272,8 +272,8 @@ func TestMasterNotionSyncUsecase_InputValidation(t *testing.T) {
 		t.Parallel()
 		uc := newMasterValidationUsecase()
 		_, err := uc.Sync(context.Background(), SyncToMasterInput{
-			PageIDs:       []string{"", "  "},
-			CardgroupName: "English",
+			PageIDs:             []string{"", "  "},
+			MasterCardgroupName: "English",
 		})
 		if !errors.Is(err, ErrNotionSyncInvalidInput) {
 			t.Fatalf("err = %v, want ErrNotionSyncInvalidInput", err)
@@ -284,8 +284,8 @@ func TestMasterNotionSyncUsecase_InputValidation(t *testing.T) {
 		t.Parallel()
 		uc := newMasterValidationUsecase()
 		_, err := uc.Sync(context.Background(), SyncToMasterInput{
-			PageIDs:       []string{"page-1"},
-			CardgroupName: " ",
+			PageIDs:             []string{"page-1"},
+			MasterCardgroupName: " ",
 		})
 		if !errors.Is(err, ErrNotionSyncInvalidInput) {
 			t.Fatalf("err = %v, want ErrNotionSyncInvalidInput", err)
@@ -307,8 +307,8 @@ func TestMasterNotionSyncUsecase_InputValidation(t *testing.T) {
 		uc := newMasterValidationUsecase()
 		overCap := strings.Repeat("a", domain.CardgroupNameMax+1)
 		_, err := uc.Sync(context.Background(), SyncToMasterInput{
-			PageIDs:       []string{"page-1"},
-			CardgroupName: overCap,
+			PageIDs:             []string{"page-1"},
+			MasterCardgroupName: overCap,
 		})
 		if !errors.Is(err, ErrNotionSyncInvalidInput) {
 			t.Fatalf("err = %v, want ErrNotionSyncInvalidInput", err)
@@ -354,8 +354,8 @@ func TestMasterNotionSyncUsecase_SoftParseFailure(t *testing.T) {
 	uc := NewMasterNotionSyncUsecaseWithTx(fetcher, cardgroups, cards, tx, newTestLogger())
 
 	_, err := uc.Sync(context.Background(), SyncToMasterInput{
-		PageIDs:       []string{"page-1"},
-		CardgroupName: "English",
+		PageIDs:             []string{"page-1"},
+		MasterCardgroupName: "English",
 	})
 	if !errors.Is(err, ErrNotionSyncParse) {
 		t.Fatalf("err = %v, want ErrNotionSyncParse", err)
@@ -385,8 +385,8 @@ func TestMasterNotionSyncUsecase_MixedSkipAndLexerErrorIsNotSkipOnly(t *testing.
 	uc := NewMasterNotionSyncUsecaseWithTx(fetcher, cardgroups, cards, tx, newTestLogger())
 
 	_, err := uc.Sync(context.Background(), SyncToMasterInput{
-		PageIDs:       []string{"page-1"},
-		CardgroupName: "English",
+		PageIDs:             []string{"page-1"},
+		MasterCardgroupName: "English",
 	})
 	if !errors.Is(err, ErrNotionSyncParse) {
 		t.Fatalf("err = %v, want ErrNotionSyncParse (mixed skip + lexer error is not skip-only)", err)
@@ -417,8 +417,8 @@ func TestMasterNotionSyncUsecase_LoneFrontDoesNotOverwriteExistingBack(t *testin
 	uc := NewMasterNotionSyncUsecaseWithTx(fetcher, cardgroups, cards, tx, newTestLogger())
 
 	out, err := uc.Sync(context.Background(), SyncToMasterInput{
-		PageIDs:       []string{"page-1"},
-		CardgroupName: "English",
+		PageIDs:             []string{"page-1"},
+		MasterCardgroupName: "English",
 	})
 	if err != nil {
 		t.Fatalf("Sync: %v", err)
@@ -455,8 +455,8 @@ func TestMasterNotionSyncUsecase_FetchErrorSkipsPersistence(t *testing.T) {
 	uc := NewMasterNotionSyncUsecaseWithTx(fetcher, cardgroups, cards, tx, newTestLogger())
 
 	_, err := uc.Sync(context.Background(), SyncToMasterInput{
-		PageIDs:       []string{"page-1"},
-		CardgroupName: "English",
+		PageIDs:             []string{"page-1"},
+		MasterCardgroupName: "English",
 	})
 	if !errors.Is(err, ErrNotionSyncFetch) || !errors.Is(err, boom) {
 		t.Fatalf("err = %v, want fetch + boom", err)
@@ -477,8 +477,8 @@ func TestMasterNotionSyncUsecase_PersistError(t *testing.T) {
 	uc := NewMasterNotionSyncUsecaseWithTx(fetcher, cardgroups, cards, tx, newTestLogger())
 
 	_, err := uc.Sync(context.Background(), SyncToMasterInput{
-		PageIDs:       []string{"page-1"},
-		CardgroupName: "English",
+		PageIDs:             []string{"page-1"},
+		MasterCardgroupName: "English",
 	})
 	if !errors.Is(err, ErrNotionSyncPersist) || !errors.Is(err, boom) {
 		t.Fatalf("err = %v, want persist + boom", err)
@@ -501,8 +501,8 @@ func TestMasterNotionSyncUsecase_CardgroupEnsureError(t *testing.T) {
 	uc := NewMasterNotionSyncUsecaseWithTx(fetcher, cardgroups, cards, tx, newTestLogger())
 
 	_, err := uc.Sync(context.Background(), SyncToMasterInput{
-		PageIDs:       []string{"page-1"},
-		CardgroupName: "English",
+		PageIDs:             []string{"page-1"},
+		MasterCardgroupName: "English",
 	})
 	if !errors.Is(err, ErrNotionSyncPersist) {
 		t.Fatalf("err = %v, want ErrNotionSyncPersist", err)
@@ -539,8 +539,8 @@ func TestMasterNotionSyncUsecase_ListFrontsError(t *testing.T) {
 	uc := NewMasterNotionSyncUsecaseWithTx(fetcher, cardgroups, cards, tx, newTestLogger())
 
 	_, err := uc.Sync(context.Background(), SyncToMasterInput{
-		PageIDs:       []string{"page-1"},
-		CardgroupName: "English",
+		PageIDs:             []string{"page-1"},
+		MasterCardgroupName: "English",
 	})
 	if !errors.Is(err, ErrNotionSyncPersist) {
 		t.Fatalf("err = %v, want ErrNotionSyncPersist", err)
@@ -585,8 +585,8 @@ func TestMasterNotionSyncUsecase_SkipOnlyLogFields(t *testing.T) {
 	uc := NewMasterNotionSyncUsecaseWithTx(fetcher, cardgroups, cards, tx, logger)
 
 	out, err := uc.Sync(context.Background(), SyncToMasterInput{
-		PageIDs:       []string{"page-1"},
-		CardgroupName: "English",
+		PageIDs:             []string{"page-1"},
+		MasterCardgroupName: "English",
 	})
 	if err != nil {
 		t.Fatalf("Sync: %v", err)
@@ -710,8 +710,8 @@ func TestMasterNotionSyncUsecase_WarnBranchLogFields(t *testing.T) {
 	uc := NewMasterNotionSyncUsecaseWithTx(fetcher, cardgroups, cards, tx, logger)
 
 	_, err := uc.Sync(context.Background(), SyncToMasterInput{
-		PageIDs:       []string{"page-1"},
-		CardgroupName: "English",
+		PageIDs:             []string{"page-1"},
+		MasterCardgroupName: "English",
 	})
 	if !errors.Is(err, ErrNotionSyncParse) {
 		t.Fatalf("expected ErrNotionSyncParse, got %v", err)
@@ -785,5 +785,141 @@ func TestMasterCardsFromParsedRows_AssignsContiguousPositions(t *testing.T) {
 		if card.MasterCardgroupID != masterCardgroupID {
 			t.Errorf("cards[%d].MasterCardgroupID = %q, want %q", i, card.MasterCardgroupID, masterCardgroupID)
 		}
+	}
+}
+
+// TestMasterNotionSyncUsecase_DeleteError verifies that a failure in
+// DeleteByMasterCardgroupAndFrontsTx (the prune-stale step) surfaces as
+// ErrNotionSyncPersist with the underlying delete error preserved in the
+// chain. UpsertManyTx runs before the delete, so it must have been called
+// exactly once even though the transaction is rolled back on the delete
+// failure.
+func TestMasterNotionSyncUsecase_DeleteError(t *testing.T) {
+	t.Parallel()
+
+	deleteErr := errors.New("delete error")
+	fetcher := &stubNotionFetcher{pages: []notion.Page{
+		{ID: "page-1", Text: "apple " + uniqueBack(1) + "\n"},
+	}}
+	cardgroups := &mockMasterCardgroupRepo{cg: &domain.MasterCardgroup{ID: "mcg-target"}}
+	// "stale" is present in the cardgroup but absent from the Notion payload, so
+	// frontsToDelete yields ["stale"] and the prune-stale delete runs.
+	cards := &mockMasterCardRepo{existingFronts: []string{"apple", "stale"}, deleteErr: deleteErr}
+	tx, txCalls := dictTxRunner()
+	uc := NewMasterNotionSyncUsecaseWithTx(fetcher, cardgroups, cards, tx, newTestLogger())
+
+	_, err := uc.Sync(context.Background(), SyncToMasterInput{
+		PageIDs:             []string{"page-1"},
+		MasterCardgroupName: "English",
+	})
+	if !errors.Is(err, ErrNotionSyncPersist) {
+		t.Fatalf("err = %v, want ErrNotionSyncPersist", err)
+	}
+	if !errors.Is(err, deleteErr) {
+		t.Fatalf("err = %v, want wrapped delete error", err)
+	}
+	if !strings.Contains(err.Error(), "delete error") {
+		t.Fatalf("err.Error() = %q, want it to contain \"delete error\"", err.Error())
+	}
+	// The tx was entered, but must have been rolled back on the delete failure.
+	if *txCalls != 1 {
+		t.Fatalf("tx calls = %d, want 1", *txCalls)
+	}
+	// UpsertManyTx runs before DeleteByMasterCardgroupAndFrontsTx; it must have
+	// run exactly once before the delete failed.
+	if cards.upsertCalls != 1 {
+		t.Fatalf("upsert calls = %d, want 1", cards.upsertCalls)
+	}
+	if cards.deleteCalls != 1 {
+		t.Fatalf("delete calls = %d, want 1 (the stale front triggers the delete)", cards.deleteCalls)
+	}
+}
+
+// TestMasterNotionSyncUsecase_OverCapRejected covers the parsed-row cap gate at
+// the usecase level: a Notion payload that parses to more than
+// cardImportParsedRowCap rows is rejected with ErrNotionSyncInvalidInput before
+// any persistence runs. Mirrors TestCardImportUsecase_PayloadOverCapBadInput on
+// the card-import path.
+func TestMasterNotionSyncUsecase_OverCapRejected(t *testing.T) {
+	t.Parallel()
+
+	const n = cardImportParsedRowCap + 1
+	var b strings.Builder
+	for i := 0; i < n; i++ {
+		b.WriteString(stringFront("front", i))
+		b.WriteString(" ")
+		b.WriteString(uniqueBack(i))
+		b.WriteString("\n")
+	}
+	fetcher := &stubNotionFetcher{pages: []notion.Page{{ID: "page-1", Text: b.String()}}}
+	cardgroups := &mockMasterCardgroupRepo{}
+	cards := &mockMasterCardRepo{}
+	tx, txCalls := dictTxRunner()
+	uc := NewMasterNotionSyncUsecaseWithTx(fetcher, cardgroups, cards, tx, newTestLogger())
+
+	_, err := uc.Sync(context.Background(), SyncToMasterInput{
+		PageIDs:             []string{"page-1"},
+		MasterCardgroupName: "English",
+	})
+	if !errors.Is(err, ErrNotionSyncInvalidInput) {
+		t.Fatalf("err = %v, want ErrNotionSyncInvalidInput (over-cap payload)", err)
+	}
+	// The cap gate runs before EnsureByName and the transaction, so no
+	// persistence may have happened.
+	if cardgroups.calls != 0 {
+		t.Fatalf("EnsureByName calls = %d, want 0 (cap gate precedes persistence)", cardgroups.calls)
+	}
+	if cards.upsertCalls != 0 || cards.listCalls != 0 || cards.deleteCalls != 0 {
+		t.Fatalf("card repo calls (upsert=%d list=%d delete=%d), want all zero",
+			cards.upsertCalls, cards.listCalls, cards.deleteCalls)
+	}
+	if *txCalls != 0 {
+		t.Fatalf("tx calls = %d, want 0 (no tx on over-cap rejection)", *txCalls)
+	}
+}
+
+// TestMasterNotionSyncUsecase_NoDeletions pins the prune "nothing stale" branch:
+// when the Notion fronts exactly match the cardgroup's existing fronts,
+// frontsToDelete is empty, but DeleteByMasterCardgroupAndFrontsTx is still
+// invoked once with an empty slice. The repository's empty-IN guard treats an
+// empty slice as a no-op, so the destructive path stays harmless while the call
+// itself remains unconditional.
+func TestMasterNotionSyncUsecase_NoDeletions(t *testing.T) {
+	t.Parallel()
+
+	fetcher := &stubNotionFetcher{pages: []notion.Page{
+		{ID: "page-1", Text: "apple " + uniqueBack(1) + "\nbanana " + uniqueBack(2) + "\n"},
+	}}
+	cardgroups := &mockMasterCardgroupRepo{cg: &domain.MasterCardgroup{ID: "mcg-target"}}
+	// existingFronts == notionFronts, so nothing is stale.
+	cards := &mockMasterCardRepo{
+		existingFronts: []string{"apple", "banana"},
+		upsertResult:   repository.UpsertManyTxResult{Updated: 2},
+	}
+	tx, txCalls := dictTxRunner()
+	uc := NewMasterNotionSyncUsecaseWithTx(fetcher, cardgroups, cards, tx, newTestLogger())
+
+	out, err := uc.Sync(context.Background(), SyncToMasterInput{
+		PageIDs:             []string{"page-1"},
+		MasterCardgroupName: "English",
+	})
+	if err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+	if out.Deleted != 0 {
+		t.Fatalf("out.Deleted = %d, want 0 (nothing stale)", out.Deleted)
+	}
+	if cards.upsertCalls != 1 {
+		t.Fatalf("upsert calls = %d, want 1", cards.upsertCalls)
+	}
+	// The delete is unconditional even with nothing to prune.
+	if cards.deleteCalls != 1 {
+		t.Fatalf("delete calls = %d, want 1 (delete is called unconditionally)", cards.deleteCalls)
+	}
+	if len(cards.deletedFronts) != 0 {
+		t.Fatalf("deletedFronts = %v, want empty slice (nothing stale)", cards.deletedFronts)
+	}
+	if *txCalls != 1 {
+		t.Fatalf("tx calls = %d, want 1", *txCalls)
 	}
 }

--- a/backend/internal/usecase/tx.go
+++ b/backend/internal/usecase/tx.go
@@ -10,5 +10,5 @@ import (
 // transaction. The composition root (cmd/server) wires the real
 // *gorm.DB.Transaction-backed implementation; unit tests pass a fake that
 // invokes fn with a sentinel *gorm.DB. Used by CardUsecase, SwipeUsecase,
-// cardImportUsecase, and NotionSyncUsecase.
+// cardImportUsecase, and MasterNotionSyncUsecase.
 type txRunner func(ctx context.Context, fn func(tx *gorm.DB) error) error

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -61,8 +61,7 @@ These values target a public API on Render. Revisit if the threat model or deplo
 | `PING_TOKEN` | yes | — | Bearer token for `POST /internal/ping`. Server refuses to start if empty. |
 | `NOTION_TOKEN` | no\* | — | Notion integration token used by the internal Notion sync job. |
 | `NOTION_PAGE_IDS` | no\* | — | Comma-separated Notion page IDs to fetch. Empty entries are ignored. |
-| `NOTION_TARGET_OWNER_ID` | no\* | — | Existing `public.users.id`/Supabase auth user UUID that owns the synced cardgroup. Required because cardgroups are user-owned in the current schema. |
-| `NOTION_TARGET_CARDGROUP_NAME` | no\* | — | Destination cardgroup name. The backend finds or creates this cardgroup for `NOTION_TARGET_OWNER_ID`. |
+| `NOTION_MASTER_CARDGROUP_NAME` | no\* | — | Name of the master cardgroup in the `master_cardgroups` table that the sync job targets. |
 | `NOTION_SYNC_TOKEN` | no\* | — | Bearer token for `POST /internal/notion-sync`. |
 | `NOTION_MAX_ATTEMPTS` | no | `5` | Retry attempt cap for Notion 429/5xx responses. Must be positive when set. |
 | `NOTION_MAX_ELAPSED` | no | `2m` | Maximum cumulative Notion retry wait per request. Must be a positive Go duration when set. |
@@ -70,7 +69,7 @@ These values target a public API on Render. Revisit if the threat model or deplo
 
 `PORT`, `SHUTDOWN_TIMEOUT`, `NOTION_MAX_ATTEMPTS`, `NOTION_MAX_ELAPSED`, and `SUPER_USER_EMAILS` are optional with safe defaults. The three `SUPABASE_JWT_*` variables, `SUPABASE_DB_URL`, and `PING_TOKEN` are strictly required — the server refuses to start if any is missing.
 
-\* **Optional as a group.** When any of the five `NOTION_*` sync vars (`NOTION_TOKEN`, `NOTION_PAGE_IDS`, `NOTION_TARGET_OWNER_ID`, `NOTION_TARGET_CARDGROUP_NAME`, `NOTION_SYNC_TOKEN`) is absent or whitespace-only, the `POST /internal/notion-sync` route is disabled and the server still starts — a single `WARN` log line is emitted listing the missing var names (via `OptionalConfigFromEnv` in `run()`). The exception: when the group is otherwise present, `NOTION_PAGE_IDS` must contain at least one non-whitespace ID — a comma/whitespace-only value fails startup.
+\* **Optional as a group.** When any of the four `NOTION_*` sync vars (`NOTION_TOKEN`, `NOTION_PAGE_IDS`, `NOTION_MASTER_CARDGROUP_NAME`, `NOTION_SYNC_TOKEN`) is absent or whitespace-only, the `POST /internal/notion-sync` route is disabled and the server still starts — a single `WARN` log line is emitted listing the missing var names (via `OptionalConfigFromEnv` in `run()`). The exception: when the group is otherwise present, `NOTION_PAGE_IDS` must contain at least one non-whitespace ID — a comma/whitespace-only value fails startup. Note: the Makefile and deployment playbook still push `NOTION_TARGET_OWNER_ID` and `NOTION_TARGET_CARDGROUP_NAME` until an operator follow-up updates those scripts; the backend no longer reads those vars.
 
 ## Testing patterns
 

--- a/docs/backend/library-gotchas/method-dispatch-nil-receiver-unreachable.md
+++ b/docs/backend/library-gotchas/method-dispatch-nil-receiver-unreachable.md
@@ -10,4 +10,4 @@ The guard is **also** unhelpful as a defensive layer because the only way to rea
 
 **Why:** removing the dead `u == nil` branch makes the method's preconditions accurate. A future reader who sees `if u.fetcher == nil` understands the constraint is on construction, not on receiver validity.
 
-**Reference:** `NotionSyncUsecase.Sync` originally had `if u == nil || u.fetcher == nil || ...`; the `u == nil` term was removed because method dispatch had already panicked before reaching it.
+**Reference:** `MasterNotionSyncUsecase.Sync` originally had `if u == nil || u.fetcher == nil || ...`; the `u == nil` term was removed because method dispatch had already panicked before reaching it.

--- a/docs/notion-sync.md
+++ b/docs/notion-sync.md
@@ -1,6 +1,6 @@
 # Notion Page Sync
 
-The backend exposes `POST /internal/notion-sync` for GitHub Actions or another trusted scheduler. The request body is ignored; all sync inputs come from backend environment variables.
+The backend exposes `POST /internal/notion-sync` for GitHub Actions or another trusted scheduler. The request body is ignored; all sync inputs come from backend environment variables. The sync writes into the admin-only `master_*` catalog tables (`master_cardgroups` / `master_cards`), not the user-owned `cardgroups` table.
 
 ## Backend env
 
@@ -8,8 +8,7 @@ Required:
 
 - `NOTION_TOKEN`: Notion integration token.
 - `NOTION_PAGE_IDS`: comma-separated page IDs.
-- `NOTION_TARGET_OWNER_ID`: existing Supabase/auth user UUID that owns the destination cardgroup.
-- `NOTION_TARGET_CARDGROUP_NAME`: destination cardgroup name. The backend creates it when absent.
+- `NOTION_MASTER_CARDGROUP_NAME`: destination master cardgroup name. The backend creates it when absent.
 - `NOTION_SYNC_TOKEN`: shared bearer token used by the scheduler.
 
 Optional:
@@ -17,7 +16,7 @@ Optional:
 - `NOTION_MAX_ATTEMPTS`: default `5`.
 - `NOTION_MAX_ELAPSED`: default `2m`.
 
-`NOTION_TARGET_OWNER_ID` is required because the current `cardgroups` table is user-owned. Use the UUID from `auth.users.id` / `public.users.id` for the account that should see the synced cards.
+Master cardgroups are owner-less: the destination deck is identified by `NOTION_MASTER_CARDGROUP_NAME` alone. The backend resolves the name to a master cardgroup id via `MasterCardgroupRepository.EnsureByName`, which serializes lookup-then-insert under a `pg_advisory_xact_lock(hashtext('master'), hashtext(name))` so concurrent runs cannot create duplicate-name rows. No owner UUID is required.
 
 ## GitHub Actions
 
@@ -84,6 +83,8 @@ make notion-local-run      # repeat as needed
 For the production sync flow, see [Operational setup](#operational-setup) below.
 
 ## Operational setup
+
+> **Pending operator step (master repoint).** The backend now reads `NOTION_MASTER_CARDGROUP_NAME` and no longer reads `NOTION_TARGET_OWNER_ID` / `NOTION_TARGET_CARDGROUP_NAME`. The deployed Render service env, `render.yaml`, `cloudbuild.yaml`, and the `make sync-notion-*` targets below still reference the old variable names; they are intentionally left unchanged in the code change that repointed the sync because rotating a deployed service's env is a deploy-affecting operation. Before the next production sync run, set `NOTION_MASTER_CARDGROUP_NAME` on the Render service (and update the Makefile push targets) so the scheduler keeps working. The `NOTION_TARGET_*` keys become inert once the new key is set.
 
 All NOTION_* values are stored in the root `.env` file (gitignored). The Makefile provides three targets that read from that file and push values to the appropriate destinations.
 
@@ -158,9 +159,9 @@ When a user creates or updates a card via GraphQL and the save succeeds, the bac
 
 ## Behavior
 
-The backend fetches every configured page, renders supported blocks to plain text, parses the existing text dictionary format, then upserts cards into the destination cardgroup. Each card is assigned a `position` equal to its zero-based index in the deduped, document-order row list (page order, then line order within a page). `position` is an internal sync-metadata field with no GraphQL field. On upsert conflict, `back`, `updated_at`, and `position` are overwritten, so re-syncing reflects the latest Notion document order for surviving cards. FSRS state is still preserved: `position` is not FSRS data and the `user_card_fsrs` row is never touched by sync. `position` is retained as sync metadata but no longer drives the learn queue: the learn-session query samples never-seen cards uniformly at random rather than walking document order. See [`docs/backend/ddd-patterns/discovery-first-due-ordering.md`](backend/ddd-patterns/discovery-first-due-ordering.md) for the ordering design. Cards whose `front` no longer appears in Notion are deleted.
+The backend fetches every configured page, renders supported blocks to plain text, parses the existing text dictionary format, then upserts master cards into the destination master cardgroup (resolved by name via `MasterCardgroupRepository.EnsureByName`). Each card is assigned a `position` equal to its zero-based index in the deduped, document-order row list (page order, then line order within a page). `position` is an internal sync-metadata field with no GraphQL field. On upsert conflict, `back`, `updated_at`, and `position` are overwritten, so re-syncing reflects the latest Notion document order for surviving master cards. Cards whose `front` no longer appears in Notion are deleted from the master cardgroup. The master catalog is admin-only and never directly owned by an end user; per-user copies are created downstream from the published master deck.
 
-Lone front-only or back-only lines are skipped and reported as validation errors; they do not drop the rest of the batch. If every non-blank row is skipped, the sync returns the skip diagnostics without mutating cards. The skip-only short-circuit returns before `EnsureByName`, so no cardgroup is auto-created for a sync that would produce no cards — a deliberate "no persistence, no side effects" invariant. For the grammar-level rationale, see [`docs/backend/library-gotchas/goyacc-lexer-recovery-via-newline.md` § "What"](backend/library-gotchas/goyacc-lexer-recovery-via-newline.md#what).
+Lone front-only or back-only lines are skipped and reported as validation errors; they do not drop the rest of the batch. If every non-blank row is skipped, the sync returns the skip diagnostics without mutating cards. The skip-only short-circuit returns before `EnsureByName`, so no master cardgroup is auto-created for a sync that would produce no cards — a deliberate "no persistence, no side effects" invariant. For the grammar-level rationale, see [`docs/backend/library-gotchas/goyacc-lexer-recovery-via-newline.md` § "What"](backend/library-gotchas/goyacc-lexer-recovery-via-newline.md#what).
 
 If Notion returns `429` or `5xx`, the backend follows the `Retry-After` header (with an exponential-backoff fallback capped at 5 seconds when the header is absent).
 

--- a/docs/notion-sync.md
+++ b/docs/notion-sync.md
@@ -43,6 +43,8 @@ Use this section to run the Notion sync against your local Supabase instance wit
 
 ### Required keys in root `.env`
 
+> **Transitional state.** The backend now reads `NOTION_MASTER_CARDGROUP_NAME` to identify the master cardgroup, but `make notion-local-setup` still writes the old `NOTION_LOCAL_TARGET_OWNER_EMAIL` / `NOTION_LOCAL_TARGET_CARDGROUP_NAME` keys into `backend/.env.local`. Until the operator follow-up in the [pending operator step callout](#operational-setup) lands, you must also set `NOTION_MASTER_CARDGROUP_NAME` manually in `backend/.env.local` (or in root `.env` and re-run `make notion-local-setup`) for local master-sync testing to work.
+
 | Key | Purpose |
 |---|---|
 | `NOTION_TOKEN` | Notion integration token (shared with prod). Same workspace as production by default. |
@@ -69,7 +71,7 @@ make dev-backend           # in another terminal
 make notion-local-run      # repeat as needed
 ```
 
-`make notion-local-setup` validates that the required keys are present in root `.env`, probes local Supabase connectivity, resolves `NOTION_LOCAL_TARGET_OWNER_EMAIL` to a UUID, then writes 7 `NOTION_*` keys into `backend/.env.local`. `make dev-backend` starts the backend on `:1323` with those env vars loaded. `make notion-local-run` fires a single authenticated POST to `/internal/notion-sync` and prints the HTTP response body. Backend progress logs appear in the terminal where `make dev-backend` is running.
+`make notion-local-setup` validates that the required keys are present in root `.env`, probes local Supabase connectivity, resolves `NOTION_LOCAL_TARGET_OWNER_EMAIL` to a UUID, then writes the `NOTION_*` keys configured in the Makefile target into `backend/.env.local`. `make dev-backend` starts the backend on `:1323` with those env vars loaded. `make notion-local-run` fires a single authenticated POST to `/internal/notion-sync` and prints the HTTP response body. Backend progress logs appear in the terminal where `make dev-backend` is running.
 
 ### Troubleshooting
 
@@ -77,7 +79,7 @@ make notion-local-run      # repeat as needed
 |---|---|
 | `make notion-local-setup` fails with "log into local app first" | Run `make dev-frontend`, sign in via Google OAuth, then re-run `make notion-local-setup`. |
 | `make notion-local-run` prints "Backend not reachable on :1323" | Start the backend in another terminal with `make dev-backend`, then re-run. |
-| Backend logs show "notion sync: disabled" | Check `backend/.env.local` for the 7 `NOTION_*` keys. Re-run `make notion-local-setup` if missing, then restart the backend. |
+| Backend logs show "notion sync: disabled" | Check `backend/.env.local` for the required `NOTION_*` keys (see note above about `NOTION_MASTER_CARDGROUP_NAME`). Re-run `make notion-local-setup` if missing, then restart the backend. |
 | psql probe fails with connection refused | Run `make supabase-start` and wait until the local Supabase stack reports healthy. |
 
 For the production sync flow, see [Operational setup](#operational-setup) below.
@@ -90,13 +92,15 @@ All NOTION_* values are stored in the root `.env` file (gitignored). The Makefil
 
 ### Required keys in root `.env`
 
+> **Transitional state.** The backend now reads `NOTION_MASTER_CARDGROUP_NAME` but the Makefile targets and playbook below still push/write the old `NOTION_TARGET_*` keys until the operator follow-up in the [pending operator step callout](#operational-setup) lands. The table below reflects the keys the Makefile currently reads; `NOTION_MASTER_CARDGROUP_NAME` must be set manually on the Render service until those targets are updated.
+
 | Key | Required | Notes |
 |---|---|---|
 | `NOTION_TOKEN` | yes | Notion integration token |
 | `NOTION_PAGE_IDS` | yes | Comma-separated page IDs |
 | `NOTION_TARGET_OWNER_EMAIL` | one of these two | Email of the destination account. `make sync-notion-secrets` resolves it to a UUID automatically via the production Supabase `auth.users` table. The account must have signed in to the production app at least once. |
 | `NOTION_TARGET_OWNER_ID` | one of these two | Manual fallback: UUID from `auth.users.id`. Set only when `NOTION_TARGET_OWNER_EMAIL` is blank. |
-| `NOTION_TARGET_CARDGROUP_NAME` | yes | Destination cardgroup name; created when absent |
+| `NOTION_TARGET_CARDGROUP_NAME` | yes | Destination cardgroup name; created when absent (Makefile only — backend reads `NOTION_MASTER_CARDGROUP_NAME` instead) |
 | `NOTION_SYNC_TOKEN` | yes | Shared bearer token — written to both Render env and the GHA secret (see note below) |
 | `NOTION_MAX_ATTEMPTS` | no | Defaults to `5` |
 | `NOTION_MAX_ELAPSED` | no | Defaults to `2m` |
@@ -113,7 +117,7 @@ All NOTION_* values are stored in the root `.env` file (gitignored). The Makefil
 make sync-notion-preflight
 ```
 
-Checks that root `.env` contains every required NOTION_* key. Exits non-zero and prints the missing keys if any are absent. Run this before any push step to confirm your `.env` is complete.
+Checks that root `.env` contains the NOTION_* keys configured in the Makefile target. Exits non-zero and prints the missing keys if any are absent. Run this before any push step to confirm your `.env` is complete.
 
 **Push Notion secrets:**
 
@@ -121,7 +125,7 @@ Checks that root `.env` contains every required NOTION_* key. Exits non-zero and
 make sync-notion-secrets
 ```
 
-Pushes all seven NOTION_* keys to the Render service's environment variables, and writes `NOTION_SYNC_URL` (derived from the Render `backend_url` + `/internal/notion-sync`) and `NOTION_SYNC_TOKEN` to GitHub Actions secrets. The target is idempotent — safe to re-run after rotating a token or adding a new page ID.
+Pushes the NOTION_* keys configured in the Makefile target to the Render service's environment variables, and writes `NOTION_SYNC_URL` (derived from the Render `backend_url` + `/internal/notion-sync`) and `NOTION_SYNC_TOKEN` to GitHub Actions secrets. The target is idempotent — safe to re-run after rotating a token or adding a new page ID.
 
 **Full production sync (includes Notion):**
 
@@ -149,7 +153,7 @@ When a user creates or updates a card via GraphQL and the save succeeds, the bac
 - `updateCard` mutation completes with an updated card.
 - The duplicate path (`outcome.Duplicate != nil`) skips the write-back entirely because the card already exists in the database.
 
-**Configuration:** No new environment variables. The write-back reuses `NOTION_TOKEN` (for API authentication) and the first entry of `NOTION_PAGE_IDS` as the target page. When any of the five `NOTION_*` variables is absent, `notionSyncDisabled` is true, the Notion `CardWritebacker` adapter is not wired, and write-back is silently disabled. This covers local development and CI environments without Notion credentials.
+**Configuration:** No new environment variables. The write-back reuses `NOTION_TOKEN` (for API authentication) and the first entry of `NOTION_PAGE_IDS` as the target page. When any of the four `NOTION_*` variables is absent, `notionSyncDisabled` is true, the Notion `CardWritebacker` adapter is not wired, and write-back is silently disabled. This covers local development and CI environments without Notion credentials.
 
 **Failure handling:** Any Notion API error (non-2xx response, network timeout, context expiry) emits `slog.Warn` with `card_id`, `cardgroup_id`, and `page_id` as structured fields. Card create/update is unaffected — the mutation returns successfully regardless of the write-back outcome.
 


### PR DESCRIPTION
## Summary

- Repoints the Notion sync pipeline from user-owned `cardgroups`/`cards` tables to the admin-only `master_cardgroups`/`master_cards` tables introduced in #396.
- Replaces the `OwnerID`-carrying `NotionSyncUsecase` / `NotionSyncCardRepository` / `NotionSyncCardgroupRepository` interfaces with owner-less `MasterNotionSyncUsecase` / `NotionSyncMasterCardgroupRepository` / `NotionSyncMasterCardRepository` counterparts.
- Swaps the two required env vars (`NOTION_TARGET_OWNER_ID` + `NOTION_TARGET_CARDGROUP_NAME`) for a single `NOTION_MASTER_CARDGROUP_NAME`; the handler now reads four vars instead of five.

Closes #397

## What changed

- **`backend/internal/usecase/notion_sync.go`** — renamed `NotionSyncUsecase` → `MasterNotionSyncUsecase`; renamed constructors (`NewNotionSyncUsecase` → `NewMasterNotionSyncUsecase`, `NewNotionSyncUsecaseWithTx` → `NewMasterNotionSyncUsecaseWithTx`); removed `OwnerID` from `SyncFromNotionInput` (renamed `SyncToMasterInput`); narrow consumer interfaces now target `domain.MasterCardgroup` / `domain.MasterCard` and the master-table Tx helpers (`ListFrontsByMasterCardgroupTx`, `DeleteByMasterCardgroupAndFrontsTx`).
- **`backend/internal/handler/notionsync/config.go`** — removed `NOTION_TARGET_OWNER_ID` and `NOTION_TARGET_CARDGROUP_NAME` from `varOrder`; added `NOTION_MASTER_CARDGROUP_NAME`; updated `EnvConfig.HandlerConfig` to set `MasterCardgroupName` instead of `OwnerID` + `CardgroupName`; updated all "five required" prose to "four required".
- **`backend/cmd/server/main.go`** — wires `NewMasterCardgroupRepository` and `NewMasterCardRepository` then passes them to `NewMasterNotionSyncUsecase`; updates comment in `main()` to reference `NOTION_MASTER_CARDGROUP_NAME`.
- **`backend/.env.example`** — removes `NOTION_TARGET_OWNER_ID` / `NOTION_TARGET_CARDGROUP_NAME`; adds `NOTION_MASTER_CARDGROUP_NAME`.
- **`backend/internal/usecase/notion_sync_test.go`** and **`backend/internal/handler/notionsync/config_test.go`** — updated to cover the master-targeted usecase and the four-var config shape.
- **`docs/notion-sync.md`** — documents the new env var and adds a pending-operator-step callout noting that `NOTION_TARGET_OWNER_ID` / `NOTION_TARGET_CARDGROUP_NAME` must be swapped for `NOTION_MASTER_CARDGROUP_NAME` on the Render service before the next production sync run.

## Test plan

- `go build ./...` — clean.
- `go vet ./...` — clean.
- `go tool go-arch-lint check --project-path .` — no layer violations.
- `go test ./internal/usecase/... ./internal/handler/notionsync/...` — green (master-targeted sync usecase and four-var config both covered).
- CJK grep gate — no CJK characters in tracked source or docs.
- PR-number grep gate — no `PR[0-9]+` references in committed text.

## Operator follow-ups

**Operator (do NOT do in this PR):** in `render.yaml` and `cloudbuild.yaml`, remove `NOTION_TARGET_OWNER_ID` and `NOTION_TARGET_CARDGROUP_NAME` and add `NOTION_MASTER_CARDGROUP_NAME`. Deploy-affecting; requires operator sign-off.

- The deployed Render service env + `render.yaml` + `cloudbuild.yaml` still reference `NOTION_TARGET_OWNER_ID` / `NOTION_TARGET_CARDGROUP_NAME`; the backend no longer reads them. Before the next production sync run, set `NOTION_MASTER_CARDGROUP_NAME` on the Render service so the scheduler keeps working. These vars were deliberately left in `render.yaml`/`cloudbuild.yaml` (deploy-affecting; per issue + scope-discipline rules). A pending-operator-step callout is recorded in `docs/notion-sync.md`.
- The Makefile `make sync-notion-*` targets and the `docs/notion-sync.md` "Operational setup" / "Local testing" sections still describe `NOTION_TARGET_OWNER_ID` / `NOTION_TARGET_CARDGROUP_NAME` and the `NOTION_LOCAL_*` owner-resolution flow. Those sections accurately describe the unchanged Makefile and were left as-is rather than describing nonexistent behavior. Updating the Makefile targets and those doc sections to the master-name flow is a follow-up that should land with the infra env rename.
- If a future cleanup wants it: the user-owned `CardgroupRepository.EnsureByName` (which accepted `ownerID`) now has zero production callers — the repoint removed its only one. It is still a tested general-purpose repo method, so it was left in place rather than cascading a removal through the `CardgroupRepository` interface, loader fakes, and tests (out of scope for this PR).
