### PR TITLE
refactor(admin): route admin list search through useDebouncedSearch

### DIFF
--- a/frontend/src/app/admin/masters/admin-masters-client.tsx
+++ b/frontend/src/app/admin/masters/admin-masters-client.tsx
@@ -4,7 +4,7 @@ import { NetworkStatus } from "@apollo/client";
 import { Plus } from "lucide-react";
 import Link from "next/link";
 import { useTranslations } from "next-intl";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { ListingPageShell } from "@/components/layout/listing-page-shell";
 import { Button } from "@/components/ui/button";
@@ -14,6 +14,7 @@ import type {
   AdminMastersQuery as AdminMastersQueryResult,
   AdminMastersQueryVariables,
 } from "@/generated/graphql";
+import { useDebouncedSearch } from "@/hooks/use-debounced-search";
 import { classifyQueryError, getBackendErrorBanner } from "@/lib/apollo/errors";
 import { useConnectionPagination } from "@/lib/pagination/use-connection-pagination";
 import { useSheetSearchParam } from "@/lib/url/use-sheet-search-param";
@@ -60,8 +61,8 @@ function mergeMastersConnection(
 export function AdminMastersClient() {
   const t = useTranslations("AdminMasters");
   const tCommon = useTranslations("Common");
-  const [searchInput, setSearchInput] = useState("");
-  const [searchQuery, setSearchQuery] = useState<string | null>(null);
+  const search = useDebouncedSearch();
+  const searchQuery = search.query;
   const [createDirty, setCreateDirty] = useState(false);
   const [createValidationError, setCreateValidationError] = useState<{
     field: string;
@@ -72,12 +73,6 @@ export function AdminMastersClient() {
     message: string;
   } | null>(null);
   const sheet = useSheetSearchParam();
-
-  // Debounce search 300ms after the last keystroke.
-  useEffect(() => {
-    const timer = setTimeout(() => setSearchQuery(searchInput.trim() || null), 300);
-    return () => clearTimeout(timer);
-  }, [searchInput]);
 
   // The cache key is ADMIN_MASTERS_BASE_VARS + the active search; the create handler reads and
   // writes the search=null variant. Memoize on searchQuery so the hook's
@@ -268,8 +263,8 @@ export function AdminMastersClient() {
         <Input
           type="search"
           placeholder={t("searchPlaceholder")}
-          value={searchInput}
-          onChange={(e) => setSearchInput(e.target.value)}
+          value={search.input}
+          onChange={(e) => search.setInput(e.target.value)}
           aria-label={t("searchLabel")}
         />
       </div>

--- a/frontend/src/app/admin/users/admin-users-client.tsx
+++ b/frontend/src/app/admin/users/admin-users-client.tsx
@@ -4,13 +4,14 @@ import { NetworkStatus } from "@apollo/client";
 import { useLazyQuery, useQuery } from "@apollo/client/react";
 import Link from "next/link";
 import { useTranslations } from "next-intl";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import { toast } from "sonner";
 import { useFragment } from "@/generated/fragment-masking";
 import type {
   AdminUsersQuery as AdminUsersQueryResult,
   AdminUsersQueryVariables,
 } from "@/generated/graphql";
+import { useDebouncedSearch } from "@/hooks/use-debounced-search";
 import {
   classifyQueryError,
   getBackendErrorBanner,
@@ -103,17 +104,9 @@ export function AdminUsersClient() {
   const t = useTranslations("Admin");
   const tCommon = useTranslations("Common");
   const tNav = useTranslations("Nav");
-  const [searchInput, setSearchInput] = useState("");
-  const [searchQuery, setSearchQuery] = useState<string | null>(null);
+  const search = useDebouncedSearch();
+  const searchQuery = search.query;
   const sheet = useSheetSearchParam();
-
-  // Debounce: update searchQuery 300ms after the last keystroke.
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      setSearchQuery(searchInput.trim() || null);
-    }, 300);
-    return () => clearTimeout(timer);
-  }, [searchInput]);
 
   // The cache key is { first, search }; memoize on searchQuery so the hook's
   // useQuery does not re-subscribe on unrelated re-renders.
@@ -250,8 +243,8 @@ export function AdminUsersClient() {
         <input
           type="search"
           placeholder={t("searchPlaceholder")}
-          value={searchInput}
-          onChange={(e) => setSearchInput(e.target.value)}
+          value={search.input}
+          onChange={(e) => search.setInput(e.target.value)}
           className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           aria-label={t("searchLabel")}
         />


### PR DESCRIPTION
## Summary

The two admin list clients (masters, users) still hand-rolled their own `searchInput` / `searchQuery` / `setTimeout(300)` debounce, while the other three cursor-paginated list screens (cards, cardgroups, catalog) already consumed the shared `useDebouncedSearch` hook. Both admin clients now route through that hook, so the 300ms constant, the `trim() || null` normalization, and the timer teardown live in one place — all five list screens now share the single debounce implementation. **Pure DRY refactor — no user-visible behaviour change.**

Closes #461.

## Background / Motivation

- `frontend/src/hooks/use-debounced-search.ts` already owns the debounce contract (`{ input, query, setInput, clear }`, 300ms default, `input.trim()` → `null` when empty). Three screens consumed it; the two admin clients duplicated the same `useState` pair + debounce `useEffect` by hand.
- A duplicated debounce means a fix to the timing or the empty-string normalization in the shared hook never reached the admin screens — the exact drift the DRY rule guards against.
- Reference consumer: `frontend/src/app/cardgroups/cardgroups-client.tsx` (`const search = useDebouncedSearch(); const searchQuery = search.query;`), wiring `search.input` / `search.setInput` to its toolbar — the shape both admin clients now mirror.

## Changes

### `app/admin/masters/admin-masters-client.tsx`

- Replaced the inline `[searchInput, setSearchInput]` / `[searchQuery, setSearchQuery]` `useState` pair and the 300ms debounce `useEffect` with `const search = useDebouncedSearch(); const searchQuery = search.query;`.
- Search `<Input>` now reads `value={search.input}` / `onChange={(e) => search.setInput(e.target.value)}`.
- Dropped the now-unused `useEffect` from the React import.

### `app/admin/users/admin-users-client.tsx`

- Same migration for the inline block; the search `<input>` now wires `search.input` / `search.setInput`.
- Dropped the now-unused `useState` from the React import (the loadAdminUser `useEffect` stays).

### Cache-key preservation

- The Apollo cache-key variables shape is byte-for-byte unchanged: masters keeps `{ ...ADMIN_MASTERS_BASE_VARS, search: searchQuery }`, users keeps `{ first: ADMIN_USERS_PAGE_SIZE, search: searchQuery }`, with `searchQuery` now derived from `search.query`. No SSR-seed / `useQuery` cache split.

## Verification

```bash
# No hand-rolled debounce timer remains in either admin client:
grep -n 'setTimeout' \
  frontend/src/app/admin/masters/admin-masters-client.tsx \
  frontend/src/app/admin/users/admin-users-client.tsx
# → (empty)

# All five cursor-paginated list screens consume the shared hook:
grep -rln "useDebouncedSearch" frontend/src/app --include='*.tsx' | grep -v test | sort
# → admin/masters, admin/users, cardgroups/[id]/cards/cards-client, cardgroups/cardgroups-client, catalog/catalog-client
```

## Test plan

- [x] `pnpm --filter frontend typecheck` — exit 0
- [x] `pnpm --filter frontend lint` (`biome check --error-on-warnings`) — clean, no fixes
- [x] `pnpm --filter frontend knip` — exit 0 (no dead exports after the `useState` / `useEffect` import trims)
- [x] `pnpm --filter frontend test` — 1368 passed (141 files), incl. `admin-masters-client.test.tsx` / `admin-users-client.test.tsx` + the broad `__tests__` page tests unchanged
- [x] `pnpm --filter frontend build` — success
- [x] No inline CJK in changed source
- [ ] Manual smoke: type in each admin search box — results still filter ~300ms after the last keystroke, empty input clears the filter
