### PR TITLE
refactor(apollo): dedupe admin mutation auth banners

### DIFF
--- a/frontend/src/app/admin/masters/admin-masters-client.tsx
+++ b/frontend/src/app/admin/masters/admin-masters-client.tsx
@@ -13,7 +13,7 @@ import { Button } from "@/components/ui/button";
 import { FormSheet } from "@/components/ui/form-sheet";
 import { Input } from "@/components/ui/input";
 import type { AdminMastersQuery as AdminMastersQueryResult } from "@/generated/graphql";
-import { classifyQueryError, getBackendErrorBanner } from "@/lib/apollo/errors";
+import { classifyQueryError, getBackendErrorBanner, mutationAuthBanner } from "@/lib/apollo/errors";
 import { liftGraphQLCodes } from "@/lib/apollo/graphql-errors";
 import type { FetchNextPageInput } from "@/lib/pagination/types";
 import { useSheetSearchParam } from "@/lib/url/use-sheet-search-param";
@@ -170,11 +170,11 @@ export function AdminMastersClient() {
           codes,
         });
         toast.error(
-          codes.includes("FORBIDDEN")
-            ? t("forbidden")
-            : codes.includes("UNAUTHENTICATED")
-              ? t("unauthenticated")
-              : t("unexpectedError"),
+          mutationAuthBanner(err, {
+            forbidden: t("forbidden"),
+            unauthenticated: t("unauthenticated"),
+            fallback: t("unexpectedError"),
+          }),
         );
         return null;
       });
@@ -255,11 +255,11 @@ export function AdminMastersClient() {
           codes,
         });
         toast.error(
-          codes.includes("FORBIDDEN")
-            ? t("forbidden")
-            : codes.includes("UNAUTHENTICATED")
-              ? t("unauthenticated")
-              : t("unexpectedError"),
+          mutationAuthBanner(err, {
+            forbidden: t("forbidden"),
+            unauthenticated: t("unauthenticated"),
+            fallback: t("unexpectedError"),
+          }),
         );
         return null;
       });
@@ -324,11 +324,11 @@ export function AdminMastersClient() {
           codes,
         });
         toast.error(
-          codes.includes("FORBIDDEN")
-            ? t("forbidden")
-            : codes.includes("UNAUTHENTICATED")
-              ? t("unauthenticated")
-              : t("deleteMasterFailed"),
+          mutationAuthBanner(err, {
+            forbidden: t("forbidden"),
+            unauthenticated: t("unauthenticated"),
+            fallback: t("deleteMasterFailed"),
+          }),
         );
       }
     },
@@ -381,11 +381,11 @@ export function AdminMastersClient() {
           codes,
         });
         toast.error(
-          codes.includes("FORBIDDEN")
-            ? t("forbidden")
-            : codes.includes("UNAUTHENTICATED")
-              ? t("unauthenticated")
-              : t("unexpectedError"),
+          mutationAuthBanner(err, {
+            forbidden: t("forbidden"),
+            unauthenticated: t("unauthenticated"),
+            fallback: t("unexpectedError"),
+          }),
         );
       }
     },

--- a/frontend/src/app/admin/roles/admin-roles-client.tsx
+++ b/frontend/src/app/admin/roles/admin-roles-client.tsx
@@ -10,7 +10,7 @@ import { RoleListItem } from "@/components/admin/role-list-item";
 import { ListingPageShell } from "@/components/layout/listing-page-shell";
 import { Button } from "@/components/ui/button";
 import { FormSheet, useFormSheetClose } from "@/components/ui/form-sheet";
-import { getBackendErrorBanner } from "@/lib/apollo/errors";
+import { classifyMutationAuthError, getBackendErrorBanner } from "@/lib/apollo/errors";
 import { liftGraphQLCodes } from "@/lib/apollo/graphql-errors";
 import { useUndoDelete } from "@/lib/undo-delete";
 import { useSheetSearchParam } from "@/lib/url/use-sheet-search-param";
