### PR TITLE
fix(onboarding): unify first-run UI via shared OnboardingShell

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -256,6 +256,7 @@
   },
   "Onboarding": {
     "welcome": "Welcome to Flamingo Armond",
+    "subtitle": "Let's set up how your name appears.",
     "displayName": "Display name",
     "displayNameHint": "1–50 characters; visible to other users.",
     "continue": "Continue",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -256,6 +256,7 @@
   },
   "Onboarding": {
     "welcome": "Flamingo Armond へようこそ",
+    "subtitle": "あなたの表示名を決めましょう。",
     "displayName": "表示名",
     "displayNameHint": "1〜50文字。他のユーザーに表示されます。",
     "continue": "続ける",

--- a/frontend/src/app/cardgroups/new/new-cardgroup-client.tsx
+++ b/frontend/src/app/cardgroups/new/new-cardgroup-client.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { Sparkles } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { useState } from "react";
 import { useCreateCardgroup } from "@/app/cardgroups/use-create-cardgroup";
+import { FlamingoMark } from "@/components/brand/flamingo-mark";
 import { CardgroupForm } from "@/components/cardgroups/cardgroup-form";
 import { ErrorBanner } from "@/components/ui/error-banner";
 
@@ -91,12 +91,12 @@ export function NewCardgroupClient({ showWelcome = false, returnTo }: NewCardgro
           className="mb-8 rounded-2xl border border-brand-tint-border bg-brand-tint p-6 sm:p-8"
         >
           <div className="flex items-start gap-4">
-            <Sparkles aria-hidden className="mt-1 h-6 w-6 shrink-0 text-brand-primary" />
+            <FlamingoMark aria-hidden="true" className="size-10 shrink-0" />
             <div>
-              <h1 id="welcome-heading" className="text-lg font-semibold tracking-tight">
+              <h1 id="welcome-heading" className="text-2xl font-semibold tracking-tight">
                 {t("welcomeHeading")}
               </h1>
-              <p className="mt-1 text-sm text-muted-foreground">{t("welcomeDesc")}</p>
+              <p className="mt-2 text-sm text-muted-foreground">{t("welcomeDesc")}</p>
             </div>
           </div>
         </section>

--- a/frontend/src/app/onboarding/onboarding-form.tsx
+++ b/frontend/src/app/onboarding/onboarding-form.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { useState } from "react";
 import { useUpdateProfile } from "@/app/profile/use-update-profile";
+import { OnboardingShell } from "@/components/onboarding/onboarding-shell";
 import { Button } from "@/components/ui/button";
 import { ErrorBanner } from "@/components/ui/error-banner";
 import { Input } from "@/components/ui/input";
@@ -85,60 +86,67 @@ export function OnboardingForm() {
     : {};
 
   return (
-    <form
-      onSubmit={(e) => {
-        e.preventDefault();
-        e.stopPropagation();
-        form.handleSubmit().catch(() => {
-          // The inner submit handler's .catch already logged; swallow here so the
-          // re-thrown rejection (which keeps formState.isSubmitSuccessful=false correct)
-          // does not surface as an unhandled browser promise rejection.
-        });
-      }}
-      className="space-y-4"
-    >
-      <h1 className="mb-6 text-2xl font-semibold">{t("welcome")}</h1>
-
-      {bannerMessage ? <ErrorBanner>{bannerMessage}</ErrorBanner> : null}
-
-      <form.Field
-        name="displayName"
-        validators={{ onChange: displayNameSchema, onBlur: displayNameSchema }}
+    <OnboardingShell heading={t("welcome")} subline={t("subtitle")}>
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          form.handleSubmit().catch(() => {
+            // The inner submit handler's .catch already logged; swallow here so the
+            // re-thrown rejection (which keeps formState.isSubmitSuccessful=false correct)
+            // does not surface as an unhandled browser promise rejection.
+          });
+        }}
+        // Centered card inside the shell's centered column. Internals stay
+        // text-left so the label / input / hint read as a normal form.
+        className="mx-auto mt-8 w-full max-w-[420px] space-y-4 rounded-2xl border border-border/70 bg-card p-6 text-left shadow-[0_1px_2px_rgba(0,0,0,0.04),0_12px_32px_-12px_rgba(0,0,0,0.12)] sm:p-8"
       >
-        {(field) => (
-          <div className="space-y-2">
-            <Label htmlFor={field.name}>{t("displayName")}</Label>
-            <Input
-              id={field.name}
-              name={field.name}
-              value={field.state.value}
-              onBlur={field.handleBlur}
-              onChange={(e) => field.handleChange(e.target.value)}
-            />
-            <p className="text-sm text-muted-foreground">{t("displayNameHint")}</p>
-            <FieldError
-              zodErrors={field.state.meta.errors}
-              backendError={fieldErrors.displayName}
-            />
-          </div>
-        )}
-      </form.Field>
+        {bannerMessage ? <ErrorBanner>{bannerMessage}</ErrorBanner> : null}
 
-      <Button
-        type="submit"
-        variant="brand"
-        disabled={loading || navigating}
-        data-testid="onboarding-submit"
-      >
-        {loading || navigating ? tCommon("saving") : t("continue")}
-      </Button>
+        <form.Field
+          name="displayName"
+          validators={{ onChange: displayNameSchema, onBlur: displayNameSchema }}
+        >
+          {(field) => (
+            <div className="space-y-2">
+              <Label htmlFor={field.name}>{t("displayName")}</Label>
+              <Input
+                id={field.name}
+                name={field.name}
+                value={field.state.value}
+                onBlur={field.handleBlur}
+                onChange={(e) => field.handleChange(e.target.value)}
+              />
+              <p className="text-sm text-muted-foreground">{t("displayNameHint")}</p>
+              <FieldError
+                zodErrors={field.state.meta.errors}
+                backendError={fieldErrors.displayName}
+              />
+            </div>
+          )}
+        </form.Field>
 
-      {/* Hidden sentinel used by tests to observe formState.isSubmitSuccessful */}
-      <form.Subscribe selector={(state) => state.isSubmitSuccessful}>
-        {(isSubmitSuccessful) => (
-          <span data-testid="is-submit-successful" data-value={String(isSubmitSuccessful)} hidden />
-        )}
-      </form.Subscribe>
-    </form>
+        <Button
+          type="submit"
+          variant="brand"
+          disabled={loading || navigating}
+          data-testid="onboarding-submit"
+          className="w-full"
+        >
+          {loading || navigating ? tCommon("saving") : t("continue")}
+        </Button>
+
+        {/* Hidden sentinel used by tests to observe formState.isSubmitSuccessful */}
+        <form.Subscribe selector={(state) => state.isSubmitSuccessful}>
+          {(isSubmitSuccessful) => (
+            <span
+              data-testid="is-submit-successful"
+              data-value={String(isSubmitSuccessful)}
+              hidden
+            />
+          )}
+        </form.Subscribe>
+      </form>
+    </OnboardingShell>
   );
 }

