### PR TITLE
refactor(backend): seal Draft/Version=1 in NewMasterCardgroup constructor

### DIFF
--- a/backend/internal/domain/master_cardgroup.go
+++ b/backend/internal/domain/master_cardgroup.go
@@ -1,6 +1,10 @@
 package domain
 
-import "time"
+import (
+	"time"
+
+	"github.com/rotisserie/eris"
+)
 
 // MasterCardgroupStatus is the publication lifecycle state of a master cardgroup.
 // The zero value (MasterCardgroupStatus("")) is invalid; use MasterStatusDraft or
@@ -38,6 +42,43 @@ type MasterCardgroup struct {
 	SortOrder        int
 	CreatedAt        time.Time
 	UpdatedAt        time.Time
+}
+
+// NewMasterCardgroup constructs a MasterCardgroup aggregate in its initial
+// admin-created state: Version = 1 and Status = MasterStatusDraft. It generates a
+// fresh UUID v7 ID and stamps CreatedAt and UpdatedAt with the current UTC time.
+// The name VO is validated upstream by ParseCardgroupName; callers pass the parsed
+// CardgroupName so this constructor stays free of validation branching (mirroring
+// NewCardgroup / NewCard). The Draft/Version=1 invariant is sealed here so it
+// cannot drift across the usecase and repository call sites. Returns a wrapped
+// error when ID generation fails.
+func NewMasterCardgroup(
+	name CardgroupName,
+	description, language, level, category, coverImageURL, source *string,
+	isDefaultStarter bool,
+	sortOrder int,
+) (*MasterCardgroup, error) {
+	id, err := NewID()
+	if err != nil {
+		return nil, eris.Wrap(err, "master cardgroup: new id")
+	}
+	now := time.Now().UTC()
+	return &MasterCardgroup{
+		ID:               id,
+		Name:             name,
+		Description:      description,
+		Language:         language,
+		Level:            level,
+		Category:         category,
+		CoverImageURL:    coverImageURL,
+		Source:           source,
+		Version:          1,
+		Status:           MasterStatusDraft,
+		IsDefaultStarter: isDefaultStarter,
+		SortOrder:        sortOrder,
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}, nil
 }
 
 // IsPublished reports whether the master cardgroup is in the published state

