### PR TITLE
style(ui): balance onboarding hero heading and refine the logout button

### DIFF
--- a/frontend/src/app/_components/logout-button.tsx
+++ b/frontend/src/app/_components/logout-button.tsx
@@ -26,18 +26,10 @@ export function LogoutButton() {
   }
 
   return (
-    // Quiet, full-width utility action that sits in the nav-row rhythm of the
-    // drawer / rail footer above it (the Profile link): same gap-3 / px-3 (from
-    // size="sm") and hover:bg-accent. font-normal + text-foreground/70 keep it a
-    // step below the Profile link's full-strength font-medium label, so it reads
-    // as a secondary sign-out rather than another navigation destination — but
-    // stays clearly interactive (muted-foreground sat at the AA contrast floor
-    // and read closer to "disabled"). Darkens to the full foreground on hover.
-    // The spacing is tuned to the drawer's gap-3 / px-3 nav rhythm; the desktop
-    // rail's SidebarMenuButton rows run a few px tighter (gap-2 / p-2), so the
-    // two surfaces differ slightly by design rather than re-spelling per-surface
-    // classes. The leading icon is decorative (the label already names the
-    // action), so it is aria-hidden.
+    // Quiet secondary sign-out, tuned to the drawer's nav-row rhythm (under the
+    // Profile link). The desktop rail's SidebarMenuButton rows run a touch
+    // tighter — the small cross-surface mismatch is intentional, not worth
+    // re-spelling per surface.
     <Button
       onClick={handleLogout}
       type="button"

--- a/frontend/src/app/_components/logout-button.tsx
+++ b/frontend/src/app/_components/logout-button.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { LogOut } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
@@ -25,7 +26,26 @@ export function LogoutButton() {
   }
 
   return (
-    <Button onClick={handleLogout} type="button" variant="outline" size="sm">
+    // Quiet, full-width utility action that sits in the nav-row rhythm of the
+    // drawer / rail footer above it (the Profile link): same gap-3 / px-3 (from
+    // size="sm") and hover:bg-accent. font-normal + text-foreground/70 keep it a
+    // step below the Profile link's full-strength font-medium label, so it reads
+    // as a secondary sign-out rather than another navigation destination — but
+    // stays clearly interactive (muted-foreground sat at the AA contrast floor
+    // and read closer to "disabled"). Darkens to the full foreground on hover.
+    // The spacing is tuned to the drawer's gap-3 / px-3 nav rhythm; the desktop
+    // rail's SidebarMenuButton rows run a few px tighter (gap-2 / p-2), so the
+    // two surfaces differ slightly by design rather than re-spelling per-surface
+    // classes. The leading icon is decorative (the label already names the
+    // action), so it is aria-hidden.
+    <Button
+      onClick={handleLogout}
+      type="button"
+      variant="ghost"
+      size="sm"
+      className="w-full justify-start gap-3 font-normal text-foreground/70 hover:text-foreground"
+    >
+      <LogOut aria-hidden="true" />
       {t("logout")}
     </Button>
   );

--- a/frontend/src/components/onboarding/onboarding-shell.tsx
+++ b/frontend/src/components/onboarding/onboarding-shell.tsx
@@ -28,14 +28,11 @@ export function OnboardingShell({ heading, subline, headingId, children }: Onboa
   return (
     <div className="mx-auto max-w-2xl px-6 py-12 text-center sm:py-16">
       <FlamingoMark aria-hidden="true" className="mx-auto size-12" />
-      <h1
-        id={headingId}
-        className="mt-4 text-3xl font-semibold leading-[1.35] tracking-normal sm:text-4xl"
-      >
+      <h1 id={headingId} className="mt-5 text-2xl font-semibold leading-[1.35] sm:text-3xl">
         {heading}
       </h1>
       {subline ? (
-        <p className="mt-3 text-base leading-[1.7] tracking-[0.01em] text-muted-foreground sm:text-[17px]">
+        <p className="mt-2 text-base leading-[1.7] tracking-[0.01em] text-muted-foreground sm:text-[17px]">
           {subline}
         </p>
       ) : null}


### PR DESCRIPTION
## Summary

The onboarding hero heading (`OnboardingShell`, shared by `/onboarding` and `/onboarding/start`) rendered at `sm:text-4xl` (36px), which competed with the 48px brand mark and read oversized for the Japanese hero copy, and the nav logout control was a small auto-width `outline` pill that sat off-rhythm beneath the full-width Profile row. This scales the `<h1>` down to `text-2xl`/`sm:text-3xl` (24/30px) with a tighter title-block rhythm, and reworks `LogoutButton` into a full-width, left-aligned `ghost` row with a leading icon so it reads as a quiet secondary action in the footer's nav rhythm. A principal-designer review pass returned ship-with-nits; the flagged nits (title-block spacing, at-rest logout contrast, redundant class) are folded in.

This branch addresses no GitHub issue (reported in-session from screenshots).

## Background / Motivation

- The shared `OnboardingShell` `<h1>` was `text-3xl`/`sm:text-4xl` (30/36px). Against the 48px `FlamingoMark` above and a 16/17px subline below, that top-heavy scale read oversized for the Japanese hero copy ("Flamingo Armond へようこそ", "最初のカードグループを選びましょう").
- The mark→heading (`mt-4`) and heading→subline (`mt-3`) gaps were nearly equal, flattening the title block into three loosely-spaced lines instead of a grouped unit.
- `LogoutButton` rendered as `variant="outline" size="sm"` — a small bordered pill, no icon, auto width — directly under a full-width Profile nav row in both the mobile drawer (`logo-drawer.tsx`) and the desktop rail footer (`global-rail.tsx`), so it looked unfinished and off-rhythm.

## Changes

### Onboarding hero heading — `components/onboarding/onboarding-shell.tsx`

- `<h1>` scaled from `text-3xl`/`sm:text-4xl` (30/36px) to `text-2xl`/`sm:text-3xl` (24/30px); `leading-[1.35]` kept (suits two-line Japanese headings).
- Title-block rhythm tightened: mark→h1 `mt-4`→`mt-5`, h1→subline `mt-3`→`mt-2`, so the heading and subline read as one grouped unit under the mark.
- Dropped the redundant `tracking-normal` (it is the default). Both onboarding steps inherit the change through the shared shell.

### Logout button — `app/_components/logout-button.tsx`

- `variant="outline" size="sm"` pill → full-width, left-aligned `ghost` row (`w-full justify-start gap-3`) with a leading `LogOut` lucide icon (decorative, `aria-hidden`), matching the Profile row's `gap-3 / px-3 / hover:bg-accent` rhythm in the drawer.
- `font-normal` + `text-foreground/70` (hover → `text-foreground`) keep it a clear step below the Profile link's full-strength `font-medium` label while staying obviously interactive. Stays neutral — logout is reversible, so no danger-red (per the design-system "red is reserved for danger" rule).
- Spacing is tuned to the drawer; the desktop rail's `SidebarMenuButton` rows run a few px tighter by design (noted inline). The sign-out behavior (`signOut` → `/login` → `refresh`) is unchanged.

## Verification

```bash
cd frontend
pnpm exec tsc --noEmit \
  && pnpm exec biome check --error-on-warnings src/components/onboarding/onboarding-shell.tsx src/app/_components/logout-button.tsx \
  && pnpm exec vitest run \
       src/components/onboarding/onboarding-shell.test.tsx \
       src/app/_components/logout-button.test.tsx \
       src/app/onboarding/onboarding-form.test.tsx \
       src/app/onboarding/start/onboarding-start-client.test.tsx \
       src/components/nav/logo-drawer.test.tsx \
       src/components/nav/global-rail.test.tsx \
       src/components/nav/app-shell.test.tsx
```

Gates green in the worktree: `tsc --noEmit` (0), `biome check --error-on-warnings` (clean, 2 files), and the targeted `vitest` run (81/81 across 7 files). No test files changed — the behavior-only logout test and the structure-only shell test still pass against the restyled markup. CJK stays confined to the message catalogs (no inline literals added).

Runtime: on `/onboarding` and `/onboarding/start` the hero heading is visibly smaller and grouped with its subline; in the nav drawer / rail footer the Logout control is a full-width muted row with a leading sign-out icon that darkens on hover.

## Test plan

- [ ] `/onboarding` and `/onboarding/start` render the hero heading at the smaller scale, grouped with its subline under the FlamingoMark.
- [ ] Open the mobile nav drawer: Logout is a full-width, left-aligned muted row with a leading icon directly under Profile; hover darkens the label and tints the row.
- [ ] Desktop rail footer (expanded): Logout aligns under Profile; collapsing the rail still hides the Logout label.
- [ ] Click Logout → signs out and navigates to `/login` (behavior unchanged).
- [ ] `pnpm --filter frontend test` — onboarding-shell, logout-button, and nav suites pass (81/81 in the targeted run).
