### PR TITLE
chore(tooling): add Claude Code hooks, reviewer subagents, codegen-sync skill, and context7 MCP

### DIFF
--- a/.claude/agents/backend-layering-reviewer.md
+++ b/.claude/agents/backend-layering-reviewer.md
@@ -1,0 +1,23 @@
+---
+name: backend-layering-reviewer
+description: Reviews backend Go diffs against this repo's error-wrapping, layer-dependency, and Go-library conventions. Use after editing files under backend/internal or backend/graph, before committing backend changes.
+tools: Read, Grep, Glob, Bash
+model: sonnet
+---
+
+You review backend Go changes in the flamingo-armond repo. Your authority is the
+repo's own rule files — read them before reviewing:
+
+- `.claude/rules/error-wrapping.md` (eris-only; `usecase: <module>:` layer prefixes;
+  `ucerr.*` typed errors; resolver wraps every usecase error via
+  `gqlerr.FromUsecaseError`; usecase must not import gqlerr).
+- `.claude/rules/backend-layering.md` (the five layer invariants; go-arch-lint).
+- `.claude/rules/go-library-gotchas.md` (Echo v5 `*echo.Context` pointer receiver;
+  `uuid.NewV7` failure must propagate; GORM `WHERE id IN ?` empty-slice full scan;
+  JWT `WithValidMethods` whitelist).
+
+Review ONLY the changed lines (run `git diff` to scope). For each finding report:
+file:line, the violated rule (cite the rule file), and the minimal fix. Confirm
+findings against the source — do not flag mechanical gqlgen/goyacc generated diffs
+as bugs (see .claude/rules/subagent-dispatch.md). Report nothing if the diff is clean.
+Run `cd backend && go tool go-arch-lint check --project-path .` when imports changed.

--- a/.claude/agents/rsc-auth-reviewer.md
+++ b/.claude/agents/rsc-auth-reviewer.md
@@ -1,0 +1,24 @@
+---
+name: rsc-auth-reviewer
+description: Reviews Next.js RSC / middleware / Apollo changes against this repo's auth and error-handling conventions. Use after editing files under frontend/src/app, frontend/src/lib/apollo, or frontend/src/lib/supabase.
+tools: Read, Grep, Glob, Bash
+model: sonnet
+---
+
+You review frontend changes in the flamingo-armond repo. Your authority is:
+
+- `.claude/rules/frontend-rsc-error-handling.md` (AuthSessionMissingError filter by
+  error.name; Header must degrade not throw; structurally parse extensions.code via
+  isUnauthenticatedGraphQLError — never substring-match; revalidate:0 for
+  user-dependent fetches; UNAUTHENTICATED redirects to /login).
+- `.claude/rules/pagination.md` (Relay Connection cache patterns; drop
+  optimisticResponse for typed-error-capable mutations; readQuery+writeQuery over
+  cache.modify for cold cache).
+- `.claude/rules/frontend-typescript-conventions.md`.
+
+Review ONLY changed lines (`git diff`). For each finding report file:line, the
+violated rule (cite the rule file), and the minimal fix. Pay special attention to:
+new auth.getUser() callers missing the AuthSessionMissingError filter; substring
+message matching instead of extensions.code; layout-level code that can throw;
+mutations carrying optimisticResponse that can fail with typed GraphQL errors.
+Report nothing if clean.

