### PR TITLE
feat(master-catalog): import mutation (backend)

### DIFF
--- a/.claude/rules/ddd-patterns.md
+++ b/.claude/rules/ddd-patterns.md
@@ -182,6 +182,18 @@ the harder-wins merge has no shared keys to arbitrate.
 
 [`docs/backend/ddd-patterns/append-only-classification-extension.md`](../../docs/backend/ddd-patterns/append-only-classification-extension.md)
 
+### Collapse "unknown" and "exists-but-hidden" into one not-found (non-disclosure gate)
+
+When a lifecycle-gated resource (draft/published, soft-deleted, other-tenant) is read by
+a caller not authorized to know it exists, return the *same* not-found for both "unknown
+id" and "exists but hidden" so the endpoint cannot be used as an existence oracle. Collapse
+at the lowest layer: the repository read is scoped to the visible set (`FindPublishedByID`
+returns `ErrNotFound` for unknown AND draft), the usecase maps it to a not-found data
+outcome, the resolver emits a state-free message. Owner-facing reads of the same resource
+may keep the distinction; erase it only across the trust boundary it protects.
+
+[`docs/backend/ddd-patterns/notfound-collapse-non-disclosure.md`](../../docs/backend/ddd-patterns/notfound-collapse-non-disclosure.md)
+
 ## Further reading (on-demand)
 
 - [Value object Parse pattern](../../docs/backend/ddd-patterns/value-object-parse-pattern.md)
@@ -201,3 +213,4 @@ the harder-wins merge has no shared keys to arbitrate.
 - [Mutation response must not carry a client-managed collection](../../docs/backend/ddd-patterns/mutation-response-must-not-carry-client-managed-collection.md)
 - [Discovery-first due ordering (80% new / 20% prior-day review)](../../docs/backend/ddd-patterns/discovery-first-due-ordering.md)
 - [Append-only extension of a classification with a secondary, independently-graded source](../../docs/backend/ddd-patterns/append-only-classification-extension.md)
