### PR TITLE
refactor(forms): extract shared DirtyStateBridge (dedupe 3 copies)

### DIFF
--- a/frontend/src/app/admin/masters/admin-master-form.tsx
+++ b/frontend/src/app/admin/masters/admin-master-form.tsx
@@ -2,7 +2,7 @@
 
 import { useForm } from "@tanstack/react-form";
 import { useTranslations } from "next-intl";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -19,6 +19,7 @@ import { Button, buttonVariants } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
+import { DirtyStateBridge } from "@/lib/forms/dirty-state-bridge";
 import { FieldError } from "@/lib/forms/field-error";
 import { masterSchema } from "@/schemas/master";
 import type { AdminMasterListItem } from "./admin-master-row";
@@ -50,19 +51,6 @@ type Props = {
 function emptyToNull(s: string): string | null {
   const trimmed = s.trim();
   return trimmed.length === 0 ? null : trimmed;
-}
-
-function DirtyStateBridge({
-  dirty,
-  onDirtyChange,
-}: {
-  dirty: boolean;
-  onDirtyChange?: (dirty: boolean) => void;
-}) {
-  useEffect(() => {
-    onDirtyChange?.(dirty);
-  }, [dirty, onDirtyChange]);
-  return null;
 }
 
 export function AdminMasterForm({

--- a/frontend/src/app/profile/profile-form.tsx
+++ b/frontend/src/app/profile/profile-form.tsx
@@ -8,6 +8,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
+import { DirtyStateBridge } from "@/lib/forms/dirty-state-bridge";
 import { FieldError } from "@/lib/forms/field-error";
 import { updateProfileSchema } from "@/schemas/profile";
 import { useUpdateProfile } from "./use-update-profile";
@@ -23,20 +24,6 @@ type Props = {
   onSaved?: () => void;
   onSubmittingChange?: (submitting: boolean) => void;
 };
-
-function DirtyStateBridge({
-  dirty,
-  onDirtyChange,
-}: {
-  dirty: boolean;
-  onDirtyChange?: (dirty: boolean) => void;
-}) {
-  useEffect(() => {
-    onDirtyChange?.(dirty);
-  }, [dirty, onDirtyChange]);
-
-  return null;
-}
 
 export function ProfileForm({
   email,

--- a/frontend/src/components/admin/role-form.tsx
+++ b/frontend/src/components/admin/role-form.tsx
@@ -2,11 +2,12 @@
 
 import { useForm } from "@tanstack/react-form";
 import { useTranslations } from "next-intl";
-import { useEffect, useMemo } from "react";
+import { useMemo } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { getBackendErrorBanner, getBackendFieldErrors } from "@/lib/apollo/errors";
+import { DirtyStateBridge } from "@/lib/forms/dirty-state-bridge";
 import { FieldError } from "@/lib/forms/field-error";
 import { roleSchema } from "@/schemas/role";
 
@@ -25,20 +26,6 @@ type RoleFormProps = {
   onCancel?: () => void;
   onDirtyChange?: (dirty: boolean) => void;
 };
-
-function DirtyStateBridge({
-  dirty,
-  onDirtyChange,
-}: {
-  dirty: boolean;
-  onDirtyChange?: (dirty: boolean) => void;
-}) {
-  useEffect(() => {
-    onDirtyChange?.(dirty);
-  }, [dirty, onDirtyChange]);
-
-  return null;
-}
 
 export function RoleForm({
   defaultValues,

--- a/frontend/src/lib/forms/dirty-state-bridge.tsx
+++ b/frontend/src/lib/forms/dirty-state-bridge.tsx
@@ -1,0 +1,19 @@
+import { useEffect } from "react";
+
+/**
+ * Bridges a TanStack Form `isDirty` subscription value to a parent callback
+ * (e.g. to drive FormSheet's discard guard). Renders nothing.
+ */
+export function DirtyStateBridge({
+  dirty,
+  onDirtyChange,
+}: {
+  dirty: boolean;
+  onDirtyChange?: (dirty: boolean) => void;
+}) {
+  useEffect(() => {
+    onDirtyChange?.(dirty);
+  }, [dirty, onDirtyChange]);
+
+  return null;
+}


### PR DESCRIPTION
## Summary

`admin-master-form.tsx`, `profile-form.tsx`, and `role-form.tsx` each declared a byte-near-identical 10-line `DirtyStateBridge` — a render-nothing component that bridges a TanStack Form `isDirty` subscription value to the parent's `onDirtyChange` callback. The component now lives once in `lib/forms/dirty-state-bridge.tsx` and all three forms import it. **Pure DRY refactor — no user-visible behaviour change.**

Closes #460.

## Background / Motivation

- The same `DirtyStateBridge` declaration appeared in three form files; a change to its effect deps or the bridge contract had to be applied in three places.
- `admin-master-form.tsx` carried a one-line whitespace drift from the other two copies (no blank line before `return null`), so the three were functionally — but not literally — identical. The extraction collapses that drift to a single canonical source.
- `lib/forms/` already hosts the shared `field-error.tsx` form helper, so the directory is the established home for cross-form presentational helpers.
- FE Tier 1 functional-cohesion follow-up (issue #460, 3/5). File-disjoint from the PII-logging and admin-debounce items; shares `role-form.tsx` with the i18n-leaks item on disjoint lines, so this lands first.

## Changes

### New `lib/forms/dirty-state-bridge.tsx`

- Exports `DirtyStateBridge({ dirty, onDirtyChange })` — a `useEffect`-only component that calls `onDirtyChange?.(dirty)` whenever `dirty` changes and renders `null`. Carries the canonical docstring describing the FormSheet discard-guard use.

### `admin-master-form.tsx` / `profile-form.tsx` / `role-form.tsx` (deduped)

- Deleted the local `function DirtyStateBridge` declaration from each and added `import { DirtyStateBridge } from "@/lib/forms/dirty-state-bridge"`. The JSX usage `<DirtyStateBridge dirty={dirty} onDirtyChange={onDirtyChange} />` is unchanged in all three.
- `admin-master-form.tsx` and `role-form.tsx` dropped the now-unused `useEffect` import (keeping `useState` / `useMemo` respectively); `profile-form.tsx` keeps `useEffect` because two other effects still use it.

### Tests

- No new test. `DirtyStateBridge` is behaviour-identical to the three deleted copies and is exercised through each consuming form's existing tests, which pass unchanged — the behaviour-preserving proof. knip stays clean because the export has three production callers.

## Verification

```bash
# No local (non-exported) copy remains in the consumer dirs — the export is the single source:
grep -rn 'function DirtyStateBridge' frontend/src/app frontend/src/components
# -> no output

# Exactly 1 export + 3 imports + 3 usages:
grep -rn 'DirtyStateBridge' frontend/src
# -> lib/forms/dirty-state-bridge.tsx (export) + 3 imports + 3 <DirtyStateBridge .../> usages
```

## Test plan

- [x] `pnpm --filter frontend typecheck` — exit 0
- [x] `pnpm --filter frontend lint` (`biome check --error-on-warnings`) — clean
- [x] `pnpm --filter frontend knip` — exit 0 (export wired; no dead code)
- [x] `pnpm --filter frontend test` — 1368 passed (141 files)
- [x] `pnpm --filter frontend build` — success
- [x] No inline CJK in changed source
