### PR TITLE
feat(cardgroups): redesign deck detail header IA with hero CTA

### DIFF
--- a/frontend/__tests__/cardgroup-edit.test.tsx
+++ b/frontend/__tests__/cardgroup-edit.test.tsx
@@ -152,16 +152,16 @@ describe("EditCardgroupPage — broad integration (RSC + management screen)", ()
     expect(screen.getByText("front-003")).toBeInTheDocument();
   });
 
-  it("renders the kebab button and card count Badge in the page header", async () => {
-    // Settings and Danger zone were moved into the kebab DropdownMenu (Task 1).
-    // The count chip was removed from the toolbar (Task 2); count shows in the
-    // page-level Badge next to the h1 instead.
+  it("renders the kebab button and card count in the page header", async () => {
+    // Settings and Danger zone were moved into the kebab DropdownMenu.
+    // The count chip was removed from the toolbar; the count now shows as muted
+    // metadata text beneath the h1 title (no Badge pill).
     mockEditPageGql(POPULATED_CONNECTION);
     await renderPage(POPULATED_CONNECTION);
 
     // The kebab trigger button is present.
     expect(screen.getByRole("button", { name: /cardgroup options/i })).toBeInTheDocument();
-    // The Badge with the card count is present (3 cards in POPULATED_CONNECTION).
+    // The card count metadata is present (3 cards in POPULATED_CONNECTION).
     expect(screen.getByText("3 cards")).toBeInTheDocument();
   });
 

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -122,6 +122,8 @@
     "createNewCardgroup": "Create new cardgroup…",
     "addMoreOptions": "More add options",
     "addCardButton": "Add card +",
+    "startLearning": "Start learning",
+    "cardsCount": "{count} cards",
     "addACard": "Add a card",
     "batchImport": "Batch import",
     "nameLabel": "Name",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -122,6 +122,8 @@
     "createNewCardgroup": "新規カードグループを作成…",
     "addMoreOptions": "追加オプション",
     "addCardButton": "カードを追加 +",
+    "startLearning": "学習を開始",
+    "cardsCount": "{count} 枚",
     "addACard": "カードを追加",
     "batchImport": "一括インポート",
     "nameLabel": "名前",

--- a/frontend/src/app/cardgroups/[id]/edit/cardgroup-management-client.tsx
+++ b/frontend/src/app/cardgroups/[id]/edit/cardgroup-management-client.tsx
@@ -22,8 +22,13 @@ export function CardgroupManagementClient({
   const t = useTranslations("Cardgroups");
   return (
     <main className="p-4 md:p-8">
-      <div className="mb-4">
-        <Link href="/cardgroups" className="text-sm text-muted-foreground hover:underline">
+      {/* Compact breadcrumb: tight to the title below so the back link reads as
+          a sibling of the header, not a floating standalone row. */}
+      <div className="mb-2">
+        <Link
+          href="/cardgroups"
+          className="inline-flex text-sm text-muted-foreground hover:text-foreground hover:underline"
+        >
           {t("backLink")}
         </Link>
       </div>

--- a/frontend/src/components/cardgroups/cardgroup-cards-section.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-cards-section.tsx
@@ -57,18 +57,22 @@ export function CardgroupCardsSection({
   }) => (
     <div>
       {renderPageHeader?.({ totalCount, onBatchImport })}
-      <div className="mb-3 flex flex-wrap items-center justify-end gap-2">
-        <Button asChild variant="outline" size="sm">
+      <div className="mb-3 flex flex-col gap-2 md:flex-row md:items-center md:justify-end">
+        {/* Primary CTA: full-width brand hero on mobile (h-11 = 44px tap target),
+            compact on desktop. Add card on mobile is provided by the global "+"
+            header action, so no Add button is duplicated here on small screens. */}
+        <Button asChild variant="brand" className="h-11 w-full px-8 md:h-9 md:w-auto md:px-4">
           <Link href={learnHref}>
-            Start learning
-            <Play aria-hidden="true" className="ml-1.5 h-4 w-4" />
+            <Play aria-hidden="true" className="h-4 w-4" />
+            {t("startLearning")}
           </Link>
         </Button>
-        {/* Desktop split button: primary Add card + dropdown with Batch import */}
+        {/* Desktop split button: secondary Add card + dropdown with Batch import.
+            Demoted to outline so Start learning is the single brand primary CTA. */}
         <div className="hidden md:inline-flex">
           <Button
             type="button"
-            variant="brand"
+            variant="outline"
             size="sm"
             className="rounded-r-none"
             onClick={onAddCard}
@@ -79,7 +83,7 @@ export function CardgroupCardsSection({
             <DropdownMenuTrigger asChild>
               <Button
                 type="button"
-                variant="brand"
+                variant="outline"
                 size="sm"
                 className="rounded-l-none border-l px-2"
                 aria-label={t("addMoreOptions")}

--- a/frontend/src/components/cardgroups/cardgroup-header.test.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-header.test.tsx
@@ -52,7 +52,7 @@ describe("<CardgroupHeader>", () => {
     expect(screen.getByRole("heading", { level: 1, name: /spanish vocab/i })).toBeInTheDocument();
   });
 
-  it("renders a Badge with the totalCount", () => {
+  it("renders the totalCount as muted metadata text below the title", () => {
     renderHeader([], 42);
     expect(screen.getByText("42 cards")).toBeInTheDocument();
   });

--- a/frontend/src/components/cardgroups/cardgroup-header.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-header.tsx
@@ -16,7 +16,6 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -64,48 +63,52 @@ export function CardgroupHeader({ cardgroup, totalCount, onBatchImport }: Props)
 
   return (
     <>
-      <div className="mb-6 flex flex-wrap items-center gap-3">
-        <h1 className="text-2xl font-semibold">{cardgroup.name}</h1>
-        <Badge variant="secondary">{totalCount} cards</Badge>
-        <div className="ml-auto">
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button variant="ghost" size="icon" aria-label={t("cardgroupOptions")}>
-                <MoreHorizontal className="h-4 w-4" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-              <DropdownMenuItem onSelect={() => setRenameOpen(true)} className="gap-2">
-                <Pencil className="h-4 w-4" />
-                {t("rename")}
-              </DropdownMenuItem>
-              {onBatchImport && (
-                <>
-                  <DropdownMenuSeparator />
-                  {/* Batch import is shown here for mobile users;
-                      the desktop split button (hidden md:inline-flex) covers desktop. */}
-                  <DropdownMenuItem onSelect={onBatchImport} className="gap-2 md:hidden">
-                    <Import className="h-4 w-4" />
-                    {t("batchImport")}
-                  </DropdownMenuItem>
-                </>
-              )}
-              <DropdownMenuSeparator />
-              {/* Future reserved items (not yet implemented):
-                  <DropdownMenuItem disabled>Export to TextDic</DropdownMenuItem>
-                  <DropdownMenuItem disabled>Duplicate</DropdownMenuItem>
-                  <DropdownMenuSeparator />
-              */}
-              <DropdownMenuItem
-                onSelect={() => setDeleteDialogOpen(true)}
-                className="gap-2 text-destructive focus:text-destructive"
-              >
-                <Trash2 className="h-4 w-4" />
-                {t("deleteCardgroupTitle")}
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
+      <div className="mb-6 flex items-start justify-between gap-3">
+        <div className="min-w-0 flex-1">
+          <h1 className="text-2xl font-semibold leading-tight break-words">{cardgroup.name}</h1>
+          {/* Count demoted from a Badge to muted metadata so the title is the
+              unambiguous anchor of the header. */}
+          <p className="mt-1 text-sm text-muted-foreground">
+            {t("cardsCount", { count: totalCount })}
+          </p>
         </div>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="ghost" size="icon" aria-label={t("cardgroupOptions")}>
+              <MoreHorizontal className="h-4 w-4" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem onSelect={() => setRenameOpen(true)} className="gap-2">
+              <Pencil className="h-4 w-4" />
+              {t("rename")}
+            </DropdownMenuItem>
+            {onBatchImport && (
+              <>
+                <DropdownMenuSeparator />
+                {/* Batch import is shown here for mobile users;
+                    the desktop split button (hidden md:inline-flex) covers desktop. */}
+                <DropdownMenuItem onSelect={onBatchImport} className="gap-2 md:hidden">
+                  <Import className="h-4 w-4" />
+                  {t("batchImport")}
+                </DropdownMenuItem>
+              </>
+            )}
+            <DropdownMenuSeparator />
+            {/* Future reserved items (not yet implemented):
+                <DropdownMenuItem disabled>Export to TextDic</DropdownMenuItem>
+                <DropdownMenuItem disabled>Duplicate</DropdownMenuItem>
+                <DropdownMenuSeparator />
+            */}
+            <DropdownMenuItem
+              onSelect={() => setDeleteDialogOpen(true)}
+              className="gap-2 text-destructive focus:text-destructive"
+            >
+              <Trash2 className="h-4 w-4" />
+              {t("deleteCardgroupTitle")}
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
       </div>
 
       <FormSheet


### PR DESCRIPTION
## Summary

The cardgroup detail header (`/cardgroups/[id]/edit`) crowded a back link, the deck title, a `N cards` Badge, and a kebab menu into one competing top row, while the screen's primary action — "Start learning" — was a weak right-aligned outline button on its own line below. This pass re-establishes a clear hierarchy: a compact breadcrumb, the title as the sole anchor with the count demoted to muted metadata, and **Start learning promoted to a full-width brand hero CTA** on mobile. The two hardcoded English strings in this region (the CTA label and the count) are also moved into the i18n catalogs.

No associated issue (header IA cleanup requested in-session).

## Background / Motivation

- The back link (`← Cardgroups`) sat in its own `mb-4` (16px) row, floating well above the title instead of reading as a breadcrumb attached to it.
- The `N cards` count was a `<Badge variant="secondary">` pill rendered inline with the `<h1>` in a `flex-wrap` row, competing with the title for visual weight and wrapping awkwardly on narrow screens.
- "Start learning" — the dominant intent when opening a deck — was `variant="outline" size="sm"`, right-aligned on a separate toolbar row, visually the weakest element despite being the primary action. The desktop "Add card" split button was `variant="brand"`, so the *secondary* action carried the only brand-primary color.
- "Start learning" was a hardcoded English literal in `cardgroup-cards-section.tsx` (absent from the message catalogs), so it rendered in English even under the `ja` locale; the `N cards` count was likewise hardcoded English.

## Changes

### Header layout (`cardgroup-header.tsx`)

- Replaced the `flex flex-wrap items-center` title row with a `flex items-start justify-between` block: a `min-w-0 flex-1` column holds the `<h1>` (now `leading-tight break-words`) plus the count, and the kebab `DropdownMenu` is pinned top-right (the `ml-auto` wrapper div is gone).
- Demoted the count from `<Badge variant="secondary">{n} cards</Badge>` to muted metadata text (`<p className="mt-1 text-sm text-muted-foreground">`) and dropped the now-unused `Badge` import. The rename / batch-import / delete menu items are unchanged.

### Breadcrumb (`cardgroup-management-client.tsx`)

- Tightened the back-link row from `mb-4` to `mb-2` and added a `hover:text-foreground` affordance so it reads as a compact breadcrumb directly above the title.

### Primary CTA + desktop toolbar (`cardgroup-cards-section.tsx`)

- "Start learning" is now `variant="brand"`: full-width `h-11` (44px tap target) on mobile and `md:h-9 md:w-auto` compact on desktop. The action row stacks `flex-col` on mobile and switches to `md:flex-row md:justify-end` on desktop.
- Demoted the desktop "Add card" split button from `variant="brand"` to `variant="outline"`, so Start learning is the single brand-primary CTA (per the design-system "brand is the one primary constructive action" rule). On mobile, "Add card" is intentionally not duplicated here — the global header `+` (`resolveHeaderCreateAction` for `/cardgroups/:id/edit`) already covers it.

### i18n (`messages/en.json`, `messages/ja.json`)

- Added `Cardgroups.startLearning` (`Start learning` / `学習を開始`) and `Cardgroups.cardsCount` (`{count} cards` / `{count} 枚`), replacing the two hardcoded English literals.

### Tests

- `cardgroup-header.test.tsx` and `cardgroup-edit.test.tsx`: updated the two test names + comments that referenced the removed `Badge`. Assertions are unchanged — `getByText("42 cards")` / `getByText("3 cards")` still pass against the new muted-text rendering (English catalog value `{count} cards`).

## Verification

```bash
cd frontend
pnpm typecheck && ./node_modules/.bin/biome check --error-on-warnings src __tests__ messages && pnpm knip && pnpm test && pnpm build
```

Gates green in the worktree: `tsc --noEmit` (0), `biome check --error-on-warnings` (354 files, clean), `knip` (0), `vitest run` (1381/1381 across 142 files), `next build` (0), and the CJK / language-policy scan (clean — the only new Japanese lives in `messages/ja.json`, the sanctioned catalog).

## Test plan

- [ ] `/cardgroups/<id>/edit` at a mobile width: the back link reads as a compact breadcrumb directly above the title; the title is the clear anchor with `N cards` as muted text beneath it (no pill); "Start learning" is a full-width brand button.
- [ ] Tap "Start learning" → navigates to `/learn/<id>`.
- [ ] Mobile: tap the global header `+` — the in-context Add card sheet still opens (Add card is not duplicated in the deck header).
- [ ] Desktop (`md+`): the action row right-aligns with a brand "Start learning" and an outline "Add card +" split button; the split dropdown still offers "Add a card" / "Batch import".
- [ ] Kebab (`⋯`) still opens Rename / Batch import (mobile) / Delete cardgroup; Delete still confirms and navigates to `/cardgroups`.
- [ ] `ja` locale: the CTA reads "学習を開始" and the count reads "{n} 枚".
- [ ] `pnpm vitest run src/components/cardgroups/cardgroup-header.test.tsx src/components/cardgroups/cardgroup-cards-section.test.tsx __tests__/cardgroup-edit.test.tsx` — all pass.