@@ -352,20 +352,16 @@ export function AdminRolesClient({ initialRoles }: Props) {
 
     const name = values.name.trim().toLowerCase();
     const result = await createRole({ variables: { name } }).catch((err) => {
-      const codes = liftGraphQLCodes(err);
-      if (codes.includes("UNAUTHENTICATED")) {
-        setCreateAuthError("unauthenticated");
-        return null;
-      }
-      if (codes.includes("FORBIDDEN")) {
-        setCreateAuthError("forbidden");
+      const authKind = classifyMutationAuthError(err);
+      if (authKind !== "other") {
+        setCreateAuthError(authKind);
         return null;
       }
       // err.message is omitted — backend messages may echo user input.
       // codes is safe to log (fixed enum of GraphQL extension codes).
       console.warn("[admin/roles] createRole rejected", {
         name: err instanceof Error ? err.name : "unknown",
-        codes,
+        codes: liftGraphQLCodes(err),
       });
       return null;
     });
@@ -401,19 +397,15 @@ export function AdminRolesClient({ initialRoles }: Props) {
 
     const name = values.name.trim().toLowerCase();
     const result = await updateRole({ variables: { id: editRole.id, name } }).catch((err) => {
-      const codes = liftGraphQLCodes(err);
-      if (codes.includes("UNAUTHENTICATED")) {
-        setEditAuthError("unauthenticated");
-        return null;
-      }
-      if (codes.includes("FORBIDDEN")) {
-        setEditAuthError("forbidden");
+      const authKind = classifyMutationAuthError(err);
+      if (authKind !== "other") {
+        setEditAuthError(authKind);
         return null;
       }
       console.warn("[admin/roles] updateRole rejected", {
         roleId: editRole.id,
         name: err instanceof Error ? err.name : "unknown",
-        codes,
+        codes: liftGraphQLCodes(err),
       });
       return null;
     });

--- a/frontend/src/app/admin/users/admin-user-profile-sheet.tsx
+++ b/frontend/src/app/admin/users/admin-user-profile-sheet.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 import { FormSheet, useFormSheetClose } from "@/components/ui/form-sheet";
+import { mutationAuthBanner } from "@/lib/apollo/errors";
 import { liftGraphQLCodes } from "@/lib/apollo/graphql-errors";
 import type { AdminUserListItem, AdminUserRole } from "./admin-user-row";
 import { AdminEditUserMutation } from "./queries";
@@ -170,12 +171,13 @@ export function AdminUserProfileSheet({
         name: err instanceof Error ? err.name : "unknown",
         codes,
       });
-      const msg = codes.includes("FORBIDDEN")
-        ? t("forbidden")
-        : codes.includes("UNAUTHENTICATED")
-          ? t("unauthenticated")
-          : t("unexpectedError");
-      setSaveError(msg);
+      setSaveError(
+        mutationAuthBanner(err, {
+          forbidden: t("forbidden"),
+          unauthenticated: t("unauthenticated"),
+          fallback: t("unexpectedError"),
+        }),
+      );
     }
   }
 
@@ -285,11 +287,11 @@ function AdminUserProfileSheetBody({
         codes,
       });
       setDeleteError(
-        codes.includes("FORBIDDEN")
-          ? t("deleteUserForbidden")
-          : codes.includes("UNAUTHENTICATED")
-            ? t("unauthenticated")
-            : t("deleteUserFailed"),
+        mutationAuthBanner(err, {
+          forbidden: t("deleteUserForbidden"),
+          unauthenticated: t("unauthenticated"),
+          fallback: t("deleteUserFailed"),
+        }),
       );
       setDeleting(false);
     }

--- a/frontend/src/lib/apollo/errors.test.ts
+++ b/frontend/src/lib/apollo/errors.test.ts
@@ -1,6 +1,11 @@
 import { CombinedGraphQLErrors } from "@apollo/client/errors";
 import { describe, expect, it } from "vitest";
-import { getBackendErrorBanner, getBackendFieldErrors } from "./errors";
+import {
+  classifyMutationAuthError,
+  getBackendErrorBanner,
+  getBackendFieldErrors,
+  mutationAuthBanner,
+} from "./errors";
 
 /** Build a CombinedGraphQLErrors from a plain errors array. */
 function makeCombinedError(
@@ -155,5 +160,83 @@ describe("getBackendErrorBanner", () => {
     ]);
     expect(getBackendErrorBanner(err)).toBe("Your session expired. Please sign in again.");
     expect(getBackendFieldErrors(err)).toEqual({ name: "Name is required" });
+  });
+});
+
+describe("classifyMutationAuthError", () => {
+  it("classifies a FORBIDDEN error as forbidden", () => {
+    const err = makeCombinedError([{ message: "Forbidden", extensions: { code: "FORBIDDEN" } }]);
+    expect(classifyMutationAuthError(err)).toBe("forbidden");
+  });
+
+  it("classifies an UNAUTHENTICATED error as unauthenticated", () => {
+    const err = makeCombinedError([
+      { message: "Not authenticated", extensions: { code: "UNAUTHENTICATED" } },
+    ]);
+    expect(classifyMutationAuthError(err)).toBe("unauthenticated");
+  });
+
+  it("classifies any other GraphQL error code as other", () => {
+    const badInput = makeCombinedError([
+      { message: "Invalid input", extensions: { code: "BAD_USER_INPUT" } },
+    ]);
+    const internal = makeCombinedError([
+      { message: "Server error", extensions: { code: "INTERNAL" } },
+    ]);
+    expect(classifyMutationAuthError(badInput)).toBe("other");
+    expect(classifyMutationAuthError(internal)).toBe("other");
+  });
+
+  it("classifies a non-CombinedGraphQLErrors network error as other", () => {
+    expect(classifyMutationAuthError(new Error("Network request failed"))).toBe("other");
+  });
+
+  it("classifies a falsy error as other", () => {
+    expect(classifyMutationAuthError(null)).toBe("other");
+    expect(classifyMutationAuthError(undefined)).toBe("other");
+  });
+
+  it("returns the kind of the first auth error in the array (mirrors classifyQueryError)", () => {
+    const forbiddenFirst = makeCombinedError([
+      { message: "Forbidden", extensions: { code: "FORBIDDEN" } },
+      { message: "Not authenticated", extensions: { code: "UNAUTHENTICATED" } },
+    ]);
+    const unauthenticatedFirst = makeCombinedError([
+      { message: "Not authenticated", extensions: { code: "UNAUTHENTICATED" } },
+      { message: "Forbidden", extensions: { code: "FORBIDDEN" } },
+    ]);
+    expect(classifyMutationAuthError(forbiddenFirst)).toBe("forbidden");
+    expect(classifyMutationAuthError(unauthenticatedFirst)).toBe("unauthenticated");
+  });
+});
+
+describe("mutationAuthBanner", () => {
+  const copy = {
+    forbidden: "You do not have permission.",
+    unauthenticated: "Your session expired.",
+    fallback: "Something went wrong.",
+  };
+
+  it("returns the forbidden copy for a FORBIDDEN error", () => {
+    const err = makeCombinedError([{ message: "Forbidden", extensions: { code: "FORBIDDEN" } }]);
+    expect(mutationAuthBanner(err, copy)).toBe(copy.forbidden);
+  });
+
+  it("returns the unauthenticated copy for an UNAUTHENTICATED error", () => {
+    const err = makeCombinedError([
+      { message: "Not authenticated", extensions: { code: "UNAUTHENTICATED" } },
+    ]);
+    expect(mutationAuthBanner(err, copy)).toBe(copy.unauthenticated);
+  });
+
+  it("returns the fallback copy for any other GraphQL error", () => {
+    const err = makeCombinedError([
+      { message: "Invalid input", extensions: { code: "BAD_USER_INPUT" } },
+    ]);
+    expect(mutationAuthBanner(err, copy)).toBe(copy.fallback);
+  });
+
+  it("returns the fallback copy for a network error", () => {
+    expect(mutationAuthBanner(new Error("Network request failed"), copy)).toBe(copy.fallback);
   });
 });

