### PR TITLE
chore(notion): repoint sync to NOTION_MASTER_CARDGROUP_NAME, drop owner vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,26 +31,18 @@ SUPER_USER_EMAILS=
 # Notion sync settings copied to Render for the backend service.
 NOTION_TOKEN=
 NOTION_PAGE_IDS=
-# Email of the Supabase account that owns the synced cardgroup.
-# make sync-notion-secrets resolves this to a UUID automatically via production
-# Supabase. The account must have signed in to the production app at least once.
-# If you prefer to supply the UUID directly, leave this blank and set
-# NOTION_TARGET_OWNER_ID instead.
-NOTION_TARGET_OWNER_EMAIL=
-# Fallback: set only when NOTION_TARGET_OWNER_EMAIL is blank.
-# NOTION_TARGET_OWNER_ID=
-NOTION_TARGET_CARDGROUP_NAME=
+# Destination master cardgroup name; created when absent. Master cardgroups are
+# owner-less, so no owner email/UUID is required.
+NOTION_MASTER_CARDGROUP_NAME=
 NOTION_SYNC_TOKEN=
 NOTION_MAX_ATTEMPTS=5
 NOTION_MAX_ELAPSED=2m
 
 # Local Supabase Postgres connection string. Run `supabase status` to confirm
-# port (default 54322 for the supabase-cli local stack). Required by
-# notion-local-setup to resolve NOTION_LOCAL_TARGET_OWNER_EMAIL → UUID.
+# port (default 54322 for the supabase-cli local stack).
 SUPABASE_DB_URL=postgresql://postgres:postgres@127.0.0.1:54322/postgres
 
 # Notion sync — local testing only (never pushed to Render; sync-notion-secrets
 # uses an explicit allowlist that excludes NOTION_LOCAL_*).
-NOTION_LOCAL_TARGET_OWNER_EMAIL=
 NOTION_LOCAL_TARGET_CARDGROUP_NAME=Local Notion Test
 NOTION_LOCAL_SYNC_TOKEN=local-dev-token

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -69,7 +69,7 @@ These values target a public API on Render. Revisit if the threat model or deplo
 
 `PORT`, `SHUTDOWN_TIMEOUT`, `NOTION_MAX_ATTEMPTS`, `NOTION_MAX_ELAPSED`, and `SUPER_USER_EMAILS` are optional with safe defaults. The three `SUPABASE_JWT_*` variables, `SUPABASE_DB_URL`, and `PING_TOKEN` are strictly required — the server refuses to start if any is missing.
 
-\* **Optional as a group.** When any of the four `NOTION_*` sync vars (`NOTION_TOKEN`, `NOTION_PAGE_IDS`, `NOTION_MASTER_CARDGROUP_NAME`, `NOTION_SYNC_TOKEN`) is absent or whitespace-only, the `POST /internal/notion-sync` route is disabled and the server still starts — a single `WARN` log line is emitted listing the missing var names (via `OptionalConfigFromEnv` in `run()`). The exception: when the group is otherwise present, `NOTION_PAGE_IDS` must contain at least one non-whitespace ID — a comma/whitespace-only value fails startup. Note: the Makefile and deployment playbook still push `NOTION_TARGET_OWNER_ID` and `NOTION_TARGET_CARDGROUP_NAME` until an operator follow-up updates those scripts; the backend no longer reads those vars.
+\* **Optional as a group.** When any of the four `NOTION_*` sync vars (`NOTION_TOKEN`, `NOTION_PAGE_IDS`, `NOTION_MASTER_CARDGROUP_NAME`, `NOTION_SYNC_TOKEN`) is absent or whitespace-only, the `POST /internal/notion-sync` route is disabled and the server still starts — a single `WARN` log line is emitted listing the missing var names (via `OptionalConfigFromEnv` in `run()`). The exception: when the group is otherwise present, `NOTION_PAGE_IDS` must contain at least one non-whitespace ID — a comma/whitespace-only value fails startup.
 
 ## Testing patterns
 

--- a/docs/notion-sync.md
+++ b/docs/notion-sync.md
@@ -38,20 +38,15 @@ Use this section to run the Notion sync against your local Supabase instance wit
 ### Prerequisites
 
 - Local Supabase is running (`make supabase-start`).
-- You have logged in to the local app at least once via `make dev-frontend` so your developer account's row exists in `auth.users` locally.
 - The root `.env` file is populated with the keys listed below.
 
 ### Required keys in root `.env`
