### PR TITLE
chore(site): add Biome and Knip, scope site/ deps in Renovate

### DIFF
--- a/.github/workflows/landing.yml
+++ b/.github/workflows/landing.yml
@@ -11,9 +11,20 @@ name: landing
 # skip building the gh-pages branch) and site/public/.nojekyll. clean-exclude
 # below preserves er-chart/ (owned by er-chart.yml, not by this workflow) when
 # this workflow cleans the gh-pages root.
+#
+# The `lint` job runs Biome + Knip over site/ on every PR (and before publish),
+# mirroring the frontend CI gate. The `publish` job only runs on a push to main
+# (or manual dispatch) and waits on `lint`. Node + pnpm are provisioned by
+# jdx/mise-action from the repo-root .tool-versions, the same as the other JS
+# workflows (frontend, e2e, mutation).
 
 on:
   push:
+    branches: [main]
+    paths:
+      - 'site/**'
+      - '.github/workflows/landing.yml'
+  pull_request:
     branches: [main]
     paths:
       - 'site/**'
@@ -24,24 +35,67 @@ concurrency:
   group: landing-${{ github.ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: write          # github-pages-deploy-action needs push access to the gh-pages branch
-
 jobs:
-  publish:
+  lint:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
 
-      # Node version mirrors the repo-root .tool-versions; pnpm is provisioned by
-      # corepack from site/package.json's "packageManager" field. This avoids the
-      # full mise toolchain (Rust/mprocs) that the landing build does not need.
-      - uses: actions/setup-node@v4
-        with:
-          node-version-file: .tool-versions
+      - name: Set up mise (Node + pnpm from .tool-versions)
+        uses: jdx/mise-action@v4
 
-      - name: Enable corepack (pnpm)
-        run: corepack enable
+      - name: Resolve pnpm store path
+        id: pnpm-store
+        working-directory: site
+        run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache pnpm store
+        uses: actions/cache@v5
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: ${{ runner.os }}-pnpm-site-${{ hashFiles('site/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-site-
+
+      - name: Install dependencies
+        working-directory: site
+        run: pnpm install --frozen-lockfile
+
+      - name: Biome (lint + format check)
+        working-directory: site
+        run: pnpm lint
+
+      - name: Knip (unused files / deps / exports)
+        working-directory: site
+        run: pnpm knip
+
+  publish:
+    needs: lint
+    # Build + deploy only on a push to main or a manual dispatch; PRs run lint only.
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write          # github-pages-deploy-action needs push access to the gh-pages branch
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up mise (Node + pnpm from .tool-versions)
+        uses: jdx/mise-action@v4
+
+      - name: Resolve pnpm store path
+        id: pnpm-store
+        working-directory: site
+        run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache pnpm store
+        uses: actions/cache@v5
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: ${{ runner.os }}-pnpm-site-${{ hashFiles('site/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-site-
 
       - name: Install dependencies
         working-directory: site

--- a/renovate.json
+++ b/renovate.json
@@ -31,6 +31,15 @@
       "rangeStrategy": "replace"
     },
     {
+      "description": "Landing page (site/). It is its own pnpm workspace with its own lockfile and deploy cadence (landing.yml publishes site/dist to gh-pages), so it gets its own group/scope/labels instead of riding the catch-all 'frontend dependencies' rule above. Renovate has no dedicated pnpm manager: the npm manager handles pnpm, pnpm-lock.yaml and pnpm-workspace.yaml, so matchManagers stays 'npm' and matchFileNames scopes the rule to site/. Placed before the pnpm-toolchain rule below so site/package.json's 'packageManager' pnpm pin still groups into 'pnpm toolchain'. rangeStrategy 'replace' mirrors the frontend rule.",
+      "matchManagers": ["npm"],
+      "matchFileNames": ["site/**"],
+      "groupName": "landing dependencies",
+      "addLabels": ["landing", "dependencies"],
+      "semanticCommitScope": "site",
+      "rangeStrategy": "replace"
+    },
+    {
       "description": "GitHub Actions",
       "matchManagers": ["github-actions"],
       "groupName": "github actions",

--- a/site/biome.json
+++ b/site/biome.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
+  "files": {
+    "includes": ["**", "!dist", "!node_modules"]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "complexity": {
+        "noImportantStyles": "off"
+      },
+      "correctness": {
+        "useExhaustiveDependencies": "warn"
+      },
+      "style": {
+        "useNodejsImportProtocol": "error",
+        "noDescendingSpecificity": "off"
+      },
+      "suspicious": {
+        "noUnknownAtRules": "off"
+      }
+    }
+  },
+  "css": {
+    "parser": {
+      "cssModules": false,
+      "tailwindDirectives": true
+    },
+    "linter": {
+      "enabled": true
+    }
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "double",
+      "trailingCommas": "all",
+      "semicolons": "always"
+    }
+  },
+  "assist": {
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
+  }
+}

--- a/site/knip.json
+++ b/site/knip.json
@@ -1,0 +1,3 @@
+{
+  "$schema": "https://unpkg.com/knip@6/schema.json"
+}

--- a/site/package.json
+++ b/site/package.json
@@ -8,15 +8,21 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "lint": "biome check --error-on-warnings .",
+    "lint:fix": "biome check --write .",
+    "format": "biome format --write .",
+    "knip": "knip"
   },
   "dependencies": {
     "react": "18.3.1",
     "react-dom": "18.3.1"
   },
   "devDependencies": {
+    "@biomejs/biome": "2.4.16",
     "@vitejs/plugin-react": "^4.3.4",
     "autoprefixer": "^10.4.20",
+    "knip": "^6.14.0",
     "postcss": "^8.4.49",
     "tailwindcss": "3.4.17",
     "vite": "^6.0.7"

--- a/site/pnpm-lock.yaml
+++ b/site/pnpm-lock.yaml
@@ -15,12 +15,18 @@ importers:
         specifier: 18.3.1
         version: 18.3.1(react@18.3.1)
     devDependencies:
+      '@biomejs/biome':
+        specifier: 2.4.16
+        version: 2.4.16
       '@vitejs/plugin-react':
         specifier: ^4.3.4
         version: 4.7.0(vite@6.4.3(jiti@1.21.7)(yaml@2.9.0))
       autoprefixer:
         specifier: ^10.4.20
         version: 10.5.0(postcss@8.5.15)
+      knip:
+        specifier: ^6.14.0
+        version: 6.17.1
       postcss:
         specifier: ^8.4.49
         version: 8.5.15
@@ -119,6 +125,72 @@ packages:
   '@babel/types@7.29.7':
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
+
+  '@biomejs/biome@2.4.16':
+    resolution: {integrity: sha512-x9ajFh1zChVybCiM3TN6OD4phAqLgtPZjFrZF+aTMYCPjwBO+k529TX7PPsAqtGNLeV4UgzwQnowEgS7bGmzcA==}
+    engines: {node: '>=14.21.3'}
+    hasBin: true
+
+  '@biomejs/cli-darwin-arm64@2.4.16':
+    resolution: {integrity: sha512-wxPvu4XOA85YJk9ixSWUmq/QBHbid85BISbOAqqBM/5xQpPk9ayjk5375tOlSC0BeCwNSbPFafQBm+vBumXq0A==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@biomejs/cli-darwin-x64@2.4.16':
+    resolution: {integrity: sha512-xFCqGPwYusQJp4N4NJLi1XJiZqjwFdjhT+KqtNy+Ug3qgfczqnTa6MSDvxJF6TkuDLoYJItMapz6tAf7kCekFw==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@biomejs/cli-linux-arm64-musl@2.4.16':
+    resolution: {integrity: sha512-oYxnW0ARfJkr72ezzF2OR8N/rtkgLUQeYtF8cFhVswbknHxtTcmzSsanVJP8yQKnGpGpc2ck6c5zLvHahL6Cbg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@biomejs/cli-linux-arm64@2.4.16':
+    resolution: {integrity: sha512-2kFb4//jxfZaP6D+Rj5VkHkxgyD9EoRAVBEQb8PKRv+s4NO2zYNJKXFaJmK1CmhufJOWEfpHKaRbOja7qjmdhQ==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@biomejs/cli-linux-x64-musl@2.4.16':
+    resolution: {integrity: sha512-iHDS+MCM65DPqWGu+ECC3uoALyj2H7F4nVUPxIPjz/PIl94EUu+EDfGZDzFP+NY1EOPVt9NQvwFqq7HdMmowdg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@biomejs/cli-linux-x64@2.4.16':
+    resolution: {integrity: sha512-NbcBbi/nJqn5baae6wqRXdS7Gadf2uRpehSh6vMSYpG8OhkXl/Xg8aorWrJ+9VWqAT5ml90alLvorkpMW0nBwQ==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@biomejs/cli-win32-arm64@2.4.16':
+    resolution: {integrity: sha512-0rgImMsNb5v/chhkIFe3wu7PEFClS6RBAYUijGL9UsYN3PanSaoK24HSSuSJb1pYbYYVjzAyZTl3gtjJ84BM8A==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@biomejs/cli-win32-x64@2.4.16':
+    resolution: {integrity: sha512-Kp85jgoBHa05gix6UIRjfCDiUV3w/8VIdZ247VyyO2gEjaw12WEVhdIjlxp/AMzXxqxQwbxNTDVZ3Mwd2RG5rw==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [win32]
+
+  '@emnapi/core@1.10.0':
+    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
+
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
@@ -292,6 +364,12 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@napi-rs/wasm-runtime@1.1.5':
+    resolution: {integrity: sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -303,6 +381,239 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@oxc-parser/binding-android-arm-eabi@0.135.0':
+    resolution: {integrity: sha512-sHeZItACNcA5WRAWqF6ixriR4GkZDyY10gVgnZU7pXku1DjHFATSqnwZM809jl0gXPHxb6fKzYQCK7bNK5cACQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxc-parser/binding-android-arm64@0.135.0':
+    resolution: {integrity: sha512-wPte+SzgzWWFgMSF8YZDNM+tBXtJg0AXBi7+tU3yS2z1f2Af9kRLZLKuJojADmuD/cZexmnMHHC3SDItTW77Iw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxc-parser/binding-darwin-arm64@0.135.0':
+    resolution: {integrity: sha512-BmKz3lHIsqVos+9aPcdYCT9MG3APoUyM43KlEFhJMWNVDOGG8FKyiFz81Bc+mGz2o0hpuQ3PfXLfVWJrKXjo2g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxc-parser/binding-darwin-x64@0.135.0':
+    resolution: {integrity: sha512-dM8BS+8+Br1fNvmh2QZbGiHaYttwLebRa6J4Uz9vuFzMNmvsdRYwf7993ptOaV0JTrR63AaoVLjX7nhWbijxjQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxc-parser/binding-freebsd-x64@0.135.0':
+    resolution: {integrity: sha512-xlZnvvJdR9bGu2pOhvR5hMuKPHCE6Sa9owK5A484mzjHdm75VRV5nCs5w/jkmGODMMTFc+KN7EnZqEieM813kw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.135.0':
+    resolution: {integrity: sha512-PSR8LmBK/H/PQRiN8g7RebQgZX/ntVCrdT/JBfNxE5ezdHG1s2i4rbazsRJYD83TTI1MmgTpC0MGL42PLtskQQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm-musleabihf@0.135.0':
+    resolution: {integrity: sha512-I85GJXzfUsigkkk7Ngdz95C217M4FdUi1Z2HrX5UyPmURobwQZ7m2bbUvwFkz4VGZd+lymFGKHvDZ3RQC9qOzA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm64-gnu@0.135.0':
+    resolution: {integrity: sha512-zqEY0npz0g0aGZj/8a5BclunjVDytsBQHYtIC10Gd26HcrLwbVF6YDbqRQjunMGYdSo97u6xOBl05aTDI2diDQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-arm64-musl@0.135.0':
+    resolution: {integrity: sha512-mWAfprP819gQ2qYst1RxgTI8b/z0b29OpoKfRflIXLHde2dZLihQD4g47Onuvtpo5GPIkMYPRlX9QoeZfs/GnQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-parser/binding-linux-ppc64-gnu@0.135.0':
+    resolution: {integrity: sha512-gri8c2AOmJKJwOux2KTHFBfUaXoJURuVMKhmKEi/2hTF55cQteTDV2XNfTiE5oCC+Tnem1Y4/MWzcyDadtsSag==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-riscv64-gnu@0.135.0':
+    resolution: {integrity: sha512-Y2tkupCG5wo0SxH2rMLG4d4Kmv6DaM3sBp+GuM5lox0S8Za6VxKgQrY2Mut088QQxKkEE89n/4CCCgmw2o0e3Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-riscv64-musl@0.135.0':
+    resolution: {integrity: sha512-xDRJq6i6WTynjeP+ISbDpyH4p9BaJ0wuQcL0lCSDkt9qOXC9dmwpOu1VG/TlwmPI3KpYntmO9nJCuc3TMTsNBA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-parser/binding-linux-s390x-gnu@0.135.0':
+    resolution: {integrity: sha512-V4MoUuiCRNvihxhIufRxvK+ka013V4joTSK0FAGA1KEjLuNprfH6N/Qw2uxQEVIFuNYMhD/hV6xJ/ptbzlKdHg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-x64-gnu@0.135.0':
+    resolution: {integrity: sha512-JCFZ7zM7KXOKoPAbK/ZB4wY0M1jxRECiem2UQuiXLjzGqS9+hno7mtX+qyK2F7HWK2xPhyJb+frpcOtk5DKOtg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-x64-musl@0.135.0':
+    resolution: {integrity: sha512-9jSVS1b3hOV7sdKH4aA2DFfnTz0RgQd0v2BefR+LYbH8yIlmSM22JJZbAAjVeVXmFgUAk3zJQ1tpE/Nd+Vi2YQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-parser/binding-openharmony-arm64@0.135.0':
+    resolution: {integrity: sha512-M857ZLBSdn1Uy/SJJz5zh0qGu67B4P9omCgXGBU2LLqTzraX6ZjVNaKq5yW1PDw/LgJXDXR/dbZfgmB310f11Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxc-parser/binding-wasm32-wasi@0.135.0':
+    resolution: {integrity: sha512-2w6DVcntQZX9U5RhXtgiWb3FLWFB5EcwI1U8yr3htOCJUJjagN4BFUHz/Y/d9ZsumndZ6ByxxWEtbUZNE1bfFw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@oxc-parser/binding-win32-arm64-msvc@0.135.0':
+    resolution: {integrity: sha512-rX1U8+IH2Z37EJjDXKa1iifvUQAdba+vZ4Ewj1iaG5eA/QaSybzclCOwtWa0/5BuUQnnK/T2JHUEFrwhL6Ck2Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxc-parser/binding-win32-ia32-msvc@0.135.0':
+    resolution: {integrity: sha512-9FAisBbH1QICGAjlJobiuKGd/jOuVmyqniWdQMwTa5SkCl6hhuotBCJf1n46B0flYbSOR5TzfV9HZCWSyb3c/Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxc-parser/binding-win32-x64-msvc@0.135.0':
+    resolution: {integrity: sha512-wYF+A2AzJ2n7ul6q+Z2G/ia0S2+8cUp0AgWZzoFvF4WmUcl1P7p+o6se1Gdr5wGnWuF0iAMIkGddrjCarNr2yA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@oxc-project/types@0.135.0':
+    resolution: {integrity: sha512-wR+xRdFkUBMvcAjBJ2q2kcZM6d+DKu2NgoOyxZgYwZdLhmiv6+rnO8PZ/P68kMiZtIKm+pW7zyEJ4kSOs0vo+Q==}
+
+  '@oxc-resolver/binding-android-arm-eabi@11.20.0':
+    resolution: {integrity: sha512-IjfWOXRgJFNdORDl+Uf1aibNgZY2guOD3zmOhx1BGVb/MIiqlFTdmjpQNplSN58lhWehnX4UNqC3QwpUo8pjJg==}
+    cpu: [arm]
+    os: [android]
+
+  '@oxc-resolver/binding-android-arm64@11.20.0':
+    resolution: {integrity: sha512-QqslZAuFQG8Q9xm7JuIn8JUbvywhSBMVhuQHtYW+auirZJloS41oxUUaBXk7uUhZJgp44c5zQLeVvmFaDQB+2Q==}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxc-resolver/binding-darwin-arm64@11.20.0':
+    resolution: {integrity: sha512-MUcavykj2ewlR+kc5arpg4tC2RvzJkUxWtNv74pf7lcNk00GpIpN43vXMj+j6r4eMmfZhlb8hueKoIb8e9kAGQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxc-resolver/binding-darwin-x64@11.20.0':
+    resolution: {integrity: sha512-BGB16nRUK5Etiv//ihPyzj8Lj1px0mhh4YIfe0FDf045ywknfSm0GEbiRESpr6Q4K82AvnyaRIhhluHByvS4bg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxc-resolver/binding-freebsd-x64@11.20.0':
+    resolution: {integrity: sha512-JZgtePaqj3qmD5XFHJaSLWzHRxQu0LaPkdoM1KJXYADvAaa83ijXHclV3ej3CueeW0wxfIAbGCZVP45J0CA7uQ==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxc-resolver/binding-linux-arm-gnueabihf@11.20.0':
+    resolution: {integrity: sha512-hOQ/p3ry3v3SchUBXicrrnszaI/UmYzM4wtS4RGfwgVUX7a+HbyQSzJ5aOzu+o6XZkFkS3ZXN4PZAzhOb77OSg==}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-resolver/binding-linux-arm-musleabihf@11.20.0':
+    resolution: {integrity: sha512-2ArPksaw0AqeuGBfoS715VF+JvJQAhD2niWgjE5hVO+L+nAfikVQopvngCMX9x4BD8itWoQ3dnikrQyl5Ho5Jg==}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-resolver/binding-linux-arm64-gnu@11.20.0':
+    resolution: {integrity: sha512-0bJnmYFp62JdZ4nVMDUZ/C58BCZOCcqgKtnUlp7L9Ojf/czIN+3j72YlLPeWLkzlr6SlYvIQA4SGV/HyO0d+qg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-resolver/binding-linux-arm64-musl@11.20.0':
+    resolution: {integrity: sha512-wKHHzPKZo7Ufhv/Bt6yxT7FOgnIgW4gwXcJUipkShGp68W3wGVqvr1Sr0fY65lN0Oy6y41+g2kIDvkgZaMMUkw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-resolver/binding-linux-ppc64-gnu@11.20.0':
+    resolution: {integrity: sha512-RN8goF7Ie0B79L4i4G6OeBocTgSC56vJbQ65VJje+oXnldVpLnOU7j/AQ/dP94TcCS+Yh6WG8u3Qt4ETteXFNQ==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-resolver/binding-linux-riscv64-gnu@11.20.0':
+    resolution: {integrity: sha512-5l1yU6/xQEqLZRzxqmMxJfWPslpwCmBsdDGaBvABPehxquCXDC7dd7oraNdKSJUMDXSM7VvVj8H2D2FTjU7oWw==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-resolver/binding-linux-riscv64-musl@11.20.0':
+    resolution: {integrity: sha512-xHEvkbgz6UC+A3JOyDQy76LkUaxsNSfIr3/GV8slwZsnuooJiIB34gzJfsyvR4JdCYNUUPsRJc/w/oWkODu+hg==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-resolver/binding-linux-s390x-gnu@11.20.0':
+    resolution: {integrity: sha512-aWPDUUmSeyHvlW+SoEUd+JIJsQhVhu6a5tBpDRMu058naPAchTgAVGCFy35zjbnFlt0i8hLWziff6HX0D3LU4g==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-resolver/binding-linux-x64-gnu@11.20.0':
+    resolution: {integrity: sha512-x2YeSimvhJjKLVD8KSu8f/rqU1potcdEMkApIPJqjZWN7c2Fpt4g2X32WDg1p+XDAmyT7nuQGe0vnhvXeLbH+g==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-resolver/binding-linux-x64-musl@11.20.0':
+    resolution: {integrity: sha512-kcRLEIxpZefeYfLChjpgFf3ilBzRDZ+yobMrpRsQlSrxuFGtm3U6PMU7AaEpMqo3NfDGVyJJseAjnRLzMFHjwQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-resolver/binding-openharmony-arm64@11.20.0':
+    resolution: {integrity: sha512-HHcfnApSZGtKhTiHqe8OZruOZe5XuFQH5/E0Yhj3u8fnFvzkM4/k6WjacUf4SvA0SPEAbfbgYmVPuo0VX/fIBQ==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxc-resolver/binding-wasm32-wasi@11.20.0':
+    resolution: {integrity: sha512-Tn0y1XOFYHNfK1wp1Z5QK8Rcld/bsOwRISQXfqAZ5IBpv8Gz1IvV39fUWNprqNdRizgcvFhOzWwFun2zkJsyBg==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@oxc-resolver/binding-win32-arm64-msvc@11.20.0':
+    resolution: {integrity: sha512-qPi25YNPe4YenS8MgsQU2+bIFHxxpLx1LVna2444cEHqNPhNjvWf9zqj4aWE43H9LpAsTmkkAlA3eL5ElBU3mA==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxc-resolver/binding-win32-x64-msvc@11.20.0':
+    resolution: {integrity: sha512-Wb14jWEW8huH6It9F6sXd9vrYmIS7pMrgkU6sxpLxkP+9z+wRgs71hUEhRpcn8FOXAFa27FVWfY2tRpbfTzfLw==}
+    cpu: [x64]
+    os: [win32]
 
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
@@ -445,6 +756,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@tybys/wasm-util@0.10.2':
+    resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
+
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
 
@@ -562,6 +876,9 @@ packages:
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
+  fd-package-json@2.0.0:
+    resolution: {integrity: sha512-jKmm9YtsNXN789RS/0mSzOC1NUq9mkVd65vbSSVsKdjGvYXBuE4oWe2QOEoFeRmJg+lPuZxpmrfFclNhoRMneQ==}
+
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -574,6 +891,11 @@ packages:
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
+
+  formatly@0.3.0:
+    resolution: {integrity: sha512-9XNj/o4wrRFyhSMJOvsuyMwy8aUfBaZ1VrqHVfohyXf0Sw0e+yfKG+xZaY3arGCOMdwFsqObtzVOc1gU9KiT9w==}
+    engines: {node: '>=18.3.0'}
+    hasBin: true
 
   fraction.js@5.3.4:
     resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
@@ -589,6 +911,9 @@ packages:
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
+
+  get-tsconfig@4.14.0:
+    resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -626,6 +951,10 @@ packages:
     resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
     hasBin: true
 
+  jiti@2.7.0:
+    resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
+    hasBin: true
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -637,6 +966,11 @@ packages:
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
+    hasBin: true
+
+  knip@6.17.1:
+    resolution: {integrity: sha512-HcQsZSQ4Ymhuay4BVzJtM5pFZNDSomYYqcNCZOSITPQh9g18a09DqziWAxSt2G+BH9wGlG+0ZjWpEnaFlnKseQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
   lilconfig@3.1.3:
@@ -687,6 +1021,13 @@ packages:
   object-hash@3.0.0:
     resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
     engines: {node: '>= 6'}
+
+  oxc-parser@0.135.0:
+    resolution: {integrity: sha512-/DaPStu0s2zzNSRRniKyTPM6Z/o+DapOp2JYNKDL8AsgaBGPK2IdZyB87SQjVH+xeQPz+Qr9mrjglfkYgtbVRA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
+  oxc-resolver@11.20.0:
+    resolution: {integrity: sha512-CblytBiV/a/ZXY34dsVU2NxhIOxMXst8CvDCtyBelVITgd7PLrKzbEbA6oKLdPjvDKDzCiW48qzmzZ+mYaqn+g==}
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
@@ -774,6 +1115,9 @@ packages:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
 
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
   resolve@1.22.12:
     resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
     engines: {node: '>= 0.4'}
@@ -798,9 +1142,17 @@ packages:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
 
+  smol-toml@1.6.1:
+    resolution: {integrity: sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==}
+    engines: {node: '>= 18'}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  strip-json-comments@5.0.3:
+    resolution: {integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==}
+    engines: {node: '>=14.16'}
 
   sucrase@3.35.1:
     resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
@@ -833,6 +1185,13 @@ packages:
 
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  unbash@4.0.1:
+    resolution: {integrity: sha512-1ajSo3813sDoVIHx4inJdUS4l5L2ic5cFiddemPiyjb/PZEoBAhFwHtbaEdRDFxbAKy7FCG7s5ww3/uCFawuIA==}
+    engines: {node: '>=14'}
 
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
@@ -883,6 +1242,10 @@ packages:
       yaml:
         optional: true
 
+  walk-up-path@4.0.0:
+    resolution: {integrity: sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A==}
+    engines: {node: 20 || >=22}
+
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
@@ -890,6 +1253,9 @@ packages:
     resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
     engines: {node: '>= 14.6'}
     hasBin: true
+
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
 snapshots:
 
@@ -1007,6 +1373,57 @@ snapshots:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
 
+  '@biomejs/biome@2.4.16':
+    optionalDependencies:
+      '@biomejs/cli-darwin-arm64': 2.4.16
+      '@biomejs/cli-darwin-x64': 2.4.16
+      '@biomejs/cli-linux-arm64': 2.4.16
+      '@biomejs/cli-linux-arm64-musl': 2.4.16
+      '@biomejs/cli-linux-x64': 2.4.16
+      '@biomejs/cli-linux-x64-musl': 2.4.16
+      '@biomejs/cli-win32-arm64': 2.4.16
+      '@biomejs/cli-win32-x64': 2.4.16
+
+  '@biomejs/cli-darwin-arm64@2.4.16':
+    optional: true
+
+  '@biomejs/cli-darwin-x64@2.4.16':
+    optional: true
+
+  '@biomejs/cli-linux-arm64-musl@2.4.16':
+    optional: true
+
+  '@biomejs/cli-linux-arm64@2.4.16':
+    optional: true
+
+  '@biomejs/cli-linux-x64-musl@2.4.16':
+    optional: true
+
+  '@biomejs/cli-linux-x64@2.4.16':
+    optional: true
+
+  '@biomejs/cli-win32-arm64@2.4.16':
+    optional: true
+
+  '@biomejs/cli-win32-x64@2.4.16':
+    optional: true
+
+  '@emnapi/core@1.10.0':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.10.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@esbuild/aix-ppc64@0.25.12':
     optional: true
 
@@ -1104,6 +1521,13 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.2
+    optional: true
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -1115,6 +1539,133 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
+
+  '@oxc-parser/binding-android-arm-eabi@0.135.0':
+    optional: true
+
+  '@oxc-parser/binding-android-arm64@0.135.0':
+    optional: true
+
+  '@oxc-parser/binding-darwin-arm64@0.135.0':
+    optional: true
+
+  '@oxc-parser/binding-darwin-x64@0.135.0':
+    optional: true
+
+  '@oxc-parser/binding-freebsd-x64@0.135.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.135.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm-musleabihf@0.135.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm64-gnu@0.135.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm64-musl@0.135.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-ppc64-gnu@0.135.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-riscv64-gnu@0.135.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-riscv64-musl@0.135.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-s390x-gnu@0.135.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-x64-gnu@0.135.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-x64-musl@0.135.0':
+    optional: true
+
+  '@oxc-parser/binding-openharmony-arm64@0.135.0':
+    optional: true
+
+  '@oxc-parser/binding-wasm32-wasi@0.135.0':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
+  '@oxc-parser/binding-win32-arm64-msvc@0.135.0':
+    optional: true
+
+  '@oxc-parser/binding-win32-ia32-msvc@0.135.0':
+    optional: true
+
+  '@oxc-parser/binding-win32-x64-msvc@0.135.0':
+    optional: true
+
+  '@oxc-project/types@0.135.0': {}
+
+  '@oxc-resolver/binding-android-arm-eabi@11.20.0':
+    optional: true
+
+  '@oxc-resolver/binding-android-arm64@11.20.0':
+    optional: true
+
+  '@oxc-resolver/binding-darwin-arm64@11.20.0':
+    optional: true
+
+  '@oxc-resolver/binding-darwin-x64@11.20.0':
+    optional: true
+
+  '@oxc-resolver/binding-freebsd-x64@11.20.0':
+    optional: true
+
+  '@oxc-resolver/binding-linux-arm-gnueabihf@11.20.0':
+    optional: true
+
+  '@oxc-resolver/binding-linux-arm-musleabihf@11.20.0':
+    optional: true
+
+  '@oxc-resolver/binding-linux-arm64-gnu@11.20.0':
+    optional: true
+
+  '@oxc-resolver/binding-linux-arm64-musl@11.20.0':
+    optional: true
+
+  '@oxc-resolver/binding-linux-ppc64-gnu@11.20.0':
+    optional: true
+
+  '@oxc-resolver/binding-linux-riscv64-gnu@11.20.0':
+    optional: true
+
+  '@oxc-resolver/binding-linux-riscv64-musl@11.20.0':
+    optional: true
+
+  '@oxc-resolver/binding-linux-s390x-gnu@11.20.0':
+    optional: true
+
+  '@oxc-resolver/binding-linux-x64-gnu@11.20.0':
+    optional: true
+
+  '@oxc-resolver/binding-linux-x64-musl@11.20.0':
+    optional: true
+
+  '@oxc-resolver/binding-openharmony-arm64@11.20.0':
+    optional: true
+
+  '@oxc-resolver/binding-wasm32-wasi@11.20.0':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
+  '@oxc-resolver/binding-win32-arm64-msvc@11.20.0':
+    optional: true
+
+  '@oxc-resolver/binding-win32-x64-msvc@11.20.0':
+    optional: true
 
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
@@ -1191,6 +1742,11 @@ snapshots:
     optional: true
 
   '@rollup/rollup-win32-x64-msvc@4.62.0':
+    optional: true
+
+  '@tybys/wasm-util@0.10.2':
+    dependencies:
+      tslib: 2.8.1
     optional: true
 
   '@types/babel__core@7.20.5':
@@ -1339,6 +1895,10 @@ snapshots:
     dependencies:
       reusify: 1.1.0
 
+  fd-package-json@2.0.0:
+    dependencies:
+      walk-up-path: 4.0.0
+
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
@@ -1346,6 +1906,10 @@ snapshots:
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
+
+  formatly@0.3.0:
+    dependencies:
+      fd-package-json: 2.0.0
 
   fraction.js@5.3.4: {}
 
@@ -1355,6 +1919,10 @@ snapshots:
   function-bind@1.1.2: {}
 
   gensync@1.0.0-beta.2: {}
+
+  get-tsconfig@4.14.0:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
 
   glob-parent@5.1.2:
     dependencies:
@@ -1386,11 +1954,29 @@ snapshots:
 
   jiti@1.21.7: {}
 
+  jiti@2.7.0: {}
+
   js-tokens@4.0.0: {}
 
   jsesc@3.1.0: {}
 
   json5@2.2.3: {}
+
+  knip@6.17.1:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      formatly: 0.3.0
+      get-tsconfig: 4.14.0
+      jiti: 2.7.0
+      oxc-parser: 0.135.0
+      oxc-resolver: 11.20.0
+      picomatch: 4.0.4
+      smol-toml: 1.6.1
+      strip-json-comments: 5.0.3
+      tinyglobby: 0.2.17
+      unbash: 4.0.1
+      yaml: 2.9.0
+      zod: 4.4.3
 
   lilconfig@3.1.3: {}
 
@@ -1428,6 +2014,53 @@ snapshots:
   object-assign@4.1.1: {}
 
   object-hash@3.0.0: {}
+
+  oxc-parser@0.135.0:
+    dependencies:
+      '@oxc-project/types': 0.135.0
+    optionalDependencies:
+      '@oxc-parser/binding-android-arm-eabi': 0.135.0
+      '@oxc-parser/binding-android-arm64': 0.135.0
+      '@oxc-parser/binding-darwin-arm64': 0.135.0
+      '@oxc-parser/binding-darwin-x64': 0.135.0
+      '@oxc-parser/binding-freebsd-x64': 0.135.0
+      '@oxc-parser/binding-linux-arm-gnueabihf': 0.135.0
+      '@oxc-parser/binding-linux-arm-musleabihf': 0.135.0
+      '@oxc-parser/binding-linux-arm64-gnu': 0.135.0
+      '@oxc-parser/binding-linux-arm64-musl': 0.135.0
+      '@oxc-parser/binding-linux-ppc64-gnu': 0.135.0
+      '@oxc-parser/binding-linux-riscv64-gnu': 0.135.0
+      '@oxc-parser/binding-linux-riscv64-musl': 0.135.0
+      '@oxc-parser/binding-linux-s390x-gnu': 0.135.0
+      '@oxc-parser/binding-linux-x64-gnu': 0.135.0
+      '@oxc-parser/binding-linux-x64-musl': 0.135.0
+      '@oxc-parser/binding-openharmony-arm64': 0.135.0
+      '@oxc-parser/binding-wasm32-wasi': 0.135.0
+      '@oxc-parser/binding-win32-arm64-msvc': 0.135.0
+      '@oxc-parser/binding-win32-ia32-msvc': 0.135.0
+      '@oxc-parser/binding-win32-x64-msvc': 0.135.0
+
+  oxc-resolver@11.20.0:
+    optionalDependencies:
+      '@oxc-resolver/binding-android-arm-eabi': 11.20.0
+      '@oxc-resolver/binding-android-arm64': 11.20.0
+      '@oxc-resolver/binding-darwin-arm64': 11.20.0
+      '@oxc-resolver/binding-darwin-x64': 11.20.0
+      '@oxc-resolver/binding-freebsd-x64': 11.20.0
+      '@oxc-resolver/binding-linux-arm-gnueabihf': 11.20.0
+      '@oxc-resolver/binding-linux-arm-musleabihf': 11.20.0
+      '@oxc-resolver/binding-linux-arm64-gnu': 11.20.0
+      '@oxc-resolver/binding-linux-arm64-musl': 11.20.0
+      '@oxc-resolver/binding-linux-ppc64-gnu': 11.20.0
+      '@oxc-resolver/binding-linux-riscv64-gnu': 11.20.0
+      '@oxc-resolver/binding-linux-riscv64-musl': 11.20.0
+      '@oxc-resolver/binding-linux-s390x-gnu': 11.20.0
+      '@oxc-resolver/binding-linux-x64-gnu': 11.20.0
+      '@oxc-resolver/binding-linux-x64-musl': 11.20.0
+      '@oxc-resolver/binding-openharmony-arm64': 11.20.0
+      '@oxc-resolver/binding-wasm32-wasi': 11.20.0
+      '@oxc-resolver/binding-win32-arm64-msvc': 11.20.0
+      '@oxc-resolver/binding-win32-x64-msvc': 11.20.0
 
   path-parse@1.0.7: {}
 
@@ -1500,6 +2133,8 @@ snapshots:
     dependencies:
       picomatch: 2.3.2
 
+  resolve-pkg-maps@1.0.0: {}
+
   resolve@1.22.12:
     dependencies:
       es-errors: 1.3.0
@@ -1550,7 +2185,11 @@ snapshots:
 
   semver@6.3.1: {}
 
+  smol-toml@1.6.1: {}
+
   source-map-js@1.2.1: {}
+
+  strip-json-comments@5.0.3: {}
 
   sucrase@3.35.1:
     dependencies:
@@ -1610,6 +2249,11 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
+  tslib@2.8.1:
+    optional: true
+
+  unbash@4.0.1: {}
+
   update-browserslist-db@1.2.3(browserslist@4.28.2):
     dependencies:
       browserslist: 4.28.2
@@ -1631,6 +2275,10 @@ snapshots:
       jiti: 1.21.7
       yaml: 2.9.0
 
+  walk-up-path@4.0.0: {}
+
   yallist@3.1.1: {}
 
   yaml@2.9.0: {}
+
+  zod@4.4.3: {}

--- a/site/src/App.jsx
+++ b/site/src/App.jsx
@@ -1,534 +1,592 @@
-import React from 'react';
+import React from "react";
 
-    const { useState } = React;
+const { useState } = React;
 
-    const navItems = ['使い方', '英単語整理', '機能', '料金'];
-    const navHrefs = ['#review-flow', '#card-groups', '#features', '#pricing'];
+const navItems = ["使い方", "英単語整理", "機能", "料金"];
+const navHrefs = ["#review-flow", "#card-groups", "#features", "#pricing"];
 
-    const logos = [
-      'IELTS', 'TOEFL', 'Duolingo', 'Anki', '教室', 'Notion', 'Quizlet', 'Memrise', 'Teams'
-    ];
+const featureSections = [
+  {
+    title: <>苦手な単語を、自然に復習へ。</>,
+    description: "覚えたか、まだ不安かを短い操作で記録。弱点だけが残るので、復習の迷いが減ります。",
+    visual: "organized",
+  },
+  {
+    title: <>単語リストを、すぐ学習カードに。</>,
+    description:
+      "CSVで取り込んだ単語を、目的別のカードグループとして整理。準備に時間をかけず、すぐ復習へ進めます。",
+    visual: "drafts",
+  },
+];
 
-    const featureSections = [
-      {
-        title: <>苦手な単語を、自然に復習へ。</>,
-        description:
-          '覚えたか、まだ不安かを短い操作で記録。弱点だけが残るので、復習の迷いが減ります。',
-        visual: 'organized',
-      },
-      {
-        title: <>単語リストを、すぐ学習カードに。</>,
-        description:
-          'CSVで取り込んだ単語を、目的別のカードグループとして整理。準備に時間をかけず、すぐ復習へ進めます。',
-        visual: 'drafts',
-      }
-    ];
+const bento = [
+  {
+    icon: "brand",
+    title: "スワイプで、迷う単語に集中",
+    text: "左右スワイプで「覚えた／まだ不安」を判定。迷った単語を自動で優先表示し、開くたびに弱点だけを効率よく復習できます。",
+  },
+  {
+    icon: "📥",
+    title: "自分の英単語を、取り込んで整理",
+    text: "CSVで取り込んだ単語を、目的別のカードグループとして整理。準備に時間をかけず、すぐ復習へ進めます。",
+  },
+  {
+    icon: "📊",
+    title: "積み上げが見える",
+    text: "学習済み・復習中・習得済みを見える化。毎日の積み上げと、弱点が減っていく様子が一目でわかります。",
+  },
+];
 
-    const bento = [
-      {
-        icon: 'brand',
-        title: 'スワイプで、迷う単語に集中',
-        text: '左右スワイプで「覚えた／まだ不安」を判定。迷った単語を自動で優先表示し、開くたびに弱点だけを効率よく復習できます。',
-      },
-      {
-        icon: '📥',
-        title: '自分の英単語を、取り込んで整理',
-        text: 'CSVで取り込んだ単語を、目的別のカードグループとして整理。準備に時間をかけず、すぐ復習へ進めます。',
-      },
-      {
-        icon: '📊',
-        title: '積み上げが見える',
-        text: '学習済み・復習中・習得済みを見える化。毎日の積み上げと、弱点が減っていく様子が一目でわかります。',
-      }
-    ];
+function Logo() {
+  return (
+    <a
+      href="#top"
+      className="flex items-center gap-[var(--fib-3)]"
+      aria-label="Flamingo Armond home"
+    >
+      <div className="brand-icon-shell flex h-[34px] w-[34px] items-center justify-center rounded-[10px] p-[5px]">
+        <img
+          className="brand-icon-img"
+          src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxMDI0IiBoZWlnaHQ9IjEwMjQiIHZpZXdCb3g9IjAgMCAxMDI0IDEwMjQiPgogIDxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDI0IiBoZWlnaHQ9IjEwMjQiIHJ4PSIxNTMiIHJ5PSIxNTMiIGZpbGw9IiNGRjZGNzkiLz4KICA8cGF0aCBkPSJNMCwwIEw5NSwwIEwxMDMsNiBMMTIyLDI1IEwxMjIsMjcgTDEyNCwyNyBMMTMxLDM1IEwxMzgsNDEgTDE0NSw0OSBMMTU2LDYwIEwxNTgsNjQgTDE1OCwxNDAgTDE1NCwxNDYgTDExOCwxODIgTDExMSwxOTAgTDMzLDI2OCBMMzEsMjY4IEwzMCwyNzEgTDI5LDMwMyBMMjc3LDMwMiBMMjg4LDI4NiBMMzAyLDI2NyBMMzA5LDI1NyBMMzIzLDIzOCBMMzM1LDIyMSBMMzQ4LDIwMyBMMzYyLDE4NCBMMzc0LDE2NyBMMzg3LDE0OSBMMzkzLDE0MSBMMzk4LDEzOCBMNDA1LDEzOCBMNDExLDE0MiBMNDEzLDE0NiBMNDEzLDE1MyBMNDA3LDE2MyBMMzk3LDE3NiBMMzg4LDE4OSBMMzc1LDIwNyBMMzYzLDIyNCBMMzQ5LDI0MyBMMzM2LDI2MSBMMzIyLDI4MSBMMzA4LDMwMCBMMzA3LDMwMiBMNDA2LDMwMyBMNDEyLDMwNyBMNDE0LDMxMSBMNDE0LDMxOSBMNDA3LDMyNyBMMzkwLDM0NCBMMzgyLDM1MSBMMzY1LDM2OCBMMzU3LDM3NSBMMzQyLDM5MCBMMzM0LDM5NyBMMzEzLDQxOCBMMzA1LDQyNSBMMjkyLDQzOCBMMjkwLDQzOCBMMjkwLDQ0MCBMMjgyLDQ0NyBMMjY1LDQ2NCBMMjU3LDQ3MSBMMjQwLDQ4OCBMMjMyLDQ5NSBMMjE0LDUxMyBMMjA2LDUyMCBMMTkzLDUzMyBMMTkyLDcxMyBMMjgzLDcxMyBMMjg5LDcxOCBMMjkwLDcyMCBMMjkwLDczMCBMMjg1LDczNiBMMjgyLDczNyBMNzgsNzM3IEw3Miw3MzMgTDcwLDczMCBMNzAsNzIwIEw3NSw3MTQgTDc4LDcxMyBMMTY4LDcxMyBMMTY3LDUzMyBMMTUxLDUxNyBMMTQzLDUxMCBMMTIwLDQ4NyBMMTEyLDQ4MCBMOTksNDY3IEw5MSw0NjAgTDcxLDQ0MCBMNjMsNDMzIEw0Nyw0MTcgTDQyLDQxMyBMMzcsNDA4IEwxOCwzODkgTDEwLDM4MiBMLTcsMzY1IEwtMTUsMzU4IEwtMjcsMzQ2IEwtMzUsMzM5IEwtNTMsMzIxIEwtNTQsMzE5IEwtNTQsMjQwIEwtNTEsMjM1IEwtMzEsMjE1IEwtMjYsMjEwIEwtMTYsMjAwIEwtOSwxOTIgTC00LDE4NyBMLTEsMTg2IEwtMSwxODQgTDEsMTg0IEwzLDE4MCBMOSwxNzUgTDE2LDE2NyBMMjMsMTYwIEwyOCwxNTUgTDY0LDExOSBMNjUsOTQgTDExLDk1IEwzLDEwMiBMLTQsMTEwIEwtMTIsMTE3IEwtMTQsMTIwIEwtMTUsMTY3IEwtMTgsMTcyIEwtMjEsMTc1IEwtMzAsMTc2IEwtMzcsMTcyIEwtMzksMTY4IEwtNDMsMTY2IEwtNzYsMTMzIEwtNzgsMTI5IEwtNzgsNzcgTC03NCw3MSBMLTY5LDY2IEwtNjcsNjYgTC02Nyw2NCBMLTY1LDY0IEwtNjUsNjIgTC02Myw2MiBMLTYxLDU4IEwtNTEsNDggTC00Myw0MSBMLTM2LDM0IEwtMjksMjYgTC0xNCwxMiBMLTMsMSBaICIgZmlsbD0iI0ZERkFGNiIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMzQ0LDE1NSkiLz4KICA8cGF0aCBkPSJNMCwwIEwyNjgsMCBMMjY2LDUgTDI1NCwyMSBMMjQyLDM4IEwyMjksNTYgTDIxNiw3NCBMMjAzLDkyIEwxOTAsMTEwIEwxODAsMTI0IEwxNzksMTMyIEwxODIsMTM4IEwxODYsMTQwIEwxOTQsMTQwIEwxOTksMTM3IEwyMTAsMTIxIEwyMjMsMTAzIEwyMzYsODUgTDI0OSw2NyBMMjYzLDQ4IEwyNzcsMjggTDI5MSw5IEwyOTgsMCBMMzgxLDAgTDM3NSw3IEwzNjMsMTkgTDM1NSwyNiBMMzM4LDQzIEwzMzAsNTAgTDMxNCw2NiBMMzA2LDczIEwyODksOTAgTDI4MSw5NyBMMjYzLDExNSBMMjYxLDExNSBMMjU5LDExOSBMMjUxLDEyNiBMMjQwLDEzNyBMMjM0LDE0MiBMMjI5LDE0NyBMMjExLDE2NSBMMjAzLDE3MiBMMTkxLDE4NCBMMTg3LDE4MiBMMTcxLDE2NiBMMTYzLDE1OSBMMTQyLDEzOCBMMTM0LDEzMSBMMTE3LDExNCBMMTA5LDEwNyBMOTAsODggTDgyLDgxIEw2NSw2NCBMNTcsNTcgTDQxLDQxIEwzMywzNCBMMTYsMTcgTDgsMTAgTDAsMiBaICIgZmlsbD0iI0ZGNkY3OSIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMzM0LDQ4MikiLz4KICA8cGF0aCBkPSJNMCwwIEw4MCwwIEw5MCwxMCBMOTUsMTUgTDExMiwzMiBMMTE5LDQwIEwxMjgsNDkgTDEyOCwxMDkgTDEwNywxMzAgTDEwMiwxMzUgTDkxLDE0NyBMODUsMTUyIEw4NCwxNTQgTDgyLDE1NCBMODIsMTU2IEw3NywxNjAgTDcyLDE2NiBMNzAsMTY2IEw2OCwxNzAgTDU2LDE4MiBMNTQsMTgyIEw1NCwxODQgTDUyLDE4NCBMNTIsMTg2IEw1MCwxODYgTDUwLDE4OCBMNDUsMTkyIEwzOCwyMDAgTDI2LDIxMiBMMTksMjE4IEwxMiwyMjYgTDcsMjMwIEw2LDIzMiBMNCwyMzIgTDIsMjM2IEwwLDIzOSBMLTEsMjgwIEwtMzgsMjgwIEwtMzgsMjI1IEwtMTIsMTk5IEwtNywxOTQgTDQsMTgzIEw5LDE3OCBMMjAsMTY3IEwyNywxNTkgTDc5LDEwNyBMODAsMTA0IEw4MCw1NiBMNzgsNTEgTDczLDQ5IEwtNSw0OSBMLTEyLDU0IEwtMTgsNjEgTC0yNiw2OCBMLTMxLDczIEwtMzgsODEgTC00Myw4NiBMLTQ0LDg4IEwtNDUsMTEzIEwtNTIsMTA3IEwtNjAsMTAwIEwtNjIsOTcgTC02Miw2MiBaICIgZmlsbD0iI0ZGNkY3OSIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMzUxLDE3OCkiLz4KPC9zdmc+"
+          alt=""
+        />
+      </div>
+      <span className="hidden text-[20px] font-semibold tracking-[-0.015em] text-ink sm:block">
+        Flamingo Armond
+      </span>
+      <span className="block text-[18px] font-semibold tracking-[-0.015em] text-ink sm:hidden">
+        Flamingo
+      </span>
+    </a>
+  );
+}
 
-    function Logo() {
-      return (
-        <a href="#" className="flex items-center gap-[var(--fib-3)]" aria-label="Flamingo Armond home">
-          <div className="brand-icon-shell flex h-[34px] w-[34px] items-center justify-center rounded-[10px] p-[5px]">
-            <img className="brand-icon-img" src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxMDI0IiBoZWlnaHQ9IjEwMjQiIHZpZXdCb3g9IjAgMCAxMDI0IDEwMjQiPgogIDxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDI0IiBoZWlnaHQ9IjEwMjQiIHJ4PSIxNTMiIHJ5PSIxNTMiIGZpbGw9IiNGRjZGNzkiLz4KICA8cGF0aCBkPSJNMCwwIEw5NSwwIEwxMDMsNiBMMTIyLDI1IEwxMjIsMjcgTDEyNCwyNyBMMTMxLDM1IEwxMzgsNDEgTDE0NSw0OSBMMTU2LDYwIEwxNTgsNjQgTDE1OCwxNDAgTDE1NCwxNDYgTDExOCwxODIgTDExMSwxOTAgTDMzLDI2OCBMMzEsMjY4IEwzMCwyNzEgTDI5LDMwMyBMMjc3LDMwMiBMMjg4LDI4NiBMMzAyLDI2NyBMMzA5LDI1NyBMMzIzLDIzOCBMMzM1LDIyMSBMMzQ4LDIwMyBMMzYyLDE4NCBMMzc0LDE2NyBMMzg3LDE0OSBMMzkzLDE0MSBMMzk4LDEzOCBMNDA1LDEzOCBMNDExLDE0MiBMNDEzLDE0NiBMNDEzLDE1MyBMNDA3LDE2MyBMMzk3LDE3NiBMMzg4LDE4OSBMMzc1LDIwNyBMMzYzLDIyNCBMMzQ5LDI0MyBMMzM2LDI2MSBMMzIyLDI4MSBMMzA4LDMwMCBMMzA3LDMwMiBMNDA2LDMwMyBMNDEyLDMwNyBMNDE0LDMxMSBMNDE0LDMxOSBMNDA3LDMyNyBMMzkwLDM0NCBMMzgyLDM1MSBMMzY1LDM2OCBMMzU3LDM3NSBMMzQyLDM5MCBMMzM0LDM5NyBMMzEzLDQxOCBMMzA1LDQyNSBMMjkyLDQzOCBMMjkwLDQzOCBMMjkwLDQ0MCBMMjgyLDQ0NyBMMjY1LDQ2NCBMMjU3LDQ3MSBMMjQwLDQ4OCBMMjMyLDQ5NSBMMjE0LDUxMyBMMjA2LDUyMCBMMTkzLDUzMyBMMTkyLDcxMyBMMjgzLDcxMyBMMjg5LDcxOCBMMjkwLDcyMCBMMjkwLDczMCBMMjg1LDczNiBMMjgyLDczNyBMNzgsNzM3IEw3Miw3MzMgTDcwLDczMCBMNzAsNzIwIEw3NSw3MTQgTDc4LDcxMyBMMTY4LDcxMyBMMTY3LDUzMyBMMTUxLDUxNyBMMTQzLDUxMCBMMTIwLDQ4NyBMMTEyLDQ4MCBMOTksNDY3IEw5MSw0NjAgTDcxLDQ0MCBMNjMsNDMzIEw0Nyw0MTcgTDQyLDQxMyBMMzcsNDA4IEwxOCwzODkgTDEwLDM4MiBMLTcsMzY1IEwtMTUsMzU4IEwtMjcsMzQ2IEwtMzUsMzM5IEwtNTMsMzIxIEwtNTQsMzE5IEwtNTQsMjQwIEwtNTEsMjM1IEwtMzEsMjE1IEwtMjYsMjEwIEwtMTYsMjAwIEwtOSwxOTIgTC00LDE4NyBMLTEsMTg2IEwtMSwxODQgTDEsMTg0IEwzLDE4MCBMOSwxNzUgTDE2LDE2NyBMMjMsMTYwIEwyOCwxNTUgTDY0LDExOSBMNjUsOTQgTDExLDk1IEwzLDEwMiBMLTQsMTEwIEwtMTIsMTE3IEwtMTQsMTIwIEwtMTUsMTY3IEwtMTgsMTcyIEwtMjEsMTc1IEwtMzAsMTc2IEwtMzcsMTcyIEwtMzksMTY4IEwtNDMsMTY2IEwtNzYsMTMzIEwtNzgsMTI5IEwtNzgsNzcgTC03NCw3MSBMLTY5LDY2IEwtNjcsNjYgTC02Nyw2NCBMLTY1LDY0IEwtNjUsNjIgTC02Myw2MiBMLTYxLDU4IEwtNTEsNDggTC00Myw0MSBMLTM2LDM0IEwtMjksMjYgTC0xNCwxMiBMLTMsMSBaICIgZmlsbD0iI0ZERkFGNiIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMzQ0LDE1NSkiLz4KICA8cGF0aCBkPSJNMCwwIEwyNjgsMCBMMjY2LDUgTDI1NCwyMSBMMjQyLDM4IEwyMjksNTYgTDIxNiw3NCBMMjAzLDkyIEwxOTAsMTEwIEwxODAsMTI0IEwxNzksMTMyIEwxODIsMTM4IEwxODYsMTQwIEwxOTQsMTQwIEwxOTksMTM3IEwyMTAsMTIxIEwyMjMsMTAzIEwyMzYsODUgTDI0OSw2NyBMMjYzLDQ4IEwyNzcsMjggTDI5MSw5IEwyOTgsMCBMMzgxLDAgTDM3NSw3IEwzNjMsMTkgTDM1NSwyNiBMMzM4LDQzIEwzMzAsNTAgTDMxNCw2NiBMMzA2LDczIEwyODksOTAgTDI4MSw5NyBMMjYzLDExNSBMMjYxLDExNSBMMjU5LDExOSBMMjUxLDEyNiBMMjQwLDEzNyBMMjM0LDE0MiBMMjI5LDE0NyBMMjExLDE2NSBMMjAzLDE3MiBMMTkxLDE4NCBMMTg3LDE4MiBMMTcxLDE2NiBMMTYzLDE1OSBMMTQyLDEzOCBMMTM0LDEzMSBMMTE3LDExNCBMMTA5LDEwNyBMOTAsODggTDgyLDgxIEw2NSw2NCBMNTcsNTcgTDQxLDQxIEwzMywzNCBMMTYsMTcgTDgsMTAgTDAsMiBaICIgZmlsbD0iI0ZGNkY3OSIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMzM0LDQ4MikiLz4KICA8cGF0aCBkPSJNMCwwIEw4MCwwIEw5MCwxMCBMOTUsMTUgTDExMiwzMiBMMTE5LDQwIEwxMjgsNDkgTDEyOCwxMDkgTDEwNywxMzAgTDEwMiwxMzUgTDkxLDE0NyBMODUsMTUyIEw4NCwxNTQgTDgyLDE1NCBMODIsMTU2IEw3NywxNjAgTDcyLDE2NiBMNzAsMTY2IEw2OCwxNzAgTDU2LDE4MiBMNTQsMTgyIEw1NCwxODQgTDUyLDE4NCBMNTIsMTg2IEw1MCwxODYgTDUwLDE4OCBMNDUsMTkyIEwzOCwyMDAgTDI2LDIxMiBMMTksMjE4IEwxMiwyMjYgTDcsMjMwIEw2LDIzMiBMNCwyMzIgTDIsMjM2IEwwLDIzOSBMLTEsMjgwIEwtMzgsMjgwIEwtMzgsMjI1IEwtMTIsMTk5IEwtNywxOTQgTDQsMTgzIEw5LDE3OCBMMjAsMTY3IEwyNywxNTkgTDc5LDEwNyBMODAsMTA0IEw4MCw1NiBMNzgsNTEgTDczLDQ5IEwtNSw0OSBMLTEyLDU0IEwtMTgsNjEgTC0yNiw2OCBMLTMxLDczIEwtMzgsODEgTC00Myw4NiBMLTQ0LDg4IEwtNDUsMTEzIEwtNTIsMTA3IEwtNjAsMTAwIEwtNjIsOTcgTC02Miw2MiBaICIgZmlsbD0iI0ZGNkY3OSIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMzUxLDE3OCkiLz4KPC9zdmc+" alt="" />
-          </div>
-          <span className="hidden text-[20px] font-semibold tracking-[-0.015em] text-ink sm:block">
-            Flamingo Armond
-          </span>
-          <span className="block text-[18px] font-semibold tracking-[-0.015em] text-ink sm:hidden">
-            Flamingo
-          </span>
-        </a>
-      );
-    }
+function Button({ children, variant = "primary", href = "#", className = "" }) {
+  if (variant === "primary") {
+    return (
+      <a
+        href={href}
+        className={`inline-flex min-h-[46px] items-center justify-center rounded-full bg-flamingo-500 px-[var(--button-x)] py-[var(--button-y)] text-[var(--button-text)] font-semibold text-white shadow-[0_2px_8px_rgba(255,95,79,0.18)] transition-colors hover:bg-flamingo-600 ${className}`}
+      >
+        {children}
+      </a>
+    );
+  }
 
-    function Button({ children, variant = 'primary', href = '#', className = '' }) {
-      if (variant === 'primary') {
-        return (
+  return (
+    <a
+      href={href}
+      className={`inline-flex min-h-[46px] items-center justify-center rounded-full border border-gray-300 bg-white px-[var(--button-x)] py-[var(--button-y)] text-[var(--button-text)] font-semibold text-gray-800 transition-colors hover:bg-gray-50 ${className}`}
+    >
+      {children}
+    </a>
+  );
+}
+
+function Header() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <header className="page-shell relative z-50 flex h-[56px] items-center justify-between bg-white/95 backdrop-blur">
+      <Logo />
+
+      <nav className="hidden items-center gap-x-[var(--fib-1)] lg:flex">
+        {navItems.map((item, index) => (
           <a
-            href={href}
-            className={`inline-flex min-h-[46px] items-center justify-center rounded-full bg-flamingo-500 px-[var(--button-x)] py-[var(--button-y)] text-[var(--button-text)] font-semibold text-white shadow-[0_2px_8px_rgba(255,95,79,0.18)] transition-colors hover:bg-flamingo-600 ${className}`}
+            key={item}
+            href={navHrefs[index]}
+            className="inline-flex h-9 items-center justify-center rounded-md px-[var(--fib-4)] py-2 text-[13px] font-medium text-gray-800 transition-colors hover:bg-gray-50"
           >
-            {children}
+            {item}
+            {index === 0 && <span className="ml-1 text-xs text-gray-400">⌄</span>}
           </a>
-        );
-      }
+        ))}
+      </nav>
 
-      return (
-        <a
-          href={href}
-          className={`inline-flex min-h-[46px] items-center justify-center rounded-full border border-gray-300 bg-white px-[var(--button-x)] py-[var(--button-y)] text-[var(--button-text)] font-semibold text-gray-800 transition-colors hover:bg-gray-50 ${className}`}
+      <div className="hidden items-center gap-[var(--fib-4)] md:flex">
+        <Button
+          variant="secondary"
+          href="https://flamingo-armond-frontend.vercel.app/"
+          className="!min-h-[36px] !px-[var(--fib-5)] !py-[var(--fib-2)] !text-sm"
         >
-          {children}
-        </a>
-      );
-    }
+          ログイン
+        </Button>
+        <Button href="https://flamingo-armond-frontend.vercel.app/" className="header-cta !text-sm">
+          無料で始める
+        </Button>
+      </div>
 
-    function Header() {
-      const [open, setOpen] = useState(false);
+      <button
+        type="button"
+        onClick={() => setOpen(!open)}
+        className="flex h-10 w-10 items-center justify-center rounded-xl border border-gray-100 bg-white text-xl md:hidden"
+        aria-label="Open menu"
+      >
+        ☰
+      </button>
 
-      return (
-        <header className="page-shell relative z-50 flex h-[56px] items-center justify-between bg-white/95 backdrop-blur">
-          <Logo />
-
-          <nav className="hidden items-center gap-x-[var(--fib-1)] lg:flex">
+      {open && (
+        <div className="mobile-menu-panel absolute left-4 right-4 top-16 z-50 rounded-3xl border border-gray-100 p-4 shadow-float md:hidden">
+          <div className="grid gap-2">
             {navItems.map((item, index) => (
               <a
                 key={item}
                 href={navHrefs[index]}
-                className="inline-flex h-9 items-center justify-center rounded-md px-[var(--fib-4)] py-2 text-[13px] font-medium text-gray-800 transition-colors hover:bg-gray-50"
+                onClick={() => setOpen(false)}
+                className="rounded-2xl px-4 py-3 text-sm font-semibold text-gray-800 hover:bg-gray-50"
               >
                 {item}
-                {index === 0 && <span className="ml-1 text-xs text-gray-400">⌄</span>}
               </a>
             ))}
-          </nav>
+            <div className="mt-3 flex gap-3">
+              <Button
+                variant="secondary"
+                href="https://flamingo-armond-frontend.vercel.app/"
+                className="flex-1 !px-[var(--fib-5)] !py-[var(--fib-4)]"
+              >
+                ログイン
+              </Button>
+              <Button
+                href="https://flamingo-armond-frontend.vercel.app/"
+                className="flex-1 !px-[var(--fib-5)] !py-[var(--fib-4)]"
+              >
+                始める
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+    </header>
+  );
+}
 
-          <div className="hidden items-center gap-[var(--fib-4)] md:flex">
-            <Button variant="secondary" href="https://flamingo-armond-frontend.vercel.app/" className="!min-h-[36px] !px-[var(--fib-5)] !py-[var(--fib-2)] !text-sm">ログイン</Button>
-            <Button href="https://flamingo-armond-frontend.vercel.app/" className="header-cta !text-sm">無料で始める</Button>
+function HeroWords({ text }) {
+  const words = text.includes("|") ? text.split("|") : text.split(" ");
+  return (
+    <>
+      {words.map((word, index) => (
+        <span
+          // biome-ignore lint/suspicious/noArrayIndexKey: words come from splitting a fixed title and never reorder
+          key={`${word}-${index}`}
+          className="hero-title-word animate-reveal"
+          style={{ animationDelay: `${index * 75}ms`, opacity: 0 }}
+        >
+          {word === "続く" ? <em className="hero-title-em">{word}</em> : word}
+        </span>
+      ))}
+    </>
+  );
+}
+
+const carouselImages = [
+  {
+    src: `images/desktop-learn.png`,
+    title: `PCでの学習画面`,
+    description: `大きなカードで、単語と意味に集中できます。`,
+    kind: `desktop`,
+  },
+  {
+    src: `images/desktop-login.png`,
+    title: `ログイン画面`,
+    description: `Googleアカウントでスムーズに開始できます。`,
+    kind: `desktop`,
+  },
+  {
+    src: `images/mobile-manage.png`,
+    title: `モバイル管理画面`,
+    description: `スマホでもカードグループを確認できます。`,
+    kind: `mobile`,
+  },
+  {
+    src: `images/mobile-learn.png`,
+    title: `モバイル学習画面`,
+    description: `移動中でも片手で復習できます。`,
+    kind: `mobile`,
+  },
+];
+
+function ProductPreview() {
+  const [activeIndex, setActiveIndex] = React.useState(0);
+  const active = carouselImages[activeIndex];
+
+  React.useEffect(() => {
+    const timer = window.setInterval(() => {
+      setActiveIndex((current) => (current + 1) % carouselImages.length);
+    }, 4200);
+
+    return () => window.clearInterval(timer);
+  }, []);
+
+  return (
+    <div className="relative w-full animate-reveal" style={{ opacity: 0, animationDelay: "575ms" }}>
+      <div className="product-carousel-shell">
+        <div className="product-carousel-stage">
+          <button
+            type="button"
+            aria-label="前の画面"
+            className="carousel-nav carousel-nav-left"
+            onClick={() =>
+              setActiveIndex((activeIndex - 1 + carouselImages.length) % carouselImages.length)
+            }
+          >
+            ‹
+          </button>
+
+          <div className="product-carousel-media" data-kind={active.kind}>
+            <img
+              key={active.src}
+              src={active.src}
+              alt={active.title}
+              className="product-carousel-image"
+            />
           </div>
 
           <button
-            onClick={() => setOpen(!open)}
-            className="flex h-10 w-10 items-center justify-center rounded-xl border border-gray-100 bg-white text-xl md:hidden"
-            aria-label="Open menu"
+            type="button"
+            aria-label="次の画面"
+            className="carousel-nav carousel-nav-right"
+            onClick={() => setActiveIndex((activeIndex + 1) % carouselImages.length)}
           >
-            ☰
+            ›
           </button>
 
-          {open && (
-            <div className="mobile-menu-panel absolute left-4 right-4 top-16 z-50 rounded-3xl border border-gray-100 p-4 shadow-float md:hidden">
-              <div className="grid gap-2">
-                {navItems.map((item, index) => (
-                  <a key={item} href={navHrefs[index]} onClick={() => setOpen(false)} className="rounded-2xl px-4 py-3 text-sm font-semibold text-gray-800 hover:bg-gray-50">
-                    {item}
-                  </a>
-                ))}
-                <div className="mt-3 flex gap-3">
-                  <Button variant="secondary" href="https://flamingo-armond-frontend.vercel.app/" className="flex-1 !px-[var(--fib-5)] !py-[var(--fib-4)]">ログイン</Button>
-                  <Button href="https://flamingo-armond-frontend.vercel.app/" className="flex-1 !px-[var(--fib-5)] !py-[var(--fib-4)]">始める</Button>
-                </div>
-              </div>
-            </div>
-          )}
-        </header>
-      );
-    }
+          <div className="carousel-caption">
+            <p className="carousel-title">{active.title}</p>
+            <p className="carousel-description">{active.description}</p>
+          </div>
+        </div>
 
-    function MailIcon() {
-      return (
-        <span className="brand-icon-shell inline-flex h-7 w-7 items-center justify-center rounded-lg p-1 shadow-sm">
-          <img className="brand-icon-img" src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxMDI0IiBoZWlnaHQ9IjEwMjQiIHZpZXdCb3g9IjAgMCAxMDI0IDEwMjQiPgogIDxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDI0IiBoZWlnaHQ9IjEwMjQiIHJ4PSIxNTMiIHJ5PSIxNTMiIGZpbGw9IiNGRjZGNzkiLz4KICA8cGF0aCBkPSJNMCwwIEw5NSwwIEwxMDMsNiBMMTIyLDI1IEwxMjIsMjcgTDEyNCwyNyBMMTMxLDM1IEwxMzgsNDEgTDE0NSw0OSBMMTU2LDYwIEwxNTgsNjQgTDE1OCwxNDAgTDE1NCwxNDYgTDExOCwxODIgTDExMSwxOTAgTDMzLDI2OCBMMzEsMjY4IEwzMCwyNzEgTDI5LDMwMyBMMjc3LDMwMiBMMjg4LDI4NiBMMzAyLDI2NyBMMzA5LDI1NyBMMzIzLDIzOCBMMzM1LDIyMSBMMzQ4LDIwMyBMMzYyLDE4NCBMMzc0LDE2NyBMMzg3LDE0OSBMMzkzLDE0MSBMMzk4LDEzOCBMNDA1LDEzOCBMNDExLDE0MiBMNDEzLDE0NiBMNDEzLDE1MyBMNDA3LDE2MyBMMzk3LDE3NiBMMzg4LDE4OSBMMzc1LDIwNyBMMzYzLDIyNCBMMzQ5LDI0MyBMMzM2LDI2MSBMMzIyLDI4MSBMMzA4LDMwMCBMMzA3LDMwMiBMNDA2LDMwMyBMNDEyLDMwNyBMNDE0LDMxMSBMNDE0LDMxOSBMNDA3LDMyNyBMMzkwLDM0NCBMMzgyLDM1MSBMMzY1LDM2OCBMMzU3LDM3NSBMMzQyLDM5MCBMMzM0LDM5NyBMMzEzLDQxOCBMMzA1LDQyNSBMMjkyLDQzOCBMMjkwLDQzOCBMMjkwLDQ0MCBMMjgyLDQ0NyBMMjY1LDQ2NCBMMjU3LDQ3MSBMMjQwLDQ4OCBMMjMyLDQ5NSBMMjE0LDUxMyBMMjA2LDUyMCBMMTkzLDUzMyBMMTkyLDcxMyBMMjgzLDcxMyBMMjg5LDcxOCBMMjkwLDcyMCBMMjkwLDczMCBMMjg1LDczNiBMMjgyLDczNyBMNzgsNzM3IEw3Miw3MzMgTDcwLDczMCBMNzAsNzIwIEw3NSw3MTQgTDc4LDcxMyBMMTY4LDcxMyBMMTY3LDUzMyBMMTUxLDUxNyBMMTQzLDUxMCBMMTIwLDQ4NyBMMTEyLDQ4MCBMOTksNDY3IEw5MSw0NjAgTDcxLDQ0MCBMNjMsNDMzIEw0Nyw0MTcgTDQyLDQxMyBMMzcsNDA4IEwxOCwzODkgTDEwLDM4MiBMLTcsMzY1IEwtMTUsMzU4IEwtMjcsMzQ2IEwtMzUsMzM5IEwtNTMsMzIxIEwtNTQsMzE5IEwtNTQsMjQwIEwtNTEsMjM1IEwtMzEsMjE1IEwtMjYsMjEwIEwtMTYsMjAwIEwtOSwxOTIgTC00LDE4NyBMLTEsMTg2IEwtMSwxODQgTDEsMTg0IEwzLDE4MCBMOSwxNzUgTDE2LDE2NyBMMjMsMTYwIEwyOCwxNTUgTDY0LDExOSBMNjUsOTQgTDExLDk1IEwzLDEwMiBMLTQsMTEwIEwtMTIsMTE3IEwtMTQsMTIwIEwtMTUsMTY3IEwtMTgsMTcyIEwtMjEsMTc1IEwtMzAsMTc2IEwtMzcsMTcyIEwtMzksMTY4IEwtNDMsMTY2IEwtNzYsMTMzIEwtNzgsMTI5IEwtNzgsNzcgTC03NCw3MSBMLTY5LDY2IEwtNjcsNjYgTC02Nyw2NCBMLTY1LDY0IEwtNjUsNjIgTC02Myw2MiBMLTYxLDU4IEwtNTEsNDggTC00Myw0MSBMLTM2LDM0IEwtMjksMjYgTC0xNCwxMiBMLTMsMSBaICIgZmlsbD0iI0ZERkFGNiIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMzQ0LDE1NSkiLz4KICA8cGF0aCBkPSJNMCwwIEwyNjgsMCBMMjY2LDUgTDI1NCwyMSBMMjQyLDM4IEwyMjksNTYgTDIxNiw3NCBMMjAzLDkyIEwxOTAsMTEwIEwxODAsMTI0IEwxNzksMTMyIEwxODIsMTM4IEwxODYsMTQwIEwxOTQsMTQwIEwxOTksMTM3IEwyMTAsMTIxIEwyMjMsMTAzIEwyMzYsODUgTDI0OSw2NyBMMjYzLDQ4IEwyNzcsMjggTDI5MSw5IEwyOTgsMCBMMzgxLDAgTDM3NSw3IEwzNjMsMTkgTDM1NSwyNiBMMzM4LDQzIEwzMzAsNTAgTDMxNCw2NiBMMzA2LDczIEwyODksOTAgTDI4MSw5NyBMMjYzLDExNSBMMjYxLDExNSBMMjU5LDExOSBMMjUxLDEyNiBMMjQwLDEzNyBMMjM0LDE0MiBMMjI5LDE0NyBMMjExLDE2NSBMMjAzLDE3MiBMMTkxLDE4NCBMMTg3LDE4MiBMMTcxLDE2NiBMMTYzLDE1OSBMMTQyLDEzOCBMMTM0LDEzMSBMMTE3LDExNCBMMTA5LDEwNyBMOTAsODggTDgyLDgxIEw2NSw2NCBMNTcsNTcgTDQxLDQxIEwzMywzNCBMMTYsMTcgTDgsMTAgTDAsMiBaICIgZmlsbD0iI0ZGNkY3OSIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMzM0LDQ4MikiLz4KICA8cGF0aCBkPSJNMCwwIEw4MCwwIEw5MCwxMCBMOTUsMTUgTDExMiwzMiBMMTE5LDQwIEwxMjgsNDkgTDEyOCwxMDkgTDEwNywxMzAgTDEwMiwxMzUgTDkxLDE0NyBMODUsMTUyIEw4NCwxNTQgTDgyLDE1NCBMODIsMTU2IEw3NywxNjAgTDcyLDE2NiBMNzAsMTY2IEw2OCwxNzAgTDU2LDE4MiBMNTQsMTgyIEw1NCwxODQgTDUyLDE4NCBMNTIsMTg2IEw1MCwxODYgTDUwLDE4OCBMNDUsMTkyIEwzOCwyMDAgTDI2LDIxMiBMMTksMjE4IEwxMiwyMjYgTDcsMjMwIEw2LDIzMiBMNCwyMzIgTDIsMjM2IEwwLDIzOSBMLTEsMjgwIEwtMzgsMjgwIEwtMzgsMjI1IEwtMTIsMTk5IEwtNywxOTQgTDQsMTgzIEw5LDE3OCBMMjAsMTY3IEwyNywxNTkgTDc5LDEwNyBMODAsMTA0IEw4MCw1NiBMNzgsNTEgTDczLDQ5IEwtNSw0OSBMLTEyLDU0IEwtMTgsNjEgTC0yNiw2OCBMLTMxLDczIEwtMzgsODEgTC00Myw4NiBMLTQ0LDg4IEwtNDUsMTEzIEwtNTIsMTA3IEwtNjAsMTAwIEwtNjIsOTcgTC02Miw2MiBaICIgZmlsbD0iI0ZGNkY3OSIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMzUxLDE3OCkiLz4KPC9zdmc+" alt="" />
-        </span>
-      );
-    }
-
-    function HeroWords({ text }) {
-      const words = text.includes('|') ? text.split('|') : text.split(' ');
-      return (
-        <>
-          {words.map((word, index) => (
-            <span
-              key={`${word}-${index}`}
-              className="hero-title-word animate-reveal"
-              style={{ animationDelay: `${index * 75}ms`, opacity: 0 }}
-            >
-              {word === '続く' ? <em className="hero-title-em">{word}</em> : word}
-            </span>
+        <div className="carousel-dots">
+          {carouselImages.map((item, index) => (
+            <button
+              key={item.title}
+              type="button"
+              aria-label={`${item.title}を表示`}
+              className={`carousel-dot ${index === activeIndex ? "is-active" : ""}`}
+              onClick={() => setActiveIndex(index)}
+            />
           ))}
-        </>
-      );
-    }
+        </div>
+      </div>
+    </div>
+  );
+}
 
-    const carouselImages = [
-      {
-        src: `images/desktop-learn.png`,
-        title: `PCでの学習画面`,
-        description: `大きなカードで、単語と意味に集中できます。`,
-        kind: `desktop`,
-      },
-      {
-        src: `images/desktop-login.png`,
-        title: `ログイン画面`,
-        description: `Googleアカウントでスムーズに開始できます。`,
-        kind: `desktop`,
-      },
-      {
-        src: `images/mobile-manage.png`,
-        title: `モバイル管理画面`,
-        description: `スマホでもカードグループを確認できます。`,
-        kind: `mobile`,
-      },
-      {
-        src: `images/mobile-learn.png`,
-        title: `モバイル学習画面`,
-        description: `移動中でも片手で復習できます。`,
-        kind: `mobile`,
-      }
-    ];
+function Hero() {
+  return (
+    <section className="hero-section mt-[var(--fib-7)] py-[var(--fib-7)] text-center md:mt-[var(--fib-8)] md:py-[var(--fib-7)]">
+      <h1 className="helvetica-title hero-title-jp mx-auto max-w-[var(--hero-title-max)] text-[30px] text-ink sm:text-[42px] md:text-[54px] lg:text-[60px]">
+        <HeroWords text="スワイプで続く|あなたの英単語学習コーチ" />
+      </h1>
 
-    function ProductPreview() {
-      const [activeIndex, setActiveIndex] = React.useState(0);
-      const active = carouselImages[activeIndex];
+      <p className="hero-copy animate-reveal" style={{ opacity: 0, animationDelay: "450ms" }}>
+        Flamingo
+        Armondは、覚えたい単語をスワイプ式のカードに変えて、苦手な英単語を効率よく復習できる学習アプリです。
+        <br />
+        退屈な暗記ではなく、毎日少しずつ続けられる英単語学習を。
+      </p>
 
-      React.useEffect(() => {
-        const timer = window.setInterval(() => {
-          setActiveIndex((current) => (current + 1) % carouselImages.length);
-        }, 4200);
-
-        return () => window.clearInterval(timer);
-      }, []);
-
-      return (
-        <div className="relative w-full animate-reveal" style={{ opacity: 0, animationDelay: '575ms' }}>
-          <div className="product-carousel-shell">
-            <div className="product-carousel-stage">
-              <button
-                type="button"
-                aria-label="前の画面"
-                className="carousel-nav carousel-nav-left"
-                onClick={() => setActiveIndex((activeIndex - 1 + carouselImages.length) % carouselImages.length)}
-              >
-                ‹
-              </button>
-
-              <div className="product-carousel-media" data-kind={active.kind}>
-                <img
-                  key={active.src}
-                  src={active.src}
-                  alt={active.title}
-                  className="product-carousel-image"
-                />
-              </div>
-
-              <button
-                type="button"
-                aria-label="次の画面"
-                className="carousel-nav carousel-nav-right"
-                onClick={() => setActiveIndex((activeIndex + 1) % carouselImages.length)}
-              >
-                ›
-              </button>
-
-              <div className="carousel-caption">
-                <p className="carousel-title">{active.title}</p>
-                <p className="carousel-description">{active.description}</p>
-              </div>
-            </div>
-
-            <div className="carousel-dots" aria-label="画面プレビュー切り替え">
-              {carouselImages.map((item, index) => (
-                <button
-                  key={item.title}
-                  type="button"
-                  aria-label={`${item.title}を表示`}
-                  className={`carousel-dot ${index === activeIndex ? 'is-active' : ''}`}
-                  onClick={() => setActiveIndex(index)}
-                />
-              ))}
-            </div>
+      <div className="mt-[var(--fib-5)] md:mt-[var(--fib-6)]">
+        <div className="hero-actions">
+          <div
+            className="flex animate-reveal items-center justify-center"
+            style={{ opacity: 0, animationDelay: "500ms" }}
+          >
+            <Button href="https://flamingo-armond-frontend.vercel.app/" className="hero-main-cta">
+              無料で始める
+            </Button>
           </div>
         </div>
-      );
-    }
 
+        <ProductPreview />
+      </div>
+    </section>
+  );
+}
 
-    function Hero() {
-      return (
-        <section className="hero-section mt-[var(--fib-7)] py-[var(--fib-7)] text-center md:mt-[var(--fib-8)] md:py-[var(--fib-7)]">
-          <h1 className="helvetica-title hero-title-jp mx-auto max-w-[var(--hero-title-max)] text-[30px] text-ink sm:text-[42px] md:text-[54px] lg:text-[60px]">
-            <HeroWords text="スワイプで続く|あなたの英単語学習コーチ" />
-          </h1>
-
-          <p className="hero-copy animate-reveal" style={{ opacity: 0, animationDelay: '450ms' }}>
-            Flamingo Armondは、覚えたい単語をスワイプ式のカードに変えて、苦手な英単語を効率よく復習できる学習アプリです。<br />
-            退屈な暗記ではなく、毎日少しずつ続けられる英単語学習を。
+function SectionVisual({ type }) {
+  if (type === "organized") {
+    return (
+      <div className="review-video-feature">
+        <div className="review-video-copy">
+          <p className="review-video-eyebrow">Review Flow</p>
+          <h3>迷ったカードだけ、次の復習に残る。</h3>
+          <p>
+            右へ、左へ、迷ったら保留。
+            <br />
+            毎回の判断が学習履歴になり、次に見るべきカードを自動で整理します。
           </p>
 
-          <div className="mt-[var(--fib-5)] md:mt-[var(--fib-6)]">
-            <div className="hero-actions">
-              <div className="flex animate-reveal items-center justify-center" style={{ opacity: 0, animationDelay: '500ms' }}>
-                <Button href="https://flamingo-armond-frontend.vercel.app/" className="hero-main-cta">無料で始める</Button>
-              </div>
-
-            </div>
-
-            <ProductPreview />
-          </div>
-        </section>
-      );
-    }
-
-    function SectionVisual({ type }) {
-      if (type === 'organized') {
-        return (
-          <div className="review-video-feature">
-            <div className="review-video-copy">
-              <p className="review-video-eyebrow">Review Flow</p>
-              <h3>迷ったカードだけ、次の復習に残る。</h3>
-              <p>
-                右へ、左へ、迷ったら保留。<br />
-                毎回の判断が学習履歴になり、次に見るべきカードを自動で整理します。
-              </p>
-
-              <div className="review-video-stats">
-                <div>
-                  <strong>Swipe</strong>
-                  <span>知っているかを記録</span>
-                </div>
-                <div>
-                  <strong>Review queue</strong>
-                  <span>復習候補を自動更新</span>
-                </div>
-              </div>
-            </div>
-
-            <div className="review-video-device" aria-label="Flamingo Armondの学習デモ動画">
-              <div className="review-video-phone">
-                <div className="review-video-screen">
-                  <video
-                    src="videos/learn-demo.mp4"
-                    className="review-video"
-                    autoPlay
-                    muted
-                    loop
-                    playsInline
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
-        );
-      }
-
-      if (type === 'drafts') {
-        return (
-          <div className="review-video-feature cardgroup-video-feature is-reversed">
-            <div className="review-video-copy">
-              <p className="review-video-eyebrow">Card Groups</p>
-              <h3>カードグループで、目的別に管理。</h3>
-              <p>
-                教材やスプレッドシートの単語をCSVで一括インポート。<br />
-                タグやカテゴリで英検・TOEIC・受験用に整理し、開いた瞬間に復習できる状態をつくれます。
-              </p>
-
-              <div className="review-video-stats">
-                <div>
-                  <strong>Import</strong>
-                  <span>CSVから一括追加</span>
-                </div>
-                <div>
-                  <strong>Groups</strong>
-                  <span>試験・教材ごとにカードグループを管理</span>
-                </div>
-              </div>
-            </div>
-
-            <div className="review-video-device" aria-label="カードグループ管理のデモ動画">
-              <div className="review-video-phone">
-                <div className="review-video-screen">
-                  <video
-                    src="videos/cardgroup-demo.mp4"
-                    className="review-video"
-                    autoPlay
-                    muted
-                    loop
-                    playsInline
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
-        );
-      }
-
-      return null;
-    }
-
-    function FeatureSection({ item }) {
-      return (
-        <section id={item.visual === "organized" ? "review-flow" : item.visual === "drafts" ? "card-groups" : undefined} className="copy-section">
-          <h2 className="mx-auto helvetica-title text-[1.875rem] text-ink md:text-[2.5rem]">
-            {item.title}
-          </h2>
-          <p className="section-copy">
-            {item.description}
-          </p>
-          <div className="section-visual flex justify-center">
-            <SectionVisual type={item.visual} />
-          </div>
-        </section>
-      );
-    }
-
-
-    function Bento() {
-      return (
-        <section id="features" className="copy-section feature-principled-section">
-          <h2 className="mx-auto helvetica-title text-[1.875rem] text-ink md:text-[2.5rem]">
-            続けるために必要な機能を、ひとつに。
-          </h2>
-          <p className="section-copy">
-            軽い操作感と、本格的な学習管理。<br />
-            日本人の英語学習・資格対策・専門用語の暗記に使える設計です。
-          </p>
-
-          <div className="section-visual">
-            <div className="feature-steps-panel">
-              {bento.map((item, index) => (
-                <div key={item.title} className="feature-step-card">
-                  <div className="feature-step-card-copy">
-                    <div className="feature-step-badge">
-                      <span>{index + 1}</span>
-                    </div>
-
-                    <h3>{item.title}</h3>
-                    <p>{item.text}</p>
-                  </div>
-
-                  <div className="feature-step-card-visual">
-                    <div className="feature-step-icon">
-                      {item.icon === 'brand' ? <img className="h-6 w-6" src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxMDI0IiBoZWlnaHQ9IjEwMjQiIHZpZXdCb3g9IjAgMCAxMDI0IDEwMjQiPgogIDxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDI0IiBoZWlnaHQ9IjEwMjQiIHJ4PSIxNTMiIHJ5PSIxNTMiIGZpbGw9IiNGRjZGNzkiLz4KICA8cGF0aCBkPSJNMCwwIEw5NSwwIEwxMDMsNiBMMTIyLDI1IEwxMjIsMjcgTDEyNCwyNyBMMTMxLDM1IEwxMzgsNDEgTDE0NSw0OSBMMTU2LDYwIEwxNTgsNjQgTDE1OCwxNDAgTDE1NCwxNDYgTDExOCwxODIgTDExMSwxOTAgTDMzLDI2OCBMMzEsMjY4IEwzMCwyNzEgTDI5LDMwMyBMMjc3LDMwMiBMMjg4LDI4NiBMMzAyLDI2NyBMMzA5LDI1NyBMMzIzLDIzOCBMMzM1LDIyMSBMMzQ4LDIwMyBMMzYyLDE4NCBMMzc0LDE2NyBMMzg3LDE0OSBMMzkzLDE0MSBMMzk4LDEzOCBMNDA1LDEzOCBMNDExLDE0MiBMNDEzLDE0NiBMNDEzLDE1MyBMNDA3LDE2MyBMMzk3LDE3NiBMMzg4LDE4OSBMMzc1LDIwNyBMMzYzLDIyNCBMMzQ5LDI0MyBMMzM2LDI2MSBMMzIyLDI4MSBMMzA4LDMwMCBMMzA3LDMwMiBMNDA2LDMwMyBMNDEyLDMwNyBMNDE0LDMxMSBMNDE0LDMxOSBMNDA3LDMyNyBMMzkwLDM0NCBMMzgyLDM1MSBMMzY1LDM2OCBMMzU3LDM3NSBMMzQyLDM5MCBMMzM0LDM5NyBMMzEzLDQxOCBMMzA1LDQyNSBMMjkyLDQzOCBMMjkwLDQzOCBMMjkwLDQ0MCBMMjgyLDQ0NyBMMjY1LDQ2NCBMMjU3LDQ3MSBMMjQwLDQ4OCBMMjMyLDQ5NSBMMjE0LDUxMyBMMjA2LDUyMCBMMTkzLDUzMyBMMTkyLDcxMyBMMjgzLDcxMyBMMjg5LDcxOCBMMjkwLDcyMCBMMjkwLDczMCBMMjg1LDczNiBMMjgyLDczNyBMNzgsNzM3IEw3Miw3MzMgTDcwLDczMCBMNzAsNzIwIEw3NSw3MTQgTDc4LDcxMyBMMTY4LDcxMyBMMTY3LDUzMyBMMTUxLDUxNyBMMTQzLDUxMCBMMTIwLDQ4NyBMMTEyLDQ4MCBMOTksNDY3IEw5MSw0NjAgTDcxLDQ0MCBMNjMsNDMzIEw0Nyw0MTcgTDQyLDQxMyBMMzcsNDA4IEwxOCwzODkgTDEwLDM4MiBMLTcsMzY1IEwtMTUsMzU4IEwtMjcsMzQ2IEwtMzUsMzM5IEwtNTMsMzIxIEwtNTQsMzE5IEwtNTQsMjQwIEwtNTEsMjM1IEwtMzEsMjE1IEwtMjYsMjEwIEwtMTYsMjAwIEwtOSwxOTIgTC00LDE4NyBMLTEsMTg2IEwtMSwxODQgTDEsMTg0IEwzLDE4MCBMOSwxNzUgTDE2LDE2NyBMMjMsMTYwIEwyOCwxNTUgTDY0LDExOSBMNjUsOTQgTDExLDk1IEwzLDEwMiBMLTQsMTEwIEwtMTIsMTE3IEwtMTQsMTIwIEwtMTUsMTY3IEwtMTgsMTcyIEwtMjEsMTc1IEwtMzAsMTc2IEwtMzcsMTcyIEwtMzksMTY4IEwtNDMsMTY2IEwtNzYsMTMzIEwtNzgsMTI5IEwtNzgsNzcgTC03NCw3MSBMLTY5LDY2IEwtNjcsNjYgTC02Nyw2NCBMLTY1LDY0IEwtNjUsNjIgTC02Myw2MiBMLTYxLDU4IEwtNTEsNDggTC00Myw0MSBMLTM2LDM0IEwtMjksMjYgTC0xNCwxMiBMLTMsMSBaICIgZmlsbD0iI0ZERkFGNiIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMzQ0LDE1NSkiLz4KICA8cGF0aCBkPSJNMCwwIEwyNjgsMCBMMjY2LDUgTDI1NCwyMSBMMjQyLDM4IEwyMjksNTYgTDIxNiw3NCBMMjAzLDkyIEwxOTAsMTEwIEwxODAsMTI0IEwxNzksMTMyIEwxODIsMTM4IEwxODYsMTQwIEwxOTQsMTQwIEwxOTksMTM3IEwyMTAsMTIxIEwyMjMsMTAzIEwyMzYsODUgTDI0OSw2NyBMMjYzLDQ4IEwyNzcsMjggTDI5MSw5IEwyOTgsMCBMMzgxLDAgTDM3NSw3IEwzNjMsMTkgTDM1NSwyNiBMMzM4LDQzIEwzMzAsNTAgTDMxNCw2NiBMMzA2LDczIEwyODksOTAgTDI4MSw5NyBMMjYzLDExNSBMMjYxLDExNSBMMjU5LDExOSBMMjUxLDEyNiBMMjQwLDEzNyBMMjM0LDE0MiBMMjI5LDE0NyBMMjExLDE2NSBMMjAzLDE3MiBMMTkxLDE4NCBMMTg3LDE4MiBMMTcxLDE2NiBMMTYzLDE1OSBMMTQyLDEzOCBMMTM0LDEzMSBMMTE3LDExNCBMMTA5LDEwNyBMOTAsODggTDgyLDgxIEw2NSw2NCBMNTcsNTcgTDQxLDQxIEwzMywzNCBMMTYsMTcgTDgsMTAgTDAsMiBaICIgZmlsbD0iI0ZGNkY3OSIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMzM0LDQ4MikiLz4KICA8cGF0aCBkPSJNMCwwIEw4MCwwIEw5MCwxMCBMOTUsMTUgTDExMiwzMiBMMTE5LDQwIEwxMjgsNDkgTDEyOCwxMDkgTDEwNywxMzAgTDEwMiwxMzUgTDkxLDE0NyBMODUsMTUyIEw4NCwxNTQgTDgyLDE1NCBMODIsMTU2IEw3NywxNjAgTDcyLDE2NiBMNzAsMTY2IEw2OCwxNzAgTDU2LDE4MiBMNTQsMTgyIEw1NCwxODQgTDUyLDE4NCBMNTIsMTg2IEw1MCwxODYgTDUwLDE4OCBMNDUsMTkyIEwzOCwyMDAgTDI2LDIxMiBMMTksMjE4IEwxMiwyMjYgTDcsMjMwIEw2LDIzMiBMNCwyMzIgTDIsMjM2IEwwLDIzOSBMLTEsMjgwIEwtMzgsMjgwIEwtMzgsMjI1IEwtMTIsMTk5IEwtNywxOTQgTDQsMTgzIEw5LDE3OCBMMjAsMTY3IEwyNywxNTkgTDc5LDEwNyBMODAsMTA0IEw4MCw1NiBMNzgsNTEgTDczLDQ5IEwtNSw0OSBMLTEyLDU0IEwtMTgsNjEgTC0yNiw2OCBMLTMxLDczIEwtMzgsODEgTC00Myw4NiBMLTQ0LDg4IEwtNDUsMTEzIEwtNTIsMTA3IEwtNjAsMTAwIEwtNjIsOTcgTC02Miw2MiBaICIgZmlsbD0iI0ZGNkY3OSIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMzUxLDE3OCkiLz4KPC9zdmc+" alt="" /> : item.icon}
-                    </div>
-                  </div>
-                </div>
-              ))}
-            </div>
-          </div>
-        </section>
-      );
-    }
-
-
-    function Pricing() {
-      return (
-        <section id="pricing" className="copy-section">
-          <h2 className="mx-auto helvetica-title text-[1.875rem] text-ink md:text-[2.5rem]">
-            まずは無料ではじめられる。
-          </h2>
-          <p className="section-copy">
-            個人学習から本格的な試験対策まで、必要に応じて使い方を広げられます。
-          </p>
-
-          <div className="section-visual mx-auto grid max-w-4xl gap-[var(--fib-6)] md:grid-cols-2">
-            <div className="ratio-card p-[var(--fib-6)] text-left">
-              <p className="text-sm font-bold uppercase tracking-[0.18em] text-flamingo-500">無料</p>
-              <h3 className="mt-4 text-4xl font-black">¥0</h3>
-              <p className="mt-[var(--fib-4)] text-sm leading-[1.72] text-[#6e6e73]">スワイプカード、英単語管理、基本的な復習を無料で始められます。</p>
-              <Button href="https://flamingo-armond-frontend.vercel.app/" className="mt-8">始める</Button>
-            </div>
-            <div className="rounded-[var(--card-radius)] border border-flamingo-100 bg-gradient-to-b from-flamingo-50 to-white p-[var(--fib-6)] text-left shadow-float">
-              <p className="text-sm font-bold uppercase tracking-[0.18em] text-flamingo-600">Pro</p>
-              <h3 className="mt-4 text-4xl font-black">¥1,500<span className="text-base font-semibold text-[#6e6e73]"> / 月</span></h3>
-              <p className="mt-[var(--fib-4)] text-sm leading-[1.72] text-[#6e6e73]">詳細な進捗分析、大量インポート、タグ管理、復習キューなどをより深く使えます。</p>
-              <Button href="https://flamingo-armond-frontend.vercel.app/" className="mt-8">アップグレード</Button>
-            </div>
-          </div>
-        </section>
-      );
-    }
-
-    function CTA() {
-      return (
-        <section id="cta" className="copy-section final-cta-section">
-          <div className="relative overflow-hidden rounded-[var(--panel-radius)] border border-[#E7E7E780] bg-gradient-to-b from-white to-flamingo-50 px-[var(--fib-5)] py-[var(--fib-7)] shadow-soft md:py-[var(--fib-8)]">
-            <div className="absolute -left-24 -top-24 h-64 w-64 rounded-full bg-flamingo-100 blur-3xl"></div>
-            <div className="absolute -bottom-28 -right-20 h-64 w-64 rounded-full bg-flamingo-100 blur-3xl"></div>
-
-            <div className="relative mx-auto max-w-3xl">
-              <h2 className="helvetica-title text-[2rem] text-ink md:text-[3.25rem]">
-                続く英単語学習に。
-              </h2>
-              <p className="section-copy">
-                最初の単語カードを追加して、短いセッションをスワイプ。<br />
-                次に復習すべき単語は、Flamingo Armondがわかりやすく整理します。
-              </p>
-              <div className="mt-[var(--fib-6)] flex justify-center">
-                <Button href="https://flamingo-armond-frontend.vercel.app/">無料で始める</Button>
-              </div>
-            </div>
-          </div>
-        </section>
-      );
-    }
-
-    function Footer() {
-      return (
-        <footer className="border-t border-gray-100 pb-[var(--fib-8)] pt-[var(--fib-7)]">
-          <div className="page-shell flex flex-col justify-between gap-[var(--fib-6)] md:flex-row">
+          <div className="review-video-stats">
             <div>
-              <Logo />
-              <p className="mt-4 max-w-sm text-sm leading-6 text-[#6e6e73]">
-                スワイプで続ける英単語学習フラッシュカード。<br />
-                日本人学習者に向けた、軽くて続けやすい学習体験を届けます。
-              </p>
+              <strong>Swipe</strong>
+              <span>知っているかを記録</span>
             </div>
-
-            <div className="grid grid-cols-2 gap-[var(--fib-7)] text-sm md:gap-[var(--fib-8)]">
-              {[
-                ['プロダクト', ['機能', '料金']],
-                ['リソース', ['概要', 'GitHub']],
-              ].map(([title, links]) => (
-                <div key={title}>
-                  <p className="font-bold text-ink">{title}</p>
-                  <div className="mt-[var(--fib-4)] grid gap-[var(--fib-4)] text-[#6e6e73]">
-                    {links.map((link) => {
-                      const isExternal = link === 'GitHub';
-                      return (
-                        <a
-                          key={link}
-                          href={isExternal ? 'https://github.com/yasuflatland-lf/flamingo-armond' : '#'}
-                          className="hover:text-flamingo-600"
-                          {...(isExternal ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
-                        >
-                          {link}
-                        </a>
-                      );
-                    })}
-                  </div>
-                </div>
-              ))}
+            <div>
+              <strong>Review queue</strong>
+              <span>復習候補を自動更新</span>
             </div>
           </div>
-
-          <div className="page-shell mt-[var(--fib-6)] text-sm text-gray-400">
-            © 2026 Flamingo Armond. All rights reserved.
-          </div>
-        </footer>
-      );
-    }
-
-    function App() {
-      return (
-        <div className="pt-[var(--fib-5)]">
-          <Header />
-          <main className="page-shell isolate">
-            <Hero />
-            {featureSections.map((section) => <FeatureSection key={section.visual} item={section} />)}
-            <Bento />
-            <Pricing />
-            <CTA />
-          </main>
-          <Footer />
         </div>
-      );
-    }
+
+        <div className="review-video-device">
+          <div className="review-video-phone">
+            <div className="review-video-screen">
+              <video
+                src="videos/learn-demo.mp4"
+                className="review-video"
+                autoPlay
+                muted
+                loop
+                playsInline
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (type === "drafts") {
+    return (
+      <div className="review-video-feature cardgroup-video-feature is-reversed">
+        <div className="review-video-copy">
+          <p className="review-video-eyebrow">Card Groups</p>
+          <h3>カードグループで、目的別に管理。</h3>
+          <p>
+            教材やスプレッドシートの単語をCSVで一括インポート。
+            <br />
+            タグやカテゴリで英検・TOEIC・受験用に整理し、開いた瞬間に復習できる状態をつくれます。
+          </p>
+
+          <div className="review-video-stats">
+            <div>
+              <strong>Import</strong>
+              <span>CSVから一括追加</span>
+            </div>
+            <div>
+              <strong>Groups</strong>
+              <span>試験・教材ごとにカードグループを管理</span>
+            </div>
+          </div>
+        </div>
+
+        <div className="review-video-device">
+          <div className="review-video-phone">
+            <div className="review-video-screen">
+              <video
+                src="videos/cardgroup-demo.mp4"
+                className="review-video"
+                autoPlay
+                muted
+                loop
+                playsInline
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return null;
+}
+
+function FeatureSection({ item }) {
+  return (
+    <section
+      id={
+        item.visual === "organized"
+          ? "review-flow"
+          : item.visual === "drafts"
+            ? "card-groups"
+            : undefined
+      }
+      className="copy-section"
+    >
+      <h2 className="mx-auto helvetica-title text-[1.875rem] text-ink md:text-[2.5rem]">
+        {item.title}
+      </h2>
+      <p className="section-copy">{item.description}</p>
+      <div className="section-visual flex justify-center">
+        <SectionVisual type={item.visual} />
+      </div>
+    </section>
+  );
+}
+
+function Bento() {
+  return (
+    <section id="features" className="copy-section feature-principled-section">
+      <h2 className="mx-auto helvetica-title text-[1.875rem] text-ink md:text-[2.5rem]">
+        続けるために必要な機能を、ひとつに。
+      </h2>
+      <p className="section-copy">
+        軽い操作感と、本格的な学習管理。
+        <br />
+        日本人の英語学習・資格対策・専門用語の暗記に使える設計です。
+      </p>
+
+      <div className="section-visual">
+        <div className="feature-steps-panel">
+          {bento.map((item, index) => (
+            <div key={item.title} className="feature-step-card">
+              <div className="feature-step-card-copy">
+                <div className="feature-step-badge">
+                  <span>{index + 1}</span>
+                </div>
+
+                <h3>{item.title}</h3>
+                <p>{item.text}</p>
+              </div>
+
+              <div className="feature-step-card-visual">
+                <div className="feature-step-icon">
+                  {item.icon === "brand" ? (
+                    <img
+                      className="h-6 w-6"
+                      src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxMDI0IiBoZWlnaHQ9IjEwMjQiIHZpZXdCb3g9IjAgMCAxMDI0IDEwMjQiPgogIDxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDI0IiBoZWlnaHQ9IjEwMjQiIHJ4PSIxNTMiIHJ5PSIxNTMiIGZpbGw9IiNGRjZGNzkiLz4KICA8cGF0aCBkPSJNMCwwIEw5NSwwIEwxMDMsNiBMMTIyLDI1IEwxMjIsMjcgTDEyNCwyNyBMMTMxLDM1IEwxMzgsNDEgTDE0NSw0OSBMMTU2LDYwIEwxNTgsNjQgTDE1OCwxNDAgTDE1NCwxNDYgTDExOCwxODIgTDExMSwxOTAgTDMzLDI2OCBMMzEsMjY4IEwzMCwyNzEgTDI5LDMwMyBMMjc3LDMwMiBMMjg4LDI4NiBMMzAyLDI2NyBMMzA5LDI1NyBMMzIzLDIzOCBMMzM1LDIyMSBMMzQ4LDIwMyBMMzYyLDE4NCBMMzc0LDE2NyBMMzg3LDE0OSBMMzkzLDE0MSBMMzk4LDEzOCBMNDA1LDEzOCBMNDExLDE0MiBMNDEzLDE0NiBMNDEzLDE1MyBMNDA3LDE2MyBMMzk3LDE3NiBMMzg4LDE4OSBMMzc1LDIwNyBMMzYzLDIyNCBMMzQ5LDI0MyBMMzM2LDI2MSBMMzIyLDI4MSBMMzA4LDMwMCBMMzA3LDMwMiBMNDA2LDMwMyBMNDEyLDMwNyBMNDE0LDMxMSBMNDE0LDMxOSBMNDA3LDMyNyBMMzkwLDM0NCBMMzgyLDM1MSBMMzY1LDM2OCBMMzU3LDM3NSBMMzQyLDM5MCBMMzM0LDM5NyBMMzEzLDQxOCBMMzA1LDQyNSBMMjkyLDQzOCBMMjkwLDQzOCBMMjkwLDQ0MCBMMjgyLDQ0NyBMMjY1LDQ2NCBMMjU3LDQ3MSBMMjQwLDQ4OCBMMjMyLDQ5NSBMMjE0LDUxMyBMMjA2LDUyMCBMMTkzLDUzMyBMMTkyLDcxMyBMMjgzLDcxMyBMMjg5LDcxOCBMMjkwLDcyMCBMMjkwLDczMCBMMjg1LDczNiBMMjgyLDczNyBMNzgsNzM3IEw3Miw3MzMgTDcwLDczMCBMNzAsNzIwIEw3NSw3MTQgTDc4LDcxMyBMMTY4LDcxMyBMMTY3LDUzMyBMMTUxLDUxNyBMMTQzLDUxMCBMMTIwLDQ4NyBMMTEyLDQ4MCBMOTksNDY3IEw5MSw0NjAgTDcxLDQ0MCBMNjMsNDMzIEw0Nyw0MTcgTDQyLDQxMyBMMzcsNDA4IEwxOCwzODkgTDEwLDM4MiBMLTcsMzY1IEwtMTUsMzU4IEwtMjcsMzQ2IEwtMzUsMzM5IEwtNTMsMzIxIEwtNTQsMzE5IEwtNTQsMjQwIEwtNTEsMjM1IEwtMzEsMjE1IEwtMjYsMjEwIEwtMTYsMjAwIEwtOSwxOTIgTC00LDE4NyBMLTEsMTg2IEwtMSwxODQgTDEsMTg0IEwzLDE4MCBMOSwxNzUgTDE2LDE2NyBMMjMsMTYwIEwyOCwxNTUgTDY0LDExOSBMNjUsOTQgTDExLDk1IEwzLDEwMiBMLTQsMTEwIEwtMTIsMTE3IEwtMTQsMTIwIEwtMTUsMTY3IEwtMTgsMTcyIEwtMjEsMTc1IEwtMzAsMTc2IEwtMzcsMTcyIEwtMzksMTY4IEwtNDMsMTY2IEwtNzYsMTMzIEwtNzgsMTI5IEwtNzgsNzcgTC03NCw3MSBMLTY5LDY2IEwtNjcsNjYgTC02Nyw2NCBMLTY1LDY0IEwtNjUsNjIgTC02Myw2MiBMLTYxLDU4IEwtNTEsNDggTC00Myw0MSBMLTM2LDM0IEwtMjksMjYgTC0xNCwxMiBMLTMsMSBaICIgZmlsbD0iI0ZERkFGNiIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMzQ0LDE1NSkiLz4KICA8cGF0aCBkPSJNMCwwIEwyNjgsMCBMMjY2LDUgTDI1NCwyMSBMMjQyLDM4IEwyMjksNTYgTDIxNiw3NCBMMjAzLDkyIEwxOTAsMTEwIEwxODAsMTI0IEwxNzksMTMyIEwxODIsMTM4IEwxODYsMTQwIEwxOTQsMTQwIEwxOTksMTM3IEwyMTAsMTIxIEwyMjMsMTAzIEwyMzYsODUgTDI0OSw2NyBMMjYzLDQ4IEwyNzcsMjggTDI5MSw5IEwyOTgsMCBMMzgxLDAgTDM3NSw3IEwzNjMsMTkgTDM1NSwyNiBMMzM4LDQzIEwzMzAsNTAgTDMxNCw2NiBMMzA2LDczIEwyODksOTAgTDI4MSw5NyBMMjYzLDExNSBMMjYxLDExNSBMMjU5LDExOSBMMjUxLDEyNiBMMjQwLDEzNyBMMjM0LDE0MiBMMjI5LDE0NyBMMjExLDE2NSBMMjAzLDE3MiBMMTkxLDE4NCBMMTg3LDE4MiBMMTcxLDE2NiBMMTYzLDE1OSBMMTQyLDEzOCBMMTM0LDEzMSBMMTE3LDExNCBMMTA5LDEwNyBMOTAsODggTDgyLDgxIEw2NSw2NCBMNTcsNTcgTDQxLDQxIEwzMywzNCBMMTYsMTcgTDgsMTAgTDAsMiBaICIgZmlsbD0iI0ZGNkY3OSIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMzM0LDQ4MikiLz4KICA8cGF0aCBkPSJNMCwwIEw4MCwwIEw5MCwxMCBMOTUsMTUgTDExMiwzMiBMMTE5LDQwIEwxMjgsNDkgTDEyOCwxMDkgTDEwNywxMzAgTDEwMiwxMzUgTDkxLDE0NyBMODUsMTUyIEw4NCwxNTQgTDgyLDE1NCBMODIsMTU2IEw3NywxNjAgTDcyLDE2NiBMNzAsMTY2IEw2OCwxNzAgTDU2LDE4MiBMNTQsMTgyIEw1NCwxODQgTDUyLDE4NCBMNTIsMTg2IEw1MCwxODYgTDUwLDE4OCBMNDUsMTkyIEwzOCwyMDAgTDI2LDIxMiBMMTksMjE4IEwxMiwyMjYgTDcsMjMwIEw2LDIzMiBMNCwyMzIgTDIsMjM2IEwwLDIzOSBMLTEsMjgwIEwtMzgsMjgwIEwtMzgsMjI1IEwtMTIsMTk5IEwtNywxOTQgTDQsMTgzIEw5LDE3OCBMMjAsMTY3IEwyNywxNTkgTDc5LDEwNyBMODAsMTA0IEw4MCw1NiBMNzgsNTEgTDczLDQ5IEwtNSw0OSBMLTEyLDU0IEwtMTgsNjEgTC0yNiw2OCBMLTMxLDczIEwtMzgsODEgTC00Myw4NiBMLTQ0LDg4IEwtNDUsMTEzIEwtNTIsMTA3IEwtNjAsMTAwIEwtNjIsOTcgTC02Miw2MiBaICIgZmlsbD0iI0ZGNkY3OSIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMzUxLDE3OCkiLz4KPC9zdmc+"
+                      alt=""
+                    />
+                  ) : (
+                    item.icon
+                  )}
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function Pricing() {
+  return (
+    <section id="pricing" className="copy-section">
+      <h2 className="mx-auto helvetica-title text-[1.875rem] text-ink md:text-[2.5rem]">
+        まずは無料ではじめられる。
+      </h2>
+      <p className="section-copy">
+        個人学習から本格的な試験対策まで、必要に応じて使い方を広げられます。
+      </p>
+
+      <div className="section-visual mx-auto grid max-w-4xl gap-[var(--fib-6)] md:grid-cols-2">
+        <div className="ratio-card p-[var(--fib-6)] text-left">
+          <p className="text-sm font-bold uppercase tracking-[0.18em] text-flamingo-500">無料</p>
+          <h3 className="mt-4 text-4xl font-black">¥0</h3>
+          <p className="mt-[var(--fib-4)] text-sm leading-[1.72] text-[#6e6e73]">
+            スワイプカード、英単語管理、基本的な復習を無料で始められます。
+          </p>
+          <Button href="https://flamingo-armond-frontend.vercel.app/" className="mt-8">
+            始める
+          </Button>
+        </div>
+        <div className="rounded-[var(--card-radius)] border border-flamingo-100 bg-gradient-to-b from-flamingo-50 to-white p-[var(--fib-6)] text-left shadow-float">
+          <p className="text-sm font-bold uppercase tracking-[0.18em] text-flamingo-600">Pro</p>
+          <h3 className="mt-4 text-4xl font-black">
+            ¥1,500<span className="text-base font-semibold text-[#6e6e73]"> / 月</span>
+          </h3>
+          <p className="mt-[var(--fib-4)] text-sm leading-[1.72] text-[#6e6e73]">
+            詳細な進捗分析、大量インポート、タグ管理、復習キューなどをより深く使えます。
+          </p>
+          <Button href="https://flamingo-armond-frontend.vercel.app/" className="mt-8">
+            アップグレード
+          </Button>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function CTA() {
+  return (
+    <section id="cta" className="copy-section final-cta-section">
+      <div className="relative overflow-hidden rounded-[var(--panel-radius)] border border-[#E7E7E780] bg-gradient-to-b from-white to-flamingo-50 px-[var(--fib-5)] py-[var(--fib-7)] shadow-soft md:py-[var(--fib-8)]">
+        <div className="absolute -left-24 -top-24 h-64 w-64 rounded-full bg-flamingo-100 blur-3xl"></div>
+        <div className="absolute -bottom-28 -right-20 h-64 w-64 rounded-full bg-flamingo-100 blur-3xl"></div>
+
+        <div className="relative mx-auto max-w-3xl">
+          <h2 className="helvetica-title text-[2rem] text-ink md:text-[3.25rem]">
+            続く英単語学習に。
+          </h2>
+          <p className="section-copy">
+            最初の単語カードを追加して、短いセッションをスワイプ。
+            <br />
+            次に復習すべき単語は、Flamingo Armondがわかりやすく整理します。
+          </p>
+          <div className="mt-[var(--fib-6)] flex justify-center">
+            <Button href="https://flamingo-armond-frontend.vercel.app/">無料で始める</Button>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function Footer() {
+  return (
+    <footer className="border-t border-gray-100 pb-[var(--fib-8)] pt-[var(--fib-7)]">
+      <div className="page-shell flex flex-col justify-between gap-[var(--fib-6)] md:flex-row">
+        <div>
+          <Logo />
+          <p className="mt-4 max-w-sm text-sm leading-6 text-[#6e6e73]">
+            スワイプで続ける英単語学習フラッシュカード。
+            <br />
+            日本人学習者に向けた、軽くて続けやすい学習体験を届けます。
+          </p>
+        </div>
+
+        <div className="grid grid-cols-2 gap-[var(--fib-7)] text-sm md:gap-[var(--fib-8)]">
+          {[
+            ["プロダクト", ["機能", "料金"]],
+            ["リソース", ["概要", "GitHub"]],
+          ].map(([title, links]) => (
+            <div key={title}>
+              <p className="font-bold text-ink">{title}</p>
+              <div className="mt-[var(--fib-4)] grid gap-[var(--fib-4)] text-[#6e6e73]">
+                {links.map((link) => {
+                  const isExternal = link === "GitHub";
+                  return (
+                    <a
+                      key={link}
+                      href={isExternal ? "https://github.com/yasuflatland-lf/flamingo-armond" : "#"}
+                      className="hover:text-flamingo-600"
+                      {...(isExternal ? { target: "_blank", rel: "noopener noreferrer" } : {})}
+                    >
+                      {link}
+                    </a>
+                  );
+                })}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="page-shell mt-[var(--fib-6)] text-sm text-gray-400">
+        © 2026 Flamingo Armond. All rights reserved.
+      </div>
+    </footer>
+  );
+}
+
+function App() {
+  return (
+    <div className="pt-[var(--fib-5)]">
+      <Header />
+      <main className="page-shell isolate">
+        <Hero />
+        {featureSections.map((section) => (
+          <FeatureSection key={section.visual} item={section} />
+        ))}
+        <Bento />
+        <Pricing />
+        <CTA />
+      </main>
+      <Footer />
+    </div>
+  );
+}
 
 export default App;

--- a/site/src/index.css
+++ b/site/src/index.css
@@ -2,2026 +2,2109 @@
 @tailwind components;
 @tailwind utilities;
 
-    html { scroll-behavior: smooth; }
-    body {
-      margin: 0;
-      background: #fff;
-      color: #242424;
-      font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", Helvetica, Arial, ui-sans-serif, system-ui, "Segoe UI", sans-serif;
-    }
-    .masked-marquee {
-      mask-image: linear-gradient(to right, transparent, black 10%, black 90%, transparent);
-      -webkit-mask-image: linear-gradient(to right, transparent, black 10%, black 90%, transparent);
-    }
-    .glass-play {
-      box-shadow: 0px 14.3px 38.74px 3.9px #0000001A, 0px 0px 4.16px 0px #0000000D;
-      backdrop-filter: blur(8px);
-    }
+html {
+  scroll-behavior: smooth;
+}
+body {
+  margin: 0;
+  background: #fff;
+  color: #242424;
+  font-family:
+    -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", Helvetica, Arial,
+    ui-sans-serif, system-ui, "Segoe UI", sans-serif;
+}
+.masked-marquee {
+  mask-image: linear-gradient(to right, transparent, black 10%, black 90%, transparent);
+  -webkit-mask-image: linear-gradient(to right, transparent, black 10%, black 90%, transparent);
+}
+.glass-play {
+  box-shadow:
+    0px 14.3px 38.74px 3.9px #0000001a,
+    0px 0px 4.16px 0px #0000000d;
+  backdrop-filter: blur(8px);
+}
 
-    :root {
-      /* Principal UI rhythm: Apple JP-inspired, tuned for 1920x1080 */
-      --fib-1: 0.1875rem;  /* 3px */
-      --fib-2: 0.3125rem;  /* 5px */
-      --fib-3: 0.5rem;     /* 8px */
-      --fib-4: 0.8125rem;  /* 13px */
-      --fib-5: 1.3125rem;  /* 21px */
-      --fib-6: 2.125rem;   /* 34px */
-      --fib-7: 3.4375rem;  /* 55px */
-      --fib-8: 5.5625rem;  /* 89px */
-      --fib-9: 9rem;       /* 144px */
+:root {
+  /* Principal UI rhythm: Apple JP-inspired, tuned for 1920x1080 */
+  --fib-1: 0.1875rem; /* 3px */
+  --fib-2: 0.3125rem; /* 5px */
+  --fib-3: 0.5rem; /* 8px */
+  --fib-4: 0.8125rem; /* 13px */
+  --fib-5: 1.3125rem; /* 21px */
+  --fib-6: 2.125rem; /* 34px */
+  --fib-7: 3.4375rem; /* 55px */
+  --fib-8: 5.5625rem; /* 89px */
+  --fib-9: 9rem; /* 144px */
 
-      --page-max: 72rem;           /* 1152px */
-      --module-max: 61.25rem;      /* 980px */
-      --wide-module-max: 68.75rem; /* 1100px */
-      --content-max: 40.5rem;
-      --narrow-copy-max: 36rem;
-      --hero-title-max: 44.5rem;
+  --page-max: 72rem; /* 1152px */
+  --module-max: 61.25rem; /* 980px */
+  --wide-module-max: 68.75rem; /* 1100px */
+  --content-max: 40.5rem;
+  --narrow-copy-max: 36rem;
+  --hero-title-max: 44.5rem;
 
-      --section-y: 6.25rem;         /* 100px */
-      --section-y-tight: 4.8125rem; /* 77px */
-      --section-y-sm: 3.4375rem;    /* 55px */
-      --module-gap: 4.25rem;        /* 68px */
+  --section-y: 6.25rem; /* 100px */
+  --section-y-tight: 4.8125rem; /* 77px */
+  --section-y-sm: 3.4375rem; /* 55px */
+  --module-gap: 4.25rem; /* 68px */
 
-      --card-gap: 1.875rem;
-      --card-radius: 1.875rem;
-      --panel-radius: 3rem;
+  --card-gap: 1.875rem;
+  --card-radius: 1.875rem;
+  --panel-radius: 3rem;
 
-      --title-tracking: -0.010em;
-      --title-word-space: 0.036em;
-      --title-line-height: 1.12;
+  --title-tracking: -0.01em;
+  --title-word-space: 0.036em;
+  --title-line-height: 1.12;
 
-      --section-title-tracking: -0.008em;
-      --section-title-word-space: 0.028em;
-      --section-title-line-height: 1.15;
+  --section-title-tracking: -0.008em;
+  --section-title-word-space: 0.028em;
+  --section-title-line-height: 1.15;
 
-      --body-tracking: 0;
-      --body-line-height: 1.72;
+  --body-tracking: 0;
+  --body-line-height: 1.72;
 
-      --hero-copy-gap: 2.125rem;
-      --hero-action-gap: 2.125rem;
-      --hero-after-actions: 5.5625rem;
+  --hero-copy-gap: 2.125rem;
+  --hero-action-gap: 2.125rem;
+  --hero-after-actions: 5.5625rem;
 
-      --button-y: 0.75rem;
-      --button-x: 1.875rem;
-      --button-text: .9375rem;
-    }
+  --button-y: 0.75rem;
+  --button-x: 1.875rem;
+  --button-text: 0.9375rem;
+}
 
-    .helvetica-title {
-      font-family: -apple-system, BlinkMacSystemFont, "SF Pro Display", "Helvetica Neue", Helvetica, Arial, ui-sans-serif, system-ui, sans-serif;
-      font-weight: 740;
-      letter-spacing: var(--title-tracking);
-      line-height: var(--title-line-height);
-      word-spacing: var(--title-word-space);
-      -webkit-font-smoothing: antialiased;
-      text-rendering: geometricPrecision;
-      font-kerning: normal;
-      font-feature-settings: "kern" 1, "palt" 1, "pwid" 1, "liga" 1;
-      text-wrap: balance;
-    }
+.helvetica-title {
+  font-family:
+    -apple-system, BlinkMacSystemFont, "SF Pro Display", "Helvetica Neue", Helvetica, Arial,
+    ui-sans-serif, system-ui, sans-serif;
+  font-weight: 740;
+  letter-spacing: var(--title-tracking);
+  line-height: var(--title-line-height);
+  word-spacing: var(--title-word-space);
+  -webkit-font-smoothing: antialiased;
+  text-rendering: geometricPrecision;
+  font-kerning: normal;
+  font-feature-settings:
+    "kern" 1,
+    "palt" 1,
+    "pwid" 1,
+    "liga" 1;
+  text-wrap: balance;
+}
 
-    .hero-title-word {
-      display: inline-block;
-      margin-right: var(--title-word-space);
-    }
+.hero-title-word {
+  display: inline-block;
+  margin-right: var(--title-word-space);
+}
 
-    .hero-title-word:last-child {
-      margin-right: 0;
-    }
+.hero-title-word:last-child {
+  margin-right: 0;
+}
 
-    .hero-title-em {
-      font-style: normal;
-      letter-spacing: -0.01em;
-      margin-left: 0;
-      margin-right: 0;
-    }
+.hero-title-em {
+  font-style: normal;
+  letter-spacing: -0.01em;
+  margin-left: 0;
+  margin-right: 0;
+}
 
-    .hero-title-jp {
-      text-align: center;
-      line-break: strict;
-      word-break: keep-all;
-      overflow-wrap: normal;
-    }
+.hero-title-jp {
+  text-align: center;
+  line-break: strict;
+  word-break: keep-all;
+  overflow-wrap: normal;
+}
 
-    .hero-title-jp .hero-title-word {
-      margin-right: var(--title-word-space);
-      margin-bottom: 0.06em;
-    }
+.hero-title-jp .hero-title-word {
+  margin-right: var(--title-word-space);
+  margin-bottom: 0.06em;
+}
 
-    section .helvetica-title:not(h1) {
-      max-width: 43.5rem;
-      margin-inline: auto;
-      font-weight: 720;
-      letter-spacing: var(--section-title-tracking);
-      line-height: var(--section-title-line-height);
-      word-spacing: var(--section-title-word-space);
-      font-feature-settings: "kern" 1, "palt" 1, "pwid" 1, "liga" 1;
-      text-wrap: balance;
-    }
+section .helvetica-title:not(h1) {
+  max-width: 43.5rem;
+  margin-inline: auto;
+  font-weight: 720;
+  letter-spacing: var(--section-title-tracking);
+  line-height: var(--section-title-line-height);
+  word-spacing: var(--section-title-word-space);
+  font-feature-settings:
+    "kern" 1,
+    "palt" 1,
+    "pwid" 1,
+    "liga" 1;
+  text-wrap: balance;
+}
 
+.helvetica-copy {
+  font-family:
+    -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", Helvetica, Arial,
+    ui-sans-serif, system-ui, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  letter-spacing: var(--body-tracking);
+  line-height: var(--body-line-height);
+  font-kerning: normal;
+  font-feature-settings:
+    "kern" 1,
+    "palt" 1,
+    "liga" 1;
+}
 
+.page-shell {
+  max-width: var(--page-max);
+  margin-inline: auto;
+  padding-inline: var(--fib-5);
+}
 
+@media (min-width: 1024px) {
+  .page-shell {
+    padding-inline: var(--fib-6);
+  }
+}
 
+@media (min-width: 1280px) {
+  .page-shell {
+    padding-inline: 0;
+  }
+}
 
-    .helvetica-copy {
-      font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", Helvetica, Arial, ui-sans-serif, system-ui, sans-serif;
-      -webkit-font-smoothing: antialiased;
-      letter-spacing: var(--body-tracking);
-      line-height: var(--body-line-height);
-      font-kerning: normal;
-      font-feature-settings: "kern" 1, "palt" 1, "liga" 1;
-    }
+.copy-section {
+  padding-block: var(--section-y-sm);
+  text-align: center;
+}
 
-    .page-shell {
-      max-width: var(--page-max);
-      margin-inline: auto;
-      padding-inline: var(--fib-5);
-    }
+@media (min-width: 768px) {
+  .copy-section {
+    padding-block: var(--section-y);
+  }
+}
 
-    @media (min-width: 1024px) {
-      .page-shell {
-        padding-inline: var(--fib-6);
-      }
-    }
+.copy-section + .copy-section {
+  padding-top: var(--section-y-tight);
+}
 
-    @media (min-width: 1280px) {
-      .page-shell {
-        padding-inline: 0;
-      }
-    }
+.section-copy {
+  max-width: var(--narrow-copy-max);
+  margin-inline: auto;
+  margin-top: var(--fib-5);
+  color: #6e6e73;
+  font-size: clamp(0.975rem, 1.08vw, 1.0625rem);
+  line-height: var(--body-line-height);
+  letter-spacing: 0;
+  font-feature-settings:
+    "kern" 1,
+    "palt" 1;
+  text-wrap: pretty;
+}
 
-    .copy-section {
-      padding-block: var(--section-y-sm);
-      text-align: center;
-    }
+.section-visual {
+  margin-top: var(--fib-7);
+}
 
-    @media (min-width: 768px) {
-      .copy-section {
-        padding-block: var(--section-y);
-      }
-    }
+@media (min-width: 768px) {
+  .section-visual {
+    margin-top: var(--fib-8);
+  }
+}
 
+.ratio-card {
+  border-radius: var(--card-radius);
+  border: 1px solid rgba(0, 0, 0, 0.06);
+  background: #fff;
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.025),
+    0 14px 34px rgba(0, 0, 0, 0.04);
+  overflow: hidden;
+}
 
+.ratio-panel {
+  border-radius: var(--panel-radius);
+  border: 1px solid rgba(0, 0, 0, 0.045);
+  background: #f5f5f7;
+  overflow: hidden;
+}
 
+.ratio-grid {
+  gap: var(--card-gap);
+}
 
+.hero-copy {
+  max-width: var(--narrow-copy-max);
+  margin-inline: auto;
+  margin-top: var(--hero-copy-gap);
+  color: #6e6e73;
+  font-size: clamp(0.975rem, 1.05vw, 1.0625rem);
+  line-height: var(--body-line-height);
+  letter-spacing: 0;
+  font-feature-settings:
+    "kern" 1,
+    "palt" 1;
+  text-wrap: pretty;
+}
 
-    .copy-section + .copy-section {
-      padding-top: var(--section-y-tight);
-    }
+.hero-actions {
+  margin-top: var(--hero-action-gap);
+  margin-bottom: var(--hero-after-actions);
+}
 
-    .section-copy {
-      max-width: var(--narrow-copy-max);
-      margin-inline: auto;
-      margin-top: var(--fib-5);
-      color: #6e6e73;
-      font-size: clamp(.975rem, 1.08vw, 1.0625rem);
-      line-height: var(--body-line-height);
-      letter-spacing: 0;
-      font-feature-settings: "kern" 1, "palt" 1;
-      text-wrap: pretty;
-    }
+.final-cta-section {
+  padding-bottom: var(--fib-7);
+}
 
+.final-cta-section + footer {
+  margin-top: 0;
+}
 
+footer {
+  margin-top: 0;
+}
 
+.brand-icon-img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
 
+.brand-icon-shell {
+  background: linear-gradient(180deg, #ff8068 0%, #ff5f4f 100%);
+  box-shadow: 0 2px 10px rgba(255, 95, 79, 0.18);
+}
 
-    .section-visual {
-      margin-top: var(--fib-7);
-    }
-
-    @media (min-width: 768px) {
-      .section-visual {
-        margin-top: var(--fib-8);
-      }
-    }
-
-    .ratio-card {
-      border-radius: var(--card-radius);
-      border: 1px solid rgba(0, 0, 0, 0.06);
-      background: #fff;
-      box-shadow: 0 1px 2px rgba(0,0,0,.025), 0 14px 34px rgba(0,0,0,.04);
-      overflow: hidden;
-    }
-
-    .ratio-panel {
-      border-radius: var(--panel-radius);
-      border: 1px solid rgba(0,0,0,.045);
-      background: #f5f5f7;
-      overflow: hidden;
-    }
-
-    .ratio-grid {
-      gap: var(--card-gap);
-    }
-
-    .hero-copy {
-      max-width: var(--narrow-copy-max);
-      margin-inline: auto;
-      margin-top: var(--hero-copy-gap);
-      color: #6e6e73;
-      font-size: clamp(.975rem, 1.05vw, 1.0625rem);
-      line-height: var(--body-line-height);
-      letter-spacing: 0;
-      font-feature-settings: "kern" 1, "palt" 1;
-      text-wrap: pretty;
-    }
-
-
-
-
-
-    .hero-actions {
-      margin-top: var(--hero-action-gap);
-      margin-bottom: var(--hero-after-actions);
-    }
-
-    .final-cta-section {
-      padding-bottom: var(--fib-7);
-    }
-
-    .final-cta-section + footer {
-      margin-top: 0;
-    }
-
-    footer {
-      margin-top: 0;
-    }
-
-    .brand-icon-img {
-      display: block;
-      width: 100%;
-      height: 100%;
-      object-fit: contain;
-    }
-
-    .brand-icon-shell {
-      background: linear-gradient(180deg, #ff8068 0%, #ff5f4f 100%);
-      box-shadow: 0 2px 10px rgba(255, 95, 79, 0.18);
-    }
-
-    /* Mobile dropdown menu: force an opaque surface so page content never
+/* Mobile dropdown menu: force an opaque surface so page content never
        bleeds through. Plain CSS (not the `bg-white` utility) so the fill is
        independent of Tailwind's runtime JIT timing and opacity tokens. */
-    .mobile-menu-panel {
-      background-color: #fff;
-    }
-
-  
-    /* Senior spacing pass: golden-ratio / Fibonacci refinement */
-    .hero-title-jp {
-      max-width: var(--hero-title-max);
-      margin-inline: auto;
-    }
-
-    .hero-title-jp .hero-title-word {
-      margin-right: var(--title-word-space);
-    }
-
-    .hero-copy {
-      max-width: var(--content-max);
-    }
-
-    .hero-actions + .relative,
-    .hero-actions + div {
-      margin-top: 0;
-    }
-
-    .section-copy {
-      max-width: var(--content-max);
-    }
-
-    .ratio-card,
-    .ratio-panel {
-      overflow: hidden;
-    }
-
-    .ratio-grid {
-      gap: var(--card-gap);
-    }
-
-    @media (min-width: 768px) {
-      .ratio-grid {
-        gap: var(--fib-6);
-      }
-    }
-
-    .copy-section + .copy-section {
-      padding-top: calc(var(--section-y) * 0.72);
-    }
-
-    .final-cta-section {
-      padding-bottom: var(--fib-7);
-    }
-
-    .final-cta-section + footer {
-      margin-top: 0;
-    }
-
-    footer {
-      margin-top: 0;
-    }
-
-    @media (min-width: 768px) {
-      .final-cta-section {
-        padding-bottom: var(--fib-7); /* 55px: enough air, no dead zone */
-      }
-    }
-
-  
-
-  
-    .product-carousel-shell {
-      width: 100%;
-      border-radius: var(--panel-radius);
-      border: 1px solid rgba(0,0,0,.055);
-      background: #f5f5f7;
-      padding: var(--fib-4);
-      box-shadow: 0 1px 2px rgba(0,0,0,.025), 0 20px 55px rgba(0,0,0,.045);
-    }
-
-    .product-carousel-stage {
-      position: relative;
-      height: clamp(420px, 52vw, 640px);
-      overflow: hidden;
-      border-radius: calc(var(--panel-radius) - var(--fib-4));
-      background: #fff;
-      border: 1px solid rgba(0,0,0,.055);
-      display: flex;
-      align-items: center;
-      justify-content: center;
-    }
-
-    .product-carousel-media {
-      width: 100%;
-      height: 100%;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      padding: clamp(18px, 3vw, 55px);
-    }
-
-    .product-carousel-media[data-kind="mobile"] {
-      padding: clamp(21px, 4vw, 55px);
-    }
-
-    .product-carousel-image {
-      max-width: 100%;
-      max-height: 100%;
-      object-fit: contain;
-      border-radius: 21px;
-      box-shadow: 0 12px 44px rgba(0,0,0,.08);
-      animation: carouselFade .38s ease both;
-    }
-
-    .product-carousel-media[data-kind="mobile"] .product-carousel-image {
-      max-width: min(330px, 46%);
-      border-radius: 21px;
-    }
-
-    .carousel-caption {
-      position: absolute;
-      left: var(--fib-6);
-      bottom: var(--fib-6);
-      max-width: min(420px, calc(100% - 110px));
-      border-radius: 999px;
-      background: rgba(255,255,255,.82);
-      border: 1px solid rgba(0,0,0,.055);
-      backdrop-filter: blur(18px);
-      padding: 13px 21px;
-      text-align: left;
-      box-shadow: 0 8px 28px rgba(0,0,0,.06);
-    }
-
-    .carousel-title {
-      margin: 0;
-      color: #1d1d1f;
-      font-size: 14px;
-      font-weight: 700;
-      letter-spacing: 0;
-      line-height: 1.35;
-    }
-
-    .carousel-description {
-      margin: 3px 0 0;
-      color: #6e6e73;
-      font-size: 13px;
-      line-height: 1.45;
-    }
-
-    .carousel-nav {
-      position: absolute;
-      z-index: 4;
-      top: 50%;
-      transform: translateY(-50%);
-      width: 44px;
-      height: 44px;
-      border-radius: 999px;
-      border: 1px solid rgba(0,0,0,.08);
-      background: rgba(255,255,255,.78);
-      color: #1d1d1f;
-      font-size: 30px;
-      line-height: 1;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      box-shadow: 0 8px 28px rgba(0,0,0,.07);
-      backdrop-filter: blur(18px);
-      transition: background .2s ease, transform .2s ease;
-    }
-
-    .carousel-nav:hover {
-      background: #fff;
-      transform: translateY(-50%) scale(1.04);
-    }
-
-    .carousel-nav-left { left: var(--fib-5); }
-    .carousel-nav-right { right: var(--fib-5); }
-
-    .carousel-dots {
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      gap: var(--fib-3);
-      padding-top: var(--fib-5);
-    }
-
-    .carousel-dot {
-      width: 7px;
-      height: 7px;
-      border-radius: 999px;
-      background: #d2d2d7;
-      transition: width .25s ease, background .25s ease;
-    }
-
-    .carousel-dot.is-active {
-      width: 21px;
-      background: #ff5f4f;
-    }
-
-    @keyframes carouselFade {
-      from { opacity: 0; transform: translateY(8px) scale(.985); }
-      to { opacity: 1; transform: translateY(0) scale(1); }
-    }
-
-    @media (max-width: 767px) {
-      .product-carousel-shell {
-        padding: var(--fib-3);
-        border-radius: var(--fib-6);
-      }
-
-      .product-carousel-stage {
-        height: 560px;
-        border-radius: calc(var(--fib-6) - var(--fib-3));
-      }
-
-      .product-carousel-media[data-kind="desktop"] .product-carousel-image {
-        max-width: 100%;
-      }
-
-      .product-carousel-media[data-kind="mobile"] .product-carousel-image {
-        max-width: min(280px, 82%);
-      }
-
-      .carousel-caption {
-        left: var(--fib-5);
-        right: var(--fib-5);
-        bottom: var(--fib-5);
-        max-width: none;
-        border-radius: 21px;
-      }
-
-      .carousel-nav { display: none; }
-    }
-
-  
-    .section-visual .product-carousel-stage {
-      height: clamp(420px, 48vw, 610px);
-    }
-
-    .section-visual .product-carousel-shell {
-      max-width: 100%;
-    }
-
-  
-    .review-video-feature {
-      position: relative;
-      width: 100%;
-      min-height: clamp(640px, 74vw, 860px);
-      overflow: hidden;
-      border-radius: var(--panel-radius);
-      border: 1px solid rgba(0,0,0,.055);
-      background:
-        radial-gradient(circle at 72% 24%, rgba(255, 95, 79, .18), transparent 34%),
-        linear-gradient(180deg, #f5f5f7 0%, #ffffff 58%, #f5f5f7 100%);
-      box-shadow: 0 1px 2px rgba(0,0,0,.025), 0 28px 70px rgba(0,0,0,.045);
-      display: grid;
-      grid-template-columns: minmax(0, 1fr) minmax(300px, .78fr);
-      align-items: center;
-      gap: var(--fib-8);
-      padding: clamp(55px, 6vw, 89px) clamp(34px, 6vw, 89px);
-      text-align: left;
-    }
-
-    .review-video-copy {
-      position: relative;
-      z-index: 2;
-      max-width: 520px;
-    }
-
-    .review-video-eyebrow {
-      margin: 0 0 var(--fib-4);
-      color: #ff5f4f;
-      font-size: 13px;
-      font-weight: 700;
-      letter-spacing: .08em;
-      text-transform: uppercase;
-    }
-
-    .review-video-copy h3 {
-      margin: 0;
-      color: #1d1d1f;
-      font-family: -apple-system, BlinkMacSystemFont, "SF Pro Display", "Helvetica Neue", Helvetica, Arial, sans-serif;
-      font-size: clamp(32px, 4.2vw, 64px);
-      font-weight: 740;
-      line-height: 1.08;
-      letter-spacing: -0.012em;
-      font-feature-settings: "palt" 1, "kern" 1;
-      text-wrap: balance;
-    }
-
-    .review-video-copy p:not(.review-video-eyebrow) {
-      margin: var(--fib-6) 0 0;
-      color: #6e6e73;
-      font-size: clamp(16px, 1.45vw, 19px);
-      line-height: 1.72;
-      letter-spacing: 0;
-    }
-
-    .review-video-device {
-      position: relative;
-      z-index: 2;
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      min-height: clamp(520px, 60vw, 660px);
-      perspective: 1200px;
-    }
-
-    .review-video-device::before {
-      content: "";
-      position: absolute;
-      width: min(520px, 72vw);
-      aspect-ratio: 1;
-      border-radius: 999px;
-      background:
-        radial-gradient(circle at 50% 45%, rgba(255,95,79,.20), transparent 58%),
-        radial-gradient(circle at 48% 72%, rgba(29,29,31,.10), transparent 62%);
-      filter: blur(10px);
-      transform: translateY(18px);
-    }
-
-    .review-video-phone {
-      position: relative;
-      z-index: 2;
-      width: min(342px, 32vw);
-      min-width: 272px;
-      aspect-ratio: 390 / 844;
-      border-radius: 54px;
-      padding: 11px;
-      background:
-        linear-gradient(90deg, transparent 0 1px, rgba(255,255,255,.10) 1px 2px, transparent 2px calc(100% - 2px), rgba(255,255,255,.08) calc(100% - 2px) calc(100% - 1px), transparent calc(100% - 1px)),
-        linear-gradient(145deg, #55575b 0%, #25262a 18%, #111214 48%, #3a3b40 77%, #0b0c0e 100%);
-      box-shadow:
-        inset 0 0 0 1px rgba(255,255,255,.12),
-        inset 0 0 0 2px rgba(0,0,0,.46),
-        0 1px 2px rgba(0,0,0,.18),
-        0 34px 90px rgba(0,0,0,.22);
-      transform: rotateX(0deg) rotateY(-1.5deg);
-    }
-
-    .review-video-phone::before {
-      content: "";
-      position: absolute;
-      z-index: 5;
-      top: 20px;
-      left: 50%;
-      transform: translateX(-50%);
-      width: 102px;
-      height: 31px;
-      border-radius: 999px;
-      background:
-        linear-gradient(180deg, #3b3c40 0%, #151619 100%);
-      box-shadow:
-        inset 0 1px 0 rgba(255,255,255,.14),
-        inset 0 -1px 0 rgba(0,0,0,.75),
-        0 1px 2px rgba(0,0,0,.2);
-      pointer-events: none;
-    }
-
-    .review-video-phone::after {
-      content: "";
-      position: absolute;
-      inset: 2px;
-      border-radius: 52px;
-      pointer-events: none;
-      background:
-        linear-gradient(115deg, rgba(255,255,255,.16), transparent 18%, transparent 72%, rgba(255,255,255,.08));
-      mix-blend-mode: screen;
-      opacity: .65;
-    }
-
-    .review-video-screen {
-      position: relative;
-      width: 100%;
-      height: 100%;
-      overflow: hidden;
-      border-radius: 44px;
-      background: #2f3033;
-      box-shadow:
-        inset 0 0 0 1px rgba(255,255,255,.05),
-        inset 0 0 0 2px rgba(0,0,0,.28);
-    }
-
-    .review-video-screen::before {
-      content: "";
-      position: absolute;
-      z-index: 3;
-      inset: 0;
-      pointer-events: none;
-      background:
-        linear-gradient(90deg, rgba(255,255,255,.08), transparent 16%, transparent 84%, rgba(255,255,255,.05)),
-        linear-gradient(180deg, rgba(255,255,255,.10), transparent 12%, transparent 88%, rgba(0,0,0,.08));
-      opacity: .52;
-      mix-blend-mode: screen;
-    }
-
-    .review-video {
-      width: 100%;
-      height: 100%;
-      object-fit: contain;
-      display: block;
-      background: #2f3033;
-    }
-
-    .review-video-phone .side-button-left,
-    .review-video-phone .side-button-right {
-      position: absolute;
-      width: 3px;
-      background: #202124;
-      border-radius: 999px;
-    }
-
-    .review-video-stats {
-      margin-top: var(--fib-7);
-      display: grid;
-      grid-template-columns: repeat(2, minmax(0, 1fr));
-      gap: var(--fib-5);
-      max-width: 520px;
-    }
-
-    .review-video-stats div {
-      border-radius: 21px;
-      border: 1px solid rgba(0,0,0,.055);
-      background: rgba(255,255,255,.82);
-      backdrop-filter: blur(18px);
-      padding: var(--fib-5);
-      box-shadow: 0 12px 34px rgba(0,0,0,.04);
-    }
-
-    .review-video-stats strong {
-      display: block;
-      color: #1d1d1f;
-      font-size: 17px;
-      line-height: 1.24;
-      letter-spacing: -0.008em;
-    }
-
-    .review-video-stats span {
-      display: block;
-      margin-top: var(--fib-2);
-      color: #6e6e73;
-      font-size: 13px;
-      line-height: 1.45;
-    }
-
-    @media (max-width: 900px) {
-      .review-video-feature {
-        grid-template-columns: 1fr;
-        gap: var(--fib-7);
-        padding: var(--fib-7) var(--fib-5);
-        text-align: center;
-      }
-
-      .review-video-copy {
-        max-width: 680px;
-        margin-inline: auto;
-      }
-
-      .review-video-device {
-        min-height: auto;
-      }
-
-      .review-video-phone {
-        width: min(318px, 72vw);
-        min-width: 0;
-        border-radius: 50px;
-      }
-
-      .review-video-screen {
-        border-radius: 40px;
-      }
-
-    }
-
-    @media (max-width: 560px) {
-      .review-video-feature {
-        border-radius: var(--fib-6);
-        padding: var(--fib-6) var(--fib-4);
-      }
-
-      .review-video-copy h3 {
-        font-size: 31px;
-      }
-
-      .review-video-stats {
-        grid-template-columns: 1fr;
-      }
-
-      .review-video-phone {
-        width: min(286px, 82vw);
-        border-radius: 46px;
-        padding: 9px;
-      }
-
-      .review-video-screen {
-        border-radius: 37px;
-      }
-
-      .review-video-phone::before {
-        top: 17px;
-        width: 88px;
-        height: 27px;
-      }
-    }
-
-  
-    #features .ratio-card {
-      min-height: 260px;
-    }
-
-    #features .ratio-card p {
-      word-break: auto-phrase;
-      line-break: strict;
-    }
-
-    @media (min-width: 1024px) {
-      #features .ratio-card {
-        min-height: 300px;
-      }
-    }
-
-  
-    .cardgroup-video-feature {
-      background:
-        radial-gradient(circle at 78% 26%, rgba(255, 95, 79, .14), transparent 34%),
-        linear-gradient(180deg, #f5f5f7 0%, #ffffff 58%, #f5f5f7 100%);
-    }
-
-    .cardgroup-video-feature .review-video-phone {
-      transform: rotateX(0deg) rotateY(1.5deg);
-    }
-
-    .cardgroup-video-feature .review-video-screen {
-      background: #2f3033;
-    }
-
-    .cardgroup-video-feature .review-video {
-      object-fit: contain;
-      background: #2f3033;
-    }
-
-  
-    .cardgroup-video-feature.is-reversed .review-video-copy {
-      grid-column: 2;
-      grid-row: 1;
-    }
-
-    .cardgroup-video-feature.is-reversed .review-video-device {
-      grid-column: 1;
-      grid-row: 1;
-    }
-
-    @media (max-width: 900px) {
-      .cardgroup-video-feature.is-reversed .review-video-copy,
-      .cardgroup-video-feature.is-reversed .review-video-device {
-        grid-column: auto;
-        grid-row: auto;
-      }
-
-      .cardgroup-video-feature.is-reversed .review-video-copy {
-        order: 1;
-      }
-
-      .cardgroup-video-feature.is-reversed .review-video-device {
-        order: 2;
-      }
-    }
-
-  
-
-  
-    .review-video-copy h3 {
-      text-wrap: balance;
-    }
-
-    .review-video-copy p:not(.review-video-eyebrow) {
-      text-wrap: pretty;
-    }
-
-  
-    .feature-steps-panel {
-      display: grid;
-      grid-template-columns: 1fr;
-      gap: var(--fib-5);
-      width: 100%;
-      border-radius: var(--panel-radius);
-      border: 1px solid rgba(0,0,0,.045);
-      background: #f5f5f7;
-      padding: var(--fib-4);
-      box-shadow: 0 1px 2px rgba(0,0,0,.02), 0 18px 48px rgba(0,0,0,.035);
-    }
-
-    @media (min-width: 1024px) {
-      .feature-steps-panel {
-        grid-template-columns: repeat(3, minmax(0, 1fr));
-        gap: var(--fib-5);
-        padding: var(--fib-5);
-      }
-    }
-
-    .feature-step-card {
-      overflow: hidden;
-      border-radius: calc(var(--card-radius) + 2px);
-      border: 1px solid rgba(0,0,0,.045);
-      background: #fff;
-      box-shadow: 0 1px 2px rgba(0,0,0,.02), 0 12px 30px rgba(0,0,0,.032);
-      min-height: 380px;
-      display: grid;
-      grid-template-rows: minmax(0, 1fr) 150px;
-    }
-
-    .feature-step-card-copy {
-      padding: var(--fib-6);
-      text-align: left;
-      display: flex;
-      flex-direction: column;
-      justify-content: flex-start;
-    }
-
-    .feature-step-badge {
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      width: 34px;
-      height: 34px;
-      border-radius: 999px;
-      background: #fff7f4;
-      color: #ff5f4f;
-      font-size: 13px;
-      font-weight: 650;
-      letter-spacing: -0.01em;
-      box-shadow: inset 0 0 0 1px rgba(255,95,79,.14);
-    }
-
-    .feature-step-card h3 {
-      margin: var(--fib-5) 0 0;
-      color: #1d1d1f;
-      font-size: clamp(1.5rem, 1.75vw, 1.75rem);
-      font-weight: 720;
-      line-height: 1.18;
-      letter-spacing: -0.012em;
-      font-feature-settings: "kern" 1, "palt" 1, "pwid" 1;
-      text-wrap: balance;
-    }
-
-    .feature-step-card p {
-      max-width: 18.5rem;
-      margin: var(--fib-4) 0 0;
-      color: #6e6e73;
-      font-size: clamp(.98rem, 1vw, 1.0625rem);
-      line-height: 1.72;
-      letter-spacing: 0;
-      font-feature-settings: "kern" 1, "palt" 1;
-      text-wrap: pretty;
-    }
-
-    .feature-step-card-visual {
-      min-height: 150px;
-      border-top: 1px solid rgba(0,0,0,.04);
-      background:
-        radial-gradient(circle at 50% 22%, rgba(255, 95, 79, .06), transparent 42%),
-        #fbfbfd;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-    }
-
-    .feature-step-icon {
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      width: 72px;
-      height: 72px;
-      border-radius: 21px;
-      background: #fff;
-      font-size: 34px;
-      box-shadow: 0 14px 34px rgba(0,0,0,.07);
-    }
-
-    .feature-step-icon img {
-      width: 30px;
-      height: 30px;
-    }
-
-    @media (max-width: 767px) {
-      .feature-step-card {
-        min-height: 320px;
-        grid-template-rows: auto 128px;
-      }
-
-      .feature-step-card-copy {
-        padding: var(--fib-5);
-      }
-
-      .feature-step-card p {
-        max-width: none;
-      }
-
-      .feature-step-card-visual {
-        min-height: 128px;
-      }
-    }
-
-  
-    .feature-principled-section .section-copy {
-      max-width: 39.5rem;
-      margin-top: var(--fib-5);
-    }
-
-    .feature-principled-section .section-visual {
-      margin-top: var(--fib-8);
-    }
-
-    @media (min-width: 1024px) {
-      .feature-principled-section .section-visual {
-        margin-top: calc(var(--fib-8) + var(--fib-5));
-      }
-    }
-
-  
-
-  
-
-  
-    /* Principal UI design review: Apple JP-inspired calm hierarchy */
-    html {
-      text-rendering: geometricPrecision;
-    }
-
-    body {
-      background: #fff;
-      color: #1d1d1f;
-    }
-
-    .page-shell {
-      max-width: var(--page-max);
-    }
-
-    header.page-shell {
-      height: 64px;
-    }
-
-    header nav a {
-      letter-spacing: -0.005em;
-      font-feature-settings: "kern" 1, "palt" 1;
-    }
-
-    .copy-section + .copy-section {
-      padding-top: var(--section-y-tight);
-    }
-
-    .section-visual {
-      margin-top: var(--module-gap);
-    }
-
-    .ratio-card {
-      border-color: rgba(0,0,0,.045);
-      border-radius: var(--card-radius);
-      box-shadow: 0 1px 2px rgba(0,0,0,.02), 0 18px 44px rgba(0,0,0,.035);
-    }
-
-    .ratio-panel {
-      border-color: rgba(0,0,0,.045);
-      border-radius: var(--panel-radius);
-      box-shadow: 0 1px 2px rgba(0,0,0,.02), 0 22px 55px rgba(0,0,0,.04);
-    }
-
-    .product-carousel-shell,
-    .review-video-feature,
-    .feature-steps-panel {
-      max-width: var(--module-max);
-      margin-inline: auto;
-    }
-
-    .product-carousel-stage {
-      height: clamp(380px, 44vw, 580px);
-    }
-
-    .review-video-feature {
-      min-height: clamp(600px, 68vw, 820px);
-      padding: clamp(55px, 5.6vw, 89px);
-      gap: var(--fib-8);
-    }
-
-    .review-video-copy h3 {
-      max-width: 25rem;
-      letter-spacing: -0.01em;
-      line-height: 1.10;
-      font-weight: 740;
-      font-feature-settings: "kern" 1, "palt" 1, "pwid" 1;
-      text-wrap: balance;
-    }
-
-    .review-video-copy p:not(.review-video-eyebrow) {
-      max-width: var(--narrow-copy-max);
-      line-height: 1.72;
-      text-wrap: pretty;
-    }
-
-    .review-video-stats {
-      margin-top: var(--fib-7);
-      gap: var(--fib-5);
-    }
-
-    .review-video-stats div {
-      border-color: rgba(0,0,0,.045);
-      box-shadow: 0 10px 28px rgba(0,0,0,.035);
-    }
-
-    .feature-principled-section .section-copy,
-    #features .section-copy {
-      max-width: 39.5rem;
-    }
-
-    #features {
-      padding-top: var(--section-y-tight);
-    }
-
-    .feature-steps-panel {
-      border-color: rgba(0,0,0,.045);
-      background: #f5f5f7;
-      padding: var(--fib-5);
-      gap: var(--fib-5);
-    }
-
-    .feature-step-card {
-      min-height: 360px;
-      grid-template-rows: minmax(0, 1fr) 132px;
-      border-color: rgba(0,0,0,.045);
-      box-shadow: 0 1px 2px rgba(0,0,0,.02), 0 12px 30px rgba(0,0,0,.03);
-    }
-
-    .feature-step-card-copy {
-      padding: var(--fib-6);
-    }
-
-    .feature-step-card h3 {
-      font-size: clamp(1.45rem, 1.55vw, 1.65rem);
-      line-height: 1.18;
-      letter-spacing: -0.012em;
-      font-weight: 720;
-      text-wrap: balance;
-    }
-
-    .feature-step-card p {
-      max-width: 18.25rem;
-      font-size: clamp(.98rem, 1vw, 1.045rem);
-      line-height: 1.72;
-      text-wrap: pretty;
-    }
-
-    .feature-step-card-visual {
-      min-height: 132px;
-      background: #fbfbfd;
-    }
-
-    .feature-step-icon {
-      width: 68px;
-      height: 68px;
-      border-radius: 21px;
-      box-shadow: 0 12px 30px rgba(0,0,0,.06);
-    }
-
-    #pricing .section-visual,
-    #cta.section-visual {
-      margin-top: var(--fib-8);
-    }
-
-    footer {
-      letter-spacing: 0;
-      color: #6e6e73;
-    }
-
-    @media (max-width: 900px) {
-      .review-video-feature {
-        gap: var(--fib-7);
-        padding: var(--fib-7) var(--fib-5);
-      }
-
-      .review-video-copy h3 {
-        max-width: none;
-      }
-    }
-
-    @media (max-width: 640px) {
-      .copy-section {
-        padding-block: var(--fib-7);
-      }
-
-      .copy-section + .copy-section {
-        padding-top: var(--fib-7);
-      }
-
-      .section-visual {
-        margin-top: var(--fib-7);
-      }
-
-      .feature-steps-panel {
-        padding: var(--fib-4);
-      }
-
-      .feature-step-card {
-        min-height: auto;
-        grid-template-rows: auto 120px;
-      }
-
-      .feature-step-card-copy {
-        padding: var(--fib-5);
-      }
-
-      .feature-step-card p {
-        max-width: none;
-      }
-    }
-
-  
-    /* 1920x1080 Principal UI review: Apple JP-inspired optical balance */
-    @media (min-width: 1440px) {
-      .page-shell {
-        max-width: var(--page-max);
-      }
-
-      header.page-shell {
-        height: 56px;
-      }
-
-      .hero-title-jp {
-        max-width: var(--hero-title-max);
-      }
-
-      .hero-copy {
-        max-width: var(--narrow-copy-max);
-      }
-
-      .copy-section {
-        padding-block: var(--section-y);
-      }
-
-      .copy-section + .copy-section {
-        padding-top: var(--section-y-tight);
-      }
-
-      .section-copy {
-        max-width: var(--narrow-copy-max);
-      }
-
-      .section-visual {
-        margin-top: var(--module-gap);
-      }
-
-      .product-carousel-shell {
-        max-width: var(--wide-module-max);
-        margin-inline: auto;
-      }
-
-      .product-carousel-stage {
-        height: 500px;
-      }
-
-      .review-video-feature {
-        max-width: var(--module-max);
-        min-height: 660px;
-        padding: var(--fib-7) var(--fib-8);
-        gap: var(--fib-7);
-        border-radius: var(--panel-radius);
-      }
-
-      .review-video-copy h3 {
-        max-width: 24rem;
-        font-size: clamp(2.125rem, 2.4vw, 3.375rem);
-        line-height: 1.08;
-        letter-spacing: -0.012em;
-      }
-
-      .review-video-copy p:not(.review-video-eyebrow) {
-        max-width: 31rem;
-        font-size: 1rem;
-        line-height: 1.72;
-      }
-
-      .review-video-device {
-        min-height: 520px;
-      }
-
-      .review-video-phone {
-        width: 300px;
-        min-width: 300px;
-      }
-
-      .review-video-stats {
-        margin-top: var(--fib-6);
-      }
-
-      .feature-steps-panel {
-        max-width: var(--module-max);
-        margin-inline: auto;
-        padding: var(--fib-5);
-        gap: var(--fib-5);
-        border-radius: var(--panel-radius);
-      }
-
-      .feature-step-card {
-        min-height: 330px;
-        grid-template-rows: minmax(0, 1fr) 120px;
-        border-radius: var(--card-radius);
-      }
-
-      .feature-step-card-copy {
-        padding: var(--fib-6);
-      }
-
-      .feature-step-card h3 {
-        font-size: 1.5rem;
-        line-height: 1.18;
-      }
-
-      .feature-step-card p {
-        font-size: .96rem;
-        line-height: 1.72;
-        max-width: 17.5rem;
-      }
-
-      .feature-step-card-visual {
-        min-height: 120px;
-      }
-
-      .feature-step-icon {
-        width: 64px;
-        height: 64px;
-        border-radius: 20px;
-        font-size: 32px;
-      }
-
-      #pricing .section-visual,
-      .pricing-section .section-visual {
-        margin-top: var(--fib-8);
-      }
-
-      .final-cta-section {
-        padding-top: var(--section-y-tight);
-        padding-bottom: var(--fib-8);
-      }
-
-      footer {
-        padding-top: var(--fib-7);
-        padding-bottom: var(--fib-8);
-      }
-    }
-
-    @media (min-width: 1440px) and (max-height: 1100px) {
-      main.page-shell {
-        padding-top: 0;
-      }
-
-      main.page-shell > section:first-child {
-        margin-top: var(--fib-6);
-        padding-top: var(--fib-6);
-        padding-bottom: var(--fib-7);
-      }
-
-      main.page-shell > section:first-child h1 {
-        font-size: 3.5rem;
-        line-height: 1.1;
-      }
-
-      main.page-shell > section:first-child .hero-copy {
-        margin-top: var(--fib-5);
-      }
-
-      main.page-shell > section:first-child .hero-actions {
-        margin-top: var(--fib-5);
-        margin-bottom: var(--fib-7);
-      }
-    }
-
-    /* Optical kerning / Japanese copy refinement */
-    .helvetica-title,
-    .section-copy,
-    .hero-copy,
-    .review-video-copy,
-    .feature-step-card,
-    footer {
-      font-feature-settings: "kern" 1, "palt" 1, "pwid" 1, "liga" 1;
-    }
-
-    .section-copy,
-    .hero-copy,
-    .review-video-copy p,
-    .feature-step-card p {
-      color: #6e6e73;
-    }
-
-    .ratio-card,
-    .ratio-panel,
-    .review-video-feature,
-    .feature-steps-panel,
-    .product-carousel-shell {
-      box-shadow: 0 1px 2px rgba(0,0,0,.018), 0 18px 44px rgba(0,0,0,.035);
-    }
-
-  
-    /* Final principal UI design review: Apple JP-inspired optical balance */
-    html {
-      text-rendering: geometricPrecision;
-    }
-
-    body {
-      background: #fff;
-      color: #1d1d1f;
-      letter-spacing: 0;
-    }
-
-    .page-shell {
-      max-width: var(--page-max);
-    }
-
-    header.page-shell {
-      height: 56px;
-    }
-
-    header nav a,
-    header a {
-      letter-spacing: -0.004em;
-      font-feature-settings: "kern" 1, "palt" 1;
-    }
-
-    .copy-section + .copy-section {
-      padding-top: var(--section-y-tight);
-    }
-
-    .section-visual {
-      margin-top: var(--module-gap);
-    }
-
-    .hero-title-jp {
-      max-width: var(--hero-title-max);
-    }
-
-    .ratio-card,
-    .ratio-panel,
-    .review-video-feature,
-    .feature-steps-panel,
-    .product-carousel-shell {
-      box-shadow: 0 1px 2px rgba(0,0,0,.018), 0 18px 44px rgba(0,0,0,.033);
-    }
-
-    .product-carousel-shell {
-      max-width: var(--wide-module-max);
-      margin-inline: auto;
-    }
-
-    .product-carousel-stage {
-      height: clamp(380px, 42vw, 560px);
-    }
-
-    .review-video-feature {
-      max-width: var(--module-max);
-      min-height: clamp(600px, 64vw, 800px);
-      padding: clamp(55px, 5vw, 89px);
-      gap: var(--fib-7);
-      border-radius: var(--panel-radius);
-      margin-inline: auto;
-    }
-
-    .review-video-copy h3 {
-      max-width: 23.5rem;
-      font-size: clamp(2rem, 2.35vw, 3.25rem);
-      line-height: 1.08;
-      letter-spacing: -0.012em;
-      font-weight: 740;
-      font-feature-settings: "kern" 1, "palt" 1, "pwid" 1;
-      text-wrap: balance;
-    }
-
-    .review-video-copy p:not(.review-video-eyebrow) {
-      max-width: 30rem;
-      font-size: clamp(.975rem, 1.05vw, 1.0625rem);
-      line-height: 1.72;
-      text-wrap: pretty;
-    }
-
-    .review-video-device {
-      min-height: clamp(480px, 52vw, 610px);
-    }
-
-    .review-video-phone {
-      width: min(300px, 29vw);
-      min-width: 270px;
-    }
-
-    .review-video-stats {
-      margin-top: var(--fib-6);
-      gap: var(--fib-5);
-    }
-
-    .review-video-stats div {
-      border-color: rgba(0,0,0,.045);
-      box-shadow: 0 10px 28px rgba(0,0,0,.032);
-    }
-
-    #features {
-      padding-top: var(--section-y-tight);
-    }
-
-    #features .section-copy,
-    .feature-principled-section .section-copy {
-      max-width: 38.5rem;
-    }
-
-    .feature-steps-panel {
-      max-width: var(--module-max);
-      margin-inline: auto;
-      padding: var(--fib-5);
-      gap: var(--fib-5);
-      border-color: rgba(0,0,0,.045);
-      border-radius: var(--panel-radius);
-      background: #f5f5f7;
-    }
-
-    .feature-step-card {
-      min-height: 332px;
-      grid-template-rows: minmax(0, 1fr) 118px;
-      border-color: rgba(0,0,0,.045);
-      border-radius: var(--card-radius);
-      box-shadow: 0 1px 2px rgba(0,0,0,.018), 0 12px 30px rgba(0,0,0,.03);
-    }
-
-    .feature-step-card-copy {
-      padding: var(--fib-6);
-    }
-
-    .feature-step-card h3 {
-      font-size: clamp(1.425rem, 1.52vw, 1.625rem);
-      line-height: 1.18;
-      letter-spacing: -0.012em;
-      font-weight: 720;
-      font-feature-settings: "kern" 1, "palt" 1, "pwid" 1;
-      text-wrap: balance;
-    }
-
-    .feature-step-card p {
-      max-width: 17.75rem;
-      font-size: clamp(.955rem, .98vw, 1rem);
-      line-height: 1.72;
-      color: #6e6e73;
-      text-wrap: pretty;
-    }
-
-    .feature-step-card-visual {
-      min-height: 118px;
-      background: #fbfbfd;
-    }
-
-    .feature-step-icon {
-      width: 64px;
-      height: 64px;
-      border-radius: 20px;
-      box-shadow: 0 12px 30px rgba(0,0,0,.058);
-      font-size: 32px;
-    }
-
-    #pricing .section-visual,
-    .pricing-section .section-visual {
-      margin-top: var(--fib-8);
-    }
-
-    .final-cta-section {
-      padding-top: var(--section-y-tight);
-      padding-bottom: var(--fib-8);
-    }
-
-    footer {
-      padding-top: var(--fib-7);
-      padding-bottom: var(--fib-8);
-      color: #6e6e73;
-      letter-spacing: 0;
-      font-feature-settings: "kern" 1, "palt" 1;
-    }
-
-    @media (min-width: 1440px) and (max-height: 1100px) {
-      main.page-shell > section:first-child {
-        margin-top: var(--fib-6);
-        padding-top: var(--fib-6);
-        padding-bottom: var(--fib-7);
-      }
-
-      main.page-shell > section:first-child h1 {
-        font-size: 3.45rem;
-        line-height: 1.1;
-      }
-
-      main.page-shell > section:first-child .hero-copy {
-        margin-top: var(--fib-5);
-      }
-
-      main.page-shell > section:first-child .hero-actions {
-        margin-top: var(--fib-5);
-        margin-bottom: var(--fib-7);
-      }
-    }
-
-    @media (max-width: 900px) {
-      .review-video-feature {
-        gap: var(--fib-7);
-        padding: var(--fib-7) var(--fib-5);
-      }
-
-      .review-video-copy h3 {
-        max-width: none;
-      }
-    }
-
-    @media (max-width: 640px) {
-      .copy-section {
-        padding-block: var(--fib-7);
-      }
-
-      .copy-section + .copy-section {
-        padding-top: var(--fib-7);
-      }
-
-      .section-visual {
-        margin-top: var(--fib-7);
-      }
-
-      .feature-steps-panel {
-        padding: var(--fib-4);
-      }
-
-      .feature-step-card {
-        min-height: auto;
-        grid-template-rows: auto 112px;
-      }
-
-      .feature-step-card-copy {
-        padding: var(--fib-5);
-      }
-
-      .feature-step-card p {
-        max-width: none;
-      }
-    }
-
-  
-    /* Hero/header principal refinement: Apple JP-inspired air and optical rhythm */
-    .hero-section {
-      margin-top: var(--fib-8) !important;
-      padding-top: var(--fib-6) !important;
-      padding-bottom: var(--fib-8) !important;
-    }
-
-    .hero-section .hero-title-jp {
-      max-width: 45rem;
-      letter-spacing: -0.009em;
-      line-height: 1.13;
-    }
-
-    .hero-section .hero-copy {
-      max-width: 36rem;
-      margin-top: var(--fib-6);
-      font-size: clamp(1rem, 1.08vw, 1.125rem);
-      line-height: 1.72;
-    }
-
-    .hero-section .hero-actions {
-      margin-top: var(--fib-6);
-      margin-bottom: var(--fib-8);
-    }
-
-    .hero-section .section-visual,
-    .hero-section .product-carousel-shell {
-      margin-top: 0;
-    }
-
-    .hero-section + section {
-      padding-top: var(--section-y-tight);
-    }
-
-    @media (min-width: 1440px) and (max-height: 1100px) {
-      .hero-section {
-        margin-top: 5.5625rem !important;
-        padding-top: var(--fib-6) !important;
-        padding-bottom: var(--fib-8) !important;
-      }
-
-      .hero-section h1 {
-        font-size: 3.75rem !important;
-        line-height: 1.12 !important;
-      }
-
-      .hero-section .hero-copy {
-        margin-top: var(--fib-6) !important;
-      }
-
-      .hero-section .hero-actions {
-        margin-top: var(--fib-6) !important;
-        margin-bottom: var(--fib-8) !important;
-      }
-
-      .hero-section .product-carousel-stage {
-        height: 500px;
-      }
-    }
-
-    @media (max-width: 768px) {
-      .hero-section {
-        margin-top: var(--fib-7) !important;
-        padding-top: var(--fib-5) !important;
-        padding-bottom: var(--fib-7) !important;
-      }
-
-      .hero-section .hero-copy {
-        margin-top: var(--fib-5);
-      }
-
-      .hero-section .hero-actions {
-        margin-top: var(--fib-5);
-        margin-bottom: var(--fib-7);
-      }
-    }
-
-  
-    header nav {
-      gap: var(--fib-6);
-    }
-
-    header nav a {
-      white-space: nowrap;
-    }
-
-    @media (min-width: 1440px) {
-      header nav {
-        gap: var(--fib-6);
-      }
-    }
-
-  
-    /* CTA hierarchy: persistent header action is quiet; hero action is primary */
-    .header-cta {
-      min-height: 40px !important;
-      padding-inline: var(--fib-5) !important;
-      padding-block: var(--fib-2) !important;
-      font-size: 0.875rem !important;
-      font-weight: 650 !important;
-      box-shadow: none !important;
-      background: #ff6b5c !important;
-    }
-
-    .header-cta:hover {
-      background: #ff5f4f !important;
-    }
-
-    .hero-main-cta {
-      min-height: 52px !important;
-      padding-inline: var(--fib-6) !important;
-      padding-block: var(--fib-4) !important;
-      font-size: 1rem !important;
-      font-weight: 700 !important;
-      box-shadow: 0 8px 26px rgba(255,95,79,.20) !important;
-    }
-
-    .hero-main-cta:hover {
-      background: #ff5144 !important;
-    }
-
-    @media (max-width: 767px) {
-      .header-cta {
-        display: none !important;
-      }
-
-      .hero-main-cta {
-        min-height: 50px !important;
-      }
-    }
-
-  
-    /* Final principal UI review: Apple JP-inspired spacing, typography, kerning */
-    html {
-      text-rendering: geometricPrecision;
-      scroll-behavior: smooth;
-    }
-
-    body {
-      background: #fff;
-      color: #1d1d1f;
-      letter-spacing: 0;
-    }
-
-    .page-shell {
-      max-width: var(--page-max);
-    }
-
-    header.page-shell {
-      height: 56px;
-    }
-
-    header nav {
-      gap: var(--fib-6);
-    }
-
-    header nav a,
-    header a {
-      letter-spacing: -0.004em;
-      font-feature-settings: "kern" 1, "palt" 1;
-      white-space: nowrap;
-    }
-
-    .hero-section {
-      margin-top: var(--fib-8) !important;
-      padding-top: var(--fib-6) !important;
-      padding-bottom: var(--fib-8) !important;
-    }
-
-    .hero-section .hero-title-jp {
-      max-width: var(--hero-title-max);
-      letter-spacing: -0.009em;
-      line-height: 1.13;
-    }
-
-    .hero-section .hero-copy {
-      max-width: var(--narrow-copy-max);
-      margin-top: var(--fib-6);
-    }
-
-    .hero-section .hero-actions {
-      margin-top: var(--fib-6);
-      margin-bottom: var(--fib-8);
-    }
-
-    .copy-section + .copy-section {
-      padding-top: var(--section-y-tight);
-    }
-
-    .section-visual {
-      margin-top: var(--module-gap);
-    }
-
-    .ratio-card,
-    .ratio-panel,
-    .review-video-feature,
-    .feature-steps-panel,
-    .product-carousel-shell {
-      box-shadow: 0 1px 2px rgba(0,0,0,.018), 0 18px 44px rgba(0,0,0,.033);
-    }
-
-    .product-carousel-shell {
-      max-width: var(--wide-module-max);
-      margin-inline: auto;
-    }
-
-    .product-carousel-stage {
-      height: clamp(380px, 42vw, 560px);
-    }
-
-    .review-video-feature {
-      max-width: var(--module-max);
-      min-height: clamp(600px, 64vw, 800px);
-      padding: clamp(55px, 5vw, 89px);
-      gap: var(--fib-7);
-      border-radius: var(--panel-radius);
-      margin-inline: auto;
-    }
-
-    .review-video-copy h3 {
-      max-width: 23.5rem;
-      font-size: clamp(2rem, 2.35vw, 3.25rem);
-      line-height: 1.08;
-      letter-spacing: -0.012em;
-      font-weight: 740;
-      font-feature-settings: "kern" 1, "palt" 1, "pwid" 1;
-      text-wrap: balance;
-    }
-
-    .review-video-copy p:not(.review-video-eyebrow) {
-      max-width: 30rem;
-      font-size: clamp(.975rem, 1.05vw, 1.0625rem);
-      line-height: 1.72;
-      text-wrap: pretty;
-    }
-
-    .review-video-device {
-      min-height: clamp(480px, 52vw, 610px);
-    }
-
-    .review-video-phone {
-      width: min(300px, 29vw);
-      min-width: 270px;
-    }
-
-    .review-video-stats {
-      margin-top: var(--fib-6);
-      gap: var(--fib-5);
-    }
-
-    .review-video-stats div {
-      border-color: rgba(0,0,0,.045);
-      box-shadow: 0 10px 28px rgba(0,0,0,.032);
-    }
-
-    #features {
-      padding-top: var(--section-y-tight);
-    }
-
-    #features .section-copy,
-    .feature-principled-section .section-copy {
-      max-width: 38.5rem;
-    }
-
-    .feature-steps-panel {
-      max-width: var(--module-max);
-      margin-inline: auto;
-      padding: var(--fib-5);
-      gap: var(--fib-5);
-      border-color: rgba(0,0,0,.045);
-      border-radius: var(--panel-radius);
-      background: #f5f5f7;
-    }
-
-    .feature-step-card {
-      min-height: 332px;
-      grid-template-rows: minmax(0, 1fr) 118px;
-      border-color: rgba(0,0,0,.045);
-      border-radius: var(--card-radius);
-      box-shadow: 0 1px 2px rgba(0,0,0,.018), 0 12px 30px rgba(0,0,0,.03);
-    }
-
-    .feature-step-card-copy {
-      padding: var(--fib-6);
-    }
-
-    .feature-step-card h3 {
-      font-size: clamp(1.425rem, 1.52vw, 1.625rem);
-      line-height: 1.18;
-      letter-spacing: -0.012em;
-      font-weight: 720;
-      font-feature-settings: "kern" 1, "palt" 1, "pwid" 1;
-      text-wrap: balance;
-    }
-
-    .feature-step-card p {
-      max-width: 17.75rem;
-      font-size: clamp(.955rem, .98vw, 1rem);
-      line-height: 1.72;
-      color: #6e6e73;
-      text-wrap: pretty;
-    }
-
-    .feature-step-card-visual {
-      min-height: 118px;
-      background: #fbfbfd;
-    }
-
-    .feature-step-icon {
-      width: 64px;
-      height: 64px;
-      border-radius: 20px;
-      box-shadow: 0 12px 30px rgba(0,0,0,.058);
-      font-size: 32px;
-    }
-
-    .header-cta {
-      min-height: 40px !important;
-      padding-inline: var(--fib-5) !important;
-      padding-block: var(--fib-2) !important;
-      font-size: 0.875rem !important;
-      font-weight: 650 !important;
-      box-shadow: none !important;
-      background: #ff6b5c !important;
-    }
-
-    .hero-main-cta {
-      min-height: 52px !important;
-      padding-inline: var(--fib-6) !important;
-      padding-block: var(--fib-4) !important;
-      font-size: 1rem !important;
-      font-weight: 700 !important;
-      box-shadow: 0 8px 26px rgba(255,95,79,.20) !important;
-    }
-
-    #pricing .section-visual,
-    .pricing-section .section-visual {
-      margin-top: var(--fib-8);
-    }
-
-    .final-cta-section {
-      padding-top: var(--section-y-tight);
-      padding-bottom: var(--fib-8);
-    }
-
-    footer {
-      padding-top: var(--fib-7);
-      padding-bottom: var(--fib-8);
-      color: #6e6e73;
-      letter-spacing: 0;
-      font-feature-settings: "kern" 1, "palt" 1;
-    }
-
-    @media (min-width: 1440px) and (max-height: 1100px) {
-      .hero-section {
-        margin-top: var(--fib-8) !important;
-        padding-top: var(--fib-6) !important;
-        padding-bottom: var(--fib-8) !important;
-      }
-
-      .hero-section h1 {
-        font-size: 3.75rem !important;
-        line-height: 1.12 !important;
-      }
-
-      .hero-section .hero-copy {
-        margin-top: var(--fib-6) !important;
-      }
-
-      .hero-section .hero-actions {
-        margin-top: var(--fib-6) !important;
-        margin-bottom: var(--fib-8) !important;
-      }
-    }
-
-    @media (max-width: 900px) {
-      .review-video-feature {
-        gap: var(--fib-7);
-        padding: var(--fib-7) var(--fib-5);
-      }
-
-      .review-video-copy h3 {
-        max-width: none;
-      }
-    }
-
-    @media (max-width: 767px) {
-      .header-cta {
-        display: none !important;
-      }
-    }
-
-    @media (max-width: 640px) {
-      .copy-section {
-        padding-block: var(--fib-7);
-      }
-
-      .copy-section + .copy-section {
-        padding-top: var(--fib-7);
-      }
-
-      .section-visual {
-        margin-top: var(--fib-7);
-      }
-
-      .feature-steps-panel {
-        padding: var(--fib-4);
-      }
-
-      .feature-step-card {
-        min-height: auto;
-        grid-template-rows: auto 112px;
-      }
-
-      .feature-step-card-copy {
-        padding: var(--fib-5);
-      }
-
-      .feature-step-card p {
-        max-width: none;
-      }
-    }
-
+.mobile-menu-panel {
+  background-color: #fff;
+}
+
+/* Senior spacing pass: golden-ratio / Fibonacci refinement */
+.hero-title-jp {
+  max-width: var(--hero-title-max);
+  margin-inline: auto;
+}
+
+.hero-title-jp .hero-title-word {
+  margin-right: var(--title-word-space);
+}
+
+.hero-copy {
+  max-width: var(--content-max);
+}
+
+.hero-actions + .relative,
+.hero-actions + div {
+  margin-top: 0;
+}
+
+.section-copy {
+  max-width: var(--content-max);
+}
+
+.ratio-card,
+.ratio-panel {
+  overflow: hidden;
+}
+
+.ratio-grid {
+  gap: var(--card-gap);
+}
+
+@media (min-width: 768px) {
+  .ratio-grid {
+    gap: var(--fib-6);
+  }
+}
+
+.copy-section + .copy-section {
+  padding-top: calc(var(--section-y) * 0.72);
+}
+
+.final-cta-section {
+  padding-bottom: var(--fib-7);
+}
+
+.final-cta-section + footer {
+  margin-top: 0;
+}
+
+footer {
+  margin-top: 0;
+}
+
+@media (min-width: 768px) {
+  .final-cta-section {
+    padding-bottom: var(--fib-7); /* 55px: enough air, no dead zone */
+  }
+}
+
+.product-carousel-shell {
+  width: 100%;
+  border-radius: var(--panel-radius);
+  border: 1px solid rgba(0, 0, 0, 0.055);
+  background: #f5f5f7;
+  padding: var(--fib-4);
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.025),
+    0 20px 55px rgba(0, 0, 0, 0.045);
+}
+
+.product-carousel-stage {
+  position: relative;
+  height: clamp(420px, 52vw, 640px);
+  overflow: hidden;
+  border-radius: calc(var(--panel-radius) - var(--fib-4));
+  background: #fff;
+  border: 1px solid rgba(0, 0, 0, 0.055);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.product-carousel-media {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(18px, 3vw, 55px);
+}
+
+.product-carousel-media[data-kind="mobile"] {
+  padding: clamp(21px, 4vw, 55px);
+}
+
+.product-carousel-image {
+  max-width: 100%;
+  max-height: 100%;
+  object-fit: contain;
+  border-radius: 21px;
+  box-shadow: 0 12px 44px rgba(0, 0, 0, 0.08);
+  animation: carouselFade 0.38s ease both;
+}
+
+.product-carousel-media[data-kind="mobile"] .product-carousel-image {
+  max-width: min(330px, 46%);
+  border-radius: 21px;
+}
+
+.carousel-caption {
+  position: absolute;
+  left: var(--fib-6);
+  bottom: var(--fib-6);
+  max-width: min(420px, calc(100% - 110px));
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.82);
+  border: 1px solid rgba(0, 0, 0, 0.055);
+  backdrop-filter: blur(18px);
+  padding: 13px 21px;
+  text-align: left;
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.06);
+}
+
+.carousel-title {
+  margin: 0;
+  color: #1d1d1f;
+  font-size: 14px;
+  font-weight: 700;
+  letter-spacing: 0;
+  line-height: 1.35;
+}
+
+.carousel-description {
+  margin: 3px 0 0;
+  color: #6e6e73;
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.carousel-nav {
+  position: absolute;
+  z-index: 4;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 44px;
+  height: 44px;
+  border-radius: 999px;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  background: rgba(255, 255, 255, 0.78);
+  color: #1d1d1f;
+  font-size: 30px;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.07);
+  backdrop-filter: blur(18px);
+  transition:
+    background 0.2s ease,
+    transform 0.2s ease;
+}
+
+.carousel-nav:hover {
+  background: #fff;
+  transform: translateY(-50%) scale(1.04);
+}
+
+.carousel-nav-left {
+  left: var(--fib-5);
+}
+.carousel-nav-right {
+  right: var(--fib-5);
+}
+
+.carousel-dots {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--fib-3);
+  padding-top: var(--fib-5);
+}
+
+.carousel-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 999px;
+  background: #d2d2d7;
+  transition:
+    width 0.25s ease,
+    background 0.25s ease;
+}
+
+.carousel-dot.is-active {
+  width: 21px;
+  background: #ff5f4f;
+}
+
+@keyframes carouselFade {
+  from {
+    opacity: 0;
+    transform: translateY(8px) scale(0.985);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@media (max-width: 767px) {
+  .product-carousel-shell {
+    padding: var(--fib-3);
+    border-radius: var(--fib-6);
+  }
+
+  .product-carousel-stage {
+    height: 560px;
+    border-radius: calc(var(--fib-6) - var(--fib-3));
+  }
+
+  .product-carousel-media[data-kind="desktop"] .product-carousel-image {
+    max-width: 100%;
+  }
+
+  .product-carousel-media[data-kind="mobile"] .product-carousel-image {
+    max-width: min(280px, 82%);
+  }
+
+  .carousel-caption {
+    left: var(--fib-5);
+    right: var(--fib-5);
+    bottom: var(--fib-5);
+    max-width: none;
+    border-radius: 21px;
+  }
+
+  .carousel-nav {
+    display: none;
+  }
+}
+
+.section-visual .product-carousel-stage {
+  height: clamp(420px, 48vw, 610px);
+}
+
+.section-visual .product-carousel-shell {
+  max-width: 100%;
+}
+
+.review-video-feature {
+  position: relative;
+  width: 100%;
+  min-height: clamp(640px, 74vw, 860px);
+  overflow: hidden;
+  border-radius: var(--panel-radius);
+  border: 1px solid rgba(0, 0, 0, 0.055);
+  background:
+    radial-gradient(circle at 72% 24%, rgba(255, 95, 79, 0.18), transparent 34%),
+    linear-gradient(180deg, #f5f5f7 0%, #ffffff 58%, #f5f5f7 100%);
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.025),
+    0 28px 70px rgba(0, 0, 0, 0.045);
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(300px, 0.78fr);
+  align-items: center;
+  gap: var(--fib-8);
+  padding: clamp(55px, 6vw, 89px) clamp(34px, 6vw, 89px);
+  text-align: left;
+}
+
+.review-video-copy {
+  position: relative;
+  z-index: 2;
+  max-width: 520px;
+}
+
+.review-video-eyebrow {
+  margin: 0 0 var(--fib-4);
+  color: #ff5f4f;
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.review-video-copy h3 {
+  margin: 0;
+  color: #1d1d1f;
+  font-family:
+    -apple-system, BlinkMacSystemFont, "SF Pro Display", "Helvetica Neue", Helvetica, Arial,
+    sans-serif;
+  font-size: clamp(32px, 4.2vw, 64px);
+  font-weight: 740;
+  line-height: 1.08;
+  letter-spacing: -0.012em;
+  font-feature-settings:
+    "palt" 1,
+    "kern" 1;
+  text-wrap: balance;
+}
+
+.review-video-copy p:not(.review-video-eyebrow) {
+  margin: var(--fib-6) 0 0;
+  color: #6e6e73;
+  font-size: clamp(16px, 1.45vw, 19px);
+  line-height: 1.72;
+  letter-spacing: 0;
+}
+
+.review-video-device {
+  position: relative;
+  z-index: 2;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: clamp(520px, 60vw, 660px);
+  perspective: 1200px;
+}
+
+.review-video-device::before {
+  content: "";
+  position: absolute;
+  width: min(520px, 72vw);
+  aspect-ratio: 1;
+  border-radius: 999px;
+  background:
+    radial-gradient(circle at 50% 45%, rgba(255, 95, 79, 0.2), transparent 58%),
+    radial-gradient(circle at 48% 72%, rgba(29, 29, 31, 0.1), transparent 62%);
+  filter: blur(10px);
+  transform: translateY(18px);
+}
+
+.review-video-phone {
+  position: relative;
+  z-index: 2;
+  width: min(342px, 32vw);
+  min-width: 272px;
+  aspect-ratio: 390 / 844;
+  border-radius: 54px;
+  padding: 11px;
+  background:
+    linear-gradient(
+      90deg,
+      transparent 0 1px,
+      rgba(255, 255, 255, 0.1) 1px 2px,
+      transparent 2px calc(100% - 2px),
+      rgba(255, 255, 255, 0.08) calc(100% - 2px) calc(100% - 1px),
+      transparent calc(100% - 1px)
+    ),
+    linear-gradient(145deg, #55575b 0%, #25262a 18%, #111214 48%, #3a3b40 77%, #0b0c0e 100%);
+  box-shadow:
+    inset 0 0 0 1px rgba(255, 255, 255, 0.12),
+    inset 0 0 0 2px rgba(0, 0, 0, 0.46),
+    0 1px 2px rgba(0, 0, 0, 0.18),
+    0 34px 90px rgba(0, 0, 0, 0.22);
+  transform: rotateX(0deg) rotateY(-1.5deg);
+}
+
+.review-video-phone::before {
+  content: "";
+  position: absolute;
+  z-index: 5;
+  top: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 102px;
+  height: 31px;
+  border-radius: 999px;
+  background: linear-gradient(180deg, #3b3c40 0%, #151619 100%);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.14),
+    inset 0 -1px 0 rgba(0, 0, 0, 0.75),
+    0 1px 2px rgba(0, 0, 0, 0.2);
+  pointer-events: none;
+}
+
+.review-video-phone::after {
+  content: "";
+  position: absolute;
+  inset: 2px;
+  border-radius: 52px;
+  pointer-events: none;
+  background: linear-gradient(
+    115deg,
+    rgba(255, 255, 255, 0.16),
+    transparent 18%,
+    transparent 72%,
+    rgba(255, 255, 255, 0.08)
+  );
+  mix-blend-mode: screen;
+  opacity: 0.65;
+}
+
+.review-video-screen {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  border-radius: 44px;
+  background: #2f3033;
+  box-shadow:
+    inset 0 0 0 1px rgba(255, 255, 255, 0.05),
+    inset 0 0 0 2px rgba(0, 0, 0, 0.28);
+}
+
+.review-video-screen::before {
+  content: "";
+  position: absolute;
+  z-index: 3;
+  inset: 0;
+  pointer-events: none;
+  background:
+    linear-gradient(
+      90deg,
+      rgba(255, 255, 255, 0.08),
+      transparent 16%,
+      transparent 84%,
+      rgba(255, 255, 255, 0.05)
+    ),
+    linear-gradient(
+      180deg,
+      rgba(255, 255, 255, 0.1),
+      transparent 12%,
+      transparent 88%,
+      rgba(0, 0, 0, 0.08)
+    );
+  opacity: 0.52;
+  mix-blend-mode: screen;
+}
+
+.review-video {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  display: block;
+  background: #2f3033;
+}
+
+.review-video-phone .side-button-left,
+.review-video-phone .side-button-right {
+  position: absolute;
+  width: 3px;
+  background: #202124;
+  border-radius: 999px;
+}
+
+.review-video-stats {
+  margin-top: var(--fib-7);
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--fib-5);
+  max-width: 520px;
+}
+
+.review-video-stats div {
+  border-radius: 21px;
+  border: 1px solid rgba(0, 0, 0, 0.055);
+  background: rgba(255, 255, 255, 0.82);
+  backdrop-filter: blur(18px);
+  padding: var(--fib-5);
+  box-shadow: 0 12px 34px rgba(0, 0, 0, 0.04);
+}
+
+.review-video-stats strong {
+  display: block;
+  color: #1d1d1f;
+  font-size: 17px;
+  line-height: 1.24;
+  letter-spacing: -0.008em;
+}
+
+.review-video-stats span {
+  display: block;
+  margin-top: var(--fib-2);
+  color: #6e6e73;
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+@media (max-width: 900px) {
+  .review-video-feature {
+    grid-template-columns: 1fr;
+    gap: var(--fib-7);
+    padding: var(--fib-7) var(--fib-5);
+    text-align: center;
+  }
+
+  .review-video-copy {
+    max-width: 680px;
+    margin-inline: auto;
+  }
+
+  .review-video-device {
+    min-height: auto;
+  }
+
+  .review-video-phone {
+    width: min(318px, 72vw);
+    min-width: 0;
+    border-radius: 50px;
+  }
+
+  .review-video-screen {
+    border-radius: 40px;
+  }
+}
+
+@media (max-width: 560px) {
+  .review-video-feature {
+    border-radius: var(--fib-6);
+    padding: var(--fib-6) var(--fib-4);
+  }
+
+  .review-video-copy h3 {
+    font-size: 31px;
+  }
+
+  .review-video-stats {
+    grid-template-columns: 1fr;
+  }
+
+  .review-video-phone {
+    width: min(286px, 82vw);
+    border-radius: 46px;
+    padding: 9px;
+  }
+
+  .review-video-screen {
+    border-radius: 37px;
+  }
+
+  .review-video-phone::before {
+    top: 17px;
+    width: 88px;
+    height: 27px;
+  }
+}
+
+#features .ratio-card {
+  min-height: 260px;
+}
+
+#features .ratio-card p {
+  word-break: auto-phrase;
+  line-break: strict;
+}
+
+@media (min-width: 1024px) {
+  #features .ratio-card {
+    min-height: 300px;
+  }
+}
+
+.cardgroup-video-feature {
+  background:
+    radial-gradient(circle at 78% 26%, rgba(255, 95, 79, 0.14), transparent 34%),
+    linear-gradient(180deg, #f5f5f7 0%, #ffffff 58%, #f5f5f7 100%);
+}
+
+.cardgroup-video-feature .review-video-phone {
+  transform: rotateX(0deg) rotateY(1.5deg);
+}
+
+.cardgroup-video-feature .review-video-screen {
+  background: #2f3033;
+}
+
+.cardgroup-video-feature .review-video {
+  object-fit: contain;
+  background: #2f3033;
+}
+
+.cardgroup-video-feature.is-reversed .review-video-copy {
+  grid-column: 2;
+  grid-row: 1;
+}
+
+.cardgroup-video-feature.is-reversed .review-video-device {
+  grid-column: 1;
+  grid-row: 1;
+}
+
+@media (max-width: 900px) {
+  .cardgroup-video-feature.is-reversed .review-video-copy,
+  .cardgroup-video-feature.is-reversed .review-video-device {
+    grid-column: auto;
+    grid-row: auto;
+  }
+
+  .cardgroup-video-feature.is-reversed .review-video-copy {
+    order: 1;
+  }
+
+  .cardgroup-video-feature.is-reversed .review-video-device {
+    order: 2;
+  }
+}
+
+.review-video-copy h3 {
+  text-wrap: balance;
+}
+
+.review-video-copy p:not(.review-video-eyebrow) {
+  text-wrap: pretty;
+}
+
+.feature-steps-panel {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--fib-5);
+  width: 100%;
+  border-radius: var(--panel-radius);
+  border: 1px solid rgba(0, 0, 0, 0.045);
+  background: #f5f5f7;
+  padding: var(--fib-4);
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.02),
+    0 18px 48px rgba(0, 0, 0, 0.035);
+}
+
+@media (min-width: 1024px) {
+  .feature-steps-panel {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: var(--fib-5);
+    padding: var(--fib-5);
+  }
+}
+
+.feature-step-card {
+  overflow: hidden;
+  border-radius: calc(var(--card-radius) + 2px);
+  border: 1px solid rgba(0, 0, 0, 0.045);
+  background: #fff;
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.02),
+    0 12px 30px rgba(0, 0, 0, 0.032);
+  min-height: 380px;
+  display: grid;
+  grid-template-rows: minmax(0, 1fr) 150px;
+}
+
+.feature-step-card-copy {
+  padding: var(--fib-6);
+  text-align: left;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+}
+
+.feature-step-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  border-radius: 999px;
+  background: #fff7f4;
+  color: #ff5f4f;
+  font-size: 13px;
+  font-weight: 650;
+  letter-spacing: -0.01em;
+  box-shadow: inset 0 0 0 1px rgba(255, 95, 79, 0.14);
+}
+
+.feature-step-card h3 {
+  margin: var(--fib-5) 0 0;
+  color: #1d1d1f;
+  font-size: clamp(1.5rem, 1.75vw, 1.75rem);
+  font-weight: 720;
+  line-height: 1.18;
+  letter-spacing: -0.012em;
+  font-feature-settings:
+    "kern" 1,
+    "palt" 1,
+    "pwid" 1;
+  text-wrap: balance;
+}
+
+.feature-step-card p {
+  max-width: 18.5rem;
+  margin: var(--fib-4) 0 0;
+  color: #6e6e73;
+  font-size: clamp(0.98rem, 1vw, 1.0625rem);
+  line-height: 1.72;
+  letter-spacing: 0;
+  font-feature-settings:
+    "kern" 1,
+    "palt" 1;
+  text-wrap: pretty;
+}
+
+.feature-step-card-visual {
+  min-height: 150px;
+  border-top: 1px solid rgba(0, 0, 0, 0.04);
+  background: radial-gradient(circle at 50% 22%, rgba(255, 95, 79, 0.06), transparent 42%), #fbfbfd;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.feature-step-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 72px;
+  height: 72px;
+  border-radius: 21px;
+  background: #fff;
+  font-size: 34px;
+  box-shadow: 0 14px 34px rgba(0, 0, 0, 0.07);
+}
+
+.feature-step-icon img {
+  width: 30px;
+  height: 30px;
+}
+
+@media (max-width: 767px) {
+  .feature-step-card {
+    min-height: 320px;
+    grid-template-rows: auto 128px;
+  }
+
+  .feature-step-card-copy {
+    padding: var(--fib-5);
+  }
+
+  .feature-step-card p {
+    max-width: none;
+  }
+
+  .feature-step-card-visual {
+    min-height: 128px;
+  }
+}
+
+.feature-principled-section .section-copy {
+  max-width: 39.5rem;
+  margin-top: var(--fib-5);
+}
+
+.feature-principled-section .section-visual {
+  margin-top: var(--fib-8);
+}
+
+@media (min-width: 1024px) {
+  .feature-principled-section .section-visual {
+    margin-top: calc(var(--fib-8) + var(--fib-5));
+  }
+}
+
+/* Principal UI design review: Apple JP-inspired calm hierarchy */
+html {
+  text-rendering: geometricPrecision;
+}
+
+body {
+  background: #fff;
+  color: #1d1d1f;
+}
+
+.page-shell {
+  max-width: var(--page-max);
+}
+
+header.page-shell {
+  height: 64px;
+}
+
+header nav a {
+  letter-spacing: -0.005em;
+  font-feature-settings:
+    "kern" 1,
+    "palt" 1;
+}
+
+.copy-section + .copy-section {
+  padding-top: var(--section-y-tight);
+}
+
+.section-visual {
+  margin-top: var(--module-gap);
+}
+
+.ratio-card {
+  border-color: rgba(0, 0, 0, 0.045);
+  border-radius: var(--card-radius);
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.02),
+    0 18px 44px rgba(0, 0, 0, 0.035);
+}
+
+.ratio-panel {
+  border-color: rgba(0, 0, 0, 0.045);
+  border-radius: var(--panel-radius);
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.02),
+    0 22px 55px rgba(0, 0, 0, 0.04);
+}
+
+.product-carousel-shell,
+.review-video-feature,
+.feature-steps-panel {
+  max-width: var(--module-max);
+  margin-inline: auto;
+}
+
+.product-carousel-stage {
+  height: clamp(380px, 44vw, 580px);
+}
+
+.review-video-feature {
+  min-height: clamp(600px, 68vw, 820px);
+  padding: clamp(55px, 5.6vw, 89px);
+  gap: var(--fib-8);
+}
+
+.review-video-copy h3 {
+  max-width: 25rem;
+  letter-spacing: -0.01em;
+  line-height: 1.1;
+  font-weight: 740;
+  font-feature-settings:
+    "kern" 1,
+    "palt" 1,
+    "pwid" 1;
+  text-wrap: balance;
+}
+
+.review-video-copy p:not(.review-video-eyebrow) {
+  max-width: var(--narrow-copy-max);
+  line-height: 1.72;
+  text-wrap: pretty;
+}
+
+.review-video-stats {
+  margin-top: var(--fib-7);
+  gap: var(--fib-5);
+}
+
+.review-video-stats div {
+  border-color: rgba(0, 0, 0, 0.045);
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.035);
+}
+
+.feature-principled-section .section-copy,
+#features .section-copy {
+  max-width: 39.5rem;
+}
+
+#features {
+  padding-top: var(--section-y-tight);
+}
+
+.feature-steps-panel {
+  border-color: rgba(0, 0, 0, 0.045);
+  background: #f5f5f7;
+  padding: var(--fib-5);
+  gap: var(--fib-5);
+}
+
+.feature-step-card {
+  min-height: 360px;
+  grid-template-rows: minmax(0, 1fr) 132px;
+  border-color: rgba(0, 0, 0, 0.045);
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.02),
+    0 12px 30px rgba(0, 0, 0, 0.03);
+}
+
+.feature-step-card-copy {
+  padding: var(--fib-6);
+}
+
+.feature-step-card h3 {
+  font-size: clamp(1.45rem, 1.55vw, 1.65rem);
+  line-height: 1.18;
+  letter-spacing: -0.012em;
+  font-weight: 720;
+  text-wrap: balance;
+}
+
+.feature-step-card p {
+  max-width: 18.25rem;
+  font-size: clamp(0.98rem, 1vw, 1.045rem);
+  line-height: 1.72;
+  text-wrap: pretty;
+}
+
+.feature-step-card-visual {
+  min-height: 132px;
+  background: #fbfbfd;
+}
+
+.feature-step-icon {
+  width: 68px;
+  height: 68px;
+  border-radius: 21px;
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.06);
+}
+
+#pricing .section-visual,
+#cta.section-visual {
+  margin-top: var(--fib-8);
+}
+
+footer {
+  letter-spacing: 0;
+  color: #6e6e73;
+}
+
+@media (max-width: 900px) {
+  .review-video-feature {
+    gap: var(--fib-7);
+    padding: var(--fib-7) var(--fib-5);
+  }
+
+  .review-video-copy h3 {
+    max-width: none;
+  }
+}
+
+@media (max-width: 640px) {
+  .copy-section {
+    padding-block: var(--fib-7);
+  }
+
+  .copy-section + .copy-section {
+    padding-top: var(--fib-7);
+  }
+
+  .section-visual {
+    margin-top: var(--fib-7);
+  }
+
+  .feature-steps-panel {
+    padding: var(--fib-4);
+  }
+
+  .feature-step-card {
+    min-height: auto;
+    grid-template-rows: auto 120px;
+  }
+
+  .feature-step-card-copy {
+    padding: var(--fib-5);
+  }
+
+  .feature-step-card p {
+    max-width: none;
+  }
+}
+
+/* 1920x1080 Principal UI review: Apple JP-inspired optical balance */
+@media (min-width: 1440px) {
+  .page-shell {
+    max-width: var(--page-max);
+  }
+
+  header.page-shell {
+    height: 56px;
+  }
+
+  .hero-title-jp {
+    max-width: var(--hero-title-max);
+  }
+
+  .hero-copy {
+    max-width: var(--narrow-copy-max);
+  }
+
+  .copy-section {
+    padding-block: var(--section-y);
+  }
+
+  .copy-section + .copy-section {
+    padding-top: var(--section-y-tight);
+  }
+
+  .section-copy {
+    max-width: var(--narrow-copy-max);
+  }
+
+  .section-visual {
+    margin-top: var(--module-gap);
+  }
+
+  .product-carousel-shell {
+    max-width: var(--wide-module-max);
+    margin-inline: auto;
+  }
+
+  .product-carousel-stage {
+    height: 500px;
+  }
+
+  .review-video-feature {
+    max-width: var(--module-max);
+    min-height: 660px;
+    padding: var(--fib-7) var(--fib-8);
+    gap: var(--fib-7);
+    border-radius: var(--panel-radius);
+  }
+
+  .review-video-copy h3 {
+    max-width: 24rem;
+    font-size: clamp(2.125rem, 2.4vw, 3.375rem);
+    line-height: 1.08;
+    letter-spacing: -0.012em;
+  }
+
+  .review-video-copy p:not(.review-video-eyebrow) {
+    max-width: 31rem;
+    font-size: 1rem;
+    line-height: 1.72;
+  }
+
+  .review-video-device {
+    min-height: 520px;
+  }
+
+  .review-video-phone {
+    width: 300px;
+    min-width: 300px;
+  }
+
+  .review-video-stats {
+    margin-top: var(--fib-6);
+  }
+
+  .feature-steps-panel {
+    max-width: var(--module-max);
+    margin-inline: auto;
+    padding: var(--fib-5);
+    gap: var(--fib-5);
+    border-radius: var(--panel-radius);
+  }
+
+  .feature-step-card {
+    min-height: 330px;
+    grid-template-rows: minmax(0, 1fr) 120px;
+    border-radius: var(--card-radius);
+  }
+
+  .feature-step-card-copy {
+    padding: var(--fib-6);
+  }
+
+  .feature-step-card h3 {
+    font-size: 1.5rem;
+    line-height: 1.18;
+  }
+
+  .feature-step-card p {
+    font-size: 0.96rem;
+    line-height: 1.72;
+    max-width: 17.5rem;
+  }
+
+  .feature-step-card-visual {
+    min-height: 120px;
+  }
+
+  .feature-step-icon {
+    width: 64px;
+    height: 64px;
+    border-radius: 20px;
+    font-size: 32px;
+  }
+
+  #pricing .section-visual,
+  .pricing-section .section-visual {
+    margin-top: var(--fib-8);
+  }
+
+  .final-cta-section {
+    padding-top: var(--section-y-tight);
+    padding-bottom: var(--fib-8);
+  }
+
+  footer {
+    padding-top: var(--fib-7);
+    padding-bottom: var(--fib-8);
+  }
+}
+
+@media (min-width: 1440px) and (max-height: 1100px) {
+  main.page-shell {
+    padding-top: 0;
+  }
+
+  main.page-shell > section:first-child {
+    margin-top: var(--fib-6);
+    padding-top: var(--fib-6);
+    padding-bottom: var(--fib-7);
+  }
+
+  main.page-shell > section:first-child h1 {
+    font-size: 3.5rem;
+    line-height: 1.1;
+  }
+
+  main.page-shell > section:first-child .hero-copy {
+    margin-top: var(--fib-5);
+  }
+
+  main.page-shell > section:first-child .hero-actions {
+    margin-top: var(--fib-5);
+    margin-bottom: var(--fib-7);
+  }
+}
+
+/* Optical kerning / Japanese copy refinement */
+.helvetica-title,
+.section-copy,
+.hero-copy,
+.review-video-copy,
+.feature-step-card,
+footer {
+  font-feature-settings:
+    "kern" 1,
+    "palt" 1,
+    "pwid" 1,
+    "liga" 1;
+}
+
+.section-copy,
+.hero-copy,
+.review-video-copy p,
+.feature-step-card p {
+  color: #6e6e73;
+}
+
+.ratio-card,
+.ratio-panel,
+.review-video-feature,
+.feature-steps-panel,
+.product-carousel-shell {
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.018),
+    0 18px 44px rgba(0, 0, 0, 0.035);
+}
+
+/* Final principal UI design review: Apple JP-inspired optical balance */
+html {
+  text-rendering: geometricPrecision;
+}
+
+body {
+  background: #fff;
+  color: #1d1d1f;
+  letter-spacing: 0;
+}
+
+.page-shell {
+  max-width: var(--page-max);
+}
+
+header.page-shell {
+  height: 56px;
+}
+
+header nav a,
+header a {
+  letter-spacing: -0.004em;
+  font-feature-settings:
+    "kern" 1,
+    "palt" 1;
+}
+
+.copy-section + .copy-section {
+  padding-top: var(--section-y-tight);
+}
+
+.section-visual {
+  margin-top: var(--module-gap);
+}
+
+.hero-title-jp {
+  max-width: var(--hero-title-max);
+}
+
+.ratio-card,
+.ratio-panel,
+.review-video-feature,
+.feature-steps-panel,
+.product-carousel-shell {
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.018),
+    0 18px 44px rgba(0, 0, 0, 0.033);
+}
+
+.product-carousel-shell {
+  max-width: var(--wide-module-max);
+  margin-inline: auto;
+}
+
+.product-carousel-stage {
+  height: clamp(380px, 42vw, 560px);
+}
+
+.review-video-feature {
+  max-width: var(--module-max);
+  min-height: clamp(600px, 64vw, 800px);
+  padding: clamp(55px, 5vw, 89px);
+  gap: var(--fib-7);
+  border-radius: var(--panel-radius);
+  margin-inline: auto;
+}
+
+.review-video-copy h3 {
+  max-width: 23.5rem;
+  font-size: clamp(2rem, 2.35vw, 3.25rem);
+  line-height: 1.08;
+  letter-spacing: -0.012em;
+  font-weight: 740;
+  font-feature-settings:
+    "kern" 1,
+    "palt" 1,
+    "pwid" 1;
+  text-wrap: balance;
+}
+
+.review-video-copy p:not(.review-video-eyebrow) {
+  max-width: 30rem;
+  font-size: clamp(0.975rem, 1.05vw, 1.0625rem);
+  line-height: 1.72;
+  text-wrap: pretty;
+}
+
+.review-video-device {
+  min-height: clamp(480px, 52vw, 610px);
+}
+
+.review-video-phone {
+  width: min(300px, 29vw);
+  min-width: 270px;
+}
+
+.review-video-stats {
+  margin-top: var(--fib-6);
+  gap: var(--fib-5);
+}
+
+.review-video-stats div {
+  border-color: rgba(0, 0, 0, 0.045);
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.032);
+}
+
+#features {
+  padding-top: var(--section-y-tight);
+}
+
+#features .section-copy,
+.feature-principled-section .section-copy {
+  max-width: 38.5rem;
+}
+
+.feature-steps-panel {
+  max-width: var(--module-max);
+  margin-inline: auto;
+  padding: var(--fib-5);
+  gap: var(--fib-5);
+  border-color: rgba(0, 0, 0, 0.045);
+  border-radius: var(--panel-radius);
+  background: #f5f5f7;
+}
+
+.feature-step-card {
+  min-height: 332px;
+  grid-template-rows: minmax(0, 1fr) 118px;
+  border-color: rgba(0, 0, 0, 0.045);
+  border-radius: var(--card-radius);
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.018),
+    0 12px 30px rgba(0, 0, 0, 0.03);
+}
+
+.feature-step-card-copy {
+  padding: var(--fib-6);
+}
+
+.feature-step-card h3 {
+  font-size: clamp(1.425rem, 1.52vw, 1.625rem);
+  line-height: 1.18;
+  letter-spacing: -0.012em;
+  font-weight: 720;
+  font-feature-settings:
+    "kern" 1,
+    "palt" 1,
+    "pwid" 1;
+  text-wrap: balance;
+}
+
+.feature-step-card p {
+  max-width: 17.75rem;
+  font-size: clamp(0.955rem, 0.98vw, 1rem);
+  line-height: 1.72;
+  color: #6e6e73;
+  text-wrap: pretty;
+}
+
+.feature-step-card-visual {
+  min-height: 118px;
+  background: #fbfbfd;
+}
+
+.feature-step-icon {
+  width: 64px;
+  height: 64px;
+  border-radius: 20px;
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.058);
+  font-size: 32px;
+}
+
+#pricing .section-visual,
+.pricing-section .section-visual {
+  margin-top: var(--fib-8);
+}
+
+.final-cta-section {
+  padding-top: var(--section-y-tight);
+  padding-bottom: var(--fib-8);
+}
+
+footer {
+  padding-top: var(--fib-7);
+  padding-bottom: var(--fib-8);
+  color: #6e6e73;
+  letter-spacing: 0;
+  font-feature-settings:
+    "kern" 1,
+    "palt" 1;
+}
+
+@media (min-width: 1440px) and (max-height: 1100px) {
+  main.page-shell > section:first-child {
+    margin-top: var(--fib-6);
+    padding-top: var(--fib-6);
+    padding-bottom: var(--fib-7);
+  }
+
+  main.page-shell > section:first-child h1 {
+    font-size: 3.45rem;
+    line-height: 1.1;
+  }
+
+  main.page-shell > section:first-child .hero-copy {
+    margin-top: var(--fib-5);
+  }
+
+  main.page-shell > section:first-child .hero-actions {
+    margin-top: var(--fib-5);
+    margin-bottom: var(--fib-7);
+  }
+}
+
+@media (max-width: 900px) {
+  .review-video-feature {
+    gap: var(--fib-7);
+    padding: var(--fib-7) var(--fib-5);
+  }
+
+  .review-video-copy h3 {
+    max-width: none;
+  }
+}
+
+@media (max-width: 640px) {
+  .copy-section {
+    padding-block: var(--fib-7);
+  }
+
+  .copy-section + .copy-section {
+    padding-top: var(--fib-7);
+  }
+
+  .section-visual {
+    margin-top: var(--fib-7);
+  }
+
+  .feature-steps-panel {
+    padding: var(--fib-4);
+  }
+
+  .feature-step-card {
+    min-height: auto;
+    grid-template-rows: auto 112px;
+  }
+
+  .feature-step-card-copy {
+    padding: var(--fib-5);
+  }
+
+  .feature-step-card p {
+    max-width: none;
+  }
+}
+
+/* Hero/header principal refinement: Apple JP-inspired air and optical rhythm */
+.hero-section {
+  margin-top: var(--fib-8) !important;
+  padding-top: var(--fib-6) !important;
+  padding-bottom: var(--fib-8) !important;
+}
+
+.hero-section .hero-title-jp {
+  max-width: 45rem;
+  letter-spacing: -0.009em;
+  line-height: 1.13;
+}
+
+.hero-section .hero-copy {
+  max-width: 36rem;
+  margin-top: var(--fib-6);
+  font-size: clamp(1rem, 1.08vw, 1.125rem);
+  line-height: 1.72;
+}
+
+.hero-section .hero-actions {
+  margin-top: var(--fib-6);
+  margin-bottom: var(--fib-8);
+}
+
+.hero-section .section-visual,
+.hero-section .product-carousel-shell {
+  margin-top: 0;
+}
+
+.hero-section + section {
+  padding-top: var(--section-y-tight);
+}
+
+@media (min-width: 1440px) and (max-height: 1100px) {
+  .hero-section {
+    margin-top: 5.5625rem !important;
+    padding-top: var(--fib-6) !important;
+    padding-bottom: var(--fib-8) !important;
+  }
+
+  .hero-section h1 {
+    font-size: 3.75rem !important;
+    line-height: 1.12 !important;
+  }
+
+  .hero-section .hero-copy {
+    margin-top: var(--fib-6) !important;
+  }
+
+  .hero-section .hero-actions {
+    margin-top: var(--fib-6) !important;
+    margin-bottom: var(--fib-8) !important;
+  }
+
+  .hero-section .product-carousel-stage {
+    height: 500px;
+  }
+}
+
+@media (max-width: 768px) {
+  .hero-section {
+    margin-top: var(--fib-7) !important;
+    padding-top: var(--fib-5) !important;
+    padding-bottom: var(--fib-7) !important;
+  }
+
+  .hero-section .hero-copy {
+    margin-top: var(--fib-5);
+  }
+
+  .hero-section .hero-actions {
+    margin-top: var(--fib-5);
+    margin-bottom: var(--fib-7);
+  }
+}
+
+header nav {
+  gap: var(--fib-6);
+}
+
+header nav a {
+  white-space: nowrap;
+}
+
+@media (min-width: 1440px) {
+  header nav {
+    gap: var(--fib-6);
+  }
+}
+
+/* CTA hierarchy: persistent header action is quiet; hero action is primary */
+.header-cta {
+  min-height: 40px !important;
+  padding-inline: var(--fib-5) !important;
+  padding-block: var(--fib-2) !important;
+  font-size: 0.875rem !important;
+  font-weight: 650 !important;
+  box-shadow: none !important;
+  background: #ff6b5c !important;
+}
+
+.header-cta:hover {
+  background: #ff5f4f !important;
+}
+
+.hero-main-cta {
+  min-height: 52px !important;
+  padding-inline: var(--fib-6) !important;
+  padding-block: var(--fib-4) !important;
+  font-size: 1rem !important;
+  font-weight: 700 !important;
+  box-shadow: 0 8px 26px rgba(255, 95, 79, 0.2) !important;
+}
+
+.hero-main-cta:hover {
+  background: #ff5144 !important;
+}
+
+@media (max-width: 767px) {
+  .header-cta {
+    display: none !important;
+  }
+
+  .hero-main-cta {
+    min-height: 50px !important;
+  }
+}
+
+/* Final principal UI review: Apple JP-inspired spacing, typography, kerning */
+html {
+  text-rendering: geometricPrecision;
+  scroll-behavior: smooth;
+}
+
+body {
+  background: #fff;
+  color: #1d1d1f;
+  letter-spacing: 0;
+}
+
+.page-shell {
+  max-width: var(--page-max);
+}
+
+header.page-shell {
+  height: 56px;
+}
+
+header nav {
+  gap: var(--fib-6);
+}
+
+header nav a,
+header a {
+  letter-spacing: -0.004em;
+  font-feature-settings:
+    "kern" 1,
+    "palt" 1;
+  white-space: nowrap;
+}
+
+.hero-section {
+  margin-top: var(--fib-8) !important;
+  padding-top: var(--fib-6) !important;
+  padding-bottom: var(--fib-8) !important;
+}
+
+.hero-section .hero-title-jp {
+  max-width: var(--hero-title-max);
+  letter-spacing: -0.009em;
+  line-height: 1.13;
+}
+
+.hero-section .hero-copy {
+  max-width: var(--narrow-copy-max);
+  margin-top: var(--fib-6);
+}
+
+.hero-section .hero-actions {
+  margin-top: var(--fib-6);
+  margin-bottom: var(--fib-8);
+}
+
+.copy-section + .copy-section {
+  padding-top: var(--section-y-tight);
+}
+
+.section-visual {
+  margin-top: var(--module-gap);
+}
+
+.ratio-card,
+.ratio-panel,
+.review-video-feature,
+.feature-steps-panel,
+.product-carousel-shell {
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.018),
+    0 18px 44px rgba(0, 0, 0, 0.033);
+}
+
+.product-carousel-shell {
+  max-width: var(--wide-module-max);
+  margin-inline: auto;
+}
+
+.product-carousel-stage {
+  height: clamp(380px, 42vw, 560px);
+}
+
+.review-video-feature {
+  max-width: var(--module-max);
+  min-height: clamp(600px, 64vw, 800px);
+  padding: clamp(55px, 5vw, 89px);
+  gap: var(--fib-7);
+  border-radius: var(--panel-radius);
+  margin-inline: auto;
+}
+
+.review-video-copy h3 {
+  max-width: 23.5rem;
+  font-size: clamp(2rem, 2.35vw, 3.25rem);
+  line-height: 1.08;
+  letter-spacing: -0.012em;
+  font-weight: 740;
+  font-feature-settings:
+    "kern" 1,
+    "palt" 1,
+    "pwid" 1;
+  text-wrap: balance;
+}
+
+.review-video-copy p:not(.review-video-eyebrow) {
+  max-width: 30rem;
+  font-size: clamp(0.975rem, 1.05vw, 1.0625rem);
+  line-height: 1.72;
+  text-wrap: pretty;
+}
+
+.review-video-device {
+  min-height: clamp(480px, 52vw, 610px);
+}
+
+.review-video-phone {
+  width: min(300px, 29vw);
+  min-width: 270px;
+}
+
+.review-video-stats {
+  margin-top: var(--fib-6);
+  gap: var(--fib-5);
+}
+
+.review-video-stats div {
+  border-color: rgba(0, 0, 0, 0.045);
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.032);
+}
+
+#features {
+  padding-top: var(--section-y-tight);
+}
+
+#features .section-copy,
+.feature-principled-section .section-copy {
+  max-width: 38.5rem;
+}
+
+.feature-steps-panel {
+  max-width: var(--module-max);
+  margin-inline: auto;
+  padding: var(--fib-5);
+  gap: var(--fib-5);
+  border-color: rgba(0, 0, 0, 0.045);
+  border-radius: var(--panel-radius);
+  background: #f5f5f7;
+}
+
+.feature-step-card {
+  min-height: 332px;
+  grid-template-rows: minmax(0, 1fr) 118px;
+  border-color: rgba(0, 0, 0, 0.045);
+  border-radius: var(--card-radius);
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.018),
+    0 12px 30px rgba(0, 0, 0, 0.03);
+}
+
+.feature-step-card-copy {
+  padding: var(--fib-6);
+}
+
+.feature-step-card h3 {
+  font-size: clamp(1.425rem, 1.52vw, 1.625rem);
+  line-height: 1.18;
+  letter-spacing: -0.012em;
+  font-weight: 720;
+  font-feature-settings:
+    "kern" 1,
+    "palt" 1,
+    "pwid" 1;
+  text-wrap: balance;
+}
+
+.feature-step-card p {
+  max-width: 17.75rem;
+  font-size: clamp(0.955rem, 0.98vw, 1rem);
+  line-height: 1.72;
+  color: #6e6e73;
+  text-wrap: pretty;
+}
+
+.feature-step-card-visual {
+  min-height: 118px;
+  background: #fbfbfd;
+}
+
+.feature-step-icon {
+  width: 64px;
+  height: 64px;
+  border-radius: 20px;
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.058);
+  font-size: 32px;
+}
+
+.header-cta {
+  min-height: 40px !important;
+  padding-inline: var(--fib-5) !important;
+  padding-block: var(--fib-2) !important;
+  font-size: 0.875rem !important;
+  font-weight: 650 !important;
+  box-shadow: none !important;
+  background: #ff6b5c !important;
+}
+
+.hero-main-cta {
+  min-height: 52px !important;
+  padding-inline: var(--fib-6) !important;
+  padding-block: var(--fib-4) !important;
+  font-size: 1rem !important;
+  font-weight: 700 !important;
+  box-shadow: 0 8px 26px rgba(255, 95, 79, 0.2) !important;
+}
+
+#pricing .section-visual,
+.pricing-section .section-visual {
+  margin-top: var(--fib-8);
+}
+
+.final-cta-section {
+  padding-top: var(--section-y-tight);
+  padding-bottom: var(--fib-8);
+}
+
+footer {
+  padding-top: var(--fib-7);
+  padding-bottom: var(--fib-8);
+  color: #6e6e73;
+  letter-spacing: 0;
+  font-feature-settings:
+    "kern" 1,
+    "palt" 1;
+}
+
+@media (min-width: 1440px) and (max-height: 1100px) {
+  .hero-section {
+    margin-top: var(--fib-8) !important;
+    padding-top: var(--fib-6) !important;
+    padding-bottom: var(--fib-8) !important;
+  }
+
+  .hero-section h1 {
+    font-size: 3.75rem !important;
+    line-height: 1.12 !important;
+  }
+
+  .hero-section .hero-copy {
+    margin-top: var(--fib-6) !important;
+  }
+
+  .hero-section .hero-actions {
+    margin-top: var(--fib-6) !important;
+    margin-bottom: var(--fib-8) !important;
+  }
+}
+
+@media (max-width: 900px) {
+  .review-video-feature {
+    gap: var(--fib-7);
+    padding: var(--fib-7) var(--fib-5);
+  }
+
+  .review-video-copy h3 {
+    max-width: none;
+  }
+}
+
+@media (max-width: 767px) {
+  .header-cta {
+    display: none !important;
+  }
+}
+
+@media (max-width: 640px) {
+  .copy-section {
+    padding-block: var(--fib-7);
+  }
+
+  .copy-section + .copy-section {
+    padding-top: var(--fib-7);
+  }
+
+  .section-visual {
+    margin-top: var(--fib-7);
+  }
+
+  .feature-steps-panel {
+    padding: var(--fib-4);
+  }
+
+  .feature-step-card {
+    min-height: auto;
+    grid-template-rows: auto 112px;
+  }
+
+  .feature-step-card-copy {
+    padding: var(--fib-5);
+  }
+
+  .feature-step-card p {
+    max-width: none;
+  }
+}

--- a/site/src/main.jsx
+++ b/site/src/main.jsx
@@ -1,5 +1,5 @@
-import { createRoot } from 'react-dom/client';
-import App from './App.jsx';
-import './index.css';
+import { createRoot } from "react-dom/client";
+import App from "./App.jsx";
+import "./index.css";
 
-createRoot(document.getElementById('root')).render(<App />);
+createRoot(document.getElementById("root")).render(<App />);


### PR DESCRIPTION
## Summary

The landing page (`site/`) shipped as its own Vite workspace but, unlike `frontend/`, had no linter, formatter, or unused-code detection, and its dependencies were managed by Renovate's catch-all `frontend` rule despite being a separate workspace with its own lockfile and deploy cadence. This brings `site/` to the same tooling baseline: Biome + Knip with config / scripts / pinned devDeps, a dedicated Renovate group, and a CI lint gate in `landing.yml` whose toolchain is now provisioned by `jdx/mise-action@v4` like the other JS workflows.

This branch addresses no GitHub issue (requested in-session).

## Background / Motivation

- `site/` was extracted into a standalone Vite + React workspace in #517 but never gained a linter/formatter or unused-export detection, while `frontend/` gates Biome + Knip in CI — the two surfaces had drifted apart.
- `site/package.json` was already detected by Renovate's `npm` manager, but it rode the catch-all `frontend dependencies` rule, so its bumps were mislabeled `frontend` even though it is a separate workspace with its own lockfile and gh-pages deploy cadence.
- `landing.yml` provisioned Node via a bespoke `setup-node` + `corepack` pair, diverging from `frontend` / `e2e` / `frontend-mutation`, which all provision Node + pnpm from `.tool-versions` via `jdx/mise-action@v4`.
- Renovate has no dedicated `pnpm` manager — the `npm` manager handles pnpm, `pnpm-lock.yaml`, and `pnpm-workspace.yaml` — so scoping `site/` must go through `matchFileNames`, not a `pnpm` matcher.

## Changes

### Biome + Knip in `site/`

- `site/biome.json` — mirrors `frontend/biome.json` (space/2, lineWidth 100, double quotes, organize-imports), tuned for the Vite/JS landing page: keeps `tailwindDirectives` and disables `noImportantStyles` / `noDescendingSpecificity` / `noUnknownAtRules`, which fight the hand-authored marketing CSS and the `@tailwind` directives.
- `site/knip.json` — minimal config; Knip auto-detects the Vite entry and the postcss/tailwind/biome plugins.
- `site/package.json` — adds `lint` (`biome check --error-on-warnings .`), `lint:fix`, `format`, and `knip` scripts plus `@biomejs/biome` `2.4.16` and `knip` `^6.14.0` (pinned to match `frontend/`); `pnpm-lock.yaml` refreshed for `--frozen-lockfile`.

### Formatter adoption + genuine fixes (`App.jsx` / `index.css` / `main.jsx`)

- The Biome formatter was applied on adoption — the bulk of the diff is mechanical (de-indenting code ported verbatim from the old inline `<script>`/`<style>`, plus CSS value normalization: lowercase hex, zero-padding, long value-list wrapping). `git diff -w` shows no semantic CSS change.
- Removed the unused `logos` array and the unrendered `MailIcon` component (`noUnusedVariables`).
- `type="button"` on the mobile menu toggle (`useButtonType`); `href="#top"` on the logo (`useValidAnchor`).
- Dropped mis-applied `aria-label`s from three generic `<div>`s (`useAriaPropsSupportedByRole`) — the carousel dots are individually labeled and the demo videos are decorative autoplay loops.
- One `biome-ignore` for the intentional static index key in `HeroWords` (the words come from splitting a fixed title and never reorder).

### Renovate scope (`renovate.json`)

- New `matchFileNames: ["site/**"]` rule → group `landing dependencies`, labels `[landing, dependencies]`, `semanticCommitScope: "site"`, `rangeStrategy: "replace"`. Placed before the `pnpm toolchain` rule so `site/package.json`'s `packageManager` pnpm pin still groups with the root pnpm pin. The description records that `matchManagers` stays `npm` because Renovate has no `pnpm` manager.

### CI gate (`.github/workflows/landing.yml`)

- Adds a `pull_request` trigger (paths `site/**`, the workflow file) and a `lint` job that runs `pnpm lint` (Biome) + `pnpm knip` over `site/`.
- Node + pnpm are now provisioned by `jdx/mise-action@v4` from the repo-root `.tool-versions` (replacing `setup-node` + `corepack`), with a pnpm-store cache, matching the other JS workflows.
- The `publish` job gains `needs: lint` and `if: github.event_name != 'pull_request'`, so PRs run lint only and build/deploy runs on push to `main` / manual dispatch after lint passes. Permissions are now per-job (`lint: contents: read`, `publish: contents: write`).

## Verification

```bash
cd site
pnpm install --frozen-lockfile                       # lockfile in sync (CI parity)
./node_modules/.bin/biome check --error-on-warnings . # lint + format check
./node_modules/.bin/knip                              # unused files / deps / exports
./node_modules/.bin/vite build                        # 27 modules; emits dist/
```

All green locally. On this PR, the new `lint` job runs Biome + Knip over `site/`; `publish` is skipped on the PR and only runs after merge to `main`, republishing `site/dist/` to the gh-pages root exactly as before.

## Test plan

- [ ] CI: the `landing` workflow's `lint` job runs on this PR (paths `site/**`) and passes Biome + Knip; the `publish` job is skipped.
- [ ] After merge, a push to `main` touching `site/**` runs `lint` then `publish`, republishing `site/dist/` to gh-pages.
- [ ] Open the landing page after deploy and confirm it renders unchanged (the menu toggle, logo link, carousel, and demo videos all work).
- [ ] Renovate: a future `site/` dependency bump opens a PR labeled `landing` with `semanticCommitScope: "site"`, separate from `frontend` bumps.


## Merge note (origin/main)

`origin/main` was merged into this branch. The only conflicts were in `site/` because #511 ("renovate/major-frontend-dependencies") swept the landing page into a major bump — `react`/`react-dom` → 19, `tailwindcss` → 4.3.0, `vite` → 8, `@vitejs/plugin-react` → 6 — **without migrating** `index.css` / `postcss.config.js` / `tailwind.config.js`, which left `pnpm build` failing (`tailwindcss` v4 moved its PostCSS plugin to `@tailwindcss/postcss`). That sweep is exactly the mislabeling this PR fixes: `site/` rode the catch-all `frontend` rule.

Resolution: `site/` is kept on its deliberate pins (`react` 18.3.1 / `tailwindcss` 3.4.17 / `vite` ^6.0.7 / `@vitejs/plugin-react` ^4.3.4) plus the new Biome + Knip devDeps; `site/pnpm-lock.yaml` is regenerated to match. `frontend/`'s bumps from #511 are untouched. A deliberate Tailwind v4 / React 19 migration for the landing page is left as a separate, reviewed change — which the new `landing dependencies` Renovate group now makes possible independently of `frontend`.
