### PR TITLE
chore(rules): scope backend/frontend rule files with paths frontmatter

### DIFF
--- a/.claude/rules/backend-layering.md
+++ b/.claude/rules/backend-layering.md
@@ -1,3 +1,8 @@
+---
+paths:
+  - "backend/**"
+---
+
 # Backend layering
 
 > Applies to: `backend/`. Source of truth: [`backend/.go-arch-lint.yml`](../../backend/.go-arch-lint.yml). Cross-cutting because every package in `backend/internal/` and `backend/cmd/` participates in the layer graph.

--- a/.claude/rules/ddd-patterns.md
+++ b/.claude/rules/ddd-patterns.md
@@ -1,3 +1,8 @@
+---
+paths:
+  - "backend/**"
+---
+
 # DDD patterns
 
 > Applies to: `backend/internal/domain/` and adjacent usecase + service layers.

--- a/.claude/rules/error-wrapping.md
+++ b/.claude/rules/error-wrapping.md
@@ -1,3 +1,8 @@
+---
+paths:
+  - "backend/**"
+---
+
 # Error wrapping convention
 
 > Applies to: `backend/internal/`, `backend/cmd/`. Enforced by CI (`.github/workflows/backend.yml`).

--- a/.claude/rules/frontend-design-system.md
+++ b/.claude/rules/frontend-design-system.md
@@ -1,3 +1,8 @@
+---
+paths:
+  - "frontend/**"
+---
+
 # Frontend design system
 
 > Applies to: `frontend/src/**/*.tsx` (UI components, dialogs). Cross-cutting because the

--- a/.claude/rules/frontend-rsc-error-handling.md
+++ b/.claude/rules/frontend-rsc-error-handling.md
@@ -1,3 +1,8 @@
+---
+paths:
+  - "frontend/**"
+---
+
 # Frontend RSC error handling
 
 > Applies to: `frontend/src/app/**/*.tsx` (React Server Components, layouts, route handlers) and `frontend/src/lib/apollo/server.ts` (the `gqlFetch` helper). Cross-cutting because every RSC that talks to Supabase + GraphQL has the same five failure modes — session-missing, session-expired, GraphQL `UNAUTHENTICATED`, GraphQL `FORBIDDEN`, and infrastructure 5xx — and they must be handled uniformly to avoid 500-ing the whole app.

--- a/.claude/rules/frontend-typescript-conventions.md
+++ b/.claude/rules/frontend-typescript-conventions.md
@@ -1,3 +1,8 @@
+---
+paths:
+  - "frontend/**"
+---
+
 # Frontend TypeScript conventions
 
 Chapter-level rules live in `docs/frontend/typescript-conventions/`. See its

--- a/.claude/rules/go-library-gotchas.md
+++ b/.claude/rules/go-library-gotchas.md
@@ -1,3 +1,8 @@
+---
+paths:
+  - "backend/**"
+---
+
 # Go library gotchas (backend)
 
 > Applies to: `backend/internal/`, `backend/cmd/`. These are library-quirk rules — counter-intuitive behaviours of `uuid`, Echo v5, GORM, `golang-jwt/v5`, `slog`, and `crypto/subtle` that must be respected anywhere the library is touched.

--- a/.claude/rules/pagination.md
+++ b/.claude/rules/pagination.md
@@ -1,3 +1,9 @@
+---
+paths:
+  - "backend/**"
+  - "frontend/**"
+---
+
 # Pagination
 
 > Single source of truth for the Relay-style Connection design used by the cards-by-cardgroup query and the Apollo client patterns that consume it. Cross-referenced from `docs/backend.md` and `frontend/CLAUDE.md`.


### PR DESCRIPTION
## Summary

Adds a `paths:` frontmatter field to 8 of the 14 `.claude/rules/*.md` files so that directory-bound conventions load **only** when Claude is working under the matching tree, instead of loading unconditionally into every session. Pure harness/config change: no source, schema, or behavior change; CI gates and edit-time hooks are unaffected.

Addresses no tracked GitHub issue — this came out of an in-session harness-tuning discussion.

## Background / Motivation

- Claude Code auto-loads every `.claude/rules/*.md` at session start with the same priority as `CLAUDE.md` **unless** the file carries a `paths:` frontmatter field (per the official Claude Code memory docs — path-scoped rules apply only when working with matching files). All 14 rule files (~1,330 lines) were loading on every turn, including pure-conversation turns and cross-tree work where most of the content does not apply.
- Most of that volume is directory-bound: the backend error-wrapping / layering / Go-gotchas / DDD-patterns rules only matter under `backend/`; the frontend design-system / TS-conventions / RSC-error-handling rules only matter under `frontend/`.
- Scoping is done **in place** via frontmatter rather than by relocating content into the hierarchical `backend/CLAUDE.md` / `frontend/CLAUDE.md`. Moving files would have broken cross-references (`go-library-gotchas.md` alone is referenced by 198 files); the frontmatter approach changes only load timing and leaves every link intact.

## Changes

Frontmatter added (the only change in each file; bodies untouched):

- `backend/**` — `error-wrapping.md`, `backend-layering.md`, `go-library-gotchas.md`, `ddd-patterns.md`
- `frontend/**` — `frontend-design-system.md`, `frontend-typescript-conventions.md`, `frontend-rsc-error-handling.md`
- `backend/**` + `frontend/**` — `pagination.md` (spans schema-side design + frontend cache patterns)

Left unconditional (cross-cutting / safety / every-request rules): `scope-discipline.md`, `subagent-dispatch.md`, `language-policy.md`, `pr-sizing.md`, `pr-updates.md`, `destructive-actions.md`.

Net effect: ~858 lines of rule content move to conditional loading; ~513 lines stay always-on.

## What this does NOT change

Enforcement is unchanged. The `backend-convention-guard.sh` PostToolUse hook, the CI grep gates, and `go-arch-lint` run regardless of which rule text is in the model's context. `paths:` only changes **when the teaching copy is loaded** for the model — it is not an enforcement mechanism.

## Verification

- `git show --stat HEAD` — 8 files, 41 insertions, frontmatter only.
- Each scoped file: the frontmatter block precedes the existing `# Heading`; bodies are byte-identical otherwise.
- No rule file was moved or renamed, so all cross-doc links remain valid.
- Behavioral check (manual): in a fresh session at repo root the scoped rules stay out of context; reading/editing a `backend/**` or `frontend/**` file loads the matching rule.
