### PR TITLE
refactor(frontend): dedup connection-create cache and finish auth-error migration

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -9,6 +9,7 @@
     "edit": "Edit",
     "delete": "Delete",
     "somethingWentWrong": "Something went wrong. Please try again.",
+    "forbidden": "You do not have permission.",
     "discardChanges": "Discard your changes?",
     "keepEditing": "Keep editing",
     "discard": "Discard",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -9,6 +9,7 @@
     "edit": "編集",
     "delete": "削除",
     "somethingWentWrong": "エラーが発生しました。もう一度お試しください。",
+    "forbidden": "権限がありません。",
     "discardChanges": "変更を破棄しますか？",
     "keepEditing": "編集を続ける",
     "discard": "破棄",

--- a/frontend/src/app/cardgroups/cache.ts
+++ b/frontend/src/app/cardgroups/cache.ts
@@ -1,0 +1,70 @@
+import type { ApolloCache } from "@apollo/client";
+import type { MyCardgroupsConnectionQuery } from "@/generated/graphql";
+import { MyCardgroupsConnectionDocument } from "@/generated/graphql";
+import { CARDGROUPS_DEFAULT_VARS } from "./queries";
+
+/**
+ * The `node` projection carried by an edge of the `myCardgroupsConnection`
+ * query — `{ __typename: "Cardgroup", id, name, updatedAt }`. Extracted from the
+ * generated query type so callers pass a complete node and the helper stays in
+ * sync with the document's selection set automatically.
+ */
+type MyCardgroupNode =
+  MyCardgroupsConnectionQuery["myCardgroupsConnection"]["edges"][number]["node"];
+
+/**
+ * Prepend a freshly-created cardgroup as a new `{ cursor, node }` edge to the
+ * cached `myCardgroupsConnection` and bump `totalCount`, so the new deck appears
+ * on `/cardgroups` without a refetch.
+ *
+ * Shared by `useCreateCardgroup` (the `/cardgroups` feature) and `useImportMaster`
+ * (the `/catalog` feature, which seeds the cardgroups connection across features).
+ * Both call this from inside their `__typename`-narrowed `update` callback after
+ * pulling the complete node off the success payload.
+ *
+ * `cache.modify` is forbidden — `readQuery` + `writeQuery` handles the cold cache
+ * (a user landing on `/cardgroups` or `/catalog` without an SSR seed) correctly.
+ * `CARDGROUPS_DEFAULT_VARS` keeps the cache key in sync with the `/cardgroups` SSR
+ * seed and client `useQuery`; any mismatch makes this write invisible. See
+ * .claude/rules/pagination.md.
+ *
+ * No `cache.writeFragment` is needed: the appended node already carries its full
+ * `{ __typename, id, name, updatedAt }` projection, so the `writeQuery` normalizes
+ * it into the standalone `Cardgroup:<id>` entry on its own.
+ */
+export function prependMyCardgroupEdge(cache: ApolloCache, node: MyCardgroupNode): void {
+  const existingConnection = cache.readQuery({
+    query: MyCardgroupsConnectionDocument,
+    variables: CARDGROUPS_DEFAULT_VARS,
+  });
+  const newEdge = {
+    __typename: "CardgroupEdge" as const,
+    cursor: node.id,
+    node,
+  };
+  const nextConnection = existingConnection
+    ? {
+        ...existingConnection.myCardgroupsConnection,
+        edges: [newEdge, ...existingConnection.myCardgroupsConnection.edges],
+        totalCount: existingConnection.myCardgroupsConnection.totalCount + 1,
+      }
+    : {
+        // Cold cache: build a minimal connection so the listing page can render
+        // the new edge immediately when the user lands there.
+        __typename: "CardgroupConnection" as const,
+        edges: [newEdge],
+        pageInfo: {
+          __typename: "PageInfo" as const,
+          hasNextPage: false,
+          hasPreviousPage: false,
+          startCursor: node.id,
+          endCursor: node.id,
+        },
+        totalCount: 1,
+      };
+  cache.writeQuery({
+    query: MyCardgroupsConnectionDocument,
+    variables: CARDGROUPS_DEFAULT_VARS,
+    data: { myCardgroupsConnection: nextConnection },
+  });
+}

