### PR TITLE
refactor(backend): dedup page-size, auth-guard, resolver, and repo helpers

### DIFF
--- a/backend/graph/resolver/admin.resolvers.go
+++ b/backend/graph/resolver/admin.resolvers.go
@@ -27,10 +27,7 @@ func (r *mutationResolver) AdminEditUser(ctx context.Context, id string, input m
 		return nil, gqlerr.FromUsecaseError(ctx, err)
 	}
 	if outcome.Validation != nil {
-		return model.InputValidationError{
-			Field:   outcome.Validation.Field,
-			Message: outcome.Validation.Message,
-		}, nil
+		return toInputValidationError(outcome.Validation), nil
 	}
 	if outcome.CannotRevokeOwnAdmin {
 		return model.CannotRevokeOwnAdminRoleError{
@@ -61,10 +58,7 @@ func (r *mutationResolver) CreateRole(ctx context.Context, name string) (model.C
 		return nil, gqlerr.FromUsecaseError(ctx, err)
 	}
 	if outcome.Validation != nil {
-		return model.InputValidationError{
-			Field:   outcome.Validation.Field,
-			Message: outcome.Validation.Message,
-		}, nil
+		return toInputValidationError(outcome.Validation), nil
 	}
 	if outcome.Role == nil {
 		return nil, gqlerr.Internal(ctx,

--- a/backend/graph/resolver/card.resolvers.go
+++ b/backend/graph/resolver/card.resolvers.go
@@ -112,10 +112,7 @@ func (r *mutationResolver) UpdateCard(ctx context.Context, id string, input mode
 		return nil, gqlerr.FromUsecaseError(ctx, err)
 	}
 	if outcome.Validation != nil {
-		return model.InputValidationError{
-			Field:   outcome.Validation.Field,
-			Message: outcome.Validation.Message,
-		}, nil
+		return toInputValidationError(outcome.Validation), nil
 	}
 	if outcome.Card == nil {
 		return nil, gqlerr.Internal(ctx,

--- a/backend/graph/resolver/cardgroup.resolvers.go
+++ b/backend/graph/resolver/cardgroup.resolvers.go
@@ -43,10 +43,7 @@ func (r *mutationResolver) CreateCardgroup(ctx context.Context, input model.NewC
 		return nil, gqlerr.FromUsecaseError(ctx, err)
 	}
 	if outcome.Validation != nil {
-		return model.InputValidationError{
-			Field:   outcome.Validation.Field,
-			Message: outcome.Validation.Message,
-		}, nil
+		return toInputValidationError(outcome.Validation), nil
 	}
 	if outcome.LimitReached != nil {
 		return model.CardgroupLimitReachedError{
@@ -74,10 +71,7 @@ func (r *mutationResolver) UpdateCardgroup(ctx context.Context, id string, input
 		return nil, gqlerr.FromUsecaseError(ctx, err)
 	}
 	if outcome.Validation != nil {
-		return model.InputValidationError{
-			Field:   outcome.Validation.Field,
-			Message: outcome.Validation.Message,
-		}, nil
+		return toInputValidationError(outcome.Validation), nil
 	}
 	if outcome.Cardgroup == nil {
 		return nil, gqlerr.Internal(ctx,

--- a/backend/graph/resolver/connection.go
+++ b/backend/graph/resolver/connection.go
@@ -17,6 +17,19 @@ func encodeCursor(id string) *string {
 	return &s
 }
 
+// buildPageInfo assembles the Relay PageInfo from the boundary flags and the
+// already-encoded start/end cursor strings. Each caller computes its own
+// start/end (some encode via cursor.Encode, others carry a pre-encoded value)
+// and passes the final strings in.
+func buildPageInfo(hasNext, hasPrev bool, start, end *string) *model.PageInfo {
+	return &model.PageInfo{
+		HasNextPage:     hasNext,
+		HasPreviousPage: hasPrev,
+		StartCursor:     start,
+		EndCursor:       end,
+	}
+}
+
 func toCardConnectionModel(ctx context.Context, out *usecase.CardConnectionOutput) *model.CardConnection {
 	if out == nil {
 		return &model.CardConnection{Edges: []*model.CardEdge{}, PageInfo: &model.PageInfo{}}
@@ -31,13 +44,8 @@ func toCardConnectionModel(ctx context.Context, out *usecase.CardConnectionOutpu
 		edges = append(edges, &model.CardEdge{Cursor: cursor.Encode(c.ID), Node: cm})
 	}
 	return &model.CardConnection{
-		Edges: edges,
-		PageInfo: &model.PageInfo{
-			HasNextPage:     out.HasNext,
-			HasPreviousPage: out.HasPrev,
-			StartCursor:     encodeCursor(out.StartCur),
-			EndCursor:       encodeCursor(out.EndCur),
-		},
+		Edges:      edges,
+		PageInfo:   buildPageInfo(out.HasNext, out.HasPrev, encodeCursor(out.StartCur), encodeCursor(out.EndCur)),
 		TotalCount: int(out.TotalCount),
 	}
 }
@@ -56,13 +64,8 @@ func toCardgroupConnectionModel(ctx context.Context, out *usecase.CardgroupConne
 		edges = append(edges, &model.CardgroupEdge{Cursor: cursor.Encode(string(cg.ID)), Node: cgm})
 	}
 	return &model.CardgroupConnection{
-		Edges: edges,
-		PageInfo: &model.PageInfo{
-			HasNextPage:     out.HasNext,
-			HasPreviousPage: out.HasPrev,
-			StartCursor:     encodeCursor(out.StartCur),
-			EndCursor:       encodeCursor(out.EndCur),
-		},
+		Edges:      edges,
+		PageInfo:   buildPageInfo(out.HasNext, out.HasPrev, encodeCursor(out.StartCur), encodeCursor(out.EndCur)),
 		TotalCount: int(out.TotalCount),
 	}
 }
@@ -81,13 +84,8 @@ func toMasterCatalogConnectionModel(ctx context.Context, out *usecase.MasterCata
 		edges = append(edges, &model.MasterCatalogEdge{Cursor: cursor.Encode(item.Cardgroup.ID), Node: mm})
 	}
 	return &model.MasterCatalogConnection{
-		Edges: edges,
-		PageInfo: &model.PageInfo{
-			HasNextPage:     out.HasNext,
-			HasPreviousPage: out.HasPrev,
-			StartCursor:     encodeCursor(out.StartCur),
-			EndCursor:       encodeCursor(out.EndCur),
-		},
+		Edges:      edges,
+		PageInfo:   buildPageInfo(out.HasNext, out.HasPrev, encodeCursor(out.StartCur), encodeCursor(out.EndCur)),
 		TotalCount: int(out.TotalCount),
 	}
 }
@@ -106,13 +104,8 @@ func toUserConnectionModel(ctx context.Context, uc *usecase.AdminUserConnection)
 		edges = append(edges, &model.UserEdge{Cursor: e.Cursor, Node: um})
 	}
 	return &model.UserConnection{
-		Edges: edges,
-		PageInfo: &model.PageInfo{
-			HasNextPage:     uc.PageInfo.HasNextPage,
-			HasPreviousPage: uc.PageInfo.HasPreviousPage,
-			StartCursor:     uc.PageInfo.StartCursor,
-			EndCursor:       uc.PageInfo.EndCursor,
-		},
+		Edges:      edges,
+		PageInfo:   buildPageInfo(uc.PageInfo.HasNextPage, uc.PageInfo.HasPreviousPage, uc.PageInfo.StartCursor, uc.PageInfo.EndCursor),
 		TotalCount: int(uc.TotalCount),
 	}
 }

--- a/backend/graph/resolver/last_viewed_cardgroup.resolvers.go
+++ b/backend/graph/resolver/last_viewed_cardgroup.resolvers.go
@@ -29,10 +29,7 @@ func (r *mutationResolver) SetLastViewedCardgroup(ctx context.Context, cardgroup
 		return nil, gqlerr.FromUsecaseError(ctx, err)
 	}
 	if outcome.Validation != nil {
-		return model.InputValidationError{
-			Field:   outcome.Validation.Field,
-			Message: outcome.Validation.Message,
-		}, nil
+		return toInputValidationError(outcome.Validation), nil
 	}
 	if outcome.User == nil {
 		return nil, gqlerr.Internal(ctx,

--- a/backend/graph/resolver/mapper.go
+++ b/backend/graph/resolver/mapper.go
@@ -12,6 +12,13 @@ import (
 	"backend/internal/usecase"
 )
 
+// toInputValidationError maps a usecase input-validation carrier to the
+// generated outcome-union variant. Shared by every promoted mutation resolver
+// that surfaces a validation failure as data.
+func toInputValidationError(v *usecase.InputValidationInfo) model.InputValidationError {
+	return model.InputValidationError{Field: v.Field, Message: v.Message}
+}
+
 func toUserModel(user *domain.User) *model.User {
 	if user == nil {
 		return nil

--- a/backend/graph/resolver/master_catalog.resolvers.go
+++ b/backend/graph/resolver/master_catalog.resolvers.go
@@ -36,7 +36,7 @@ func (r *mutationResolver) AdminCreateMasterCardgroup(ctx context.Context, input
 		return nil, gqlerr.FromUsecaseError(ctx, err)
 	}
 	if out.Validation != nil {
-		return model.InputValidationError{Field: out.Validation.Field, Message: out.Validation.Message}, nil
+		return toInputValidationError(out.Validation), nil
 	}
 	if out.Master == nil {
 		return nil, gqlerr.Internal(ctx, eris.New("resolver: CreateMasterOutcome has no variant set"))
@@ -66,7 +66,7 @@ func (r *mutationResolver) AdminUpdateMasterCardgroup(ctx context.Context, id st
 		return nil, gqlerr.FromUsecaseError(ctx, err)
 	}
 	if out.Validation != nil {
-		return model.InputValidationError{Field: out.Validation.Field, Message: out.Validation.Message}, nil
+		return toInputValidationError(out.Validation), nil
 	}
 	if out.Master == nil {
 		return nil, gqlerr.Internal(ctx, eris.New("resolver: UpdateMasterOutcome has no variant set"))

--- a/backend/graph/resolver/swipe.resolvers.go
+++ b/backend/graph/resolver/swipe.resolvers.go
@@ -31,10 +31,7 @@ func (r *mutationResolver) HandleSwipe(ctx context.Context, input model.HandleSw
 		return nil, gqlerr.FromUsecaseError(ctx, err)
 	}
 	if outcome.Validation != nil {
-		return model.InputValidationError{
-			Field:   outcome.Validation.Field,
-			Message: outcome.Validation.Message,
-		}, nil
+		return toInputValidationError(outcome.Validation), nil
 	}
 	if outcome.Swipe == nil {
 		return nil, gqlerr.Internal(ctx,

--- a/backend/graph/resolver/user.resolvers.go
+++ b/backend/graph/resolver/user.resolvers.go
@@ -30,10 +30,7 @@ func (r *mutationResolver) UpdateProfile(ctx context.Context, input model.Update
 		return nil, gqlerr.FromUsecaseError(ctx, err)
 	}
 	if outcome.Validation != nil {
-		return model.InputValidationError{
-			Field:   outcome.Validation.Field,
-			Message: outcome.Validation.Message,
-		}, nil
+		return toInputValidationError(outcome.Validation), nil
 	}
 	if outcome.User == nil {
 		return nil, gqlerr.Internal(ctx,

--- a/backend/internal/domain/cardgroup.go
+++ b/backend/internal/domain/cardgroup.go
@@ -29,6 +29,26 @@ type Cardgroup struct {
 	UpdatedAt time.Time
 }
 
+// NewCardgroup constructs a Cardgroup aggregate, generating a fresh UUID v7 ID
+// and stamping CreatedAt and UpdatedAt with the current UTC time. The name VO is
+// validated upstream by ParseCardgroupName; callers pass the parsed CardgroupName
+// so this constructor stays free of validation branching. Returns a wrapped error
+// when ID generation fails.
+func NewCardgroup(ownerID UserID, name CardgroupName) (*Cardgroup, error) {
+	id, err := NewID()
+	if err != nil {
+		return nil, eris.Wrap(err, "cardgroup: new id")
+	}
+	now := time.Now().UTC()
+	return &Cardgroup{
+		ID:        CardgroupID(id),
+		OwnerID:   ownerID,
+		Name:      name,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}, nil
+}
+
 // IsOwnedBy reports whether the cardgroup belongs to the user identified by userID.
 // Empty userID always returns false so callers do not need a redundant nil/empty guard.
 func (c Cardgroup) IsOwnedBy(userID UserID) bool {

--- a/backend/internal/domain/cardgroup_test.go
+++ b/backend/internal/domain/cardgroup_test.go
@@ -144,3 +144,36 @@ func TestCardgroup_IsOwnedBy_TypedEmptyHandle(t *testing.T) {
 	require.False(t, cg.IsOwnedBy(UserID("u-2")))
 	require.False(t, cg.IsOwnedBy(UserID("")), "empty UserID never matches")
 }
+
+func TestNewCardgroup(t *testing.T) {
+	t.Parallel()
+
+	owner := UserID("owner-001")
+	name := CardgroupName("My Deck")
+
+	before := time.Now().UTC()
+	cg, err := NewCardgroup(owner, name)
+	after := time.Now().UTC()
+
+	require.NoError(t, err)
+	require.NotNil(t, cg)
+
+	// A fresh UUID v7 id is generated and is non-empty.
+	require.NotEmpty(t, cg.ID)
+
+	// OwnerID and Name are carried through verbatim.
+	require.Equal(t, owner, cg.OwnerID)
+	require.Equal(t, name, cg.Name)
+
+	// CreatedAt and UpdatedAt are stamped with the current UTC time and are
+	// equal to each other (a freshly constructed aggregate has not been modified).
+	require.Equal(t, cg.CreatedAt, cg.UpdatedAt)
+	require.False(t, cg.CreatedAt.IsZero(), "CreatedAt must be stamped")
+	require.False(t, cg.CreatedAt.Before(before), "CreatedAt must be at or after the construction window start")
+	require.False(t, cg.CreatedAt.After(after), "CreatedAt must be at or before the construction window end")
+
+	// Two constructions produce distinct ids.
+	other, err := NewCardgroup(owner, name)
+	require.NoError(t, err)
+	require.NotEqual(t, cg.ID, other.ID)
+}

--- a/backend/internal/repository/user_card_fsrs.go
+++ b/backend/internal/repository/user_card_fsrs.go
@@ -63,27 +63,36 @@ func (r *userCardFSRSRepo) UpsertTx(ctx context.Context, tx *gorm.DB, u *domain.
 }
 
 func (r *userCardFSRSRepo) FindByUserAndCardIDs(ctx context.Context, userID string, cardIDs []string) (map[string]*domain.UserCardFSRS, error) {
-	if len(cardIDs) == 0 {
-		return map[string]*domain.UserCardFSRS{}, nil
-	}
-	var rows []gormUserCardFSRS
-	if err := r.db.WithContext(ctx).
-		Where("user_id = ? AND card_id IN ?", userID, cardIDs).
-		Find(&rows).Error; err != nil {
+	out, err := findUserCardFSRSByUserAndCardIDs(ctx, r.db, userID, cardIDs)
+	if err != nil {
 		return nil, eris.Wrap(err, "repository: find user card fsrs by user and card ids")
 	}
-	return rowsToUserCardFSRSMap(rows)
+	return out, nil
 }
 
 func (r *userCardFSRSRepo) FindByUserAndCardIDsTx(ctx context.Context, tx *gorm.DB, userID string, cardIDs []string) (map[string]*domain.UserCardFSRS, error) {
+	out, err := findUserCardFSRSByUserAndCardIDs(ctx, tx, userID, cardIDs)
+	if err != nil {
+		return nil, eris.Wrap(err, "repository: find user card fsrs by user and card ids tx")
+	}
+	return out, nil
+}
+
+// findUserCardFSRSByUserAndCardIDs is shared by FindByUserAndCardIDs (pool) and
+// FindByUserAndCardIDsTx (transaction). It runs the (user_id, card_id IN ?)
+// fetch against the supplied db handle and maps the rows into domain values. An
+// empty cardIDs slice returns an empty map with no SQL (GORM drops an empty
+// IN ? clause and would otherwise full-table scan). The error is returned
+// unwrapped so each caller can attach its own layer prefix.
+func findUserCardFSRSByUserAndCardIDs(ctx context.Context, db *gorm.DB, userID string, cardIDs []string) (map[string]*domain.UserCardFSRS, error) {
 	if len(cardIDs) == 0 {
 		return map[string]*domain.UserCardFSRS{}, nil
 	}
 	var rows []gormUserCardFSRS
-	if err := tx.WithContext(ctx).
+	if err := db.WithContext(ctx).
 		Where("user_id = ? AND card_id IN ?", userID, cardIDs).
 		Find(&rows).Error; err != nil {
-		return nil, eris.Wrap(err, "repository: find user card fsrs by user and card ids tx")
+		return nil, err
 	}
 	return rowsToUserCardFSRSMap(rows)
 }

--- a/backend/internal/usecase/card.go
+++ b/backend/internal/usecase/card.go
@@ -221,8 +221,8 @@ const (
 
 func (u *cardUsecase) Card(ctx context.Context, id string) (*domain.Card, error) {
 	user := auth.UserFrom(ctx)
-	if user == nil {
-		return nil, ucerr.ErrUnauthenticated
+	if err := requireCallerSub(user); err != nil {
+		return nil, err
 	}
 	card, err := u.cardRepo.FindByID(ctx, id)
 	if err != nil {
@@ -244,8 +244,8 @@ func (u *cardUsecase) Card(ctx context.Context, id string) (*domain.Card, error)
 // gqlerr.FromUsecaseError into the wire-format GraphQL error.
 func (u *cardUsecase) Create(ctx context.Context, in CreateCardInput) (CreateCardOutcome, error) {
 	user := auth.UserFrom(ctx)
-	if user == nil {
-		return CreateCardOutcome{}, ucerr.ErrUnauthenticated
+	if err := requireCallerSub(user); err != nil {
+		return CreateCardOutcome{}, err
 	}
 	if err := authorizeCardgroupOrBadInput(ctx, u.cardgroupRepo, domain.CardgroupID(in.CardgroupID), domain.UserID(user.Sub)); err != nil {
 		return CreateCardOutcome{}, err
@@ -278,8 +278,8 @@ func (u *cardUsecase) Create(ctx context.Context, in CreateCardInput) (CreateCar
 
 func (u *cardUsecase) Update(ctx context.Context, id string, in UpdateCardInput) (UpdateCardOutcome, error) {
 	user := auth.UserFrom(ctx)
-	if user == nil {
-		return UpdateCardOutcome{}, ucerr.ErrUnauthenticated
+	if err := requireCallerSub(user); err != nil {
+		return UpdateCardOutcome{}, err
 	}
 	existing, err := u.cardRepo.FindByID(ctx, id)
 	if err != nil {
@@ -341,8 +341,8 @@ func (u *cardUsecase) Update(ctx context.Context, id string, in UpdateCardInput)
 
 func (u *cardUsecase) Delete(ctx context.Context, id string) error {
 	user := auth.UserFrom(ctx)
-	if user == nil {
-		return ucerr.ErrUnauthenticated
+	if err := requireCallerSub(user); err != nil {
+		return err
 	}
 	card, err := u.cardRepo.FindByID(ctx, id)
 	if err != nil {
@@ -366,14 +366,14 @@ func (u *cardUsecase) ListCardsByCardgroupConnection(
 	ctx context.Context, in CardConnectionInput,
 ) (*CardConnectionOutput, error) {
 	user := auth.UserFrom(ctx)
-	if user == nil {
-		return nil, ucerr.ErrUnauthenticated
+	if err := requireCallerSub(user); err != nil {
+		return nil, err
 	}
 	if err := authorizeCardgroupOrBadInput(ctx, u.cardgroupRepo, domain.CardgroupID(in.CardgroupID), domain.UserID(user.Sub)); err != nil {
 		return nil, err
 	}
 
-	first, last, err := resolveRelayPage(in.First, in.Last, in.After, in.Before, resolvePageSize)
+	first, last, err := resolveRelayPage(in.First, in.Last, in.After, in.Before, resolveStandardPageSize)
 	if err != nil {
 		return nil, err
 	}
@@ -463,30 +463,6 @@ func resolveOrderBy(orderBy *CardOrderBy, dir *SortOrder) (repository.CardOrderB
 	return field, d, nil
 }
 
-// resolvePageSize clamps first/last to [0, maxPageSize] and rejects passing
-// both. Defaults first=defaultPageSize when neither is provided.
-func resolvePageSize(first, last *int) (int, int, error) {
-	if first != nil && last != nil {
-		return 0, 0, ucerr.NewValidationError("first", "specify either first or last")
-	}
-	if first == nil && last == nil {
-		return defaultPageSize, 0, nil
-	}
-	clamp := func(v int) int {
-		if v < 0 {
-			return 0
-		}
-		if v > maxPageSize {
-			return maxPageSize
-		}
-		return v
-	}
-	if first != nil {
-		return clamp(*first), 0, nil
-	}
-	return 0, clamp(*last), nil
-}
-
 // resolveCursor decodes an opaque cursor string into a *repository.CardCursor
 // with the field needed for the active orderBy populated. The cursor may be a
 // v1 envelope ("v1:" + base64) or a legacy bare UUID; both are accepted during
@@ -554,8 +530,8 @@ func (u *cardUsecase) resolveCursor(
 // exceeding the cap returns BAD_USER_INPUT.
 func (u *cardUsecase) BulkDelete(ctx context.Context, ids []string) (int64, error) {
 	user := auth.UserFrom(ctx)
-	if user == nil {
-		return 0, ucerr.ErrUnauthenticated
+	if err := requireCallerSub(user); err != nil {
+		return 0, err
 	}
 	if len(ids) > maxBulkDelete {
 		return 0, ucerr.NewValidationError("ids", fmt.Sprintf("at most %d ids per call", maxBulkDelete))

--- a/backend/internal/usecase/cardgroup.go
+++ b/backend/internal/usecase/cardgroup.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"errors"
 	"log/slog"
-	"time"
 
 	"github.com/rotisserie/eris"
 
@@ -106,8 +105,8 @@ func NewCardgroupUsecase(repo CardgroupRepository, admin AdminChecker, logger *s
 // A missing row returns (nil, nil) so the nullable GraphQL field resolves to null.
 func (u *cardgroupUsecase) Cardgroup(ctx context.Context, id string) (*domain.Cardgroup, error) {
 	user := auth.UserFrom(ctx)
-	if user == nil {
-		return nil, ucerr.ErrUnauthenticated
+	if err := requireCallerSub(user); err != nil {
+		return nil, err
 	}
 	cg, err := u.repo.FindByID(ctx, id)
 	if err != nil {
@@ -184,8 +183,8 @@ func checkCardgroupLimit(ctx context.Context, counter cardgroupOwnerCounter, adm
 // Create creates a new cardgroup owned by the authenticated caller.
 func (u *cardgroupUsecase) Create(ctx context.Context, in CreateCardgroupInput) (CreateCardgroupOutcome, error) {
 	user := auth.UserFrom(ctx)
-	if user == nil {
-		return CreateCardgroupOutcome{}, ucerr.ErrUnauthenticated
+	if err := requireCallerSub(user); err != nil {
+		return CreateCardgroupOutcome{}, err
 	}
 
 	name, nameErr := domain.ParseCardgroupName(in.Name)
@@ -208,18 +207,9 @@ func (u *cardgroupUsecase) Create(ctx context.Context, in CreateCardgroupInput) 
 		return CreateCardgroupOutcome{LimitReached: limit}, nil
 	}
 
-	id, err := domain.NewID()
+	cg, err := domain.NewCardgroup(domain.UserID(user.Sub), name)
 	if err != nil {
-		return CreateCardgroupOutcome{}, eris.Wrap(err, "usecase: cardgroup: generate id")
-	}
-
-	now := time.Now().UTC()
-	cg := &domain.Cardgroup{
-		ID:        domain.CardgroupID(id),
-		OwnerID:   domain.UserID(user.Sub),
-		Name:      name,
-		CreatedAt: now,
-		UpdatedAt: now,
+		return CreateCardgroupOutcome{}, eris.Wrap(err, "usecase: cardgroup: new cardgroup")
 	}
 
 	if err := u.repo.Create(ctx, cg); err != nil {
@@ -247,8 +237,8 @@ type UpdateCardgroupOutcome struct {
 // without any database write.
 func (u *cardgroupUsecase) Update(ctx context.Context, id string, in UpdateCardgroupInput) (UpdateCardgroupOutcome, error) {
 	user := auth.UserFrom(ctx)
-	if user == nil {
-		return UpdateCardgroupOutcome{}, ucerr.ErrUnauthenticated
+	if err := requireCallerSub(user); err != nil {
+		return UpdateCardgroupOutcome{}, err
 	}
 
 	existing, err := u.repo.FindByID(ctx, id)
@@ -292,8 +282,8 @@ func (u *cardgroupUsecase) Update(ctx context.Context, id string, in UpdateCardg
 // Non-owners and missing rows both return UNAUTHENTICATED to prevent ID enumeration.
 func (u *cardgroupUsecase) Delete(ctx context.Context, id string) error {
 	user := auth.UserFrom(ctx)
-	if user == nil {
-		return ucerr.ErrUnauthenticated
+	if err := requireCallerSub(user); err != nil {
+		return err
 	}
 
 	existing, err := u.repo.FindByID(ctx, id)
@@ -325,11 +315,11 @@ func (u *cardgroupUsecase) ListCardgroupsByOwnerConnection(
 	ctx context.Context, in CardgroupConnectionInput,
 ) (*CardgroupConnectionOutput, error) {
 	user := auth.UserFrom(ctx)
-	if user == nil {
-		return nil, ucerr.ErrUnauthenticated
+	if err := requireCallerSub(user); err != nil {
+		return nil, err
 	}
 
-	first, last, err := resolveRelayPage(in.First, in.Last, in.After, in.Before, resolveCardgroupPageSize)
+	first, last, err := resolveRelayPage(in.First, in.Last, in.After, in.Before, resolveStandardPageSize)
 	if err != nil {
 		return nil, err
 	}
@@ -413,32 +403,6 @@ func resolveCardgroupOrderBy(
 		}
 	}
 	return field, d, nil
-}
-
-// resolveCardgroupPageSize clamps first/last to [0, maxPageSize] and rejects
-// passing both. Defaults first=defaultPageSize (20) when neither is provided,
-// matching the schema's documented default. maxPageSize is the package-wide
-// cap shared with the card/master-catalog resolvers.
-func resolveCardgroupPageSize(first, last *int) (int, int, error) {
-	if first != nil && last != nil {
-		return 0, 0, ucerr.NewValidationError("first", "specify either first or last, not both")
-	}
-	if first == nil && last == nil {
-		return defaultPageSize, 0, nil
-	}
-	clamp := func(v int) int {
-		if v < 0 {
-			return 0
-		}
-		if v > maxPageSize {
-			return maxPageSize
-		}
-		return v
-	}
-	if first != nil {
-		return clamp(*first), 0, nil
-	}
-	return 0, clamp(*last), nil
 }
 
 // resolveCardgroupCursor decodes an opaque cursor string into a

--- a/backend/internal/usecase/cardgroup_test.go
+++ b/backend/internal/usecase/cardgroup_test.go
@@ -1002,7 +1002,7 @@ func TestCardgroupUC_Connection_Anonymous(t *testing.T) {
 
 // TestCardgroupUC_ConnectionGuards_FirstAndLast verifies that supplying both
 // first and last is rejected with BAD_USER_INPUT(field="first") via
-// resolveCardgroupPageSize.
+// resolveStandardPageSize.
 func TestCardgroupUC_ConnectionGuards_FirstAndLast(t *testing.T) {
 	t.Parallel()
 	repo := &mockCardgroupRepository{}
@@ -1223,7 +1223,7 @@ func TestCardgroupUC_Connection_DefaultOrderBy_WhenNil(t *testing.T) {
 
 // TestCardgroupUC_Connection_DefaultPageSize_WhenAllNil verifies that when
 // neither first nor last is supplied (and neither is a cursor), the
-// resolveCardgroupPageSize default of 20 is used.
+// resolveStandardPageSize default of 20 is used.
 func TestCardgroupUC_Connection_DefaultPageSize_WhenAllNil(t *testing.T) {
 	t.Parallel()
 
@@ -1568,7 +1568,7 @@ func TestCardgroupUC_Connection_CountError_Internal(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// resolveCardgroupOrderBy / resolveCardgroupPageSize / resolveCardgroupCursor
+// resolveCardgroupOrderBy / resolveStandardPageSize / resolveCardgroupCursor
 // — direct unit tests for branches that are hard to reach end-to-end.
 // ---------------------------------------------------------------------------
 
@@ -1599,7 +1599,7 @@ func TestResolveCardgroupPageSize_LastClamp(t *testing.T) {
 	t.Parallel()
 
 	last := 9999
-	first, gotLast, err := resolveCardgroupPageSize(nil, &last)
+	first, gotLast, err := resolveStandardPageSize(nil, &last)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1617,7 +1617,7 @@ func TestResolveCardgroupPageSize_LastNegativeClampedToZero(t *testing.T) {
 	t.Parallel()
 
 	last := -7
-	first, gotLast, err := resolveCardgroupPageSize(nil, &last)
+	first, gotLast, err := resolveStandardPageSize(nil, &last)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/backend/internal/usecase/learn.go
+++ b/backend/internal/usecase/learn.go
@@ -136,8 +136,8 @@ func NewLearnUsecase(
 // (callers only need the ownership decision and the user's Sub).
 func (u *learnUsecase) authorizeCardgroupForLearn(ctx context.Context, cardgroupID string) (*auth.AuthUser, error) {
 	user := auth.UserFrom(ctx)
-	if user == nil {
-		return nil, ucerr.ErrUnauthenticated
+	if err := requireCallerSub(user); err != nil {
+		return nil, err
 	}
 	cg, err := u.cardgroupRepo.FindByID(ctx, cardgroupID)
 	if err != nil {

--- a/backend/internal/usecase/master_catalog.go
+++ b/backend/internal/usecase/master_catalog.go
@@ -162,7 +162,7 @@ func (u *masterCatalogUsecase) ListPublishedConnection(
 		return nil, ucerr.ErrUnauthenticated
 	}
 
-	first, last, err := resolveRelayPage(in.First, in.Last, in.After, in.Before, resolveMasterCatalogPageSize)
+	first, last, err := resolveRelayPage(in.First, in.Last, in.After, in.Before, resolveStandardPageSize)
 	if err != nil {
 		return nil, err
 	}
@@ -242,34 +242,6 @@ func resolveMasterCatalogOrderBy(
 		}
 	}
 	return field, d, nil
-}
-
-// resolveMasterCatalogPageSize clamps first/last to [0, maxPageSize] and rejects
-// passing both. Defaults first=defaultPageSize (20) when neither is provided,
-// matching the schema's documented default. maxPageSize/defaultPageSize are the
-// package-wide page-size caps shared with the card/cardgroup resolvers; the
-// repository-level cap (repository.PageCap = maxPageSize + 1) is one greater so
-// the "+1 fetch" trick survives a maximum-sized request.
-func resolveMasterCatalogPageSize(first, last *int) (int, int, error) {
-	if first != nil && last != nil {
-		return 0, 0, ucerr.NewValidationError("first", "specify either first or last, not both")
-	}
-	if first == nil && last == nil {
-		return defaultPageSize, 0, nil
-	}
-	clamp := func(v int) int {
-		if v < 0 {
-			return 0
-		}
-		if v > maxPageSize {
-			return maxPageSize
-		}
-		return v
-	}
-	if first != nil {
-		return clamp(*first), 0, nil
-	}
-	return 0, clamp(*last), nil
 }
 
 // resolveMasterCatalogCursor decodes an opaque cursor string into a
@@ -576,7 +548,7 @@ func (u *masterCatalogUsecase) ListAdminConnection(
 		return nil, err
 	}
 
-	first, last, err := resolveRelayPage(in.First, in.Last, in.After, in.Before, resolveMasterCatalogPageSize)
+	first, last, err := resolveRelayPage(in.First, in.Last, in.After, in.Before, resolveStandardPageSize)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/usecase/master_catalog_test.go
+++ b/backend/internal/usecase/master_catalog_test.go
@@ -497,7 +497,7 @@ func TestResolveMasterCatalogOrderBy_Invalid(t *testing.T) {
 }
 
 func TestResolveMasterCatalogPageSize_ClampsAtMax(t *testing.T) {
-	first, _, err := resolveMasterCatalogPageSize(intPtr(1000), nil)
+	first, _, err := resolveStandardPageSize(intPtr(1000), nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -507,7 +507,7 @@ func TestResolveMasterCatalogPageSize_ClampsAtMax(t *testing.T) {
 }
 
 func TestResolveMasterCatalogPageSize_DefaultWhenAbsent(t *testing.T) {
-	first, last, err := resolveMasterCatalogPageSize(nil, nil)
+	first, last, err := resolveStandardPageSize(nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/backend/internal/usecase/master_deck.go
+++ b/backend/internal/usecase/master_deck.go
@@ -3,7 +3,6 @@ package usecase
 import (
 	"context"
 	"log/slog"
-	"time"
 
 	"github.com/rotisserie/eris"
 	"gorm.io/gorm"
@@ -241,28 +240,20 @@ func (u *masterDeckUsecase) copyMasterToUserTx(ctx context.Context, tx *gorm.DB,
 		return nil, eris.Wrap(err, "list master cards")
 	}
 
-	newCGID, err := domain.NewID()
+	newCG, err := domain.NewCardgroup(domain.UserID(ownerID), master.Name)
 	if err != nil {
-		return nil, eris.Wrap(err, "new cardgroup id")
-	}
-
-	now := time.Now().UTC()
-	newCG := &domain.Cardgroup{
-		ID:        domain.CardgroupID(newCGID),
-		OwnerID:   domain.UserID(ownerID),
-		Name:      master.Name,
-		CreatedAt: now,
-		UpdatedAt: now,
+		return nil, eris.Wrap(err, "new cardgroup")
 	}
 	if err := u.userCG.CreateTx(ctx, tx, newCG); err != nil {
 		return nil, eris.Wrap(err, "create user cardgroup")
 	}
 
+	now := newCG.CreatedAt
 	userCards := make([]*domain.Card, 0, len(cards))
 	for _, mc := range cards {
 		// The source master cards are already valid; the constructor re-parses
 		// the text (idempotent) and generates the new user-card ID.
-		card, err := domain.NewCard(domain.CardgroupID(newCGID), mc.Front.String(), mc.Back.String(), mc.Position)
+		card, err := domain.NewCard(newCG.ID, mc.Front.String(), mc.Back.String(), mc.Position)
 		if err != nil {
 			return nil, eris.Wrap(err, "new card from master")
 		}

--- a/backend/internal/usecase/page.go
+++ b/backend/internal/usecase/page.go
@@ -1,5 +1,38 @@
 package usecase
 
+import "backend/internal/usecase/ucerr"
+
+// resolveStandardPageSize clamps first/last to [0, maxPageSize] and rejects
+// passing both. Defaults first=defaultPageSize (20) when neither is provided,
+// matching the schema's documented default. maxPageSize/defaultPageSize are the
+// package-wide page-size caps (declared in card.go) shared by the card,
+// cardgroup, and master-catalog connection resolvers; the repository-level cap
+// (repository.PageCap = maxPageSize + 1) is one greater so the "+1 fetch" trick
+// survives a maximum-sized request. The admin connections deliberately do NOT
+// use this resolver (resolveAdminPageSize defaults to maxPageSize and rejects
+// rather than clamps out-of-range values).
+func resolveStandardPageSize(first, last *int) (int, int, error) {
+	if first != nil && last != nil {
+		return 0, 0, ucerr.NewValidationError("first", "specify either first or last, not both")
+	}
+	if first == nil && last == nil {
+		return defaultPageSize, 0, nil
+	}
+	clamp := func(v int) int {
+		if v < 0 {
+			return 0
+		}
+		if v > maxPageSize {
+			return maxPageSize
+		}
+		return v
+	}
+	if first != nil {
+		return clamp(*first), 0, nil
+	}
+	return 0, clamp(*last), nil
+}
+
 // TrimAndDetect trims one trailing item from items when len(items) > want and
 // returns (trimmed, true) so the caller can set hasNextPage / hasPreviousPage.
 // Used after the repository's "+1 fetch" trick for forward pagination: ask for

--- a/backend/internal/usecase/swipe.go
+++ b/backend/internal/usecase/swipe.go
@@ -130,8 +130,8 @@ func NewSwipeUsecaseWithTx(
 
 func (u *swipeUsecase) HandleSwipe(ctx context.Context, in HandleSwipeInput) (HandleSwipeOutcome, error) {
 	user := auth.UserFrom(ctx)
-	if user == nil {
-		return HandleSwipeOutcome{}, ucerr.ErrUnauthenticated
+	if err := requireCallerSub(user); err != nil {
+		return HandleSwipeOutcome{}, err
 	}
 	rating, err := domain.RatingFromSwipeMode(in.Mode)
 	if err != nil {

--- a/backend/internal/usecase/user.go
+++ b/backend/internal/usecase/user.go
@@ -64,8 +64,8 @@ func NewUserUsecase(repo UserRepository, roles UserRolesRepository, authSvc Admi
 
 func (u *userUsecase) Me(ctx context.Context) (*domain.User, error) {
 	user := auth.UserFrom(ctx)
-	if user == nil {
-		return nil, ucerr.ErrUnauthenticated
+	if err := requireCallerSub(user); err != nil {
+		return nil, err
 	}
 	appUser, err := u.repo.FindByID(ctx, user.Sub)
 	if err == nil {
@@ -135,8 +135,8 @@ type UpdateProfileOutcome struct {
 // field, not on the error channel.
 func (u *userUsecase) UpdateUser(ctx context.Context, in UpdateUserInput) (UpdateProfileOutcome, error) {
 	user := auth.UserFrom(ctx)
-	if user == nil {
-		return UpdateProfileOutcome{}, ucerr.ErrUnauthenticated
+	if err := requireCallerSub(user); err != nil {
+		return UpdateProfileOutcome{}, err
 	}
 
 	dn, err := domain.ParseDisplayName(in.DisplayName)


### PR DESCRIPTION
## Summary

Six byte-level / near-byte-level duplications surfaced by a 2026-06-15 DDD/layered-architecture review, collapsed into shared helpers. **Pure DRY refactor — net −59 production lines, no user-visible behaviour change** (one site additionally closes a latent empty-`Sub` gap, noted below).

No tracking issue — companion to `fix/backend-latent-silent-failures` and `test/shared-bootstrap-auth-schema` from the same review.

## Changes

### `refactor(usecase)`
- **`resolveStandardPageSize`** — the three byte-identical clamp functions (`resolvePageSize` / `resolveCardgroupPageSize` / `resolveMasterCatalogPageSize`, which had already drifted on one error string) collapse to one shared helper in `page.go`. `resolveAdminPageSize` keeps its distinct default-max / reject-not-clamp semantics and stays separate.
- **`requireCallerSub`** — 16 inline `user := auth.UserFrom(ctx); if user == nil { … ucerr.ErrUnauthenticated }` guards now route through the existing helper, which additionally rejects an empty `Sub` (a latent gap the inline form left open). The anti-enumeration `ErrUnauthenticated` returns (not-found / owner-check paths) are left intact.
- **`domain.NewCardgroup`** — id-gen + timestamp + struct-literal creation was open-coded in `cardgroup.go` and `master_deck.go`; both now call a `NewCardgroup` constructor that mirrors the existing `NewCard`.

### `refactor(resolver)`
- **`buildPageInfo`** — the identical `&model.PageInfo{…}` assembly in the four `to*ConnectionModel` funcs is extracted; the per-type edge loops stay as-is.
- **`toInputValidationError`** — the 10 hand-written `model.InputValidationError{Field, Message}` mappings route through one helper in `mapper.go`.

### `refactor(repository)`
- **`findUserCardFSRSByUserAndCardIDs`** — the `FindByUserAndCardIDs` Tx / non-Tx pair now share a private helper (mirroring `findRolesByIDs`), preserving each method's wrap message and the empty-slice guard.

## Verification

```bash
cd backend
go build ./... && go vet ./... && go tool go-arch-lint check --project-path .
go test -race ./...
```

Behaviour-preserving — the existing suites are the proof. Helper call-site counts verified (e.g. 10 `toInputValidationError` sites, 0 inline `model.InputValidationError{` remaining; 0 inline `user == nil` guards remaining).
