### PR TITLE
feat(onboarding): catalog deck selection on a new /onboarding/start chooser

### DIFF
--- a/.claude/rules/scope-discipline.md
+++ b/.claude/rules/scope-discipline.md
@@ -165,3 +165,15 @@ grep -rln "admin/users" frontend/src frontend/__tests__
 ```
 
 A grep scoped to the co-located file alone (or an agent told to "update the test" that creates a fresh co-located test and stops) leaves any broad page test under `frontend/__tests__/` still pinned to the old behavior. That broad test breaks the full suite, and the gap surfaces only at the orchestrator's full-suite re-run — exactly the resolver-test-compile-failure shape of the backend rule, one tree over.
+
+#### Routing / redirect-flow changes add a THIRD tree: `frontend/e2e/*.spec.ts`
+
+Co-located and broad vitest tests pin a page's *local* behavior (one redirect target, one rendered branch); a Playwright e2e spec pins the *whole redirect chain* end-to-end — and `vitest` never runs it. When a change retargets a `redirect()` / `router.push()` or reorders a redirect chain, the pre-flight grep MUST also cover the e2e tree, keyed on the route string:
+
+```bash
+grep -rln "cardgroups/new?welcome=1\|onboarding" frontend/src frontend/__tests__ frontend/e2e
+```
+
+The e2e tree is the most dangerous one to miss because it cannot be run from a normal worktree — it needs a live Supabase + backend stack and `E2E_SUPABASE_*` env vars — so a broken or silently-altered e2e spec surfaces only in CI, not at the local full-suite re-run.
+
+A worked example: inserting the `/onboarding/start` chooser between OnboardingForm-success and `/cardgroups/new?welcome=1` retargeted the post-onboarding destination. The co-located vitest tests (`onboarding-form.test.tsx`, `page.test.tsx`) were updated, but two e2e specs (`new-user-onboarding.spec.ts`, `display-name-onboarding.spec.ts`) `waitForURL("**/cardgroups/new?welcome=1")` and were silently affected. They stayed green only because the e2e DB seeds no master decks, so `/onboarding/start` hits its empty-catalog fallback to the *same* URL; a populated catalog would have broken both. The fix was to grep `frontend/e2e/` for the route, confirm the fallback keeps the assertions valid, and update the now-stale spec comments to document the new hop. **A conditional redirect that falls back to the old destination on empty data is the trap: the e2e passes by coincidence, so only the grep — not the test run — reveals that the spec's intent has drifted.**

--- a/docs/frontend/codegen.md
+++ b/docs/frontend/codegen.md
@@ -14,6 +14,7 @@ make codegen                     # repo root — runs backend (gqlgen) + fronten
 - **Document discovery**: the client-preset scans `frontend/src/**/*.{ts,tsx}` for `graphql()` tagged templates and includes only the operations actually used.
 - **Lifecycle**: a `prebuild` hook in `frontend/package.json` runs codegen automatically before `pnpm build`. In CI, a dedicated `Codegen (graphql-codegen)` step runs between `Install dependencies` and `Biome check`.
 - `src/generated/**` is NOT in `tsconfig.json`'s `exclude` — generated output participates in `tsc --noEmit`. If codegen produces broken types, typecheck fails fast rather than hiding behind the exclude.
+- **Fragment masking is ON** (client-preset default; `fragment-masking.ts` is generated and in use). A query that spreads `...XFields` exposes a masked ref, not the fields — consumers unmask with `useFragment(XFieldsFragment, ref)` from `@/generated/fragment-masking` (see `app/admin/users/admin-users-client.tsx`, `app/learn/[cardgroupId]/learn-client.tsx`). Test fixtures wrap plain objects with `makeFragmentData(obj, XFieldsFragment)`. Do **not** set `presetConfig: { fragmentMasking: false }` to "simplify" a new fragment: it inlines fragment fields globally and breaks every existing `useFragment` call site (typecheck goes red on `admin-users-client.tsx` first). To extract a shared node fragment for a component used by multiple queries, follow the `admin-users` `useFragment` pattern rather than disabling masking.
 
 Usage pattern:
 

--- a/docs/frontend/onboarding-gate.md
+++ b/docs/frontend/onboarding-gate.md
@@ -27,6 +27,6 @@ The form (`frontend/src/app/onboarding/onboarding-form.tsx`) follows the same Ta
 
 ## Why `/onboarding` bypasses `AppShell`
 
-`/onboarding` is in the root layout's bare-shell branch alongside `/login`. The user has no `displayName` yet — a header that shows their email next to an empty name slot would surface the very state the page is asking them to fix, and the rail's Profile link would offer a competing edit path that has nothing to do with the onboarding flow. Bare-shell focuses the viewport on the single decision the user needs to make.
+`/onboarding` is in `ConditionalShell`'s `BARE_ROUTES` set (`frontend/src/components/conditional-shell.tsx`) alongside `/login` and the first-deck chooser `/onboarding/start`. The user has no `displayName` yet — a header that shows their email next to an empty name slot would surface the very state the page is asking them to fix, and the rail's Profile link would offer a competing edit path that has nothing to do with the onboarding flow. Bare-shell focuses the viewport on the single decision the user needs to make.
 
 Because the page bypasses `AppShell`, it renders its own `<main>` landmark — see [`rsc-error-handling/pages-bypassing-appshell-must-render-main.md`](./rsc-error-handling/pages-bypassing-appshell-must-render-main.md).

