### PR TITLE
fix(backend): introspection gate, master-status validity, and SuperUserPromoter logger

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -48,11 +48,20 @@ const defaultShutdownTimeout = 25 * time.Second
 
 type serverConfig struct {
 	shutdownTimeout time.Duration
+	// introspectionEnabled is the single source of truth for whether GraphQL
+	// introspection (and the Playground UI that depends on it) is served.
+	// Resolved from one predicate so the schema-introspection gate and the
+	// Playground route gate can never disagree.
+	introspectionEnabled bool
 }
 
 // serverConfigFromEnv builds a serverConfig from environment variables.
 // SHUTDOWN_TIMEOUT accepts any value accepted by time.ParseDuration; invalid
 // or non-positive values fall back to defaultShutdownTimeout with a WARN log.
+//
+// Introspection is fail-safe: enabled only when GRAPHQL_INTROSPECTION is exactly
+// "on". Unset or any other value (including "true") keeps the schema hidden so a
+// new deploy target cannot leak it by forgetting to set the variable.
 func serverConfigFromEnv(logger *slog.Logger) serverConfig {
 	shutdownDur := defaultShutdownTimeout
 	if v := os.Getenv("SHUTDOWN_TIMEOUT"); v != "" {
@@ -68,7 +77,8 @@ func serverConfigFromEnv(logger *slog.Logger) serverConfig {
 		}
 	}
 	return serverConfig{
-		shutdownTimeout: shutdownDur,
+		shutdownTimeout:      shutdownDur,
+		introspectionEnabled: os.Getenv("GRAPHQL_INTROSPECTION") == "on",
 	}
 }
 
@@ -187,7 +197,7 @@ func buildResolver(
 	return resolvers, pingHandler, notionSyncHandler, nil
 }
 
