### PR TITLE
fix(frontend): i18n admin master-cards fetchMore error + export MASTER_CARDS_PAGE_SIZE

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -134,6 +134,7 @@
     "noMatch": "No cards match \"{search}\"",
     "clearSearch": "Clear search",
     "loadingMore": "Loading more cards...",
+    "fetchMoreFailed": "Could not load more cards. Please try again.",
     "addCard": "Add card",
     "editCard": "Edit card",
     "batchImportSrOnly": "Batch import into ",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -134,6 +134,7 @@
     "noMatch": "「{search}」に一致するカードがありません",
     "clearSearch": "検索をクリア",
     "loadingMore": "カードをさらに読み込んでいます...",
+    "fetchMoreFailed": "カードの追加読み込みに失敗しました。もう一度お試しください。",
     "addCard": "カードを追加",
     "editCard": "カードを編集",
     "batchImportSrOnly": "一括インポート先: ",

--- a/frontend/src/app/admin/masters/[id]/edit/cards/master-cards-client.test.tsx
+++ b/frontend/src/app/admin/masters/[id]/edit/cards/master-cards-client.test.tsx
@@ -2,10 +2,11 @@
 import { MockedProvider } from "@apollo/client/testing/react";
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AdminMasterCardsConnectionDocument } from "@/generated/graphql";
 import { UndoDeleteProvider } from "@/lib/undo-delete";
 import { renderWithIntl } from "@/test/render-with-intl";
+import jaMessages from "../../../../../../../messages/ja.json";
 import { MasterCardsClient } from "./master-cards-client";
 import { masterCardsDefaultVars } from "./queries";
 
@@ -60,6 +61,39 @@ const seed = {
   },
 };
 
