### PR TITLE
test(admin): document and pin intentional roles delete auth-error divergence

### DIFF
--- a/frontend/src/app/admin/roles/admin-roles-client.test.tsx
+++ b/frontend/src/app/admin/roles/admin-roles-client.test.tsx
@@ -788,4 +788,85 @@ describe("AdminRolesClient — delete failure", () => {
       warnSpy.mockRestore();
     }
   });
+
+  // Regression locks for the deliberate divergence from the shared kind-only
+  // classifyMutationAuthError used by the create/update branches: delete passes
+  // the server's FORBIDDEN message through verbatim (system-role protection) but
+  // collapses UNAUTHENTICATED to generic copy. A future "DRY" refactor that
+  // routed delete through the kind-only classifier would break these.
+  it("keeps the server's FORBIDDEN message verbatim when deleting a system role is refused", async () => {
+    const user = userEvent.setup();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const mocks = [
+        {
+          request: { query: AdminDeleteRoleDocument, variables: { id: CUSTOM_ROLE.id } },
+          result: {
+            errors: [
+              new GraphQLError('cannot delete system role "admin"', {
+                extensions: { code: "FORBIDDEN" },
+              }),
+            ],
+          },
+        },
+      ];
+
+      renderRoles([CUSTOM_ROLE], mocks);
+
+      await user.click(screen.getByTestId(`admin-role-delete-btn-${CUSTOM_ROLE.id}`));
+      await waitFor(() => {
+        expect(screen.queryByTestId(`admin-role-row-${CUSTOM_ROLE.id}`)).toBeNull();
+      });
+
+      act(() => vi.advanceTimersByTime(5100));
+      vi.useRealTimers();
+
+      await waitFor(() => {
+        expect(screen.getByTestId("admin-roles-error")).toHaveTextContent(
+          'cannot delete system role "admin"',
+        );
+      });
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("collapses a delete UNAUTHENTICATED failure to the generic sign-in copy, dropping the server detail", async () => {
+    const user = userEvent.setup();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const mocks = [
+        {
+          request: { query: AdminDeleteRoleDocument, variables: { id: CUSTOM_ROLE.id } },
+          result: {
+            errors: [
+              new GraphQLError("token expired at the edge proxy", {
+                extensions: { code: "UNAUTHENTICATED" },
+              }),
+            ],
+          },
+        },
+      ];
+
+      renderRoles([CUSTOM_ROLE], mocks);
+
+      await user.click(screen.getByTestId(`admin-role-delete-btn-${CUSTOM_ROLE.id}`));
+      await waitFor(() => {
+        expect(screen.queryByTestId(`admin-role-row-${CUSTOM_ROLE.id}`)).toBeNull();
+      });
+
+      act(() => vi.advanceTimersByTime(5100));
+      vi.useRealTimers();
+
+      const banner = await screen.findByTestId("admin-roles-error");
+      expect(banner).toHaveTextContent("Your session has expired. Please sign in again.");
+      expect(banner).not.toHaveTextContent("token expired at the edge proxy");
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
 });

--- a/frontend/src/app/admin/roles/admin-roles-client.tsx
+++ b/frontend/src/app/admin/roles/admin-roles-client.tsx
@@ -292,11 +292,17 @@ export function AdminRolesClient({ initialRoles }: Props) {
       commitDelete: () => deleteRoleMutate({ variables: { id } }),
       onCommitFailed: (err) => {
         const codes = liftGraphQLCodes(err);
-        // UNAUTHENTICATED collapses to a generic sign-in prompt — the user has
-        // no actionable detail to recover from. FORBIDDEN keeps the server's
-        // specific reason because the same code covers system-role races where
-        // the backend message ("cannot delete a protected role") is what the
-        // operator needs to see.
+        // This branch deliberately does NOT use the shared
+        // classifyMutationAuthError / mutationAuthBanner helpers (used by the
+        // create/update branches): those are kind-only and would discard the
+        // server's FORBIDDEN message. UNAUTHENTICATED collapses to a generic
+        // sign-in prompt — the user has no actionable detail to recover from.
+        // FORBIDDEN keeps the server's specific reason because the same code
+        // covers system-role protection, where the backend message
+        // (`cannot delete system role "admin"`) is what the operator needs to
+        // see. deleteRole returns Boolean! (no typed outcome union), so this
+        // FORBIDDEN passthrough is the only channel for that message — unlike
+        // update, whose system-role guard travels via CannotModifySystemRoleError.
         if (codes.includes("UNAUTHENTICATED")) {
           setDeleteError(t("deleteAuthFailed"));
           console.warn("[admin/roles] deleteRole auth failure", { roleId: id, codes });


### PR DESCRIPTION
## Summary

Investigate-first resolution of #475: the roles **delete** branch in `frontend/src/app/admin/roles/admin-roles-client.tsx` classifies auth errors differently from the create/update branches (`liftGraphQLCodes` + `codes.includes("UNAUTHENTICATED")` vs. the shared kind-only `classifyMutationAuthError`). The divergence is **intentional and structurally necessary**: `deleteRole(id: ID!): Boolean!` has no typed outcome union, so the system-role-protection `FORBIDDEN` message (`cannot delete system role "admin"`) can only reach the operator via a verbatim passthrough that the kind-only classifier cannot express. This PR documents *why* the branch diverges and locks the behaviour with regression tests. **No behaviour change.**

Closes #475.

## Background / Motivation

- The issue flagged a possible inconsistency: delete uses `liftGraphQLCodes(err) + codes.includes("UNAUTHENTICATED")`, while create (~L322) and update (~L367) use the shared `classifyMutationAuthError(err)`.
- Verified against source that the divergence is required, not an oversight:
  - `deleteRole` returns `Boolean!` (`schema/admin.graphql:139`) — no `CannotModifySystemRoleError`-style typed payload, unlike `updateRole`. Its business-specific failure arrives only as a GraphQL `FORBIDDEN` error.
  - Deleting a system role returns `ucerr.NewForbiddenError("cannot delete system role %q")` (`backend/internal/usecase/admin_role.go:235`) → wire `FORBIDDEN` + that operator-actionable message.
  - `classifyMutationAuthError` / `mutationAuthBanner` are kind-only (`forbidden | unauthenticated | other`) and fold into caller-supplied fixed strings; neither can pass the server's FORBIDDEN message through. Routing delete through them would replace `cannot delete system role "admin"` with generic copy — a regression.
  - create/update collapse FORBIDDEN to generic copy correctly: their system-role protection travels via the typed `CannotModifySystemRoleError` payload, preserved separately (`setEditSystemRoleError(payload.message)`).
- Test-coverage gap: the two existing delete-failure tests assert only that *a* banner renders, not its text, and there is no UNAUTHENTICATED delete case — so a future "DRY" refactor that collapsed delete-FORBIDDEN would pass the suite.
- FE Tier 2 investigate-first cleanup (issue #475).

## Changes

### `admin-roles-client.tsx`: document why the delete branch diverges

- The `onCommitFailed` comment is expanded to state explicitly that the branch deliberately does **not** use the shared `classifyMutationAuthError` / `mutationAuthBanner` helpers (kind-only → would discard the server message), and that `deleteRole`'s `Boolean!` return (no typed outcome union) makes the FORBIDDEN passthrough the only channel for `cannot delete system role "admin"`. The paraphrased example string is corrected to the real backend message.
- **No logic change** — the `codes.includes("UNAUTHENTICATED")` branch and both warn paths are untouched.

### Tests (`admin-roles-client.test.tsx`)

- **FORBIDDEN passthrough**: delete fails with `FORBIDDEN` carrying `cannot delete system role "admin"` → asserts the list error banner shows that server message verbatim.
- **UNAUTHENTICATED collapse**: delete fails with `UNAUTHENTICATED` carrying a distinctive server detail → asserts the banner shows the generic `Your session has expired. Please sign in again.` copy and **not** the server detail.
- Together these break any future refactor that routes delete through the kind-only classifier.

## Verification

```bash
# The comment names the divergence reason and the real backend message:
grep -n 'classifyMutationAuthError\|cannot delete system role' \
  frontend/src/app/admin/roles/admin-roles-client.tsx
```

Runtime: refusing to delete a system role on `/admin/roles` shows the backend's `cannot delete system role "<name>"` in the list error banner; an expired session shows the generic sign-in prompt instead. Out of scope (per #475): `loadRole` and the create/update branches are untouched.

## Test plan

- [x] `pnpm --filter frontend typecheck` (`tsc --noEmit`) — exit 0
- [x] `pnpm --filter frontend lint` (`biome check --error-on-warnings .`) — 375 files clean
- [x] `pnpm --filter frontend knip` — exit 0 (no new exports)
- [x] `pnpm --filter frontend test` — 1378 passed (142 files), incl. the 2 new delete-failure cases
- [x] `pnpm --filter frontend build` — success
- [x] CJK guard clean on changed source; no PR-order references in committed text
