### PR TITLE
fix(onboarding): keep submit in saving state until navigation completes

### DIFF
--- a/frontend/src/app/onboarding/onboarding-form.test.tsx
+++ b/frontend/src/app/onboarding/onboarding-form.test.tsx
@@ -114,6 +114,39 @@ describe("<OnboardingForm>", () => {
     });
   });
 
+  it("holds the button in the saving state through the success navigation (no flicker back to Continue)", async () => {
+    const user = userEvent.setup();
+
+    const mocks = [makeUpdateProfileMock({ input: { displayName: "Alice" } })];
+
+    renderWithIntl(
+      <MockedProvider mocks={mocks}>
+        <OnboardingForm />
+      </MockedProvider>,
+    );
+
+    const displayNameInput = screen.getByLabelText(/display name/i);
+    await user.click(displayNameInput);
+    await user.type(displayNameInput, "Alice");
+    await user.click(screen.getByRole("button", { name: /continue/i }));
+
+    // The success navigation has been initiated.
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith("/onboarding/start");
+    });
+
+    // The mutation has resolved (Apollo `loading` is back to false), but the
+    // App Router navigation to /onboarding/start is still settling and the form
+    // stays mounted until it completes. The button MUST remain "Saving..." and
+    // disabled — it must NOT flicker back to an enabled "Continue" (regression:
+    // loading-only gating reverted the button mid-navigation).
+    await waitFor(() => {
+      expect(screen.getByTestId("onboarding-submit")).toBeDisabled();
+    });
+    expect(screen.getByTestId("onboarding-submit")).toHaveTextContent(/saving/i);
+    expect(screen.queryByRole("button", { name: /continue/i })).not.toBeInTheDocument();
+  });
+
   it("InputValidationError variant surfaces field error in the form", async () => {
     const user = userEvent.setup();
 

--- a/frontend/src/app/onboarding/onboarding-form.tsx
+++ b/frontend/src/app/onboarding/onboarding-form.tsx
@@ -27,6 +27,16 @@ export function OnboardingForm() {
   // Mid-session auth failures or unexpected payloads. Cleared on each submission.
   const [bannerMessage, setBannerMessage] = useState<string | null>(null);
 
+  // Held true from a successful save until this component unmounts on the
+  // `router.push("/onboarding/start")` navigation. Apollo's `loading` flips back
+  // to false the instant the mutation resolves — before the App Router
+  // navigation (RSC fetch + transition) completes — so gating the button on
+  // `loading` alone makes it flicker from "Saving…" back to an enabled
+  // "Continue" while the form is still mounted. Mirrors how OnboardingStartClient
+  // holds `importingId` through its unmounting navigation. Set only on the
+  // success path; every failure branch leaves it false so the user can resubmit.
+  const [navigating, setNavigating] = useState(false);
+
   const { submit, loading } = useUpdateProfile();
 
   const displayNameSchema = updateProfileSchema.shape.displayName;
@@ -45,6 +55,10 @@ export function OnboardingForm() {
 
       switch (outcome.status) {
         case "success":
+          // Keep the button in its "Saving…"/disabled state through the
+          // navigation that unmounts this component, so it does not flicker back
+          // to "Continue" once Apollo's `loading` clears.
+          setNavigating(true);
           router.push("/onboarding/start");
           return;
         case "validation":
@@ -110,8 +124,13 @@ export function OnboardingForm() {
         )}
       </form.Field>
 
-      <Button type="submit" variant="brand" disabled={loading} data-testid="onboarding-submit">
-        {loading ? tCommon("saving") : t("continue")}
+      <Button
+        type="submit"
+        variant="brand"
+        disabled={loading || navigating}
+        data-testid="onboarding-submit"
+      >
+        {loading || navigating ? tCommon("saving") : t("continue")}
       </Button>
 
       {/* Hidden sentinel used by tests to observe formState.isSubmitSuccessful */}


### PR DESCRIPTION
## Summary

On `/onboarding`, after setting a display name and pressing **Continue**, the button flips to **Saving…** and then flickers back to an enabled **Continue** before the page actually moves on to `/onboarding/start`. The submit button's loading state was gated solely on Apollo's `useMutation` `loading` flag, which clears the instant the mutation resolves — before the async App Router navigation completes — while the form is still mounted. This holds a `navigating` flag from the successful save through the unmounting navigation, so the button stays **Saving…**/disabled until the page transitions.

This branch addresses no GitHub issue (reported in-session).

## Background / Motivation

- `OnboardingForm`'s submit button label (`Saving…`/`Continue`) and `disabled` were driven only by `loading` from `useUpdateProfile`'s `useMutation`. On a successful save, `loading` flips back to `false` the moment the mutation resolves.
- The `success` branch then calls `router.push("/onboarding/start")`, an asynchronous Next.js App Router navigation that fetches the target route's RSC payload before transitioning. The form stays mounted during that window, so with `loading` already `false` the button reverts to an enabled `Continue` — the visible flicker the user reported.
- The sibling `OnboardingStartClient` already avoids this exact problem by holding `importingId` through its unmounting navigation; `OnboardingForm` lacked the equivalent guard.

## Changes

### Hold the saving state through the success navigation (`onboarding-form.tsx`)

- Add a `navigating` state, set to `true` **only** on the `success` branch immediately before `router.push("/onboarding/start")`, and never reset — the component unmounts on the navigation. Every failure branch (`validation` / `unauthenticated` / `unexpected` / `rejected`) leaves it `false` so the user can still resubmit.
- Gate the submit button on `loading || navigating` for both `disabled` and the `Saving…`/`Continue` label.

### Regression test (`onboarding-form.test.tsx`)

- Added (TDD, RED → GREEN): after a successful submit and `router.push("/onboarding/start")`, the button stays disabled with the `Saving…` label and no enabled `Continue` button remains. Confirmed failing before the fix (the button rendered an enabled `Continue`) and passing after.

## Verification

```bash
cd frontend
pnpm exec tsc --noEmit && ./node_modules/.bin/biome check --error-on-warnings src/app/onboarding && pnpm exec knip && pnpm exec vitest run && pnpm exec next build
```

Gates green in the worktree: `tsc --noEmit` (0), `biome check --error-on-warnings` (clean), `knip` (0), `vitest run` (1389/1389 across 142 files, incl. the new `OnboardingForm` regression case), `next build` (0, `/onboarding` and `/onboarding/start` generated), and the CJK / language-policy scan (clean). The new test was confirmed failing for the right reason (button reverted to an enabled `Continue`) before the fix landed.

The two onboarding Playwright e2e specs (`display-name-onboarding.spec.ts`, `new-user-onboarding.spec.ts`) only `waitForURL` after submit and assert nothing about the button re-enabling, so holding the saving state longer does not affect them.

## Test plan

- [ ] On `/onboarding`, enter a valid display name and press **Continue**: the button shows **Saving…** and stays disabled continuously until the app navigates to `/onboarding/start` (or its empty-catalog fallback `/cardgroups/new?welcome=1`) — it never flickers back to **Continue**.
- [ ] Trigger a field-validation failure (empty / too-long name): the button returns to an enabled **Continue** and the field error is shown (resubmit still works).
- [ ] Trigger a transport rejection: the banner appears and the button returns to an enabled **Continue**.
- [ ] `pnpm --filter frontend test` — 1389/1389 pass, including the new "holds the button in the saving state through the success navigation" case.
