### PR TITLE
refactor(frontend): extract shared AdminQueryErrorBanner from admin list clients

### DIFF
--- a/frontend/src/app/admin/masters/admin-masters-client.tsx
+++ b/frontend/src/app/admin/masters/admin-masters-client.tsx
@@ -2,11 +2,11 @@
 
 import { NetworkStatus } from "@apollo/client";
 import { Plus } from "lucide-react";
-import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { useCallback, useMemo, useState } from "react";
 import { toast } from "sonner";
+import { AdminQueryErrorBanner } from "@/components/admin/admin-query-error-banner";
 import { ListingPageShell } from "@/components/layout/listing-page-shell";
 import { Button } from "@/components/ui/button";
 import { ErrorBanner } from "@/components/ui/error-banner";
@@ -99,7 +99,6 @@ export function AdminMastersClient() {
   const hasNextPage = pageInfo.hasNextPage;
 
   const queryErrorKind = classifyQueryError(queryError);
-  const queryBannerError = queryErrorKind?.kind === "banner" ? queryErrorKind.message : undefined;
 
   const { createMaster, creating, resetCreate } = useMasterMutations();
 
@@ -162,27 +161,17 @@ export function AdminMastersClient() {
         />
       </div>
 
-      {queryErrorKind?.kind === "forbidden" && (
-        <ErrorBanner data-testid="admin-masters-query-error">{t("viewForbidden")}</ErrorBanner>
-      )}
-
-      {queryErrorKind?.kind === "unauthenticated" && (
-        <ErrorBanner data-testid="admin-masters-query-error">
-          <span>{t("sessionExpired")}</span>{" "}
-          <Link href="/login" className="underline">
-            {t("pleaseSignInAgain")}
-          </Link>
-        </ErrorBanner>
-      )}
-
-      {queryBannerError && (
-        <ErrorBanner data-testid="admin-masters-query-error">
-          <span>{queryBannerError}</span>
-          <button type="button" className="ml-3 underline" onClick={() => refetch()}>
-            {tCommon("retry")}
-          </button>
-        </ErrorBanner>
-      )}
+      <AdminQueryErrorBanner
+        kind={queryErrorKind}
+        onRetry={refetch}
+        testId="admin-masters-query-error"
+        copy={{
+          viewForbidden: t("viewForbidden"),
+          sessionExpired: t("sessionExpired"),
+          signInAgain: t("pleaseSignInAgain"),
+          retry: tCommon("retry"),
+        }}
+      />
 
       {!initialLoading && !queryErrorKind && edges.length === 0 && (
         <p className="text-sm text-muted-foreground" data-testid="admin-masters-empty">

--- a/frontend/src/app/admin/users/admin-users-client.tsx
+++ b/frontend/src/app/admin/users/admin-users-client.tsx
@@ -2,10 +2,10 @@
 
 import { NetworkStatus } from "@apollo/client";
 import { useLazyQuery, useQuery } from "@apollo/client/react";
-import Link from "next/link";
 import { useTranslations } from "next-intl";
 import { useCallback, useEffect, useMemo } from "react";
 import { toast } from "sonner";
+import { AdminQueryErrorBanner } from "@/components/admin/admin-query-error-banner";
 import { ErrorBanner } from "@/components/ui/error-banner";
 import { useFragment } from "@/generated/fragment-masking";
 import type {
@@ -158,7 +158,6 @@ export function AdminUsersClient() {
   // Fan out into three render branches: forbidden, unauthenticated, banner.
   // See `classifyQueryError` for the source of the discriminated kinds.
   const queryErrorKind = classifyQueryError(queryError);
-  const queryBannerError = queryErrorKind?.kind === "banner" ? queryErrorKind.message : undefined;
 
   const allRoles = useFragment(AdminRoleFieldsFragment, rolesData?.roles ?? []);
   const roleOptions = useMemo(
@@ -248,39 +247,26 @@ export function AdminUsersClient() {
         />
       </div>
 
-      {/* FORBIDDEN error banner — no Retry since re-issuing the query would fail again */}
-      {queryErrorKind?.kind === "forbidden" && (
-        <ErrorBanner className="mb-4" data-testid="admin-users-query-error">
-          {t("viewForbidden")}
-        </ErrorBanner>
-      )}
-
       {/*
-        UNAUTHENTICATED post-mount means the session expired while the page was
-        open. The server-side gate in page.tsx + the admin layout already block
-        the initial load (which redirects to "/"), so this only fires mid-session.
-        Render a degraded banner pointing to /login rather than calling
-        `redirect()` from a client component — see
+        Admin users query-error banner. UNAUTHENTICATED here means the session
+        expired mid-page: the server-side gate in page.tsx + the admin layout
+        block the initial load (redirecting to "/"), so the degraded /login
+        banner only fires post-mount. FORBIDDEN renders without Retry since
+        re-issuing the same query would fail again. See
         .claude/rules/frontend-rsc-error-handling.md.
       */}
-      {queryErrorKind?.kind === "unauthenticated" && (
-        <ErrorBanner className="mb-4" data-testid="admin-users-query-error">
-          <span>{t("sessionExpired")}</span>{" "}
-          <Link href="/login" className="underline">
-            {t("pleaseSignInAgain")}
-          </Link>
-        </ErrorBanner>
-      )}
-
-      {/* Generic query error banner with Retry */}
-      {queryBannerError && (
-        <ErrorBanner className="mb-4" data-testid="admin-users-query-error">
-          <span>{queryBannerError}</span>
-          <button type="button" className="ml-3 underline" onClick={() => refetch()}>
-            {tCommon("retry")}
-          </button>
-        </ErrorBanner>
-      )}
+      <AdminQueryErrorBanner
+        kind={queryErrorKind}
+        onRetry={refetch}
+        testId="admin-users-query-error"
+        className="mb-4"
+        copy={{
+          viewForbidden: t("viewForbidden"),
+          sessionExpired: t("sessionExpired"),
+          signInAgain: t("pleaseSignInAgain"),
+          retry: tCommon("retry"),
+        }}
+      />
 
       {rolesBannerError && (
         <ErrorBanner className="mb-4" data-testid="admin-users-roles-error">

--- a/frontend/src/components/admin/admin-query-error-banner.test.tsx
+++ b/frontend/src/components/admin/admin-query-error-banner.test.tsx
@@ -1,0 +1,108 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { AdminQueryErrorBanner } from "./admin-query-error-banner";
+
+const COPY = {
+  viewForbidden: "You do not have permission to view this page.",
+  sessionExpired: "Your session has expired.",
+  signInAgain: "Please sign in again.",
+  retry: "Retry",
+};
+
+describe("<AdminQueryErrorBanner>", () => {
+  it("renders nothing when kind is null", () => {
+    const { container } = render(
+      <AdminQueryErrorBanner
+        kind={null}
+        onRetry={vi.fn()}
+        copy={COPY}
+        testId="admin-query-error"
+      />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders the forbidden copy without a Retry button for the forbidden kind", () => {
+    render(
+      <AdminQueryErrorBanner
+        kind={{ kind: "forbidden" }}
+        onRetry={vi.fn()}
+        copy={COPY}
+        testId="admin-query-error"
+      />,
+    );
+
+    const banner = screen.getByTestId("admin-query-error");
+    expect(banner).toHaveTextContent(COPY.viewForbidden);
+    expect(screen.queryByRole("button", { name: /retry/i })).not.toBeInTheDocument();
+  });
+
+  it("renders the session-expired copy with a /login link for the unauthenticated kind", () => {
+    render(
+      <AdminQueryErrorBanner
+        kind={{ kind: "unauthenticated" }}
+        onRetry={vi.fn()}
+        copy={COPY}
+        testId="admin-query-error"
+      />,
+    );
+
+    const banner = screen.getByTestId("admin-query-error");
+    expect(banner).toHaveTextContent(COPY.sessionExpired);
+
+    const link = screen.getByRole("link", { name: COPY.signInAgain });
+    expect(link).toHaveAttribute("href", "/login");
+    expect(screen.queryByRole("button", { name: /retry/i })).not.toBeInTheDocument();
+  });
+
+  it("renders the banner message and a Retry button for the banner kind", () => {
+    render(
+      <AdminQueryErrorBanner
+        kind={{ kind: "banner", message: "Something went wrong" }}
+        onRetry={vi.fn()}
+        copy={COPY}
+        testId="admin-query-error"
+      />,
+    );
+
+    const banner = screen.getByTestId("admin-query-error");
+    expect(banner).toHaveTextContent("Something went wrong");
+    expect(screen.getByRole("button", { name: COPY.retry })).toBeInTheDocument();
+  });
+
+  it("invokes onRetry with no arguments when the Retry button is clicked", async () => {
+    const user = userEvent.setup();
+    const onRetry = vi.fn();
+    render(
+      <AdminQueryErrorBanner
+        kind={{ kind: "banner", message: "boom" }}
+        onRetry={onRetry}
+        copy={COPY}
+        testId="admin-query-error"
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: COPY.retry }));
+
+    expect(onRetry).toHaveBeenCalledOnce();
+    // The click event must not leak through as a refetch variables argument.
+    expect(onRetry).toHaveBeenCalledWith();
+  });
+
+  it("applies the testId and an optional className to the rendered banner", () => {
+    render(
+      <AdminQueryErrorBanner
+        kind={{ kind: "forbidden" }}
+        onRetry={vi.fn()}
+        copy={COPY}
+        testId="admin-users-query-error"
+        className="mb-4"
+      />,
+    );
+
+    const banner = screen.getByTestId("admin-users-query-error");
+    expect(banner).toHaveClass("mb-4");
+  });
+});

--- a/frontend/src/components/admin/admin-query-error-banner.tsx
+++ b/frontend/src/components/admin/admin-query-error-banner.tsx
@@ -1,0 +1,74 @@
+import Link from "next/link";
+import { ErrorBanner } from "@/components/ui/error-banner";
+import type { QueryErrorKind } from "@/lib/apollo/errors";
+
+/**
+ * Copy slots for the admin query-error banner. Callers resolve these from their
+ * own i18n namespace: the admin list screens use different next-intl namespaces
+ * (`AdminMasters`, `Admin`) that share the same key names, so the banner takes
+ * resolved strings rather than a namespace-bound `t`, keeping it a pure
+ * presentational leaf with no i18n coupling.
+ */
+type AdminQueryErrorBannerCopy = {
+  viewForbidden: string;
+  sessionExpired: string;
+  signInAgain: string;
+  retry: string;
+};
+
+type AdminQueryErrorBannerProps = {
+  kind: QueryErrorKind | null;
+  onRetry: () => void;
+  copy: AdminQueryErrorBannerCopy;
+  testId: string;
+  className?: string;
+};
+
+/**
+ * Shared three-branch banner for an admin list query error:
+ *  - `forbidden`:       caller lacks the admin role — no Retry, since re-issuing
+ *                       the same query would fail again.
+ *  - `unauthenticated`: session expired mid-page — a degraded banner pointing to
+ *                       /login rather than a client-side redirect.
+ *  - `banner`:          any other error — the message plus a Retry that re-issues
+ *                       the query via `onRetry`.
+ *
+ * Renders nothing when `kind` is null.
+ */
+export function AdminQueryErrorBanner({
+  kind,
+  onRetry,
+  copy,
+  testId,
+  className,
+}: AdminQueryErrorBannerProps) {
+  if (!kind) return null;
+
+  if (kind.kind === "forbidden") {
+    return (
+      <ErrorBanner className={className} data-testid={testId}>
+        {copy.viewForbidden}
+      </ErrorBanner>
+    );
+  }
+
+  if (kind.kind === "unauthenticated") {
+    return (
+      <ErrorBanner className={className} data-testid={testId}>
+        <span>{copy.sessionExpired}</span>{" "}
+        <Link href="/login" className="underline">
+          {copy.signInAgain}
+        </Link>
+      </ErrorBanner>
+    );
+  }
+
+  return (
+    <ErrorBanner className={className} data-testid={testId}>
+      <span>{kind.message}</span>
+      <button type="button" className="ml-3 underline" onClick={() => onRetry()}>
+        {copy.retry}
+      </button>
+    </ErrorBanner>
+  );
+}


### PR DESCRIPTION
## Summary

Collapses the byte-identical three-branch query-error banner — FORBIDDEN / UNAUTHENTICATED / generic-with-Retry — duplicated across the admin masters and users list clients into a single shared `AdminQueryErrorBanner`. Pure refactor: zero behavior change, no new strings, no schema/codegen.

Closes #536.

## Background / Motivation

- The admin masters (`admin-masters-client.tsx`) and users (`admin-users-client.tsx`) list screens each inlined the same three `ErrorBanner` blocks keyed on `classifyQueryError`'s `QueryErrorKind`: a no-Retry permission banner (`forbidden`), a degraded `/login` banner (`unauthenticated`), and a generic message + Retry banner. A future change to the error copy or the Retry affordance had to be made in two places.
- The two copies differed only in their `data-testid` (`admin-masters-query-error` vs `admin-users-query-error`) and a single `className="mb-4"` on the users side — the branch logic and i18n keys were otherwise identical.
- The issue's suggested "component owns its own `useTranslations`" approach does not hold: the callers use **different** next-intl namespaces (`AdminMasters` vs `Admin`) that happen to duplicate the same key names. There is no single shared admin namespace to bind to, and next-intl types `t` per namespace, so a namespace-bound `t` prop would erode type safety. The component therefore takes resolved copy strings, staying a pure presentational leaf with no i18n coupling (and no catalog churn).
- `admin/roles` was checked and deliberately left out: it is an SSR-seeded full list with no `useConnectionPagination`, no `classifyQueryError`, and no Retry — it has no three-branch query-error banner to fold in.

## Changes

### Shared component

- `frontend/src/components/admin/admin-query-error-banner.tsx` (new) — `AdminQueryErrorBanner({ kind, onRetry, copy, testId, className? })` renders the three `QueryErrorKind` branches and nothing when `kind` is null. Imports no i18n; the four copy slots (`viewForbidden` / `sessionExpired` / `signInAgain` / `retry`) arrive as resolved strings. The internal `AdminQueryErrorBannerCopy` type is intentionally **not** exported (no external consumer — keeps knip green). The generic-branch Retry calls `onRetry()` with no arguments, mirroring the callers' prior `() => refetch()` so a click event never leaks through as refetch variables.
- `frontend/src/components/admin/admin-query-error-banner.test.tsx` (new) — co-located, TDD-first: each `kind` renders its branch, `forbidden`/`unauthenticated` carry no Retry, the `/login` link resolves, Retry invokes `onRetry` with no args, and `testId`/`className` are applied; `null` renders nothing.

### Consumer rewiring

- `app/admin/masters/admin-masters-client.tsx` — the three inline banner blocks replaced with `<AdminQueryErrorBanner kind={queryErrorKind} onRetry={refetch} testId="admin-masters-query-error" copy={{…}} />`. The now-unused `queryBannerError` const and the `next/link` import (only used by the moved unauthenticated branch) are removed. The `fetchMoreError` banner is untouched.
- `app/admin/users/admin-users-client.tsx` — same rewiring with `className="mb-4"` preserved and `testId="admin-users-query-error"`. The `queryBannerError` const and `next/link` import are removed; the page-specific UNAUTHENTICATED-mid-session comment is retained at the call site. The `rolesBannerError` and `fetchMoreError` banners are untouched; `QueryErrorKind` stays imported (still used by a local helper).

### Out of scope

- `app/admin/roles/admin-roles-client.tsx` — left unchanged. Its banners (create-form validation, edit-query, delete, mutation-auth) do not match the three-branch query-error shape, per the issue's "if it diverges, leave it and note it".

## Verification

```bash
cd frontend && pnpm typecheck && pnpm lint && pnpm knip && pnpm test && pnpm build
```

All green locally: typecheck / biome (`--error-on-warnings`) / knip clean, vitest 155 files / 1455 tests, build OK. codegen output is gitignored and regenerated in CI.

- `pnpm knip` clean confirms the `AdminQueryErrorBannerCopy` type and the removed `queryBannerError` / `Link` left nothing orphaned.
- No inline banner survives — every admin query-error hit is now a `kind` prop, an empty-state guard, or a comment:

  ```bash
  grep -rn 'queryErrorKind\|FORBIDDEN' frontend/src/app/admin --include='*.tsx' | grep -v test
  ```

- Runtime: the broad page tests `__tests__/admin-masters-list.test.tsx` and `__tests__/admin-users-list.test.tsx` (which pin `admin-{masters,users}-query-error` and the FORBIDDEN "You do not have permission to view this page." banner without Retry) stay green, confirming the testids, copy, and Retry behavior are byte-for-byte preserved.

## Test plan

- [ ] `cd frontend && pnpm typecheck && pnpm lint && pnpm knip && pnpm test && pnpm build` all green in CI.
- [ ] `/admin/masters` and `/admin/users` — a FORBIDDEN query renders the permission banner with no Retry; a generic error renders the message + Retry that re-issues the query; a mid-session UNAUTHENTICATED renders the degraded `/login` banner. Behavior identical to before.
- [ ] `/admin/roles` — unchanged (no regression).
- [ ] Residue grep above returns only `kind`-prop / empty-state / comment hits, no inline banner JSX.
