### PR TITLE
feat(notion-sync): match master_cards.front case-insensitively via citext

### DIFF
--- a/backend/internal/database/cards_position_roundtrip_test.go
+++ b/backend/internal/database/cards_position_roundtrip_test.go
@@ -44,15 +44,15 @@ func TestCardsPositionDownUpRoundtrip(t *testing.T) {
 		}
 	}()
 
-	// Step back past the six migrations newer than add_position_to_cards
+	// Step back past the seven migrations newer than add_position_to_cards
 	// (enable_rls_schema_migrations, pin_trigger_function_search_path,
 	// restrict_definer_function_exposure, add_master_tables,
 	// add_learn_display_mode_to_user_preferences,
-	// add_user_card_fsrs_card_id_index), then past add_position_to_cards
-	// itself. Seven steps are required because add_position_to_cards is no
-	// longer near the newest migration; bump this count when adding migrations
-	// after it.
-	if err := m.Steps(-7); err != nil {
+	// add_user_card_fsrs_card_id_index, master_cards_front_citext), then past
+	// add_position_to_cards itself. Eight steps are required because
+	// add_position_to_cards is no longer near the newest migration; bump this
+	// count when adding migrations after it.
+	if err := m.Steps(-8); err != nil {
 		t.Fatalf("migrate down to before add_position_to_cards: %v", err)
 	}
 

--- a/backend/internal/database/learn_display_mode_roundtrip_test.go
+++ b/backend/internal/database/learn_display_mode_roundtrip_test.go
@@ -54,12 +54,13 @@ func TestLearnDisplayModeDownUpRoundtrip(t *testing.T) {
 		}
 	}()
 
-	// Step back two migrations: first reverse add_user_card_fsrs_card_id_index
-	// (now the newest), then add_learn_display_mode_to_user_preferences (the
-	// target). The Steps(1) below re-applies add_learn_display_mode, and the
-	// t.Cleanup restores the rest. Bump this count when adding migrations after
+	// Step back three migrations newest-first: master_cards_front_citext (now
+	// the newest), then add_user_card_fsrs_card_id_index, then
+	// add_learn_display_mode_to_user_preferences (the target). The Steps(1)
+	// below re-applies add_learn_display_mode, and the t.Cleanup restores the
+	// rest. Bump this count when adding migrations after
 	// add_learn_display_mode_to_user_preferences.
