### PR TITLE
feat(frontend): add icons to card-add dropdown menu items

### DIFF
--- a/frontend/src/components/cardgroups/cardgroup-cards-section.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-cards-section.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ChevronDown, Play } from "lucide-react";
+import { ChevronDown, Import, Play, Plus } from "lucide-react";
 import Link from "next/link";
 import { useTranslations } from "next-intl";
 import type { ReactNode } from "react";
@@ -93,11 +93,16 @@ export function CardgroupCardsSection({
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
-              <DropdownMenuItem onSelect={onAddCard}>{t("addACard")}</DropdownMenuItem>
+              <DropdownMenuItem onSelect={onAddCard} className="gap-2">
+                <Plus aria-hidden="true" className="h-4 w-4" />
+                {t("addACard")}
+              </DropdownMenuItem>
               <DropdownMenuItem
                 onSelect={onBatchImport}
                 data-testid="cardgroup-batch-import-menuitem"
+                className="gap-2"
               >
+                <Import aria-hidden="true" className="h-4 w-4" />
                 {t("batchImport")}
               </DropdownMenuItem>
             </DropdownMenuContent>


### PR DESCRIPTION
## Summary

The desktop "Add card" split-button dropdown (on the cardgroup cards screen) listed its two actions — "Add a card" and "Batch import" — as plain text, while the mobile cardgroup options ("...") menu already renders each action with a leading lucide icon. This adds matching icons to the two dropdown items so the desktop menu speaks the same visual language as the mobile one.

This branch addresses no GitHub issue (requested in-session).

## Background / Motivation

- `CardgroupHeader`'s mobile options menu (`Pencil` / `Import` / `Trash2`) already pairs every action with an icon, but the desktop split-button dropdown in `CardgroupCardsSection` rendered text-only items — an inconsistent treatment of the same actions across the two surfaces.
- "Batch import" appears in both menus; reusing the same `Import` icon the mobile menu already uses keeps one action looking identical wherever it surfaces.

## Changes

### Icons on the desktop "Add card" dropdown items

- **`src/components/cardgroups/cardgroup-cards-section.tsx`** — adds a leading icon to each `DropdownMenuItem` in the split-button menu, mirroring the `className="gap-2"` + `h-4 w-4` icon pattern already used in `cardgroup-header.tsx`:
  - "Add a card" → `Plus`
  - "Batch import" → `Import` (the same icon the mobile options menu uses for this action)
- Icons are decorative (`aria-hidden="true"`, matching the existing `Play` / `ChevronDown` icons in the same file), so the menu items' accessible names are unchanged and the existing tests that query by accessible name stay valid. No new i18n keys; no behavior change.

## Verification

```bash
cd frontend
pnpm exec tsc --noEmit \
  && ./node_modules/.bin/biome check --error-on-warnings src/components/cardgroups/cardgroup-cards-section.tsx \
  && pnpm exec vitest run src/components/cardgroups/cardgroup-cards-section.test.tsx
```

All green locally: `cardgroup-cards-section.test.tsx` 10/10 and the related `cardgroup-management-client` / `cardgroup-edit` suites 10/10, typecheck and lint clean.

Runtime check: open a cardgroup's cards screen on a desktop-width viewport, click the chevron next to "Add card", and confirm the dropdown items render with a leading `+` (Add a card) and import-tray (Batch import) icon — matching the icons in the mobile "..." options menu.

## Test plan

- [ ] On a desktop-width viewport, open the "Add card" split-button dropdown and confirm "Add a card" shows a `Plus` icon and "Batch import" shows the `Import` icon.
- [ ] Confirm the "Batch import" icon matches the one in the mobile cardgroup "..." options menu.
- [ ] Click each dropdown item and confirm the existing actions still fire (add-card sheet opens; batch-import flow starts).
