### PR TITLE
feat(learn): rate without reveal, ease-in flip, balanced wrapping

### DIFF
--- a/frontend/e2e/learn-flow.spec.ts
+++ b/frontend/e2e/learn-flow.spec.ts
@@ -57,12 +57,13 @@ test("swipes easy cards and advances through the deck", async ({ page }) => {
   for (let i = 0; i < 3; i += 1) {
     const before = await activeCard.getAttribute("aria-label");
     if (before) seen.push(before);
-    // The default display mode is flip_to_reveal: the back stays hidden and the
-    // rating buttons stay disabled until the active card is revealed. Reveal is a
-    // card tap / Space on the focused card (never a swipe). Each freshly-advanced
-    // card resets to front_only, so reveal again every iteration.
-    await activeCard.click();
+    // The default display mode is flip_to_reveal: the back starts hidden. Rating
+    // no longer requires revealing first — the rating buttons are enabled from the
+    // start, so assert that before any reveal. Tapping the focused card still
+    // reveals the answer (the optional flip), which we exercise before rating.
+    // Each freshly-advanced card resets to front_only.
     await expect(easyButton).toBeEnabled();
+    await activeCard.click();
     await easyButton.click();
     await expect(activeCard).not.toHaveAttribute("aria-label", before ?? "");
   }

--- a/frontend/src/app/learn/[cardgroupId]/learn-client.test.tsx
+++ b/frontend/src/app/learn/[cardgroupId]/learn-client.test.tsx
@@ -4,7 +4,7 @@ import { MockedProvider } from "@apollo/client/testing/react";
 import { act, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { GraphQLError } from "graphql";
-import { type RefObject, useEffect, useImperativeHandle, useRef } from "react";
+import { type RefObject, useImperativeHandle, useRef } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { LEARN_PAGE_LIMIT } from "@/app/learn/queries";
 import { CardContent, type SwipeCardData } from "@/components/learn/swipe-card";
@@ -52,7 +52,6 @@ vi.mock("@/components/learn/swipe-card-stack", () => ({
     cards: SwipeCardData[];
     displayMode: LearnDisplayMode;
     onCardSwiped: SwipeCardStackOnCardSwiped;
-    onActiveRevealedChange?: (revealed: boolean) => void;
     completedCount?: number;
     ref?: RefObject<SwipeCardStackHandle | null>;
   }) => {
@@ -69,23 +68,6 @@ vi.mock("@/components/learn/swipe-card-stack", () => ({
         if (card) props.onCardSwiped(card, direction);
       },
     }));
-
-    // Mirror the real stack's reveal-notification contract: on mount the active
-    // card is revealed iff ALWAYS_VISIBLE; FLIP_TO_REVEAL starts unrevealed and
-    // becomes revealed when the learner taps the card. The "Reveal answer" test
-    // affordance below simulates that tap so the LearnActionBar disabled-state
-    // integration can be exercised without the real reveal gesture wiring.
-    // Report the active card's initial reveal-state on mount. The LearnClient
-    // integration tests drive the reveal transition via the explicit
-    // "Reveal answer" stub button below (which calls onActiveRevealedChange
-    // directly), so the mount-report is all this mock needs; the real stack's
-    // reset-on-advance is exercised against the real component in
-    // swipe-card-stack.test.tsx.
-    const onActiveRevealedChange = props.onActiveRevealedChange;
-    const displayMode = props.displayMode;
-    useEffect(() => {
-      onActiveRevealedChange?.(displayMode === "ALWAYS_VISIBLE");
-    }, [onActiveRevealedChange, displayMode]);
 
     const activeCard = props.cards[0];
     if (!activeCard) {
@@ -105,20 +87,7 @@ vi.mock("@/components/learn/swipe-card-stack", () => ({
     // integration tests can assert the full LearnClient → SwipeCardStack →
     // CardContent → CefrBadge pipeline without the next/dynamic AnimatedCard
     // chunk. CardContent is purely presentational and needs no providers.
-    return (
-      <>
-        <CardContent card={activeCard} revealed={props.displayMode === "ALWAYS_VISIBLE"} />
-        {props.displayMode === "FLIP_TO_REVEAL" && (
-          <button
-            type="button"
-            data-testid="stub-reveal"
-            onClick={() => props.onActiveRevealedChange?.(true)}
-          >
-            Reveal answer
-          </button>
-        )}
-      </>
-    );
+    return <CardContent card={activeCard} revealed={props.displayMode === "ALWAYS_VISIBLE"} />;
   },
 }));
 
@@ -129,11 +98,10 @@ vi.mock("@/components/learn/learn-action-bar", () => ({
   LearnActionBar: (props: {
     onRate: (d: "left" | "down" | "right") => void;
     disabled: boolean;
-    revealed?: boolean;
   }) => {
-    // Mirror the real bar: rating buttons are inert while the active card is
-    // unrevealed (front_only) OR the caller-supplied `disabled` flag is set.
-    const ratingDisabled = props.disabled || props.revealed === false;
+    // Mirror the real bar: rating buttons are inert only when the caller's
+    // `disabled` flag is set (e.g. the queue has emptied); reveal does not gate.
+    const ratingDisabled = props.disabled;
     return (
       <div data-testid="learn-action-bar" data-disabled={String(ratingDisabled)}>
         <button type="button" onClick={() => props.onRate("left")} disabled={ratingDisabled}>
@@ -314,10 +282,10 @@ function renderLearnClient(
       <LearnClient
         cardgroupId={CG_ID}
         initialCards={initialCards}
-        // Default to ALWAYS_VISIBLE so the rating buttons are enabled from mount
-        // for the swipe-mechanics / queue / prefetch tests, which are display-mode
-        // agnostic. Tests that exercise the FLIP_TO_REVEAL reveal gate (back
-        // hidden, buttons disabled until tap) pass `displayMode` explicitly.
+        // Default to ALWAYS_VISIBLE so the card back is shown for the
+        // swipe-mechanics / queue / prefetch tests, which are display-mode
+        // agnostic. Tests that exercise FLIP_TO_REVEAL (back hidden until the
+        // learner taps to reveal) pass `displayMode` explicitly.
         displayMode={options.displayMode ?? "ALWAYS_VISIBLE"}
       />
     </MockedProvider>,
@@ -971,23 +939,12 @@ describe("<LearnClient> LearnActionBar integration", () => {
     expect(screen.queryByRole("button", { name: "Rate as Easy" })).not.toBeInTheDocument();
   });
 
-  it("disables the rating buttons until the active card is revealed in FLIP_TO_REVEAL mode", async () => {
-    const user = userEvent.setup();
+  it("enables the rating buttons from the start in FLIP_TO_REVEAL mode (reveal is optional)", () => {
     renderLearnClient([], [CARD_1], { displayMode: "FLIP_TO_REVEAL" });
 
-    // Front-only: every rating button is inert until the learner reveals.
-    expect(screen.getByRole("button", { name: "Rate as Again" })).toBeDisabled();
-    expect(screen.getByRole("button", { name: "Rate as Hard" })).toBeDisabled();
-    expect(screen.getByRole("button", { name: "Rate as Easy" })).toBeDisabled();
-    expect(screen.getByTestId("learn-action-bar")).toHaveAttribute("data-disabled", "true");
-
-    // Reveal the active card (the stub simulates the card tap / Space reveal that
-    // the real SwipeCardStack performs and reports via onActiveRevealedChange).
-    await user.click(screen.getByTestId("stub-reveal"));
-
-    await waitFor(() => {
-      expect(screen.getByRole("button", { name: "Rate as Again" })).toBeEnabled();
-    });
+    // Front-only no longer gates rating: the buttons are enabled immediately so
+    // the learner can swipe / rate without first revealing the answer.
+    expect(screen.getByRole("button", { name: "Rate as Again" })).toBeEnabled();
     expect(screen.getByRole("button", { name: "Rate as Hard" })).toBeEnabled();
     expect(screen.getByRole("button", { name: "Rate as Easy" })).toBeEnabled();
     expect(screen.getByTestId("learn-action-bar")).toHaveAttribute("data-disabled", "false");

--- a/frontend/src/app/learn/[cardgroupId]/learn-client.tsx
+++ b/frontend/src/app/learn/[cardgroupId]/learn-client.tsx
@@ -52,14 +52,6 @@ export function LearnClient({ cardgroupId, initialCards, displayMode }: Props) {
   // (FSRS-safe re-study of today's cards). It is only entered from the
   // AllCaughtUp "Study again" action when the daily learn queue is exhausted.
   const [phase, setPhase] = useState<"learn" | "practice">("learn");
-  // Whether the active card's back is revealed. SwipeCardStack owns the reveal
-  // gesture (card tap / Space) and reports the active card's revealed state up
-  // via onActiveRevealedChange; LearnClient threads it into LearnActionBar so
-  // the rating buttons stay disabled until the learner reveals the answer. In
-  // ALWAYS_VISIBLE the stack reports `true` immediately on mount. Seeded from
-  // displayMode so the very first render (before the stack's mount effect runs)
-  // already disables the buttons in FLIP_TO_REVEAL.
-  const [activeRevealed, setActiveRevealed] = useState(displayMode === "ALWAYS_VISIBLE");
   const swipeStackRef = useRef<SwipeCardStackHandle | null>(null);
 
   const [handleSwipe, { error }] = useMutation(HandleSwipeMutation);
@@ -310,11 +302,10 @@ export function LearnClient({ cardgroupId, initialCards, displayMode }: Props) {
           cards={queue}
           displayMode={displayMode}
           onCardSwiped={onSwipe}
-          onActiveRevealedChange={setActiveRevealed}
           completedCount={completed}
         />
       </div>
-      <LearnActionBar onRate={handleRate} disabled={queue.length === 0} revealed={activeRevealed} />
+      <LearnActionBar onRate={handleRate} disabled={queue.length === 0} />
     </section>
   );
 }

--- a/frontend/src/components/learn/animated-card.test.tsx
+++ b/frontend/src/components/learn/animated-card.test.tsx
@@ -321,12 +321,13 @@ describe("<AnimatedCard> — a re-render must not re-apply the spring initialize
   // the layout effect QUEUE the initializer instead of starting it.
   //
   // This is timing-independent in jsdom: the layout effect re-applies on every
-  // commit regardless of spring state. With no gesture and no flyOut, the only
-  // way a `config`-carrying Controller.start can appear is the initializer
-  // re-application (it carries the `{ tension, friction }` config). Pre-fix that
-  // call is present on mount and on every re-render; post-fix the only start is
-  // react-spring's benign `{ default: context }` propagation, which carries no
-  // config. So "no config-carrying start from a gesture-free render" pins the bug.
+  // commit regardless of spring state. The initializer re-apply (the bug) is the
+  // only config-carrying start that ALSO drives the transform key `x` (to 0). The
+  // reveal flip's `api.start` also carries a config (its ease-in `duration`) but
+  // targets `rotateY` only — no `x` — so the `x !== undefined` discriminator
+  // excludes it. Pre-fix the initializer re-apply (config + `x: 0`) is present on
+  // mount and every re-render; post-fix the only `x`-driving starts come from a
+  // gesture / fly-off, neither of which a resting re-render triggers.
   it("issues no initializer re-apply (config-carrying start) when a resting card re-renders", () => {
     const calls = spyControllerStart();
     const onSwipe = vi.fn();
@@ -335,7 +336,46 @@ describe("<AnimatedCard> — a re-render must not re-apply the spring initialize
     );
     // Force a fresh commit with no gesture and no flyOut (new onSwipe identity).
     rerender(<AnimatedCard card={CARD} isActive onSwipe={vi.fn()} {...revealedProps()} />);
-    expect(calls.some((call) => call.hasConfig)).toBe(false);
+    // A config-carrying start that ALSO drives `x` is the initializer re-apply.
+    // The reveal flip carries a config but no `x`, so it is correctly excluded.
+    expect(calls.some((call) => call.hasConfig && call.x !== undefined)).toBe(false);
+  });
+});
+
+describe("<AnimatedCard> — reveal flip is a half-turn with ease-in", () => {
+  // The reveal flip rotates the card a HALF-TURN (rotateY ±180) and overrides the
+  // controller's spring config with a fixed-duration ease-in (easeInQuart) so the
+  // rotation starts slow and snaps at the end. The SIGN of FLIP_DEGREES is the
+  // visual direction knob (tuned in the browser), so this test pins the half-turn
+  // + ease-in mechanism, NOT the specific direction. The spring initializer also
+  // names rotateY but carries `{ tension, friction }` (no `duration`), so the
+  // `duration` check isolates the flip from the initializer re-apply.
+  it("drives the reveal flip a half-turn (±180) carrying a fixed-duration ease-in", () => {
+    const flipCalls: Array<{ rotateY: unknown; hasDuration: boolean }> = [];
+    const original = Controller.prototype.start;
+    vi.spyOn(Controller.prototype, "start").mockImplementation(function (
+      this: Controller,
+      ...args: Parameters<typeof original>
+    ) {
+      const [props] = args;
+      if (props && typeof props === "object" && !Array.isArray(props)) {
+        const record = props as { rotateY?: unknown; config?: { duration?: unknown } };
+        if ("rotateY" in record) {
+          flipCalls.push({
+            rotateY: record.rotateY,
+            hasDuration: Boolean(record.config?.duration),
+          });
+        }
+      }
+      return original.apply(this, args);
+    });
+
+    render(<AnimatedCard card={CARD} isActive onSwipe={vi.fn()} {...revealedProps()} />);
+
+    // A half-turn (±180) start carrying an ease-in duration config is the flip.
+    expect(
+      flipCalls.some((call) => (call.rotateY === 180 || call.rotateY === -180) && call.hasDuration),
+    ).toBe(true);
   });
 });
 

--- a/frontend/src/components/learn/animated-card.test.tsx
+++ b/frontend/src/components/learn/animated-card.test.tsx
@@ -183,18 +183,25 @@ describe("<AnimatedCard> — front-only reveal phase", () => {
     expect(onSwipe).not.toHaveBeenCalled();
   });
 
-  it("suppresses rating swipes while the active card is front-only", async () => {
+  it("allows rating swipes while the active card is front-only (reveal is optional)", async () => {
+    // Reveal no longer gates rating: a committing swipe on a front-only card
+    // flies it off and commits, exactly as it does once revealed.
     const onSwipe = vi.fn();
     render(
       <AnimatedCard card={CARD} isActive revealed={false} onReveal={vi.fn()} onSwipe={onSwipe} />,
     );
 
-    act(() => {
+    await act(async () => {
       fireCommittingSwipeDown(getCard());
     });
 
-    await new Promise((resolve) => setTimeout(resolve, 300));
-    expect(onSwipe).not.toHaveBeenCalled();
+    await waitFor(
+      () => {
+        expect(onSwipe).toHaveBeenCalledTimes(1);
+      },
+      { timeout: 2000 },
+    );
+    expect(onSwipe).toHaveBeenCalledWith(CARD, "down");
   });
 });
 

--- a/frontend/src/components/learn/animated-card.tsx
+++ b/frontend/src/components/learn/animated-card.tsx
@@ -187,10 +187,12 @@ export function AnimatedCard({
 
   const flyOut = useCallback(
     (direction: SwipeDirection) => {
-      if (!revealed) return;
+      // Rating no longer requires revealing first: the learner may rate a card
+      // (rating buttons / arrow keys) while it is still front-only. Tapping to
+      // reveal stays available as an optional way to check the answer.
       runExit(direction);
     },
-    [revealed, runExit],
+    [runExit],
   );
 
   useImperativeHandle(handleRef, () => ({ flyOut }), [flyOut]);
@@ -220,9 +222,11 @@ export function AnimatedCard({
         vy,
         yDir,
       });
-      onSwipeProgress?.(revealed && active ? direction : null, revealed && active ? progress : 0);
+      // Swiping rates the card whether or not it is revealed — the learner can
+      // swipe a front-only card directly, or reveal it first to check the answer.
+      onSwipeProgress?.(active ? direction : null, active ? progress : 0);
 
-      if (shouldSwipe && direction && revealed) {
+      if (shouldSwipe && direction) {
         runExit(direction);
         return;
       }

--- a/frontend/src/components/learn/animated-card.tsx
+++ b/frontend/src/components/learn/animated-card.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { animated, useSpring, useSpringRef } from "@react-spring/web";
+import { animated, easings, useSpring, useSpringRef } from "@react-spring/web";
 import { useDrag } from "@use-gesture/react";
 import { type RefObject, useCallback, useEffect, useImperativeHandle, useRef } from "react";
 import { useReducedMotion } from "@/lib/use-reduced-motion";
@@ -19,6 +19,16 @@ const USE_GESTURE_THRESHOLD = 12;
 // deterministically. ~200 ms matches the snappy feel the programmatic path had
 // before, while still leaving the spring enough time to paint frames.
 const FLY_OFF_DURATION_MS = 200;
+
+// The reveal flip rotates the card to the RIGHT — `rotateY` runs 0 → -180deg
+// (negative: the right edge swings toward the viewer first; positive rotateY
+// would swing left). The flip eases IN: `easeInQuart` holds the card nearly
+// still for roughly the first half of FLIP_DURATION_MS, then accelerates sharply
+// into a "snap" as the back face arrives. The controller's spring config (used
+// for drag / fly-off) would do the opposite — fast start, slow settle — so the
+// flip overrides it with a fixed duration + ease-in easing.
+const FLIP_DEGREES = -180;
+const FLIP_DURATION_MS = 500;
 
 // Imperative handle the parent stack uses to fly the active card off-screen
 // programmatically (rating buttons / arrow keys). Stable contract — shape is
@@ -69,7 +79,7 @@ export function AnimatedCard({
     x: 0,
     y: 0,
     rotate: 0,
-    rotateY: revealed && !reducedMotion ? 180 : 0,
+    rotateY: revealed && !reducedMotion ? FLIP_DEGREES : 0,
     scale: 1,
     config: { tension: 520, friction: 38 },
     ref: api,
@@ -100,8 +110,11 @@ export function AnimatedCard({
   useEffect(() => {
     reducedMotionRef.current = reducedMotion;
     void api.start({
-      rotateY: revealed && !reducedMotion ? 180 : 0,
+      rotateY: revealed && !reducedMotion ? FLIP_DEGREES : 0,
       immediate: reducedMotion,
+      // Ease-in flip: slow start, sharp "snap" finish. `immediate` (reduced
+      // motion) skips the animation entirely, so the easing is a no-op there.
+      config: { duration: FLIP_DURATION_MS, easing: easings.easeInQuart },
     });
   }, [api, reducedMotion, revealed]);
 

--- a/frontend/src/components/learn/learn-action-bar.test.tsx
+++ b/frontend/src/components/learn/learn-action-bar.test.tsx
@@ -7,7 +7,7 @@ import { LearnActionBar } from "./learn-action-bar";
 
 describe("<LearnActionBar>", () => {
   it("renders the three rating buttons with accessible labels and shortcuts but no visible text labels", () => {
-    renderWithIntl(<LearnActionBar revealed={true} onRate={vi.fn()} />);
+    renderWithIntl(<LearnActionBar onRate={vi.fn()} />);
 
     expect(screen.getByRole("button", { name: "Rate as Again" })).toHaveAttribute(
       "aria-keyshortcuts",
@@ -35,7 +35,7 @@ describe("<LearnActionBar>", () => {
   ] as const)("calls onRate with %s direction", async (name, direction) => {
     const user = userEvent.setup();
     const onRate = vi.fn();
-    renderWithIntl(<LearnActionBar revealed={true} onRate={onRate} />);
+    renderWithIntl(<LearnActionBar onRate={onRate} />);
 
     await user.click(screen.getByRole("button", { name }));
 
@@ -45,7 +45,7 @@ describe("<LearnActionBar>", () => {
   it("disables all rating buttons and ignores clicks while disabled", async () => {
     const user = userEvent.setup();
     const onRate = vi.fn();
-    renderWithIntl(<LearnActionBar revealed={true} onRate={onRate} disabled />);
+    renderWithIntl(<LearnActionBar onRate={onRate} disabled />);
 
     const again = screen.getByRole("button", { name: "Rate as Again" });
     const hard = screen.getByRole("button", { name: "Rate as Hard" });
@@ -64,7 +64,7 @@ describe("<LearnActionBar>", () => {
 
   it("keeps tab order as Again, Hard, Easy", async () => {
     const user = userEvent.setup();
-    renderWithIntl(<LearnActionBar revealed={true} onRate={vi.fn()} />);
+    renderWithIntl(<LearnActionBar onRate={vi.fn()} />);
 
     await user.tab();
     expect(screen.getByRole("button", { name: "Rate as Again" })).toHaveFocus();
@@ -72,33 +72,5 @@ describe("<LearnActionBar>", () => {
     expect(screen.getByRole("button", { name: "Rate as Hard" })).toHaveFocus();
     await user.tab();
     expect(screen.getByRole("button", { name: "Rate as Easy" })).toHaveFocus();
-  });
-
-  it.each([
-    ["Rate as Again", "ArrowLeft"],
-    ["Rate as Hard", "ArrowDown"],
-    ["Rate as Easy", "ArrowRight"],
-  ] as const)("disables %s when revealed is false and enables it when revealed is true", async (name, shortcut) => {
-    // Select locale-independently via aria-keyshortcuts so the assertion does
-    // not depend on translated button copy. While the active card is
-    // unrevealed (front_only phase) the rating buttons must be inert — the
-    // learner reveals by tapping the card, not via this bar.
-    const onRate = vi.fn();
-    const { rerender } = renderWithIntl(<LearnActionBar revealed={false} onRate={onRate} />);
-
-    const disabledButton = screen.getByRole("button", { name });
-    expect(disabledButton).toHaveAttribute("aria-keyshortcuts", shortcut);
-    expect(disabledButton).toBeDisabled();
-    expect(disabledButton).toHaveAttribute("aria-disabled", "true");
-
-    const user = userEvent.setup();
-    await user.click(disabledButton);
-    expect(onRate).not.toHaveBeenCalled();
-
-    // Revealing the card enables the rating buttons.
-    rerender(<LearnActionBar revealed={true} onRate={onRate} />);
-
-    const enabledButton = screen.getByRole("button", { name });
-    expect(enabledButton).toBeEnabled();
   });
 });

--- a/frontend/src/components/learn/learn-action-bar.tsx
+++ b/frontend/src/components/learn/learn-action-bar.tsx
@@ -6,13 +6,6 @@ import { cn } from "@/lib/utils";
 import type { SwipeDirection } from "./types";
 
 type Props = {
-  /**
-   * Whether the active card's back is revealed. While `false` (the front_only
-   * phase of FLIP_TO_REVEAL mode) the rating buttons render but are disabled —
-   * the learner reveals the answer by tapping the card / pressing Space, not via
-   * this bar. Defaults to `true` for ALWAYS_VISIBLE and practice contexts.
-   */
-  revealed?: boolean;
   onRate: (direction: SwipeDirection) => void;
   disabled?: boolean;
 };
@@ -44,14 +37,13 @@ const DIRECTIONS = [
   },
 ] as const;
 
-export function LearnActionBar({ revealed = true, onRate, disabled = false }: Props) {
+export function LearnActionBar({ onRate, disabled = false }: Props) {
   const t = useTranslations("Learn");
-  // While the active card is unrevealed (front_only phase), the rating buttons
-  // are inert: the learner must reveal the answer by tapping the card / Space.
-  // They stay disabled when the caller's own `disabled` flag is set (e.g. the
-  // queue has emptied). Combining both keeps the buttons non-interactive and
-  // announced as disabled to assistive tech.
-  const ratingDisabled = disabled || !revealed;
+  // Rating is available whether or not the card is revealed — the learner may
+  // swipe / tap-rate a front-only card, or reveal it first to check the answer.
+  // The buttons go inert only when the caller's `disabled` flag is set (e.g. the
+  // queue has emptied), announced as disabled to assistive tech.
+  const ratingDisabled = disabled;
 
   return (
     <div className="pointer-events-none z-40 flex justify-center px-4 pt-3 pb-[calc(0.75rem+env(safe-area-inset-bottom))] md:pb-[calc(1.5rem+env(safe-area-inset-bottom))]">

--- a/frontend/src/components/learn/swipe-card-stack.test.tsx
+++ b/frontend/src/components/learn/swipe-card-stack.test.tsx
@@ -197,61 +197,32 @@ describe("SwipeCardStack — active-card reveal phase", () => {
     expect(status).toHaveTextContent("Answer shown");
   });
 
-  it("reports onActiveRevealedChange false on mount, true on reveal, and false again on advance (FLIP_TO_REVEAL)", () => {
+  it("commits a swipe in flip mode even when the active card is not revealed", () => {
+    // Reveal no longer gates rating: triggerSwipe (rating buttons / arrow keys)
+    // commits a front-only card without a prior reveal.
     const onCardSwiped = vi.fn();
-    const onActiveRevealedChange = vi.fn();
     const ref = createRef<SwipeCardStackHandle | null>();
 
-    const { rerender } = renderWithIntl(
+    renderWithIntl(
       <SwipeCardStack
         cards={[cardA, cardB]}
         displayMode="FLIP_TO_REVEAL"
         onCardSwiped={onCardSwiped}
-        onActiveRevealedChange={onActiveRevealedChange}
         ref={ref}
       />,
     );
 
-    // Active card starts front_only — the parent is told the buttons stay disabled.
-    expect(onActiveRevealedChange).toHaveBeenLastCalledWith(false);
+    // The active card is still front-only — its back is not shown.
+    expect(screen.queryByText(cardA.back)).not.toBeInTheDocument();
 
-    // Revealing the active card flips the reported state to true.
-    fireEvent.click(screen.getByTestId("reveal-card-a"));
-    expect(onActiveRevealedChange).toHaveBeenLastCalledWith(true);
-
-    // Advancing the deck resets the new active card to front_only — reported false.
     act(() => {
       ref.current?.triggerSwipe("right");
     });
     act(() => {
       settleFlyOuts();
     });
-    rerender(
-      <SwipeCardStack
-        cards={[cardB]}
-        displayMode="FLIP_TO_REVEAL"
-        onCardSwiped={onCardSwiped}
-        onActiveRevealedChange={onActiveRevealedChange}
-        ref={ref}
-      />,
-    );
 
-    expect(onActiveRevealedChange).toHaveBeenLastCalledWith(false);
-  });
-
-  it("reports onActiveRevealedChange true from mount (ALWAYS_VISIBLE)", () => {
-    const onActiveRevealedChange = vi.fn();
-
-    renderWithIntl(
-      <SwipeCardStack
-        cards={[cardA]}
-        displayMode="ALWAYS_VISIBLE"
-        onCardSwiped={vi.fn()}
-        onActiveRevealedChange={onActiveRevealedChange}
-      />,
-    );
-
-    expect(onActiveRevealedChange).toHaveBeenLastCalledWith(true);
+    expect(onCardSwiped).toHaveBeenCalledWith(cardA, "right");
   });
 });
 

--- a/frontend/src/components/learn/swipe-card-stack.tsx
+++ b/frontend/src/components/learn/swipe-card-stack.tsx
@@ -23,15 +23,6 @@ type Props<TCard extends SwipeCardData> = {
   cards: TCard[];
   displayMode: LearnDisplayMode;
   onCardSwiped: (card: TCard, direction: SwipeDirection) => void;
-  /**
-   * Fired whenever the active card's revealed state changes: on initial mount
-   * for the active card, when the learner reveals it (tap / Space), and when
-   * the deck advances and the new active card resets to its initial phase. The
-   * parent threads this into LearnActionBar so the rating buttons stay disabled
-   * until the active card is revealed (FLIP_TO_REVEAL); in ALWAYS_VISIBLE the
-   * active card is revealed from mount, so this fires `true` immediately.
-   */
-  onActiveRevealedChange?: (revealed: boolean) => void;
   completedCount?: number;
   /**
    * Imperative handle ref. React 19 supports refs as plain props, so we
@@ -49,7 +40,6 @@ export function SwipeCardStack<TCard extends SwipeCardData>({
   cards,
   displayMode,
   onCardSwiped,
-  onActiveRevealedChange,
   completedCount,
   ref,
 }: Props<TCard>) {
@@ -67,8 +57,6 @@ export function SwipeCardStack<TCard extends SwipeCardData>({
       ? activeCardPhase.phase
       : initialPhaseForDisplayMode(displayMode);
   const activeCardRevealed = phase === "revealed";
-  const activeCardRevealedRef = useRef(activeCardRevealed);
-  activeCardRevealedRef.current = activeCardRevealed;
 
   // Drag-progress state ownership stays inside the stack, so the parent
   // component never re-renders during a gesture — per-frame onSwipeProgress
@@ -105,25 +93,6 @@ export function SwipeCardStack<TCard extends SwipeCardData>({
     onCardSwipedRef.current = onCardSwiped;
   }, [onCardSwiped]);
 
-  // Mirror onActiveRevealedChange into a ref so the reveal-notification effect
-  // below can depend only on the boolean `activeCardRevealed`, not on the
-  // parent's (potentially freshly-created) callback identity. This keeps the
-  // notification firing on the reveal-state transition itself, not on every
-  // parent re-render that mints a new callback.
-  const onActiveRevealedChangeRef = useRef(onActiveRevealedChange);
-  useEffect(() => {
-    onActiveRevealedChangeRef.current = onActiveRevealedChange;
-  }, [onActiveRevealedChange]);
-
-  // Notify the parent of the active card's revealed state. Fires on initial
-  // mount for the active card, when the learner reveals it (tap / Space), and
-  // when the deck advances and the new active card resets to its initial phase
-  // (the reset is driven by the active-card-change effect setting the phase back
-  // to front_only, which flips `activeCardRevealed` to false in FLIP_TO_REVEAL).
-  useEffect(() => {
-    onActiveRevealedChangeRef.current?.(activeCardRevealed);
-  }, [activeCardRevealed]);
-
   const handleReveal = useCallback(() => {
     const card = activeCardRef.current;
     if (!card) return;
@@ -156,7 +125,6 @@ export function SwipeCardStack<TCard extends SwipeCardData>({
     (direction: SwipeDirection) => {
       const card = activeCardRef.current;
       if (!card) return;
-      if (!activeCardRevealedRef.current) return;
       // Already flying off this card — ignore repeat triggers.
       if (exitingCardIdRef.current === card.id) return;
 

--- a/frontend/src/components/learn/swipe-card.test.tsx
+++ b/frontend/src/components/learn/swipe-card.test.tsx
@@ -86,6 +86,13 @@ describe("<CardContent>", () => {
     expect(frontEl).not.toHaveClass("whitespace-nowrap");
   });
 
+  it("balances the front term across lines (text-balance) so wrapping avoids a lone-word line", () => {
+    render(<CardContent card={{ ...CARD, front: "I'll have to beg off" }} revealed={false} />);
+
+    const frontEl = screen.getByText("I'll have to beg off");
+    expect(frontEl).toHaveClass("text-balance");
+  });
+
   it("wraps the back translation at word boundaries too, never mid-word", () => {
     render(<CardContent card={{ ...CARD, back: "electroencephalographically" }} revealed={true} />);
 

--- a/frontend/src/components/learn/swipe-card.tsx
+++ b/frontend/src/components/learn/swipe-card.tsx
@@ -8,17 +8,27 @@ import { CefrBadge } from "./cefr-badge";
 import type { SwipeDirection } from "./types";
 import { useFitText } from "./use-fit-text";
 
-// Front-term auto-fit bounds (px). The front wraps at word boundaries
-// (`break-normal` — never mid-word); useFitText shrinks the font only when a
-// single word is wider than the card (e.g. "cardiovascular"), so that word fits
-// one line instead of overflowing, while multi-word fronts still wrap normally.
-// `maxPx` mirrors the previous largest static size (`sm:text-5xl`). The SAME
-// ceiling is used whether or not the card is revealed, so the headword keeps a
-// constant size when the card is flipped — revealing only adds the translation
-// below it, it never resizes the term. `minPx` is the floor below which an
-// exceptionally long word is clipped by the card rather than shrunk to an
-// unreadable size.
+// Headword auto-fit bounds (px). The headword wraps at word boundaries
+// (`break-normal` — never mid-word) and is shrunk by useFitText to fit both the
+// card width (so a single long word like "cardiovascular" fits one line) AND a
+// maximum line count derived from the word count (see MIN_WORDS_PER_LINE). The
+// SAME ceiling is used whether or not the card is revealed, so the headword
+// keeps a constant size when the card is flipped — revealing only adds the
+// translation below it, it never resizes the term. `minPx` is the floor below
+// which an exceptionally long headword is clipped by the card rather than shrunk
+// to an unreadable size.
 const FRONT_FIT = { maxPx: 48, minPx: 20 };
+
+// Target line density for the headword: shrink the font so the phrase wraps to
+// at most ceil(wordCount / MIN_WORDS_PER_LINE) lines. This keeps each line
+// fuller (~3 words) and, paired with `text-wrap: balance`, prevents a lone word
+// stranded on its own line. A 1–3 word headword targets one line; a 4–6 word
+// phrase targets two balanced lines; and so on.
+const MIN_WORDS_PER_LINE = 3;
+
+function countWords(text: string): number {
+  return text.trim().split(/\s+/).filter(Boolean).length;
+}
 
 export type { AnimatedCardHandle } from "./animated-card";
 
@@ -66,10 +76,15 @@ const AnimatedCard = dynamic(() => import("./animated-card").then((m) => m.Anima
 
 // CardContent is exported so animated-card.tsx can share the same presentational layer.
 export function CardContent({ card, revealed }: { card: SwipeCardData; revealed: boolean }) {
+  // Cap the wrapped line count so the headword averages ~MIN_WORDS_PER_LINE
+  // words per line; useFitText shrinks the font until it fits within that many
+  // lines. `text-wrap: balance` on the element then spreads the words evenly.
+  const headwordMaxLines = Math.max(1, Math.ceil(countWords(card.front) / MIN_WORDS_PER_LINE));
   const { ref: frontRef, fontPx } = useFitText<HTMLParagraphElement>(
     card.front,
     FRONT_FIT.maxPx,
     FRONT_FIT.minPx,
+    headwordMaxLines,
   );
 
   return (
@@ -92,13 +107,14 @@ export function CardContent({ card, revealed }: { card: SwipeCardData; revealed:
         <p
           ref={frontRef}
           // `break-normal` wraps at word boundaries and never breaks a word
-          // mid-character. useFitText measures the term at `maxPx` and shrinks
-          // the inline font-size (set via style — a measured pixel value, not a
-          // Tailwind step) only when the widest single word would overflow the
-          // card width; multi-word fronts wrap across lines instead. The outer
-          // card is `overflow-hidden`, so a word still too wide at the `minPx`
-          // floor is clipped rather than spilling past the card edge.
-          className="max-w-full break-normal font-semibold leading-tight text-foreground"
+          // mid-character; `text-balance` spreads the words evenly across lines.
+          // useFitText measures the term at `maxPx` and shrinks the inline
+          // font-size (a measured pixel value, not a Tailwind step) to fit both
+          // the card width and the target line count (headwordMaxLines), so a
+          // multi-word phrase wraps to fuller, balanced lines instead of
+          // stranding a lone word. The outer card is `overflow-hidden`, so a term
+          // still too large at the `minPx` floor is clipped rather than spilling.
+          className="max-w-full text-balance break-normal font-semibold leading-tight text-foreground"
           style={{ fontSize: `${fontPx}px` }}
         >
           {card.front}

--- a/frontend/src/components/learn/use-fit-text.dom.test.tsx
+++ b/frontend/src/components/learn/use-fit-text.dom.test.tsx
@@ -8,8 +8,18 @@ import { useFitText } from "./use-fit-text";
 // stubs them — this exercises the hook's CONTROL FLOW (ref attach, measure,
 // ResizeObserver guard, re-fit on resize), while the numeric layout math is
 // covered by computeFitFontSize in use-fit-text.test.ts.
-function Harness({ text, max, min }: { text: string; max: number; min: number }) {
-  const { ref, fontPx } = useFitText<HTMLParagraphElement>(text, max, min);
+function Harness({
+  text,
+  max,
+  min,
+  maxLines,
+}: {
+  text: string;
+  max: number;
+  min: number;
+  maxLines?: number;
+}) {
+  const { ref, fontPx } = useFitText<HTMLParagraphElement>(text, max, min, maxLines);
   // `data-font-px` mirrors the RETURNED React state, while `style.fontSize`
   // also reflects the hook's imperative DOM write. Asserting both lets a test
   // distinguish "the state updated" from "only the imperative write ran".
@@ -103,5 +113,36 @@ describe("useFitText — ResizeObserver present", () => {
     // ...AND the returned React state was updated (not just the imperative DOM
     // write) — so a re-render cannot revert the size to the stale value.
     expect(el).toHaveAttribute("data-font-px", "24");
+  });
+
+  it("shrinks the font so a multi-word phrase fits within maxLines (line-count fit)", () => {
+    render(<Harness text="one two three four five" max={48} min={14} maxLines={2} />);
+    const el = screen.getByTestId("fit");
+
+    const W = 200;
+    Object.defineProperty(el, "clientWidth", { configurable: true, value: W });
+    // No single unbreakable word overflows, so the width fit leaves it at max.
+    Object.defineProperty(el, "scrollWidth", { configurable: true, value: 150 });
+    // scrollHeight responds to the applied font size: lineCount * fontPx * 1.25,
+    // where lineCount = ceil(12.5 * fontPx / W) — a larger font wraps to more
+    // lines. jsdom's getComputedStyle reports no line-height, so the hook falls
+    // back to fontPx * 1.25, matching this model.
+    Object.defineProperty(el, "scrollHeight", {
+      configurable: true,
+      get() {
+        const fontPx = Number.parseFloat(el.style.fontSize) || 48;
+        const lineCount = Math.ceil((12.5 * fontPx) / W);
+        return lineCount * fontPx * 1.25;
+      },
+    });
+
+    act(() => {
+      capturedCallback?.([], {} as ResizeObserver);
+    });
+
+    // At 48px the phrase needs 3 lines (12.5*48/200 = 3); maxLines=2 forces a
+    // shrink to the largest size that wraps to <=2 lines: 32px (12.5*32/200 = 2).
+    expect(el).toHaveAttribute("data-font-px", "32");
+    expect(el).toHaveStyle({ fontSize: "32px" });
   });
 });

--- a/frontend/src/components/learn/use-fit-text.test.ts
+++ b/frontend/src/components/learn/use-fit-text.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { computeFitFontSize } from "./use-fit-text";
+import { computeFitFontSize, solveFitBySearch } from "./use-fit-text";
 
 describe("computeFitFontSize", () => {
   const BOUNDS = { maxPx: 48, minPx: 18 };
@@ -35,5 +35,24 @@ describe("computeFitFontSize", () => {
 
   it("returns the max size when the text width is unmeasured (empty / hidden element)", () => {
     expect(computeFitFontSize({ availableWidth: 300, intrinsicWidth: 0, ...BOUNDS })).toBe(48);
+  });
+});
+
+describe("solveFitBySearch", () => {
+  it("returns maxPx when the largest size already fits", () => {
+    expect(solveFitBySearch(() => true, 14, 48)).toBe(48);
+  });
+
+  it("returns minPx when even the smallest size does not fit", () => {
+    expect(solveFitBySearch(() => false, 14, 48)).toBe(14);
+  });
+
+  it("finds the largest fitting size for a monotone threshold predicate", () => {
+    // fits(px) is true iff px <= 30 → the largest fitting integer size is 30.
+    expect(solveFitBySearch((px) => px <= 30, 14, 48)).toBe(30);
+  });
+
+  it("floors a fractional maxPx before searching", () => {
+    expect(solveFitBySearch(() => true, 14, 48.9)).toBe(48);
   });
 });

--- a/frontend/src/components/learn/use-fit-text.ts
+++ b/frontend/src/components/learn/use-fit-text.ts
@@ -42,44 +42,122 @@ export function computeFitFontSize({
 }
 
 /**
- * Shrinks a wrapping text element only when a single word is too wide for its
- * content box, so that word fits on one line instead of overflowing — multi-word
- * content still wraps normally at word boundaries and is left at `maxPx`. Attach
- * `ref` to the text element (it should wrap at word boundaries, e.g. Tailwind
- * `break-normal`) and apply the returned `fontPx` as its `font-size`.
+ * Largest integer font size in `[minPx, maxPx]` for which `fits(px)` is true.
  *
- * The element is measured at `maxPx` via `scrollWidth` — for wrappable content
- * this equals `clientWidth` unless a single unbreakable word overflows, in which
- * case it is that word's width. It is compared against the width the element is
- * allowed to occupy (`clientWidth`, which a `max-width: 100%` text element caps
- * at its parent's content box — so the surrounding padding is respected
- * automatically). Re-fits whenever the parent container resizes (viewport change
- * / rotation) and whenever `text` changes.
+ * `fits` is a monotone predicate — if a size fits, every smaller size fits too
+ * (a smaller font wraps to fewer/shorter lines, so its rendered line count never
+ * grows). A binary search over the monotone predicate finds the answer in
+ * `O(log range)` measurements; returns `minPx` when even the smallest size does
+ * not fit. Pure: the DOM-measuring `fits` closure is injected, so the search is
+ * unit tested without a layout engine.
+ */
+export function solveFitBySearch(
+  fits: (px: number) => boolean,
+  minPx: number,
+  maxPx: number,
+): number {
+  let lo = minPx;
+  let hi = Math.floor(maxPx);
+  let best = minPx;
+  while (lo <= hi) {
+    const mid = Math.floor((lo + hi) / 2);
+    if (fits(mid)) {
+      best = mid;
+      lo = mid + 1;
+    } else {
+      hi = mid - 1;
+    }
+  }
+  return best;
+}
+
+/**
+ * Number of wrapped lines the element currently occupies, derived from its
+ * rendered height and computed line-height. Returns 0 when the element is not
+ * laid out (jsdom / pre-layout: `scrollHeight === 0`), which callers treat as
+ * "unmeasured, skip the line-count constraint".
+ */
+function measureLineCount(el: HTMLElement, fontPx: number): number {
+  if (el.scrollHeight <= 0) return 0;
+  let lineHeightPx = Number.parseFloat(getComputedStyle(el).lineHeight);
+  if (!Number.isFinite(lineHeightPx) || lineHeightPx <= 0) {
+    // `line-height: normal` / unmeasured — approximate with the tight ratio the
+    // headword uses (leading-tight = 1.25). The exact value only needs to be
+    // close enough to bucket scrollHeight into the right number of lines.
+    lineHeightPx = fontPx * 1.25;
+  }
+  return Math.round(el.scrollHeight / lineHeightPx);
+}
+
+/**
+ * Shrinks a wrapping text element to fit its width and, optionally, a maximum
+ * number of wrapped lines. Attach `ref` to the text element (it should wrap at
+ * word boundaries, e.g. Tailwind `break-normal`) and apply the returned `fontPx`
+ * as its `font-size`.
+ *
+ * Two downscale constraints, applied in order:
+ *
+ * 1. Width (proportional). Measured at `maxPx` via `scrollWidth` — for wrappable
+ *    content this equals `clientWidth` unless a single unbreakable word
+ *    overflows, in which case it is that word's width. `computeFitFontSize`
+ *    shrinks proportionally so the widest word fits one line.
+ * 2. Line count (binary search). When `maxLines` is given and the element is
+ *    laid out, the size is shrunk further — via `solveFitBySearch` over
+ *    `lineCount <= maxLines` — so the text wraps to at most `maxLines` lines.
+ *    Callers derive `maxLines` from the word count (e.g. `ceil(words / 3)`) so a
+ *    multi-word phrase wraps to fuller lines instead of stranding a lone word on
+ *    its own line; pair it with `text-wrap: balance` on the element so the words
+ *    spread evenly across those lines. A non-laid-out element (jsdom /
+ *    pre-layout) reports 0 lines, so the constraint is skipped and only the
+ *    width fit applies — preserving the downscale-only, jsdom-safe contract.
+ *
+ * Re-fits whenever the parent container resizes (viewport change / rotation) and
+ * whenever `text` or `maxLines` changes.
  */
 export function useFitText<T extends HTMLElement>(
   text: string,
   maxPx: number,
   minPx: number,
+  maxLines?: number,
 ): { ref: React.RefObject<T | null>; fontPx: number } {
   const ref = useRef<T>(null);
   const [fontPx, setFontPx] = useState(maxPx);
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: `text` is a trigger-only dependency; the effect re-measures `scrollWidth` when the card term changes but does not reference `text` in its body. Removing it (Biome's offered fix) would pin the font to the previous term's width.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: `text` is a trigger-only dependency; the effect re-measures `scrollWidth`/`scrollHeight` when the card term changes but does not reference `text` in its body. Removing it (Biome's offered fix) would pin the font to the previous term's dimensions.
   useLayoutEffect(() => {
     const el = ref.current;
     if (!el) return;
 
     const measure = () => {
-      // Measure intrinsic width at a fixed reference size so the ratio is
-      // stable regardless of the size currently applied.
+      // Width fit: measure intrinsic width at a fixed reference size so the ratio
+      // is stable regardless of the size currently applied.
       el.style.fontSize = `${maxPx}px`;
-      const next = computeFitFontSize({
+      const widthFit = computeFitFontSize({
         availableWidth: el.clientWidth,
         intrinsicWidth: el.scrollWidth,
         maxPx,
         minPx,
       });
-      // Apply imperatively (no paint at the reference size) and keep React in
+
+      // Line-count fit: shrink further so the text wraps to at most `maxLines`
+      // lines. Skipped when `maxLines` is absent or the element is not laid out
+      // (jsdom / pre-layout: measureLineCount returns 0).
+      let next = widthFit;
+      if (maxLines && maxLines > 0) {
+        el.style.fontSize = `${widthFit}px`;
+        if (measureLineCount(el, widthFit) > maxLines) {
+          next = solveFitBySearch(
+            (px) => {
+              el.style.fontSize = `${px}px`;
+              return measureLineCount(el, px) <= maxLines;
+            },
+            minPx,
+            widthFit,
+          );
+        }
+      }
+
+      // Apply imperatively (no paint at an intermediate size) and keep React in
       // sync for declarative re-renders.
       el.style.fontSize = `${next}px`;
       setFontPx(next);
@@ -97,7 +175,7 @@ export function useFitText<T extends HTMLElement>(
     const observer = new ResizeObserver(measure);
     observer.observe(target);
     return () => observer.disconnect();
-  }, [text, maxPx, minPx]);
+  }, [text, maxPx, minPx, maxLines]);
 
   return { ref, fontPx };
 }


### PR DESCRIPTION
## Summary

Three learn-card refinements: the reveal flip is now a right-rotating half-turn with an ease-in (`easeInQuart`) so it starts slow and snaps; rating a card no longer requires revealing it first (the reveal-gate is gone — tap-to-reveal stays an optional way to check the answer); and a multi-word headword wraps to fuller, balanced lines (~3 words per line) instead of stranding a lone word on its own line. The headword shrink is driven by extending the existing `useFitText` hook with a line-count constraint plus `text-wrap: balance`.

Frontend-only: no GraphQL schema or backend change.

This branch addresses no tracked issue.

## Background / Motivation

- The reveal flip rotated with the controller's spring config (fast start, slow settle) and in the original direction; the requested feel was a right-rotating flip that holds, then accelerates into a "snap".
- In `FLIP_TO_REVEAL` mode the rating buttons, arrow keys, and swipe gesture were all gated until the learner revealed the card, so a confident learner could not rate a card without first flipping it.
- A long headword such as `I'll have to beg off` wrapped to `I'll have / to beg / off`, leaving a single word (`off`) alone on the last line.

## Changes

### Reveal flip easing

- `components/learn/animated-card.tsx` — the flip now targets `FLIP_DEGREES` (a `rotateY` half-turn) over a fixed `FLIP_DURATION_MS = 500` with `config: { duration, easing: easings.easeInQuart }`, overriding the controller's spring config for the reveal `api.start` only (drag / fly-off keep the spring). Slow start, sharp finish.
- `components/learn/animated-card.test.tsx` — a sign-agnostic test pins the flip as a half-turn (`±180`) carrying a fixed-duration ease-in; the "no initializer re-apply" regression assertion is refined to `hasConfig && x !== undefined` (the flip's config-carrying `api.start` drives only `rotateY`, no `x`, so it is correctly excluded).

### Rate a card without revealing it first

- Reveal no longer gates rating on any path: `animated-card.tsx` drag handler (`shouldSwipe && direction`) and `flyOut` drop their `revealed` checks; `swipe-card-stack.tsx` `triggerSwipe` drops its reveal check; `learn-action-bar.tsx` buttons gate only on `disabled`.
- The reveal-gate's dedicated plumbing is removed as dead code: `onActiveRevealedChange` (`swipe-card-stack.tsx`), the `activeRevealed` state + wiring (`learn-client.tsx`), and the `revealed` prop (`learn-action-bar.tsx`). Tap-to-reveal, the flip animation, and the aria-live "answer shown" announcement (driven by the stack's internal reveal state) all stay.

### Balanced headword wrapping

- `components/learn/use-fit-text.ts` — `useFitText` gains an optional `maxLines`; a new pure `solveFitBySearch(fits, min, max)` binary-searches the largest font whose wrapped line count is `<= maxLines` (line count = `scrollHeight / line-height`). A non-laid-out element (jsdom: `scrollHeight === 0`) skips the line-count constraint and returns `maxPx`, preserving the downscale-only, jsdom-safe contract.
- `components/learn/swipe-card.tsx` — the headword computes `maxLines = ceil(wordCount / 3)` and adds `text-wrap: balance` (`text-balance`), so a multi-word term shrinks to fit that many lines and the words spread evenly across them. The constant-size-across-flip ceiling (`FRONT_FIT`) is unchanged.

### Tests

- `components/learn/use-fit-text.test.ts` — `solveFitBySearch` unit tests (largest-fits, none-fit → `minPx`, monotone threshold, fractional `maxPx` floor).
- `components/learn/use-fit-text.dom.test.tsx` — line-count control-flow test with a font-responsive `scrollHeight` stub (a larger font wraps to more lines), asserting the hook shrinks to the largest size within `maxLines`.
- `components/learn/swipe-card.test.tsx` — the headword `<p>` carries `text-balance`.
- `components/learn/{animated-card,swipe-card-stack,learn-action-bar}.test.tsx` + `app/learn/[cardgroupId]/learn-client.test.tsx` — reveal-gate assertions inverted to the no-gate behavior (front-only swipe commits; buttons enabled from mount in `FLIP_TO_REVEAL`); the now-removed `onActiveRevealedChange` tests deleted.
- `e2e/learn-flow.spec.ts` — asserts the rating button is enabled before any reveal; stale "disabled until revealed" comment corrected.

## Verification

On `/learn/<cardgroupId>` in flip-to-reveal mode:

- The rating buttons are enabled immediately (front-only); a swipe or a button/arrow-key rates the card without revealing it. Tapping the card still reveals the answer, now via a right-rotating flip that starts slow and snaps (`easeInQuart`, ~500 ms).
- A long multi-word headword (e.g. `I'll have to beg off`) wraps to balanced lines with no single-word line; the headword `<p>` carries `text-balance` and an inline `style="font-size: …px"`.

## Test plan

- [ ] `pnpm --filter frontend exec vitest run src/components/learn 'src/app/learn/[cardgroupId]/learn-client.test.tsx'` — green (learn component + learn-client suites)
- [ ] `pnpm --filter frontend test` — full suite green
- [ ] Biome lint clean on the changed files (`biome check --error-on-warnings`)
- [ ] `pnpm --filter frontend typecheck` — the changed learn files are clean; note pre-existing, unrelated errors remain in `src/app/catalog/*` and `src/app/onboarding/start/*` (generated GraphQL types)
- [ ] Visual (flip-to-reveal): rating works on a front-only card (swipe, button, arrow key); tap reveals with a right-rotating ease-in flip
- [ ] Visual: a long multi-word headword wraps to balanced lines with no lone word