--- a/frontend/src/app/onboarding/page.tsx
+++ b/frontend/src/app/onboarding/page.tsx
@@ -26,9 +26,10 @@ export default async function OnboardingPage() {
 
   if (isUserOnboarded(data.me)) redirect("/");
 
-  // This page bypasses AppShell, so it renders its own <main> landmark.
+  // This page bypasses AppShell, so it renders its own <main> landmark. The
+  // OnboardingShell owns the centered hero layout, so <main> carries no padding.
   return (
-    <main className="p-8">
+    <main>
       <OnboardingForm />
     </main>
   );

--- a/frontend/src/app/onboarding/start/onboarding-start-client.tsx
+++ b/frontend/src/app/onboarding/start/onboarding-start-client.tsx
@@ -7,7 +7,7 @@ import { type CSSProperties, useCallback, useState } from "react";
 import { CatalogCard } from "@/app/catalog/catalog-card";
 import type { CatalogCardFieldsFragment } from "@/app/catalog/queries";
 import { useImportMaster } from "@/app/catalog/use-import-master";
-import { FlamingoMark } from "@/components/brand/flamingo-mark";
+import { OnboardingShell } from "@/components/onboarding/onboarding-shell";
 import { BrandSplash } from "@/components/pwa/brand-splash";
 import { Button } from "@/components/ui/button";
 import { ErrorBanner } from "@/components/ui/error-banner";
@@ -90,15 +90,7 @@ export function OnboardingStartClient({ cardgroups }: OnboardingStartClientProps
         </BrandSplash>
       ) : null}
 
