### PR TITLE
refactor(cards): extract useCardMutations hook from cards-client

### DIFF
--- a/frontend/src/app/cardgroups/[id]/cards/cards-client.tsx
+++ b/frontend/src/app/cardgroups/[id]/cards/cards-client.tsx
@@ -1,34 +1,22 @@
 "use client";
 
-import { useApolloClient, useMutation } from "@apollo/client/react";
 import { Search } from "lucide-react";
 import { useTranslations } from "next-intl";
 import type { ReactNode, RefObject } from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
-import {
-  CreateCardMutation,
-  DeleteCardMutation,
-  DeleteCardsMutation,
-  UpdateCardMutation,
-} from "@/app/cardgroups/queries";
 import { CardForm } from "@/components/cardgroups/card-form";
 import { CardgroupBatchImportForm } from "@/components/cardgroups/cardgroup-batch-import-form";
 import type { SwipeableRowHandle } from "@/components/cardgroups/swipeable-row";
 import { Button } from "@/components/ui/button";
 import { ErrorBanner } from "@/components/ui/error-banner";
 import { FormSheet, useFormSheetClose } from "@/components/ui/form-sheet";
-import {
-  CardsByCardgroupConnectionDocument,
-  type CardsByCardgroupConnectionQuery,
-  type CardsByCardgroupConnectionQueryVariables,
-} from "@/generated/graphql";
+import type { CardsByCardgroupConnectionQuery } from "@/generated/graphql";
 import { useBulkSelection } from "@/hooks/use-bulk-selection";
 import { useDebouncedSearch } from "@/hooks/use-debounced-search";
 import { getBackendErrorBanner } from "@/lib/apollo/errors";
-import { useUndoDelete } from "@/lib/undo-delete";
 import { BulkActionBar } from "./components/bulk-action-bar";
 import { CardRow } from "./components/card-row";
-import { cardsDefaultVars } from "./queries";
+import { useCardMutations } from "./use-card-mutations";
 import { useCardsConnection } from "./use-cards-connection";
 
 type Connection = CardsByCardgroupConnectionQuery["cardsByCardgroupConnection"];
