### PR TITLE
refactor(frontend): extract shared CatalogImportButton from card + list item

### DIFF
--- a/frontend/src/app/catalog/_components/catalog-import-button.test.tsx
+++ b/frontend/src/app/catalog/_components/catalog-import-button.test.tsx
@@ -1,0 +1,85 @@
+// @vitest-environment jsdom
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { renderWithIntl } from "@/test/render-with-intl";
+import { CatalogImportButton } from "./catalog-import-button";
+
+const CARD = { id: "m-1" };
+
+describe("<CatalogImportButton>", () => {
+  it("renders the idle action label and stays enabled", () => {
+    renderWithIntl(
+      <CatalogImportButton card={CARD} importing={false} imported={false} onImport={vi.fn()} />,
+    );
+
+    const btn = screen.getByTestId("catalog-import-m-1");
+    expect(btn).toBeEnabled();
+    expect(btn).toHaveTextContent("Import");
+  });
+
+  it("shows the in-flight label and disables the button while importing", () => {
+    renderWithIntl(
+      <CatalogImportButton card={CARD} importing={true} imported={false} onImport={vi.fn()} />,
+    );
+
+    const btn = screen.getByTestId("catalog-import-m-1");
+    expect(btn).toBeDisabled();
+    expect(btn).toHaveTextContent("Importing...");
+  });
+
+  it("shows the imported label and disables the button once imported", () => {
+    renderWithIntl(
+      <CatalogImportButton card={CARD} importing={false} imported={true} onImport={vi.fn()} />,
+    );
+
+    const btn = screen.getByTestId("catalog-import-m-1");
+    expect(btn).toBeDisabled();
+    expect(btn).toHaveTextContent("Imported");
+  });
+
+  it("calls onImport with the deck id when the idle button is clicked", async () => {
+    const user = userEvent.setup();
+    const onImport = vi.fn();
+    renderWithIntl(
+      <CatalogImportButton card={CARD} importing={false} imported={false} onImport={onImport} />,
+    );
+
+    await user.click(screen.getByTestId("catalog-import-m-1"));
+
+    expect(onImport).toHaveBeenCalledWith("m-1");
+  });
+
+  it("uses custom labels and a custom testId prefix when provided", () => {
+    renderWithIntl(
+      <CatalogImportButton
+        card={CARD}
+        importing={false}
+        imported={false}
+        onImport={vi.fn()}
+        labels={{ action: "Start with this deck", inProgress: "Starting...", done: "Added" }}
+        testIdPrefix="onboarding-deck"
+      />,
+    );
+
+    const btn = screen.getByTestId("onboarding-deck-m-1");
+    expect(btn).toHaveTextContent("Start with this deck");
+    // The default catalog testId must NOT be present when a prefix override is given.
+    expect(screen.queryByTestId("catalog-import-m-1")).toBeNull();
+  });
+
+  it("merges the passthrough className onto the rendered button", () => {
+    renderWithIntl(
+      <CatalogImportButton
+        card={CARD}
+        importing={false}
+        imported={false}
+        onImport={vi.fn()}
+        className="mt-auto w-full"
+      />,
+    );
+
+    const btn = screen.getByTestId("catalog-import-m-1");
+    expect(btn).toHaveClass("mt-auto", "w-full");
+  });
+});

--- a/frontend/src/app/catalog/_components/catalog-import-button.tsx
+++ b/frontend/src/app/catalog/_components/catalog-import-button.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { Check, Download } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { Button } from "@/components/ui/button";
+
+export type CatalogImportButtonProps = {
+  /** The deck to import — only `id` is read (the click-handler arg and the `data-testid` suffix). */
+  card: { id: string };
+  /** True while this cardgroup's import mutation is in flight. */
+  importing: boolean;
+  /** True once this cardgroup has been imported in the current session. */
+  imported: boolean;
+  onImport: (id: string) => void;
+  /**
+   * Optional button label overrides. When omitted, the labels default to the
+   * `/catalog` copy (`Catalog` namespace); pass an explicit object to reuse this
+   * button in another context (e.g. an onboarding chooser). All three keys must
+   * be supplied together — partial override is not supported.
+   */
+  labels?: { action: string; inProgress: string; done: string };
+  /** Optional `data-testid` prefix on the Import button. Defaults to `"catalog-import"`. */
+  testIdPrefix?: string;
+  /**
+   * Layout class passthrough merged onto the rendered `Button` (e.g. `mt-auto w-full`
+   * for the card tile, `order-3 shrink-0 sm:order-4` for the list row). `Button`
+   * merges it with its variant classes via `cn`.
+   */
+  className?: string;
+};
+
+/**
+ * The Import CTA shared by `CatalogCard` (full-width tile button) and
+ * `CatalogListItem` (right-aligned inline button). Owns the three-state label
+ * derivation and the imported / in-flight / idle rendering so the two layouts
+ * cannot drift. The locale-independent `data-testid` (`catalog-import-{id}`) lets
+ * e2e — which runs in the ja-JP locale — target the button without depending on
+ * translated copy. The only per-layout difference is `className`.
+ *
+ * Invariant: `importing` and `imported` are never both true; if they are, the
+ * imported (done) state wins and the in-flight label is not shown.
+ */
+export function CatalogImportButton({
+  card,
+  importing,
+  imported,
+  onImport,
+  labels,
+  testIdPrefix,
+  className,
+}: CatalogImportButtonProps) {
+  const t = useTranslations("Catalog");
+
+  const actionLabel = labels?.action ?? t("import");
+  const inProgressLabel = labels?.inProgress ?? t("importing");
+  const doneLabel = labels?.done ?? t("imported");
+  const idPrefix = testIdPrefix ?? "catalog-import";
+
+  return (
+    <Button
+      type="button"
+      variant={imported ? "outline" : "brand"}
+      onClick={() => onImport(card.id)}
+      disabled={importing || imported}
+      data-testid={`${idPrefix}-${card.id}`}
+      className={className}
+    >
+      {imported ? (
+        <>
+          <Check aria-hidden="true" className="h-4 w-4" />
+          <span className="break-keep">{doneLabel}</span>
+        </>
+      ) : (
+        <>
+          <Download aria-hidden="true" className="h-4 w-4" />
+          <span className="break-keep">{importing ? inProgressLabel : actionLabel}</span>
+        </>
+      )}
+    </Button>
+  );
+}

