### PR TITLE
feat(login): redesign sign-in and rebrand to "Flamingo Armond"

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -123,6 +123,11 @@
   --radius-md: calc(var(--radius) - 2px);
   --radius-lg: var(--radius);
   --radius-xl: calc(var(--radius) + 4px);
+  /* Inter for Latin (set on <html> by next/font), Hiragino / Noto Sans JP for
+     Japanese — the same Latin+JP pairing apple.com/jp uses. */
+  --font-sans:
+    var(--font-inter), system-ui, -apple-system, "Hiragino Kaku Gothic ProN", "Hiragino Sans",
+    "Noto Sans JP", "Yu Gothic", Meiryo, sans-serif;
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
@@ -138,6 +143,12 @@
     @apply border-border outline-ring/50;
   }
   body {
-    @apply bg-background text-foreground;
+    @apply bg-background text-foreground font-sans antialiased;
+    /* Apple-grade legibility: kerning, ligatures, contextual alternates. */
+    font-feature-settings:
+      "kern" 1,
+      "liga" 1,
+      "calt" 1;
+    text-rendering: optimizeLegibility;
   }
 }

--- a/frontend/src/app/layout.test.tsx
+++ b/frontend/src/app/layout.test.tsx
@@ -50,6 +50,14 @@ vi.mock("@vercel/speed-insights/next", () => ({
   SpeedInsights: () => null,
 }));
 
+// next/font/google — the font loader is a build-time transform that only runs
+// under the Next.js pipeline; in vitest the module-level Inter() call in
+// layout.tsx must be stubbed to return a font object carrying the `variable`
+// className the layout applies to <html>.
+vi.mock("next/font/google", () => ({
+  Inter: () => ({ variable: "__inter_variable", className: "__inter" }),
+}));
+
 // next-intl — the layout reads the active locale and wraps the tree in the
 // client provider. Stub both so RootLayout/generateMetadata run without the
 // Next.js request context. The provider is a passthrough so findElement can
