### PR TITLE
style(login): align typography, kerning & spacing with apple.com/jp

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -171,4 +171,18 @@
       "calt" 1;
     text-rendering: optimizeLegibility;
   }
+  /* Japanese: enable proportional-width metrics (palt) so kana and full-width
+     punctuation (、。「」etc.) tighten the way apple.com/jp's Japanese
+     typography does — the single biggest "kerning" win for Japanese text.
+     Gated on the document language (<html lang>), so Latin runs stay untouched
+     (Inter exposes no palt table) and non-ja locales keep the body set above.
+     font-feature-settings is not additive, so the Latin features are
+     re-declared alongside palt. */
+  :lang(ja) {
+    font-feature-settings:
+      "kern" 1,
+      "liga" 1,
+      "calt" 1,
+      "palt" 1;
+  }
 }

--- a/frontend/src/app/login/login-button.tsx
+++ b/frontend/src/app/login/login-button.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
 import { createSupabaseBrowserClient } from "@/lib/supabase/client";
 
@@ -32,6 +32,7 @@ function GoogleGLogo() {
 
 export function LoginButton() {
   const t = useTranslations("Login");
+  const isJa = useLocale() === "ja";
 
   async function handleSignIn() {
     const supabase = createSupabaseBrowserClient();
@@ -47,13 +48,14 @@ export function LoginButton() {
   }
 
   return (
-    // Taller (48px) than the default control height and slightly tighter tracking
-    // for a premium primary CTA; the flex-column card stretches it to full width.
+    // Taller (48px) than the default control height; locale-aware tracking
+    // (tight negative for Latin, near-zero for Japanese so kana stays legible)
+    // for a premium primary CTA. The flex-column card stretches it to full width.
     <Button
       onClick={handleSignIn}
       type="button"
       variant="brand"
-      className="h-12 rounded-[13px] text-[15px] tracking-[-0.01em]"
+      className={`h-12 rounded-[13px] text-[15px] ${isJa ? "tracking-[0.01em]" : "tracking-[-0.01em]"}`}
     >
       <GoogleGLogo />
       {t("googleButton")}

--- a/frontend/src/app/login/page.test.tsx
+++ b/frontend/src/app/login/page.test.tsx
@@ -33,10 +33,14 @@ vi.mock("next-intl/server", () => ({
   getTranslations: vi.fn(async (namespace: "Login") =>
     createTranslator({ locale: "en", messages: enMessages, namespace }),
   ),
+  // Default to "en" so the existing Latin-tracking assertions hold; the ja test
+  // overrides this once to exercise the locale-aware typography branch.
+  getLocale: vi.fn(async () => "en"),
 }));
 
 import { headers } from "next/headers";
 import { createTranslator } from "next-intl";
+import { getLocale } from "next-intl/server";
 import enMessages from "../../../messages/en.json";
 import LoginPage from "./page";
 
@@ -206,5 +210,27 @@ describe("LoginPage", () => {
     render(jsx);
 
     expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  // Apple's Japanese typography uses locale-specific letter-spacing: Latin display
+  // text takes negative tracking, Japanese does not (it cramps kana). These pin
+  // that the heading switches treatment with the active locale.
+  describe("locale-aware typography (apple.com/jp)", () => {
+    it("en (default): heading carries tight Latin negative tracking", async () => {
+      const jsx = await LoginPage({ searchParams: Promise.resolve({}) });
+      const { container } = render(jsx);
+
+      expect(container.querySelector("h1")?.className).toMatch(/tracking-\[-0\.018em\]/);
+    });
+
+    it("ja: heading drops Latin negative tracking so kana is not cramped", async () => {
+      vi.mocked(getLocale).mockResolvedValueOnce("ja");
+      const jsx = await LoginPage({ searchParams: Promise.resolve({}) });
+      const { container } = render(jsx);
+
+      const h1 = container.querySelector("h1");
+      expect(h1?.className).not.toMatch(/tracking-\[-/);
+      expect(h1?.className).toMatch(/tracking-\[0\.01em\]/);
+    });
   });
 });

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
-import { getTranslations } from "next-intl/server";
+import { getLocale, getTranslations } from "next-intl/server";
 import type { ReactNode } from "react";
 import { FlamingoMark } from "@/components/brand/flamingo-mark";
 import { readAuthContext } from "@/lib/supabase/auth-status";
@@ -19,6 +19,13 @@ export default async function LoginPage({ searchParams }: { searchParams: Search
 
   const t = await getTranslations("Login");
   const { error } = await searchParams;
+
+  // Locale-aware tracking, mirroring apple.com/jp's locale-specific
+  // letter-spacing: Latin display text takes tight negative tracking, while
+  // Japanese takes near-zero / slightly positive tracking (negative tracking
+  // cramps kana) plus the wider leading dense Japanese glyphs need. Proportional
+  // metrics (palt) are enabled globally for `:lang(ja)` in globals.css.
+  const isJa = (await getLocale()) === "ja";
 
   // Both footer rich-text tags render the same styled link, differing only in href.
   const footerLink = (href: string) => (chunks: ReactNode) => (
@@ -53,10 +60,15 @@ export default async function LoginPage({ searchParams }: { searchParams: Search
         <div className="relative flex flex-col items-center gap-[34px] px-[55px] text-center">
           <FlamingoMark background={false} className="size-[144px]" />
           <div className="flex flex-col items-center gap-[13px]">
-            <span className="text-[55px] font-semibold leading-[1.05] tracking-[-0.025em] text-white drop-shadow-[0_2px_12px_rgba(120,20,40,0.45)]">
+            {/* Wordmark is always Latin → tight Apple-display negative tracking. */}
+            <span className="text-[55px] font-semibold leading-[1.05] tracking-[-0.02em] text-white drop-shadow-[0_2px_12px_rgba(120,20,40,0.45)]">
               Flamingo Armond
             </span>
-            <span className="text-[21px] font-medium leading-[1.45] tracking-[-0.01em] text-white/90 drop-shadow-[0_1px_6px_rgba(120,20,40,0.35)]">
+            <span
+              className={`text-[21px] font-medium text-white/90 drop-shadow-[0_1px_6px_rgba(120,20,40,0.35)] ${
+                isJa ? "leading-[1.6] tracking-[0.03em]" : "leading-[1.45] tracking-[-0.01em]"
+              }`}
+            >
               {t("tagline")}
             </span>
           </div>
@@ -79,10 +91,20 @@ export default async function LoginPage({ searchParams }: { searchParams: Search
           <div className="w-full max-w-[377px]">
             <div className="flex flex-col gap-[21px] rounded-[21px] border border-border/70 bg-card p-[34px] shadow-[0_1px_2px_rgba(0,0,0,0.04),0_12px_32px_-12px_rgba(0,0,0,0.12)]">
               <div className="flex flex-col gap-[13px] text-start">
-                <h1 className="text-[28px] font-semibold leading-[1.15] tracking-[-0.02em]">
+                <h1
+                  className={`text-[28px] font-semibold ${
+                    isJa ? "leading-[1.25] tracking-[0.01em]" : "leading-[1.15] tracking-[-0.018em]"
+                  }`}
+                >
                   {t("heading")}
                 </h1>
-                <p className="text-[15px] leading-[1.55] text-muted-foreground">{t("googleCta")}</p>
+                <p
+                  className={`text-[15px] text-muted-foreground ${
+                    isJa ? "leading-[1.8] tracking-[0.02em]" : "leading-[1.55] tracking-[-0.006em]"
+                  }`}
+                >
+                  {t("googleCta")}
+                </p>
               </div>
 
               {error && (
@@ -95,7 +117,11 @@ export default async function LoginPage({ searchParams }: { searchParams: Search
 
               <LoginButton />
 
-              <footer className="border-t pt-[21px] text-[12px] leading-[1.5] text-muted-foreground text-center">
+              <footer
+                className={`border-t pt-[21px] text-[12px] text-muted-foreground text-center ${
+                  isJa ? "leading-[1.7] tracking-[0.01em]" : "leading-[1.5]"
+                }`}
+              >
                 {t.rich("terms", {
                   terms: footerLink("/terms"),
                   privacy: footerLink("/privacy"),


### PR DESCRIPTION
## Summary

Refines the `/login` screen's typography, kerning, and spacing to match apple.com/jp's bilingual type treatment. The two substantive fixes: Japanese text now gets proportional-width metrics (`palt`) so kana and full-width punctuation (`、` `。`) stop reading as gappy full-width boxes, and letter-spacing / line-height are now locale-aware so Latin display tracking is no longer applied to Japanese (which cramps kana). **Presentational only — no behaviour, copy, or markup-structure change.**

No linked issue — UI-polish follow-up to the existing login split-screen redesign.

## Background / Motivation

- The global `body` rule set `font-feature-settings: "kern" "liga" "calt"` — all **Latin-only** OpenType features. Japanese had no `palt`, so the tagline `少ない学習で、より多く記憶。` rendered with the wide full-width gaps after `、` and around `。` that premium Japanese web typography (apple.com/jp, note, …) removes.
- The same Tailwind classes drove both locales, so Latin's negative tracking landed on Japanese: the `ログイン` heading carried `tracking-[-0.02em]` and the tagline `tracking-[-0.01em]` — negative tracking cramps kana/katakana.
- Japanese body copy inherited Latin's line-height (`1.55`); dense Japanese glyphs need more leading than Latin at the same size.

## Changes

### Japanese kerning via `palt` (globals.css)

- Added a `:lang(ja)` base rule re-declaring `"kern" "liga" "calt"` **plus `"palt" 1`**, so proportional-width metrics activate for Japanese only. Gated on `<html lang>` and a no-op on Latin runs (Inter exposes no `palt` table), so non-`ja` locales keep the existing body set. Placed at the language root — apple.com/jp applies `palt` site-wide, not per component — so every Japanese surface benefits, not just `/login`.

### Locale-aware tracking & leading (login/page.tsx, login/login-button.tsx)

- `LoginPage` now reads `getLocale()` and branches each text element. Latin keeps tight Apple-display negative tracking; Japanese switches to near-zero / slightly-positive tracking plus wider leading:
  - Wordmark (always Latin): `-0.025em` → `-0.02em`.
  - Heading 28px: en `-0.018em`/`leading-1.15`, ja `+0.01em`/`leading-1.25`.
  - Lede 15px: en `-0.006em`/`leading-1.55`, ja `+0.02em`/`leading-1.8`.
  - Tagline 21px: en `-0.01em`/`leading-1.45`, ja `+0.03em`/`leading-1.6`.
  - Footer 12px: en `leading-1.5`, ja `+0.01em`/`leading-1.7`.
- `LoginButton` reads `useLocale()` for the same split on the CTA: en `-0.01em`, ja `+0.01em`.
- Font sizes (55 / 28 / 21 / 15, Fibonacci) and the φ² vertical rhythm are deliberately left untouched — only tracking, leading, and `palt` were adjusted.

### Tests

- `page.test.tsx`: mocked `next-intl/server` now also returns `getLocale` (defaults to `en`, overridden once for the ja case). Added a `locale-aware typography` block pinning the design rule — the heading carries `tracking-[-0.018em]` under en and **must not** carry any negative tracking under ja (asserts `tracking-[0.01em]`).
- Existing layout / role / a11y assertions unchanged (class strings for `h-svh`, `lg:grid-cols-2`, visibility toggles were not touched).

## Verification

```bash
# palt is enabled for Japanese only, at the language root:
grep -n 'palt' frontend/src/app/globals.css         # → :lang(ja) rule

# No negative tracking is hardcoded for the Japanese branch of any login element:
grep -nE 'isJa \? .*tracking-\[-' \
  frontend/src/app/login/page.tsx frontend/src/app/login/login-button.tsx
# → no output
```

Runtime: load `/login` with the locale cookie set to `ja` and confirm the gap after `、` in the tagline tightens and the rating heading no longer looks cramped; switch to `en` and confirm Latin keeps its tighter display tracking.

## Test plan

- [x] `pnpm typecheck` / `pnpm lint` (`biome --error-on-warnings`) / `pnpm knip` — clean.
- [x] `pnpm test` — 1370 passed (incl. the new en/ja typography assertions).
- [x] `pnpm build` — Next.js production build green.
- [x] CJK + PR-order language-policy greps clean on the diff (no source strings added).
