### PR TITLE
refactor(domain): aggregates own their invariants and state transitions

### DIFF
--- a/backend/internal/domain/card.go
+++ b/backend/internal/domain/card.go
@@ -20,7 +20,7 @@ var (
 //
 // CardgroupID ownership is enforced at the usecase boundary via
 // authorizeCardgroupOrBadInput before a Card is constructed; the domain
-// aggregate therefore does not re-check CardgroupID presence in Validate.
+// aggregate therefore does not re-check CardgroupID presence in NewCard.
 type Card struct {
 	ID          string
 	CardgroupID string
@@ -42,14 +42,36 @@ func (c *Card) BelongsToCardgroup(cardgroupID string) bool {
 	return cardgroupID != "" && c.CardgroupID == cardgroupID
 }
 
-func (c *Card) Validate() error {
-	if _, err := ParseCardText(string(c.Front), ErrCardFrontRequired, ErrCardFrontTooLong); err != nil {
-		return err
+// NewCard constructs a Card aggregate, enforcing its invariants at construction
+// time: Front and Back are validated and trimmed through ParseCardText and a
+// fresh UUID v7 ID is generated. CreatedAt and UpdatedAt are stamped with the
+// current UTC time; batch callers may override both with a shared timestamp
+// before persisting. Returns the field-specific CardText sentinel (e.g.
+// ErrCardFrontRequired) on invalid input — callers translate it via
+// translateCardErr — or a wrapped error when ID generation fails.
+func NewCard(cardgroupID, front, back string, position int) (*Card, error) {
+	frontVO, err := ParseCardText(front, ErrCardFrontRequired, ErrCardFrontTooLong)
+	if err != nil {
+		return nil, err
 	}
-	if _, err := ParseCardText(string(c.Back), ErrCardBackRequired, ErrCardBackTooLong); err != nil {
-		return err
+	backVO, err := ParseCardText(back, ErrCardBackRequired, ErrCardBackTooLong)
+	if err != nil {
+		return nil, err
 	}
-	return nil
+	id, err := NewID()
+	if err != nil {
+		return nil, eris.Wrap(err, "card: new id")
+	}
+	now := time.Now().UTC()
+	return &Card{
+		ID:          id,
+		CardgroupID: cardgroupID,
+		Front:       frontVO,
+		Back:        backVO,
+		Position:    position,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}, nil
 }
 
 // UpdateFront updates the card's front text to the supplied value and returns an

--- a/backend/internal/domain/card_test.go
+++ b/backend/internal/domain/card_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 )
 
@@ -33,59 +34,69 @@ func TestCardShape(t *testing.T) {
 	require.False(t, ok, "Card must not embed per-user FSRS state")
 }
 
-func TestCardValidate(t *testing.T) {
+func TestNewCard(t *testing.T) {
 	t.Parallel()
 
 	const zwjEmoji = "👨‍👩‍👧‍👦"
+
+	t.Run("valid input constructs a fully-formed card", func(t *testing.T) {
+		t.Parallel()
+
+		c, err := NewCard("cg-1", "  front  ", "back", 7)
+		require.NoError(t, err)
+		require.NotEmpty(t, c.ID, "constructor must generate an ID")
+		require.Equal(t, "cg-1", c.CardgroupID)
+		require.Equal(t, CardText("front"), c.Front, "front must be trimmed via ParseCardText")
+		require.Equal(t, CardText("back"), c.Back)
+		require.Equal(t, 7, c.Position)
+		require.False(t, c.CreatedAt.IsZero(), "constructor must stamp CreatedAt")
+		require.Equal(t, c.CreatedAt, c.UpdatedAt, "CreatedAt and UpdatedAt must match at construction")
+	})
+
+	t.Run("valid at max grapheme length", func(t *testing.T) {
+		t.Parallel()
+
+		c, err := NewCard("cg", strings.Repeat(zwjEmoji, 500), strings.Repeat("b", 500), 0)
+		require.NoError(t, err)
+		require.Equal(t, CardText(strings.Repeat(zwjEmoji, 500)), c.Front)
+	})
+
 	cases := []struct {
 		name        string
-		card        Card
+		front       string
+		back        string
 		sentinelErr error
 	}{
-		{
-			name:        "front required",
-			card:        Card{CardgroupID: "cg", Front: "", Back: "back"},
-			sentinelErr: ErrCardFrontRequired,
-		},
-		{
-			name:        "front whitespace only treated as required",
-			card:        Card{CardgroupID: "cg", Front: "   ", Back: "back"},
-			sentinelErr: ErrCardFrontRequired,
-		},
-		{
-			name:        "back required",
-			card:        Card{CardgroupID: "cg", Front: "front", Back: "  "},
-			sentinelErr: ErrCardBackRequired,
-		},
-		{
-			name:        "front too long",
-			card:        Card{CardgroupID: "cg", Front: CardText(strings.Repeat("a", 501)), Back: "back"},
-			sentinelErr: ErrCardFrontTooLong,
-		},
-		{
-			name:        "back too long with graphemes",
-			card:        Card{CardgroupID: "cg", Front: "front", Back: CardText(strings.Repeat(zwjEmoji, 501))},
-			sentinelErr: ErrCardBackTooLong,
-		},
-		{
-			name: "valid at max grapheme length",
-			card: Card{CardgroupID: "cg", Front: CardText(strings.Repeat(zwjEmoji, 500)), Back: CardText(strings.Repeat("b", 500))},
-		},
+		{"front required", "", "back", ErrCardFrontRequired},
+		{"front whitespace only treated as required", "   ", "back", ErrCardFrontRequired},
+		{"back required", "front", "  ", ErrCardBackRequired},
+		{"front too long", strings.Repeat("a", CardTextMax+1), "back", ErrCardFrontTooLong},
+		{"back too long with graphemes", "front", strings.Repeat(zwjEmoji, CardTextMax+1), ErrCardBackTooLong},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			err := tc.card.Validate()
-			if tc.sentinelErr == nil {
-				require.NoError(t, err)
-				return
-			}
-			require.Error(t, err)
-			require.True(t, errors.Is(err, tc.sentinelErr), "got %v", err)
+			c, err := NewCard("cg", tc.front, tc.back, 0)
+			require.Nil(t, c, "no aggregate may be constructed from invalid input")
+			require.ErrorIs(t, err, tc.sentinelErr, "got %v", err)
 		})
 	}
+}
+
+// TestNewCard_IDFailure pins the id-generation failure path through the newV7
+// test seam; ParseCardText runs first, so valid text reaches NewID.
+func TestNewCard_IDFailure(t *testing.T) {
+	orig := newV7
+	newV7 = func() (uuid.UUID, error) { return uuid.UUID{}, errors.New("crypto/rand unavailable") }
+	t.Cleanup(func() { newV7 = orig })
+
+	c, err := NewCard("cg", "front", "back", 0)
+	require.Nil(t, c)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "card: new id")
+	require.Contains(t, err.Error(), "domain: new uuid v7")
 }
 
 func TestCardBelongsToCardgroup(t *testing.T) {

--- a/backend/internal/domain/master_card.go
+++ b/backend/internal/domain/master_card.go
@@ -1,6 +1,10 @@
 package domain
 
-import "time"
+import (
+	"time"
+
+	"github.com/rotisserie/eris"
+)
 
 // MasterCard is a single card within a MasterCardgroup. It references its
 // parent by MasterCardgroupID only; cross-aggregate resolution is handled by
@@ -19,16 +23,34 @@ type MasterCard struct {
 	UpdatedAt         time.Time
 }
 
-// Validate checks that Front and Back are non-empty and within the CardTextMax
-// limit. It reuses ParseCardText with the same field-specific sentinels as
-// Card.Validate() — ErrCardFrontRequired / ErrCardFrontTooLong for Front, and
-// ErrCardBackRequired / ErrCardBackTooLong for Back.
-func (c *MasterCard) Validate() error {
-	if _, err := ParseCardText(string(c.Front), ErrCardFrontRequired, ErrCardFrontTooLong); err != nil {
-		return err
+// NewMasterCard constructs a MasterCard aggregate, mirroring NewCard: Front and
+// Back are validated and trimmed through ParseCardText with the same
+// field-specific sentinels (ErrCardFrontRequired / ErrCardFrontTooLong for
+// Front, ErrCardBackRequired / ErrCardBackTooLong for Back), and a fresh UUID
+// v7 ID is generated. CreatedAt and UpdatedAt are stamped with the current UTC
+// time; batch callers may override both with a shared timestamp before
+// persisting.
+func NewMasterCard(masterCardgroupID, front, back string, position int) (*MasterCard, error) {
+	frontVO, err := ParseCardText(front, ErrCardFrontRequired, ErrCardFrontTooLong)
+	if err != nil {
+		return nil, err
 	}
-	if _, err := ParseCardText(string(c.Back), ErrCardBackRequired, ErrCardBackTooLong); err != nil {
-		return err
+	backVO, err := ParseCardText(back, ErrCardBackRequired, ErrCardBackTooLong)
+	if err != nil {
+		return nil, err
 	}
-	return nil
+	id, err := NewID()
+	if err != nil {
+		return nil, eris.Wrap(err, "master card: new id")
+	}
+	now := time.Now().UTC()
+	return &MasterCard{
+		ID:                id,
+		MasterCardgroupID: masterCardgroupID,
+		Front:             frontVO,
+		Back:              backVO,
+		Position:          position,
+		CreatedAt:         now,
+		UpdatedAt:         now,
+	}, nil
 }

--- a/backend/internal/domain/master_card_test.go
+++ b/backend/internal/domain/master_card_test.go
@@ -5,94 +5,64 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 )
 
-func TestMasterCardValidate(t *testing.T) {
+func TestNewMasterCard(t *testing.T) {
 	t.Parallel()
 
 	const zwjEmoji = "👨‍👩‍👧‍👦"
 
+	t.Run("valid input constructs a fully-formed master card", func(t *testing.T) {
+		t.Parallel()
+
+		c, err := NewMasterCard("mcg", "  front  ", "back", 3)
+		require.NoError(t, err)
+		require.NotEmpty(t, c.ID, "constructor must generate an ID")
+		require.Equal(t, "mcg", c.MasterCardgroupID)
+		require.Equal(t, CardText("front"), c.Front, "front must be trimmed via ParseCardText")
+		require.Equal(t, CardText("back"), c.Back)
+		require.Equal(t, 3, c.Position)
+		require.False(t, c.CreatedAt.IsZero(), "constructor must stamp CreatedAt")
+		require.Equal(t, c.CreatedAt, c.UpdatedAt, "CreatedAt and UpdatedAt must match at construction")
+	})
+
 	cases := []struct {
 		name        string
-		card        MasterCard
+		front       string
+		back        string
 		sentinelErr error
 	}{
-		{
-			name: "valid front and back",
-			card: MasterCard{
-				MasterCardgroupID: "mcg",
-				Front:             CardText("front"),
-				Back:              CardText("back"),
-			},
-		},
-		{
-			name: "empty front returns ErrCardFrontRequired",
-			card: MasterCard{
-				MasterCardgroupID: "mcg",
-				Front:             CardText(""),
-				Back:              CardText("back"),
-			},
-			sentinelErr: ErrCardFrontRequired,
-		},
-		{
-			name: "whitespace-only front returns ErrCardFrontRequired",
-			card: MasterCard{
-				MasterCardgroupID: "mcg",
-				Front:             CardText("   "),
-				Back:              CardText("back"),
-			},
-			sentinelErr: ErrCardFrontRequired,
-		},
-		{
-			name: "front over CardTextMax returns ErrCardFrontTooLong",
-			card: MasterCard{
-				MasterCardgroupID: "mcg",
-				Front:             CardText(strings.Repeat("a", CardTextMax+1)),
-				Back:              CardText("back"),
-			},
-			sentinelErr: ErrCardFrontTooLong,
-		},
-		{
-			name: "front over CardTextMax with graphemes returns ErrCardFrontTooLong",
-			card: MasterCard{
-				MasterCardgroupID: "mcg",
-				Front:             CardText(strings.Repeat(zwjEmoji, CardTextMax+1)),
-				Back:              CardText("back"),
-			},
-			sentinelErr: ErrCardFrontTooLong,
-		},
-		{
-			name: "empty back returns ErrCardBackRequired",
-			card: MasterCard{
-				MasterCardgroupID: "mcg",
-				Front:             CardText("front"),
-				Back:              CardText(""),
-			},
-			sentinelErr: ErrCardBackRequired,
-		},
-		{
-			name: "back over CardTextMax returns ErrCardBackTooLong",
-			card: MasterCard{
-				MasterCardgroupID: "mcg",
-				Front:             CardText("front"),
-				Back:              CardText(strings.Repeat("b", CardTextMax+1)),
-			},
-			sentinelErr: ErrCardBackTooLong,
-		},
+		{"empty front returns ErrCardFrontRequired", "", "back", ErrCardFrontRequired},
+		{"whitespace-only front returns ErrCardFrontRequired", "   ", "back", ErrCardFrontRequired},
+		{"front over CardTextMax returns ErrCardFrontTooLong", strings.Repeat("a", CardTextMax+1), "back", ErrCardFrontTooLong},
+		{"front over CardTextMax with graphemes returns ErrCardFrontTooLong", strings.Repeat(zwjEmoji, CardTextMax+1), "back", ErrCardFrontTooLong},
+		{"empty back returns ErrCardBackRequired", "front", "", ErrCardBackRequired},
+		{"back over CardTextMax returns ErrCardBackTooLong", "front", strings.Repeat("b", CardTextMax+1), ErrCardBackTooLong},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			err := tc.card.Validate()
-			if tc.sentinelErr == nil {
-				require.NoError(t, err)
-				return
-			}
-			require.Error(t, err)
-			require.True(t, errors.Is(err, tc.sentinelErr), "got %v", err)
+			c, err := NewMasterCard("mcg", tc.front, tc.back, 0)
+			require.Nil(t, c, "no aggregate may be constructed from invalid input")
+			require.ErrorIs(t, err, tc.sentinelErr, "got %v", err)
 		})
 	}
+}
+
+// TestNewMasterCard_IDFailure pins the id-generation failure path through the
+// newV7 test seam; ParseCardText runs first, so valid text reaches NewID.
+func TestNewMasterCard_IDFailure(t *testing.T) {
+	orig := newV7
+	newV7 = func() (uuid.UUID, error) { return uuid.UUID{}, errors.New("crypto/rand unavailable") }
+	t.Cleanup(func() { newV7 = orig })
+
+	c, err := NewMasterCard("mcg", "front", "back", 0)
+	require.Nil(t, c)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "master card: new id")
+	require.Contains(t, err.Error(), "domain: new uuid v7")
 }

--- a/backend/internal/domain/master_cardgroup.go
+++ b/backend/internal/domain/master_cardgroup.go
@@ -45,3 +45,27 @@ type MasterCardgroup struct {
 func (m *MasterCardgroup) IsPublished() bool {
 	return m.Status == MasterStatusPublished
 }
+
+// Publish transitions the master cardgroup to the published state. It is
+// idempotent: publishing an already-published group is a no-op and leaves the
+// version untouched, so two concurrent publishes (serialized by the
+// repository's row lock) increment the version exactly once. The version is
+// bumped ONLY on the draft -> published transition; this asymmetry with
+// Unpublish (which never touches the version) is the core publication rule and
+// is encoded here, in the aggregate, rather than in repository SQL.
+func (m *MasterCardgroup) Publish() error {
+	if m.IsPublished() {
+		return nil
+	}
+	m.Status = MasterStatusPublished
+	m.Version++
+	return nil
+}
+
+// Unpublish transitions the master cardgroup back to the draft state. The
+// version is deliberately left unchanged — only Publish bumps it — so the
+// version counter tracks publication events, not unpublications.
+func (m *MasterCardgroup) Unpublish() error {
+	m.Status = MasterStatusDraft
+	return nil
+}

--- a/backend/internal/domain/master_cardgroup_test.go
+++ b/backend/internal/domain/master_cardgroup_test.go
@@ -29,6 +29,46 @@ func TestMasterCardgroupStatusIsValid(t *testing.T) {
 	}
 }
 
+func TestMasterCardgroupPublish(t *testing.T) {
+	t.Parallel()
+
+	t.Run("draft transitions to published and bumps version by one", func(t *testing.T) {
+		t.Parallel()
+		m := &MasterCardgroup{Name: "n", Status: MasterStatusDraft, Version: 1}
+		require.NoError(t, m.Publish())
+		require.Equal(t, MasterStatusPublished, m.Status)
+		require.Equal(t, 2, m.Version, "publish must increment version 1 -> 2")
+	})
+
+	t.Run("already published is idempotent and does not bump version", func(t *testing.T) {
+		t.Parallel()
+		m := &MasterCardgroup{Name: "n", Status: MasterStatusPublished, Version: 5}
+		require.NoError(t, m.Publish())
+		require.Equal(t, MasterStatusPublished, m.Status)
+		require.Equal(t, 5, m.Version, "re-publishing an already-published group must not bump version")
+	})
+}
+
+func TestMasterCardgroupUnpublish(t *testing.T) {
+	t.Parallel()
+
+	t.Run("published transitions to draft without changing version", func(t *testing.T) {
+		t.Parallel()
+		m := &MasterCardgroup{Name: "n", Status: MasterStatusPublished, Version: 3}
+		require.NoError(t, m.Unpublish())
+		require.Equal(t, MasterStatusDraft, m.Status)
+		require.Equal(t, 3, m.Version, "unpublish must leave version unchanged")
+	})
+
+	t.Run("already draft stays draft with version unchanged", func(t *testing.T) {
+		t.Parallel()
+		m := &MasterCardgroup{Name: "n", Status: MasterStatusDraft, Version: 3}
+		require.NoError(t, m.Unpublish())
+		require.Equal(t, MasterStatusDraft, m.Status)
+		require.Equal(t, 3, m.Version)
+	})
+}
+
 func TestMasterCardgroupIsPublished(t *testing.T) {
 	t.Parallel()
 

--- a/backend/internal/repository/master_cardgroup.go
+++ b/backend/internal/repository/master_cardgroup.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/rotisserie/eris"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 
 	"backend/internal/domain"
 )
@@ -614,38 +615,58 @@ func (r *masterCardgroupRepo) FindAdminPage(
 	return out, nil
 }
 
-// Publish atomically sets the master cardgroup status to published and
-// increments the version counter by 1. Returns ErrNotFound when no row
-// matches id.
+// Publish transitions the master cardgroup to the published state, bumping its
+// version exactly once. The publish state machine and the version-bump rule live
+// in domain.MasterCardgroup.Publish; this method only loads, applies, and
+// persists. The row is loaded FOR UPDATE inside a transaction so concurrent
+// publishes serialize and the idempotent aggregate method cannot double-bump or
+// lose the version increment. Returns ErrNotFound when no row matches id.
 func (r *masterCardgroupRepo) Publish(ctx context.Context, id string) (*domain.MasterCardgroup, error) {
-	res := r.db.WithContext(ctx).Model(&gormMasterCardgroup{}).
-		Where("id = ?", id).
-		Updates(map[string]any{
-			"status":  string(domain.MasterStatusPublished),
-			"version": gorm.Expr("version + 1"),
-		})
-	if res.Error != nil {
-		return nil, eris.Wrap(res.Error, "repository: master cardgroup: publish")
-	}
-	if res.RowsAffected == 0 {
-		return nil, ErrNotFound
-	}
-	return r.FindByID(ctx, id)
+	return r.applyStatusTransition(ctx, id, "publish", (*domain.MasterCardgroup).Publish)
 }
 
-// Unpublish sets the master cardgroup status back to draft without changing the
-// version counter. Returns ErrNotFound when no row matches id.
+// Unpublish transitions the master cardgroup back to draft without changing the
+// version. Same load-FOR-UPDATE → aggregate-method → save transaction shape as
+// Publish; the version-unchanged rule lives in domain.MasterCardgroup.Unpublish.
+// Returns ErrNotFound when no row matches id.
 func (r *masterCardgroupRepo) Unpublish(ctx context.Context, id string) (*domain.MasterCardgroup, error) {
-	res := r.db.WithContext(ctx).Model(&gormMasterCardgroup{}).
-		Where("id = ?", id).
-		Updates(map[string]any{"status": string(domain.MasterStatusDraft)})
-	if res.Error != nil {
-		return nil, eris.Wrap(res.Error, "repository: master cardgroup: unpublish")
+	return r.applyStatusTransition(ctx, id, "unpublish", (*domain.MasterCardgroup).Unpublish)
+}
+
+// applyStatusTransition loads the master cardgroup FOR UPDATE inside a single
+// transaction, applies the supplied aggregate state transition, and persists the
+// resulting status and version. The row lock serializes concurrent transitions
+// so the version invariant encoded in the aggregate holds without the previous
+// two divergent Updates(map) statements. op is the caller-supplied verb embedded
+// in the wrap prefix so the error chain attributes to publish vs. unpublish.
+func (r *masterCardgroupRepo) applyStatusTransition(
+	ctx context.Context, id, op string, transition func(*domain.MasterCardgroup) error,
+) (*domain.MasterCardgroup, error) {
+	var out *domain.MasterCardgroup
+	err := r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var row gormMasterCardgroup
+		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
+			Where("id = ?", id).Take(&row).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return ErrNotFound
+			}
+			return eris.Wrap(err, "repository: master cardgroup: "+op+": load")
+		}
+		m := masterCardgroupToDomain(row)
+		if err := transition(m); err != nil {
+			return eris.Wrap(err, "repository: master cardgroup: "+op+": apply")
+		}
+		if err := tx.Model(&gormMasterCardgroup{}).Where("id = ?", id).
+			Updates(map[string]any{"status": string(m.Status), "version": m.Version}).Error; err != nil {
+			return eris.Wrap(err, "repository: master cardgroup: "+op+": save")
+		}
+		out = m
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
-	if res.RowsAffected == 0 {
-		return nil, ErrNotFound
-	}
-	return r.FindByID(ctx, id)
+	return out, nil
 }
 
 func masterCardgroupToDomain(g gormMasterCardgroup) *domain.MasterCardgroup {

--- a/backend/internal/repository/master_cardgroup_admin_test.go
+++ b/backend/internal/repository/master_cardgroup_admin_test.go
@@ -15,6 +15,7 @@ package repository_test
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 
 	"github.com/google/uuid"
@@ -247,6 +248,46 @@ func TestMasterCardgroupRepository_Publish_NotFound(t *testing.T) {
 	_, err := repo.Publish(ctx, uuid.NewString())
 	require.True(t, errors.Is(err, repository.ErrNotFound),
 		"Publish on a non-existent id must return ErrNotFound")
+}
+
+// TestMasterCardgroupRepository_Publish_ConcurrentBumpsVersionExactlyOnce proves
+// the version invariant under contention. Two goroutines publish the same draft
+// at the same time; the repository loads the row FOR UPDATE inside a tx and the
+// aggregate's idempotent Publish() makes the second call a no-op. The version
+// therefore bumps exactly once (1 -> 2): the row lock prevents a lost update and
+// the idempotency guard prevents a double bump.
+func TestMasterCardgroupRepository_Publish_ConcurrentBumpsVersionExactlyOnce(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	repo := repository.NewMasterCardgroupRepository(testDB.GORM)
+
+	m := newMasterCardgroupMinimal("Concurrent Publish " + uuid.NewString())
+	m.Version = 1
+	m.Status = domain.MasterStatusDraft
+	require.NoError(t, repo.Create(ctx, m))
+
+	const n = 2
+	var wg sync.WaitGroup
+	errc := make(chan error, n)
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			_, err := repo.Publish(ctx, m.ID)
+			errc <- err
+		}()
+	}
+	wg.Wait()
+	close(errc)
+	for err := range errc {
+		require.NoError(t, err)
+	}
+
+	got, err := repo.FindByID(ctx, m.ID)
+	require.NoError(t, err)
+	require.Equal(t, domain.MasterStatusPublished, got.Status)
+	require.Equal(t, 2, got.Version,
+		"concurrent publishes must bump version exactly once (no double, no lost update)")
 }
 
 // ---------------------------------------------------------------------------

--- a/backend/internal/usecase/card.go
+++ b/backend/internal/usecase/card.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
-	"time"
 
 	"github.com/rotisserie/eris"
 	"gorm.io/gorm"
@@ -252,27 +251,9 @@ func (u *cardUsecase) Create(ctx context.Context, in CreateCardInput) (CreateCar
 		return CreateCardOutcome{}, err
 	}
 
-	frontVO, err := domain.ParseCardText(in.Front, domain.ErrCardFrontRequired, domain.ErrCardFrontTooLong)
+	card, err := domain.NewCard(in.CardgroupID, in.Front, in.Back, 0)
 	if err != nil {
 		return CreateCardOutcome{}, translateCardErr(err)
-	}
-	backVO, err := domain.ParseCardText(in.Back, domain.ErrCardBackRequired, domain.ErrCardBackTooLong)
-	if err != nil {
-		return CreateCardOutcome{}, translateCardErr(err)
-	}
-	now := time.Now().UTC()
-	id, err := domain.NewID()
-	if err != nil {
-		return CreateCardOutcome{}, eris.Wrap(err, "usecase: create card: generate id")
-	}
-
-	card := &domain.Card{
-		ID:          id,
-		CardgroupID: in.CardgroupID,
-		Front:       frontVO,
-		Back:        backVO,
-		CreatedAt:   now,
-		UpdatedAt:   now,
 	}
 	if err := u.cardRepo.Create(ctx, card); err != nil {
 		if errors.Is(err, repository.ErrCardDuplicateFront) {

--- a/backend/internal/usecase/card_import.go
+++ b/backend/internal/usecase/card_import.go
@@ -253,13 +253,18 @@ func (u *cardImportUsecase) Import(ctx context.Context, input ImportCardsInput) 
 	now := time.Now().UTC()
 	cards := make([]*domain.Card, 0, len(words))
 	for _, w := range words {
-		c := &domain.Card{
-			CardgroupID: input.CardgroupID,
-			Front:       domain.CardText(w.Front),
-			Back:        domain.CardText(w.Back),
-			CreatedAt:   now,
-			UpdatedAt:   now,
+		// Build through the enforcing constructor so an over-length front/back
+		// cannot reach the repository. textdic guarantees both fields are
+		// present, so the realistic failure is the length cap; surface it as a
+		// typed validation error (the DB CHECK would otherwise abort the tx with
+		// an opaque constraint violation).
+		c, err := domain.NewCard(input.CardgroupID, w.Front, w.Back, 0)
+		if err != nil {
+			return ImportCardsOutput{}, translateCardErr(err)
 		}
+		// NewCard stamps per-card timestamps; pin the whole batch to one now.
+		c.CreatedAt = now
+		c.UpdatedAt = now
 		cards = append(cards, c)
 	}
 

--- a/backend/internal/usecase/card_import_test.go
+++ b/backend/internal/usecase/card_import_test.go
@@ -585,6 +585,49 @@ func TestCardImportUsecase_BadRowsSurfaceAsErrors(t *testing.T) {
 	}
 }
 
+// TestCardImportUsecase_OverLengthFrontAbortsAsValidationError covers the
+// construction-time validation now enforced by domain.NewCard: a row whose
+// front exceeds CardTextMax parses cleanly through textdic but cannot be built
+// into a Card. The import aborts with a typed BAD_USER_INPUT validation error
+// (field "front") BEFORE the repository is touched — the all-or-nothing
+// semantics the DB CHECK constraint previously enforced via an opaque tx abort.
+func TestCardImportUsecase_OverLengthFrontAbortsAsValidationError(t *testing.T) {
+	t.Parallel()
+
+	// One valid row followed by a row whose front is one grapheme over the cap.
+	// The 501-char ASCII front lexes as a single WORD token.
+	var b strings.Builder
+	b.WriteString("apple ")
+	b.WriteString(uniqueBack(1))
+	b.WriteString("\n")
+	b.WriteString(strings.Repeat("a", domain.CardTextMax+1))
+	b.WriteString(" ")
+	b.WriteString(uniqueBack(2))
+	b.WriteString("\n")
+	payload := base64.StdEncoding.EncodeToString([]byte(b.String()))
+
+	repo := &mockDictCardRepo{}
+	tx, calls := dictTxRunner()
+	uc := NewCardImportUsecaseWithTx(ownedCardImportCardgroupRepo("user-1"), repo, tx, newTestLogger())
+
+	out, err := uc.Import(authedCtx("user-1"), ImportCardsInput{
+		CardgroupID: "cg-target",
+		Payload:     payload,
+	})
+
+	assertValidationError(t, err, "front", "")
+	if out.Inserted != 0 || out.Updated != 0 {
+		t.Fatalf("expected zero-valued output on abort, got %+v", out)
+	}
+	// All-or-nothing: the repository and tx runner must never be reached.
+	if repo.upsertCalls != 0 {
+		t.Fatalf("expected 0 UpsertManyTx calls on abort, got %d", repo.upsertCalls)
+	}
+	if *calls != 0 {
+		t.Fatalf("expected 0 tx invocations on abort, got %d", *calls)
+	}
+}
+
 // TestCardImportUsecase_ValidSkipValidMixedPayload covers the GraphQL
 // importCards path with a payload that interleaves a valid row, a lone
 // front (skip), and another valid row. The two valid rows must be persisted

--- a/backend/internal/usecase/master_deck.go
+++ b/backend/internal/usecase/master_deck.go
@@ -260,19 +260,16 @@ func (u *masterDeckUsecase) copyMasterToUserTx(ctx context.Context, tx *gorm.DB,
 
 	userCards := make([]*domain.Card, 0, len(cards))
 	for _, mc := range cards {
-		cardID, err := domain.NewID()
+		// The source master cards are already valid; the constructor re-parses
+		// the text (idempotent) and generates the new user-card ID.
+		card, err := domain.NewCard(newCGID, mc.Front.String(), mc.Back.String(), mc.Position)
 		if err != nil {
-			return nil, eris.Wrap(err, "new card id")
+			return nil, eris.Wrap(err, "new card from master")
 		}
-		userCards = append(userCards, &domain.Card{
-			ID:          cardID,
-			CardgroupID: newCGID,
-			Front:       mc.Front,
-			Back:        mc.Back,
-			Position:    mc.Position,
-			CreatedAt:   now,
-			UpdatedAt:   now,
-		})
+		// Pin the copied batch to the cardgroup's creation timestamp.
+		card.CreatedAt = now
+		card.UpdatedAt = now
+		userCards = append(userCards, card)
 	}
 
 	if _, err := u.userCard.UpsertManyTx(ctx, tx, userCards); err != nil {

--- a/backend/internal/usecase/notion_sync.go
+++ b/backend/internal/usecase/notion_sync.go
@@ -330,51 +330,57 @@ func dedupeParsedRows(rows []ParsedRow, errs []CardImportError) ([]ParsedRow, []
 
 // masterCardsFromParsedRows builds master cards from deduped, document-order
 // parsed rows. Position is the index in the deduped slice (0..n-1) so the
-// catalog reflects the original Notion document position. Each row's Front and
-// Back are validated and normalized through domain.ParseCardText; a row whose
-// front or back is empty/whitespace-only or exceeds CardTextMax graphemes is
-// skipped (not persisted) and a structured warn is emitted so the rest of the
-// sync still imports the valid rows. See
-// docs/backend/error-wrapping/log-structured-event-when-batch-item-fails.md.
+// catalog reflects the original Notion document position. Each row is built
+// through domain.NewMasterCard, which validates and normalizes Front and Back;
+// a row whose constructor fails (empty/whitespace-only or over-CardTextMax
+// front/back, or an ID-generation failure) is skipped (not persisted) and a
+// structured warn is emitted so the rest of the sync still imports the valid
+// rows. See docs/backend/error-wrapping/log-structured-event-when-batch-item-fails.md.
 func (u *MasterNotionSyncUsecase) masterCardsFromParsedRows(
 	ctx context.Context, masterCardgroupID string, rows []ParsedRow,
 ) []*domain.MasterCard {
 	now := time.Now().UTC()
 	cards := make([]*domain.MasterCard, 0, len(rows))
 	for i, row := range rows {
-		front, err := domain.ParseCardText(row.Front, domain.ErrCardFrontRequired, domain.ErrCardFrontTooLong)
+		card, err := domain.NewMasterCard(masterCardgroupID, row.Front, row.Back, i)
 		if err != nil {
-			u.warnSkippedMasterRow(ctx, masterCardgroupID, i, "front", err)
+			u.warnSkippedMasterRow(ctx, masterCardgroupID, i, err)
 			continue
 		}
-		back, err := domain.ParseCardText(row.Back, domain.ErrCardBackRequired, domain.ErrCardBackTooLong)
-		if err != nil {
-			u.warnSkippedMasterRow(ctx, masterCardgroupID, i, "back", err)
-			continue
-		}
-		cards = append(cards, &domain.MasterCard{
-			MasterCardgroupID: masterCardgroupID,
-			Front:             front,
-			Back:              back,
-			Position:          i,
-			CreatedAt:         now,
-			UpdatedAt:         now,
-		})
+		// NewMasterCard stamps per-card timestamps; pin the whole sync batch to
+		// one now.
+		card.CreatedAt = now
+		card.UpdatedAt = now
+		cards = append(cards, card)
 	}
 	return cards
 }
 
-// warnSkippedMasterRow emits a structured warn for a master-card row that failed
-// CardText validation and was dropped from the import.
+// warnSkippedMasterRow emits a structured warn for a master-card row whose
+// constructor (domain.NewMasterCard) failed and was dropped from the import.
 func (u *MasterNotionSyncUsecase) warnSkippedMasterRow(
-	ctx context.Context, masterCardgroupID string, position int, field string, reason error,
+	ctx context.Context, masterCardgroupID string, position int, reason error,
 ) {
 	u.logger.WarnContext(ctx, "notion sync: skipping invalid master card row",
 		"cardgroupID", masterCardgroupID,
 		"position", position,
-		"field", field,
+		"field", masterRowErrorField(reason),
 		"reason", reason.Error(),
 	)
+}
+
+// masterRowErrorField maps a NewMasterCard error to the field label used in the
+// skip warning. Front and back CardText sentinels resolve to their field; any
+// other error (e.g. an ID-generation failure) is attributed to "id".
+func masterRowErrorField(err error) string {
+	switch {
+	case errors.Is(err, domain.ErrCardFrontRequired), errors.Is(err, domain.ErrCardFrontTooLong):
+		return "front"
+	case errors.Is(err, domain.ErrCardBackRequired), errors.Is(err, domain.ErrCardBackTooLong):
+		return "back"
+	default:
+		return "id"
+	}
 }
 
 func frontsToDelete(current []string, notionFronts map[string]struct{}) []string {

--- a/docs/backend/ddd-patterns/boundary-gate-replaces-domain-recheck.md
+++ b/docs/backend/ddd-patterns/boundary-gate-replaces-domain-recheck.md
@@ -4,10 +4,10 @@
 
 ## Why
 
-A domain aggregate's `Validate()` method is the temptation to centralise every
-invariant in one place: "validate everything every time, then it is impossible
-to forget". The problem with double-checking an invariant that the usecase
-boundary already enforces is twofold:
+A domain aggregate's enforced constructor (e.g. `NewCard`) is the temptation to
+centralise every invariant in one place: "validate everything every time, then
+it is impossible to forget". The problem with double-checking an invariant that
+the usecase boundary already enforces is twofold:
 
 - **Dead code.** If the only callers of the aggregate constructor flow through
   the boundary gate, the domain-side check never fires for any non-malicious
@@ -58,7 +58,7 @@ An empty `CardgroupID` reaches `repo.FindByID`, which returns `ErrNotFound`,
 which the gate translates into `BAD_USER_INPUT(field=cardgroupId)`. The
 GraphQL caller sees a typed validation error before any `Card` is constructed.
 
-A domain-side `if c.CardgroupID == ""` check inside `Card.Validate()` would
+A domain-side `if c.CardgroupID == ""` check inside `NewCard` would
 have been unreachable for every production caller. The check was removed
 along with its `ErrCardCardgroupIDRequired` sentinel; the aggregate's
 docstring documents the boundary contract instead:
@@ -69,19 +69,20 @@ docstring documents the boundary contract instead:
 //
 // CardgroupID ownership is enforced at the usecase boundary via
 // authorizeCardgroupOrBadInput before a Card is constructed; the domain
-// aggregate therefore does not re-check CardgroupID presence in Validate.
+// aggregate therefore does not re-check CardgroupID presence in NewCard.
 type Card struct { ... }
 ```
 
-## The other Card.Validate fields stayed
+## Front and Back stay enforced in NewCard
 
-`Card.Validate()` retains `ParseCardText` calls for `Front` and `Back`. Those
-fields are not gated at the usecase boundary; `ParseCardText` is the
-single source of truth for the grapheme-bound + non-empty invariants. The
-aggregate's `Validate()` method is still load-bearing for any caller that
-constructs a `Card` outside the usecase's `Create`/`Update` paths (today: no
-such callers in production, but the contract is the right shape for future
-seed/migration paths).
+`NewCard` (and its `MasterCard` sibling `NewMasterCard`) validates `Front` and
+`Back` through `ParseCardText`. Those fields are not gated at the usecase
+boundary; `ParseCardText` is the single source of truth for the grapheme-bound +
+non-empty invariants. The enforced constructor is the single construction path
+for a new `Card` — an invalid `Front`/`Back` cannot produce a constructed
+aggregate — so the invariant is enforced exactly once, in the constructor,
+rather than re-checked by a separate `Validate()` method (which had zero
+production callers and was removed).
 
 The pattern is: each invariant has a single enforcement site. If the
 boundary enforces it, the domain skips it. If the domain owns it (because
@@ -99,6 +100,6 @@ no boundary gate has it), the domain enforces it.
 
 ## Reference
 
-- `backend/internal/domain/card.go` — `Card.Validate` minus the `CardgroupID` check; docstring notes the boundary contract.
+- `backend/internal/domain/card.go` — `NewCard` enforces `Front`/`Back` but not `CardgroupID` presence; docstring notes the boundary contract.
 - `backend/internal/usecase/ownership.go` — `authorizeCardgroupOrBadInput`, the gate that owns the invariant.
 - `backend/internal/usecase/card.go` — `Create` / `Update` call the gate before constructing the aggregate.

--- a/docs/backend/ddd-patterns/caller-supplied-sentinels-in-parser.md
+++ b/docs/backend/ddd-patterns/caller-supplied-sentinels-in-parser.md
@@ -37,21 +37,21 @@ func ParseCardText(s string, requiredErr, tooLongErr error) (CardText, error) {
 }
 ```
 
-The VO stays field-agnostic. The aggregate (`Card.Validate`) picks the right
-sentinel for each field:
+The VO stays field-agnostic. The aggregate constructor (`NewCard`) picks the
+right sentinel for each field:
 
 ```go
 // domain/card.go
 
-func (c *Card) Validate() error {
+func NewCard(cardgroupID, front, back string, position int) (*Card, error) {
     // ...
-    if _, err := ParseCardText(c.Front, ErrCardFrontRequired, ErrCardFrontTooLong); err != nil {
-        return err
+    if _, err := ParseCardText(front, ErrCardFrontRequired, ErrCardFrontTooLong); err != nil {
+        return nil, err
     }
-    if _, err := ParseCardText(c.Back, ErrCardBackRequired, ErrCardBackTooLong); err != nil {
-        return err
+    if _, err := ParseCardText(back, ErrCardBackRequired, ErrCardBackTooLong); err != nil {
+        return nil, err
     }
-    return nil
+    // ... generate ID, stamp timestamps, return &Card{...}, nil
 }
 ```
 

--- a/docs/backend/ddd-patterns/helpers-introduced-but-not-wired-must-be-deleted.md
+++ b/docs/backend/ddd-patterns/helpers-introduced-but-not-wired-must-be-deleted.md
@@ -87,11 +87,15 @@ domain behaviour methods alike — has zero production callers by construction.
 Deleting them would mean deleting the deliverable.
 
 The correct resolution for spec'd domain behaviour methods (e.g.
-`MasterCardgroupStatus.IsValid()`, `MasterCardgroup.IsPublished()`,
-`MasterCard.Validate()` in the master-catalog aggregates) is to **wire them by a
-domain unit test**, consistent with how `Rating.IsValid()` and `CEFRLevel.IsValid()` are
-pinned in this codebase. A unit test is a caller: it keeps the method greppably
-reachable from a tested code path and prevents dead-surface rot.
+`MasterCardgroupStatus.IsValid()` and `MasterCardgroup.IsPublished()` in the
+master-catalog aggregates) is to **wire them by a domain unit test**, consistent
+with how `Rating.IsValid()` and `CEFRLevel.IsValid()` are pinned in this
+codebase. A unit test is a caller: it keeps the method greppably reachable from a
+tested code path and prevents dead-surface rot. (A spec'd method can later
+graduate to a production caller — `MasterCardgroup.IsPublished()` is now also
+wired into `Publish()` — or, if a constructor subsumes it, be deleted outright,
+as `Card.Validate()` / `MasterCard.Validate()` were once `NewCard` /
+`NewMasterCard` took over construction.)
 
 The rule still bites for a **single speculative helper** added inside an
 otherwise-wired PR — the `ResolvePageSize` case from issue #181 is the canonical


### PR DESCRIPTION
## Summary

Brings the `Card` / `MasterCard` / `MasterCardgroup` aggregates up to the `UserCardFSRS` standard: each aggregate now owns its invariants (an enforced constructor) and owns its state transitions (behaviour methods), instead of the usecase/repository owning them. **Refactor — no user-visible behaviour change on the success paths;** the only observable difference is that an over-length card import now surfaces a typed `BAD_USER_INPUT` instead of an opaque DB-constraint tx abort.

Closes #441.

## Background / Motivation

- `Card.Validate()` and `MasterCard.Validate()` had **zero** production callers — validation lived in the usecase (`domain.ParseCardText` + a raw `&domain.Card{}` literal), so the aggregate could not guarantee its own consistency (audit 2a).
- The publish state machine + the version-bump-on-publish-only rule lived as **two divergent `Updates(map)`** statements in the repository, and `MasterCardgroup.IsPublished()` was unused (audit 2b).

## Changes

### A — `NewCard` / `NewMasterCard` enforced constructors (audit 2a)

- Added `NewCard(cardgroupID, front, back string, position int) (*Card, error)` and `NewMasterCard(...)` in `domain/card.go` / `domain/master_card.go`: validate Front/Back via `ParseCardText`, generate the UUID v7 id, stamp `CreatedAt`/`UpdatedAt` (caller may override before persist). Text sentinels are returned raw so callers translate them via `translateCardErr`; an id-generation failure is wrapped (`card: new id` / `master card: new id`).
- Rewired the 4 usecase construction sites: `usecase/card.go` (Create), `usecase/card_import.go`, `usecase/master_deck.go`, `usecase/notion_sync.go`.
- Deleted the dead `Card.Validate()` / `MasterCard.Validate()` and their tests. Repository hydration sites (`repository/card.go`, `card_due.go`, `master_card.go`) stay struct-literal — they reconstitute already-valid persisted rows and must NOT go through the validating constructor.

### A — behaviour decisions (per issue)

- **`Card.UpdateFront` / `UpdateBack` kept** as defense-in-depth. They are NOT dead: `CardUsecase.Update` calls them after parsing the patch via `ParseCardText`. The constructor seals the Create path; the mutators seal the Update path.
- **`card_import` aborts on a construction error** via `translateCardErr` (all-or-nothing, matching the prior DB `CHECK(char_length(trim(front)) BETWEEN 1 AND 500)` tx-abort, but as a typed `BAD_USER_INPUT(field=front/back)` raised before the repository is touched).
- **`notion_sync` keeps skip+warn** (#439 task 1): a constructor error skips the row and emits a structured warn, never aborting the sync. The warn's `field` attribute is derived from the returned sentinel (`masterRowErrorField`).
- **Batch sites pin the batch to one `now`**: `card_import` / `master_deck` / `notion_sync` override the constructor's per-row timestamp with the shared batch timestamp.

### B — `MasterCardgroup.Publish()` / `Unpublish()` (audit 2b)

- `Publish()` is **idempotent**: it no-ops when already published (wiring the previously-unused `IsPublished()`), otherwise sets `Status = published` and `Version++`. The version bumps ONLY on the draft → published transition.
- `Unpublish()` sets `Status = draft` and **never touches `Version`** — the asymmetry is the core rule, now encoded once in the aggregate.
- Repository `Publish`/`Unpublish` are consolidated into one `applyStatusTransition` helper: load the row **`FOR UPDATE`** inside a transaction → apply the aggregate method → save status+version. The row lock serializes concurrent publishes; combined with the idempotency guard the version bumps **exactly once** (no lost update, no double bump), replacing the two divergent `Updates(map)` statements without regressing atomicity.

### Tests & docs

- New: domain `TestNewCard` / `TestNewMasterCard` (+ id-failure seam), `TestMasterCardgroupPublish` / `Unpublish` (incl. idempotent re-publish); usecase `TestCardImportUsecase_OverLengthFrontAbortsAsValidationError`; repository `TestMasterCardgroupRepository_Publish_ConcurrentBumpsVersionExactlyOnce` (tx-level, proves the version bumps once under contention).
- Updated stale `Card.Validate()` / `MasterCard.Validate()` references in 3 DDD-pattern docs to `NewCard` / `NewMasterCard`.

## Verification

- `grep -rn '\.Validate()' backend/internal/usecase` returns no `Card` / `MasterCard` hits.
- `go tool go-arch-lint check --project-path .` reports no warnings (layer graph unchanged).

## Test plan

- [x] `go build ./... && go vet ./...` — clean.
- [x] `go test -race ./...` — 1704 passed (25 packages, incl. testcontainers integration).
- [x] `go tool go-arch-lint check --project-path .` — OK.
- [x] Concurrent-publish tx test proves version bumps exactly once (no double / no lost update).
- [x] CJK + PR-order language-policy greps clean on the diff.

## Out of scope

- `assemblePage[T]` extraction + `master_cardgroup.go` file split — Wave 3.
- ID value-object typing — #438.
