### PR TITLE
docs(terms): disclose free-tier beta, no support, and no data guarantee

### DIFF
--- a/frontend/src/app/terms/content.ts
+++ b/frontend/src/app/terms/content.ts
@@ -9,7 +9,7 @@ type TermsContent = {
 
 export const TERMS_EN: TermsContent = {
   title: "Terms of Service",
-  lastUpdated: "Last updated: June 12, 2026",
+  lastUpdated: "Last updated: June 13, 2026",
   backToLogin: "Back to login",
   sections: [
     {
@@ -21,39 +21,43 @@ export const TERMS_EN: TermsContent = {
       body: "flamingo-armond is a personal flashcard application that uses spaced repetition to help you study and memorize content. The Service is intended for personal and educational use.",
     },
     {
-      title: "3. Account Registration",
+      title: "3. Beta Service, No Support, and No Data Guarantee",
+      body: "flamingo-armond is currently offered as a free, public beta and runs on free-tier, no-cost hosting infrastructure. The Service is therefore provided on a best-effort basis only: (a) we provide no user support of any kind and are under no obligation to respond to inquiries, fix defects, or restore lost data; (b) availability, features, and stored data may be changed, interrupted, or discontinued at any time without prior notice; and (c) we do not guarantee that your data will be preserved. Your flashcards and other content may be corrupted, lost, or permanently deleted, including as a result of the underlying free-tier infrastructure, and we accept no liability for any such loss. You are solely responsible for exporting and keeping your own backups of any content you consider important.",
+    },
+    {
+      title: "4. Account Registration",
       body: "You must sign in with a Google account to use the Service. You are responsible for all activity that occurs under your account. Please notify us immediately if you suspect unauthorized use of your account.",
     },
     {
-      title: "4. Acceptable Use",
+      title: "5. Acceptable Use",
       body: "You may use the Service only for lawful, personal, and educational purposes. You agree not to: (a) use the Service for any illegal or unauthorized purpose; (b) attempt to gain unauthorized access to any part of the Service or its infrastructure; (c) interfere with or disrupt the integrity or performance of the Service; or (d) create or store content that is harmful, offensive, or infringes on the rights of others.",
     },
     {
-      title: "5. User Content",
+      title: "6. User Content",
       body: "You retain ownership of the flashcards and other content you create in the Service. By using the Service, you grant us a limited license to store, process, and display your content solely for the purpose of providing the Service to you. You are solely responsible for the content you create.",
     },
     {
-      title: "6. Service Availability",
+      title: "7. Service Availability",
       body: 'We provide the Service on an "as is" and "as available" basis. We do not guarantee uninterrupted, timely, or error-free access. We reserve the right to modify, suspend, or discontinue any part of the Service at any time without prior notice.',
     },
     {
-      title: "7. Termination",
+      title: "8. Termination",
       body: "You may stop using the Service and request deletion of your account at any time. We reserve the right to suspend or terminate your access to the Service at our discretion, without notice, for conduct that we determine violates these Terms or is harmful to other users, us, or third parties.",
     },
     {
-      title: "8. Disclaimer of Warranties",
+      title: "9. Disclaimer of Warranties",
       body: 'THE SERVICE IS PROVIDED "AS IS" WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, OR NON-INFRINGEMENT. WE DO NOT WARRANT THAT THE SERVICE WILL BE UNINTERRUPTED, SECURE, OR ERROR-FREE.',
     },
     {
-      title: "9. Limitation of Liability",
+      title: "10. Limitation of Liability",
       body: "TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, WE SHALL NOT BE LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, OR PUNITIVE DAMAGES, OR ANY LOSS OF PROFITS, DATA, OR GOODWILL, ARISING OUT OF OR IN CONNECTION WITH YOUR USE OF THE SERVICE.",
     },
     {
-      title: "10. Changes to These Terms",
+      title: "11. Changes to These Terms",
       body: "We may update these Terms of Service from time to time. The updated Terms will be effective upon posting to the Service. Your continued use of the Service after any changes constitutes your acceptance of the revised Terms. We will indicate the date of the latest revision at the top of this page.",
     },
     {
-      title: "11. Contact",
+      title: "12. Contact",
       body: "If you have any questions about these Terms of Service, please open an issue on our GitHub repository.",
     },
   ],
@@ -61,7 +65,7 @@ export const TERMS_EN: TermsContent = {
 
 export const TERMS_JA: TermsContent = {
   title: "利用規約",
-  lastUpdated: "最終更新日：2026年6月12日",
+  lastUpdated: "最終更新日：2026年6月13日",
   backToLogin: "ログインに戻る",
   sections: [
     {
@@ -73,39 +77,43 @@ export const TERMS_JA: TermsContent = {
       body: "flamingo-armondは、間隔反復法を用いた個人向けフラッシュカードアプリです。学習・暗記のサポートを目的として提供され、個人的・教育的な用途を想定しています。",
     },
     {
-      title: "3. アカウント登録",
+      title: "3. ベータサービス・サポート非提供・データ無保証",
+      body: "flamingo-armondは現在、無料のパブリックベータ版として提供されており、無償（無料枠）のホスティング基盤上で運営されています。そのため、本サービスはベストエフォート（合理的な範囲での最善の努力）でのみ提供されます：（a）当社はいかなるユーザーサポートも提供せず、お問い合わせへの対応、不具合の修正、失われたデータの復旧を行う義務を負いません、（b）可用性・機能・保存されたデータは、事前の通知なくいつでも変更・中断・廃止される場合があります、（c）お客様のデータが保持されることは保証しません。お客様のフラッシュカードやその他のコンテンツは、無料枠の基盤に起因する場合を含め、破損・消失または完全に削除される可能性があり、当社はそのような損失について一切の責任を負いません。重要なコンテンツについては、お客様ご自身でエクスポートおよびバックアップを保持する責任を負うものとします。",
+    },
+    {
+      title: "4. アカウント登録",
       body: "本サービスのご利用にはGoogleアカウントによるログインが必要です。お客様のアカウントで発生したすべての活動についてお客様が責任を負います。アカウントへの不正アクセスが疑われる場合は、直ちにご連絡ください。",
     },
     {
-      title: "4. 禁止事項",
+      title: "5. 禁止事項",
       body: "本サービスは、合法的かつ個人的・教育的な目的においてのみご利用いただけます。以下の行為を禁止します：（a）違法または不正な目的での利用、（b）本サービスまたはそのインフラへの不正アクセスの試み、（c）本サービスの整合性またはパフォーマンスへの妨害、（d）有害・不快なコンテンツや第三者の権利を侵害するコンテンツの作成・保存。",
     },
     {
-      title: "5. ユーザーコンテンツ",
+      title: "6. ユーザーコンテンツ",
       body: "本サービスで作成したフラッシュカードおよびその他コンテンツの所有権はお客様に帰属します。本サービスのご利用により、本サービス提供のみを目的として、お客様のコンテンツを保存・処理・表示する限定的なライセンスを当社に付与するものとします。作成したコンテンツに関する責任はお客様が負います。",
     },
     {
-      title: "6. サービスの提供",
+      title: "7. サービスの提供",
       body: "本サービスは「現状有姿」かつ「利用可能な状態」で提供されます。継続的・タイムリー・エラーなしのアクセスは保証しません。事前の通知なく、本サービスの全部または一部を変更・中断・廃止する権利を留保します。",
     },
     {
-      title: "7. 利用の終了",
+      title: "8. 利用の終了",
       body: "いつでも本サービスのご利用を停止し、アカウントの削除を申請することができます。当社は、本利用規約に違反する、またはユーザー・当社・第三者に有害と判断する行為に対して、通知なしにお客様のアクセスを停止または終了する権利を留保します。",
     },
     {
-      title: "8. 保証の否認",
+      title: "9. 保証の否認",
       body: "本サービスは、商品性・特定目的への適合性・非侵害性を含む明示または黙示の一切の保証なしに「現状有姿」で提供されます。本サービスが中断なく、安全に、エラーなく提供されることは保証しません。",
     },
     {
-      title: "9. 責任の制限",
+      title: "10. 責任の制限",
       body: "適用法の最大限許容される範囲において、当社は本サービスのご利用に起因または関連する、利益・データ・のれんの損失を含む間接的・付随的・特別・結果的・懲罰的損害賠償について責任を負いません。",
     },
     {
-      title: "10. 利用規約の変更",
+      title: "11. 利用規約の変更",
       body: "本利用規約は随時更新される場合があります。更新された規約は本サービスに掲載された時点で有効となります。変更後も本サービスを継続してご利用いただくことにより、改訂された規約に同意したものとみなされます。最新の改訂日はページ上部に表示されます。",
     },
     {
-      title: "11. お問い合わせ",
+      title: "12. お問い合わせ",
       body: "本利用規約に関するご質問は、GitHubリポジトリのIssueよりお問い合わせください。",
     },
   ],

--- a/frontend/src/app/terms/page.test.tsx
+++ b/frontend/src/app/terms/page.test.tsx
@@ -17,14 +17,29 @@ describe("TermsPage", () => {
     expect(screen.getByRole("heading", { level: 1, name: "Terms of Service" })).toBeInTheDocument();
   });
 
-  it("en locale: renders all 11 section headings", async () => {
+  it("en locale: renders all 12 section headings", async () => {
     const jsx = await TermsPage();
     render(jsx);
 
     expect(
       screen.getByRole("heading", { level: 2, name: "1. Acceptance of Terms" }),
     ).toBeInTheDocument();
-    expect(screen.getByRole("heading", { level: 2, name: "11. Contact" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", {
+        level: 2,
+        name: "3. Beta Service, No Support, and No Data Guarantee",
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 2, name: "12. Contact" })).toBeInTheDocument();
+  });
+
+  it("en locale: beta section discloses no support and no data guarantee", async () => {
+    const jsx = await TermsPage();
+    render(jsx);
+
+    expect(screen.getByText(/free, public beta/i)).toBeInTheDocument();
+    expect(screen.getByText(/we provide no user support/i)).toBeInTheDocument();
+    expect(screen.getByText(/may be corrupted, lost, or permanently deleted/i)).toBeInTheDocument();
   });
 
   it("en locale: renders back-to-login link pointing to /login", async () => {


### PR DESCRIPTION
## Summary

- Adds a **Beta Service disclosure** to the Terms of Service page (`frontend/src/app/terms`), telling users up front that the service runs on free-tier infrastructure, is offered as a public beta, provides **no user support**, and gives **no guarantee that data is preserved**.
- A single new section is inserted after **Description of Service** (now section 3); the remaining sections are renumbered (11 → 12) and the last-updated date is bumped to June 13, 2026.
- Both `TERMS_EN` and `TERMS_JA` are updated together, per this page's established EN/JA-in-`content.ts` pattern (the terms/privacy pages keep localized legal copy inline rather than in the next-intl catalogs).

No related issue — direct request to update the Terms of Service.

## Changes

### Terms content (`frontend/src/app/terms/content.ts`)

- New section **"3. Beta Service, No Support, and No Data Guarantee"** ("3. ベータサービス・サポート非提供・データ無保証") inserted after "2. Description of Service", disclosing: (a) a free, public beta running on free-tier / no-cost hosting infrastructure; (b) no user support of any kind and no obligation to respond to inquiries, fix defects, or restore lost data; (c) no data-preservation guarantee — flashcards and other content may be corrupted, lost, or permanently deleted (including as a result of the free-tier infrastructure) with no liability, and users are solely responsible for their own exports/backups.
- Existing sections 3–11 (`Account Registration` … `Contact`) renumbered to 4–12; their bodies are otherwise unchanged.
- `lastUpdated` bumped to `June 13, 2026` / `2026年6月13日` in both locales.

### Tests (`frontend/src/app/terms/page.test.tsx`)

- Heading-count test updated 11 → 12 (now asserts `12. Contact` and the new `3. Beta Service…` heading render).
- New test: the beta section discloses no support and no data guarantee — asserts `free, public beta`, `we provide no user support`, and `may be corrupted, lost, or permanently deleted` render.

## Verification

- `pnpm --filter frontend test src/app/terms/page.test.tsx` ✓ (**8/8**, including the new disclosure test)
- `pnpm --filter frontend lint` (`biome check --error-on-warnings`) ✓
- `pnpm --filter frontend typecheck` (`tsc --noEmit`) ✓
- Japanese copy stays in `terms/content.ts`, consistent with the existing terms/privacy localized-legal-copy pattern (no CI CJK gate applies to these pages).

## Test plan

- [ ] Visit `/terms` in English → **3. Beta Service, No Support, and No Data Guarantee** renders between Description of Service and Account Registration; Contact is numbered **12**.
- [ ] Switch the `NEXT_LOCALE` cookie to `ja` → 「3. ベータサービス・サポート非提供・データ無保証」 renders with the matching disclosure copy.
- [ ] Confirm the beta section states there is no user support and that data may be corrupted/lost with no liability (users keep their own backups).
- [ ] Last-updated header shows June 13, 2026 / 2026年6月13日.
