### PR TITLE
fix(landing): pin CDN deps + add SRI to fix Babel 8 blank page

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -7,10 +7,27 @@
   <meta name="description" content="スワイプで続ける、日本人向けの英単語学習フラッシュカード。単語を追加し、カードをめくり、苦手な英単語を効率よく復習できます。" />
   <link rel="icon" href="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxMDI0IiBoZWlnaHQ9IjEwMjQiIHZpZXdCb3g9IjAgMCAxMDI0IDEwMjQiPgogIDxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDI0IiBoZWlnaHQ9IjEwMjQiIHJ4PSIxNTMiIHJ5PSIxNTMiIGZpbGw9IiNGRjZGNzkiLz4KICA8cGF0aCBkPSJNMCwwIEw5NSwwIEwxMDMsNiBMMTIyLDI1IEwxMjIsMjcgTDEyNCwyNyBMMTMxLDM1IEwxMzgsNDEgTDE0NSw0OSBMMTU2LDYwIEwxNTgsNjQgTDE1OCwxNDAgTDE1NCwxNDYgTDExOCwxODIgTDExMSwxOTAgTDMzLDI2OCBMMzEsMjY4IEwzMCwyNzEgTDI5LDMwMyBMMjc3LDMwMiBMMjg4LDI4NiBMMzAyLDI2NyBMMzA5LDI1NyBMMzIzLDIzOCBMMzM1LDIyMSBMMzQ4LDIwMyBMMzYyLDE4NCBMMzc0LDE2NyBMMzg3LDE0OSBMMzkzLDE0MSBMMzk4LDEzOCBMNDA1LDEzOCBMNDExLDE0MiBMNDEzLDE0NiBMNDEzLDE1MyBMNDA3LDE2MyBMMzk3LDE3NiBMMzg4LDE4OSBMMzc1LDIwNyBMMzYzLDIyNCBMMzQ5LDI0MyBMMzM2LDI2MSBMMzIyLDI4MSBMMzA4LDMwMCBMMzA3LDMwMiBMNDA2LDMwMyBMNDEyLDMwNyBMNDE0LDMxMSBMNDE0LDMxOSBMNDA3LDMyNyBMMzkwLDM0NCBMMzgyLDM1MSBMMzY1LDM2OCBMMzU3LDM3NSBMMzQyLDM5MCBMMzM0LDM5NyBMMzEzLDQxOCBMMzA1LDQyNSBMMjkyLDQzOCBMMjkwLDQzOCBMMjkwLDQ0MCBMMjgyLDQ0NyBMMjY1LDQ2NCBMMjU3LDQ3MSBMMjQwLDQ4OCBMMjMyLDQ5NSBMMjE0LDUxMyBMMjA2LDUyMCBMMTkzLDUzMyBMMTkyLDcxMyBMMjgzLDcxMyBMMjg5LDcxOCBMMjkwLDcyMCBMMjkwLDczMCBMMjg1LDczNiBMMjgyLDczNyBMNzgsNzM3IEw3Miw3MzMgTDcwLDczMCBMNzAsNzIwIEw3NSw3MTQgTDc4LDcxMyBMMTY4LDcxMyBMMTY3LDUzMyBMMTUxLDUxNyBMMTQzLDUxMCBMMTIwLDQ4NyBMMTEyLDQ4MCBMOTksNDY3IEw5MSw0NjAgTDcxLDQ0MCBMNjMsNDMzIEw0Nyw0MTcgTDQyLDQxMyBMMzcsNDA4IEwxOCwzODkgTDEwLDM4MiBMLTcsMzY1IEwtMTUsMzU4IEwtMjcsMzQ2IEwtMzUsMzM5IEwtNTMsMzIxIEwtNTQsMzE5IEwtNTQsMjQwIEwtNTEsMjM1IEwtMzEsMjE1IEwtMjYsMjEwIEwtMTYsMjAwIEwtOSwxOTIgTC00LDE4NyBMLTEsMTg2IEwtMSwxODQgTDEsMTg0IEwzLDE4MCBMOSwxNzUgTDE2LDE2NyBMMjMsMTYwIEwyOCwxNTUgTDY0LDExOSBMNjUsOTQgTDExLDk1IEwzLDEwMiBMLTQsMTEwIEwtMTIsMTE3IEwtMTQsMTIwIEwtMTUsMTY3IEwtMTgsMTcyIEwtMjEsMTc1IEwtMzAsMTc2IEwtMzcsMTcyIEwtMzksMTY4IEwtNDMsMTY2IEwtNzYsMTMzIEwtNzgsMTI5IEwtNzgsNzcgTC03NCw3MSBMLTY5LDY2IEwtNjcsNjYgTC02Nyw2NCBMLTY1LDY0IEwtNjUsNjIgTC02Myw2MiBMLTYxLDU4IEwtNTEsNDggTC00Myw0MSBMLTM2LDM0IEwtMjksMjYgTC0xNCwxMiBMLTMsMSBaICIgZmlsbD0iI0ZERkFGNiIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMzQ0LDE1NSkiLz4KICA8cGF0aCBkPSJNMCwwIEwyNjgsMCBMMjY2LDUgTDI1NCwyMSBMMjQyLDM4IEwyMjksNTYgTDIxNiw3NCBMMjAzLDkyIEwxOTAsMTEwIEwxODAsMTI0IEwxNzksMTMyIEwxODIsMTM4IEwxODYsMTQwIEwxOTQsMTQwIEwxOTksMTM3IEwyMTAsMTIxIEwyMjMsMTAzIEwyMzYsODUgTDI0OSw2NyBMMjYzLDQ4IEwyNzcsMjggTDI5MSw5IEwyOTgsMCBMMzgxLDAgTDM3NSw3IEwzNjMsMTkgTDM1NSwyNiBMMzM4LDQzIEwzMzAsNTAgTDMxNCw2NiBMMzA2LDczIEwyODksOTAgTDI4MSw5NyBMMjYzLDExNSBMMjYxLDExNSBMMjU5LDExOSBMMjUxLDEyNiBMMjQwLDEzNyBMMjM0LDE0MiBMMjI5LDE0NyBMMjExLDE2NSBMMjAzLDE3MiBMMTkxLDE4NCBMMTg3LDE4MiBMMTcxLDE2NiBMMTYzLDE1OSBMMTQyLDEzOCBMMTM0LDEzMSBMMTE3LDExNCBMMTA5LDEwNyBMOTAsODggTDgyLDgxIEw2NSw2NCBMNTcsNTcgTDQxLDQxIEwzMywzNCBMMTYsMTcgTDgsMTAgTDAsMiBaICIgZmlsbD0iI0ZGNkY3OSIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMzM0LDQ4MikiLz4KICA8cGF0aCBkPSJNMCwwIEw4MCwwIEw5MCwxMCBMOTUsMTUgTDExMiwzMiBMMTE5LDQwIEwxMjgsNDkgTDEyOCwxMDkgTDEwNywxMzAgTDEwMiwxMzUgTDkxLDE0NyBMODUsMTUyIEw4NCwxNTQgTDgyLDE1NCBMODIsMTU2IEw3NywxNjAgTDcyLDE2NiBMNzAsMTY2IEw2OCwxNzAgTDU2LDE4MiBMNTQsMTgyIEw1NCwxODQgTDUyLDE4NCBMNTIsMTg2IEw1MCwxODYgTDUwLDE4OCBMNDUsMTkyIEwzOCwyMDAgTDI2LDIxMiBMMTksMjE4IEwxMiwyMjYgTDcsMjMwIEw2LDIzMiBMNCwyMzIgTDIsMjM2IEwwLDIzOSBMLTEsMjgwIEwtMzgsMjgwIEwtMzgsMjI1IEwtMTIsMTk5IEwtNywxOTQgTDQsMTgzIEw5LDE3OCBMMjAsMTY3IEwyNywxNTkgTDc5LDEwNyBMODAsMTA0IEw4MCw1NiBMNzgsNTEgTDczLDQ5IEwtNSw0OSBMLTEyLDU0IEwtMTgsNjEgTC0yNiw2OCBMLTMxLDczIEwtMzgsODEgTC00Myw4NiBMLTQ0LDg4IEwtNDUsMTEzIEwtNTIsMTA3IEwtNjAsMTAwIEwtNjIsOTcgTC02Miw2MiBaICIgZmlsbD0iI0ZGNkY3OSIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMzUxLDE3OCkiLz4KPC9zdmc+" type="image/svg+xml" />
 