--- a/docs/frontend/profile-page-profile.md
+++ b/docs/frontend/profile-page-profile.md
@@ -122,7 +122,7 @@ The mirror uses `Intl.Segmenter` (UAX #29) for `displayName` and `bio` length ch
 We use `@tanstack/react-form` for all forms. No adapter package is needed —
 validators are passed directly as per-field Zod schemas.
 
-The pattern documented in this section — TanStack Form + Apollo `useMutation` + `getBackendFieldErrors` / `getBackendErrorBanner` + the inner `.catch + throw` paired with the outer `.handleSubmit().catch(() => {})` — has two consumers today: `frontend/src/app/profile/profile-form.tsx` (the canonical reference) and `frontend/src/app/onboarding/onboarding-form.tsx` (which submits the same `UpdateProfile` mutation but routes the user forward into `/cardgroups/new?welcome=1` on success). Any third consumer should follow the same shape rather than re-deriving it.
+The pattern documented in this section — TanStack Form + Apollo `useMutation` + `getBackendFieldErrors` / `getBackendErrorBanner` + the inner `.catch + throw` paired with the outer `.handleSubmit().catch(() => {})` — has two consumers today: `frontend/src/app/profile/profile-form.tsx` (the canonical reference) and `frontend/src/app/onboarding/onboarding-form.tsx` (which submits the same `UpdateProfile` mutation but routes the user forward into `/onboarding/start` on success). Any third consumer should follow the same shape rather than re-deriving it.
 shadcn's `form.tsx` wrapper was removed — TanStack Form's render-prop
 API (`<form.Field>`) does not need it. Forms compose primitive shadcn
 components (`Label`, `Input`, `Textarea`) directly.

--- a/docs/frontend/routing-topology.md
+++ b/docs/frontend/routing-topology.md
@@ -10,6 +10,7 @@
 | `/login` (`app/login/page.tsx`) | render `LoginButton` | `/` (delegating the post-login routing decision back to HomePage) |
 | `/auth/callback?code=...` (`app/auth/callback/route.ts`) | n/a | `next` query value, defaulting to `/` (so HomePage owns the post-OAuth landing decision) |
 | `/onboarding` (`app/onboarding/page.tsx`) | `/login` | render `OnboardingForm`; already-onboarded users redirect to `/` (self-guard via `isUserOnboarded`) |
+| `/onboarding/start` (`app/onboarding/start/page.tsx`) | `/login` | first-deck chooser: import a master-catalog deck (→ `/learn/{id}`) or create your own (→ `/cardgroups/new?welcome=1`); not-onboarded self-guard → `/onboarding`; empty catalog → `/cardgroups/new?welcome=1` |
 | `/cards/new?cardgroup=<id>` | `/login` | render chip + `CardForm`; resolves cardgroup via 4-priority chain (see `/cards/new` below) |
 | `/cardgroups/new?welcome=1` | `/login` | render new-cardgroup form with welcome copy (post-onboarding entry) |
 | Admin entry (rail item, admin only) | hidden | `/admin/<sub>` (no `/admin` shim — see "Unified admin layout" in [`profile-page-profile.md`](./profile-page-profile.md)) |
@@ -24,8 +25,10 @@ HomePage (/)
 ├─ !isUserOnboarded(me)           → /onboarding          (highest signed-in priority)
 ├─ me.lastViewedCardgroup != null → /learn/{id}
 ├─ myCardgroupsConnection.totalCount > 0 → /cardgroups
-└─ else                           → /cardgroups/new?welcome=1
+└─ else                           → /onboarding/start
 ```
+
+The terminal `else` (onboarded, no `lastViewedCardgroup`, zero cardgroups) lands on `/onboarding/start`, the first-deck chooser — see its row in the table above. The chooser lets the user import a master-catalog deck or create their own; when the master catalog is empty it falls through to `/cardgroups/new?welcome=1`.
 
 Why `isUserOnboarded` is the highest signed-in priority: a user whose `displayName` was nulled by an admin (or who completed OAuth but never finished `/onboarding`) would otherwise land on `/learn/{lastViewedCardgroup}` or `/cardgroups` with an empty profile — visible to other users — and have no in-product affordance to fix it. The gate sits ahead of the cardgroup branches so the empty-`displayName` state is structurally unreachable on any signed-in surface.
 
@@ -50,7 +53,7 @@ On the `/cards/new?cardgroup=<id>` targets above, the id is supplied by the orig
 1. `searchParams.cardgroup` — accepted only if the id appears in the user's `myCardgroupsConnection` edges. A non-owned id silently falls through (no `BAD_USER_INPUT` surface) so a stale URL after sharing or revoke does not 500.
 2. `me.lastViewedCardgroup.id` — same ownership check (defensive; the FK already cascades).
 3. User has cardgroups but neither (1) nor (2) resolved → render the chip in undetermined state and **force the picker open** so the user explicitly chooses.
-4. `myCardgroupsConnection.totalCount === 0` → `redirect("/cardgroups/new?welcome=1")` — the same target as HomePage's "no cardgroups yet" branch.
+4. `myCardgroupsConnection.totalCount === 0` → `redirect("/cardgroups/new?welcome=1")` — the post-onboarding first-cardgroup screen. (HomePage's "no cardgroups yet" branch routes through `/onboarding/start` first, which falls through to this same screen when the catalog is empty or the user chooses to create their own.)
 
 The URL `?cardgroup=<id>` is the **single source of truth** for the chip + form pair: the picker calls `router.replace("/cards/new?cardgroup=<newId>", { scroll: false })`, and chip / form re-render against the new URL. No client-side state holds a duplicate "selected cardgroup" — eliminates the chip-vs-form drift class of bugs.
 
@@ -121,11 +124,11 @@ Every other surface uses shadcn's slate-based defaults (`--primary`, `--secondar
 
 ### Welcome copy on `/cardgroups/new?welcome=1`
 
-The `?welcome=1` query parameter makes `/cardgroups/new` (already the cardgroup-create page) double as the post-onboarding "first cardgroup" screen by conditionally rendering a welcome banner above the form. The HomePage `else` branch and the `/cards/new` "no cardgroups" priority both target this URL — and so does `OnboardingForm`'s success redirect, since the user has just finished filling in `displayName` and the natural next step is to create their first cardgroup. Without the query parameter, the page renders only the form — same behaviour as before. Driving the difference from the URL keeps the welcome surface statelessly bookmarkable / sharable and avoids a separate `/welcome` route whose only difference would be the copy.
+The `?welcome=1` query parameter makes `/cardgroups/new` (already the cardgroup-create page) double as the post-onboarding "first cardgroup" screen by conditionally rendering a welcome banner above the form. The `/cards/new` "no cardgroups" priority targets this URL directly, as does `/onboarding/start` — both its "create your own" link and its empty-catalog fallback. The HomePage `else` branch and `OnboardingForm`'s success redirect now route through `/onboarding/start` first, landing here when the catalog is empty or the user chooses to create their own. Without the query parameter, the page renders only the form — same behaviour as before. Driving the difference from the URL keeps the welcome surface statelessly bookmarkable / sharable and avoids a separate `/welcome` route whose only difference would be the copy.
 
 ### Bare-shell routes (no `AppShell`)
 
-The root layout in `app/layout.tsx` short-circuits `AppShell` for routes that own the entire viewport without nav chrome. The current bypass set is `/login` and `/onboarding` — `/login` because the sign-in screen owns the viewport, `/onboarding` because the user has no `displayName` yet so a header showing their email next to an empty name slot would surface the very state the page is asking them to fix. Both routes render their own `<main>` landmark — see [`rsc-error-handling/pages-bypassing-appshell-must-render-main.md`](./rsc-error-handling/pages-bypassing-appshell-must-render-main.md).
+`ConditionalShell` (`frontend/src/components/conditional-shell.tsx`) short-circuits `AppShell` for routes that own the entire viewport without nav chrome. The current bypass set (`BARE_ROUTES`) is `/login`, `/onboarding`, `/onboarding/start`, `/terms`, and `/privacy` — `/login` because the sign-in screen owns the viewport; `/onboarding` because the user has no `displayName` yet, so a header showing their email next to an empty name slot would surface the very state the page is asking them to fix; `/onboarding/start` because a deckless user's nav rail would point at empty destinations, and it is part of the same focused onboarding flow; `/terms` and `/privacy` because they are public legal pages. Every bare route renders its own `<main>` landmark — see [`rsc-error-handling/pages-bypassing-appshell-must-render-main.md`](./rsc-error-handling/pages-bypassing-appshell-must-render-main.md).
 
 ### Sign-in page layout (`/login`)
 

--- a/frontend/e2e/display-name-onboarding.spec.ts
+++ b/frontend/e2e/display-name-onboarding.spec.ts
@@ -3,7 +3,11 @@ import { expect, test } from "@playwright/test";
 import { loginAs, seedUser } from "./_auth";
 
 // Scenario: a user whose displayName is empty is redirected from / to /onboarding,
-// fills in a display name, submits, and lands on /cardgroups/new?welcome=1.
+// fills in a display name, and submits. OnboardingForm pushes /onboarding/start
+// (the first-deck chooser); because the e2e DB seeds no master decks, that route
+// hits its empty-catalog fallback and redirects to /cardgroups/new?welcome=1,
+// which is the URL this test waits for. Seeding a master deck would make the
+// chooser render and stay on /onboarding/start instead.
 
 const runId = randomUUID().slice(0, 8);
 const onboarder = {
@@ -24,7 +28,7 @@ test.describe
       });
     });
 
