### PR TITLE
chore(ci): run go mod tidy on Renovate Go bumps via gomodTidy

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,11 +15,12 @@
   "prConcurrentLimit": 10,
   "packageRules": [
     {
-      "description": "Backend (Go modules)",
+      "description": "Backend (Go modules). gomodTidy runs `go mod tidy` after each bump so go.sum is reconciled in the same PR. A bare version bump updates only the changed module's go.sum hashes; indirect-dep additions/removals it leaves behind would otherwise fail `go mod download` / `go mod verify` in CI and block auto-merge. postUpdateOptions is a normal repo-config option (NOT the self-hosted-only postUpgradeTasks command allowlist), so it works on the hosted Mend app.",
       "matchManagers": ["gomod"],
       "groupName": "backend dependencies",
       "addLabels": ["backend", "dependencies"],
-      "semanticCommitScope": "backend"
+      "semanticCommitScope": "backend",
+      "postUpdateOptions": ["gomodTidy"]
     },
     {
       "description": "Frontend (npm / pnpm). Override rangeStrategy to 'replace' so engines constraints (e.g. node >=24.0.0 <25.0.0) and caret ranges are only rewritten when the new version no longer satisfies them; the top-level 'bump' default would otherwise churn lower bounds on every patch.",


### PR DESCRIPTION
## Summary

Add `postUpdateOptions: ["gomodTidy"]` to the backend (gomod) packageRule so Renovate runs `go mod tidy` after each Go dependency bump and commits the reconciled `go.mod`/`go.sum` into the same PR. This stops indirect-dependency drift from failing `go mod download` / `go mod verify` in CI and blocking the auto-merge configured for minor/patch Go bumps.

This branch addresses no GitHub issue.

## Background / Motivation

- Renovate's gomod manager updates only the bumped module's `go.sum` hashes by default. Indirect-dep additions/removals it leaves behind fail `go mod download` / `go mod verify` in `.github/workflows/backend.yml`, turning CI red and blocking the auto-merge configured for minor/patch Go bumps — so every such PR needs a manual `go mod tidy` push.
- The original idea was a Renovate post-upgrade task that regenerates `go.sum` + gqlgen and commits. Two blockers ruled that mechanism out: (a) `postUpgradeTasks` shell commands do not run on the hosted Mend Renovate app — `allowedPostUpgradeCommands` is a self-hosted-only admin allowlist that defaults to empty ("If this list is empty then no tasks will be executed"); (b) the PR author is `app/renovate` with no self-hosted runner in `.github/`, confirming the hosted app.
- `postUpdateOptions: ["gomodTidy"]` is the native gomod option that covers exactly the `go.sum` reconciliation, is a normal repo-config option (not the self-hosted command allowlist), and commits the result into the PR branch.

## Changes

- `renovate.json`: the `matchManagers: ["gomod"]` packageRule gains `postUpdateOptions: ["gomodTidy"]`, plus an expanded `description` documenting the rationale (go.sum reconciliation, hosted-Mend-app compatibility, and the distinction from the self-hosted-only `postUpgradeTasks`).

## Scope note (important) — generated-code gitignore policy unchanged

The original framing assumed gqlgen / graphql-codegen output is committed and should be Renovate-regenerated. It is not. `backend/graph/generated/`, `backend/graph/model/models_gen.go`, and `frontend/src/generated/` are gitignored (`docs/dev-setup.md` §"Policy on generated files"), and every consumer regenerates them at build time:

- CI: `backend.yml` runs `go tool gqlgen generate`; `frontend.yml` runs `pnpm --filter frontend codegen`.
- Render: `render.yaml` `buildCommand` runs `go tool gqlgen generate` before `go build`.
- Vercel: `pnpm build` → `prebuild` → `pnpm codegen`.

Because no generated output is committed, it cannot go stale anywhere, so this PR deliberately does **not** touch the gitignore policy. The recurrence this PR prevents is `go.sum` drift only.

## Verification

- Verified against the Renovate config schema (`renovate-schema.json`) that `gomodTidy` is a valid `postUpdateOptions` enum value and that `postUpdateOptions` is allowed inside `packageRules`.
- `renovate.json` is valid JSON and the gomod rule carries `postUpdateOptions: ["gomodTidy"]`.
- After merge: the next Renovate Go-dependency PR carries a `go mod tidy`-reconciled `go.mod`/`go.sum` in the same PR, so backend CI's `go mod verify` passes without a manual follow-up commit.

## Test plan

- [ ] `renovate.json` is valid JSON and the `matchManagers: ["gomod"]` rule contains `postUpdateOptions: ["gomodTidy"]`.
- [ ] (Optional) `npx --yes renovate-config-validator renovate.json` reports the config valid.
- [ ] The next Renovate Go-dependency PR includes a tidied `go.mod`/`go.sum` and backend CI's `go mod verify` step passes without manual intervention.