-
-> **Transitional state.** The backend now reads `NOTION_MASTER_CARDGROUP_NAME` to identify the master cardgroup, but `make notion-local-setup` still writes the old `NOTION_LOCAL_TARGET_OWNER_EMAIL` / `NOTION_LOCAL_TARGET_CARDGROUP_NAME` keys into `backend/.env.local`. Until the operator follow-up in the [pending operator step callout](#operational-setup) lands, you must also set `NOTION_MASTER_CARDGROUP_NAME` manually in `backend/.env.local` (or in root `.env` and re-run `make notion-local-setup`) for local master-sync testing to work.
 
 | Key | Purpose |
 |---|---|
 | `NOTION_TOKEN` | Notion integration token (shared with prod). Same workspace as production by default. |
 | `NOTION_PAGE_IDS` | Comma-separated list of Notion page UUIDs to sync (shared with prod). |
-| `NOTION_LOCAL_TARGET_OWNER_EMAIL` | Email of the local Supabase user who will own the synced cardgroup. Resolved to UUID at setup. |
-| `SUPABASE_DB_URL` | Local Supabase Postgres connection string (e.g. `postgresql://postgres:postgres@127.0.0.1:54322/postgres`). Run `supabase status` to confirm. Used to resolve the owner email to its UUID. |
-| `NOTION_LOCAL_TARGET_CARDGROUP_NAME` | Name of the cardgroup that holds locally-synced cards. Kept distinct from prod by convention so a misconfigured `SUPABASE_DB_URL` cannot delete prod data. |
+| `NOTION_LOCAL_TARGET_CARDGROUP_NAME` | Name of the master cardgroup that holds locally-synced cards. Kept distinct from prod by convention so a misconfigured local connection cannot touch prod data. |
 | `NOTION_LOCAL_SYNC_TOKEN` | Bearer token used by the local backend to authenticate the `/internal/notion-sync` POST. Local-only; not pushed to Render. |
 
 #### Hybrid env model: shared vs. local-only keys
@@ -59,9 +54,9 @@ Use this section to run the Notion sync against your local Supabase instance wit
 The local-testing keys split into two groups by design:
 
 - **Shared with prod** — `NOTION_TOKEN` and `NOTION_PAGE_IDS` are read from the same root `.env` keys that the production flow uses. There is no `NOTION_LOCAL_TOKEN`; the same Notion integration token authenticates against the same Notion workspace in both flows.
-- **Local-only** — `NOTION_LOCAL_TARGET_OWNER_EMAIL`, `NOTION_LOCAL_TARGET_CARDGROUP_NAME`, `NOTION_LOCAL_SYNC_TOKEN`, and `SUPABASE_DB_URL` exist solely to point the backend at the local Supabase instance and a local owner/cardgroup. The production sync push (`make sync-notion-secrets`) does not read these — it pushes the prod-specific keys (`NOTION_TARGET_OWNER_ID`, `NOTION_TARGET_CARDGROUP_NAME`, `NOTION_SYNC_TOKEN`) listed in [§ "Required keys in root `.env`"](#required-keys-in-root-env-1) below, and ignores any `NOTION_LOCAL_*` entry.
+- **Local-only** — `NOTION_LOCAL_TARGET_CARDGROUP_NAME` and `NOTION_LOCAL_SYNC_TOKEN` exist solely to point the backend at a local master cardgroup and a local bearer token. The production sync push (`make sync-notion-secrets`) does not read these — it pushes the prod-specific keys (`NOTION_MASTER_CARDGROUP_NAME`, `NOTION_SYNC_TOKEN`) listed in [§ "Required keys in root `.env`"](#required-keys-in-root-env-1) below, and ignores any `NOTION_LOCAL_*` entry.
 
-The `NOTION_LOCAL_*` prefix is the boundary marker: anything under it is consumed only by `make notion-local-setup` and is rewritten into the prod-equivalent key name (e.g. `NOTION_LOCAL_SYNC_TOKEN` → `NOTION_SYNC_TOKEN`) inside `backend/.env.local`. Keeping the cardgroup name distinct from prod by convention also means a misconfigured `SUPABASE_DB_URL` cannot delete prod data.
+The `NOTION_LOCAL_*` prefix is the boundary marker: anything under it is consumed only by `make notion-local-setup` and is rewritten into the prod-equivalent key name (e.g. `NOTION_LOCAL_SYNC_TOKEN` → `NOTION_SYNC_TOKEN`, `NOTION_LOCAL_TARGET_CARDGROUP_NAME` → `NOTION_MASTER_CARDGROUP_NAME`) inside `backend/.env.local`. Keeping the master cardgroup name distinct from prod by convention also means a misconfigured local connection cannot touch prod data.
 
 ### Quickstart
 
@@ -71,41 +66,33 @@ make dev-backend           # in another terminal
 make notion-local-run      # repeat as needed
 ```
 
-`make notion-local-setup` validates that the required keys are present in root `.env`, probes local Supabase connectivity, resolves `NOTION_LOCAL_TARGET_OWNER_EMAIL` to a UUID, then writes the `NOTION_*` keys configured in the Makefile target into `backend/.env.local`. `make dev-backend` starts the backend on `:1323` with those env vars loaded. `make notion-local-run` fires a single authenticated POST to `/internal/notion-sync` and prints the HTTP response body. Backend progress logs appear in the terminal where `make dev-backend` is running.
+`make notion-local-setup` validates that the required keys are present in root `.env`, then writes the `NOTION_*` keys configured in the Makefile target into `backend/.env.local`. `make dev-backend` starts the backend on `:1323` with those env vars loaded. `make notion-local-run` fires a single authenticated POST to `/internal/notion-sync` and prints the HTTP response body. Backend progress logs appear in the terminal where `make dev-backend` is running.
 
 ### Troubleshooting
 
 | Symptom | Fix |
 |---|---|
-| `make notion-local-setup` fails with "log into local app first" | Run `make dev-frontend`, sign in via Google OAuth, then re-run `make notion-local-setup`. |
 | `make notion-local-run` prints "Backend not reachable on :1323" | Start the backend in another terminal with `make dev-backend`, then re-run. |
-| Backend logs show "notion sync: disabled" | Check `backend/.env.local` for the required `NOTION_*` keys (see note above about `NOTION_MASTER_CARDGROUP_NAME`). Re-run `make notion-local-setup` if missing, then restart the backend. |
-| psql probe fails with connection refused | Run `make supabase-start` and wait until the local Supabase stack reports healthy. |
+| Backend logs show "notion sync: disabled" | Check `backend/.env.local` for the four required `NOTION_*` keys (`NOTION_TOKEN`, `NOTION_PAGE_IDS`, `NOTION_MASTER_CARDGROUP_NAME`, `NOTION_SYNC_TOKEN`). Re-run `make notion-local-setup` if missing, then restart the backend. |
 
 For the production sync flow, see [Operational setup](#operational-setup) below.
 
 ## Operational setup
 
-> **Pending operator step (master repoint).** The backend now reads `NOTION_MASTER_CARDGROUP_NAME` and no longer reads `NOTION_TARGET_OWNER_ID` / `NOTION_TARGET_CARDGROUP_NAME`. The deployed Render service env, `render.yaml`, `cloudbuild.yaml`, and the `make sync-notion-*` targets below still reference the old variable names; they are intentionally left unchanged in the code change that repointed the sync because rotating a deployed service's env is a deploy-affecting operation. Before the next production sync run, set `NOTION_MASTER_CARDGROUP_NAME` on the Render service (and update the Makefile push targets) so the scheduler keeps working. The `NOTION_TARGET_*` keys become inert once the new key is set.
+> **Deploy action required.** `render.yaml`, the Ansible playbook, and the `make sync-notion-*` targets now use `NOTION_MASTER_CARDGROUP_NAME` (the backend's variable). The **deployed Render service env still carries the old `NOTION_TARGET_OWNER_ID` / `NOTION_TARGET_CARDGROUP_NAME` keys** until an operator runs Blueprint Manual Sync (which creates the new `NOTION_MASTER_CARDGROUP_NAME` placeholder from `render.yaml`) followed by `make sync-notion-secrets` (which pushes its value from root `.env`). The old `NOTION_TARGET_*` keys are inert once the new key is set and can be deleted from the service manually.
 
 All NOTION_* values are stored in the root `.env` file (gitignored). The Makefile provides three targets that read from that file and push values to the appropriate destinations.
 
 ### Required keys in root `.env`
 
-> **Transitional state.** The backend now reads `NOTION_MASTER_CARDGROUP_NAME` but the Makefile targets and playbook below still push/write the old `NOTION_TARGET_*` keys until the operator follow-up in the [pending operator step callout](#operational-setup) lands. The table below reflects the keys the Makefile currently reads; `NOTION_MASTER_CARDGROUP_NAME` must be set manually on the Render service until those targets are updated.
-
 | Key | Required | Notes |
 |---|---|---|
 | `NOTION_TOKEN` | yes | Notion integration token |
 | `NOTION_PAGE_IDS` | yes | Comma-separated page IDs |
-| `NOTION_TARGET_OWNER_EMAIL` | one of these two | Email of the destination account. `make sync-notion-secrets` resolves it to a UUID automatically via the production Supabase `auth.users` table. The account must have signed in to the production app at least once. |
-| `NOTION_TARGET_OWNER_ID` | one of these two | Manual fallback: UUID from `auth.users.id`. Set only when `NOTION_TARGET_OWNER_EMAIL` is blank. |
-| `NOTION_TARGET_CARDGROUP_NAME` | yes | Destination cardgroup name; created when absent (Makefile only — backend reads `NOTION_MASTER_CARDGROUP_NAME` instead) |
+| `NOTION_MASTER_CARDGROUP_NAME` | yes | Destination master cardgroup name; created when absent. Owner-less — no owner email/UUID is required. |
 | `NOTION_SYNC_TOKEN` | yes | Shared bearer token — written to both Render env and the GHA secret (see note below) |
 | `NOTION_MAX_ATTEMPTS` | no | Defaults to `5` |
 | `NOTION_MAX_ELAPSED` | no | Defaults to `2m` |
-
-`NOTION_TARGET_OWNER_EMAIL` is preferred over `NOTION_TARGET_OWNER_ID` because it eliminates the manual UUID lookup step. When both are set, `NOTION_TARGET_OWNER_EMAIL` takes precedence and the UUID is resolved fresh each run.
 
 `NOTION_SYNC_TOKEN` is deliberately written to **two destinations with the same value**: the Render service env and the `NOTION_SYNC_TOKEN` GitHub Actions secret. This is what guarantees bearer-auth integrity — the backend validates the token in the incoming `Authorization: Bearer` header, and the GHA workflow supplies it as that same secret. If the two values drift, every sync request returns `401`.
 

--- a/playbooks/setup-prod/postapply.yml
+++ b/playbooks/setup-prod/postapply.yml
@@ -14,31 +14,25 @@
 #      vars Phase 4 registered. We don't poll Vercel: the build (~1-2 min) runs
 #      in parallel with the Render poll below, finishing well before the
 #      front-end HEAD probe.
-#   4. Resolve the Notion owner UUID from NOTION_TARGET_OWNER_EMAIL against the
-#      production auth.users table. This runs AFTER the Vercel deploy on
-#      purpose: the email row only exists once the owner has signed in to the
-#      live frontend, so the deploy that enables sign-in must fire first. On a
-#      fresh bring-up the FIRST pass stops here (no row yet) -- sign in once,
-#      then re-run `make setup-prod-postapply` to complete in a second pass.
-#   5. Reconcile the dynamic Render env vars, then POST a deploy to Render and
+#   4. Reconcile the dynamic Render env vars, then POST a deploy to Render and
 #      capture the deploy id.
-#   6. Poll the Render deploy until it reaches "live" (max 15 min, fast-fail
+#   5. Poll the Render deploy until it reaches "live" (max 15 min, fast-fail
 #      on build_failed / update_failed / canceled / deactivated /
 #      pre_deploy_failed). Reaching "live" implies database.Migrate ran on
 #      boot, so the schema (incl. the handle_new_user trigger) now exists.
-#   7. Backfill public.users for any auth.users created before the backend's
+#   6. Backfill public.users for any auth.users created before the backend's
 #      first boot applied migrations. The first operator signs in before this
 #      phase can boot the backend, so their auth.users row predates the bridge
 #      trigger and has no public.users row; this heals the gap idempotently.
-#   8. Grant the admin role to SUPER_USER_EMAILS now that the bridge row exists
+#   7. Grant the admin role to SUPER_USER_EMAILS now that the bridge row exists
 #      (idempotent). Addresses not yet in auth.users are skipped; the same step
 #      is also available standalone via `make seed-admin-prod`.
-#   9. Smoke test backend /health, GraphQL /query, and the production URL HEAD.
-#  10. Print the three URLs and remind the operator that the /profile E2E
+#   8. Smoke test backend /health, GraphQL /query, and the production URL HEAD.
+#   9. Print the three URLs and remind the operator that the /profile E2E
 #      check is a manual step (Google sign-in required).
 #
 # Re-run safety: this phase makes no state-file writes; its DB writes (steps
-# 7-8) are idempotent, so re-running is harmless -- every invocation triggers
+# 6-7) are idempotent, so re-running is harmless -- every invocation triggers
 # a fresh Vercel + Render deploy.
 
 # Postapply cannot run before Phases 3 + 4 have written state, so a
@@ -124,7 +118,7 @@
   loop:
     - NOTION_TOKEN
     - NOTION_PAGE_IDS
-    - NOTION_TARGET_CARDGROUP_NAME
+    - NOTION_MASTER_CARDGROUP_NAME
     - NOTION_SYNC_TOKEN
   tags: [preflight, notion-preflight, notion, notion-secrets, postapply]
 
@@ -136,20 +130,6 @@
 
       Set all of the above in the root .env file and re-run.
   when: (_missing_notion_keys | default([])) | length > 0
-  tags: [preflight, notion-preflight, notion, notion-secrets, postapply]
-
-- name: Fail if neither NOTION_TARGET_OWNER_EMAIL nor NOTION_TARGET_OWNER_ID is set
-  ansible.builtin.fail:
-    msg: |
-      At least one of these must be set in root .env:
-        NOTION_TARGET_OWNER_EMAIL  (preferred) -- email of the destination account;
-                                                  resolved to UUID via production Supabase.
-        NOTION_TARGET_OWNER_ID     (fallback)  -- UUID from auth.users.id, set manually.
-
-      Set one of the above in root .env and re-run.
-  when: >-
-    ((lookup('env', 'NOTION_TARGET_OWNER_EMAIL') | default('')) | trim | length == 0) and
-    ((lookup('env', 'NOTION_TARGET_OWNER_ID')    | default('')) | trim | length == 0)
   tags: [preflight, notion-preflight, notion, notion-secrets, postapply]
 
 # ---------------------------------------------------------------------------
@@ -261,95 +241,6 @@
     msg: "Vercel deploy kicked: {{ vercel_deploy_id }} (build runs in parallel with Render poll)"
 
 # ---------------------------------------------------------------------------
-# Resolve NOTION_TARGET_OWNER_ID.
-#
-# This runs AFTER the Vercel deploy on purpose. Path 1 below resolves the
-# owner email against the production auth.users table, and that row only
-# exists once the owner has signed in to the live frontend. The deploy that
-# makes sign-in possible must therefore fire first; placing this block before
-# the deploy would dead-lock a fresh bring-up (no app -> no sign-in -> no row
-# -> the resolution fails before the deploy that would have unblocked it).
-#
-# Two paths are supported:
-#   1. NOTION_TARGET_OWNER_EMAIL (preferred) -- psql queries the production
-#      Supabase auth.users table using supabase_db_url from the state file,
-#      resolves the email to a UUID, and stores it as _notion_owner_id.
-#      The target account must have signed in to the production app at least
-#      once so the row exists.
-#   2. NOTION_TARGET_OWNER_ID (manual fallback) -- operator supplies the UUID
-#      directly in root .env; _notion_owner_id is set from that value.
-#
-# When NOTION_TARGET_OWNER_EMAIL is set it takes precedence; the fallback is
-# only used when the email key is absent or blank.
-# ---------------------------------------------------------------------------
-- name: Resolve NOTION_TARGET_OWNER_EMAIL to a UUID
-  when: (lookup('env', 'NOTION_TARGET_OWNER_EMAIL') | default('')) | trim | length > 0
-  tags: [notion, notion-secrets, postapply]
-  block:
-    - name: Validate NOTION_TARGET_OWNER_EMAIL format
-      ansible.builtin.fail:
-        msg: |
-          NOTION_TARGET_OWNER_EMAIL does not look like a valid email address:
-            {{ lookup('env', 'NOTION_TARGET_OWNER_EMAIL') | trim }}
-          Fix the value in root .env and re-run.
-      when: >-
-        not (lookup('env', 'NOTION_TARGET_OWNER_EMAIL') | trim
-             | regex_search('^[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}$'))
-
-    - name: Resolve NOTION_TARGET_OWNER_EMAIL to UUID in auth.users
-      # psql interpolates `:'var'` only for queries read from stdin or -f,
-      # never for queries passed via -c. Pipe the SQL through stdin so the
-      # email is bound as a quoted literal (psql escapes it) instead of being
-      # string-concatenated into the query.
-      ansible.builtin.command:
-        argv:
-          - psql
-          - "{{ supabase_db_url }}"
-          - -v
-          - "ON_ERROR_STOP=1"
-          - -v
-          - "email={{ lookup('env', 'NOTION_TARGET_OWNER_EMAIL') | trim }}"
-          - -t
-          - -A
-        stdin: "SELECT id FROM auth.users WHERE lower(email) = lower(:'email');"
-      register: _notion_owner_uuid_result
-      changed_when: false
-
-    - name: Fail if email not found in auth.users
-      ansible.builtin.fail:
-        msg: |
-          No auth.users row for {{ lookup('env', 'NOTION_TARGET_OWNER_EMAIL') }}.
-
-          The Vercel production deploy has already been kicked above, so the
-          frontend is (or will shortly be) live at:
-            {{ production_url }}
-
-          This is the expected first-pass stop on a fresh bring-up:
-            1. Wait for the Vercel build to finish, then sign in once with
-               {{ lookup('env', 'NOTION_TARGET_OWNER_EMAIL') }} so Supabase
-               creates the auth.users row.
-            2. Re-run: make setup-prod-postapply
-          The second pass resolves the UUID and finishes Notion + Render wiring.
-      when: (_notion_owner_uuid_result.stdout | trim) | length == 0
-
-    - name: Fail if duplicate email rows found in auth.users
-      ansible.builtin.fail:
-        msg: |
-          Duplicate email in production auth.users; manual review required.
-          Email: {{ lookup('env', 'NOTION_TARGET_OWNER_EMAIL') }}
-      when: (_notion_owner_uuid_result.stdout | trim).split('\n') | length > 1
-
-    - name: Store resolved owner UUID from email
-      ansible.builtin.set_fact:
-        _notion_owner_id: "{{ _notion_owner_uuid_result.stdout | trim }}"
-
-- name: Use NOTION_TARGET_OWNER_ID when email resolution is skipped
-  ansible.builtin.set_fact:
-    _notion_owner_id: "{{ lookup('env', 'NOTION_TARGET_OWNER_ID') | default('') }}"
-  when: (lookup('env', 'NOTION_TARGET_OWNER_EMAIL') | default('')) | trim | length == 0
-  tags: [notion, notion-secrets, postapply]
-
-# ---------------------------------------------------------------------------
 # Reconcile the dynamic Render env vars from state before triggering deploy.
 #
 # Static env vars (APP_ENV, GRAPHQL_INTROSPECTION, OTEL_TRACES_SAMPLER_ARG,
@@ -402,10 +293,8 @@
           value: "{{ lookup('env', 'NOTION_TOKEN') | default('') }}"
         - key: NOTION_PAGE_IDS
           value: "{{ lookup('env', 'NOTION_PAGE_IDS') | default('') }}"
-        - key: NOTION_TARGET_OWNER_ID
-          value: "{{ _notion_owner_id }}"
-        - key: NOTION_TARGET_CARDGROUP_NAME
-          value: "{{ lookup('env', 'NOTION_TARGET_CARDGROUP_NAME') | default('') }}"
+        - key: NOTION_MASTER_CARDGROUP_NAME
+          value: "{{ lookup('env', 'NOTION_MASTER_CARDGROUP_NAME') | default('') }}"
         - key: NOTION_SYNC_TOKEN
           value: "{{ notion_sync_token }}"
         - key: NOTION_MAX_ATTEMPTS
@@ -760,14 +649,13 @@
 #
 # Migrations -- which create public.users and the auth.users -> public.users
 # bridge trigger -- run only on backend boot (database.Migrate). On a fresh
-# bring-up the first operator MUST sign in before this phase completes: the
-# Notion owner step above gates on their auth.users row, and the backend
-# cannot boot (so cannot migrate) until this phase wires its env and triggers
-# the Render deploy. So the first operator's auth.users row is created before
-# the trigger exists, and no public.users bridge row is made. The Render
-# deploy verified live above has now booted the backend and applied
-# migrations, so the table and trigger exist; this task self-heals that gap
-# idempotently. Later signups are provisioned by the trigger directly.
+# bring-up an operator can sign in to the freshly-deployed frontend before this
+# phase triggers the Render deploy that first boots the backend and applies
+# migrations. Such an operator's auth.users row is created before the trigger
+# exists, so no public.users bridge row is made. The Render deploy verified
+# live above has now booted the backend and applied migrations, so the table
+# and trigger exist; this task self-heals that gap idempotently. Later signups
+# are provisioned by the trigger directly.
 #
 # Without the bridge row, updateProfile (onboarding) fails with INTERNAL
 # (the UPDATE matches 0 rows -> ErrNotFound), and seed-admin-prod fails on the
@@ -796,11 +684,10 @@
 
 # ---------------------------------------------------------------------------
 # Grant the admin role to SUPER_USER_EMAILS now that the bootstrap gap is
-# healed. The Notion owner gate above already blocked the bring-up until the
-# first operator signed in, and the backfill above guarantees the public.users
-# bridge row exists, so the user_roles -> public.users FK can no longer fail.
-# The grant is idempotent and silently skips any address not yet in auth.users,
-# preserving this phase's re-run safety.
+# healed. The backfill above guarantees the public.users bridge row exists for
+# any operator already in auth.users, so the user_roles -> public.users FK can
+# no longer fail. The grant is idempotent and silently skips any address not yet
+# in auth.users, preserving this phase's re-run safety.
 #
 # These tasks also remain available standalone via `make seed-admin-prod`, for
 # granting additional admins who sign in after this phase completes. The two

--- a/playbooks/setup.yml
+++ b/playbooks/setup.yml
@@ -239,8 +239,8 @@
     # --- Notion local-testing wire-up (--tags notion-local only) ---
     # The [notion-local, never] tag set keeps this block out of `make setup` /
     # `make sync-env`; explicit `--tags notion-local` (i.e. `make notion-local-setup`)
-    # overrides `never`. Reads root .env, validates Supabase, resolves the target
-    # user email to a UUID, then upserts 7 NOTION_* keys into backend/.env.local.
+    # overrides `never`. Reads root .env, then upserts the NOTION_* keys the
+    # owner-less master sync needs into backend/.env.local.
     - name: Stat root .env for notion-local
       ansible.builtin.stat:
         path: "{{ repo_root }}/.env"
@@ -300,12 +300,10 @@
         _notion_missing_keys: "{{ _notion_missing_keys + [item] }}"
       when: (_notion_root_kv.get(item, '') | trim('"') | trim) | length == 0
       loop:
-        - NOTION_LOCAL_TARGET_OWNER_EMAIL
         - NOTION_LOCAL_TARGET_CARDGROUP_NAME
         - NOTION_LOCAL_SYNC_TOKEN
         - NOTION_TOKEN
         - NOTION_PAGE_IDS
-        - SUPABASE_DB_URL
       tags: [notion-local, never]
 
     - name: Fail if any required notion-local keys are missing or empty
@@ -317,76 +315,6 @@
       when: _notion_missing_keys | length > 0
       tags: [notion-local, never]
 
-    - name: Probe local Supabase readiness for notion-local
-      ansible.builtin.command:
-        argv:
-          - pg_isready
-          - -d
-          - "{{ _notion_root_kv['SUPABASE_DB_URL'] | trim('\"') }}"
-      register: _notion_pg_ready
-      changed_when: false
-      failed_when: false
-      tags: [notion-local, never]
-
-    - name: Fail if local Supabase is not accepting connections
-      ansible.builtin.fail:
-        msg: |
-          notion-local: local Supabase is not ready.
-          Run `make supabase-start` first, then retry `make notion-local-setup`.
-      when: _notion_pg_ready.rc != 0
-      tags: [notion-local, never]
-
-    - name: Validate NOTION_LOCAL_TARGET_OWNER_EMAIL matches a basic email pattern
-      ansible.builtin.fail:
-        msg: |
-          notion-local: NOTION_LOCAL_TARGET_OWNER_EMAIL does not look like a valid email address.
-          Value: {{ _notion_owner_email }}
-      vars:
-        _notion_owner_email: "{{ _notion_root_kv['NOTION_LOCAL_TARGET_OWNER_EMAIL'] | trim('\"') | trim }}"
-      when: not (_notion_owner_email | regex_search('^[A-Za-z0-9._%+\\-]+@[A-Za-z0-9.\\-]+\\.[A-Za-z]{2,}$'))
-      tags: [notion-local, never]
-
-    # psql interpolates `:'var'` only for queries read from stdin or `-f`,
-    # never for queries passed via `-c`. Pipe the SQL through stdin so the
-    # email is bound as a quoted literal (psql escapes it) instead of being
-    # string-concatenated into the query.
-    - name: Resolve NOTION_LOCAL_TARGET_OWNER_EMAIL to a UUID in auth.users
-      ansible.builtin.command:
-        argv:
-          - psql
-          - "{{ _notion_root_kv['SUPABASE_DB_URL'] | trim('\"') }}"
-          - -v
-          - "ON_ERROR_STOP=1"
-          - -v
-          - "email={{ _notion_root_kv['NOTION_LOCAL_TARGET_OWNER_EMAIL'] | trim('\"') | trim }}"
-          - -t
-          - -A
-        stdin: "SELECT id FROM auth.users WHERE lower(email) = lower(:'email');"
-      register: _notion_owner_uuid_result
-      changed_when: false
-      tags: [notion-local, never]
-
-    - name: Fail if email not found in auth.users (user has not signed in yet)
-      ansible.builtin.fail:
-        msg: |
-          notion-local: no auth.users row for {{ _notion_root_kv['NOTION_LOCAL_TARGET_OWNER_EMAIL'] | trim('"') }}.
-          Log into the local app first via `make dev-frontend`, then retry.
-      when: (_notion_owner_uuid_result.stdout | trim) | length == 0
-      tags: [notion-local, never]
-
-    - name: Fail if duplicate email rows found in auth.users
-      ansible.builtin.fail:
-        msg: |
-          notion-local: duplicate email in local auth.users; manual review required.
-          Email: {{ _notion_root_kv['NOTION_LOCAL_TARGET_OWNER_EMAIL'] | trim('"') }}
-      when: (_notion_owner_uuid_result.stdout | trim).split('\n') | length > 1
-      tags: [notion-local, never]
-
-    - name: Store resolved owner UUID for notion-local
-      ansible.builtin.set_fact:
-        _notion_owner_uuid: "{{ _notion_owner_uuid_result.stdout | trim }}"
-      tags: [notion-local, never]
-
     - name: Upsert NOTION_* keys into backend/.env.local
       ansible.builtin.lineinfile:
         path: "{{ repo_root }}/backend/.env.local"
@@ -395,11 +323,10 @@
         create: false
         mode: "0600"
       loop:
-        - { tgt: NOTION_TOKEN,                 value: "{{ _notion_root_kv['NOTION_TOKEN'] | trim('\"') }}" }
-        - { tgt: NOTION_PAGE_IDS,              value: "{{ _notion_root_kv['NOTION_PAGE_IDS'] | trim('\"') }}" }
-        - { tgt: NOTION_TARGET_OWNER_ID,       value: "{{ _notion_owner_uuid }}" }
-        - { tgt: NOTION_TARGET_CARDGROUP_NAME, value: "{{ _notion_root_kv['NOTION_LOCAL_TARGET_CARDGROUP_NAME'] | trim('\"') }}" }
-        - { tgt: NOTION_SYNC_TOKEN,            value: "{{ _notion_root_kv['NOTION_LOCAL_SYNC_TOKEN'] | trim('\"') }}" }
+        - { tgt: NOTION_TOKEN,                  value: "{{ _notion_root_kv['NOTION_TOKEN'] | trim('\"') }}" }
+        - { tgt: NOTION_PAGE_IDS,               value: "{{ _notion_root_kv['NOTION_PAGE_IDS'] | trim('\"') }}" }
+        - { tgt: NOTION_MASTER_CARDGROUP_NAME,  value: "{{ _notion_root_kv['NOTION_LOCAL_TARGET_CARDGROUP_NAME'] | trim('\"') }}" }
+        - { tgt: NOTION_SYNC_TOKEN,             value: "{{ _notion_root_kv['NOTION_LOCAL_SYNC_TOKEN'] | trim('\"') }}" }
         - { tgt: NOTION_MAX_ATTEMPTS,          value: "{{ _notion_root_kv.get('NOTION_MAX_ATTEMPTS', '5') | trim('\"') }}" }
         - { tgt: NOTION_MAX_ELAPSED,           value: "{{ _notion_root_kv.get('NOTION_MAX_ELAPSED', '2m') | trim('\"') }}" }
       loop_control:
@@ -409,7 +336,7 @@
     - name: Confirm notion-local setup complete
       ansible.builtin.debug:
         msg: >-
-          Wrote 7 NOTION_* keys. Restart backend (`make dev-backend`) to apply,
+          Wrote 6 NOTION_* keys. Restart backend (`make dev-backend`) to apply,
           then run `make notion-local-run`.
       tags: [notion-local, never]
 
@@ -440,13 +367,12 @@
           grep -qE '^{{ item.key }}=' '{{ repo_root }}/.env' ||
           echo '{{ item.key }}={{ item.val }}' >> '{{ repo_root }}/.env'
       loop:
-        - { key: NOTION_TOKEN,                val: "" }
-        - { key: NOTION_PAGE_IDS,             val: "" }
-        - { key: NOTION_TARGET_OWNER_EMAIL,   val: "" }
-        - { key: NOTION_TARGET_CARDGROUP_NAME, val: "" }
-        - { key: NOTION_SYNC_TOKEN,           val: "" }
-        - { key: NOTION_MAX_ATTEMPTS,         val: "5" }
-        - { key: NOTION_MAX_ELAPSED,          val: "2m" }
+        - { key: NOTION_TOKEN,                 val: "" }
+        - { key: NOTION_PAGE_IDS,              val: "" }
+        - { key: NOTION_MASTER_CARDGROUP_NAME, val: "" }
+        - { key: NOTION_SYNC_TOKEN,            val: "" }
+        - { key: NOTION_MAX_ATTEMPTS,          val: "5" }
+        - { key: NOTION_MAX_ELAPSED,           val: "2m" }
       loop_control:
         label: "{{ item.key }}"
       changed_when: false
@@ -457,7 +383,7 @@
         msg: >-
           Seeded NOTION_* placeholders into .env.
           Open .env and fill in: NOTION_TOKEN, NOTION_PAGE_IDS,
-          NOTION_TARGET_OWNER_EMAIL, NOTION_TARGET_CARDGROUP_NAME, NOTION_SYNC_TOKEN.
+          NOTION_MASTER_CARDGROUP_NAME, NOTION_SYNC_TOKEN.
       tags: [notion-env-init, never]
 
     # --- Google OAuth credentials check (root .env) ---

--- a/render.yaml
+++ b/render.yaml
@@ -76,9 +76,7 @@ services:
         sync: false
       - key: NOTION_PAGE_IDS
         sync: false
-      - key: NOTION_TARGET_OWNER_ID
-        sync: false
-      - key: NOTION_TARGET_CARDGROUP_NAME
+      - key: NOTION_MASTER_CARDGROUP_NAME
         sync: false
       - key: NOTION_SYNC_TOKEN
         sync: false


### PR DESCRIPTION
## Summary

- The backend already reads the owner-less `NOTION_MASTER_CARDGROUP_NAME` (master-catalog sync), but the Ansible playbooks, `render.yaml`, `.env.example`, and docs were stale — still seeding/pushing the removed `NOTION_TARGET_OWNER_ID` / `NOTION_TARGET_OWNER_EMAIL` / `NOTION_TARGET_CARDGROUP_NAME` names. Locally this left `POST /internal/notion-sync` **disabled** (the route is skipped whenever `NOTION_MASTER_CARDGROUP_NAME` is absent), and in prod it pushed a key the backend never reads.
- Repoints all infra + docs to `NOTION_MASTER_CARDGROUP_NAME` and removes the now-dead owner-resolution logic — the email→UUID `psql` lookup, the email-format validation, and the local Supabase `pg_isready` probe — from both the local and prod playbooks. Net ~210 fewer lines.
- **No backend code change** — purely infra/docs catch-up to an already-shipped backend rename.

This branch addresses no tracked issue.

## What changed

### Local wire-up (`playbooks/setup.yml`)

- `make notion-local-setup` now writes `NOTION_MASTER_CARDGROUP_NAME` (mapped from `NOTION_LOCAL_TARGET_CARDGROUP_NAME`) into `backend/.env.local`, instead of the old `NOTION_TARGET_CARDGROUP_NAME` + `NOTION_TARGET_OWNER_ID`.
- Removed the owner email→UUID `psql` resolution, the `NOTION_LOCAL_TARGET_OWNER_EMAIL` validation, and the local Supabase `pg_isready` probe (all existed only to resolve the now-gone owner). `notion-env-init` seeds the new key and drops the owner placeholder.

### Prod wire-up (`playbooks/setup-prod/postapply.yml`)

- `make sync-notion-secrets` PUTs `NOTION_MASTER_CARDGROUP_NAME` to the Render service; dropped the `NOTION_TARGET_OWNER_ID` PUT, the entire owner-resolution block, and the "owner email or id required" preflight.
- Updated the phase-flow header comment (removed the owner step, renumbered 5–10 → 4–9) and the backfill / admin-grant rationale comments that referenced the removed owner gate.

### `render.yaml`

- Dropped the `NOTION_TARGET_OWNER_ID` placeholder; renamed `NOTION_TARGET_CARDGROUP_NAME` → `NOTION_MASTER_CARDGROUP_NAME` (`sync: false`).

### `.env.example`

- Replaced the prod owner block + old cardgroup key with `NOTION_MASTER_CARDGROUP_NAME`; dropped `NOTION_LOCAL_TARGET_OWNER_EMAIL`; de-owner-ified the `SUPABASE_DB_URL` comment.

### Docs

- `docs/notion-sync.md` — removed the two "transitional state" callouts, retabled the env keys to the new name, dropped the owner rows + psql-probe troubleshooting, and replaced the "pending operator step" note with a concrete **"Deploy action required"** runbook (Blueprint Manual Sync → `make sync-notion-secrets` → delete orphan keys).
- `docs/backend.md` — dropped the stale "playbook still pushes `NOTION_TARGET_*`" note.

## Verification

- `ansible-playbook --syntax-check` — `setup.yml` and `setup-prod.yml` both pass.
- `render.yaml` parses as valid YAML.
- No dangling Jinja vars after the owner-block removal (`_notion_owner_uuid` / `_notion_pg_ready` / `_notion_owner_id` greps clean).
- Repo-wide grep for the four removed names returns only the single **intentional** reference in `docs/notion-sync.md` (the runbook note that the old keys still sit on the deployed Render service until an operator clears them).
- `.env.example` keys match every consumer: postapply prod-required `{TOKEN, PAGE_IDS, MASTER_CARDGROUP_NAME, SYNC_TOKEN}`, plus `setup.yml`'s notion-local required + upsert-target sets.

## Notes

- **The deployed prod env is NOT touched by this PR.** Rotating a live Render service's env is deploy-affecting, so after merge an operator must: Render Blueprint **Manual Sync** (creates the `NOTION_MASTER_CARDGROUP_NAME` placeholder from `render.yaml`) → `make sync-notion-secrets` (pushes the value) → trigger a redeploy → delete the orphaned `NOTION_TARGET_OWNER_ID` / `NOTION_TARGET_CARDGROUP_NAME` keys. Full runbook in `docs/notion-sync.md` § "Operational setup".
- **Behavior change**: `make setup-prod-postapply` no longer gates the bring-up on the Notion owner signing in (owner is gone). The admin grant stays idempotent and standalone-runnable via `make seed-admin-prod`.
- The GitHub Actions cron (`notion-sync.yml`) needs no change — it POSTs the bearer token and never passes the cardgroup name (a backend env concern).