+// IntersectionObserver stub — capture the latest observer callback so a test
+// can drive the sentinel into view and trigger the hook's fetchMore. The hook
+// only constructs an observer when `hasNextPage` is true, so the two seeded
+// tests below (hasNextPage: false) never touch it.
+let ioCallbacks: IntersectionObserverCallback[] = [];
+
+class FakeIntersectionObserver {
+  constructor(cb: IntersectionObserverCallback) {
+    ioCallbacks.push(cb);
+  }
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+  takeRecords() {
+    return [];
+  }
+}
+
+function fireIntersect() {
+  const cb = ioCallbacks[ioCallbacks.length - 1];
+  if (!cb) return;
+  cb([{ isIntersecting: true } as IntersectionObserverEntry], {} as IntersectionObserver);
+}
+
+beforeEach(() => {
+  ioCallbacks = [];
+  vi.stubGlobal("IntersectionObserver", FakeIntersectionObserver);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
 function render(onTotalCountChange = vi.fn()) {
   renderWithIntl(
     <MockedProvider mocks={[seed]}>
@@ -89,5 +123,74 @@ describe("<MasterCardsClient>", () => {
     render();
     await userEvent.click(screen.getByRole("button", { name: /add card/i }));
     expect(screen.getByLabelText(/front/i)).toBeInTheDocument();
+  });
+
+  it("renders the localized fetchMore-failure banner under the ja locale", async () => {
+    const pageInfoWithNext = {
+      __typename: "PageInfo" as const,
+      hasNextPage: true,
+      hasPreviousPage: false,
+      startCursor: "c-1",
+      endCursor: "c-1",
+    };
+    const seedWithNext = {
+      request: {
+        query: AdminMasterCardsConnectionDocument,
+        variables: masterCardsDefaultVars(MASTER_ID),
+      },
+      result: {
+        data: {
+          adminMasterCardsConnection: {
+            __typename: "MasterCardConnection" as const,
+            edges: [edge("c-1", "apple")],
+            pageInfo: pageInfoWithNext,
+            totalCount: 1,
+          },
+        },
+      },
+    };
+    // The next page fails with ONLY a field-level BAD_USER_INPUT error, the one
+    // shape getBackendErrorBanner returns undefined for — so the hook falls back
+    // to the caller-supplied localized message (the path issue #535 fixes).
+    // A plain network error would instead hit getBackendErrorBanner's own
+    // NETWORK_ERROR banner and never reach the fallback.
+    const { CombinedGraphQLErrors } = await import("@apollo/client/errors");
+    const fieldOnlyError = new CombinedGraphQLErrors({
+      data: null,
+      errors: [{ message: "bad input", extensions: { code: "BAD_USER_INPUT", field: "search" } }],
+    });
+    const fetchMoreErrorMock = {
+      request: {
+        query: AdminMasterCardsConnectionDocument,
+        variables: { ...masterCardsDefaultVars(MASTER_ID), after: "c-1", search: null },
+      },
+      error: fieldOnlyError,
+    };
+
+    renderWithIntl(
+      <MockedProvider mocks={[seedWithNext, fetchMoreErrorMock]}>
+        <UndoDeleteProvider>
+          <MasterCardsClient
+            masterId={MASTER_ID}
+            deckName="Deck One"
+            initialEdges={[edge("c-1", "apple")]}
+            initialPageInfo={pageInfoWithNext}
+            initialTotalCount={1}
+            onTotalCountChange={vi.fn()}
+          />
+        </UndoDeleteProvider>
+      </MockedProvider>,
+      { locale: "ja", messages: jaMessages },
+    );
+
+    // Drive the sentinel into view → the hook fires fetchMore, which fails.
+    fireIntersect();
+
+    const banner = await screen.findByTestId("cards-fetch-more-error");
+    // The localized ja copy now flows through next-intl rather than a hardcoded
+    // English literal. Reference the catalog string to keep CJK out of source
+    // (language-policy), and assert the old English literal is absent.
+    expect(banner).toHaveTextContent(jaMessages.Cards.fetchMoreFailed);
+    expect(banner).not.toHaveTextContent("Could not load more cards");
   });
 });

--- a/frontend/src/app/admin/masters/[id]/edit/cards/master-cards-client.tsx
+++ b/frontend/src/app/admin/masters/[id]/edit/cards/master-cards-client.tsx
@@ -204,6 +204,7 @@ export function MasterCardsClient({
     initialEdges,
     initialPageInfo,
     initialTotalCount,
+    fetchMoreErrorMessage: t("fetchMoreFailed"),
   });
 
   const {

--- a/frontend/src/app/admin/masters/[id]/edit/cards/queries.ts
+++ b/frontend/src/app/admin/masters/[id]/edit/cards/queries.ts
@@ -2,7 +2,7 @@ import { graphql } from "@/generated";
 import type { AdminMasterCardsConnectionQueryVariables } from "@/generated/graphql";
 
 /** Default page size for the admin master-cards connection. Must stay in sync between SSR seed and client useQuery/cache reads. */
-const MASTER_CARDS_PAGE_SIZE = 20;
+export const MASTER_CARDS_PAGE_SIZE = 20;
 
 export const AdminMasterCardsConnectionQuery = graphql(`
   query AdminMasterCardsConnection(

--- a/frontend/src/app/admin/masters/[id]/edit/cards/use-master-cards-connection.test.tsx
+++ b/frontend/src/app/admin/masters/[id]/edit/cards/use-master-cards-connection.test.tsx
@@ -4,7 +4,7 @@ import { renderHook, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { describe, expect, it } from "vitest";
 import { AdminMasterCardsConnectionDocument } from "@/generated/graphql";
-import { masterCardsDefaultVars } from "./queries";
+import { MASTER_CARDS_PAGE_SIZE, masterCardsDefaultVars } from "./queries";
 import { useMasterCardsConnection } from "./use-master-cards-connection";
 
 const MASTER_ID = "m-1";
@@ -59,6 +59,12 @@ function wrapper({ children }: { children: ReactNode }) {
 }
 
 describe("useMasterCardsConnection", () => {
+  it("seeds first from the exported MASTER_CARDS_PAGE_SIZE single source", () => {
+    // Pins the documented "stay in sync between SSR seed and client" invariant:
+    // every read site builds its `first` from the one exported constant.
+    expect(masterCardsDefaultVars(MASTER_ID).first).toBe(MASTER_CARDS_PAGE_SIZE);
+  });
+
   it("renders the prop-seeded edges before the query resolves and exposes queryVariables", () => {
     const { result } = renderHook(
       () =>
@@ -68,6 +74,7 @@ describe("useMasterCardsConnection", () => {
           initialEdges: [edge("c-1")],
           initialPageInfo: seedPageInfo,
           initialTotalCount: 1,
+          fetchMoreErrorMessage: "fetch-more-failed",
         }),
       { wrapper },
     );
@@ -84,6 +91,7 @@ describe("useMasterCardsConnection", () => {
           initialEdges: [],
           initialPageInfo: seedPageInfo,
           initialTotalCount: 0,
+          fetchMoreErrorMessage: "fetch-more-failed",
         }),
       { wrapper },
     );

--- a/frontend/src/app/admin/masters/[id]/edit/cards/use-master-cards-connection.ts
+++ b/frontend/src/app/admin/masters/[id]/edit/cards/use-master-cards-connection.ts
@@ -22,6 +22,12 @@ export interface UseMasterCardsConnectionInput {
   initialEdges: MasterCardEdge[];
   initialPageInfo: MasterCardConnectionPageInfo;
   initialTotalCount: number;
+  /**
+   * Localized banner copy shown when a load-more page fails with no backend
+   * banner of its own. The hook has no `useTranslations`, so the caller passes
+   * the resolved `t("fetchMoreFailed")` string in (mirrors admin-masters-client).
+   */
+  fetchMoreErrorMessage: string;
 }
 
 export type UseMasterCardsConnectionResult = UseConnectionPaginationResult<
@@ -46,7 +52,14 @@ function mergeMasterCardsConnection(
 export function useMasterCardsConnection(
   input: UseMasterCardsConnectionInput,
 ): UseMasterCardsConnectionResult {
-  const { masterId, searchQuery, initialEdges, initialPageInfo, initialTotalCount } = input;
+  const {
+    masterId,
+    searchQuery,
+    initialEdges,
+    initialPageInfo,
+    initialTotalCount,
+    fetchMoreErrorMessage,
+  } = input;
 
   const variables = useMemo<AdminMasterCardsConnectionQueryVariables>(
     () =>
@@ -81,8 +94,7 @@ export function useMasterCardsConnection(
     buildFetchMoreVariables,
     mergeConnection: mergeMasterCardsConnection,
     initial: { edges: initialEdges, pageInfo: initialPageInfo, totalCount: initialTotalCount },
-    resolveFetchMoreError: (err) =>
-      getBackendErrorBanner(err) ?? "Could not load more cards. Please try again.",
+    resolveFetchMoreError: (err) => getBackendErrorBanner(err) ?? fetchMoreErrorMessage,
     logScope: "[master-cards-client]",
   });
 }


### PR DESCRIPTION
## Summary

Two small correctness/consistency fixes in the admin master-cards screen (`frontend/src/app/admin/masters/[id]/edit/cards/`): the load-more failure banner now flows through `next-intl` instead of a hardcoded English literal, and `MASTER_CARDS_PAGE_SIZE` becomes the single exported source for the connection page size. Pure refactor/bugfix — no schema, codegen, or new behavior beyond the localized banner.

Closes #535.

## Background / Motivation

- `use-master-cards-connection.ts` hardcoded an English fallback (`"Could not load more cards. Please try again."`) inside `resolveFetchMoreError`. Because Playwright runs in the `ja-JP` locale, that English string leaks into the Japanese UI on a load-more failure — a defect `vitest` cannot catch (only a ja-locale render or e2e can). The sibling `admin-masters-client.tsx` already routes the same path through `t("fetchMoreFailed")`.
- `MASTER_CARDS_PAGE_SIZE` was an unexported `const` even though its own docstring says it "Must stay in sync between SSR seed and client". The sibling `ADMIN_MASTERS_PAGE_SIZE` is exported and pinned by a test; this aligns master-cards with that pattern and gives the documented single-source invariant an explicit guard.

## Changes

### i18n the fetchMore-failure banner

- `use-master-cards-connection.ts` — dropped the hardcoded English fallback. The hook has no `useTranslations`, so it now takes a required `fetchMoreErrorMessage: string` on its input and uses `getBackendErrorBanner(err) ?? fetchMoreErrorMessage`, mirroring how `admin-masters-client.tsx` supplies the resolved string.
- `master-cards-client.tsx` — passes `fetchMoreErrorMessage: t("fetchMoreFailed")` into the hook (the screen already holds `useTranslations("Cards")`).
- `messages/en.json` + `messages/ja.json` — added `Cards.fetchMoreFailed` (the `Cards` namespace did not previously carry it). en text matches the prior literal; ja is the localized copy. No Japanese string is inlined into any `.ts`/`.tsx` source.

### Export the page-size single source

- `queries.ts` — `MASTER_CARDS_PAGE_SIZE` is now `export const`. The RSC seed (`[id]/edit/page.tsx`) already consumes it transitively via `masterCardsDefaultVars(id)` and was **not** re-hardcoding `20`, so the page is unchanged.

### Tests

- `master-cards-client.test.tsx` — added a ja-locale, IntersectionObserver-driven fetchMore-failure test. It uses the one error shape `getBackendErrorBanner` returns `undefined` for (a `CombinedGraphQLErrors` carrying only a field-level `BAD_USER_INPUT`), so the localized fallback is actually exercised, then asserts the banner renders the ja catalog string (referenced via `jaMessages.Cards.fetchMoreFailed`, not a CJK literal) and not the old English literal.
- `use-master-cards-connection.test.tsx` — threads the now-required `fetchMoreErrorMessage` through the existing `renderHook` calls and pins the single-source invariant (`masterCardsDefaultVars(MASTER_ID).first === MASTER_CARDS_PAGE_SIZE`), which is also the consumer that keeps the new export wired (knip).

## Verification

- `grep -rn 'Could not load more cards' frontend/src/app/admin/masters` returns only the test's negative assertion — no production literal.
- In the running app under the Japanese locale, force a load-more failure on the admin master-cards edit screen; the `data-testid="cards-fetch-more-error"` banner shows the Japanese copy, not English.
- `MASTER_CARDS_PAGE_SIZE` is exported from `queries.ts` and imported by `use-master-cards-connection.test.tsx`; `pnpm knip` reports no unused export.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm knip`
- [x] `pnpm test` (1462 passed)
- [x] `pnpm build`
- [x] ja-locale fetchMore-failure test asserts the localized banner and the absence of the English literal
- [x] CJK grep clean — no Japanese inlined into `.ts`/`.tsx` (catalogs only)
