### PR TITLE
chore(frontend): run codegen on predev to prevent stale generated code

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "type": "module",
   "scripts": {
-    "predev": "node scripts/stamp-sw-version.mjs",
+    "predev": "pnpm codegen && node scripts/stamp-sw-version.mjs",
     "dev": "next dev",
     "build": "next build",
     "start": "next start",


### PR DESCRIPTION
## Summary

Add `pnpm codegen` to the `predev` lifecycle hook so `pnpm --filter frontend dev` regenerates `frontend/src/generated/` (GraphQL types + documents) on every dev-server start, matching what `prebuild` already does for production builds. This closes a "stale generated code" gap in local development.

This branch addresses no GitHub issue.

## Background / Motivation

Reported symptom: `/catalog` renders **"NaN 枚のカード"** with an empty deck name.

Root cause, traced end-to-end:

- The catalog tile renders `t("cardCount", { count: card.cardCount })` against the ICU message `"{count, plural, other {# 枚のカード}}"`. When `card.cardCount` is `undefined`, ICU renders the `#` as **NaN**; an `undefined` `card.name` renders an empty `<h3>`. Both symptoms share one cause: the GraphQL response is missing the `CatalogCardFields` selection (`name`, `cardCount`, …).
- The schema field is `MasterCardgroup.cardCount: Int!` (non-null), and the backend always fills it via a correlated `COUNT(*)` (`graph/resolver/mapper.go`, `internal/repository/master_catalog_read.go`). A non-null field cannot be `null` in a successful response, so the backend cannot produce `NaN` (a missing count would be `0`). The `undefined` therefore originates on the frontend: the executed query did not select the fields.
- `frontend/src/generated/` is gitignored and produced by `graphql-codegen`. `pnpm dev` runs only `predev` (service-worker version stamp) — it does **not** run codegen. So a dev server started against an older `src/generated/` (generated before the catalog fragment gained `name`/`cardCount`) keeps sending a query that omits those fields, producing the NaN + empty-name render. Re-running codegen on the current schema produces a `MasterCatalogDocument` that embeds the `CatalogCardFields` fragment (including `cardCount`) — verified by inspecting the regenerated output.

## Scope note (important)

The observed failure was on the **deployed (Vercel)** catalog page. Vercel builds run `pnpm build` → `prebuild` → `pnpm codegen` (there is no build-command override in `frontend/vercel.json`, which only pins the region), so a fresh deploy from current `main` already regenerates the query and resolves the deployed NaN. **This PR does not change the Vercel build path** — it only closes the local-dev gap where `pnpm dev` could serve stale generated code. The deployed fix is "redeploy from current main"; this PR is re-recurrence prevention for local development.

## Changes

- `frontend/package.json`: `predev` now runs `pnpm codegen && node scripts/stamp-sw-version.mjs` (previously only the SW stamp), mirroring `prebuild`.

## Verification

```bash
pnpm --filter frontend run predev
```

Regenerates `src/generated/` via codegen, then stamps the service worker; exits 0.

## Test plan

- [ ] `pnpm --filter frontend dev` regenerates `src/generated/` before serving.
- [ ] `/catalog` shows real card counts (no "NaN") against a backend that serves `masterCatalog`.
