### PR TITLE
fix(learn): move CEFR badge outside flip rotator to stop mirrored badge

### DIFF
--- a/frontend/src/app/learn/[cardgroupId]/learn-client.test.tsx
+++ b/frontend/src/app/learn/[cardgroupId]/learn-client.test.tsx
@@ -7,6 +7,7 @@ import { GraphQLError } from "graphql";
 import { type RefObject, useImperativeHandle, useRef } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { LEARN_PAGE_LIMIT } from "@/app/learn/queries";
+import { CefrBadge } from "@/components/learn/cefr-badge";
 import { CardContent, type SwipeCardData } from "@/components/learn/swipe-card";
 import type { SwipeCardStackHandle } from "@/components/learn/swipe-card-stack";
 import type { LearnDisplayMode } from "@/components/learn/types";
@@ -83,11 +84,18 @@ vi.mock("@/components/learn/swipe-card-stack", () => ({
         </div>
       );
     }
-    // Render CardContent (the real presentational layer) so badge-render
-    // integration tests can assert the full LearnClient → SwipeCardStack →
-    // CardContent → CefrBadge pipeline without the next/dynamic AnimatedCard
-    // chunk. CardContent is purely presentational and needs no providers.
-    return <CardContent card={activeCard} revealed={props.displayMode === "ALWAYS_VISIBLE"} />;
+    // Render the real presentational layer so badge-render integration tests can
+    // assert the full LearnClient → SwipeCardStack → card pipeline without the
+    // next/dynamic AnimatedCard chunk. The real AnimatedCard overlays the
+    // CefrBadge OUTSIDE the flip rotator (so the reveal flip cannot duplicate it);
+    // this mock mirrors that layout — CardContent for the content, CefrBadge
+    // alongside it.
+    return (
+      <>
+        <CardContent card={activeCard} revealed={props.displayMode === "ALWAYS_VISIBLE"} />
+        <CefrBadge level={activeCard.cefrLevel} />
+      </>
+    );
   },
 }));
 
@@ -625,12 +633,13 @@ describe("<LearnClient>", () => {
     });
   });
 
