### PR TITLE
feat: limit general users to 5 cardgroups

### DIFF
--- a/.claude/rules/go-library-gotchas.md
+++ b/.claude/rules/go-library-gotchas.md
@@ -130,6 +130,7 @@ This matters most in DataLoader batch functions, where an empty key slice is a n
 - [Fat repository interface split: CRUD vs membership seam — when and how to split, wiring checklist, context pass-through in validation helpers](../../docs/backend/library-gotchas/fat-repository-interface-split.md)
 - [Codegen two-pass failure mode: schema field drop blocks regen until production code is fixed](../../docs/backend/library-gotchas/codegen-two-pass-schema-field-drop.md)
 - [CI bash glob `for $(ls)` silently passes on zero matches under `set -e` — use `nullglob` array form](../../docs/backend/library-gotchas/ci-bash-glob-nullglob-silent-pass.md)
+- [Inject `AdminChecker` (bool) for admin-exempt business rules, not `AdminGate.Require`](../../docs/backend/library-gotchas/admin-checker-inject-for-admin-exempt-business-logic.md)
 
 ## DDD patterns (on-demand)
 

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -285,7 +285,7 @@ func run(ctx context.Context, logger *slog.Logger) error {
 	}
 
 	userUC := usecase.NewUserUsecase(userRepo, userRoleRepo, authSvc, logger)
-	cardgroupUC := usecase.NewCardgroupUsecase(cardgroupRepo, logger)
+	cardgroupUC := usecase.NewCardgroupUsecase(cardgroupRepo, authSvc, logger)
 	learnUC := usecase.NewLearnUsecase(cardRepo, cardgroupRepo, service.NewOrderingPolicy(), nil, 0, 0, nil, logger)
 	swipeUC := usecase.NewSwipeUsecase(db.GORM, cardRepo, cardgroupRepo, swipeRecordRepo, service.NewFSRSScheduler(), userCardFSRSRepo, logger)
 	cardImportUC := usecase.NewCardImportUsecase(cardgroupRepo, cardRepo, db.GORM, logger)

