### PR TITLE
feat(frontend): relocate master card add/import to header and overflow

### DIFF
--- a/frontend/__tests__/admin-master-cards.test.tsx
+++ b/frontend/__tests__/admin-master-cards.test.tsx
@@ -3,7 +3,7 @@
  * Broad page-level test for the MasterManagementClient tree.
  * Exercises the full card-editor integration: SSR-seeded render and
  * live-count propagation from the cards client up to the header badge
- * (onTotalCountChange → liveCount → MasterEditHeader).
+ * (MasterCardsClient totalCount → renderPageHeader render-prop → MasterEditHeader).
  *
  * Mirror: frontend/__tests__/admin-masters-edit.test.tsx (provider stack)
  * Mirror: frontend/__tests__/cards-bulk-delete.test.tsx (interaction style)
@@ -192,8 +192,8 @@ describe("MasterManagementClient — broad page integration", () => {
 
   // T2: Live count on create — open the add-card sheet, fill front + back,
   // submit with a mocked AdminCreateMasterCard success. The create's cache write
-  // bumps the connection's totalCount, which flows up via onTotalCountChange,
-  // and the header updates from "1 card" to "2 cards".
+  // bumps the connection's totalCount, which flows up through the renderPageHeader
+  // render-prop, and the header updates from "1 card" to "2 cards".
   it("updates the header count from 1 to 2 after a successful card create", async () => {
     const user = userEvent.setup();
     const C2 = "c-broad-2";
@@ -249,10 +249,10 @@ describe("MasterManagementClient — broad page integration", () => {
     // default for mode="create" when no submitLabel prop is passed).
     await user.click(screen.getByRole("button", { name: /^add$/i }));
 
-    // After a successful create the cache is updated (+1 to totalCount) and the
-    // useEffect in MasterCardsClient calls onTotalCountChange(2), which updates
-    // liveCount in MasterManagementClient and re-renders MasterEditHeader with
-    // count=2. The ICU plural for count=2 resolves to "2 cards".
+    // After a successful create the cache is updated (+1 to totalCount). The new
+    // totalCount flows from MasterCardsClient into the renderPageHeader render-prop,
+    // which re-renders MasterEditHeader with count=2. The ICU plural for count=2
+    // resolves to "2 cards".
     await waitFor(() => {
       expect(screen.getByText("2 cards")).toBeInTheDocument();
     });

--- a/frontend/src/app/admin/masters/[id]/edit/cards/master-cards-client.test.tsx
+++ b/frontend/src/app/admin/masters/[id]/edit/cards/master-cards-client.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { MockedProvider } from "@apollo/client/testing/react";
-import { screen, waitFor } from "@testing-library/react";
+import { act, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AdminMasterCardsConnectionDocument } from "@/generated/graphql";
@@ -94,7 +94,15 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
-function render(onTotalCountChange = vi.fn()) {
+type SectionHeader =
+  | React.ReactNode
+  | ((args: {
+      totalCount: number;
+      onAddCard: () => void;
+      onBatchImport: () => void;
+    }) => React.ReactNode);
+
+function renderClient(sectionHeader?: SectionHeader) {
   renderWithIntl(
     <MockedProvider mocks={[seed]}>
       <UndoDeleteProvider>
@@ -104,30 +112,59 @@ function render(onTotalCountChange = vi.fn()) {
           initialEdges={[edge("c-1", "apple")]}
           initialPageInfo={seed.result.data.adminMasterCardsConnection.pageInfo}
           initialTotalCount={1}
-          onTotalCountChange={onTotalCountChange}
+          sectionHeader={sectionHeader}
         />
       </UndoDeleteProvider>
     </MockedProvider>,
   );
-  return onTotalCountChange;
 }
 
 describe("<MasterCardsClient>", () => {
-  it("renders the seeded card and reports the initial total count upward", async () => {
-    const onTotalCountChange = render();
+  it("renders the seeded card and passes the live total count to the section header", async () => {
+    renderClient(({ totalCount }) => <span data-testid="hdr-count">{totalCount}</span>);
     expect(screen.getByText("apple")).toBeInTheDocument();
-    await waitFor(() => expect(onTotalCountChange).toHaveBeenCalledWith(1));
+    await waitFor(() => expect(screen.getByTestId("hdr-count")).toHaveTextContent("1"));
   });
 
-  it("opens the add-card sheet from the toolbar", async () => {
-    render();
-    await userEvent.click(screen.getByRole("button", { name: /add card/i }));
+  it("opens the add-card sheet when a flamingo:add-master-card event targets this master", async () => {
+    renderClient();
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent("flamingo:add-master-card", { detail: { masterId: MASTER_ID } }),
+      );
+    });
+    expect(await screen.findByLabelText(/front/i)).toBeInTheDocument();
+  });
+
+  it("ignores a flamingo:add-master-card event addressed to a different master", async () => {
+    renderClient();
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent("flamingo:add-master-card", { detail: { masterId: "other-master" } }),
+      );
+    });
+    // The card list is present, but the add-card sheet's front field never opens.
+    expect(screen.getByText("apple")).toBeInTheDocument();
+    expect(screen.queryByLabelText(/front/i)).not.toBeInTheDocument();
+  });
+
+  it("opens the add-card sheet via the section-header onAddCard callback", async () => {
+    renderClient(({ onAddCard }) => (
+      <button type="button" data-testid="hdr-add" onClick={onAddCard}>
+        add
+      </button>
+    ));
+    await userEvent.click(screen.getByTestId("hdr-add"));
     expect(screen.getByLabelText(/front/i)).toBeInTheDocument();
   });
 
-  it("opens the batch-import sheet from the mobile toolbar button", async () => {
-    render();
-    await userEvent.click(screen.getByTestId("master-batch-import"));
+  it("opens the batch-import sheet via the section-header onBatchImport callback", async () => {
+    renderClient(({ onBatchImport }) => (
+      <button type="button" data-testid="hdr-import" onClick={onBatchImport}>
+        import
+      </button>
+    ));
+    await userEvent.click(screen.getByTestId("hdr-import"));
     // The shared batch-import wizard renders its paste textarea inside the sheet.
     expect(await screen.findByTestId("batch-import-payload")).toBeInTheDocument();
   });
@@ -183,7 +220,6 @@ describe("<MasterCardsClient>", () => {
             initialEdges={[edge("c-1", "apple")]}
             initialPageInfo={pageInfoWithNext}
             initialTotalCount={1}
-            onTotalCountChange={vi.fn()}
           />
         </UndoDeleteProvider>
       </MockedProvider>,

--- a/frontend/src/app/admin/masters/[id]/edit/cards/master-cards-client.tsx
+++ b/frontend/src/app/admin/masters/[id]/edit/cards/master-cards-client.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { Import, Plus, Search } from "lucide-react";
+import { Search } from "lucide-react";
 import { useTranslations } from "next-intl";
-import type { RefObject } from "react";
+import type { ReactNode, RefObject } from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { BulkActionBar } from "@/components/cardgroups/bulk-action-bar";
 import { CardForm } from "@/components/cardgroups/card-form";
@@ -11,7 +11,6 @@ import type { SwipeableRowHandle } from "@/components/cardgroups/swipeable-row";
 import { Button } from "@/components/ui/button";
 import { ErrorBanner } from "@/components/ui/error-banner";
 import { FormSheet, useFormSheetClose } from "@/components/ui/form-sheet";
-import { SplitButtonMenu } from "@/components/ui/split-button-menu";
 import type { AdminMasterCardsConnectionQuery } from "@/generated/graphql";
 import { useBulkSelection } from "@/hooks/use-bulk-selection";
 import { useDebouncedSearch } from "@/hooks/use-debounced-search";
@@ -152,13 +151,25 @@ const EmptyState = ({ search, onClear }: { search: string | null; onClear: () =>
   );
 };
 
+type SectionHeaderArgs = {
+  totalCount: number;
+  onAddCard: () => void;
+  onBatchImport: () => void;
+};
+
 type Props = {
   masterId: string;
   deckName: string;
   initialEdges: MasterCardEdge[];
   initialPageInfo: MasterCardConnectionPageInfo;
   initialTotalCount: number;
-  onTotalCountChange: (count: number) => void;
+  /**
+   * Page-level header rendered above the search box. Pass a render function to
+   * receive the live `totalCount` (sourced from the Apollo cache, kept in sync
+   * with create/delete/fetchMore) plus the add-card and batch-import openers,
+   * or a plain `ReactNode` to render as-is. Omitted → no header is rendered.
+   */
+  sectionHeader?: ReactNode | ((args: SectionHeaderArgs) => ReactNode);
 };
 
 export function MasterCardsClient({
@@ -167,10 +178,9 @@ export function MasterCardsClient({
   initialEdges,
   initialPageInfo,
   initialTotalCount,
-  onTotalCountChange,
+  sectionHeader,
 }: Props) {
   const t = useTranslations("Cards");
-  const tCardgroups = useTranslations("Cardgroups");
   const [addOpen, setAddOpen] = useState(false);
   const [addDirty, setAddDirty] = useState(false);
   const [batchImportOpen, setBatchImportOpen] = useState(false);
@@ -229,11 +239,6 @@ export function MasterCardsClient({
   const deleteRowBannerError =
     deleteRowError !== null ? (getBackendErrorBanner(deleteRowError) ?? t("deleteError")) : null;
 
-  // Report live total count upward so the page header stays in sync.
-  useEffect(() => {
-    onTotalCountChange(totalCount);
-  }, [totalCount, onTotalCountChange]);
-
   const closeOtherRows = useCallback((exceptCardId: string) => {
     for (const [id, ref] of rowRefs.current.entries()) {
       if (id !== exceptCardId) ref.current?.close();
@@ -251,6 +256,22 @@ export function MasterCardsClient({
 
   const openBatchImport = useCallback(() => setBatchImportOpen(true), []);
   const closeBatchImport = useCallback(() => setBatchImportOpen(false), []);
+
+  // The global header "+" (LogoDrawer) dispatches flamingo:add-master-card on
+  // the master-edit route; claim it for this deck to open the add-card sheet.
+  // Master cards have no separate-page create target, so there is no fallback
+  // navigation to preventDefault against — the listener simply opens the sheet.
+  useEffect(() => {
+    function handleAddMasterCard(event: Event) {
+      if (!(event instanceof CustomEvent)) return;
+      const detail = event.detail as { masterId?: unknown } | null;
+      if (detail?.masterId !== masterId) return;
+      event.preventDefault();
+      openAddSheet();
+    }
+    window.addEventListener("flamingo:add-master-card", handleAddMasterCard);
+    return () => window.removeEventListener("flamingo:add-master-card", handleAddMasterCard);
+  }, [masterId, openAddSheet]);
 
   async function handleCreate(values: { front: string; back: string }) {
     resetCreateCard();
@@ -320,56 +341,17 @@ export function MasterCardsClient({
       )}
 
       <section>
-        {/* Right-aligned toolbar. Desktop: an Add card split button whose
-            dropdown folds in Batch import. Mobile: Add card + Batch import as
-            two separate buttons (the chevron is hidden below sm). */}
-        <div className="mb-3 flex justify-end gap-2">
-          <div className="inline-flex">
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              className="sm:rounded-r-none"
-              onClick={openAddSheet}
-              data-testid="master-add-card"
-            >
-              <Plus aria-hidden="true" className="h-4 w-4" />
-              {t("addCard")}
-            </Button>
-            <div className="hidden sm:inline-flex">
-              <SplitButtonMenu
-                triggerLabel={tCardgroups("addMoreOptions")}
-                data-testid="master-add-more-options"
-                items={[
-                  {
-                    key: "add",
-                    icon: <Plus aria-hidden="true" className="h-4 w-4" />,
-                    label: t("addCard"),
-                    onSelect: openAddSheet,
-                  },
-                  {
-                    key: "import",
-                    icon: <Import aria-hidden="true" className="h-4 w-4" />,
-                    label: tCardgroups("batchImport"),
-                    onSelect: openBatchImport,
-                    "data-testid": "master-batch-import-menuitem",
-                  },
-                ]}
-              />
-            </div>
-          </div>
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            className="sm:hidden"
-            onClick={openBatchImport}
-            data-testid="master-batch-import"
-          >
-            <Import aria-hidden="true" className="h-4 w-4" />
-            {tCardgroups("batchImport")}
-          </Button>
-        </div>
+        {/* Page header (deck title/badge/kebab + the desktop add/import toolbar)
+            is supplied by the parent via the render-prop, so it receives the
+            live totalCount and the add/import openers. On mobile the openers are
+            reached through the global "+" header and the deck overflow menu. */}
+        {typeof sectionHeader === "function"
+          ? sectionHeader({
+              totalCount,
+              onAddCard: openAddSheet,
+              onBatchImport: openBatchImport,
+            })
+          : sectionHeader}
 
         <SearchInput value={search.input} onChange={search.setInput} />
 

--- a/frontend/src/app/admin/masters/[id]/edit/master-cards-section.test.tsx
+++ b/frontend/src/app/admin/masters/[id]/edit/master-cards-section.test.tsx
@@ -39,8 +39,7 @@ const node = {
   updatedAt: "2026-01-01T00:00:00Z",
 };
 
-it("renders MasterCardsClient with the seed and reports the count", async () => {
-  const onTotalCountChange = vi.fn();
+it("renders MasterCardsClient with the seed and exposes the live count to renderPageHeader", async () => {
   renderWithIntl(
     <MockedProvider
       mocks={[
@@ -69,11 +68,11 @@ it("renders MasterCardsClient with the seed and reports the count", async () => 
           initialEdges={[{ __typename: "MasterCardEdge", cursor: "c-1", node }]}
           initialPageInfo={pageInfo}
           initialTotalCount={1}
-          onTotalCountChange={onTotalCountChange}
+          renderPageHeader={({ totalCount }) => <span data-testid="hdr-count">{totalCount}</span>}
         />
       </UndoDeleteProvider>
     </MockedProvider>,
   );
   expect(screen.getByText("apple")).toBeInTheDocument();
-  await waitFor(() => expect(onTotalCountChange).toHaveBeenCalledWith(1));
+  await waitFor(() => expect(screen.getByTestId("hdr-count")).toHaveTextContent("1"));
 });

--- a/frontend/src/app/admin/masters/[id]/edit/master-cards-section.tsx
+++ b/frontend/src/app/admin/masters/[id]/edit/master-cards-section.tsx
@@ -1,5 +1,10 @@
 "use client";
 
+import { Import, Plus } from "lucide-react";
+import { useTranslations } from "next-intl";
+import type { ReactNode } from "react";
+import { Button } from "@/components/ui/button";
+import { SplitButtonMenu } from "@/components/ui/split-button-menu";
 import {
   type MasterCardConnectionPageInfo,
   type MasterCardEdge,
@@ -12,7 +17,13 @@ type MasterCardsSectionProps = {
   initialEdges: MasterCardEdge[];
   initialPageInfo: MasterCardConnectionPageInfo;
   initialTotalCount: number;
-  onTotalCountChange: (count: number) => void;
+  /**
+   * Renders the deck-level page header (title / status badge / overflow menu)
+   * with the live `totalCount` and the batch-import opener. "Add card" is
+   * reached separately: the global header "+" on mobile, the desktop toolbar
+   * split button rendered below. Omitted → no page header.
+   */
+  renderPageHeader?: (args: { totalCount: number; onBatchImport: () => void }) => ReactNode;
 };
 
 export function MasterCardsSection({
@@ -21,8 +32,65 @@ export function MasterCardsSection({
   initialEdges,
   initialPageInfo,
   initialTotalCount,
-  onTotalCountChange,
+  renderPageHeader,
 }: MasterCardsSectionProps) {
+  const tCards = useTranslations("Cards");
+  const tCardgroups = useTranslations("Cardgroups");
+
+  // MasterCardsClient passes its live totalCount (read from the Apollo cache,
+  // kept in sync with create / delete / fetchMore) into this render fn, so the
+  // page header and the desktop toolbar stay current without a second useQuery.
+  const renderHeader = ({
+    totalCount,
+    onAddCard,
+    onBatchImport,
+  }: {
+    totalCount: number;
+    onAddCard: () => void;
+    onBatchImport: () => void;
+  }) => (
+    <div>
+      {renderPageHeader?.({ totalCount, onBatchImport })}
+      {/* Desktop-only (md+) action cluster: Add card + a dropdown that folds in
+          Batch import. Below md, Add card is the global header "+" and Batch
+          import lives in the deck overflow menu, so nothing renders here. */}
+      <div className="mb-3 hidden justify-end md:flex">
+        <div className="inline-flex">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="rounded-r-none"
+            onClick={onAddCard}
+            data-testid="master-add-card"
+          >
+            <Plus aria-hidden="true" className="h-4 w-4" />
+            {tCards("addCard")}
+          </Button>
+          <SplitButtonMenu
+            triggerLabel={tCardgroups("addMoreOptions")}
+            data-testid="master-add-more-options"
+            items={[
+              {
+                key: "add",
+                icon: <Plus aria-hidden="true" className="h-4 w-4" />,
+                label: tCards("addCard"),
+                onSelect: onAddCard,
+              },
+              {
+                key: "import",
+                icon: <Import aria-hidden="true" className="h-4 w-4" />,
+                label: tCardgroups("batchImport"),
+                onSelect: onBatchImport,
+                "data-testid": "master-batch-import-menuitem",
+              },
+            ]}
+          />
+        </div>
+      </div>
+    </div>
+  );
+
   return (
     <section data-testid="master-cards-section" data-master-id={masterId}>
       <MasterCardsClient
@@ -31,7 +99,7 @@ export function MasterCardsSection({
         initialEdges={initialEdges}
         initialPageInfo={initialPageInfo}
         initialTotalCount={initialTotalCount}
-        onTotalCountChange={onTotalCountChange}
+        sectionHeader={renderHeader}
       />
     </section>
   );

--- a/frontend/src/app/admin/masters/[id]/edit/master-edit-header.test.tsx
+++ b/frontend/src/app/admin/masters/[id]/edit/master-edit-header.test.tsx
@@ -57,11 +57,15 @@ const DECK: AdminMasterDeck = {
   updatedAt: "2026-01-01T00:00:00Z",
 };
 
-function renderHeader(deck: AdminMasterDeck, mocks: ReadonlyArray<unknown> = []) {
+function renderHeader(
+  deck: AdminMasterDeck,
+  mocks: ReadonlyArray<unknown> = [],
+  onBatchImport?: () => void,
+) {
   return render(
     <MockedProvider mocks={mocks as never}>
       <NextIntlClientProvider locale="en" messages={enMessages} timeZone="UTC">
-        <MasterEditHeader master={deck} cardCount={deck.cardCount} />
+        <MasterEditHeader master={deck} cardCount={deck.cardCount} onBatchImport={onBatchImport} />
       </NextIntlClientProvider>
     </MockedProvider>,
   );
@@ -261,6 +265,26 @@ describe("MasterEditHeader", () => {
     await user.click(screen.getByTestId("master-edit-overflow"));
     await user.click(await screen.findByTestId("master-edit-publish-mobile"));
     await waitFor(() => expect(refresh).toHaveBeenCalledTimes(1));
+  });
+
+  it("overflow menu (mobile): renders a Bulk import item that calls onBatchImport", async () => {
+    const user = userEvent.setup();
+    const onBatchImport = vi.fn();
+    renderHeader(DECK, [], onBatchImport);
+    await user.click(screen.getByTestId("master-edit-overflow"));
+    const importItem = await screen.findByTestId("master-edit-batch-import");
+    expect(importItem).toHaveTextContent(/batch import/i);
+    await user.click(importItem);
+    expect(onBatchImport).toHaveBeenCalledTimes(1);
+  });
+
+  it("overflow menu (mobile): omits the Bulk import item when onBatchImport is not provided", async () => {
+    const user = userEvent.setup();
+    renderHeader(DECK);
+    await user.click(screen.getByTestId("master-edit-overflow"));
+    // The deck-settings item proves the menu opened; the import item is absent.
+    expect(await screen.findByTestId("master-edit-deck-settings-mobile")).toBeInTheDocument();
+    expect(screen.queryByTestId("master-edit-batch-import")).not.toBeInTheDocument();
   });
 
   it("displays the cardCount prop (live count), not master.cardCount", () => {

--- a/frontend/src/app/admin/masters/[id]/edit/master-edit-header.tsx
+++ b/frontend/src/app/admin/masters/[id]/edit/master-edit-header.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Eye, EyeOff, MoreHorizontal, Settings, Trash2 } from "lucide-react";
+import { Eye, EyeOff, Import, MoreHorizontal, Settings, Trash2 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { useCallback, useState } from "react";
@@ -23,17 +23,28 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { FormSheet } from "@/components/ui/form-sheet";
 import { SplitButtonMenu } from "@/components/ui/split-button-menu";
 import type { AdminMasterDeck } from "./queries";
 
-type Props = { master: AdminMasterDeck; cardCount: number };
+type Props = {
+  master: AdminMasterDeck;
+  cardCount: number;
+  /**
+   * Opens the batch-import sheet owned by MasterCardsClient. Wired only on the
+   * mobile overflow menu — desktop reaches batch import through the cards
+   * toolbar's split button. Omitted (e.g. in isolated tests) → no import item.
+   */
+  onBatchImport?: () => void;
+};
 
-export function MasterEditHeader({ master, cardCount }: Props) {
+export function MasterEditHeader({ master, cardCount, onBatchImport }: Props) {
   const t = useTranslations("AdminMasters");
   const tCommon = useTranslations("Common");
+  const tCardgroups = useTranslations("Cardgroups");
   const router = useRouter();
 
   const [settingsOpen, setSettingsOpen] = useState(false);
@@ -150,11 +161,12 @@ export function MasterEditHeader({ master, cardCount }: Props) {
 
   return (
     <>
-      {/* Mobile: the title takes the full line width and the actions collapse
-          into the meta row (kebab) / move below. Desktop: title left, the
-          publish split button on the right. */}
-      <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-        <div className="min-w-0 sm:flex-1">
+      {/* Mobile (<md): the title takes the full line width and the actions
+          collapse into the meta row (kebab). Desktop (md+): title left, the
+          publish split button on the right. The md breakpoint matches the app
+          shell — the global header "+" shows below md, the rail at md+. */}
+      <div className="mb-6 flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+        <div className="min-w-0 md:flex-1">
           <h1 className="text-2xl font-semibold leading-tight break-words">{master.name}</h1>
           <div className="mt-1 flex items-center justify-between gap-2">
             <div className="flex items-center gap-2">
@@ -177,7 +189,7 @@ export function MasterEditHeader({ master, cardCount }: Props) {
                   type="button"
                   variant="ghost"
                   size="icon"
-                  className="shrink-0 sm:hidden"
+                  className="shrink-0 md:hidden"
                   data-testid="master-edit-overflow"
                   aria-label={t("masterOptions")}
                 >
@@ -185,6 +197,23 @@ export function MasterEditHeader({ master, cardCount }: Props) {
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">
+                {/* Bulk import is a card-content action — grouped above a
+                    separator, apart from the deck-lifecycle items below. On
+                    mobile, "Add card" is the global header "+" and batch import
+                    lives here; desktop reaches both via the cards toolbar. */}
+                {onBatchImport ? (
+                  <>
+                    <DropdownMenuItem
+                      onSelect={onBatchImport}
+                      data-testid="master-edit-batch-import"
+                      className="gap-2"
+                    >
+                      <Import aria-hidden="true" className="h-4 w-4" />
+                      {tCardgroups("batchImport")}
+                    </DropdownMenuItem>
+                    <DropdownMenuSeparator />
+                  </>
+                ) : null}
                 <DropdownMenuItem
                   onSelect={handlePublishToggle}
                   disabled={publishing || emptyDraft}
@@ -221,7 +250,7 @@ export function MasterEditHeader({ master, cardCount }: Props) {
         </div>
 
         {/* Desktop split button: publish primary + dropdown (deck settings, delete). */}
-        <div className="hidden shrink-0 items-center sm:flex">
+        <div className="hidden shrink-0 items-center md:flex">
           <Button
             type="button"
             variant={published ? "outline" : "brand"}

--- a/frontend/src/app/admin/masters/[id]/edit/master-management-client.tsx
+++ b/frontend/src/app/admin/masters/[id]/edit/master-management-client.tsx
@@ -3,7 +3,6 @@
 import { ChevronLeft } from "lucide-react";
 import Link from "next/link";
 import { useTranslations } from "next-intl";
-import { useState } from "react";
 import type { MasterCardConnectionPageInfo, MasterCardEdge } from "./cards/master-cards-client";
 import { MasterCardsSection } from "./master-cards-section";
 import { MasterEditHeader } from "./master-edit-header";
@@ -23,7 +22,6 @@ export function MasterManagementClient({
   initialTotalCount,
 }: Props) {
   const t = useTranslations("AdminMasters");
-  const [liveCount, setLiveCount] = useState(initialTotalCount);
   return (
     <main className="p-4 md:p-8">
       <div className="mb-2">
@@ -36,14 +34,19 @@ export function MasterManagementClient({
         </Link>
       </div>
 
-      <MasterEditHeader master={master} cardCount={liveCount} />
+      {/* The header is rendered inside the cards section via the render-prop so
+          its card count tracks the live Apollo-cache totalCount, and the deck
+          overflow menu's batch-import item is wired to the cards client's
+          import sheet — no count state is lifted into this component. */}
       <MasterCardsSection
         masterId={master.id}
         deckName={master.name}
         initialEdges={initialEdges}
         initialPageInfo={initialPageInfo}
         initialTotalCount={initialTotalCount}
-        onTotalCountChange={setLiveCount}
+        renderPageHeader={({ totalCount, onBatchImport }) => (
+          <MasterEditHeader master={master} cardCount={totalCount} onBatchImport={onBatchImport} />
+        )}
       />
     </main>
   );

--- a/frontend/src/components/nav/header-create-action.test.ts
+++ b/frontend/src/components/nav/header-create-action.test.ts
@@ -123,6 +123,39 @@ describe("resolveHeaderCreateAction", () => {
     });
   });
 
+  describe("/admin/masters/:id/edit route", () => {
+    it.each([
+      ["/admin/masters/m-1/edit", "m-1"],
+      ["/admin/masters/m-1/edit/", "m-1"],
+      [
+        "/admin/masters/0190f9f4-3ad8-7d52-b1d0-6f6b5f5a9c2c/edit",
+        "0190f9f4-3ad8-7d52-b1d0-6f6b5f5a9c2c",
+      ],
+    ])("returns master-card for %s", (pathname, masterId) => {
+      expect(resolveHeaderCreateAction(pathname)).toEqual({
+        kind: "master-card",
+        label: "Add new card",
+        masterId,
+      });
+    });
+
+    it("decodes percent-encoded segment: a%2Fb -> masterId a/b", () => {
+      expect(resolveHeaderCreateAction("/admin/masters/a%2Fb/edit")).toEqual({
+        kind: "master-card",
+        label: "Add new card",
+        masterId: "a/b",
+      });
+    });
+
+    it("returns null for malformed percent-escape in /admin/masters/:id/edit", () => {
+      expect(resolveHeaderCreateAction("/admin/masters/%ZZ/edit")).toBeNull();
+    });
+
+    it("returns null for /admin/masters/m-1 (no /edit)", () => {
+      expect(resolveHeaderCreateAction("/admin/masters/m-1")).toBeNull();
+    });
+  });
+
   describe("routes that return null", () => {
     it.each([
       ["/"],

--- a/frontend/src/components/nav/header-create-action.ts
+++ b/frontend/src/components/nav/header-create-action.ts
@@ -2,6 +2,7 @@ import { safeDecodePathSegment } from "@/lib/safe-decode-path-segment";
 
 const CARDGROUP_EDIT_RE = /^\/cardgroups\/([^/]+)\/edit(\/|$)/;
 const LEARN_RE = /^\/learn\/([^/]+)(\/|$)/;
+const MASTER_EDIT_RE = /^\/admin\/masters\/([^/]+)\/edit(\/|$)/;
 
 export type HeaderCreateAction =
   | { kind: "cardgroup"; label: "Add new cardgroup"; href: "/cardgroups/new" }
@@ -22,7 +23,12 @@ export type HeaderCreateAction =
   | { kind: "role"; label: "Add new role" }
   // No href: master creation opens the create sheet the same way as role —
   // ?new=true on the current path (via useSheetSearchParam).
-  | { kind: "master"; label: "Add new master" };
+  | { kind: "master"; label: "Add new master" }
+  // No href: adding a card to a master deck has no separate-page target (unlike
+  // a user cardgroup, which can fall back to /cards/new). The '+' dispatches a
+  // cancelable flamingo:add-master-card event that the in-page MasterCardsClient
+  // claims; there is no navigation fallback.
+  | { kind: "master-card"; label: "Add new card"; masterId: string };
 
 /**
  * Build a `card-with-group` action for the /cardgroups/:id/edit route.
@@ -67,9 +73,10 @@ function cardWithGroupFromLearn(
  * - `/cardgroups`          -> create new cardgroup
  * - `/cardgroups/:id/edit` -> create card pre-filled with the cardgroup
  * - `/learn/:id`           -> create card pre-filled with the cardgroup + return param
- * - `/admin/roles`         -> create new role
- * - `/admin/masters`       -> create new master
- * - anything else          -> `null`
+ * - `/admin/roles`            -> create new role
+ * - `/admin/masters`          -> create new master
+ * - `/admin/masters/:id/edit` -> add card to the master deck
+ * - anything else             -> `null`
  */
 export function resolveHeaderCreateAction(pathname: string): HeaderCreateAction | null {
   if (pathname === "/cardgroups") {
@@ -98,6 +105,13 @@ export function resolveHeaderCreateAction(pathname: string): HeaderCreateAction 
 
   if (pathname === "/admin/masters") {
     return { kind: "master", label: "Add new master" };
+  }
+
+  const masterEditMatch = MASTER_EDIT_RE.exec(pathname);
+  if (masterEditMatch) {
+    const rawId = safeDecodePathSegment(masterEditMatch[1] as string);
+    if (rawId === null) return null;
+    return { kind: "master-card", label: "Add new card", masterId: rawId };
   }
 
   return null;

--- a/frontend/src/components/nav/logo-drawer.test.tsx
+++ b/frontend/src/components/nav/logo-drawer.test.tsx
@@ -332,6 +332,42 @@ describe("<LogoDrawer>", () => {
     expect(target).toContain("new=true");
   });
 
+  it("S-ME1: on /admin/masters/:id/edit the '+' (Add new card) dispatches add-master-card with the decoded masterId and does not navigate", async () => {
+    const user = userEvent.setup();
+    mockUsePathname.mockReturnValue("/admin/masters/m-1/edit");
+    const listener = vi.fn();
+    window.addEventListener("flamingo:add-master-card", listener);
+    renderWithIntl(<LogoDrawer user={SIGNED_IN_USER} isAdmin={true} />);
+
+    await user.click(screen.getByRole("button", { name: /add new card/i }));
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    const event = listener.mock.calls[0]?.[0] as CustomEvent<{ masterId: string }>;
+    expect(event.cancelable).toBe(true);
+    expect(event.detail).toEqual({ masterId: "m-1" });
+    // Master cards have no separate-page create target, so the '+' never falls
+    // back to a route push the way the cardgroup add-card '+' does.
+    expect(mockPush).not.toHaveBeenCalled();
+
+    window.removeEventListener("flamingo:add-master-card", listener);
+  });
+
+  it("S-ME2: master-edit '+' decodes a percent-encoded masterId for the event detail", async () => {
+    const user = userEvent.setup();
+    mockUsePathname.mockReturnValue("/admin/masters/a%26b/edit");
+    const listener = vi.fn();
+    window.addEventListener("flamingo:add-master-card", listener);
+    renderWithIntl(<LogoDrawer user={SIGNED_IN_USER} isAdmin={true} />);
+
+    await user.click(screen.getByRole("button", { name: /add new card/i }));
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    const event = listener.mock.calls[0]?.[0] as CustomEvent<{ masterId: string }>;
+    expect(event.detail).toEqual({ masterId: "a&b" });
+
+    window.removeEventListener("flamingo:add-master-card", listener);
+  });
+
   it("S-G1: on an unknown route (/profile) the '+' button is not rendered", () => {
     mockUsePathname.mockReturnValue("/profile");
     renderWithIntl(<LogoDrawer user={SIGNED_IN_USER} isAdmin={false} />);

--- a/frontend/src/components/nav/logo-drawer.tsx
+++ b/frontend/src/components/nav/logo-drawer.tsx
@@ -68,6 +68,18 @@ export function LogoDrawer({ user, isAdmin }: LogoDrawerProps) {
         open({ mode: "new" });
         return;
       }
+      // Adding a card to a master deck has no separate-page fallback: the
+      // in-page MasterCardsClient is always mounted on the edit screen and
+      // claims this event to open its add-card sheet. No router.push fallback.
+      case "master-card": {
+        window.dispatchEvent(
+          new CustomEvent("flamingo:add-master-card", {
+            cancelable: true,
+            detail: { masterId: createAction.masterId },
+          }),
+        );
+        return;
+      }
       default: {
         const _exhaustive: never = createAction;
         console.error("[LogoDrawer] unhandled createAction kind", createAction);


### PR DESCRIPTION
## Summary

On the master-deck admin card screen, "Add card" moves to the global mobile header "+" and "Bulk import" moves into the deck overflow ("…") menu, bringing the master surface to parity with the user cardgroup card screen. Internally the master edit tree adopts the cardgroup `renderPageHeader` render-prop, dropping the bespoke lifted live-count state.

No related issue — ad-hoc UI change from a design screenshot.

## Background / Motivation

- The cardgroup card screen already routes "Add card" through the global header "+" (`flamingo:add-card`) and parks "Bulk import" in the header kebab; the master card screen was the only card-management surface still rendering both as in-page toolbar buttons. This is the direct follow-up to #547, which consolidated the deck-detail *management* actions but left the add/import pair in the toolbar.
- The master header carried bespoke lifted live-count state — `MasterManagementClient` owned `liveCount` and threaded it down via an `onTotalCountChange` callback — diverging from the cardgroup screen, which sources the live count through the `renderPageHeader` render-prop.
- The master toolbar used `sm:` breakpoints while the app shell switches mobile↔desktop at `md` (the global header "+" shows below `md`, the rail at `md+`), leaving a 640–767px band where "Add card" double-rendered and the import affordance could fall through.

## Design — per-boundary wiring

The placement is one feature, but the two actions cross different component boundaries, so each uses the right tool:

- **Add card** crosses the shell → page boundary: `LogoDrawer` lives in the app shell with no React prop path to the page, so the "+" dispatches a `flamingo:add-master-card` window event that the in-page `MasterCardsClient` claims — exactly how the cardgroup add-card "+" works. Master cards have no separate-page create flow, so there is no navigation fallback.
- **Bulk import** crosses a sibling boundary under one parent (`MasterEditHeader` ↔ `MasterCardsClient`), so it flows as a React render-prop callback (`renderPageHeader` → `onBatchImport`) rather than a window event — again matching cardgroup. This also removes the lifted `liveCount` state, since the count now flows through the same render-prop.

## Changes

### Header "+" → add master card

- `nav/header-create-action.ts` — new `master-card` action kind + `MASTER_EDIT_RE` matching `/admin/masters/:id/edit` (percent-decoded id, `null` on a malformed escape). No `href`: master cards have no separate-page create target.
- `nav/logo-drawer.tsx` — on the master edit route the "+" dispatches a cancelable `flamingo:add-master-card` event carrying `{ masterId }`; no `router.push` fallback.

### Overflow "…" menu → bulk import

- `master-edit-header.tsx` — new optional `onBatchImport` prop; the mobile overflow menu gains a "Bulk import" item (`Import` icon, reusing the `Cardgroups.batchImport` label) grouped above a `DropdownMenuSeparator`, apart from the deck-lifecycle items (publish / deck settings / delete). The header's mobile↔desktop breakpoints move `sm:` → `md:` to match the app shell.

### Render-prop refactor

- `cards/master-cards-client.tsx` — drops `onTotalCountChange`; gains a `sectionHeader` render-prop (receiving the live `totalCount` plus the add-card / batch-import openers) and a `flamingo:add-master-card` listener (filtered by `masterId`) that opens the add-card sheet. The in-page action toolbar is removed from this component.
- `master-cards-section.tsx` — gains `renderPageHeader`; renders the desktop-only (`md+`) add/import split button above the list, keeping the `master-add-card` / `master-add-more-options` / `master-batch-import-menuitem` testids.
- `master-management-client.tsx` — drops the lifted `liveCount` state and renders `MasterEditHeader` through `renderPageHeader`, so the card count tracks the live Apollo-cache total and the overflow import item is wired to the cards client's sheet.

### Tests

- `nav/header-create-action.test.ts`, `nav/logo-drawer.test.tsx` — master-card route resolution (decode + malformed-escape `null`) and the `flamingo:add-master-card` dispatch (decoded id, no fallback navigation).
- `cards/master-cards-client.test.tsx` — event-driven add-card plus the wrong-master filter, the `sectionHeader` add/import callbacks, and the live count passed to the render-prop.
- `master-edit-header.test.tsx` — the overflow "Bulk import" item presence (with `onBatchImport`) / absence (without) and its callback.
- `master-cards-section.test.tsx`, `__tests__/admin-master-cards.test.tsx` — live-count flow through the render-prop.

## Verification

Full frontend gate, all green:

```bash
cd frontend && pnpm typecheck && pnpm lint && pnpm knip && pnpm test && pnpm build
```

- typecheck ✓ · lint ✓ (biome `--error-on-warnings`) · knip ✓ · test ✓ (1479 passing, 158 files) · build ✓
- CJK / English-only grep on the changed source: no output. No new i18n keys (reuses `Cardgroups.batchImport`).

Runtime handles: on `/admin/masters/<id>/edit` the global header "+" carries `aria-label="Add new card"`; the overflow import item is `master-edit-batch-import`; the desktop add split keeps `master-add-card` / `master-add-more-options` / `master-batch-import-menuitem`.

## Test plan

- [ ] CI gate (typecheck / lint / knip / test / build) green.
- [ ] `/admin/masters/<id>/edit` on mobile (`<md`) — the top header shows a "+" left of the `☰`; tapping it opens the add-card sheet. The in-page "Add card" / "Bulk import" toolbar buttons are gone.
- [ ] Same page, the `⋯` overflow menu — holds "Bulk import" (opens the import wizard) above publish / deck settings / delete.
- [ ] Same page on desktop (`md+`) — the in-page "Add card ▾" split button still folds in "Bulk import"; both open their sheets.
- [ ] `/cardgroups/<id>/edit` — unchanged: no regression in the header "+" add-card or the kebab batch-import.
