### PR TITLE
refactor(learn): consume useCardMutations in learn-add-card-sheet

### DIFF
--- a/frontend/src/app/learn/[cardgroupId]/_components/learn-add-card-sheet.test.tsx
+++ b/frontend/src/app/learn/[cardgroupId]/_components/learn-add-card-sheet.test.tsx
@@ -4,6 +4,7 @@ import { act, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { CreateCardDocument } from "@/generated/graphql";
+import { UndoDeleteProvider } from "@/lib/undo-delete";
 import { renderWithIntl } from "@/test/render-with-intl";
 import { LearnAddCardSheet } from "./learn-add-card-sheet";
 
@@ -32,7 +33,9 @@ describe("<LearnAddCardSheet>", () => {
   it("opens the add-card drawer when the event targets this cardgroup", async () => {
     renderWithIntl(
       <MockedProvider mocks={[]}>
-        <LearnAddCardSheet cardgroupId="cg-1" />
+        <UndoDeleteProvider>
+          <LearnAddCardSheet cardgroupId="cg-1" />
+        </UndoDeleteProvider>
       </MockedProvider>,
     );
 
@@ -46,7 +49,9 @@ describe("<LearnAddCardSheet>", () => {
   it("ignores an add-card event for a different cardgroup", () => {
     renderWithIntl(
       <MockedProvider mocks={[]}>
-        <LearnAddCardSheet cardgroupId="cg-1" />
+        <UndoDeleteProvider>
+          <LearnAddCardSheet cardgroupId="cg-1" />
+        </UndoDeleteProvider>
       </MockedProvider>,
     );
 
@@ -82,7 +87,9 @@ describe("<LearnAddCardSheet>", () => {
 
     renderWithIntl(
       <MockedProvider mocks={[createMock]}>
-        <LearnAddCardSheet cardgroupId="cg-1" />
+        <UndoDeleteProvider>
+          <LearnAddCardSheet cardgroupId="cg-1" />
+        </UndoDeleteProvider>
       </MockedProvider>,
     );
 

--- a/frontend/src/app/learn/[cardgroupId]/_components/learn-add-card-sheet.tsx
+++ b/frontend/src/app/learn/[cardgroupId]/_components/learn-add-card-sheet.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useMutation } from "@apollo/client/react";
 import { useTranslations } from "next-intl";
-import { useCallback, useEffect, useState } from "react";
-import { CreateCardMutation } from "@/app/cardgroups/queries";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { cardsDefaultVars } from "@/app/cardgroups/[id]/cards/queries";
+import { useCardMutations } from "@/app/cardgroups/[id]/cards/use-card-mutations";
 import { CardForm } from "@/components/cardgroups/card-form";
 import { FormSheet, useFormSheetClose } from "@/components/ui/form-sheet";
 
@@ -56,8 +56,14 @@ export function LearnAddCardSheet({ cardgroupId }: { cardgroupId: string }) {
     message: string;
   } | null>(null);
 
-  const [createCard, { loading: creating, error: createError, reset: resetCreateCard }] =
-    useMutation(CreateCardMutation);
+  // The Learn screen has no cards-connection subscription of its own, so the
+  // shared hook's create path seeds the cardgroup's default-vars connection
+  // (search: null) — the same create slice the cards screen uses.
+  const queryVariables = useMemo(() => cardsDefaultVars(cardgroupId), [cardgroupId]);
+  const { createCard, creating, createError, resetCreateCard } = useCardMutations({
+    cardgroupId,
+    queryVariables,
+  });
 
   const openSheet = useCallback(() => {
     resetCreateCard();
@@ -83,33 +89,18 @@ export function LearnAddCardSheet({ cardgroupId }: { cardgroupId: string }) {
   async function handleCreate(values: { front: string; back: string }) {
     resetCreateCard();
     setValidationError(null);
-    const result = await createCard({
-      variables: { input: { cardgroupId, front: values.front, back: values.back } },
-    }).catch((err) => {
-      // err.message is omitted — backend messages may echo user-authored content.
-      console.error("[LearnAddCardSheet] create rejection", {
-        name: err instanceof Error ? err.name : "unknown",
-        cardgroupId,
-      });
-      return null;
-    });
-    if (!result) return;
-
-    const payload = result.data?.createCard;
-    if (payload?.__typename === "CreateCardSuccess") {
+    const outcome = await createCard(values);
+    if (outcome.status === "success") {
       setDirty(false);
       setValidationError(null);
       setOpen(false);
-    } else if (payload?.__typename === "CardDuplicateFrontError") {
-      setValidationError({ field: "front", message: payload.message });
-    } else {
-      const unknownPayload = payload as unknown as { __typename?: string } | null | undefined;
-      console.warn("[LearnAddCardSheet] unexpected createCard payload", {
-        typename: unknownPayload?.__typename ?? null,
-        cardgroupId,
-      });
+    } else if (outcome.status === "validation") {
+      setValidationError({ field: outcome.field, message: outcome.message });
+    } else if (outcome.status === "unexpected") {
       setValidationError({ field: "front", message: "Add failed. Please try again." });
     }
+    // outcome.status === "rejected": the hook already logged the rejection;
+    // leave the sheet open so the user can retry.
   }
 
   return (


### PR DESCRIPTION
## Summary

`learn-add-card-sheet.tsx` was the last screen carrying an inline `useMutation(CreateCardMutation)` for the create-card flow — the same create path #484 moved into the shared `useCardMutations` hook. This routes the Learn screen's in-context "add card" drawer through that hook, completing the FE Tier-2 DRY wave (6/6). **Behaviour-preserving — same validation copy, same dirty-state behaviour, same drawer open/close logic.**

Closes #477.

## Background / Motivation

- The Learn screen's add-card drawer duplicated the create-card flow: its own `useMutation(CreateCardMutation)` plus the `CreateCardSuccess` / `CardDuplicateFrontError` / unexpected-payload branching — the exact create slice `useCardMutations` already exposes as a typed outcome.
- `cards-client.tsx` (#484) and the admin screens already route create through the shared hook; the Learn drawer was the only remaining inline create path — the cohesion asymmetry this Tier-2 item set out to remove.

## Changes

### `learn-add-card-sheet.tsx` consumes the hook

- Drops the inline `useMutation(CreateCardMutation)` (and the `CreateCardMutation` import) in favour of `useCardMutations({ cardgroupId, queryVariables })`. The Learn screen has no cards-connection subscription of its own, so `queryVariables` is a memoized `cardsDefaultVars(cardgroupId)` (`search: null`) — the hook's create path seeds the cardgroup's default-vars connection, exactly the slice the cards screen uses, and skips the active-search-filter variant.
- `handleCreate` now switches on the hook's discriminated-union outcome: `success` → reset dirty + close the drawer; `validation` → set the field/message validation error; `unexpected` → the existing `"Add failed. Please try again."` front error; `rejected` → leave the sheet open (the hook already logged the rejection).
- `creating` / `createError` / `resetCreateCard` now come from the hook; the `FormSheet` submitting/dirty wiring and the `flamingo:add-card` event listener are unchanged.

### Out of scope (unchanged)

- The drawer open/close + `flamingo:add-card` event logic is untouched.
- No change to the connection-seed semantics — the shared hook's create path owns them.

### Tests

- `learn-add-card-sheet.test.tsx` wraps the rendered component in `<UndoDeleteProvider>` (the hook calls `useUndoDelete` for its delete slice; in production the provider is mounted app-wide via `app/providers.tsx`). The three existing cases (open on matching event, ignore non-matching event, create + close on success) are otherwise unchanged.

## Verification

```bash
cd frontend
pnpm typecheck && ./node_modules/.bin/biome check --error-on-warnings . && pnpm knip && pnpm test && pnpm build
```

Gates green in the worktree: `tsc --noEmit` (0), `biome check --error-on-warnings` (0), `knip` (0), `vitest run` (1381/1381 across 142 files), `next build` (0), and the CJK / language-policy scan (clean).

## Test plan

- [ ] On the Learn screen, tap the LogoDrawer '+' (or dispatch `flamingo:add-card` for the active cardgroup): the add-card drawer opens.
- [ ] Add a card with valid front/back: the drawer closes; the card surfaces in a later session via FSRS scheduling (the current swipe queue is untouched).
- [ ] Add a duplicate front: the drawer stays open with the front validation error.
- [ ] After adding, open the cardgroup's cards screen: the new card appears (the hook seeded the default-vars connection).
- [ ] Dismiss the drawer with unsaved edits: the confirm-on-dismiss prompt fires (dirty-state preserved).
