### PR TITLE
refactor(pagination): extract shared useConnectionPagination hook

### DIFF
--- a/frontend/src/app/cardgroups/[id]/cards/use-cards-connection.ts
+++ b/frontend/src/app/cardgroups/[id]/cards/use-cards-connection.ts
@@ -1,14 +1,14 @@
-import { type ErrorLike, NetworkStatus } from "@apollo/client";
-import { useQuery } from "@apollo/client/react";
-import type { RefObject } from "react";
-import { useCallback, useEffect, useEffectEvent, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo } from "react";
 import {
   CardsByCardgroupConnectionDocument,
   type CardsByCardgroupConnectionQuery,
   type CardsByCardgroupConnectionQueryVariables,
 } from "@/generated/graphql";
 import { getBackendErrorBanner } from "@/lib/apollo/errors";
-import type { FetchNextPageInput } from "@/lib/pagination/types";
+import {
+  type UseConnectionPaginationResult,
+  useConnectionPagination,
+} from "@/lib/pagination/use-connection-pagination";
 import { cardsDefaultVars } from "./queries";
 
 type CardEdge = CardsByCardgroupConnectionQuery["cardsByCardgroupConnection"]["edges"][number];
@@ -23,49 +23,38 @@ export interface UseCardsConnectionInput {
   initialTotalCount: number;
 }
 
