### PR TITLE
refactor(pagination): hoist shared EMPTY_PAGE_INFO constant (DRY)

### DIFF
--- a/frontend/src/app/admin/masters/admin-masters-client.tsx
+++ b/frontend/src/app/admin/masters/admin-masters-client.tsx
@@ -17,6 +17,7 @@ import type {
 } from "@/generated/graphql";
 import { useDebouncedSearch } from "@/hooks/use-debounced-search";
 import { classifyQueryError, getBackendErrorBanner } from "@/lib/apollo/errors";
+import { EMPTY_PAGE_INFO } from "@/lib/pagination/empty-page-info";
 import { useConnectionPagination } from "@/lib/pagination/use-connection-pagination";
 import { useSheetSearchParam } from "@/lib/url/use-sheet-search-param";
 import { AdminMasterForm, type MasterFormValues } from "./admin-master-form";
@@ -28,14 +29,6 @@ import { type AuthKind, useMasterMutations } from "./use-master-mutations";
 type Connection = AdminMastersQueryResult["adminMasters"];
 type Edge = Connection["edges"][number];
 type PageInfo = Connection["pageInfo"];
-
-const EMPTY_PAGE_INFO: PageInfo = {
-  __typename: "PageInfo",
-  hasNextPage: false,
-  hasPreviousPage: false,
-  startCursor: null,
-  endCursor: null,
-};
 
 // Render fallback for useConnectionPagination before the first query resolves.
 // Admin masters has no SSR seed, so this is the initial render value; it keeps

--- a/frontend/src/app/admin/users/admin-users-client.tsx
+++ b/frontend/src/app/admin/users/admin-users-client.tsx
@@ -18,6 +18,7 @@ import {
   getBackendErrorBanner,
   type QueryErrorKind,
 } from "@/lib/apollo/errors";
+import { EMPTY_PAGE_INFO } from "@/lib/pagination/empty-page-info";
 import { useConnectionPagination } from "@/lib/pagination/use-connection-pagination";
 import { useSheetSearchParam } from "@/lib/url/use-sheet-search-param";
 import { AdminUserProfileSheet } from "./admin-user-profile-sheet";
@@ -37,14 +38,6 @@ import { useAdminUserMutations } from "./use-admin-user-mutations";
 type Connection = AdminUsersQueryResult["users"];
 type Edge = Connection["edges"][number];
 type PageInfo = Connection["pageInfo"];
-
-const EMPTY_PAGE_INFO: PageInfo = {
-  __typename: "PageInfo",
-  hasNextPage: false,
-  hasPreviousPage: false,
-  startCursor: null,
-  endCursor: null,
-};
 
 // Render fallback for useConnectionPagination before the first query resolves.
 // Admin users has no SSR seed, so this is the initial render value; it keeps the

--- a/frontend/src/app/catalog/catalog-client.tsx
+++ b/frontend/src/app/catalog/catalog-client.tsx
@@ -15,6 +15,7 @@ import {
   type MasterCatalogQueryVariables,
 } from "@/generated/graphql";
 import { useDebouncedSearch } from "@/hooks/use-debounced-search";
+import { EMPTY_PAGE_INFO } from "@/lib/pagination/empty-page-info";
 import { useConnectionPagination } from "@/lib/pagination/use-connection-pagination";
 import { CatalogCard } from "./catalog-card";
 import { CATALOG_DEFAULT_VARS } from "./queries";
@@ -27,14 +28,6 @@ type CatalogPageInfo = Connection["pageInfo"];
 interface CatalogClientProps {
   initialConnection: Connection | null;
 }
-
-const EMPTY_PAGE_INFO: CatalogPageInfo = {
-  __typename: "PageInfo",
-  hasNextPage: false,
-  hasPreviousPage: false,
-  startCursor: null,
-  endCursor: null,
-};
 
 // Render fallback for useConnectionPagination. The client seeds the cache
 // synchronously before useQuery runs, so this is never read on the happy path;

--- a/frontend/src/lib/pagination/empty-page-info.ts
+++ b/frontend/src/lib/pagination/empty-page-info.ts
@@ -1,0 +1,18 @@
+import type { PageInfo } from "@/generated/base-types";
+
+/**
+ * Empty `PageInfo` render-fallback shared by the cursor-paginated list clients.
+ *
+ * Each `useConnectionPagination` consumer needs an `initial` connection slice to
+ * render before the first query resolves; this object is its empty `pageInfo`.
+ * It is typed against the canonical generated `PageInfo` (the base schema object
+ * type), so it is structurally assignable to every operation's nominally-distinct
+ * inline `pageInfo` type without coupling this constant to one operation.
+ */
+export const EMPTY_PAGE_INFO: PageInfo = {
+  __typename: "PageInfo",
+  hasNextPage: false,
+  hasPreviousPage: false,
+  startCursor: null,
+  endCursor: null,
+};


