### PR TITLE
refactor(profile): remove read-only summary caption

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -211,7 +211,6 @@
   },
   "Profile": {
     "title": "Profile",
-    "readOnlySummary": "Read-only summary",
     "displayName": "Display name",
     "email": "Email",
     "bio": "Bio",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -211,7 +211,6 @@
   },
   "Profile": {
     "title": "プロフィール",
-    "readOnlySummary": "読み取り専用の概要",
     "displayName": "表示名",
     "email": "メールアドレス",
     "bio": "自己紹介",

--- a/frontend/src/app/profile/profile-page-client.tsx
+++ b/frontend/src/app/profile/profile-page-client.tsx
@@ -119,7 +119,6 @@ export function ProfilePageClient({ email, initial, displayMode }: Props) {
                 <Pencil className="h-4 w-4" />
               </Button>
             </div>
-            <p className="text-sm text-muted-foreground">{t("readOnlySummary")}</p>
           </div>
           <dl className="grid gap-4 sm:grid-cols-3">
             <div className="space-y-1">


### PR DESCRIPTION
## Summary

The `/profile` page no longer renders the muted "Read-only summary" caption that sat directly under the **Profile** heading. The heading is now followed immediately by the Display name / Email / Bio detail grid. The now-unused `readOnlySummary` i18n key is dropped from both message catalogs.

This branch addresses no tracked issue; it is a follow-up to the profile header cleanup in #425.

## Changes

### Profile header

- `profile-page-client.tsx` — remove the `<p className="text-sm text-muted-foreground">{t("readOnlySummary")}</p>` caption line below the title row. No layout wrapper changes; the surrounding `<div>` / `<section>` structure is untouched.

### i18n catalogs

- `messages/en.json` / `messages/ja.json` — delete the `Profile.readOnlySummary` entry from both catalogs (`"Read-only summary"` / `"読み取り専用の概要"`), keeping en/ja key parity. `readOnlySummary` had a single consumer (the line removed above), so the key is now dead.

## Verification

On `/profile`, the **Profile** heading is followed directly by the Display name field — there is no muted caption line between them (no "Read-only summary" in the English UI, no "読み取り専用の概要" in the Japanese UI). `grep -rn "readOnlySummary" frontend/` returns no results.

## Test plan

- [ ] `pnpm --filter frontend test` — green, including `src/app/profile`
- [ ] `pnpm --filter frontend typecheck` — exit 0
- [ ] `pnpm --filter frontend lint` — no new findings
- [ ] Visual: `/profile` shows the title immediately above the Display name field, with no caption line