--- a/frontend/src/app/catalog/catalog-card.tsx
+++ b/frontend/src/app/catalog/catalog-card.tsx
@@ -1,11 +1,10 @@
 "use client";
 
-import { Check, Download } from "lucide-react";
 import { useTranslations } from "next-intl";
 import type { CSSProperties } from "react";
+import { CatalogImportButton } from "@/app/catalog/_components/catalog-import-button";
 import { CatalogCardFieldsFragment } from "@/app/catalog/queries";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
 import { type FragmentType, useFragment } from "@/generated/fragment-masking";
 import { cn } from "@/lib/utils";
 
@@ -50,11 +49,6 @@ export function CatalogCard({
   const t = useTranslations("Catalog");
   const card = useFragment(CatalogCardFieldsFragment, node);
 
-  const actionLabel = labels?.action ?? t("import");
-  const inProgressLabel = labels?.inProgress ?? t("importing");
-  const doneLabel = labels?.done ?? t("imported");
-  const idPrefix = testIdPrefix ?? "catalog-import";
-
   return (
     <li
       className={cn(
@@ -83,26 +77,15 @@ export function CatalogCard({
         </span>
       </div>
 
-      <Button
-        type="button"
-        variant={imported ? "outline" : "brand"}
-        onClick={() => onImport(card.id)}
-        disabled={importing || imported}
-        data-testid={`${idPrefix}-${card.id}`}
+      <CatalogImportButton
+        card={card}
+        importing={importing}
+        imported={imported}
+        onImport={onImport}
+        labels={labels}
+        testIdPrefix={testIdPrefix}
         className="mt-auto w-full"
-      >
-        {imported ? (
-          <>
-            <Check aria-hidden="true" className="h-4 w-4" />
-            <span className="break-keep">{doneLabel}</span>
-          </>
-        ) : (
-          <>
-            <Download aria-hidden="true" className="h-4 w-4" />
-            <span className="break-keep">{importing ? inProgressLabel : actionLabel}</span>
-          </>
-        )}
-      </Button>
+      />
     </li>
   );
 }

--- a/frontend/src/app/catalog/catalog-list-item.tsx
+++ b/frontend/src/app/catalog/catalog-list-item.tsx
@@ -1,10 +1,9 @@
 "use client";
 
-import { Check, Download } from "lucide-react";
 import { useTranslations } from "next-intl";
+import { CatalogImportButton } from "@/app/catalog/_components/catalog-import-button";
 import { CatalogCardFieldsFragment } from "@/app/catalog/queries";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
 import { type FragmentType, useFragment } from "@/generated/fragment-masking";
 
 export type CatalogListItemProps = {
@@ -50,11 +49,6 @@ export function CatalogListItem({
   const t = useTranslations("Catalog");
   const card = useFragment(CatalogCardFieldsFragment, node);
 
-  const actionLabel = labels?.action ?? t("import");
-  const inProgressLabel = labels?.inProgress ?? t("importing");
-  const doneLabel = labels?.done ?? t("imported");
-  const idPrefix = testIdPrefix ?? "catalog-import";
-
   return (
     <li
       className="rounded-md border border-border transition-colors hover:bg-accent"
@@ -97,26 +91,15 @@ export function CatalogListItem({
           </span>
         </div>
 
-        <Button
-          type="button"
-          variant={imported ? "outline" : "brand"}
-          onClick={() => onImport(card.id)}
-          disabled={importing || imported}
-          data-testid={`${idPrefix}-${card.id}`}
+        <CatalogImportButton
+          card={card}
+          importing={importing}
+          imported={imported}
+          onImport={onImport}
+          labels={labels}
+          testIdPrefix={testIdPrefix}
           className="order-3 shrink-0 sm:order-4"
-        >
-          {imported ? (
-            <>
-              <Check aria-hidden="true" className="h-4 w-4" />
-              <span className="break-keep">{doneLabel}</span>
-            </>
-          ) : (
-            <>
-              <Download aria-hidden="true" className="h-4 w-4" />
-              <span className="break-keep">{importing ? inProgressLabel : actionLabel}</span>
-            </>
-          )}
-        </Button>
+        />
       </div>
     </li>
   );


### PR DESCRIPTION
## Summary

Collapses the two byte-identical copies of the catalog Import CTA — the three-state label derivation plus the `Button` JSX — into a single shared `CatalogImportButton`, consumed by both `CatalogCard` (full-width tile button) and `CatalogListItem` (right-aligned inline button). Pure refactor: zero behavior change, no new strings, no schema/codegen.

Closes #537.

## Background / Motivation

- `catalog-card.tsx` and `catalog-list-item.tsx` carried byte-identical label derivation (`labels?.action ?? t("import")`, `importing`/`imported` fallbacks, the `catalog-import` testId prefix) and an identical `Button` block (`variant={imported ? "outline" : "brand"}`, `disabled`, `data-testid`, `Check`/`Download` icon, `break-keep`). Any future tweak — a new disabled state, a copy change, a variant swap — had to be made twice or one layout silently diverged.
- The only real per-layout difference was the wrapper `className` (`mt-auto w-full` on the tile vs `order-3 shrink-0 sm:order-4` on the row), so the duplication was pure boilerplate around one layout knob.
- `onboarding/start/onboarding-start-client.tsx` consumes `CatalogCard` + `useImportMaster`, so `CatalogCard`'s public props were kept stable — onboarding is unaffected.

## Changes

### Shared component

- `frontend/src/app/catalog/_components/catalog-import-button.tsx` (new) — `CatalogImportButton({ card, importing, imported, onImport, labels, testIdPrefix, className })`. Owns the three-state label derivation and the imported / in-flight / idle rendering. `card` is typed minimally as `{ id: string }` (only the id is read — for the click-handler arg and the `data-testid` suffix). `className` is passed straight to `Button`, which merges it with its variant classes via `cn`, so the per-layout class is the only caller-supplied difference.

### Consumer rewiring

- `frontend/src/app/catalog/catalog-card.tsx` — drops the inline label derivation + `Button` block (and the now-unused `Button` / `Check` / `Download` imports), renders `<CatalogImportButton ... className="mt-auto w-full" />`. Public `CatalogCardProps` unchanged.
- `frontend/src/app/catalog/catalog-list-item.tsx` — same swap, `className="order-3 shrink-0 sm:order-4"`. Public `CatalogListItemProps` unchanged.

### Placement note

- The issue specified `catalog/_internal/`, but this lands under `catalog/_components/` to match the established repo convention — `_components/` already exists in 5 app directories (`app/`, `cardgroups/`, `cards/new/`, `catalog/`, `learn/[cardgroupId]/`) and houses the sibling `catalog-skeleton.tsx`, while `_internal/` exists nowhere in the tree.

### Tests

- `frontend/src/app/catalog/_components/catalog-import-button.test.tsx` (new) — co-located, TDD-first (written and watched fail before the component existed). Six cases: the idle / importing / imported label + disabled states, `onImport` called with the deck id on click, custom `labels` + `testIdPrefix` override, and the `className` passthrough landing on the rendered button. The existing `catalog-card.test.tsx` / `catalog-list-item.test.tsx` button assertions stay green unchanged.

## Verification

```bash
cd frontend && pnpm typecheck && pnpm lint && pnpm knip && pnpm test && pnpm build
```

All green locally: typecheck / biome (`--error-on-warnings`) / knip clean, vitest 155 files / 1455 tests, build OK. CJK / English-only grep clean. codegen output is gitignored and regenerated in CI.

The de-dup can be confirmed by grep — the label derivation now exists in exactly one place:

```bash
grep -rn 'labels?.action ?? t("import")' frontend/src/app/catalog   # one hit (catalog-import-button.tsx)
```

## Test plan

- [ ] `cd frontend && pnpm typecheck && pnpm lint && pnpm knip && pnpm test && pnpm build` all green in CI.
- [ ] `/catalog` — grid (card) and list (row) layouts both show Import → Importing... → Imported with correct disabled states and the `catalog-import-{id}` testId, identical to before.
- [ ] `/onboarding/start` — the deck chooser (which renders `CatalogCard`) imports a master deck unchanged.
- [ ] Dedup grep above returns a single hit inside `catalog-import-button.tsx`.
