### PR TITLE
fix(login): center the left/right panel split at 50/50

### DIFF
--- a/frontend/src/app/login/page.test.tsx
+++ b/frontend/src/app/login/page.test.tsx
@@ -106,12 +106,12 @@ describe("LoginPage", () => {
       ({ container } = render(jsx));
     });
 
-    it("outer wrapper has h-svh and the golden-ratio grid template", () => {
+    it("outer wrapper has h-svh and the even-split grid template", () => {
       const grid = container.querySelector("[data-testid='login-grid']");
       expect(grid).toBeInTheDocument();
       expect(grid?.className).toMatch(/h-svh/);
-      // φ split: brand column 1.618fr, form column 1fr.
-      expect(grid?.className).toMatch(/lg:grid-cols-\[1\.618fr_1fr\]/);
+      // Even split: two equal columns put the panel boundary at the centre.
+      expect(grid?.className).toMatch(/lg:grid-cols-2/);
     });
 
     it("brand panel has max-lg:hidden", () => {

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -28,12 +28,13 @@ export default async function LoginPage({ searchParams }: { searchParams: Search
   );
 
   return (
-    // Golden-ratio split: brand panel (61.8%) left, form column (38.2%) right.
-    // The `1.618fr_1fr` grid template is the exact φ division; below lg the brand
-    // panel is hidden and the form takes the full width.
-    <main data-testid="login-grid" className="relative grid h-svh lg:grid-cols-[1.618fr_1fr]">
-      {/* LEFT — brand panel (lg+ only). First grid child so it occupies the wider
-          golden column on the left. */}
+    // Even split: brand panel (50%) left, form column (50%) right. The
+    // `grid-cols-2` template divides the viewport equally so the panel boundary
+    // sits at the centre; below lg the brand panel is hidden and the form takes
+    // the full width.
+    <main data-testid="login-grid" className="relative grid h-svh lg:grid-cols-2">
+      {/* LEFT — brand panel (lg+ only). First grid child so it occupies the left
+          half. */}
       <div
         data-testid="brand-panel"
         className="max-lg:hidden relative flex items-center justify-center overflow-hidden bg-gradient-to-br from-[oklch(83%_0.11_22)] via-[oklch(72%_0.185_18.45)] to-[oklch(60%_0.2_13)]"
@@ -62,8 +63,8 @@ export default async function LoginPage({ searchParams }: { searchParams: Search
         </div>
       </div>
 
-      {/* RIGHT — form column. Second grid child → narrower golden column on the
-          right at lg+, full-width and centered below lg. */}
+      {/* RIGHT — form column. Second grid child → right half at lg+,
+          full-width and centered below lg. */}
       <div className="flex flex-col">
         <div
           data-testid="form-brand-header"


### PR DESCRIPTION
## Summary

The `/login` screen split the viewport with a golden-ratio grid (`lg:grid-cols-[1.618fr_1fr]`), placing the brand-panel / form-column boundary at ≈61.8% from the left. It now uses two equal columns (`lg:grid-cols-2`) so the boundary sits at the horizontal centre (50 / 50). The brand panel's internal Fibonacci / φ² lockup sizing (mark 144 / wordmark 55 / tagline 21, card `max-w-[377px]`) and the sub-`lg` responsive behaviour (brand panel hidden, form full-width) are unchanged.

Frontend-only: no GraphQL schema or backend change.

This branch addresses no tracked issue.

## Changes

### Even-split layout (`app/login/page.tsx`)

- `lg:grid-cols-[1.618fr_1fr]` → `lg:grid-cols-2` — the two columns become equal width, so the coral brand panel (left) and the form column (right) each take 50% and the dividing line falls at the viewport centre.
- The three split-describing comments (the grid block, the `LEFT` brand-panel note, the `RIGHT` form-column note) are rewritten from "golden-ratio / wider-golden / narrower-golden column" to the even-split description.

### Tests

- `login/page.test.tsx` — the grid-template assertion changes from `lg:grid-cols-[1.618fr_1fr]` to `lg:grid-cols-2`; the test name and inline comment are updated from "golden-ratio" / "φ split" to "even-split".

## Verification

On `/login` at `lg+`: the coral brand panel and the white sign-in column each occupy half the viewport, with the panel boundary at the horizontal centre instead of ≈62% from the left. Below `lg` (`max-lg:hidden`) the brand panel is still hidden and the form is full-width — unchanged. The rendered `[data-testid="login-grid"]` element carries `lg:grid-cols-2`. This also aligns the code with the example snippets in `docs/frontend/routing-topology.md` and `docs/frontend/rsc-error-handling/pages-bypassing-appshell-must-render-main.md`, which already showed `lg:grid-cols-2`.

## Test plan

- [x] `vitest run src/app/login/page.test.tsx` — 20 passed
- [x] `tsc --noEmit` — exit 0
- [x] `biome check --error-on-warnings` (changed files) — clean
- [ ] `pnpm --filter frontend test` (full suite) — to run in CI
- [ ] `pnpm --filter frontend knip` — to run in CI
- [ ] `pnpm --filter frontend build` — to run in CI
- [ ] Visual `/login` at `lg+`: brand panel / form column are 50 / 50, boundary at the centre
- [ ] Visual `/login` below `lg`: brand panel hidden, form full-width (unchanged)