-func newGraphQLServer(r *resolver.Resolver) *handler.Server {
+func newGraphQLServer(r *resolver.Resolver, introspectionEnabled bool) *handler.Server {
 	srv := handler.New(generated.NewExecutableSchema(generated.Config{Resolvers: r}))
 	srv.AddTransport(transport.Options{})
 	srv.AddTransport(transport.POST{
@@ -200,11 +210,11 @@ func newGraphQLServer(r *resolver.Resolver) *handler.Server {
 
 	srv.Use(extension.FixedComplexityLimit(100))
 
-	// Introspection is fail-safe: opt-in only. Enabled when
-	// GRAPHQL_INTROSPECTION is exactly "on"; unset or any other value keeps
-	// the schema hidden so a new deploy target cannot leak it by forgetting
-	// to set the variable.
-	if os.Getenv("GRAPHQL_INTROSPECTION") == "on" {
+	// Introspection is fail-safe: opt-in only. The introspectionEnabled flag is
+	// resolved once in serverConfigFromEnv from a single predicate
+	// (GRAPHQL_INTROSPECTION == "on"), so this schema gate and the Playground
+	// route gate in newRouter can never disagree.
+	if introspectionEnabled {
 		srv.Use(extension.Introspection{})
 	}
 
@@ -221,6 +231,7 @@ func newRouter(
 	ld loaderDeps,
 	pingHandler *ping.Handler,
 	notionSyncHandler *notionsync.Handler,
+	introspectionEnabled bool,
 ) *echo.Echo {
 	e := echo.New()
 	e.Use(internalmw.RequestID())
@@ -252,7 +263,7 @@ func newRouter(
 		e.POST("/internal/notion-sync", notionSyncHandler.Handle)
 	}
 
-	gqlSrv := newGraphQLServer(resolvers)
+	gqlSrv := newGraphQLServer(resolvers, introspectionEnabled)
 	// Wrap only the GraphQL POST handler with otelhttp so the HTTP layer
 	// extracts an incoming traceparent and creates the root HTTP span.
 	// /health and /playground are intentionally excluded to reduce noise.
@@ -274,11 +285,11 @@ func newRouter(
 	q := e.Group("/query", authMW, promoter.Middleware(), loader.MiddlewareWithUserCardFSRS(ld.user, ld.role, ld.userRole, ld.cardgroup, ld.card, ld.userPreference, ld.swipeRecord, ld.userCardFSRS))
 	q.POST("", echo.WrapHandler(otelGQLHandler))
 
-	// Gate the Playground UI on the same switch as introspection (main.go
-	// `extension.Introspection{}` gate): the UI is useless without
-	// introspection, so production (GRAPHQL_INTROSPECTION=off) does not serve
+	// Gate the Playground UI on the same single introspectionEnabled flag as the
+	// schema introspection gate in newGraphQLServer: the UI is useless without
+	// introspection, so a deployment with introspection disabled does not serve
 	// it at all rather than serving a non-functional page.
-	if os.Getenv("GRAPHQL_INTROSPECTION") != "off" {
+	if introspectionEnabled {
 		e.GET("/playground", echo.WrapHandler(playground.Handler("GraphQL", "/query")))
 	}
 
@@ -308,7 +319,7 @@ func bootstrapSuperUserPromoter(
 			return nil, eris.Wrap(err, "run: lookup admin role for super-user bootstrap")
 		}
 		logger.Info("super-user bootstrap enabled", "email_count", len(superUserEmails))
-		return auth.NewSuperUserPromoter(superUserEmails, adminRole.ID, authSvc, userRoleRepo), nil
+		return auth.NewSuperUserPromoter(superUserEmails, adminRole.ID, authSvc, userRoleRepo, logger), nil
 	}
 	// No SUPER_USER_EMAILS configured. Check whether at least one admin
 	// already exists in the DB; if not, the operator has no escape hatch
@@ -321,7 +332,7 @@ func bootstrapSuperUserPromoter(
 		logger.Warn("super-user bootstrap: no admin configured and no admin role-holder exists",
 			"admin_count", adminCount)
 	}
-	return auth.NewSuperUserPromoter(nil, "", nil, nil), nil
+	return auth.NewSuperUserPromoter(nil, "", nil, nil, logger), nil
 }
 
 func run(ctx context.Context, logger *slog.Logger) error {
@@ -393,7 +404,7 @@ func run(ctx context.Context, logger *slog.Logger) error {
 	// constructs reads otel.GetTextMapPropagator() eagerly (it is newRouter, not
 	// the buildResolver call just above, that constructs that handler). See comment
 	// above telemetry.Init for the full ordering invariant.
-	e := newRouter(resolvers, authMW, promoter, repos.loaderDeps(), pingHandler, notionSyncHandler)
+	e := newRouter(resolvers, authMW, promoter, repos.loaderDeps(), pingHandler, notionSyncHandler, srvCfg.introspectionEnabled)
 	e.Logger = logger
 
 	port := os.Getenv("PORT")

--- a/backend/cmd/server/main_test.go
+++ b/backend/cmd/server/main_test.go
@@ -161,7 +161,7 @@ func noopAuthMW(next echo.HandlerFunc) echo.HandlerFunc {
 
 func newTestServer(t *testing.T) *httptest.Server {
 	t.Helper()
-	ts := httptest.NewServer(newRouter(resolver.NewResolver(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil), noopAuthMW, auth.NewSuperUserPromoter(nil, "", nil, nil), loaderDeps{}, ping.New(nil, "test-token"), nil))
+	ts := httptest.NewServer(newRouter(resolver.NewResolver(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil), noopAuthMW, auth.NewSuperUserPromoter(nil, "", nil, nil, nil), loaderDeps{}, ping.New(nil, "test-token"), nil, serverConfigFromEnv(slog.Default()).introspectionEnabled))
 	t.Cleanup(ts.Close)
 	return ts
 }
@@ -669,7 +669,7 @@ func newGraphQLTestServerWithUserRepo(t *testing.T, f *jwtFixture, userRepo repo
 	swipeUC := usecase.NewSwipeUsecase(db.GORM, cardRepo, cardgroupRepo, swipeRecordRepo, service.NewFSRSScheduler(), userCardFSRSRepo, logger)
 	pingRecordRepo := repository.NewPingRecordRepository(db.GORM)
 	userPreferenceRepo := repository.NewUserPreferenceRepository(db.GORM)
-	e := newRouter(resolver.NewResolver(userUC, cardgroupUC, cardUC, swipeUC, nil, nil, nil, nil, nil, nil, nil, nil, nil), mw, auth.NewSuperUserPromoter(nil, "", nil, nil), loaderDeps{
+	e := newRouter(resolver.NewResolver(userUC, cardgroupUC, cardUC, swipeUC, nil, nil, nil, nil, nil, nil, nil, nil, nil), mw, auth.NewSuperUserPromoter(nil, "", nil, nil, nil), loaderDeps{
 		user:           userRepo,
 		role:           roleRepo,
 		userRole:       userRoleRepo,
@@ -678,7 +678,7 @@ func newGraphQLTestServerWithUserRepo(t *testing.T, f *jwtFixture, userRepo repo
 		userPreference: userPreferenceRepo,
 		swipeRecord:    swipeRecordRepo,
 		userCardFSRS:   userCardFSRSRepo,
-	}, ping.New(pingRecordRepo, "test-token"), nil)
+	}, ping.New(pingRecordRepo, "test-token"), nil, false)
 
 	ts := httptest.NewServer(e)
 	t.Cleanup(ts.Close)
@@ -939,7 +939,7 @@ func TestComplexityLimit_Rejects(t *testing.T) {
 
 func newIntrospectionTestServer(t *testing.T) *httptest.Server {
 	t.Helper()
-	ts := httptest.NewServer(newGraphQLServer(resolver.NewResolver(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)))
+	ts := httptest.NewServer(newGraphQLServer(resolver.NewResolver(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil), serverConfigFromEnv(slog.Default()).introspectionEnabled))
 	t.Cleanup(ts.Close)
 	return ts
 }
@@ -1023,9 +1023,14 @@ func getStatus(t *testing.T, url string) int {
 	return res.StatusCode
 }
 
+// The Playground UI is gated on the SAME single introspectionEnabled flag as
+// schema introspection (GRAPHQL_INTROSPECTION == "on"). The two gates can never
+// disagree: a value like "true" disables both, so the Playground is never served
+// against a server that rejects its introspection query.
+
 // TestPlayground_GatedOff asserts that GRAPHQL_INTROSPECTION=off leaves the
 // /playground route unregistered (404). The Playground UI is useless without
-// introspection, so production (where introspection is off) does not serve it.
+// introspection, so a server with introspection off does not serve it.
 func TestPlayground_GatedOff(t *testing.T) {
 	t.Setenv("GRAPHQL_INTROSPECTION", "off")
 	ts := newTestServer(t)
@@ -1035,15 +1040,40 @@ func TestPlayground_GatedOff(t *testing.T) {
 	}
 }
 
-// TestPlayground_DefaultOn asserts that the /playground route is registered
-// (returns 200) for any value other than "off" — the route gate is `!= "off"`,
-// which is intentionally looser than the introspection gate (`== "on"`).
-func TestPlayground_DefaultOn(t *testing.T) {
+// TestPlayground_UnsetGatedOff asserts that an unset GRAPHQL_INTROSPECTION leaves
+// the /playground route unregistered (404). Under the single-predicate gate, an
+// unset value disables introspection, so the Playground is gated off too — the
+// fail-safe default never serves a non-functional UI.
+func TestPlayground_UnsetGatedOff(t *testing.T) {
 	t.Setenv("GRAPHQL_INTROSPECTION", "")
+	ts := newTestServer(t)
+
+	if got := getStatus(t, ts.URL+"/playground"); got != http.StatusNotFound {
+		t.Fatalf("GET /playground status = %d, want %d (unset should gate the route off)", got, http.StatusNotFound)
+	}
+}
+
+// TestPlayground_OnRegistered asserts that GRAPHQL_INTROSPECTION=on registers the
+// /playground route (200), matching the introspection gate exactly.
+func TestPlayground_OnRegistered(t *testing.T) {
+	t.Setenv("GRAPHQL_INTROSPECTION", "on")
 	ts := newTestServer(t)
 
 	if got := getStatus(t, ts.URL+"/playground"); got != http.StatusOK {
 		t.Fatalf("GET /playground status = %d, want %d (route should be registered)", got, http.StatusOK)
+	}
+}
+
+// TestPlayground_StrayValueGatedOff asserts that a non-"on" value like "true"
+// leaves the /playground route unregistered (404). This pins the single-predicate
+// fix: the Playground and introspection gates resolve from the same `== "on"`
+// predicate, so "true" disables both rather than serving a broken UI.
+func TestPlayground_StrayValueGatedOff(t *testing.T) {
+	t.Setenv("GRAPHQL_INTROSPECTION", "true")
+	ts := newTestServer(t)
+
+	if got := getStatus(t, ts.URL+"/playground"); got != http.StatusNotFound {
+		t.Fatalf("GET /playground status = %d, want %d (stray value should gate the route off)", got, http.StatusNotFound)
 	}
 }
 
@@ -1844,7 +1874,7 @@ func newLastViewedGraphQLTestServer(t *testing.T, f *jwtFixture) (*httptest.Serv
 	e := newRouter(
 		resolver.NewResolver(userUC, cardgroupUC, cardUC, swipeUC, nil, nil, nil, nil, lastViewedUC, nil, nil, nil, nil),
 		mw,
-		auth.NewSuperUserPromoter(nil, "", nil, nil),
+		auth.NewSuperUserPromoter(nil, "", nil, nil, nil),
 		loaderDeps{
 			user:           userRepo,
 			role:           roleRepo,
@@ -1856,6 +1886,7 @@ func newLastViewedGraphQLTestServer(t *testing.T, f *jwtFixture) (*httptest.Serv
 			userCardFSRS:   userCardFSRSRepo,
 		},
 		ping.New(pingRecordRepo, "test-token"), nil,
+		false,
 	)
 
 	ts := httptest.NewServer(e)
@@ -2755,6 +2786,34 @@ func TestServerConfigFromEnv(t *testing.T) {
 			}
 			if tc.wantLog == "" && buf.Len() > 0 {
 				t.Errorf("expected no log output, got %q", buf.String())
+			}
+		})
+	}
+}
+
+// TestServerConfigFromEnv_Introspection pins the single-predicate resolution of
+// GRAPHQL_INTROSPECTION into the one introspectionEnabled flag. Only "on" enables
+// introspection; "off", unset, and a stray value like "true" all disable it. The
+// "true" case proves the fix: the prior split gates (one `== "on"`, one `!= "off"`)
+// disagreed on "true", serving a Playground UI against a server with introspection
+// disabled.
+func TestServerConfigFromEnv_Introspection(t *testing.T) {
+	cases := []struct {
+		name string
+		env  string
+		want bool
+	}{
+		{"on enables", "on", true},
+		{"off disables", "off", false},
+		{"unset disables", "", false},
+		{"stray value true disables", "true", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("GRAPHQL_INTROSPECTION", tc.env)
+			cfg := serverConfigFromEnv(slog.New(slog.DiscardHandler))
+			if cfg.introspectionEnabled != tc.want {
+				t.Errorf("introspectionEnabled = %v, want %v", cfg.introspectionEnabled, tc.want)
 			}
 		})
 	}

--- a/backend/internal/auth/superuser.go
+++ b/backend/internal/auth/superuser.go
@@ -30,6 +30,7 @@ type SuperUserPromoter struct {
 	adminRoleID string
 	checker     adminChecker
 	assigner    roleAssigner
+	logger      *slog.Logger
 }
 
 // ParseSuperUserSet splits a comma-separated string of email addresses into a
@@ -58,11 +59,17 @@ func canonicalEmail(s string) string {
 // returns a zero-cost pass-through; checker, assigner, and adminRoleID may be
 // nil/empty in that case. Panics if emails is non-empty but any dependency is
 // missing — catches misconfiguration at process startup, not per-request.
+//
+// logger is the injected structured logger the middleware uses for its WARN and
+// INFO promotion events. A nil logger falls back to slog.Default() so existing
+// callers that do not yet thread a logger keep working; production callers
+// should pass the composition-root logger so the events carry request context.
 func NewSuperUserPromoter(
 	emails map[string]struct{},
 	adminRoleID string,
 	checker adminChecker,
 	assigner roleAssigner,
+	logger *slog.Logger,
 ) *SuperUserPromoter {
 	if len(emails) > 0 {
 		if checker == nil {
@@ -76,6 +83,10 @@ func NewSuperUserPromoter(
 		}
 	}
 
+	if logger == nil {
+		logger = slog.Default()
+	}
+
 	emailsCopy := make(map[string]struct{}, len(emails))
 	for k := range emails {
 		emailsCopy[k] = struct{}{}
@@ -86,6 +97,7 @@ func NewSuperUserPromoter(
 		adminRoleID: adminRoleID,
 		checker:     checker,
 		assigner:    assigner,
+		logger:      logger,
 	}
 }
 
@@ -121,7 +133,7 @@ func (p *SuperUserPromoter) Middleware() echo.MiddlewareFunc {
 
 			isAdmin, err := p.checker.IsAdmin(ctx, u.Sub)
 			if err != nil {
-				logging.LogWarn(ctx, slog.Default(), "superuser: admin check failed",
+				logging.LogWarn(ctx, p.logger, "superuser: admin check failed",
 					eris.Wrap(err, "superuser: IsAdmin"),
 					slog.String("user_id", u.Sub))
 				return next(c)
@@ -132,13 +144,13 @@ func (p *SuperUserPromoter) Middleware() echo.MiddlewareFunc {
 			}
 
 			if err := p.assigner.AssignToUser(ctx, u.Sub, p.adminRoleID); err != nil {
-				logging.LogWarn(ctx, slog.Default(), "superuser: role assignment failed",
+				logging.LogWarn(ctx, p.logger, "superuser: role assignment failed",
 					eris.Wrap(err, "superuser: AssignToUser"),
 					slog.String("user_id", u.Sub))
 				return next(c)
 			}
 
-			slog.InfoContext(ctx, "superuser: promoted to admin", slog.String("user_id", u.Sub))
+			p.logger.InfoContext(ctx, "superuser: promoted to admin", slog.String("user_id", u.Sub))
 			return next(c)
 		}
 	}

--- a/backend/internal/auth/superuser_test.go
+++ b/backend/internal/auth/superuser_test.go
@@ -200,7 +200,7 @@ func TestSuperUserPromoter_M1_EmptyEmails(t *testing.T) {
 		assignCalls.Add(1)
 		return nil
 	}}
-	promoter := NewSuperUserPromoter(map[string]struct{}{}, "role-id", checker, assigner)
+	promoter := NewSuperUserPromoter(map[string]struct{}{}, "role-id", checker, assigner, nil)
 
 	u := &AuthUser{Sub: "user-1", Email: "a@x.com", EmailVerified: true}
 	rec := runMiddleware(t, promoter, u)
@@ -228,7 +228,7 @@ func TestSuperUserPromoter_M2_AnonymousRequest(t *testing.T) {
 		assignCalls.Add(1)
 		return nil
 	}}
-	promoter := NewSuperUserPromoter(makeSet("a@x.com"), "role-id", checker, assigner)
+	promoter := NewSuperUserPromoter(makeSet("a@x.com"), "role-id", checker, assigner, nil)
 
 	rec := runMiddleware(t, promoter, nil /* anonymous */)
 
@@ -255,7 +255,7 @@ func TestSuperUserPromoter_M3_EmailNotInSet(t *testing.T) {
 		assignCalls.Add(1)
 		return nil
 	}}
-	promoter := NewSuperUserPromoter(makeSet("other@x.com"), "role-id", checker, assigner)
+	promoter := NewSuperUserPromoter(makeSet("other@x.com"), "role-id", checker, assigner, nil)
 
 	u := &AuthUser{Sub: "user-1", Email: "a@x.com", EmailVerified: true}
 	rec := runMiddleware(t, promoter, u)
@@ -283,7 +283,7 @@ func TestSuperUserPromoter_M4_EmailVerifiedFalse(t *testing.T) {
 		assignCalls.Add(1)
 		return nil
 	}}
-	promoter := NewSuperUserPromoter(makeSet("a@x.com"), "role-id", checker, assigner)
+	promoter := NewSuperUserPromoter(makeSet("a@x.com"), "role-id", checker, assigner, nil)
 
 	u := &AuthUser{Sub: "user-1", Email: "a@x.com", EmailVerified: false}
 	rec := runMiddleware(t, promoter, u)
@@ -314,7 +314,7 @@ func TestSuperUserPromoter_M5_AlreadyAdmin(t *testing.T) {
 		assignCalls.Add(1)
 		return nil
 	}}
-	promoter := NewSuperUserPromoter(makeSet("a@x.com"), "role-id", checker, assigner)
+	promoter := NewSuperUserPromoter(makeSet("a@x.com"), "role-id", checker, assigner, nil)
 
 	u := &AuthUser{Sub: "user-1", Email: "a@x.com", EmailVerified: true}
 	rec := runMiddleware(t, promoter, u)
@@ -354,7 +354,7 @@ func TestSuperUserPromoter_M6_SuccessfulPromotion(t *testing.T) {
 		gotRoleID = roleID
 		return nil
 	}}
-	promoter := NewSuperUserPromoter(makeSet("a@x.com"), wantRoleID, checker, assigner)
+	promoter := NewSuperUserPromoter(makeSet("a@x.com"), wantRoleID, checker, assigner, nil)
 
 	u := &AuthUser{Sub: wantUserID, Email: "a@x.com", EmailVerified: true}
 	rec := runMiddleware(t, promoter, u)
@@ -410,7 +410,7 @@ func TestSuperUserPromoter_M7_IsAdminError(t *testing.T) {
 		assignCalls.Add(1)
 		return nil
 	}}
-	promoter := NewSuperUserPromoter(makeSet("a@x.com"), "role-id", checker, assigner)
+	promoter := NewSuperUserPromoter(makeSet("a@x.com"), "role-id", checker, assigner, nil)
 
 	u := &AuthUser{Sub: wantUserID, Email: "a@x.com", EmailVerified: true}
 	rec := runMiddleware(t, promoter, u)
@@ -454,6 +454,58 @@ func TestSuperUserPromoter_M7_IsAdminError(t *testing.T) {
 	}
 }
 
+// TestSuperUserPromoter_InjectedLogger_WarnsOnAdminCheckFailure verifies the
+// logger-DI path: a logger passed to NewSuperUserPromoter (writing to a local
+// bytes.Buffer) is the one the middleware uses, NOT the global slog.Default().
+// The admin-check-failure path must emit its WARN line through the injected
+// logger. This is the DI replacement for the captureDefaultLogger global-mutation
+// pattern the M5–M9 tests use; it runs in parallel because it touches no global
+// state.
+func TestSuperUserPromoter_InjectedLogger_WarnsOnAdminCheckFailure(t *testing.T) {
+	t.Parallel()
+
+	const wantUserID = "user-injected-1"
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	checker := stubAdminChecker{fn: func(_ context.Context, _ string) (bool, error) {
+		return false, eris.New("db: connection refused")
+	}}
+	assigner := stubRoleAssigner{fn: func(_ context.Context, _, _ string) error {
+		t.Fatal("AssignToUser must not be called when the admin check fails")
+		return nil
+	}}
+	promoter := NewSuperUserPromoter(makeSet("a@x.com"), "role-id", checker, assigner, logger)
+
+	u := &AuthUser{Sub: wantUserID, Email: "a@x.com", EmailVerified: true}
+	rec := runMiddleware(t, promoter, u)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	records := decodeLogLines(t, &buf)
+	if len(records) != 1 {
+		t.Fatalf("expected 1 log line on the injected logger, got %d: %s", len(records), buf.String())
+	}
+	rec0 := records[0]
+	if rec0["level"] != "WARN" {
+		t.Errorf("expected level=WARN, got %v", rec0["level"])
+	}
+	if rec0["msg"] != "superuser: admin check failed" {
+		t.Errorf("unexpected msg: %v", rec0["msg"])
+	}
+	if rec0["user_id"] != wantUserID {
+		t.Errorf("expected user_id=%q in WARN log, got %v", wantUserID, rec0["user_id"])
+	}
+	if _, hasEmail := rec0["email"]; hasEmail {
+		t.Error("WARN log must not contain 'email' field (PII protection)")
+	}
+	if _, hasChain := rec0["error_chain"]; !hasChain {
+		t.Error("WARN log must carry the error_chain attribute")
+	}
+}
+
 // M8: AssignToUser returns an error — WARN log with error_chain, 200.
 func TestSuperUserPromoter_M8_AssignToUserError(t *testing.T) {
 	// Not parallel: captureDefaultLogger mutates global slog default.
@@ -467,7 +519,7 @@ func TestSuperUserPromoter_M8_AssignToUserError(t *testing.T) {
 	assigner := stubRoleAssigner{fn: func(_ context.Context, _, _ string) error {
 		return eris.New("db: deadlock detected")
 	}}
-	promoter := NewSuperUserPromoter(makeSet("a@x.com"), "role-id", checker, assigner)
+	promoter := NewSuperUserPromoter(makeSet("a@x.com"), "role-id", checker, assigner, nil)
 
 	u := &AuthUser{Sub: wantUserID, Email: "a@x.com", EmailVerified: true}
 	rec := runMiddleware(t, promoter, u)
@@ -525,7 +577,7 @@ func TestSuperUserPromoter_M9_ConcurrentFirstLogin(t *testing.T) {
 		assignCalls.Add(1)
 		return nil // ON CONFLICT DO NOTHING equivalent
 	}}
-	promoter := NewSuperUserPromoter(makeSet("a@x.com"), "role-id", checker, assigner)
+	promoter := NewSuperUserPromoter(makeSet("a@x.com"), "role-id", checker, assigner, nil)
 
 	const goroutines = 2
 	var wg sync.WaitGroup
@@ -588,6 +640,7 @@ func TestSuperUserPromoter_AuthUserWithEmptySub(t *testing.T) {
 			assignerCalls.Add(1)
 			return nil
 		}},
+		nil,
 	)
 	u := &AuthUser{Sub: "", Email: "a@x.com", EmailVerified: true}
 	rec := runMiddleware(t, promoter, u)
@@ -608,7 +661,7 @@ func TestSuperUserPromoter_AuthUserWithEmptySub(t *testing.T) {
 func TestNewSuperUserPromoter_NilMapIsPassthrough(t *testing.T) {
 	t.Parallel()
 	// No checker/assigner provided; must not be called when map is empty/nil.
-	promoter := NewSuperUserPromoter(nil, "", nil, nil)
+	promoter := NewSuperUserPromoter(nil, "", nil, nil, nil)
 	u := &AuthUser{Sub: "user-1", Email: "anyone@example.com", EmailVerified: true}
 	rec := runMiddleware(t, promoter, u)
 	if rec.Code != http.StatusOK {

--- a/backend/internal/repository/master_cardgroup.go
+++ b/backend/internal/repository/master_cardgroup.go
@@ -159,7 +159,7 @@ func (r *masterCardgroupRepo) FindByID(ctx context.Context, id string) (*domain.
 		}
 		return nil, eris.Wrap(err, "repository: master cardgroup: find by id")
 	}
-	return masterCardgroupToDomain(row), nil
+	return masterCardgroupToDomain(row)
 }
 
 // EnsureByName returns the existing master cardgroup with the given name or
@@ -178,8 +178,8 @@ func (r *masterCardgroupRepo) EnsureByName(ctx context.Context, name string) (*d
 		var row gormMasterCardgroup
 		err := tx.Where("name = ?", name).Take(&row).Error
 		if err == nil {
-			out = masterCardgroupToDomain(row)
-			return nil
+			out, err = masterCardgroupToDomain(row)
+			return err
 		}
 		if !errors.Is(err, gorm.ErrRecordNotFound) {
 			return eris.Wrap(err, "repository: master cardgroup: ensure by name: lookup")
@@ -203,8 +203,8 @@ func (r *masterCardgroupRepo) EnsureByName(ctx context.Context, name string) (*d
 		if err := tx.Create(&row).Error; err != nil {
 			return eris.Wrap(err, "repository: master cardgroup: ensure by name: create")
 		}
-		out = masterCardgroupToDomain(row)
-		return nil
+		out, err = masterCardgroupToDomain(row)
+		return err
 	})
 	if err != nil {
 		return nil, err
@@ -302,7 +302,11 @@ func (r *masterCardgroupRepo) ListDefaultStarters(ctx context.Context) ([]*domai
 	}
 	out := make([]*domain.MasterCardgroup, len(rows))
 	for i := range rows {
-		out[i] = masterCardgroupToDomain(rows[i])
+		m, err := masterCardgroupToDomain(rows[i])
+		if err != nil {
+			return nil, err
+		}
+		out[i] = m
 	}
 	return out, nil
 }
@@ -321,7 +325,7 @@ func (r *masterCardgroupRepo) FindPublishedByID(ctx context.Context, id string) 
 		}
 		return nil, eris.Wrap(err, "repository: master cardgroup: find published by id")
 	}
-	return masterCardgroupToDomain(row), nil
+	return masterCardgroupToDomain(row)
 }
 
 // Publish transitions the master cardgroup to the published state, bumping its
@@ -361,7 +365,10 @@ func (r *masterCardgroupRepo) applyStatusTransition(
 			}
 			return eris.Wrap(err, "repository: master cardgroup: "+op+": load")
 		}
-		m := masterCardgroupToDomain(row)
+		m, err := masterCardgroupToDomain(row)
+		if err != nil {
+			return err
+		}
 		if err := transition(m); err != nil {
 			return eris.Wrap(err, "repository: master cardgroup: "+op+": apply")
 		}
@@ -378,7 +385,11 @@ func (r *masterCardgroupRepo) applyStatusTransition(
 	return out, nil
 }
 
-func masterCardgroupToDomain(g gormMasterCardgroup) *domain.MasterCardgroup {
+func masterCardgroupToDomain(g gormMasterCardgroup) (*domain.MasterCardgroup, error) {
+	status := domain.MasterCardgroupStatus(g.Status)
+	if !status.IsValid() {
+		return nil, eris.Errorf("repository: master cardgroup: invalid status %q", g.Status)
+	}
 	return &domain.MasterCardgroup{
 		ID:               g.ID,
 		Name:             domain.CardgroupName(g.Name),
@@ -389,12 +400,12 @@ func masterCardgroupToDomain(g gormMasterCardgroup) *domain.MasterCardgroup {
 		CoverImageURL:    g.CoverImageURL,
 		Source:           g.Source,
 		Version:          g.Version,
-		Status:           domain.MasterCardgroupStatus(g.Status),
+		Status:           status,
 		IsDefaultStarter: g.IsDefaultStarter,
 		SortOrder:        g.SortOrder,
 		CreatedAt:        g.CreatedAt,
 		UpdatedAt:        g.UpdatedAt,
-	}
+	}, nil
 }
 
 func masterCardgroupFromDomain(m *domain.MasterCardgroup) gormMasterCardgroup {

--- a/backend/internal/repository/master_cardgroup_mapper_test.go
+++ b/backend/internal/repository/master_cardgroup_mapper_test.go
@@ -1,0 +1,75 @@
+package repository
+
+// White-box tests for masterCardgroupToDomain. The mapper is unexported and is
+// a pure function of the row struct, so the tests live in the same package and
+// need no live DB. They pin the DB-reconstitution guard that rejects an unknown
+// MasterCardgroupStatus column value (mirrors the FSRSCardState guard in
+// userCardFSRSToDomain / dueCardsFromRows): a corrupt status would otherwise
+// flow silently into the domain and make IsPublished() return false, hiding the
+// deck instead of surfacing the corruption.
+
+import (
+	"testing"
+	"time"
+
+	"backend/internal/domain"
+)
+
+func TestMasterCardgroupToDomain_InvalidStatus_ReturnsError(t *testing.T) {
+	t.Parallel()
+	row := gormMasterCardgroup{
+		ID:        "00000000-0000-0000-0000-000000000001",
+		Name:      "Garbage Status Deck",
+		Version:   1,
+		Status:    "garbage",
+		SortOrder: 0,
+		CreatedAt: time.Now().UTC(),
+		UpdatedAt: time.Now().UTC(),
+	}
+
+	got, err := masterCardgroupToDomain(row)
+	if err == nil {
+		t.Fatalf("expected an error for invalid status, got nil (mapper returned %+v)", got)
+	}
+	if got != nil {
+		t.Fatalf("expected nil aggregate on error, got %+v", got)
+	}
+}
+
+func TestMasterCardgroupToDomain_ValidStatus_RoundTrips(t *testing.T) {
+	t.Parallel()
+	for _, status := range []domain.MasterCardgroupStatus{
+		domain.MasterStatusDraft,
+		domain.MasterStatusPublished,
+	} {
+		row := gormMasterCardgroup{
+			ID:        "00000000-0000-0000-0000-000000000002",
+			Name:      "Valid Status Deck",
+			Version:   3,
+			Status:    string(status),
+			SortOrder: 7,
+			CreatedAt: time.Now().UTC(),
+			UpdatedAt: time.Now().UTC(),
+		}
+
+		got, err := masterCardgroupToDomain(row)
+		if err != nil {
+			t.Fatalf("unexpected error for status %q: %v", status, err)
+		}
+		if got == nil {
+			t.Fatalf("expected non-nil aggregate for status %q", status)
+		}
+		if got.Status != status {
+			t.Fatalf("status not preserved: want %q, got %q", status, got.Status)
+		}
+		if got.ID != row.ID {
+			t.Fatalf("id not preserved: want %q, got %q", row.ID, got.ID)
+		}
+		if got.Version != row.Version {
+			t.Fatalf("version not preserved: want %d, got %d", row.Version, got.Version)
+		}
+		if got.SortOrder != row.SortOrder {
+			t.Fatalf("sort order not preserved: want %d, got %d", row.SortOrder, got.SortOrder)
+		}
+	}
+}

--- a/backend/internal/repository/master_catalog_read.go
+++ b/backend/internal/repository/master_catalog_read.go
@@ -227,8 +227,12 @@ func (r *masterCardgroupRepo) findCatalogPage(
 
 	out := make([]*MasterCatalogItem, len(rows))
 	for i := range rows {
+		cg, err := masterCardgroupToDomain(rows[i].toGorm())
+		if err != nil {
+			return nil, err
+		}
 		out[i] = &MasterCatalogItem{
-			Cardgroup: masterCardgroupToDomain(rows[i].toGorm()),
+			Cardgroup: cg,
 			CardCount: rows[i].CardCount,
 		}
 	}


### PR DESCRIPTION
## Summary

Three latent silent-failures / misconfigurations surfaced by a 2026-06-15 DDD/layered-architecture review, each a small self-contained fix. **Two carry a deliberate behaviour change — see "Behaviour changes" below.**

No tracking issue — this and the sibling PRs (`refactor/backend-helper-dedup`, `test/shared-bootstrap-auth-schema`) come from a whole-repo architecture review, not an existing issue.

## Changes

### `fix(server)`: single-predicate GraphQL introspection gate
`GRAPHQL_INTROSPECTION` was read with two inverted predicates — introspection enabled on `== "on"` but the Playground served on `!= "off"`. A stray value like `GRAPHQL_INTROSPECTION=true` therefore served a Playground UI with introspection disabled (a broken Playground). Introspection now resolves once to `serverConfig.introspectionEnabled` (`== "on"`), and both the gqlgen `extension.Introspection{}` registration and the `/playground` route gate read that single bool.

### `fix(server)`: inject a logger into `SuperUserPromoter`
`SuperUserPromoter` was the one infra-layer holdout still logging via `slog.Default()` / bare `slog.InfoContext`. It now takes a `logger *slog.Logger` (defaulting to `slog.Default()` only when nil), threaded from `bootstrapSuperUserPromoter`, so its log output is testable and consistent with the DI'd-logger convention.

### `fix(catalog)`: enforce `MasterCardgroupStatus` validity on DB reconstitution
`masterCardgroupToDomain` cast the raw `status` column with no validity check, so a corrupt/unknown status flowed silently into the domain and `IsPublished()` returned `false` — the deck quietly vanished from the published catalog. It now rejects an invalid status on read (`eris.Errorf`), mirroring the `FSRSState` / `Rating` reconstitution guards. This also wires the previously-dead `MasterCardgroupStatus.IsValid()`.

## Behaviour changes (operator note)

- **Playground default flips to OFF when `GRAPHQL_INTROSPECTION` is unset.** Previously an unset var still served the Playground (introspection off). Now unset ⇒ both off. Set `GRAPHQL_INTROSPECTION=on` in any environment that wants the Playground; the production default should stay off.
- **A corrupt `master_cardgroups.status` row now errors on read** instead of silently degrading to unpublished. No valid data path is affected — `draft` / `published` round-trip unchanged.

## Verification

```bash
cd backend
go build ./... && go vet ./... && go tool go-arch-lint check --project-path .
go test -race ./cmd/server/... ./internal/auth/... ./internal/repository/...
```

New tests: `TestServerConfigFromEnv_Introspection`, `TestSuperUserPromoter_InjectedLogger_WarnsOnAdminCheckFailure`, `TestMasterCardgroupToDomain_InvalidStatus_ReturnsError`, `TestMasterCardgroupToDomain_ValidStatus_RoundTrips`, plus rewritten Playground gate tests pinning the single-predicate behaviour.
