### PR TITLE
chore(i18n): reword onboarding start loading label

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -267,7 +267,7 @@
     "or": "or",
     "createCta": "create your own empty cardgroup",
     "startWithDeck": "Start learning",
-    "starting": "Starting...",
+    "starting": "Setting up your environment...",
     "imported": "Added",
     "importError": "Could not start with that cardgroup. Please try again.",
     "importNotFound": "This cardgroup is no longer available.",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -267,7 +267,7 @@
     "or": "または",
     "createCta": "空のカードグループを自分で作る",
     "startWithDeck": "学習を始める",
-    "starting": "開始中...",
+    "starting": "環境を構成中...",
     "imported": "追加済み",
     "importError": "このカードグループで開始できませんでした。もう一度お試しください。",
     "importNotFound": "このカードグループは利用できなくなりました。",

--- a/frontend/src/app/onboarding/start/onboarding-start-client.test.tsx
+++ b/frontend/src/app/onboarding/start/onboarding-start-client.test.tsx
@@ -131,14 +131,18 @@ describe("<OnboardingStartClient>", () => {
     await user.click(screen.getByTestId("onboarding-deck-m-1"));
 
     // The branded coral splash appears immediately while the import is in flight.
-    expect(screen.getByRole("status", { name: /starting/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("status", { name: /setting up your environment/i }),
+    ).toBeInTheDocument();
 
     // It stays through the success navigation (importingId is held until unmount).
     resolve?.({ status: "success", cardgroupId: "cg-9", cardgroupName: "x" });
     await waitFor(() => {
       expect(mockPush).toHaveBeenCalledWith("/learn/cg-9");
     });
-    expect(screen.getByRole("status", { name: /starting/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("status", { name: /setting up your environment/i }),
+    ).toBeInTheDocument();
   });
 
   it("removes the coral splash and shows the error banner when the import fails", async () => {
@@ -154,7 +158,9 @@ describe("<OnboardingStartClient>", () => {
     await user.click(screen.getByTestId("onboarding-deck-m-1"));
 
     // Splash is up while the import is in flight...
-    expect(screen.getByRole("status", { name: /starting/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("status", { name: /setting up your environment/i }),
+    ).toBeInTheDocument();
 
     // ...and is torn down when the import fails, leaving the error banner behind.
     resolve?.({ status: "rejected" });


### PR DESCRIPTION
## Summary

Reword the loading label shown on `/onboarding/start` while a selected preset cardgroup is being imported. The `OnboardingStart.starting` string — surfaced as both the coral `BrandSplash` caption and its `role="status"` accessible label — now tells a first-run user their environment is being set up, rather than a generic "starting" message. Copy-only change in both locales, plus the test-matcher update it forces; no component or behavior change.

No associated issue (loading-label wording refinement requested in-session).

## Background / Motivation

- The preset-import splash reuses `OnboardingStart.starting` (`開始中...` / `Starting...`) as its visible caption and accessible name, but that wording is vague about what the network wait is actually doing during a first-run import.
- `環境を構成中...` / `Setting up your environment...` names the real work — provisioning the new user's initial cards — giving clearer feedback across the import → `/learn/{id}` navigation window.

## Changes

### i18n — `frontend/messages/ja.json`, `frontend/messages/en.json`

- `OnboardingStart.starting`: `開始中...` → `環境を構成中...` (ja); `Starting...` → `Setting up your environment...` (en).
- Trailing `...` kept to match the existing loading-label style; no catalog key added or removed, so en/ja parity is preserved (344 keys).

### Tests — `frontend/src/app/onboarding/start/onboarding-start-client.test.tsx`

- The three `getByRole("status", { name: /starting/i })` splash-presence assertions resolve against the English catalog via `renderWithIntl`, so the reworded label would have broken the matcher. Updated to `/setting up your environment/i`, still pinning the same `role="status"` node on press, through a successful import, and while an import is in flight before failure.

## Verification

```bash
cd frontend
pnpm --filter frontend test onboarding-start-client   # 10/10 pass
pnpm --filter frontend i18n:parity                    # Parity OK — 344 keys in both catalogs
```

Runtime: on `/onboarding/start` with at least one preset, tap "Start learning" — the full-screen coral splash caption now reads `Setting up your environment...` (en) / `環境を構成中...` (ja) until navigation to `/learn/{id}`.

## Test plan

- [ ] `pnpm --filter frontend test onboarding-start-client` — 10/10 pass.
- [ ] `pnpm --filter frontend i18n:parity` — parity OK.
- [ ] On `/onboarding/start` (en locale), tap a preset's "Start learning": the coral loading splash caption reads `Setting up your environment...`.
- [ ] Switch locale to ja and repeat: caption reads `環境を構成中...`.
- [ ] Trigger an import failure: splash tears down and the existing error banner shows (unchanged).