--- a/frontend/src/lib/apollo/errors.ts
+++ b/frontend/src/lib/apollo/errors.ts
@@ -96,3 +96,53 @@ export function classifyQueryError(err: unknown): QueryErrorKind | null {
     message: getBackendErrorBanner(err) ?? "An unexpected error occurred. Please try again.",
   };
 }
+
+/**
+ * Auth-relevant classification of a mutation-level Apollo error.
+ *
+ * - `forbidden`:       FORBIDDEN code — caller lacks the required role.
+ * - `unauthenticated`: UNAUTHENTICATED code — session expired.
+ * - `other`:           Any other GraphQL error or a network/transport failure.
+ */
+export type MutationAuthErrorKind = "forbidden" | "unauthenticated" | "other";
+
+/**
+ * Classify a mutation-level Apollo error by its auth-relevant extensions.code.
+ * Returns the kind so callers can fold it into either a translated banner string
+ * (see `mutationAuthBanner`) or a discriminated state key, without re-implementing
+ * the FORBIDDEN / UNAUTHENTICATED detection per screen.
+ *
+ * Precedence mirrors `classifyQueryError`: the first auth error encountered in the
+ * `errors` array wins. Anything that is not a CombinedGraphQLErrors (network /
+ * transport failure, falsy value) classifies as `other`.
+ */
+export function classifyMutationAuthError(err: unknown): MutationAuthErrorKind {
+  if (CombinedGraphQLErrors.is(err)) {
+    for (const ge of err.errors) {
+      const code = extensionString(ge.extensions, "code");
+      if (code === "FORBIDDEN") return "forbidden";
+      if (code === "UNAUTHENTICATED") return "unauthenticated";
+    }
+  }
+  return "other";
+}
+
+/**
+ * Fold a mutation-level Apollo error into one of three caller-supplied banner
+ * strings. The caller passes already-translated copy so the i18n namespace stays
+ * at the call site; FORBIDDEN and UNAUTHENTICATED are detected via
+ * `classifyMutationAuthError`, and everything else falls through to `fallback`.
+ */
+export function mutationAuthBanner(
+  err: unknown,
+  copy: { forbidden: string; unauthenticated: string; fallback: string },
+): string {
+  switch (classifyMutationAuthError(err)) {
+    case "forbidden":
+      return copy.forbidden;
+    case "unauthenticated":
+      return copy.unauthenticated;
+    default:
+      return copy.fallback;
+  }
+}


