### PR TITLE
refactor(schemas): use shared graphemeCount helper in profile schema

### DIFF
--- a/frontend/src/schemas/profile.ts
+++ b/frontend/src/schemas/profile.ts
@@ -1,13 +1,8 @@
 import { z } from "zod";
+import { graphemeCount } from "./grapheme";
 
 // Mirrors UpdateProfileInput in schema/schema.graphql; bio: undefined = unchanged, "" = explicit clear.
 // UAX #29 grapheme cluster counting keeps FE and BE length rules in sync.
-const segmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
-
-function graphemeCount(s: string): number {
-  return Array.from(segmenter.segment(s)).length;
-}
-
 const displayName = z
   .string()
   .trim()


### PR DESCRIPTION
## Summary

`frontend/src/schemas/profile.ts` re-declared its own `Intl.Segmenter` + local `graphemeCount` instead of importing the shared `graphemeCount` from `frontend/src/schemas/grapheme.ts`. It now imports the shared counter, so all five Zod schemas (`card`, `cardgroup`, `master`, `role`, `profile`) count graphemes through a single source of truth. **Pure DRY refactor — no behaviour change, no signature change.**

Closes #443.

## Background / Motivation

- `grapheme.ts` exists specifically to keep FE and BE length rules in sync via one UAX #29 counter (ZWJ emoji count as 1 grapheme) — its docstring says so.
- Four schemas already honoured that invariant: `card.ts`, `cardgroup.ts`, `master.ts`, and `role.ts` all `import { graphemeCount } from "./grapheme"`.
- Only `profile.ts` re-implemented the identical counter locally (byte-for-byte the same logic as `grapheme.ts`). If UAX #29 counting is ever adjusted in `grapheme.ts`, the local copy would silently drift and break the "single counter" invariant the other four schemas uphold.

## Changes

### `schemas/profile.ts`

- Added `import { graphemeCount } from "./grapheme";` alongside the existing `import { z } from "zod";`.
- Deleted the local `segmenter` const and the local `graphemeCount` function (the duplicated UAX #29 counter).
- The three `.refine((s) => graphemeCount(s) ...)` call sites (display-name min/max, bio max) are unchanged — they now resolve to the shared function.
- The explanatory comment documenting the `bio` trinary contract (`undefined` = unchanged, `""` = explicit clear) is retained.

### Tests

- No test changes — counting behaviour is identical, so existing `schemas/profile` validation tests pass unchanged.

## Verification

```bash
# All five schemas route grapheme counting through grapheme.ts:
grep -rn 'from "./grapheme"' frontend/src/schemas/
# The only remaining local Intl.Segmenter in schemas is grapheme.ts itself:
grep -rln 'Intl.Segmenter' frontend/src/schemas/
```

The branch diff is `frontend/src/schemas/profile.ts` only (1 file changed, +1 / -6).

## Test plan

- [x] `pnpm --filter frontend typecheck` — exit 0
- [x] `pnpm --filter frontend lint` (`biome check --error-on-warnings`) — clean
- [x] `pnpm --filter frontend knip` — exit 0
- [x] `pnpm --filter frontend test` — 1327 passed (137 files)
- [x] `pnpm --filter frontend build` — success
- [x] No inline CJK in changed source
