### PR TITLE
refactor(cardgroups): extract useDeleteCardgroup hook from cardgroup-header

### DIFF
--- a/frontend/src/components/cardgroups/cardgroup-header.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-header.tsx
@@ -1,12 +1,11 @@
 "use client";
 
-import { useMutation } from "@apollo/client/react";
 import { Import, MoreHorizontal, Pencil, Trash2 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { useCallback, useState } from "react";
-import { CARDGROUPS_DEFAULT_VARS, DeleteCardgroupMutation } from "@/app/cardgroups/queries";
 import { CardgroupRenameForm } from "@/components/cardgroups/cardgroup-rename-form";
+import { useDeleteCardgroup } from "@/components/cardgroups/use-delete-cardgroup";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -28,7 +27,6 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { ErrorBanner } from "@/components/ui/error-banner";
 import { FormSheet } from "@/components/ui/form-sheet";
-import { MyCardgroupsConnectionDocument } from "@/generated/graphql";
 import { getBackendErrorBanner } from "@/lib/apollo/errors";
 
 type Props = {
@@ -44,8 +42,7 @@ export function CardgroupHeader({ cardgroup, totalCount, onBatchImport }: Props)
   const [renaming, setRenaming] = useState(false);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
 
-  const [deleteCardgroup, { loading: deleting, error: deleteError }] =
-    useMutation(DeleteCardgroupMutation);
+  const { deleteCardgroup, deleting, error: deleteError } = useDeleteCardgroup();
 
   const deleteBannerError = getBackendErrorBanner(deleteError);
 
@@ -57,42 +54,8 @@ export function CardgroupHeader({ cardgroup, totalCount, onBatchImport }: Props)
   }, []);
 
   async function handleDelete() {
-    const result = await deleteCardgroup({
-      variables: { id: cardgroup.id },
-      update(cache, { data }) {
-        if (!data?.deleteCardgroup) return;
-
-        const existingConnection = cache.readQuery({
-          query: MyCardgroupsConnectionDocument,
-          variables: CARDGROUPS_DEFAULT_VARS,
-        });
-        if (existingConnection) {
-          cache.writeQuery({
-            query: MyCardgroupsConnectionDocument,
-            variables: CARDGROUPS_DEFAULT_VARS,
-            data: {
-              myCardgroupsConnection: {
-                ...existingConnection.myCardgroupsConnection,
-                edges: existingConnection.myCardgroupsConnection.edges.filter(
-                  (edge) => edge.node.id !== cardgroup.id,
-                ),
-                totalCount: Math.max(0, existingConnection.myCardgroupsConnection.totalCount - 1),
-              },
-            },
-          });
-        }
-
-        cache.evict({
-          id: cache.identify({ __typename: "Cardgroup", id: cardgroup.id }),
-        });
-        cache.gc();
-      },
-    }).catch((err) => {
-      console.error("[CardgroupHeader] delete rejection", err);
-      return null;
-    });
-
-    if (result?.data?.deleteCardgroup === true) {
+    const deleted = await deleteCardgroup(cardgroup.id);
+    if (deleted) {
       setDeleteDialogOpen(false);
       router.push("/cardgroups");
       router.refresh();

--- a/frontend/src/components/cardgroups/use-delete-cardgroup.ts
+++ b/frontend/src/components/cardgroups/use-delete-cardgroup.ts
@@ -1,0 +1,72 @@
+"use client";
+
+import { useMutation } from "@apollo/client/react";
+import { useCallback } from "react";
+import { CARDGROUPS_DEFAULT_VARS, DeleteCardgroupMutation } from "@/app/cardgroups/queries";
+import { MyCardgroupsConnectionDocument } from "@/generated/graphql";
+
+/**
+ * Owns the cardgroup delete mutation and its Connection-delete cache surgery:
+ * filter the deleted edge out of `myCardgroupsConnection`, decrement
+ * `totalCount` (clamped at 0 — the item may live on a page never fetched into
+ * edges), then `evict` + `gc` the normalized entity (.claude/rules/pagination.md
+ * "Connection delete"). The cache key is `CARDGROUPS_DEFAULT_VARS` so the
+ * read/write match the SSR seed and client `useQuery` key
+ * (docs/pagination/variables-shape-must-match.md).
+ *
+ * Unlike `useAdminUserMutations` (which re-throws so the caller's catch renders
+ * the reason), this hook mirrors the header's existing contract: it swallows the
+ * rejection (returns `false`) and exposes `useMutation`'s reactive `error` state
+ * so the caller drives the banner via `getBackendErrorBanner(error)`. The caller
+ * branches on the returned boolean for the success navigation.
+ *
+ * No `optimisticResponse`: a delete can fail with FORBIDDEN and Apollo does not
+ * reliably roll back optimistic writes for typed GraphQL errors.
+ */
+export function useDeleteCardgroup() {
+  const [runDeleteCardgroup, { loading: deleting, error }] = useMutation(DeleteCardgroupMutation);
+
+  const deleteCardgroup = useCallback(
+    async (id: string): Promise<boolean> => {
+      const result = await runDeleteCardgroup({
+        variables: { id },
+        update(cache, { data }) {
+          if (!data?.deleteCardgroup) return;
+
+          const existingConnection = cache.readQuery({
+            query: MyCardgroupsConnectionDocument,
+            variables: CARDGROUPS_DEFAULT_VARS,
+          });
+          if (existingConnection) {
+            cache.writeQuery({
+              query: MyCardgroupsConnectionDocument,
+              variables: CARDGROUPS_DEFAULT_VARS,
+              data: {
+                myCardgroupsConnection: {
+                  ...existingConnection.myCardgroupsConnection,
+                  edges: existingConnection.myCardgroupsConnection.edges.filter(
+                    (edge) => edge.node.id !== id,
+                  ),
+                  totalCount: Math.max(0, existingConnection.myCardgroupsConnection.totalCount - 1),
+                },
+              },
+            });
+          }
+
+          cache.evict({
+            id: cache.identify({ __typename: "Cardgroup", id }),
+          });
+          cache.gc();
+        },
+      }).catch((err) => {
+        console.error("[useDeleteCardgroup] delete rejection", err);
+        return null;
+      });
+
+      return result?.data?.deleteCardgroup === true;
+    },
+    [runDeleteCardgroup],
+  );
+
+  return { deleteCardgroup, deleting, error };
+}


### PR DESCRIPTION
## Summary

The cardgroup delete mutation and its full Connection-delete cache surgery were inlined directly in the presentational `cardgroup-header.tsx`. This extracts them into a dedicated `useDeleteCardgroup` hook — the same shape the admin wave already applied with `use-admin-user-mutations.ts`. **Behaviour-preserving — same toast/redirect, same cache outcome, same banner surface.**

Closes #473.

## Background / Motivation

- `cardgroup-header.tsx` is a presentational header, yet it owned `useMutation(DeleteCardgroupMutation)` plus `cache.readQuery` → `cache.writeQuery` (edge filter + `totalCount` decrement) plus `cache.evict` + `cache.gc()`. Deletes are the most bug-prone cache op, so leaving the full surgery inline in a header is a cohesion loss.
- This is the exact "Connection delete" pattern the admin wave already extracted into `use-admin-user-mutations.ts` (FE Tier-2 DRY follow-up, 2/6).

## Changes

### New `components/cardgroups/use-delete-cardgroup.ts`

- `"use client"` hook owning `useMutation(DeleteCardgroupMutation)` and the Connection-delete cache `update`: filter the deleted edge out of `myCardgroupsConnection`, decrement `totalCount` (clamped ≥0), then `evict` + `gc` the normalized entity. The cache key stays `CARDGROUPS_DEFAULT_VARS` so the read/write match the SSR seed and client `useQuery` key.
- Mirrors the header's existing **non-rethrow** contract (deliberately asymmetric with `useAdminUserMutations`, which re-throws): the rejection is swallowed (`console.error` + return `false`) and `useMutation`'s reactive `error` state is exposed so the caller drives the banner via `getBackendErrorBanner(error)`. `deleteCardgroup(id)` returns a `boolean` the caller branches on for the success navigation. No `optimisticResponse`.

### `cardgroup-header.tsx` consumes the hook

- Drops the inline `useMutation` / `cache.*` calls and the `@apollo/client/react`, `CARDGROUPS_DEFAULT_VARS`, `DeleteCardgroupMutation`, `MyCardgroupsConnectionDocument` imports. `handleDelete` now awaits `deleteCardgroup(cardgroup.id)` and runs the existing `setDeleteDialogOpen(false)` + `router.push("/cardgroups")` + `router.refresh()` on success. The banner/`disabled` wiring (`deleting`, `getBackendErrorBanner(deleteError)`) is unchanged.

### Out of scope (unchanged)

- The second delete path in `cardgroups-client.tsx` keeps its snapshot-undo strategy (intentionally separate).
- No banner-markup changes — already handled by the `ErrorBanner` primitive (#471).

### Tests

- No test changes. The behaviour is exercised by the existing `cardgroup-header.test.tsx` (11 cases incl. confirm-fires-and-navigates, UNAUTHENTICATED banner stays open, network-rejection banner stays open, cancel does not fire), which now drives the extracted hook through the component — the behaviour-preservation proof. This matches the admin precedent (`use-admin-user-mutations.ts` has no dedicated hook test; the consumer test covers it).

## Verification

```bash
cd frontend
pnpm typecheck && ./node_modules/.bin/biome check --error-on-warnings . && pnpm knip && pnpm test && pnpm build
```

Gates green in the worktree: `tsc --noEmit` (0), `biome check --error-on-warnings` (0), `knip` (0), `vitest run` (1376/1376), `next build` (0), and the CJK / language-policy scan (clean).

## Test plan

- [ ] Open a cardgroup, kebab menu → Delete cardgroup → confirm: the dialog closes, the app navigates to `/cardgroups`, and the deleted group is gone from the list (edge filtered, `totalCount` decremented).
- [ ] Trigger a delete that returns `UNAUTHENTICATED` / a network failure: the error banner renders and the dialog stays open (no navigation).
- [ ] Cancel in the delete dialog: no mutation fires.
