### PR TITLE
fix(ui): use destructive variant on data-loss confirm dialogs

### DIFF
--- a/.claude/rules/frontend-design-system.md
+++ b/.claude/rules/frontend-design-system.md
@@ -1,0 +1,56 @@
+# Frontend design system
+
+> Applies to: `frontend/src/**/*.tsx` (UI components, dialogs). Cross-cutting because the
+> color-intent rules below govern every action button and confirm dialog. Source of truth for
+> the token table and rationale: [`docs/frontend/design-system.md`](../../docs/frontend/design-system.md).
+
+The app is **light-only**; the flamingo coral brand and a deep-red danger color are both present.
+The two rules below keep them from colliding and keep destructive actions unmistakable.
+
+## Red is reserved for danger
+
+`destructive` (deep red) means "stop / irreversible". `brand` (flamingo coral) is the primary
+constructive CTA color. They are different tokens doing different jobs:
+
+- **Never style a constructive action** (Save, Create, Login, Import, Publish) with `destructive`.
+  A constructive primary action is `variant="brand"`.
+- **Never leave a destructive action in a neutral variant.** A delete / overwrite / discard action
+  is `variant="destructive"` (or the dialog form below).
+
+Keeping both reds is deliberate — they are token-distinguishable (deep red L≈58 vs. coral L≈74)
+and never render on the same surface, so the brand-red CTAs are kept, not flattened to neutral.
+Full rationale: [`docs/frontend/design-system.md` § "Red is reserved for danger"](../../docs/frontend/design-system.md#red-is-reserved-for-danger).
+
+## Destructive / data-loss confirm dialogs MUST pass `variant="destructive"`
+
+shadcn's [`AlertDialogAction`](../../frontend/src/components/ui/alert-dialog.tsx) defaults to
+`buttonVariants()` → the `default` (neutral near-black) variant. So a confirm button that deletes
+or irreversibly loses data renders **neutral black by default** and reads as a safe "next" button —
+a silent footgun. Every destructive / data-loss confirm MUST opt in explicitly:
+
+```tsx
+import { buttonVariants } from "@/components/ui/button";
+
+<AlertDialogAction className={buttonVariants({ variant: "destructive" })} onClick={onConfirm}>
+  {t("confirmLabel")}
+</AlertDialogAction>
+```
+
+What counts as a danger confirm: permanent delete (single + bulk), overwrite of existing data,
+and discard of unsaved edits. See the worked-example table in
+[`docs/frontend/design-system.md` § "What counts as a danger confirm"](../../docs/frontend/design-system.md#what-counts-as-a-danger-confirm).
+
+### Verification grep
+
+Enumerate every `AlertDialogAction` call site and confirm each destructive one carries the
+destructive variant (the cancel/keep-editing siblings stay `outline`):
+
+```bash
+grep -rn "AlertDialogAction" frontend/src --include='*.tsx' | grep -v test | grep -v "components/ui/alert-dialog.tsx"
+```
+
+Today's danger confirms that MUST carry `buttonVariants({ variant: "destructive" })`:
+`admin-master-form.tsx` (Delete master), `bulk-action-bar.tsx` (bulk delete),
+`cards-new-client.tsx` (Overwrite), `form-sheet.tsx` (Discard).
+`cardgroup-header.tsx` (Delete group) styles its action red inline (`bg-destructive`).
+A confirm with no danger color and a delete/overwrite/discard onClick is a bug, not a style choice.

--- a/docs/frontend/design-system.md
+++ b/docs/frontend/design-system.md
@@ -1,0 +1,137 @@
+# Frontend design system
+
+> Color-token semantics, `Button` variant usage, and the destructive-confirm-dialog
+> convention. The enforceable subset of this doc is mirrored as an auto-loaded rule in
+> [`.claude/rules/frontend-design-system.md`](../../.claude/rules/frontend-design-system.md);
+> this file is the source of truth for the rationale and the lookup tables.
+
+The app is **light-only** — `globals.css` sets `color-scheme: light` so an iOS standalone
+PWA on a dark-mode device does not flash a black backdrop before paint. A `.dark` token
+block exists but is never activated, so the **light-mode token values are what render**.
+The brand is the flamingo coral palette.
+
+Source of truth for the values quoted below:
+[`frontend/src/app/globals.css`](../../frontend/src/app/globals.css) (tokens) and
+[`frontend/src/components/ui/button.tsx`](../../frontend/src/components/ui/button.tsx) (variants).
+
+## Semantic color tokens
+
+The action-button palette resolves to three semantically distinct fills (light mode):
+
+| Token | oklch (L / C / H) | Renders as | Meaning |
+|---|---|---|---|
+| `--primary` | `0.205 / 0 / 0` | near-black, neutral | Neutral default emphasis — **not** a brand or danger signal |
+| `--primary-foreground` | `0.985 / 0 / 0` | near-white | Text on `--primary` |
+| `--brand-primary` | `0.7364 / 0.189 / 18.45` | bright flamingo coral | The product's primary constructive CTA color |
+| `--brand-primary-foreground` | `1 / 0 / 0` | white | Text on `--brand-primary` |
+| `--destructive` | `0.577 / 0.245 / 27.325` | deep blood-red | Danger / irreversible / data-loss |
+| `--destructive-foreground` | `0.985 / 0 / 0` | near-white | Text on `--destructive` |
+| `--secondary` | `0.97 / 0 / 0` | light gray | Low-emphasis secondary |
+
+Adjacent palettes that are **not** part of the action-button system: `--brand-tint*`
+(subtle brand-tinted surfaces) and `--cefr-a/b/c*` (domain difficulty bands, contrast-guarded
+in `cefr-badge.test.tsx`). They do not participate in the red-is-danger rule below.
+
+## Red is reserved for danger
+
+There are two reds in the system and they do different jobs:
+
+- `brand` (CTA) — **bright coral**, lightness ≈ 74%, chroma 0.189, hue 18.
+- `destructive` (danger) — **deep red**, lightness ≈ 58%, chroma 0.245, hue 27.
+
+The principle: **`destructive` red means "stop / irreversible". Never style a constructive
+action (Save, Create, Login) with `destructive`, and never leave a destructive action in a
+neutral variant.** A constructive primary action stays `brand`; a destructive action is
+`destructive`.
+
+Keeping a coral `brand` CTA *and* a danger `destructive` red does **not** create ambiguity,
+for two reasons:
+
+1. **The tokens are distinguishable** — deep red (L58, more saturated) vs. bright coral (L74)
+   read as different colors when seen side by side.
+2. **They never co-locate** — a delete dialog has no Save button; a form's Save has no delete
+   beside it. The "two reds collide" concern is theoretical, not a surface that actually renders.
+
+This is why the brand-red CTAs across the app were deliberately **kept** rather than flattened
+to neutral: the safety goal is met by making destructive actions reliably red, not by removing
+the brand from constructive ones.
+
+## Button variants
+
+[`Button`](../../frontend/src/components/ui/button.tsx) exposes these variants. Pick by intent,
+not by appearance:
+
+| Variant | Fill | Use for |
+|---|---|---|
+| `brand` | flamingo coral | **Primary constructive CTA** — Save, Create, Login, Import, Publish, Study again |
+| `destructive` | deep red | **Destructive / data-loss confirmation** — see the dialog convention below |
+| `outline` | bordered, transparent | Cancel, Keep-editing, toggle-off, secondary action beside a primary |
+| `default` | neutral near-black | Neutral emphasis where neither brand nor danger applies |
+| `secondary` | light gray | Low-emphasis secondary |
+| `ghost` | none until hover | Toolbar / icon-only actions inside dense UI |
+| `link` | text + underline | Inline text-link affordance |
+
+`default` is the cva fallback (`defaultVariants.variant`). Because it is neutral near-black, an
+action that *should* be brand or danger but omits its variant renders as a flat neutral button —
+which is exactly the footgun the next section guards against.
+
+## Destructive and data-loss confirm dialogs
+
+shadcn's [`AlertDialog`](../../frontend/src/components/ui/alert-dialog.tsx) wires its two footer
+buttons like this:
+
+- `AlertDialogCancel` → `buttonVariants({ variant: "outline" })` (white, bordered) — correct default.
+- `AlertDialogAction` → `buttonVariants()` with **no variant** → falls back to `default`
+  (neutral near-black).
+
+So a confirm button that performs a destructive or data-loss action renders **neutral black by
+default** and reads as a safe "next" button. Every such confirm MUST opt into the danger color
+explicitly:
+
+```tsx
+import { buttonVariants } from "@/components/ui/button";
+
+<AlertDialogAction
+  className={buttonVariants({ variant: "destructive" })}
+  onClick={handleConfirmDelete}
+>
+  {t("deleteMasterConfirmButton")}
+</AlertDialogAction>
+```
+
+`AlertDialogAction` already applies `cn(buttonVariants(), className)` internally, and `cn`
+(tailwind-merge) lets the later `bg-destructive` win over the default `bg-primary`, so passing
+the destructive classes via `className` is sufficient — no override of the component is needed.
+
+### What counts as a "danger" confirm
+
+Route the confirm to `destructive` whenever the action **deletes or irreversibly loses data**:
+
+| Action | Example site | Variant |
+|---|---|---|
+| Permanent delete | `admin-master-form.tsx` (Delete master), `cardgroup-header.tsx` (Delete group) | `destructive` |
+| Bulk delete | `bulk-action-bar.tsx` (delete selected cards) | `destructive` |
+| Overwrite existing data | `cards-new-client.tsx` (Overwrite duplicate) | `destructive` |
+| Discard unsaved edits | `form-sheet.tsx` (Discard changes — shared by every form sheet) | `destructive` |
+
+Constructive confirms in the same dialogs stay non-red: `AlertDialogCancel` is `outline`,
+"Keep editing" is `outline`. A constructive *primary* action elsewhere (Save / Create) is `brand`,
+never `destructive`.
+
+## Accessibility notes
+
+- **Color is never the sole signal.** The action label carries the meaning — "Delete master",
+  "Discard" — so a user who does not perceive the red still reads the consequence. Treat the
+  danger color as reinforcement, not as the only cue.
+- **Cancel is the safe default focus.** In a Radix `AlertDialog`, focus lands on `AlertDialogCancel`,
+  so an accidental Enter dismisses rather than confirms a destructive action. Preserve that — do
+  not autofocus the destructive `AlertDialogAction`.
+- **Foreground contrast.** `--destructive-foreground` (near-white) on the deep-red `--destructive`
+  fill, and `--brand-primary-foreground` (white) on coral, are the intended pairings; do not hand-pick
+  a different text color on these fills.
+
+## Further reading
+
+- [`docs/frontend/shadcnui.md`](shadcnui.md) — committed `components.json` and the `cn()` helper.
+- [`docs/frontend/tailwind-4-notes.md`](tailwind-4-notes.md) — CSS-first `@theme` config; where these tokens are exposed as Tailwind colors.
+- [`.claude/rules/frontend-design-system.md`](../../.claude/rules/frontend-design-system.md) — the auto-loaded, enforceable subset of this doc.

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -27,6 +27,7 @@ The frontend package manager is **pnpm** (pinned via `package.json` engines + `p
 - [`docs/frontend/backend-rewrite-contract.md`](../docs/frontend/backend-rewrite-contract.md) — `/api/graphql` rewrite contract.
 - [`docs/frontend/e2e-tests.md`](../docs/frontend/e2e-tests.md) — Playwright + service-role-key handling.
 - [`docs/frontend/tailwind-4-notes.md`](../docs/frontend/tailwind-4-notes.md) — CSS-first config via `@theme`, no `tailwind.config.ts`.
+- [`docs/frontend/design-system.md`](../docs/frontend/design-system.md) — Color-token semantics (brand/destructive/primary), `Button` variant usage, and the destructive-confirm-dialog convention.
 - [`docs/frontend/codegen.md`](../docs/frontend/codegen.md) — `graphql-codegen` wiring and `prebuild` lifecycle.
 - [`docs/frontend/apollo-wiring.md`](../docs/frontend/apollo-wiring.md) — `gqlFetch` for RSC and Apollo client cache patterns.
 - [`docs/frontend/routing-topology.md`](../docs/frontend/routing-topology.md) — HomePage / cardgroup / login / `/cards/new` chains.

--- a/frontend/src/app/admin/masters/admin-master-form.tsx
+++ b/frontend/src/app/admin/masters/admin-master-form.tsx
@@ -15,7 +15,7 @@ import {
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
+import { Button, buttonVariants } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
@@ -351,6 +351,7 @@ export function AdminMasterForm({
                   {tCommon("cancel")}
                 </AlertDialogCancel>
                 <AlertDialogAction
+                  className={buttonVariants({ variant: "destructive" })}
                   data-testid="master-delete-dialog-confirm"
                   disabled={deleting}
                   onClick={handleConfirmDelete}

--- a/frontend/src/app/cardgroups/[id]/cards/components/bulk-action-bar.tsx
+++ b/frontend/src/app/cardgroups/[id]/cards/components/bulk-action-bar.tsx
@@ -13,7 +13,7 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
-import { Button } from "@/components/ui/button";
+import { Button, buttonVariants } from "@/components/ui/button";
 
 export type BulkActionBarProps = {
   count: number;
@@ -51,7 +51,11 @@ export function BulkActionBar({ count, busy, onConfirm, onClear }: BulkActionBar
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel>{tCommon("cancel")}</AlertDialogCancel>
-            <AlertDialogAction data-testid="cards-bulk-confirm" onClick={onConfirm}>
+            <AlertDialogAction
+              className={buttonVariants({ variant: "destructive" })}
+              data-testid="cards-bulk-confirm"
+              onClick={onConfirm}
+            >
               {t("deleteConfirmCount", { count })}
             </AlertDialogAction>
           </AlertDialogFooter>

--- a/frontend/src/app/cards/new/cards-new-client.tsx
+++ b/frontend/src/app/cards/new/cards-new-client.tsx
@@ -19,6 +19,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
+import { buttonVariants } from "@/components/ui/button";
 import { getBackendErrorBanner, getBackendFieldErrors } from "@/lib/apollo/errors";
 import { sanitizeReturnTo } from "@/lib/sanitize-return-to";
 
@@ -108,6 +109,7 @@ function DuplicateOverwriteDialog({
         <AlertDialogFooter>
           <AlertDialogCancel disabled={loading}>{tCommon("cancel")}</AlertDialogCancel>
           <AlertDialogAction
+            className={buttonVariants({ variant: "destructive" })}
             onClick={(e) => {
               // Suppress Radix's default close-on-action behaviour. Closing is
               // driven by the parent clearing `duplicate` after a successful

--- a/frontend/src/components/ui/form-sheet.tsx
+++ b/frontend/src/components/ui/form-sheet.tsx
@@ -12,6 +12,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
+import { buttonVariants } from "@/components/ui/button";
 import {
   Drawer,
   DrawerContent,
@@ -167,7 +168,11 @@ function FormSheet({
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel>{t("keepEditing")}</AlertDialogCancel>
-            <AlertDialogAction disabled={submitting} onClick={discard}>
+            <AlertDialogAction
+              className={buttonVariants({ variant: "destructive" })}
+              disabled={submitting}
+              onClick={discard}
+            >
               {t("discard")}
             </AlertDialogAction>
           </AlertDialogFooter>


### PR DESCRIPTION
## Summary

Destructive and data-loss confirmation dialogs rendered their confirm button in the neutral near-black `default` variant, because shadcn's `AlertDialogAction` falls back to `buttonVariants()` when no variant is passed — so an irreversible action read as a safe "next" button. Each such confirm now opts into `variant="destructive"` (deep red). Brand-red CTAs are intentionally kept rather than flattened to neutral: the two reds are token-distinguishable and never co-locate, so the safety goal is met by making destructive actions reliably red.

This branch addresses no tracked issue.

## Changes

### Destructive confirm dialogs

- `admin-master-form.tsx` (Delete master) — pass `buttonVariants({ variant: "destructive" })` to `AlertDialogAction`; was rendering the neutral `default` (near-black) variant.
- `bulk-action-bar.tsx` (delete selected cards, shown with a "cannot be undone" note) — same fix; this carried the identical defect as Delete master.
- `cards-new-client.tsx` (Overwrite duplicate card) — overwrite of existing data now confirms in red.
- `form-sheet.tsx` (Discard unsaved edits — shared by every form sheet) — discard now confirms in red.

`cardgroup-header.tsx` (Delete group) already styled its action red and is unchanged.

### Design-system documentation

- `docs/frontend/design-system.md` (L2, new) — color-token semantics (`brand` / `destructive` / `primary`), the "red is reserved for danger" principle and why brand-red CTAs are kept, the `Button` variant usage table, and the destructive-confirm-dialog convention with worked examples.
- `.claude/rules/frontend-design-system.md` (L3, new, auto-loaded) — the two enforceable rules (red reserved for danger; destructive/data-loss confirms MUST pass `variant="destructive"`) plus a verification grep, linking back to the L2 doc.
- `frontend/CLAUDE.md` (L1) — topic-docs pointer to the new L2 doc.

## Verification

Open each affected dialog: Delete master (edit a row on `/admin/masters`), bulk delete on a cardgroup's cards page, the Overwrite-duplicate dialog on `/cards/new`, and the Discard-changes dialog of any form sheet. The confirm button now renders the deep-red `destructive` fill (`bg-destructive`, white text) instead of neutral `bg-primary`; the Cancel / Keep-editing sibling stays `outline`.

## Test plan

- [ ] `pnpm --filter frontend typecheck` — exit 0
- [ ] `pnpm --filter frontend lint` — no new findings
- [ ] `pnpm --filter frontend test` — green across `admin/masters`, `cardgroups`, `cards/new`, and `ui/form-sheet`
- [ ] Visual: confirm button is deep red on the Delete master / bulk delete / Overwrite / Discard dialogs, with Cancel remaining outline
