### PR TITLE
refactor(profile): icon-only edit button beside the title

### DIFF
--- a/frontend/src/app/profile/profile-page-client.test.tsx
+++ b/frontend/src/app/profile/profile-page-client.test.tsx
@@ -95,7 +95,11 @@ describe("<ProfilePageClient>", () => {
       </MockedProvider>,
     );
 
-    await user.click(screen.getByRole("button", { name: /edit profile/i }));
+    const editButton = screen.getByRole("button", { name: /edit profile/i });
+    // Icon-only: the visible label was removed; the accessible name comes from aria-label.
+    expect(editButton).not.toHaveTextContent(/edit profile/i);
+
+    await user.click(editButton);
 
     expect(mockPush).toHaveBeenCalledWith("/profile?edit=self", { scroll: false });
   });

--- a/frontend/src/app/profile/profile-page-client.tsx
+++ b/frontend/src/app/profile/profile-page-client.tsx
@@ -104,37 +104,39 @@ export function ProfilePageClient({ email, initial, displayMode }: Props) {
   return (
     <main className="p-8">
       <div className="mx-auto flex w-full max-w-3xl flex-col gap-8">
-        <section className="flex flex-wrap items-start gap-4 border-b pb-6">
-          <div className="min-w-0 flex-1 space-y-3">
-            <div>
+        <section className="space-y-3 border-b pb-6">
+          <div>
+            <div className="flex items-center gap-1">
               <h1 className="text-2xl font-semibold">{t("title")}</h1>
-              <p className="text-sm text-muted-foreground">{t("readOnlySummary")}</p>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className="size-8 text-muted-foreground"
+                aria-label={t("editProfile")}
+                onClick={() => sheet.open({ mode: "edit", id: PROFILE_SHEET_SENTINEL_ID })}
+              >
+                <Pencil className="h-4 w-4" />
+              </Button>
             </div>
-            <dl className="grid gap-4 sm:grid-cols-3">
-              <div className="space-y-1">
-                <dt className="text-sm font-medium text-muted-foreground">{t("displayName")}</dt>
-                <dd className="break-words text-sm">{initial.displayName || t("notSet")}</dd>
-              </div>
-              <div className="space-y-1">
-                <dt className="text-sm font-medium text-muted-foreground">{t("email")}</dt>
-                <dd className="break-words text-sm">
-                  {email ?? <span className="italic">{t("noEmail")}</span>}
-                </dd>
-              </div>
-              <div className="space-y-1">
-                <dt className="text-sm font-medium text-muted-foreground">{t("bio")}</dt>
-                <dd className="break-words text-sm">{initial.bio || t("notSet")}</dd>
-              </div>
-            </dl>
+            <p className="text-sm text-muted-foreground">{t("readOnlySummary")}</p>
           </div>
-          <Button
-            type="button"
-            variant="outline"
-            onClick={() => sheet.open({ mode: "edit", id: PROFILE_SHEET_SENTINEL_ID })}
-          >
-            <Pencil className="h-4 w-4" />
-            {t("editProfile")}
-          </Button>
+          <dl className="grid gap-4 sm:grid-cols-3">
+            <div className="space-y-1">
+              <dt className="text-sm font-medium text-muted-foreground">{t("displayName")}</dt>
+              <dd className="break-words text-sm">{initial.displayName || t("notSet")}</dd>
+            </div>
+            <div className="space-y-1">
+              <dt className="text-sm font-medium text-muted-foreground">{t("email")}</dt>
+              <dd className="break-words text-sm">
+                {email ?? <span className="italic">{t("noEmail")}</span>}
+              </dd>
+            </div>
+            <div className="space-y-1">
+              <dt className="text-sm font-medium text-muted-foreground">{t("bio")}</dt>
+              <dd className="break-words text-sm">{initial.bio || t("notSet")}</dd>
+            </div>
+          </dl>
         </section>
 
         <section className="space-y-4">


### PR DESCRIPTION
## Summary

The `/profile` edit affordance is simplified from a labeled outline button sitting to the right of the profile details into an icon-only pen button placed directly beside the **Profile** heading. The visible "Edit profile" label is removed; the accessible name is preserved via `aria-label`.

This branch addresses no tracked issue.

## Changes

### Profile header

- `profile-page-client.tsx` — replace the right-aligned `variant="outline"` button (pen icon + `t("editProfile")` text) with a `variant="ghost" size="icon"` button rendered inline next to `<h1>{t("title")}</h1>`. The button keeps `aria-label={t("editProfile")}`, so screen readers and tests still resolve it by name.
- Drop the `flex flex-wrap items-start gap-4` two-column section layout (text block + side button) in favor of a vertical `space-y-3` stack, now that the action lives in the title row.

### Tests

- `profile-page-client.test.tsx` — add a regression assertion that the edit button is icon-only (`not.toHaveTextContent(/edit profile/i)`) while still being reachable by its accessible name; the existing "pushes `?edit=self`" behavior assertion is unchanged.

## Verification

On `/profile`, the **Profile** heading is followed by a borderless pen icon with no visible label text. Hovering shows a subtle background; clicking opens the edit drawer (URL gains `?edit=self`). The button still exposes the localized `editProfile` accessible name (e.g. "Edit profile" in English) via `aria-label`.

## Test plan

- [ ] `pnpm --filter frontend test` — green, including `profile-page-client.test.tsx`
- [ ] `pnpm --filter frontend typecheck` — exit 0
- [ ] `pnpm --filter frontend lint` — no new findings
- [ ] Visual: `/profile` shows the pen icon beside the title with no label text; clicking it opens the edit drawer
