### PR TITLE
refactor(admin): extract mutation/cache hooks from masters + users (SRP)

### DIFF
--- a/frontend/src/app/admin/masters/admin-masters-client.test.tsx
+++ b/frontend/src/app/admin/masters/admin-masters-client.test.tsx
@@ -385,8 +385,10 @@ describe("AdminMastersClient", () => {
     // MasterCardgroupEmptyError); Apollo v4 does not consistently roll back optimistic
     // writes on typed GraphQL errors, so neither toggle mutation may carry one.
     // See .claude/rules/pagination.md "Drop optimisticResponse ...".
+    // After the useMasterMutations refactor the runPublish/runUnpublish calls live in
+    // the hook file, not in the client — check there so the guard remains meaningful.
     const source = readFileSync(
-      join(process.cwd(), "src/app/admin/masters/admin-masters-client.tsx"),
+      join(process.cwd(), "src/app/admin/masters/use-master-mutations.ts"),
       "utf8",
     );
     for (const call of ["runPublish({", "runUnpublish({"]) {

--- a/frontend/src/app/admin/masters/admin-masters-client.tsx
+++ b/frontend/src/app/admin/masters/admin-masters-client.tsx
@@ -1,8 +1,6 @@
 "use client";
 
 import { NetworkStatus } from "@apollo/client";
-import { useApolloClient, useMutation } from "@apollo/client/react";
-import type { Reference } from "@apollo/client/utilities";
 import { Plus } from "lucide-react";
 import Link from "next/link";
 import { useTranslations } from "next-intl";
@@ -16,32 +14,18 @@ import type {
   AdminMastersQuery as AdminMastersQueryResult,
   AdminMastersQueryVariables,
 } from "@/generated/graphql";
-import { classifyQueryError, getBackendErrorBanner, mutationAuthBanner } from "@/lib/apollo/errors";
-import { liftGraphQLCodes } from "@/lib/apollo/graphql-errors";
+import { classifyQueryError, getBackendErrorBanner } from "@/lib/apollo/errors";
 import { useConnectionPagination } from "@/lib/pagination/use-connection-pagination";
 import { useSheetSearchParam } from "@/lib/url/use-sheet-search-param";
 import { AdminMasterForm, type MasterFormValues } from "./admin-master-form";
 import { AdminMasterRow } from "./admin-master-row";
 import { AdminMastersSkeleton } from "./admin-masters-skeleton";
-import {
-  ADMIN_MASTERS_PAGE_SIZE,
-  AdminCreateMasterMutation,
-  AdminDeleteMasterMutation,
-  AdminMastersQuery,
-  AdminPublishMasterMutation,
-  AdminUnpublishMasterMutation,
-  AdminUpdateMasterMutation,
-} from "./queries";
+import { ADMIN_MASTERS_BASE_VARS, AdminMastersQuery } from "./queries";
+import { type AuthKind, useMasterMutations } from "./use-master-mutations";
 
 type Connection = AdminMastersQueryResult["adminMasters"];
 type Edge = Connection["edges"][number];
 type PageInfo = Connection["pageInfo"];
-
-const BASE_VARS = {
-  first: ADMIN_MASTERS_PAGE_SIZE,
-  orderBy: "SORT_ORDER" as const,
-  orderDirection: "ASC" as const,
-};
 
 const EMPTY_PAGE_INFO: PageInfo = {
   __typename: "PageInfo",
@@ -95,11 +79,11 @@ export function AdminMastersClient() {
     return () => clearTimeout(timer);
   }, [searchInput]);
 
-  // The cache key is BASE_VARS + the active search; the create handler reads and
+  // The cache key is ADMIN_MASTERS_BASE_VARS + the active search; the create handler reads and
   // writes the search=null variant. Memoize on searchQuery so the hook's
   // useQuery does not re-subscribe on unrelated re-renders.
   const queryVariables = useMemo<AdminMastersQueryVariables>(
-    () => ({ ...BASE_VARS, search: searchQuery }),
+    () => ({ ...ADMIN_MASTERS_BASE_VARS, search: searchQuery }),
     [searchQuery],
   );
 
@@ -119,7 +103,7 @@ export function AdminMastersClient() {
     variables: queryVariables,
     searchQuery,
     selectConnection: (data) => data?.adminMasters,
-    buildFetchMoreVariables: (after, search) => ({ ...BASE_VARS, after, search }),
+    buildFetchMoreVariables: (after, search) => ({ ...ADMIN_MASTERS_BASE_VARS, after, search }),
     mergeConnection: mergeMastersConnection,
     initial: MASTERS_INITIAL,
     resolveFetchMoreError: (err) => getBackendErrorBanner(err) ?? t("fetchMoreFailed"),
@@ -130,252 +114,128 @@ export function AdminMastersClient() {
   const queryErrorKind = classifyQueryError(queryError);
   const queryBannerError = queryErrorKind?.kind === "banner" ? queryErrorKind.message : undefined;
 
-  const apolloClient = useApolloClient();
-  const [runCreate, { loading: creating, reset: resetCreate }] =
-    useMutation(AdminCreateMasterMutation);
-  const [runUpdate, { loading: updating, reset: resetUpdate }] =
-    useMutation(AdminUpdateMasterMutation);
-  const [runDelete] = useMutation(AdminDeleteMasterMutation);
-  const [runPublish] = useMutation(AdminPublishMasterMutation);
-  const [runUnpublish] = useMutation(AdminUnpublishMasterMutation);
+  const {
+    createMaster,
+    updateMaster,
+    deleteMaster,
+    publishMaster,
+    unpublishMaster,
+    creating,
+    updating,
+    resetCreate,
+    resetUpdate,
+  } = useMasterMutations();
 
   const editId = sheet.state.mode === "edit" ? sheet.state.id : null;
   // Resolve the edit target by node.id, never by `cursor`: the backend emits an
-  // opaque encoded cursor ("v1:..."), so matching against the raw id always misses
-  // and renders "Master not found." for every master.
+  // opaque encoded cursor ("v1:..."), so matching against the raw id always misses.
   const editEdge = editId ? edges.find((e) => e.node.id === editId) : undefined;
 
-  // Create: prepend the new edge to the base (search=null) connection.
+  const authToast = useCallback(
+    (kind: AuthKind) => {
+      toast.error(kind === "forbidden" ? t("forbidden") : t("unauthenticated"));
+    },
+    [t],
+  );
+
   const handleCreate = useCallback(
     async (values: MasterFormValues) => {
       setCreateValidationError(null);
-      const result = await runCreate({ variables: { input: values } }).catch((err) => {
-        const codes = liftGraphQLCodes(err);
-        console.warn("[admin-masters] create rejected", {
-          name: err instanceof Error ? err.name : "unknown",
-          codes,
-        });
-        toast.error(
-          mutationAuthBanner(err, {
-            forbidden: t("forbidden"),
-            unauthenticated: t("unauthenticated"),
-            fallback: t("unexpectedError"),
-          }),
-        );
-        return null;
-      });
-      if (!result) return;
-      const payload = result.data?.adminCreateMasterCardgroup;
-      const typename = payload?.__typename ?? "null";
-      if (payload?.__typename === "InputValidationError") {
-        setCreateValidationError({ field: payload.field, message: payload.message });
-        return;
+      const outcome = await createMaster(values);
+      switch (outcome.status) {
+        case "validation":
+          setCreateValidationError({ field: outcome.field, message: outcome.message });
+          return;
+        case "success":
+          toast.success(t("createSuccess"));
+          resetCreate();
+          setCreateDirty(false);
+          sheet.close({ refresh: true });
+          return;
+        case "auth":
+          authToast(outcome.kind);
+          return;
+        default:
+          toast.error(t("unexpectedError"));
       }
-      if (payload?.__typename === "CreateMasterCardgroupSuccess") {
-        const created = payload.master;
-        const vars = { ...BASE_VARS, search: null };
-        const existing = apolloClient.cache.readQuery<AdminMastersQueryResult>({
-          query: AdminMastersQuery,
-          variables: vars,
-        });
-        const createdEdge = {
-          __typename: "MasterCatalogEdge" as const,
-          cursor: created.id,
-          node: created,
-        };
-        if (existing?.adminMasters) {
-          apolloClient.cache.writeQuery<AdminMastersQueryResult>({
-            query: AdminMastersQuery,
-            variables: vars,
-            data: {
-              adminMasters: {
-                ...existing.adminMasters,
-                edges: [createdEdge, ...existing.adminMasters.edges],
-                totalCount: existing.adminMasters.totalCount + 1,
-              },
-            },
-          });
-        } else {
-          apolloClient.cache.writeQuery<AdminMastersQueryResult>({
-            query: AdminMastersQuery,
-            variables: vars,
-            data: {
-              adminMasters: {
-                __typename: "MasterCatalogConnection",
-                edges: [createdEdge],
-                pageInfo: {
-                  __typename: "PageInfo",
-                  hasNextPage: false,
-                  hasPreviousPage: false,
-                  startCursor: created.id,
-                  endCursor: created.id,
-                },
-                totalCount: 1,
-              },
-            },
-          });
-        }
-        toast.success(t("createSuccess"));
-        resetCreate();
-        setCreateDirty(false);
-        sheet.close({ refresh: true });
-        return;
-      }
-      // Neither known variant matched (null or an unknown union member) — never fail silently.
-      console.warn("[admin-masters] unexpected createMaster payload", { typename });
-      toast.error(t("unexpectedError"));
     },
-    [apolloClient, runCreate, resetCreate, sheet, t],
+    [createMaster, resetCreate, sheet, t, authToast],
   );
 
-  // Update: normalization by id propagates the new fields; no manual cache write.
   const handleUpdate = useCallback(
     async (values: MasterFormValues) => {
       if (!editId) return;
       setEditValidationError(null);
-      const result = await runUpdate({ variables: { id: editId, input: values } }).catch((err) => {
-        const codes = liftGraphQLCodes(err);
-        console.warn("[admin-masters] update rejected", {
-          masterId: editId,
-          name: err instanceof Error ? err.name : "unknown",
-          codes,
-        });
-        toast.error(
-          mutationAuthBanner(err, {
-            forbidden: t("forbidden"),
-            unauthenticated: t("unauthenticated"),
-            fallback: t("unexpectedError"),
-          }),
-        );
-        return null;
-      });
-      if (!result) return;
-      const payload = result.data?.adminUpdateMasterCardgroup;
-      const typename = payload?.__typename ?? "null";
-      if (payload?.__typename === "InputValidationError") {
-        setEditValidationError({ field: payload.field, message: payload.message });
-        return;
+      const outcome = await updateMaster(editId, values);
+      switch (outcome.status) {
+        case "validation":
+          setEditValidationError({ field: outcome.field, message: outcome.message });
+          return;
+        case "success":
+          toast.success(t("updateSuccess"));
+          resetUpdate();
+          sheet.close({ refresh: true });
+          return;
+        case "auth":
+          authToast(outcome.kind);
+          return;
+        default:
+          toast.error(t("unexpectedError"));
       }
-      if (payload?.__typename === "UpdateMasterCardgroupSuccess") {
-        toast.success(t("updateSuccess"));
-        resetUpdate();
-        sheet.close({ refresh: true });
-        return;
-      }
-      console.warn("[admin-masters] unexpected updateMaster payload", { typename });
-      toast.error(t("unexpectedError"));
     },
-    [editId, runUpdate, resetUpdate, sheet, t],
+    [editId, updateMaster, resetUpdate, sheet, t, authToast],
   );
 
-  // Delete: filter the edge from every cached adminMasters variant, decrement
-  // totalCount, evict the entity. Catches its own errors (toast) so the form's
-  // confirm handler never sees a rejection.
   const handleDelete = useCallback(
     async (id: string) => {
-      try {
-        const result = await runDelete({ variables: { id } });
-        if (!result.data?.adminDeleteMasterCardgroup) {
-          throw new Error("adminDeleteMasterCardgroup returned false");
-        }
-        apolloClient.cache.modify({
-          fields: {
-            adminMasters(existing, { readField }) {
-              const conn = existing as {
-                edges?: ReadonlyArray<{ node: Reference }>;
-                totalCount?: number;
-              };
-              if (!conn.edges) return existing;
-              // Filter by the normalized node's id, not by `cursor`: in the cache the
-              // edge cursor is the opaque encoded value ("v1:..."), so `cursor !== id`
-              // never matches and the deleted edge would linger in the connection.
-              const next = conn.edges.filter((edge) => readField<string>("id", edge.node) !== id);
-              if (next.length === conn.edges.length) return existing;
-              return { ...conn, edges: next, totalCount: Math.max(0, (conn.totalCount ?? 0) - 1) };
-            },
-          },
-        });
-        const cacheId = apolloClient.cache.identify({ __typename: "MasterCardgroup", id });
-        if (cacheId) {
-          apolloClient.cache.evict({ id: cacheId });
-          apolloClient.cache.gc();
-        }
-        toast.success(t("deleteMasterSuccess"));
-        sheet.close();
-      } catch (err) {
-        const codes = liftGraphQLCodes(err);
-        console.warn("[admin-masters] delete rejected", {
-          masterId: id,
-          name: err instanceof Error ? err.name : "unknown",
-          codes,
-        });
-        toast.error(
-          mutationAuthBanner(err, {
-            forbidden: t("forbidden"),
-            unauthenticated: t("unauthenticated"),
-            fallback: t("deleteMasterFailed"),
-          }),
-        );
+      const outcome = await deleteMaster(id);
+      switch (outcome.status) {
+        case "success":
+          toast.success(t("deleteMasterSuccess"));
+          sheet.close();
+          return;
+        case "auth":
+          authToast(outcome.kind);
+          return;
+        default:
+          toast.error(t("deleteMasterFailed"));
       }
     },
-    [apolloClient, runDelete, sheet, t],
+    [deleteMaster, sheet, t, authToast],
   );
 
-  // Publish / unpublish from the edit panel. Both mutations return the updated
-  // node keyed by `id`, so Apollo normalization propagates the new status to the
-  // list row badge and the form's `master.status` — no manual cache write needed.
-  // Catches its own errors (toast) so the form's click handler never sees a
-  // rejection beyond logging.
   const handlePublishToggle = useCallback(
     async (id: string, currentlyPublished: boolean) => {
-      try {
-        if (currentlyPublished) {
-          const result = await runUnpublish({ variables: { id } });
-          if (!result.data?.adminUnpublishMasterCardgroup) {
-            console.warn("[admin-masters] unpublish returned null payload", { masterId: id });
-            toast.error(t("unexpectedError"));
+      if (currentlyPublished) {
+        const outcome = await unpublishMaster(id);
+        switch (outcome.status) {
+          case "success":
+            toast.success(t("unpublishSuccess"));
             return;
-          }
-          toast.success(t("unpublishSuccess"));
-          return;
+          case "auth":
+            authToast(outcome.kind);
+            return;
+          default:
+            toast.error(t("unexpectedError"));
         }
-        const result = await runPublish({ variables: { id } });
-        const payload = result.data?.adminPublishMasterCardgroup;
-        // Capture the typename before narrowing exhausts the union type below.
-        const typename = payload?.__typename ?? "null";
-        if (payload?.__typename === "PublishMasterCardgroupSuccess") {
+        return;
+      }
+      const outcome = await publishMaster(id);
+      switch (outcome.status) {
+        case "success":
           toast.success(t("publishSuccess"));
           return;
-        }
-        if (payload?.__typename === "MasterCardgroupEmptyError") {
-          // Backstop: the form disables Publish for 0-card drafts, but cardCount
-          // may be stale. Surface the backend's empty-deck rejection.
+        case "empty":
           toast.error(t("publishEmptyToast"));
           return;
-        }
-        // Unexpected payload shape (null or unknown variant) — never fail silently.
-        console.warn("[admin-masters] publish returned unexpected payload", {
-          masterId: id,
-          typename,
-        });
-        toast.error(t("unexpectedError"));
-      } catch (err) {
-        const codes = liftGraphQLCodes(err);
-        console.warn("[admin-masters] publish toggle failed", {
-          masterId: id,
-          name: err instanceof Error ? err.name : "unknown",
-          codes,
-        });
-        toast.error(
-          mutationAuthBanner(err, {
-            forbidden: t("forbidden"),
-            unauthenticated: t("unauthenticated"),
-            fallback: t("unexpectedError"),
-          }),
-        );
+        case "auth":
+          authToast(outcome.kind);
+          return;
+        default:
+          toast.error(t("unexpectedError"));
       }
     },
-    [runPublish, runUnpublish, t],
+    [publishMaster, unpublishMaster, t, authToast],
   );
 
   const initialLoading = networkStatus === NetworkStatus.loading && edges.length === 0;

--- a/frontend/src/app/admin/masters/queries.ts
+++ b/frontend/src/app/admin/masters/queries.ts
@@ -3,6 +3,18 @@ import { graphql } from "@/generated";
 /** Default page size for the admin masters connection. Keep in sync with cache reads. */
 export const ADMIN_MASTERS_PAGE_SIZE = 20;
 
+/**
+ * Base variables for the admin masters connection (everything except `search`).
+ * Single source of truth shared by the client's useConnectionPagination query and
+ * the create-cache write in useMasterMutations — they MUST match exactly or the
+ * prepended edge is written under a different cache key and never appears.
+ */
+export const ADMIN_MASTERS_BASE_VARS = {
+  first: ADMIN_MASTERS_PAGE_SIZE,
+  orderBy: "SORT_ORDER" as const,
+  orderDirection: "ASC" as const,
+};
+
 export const AdminMastersQuery = graphql(`
   query AdminMasters(
     $first: Int

--- a/frontend/src/app/admin/masters/use-master-mutations.test.tsx
+++ b/frontend/src/app/admin/masters/use-master-mutations.test.tsx
@@ -329,6 +329,8 @@ describe("useMasterMutations.deleteMaster", () => {
     const conn = readConnection(cache);
     expect(conn?.adminMasters.totalCount).toBe(1);
     expect(conn?.adminMasters.edges.map((e) => e.node.id)).toEqual(["m-2"]);
+    // The deleted entity is evicted + gc'd from the normalized cache.
+    expect(cache.extract()["MasterCardgroup:m-1"]).toBeUndefined();
   });
 
   it("returns rejected when the mutation returns false", async () => {

--- a/frontend/src/app/admin/masters/use-master-mutations.test.tsx
+++ b/frontend/src/app/admin/masters/use-master-mutations.test.tsx
@@ -1,0 +1,439 @@
+// @vitest-environment jsdom
+import { InMemoryCache } from "@apollo/client";
+import type { MockedResponse } from "@apollo/client/testing";
+import { MockedProvider } from "@apollo/client/testing/react";
+import { act, renderHook } from "@testing-library/react";
+import { GraphQLError } from "graphql";
+import { createElement, type ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type {
+  AdminMastersQuery as AdminMastersQueryResult,
+  MasterCardgroupStatus,
+} from "@/generated/graphql";
+import type { MasterFormValues } from "./admin-master-form";
+import {
+  ADMIN_MASTERS_BASE_VARS,
+  AdminCreateMasterMutation,
+  AdminDeleteMasterMutation,
+  AdminMastersQuery,
+  AdminPublishMasterMutation,
+  AdminUnpublishMasterMutation,
+  AdminUpdateMasterMutation,
+} from "./queries";
+import { useMasterMutations } from "./use-master-mutations";
+
+const VALUES: MasterFormValues = {
+  name: "Deck A",
+  description: null,
+  language: null,
+  level: null,
+  category: null,
+  coverImageUrl: null,
+  source: null,
+  isDefaultStarter: false,
+  sortOrder: null,
+};
+
+// A fully-populated MasterCardgroup node matching the create/update payload selection set.
+function masterNode(
+  id: string,
+  overrides: { status?: MasterCardgroupStatus; [key: string]: unknown } = {},
+) {
+  return {
+    __typename: "MasterCardgroup" as const,
+    id,
+    name: "Deck A",
+    description: null,
+    language: null,
+    level: null,
+    category: null,
+    coverImageUrl: null,
+    source: null,
+    version: 1,
+    status: "DRAFT" as MasterCardgroupStatus,
+    isDefaultStarter: false,
+    sortOrder: 0,
+    cardCount: 0,
+    ...overrides,
+  };
+}
+
+const NULL_SEARCH_VARS = { ...ADMIN_MASTERS_BASE_VARS, search: null };
+
+function render(mocks: MockedResponse[], cache = new InMemoryCache()) {
+  return renderHook(() => useMasterMutations(), {
+    wrapper: ({ children }: { children: ReactNode }) =>
+      createElement(MockedProvider, { mocks, cache }, children),
+  });
+}
+
+function readConnection(cache: InMemoryCache): AdminMastersQueryResult | null {
+  return cache.readQuery<AdminMastersQueryResult>({
+    query: AdminMastersQuery,
+    variables: NULL_SEARCH_VARS,
+  });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("useMasterMutations.createMaster", () => {
+  it("returns success and writes a cold-cache connection with the new edge", async () => {
+    const cache = new InMemoryCache();
+    const mocks: MockedResponse[] = [
+      {
+        request: { query: AdminCreateMasterMutation, variables: { input: VALUES } },
+        result: {
+          data: {
+            adminCreateMasterCardgroup: {
+              __typename: "CreateMasterCardgroupSuccess",
+              master: masterNode("m-1"),
+            },
+          },
+        },
+      },
+    ];
+    const { result } = render(mocks, cache);
+
+    let outcome: unknown;
+    await act(async () => {
+      outcome = await result.current.createMaster(VALUES);
+    });
+
+    expect(outcome).toEqual({ status: "success" });
+    const conn = readConnection(cache);
+    expect(conn?.adminMasters.totalCount).toBe(1);
+    expect(conn?.adminMasters.edges).toHaveLength(1);
+    expect(conn?.adminMasters.edges.at(0)?.node.id).toBe("m-1");
+  });
+
+  it("prepends onto a warm-cache connection and bumps totalCount", async () => {
+    const cache = new InMemoryCache();
+    cache.writeQuery<AdminMastersQueryResult>({
+      query: AdminMastersQuery,
+      variables: NULL_SEARCH_VARS,
+      data: {
+        adminMasters: {
+          __typename: "MasterCatalogConnection",
+          edges: [{ __typename: "MasterCatalogEdge", cursor: "m-0", node: masterNode("m-0") }],
+          pageInfo: {
+            __typename: "PageInfo",
+            hasNextPage: false,
+            hasPreviousPage: false,
+            startCursor: "m-0",
+            endCursor: "m-0",
+          },
+          totalCount: 1,
+        },
+      },
+    });
+    const mocks: MockedResponse[] = [
+      {
+        request: { query: AdminCreateMasterMutation, variables: { input: VALUES } },
+        result: {
+          data: {
+            adminCreateMasterCardgroup: {
+              __typename: "CreateMasterCardgroupSuccess",
+              master: masterNode("m-1"),
+            },
+          },
+        },
+      },
+    ];
+    const { result } = render(mocks, cache);
+
+    await act(async () => {
+      await result.current.createMaster(VALUES);
+    });
+
+    const conn = readConnection(cache);
+    expect(conn?.adminMasters.totalCount).toBe(2);
+    expect(conn?.adminMasters.edges.map((e) => e.node.id)).toEqual(["m-1", "m-0"]);
+  });
+
+  it("returns validation on InputValidationError", async () => {
+    const mocks: MockedResponse[] = [
+      {
+        request: { query: AdminCreateMasterMutation, variables: { input: VALUES } },
+        result: {
+          data: {
+            adminCreateMasterCardgroup: {
+              __typename: "InputValidationError",
+              field: "name",
+              message: "name is required",
+            },
+          },
+        },
+      },
+    ];
+    const cache = new InMemoryCache();
+    const { result } = render(mocks, cache);
+
+    let outcome: unknown;
+    await act(async () => {
+      outcome = await result.current.createMaster(VALUES);
+    });
+
+    expect(outcome).toEqual({ status: "validation", field: "name", message: "name is required" });
+    // The update callback must not touch the cache on a validation payload.
+    expect(readConnection(cache)).toBeNull();
+  });
+
+  it("returns auth(forbidden) when the mutation rejects with FORBIDDEN", async () => {
+    const mocks: MockedResponse[] = [
+      {
+        request: { query: AdminCreateMasterMutation, variables: { input: VALUES } },
+        result: { errors: [new GraphQLError("Forbidden", { extensions: { code: "FORBIDDEN" } })] },
+      },
+    ];
+    const { result } = render(mocks);
+
+    let outcome: unknown;
+    await act(async () => {
+      outcome = await result.current.createMaster(VALUES);
+    });
+
+    expect(outcome).toEqual({ status: "auth", kind: "forbidden" });
+  });
+
+  it("returns rejected on a transport error", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const mocks: MockedResponse[] = [
+      {
+        request: { query: AdminCreateMasterMutation, variables: { input: VALUES } },
+        error: new Error("network down"),
+      },
+    ];
+    const { result } = render(mocks);
+
+    let outcome: unknown;
+    await act(async () => {
+      outcome = await result.current.createMaster(VALUES);
+    });
+
+    expect(outcome).toEqual({ status: "rejected" });
+  });
+
+  it("returns unexpected on an unknown payload variant", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const mocks: MockedResponse[] = [
+      {
+        request: { query: AdminCreateMasterMutation, variables: { input: VALUES } },
+        result: { data: { adminCreateMasterCardgroup: { __typename: "SomeFutureVariant" } } },
+      },
+    ];
+    const cache = new InMemoryCache();
+    const { result } = render(mocks, cache);
+
+    let outcome: unknown;
+    await act(async () => {
+      outcome = await result.current.createMaster(VALUES);
+    });
+
+    expect(outcome).toEqual({ status: "unexpected" });
+    // The update callback must not touch the cache on an unknown payload variant.
+    expect(readConnection(cache)).toBeNull();
+  });
+});
+
+describe("useMasterMutations.updateMaster", () => {
+  it("returns success on UpdateMasterCardgroupSuccess", async () => {
+    const mocks: MockedResponse[] = [
+      {
+        request: { query: AdminUpdateMasterMutation, variables: { id: "m-1", input: VALUES } },
+        result: {
+          data: {
+            adminUpdateMasterCardgroup: {
+              __typename: "UpdateMasterCardgroupSuccess",
+              master: masterNode("m-1", { name: "Deck A2" }),
+            },
+          },
+        },
+      },
+    ];
+    const { result } = render(mocks);
+
+    let outcome: unknown;
+    await act(async () => {
+      outcome = await result.current.updateMaster("m-1", VALUES);
+    });
+
+    expect(outcome).toEqual({ status: "success" });
+  });
+
+  it("returns validation on InputValidationError", async () => {
+    const mocks: MockedResponse[] = [
+      {
+        request: { query: AdminUpdateMasterMutation, variables: { id: "m-1", input: VALUES } },
+        result: {
+          data: {
+            adminUpdateMasterCardgroup: {
+              __typename: "InputValidationError",
+              field: "name",
+              message: "name too long",
+            },
+          },
+        },
+      },
+    ];
+    const { result } = render(mocks);
+
+    let outcome: unknown;
+    await act(async () => {
+      outcome = await result.current.updateMaster("m-1", VALUES);
+    });
+
+    expect(outcome).toEqual({ status: "validation", field: "name", message: "name too long" });
+  });
+});
+
+describe("useMasterMutations.deleteMaster", () => {
+  it("removes the edge by node.id, decrements totalCount, evicts, returns success", async () => {
+    const cache = new InMemoryCache();
+    cache.writeQuery<AdminMastersQueryResult>({
+      query: AdminMastersQuery,
+      variables: NULL_SEARCH_VARS,
+      data: {
+        adminMasters: {
+          __typename: "MasterCatalogConnection",
+          edges: [
+            { __typename: "MasterCatalogEdge", cursor: "v1:enc-m-1", node: masterNode("m-1") },
+            { __typename: "MasterCatalogEdge", cursor: "v1:enc-m-2", node: masterNode("m-2") },
+          ],
+          pageInfo: {
+            __typename: "PageInfo",
+            hasNextPage: false,
+            hasPreviousPage: false,
+            startCursor: "v1:enc-m-1",
+            endCursor: "v1:enc-m-2",
+          },
+          totalCount: 2,
+        },
+      },
+    });
+    const mocks: MockedResponse[] = [
+      {
+        request: { query: AdminDeleteMasterMutation, variables: { id: "m-1" } },
+        result: { data: { adminDeleteMasterCardgroup: true } },
+      },
+    ];
+    const { result } = render(mocks, cache);
+
+    let outcome: unknown;
+    await act(async () => {
+      outcome = await result.current.deleteMaster("m-1");
+    });
+
+    expect(outcome).toEqual({ status: "success" });
+    const conn = readConnection(cache);
+    expect(conn?.adminMasters.totalCount).toBe(1);
+    expect(conn?.adminMasters.edges.map((e) => e.node.id)).toEqual(["m-2"]);
+  });
+
+  it("returns rejected when the mutation returns false", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const mocks: MockedResponse[] = [
+      {
+        request: { query: AdminDeleteMasterMutation, variables: { id: "m-1" } },
+        result: { data: { adminDeleteMasterCardgroup: false } },
+      },
+    ];
+    const { result } = render(mocks);
+
+    let outcome: unknown;
+    await act(async () => {
+      outcome = await result.current.deleteMaster("m-1");
+    });
+
+    expect(outcome).toEqual({ status: "rejected" });
+  });
+
+  it("returns auth(unauthenticated) when the mutation rejects with UNAUTHENTICATED", async () => {
+    const mocks: MockedResponse[] = [
+      {
+        request: { query: AdminDeleteMasterMutation, variables: { id: "m-1" } },
+        result: {
+          errors: [
+            new GraphQLError("Unauthenticated", { extensions: { code: "UNAUTHENTICATED" } }),
+          ],
+        },
+      },
+    ];
+    const { result } = render(mocks);
+
+    let outcome: unknown;
+    await act(async () => {
+      outcome = await result.current.deleteMaster("m-1");
+    });
+
+    expect(outcome).toEqual({ status: "auth", kind: "unauthenticated" });
+  });
+});
+
+describe("useMasterMutations.publishMaster / unpublishMaster", () => {
+  it("publishMaster returns success on PublishMasterCardgroupSuccess", async () => {
+    const mocks: MockedResponse[] = [
+      {
+        request: { query: AdminPublishMasterMutation, variables: { id: "m-1" } },
+        result: {
+          data: {
+            adminPublishMasterCardgroup: {
+              __typename: "PublishMasterCardgroupSuccess",
+              master: masterNode("m-1", { status: "PUBLISHED" }),
+            },
+          },
+        },
+      },
+    ];
+    const { result } = render(mocks);
+
+    let outcome: unknown;
+    await act(async () => {
+      outcome = await result.current.publishMaster("m-1");
+    });
+
+    expect(outcome).toEqual({ status: "success" });
+  });
+
+  it("publishMaster returns empty on MasterCardgroupEmptyError", async () => {
+    const mocks: MockedResponse[] = [
+      {
+        request: { query: AdminPublishMasterMutation, variables: { id: "m-1" } },
+        result: {
+          data: {
+            adminPublishMasterCardgroup: {
+              __typename: "MasterCardgroupEmptyError",
+              message: "cannot publish empty deck",
+            },
+          },
+        },
+      },
+    ];
+    const { result } = render(mocks);
+
+    let outcome: unknown;
+    await act(async () => {
+      outcome = await result.current.publishMaster("m-1");
+    });
+
+    expect(outcome).toEqual({ status: "empty" });
+  });
+
+  it("unpublishMaster returns success on a truthy payload", async () => {
+    const mocks: MockedResponse[] = [
+      {
+        request: { query: AdminUnpublishMasterMutation, variables: { id: "m-1" } },
+        result: { data: { adminUnpublishMasterCardgroup: masterNode("m-1", { status: "DRAFT" }) } },
+      },
+    ];
+    const { result } = render(mocks);
+
+    let outcome: unknown;
+    await act(async () => {
+      outcome = await result.current.unpublishMaster("m-1");
+    });
+
+    expect(outcome).toEqual({ status: "success" });
+  });
+});

--- a/frontend/src/app/admin/masters/use-master-mutations.ts
+++ b/frontend/src/app/admin/masters/use-master-mutations.ts
@@ -1,0 +1,297 @@
+"use client";
+
+import { useApolloClient, useMutation } from "@apollo/client/react";
+import type { Reference } from "@apollo/client/utilities";
+import { useCallback } from "react";
+import type { AdminMastersQuery as AdminMastersQueryResult } from "@/generated/graphql";
+import { classifyMutationAuthError } from "@/lib/apollo/errors";
+import { liftGraphQLCodes } from "@/lib/apollo/graphql-errors";
+import type { MasterFormValues } from "./admin-master-form";
+import {
+  ADMIN_MASTERS_BASE_VARS,
+  AdminCreateMasterMutation,
+  AdminDeleteMasterMutation,
+  AdminMastersQuery,
+  AdminPublishMasterMutation,
+  AdminUnpublishMasterMutation,
+  AdminUpdateMasterMutation,
+} from "./queries";
+
+/** Auth-relevant failure kind surfaced to the caller for toast copy selection. */
+export type AuthKind = "forbidden" | "unauthenticated";
+
+export type CreateMasterOutcome =
+  | { status: "success" }
+  | { status: "validation"; field: string; message: string }
+  | { status: "auth"; kind: AuthKind }
+  | { status: "unexpected" }
+  | { status: "rejected" };
+
+export type UpdateMasterOutcome =
+  | { status: "success" }
+  | { status: "validation"; field: string; message: string }
+  | { status: "auth"; kind: AuthKind }
+  | { status: "unexpected" }
+  | { status: "rejected" };
+
+export type DeleteMasterOutcome =
+  | { status: "success" }
+  | { status: "auth"; kind: AuthKind }
+  | { status: "rejected" };
+
+export type PublishMasterOutcome =
+  | { status: "success" }
+  | { status: "empty" }
+  | { status: "auth"; kind: AuthKind }
+  | { status: "unexpected" }
+  | { status: "rejected" };
+
+export type UnpublishMasterOutcome =
+  | { status: "success" }
+  | { status: "auth"; kind: AuthKind }
+  | { status: "unexpected" }
+  | { status: "rejected" };
+
+// FORBIDDEN / UNAUTHENTICATED → an auth outcome; anything else → null so the
+// caller falls through to its own rejected/unexpected branch.
+function authOutcome(err: unknown): { status: "auth"; kind: AuthKind } | null {
+  const kind = classifyMutationAuthError(err);
+  if (kind === "other") return null;
+  return { status: "auth", kind };
+}
+
+/**
+ * Owns the five admin-masters mutations and their Apollo cache writes. The client
+ * maps the returned typed outcomes to toast copy, sheet navigation, and validation
+ * state. Mirrors the thin-outcome-hook shape of `useCreateCardgroup` /
+ * `useImportMaster`.
+ *
+ * No `optimisticResponse`: typed errors (InputValidationError, FORBIDDEN) can fail
+ * these mutations and Apollo does not reliably roll back optimistic writes for
+ * typed GraphQL errors — see .claude/rules/pagination.md.
+ */
+export function useMasterMutations() {
+  const apolloClient = useApolloClient();
+
+  const [runCreate, { loading: creating, reset: resetCreate }] = useMutation(
+    AdminCreateMasterMutation,
+    {
+      update(cache, { data }) {
+        // Narrow before touching .master so a validation/unknown variant cannot
+        // mutate the cache.
+        if (data?.adminCreateMasterCardgroup?.__typename !== "CreateMasterCardgroupSuccess") return;
+        const created = data.adminCreateMasterCardgroup.master;
+        // cache.modify is forbidden — readQuery + writeQuery handles the cold cache
+        // too. Write the search=null variant only; ADMIN_MASTERS_BASE_VARS keeps the
+        // key in sync with the client useConnectionPagination query. See
+        // .claude/rules/pagination.md.
+        const existing = cache.readQuery<AdminMastersQueryResult>({
+          query: AdminMastersQuery,
+          variables: { ...ADMIN_MASTERS_BASE_VARS, search: null },
+        });
+        const createdEdge = {
+          __typename: "MasterCatalogEdge" as const,
+          cursor: created.id,
+          node: created,
+        };
+        cache.writeQuery<AdminMastersQueryResult>({
+          query: AdminMastersQuery,
+          variables: { ...ADMIN_MASTERS_BASE_VARS, search: null },
+          data: existing?.adminMasters
+            ? {
+                adminMasters: {
+                  ...existing.adminMasters,
+                  edges: [createdEdge, ...existing.adminMasters.edges],
+                  totalCount: existing.adminMasters.totalCount + 1,
+                },
+              }
+            : {
+                adminMasters: {
+                  __typename: "MasterCatalogConnection",
+                  edges: [createdEdge],
+                  pageInfo: {
+                    __typename: "PageInfo",
+                    hasNextPage: false,
+                    hasPreviousPage: false,
+                    startCursor: created.id,
+                    endCursor: created.id,
+                  },
+                  totalCount: 1,
+                },
+              },
+        });
+      },
+    },
+  );
+  const [runUpdate, { loading: updating, reset: resetUpdate }] =
+    useMutation(AdminUpdateMasterMutation);
+  const [runDelete] = useMutation(AdminDeleteMasterMutation);
+  const [runPublish] = useMutation(AdminPublishMasterMutation);
+  const [runUnpublish] = useMutation(AdminUnpublishMasterMutation);
+
+  const createMaster = useCallback(
+    async (values: MasterFormValues): Promise<CreateMasterOutcome> => {
+      try {
+        const result = await runCreate({ variables: { input: values } });
+        const payload = result.data?.adminCreateMasterCardgroup;
+        const typename = payload?.__typename ?? null;
+        if (payload?.__typename === "InputValidationError") {
+          return { status: "validation", field: payload.field, message: payload.message };
+        }
+        if (payload?.__typename === "CreateMasterCardgroupSuccess") {
+          return { status: "success" };
+        }
+        console.warn("[useMasterMutations] unexpected createMaster payload", { typename });
+        return { status: "unexpected" };
+      } catch (err) {
+        const auth = authOutcome(err);
+        if (auth) return auth;
+        console.warn("[useMasterMutations] createMaster rejected", {
+          name: err instanceof Error ? err.name : "unknown",
+          codes: liftGraphQLCodes(err),
+        });
+        return { status: "rejected" };
+      }
+    },
+    [runCreate],
+  );
+
+  const updateMaster = useCallback(
+    async (id: string, values: MasterFormValues): Promise<UpdateMasterOutcome> => {
+      try {
+        const result = await runUpdate({ variables: { id, input: values } });
+        const payload = result.data?.adminUpdateMasterCardgroup;
+        const typename = payload?.__typename ?? null;
+        if (payload?.__typename === "InputValidationError") {
+          return { status: "validation", field: payload.field, message: payload.message };
+        }
+        if (payload?.__typename === "UpdateMasterCardgroupSuccess") {
+          return { status: "success" };
+        }
+        console.warn("[useMasterMutations] unexpected updateMaster payload", { typename });
+        return { status: "unexpected" };
+      } catch (err) {
+        const auth = authOutcome(err);
+        if (auth) return auth;
+        console.warn("[useMasterMutations] updateMaster rejected", {
+          masterId: id,
+          name: err instanceof Error ? err.name : "unknown",
+          codes: liftGraphQLCodes(err),
+        });
+        return { status: "rejected" };
+      }
+    },
+    [runUpdate],
+  );
+
+  const deleteMaster = useCallback(
+    async (id: string): Promise<DeleteMasterOutcome> => {
+      try {
+        const result = await runDelete({ variables: { id } });
+        if (!result.data?.adminDeleteMasterCardgroup) {
+          throw new Error("adminDeleteMasterCardgroup returned false");
+        }
+        apolloClient.cache.modify({
+          fields: {
+            adminMasters(existing, { readField }) {
+              const conn = existing as {
+                edges?: ReadonlyArray<{ node: Reference }>;
+                totalCount?: number;
+              };
+              if (!conn.edges) return existing;
+              // Filter by the normalized node id, not by `cursor` (the edge cursor is
+              // an opaque "v1:..." value that never equals the raw id).
+              const next = conn.edges.filter((edge) => readField<string>("id", edge.node) !== id);
+              if (next.length === conn.edges.length) return existing;
+              return { ...conn, edges: next, totalCount: Math.max(0, (conn.totalCount ?? 0) - 1) };
+            },
+          },
+        });
+        const cacheId = apolloClient.cache.identify({ __typename: "MasterCardgroup", id });
+        if (cacheId) {
+          apolloClient.cache.evict({ id: cacheId });
+          apolloClient.cache.gc();
+        }
+        return { status: "success" };
+      } catch (err) {
+        const auth = authOutcome(err);
+        if (auth) return auth;
+        console.warn("[useMasterMutations] deleteMaster rejected", {
+          masterId: id,
+          name: err instanceof Error ? err.name : "unknown",
+          codes: liftGraphQLCodes(err),
+        });
+        return { status: "rejected" };
+      }
+    },
+    [apolloClient, runDelete],
+  );
+
+  const publishMaster = useCallback(
+    async (id: string): Promise<PublishMasterOutcome> => {
+      try {
+        const result = await runPublish({ variables: { id } });
+        const payload = result.data?.adminPublishMasterCardgroup;
+        const typename = payload?.__typename ?? null;
+        if (payload?.__typename === "PublishMasterCardgroupSuccess") {
+          return { status: "success" };
+        }
+        if (payload?.__typename === "MasterCardgroupEmptyError") {
+          return { status: "empty" };
+        }
+        console.warn("[useMasterMutations] unexpected publishMaster payload", {
+          masterId: id,
+          typename,
+        });
+        return { status: "unexpected" };
+      } catch (err) {
+        const auth = authOutcome(err);
+        if (auth) return auth;
+        console.warn("[useMasterMutations] publishMaster rejected", {
+          masterId: id,
+          name: err instanceof Error ? err.name : "unknown",
+          codes: liftGraphQLCodes(err),
+        });
+        return { status: "rejected" };
+      }
+    },
+    [runPublish],
+  );
+
+  const unpublishMaster = useCallback(
+    async (id: string): Promise<UnpublishMasterOutcome> => {
+      try {
+        const result = await runUnpublish({ variables: { id } });
+        if (!result.data?.adminUnpublishMasterCardgroup) {
+          console.warn("[useMasterMutations] unpublishMaster returned null payload", {
+            masterId: id,
+          });
+          return { status: "unexpected" };
+        }
+        return { status: "success" };
+      } catch (err) {
+        const auth = authOutcome(err);
+        if (auth) return auth;
+        console.warn("[useMasterMutations] unpublishMaster rejected", {
+          masterId: id,
+          name: err instanceof Error ? err.name : "unknown",
+          codes: liftGraphQLCodes(err),
+        });
+        return { status: "rejected" };
+      }
+    },
+    [runUnpublish],
+  );
+
+  return {
+    createMaster,
+    updateMaster,
+    deleteMaster,
+    publishMaster,
+    unpublishMaster,
+    creating,
+    updating,
+    resetCreate,
+    resetUpdate,
+  };
+}

--- a/frontend/src/app/admin/users/admin-users-client.test.tsx
+++ b/frontend/src/app/admin/users/admin-users-client.test.tsx
@@ -562,7 +562,7 @@ describe("<AdminUsersClient> delete", () => {
 
   it("does not configure optimisticResponse for adminDeleteUser", () => {
     const source = readFileSync(
-      join(process.cwd(), "src/app/admin/users/admin-users-client.tsx"),
+      join(process.cwd(), "src/app/admin/users/use-admin-user-mutations.ts"),
       "utf8",
     );
     const start = source.indexOf("runDeleteUser({");

--- a/frontend/src/app/admin/users/admin-users-client.tsx
+++ b/frontend/src/app/admin/users/admin-users-client.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { NetworkStatus } from "@apollo/client";
-import { useApolloClient, useLazyQuery, useMutation, useQuery } from "@apollo/client/react";
+import { useLazyQuery, useQuery } from "@apollo/client/react";
 import Link from "next/link";
 import { useTranslations } from "next-intl";
 import { useCallback, useEffect, useMemo, useState } from "react";
@@ -23,7 +23,6 @@ import { type AdminUserListItem, AdminUserRow } from "./admin-user-row";
 import { AdminUsersSkeleton } from "./admin-users-skeleton";
 import {
   ADMIN_USERS_PAGE_SIZE,
-  AdminDeleteUserMutation,
   AdminRoleFieldsFragment,
   AdminRolesQuery,
   AdminUserFieldsFragment,
@@ -31,6 +30,7 @@ import {
   AdminUserQuery,
   AdminUsersQuery,
 } from "./queries";
+import { useAdminUserMutations } from "./use-admin-user-mutations";
 
 type Connection = AdminUsersQueryResult["users"];
 type Edge = Connection["edges"][number];
@@ -215,48 +215,18 @@ export function AdminUsersClient() {
     void loadAdminUser({ variables: { id: editUserId } });
   }, [editUserId, loadAdminUser, refetch]);
 
-  const apolloClient = useApolloClient();
-  const [runDeleteUser] = useMutation(AdminDeleteUserMutation);
+  const { deleteUser } = useAdminUserMutations();
 
-  // Deletes a user, updates the cache, toasts, and closes the sheet. Rejects on
-  // failure (e.g. FORBIDDEN) so the sheet's danger zone can render the reason.
+  // Deletes a user (mutation + cache eviction live in the hook), then toasts and
+  // closes the sheet. Re-throws on failure so AdminUserProfileSheet's danger zone
+  // can render the reason.
   const handleDeleteUser = useCallback(
     async (id: string) => {
-      const result = await runDeleteUser({ variables: { id } });
-      if (!result.data?.adminDeleteUser) {
-        throw new Error("adminDeleteUser returned false");
-      }
-      // Drop the deleted user from every cached `users` connection variant (each
-      // search / pagination combo is a separate field entry). The edge cursor
-      // equals the user id by schema contract, so filter on cursor and avoid
-      // unmasking the node fragment. Then evict the now-orphaned entity.
-      apolloClient.cache.modify({
-        fields: {
-          users(existing) {
-            const connection = existing as {
-              edges?: ReadonlyArray<{ cursor: string }>;
-              totalCount?: number;
-            };
-            if (!connection.edges) return existing;
-            const edges = connection.edges.filter((edge) => edge.cursor !== id);
-            if (edges.length === connection.edges.length) return existing;
-            return {
-              ...connection,
-              edges,
-              totalCount: Math.max(0, (connection.totalCount ?? 0) - 1),
-            };
-          },
-        },
-      });
-      const cacheId = apolloClient.cache.identify({ __typename: "User", id });
-      if (cacheId) {
-        apolloClient.cache.evict({ id: cacheId });
-        apolloClient.cache.gc();
-      }
+      await deleteUser(id);
       toast.success(t("deleteUserSuccess"));
       sheet.close();
     },
-    [apolloClient, runDeleteUser, sheet, t],
+    [deleteUser, t, sheet],
   );
 
   // Show the full-page skeleton only on the very first load (NetworkStatus.loading = 1).

--- a/frontend/src/app/admin/users/use-admin-user-mutations.test.tsx
+++ b/frontend/src/app/admin/users/use-admin-user-mutations.test.tsx
@@ -1,0 +1,128 @@
+// @vitest-environment jsdom
+import { InMemoryCache } from "@apollo/client";
+import type { MockedResponse } from "@apollo/client/testing";
+import { MockedProvider } from "@apollo/client/testing/react";
+import { act, renderHook } from "@testing-library/react";
+import { GraphQLError } from "graphql";
+import { createElement, type ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { AdminUsersQuery as AdminUsersQueryResult } from "@/generated/graphql";
+import { ADMIN_USERS_PAGE_SIZE, AdminDeleteUserMutation, AdminUsersQuery } from "./queries";
+import { useAdminUserMutations } from "./use-admin-user-mutations";
+
+const USERS_VARS = { first: ADMIN_USERS_PAGE_SIZE, search: null };
+
+// A user edge: the backend contract sets edge.cursor === user id for the users
+// connection (the delete cache filter relies on this).
+function userEdge(id: string) {
+  return {
+    __typename: "UserEdge" as const,
+    cursor: id,
+    node: {
+      __typename: "User" as const,
+      id,
+      displayName: `User ${id}`,
+      bio: null,
+      avatarUrl: null,
+      roles: [],
+    },
+  };
+}
+
+function seedUsers(cache: InMemoryCache, ids: string[]) {
+  cache.writeQuery<AdminUsersQueryResult>({
+    query: AdminUsersQuery,
+    variables: USERS_VARS,
+    data: {
+      users: {
+        __typename: "UserConnection",
+        edges: ids.map(userEdge),
+        pageInfo: {
+          __typename: "PageInfo",
+          hasNextPage: false,
+          hasPreviousPage: false,
+          startCursor: ids[0] ?? null,
+          endCursor: ids[ids.length - 1] ?? null,
+        },
+        totalCount: ids.length,
+      },
+    },
+  });
+}
+
+function readUsers(cache: InMemoryCache): AdminUsersQueryResult | null {
+  return cache.readQuery<AdminUsersQueryResult>({ query: AdminUsersQuery, variables: USERS_VARS });
+}
+
+function render(mocks: MockedResponse[], cache: InMemoryCache) {
+  return renderHook(() => useAdminUserMutations(), {
+    wrapper: ({ children }: { children: ReactNode }) =>
+      createElement(MockedProvider, { mocks, cache }, children),
+  });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("useAdminUserMutations.deleteUser", () => {
+  it("removes the edge by cursor, decrements totalCount, and evicts on success", async () => {
+    const cache = new InMemoryCache();
+    seedUsers(cache, ["u-1", "u-2"]);
+    const mocks: MockedResponse[] = [
+      {
+        request: { query: AdminDeleteUserMutation, variables: { id: "u-1" } },
+        result: { data: { adminDeleteUser: true } },
+      },
+    ];
+    const { result } = render(mocks, cache);
+
+    await act(async () => {
+      await result.current.deleteUser("u-1");
+    });
+
+    const conn = readUsers(cache);
+    expect(conn?.users.totalCount).toBe(1);
+    expect(conn?.users.edges.map((e) => e.cursor)).toEqual(["u-2"]);
+  });
+
+  it("re-throws and leaves the cache untouched on FORBIDDEN", async () => {
+    const cache = new InMemoryCache();
+    seedUsers(cache, ["u-1", "u-2"]);
+    const mocks: MockedResponse[] = [
+      {
+        request: { query: AdminDeleteUserMutation, variables: { id: "u-1" } },
+        result: { errors: [new GraphQLError("Forbidden", { extensions: { code: "FORBIDDEN" } })] },
+      },
+    ];
+    const { result } = render(mocks, cache);
+
+    await expect(
+      act(async () => {
+        await result.current.deleteUser("u-1");
+      }),
+    ).rejects.toThrow();
+
+    const conn = readUsers(cache);
+    expect(conn?.users.totalCount).toBe(2);
+    expect(conn?.users.edges.map((e) => e.cursor)).toEqual(["u-1", "u-2"]);
+  });
+
+  it("throws when the mutation returns false", async () => {
+    const cache = new InMemoryCache();
+    seedUsers(cache, ["u-1"]);
+    const mocks: MockedResponse[] = [
+      {
+        request: { query: AdminDeleteUserMutation, variables: { id: "u-1" } },
+        result: { data: { adminDeleteUser: false } },
+      },
+    ];
+    const { result } = render(mocks, cache);
+
+    await expect(
+      act(async () => {
+        await result.current.deleteUser("u-1");
+      }),
+    ).rejects.toThrow("adminDeleteUser returned false");
+  });
+});

--- a/frontend/src/app/admin/users/use-admin-user-mutations.test.tsx
+++ b/frontend/src/app/admin/users/use-admin-user-mutations.test.tsx
@@ -84,6 +84,8 @@ describe("useAdminUserMutations.deleteUser", () => {
     const conn = readUsers(cache);
     expect(conn?.users.totalCount).toBe(1);
     expect(conn?.users.edges.map((e) => e.cursor)).toEqual(["u-2"]);
+    // The deleted entity is evicted + gc'd from the normalized cache.
+    expect(cache.extract()["User:u-1"]).toBeUndefined();
   });
 
   it("re-throws and leaves the cache untouched on FORBIDDEN", async () => {

--- a/frontend/src/app/admin/users/use-admin-user-mutations.ts
+++ b/frontend/src/app/admin/users/use-admin-user-mutations.ts
@@ -1,0 +1,60 @@
+"use client";
+
+import { useApolloClient, useMutation } from "@apollo/client/react";
+import { useCallback } from "react";
+import { AdminDeleteUserMutation } from "./queries";
+
+/**
+ * Owns the admin delete-user mutation and its cursor-filter cache eviction.
+ *
+ * `deleteUser` resolves `void` on success — after dropping the user from every
+ * cached `users` connection variant (filtering by `edge.cursor`, which equals the
+ * user id by the schema's connection contract) and evicting the normalized entity.
+ * On failure it RE-THROWS the raw error: `AdminUserProfileSheet`'s danger zone
+ * catches it and renders the reason via `mutationAuthBanner`, so a typed-outcome
+ * shape would strip the error the sheet needs. This is intentionally asymmetric
+ * with masters' delete (node.id filter + swallow-into-outcome) — see issue #448
+ * and .claude/rules/pagination.md "Connection delete".
+ *
+ * No `optimisticResponse`: a delete can fail with FORBIDDEN and Apollo does not
+ * reliably roll back optimistic writes for typed GraphQL errors.
+ */
+export function useAdminUserMutations() {
+  const apolloClient = useApolloClient();
+  const [runDeleteUser] = useMutation(AdminDeleteUserMutation);
+
+  const deleteUser = useCallback(
+    async (id: string): Promise<void> => {
+      const result = await runDeleteUser({ variables: { id } });
+      if (!result.data?.adminDeleteUser) {
+        throw new Error("adminDeleteUser returned false");
+      }
+      apolloClient.cache.modify({
+        fields: {
+          users(existing) {
+            const connection = existing as {
+              edges?: ReadonlyArray<{ cursor: string }>;
+              totalCount?: number;
+            };
+            if (!connection.edges) return existing;
+            const edges = connection.edges.filter((edge) => edge.cursor !== id);
+            if (edges.length === connection.edges.length) return existing;
+            return {
+              ...connection,
+              edges,
+              totalCount: Math.max(0, (connection.totalCount ?? 0) - 1),
+            };
+          },
+        },
+      });
+      const cacheId = apolloClient.cache.identify({ __typename: "User", id });
+      if (cacheId) {
+        apolloClient.cache.evict({ id: cacheId });
+        apolloClient.cache.gc();
+      }
+    },
+    [apolloClient, runDeleteUser],
+  );
+
+  return { deleteUser };
+}

--- a/frontend/src/app/admin/users/use-admin-user-mutations.ts
+++ b/frontend/src/app/admin/users/use-admin-user-mutations.ts
@@ -37,6 +37,13 @@ export function useAdminUserMutations() {
               totalCount?: number;
             };
             if (!connection.edges) return existing;
+            // Filter by `edge.cursor`, NOT `readField("id", edge.node)`. This is the
+            // deliberate exception to .claude/rules/pagination.md "Resolve an edge by
+            // node.id, never by edge.cursor": the backend emits the raw user id as the
+            // users-connection cursor (AdminUserEdge{Cursor: user.ID} in
+            // backend/internal/usecase/admin_user.go — NOT cursor.Encode), so here
+            // cursor === id. Masters/cards/cardgroups encode their cursors, so they must
+            // use node.id; users intentionally differ (issue #448).
             const edges = connection.edges.filter((edge) => edge.cursor !== id);
             if (edges.length === connection.edges.length) return existing;
             return {


### PR DESCRIPTION
## Summary

The admin masters and users clients still owned all their Apollo mutations and cache writes inline — the concern #456 explicitly deferred to this follow-up. Both now delegate to per-screen feature hooks (`useMasterMutations` / `useAdminUserMutations`), leaving each client as compose-hook + render. This completes the frontend functional-cohesion plan (FE cohesion 6/6). **Pure SRP refactor — no user-visible behaviour change.**

Closes #448.

## Background / Motivation

- #456 migrated the pagination IO out of these two clients but deliberately left the mutation + cache concern inline (the Wave-3 SRP follow-up). This is that follow-up.
- Both clients carried plural change-reasons in one component (mutation contract, Apollo cache normalization, i18n, layout): the masters client owned 5 mutations + their cache writes; the users client owned the delete cache filter and eviction.
- The repo already had the thin-outcome-hook pattern (`useCreateCardgroup`, `useImportMaster`, `useUpdateProfile`) — the hook owns the mutation document + cache write + typed-outcome classification; the caller owns presentation. This PR applies that shape to the two admin screens.

## Changes

### New `app/admin/masters/use-master-mutations.ts`

- Owns the 5 masters mutations (create / update / delete / publish / unpublish) + their cache writes. Exposes `createMaster` / `updateMaster` / `deleteMaster` / `publishMaster` / `unpublishMaster` returning typed discriminated-union outcomes, plus `creating` / `updating` loading flags and `resetCreate` / `resetUpdate`.
- Create cache write in the mutation `update` callback: `readQuery + writeQuery` prepend to the `search: null` variant (cold cache builds a minimal `MasterCatalogConnection`). Delete uses `cache.modify` filtering edges by `node.id` + `totalCount` decrement + `evict` + `gc`. Auth classified via `classifyMutationAuthError`; `console.warn` scope `[useMasterMutations]`, codes only (no `err.message`).

### New `app/admin/users/use-admin-user-mutations.ts`

- Owns ONLY the delete-user mutation + its cursor-filter cache eviction. `deleteUser(id): Promise<void>` evicts on success and re-throws the raw error on failure, so `AdminUserProfileSheet`'s danger zone keeps rendering the FORBIDDEN reason.
- Deliberately asymmetric with masters: filters by `edge.cursor` (the users connection emits the raw user id as the cursor — `AdminUserEdge{Cursor: user.ID}` in `backend/internal/usecase/admin_user.go`, documented inline) and re-throws rather than swallowing into a typed outcome. No shared delete/cache helper — the two strategies stay intentionally distinct.

### `app/admin/masters/admin-masters-client.tsx` (slimmed)

- Removed the 5 inline `useMutation`s, `useApolloClient`, and every `readQuery` / `writeQuery` / `cache.modify`; now calls `useMasterMutations()` and maps each outcome to the existing toast copy / sheet navigation / validation state via thin wrappers (`authToast` folds the auth kind to copy). Render JSX unchanged.

### `app/admin/users/admin-users-client.tsx` (slimmed)

- Removed the inline delete mutation + cache eviction; `handleDeleteUser` now `await deleteUser(id)` then toasts + closes the sheet (the re-throw propagates to the profile sheet untouched). The roles `useQuery`, the edit-user `useLazyQuery` + derivation, and `reloadEditedUser` stay in the client — the hook is delete-only by design.

### `app/admin/masters/queries.ts`

- Added `ADMIN_MASTERS_BASE_VARS` (the `{ first, orderBy, orderDirection }` create-cache key) as the single source of truth shared by the client `useConnectionPagination` query and the hook's create write, so the prepended edge lands under the same cache key.

### Tests

- New `use-master-mutations.test.tsx` / `use-admin-user-mutations.test.tsx` (`renderHook` + `MockedProvider` + `InMemoryCache`): cold/warm-cache create prepend (asserted via `readQuery`), validation / auth / unexpected / rejected, delete edge-removal + `totalCount` decrement + entity eviction (asserted via `cache.extract()`), publish / empty / unpublish; users delete success + FORBIDDEN re-throw-with-cache-untouched + false-return throw.
- The two `optimisticResponse` static-grep guards relocated from the client files to the hook files (the `runPublish` / `runUnpublish` / `runDeleteUser` calls moved there); the assertion logic is unchanged. Existing admin client + broad page tests pass unchanged — the behaviour-preserving proof.

## Verification

```bash
# Neither client declares an inline mutation or cache write — the hooks own it:
grep -nE 'useMutation|useApolloClient|cache\.(modify|writeQuery|readQuery)' \
  frontend/src/app/admin/masters/admin-masters-client.tsx \
  frontend/src/app/admin/users/admin-users-client.tsx
# → no output

# Both hooks are wired (knip-clean; non-test production callers):
grep -rln "useMasterMutations\|useAdminUserMutations" frontend/src --include='*.tsx' \
  | grep -v test | grep -v use-master-mutations.ts | grep -v use-admin-user-mutations.ts
# → admin-masters-client.tsx, admin-users-client.tsx
```

## Test plan

- [x] typecheck / biome lint (`--error-on-warnings`) / knip / vitest (1368 passed) / next build / CJK grep all green.
- [x] New hook tests cover every cache-write branch (cold/warm create prepend, delete eviction by node.id and by cursor, publish-empty, users re-throw with cache untouched).
- [x] Existing `admin-masters-client.test.tsx` / `admin-users-client.test.tsx` + the broad `__tests__` page tests pass unchanged.
- [ ] Manual smoke: create / edit / delete / publish / unpublish a master and delete a user (including a FORBIDDEN attempt → danger-zone reason renders) — all behave as before.
