### PR TITLE
feat(frontend): consolidate deck-detail actions (master + cardgroup)

### DIFF
--- a/frontend/e2e/admin-masters-edit.spec.ts
+++ b/frontend/e2e/admin-masters-edit.spec.ts
@@ -22,7 +22,10 @@ test.describe("admin master edit navigation", () => {
     await page.getByTestId(`master-catalog-row-${deck.id}`).click();
 
     await page.waitForURL(new RegExp(`/admin/masters/${deck.id}/edit$`), { timeout: 15_000 });
-    // Deck-settings opens the metadata form (select by testid, not translated label).
+    // Deck settings now lives in the desktop split-button dropdown (e2e runs at a
+    // Desktop Chrome viewport), so open the chevron first. Select by testid, not
+    // translated label.
+    await page.getByTestId("master-edit-more-options").click();
     await page.getByTestId("master-edit-deck-settings").click();
     await expect(page.getByTestId("master-field-name")).toBeVisible();
   });

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -105,7 +105,7 @@
     "noPermission": "You do not have permission. ",
     "signInAgain": "Sign in again",
     "deleteAriaLabel": "Delete cardgroup {name}",
-    "backLink": "← Cardgroups",
+    "backLink": "Back to cardgroups",
     "welcomeHeading": "Welcome! Let's create your first cardgroup.",
     "welcomeDesc": "A cardgroup holds the cards you study together — you can add more anytime.",
     "filterPlaceholder": "Filter cardgroups...",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -105,7 +105,7 @@
     "noPermission": "権限がありません。",
     "signInAgain": "再度ログイン",
     "deleteAriaLabel": "カードグループ「{name}」を削除",
-    "backLink": "← カードグループ",
+    "backLink": "カードグループへ戻る",
     "welcomeHeading": "ようこそ！最初のカードグループを作成しましょう。",
     "welcomeDesc": "カードグループには一緒に学習するカードをまとめます。いつでも追加できます。",
     "filterPlaceholder": "カードグループを絞り込む...",

--- a/frontend/src/app/admin/masters/[id]/edit/cards/master-cards-client.test.tsx
+++ b/frontend/src/app/admin/masters/[id]/edit/cards/master-cards-client.test.tsx
@@ -90,4 +90,11 @@ describe("<MasterCardsClient>", () => {
     await userEvent.click(screen.getByRole("button", { name: /add card/i }));
     expect(screen.getByLabelText(/front/i)).toBeInTheDocument();
   });
+
+  it("opens the batch-import sheet from the mobile toolbar button", async () => {
+    render();
+    await userEvent.click(screen.getByTestId("master-batch-import"));
+    // The shared batch-import wizard renders its paste textarea inside the sheet.
+    expect(await screen.findByTestId("batch-import-payload")).toBeInTheDocument();
+  });
 });

--- a/frontend/src/app/admin/masters/[id]/edit/cards/master-cards-client.tsx
+++ b/frontend/src/app/admin/masters/[id]/edit/cards/master-cards-client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Search } from "lucide-react";
+import { Import, Plus, Search } from "lucide-react";
 import { useTranslations } from "next-intl";
 import type { RefObject } from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -11,6 +11,7 @@ import type { SwipeableRowHandle } from "@/components/cardgroups/swipeable-row";
 import { Button } from "@/components/ui/button";
 import { ErrorBanner } from "@/components/ui/error-banner";
 import { FormSheet, useFormSheetClose } from "@/components/ui/form-sheet";
+import { SplitButtonMenu } from "@/components/ui/split-button-menu";
 import type { AdminMasterCardsConnectionQuery } from "@/generated/graphql";
 import { useBulkSelection } from "@/hooks/use-bulk-selection";
 import { useDebouncedSearch } from "@/hooks/use-debounced-search";
@@ -318,24 +319,53 @@ export function MasterCardsClient({
       )}
 
       <section>
-        {/* Inline toolbar: right-aligned Add card and Batch import buttons. */}
+        {/* Right-aligned toolbar. Desktop: an Add card split button whose
+            dropdown folds in Batch import. Mobile: Add card + Batch import as
+            two separate buttons (the chevron is hidden below sm). */}
         <div className="mb-3 flex justify-end gap-2">