-  <script src="https://cdn.tailwindcss.com"></script>
-  <script src="https://unpkg.com/react@18/umd/react.development.js"></script>
-  <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
-  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+  <!--
+    CDN dependencies are pinned to immutable releases. An unpinned @latest URL
+    silently follows a breaking major bump: @babel/standalone@latest moving to
+    Babel 8 (preset-react default runtime "classic" -> "automatic") injected an
+    `import { jsx } from "react/jsx-runtime"` into the in-browser-transpiled
+    inline script, which @babel/standalone re-injects as a classic (non-module)
+    <script>, throwing "Cannot use import statement outside a module" and leaving
+    the page blank. Pinning to 7.29.7 keeps the classic runtime. Subresource
+    Integrity guards each pinned file against CDN tampering; the Tailwind Play CDN
+    sends no CORS header, so it gets a version pin only (SRI needs crossorigin).
+  -->
+  <script src="https://cdn.tailwindcss.com/3.4.17"></script>
+  <script src="https://unpkg.com/react@18.3.1/umd/react.development.js"
+          integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L"
+          crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js"
+          integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm"
+          crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/@babel/standalone@7.29.7/babel.min.js"
+          integrity="sha384-ezQ6HS3FLspd9te19o2McUV6FAK091+GG7KO54f/R8DKgCDi7fULhapNrd5LY+vG"
+          crossorigin="anonymous"></script>
 
   <script>
     tailwind.config = {


### PR DESCRIPTION
## Summary

The GitHub Pages landing page at `https://yasuflatland-lf.github.io/flamingo-armond/` rendered a blank page while the deploy itself was healthy (HTTP 200, full HTML served). The cause was an unpinned `@babel/standalone` CDN URL silently following Babel's breaking major bump to 8.x; this pins every CDN dependency to an immutable release and adds Subresource Integrity where the CDN supports CORS, so the landing page renders again and can't be re-broken by a future `@latest` rollover.

This branch addresses no GitHub issue (investigated in-session).

## Background / Motivation

- `site/index.html` is a client-side React app that transpiles its single inline JSX block **in the browser** via `@babel/standalone`, which was loaded from an **unpinned** `https://unpkg.com/@babel/standalone/babel.min.js`. `@latest` now resolves to **8.0.0**; React (`@18`) and Tailwind were the only pinned deps.
- **Babel 8 changed `@babel/preset-react`'s default JSX runtime from `classic` to `automatic`.** Verified against both bundles: with presets `["react","env"]`, 7.29.7 emits `React.createElement(...)` while 8.0.0 emits `import { jsx as _jsx } from "react/jsx-runtime"` at the top of the output. The default preset set (`["react","env"]`) is identical in `transformScriptTags.ts` for v7 and v8 — only the runtime default differs.
- `@babel/standalone` re-injects each transpiled inline script as a **classic (non-module) `<script>`**, so the injected `import` throws `Uncaught SyntaxError: Cannot use import statement outside a module`. The script aborts, React never mounts, and `#root` stays empty — a blank page. No repo change triggered this; the unpinned CDN did.

## Changes

### Pin every CDN dependency to an immutable release (`site/index.html`)

- `@babel/standalone` → `@7.29.7` — keeps the classic JSX runtime, which emits no `import` and runs as a classic `<script>`.
- `react` / `react-dom` → exact `@18.3.1` UMD builds (previously the floating `@18`).
- Tailwind Play CDN → pinned to `/3.4.17` (previously the bare `cdn.tailwindcss.com`).

### Subresource Integrity on CORS-capable CDNs (`site/index.html`)

- `react`, `react-dom`, and `@babel/standalone` gain `integrity="sha384-…"` + `crossorigin="anonymous"` (unpkg sends `access-control-allow-origin: *`, so SRI works).
- Tailwind gets a version pin **only**: the Tailwind Play CDN sends no `access-control-allow-origin` header, so adding `crossorigin`/`integrity` would block the load. An inline comment records this asymmetry.

### Inline documentation

- A comment above the script tags records the failure mode (Babel 8 automatic-runtime → injected `import` → non-module `<script>` SyntaxError → blank page) so a future reader understands why the versions are pinned.

## Verification

Reproduced and confirmed fixed with a headless Chromium harness (collecting `pageerror`, console messages, and `#root` content):

| | `#root` innerHTML | Uncaught error |
| --- | --- | --- |
| **Before** — live URL | `0` (blank) | `SyntaxError: Cannot use import statement outside a module` |
| **After** — patched `site/` served locally | `22718` (full landing renders) | none |

All three SRI hashes validated at load time — a wrong hash would block the script and re-blank the page, so a rendered page is itself proof the hashes match.

## Test plan

- [ ] After merge, the `landing` workflow republishes `site/` to gh-pages on push to `main` (paths `site/**`).
- [ ] Open `https://yasuflatland-lf.github.io/flamingo-armond/` and confirm the landing page renders (not blank) with no console errors.
- [ ] Confirm `https://yasuflatland-lf.github.io/flamingo-armond/er-chart/` still works (untouched by this change).

## Follow-ups (not in this PR)

- Switch the React UMD scripts to the `*.production.min.js` builds (smaller, faster LCP) — a behavior-neutral swap deferred to keep this change minimal.
- Longer term: precompile the landing JSX at build time instead of relying on in-browser `@babel/standalone` (Babel itself warns against the in-browser transformer for production).
