### PR TITLE
refactor(catalog): extract shared CatalogCardFields GraphQL fragment for CatalogCard

### DIFF
--- a/frontend/src/app/catalog/catalog-card.test.tsx
+++ b/frontend/src/app/catalog/catalog-card.test.tsx
@@ -2,30 +2,41 @@
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
+import { CatalogCardFieldsFragment } from "@/app/catalog/queries";
+import { makeFragmentData } from "@/generated/fragment-masking";
 import { renderWithIntl } from "@/test/render-with-intl";
 import { CatalogCard } from "./catalog-card";
 
-const FULL_NODE = {
-  __typename: "MasterCardgroup" as const,
-  id: "m-1",
-  name: "Business English",
-  description: "Professional vocabulary",
-  language: "en",
-  level: "B2",
-  category: "Business",
-  cardCount: 42,
-};
+// `makeFragmentData` is identity at runtime, so the wrapped object still carries
+// every field the component reads via `useFragment`; the wrap only supplies the
+// masked `FragmentType` the `node` prop now expects.
+const FULL_NODE = makeFragmentData(
+  {
+    __typename: "MasterCardgroup" as const,
+    id: "m-1",
+    name: "Business English",
+    description: "Professional vocabulary",
+    language: "en",
+    level: "B2",
+    category: "Business",
+    cardCount: 42,
+  },
+  CatalogCardFieldsFragment,
+);
 