+          <div className="inline-flex">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="sm:rounded-r-none"
+              onClick={openAddSheet}
+              data-testid="master-add-card"
+            >
+              <Plus aria-hidden="true" className="h-4 w-4" />
+              {t("addCard")}
+            </Button>
+            <div className="hidden sm:inline-flex">
+              <SplitButtonMenu
+                triggerLabel={tCardgroups("addMoreOptions")}
+                data-testid="master-add-more-options"
+                items={[
+                  {
+                    key: "add",
+                    icon: <Plus aria-hidden="true" className="h-4 w-4" />,
+                    label: t("addCard"),
+                    onSelect: openAddSheet,
+                  },
+                  {
+                    key: "import",
+                    icon: <Import aria-hidden="true" className="h-4 w-4" />,
+                    label: tCardgroups("batchImport"),
+                    onSelect: openBatchImport,
+                    "data-testid": "master-batch-import-menuitem",
+                  },
+                ]}
+              />
+            </div>
+          </div>
           <Button
             type="button"
             variant="outline"
             size="sm"
-            onClick={openAddSheet}
-            data-testid="master-add-card"
-          >
-            {t("addCard")}
-          </Button>
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
+            className="sm:hidden"
             onClick={openBatchImport}
             data-testid="master-batch-import"
           >
+            <Import aria-hidden="true" className="h-4 w-4" />
             {tCardgroups("batchImport")}
           </Button>
         </div>