-export interface UseCardsConnectionResult {
-  edges: CardEdge[];
-  pageInfo: CardConnectionPageInfo;
-  totalCount: number;
-  loading: boolean;
-  networkStatus: NetworkStatus;
-  fetchingMore: boolean;
-  fetchMoreError: string | null;
-  retryFetchMore: () => void;
-  sentinelRef: RefObject<HTMLDivElement | null>;
-  queryVariables: CardsByCardgroupConnectionQueryVariables;
-  queryError: ErrorLike | undefined;
+export type UseCardsConnectionResult = UseConnectionPaginationResult<
+  CardEdge,
+  CardConnectionPageInfo,
+  CardsByCardgroupConnectionQueryVariables
+>;
+
+// Concatenate the next page's edges onto the cached cards connection.
+function mergeCardsConnection(
+  prev: CardsByCardgroupConnectionQuery,
+  more: CardsByCardgroupConnectionQuery,
+): CardsByCardgroupConnectionQuery {
+  return {
+    cardsByCardgroupConnection: {
+      ...more.cardsByCardgroupConnection,
+      edges: [...prev.cardsByCardgroupConnection.edges, ...more.cardsByCardgroupConnection.edges],
+    },
+  };
 }
 
-// Apollo connection + fetchMore + IntersectionObserver hook for the
-// cards-by-cardgroup paginated query. Preserves three invariants from
-// .claude/rules/pagination.md: the IO in-flight guard (useRef<boolean>), the
-// React 19.2 useEffectEvent observer advance path, and the split
-// debounce-vs-immediate-reset effects driven by searchQuery changes.
+// Cards-by-cardgroup pagination — a thin wrapper over the generic
+// useConnectionPagination hook. Supplies the three cards-specific bits: the
+// document, the cardsDefaultVars-based variables, and the
+// data?.cardsByCardgroupConnection accessor + edges concat. The three
+// pagination-rule invariants (in-flight guard, Effect Event observer advance,
+// split debounce-vs-immediate-reset) live in the generic hook.
 export function useCardsConnection(input: UseCardsConnectionInput): UseCardsConnectionResult {
   const { cardgroupId, searchQuery, initialEdges, initialPageInfo, initialTotalCount } = input;
-
-  const [fetchMoreError, setFetchMoreError] = useState<string | null>(null);
-
-  const sentinelRef = useRef<HTMLDivElement | null>(null);
-  // In-flight guard MUST be useRef<boolean>, not useState — see
-  // docs/pagination/intersection-observer-in-flight-guard.md.
-  const fetchingRef = useRef(false);
-
-  // When the active search query changes, any in-flight fetchMore from the
-  // previous search holds a stale cursor. Reset the IO guard and error state
-  // immediately so the new query starts from a clean slate.
-  // See docs/pagination/intersection-observer-in-flight-guard.md.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: searchQuery is an intentional trigger dependency; it is not referenced in the body because the effect resets derived IO state, not searchQuery itself.
-  useEffect(() => {
-    fetchingRef.current = false;
-    setFetchMoreError(null);
-  }, [searchQuery]);
 
   // When searchQuery is null we use cardsDefaultVars verbatim so the cache key
   // matches the SSR seed exactly. For non-null searches we spread and override
   // `search`, keeping `cardgroupId`/`first` in sync with the default.
-  const queryVariables: CardsByCardgroupConnectionQueryVariables = useMemo(
+  const variables = useMemo<CardsByCardgroupConnectionQueryVariables>(
     () =>
       searchQuery === null
         ? cardsDefaultVars(cardgroupId)
@@ -73,117 +62,33 @@ export function useCardsConnection(input: UseCardsConnectionInput): UseCardsConn
     [cardgroupId, searchQuery],
   );
 
-  const {
-    data,
-    fetchMore,
-    loading,
-    networkStatus,
-    error: queryError,
-  } = useQuery(CardsByCardgroupConnectionDocument, {
-    variables: queryVariables,
-    fetchPolicy: "cache-first",
-    notifyOnNetworkStatusChange: true,
-  });
-
-  const connection = data?.cardsByCardgroupConnection;
-  const edges = connection?.edges ?? initialEdges;
-  const pageInfo = connection?.pageInfo ?? initialPageInfo;
-  const totalCount = connection?.totalCount ?? initialTotalCount;
-
-  const fetchNextPage = useCallback(
-    ({ hasNextPage, endCursor, searchQuery }: FetchNextPageInput) => {
-      if (fetchingRef.current || !hasNextPage) return;
-
-      fetchingRef.current = true;
-      fetchMore({
-        variables: {
-          ...cardsDefaultVars(cardgroupId),
-          after: endCursor,
-          search: searchQuery,
-        },
-        updateQuery: (prev, { fetchMoreResult }) => {
-          if (!fetchMoreResult) return prev;
-          return {
-            cardsByCardgroupConnection: {
-              ...fetchMoreResult.cardsByCardgroupConnection,
-              edges: [
-                ...prev.cardsByCardgroupConnection.edges,
-                ...fetchMoreResult.cardsByCardgroupConnection.edges,
-              ],
-            },
-          };
-        },
-      })
-        .then(() => {
-          // Clear any previous fetchMore error on success so the observer can resume.
-          setFetchMoreError(null);
-        })
-        .catch((err) => {
-          // Structured warn for operator triage: name + request context only.
-          // err.message is omitted — backend messages may carry user-authored content.
-          // See docs/frontend/rsc-error-handling/redact-err-message-from-console-payloads.md.
-          console.warn("[cards-client] fetchMore failed", {
-            name: err instanceof Error ? err.name : "unknown",
-            searchQuery,
-            endCursor,
-          });
-          const banner =
-            getBackendErrorBanner(err) ?? "Could not load more cards. Please try again.";
-          setFetchMoreError(banner);
-        })
-        .finally(() => {
-          fetchingRef.current = false;
-        });
-    },
-    [cardgroupId, fetchMore],
+  const buildFetchMoreVariables = useCallback(
+    (
+      endCursor: string | null,
+      search: string | null,
+    ): CardsByCardgroupConnectionQueryVariables => ({
+      ...cardsDefaultVars(cardgroupId),
+      after: endCursor,
+      search,
+    }),
+    [cardgroupId],
   );
 
-  const requestNextPageFromObserver = useEffectEvent(() => {
-    fetchNextPage({
-      hasNextPage: pageInfo.hasNextPage,
-      endCursor: pageInfo.endCursor ?? null,
-      searchQuery,
-    });
+  return useConnectionPagination<
+    CardsByCardgroupConnectionQuery,
+    CardsByCardgroupConnectionQueryVariables,
+    CardEdge,
+    CardConnectionPageInfo
+  >({
+    document: CardsByCardgroupConnectionDocument,
+    variables,
+    searchQuery,
+    selectConnection: (data) => data?.cardsByCardgroupConnection,
+    buildFetchMoreVariables,
+    mergeConnection: mergeCardsConnection,
+    initial: { edges: initialEdges, pageInfo: initialPageInfo, totalCount: initialTotalCount },
+    resolveFetchMoreError: (err) =>
+      getBackendErrorBanner(err) ?? "Could not load more cards. Please try again.",
+    logScope: "[cards-client]",
   });
-
-  useEffect(() => {
-    if (!pageInfo.hasNextPage) return;
-    // Stop the observer loop while a previous fetch failed; user must click Retry to resume.
-    if (fetchMoreError != null) return;
-    const node = sentinelRef.current;
-    if (!node) return;
-
-    const observer = new IntersectionObserver((entries) => {
-      if (!entries[0]?.isIntersecting || fetchingRef.current) return;
-      requestNextPageFromObserver();
-    });
-
-    observer.observe(node);
-    return () => observer.disconnect();
-  }, [pageInfo.hasNextPage, fetchMoreError]);
-
-  const retryFetchMore = useCallback(() => {
-    setFetchMoreError(null);
-    fetchNextPage({
-      hasNextPage: pageInfo.hasNextPage,
-      endCursor: pageInfo.endCursor ?? null,
-      searchQuery,
-    });
-  }, [fetchNextPage, pageInfo.endCursor, pageInfo.hasNextPage, searchQuery]);
-
-  const fetchingMore = networkStatus === NetworkStatus.fetchMore || (loading && edges.length > 0);
-
-  return {
-    edges,
-    pageInfo,
-    totalCount,
-    loading,
-    networkStatus,
-    fetchingMore,
-    fetchMoreError,
-    retryFetchMore,
-    sentinelRef,
-    queryVariables,
-    queryError,
-  };
 }

--- a/frontend/src/app/cardgroups/cardgroups-client.tsx
+++ b/frontend/src/app/cardgroups/cardgroups-client.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import { NetworkStatus } from "@apollo/client";
-import { useApolloClient, useMutation, useQuery } from "@apollo/client/react";
+import { useApolloClient, useMutation } from "@apollo/client/react";
 import { Plus } from "lucide-react";
 import Link from "next/link";
 import { useTranslations } from "next-intl";
-import { useCallback, useEffect, useEffectEvent, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { CardgroupForm } from "@/components/cardgroups/cardgroup-form";
 import { CardgroupListItem } from "@/components/cardgroups/cardgroup-list-item";
 import { CardgroupsToolbar } from "@/components/cardgroups/cardgroups-toolbar";
@@ -15,17 +15,51 @@ import { FormSheet, useFormSheetClose } from "@/components/ui/form-sheet";
 import {
   MyCardgroupsConnectionDocument,
   type MyCardgroupsConnectionQuery,
+  type MyCardgroupsConnectionQueryVariables,
 } from "@/generated/graphql";
+import { useDebouncedSearch } from "@/hooks/use-debounced-search";
 import { getBackendErrorBanner } from "@/lib/apollo/errors";
-import type { FetchNextPageInput } from "@/lib/pagination/types";
+import { useConnectionPagination } from "@/lib/pagination/use-connection-pagination";
 import { useUndoDelete } from "@/lib/undo-delete";
 import { CARDGROUPS_DEFAULT_VARS, DeleteCardgroupMutation } from "./queries";
 import { useCreateCardgroup } from "./use-create-cardgroup";
 
 type Connection = MyCardgroupsConnectionQuery["myCardgroupsConnection"];
+type CardgroupEdge = Connection["edges"][number];
+type CardgroupPageInfo = Connection["pageInfo"];
 
 interface CardgroupsClientProps {
   initialConnection: Connection | null;
+}
+
+const EMPTY_PAGE_INFO: CardgroupPageInfo = {
+  __typename: "PageInfo",
+  hasNextPage: false,
+  hasPreviousPage: false,
+  startCursor: null,
+  endCursor: null,
+};
+
+// Render fallback for useConnectionPagination. The client seeds the cache
+// synchronously before useQuery runs, so this is never read on the happy path;
+// it keeps the empty-edges shape the inline implementation used (`?? []`).
+const CARDGROUPS_INITIAL = {
+  edges: [] as CardgroupEdge[],
+  pageInfo: EMPTY_PAGE_INFO,
+  totalCount: 0,
+};
+
+// Concatenate the next page's edges onto the cached cardgroups connection.
+function mergeCardgroupsConnection(
+  prev: MyCardgroupsConnectionQuery,
+  more: MyCardgroupsConnectionQuery,
+): MyCardgroupsConnectionQuery {
+  return {
+    myCardgroupsConnection: {
+      ...more.myCardgroupsConnection,
+      edges: [...prev.myCardgroupsConnection.edges, ...more.myCardgroupsConnection.edges],
+    },
+  };
 }
 
 function CreateCardgroupSheetContent({
@@ -119,9 +153,8 @@ export default function CardgroupsClient({ initialConnection }: CardgroupsClient
   const apollo = useApolloClient();
   const t = useTranslations("Cardgroups");
   const tCommon = useTranslations("Common");
-  const [searchInput, setSearchInput] = useState("");
-  const [searchQuery, setSearchQuery] = useState<string | null>(null);
-  const [fetchMoreError, setFetchMoreError] = useState<string | null>(null);
+  const search = useDebouncedSearch();
+  const searchQuery = search.query;
   const [deleteCommitError, setDeleteCommitError] = useState<string | null>(null);
 
   const { scheduleDelete } = useUndoDelete();
@@ -196,30 +229,8 @@ export default function CardgroupsClient({ initialConnection }: CardgroupsClient
     }
   }
 
-  const sentinelRef = useRef<HTMLDivElement | null>(null);
-  // In-flight guard MUST be useRef<boolean>, not useState — see
-  // docs/pagination/intersection-observer-in-flight-guard.md.
-  const fetchingRef = useRef(false);
   // Strict Mode double-mount safety: only write the SSR seed into the cache once.
   const seededRef = useRef(false);
-
-  // Debounce: update searchQuery 300ms after the last keystroke.
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      setSearchQuery(searchInput.trim() || null);
-    }, 300);
-    return () => clearTimeout(timer);
-  }, [searchInput]);
-
-  // When the active search query changes, any in-flight fetchMore from the
-  // previous search holds a stale cursor. Reset the IO guard and error state
-  // immediately so the new query starts from a clean slate.
-  // See docs/pagination/intersection-observer-in-flight-guard.md.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: searchQuery is an intentional trigger dependency; it is not referenced in the body because the effect resets derived IO state, not searchQuery itself.
-  useEffect(() => {
-    fetchingRef.current = false;
-    setFetchMoreError(null);
-  }, [searchQuery]);
 
   // Seed the cache synchronously during render (before useQuery runs) with the
   // SSR initialConnection so the first useQuery pass (cache-first) finds the
@@ -246,22 +257,46 @@ export default function CardgroupsClient({ initialConnection }: CardgroupsClient
 
   // When searchQuery is null we use CARDGROUPS_DEFAULT_VARS verbatim so the
   // cache key matches the SSR seed exactly. For non-null searches we spread and
-  // override `search`, keeping `first` in sync with the default.
-  const queryVariables =
-    searchQuery === null
-      ? CARDGROUPS_DEFAULT_VARS
-      : { ...CARDGROUPS_DEFAULT_VARS, search: searchQuery };
+  // override `search`, keeping `first` in sync with the default. Memoized so the
+  // hook's useQuery does not re-subscribe on unrelated re-renders.
+  const queryVariables = useMemo(
+    () =>
+      searchQuery === null
+        ? CARDGROUPS_DEFAULT_VARS
+        : { ...CARDGROUPS_DEFAULT_VARS, search: searchQuery },
+    [searchQuery],
+  );
 
-  const { data, fetchMore, loading, networkStatus } = useQuery(MyCardgroupsConnectionDocument, {
+  const {
+    edges,
+    pageInfo,
+    loading,
+    networkStatus,
+    fetchingMore,
+    fetchMoreError,
+    retryFetchMore,
+    sentinelRef,
+  } = useConnectionPagination<
+    MyCardgroupsConnectionQuery,
+    MyCardgroupsConnectionQueryVariables,
+    CardgroupEdge,
+    CardgroupPageInfo
+  >({
+    document: MyCardgroupsConnectionDocument,
     variables: queryVariables,
-    fetchPolicy: "cache-first",
-    notifyOnNetworkStatusChange: true,
+    searchQuery: searchQuery,
+    selectConnection: (data) => data?.myCardgroupsConnection,
+    buildFetchMoreVariables: (after, searchValue) => ({
+      ...CARDGROUPS_DEFAULT_VARS,
+      after,
+      search: searchValue,
+    }),
+    mergeConnection: mergeCardgroupsConnection,
+    initial: CARDGROUPS_INITIAL,
+    resolveFetchMoreError: (err) => getBackendErrorBanner(err) ?? t("fetchMoreError"),
+    logScope: "[cardgroups]",
   });
-
-  const connection = data?.myCardgroupsConnection;
-  const edges = connection?.edges ?? [];
-  const hasNextPage = connection?.pageInfo.hasNextPage ?? false;
-  const endCursor = connection?.pageInfo.endCursor ?? null;
+  const hasNextPage = pageInfo.hasNextPage;
 
   function handleDelete(id: string, name: string) {
     // Clear any stale delete-error banner so a new attempt starts clean.
@@ -313,68 +348,6 @@ export default function CardgroupsClient({ initialConnection }: CardgroupsClient
     });
   }
 
-  const fetchNextPage = useCallback(
-    ({ hasNextPage, endCursor, searchQuery }: FetchNextPageInput) => {
-      if (fetchingRef.current || !hasNextPage) return;
-
-      fetchingRef.current = true;
-      fetchMore({
-        variables: { ...CARDGROUPS_DEFAULT_VARS, after: endCursor, search: searchQuery },
-        updateQuery: (prev, { fetchMoreResult }) => {
-          if (!fetchMoreResult) return prev;
-          return {
-            myCardgroupsConnection: {
-              ...fetchMoreResult.myCardgroupsConnection,
-              edges: [
-                ...prev.myCardgroupsConnection.edges,
-                ...fetchMoreResult.myCardgroupsConnection.edges,
-              ],
-            },
-          };
-        },
-      })
-        .then(() => {
-          // Clear any previous fetchMore error on success so the observer can resume.
-          setFetchMoreError(null);
-        })
-        .catch((err) => {
-          // Structured warn for operator triage: name + request context only.
-          // err.message is omitted — backend messages may carry user-authored content.
-          // See docs/frontend/typescript-conventions.md § "expect.objectContaining".
-          console.warn("[cardgroups] fetchMore failed", {
-            name: err instanceof Error ? err.name : "unknown",
-            searchQuery,
-            endCursor,
-          });
-          setFetchMoreError(getBackendErrorBanner(err) ?? t("fetchMoreError"));
-        })
-        .finally(() => {
-          fetchingRef.current = false;
-        });
-    },
-    [fetchMore, t],
-  );
-
-  const requestNextPageFromObserver = useEffectEvent(() => {
-    fetchNextPage({ hasNextPage, endCursor, searchQuery });
-  });
-
-  useEffect(() => {
-    // Halt the observer loop while a previous fetch failed; user must click Retry to resume.
-    if (!hasNextPage || fetchMoreError != null) return;
-    const node = sentinelRef.current;
-    if (!node) return;
-
-    const observer = new IntersectionObserver((entries) => {
-      if (!entries[0]?.isIntersecting || fetchingRef.current) return;
-      requestNextPageFromObserver();
-    });
-
-    observer.observe(node);
-    return () => observer.disconnect();
-  }, [hasNextPage, fetchMoreError]);
-
-  const fetchingMore = networkStatus === NetworkStatus.fetchMore || (loading && edges.length > 0);
   const initialLoading = loading && edges.length === 0 && networkStatus !== NetworkStatus.fetchMore;
   const hasSearch = searchQuery !== null && searchQuery !== "";
 
@@ -394,7 +367,9 @@ export default function CardgroupsClient({ initialConnection }: CardgroupsClient
           <Plus aria-hidden="true" />
         </Button>
       }
-      toolbar={<CardgroupsToolbar searchInput={searchInput} onSearchInputChange={setSearchInput} />}
+      toolbar={
+        <CardgroupsToolbar searchInput={search.input} onSearchInputChange={search.setInput} />
+      }
     >
       {initialLoading && (
         <p className="text-sm text-muted-foreground" data-testid="cardgroups-loading">
@@ -459,15 +434,7 @@ export default function CardgroupsClient({ initialConnection }: CardgroupsClient
           data-testid="cardgroups-fetch-more-error"
         >
           <span>{fetchMoreError}</span>
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            onClick={() => {
-              setFetchMoreError(null);
-              fetchNextPage({ hasNextPage, endCursor, searchQuery });
-            }}
-          >
+          <Button type="button" variant="outline" size="sm" onClick={retryFetchMore}>
             {tCommon("retry")}
           </Button>
         </div>

--- a/frontend/src/app/catalog/catalog-client.tsx
+++ b/frontend/src/app/catalog/catalog-client.tsx
@@ -1,23 +1,60 @@
 "use client";
 
 import { NetworkStatus } from "@apollo/client";
-import { useApolloClient, useQuery } from "@apollo/client/react";
+import { useApolloClient } from "@apollo/client/react";
 import Link from "next/link";
 import { useTranslations } from "next-intl";
-import { useCallback, useEffect, useEffectEvent, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { ListingPageShell } from "@/components/layout/listing-page-shell";
 import { Button } from "@/components/ui/button";
-import { MasterCatalogDocument, type MasterCatalogQuery } from "@/generated/graphql";
-import type { FetchNextPageInput } from "@/lib/pagination/types";
+import {
+  MasterCatalogDocument,
+  type MasterCatalogQuery,
+  type MasterCatalogQueryVariables,
+} from "@/generated/graphql";
+import { useDebouncedSearch } from "@/hooks/use-debounced-search";
+import { useConnectionPagination } from "@/lib/pagination/use-connection-pagination";
 import { CatalogCard } from "./catalog-card";
 import { CATALOG_DEFAULT_VARS } from "./queries";
 import { useImportMaster } from "./use-import-master";
 
 type Connection = MasterCatalogQuery["masterCatalog"];
+type CatalogEdge = Connection["edges"][number];
+type CatalogPageInfo = Connection["pageInfo"];
 
 interface CatalogClientProps {
   initialConnection: Connection | null;
+}
+
+const EMPTY_PAGE_INFO: CatalogPageInfo = {
+  __typename: "PageInfo",
+  hasNextPage: false,
+  hasPreviousPage: false,
+  startCursor: null,
+  endCursor: null,
+};
+
+// Render fallback for useConnectionPagination. The client seeds the cache
+// synchronously before useQuery runs, so this is never read on the happy path;
+// it keeps the empty-edges shape the inline implementation used (`?? []`).
+const CATALOG_INITIAL = {
+  edges: [] as CatalogEdge[],
+  pageInfo: EMPTY_PAGE_INFO,
+  totalCount: 0,
+};
+
+// Concatenate the next page's edges onto the cached catalog connection.
+function mergeCatalogConnection(
+  prev: MasterCatalogQuery,
+  more: MasterCatalogQuery,
+): MasterCatalogQuery {
+  return {
+    masterCatalog: {
+      ...more.masterCatalog,
+      edges: [...prev.masterCatalog.edges, ...more.masterCatalog.edges],
+    },
+  };
 }
 
 /**
@@ -44,9 +81,8 @@ export default function CatalogClient({ initialConnection }: CatalogClientProps)
   const t = useTranslations("Catalog");
   const tCommon = useTranslations("Common");
 
-  const [searchInput, setSearchInput] = useState("");
-  const [searchQuery, setSearchQuery] = useState<string | null>(null);
-  const [fetchMoreError, setFetchMoreError] = useState<string | null>(null);
+  const search = useDebouncedSearch();
+  const searchQuery = search.query;
 
   // Import state. `importingId` serializes imports to one at a time;
   // `importedIds` drives the per-card "Imported" affordance.
@@ -58,29 +94,8 @@ export default function CatalogClient({ initialConnection }: CatalogClientProps)
     null,
   );
 
-  const sentinelRef = useRef<HTMLDivElement | null>(null);
-  // In-flight guard MUST be useRef<boolean>, not useState — see
-  // docs/pagination/intersection-observer-in-flight-guard.md.
-  const fetchingRef = useRef(false);
   // Strict Mode double-mount safety: only write the SSR seed into the cache once.
   const seededRef = useRef(false);
-
-  // Debounce: update searchQuery 300ms after the last keystroke.
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      setSearchQuery(searchInput.trim() || null);
-    }, 300);
-    return () => clearTimeout(timer);
-  }, [searchInput]);
-
-  // When the active search query changes, any in-flight fetchMore from the
-  // previous search holds a stale cursor. Reset the IO guard and error state
-  // immediately so the new query starts from a clean slate.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: searchQuery is an intentional trigger dependency; it is not referenced in the body because the effect resets derived IO state, not searchQuery itself.
-  useEffect(() => {
-    fetchingRef.current = false;
-    setFetchMoreError(null);
-  }, [searchQuery]);
 
   // Seed the cache synchronously during render (before useQuery runs) with the
   // SSR initialConnection so the first useQuery pass (cache-first) finds the data
@@ -104,77 +119,48 @@ export default function CatalogClient({ initialConnection }: CatalogClientProps)
 
   // When searchQuery is null we use CATALOG_DEFAULT_VARS verbatim so the cache key
   // matches the SSR seed exactly. For non-null searches we spread and override
-  // `search`, keeping `first` in sync with the default.
-  const queryVariables =
-    searchQuery === null ? CATALOG_DEFAULT_VARS : { ...CATALOG_DEFAULT_VARS, search: searchQuery };
-
-  const { data, fetchMore, loading, networkStatus } = useQuery(MasterCatalogDocument, {
-    variables: queryVariables,
-    fetchPolicy: "cache-first",
-    notifyOnNetworkStatusChange: true,
-  });
-
-  const connection = data?.masterCatalog;
-  const edges = connection?.edges ?? [];
-  const hasNextPage = connection?.pageInfo.hasNextPage ?? false;
-  const endCursor = connection?.pageInfo.endCursor ?? null;
-
-  const fetchNextPage = useCallback(
-    ({ hasNextPage, endCursor, searchQuery }: FetchNextPageInput) => {
-      if (fetchingRef.current || !hasNextPage) return;
-
-      fetchingRef.current = true;
-      fetchMore({
-        variables: { ...CATALOG_DEFAULT_VARS, after: endCursor, search: searchQuery },
-        updateQuery: (prev, { fetchMoreResult }) => {
-          if (!fetchMoreResult) return prev;
-          return {
-            masterCatalog: {
-              ...fetchMoreResult.masterCatalog,
-              edges: [...prev.masterCatalog.edges, ...fetchMoreResult.masterCatalog.edges],
-            },
-          };
-        },
-      })
-        .then(() => {
-          // Clear any previous fetchMore error on success so the observer can resume.
-          setFetchMoreError(null);
-        })
-        .catch((err) => {
-          // Structured warn for operator triage: name + request context only.
-          // err.message is omitted — backend messages may carry user-authored content.
-          console.warn("[catalog] fetchMore failed", {
-            name: err instanceof Error ? err.name : "unknown",
-            searchQuery,
-            endCursor,
-          });
-          setFetchMoreError(t("fetchMoreError"));
-        })
-        .finally(() => {
-          fetchingRef.current = false;
-        });
-    },
-    [fetchMore, t],
+  // `search`, keeping `first` in sync with the default. Memoized so the hook's
+  // useQuery does not re-subscribe on unrelated re-renders.
+  const queryVariables = useMemo(
+    () =>
+      searchQuery === null
+        ? CATALOG_DEFAULT_VARS
+        : { ...CATALOG_DEFAULT_VARS, search: searchQuery },
+    [searchQuery],
   );
 
-  const requestNextPageFromObserver = useEffectEvent(() => {
-    fetchNextPage({ hasNextPage, endCursor, searchQuery });
+  const {
+    edges,
+    pageInfo,
+    loading,
+    networkStatus,
+    fetchingMore,
+    fetchMoreError,
+    retryFetchMore,
+    sentinelRef,
+  } = useConnectionPagination<
+    MasterCatalogQuery,
+    MasterCatalogQueryVariables,
+    CatalogEdge,
+    CatalogPageInfo
+  >({
+    document: MasterCatalogDocument,
+    variables: queryVariables,
+    searchQuery: searchQuery,
+    selectConnection: (data) => data?.masterCatalog,
+    buildFetchMoreVariables: (after, searchValue) => ({
+      ...CATALOG_DEFAULT_VARS,
+      after,
+      search: searchValue,
+    }),
+    mergeConnection: mergeCatalogConnection,
+    initial: CATALOG_INITIAL,
+    // Catalog deliberately shows a single generic banner for every fetchMore
+    // failure (no backend-message surfacing), matching the inline original.
+    resolveFetchMoreError: () => t("fetchMoreError"),
+    logScope: "[catalog]",
   });
-
-  useEffect(() => {
-    // Halt the observer loop while a previous fetch failed; user must click Retry to resume.
-    if (!hasNextPage || fetchMoreError != null) return;
-    const node = sentinelRef.current;
-    if (!node) return;
-
-    const observer = new IntersectionObserver((entries) => {
-      if (!entries[0]?.isIntersecting || fetchingRef.current) return;
-      requestNextPageFromObserver();
-    });
-
-    observer.observe(node);
-    return () => observer.disconnect();
-  }, [hasNextPage, fetchMoreError]);
+  const hasNextPage = pageInfo.hasNextPage;
 
   const handleImport = useCallback(
     async (id: string) => {
@@ -210,7 +196,6 @@ export default function CatalogClient({ initialConnection }: CatalogClientProps)
     [importingId, importMasterCardgroup, t],
   );
 
-  const fetchingMore = networkStatus === NetworkStatus.fetchMore || (loading && edges.length > 0);
   const initialLoading = loading && edges.length === 0 && networkStatus !== NetworkStatus.fetchMore;
   const hasSearch = searchQuery !== null && searchQuery !== "";
 
@@ -223,8 +208,8 @@ export default function CatalogClient({ initialConnection }: CatalogClientProps)
           <input
             type="search"
             placeholder={t("searchPlaceholder")}
-            value={searchInput}
-            onChange={(e) => setSearchInput(e.target.value)}
+            value={search.input}
+            onChange={(e) => search.setInput(e.target.value)}
             className="w-full max-w-sm rounded-md border border-input bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             aria-label={t("searchAriaLabel")}
             data-testid="catalog-search"
@@ -299,15 +284,7 @@ export default function CatalogClient({ initialConnection }: CatalogClientProps)
           data-testid="catalog-fetch-more-error"
         >
           <span>{fetchMoreError}</span>
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            onClick={() => {
-              setFetchMoreError(null);
-              fetchNextPage({ hasNextPage, endCursor, searchQuery });
-            }}
-          >
+          <Button type="button" variant="outline" size="sm" onClick={retryFetchMore}>
             {tCommon("retry")}
           </Button>
         </div>

--- a/frontend/src/app/pagination-ref-triplet-removal-rule.test.ts
+++ b/frontend/src/app/pagination-ref-triplet-removal-rule.test.ts
@@ -1,49 +1,62 @@
 /**
- * Regression-rule test: ref-triplet removal and useEffectEvent adoption.
+ * Regression-rule test: ref-triplet removal / useEffectEvent adoption AND the
+ * shared-hook extraction for cursor-paginated list screens.
  *
  * WHAT THIS FILE TESTS
  * --------------------
- * Static string checks on production source files that enforce two rules:
- *   1. `useEffectEvent` is present — each pagination call site must use the
- *      React 19.2 Effect Event pattern to read the latest cursor/page state
- *      inside an IntersectionObserver callback without capturing stale values.
- *   2. The deprecated `endCursorRef` / `hasNextPageRef` / `searchQueryRef`
- *      ref-triplet identifiers are absent — these were the pre-migration
- *      stale-value capture refs (replaced by useEffectEvent latest-value reads)
- *      and must not re-appear after the migration landed.
+ * Static string checks on production source files that enforce two families of
+ * rules:
  *
- * NOTE: `fetchingRef` is INTENTIONALLY retained in production as the same-tick
- * in-flight mutex, per `.claude/rules/pagination.md`. This rule does not assert
- * anything about `fetchingRef`.
+ *   IO-owning sites (the files that build an IntersectionObserver loop directly):
+ *     1. `useEffectEvent` is present — the React 19.2 Effect Event pattern is
+ *        used to read the latest cursor/page state inside the observer callback
+ *        without capturing stale values.
+ *     2. The deprecated `endCursorRef` / `hasNextPageRef` / `searchQueryRef`
+ *        ref-triplet identifiers are absent — these were the pre-migration
+ *        stale-value capture refs, replaced by useEffectEvent latest-value
+ *        reads, and must not re-appear.
+ *
+ *   Migrated sites (the screens/hooks that consume the shared
+ *   `useConnectionPagination` hook instead of inlining the loop):
+ *     3. `useConnectionPagination` is present — the screen routes its IO through
+ *        the single shared implementation.
+ *     4. No inline IO loop remains — `new IntersectionObserver` and
+ *        `useEffectEvent` are absent (they live in the shared hook now), and the
+ *        ref-triplet is still absent.
+ *
+ * The shared `src/lib/pagination/use-connection-pagination.ts` hook is now the
+ * canonical owner of the observer loop; cards / cardgroups / catalog all consume
+ * it. Admin listings still inline their own loop pending their follow-up
+ * migration, so they remain in the IO-owning set.
+ *
+ * NOTE: `fetchingRef` is INTENTIONALLY retained in the shared hook as the
+ * same-tick in-flight mutex, per `.claude/rules/pagination.md`. This rule does
+ * not assert anything about `fetchingRef`.
  *
  * WHAT THIS FILE DOES NOT TEST
  * ----------------------------
- * Behavioral invariants (e.g. that fetchMore is called with the correct
- * cursor, that overlapping observer fires are deduplicated, that the error
- * halt gate stops the IO loop) are NOT tested here. Those invariants live in
- * the per-file behavioral test companions:
+ * Behavioral invariants (correct cursor on fetchMore, overlapping-fire dedup,
+ * error halt gate) are NOT tested here. Those live in the behavioral companions:
+ *   - src/lib/pagination/use-connection-pagination.test.tsx
  *   - src/app/cardgroups/[id]/cards/use-cards-connection.test.ts
  *   - src/app/cardgroups/cardgroups-client.test.tsx
+ *   - src/app/catalog/catalog-client.test.tsx
  *   - src/app/admin/users/admin-users-client.test.tsx
  *
- * This file is intentionally a grep-style regression guard: if a future
- * refactor accidentally reintroduces the ref-triplet pattern or removes the
- * useEffectEvent call, this test fails immediately without requiring a full
- * behavioral test run.
+ * This file is intentionally a grep-style regression guard: if a future refactor
+ * reintroduces the ref-triplet, drops useEffectEvent from an IO owner, or
+ * re-inlines an observer loop into a migrated screen, this test fails
+ * immediately without requiring a full behavioral test run.
  */
 
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
-const productionSites = [
+const ioOwningSites = [
   {
-    name: "cardgroups listing",
-    sourcePath: "src/app/cardgroups/cardgroups-client.tsx",
-  },
-  {
-    name: "cardgroup cards connection hook",
-    sourcePath: "src/app/cardgroups/[id]/cards/use-cards-connection.ts",
+    name: "connection pagination hook",
+    sourcePath: "src/lib/pagination/use-connection-pagination.ts",
   },
   {
     name: "admin users listing",
@@ -51,13 +64,32 @@ const productionSites = [
   },
 ];
 
+const migratedSites = [
+  {
+    name: "cardgroups listing",
+    sourcePath: "src/app/cardgroups/cardgroups-client.tsx",
+  },
+  {
+    name: "catalog gallery",
+    sourcePath: "src/app/catalog/catalog-client.tsx",
+  },
+  {
+    name: "cardgroup cards connection hook",
+    sourcePath: "src/app/cardgroups/[id]/cards/use-cards-connection.ts",
+  },
+];
+
+function readSource(sourcePath: string): string {
+  return readFileSync(join(process.cwd(), sourcePath), "utf8");
+}
+
 describe("pagination ref-triplet removal regression rule", () => {
   it.each(
-    productionSites,
+    ioOwningSites,
   )("$name: uses useEffectEvent and does not contain deprecated endCursorRef/hasNextPageRef/searchQueryRef identifiers", ({
     sourcePath,
   }) => {
-    const source = readFileSync(join(process.cwd(), sourcePath), "utf8");
+    const source = readSource(sourcePath);
 
     // Rule 1: useEffectEvent must be present — confirms the React 19.2
     // Effect Event pattern is in use for observer-owned latest-value reads.
@@ -66,6 +98,25 @@ describe("pagination ref-triplet removal regression rule", () => {
     // Rule 2: the old ref-triplet identifiers must not reappear — these were
     // the pre-migration stale-value capture refs, replaced by useEffectEvent
     // latest-value reads, and are now deleted.
+    expect(source).not.toMatch(/\b(endCursorRef|hasNextPageRef|searchQueryRef)\b/);
+  });
+});
+
+describe("pagination shared-hook extraction regression rule", () => {
+  it.each(
+    migratedSites,
+  )("$name: consumes useConnectionPagination and carries no inline IntersectionObserver IO loop", ({
+    sourcePath,
+  }) => {
+    const source = readSource(sourcePath);
+
+    // Rule 3: the screen routes its pagination through the shared hook.
+    expect(source).toContain("useConnectionPagination");
+
+    // Rule 4: no inline IO loop remains — the observer construction and the
+    // Effect Event live in the shared hook now, and the ref-triplet stays out.
+    expect(source).not.toContain("new IntersectionObserver");
+    expect(source).not.toContain("useEffectEvent");
     expect(source).not.toMatch(/\b(endCursorRef|hasNextPageRef|searchQueryRef)\b/);
   });
 });

--- a/frontend/src/lib/pagination/use-connection-pagination.test.tsx
+++ b/frontend/src/lib/pagination/use-connection-pagination.test.tsx
@@ -1,0 +1,441 @@
+// @vitest-environment jsdom
+import { InMemoryCache } from "@apollo/client";
+import { MockedProvider } from "@apollo/client/testing/react";
+import { act, render, waitFor } from "@testing-library/react";
+import { GraphQLError } from "graphql";
+import { createElement, type ReactNode, useMemo } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  MyCardgroupsConnectionDocument,
+  type MyCardgroupsConnectionQuery,
+  type MyCardgroupsConnectionQueryVariables,
+} from "@/generated/graphql";
+import {
+  type ApolloMockLeakSpyResult,
+  installApolloMockLeakSpy,
+} from "../../../__tests__/utils/mock-apollo-paginated";
+import {
+  type UseConnectionPaginationResult,
+  useConnectionPagination,
+} from "./use-connection-pagination";
+
+// ---------------------------------------------------------------------------
+// This suite exercises the GENERIC hook against a non-cards document
+// (MyCardgroupsConnection) to prove the generalisation is document-agnostic.
+// The cards-specific behaviour is covered separately by
+// app/cardgroups/[id]/cards/use-cards-connection.test.ts (the regression proof
+// that the wrapper is behaviour-preserving).
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const PAGE_SIZE = 20;
+const DEFAULT_VARS: MyCardgroupsConnectionQueryVariables = { first: PAGE_SIZE, search: null };
+
+const CG_1 = {
+  __typename: "Cardgroup" as const,
+  id: "cg-1",
+  name: "Alpha",
+  updatedAt: "2024-06-15T10:00:00.000Z",
+};
+const CG_2 = {
+  __typename: "Cardgroup" as const,
+  id: "cg-2",
+  name: "Beta",
+  updatedAt: "2024-05-20T08:00:00.000Z",
+};
+const CG_3 = {
+  __typename: "Cardgroup" as const,
+  id: "cg-3",
+  name: "Gamma",
+  updatedAt: "2024-04-10T06:00:00.000Z",
+};
+
+type CgLike = typeof CG_1;
+type CgConnection = MyCardgroupsConnectionQuery["myCardgroupsConnection"];
+type CgEdge = CgConnection["edges"][number];
+type CgPageInfo = CgConnection["pageInfo"];
+
+const EMPTY_PAGE_INFO: CgPageInfo = {
+  __typename: "PageInfo",
+  hasNextPage: false,
+  hasPreviousPage: false,
+  startCursor: null,
+  endCursor: null,
+};
+
+function cgEdge(cg: CgLike): CgEdge {
+  return { __typename: "CardgroupEdge", cursor: cg.id, node: cg };
+}
+
+function connection(items: ReadonlyArray<CgLike>, hasNext = false): CgConnection {
+  return {
+    __typename: "CardgroupConnection",
+    edges: items.map(cgEdge),
+    pageInfo: {
+      __typename: "PageInfo",
+      hasNextPage: hasNext,
+      hasPreviousPage: false,
+      startCursor: items[0]?.id ?? null,
+      endCursor: items[items.length - 1]?.id ?? null,
+    },
+    totalCount: items.length,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Caller-supplied wiring (the three cards-specific bits, now injected).
+// ---------------------------------------------------------------------------
+
+const selectConnection = (data: MyCardgroupsConnectionQuery | undefined) =>
+  data?.myCardgroupsConnection;
+
+const buildFetchMoreVariables = (
+  after: string | null,
+  search: string | null,
+): MyCardgroupsConnectionQueryVariables => ({ ...DEFAULT_VARS, after, search });
+
+const mergeConnection = (
+  prev: MyCardgroupsConnectionQuery,
+  more: MyCardgroupsConnectionQuery,
+): MyCardgroupsConnectionQuery => ({
+  myCardgroupsConnection: {
+    ...more.myCardgroupsConnection,
+    edges: [...prev.myCardgroupsConnection.edges, ...more.myCardgroupsConnection.edges],
+  },
+});
+
+const resolveFetchMoreError = () => "Could not load more.";
+
+// ---------------------------------------------------------------------------
+// IntersectionObserver stub — capture observer instances so each test can
+// invoke their callbacks and assert observe/disconnect lifecycle.
+// ---------------------------------------------------------------------------
+
+type FakeObserver = {
+  cb: IntersectionObserverCallback;
+  observed: Element[];
+  disconnected: boolean;
+};
+
+let observers: FakeObserver[] = [];
+
+class FakeIntersectionObserver {
+  private state: FakeObserver;
+  constructor(cb: IntersectionObserverCallback) {
+    this.state = { cb, observed: [], disconnected: false };
+    observers.push(this.state);
+  }
+  observe(node: Element) {
+    this.state.observed.push(node);
+  }
+  unobserve() {}
+  disconnect() {
+    this.state.disconnected = true;
+  }
+  takeRecords() {
+    return [];
+  }
+}
+
+function latestObserver(): FakeObserver | undefined {
+  for (let i = observers.length - 1; i >= 0; i -= 1) {
+    const o = observers[i];
+    if (o && !o.disconnected) return o;
+  }
+  return undefined;
+}
+
+function fireIntersect() {
+  const obs = latestObserver();
+  if (!obs) return;
+  obs.cb([{ isIntersecting: true } as IntersectionObserverEntry], {} as IntersectionObserver);
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+
+let leakSpy: ApolloMockLeakSpyResult;
+
+beforeEach(() => {
+  leakSpy = installApolloMockLeakSpy({ operationNames: ["MyCardgroupsConnection"] });
+  observers = [];
+  vi.stubGlobal("IntersectionObserver", FakeIntersectionObserver);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+  leakSpy.assertNoLeaks();
+  leakSpy.teardown();
+});
+
+// ---------------------------------------------------------------------------
+// Harness — render (not renderHook) so sentinelRef attaches to a real node
+// and the IO observer effect (which short-circuits on `if (!node) return`)
+// actually wires up.
+// ---------------------------------------------------------------------------
+
+type HookResult = UseConnectionPaginationResult<
+  CgEdge,
+  CgPageInfo,
+  MyCardgroupsConnectionQueryVariables
+>;
+
+type ProbeProps = {
+  searchQuery: string | null;
+  initial: { edges: CgEdge[]; pageInfo: CgPageInfo; totalCount: number };
+};
+
+type Holder = { current: HookResult | null };
+
+function HookProbe({ props, holder }: { props: ProbeProps; holder: Holder }) {
+  const variables: MyCardgroupsConnectionQueryVariables = useMemo(
+    () =>
+      props.searchQuery === null ? DEFAULT_VARS : { ...DEFAULT_VARS, search: props.searchQuery },
+    [props.searchQuery],
+  );
+
+  const value = useConnectionPagination<
+    MyCardgroupsConnectionQuery,
+    MyCardgroupsConnectionQueryVariables,
+    CgEdge,
+    CgPageInfo
+  >({
+    document: MyCardgroupsConnectionDocument,
+    variables,
+    searchQuery: props.searchQuery,
+    selectConnection,
+    buildFetchMoreVariables,
+    mergeConnection,
+    initial: props.initial,
+    resolveFetchMoreError,
+    logScope: "[test]",
+  });
+
+  holder.current = value;
+  return createElement("div", { ref: value.sentinelRef, "data-testid": "sentinel" });
+}
+
+type RenderOptions = {
+  mocks: ReadonlyArray<unknown>;
+  cache: InMemoryCache;
+  searchQuery?: string | null;
+  initial?: { edges: CgEdge[]; pageInfo: CgPageInfo; totalCount: number };
+};
+
+function renderProbe(opts: RenderOptions) {
+  const holder: Holder = { current: null };
+  const initial = opts.initial ?? { edges: [], pageInfo: EMPTY_PAGE_INFO, totalCount: 0 };
+
+  const wrap = (searchQuery: string | null): ReactNode =>
+    createElement(
+      MockedProvider,
+      { mocks: opts.mocks as never, cache: opts.cache } as never,
+      createElement(HookProbe, { props: { searchQuery, initial }, holder }),
+    );
+
+  const utils = render(wrap(opts.searchQuery ?? null));
+
+  const result = {
+    get current(): HookResult {
+      if (!holder.current) throw new Error("useConnectionPagination has not produced a value yet");
+      return holder.current;
+    },
+  };
+
+  const rerender = (searchQuery: string | null) => utils.rerender(wrap(searchQuery));
+
+  return { ...utils, result, rerender };
+}
+
+function seedCache(cache: InMemoryCache, conn: CgConnection) {
+  cache.writeQuery({
+    query: MyCardgroupsConnectionDocument,
+    variables: DEFAULT_VARS,
+    data: { myCardgroupsConnection: conn },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("useConnectionPagination", () => {
+  it("returns the SSR-seeded edges/pageInfo/totalCount from cache without a network call", () => {
+    const cache = new InMemoryCache();
+    seedCache(cache, connection([CG_1, CG_2]));
+
+    // initial is empty on purpose: a non-empty edges result proves the value
+    // came from the cache seed, not from the `initial` fallback.
+    const { result } = renderProbe({ mocks: [], cache });
+
+    expect(result.current.edges).toHaveLength(2);
+    expect(result.current.edges[0]?.node.id).toBe(CG_1.id);
+    expect(result.current.edges[1]?.node.id).toBe(CG_2.id);
+    expect(result.current.totalCount).toBe(2);
+    expect(result.current.pageInfo.hasNextPage).toBe(false);
+    expect(result.current.fetchMoreError).toBeNull();
+    expect(result.current.queryVariables).toEqual(DEFAULT_VARS);
+  });
+
+  it("observer-driven fetchMore advances the cursor and appends the next page", async () => {
+    const cache = new InMemoryCache();
+    const page1 = connection([CG_1, CG_2], true);
+    seedCache(cache, page1);
+
+    const page2Mock = {
+      request: {
+        query: MyCardgroupsConnectionDocument,
+        variables: { ...DEFAULT_VARS, after: CG_2.id, search: null },
+      },
+      result: { data: { myCardgroupsConnection: connection([CG_3]) } },
+    };
+
+    const { result } = renderProbe({ mocks: [page2Mock], cache });
+
+    expect(result.current.pageInfo.hasNextPage).toBe(true);
+    expect(result.current.edges).toHaveLength(2);
+
+    act(() => {
+      fireIntersect();
+    });
+
+    await waitFor(() => {
+      expect(result.current.edges).toHaveLength(3);
+    });
+    expect(result.current.edges[2]?.node.id).toBe(CG_3.id);
+    expect(result.current.fetchMoreError).toBeNull();
+  });
+
+  it("in-flight guard prevents a second fetchMore while the first is in flight", async () => {
+    let page2CallCount = 0;
+    const cache = new InMemoryCache();
+    seedCache(cache, connection([CG_1, CG_2], true));
+
+    const page2Mock = {
+      request: {
+        query: MyCardgroupsConnectionDocument,
+        variables: { ...DEFAULT_VARS, after: CG_2.id, search: null },
+      },
+      delay: 30,
+      result: () => {
+        page2CallCount += 1;
+        return { data: { myCardgroupsConnection: connection([CG_3]) } };
+      },
+    };
+
+    const { result } = renderProbe({ mocks: [page2Mock], cache });
+
+    act(() => {
+      fireIntersect();
+      fireIntersect();
+    });
+
+    await waitFor(() => {
+      expect(result.current.edges).toHaveLength(3);
+    });
+
+    expect(page2CallCount).toBe(1);
+  });
+
+  it("fetchMore error halts the IO loop, then retryFetchMore clears it and succeeds", async () => {
+    const cache = new InMemoryCache();
+    seedCache(cache, connection([CG_1, CG_2], true));
+
+    const errorMock = {
+      request: {
+        query: MyCardgroupsConnectionDocument,
+        variables: { ...DEFAULT_VARS, after: CG_2.id, search: null },
+      },
+      result: {
+        errors: [new GraphQLError("boom", { extensions: { code: "INTERNAL" } })],
+      },
+    };
+    const retryMock = {
+      request: {
+        query: MyCardgroupsConnectionDocument,
+        variables: { ...DEFAULT_VARS, after: CG_2.id, search: null },
+      },
+      result: { data: { myCardgroupsConnection: connection([CG_3]) } },
+    };
+
+    const { result } = renderProbe({ mocks: [errorMock, retryMock], cache });
+
+    act(() => {
+      fireIntersect();
+    });
+
+    await waitFor(() => {
+      expect(result.current.fetchMoreError).not.toBeNull();
+    });
+    expect(result.current.fetchMoreError).toBe("Could not load more.");
+
+    // Halt gate: the observer disconnected, so a second intersect does nothing.
+    expect(latestObserver()).toBeUndefined();
+    act(() => {
+      fireIntersect();
+    });
+    await new Promise((r) => setTimeout(r, 10));
+    expect(result.current.edges).toHaveLength(2);
+
+    // Retry clears the error and re-runs the request, merging page 2.
+    act(() => {
+      result.current.retryFetchMore();
+    });
+
+    await waitFor(() => {
+      expect(result.current.edges).toHaveLength(3);
+    });
+    expect(result.current.fetchMoreError).toBeNull();
+    expect(result.current.edges[2]?.node.id).toBe(CG_3.id);
+  });
+
+  it("searchQuery change clears fetchMoreError via the immediate-reset effect", async () => {
+    const cache = new InMemoryCache();
+    const page1 = connection([CG_1, CG_2], true);
+    seedCache(cache, page1);
+
+    const errorMock = {
+      request: {
+        query: MyCardgroupsConnectionDocument,
+        variables: { ...DEFAULT_VARS, after: CG_2.id, search: null },
+      },
+      result: {
+        errors: [new GraphQLError("boom", { extensions: { code: "INTERNAL" } })],
+      },
+    };
+    const searchMock = {
+      request: {
+        query: MyCardgroupsConnectionDocument,
+        variables: { ...DEFAULT_VARS, search: "x" },
+      },
+      result: { data: { myCardgroupsConnection: connection([CG_1]) } },
+    };
+
+    const { result, rerender } = renderProbe({
+      mocks: [errorMock, searchMock],
+      cache,
+      searchQuery: null,
+    });
+
+    act(() => {
+      fireIntersect();
+    });
+
+    await waitFor(() => {
+      expect(result.current.fetchMoreError).not.toBeNull();
+    });
+
+    rerender("x");
+
+    await waitFor(() => {
+      expect(result.current.fetchMoreError).toBeNull();
+    });
+    expect(result.current.queryVariables).toEqual({ ...DEFAULT_VARS, search: "x" });
+  });
+});

--- a/frontend/src/lib/pagination/use-connection-pagination.ts
+++ b/frontend/src/lib/pagination/use-connection-pagination.ts
@@ -1,0 +1,221 @@
+import {
+  type ErrorLike,
+  NetworkStatus,
+  type OperationVariables,
+  type TypedDocumentNode,
+} from "@apollo/client";
+import { useQuery } from "@apollo/client/react";
+import type { RefObject } from "react";
+import { useCallback, useEffect, useEffectEvent, useRef, useState } from "react";
+import type { FetchNextPageInput } from "@/lib/pagination/types";
+
+/** Minimal `pageInfo` shape the IO loop reads: the next-page flag and the cursor. */
+interface PageInfoLike {
+  hasNextPage: boolean;
+  endCursor?: string | null;
+}
+
+/** The Relay connection slice the hook renders and advances. */
+interface ConnectionShape<TEdge, TPageInfo> {
+  edges: TEdge[];
+  pageInfo: TPageInfo;
+  totalCount: number;
+}
+
+export interface UseConnectionPaginationInput<
+  TData,
+  TVars extends OperationVariables,
+  TEdge,
+  TPageInfo extends PageInfoLike,
+> {
+  /** The typed connection query document. */
+  document: TypedDocumentNode<TData, TVars>;
+  /**
+   * The variables for the active query. The caller weaves the debounced
+   * `searchQuery` into these; the hook does not mutate them. Memoize at the
+   * call site so the underlying `useQuery` does not re-subscribe each render.
+   */
+  variables: TVars;
+  /**
+   * The active debounced search value (or `null`). Used only as the
+   * immediate-reset trigger — when it changes, the in-flight guard and
+   * fetch-more error are cleared so a stale-cursor fetch from the previous
+   * search cannot complete against the new query.
+   */
+  searchQuery: string | null;
+  /** Reads the connection slice out of the query result (document-specific field). */
+  selectConnection: (data: TData | undefined) => ConnectionShape<TEdge, TPageInfo> | undefined;
+  /** Builds the `fetchMore` variables for the next page given the cursor + search. */
+  buildFetchMoreVariables: (endCursor: string | null, searchQuery: string | null) => TVars;
+  /** Concatenates the next page's edges onto the previous result (document-specific field). */
+  mergeConnection: (prev: TData, more: TData) => TData;
+  /**
+   * Render fallback used until the query resolves. For SSR-seeded screens this
+   * is never read (the cache seed makes the first `useQuery` pass synchronous);
+   * for prop-seeded screens it is the initial render value.
+   */
+  initial: ConnectionShape<TEdge, TPageInfo>;
+  /** Maps a failed `fetchMore` error to the user-facing banner string. */
+  resolveFetchMoreError: (err: unknown) => string;
+  /** Log prefix for the structured `fetchMore failed` warn, e.g. `"[cardgroups]"`. */
+  logScope: string;
+}
+
+export interface UseConnectionPaginationResult<TEdge, TPageInfo, TVars> {
+  edges: TEdge[];
+  pageInfo: TPageInfo;
+  totalCount: number;
+  loading: boolean;
+  networkStatus: NetworkStatus;
+  fetchingMore: boolean;
+  fetchMoreError: string | null;
+  retryFetchMore: () => void;
+  sentinelRef: RefObject<HTMLDivElement | null>;
+  queryVariables: TVars;
+  queryError: ErrorLike | undefined;
+}
+
+// Generic Apollo connection + fetchMore + IntersectionObserver hook for
+// cursor-paginated lists. Generalised from the cards-by-cardgroup hook;
+// the only document-specific bits (the query, the variables factory, the
+// connection accessor + edges concat) are injected by the caller. Preserves
+// three invariants from .claude/rules/pagination.md: the IO in-flight guard
+// (useRef<boolean>), the React 19.2 useEffectEvent observer advance path, and
+// the immediate-reset effect driven by searchQuery changes.
+export function useConnectionPagination<
+  TData,
+  TVars extends OperationVariables,
+  TEdge,
+  TPageInfo extends PageInfoLike,
+>(
+  input: UseConnectionPaginationInput<TData, TVars, TEdge, TPageInfo>,
+): UseConnectionPaginationResult<TEdge, TPageInfo, TVars> {
+  const {
+    document,
+    variables,
+    searchQuery,
+    selectConnection,
+    buildFetchMoreVariables,
+    mergeConnection,
+    initial,
+    resolveFetchMoreError,
+    logScope,
+  } = input;
+
+  const [fetchMoreError, setFetchMoreError] = useState<string | null>(null);
+
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
+  // In-flight guard MUST be useRef<boolean>, not useState — see
+  // docs/pagination/intersection-observer-in-flight-guard.md.
+  const fetchingRef = useRef(false);
+
+  // When the active search query changes, any in-flight fetchMore from the
+  // previous search holds a stale cursor. Reset the IO guard and error state
+  // immediately so the new query starts from a clean slate.
+  // See docs/pagination/intersection-observer-in-flight-guard.md.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: searchQuery is an intentional trigger dependency; it is not referenced in the body because the effect resets derived IO state, not searchQuery itself.
+  useEffect(() => {
+    fetchingRef.current = false;
+    setFetchMoreError(null);
+  }, [searchQuery]);
+
+  const {
+    data,
+    fetchMore,
+    loading,
+    networkStatus,
+    error: queryError,
+  } = useQuery(document, {
+    variables,
+    fetchPolicy: "cache-first",
+    notifyOnNetworkStatusChange: true,
+  });
+
+  const connection = selectConnection(data);
+  const edges = connection?.edges ?? initial.edges;
+  const pageInfo = connection?.pageInfo ?? initial.pageInfo;
+  const totalCount = connection?.totalCount ?? initial.totalCount;
+
+  const fetchNextPage = useCallback(
+    ({ hasNextPage, endCursor, searchQuery }: FetchNextPageInput) => {
+      if (fetchingRef.current || !hasNextPage) return;
+
+      fetchingRef.current = true;
+      fetchMore({
+        variables: buildFetchMoreVariables(endCursor, searchQuery),
+        updateQuery: (prev, { fetchMoreResult }) => {
+          if (!fetchMoreResult) return prev;
+          return mergeConnection(prev, fetchMoreResult);
+        },
+      })
+        .then(() => {
+          // Clear any previous fetchMore error on success so the observer can resume.
+          setFetchMoreError(null);
+        })
+        .catch((err) => {
+          // Structured warn for operator triage: name + request context only.
+          // err.message is omitted — backend messages may carry user-authored content.
+          // See docs/frontend/rsc-error-handling/redact-err-message-from-console-payloads.md.
+          console.warn(`${logScope} fetchMore failed`, {
+            name: err instanceof Error ? err.name : "unknown",
+            searchQuery,
+            endCursor,
+          });
+          setFetchMoreError(resolveFetchMoreError(err));
+        })
+        .finally(() => {
+          fetchingRef.current = false;
+        });
+    },
+    [fetchMore, buildFetchMoreVariables, mergeConnection, resolveFetchMoreError, logScope],
+  );
+
+  const requestNextPageFromObserver = useEffectEvent(() => {
+    fetchNextPage({
+      hasNextPage: pageInfo.hasNextPage,
+      endCursor: pageInfo.endCursor ?? null,
+      searchQuery,
+    });
+  });
+
+  useEffect(() => {
+    if (!pageInfo.hasNextPage) return;
+    // Stop the observer loop while a previous fetch failed; user must click Retry to resume.
+    if (fetchMoreError != null) return;
+    const node = sentinelRef.current;
+    if (!node) return;
+
+    const observer = new IntersectionObserver((entries) => {
+      if (!entries[0]?.isIntersecting || fetchingRef.current) return;
+      requestNextPageFromObserver();
+    });
+
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [pageInfo.hasNextPage, fetchMoreError]);
+
+  const retryFetchMore = useCallback(() => {
+    setFetchMoreError(null);
+    fetchNextPage({
+      hasNextPage: pageInfo.hasNextPage,
+      endCursor: pageInfo.endCursor ?? null,
+      searchQuery,
+    });
+  }, [fetchNextPage, pageInfo.endCursor, pageInfo.hasNextPage, searchQuery]);
+
+  const fetchingMore = networkStatus === NetworkStatus.fetchMore || (loading && edges.length > 0);
+
+  return {
+    edges,
+    pageInfo,
+    totalCount,
+    loading,
+    networkStatus,
+    fetchingMore,
+    fetchMoreError,
+    retryFetchMore,
+    sentinelRef,
+    queryVariables: variables,
+    queryError,
+  };
+}


### PR DESCRIPTION
## Summary

`cardgroups-client.tsx`, `catalog-client.tsx`, and the cards-by-cardgroup hook each re-implemented the same Apollo `useQuery` + `fetchMore` + `IntersectionObserver` infinite-scroll loop (in-flight guard, `useEffectEvent` observer advance, split debounce / immediate-reset, error-halt gate). The loop now lives once in a generic `useConnectionPagination` hook; `useCardsConnection` is a thin wrapper over it and the two list screens consume it directly. **Pure DRY refactor — no user-visible behaviour change.**

Closes #446.

## Background / Motivation

- The infinite-scroll IO core (`fetchingRef` / `requestNextPageFromObserver` / `useEffectEvent` / the observer `useEffect`) appeared in five files; only the cards list (`use-cards-connection.ts`) had extracted it. A fix to any one invariant (e.g. the error-halt gate) had to be applied N times.
- The only document-specific bits of the cards hook were the query document, the variables factory, and the `data?.<field>` connection accessor + edges concat — everything else was identical boilerplate.
- Wave 1 of the frontend functional-cohesion review (issue #446). Admin masters/users keep their inline copies pending the follow-up issue, so this PR stays ≈500 production lines and does not race the admin work on the same files.

## Changes

### New `lib/pagination/use-connection-pagination.ts`

- Generic hook over `<TData, TVars, TEdge, TPageInfo>`. The caller injects the document, the active `variables`, `searchQuery` (the immediate-reset trigger), `selectConnection`, `buildFetchMoreVariables`, `mergeConnection`, the `initial` render fallback, `resolveFetchMoreError`, and a `logScope`.
- Owns all three pagination-rule invariants (`useRef<boolean>` in-flight guard, React 19.2 `useEffectEvent` observer advance, the `searchQuery`-triggered immediate-reset effect) plus the `fetchMoreError != null` IO halt gate and `retryFetchMore` re-entry.
- Banner resolution is an injected `resolveFetchMoreError(err)` callback rather than a fixed string: `getBackendErrorBanner` returns a network message (not `undefined`) for a plain `Error`, so catalog — which always showed the generic banner — opts out of the backend-message path to stay behaviour-identical.

### `app/cardgroups/[id]/cards/use-cards-connection.ts` (rebased)

- Now a thin wrapper that calls `useConnectionPagination` with the cards document / `cardsDefaultVars` / `data?.cardsByCardgroupConnection` accessor. The public `UseCardsConnectionInput` / `UseCardsConnectionResult` and every call site are unchanged; the existing `use-cards-connection.test.ts` passes unchanged — the behaviour-preserving proof.

### `app/cardgroups/cardgroups-client.tsx` + `app/catalog/catalog-client.tsx` (migrated)

- Inline IO blocks removed; both now consume `useConnectionPagination`. Debounce switched to the shared `useDebouncedSearch` hook.
- The SSR-seed `writeQuery` block (and its `initialConnection`-null warn) deliberately stays in each client — the seed is the client's responsibility, the cache key still matches each screen's `*_DEFAULT_VARS`, and the catalog null-seed warning test relies on it.
- cardgroups passes `(err) => getBackendErrorBanner(err) ?? t("fetchMoreError")`; catalog passes `() => t("fetchMoreError")` (always generic) — each via the injected `resolveFetchMoreError`, preserving its prior banner behaviour exactly.

### Tests

- New `lib/pagination/use-connection-pagination.test.tsx` drives the generic hook against the `MyCardgroupsConnection` document (a non-cards document, to prove genericity) across SSR seed, observer-driven fetchMore, in-flight guard, error → halt → retry, and search-change reset.
- `pagination-ref-triplet-removal-rule.test.ts` updated for the new shape: the shared hook (plus the not-yet-migrated admin clients) is the `useEffectEvent` IO owner; the migrated screens are asserted to consume `useConnectionPagination` and carry no inline `new IntersectionObserver` / `useEffectEvent`.
- `use-cards-connection.test.ts`, `cardgroups-client.test.tsx`, `catalog-client.test.tsx` all pass unchanged.

## Verification

```bash
# The observer loop is constructed in exactly one shared place (plus the
# not-yet-migrated admin clients):
grep -rln "new IntersectionObserver" frontend/src/app frontend/src/lib --include='*.ts' --include='*.tsx' | grep -v test
# → lib/pagination/use-connection-pagination.ts + admin masters/users only

# The three migrated sites consume the shared hook:
grep -rln "useConnectionPagination" frontend/src/app --include='*.ts' --include='*.tsx' | grep -v test
# → cardgroups-client.tsx, catalog-client.tsx, [id]/cards/use-cards-connection.ts
```

## Test plan

- [x] `pnpm --filter frontend typecheck` — exit 0
- [x] `pnpm --filter frontend lint` (`biome check --error-on-warnings`) — clean
- [x] `pnpm --filter frontend knip` — exit 0 (hook wired; no dead exports)
- [x] `pnpm --filter frontend test` — 1334 passed (138 files)
- [x] `pnpm --filter frontend build` — success
- [x] No inline CJK in changed source
