### PR TITLE
feat(learn): replace card corner-curl with a pulsing coral tap hint

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -149,11 +149,11 @@
 @keyframes tap-pulse {
   0%,
   100% {
-    opacity: 0.2;
+    opacity: 0.15;
     transform: scale(0.85);
   }
   50% {
-    opacity: 0.6;
+    opacity: 0.45;
     transform: scale(1);
   }
 }

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -123,6 +123,10 @@
   --radius-md: calc(var(--radius) - 2px);
   --radius-lg: var(--radius);
   --radius-xl: calc(var(--radius) + 4px);
+  /* Tap affordance — a faint coral dot gently breathes on the un-revealed card
+     corner, hinting the card is tappable to reveal the back. 3s so it reads as
+     a calm pulse, not an alert. Used via `animate-tap-pulse` (motion-safe). */
+  --animate-tap-pulse: tap-pulse 3s ease-in-out infinite;
   /* Inter for Latin (set on <html> by next/font), Hiragino / Noto Sans JP for
      Japanese — the same Latin+JP pairing apple.com/jp uses. */
   --font-sans:
@@ -136,6 +140,22 @@
   --color-sidebar-primary: var(--sidebar-primary);
   --color-sidebar-foreground: var(--sidebar-foreground);
   --color-sidebar: var(--sidebar);