--- a/frontend/src/app/admin/masters/[id]/edit/master-edit-header.test.tsx
+++ b/frontend/src/app/admin/masters/[id]/edit/master-edit-header.test.tsx
@@ -90,6 +90,8 @@ describe("MasterEditHeader", () => {
   it("opens the deck-settings dialog with the metadata form (no publish/delete sections)", async () => {
     const user = userEvent.setup();
     renderHeader(DECK);
+    // Deck settings now lives in the desktop split-button dropdown.
+    await user.click(screen.getByTestId("master-edit-more-options"));
     await user.click(screen.getByTestId("master-edit-deck-settings"));
     expect(await screen.findByTestId("master-field-name")).toBeInTheDocument();
     // Metadata-only: the form's in-dialog publish/delete sections are absent.
@@ -143,6 +145,8 @@ describe("MasterEditHeader", () => {
       },
     ];
     renderHeader(DECK, mocks);
+    // Delete now lives in the desktop split-button dropdown.
+    await user.click(screen.getByTestId("master-edit-more-options"));
     await user.click(screen.getByTestId("master-edit-delete"));
     const confirm = await screen.findByTestId("master-delete-dialog-confirm");
     expect(confirm.className).toContain("bg-destructive");
@@ -169,7 +173,8 @@ describe("MasterEditHeader", () => {
       },
     ];
     renderHeader(DECK, mocks);
-    // Open the deck-settings dialog.
+    // Open the deck-settings dialog from the desktop split-button dropdown.
+    await user.click(screen.getByTestId("master-edit-more-options"));
     await user.click(screen.getByTestId("master-edit-deck-settings"));
     expect(await screen.findByTestId("master-field-name")).toBeInTheDocument();
     // Submit the form without changing values (form submits prefilled values).
@@ -199,6 +204,7 @@ describe("MasterEditHeader", () => {
       },
     ];
     renderHeader(DECK, mocks);
+    await user.click(screen.getByTestId("master-edit-more-options"));
     await user.click(screen.getByTestId("master-edit-deck-settings"));
     expect(await screen.findByTestId("master-field-name")).toBeInTheDocument();
     await user.click(screen.getByTestId("master-form-submit"));
@@ -234,6 +240,27 @@ describe("MasterEditHeader", () => {
     const settingsItem = await screen.findByRole("menuitem", { name: /deck settings/i });
     await user.click(settingsItem);
     expect(await screen.findByTestId("master-field-name")).toBeInTheDocument();
+  });
+
+  it("overflow menu (mobile): the publish toggle publishes the deck and refreshes", async () => {
+    const user = userEvent.setup();
+    const mocks = [
+      {
+        request: { query: AdminPublishMasterMutation, variables: { id: "m-1" } },
+        result: {
+          data: {
+            adminPublishMasterCardgroup: {
+              __typename: "PublishMasterCardgroupSuccess",
+              master: { ...DECK, status: "PUBLISHED" },
+            },
+          },
+        },
+      },
+    ];
+    renderHeader(DECK, mocks);
+    await user.click(screen.getByTestId("master-edit-overflow"));
+    await user.click(await screen.findByTestId("master-edit-publish-mobile"));
+    await waitFor(() => expect(refresh).toHaveBeenCalledTimes(1));
   });
 
   it("displays the cardCount prop (live count), not master.cardCount", () => {

--- a/frontend/src/app/admin/masters/[id]/edit/master-edit-header.tsx
+++ b/frontend/src/app/admin/masters/[id]/edit/master-edit-header.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { MoreHorizontal } from "lucide-react";
+import { Eye, EyeOff, MoreHorizontal, Settings, Trash2 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { useCallback, useState } from "react";
@@ -26,6 +26,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { FormSheet } from "@/components/ui/form-sheet";
+import { SplitButtonMenu } from "@/components/ui/split-button-menu";
 import type { AdminMasterDeck } from "./queries";
 
 type Props = { master: AdminMasterDeck; cardCount: number };
@@ -140,22 +141,77 @@ export function MasterEditHeader({ master, cardCount }: Props) {
     }
   }, [deleteMaster, master.id, t, authToast, router]);
 
+  const publishIcon = published ? (
+    <EyeOff aria-hidden="true" className="h-4 w-4" />
+  ) : (
+    <Eye aria-hidden="true" className="h-4 w-4" />
+  );
+  const publishLabel = published ? t("unpublish") : t("publish");
+
   return (
     <>
-      <div className="mb-6 flex flex-wrap items-start justify-between gap-3">
-        <div className="min-w-0 flex-1">
+      {/* Mobile: the title takes the full line width and the actions collapse
+          into the meta row (kebab) / move below. Desktop: title left, the
+          publish split button on the right. */}
+      <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="min-w-0 sm:flex-1">
           <h1 className="text-2xl font-semibold leading-tight break-words">{master.name}</h1>
-          <div className="mt-1 flex items-center gap-2">
-            <Badge
-              variant={published ? "default" : "secondary"}
-              role="status"
-              data-testid="master-edit-status-badge"
-            >
-              {published ? t("statusPublished") : t("statusDraft")}
-            </Badge>
-            <span className="text-sm text-muted-foreground">
-              {t("cardCount", { count: cardCount })}
-            </span>
+          <div className="mt-1 flex items-center justify-between gap-2">
+            <div className="flex items-center gap-2">
+              <Badge
+                variant={published ? "default" : "secondary"}
+                role="status"
+                data-testid="master-edit-status-badge"
+              >
+                {published ? t("statusPublished") : t("statusDraft")}
+              </Badge>
+              <span className="text-sm text-muted-foreground">
+                {t("cardCount", { count: cardCount })}
+              </span>
+            </div>
+
+            {/* Mobile management menu: publish toggle + deck settings + delete. */}
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="shrink-0 sm:hidden"
+                  data-testid="master-edit-overflow"
+                  aria-label={t("masterOptions")}
+                >
+                  <MoreHorizontal aria-hidden="true" className="h-4 w-4" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem
+                  onSelect={handlePublishToggle}
+                  disabled={publishing || emptyDraft}
+                  data-testid="master-edit-publish-mobile"
+                  className="gap-2"
+                >
+                  {publishIcon}
+                  {publishLabel}
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  onSelect={() => setSettingsOpen(true)}
+                  data-testid="master-edit-deck-settings-mobile"
+                  className="gap-2"
+                >
+                  <Settings aria-hidden="true" className="h-4 w-4" />
+                  {t("deckSettingsButton")}
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  onSelect={() => setDeleteOpen(true)}
+                  data-testid="master-edit-delete-mobile"
+                  className="gap-2 text-destructive focus:text-destructive"
+                >
+                  <Trash2 aria-hidden="true" className="h-4 w-4" />
+                  {t("deleteMasterButton")}
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
           </div>
           {emptyDraft ? (
             <p className="mt-1 text-xs text-muted-foreground" data-testid="master-edit-empty-hint">
@@ -164,63 +220,43 @@ export function MasterEditHeader({ master, cardCount }: Props) {
           ) : null}
         </div>
 
-        <div className="flex shrink-0 items-center gap-2">
+        {/* Desktop split button: publish primary + dropdown (deck settings, delete). */}
+        <div className="hidden shrink-0 items-center sm:flex">
           <Button
             type="button"
             variant={published ? "outline" : "brand"}
+            className="rounded-r-none"
             data-testid="master-edit-publish"
             aria-pressed={published}
             disabled={publishing || emptyDraft}
             onClick={handlePublishToggle}
           >
-            {publishing ? tCommon("loading") : published ? t("unpublish") : t("publish")}
+            {publishIcon}
+            {publishing ? tCommon("loading") : publishLabel}
           </Button>
-
-          <Button
-            type="button"
-            variant="outline"
-            className="hidden sm:inline-flex"
-            data-testid="master-edit-deck-settings"
-            onClick={() => setSettingsOpen(true)}
-          >
-            {t("deckSettingsButton")}
-          </Button>
-
-          <Button
-            type="button"
-            variant="destructive"
-            className="hidden sm:inline-flex"
-            data-testid="master-edit-delete"
-            onClick={() => setDeleteOpen(true)}
-          >
-            {t("deleteMasterButton")}
-          </Button>
-
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon"
-                className="sm:hidden"
-                data-testid="master-edit-overflow"
-                aria-label={t("masterOptions")}
-              >
-                <MoreHorizontal className="h-4 w-4" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-              <DropdownMenuItem onSelect={() => setSettingsOpen(true)}>
-                {t("deckSettingsButton")}
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                onSelect={() => setDeleteOpen(true)}
-                className="text-destructive focus:text-destructive"
-              >
-                {t("deleteMasterButton")}
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
+          <SplitButtonMenu
+            triggerLabel={t("masterOptions")}
+            variant={published ? "outline" : "brand"}
+            size="default"
+            data-testid="master-edit-more-options"
+            items={[
+              {
+                key: "settings",
+                icon: <Settings aria-hidden="true" className="h-4 w-4" />,
+                label: t("deckSettingsButton"),
+                onSelect: () => setSettingsOpen(true),
+                "data-testid": "master-edit-deck-settings",
+              },
+              {
+                key: "delete",
+                icon: <Trash2 aria-hidden="true" className="h-4 w-4" />,
+                label: t("deleteMasterButton"),
+                onSelect: () => setDeleteOpen(true),
+                destructive: true,
+                "data-testid": "master-edit-delete",
+              },
+            ]}
+          />
         </div>
       </div>
 

--- a/frontend/src/app/admin/masters/[id]/edit/master-management-client.tsx
+++ b/frontend/src/app/admin/masters/[id]/edit/master-management-client.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { ChevronLeft } from "lucide-react";
 import Link from "next/link";
 import { useTranslations } from "next-intl";
 import { useState } from "react";
@@ -28,9 +29,10 @@ export function MasterManagementClient({
       <div className="mb-2">
         <Link
           href="/admin/masters"
-          className="inline-flex text-sm text-muted-foreground hover:text-foreground hover:underline"
+          className="inline-flex items-center text-muted-foreground hover:text-foreground"
         >
-          {t("backToList")}
+          <ChevronLeft aria-hidden="true" className="h-5 w-5" />
+          <span className="sr-only">{t("backToList")}</span>
         </Link>
       </div>
 

--- a/frontend/src/app/cardgroups/[id]/edit/cardgroup-management-client.tsx
+++ b/frontend/src/app/cardgroups/[id]/edit/cardgroup-management-client.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { ChevronLeft } from "lucide-react";
 import Link from "next/link";
 import { useTranslations } from "next-intl";
 import type { CardConnectionPageInfo, CardEdge } from "@/app/cardgroups/[id]/cards/cards-client";
@@ -27,9 +28,10 @@ export function CardgroupManagementClient({
       <div className="mb-2">
         <Link
           href="/cardgroups"
-          className="inline-flex text-sm text-muted-foreground hover:text-foreground hover:underline"
+          className="inline-flex items-center text-muted-foreground hover:text-foreground"
         >
-          {t("backLink")}
+          <ChevronLeft aria-hidden="true" className="h-5 w-5" />
+          <span className="sr-only">{t("backLink")}</span>
         </Link>
       </div>
 

--- a/frontend/src/components/cardgroups/cardgroup-cards-section.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-cards-section.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ChevronDown, Import, Play, Plus } from "lucide-react";
+import { Import, Play, Plus } from "lucide-react";
 import Link from "next/link";
 import { useTranslations } from "next-intl";
 import type { ReactNode } from "react";
@@ -10,12 +10,7 @@ import {
   CardsClient,
 } from "@/app/cardgroups/[id]/cards/cards-client";
 import { Button } from "@/components/ui/button";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
+import { SplitButtonMenu } from "@/components/ui/split-button-menu";
 
 type Props = {
   cardgroupId: string;
@@ -79,34 +74,25 @@ export function CardgroupCardsSection({
           >
             {t("addCardButton")}
           </Button>
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                className="rounded-l-none border-l px-2"
-                aria-label={t("addMoreOptions")}
-                data-testid="cardgroup-add-more-options"
-              >
-                <ChevronDown aria-hidden="true" className="h-4 w-4" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-              <DropdownMenuItem onSelect={onAddCard} className="gap-2">
-                <Plus aria-hidden="true" className="h-4 w-4" />
-                {t("addACard")}
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                onSelect={onBatchImport}
-                data-testid="cardgroup-batch-import-menuitem"
-                className="gap-2"
-              >
-                <Import aria-hidden="true" className="h-4 w-4" />
-                {t("batchImport")}
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
+          <SplitButtonMenu
+            triggerLabel={t("addMoreOptions")}
+            data-testid="cardgroup-add-more-options"
+            items={[
+              {
+                key: "add",
+                icon: <Plus aria-hidden="true" className="h-4 w-4" />,
+                label: t("addACard"),
+                onSelect: onAddCard,
+              },
+              {
+                key: "import",
+                icon: <Import aria-hidden="true" className="h-4 w-4" />,
+                label: t("batchImport"),
+                onSelect: onBatchImport,
+                "data-testid": "cardgroup-batch-import-menuitem",
+              },
+            ]}
+          />
         </div>
       </div>
     </div>

--- a/frontend/src/components/ui/split-button-menu.test.tsx
+++ b/frontend/src/components/ui/split-button-menu.test.tsx
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { SplitButtonMenu } from "./split-button-menu";
+
+describe("SplitButtonMenu", () => {
+  it("renders an icon-only trigger labelled by triggerLabel", () => {
+    render(
+      <SplitButtonMenu
+        triggerLabel="More options"
+        data-testid="more"
+        items={[{ key: "a", label: "Action A", onSelect: vi.fn() }]}
+      />,
+    );
+    const trigger = screen.getByTestId("more");
+    expect(trigger).toHaveAttribute("aria-label", "More options");
+    // Closed by default: items are not in the document.
+    expect(screen.queryByRole("menuitem", { name: "Action A" })).not.toBeInTheDocument();
+  });
+
+  it("reveals items on open and calls onSelect when one is chosen", async () => {
+    const user = userEvent.setup();
+    const onA = vi.fn();
+    const onB = vi.fn();
+    render(
+      <SplitButtonMenu
+        triggerLabel="More options"
+        data-testid="more"
+        items={[
+          { key: "a", label: "Action A", onSelect: onA },
+          { key: "b", label: "Action B", onSelect: onB },
+        ]}
+      />,
+    );
+    await user.click(screen.getByTestId("more"));
+    await user.click(await screen.findByRole("menuitem", { name: "Action B" }));
+    expect(onB).toHaveBeenCalledTimes(1);
+    expect(onA).not.toHaveBeenCalled();
+  });
+
+  it("marks destructive items with the destructive intent and disables disabled items", async () => {
+    const user = userEvent.setup();
+    const onDelete = vi.fn();
+    render(
+      <SplitButtonMenu
+        triggerLabel="More options"
+        data-testid="more"
+        items={[
+          { key: "del", label: "Delete", onSelect: onDelete, destructive: true },
+          { key: "off", label: "Disabled", onSelect: vi.fn(), disabled: true },
+        ]}
+      />,
+    );
+    await user.click(screen.getByTestId("more"));
+    const del = await screen.findByRole("menuitem", { name: "Delete" });
+    expect(del.className).toContain("text-destructive");
+    const disabled = screen.getByRole("menuitem", { name: "Disabled" });
+    expect(disabled).toHaveAttribute("aria-disabled", "true");
+  });
+});

--- a/frontend/src/components/ui/split-button-menu.tsx
+++ b/frontend/src/components/ui/split-button-menu.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { ChevronDown } from "lucide-react";
+import type { ComponentProps, ReactNode } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { cn } from "@/lib/utils";
+
+type SplitButtonMenuItem = {
+  /** Stable React key for the item. */
+  key: string;
+  /** Leading icon, e.g. `<Plus className="h-4 w-4" />`. */
+  icon?: ReactNode;
+  label: ReactNode;
+  onSelect: () => void;
+  /** Renders the item in the destructive (deep-red) intent. */
+  destructive?: boolean;
+  disabled?: boolean;
+  "data-testid"?: string;
+};
+
+type Props = {
+  items: SplitButtonMenuItem[];
+  /** Accessible label for the chevron trigger (icon-only). */
+  triggerLabel: string;
+  /**
+   * Variant/size MUST match the sibling primary button so the two flush
+   * segments read as one control.
+   */
+  variant?: ComponentProps<typeof Button>["variant"];
+  size?: ComponentProps<typeof Button>["size"];
+  /** test id for the chevron trigger button. */
+  "data-testid"?: string;
+};
+
+/**
+ * The trailing chevron segment of a split button: an icon-only trigger that
+ * opens a dropdown of secondary actions. The primary action stays at the call
+ * site (rendered flush to the left with `rounded-r-none`) so each consumer keeps
+ * full control over its primary's state (variant, disabled, loading, link vs
+ * button). Used by the cardgroup/master deck-detail action clusters.
+ */
+export function SplitButtonMenu({
+  items,
+  triggerLabel,
+  variant = "outline",
+  size = "sm",
+  "data-testid": testId,
+}: Props) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          type="button"
+          variant={variant}
+          size={size}
+          className="rounded-l-none border-l px-2"
+          aria-label={triggerLabel}
+          data-testid={testId}
+        >
+          <ChevronDown aria-hidden="true" className="h-4 w-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        {items.map((item) => (
+          <DropdownMenuItem
+            key={item.key}
+            onSelect={item.onSelect}
+            disabled={item.disabled}
+            data-testid={item["data-testid"]}
+            className={cn("gap-2", item.destructive && "text-destructive focus:text-destructive")}
+          >
+            {item.icon}
+            {item.label}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}


### PR DESCRIPTION
## Summary

Restructures the deck-detail action UI on the master-deck admin page and the cardgroup page. Management actions collapse into a desktop split button plus a mobile kebab; the add-card / batch-import pair becomes a split button on desktop; both back links become an icon-only chevron; and the master title now spans the full line width on mobile. A new shared `SplitButtonMenu` primitive backs all three split buttons.

No related issue — ad-hoc UI polish from design screenshots.

## Background / Motivation

- The master deck-detail header crowded five controls (publish toggle, deck settings, delete, add card, batch import) into the action area. On mobile the visible publish button squeezed the title so a name like "Advanced Cards" wrapped to two lines.
- The cardgroup page already had the target shape (a header kebab plus an add-card split button with a chevron dropdown), so the master surface was asked to mirror it.
- The cardgroup chevron + dropdown was inline JSX with no shared component, so adding the same control to two more spots (master management + master cards) would have duplicated the chevron / `rounded-l-none border-l` / menu boilerplate three times.
- Both back links rendered as a leading "←" text string rather than an icon.

## Changes

### Shared SplitButtonMenu primitive

- `frontend/src/components/ui/split-button-menu.tsx` (new) — the trailing chevron segment of a split button: an icon-only `DropdownMenu` trigger (`rounded-l-none border-l px-2`) over a list of `{ icon, label, onSelect, destructive, disabled }` items. The primary button stays at the call site (rendered flush with `rounded-r-none`), so each consumer keeps control of its primary's variant / disabled / loading state. `variant` and `size` pass through so the two segments align.
- `frontend/src/components/ui/split-button-menu.test.tsx` (new) — icon-only trigger label, open-reveals-items + `onSelect`, destructive-intent class, disabled item.

### Master deck-detail header

- `master-edit-header.tsx` — the title now takes the full line width on mobile. Management actions collapse into a mobile kebab (all three: publish toggle, deck settings, delete) and a desktop split button (publish/unpublish primary + dropdown of deck settings and delete). Adds `Eye` / `EyeOff` / `Settings` / `Trash2` icons. The `disabled` (empty-draft / publishing) and `aria-pressed` states are wired on both the desktop primary and the mobile publish item. The delete confirm keeps `buttonVariants({ variant: "destructive" })`.

### Master cards toolbar

- `cards/master-cards-client.tsx` — "Add card" primary (`Plus`) is always visible; on mobile a separate "Batch import" button (`Import`) renders alongside it, and on desktop the chevron folds batch import into the dropdown.

### Icon back-links

- `master-management-client.tsx`, `cardgroup-management-client.tsx` — back links become an icon-only `ChevronLeft` with an `sr-only` accessible label (reusing the existing `backToList` / `backLink` keys). The `sr-only` span keeps the link's accessible name without colliding with the card form's "Back" field under `getByLabelText(/back/i)`.

### Cardgroup adoption + i18n

- `cardgroup-cards-section.tsx` — its inline chevron + dropdown is replaced by `SplitButtonMenu`, preserving the `More add options` trigger label, the `Add a card` / `Batch import` menu items, and the `cardgroup-add-more-options` / `cardgroup-batch-import-menuitem` testids, so existing tests are untouched.
- `messages/en.json`, `messages/ja.json` — `Cardgroups.backLink` changed from a leading "←" text arrow to a plain back phrase ("Back to cardgroups" + Japanese equivalent), since it is now an `sr-only` label behind the icon.

### Tests

- `master-edit-header.test.tsx` — deck-settings / delete now open via the desktop split-button dropdown (open the chevron first); added a mobile-kebab publish-toggle test.
- `master-cards-client.test.tsx` — added a reachability test for the mobile batch-import button (opens the shared wizard).

## Verification

Full frontend gate, all green:

```bash
cd frontend && pnpm typecheck && pnpm lint && pnpm knip && pnpm test && pnpm build
```

- typecheck ✓ · lint ✓ (biome `--error-on-warnings`) · knip ✓ · test ✓ (1464 passing, 158 files) · build ✓
- i18n parity ✓ (351 keys both catalogs) · CJK / English-only grep on the changed source: no output.

Runtime handles: the desktop publish primary keeps `data-testid="master-edit-publish"`; the new chevron triggers carry `master-edit-more-options` (master management), `master-add-more-options` (master cards), and `cardgroup-add-more-options` (cardgroup).

## Test plan

- [ ] CI gate (`typecheck` / `lint` / `knip` / `test` / `build`) green.
- [ ] `/admin/masters/<id>/edit` desktop — header shows a "Publish/Unpublish ▾" split button; the chevron reveals "Deck settings" + "Delete master"; the delete confirm is red; the publish toggle flips state.
- [ ] Same page on mobile — a long title fits on one line; the `⋯` kebab holds publish + deck settings + delete; the back link is a `<` icon.
- [ ] Master cards — desktop "Add card ▾" folds in "Batch import"; mobile shows both "Add card" and "Batch import" as buttons; both open their sheets.
- [ ] `/cardgroups/<id>/edit` — the add-card split button still works (primary Add card, dropdown Add a card / Batch import); the back link is a `<` icon.
