### PR TITLE
fix(rsc): redact err.message from RSC console payloads (PII)

### DIFF
--- a/frontend/src/app/cardgroups/[id]/edit/page.tsx
+++ b/frontend/src/app/cardgroups/[id]/edit/page.tsx
@@ -40,11 +40,9 @@ export default async function EditCardgroupPage({ params }: Props) {
     ]);
   } catch (err) {
     if (isUnauthenticatedGraphQLError(err)) redirect("/cardgroups");
-    console.error(
-      "[cardgroups/:id/edit] gqlFetch failed:",
-      err instanceof Error ? err.name : "unknown",
-      err instanceof Error ? err.message : String(err),
-    );
+    console.error("[cardgroups/:id/edit] gqlFetch failed:", {
+      name: err instanceof Error ? err.name : "unknown",
+    });
     throw err;
   }
 

--- a/frontend/src/app/onboarding/page.test.tsx
+++ b/frontend/src/app/onboarding/page.test.tsx
@@ -119,11 +119,10 @@ describe("OnboardingPage — gqlFetch error branches", () => {
     await expect(OnboardingPage()).rejects.toBe(otherErr);
 
     expect(redirect).not.toHaveBeenCalled();
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
-      expect.stringContaining("[onboarding]"),
-      otherErr.name,
-      otherErr.message,
-    );
+    // PII redaction: only the error name is logged, never the message.
+    expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining("[onboarding]"), {
+      name: otherErr.name,
+    });
   });
 });
 

--- a/frontend/src/app/onboarding/page.tsx
+++ b/frontend/src/app/onboarding/page.tsx
@@ -18,11 +18,9 @@ export default async function OnboardingPage() {
     if (isUnauthenticatedGraphQLError(err)) {
       redirect("/login");
     }
-    console.error(
-      "[onboarding] gqlFetch failed:",
-      err instanceof Error ? err.name : "unknown",
-      err instanceof Error ? err.message : String(err),
-    );
+    console.error("[onboarding] gqlFetch failed:", {
+      name: err instanceof Error ? err.name : "unknown",
+    });
     throw err;
   }
 

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -18,11 +18,9 @@ export default async function HomePage() {
     if (isUnauthenticatedGraphQLError(err)) {
       redirect("/login");
     }
-    console.error(
-      "[home] gqlFetch failed:",
-      err instanceof Error ? err.name : "unknown",
-      err instanceof Error ? err.message : String(err),
-    );
+    console.error("[home] gqlFetch failed:", {
+      name: err instanceof Error ? err.name : "unknown",
+    });
     throw err;
   }
 

--- a/frontend/src/app/profile/page.test.tsx
+++ b/frontend/src/app/profile/page.test.tsx
@@ -157,7 +157,10 @@ describe("ProfilePage — gqlFetch error branches", () => {
     await expect(ProfilePage()).rejects.toBe(otherErr);
 
     expect(redirect).not.toHaveBeenCalled();
-    expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining("[profile]"), otherErr);
+    // PII redaction: only the error name is logged, never the message/object.
+    expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining("[profile]"), {
+      name: "Error",
+    });
   });
 });
 

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -33,7 +33,9 @@ export default async function ProfilePage() {
     if (isUnauthenticatedGraphQLError(err)) {
       redirect("/login");
     }
-    console.error("[profile] gqlFetch failed:", err);
+    console.error("[profile] gqlFetch failed:", {
+      name: err instanceof Error ? err.name : "unknown",
+    });
     throw err;
   }
   if (!data.me) {


### PR DESCRIPTION
## Summary

Four page-level RSCs logged `err.message` / a raw `err` object in their `gqlFetch` catch blocks, and `gqlFetch` error messages can carry backend-echoed user content (PII). They now log only the name-only shape `{ name: err instanceof Error ? err.name : "unknown" }`, mirroring the already-compliant `catalog` / `learn` pages. **No behaviour change beyond the log payload** — the `[scope]` prefix and `redirect()` / `throw err` control flow are untouched.

Closes #459.

## Background / Motivation

- The repo rule [`redact-err-message-from-console-payloads.md`](https://github.com/yasuflatland-lf/flamingo-armond/blob/main/docs/frontend/rsc-error-handling/redact-err-message-from-console-payloads.md) requires RSC `console` logs to omit `err.message`, because a `gqlFetch` error message can echo backend-supplied user content. Five pages already complied; four did not.
- `/profile` was the worst case — it logged the raw `err` object (`console.error("[profile] gqlFetch failed:", err)`), exposing the full message and any attached payload.
- `page.tsx` / `onboarding/page.tsx` logged `err.message` as a third positional argument; `cardgroups/[id]/edit/page.tsx` logged both `err.name` and `err.message`.

## Changes

### Name-only console payload (4 RSC pages)

- `app/page.tsx`, `app/onboarding/page.tsx`: replaced the `(name, message)` positional pair with the single `{ name: … }` object.
- `app/cardgroups/[id]/edit/page.tsx`: dropped the `err.message` argument, kept the name.
- `app/profile/page.tsx`: replaced the raw `err` object with the `{ name: … }` object.
- Scope is exactly these four files; the `try`/`catch` is not restructured and no `redirect()` / `throw err` path changes.

### Tests

- `app/onboarding/page.test.tsx`, `app/profile/page.test.tsx`: updated the non-UNAUTHENTICATED-error assertions from the old `(name, message)` / raw-`err` shape to `{ name: … }`. The new assertions now positively prove the message (PII) is never logged.
- `app/page.test.tsx` is unaffected — its only `console.error` assertion is the single-argument `myCardgroupsConnection is null` path, not the `gqlFetch failed` path.

## Verification

```bash
# Acceptance grep — no err.message / String(err) / bare err reaches console.error:
grep -nE 'err\.message|String\(err\)|failed:", err' \
  frontend/src/app/page.tsx frontend/src/app/onboarding/page.tsx \
  'frontend/src/app/cardgroups/[id]/edit/page.tsx' frontend/src/app/profile/page.tsx
# → no output
```

Runtime: trigger a non-auth `gqlFetch` failure on any of the four routes and confirm the server log line carries only `{ name: "<ErrorName>" }`, never the message text.

## Test plan

- [x] `pnpm --filter frontend typecheck` (`tsc --noEmit`) — no errors.
- [x] biome (`./node_modules/.bin/biome check --error-on-warnings`) — clean on all 6 edited files.
- [x] `pnpm --filter frontend knip` — clean.
- [x] `pnpm --filter frontend test` (`vitest run`) — 1368 passed, 0 failed.
- [x] `pnpm --filter frontend build` — Next.js production build green.
- [x] CJK + PR-order language-policy greps clean on the diff.