### PR DESCRIPTION
## Summary

The admin screens hand-rolled a `FORBIDDEN ? … : UNAUTHENTICATED ? … : fallback` classification at every mutation `.catch`, with no shared helper (the existing `classifyQueryError` covered **queries** only). This adds `classifyMutationAuthError` + `mutationAuthBanner` to `lib/apollo/errors.ts` and routes all eight admin mutation catch-blocks through them. **Pure DRY refactor — no user-visible behaviour change, per-screen copy unchanged.**

Closes #445.

## Background / Motivation

- `errors.ts` already centralised query-error classification (`classifyQueryError` → `QueryErrorKind`), but there was no mutation equivalent, so each admin screen re-implemented `liftGraphQLCodes(err)` + a FORBIDDEN/UNAUTHENTICATED branch.
- The classification logic (read `extensions.code`, pick FORBIDDEN vs UNAUTHENTICATED vs generic) is invariant across screens; only the translated copy differs. Duplicating it means a missed code (e.g. forgetting `UNAUTHENTICATED`) can drift per screen.
- The two consumer shapes differ: masters/users fold the result into a translated toast/banner **string**, while roles store a **state key** (`"forbidden" | "unauthenticated"`). A string-only classifier cannot serve the roles sites, so the shared primitive returns the *kind* and the string fold is layered on top — mirroring the established `classifyQueryError` (kind) + caller-supplies-copy pattern.

