### PR TITLE
fix(admin): wrap admin/roles page gqlFetch in try/catch

### DIFF
--- a/frontend/__tests__/admin-roles.test.tsx
+++ b/frontend/__tests__/admin-roles.test.tsx
@@ -2,8 +2,9 @@
 /**
  * Broad page-level tests for /admin/roles (AdminRolesPage RSC).
  *
- * Scope: SSR-seed rendering, empty-seed path, gqlFetch error propagation, and
- * system-role presence in the rendered list.
+ * Scope: SSR-seed rendering, empty-seed path, gqlFetch error branches
+ * (auth-code redirect vs. redacted-log-and-rethrow), and system-role presence
+ * in the rendered list.
  *
  * NOT covered here (owned by admin-roles-crud.test.tsx):
  *   - Create / update / delete mutation flows.
@@ -17,6 +18,10 @@
 // ---------------------------------------------------------------------------
 // Module mocks — hoisted by Vitest before imports
 // ---------------------------------------------------------------------------
+
+// redirect() throws with this prefix so RSC tests can assert the target path,
+// mirroring how Next.js's server runtime aborts the render on redirect.
+const REDIRECT_PREFIX = "REDIRECT:";
 
 vi.mock("@/lib/apollo/server", () => ({
   gqlFetch: vi.fn(),
@@ -36,8 +41,13 @@ vi.mock("@/lib/undo-delete", () => ({
   UndoDeleteProvider: ({ children }: { children: React.ReactNode }) => children,
 }));
 
-// usePathname is consumed by UndoDeleteProvider for flush-on-navigation.
+// redirect throws so the page's catch-block redirect aborts the render like
+// Next.js does. usePathname / useRouter / useSearchParams are consumed by
+// UndoDeleteProvider (flush-on-navigation) in the SSR-seed render tests.
 vi.mock("next/navigation", () => ({
+  redirect: vi.fn((path: string) => {
+    throw new Error(`${REDIRECT_PREFIX}${path}`);
+  }),
   usePathname: () => "/admin/roles",
   useRouter: () => ({ push: vi.fn(), refresh: vi.fn(), replace: vi.fn() }),
   useSearchParams: () => new URLSearchParams(""),
@@ -48,6 +58,7 @@ vi.mock("next/navigation", () => ({
 // ---------------------------------------------------------------------------
 
 import { screen } from "@testing-library/react";
+import { redirect } from "next/navigation";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import AdminRolesPage from "@/app/admin/roles/page";
 import { gqlFetch } from "@/lib/apollo/server";
@@ -145,14 +156,43 @@ describe("AdminRolesPage (page-level SSR seed)", () => {
   });
 
   // -------------------------------------------------------------------------
-  // 3. gqlFetch error: the RSC throws — error propagates to the caller
+  // 3. gqlFetch error branches — auth codes redirect, others log + rethrow
   // -------------------------------------------------------------------------
 
-  it("propagates a gqlFetch error (page throws — error boundary handles it)", async () => {
+  it("propagates a non-auth gqlFetch error and logs a redacted, scoped error", async () => {
     const networkErr = new Error("network failure");
     mockGqlFetchError(networkErr);
 
-    await expect(AdminRolesPage()).rejects.toThrow("network failure");
+    await expect(AdminRolesPage()).rejects.toBe(networkErr);
+
+    expect(redirect).not.toHaveBeenCalled();
+    // PII redaction: only the error name is logged, never the message/object.
+    expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining("[admin/roles]"), {
+      name: "Error",
+    });
+  });
+
+  it("redirects to / on UNAUTHENTICATED without logging (admin pages → /, not /login)", async () => {
+    mockGqlFetchError(
+      new Error(`GraphQL errors: ${JSON.stringify([{ extensions: { code: "UNAUTHENTICATED" } }])}`),
+    );
+
+    await expect(AdminRolesPage()).rejects.toThrow(`${REDIRECT_PREFIX}/`);
+
+    expect(redirect).toHaveBeenCalledWith("/");
+    // The redirect path swallows the error cleanly — no error log.
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
+
+  it("redirects to / on FORBIDDEN without logging", async () => {
+    mockGqlFetchError(
+      new Error(`GraphQL errors: ${JSON.stringify([{ extensions: { code: "FORBIDDEN" } }])}`),
+    );
+
+    await expect(AdminRolesPage()).rejects.toThrow(`${REDIRECT_PREFIX}/`);
+
+    expect(redirect).toHaveBeenCalledWith("/");
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
   });
 
   // -------------------------------------------------------------------------

--- a/frontend/src/app/admin/roles/page.tsx
+++ b/frontend/src/app/admin/roles/page.tsx
@@ -1,5 +1,11 @@
 import type { Metadata } from "next";
+import { redirect } from "next/navigation";
 import { graphql } from "@/generated";
+import type { AdminRolesPageQuery as AdminRolesPageQueryType } from "@/generated/graphql";
+import {
+  isForbiddenGraphQLError,
+  isUnauthenticatedGraphQLError,
+} from "@/lib/apollo/graphql-errors";
 import { gqlFetch } from "@/lib/apollo/server";
 import { AdminRolesClient, type RoleItem } from "./admin-roles-client";
 
@@ -27,7 +33,19 @@ const AdminRolesPageQuery = graphql(`
 `);
 
 export default async function AdminRolesPage() {
-  const data = await gqlFetch(AdminRolesPageQuery, { revalidate: 0 });
+  let data: AdminRolesPageQueryType;
+  try {
+    data = await gqlFetch(AdminRolesPageQuery, { revalidate: 0 });
+  } catch (err) {
+    // Admin pages redirect to "/" (not "/login"), matching admin/layout.tsx
+    // and admin/users/page.tsx. UNAUTHENTICATED / FORBIDDEN fold into the same
+    // redirect path; everything else is logged (PII-redacted) and rethrown.
+    if (isUnauthenticatedGraphQLError(err) || isForbiddenGraphQLError(err)) redirect("/");
+    console.error("[admin/roles] gqlFetch failed:", {
+      name: err instanceof Error ? err.name : "unknown",
+    });
+    throw err;
+  }
   // Cast fragment-masked type to the plain serializable shape; runtime value is already plain.
   const initialRoles = data.roles as unknown as RoleItem[];
   return <AdminRolesClient initialRoles={initialRoles} />;


### PR DESCRIPTION
## Summary

`frontend/src/app/admin/roles/page.tsx` was the only page-level `gqlFetch` call in the app without a try/catch — an observability gap relative to every sibling RSC page (`app/page.tsx`, `app/profile/page.tsx`, `app/onboarding/page.tsx`, `app/cardgroups/[id]/edit/page.tsx`, all post-#466). The call is now wrapped: `UNAUTHENTICATED` / `FORBIDDEN` redirect to `/` (matching `admin/layout.tsx` and `admin/users/page.tsx`), and every other error logs a PII-redacted, scoped message before rethrowing. **No behaviour change to the happy path** — the query, the rendered client, and the page's data shape are untouched.

Closes #476.

## Background / Motivation

- `admin/roles/page.tsx` (~L30) called `gqlFetch(AdminRolesPageQuery, { revalidate: 0 })` bare; an SSR fetch failure threw with no scoped log line, leaving operators without the `[scope]`-prefixed signal every other page emits.
- Admin pages redirect unauthenticated / forbidden traffic to `/`, not `/login` (sending a logged-in non-admin to `/login` is awkward UX) — verified against `admin/layout.tsx` and `admin/users/page.tsx` before finalizing.
- PII redaction is mandatory: only `err.name` is logged, never `err.message` or the raw error (`.claude/rules/frontend-rsc-error-handling.md` — "Redact err.message").
- FE Tier 2 observability item (issue #476, 5/6).

## Changes

### `admin/roles/page.tsx`: try/catch around the SSR seed fetch

- The bare `const data = await gqlFetch(...)` becomes a `let data: AdminRolesPageQuery` assigned inside a `try`. The `catch` redirects to `/` when `isUnauthenticatedGraphQLError(err) || isForbiddenGraphQLError(err)`, otherwise logs `console.error("[admin/roles] gqlFetch failed:", { name: err instanceof Error ? err.name : "unknown" })` and rethrows.
- New imports: `redirect` (`next/navigation`), `isForbiddenGraphQLError` / `isUnauthenticatedGraphQLError` (`@/lib/apollo/graphql-errors`), and the generated `AdminRolesPageQuery` type (the `let` needs an explicit annotation). The `data.roles as unknown as RoleItem[]` cast and the rendered client are unchanged.

### Tests (`__tests__/admin-roles.test.tsx`)

- The single "propagates a gqlFetch error" case is expanded into three: a non-auth error now also asserts the redacted, scoped `[admin/roles]` log and that `redirect` was not called; new `UNAUTHENTICATED` and `FORBIDDEN` cases assert `redirect("/")` with no error log.
- The `next/navigation` mock gains a throwing `redirect` (shared `REDIRECT:` prefix) so the catch-block redirect aborts the render the way Next.js's server runtime does.

## Verification

```bash
# The page wraps the fetch and emits a scoped, redacted log on non-auth failure:
grep -n 'isUnauthenticatedGraphQLError\|\[admin/roles\] gqlFetch failed' \
  frontend/src/app/admin/roles/page.tsx
```

Runtime: an SSR `roles` fetch failure on `/admin/roles` now emits `[admin/roles] gqlFetch failed: { name: ... }` (name only, no message); an expired or non-admin session redirects to `/` instead of throwing an unscoped error.

## Test plan

- [x] `pnpm --filter frontend typecheck` (`tsc --noEmit`) — exit 0
- [x] `pnpm --filter frontend lint` (`biome check --error-on-warnings`) — clean, no fixes
- [x] `pnpm --filter frontend knip` — exit 0 (no new exports)
- [x] `pnpm --filter frontend test` — 1378 passed (142 files), incl. the new auth-redirect + redacted-log cases
- [x] `pnpm --filter frontend build` — success
- [x] CJK guard clean on changed source; no PR-order references in committed text