+- [Collapse "unknown" and "exists-but-hidden" into one not-found (non-disclosure gate)](../../docs/backend/ddd-patterns/notfound-collapse-non-disclosure.md)

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -321,7 +321,7 @@ func run(ctx context.Context, logger *slog.Logger) error {
 	var cefrWords domain.CEFRWordList = cefr.NewWordList()
 	cefrClassifier := service.NewCEFRClassifier(cefrWords)
 	cefrUC := usecase.NewCEFRUsecase(cefrClassifier)
-	masterCatalogUC := usecase.NewMasterCatalogUsecase(masterCardgroupRepo, logger)
+	masterCatalogUC := usecase.NewMasterCatalogUsecase(masterCardgroupRepo, masterDeckUC, logger)
 	resolvers := resolver.NewResolver(userUC, cardgroupUC, cardUC, swipeUC, authSvc, cardImportUC, adminUserUC, adminRoleUC, lastViewedCardgroupUC, updateLearnDisplayModeUC, learnUC, cefrUC, masterCatalogUC)
 	// newRouter must be called after telemetry.Init: the otelhttp handler it
 	// constructs reads otel.GetTextMapPropagator() eagerly. See comment above

--- a/backend/graph/resolver/master_catalog.resolvers.go
+++ b/backend/graph/resolver/master_catalog.resolvers.go
@@ -10,12 +10,33 @@ import (
 	"backend/internal/gqlerr"
 	"backend/internal/usecase"
 	"context"
-	"fmt"
+
+	"github.com/rotisserie/eris"
 )
 
 // ImportMasterCardgroup is the resolver for the importMasterCardgroup field.
+//
+// Returns a union: model.ImportMasterCardgroupSuccess on the happy path, or
+// model.MasterNotFoundError when the master id is unknown or not published
+// (draft existence is never leaked). The not-found case is "errors as data";
+// the error return is reserved for auth and infrastructure failures.
 func (r *mutationResolver) ImportMasterCardgroup(ctx context.Context, masterCardgroupID string) (model.ImportMasterCardgroupResult, error) {
-	panic(fmt.Errorf("not implemented: ImportMasterCardgroup - importMasterCardgroup"))
+	outcome, err := r.MasterCatalogUC.ImportMaster(ctx, masterCardgroupID)
+	if err != nil {
+		return nil, gqlerr.FromUsecaseError(ctx, err)
+	}
+	if outcome.NotFound {
+		return model.MasterNotFoundError{
+			Message: "Master cardgroup not found",
+		}, nil
+	}
+	if outcome.Cardgroup == nil {
+		return nil, gqlerr.Internal(ctx,
+			eris.New("resolver: ImportMasterOutcome has no variant set"))
+	}
+	return model.ImportMasterCardgroupSuccess{
+		Cardgroup: toCardgroupModel(outcome.Cardgroup),
+	}, nil
 }
 
 // MasterCatalog is the resolver for the masterCatalog field.

--- a/backend/graph/resolver/master_catalog.resolvers.go
+++ b/backend/graph/resolver/master_catalog.resolvers.go
@@ -10,7 +10,13 @@ import (
 	"backend/internal/gqlerr"
 	"backend/internal/usecase"
 	"context"
+	"fmt"
 )
+
+// ImportMasterCardgroup is the resolver for the importMasterCardgroup field.
+func (r *mutationResolver) ImportMasterCardgroup(ctx context.Context, masterCardgroupID string) (model.ImportMasterCardgroupResult, error) {
+	panic(fmt.Errorf("not implemented: ImportMasterCardgroup - importMasterCardgroup"))
+}
 
 // MasterCatalog is the resolver for the masterCatalog field.
 func (r *queryResolver) MasterCatalog(ctx context.Context, first *int, after *string, last *int, before *string, search *string, orderBy *model.MasterCatalogOrderBy, orderDirection *model.SortOrder) (*model.MasterCatalogConnection, error) {

--- a/backend/graph/resolver/master_catalog_import_test.go
+++ b/backend/graph/resolver/master_catalog_import_test.go
@@ -90,3 +90,22 @@ func TestMutationResolver_ImportMasterCardgroup_InfraError_WrapsInternal(t *test
 		t.Fatalf("expected INTERNAL wire error, got %v", err)
 	}
 }
+
+func TestMutationResolver_ImportMasterCardgroup_XORInvariantViolation(t *testing.T) {
+	t.Parallel()
+
+	// A degenerate {Cardgroup:nil, NotFound:false} outcome is a producer-contract
+	// violation; the resolver's defensive guard must surface it as INTERNAL rather
+	// than a nil union or a schema-null. Mirrors the sibling _XORInvariantViolation
+	// tests on the admin role/user outcome-union resolvers.
+	stub := &stubMasterCatalogUC{importOut: usecase.ImportMasterOutcome{}}
+	r := &Resolver{MasterCatalogUC: stub}
+
+	res, err := r.Mutation().ImportMasterCardgroup(context.Background(), "m1")
+	if res != nil {
+		t.Fatalf("expected nil union on invariant violation, got %T", res)
+	}
+	if !gqlerr.IsCode(err, gqlerr.CodeInternal) {
+		t.Fatalf("expected INTERNAL wire error, got %v", err)
+	}
+}

--- a/backend/graph/resolver/master_catalog_import_test.go
+++ b/backend/graph/resolver/master_catalog_import_test.go
@@ -1,0 +1,92 @@
+package resolver
+
+import (
+	"context"
+	"testing"
+
+	"github.com/rotisserie/eris"
+
+	"backend/graph/model"
+	"backend/internal/domain"
+	"backend/internal/gqlerr"
+	"backend/internal/usecase"
+	"backend/internal/usecase/ucerr"
+)
+
+func TestMutationResolver_ImportMasterCardgroup_Success(t *testing.T) {
+	t.Parallel()
+
+	stub := &stubMasterCatalogUC{
+		importOut: usecase.ImportMasterOutcome{
+			Cardgroup: &domain.Cardgroup{ID: "cg1", OwnerID: "u1", Name: domain.CardgroupName("Deck")},
+		},
+	}
+	r := &Resolver{MasterCatalogUC: stub}
+
+	res, err := r.Mutation().ImportMasterCardgroup(context.Background(), "m1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if stub.gotImport != "m1" {
+		t.Fatalf("usecase called with %q, want m1", stub.gotImport)
+	}
+	ok, isOK := res.(model.ImportMasterCardgroupSuccess)
+	if !isOK {
+		t.Fatalf("expected ImportMasterCardgroupSuccess, got %T", res)
+	}
+	if ok.Cardgroup == nil || ok.Cardgroup.ID != "cg1" {
+		t.Fatalf("expected mapped cardgroup cg1, got %+v", ok.Cardgroup)
+	}
+}
+
+func TestMutationResolver_ImportMasterCardgroup_NotFound_ReturnsTypedError(t *testing.T) {
+	t.Parallel()
+
+	stub := &stubMasterCatalogUC{importOut: usecase.ImportMasterOutcome{NotFound: true}}
+	r := &Resolver{MasterCatalogUC: stub}
+
+	res, err := r.Mutation().ImportMasterCardgroup(context.Background(), "missing")
+	if err != nil {
+		t.Fatalf("not-found must be data, not error; got %v", err)
+	}
+	notFound, ok := res.(model.MasterNotFoundError)
+	if !ok {
+		t.Fatalf("expected MasterNotFoundError, got %T", res)
+	}
+	if notFound.Message == "" {
+		t.Fatal("expected a non-empty message")
+	}
+}
+
+func TestMutationResolver_ImportMasterCardgroup_Unauthenticated_WrapsError(t *testing.T) {
+	t.Parallel()
+
+	stub := &stubMasterCatalogUC{importErr: ucerr.ErrUnauthenticated}
+	r := &Resolver{MasterCatalogUC: stub}
+
+	res, err := r.Mutation().ImportMasterCardgroup(context.Background(), "m1")
+	if res != nil {
+		t.Fatalf("expected nil union on error, got %T", res)
+	}
+	if !gqlerr.IsCode(err, gqlerr.CodeUnauthenticated) {
+		t.Fatalf("expected UNAUTHENTICATED wire error, got %v", err)
+	}
+}
+
+func TestMutationResolver_ImportMasterCardgroup_InfraError_WrapsInternal(t *testing.T) {
+	t.Parallel()
+
+	// A non-auth usecase error (e.g. a DB outage surfaced by ImportMaster) must
+	// transit gqlerr.FromUsecaseError to the INTERNAL wire code rather than
+	// escaping uncoded — mirrors TestQueryResolver_MasterCatalog_WrapsUsecaseError.
+	stub := &stubMasterCatalogUC{importErr: eris.New("db: connection reset")}
+	r := &Resolver{MasterCatalogUC: stub}
+
+	res, err := r.Mutation().ImportMasterCardgroup(context.Background(), "m1")
+	if res != nil {
+		t.Fatalf("expected nil union on error, got %T", res)
+	}
+	if !gqlerr.IsCode(err, gqlerr.CodeInternal) {
+		t.Fatalf("expected INTERNAL wire error, got %v", err)
+	}
+}

--- a/backend/graph/resolver/master_catalog_query_test.go
+++ b/backend/graph/resolver/master_catalog_query_test.go
@@ -19,9 +19,12 @@ import (
 // so the resolver's input mapping and error wrapping can be unit-tested without
 // a real usecase or database.
 type stubMasterCatalogUC struct {
-	gotInput usecase.MasterCatalogConnectionInput
-	out      *usecase.MasterCatalogConnectionOutput
-	err      error
+	gotInput  usecase.MasterCatalogConnectionInput
+	out       *usecase.MasterCatalogConnectionOutput
+	err       error
+	importOut usecase.ImportMasterOutcome
+	importErr error
+	gotImport string
 }
 
 func (s *stubMasterCatalogUC) ListPublishedConnection(
@@ -29,6 +32,11 @@ func (s *stubMasterCatalogUC) ListPublishedConnection(
 ) (*usecase.MasterCatalogConnectionOutput, error) {
 	s.gotInput = in
 	return s.out, s.err
+}
+
+func (s *stubMasterCatalogUC) ImportMaster(_ context.Context, masterID string) (usecase.ImportMasterOutcome, error) {
+	s.gotImport = masterID
+	return s.importOut, s.importErr
 }
 
 // TestQueryResolver_MasterCatalog_Success verifies the resolver maps the model

--- a/backend/internal/usecase/master_catalog.go
+++ b/backend/internal/usecase/master_catalog.go
@@ -64,24 +64,36 @@ type MasterCatalogConnectionOutput struct {
 	EndCur     string
 }
 
-// MasterCatalogUsecase is the read-only published-catalog surface. Every method
-// requires an authenticated caller — the catalog is not public.
+// MasterCatalogUsecase is the published-catalog surface. Every method requires an
+// authenticated caller — the catalog is not public.
 type MasterCatalogUsecase interface {
 	ListPublishedConnection(ctx context.Context, in MasterCatalogConnectionInput) (*MasterCatalogConnectionOutput, error)
+	ImportMaster(ctx context.Context, masterID string) (ImportMasterOutcome, error)
+}
+
+// ImportMasterOutcome is the usecase result of ImportMaster. Exactly one signal is
+// set: Cardgroup on the happy path, or NotFound=true when the master id is unknown
+// or not published. The not-found case is surfaced as data (the MasterNotFoundError
+// union variant) rather than as an error so the resolver can return it in `data`.
+type ImportMasterOutcome struct {
+	Cardgroup *domain.Cardgroup
+	NotFound  bool
 }
 
 type masterCatalogUsecase struct {
 	repo   MasterCatalogRepository
+	copyUC CopyMasterToUserUsecase
 	logger *slog.Logger
 }
 
 // NewMasterCatalogUsecase constructs a MasterCatalogUsecase backed by the given
-// repository. Panics on a nil logger.
-func NewMasterCatalogUsecase(repo MasterCatalogRepository, logger *slog.Logger) MasterCatalogUsecase {
+// repository. copyUC is the #398 copy primitive used by ImportMaster. Panics on a
+// nil logger.
+func NewMasterCatalogUsecase(repo MasterCatalogRepository, copyUC CopyMasterToUserUsecase, logger *slog.Logger) MasterCatalogUsecase {
 	if logger == nil {
 		panic("usecase: master catalog: logger is required")
 	}
-	return &masterCatalogUsecase{repo: repo, logger: logger}
+	return &masterCatalogUsecase{repo: repo, copyUC: copyUC, logger: logger}
 }
 
 // ListPublishedConnection paginates the published master catalog with
@@ -271,4 +283,30 @@ func (u *masterCatalogUsecase) resolveMasterCatalogCursor(
 		return nil, eris.Errorf("usecase: master catalog: unhandled orderBy %q", orderBy)
 	}
 	return c, nil
+}
+
+// ImportMaster copies the published master cardgroup identified by masterID into a
+// fresh cardgroup owned by the authenticated caller. The master is gated through
+// FindPublishedByID, which returns ErrNotFound for both unknown ids and draft decks,
+// so draft existence is never disclosed — both collapse to ImportMasterOutcome{NotFound:true}.
+// Unauthenticated callers receive ucerr.ErrUnauthenticated. The copy is a one-time
+// snapshot delegated to CopyMasterToUserUsecase; FSRS/swipe state starts empty.
+func (u *masterCatalogUsecase) ImportMaster(ctx context.Context, masterID string) (ImportMasterOutcome, error) {
+	caller := auth.UserFrom(ctx)
+	if caller == nil {
+		return ImportMasterOutcome{}, ucerr.ErrUnauthenticated
+	}
+
+	if _, err := u.repo.FindPublishedByID(ctx, masterID); err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return ImportMasterOutcome{NotFound: true}, nil
+		}
+		return ImportMasterOutcome{}, eris.Wrap(err, "usecase: master catalog: import: verify published")
+	}
+
+	cg, err := u.copyUC.CopyMasterToUser(ctx, masterID, caller.Sub)
+	if err != nil {
+		return ImportMasterOutcome{}, eris.Wrap(err, "usecase: master catalog: import: copy master to user")
+	}
+	return ImportMasterOutcome{Cardgroup: cg}, nil
 }

--- a/backend/internal/usecase/master_catalog.go
+++ b/backend/internal/usecase/master_catalog.go
@@ -71,13 +71,21 @@ type MasterCatalogUsecase interface {
 	ImportMaster(ctx context.Context, masterID string) (ImportMasterOutcome, error)
 }
 
-// ImportMasterOutcome is the usecase result of ImportMaster. Exactly one signal is
-// set: Cardgroup on the happy path, or NotFound=true when the master id is unknown
-// or not published. The not-found case is surfaced as data (the MasterNotFoundError
-// union variant) rather than as an error so the resolver can return it in `data`.
+// ImportMasterOutcome is the usecase result of ImportMaster. On the valid paths
+// exactly one signal is set: Cardgroup on the happy path, or NotFound=true when the
+// master id is unknown or not published. The not-found case is surfaced as data (the
+// MasterNotFoundError union variant) rather than as an error so the resolver can
+// return it in `data`. The XOR is a producer contract, not a compile-time guarantee:
+// a degenerate {Cardgroup:nil, NotFound:false} result is treated as INTERNAL by the
+// resolver's defensive guard.
 type ImportMasterOutcome struct {
+	// Cardgroup is the newly created user-owned cardgroup snapshot on the happy
+	// path. Non-nil iff NotFound is false.
 	Cardgroup *domain.Cardgroup
-	NotFound  bool
+	// NotFound is true when the master id is unknown or not published; it subsumes
+	// draft existence so draft ids are indistinguishable from absent ids. True iff
+	// Cardgroup is nil.
+	NotFound bool
 }
 
 type masterCatalogUsecase struct {
@@ -87,9 +95,16 @@ type masterCatalogUsecase struct {
 }
 
 // NewMasterCatalogUsecase constructs a MasterCatalogUsecase backed by the given
-// repository. copyUC is the #398 copy primitive used by ImportMaster. Panics on a
-// nil logger.
+// repository. copyUC is the copy primitive (CopyMasterToUserUsecase) used by
+// ImportMaster. Panics when repo, copyUC, or logger is nil — a nil required
+// dependency is a wiring bug that must fail at startup, not at first use.
 func NewMasterCatalogUsecase(repo MasterCatalogRepository, copyUC CopyMasterToUserUsecase, logger *slog.Logger) MasterCatalogUsecase {
+	if repo == nil {
+		panic("usecase: master catalog: repo is required")
+	}
+	if copyUC == nil {
+		panic("usecase: master catalog: copyUC is required")
+	}
 	if logger == nil {
 		panic("usecase: master catalog: logger is required")
 	}
@@ -301,11 +316,17 @@ func (u *masterCatalogUsecase) ImportMaster(ctx context.Context, masterID string
 		if errors.Is(err, repository.ErrNotFound) {
 			return ImportMasterOutcome{NotFound: true}, nil
 		}
+		if isContextDone(err) {
+			return ImportMasterOutcome{}, err
+		}
 		return ImportMasterOutcome{}, eris.Wrap(err, "usecase: master catalog: import: verify published")
 	}
 
 	cg, err := u.copyUC.CopyMasterToUser(ctx, masterID, caller.Sub)
 	if err != nil {
+		if isContextDone(err) {
+			return ImportMasterOutcome{}, err
+		}
 		return ImportMasterOutcome{}, eris.Wrap(err, "usecase: master catalog: import: copy master to user")
 	}
 	return ImportMasterOutcome{Cardgroup: cg}, nil

--- a/backend/internal/usecase/master_catalog_test.go
+++ b/backend/internal/usecase/master_catalog_test.go
@@ -456,6 +456,12 @@ type mockCopyMasterToUserUC struct {
 }
 
 func (m *mockCopyMasterToUserUC) CopyMasterToUser(ctx context.Context, masterID, ownerID string) (*domain.Cardgroup, error) {
+	// Mirror mockMasterCatalogRepository.FindPublishedByID: a nil fn (the placeholder
+	// passed on paths that never reach the copy) yields an attributed error rather
+	// than an unattributed nil-function panic if a future test wires it incorrectly.
+	if m.fn == nil {
+		return nil, eris.New("mockCopyMasterToUserUC: fn not set")
+	}
 	return m.fn(ctx, masterID, ownerID)
 }
 

--- a/backend/internal/usecase/master_catalog_test.go
+++ b/backend/internal/usecase/master_catalog_test.go
@@ -97,13 +97,31 @@ func catalogItem(id string, cardCount int64) *repository.MasterCatalogItem {
 // Constructor
 // ---------------------------------------------------------------------------
 
+func TestNewMasterCatalogUsecase_NilRepoPanics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic on nil repo")
+		}
+	}()
+	NewMasterCatalogUsecase(nil, &mockCopyMasterToUserUC{}, newTestLogger())
+}
+
+func TestNewMasterCatalogUsecase_NilCopyUCPanics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic on nil copyUC")
+		}
+	}()
+	NewMasterCatalogUsecase(&mockMasterCatalogRepository{}, nil, newTestLogger())
+}
+
 func TestNewMasterCatalogUsecase_NilLoggerPanics(t *testing.T) {
 	defer func() {
 		if r := recover(); r == nil {
 			t.Fatal("expected panic on nil logger")
 		}
 	}()
-	NewMasterCatalogUsecase(&mockMasterCatalogRepository{}, nil, nil)
+	NewMasterCatalogUsecase(&mockMasterCatalogRepository{}, &mockCopyMasterToUserUC{}, nil)
 }
 
 // ---------------------------------------------------------------------------
