### PR TITLE
fix(i18n): route hardcoded form strings through next-intl

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -100,6 +100,7 @@
     "fetchMoreError": "Could not load more cardgroups. Please try again.",
     "deleteReloadError": "Could not delete cardgroup. Please reload and try again.",
     "sessionExpired": "Your session has expired. ",
+    "sessionExpiredSignIn": "Your session expired. Please sign in again.",
     "noPermission": "You do not have permission. ",
     "signInAgain": "Sign in again",
     "deleteAriaLabel": "Delete cardgroup {name}",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -100,6 +100,7 @@
     "fetchMoreError": "カードグループをさらに読み込めませんでした。もう一度お試しください。",
     "deleteReloadError": "カードグループを削除できませんでした。ページを再読み込みしてください。",
     "sessionExpired": "セッションの有効期限が切れました。",
+    "sessionExpiredSignIn": "セッションの有効期限が切れました。もう一度ログインしてください。",
     "noPermission": "権限がありません。",
     "signInAgain": "再度ログイン",
     "deleteAriaLabel": "カードグループ「{name}」を削除",

--- a/frontend/src/components/admin/role-form.tsx
+++ b/frontend/src/components/admin/role-form.tsx
@@ -38,6 +38,7 @@ export function RoleForm({
   onDirtyChange,
 }: RoleFormProps) {
   const t = useTranslations("Admin");
+  const tCommon = useTranslations("Common");
   const nameSchema = roleSchema.shape.name;
 
   const fieldErrors = useMemo(() => getBackendFieldErrors(error), [error]);
@@ -99,7 +100,7 @@ export function RoleForm({
 
       <div className="flex items-center gap-2">
         <Button type="submit" variant="brand" disabled={submitting || readOnly}>
-          {submitting ? "Saving..." : submitLabel}
+          {submitting ? tCommon("saving") : submitLabel}
         </Button>
         {onCancel ? (
           <Button type="button" variant="outline" onClick={onCancel}>

--- a/frontend/src/components/cardgroups/card-form.tsx
+++ b/frontend/src/components/cardgroups/card-form.tsx
@@ -45,6 +45,7 @@ export function CardForm({
   onCancel,
 }: CardFormProps) {
   const t = useTranslations("Cards");
+  const tCommon = useTranslations("Common");
   const resolvedLabel = submitLabel ?? (mode === "create" ? "Add" : "Save");
   const schema = mode === "create" ? newCardSchema.omit({ cardgroupId: true }) : updateCardSchema;
   const frontSchema = schema.shape.front;
@@ -132,7 +133,7 @@ export function CardForm({
 
       <div className="flex items-center gap-2">
         <Button type="submit" variant="brand" disabled={submitting}>
-          {submitting ? "Saving..." : resolvedLabel}
+          {submitting ? tCommon("saving") : resolvedLabel}
         </Button>
         {onCancel && (
           <Button type="button" variant="outline" onClick={onCancel}>

--- a/frontend/src/components/cardgroups/cardgroup-form.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-form.tsx
@@ -45,6 +45,7 @@ export function CardgroupForm({
   secondarySlot,
 }: CardgroupFormProps) {
   const t = useTranslations("Cardgroups");
+  const tCommon = useTranslations("Common");
   const resolvedLabel = submitLabel ?? (mode === "create" ? "Create" : "Save");
 
   const schema = mode === "create" ? newCardgroupSchema : updateCardgroupSchema;
@@ -107,7 +108,7 @@ export function CardgroupForm({
 
       <div className="flex items-center gap-2">
         <Button type="submit" variant="brand" disabled={submitting}>
-          {submitting ? "Saving..." : resolvedLabel}
+          {submitting ? tCommon("saving") : resolvedLabel}
         </Button>
         {secondarySlot}
       </div>

--- a/frontend/src/components/cardgroups/cardgroup-rename-form.test.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-rename-form.test.tsx
@@ -3,6 +3,7 @@ import type { MockedResponse } from "@apollo/client/testing";
 import { MockedProvider } from "@apollo/client/testing/react";
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { GraphQLError } from "graphql";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { UpdateCardgroupDocument } from "@/generated/graphql";
 import { renderWithIntl } from "@/test/render-with-intl";
@@ -109,6 +110,30 @@ describe("<CardgroupRenameForm>", () => {
 
     await waitFor(() => {
       expect(screen.getByText("Could not reach the server. Please try again.")).toBeInTheDocument();
+    });
+    expect(mockRefresh).not.toHaveBeenCalled();
+    expect(onSaved).not.toHaveBeenCalled();
+  });
+
+  it("UNAUTHENTICATED rejection shows the session-expired banner and keeps the form open", async () => {
+    const user = userEvent.setup();
+    const { onSaved } = renderForm([
+      makeUpdateMock(
+        { id: "cg-1", input: { name: "Spanish Vocab" } },
+        {
+          errors: [
+            new GraphQLError("Unauthenticated", {
+              extensions: { code: "UNAUTHENTICATED" },
+            }),
+          ],
+        },
+      ),
+    ]);
+
+    await user.click(screen.getByRole("button", { name: /^save$/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/your session has expired/i)).toBeInTheDocument();
     });
     expect(mockRefresh).not.toHaveBeenCalled();
     expect(onSaved).not.toHaveBeenCalled();

--- a/frontend/src/components/cardgroups/cardgroup-rename-form.test.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-rename-form.test.tsx
@@ -133,7 +133,7 @@ describe("<CardgroupRenameForm>", () => {
     await user.click(screen.getByRole("button", { name: /^save$/i }));
 
     await waitFor(() => {
-      expect(screen.getByText(/your session has expired/i)).toBeInTheDocument();
+      expect(screen.getByText("Your session expired. Please sign in again.")).toBeInTheDocument();
     });
     expect(mockRefresh).not.toHaveBeenCalled();
     expect(onSaved).not.toHaveBeenCalled();

--- a/frontend/src/components/cardgroups/cardgroup-rename-form.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-rename-form.tsx
@@ -56,7 +56,7 @@ export function CardgroupRenameForm({ cardgroup, onSaved, onSubmittingChange }: 
       });
       const codes = liftGraphQLCodes(err);
       if (codes.includes("UNAUTHENTICATED")) {
-        setBannerMessage(t("sessionExpired"));
+        setBannerMessage(t("sessionExpiredSignIn"));
         return null;
       }
       const banner = getBackendErrorBanner(err) ?? tCommon("somethingWentWrong");

--- a/frontend/src/components/cardgroups/cardgroup-rename-form.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-rename-form.tsx
@@ -2,6 +2,7 @@
 
 import { useMutation } from "@apollo/client/react";
 import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
 import { useEffect, useState } from "react";
 import { UpdateCardgroupMutation } from "@/app/cardgroups/queries";
 import { CardgroupForm } from "@/components/cardgroups/cardgroup-form";
@@ -16,6 +17,8 @@ type Props = {
 
 export function CardgroupRenameForm({ cardgroup, onSaved, onSubmittingChange }: Props) {
   const router = useRouter();
+  const t = useTranslations("Cardgroups");
+  const tCommon = useTranslations("Common");
 
   // Typed InputValidationError variant — field-level validation failure
   // surfaced by the server via the outcome union. Cleared on each new submission.
@@ -53,10 +56,10 @@ export function CardgroupRenameForm({ cardgroup, onSaved, onSubmittingChange }: 
       });
       const codes = liftGraphQLCodes(err);
       if (codes.includes("UNAUTHENTICATED")) {
-        setBannerMessage("Your session expired. Please sign in again.");
+        setBannerMessage(t("sessionExpired"));
         return null;
       }
-      const banner = getBackendErrorBanner(err) ?? "Something went wrong. Please try again.";
+      const banner = getBackendErrorBanner(err) ?? tCommon("somethingWentWrong");
       setBannerMessage(banner);
       return null;
     });
@@ -83,7 +86,7 @@ export function CardgroupRenameForm({ cardgroup, onSaved, onSubmittingChange }: 
     console.warn("[CardgroupRenameForm] unexpected updateCardgroup payload", {
       typename: unknownPayload?.__typename ?? null,
     });
-    setBannerMessage("Something went wrong. Please try again.");
+    setBannerMessage(tCommon("somethingWentWrong"));
   }
 
   return (


### PR DESCRIPTION
## Summary

`role-form.tsx`, `card-form.tsx`, and `cardgroup-form.tsx` hardcoded `"Saving..."`, and `cardgroup-rename-form.tsx` hardcoded three banner strings (session-expired + two something-went-wrong) — all bypassing the next-intl catalog. Because Playwright e2e runs in the `ja-JP` locale, these rendered English against an otherwise Japanese UI — a real locale bug vitest cannot catch. All four forms now route those strings through the catalog, and the rename form's English UNAUTHENTICATED banner keeps its "Please sign in again." call-to-action via a new full-sentence key. **No behaviour change beyond the resolved copy** — the `.catch` control flow and console logging are untouched.

Closes #462.

## Background / Motivation

- Six hardcoded English strings sat in four form components; e2e (`ja-JP`) would render them in English, and vitest (en-default `renderWithIntl`) never surfaces the mismatch.
- The "Saving..." and something-went-wrong targets already had keys: `Common.saving` and `Common.somethingWentWrong` are byte-identical to the literals they replace, so those swaps are pure routing.
- `Cardgroups.sessionExpired` is a trailing-space FRAGMENT (`"Your session has expired. "`) that `cardgroups-client.tsx` / `new-cardgroup-client.tsx` concatenate with a `<Link>{t("signInAgain")}</Link>`. Reusing it for the rename form's standalone banner would silently drop the English "Please sign in again." CTA — so a new full-sentence key was added rather than mutating the shared fragment.
- FE Tier 1 functional-cohesion follow-up (issue #462, 4/5). Shares `role-form.tsx` with the DirtyStateBridge item (#460, merged) on disjoint lines.

## Changes

### `"Saving..."` → `tCommon("saving")` (3 forms)

- `admin/role-form.tsx`, `cardgroups/card-form.tsx`, `cardgroups/cardgroup-form.tsx`: each adds `const tCommon = useTranslations("Common")` and swaps the `submitting ? "Saving..." : <label>` literal for `tCommon("saving")`. The pre-existing `t` hook stays in use; resolved English copy is unchanged.

### `cardgroup-rename-form.tsx` banners → catalog

- Added the `next-intl` import plus `t = useTranslations("Cardgroups")` / `tCommon = useTranslations("Common")` hooks.
- UNAUTHENTICATED branch → `t("sessionExpiredSignIn")`; the `getBackendErrorBanner(err) ??` fallback and the unexpected-payload banner → `tCommon("somethingWentWrong")`. The `.catch` control flow and `console.error` / `console.warn` logging are unchanged.

### New `Cardgroups.sessionExpiredSignIn` key (en + ja)

- en: `"Your session expired. Please sign in again."` / ja: `"セッションの有効期限が切れました。もう一度ログインしてください。"` — added to both catalogs, byte-matching the established `Profile.sessionExpired` copy.
- Restores the rename form's English CTA without touching the `Cardgroups.sessionExpired` fragment, so the `cardgroups-client.tsx` / `new-cardgroup-client.tsx` `<span>fragment</span><Link>` composition is unaffected.

### Tests

- `cardgroup-rename-form.test.tsx`: added an UNAUTHENTICATED-rejection case (mocks a `GraphQLError` carrying `extensions.code: "UNAUTHENTICATED"`, asserts the banner shows "Your session expired. Please sign in again." and that `onSaved` / `router.refresh` are not called). Pins the one branch this PR rewrote, which previously had zero direct coverage.

## Verification

```bash
# No hardcoded target strings remain in the four forms:
grep -rn '"Saving\.\.\."\|"Your session expired\|"Something went wrong' \
  frontend/src/components/admin/role-form.tsx \
  frontend/src/components/cardgroups/card-form.tsx \
  frontend/src/components/cardgroups/cardgroup-form.tsx \
  frontend/src/components/cardgroups/cardgroup-rename-form.tsx
# -> no output

# The shared fragment key is untouched; both consumers still read it:
grep -rn 't("sessionExpired")' frontend/src/app/cardgroups
# -> cardgroups-client.tsx + new-cardgroup-client.tsx (unchanged)
```

Runtime: in `ja-JP`, trigger a cardgroup rename submit while signed out — the banner now reads "セッションの有効期限が切れました。もう一度ログインしてください。" (was English).

## Test plan

- [x] `pnpm --filter frontend typecheck` (`tsc --noEmit`) — exit 0
- [x] `pnpm --filter frontend lint` (`biome check --error-on-warnings`) — clean, no fixes
- [x] `pnpm --filter frontend knip` — exit 0 (no new exports; catalog change is data)
- [x] `pnpm --filter frontend test` — 1371 passed (141 files), incl. the new rename-form UNAUTHENTICATED case
- [x] `pnpm --filter frontend build` — success (28 static pages)
- [x] CJK guard clean on changed source (`messages/*.json` exempt by language-policy)
- [x] e2e static check — no `frontend/e2e` spec asserts the changed strings or the rename form
