### PR TITLE
refactor(profile): extract shared useUpdateProfile hook

### DIFF
--- a/frontend/src/app/onboarding/onboarding-form.tsx
+++ b/frontend/src/app/onboarding/onboarding-form.tsx
@@ -1,38 +1,15 @@
 "use client";
 
-import { useMutation } from "@apollo/client/react";
 import { useForm } from "@tanstack/react-form";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { useState } from "react";
+import { useUpdateProfile } from "@/app/profile/use-update-profile";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { graphql } from "@/generated";
-import { getBackendErrorBanner } from "@/lib/apollo/errors";
-import { liftGraphQLCodes } from "@/lib/apollo/graphql-errors";
 import { FieldError } from "@/lib/forms/field-error";
 import { updateProfileSchema } from "@/schemas/profile";
-
-const UpdateProfileMutation = graphql(`
-  mutation UpdateProfile($input: UpdateProfileInput!) {
-    updateProfile(input: $input) {
-      __typename
-      ... on UpdateProfileSuccess {
-        user {
-          id
-          displayName
-          bio
-          avatarUrl
-        }
-      }
-      ... on InputValidationError {
-        field
-        message
-      }
-    }
-  }
-`);
 
 export function OnboardingForm() {
   const router = useRouter();
@@ -49,7 +26,7 @@ export function OnboardingForm() {
   // Mid-session auth failures or unexpected payloads. Cleared on each submission.
   const [bannerMessage, setBannerMessage] = useState<string | null>(null);
 
-  const [updateProfile, { loading }] = useMutation(UpdateProfileMutation);
+  const { submit, loading } = useUpdateProfile();
 
   const displayNameSchema = updateProfileSchema.shape.displayName;
 
@@ -61,45 +38,29 @@ export function OnboardingForm() {
       setValidationError(null);
       setBannerMessage(null);
 
-      const result = await updateProfile({
-        variables: {
-          input: {
-            displayName: value.displayName,
-          },
-        },
-      }).catch((err) => {
-        const codes = liftGraphQLCodes(err);
-        if (codes.includes("UNAUTHENTICATED")) {
+      const outcome = await submit({
+        displayName: value.displayName,
+      });
+
+      switch (outcome.status) {
+        case "success":
+          router.push("/onboarding/start");
+          return;
+        case "validation":
+          setValidationError({ field: outcome.field, message: outcome.message });
+          return;
+        case "unauthenticated":
           setBannerMessage(t("sessionExpired"));
-          return null;
-        }
-        const banner = getBackendErrorBanner(err) ?? tCommon("somethingWentWrong");
-        setBannerMessage(banner);
-        console.error("[OnboardingForm] mutation rejection", err);
-        throw err; // keep formState.isSubmitSuccessful correct
-      });
-
-      if (!result) return;
-
-      const payload = result.data?.updateProfile;
-
-      if (payload?.__typename === "InputValidationError") {
-        setValidationError({ field: payload.field, message: payload.message });
-        return;
+          return;
+        case "unexpected":
+          setBannerMessage(tCommon("somethingWentWrong"));
+          return;
+        case "rejected":
+          setBannerMessage(outcome.banner ?? tCommon("somethingWentWrong"));
+          // Re-throw so TanStack Form keeps formState.isSubmitSuccessful=false; the
+          // outer form.handleSubmit().catch() at the JSX call site swallows it.
+          throw new Error("[OnboardingForm] update profile rejected");
       }
-
-      if (payload?.__typename === "UpdateProfileSuccess") {
-        router.push("/onboarding/start");
-        return;
-      }
-
-      // Unknown variant: null payload or a future union variant the client was not
-      // regenerated against.
-      const unknownPayload = payload as unknown as { __typename?: string } | null | undefined;
-      console.warn("[OnboardingForm] unexpected updateProfile payload", {
-        typename: unknownPayload?.__typename ?? null,
-      });
-      setBannerMessage(tCommon("somethingWentWrong"));
     },
   });
 

--- a/frontend/src/app/profile/profile-form.tsx
+++ b/frontend/src/app/profile/profile-form.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useMutation } from "@apollo/client/react";
 import { useForm } from "@tanstack/react-form";
 import Link from "next/link";
 import { useTranslations } from "next-intl";