-      <div className="mx-auto max-w-2xl px-6 py-12 text-center sm:py-16">
-        <FlamingoMark aria-hidden="true" className="mx-auto size-12" />
-        <h1 className="mt-4 text-3xl font-semibold leading-[1.35] tracking-normal sm:text-4xl">
-          {t("heading")}
-        </h1>
-        <p className="mt-3 text-base leading-[1.7] tracking-[0.01em] text-muted-foreground sm:text-[17px]">
-          {t("subline")}
-        </p>
-
+      <OnboardingShell heading={t("heading")} subline={t("subline")}>
         {hasBanner && (
           <div className="mt-6 space-y-6 text-left">
             {importAuthError ? (
@@ -156,7 +148,7 @@ export function OnboardingStartClient({ cardgroups }: OnboardingStartClientProps
             </Link>
           </Button>
         </p>
-      </div>
+      </OnboardingShell>
     </>
   );
 }

--- a/frontend/src/components/onboarding/onboarding-shell.test.tsx
+++ b/frontend/src/components/onboarding/onboarding-shell.test.tsx
@@ -1,0 +1,60 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { OnboardingShell } from "./onboarding-shell";
+
+describe("OnboardingShell", () => {
+  it("renders the heading as the single h1 and the children", () => {
+    render(
+      <OnboardingShell heading="Welcome">
+        <p>step content</p>
+      </OnboardingShell>,
+    );
+
+    const headings = screen.getAllByRole("heading", { level: 1 });
+    expect(headings).toHaveLength(1);
+    expect(headings[0]).toHaveTextContent("Welcome");
+    expect(screen.getByText("step content")).toBeInTheDocument();
+  });
+
+  it("renders the subline when provided", () => {
+    render(
+      <OnboardingShell heading="Welcome" subline="Set up your name.">
+        <span />
+      </OnboardingShell>,
+    );
+
+    expect(screen.getByText("Set up your name.")).toBeInTheDocument();
+  });
+
+  it("omits the subline paragraph when none is given", () => {
+    render(
+      <OnboardingShell heading="Welcome">
+        <span />
+      </OnboardingShell>,
+    );
+
+    // Heading only — no supporting paragraph element rendered.
+    expect(screen.queryByText("Set up your name.")).not.toBeInTheDocument();
+  });
+
+  it("forwards headingId to the h1 so callers keep a stable anchor", () => {
+    render(
+      <OnboardingShell heading="Welcome" headingId="welcome-heading">
+        <span />
+      </OnboardingShell>,
+    );
+
+    expect(screen.getByRole("heading", { level: 1 })).toHaveAttribute("id", "welcome-heading");
+  });
+
+  it("renders the decorative FlamingoMark", () => {
+    const { container } = render(
+      <OnboardingShell heading="Welcome">
+        <span />
+      </OnboardingShell>,
+    );
+
+    expect(container.querySelector("svg")).not.toBeNull();
+  });
+});

--- a/frontend/src/components/onboarding/onboarding-shell.tsx
+++ b/frontend/src/components/onboarding/onboarding-shell.tsx
@@ -1,0 +1,45 @@
+import type { ReactNode } from "react";
+import { FlamingoMark } from "@/components/brand/flamingo-mark";
+
+interface OnboardingShellProps {
+  /** First-run heading rendered as the page's single `<h1>`. */
+  heading: string;
+  /** Optional supporting line under the heading. */
+  subline?: string;
+  /** Forwarded to the `<h1>` so callers can keep a stable anchor (e.g. e2e ids). */
+  headingId?: string;
+  /** Step-specific content rendered below the hero block. */
+  children: ReactNode;
+}
+
+/**
+ * Centered first-run hero shell shared by the bare onboarding routes
+ * (`/onboarding`, `/onboarding/start`). It is the single source of truth for the
+ * onboarding rhythm — FlamingoMark size, heading scale, and vertical spacing —
+ * so the two consecutive wizard steps stay visually identical instead of each
+ * re-spelling the layout. Presentational only (no I/O, no client hooks), so it
+ * renders safely in either a server or client subtree.
+ *
+ * The shell centers its content (`text-center`); step content that must read
+ * left-aligned (form fields, banners) opts back in with `text-left` on its own
+ * container.
+ */
+export function OnboardingShell({ heading, subline, headingId, children }: OnboardingShellProps) {
+  return (
+    <div className="mx-auto max-w-2xl px-6 py-12 text-center sm:py-16">
+      <FlamingoMark aria-hidden="true" className="mx-auto size-12" />
+      <h1
+        id={headingId}
+        className="mt-4 text-3xl font-semibold leading-[1.35] tracking-normal sm:text-4xl"
+      >
+        {heading}
+      </h1>
+      {subline ? (
+        <p className="mt-3 text-base leading-[1.7] tracking-[0.01em] text-muted-foreground sm:text-[17px]">
+          {subline}
+        </p>
+      ) : null}
+      {children}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

`/onboarding` (the display-name step) rendered a bare, left-aligned form jammed against the top-left edge, while the very next step `/onboarding/start` was a centered FlamingoMark hero — two consecutive steps of the same wizard that did not look like the same product. A new shared `OnboardingShell` now owns the centered first-run hero (FlamingoMark, heading scale, vertical rhythm) as a single source of truth; the display-name input sits in a centered card inside it, `/onboarding/start` is refactored onto the same shell, and the `/cardgroups/new?welcome=1` welcome screen is brought into the same first-run family.

This branch addresses no GitHub issue (reported in-session from a screenshot).

## Background / Motivation

- `/onboarding` wrapped `OnboardingForm` in `<main className="p-8">` around a bare `<form className="space-y-4">` — no centering, no max-width, no brand mark — so the display-name form sat pinned to the top-left edge.
- The immediately-following `/onboarding/start` was already a polished centered hero (`mx-auto max-w-2xl … text-center`, FlamingoMark, heading scale, brand-tint preset panel). The two steps matched only by coincidence, not structure, so any new or edited step would drift again.
- `/onboarding` and `/onboarding/start` are bare routes (no nav shell); `/cardgroups/new` renders inside the AppShell, so its welcome variant can share the family's tokens/tone but not a full-viewport hero.

## Changes

### Shared `OnboardingShell` (single source of truth)

- New `components/onboarding/onboarding-shell.tsx`: presentational, `children`-only, server/client-safe. Owns the centered column (`mx-auto max-w-2xl px-6 py-12 sm:py-16 text-center`), the decorative `FlamingoMark`, the single `<h1>` heading scale, and the optional subline — so both bare onboarding steps inherit one rhythm instead of each re-spelling it.

### `/onboarding` display-name step

- `OnboardingForm` now renders inside `OnboardingShell`; the label/input/hint/Continue button live in a centered card (`max-w-[420px] bg-card` + border + soft shadow) with left-aligned internals. The old in-form `<h1>` is removed (the shell owns the heading). `page.tsx` drops `p-8` from `<main>` since the shell owns the layout.

### `/onboarding/start` refactor

- The existing hero is refactored to consume `OnboardingShell` (heading/subline/FlamingoMark moved into the shell; preset panel + "create your own" link become its children). All `data-testid` / `aria` handles are preserved.

### `/cardgroups/new?welcome=1` welcome screen

- The welcome section is aligned to the first-run family: `Sparkles` → `FlamingoMark`, heading `text-lg` → `text-2xl`. It stays in the left content column (inside the AppShell); `#welcome-heading` is preserved.

### i18n

- Add `Onboarding.subtitle` to the en/ja message catalogs (e.g. en: "Let's set up how your name appears.").

### Tests

- New co-located `onboarding-shell.test.tsx`: single `<h1>`, subline present/absent, `headingId` passthrough, decorative mark rendered, children rendered.

## Verification

```bash
cd frontend
pnpm exec tsc --noEmit \
  && ./node_modules/.bin/biome check --error-on-warnings src/components/onboarding src/app/onboarding src/app/cardgroups/new messages \
  && pnpm exec knip \
  && pnpm exec vitest run \
  && pnpm exec next build
```

Gates green in the worktree: `tsc --noEmit` (0), `biome check --error-on-warnings` (clean, 17 files), `knip` (0), `vitest run` (1395/1395 across 143 files, incl. the new `OnboardingShell` suite), `next build` (0, `/onboarding` and `/onboarding/start` generated). The CJK / language-policy scan over changed source is clean (no CJK outside the message catalogs).

This is a pure layout change: the onboarding Playwright e2e specs (`display-name-onboarding.spec.ts`, `new-user-onboarding.spec.ts`) select on stable handles (`#displayName`, `onboarding-submit`, `#welcome-heading`, `input[name="name"]`) and redirect URLs, none of which changed, so they are unaffected.

## Test plan

- [ ] On `/onboarding`, the display-name form renders as a centered card under the FlamingoMark hero (no longer pinned to the left edge), matching `/onboarding/start`.
- [ ] Enter a valid display name and press **Continue** → navigates to `/onboarding/start` (or its empty-catalog fallback `/cardgroups/new?welcome=1`).
- [ ] Field validation (empty / over 50 chars) shows the inline error inside the card; resubmit still works.
- [ ] `/onboarding/start` still renders the preset hero, deck cards, and "create your own" link unchanged.
- [ ] `/cardgroups/new?welcome=1` shows the FlamingoMark welcome banner (no Sparkles) and creates a cardgroup.
- [ ] `pnpm --filter frontend test` — 1395/1395 pass, including the new `OnboardingShell` suite.