-const BARE_NODE = {
-  __typename: "MasterCardgroup" as const,
-  id: "m-2",
-  name: "JLPT N3 Kanji",
-  description: null,
-  language: null,
-  level: null,
-  category: null,
-  cardCount: 100,
-};
+const BARE_NODE = makeFragmentData(
+  {
+    __typename: "MasterCardgroup" as const,
+    id: "m-2",
+    name: "JLPT N3 Kanji",
+    description: null,
+    language: null,
+    level: null,
+    category: null,
+    cardCount: 100,
+  },
+  CatalogCardFieldsFragment,
+);
 
 describe("<CatalogCard>", () => {
   it("renders name, card count, and metadata badges when present", () => {

--- a/frontend/src/app/catalog/catalog-card.tsx
+++ b/frontend/src/app/catalog/catalog-card.tsx
@@ -2,15 +2,14 @@
 
 import { Check, Download } from "lucide-react";
 import { useTranslations } from "next-intl";
+import { CatalogCardFieldsFragment } from "@/app/catalog/queries";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import type { MasterCatalogQuery } from "@/generated/graphql";
-
-/** A single published master deck node, derived from the catalog query selection. */
-type MasterCatalogNode = MasterCatalogQuery["masterCatalog"]["edges"][number]["node"];
+import { type FragmentType, useFragment } from "@/generated/fragment-masking";
 
 export type CatalogCardProps = {
-  node: MasterCatalogNode;
+  /** A masked `CatalogCardFields` ref — unmasked once via `useFragment` below. */
+  node: FragmentType<typeof CatalogCardFieldsFragment>;
   /** True while this deck's import mutation is in flight. */
   importing: boolean;
   /** True once this deck has been imported in the current session. */
@@ -40,6 +39,7 @@ export function CatalogCard({
   testIdPrefix,
 }: CatalogCardProps) {
   const t = useTranslations("Catalog");
+  const card = useFragment(CatalogCardFieldsFragment, node);
 
   const actionLabel = labels?.action ?? t("import");
   const inProgressLabel = labels?.inProgress ?? t("importing");
@@ -49,31 +49,31 @@ export function CatalogCard({
   return (
     <li className="flex flex-col gap-3 rounded-lg border border-border bg-background p-4">
       <div className="flex flex-col gap-1">
-        <h3 className="truncate font-medium text-foreground">{node.name}</h3>
-        {node.description && (
-          <p className="line-clamp-2 text-sm text-muted-foreground">{node.description}</p>
+        <h3 className="truncate font-medium text-foreground">{card.name}</h3>
+        {card.description && (
+          <p className="line-clamp-2 text-sm text-muted-foreground">{card.description}</p>
         )}
       </div>
 
-      {(node.language || node.level || node.category) && (
+      {(card.language || card.level || card.category) && (
         <div className="flex flex-wrap gap-1.5">
-          {node.language && <Badge variant="secondary">{node.language}</Badge>}
-          {node.level && <Badge variant="outline">{t("level", { level: node.level })}</Badge>}
-          {node.category && <Badge variant="outline">{node.category}</Badge>}
+          {card.language && <Badge variant="secondary">{card.language}</Badge>}
+          {card.level && <Badge variant="outline">{t("level", { level: card.level })}</Badge>}
+          {card.category && <Badge variant="outline">{card.category}</Badge>}
         </div>
       )}
 
       <div className="mt-auto flex items-center justify-between gap-2">
         <span className="text-sm text-muted-foreground">
-          {t("cardCount", { count: node.cardCount })}
+          {t("cardCount", { count: card.cardCount })}
         </span>
         <Button
           type="button"
           variant={imported ? "outline" : "brand"}
           size="sm"
-          onClick={() => onImport(node.id)}
+          onClick={() => onImport(card.id)}
           disabled={importing || imported}
-          data-testid={`${idPrefix}-${node.id}`}
+          data-testid={`${idPrefix}-${card.id}`}
         >
           {imported ? (
             <>

--- a/frontend/src/app/catalog/catalog-client.tsx
+++ b/frontend/src/app/catalog/catalog-client.tsx
@@ -280,7 +280,7 @@ export default function CatalogClient({ initialConnection }: CatalogClientProps)
         >
           {edges.map((edge) => (
             <CatalogCard
-              key={edge.node.id}
+              key={edge.cursor}
               node={edge.node}
               importing={importingId === edge.node.id}
               imported={importedIds.has(edge.node.id)}

--- a/frontend/src/app/catalog/queries.ts
+++ b/frontend/src/app/catalog/queries.ts
@@ -20,6 +20,25 @@ export const CATALOG_DEFAULT_VARS: MasterCatalogQueryVariables = {
   search: null,
 };
 
+/**
+ * The `MasterCardgroup` field set the {@link CatalogCard} tile renders. Both
+ * `MasterCatalogQuery` (the /catalog gallery) and `OnboardingStartQuery` (the
+ * /onboarding/start chooser) spread this fragment, so the two queries share a
+ * single declared contract instead of two hand-mirrored node selections that
+ * can silently drift. `CatalogCard` unmasks it via `useFragment`.
+ */
+export const CatalogCardFieldsFragment = graphql(`
+  fragment CatalogCardFields on MasterCardgroup {
+    id
+    name
+    description
+    language
+    level
+    category
+    cardCount
+  }
+`);
+
 export const MasterCatalogQuery = graphql(`
   query MasterCatalog(
     $first: Int
@@ -43,12 +62,7 @@ export const MasterCatalogQuery = graphql(`
         cursor
         node {
           id
-          name
-          description
-          language
-          level
-          category
-          cardCount
+          ...CatalogCardFields
         }
       }
       pageInfo {

--- a/frontend/src/app/onboarding/start/onboarding-start-client.test.tsx
+++ b/frontend/src/app/onboarding/start/onboarding-start-client.test.tsx
@@ -2,7 +2,9 @@
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CatalogCardFieldsFragment } from "@/app/catalog/queries";
 import type { ImportMasterOutcome } from "@/app/catalog/use-import-master";
+import { makeFragmentData } from "@/generated/fragment-masking";
 import { renderWithIntl } from "@/test/render-with-intl";
 import { OnboardingStartClient } from "./onboarding-start-client";
 
@@ -30,27 +32,35 @@ vi.mock("@/app/catalog/use-import-master", () => ({
   useImportMaster: () => ({ importMasterCardgroup: mockImport, loading: false }),
 }));
 
+// Each deck carries a top-level `id` (read for React keys + per-deck `importing`
+// state) plus a masked `CatalogCardFields` ref the chooser hands to `CatalogCard`
+// — mirroring the `OnboardingStartQuery` node shape. `makeFragmentData` is
+// identity at runtime, so the card's `useFragment` still sees every field.
+const M1_FIELDS = {
+  __typename: "MasterCardgroup" as const,
+  id: "m-1",
+  name: "Business English",
+  description: "Professional vocabulary",
+  language: "en",
+  level: "B2",
+  category: "Business",
+  cardCount: 42,
+};
+
+const M2_FIELDS = {
+  __typename: "MasterCardgroup" as const,
+  id: "m-2",
+  name: "JLPT N3 Kanji",
+  description: null,
+  language: "ja",
+  level: null,
+  category: null,
+  cardCount: 100,
+};
+
 const DECKS = [
-  {
-    __typename: "MasterCardgroup" as const,
-    id: "m-1",
-    name: "Business English",
-    description: "Professional vocabulary",
-    language: "en",
-    level: "B2",
-    category: "Business",
-    cardCount: 42,
-  },
-  {
-    __typename: "MasterCardgroup" as const,
-    id: "m-2",
-    name: "JLPT N3 Kanji",
-    description: null,
-    language: "ja",
-    level: null,
-    category: null,
-    cardCount: 100,
-  },
+  { id: M1_FIELDS.id, ...makeFragmentData(M1_FIELDS, CatalogCardFieldsFragment) },
+  { id: M2_FIELDS.id, ...makeFragmentData(M2_FIELDS, CatalogCardFieldsFragment) },
 ];
 
 beforeEach(() => {

--- a/frontend/src/app/onboarding/start/onboarding-start-client.tsx
+++ b/frontend/src/app/onboarding/start/onboarding-start-client.tsx
@@ -5,10 +5,14 @@ import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { useCallback, useState } from "react";
 import { CatalogCard } from "@/app/catalog/catalog-card";
+import type { CatalogCardFieldsFragment } from "@/app/catalog/queries";
 import { useImportMaster } from "@/app/catalog/use-import-master";
-import type { OnboardingStartQuery } from "@/generated/graphql";
+import type { FragmentType } from "@/generated/fragment-masking";
 
-type MasterDeckNode = OnboardingStartQuery["masterCatalog"]["edges"][number]["node"];
+// `id` is read at this level (React keys, per-deck `importing` state); the rest
+// of the card's fields travel as a masked `CatalogCardFields` ref that
+// `CatalogCard` unmasks — the same fragment the /catalog gallery feeds it.
+type MasterDeckNode = { id: string } & FragmentType<typeof CatalogCardFieldsFragment>;
 
 interface OnboardingStartClientProps {
   decks: MasterDeckNode[];

--- a/frontend/src/app/onboarding/start/queries.ts
+++ b/frontend/src/app/onboarding/start/queries.ts
@@ -16,12 +16,7 @@ export const OnboardingStartQuery = graphql(`
         cursor
         node {
           id
-          name
-          description
-          language
-          level
-          category
-          cardCount
+          ...CatalogCardFields
         }
       }
       totalCount


### PR DESCRIPTION
## Summary

`MasterCatalogQuery` (the `/catalog` gallery) and `OnboardingStartQuery` (the `/onboarding/start` chooser) previously hand-mirrored the identical 8-field `MasterCardgroup` node selection that `CatalogCard` renders. Both queries now spread one shared `CatalogCardFields` fragment, so their structural compatibility is **declared** in a single source of truth instead of **coincidental** across two selections that could silently drift. Pure type-/query-structure refactor — no change to rendered output, the import flow, or the chooser behaviour.

Closes #429. Deferred from #428, where `CatalogCard` gained its second consumer.

## Background / Motivation

- `CatalogCard` typed its `node` prop against `MasterCatalogQuery[...]["node"]`, and `OnboardingStartClient` fed it nodes from `OnboardingStartQuery`, relying on the two hand-written selections producing the same structural type.
- The compiler catches the dangerous drift direction (a field `CatalogCard` requires going missing), but a field added to only one query drifts silently — a latent maintenance hazard a type-design review flagged on #428.
- The repo already uses graphql-codegen client-preset **fragment masking** (`admin/users`, `learn`), so the fix follows an established, tested pattern rather than introducing a new one.

## Changes

### Shared `CatalogCardFields` fragment

- `app/catalog/queries.ts` — new `CatalogCardFieldsFragment` (`fragment CatalogCardFields on MasterCardgroup` over `id`, `name`, `description`, `language`, `level`, `category`, `cardCount`). `MasterCatalogQuery`'s node selection collapses to `node { id ...CatalogCardFields }`.
- `app/onboarding/start/queries.ts` — `OnboardingStartQuery`'s node selection collapses to `node { id ...CatalogCardFields }`. `id` stays selected at the node level for React keys and per-deck import state.

### `CatalogCard` consumes the masked fragment

- `app/catalog/catalog-card.tsx` — `node` prop retyped from the inlined `MasterCatalogQuery` node alias to `FragmentType<typeof CatalogCardFieldsFragment>`. The component unmasks once via `useFragment(CatalogCardFieldsFragment, node)` and reads `card.*` everywhere it previously read `node.*` (including `onImport(card.id)` and the `${prefix}-${card.id}` testid). The optional `labels` / `testIdPrefix` props are untouched.

### Consumer wiring

- `app/catalog/catalog-client.tsx` — React `key` switches from `edge.node.id` to `edge.cursor` (matching `admin-users-client.tsx`); `importing` / `imported` keep reading the node-level `id`, and `node={edge.node}` passes the masked ref unchanged.
- `app/onboarding/start/onboarding-start-client.tsx` — `MasterDeckNode` retyped to `{ id: string } & FragmentType<typeof CatalogCardFieldsFragment>`, binding the chooser's deck type to the same fragment `CatalogCard` consumes. `page.tsx` pass-through is unchanged.

### Tests

- `app/catalog/catalog-card.test.tsx` — `FULL_NODE` / `BARE_NODE` wrapped with `makeFragmentData(..., CatalogCardFieldsFragment)` (identity at runtime, so existing `getByText` / `getByTestId` assertions still pass).
- `app/onboarding/start/onboarding-start-client.test.tsx` — `DECKS` rebuilt as a top-level `id` plus a `makeFragmentData` masked ref; behavioural assertions (navigation, banners, serialization) unchanged.
- `app/catalog/catalog-client.test.tsx` — no change; it drives the real `MasterCatalogDocument` through `MockedProvider`, where `useFragment` is identity at runtime.

`fragmentMasking` is left **enabled** in `codegen.ts` (no global masking change).

## Verification

`/catalog` and `/onboarding/start` render and import identically — the locale-independent testids `catalog-import-{id}` and `onboarding-deck-{id}` are unchanged. `grep -n '\.\.\.CatalogCardFields' frontend/src/app/catalog/queries.ts frontend/src/app/onboarding/start/queries.ts` shows both queries spread the fragment, and neither retains the hand-duplicated 8-field node list.

## Test plan

- [ ] `pnpm --filter frontend test` — 1307 passed (135 files)
- [ ] `pnpm --filter frontend typecheck` — exit 0
- [ ] `pnpm --filter frontend lint` — exit 0
- [ ] `pnpm --filter frontend knip` — exit 0 (no unused exports)
- [ ] `pnpm --filter frontend build` — exit 0
- [ ] No inline CJK in changed source
