### PR TITLE
feat(admin-masters): move new-master action to mobile header

### DIFF
--- a/frontend/src/app/admin/masters/admin-masters-client.tsx
+++ b/frontend/src/app/admin/masters/admin-masters-client.tsx
@@ -410,6 +410,7 @@ export function AdminMastersClient() {
         <Button
           type="button"
           variant="brand"
+          className="hidden md:inline-flex"
           data-testid="admin-masters-new-btn"
           onClick={() => sheet.open({ mode: "new" })}
         >

--- a/frontend/src/components/nav/header-create-action.test.ts
+++ b/frontend/src/components/nav/header-create-action.test.ts
@@ -114,6 +114,15 @@ describe("resolveHeaderCreateAction", () => {
     });
   });
 
+  describe("/admin/masters route", () => {
+    it("returns master action for exact /admin/masters", () => {
+      expect(resolveHeaderCreateAction("/admin/masters")).toEqual({
+        kind: "master",
+        label: "Add new master",
+      });
+    });
+  });
+
   describe("routes that return null", () => {
     it.each([
       ["/"],

--- a/frontend/src/components/nav/header-create-action.ts
+++ b/frontend/src/components/nav/header-create-action.ts
@@ -19,7 +19,10 @@ export type HeaderCreateAction =
     }
   // No href: role creation has no separate-page target — it opens the create
   // sheet by appending ?new=true to the current path (via useSheetSearchParam).
-  | { kind: "role"; label: "Add new role" };
+  | { kind: "role"; label: "Add new role" }
+  // No href: master creation opens the create sheet the same way as role —
+  // ?new=true on the current path (via useSheetSearchParam).
+  | { kind: "master"; label: "Add new master" };
 
 /**
  * Build a `card-with-group` action for the /cardgroups/:id/edit route.
@@ -65,6 +68,7 @@ function cardWithGroupFromLearn(
  * - `/cardgroups/:id/edit` -> create card pre-filled with the cardgroup
  * - `/learn/:id`           -> create card pre-filled with the cardgroup + return param
  * - `/admin/roles`         -> create new role
+ * - `/admin/masters`       -> create new master
  * - anything else          -> `null`
  */
 export function resolveHeaderCreateAction(pathname: string): HeaderCreateAction | null {
@@ -90,6 +94,10 @@ export function resolveHeaderCreateAction(pathname: string): HeaderCreateAction 
 
   if (pathname === "/admin/roles") {
     return { kind: "role", label: "Add new role" };
+  }
+
+  if (pathname === "/admin/masters") {
+    return { kind: "master", label: "Add new master" };
   }
 
   return null;

--- a/frontend/src/components/nav/logo-drawer.test.tsx
+++ b/frontend/src/components/nav/logo-drawer.test.tsx
@@ -320,6 +320,18 @@ describe("<LogoDrawer>", () => {
     expect(target).toContain("new=true");
   });
 
+  it("S-M1: on /admin/masters the '+' (Add new master) opens the create sheet by writing ?new=true to the URL", async () => {
+    const user = userEvent.setup();
+    mockUsePathname.mockReturnValue("/admin/masters");
+    renderWithIntl(<LogoDrawer user={SIGNED_IN_USER} isAdmin={true} />);
+
+    await user.click(screen.getByRole("button", { name: /add new master/i }));
+
+    expect(mockPush).toHaveBeenCalledTimes(1);
+    const target = mockPush.mock.calls[0]?.[0] as string;
+    expect(target).toContain("new=true");
+  });
+
   it("S-G1: on an unknown route (/profile) the '+' button is not rendered", () => {
     mockUsePathname.mockReturnValue("/profile");
     renderWithIntl(<LogoDrawer user={SIGNED_IN_USER} isAdmin={false} />);

--- a/frontend/src/components/nav/logo-drawer.tsx
+++ b/frontend/src/components/nav/logo-drawer.tsx
@@ -36,7 +36,8 @@ export function LogoDrawer({ user, isAdmin }: LogoDrawerProps) {
   // The '+' affordance dispatches a cancelable event so an in-context drawer can
   // claim the action (LearnAddCardSheet / cardgroup / card sheets listen and call
   // preventDefault). When no listener is mounted the event is uncancelled and we
-  // fall back to the full-page route. The role action writes URL state directly.
+  // fall back to the full-page route. The role and master actions write URL
+  // state directly.
   function handleCreate() {
     if (!createAction) return;
     switch (createAction.kind) {
@@ -59,7 +60,11 @@ export function LogoDrawer({ user, isAdmin }: LogoDrawerProps) {
         }
         return;
       }
-      case "role": {
+      // Both role and master have no separate-page target: they open the
+      // create sheet by writing ?new=true to the current path. The page's own
+      // useSheetSearchParam picks it up and renders its create FormSheet.
+      case "role":
+      case "master": {
         open({ mode: "new" });
         return;
       }


### PR DESCRIPTION
## Summary

On the admin masters list (`/admin/masters`), the "New master" primary action now lives in the mobile top-bar `+` (next to the menu trigger) instead of an in-page button, mirroring the existing `/cardgroups` and `/admin/roles` mobile pattern. The desktop layout is unchanged — the in-page button still shows at `md+`.

This branch addresses no tracked issue.

## What changed

### Mobile header `+` action

- `components/nav/header-create-action.ts` — `resolveHeaderCreateAction` now maps `/admin/masters` to a new `{ kind: "master", label: "Add new master" }` descriptor (type union + JSDoc routing rules updated).
- `components/nav/logo-drawer.tsx` — `handleCreate` handles the `master` kind alongside `role`: both open the page's create sheet by writing `?new=true` to the current path (`useSheetSearchParam`), which the masters client picks up and renders its create `FormSheet`.

### In-page button

- `app/admin/masters/admin-masters-client.tsx` — the "New master" `primaryActions` button gains `hidden md:inline-flex`, so it is hidden on mobile (where the header `+` takes over) and shown only on desktop, matching `admin-roles-client.tsx`.

### Tests

- `header-create-action.test.ts` — `resolveHeaderCreateAction("/admin/masters")` returns the master action.
- `logo-drawer.test.tsx` — on `/admin/masters`, clicking the `+` (`aria-label` "Add new master") writes `?new=true` (S-M1, mirroring the role S-R1 case).

## Verification

On a `<md` (mobile) viewport at `/admin/masters` while signed in: the top bar shows a `+` button with `aria-label="Add new master"` between the logo and the menu trigger; tapping it appends `?new=true` and opens the create sheet. The in-page button (`data-testid="admin-masters-new-btn"`) is `display:none` on mobile and visible at `md+`. Reachability holds because `/admin/masters` is not a bare route, so `ConditionalShell` mounts the `AppShell` mobile header that renders the `+`.

## Test plan

- [ ] `pnpm --filter frontend test` — 1284 passed (133 files)
- [ ] `pnpm --filter frontend typecheck` — exit 0
- [ ] `pnpm --filter frontend lint` — exit 0
- [ ] `pnpm --filter frontend knip` — exit 0 (no unused exports)
- [ ] `pnpm --filter frontend build` — exit 0
- [ ] Mobile `/admin/masters`: header `+` opens the create sheet; in-page button hidden
- [ ] Desktop `/admin/masters`: in-page "New master" button still visible; no header `+`
