### PR TITLE
test(backend): extract shared bootstrapAuthSchema helper and fix grant drift

### DIFF
--- a/backend/.go-arch-lint.yml
+++ b/backend/.go-arch-lint.yml
@@ -18,6 +18,7 @@ components:
   cefr:                { in: internal/cefr }
   cursor:              { in: internal/cursor }
   database:            { in: internal/database }
+  database_testsupport: { in: internal/database/testsupport }
   domain:              { in: internal/domain }
   domain_service:      { in: internal/domain/service }
   gqlerr:              { in: internal/gqlerr }
@@ -49,6 +50,7 @@ deps:
   cefr:               { mayDependOn: [domain] }
   cursor:             { anyVendorDeps: true }           # leaf: vendor-only deps (eris, std)
   database:           { anyVendorDeps: true }           # leaf: vendor-only deps (gorm, pgx, migrate, eris)
+  database_testsupport: { anyVendorDeps: true }         # leaf: test-only helper, vendor-only deps (pgx, eris)
   domain:             { anyVendorDeps: true }           # leaf: vendor-only deps (uuid, uniseg, eris)
   domain_service:     { mayDependOn: [domain] }
   gqlerr:             { mayDependOn: [logging, ucerr] }

--- a/backend/cmd/migrate-to-master/main_test.go
+++ b/backend/cmd/migrate-to-master/main_test.go
@@ -14,6 +14,7 @@ import (
 	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
 
 	"backend/internal/database"
+	"backend/internal/database/testsupport"
 	_ "github.com/jackc/pgx/v5/stdlib"
 )
 
@@ -47,7 +48,7 @@ func runTests(m *testing.M) int {
 		fmt.Fprintf(os.Stderr, "conn string: %v\n", err)
 		return 1
 	}