### PR DESCRIPTION
## Summary

The empty-`PageInfo` render-fallback was defined as three byte-identical local `EMPTY_PAGE_INFO` consts across the Wave-1 list clients. This hoists them into one shared constant under `frontend/src/lib/pagination/` and routes the three clients through it. **Behaviour-preserving** — same `initial` connection slice, same render fallback.

Closes #474.

## Background / Motivation

- `catalog/catalog-client.tsx`, `admin/users/admin-users-client.tsx`, and `admin/masters/admin-masters-client.tsx` each declared their own `EMPTY_PAGE_INFO` with the identical shape `{ __typename: "PageInfo", hasNextPage: false, hasPreviousPage: false, startCursor: null, endCursor: null }` — three copies of the same `useConnectionPagination` render fallback that drift independently.
- FE Tier-2 DRY (3/6), Wave 1. The shared `useConnectionPagination` hook (the #443–#463 cohesion series) already centralized the IO loop; the empty-`pageInfo` fallback it consumes was the remaining per-screen copy.

## Changes

### New `lib/pagination/empty-page-info.ts`

- Exports `EMPTY_PAGE_INFO`, typed against the canonical generated `PageInfo` (the base schema object type from `@/generated/base-types`), so it is structurally assignable to every operation's nominally-distinct inline `pageInfo` type without coupling the constant to one operation.

### Three list clients consume the shared const

- `catalog-client.tsx`, `admin-users-client.tsx`, `admin-masters-client.tsx` drop their local `EMPTY_PAGE_INFO` and import the shared one. The per-screen `pageInfo` type aliases (`CatalogPageInfo` / `PageInfo`) stay — they parameterise `useConnectionPagination<…, TPageInfo>`; only the const moved. The `*_INITIAL` wrapper objects and their comments are untouched beyond the const swap.

### Deviations from the issue body (verified against source)

- **Import path.** The issue said "from `@/generated/graphql`", but the canonical `PageInfo` object type is generated into `@/generated/base-types` — `graphql.ts` carries only per-operation inline `pageInfo` shapes. Imported from `base-types`.
- **`use-import-master.ts` left as a local literal (intentional).** The issue listed its literal as "the same shape", but the actual literal builds a *cold-cache single-edge* `CardgroupConnection` with `startCursor: created.id, endCursor: created.id` — it is **not** empty. Substituting the `EMPTY_PAGE_INFO` const there would change behaviour, or require overriding both cursor fields with a misleadingly-named "EMPTY" const, so it stays inline.
- **`cardgroups-client.tsx` out of scope.** It carries the same pattern, but the issue scopes Wave 1 to the three clients above and notes no overlap with the parallel PRs (#472 / #473 / #475 / #476). Left for a follow-up to avoid cross-PR edit conflicts; the shared const is now available for it.

### Tests

- No test changes. The fallback is exercised by the existing client tests through `useConnectionPagination`; the swap is a const move with an unchanged value.

## Verification

```bash
cd frontend
pnpm typecheck && ./node_modules/.bin/biome check --error-on-warnings . && pnpm knip && pnpm test && pnpm build
```

Gates green in the worktree: `tsc --noEmit` (0), `biome check --error-on-warnings` (0), `knip` (0 — shared `EMPTY_PAGE_INFO` is consumed, no unused export), `vitest run` (1376/1376 across 142 files), `next build` (0), and the CJK / language-policy scan (clean). `typecheck` passing confirms the shared base `PageInfo` is structurally assignable to all three operation-specific inline types (no `satisfies`/spread needed).

## Test plan

- [ ] `pnpm typecheck` — passes (structural assignability of the shared const to all three screens).
- [ ] `pnpm knip` — passes (no unused export; all three clients import `EMPTY_PAGE_INFO`).
- [ ] Load `/catalog`, `/admin/users`, `/admin/masters` before the first query resolves — the empty render fallback is unchanged (empty list, no next/prev page).
- [ ] `grep -rn "EMPTY_PAGE_INFO" frontend/src` — the three clients reference the shared `@/lib/pagination/empty-page-info` export; no local re-declaration remains.