-	if err := m.Steps(-2); err != nil {
+	if err := m.Steps(-3); err != nil {
 		t.Fatalf("migrate down to before add_learn_display_mode_to_user_preferences: %v", err)
 	}
 

--- a/backend/internal/database/migrations/20260616120000_master_cards_front_citext.down.sql
+++ b/backend/internal/database/migrations/20260616120000_master_cards_front_citext.down.sql
@@ -1,0 +1,13 @@
+BEGIN;
+
+-- Revert master_cards.front to case-sensitive text. The dependent unique index
+-- (uq_master_cards_cg_front) rebuilds with text's default case-sensitive
+-- operator class.
+--
+-- The citext extension is intentionally left installed: the up migration created
+-- it with IF NOT EXISTS and may not have been the entity that first enabled it,
+-- so dropping it here could remove a shared or pre-existing extension.
+ALTER TABLE public.master_cards
+    ALTER COLUMN front TYPE text USING front::text;
+
+COMMIT;

--- a/backend/internal/database/migrations/20260616120000_master_cards_front_citext.up.sql
+++ b/backend/internal/database/migrations/20260616120000_master_cards_front_citext.up.sql
@@ -1,0 +1,31 @@
+BEGIN;
+
+-- Make master_cards.front case-insensitive so the Notion dictionary sync treats
+-- "Drive" and "drive" as the same headword. citext compares case-insensitively
+-- while preserving the stored case for display.
+--
+-- PRECONDITION: master_cards must contain no case-duplicate fronts within a
+-- cardgroup, or the unique-index rebuild below fails. Resolve duplicates at the
+-- source first (merge the Notion entries, then run the sync so the
+-- case-sensitive prune removes the orphaned rows) and confirm this returns zero
+-- rows before applying:
+--   SELECT master_cardgroup_id, lower(front)
+--   FROM public.master_cards
+--   GROUP BY master_cardgroup_id, lower(front) HAVING count(*) > 1;
+
+-- citext is installed without an explicit schema for portability: the local test
+-- Postgres has no `extensions` schema, while `public` is on the search_path in
+-- both environments. (A Supabase "extension in public" advisory may follow;
+-- address it separately if the project relocates extensions to a dedicated
+-- schema.)
+CREATE EXTENSION IF NOT EXISTS citext;
+
+-- Changing the column type rebuilds the dependent unique index
+-- (uq_master_cards_cg_front) with citext's case-insensitive operator class, so
+-- the ON CONFLICT (master_cardgroup_id, front) upsert becomes case-insensitive
+-- with no index changes here. The front-length CHECK is re-validated and still
+-- holds (char_length / trim work on citext).
+ALTER TABLE public.master_cards
+    ALTER COLUMN front TYPE citext USING front::citext;
+
+COMMIT;

--- a/backend/internal/database/users_version_roundtrip_test.go
+++ b/backend/internal/database/users_version_roundtrip_test.go
@@ -38,18 +38,19 @@ func TestUsersVersionDownUpRoundtrip(t *testing.T) {
 		}
 	}()
 
-	// Step back through the 8 migrations listed newest-first until
+	// Step back through the 9 migrations listed newest-first until
 	// add_version_to_users (the target) is also rolled back:
-	//   1. add_user_card_fsrs_card_id_index
-	//   2. add_learn_display_mode_to_user_preferences
-	//   3. add_master_tables
-	//   4. restrict_definer_function_exposure
-	//   5. pin_trigger_function_search_path
-	//   6. enable_rls_schema_migrations
-	//   7. add_position_to_cards
-	//   8. add_version_to_users  ← target (rolls back the version column)
+	//   1. master_cards_front_citext
+	//   2. add_user_card_fsrs_card_id_index
+	//   3. add_learn_display_mode_to_user_preferences
+	//   4. add_master_tables
+	//   5. restrict_definer_function_exposure
+	//   6. pin_trigger_function_search_path
+	//   7. enable_rls_schema_migrations
+	//   8. add_position_to_cards
+	//   9. add_version_to_users  ← target (rolls back the version column)
 	// Bump the count here when adding migrations after add_version_to_users.