--- a/frontend/src/app/cardgroups/use-create-cardgroup.ts
+++ b/frontend/src/app/cardgroups/use-create-cardgroup.ts
@@ -2,9 +2,10 @@
 
 import { useMutation } from "@apollo/client/react";
 import { useCallback } from "react";
-import { MyCardgroupsConnectionDocument } from "@/generated/graphql";
+import { classifyMutationAuthError } from "@/lib/apollo/errors";
 import { liftGraphQLCodes } from "@/lib/apollo/graphql-errors";
-import { CARDGROUPS_DEFAULT_VARS, CreateCardgroupMutation } from "./queries";
+import { prependMyCardgroupEdge } from "./cache";
+import { CreateCardgroupMutation } from "./queries";
 
 /**
  * Discriminated outcome of a create-cardgroup attempt. Callers branch on
@@ -41,46 +42,7 @@ export function useCreateCardgroup() {
       // Narrow on __typename before accessing .cardgroup so an InputValidationError
       // or unknown variant does not silently mutate the cache.
       if (data?.createCardgroup?.__typename !== "CreateCardgroupSuccess") return;
-      const created = data.createCardgroup.cardgroup;
-
-      // cache.modify is forbidden — use readQuery + writeQuery so cold-cache
-      // entries are also handled correctly. CARDGROUPS_DEFAULT_VARS keeps the
-      // cache key in sync with the SSR seed and the client useQuery — any
-      // mismatch makes this write invisible. See .claude/rules/pagination.md.
-      const existingConnection = cache.readQuery({
-        query: MyCardgroupsConnectionDocument,
-        variables: CARDGROUPS_DEFAULT_VARS,
-      });
-      const newEdge = {
-        __typename: "CardgroupEdge" as const,
-        cursor: created.id,
-        node: created,
-      };
-      const nextConnection = existingConnection
-        ? {
-            ...existingConnection.myCardgroupsConnection,
-            edges: [newEdge, ...existingConnection.myCardgroupsConnection.edges],
-            totalCount: existingConnection.myCardgroupsConnection.totalCount + 1,
-          }
-        : {
-            // Cold cache: build a minimal connection so the listing page can render
-            // the new edge immediately when the user lands there.
-            __typename: "CardgroupConnection" as const,
-            edges: [newEdge],
-            pageInfo: {
-              __typename: "PageInfo" as const,
-              hasNextPage: false,
-              hasPreviousPage: false,
-              startCursor: created.id,
-              endCursor: created.id,
-            },
-            totalCount: 1,
-          };
-      cache.writeQuery({
-        query: MyCardgroupsConnectionDocument,
-        variables: CARDGROUPS_DEFAULT_VARS,
-        data: { myCardgroupsConnection: nextConnection },
-      });
+      prependMyCardgroupEdge(cache, data.createCardgroup.cardgroup);
     },
   });
 
@@ -106,14 +68,13 @@ export function useCreateCardgroup() {
         console.warn("[useCreateCardgroup] unexpected createCardgroup payload", { typename });
         return { status: "unexpected" };
       } catch (err) {
-        const codes = liftGraphQLCodes(err);
-        if (codes.includes("UNAUTHENTICATED")) return { status: "auth", kind: "unauthenticated" };
-        if (codes.includes("FORBIDDEN")) return { status: "auth", kind: "forbidden" };
+        const authKind = classifyMutationAuthError(err);
+        if (authKind !== "other") return { status: "auth", kind: authKind };
         // err.message is omitted — backend messages may echo user input.
         // codes is safe to log (fixed enum of GraphQL extension codes).
         console.warn("[useCreateCardgroup] createCardgroup rejected", {
           name: err instanceof Error ? err.name : "unknown",
-          codes,
+          codes: liftGraphQLCodes(err),
         });
         return { status: "rejected" };
       }

--- a/frontend/src/app/catalog/use-import-master.ts
+++ b/frontend/src/app/catalog/use-import-master.ts
@@ -2,8 +2,8 @@
 
 import { useMutation } from "@apollo/client/react";
 import { useCallback } from "react";
-import { CARDGROUPS_DEFAULT_VARS } from "@/app/cardgroups/queries";
-import { MyCardgroupsConnectionDocument } from "@/generated/graphql";
+import { prependMyCardgroupEdge } from "@/app/cardgroups/cache";
+import { classifyMutationAuthError } from "@/lib/apollo/errors";
 import { liftGraphQLCodes } from "@/lib/apollo/graphql-errors";
 import { ImportMasterCardgroupMutation } from "./queries";
 
@@ -52,47 +52,7 @@ export function useImportMaster() {
       // Narrow on __typename before touching .cardgroup so a MasterNotFoundError
       // or unknown variant does not mutate the cache.
       if (data?.importMasterCardgroup?.__typename !== "ImportMasterCardgroupSuccess") return;
-      const created = data.importMasterCardgroup.cardgroup;
-
-      // cache.modify is forbidden — use readQuery + writeQuery so a cold cache
-      // (user landing on /catalog without having visited /cardgroups) is also
-      // handled. CARDGROUPS_DEFAULT_VARS keeps the cache key in sync with the
-      // /cardgroups SSR seed and client useQuery — any mismatch makes this write
-      // invisible. See .claude/rules/pagination.md.
-      const existingConnection = cache.readQuery({
-        query: MyCardgroupsConnectionDocument,
-        variables: CARDGROUPS_DEFAULT_VARS,
-      });
-      const newEdge = {
-        __typename: "CardgroupEdge" as const,
-        cursor: created.id,
-        node: created,
-      };
-      const nextConnection = existingConnection
-        ? {
-            ...existingConnection.myCardgroupsConnection,
-            edges: [newEdge, ...existingConnection.myCardgroupsConnection.edges],
-            totalCount: existingConnection.myCardgroupsConnection.totalCount + 1,
-          }
-        : {
-            // Cold cache: build a minimal connection so the listing page renders
-            // the new edge immediately when the user navigates there.
-            __typename: "CardgroupConnection" as const,
-            edges: [newEdge],
-            pageInfo: {
-              __typename: "PageInfo" as const,
-              hasNextPage: false,
-              hasPreviousPage: false,
-              startCursor: created.id,
-              endCursor: created.id,
-            },
-            totalCount: 1,
-          };
-      cache.writeQuery({
-        query: MyCardgroupsConnectionDocument,
-        variables: CARDGROUPS_DEFAULT_VARS,
-        data: { myCardgroupsConnection: nextConnection },
-      });
+      prependMyCardgroupEdge(cache, data.importMasterCardgroup.cardgroup);
     },
   });
 
@@ -121,14 +81,13 @@ export function useImportMaster() {
         console.warn("[useImportMaster] unexpected importMasterCardgroup payload", { typename });
         return { status: "rejected" };
       } catch (err) {
-        const codes = liftGraphQLCodes(err);
-        if (codes.includes("UNAUTHENTICATED")) return { status: "auth", kind: "unauthenticated" };
-        if (codes.includes("FORBIDDEN")) return { status: "auth", kind: "forbidden" };
+        const authKind = classifyMutationAuthError(err);
+        if (authKind !== "other") return { status: "auth", kind: authKind };
         // err.message is omitted — backend messages may echo user input.
         // codes is safe to log (fixed enum of GraphQL extension codes).
         console.warn("[useImportMaster] importMasterCardgroup rejected", {
           name: err instanceof Error ? err.name : "unknown",
-          codes,
+          codes: liftGraphQLCodes(err),
         });
         return { status: "rejected" };
       }

--- a/frontend/src/app/profile/delete-account-section.tsx
+++ b/frontend/src/app/profile/delete-account-section.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 import { ErrorBanner } from "@/components/ui/error-banner";
+import { mutationAuthBanner } from "@/lib/apollo/errors";
 import { liftGraphQLCodes } from "@/lib/apollo/graphql-errors";
 import { createSupabaseBrowserClient } from "@/lib/supabase/client";
 import { DeleteMyAccountMutation } from "./mutations";
@@ -76,14 +77,13 @@ export function DeleteAccountSection() {
       router.refresh();
       // No further state updates — this component unmounts on navigation.
     } catch (err) {
-      const codes = liftGraphQLCodes(err);
-      console.warn("[profile] deleteMyAccount rejected", { codes });
+      console.warn("[profile] deleteMyAccount rejected", { codes: liftGraphQLCodes(err) });
       setDeleteError(
-        codes.includes("FORBIDDEN")
-          ? t("deleteAccountForbidden")
-          : codes.includes("UNAUTHENTICATED")
-            ? t("deleteAccountSessionExpired")
-            : t("deleteAccountFailed"),
+        mutationAuthBanner(err, {
+          forbidden: t("deleteAccountForbidden"),
+          unauthenticated: t("deleteAccountSessionExpired"),
+          fallback: t("deleteAccountFailed"),
+        }),
       );
       setDeleting(false);
     }

--- a/frontend/src/app/profile/display-mode-section.tsx
+++ b/frontend/src/app/profile/display-mode-section.tsx
@@ -6,6 +6,7 @@ import { useState } from "react";
 import { UpdateLearnDisplayModeMutation } from "@/app/learn/queries";
 import { ErrorBanner } from "@/components/ui/error-banner";
 import type { LearnDisplayMode } from "@/generated/graphql";
+import { mutationAuthBanner } from "@/lib/apollo/errors";
 import { liftGraphQLCodes } from "@/lib/apollo/graphql-errors";
 import { cn } from "@/lib/utils";
 
@@ -28,9 +29,9 @@ export function DisplayModeSection({ initialMode }: { initialMode: LearnDisplayM
   const tCommon = useTranslations("Common");
   const [mode, setMode] = useState<LearnDisplayMode>(initialMode);
   // Surfaced when a save fails, mirroring ProfileForm's banner approach on this
-  // page: UNAUTHENTICATED maps to the session-expired copy, anything else to the
-  // generic "something went wrong" message. Cleared at the start of each new
-  // selection.
+  // page: UNAUTHENTICATED maps to the session-expired copy, FORBIDDEN to the
+  // permission-denied copy, anything else to the generic "something went wrong"
+  // message. Cleared at the start of each new selection.
   const [saveError, setSaveError] = useState<string | null>(null);
   const [updateMode, { loading }] = useMutation(UpdateLearnDisplayModeMutation);
 
@@ -50,11 +51,14 @@ export function DisplayModeSection({ initialMode }: { initialMode: LearnDisplayM
       // Roll the segmented control back to the previously committed mode so the
       // UI never shows a value the server rejected.
       setMode(previous);
-      const codes = liftGraphQLCodes(err);
       setSaveError(
-        codes.includes("UNAUTHENTICATED") ? t("sessionExpired") : tCommon("somethingWentWrong"),
+        mutationAuthBanner(err, {
+          forbidden: tCommon("forbidden"),
+          unauthenticated: t("sessionExpired"),
+          fallback: tCommon("somethingWentWrong"),
+        }),
       );
-      console.warn("[profile] updateLearnDisplayMode rejected", { codes });
+      console.warn("[profile] updateLearnDisplayMode rejected", { codes: liftGraphQLCodes(err) });
     }
   }
 

--- a/frontend/src/app/profile/profile-page-client.test.tsx
+++ b/frontend/src/app/profile/profile-page-client.test.tsx
@@ -318,6 +318,49 @@ describe("<DisplayModeSection> error handling and no-op guard", () => {
     );
   });
 
+  it("reverts the toggle and shows the permission-denied error on FORBIDDEN", async () => {
+    const user = userEvent.setup();
+    const mocks = [
+      {
+        request: {
+          query: UpdateLearnDisplayModeDocument,
+          variables: { mode: "ALWAYS_VISIBLE" },
+        },
+        result: {
+          errors: [new GraphQLError("not allowed", { extensions: { code: "FORBIDDEN" } })],
+        },
+      },
+    ];
+
+    renderWithIntl(
+      <MockedProvider mocks={mocks}>
+        <DisplayModeSection initialMode="FLIP_TO_REVEAL" />
+      </MockedProvider>,
+    );
+
+    const flipOption = screen.getByTestId("display-mode-flip-to-reveal");
+    const alwaysVisibleOption = screen.getByTestId("display-mode-always-visible");
+
+    await user.click(alwaysVisibleOption);
+
+    // After the FORBIDDEN rejection the optimistic selection rolls back.
+    await waitFor(() => {
+      expect(flipOption).toHaveAttribute("aria-pressed", "true");
+      expect(alwaysVisibleOption).toHaveAttribute("aria-pressed", "false");
+    });
+
+    // The FORBIDDEN branch surfaces the permission-denied copy, distinct from the
+    // session-expired copy used for UNAUTHENTICATED.
+    const alert = await screen.findByRole("alert");
+    expect(alert).toBe(screen.getByTestId("display-mode-error"));
+    expect(alert).toHaveTextContent(/permission/i);
+
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      "[profile] updateLearnDisplayMode rejected",
+      expect.objectContaining({ codes: expect.arrayContaining(["FORBIDDEN"]) }),
+    );
+  });
+
   it("does not fire the mutation when the already-active option is clicked", async () => {
     const user = userEvent.setup();
     const mutationCalled = vi.fn();


### PR DESCRIPTION
## Summary

Two frontend duplications surfaced by the same 2026-06-15 architecture review, collapsed into shared helpers; also completes the `classifyMutationAuthError` migration to the remaining user-facing mutation sites. **Behaviour-preserving** — `display-mode-section` additionally gains a (defensive) FORBIDDEN branch it previously omitted.

No tracking issue — frontend companion to the backend review PRs. Follows the `useConnectionPagination` / `classifyMutationAuthError` work in the #443–#463 cohesion series.

## Changes

### `refactor(cardgroups)`: `prependMyCardgroupEdge`
The byte-identical Apollo connection-create `update` body in `use-create-cardgroup.ts` and `use-import-master.ts` extracts to one `prependMyCardgroupEdge(cache, node)` helper in `app/cardgroups/cache.ts`, co-located with `CARDGROUPS_DEFAULT_VARS` / `MyCardgroupsConnectionDocument` so the cache key stays in one place. Cold-cache branch and `totalCount` bump are preserved; no `writeFragment` (the node is a complete `{ id, name, updatedAt }` projection).

### `refactor(profile/catalog/cardgroups)`: finish the auth-error migration
The remaining inline `liftGraphQLCodes(err) + codes.includes("UNAUTHENTICATED" / "FORBIDDEN")` sites (`use-create-cardgroup`, `use-import-master`, `delete-account-section`, `display-mode-section`) now route through the existing `classifyMutationAuthError` / `mutationAuthBanner`. `liftGraphQLCodes` is kept only inside `console.warn` payloads.
- **`display-mode-section` gains a FORBIDDEN branch** it previously omitted (it silently treated FORBIDDEN as the generic error). The branch is defensive — `updateLearnDisplayMode` only emits `UNAUTHENTICATED` today — and uses a new generic `Common.forbidden` key reusing the verbatim `"You do not have permission." / "権限がありません。"` already present in the Admin namespaces, not the account-deletion-specific copy.

## Verification

```bash
cd frontend
pnpm typecheck && ./node_modules/.bin/biome check --error-on-warnings . && pnpm i18n:parity && pnpm test
```

1377 tests pass; i18n parity 344 keys in both catalogs; new FORBIDDEN-branch test in `profile-page-client.test.tsx`.