@@ -111,7 +129,7 @@ func TestNewMasterCatalogUsecase_NilLoggerPanics(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestListPublishedConnection_Unauthenticated(t *testing.T) {
-	uc := NewMasterCatalogUsecase(&mockMasterCatalogRepository{}, nil, newTestLogger())
+	uc := NewMasterCatalogUsecase(&mockMasterCatalogRepository{}, &mockCopyMasterToUserUC{}, newTestLogger())
 
 	_, err := uc.ListPublishedConnection(context.Background(), MasterCatalogConnectionInput{})
 	if !errors.Is(err, ucerr.ErrUnauthenticated) {
@@ -131,7 +149,7 @@ func TestListPublishedConnection_Forward_TrimsExtraRow_SetsHasNext(t *testing.T)
 			catalogItem("a", 10), catalogItem("b", 20), catalogItem("c", 30),
 		},
 	}
-	uc := NewMasterCatalogUsecase(repo, nil, newTestLogger())
+	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, newTestLogger())
 
 	out, err := uc.ListPublishedConnection(authedCtx("u1"), MasterCatalogConnectionInput{
 		First: intPtr(2),
@@ -179,7 +197,7 @@ func TestListPublishedConnection_Forward_NoExtraRow_NoNextPage(t *testing.T) {
 		countResult:    2,
 		findPageResult: []*repository.MasterCatalogItem{catalogItem("a", 1), catalogItem("b", 2)},
 	}
-	uc := NewMasterCatalogUsecase(repo, nil, newTestLogger())
+	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, newTestLogger())
 
 	out, err := uc.ListPublishedConnection(authedCtx("u1"), MasterCatalogConnectionInput{First: intPtr(5)})
 	if err != nil {
@@ -210,7 +228,7 @@ func TestListPublishedConnection_Backward_TrimsLeadingRow_SetsHasPrev(t *testing
 			catalogItem("x", 1), catalogItem("y", 2), catalogItem("w", 3),
 		},
 	}
-	uc := NewMasterCatalogUsecase(repo, nil, newTestLogger())
+	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, newTestLogger())
 
 	out, err := uc.ListPublishedConnection(authedCtx("u1"), MasterCatalogConnectionInput{
 		Last:   intPtr(2),
@@ -249,7 +267,7 @@ func TestListPublishedConnection_Backward_TrimsLeadingRow_SetsHasPrev(t *testing
 
 func TestListPublishedConnection_OrderByName_Desc(t *testing.T) {
 	repo := &mockMasterCatalogRepository{countResult: 0, findPageResult: nil}
-	uc := NewMasterCatalogUsecase(repo, nil, newTestLogger())
+	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, newTestLogger())
 
 	ob := MasterCatalogOrderByName
 	dir := SortOrderDesc
@@ -275,7 +293,7 @@ func TestListPublishedConnection_OrderByName_Desc(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestListPublishedConnection_FirstAndLast_Rejected(t *testing.T) {
-	uc := NewMasterCatalogUsecase(&mockMasterCatalogRepository{}, nil, newTestLogger())
+	uc := NewMasterCatalogUsecase(&mockMasterCatalogRepository{}, &mockCopyMasterToUserUC{}, newTestLogger())
 
 	_, err := uc.ListPublishedConnection(authedCtx("u1"), MasterCatalogConnectionInput{
 		First: intPtr(2),
@@ -296,7 +314,7 @@ func TestListPublishedConnection_TotalCountOnlyRequest(t *testing.T) {
 		countResult:    42,
 		findPageResult: []*repository.MasterCatalogItem{},
 	}
-	uc := NewMasterCatalogUsecase(repo, nil, newTestLogger())
+	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, newTestLogger())
 
 	// first=0 → no rows fetched, but COUNT still runs.
 	out, err := uc.ListPublishedConnection(authedCtx("u1"), MasterCatalogConnectionInput{First: intPtr(0)})
@@ -317,7 +335,7 @@ func TestListPublishedConnection_TotalCountOnlyRequest(t *testing.T) {
 
 func TestListPublishedConnection_InvalidCursor(t *testing.T) {
 	repo := &mockMasterCatalogRepository{countResult: 0}
-	uc := NewMasterCatalogUsecase(repo, nil, newTestLogger())
+	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, newTestLogger())
 
 	bad := "%%%not-a-cursor"
 	_, err := uc.ListPublishedConnection(authedCtx("u1"), MasterCatalogConnectionInput{
@@ -343,7 +361,7 @@ func TestListPublishedConnection_CursorNotPublished(t *testing.T) {
 			return nil, repository.ErrNotFound
 		},
 	}
-	uc := NewMasterCatalogUsecase(repo, nil, newTestLogger())
+	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, newTestLogger())
 
 	_, err := uc.ListPublishedConnection(authedCtx("u1"), MasterCatalogConnectionInput{
 		First: intPtr(2),
@@ -361,7 +379,7 @@ func TestListPublishedConnection_CursorNotPublished(t *testing.T) {
 
 func TestListPublishedConnection_CountError_Wrapped(t *testing.T) {
 	repo := &mockMasterCatalogRepository{countErr: eris.New("db down")}
-	uc := NewMasterCatalogUsecase(repo, nil, newTestLogger())
+	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, newTestLogger())
 
 	_, err := uc.ListPublishedConnection(authedCtx("u1"), MasterCatalogConnectionInput{First: intPtr(2)})
 	if err == nil {
@@ -374,7 +392,7 @@ func TestListPublishedConnection_CountError_Wrapped(t *testing.T) {
 
 func TestListPublishedConnection_FindPageError_Wrapped(t *testing.T) {
 	repo := &mockMasterCatalogRepository{countResult: 1, findPageErr: eris.New("db down")}
-	uc := NewMasterCatalogUsecase(repo, nil, newTestLogger())
+	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, newTestLogger())
 
 	_, err := uc.ListPublishedConnection(authedCtx("u1"), MasterCatalogConnectionInput{First: intPtr(2)})
 	if err == nil {
@@ -432,7 +450,7 @@ func TestResolveMasterCatalogPageSize_DefaultWhenAbsent(t *testing.T) {
 // ImportMaster
 // ---------------------------------------------------------------------------
 
-// mockCopyMasterToUserUC stubs the #398 copy primitive for ImportMaster tests.
+// mockCopyMasterToUserUC stubs the copy primitive (CopyMasterToUserUsecase) for ImportMaster tests.
 type mockCopyMasterToUserUC struct {
 	fn func(ctx context.Context, masterID, ownerID string) (*domain.Cardgroup, error)
 }
@@ -533,4 +551,41 @@ func TestImportMaster_VerifyPublishedError_Wrapped(t *testing.T) {
 
 	_, err := uc.ImportMaster(authedCtx("u1"), "m1")
 	assertInternalChain(t, err, "usecase: master catalog: import: verify published")
+}
+
+func TestImportMaster_FindPublishedByID_ContextCancelled_PassesThrough(t *testing.T) {
+	// context.Canceled from the published-check must propagate unwrapped so its
+	// identity survives errors.Is at the resolver boundary (FromUsecaseError →
+	// CANCELLED). An eris.Wrap here would break the == identity contract.
+	repo := &mockMasterCatalogRepository{
+		findByIDFn: func(string) (*domain.MasterCardgroup, error) {
+			return nil, context.Canceled
+		},
+	}
+	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, newTestLogger())
+
+	_, err := uc.ImportMaster(authedCtx("u1"), "m1")
+	assertCancelled(t, err)
+	if err != context.Canceled {
+		t.Fatalf("expected unwrapped context.Canceled, got %v", err)
+	}
+}
+
+func TestImportMaster_CopyMasterToUser_ContextCancelled_PassesThrough(t *testing.T) {
+	// context.Canceled surfaced by the copy primitive must propagate unwrapped.
+	repo := &mockMasterCatalogRepository{
+		findByIDFn: func(id string) (*domain.MasterCardgroup, error) {
+			return &domain.MasterCardgroup{ID: id, Name: domain.CardgroupName("Deck"), Status: domain.MasterStatusPublished}, nil
+		},
+	}
+	copyUC := &mockCopyMasterToUserUC{fn: func(context.Context, string, string) (*domain.Cardgroup, error) {
+		return nil, context.Canceled
+	}}
+	uc := NewMasterCatalogUsecase(repo, copyUC, newTestLogger())
+
+	_, err := uc.ImportMaster(authedCtx("u1"), "m1")
+	assertCancelled(t, err)
+	if err != context.Canceled {
+		t.Fatalf("expected unwrapped context.Canceled, got %v", err)
+	}
 }

--- a/backend/internal/usecase/master_catalog_test.go
+++ b/backend/internal/usecase/master_catalog_test.go
@@ -103,7 +103,7 @@ func TestNewMasterCatalogUsecase_NilLoggerPanics(t *testing.T) {
 			t.Fatal("expected panic on nil logger")
 		}
 	}()
-	NewMasterCatalogUsecase(&mockMasterCatalogRepository{}, nil)
+	NewMasterCatalogUsecase(&mockMasterCatalogRepository{}, nil, nil)
 }
 
 // ---------------------------------------------------------------------------
@@ -111,7 +111,7 @@ func TestNewMasterCatalogUsecase_NilLoggerPanics(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestListPublishedConnection_Unauthenticated(t *testing.T) {
-	uc := NewMasterCatalogUsecase(&mockMasterCatalogRepository{}, newTestLogger())
+	uc := NewMasterCatalogUsecase(&mockMasterCatalogRepository{}, nil, newTestLogger())
 
 	_, err := uc.ListPublishedConnection(context.Background(), MasterCatalogConnectionInput{})
 	if !errors.Is(err, ucerr.ErrUnauthenticated) {
@@ -131,7 +131,7 @@ func TestListPublishedConnection_Forward_TrimsExtraRow_SetsHasNext(t *testing.T)
 			catalogItem("a", 10), catalogItem("b", 20), catalogItem("c", 30),
 		},
 	}
-	uc := NewMasterCatalogUsecase(repo, newTestLogger())
+	uc := NewMasterCatalogUsecase(repo, nil, newTestLogger())
 
 	out, err := uc.ListPublishedConnection(authedCtx("u1"), MasterCatalogConnectionInput{
 		First: intPtr(2),
@@ -179,7 +179,7 @@ func TestListPublishedConnection_Forward_NoExtraRow_NoNextPage(t *testing.T) {
 		countResult:    2,
 		findPageResult: []*repository.MasterCatalogItem{catalogItem("a", 1), catalogItem("b", 2)},
 	}
-	uc := NewMasterCatalogUsecase(repo, newTestLogger())
+	uc := NewMasterCatalogUsecase(repo, nil, newTestLogger())
 
 	out, err := uc.ListPublishedConnection(authedCtx("u1"), MasterCatalogConnectionInput{First: intPtr(5)})
 	if err != nil {
@@ -210,7 +210,7 @@ func TestListPublishedConnection_Backward_TrimsLeadingRow_SetsHasPrev(t *testing
 			catalogItem("x", 1), catalogItem("y", 2), catalogItem("w", 3),
 		},
 	}
-	uc := NewMasterCatalogUsecase(repo, newTestLogger())
+	uc := NewMasterCatalogUsecase(repo, nil, newTestLogger())
 
 	out, err := uc.ListPublishedConnection(authedCtx("u1"), MasterCatalogConnectionInput{
 		Last:   intPtr(2),
@@ -249,7 +249,7 @@ func TestListPublishedConnection_Backward_TrimsLeadingRow_SetsHasPrev(t *testing
 
 func TestListPublishedConnection_OrderByName_Desc(t *testing.T) {
 	repo := &mockMasterCatalogRepository{countResult: 0, findPageResult: nil}
-	uc := NewMasterCatalogUsecase(repo, newTestLogger())
+	uc := NewMasterCatalogUsecase(repo, nil, newTestLogger())
 
 	ob := MasterCatalogOrderByName
 	dir := SortOrderDesc
@@ -275,7 +275,7 @@ func TestListPublishedConnection_OrderByName_Desc(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestListPublishedConnection_FirstAndLast_Rejected(t *testing.T) {
-	uc := NewMasterCatalogUsecase(&mockMasterCatalogRepository{}, newTestLogger())
+	uc := NewMasterCatalogUsecase(&mockMasterCatalogRepository{}, nil, newTestLogger())
 
 	_, err := uc.ListPublishedConnection(authedCtx("u1"), MasterCatalogConnectionInput{
 		First: intPtr(2),
@@ -296,7 +296,7 @@ func TestListPublishedConnection_TotalCountOnlyRequest(t *testing.T) {
 		countResult:    42,
 		findPageResult: []*repository.MasterCatalogItem{},
 	}
-	uc := NewMasterCatalogUsecase(repo, newTestLogger())
+	uc := NewMasterCatalogUsecase(repo, nil, newTestLogger())
 
 	// first=0 → no rows fetched, but COUNT still runs.
 	out, err := uc.ListPublishedConnection(authedCtx("u1"), MasterCatalogConnectionInput{First: intPtr(0)})
@@ -317,7 +317,7 @@ func TestListPublishedConnection_TotalCountOnlyRequest(t *testing.T) {
 
 func TestListPublishedConnection_InvalidCursor(t *testing.T) {
 	repo := &mockMasterCatalogRepository{countResult: 0}
-	uc := NewMasterCatalogUsecase(repo, newTestLogger())
+	uc := NewMasterCatalogUsecase(repo, nil, newTestLogger())
 
 	bad := "%%%not-a-cursor"
 	_, err := uc.ListPublishedConnection(authedCtx("u1"), MasterCatalogConnectionInput{
@@ -343,7 +343,7 @@ func TestListPublishedConnection_CursorNotPublished(t *testing.T) {
 			return nil, repository.ErrNotFound
 		},
 	}
-	uc := NewMasterCatalogUsecase(repo, newTestLogger())
+	uc := NewMasterCatalogUsecase(repo, nil, newTestLogger())
 
 	_, err := uc.ListPublishedConnection(authedCtx("u1"), MasterCatalogConnectionInput{
 		First: intPtr(2),
@@ -361,7 +361,7 @@ func TestListPublishedConnection_CursorNotPublished(t *testing.T) {
 
 func TestListPublishedConnection_CountError_Wrapped(t *testing.T) {
 	repo := &mockMasterCatalogRepository{countErr: eris.New("db down")}
-	uc := NewMasterCatalogUsecase(repo, newTestLogger())
+	uc := NewMasterCatalogUsecase(repo, nil, newTestLogger())
 
 	_, err := uc.ListPublishedConnection(authedCtx("u1"), MasterCatalogConnectionInput{First: intPtr(2)})
 	if err == nil {
@@ -374,7 +374,7 @@ func TestListPublishedConnection_CountError_Wrapped(t *testing.T) {
 
 func TestListPublishedConnection_FindPageError_Wrapped(t *testing.T) {
 	repo := &mockMasterCatalogRepository{countResult: 1, findPageErr: eris.New("db down")}
-	uc := NewMasterCatalogUsecase(repo, newTestLogger())
+	uc := NewMasterCatalogUsecase(repo, nil, newTestLogger())
 
 	_, err := uc.ListPublishedConnection(authedCtx("u1"), MasterCatalogConnectionInput{First: intPtr(2)})
 	if err == nil {
@@ -426,4 +426,111 @@ func TestResolveMasterCatalogPageSize_DefaultWhenAbsent(t *testing.T) {
 	if first != defaultPageSize || last != 0 {
 		t.Fatalf("want default first=%d last=0, got first=%d last=%d", defaultPageSize, first, last)
 	}
+}
+
+// ---------------------------------------------------------------------------
+// ImportMaster
+// ---------------------------------------------------------------------------
+
+// mockCopyMasterToUserUC stubs the #398 copy primitive for ImportMaster tests.
+type mockCopyMasterToUserUC struct {
+	fn func(ctx context.Context, masterID, ownerID string) (*domain.Cardgroup, error)
+}
+
+func (m *mockCopyMasterToUserUC) CopyMasterToUser(ctx context.Context, masterID, ownerID string) (*domain.Cardgroup, error) {
+	return m.fn(ctx, masterID, ownerID)
+}
+
+func TestImportMaster_Unauthenticated(t *testing.T) {
+	uc := NewMasterCatalogUsecase(&mockMasterCatalogRepository{}, &mockCopyMasterToUserUC{}, newTestLogger())
+
+	_, err := uc.ImportMaster(context.Background(), "m1")
+	if !errors.Is(err, ucerr.ErrUnauthenticated) {
+		t.Fatalf("expected ErrUnauthenticated, got %v", err)
+	}
+}
+
+func TestImportMaster_UnknownOrDraft_ReturnsNotFoundOutcome(t *testing.T) {
+	// Default mock FindPublishedByID returns repository.ErrNotFound (covers both
+	// unknown id and draft — FindPublishedByID filters status='published').
+	repo := &mockMasterCatalogRepository{}
+	copyUC := &mockCopyMasterToUserUC{fn: func(context.Context, string, string) (*domain.Cardgroup, error) {
+		t.Fatal("copy must not run when the master is not published")
+		return nil, nil
+	}}
+	uc := NewMasterCatalogUsecase(repo, copyUC, newTestLogger())
+
+	out, err := uc.ImportMaster(authedCtx("u1"), "missing")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !out.NotFound {
+		t.Fatal("expected NotFound outcome")
+	}
+	if out.Cardgroup != nil {
+		t.Fatal("expected nil cardgroup on NotFound")
+	}
+}
+
+func TestImportMaster_Published_CopiesAndReturnsCardgroup(t *testing.T) {
+	repo := &mockMasterCatalogRepository{
+		findByIDFn: func(id string) (*domain.MasterCardgroup, error) {
+			return &domain.MasterCardgroup{ID: id, Name: domain.CardgroupName("Deck"), Status: domain.MasterStatusPublished}, nil
+		},
+	}
+	want := &domain.Cardgroup{ID: "new-cg", OwnerID: "u1", Name: domain.CardgroupName("Deck")}
+	var gotMaster, gotOwner string
+	copyUC := &mockCopyMasterToUserUC{fn: func(_ context.Context, masterID, ownerID string) (*domain.Cardgroup, error) {
+		gotMaster, gotOwner = masterID, ownerID
+		return want, nil
+	}}
+	uc := NewMasterCatalogUsecase(repo, copyUC, newTestLogger())
+
+	out, err := uc.ImportMaster(authedCtx("u1"), "m1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.NotFound {
+		t.Fatal("did not expect NotFound")
+	}
+	if out.Cardgroup != want {
+		t.Fatalf("expected the copied cardgroup, got %v", out.Cardgroup)
+	}
+	if gotMaster != "m1" || gotOwner != "u1" {
+		t.Fatalf("copy called with (%q,%q), want (m1,u1)", gotMaster, gotOwner)
+	}
+}
+
+func TestImportMaster_CopyError_Wrapped(t *testing.T) {
+	repo := &mockMasterCatalogRepository{
+		findByIDFn: func(id string) (*domain.MasterCardgroup, error) {
+			return &domain.MasterCardgroup{ID: id, Name: domain.CardgroupName("Deck"), Status: domain.MasterStatusPublished}, nil
+		},
+	}
+	copyUC := &mockCopyMasterToUserUC{fn: func(context.Context, string, string) (*domain.Cardgroup, error) {
+		return nil, eris.New("boom")
+	}}
+	uc := NewMasterCatalogUsecase(repo, copyUC, newTestLogger())
+
+	_, err := uc.ImportMaster(authedCtx("u1"), "m1")
+	assertInternalChain(t, err, "usecase: master catalog: import: copy master to user")
+}
+
+func TestImportMaster_VerifyPublishedError_Wrapped(t *testing.T) {
+	// A non-ErrNotFound failure from FindPublishedByID (e.g. a DB outage) is an
+	// internal error, not the errors-as-data NotFound outcome. The copy primitive
+	// must not run when the published-check itself fails.
+	repo := &mockMasterCatalogRepository{
+		findByIDFn: func(string) (*domain.MasterCardgroup, error) {
+			return nil, eris.New("db down")
+		},
+	}
+	copyUC := &mockCopyMasterToUserUC{fn: func(context.Context, string, string) (*domain.Cardgroup, error) {
+		t.Fatal("copy must not run when the published-check fails")
+		return nil, nil
+	}}
+	uc := NewMasterCatalogUsecase(repo, copyUC, newTestLogger())
+
+	_, err := uc.ImportMaster(authedCtx("u1"), "m1")
+	assertInternalChain(t, err, "usecase: master catalog: import: verify published")
 }

--- a/backend/internal/usecase/master_deck.go
+++ b/backend/internal/usecase/master_deck.go
@@ -52,8 +52,8 @@ type SeedForNewUserUsecase interface {
 }
 
 // CopyMasterToUserUsecase snapshots a single master deck into a user-owned
-// cardgroup. Intended for a future master-deck import mutation; the copy is a
-// one-time snapshot with empty FSRS/swipe state.
+// cardgroup. Used by the importMasterCardgroup mutation (via MasterCatalogUsecase.
+// ImportMaster); the copy is a one-time snapshot with empty FSRS/swipe state.
 type CopyMasterToUserUsecase interface {
 	CopyMasterToUser(ctx context.Context, masterID, ownerID string) (*domain.Cardgroup, error)
 }

--- a/docs/backend/ddd-patterns/notfound-collapse-non-disclosure.md
+++ b/docs/backend/ddd-patterns/notfound-collapse-non-disclosure.md
@@ -1,0 +1,63 @@
+# Collapse "unknown" and "exists-but-hidden" into one not-found (non-disclosure gate)
+
+> Part of the [DDD patterns](../../../.claude/rules/ddd-patterns.md) rules.
+
+When a resource has a visibility lifecycle (draft/published, soft-deleted, other-tenant)
+and the caller is **not authorized to know it exists**, the layer that answers the
+request must return the *same* "not found" response for two distinct internal states:
+
+1. the id genuinely does not exist, and
+2. the id exists but the caller may not see it (it is a draft / hidden / not theirs).
+
+Returning a *distinct* response per state — `NOT_FOUND` for unknown, `FORBIDDEN`
+for draft — turns the endpoint into an **existence oracle**: a caller can enumerate
+which ids map to hidden resources by diffing the two error codes. Collapsing both
+into one indistinguishable not-found removes the oracle. (This is the same principle
+as preferring a 404 over a 403 for resources whose very existence is privileged.)
+
+## Mechanism — collapse at the lowest layer, carry it up unchanged
+
+The collapse is cheapest and least bypassable when performed at the **repository**
+read, not reconstructed in the usecase from a richer result:
+
+- **Repository:** the read method is scoped to the visible set, so it cannot
+  distinguish the two states for the caller. `FindPublishedByID` filters
+  `WHERE id = ? AND status = 'published'` and returns `repository.ErrNotFound` for
+  *both* an unknown id and a draft id (`backend/internal/repository/master_cardgroup.go`).
+  A method that returned the row regardless of status and left the status check to
+  the usecase would leak the row's existence to any usecase bug that forgot the check.
+- **Usecase:** maps `ErrNotFound` to a not-found *data* outcome (errors-as-data),
+  not an error. `ImportMaster` returns `ImportMasterOutcome{NotFound: true}, nil`
+  (`backend/internal/usecase/master_catalog.go`). It never branches on draft-vs-unknown
+  because the repository already erased the distinction.
+- **Resolver:** returns a generic, state-free message. `ImportMasterCardgroup`
+  returns `MasterNotFoundError{Message: "Master cardgroup not found"}` — no field
+  reveals whether the id was unknown or a draft.
+
+The docstrings at each layer name the invariant ("draft existence is never leaked")
+so a future maintainer does not "helpfully" split the two cases back apart.
+
+## The boundary — this is for unauthorized observers only
+
+The collapse applies when the caller has no right to know the resource exists. For
+an **owner-facing** read of the same resource, a distinct response is correct and
+expected (the owner may legitimately learn their own draft exists, or get a specific
+`FORBIDDEN` when editing someone else's published resource). Decide per audience:
+erase the distinction only across the trust boundary it protects.
+
+## Proving it
+
+Pin the collapse where it happens, not only end-to-end:
+
+- Repository: a test that a **draft** row returns `ErrNotFound`
+  (`TestMasterCardgroupRepository_FindPublishedByID`) — this is the load-bearing
+  layer; if it regresses, every consumer leaks.
+- Usecase: a test that both an unknown id and a draft (both surfaced as `ErrNotFound`
+  by the repo mock) yield the not-found outcome with the copy/side-effect **not run**
+  (`TestImportMaster_UnknownOrDraft_ReturnsNotFoundOutcome`).
+- Resolver: a test that the not-found outcome maps to the typed error variant with a
+  generic message (`TestMutationResolver_ImportMasterCardgroup_NotFound_ReturnsTypedError`).
+
+Worked example throughout: the `importMasterCardgroup` mutation (issue #401). See also
+[`result-union-errors-as-data.md`](../error-wrapping/result-union-errors-as-data.md)
+for the errors-as-data outcome shape the usecase returns.

--- a/docs/backend/error-wrapping/pin-unwrapped-context-error-with-identity-check.md
+++ b/docs/backend/error-wrapping/pin-unwrapped-context-error-with-identity-check.md
@@ -170,3 +170,25 @@ Pin the contract with identity tests on each branch:
 `_CountDeadlineExceeded_IdentityPreserved` assert `err == context.Canceled` /
 `context.DeadlineExceeded` (bare identity) for the count path, complementing
 the `IsAdmin`-branch tests.
+
+## Delegating to another usecase: the delegate's bare sentinel must survive the outer wrap
+
+When usecase A calls usecase B as a delegate, and B already honors this contract
+(returns a bare `context.Canceled` / `context.DeadlineExceeded` on cancellation),
+A must *still* place `if isContextDone(err) { return ..., err }` before its own
+`eris.Wrap` of B's error. The intuition "B already handles context, so A doesn't
+need to" is backwards: precisely *because* B returns the bare sentinel, A's wrap
+would clobber the identity B worked to preserve. The delegate honoring the
+contract is the reason the outer guard is load-bearing, not a reason to skip it.
+
+Worked example: `MasterCatalogUsecase.ImportMaster`
+(`backend/internal/usecase/master_catalog.go`) gates a master via
+`repo.FindPublishedByID`, then delegates the copy to
+`CopyMasterToUserUsecase.CopyMasterToUser`. `CopyMasterToUser` already returns a
+bare `context.Canceled` (it guards `isContextDone` before its own wrap). Both of
+`ImportMaster`'s error branches — the `FindPublishedByID` infra branch and the
+delegated-copy branch — guard `isContextDone` before `eris.Wrap`, so a
+cancellation surfaced by either path reaches the resolver as the bare sentinel.
+Pinned by `TestImportMaster_FindPublishedByID_ContextCancelled_PassesThrough`
+and `TestImportMaster_CopyMasterToUser_ContextCancelled_PassesThrough`, each
+using the dual assertion (`assertCancelled` + `err != context.Canceled`).

--- a/docs/backend/library-gotchas/constructor-panics-for-non-empty-config.md
+++ b/docs/backend/library-gotchas/constructor-panics-for-non-empty-config.md
@@ -18,6 +18,14 @@ func NewSuperUserPromoter(emails map[string]struct{}, adminRoleID string,
 
 The pattern only applies to config-shaped constructors where one branch (here, the OFF branch) legitimately accepts zero values. For constructors whose contract is "always need these deps" (no OFF branch), panic is equally correct — a nil required dep is still an operator-visible wiring bug, not a runtime input, and the process should crash at boot before accepting requests. See `NewAdminGate` (`backend/internal/usecase/admin_gate.go`) and `NewLearnUsecase` (`backend/internal/usecase/learn.go`) for examples of unconditional nil-guards that panic.
 
+## A dependency exercised by only some interface methods is still required
+
+A subtler case sits between the two above: a constructor dependency that every caller supplies unconditionally, but that only *some* of the interface's methods exercise at runtime. The trap is to reason "method X never touches this dep, so a nil is harmless for an X-only caller" and leave it nil-tolerant. That makes a nil dep — always a wiring bug — fail lazily at the first call to a method that *does* use it (an unattributed nil-interface panic deep inside a request), instead of loudly at boot.
+
+The deciding question is the same as the OFF-branch case: *is there a runtime branch where nil is the intended, correct configuration?* For a config-flag OFF branch the answer is yes (nil deps are deliberate; the feature is disabled). For a dep that is merely unused by some methods the answer is no — nil never means "configured correctly", only "this subset of methods will crash". Guard it at construction.
+
+Worked example: `usecase.NewMasterCatalogUsecase(repo, copyUC, logger)` (`backend/internal/usecase/master_catalog.go`). `copyUC` (`CopyMasterToUserUsecase`) is exercised only by `ImportMaster`; the pre-existing `ListPublishedConnection` never touches it, and its tests legitimately pass a placeholder. An initial implementation panicked only on a nil `logger` and accepted nil `repo`/`copyUC` silently, deferring a nil-interface panic to the first `ImportMaster` call. Three independent review agents flagged it; the fix panics on all three deps at construction. Test code exercising only `ListPublishedConnection` now passes a non-nil placeholder stub rather than `nil`, which also self-documents that the dep is required.
+
 ## Asymmetric guards: panic only when the wire consequence is unrecoverable
 
 When applying panic guards to typed-error constructors, the decision to panic must trace back to the wire-format consequence of the missing value, not to a uniform "non-empty / non-nil" policy.

--- a/schema/master_catalog.graphql
+++ b/schema/master_catalog.graphql
@@ -67,3 +67,30 @@ extend type Query {
     orderDirection: SortOrder = ASC
   ): MasterCatalogConnection!
 }
+
+"""Success variant of `importMasterCardgroup`: the newly created user-owned cardgroup snapshot."""
+type ImportMasterCardgroupSuccess {
+  cardgroup: Cardgroup!
+}
+
+"""
+Typed business error returned by `importMasterCardgroup` when the requested master
+cardgroup does not exist OR is not published. Draft existence is never disclosed:
+both cases collapse to this single error so a caller cannot probe for unpublished decks.
+"""
+type MasterNotFoundError implements UserError {
+  message: String!
+}
+
+"""Result of `importMasterCardgroup`: the imported cardgroup, or a typed not-found error returned as data."""
+union ImportMasterCardgroupResult = ImportMasterCardgroupSuccess | MasterNotFoundError
+
+extend type Mutation {
+  """
+  Copy a published master cardgroup into the authenticated caller's own cardgroups
+  as a one-time snapshot (no live link; FSRS/swipe state starts empty). An unknown id
+  or a draft master returns `MasterNotFoundError` — draft existence is never leaked.
+  Unauthenticated callers receive UNAUTHENTICATED.
+  """
+  importMasterCardgroup(masterCardgroupId: ID!): ImportMasterCardgroupResult!
+}


### PR DESCRIPTION
## Summary

- Adds the **`importMasterCardgroup(masterCardgroupId)` mutation** (backend) — an authenticated user copies a **published** master cardgroup into their own `cardgroups` as a one-time snapshot (no live link; FSRS/swipe state starts empty). Master Catalog Phase 2.
- Modeled as an **errors-as-data outcome union**: `ImportMasterCardgroupResult = ImportMasterCardgroupSuccess | MasterNotFoundError`. An unknown id **or** a draft master both return `MasterNotFoundError` with a generic message — draft existence is never leaked.
- The copy itself is delegated to the existing `CopyMasterToUserUsecase` primitive (#398); this PR adds only the published-gate + auth-gate + wire mapping.

Closes #401

## What changed

- `schema/master_catalog.graphql` — `ImportMasterCardgroupSuccess`, `MasterNotFoundError implements UserError`, `union ImportMasterCardgroupResult`, and `extend type Mutation { importMasterCardgroup(...) }`.
- `backend/internal/usecase/master_catalog.go` — `ImportMaster(ctx, masterID) (ImportMasterOutcome, error)`: require auth (`ucerr.ErrUnauthenticated`); gate via `repo.FindPublishedByID` (its `ErrNotFound` collapses unknown **and** draft into `ImportMasterOutcome{NotFound:true}`); delegate to `copyUC.CopyMasterToUser(ctx, masterID, caller.Sub)`. `CopyMasterToUserUsecase` is injected into `NewMasterCatalogUsecase` (now 3-arg, panics on nil `repo`/`copyUC`/`logger`). Both error branches pass `context.Canceled`/`DeadlineExceeded` through unwrapped via `isContextDone`.
- `backend/graph/resolver/master_catalog.resolvers.go` — `ImportMasterCardgroup` resolver maps the outcome to the union (`gqlerr.FromUsecaseError` for real errors; `NotFound` → `MasterNotFoundError` as data; defensive `gqlerr.Internal` guard for a degenerate no-variant outcome).
- `backend/cmd/server/main.go` — pass the existing `masterDeckUC` (which implements `CopyMasterToUserUsecase`) into the catalog usecase constructor.
- `backend/internal/usecase/master_deck.go` — refresh the now-stale `CopyMasterToUserUsecase` docstring ("future mutation" → names `importMasterCardgroup`).
- Tests: `master_catalog_test.go` (ImportMaster happy/not-found/copy-error/verify-published-error/two context-passthrough cases + three constructor nil-guard tests), `master_catalog_import_test.go` (resolver success/not-found/unauthenticated/infra→INTERNAL/XOR-invariant), `master_catalog_query_test.go` (`stubMasterCatalogUC` gains `ImportMaster`).
- Docs: records three reusable learnings — non-disclosure not-found collapse (`docs/backend/ddd-patterns/notfound-collapse-non-disclosure.md`), partial-dependency nil-guard (`constructor-panics-for-non-empty-config.md`), and delegate-usecase context passthrough (`pin-unwrapped-context-error-with-identity-check.md`).

## Test plan

Run locally from `backend/` (Docker available — full integration suite executed):

```
go build ./... && go vet ./...                 # clean
go tool go-arch-lint check --project-path .    # no layer violations
go run ./cmd/schema-lint                        # 0 violations, 0 drifts
go test -race ./...                             # 0 failures, 23 packages ok
```

The full `-race` suite passed including the testcontainers-backed integration packages (`internal/repository`, `internal/database`, `cmd/server`, `cmd/seed`, `cmd/migrate-to-master`). The new mutation was reviewed by the pr-review-toolkit agents over two rounds until no Critical/Important findings remained. Production diff is ~98 Go lines (within the 800-line ceiling).

## Notes

- **Generated gqlgen output** (`backend/graph/generated/`, `backend/graph/model/models_gen.go`) is `.gitignore`-blocked and regenerated by CI — not committed. Only the hand-written resolver stub in `backend/graph/resolver/master_catalog.resolvers.go` is tracked.
- **Frontend** (`#402`) consumes this mutation and runs `pnpm --filter frontend codegen` — out of scope here.