--- a/backend/internal/domain/master_cardgroup_test.go
+++ b/backend/internal/domain/master_cardgroup_test.go
@@ -1,11 +1,98 @@
 package domain
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 )
+
+func TestNewMasterCardgroup(t *testing.T) {
+	t.Parallel()
+
+	t.Run("constructs a draft master cardgroup at version 1 with fields passed through", func(t *testing.T) {
+		t.Parallel()
+
+		name, err := ParseCardgroupName("Starter Deck")
+		require.NoError(t, err)
+
+		desc := "an intro deck"
+		lang := "en"
+		level := "A1"
+		category := "general"
+		cover := "https://example.test/cover.png"
+		source := "oxford"
+
+		m, err := NewMasterCardgroup(name, &desc, &lang, &level, &category, &cover, &source, true, 5)
+		require.NoError(t, err)
+		require.NotNil(t, m)
+
+		require.NotEmpty(t, m.ID, "constructor must generate an ID")
+		require.Equal(t, name, m.Name)
+		require.Equal(t, &desc, m.Description)
+		require.Equal(t, &lang, m.Language)
+		require.Equal(t, &level, m.Level)
+		require.Equal(t, &category, m.Category)
+		require.Equal(t, &cover, m.CoverImageURL)
+		require.Equal(t, &source, m.Source)
+		require.Equal(t, 1, m.Version, "a new master deck starts at version 1")
+		require.Equal(t, MasterStatusDraft, m.Status, "a new master deck starts in draft")
+		require.True(t, m.IsDefaultStarter)
+		require.Equal(t, 5, m.SortOrder)
+		require.False(t, m.CreatedAt.IsZero(), "constructor must stamp CreatedAt")
+		require.Equal(t, m.CreatedAt, m.UpdatedAt, "CreatedAt and UpdatedAt must match at construction")
+	})
+
+	t.Run("nil optional fields stay nil and defaults hold", func(t *testing.T) {
+		t.Parallel()
+
+		name, err := ParseCardgroupName("Minimal")
+		require.NoError(t, err)
+
+		m, err := NewMasterCardgroup(name, nil, nil, nil, nil, nil, nil, false, 0)
+		require.NoError(t, err)
+		require.Nil(t, m.Description)
+		require.Nil(t, m.Language)
+		require.Nil(t, m.Level)
+		require.Nil(t, m.Category)
+		require.Nil(t, m.CoverImageURL)
+		require.Nil(t, m.Source)
+		require.Equal(t, 1, m.Version)
+		require.Equal(t, MasterStatusDraft, m.Status)
+		require.False(t, m.IsDefaultStarter)
+		require.Equal(t, 0, m.SortOrder)
+	})
+
+	t.Run("name length invariant is surfaced upstream via CardgroupName", func(t *testing.T) {
+		t.Parallel()
+
+		// The constructor takes a parsed CardgroupName, so the 1..CardgroupNameMax
+		// invariant is enforced by ParseCardgroupName before construction — mirroring
+		// NewCardgroup. An over-long name never reaches NewMasterCardgroup.
+		_, err := ParseCardgroupName(strings.Repeat("a", CardgroupNameMax+1))
+		require.ErrorIs(t, err, ErrCardgroupNameTooLong)
+	})
+}
+
+// TestNewMasterCardgroup_IDFailure pins the id-generation failure path through
+// the newV7 test seam. Like TestNewCard_IDFailure it must NOT run in parallel:
+// it swaps the package-level seam (see ids_test.go).
+func TestNewMasterCardgroup_IDFailure(t *testing.T) {
+	orig := newV7
+	newV7 = func() (uuid.UUID, error) { return uuid.UUID{}, errors.New("crypto/rand unavailable") }
+	t.Cleanup(func() { newV7 = orig })
+
+	name, err := ParseCardgroupName("Starter")
+	require.NoError(t, err)
+
+	m, err := NewMasterCardgroup(name, nil, nil, nil, nil, nil, nil, false, 0)
+	require.Nil(t, m)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "master cardgroup: new id")
+	require.Contains(t, err.Error(), "domain: new uuid v7")
+}
 
 func TestMasterCardgroupStatusIsValid(t *testing.T) {
 	t.Parallel()

--- a/backend/internal/repository/master_cardgroup.go
+++ b/backend/internal/repository/master_cardgroup.go
@@ -185,21 +185,11 @@ func (r *masterCardgroupRepo) EnsureByName(ctx context.Context, name string) (*d
 			return eris.Wrap(err, "repository: master cardgroup: ensure by name: lookup")
 		}
 
-		id, err := domain.NewID()
+		m, err := domain.NewMasterCardgroup(domain.CardgroupName(name), nil, nil, nil, nil, nil, nil, false, 0)
 		if err != nil {
-			return eris.Wrap(err, "repository: master cardgroup: ensure by name: id")
+			return eris.Wrap(err, "repository: master cardgroup: ensure by name: construct")
 		}
-		now := time.Now().UTC()
-		row = gormMasterCardgroup{
-			ID:               id,
-			Name:             name,
-			Version:          1,
-			Status:           string(domain.MasterStatusDraft),
-			IsDefaultStarter: false,
-			SortOrder:        0,
-			CreatedAt:        now,
-			UpdatedAt:        now,
-		}
+		row = masterCardgroupFromDomain(m)
 		if err := tx.Create(&row).Error; err != nil {
 			return eris.Wrap(err, "repository: master cardgroup: ensure by name: create")
 		}
@@ -213,7 +203,8 @@ func (r *masterCardgroupRepo) EnsureByName(ctx context.Context, name string) (*d
 }
 
 // Create inserts a new master cardgroup row. The caller is responsible for
-// pre-filling m.ID (uuid v7 via domain.NewID) and both timestamps.
+// supplying a fully-formed value (ID and both timestamps set); build it via
+// domain.NewMasterCardgroup.
 func (r *masterCardgroupRepo) Create(ctx context.Context, m *domain.MasterCardgroup) error {
 	row := masterCardgroupFromDomain(m)
 	if err := r.db.WithContext(ctx).Create(&row).Error; err != nil {

--- a/backend/internal/usecase/master_catalog.go
+++ b/backend/internal/usecase/master_catalog.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"log/slog"
-	"time"
 
 	"github.com/rotisserie/eris"
 
@@ -414,26 +413,19 @@ func (u *masterCatalogUsecase) CreateMaster(ctx context.Context, in CreateMaster
 		return CreateMasterOutcome{Validation: info}, nil
 	}
 
-	id, err := domain.NewID()
+	m, err := domain.NewMasterCardgroup(
+		name,
+		in.Description,
+		in.Language,
+		in.Level,
+		in.Category,
+		in.CoverImageURL,
+		in.Source,
+		derefOr(in.IsDefaultStarter, false),
+		derefOr(in.SortOrder, 0),
+	)
 	if err != nil {
-		return CreateMasterOutcome{}, eris.Wrap(err, "usecase: master catalog: create master: id")
-	}
-	now := time.Now().UTC()
-	m := &domain.MasterCardgroup{
-		ID:               id,
-		Name:             name,
-		Description:      in.Description,
-		Language:         in.Language,
-		Level:            in.Level,
-		Category:         in.Category,
-		CoverImageURL:    in.CoverImageURL,
-		Source:           in.Source,
-		Version:          1,
-		Status:           domain.MasterStatusDraft,
-		IsDefaultStarter: derefOr(in.IsDefaultStarter, false),
-		SortOrder:        derefOr(in.SortOrder, 0),
-		CreatedAt:        now,
-		UpdatedAt:        now,
+		return CreateMasterOutcome{}, eris.Wrap(err, "usecase: master catalog: create master: construct")
 	}
 	if err := u.repo.Create(ctx, m); err != nil {
 		return CreateMasterOutcome{}, eris.Wrap(err, "usecase: master catalog: create master")


### PR DESCRIPTION
## Summary

Adds the `NewMasterCardgroup` domain constructor and routes the two new-master-deck creation sites through it, so the "new deck starts at `Version = 1`, `Status = Draft`" initial-state invariant lives in exactly one place instead of being hand-written as a struct literal in both the usecase and the repository. Pure refactor: zero behavior change, no new strings, no schema/codegen.

Closes #533.

## Background / Motivation

- `MasterCardgroup` was the only deck aggregate **without** a domain constructor — `Card` and `Cardgroup` already own `NewCard` / `NewCardgroup`, which seal their construction invariants.
- The `Version = 1` / `Status = Draft` initial state was duplicated as a raw struct literal in two layers: `usecase/master_catalog.go` (`CreateMaster`) and `repository/master_cardgroup.go` (`EnsureByName`). A future change to the initial version (or a new required-field default) would silently drift unless both literals were updated together.
- The aggregate already owns `Publish()` / `Unpublish()` / `IsPublished()`; only construction had leaked out, leaving it anemic on creation.

## Changes

### Domain constructor

- `internal/domain/master_cardgroup.go` — adds `NewMasterCardgroup(name CardgroupName, description, language, level, category, coverImageURL, source *string, isDefaultStarter bool, sortOrder int) (*MasterCardgroup, error)`. It seals `Version = 1` and `Status = MasterStatusDraft`, generates the UUID v7 id via `NewID()`, and stamps `CreatedAt` / `UpdatedAt`. Mirrors `NewCardgroup` / `NewCard`: it takes the already-parsed `CardgroupName` VO (validation stays upstream in `ParseCardgroupName`) and wraps an id-generation failure with the domain-layer prefix `"master cardgroup: new id"`.

### Call-site routing

- `internal/usecase/master_catalog.go` — `CreateMaster` replaces the raw `&domain.MasterCardgroup{…}` literal (and its inline `domain.NewID()` + `time.Now()`) with a `NewMasterCardgroup(...)` call; the now-unused `time` import is dropped.
- `internal/repository/master_cardgroup.go` — `EnsureByName` builds the aggregate via the constructor and maps it to the gorm row through the existing `masterCardgroupFromDomain`, instead of an inline `gormMasterCardgroup{…}` literal. The arrow stays `repository → domain` (the normal inward direction, same as `auth → domain`). `Create`'s docstring is refreshed to point callers at the constructor.

### Tests

- `internal/domain/master_cardgroup_test.go` — `TestNewMasterCardgroup` asserts the `Version = 1` / `Status = Draft` defaults, full field pass-through, nil-optionals staying nil, and that the name-length invariant is surfaced upstream by `ParseCardgroupName`. `TestNewMasterCardgroup_IDFailure` pins the id-generation failure chain through the package-level `newV7` seam (non-parallel, per the convention in `ids_test.go`).

## Verification

```bash
cd backend && go build ./... && go vet ./... \
  && go test -race ./... \
  && go tool go-arch-lint check --project-path .
```

All green locally: full backend suite (26 packages, incl. the `internal/repository` testcontainers integration tests) passed, `go-arch-lint` clean (`repository → domain` is the correct inward arrow), CJK / English-only grep clean. gqlgen output is gitignored and regenerated in CI.

The drift-removal can be confirmed by grep — the `Version: 1` literal now exists only in the constructor:

```bash
grep -rn 'Version:[[:space:]]*1' backend/internal/usecase/master_catalog.go backend/internal/repository/master_cardgroup.go   # zero hits
grep -rn 'Version:[[:space:]]*1' backend/internal/domain/master_cardgroup.go                                                  # one hit (NewMasterCardgroup)
```

## Test plan

- [ ] `go test ./internal/domain/ -run TestNewMasterCardgroup` — constructor returns `Version == 1`, `Status == MasterStatusDraft`, a generated id, and matching `CreatedAt` / `UpdatedAt`.
- [ ] `go test ./internal/usecase/ -run CreateMaster` and `go test ./internal/repository/ -run EnsureByName` stay green — both creation paths still produce a Draft deck at version 1 (no behavior change).
- [ ] `go tool go-arch-lint check --project-path .` reports no new layer violations.