@@ -9,31 +8,9 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
-import { graphql } from "@/generated";
-import { getBackendErrorBanner } from "@/lib/apollo/errors";
-import { liftGraphQLCodes } from "@/lib/apollo/graphql-errors";
 import { FieldError } from "@/lib/forms/field-error";
 import { updateProfileSchema } from "@/schemas/profile";
-
-const UpdateProfileMutation = graphql(`
-  mutation UpdateProfile($input: UpdateProfileInput!) {
-    updateProfile(input: $input) {
-      __typename
-      ... on UpdateProfileSuccess {
-        user {
-          id
-          displayName
-          bio
-          avatarUrl
-        }
-      }
-      ... on InputValidationError {
-        field
-        message
-      }
-    }
-  }
-`);
+import { useUpdateProfile } from "./use-update-profile";
 
 type Props = {
   /** The user's email address. Required — callers must pass the value or explicit null; never collapse to "". */
@@ -84,7 +61,7 @@ export function ProfileForm({
   // Mid-session auth failures or unexpected payloads. Cleared on each submission.
   const [bannerMessage, setBannerMessage] = useState<string | null>(null);
 
-  const [updateProfile, { loading, reset }] = useMutation(UpdateProfileMutation);
+  const { submit, loading, reset } = useUpdateProfile();
 
   const resetLocalState = useCallback(() => {
     setValidationError(null);
@@ -112,46 +89,30 @@ export function ProfileForm({
       setValidationError(null);
       setBannerMessage(null);
 
-      const result = await updateProfile({
-        variables: {
-          input: {
-            displayName: value.displayName,
-            bio: value.bio,
-          },
-        },
-      }).catch((err) => {
-        const codes = liftGraphQLCodes(err);
-        if (codes.includes("UNAUTHENTICATED")) {
+      const outcome = await submit({
+        displayName: value.displayName,
+        bio: value.bio,
+      });
+
+      switch (outcome.status) {
+        case "success":
+          onSaved?.();
+          return;
+        case "validation":
+          setValidationError({ field: outcome.field, message: outcome.message });
+          return;
+        case "unauthenticated":
           setBannerMessage(t("sessionExpired"));
-          return null;
-        }
-        const banner = getBackendErrorBanner(err) ?? tCommon("somethingWentWrong");
-        setBannerMessage(banner);
-        console.error("[ProfileForm] mutation rejection", err);
-        throw err; // keep formState.isSubmitSuccessful correct
-      });
-
-      if (!result) return;
-
-      const payload = result.data?.updateProfile;
-
-      if (payload?.__typename === "InputValidationError") {
-        setValidationError({ field: payload.field, message: payload.message });
-        return;
+          return;
+        case "unexpected":
+          setBannerMessage(tCommon("somethingWentWrong"));
+          return;
+        case "rejected":
+          setBannerMessage(outcome.banner ?? tCommon("somethingWentWrong"));
+          // Re-throw so TanStack Form keeps formState.isSubmitSuccessful=false; the
+          // outer form.handleSubmit().catch() at the JSX call site swallows it.
+          throw new Error("[ProfileForm] update profile rejected");
       }
-
-      if (payload?.__typename === "UpdateProfileSuccess") {
-        onSaved?.();
-        return;
-      }
-
-      // Unknown variant: null payload or a future union variant the client was not
-      // regenerated against.
-      const unknownPayload = payload as unknown as { __typename?: string } | null | undefined;
-      console.warn("[ProfileForm] unexpected updateProfile payload", {
-        typename: unknownPayload?.__typename ?? null,
-      });
-      setBannerMessage(tCommon("somethingWentWrong"));
     },
   });
 

--- a/frontend/src/app/profile/use-update-profile.test.tsx
+++ b/frontend/src/app/profile/use-update-profile.test.tsx
@@ -1,0 +1,169 @@
+// @vitest-environment jsdom
+import type { MockedResponse } from "@apollo/client/testing";
+import { MockedProvider } from "@apollo/client/testing/react";
+import { act, renderHook } from "@testing-library/react";
+import { GraphQLError } from "graphql";
+import { createElement, type ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { UpdateProfileDocument } from "@/generated/graphql";
+import { type UpdateProfileOutcome, useUpdateProfile } from "./use-update-profile";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const INPUT = { displayName: "Alice" };
+const REQUEST = { query: UpdateProfileDocument, variables: { input: INPUT } };
+
+function renderUpdateProfile(mocks: MockedResponse[]) {
+  return renderHook(() => useUpdateProfile(), {
+    wrapper: ({ children }: { children: ReactNode }) =>
+      createElement(MockedProvider, { mocks }, children),
+  });
+}
+
+type RenderResult = ReturnType<typeof renderUpdateProfile>["result"];
+
+async function runSubmit(result: RenderResult): Promise<UpdateProfileOutcome> {
+  let outcome: UpdateProfileOutcome | undefined;
+  await act(async () => {
+    outcome = await result.current.submit(INPUT);
+  });
+  return outcome as UpdateProfileOutcome;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("useUpdateProfile", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns success when the server resolves UpdateProfileSuccess", async () => {
+    const mocks = [
+      {
+        request: REQUEST,
+        result: {
+          data: {
+            updateProfile: {
+              __typename: "UpdateProfileSuccess",
+              user: {
+                __typename: "User",
+                id: "user-1",
+                displayName: "Alice",
+                bio: null,
+                avatarUrl: null,
+              },
+            },
+          },
+        },
+      },
+    ];
+
+    const { result } = renderUpdateProfile(mocks);
+    const outcome = await runSubmit(result);
+
+    expect(outcome).toEqual({ status: "success" });
+  });
+
+  it("returns validation with the field + message on InputValidationError", async () => {
+    const mocks = [
+      {
+        request: REQUEST,
+        result: {
+          data: {
+            updateProfile: {
+              __typename: "InputValidationError",
+              field: "displayName",
+              message: "displayName must be 1-50 characters",
+            },
+          },
+        },
+      },
+    ];
+
+    const { result } = renderUpdateProfile(mocks);
+    const outcome = await runSubmit(result);
+
+    expect(outcome).toEqual({
+      status: "validation",
+      field: "displayName",
+      message: "displayName must be 1-50 characters",
+    });
+  });
+
+  it("returns unauthenticated when the mutation rejects with UNAUTHENTICATED", async () => {
+    const mocks = [
+      {
+        request: REQUEST,
+        result: {
+          errors: [
+            new GraphQLError("Unauthenticated", { extensions: { code: "UNAUTHENTICATED" } }),
+          ],
+        },
+      },
+    ];
+
+    const { result } = renderUpdateProfile(mocks);
+    const outcome = await runSubmit(result);
+
+    expect(outcome).toEqual({ status: "unauthenticated" });
+  });
+
+  it("returns rejected with the backend banner on a non-auth GraphQL error", async () => {
+    const mocks = [
+      {
+        request: REQUEST,
+        result: {
+          errors: [
+            new GraphQLError("Something went wrong on the server", {
+              extensions: { code: "INTERNAL" },
+            }),
+          ],
+        },
+      },
+    ];
+
+    const { result } = renderUpdateProfile(mocks);
+    const outcome = await runSubmit(result);
+
+    expect(outcome).toEqual({
+      status: "rejected",
+      banner: "Something went wrong on the server",
+    });
+  });
+
+  it("returns rejected with the generic network banner on a transport error", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const mocks = [{ request: REQUEST, error: new Error("network down") }];
+
+    const { result } = renderUpdateProfile(mocks);
+    const outcome = await runSubmit(result);
+
+    expect(outcome).toEqual({
+      status: "rejected",
+      banner: "Could not reach the server. Please try again.",
+    });
+    // Redaction contract: the structured warn must not leak err.message.
+    const warnArgs = warnSpy.mock.calls.flat().map((a) => JSON.stringify(a));
+    expect(warnArgs.some((a) => a.includes("network down"))).toBe(false);
+  });
+
+  it("returns unexpected on an unknown / future union variant", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const mocks = [
+      {
+        request: REQUEST,
+        result: { data: { updateProfile: { __typename: "SomeFutureVariant" } } },
+      },
+    ];
+
+    const { result } = renderUpdateProfile(mocks);
+    const outcome = await runSubmit(result);
+
+    expect(outcome).toEqual({ status: "unexpected" });
+    expect(warnSpy).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/app/profile/use-update-profile.ts
+++ b/frontend/src/app/profile/use-update-profile.ts
@@ -1,0 +1,106 @@
+"use client";
+
+import { useMutation } from "@apollo/client/react";
+import { useCallback } from "react";
+import { graphql } from "@/generated";
+import type { UpdateProfileInput } from "@/generated/graphql";
+import { getBackendErrorBanner } from "@/lib/apollo/errors";
+import { liftGraphQLCodes } from "@/lib/apollo/graphql-errors";
+
+const UpdateProfileMutation = graphql(`
+  mutation UpdateProfile($input: UpdateProfileInput!) {
+    updateProfile(input: $input) {
+      __typename
+      ... on UpdateProfileSuccess {
+        user {
+          id
+          displayName
+          bio
+          avatarUrl
+        }
+      }
+      ... on InputValidationError {
+        field
+        message
+      }
+    }
+  }
+`);
+
+/**
+ * Discriminated outcome of an update-profile attempt. Both `/profile`
+ * (`ProfileForm`) and `/onboarding` (`OnboardingForm`) consume this hook and
+ * branch on `status`:
+ *
+ * - `success`        — the caller runs its own success behaviour (profile calls
+ *   `onSaved()`; onboarding navigates to `/onboarding/start`).
+ * - `validation`     — a typed `InputValidationError`; the caller surfaces the
+ *   `message` under the named `field`.
+ * - `unauthenticated`— the session expired mid-submit; the caller shows its own
+ *   sign-in banner. The submit completes normally (no re-throw).
+ * - `unexpected`     — a null payload, partial-response null bubble, or a future
+ *   union variant the client was not regenerated against; the caller shows a
+ *   generic banner. The submit completes normally (no re-throw).
+ * - `rejected`       — a non-auth transport / `INTERNAL` error. `banner` carries
+ *   the derived backend message (`null` when none could be extracted, so the
+ *   caller falls back to its own generic copy). Forms backed by TanStack Form
+ *   re-throw on this outcome to keep `formState.isSubmitSuccessful` false.
+ *
+ * Mirrors the established feature-hook shape of `useImportMaster` /
+ * `useCreateCardgroup`: the hook owns the mutation document and the typed-outcome
+ * classification; the caller owns presentation (i18n copy, navigation, re-throw).
+ */
+export type UpdateProfileOutcome =
+  | { status: "success" }
+  | { status: "validation"; field: string; message: string }
+  | { status: "unauthenticated" }
+  | { status: "unexpected" }
+  | { status: "rejected"; banner: string | null };
+
+/**
+ * Shared `updateProfile` mutation + typed-outcome translation. Declares the
+ * `UpdateProfile` document once (previously duplicated byte-for-byte between
+ * `profile-form.tsx` and `onboarding-form.tsx`) and classifies every response
+ * into an `UpdateProfileOutcome`.
+ *
+ * `reset` is the underlying Apollo mutation reset, surfaced for `ProfileForm`'s
+ * `onRegisterReset` flow; onboarding does not use it.
+ */
+export function useUpdateProfile() {
+  const [updateProfile, { loading, reset }] = useMutation(UpdateProfileMutation);
+
+  const submit = useCallback(
+    async (input: UpdateProfileInput): Promise<UpdateProfileOutcome> => {
+      try {
+        const result = await updateProfile({ variables: { input } });
+        const payload = result.data?.updateProfile;
+        // Capture typename before narrowing so the unknown-variant branch can log
+        // it (TypeScript narrows to `never` after the known cases).
+        const typename = payload?.__typename ?? null;
+        if (payload?.__typename === "InputValidationError") {
+          return { status: "validation", field: payload.field, message: payload.message };
+        }
+        if (payload?.__typename === "UpdateProfileSuccess") {
+          return { status: "success" };
+        }
+        // Null payload, partial-response null bubble, or a future union variant
+        // the client was not regenerated against.
+        console.warn("[useUpdateProfile] unexpected updateProfile payload", { typename });
+        return { status: "unexpected" };
+      } catch (err) {
+        const codes = liftGraphQLCodes(err);
+        if (codes.includes("UNAUTHENTICATED")) return { status: "unauthenticated" };
+        // err.message is omitted — backend messages may echo user input.
+        // codes is safe to log (fixed enum of GraphQL extension codes).
+        console.warn("[useUpdateProfile] updateProfile rejected", {
+          name: err instanceof Error ? err.name : "unknown",
+          codes,
+        });
+        return { status: "rejected", banner: getBackendErrorBanner(err) ?? null };
+      }
+    },
+    [updateProfile],
+  );
+
+  return { submit, loading, reset };
+}


### PR DESCRIPTION
## Summary

`profile-form.tsx` and `onboarding-form.tsx` each declared a byte-identical `UpdateProfile` mutation document and re-implemented the same submit/outcome branching. Both now consume a shared `useUpdateProfile` hook that owns the document and the typed-outcome classification; each form keeps only its own fields and success-time navigation. **Pure DRY refactor — no user-visible behaviour change.**

Closes #444.

## Background / Motivation

- The `UpdateProfile` mutation document was duplicated byte-for-byte (only a blank-line difference) between the two forms.
- The submit handlers were near-identical: success / `InputValidationError` / unknown-payload / `UNAUTHENTICATED` / non-auth transport-error branching, copied in both files — a new union variant had to be handled twice and could drift independently.
- `useImportMaster` / `useCreateCardgroup` already establish the feature-hook shape in this repo (own the mutation + typed-outcome translation, return a discriminated union); the profile/onboarding pair was the outlier.

## Changes

### New `app/profile/use-update-profile.ts`

- Declares the `UpdateProfile` document once (previously inlined in both forms).
- Wraps `useMutation`; exposes `submit(input): Promise<UpdateProfileOutcome>` plus `loading` and `reset`.
- `UpdateProfileOutcome` is a discriminated union: `success | validation | unauthenticated | unexpected | rejected`. `rejected` carries the derived backend `banner` (from `getBackendErrorBanner`, `null` when none could be extracted); the other four classify the resolved / auth / unknown-payload responses.
- Redacted structured `console.warn` for the unknown-payload and transport-rejection paths (logs `name` + extension `codes`, never `err.message`) — mirrors the sibling hooks and the redaction contract.

### `app/profile/profile-form.tsx`

- Replaces the local document + inline `.catch` branching with `const { submit, loading, reset } = useUpdateProfile();` and a `switch (outcome.status)`.
- Keeps its own concerns: field rendering, dirty/submitting bridges, `onSaved()` on success, and `reset` wiring via `onRegisterReset`.

### `app/onboarding/onboarding-form.tsx`

- Same swap; keeps `router.push("/onboarding/start")` on success.
- Both forms re-throw on the `rejected` outcome so TanStack Form keeps `formState.isSubmitSuccessful = false` (the issue #111 regression contract) — `rejected` is the only branch that throws; the other four return normally.

### Tests

- New `app/profile/use-update-profile.test.tsx` covers every outcome branch (success, validation, unauthenticated, rejected via GraphQL `INTERNAL`, rejected via network, unexpected) with `renderHook` + `MockedProvider`, including a redaction assertion that the warn payload carries no `err.message`.
- Existing `profile-form.test.tsx` / `onboarding-form.test.tsx` are unchanged and pass — they mock the generated `UpdateProfileDocument`, whose codegen output is unaffected by moving the document.

## Verification

```bash
# Exactly one UpdateProfile document outside generated code:
grep -rln "mutation UpdateProfile" frontend/src --include='*.ts' --include='*.tsx' | grep -v generated
# Both forms consume the hook; neither re-declares useMutation / graphql():
grep -n "useUpdateProfile" frontend/src/app/profile/profile-form.tsx frontend/src/app/onboarding/onboarding-form.tsx
grep -nE "useMutation|graphql\(" frontend/src/app/profile/profile-form.tsx frontend/src/app/onboarding/onboarding-form.tsx  # → no matches
```

## Test plan

- [x] `pnpm --filter frontend typecheck` — exit 0
- [x] `pnpm --filter frontend lint` (`biome check --error-on-warnings`) — clean
- [x] `pnpm --filter frontend knip` — exit 0 (hook + `UpdateProfileOutcome` wired)
- [x] `pnpm --filter frontend test` — 1333 passed (138 files)
- [x] `pnpm --filter frontend build` — success
- [x] No inline CJK in changed source