--- a/.claude/hooks/backend-convention-guard.sh
+++ b/.claude/hooks/backend-convention-guard.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# PostToolUse guard: mirror backend CI grep gates at edit time.
+# Operates on the single edited file. Exit 2 surfaces violations to Claude so it
+# self-corrects; the file write has already happened, so this re-prompts rather
+# than blocking. Source rules: .claude/rules/error-wrapping.md, language-policy.md.
+#
+# NOTE: CI also runs an awk-based "Forbid resolver returning raw usecase error"
+# gate over graph/resolver/*.resolvers.go (backend.yml). That check is multi-line
+# and stateful (it scans a 5-line window after each usecase call), so a per-file
+# single-window port would misread context. It is deliberately left to CI only.
+set -euo pipefail
+FILE="$(jq -r '.tool_input.file_path // empty')"
+[ -z "$FILE" ] && exit 0
+case "$FILE" in
+  */backend/internal/*.go|*/backend/cmd/*.go|*/backend/graph/*.go) ;;
+  *) exit 0 ;;
+esac
+case "$FILE" in *_test.go) exit 0 ;; esac
+
+violations=""
+add() { violations="${violations}$1"$'\n'; }
+
+if grep -nE 'fmt\.Errorf\([^)]*%w' "$FILE" >/dev/null 2>&1; then
+  add "eris violation: fmt.Errorf(\"...%w\") is forbidden; use eris.Wrap. See .claude/rules/error-wrapping.md."
+fi
+case "$FILE" in
+  *internal/usecase/ucerr/errors.go) ;;
+  *) if grep -nE '&ucerr\.(ValidationError|ForbiddenError)\{' "$FILE" >/dev/null 2>&1; then
+       add "ucerr violation: use ucerr.NewValidationError / ucerr.NewForbiddenError, not struct literals. See .claude/rules/error-wrapping.md."
+     fi ;;
+esac
+case "$FILE" in
+  *internal/gqlerr/*) ;;
+  *) if grep -nE '"code"[[:space:]]*:[[:space:]]*"(UNAUTHENTICATED|BAD_USER_INPUT|FORBIDDEN|INTERNAL|CANCELLED)"' "$FILE" >/dev/null 2>&1; then
+       add "wire-format violation: hardcoded extensions.code outside gqlerr. Use gqlerr.* / gqlerr.FromUsecaseError. See .claude/rules/error-wrapping.md."
+     fi ;;
+esac
+# print-if + non-empty test is the canonical CJK check (see .claude/rules/language-policy.md).
+# Do NOT use `perl -ne 'exit 0 if //; END { exit 1 }'`: an END block runs even after an
+# explicit `exit 0` and overrides the status to 1, so that form never detects anything.
+if [ -n "$(perl -CSD -ne 'print if /[\x{3040}-\x{30ff}\x{4e00}-\x{9fff}]/' "$FILE")" ]; then
+  add "language-policy violation: CJK characters in committed source. English only. See .claude/rules/language-policy.md."
+fi
+
+if [ -n "$violations" ]; then
+  printf '%s\n%s' "backend-convention-guard found issues in $FILE:" "$violations" >&2
+  exit 2
+fi
+exit 0

--- a/.claude/hooks/format-on-edit.sh
+++ b/.claude/hooks/format-on-edit.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# PostToolUse formatter: auto-format the single edited file so Biome / gofmt
+# diffs never surprise the developer in CI. Exit 0 always — a formatting failure
+# must never block the session.
+set -euo pipefail
+FILE="$(jq -r '.tool_input.file_path // empty')"
+[ -z "$FILE" ] && exit 0
+case "$FILE" in
+  *.ts|*.tsx|*.js|*.mjs)
+    # MUST be `biome check --write`, not `biome format --write`:
+    # only `check` applies assist/source/organizeImports (see .claude/rules/subagent-dispatch.md).
+    (cd "$CLAUDE_PROJECT_DIR/frontend" && pnpm exec biome check --write "$FILE" >/dev/null 2>&1) || true
+    ;;
+  *.go)
+    command -v gofmt >/dev/null 2>&1 && gofmt -w "$FILE" || true
+    ;;
+esac
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,13 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|MultiEdit|Write",
+        "hooks": [
+          { "type": "command", "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/format-on-edit.sh\"" },
+          { "type": "command", "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/backend-convention-guard.sh\"" }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/codegen-sync/SKILL.md
+++ b/.claude/skills/codegen-sync/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: codegen-sync
+description: Regenerate GraphQL artifacts (gqlgen + graphql-codegen + Next typegen) in the correct order and smoke-build, after editing schema/schema.graphql. Handles the two-pass schema-field-drop failure mode.
+disable-model-invocation: true
+---
+
+Run after any change to `schema/schema.graphql`.
+
+1. Regenerate everything: `make codegen` (runs gqlgen for backend and
+   graphql-codegen for frontend). If it fails on a *removed* schema field, that
+   is the documented two-pass failure: regen cannot succeed until the production
+   Go/TS code that referenced the field is updated. Fix the referencing code,
+   then re-run. See docs/backend/library-gotchas/codegen-two-pass-schema-field-drop.md.
+2. Smoke-build backend: `cd backend && go build ./...`.
+3. Typecheck frontend: `cd frontend && pnpm typecheck`.
+4. Report which generated files changed (`git status --short backend/graph frontend/src/generated`)
+   and whether builds passed. Do NOT commit — leave staging to the user.


### PR DESCRIPTION
## Summary

- Moves several heavily-documented `.claude/rules/` conventions from **CI-only enforcement** to **edit-time enforcement** inside Claude Code sessions, and adds two repo-specific reviewer subagents plus a codegen-sync skill.
- All automations are **additive** — no existing CI gate is changed; CI remains the source of truth.
- Team-shared config lands in the now-committed `.claude/settings.json` (previously absent); the personal, git-ignored `.claude/settings.local.json` is untouched.

Closes #413.

## Changes

### Hooks (`.claude/hooks/` + `.claude/settings.json`)

- `backend-convention-guard.sh` (PostToolUse, `exit 2` surfaces to Claude for self-correction): mirrors the backend CI grep gates on the **single edited** backend Go file — forbids `fmt.Errorf("…%w")`, `&ucerr.{Validation,Forbidden}Error{}` struct literals, hardcoded `extensions.code` literals outside `gqlerr`, and CJK characters. Skips `_test.go`; excludes `internal/usecase/ucerr/errors.go` and `internal/gqlerr/` to match the corresponding CI gates. The multi-line, stateful resolver `awk` gate is deliberately **left to CI** (documented in the script header).
- `format-on-edit.sh` (PostToolUse, always `exit 0`): `biome check --write` for `.ts/.tsx/.js/.mjs` (note: `check`, not `format` — only `check` runs `organizeImports`) and `gofmt -w` for `.go`. A formatting failure never blocks the session.
- `.claude/settings.json`: wires both hooks under one `Edit|MultiEdit|Write` PostToolUse matcher.

### Reviewer subagents (`.claude/agents/`)

- `backend-layering-reviewer` (sonnet): reviews backend Go diffs against the error-wrapping, layer-dependency, and Go-library-gotcha rules.
- `rsc-auth-reviewer` (sonnet): reviews Next.js RSC / middleware / Apollo diffs against the RSC-error-handling, pagination, and TypeScript-convention rules.

### Skill (`.claude/skills/codegen-sync/`)

- `/codegen-sync` (user-only via `disable-model-invocation: true`): runs `make codegen` → `go build ./...` → `pnpm typecheck` in order and reports which generated files changed; handles the documented two-pass schema-field-drop failure mode. Does not commit.

### Not committed (Task 6)

- **context7 MCP** was added **local-only** (`claude mcp add context7`, local scope) per the maintainer decision — no `.mcp.json` is committed, so the team's shared MCP set is unchanged.

## Deviation from the issue spec

The issue's provided CJK check — `perl -CSD -ne 'exit 0 if /…/; END { exit 1 }'` — is buggy: a Perl `END` block runs even after an explicit `exit 0` and overrides the exit status to `1`, so that form **never** detects CJK (the acceptance criterion "a file with a Japanese character is flagged" would silently fail). Verified empirically, then replaced with the canonical `print if /…/` + non-empty-output check used by `.claude/rules/language-policy.md`.

## Verification

- `bash -n` on both hooks ✓; `.claude/settings.json` is valid JSON (`jq`) ✓; both `.sh` committed as `100755` ✓.
- `backend-convention-guard.sh` (driven with the real PostToolUse stdin JSON): flags `fmt.Errorf("%w")`, `&ucerr.ValidationError{}`, hardcoded `"code":"UNAUTHENTICATED"`, and CJK (hiragana + kanji) with `exit 2`; **no** violation for `_test.go`, `internal/usecase/ucerr/errors.go`, `internal/gqlerr/`, a clean English file, or a non-backend path ✓.
- `format-on-edit.sh`: a `.tsx` with unsorted imports becomes Biome-clean (`biome check` reports no fixes); a misformatted `.go` becomes `gofmt -l`-clean ✓.
- All committed files pass the `language-policy.md` CJK grep (GNU grep + `perl -CSD`) and carry no PR-order references ✓.
- `claude mcp get context7` → **Connected** ✓.

## Test plan

- [ ] Restart a Claude Code session at repo root (hooks / agents / skills load at startup).
- [ ] Edit a non-test `backend/internal/**.go` file to add `fmt.Errorf("x: %w", err)` → the guard surfaces a violation; remove it → it clears. Same content in a `_test.go` → no violation.
- [ ] Edit a `.tsx` with unsorted imports → imports are auto-sorted on save.
- [ ] Dispatch `backend-layering-reviewer` / `rsc-auth-reviewer` against a diff → they appear in the project agent list and cite the rule files.
- [ ] Run `/codegen-sync` on a clean tree → codegen + both smoke checks report green.