+}
+
+/* Drives `animate-tap-pulse` (see --animate-tap-pulse above). Opacity stays low
+   so the dot reads as a faint coral hint, never an alert; the gentle scale adds
+   a "breathing" feel. Decorative only — gated behind motion-safe at the call
+   site, so prefers-reduced-motion users get a static dot instead. */
+@keyframes tap-pulse {
+  0%,
+  100% {
+    opacity: 0.2;
+    transform: scale(0.85);
+  }
+  50% {
+    opacity: 0.6;
+    transform: scale(1);
+  }
 }
 
 @layer base {

--- a/frontend/src/components/learn/swipe-card.test.tsx
+++ b/frontend/src/components/learn/swipe-card.test.tsx
@@ -30,6 +30,22 @@ describe("<CardContent>", () => {
     expect(screen.queryByText("Hola")).not.toBeInTheDocument();
   });
 
+  it("shows the tap-affordance hint only while the card is un-revealed", () => {
+    const { rerender } = render(<CardContent card={CARD} revealed={false} />);
+
+    const hint = screen.getByTestId("tap-hint");
+    expect(hint).toBeInTheDocument();
+    // Decorative-only: never exposed to assistive tech.
+    expect(hint).toHaveAttribute("aria-hidden", "true");
+    // The pulse runs only when motion is allowed; a static faint dot remains
+    // for prefers-reduced-motion users so the hint never disappears.
+    expect(hint).toHaveClass("motion-safe:animate-tap-pulse");
+    expect(hint).toHaveClass("motion-reduce:opacity-40");
+
+    rerender(<CardContent card={CARD} revealed={true} />);
+    expect(screen.queryByTestId("tap-hint")).not.toBeInTheDocument();
+  });
+
   it("does not render rating buttons inside the card", () => {
     render(<CardContent card={CARD} revealed={true} />);
 

--- a/frontend/src/components/learn/swipe-card.tsx
+++ b/frontend/src/components/learn/swipe-card.tsx
@@ -95,7 +95,7 @@ export function CardContent({ card, revealed }: { card: SwipeCardData; revealed:
         <span
           data-testid="tap-hint"
           aria-hidden="true"
-          className="pointer-events-none absolute right-5 bottom-5 h-3 w-3 rounded-full bg-brand-primary motion-safe:animate-tap-pulse motion-reduce:opacity-40"
+          className="pointer-events-none absolute right-5 bottom-5 h-10 w-10 rounded-full bg-brand-primary blur-[10px] motion-safe:animate-tap-pulse motion-reduce:opacity-40"
         />
       )}
     </div>

--- a/frontend/src/components/learn/swipe-card.tsx
+++ b/frontend/src/components/learn/swipe-card.tsx
@@ -88,9 +88,14 @@ export function CardContent({ card, revealed }: { card: SwipeCardData; revealed:
         )}
       </div>
       {!revealed && (
-        <div
-          className="pointer-events-none absolute right-0 bottom-0 h-16 w-16 bg-muted shadow-inner [clip-path:polygon(100%_0,0_100%,100%_100%)]"
+        // Tap affordance: a faint coral dot gently pulses (~3s) to hint the card
+        // is tappable to reveal the back. Decorative only (aria-hidden); the
+        // pulse runs only when motion is allowed and degrades to a static faint
+        // dot under prefers-reduced-motion so the hint never disappears.
+        <span
+          data-testid="tap-hint"
           aria-hidden="true"
+          className="pointer-events-none absolute right-5 bottom-5 h-3 w-3 rounded-full bg-brand-primary motion-safe:animate-tap-pulse motion-reduce:opacity-40"
         />
       )}
     </div>


### PR DESCRIPTION
## Summary

Un-revealed learn cards showed a grey "page-curl" (dog-ear) triangle pinned to the bottom-right corner as the tap hint. It now renders as a soft, hazy flamingo-coral glow that gently breathes on a ~3s cycle, reading as a calm "tap to reveal" affordance instead of a static fold. The effect is pure CSS — a `tap-pulse` keyframe in the Tailwind v4 theme plus a `motion-safe:animate-tap-pulse` utility on a blurred coral dot — so there is no JS, no re-render, and it runs on the compositor. Under `prefers-reduced-motion: reduce` the pulse is suppressed and a static faint dot remains, so the hint never disappears (matching the repo's existing `motion-safe` / `motion-reduce` affordance convention).

This branch addresses no tracked issue.

## Changes

### Tap-affordance keyframe (CSS)

- `app/globals.css` — register `--animate-tap-pulse: tap-pulse 3s ease-in-out infinite` in the `@theme inline` block (this generates the `animate-tap-pulse` utility), and add the top-level `@keyframes tap-pulse` (opacity `0.15 → 0.45 → 0.15` with `scale(0.85) → scale(1)` for a calm "breathing" feel rather than an alert blink).

### Card affordance

- `components/learn/swipe-card.tsx` — in `CardContent`, replace the `clip-path` dog-ear `<div>` (`h-16 w-16 bg-muted` corner triangle) with a blurred coral dot: `h-10 w-10 rounded-full bg-brand-primary blur-[10px]` inset at `right-5 bottom-5`, gated on `!revealed`. It carries `aria-hidden="true"`, `motion-safe:animate-tap-pulse`, `motion-reduce:opacity-40`, and `data-testid="tap-hint"`. `CardContent` is shared by the gesture `AnimatedCard` front face, so the hint shows only while a card displays its front: in `FLIP_TO_REVEAL` it appears on the active card until it is revealed, and in `ALWAYS_VISIBLE` the card mounts flipped to its back face, so the hint never shows.

### Tests

- `components/learn/swipe-card.test.tsx` — new case pins the render gate (hint present only while `revealed={false}`, gone after reveal) and the `aria-hidden` / `motion-safe:animate-tap-pulse` / `motion-reduce:opacity-40` classes.

## Verification

On `/learn/<cardgroupId>` in flip-to-reveal mode, the un-revealed card's bottom-right shows a soft, hazy coral glow (`data-testid="tap-hint"`, `bg-brand-primary rounded-full blur-[10px]`) that breathes on a ~3s loop; it disappears once the card is revealed and never appears in always-visible mode. With OS "Reduce motion" enabled the dot is static (no pulse) but still visible via `motion-reduce:opacity-40`. `grep -n "clip-path" frontend/src/components/learn/swipe-card.tsx` returns no results — the old dog-ear is fully removed.

## Test plan

- [ ] `pnpm --filter frontend test` — green, including `components/learn/swipe-card` (7 cases)
- [ ] `pnpm --filter frontend typecheck` — exit 0
- [ ] `pnpm --filter frontend lint` — no new findings
- [ ] Visual (flip-to-reveal): pulsing hazy coral glow on the un-revealed card; gone after reveal
- [ ] Visual (always-visible): no hint at all
- [ ] Visual (Reduce motion): static-but-visible dot, no pulse
