### PR TITLE
feat(frontend): master card editing UI (list + CRUD + bulk + import)

### DIFF
--- a/frontend/__tests__/admin-master-cards.test.tsx
+++ b/frontend/__tests__/admin-master-cards.test.tsx
@@ -1,0 +1,260 @@
+// @vitest-environment jsdom
+/**
+ * Broad page-level test for the MasterManagementClient tree.
+ * Exercises the full card-editor integration: SSR-seeded render and
+ * live-count propagation from the cards client up to the header badge
+ * (onTotalCountChange → liveCount → MasterEditHeader).
+ *
+ * Mirror: frontend/__tests__/admin-masters-edit.test.tsx (provider stack)
+ * Mirror: frontend/__tests__/cards-bulk-delete.test.tsx (interaction style)
+ */
+
+vi.mock("next/navigation", () => ({
+  redirect: vi.fn((url: string) => {
+    throw new Error(`REDIRECT:${url}`);
+  }),
+  notFound: vi.fn(() => {
+    throw new Error("NOT_FOUND");
+  }),
+  useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
+  // UndoDeleteProvider calls usePathname to detect navigation flushes.
+  usePathname: () => "/admin/masters/m-broad-1/edit",
+}));
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    ...rest
+  }: {
+    href: string;
+    children: React.ReactNode;
+    [key: string]: unknown;
+  }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+// MasterCardRow wraps each card in SwipeableRow; stub it to avoid gesture-lib load.
+vi.mock("@/components/cardgroups/swipeable-row", async () => {
+  const { forwardRef } = await import("react");
+  return {
+    SwipeableRow: forwardRef(function Mock(
+      { children }: { children: React.ReactNode },
+      _ref: React.Ref<{ close(): void }>,
+    ) {
+      return <div>{children}</div>;
+    }),
+  };
+});
+
+import { MockedProvider } from "@apollo/client/testing/react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { NextIntlClientProvider } from "next-intl";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { masterCardsDefaultVars } from "@/app/admin/masters/[id]/edit/cards/queries";
+import { MasterManagementClient } from "@/app/admin/masters/[id]/edit/master-management-client";
+import {
+  AdminCreateMasterCardDocument,
+  AdminMasterCardsConnectionDocument,
+} from "@/generated/graphql";
+import { UndoDeleteProvider } from "@/lib/undo-delete";
+import enMessages from "../messages/en.json";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const ID = "m-broad-1";
+const C1 = "c-broad-1";
+
+const DECK = {
+  __typename: "MasterCardgroup" as const,
+  id: ID,
+  name: "Broad Test Deck",
+  description: null,
+  language: null,
+  level: null,
+  category: null,
+  coverImageUrl: null,
+  source: null,
+  version: 1,
+  status: "DRAFT" as const,
+  isDefaultStarter: false,
+  sortOrder: 0,
+  cardCount: 1,
+  createdAt: "2026-01-01T00:00:00Z",
+  updatedAt: "2026-01-01T00:00:00Z",
+};
+
+const INITIAL_EDGE = {
+  __typename: "MasterCardEdge" as const,
+  cursor: C1,
+  node: {
+    __typename: "MasterCard" as const,
+    id: C1,
+    masterCardgroupId: ID,
+    front: "apple",
+    back: "apple-back",
+    position: 0,
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+  },
+};
+
+const INITIAL_PAGE_INFO = {
+  __typename: "PageInfo" as const,
+  hasNextPage: false,
+  hasPreviousPage: false,
+  startCursor: C1,
+  endCursor: C1,
+};
+
+// MockedProvider mock: the connection query fired by useMasterCardsConnection
+// on mount (seeded from the SSR props, no network round-trip needed here — the
+// mock is provided so any background refetch does not generate an unmatched warn).
+const connMock = {
+  request: {
+    query: AdminMasterCardsConnectionDocument,
+    variables: masterCardsDefaultVars(ID),
+  },
+  result: {
+    data: {
+      adminMasterCardsConnection: {
+        __typename: "MasterCardConnection",
+        edges: [INITIAL_EDGE],
+        pageInfo: INITIAL_PAGE_INFO,
+        totalCount: 1,
+      },
+    },
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Render helper
+// ---------------------------------------------------------------------------
+
+// Stub IntersectionObserver so the IO-driven pagination sentinel is a no-op.
+class FakeIO {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+  takeRecords(): IntersectionObserverEntry[] {
+    return [];
+  }
+}
+
+beforeEach(() => {
+  vi.stubGlobal("IntersectionObserver", FakeIO);
+});
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+function renderClient(mocks: object[] = [connMock]) {
+  render(
+    <MockedProvider mocks={mocks as never}>
+      <NextIntlClientProvider locale="en" messages={enMessages} timeZone="UTC">
+        <UndoDeleteProvider>
+          <MasterManagementClient
+            master={DECK}
+            initialEdges={[INITIAL_EDGE]}
+            initialPageInfo={INITIAL_PAGE_INFO}
+            initialTotalCount={1}
+          />
+        </UndoDeleteProvider>
+      </NextIntlClientProvider>
+    </MockedProvider>,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("MasterManagementClient — broad page integration", () => {
+  // T1: Seed render — the seeded card's front text is visible and the header
+  // reflects the initial total count (1 card).
+  it("renders the seeded card and shows the initial card count in the header", async () => {
+    renderClient();
+
+    // The seeded card's front text appears in the card list.
+    expect(screen.getByText("apple")).toBeInTheDocument();
+
+    // The header status badge region renders the AdminMasters.cardCount message.
+    // With count=1 the ICU plural resolves to "1 card".
+    await waitFor(() => {
+      expect(screen.getByText("1 card")).toBeInTheDocument();
+    });
+  });
+
+  // T2: Live count on create — open the add-card sheet, fill front + back,
+  // submit with a mocked AdminCreateMasterCard success. The create's cache write
+  // bumps the connection's totalCount, which flows up via onTotalCountChange,
+  // and the header updates from "1 card" to "2 cards".
+  it("updates the header count from 1 to 2 after a successful card create", async () => {
+    const user = userEvent.setup();
+    const C2 = "c-broad-2";
+
+    const createMock = {
+      request: {
+        query: AdminCreateMasterCardDocument,
+        variables: {
+          input: {
+            masterCardgroupId: ID,
+            front: "banana",
+            back: "banana-back",
+          },
+        },
+      },
+      result: {
+        data: {
+          adminCreateMasterCard: {
+            __typename: "CreateMasterCardSuccess",
+            masterCard: {
+              __typename: "MasterCard",
+              id: C2,
+              masterCardgroupId: ID,
+              front: "banana",
+              back: "banana-back",
+              position: 1,
+              createdAt: "2026-01-02T00:00:00Z",
+              updatedAt: "2026-01-02T00:00:00Z",
+            },
+          },
+        },
+      },
+    };
+
+    renderClient([connMock, createMock]);
+
+    // Confirm initial count before mutation.
+    await waitFor(() => {
+      expect(screen.getByText("1 card")).toBeInTheDocument();
+    });
+
+    // Open the add-card sheet via the toolbar "Add card" button.
+    await user.click(screen.getByRole("button", { name: /add card/i }));
+
+    // The CardForm renders labeled inputs: "Front" and "Back".
+    const frontInput = await screen.findByLabelText(/front/i);
+    const backInput = screen.getByLabelText(/back/i);
+
+    await user.type(frontInput, "banana");
+    await user.type(backInput, "banana-back");
+
+    // Submit the form. The label for the create button resolves to "Add" (the
+    // default for mode="create" when no submitLabel prop is passed).
+    await user.click(screen.getByRole("button", { name: /^add$/i }));
+
+    // After a successful create the cache is updated (+1 to totalCount) and the
+    // useEffect in MasterCardsClient calls onTotalCountChange(2), which updates
+    // liveCount in MasterManagementClient and re-renders MasterEditHeader with
+    // count=2. The ICU plural for count=2 resolves to "2 cards".
+    await waitFor(() => {
+      expect(screen.getByText("2 cards")).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/__tests__/admin-masters-edit.test.tsx
+++ b/frontend/__tests__/admin-masters-edit.test.tsx
@@ -11,6 +11,7 @@ vi.mock("next/navigation", () => ({
     throw new Error("NOT_FOUND");
   }),
   useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
+  usePathname: () => "/admin/masters/m-int-1/edit",
 }));
 vi.mock("next/link", () => ({
   default: ({ href, children, ...rest }: { href: string; children: React.ReactNode }) => (
@@ -23,12 +24,26 @@ vi.mock("next/headers", () => ({
   headers: vi.fn(async () => new Headers({ "x-auth-status": "authenticated" })),
 }));
 vi.mock("@/lib/apollo/server", () => ({ gqlFetch: vi.fn() }));
+vi.mock("@/components/cardgroups/swipeable-row", async () => {
+  const { forwardRef } = await import("react");
+  return {
+    SwipeableRow: forwardRef(function Mock(
+      { children }: { children: React.ReactNode },
+      _ref: React.Ref<{ close(): void }>,
+    ) {
+      return <div>{children}</div>;
+    }),
+  };
+});
 
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 import { NextIntlClientProvider } from "next-intl";
+import { masterCardsDefaultVars } from "@/app/admin/masters/[id]/edit/cards/queries";
 import EditMasterPage from "@/app/admin/masters/[id]/edit/page";
+import { AdminMasterCardsConnectionDocument } from "@/generated/graphql";
 import { gqlFetch } from "@/lib/apollo/server";
+import { UndoDeleteProvider } from "@/lib/undo-delete";
 import enMessages from "../messages/en.json";
 
 const ID = "m-int-1";
@@ -51,12 +66,35 @@ const DECK = {
   updatedAt: "2026-01-01T00:00:00Z",
 };
 
+const connMock = {
+  request: {
+    query: AdminMasterCardsConnectionDocument,
+    variables: masterCardsDefaultVars(ID),
+  },
+  result: {
+    data: {
+      adminMasterCardsConnection: {
+        __typename: "MasterCardConnection",
+        edges: [],
+        pageInfo: {
+          __typename: "PageInfo",
+          hasNextPage: false,
+          hasPreviousPage: false,
+          startCursor: null,
+          endCursor: null,
+        },
+        totalCount: 4,
+      },
+    },
+  },
+};
+
 async function renderPage() {
   const jsx = await EditMasterPage({ params: Promise.resolve({ id: ID }) });
   render(
-    <MockedProvider mocks={[]}>
+    <MockedProvider mocks={[connMock]}>
       <NextIntlClientProvider locale="en" messages={enMessages} timeZone="UTC">
-        {jsx as React.ReactElement}
+        <UndoDeleteProvider>{jsx as React.ReactElement}</UndoDeleteProvider>
       </NextIntlClientProvider>
     </MockedProvider>,
   );
@@ -66,7 +104,7 @@ beforeEach(() => vi.clearAllMocks());
 afterEach(() => vi.clearAllMocks());
 
 describe("EditMasterPage — broad integration", () => {
-  it("renders the deck name as the h1 and mounts the cards-section placeholder", async () => {
+  it("renders the deck name as the h1 and mounts the cards section", async () => {
     vi.mocked(gqlFetch)
       .mockResolvedValueOnce({ adminMaster: DECK } as never)
       .mockResolvedValueOnce({

--- a/frontend/__tests__/admin-masters-edit.test.tsx
+++ b/frontend/__tests__/admin-masters-edit.test.tsx
@@ -67,7 +67,20 @@ afterEach(() => vi.clearAllMocks());
 
 describe("EditMasterPage — broad integration", () => {
   it("renders the deck name as the h1 and mounts the cards-section placeholder", async () => {
-    vi.mocked(gqlFetch).mockResolvedValueOnce({ adminMaster: DECK } as never);
+    vi.mocked(gqlFetch)
+      .mockResolvedValueOnce({ adminMaster: DECK } as never)
+      .mockResolvedValueOnce({
+        adminMasterCardsConnection: {
+          edges: [],
+          pageInfo: {
+            hasNextPage: false,
+            hasPreviousPage: false,
+            startCursor: null,
+            endCursor: null,
+          },
+          totalCount: 4,
+        },
+      } as never);
     await renderPage();
     expect(screen.getByRole("heading", { level: 1, name: "Integration Deck" })).toBeInTheDocument();
     expect(screen.getByTestId("master-cards-section")).toBeInTheDocument();

--- a/frontend/e2e/admin-masters-edit.spec.ts
+++ b/frontend/e2e/admin-masters-edit.spec.ts
@@ -53,7 +53,7 @@ test.describe("admin master card CRUD", () => {
     await page.getByTestId("master-add-card").click();
     await page.locator("#add-card-front-field").fill(cardFront);
     await page.locator("#add-card-back-field").fill(cardBack);
-    await page.getByRole("dialog").locator('button[type="submit"]').click();
+    await page.locator('[data-testid="form-sheet-body"]').locator('button[type="submit"]').click();
     // Assert the new card row is now visible in the list.
     await expect(page.getByText(cardFront)).toBeVisible({ timeout: 10_000 });
 
@@ -62,9 +62,11 @@ test.describe("admin master card CRUD", () => {
     // Locate the card row by front text and click its edit-target.
     const cardRow = page.locator("li").filter({ hasText: cardFront });
     await cardRow.locator('[data-testid^="card-edit-target-"]').click();
-    const backInput = page.getByRole("dialog").locator('[id$="-back-field"]');
+    const backInput = page
+      .locator('[data-testid="form-sheet-body"]')
+      .locator('[id$="-back-field"]');
     await backInput.fill(editedBack);
-    await page.getByRole("dialog").locator('button[type="submit"]').click();
+    await page.locator('[data-testid="form-sheet-body"]').locator('button[type="submit"]').click();
     // Assert the edited back text is visible.
     await expect(page.getByText(editedBack)).toBeVisible({ timeout: 10_000 });
 

--- a/frontend/e2e/admin-masters-edit.spec.ts
+++ b/frontend/e2e/admin-masters-edit.spec.ts
@@ -27,3 +27,53 @@ test.describe("admin master edit navigation", () => {
     await expect(page.getByTestId("master-field-name")).toBeVisible();
   });
 });
+
+test.describe("admin master card CRUD", () => {
+  test("add then edit then delete a card on the master edit page", async ({ context, page }) => {
+    const runId = `${Date.now()}-${test.info().workerIndex}`;
+    const admin = await seedUser({
+      email: `admin-card-crud-${runId}@example.com`,
+      password: "Password123!",
+      role: "admin",
+      displayName: "Admin Card CRUD",
+    });
+    const deck = await seedMaster({
+      name: `CRUD Deck ${runId}`,
+      status: "DRAFT",
+      cards: [{ front: "seedfront", back: "seedback" }],
+    });
+
+    await loginAs(context, { email: admin.email, password: admin.password });
+    await page.goto(`/admin/masters/${deck.id}/edit`);
+    await expect(page.getByTestId("master-cards-section")).toBeVisible({ timeout: 15_000 });
+
+    // ADD: open the add-card sheet, fill in unique front/back, and submit.
+    const cardFront = `e2efront-${runId}`;
+    const cardBack = "e2eback";
+    await page.getByTestId("master-add-card").click();
+    await page.locator("#add-card-front-field").fill(cardFront);
+    await page.locator("#add-card-back-field").fill(cardBack);
+    await page.getByRole("dialog").locator('button[type="submit"]').click();
+    // Assert the new card row is now visible in the list.
+    await expect(page.getByText(cardFront)).toBeVisible({ timeout: 10_000 });
+
+    // EDIT: click the card's edit-target div to open the edit sheet, change back text, save.
+    const editedBack = "e2eback-edited";
+    // Locate the card row by front text and click its edit-target.
+    const cardRow = page.locator("li").filter({ hasText: cardFront });
+    await cardRow.locator('[data-testid^="card-edit-target-"]').click();
+    const backInput = page.getByRole("dialog").locator('[id$="-back-field"]');
+    await backInput.fill(editedBack);
+    await page.getByRole("dialog").locator('button[type="submit"]').click();
+    // Assert the edited back text is visible.
+    await expect(page.getByText(editedBack)).toBeVisible({ timeout: 10_000 });
+
+    // DELETE: check the card's select checkbox, trigger bulk delete, confirm.
+    const deletedRow = page.locator("li").filter({ hasText: cardFront });
+    await deletedRow.locator('[data-testid^="card-select-"]').check();
+    await page.getByTestId("cards-bulk-delete-button").click();
+    await page.getByTestId("cards-bulk-confirm").click();
+    // Assert the card front text is gone from the list.
+    await expect(page.getByText(cardFront)).not.toBeVisible({ timeout: 10_000 });
+  });
+});

--- a/frontend/src/app/admin/masters/[id]/edit/cards/master-batch-import-form.test.tsx
+++ b/frontend/src/app/admin/masters/[id]/edit/cards/master-batch-import-form.test.tsx
@@ -1,0 +1,44 @@
+// @vitest-environment jsdom
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { resolveStep1Button } from "./master-batch-import-form";
+
+describe("MasterBatchImportForm / resolveStep1Button", () => {
+  it("disables the button with no text", () => {
+    expect(
+      resolveStep1Button({ hasText: false, validating: false, result: null, isStale: false }),
+    ).toEqual({ labelKey: "validate", action: null, disabled: true });
+  });
+
+  it("offers continue when a valid non-stale result exists", () => {
+    expect(
+      resolveStep1Button({
+        hasText: true,
+        validating: false,
+        result: { valid: true, parsedCards: [], errors: [] },
+        isStale: false,
+      }),
+    ).toEqual({ labelKey: "import", action: "continue", disabled: false });
+  });
+
+  it("forces re-validate when the validated payload is stale", () => {
+    expect(
+      resolveStep1Button({
+        hasText: true,
+        validating: false,
+        result: { valid: true, parsedCards: [], errors: [] },
+        isStale: true,
+      }),
+    ).toEqual({ labelKey: "validate", action: "validate", disabled: false });
+  });
+
+  it("does not carry optimisticResponse (static-source guard)", () => {
+    const src = readFileSync(
+      join(process.cwd(), "src/app/admin/masters/[id]/edit/cards/master-batch-import-form.tsx"),
+      "utf8",
+    );
+    expect(src).toContain("adminImportMasterCards");
+    expect(src).not.toContain("importCards(");
+  });
+});

--- a/frontend/src/app/admin/masters/[id]/edit/cards/master-batch-import-form.tsx
+++ b/frontend/src/app/admin/masters/[id]/edit/cards/master-batch-import-form.tsx
@@ -1,0 +1,508 @@
+"use client";
+
+import { useApolloClient, useLazyQuery, useMutation } from "@apollo/client/react";
+import { ChevronDown } from "lucide-react";
+import { useTranslations } from "next-intl";
+import type { JSX, ReactNode } from "react";
+import { useState } from "react";
+import { ValidateCardImportQuery } from "@/app/cardgroups/[id]/cards/queries";
+import { Button } from "@/components/ui/button";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import { ErrorBanner } from "@/components/ui/error-banner";
+import { Textarea } from "@/components/ui/textarea";
+import { AdminMasterCardsConnectionDocument, type CardImportErrorKind } from "@/generated/graphql";
+import { getBackendErrorBanner } from "@/lib/apollo/errors";
+import { cn } from "@/lib/utils";
+import { AdminImportMasterCards } from "./queries";
+
+/**
+ * Encode a UTF-8 string to base64 using the standard alphabet (with padding).
+ * Matches the server contract for `payload` in ValidateCardImportInput /
+ * ImportMasterCardsInput: base64-encoded text, one tab-separated front/back pair per
+ * line.
+ */
+function encodePayload(text: string): string {
+  // encodeURIComponent escapes all non-ASCII bytes; unescape maps them back to
+  // a byte string so that btoa sees only ASCII characters.
+  return btoa(unescape(encodeURIComponent(text)));
+}
+
+type ValidationResult = {
+  valid: boolean;
+  parsedCards: Array<{ front: string; back: string; line: number }>;
+  errors: Array<{ line: number; message: string }>;
+};
+
+type ImportResult = {
+  inserted: number;
+  updated: number;
+  errors: Array<{ line: number; message: string; kind: CardImportErrorKind }>;
+};
+
+/**
+ * `DUPLICATE` is non-fatal: the row still persisted via last-write-wins, so it
+ * reads as a warning. Every other kind dropped a row and reads as an error.
+ */
+function isWarningKind(kind: CardImportErrorKind | undefined): boolean {
+  return kind === "DUPLICATE";
+}
+
+/**
+ * Classify a raw Apollo error into a user-facing banner string, delegating to
+ * the shared backend-error banner helper.
+ */
+function classifyError(err: unknown, fallback: string): string {
+  if (!err) return "";
+  return getBackendErrorBanner(err) ?? fallback;
+}
+
+type Step1ButtonState = {
+  hasText: boolean;
+  validating: boolean;
+  result: ValidationResult | null;
+  /**
+   * True when the textarea was edited since the last successful validate. Only
+   * inspected when `result?.valid === true`; it is ignored on every other
+   * branch, so `{ result: null, isStale: true }` is a meaningless but harmless
+   * input combination.
+   */
+  isStale: boolean;
+};
+
+type Step1ButtonAction = "validate" | "continue";
+
+/**
+ * Discriminated on `action`: a button with no action is always disabled, and a
+ * button with an action is always enabled. This makes the phantom
+ * `{ action: null, disabled: false }` state unrepresentable.
+ */
+type Step1ButtonSpec =
+  | { action: null; labelKey: "validate" | "validating"; disabled: true }
+  | { action: Step1ButtonAction; labelKey: "validate" | "import"; disabled: false };
+
+/**
+ * Pure state machine for the step-1 forward button. A string discriminant for
+ * `action` (rather than a closure) keeps this trivially unit-testable; the
+ * parent maps the discriminant to the real handler.
+ *
+ * The `valid + isStale` case falls back to "validate" so that editing the
+ * textarea after a successful validate forces a re-validate before continuing.
+ */
+export function resolveStep1Button(state: Step1ButtonState): Step1ButtonSpec {
+  if (!state.hasText) {
+    return { labelKey: "validate", action: null, disabled: true };
+  }
+  if (state.validating) {
+    return { labelKey: "validating", action: null, disabled: true };
+  }
+  if (state.result?.valid === true && !state.isStale) {
+    return { labelKey: "import", action: "continue", disabled: false };
+  }
+  return { labelKey: "validate", action: "validate", disabled: false };
+}
+
+/** Quiet 2-segment progress bar showing the two import steps with a back affordance on step 2. */
+function ImportStepper(props: {
+  current: 1 | 2;
+  importing: boolean;
+  onBack: () => void;
+}): JSX.Element {
+  const { current, importing, onBack } = props;
+  const t = useTranslations("BatchImport");
+  const caption = current === 1 ? t("pasteAndReview") : t("import");
+  return (
+    <nav aria-label={t("importStepsAriaLabel")} className="flex items-center gap-2">
+      {current === 2 ? (
+        <button
+          type="button"
+          onClick={onBack}
+          disabled={importing}
+          aria-label={t("pasteAndReview")}
+          className="-my-2 py-2 disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+        >
+          <span className="block h-1 w-10 rounded-full bg-brand-primary" />
+        </button>
+      ) : (
+        <div className="h-1 w-10 rounded-full bg-brand-primary" />
+      )}
+      <div
+        className={cn("h-1 w-10 rounded-full", current === 2 ? "bg-brand-primary" : "bg-muted")}
+      />
+      <span className="ml-1 text-xs text-muted-foreground">{caption}</span>
+      <span className="sr-only">{t("stepOf", { current })}</span>
+    </nav>
+  );
+}
+
+/**
+ * Renders a list of line-level import/validation messages. A `DUPLICATE`-kind
+ * row reads as a non-fatal warning (amber — the row still persisted via
+ * last-write-wins); every other kind, and any row without a kind (validation
+ * step), reads as a blocking error (red).
+ */
+function ErrorList(props: {
+  errors: Array<{ line: number; message: string; kind?: CardImportErrorKind }>;
+  className?: string;
+  role?: string;
+}): JSX.Element {
+  const { errors, className, role } = props;
+  const t = useTranslations("BatchImport");
+  return (
+    <ul className={cn("space-y-1", className)} role={role}>
+      {errors.map((err) => (
+        <li
+          key={`${err.line}-${err.message}`}
+          className={cn(
+            "rounded-md px-3 py-2 text-sm",
+            isWarningKind(err.kind)
+              ? "bg-amber-50 text-amber-800"
+              : "bg-destructive/10 text-destructive",
+          )}
+        >
+          <span className="font-medium">{t("errorLine", { line: err.line })}</span> {err.message}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+/**
+ * Unified collapsible for the validate result: a preview table when valid, an
+ * error list when invalid. Collapsed when valid, open when invalid.
+ */
+function ValidateResult(props: { result: ValidationResult }): JSX.Element {
+  const { result } = props;
+  const t = useTranslations("BatchImport");
+  const [open, setOpen] = useState<boolean>(!result.valid);
+
+  let triggerLabel: string;
+  if (result.valid) {
+    triggerLabel = t("showPreview", { count: result.parsedCards.length });
+  } else if (open) {
+    triggerLabel = t("hideErrors");
+  } else {
+    triggerLabel = t("showErrors", { count: result.errors.length });
+  }
+
+  return (
+    <Collapsible open={open} onOpenChange={setOpen} className="rounded-md border border-border">
+      <CollapsibleTrigger
+        className="flex w-full items-center justify-between px-3 py-2 text-sm font-medium hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+        data-testid="batch-import-preview-toggle"
+      >
+        <span>{triggerLabel}</span>
+        <ChevronDown
+          aria-hidden="true"
+          className={cn("size-4 transition-transform", open && "rotate-180")}
+        />
+      </CollapsibleTrigger>
+      <CollapsibleContent>
+        {result.valid ? (
+          <div className="overflow-auto border-t border-border">
+            <table className="w-full text-sm">
+              <thead className="bg-muted/50">
+                <tr>
+                  <th className="px-3 py-2 text-left font-medium text-muted-foreground">
+                    {t("previewLine")}
+                  </th>
+                  <th className="px-3 py-2 text-left font-medium text-muted-foreground">
+                    {t("previewFront")}
+                  </th>
+                  <th className="px-3 py-2 text-left font-medium text-muted-foreground">
+                    {t("previewBack")}
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {result.parsedCards.map((card) => (
+                  <tr key={card.line} className="border-t border-border">
+                    <td className="px-3 py-2 text-muted-foreground">{card.line}</td>
+                    <td className="px-3 py-2">{card.front}</td>
+                    <td className="px-3 py-2">{card.back}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        ) : (
+          <ErrorList errors={result.errors} className="border-t border-border p-3" role="alert" />
+        )}
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}
+
+/**
+ * Two-slot wizard footer: a secondary/back affordance on the left and the
+ * primary/forward action on the right. The primary stays pinned to the right
+ * edge even when `left` is omitted (the left cell is rendered empty), so the
+ * forward action keeps a stable position across every step.
+ */
+function WizardFooter(props: { left?: ReactNode; right: ReactNode }): JSX.Element {
+  const { left, right } = props;
+  return (
+    <div className="flex items-center justify-between gap-3 border-t border-border pt-4">
+      <div>{left}</div>
+      <div>{right}</div>
+    </div>
+  );
+}
+
+export function MasterBatchImportForm(props: {
+  masterId: string;
+  deckName: string;
+  onImported?: () => void;
+  onCancel?: () => void;
+}): JSX.Element {
+  const { masterId, deckName, onImported, onCancel } = props;
+  const t = useTranslations("BatchImport");
+
+  const [step, setStep] = useState<1 | 2>(1);
+  const [payloadText, setPayloadText] = useState<string>("");
+  const [validationResult, setValidationResult] = useState<ValidationResult | null>(null);
+  // validatedPayload tracks the payloadText value that was in effect when the
+  // last successful validate call completed. resolveStep1Button compares this
+  // against the current payloadText (the isStale flag) to prevent continuing to
+  // import a stale/edited payload without re-validating. It is also cleared after
+  // each import attempt so a re-import requires re-validation.
+  const [validatedPayload, setValidatedPayload] = useState<string | null>(null);
+  const [importResult, setImportResult] = useState<ImportResult | null>(null);
+  const [bannerError, setBannerError] = useState<string>("");
+
+  const apollo = useApolloClient();
+
+  const [runValidate, { loading: validating }] = useLazyQuery(ValidateCardImportQuery, {
+    fetchPolicy: "no-cache",
+  });
+
+  const [runImport, { loading: importing }] = useMutation(AdminImportMasterCards);
+
+  async function handleValidate() {
+    setBannerError("");
+    setValidationResult(null);
+    setValidatedPayload(null);
+    setImportResult(null);
+    const payload = encodePayload(payloadText);
+    try {
+      const result = await runValidate({ variables: { input: { payload } } });
+      if (result.data?.validateCardImport) {
+        setValidationResult(result.data.validateCardImport);
+        // Record which payloadText was validated so resolveStep1Button can detect stale edits.
+        setValidatedPayload(payloadText);
+      }
+      if (result.error) {
+        setBannerError(classifyError(result.error, t("unexpectedError")));
+      }
+    } catch (err) {
+      setBannerError(classifyError(err, t("unexpectedError")));
+    }
+  }
+
+  async function handleImport() {
+    setBannerError("");
+    setImportResult(null);
+    const payload = encodePayload(payloadText);
+    try {
+      const result = await runImport({
+        variables: { input: { masterCardgroupId: masterId, payload } },
+      });
+      const data = result.data?.adminImportMasterCards;
+      if (!data) {
+        setBannerError(t("unexpectedError"));
+        return;
+      }
+      setImportResult(data);
+      // Reset the stale-guard so the user must re-validate before importing
+      // again — prevents accidental re-upsert of the same payload on a
+      // partial-success result where the sheet stays open.
+      setValidatedPayload(null);
+      // Refresh the cards list so the background list and the "N cards" badge
+      // reflect the freshly imported rows.
+      try {
+        await apollo.refetchQueries({ include: [AdminMasterCardsConnectionDocument] });
+      } catch (refetchErr) {
+        // A failed refetch must not block closing the sheet on a successful
+        // import; the next mount/poll re-reads the list. Log and continue.
+        console.warn("[MasterBatchImportForm] cards refetch failed", {
+          name: refetchErr instanceof Error ? refetchErr.name : "unknown",
+          masterId,
+        });
+      }
+      if (data.errors.length === 0) {
+        // Full success: close the sheet.
+        onImported?.();
+      }
+      // Partial failure (error rows present): keep the sheet open so the result
+      // banner and error rows stay visible.
+    } catch (err) {
+      setBannerError(classifyError(err, t("unexpectedError")));
+    }
+  }
+
+  const parsedCards = validationResult?.parsedCards ?? [];
+  // Duplicate-front rows are non-fatal warnings (last-write-wins still
+  // persisted the row); every other kind is a genuine error.
+  const importWarningCount = importResult?.errors.filter((e) => isWarningKind(e.kind)).length ?? 0;
+  const importErrorCount = importResult?.errors.filter((e) => !isWarningKind(e.kind)).length ?? 0;
+  // "Failed" is keyed on genuine errors only: warnings never block a row from
+  // persisting, so a result with nothing persisted and only warnings is still
+  // a success (and in practice cannot occur — a warning implies a winner row).
+  const importAllFailed =
+    importResult != null &&
+    importResult.inserted === 0 &&
+    importResult.updated === 0 &&
+    importErrorCount > 0;
+
+  function goBackToStep1() {
+    setBannerError("");
+    setStep(1);
+  }
+
+  const buttonSpec = resolveStep1Button({
+    hasText: payloadText.trim() !== "",
+    validating,
+    result: validationResult,
+    isStale: validatedPayload !== payloadText,
+  });
+
+  function onStep1ButtonClick() {
+    if (buttonSpec.action === "validate") {
+      void handleValidate();
+    } else if (buttonSpec.action === "continue") {
+      setImportResult(null);
+      setBannerError("");
+      setStep(2);
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <ImportStepper current={step} importing={importing} onBack={goBackToStep1} />
+
+      {bannerError && <ErrorBanner>{bannerError}</ErrorBanner>}
+
+      {step === 1 ? (
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <label htmlFor="batch-import-payload" className="block text-xs">
+              <span className="font-medium text-muted-foreground">{t("cardsToImport")}</span>
+              <span className="font-normal text-muted-foreground/70">{t("tabHint")}</span>
+            </label>
+            <Textarea
+              id="batch-import-payload"
+              data-testid="batch-import-payload"
+              value={payloadText}
+              onChange={(e) => setPayloadText(e.target.value)}
+              rows={10}
+              className="font-mono"
+              placeholder={"apple\tapple (the fruit)\nbanana\ta yellow fruit"}
+            />
+          </div>
+
+          {validationResult && (
+            <div
+              className={cn(
+                "rounded-md p-3 text-sm",
+                validationResult.valid
+                  ? "bg-green-50 text-green-800"
+                  : "bg-destructive/10 text-destructive",
+              )}
+              role="status"
+              data-testid="batch-import-validate-status"
+            >
+              {validationResult.valid
+                ? t("validResult", { count: parsedCards.length })
+                : t("invalidResult", { count: validationResult.errors.length })}
+            </div>
+          )}
+
+          {validationResult && <ValidateResult result={validationResult} />}
+
+          <WizardFooter
+            left={
+              <Button type="button" variant="ghost" onClick={() => onCancel?.()}>
+                {t("backToCardgroup")}
+              </Button>
+            }
+            right={
+              <Button
+                type="button"
+                variant={buttonSpec.action !== null ? "brand" : "outline"}
+                onClick={onStep1ButtonClick}
+                disabled={buttonSpec.disabled}
+                data-testid="batch-import-step1-btn"
+              >
+                {t(buttonSpec.labelKey)}
+              </Button>
+            }
+          />
+        </div>
+      ) : (
+        <div className="space-y-4">
+          {importResult ? (
+            <section className="space-y-4">
+              <div role="status">
+                {importAllFailed ? (
+                  <ErrorBanner>{t("importFailed", { count: importErrorCount })}</ErrorBanner>
+                ) : (
+                  <div className="rounded-md bg-green-50 p-3 text-sm text-green-800">
+                    {t("importComplete", {
+                      inserted: importResult.inserted,
+                      updated: importResult.updated,
+                    })}
+                    {importWarningCount > 0 && t("withWarnings", { count: importWarningCount })}
+                    {importErrorCount > 0 && t("withErrors", { count: importErrorCount })}
+                    {"."}
+                  </div>
+                )}
+              </div>
+              {importResult.errors.length > 0 && <ErrorList errors={importResult.errors} />}
+              <WizardFooter
+                left={
+                  <Button type="button" variant="outline" onClick={goBackToStep1}>
+                    {t("backToEdit")}
+                  </Button>
+                }
+                right={
+                  <Button type="button" variant="brand" onClick={() => onImported?.()}>
+                    {t("done")}
+                  </Button>
+                }
+              />
+            </section>
+          ) : (
+            <>
+              <h2 className="text-base font-semibold">
+                {t("confirmHeading", { count: parsedCards.length, cardgroupName: deckName })}
+              </h2>
+              <p className="text-sm text-muted-foreground">{t("confirmDesc")}</p>
+              <WizardFooter
+                left={
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={goBackToStep1}
+                    disabled={importing}
+                  >
+                    {t("backToEdit")}
+                  </Button>
+                }
+                right={
+                  <Button
+                    type="button"
+                    variant="brand"
+                    onClick={handleImport}
+                    disabled={importing}
+                    data-testid="batch-import-confirm-btn"
+                  >
+                    {importing ? t("importing") : t("importButton", { count: parsedCards.length })}
+                  </Button>
+                }
+              />
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/app/admin/masters/[id]/edit/cards/master-bulk-action-bar.tsx
+++ b/frontend/src/app/admin/masters/[id]/edit/cards/master-bulk-action-bar.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { Trash2, X } from "lucide-react";
+import { useTranslations } from "next-intl";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { Button, buttonVariants } from "@/components/ui/button";
+
+export type MasterBulkActionBarProps = {
+  count: number;
+  busy: boolean;
+  onConfirm: () => void;
+  onClear: () => void;
+};
+
+export function MasterBulkActionBar({ count, busy, onConfirm, onClear }: MasterBulkActionBarProps) {
+  const t = useTranslations("Cards");
+  const tCommon = useTranslations("Common");
+
+  return (
+    <div
+      className="mb-3 flex items-center gap-3 rounded-md border border-border bg-muted/50 px-4 py-2"
+      data-testid="cards-bulk-action-bar"
+    >
+      <span className="flex-1 text-sm font-medium">{t("selectedCount", { count })}</span>
+      <AlertDialog>
+        <AlertDialogTrigger asChild>
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={busy}
+            data-testid="cards-bulk-delete-button"
+          >
+            {tCommon("deleteSelected")}
+            <Trash2 aria-hidden="true" className="ml-1.5 h-4 w-4" />
+          </Button>
+        </AlertDialogTrigger>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t("deleteCardsTitle", { count })}</AlertDialogTitle>
+            <AlertDialogDescription>{tCommon("cannotBeUndone")}</AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>{tCommon("cancel")}</AlertDialogCancel>
+            <AlertDialogAction
+              className={buttonVariants({ variant: "destructive" })}
+              data-testid="cards-bulk-confirm"
+              onClick={onConfirm}
+            >
+              {t("deleteConfirmCount", { count })}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+      <Button variant="outline" size="sm" onClick={onClear}>
+        {tCommon("cancel")}
+        <X aria-hidden="true" className="ml-1.5 h-4 w-4" />
+      </Button>
+    </div>
+  );
+}

--- a/frontend/src/app/admin/masters/[id]/edit/cards/master-card-row.test.tsx
+++ b/frontend/src/app/admin/masters/[id]/edit/cards/master-card-row.test.tsx
@@ -1,0 +1,95 @@
+// @vitest-environment jsdom
+import { screen } from "@testing-library/react";
+import { createRef } from "react";
+import { describe, expect, it, vi } from "vitest";
+import type { SwipeableRowHandle } from "@/components/cardgroups/swipeable-row";
+import { renderWithIntl } from "@/test/render-with-intl";
+
+// Mock SwipeableRow as a plain div to avoid gesture library dependencies.
+// The `disabled` prop is forwarded as a data attribute so tests can assert
+// that selection mode propagates correctly.
+// swipeable-row.test.tsx is the canonical test for gesture behaviour.
+vi.mock("@/components/cardgroups/swipeable-row", async () => {
+  const { forwardRef } = await import("react");
+  return {
+    SwipeableRow: forwardRef(function SwipeableRowMock(
+      {
+        children,
+        disabled,
+      }: {
+        children: React.ReactNode;
+        disabled?: boolean;
+        onDelete: () => void;
+        ariaLabel: string | null;
+      },
+      _ref: React.Ref<{ close(): void }>,
+    ) {
+      return (
+        <div data-testid="swipeable-row-mock" data-disabled={disabled ? "true" : "false"}>
+          {children}
+        </div>
+      );
+    }),
+  };
+});
+
+import { MasterCardRow } from "./master-card-row";
+
+const CARD = { id: "c-1", front: "Hello", back: "Hola" };
+
+function renderMasterCardRow(overrides: Partial<React.ComponentProps<typeof MasterCardRow>> = {}) {
+  const rowRef = createRef<SwipeableRowHandle | null>();
+  renderWithIntl(
+    <MasterCardRow
+      card={CARD}
+      rowRef={rowRef}
+      selected={false}
+      disabled={false}
+      onSelectToggle={vi.fn()}
+      onEdit={vi.fn()}
+      onDelete={vi.fn()}
+      {...overrides}
+    />,
+  );
+}
+
+describe("<MasterCardRow>", () => {
+  it("Trash icon button className contains the hover-reveal and motion-reduce classes", () => {
+    renderMasterCardRow();
+
+    const deleteButton = screen.getByTestId(`card-delete-${CARD.id}`);
+    const cls = deleteButton.className;
+
+    expect(cls).toContain("opacity-0");
+    expect(cls).toContain("sm:group-hover:opacity-100");
+    expect(cls).toContain("motion-reduce:opacity-100");
+  });
+
+  it("gates pointer-events on the same variants as opacity (hidden button is non-clickable)", () => {
+    // opacity:0 alone leaves the button clickable, so on a narrow viewport (sm:
+    // hover variant inactive) the invisible Delete button would steal a row tap
+    // and delete the card. pointer-events must track the exact opacity variants
+    // so "visible ⟺ clickable" holds at every breakpoint.
+    renderMasterCardRow();
+
+    const cls = screen.getByTestId(`card-delete-${CARD.id}`).className;
+    expect(cls).toContain("pointer-events-none");
+    expect(cls).toContain("sm:group-hover:pointer-events-auto");
+    expect(cls).toContain("sm:group-focus-within:pointer-events-auto");
+    expect(cls).toContain("motion-reduce:pointer-events-auto");
+  });
+
+  it("wraps the row content in SwipeableRow", () => {
+    renderMasterCardRow();
+
+    expect(screen.getByTestId("swipeable-row-mock")).toBeInTheDocument();
+  });
+
+  it("passes disabled=true to SwipeableRow when selection mode is active", () => {
+    // Selection mode is signalled to MasterCardRow by the parent via disabled=true
+    // (set when selectedIds.size > 0 in MasterCardsClient).
+    renderMasterCardRow({ disabled: true });
+
+    expect(screen.getByTestId("swipeable-row-mock")).toHaveAttribute("data-disabled", "true");
+  });
+});

--- a/frontend/src/app/admin/masters/[id]/edit/cards/master-card-row.tsx
+++ b/frontend/src/app/admin/masters/[id]/edit/cards/master-card-row.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { Trash2 } from "lucide-react";
+import { useTranslations } from "next-intl";
+import type { RefObject } from "react";
+import { SwipeableRow, type SwipeableRowHandle } from "@/components/cardgroups/swipeable-row";
+import { Button } from "@/components/ui/button";
+
+export type MasterCardRowProps = {
+  card: { id: string; front: string; back: string };
+  rowRef: RefObject<SwipeableRowHandle | null>;
+  selected: boolean;
+  disabled: boolean;
+  onSelectToggle: () => void;
+  onEdit: () => void;
+  onDelete: () => void;
+};
+
+export function MasterCardRow({
+  card,
+  rowRef,
+  selected,
+  disabled,
+  onSelectToggle,
+  onEdit,
+  onDelete,
+}: MasterCardRowProps) {
+  const t = useTranslations("Cards");
+  return (
+    <SwipeableRow
+      ref={rowRef}
+      onDelete={onDelete}
+      disabled={disabled}
+      ariaLabel={t("deleteCardAriaLabel")}
+    >
+      <div className="group flex items-center justify-between gap-4 px-4 py-3 hover:bg-accent active:bg-accent transition-colors">
+        {/* biome-ignore lint/a11y/noStaticElementInteractions: span is a click/keydown stopper, not an interactive element; the inner <input> is the actual control. */}
+        <span
+          onClick={(e) => e.stopPropagation()}
+          onKeyDown={(e) => e.stopPropagation()}
+          className="shrink-0"
+        >
+          <input
+            type="checkbox"
+            className="h-4 w-4 cursor-pointer accent-primary"
+            checked={selected}
+            onChange={onSelectToggle}
+            aria-label={t("selectCardAriaLabel")}
+            data-testid={`card-select-${card.id}`}
+          />
+        </span>
+        {/* biome-ignore lint/a11y/useSemanticElements: a native <button> here would nest the action <button> for delete (invalid HTML); role="button" preserves screen-reader semantics without the markup conflict. */}
+        <div
+          role="button"
+          tabIndex={0}
+          onClick={onEdit}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault();
+              onEdit();
+            }
+          }}
+          className="min-w-0 flex-1 cursor-pointer space-y-1 rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          aria-label={t("editCardAriaLabel", { front: card.front })}
+          data-testid={`card-edit-target-${card.id}`}
+        >
+          <p className="text-sm font-medium">{card.front}</p>
+          <p className="text-sm text-muted-foreground">{card.back}</p>
+        </div>
+        {/* biome-ignore lint/a11y/noStaticElementInteractions: div is a click/keydown stopper, not an interactive element; the inner Delete <button> is the actual control. */}
+        <div
+          className="flex shrink-0 gap-2"
+          onClick={(e) => e.stopPropagation()}
+          onKeyDown={(e) => e.stopPropagation()}
+        >
+          <Button
+            variant="outline"
+            size="icon"
+            aria-label={t("deleteCardAriaLabel")}
+            onClick={onDelete}
+            data-testid={`card-delete-${card.id}`}
+            className="pointer-events-none opacity-0 sm:group-hover:pointer-events-auto sm:group-hover:opacity-100 sm:group-focus-within:pointer-events-auto sm:group-focus-within:opacity-100 motion-reduce:pointer-events-auto motion-reduce:opacity-100 transition-opacity"
+          >
+            <Trash2 aria-hidden="true" className="h-4 w-4" />
+          </Button>
+        </div>
+      </div>
+    </SwipeableRow>
+  );
+}

--- a/frontend/src/app/admin/masters/[id]/edit/cards/master-cards-client.test.tsx
+++ b/frontend/src/app/admin/masters/[id]/edit/cards/master-cards-client.test.tsx
@@ -1,0 +1,93 @@
+// @vitest-environment jsdom
+import { MockedProvider } from "@apollo/client/testing/react";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { AdminMasterCardsConnectionDocument } from "@/generated/graphql";
+import { UndoDeleteProvider } from "@/lib/undo-delete";
+import { renderWithIntl } from "@/test/render-with-intl";
+import { MasterCardsClient } from "./master-cards-client";
+import { masterCardsDefaultVars } from "./queries";
+
+vi.mock("@/components/cardgroups/swipeable-row", async () => {
+  const { forwardRef } = await import("react");
+  return {
+    SwipeableRow: forwardRef(function Mock(
+      { children }: { children: React.ReactNode },
+      _ref: React.Ref<{ close(): void }>,
+    ) {
+      return <div>{children}</div>;
+    }),
+  };
+});
+
+const MASTER_ID = "m-1";
+const edge = (id: string, front: string) => ({
+  __typename: "MasterCardEdge" as const,
+  cursor: id,
+  node: {
+    __typename: "MasterCard" as const,
+    id,
+    masterCardgroupId: MASTER_ID,
+    front,
+    back: `${front}-back`,
+    position: 0,
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+  },
+});
+
+const seed = {
+  request: {
+    query: AdminMasterCardsConnectionDocument,
+    variables: masterCardsDefaultVars(MASTER_ID),
+  },
+  result: {
+    data: {
+      adminMasterCardsConnection: {
+        __typename: "MasterCardConnection" as const,
+        edges: [edge("c-1", "apple")],
+        pageInfo: {
+          __typename: "PageInfo" as const,
+          hasNextPage: false,
+          hasPreviousPage: false,
+          startCursor: "c-1",
+          endCursor: "c-1",
+        },
+        totalCount: 1,
+      },
+    },
+  },
+};
+
+function render(onTotalCountChange = vi.fn()) {
+  renderWithIntl(
+    <MockedProvider mocks={[seed]}>
+      <UndoDeleteProvider>
+        <MasterCardsClient
+          masterId={MASTER_ID}
+          deckName="Deck One"
+          initialEdges={[edge("c-1", "apple")]}
+          initialPageInfo={seed.result.data.adminMasterCardsConnection.pageInfo}
+          initialTotalCount={1}
+          onTotalCountChange={onTotalCountChange}
+        />
+      </UndoDeleteProvider>
+    </MockedProvider>,
+  );
+  return onTotalCountChange;
+}
+
+describe("<MasterCardsClient>", () => {
+  it("renders the seeded card and reports the initial total count upward", async () => {
+    const onTotalCountChange = render();
+    expect(screen.getByText("apple")).toBeInTheDocument();
+    await waitFor(() => expect(onTotalCountChange).toHaveBeenCalledWith(1));
+  });
+
+  it("opens the add-card sheet from the toolbar", async () => {
+    render();
+    await userEvent.click(screen.getByRole("button", { name: /add card/i }));
+    expect(screen.getByLabelText(/front/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/admin/masters/[id]/edit/cards/master-cards-client.tsx
+++ b/frontend/src/app/admin/masters/[id]/edit/cards/master-cards-client.tsx
@@ -320,10 +320,22 @@ export function MasterCardsClient({
       <section>
         {/* Inline toolbar: right-aligned Add card and Batch import buttons. */}
         <div className="mb-3 flex justify-end gap-2">
-          <Button type="button" variant="outline" size="sm" onClick={openAddSheet}>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={openAddSheet}
+            data-testid="master-add-card"
+          >
             {t("addCard")}
           </Button>
-          <Button type="button" variant="outline" size="sm" onClick={openBatchImport}>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={openBatchImport}
+            data-testid="master-batch-import"
+          >
             {tCardgroups("batchImport")}
           </Button>
         </div>

--- a/frontend/src/app/admin/masters/[id]/edit/cards/master-cards-client.tsx
+++ b/frontend/src/app/admin/masters/[id]/edit/cards/master-cards-client.tsx
@@ -1,0 +1,444 @@
+"use client";
+
+import { Search } from "lucide-react";
+import { useTranslations } from "next-intl";
+import type { RefObject } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { CardForm } from "@/components/cardgroups/card-form";
+import type { SwipeableRowHandle } from "@/components/cardgroups/swipeable-row";
+import { Button } from "@/components/ui/button";
+import { ErrorBanner } from "@/components/ui/error-banner";
+import { FormSheet, useFormSheetClose } from "@/components/ui/form-sheet";
+import type { AdminMasterCardsConnectionQuery } from "@/generated/graphql";
+import { useBulkSelection } from "@/hooks/use-bulk-selection";
+import { useDebouncedSearch } from "@/hooks/use-debounced-search";
+import { getBackendErrorBanner } from "@/lib/apollo/errors";
+import { MasterBatchImportForm } from "./master-batch-import-form";
+import { MasterBulkActionBar } from "./master-bulk-action-bar";
+import { MasterCardRow } from "./master-card-row";
+import { useMasterCardMutations } from "./use-master-card-mutations";
+import { useMasterCardsConnection } from "./use-master-cards-connection";
+
+type Connection = AdminMasterCardsConnectionQuery["adminMasterCardsConnection"];
+export type MasterCardEdge = Connection["edges"][number];
+export type MasterCardConnectionPageInfo = Connection["pageInfo"];
+
+const FetchMoreError = ({ message, onRetry }: { message: string; onRetry: () => void }) => {
+  const tCommon = useTranslations("Common");
+  return (
+    <ErrorBanner
+      className="mt-3 flex flex-col items-center gap-2"
+      data-testid="cards-fetch-more-error"
+    >
+      <span>{message}</span>
+      <Button type="button" variant="outline" size="sm" onClick={onRetry}>
+        {tCommon("retry")}
+      </Button>
+    </ErrorBanner>
+  );
+};
+
+const SearchInput = ({ value, onChange }: { value: string; onChange: (next: string) => void }) => {
+  const t = useTranslations("Cards");
+  return (
+    <div className="mb-3">
+      <div className="relative">
+        <Search
+          aria-hidden="true"
+          className="pointer-events-none absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+        />
+        <input
+          type="search"
+          placeholder={t("searchPlaceholder")}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          className="w-full rounded-md border border-input bg-background pl-8 pr-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          aria-label={t("searchAriaLabel")}
+          data-testid="cards-search-input"
+        />
+      </div>
+    </div>
+  );
+};
+
+function EditCardSheetContent({
+  card,
+  submit,
+  submitting,
+  error,
+  validationError,
+}: {
+  card: { id: string; front: string; back: string };
+  submit: (values: { front: string; back: string }) => Promise<void>;
+  submitting: boolean;
+  error: unknown;
+  validationError: { field: string; message: string } | null;
+}) {
+  const close = useFormSheetClose();
+  const tCommon = useTranslations("Common");
+
+  return (
+    <CardForm
+      mode="edit"
+      idPrefix={`edit-${card.id}-`}
+      defaultValues={{ front: card.front, back: card.back }}
+      submit={submit}
+      submitLabel={tCommon("save")}
+      submitting={submitting}
+      error={error}
+      validationError={validationError}
+      onCancel={close}
+    />
+  );
+}
+
+function AddCardSheetContent({
+  submit,
+  submitting,
+  error,
+  validationError,
+  onDirty,
+}: {
+  submit: (values: { front: string; back: string }) => Promise<void>;
+  submitting: boolean;
+  error: unknown;
+  validationError: { field: string; message: string } | null;
+  onDirty: () => void;
+}) {
+  const close = useFormSheetClose();
+
+  return (
+    <div onInput={onDirty}>
+      <CardForm
+        mode="create"
+        idPrefix="add-card-"
+        defaultValues={{ front: "", back: "" }}
+        submit={submit}
+        submitting={submitting}
+        error={error}
+        validationError={validationError}
+        onCancel={close}
+      />
+    </div>
+  );
+}
+
+const EmptyState = ({ search, onClear }: { search: string | null; onClear: () => void }) => {
+  const t = useTranslations("Cards");
+  return search !== null ? (
+    <div
+      className="flex flex-col items-center gap-3 rounded-md border border-dashed border-border p-6"
+      data-testid="cards-empty-search"
+    >
+      <p className="text-sm text-muted-foreground">{t("noMatch", { search })}</p>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={onClear}
+        data-testid="cards-clear-search"
+      >
+        {t("clearSearch")}
+      </Button>
+    </div>
+  ) : (
+    <div
+      className="flex flex-col items-center gap-3 rounded-md border border-dashed border-border p-6"
+      data-testid="cards-empty"
+    >
+      <p className="text-sm text-muted-foreground">{t("addSomeCards")}</p>
+    </div>
+  );
+};
+
+type Props = {
+  masterId: string;
+  deckName: string;
+  initialEdges: MasterCardEdge[];
+  initialPageInfo: MasterCardConnectionPageInfo;
+  initialTotalCount: number;
+  onTotalCountChange: (count: number) => void;
+};
+
+export function MasterCardsClient({
+  masterId,
+  deckName,
+  initialEdges,
+  initialPageInfo,
+  initialTotalCount,
+  onTotalCountChange,
+}: Props) {
+  const t = useTranslations("Cards");
+  const tCardgroups = useTranslations("Cardgroups");
+  const [addOpen, setAddOpen] = useState(false);
+  const [addDirty, setAddDirty] = useState(false);
+  const [batchImportOpen, setBatchImportOpen] = useState(false);
+  const [createValidationError, setCreateValidationError] = useState<{
+    field: string;
+    message: string;
+  } | null>(null);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  // Field-level error for the editing row (from updateCard's outcome-union).
+  const [rowValidationError, setRowValidationError] = useState<{
+    field: string;
+    message: string;
+  } | null>(null);
+  // Per-card SwipeableRow handles; lets a row close any half-open sibling.
+  const rowRefs = useRef<Map<string, RefObject<SwipeableRowHandle | null>>>(new Map());
+  const selection = useBulkSelection<string>();
+  const search = useDebouncedSearch();
+
+  const {
+    edges,
+    pageInfo,
+    totalCount,
+    fetchingMore,
+    fetchMoreError,
+    retryFetchMore,
+    sentinelRef,
+    queryVariables,
+    queryError,
+  } = useMasterCardsConnection({
+    masterId,
+    searchQuery: search.query,
+    initialEdges,
+    initialPageInfo,
+    initialTotalCount,
+  });
+
+  const {
+    createCard,
+    updateCard,
+    deleteRow,
+    deleteCards,
+    creating,
+    updating,
+    bulkDeleting,
+    createError,
+    updateError,
+    bulkDeleteError,
+    deleteRowError,
+    resetCreateCard,
+  } = useMasterCardMutations({ masterId, queryVariables });
+
+  const queryBannerError = getBackendErrorBanner(queryError);
+  const bulkDeleteBannerError = getBackendErrorBanner(bulkDeleteError);
+  // Raw per-row delete error → localized banner copy (server message or fallback).
+  const deleteRowBannerError =
+    deleteRowError !== null ? (getBackendErrorBanner(deleteRowError) ?? t("deleteError")) : null;
+
+  // Report live total count upward so the page header stays in sync.
+  useEffect(() => {
+    onTotalCountChange(totalCount);
+  }, [totalCount, onTotalCountChange]);
+
+  const closeOtherRows = useCallback((exceptCardId: string) => {
+    for (const [id, ref] of rowRefs.current.entries()) {
+      if (id !== exceptCardId) ref.current?.close();
+    }
+  }, []);
+
+  const editingCard = edges.find((edge) => edge.node.id === editingId)?.node;
+
+  const openAddSheet = useCallback(() => {
+    resetCreateCard();
+    setCreateValidationError(null);
+    setAddDirty(false);
+    setAddOpen(true);
+  }, [resetCreateCard]);
+
+  const openBatchImport = useCallback(() => setBatchImportOpen(true), []);
+  const closeBatchImport = useCallback(() => setBatchImportOpen(false), []);
+
+  async function handleCreate(values: { front: string; back: string }) {
+    resetCreateCard();
+    setCreateValidationError(null);
+    const outcome = await createCard(values);
+    switch (outcome.status) {
+      case "success":
+        setAddDirty(false);
+        setCreateValidationError(null);
+        setAddOpen(false);
+        break;
+      case "validation":
+        setCreateValidationError({ field: outcome.field, message: outcome.message });
+        break;
+      case "unexpected":
+        setCreateValidationError({ field: "front", message: t("addFailed") });
+        break;
+      case "rejected":
+        // The CardForm error banner surfaces the rejection via `createError`.
+        break;
+    }
+  }
+
+  async function handleBulkDelete() {
+    const ids = Array.from(selection.selectedIds);
+    try {
+      await deleteCards(ids);
+      selection.clearSelection();
+    } catch (err) {
+      console.error("[MasterCardsClient] bulk delete rejection", {
+        name: err instanceof Error ? err.name : "unknown",
+        masterId,
+        ids,
+      });
+    }
+  }
+
+  async function handleUpdate(id: string, values: { front: string; back: string }) {
+    setRowValidationError(null);
+    const outcome = await updateCard(id, values);
+    switch (outcome.status) {
+      case "success":
+        setEditingId(null);
+        break;
+      case "validation":
+        setRowValidationError({ field: outcome.field, message: outcome.message });
+        break;
+      case "unexpected":
+        setRowValidationError({ field: "front", message: t("saveFailed") });
+        break;
+      case "rejected":
+        // The edit-sheet error banner surfaces the rejection via `updateError`.
+        break;
+    }
+  }
+
+  return (
+    <div className="space-y-3">
+      {queryBannerError && (
+        <ErrorBanner data-testid="cards-query-error">{queryBannerError}</ErrorBanner>
+      )}
+      {deleteRowBannerError && (
+        <ErrorBanner data-testid="cards-delete-error">{deleteRowBannerError}</ErrorBanner>
+      )}
+      {bulkDeleteBannerError && (
+        <ErrorBanner data-testid="cards-bulk-delete-error">{bulkDeleteBannerError}</ErrorBanner>
+      )}
+
+      <section>
+        {/* Inline toolbar: right-aligned Add card and Batch import buttons. */}
+        <div className="mb-3 flex justify-end gap-2">
+          <Button type="button" variant="outline" size="sm" onClick={openAddSheet}>
+            {t("addCard")}
+          </Button>
+          <Button type="button" variant="outline" size="sm" onClick={openBatchImport}>
+            {tCardgroups("batchImport")}
+          </Button>
+        </div>
+
+        <SearchInput value={search.input} onChange={search.setInput} />
+
+        {selection.count > 0 && (
+          <MasterBulkActionBar
+            count={selection.count}
+            busy={bulkDeleting}
+            onConfirm={handleBulkDelete}
+            onClear={selection.clearSelection}
+          />
+        )}
+
+        {edges.length === 0 ? (
+          <EmptyState search={search.query} onClear={search.clear} />
+        ) : (
+          <ul className="space-y-3">
+            {edges.map((edge) => {
+              const card = edge.node;
+              return (
+                <li key={card.id} className="rounded-md border border-border overflow-hidden">
+                  <MasterCardRow
+                    card={card}
+                    rowRef={(() => {
+                      if (!rowRefs.current.has(card.id)) {
+                        rowRefs.current.set(card.id, { current: null });
+                      }
+                      // biome-ignore lint/style/noNonNullAssertion: we just set the entry above so it is always defined.
+                      return rowRefs.current.get(card.id)!;
+                    })()}
+                    selected={selection.isSelected(card.id)}
+                    disabled={selection.count > 0 || editingId === card.id}
+                    onSelectToggle={() => selection.toggleSelected(card.id)}
+                    onEdit={() => {
+                      closeOtherRows(card.id);
+                      setRowValidationError(null);
+                      setEditingId(card.id);
+                    }}
+                    onDelete={() => deleteRow(card.id, t("cardDeleted"))}
+                  />
+                </li>
+              );
+            })}
+          </ul>
+        )}
+
+        <FormSheet
+          title={t("addCard")}
+          open={addOpen}
+          onOpenChange={(nextOpen) => {
+            setAddOpen(nextOpen);
+            if (!nextOpen) {
+              resetCreateCard();
+              setAddDirty(false);
+              setCreateValidationError(null);
+            }
+          }}
+          submitting={creating}
+          dirty={addDirty}
+          confirmOnDismiss
+        >
+          <AddCardSheetContent
+            submit={handleCreate}
+            submitting={creating}
+            error={createError}
+            validationError={createValidationError}
+            onDirty={() => setAddDirty(true)}
+          />
+        </FormSheet>
+
+        <FormSheet
+          title={deckName}
+          open={batchImportOpen}
+          onOpenChange={setBatchImportOpen}
+          size="lg"
+        >
+          <MasterBatchImportForm
+            masterId={masterId}
+            deckName={deckName}
+            onImported={closeBatchImport}
+            onCancel={closeBatchImport}
+          />
+        </FormSheet>
+
+        <FormSheet
+          title={t("editCard")}
+          open={editingCard !== undefined}
+          onOpenChange={(nextOpen) => {
+            if (!nextOpen) {
+              setRowValidationError(null);
+              setEditingId(null);
+            }
+          }}
+          submitting={updating}
+          confirmOnDismiss={false}
+        >
+          {editingCard ? (
+            <EditCardSheetContent
+              card={editingCard}
+              submit={(values) => handleUpdate(editingCard.id, values)}
+              submitting={updating}
+              error={updateError}
+              validationError={rowValidationError}
+            />
+          ) : null}
+        </FormSheet>
+
+        <div ref={sentinelRef} aria-hidden="true" data-testid="cards-sentinel" />
+        {fetchMoreError && <FetchMoreError message={fetchMoreError} onRetry={retryFetchMore} />}
+        {!fetchMoreError && fetchingMore && pageInfo.hasNextPage && (
+          <p className="mt-3 text-center text-xs text-muted-foreground">{t("loadingMore")}</p>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/app/admin/masters/[id]/edit/cards/queries.ts
+++ b/frontend/src/app/admin/masters/[id]/edit/cards/queries.ts
@@ -1,0 +1,131 @@
+import { graphql } from "@/generated";
+import type { AdminMasterCardsConnectionQueryVariables } from "@/generated/graphql";
+
+/** Default page size for the admin master-cards connection. Must stay in sync between SSR seed and client useQuery/cache reads. */
+const MASTER_CARDS_PAGE_SIZE = 20;
+
+export const AdminMasterCardsConnectionQuery = graphql(`
+  query AdminMasterCardsConnection(
+    $masterCardgroupId: ID!
+    $first: Int
+    $after: ID
+    $search: String
+  ) {
+    adminMasterCardsConnection(
+      masterCardgroupId: $masterCardgroupId
+      first: $first
+      after: $after
+      search: $search
+    ) {
+      edges {
+        cursor
+        node {
+          id
+          masterCardgroupId
+          front
+          back
+          position
+          createdAt
+          updatedAt
+        }
+      }
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+    }
+  }
+`);
+
+/**
+ * Default variables for {@link AdminMasterCardsConnectionDocument}, scoped by
+ * the route's master deck id. Every read site — RSC seed, client `useQuery`,
+ * mutation `update` callbacks — MUST use this factory (or spread its result) so
+ * Apollo's cache key is identical across all three.
+ * See: docs/pagination/variables-shape-must-match.md
+ */
+export function masterCardsDefaultVars(
+  masterCardgroupId: string,
+): AdminMasterCardsConnectionQueryVariables {
+  return {
+    masterCardgroupId,
+    first: MASTER_CARDS_PAGE_SIZE,
+    search: null,
+  };
+}
+
+export const AdminCreateMasterCard = graphql(`
+  mutation AdminCreateMasterCard($input: NewMasterCardInput!) {
+    adminCreateMasterCard(input: $input) {
+      __typename
+      ... on CreateMasterCardSuccess {
+        masterCard {
+          id
+          masterCardgroupId
+          front
+          back
+          position
+          createdAt
+          updatedAt
+        }
+      }
+      ... on MasterCardDuplicateFrontError {
+        message
+        existingCardId
+        existingBack
+      }
+    }
+  }
+`);
+
+export const AdminUpdateMasterCard = graphql(`
+  mutation AdminUpdateMasterCard($id: ID!, $input: UpdateMasterCardInput!) {
+    adminUpdateMasterCard(id: $id, input: $input) {
+      __typename
+      ... on UpdateMasterCardSuccess {
+        masterCard {
+          id
+          masterCardgroupId
+          front
+          back
+          position
+          createdAt
+          updatedAt
+        }
+      }
+      ... on InputValidationError {
+        field
+        message
+      }
+    }
+  }
+`);
+
+export const AdminDeleteMasterCard = graphql(`
+  mutation AdminDeleteMasterCard($id: ID!) {
+    adminDeleteMasterCard(id: $id)
+  }
+`);
+
+export const AdminDeleteMasterCards = graphql(`
+  mutation AdminDeleteMasterCards($ids: [ID!]!) {
+    adminDeleteMasterCards(ids: $ids)
+  }
+`);
+
+export const AdminImportMasterCards = graphql(`
+  mutation AdminImportMasterCards($input: ImportMasterCardsInput!) {
+    adminImportMasterCards(input: $input) {
+      inserted
+      updated
+      errors {
+        line
+        message
+        kind
+      }
+    }
+  }
+`);

--- a/frontend/src/app/admin/masters/[id]/edit/cards/use-master-card-mutations.test.tsx
+++ b/frontend/src/app/admin/masters/[id]/edit/cards/use-master-card-mutations.test.tsx
@@ -1,0 +1,132 @@
+// @vitest-environment jsdom
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { MockedProvider } from "@apollo/client/testing/react";
+import { act, renderHook } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import type { ReactNode } from "react";
+import { describe, expect, it } from "vitest";
+import {
+  AdminCreateMasterCardDocument,
+  AdminMasterCardsConnectionDocument,
+  AdminUpdateMasterCardDocument,
+} from "@/generated/graphql";
+import { UndoDeleteProvider } from "@/lib/undo-delete";
+import enMessages from "../../../../../../../messages/en.json";
+import { masterCardsDefaultVars } from "./queries";
+import { useMasterCardMutations } from "./use-master-card-mutations";
+
+const MASTER_ID = "m-1";
+
+const baseSeed = {
+  request: {
+    query: AdminMasterCardsConnectionDocument,
+    variables: masterCardsDefaultVars(MASTER_ID),
+  },
+  result: {
+    data: {
+      adminMasterCardsConnection: {
+        __typename: "MasterCardConnection" as const,
+        edges: [],
+        pageInfo: {
+          __typename: "PageInfo" as const,
+          hasNextPage: false,
+          hasPreviousPage: false,
+          startCursor: null,
+          endCursor: null,
+        },
+        totalCount: 0,
+      },
+    },
+  },
+};
+
+function makeWrapper(extraMocks: object[]) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <NextIntlClientProvider locale="en" messages={enMessages} timeZone="UTC">
+        <MockedProvider mocks={[baseSeed, ...extraMocks] as never}>
+          <UndoDeleteProvider>{children}</UndoDeleteProvider>
+        </MockedProvider>
+      </NextIntlClientProvider>
+    );
+  };
+}
+
+describe("useMasterCardMutations", () => {
+  it("maps MasterCardDuplicateFrontError to an inline front validation outcome", async () => {
+    const wrapper = makeWrapper([
+      {
+        request: {
+          query: AdminCreateMasterCardDocument,
+          variables: { input: { masterCardgroupId: MASTER_ID, front: "dup", back: "b" } },
+        },
+        result: {
+          data: {
+            adminCreateMasterCard: {
+              __typename: "MasterCardDuplicateFrontError",
+              message: "already exists",
+              existingCardId: "x-1",
+              existingBack: "old",
+            },
+          },
+        },
+      },
+    ]);
+    const { result } = renderHook(
+      () =>
+        useMasterCardMutations({
+          masterId: MASTER_ID,
+          queryVariables: masterCardsDefaultVars(MASTER_ID),
+        }),
+      { wrapper },
+    );
+    let outcome: Awaited<ReturnType<typeof result.current.createCard>> | undefined;
+    await act(async () => {
+      outcome = await result.current.createCard({ front: "dup", back: "b" });
+    });
+    expect(outcome).toEqual({ status: "validation", field: "front", message: "already exists" });
+  });
+
+  it("maps InputValidationError on update to an inline validation outcome", async () => {
+    const wrapper = makeWrapper([
+      {
+        request: {
+          query: AdminUpdateMasterCardDocument,
+          variables: { id: "c-1", input: { front: "", back: "b" } },
+        },
+        result: {
+          data: {
+            adminUpdateMasterCard: {
+              __typename: "InputValidationError",
+              field: "front",
+              message: "front is required",
+            },
+          },
+        },
+      },
+    ]);
+    const { result } = renderHook(
+      () =>
+        useMasterCardMutations({
+          masterId: MASTER_ID,
+          queryVariables: masterCardsDefaultVars(MASTER_ID),
+        }),
+      { wrapper },
+    );
+    let outcome: Awaited<ReturnType<typeof result.current.updateCard>> | undefined;
+    await act(async () => {
+      outcome = await result.current.updateCard("c-1", { front: "", back: "b" });
+    });
+    expect(outcome).toEqual({ status: "validation", field: "front", message: "front is required" });
+  });
+
+  it("does not carry optimisticResponse in any mutation call (static-source guard)", () => {
+    const src = readFileSync(
+      join(process.cwd(), "src/app/admin/masters/[id]/edit/cards/use-master-card-mutations.ts"),
+      "utf8",
+    );
+    expect(src).not.toContain("optimisticResponse");
+  });
+});

--- a/frontend/src/app/admin/masters/[id]/edit/cards/use-master-card-mutations.test.tsx
+++ b/frontend/src/app/admin/masters/[id]/edit/cards/use-master-card-mutations.test.tsx
@@ -122,11 +122,13 @@ describe("useMasterCardMutations", () => {
     expect(outcome).toEqual({ status: "validation", field: "front", message: "front is required" });
   });
 
-  it("does not carry optimisticResponse in any mutation call (static-source guard)", () => {
+  it("does not pass optimisticResponse as a mutation option (static-source guard)", () => {
     const src = readFileSync(
       join(process.cwd(), "src/app/admin/masters/[id]/edit/cards/use-master-card-mutations.ts"),
       "utf8",
     );
-    expect(src).not.toContain("optimisticResponse");
+    // Matches the option key `optimisticResponse:` passed to a mutation call;
+    // tolerates the documenting comment `optimisticResponse` (backtick, not colon, follows).
+    expect(src).not.toMatch(/optimisticResponse\s*:/);
   });
 });

--- a/frontend/src/app/admin/masters/[id]/edit/cards/use-master-card-mutations.ts
+++ b/frontend/src/app/admin/masters/[id]/edit/cards/use-master-card-mutations.ts
@@ -1,0 +1,297 @@
+"use client";
+
+import { useApolloClient, useMutation } from "@apollo/client/react";
+import { useCallback, useState } from "react";
+import {
+  AdminMasterCardsConnectionDocument,
+  type AdminMasterCardsConnectionQuery,
+  type AdminMasterCardsConnectionQueryVariables,
+} from "@/generated/graphql";
+import { useUndoDelete } from "@/lib/undo-delete";
+import {
+  AdminCreateMasterCard,
+  AdminDeleteMasterCard,
+  AdminDeleteMasterCards,
+  AdminUpdateMasterCard,
+  masterCardsDefaultVars,
+} from "./queries";
+
+type MasterCardNode =
+  AdminMasterCardsConnectionQuery["adminMasterCardsConnection"]["edges"][number]["node"];
+
+/** Outcome of a create attempt; the client maps it to validation / sheet / banner state. */
+type CreateCardOutcome =
+  | { status: "success" }
+  | { status: "validation"; field: string; message: string }
+  | { status: "unexpected" }
+  | { status: "rejected" };
+
+/** Outcome of an update attempt; the client maps it to the inline row validation error. */
+type UpdateCardOutcome =
+  | { status: "success" }
+  | { status: "validation"; field: string; message: string }
+  | { status: "unexpected" }
+  | { status: "rejected" };
+
+function cardMatchesSearch(card: MasterCardNode, searchValue: string): boolean {
+  const normalized = searchValue.trim().toLowerCase();
+  if (normalized === "") return true;
+  return (
+    card.front.toLowerCase().includes(normalized) || card.back.toLowerCase().includes(normalized)
+  );
+}
+
+export interface UseMasterCardMutationsInput {
+  masterId: string;
+  /**
+   * The connection's active query variables (search-filter-aware). MUST be the
+   * same object the live `useQuery` is keyed on so cache reads/writes land on the
+   * right entry under any active search filter.
+   * See docs/pagination/optimistic-rollback-cache-key.md.
+   */
+  queryVariables: AdminMasterCardsConnectionQueryVariables;
+}
+
+/**
+ * Owns the four master card mutations (create / update / per-row delete / bulk delete)
+ * and every Apollo cache write they perform. The client maps the returned typed
+ * outcomes to sheet navigation, validation, and banner state. Mirrors the
+ * thin-outcome-hook shape of `useMasterMutations` / `useAdminUserMutations`.
+ *
+ * No optimistic writes: typed errors (MasterCardDuplicateFrontError,
+ * InputValidationError, UNAUTHENTICATED, FORBIDDEN) can fail these mutations and
+ * Apollo does not reliably roll back optimistic writes for typed GraphQL errors
+ * — see .claude/rules/pagination.md.
+ */
+export function useMasterCardMutations({ masterId, queryVariables }: UseMasterCardMutationsInput) {
+  const apollo = useApolloClient();
+  const { scheduleDelete } = useUndoDelete();
+
+  const [
+    createMasterCardMutation,
+    { loading: creating, error: createError, reset: resetCreateCard },
+  ] = useMutation(AdminCreateMasterCard);
+  // Updates propagate automatically via Apollo cache normalization (MasterCard has id).
+  const [updateMasterCardMutation, { loading: updating, error: updateError }] =
+    useMutation(AdminUpdateMasterCard);
+  // scheduleDelete (5s undo window) fires the per-row mutation imperatively.
+  const [deleteMasterCardMutation] = useMutation(AdminDeleteMasterCard);
+
+  const [deleteCardsMutation, { error: bulkDeleteError, loading: bulkDeleting }] = useMutation(
+    AdminDeleteMasterCards,
+    {
+      // queryVariables matches the live cache entry under any active search filter.
+      // See docs/pagination/optimistic-rollback-cache-key.md.
+      update(cache, { data: bulkData }, { variables: mutationVars }) {
+        const ids = mutationVars?.ids as string[] | undefined;
+        if (!ids) return;
+        if (bulkData?.adminDeleteMasterCards == null) return;
+        const deletedCount = bulkData.adminDeleteMasterCards;
+        if (deletedCount === 0) return;
+        const existing = cache.readQuery({
+          query: AdminMasterCardsConnectionDocument,
+          variables: queryVariables,
+        });
+        if (existing) {
+          const next = existing.adminMasterCardsConnection;
+          cache.writeQuery({
+            query: AdminMasterCardsConnectionDocument,
+            variables: queryVariables,
+            data: {
+              adminMasterCardsConnection: {
+                ...next,
+                edges: next.edges.filter((edge) => !ids.includes(edge.node.id)),
+                totalCount: Math.max(0, next.totalCount - deletedCount),
+              },
+            },
+          });
+        }
+        for (const id of ids) {
+          cache.evict({ id: cache.identify({ __typename: "MasterCard", id }) });
+        }
+        cache.gc();
+      },
+    },
+  );
+
+  // Per-row delete commit error — surfaced after the 5s undo window elapses and
+  // the DELETE mutation rejects. Stored as the raw error so the client derives
+  // the localized banner copy; persists across mutation calls. See
+  // docs/pagination/do-not-reuse-mutation-error-state.md.
+  const [deleteRowError, setDeleteRowError] = useState<unknown>(null);
+
+  // Write a freshly-created master card to the connection cached under `variables`.
+  const writeCreatedMasterCardToConnection = useCallback(
+    (card: MasterCardNode, variables: AdminMasterCardsConnectionQueryVariables) => {
+      const existing = apollo.readQuery({
+        query: AdminMasterCardsConnectionDocument,
+        variables,
+      });
+      if (!existing) return;
+
+      const next = existing.adminMasterCardsConnection;
+      if (next.edges.some((edge) => edge.node.id === card.id)) return;
+
+      apollo.writeQuery({
+        query: AdminMasterCardsConnectionDocument,
+        variables,
+        data: {
+          adminMasterCardsConnection: {
+            ...next,
+            edges: [
+              { __typename: "MasterCardEdge" as const, cursor: card.id, node: card },
+              ...next.edges,
+            ],
+            totalCount: next.totalCount + 1,
+          },
+        },
+      });
+    },
+    [apollo],
+  );
+
+  const createCard = useCallback(
+    async (values: { front: string; back: string }): Promise<CreateCardOutcome> => {
+      const result = await createMasterCardMutation({
+        variables: {
+          input: { masterCardgroupId: masterId, front: values.front, back: values.back },
+        },
+      }).catch((err) => {
+        console.error("[useMasterCardMutations] create rejection", {
+          name: err instanceof Error ? err.name : "unknown",
+          masterId,
+        });
+        return null;
+      });
+      if (!result) return { status: "rejected" };
+
+      const payload = result.data?.adminCreateMasterCard;
+      if (payload?.__typename === "CreateMasterCardSuccess") {
+        writeCreatedMasterCardToConnection(payload.masterCard, masterCardsDefaultVars(masterId));
+        if (
+          typeof queryVariables.search === "string" &&
+          cardMatchesSearch(payload.masterCard, queryVariables.search)
+        ) {
+          writeCreatedMasterCardToConnection(payload.masterCard, queryVariables);
+        }
+        return { status: "success" };
+      }
+      if (payload?.__typename === "MasterCardDuplicateFrontError") {
+        return { status: "validation", field: "front", message: payload.message };
+      }
+      const unknownPayload = payload as unknown as { __typename?: string } | null | undefined;
+      console.warn("[useMasterCardMutations] unexpected adminCreateMasterCard payload", {
+        typename: unknownPayload?.__typename ?? null,
+        masterId,
+      });
+      return { status: "unexpected" };
+    },
+    [masterId, createMasterCardMutation, queryVariables, writeCreatedMasterCardToConnection],
+  );
+
+  const updateCard = useCallback(
+    async (id: string, values: { front: string; back: string }): Promise<UpdateCardOutcome> => {
+      const result = await updateMasterCardMutation({
+        variables: { id, input: { front: values.front, back: values.back } },
+      }).catch((err) => {
+        console.error("[useMasterCardMutations] update rejection", {
+          name: err instanceof Error ? err.name : "unknown",
+          masterId,
+          cardId: id,
+        });
+        return null;
+      });
+      if (!result) return { status: "rejected" };
+
+      const payload = result.data?.adminUpdateMasterCard;
+      if (payload?.__typename === "UpdateMasterCardSuccess") {
+        return { status: "success" };
+      }
+      if (payload?.__typename === "InputValidationError") {
+        return { status: "validation", field: payload.field, message: payload.message };
+      }
+      const unknownPayload = payload as unknown as { __typename?: string } | null | undefined;
+      console.warn("[useMasterCardMutations] unexpected adminUpdateMasterCard payload", {
+        typename: unknownPayload?.__typename ?? null,
+        cardId: id,
+        masterId,
+      });
+      return { status: "unexpected" };
+    },
+    [masterId, updateMasterCardMutation],
+  );
+
+  // Per-row delete: snapshot, optimistic drop, schedule DELETE with a 5s undo
+  // window. See docs/pagination/optimistic-rollback-cache-key.md for the
+  // queryVariables rule. `label` is the caller-supplied (localized) toast title.
+  const deleteRow = useCallback(
+    (cardId: string, label: string) => {
+      const snapshot = apollo.readQuery({
+        query: AdminMasterCardsConnectionDocument,
+        variables: queryVariables,
+      });
+      if (snapshot) {
+        const next = snapshot.adminMasterCardsConnection;
+        apollo.writeQuery({
+          query: AdminMasterCardsConnectionDocument,
+          variables: queryVariables,
+          data: {
+            adminMasterCardsConnection: {
+              ...next,
+              edges: next.edges.filter((edge) => edge.node.id !== cardId),
+              totalCount: Math.max(0, next.totalCount - 1),
+            },
+          },
+        });
+      }
+      scheduleDelete({
+        id: cardId,
+        label,
+        optimisticRollback: () => {
+          if (snapshot !== null) {
+            apollo.writeQuery({
+              query: AdminMasterCardsConnectionDocument,
+              variables: queryVariables,
+              data: snapshot,
+            });
+          }
+          setDeleteRowError(null);
+        },
+        commitDelete: async () => {
+          setDeleteRowError(null);
+          const result = await deleteMasterCardMutation({ variables: { id: cardId } });
+          if (result.data?.adminDeleteMasterCard) {
+            apollo.cache.evict({
+              id: apollo.cache.identify({ __typename: "MasterCard", id: cardId }),
+            });
+            apollo.cache.gc();
+          }
+        },
+        onCommitFailed: (err) => {
+          setDeleteRowError(err);
+        },
+      });
+    },
+    [apollo, deleteMasterCardMutation, queryVariables, scheduleDelete],
+  );
+
+  const deleteCards = useCallback(
+    (ids: string[]) => deleteCardsMutation({ variables: { ids } }),
+    [deleteCardsMutation],
+  );
+
+  return {
+    createCard,
+    updateCard,
+    deleteRow,
+    deleteCards,
+    creating,
+    updating,
+    bulkDeleting,
+    createError,
+    updateError,
+    bulkDeleteError,
+    deleteRowError,
+    resetCreateCard,
+  };
+}

--- a/frontend/src/app/admin/masters/[id]/edit/cards/use-master-card-mutations.ts
+++ b/frontend/src/app/admin/masters/[id]/edit/cards/use-master-card-mutations.ts
@@ -58,7 +58,7 @@ export interface UseMasterCardMutationsInput {
  * outcomes to sheet navigation, validation, and banner state. Mirrors the
  * thin-outcome-hook shape of `useMasterMutations` / `useAdminUserMutations`.
  *
- * No optimistic writes: typed errors (MasterCardDuplicateFrontError,
+ * No `optimisticResponse`: typed errors (MasterCardDuplicateFrontError,
  * InputValidationError, UNAUTHENTICATED, FORBIDDEN) can fail these mutations and
  * Apollo does not reliably roll back optimistic writes for typed GraphQL errors
  * — see .claude/rules/pagination.md.

--- a/frontend/src/app/admin/masters/[id]/edit/cards/use-master-cards-connection.test.tsx
+++ b/frontend/src/app/admin/masters/[id]/edit/cards/use-master-cards-connection.test.tsx
@@ -1,0 +1,95 @@
+// @vitest-environment jsdom
+import { MockedProvider } from "@apollo/client/testing/react";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it } from "vitest";
+import { AdminMasterCardsConnectionDocument } from "@/generated/graphql";
+import { masterCardsDefaultVars } from "./queries";
+import { useMasterCardsConnection } from "./use-master-cards-connection";
+
+const MASTER_ID = "m-1";
+const edge = (id: string) => ({
+  __typename: "MasterCardEdge" as const,
+  cursor: id,
+  node: {
+    __typename: "MasterCard" as const,
+    id,
+    masterCardgroupId: MASTER_ID,
+    front: `front-${id}`,
+    back: `back-${id}`,
+    position: 0,
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+  },
+});
+
+const seedPageInfo = {
+  __typename: "PageInfo" as const,
+  hasNextPage: false,
+  hasPreviousPage: false,
+  startCursor: "c-1",
+  endCursor: "c-1",
+};
+
+function wrapper({ children }: { children: ReactNode }) {
+  return (
+    <MockedProvider
+      mocks={[
+        {
+          request: {
+            query: AdminMasterCardsConnectionDocument,
+            variables: masterCardsDefaultVars(MASTER_ID),
+          },
+          result: {
+            data: {
+              adminMasterCardsConnection: {
+                __typename: "MasterCardConnection",
+                edges: [edge("c-1")],
+                pageInfo: seedPageInfo,
+                totalCount: 1,
+              },
+            },
+          },
+        },
+      ]}
+    >
+      {children}
+    </MockedProvider>
+  );
+}
+
+describe("useMasterCardsConnection", () => {
+  it("renders the prop-seeded edges before the query resolves and exposes queryVariables", () => {
+    const { result } = renderHook(
+      () =>
+        useMasterCardsConnection({
+          masterId: MASTER_ID,
+          searchQuery: null,
+          initialEdges: [edge("c-1")],
+          initialPageInfo: seedPageInfo,
+          initialTotalCount: 1,
+        }),
+      { wrapper },
+    );
+    expect(result.current.edges).toHaveLength(1);
+    expect(result.current.queryVariables).toEqual(masterCardsDefaultVars(MASTER_ID));
+  });
+
+  it("keeps queryVariables.search in sync with a non-null search query", async () => {
+    const { result } = renderHook(
+      () =>
+        useMasterCardsConnection({
+          masterId: MASTER_ID,
+          searchQuery: "apple",
+          initialEdges: [],
+          initialPageInfo: seedPageInfo,
+          initialTotalCount: 0,
+        }),
+      { wrapper },
+    );
+    await waitFor(() => {
+      expect(result.current.queryVariables.search).toBe("apple");
+      expect(result.current.queryVariables.masterCardgroupId).toBe(MASTER_ID);
+    });
+  });
+});

--- a/frontend/src/app/admin/masters/[id]/edit/cards/use-master-cards-connection.ts
+++ b/frontend/src/app/admin/masters/[id]/edit/cards/use-master-cards-connection.ts
@@ -1,0 +1,88 @@
+import { useCallback, useMemo } from "react";
+import {
+  AdminMasterCardsConnectionDocument,
+  type AdminMasterCardsConnectionQuery,
+  type AdminMasterCardsConnectionQueryVariables,
+} from "@/generated/graphql";
+import { getBackendErrorBanner } from "@/lib/apollo/errors";
+import {
+  type UseConnectionPaginationResult,
+  useConnectionPagination,
+} from "@/lib/pagination/use-connection-pagination";
+import { masterCardsDefaultVars } from "./queries";
+
+type MasterCardEdge =
+  AdminMasterCardsConnectionQuery["adminMasterCardsConnection"]["edges"][number];
+type MasterCardConnectionPageInfo =
+  AdminMasterCardsConnectionQuery["adminMasterCardsConnection"]["pageInfo"];
+
+export interface UseMasterCardsConnectionInput {
+  masterId: string;
+  searchQuery: string | null;
+  initialEdges: MasterCardEdge[];
+  initialPageInfo: MasterCardConnectionPageInfo;
+  initialTotalCount: number;
+}
+
+export type UseMasterCardsConnectionResult = UseConnectionPaginationResult<
+  AdminMasterCardsConnectionQuery,
+  MasterCardEdge,
+  MasterCardConnectionPageInfo,
+  AdminMasterCardsConnectionQueryVariables
+>;
+
+function mergeMasterCardsConnection(
+  prev: AdminMasterCardsConnectionQuery,
+  more: AdminMasterCardsConnectionQuery,
+): AdminMasterCardsConnectionQuery {
+  return {
+    adminMasterCardsConnection: {
+      ...more.adminMasterCardsConnection,
+      edges: [...prev.adminMasterCardsConnection.edges, ...more.adminMasterCardsConnection.edges],
+    },
+  };
+}
+
+export function useMasterCardsConnection(
+  input: UseMasterCardsConnectionInput,
+): UseMasterCardsConnectionResult {
+  const { masterId, searchQuery, initialEdges, initialPageInfo, initialTotalCount } = input;
+
+  const variables = useMemo<AdminMasterCardsConnectionQueryVariables>(
+    () =>
+      searchQuery === null
+        ? masterCardsDefaultVars(masterId)
+        : { ...masterCardsDefaultVars(masterId), search: searchQuery },
+    [masterId, searchQuery],
+  );
+
+  const buildFetchMoreVariables = useCallback(
+    (
+      endCursor: string | null,
+      search: string | null,
+    ): AdminMasterCardsConnectionQueryVariables => ({
+      ...masterCardsDefaultVars(masterId),
+      after: endCursor,
+      search,
+    }),
+    [masterId],
+  );
+
+  return useConnectionPagination<
+    AdminMasterCardsConnectionQuery,
+    AdminMasterCardsConnectionQueryVariables,
+    MasterCardEdge,
+    MasterCardConnectionPageInfo
+  >({
+    document: AdminMasterCardsConnectionDocument,
+    variables,
+    searchQuery,
+    selectConnection: (data) => data?.adminMasterCardsConnection,
+    buildFetchMoreVariables,
+    mergeConnection: mergeMasterCardsConnection,
+    initial: { edges: initialEdges, pageInfo: initialPageInfo, totalCount: initialTotalCount },
+    resolveFetchMoreError: (err) =>
+      getBackendErrorBanner(err) ?? "Could not load more cards. Please try again.",
+    logScope: "[master-cards-client]",
+  });
+}

--- a/frontend/src/app/admin/masters/[id]/edit/master-cards-section.test.tsx
+++ b/frontend/src/app/admin/masters/[id]/edit/master-cards-section.test.tsx
@@ -1,13 +1,79 @@
 // @vitest-environment jsdom
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { MockedProvider } from "@apollo/client/testing/react";
+import { screen, waitFor } from "@testing-library/react";
+import { expect, it, vi } from "vitest";
+import { AdminMasterCardsConnectionDocument } from "@/generated/graphql";
+import { UndoDeleteProvider } from "@/lib/undo-delete";
+import { renderWithIntl } from "@/test/render-with-intl";
+import { masterCardsDefaultVars } from "./cards/queries";
 import { MasterCardsSection } from "./master-cards-section";
 
-describe("MasterCardsSection (placeholder)", () => {
-  it("mounts a stable container keyed to the master id", () => {
-    render(<MasterCardsSection masterId="m-1" />);
-    const section = screen.getByTestId("master-cards-section");
-    expect(section).toBeInTheDocument();
-    expect(section).toHaveAttribute("data-master-id", "m-1");
-  });
+vi.mock("@/components/cardgroups/swipeable-row", async () => {
+  const { forwardRef } = await import("react");
+  return {
+    SwipeableRow: forwardRef(function Mock(
+      { children }: { children: React.ReactNode },
+      _ref: React.Ref<{ close(): void }>,
+    ) {
+      return <div>{children}</div>;
+    }),
+  };
+});
+
+const MASTER_ID = "m-1";
+const pageInfo = {
+  __typename: "PageInfo" as const,
+  hasNextPage: false,
+  hasPreviousPage: false,
+  startCursor: "c-1",
+  endCursor: "c-1",
+};
+const node = {
+  __typename: "MasterCard" as const,
+  id: "c-1",
+  masterCardgroupId: MASTER_ID,
+  front: "apple",
+  back: "fruit",
+  position: 0,
+  createdAt: "2026-01-01T00:00:00Z",
+  updatedAt: "2026-01-01T00:00:00Z",
+};
+
+it("renders MasterCardsClient with the seed and reports the count", async () => {
+  const onTotalCountChange = vi.fn();
+  renderWithIntl(
+    <MockedProvider
+      mocks={[
+        {
+          request: {
+            query: AdminMasterCardsConnectionDocument,
+            variables: masterCardsDefaultVars(MASTER_ID),
+          },
+          result: {
+            data: {
+              adminMasterCardsConnection: {
+                __typename: "MasterCardConnection",
+                edges: [{ __typename: "MasterCardEdge", cursor: "c-1", node }],
+                pageInfo,
+                totalCount: 1,
+              },
+            },
+          },
+        },
+      ]}
+    >
+      <UndoDeleteProvider>
+        <MasterCardsSection
+          masterId={MASTER_ID}
+          deckName="Deck One"
+          initialEdges={[{ __typename: "MasterCardEdge", cursor: "c-1", node }]}
+          initialPageInfo={pageInfo}
+          initialTotalCount={1}
+          onTotalCountChange={onTotalCountChange}
+        />
+      </UndoDeleteProvider>
+    </MockedProvider>,
+  );
+  expect(screen.getByText("apple")).toBeInTheDocument();
+  await waitFor(() => expect(onTotalCountChange).toHaveBeenCalledWith(1));
 });

--- a/frontend/src/app/admin/masters/[id]/edit/master-cards-section.tsx
+++ b/frontend/src/app/admin/masters/[id]/edit/master-cards-section.tsx
@@ -1,9 +1,38 @@
-/**
- * Placeholder for the master-cards editing UI. #522 replaces the body with the
- * paginated cards connection and extends the props with
- * `initialEdges` / `initialPageInfo` / `initialTotalCount`. The `masterId` prop
- * name is the stable interface this file exposes — do not rename it.
- */
-export function MasterCardsSection({ masterId }: { masterId: string }) {
-  return <section data-testid="master-cards-section" data-master-id={masterId} />;
+"use client";
+
+import {
+  type MasterCardConnectionPageInfo,
+  type MasterCardEdge,
+  MasterCardsClient,
+} from "./cards/master-cards-client";
+
+type MasterCardsSectionProps = {
+  masterId: string;
+  deckName: string;
+  initialEdges: MasterCardEdge[];
+  initialPageInfo: MasterCardConnectionPageInfo;
+  initialTotalCount: number;
+  onTotalCountChange: (count: number) => void;
+};
+
+export function MasterCardsSection({
+  masterId,
+  deckName,
+  initialEdges,
+  initialPageInfo,
+  initialTotalCount,
+  onTotalCountChange,
+}: MasterCardsSectionProps) {
+  return (
+    <section data-testid="master-cards-section" data-master-id={masterId}>
+      <MasterCardsClient
+        masterId={masterId}
+        deckName={deckName}
+        initialEdges={initialEdges}
+        initialPageInfo={initialPageInfo}
+        initialTotalCount={initialTotalCount}
+        onTotalCountChange={onTotalCountChange}
+      />
+    </section>
+  );
 }

--- a/frontend/src/app/admin/masters/[id]/edit/master-edit-header.test.tsx
+++ b/frontend/src/app/admin/masters/[id]/edit/master-edit-header.test.tsx
@@ -61,7 +61,7 @@ function renderHeader(deck: AdminMasterDeck, mocks: ReadonlyArray<unknown> = [])
   return render(
     <MockedProvider mocks={mocks as never}>
       <NextIntlClientProvider locale="en" messages={enMessages} timeZone="UTC">
-        <MasterEditHeader master={deck} />
+        <MasterEditHeader master={deck} cardCount={deck.cardCount} />
       </NextIntlClientProvider>
     </MockedProvider>,
   );
@@ -234,5 +234,17 @@ describe("MasterEditHeader", () => {
     const settingsItem = await screen.findByRole("menuitem", { name: /deck settings/i });
     await user.click(settingsItem);
     expect(await screen.findByTestId("master-field-name")).toBeInTheDocument();
+  });
+
+  it("displays the cardCount prop (live count), not master.cardCount", () => {
+    render(
+      <MockedProvider mocks={[]}>
+        <NextIntlClientProvider locale="en" messages={enMessages} timeZone="UTC">
+          <MasterEditHeader master={{ ...DECK, cardCount: 0 }} cardCount={5} />
+        </NextIntlClientProvider>
+      </MockedProvider>,
+    );
+    // Publish is enabled because the LIVE count is 5, even though master.cardCount is 0.
+    expect(screen.getByTestId("master-edit-publish")).not.toBeDisabled();
   });
 });

--- a/frontend/src/app/admin/masters/[id]/edit/master-edit-header.tsx
+++ b/frontend/src/app/admin/masters/[id]/edit/master-edit-header.tsx
@@ -28,9 +28,9 @@ import {
 import { FormSheet } from "@/components/ui/form-sheet";
 import type { AdminMasterDeck } from "./queries";
 
-type Props = { master: AdminMasterDeck };
+type Props = { master: AdminMasterDeck; cardCount: number };
 
-export function MasterEditHeader({ master }: Props) {
+export function MasterEditHeader({ master, cardCount }: Props) {
   const t = useTranslations("AdminMasters");
   const tCommon = useTranslations("Common");
   const router = useRouter();
@@ -48,7 +48,7 @@ export function MasterEditHeader({ master }: Props) {
     useMasterMutations();
 
   const published = master.status === "PUBLISHED";
-  const emptyDraft = master.status === "DRAFT" && master.cardCount === 0;
+  const emptyDraft = master.status === "DRAFT" && cardCount === 0;
 
   const authToast = useCallback(
     (kind: AuthKind) => {
@@ -154,7 +154,7 @@ export function MasterEditHeader({ master }: Props) {
               {published ? t("statusPublished") : t("statusDraft")}
             </Badge>
             <span className="text-sm text-muted-foreground">
-              {t("cardCount", { count: master.cardCount })}
+              {t("cardCount", { count: cardCount })}
             </span>
           </div>
           {emptyDraft ? (

--- a/frontend/src/app/admin/masters/[id]/edit/master-management-client.tsx
+++ b/frontend/src/app/admin/masters/[id]/edit/master-management-client.tsx
@@ -19,7 +19,7 @@ const EMPTY_PAGE_INFO = {
 
 export function MasterManagementClient({ master }: Props) {
   const t = useTranslations("AdminMasters");
-  const [totalCount, setTotalCount] = useState(master.cardCount);
+  const [liveCount, setLiveCount] = useState(master.cardCount);
   return (
     <main className="p-4 md:p-8">
       <div className="mb-2">
@@ -31,14 +31,14 @@ export function MasterManagementClient({ master }: Props) {
         </Link>
       </div>
 
-      <MasterEditHeader master={{ ...master, cardCount: totalCount }} />
+      <MasterEditHeader master={master} cardCount={liveCount} />
       <MasterCardsSection
         masterId={master.id}
         deckName={master.name}
         initialEdges={[]}
         initialPageInfo={EMPTY_PAGE_INFO}
         initialTotalCount={master.cardCount}
-        onTotalCountChange={setTotalCount}
+        onTotalCountChange={setLiveCount}
       />
     </main>
   );

--- a/frontend/src/app/admin/masters/[id]/edit/master-management-client.tsx
+++ b/frontend/src/app/admin/masters/[id]/edit/master-management-client.tsx
@@ -3,23 +3,26 @@
 import Link from "next/link";
 import { useTranslations } from "next-intl";
 import { useState } from "react";
+import type { MasterCardConnectionPageInfo, MasterCardEdge } from "./cards/master-cards-client";
 import { MasterCardsSection } from "./master-cards-section";
 import { MasterEditHeader } from "./master-edit-header";
 import type { AdminMasterDeck } from "./queries";
 
-type Props = { master: AdminMasterDeck };
-
-const EMPTY_PAGE_INFO = {
-  __typename: "PageInfo" as const,
-  hasNextPage: false,
-  hasPreviousPage: false,
-  startCursor: null,
-  endCursor: null,
+type Props = {
+  master: AdminMasterDeck;
+  initialEdges: MasterCardEdge[];
+  initialPageInfo: MasterCardConnectionPageInfo;
+  initialTotalCount: number;
 };
 
-export function MasterManagementClient({ master }: Props) {
+export function MasterManagementClient({
+  master,
+  initialEdges,
+  initialPageInfo,
+  initialTotalCount,
+}: Props) {
   const t = useTranslations("AdminMasters");
-  const [liveCount, setLiveCount] = useState(master.cardCount);
+  const [liveCount, setLiveCount] = useState(initialTotalCount);
   return (
     <main className="p-4 md:p-8">
       <div className="mb-2">
@@ -35,9 +38,9 @@ export function MasterManagementClient({ master }: Props) {
       <MasterCardsSection
         masterId={master.id}
         deckName={master.name}
-        initialEdges={[]}
-        initialPageInfo={EMPTY_PAGE_INFO}
-        initialTotalCount={master.cardCount}
+        initialEdges={initialEdges}
+        initialPageInfo={initialPageInfo}
+        initialTotalCount={initialTotalCount}
         onTotalCountChange={setLiveCount}
       />
     </main>

--- a/frontend/src/app/admin/masters/[id]/edit/master-management-client.tsx
+++ b/frontend/src/app/admin/masters/[id]/edit/master-management-client.tsx
@@ -2,14 +2,24 @@
 
 import Link from "next/link";
 import { useTranslations } from "next-intl";
+import { useState } from "react";
 import { MasterCardsSection } from "./master-cards-section";
 import { MasterEditHeader } from "./master-edit-header";
 import type { AdminMasterDeck } from "./queries";
 
 type Props = { master: AdminMasterDeck };
 
+const EMPTY_PAGE_INFO = {
+  __typename: "PageInfo" as const,
+  hasNextPage: false,
+  hasPreviousPage: false,
+  startCursor: null,
+  endCursor: null,
+};
+
 export function MasterManagementClient({ master }: Props) {
   const t = useTranslations("AdminMasters");
+  const [totalCount, setTotalCount] = useState(master.cardCount);
   return (
     <main className="p-4 md:p-8">
       <div className="mb-2">
@@ -21,8 +31,15 @@ export function MasterManagementClient({ master }: Props) {
         </Link>
       </div>
 
-      <MasterEditHeader master={master} />
-      <MasterCardsSection masterId={master.id} />
+      <MasterEditHeader master={{ ...master, cardCount: totalCount }} />
+      <MasterCardsSection
+        masterId={master.id}
+        deckName={master.name}
+        initialEdges={[]}
+        initialPageInfo={EMPTY_PAGE_INFO}
+        initialTotalCount={master.cardCount}
+        onTotalCountChange={setTotalCount}
+      />
     </main>
   );
 }

--- a/frontend/src/app/admin/masters/[id]/edit/page.test.tsx
+++ b/frontend/src/app/admin/masters/[id]/edit/page.test.tsx
@@ -15,8 +15,16 @@ vi.mock("next/headers", () => ({
 }));
 vi.mock("@/lib/apollo/server", () => ({ gqlFetch: vi.fn() }));
 vi.mock("./master-management-client", () => ({
-  MasterManagementClient: ({ master }: { master: { name: string } }) => (
-    <div data-testid="master-management-client">{master.name}</div>
+  MasterManagementClient: ({
+    master,
+    initialTotalCount,
+  }: {
+    master: { name: string };
+    initialTotalCount: number;
+  }) => (
+    <div data-testid="master-management-client" data-initial-total-count={initialTotalCount}>
+      {master.name}
+    </div>
   ),
 }));
 
@@ -39,23 +47,53 @@ describe("EditMasterPage — gate", () => {
   });
 
   it("calls notFound when adminMaster is null", async () => {
-    vi.mocked(gqlFetch).mockResolvedValueOnce({ adminMaster: null } as never);
+    vi.mocked(gqlFetch)
+      .mockResolvedValueOnce({ adminMaster: null } as never)
+      .mockResolvedValueOnce({ adminMasterCardsConnection: null } as never);
     await expect(EditMasterPage({ params: params() })).rejects.toThrow("NOT_FOUND");
     expect(notFound).toHaveBeenCalled();
   });
 
   it("renders the management client when the master is found", async () => {
-    vi.mocked(gqlFetch).mockResolvedValueOnce({
-      adminMaster: {
-        __typename: "MasterCardgroup",
-        id: ID,
-        name: "Spanish A1",
-        status: "DRAFT",
-        cardCount: 3,
-      },
-    } as never);
+    vi.mocked(gqlFetch)
+      .mockResolvedValueOnce({
+        adminMaster: {
+          __typename: "MasterCardgroup",
+          id: ID,
+          name: "Spanish A1",
+          status: "DRAFT",
+          cardCount: 3,
+        },
+      } as never)
+      .mockResolvedValueOnce({
+        adminMasterCardsConnection: {
+          edges: [
+            {
+              cursor: "v1:abc",
+              node: {
+                id: "c-1",
+                masterCardgroupId: ID,
+                front: "hola",
+                back: "hello",
+                position: 1,
+                createdAt: "2024-01-01T00:00:00Z",
+                updatedAt: "2024-01-01T00:00:00Z",
+              },
+            },
+          ],
+          pageInfo: {
+            hasNextPage: false,
+            hasPreviousPage: false,
+            startCursor: "v1:abc",
+            endCursor: "v1:abc",
+          },
+          totalCount: 1,
+        },
+      } as never);
     const jsx = await EditMasterPage({ params: params() });
     render(jsx as React.ReactElement);
-    expect(screen.getByTestId("master-management-client")).toHaveTextContent("Spanish A1");
+    const el = screen.getByTestId("master-management-client");
+    expect(el).toHaveTextContent("Spanish A1");
+    expect(el).toHaveAttribute("data-initial-total-count", "1");
   });
 });

--- a/frontend/src/app/admin/masters/[id]/edit/page.tsx
+++ b/frontend/src/app/admin/masters/[id]/edit/page.tsx
@@ -1,13 +1,17 @@
 import type { Metadata } from "next";
 import { headers } from "next/headers";
 import { notFound, redirect } from "next/navigation";
-import type { AdminMasterQuery } from "@/generated/graphql";
+import type {
+  AdminMasterCardsConnectionQuery as AdminMasterCardsConnectionQueryType,
+  AdminMasterQuery,
+} from "@/generated/graphql";
 import {
   isForbiddenGraphQLError,
   isUnauthenticatedGraphQLError,
 } from "@/lib/apollo/graphql-errors";
 import { gqlFetch } from "@/lib/apollo/server";
 import { readAuthContext } from "@/lib/supabase/auth-status";
+import { AdminMasterCardsConnectionQuery, masterCardsDefaultVars } from "./cards/queries";
 import { MasterManagementClient } from "./master-management-client";
 import { AdminMasterQueryDocument } from "./queries";
 
@@ -22,9 +26,16 @@ export default async function EditMasterPage({ params }: Props) {
   // Defense-in-depth under the admin layout: redirect to / for stale/anonymous.
   if (readAuthContext(await headers()).status !== "authenticated") redirect("/");
 
-  let data: AdminMasterQuery | null = null;
+  let deckData: AdminMasterQuery | null = null;
+  let connectionData: AdminMasterCardsConnectionQueryType | null = null;
   try {
-    data = await gqlFetch(AdminMasterQueryDocument, { variables: { id }, revalidate: 0 });
+    [deckData, connectionData] = await Promise.all([
+      gqlFetch(AdminMasterQueryDocument, { variables: { id }, revalidate: 0 }),
+      gqlFetch(AdminMasterCardsConnectionQuery, {
+        variables: masterCardsDefaultVars(id),
+        revalidate: 0,
+      }),
+    ]);
   } catch (err) {
     if (isUnauthenticatedGraphQLError(err) || isForbiddenGraphQLError(err)) redirect("/");
     console.error("[admin/masters/:id/edit] gqlFetch failed:", {
@@ -33,7 +44,25 @@ export default async function EditMasterPage({ params }: Props) {
     throw err;
   }
 
-  if (!data?.adminMaster) notFound();
+  if (!deckData?.adminMaster) notFound();
 
-  return <MasterManagementClient master={data.adminMaster} />;
+  const conn = connectionData?.adminMasterCardsConnection;
+  const initialEdges = conn?.edges ?? [];
+  const initialPageInfo = conn?.pageInfo ?? {
+    __typename: "PageInfo" as const,
+    hasNextPage: false,
+    hasPreviousPage: false,
+    startCursor: null,
+    endCursor: null,
+  };
+  const initialTotalCount = conn?.totalCount ?? 0;
+
+  return (
+    <MasterManagementClient
+      master={deckData.adminMaster}
+      initialEdges={initialEdges}
+      initialPageInfo={initialPageInfo}
+      initialTotalCount={initialTotalCount}
+    />
+  );
 }


### PR DESCRIPTION
## Summary

Replaces the `<MasterCardsSection>` placeholder (#521) with the real master-card editor: a cursor-paginated card list with debounced search, inline add/edit via `FormSheet`, per-row delete with a 5s undo window, bulk-select delete, and batch text import — full parity with the cardgroup card screen, wired to the master-card write API (#520). The deck's card count in the page header updates live on every mutation. Frontend-only; mirrors the cardgroup card stack into the admin master-edit tree.

Closes #522.

## Background / Motivation

- #521 landed the master-edit page shell with a `<MasterCardsSection masterId>` placeholder, and #520 landed the master-card write API — but no card-editing UI existed to drive them.
- Mirrors the proven cardgroup card stack (`app/cardgroups/[id]/cards/` + the `/cardgroups/[id]/edit` RSC seed) so the admin surface stays consistent and consumes the shared `useConnectionPagination` IO owner rather than re-inlining an `IntersectionObserver` loop.
- The page header's card count and its Publish-enable gate (`emptyDraft = DRAFT && count === 0`) previously read the static `master.cardCount` RSC value; card mutations happen in the section, so the count must be lifted to a common ancestor to react live — without a full `router.refresh()` per mutation or a second `useQuery` that would split the cache.
- The two generic presentational primitives (`card-row`, `bulk-action-bar`) and the import wizard are deliberately mirrored here rather than shared; collapsing the duplicate copies into `@/components/cardgroups/` is tracked in #527 (depends on this PR).

## Changes

### GraphQL documents + connection hook

- `app/admin/masters/[id]/edit/cards/queries.ts` (new) — the `AdminMasterCardsConnection` query plus the five mutation documents (`AdminCreateMasterCard`, `AdminUpdateMasterCard`, `AdminDeleteMasterCard`, `AdminDeleteMasterCards`, `AdminImportMasterCards`), and the `masterCardsDefaultVars(id)` factory `{ masterCardgroupId, first: 20, search: null }` that keys the SSR seed, the client `useQuery`, and every cache write identically. Reuses the existing `ValidateCardImport` query (not redeclared).
- `cards/use-master-cards-connection.ts` (new) — a thin wrapper over the shared `@/lib/pagination/use-connection-pagination`; supplies the document, the `masterCardsDefaultVars`-based variables, the `data?.adminMasterCardsConnection` accessor, and the edges-concat. Exposes `refetch` + `queryVariables`.

### Mutations + cache writes

- `cards/use-master-card-mutations.ts` (new) — owns create / update / per-row delete / bulk delete and every Apollo cache write. Create prepends a `{ cursor: node.id, node }` edge via `readQuery + writeQuery` and bumps `totalCount`; bulk delete filters edges + `cache.evict` + `cache.gc()`; per-row delete snapshots, optimistically drops the edge, and commits behind a 5s undo window. `MasterCardDuplicateFrontError` and `InputValidationError` map to inline `{ status: "validation", field, message }` outcomes. Edges resolve by `node.id`, never `edge.cursor`. No `optimisticResponse` on any typed-error mutation (a static-source guard pins this).

### List / CRUD / import UI

- `cards/master-cards-client.tsx` (new) — the list/search/CRUD/import screen; renders an inline `Add card` / `Batch import` toolbar (the admin header has no Start-learning CTA), the `MasterCardRow` list off the shared IO sentinel, the bulk bar, and four `FormSheet`s. Reuses `CardForm` for the add/edit sheets and reports its live `totalCount` upward via `onTotalCountChange`.
- `cards/master-card-row.tsx`, `cards/master-bulk-action-bar.tsx` (new) — mirrors of the cardgroup row / bulk bar; the bulk-delete confirm carries `buttonVariants({ variant: "destructive" })`.
- `cards/master-batch-import-form.tsx` (new) — the two-step validate→import wizard, mirrored from `cardgroup-batch-import-form.tsx` with the import mutation swapped to `adminImportMasterCards` (`{ masterCardgroupId, payload }`, base64) and the post-import refetch retargeted to `AdminMasterCardsConnectionDocument`.

### Live card count (state-lift)

- `master-management-client.tsx` — holds `liveCount` state (seeded from the SSR `initialTotalCount`), passes `cardCount={liveCount}` to the header and `onTotalCountChange={setLiveCount}` to the section.
- `master-edit-header.tsx` — gains an explicit `cardCount: number` prop; both the count display and the `emptyDraft` Publish gate now read the prop instead of `master.cardCount`, so adding the first card enables Publish without a refetch.

### RSC seed

- `page.tsx` — adds a parallel `gqlFetch(AdminMasterCardsConnection, { variables: masterCardsDefaultVars(id), revalidate: 0 })` alongside the existing deck fetch and threads the seed (`initialEdges` / `initialPageInfo` / `initialTotalCount`) into `MasterManagementClient`.
- `master-cards-section.tsx` — implemented over the stable `masterId` interface; forwards the seed + `onTotalCountChange` to `MasterCardsClient`.

### i18n

- `messages/{en,ja}.json` — no new keys: the screen reuses the existing `Cards.*`, `BatchImport.*`, `Common.*`, and `Cardgroups.batchImport` catalog entries (every referenced key verified present in both catalogs).

### Tests

- Narrow: `use-master-cards-connection.test.tsx`, `use-master-card-mutations.test.tsx` (duplicate-front → inline, update validation → inline, no-`optimisticResponse` static guard), `master-card-row.test.tsx`, `master-batch-import-form.test.tsx`, `master-cards-client.test.tsx`, `master-cards-section.test.tsx`, and the updated `master-edit-header.test.tsx` (the `cardCount`-prop-drives-the-gate case).
- Broad: `__tests__/admin-master-cards.test.tsx` (seed render + the create→count-1→2 live-count chain end-to-end) and the updated `__tests__/admin-masters-edit.test.tsx` (now mounts the real client tree with `UndoDeleteProvider` + a connection mock).
- e2e: `e2e/admin-masters-edit.spec.ts` gains an add → edit → delete happy path; selectors are locale-independent (`data-testid`, input ids, `[data-testid="form-sheet-body"]`) because the suite runs in `ja-JP`.

## Verification

```bash
cd frontend && pnpm codegen && pnpm typecheck && pnpm lint && pnpm knip && pnpm test && pnpm build
```

All green locally: codegen clean, typecheck / biome / knip clean, vitest 155 files / 1453 tests, build OK (`/admin/masters/[id]/edit` route compiled). gqlgen/codegen output is gitignored and regenerated in CI. The e2e spec is not run locally (it needs the live Supabase + backend stack and `E2E_*` env, and `e2e/` is outside the project tsconfig) and runs in CI.

Runtime check: as an admin, open `/admin/masters/[id]/edit` — the cards list renders; **Add card** opens the add sheet and a valid front/back appends a row and bumps the header count; adding a card whose front already exists (case-insensitive) shows an inline `front` error; editing a row and saving updates it in place; per-row delete shows a 5s undo toast; selecting rows and confirming the red bulk-delete removes them and decrements the count; **Batch import** validates then imports tab-separated pairs.

## Test plan

- [ ] Add a card with a valid front/back — it appears in the list and the header count increments.
- [ ] Add a card whose front already exists (case-insensitive) — an inline `front` duplicate error renders; the card is not created.
- [ ] Edit a row, change the back, save — the new back text shows in place; an empty front surfaces an inline validation error.
- [ ] Delete a single row — a 5s undo toast appears; undo restores the row, otherwise it is committed and evicted.
- [ ] Select multiple rows and confirm the red bulk delete — the rows disappear and the header count decrements.
- [ ] Batch-import tab-separated pairs — new fronts insert, existing fronts update, per-line parse errors are listed.
- [ ] Search filters the list; scrolling pages the next batch with no double-subscribe (one network request per page).
- [ ] The Publish button enables as soon as the first card is added to an empty draft (no page refresh).