-	if err := bootstrapAuthSchema(ctx, dsn); err != nil {
+	if err := testsupport.BootstrapAuthSchema(ctx, dsn); err != nil {
 		fmt.Fprintf(os.Stderr, "bootstrap: %v\n", err)
 		return 1
 	}
@@ -57,46 +58,6 @@ func runTests(m *testing.M) int {
 	}
 	testDBURL = dsn
 	return m.Run()
-}
-
-func bootstrapAuthSchema(ctx context.Context, dsn string) error {
-	cfg, err := pgxpool.ParseConfig(dsn)
-	if err != nil {
-		return err
-	}
-	pool, err := pgxpool.NewWithConfig(ctx, cfg)
-	if err != nil {
-		return err
-	}
-	defer pool.Close()
-	_, err = pool.Exec(ctx, `
-        DO $$
-        BEGIN
-            IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'authenticated') THEN
-                CREATE ROLE authenticated LOGIN PASSWORD 'test';
-            END IF;
-        END
-        $$;
-        CREATE SCHEMA IF NOT EXISTS auth;
-        CREATE TABLE IF NOT EXISTS auth.users (
-            id uuid PRIMARY KEY,
-            email text
-        );
-        CREATE OR REPLACE FUNCTION auth.uid()
-        RETURNS uuid
-        LANGUAGE sql
-        STABLE
-        AS $$
-            SELECT COALESCE(
-                NULLIF(current_setting('request.jwt.claim.sub', true), ''),
-                NULLIF(current_setting('request.jwt.claims', true), '')::jsonb ->> 'sub'
-            )::uuid
-        $$;
-        GRANT USAGE ON SCHEMA auth TO authenticated;
-        GRANT EXECUTE ON FUNCTION auth.uid() TO authenticated;
-        GRANT USAGE ON SCHEMA public TO authenticated;
-    `)
-	return err
 }
 
 func openPool(t *testing.T) *pgxpool.Pool {

--- a/backend/cmd/seed/main_test.go
+++ b/backend/cmd/seed/main_test.go
@@ -16,6 +16,7 @@ import (
 	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
 
 	"backend/internal/database"
+	"backend/internal/database/testsupport"
 	_ "github.com/jackc/pgx/v5/stdlib"
 )
 
@@ -49,7 +50,7 @@ func runTests(m *testing.M) int {
 		fmt.Fprintf(os.Stderr, "conn string: %v\n", err)
 		return 1
 	}
-	if err := bootstrapAuthSchema(ctx, dsn); err != nil {
+	if err := testsupport.BootstrapAuthSchema(ctx, dsn); err != nil {
 		fmt.Fprintf(os.Stderr, "bootstrap: %v\n", err)
 		return 1
 	}
@@ -59,50 +60,6 @@ func runTests(m *testing.M) int {
 	}
 	testDBURL = dsn
 	return m.Run()
-}
-
-func bootstrapAuthSchema(ctx context.Context, dsn string) error {
-	cfg, err := pgxpool.ParseConfig(dsn)
-	if err != nil {
-		return err
-	}
-	pool, err := pgxpool.NewWithConfig(ctx, cfg)
-	if err != nil {
-		return err
-	}
-	defer pool.Close()
-	_, err = pool.Exec(ctx, `
-        DO $$
-        BEGIN
-            IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'authenticated') THEN
-                CREATE ROLE authenticated LOGIN PASSWORD 'test';
-            END IF;
-        END
-        $$;
-        CREATE SCHEMA IF NOT EXISTS auth;
-        CREATE TABLE IF NOT EXISTS auth.users (
-            id uuid PRIMARY KEY,
-            email text
-        );
-        CREATE OR REPLACE FUNCTION auth.uid()
-        RETURNS uuid
-        LANGUAGE sql
-        STABLE
-        AS $$
-            SELECT COALESCE(
-                NULLIF(current_setting('request.jwt.claim.sub', true), ''),
-                NULLIF(current_setting('request.jwt.claims', true), '')::jsonb ->> 'sub'
-            )::uuid
-        $$;
-        GRANT USAGE ON SCHEMA auth TO authenticated;
-        GRANT EXECUTE ON FUNCTION auth.uid() TO authenticated;
-        GRANT USAGE ON SCHEMA public TO authenticated;
-        ALTER DEFAULT PRIVILEGES IN SCHEMA public
-            GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO authenticated;
-        ALTER DEFAULT PRIVILEGES IN SCHEMA public
-            GRANT USAGE, SELECT ON SEQUENCES TO authenticated;
-    `)
-	return err
 }
 
 func openPool(t *testing.T) *pgxpool.Pool {

--- a/backend/cmd/server/main_test.go
+++ b/backend/cmd/server/main_test.go
@@ -42,6 +42,7 @@ import (
 	"backend/graph/resolver"
 	"backend/internal/auth"
 	"backend/internal/database"
+	"backend/internal/database/testsupport"
 	"backend/internal/domain"
 	"backend/internal/domain/service"
 	"backend/internal/gqlerr"
@@ -97,7 +98,7 @@ func runTests(m *testing.M) int {
 		fmt.Fprintf(os.Stderr, "conn string: %v\n", err)
 		return 1
 	}
-	if err := bootstrapAuthSchema(ctx, dsn); err != nil {
+	if err := testsupport.BootstrapAuthSchema(ctx, dsn); err != nil {
 		fmt.Fprintf(os.Stderr, "bootstrap: %v\n", err)
 		return 1
 	}
@@ -107,52 +108,6 @@ func runTests(m *testing.M) int {
 	}
 	testDBURL = dsn
 	return m.Run()
-}
-
-// bootstrapAuthSchema mimics the Supabase-managed auth schema and roles just
-// enough for FK, trigger, and RLS policy references in migrations to resolve.
-func bootstrapAuthSchema(ctx context.Context, dsn string) error {
-	cfg, err := pgxpool.ParseConfig(dsn)
-	if err != nil {
-		return err
-	}
-	pool, err := pgxpool.NewWithConfig(ctx, cfg)
-	if err != nil {
-		return err
-	}
-	defer pool.Close()
-	_, err = pool.Exec(ctx, `
-        DO $$
-        BEGIN
-            IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'authenticated') THEN
-                CREATE ROLE authenticated LOGIN PASSWORD 'test';
-            END IF;
-        END
-        $$;
-        CREATE SCHEMA IF NOT EXISTS auth;
-        CREATE TABLE IF NOT EXISTS auth.users (
-            id uuid PRIMARY KEY,
-            email text
-        );
-        CREATE OR REPLACE FUNCTION auth.uid()
-        RETURNS uuid
-        LANGUAGE sql
-        STABLE
-        AS $$
-            SELECT COALESCE(
-                NULLIF(current_setting('request.jwt.claim.sub', true), ''),
-                NULLIF(current_setting('request.jwt.claims', true), '')::jsonb ->> 'sub'
-            )::uuid
-        $$;
-        GRANT USAGE ON SCHEMA auth TO authenticated;
-        GRANT EXECUTE ON FUNCTION auth.uid() TO authenticated;
-        GRANT USAGE ON SCHEMA public TO authenticated;
-        ALTER DEFAULT PRIVILEGES IN SCHEMA public
-            GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO authenticated;
-        ALTER DEFAULT PRIVILEGES IN SCHEMA public
-            GRANT USAGE, SELECT ON SEQUENCES TO authenticated;
-    `)
-	return err
 }
 
 func noopAuthMW(next echo.HandlerFunc) echo.HandlerFunc {

--- a/backend/internal/database/pool_test.go
+++ b/backend/internal/database/pool_test.go
@@ -7,11 +7,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/testcontainers/testcontainers-go"
 	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
 
 	"backend/internal/database"
+	"backend/internal/database/testsupport"
 )
 
 var testDSN string
@@ -46,58 +46,12 @@ func runTests(m *testing.M) int {
 		fmt.Fprintf(os.Stderr, "connection string: %v\n", err)
 		return 1
 	}
-	if err := bootstrapAuthSchema(ctx, dsn); err != nil {
+	if err := testsupport.BootstrapAuthSchema(ctx, dsn); err != nil {
 		fmt.Fprintf(os.Stderr, "bootstrap auth schema: %v\n", err)
 		return 1
 	}
 	testDSN = dsn
 	return m.Run()
-}
-
-// bootstrapAuthSchema mimics the Supabase-managed auth schema and roles just
-// enough for FK, trigger, and RLS policy references in migrations to resolve.
-func bootstrapAuthSchema(ctx context.Context, dsn string) error {
-	cfg, err := pgxpool.ParseConfig(dsn)
-	if err != nil {
-		return err
-	}
-	pool, err := pgxpool.NewWithConfig(ctx, cfg)
-	if err != nil {
-		return err
-	}
-	defer pool.Close()
-	_, err = pool.Exec(ctx, `
-        DO $$
-        BEGIN
-            IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'authenticated') THEN
-                CREATE ROLE authenticated LOGIN PASSWORD 'test';
-            END IF;
-        END
-        $$;
-        CREATE SCHEMA IF NOT EXISTS auth;
-        CREATE TABLE IF NOT EXISTS auth.users (
-            id uuid PRIMARY KEY,
-            email text
-        );
-        CREATE OR REPLACE FUNCTION auth.uid()
-        RETURNS uuid
-        LANGUAGE sql
-        STABLE
-        AS $$
-            SELECT COALESCE(
-                NULLIF(current_setting('request.jwt.claim.sub', true), ''),
-                NULLIF(current_setting('request.jwt.claims', true), '')::jsonb ->> 'sub'
-            )::uuid
-        $$;
-        GRANT USAGE ON SCHEMA auth TO authenticated;
-        GRANT EXECUTE ON FUNCTION auth.uid() TO authenticated;
-        GRANT USAGE ON SCHEMA public TO authenticated;
-        ALTER DEFAULT PRIVILEGES IN SCHEMA public
-            GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO authenticated;
-        ALTER DEFAULT PRIVILEGES IN SCHEMA public
-            GRANT USAGE, SELECT ON SEQUENCES TO authenticated;
-    `)
-	return err
 }
 
 func TestOpenAndPing(t *testing.T) {

--- a/backend/internal/database/testsupport/auth_schema.go
+++ b/backend/internal/database/testsupport/auth_schema.go
@@ -1,0 +1,64 @@
+// Package testsupport provides shared helpers for integration tests that run
+// against a real Postgres (via testcontainers). It deliberately holds no test
+// files itself so it can be imported as a normal package from any *_test.go in
+// the backend.
+package testsupport
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/rotisserie/eris"
+)
+
+// BootstrapAuthSchema mimics the Supabase-managed auth schema and roles just
+// enough for FK, trigger, and RLS policy references in migrations to resolve.
+// It connects to dsn, creates the `authenticated` role, the `auth` schema with
+// the `auth.users` table and `auth.uid()` function, and grants the privileges
+// (including ALTER DEFAULT PRIVILEGES for future tables/sequences) that RLS
+// policies rely on. Run it before database.Migrate against a throwaway test DB.
+func BootstrapAuthSchema(ctx context.Context, dsn string) error {
+	cfg, err := pgxpool.ParseConfig(dsn)
+	if err != nil {
+		return eris.Wrap(err, "testsupport: parse dsn")
+	}
+	pool, err := pgxpool.NewWithConfig(ctx, cfg)
+	if err != nil {
+		return eris.Wrap(err, "testsupport: open pool")
+	}
+	defer pool.Close()
+	if _, err := pool.Exec(ctx, `
+        DO $$
+        BEGIN
+            IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'authenticated') THEN
+                CREATE ROLE authenticated LOGIN PASSWORD 'test';
+            END IF;
+        END
+        $$;
+        CREATE SCHEMA IF NOT EXISTS auth;
+        CREATE TABLE IF NOT EXISTS auth.users (
+            id uuid PRIMARY KEY,
+            email text
+        );
+        CREATE OR REPLACE FUNCTION auth.uid()
+        RETURNS uuid
+        LANGUAGE sql
+        STABLE
+        AS $$
+            SELECT COALESCE(
+                NULLIF(current_setting('request.jwt.claim.sub', true), ''),
+                NULLIF(current_setting('request.jwt.claims', true), '')::jsonb ->> 'sub'
+            )::uuid
+        $$;
+        GRANT USAGE ON SCHEMA auth TO authenticated;
+        GRANT EXECUTE ON FUNCTION auth.uid() TO authenticated;
+        GRANT USAGE ON SCHEMA public TO authenticated;
+        ALTER DEFAULT PRIVILEGES IN SCHEMA public
+            GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO authenticated;
+        ALTER DEFAULT PRIVILEGES IN SCHEMA public
+            GRANT USAGE, SELECT ON SEQUENCES TO authenticated;
+    `); err != nil {
+		return eris.Wrap(err, "testsupport: exec bootstrap auth schema")
+	}
+	return nil
+}

--- a/backend/internal/repository/user_test.go
+++ b/backend/internal/repository/user_test.go
@@ -10,12 +10,12 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/testcontainers/testcontainers-go"
 	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
 	"gorm.io/gorm"
 
 	"backend/internal/database"
+	"backend/internal/database/testsupport"
 	"backend/internal/repository"
 )
 
@@ -54,7 +54,7 @@ func runTests(m *testing.M) int {
 		fmt.Fprintf(os.Stderr, "conn string: %v\n", err)
 		return 1
 	}
-	if err := bootstrapAuthSchema(ctx, dsn); err != nil {
+	if err := testsupport.BootstrapAuthSchema(ctx, dsn); err != nil {
 		fmt.Fprintf(os.Stderr, "bootstrap auth schema: %v\n", err)
 		return 1
 	}
@@ -73,52 +73,6 @@ func runTests(m *testing.M) int {
 	testDSN = dsn
 	testDB = db
 	return m.Run()
-}
-
-// bootstrapAuthSchema mimics the Supabase-managed auth schema and roles just
-// enough for FK, trigger, and RLS policy references in migrations to resolve.
-func bootstrapAuthSchema(ctx context.Context, dsn string) error {
-	cfg, err := pgxpool.ParseConfig(dsn)
-	if err != nil {
-		return err
-	}
-	pool, err := pgxpool.NewWithConfig(ctx, cfg)
-	if err != nil {
-		return err
-	}
-	defer pool.Close()
-	_, err = pool.Exec(ctx, `
-        DO $$
-        BEGIN
-            IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'authenticated') THEN
-                CREATE ROLE authenticated LOGIN PASSWORD 'test';
-            END IF;
-        END
-        $$;
-        CREATE SCHEMA IF NOT EXISTS auth;
-        CREATE TABLE IF NOT EXISTS auth.users (
-            id uuid PRIMARY KEY,
-            email text
-        );
-        CREATE OR REPLACE FUNCTION auth.uid()
-        RETURNS uuid
-        LANGUAGE sql
-        STABLE
-        AS $$
-            SELECT COALESCE(
-                NULLIF(current_setting('request.jwt.claim.sub', true), ''),
-                NULLIF(current_setting('request.jwt.claims', true), '')::jsonb ->> 'sub'
-            )::uuid
-        $$;
-        GRANT USAGE ON SCHEMA auth TO authenticated;
-        GRANT EXECUTE ON FUNCTION auth.uid() TO authenticated;
-        GRANT USAGE ON SCHEMA public TO authenticated;
-        ALTER DEFAULT PRIVILEGES IN SCHEMA public
-            GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO authenticated;
-        ALTER DEFAULT PRIVILEGES IN SCHEMA public
-            GRANT USAGE, SELECT ON SEQUENCES TO authenticated;
-    `)
-	return err
 }
 
 // insertAuthUser inserts a fresh row in auth.users so the trigger creates a

--- a/codecov.yml
+++ b/codecov.yml
@@ -32,3 +32,9 @@ comment:
   layout: "reach, diff, flags, files"
   behavior: default
   require_changes: false
+
+ignore:
+  # Test-support helpers (testcontainers DB bootstrap) are exercised by the
+  # consuming packages' tests, but `go test ./...` only credits coverage to the
+  # package that owns the test, so the helper shows 0% and skews patch coverage.
+  - "backend/internal/database/testsupport"


### PR DESCRIPTION
## Summary

The 43-line `bootstrapAuthSchema` Supabase-auth bootstrap helper was copy-pasted into five `*_test.go` files — and one copy had already drifted. Extracted to one importable test-support package. **Net −153 lines; also fixes a real test-fixture drift.**

No tracking issue — companion to `fix/backend-latent-silent-failures` and `refactor/backend-helper-dedup` from the same 2026-06-15 review.

## Changes

### New `internal/database/testsupport` package
- `BootstrapAuthSchema(ctx, dsn) error` — the complete auth-schema bootstrap (`CREATE SCHEMA auth`, `auth.users`, and the **full** `ALTER DEFAULT PRIVILEGES` grants), eris-wrapped. Registered in `.go-arch-lint.yml` as a leaf component (`anyVendorDeps: true`); imports only stdlib + `pgxpool` + `eris`.

### Deduped 5 call sites
`repository/user_test.go`, `cmd/server/main_test.go`, `internal/database/pool_test.go`, `cmd/seed/main_test.go`, and `cmd/migrate-to-master/main_test.go` each drop their local copy and call `testsupport.BootstrapAuthSchema`.

### Drift fixed
The `cmd/migrate-to-master` copy was missing the `ALTER DEFAULT PRIVILEGES … GRANT` blocks the other four carried — it now bootstraps with the complete grants via the shared helper.

## Verification

```bash
cd backend
go build ./... && go vet ./... && go tool go-arch-lint check --project-path .
go test -race ./internal/repository/... ./cmd/server/... ./internal/database/... ./cmd/seed/... ./cmd/migrate-to-master/...
```

go-arch-lint passes with the new `database_testsupport` component; the migrate-to-master RLS-sensitive tests now run with the complete grants.