-  it("renders the CefrBadge for a card whose cefrLevel is non-null (end-to-end through CardContent)", async () => {
+  it("renders the CefrBadge for a card whose cefrLevel is non-null (end-to-end)", async () => {
     // End-to-end acceptance criterion: a card with a non-null cefrLevel must
     // show a CEFR badge on the learn page. The path exercised here is:
-    //   LearnClient (state) → SwipeCardStack mock → CardContent → CefrBadge
-    // The SwipeCardStack mock renders the real CardContent component so the
-    // badge pipeline is exercised without the next/dynamic AnimatedCard chunk.
+    //   LearnClient (state) → SwipeCardStack mock → card content + CefrBadge
+    // The mock mirrors the real AnimatedCard layout (badge overlaid outside the
+    // flip rotator) so the badge pipeline is exercised without the next/dynamic
+    // AnimatedCard chunk.
     //
     // `renderLearnClient`'s `initialCards` parameter is inferred from the
     // default `[CARD_1]`, which narrows `cefrLevel` to `null`. Inline the render

--- a/frontend/src/components/learn/animated-card.test.tsx
+++ b/frontend/src/components/learn/animated-card.test.tsx
@@ -539,3 +539,55 @@ describe("<AnimatedCard> — React StrictMode double-mount", () => {
     expect(onSwipe).toHaveBeenCalledWith(CARD, "right");
   });
 });
+
+describe("<AnimatedCard> — CEFR badge does not duplicate across the flipped faces", () => {
+  // Regression for the mirrored top-left badge bug. In the non-reduced-motion
+  // reveal flip the card renders a front face (revealed=false) AND a back face
+  // (revealed=true, rotateY 180). When the badge lived inside CardContent, BOTH
+  // faces carried a CefrBadge; after the half-turn flip the front face is turned
+  // away (rotateY -180 = horizontally mirrored) and its badge leaked through
+  // `[backface-visibility:hidden]` — an absolutely-positioned, z-indexed child
+  // forms its own stacking context that the ancestor's backface-visibility does
+  // not clip in WebKit — surfacing as a mirrored badge in the TOP-LEFT corner.
+  // The fix lifts the badge OUT of the flip rotator, so exactly one badge
+  // renders regardless of flip state.
+  it("renders exactly one CEFR badge when revealed (no mirrored backface duplicate)", () => {
+    render(
+      <AnimatedCard
+        card={{ ...CARD, cefrLevel: "C2" }}
+        isActive
+        onSwipe={vi.fn()}
+        {...revealedProps()}
+      />,
+    );
+
+    expect(screen.getAllByLabelText("CEFR level C2")).toHaveLength(1);
+  });
+
+  it("renders the badge once even when the card is front-only (not yet revealed)", () => {
+    render(
+      <AnimatedCard
+        card={{ ...CARD, cefrLevel: "C2" }}
+        isActive
+        revealed={false}
+        onReveal={vi.fn()}
+        onSwipe={vi.fn()}
+      />,
+    );
+
+    expect(screen.getAllByLabelText("CEFR level C2")).toHaveLength(1);
+  });
+
+  it("renders no CEFR badge when the card has no level (null)", () => {
+    render(
+      <AnimatedCard
+        card={{ ...CARD, cefrLevel: null }}
+        isActive
+        onSwipe={vi.fn()}
+        {...revealedProps()}
+      />,
+    );
+
+    expect(screen.queryByLabelText(/CEFR level/)).toBeNull();
+  });
+});

--- a/frontend/src/components/learn/animated-card.tsx
+++ b/frontend/src/components/learn/animated-card.tsx
@@ -4,6 +4,7 @@ import { animated, easings, useSpring, useSpringRef } from "@react-spring/web";
 import { useDrag } from "@use-gesture/react";
 import { type RefObject, useCallback, useEffect, useImperativeHandle, useRef } from "react";
 import { useReducedMotion } from "@/lib/use-reduced-motion";
+import { CefrBadge } from "./cefr-badge";
 import { evaluateSwipeGesture } from "./gesture-evaluation";
 import type { SwipeCardData } from "./swipe-card";
 import { CardContent } from "./swipe-card";
@@ -292,6 +293,14 @@ export function AnimatedCard({
           )}
         </animated.div>
       )}
+      {/*
+        CEFR badge is overlaid OUTSIDE the flip rotator (not inside each
+        CardContent face), so the half-turn reveal flip cannot duplicate it —
+        otherwise the turned-away front face's badge leaks through
+        `[backface-visibility:hidden]` as a mirrored top-left badge. Anchors to
+        this positioned `article` (filled via `inset-0`).
+      */}
+      <CefrBadge level={card.cefrLevel} />
     </animated.article>
   );
 }

--- a/frontend/src/components/learn/swipe-card.test.tsx
+++ b/frontend/src/components/learn/swipe-card.test.tsx
@@ -54,16 +54,12 @@ describe("<CardContent>", () => {
     expect(screen.queryByRole("button", { name: "Easy" })).not.toBeInTheDocument();
   });
 