--- a/backend/cmd/server/main_test.go
+++ b/backend/cmd/server/main_test.go
@@ -54,6 +54,18 @@ import (
 
 var testDBURL string
 
+// stubAdminChecker satisfies usecase.AdminChecker for wiring/smoke tests that
+// do not exercise the cardgroup-limit guard. Passing isAdmin: true short-circuits
+// the limit check and preserves prior test behavior.
+type stubAdminChecker struct {
+	isAdmin bool
+	err     error
+}
+
+func (s stubAdminChecker) IsAdmin(_ context.Context, _ string) (bool, error) {
+	return s.isAdmin, s.err
+}
+
 func TestMain(m *testing.M) {
 	os.Exit(runTests(m))
 }
@@ -585,7 +597,7 @@ func newGraphQLTestServerWithUserRepo(t *testing.T, f *jwtFixture, userRepo repo
 	swipeRecordRepo := repository.NewSwipeRecordRepository(db.GORM)
 	logger := slog.New(slog.DiscardHandler)
 	userUC := usecase.NewUserUsecase(userRepo, userRoleRepo, nil, logger)
-	cardgroupUC := usecase.NewCardgroupUsecase(cardgroupRepo, logger)
+	cardgroupUC := usecase.NewCardgroupUsecase(cardgroupRepo, stubAdminChecker{isAdmin: true}, logger)
 	cardUC := usecase.NewCardUsecase(db.GORM, cardRepo, cardgroupRepo, userCardFSRSRepo, nil, logger)
 	swipeUC := usecase.NewSwipeUsecase(db.GORM, cardRepo, cardgroupRepo, swipeRecordRepo, service.NewFSRSScheduler(), userCardFSRSRepo, logger)
 	pingRecordRepo := repository.NewPingRecordRepository(db.GORM)
@@ -1748,7 +1760,7 @@ func newLastViewedGraphQLTestServer(t *testing.T, f *jwtFixture) (*httptest.Serv
 	userPreferenceRepo := repository.NewUserPreferenceRepository(db.GORM)
 	logger := slog.New(slog.DiscardHandler)
 	userUC := usecase.NewUserUsecase(userRepo, userRoleRepo, nil, logger)
-	cardgroupUC := usecase.NewCardgroupUsecase(cardgroupRepo, logger)
+	cardgroupUC := usecase.NewCardgroupUsecase(cardgroupRepo, stubAdminChecker{isAdmin: true}, logger)
 	cardUC := usecase.NewCardUsecase(db.GORM, cardRepo, cardgroupRepo, userCardFSRSRepo, nil, logger)
 	swipeUC := usecase.NewSwipeUsecase(db.GORM, cardRepo, cardgroupRepo, swipeRecordRepo, service.NewFSRSScheduler(), userCardFSRSRepo, logger)
 	lastViewedUC := usecase.NewLastViewedCardgroup(userPreferenceRepo, userRepo, logger)

--- a/backend/graph/resolver/cardgroup.resolvers.go
+++ b/backend/graph/resolver/cardgroup.resolvers.go
@@ -31,10 +31,12 @@ func (r *cardgroupResolver) Owner(ctx context.Context, obj *model.Cardgroup) (*m
 
 // CreateCardgroup is the resolver for the createCardgroup field.
 //
-// Returns a union: `model.CreateCardgroupSuccess` on the happy path, or
+// Returns a union: `model.CreateCardgroupSuccess` on the happy path,
 // `model.InputValidationError` when the name fails validation (e.g. empty,
-// too long). Validation failures are "errors as data" — the error return is
-// reserved for auth and infrastructure failures.
+// too long), or `model.CardgroupLimitReachedError` when a non-admin caller
+// has already reached the per-user cardgroup cap. Validation failures and
+// limit errors are "errors as data" — the error return is reserved for auth
+// and infrastructure failures.
 func (r *mutationResolver) CreateCardgroup(ctx context.Context, input model.NewCardgroupInput) (model.CreateCardgroupResult, error) {
 	outcome, err := r.CardgroupUC.Create(ctx, usecase.CreateCardgroupInput{Name: input.Name})
 	if err != nil {

--- a/backend/graph/resolver/cardgroup.resolvers.go
+++ b/backend/graph/resolver/cardgroup.resolvers.go
@@ -46,6 +46,13 @@ func (r *mutationResolver) CreateCardgroup(ctx context.Context, input model.NewC
 			Message: outcome.Validation.Message,
 		}, nil
 	}
+	if outcome.LimitReached != nil {
+		return model.CardgroupLimitReachedError{
+			Message: "cardgroup limit reached",
+			Limit:   outcome.LimitReached.Limit,
+			Current: outcome.LimitReached.Current,
+		}, nil
+	}
 	if outcome.Cardgroup == nil {
 		return nil, gqlerr.Internal(ctx,
 			eris.New("resolver: CreateCardgroupOutcome has no variant set"))

--- a/backend/graph/resolver/cardgroup_resolvers_test.go
+++ b/backend/graph/resolver/cardgroup_resolvers_test.go
@@ -74,10 +74,31 @@ func (m *mockCardgroupRepoForResolver) Delete(_ context.Context, _ string) error
 	return nil
 }
 
+// stubAdminCheckerForResolver satisfies usecase.AdminChecker for resolver-level
+// unit tests. Most tests pass isAdmin: true to bypass the cardgroup-limit guard
+// and preserve prior behavior; the limit-reached test passes isAdmin: false.
+type stubAdminCheckerForResolver struct {
+	isAdmin bool
+	err     error
+}
+
+func (s stubAdminCheckerForResolver) IsAdmin(_ context.Context, _ string) (bool, error) {
+	return s.isAdmin, s.err
+}
+
 // newCardgroupSrv builds a gqlgen handler.Server backed by a real
-// CardgroupUsecase wired to the supplied mock repository.
+// CardgroupUsecase wired to the supplied mock repository. The admin stub
+// returns isAdmin: true so the cardgroup-limit guard is bypassed for all
+// tests that do not specifically exercise the limit path.
 func newCardgroupSrv(repo usecase.CardgroupRepository) *handler.Server {
-	cgUC := usecase.NewCardgroupUsecase(repo, newDiscardLogger())
+	return newCardgroupSrvWithAdmin(repo, stubAdminCheckerForResolver{isAdmin: true})
+}
+
+// newCardgroupSrvWithAdmin builds a gqlgen handler.Server allowing the caller
+// to supply a custom AdminChecker stub. Use this when a test needs to exercise
+// the cardgroup-limit code path (isAdmin: false).
+func newCardgroupSrvWithAdmin(repo usecase.CardgroupRepository, admin usecase.AdminChecker) *handler.Server {
+	cgUC := usecase.NewCardgroupUsecase(repo, admin, newDiscardLogger())
 	r := resolver.NewResolver(nil, cgUC, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	srv := handler.New(generated.NewExecutableSchema(generated.Config{Resolvers: r}))
 	srv.AddTransport(transport.POST{})
@@ -417,6 +438,46 @@ func TestResolver_CreateCardgroup_ValidationError_EmptyName(t *testing.T) {
 	}
 	if payload["field"] != "name" {
 		t.Fatalf("expected field=name, got %v; response: %v", payload["field"], resp)
+	}
+}
+
+// createCardgroupBodyWithLimit returns a mutation body that selects all three
+// union variants of CreateCardgroupResult, including CardgroupLimitReachedError.
+func createCardgroupBodyWithLimit(name string) string {
+	return `{"query":"mutation { createCardgroup(input: {name: \"` + name + `\"}) { __typename ... on CreateCardgroupSuccess { cardgroup { id name } } ... on InputValidationError { field message } ... on CardgroupLimitReachedError { message limit current } } }"}`
+}
+
+// TestResolver_CreateCardgroup_LimitReached verifies that a non-admin caller
+// who already owns generalUserCardgroupLimit (5) cardgroups receives the
+// CardgroupLimitReachedError union variant with the correct Limit and Current
+// fields rather than a GraphQL protocol error.
+func TestResolver_CreateCardgroup_LimitReached(t *testing.T) {
+	t.Parallel()
+
+	// CountByOwner returns 5 — the non-admin caller is at the limit.
+	repo := &mockCardgroupRepoForResolver{countResult: 5}
+	// isAdmin: false so the limit check is not bypassed.
+	srv := newCardgroupSrvWithAdmin(repo, stubAdminCheckerForResolver{isAdmin: false})
+	resp := gqlRequest(t, srv, authedCtx("u1"), createCardgroupBodyWithLimit("Over Limit"))
+
+	if _, hasErrs := resp["errors"]; hasErrs {
+		t.Fatalf("unexpected protocol errors (limit should come as data): %v", resp["errors"])
+	}
+	data, _ := resp["data"].(map[string]any)
+	payload, _ := data["createCardgroup"].(map[string]any)
+	if payload == nil {
+		t.Fatalf("expected data.createCardgroup, got nil; response: %v", resp)
+	}
+	if payload["__typename"] != "CardgroupLimitReachedError" {
+		t.Fatalf("expected CardgroupLimitReachedError, got %v; response: %v", payload["__typename"], resp)
+	}
+	limit, _ := payload["limit"].(float64)
+	if int(limit) != 5 {
+		t.Fatalf("expected limit=5, got %v; response: %v", limit, resp)
+	}
+	current, _ := payload["current"].(float64)
+	if int(current) != 5 {
+		t.Fatalf("expected current=5, got %v; response: %v", current, resp)
 	}
 }
 

--- a/backend/internal/usecase/cardgroup.go
+++ b/backend/internal/usecase/cardgroup.go
@@ -80,17 +80,25 @@ type CardgroupUsecase interface {
 	ListCardgroupsByOwnerConnection(ctx context.Context, in CardgroupConnectionInput) (*CardgroupConnectionOutput, error)
 }
 
+// generalUserCardgroupLimit caps the number of cardgroups a non-admin owner
+// may create. Admins are exempt. Enforced in Create via checkCardgroupLimit.
+const generalUserCardgroupLimit = 5
+
 type cardgroupUsecase struct {
 	repo   CardgroupRepository
+	admin  AdminChecker
 	logger *slog.Logger
 }
 
 // NewCardgroupUsecase constructs a CardgroupUsecase backed by the given repository.
-func NewCardgroupUsecase(repo CardgroupRepository, logger *slog.Logger) CardgroupUsecase {
+func NewCardgroupUsecase(repo CardgroupRepository, admin AdminChecker, logger *slog.Logger) CardgroupUsecase {
+	if admin == nil {
+		panic("usecase: cardgroup: admin checker is required")
+	}
 	if logger == nil {
 		panic("usecase: cardgroup: logger is required")
 	}
-	return &cardgroupUsecase{repo: repo, logger: logger}
+	return &cardgroupUsecase{repo: repo, admin: admin, logger: logger}
 }
 
 // Cardgroup returns a single cardgroup by id. Non-owners receive UNAUTHENTICATED
@@ -118,13 +126,53 @@ func (u *cardgroupUsecase) Cardgroup(ctx context.Context, id string) (*domain.Ca
 type CreateCardgroupInput struct{ Name string }
 
 // CreateCardgroupOutcome is the result of CardgroupUsecase.Create. Exactly one
-// of Cardgroup or Validation is non-nil on a nil-error return: a successful
-// insert carries the new Cardgroup; a name that fails validation surfaces via
-// Validation so the resolver maps it to the CreateCardgroupResult union's
-// InputValidationError variant.
+// of Cardgroup, Validation, or LimitReached is non-nil on a nil-error return: a
+// successful insert carries the new Cardgroup; a name that fails validation
+// surfaces via Validation so the resolver maps it to the CreateCardgroupResult
+// union's InputValidationError variant; a non-admin owner who already holds the
+// per-user cardgroup limit surfaces via LimitReached.
 type CreateCardgroupOutcome struct {
-	Cardgroup  *domain.Cardgroup
-	Validation *InputValidationInfo
+	Cardgroup    *domain.Cardgroup
+	Validation   *InputValidationInfo
+	LimitReached *CardgroupLimitInfo
+}
+
+// CardgroupLimitInfo reports that the authenticated owner has reached the
+// per-user cardgroup limit. Limit is the cap; Current is the owner's count at
+// the time the create was rejected.
+type CardgroupLimitInfo struct {
+	Limit   int
+	Current int
+}
+
+// cardgroupOwnerCounter is the narrow surface checkCardgroupLimit needs.
+// Satisfied by CardgroupRepository and reused by the future import path.
+type cardgroupOwnerCounter interface {
+	CountByOwner(ctx context.Context, ownerID string, search *string) (int64, error)
+}
+
+// checkCardgroupLimit returns a non-nil *CardgroupLimitInfo when a non-admin
+// owner already holds generalUserCardgroupLimit cardgroups. Admins are exempt
+// (returns nil, nil without counting). Infrastructure failures propagate wrapped.
+func checkCardgroupLimit(ctx context.Context, counter cardgroupOwnerCounter, admin AdminChecker, ownerID string) (*CardgroupLimitInfo, error) {
+	isAdmin, err := admin.IsAdmin(ctx, ownerID)
+	if err != nil {
+		if isContextDone(err) {
+			return nil, err
+		}
+		return nil, eris.Wrap(err, "usecase: cardgroup: check admin")
+	}
+	if isAdmin {
+		return nil, nil
+	}
+	count, err := counter.CountByOwner(ctx, ownerID, nil)
+	if err != nil {
+		return nil, eris.Wrap(err, "usecase: cardgroup: count by owner")
+	}
+	if count >= generalUserCardgroupLimit {
+		return &CardgroupLimitInfo{Limit: generalUserCardgroupLimit, Current: int(count)}, nil
+	}
+	return nil, nil
 }
 
 // Create creates a new cardgroup owned by the authenticated caller.
@@ -141,6 +189,17 @@ func (u *cardgroupUsecase) Create(ctx context.Context, in CreateCardgroupInput) 
 	}
 	if info != nil {
 		return CreateCardgroupOutcome{Validation: info}, nil
+	}
+
+	// Name validation (no DB) runs first to avoid the IsAdmin + Count queries
+	// on the common invalid-name path. Non-admins are capped at
+	// generalUserCardgroupLimit cardgroups; admins are exempt.
+	limit, err := checkCardgroupLimit(ctx, u.repo, u.admin, user.Sub)
+	if err != nil {
+		return CreateCardgroupOutcome{}, err
+	}
+	if limit != nil {
+		return CreateCardgroupOutcome{LimitReached: limit}, nil
 	}
 
 	id, err := domain.NewID()

--- a/backend/internal/usecase/cardgroup.go
+++ b/backend/internal/usecase/cardgroup.go
@@ -139,14 +139,16 @@ type CreateCardgroupOutcome struct {
 
 // CardgroupLimitInfo reports that the authenticated owner has reached the
 // per-user cardgroup limit. Limit is the cap; Current is the owner's count at
-// the time the create was rejected.
+// the time the create was rejected. Current is always >= Limit when this
+// struct is constructed.
 type CardgroupLimitInfo struct {
 	Limit   int
 	Current int
 }
 
 // cardgroupOwnerCounter is the narrow surface checkCardgroupLimit needs.
-// Satisfied by CardgroupRepository and reused by the future import path.
+// Keeping it separate from CardgroupRepository lets tests stub only the
+// counting method.
 type cardgroupOwnerCounter interface {
 	CountByOwner(ctx context.Context, ownerID string, search *string) (int64, error)
 }
@@ -167,6 +169,9 @@ func checkCardgroupLimit(ctx context.Context, counter cardgroupOwnerCounter, adm
 	}
 	count, err := counter.CountByOwner(ctx, ownerID, nil)
 	if err != nil {
+		if isContextDone(err) {
+			return nil, err
+		}
 		return nil, eris.Wrap(err, "usecase: cardgroup: count by owner")
 	}
 	if count >= generalUserCardgroupLimit {

--- a/backend/internal/usecase/cardgroup.go
+++ b/backend/internal/usecase/cardgroup.go
@@ -155,7 +155,8 @@ type cardgroupOwnerCounter interface {
 
 // checkCardgroupLimit returns a non-nil *CardgroupLimitInfo when a non-admin
 // owner already holds generalUserCardgroupLimit cardgroups. Admins are exempt
-// (returns nil, nil without counting). Infrastructure failures propagate wrapped.
+// (returns nil, nil without counting). Context cancellation and deadline
+// errors pass through unwrapped; other infrastructure failures propagate wrapped.
 func checkCardgroupLimit(ctx context.Context, counter cardgroupOwnerCounter, admin AdminChecker, ownerID string) (*CardgroupLimitInfo, error) {
 	isAdmin, err := admin.IsAdmin(ctx, ownerID)
 	if err != nil {

--- a/backend/internal/usecase/cardgroup_test.go
+++ b/backend/internal/usecase/cardgroup_test.go
@@ -1903,3 +1903,62 @@ func TestCheckCardgroupLimit_IsAdminCancelled_IdentityPreserved(t *testing.T) {
 		t.Fatalf("expected counter NOT to be called when IsAdmin is cancelled, got %d calls", counter.calls)
 	}
 }
+
+// TestCardgroupUsecase_Create_CountByOwnerCancelled_IdentityPreserved verifies
+// that a context.Canceled returned from CountByOwner propagates with its
+// identity intact (errors.Is matches and err == context.Canceled, NOT an eris
+// wrap) and that repo.Create is not reached. The admin stub reports isAdmin=false
+// so the count query is reached and injects the cancellation.
+func TestCardgroupUsecase_Create_CountByOwnerCancelled_IdentityPreserved(t *testing.T) {
+	t.Parallel()
+	repo := &mockCardgroupRepository{countErr: context.Canceled}
+	uc := NewCardgroupUsecase(repo, &mockAdminChecker{isAdmin: false}, newTestLogger())
+
+	outcome, err := uc.Create(cgAuthedCtx("user-1"), CreateCardgroupInput{Name: "Group"})
+
+	if err == nil {
+		t.Fatal("expected context.Canceled, got nil")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected errors.Is(err, context.Canceled)=true, got %v (%T)", err, err)
+	}
+	// Identity preserved: the returned error IS context.Canceled, not an eris wrap.
+	if err != context.Canceled {
+		t.Fatalf("expected the unwrapped context.Canceled, got %v (%T)", err, err)
+	}
+	// The outcome must be the zero value — no LimitReached, no Cardgroup.
+	if outcome.LimitReached != nil {
+		t.Fatalf("expected nil LimitReached on cancellation, got %+v", outcome.LimitReached)
+	}
+	if outcome.Cardgroup != nil {
+		t.Fatalf("expected nil Cardgroup on cancellation, got %+v", outcome.Cardgroup)
+	}
+	if repo.capturedCreate != nil {
+		t.Fatal("repository.Create must not be called when CountByOwner is cancelled")
+	}
+}
+
+// TestCheckCardgroupLimit_CountCancelled_IdentityPreserved verifies that a
+// context.Canceled returned from CountByOwner passes through checkCardgroupLimit
+// unwrapped: errors.Is matches and err == context.Canceled (bare identity).
+func TestCheckCardgroupLimit_CountCancelled_IdentityPreserved(t *testing.T) {
+	t.Parallel()
+	counter := &stubCardgroupCounter{err: context.Canceled}
+	admin := &stubLimitAdminChecker{isAdmin: false}
+
+	info, err := checkCardgroupLimit(context.Background(), counter, admin, "user-1")
+
+	if err == nil {
+		t.Fatal("expected context.Canceled, got nil")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected errors.Is(err, context.Canceled)=true, got %v (%T)", err, err)
+	}
+	// Identity preserved: the returned error IS context.Canceled, not an eris wrap.
+	if err != context.Canceled {
+		t.Fatalf("expected the unwrapped context.Canceled, got %v (%T)", err, err)
+	}
+	if info != nil {
+		t.Fatalf("expected nil LimitInfo on cancellation, got %+v", info)
+	}
+}

--- a/backend/internal/usecase/cardgroup_test.go
+++ b/backend/internal/usecase/cardgroup_test.go
@@ -1764,25 +1764,12 @@ func (s *stubCardgroupCounter) CountByOwner(_ context.Context, _ string, _ *stri
 	return s.count, s.err
 }
 
-// stubLimitAdminChecker is a minimal AdminChecker for the direct
-// checkCardgroupLimit tests.
-type stubLimitAdminChecker struct {
-	isAdmin bool
-	err     error
-	calls   int
-}
-
-func (s *stubLimitAdminChecker) IsAdmin(_ context.Context, _ string) (bool, error) {
-	s.calls++
-	return s.isAdmin, s.err
-}
-
 // TestCheckCardgroupLimit_Admin_Exempt verifies that an admin owner is exempt:
 // the helper returns (nil, nil) and the counter is never consulted.
 func TestCheckCardgroupLimit_Admin_Exempt(t *testing.T) {
 	t.Parallel()
 	counter := &stubCardgroupCounter{count: generalUserCardgroupLimit}
-	admin := &stubLimitAdminChecker{isAdmin: true}
+	admin := &mockAdminChecker{isAdmin: true}
 
 	info, err := checkCardgroupLimit(context.Background(), counter, admin, "admin-1")
 
@@ -1802,7 +1789,7 @@ func TestCheckCardgroupLimit_Admin_Exempt(t *testing.T) {
 func TestCheckCardgroupLimit_UnderLimit(t *testing.T) {
 	t.Parallel()
 	counter := &stubCardgroupCounter{count: generalUserCardgroupLimit - 1}
-	admin := &stubLimitAdminChecker{isAdmin: false}
+	admin := &mockAdminChecker{isAdmin: false}
 
 	info, err := checkCardgroupLimit(context.Background(), counter, admin, "user-1")
 
@@ -1834,7 +1821,7 @@ func TestCheckCardgroupLimit_AtOrOverLimit(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			counter := &stubCardgroupCounter{count: tc.count}
-			admin := &stubLimitAdminChecker{isAdmin: false}
+			admin := &mockAdminChecker{isAdmin: false}
 
 			info, err := checkCardgroupLimit(context.Background(), counter, admin, "user-1")
 
@@ -1859,8 +1846,8 @@ func TestCheckCardgroupLimit_AtOrOverLimit(t *testing.T) {
 // and the counter is never consulted.
 func TestCheckCardgroupLimit_IsAdminError_Wrapped(t *testing.T) {
 	t.Parallel()
-	counter := &stubCardgroupCounter{count: 0}
-	admin := &stubLimitAdminChecker{err: errors.New("auth: lookup failed")}
+	counter := &stubCardgroupCounter{}
+	admin := &mockAdminChecker{err: errors.New("auth: lookup failed")}
 
 	_, err := checkCardgroupLimit(context.Background(), counter, admin, "user-1")
 
@@ -1876,7 +1863,7 @@ func TestCheckCardgroupLimit_IsAdminError_Wrapped(t *testing.T) {
 func TestCheckCardgroupLimit_CountError_Wrapped(t *testing.T) {
 	t.Parallel()
 	counter := &stubCardgroupCounter{err: errors.New("db: count failed")}
-	admin := &stubLimitAdminChecker{isAdmin: false}
+	admin := &mockAdminChecker{isAdmin: false}
 
 	_, err := checkCardgroupLimit(context.Background(), counter, admin, "user-1")
 
@@ -1888,8 +1875,8 @@ func TestCheckCardgroupLimit_CountError_Wrapped(t *testing.T) {
 // the returned error IS context.Canceled), and the counter is never consulted.
 func TestCheckCardgroupLimit_IsAdminCancelled_IdentityPreserved(t *testing.T) {
 	t.Parallel()
-	counter := &stubCardgroupCounter{count: 0}
-	admin := &stubLimitAdminChecker{err: context.Canceled}
+	counter := &stubCardgroupCounter{}
+	admin := &mockAdminChecker{err: context.Canceled}
 
 	_, err := checkCardgroupLimit(context.Background(), counter, admin, "user-1")
 
@@ -1944,7 +1931,7 @@ func TestCardgroupUsecase_Create_CountByOwnerCancelled_IdentityPreserved(t *test
 func TestCheckCardgroupLimit_CountCancelled_IdentityPreserved(t *testing.T) {
 	t.Parallel()
 	counter := &stubCardgroupCounter{err: context.Canceled}
-	admin := &stubLimitAdminChecker{isAdmin: false}
+	admin := &mockAdminChecker{isAdmin: false}
 
 	info, err := checkCardgroupLimit(context.Background(), counter, admin, "user-1")
 
@@ -1971,7 +1958,7 @@ func TestCheckCardgroupLimit_CountCancelled_IdentityPreserved(t *testing.T) {
 func TestCheckCardgroupLimit_CountDeadlineExceeded_IdentityPreserved(t *testing.T) {
 	t.Parallel()
 	counter := &stubCardgroupCounter{err: context.DeadlineExceeded}
-	admin := &stubLimitAdminChecker{isAdmin: false}
+	admin := &mockAdminChecker{isAdmin: false}
 
 	info, err := checkCardgroupLimit(context.Background(), counter, admin, "user-1")
 

--- a/backend/internal/usecase/cardgroup_test.go
+++ b/backend/internal/usecase/cardgroup_test.go
@@ -1962,3 +1962,30 @@ func TestCheckCardgroupLimit_CountCancelled_IdentityPreserved(t *testing.T) {
 		t.Fatalf("expected nil LimitInfo on cancellation, got %+v", info)
 	}
 }
+
+// TestCheckCardgroupLimit_CountDeadlineExceeded_IdentityPreserved verifies that
+// a context.DeadlineExceeded returned from CountByOwner passes through
+// checkCardgroupLimit unwrapped: errors.Is matches and err ==
+// context.DeadlineExceeded (bare identity). Mirrors the Canceled case above
+// because isContextDone handles both sentinels.
+func TestCheckCardgroupLimit_CountDeadlineExceeded_IdentityPreserved(t *testing.T) {
+	t.Parallel()
+	counter := &stubCardgroupCounter{err: context.DeadlineExceeded}
+	admin := &stubLimitAdminChecker{isAdmin: false}
+
+	info, err := checkCardgroupLimit(context.Background(), counter, admin, "user-1")
+
+	if err == nil {
+		t.Fatal("expected context.DeadlineExceeded, got nil")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected errors.Is(err, context.DeadlineExceeded)=true, got %v (%T)", err, err)
+	}
+	// Identity preserved: the returned error IS context.DeadlineExceeded, not an eris wrap.
+	if err != context.DeadlineExceeded {
+		t.Fatalf("expected the unwrapped context.DeadlineExceeded, got %v (%T)", err, err)
+	}
+	if info != nil {
+		t.Fatalf("expected nil LimitInfo on deadline exceeded, got %+v", info)
+	}
+}

--- a/backend/internal/usecase/cardgroup_test.go
+++ b/backend/internal/usecase/cardgroup_test.go
@@ -151,12 +151,21 @@ func cgAuthedCtx(sub string) context.Context {
 	return auth.ContextWithUser(context.Background(), &auth.AuthUser{Sub: sub})
 }
 
+// cgDefaultAdmin returns a fresh admin stub that reports isAdmin=true. Every
+// existing Create/Update/Find/pagination test passes this so checkCardgroupLimit
+// short-circuits before CountByOwner is reached — the prior behaviour of those
+// tests is unchanged. The per-call-site freshness keeps the stub's call counter
+// isolated. mockAdminChecker is defined in helpers_test.go.
+func cgDefaultAdmin() *mockAdminChecker {
+	return &mockAdminChecker{isAdmin: true}
+}
+
 // --- Cardgroup tests ---
 
 func TestCardgroupUsecase_Cardgroup_Anonymous(t *testing.T) {
 	t.Parallel()
 	repo := &mockCardgroupRepository{}
-	uc := NewCardgroupUsecase(repo, newTestLogger())
+	uc := NewCardgroupUsecase(repo, cgDefaultAdmin(), newTestLogger())
 
 	_, err := uc.Cardgroup(anonCtx(), "cg1")
 
@@ -169,7 +178,7 @@ func TestCardgroupUsecase_Cardgroup_Anonymous(t *testing.T) {
 func TestCardgroupUsecase_Cardgroup_NotFound_ReturnsNilNoError(t *testing.T) {
 	t.Parallel()
 	repo := &mockCardgroupRepository{findErr: repository.ErrNotFound}
-	uc := NewCardgroupUsecase(repo, newTestLogger())
+	uc := NewCardgroupUsecase(repo, cgDefaultAdmin(), newTestLogger())
 
 	got, err := uc.Cardgroup(cgAuthedCtx("user-1"), "cg-missing")
 
@@ -185,7 +194,7 @@ func TestCardgroupUsecase_Cardgroup_OwnerSeesOwn(t *testing.T) {
 	t.Parallel()
 	cg := &domain.Cardgroup{ID: "cg1", OwnerID: "user-1", Name: "Mine"}
 	repo := &mockCardgroupRepository{findResult: cg}
-	uc := NewCardgroupUsecase(repo, newTestLogger())
+	uc := NewCardgroupUsecase(repo, cgDefaultAdmin(), newTestLogger())
 
 	got, err := uc.Cardgroup(cgAuthedCtx("user-1"), "cg1")
 
@@ -201,7 +210,7 @@ func TestCardgroupUsecase_Cardgroup_NonOwnerGetsUnauthenticated(t *testing.T) {
 	t.Parallel()
 	cg := &domain.Cardgroup{ID: "cg1", OwnerID: "user-1", Name: "Mine"}
 	repo := &mockCardgroupRepository{findResult: cg}
-	uc := NewCardgroupUsecase(repo, newTestLogger())
+	uc := NewCardgroupUsecase(repo, cgDefaultAdmin(), newTestLogger())
 
 	_, err := uc.Cardgroup(cgAuthedCtx("user-2"), "cg1")
 
@@ -216,7 +225,7 @@ func TestCardgroupUsecase_Cardgroup_NonOwnerGetsUnauthenticated(t *testing.T) {
 func TestCardgroupUsecase_Create_Anonymous(t *testing.T) {
 	t.Parallel()
 	repo := &mockCardgroupRepository{}
-	uc := NewCardgroupUsecase(repo, newTestLogger())
+	uc := NewCardgroupUsecase(repo, cgDefaultAdmin(), newTestLogger())
 
 	_, err := uc.Create(anonCtx(), CreateCardgroupInput{Name: "Hello"})
 
@@ -229,7 +238,7 @@ func TestCardgroupUsecase_Create_Anonymous(t *testing.T) {
 func TestCardgroupUsecase_Create_EmptyName_ValidationVariant(t *testing.T) {
 	t.Parallel()
 	repo := &mockCardgroupRepository{}
-	uc := NewCardgroupUsecase(repo, newTestLogger())
+	uc := NewCardgroupUsecase(repo, cgDefaultAdmin(), newTestLogger())
 
 	outcome, err := uc.Create(cgAuthedCtx("user-1"), CreateCardgroupInput{Name: ""})
 
@@ -253,7 +262,7 @@ func TestCardgroupUsecase_Create_EmptyName_ValidationVariant(t *testing.T) {
 func TestCardgroupUsecase_Create_TooLong_ValidationVariant(t *testing.T) {
 	t.Parallel()
 	repo := &mockCardgroupRepository{}
-	uc := NewCardgroupUsecase(repo, newTestLogger())
+	uc := NewCardgroupUsecase(repo, cgDefaultAdmin(), newTestLogger())
 
 	outcome, err := uc.Create(cgAuthedCtx("user-1"), CreateCardgroupInput{Name: strings.Repeat("a", 101)})
 
@@ -277,7 +286,7 @@ func TestCardgroupUsecase_Create_TooLong_ValidationVariant(t *testing.T) {
 func TestCardgroupUsecase_Create_Trims(t *testing.T) {
 	t.Parallel()
 	repo := &mockCardgroupRepository{}
-	uc := NewCardgroupUsecase(repo, newTestLogger())
+	uc := NewCardgroupUsecase(repo, cgDefaultAdmin(), newTestLogger())
 
 	outcome, err := uc.Create(cgAuthedCtx("user-1"), CreateCardgroupInput{Name: "  Hello  "})
 
@@ -298,7 +307,7 @@ func TestCardgroupUsecase_Create_Trims(t *testing.T) {
 func TestCardgroupUsecase_Create_Success_AssignsOwnerToCaller(t *testing.T) {
 	t.Parallel()
 	repo := &mockCardgroupRepository{}
-	uc := NewCardgroupUsecase(repo, newTestLogger())
+	uc := NewCardgroupUsecase(repo, cgDefaultAdmin(), newTestLogger())
 
 	outcome, err := uc.Create(cgAuthedCtx("user-1"), CreateCardgroupInput{Name: "My Group"})
 
@@ -325,12 +334,230 @@ func TestCardgroupUsecase_Create_Success_AssignsOwnerToCaller(t *testing.T) {
 	}
 }
 
+// --- Create per-user cardgroup-limit tests ---
+
+// TestCardgroupUsecase_Create_GeneralUser_UnderLimit_Succeeds verifies that a
+// non-admin owner holding 4 cardgroups (below the limit of 5) can create one
+// more: the outcome carries the new Cardgroup and LimitReached stays nil.
+func TestCardgroupUsecase_Create_GeneralUser_UnderLimit_Succeeds(t *testing.T) {
+	t.Parallel()
+	repo := &mockCardgroupRepository{countResult: 4}
+	uc := NewCardgroupUsecase(repo, &mockAdminChecker{isAdmin: false}, newTestLogger())
+
+	outcome, err := uc.Create(cgAuthedCtx("user-1"), CreateCardgroupInput{Name: "Fifth"})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if outcome.Cardgroup == nil {
+		t.Fatal("expected non-nil Cardgroup when under the limit")
+	}
+	if outcome.LimitReached != nil {
+		t.Fatalf("expected nil LimitReached under the limit, got %+v", outcome.LimitReached)
+	}
+	if repo.capturedCreate == nil {
+		t.Fatal("expected repo.Create to be called when under the limit")
+	}
+}
+
+// TestCardgroupUsecase_Create_GeneralUser_AtLimit_Rejected verifies that a
+// non-admin owner already holding 5 cardgroups (the limit) is rejected via the
+// LimitReached outcome, and repo.Create is NOT called.
+func TestCardgroupUsecase_Create_GeneralUser_AtLimit_Rejected(t *testing.T) {
+	t.Parallel()
+	repo := &mockCardgroupRepository{countResult: generalUserCardgroupLimit}
+	uc := NewCardgroupUsecase(repo, &mockAdminChecker{isAdmin: false}, newTestLogger())
+
+	outcome, err := uc.Create(cgAuthedCtx("user-1"), CreateCardgroupInput{Name: "Sixth"})
+
+	if err != nil {
+		t.Fatalf("expected nil error (limit goes to outcome), got: %v", err)
+	}
+	if outcome.Cardgroup != nil {
+		t.Fatalf("expected nil Cardgroup at the limit, got %+v", outcome.Cardgroup)
+	}
+	if outcome.LimitReached == nil {
+		t.Fatal("expected non-nil LimitReached at the limit")
+	}
+	if outcome.LimitReached.Limit != generalUserCardgroupLimit {
+		t.Fatalf("expected LimitReached.Limit=%d, got %d", generalUserCardgroupLimit, outcome.LimitReached.Limit)
+	}
+	if outcome.LimitReached.Current != generalUserCardgroupLimit {
+		t.Fatalf("expected LimitReached.Current=%d, got %d", generalUserCardgroupLimit, outcome.LimitReached.Current)
+	}
+	if repo.capturedCreate != nil {
+		t.Fatal("repository.Create must not be called when the limit is reached")
+	}
+}
+
+// TestCardgroupUsecase_Create_GeneralUser_AboveLimit_Rejected pins the
+// "existing 6+ users: reject-new-only" behaviour: an owner already holding 6
+// cardgroups (above the cap of 5) is rejected and LimitReached.Current reports
+// the real count rather than the cap.
+func TestCardgroupUsecase_Create_GeneralUser_AboveLimit_Rejected(t *testing.T) {
+	t.Parallel()
+	repo := &mockCardgroupRepository{countResult: 6}
+	uc := NewCardgroupUsecase(repo, &mockAdminChecker{isAdmin: false}, newTestLogger())
+
+	outcome, err := uc.Create(cgAuthedCtx("user-1"), CreateCardgroupInput{Name: "Seventh"})
+
+	if err != nil {
+		t.Fatalf("expected nil error (limit goes to outcome), got: %v", err)
+	}
+	if outcome.LimitReached == nil {
+		t.Fatal("expected non-nil LimitReached above the limit")
+	}
+	if outcome.LimitReached.Current != 6 {
+		t.Fatalf("expected LimitReached.Current=6 (real count, not the cap), got %d", outcome.LimitReached.Current)
+	}
+	if repo.capturedCreate != nil {
+		t.Fatal("repository.Create must not be called when above the limit")
+	}
+}
+
+// TestCardgroupUsecase_Create_Admin_SkipsCounting verifies that an admin owner
+// bypasses the cardgroup limit entirely: repo.Create runs even though the
+// owner's count would be at the cap, and CountByOwner is NEVER called because
+// the admin short-circuit precedes the count query.
+func TestCardgroupUsecase_Create_Admin_SkipsCounting(t *testing.T) {
+	t.Parallel()
+	// countResult is set to the cap to prove that even when the count WOULD
+	// reject a general user, an admin is never subjected to it.
+	repo := &mockCardgroupRepository{countResult: generalUserCardgroupLimit}
+	admin := &mockAdminChecker{isAdmin: true}
+	uc := NewCardgroupUsecase(repo, admin, newTestLogger())
+
+	outcome, err := uc.Create(cgAuthedCtx("admin-1"), CreateCardgroupInput{Name: "AdminGroup"})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if outcome.Cardgroup == nil {
+		t.Fatal("expected non-nil Cardgroup for admin owner")
+	}
+	if outcome.LimitReached != nil {
+		t.Fatalf("expected nil LimitReached for admin owner, got %+v", outcome.LimitReached)
+	}
+	if repo.capturedCreate == nil {
+		t.Fatal("expected repo.Create to be called for admin owner")
+	}
+	if len(repo.countCalls) != 0 {
+		t.Fatalf("expected CountByOwner NOT to be called for admin owner, got %d calls", len(repo.countCalls))
+	}
+}
+
+// TestCardgroupUsecase_Create_IsAdminError_Wrapped verifies that a non-context
+// error from IsAdmin propagates wrapped with the "usecase: cardgroup: check
+// admin" prefix and that repo.Create is not reached.
+func TestCardgroupUsecase_Create_IsAdminError_Wrapped(t *testing.T) {
+	t.Parallel()
+	repo := &mockCardgroupRepository{}
+	admin := &mockAdminChecker{err: errors.New("auth: lookup failed")}
+	uc := NewCardgroupUsecase(repo, admin, newTestLogger())
+
+	_, err := uc.Create(cgAuthedCtx("user-1"), CreateCardgroupInput{Name: "Group"})
+
+	if err == nil {
+		t.Fatal("expected error from IsAdmin, got nil")
+	}
+	assertInternalChain(t, err, "usecase: cardgroup: check admin")
+	if repo.capturedCreate != nil {
+		t.Fatal("repository.Create must not be called when IsAdmin fails")
+	}
+}
+
+// TestCardgroupUsecase_Create_CountByOwnerError_Wrapped verifies that a
+// non-context error from CountByOwner propagates wrapped with the "usecase:
+// cardgroup: count by owner" prefix.
+func TestCardgroupUsecase_Create_CountByOwnerError_Wrapped(t *testing.T) {
+	t.Parallel()
+	repo := &mockCardgroupRepository{countErr: errors.New("db: count failed")}
+	uc := NewCardgroupUsecase(repo, &mockAdminChecker{isAdmin: false}, newTestLogger())
+
+	_, err := uc.Create(cgAuthedCtx("user-1"), CreateCardgroupInput{Name: "Group"})
+
+	if err == nil {
+		t.Fatal("expected error from CountByOwner, got nil")
+	}
+	assertInternalChain(t, err, "usecase: cardgroup: count by owner")
+	if repo.capturedCreate != nil {
+		t.Fatal("repository.Create must not be called when CountByOwner fails")
+	}
+}
+
+// TestCardgroupUsecase_Create_IsAdminCancelled_IdentityPreserved verifies that
+// a context.Canceled returned from IsAdmin is propagated with its identity
+// intact (errors.Is matches) and is NOT wrapped — the resolver matches the
+// cancellation via errors.Is, which an eris wrap would defeat.
+func TestCardgroupUsecase_Create_IsAdminCancelled_IdentityPreserved(t *testing.T) {
+	t.Parallel()
+	repo := &mockCardgroupRepository{}
+	admin := &mockAdminChecker{err: context.Canceled}
+	uc := NewCardgroupUsecase(repo, admin, newTestLogger())
+
+	_, err := uc.Create(cgAuthedCtx("user-1"), CreateCardgroupInput{Name: "Group"})
+
+	if err == nil {
+		t.Fatal("expected context.Canceled, got nil")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected errors.Is(err, context.Canceled)=true, got %v (%T)", err, err)
+	}
+	// Identity preserved means the returned error IS context.Canceled, not an
+	// eris wrap around it.
+	if err != context.Canceled {
+		t.Fatalf("expected the unwrapped context.Canceled, got %v (%T)", err, err)
+	}
+	if repo.capturedCreate != nil {
+		t.Fatal("repository.Create must not be called when IsAdmin is cancelled")
+	}
+}
+
+// TestCardgroupUsecase_Create_LimitAndInvalidName_NameValidationFirst pins the
+// ordering: name validation runs BEFORE the limit check. With an invalid name
+// and a count that would otherwise trip the limit, the outcome carries
+// Validation (not LimitReached), and neither IsAdmin nor CountByOwner is
+// consulted.
+func TestCardgroupUsecase_Create_LimitAndInvalidName_NameValidationFirst(t *testing.T) {
+	t.Parallel()
+	repo := &mockCardgroupRepository{countResult: generalUserCardgroupLimit}
+	admin := &mockAdminChecker{isAdmin: false}
+	uc := NewCardgroupUsecase(repo, admin, newTestLogger())
+
+	outcome, err := uc.Create(cgAuthedCtx("user-1"), CreateCardgroupInput{Name: ""})
+
+	if err != nil {
+		t.Fatalf("expected nil error (validation goes to outcome), got: %v", err)
+	}
+	if outcome.Validation == nil {
+		t.Fatal("expected non-nil Validation when the name is invalid")
+	}
+	if outcome.Validation.Field != "name" {
+		t.Fatalf("expected Validation.Field=%q, got %q", "name", outcome.Validation.Field)
+	}
+	if outcome.LimitReached != nil {
+		t.Fatalf("expected nil LimitReached when name validation wins, got %+v", outcome.LimitReached)
+	}
+	if outcome.Cardgroup != nil {
+		t.Fatal("expected nil Cardgroup on validation failure")
+	}
+	if admin.calls != 0 {
+		t.Fatalf("expected IsAdmin NOT to be called when name validation fails first, got %d calls", admin.calls)
+	}
+	if len(repo.countCalls) != 0 {
+		t.Fatalf("expected CountByOwner NOT to be called when name validation fails first, got %d calls", len(repo.countCalls))
+	}
+	if repo.capturedCreate != nil {
+		t.Fatal("repository.Create must not be called on validation failure")
+	}
+}
+
 // --- Update tests ---
 
 func TestCardgroupUsecase_Update_Anonymous(t *testing.T) {
 	t.Parallel()
 	repo := &mockCardgroupRepository{}
-	uc := NewCardgroupUsecase(repo, newTestLogger())
+	uc := NewCardgroupUsecase(repo, cgDefaultAdmin(), newTestLogger())
 
 	_, err := uc.Update(anonCtx(), "cg1", UpdateCardgroupInput{Name: ptr("New")})
 
@@ -344,7 +571,7 @@ func TestCardgroupUsecase_Update_NonOwner_Unauthenticated(t *testing.T) {
 	t.Parallel()
 	cg := &domain.Cardgroup{ID: "cg1", OwnerID: "user-1", Name: "Original"}
 	repo := &mockCardgroupRepository{findResult: cg}
-	uc := NewCardgroupUsecase(repo, newTestLogger())
+	uc := NewCardgroupUsecase(repo, cgDefaultAdmin(), newTestLogger())
 
 	_, err := uc.Update(cgAuthedCtx("user-2"), "cg1", UpdateCardgroupInput{Name: ptr("Hacked")})
 
@@ -357,7 +584,7 @@ func TestCardgroupUsecase_Update_NonOwner_Unauthenticated(t *testing.T) {
 func TestCardgroupUsecase_Update_NotFound_Unauthenticated(t *testing.T) {
 	t.Parallel()
 	repo := &mockCardgroupRepository{findErr: repository.ErrNotFound}
-	uc := NewCardgroupUsecase(repo, newTestLogger())
+	uc := NewCardgroupUsecase(repo, cgDefaultAdmin(), newTestLogger())
 
 	_, err := uc.Update(cgAuthedCtx("user-1"), "cg-missing", UpdateCardgroupInput{Name: ptr("Anything")})
 
@@ -372,7 +599,7 @@ func TestCardgroupUsecase_Update_NameChange_Success(t *testing.T) {
 	existing := &domain.Cardgroup{ID: "cg1", OwnerID: "user-1", Name: "Old"}
 	updated := &domain.Cardgroup{ID: "cg1", OwnerID: "user-1", Name: "New"}
 	repo := &mockCardgroupRepository{findResult: existing, updateResult: updated}
-	uc := NewCardgroupUsecase(repo, newTestLogger())
+	uc := NewCardgroupUsecase(repo, cgDefaultAdmin(), newTestLogger())
 
 	outcome, err := uc.Update(cgAuthedCtx("user-1"), "cg1", UpdateCardgroupInput{Name: ptr("New")})
 
@@ -411,7 +638,7 @@ func TestCardgroupUsecase_Update_EmptyPatch_NoWrite(t *testing.T) {
 	t.Parallel()
 	existing := &domain.Cardgroup{ID: "cg1", OwnerID: "user-1", Name: "Original"}
 	repo := &mockCardgroupRepository{findResult: existing}
-	uc := NewCardgroupUsecase(repo, newTestLogger())
+	uc := NewCardgroupUsecase(repo, cgDefaultAdmin(), newTestLogger())
 
 	outcome, err := uc.Update(cgAuthedCtx("user-1"), "cg1", UpdateCardgroupInput{Name: nil})
 
@@ -433,7 +660,7 @@ func TestCardgroupUsecase_Update_EmptyName_ValidationVariant(t *testing.T) {
 	t.Parallel()
 	existing := &domain.Cardgroup{ID: "cg1", OwnerID: "user-1", Name: "Original"}
 	repo := &mockCardgroupRepository{findResult: existing}
-	uc := NewCardgroupUsecase(repo, newTestLogger())
+	uc := NewCardgroupUsecase(repo, cgDefaultAdmin(), newTestLogger())
 
 	outcome, err := uc.Update(cgAuthedCtx("user-1"), "cg1", UpdateCardgroupInput{Name: ptr("")})
 
@@ -458,7 +685,7 @@ func TestCardgroupUsecase_Update_TooLongName_ValidationVariant(t *testing.T) {
 	t.Parallel()
 	existing := &domain.Cardgroup{ID: "cg1", OwnerID: "user-1", Name: "Original"}
 	repo := &mockCardgroupRepository{findResult: existing}
-	uc := NewCardgroupUsecase(repo, newTestLogger())
+	uc := NewCardgroupUsecase(repo, cgDefaultAdmin(), newTestLogger())
 
 	outcome, err := uc.Update(cgAuthedCtx("user-1"), "cg1", UpdateCardgroupInput{Name: ptr(strings.Repeat("a", 101))})
 
@@ -486,7 +713,7 @@ func TestCardgroupUsecase_Update_RepoError_InfraChannel(t *testing.T) {
 		findResult: existing,
 		updateErr:  errors.New("db: connection lost"),
 	}
-	uc := NewCardgroupUsecase(repo, newTestLogger())
+	uc := NewCardgroupUsecase(repo, cgDefaultAdmin(), newTestLogger())
 
 	_, err := uc.Update(cgAuthedCtx("user-1"), "cg1", UpdateCardgroupInput{Name: ptr("New")})
 
@@ -501,7 +728,7 @@ func TestCardgroupUsecase_Update_RepoError_InfraChannel(t *testing.T) {
 func TestCardgroupUsecase_Delete_Anonymous(t *testing.T) {
 	t.Parallel()
 	repo := &mockCardgroupRepository{}
-	uc := NewCardgroupUsecase(repo, newTestLogger())
+	uc := NewCardgroupUsecase(repo, cgDefaultAdmin(), newTestLogger())
 
 	err := uc.Delete(anonCtx(), "cg1")
 
@@ -515,7 +742,7 @@ func TestCardgroupUsecase_Delete_NonOwner_Unauthenticated(t *testing.T) {
 	t.Parallel()
 	cg := &domain.Cardgroup{ID: "cg1", OwnerID: "user-1", Name: "Mine"}
 	repo := &mockCardgroupRepository{findResult: cg}
-	uc := NewCardgroupUsecase(repo, newTestLogger())
+	uc := NewCardgroupUsecase(repo, cgDefaultAdmin(), newTestLogger())
 
 	err := uc.Delete(cgAuthedCtx("user-2"), "cg1")
 
@@ -531,7 +758,7 @@ func TestCardgroupUsecase_Delete_NonOwner_Unauthenticated(t *testing.T) {
 func TestCardgroupUsecase_Delete_NotFound_Unauthenticated(t *testing.T) {
 	t.Parallel()
 	repo := &mockCardgroupRepository{findErr: repository.ErrNotFound}
-	uc := NewCardgroupUsecase(repo, newTestLogger())
+	uc := NewCardgroupUsecase(repo, cgDefaultAdmin(), newTestLogger())
 
 	err := uc.Delete(cgAuthedCtx("user-1"), "cg-missing")
 
@@ -545,7 +772,7 @@ func TestCardgroupUsecase_Delete_Success(t *testing.T) {
 	t.Parallel()
 	cg := &domain.Cardgroup{ID: "cg1", OwnerID: "user-1", Name: "Mine"}
 	repo := &mockCardgroupRepository{findResult: cg}
-	uc := NewCardgroupUsecase(repo, newTestLogger())
+	uc := NewCardgroupUsecase(repo, cgDefaultAdmin(), newTestLogger())
 
 	err := uc.Delete(cgAuthedCtx("user-1"), "cg1")
 
@@ -566,7 +793,7 @@ func TestCardgroupUsecase_Delete_Success(t *testing.T) {
 func TestCardgroupUC_ConnectionGuards_AfterAndBefore(t *testing.T) {
 	t.Parallel()
 	repo := &mockCardgroupRepository{}
-	uc := NewCardgroupUsecase(repo, newTestLogger())
+	uc := NewCardgroupUsecase(repo, cgDefaultAdmin(), newTestLogger())
 
 	after := "cursor-a"
 	before := "cursor-b"
@@ -583,7 +810,7 @@ func TestCardgroupUC_ConnectionGuards_AfterAndBefore(t *testing.T) {
 func TestCardgroupUC_ConnectionGuards_FirstAndBefore(t *testing.T) {
 	t.Parallel()
 	repo := &mockCardgroupRepository{}
-	uc := NewCardgroupUsecase(repo, newTestLogger())
+	uc := NewCardgroupUsecase(repo, cgDefaultAdmin(), newTestLogger())
 
 	first := 5
 	before := "cursor-b"
@@ -600,7 +827,7 @@ func TestCardgroupUC_ConnectionGuards_FirstAndBefore(t *testing.T) {
 func TestCardgroupUC_ConnectionGuards_LastAndAfter(t *testing.T) {
 	t.Parallel()
 	repo := &mockCardgroupRepository{}
-	uc := NewCardgroupUsecase(repo, newTestLogger())
+	uc := NewCardgroupUsecase(repo, cgDefaultAdmin(), newTestLogger())
 
 	last := 5
 	after := "cursor-a"
@@ -617,7 +844,7 @@ func TestCardgroupUC_ConnectionGuards_LastAndAfter(t *testing.T) {
 func TestCardgroupUC_ConnectionGuards_BeforeAlone(t *testing.T) {
 	t.Parallel()
 	repo := &mockCardgroupRepository{}
-	uc := NewCardgroupUsecase(repo, newTestLogger())
+	uc := NewCardgroupUsecase(repo, cgDefaultAdmin(), newTestLogger())
 
 	before := "cursor-b"
 	_, err := uc.ListCardgroupsByOwnerConnection(cgAuthedCtx("user-1"), CardgroupConnectionInput{
@@ -632,7 +859,7 @@ func TestCardgroupUC_ConnectionGuards_BeforeAlone(t *testing.T) {
 func TestCardgroupUC_ConnectionGuards_AfterAlone(t *testing.T) {
 	t.Parallel()
 	repo := &mockCardgroupRepository{}
-	uc := NewCardgroupUsecase(repo, newTestLogger())
+	uc := NewCardgroupUsecase(repo, cgDefaultAdmin(), newTestLogger())
 
 	after := "cursor-a"
 	_, err := uc.ListCardgroupsByOwnerConnection(cgAuthedCtx("user-1"), CardgroupConnectionInput{
@@ -655,7 +882,7 @@ func TestCardgroupUC_Connection_CursorFromOtherOwner_BadUserInput(t *testing.T) 
 	// The cursor ID maps to a cardgroup owned by owner-A, not owner-B.
 	foreignCG := &domain.Cardgroup{ID: "cg-owner-a", OwnerID: "owner-a", Name: "Foreign"}
 	repo := &mockCardgroupRepository{findResult: foreignCG}
-	uc := NewCardgroupUsecase(repo, newTestLogger())
+	uc := NewCardgroupUsecase(repo, cgDefaultAdmin(), newTestLogger())
 
 	first := 5
 	after := "cg-owner-a"
@@ -688,7 +915,7 @@ func TestCardgroupUC_Connection_FirstPage(t *testing.T) {
 		findPageResult: cgs,
 		countResult:    3,
 	}
-	uc := NewCardgroupUsecase(repo, newTestLogger())
+	uc := NewCardgroupUsecase(repo, cgDefaultAdmin(), newTestLogger())
 
 	first := 2
 	out, err := uc.ListCardgroupsByOwnerConnection(cgAuthedCtx("user-1"), CardgroupConnectionInput{
@@ -731,7 +958,7 @@ func TestCardgroupUC_Connection_Search(t *testing.T) {
 		findPageResult: matched,
 		countResult:    1,
 	}
-	uc := NewCardgroupUsecase(repo, newTestLogger())
+	uc := NewCardgroupUsecase(repo, cgDefaultAdmin(), newTestLogger())
 
 	first := 10
 	search := "app"
@@ -763,7 +990,7 @@ func TestCardgroupUC_Connection_Search(t *testing.T) {
 func TestCardgroupUC_Connection_Anonymous(t *testing.T) {
 	t.Parallel()
 	repo := &mockCardgroupRepository{}
-	uc := NewCardgroupUsecase(repo, newTestLogger())
+	uc := NewCardgroupUsecase(repo, cgDefaultAdmin(), newTestLogger())
 
 	first := 10
 	_, err := uc.ListCardgroupsByOwnerConnection(anonCtx(), CardgroupConnectionInput{First: &first})
@@ -779,7 +1006,7 @@ func TestCardgroupUC_Connection_Anonymous(t *testing.T) {
 func TestCardgroupUC_ConnectionGuards_FirstAndLast(t *testing.T) {
 	t.Parallel()
 	repo := &mockCardgroupRepository{}
-	uc := NewCardgroupUsecase(repo, newTestLogger())
+	uc := NewCardgroupUsecase(repo, cgDefaultAdmin(), newTestLogger())
 
 	first, last := 5, 5
 	_, err := uc.ListCardgroupsByOwnerConnection(cgAuthedCtx("u1"), CardgroupConnectionInput{
@@ -802,7 +1029,7 @@ func TestCardgroupUC_Connection_FirstPage_AssertFirstPlusOne(t *testing.T) {
 		{ID: "cg3", OwnerID: "u1", Name: "C"},
 	}
 	repo := &mockCardgroupRepository{findPageResult: cgs, countResult: 3}
-	uc := NewCardgroupUsecase(repo, newTestLogger())
+	uc := NewCardgroupUsecase(repo, cgDefaultAdmin(), newTestLogger())
 
 	first := 2
 	_, err := uc.ListCardgroupsByOwnerConnection(cgAuthedCtx("u1"), CardgroupConnectionInput{
@@ -843,7 +1070,7 @@ func TestCardgroupUC_Connection_BackwardPagination_HappyPath(t *testing.T) {
 		countResult:    10,
 		findResult:     cursorCG, // hydrate the before cursor
 	}
-	uc := NewCardgroupUsecase(repo, newTestLogger())
+	uc := NewCardgroupUsecase(repo, cgDefaultAdmin(), newTestLogger())
 
 	last := 2
 	before := "cg-cursor"
@@ -887,7 +1114,7 @@ func TestCardgroupUC_Connection_OrderBy_Name_Asc(t *testing.T) {
 		findPageResult: []*domain.Cardgroup{},
 		countResult:    0,
 	}
-	uc := NewCardgroupUsecase(repo, newTestLogger())
+	uc := NewCardgroupUsecase(repo, cgDefaultAdmin(), newTestLogger())
 
 	first := 5
 	ob := CardgroupOrderByName
@@ -920,7 +1147,7 @@ func TestCardgroupUC_Connection_OrderBy_CreatedAt_Desc(t *testing.T) {
 		findPageResult: []*domain.Cardgroup{},
 		countResult:    0,
 	}
-	uc := NewCardgroupUsecase(repo, newTestLogger())
+	uc := NewCardgroupUsecase(repo, cgDefaultAdmin(), newTestLogger())
 
 	first := 5
 	ob := CardgroupOrderByCreatedAt
@@ -950,7 +1177,7 @@ func TestCardgroupUC_Connection_OrderBy_ID_Asc(t *testing.T) {
 		findPageResult: []*domain.Cardgroup{},
 		countResult:    0,
 	}
-	uc := NewCardgroupUsecase(repo, newTestLogger())
+	uc := NewCardgroupUsecase(repo, cgDefaultAdmin(), newTestLogger())
 
 	first := 5
 	ob := CardgroupOrderByID
@@ -977,7 +1204,7 @@ func TestCardgroupUC_Connection_DefaultOrderBy_WhenNil(t *testing.T) {
 		findPageResult: []*domain.Cardgroup{},
 		countResult:    0,
 	}
-	uc := NewCardgroupUsecase(repo, newTestLogger())
+	uc := NewCardgroupUsecase(repo, cgDefaultAdmin(), newTestLogger())
 
 	first := 5
 	_, err := uc.ListCardgroupsByOwnerConnection(cgAuthedCtx("u1"), CardgroupConnectionInput{
@@ -1004,7 +1231,7 @@ func TestCardgroupUC_Connection_DefaultPageSize_WhenAllNil(t *testing.T) {
 		findPageResult: []*domain.Cardgroup{},
 		countResult:    0,
 	}
-	uc := NewCardgroupUsecase(repo, newTestLogger())
+	uc := NewCardgroupUsecase(repo, cgDefaultAdmin(), newTestLogger())
 
 	_, err := uc.ListCardgroupsByOwnerConnection(cgAuthedCtx("u1"), CardgroupConnectionInput{})
 	if err != nil {
@@ -1026,7 +1253,7 @@ func TestCardgroupUC_Connection_PageSize_Clamp(t *testing.T) {
 		findPageResult: []*domain.Cardgroup{},
 		countResult:    0,
 	}
-	uc := NewCardgroupUsecase(repo, newTestLogger())
+	uc := NewCardgroupUsecase(repo, cgDefaultAdmin(), newTestLogger())
 
 	first := 200 // above cardgroupMaxPageSize=100
 	_, err := uc.ListCardgroupsByOwnerConnection(cgAuthedCtx("u1"), CardgroupConnectionInput{
@@ -1052,7 +1279,7 @@ func TestCardgroupUC_Connection_PageSize_NegativeFirst(t *testing.T) {
 		findPageResult: []*domain.Cardgroup{},
 		countResult:    0,
 	}
-	uc := NewCardgroupUsecase(repo, newTestLogger())
+	uc := NewCardgroupUsecase(repo, cgDefaultAdmin(), newTestLogger())
 
 	first := -5
 	_, err := uc.ListCardgroupsByOwnerConnection(cgAuthedCtx("u1"), CardgroupConnectionInput{
@@ -1078,7 +1305,7 @@ func TestCardgroupUC_Connection_CursorHydration_Name(t *testing.T) {
 		findPageResult: []*domain.Cardgroup{},
 		countResult:    0,
 	}
-	uc := NewCardgroupUsecase(repo, newTestLogger())
+	uc := NewCardgroupUsecase(repo, cgDefaultAdmin(), newTestLogger())
 
 	first := 5
 	after := "cg-cursor"
@@ -1115,7 +1342,7 @@ func TestCardgroupUC_Connection_CursorHydration_CreatedAt(t *testing.T) {
 		findPageResult: []*domain.Cardgroup{},
 		countResult:    0,
 	}
-	uc := NewCardgroupUsecase(repo, newTestLogger())
+	uc := NewCardgroupUsecase(repo, cgDefaultAdmin(), newTestLogger())
 
 	first := 5
 	after := "cg-cursor"
@@ -1149,7 +1376,7 @@ func TestCardgroupUC_Connection_CursorHydration_UpdatedAt(t *testing.T) {
 		findPageResult: []*domain.Cardgroup{},
 		countResult:    0,
 	}
-	uc := NewCardgroupUsecase(repo, newTestLogger())
+	uc := NewCardgroupUsecase(repo, cgDefaultAdmin(), newTestLogger())
 
 	first := 5
 	after := "cg-cursor"
@@ -1181,7 +1408,7 @@ func TestCardgroupUC_Connection_CursorHydration_OrderByID(t *testing.T) {
 		findPageResult: []*domain.Cardgroup{},
 		countResult:    0,
 	}
-	uc := NewCardgroupUsecase(repo, newTestLogger())
+	uc := NewCardgroupUsecase(repo, cgDefaultAdmin(), newTestLogger())
 
 	first := 5
 	after := "cg-cursor"
@@ -1214,7 +1441,7 @@ func TestCardgroupUC_Connection_CursorHydration_OrderByID_NotFound(t *testing.T)
 	t.Parallel()
 
 	repo := &mockCardgroupRepository{findErr: repository.ErrNotFound}
-	uc := NewCardgroupUsecase(repo, newTestLogger())
+	uc := NewCardgroupUsecase(repo, cgDefaultAdmin(), newTestLogger())
 
 	first := 5
 	after := "cg-missing"
@@ -1234,7 +1461,7 @@ func TestCardgroupUC_Connection_CursorHydration_OrderByID_RepoError(t *testing.T
 	t.Parallel()
 
 	repo := &mockCardgroupRepository{findErr: errors.New("db died")}
-	uc := NewCardgroupUsecase(repo, newTestLogger())
+	uc := NewCardgroupUsecase(repo, cgDefaultAdmin(), newTestLogger())
 
 	first := 5
 	after := "cg-x"
@@ -1256,7 +1483,7 @@ func TestCardgroupUC_Connection_CursorHydration_OrderByID_OtherOwner(t *testing.
 
 	foreignCG := &domain.Cardgroup{ID: "cg-x", OwnerID: "owner-a", Name: "Foreign"}
 	repo := &mockCardgroupRepository{findResult: foreignCG}
-	uc := NewCardgroupUsecase(repo, newTestLogger())
+	uc := NewCardgroupUsecase(repo, cgDefaultAdmin(), newTestLogger())
 
 	first := 5
 	after := "cg-x"
@@ -1275,7 +1502,7 @@ func TestCardgroupUC_Connection_CursorHydration_NotFound_BadUserInput(t *testing
 	t.Parallel()
 
 	repo := &mockCardgroupRepository{findErr: repository.ErrNotFound}
-	uc := NewCardgroupUsecase(repo, newTestLogger())
+	uc := NewCardgroupUsecase(repo, cgDefaultAdmin(), newTestLogger())
 
 	first := 5
 	after := "cg-missing"
@@ -1292,7 +1519,7 @@ func TestCardgroupUC_Connection_CursorHydration_RepoError_Internal(t *testing.T)
 	t.Parallel()
 
 	repo := &mockCardgroupRepository{findErr: errors.New("db dead")}
-	uc := NewCardgroupUsecase(repo, newTestLogger())
+	uc := NewCardgroupUsecase(repo, cgDefaultAdmin(), newTestLogger())
 
 	first := 5
 	after := "cg-cursor"
@@ -1312,7 +1539,7 @@ func TestCardgroupUC_Connection_FindPageRepoError_Internal(t *testing.T) {
 		countResult: 5,
 		findPageErr: errors.New("db dead"),
 	}
-	uc := NewCardgroupUsecase(repo, newTestLogger())
+	uc := NewCardgroupUsecase(repo, cgDefaultAdmin(), newTestLogger())
 
 	first := 5
 	_, err := uc.ListCardgroupsByOwnerConnection(cgAuthedCtx("u1"), CardgroupConnectionInput{
@@ -1327,7 +1554,7 @@ func TestCardgroupUC_Connection_CountError_Internal(t *testing.T) {
 	t.Parallel()
 
 	repo := &mockCardgroupRepository{countErr: errors.New("count dead")}
-	uc := NewCardgroupUsecase(repo, newTestLogger())
+	uc := NewCardgroupUsecase(repo, cgDefaultAdmin(), newTestLogger())
 
 	first := 5
 	_, err := uc.ListCardgroupsByOwnerConnection(cgAuthedCtx("u1"), CardgroupConnectionInput{
@@ -1404,7 +1631,7 @@ func TestResolveCardgroupPageSize_LastNegativeClampedToZero(t *testing.T) {
 func TestResolveCardgroupCursor_NilCursor(t *testing.T) {
 	t.Parallel()
 	repo := &mockCardgroupRepository{}
-	uc := NewCardgroupUsecase(repo, newTestLogger())
+	uc := NewCardgroupUsecase(repo, cgDefaultAdmin(), newTestLogger())
 
 	c, err := uc.(*cardgroupUsecase).resolveCardgroupCursor(
 		context.Background(),
@@ -1437,7 +1664,7 @@ func TestResolveCardgroupCursor_OtherOwner_NonIDOrderBy(t *testing.T) {
 
 	foreignCG := &domain.Cardgroup{ID: "cg-x", OwnerID: "owner-a", Name: "Foreign"}
 	repo := &mockCardgroupRepository{findResult: foreignCG}
-	uc := NewCardgroupUsecase(repo, newTestLogger())
+	uc := NewCardgroupUsecase(repo, cgDefaultAdmin(), newTestLogger())
 
 	id := "cg-x"
 	_, err := uc.(*cardgroupUsecase).resolveCardgroupCursor(
@@ -1456,7 +1683,7 @@ func TestResolveCardgroupCursor_UnknownOrderBy(t *testing.T) {
 
 	cg := &domain.Cardgroup{ID: "cg-cursor", OwnerID: "u1", Name: "X"}
 	repo := &mockCardgroupRepository{findResult: cg}
-	uc := NewCardgroupUsecase(repo, newTestLogger())
+	uc := NewCardgroupUsecase(repo, cgDefaultAdmin(), newTestLogger())
 
 	id := "cg-cursor"
 	_, err := uc.(*cardgroupUsecase).resolveCardgroupCursor(
@@ -1483,7 +1710,7 @@ func TestResolveCardgroupCursor_MalformedV1_ReturnsBadUserInput(t *testing.T) {
 	t.Parallel()
 
 	repo := &mockCardgroupRepository{}
-	uc := NewCardgroupUsecase(repo, newTestLogger())
+	uc := NewCardgroupUsecase(repo, cgDefaultAdmin(), newTestLogger())
 
 	malformed := "v1:!!!not-base64!!!"
 	_, err := uc.(*cardgroupUsecase).resolveCardgroupCursor(
@@ -1500,7 +1727,7 @@ func TestResolveCardgroupCursor_V1EncodedID(t *testing.T) {
 
 	cg := &domain.Cardgroup{ID: "cg-cursor", OwnerID: "u1", Name: "X"}
 	repo := &mockCardgroupRepository{findResult: cg}
-	uc := NewCardgroupUsecase(repo, newTestLogger())
+	uc := NewCardgroupUsecase(repo, cgDefaultAdmin(), newTestLogger())
 
 	// Encode the raw ID into the v1 envelope the way the resolver would.
 	encoded := "v1:Y2ctY3Vyc29y" // base64.RawURLEncoding.EncodeToString([]byte("cg-cursor"))
@@ -1516,5 +1743,163 @@ func TestResolveCardgroupCursor_V1EncodedID(t *testing.T) {
 	}
 	if c.ID != "cg-cursor" {
 		t.Fatalf("expected decoded ID=cg-cursor, got %q", c.ID)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// checkCardgroupLimit — direct unit tests for the shared limit helper.
+// ---------------------------------------------------------------------------
+
+// stubCardgroupCounter is a minimal cardgroupOwnerCounter for the direct
+// checkCardgroupLimit tests. calls tracks invocations so admin-exempt and
+// name-validation-first paths can assert the counter is never reached.
+type stubCardgroupCounter struct {
+	count int64
+	err   error
+	calls int
+}
+
+func (s *stubCardgroupCounter) CountByOwner(_ context.Context, _ string, _ *string) (int64, error) {
+	s.calls++
+	return s.count, s.err
+}
+
+// stubLimitAdminChecker is a minimal AdminChecker for the direct
+// checkCardgroupLimit tests.
+type stubLimitAdminChecker struct {
+	isAdmin bool
+	err     error
+	calls   int
+}
+
+func (s *stubLimitAdminChecker) IsAdmin(_ context.Context, _ string) (bool, error) {
+	s.calls++
+	return s.isAdmin, s.err
+}
+
+// TestCheckCardgroupLimit_Admin_Exempt verifies that an admin owner is exempt:
+// the helper returns (nil, nil) and the counter is never consulted.
+func TestCheckCardgroupLimit_Admin_Exempt(t *testing.T) {
+	t.Parallel()
+	counter := &stubCardgroupCounter{count: generalUserCardgroupLimit}
+	admin := &stubLimitAdminChecker{isAdmin: true}
+
+	info, err := checkCardgroupLimit(context.Background(), counter, admin, "admin-1")
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if info != nil {
+		t.Fatalf("expected nil LimitInfo for admin, got %+v", info)
+	}
+	if counter.calls != 0 {
+		t.Fatalf("expected counter NOT to be called for admin, got %d calls", counter.calls)
+	}
+}
+
+// TestCheckCardgroupLimit_UnderLimit verifies that a non-admin owner below the
+// limit returns (nil, nil) — no limit info, no error.
+func TestCheckCardgroupLimit_UnderLimit(t *testing.T) {
+	t.Parallel()
+	counter := &stubCardgroupCounter{count: generalUserCardgroupLimit - 1}
+	admin := &stubLimitAdminChecker{isAdmin: false}
+
+	info, err := checkCardgroupLimit(context.Background(), counter, admin, "user-1")
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if info != nil {
+		t.Fatalf("expected nil LimitInfo below the limit, got %+v", info)
+	}
+	if counter.calls != 1 {
+		t.Fatalf("expected counter to be called once, got %d", counter.calls)
+	}
+}
+
+// TestCheckCardgroupLimit_AtOrOverLimit verifies that a non-admin owner at or
+// above the limit returns a non-nil CardgroupLimitInfo with the cap and the
+// owner's real count.
+func TestCheckCardgroupLimit_AtOrOverLimit(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name        string
+		count       int64
+		wantCurrent int
+	}{
+		{name: "at limit", count: generalUserCardgroupLimit, wantCurrent: generalUserCardgroupLimit},
+		{name: "over limit", count: generalUserCardgroupLimit + 3, wantCurrent: generalUserCardgroupLimit + 3},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			counter := &stubCardgroupCounter{count: tc.count}
+			admin := &stubLimitAdminChecker{isAdmin: false}
+
+			info, err := checkCardgroupLimit(context.Background(), counter, admin, "user-1")
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if info == nil {
+				t.Fatal("expected non-nil LimitInfo at/over the limit")
+			}
+			if info.Limit != generalUserCardgroupLimit {
+				t.Fatalf("expected Limit=%d, got %d", generalUserCardgroupLimit, info.Limit)
+			}
+			if info.Current != tc.wantCurrent {
+				t.Fatalf("expected Current=%d, got %d", tc.wantCurrent, info.Current)
+			}
+		})
+	}
+}
+
+// TestCheckCardgroupLimit_IsAdminError_Wrapped verifies that a non-context
+// IsAdmin error is wrapped with the "usecase: cardgroup: check admin" prefix
+// and the counter is never consulted.
+func TestCheckCardgroupLimit_IsAdminError_Wrapped(t *testing.T) {
+	t.Parallel()
+	counter := &stubCardgroupCounter{count: 0}
+	admin := &stubLimitAdminChecker{err: errors.New("auth: lookup failed")}
+
+	_, err := checkCardgroupLimit(context.Background(), counter, admin, "user-1")
+
+	assertInternalChain(t, err, "usecase: cardgroup: check admin")
+	if counter.calls != 0 {
+		t.Fatalf("expected counter NOT to be called when IsAdmin fails, got %d calls", counter.calls)
+	}
+}
+
+// TestCheckCardgroupLimit_CountError_Wrapped verifies that a non-context
+// CountByOwner error is wrapped with the "usecase: cardgroup: count by owner"
+// prefix.
+func TestCheckCardgroupLimit_CountError_Wrapped(t *testing.T) {
+	t.Parallel()
+	counter := &stubCardgroupCounter{err: errors.New("db: count failed")}
+	admin := &stubLimitAdminChecker{isAdmin: false}
+
+	_, err := checkCardgroupLimit(context.Background(), counter, admin, "user-1")
+
+	assertInternalChain(t, err, "usecase: cardgroup: count by owner")
+}
+
+// TestCheckCardgroupLimit_IsAdminCancelled_IdentityPreserved verifies that a
+// context.Canceled from IsAdmin passes through unwrapped (errors.Is matches and
+// the returned error IS context.Canceled), and the counter is never consulted.
+func TestCheckCardgroupLimit_IsAdminCancelled_IdentityPreserved(t *testing.T) {
+	t.Parallel()
+	counter := &stubCardgroupCounter{count: 0}
+	admin := &stubLimitAdminChecker{err: context.Canceled}
+
+	_, err := checkCardgroupLimit(context.Background(), counter, admin, "user-1")
+
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected errors.Is(err, context.Canceled)=true, got %v (%T)", err, err)
+	}
+	if err != context.Canceled {
+		t.Fatalf("expected the unwrapped context.Canceled, got %v (%T)", err, err)
+	}
+	if counter.calls != 0 {
+		t.Fatalf("expected counter NOT to be called when IsAdmin is cancelled, got %d calls", counter.calls)
 	}
 }

--- a/docs/backend-graphql.md
+++ b/docs/backend-graphql.md
@@ -205,6 +205,8 @@ The `auth` package exposes two distinct types with different lifetimes and data 
 | `AuthUser` (`auth/user.go`) | Request-scoped | JWT claims (Supabase) | Who is the caller? |
 | `auth.Service` (`auth/role.go`) | Boot-scoped | DB-backed (`UserRoleRepository`) | What can the caller do? |
 
+`AuthUser.Role` carries the Supabase/Postgres database role (`authenticated`, `anon`, or `service_role`) — it is NOT the application-level `admin`/`general` role; the application role lives in `public.user_roles` and is determined by `auth.Service.IsAdmin`, which performs a membership check against `domain.AdminRoleName`.
+
 The split is deliberate: the JWT does not carry roles in this project, so every role check goes through the DB. `auth.Service` is constructed once at boot in `run()` against the `UserRoleRepository` and injected into resolvers/usecases that need to gate on role membership.
 
 `auth.Service.IsAdmin(ctx, userID)` hardcodes the literal `"admin"` role name in the method body — callers cannot pass a role string. This prevents drift to bespoke role names; add a new dedicated method (e.g. `IsModerator`) when a second role is needed rather than parameterising `IsAdmin`. The same `"admin"` literal is exposed to the role-CRUD usecase as `domain.AdminRoleName` (see `internal/domain/role.go`) so the system-role rename / delete guards stay in lockstep with the auth-side check; both move together when a second privileged role is introduced.
@@ -213,7 +215,7 @@ The DB side of the same check is `private.is_admin(uid uuid) RETURNS boolean`, c
 
 ### Admin usecase split: one auth gate, separate business surfaces
 
-`AdminUserUsecase` and `AdminRoleUsecase` share the same `AdminGate.Require` shape (UNAUTHENTICATED → CANCELLED → INTERNAL → FORBIDDEN classification) but hold no business state in common. They live as two structs in `internal/usecase/` and are wired into separate fields on `Resolver`. Two consequences:
+`AdminUserUsecase` and `AdminRoleUsecase` share the same `AdminGate.Require` shape (UNAUTHENTICATED → CANCELLED → INTERNAL → FORBIDDEN classification) but hold no business state in common. They live as two structs in `internal/usecase/` and are wired into separate fields on `Resolver`. There are two distinct admin patterns: `AdminGate.Require` for admin-required gates (non-admin → FORBIDDEN), and injecting an `AdminChecker` bool for admin-exempt business rules where admins bypass a restriction such as the per-user cardgroup cap — see [inject AdminChecker for admin-exempt business rules](backend/library-gotchas/admin-checker-inject-for-admin-exempt-business-logic.md). Two consequences:
 
 - **Query.roles routes through `AdminRoleUC.List`, not `AdminUserUC.ListRoles`.** A `ListRoles` method on the user usecase that ultimately delegates to the role repository duplicates the auth gate and creates a "two truths" problem when the gate evolves. After `AdminRoleUC` exists, the role-list field belongs there; the duplicate method on `AdminUserUC` must be removed in the same change rather than left as dead code.
 - **The narrow consumer interface lists only what the usecase calls.** `adminRoleRepoForCRUD` (in `admin_role.go`) lists `FindByID`, `Create`, `Update`, `Delete`, `ListAll` — five methods. It must not list `AssignToUser` / `RevokeFromUser` even though the concrete `RoleRepository` has them, because the AdminRole CRUD usecase never calls those methods. Adding them forces every test stub to implement assignment plumbing it never exercises and obscures which surface each usecase actually depends on. The pattern is the same one documented in `docs/backend.md` § "Consumer-defined narrow interfaces…", applied per-usecase rather than per-repository.
@@ -233,7 +235,7 @@ Reading the input name instead would force the guard to also know that admin exi
 
 ### Sentinel errors and domain validation
 
-`domain.ParseCardgroupName` returns typed sentinels (`ErrCardgroupNameRequired`, `ErrCardgroupNameTooLong`). The usecase translates them via a dedicated helper (`translateCardgroupNameErr`) to `gqlerr.BadUserInput`. The validation rule itself lives only in the domain's `ParseCardgroupName` constructor; the usecase holds only the domain→GraphQL mapping. Apply this pattern to every new aggregate.
+`domain.ParseCardgroupName` returns typed sentinels (`ErrCardgroupNameRequired`, `ErrCardgroupNameTooLong`). The usecase translates them via a dedicated helper (`translateCardgroupNameErr`) to `gqlerr.BadUserInput`. The validation rule itself lives only in the domain's `ParseCardgroupName` constructor; the usecase holds only the domain→GraphQL mapping. Apply this pattern to every new aggregate. `createCardgroup` returns the `CreateCardgroupResult` union with three variants: `CreateCardgroupSuccess`, `InputValidationError`, and `CardgroupLimitReachedError` (the per-user cap rejection, delivered as errors-as-data rather than a wire error).
 
 ### Validation rules in `usecase.UpdateUser`
 

--- a/docs/backend/error-wrapping/pin-unwrapped-context-error-with-identity-check.md
+++ b/docs/backend/error-wrapping/pin-unwrapped-context-error-with-identity-check.md
@@ -146,3 +146,27 @@ passes even when the inner wrap snuck in. The dual-assertion pattern from
 [The dual assertion](#the-dual-assertion) above applies inside the tx-callback
 too — each sub-op branch that can carry a context error needs its own
 identity pin, not a chain-shape pin shared with the others.
+
+## Multi-call free-function helpers: guard every branch, not just the first
+
+The same per-branch discipline applies outside a tx callback. A free-function
+helper that makes two or more sequential infrastructure calls must place
+`if isContextDone(err) { return nil, err }` on **each** call's error branch
+before the `eris.Wrap`. Guarding only the first call while wrapping the second
+silently double-wraps a `context.Canceled` / `context.DeadlineExceeded` from
+the second call, breaking the bare-identity contract for that path even though
+the chain still satisfies `errors.Is`.
+
+Worked example: `checkCardgroupLimit` (`backend/internal/usecase/cardgroup.go`)
+calls `admin.IsAdmin` then `counter.CountByOwner`. Both error branches guard
+context errors via `isContextDone`. An asymmetric version that guarded only the
+`IsAdmin` branch shipped briefly and was caught in review — the
+`CountByOwner`-cancelled path returned a wrapped error that failed an
+`err == context.Canceled` identity check at the caller. The fix mirrored the
+guard onto the second branch.
+
+Pin the contract with identity tests on each branch:
+`TestCheckCardgroupLimit_CountCancelled_IdentityPreserved` and
+`_CountDeadlineExceeded_IdentityPreserved` assert `err == context.Canceled` /
+`context.DeadlineExceeded` (bare identity) for the count path, complementing
+the `IsAdmin`-branch tests.

--- a/docs/backend/library-gotchas/admin-checker-inject-for-admin-exempt-business-logic.md
+++ b/docs/backend/library-gotchas/admin-checker-inject-for-admin-exempt-business-logic.md
@@ -1,0 +1,137 @@
+# Inject `AdminChecker` (bool) for admin-exempt business rules, not `AdminGate.Require`
+
+> Part of the [Go library gotchas](../../../.claude/rules/go-library-gotchas.md) rules.
+
+The backend has two distinct patterns for involving admin status in a usecase. Choosing
+the wrong one produces either an overly restrictive gate or a missed exemption.
+
+## The critical distinction: JWT database role vs. application role
+
+`auth.AuthUser.Role` carries the **Supabase/Postgres database role** set in the JWT
+(`authenticated`, `anon`, `service_role`). It is NOT the application-level
+`admin` / `general` role stored in `public.user_roles`. The application role is
+determined by `auth.Service.IsAdmin(ctx, userID)`, which performs a database membership
+check against `domain.AdminRoleName`. Reading `AuthUser.Role` to decide whether the
+caller is an admin silently compares two unrelated concepts and always returns false
+for admin users.
+
+## The two patterns and when to use each
+
+### Admin-required gate: `AdminGate.Require`
+
+Use this when **only admins may call the operation at all** (typically admin mutations).
+`AdminGate.Require` confirms the bearer is an admin and returns their user ID; a
+non-admin receives `ForbiddenError("admin only")` and the operation is not attempted.
+See [`error-classifier-helper-pass-through-with-caller-prefix.md`](../error-wrapping/error-classifier-helper-pass-through-with-caller-prefix.md)
+for the wrap convention.
+
+### Admin-exempt rule: inject `AdminChecker` directly
+
+Use this when **everyone may call the operation, but admins bypass a restriction**.
+Inject the `AdminChecker` interface as a usecase struct field and branch on `IsAdmin`
+inside the business-logic path. `*auth.Service` satisfies `AdminChecker` in production;
+tests substitute a stub. The constructor panics when the injected checker is nil —
+required dependencies are enforced at construction time, not per-call.
+
+```go
+// AdminChecker is the surface both AdminGate and direct admin-exempt callers use.
+// Declared in usecase/admin_gate.go; *auth.Service satisfies it.
+type AdminChecker interface {
+    IsAdmin(ctx context.Context, userID string) (bool, error)
+}
+```
+
+`userUsecase` already follows this pattern: it holds an `auth AdminChecker` field
+and calls `IsAdmin` to conditionally skip operations that only apply to non-admins.
+`cardgroupUsecase` uses the same pattern for the per-user cardgroup creation cap.
+
+## Worked example: per-user cardgroup creation cap
+
+`const generalUserCardgroupLimit = 5` (package-private in `backend/internal/usecase/`)
+caps the number of cardgroups a non-admin owner may create. Admins are exempt.
+
+`cardgroupUsecase` holds an `admin AdminChecker` field. Its constructor panics when
+the checker is nil:
+
+```go
+type cardgroupUsecase struct {
+    repo   CardgroupRepository
+    admin  AdminChecker
+    logger *slog.Logger
+}
+
+func NewCardgroupUsecase(repo CardgroupRepository, admin AdminChecker, logger *slog.Logger) CardgroupUsecase {
+    if admin == nil {
+        panic("usecase: cardgroup: admin checker is required")
+    }
+    // ...
+}
+```
+
+The limit check lives in the free function `checkCardgroupLimit`. It calls `IsAdmin`
+first; admins return `(nil, nil)` immediately without a count query. For non-admins
+it counts via the narrow `cardgroupOwnerCounter` interface and returns a non-nil
+`*CardgroupLimitInfo` when `count >= generalUserCardgroupLimit`:
+
+```go
+// cardgroupOwnerCounter is the narrow surface checkCardgroupLimit needs.
+type cardgroupOwnerCounter interface {
+    CountByOwner(ctx context.Context, ownerID string, search *string) (int64, error)
+}
+
+func checkCardgroupLimit(
+    ctx context.Context,
+    counter cardgroupOwnerCounter,
+    admin AdminChecker,
+    ownerID string,
+) (*CardgroupLimitInfo, error) {
+    isAdmin, err := admin.IsAdmin(ctx, ownerID)
+    if err != nil {
+        if isContextDone(err) {
+            return nil, err
+        }
+        return nil, eris.Wrap(err, "usecase: cardgroup: check admin")
+    }
+    if isAdmin {
+        return nil, nil // admin exempt — no count query
+    }
+    count, err := counter.CountByOwner(ctx, ownerID, nil)
+    if err != nil {
+        if isContextDone(err) {
+            return nil, err
+        }
+        return nil, eris.Wrap(err, "usecase: cardgroup: count by owner")
+    }
+    if count >= generalUserCardgroupLimit {
+        return &CardgroupLimitInfo{Limit: generalUserCardgroupLimit, Current: int(count)}, nil
+    }
+    return nil, nil
+}
+```
+
+When `checkCardgroupLimit` returns a non-nil `*CardgroupLimitInfo`, `Create` surfaces
+the rejection via the `CardgroupLimitReachedError` GraphQL union variant (errors-as-data),
+carrying `limit` and `current`. Existing users already over the cap are rejected for
+new creates only — the `>=` comparison rejects at-or-above the limit without deleting
+existing cardgroups.
+
+## Call ordering in `Create`
+
+The `Create` method runs its checks in this order:
+
+1. Auth guard (`user == nil` → UNAUTHENTICATED) — no DB.
+2. Name validation (`domain.ParseCardgroupName`) — no DB.
+3. Limit check (`checkCardgroupLimit` → `IsAdmin` + optionally `CountByOwner`).
+4. ID generation and insert.
+
+Name validation runs before the limit check because it requires no DB round-trips.
+An invalid name fails immediately, avoiding the `IsAdmin` and `CountByOwner` queries
+on the common invalid-input path.
+
+## References
+
+- [Result union "errors as data"](../error-wrapping/result-union-errors-as-data.md) — `CardgroupLimitReachedError` as the rejection union variant.
+- [XOR-invariant outcome struct](xor-invariant-outcome-struct.md) — `CreateCardgroupOutcome` is a three-variant XOR (`Cardgroup` / `Validation` / `LimitReached`).
+- [Consumer-defined narrow interface](consumer-defined-narrow-repo-interface.md) — `cardgroupOwnerCounter` is the helper-site narrow interface.
+- [Pin unwrapped context error identity](../error-wrapping/pin-unwrapped-context-error-with-identity-check.md) — both infra calls in `checkCardgroupLimit` (`IsAdmin` and `CountByOwner`) guard context errors via `isContextDone` before wrapping.
+- [AdminGate error classifier](../error-wrapping/error-classifier-helper-pass-through-with-caller-prefix.md) — the admin-required counterpart that returns `ForbiddenError` for non-admins.

--- a/docs/frontend/typescript-conventions/shared-component-partial-outcome-union-migration.md
+++ b/docs/frontend/typescript-conventions/shared-component-partial-outcome-union-migration.md
@@ -87,7 +87,11 @@ if (payload?.__typename === "InputValidationError") {
   setValidationError({ field: payload.field, message: payload.message });
   return;
 }
-// ... handle Success and unknown-variant fallthrough.
+// `CreateCardgroupResult` has three variants: `CreateCardgroupSuccess`,
+// `InputValidationError`, and `CardgroupLimitReachedError` (carries `limit`
+// and `current` when the per-user cardgroup cap is reached, handled as a
+// distinct `status: "limit"` branch). Any unrecognized `__typename` falls
+// through to a generic error path.
 
 <CardgroupForm mode="create" submit={handleSubmit} validationError={validationError} />
 ```

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -100,7 +100,7 @@
     "addACard": "Add a card",
     "batchImport": "Batch import",
     "nameLabel": "Name",
-    "limitReached": "You can create up to {limit} card groups."
+    "limitReached": "You already have {current} card groups (maximum {limit})."
   },
   "Cards": {
     "addSomeCards": "Add some new cards to get started.",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -99,7 +99,8 @@
     "addCardButton": "Add card +",
     "addACard": "Add a card",
     "batchImport": "Batch import",
-    "nameLabel": "Name"
+    "nameLabel": "Name",
+    "limitReached": "You can create up to {limit} card groups."
   },
   "Cards": {
     "addSomeCards": "Add some new cards to get started.",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -100,7 +100,7 @@
     "addACard": "カードを追加",
     "batchImport": "一括インポート",
     "nameLabel": "名前",
-    "limitReached": "カードグループは{limit}個まで作成できます。"
+    "limitReached": "すでに{current}個のカードグループがあります（上限{limit}個）。"
   },
   "Cards": {
     "addSomeCards": "新しいカードを追加して始めましょう。",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -99,7 +99,8 @@
     "addCardButton": "カードを追加 +",
     "addACard": "カードを追加",
     "batchImport": "一括インポート",
-    "nameLabel": "名前"
+    "nameLabel": "名前",
+    "limitReached": "カードグループは{limit}個まで作成できます。"
   },
   "Cards": {
     "addSomeCards": "新しいカードを追加して始めましょう。",

--- a/frontend/src/app/cardgroups/cardgroups-client.test.tsx
+++ b/frontend/src/app/cardgroups/cardgroups-client.test.tsx
@@ -5,7 +5,11 @@ import { act, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { GraphQLError } from "graphql";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { DeleteCardgroupDocument, MyCardgroupsConnectionDocument } from "@/generated/graphql";
+import {
+  CreateCardgroupDocument,
+  DeleteCardgroupDocument,
+  MyCardgroupsConnectionDocument,
+} from "@/generated/graphql";
 import { UndoDeleteProvider } from "@/lib/undo-delete";
 import { renderWithIntl } from "@/test/render-with-intl";
 import {
@@ -139,7 +143,7 @@ let leakSpy: ApolloMockLeakSpyResult;
 
 beforeEach(() => {
   leakSpy = installApolloMockLeakSpy({
-    operationNames: ["MyCardgroupsConnection", "DeleteCardgroup"],
+    operationNames: ["MyCardgroupsConnection", "DeleteCardgroup", "CreateCardgroup"],
   });
   ioCallbacks = [];
   lastToastLabel = undefined;
@@ -1092,5 +1096,80 @@ describe("<CardgroupsClient> connection cache update (readQuery + writeQuery)", 
     });
     expect(result?.myCardgroupsConnection.pageInfo.hasNextPage).toBe(false);
     expect(result?.myCardgroupsConnection.totalCount).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// S-create-limit: in-list drawer surfaces CardgroupLimitReachedError via
+// the dedicated `cardgroup-create-limit-error` testid, not the overloaded
+// unexpected-error banner.
+// ---------------------------------------------------------------------------
+
+describe("<CardgroupsClient> create drawer — limit reached", () => {
+  it("shows the dedicated limit-error banner and not the unexpected-error banner when CardgroupLimitReachedError is returned", async () => {
+    const user = userEvent.setup();
+
+    const cache = new InMemoryCache();
+    const emptyConn = makeConnection([]);
+    cache.writeQuery({
+      query: MyCardgroupsConnectionDocument,
+      variables: { first: CARDGROUPS_PAGE_SIZE, search: null },
+      data: { myCardgroupsConnection: emptyConn },
+    });
+
+    const initialMock = {
+      request: {
+        query: MyCardgroupsConnectionDocument,
+        variables: { first: CARDGROUPS_PAGE_SIZE, search: null },
+      },
+      result: { data: { myCardgroupsConnection: emptyConn } },
+    };
+
+    // MockedProvider matches on the document object identity: CreateCardgroupDocument
+    // is the gql document produced by the same `CreateCardgroup` mutation in queries.ts.
+    const limitMock = {
+      request: {
+        query: CreateCardgroupDocument,
+        variables: { input: { name: "Over Limit" } },
+      },
+      result: () => ({
+        data: {
+          createCardgroup: {
+            __typename: "CardgroupLimitReachedError" as const,
+            message: "cardgroup limit reached",
+            limit: 5,
+            current: 5,
+          },
+        },
+      }),
+    };
+
+    renderClient([initialMock, limitMock], null, cache);
+
+    // Wait for the initial query to settle before opening the drawer.
+    await screen.findByTestId("cardgroups-header-new-btn");
+
+    // Open the in-list create drawer via the flamingo:add-cardgroup custom event
+    // (same mechanism as the nav-header "+" button).
+    act(() => {
+      window.dispatchEvent(new CustomEvent("flamingo:add-cardgroup", { cancelable: true }));
+    });
+
+    // The drawer renders a name input — wait for it.
+    const nameInput = await screen.findByRole("textbox", { name: /name/i });
+    await user.type(nameInput, "Over Limit");
+    await user.click(screen.getByRole("button", { name: /create/i }));
+
+    // The dedicated limit-error banner must appear with the localized text.
+    await waitFor(() => {
+      expect(screen.getByTestId("cardgroup-create-limit-error")).toBeInTheDocument();
+    });
+    expect(screen.getByTestId("cardgroup-create-limit-error")).toHaveTextContent(
+      "You already have 5 card groups (maximum 5).",
+    );
+
+    // The generic unexpected-error banner must NOT be shown — proving the
+    // dedicated limit state is used, not the overloaded unexpected-error path.
+    expect(screen.queryByTestId("cardgroup-create-unexpected-error")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/app/cardgroups/cardgroups-client.tsx
+++ b/frontend/src/app/cardgroups/cardgroups-client.tsx
@@ -163,6 +163,9 @@ export default function CardgroupsClient({ initialConnection }: CardgroupsClient
       case "auth":
         setAddAuthError(outcome.kind);
         return;
+      case "limit":
+        setAddUnexpectedError(t("limitReached", { limit: outcome.limit }));
+        return;
       case "unexpected":
       case "rejected":
         // The drawer is modal, so surface a banner for both an unparseable

--- a/frontend/src/app/cardgroups/cardgroups-client.tsx
+++ b/frontend/src/app/cardgroups/cardgroups-client.tsx
@@ -34,6 +34,7 @@ function CreateCardgroupSheetContent({
   validationError,
   authError,
   unexpectedError,
+  limitError,
   onDirty,
 }: {
   submit: (values: { name: string }) => Promise<void>;
@@ -41,6 +42,7 @@ function CreateCardgroupSheetContent({
   validationError: { field: string; message: string } | null;
   authError: "unauthenticated" | "forbidden" | null;
   unexpectedError: string | null;
+  limitError: string | null;
   onDirty: () => void;
 }) {
   const close = useFormSheetClose();
@@ -60,6 +62,16 @@ function CreateCardgroupSheetContent({
             {t("signInAgain")}
           </Link>
           .
+        </div>
+      ) : null}
+
+      {limitError ? (
+        <div
+          role="alert"
+          data-testid="cardgroup-create-limit-error"
+          className="rounded-md bg-destructive/10 p-3 text-sm text-destructive"
+        >
+          {limitError}
         </div>
       ) : null}
 
@@ -129,11 +141,13 @@ export default function CardgroupsClient({ initialConnection }: CardgroupsClient
   } | null>(null);
   const [addAuthError, setAddAuthError] = useState<"unauthenticated" | "forbidden" | null>(null);
   const [addUnexpectedError, setAddUnexpectedError] = useState<string | null>(null);
+  const [addLimitError, setAddLimitError] = useState<string | null>(null);
 
   const openAddSheet = useCallback(() => {
     setAddValidationError(null);
     setAddAuthError(null);
     setAddUnexpectedError(null);
+    setAddLimitError(null);
     setAddDirty(false);
     setAddOpen(true);
   }, []);
@@ -153,6 +167,7 @@ export default function CardgroupsClient({ initialConnection }: CardgroupsClient
     setAddValidationError(null);
     setAddAuthError(null);
     setAddUnexpectedError(null);
+    setAddLimitError(null);
 
     const outcome = await createCardgroup(values.name);
 
@@ -164,7 +179,7 @@ export default function CardgroupsClient({ initialConnection }: CardgroupsClient
         setAddAuthError(outcome.kind);
         return;
       case "limit":
-        setAddUnexpectedError(t("limitReached", { limit: outcome.limit }));
+        setAddLimitError(t("limitReached", { limit: outcome.limit, current: outcome.current }));
         return;
       case "unexpected":
       case "rejected":
@@ -477,6 +492,7 @@ export default function CardgroupsClient({ initialConnection }: CardgroupsClient
             setAddValidationError(null);
             setAddAuthError(null);
             setAddUnexpectedError(null);
+            setAddLimitError(null);
           }
         }}
         submitting={creating}
@@ -490,6 +506,7 @@ export default function CardgroupsClient({ initialConnection }: CardgroupsClient
           validationError={addValidationError}
           authError={addAuthError}
           unexpectedError={addUnexpectedError}
+          limitError={addLimitError}
           onDirty={() => setAddDirty(true)}
         />
       </FormSheet>

--- a/frontend/src/app/cardgroups/new/new-cardgroup-client.tsx
+++ b/frontend/src/app/cardgroups/new/new-cardgroup-client.tsx
@@ -32,6 +32,10 @@ export function NewCardgroupClient({ showWelcome = false, returnTo }: NewCardgro
   // response null bubble.
   const [unexpectedPayloadError, setUnexpectedPayloadError] = useState<string | null>(null);
 
+  // Server-enforced cardgroup limit reached. Rendered as a banner so the
+  // user knows creation is blocked without a field-level error indicator.
+  const [limitError, setLimitError] = useState<string | null>(null);
+
   // Mid-session auth failures. Cleared on each new submission attempt so a
   // retry after re-login does not show a stale banner.
   // Per .claude/rules/frontend-rsc-error-handling.md § "Mid-session
@@ -45,6 +49,7 @@ export function NewCardgroupClient({ showWelcome = false, returnTo }: NewCardgro
     setValidationError(null);
     setUnexpectedPayloadError(null);
     setAuthError(null);
+    setLimitError(null);
 
     const outcome = await create(values.name);
 
@@ -54,6 +59,9 @@ export function NewCardgroupClient({ showWelcome = false, returnTo }: NewCardgro
         return;
       case "auth":
         setAuthError(outcome.kind);
+        return;
+      case "limit":
+        setLimitError(t("limitReached", { limit: outcome.limit }));
         return;
       case "unexpected":
         setUnexpectedPayloadError(tCommon("somethingWentWrong"));
@@ -118,6 +126,16 @@ export function NewCardgroupClient({ showWelcome = false, returnTo }: NewCardgro
           className="mb-4 rounded-md bg-destructive/10 p-3 text-sm text-destructive"
         >
           {validationError.message}
+        </div>
+      ) : null}
+
+      {limitError ? (
+        <div
+          role="alert"
+          data-testid="cardgroup-new-limit-error"
+          className="mb-4 rounded-md bg-destructive/10 p-3 text-sm text-destructive"
+        >
+          {limitError}
         </div>
       ) : null}
 

--- a/frontend/src/app/cardgroups/new/new-cardgroup-client.tsx
+++ b/frontend/src/app/cardgroups/new/new-cardgroup-client.tsx
@@ -61,7 +61,7 @@ export function NewCardgroupClient({ showWelcome = false, returnTo }: NewCardgro
         setAuthError(outcome.kind);
         return;
       case "limit":
-        setLimitError(t("limitReached", { limit: outcome.limit }));
+        setLimitError(t("limitReached", { limit: outcome.limit, current: outcome.current }));
         return;
       case "unexpected":
         setUnexpectedPayloadError(tCommon("somethingWentWrong"));

--- a/frontend/src/app/cardgroups/new/page.test.tsx
+++ b/frontend/src/app/cardgroups/new/page.test.tsx
@@ -390,6 +390,47 @@ describe("<NewCardgroupPage> (client)", () => {
     }
   });
 
+  it("CardgroupLimitReachedError — shows limit banner with localized message, no navigation", async () => {
+    const user = userEvent.setup();
+
+    const mocks = [
+      {
+        request: {
+          query: CreateCardgroupDocument,
+          variables: { input: { name: "My Group" } },
+        },
+        result: () => ({
+          data: {
+            createCardgroup: {
+              __typename: "CardgroupLimitReachedError" as const,
+              message: "cardgroup limit reached",
+              limit: 5,
+              current: 5,
+            },
+          },
+        }),
+      },
+    ];
+
+    renderPage(mocks);
+
+    await user.type(screen.getByRole("textbox"), "My Group");
+    await user.click(screen.getByRole("button", { name: /create/i }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("cardgroup-new-limit-error")).toBeInTheDocument();
+    });
+    expect(screen.getByTestId("cardgroup-new-limit-error")).toHaveTextContent(
+      "You can create up to 5 card groups.",
+    );
+    // No navigation: the limit variant is data, not a success.
+    expect(mockPush).not.toHaveBeenCalled();
+    expect(mockRefresh).not.toHaveBeenCalled();
+    // Limit branch returns early — no generic warn must fire.
+    expect(screen.queryByTestId("cardgroup-new-validation-error")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("cardgroup-new-unexpected-payload-error")).not.toBeInTheDocument();
+  });
+
   it("null createCardgroup payload (partial-response null bubble) — warns and shows degraded banner", async () => {
     const user = userEvent.setup();
 

--- a/frontend/src/app/cardgroups/new/page.test.tsx
+++ b/frontend/src/app/cardgroups/new/page.test.tsx
@@ -421,7 +421,7 @@ describe("<NewCardgroupPage> (client)", () => {
       expect(screen.getByTestId("cardgroup-new-limit-error")).toBeInTheDocument();
     });
     expect(screen.getByTestId("cardgroup-new-limit-error")).toHaveTextContent(
-      "You can create up to 5 card groups.",
+      "You already have 5 card groups (maximum 5).",
     );
     // No navigation: the limit variant is data, not a success.
     expect(mockPush).not.toHaveBeenCalled();

--- a/frontend/src/app/cardgroups/queries.ts
+++ b/frontend/src/app/cardgroups/queries.ts
@@ -86,6 +86,11 @@ export const CreateCardgroupMutation = graphql(`
         field
         message
       }
+      ... on CardgroupLimitReachedError {
+        message
+        limit
+        current
+      }
     }
   }
 `);

--- a/frontend/src/app/cardgroups/use-create-cardgroup.ts
+++ b/frontend/src/app/cardgroups/use-create-cardgroup.ts
@@ -16,6 +16,7 @@ export type CreateCardgroupOutcome =
   | { status: "success"; cardgroupId: string }
   | { status: "validation"; field: string; message: string }
   | { status: "auth"; kind: "unauthenticated" | "forbidden" }
+  | { status: "limit"; limit: number; current: number }
   // The mutation resolved with an unparseable payload (unknown __typename or a
   // partial-response null bubble).
   | { status: "unexpected" }
@@ -93,6 +94,9 @@ export function useCreateCardgroup() {
         const typename = payload?.__typename ?? null;
         if (payload?.__typename === "InputValidationError") {
           return { status: "validation", field: payload.field, message: payload.message };
+        }
+        if (payload?.__typename === "CardgroupLimitReachedError") {
+          return { status: "limit", limit: payload.limit, current: payload.current };
         }
         if (payload?.__typename === "CreateCardgroupSuccess") {
           return { status: "success", cardgroupId: payload.cardgroup.id };

--- a/schema/cardgroup.graphql
+++ b/schema/cardgroup.graphql
@@ -37,7 +37,7 @@ type CardgroupLimitReachedError implements UserError {
   current: Int!
 }
 
-"""Result of `createCardgroup`. Either the created cardgroup or an input-validation failure."""
+"""Result of `createCardgroup`. One of: the created cardgroup, an input-validation failure, or a limit-reached error when a non-admin caller's cardgroup cap is exceeded."""
 union CreateCardgroupResult =
     CreateCardgroupSuccess
   | InputValidationError
@@ -98,8 +98,10 @@ extend type Query {
 extend type Mutation {
   """
   Create a cardgroup owned by the authenticated caller.
-  Returns a union: `CreateCardgroupSuccess` for the happy path, or `InputValidationError`
-  when the name fails validation (typed "error as data").
+  Returns a union: `CreateCardgroupSuccess` on the happy path,
+  `InputValidationError` when the name fails validation (typed "error as data"),
+  or `CardgroupLimitReachedError` when a non-admin caller already owns the
+  maximum number of cardgroups.
   """
   createCardgroup(input: NewCardgroupInput!): CreateCardgroupResult!
   """Update a cardgroup. Non-owners receive UNAUTHENTICATED."""

--- a/schema/cardgroup.graphql
+++ b/schema/cardgroup.graphql
@@ -26,10 +26,22 @@ type CreateCardgroupSuccess {
   cardgroup: Cardgroup!
 }
 
+"""
+Returned by `createCardgroup` when a non-admin caller already owns the maximum
+number of cardgroups. Admins are exempt. `limit` is the cap; `current` is the
+caller's existing count at rejection time so the client can localize the copy.
+"""
+type CardgroupLimitReachedError implements UserError {
+  message: String!
+  limit: Int!
+  current: Int!
+}
+
 """Result of `createCardgroup`. Either the created cardgroup or an input-validation failure."""
 union CreateCardgroupResult =
     CreateCardgroupSuccess
   | InputValidationError
+  | CardgroupLimitReachedError
 
 """Success variant returned by `updateCardgroup` when the cardgroup was updated. Carries the updated `cardgroup` so clients can refresh local state without a follow-up query."""
 type UpdateCardgroupSuccess {


### PR DESCRIPTION
## Summary

- Limits **general (non-admin) users to creating at most 5 cardgroups**. Admins are exempt — they are never counted and never blocked.
- When a non-admin at the cap calls `createCardgroup`, the mutation returns a new **errors-as-data union variant `CardgroupLimitReachedError`** (carrying `limit` and `current`), not a wire-level error — the client renders a localized message from `limit`/`current`.
- **Existing owners already over the cap are reject-new-only**: `count >= 5` blocks new creation until they drop below the cap; existing decks are never deleted or migrated.
- Admin-ness is resolved by **injecting the bool `AdminChecker` into `cardgroupUsecase`** (admin-exempt), not via `AdminGate.Require` (admin-required) — because `AuthUser.Role` is the Supabase/Postgres JWT role, not the application admin role.
- The shared limit check is a free function (`checkCardgroupLimit`) over a narrow `cardgroupOwnerCounter` interface, so a future bulk-import path can reuse it without bypassing the cap.

No related issue — standalone feature request.

## Changes

### Schema (`schema/cardgroup.graphql`)

- Add `CardgroupLimitReachedError implements UserError { message, limit, current }` and append it to the `CreateCardgroupResult` union (now `CreateCardgroupSuccess | InputValidationError | CardgroupLimitReachedError`). `updateCardgroup` is untouched.

### Usecase (`backend/internal/usecase/cardgroup.go`)

- `const generalUserCardgroupLimit = 5`.
- Inject `admin AdminChecker` into `cardgroupUsecase`; the constructor panics if it is nil (mandatory-dependency invariant). `*auth.Service` satisfies `AdminChecker`.
- New `CardgroupLimitInfo{Limit, Current}` and a third mutually-exclusive `LimitReached` field on `CreateCardgroupOutcome` (XOR with `Cardgroup` / `Validation`).
- `checkCardgroupLimit(ctx, counter cardgroupOwnerCounter, admin AdminChecker, ownerID)` — admins return `(nil, nil)` without counting; non-admins count via `CountByOwner` and return a non-nil `*CardgroupLimitInfo` at/over the cap. Both infra-call error branches (`IsAdmin`, `CountByOwner`) preserve `context.Canceled` / `context.DeadlineExceeded` identity via `isContextDone`.
- `Create` order is auth → name validation → limit check → create, so the no-DB name validation short-circuits before the `IsAdmin` + `Count` queries.

### Resolver + composition root

- `graph/resolver/cardgroup.resolvers.go`: return `model.CardgroupLimitReachedError` on `outcome.LimitReached` (errors-as-data, nil error), after the validation branch.
- `cmd/server/main.go`: wire `authSvc` into `NewCardgroupUsecase`.

### Frontend (`frontend/src/app/cardgroups/`)

- `queries.ts`: select the new union variant. `use-create-cardgroup.ts`: `status: "limit"` outcome branch.
- `new/new-cardgroup-client.tsx`: dedicated `limitError` state + `data-testid="cardgroup-new-limit-error"` banner.
- `cardgroups-client.tsx`: dedicated `addLimitError` state + `data-testid="cardgroup-create-limit-error"` banner in the in-list drawer (no longer overloads the unexpected-error banner).
- `messages/{en,ja}.json`: `Cardgroups.limitReached` ("You already have {current} card groups (maximum {limit}).") — Japanese confined to the catalog.

### Docs

- New harness chapter `docs/backend/library-gotchas/admin-checker-inject-for-admin-exempt-business-logic.md`: inject bool `AdminChecker` for admin-exempt rules vs `AdminGate.Require`; `AuthUser.Role` is the Postgres JWT role, not the app admin role.
- Refinement in `pin-unwrapped-context-error-with-identity-check.md`: multi-call free-function helpers must guard `context` errors on **every** branch.
- Accuracy updates to `docs/backend-graphql.md` and the frontend outcome-union migration doc for the now-three-variant union.

## Verification

- **Backend:** `go test ./...` — **all packages pass** (incl. `internal/repository`, `internal/database`); changed-package counts: usecase **489**, resolver **115**, cmd/server **56**. `go vet ./...` clean · `go tool go-arch-lint check` no layer violations · `cmd/schema-lint` **0 violations / 0 drifts**.
- **Backend gates:** no `fmt.Errorf("%w")` in `internal/`/`cmd/`; no `&ucerr.*{}` struct literals in production; no CJK in Go source.
- **Frontend:** `typecheck` ✓ · `lint` ✓ · `test` ✓ (**1193 tests / 123 files**) · `knip` ✓ · `i18n:parity` ✓ (252 keys) · `build` ✓ · CJK source check ✓ (Japanese confined to `messages/*.json`).
- Backend repository integration tests run in **CI** via testcontainers; they also passed locally here.
- Production Go non-test diff is well within the 800-line ceiling (~85 lines).

## Test plan

- [ ] General user owning 4 cardgroups → `createCardgroup` succeeds (5th is allowed).
- [ ] General user owning 5 → `CardgroupLimitReachedError { limit: 5, current: 5 }`; `repo.Create` is not called.
- [ ] Existing general user owning 6 → `CardgroupLimitReachedError { current: 6 }` (reject-new-only; no deletion).
- [ ] Admin owning 5 → `createCardgroup` succeeds and `CountByOwner` is never called (admin-exempt).
- [ ] `IsAdmin` / `CountByOwner` infra errors propagate wrapped (`usecase: cardgroup: ...`); `context.Canceled` / `context.DeadlineExceeded` from either propagate with bare identity preserved.
- [ ] Invalid name + at-cap simultaneously → name validation wins (returns `InputValidationError`, not the limit error).
- [ ] Frontend: at-cap create on `/cardgroups/new` and in the cardgroups drawer each show the localized limit banner (`cardgroup-new-limit-error` / `cardgroup-create-limit-error`), with no navigation/refresh and the generic error banner absent.