-	if err := m.Steps(-8); err != nil {
+	if err := m.Steps(-9); err != nil {
 		t.Fatalf("migrate down to before add_version_to_users: %v", err)
 	}
 

--- a/backend/internal/repository/master_card_test.go
+++ b/backend/internal/repository/master_card_test.go
@@ -182,6 +182,48 @@ func TestMasterCardRepository_UpsertManyTx_AllUpdates(t *testing.T) {
 	require.Equal(t, domain.CardText("new-b2"), byFront[domain.CardText("UpsertUpd-f2")].Back)
 }
 
+// TestMasterCardRepository_UpsertManyTx_CaseInsensitiveFront verifies the citext
+// front column: upserting a case-variant of an existing front ("drive" when
+// "Drive" exists) UPDATES the existing row rather than inserting a second one,
+// and the stored case is preserved (ON CONFLICT DO UPDATE does not touch front).
+func TestMasterCardRepository_UpsertManyTx_CaseInsensitiveFront(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	mcg := insertMCGForCardTest(t, ctx, "Upsert-CaseInsensitive-Group")
+	repo := repository.NewMasterCardRepository(testDB.GORM)
+
+	// Seed the capitalized variant.
+	err := testDB.GORM.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		_, txErr := repo.UpsertManyTx(ctx, tx, []*domain.MasterCard{
+			newMasterCard(mcg.ID, "Drive", "old-back", 0),
+		})
+		return txErr
+	})
+	require.NoError(t, err)
+
+	// Upsert the lowercase variant with a new back.
+	var result repository.UpsertManyTxResult
+	err = testDB.GORM.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var txErr error
+		result, txErr = repo.UpsertManyTx(ctx, tx, []*domain.MasterCard{
+			newMasterCard(mcg.ID, "drive", "new-back", 0),
+		})
+		return txErr
+	})
+	require.NoError(t, err)
+	// Matched case-insensitively: update, not a second insert.
+	require.Equal(t, int64(0), result.Inserted)
+	require.Equal(t, int64(1), result.Updated)
+
+	stored, err := repo.ListByMasterCardgroup(ctx, mcg.ID)
+	require.NoError(t, err)
+	require.Len(t, stored, 1)
+	// Back is overwritten; the stored front keeps its original case (citext
+	// preserves storage case, and ON CONFLICT DO UPDATE leaves front untouched).
+	require.Equal(t, domain.CardText("new-back"), stored[0].Back)
+	require.Equal(t, domain.CardText("Drive"), stored[0].Front)
+}
+
 // TestMasterCardRepository_UpsertManyTx_Mixed verifies that a batch containing
 // both new fronts and existing fronts reports the correct Inserted/Updated split.
 func TestMasterCardRepository_UpsertManyTx_Mixed(t *testing.T) {

--- a/backend/internal/usecase/notion_sync.go
+++ b/backend/internal/usecase/notion_sync.go
@@ -187,10 +187,11 @@ func (u *MasterNotionSyncUsecase) Sync(ctx context.Context, input SyncToMasterIn
 	// Derive the keep-set from the validated cards' (trimmed) fronts so the
 	// diff-prune step stays consistent with what was actually upserted: rows
 	// dropped by ParseCardText validation are absent here and so are pruned if
-	// a stale card with the same front exists.
+	// a stale card with the same front exists. Keyed by frontMatchKey so the
+	// prune is case-insensitive, matching the citext master_cards.front column.
 	notionFronts := make(map[string]struct{}, len(cards))
 	for _, card := range cards {
-		notionFronts[card.Front.String()] = struct{}{}
+		notionFronts[frontMatchKey(card.Front.String())] = struct{}{}
 	}
 
 	out := MasterNotionSyncOutput{
@@ -306,14 +307,29 @@ func parseNotionPages(ctx context.Context, logger *slog.Logger, pages []notion.P
 	return rows, errs, nil
 }
 
+// frontMatchKey is the case-insensitive key used to match Notion fronts against
+// each other (dedupe) and against existing master_cards rows (prune). It mirrors
+// the citext semantics of the master_cards.front column, whose unique index and
+// upsert conflict target compare case-insensitively. Fronts are ASCII by
+// construction — the textdic lexer restricts the front token to ASCII letters —
+// so strings.ToLower agrees with Postgres lower() with no locale ambiguity.
+func frontMatchKey(front string) string {
+	return strings.ToLower(front)
+}
+
 func dedupeParsedRows(rows []ParsedRow, errs []CardImportError) ([]ParsedRow, []CardImportError) {
+	// Keyed by frontMatchKey so case-variant fronts (e.g. "Drive" / "drive")
+	// collapse to one row. This is mandatory, not cosmetic: feeding two
+	// case-variant rows into the citext upsert would make a single multi-row
+	// INSERT hit the same ON CONFLICT target twice ("cannot affect row a second
+	// time"). The last occurrence wins, keeping its original case for storage.
 	lastIndex := make(map[string]int, len(rows))
 	for i, row := range rows {
-		lastIndex[row.Front] = i
+		lastIndex[frontMatchKey(row.Front)] = i
 	}
 	out := make([]ParsedRow, 0, len(rows))
 	for i, row := range rows {
-		if lastIndex[row.Front] != i {
+		if lastIndex[frontMatchKey(row.Front)] != i {
 			errs = append(errs, CardImportError{
 				Line:    row.Line,
 				Message: "duplicate front in Notion pages (later occurrence wins)",
@@ -384,9 +400,14 @@ func masterRowErrorField(err error) string {
 }
 
 func frontsToDelete(current []string, notionFronts map[string]struct{}) []string {
+	// Compare case-insensitively (frontMatchKey) so an existing row whose stored
+	// case differs from the current Notion line (e.g. DB "Drive" vs Notion
+	// "drive", reconciled by the citext upsert) is not mistaken for stale and
+	// pruned. The original stored front is passed to the delete so the
+	// WHERE front IN (...) targets the exact row.
 	deleteFronts := make([]string, 0, len(current))
 	for _, front := range current {
-		if _, ok := notionFronts[front]; !ok {
+		if _, ok := notionFronts[frontMatchKey(front)]; !ok {
 			deleteFronts = append(deleteFronts, front)
 		}
 	}

--- a/backend/internal/usecase/notion_sync_test.go
+++ b/backend/internal/usecase/notion_sync_test.go
@@ -262,6 +262,84 @@ func TestMasterNotionSyncUsecase_DuplicateFrontSamePageLastWins(t *testing.T) {
 	}
 }
 
+func TestMasterNotionSyncUsecase_CaseInsensitiveDedupe(t *testing.T) {
+	t.Parallel()
+
+	// Two case-variant fronts in one sync ("Drive" then "drive") must collapse to
+	// a single row. Without case-insensitive dedupe both rows would reach the
+	// citext upsert and a single multi-row INSERT would hit the same ON CONFLICT
+	// target twice ("cannot affect row a second time"). The later occurrence wins.
+	fetcher := &stubNotionFetcher{pages: []notion.Page{
+		{ID: "page-1", Text: "Drive " + uniqueBack(1) + "\ndrive " + uniqueBack(2) + "\n"},
+	}}
+	cardgroups := &mockMasterCardgroupRepo{cg: &domain.MasterCardgroup{ID: "mcg-target"}}
+	cards := &mockMasterCardRepo{upsertResult: repository.UpsertManyTxResult{Inserted: 1}}
+	tx, txCalls := dictTxRunner()
+	uc := NewMasterNotionSyncUsecaseWithTx(fetcher, cardgroups, cards, tx, newTestLogger())
+
+	out, err := uc.Sync(context.Background(), SyncToMasterInput{
+		PageIDs:             []string{"page-1"},
+		MasterCardgroupName: "English",
+	})
+	if err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+	if len(out.Parsed) != 1 {
+		t.Fatalf("Parsed len = %d, want 1 (case variants collapse)", len(out.Parsed))
+	}
+	if out.Parsed[0].Front != "drive" {
+		t.Fatalf("kept Front = %q, want %q (later occurrence)", out.Parsed[0].Front, "drive")
+	}
+	if len(cards.upserted) != 1 {
+		t.Fatalf("upserted len = %d, want 1", len(cards.upserted))
+	}
+	if string(cards.upserted[0].Front) != "drive" || string(cards.upserted[0].Back) != uniqueBack(2) {
+		t.Fatalf("upserted = (%q,%q), want (drive,%q)",
+			cards.upserted[0].Front, cards.upserted[0].Back, uniqueBack(2))
+	}
+	if len(out.ParseErrors) != 1 {
+		t.Fatalf("ParseErrors len = %d, want 1 duplicate warning", len(out.ParseErrors))
+	}
+	if out.ParseErrors[0].Front != "Drive" {
+		t.Fatalf("ParseErrors[0].Front = %q, want %q (the discarded variant's original case)",
+			out.ParseErrors[0].Front, "Drive")
+	}
+	if *txCalls != 1 {
+		t.Fatalf("txCalls = %d, want 1", *txCalls)
+	}
+}
+
+func TestMasterNotionSyncUsecase_CaseInsensitivePrune(t *testing.T) {
+	t.Parallel()
+
+	// The DB stored "Apple" (capitalized). Notion now has "apple" (lowercase),
+	// which the citext upsert reconciles onto the same row. The diff-prune must
+	// NOT treat "Apple" as stale just because its stored case differs from the
+	// Notion line. A genuinely absent front ("stale") is still pruned.
+	fetcher := &stubNotionFetcher{pages: []notion.Page{
+		{ID: "page-1", Text: "apple " + uniqueBack(1) + "\n"},
+	}}
+	cardgroups := &mockMasterCardgroupRepo{cg: &domain.MasterCardgroup{ID: "mcg-target"}}
+	cards := &mockMasterCardRepo{
+		existingFronts: []string{"Apple", "stale"},
+		upsertResult:   repository.UpsertManyTxResult{Updated: 1},
+	}
+	tx, _ := dictTxRunner()
+	uc := NewMasterNotionSyncUsecaseWithTx(fetcher, cardgroups, cards, tx, newTestLogger())
+
+	_, err := uc.Sync(context.Background(), SyncToMasterInput{
+		PageIDs:             []string{"page-1"},
+		MasterCardgroupName: "English",
+	})
+	if err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+	if len(cards.deletedFronts) != 1 || cards.deletedFronts[0] != "stale" {
+		t.Fatalf("deleted fronts = %v, want [stale] (Apple matched case-insensitively)",
+			cards.deletedFronts)
+	}
+}
+
 func TestMasterNotionSyncUsecase_InputValidation(t *testing.T) {
 	t.Parallel()
 
@@ -803,11 +881,11 @@ func TestMasterCardsFromParsedRows_SkipsInvalidRowsWithWarn(t *testing.T) {
 	uc := NewMasterNotionSyncUsecaseWithTx(nil, nil, nil, nil, logger)
 
 	rows := []ParsedRow{
-		{Front: "apple", Back: "fruit", SourcePageID: "page-1", Line: 1},     // valid
-		{Front: "   ", Back: "fruit", SourcePageID: "page-1", Line: 2},       // empty front -> skip
-		{Front: "carrot", Back: "", SourcePageID: "page-1", Line: 3},         // empty back -> skip
-		{Front: strings.Repeat("x", 501), Back: "ok", Line: 4},              // oversized front -> skip
-		{Front: "banana", Back: "fruit", SourcePageID: "page-1", Line: 5},    // valid
+		{Front: "apple", Back: "fruit", SourcePageID: "page-1", Line: 1},  // valid
+		{Front: "   ", Back: "fruit", SourcePageID: "page-1", Line: 2},    // empty front -> skip
+		{Front: "carrot", Back: "", SourcePageID: "page-1", Line: 3},      // empty back -> skip
+		{Front: strings.Repeat("x", 501), Back: "ok", Line: 4},            // oversized front -> skip
+		{Front: "banana", Back: "fruit", SourcePageID: "page-1", Line: 5}, // valid
 	}
 
 	const masterCardgroupID = "mcg-skip"


### PR DESCRIPTION
## Summary

The Notion dictionary sync matched `master_cards.front` case-sensitively, so an editor's `Drive` and `drive` became two distinct catalog rows that the upsert never reconciled. This switches `master_cards.front` to `citext` and folds case at the three usecase match points, so case-variant headwords collapse to one row on sync while the stored display case is preserved. Scope is intentionally limited to `master_cards`: user-owned `cards` stay case-sensitive (case can be meaningful in a learner's own deck).

Closes #504

## Background / Motivation

- `master_cards.front` was `text`, and the `uq_master_cards_cg_front` unique index plus the `ON CONFLICT (master_cardgroup_id, front)` upsert compared case-sensitively, so `Drive` / `drive` coexisted instead of merging.
- The Go sync mirrored that: `dedupeParsedRows`, the `notionFronts` keep-set, and `frontsToDelete` all keyed on the raw front string, so case variants were neither deduped within a sync nor matched against existing rows during the prune.
- Making only the DB column `citext` without folding the Go side would be unsafe: two case-variant rows in one batch would hit the same `ON CONFLICT` target in a single multi-row `INSERT` (`ON CONFLICT DO UPDATE command cannot affect row a second time`), and the prune would delete a row the upsert had just reconciled.

## Changes

### citext migration — `20260616120000_master_cards_front_citext.{up,down}.sql`

- `up`: `CREATE EXTENSION IF NOT EXISTS citext` + `ALTER COLUMN front TYPE citext USING front::citext`. Changing the column type rebuilds `uq_master_cards_cg_front` with citext's case-insensitive operator class, so the upsert conflict target becomes case-insensitive with no index DDL here; the `front` length CHECK still holds.
- `down`: reverts the column to `text`; the citext extension is intentionally left installed (the up created it with `IF NOT EXISTS` and may not have been what first enabled it).
- The extension is installed without an explicit schema for portability (the local test Postgres has no `extensions` schema; `public` is on the search_path in both environments).
- **Rollout precondition:** the unique-index rebuild fails if any case-duplicate fronts exist within a cardgroup. Resolve duplicates at the source first (merge the Notion entries, then run the sync so the current case-sensitive prune removes the orphaned rows) and confirm `SELECT master_cardgroup_id, lower(front) ... GROUP BY ... HAVING count(*) > 1` returns zero rows before applying.

### Case-insensitive matching in the sync — `internal/usecase/notion_sync.go`

- New `frontMatchKey` (`strings.ToLower`) helper, documented as mirroring the citext column semantics (fronts are ASCII by construction, so `ToLower` agrees with Postgres `lower()`).
- `dedupeParsedRows` keys on `frontMatchKey`, so case-variant fronts collapse to one row (later occurrence wins, original case kept for storage) before reaching the upsert.
- The `notionFronts` keep-set and `frontsToDelete` compare on `frontMatchKey`, so an existing row whose stored case differs from the current Notion line is not mistaken for stale; the original stored front is still passed to the delete.

### Tests

- `notion_sync_test.go`: `TestMasterNotionSyncUsecase_CaseInsensitiveDedupe` (two case-variant fronts in one sync collapse to one row + a duplicate warning) and `TestMasterNotionSyncUsecase_CaseInsensitivePrune` (a DB `Apple` is not pruned when Notion has `apple`, while a genuinely absent front is).
- `master_card_test.go`: `TestMasterCardRepository_UpsertManyTx_CaseInsensitiveFront` — upserting `drive` when `Drive` exists reports `Updated == 1` (not a second insert) and preserves the stored case, validated against a real citext column via testcontainers.

## Verification

```bash
cd backend
go vet ./internal/usecase/... \
  && go test ./internal/usecase/ \
  && go test ./internal/repository/ -run 'TestMasterCardRepository_UpsertManyTx' \
  && go test ./internal/database/ -run 'TestMigrateDownUpRoundtrip'
```

The repository and database tests provision a real Postgres via testcontainers, so they exercise the citext migration end to end (case-insensitive upsert + down/up roundtrip).

## Test plan

- [x] `go vet` + full `internal/usecase` package suite (592 tests) green
- [x] `TestMasterCardRepository_UpsertManyTx_CaseInsensitiveFront` proves `Drive` + `drive` → one updated row, stored case preserved
- [x] `TestMigrateDownUpRoundtrip` proves the citext up/down migration applies and reverts cleanly
- [ ] Operator: merge the 15 production case-pairs in Notion and re-run the sync so zero case-duplicates remain before deploying the migration
