### PR TITLE
feat(learn): auto-fit card front text so long words fit one line

### DIFF
--- a/docs/frontend/auto-fit-text.md
+++ b/docs/frontend/auto-fit-text.md
@@ -1,0 +1,103 @@
+# Auto-fit card text (`useFitText`)
+
+> Applies to: `frontend/src/components/learn/` (the flashcard front term). The
+> pattern — shrink a measured DOM element to fit, with a pure solver and a
+> jsdom-safe test harness — generalizes to any layout-measuring hook.
+
+The learn-card **front** term auto-shrinks so a long single word (e.g.
+`cardiovascular`) fits on one line instead of overflowing, while multi-word
+fronts wrap normally. Implemented by `computeFitFontSize` (pure solver) +
+`useFitText` (hook) in `frontend/src/components/learn/use-fit-text.ts`, wired
+into `CardContent` in `swipe-card.tsx`.
+
+## Behaviour and the rules behind it
+
+### `break-normal`, never `break-words` — and shrink only when a word overflows
+
+The front uses Tailwind `break-normal` (`overflow-wrap: normal; word-break:
+normal`): text wraps **at word boundaries** and a word is never split
+mid-character. A single word longer than the line does **not** wrap under
+`break-normal` — it overflows. That overflow is what `useFitText` removes by
+shrinking the font, so the widest unbreakable word fits one line. Multi-word
+content that already fits is left at the ceiling and simply wraps across lines.
+
+Do **not** use `break-words` (`overflow-wrap: break-word`) on text that should
+never break mid-word, and do **not** use `whitespace-nowrap` (it forbids the
+multi-line wrap).
+
+### Measure the widest word via `scrollWidth`
+
+`computeFitFontSize` compares `intrinsicWidth` (the element's `scrollWidth` at
+the reference `maxPx`) against `availableWidth` (its `clientWidth`). For a
+`break-normal` element, `scrollWidth == clientWidth` **unless** a single word
+overflows, in which case `scrollWidth` is that word's width. So the proportional
+shrink (`maxPx * available / intrinsic`) fires exactly when — and only when — a
+word is wider than the card. A `max-width: 100%` element caps its own
+`clientWidth` at the parent's content box, so surrounding padding is respected
+with no explicit subtraction.
+
+### Observe the PARENT, not the element
+
+`useFitText` attaches its `ResizeObserver` to `el.parentElement`, not `el`.
+Changing the element's `font-size` changes the element's own height (wrapped
+line count), which would re-fire an observer watching the element and risk a
+measure loop. The parent's width tracks the viewport (the only re-fit trigger
+we want), so observing the parent is both correct and loop-free.
+
+### The apply-write after measurement is load-bearing
+
+`measure()` writes `el.style.fontSize` twice: first to the reference `maxPx`
+(to read a stable `scrollWidth`), then to the computed `next` size. The second
+write is **not** redundant with `setFontPx(next)`: when `next` equals the
+current React state, `setFontPx` is a no-op and React skips the re-render, which
+would otherwise leave the element pinned at the reference `maxPx` from the first
+write. Keep both writes.
+
+### Trigger-only `text` dependency
+
+The effect lists `text` in its dependency array but never reads it in the body —
+it is a trigger that forces a re-measure when the card term changes. Biome's
+`useExhaustiveDependencies` flags it; the fix is a load-bearing `biome-ignore`,
+not removing the dep (removing it would pin the font to the previous term's
+width). See [`docs/pagination/load-bearing-biome-ignore.md`](../pagination/load-bearing-biome-ignore.md).
+
+### One ceiling across reveal — the headword keeps its size on flip
+
+`FRONT_FIT = { maxPx: 48, minPx: 20 }` is a **single** constant used whether or
+not the card is revealed. Flipping the card does not resize the headword; it
+only adds the translation below it. (The earlier design shrank the revealed
+front to a smaller ceiling, which read as the headword "jumping" size on flip.)
+`minPx` is the floor below which an exceptionally long word is clipped by the
+card's `overflow-hidden` rather than shrunk to an unreadable size.
+
+## Testing harness — jsdom has no layout engine
+
+jsdom reports `clientWidth`/`scrollWidth` as `0` and provides **no**
+`ResizeObserver`. That shapes the test split:
+
+- **Layout math → a pure function.** `computeFitFontSize` takes explicit width
+  numbers and is unit-tested directly (`use-fit-text.test.ts`) — fits,
+  exact-boundary, proportional shrink, floor-to-whole-pixel, clamp-to-`minPx`,
+  and the unmeasured (`0`-width) guard. No DOM needed.
+- **Hook control flow → testable in jsdom anyway.** Attach the hook's ref to a
+  real element via a tiny `Harness` component and exercise (`use-fit-text.dom.test.tsx`):
+  - the `typeof ResizeObserver === "undefined"` guard (jsdom default) — no throw, returns `maxPx`;
+  - that the observer targets the **parent**, not the text element;
+  - `disconnect()` on unmount (no leak);
+  - the **re-fit on resize**: `vi.stubGlobal("ResizeObserver", Fake)` where the
+    fake captures the callback, then `Object.defineProperty(el, "clientWidth"/"scrollWidth", …)`
+    to non-zero values, fire the captured callback in `act()`, and assert the
+    new size.
+- **Assert the returned React state, not just the imperative DOM write.** The
+  hook mutates `el.style.fontSize` imperatively *and* via `setFontPx`. A test
+  that reads only `el.style.fontSize` passes even if `setFontPx` is dropped
+  (the imperative write masks it), but production binds the **React** value, so
+  a stale state would revert on the next re-render. Mirror `fontPx` onto a
+  `data-*` attribute in the Harness and assert both.
+
+The component-level test (`swipe-card.test.tsx`) pins the structural
+preconditions the math depends on (front is `break-normal`, not
+`break-words`/`break-all`/`whitespace-nowrap`) and the headword's constant size
+across an in-place reveal — `jsdom`'s `0`-width keeps `computeFitFontSize` at
+`maxPx`, so the inline `font-size` equals the ceiling and is assertable without
+a layout engine.

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -28,6 +28,7 @@ The frontend package manager is **pnpm** (pinned via `package.json` engines + `p
 - [`docs/frontend/e2e-tests.md`](../docs/frontend/e2e-tests.md) — Playwright + service-role-key handling.
 - [`docs/frontend/tailwind-4-notes.md`](../docs/frontend/tailwind-4-notes.md) — CSS-first config via `@theme`, no `tailwind.config.ts`.
 - [`docs/frontend/design-system.md`](../docs/frontend/design-system.md) — Color-token semantics (brand/destructive/primary), `Button` variant usage, and the destructive-confirm-dialog convention.
+- [`docs/frontend/auto-fit-text.md`](../docs/frontend/auto-fit-text.md) — `useFitText` card-front auto-shrink: `break-normal` word-wrap, pure solver + jsdom-safe test harness, observe-parent / load-bearing-write gotchas.
 - [`docs/frontend/codegen.md`](../docs/frontend/codegen.md) — `graphql-codegen` wiring and `prebuild` lifecycle.
 - [`docs/frontend/apollo-wiring.md`](../docs/frontend/apollo-wiring.md) — `gqlFetch` for RSC and Apollo client cache patterns.
 - [`docs/frontend/routing-topology.md`](../docs/frontend/routing-topology.md) — HomePage / cardgroup / login / `/cards/new` chains.

--- a/frontend/src/components/learn/swipe-card.test.tsx
+++ b/frontend/src/components/learn/swipe-card.test.tsx
@@ -54,6 +54,26 @@ describe("<CardContent>", () => {
     expect(screen.getByText("Hola")).toBeInTheDocument();
   });
 
+  it("renders the front term on a single line so auto-fit can shrink it instead of wrapping", () => {
+    // The front term is held on one line (`whitespace-nowrap`); useFitText
+    // shrinks the font to fit the card width. jsdom has no layout engine, so
+    // the auto-fit math is unit-tested in use-fit-text.test.ts; here we pin the
+    // structural precondition (nowrap) the shrink relies on.
+    render(<CardContent card={{ ...CARD, front: "cardiovascular" }} revealed={false} />);
+
+    const frontEl = screen.getByText("cardiovascular");
+    expect(frontEl).toHaveClass("whitespace-nowrap");
+    expect(frontEl).not.toHaveClass("break-words");
+  });
+
+  it("lets the back translation wrap normally — it may be a phrase, not a single term", () => {
+    render(<CardContent card={{ ...CARD, back: "a multi word phrase" }} revealed={true} />);
+
+    const backEl = screen.getByText("a multi word phrase");
+    expect(backEl).toHaveClass("break-words");
+    expect(backEl).not.toHaveClass("whitespace-nowrap");
+  });
+
   it("reserves horizontal padding so a long front term cannot slide under the badge", () => {
     // jsdom has no real layout engine, so the overlap is guarded structurally:
     // the centered content block must carry the horizontal-padding utility that

--- a/frontend/src/components/learn/swipe-card.test.tsx
+++ b/frontend/src/components/learn/swipe-card.test.tsx
@@ -54,24 +54,44 @@ describe("<CardContent>", () => {
     expect(screen.getByText("Hola")).toBeInTheDocument();
   });
 
-  it("renders the front term on a single line so auto-fit can shrink it instead of wrapping", () => {
-    // The front term is held on one line (`whitespace-nowrap`); useFitText
-    // shrinks the font to fit the card width. jsdom has no layout engine, so
-    // the auto-fit math is unit-tested in use-fit-text.test.ts; here we pin the
-    // structural precondition (nowrap) the shrink relies on.
+  it("wraps the front term at word boundaries, never mid-word (break-normal, not break-words/nowrap)", () => {
+    // A multi-word front wraps across lines at spaces; a single overflowing
+    // word is shrunk by useFitText rather than broken mid-word. The structural
+    // precondition is `break-normal` (word-break: normal; overflow-wrap:
+    // normal) — NOT `break-words` (breaks mid-word) and NOT `whitespace-nowrap`
+    // (forbids the multi-line wrap the user asked for). jsdom has no layout
+    // engine, so the shrink math is unit-tested in use-fit-text.test.ts.
     render(<CardContent card={{ ...CARD, front: "cardiovascular" }} revealed={false} />);
 
     const frontEl = screen.getByText("cardiovascular");
-    expect(frontEl).toHaveClass("whitespace-nowrap");
+    expect(frontEl).toHaveClass("break-normal");
     expect(frontEl).not.toHaveClass("break-words");
+    expect(frontEl).not.toHaveClass("break-all");
+    expect(frontEl).not.toHaveClass("whitespace-nowrap");
   });
 
-  it("lets the back translation wrap normally — it may be a phrase, not a single term", () => {
-    render(<CardContent card={{ ...CARD, back: "a multi word phrase" }} revealed={true} />);
+  it("wraps the back translation at word boundaries too, never mid-word", () => {
+    render(<CardContent card={{ ...CARD, back: "electroencephalographically" }} revealed={true} />);
 
-    const backEl = screen.getByText("a multi word phrase");
-    expect(backEl).toHaveClass("break-words");
-    expect(backEl).not.toHaveClass("whitespace-nowrap");
+    const backEl = screen.getByText("electroencephalographically");
+    expect(backEl).toHaveClass("break-normal");
+    expect(backEl).not.toHaveClass("break-words");
+    expect(backEl).not.toHaveClass("break-all");
+  });
+
+  it("applies the unrevealed front-fit ceiling (maxPx=48) as an inline font size", () => {
+    // jsdom reports clientWidth/scrollWidth = 0, so useFitText returns the
+    // ceiling unchanged — letting us pin the revealed→bounds switch and the
+    // style wiring without a layout engine.
+    render(<CardContent card={{ ...CARD, front: "Hello" }} revealed={false} />);
+
+    expect(screen.getByText("Hello")).toHaveStyle({ fontSize: "48px" });
+  });
+
+  it("applies the revealed front-fit ceiling (maxPx=30) as an inline font size", () => {
+    render(<CardContent card={{ ...CARD, front: "Hello" }} revealed={true} />);
+
+    expect(screen.getByText("Hello")).toHaveStyle({ fontSize: "30px" });
   });
 
   it("reserves horizontal padding so a long front term cannot slide under the badge", () => {

--- a/frontend/src/components/learn/swipe-card.test.tsx
+++ b/frontend/src/components/learn/swipe-card.test.tsx
@@ -79,19 +79,32 @@ describe("<CardContent>", () => {
     expect(backEl).not.toHaveClass("break-all");
   });
 
-  it("applies the unrevealed front-fit ceiling (maxPx=48) as an inline font size", () => {
+  it("applies the fixed front-fit ceiling (maxPx=48) as an inline font size when unrevealed", () => {
     // jsdom reports clientWidth/scrollWidth = 0, so useFitText returns the
-    // ceiling unchanged — letting us pin the revealed→bounds switch and the
-    // style wiring without a layout engine.
+    // ceiling unchanged — letting us pin the bounds and the style wiring
+    // without a layout engine.
     render(<CardContent card={{ ...CARD, front: "Hello" }} revealed={false} />);
 
     expect(screen.getByText("Hello")).toHaveStyle({ fontSize: "48px" });
   });
 
-  it("applies the revealed front-fit ceiling (maxPx=30) as an inline font size", () => {
+  it("keeps the same front-fit ceiling (48px) when revealed — the headword does not shrink on flip", () => {
     render(<CardContent card={{ ...CARD, front: "Hello" }} revealed={true} />);
 
-    expect(screen.getByText("Hello")).toHaveStyle({ fontSize: "30px" });
+    expect(screen.getByText("Hello")).toHaveStyle({ fontSize: "48px" });
+  });
+
+  it("keeps the front size constant across an in-place reveal (reveal must not resize the headword)", () => {
+    // The reduced-motion path keeps ONE CardContent instance and flips
+    // `revealed` false→true in place. The headword size must stay constant
+    // (48px → 48px); revealing only adds the translation below it.
+    const { rerender } = render(
+      <CardContent card={{ ...CARD, front: "Hello" }} revealed={false} />,
+    );
+    expect(screen.getByText("Hello")).toHaveStyle({ fontSize: "48px" });
+
+    rerender(<CardContent card={{ ...CARD, front: "Hello" }} revealed={true} />);
+    expect(screen.getByText("Hello")).toHaveStyle({ fontSize: "48px" });
   });
 
   it("reserves horizontal padding so a long front term cannot slide under the badge", () => {

--- a/frontend/src/components/learn/swipe-card.tsx
+++ b/frontend/src/components/learn/swipe-card.tsx
@@ -12,12 +12,13 @@ import { useFitText } from "./use-fit-text";
 // (`break-normal` — never mid-word); useFitText shrinks the font only when a
 // single word is wider than the card (e.g. "cardiovascular"), so that word fits
 // one line instead of overflowing, while multi-word fronts still wrap normally.
-// `max` mirrors the previous largest static size (the `sm:` step: text-5xl
-// unrevealed, text-3xl revealed); `min` is the floor below which an
+// `maxPx` mirrors the previous largest static size (`sm:text-5xl`). The SAME
+// ceiling is used whether or not the card is revealed, so the headword keeps a
+// constant size when the card is flipped — revealing only adds the translation
+// below it, it never resizes the term. `minPx` is the floor below which an
 // exceptionally long word is clipped by the card rather than shrunk to an
 // unreadable size.
-const FRONT_FIT_UNREVEALED = { maxPx: 48, minPx: 20 };
-const FRONT_FIT_REVEALED = { maxPx: 30, minPx: 16 };
+const FRONT_FIT = { maxPx: 48, minPx: 20 };
 
 export type { AnimatedCardHandle } from "./animated-card";
 
@@ -65,8 +66,11 @@ const AnimatedCard = dynamic(() => import("./animated-card").then((m) => m.Anima
 
 // CardContent is exported so animated-card.tsx can share the same presentational layer.
 export function CardContent({ card, revealed }: { card: SwipeCardData; revealed: boolean }) {
-  const { maxPx, minPx } = revealed ? FRONT_FIT_REVEALED : FRONT_FIT_UNREVEALED;
-  const { ref: frontRef, fontPx } = useFitText<HTMLParagraphElement>(card.front, maxPx, minPx);
+  const { ref: frontRef, fontPx } = useFitText<HTMLParagraphElement>(
+    card.front,
+    FRONT_FIT.maxPx,
+    FRONT_FIT.minPx,
+  );
 
   return (
     // `relative` anchors the absolutely-positioned CefrBadge to this card.

--- a/frontend/src/components/learn/swipe-card.tsx
+++ b/frontend/src/components/learn/swipe-card.tsx
@@ -8,12 +8,14 @@ import { CefrBadge } from "./cefr-badge";
 import type { SwipeDirection } from "./types";
 import { useFitText } from "./use-fit-text";
 
-// Front-term auto-fit bounds (px). The front is a single term held on one line
-// (`whitespace-nowrap`); useFitText shrinks the font so a long word like
-// "cardiovascular" fits the card width instead of wrapping. `max` mirrors the
-// previous static sizes (≈ text-5xl unrevealed, ≈ text-3xl revealed); `min`
-// is the floor below which the term may overflow the clipped card rather than
-// shrink to an unreadable size.
+// Front-term auto-fit bounds (px). The front wraps at word boundaries
+// (`break-normal` — never mid-word); useFitText shrinks the font only when a
+// single word is wider than the card (e.g. "cardiovascular"), so that word fits
+// one line instead of overflowing, while multi-word fronts still wrap normally.
+// `max` mirrors the previous largest static size (the `sm:` step: text-5xl
+// unrevealed, text-3xl revealed); `min` is the floor below which an
+// exceptionally long word is clipped by the card rather than shrunk to an
+// unreadable size.
 const FRONT_FIT_UNREVEALED = { maxPx: 48, minPx: 20 };
 const FRONT_FIT_REVEALED = { maxPx: 30, minPx: 16 };
 
@@ -85,18 +87,22 @@ export function CardContent({ card, revealed }: { card: SwipeCardData; revealed:
       <div className="flex min-h-0 flex-1 flex-col items-center justify-center gap-8 px-10 text-center">
         <p
           ref={frontRef}
-          // Single-line: useFitText measures the term at `maxPx` and shrinks
-          // the inline font-size to fit the card width (set via style, so it is
-          // a measured pixel value, not a Tailwind step). The outer card is
-          // `overflow-hidden`, so a term at the `minPx` floor is clipped rather
-          // than spilling past the card edge.
-          className="max-w-full whitespace-nowrap font-semibold leading-tight text-foreground"
+          // `break-normal` wraps at word boundaries and never breaks a word
+          // mid-character. useFitText measures the term at `maxPx` and shrinks
+          // the inline font-size (set via style — a measured pixel value, not a
+          // Tailwind step) only when the widest single word would overflow the
+          // card width; multi-word fronts wrap across lines instead. The outer
+          // card is `overflow-hidden`, so a word still too wide at the `minPx`
+          // floor is clipped rather than spilling past the card edge.
+          className="max-w-full break-normal font-semibold leading-tight text-foreground"
           style={{ fontSize: `${fontPx}px` }}
         >
           {card.front}
         </p>
         {revealed ? (
-          <p className="max-w-full break-words text-xl leading-relaxed text-muted-foreground sm:text-2xl">
+          // `break-normal` (not `break-words`): the translation wraps across
+          // lines at word boundaries and is never broken mid-word.
+          <p className="max-w-full break-normal text-xl leading-relaxed text-muted-foreground sm:text-2xl">
             {card.back}
           </p>
         ) : (

--- a/frontend/src/components/learn/swipe-card.tsx
+++ b/frontend/src/components/learn/swipe-card.tsx
@@ -3,10 +3,19 @@
 import dynamic from "next/dynamic";
 import type { RefObject } from "react";
 import type { CefrLevel } from "@/generated/graphql";
-import { cn } from "@/lib/utils";
 import type { AnimatedCardHandle } from "./animated-card";
 import { CefrBadge } from "./cefr-badge";
 import type { SwipeDirection } from "./types";
+import { useFitText } from "./use-fit-text";
+
+// Front-term auto-fit bounds (px). The front is a single term held on one line
+// (`whitespace-nowrap`); useFitText shrinks the font so a long word like
+// "cardiovascular" fits the card width instead of wrapping. `max` mirrors the
+// previous static sizes (≈ text-5xl unrevealed, ≈ text-3xl revealed); `min`
+// is the floor below which the term may overflow the clipped card rather than
+// shrink to an unreadable size.
+const FRONT_FIT_UNREVEALED = { maxPx: 48, minPx: 20 };
+const FRONT_FIT_REVEALED = { maxPx: 30, minPx: 16 };
 
 export type { AnimatedCardHandle } from "./animated-card";
 
@@ -54,6 +63,9 @@ const AnimatedCard = dynamic(() => import("./animated-card").then((m) => m.Anima
 
 // CardContent is exported so animated-card.tsx can share the same presentational layer.
 export function CardContent({ card, revealed }: { card: SwipeCardData; revealed: boolean }) {
+  const { maxPx, minPx } = revealed ? FRONT_FIT_REVEALED : FRONT_FIT_UNREVEALED;
+  const { ref: frontRef, fontPx } = useFitText<HTMLParagraphElement>(card.front, maxPx, minPx);
+
   return (
     // `relative` anchors the absolutely-positioned CefrBadge to this card.
     // The TOP-RIGHT corner is reserved for the CEFR badge; future FSRS badges
@@ -72,10 +84,14 @@ export function CardContent({ card, revealed }: { card: SwipeCardData; revealed:
       */}
       <div className="flex min-h-0 flex-1 flex-col items-center justify-center gap-8 px-10 text-center">
         <p
-          className={cn(
-            "max-w-full break-words font-semibold leading-tight text-foreground",
-            revealed ? "text-2xl sm:text-3xl" : "text-4xl sm:text-5xl",
-          )}
+          ref={frontRef}
+          // Single-line: useFitText measures the term at `maxPx` and shrinks
+          // the inline font-size to fit the card width (set via style, so it is
+          // a measured pixel value, not a Tailwind step). The outer card is
+          // `overflow-hidden`, so a term at the `minPx` floor is clipped rather
+          // than spilling past the card edge.
+          className="max-w-full whitespace-nowrap font-semibold leading-tight text-foreground"
+          style={{ fontSize: `${fontPx}px` }}
         >
           {card.front}
         </p>

--- a/frontend/src/components/learn/use-fit-text.dom.test.tsx
+++ b/frontend/src/components/learn/use-fit-text.dom.test.tsx
@@ -10,8 +10,11 @@ import { useFitText } from "./use-fit-text";
 // covered by computeFitFontSize in use-fit-text.test.ts.
 function Harness({ text, max, min }: { text: string; max: number; min: number }) {
   const { ref, fontPx } = useFitText<HTMLParagraphElement>(text, max, min);
+  // `data-font-px` mirrors the RETURNED React state, while `style.fontSize`
+  // also reflects the hook's imperative DOM write. Asserting both lets a test
+  // distinguish "the state updated" from "only the imperative write ran".
   return (
-    <p ref={ref} data-testid="fit" style={{ fontSize: `${fontPx}px` }}>
+    <p ref={ref} data-testid="fit" data-font-px={fontPx} style={{ fontSize: `${fontPx}px` }}>
       {text}
     </p>
   );
@@ -95,7 +98,10 @@ describe("useFitText — ResizeObserver present", () => {
       capturedCallback?.([], {} as ResizeObserver);
     });
 
-    // 48 * 100 / 200 = 24 — the re-fit ran and updated the applied size.
+    // 48 * 100 / 200 = 24 — the re-fit ran and updated the applied size...
     expect(el).toHaveStyle({ fontSize: "24px" });
+    // ...AND the returned React state was updated (not just the imperative DOM
+    // write) — so a re-render cannot revert the size to the stale value.
+    expect(el).toHaveAttribute("data-font-px", "24");
   });
 });

--- a/frontend/src/components/learn/use-fit-text.dom.test.tsx
+++ b/frontend/src/components/learn/use-fit-text.dom.test.tsx
@@ -1,0 +1,77 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useFitText } from "./use-fit-text";
+
+// Attaches the hook's ref to a real <p> so the effect's measure path runs.
+// jsdom has no layout engine, so clientWidth/scrollWidth read 0 and the hook
+// returns maxPx unchanged — this exercises the hook's CONTROL FLOW (ref attach,
+// measure-at-zero, ResizeObserver guard), not the numeric layout math (that is
+// covered by computeFitFontSize in use-fit-text.test.ts).
+function Harness({ text, max, min }: { text: string; max: number; min: number }) {
+  const { ref, fontPx } = useFitText<HTMLParagraphElement>(text, max, min);
+  return (
+    <p ref={ref} data-testid="fit" style={{ fontSize: `${fontPx}px` }}>
+      {text}
+    </p>
+  );
+}
+
+describe("useFitText — ResizeObserver absent (jsdom default)", () => {
+  it("initializes fontPx to maxPx and does not throw when ResizeObserver is undefined", () => {
+    // jsdom provides no ResizeObserver, so this reaches the typeof-undefined
+    // guard. A throw here would blank the card on first paint.
+    expect(() => render(<Harness text="hello" max={48} min={20} />)).not.toThrow();
+    expect(screen.getByTestId("fit")).toHaveStyle({ fontSize: "48px" });
+  });
+});
+
+describe("useFitText — ResizeObserver present", () => {
+  let observed: Element[];
+  let disconnectCount: number;
+
+  // Captures observe targets and disconnect calls. The constructor callback is
+  // intentionally ignored — these tests assert wiring (which element is
+  // observed, disconnect on unmount), not re-fit behavior.
+  class FakeResizeObserver {
+    observe(el: Element) {
+      observed.push(el);
+    }
+    unobserve() {}
+    disconnect() {
+      disconnectCount += 1;
+    }
+  }
+
+  beforeEach(() => {
+    observed = [];
+    disconnectCount = 0;
+    vi.stubGlobal("ResizeObserver", FakeResizeObserver);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("observes the PARENT element, not the text element, to avoid a measure loop", () => {
+    render(
+      <div data-testid="parent">
+        <Harness text="hello" max={48} min={20} />
+      </div>,
+    );
+
+    const textEl = screen.getByTestId("fit");
+    const parentEl = screen.getByTestId("parent");
+    expect(observed).toContain(parentEl);
+    expect(observed).not.toContain(textEl);
+  });
+
+  it("disconnects the observer on unmount (no leak)", () => {
+    const { unmount } = render(<Harness text="hello" max={48} min={20} />);
+    expect(disconnectCount).toBe(0);
+
+    unmount();
+
+    expect(disconnectCount).toBeGreaterThan(0);
+  });
+});

--- a/frontend/src/components/learn/use-fit-text.dom.test.tsx
+++ b/frontend/src/components/learn/use-fit-text.dom.test.tsx
@@ -1,13 +1,13 @@
 // @vitest-environment jsdom
-import { render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useFitText } from "./use-fit-text";
 
 // Attaches the hook's ref to a real <p> so the effect's measure path runs.
-// jsdom has no layout engine, so clientWidth/scrollWidth read 0 and the hook
-// returns maxPx unchanged — this exercises the hook's CONTROL FLOW (ref attach,
-// measure-at-zero, ResizeObserver guard), not the numeric layout math (that is
-// covered by computeFitFontSize in use-fit-text.test.ts).
+// jsdom has no layout engine, so clientWidth/scrollWidth read 0 unless a test
+// stubs them — this exercises the hook's CONTROL FLOW (ref attach, measure,
+// ResizeObserver guard, re-fit on resize), while the numeric layout math is
+// covered by computeFitFontSize in use-fit-text.test.ts.
 function Harness({ text, max, min }: { text: string; max: number; min: number }) {
   const { ref, fontPx } = useFitText<HTMLParagraphElement>(text, max, min);
   return (
@@ -29,11 +29,15 @@ describe("useFitText — ResizeObserver absent (jsdom default)", () => {
 describe("useFitText — ResizeObserver present", () => {
   let observed: Element[];
   let disconnectCount: number;
+  let capturedCallback: ResizeObserverCallback | null;
 
-  // Captures observe targets and disconnect calls. The constructor callback is
-  // intentionally ignored — these tests assert wiring (which element is
-  // observed, disconnect on unmount), not re-fit behavior.
+  // Captures the observe targets, disconnect calls, and the resize callback so a
+  // test can fire a synthetic resize. The constructor records the callback
+  // (real ResizeObserver delivers it); the body is never auto-invoked by jsdom.
   class FakeResizeObserver {
+    constructor(cb: ResizeObserverCallback) {
+      capturedCallback = cb;
+    }
     observe(el: Element) {
       observed.push(el);
     }
@@ -46,6 +50,7 @@ describe("useFitText — ResizeObserver present", () => {
   beforeEach(() => {
     observed = [];
     disconnectCount = 0;
+    capturedCallback = null;
     vi.stubGlobal("ResizeObserver", FakeResizeObserver);
   });
 
@@ -73,5 +78,24 @@ describe("useFitText — ResizeObserver present", () => {
     unmount();
 
     expect(disconnectCount).toBeGreaterThan(0);
+  });
+
+  it("re-fits (shrinks) when an observed resize reports a now-overflowing width", () => {
+    render(<Harness text="cardiovascular" max={48} min={20} />);
+    const el = screen.getByTestId("fit");
+    // Initial: jsdom widths are 0, so the unmeasured guard keeps maxPx.
+    expect(el).toHaveStyle({ fontSize: "48px" });
+
+    // Simulate a layout where the single word is twice the available width.
+    Object.defineProperty(el, "clientWidth", { configurable: true, value: 100 });
+    Object.defineProperty(el, "scrollWidth", { configurable: true, value: 200 });
+
+    // Fire the resize the observer is subscribed to.
+    act(() => {
+      capturedCallback?.([], {} as ResizeObserver);
+    });
+
+    // 48 * 100 / 200 = 24 — the re-fit ran and updated the applied size.
+    expect(el).toHaveStyle({ fontSize: "24px" });
   });
 });

--- a/frontend/src/components/learn/use-fit-text.test.ts
+++ b/frontend/src/components/learn/use-fit-text.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { computeFitFontSize } from "./use-fit-text";
+
+describe("computeFitFontSize", () => {
+  const BOUNDS = { maxPx: 48, minPx: 18 };
+
+  it("returns the max size when the word already fits within the available width", () => {
+    expect(computeFitFontSize({ availableWidth: 300, intrinsicWidth: 200, ...BOUNDS })).toBe(48);
+  });
+
+  it("treats an exact fit as fitting (no shrink at the boundary)", () => {
+    expect(computeFitFontSize({ availableWidth: 200, intrinsicWidth: 200, ...BOUNDS })).toBe(48);
+  });
+
+  it("shrinks proportionally when the word overflows the available width", () => {
+    // 48 * 100 / 200 = 24
+    expect(computeFitFontSize({ availableWidth: 100, intrinsicWidth: 200, ...BOUNDS })).toBe(24);
+  });
+
+  it("floors the shrunk size to a whole pixel", () => {
+    // 48 * 100 / 150 = 32 → fits; use a ratio that is non-integer:
+    // 48 * 100 / 140 = 34.28… → floor 34
+    expect(computeFitFontSize({ availableWidth: 100, intrinsicWidth: 140, ...BOUNDS })).toBe(34);
+  });
+
+  it("clamps to the minimum size for a pathologically long word", () => {
+    // 48 * 10 / 400 = 1.2 → floor 1 → clamped up to minPx (18)
+    expect(computeFitFontSize({ availableWidth: 10, intrinsicWidth: 400, ...BOUNDS })).toBe(18);
+  });
+
+  it("returns the max size when the container width is unmeasured (jsdom / pre-layout)", () => {
+    expect(computeFitFontSize({ availableWidth: 0, intrinsicWidth: 0, ...BOUNDS })).toBe(48);
+    expect(computeFitFontSize({ availableWidth: 0, intrinsicWidth: 200, ...BOUNDS })).toBe(48);
+  });
+
+  it("returns the max size when the text width is unmeasured (empty / hidden element)", () => {
+    expect(computeFitFontSize({ availableWidth: 300, intrinsicWidth: 0, ...BOUNDS })).toBe(48);
+  });
+});

--- a/frontend/src/components/learn/use-fit-text.ts
+++ b/frontend/src/components/learn/use-fit-text.ts
@@ -3,7 +3,11 @@ import { useLayoutEffect, useRef, useState } from "react";
 type FitParams = {
   /** Content-box width the text must fit into (px). */
   availableWidth: number;
-  /** Single-line width the text occupies at `maxPx` (px). */
+  /**
+   * Width the content needs at `maxPx` (px). For wrappable content this equals
+   * `availableWidth` unless a single unbreakable word overflows, in which case
+   * it is that word's width.
+   */
   intrinsicWidth: number;
   /** Upper bound: the size used when the text already fits. */
   maxPx: number;
@@ -12,10 +16,11 @@ type FitParams = {
 };
 
 /**
- * Pure font-size solver for single-line auto-fit text.
+ * Pure font-size solver: downscales only when the measured content width
+ * exceeds the available width.
  *
- * Downscale-only: a word that already fits keeps `maxPx`; a word that
- * overflows shrinks proportionally (text width scales ~linearly with
+ * Downscale-only: content that already fits keeps `maxPx`; when a single word
+ * overflows, the size shrinks proportionally (text width scales ~linearly with
  * font-size for the same string) and is clamped to `minPx`.
  *
  * A non-positive `availableWidth` or `intrinsicWidth` means the element has

--- a/frontend/src/components/learn/use-fit-text.ts
+++ b/frontend/src/components/learn/use-fit-text.ts
@@ -37,16 +37,19 @@ export function computeFitFontSize({
 }
 
 /**
- * Shrinks a single-line text element so a long word fits on one line instead
- * of wrapping. Attach `ref` to the text element (it must render with
- * `white-space: nowrap`) and apply the returned `fontPx` as its `font-size`.
+ * Shrinks a wrapping text element only when a single word is too wide for its
+ * content box, so that word fits on one line instead of overflowing — multi-word
+ * content still wraps normally at word boundaries and is left at `maxPx`. Attach
+ * `ref` to the text element (it should wrap at word boundaries, e.g. Tailwind
+ * `break-normal`) and apply the returned `fontPx` as its `font-size`.
  *
- * The element is measured at `maxPx` (its intrinsic single-line width via
- * `scrollWidth`) against the width it is allowed to occupy (`clientWidth`,
- * which a `max-width: 100%` text element caps at its parent's content box —
- * so the surrounding padding is respected automatically). Re-fits whenever the
- * parent container resizes (viewport change / rotation) and whenever `text`
- * changes.
+ * The element is measured at `maxPx` via `scrollWidth` — for wrappable content
+ * this equals `clientWidth` unless a single unbreakable word overflows, in which
+ * case it is that word's width. It is compared against the width the element is
+ * allowed to occupy (`clientWidth`, which a `max-width: 100%` text element caps
+ * at its parent's content box — so the surrounding padding is respected
+ * automatically). Re-fits whenever the parent container resizes (viewport change
+ * / rotation) and whenever `text` changes.
  */
 export function useFitText<T extends HTMLElement>(
   text: string,

--- a/frontend/src/components/learn/use-fit-text.ts
+++ b/frontend/src/components/learn/use-fit-text.ts
@@ -56,6 +56,7 @@ export function useFitText<T extends HTMLElement>(
   const ref = useRef<T>(null);
   const [fontPx, setFontPx] = useState(maxPx);
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: `text` is a trigger-only dependency; the effect re-measures `scrollWidth` when the card term changes but does not reference `text` in its body. Removing it (Biome's offered fix) would pin the font to the previous term's width.
   useLayoutEffect(() => {
     const el = ref.current;
     if (!el) return;

--- a/frontend/src/components/learn/use-fit-text.ts
+++ b/frontend/src/components/learn/use-fit-text.ts
@@ -1,0 +1,94 @@
+import { useLayoutEffect, useRef, useState } from "react";
+
+type FitParams = {
+  /** Content-box width the text must fit into (px). */
+  availableWidth: number;
+  /** Single-line width the text occupies at `maxPx` (px). */
+  intrinsicWidth: number;
+  /** Upper bound: the size used when the text already fits. */
+  maxPx: number;
+  /** Lower bound: the smallest size the text is allowed to shrink to. */
+  minPx: number;
+};
+
+/**
+ * Pure font-size solver for single-line auto-fit text.
+ *
+ * Downscale-only: a word that already fits keeps `maxPx`; a word that
+ * overflows shrinks proportionally (text width scales ~linearly with
+ * font-size for the same string) and is clamped to `minPx`.
+ *
+ * A non-positive `availableWidth` or `intrinsicWidth` means the element has
+ * not been laid out yet (the common case under jsdom, which has no layout
+ * engine, and on the first render before the ResizeObserver fires). In that
+ * case there is nothing to measure against, so we return `maxPx` and let the
+ * effect re-run once real dimensions exist.
+ */
+export function computeFitFontSize({
+  availableWidth,
+  intrinsicWidth,
+  maxPx,
+  minPx,
+}: FitParams): number {
+  if (availableWidth <= 0 || intrinsicWidth <= 0) return maxPx;
+  if (intrinsicWidth <= availableWidth) return maxPx;
+  const scaled = Math.floor((maxPx * availableWidth) / intrinsicWidth);
+  return Math.max(minPx, scaled);
+}
+
+/**
+ * Shrinks a single-line text element so a long word fits on one line instead
+ * of wrapping. Attach `ref` to the text element (it must render with
+ * `white-space: nowrap`) and apply the returned `fontPx` as its `font-size`.
+ *
+ * The element is measured at `maxPx` (its intrinsic single-line width via
+ * `scrollWidth`) against the width it is allowed to occupy (`clientWidth`,
+ * which a `max-width: 100%` text element caps at its parent's content box —
+ * so the surrounding padding is respected automatically). Re-fits whenever the
+ * parent container resizes (viewport change / rotation) and whenever `text`
+ * changes.
+ */
+export function useFitText<T extends HTMLElement>(
+  text: string,
+  maxPx: number,
+  minPx: number,
+): { ref: React.RefObject<T | null>; fontPx: number } {
+  const ref = useRef<T>(null);
+  const [fontPx, setFontPx] = useState(maxPx);
+
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    const measure = () => {
+      // Measure intrinsic width at a fixed reference size so the ratio is
+      // stable regardless of the size currently applied.
+      el.style.fontSize = `${maxPx}px`;
+      const next = computeFitFontSize({
+        availableWidth: el.clientWidth,
+        intrinsicWidth: el.scrollWidth,
+        maxPx,
+        minPx,
+      });
+      // Apply imperatively (no paint at the reference size) and keep React in
+      // sync for declarative re-renders.
+      el.style.fontSize = `${next}px`;
+      setFontPx(next);
+    };
+
+    measure();
+
+    // jsdom has no ResizeObserver; the initial measure() above is enough there.
+    if (typeof ResizeObserver === "undefined") return;
+
+    // Observe the parent (its width tracks the viewport) rather than `el`
+    // itself — changing `el`'s font-size would otherwise re-trigger the
+    // observer and risk a measure loop.
+    const target = el.parentElement ?? el;
+    const observer = new ResizeObserver(measure);
+    observer.observe(target);
+    return () => observer.disconnect();
+  }, [text, maxPx, minPx]);
+
+  return { ref, fontPx };
+}


### PR DESCRIPTION
## Summary

A long single word on a flashcard front (e.g. `cardiovascular`) used to wrap mid-word; it now auto-shrinks to fit on one line. Multi-word fronts wrap at word boundaries (never mid-word), and the headword keeps a constant size when the card is flipped — revealing only adds the translation below it. The shrink is driven by a new `useFitText` hook that measures the term's `scrollWidth` against the card width and applies an inline `font-size`, shrinking only when a single word is wider than the card; the layout math is isolated in a pure `computeFitFontSize` solver so it is unit-testable without a browser layout engine.

Frontend-only: no GraphQL schema or backend change.

This branch addresses no tracked issue.

## Changes

### Auto-fit hook + pure solver

- `components/learn/use-fit-text.ts` (new) — `computeFitFontSize(...)`, a pure downscale-only solver (proportional shrink, clamp to `minPx`, return `maxPx` for unmeasured/`0`-width input), plus the `useFitText(text, maxPx, minPx)` hook. The hook measures at a `maxPx` reference via `scrollWidth`/`clientWidth`, applies an inline `font-size`, observes the **parent** for re-fit (so font-size changes do not re-trigger its own observer — no measure loop), guards the jsdom no-`ResizeObserver` case, and carries a load-bearing `biome-ignore` for the trigger-only `text` dependency.

### Card wiring

- `components/learn/swipe-card.tsx` — `CardContent` wires `useFitText` into the front `<p>`. The front term switches to `break-normal` (wrap at word boundaries) from the prior single-line / `break-words` shape, and the back translation switches `break-words` → `break-normal` so neither is ever broken mid-word. A single `FRONT_FIT = { maxPx: 48, minPx: 20 }` ceiling is now used whether or not the card is revealed (previously `text-4xl sm:text-5xl` unrevealed / `text-2xl sm:text-3xl` revealed), so the headword no longer changes size on flip.

### Tests

- `components/learn/use-fit-text.test.ts` (new) — pure-solver unit tests: fits, exact boundary, proportional shrink, floor-to-whole-pixel, clamp-to-`minPx`, and both `0`-width guards.
- `components/learn/use-fit-text.dom.test.tsx` (new) — hook control flow in jsdom: the `ResizeObserver`-absent guard, observes-parent-not-text-element, disconnect-on-unmount, and re-fit-on-resize (fake `ResizeObserver` capturing the callback + `Object.defineProperty` stubs for `clientWidth`/`scrollWidth`, asserting both the applied `style.fontSize` and the returned React state via `data-font-px`).
- `components/learn/swipe-card.test.tsx` — front/back `<p>` carry `break-normal` (and not `break-words`/`break-all`/`whitespace-nowrap`); the front carries the inline ceiling and keeps it across an in-place reveal.

### Docs

- `docs/frontend/auto-fit-text.md` (new) + a pointer in `frontend/CLAUDE.md` — the `useFitText` pattern (the `break-normal` / measure-widest-word / observe-parent / load-bearing-write rules) and the jsdom-safe test harness (pure solver + fake `ResizeObserver`). Reuses the existing `docs/pagination/load-bearing-biome-ignore.md` for the trigger-only-dep rule rather than duplicating it.

## Verification

On `/learn/<cardgroupId>`, a card whose front is a long single word (e.g. `cardiovascular`) renders on one line at a reduced size instead of wrapping mid-word; a multi-word front wraps at spaces. Flipping the card keeps the front term at the same size and shows the translation below it. Resizing the viewport re-fits the term. The front and back `<p>` classNames use `break-normal` (not `break-words`/`whitespace-nowrap`), and the front `<p>` carries an inline `style="font-size: …px"`.

## Test plan

- [ ] `pnpm --filter frontend test` — 1323 passed (137 files)
- [ ] `pnpm --filter frontend typecheck` — exit 0
- [ ] `pnpm --filter frontend lint` — exit 0 (biome, `--error-on-warnings`)
- [ ] `pnpm --filter frontend build` — success
- [ ] Visual: a long single-word front fits one line (shrunk); a multi-word front wraps at word boundaries, never mid-word
- [ ] Visual: flipping a card keeps the front term the same size; the translation appears below
- [ ] Visual: resizing the viewport re-fits the front term