@@ -193,8 +181,6 @@ export function CardsClient({
   sectionHeader,
 }: Props) {
   const t = useTranslations("Cards");
-  const apollo = useApolloClient();
-  const { scheduleDelete } = useUndoDelete();
   const [addOpen, setAddOpen] = useState(false);
   const [addDirty, setAddDirty] = useState(false);
   const [batchImportOpen, setBatchImportOpen] = useState(false);
@@ -212,9 +198,6 @@ export function CardsClient({
   const rowRefs = useRef<Map<string, RefObject<SwipeableRowHandle | null>>>(new Map());
   const selection = useBulkSelection<string>();
   const search = useDebouncedSearch();
-  // Per-row delete commit error banner persists across useMutation calls.
-  // See docs/pagination/do-not-reuse-mutation-error-state.md.
-  const [deleteCommitError, setDeleteCommitError] = useState<string | null>(null);
 
   const {
     edges,
@@ -234,7 +217,26 @@ export function CardsClient({
     initialTotalCount,
   });
 
+  const {
+    createCard,
+    updateCard,
+    deleteRow,
+    deleteCards,
+    creating,
+    updating,
+    bulkDeleting,
+    createError,
+    updateError,
+    bulkDeleteError,
+    deleteRowError,
+    resetCreateCard,
+  } = useCardMutations({ cardgroupId, queryVariables });
+
   const queryBannerError = getBackendErrorBanner(queryError);
+  const bulkDeleteBannerError = getBackendErrorBanner(bulkDeleteError);
+  // Raw per-row delete error → localized banner copy (server message or fallback).
+  const deleteRowBannerError =
+    deleteRowError !== null ? (getBackendErrorBanner(deleteRowError) ?? t("deleteError")) : null;
 
   const closeOtherRows = useCallback((exceptCardId: string) => {
     for (const [id, ref] of rowRefs.current.entries()) {
@@ -243,52 +245,6 @@ export function CardsClient({
   }, []);
 
   const editingCard = edges.find((edge) => edge.node.id === editingId)?.node;
-
-  const [createCard, { loading: creating, error: createError, reset: resetCreateCard }] =
-    useMutation(CreateCardMutation);
-  // Updates propagate automatically via Apollo cache normalization (Card has id).
-  const [updateCard, { loading: updating, error: updateError }] = useMutation(UpdateCardMutation);
-  // scheduleDelete (5s undo window) fires the per-row mutation imperatively.
-  const [deleteCardMutation] = useMutation(DeleteCardMutation);
-
-  const [deleteCards, { error: bulkDeleteError, loading: bulkDeleting }] = useMutation(
-    DeleteCardsMutation,
-    {
-      // queryVariables matches the live cache entry under any active search filter.
-      // See docs/pagination/optimistic-rollback-cache-key.md.
-      update(cache, { data: bulkData }, { variables: mutationVars }) {
-        const ids = mutationVars?.ids as string[] | undefined;
-        if (!ids) return;
-        if (bulkData?.deleteCards == null) return;
-        const deletedCount = bulkData.deleteCards;
-        if (deletedCount === 0) return;
-        const existing = cache.readQuery({
-          query: CardsByCardgroupConnectionDocument,
-          variables: queryVariables,
-        });
-        if (existing) {
-          const next = existing.cardsByCardgroupConnection;
-          cache.writeQuery({
-            query: CardsByCardgroupConnectionDocument,
-            variables: queryVariables,
-            data: {
-              cardsByCardgroupConnection: {
-                ...next,
-                edges: next.edges.filter((edge) => !ids.includes(edge.node.id)),
-                totalCount: Math.max(0, next.totalCount - deletedCount),
-              },
-            },
-          });
-        }
-        for (const id of ids) {
-          cache.evict({ id: cache.identify({ __typename: "Card", id }) });
-        }
-        cache.gc();
-      },
-    },
-  );
-
-  const bulkDeleteBannerError = getBackendErrorBanner(bulkDeleteError);
 
   const openAddSheet = useCallback(() => {
     resetCreateCard();
@@ -314,85 +270,32 @@ export function CardsClient({
     return () => window.removeEventListener("flamingo:add-card", handleAddCardEvent);
   }, [cardgroupId, openAddSheet]);
 
-  function cardMatchesSearch(
-    card: CardsByCardgroupConnectionQuery["cardsByCardgroupConnection"]["edges"][number]["node"],
-    searchValue: string,
-  ) {
-    const normalized = searchValue.trim().toLowerCase();
-    if (normalized === "") return true;
-    return (
-      card.front.toLowerCase().includes(normalized) || card.back.toLowerCase().includes(normalized)
-    );
-  }
-
-  function writeCreatedCardToConnection(
-    card: CardsByCardgroupConnectionQuery["cardsByCardgroupConnection"]["edges"][number]["node"],
-    variables: CardsByCardgroupConnectionQueryVariables,
-  ) {
-    const existing = apollo.readQuery({
-      query: CardsByCardgroupConnectionDocument,
-      variables,
-    });
-    if (!existing) return;
-
-    const next = existing.cardsByCardgroupConnection;
-    if (next.edges.some((edge) => edge.node.id === card.id)) return;
-
-    apollo.writeQuery({
-      query: CardsByCardgroupConnectionDocument,
-      variables,
-      data: {
-        cardsByCardgroupConnection: {
-          ...next,
-          edges: [{ __typename: "CardEdge" as const, cursor: card.id, node: card }, ...next.edges],
-          totalCount: next.totalCount + 1,
-        },
-      },
-    });
-  }
-
   async function handleCreate(values: { front: string; back: string }) {
     resetCreateCard();
     setCreateValidationError(null);
-    const result = await createCard({
-      variables: { input: { cardgroupId, front: values.front, back: values.back } },
-    }).catch((err) => {
-      console.error("[CardsClient] create rejection", {
-        name: err instanceof Error ? err.name : "unknown",
-        cardgroupId,
-      });
-      return null;
-    });
-    if (!result) return;
-
-    const payload = result.data?.createCard;
-    if (payload?.__typename === "CreateCardSuccess") {
-      writeCreatedCardToConnection(payload.card, cardsDefaultVars(cardgroupId));
-      if (
-        typeof queryVariables.search === "string" &&
-        cardMatchesSearch(payload.card, queryVariables.search)
-      ) {
-        writeCreatedCardToConnection(payload.card, queryVariables);
-      }
-      setAddDirty(false);
-      setCreateValidationError(null);
-      setAddOpen(false);
-    } else if (payload?.__typename === "CardDuplicateFrontError") {
-      setCreateValidationError({ field: "front", message: payload.message });
-    } else {
-      const unknownPayload = payload as unknown as { __typename?: string } | null | undefined;
-      console.warn("[CardsClient] unexpected createCard payload", {
-        typename: unknownPayload?.__typename ?? null,
-        cardgroupId,
-      });
-      setCreateValidationError({ field: "front", message: t("addFailed") });
+    const outcome = await createCard(values);
+    switch (outcome.status) {
+      case "success":
+        setAddDirty(false);
+        setCreateValidationError(null);
+        setAddOpen(false);
+        break;
+      case "validation":
+        setCreateValidationError({ field: outcome.field, message: outcome.message });
+        break;
+      case "unexpected":
+        setCreateValidationError({ field: "front", message: t("addFailed") });
+        break;
+      case "rejected":
+        // The CardForm error banner surfaces the rejection via `createError`.
+        break;
     }
   }
 
   async function handleBulkDelete() {
     const ids = Array.from(selection.selectedIds);
     try {
-      await deleteCards({ variables: { ids } });
+      await deleteCards(ids);
       selection.clearSelection();
     } catch (err) {
       console.error("[CardsClient] bulk delete rejection", {
@@ -403,84 +306,22 @@ export function CardsClient({
     }
   }
 
-  // Per-row delete: snapshot, optimistic drop, schedule DELETE with a 5s undo window.
-  // See docs/pagination/optimistic-rollback-cache-key.md for the queryVariables rule.
-  const handleDeleteRow = useCallback(
-    (cardId: string) => {
-      const snapshot = apollo.readQuery({
-        query: CardsByCardgroupConnectionDocument,
-        variables: queryVariables,
-      });
-      if (snapshot) {
-        const next = snapshot.cardsByCardgroupConnection;
-        apollo.writeQuery({
-          query: CardsByCardgroupConnectionDocument,
-          variables: queryVariables,
-          data: {
-            cardsByCardgroupConnection: {
-              ...next,
-              edges: next.edges.filter((edge) => edge.node.id !== cardId),
-              totalCount: Math.max(0, next.totalCount - 1),
-            },
-          },
-        });
-      }
-      scheduleDelete({
-        id: cardId,
-        label: t("cardDeleted"),
-        optimisticRollback: () => {
-          if (snapshot !== null) {
-            apollo.writeQuery({
-              query: CardsByCardgroupConnectionDocument,
-              variables: queryVariables,
-              data: snapshot,
-            });
-          }
-          setDeleteCommitError(null);
-        },
-        commitDelete: async () => {
-          setDeleteCommitError(null);
-          const result = await deleteCardMutation({ variables: { id: cardId } });
-          if (result.data?.deleteCard) {
-            apollo.cache.evict({ id: apollo.cache.identify({ __typename: "Card", id: cardId }) });
-            apollo.cache.gc();
-          }
-        },
-        onCommitFailed: (err) => {
-          setDeleteCommitError(getBackendErrorBanner(err) ?? t("deleteError"));
-        },
-      });
-    },
-    [apollo, deleteCardMutation, queryVariables, scheduleDelete, t],
-  );
-
   async function handleUpdate(id: string, values: { front: string; back: string }) {
     setRowValidationError(null);
-    const result = await updateCard({
-      variables: { id, input: { front: values.front, back: values.back } },
-    }).catch((err) => {
-      console.error("[CardsClient] update rejection", {
-        name: err instanceof Error ? err.name : "unknown",
-        cardgroupId,
-        cardId: id,
-      });
-      return null;
-    });
-    if (!result) return;
-    const payload = result.data?.updateCard;
-    if (payload?.__typename === "UpdateCardSuccess") {
-      setEditingId(null);
-    } else if (payload?.__typename === "InputValidationError") {
-      setRowValidationError({ field: payload.field, message: payload.message });
-    } else {
-      // Null payload or a future union member from a stale codegen.
-      const unknownPayload = payload as unknown as { __typename?: string } | null | undefined;
-      console.warn("[CardsClient] unexpected updateCard payload", {
-        typename: unknownPayload?.__typename ?? null,
-        cardId: id,
-        cardgroupId,
-      });
-      setRowValidationError({ field: "front", message: t("saveFailed") });
+    const outcome = await updateCard(id, values);
+    switch (outcome.status) {
+      case "success":
+        setEditingId(null);
+        break;
+      case "validation":
+        setRowValidationError({ field: outcome.field, message: outcome.message });
+        break;
+      case "unexpected":
+        setRowValidationError({ field: "front", message: t("saveFailed") });
+        break;
+      case "rejected":
+        // The edit-sheet error banner surfaces the rejection via `updateError`.
+        break;
     }
   }
 
@@ -489,8 +330,8 @@ export function CardsClient({
       {queryBannerError && (
         <ErrorBanner data-testid="cards-query-error">{queryBannerError}</ErrorBanner>
       )}
-      {deleteCommitError && (
-        <ErrorBanner data-testid="cards-delete-error">{deleteCommitError}</ErrorBanner>
+      {deleteRowBannerError && (
+        <ErrorBanner data-testid="cards-delete-error">{deleteRowBannerError}</ErrorBanner>
       )}
       {bulkDeleteBannerError && (
         <ErrorBanner data-testid="cards-bulk-delete-error">{bulkDeleteBannerError}</ErrorBanner>
@@ -543,7 +384,7 @@ export function CardsClient({
                       setRowValidationError(null);
                       setEditingId(card.id);
                     }}
-                    onDelete={() => handleDeleteRow(card.id)}
+                    onDelete={() => deleteRow(card.id, t("cardDeleted"))}
                   />
                 </li>
               );

--- a/frontend/src/app/cardgroups/[id]/cards/use-card-mutations.ts
+++ b/frontend/src/app/cardgroups/[id]/cards/use-card-mutations.ts
@@ -1,0 +1,291 @@
+"use client";
+
+import { useApolloClient, useMutation } from "@apollo/client/react";
+import { useCallback, useState } from "react";
+import {
+  CreateCardMutation,
+  DeleteCardMutation,
+  DeleteCardsMutation,
+  UpdateCardMutation,
+} from "@/app/cardgroups/queries";
+import {
+  CardsByCardgroupConnectionDocument,
+  type CardsByCardgroupConnectionQuery,
+  type CardsByCardgroupConnectionQueryVariables,
+} from "@/generated/graphql";
+import { useUndoDelete } from "@/lib/undo-delete";
+import { cardsDefaultVars } from "./queries";
+
+type CardNode =
+  CardsByCardgroupConnectionQuery["cardsByCardgroupConnection"]["edges"][number]["node"];
+
+/** Outcome of a create attempt; the client maps it to validation / sheet / banner state. */
+type CreateCardOutcome =
+  | { status: "success" }
+  | { status: "validation"; field: string; message: string }
+  | { status: "unexpected" }
+  | { status: "rejected" };
+
+/** Outcome of an update attempt; the client maps it to the inline row validation error. */
+type UpdateCardOutcome =
+  | { status: "success" }
+  | { status: "validation"; field: string; message: string }
+  | { status: "unexpected" }
+  | { status: "rejected" };
+
+function cardMatchesSearch(card: CardNode, searchValue: string): boolean {
+  const normalized = searchValue.trim().toLowerCase();
+  if (normalized === "") return true;
+  return (
+    card.front.toLowerCase().includes(normalized) || card.back.toLowerCase().includes(normalized)
+  );
+}
+
+export interface UseCardMutationsInput {
+  cardgroupId: string;
+  /**
+   * The connection's active query variables (search-filter-aware). MUST be the
+   * same object the live `useQuery` is keyed on so cache reads/writes land on the
+   * right entry under any active search filter.
+   * See docs/pagination/optimistic-rollback-cache-key.md.
+   */
+  queryVariables: CardsByCardgroupConnectionQueryVariables;
+}
+
+/**
+ * Owns the four card mutations (create / update / per-row delete / bulk delete)
+ * and every Apollo cache write they perform. The client maps the returned typed
+ * outcomes to sheet navigation, validation, and banner state. Mirrors the
+ * thin-outcome-hook shape of `useMasterMutations` / `useAdminUserMutations`.
+ *
+ * No `optimisticResponse`: typed errors (CardDuplicateFrontError,
+ * InputValidationError, UNAUTHENTICATED, FORBIDDEN) can fail these mutations and
+ * Apollo does not reliably roll back optimistic writes for typed GraphQL errors
+ * — see .claude/rules/pagination.md.
+ */
+export function useCardMutations({ cardgroupId, queryVariables }: UseCardMutationsInput) {
+  const apollo = useApolloClient();
+  const { scheduleDelete } = useUndoDelete();
+
+  const [createCardMutation, { loading: creating, error: createError, reset: resetCreateCard }] =
+    useMutation(CreateCardMutation);
+  // Updates propagate automatically via Apollo cache normalization (Card has id).
+  const [updateCardMutation, { loading: updating, error: updateError }] =
+    useMutation(UpdateCardMutation);
+  // scheduleDelete (5s undo window) fires the per-row mutation imperatively.
+  const [deleteCardMutation] = useMutation(DeleteCardMutation);
+
+  const [deleteCardsMutation, { error: bulkDeleteError, loading: bulkDeleting }] = useMutation(
+    DeleteCardsMutation,
+    {
+      // queryVariables matches the live cache entry under any active search filter.
+      // See docs/pagination/optimistic-rollback-cache-key.md.
+      update(cache, { data: bulkData }, { variables: mutationVars }) {
+        const ids = mutationVars?.ids as string[] | undefined;
+        if (!ids) return;
+        if (bulkData?.deleteCards == null) return;
+        const deletedCount = bulkData.deleteCards;
+        if (deletedCount === 0) return;
+        const existing = cache.readQuery({
+          query: CardsByCardgroupConnectionDocument,
+          variables: queryVariables,
+        });
+        if (existing) {
+          const next = existing.cardsByCardgroupConnection;
+          cache.writeQuery({
+            query: CardsByCardgroupConnectionDocument,
+            variables: queryVariables,
+            data: {
+              cardsByCardgroupConnection: {
+                ...next,
+                edges: next.edges.filter((edge) => !ids.includes(edge.node.id)),
+                totalCount: Math.max(0, next.totalCount - deletedCount),
+              },
+            },
+          });
+        }
+        for (const id of ids) {
+          cache.evict({ id: cache.identify({ __typename: "Card", id }) });
+        }
+        cache.gc();
+      },
+    },
+  );
+
+  // Per-row delete commit error — surfaced after the 5s undo window elapses and
+  // the DELETE mutation rejects. Stored as the raw error so the client derives
+  // the localized banner copy; persists across mutation calls. See
+  // docs/pagination/do-not-reuse-mutation-error-state.md.
+  const [deleteRowError, setDeleteRowError] = useState<unknown>(null);
+
+  // Write a freshly-created card to the connection cached under `variables`.
+  const writeCreatedCardToConnection = useCallback(
+    (card: CardNode, variables: CardsByCardgroupConnectionQueryVariables) => {
+      const existing = apollo.readQuery({
+        query: CardsByCardgroupConnectionDocument,
+        variables,
+      });
+      if (!existing) return;
+
+      const next = existing.cardsByCardgroupConnection;
+      if (next.edges.some((edge) => edge.node.id === card.id)) return;
+
+      apollo.writeQuery({
+        query: CardsByCardgroupConnectionDocument,
+        variables,
+        data: {
+          cardsByCardgroupConnection: {
+            ...next,
+            edges: [
+              { __typename: "CardEdge" as const, cursor: card.id, node: card },
+              ...next.edges,
+            ],
+            totalCount: next.totalCount + 1,
+          },
+        },
+      });
+    },
+    [apollo],
+  );
+
+  const createCard = useCallback(
+    async (values: { front: string; back: string }): Promise<CreateCardOutcome> => {
+      const result = await createCardMutation({
+        variables: { input: { cardgroupId, front: values.front, back: values.back } },
+      }).catch((err) => {
+        console.error("[useCardMutations] create rejection", {
+          name: err instanceof Error ? err.name : "unknown",
+          cardgroupId,
+        });
+        return null;
+      });
+      if (!result) return { status: "rejected" };
+
+      const payload = result.data?.createCard;
+      if (payload?.__typename === "CreateCardSuccess") {
+        writeCreatedCardToConnection(payload.card, cardsDefaultVars(cardgroupId));
+        if (
+          typeof queryVariables.search === "string" &&
+          cardMatchesSearch(payload.card, queryVariables.search)
+        ) {
+          writeCreatedCardToConnection(payload.card, queryVariables);
+        }
+        return { status: "success" };
+      }
+      if (payload?.__typename === "CardDuplicateFrontError") {
+        return { status: "validation", field: "front", message: payload.message };
+      }
+      const unknownPayload = payload as unknown as { __typename?: string } | null | undefined;
+      console.warn("[useCardMutations] unexpected createCard payload", {
+        typename: unknownPayload?.__typename ?? null,
+        cardgroupId,
+      });
+      return { status: "unexpected" };
+    },
+    [cardgroupId, createCardMutation, queryVariables, writeCreatedCardToConnection],
+  );
+
+  const updateCard = useCallback(
+    async (id: string, values: { front: string; back: string }): Promise<UpdateCardOutcome> => {
+      const result = await updateCardMutation({
+        variables: { id, input: { front: values.front, back: values.back } },
+      }).catch((err) => {
+        console.error("[useCardMutations] update rejection", {
+          name: err instanceof Error ? err.name : "unknown",
+          cardgroupId,
+          cardId: id,
+        });
+        return null;
+      });
+      if (!result) return { status: "rejected" };
+
+      const payload = result.data?.updateCard;
+      if (payload?.__typename === "UpdateCardSuccess") {
+        return { status: "success" };
+      }
+      if (payload?.__typename === "InputValidationError") {
+        return { status: "validation", field: payload.field, message: payload.message };
+      }
+      const unknownPayload = payload as unknown as { __typename?: string } | null | undefined;
+      console.warn("[useCardMutations] unexpected updateCard payload", {
+        typename: unknownPayload?.__typename ?? null,
+        cardId: id,
+        cardgroupId,
+      });
+      return { status: "unexpected" };
+    },
+    [cardgroupId, updateCardMutation],
+  );
+
+  // Per-row delete: snapshot, optimistic drop, schedule DELETE with a 5s undo
+  // window. See docs/pagination/optimistic-rollback-cache-key.md for the
+  // queryVariables rule. `label` is the caller-supplied (localized) toast title.
+  const deleteRow = useCallback(
+    (cardId: string, label: string) => {
+      const snapshot = apollo.readQuery({
+        query: CardsByCardgroupConnectionDocument,
+        variables: queryVariables,
+      });
+      if (snapshot) {
+        const next = snapshot.cardsByCardgroupConnection;
+        apollo.writeQuery({
+          query: CardsByCardgroupConnectionDocument,
+          variables: queryVariables,
+          data: {
+            cardsByCardgroupConnection: {
+              ...next,
+              edges: next.edges.filter((edge) => edge.node.id !== cardId),
+              totalCount: Math.max(0, next.totalCount - 1),
+            },
+          },
+        });
+      }
+      scheduleDelete({
+        id: cardId,
+        label,
+        optimisticRollback: () => {
+          if (snapshot !== null) {
+            apollo.writeQuery({
+              query: CardsByCardgroupConnectionDocument,
+              variables: queryVariables,
+              data: snapshot,
+            });
+          }
+          setDeleteRowError(null);
+        },
+        commitDelete: async () => {
+          setDeleteRowError(null);
+          const result = await deleteCardMutation({ variables: { id: cardId } });
+          if (result.data?.deleteCard) {
+            apollo.cache.evict({ id: apollo.cache.identify({ __typename: "Card", id: cardId }) });
+            apollo.cache.gc();
+          }
+        },
+        onCommitFailed: (err) => {
+          setDeleteRowError(err);
+        },
+      });
+    },
+    [apollo, deleteCardMutation, queryVariables, scheduleDelete],
+  );
+
+  const deleteCards = useCallback(
+    (ids: string[]) => deleteCardsMutation({ variables: { ids } }),
+    [deleteCardsMutation],
+  );
+
+  return {
+    createCard,
+    updateCard,
+    deleteRow,
+    deleteCards,
+    creating,
+    updating,
+    bulkDeleting,
+    createError,
+    updateError,
+    bulkDeleteError,
+    deleteRowError,
+    resetCreateCard,
+  };
+}


### PR DESCRIPTION
## Summary

`cards-client.tsx` is the largest client component and inlined **four card mutations and all their Apollo cache writes** in the component body. This extracts them into a dedicated `useCardMutations` hook — the same shape the admin wave already applied with `use-master-mutations.ts` / `use-admin-user-mutations.ts`. **Behaviour-preserving — same cache outcomes, same undo timing, same validation/banner surfaces.**

Closes #472.

## Background / Motivation

- `cards-client.tsx` owned `useMutation` for create / update / per-row delete / bulk delete, plus every cache write they perform — the create connection seed (`writeQuery`), the bulk-delete `update` (edge filter + `totalCount` decrement + `evict`/`gc`), and the per-row optimistic drop / rollback / commit-evict. Cache writes are the most bug-prone surface, and they sat in the biggest file.
- The user-facing cards screen was the only large screen still carrying inline mutation + cache logic — a cohesion asymmetry with the admin wave (FE Tier-2 DRY follow-up, 1/6). This is the highest-cohesion-ROI item in the Tier-2 set.

## Changes

### New `app/cardgroups/[id]/cards/use-card-mutations.ts`

- `"use client"` hook owning `useMutation(CreateCard / UpdateCard / DeleteCard / DeleteCards)` and every cache write:
  - **create** — `readQuery + writeQuery` seeds the connection (default-vars variant, plus the active-search-filter variant when the new card matches the live search).
  - **bulk delete** — the `update` callback filters edges by `edge.node.id`, decrements `totalCount` (clamped ≥0), then `evict` + `gc`. The cache key stays the caller's active `queryVariables` so the read/write match the live `useQuery` under any search filter.
  - **per-row delete** — snapshot → optimistic drop → `scheduleDelete` (5s undo window) → commit `evict` + `gc`; the raw commit error is held in the hook so the caller derives the localized banner.
- `create` / `update` return a discriminated-union outcome (`success` / `validation` / `unexpected` / `rejected`), mirroring `useMasterMutations`; the caller maps the outcome to sheet navigation, field validation, and banner state.
- No `optimisticResponse` (typed errors — `CardDuplicateFrontError`, `InputValidationError`, `UNAUTHENTICATED`, `FORBIDDEN` — can fail these and Apollo does not reliably roll back optimistic writes for typed GraphQL errors).

### `cards-client.tsx` consumes the hook

- Drops the four inline `useMutation` calls and the `useApolloClient` / `useUndoDelete` / `cardsDefaultVars` / `CardsByCardgroupConnectionDocument` usage. `handleCreate` / `handleUpdate` now switch on the hook's typed outcome; `handleBulkDelete` keeps its `[CardsClient]`-scoped rejection log + `clearSelection`; per-row delete is a direct `deleteRow(card.id, t("cardDeleted"))`. Net production diff: −159 lines.
- Banner/`disabled`/`submitting` wiring (`getBackendErrorBanner(...)`, `creating`, `updating`, `bulkDeleting`, `createError`, `updateError`) is unchanged.

### Out of scope (unchanged)

- `learn-add-card-sheet.tsx` is untouched (that is FE Tier-2 6/6, the follow-up that consumes this hook).
- No banner-markup changes — already handled by the `ErrorBanner` primitive (#471).

### Tests

- No test changes. The behaviour is exercised by the existing `cards-client.test.tsx` (create-success/duplicate/throw, edit save + InputValidationError, per-row delete + Undo + UNAUTHENTICATED banner, bulk delete + active-search regressions, beforeunload/pathname flush), which now drives the extracted hook through the component — the behaviour-preservation proof. Matches the admin precedent (no dedicated hook test; the consumer test covers it).

## Verification

```bash
cd frontend
pnpm typecheck && ./node_modules/.bin/biome check --error-on-warnings . && pnpm knip && pnpm test && pnpm build
```

Gates green in the worktree: `tsc --noEmit` (0), `biome check --error-on-warnings` (0), `knip` (0), `vitest run` (1376/1376), `next build` (0), and the CJK / language-policy scan (clean).

## Test plan

- [ ] Add a card: the new card appears at the top of the list, `totalCount` bumps, and the sheet closes.
- [ ] Add a card while a search filter is active: the card does not pollute the filtered view but appears after clearing the search.
- [ ] Add a duplicate front: the sheet stays open with the front validation error.
- [ ] Edit a card → save: updated values render; an empty front returns `InputValidationError` and the sheet stays open with the inline error.
- [ ] Per-row delete: the row disappears immediately; Undo within 5s restores it (no DELETE); past 5s the DELETE fires; a failing DELETE surfaces the `cards-delete-error` banner.
- [ ] Bulk delete: confirm dialog → both rows leave the active-search list, `totalCount` decrements; a rejection logs the `[CardsClient]` payload (no `message`) and shows the bulk-delete banner.