## Changes

### `lib/apollo/errors.ts` — shared classifier

- `MutationAuthErrorKind = "forbidden" | "unauthenticated" | "other"`.
- `classifyMutationAuthError(err): MutationAuthErrorKind` — reuses the existing `CombinedGraphQLErrors.is` + `extensionString` helpers; precedence matches `classifyQueryError` (first auth error in the array wins). Non-`CombinedGraphQLErrors` (network/transport, falsy) → `"other"`.
- `mutationAuthBanner(err, { forbidden, unauthenticated, fallback }): string` — thin fold over the kind; the caller supplies already-translated copy so the i18n namespace stays at the call site.

### `admin/masters` + `admin/users` — banner sites (6)

- Replaced the inline `codes.includes("FORBIDDEN") ? … : …` ternaries with `mutationAuthBanner(err, { … })` at masters create / update / delete / publish-toggle and users adminEditUser / adminDeleteUser.
- Each screen's existing translation keys are preserved verbatim (masters delete keeps `deleteMasterFailed`; users delete keeps `deleteUserForbidden` / `deleteUserFailed`).

### `admin/roles` — state-key sites (2)

- `createRole` / `updateRole` catch-blocks: the two `if (codes.includes(...))` blocks collapse to `const authKind = classifyMutationAuthError(err); if (authKind !== "other") { setXAuthError(authKind); return null; }` — the kind union exactly matches the `"forbidden" | "unauthenticated"` state type.
- Out of scope (unchanged): roles `deleteRole` (UNAUTHENTICATED-only branch; FORBIDDEN deliberately keeps the server's specific message) and `loadRole` (no auth classification).

### `console.warn` telemetry preserved

- Every catch still logs `codes` via `liftGraphQLCodes(err)` (inlined into the warn payload where it had been a separate local). `liftGraphQLCodes` keeps 12 callers across learn / profile / onboarding / cardgroups / admin, so it is **not** dead and is retained.

### Tests

- New unit tests in `errors.test.ts` cover `classifyMutationAuthError` (FORBIDDEN, UNAUTHENTICATED, other GraphQL code, network, falsy, array-order precedence) and `mutationAuthBanner` (each branch + network fallback).
- Existing admin client tests pass unchanged — the rendered banner strings are identical.

## Verification

```bash
# No hand-rolled FORBIDDEN/UNAUTHENTICATED branch remains in the converted admin sites.
# The only hit is the intentionally out-of-scope roles deleteRole UNAUTHENTICATED-only branch:
grep -rn 'codes.includes("FORBIDDEN")\|codes.includes("UNAUTHENTICATED")' frontend/src/app/admin

# The shared helpers are wired at all eight sites:
grep -rn 'mutationAuthBanner\|classifyMutationAuthError' frontend/src/app/admin

# liftGraphQLCodes still has production callers, so it is correctly retained (not removed):
grep -rln 'liftGraphQLCodes' frontend/src --include='*.ts' --include='*.tsx' | grep -v test
```

## Test plan

- [x] `pnpm --filter frontend typecheck` — exit 0
- [x] `pnpm --filter frontend lint` (`biome check --error-on-warnings .`) — clean (364 files)
- [x] `pnpm --filter frontend knip` — exit 0
- [x] `pnpm --filter frontend test` — 1337 passed (137 files)
- [x] `pnpm --filter frontend build` — success
- [x] No inline CJK in changed source
