### PR TITLE
refactor(backend): unify master-catalog cursor resolution + normalize search

### DIFF
--- a/backend/internal/usecase/master_catalog.go
+++ b/backend/internal/usecase/master_catalog.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/rotisserie/eris"
@@ -182,26 +183,30 @@ func (u *masterCatalogUsecase) ListPublishedConnection(
 		return nil, err
 	}
 
-	after, err := u.resolveMasterCatalogCursor(ctx, in.After, orderBy, "after")
+	after, err := u.resolveMasterCursor(ctx, in.After, orderBy, "after", true)
 	if err != nil {
 		return nil, err
 	}
-	before, err := u.resolveMasterCatalogCursor(ctx, in.Before, orderBy, "before")
+	before, err := u.resolveMasterCursor(ctx, in.Before, orderBy, "before", true)
 	if err != nil {
 		return nil, err
 	}
 
+	// Normalize search once so the count and the page query see the same filter
+	// (nil and whitespace-only both mean "no filter").
+	search := normalizeSearch(in.Search)
+
 	// totalCount comes from a separate COUNT(*) scoped to published rows and the
 	// optional search predicate. Computed before the page fetch so callers asking
 	// only for totalCount still see a real value.
-	total, err := u.repo.CountPublished(ctx, in.Search)
+	total, err := u.repo.CountPublished(ctx, search)
 	if err != nil {
 		return nil, eris.Wrap(err, "usecase: master catalog: count published")
 	}
 
 	items, hasNext, hasPrev, err := assemblePage(first, last, after != nil, before != nil,
 		func(wantFirst, wantLast int) ([]*repository.MasterCatalogItem, error) {
-			rows, e := u.repo.FindPublishedPage(ctx, after, before, wantFirst, wantLast, orderBy, dir, in.Search)
+			rows, e := u.repo.FindPublishedPage(ctx, after, before, wantFirst, wantLast, orderBy, dir, search)
 			if e != nil {
 				return nil, eris.Wrap(e, "usecase: master catalog: find published page")
 			}
@@ -254,16 +259,20 @@ func resolveMasterCatalogOrderBy(
 	return field, d, nil
 }
 
-// resolveMasterCatalogCursor decodes an opaque cursor string into a
-// *repository.MasterCatalogCursor with the column required by the active
-// orderBy populated. Returns BAD_USER_INPUT when the cursor cannot be decoded
-// or references a master cardgroup that is not a published catalog row. The
-// published-row check runs even when orderBy is missing a hydratable column.
-func (u *masterCatalogUsecase) resolveMasterCatalogCursor(
+// resolveMasterCursor decodes an opaque cursor string into a
+// *repository.MasterCatalogCursor with the column required by the active orderBy
+// populated. The publishedOnly flag selects the hydration scope: true hydrates
+// via FindPublishedByID (catalog scope — a draft or unknown id is rejected as
+// cursor-not-found so drafts never leak); false hydrates via FindByID (admin
+// scope — DRAFT decks are valid cursors). Returns BAD_USER_INPUT when the cursor
+// cannot be decoded or references a row outside the active scope. The scope check
+// runs even when orderBy is missing a hydratable column.
+func (u *masterCatalogUsecase) resolveMasterCursor(
 	ctx context.Context,
 	cursorStr *string,
 	orderBy repository.MasterCatalogOrderBy,
 	field string,
+	publishedOnly bool,
 ) (*repository.MasterCatalogCursor, error) {
 	if cursorStr == nil || *cursorStr == "" {
 		return nil, nil
@@ -272,7 +281,11 @@ func (u *masterCatalogUsecase) resolveMasterCatalogCursor(
 	if err != nil {
 		return nil, ucerr.NewValidationError(field, "invalid cursor")
 	}
-	mcg, err := u.repo.FindPublishedByID(ctx, id)
+	fetchByID := u.repo.FindByID
+	if publishedOnly {
+		fetchByID = u.repo.FindPublishedByID
+	}
+	mcg, err := fetchByID(ctx, id)
 	if err != nil {
 		if errors.Is(err, repository.ErrNotFound) {
 			return nil, ucerr.NewValidationError(field, "cursor not found")
@@ -391,6 +404,22 @@ func derefOr[T any](p *T, def T) T {
 		return *p
 	}
 	return def
+}
+
+// normalizeSearch collapses nil and whitespace-only search inputs to nil and
+// trims a non-empty search. After this the repository receives either nil (no
+// filter) or a non-empty, trimmed string — the same invariant ListMasterCards
+// relies on. Normalizing at the usecase boundary keeps totalCount and the page
+// query in agreement instead of depending on the repository to trim.
+func normalizeSearch(search *string) *string {
+	if search == nil {
+		return nil
+	}
+	trimmed := strings.TrimSpace(*search)
+	if trimmed == "" {
+		return nil
+	}
+	return &trimmed
 }
 
 // ---------------------------------------------------------------------------
@@ -568,23 +597,27 @@ func (u *masterCatalogUsecase) ListAdminConnection(
 		return nil, err
 	}
 
-	after, err := u.resolveMasterAdminCursor(ctx, in.After, orderBy, "after")
+	after, err := u.resolveMasterCursor(ctx, in.After, orderBy, "after", false)
 	if err != nil {
 		return nil, err
 	}
-	before, err := u.resolveMasterAdminCursor(ctx, in.Before, orderBy, "before")
+	before, err := u.resolveMasterCursor(ctx, in.Before, orderBy, "before", false)
 	if err != nil {
 		return nil, err
 	}
 
-	total, err := u.repo.CountAdmin(ctx, in.Search)
+	// Normalize search once so the count and the page query see the same filter
+	// (nil and whitespace-only both mean "no filter").
+	search := normalizeSearch(in.Search)
+
+	total, err := u.repo.CountAdmin(ctx, search)
 	if err != nil {
 		return nil, eris.Wrap(err, "usecase: master catalog: count admin")
 	}
 
 	items, hasNext, hasPrev, err := assemblePage(first, last, after != nil, before != nil,
 		func(wantFirst, wantLast int) ([]*repository.MasterCatalogItem, error) {
-			rows, e := u.repo.FindAdminPage(ctx, after, before, wantFirst, wantLast, orderBy, dir, in.Search)
+			rows, e := u.repo.FindAdminPage(ctx, after, before, wantFirst, wantLast, orderBy, dir, search)
 			if e != nil {
 				return nil, eris.Wrap(e, "usecase: master catalog: find admin page")
 			}
@@ -601,43 +634,6 @@ func (u *masterCatalogUsecase) ListAdminConnection(
 		out.EndCur = items[len(items)-1].Cardgroup.ID
 	}
 	return out, nil
-}
-
-// resolveMasterAdminCursor decodes an opaque cursor into a repository cursor with
-// the column required by the active orderBy. Unlike resolveMasterCatalogCursor it
-// hydrates via FindByID (any status), since the admin list includes DRAFT decks.
-func (u *masterCatalogUsecase) resolveMasterAdminCursor(
-	ctx context.Context, cursorStr *string, orderBy repository.MasterCatalogOrderBy, field string,
-) (*repository.MasterCatalogCursor, error) {
-	if cursorStr == nil || *cursorStr == "" {
-		return nil, nil
-	}
-	id, err := cursor.Decode(*cursorStr)
-	if err != nil {
-		return nil, ucerr.NewValidationError(field, "invalid cursor")
-	}
-	mcg, err := u.repo.FindByID(ctx, id)
-	if err != nil {
-		if errors.Is(err, repository.ErrNotFound) {
-			return nil, ucerr.NewValidationError(field, "cursor not found")
-		}
-		return nil, eris.Wrap(err, "usecase: master catalog: hydrate admin cursor")
-	}
-	c := &repository.MasterCatalogCursor{ID: id}
-	switch orderBy {
-	case repository.MasterCatalogOrderBySortOrder:
-		so := mcg.SortOrder
-		c.SortOrder = &so
-	case repository.MasterCatalogOrderByCreatedAt:
-		ca := mcg.CreatedAt
-		c.CreatedAt = &ca
-	case repository.MasterCatalogOrderByName:
-		name := mcg.Name.String()
-		c.Name = &name
-	default:
-		return nil, eris.Errorf("usecase: master catalog: unhandled orderBy %q", orderBy)
-	}
-	return c, nil
 }
 
 // ImportMaster copies the published master cardgroup identified by masterID into a

--- a/backend/internal/usecase/master_catalog_test.go
+++ b/backend/internal/usecase/master_catalog_test.go
@@ -26,14 +26,21 @@ type mockMasterCatalogRepository struct {
 	countErr    error
 	countCalls  []countPublishedCall
 
-	// FindPublishedByID (also used by published cursor resolution)
-	findByIDFn func(id string) (*domain.MasterCardgroup, error)
+	// FindByID (admin cursor resolution) and FindPublishedByID (published cursor
+	// resolution + ImportMaster's published check) are backed by separate funcs so
+	// a test can assert which scope a cursor was hydrated through. FindPublishedByID
+	// falls back to findByIDFn when findPublishedByIDFn is nil, so existing tests
+	// that only set findByIDFn keep working.
+	findByIDFn          func(id string) (*domain.MasterCardgroup, error)
+	findPublishedByIDFn func(id string) (*domain.MasterCardgroup, error)
 
 	// admin methods
-	findAdminPage []*repository.MasterCatalogItem
-	findAdminErr  error
-	countAdminRes int64
-	countAdminErr error
+	findAdminPage   []*repository.MasterCatalogItem
+	findAdminErr    error
+	findAdminCalls  []findPublishedPageCall
+	countAdminRes   int64
+	countAdminErr   error
+	countAdminCalls []countPublishedCall
 	countCardsRes int64
 	countCardsErr error
 	createCalls   []*domain.MasterCardgroup
@@ -85,6 +92,9 @@ func (m *mockMasterCatalogRepository) CountPublished(_ context.Context, search *
 }
 
 func (m *mockMasterCatalogRepository) FindPublishedByID(_ context.Context, id string) (*domain.MasterCardgroup, error) {
+	if m.findPublishedByIDFn != nil {
+		return m.findPublishedByIDFn(id)
+	}
 	if m.findByIDFn != nil {
 		return m.findByIDFn(id)
 	}
@@ -99,16 +109,25 @@ func (m *mockMasterCatalogRepository) FindByID(_ context.Context, id string) (*d
 }
 
 func (m *mockMasterCatalogRepository) FindAdminPage(
-	_ context.Context, _, _ *repository.MasterCatalogCursor, _, _ int,
-	_ repository.MasterCatalogOrderBy, _ repository.SortOrder, _ *string,
+	_ context.Context,
+	after, before *repository.MasterCatalogCursor,
+	first, last int,
+	orderBy repository.MasterCatalogOrderBy,
+	dir repository.SortOrder,
+	search *string,
 ) ([]*repository.MasterCatalogItem, error) {
+	m.findAdminCalls = append(m.findAdminCalls, findPublishedPageCall{
+		After: after, Before: before, First: first, Last: last,
+		OrderBy: orderBy, Dir: dir, Search: search,
+	})
 	if m.findAdminErr != nil {
 		return nil, m.findAdminErr
 	}
 	return m.findAdminPage, nil
 }
 
-func (m *mockMasterCatalogRepository) CountAdmin(_ context.Context, _ *string) (int64, error) {
+func (m *mockMasterCatalogRepository) CountAdmin(_ context.Context, search *string) (int64, error) {
+	m.countAdminCalls = append(m.countAdminCalls, countPublishedCall{Search: search})
 	return m.countAdminRes, m.countAdminErr
 }
 
@@ -467,6 +486,165 @@ func TestListPublishedConnection_FindPageError_Wrapped(t *testing.T) {
 	_, err := uc.ListPublishedConnection(authedCtx("u1"), MasterCatalogConnectionInput{First: intPtr(2)})
 	if err == nil {
 		t.Fatal("want error from find-page failure")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Search normalization at the usecase boundary
+//
+// nil and whitespace-only search both mean "no filter"; a non-empty search is
+// trimmed. The normalized value must reach BOTH the count and the page query so
+// totalCount and the page agree under an active filter, mirroring ListMasterCards.
+// ---------------------------------------------------------------------------
+
+func TestListPublishedConnection_SearchNormalizedToNil(t *testing.T) {
+	t.Parallel()
+	repo := &mockMasterCatalogRepository{}
+	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, newTestAdminGate(true), newTestLogger())
+
+	blank := "   "
+	_, err := uc.ListPublishedConnection(authedCtx("u1"), MasterCatalogConnectionInput{
+		First:  intPtr(5),
+		Search: &blank,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := repo.countCalls[0].Search; got != nil {
+		t.Fatalf("whitespace-only search must normalize to nil for count, got %q", *got)
+	}
+	if got := repo.findPageCalls[0].Search; got != nil {
+		t.Fatalf("whitespace-only search must normalize to nil for page, got %q", *got)
+	}
+}
+
+func TestListPublishedConnection_SearchTrimmed(t *testing.T) {
+	t.Parallel()
+	repo := &mockMasterCatalogRepository{}
+	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, newTestAdminGate(true), newTestLogger())
+
+	raw := "  hello  "
+	_, err := uc.ListPublishedConnection(authedCtx("u1"), MasterCatalogConnectionInput{
+		First:  intPtr(5),
+		Search: &raw,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := repo.countCalls[0].Search; got == nil || *got != "hello" {
+		t.Fatalf("count search must be trimmed to %q, got %v", "hello", got)
+	}
+	if got := repo.findPageCalls[0].Search; got == nil || *got != "hello" {
+		t.Fatalf("page search must be trimmed to %q, got %v", "hello", got)
+	}
+}
+
+func TestListAdminConnection_SearchNormalizedToNil(t *testing.T) {
+	t.Parallel()
+	repo := &mockMasterCatalogRepository{}
+	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, newTestAdminGate(true), newTestLogger())
+
+	blank := "   "
+	_, err := uc.ListAdminConnection(authedCtx("admin1"), MasterCatalogConnectionInput{
+		First:  intPtr(5),
+		Search: &blank,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := repo.countAdminCalls[0].Search; got != nil {
+		t.Fatalf("whitespace-only search must normalize to nil for admin count, got %q", *got)
+	}
+	if got := repo.findAdminCalls[0].Search; got != nil {
+		t.Fatalf("whitespace-only search must normalize to nil for admin page, got %q", *got)
+	}
+}
+
+func TestListAdminConnection_SearchTrimmed(t *testing.T) {
+	t.Parallel()
+	repo := &mockMasterCatalogRepository{}
+	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, newTestAdminGate(true), newTestLogger())
+
+	raw := "  hello  "
+	_, err := uc.ListAdminConnection(authedCtx("admin1"), MasterCatalogConnectionInput{
+		First:  intPtr(5),
+		Search: &raw,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := repo.countAdminCalls[0].Search; got == nil || *got != "hello" {
+		t.Fatalf("admin count search must be trimmed to %q, got %v", "hello", got)
+	}
+	if got := repo.findAdminCalls[0].Search; got == nil || *got != "hello" {
+		t.Fatalf("admin page search must be trimmed to %q, got %v", "hello", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Cursor-resolution scope (guards the published-vs-admin split through the
+// unified helper). Published cursors hydrate via FindPublishedByID (drafts are
+// rejected as cursor-not-found); admin cursors hydrate via FindByID (drafts are
+// valid). An inverted scope would swap these behaviors.
+// ---------------------------------------------------------------------------
+
+func TestListPublishedConnection_CursorRejectsDraftViaPublishedScope(t *testing.T) {
+	t.Parallel()
+	cur := cursor.Encode("draft-id")
+	repo := &mockMasterCatalogRepository{
+		// FindByID would resolve the draft (admin scope) — present to prove the
+		// published path does NOT use it.
+		findByIDFn: func(id string) (*domain.MasterCardgroup, error) {
+			return &domain.MasterCardgroup{ID: id, Name: domain.CardgroupName("Draft"), Status: domain.MasterStatusDraft}, nil
+		},
+		// FindPublishedByID rejects the draft, which is the path the published list
+		// must take.
+		findPublishedByIDFn: func(string) (*domain.MasterCardgroup, error) {
+			return nil, repository.ErrNotFound
+		},
+	}
+	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, newTestAdminGate(true), newTestLogger())
+
+	_, err := uc.ListPublishedConnection(authedCtx("u1"), MasterCatalogConnectionInput{
+		First: intPtr(2),
+		After: &cur,
+	})
+	var ve *ucerr.ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("published cursor must hydrate via FindPublishedByID and reject a draft, got %v", err)
+	}
+	if ve.Field != "after" {
+		t.Fatalf("want field=after, got %q", ve.Field)
+	}
+}
+
+func TestListAdminConnection_CursorAcceptsDraftViaFindByID(t *testing.T) {
+	t.Parallel()
+	cur := cursor.Encode("draft-id")
+	repo := &mockMasterCatalogRepository{
+		countAdminRes: 1,
+		findAdminPage: []*repository.MasterCatalogItem{catalogItem("x", 1)},
+		// FindByID resolves the draft — the admin list includes DRAFT decks.
+		findByIDFn: func(id string) (*domain.MasterCardgroup, error) {
+			return &domain.MasterCardgroup{ID: id, Name: domain.CardgroupName("Draft"), Status: domain.MasterStatusDraft}, nil
+		},
+		// FindPublishedByID would reject the draft — present to prove the admin path
+		// does NOT use it (an inverted scope would surface as cursor-not-found).
+		findPublishedByIDFn: func(string) (*domain.MasterCardgroup, error) {
+			return nil, repository.ErrNotFound
+		},
+	}
+	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, newTestAdminGate(true), newTestLogger())
+
+	_, err := uc.ListAdminConnection(authedCtx("admin1"), MasterCatalogConnectionInput{
+		Last:   intPtr(2),
+		Before: &cur,
+	})
+	if err != nil {
+		t.Fatalf("admin cursor must hydrate a draft via FindByID, got %v", err)
+	}
+	if repo.findAdminCalls[0].Before == nil || repo.findAdminCalls[0].Before.ID != "draft-id" {
+		t.Fatalf("want before cursor id=draft-id hydrated, got %+v", repo.findAdminCalls[0].Before)
 	}
 }
 


### PR DESCRIPTION
## Summary

Unifies the two near-identical master-catalog cursor resolvers into a single helper parameterized by `publishedOnly bool`, and normalizes `search` at the usecase boundary in both list connections so the count and the page query always see the same filter. Pure refactor: zero behavior change, no new strings, no schema/codegen.

Closes #534.

## Background / Motivation

- `resolveMasterCatalogCursor` (published scope) and `resolveMasterAdminCursor` (admin scope) were ~80 lines of near-identical code differing only in `FindPublishedByID` vs `FindByID`. Any change to cursor decoding, the not-found mapping, or the `orderBy`→column hydration had to be edited in lockstep across both, with nothing enforcing they stay in sync.
- `ListPublishedConnection` / `ListAdminConnection` passed `in.Search` **raw** into both the count and the page query, unlike `ListMasterCards`, which trims and collapses empty→nil first. Today this happens to produce correct results only because the repository trims; if the repository ever stopped, an all-whitespace search would silently change results. This is the convention gap in `go-library-gotchas.md` § "Nullable filter fields: normalize nil/empty/whitespace at the usecase boundary".

## Changes

### Unified cursor resolution

- `internal/usecase/master_catalog.go` — merges `resolveMasterCatalogCursor` + `resolveMasterAdminCursor` into one `resolveMasterCursor(ctx, cursorStr, orderBy, field, publishedOnly bool)`. `publishedOnly = true` hydrates via `FindPublishedByID` (a draft or unknown id collapses to cursor-not-found, so drafts never leak); `publishedOnly = false` hydrates via `FindByID` (the admin list includes DRAFT decks). The four call sites in `ListPublishedConnection` / `ListAdminConnection` pass `true` / `false`. The two former wrap messages (`"hydrate cursor"` / `"hydrate admin cursor"`) converge on the single `"usecase: master catalog: hydrate cursor"` — no test pinned the admin variant.

### Search normalization at the usecase boundary

- Adds a `normalizeSearch(*string) *string` helper (nil / whitespace-only → nil; non-empty → trimmed) and wires both `ListPublishedConnection` and `ListAdminConnection` to normalize once and pass the result to **both** the count (`CountPublished` / `CountAdmin`) and the page query (`FindPublishedPage` / `FindAdminPage`). This mirrors the inline normalize block in `master_card.go`'s `ListMasterCards`.

### Tests

- `internal/usecase/master_catalog_test.go` — the mock now backs `FindByID` and `FindPublishedByID` with separate funcs (the existing `findByIDFn` fallback is preserved so prior tests are untouched) and records the `FindAdminPage` / `CountAdmin` search args. New cases: whitespace-only→nil and trimmed search for **both** the published and the admin connection, asserted on both the count call and the page call; plus two cursor-scope regression guards — published rejects a draft cursor via `FindPublishedByID`, admin accepts a draft cursor via `FindByID` — that pin the `publishedOnly` direction so an inverted scope cannot slip through.

## Verification

```bash
cd backend && go vet ./... && go build ./... \
  && go test ./... \
  && go tool go-arch-lint check --project-path .
```

All green locally: full backend suite **1883 passed / 26 packages** (incl. the `internal/repository` testcontainers integration tests), `go vet` clean, `go-arch-lint` clean, CJK / English-only grep clean, no `fmt.Errorf("%w")` introduced. gqlgen output is gitignored and regenerated in CI.

Exactly one cursor helper remains after the merge:

```bash
grep -n 'func (u .*resolveMaster.*Cursor' backend/internal/usecase/master_catalog.go   # one hit: resolveMasterCursor
grep -rn 'resolveMasterCatalogCursor\|resolveMasterAdminCursor' backend/                # zero hits
```

## Test plan

- [ ] `go test ./internal/usecase/ -run 'TestList(Published|Admin)Connection_Search'` — whitespace-only search reaches the count and page calls as `nil`; a padded search reaches both trimmed.
- [ ] `go test ./internal/usecase/ -run 'TestList(Published|Admin)Connection_Cursor'` — published rejects a draft cursor (BAD_USER_INPUT on `after`); admin hydrates a draft cursor via `FindByID`.
- [ ] Existing pagination / cursor / import cases in `master_catalog_test.go` stay green (no behavior change).
- [ ] `go tool go-arch-lint check --project-path .` reports no new layer violations.