-  it("renders the CEFR badge alongside the front/back when the card has a level", () => {
+  it("does not render the CEFR badge itself — AnimatedCard pins it outside the flip rotator", () => {
+    // The badge was lifted OUT of CardContent so the reveal flip cannot
+    // duplicate it across the front/back faces (see animated-card.tsx). The CEFR
+    // level still rides on the card data, but CardContent renders only the
+    // textual content; AnimatedCard overlays the badge once over the card.
     render(<CardContent card={{ ...CARD, cefrLevel: "B1" }} revealed={true} />);
-
-    expect(screen.getByLabelText("CEFR level B1")).toBeInTheDocument();
-    expect(screen.getByText("Hello")).toBeInTheDocument();
-    expect(screen.getByText("Hola")).toBeInTheDocument();
-  });
-
-  it("renders no CEFR badge when the level is null, but still shows the front/back", () => {
-    render(<CardContent card={{ ...CARD, cefrLevel: null }} revealed={true} />);
 
     expect(screen.queryByLabelText(/CEFR level/)).toBeNull();
     expect(screen.getByText("Hello")).toBeInTheDocument();
@@ -133,14 +129,13 @@ describe("<CardContent>", () => {
   it("reserves horizontal padding so a long front term cannot slide under the badge", () => {
     // jsdom has no real layout engine, so the overlap is guarded structurally:
     // the centered content block must carry the horizontal-padding utility that
-    // keeps a pathological single-token `front` clear of the right-pinned badge.
+    // keeps a pathological single-token `front` clear of the top-right CEFR
+    // badge (the badge itself is overlaid by AnimatedCard, not CardContent).
     const longFront = "Pneumonoultramicroscopicsilicovolcanoconiosis";
     render(<CardContent card={{ ...CARD, front: longFront, cefrLevel: "C1" }} revealed={true} />);
 
-    // Both the long front term and the badge render.
     const frontEl = screen.getByText(longFront);
     expect(frontEl).toBeInTheDocument();
-    expect(screen.getByLabelText("CEFR level C1")).toBeInTheDocument();
 
     // The centered content block is the parent of the front <p>; pin the
     // reserved horizontal-padding class on it.
@@ -148,9 +143,10 @@ describe("<CardContent>", () => {
     expect(contentBlock).not.toBeNull();
     expect(contentBlock).toHaveClass("px-10");
 
-    // The outer card container must carry `relative`: the absolutely-positioned
-    // badge anchors to it, so removing `relative` would dislocate the badge to
-    // the viewport. Navigate up from the content block to the outer card <div>.
+    // The outer card container must carry `relative`: the tap-hint dot anchors
+    // to it, and the AnimatedCard badge overlay assumes the card is positioned.
+    // Removing `relative` would dislocate both. Navigate up from the content
+    // block to the outer card <div>.
     const outerCard = contentBlock?.parentElement;
     expect(outerCard).not.toBeNull();
     expect(outerCard).toHaveClass("relative");

--- a/frontend/src/components/learn/swipe-card.tsx
+++ b/frontend/src/components/learn/swipe-card.tsx
@@ -4,7 +4,6 @@ import dynamic from "next/dynamic";
 import type { RefObject } from "react";
 import type { CefrLevel } from "@/generated/graphql";
 import type { AnimatedCardHandle } from "./animated-card";
-import { CefrBadge } from "./cefr-badge";
 import type { SwipeDirection } from "./types";
 import { useFitText } from "./use-fit-text";
 
@@ -88,18 +87,14 @@ export function CardContent({ card, revealed }: { card: SwipeCardData; revealed:
   );
 
   return (
-    // `relative` anchors the absolutely-positioned CefrBadge to this card.
-    // The TOP-RIGHT corner is reserved for the CEFR badge; future FSRS badges
-    // (#276 / #277) MUST claim a DIFFERENT corner so the two never collide.
+    // `relative` anchors the tap-hint dot below. The CEFR badge is NOT rendered
+    // here — AnimatedCard overlays it outside the flip rotator (see there). The
+    // top-right corner stays reserved for it; future FSRS badges (#276 / #277)
+    // must claim a different corner.
     <div className="relative flex h-full flex-col overflow-hidden rounded-lg border border-border bg-card p-6 shadow-lg">
       {/*
-        The badge is `position: absolute`, so it never participates in the
-        flow and CLS is zero by construction.
-      */}
-      <CefrBadge level={card.cefrLevel} />
-      {/*
         Reserve horizontal space (`px-10`) on the centered content block so a
-        long wrapped `front` term cannot slide UNDER the right-pinned badge on
+        long wrapped `front` term cannot slide UNDER the top-right CEFR badge on
         a narrow (~320px) viewport. Padding does not reflow the absolute badge,
         so CLS stays zero.
       */}


### PR DESCRIPTION
## Summary

On the Learn screen, a revealed card showed a duplicate CEFR badge — mirrored and pinned to the top-left corner — on top of the correct top-right badge. The reveal flip is a half-turn (`rotateY -180°`): while revealed, `AnimatedCard` renders a front face and a back face inside the flip rotator and each `CardContent` carried its own `CefrBadge`, so the turned-away front face's badge leaked through `[backface-visibility:hidden]` (a `z-index`ed absolutely-positioned child forms its own stacking context that WebKit does not clip) and surfaced mirrored in the top-left corner. The badge is now rendered once, outside the flip rotator, as a fixed overlay on the card — so it can never be duplicated across the two faces and never depends on backface-visibility behaviour.

This branch addresses no GitHub issue (reported in-session from a screenshot).

## Background / Motivation

- `AnimatedCard` (non-reduced-motion path) renders the reveal flip as a rotator holding two `CardContent` faces — a front face (`revealed={false}`) and, once revealed, a back face (`revealed={true}` at `rotateY(180deg)`). Each face rendered its own `CefrBadge` (`position: absolute; z-10`).
- After the half-turn flip the front face is turned away (`rotateY -180°`, horizontally mirrored). It should be hidden by `[backface-visibility:hidden]`, but `backface-visibility` does not inherit and a `z-index`ed absolutely-positioned child (the badge) forms its own stacking context that WebKit does not clip — so the front face's badge leaked through.
- The back face's opaque card background hides the overlapping centered text, but the corner badges land at opposite corners after mirroring (top-right ↔ top-left), so both stayed visible — the leaked front-face badge appeared mirrored in the top-left corner.
- The reduced-motion path renders a single `CardContent` (no flip, no rotator), so it never had the duplicate; only the animated flip path was affected.

## Changes

### CEFR badge lifted out of the flip rotator — `frontend/src/components/learn/animated-card.tsx`

- Render `CefrBadge` once, directly under the positioned `<article>` (outside the rotator), so it is a fixed overlay shared by both the reduced-motion and animated paths and can never be duplicated across the front/back faces. As a non-flipping overlay it always reads upright and in place.

### `CardContent` no longer renders the badge — `frontend/src/components/learn/swipe-card.tsx`

- Remove the `CefrBadge` import and its render from `CardContent`. The outer `relative` is kept (it still anchors the tap-hint dot and the AnimatedCard badge overlay), and the `px-10` reserve on the centered content block stays so a long front term cannot slide under the top-right badge.

### Tests

- `animated-card.test.tsx`: new regression suite — a revealed card renders exactly one CEFR badge (was 2), a front-only card renders one, and a null-level card renders none.
- `swipe-card.test.tsx`: assert `CardContent` itself renders no badge (the badge is now overlaid by `AnimatedCard`); keep the `px-10` / `relative` structural guards.
- `learn-client.test.tsx`: update the `SwipeCardStack` mock to mirror the real `AnimatedCard` layout (badge overlaid outside the rotator) so the end-to-end badge-pipeline test still holds.

## Verification

```bash
cd frontend
pnpm exec tsc --noEmit \
  && ./node_modules/.bin/biome check --error-on-warnings src/components/learn src/app/learn \
  && pnpm exec knip \
  && pnpm exec vitest run \
  && pnpm exec next build
```

Gates green in the worktree: `tsc --noEmit` (0), `biome check --error-on-warnings` (clean), `knip` (0), `vitest run` (1406/1406, incl. the new one-badge regression suite), `next build` (0, `/learn/[cardgroupId]` generated). The CJK / language-policy scan over the changed files is clean.

At runtime, confirm on a revealed Learn card: exactly one CEFR badge in the top-right corner and no mirrored badge in the top-left — in both `FLIP_TO_REVEAL` (after tapping to reveal) and `ALWAYS_VISIBLE` display modes.

## Test plan

- [ ] Open `/learn/{id}` in `FLIP_TO_REVEAL` mode and tap to reveal a card with a CEFR level: one badge in the top-right, none in the top-left.
- [ ] Switch to `ALWAYS_VISIBLE` mode: the revealed card still shows exactly one top-right badge.
- [ ] A card with no CEFR level shows no badge in either mode.
- [ ] `pnpm --filter frontend test` — 1406/1406 pass, including the new "CEFR badge does not duplicate across the flipped faces" suite.
- [ ] Regression direction: rendering the badge inside `CardContent` again surfaces the mirrored top-left badge on a revealed card (the new one-badge test fails).