@@ -245,8 +253,8 @@ describe("root metadata", () => {
 
   test("keeps the default title and appends the site name via the template", () => {
     expect(metadata.title).toMatchObject({
-      default: "flamingo-armond",
-      template: "%s | flamingo-armond",
+      default: "Flamingo Armond",
+      template: "%s | Flamingo Armond",
     });
   });
 
@@ -257,8 +265,8 @@ describe("root metadata", () => {
   test("carries the Open Graph fields with the generated OG image", () => {
     expect(metadata.openGraph).toMatchObject({
       type: "website",
-      siteName: "flamingo-armond",
-      title: "flamingo-armond",
+      siteName: "Flamingo Armond",
+      title: "Flamingo Armond",
       description: "Swiping flashcard app.",
       url: "/",
       locale: "en_US",
@@ -275,7 +283,7 @@ describe("root metadata", () => {
   test("carries the Twitter Card fields with the generated OG image", () => {
     expect(metadata.twitter).toMatchObject({
       card: "summary_large_image",
-      title: "flamingo-armond",
+      title: "Flamingo Armond",
       description: "Swiping flashcard app.",
       images: ["/opengraph-image"],
     });

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import type { Metadata, Viewport } from "next";
+import { Inter } from "next/font/google";
 import { headers } from "next/headers";
 import { NextIntlClientProvider } from "next-intl";
 import { getLocale, getTranslations } from "next-intl/server";
@@ -12,7 +13,14 @@ import { readAuthContext } from "@/lib/supabase/auth-status";
 import { Providers } from "./providers";
 import "./globals.css";
 
-const siteTitle = "flamingo-armond";
+// Inter is the Latin UI typeface (geometric humanist sans, close to Apple's
+// SF Pro). next/font self-hosts the woff2 under /_next at build time, so no CSP
+// font-src change is needed. Japanese glyphs fall back to the Hiragino / Noto
+// Sans JP stack declared in globals.css (`--font-sans`). Exposed as the
+// `--font-inter` CSS variable so Tailwind's `--font-sans` can reference it.
+const inter = Inter({ subsets: ["latin"], variable: "--font-inter", display: "swap" });
+
+const siteTitle = "Flamingo Armond";
 
 // Apple PWA splash screens, keyed by device dimensions. Lifted to a module const
 // so generateMetadata stays readable.
@@ -134,14 +142,14 @@ export default async function RootLayout({ children }: { children: ReactNode }) 
   const isAdmin = auth.status === "authenticated" && auth.isAdmin;
 
   return (
-    <html lang={locale}>
+    <html lang={locale} className={inter.variable}>
       {/*
         Browser extensions (ColorZilla, Grammarly, etc.) inject attributes onto
         <body> before React hydrates, which causes a benign hydration mismatch.
         suppressHydrationWarning is shallow (this element only) so real hydration
         bugs in children still surface.
       */}
-      <body suppressHydrationWarning>
+      <body suppressHydrationWarning className="font-sans antialiased">
         <NextIntlClientProvider>
           <Providers nonce={nonce}>
             {/*

--- a/frontend/src/app/login/in-app-browser-notice.tsx
+++ b/frontend/src/app/login/in-app-browser-notice.tsx
@@ -51,7 +51,7 @@ export function InAppBrowserNotice() {
   return (
     <div
       role="alert"
-      className="flex flex-col gap-3 rounded-lg border border-amber-300 bg-amber-50 p-4 text-sm text-amber-900"
+      className="flex flex-col gap-[13px] rounded-[13px] border border-amber-300 bg-amber-50 p-4 text-sm text-amber-900"
     >
       <p className="font-medium leading-snug">{t("inAppBrowserWarning")}</p>
       {browser === "line" ? (

--- a/frontend/src/app/login/login-button.tsx
+++ b/frontend/src/app/login/login-button.tsx
@@ -47,7 +47,14 @@ export function LoginButton() {
   }
 
   return (
-    <Button onClick={handleSignIn} type="button" variant="brand">
+    // Taller (48px) than the default control height and slightly tighter tracking
+    // for a premium primary CTA; the flex-column card stretches it to full width.
+    <Button
+      onClick={handleSignIn}
+      type="button"
+      variant="brand"
+      className="h-12 rounded-[13px] text-[15px] tracking-[-0.01em]"
+    >
       <GoogleGLogo />
       {t("googleButton")}
     </Button>

--- a/frontend/src/app/login/page.test.tsx
+++ b/frontend/src/app/login/page.test.tsx
@@ -106,11 +106,12 @@ describe("LoginPage", () => {
       ({ container } = render(jsx));
     });
 
-    it("outer wrapper has h-svh and lg:grid-cols-2", () => {
+    it("outer wrapper has h-svh and the golden-ratio grid template", () => {
       const grid = container.querySelector("[data-testid='login-grid']");
       expect(grid).toBeInTheDocument();
       expect(grid?.className).toMatch(/h-svh/);
-      expect(grid?.className).toMatch(/lg:grid-cols-2/);
+      // φ split: brand column 1.618fr, form column 1fr.
+      expect(grid?.className).toMatch(/lg:grid-cols-\[1\.618fr_1fr\]/);
     });
 
     it("brand panel has max-lg:hidden", () => {
@@ -123,7 +124,7 @@ describe("LoginPage", () => {
       const brandPanel = container.querySelector("[data-testid='brand-panel']");
       expect(brandPanel).toBeInTheDocument();
       expect(brandPanel?.querySelector("[aria-label='Flamingo']")).toBeInTheDocument();
-      expect(brandPanel?.textContent).toContain("flamingo-armond");
+      expect(brandPanel?.textContent).toContain("Flamingo Armond");
     });
 
     it("brand panel does not contain an email address (PII)", () => {
@@ -149,7 +150,7 @@ describe("LoginPage", () => {
       const mobileBrand = container.querySelector("[data-testid='form-brand-header']");
       expect(mobileBrand).toBeInTheDocument();
       expect(mobileBrand?.className).toMatch(/lg:hidden/);
-      expect(mobileBrand?.textContent).toContain("flamingo-armond");
+      expect(mobileBrand?.textContent).toContain("Flamingo Armond");
     });
 
     it("sub-copy explaining OAuth-first-time semantics is rendered under h1", () => {
@@ -157,7 +158,7 @@ describe("LoginPage", () => {
       expect(screen.getByText(/an account is created on first sign-in/i)).toBeInTheDocument();
     });
 
-    it("brand panel comes after the form column in DOM order (right-side placement)", () => {
+    it("brand panel comes before the form column in DOM order (left-side placement)", () => {
       const grid = container.querySelector("[data-testid='login-grid']");
       const brandPanel = container.querySelector("[data-testid='brand-panel']");
       expect(grid).toBeInTheDocument();
@@ -168,8 +169,9 @@ describe("LoginPage", () => {
       );
       const brandIndex = children.indexOf(brandPanel as Element);
       expect(brandIndex).not.toBe(-1);
-      expect(formIndex).toBe(0);
-      expect(brandIndex).toBe(1);
+      // Golden-ratio split places the brand panel in the wider left column.
+      expect(brandIndex).toBe(0);
+      expect(formIndex).toBe(1);
     });
 
     it("form-brand-header and brand-panel have mutually exclusive viewport visibility", () => {

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -28,22 +28,60 @@ export default async function LoginPage({ searchParams }: { searchParams: Search
   );
 
   return (
-    <main data-testid="login-grid" className="relative grid h-svh lg:grid-cols-2">
+    // Golden-ratio split: brand panel (61.8%) left, form column (38.2%) right.
+    // The `1.618fr_1fr` grid template is the exact φ division; below lg the brand
+    // panel is hidden and the form takes the full width.
+    <main data-testid="login-grid" className="relative grid h-svh lg:grid-cols-[1.618fr_1fr]">
+      {/* LEFT — brand panel (lg+ only). First grid child so it occupies the wider
+          golden column on the left. */}
+      <div
+        data-testid="brand-panel"
+        className="max-lg:hidden relative flex items-center justify-center overflow-hidden bg-gradient-to-br from-[oklch(83%_0.11_22)] via-[oklch(72%_0.185_18.45)] to-[oklch(60%_0.2_13)]"
+      >
+        {/* Soft radial glows give the flat coral gradient depth and atmosphere. */}
+        <div className="pointer-events-none absolute -top-24 -left-16 size-96 rounded-full bg-white/20 blur-3xl" />
+        <div className="pointer-events-none absolute -right-12 -bottom-32 size-[30rem] rounded-full bg-[rgba(150,25,60,0.45)] blur-3xl" />
+        {/* Right-edge vignette: a hint of depth where the panel meets the form. */}
+        <div className="pointer-events-none absolute inset-y-0 right-0 w-32 bg-gradient-to-l from-[rgba(120,20,40,0.16)] to-transparent" />
+
+        {/* Centered vertical lockup: the bare app-mark (no badge, no shadow) over
+            the wordmark and tagline. The three sizes 144 / 55 / 21 are alternating
+            Fibonacci numbers, so each step is φ² (≈2.618) — the mark reads as the
+            golden-ratio counterpart of the wordmark. Vertical gaps 34 / 13 are the
+            same φ² step on the Fibonacci ladder. */}
+        <div className="relative flex flex-col items-center gap-[34px] px-[55px] text-center">
+          <FlamingoMark background={false} className="size-[144px]" />
+          <div className="flex flex-col items-center gap-[13px]">
+            <span className="text-[55px] font-semibold leading-[1.05] tracking-[-0.025em] text-white drop-shadow-[0_2px_12px_rgba(120,20,40,0.45)]">
+              Flamingo Armond
+            </span>
+            <span className="text-[21px] font-medium leading-[1.45] tracking-[-0.01em] text-white/90 drop-shadow-[0_1px_6px_rgba(120,20,40,0.35)]">
+              {t("tagline")}
+            </span>
+          </div>
+        </div>
+      </div>
+
+      {/* RIGHT — form column. Second grid child → narrower golden column on the
+          right at lg+, full-width and centered below lg. */}
       <div className="flex flex-col">
         <div
           data-testid="form-brand-header"
-          className="lg:hidden flex items-center justify-center gap-2 pt-8"
+          className="lg:hidden flex items-center justify-center gap-[13px] pt-[34px]"
         >
           <FlamingoMark className="size-7" />
-          <span className="text-base font-medium">flamingo-armond</span>
+          <span className="text-base font-medium tracking-[-0.01em]">Flamingo Armond</span>
         </div>
 
-        <div className="flex flex-1 items-center justify-center p-6 sm:p-8">
-          <div className="w-full max-w-sm">
-            <div className="flex flex-col gap-6 rounded-2xl border bg-card p-8 shadow-[0_8px_40px_-12px_rgba(0,0,0,0.18)]">
-              <div className="flex flex-col gap-2 text-start">
-                <h1 className="text-2xl font-semibold tracking-tight">{t("heading")}</h1>
-                <p className="text-sm text-muted-foreground">{t("googleCta")}</p>
+        <div className="flex flex-1 items-center justify-center px-6 py-[34px] sm:px-8 lg:px-12 xl:px-16">
+          {/* 377px is a Fibonacci number — a deliberately calm form measure. */}
+          <div className="w-full max-w-[377px]">
+            <div className="flex flex-col gap-[21px] rounded-[21px] border border-border/70 bg-card p-[34px] shadow-[0_1px_2px_rgba(0,0,0,0.04),0_12px_32px_-12px_rgba(0,0,0,0.12)]">
+              <div className="flex flex-col gap-[13px] text-start">
+                <h1 className="text-[28px] font-semibold leading-[1.15] tracking-[-0.02em]">
+                  {t("heading")}
+                </h1>
+                <p className="text-[15px] leading-[1.55] text-muted-foreground">{t("googleCta")}</p>
               </div>
 
               {error && (
@@ -56,38 +94,13 @@ export default async function LoginPage({ searchParams }: { searchParams: Search
 
               <LoginButton />
 
-              <footer className="border-t pt-5 text-xs text-muted-foreground text-center">
+              <footer className="border-t pt-[21px] text-[12px] leading-[1.5] text-muted-foreground text-center">
                 {t.rich("terms", {
                   terms: footerLink("/terms"),
                   privacy: footerLink("/privacy"),
                 })}
               </footer>
             </div>
-          </div>
-        </div>
-      </div>
-
-      <div
-        data-testid="brand-panel"
-        className="max-lg:hidden relative flex items-center justify-center overflow-hidden bg-gradient-to-br from-[oklch(83%_0.11_22)] via-[oklch(72%_0.185_18.45)] to-[oklch(60%_0.2_13)]"
-      >
-        {/* Soft radial glows give the flat coral gradient depth and atmosphere. */}
-        <div className="pointer-events-none absolute -top-24 -left-16 size-96 rounded-full bg-white/20 blur-3xl" />
-        <div className="pointer-events-none absolute -right-12 -bottom-32 size-[30rem] rounded-full bg-[rgba(150,25,60,0.45)] blur-3xl" />
-
-        {/* Horizontal brand lockup: white-framed logo beside the wordmark. The
-            mark is itself coral, so a white badge lifts it off the pink ground. */}
-        <div className="relative flex items-center gap-5">
-          <div className="rounded-[1.3rem] bg-white p-2.5 shadow-xl shadow-rose-950/20">
-            <FlamingoMark className="size-16" />
-          </div>
-          <div className="flex flex-col gap-1.5">
-            <span className="text-4xl font-semibold tracking-tight text-white drop-shadow-[0_2px_10px_rgba(120,20,40,0.45)]">
-              flamingo-armond
-            </span>
-            <span className="text-sm font-medium text-white/90 drop-shadow-[0_1px_6px_rgba(120,20,40,0.35)]">
-              {t("tagline")}
-            </span>
           </div>
         </div>
       </div>

--- a/frontend/src/app/manifest.ts
+++ b/frontend/src/app/manifest.ts
@@ -2,8 +2,8 @@ import type { MetadataRoute } from "next";
 
 export default function manifest(): MetadataRoute.Manifest {
   return {
-    name: "flamingo-armond",
-    short_name: "flamingo",
+    name: "Flamingo Armond",
+    short_name: "Flamingo",
     description: "Swiping flashcard app.",
     start_url: "/",
     display: "standalone",

--- a/frontend/src/app/opengraph-image.tsx
+++ b/frontend/src/app/opengraph-image.tsx
@@ -5,7 +5,7 @@ import { ImageResponse } from "next/og";
 
 export const size = { width: 1200, height: 630 };
 export const contentType = "image/png";
-export const alt = "flamingo-armond — Remember more, study less.";
+export const alt = "Flamingo Armond — Remember more, study less.";
 
 export default function OpengraphImage() {
   return new ImageResponse(
@@ -22,7 +22,7 @@ export default function OpengraphImage() {
         color: "#FFFFFF",
       }}
     >
-      <div style={{ fontSize: 96, fontWeight: 700, letterSpacing: -2 }}>flamingo-armond</div>
+      <div style={{ fontSize: 96, fontWeight: 700, letterSpacing: -2 }}>Flamingo Armond</div>
       <div style={{ fontSize: 40, opacity: 0.9 }}>Remember more, study less.</div>
     </div>,
     { ...size },

--- a/frontend/src/app/privacy/content.ts
+++ b/frontend/src/app/privacy/content.ts
@@ -13,7 +13,7 @@ export const PRIVACY_EN: PrivacyContent = {
   lastUpdated: "Last updated: June 12, 2026",
   backToLogin: "Back to login",
   intro:
-    "Your privacy is important to us. This Privacy Policy explains how flamingo-armond collects, uses, and protects your information.",
+    "Your privacy is important to us. This Privacy Policy explains how Flamingo Armond collects, uses, and protects your information.",
   sections: [
     {
       title: "1. Information We Collect",
@@ -59,7 +59,7 @@ export const PRIVACY_JA: PrivacyContent = {
   lastUpdated: "最終更新日：2026年6月12日",
   backToLogin: "ログインに戻る",
   intro:
-    "お客様のプライバシーは私たちにとって重要です。本プライバシーポリシーでは、flamingo-armondがお客様の情報をどのように収集・利用・保護するかを説明します。",
+    "お客様のプライバシーは私たちにとって重要です。本プライバシーポリシーでは、Flamingo Armondがお客様の情報をどのように収集・利用・保護するかを説明します。",
   sections: [
     {
       title: "1. 収集する情報",

--- a/frontend/src/app/terms/content.ts
+++ b/frontend/src/app/terms/content.ts
@@ -14,15 +14,15 @@ export const TERMS_EN: TermsContent = {
   sections: [
     {
       title: "1. Acceptance of Terms",
-      body: 'By accessing or using flamingo-armond (the "Service"), you agree to be bound by these Terms of Service. If you do not agree to these terms, please do not use the Service.',
+      body: 'By accessing or using Flamingo Armond (the "Service"), you agree to be bound by these Terms of Service. If you do not agree to these terms, please do not use the Service.',
     },
     {
       title: "2. Description of Service",
-      body: "flamingo-armond is a personal flashcard application that uses spaced repetition to help you study and memorize content. The Service is intended for personal and educational use.",
+      body: "Flamingo Armond is a personal flashcard application that uses spaced repetition to help you study and memorize content. The Service is intended for personal and educational use.",
     },
     {
       title: "3. Beta Service, No Support, and No Data Guarantee",
-      body: "flamingo-armond is currently offered as a free, public beta and runs on free-tier, no-cost hosting infrastructure. The Service is therefore provided on a best-effort basis only: (a) we provide no user support of any kind and are under no obligation to respond to inquiries, fix defects, or restore lost data; (b) availability, features, and stored data may be changed, interrupted, or discontinued at any time without prior notice; and (c) we do not guarantee that your data will be preserved. Your flashcards and other content may be corrupted, lost, or permanently deleted, including as a result of the underlying free-tier infrastructure, and we accept no liability for any such loss. You are solely responsible for exporting and keeping your own backups of any content you consider important.",
+      body: "Flamingo Armond is currently offered as a free, public beta and runs on free-tier, no-cost hosting infrastructure. The Service is therefore provided on a best-effort basis only: (a) we provide no user support of any kind and are under no obligation to respond to inquiries, fix defects, or restore lost data; (b) availability, features, and stored data may be changed, interrupted, or discontinued at any time without prior notice; and (c) we do not guarantee that your data will be preserved. Your flashcards and other content may be corrupted, lost, or permanently deleted, including as a result of the underlying free-tier infrastructure, and we accept no liability for any such loss. You are solely responsible for exporting and keeping your own backups of any content you consider important.",
     },
     {
       title: "4. Account Registration",
@@ -70,15 +70,15 @@ export const TERMS_JA: TermsContent = {
   sections: [
     {
       title: "1. 利用規約への同意",
-      body: "flamingo-armond（以下「本サービス」）にアクセスまたはご利用いただくことにより、本利用規約に同意したものとみなされます。同意いただけない場合は、本サービスのご利用はお控えください。",
+      body: "Flamingo Armond（以下「本サービス」）にアクセスまたはご利用いただくことにより、本利用規約に同意したものとみなされます。同意いただけない場合は、本サービスのご利用はお控えください。",
     },
     {
       title: "2. サービスの説明",
-      body: "flamingo-armondは、間隔反復法を用いた個人向けフラッシュカードアプリです。学習・暗記のサポートを目的として提供され、個人的・教育的な用途を想定しています。",
+      body: "Flamingo Armondは、間隔反復法を用いた個人向けフラッシュカードアプリです。学習・暗記のサポートを目的として提供され、個人的・教育的な用途を想定しています。",
     },
     {
       title: "3. ベータサービス・サポート非提供・データ無保証",
-      body: "flamingo-armondは現在、無料のパブリックベータ版として提供されており、無償（無料枠）のホスティング基盤上で運営されています。そのため、本サービスはベストエフォート（合理的な範囲での最善の努力）でのみ提供されます：（a）当社はいかなるユーザーサポートも提供せず、お問い合わせへの対応、不具合の修正、失われたデータの復旧を行う義務を負いません、（b）可用性・機能・保存されたデータは、事前の通知なくいつでも変更・中断・廃止される場合があります、（c）お客様のデータが保持されることは保証しません。お客様のフラッシュカードやその他のコンテンツは、無料枠の基盤に起因する場合を含め、破損・消失または完全に削除される可能性があり、当社はそのような損失について一切の責任を負いません。重要なコンテンツについては、お客様ご自身でエクスポートおよびバックアップを保持する責任を負うものとします。",
+      body: "Flamingo Armondは現在、無料のパブリックベータ版として提供されており、無償（無料枠）のホスティング基盤上で運営されています。そのため、本サービスはベストエフォート（合理的な範囲での最善の努力）でのみ提供されます：（a）当社はいかなるユーザーサポートも提供せず、お問い合わせへの対応、不具合の修正、失われたデータの復旧を行う義務を負いません、（b）可用性・機能・保存されたデータは、事前の通知なくいつでも変更・中断・廃止される場合があります、（c）お客様のデータが保持されることは保証しません。お客様のフラッシュカードやその他のコンテンツは、無料枠の基盤に起因する場合を含め、破損・消失または完全に削除される可能性があり、当社はそのような損失について一切の責任を負いません。重要なコンテンツについては、お客様ご自身でエクスポートおよびバックアップを保持する責任を負うものとします。",
     },
     {
       title: "4. アカウント登録",

--- a/frontend/src/components/brand/flamingo-mark.tsx
+++ b/frontend/src/components/brand/flamingo-mark.tsx
@@ -1,10 +1,20 @@
 import type { SVGProps } from "react";
 
+type FlamingoMarkProps = SVGProps<SVGSVGElement> & {
+  /**
+   * Render the coral rounded-square plate behind the flamingo. Default `true`
+   * (the app-icon form used by favicons and on-white surfaces). Pass `false` to
+   * float the bare flamingo line art directly on a coloured surface — the coral
+   * detail strokes then blend into a coral background, leaving the white line art.
+   */
+  background?: boolean;
+};
+
 // Brand mark: coral rounded-square app icon with the geometric flamingo line art.
 // Shared by the favicon assets and every in-app brand surface so the logo stays
 // in one place. Size via the `className` prop (e.g. `size-7`); callers that wrap
 // it in an already-labeled control pass `aria-hidden` to keep it decorative.
-export function FlamingoMark(props: SVGProps<SVGSVGElement>) {
+export function FlamingoMark({ background = true, ...props }: FlamingoMarkProps) {
   return (
     <svg
       viewBox="0 0 1024 1024"
@@ -13,7 +23,9 @@ export function FlamingoMark(props: SVGProps<SVGSVGElement>) {
       xmlns="http://www.w3.org/2000/svg"
       {...props}
     >
-      <rect x="0" y="0" width="1024" height="1024" rx="153" ry="153" fill="#FF6F79" />
+      {background && (
+        <rect x="0" y="0" width="1024" height="1024" rx="153" ry="153" fill="#FF6F79" />
+      )}
       <path
         d="M0,0 L95,0 L103,6 L122,25 L122,27 L124,27 L131,35 L138,41 L145,49 L156,60 L158,64 L158,140 L154,146 L118,182 L111,190 L33,268 L31,268 L30,271 L29,303 L277,302 L288,286 L302,267 L309,257 L323,238 L335,221 L348,203 L362,184 L374,167 L387,149 L393,141 L398,138 L405,138 L411,142 L413,146 L413,153 L407,163 L397,176 L388,189 L375,207 L363,224 L349,243 L336,261 L322,281 L308,300 L307,302 L406,303 L412,307 L414,311 L414,319 L407,327 L390,344 L382,351 L365,368 L357,375 L342,390 L334,397 L313,418 L305,425 L292,438 L290,438 L290,440 L282,447 L265,464 L257,471 L240,488 L232,495 L214,513 L206,520 L193,533 L192,713 L283,713 L289,718 L290,720 L290,730 L285,736 L282,737 L78,737 L72,733 L70,730 L70,720 L75,714 L78,713 L168,713 L167,533 L151,517 L143,510 L120,487 L112,480 L99,467 L91,460 L71,440 L63,433 L47,417 L42,413 L37,408 L18,389 L10,382 L-7,365 L-15,358 L-27,346 L-35,339 L-53,321 L-54,319 L-54,240 L-51,235 L-31,215 L-26,210 L-16,200 L-9,192 L-4,187 L-1,186 L-1,184 L1,184 L3,180 L9,175 L16,167 L23,160 L28,155 L64,119 L65,94 L11,95 L3,102 L-4,110 L-12,117 L-14,120 L-15,167 L-18,172 L-21,175 L-30,176 L-37,172 L-39,168 L-43,166 L-76,133 L-78,129 L-78,77 L-74,71 L-69,66 L-67,66 L-67,64 L-65,64 L-65,62 L-63,62 L-61,58 L-51,48 L-43,41 L-36,34 L-29,26 L-14,12 L-3,1 Z "
         fill="#FDFAF6"


### PR DESCRIPTION
## Summary

The `/login` sign-in screen is rebuilt around an exact golden-ratio split — a coral brand panel on the wider left column (61.8%) and the sign-in card on the narrower right (38.2%) — with Inter as the app-wide UI typeface, a Fibonacci-derived spacing and type scale, and a frameless white line-art flamingo mark. The app's display name is unified to **Flamingo Armond** across the login surface, document title, Open Graph, PWA manifest, and legal copy.

This branch addresses no tracked issue.

## Changes

### Golden-ratio split layout (`app/login/page.tsx`)

- `lg:grid-cols-[1.618fr_1fr]` — the exact φ division; the brand panel is the wider left column, the form the narrower right. Below `lg` the brand panel hides (`max-lg:hidden`) and the form goes full-width with a compact brand header on top.
- Spacing uses a single Fibonacci ladder (8 / 13 / 21 / 34 / 55 / 89 px) chosen by hierarchy depth — consecutive ratios converge on φ, so the Fibonacci and golden-ratio systems coincide.
- Form card: `max-w-[377px]` (Fibonacci), `rounded-[21px]`, hairline border, and a two-layer Apple-style shadow (tight contact + soft ambient); the CTA button is raised to `h-12 rounded-[13px]` (`login-button.tsx`).
- Brand lockup sizes 144 / 55 / 21 px for mark / wordmark / tagline — alternating Fibonacci numbers, so each step is φ² (≈2.618).

### Inter typography (app-wide) (`app/layout.tsx`, `app/globals.css`)

- `next/font/google` Inter is loaded on `<html>` via the `--font-inter` variable; `body` gains `antialiased`.
- `--font-sans` becomes `Inter, system-ui, "Hiragino Kaku Gothic ProN", …, "Noto Sans JP", …` so Latin renders Inter and Japanese falls back to the Hiragino / Noto stack (the apple.com/jp pairing). Base `font-feature-settings: "kern" "liga" "calt"` + `text-rendering: optimizeLegibility`.
- No CSP change: next/font self-hosts under `/_next`, already covered by `default-src 'self'`, and the inlined `@font-face` is covered by the existing `style-src 'unsafe-inline'`.

### Frameless line-art brand mark (`components/brand/flamingo-mark.tsx`)

- `FlamingoMark` gains an optional `background` prop (default `true`, backward-compatible — favicons and on-white surfaces keep the coral plate). The login panel passes `background={false}`, which drops the coral rounded-square plate; the coral detail strokes then blend into the coral gradient, leaving a bare white line-art flamingo with no badge and no shadow.

### "Flamingo Armond" brand name

- Login wordmark + mobile header (`app/login/page.tsx`); document title default + template, Open Graph `siteName` / title, and Twitter title (`app/layout.tsx`); the generated OG image text + `alt` (`app/opengraph-image.tsx`); PWA manifest `name` (`app/manifest.ts`, with `short_name` capitalized to "Flamingo" for the home-screen label); and the EN/JA legal copy (`app/privacy/content.ts`, `app/terms/content.ts`).

### Tests

- `login/page.test.tsx` — grid assertion updated to the φ template; the DOM-order test is flipped to brand-on-left; brand-panel and mobile-header text now assert "Flamingo Armond".
- `layout.test.tsx` — adds a `next/font/google` mock (Inter is a build-time transform, absent in the vitest environment) and updates the metadata name assertions to "Flamingo Armond".

## Verification

On `/login` at `lg+`: the coral brand panel fills the wider left column (≈61.8%) with a frameless white line-art flamingo, the "Flamingo Armond" wordmark, and the tagline; the sign-in card sits in the right column (`max-w-[377px]`). Below `lg` (`max-lg:hidden`) the panel is hidden and a compact brand header shows above the card. The document title resolves to `Flamingo Armond` / `<page> | Flamingo Armond`, and the PWA install name and OG card render "Flamingo Armond".

## Test plan

- [x] `pnpm --filter frontend typecheck` — exit 0
- [x] `pnpm --filter frontend test` — 1290 passed (133 files)
- [x] `pnpm --filter frontend lint` — clean on changed files
- [x] `pnpm --filter frontend knip` — exit 0 (no unused exports)
- [x] `pnpm --filter frontend build` — exit 0
- [ ] Visual `/login` at `lg+`: golden-ratio split, frameless line-art flamingo, "Flamingo Armond" wordmark
- [ ] Visual `/login` below `lg`: brand panel hidden, compact header above the card
- [ ] Visual: document title, PWA install name, and OG card all read "Flamingo Armond"