-    test("home redirects to /onboarding, form accepts display name, then lands on /cardgroups/new?welcome=1", async ({
+    test("home redirects to /onboarding, form accepts display name, then lands on /cardgroups/new?welcome=1 via the /onboarding/start chooser fallback", async ({
       context,
       page,
     }) => {
@@ -44,7 +48,9 @@ test.describe
       await displayNameInput.fill("E2E Onboarder");
       await page.getByTestId("onboarding-submit").click();
 
-      // 4. On success, the form's onCompleted callback pushes /cardgroups/new?welcome=1.
+      // 4. On success, the form pushes /onboarding/start (the first-deck chooser).
+      //    With no master decks seeded, /onboarding/start hits its empty-catalog
+      //    fallback and redirects to /cardgroups/new?welcome=1 — the URL we wait for.
       await page.waitForURL("**/cardgroups/new?welcome=1", { timeout: 15_000 });
     });
   });

--- a/frontend/e2e/new-user-onboarding.spec.ts
+++ b/frontend/e2e/new-user-onboarding.spec.ts
@@ -2,10 +2,12 @@ import { randomUUID } from "node:crypto";
 import { expect, test } from "@playwright/test";
 import { loginAs, seedUser } from "./_auth";
 
-// Scenario: a brand-new user (zero cardgroups, no last_viewed) is funnelled
-// into onboarding (/cardgroups/new?welcome=1), creates their first cardgroup,
-// and the nav-header "+" button opens the inline "Add card" FormSheet on the
-// cardgroup edit page (no navigation to /cards/new).
+// Scenario: a brand-new user (zero cardgroups, no last_viewed) is funnelled by
+// the HomePage chain to /onboarding/start (the first-deck chooser). Because the
+// e2e DB seeds no master decks, that route hits its empty-catalog fallback and
+// redirects to /cardgroups/new?welcome=1, where the user creates their first
+// cardgroup; the nav-header "+" button then opens the inline "Add card"
+// FormSheet on the cardgroup edit page (no navigation to /cards/new).
 
 const runId = randomUUID().slice(0, 8);
 const newcomer = {
@@ -28,7 +30,8 @@ test.describe
 
     test.beforeAll(async () => {
       // Seed only the auth user + role; deliberately NO cardgroup so the home
-      // RSC routes to /cardgroups/new?welcome=1 on first login.
+      // RSC routes the deckless-onboarded user to /onboarding/start on first
+      // login (which falls back to /cardgroups/new?welcome=1 — see file header).
       await seedUser({
         email: newcomer.email,
         password: newcomer.password,
@@ -43,7 +46,8 @@ test.describe
     }) => {
       await loginAs(context, newcomer);
 
-      // 1. Home redirects to onboarding because user has no cardgroups.
+      // 1. Home routes the deckless-onboarded user to /onboarding/start, which
+      //    (no master decks seeded) falls back to /cardgroups/new?welcome=1.
       await page.goto("/");
       await page.waitForURL("**/cardgroups/new?welcome=1", { timeout: 10_000 });
       // Use the existing id="welcome-heading" to avoid locale-dependent text matching

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -257,6 +257,22 @@
     "continue": "Continue",
     "sessionExpired": "Your session expired. Please sign in again."
   },
+  "OnboardingStart": {
+    "heading": "Pick your first deck",
+    "catalogTitle": "Start with a ready-made deck",
+    "catalogDescription": "Choose a deck from our catalog and begin learning right away.",
+    "createTitle": "Create your own from scratch",
+    "createDescription": "Prefer to build your own? Start with an empty deck.",
+    "createCta": "Create a deck",
+    "or": "or",
+    "startWithDeck": "Start with this deck",
+    "starting": "Starting...",
+    "imported": "Added",
+    "importError": "Could not start with that deck. Please try again.",
+    "importNotFound": "This deck is no longer available.",
+    "sessionExpired": "Your session has expired. ",
+    "signInAgain": "Sign in again"
+  },
   "AdminMasters": {
     "title": "Masters",
     "description": "Manage master decks shown in the public catalog.",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -257,6 +257,22 @@
     "continue": "続ける",
     "sessionExpired": "セッションの有効期限が切れました。もう一度ログインしてください。"
   },
+  "OnboardingStart": {
+    "heading": "最初のデッキを選びましょう",
+    "catalogTitle": "出来合いのデッキから始める",
+    "catalogDescription": "カタログからデッキを選んで、すぐに学習を始められます。",
+    "createTitle": "自分で一から作る",
+    "createDescription": "自分で作りたい方は、空のデッキから始めましょう。",
+    "createCta": "デッキを作成",
+    "or": "または",
+    "startWithDeck": "このデッキで始める",
+    "starting": "開始中...",
+    "imported": "追加済み",
+    "importError": "このデッキで開始できませんでした。もう一度お試しください。",
+    "importNotFound": "このデッキは利用できなくなりました。",
+    "sessionExpired": "セッションの有効期限が切れました。",
+    "signInAgain": "再度サインイン"
+  },
   "AdminMasters": {
     "title": "マスター",
     "description": "公開カタログに表示するマスターデッキを管理します。",

--- a/frontend/src/app/catalog/catalog-card.test.tsx
+++ b/frontend/src/app/catalog/catalog-card.test.tsx
@@ -84,4 +84,22 @@ describe("<CatalogCard>", () => {
 
     expect(onImport).toHaveBeenCalledWith("m-1");
   });
+
+  it("uses custom labels and a custom testId prefix when provided", () => {
+    renderWithIntl(
+      <CatalogCard
+        node={FULL_NODE}
+        importing={false}
+        imported={false}
+        onImport={vi.fn()}
+        labels={{ action: "Start with this deck", inProgress: "Starting...", done: "Added" }}
+        testIdPrefix="onboarding-deck"
+      />,
+    );
+
+    const btn = screen.getByTestId("onboarding-deck-m-1");
+    expect(btn).toHaveTextContent("Start with this deck");
+    // The default catalog testId must NOT be present when a prefix override is given.
+    expect(screen.queryByTestId("catalog-import-m-1")).toBeNull();
+  });
 });

--- a/frontend/src/app/catalog/catalog-card.tsx
+++ b/frontend/src/app/catalog/catalog-card.tsx
@@ -16,6 +16,13 @@ export type CatalogCardProps = {
   /** True once this deck has been imported in the current session. */
   imported: boolean;
   onImport: (id: string) => void;
+  /**
+   * Optional button label overrides. Defaults reproduce the `/catalog` copy
+   * (`Catalog` namespace) so existing call sites are unaffected.
+   */
+  labels?: { action: string; inProgress: string; done: string };
+  /** Optional `data-testid` prefix. Defaults to `"catalog-import"`. */
+  testIdPrefix?: string;
 };
 
 /**
@@ -24,8 +31,20 @@ export type CatalogCardProps = {
  * which runs in the ja-JP locale — can target it without depending on
  * translated copy. See project memory "E2E runs in Japanese locale".
  */
-export function CatalogCard({ node, importing, imported, onImport }: CatalogCardProps) {
+export function CatalogCard({
+  node,
+  importing,
+  imported,
+  onImport,
+  labels,
+  testIdPrefix,
+}: CatalogCardProps) {
   const t = useTranslations("Catalog");
+
+  const actionLabel = labels?.action ?? t("import");
+  const inProgressLabel = labels?.inProgress ?? t("importing");
+  const doneLabel = labels?.done ?? t("imported");
+  const idPrefix = testIdPrefix ?? "catalog-import";
 
   return (
     <li className="flex flex-col gap-3 rounded-lg border border-border bg-background p-4">
@@ -54,17 +73,17 @@ export function CatalogCard({ node, importing, imported, onImport }: CatalogCard
           size="sm"
           onClick={() => onImport(node.id)}
           disabled={importing || imported}
-          data-testid={`catalog-import-${node.id}`}
+          data-testid={`${idPrefix}-${node.id}`}
         >
           {imported ? (
             <>
               <Check aria-hidden="true" className="h-4 w-4" />
-              <span>{t("imported")}</span>
+              <span>{doneLabel}</span>
             </>
           ) : (
             <>
               <Download aria-hidden="true" className="h-4 w-4" />
-              <span>{importing ? t("importing") : t("import")}</span>
+              <span>{importing ? inProgressLabel : actionLabel}</span>
             </>
           )}
         </Button>

--- a/frontend/src/app/onboarding/onboarding-form.test.tsx
+++ b/frontend/src/app/onboarding/onboarding-form.test.tsx
@@ -93,7 +93,7 @@ describe("<OnboardingForm>", () => {
     });
   });
 
-  it("onCompleted triggers router.push('/cardgroups/new?welcome=1')", async () => {
+  it("onCompleted triggers router.push('/onboarding/start')", async () => {
     const user = userEvent.setup();
 
     const mocks = [makeUpdateProfileMock({ input: { displayName: "Alice" } })];
@@ -110,7 +110,7 @@ describe("<OnboardingForm>", () => {
     await user.click(screen.getByRole("button", { name: /continue/i }));
 
     await waitFor(() => {
-      expect(mockPush).toHaveBeenCalledWith("/cardgroups/new?welcome=1");
+      expect(mockPush).toHaveBeenCalledWith("/onboarding/start");
     });
   });
 

--- a/frontend/src/app/onboarding/onboarding-form.tsx
+++ b/frontend/src/app/onboarding/onboarding-form.tsx
@@ -89,7 +89,7 @@ export function OnboardingForm() {
       }
 
       if (payload?.__typename === "UpdateProfileSuccess") {
-        router.push("/cardgroups/new?welcome=1");
+        router.push("/onboarding/start");
         return;
       }
 

--- a/frontend/src/app/onboarding/start/onboarding-start-client.test.tsx
+++ b/frontend/src/app/onboarding/start/onboarding-start-client.test.tsx
@@ -130,6 +130,18 @@ describe("<OnboardingStartClient>", () => {
     expect(mockPush).not.toHaveBeenCalled();
   });
 
+  it("shows the auth banner with a sign-in link on a forbidden outcome", async () => {
+    const user = userEvent.setup();
+    mockImport.mockResolvedValueOnce({ status: "auth", kind: "forbidden" });
+
+    renderWithIntl(<OnboardingStartClient decks={DECKS} />);
+    await user.click(screen.getByTestId("onboarding-deck-m-1"));
+
+    const banner = await screen.findByTestId("onboarding-import-auth-error");
+    expect(banner.querySelector("a")).toHaveAttribute("href", "/login");
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
   it("serializes imports — a second click while one is in flight is ignored", async () => {
     const user = userEvent.setup();
     let resolve: ((o: ImportMasterOutcome) => void) | undefined;

--- a/frontend/src/app/onboarding/start/onboarding-start-client.test.tsx
+++ b/frontend/src/app/onboarding/start/onboarding-start-client.test.tsx
@@ -1,0 +1,153 @@
+// @vitest-environment jsdom
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ImportMasterOutcome } from "@/app/catalog/use-import-master";
+import { renderWithIntl } from "@/test/render-with-intl";
+import { OnboardingStartClient } from "./onboarding-start-client";
+
+const mockPush = vi.fn();
+vi.mock("next/navigation", () => ({ useRouter: () => ({ push: mockPush }) }));
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    ...rest
+  }: {
+    href: string;
+    children: React.ReactNode;
+    [key: string]: unknown;
+  }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+const mockImport = vi.fn<(id: string) => Promise<ImportMasterOutcome>>();
+vi.mock("@/app/catalog/use-import-master", () => ({
+  useImportMaster: () => ({ importMasterCardgroup: mockImport, loading: false }),
+}));
+
+const DECKS = [
+  {
+    __typename: "MasterCardgroup" as const,
+    id: "m-1",
+    name: "Business English",
+    description: "Professional vocabulary",
+    language: "en",
+    level: "B2",
+    category: "Business",
+    cardCount: 42,
+  },
+  {
+    __typename: "MasterCardgroup" as const,
+    id: "m-2",
+    name: "JLPT N3 Kanji",
+    description: null,
+    language: "ja",
+    level: null,
+    category: null,
+    cardCount: 100,
+  },
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("<OnboardingStartClient>", () => {
+  it("renders a card per deck and the create-your-own link", () => {
+    renderWithIntl(<OnboardingStartClient decks={DECKS} />);
+
+    expect(screen.getByTestId("onboarding-deck-m-1")).toBeInTheDocument();
+    expect(screen.getByTestId("onboarding-deck-m-2")).toBeInTheDocument();
+    expect(screen.getByText("Business English")).toBeInTheDocument();
+    expect(screen.getByTestId("onboarding-create-link")).toHaveAttribute(
+      "href",
+      "/cardgroups/new?welcome=1",
+    );
+  });
+
+  it("imports the chosen deck and navigates to /learn/{id} on success", async () => {
+    const user = userEvent.setup();
+    mockImport.mockResolvedValueOnce({
+      status: "success",
+      cardgroupId: "cg-9",
+      cardgroupName: "Business English",
+    });
+
+    renderWithIntl(<OnboardingStartClient decks={DECKS} />);
+    await user.click(screen.getByTestId("onboarding-deck-m-1"));
+
+    expect(mockImport).toHaveBeenCalledWith("m-1");
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith("/learn/cg-9");
+    });
+  });
+
+  it("shows a generic error banner and does not navigate on a rejected import", async () => {
+    const user = userEvent.setup();
+    mockImport.mockResolvedValueOnce({ status: "rejected" });
+
+    renderWithIntl(<OnboardingStartClient decks={DECKS} />);
+    await user.click(screen.getByTestId("onboarding-deck-m-1"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("onboarding-import-error")).toBeInTheDocument();
+    });
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it("shows the not-found copy on a not_found outcome", async () => {
+    const user = userEvent.setup();
+    mockImport.mockResolvedValueOnce({ status: "not_found" });
+
+    renderWithIntl(<OnboardingStartClient decks={DECKS} />);
+    await user.click(screen.getByTestId("onboarding-deck-m-1"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("onboarding-import-error")).toHaveTextContent(
+        /no longer available/i,
+      );
+    });
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it("shows the auth banner with a sign-in link on an auth outcome", async () => {
+    const user = userEvent.setup();
+    mockImport.mockResolvedValueOnce({ status: "auth", kind: "unauthenticated" });
+
+    renderWithIntl(<OnboardingStartClient decks={DECKS} />);
+    await user.click(screen.getByTestId("onboarding-deck-m-1"));
+
+    const banner = await screen.findByTestId("onboarding-import-auth-error");
+    expect(banner.querySelector("a")).toHaveAttribute("href", "/login");
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it("serializes imports — a second click while one is in flight is ignored", async () => {
+    const user = userEvent.setup();
+    let resolve: ((o: ImportMasterOutcome) => void) | undefined;
+    mockImport.mockReturnValueOnce(
+      new Promise<ImportMasterOutcome>((r) => {
+        resolve = r;
+      }),
+    );
+
+    renderWithIntl(<OnboardingStartClient decks={DECKS} />);
+    await user.click(screen.getByTestId("onboarding-deck-m-1"));
+    await user.click(screen.getByTestId("onboarding-deck-m-2"));
+
+    expect(mockImport).toHaveBeenCalledTimes(1);
+
+    resolve?.({ status: "success", cardgroupId: "cg-9", cardgroupName: "x" });
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith("/learn/cg-9");
+    });
+  });
+});

--- a/frontend/src/app/onboarding/start/onboarding-start-client.tsx
+++ b/frontend/src/app/onboarding/start/onboarding-start-client.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
+import { useCallback, useState } from "react";
+import { CatalogCard } from "@/app/catalog/catalog-card";
+import { useImportMaster } from "@/app/catalog/use-import-master";
+import type { OnboardingStartQuery } from "@/generated/graphql";
+
+type MasterDeckNode = OnboardingStartQuery["masterCatalog"]["edges"][number]["node"];
+
+interface OnboardingStartClientProps {
+  decks: MasterDeckNode[];
+}
+
+/**
+ * Onboarding chooser for a deckless, just-onboarded user. Presents two
+ * first-class paths: import a ready-made master deck (primary) or create an
+ * empty cardgroup (secondary). Single selection — each card's button imports
+ * that deck via `useImportMaster` and, on success, navigates straight to
+ * `/learn/{id}`. Imports are serialized to one at a time via `importingId`.
+ */
+export function OnboardingStartClient({ decks }: OnboardingStartClientProps) {
+  const t = useTranslations("OnboardingStart");
+  const router = useRouter();
+  const { importMasterCardgroup } = useImportMaster();
+
+  const [importingId, setImportingId] = useState<string | null>(null);
+  const [importError, setImportError] = useState<string | null>(null);
+  const [importAuthError, setImportAuthError] = useState<"unauthenticated" | "forbidden" | null>(
+    null,
+  );
+
+  const handleStart = useCallback(
+    async (id: string) => {
+      // Serialize: ignore a second click while another import is in flight.
+      if (importingId !== null) return;
+      setImportError(null);
+      setImportAuthError(null);
+      setImportingId(id);
+
+      const outcome = await importMasterCardgroup(id);
+
+      switch (outcome.status) {
+        case "success":
+          // Leave importingId set so the buttons stay disabled through the
+          // navigation that unmounts this component.
+          router.push(`/learn/${outcome.cardgroupId}`);
+          return;
+        case "not_found":
+          setImportError(t("importNotFound"));
+          setImportingId(null);
+          return;
+        case "auth":
+          setImportAuthError(outcome.kind);
+          setImportingId(null);
+          return;
+        case "rejected":
+          setImportError(t("importError"));
+          setImportingId(null);
+          return;
+      }
+    },
+    [importingId, importMasterCardgroup, router, t],
+  );
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-8">
+      <h1 className="text-2xl font-semibold">{t("heading")}</h1>
+
+      {importAuthError ? (
+        <div
+          role="alert"
+          data-testid="onboarding-import-auth-error"
+          className="rounded-md bg-destructive/10 p-3 text-sm text-destructive"
+        >
+          <span>{t("sessionExpired")}</span>
+          <Link href="/login" className="underline">
+            {t("signInAgain")}
+          </Link>
+        </div>
+      ) : null}
+
+      {importError ? (
+        <div
+          role="alert"
+          data-testid="onboarding-import-error"
+          className="rounded-md bg-destructive/10 p-3 text-sm text-destructive"
+        >
+          {importError}
+        </div>
+      ) : null}
+
+      <section className="space-y-3" aria-labelledby="onboarding-catalog-title">
+        <h2 id="onboarding-catalog-title" className="text-lg font-medium">
+          {t("catalogTitle")}
+        </h2>
+        <p className="text-sm text-muted-foreground">{t("catalogDescription")}</p>
+        <ul
+          className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3"
+          data-testid="onboarding-deck-list"
+        >
+          {decks.map((node) => (
+            <CatalogCard
+              key={node.id}
+              node={node}
+              importing={importingId === node.id}
+              imported={false}
+              onImport={handleStart}
+              labels={{
+                action: t("startWithDeck"),
+                inProgress: t("starting"),
+                done: t("imported"),
+              }}
+              testIdPrefix="onboarding-deck"
+            />
+          ))}
+        </ul>
+      </section>
+
+      <div
+        className="flex items-center gap-3 text-xs uppercase text-muted-foreground"
+        aria-hidden="true"
+      >
+        <span className="h-px flex-1 bg-border" />
+        {t("or")}
+        <span className="h-px flex-1 bg-border" />
+      </div>
+
+      <section
+        className="space-y-3 rounded-lg border border-border p-4"
+        aria-labelledby="onboarding-create-title"
+      >
+        <h2 id="onboarding-create-title" className="text-lg font-medium">
+          {t("createTitle")}
+        </h2>
+        <p className="text-sm text-muted-foreground">{t("createDescription")}</p>
+        <Link
+          href="/cardgroups/new?welcome=1"
+          className="inline-flex items-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground"
+          data-testid="onboarding-create-link"
+        >
+          {t("createCta")}
+        </Link>
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/app/onboarding/start/page.test.tsx
+++ b/frontend/src/app/onboarding/start/page.test.tsx
@@ -1,0 +1,155 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+const REDIRECT_PREFIX = "REDIRECT:";
+
+vi.mock("next/navigation", () => ({
+  redirect: vi.fn((path: string) => {
+    throw new Error(`${REDIRECT_PREFIX}${path}`);
+  }),
+}));
+
+vi.mock("next/headers", () => ({
+  headers: vi.fn(async () => new Headers({ "x-auth-status": "authenticated" })),
+}));
+
+vi.mock("@/lib/apollo/server", () => ({ gqlFetch: vi.fn() }));
+
+// Stub the client — the RSC test only verifies the render branch.
+vi.mock("./onboarding-start-client", () => ({
+  OnboardingStartClient: () => <div data-testid="onboarding-start-client" />,
+}));
+
+import { headers } from "next/headers";
+import { redirect } from "next/navigation";
+import OnboardingStartPage from "@/app/onboarding/start/page";
+import { gqlFetch } from "@/lib/apollo/server";
+
+type DeckNode = {
+  __typename: "MasterCardgroup";
+  id: string;
+  name: string;
+  description: string | null;
+  language: string | null;
+  level: string | null;
+  category: string | null;
+  cardCount: number;
+};
+
+function makeData(
+  opts: { displayName?: string | null; totalCount?: number; nodes?: DeckNode[] } = {},
+) {
+  const nodes: DeckNode[] = opts.nodes ?? [
+    {
+      __typename: "MasterCardgroup",
+      id: "m-1",
+      name: "Business English",
+      description: null,
+      language: "en",
+      level: "B2",
+      category: null,
+      cardCount: 42,
+    },
+  ];
+  return {
+    me: { id: "u-1", displayName: opts.displayName !== undefined ? opts.displayName : "Alice" },
+    masterCatalog: {
+      __typename: "MasterCatalogConnection",
+      edges: nodes.map((n) => ({ __typename: "MasterCatalogEdge", cursor: n.id, node: n })),
+      totalCount: opts.totalCount ?? nodes.length,
+      pageInfo: {
+        __typename: "PageInfo",
+        hasNextPage: false,
+        hasPreviousPage: false,
+        startCursor: nodes[0]?.id ?? null,
+        endCursor: nodes[nodes.length - 1]?.id ?? null,
+      },
+    },
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(headers).mockResolvedValue(new Headers({ "x-auth-status": "authenticated" }));
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("OnboardingStartPage — auth", () => {
+  test("anonymous → /login, gqlFetch not called", async () => {
+    vi.mocked(headers).mockResolvedValue(new Headers({ "x-auth-status": "anonymous" }));
+
+    await expect(OnboardingStartPage()).rejects.toThrow(`${REDIRECT_PREFIX}/login`);
+    expect(redirect).toHaveBeenCalledWith("/login");
+    expect(gqlFetch).not.toHaveBeenCalled();
+  });
+});
+
+describe("OnboardingStartPage — gqlFetch errors", () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+  beforeEach(() => {
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  test("UNAUTHENTICATED from gqlFetch → /login", async () => {
+    vi.mocked(gqlFetch).mockRejectedValueOnce(
+      new Error(`GraphQL errors: ${JSON.stringify([{ extensions: { code: "UNAUTHENTICATED" } }])}`),
+    );
+
+    await expect(OnboardingStartPage()).rejects.toThrow(`${REDIRECT_PREFIX}/login`);
+    expect(redirect).toHaveBeenCalledWith("/login");
+  });
+
+  test("non-UNAUTHENTICATED error → console.error + rethrow", async () => {
+    const otherErr = new Error("GraphQL HTTP 500");
+    vi.mocked(gqlFetch).mockRejectedValueOnce(otherErr);
+
+    await expect(OnboardingStartPage()).rejects.toBe(otherErr);
+    expect(redirect).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("[onboarding-start]"),
+      expect.anything(),
+    );
+  });
+});
+
+describe("OnboardingStartPage — guards & fallback", () => {
+  test("not onboarded (displayName null) → /onboarding", async () => {
+    vi.mocked(gqlFetch).mockResolvedValueOnce(makeData({ displayName: null }) as never);
+
+    await expect(OnboardingStartPage()).rejects.toThrow(`${REDIRECT_PREFIX}/onboarding`);
+    expect(redirect).toHaveBeenCalledWith("/onboarding");
+  });
+
+  test("empty catalog (totalCount 0) → /cardgroups/new?welcome=1", async () => {
+    vi.mocked(gqlFetch).mockResolvedValueOnce(makeData({ totalCount: 0, nodes: [] }) as never);
+
+    await expect(OnboardingStartPage()).rejects.toThrow(
+      `${REDIRECT_PREFIX}/cardgroups/new?welcome=1`,
+    );
+    expect(redirect).toHaveBeenCalledWith("/cardgroups/new?welcome=1");
+  });
+
+  test("null masterCatalog → console.error + throws", async () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.mocked(gqlFetch).mockResolvedValueOnce({
+      me: { id: "u-1", displayName: "Alice" },
+      masterCatalog: null,
+    } as never);
+
+    await expect(OnboardingStartPage()).rejects.toThrow(/masterCatalog missing/);
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining("[onboarding-start]"));
+  });
+});
+
+describe("OnboardingStartPage — render", () => {
+  test("populated catalog renders the client inside a <main> landmark", async () => {
+    vi.mocked(gqlFetch).mockResolvedValueOnce(makeData({ displayName: "Alice" }) as never);
+
+    const result = await OnboardingStartPage();
+
+    expect(redirect).not.toHaveBeenCalled();
+    expect((result as { type?: unknown }).type).toBe("main");
+  });
+});

--- a/frontend/src/app/onboarding/start/page.tsx
+++ b/frontend/src/app/onboarding/start/page.tsx
@@ -1,0 +1,52 @@
+import type { Metadata } from "next";
+import { headers } from "next/headers";
+import { redirect } from "next/navigation";
+import type { OnboardingStartQuery as OnboardingStartQueryType } from "@/generated/graphql";
+import { isUnauthenticatedGraphQLError } from "@/lib/apollo/graphql-errors";
+import { gqlFetch } from "@/lib/apollo/server";
+import { isUserOnboarded } from "@/lib/auth/onboarding";
+import { readAuthContext } from "@/lib/supabase/auth-status";
+import { OnboardingStartClient } from "./onboarding-start-client";
+import { OnboardingStartQuery } from "./queries";
+
+export const metadata: Metadata = { title: "Get started" };
+
+/**
+ * Chooser step for a just-onboarded, deckless user. Reached from the HomePage
+ * redirect chain and from OnboardingForm success. Self-guards the
+ * not-onboarded direct-URL bypass and falls back to the create screen when the
+ * catalog is empty. Bypasses AppShell (bare route), so it renders its own
+ * <main> landmark.
+ */
+export default async function OnboardingStartPage() {
+  if (readAuthContext(await headers()).status !== "authenticated") redirect("/login");
+
+  let data: OnboardingStartQueryType;
+  try {
+    data = await gqlFetch(OnboardingStartQuery, { revalidate: 0 });
+  } catch (err) {
+    if (isUnauthenticatedGraphQLError(err)) redirect("/login");
+    console.error(
+      "[onboarding-start] gqlFetch failed:",
+      err instanceof Error ? err.name : "unknown",
+    );
+    throw err;
+  }
+
+  if (!isUserOnboarded(data.me)) redirect("/onboarding");
+
+  const catalog = data.masterCatalog;
+  if (!catalog) {
+    console.error("[onboarding-start] masterCatalog is null — partial response from backend");
+    throw new Error("masterCatalog missing from onboarding-start data");
+  }
+  if (catalog.totalCount === 0) redirect("/cardgroups/new?welcome=1");
+
+  const decks = catalog.edges.map((edge) => edge.node);
+
+  return (
+    <main className="p-8">
+      <OnboardingStartClient decks={decks} />
+    </main>
+  );
+}

--- a/frontend/src/app/onboarding/start/page.tsx
+++ b/frontend/src/app/onboarding/start/page.tsx
@@ -26,6 +26,9 @@ export default async function OnboardingStartPage() {
     data = await gqlFetch(OnboardingStartQuery, { revalidate: 0 });
   } catch (err) {
     if (isUnauthenticatedGraphQLError(err)) redirect("/login");
+    // err.message is omitted deliberately — gqlFetch error messages can carry
+    // backend-echoed content; err.name is sufficient for triage. Same posture as
+    // catalog/page.tsx. See docs/frontend/rsc-error-handling/redact-err-message-from-console-payloads.md.
     console.error(
       "[onboarding-start] gqlFetch failed:",
       err instanceof Error ? err.name : "unknown",

--- a/frontend/src/app/onboarding/start/queries.ts
+++ b/frontend/src/app/onboarding/start/queries.ts
@@ -1,0 +1,30 @@
+import { graphql } from "@/generated";
+
+// Auth-sensitive — callers MUST pass `revalidate: 0` to gqlFetch.
+//
+// `me { displayName }` drives the not-onboarded self-guard; `masterCatalog`
+// supplies the chooser gallery (first 20, no pagination in onboarding) and the
+// `totalCount === 0` empty-catalog fallback.
+export const OnboardingStartQuery = graphql(`
+  query OnboardingStart {
+    me {
+      id
+      displayName
+    }
+    masterCatalog(first: 20) {
+      edges {
+        cursor
+        node {
+          id
+          name
+          description
+          language
+          level
+          category
+          cardCount
+        }
+      }
+      totalCount
+    }
+  }
+`);

--- a/frontend/src/app/page.test.tsx
+++ b/frontend/src/app/page.test.tsx
@@ -175,7 +175,7 @@ describe("HomePage (root redirect)", () => {
     expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining("[home]"));
   });
 
-  test("onboarded user with no lastViewed and no cardgroups → /cardgroups/new?welcome=1", async () => {
+  test("onboarded user with no lastViewed and no cardgroups → /onboarding/start", async () => {
     vi.mocked(gqlFetch).mockResolvedValueOnce({
       me: { id: "u-1", displayName: "Alice", lastViewedCardgroup: null },
       myCardgroupsConnection: {
@@ -192,7 +192,7 @@ describe("HomePage (root redirect)", () => {
       },
     } as never);
 
-    await expect(HomePage()).rejects.toThrow(`${REDIRECT_PREFIX}/cardgroups/new?welcome=1`);
-    expect(redirect).toHaveBeenCalledWith("/cardgroups/new?welcome=1");
+    await expect(HomePage()).rejects.toThrow(`${REDIRECT_PREFIX}/onboarding/start`);
+    expect(redirect).toHaveBeenCalledWith("/onboarding/start");
   });
 });

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -41,5 +41,5 @@ export default async function HomePage() {
     redirect("/cardgroups");
   }
 
-  redirect("/cardgroups/new?welcome=1");
+  redirect("/onboarding/start");
 }

--- a/frontend/src/app/queries.ts
+++ b/frontend/src/app/queries.ts
@@ -6,7 +6,7 @@ import { graphql } from "@/generated";
  * Used to decide where to redirect a signed-in caller:
  *   - me.lastViewedCardgroup != null            → /learn/{id}
  *   - myCardgroupsConnection.totalCount > 0     → /cardgroups
- *   - otherwise                                  → /cardgroups/new?welcome=1
+ *   - otherwise                                  → /onboarding/start
  *
  * Auth-sensitive (requires Authorization), so callers MUST pass `revalidate: 0`
  * to gqlFetch.

--- a/frontend/src/components/conditional-shell.test.tsx
+++ b/frontend/src/components/conditional-shell.test.tsx
@@ -41,6 +41,7 @@ describe("<ConditionalShell>", () => {
     it.each([
       "/login",
       "/onboarding",
+      "/onboarding/start",
       "/terms",
       "/privacy",
     ])("renders children directly without the navigation shell on %s", (pathname) => {

--- a/frontend/src/components/conditional-shell.test.tsx
+++ b/frontend/src/components/conditional-shell.test.tsx
@@ -60,11 +60,13 @@ describe("<ConditionalShell>", () => {
     it.each([
       "/login",
       "/onboarding",
+      "/onboarding/start",
     ])("keeps the shell hidden on %s even for an authenticated identity", (pathname) => {
       // A soft navigation can reach a bare route while the layout-computed
       // identity is still authenticated; the shell must stay hidden regardless
-      // of identity. /onboarding in particular is reached WHILE authenticated
-      // (it is the display-name gate), so the authenticated case matters there.
+      // of identity. /onboarding and /onboarding/start are both reached WHILE
+      // authenticated (the display-name gate and the first-deck chooser), so the
+      // authenticated case matters there.
       mockUsePathname.mockReturnValue(pathname);
       render(
         <ConditionalShell user={{ email: "a@b.c" }} isAdmin={true}>

--- a/frontend/src/components/conditional-shell.tsx
+++ b/frontend/src/components/conditional-shell.tsx
@@ -7,10 +7,12 @@ import { AppleInstallHint } from "./pwa/apple-install-hint";
 
 /**
  * Routes that own the entire viewport and must render without the navigation
- * shell. /login is the sign-in screen, /onboarding the display-name gate, and
- * /terms + /privacy the public legal pages (each renders its own `<main>`).
+ * shell. /login is the sign-in screen, /onboarding the display-name gate,
+ * /onboarding/start the first-deck chooser (a deckless user's rail would point
+ * at empty destinations), and /terms + /privacy the public legal pages (each
+ * renders its own `<main>`).
  */
-const BARE_ROUTES = new Set(["/login", "/onboarding", "/terms", "/privacy"]);
+const BARE_ROUTES = new Set(["/login", "/onboarding", "/onboarding/start", "/terms", "/privacy"]);
 
 interface ConditionalShellProps {
   /** Shell display identity, or null for the anonymous shell. */


### PR DESCRIPTION
## Summary

After a user sets their display name, if they own zero cardgroups they now land on a new bare-shell chooser at `/onboarding/start` instead of going straight to the empty-cardgroup form. The chooser presents the master catalog as a gallery — importing a ready-made deck drops the user straight into `/learn/{id}` — alongside a first-class "create your own" link to the existing `/cardgroups/new?welcome=1`. When the master catalog is empty, the chooser falls through to the create screen, so behaviour is unchanged for catalog-less environments.

Frontend-only: no GraphQL schema or backend change. The new client `OnboardingStartQuery` selects only existing fields (`me`, `masterCatalog`).

This branch addresses no tracked issue.

## What changed

### New `/onboarding/start` chooser route (bare shell)

- `app/onboarding/start/page.tsx` — RSC: auth gate (`readAuthContext` → `/login`), `gqlFetch(OnboardingStartQuery, { revalidate: 0 })`, `isUnauthenticatedGraphQLError` → `/login`, not-onboarded self-guard (`isUserOnboarded` → `/onboarding`), null-`masterCatalog` partial-response guard, empty-catalog fallback (`totalCount === 0` → `/cardgroups/new?welcome=1`), and its own `<main>` landmark (bypasses `AppShell`).
- `app/onboarding/start/onboarding-start-client.tsx` — thin client: renders a `CatalogCard` per deck (first 20, no search / infinite-scroll) plus the "create your own" link. Single-select import via the reused `useImportMaster`; success → `router.push('/learn/{id}')`; `not_found` / `rejected` → error banner; `auth` → degraded banner with `<Link href="/login">`. Imports serialized one-at-a-time via `importingId`.
- `app/onboarding/start/queries.ts` — new `OnboardingStartQuery` document.

### Reuse, not duplication

- `app/catalog/catalog-card.tsx` — additive optional `labels` + `testIdPrefix` props. Defaults reproduce the `/catalog` copy and the `catalog-import-{id}` testid exactly, so `/catalog` is unaffected; the chooser passes "Start with this deck" copy and an `onboarding-deck-{id}` testid.
- `useImportMaster` is reused verbatim (its `/cardgroups` connection-cache prepend is harmless here, since the user navigates to `/learn`).

### Entry-point rewiring (both → the chooser)

- `app/page.tsx` — the HomePage redirect chain's deckless-onboarded `else` branch now targets `/onboarding/start` (was `/cardgroups/new?welcome=1`); `app/queries.ts` docstring updated to match.
- `app/onboarding/onboarding-form.tsx` — the post-display-name success push now targets `/onboarding/start`.
- `components/conditional-shell.tsx` — `/onboarding/start` added to `BARE_ROUTES`.

### i18n

- `messages/{en,ja}.json` — new `OnboardingStart` namespace (14 keys, en/ja parity). Japanese copy lives only in `ja.json`.

### Docs

- `docs/frontend/routing-topology.md` — HomePage chain, routing table, welcome-copy section, and the bare-shell set updated for the new route (the bare-shell set was also corrected to include the pre-existing `/terms` + `/privacy`).
- `docs/frontend/profile-page-profile.md` — onboarding-form redirect target updated.

## Verification

Signed in with a display name but zero cardgroups, landing on `/` redirects to `/onboarding/start`. The chooser renders the master decks; "Start with this deck" imports the deck and navigates to `/learn/{id}`; "Create a deck" links to `/cardgroups/new?welcome=1`. A non-onboarded direct hit to `/onboarding/start` redirects to `/onboarding`; an empty catalog redirects to `/cardgroups/new?welcome=1`. The route renders without the navigation shell (bare).

## Test plan

- [ ] `pnpm --filter frontend test` — 1307 passed (135 files)
- [ ] `pnpm --filter frontend typecheck` — exit 0
- [ ] `pnpm --filter frontend lint` — exit 0 (biome)
- [ ] `pnpm --filter frontend knip` — exit 0 (no unused exports)
- [ ] `pnpm --filter frontend i18n:parity` — exit 0 (343 keys, en/ja)
- [ ] `pnpm --filter frontend build` — exit 0 (`/onboarding/start` registered)
- [ ] No inline CJK in new source (message catalogs exempt)

## Follow-up

- #429 — extract a shared `CatalogCardFields` GraphQL fragment so `MasterCatalogQuery` and `OnboardingStartQuery` stop duplicating the `CatalogCard` node selection. Deferred from this PR: the codebase uses graphql-codegen fragment masking, so a shared fragment requires `useFragment` adoption in `CatalogCard` + `makeFragmentData` in its existing tests (~8 files), which is broader than this onboarding change. The current duplicated selections are correct (typecheck-green; the dangerous drift direction fails loudly at compile time).
