### PR TITLE
feat(frontend): mobile header-takeover search for cardgroups

### DIFF
--- a/frontend/e2e/cardgroups-mobile-search.spec.ts
+++ b/frontend/e2e/cardgroups-mobile-search.spec.ts
@@ -43,7 +43,7 @@ test.describe("cardgroups mobile search takeover", () => {
     await expect(page.getByText(`Beta ${runId}`)).toHaveCount(0);
 
     // Close: the bar disappears; the active dot remains because the query is set.
-    await page.getByTestId("search-takeover").getByRole("button").first().click();
+    await page.getByTestId("search-takeover-close").click();
     await expect(page.getByTestId("search-takeover")).toBeHidden();
     await expect(page.getByTestId("header-search-active-dot")).toBeVisible();
   });

--- a/frontend/e2e/cardgroups-mobile-search.spec.ts
+++ b/frontend/e2e/cardgroups-mobile-search.spec.ts
@@ -1,0 +1,50 @@
+import { randomUUID } from "node:crypto";
+import { expect, test } from "@playwright/test";
+import { loginAs, seedCardgroup, seedUser } from "./_auth";
+
+// The header search takeover is mobile-only (md:hidden). The default
+// e2e viewport is Desktop Chrome (1280px), so this scenario overrides to a
+// phone viewport (390x844), mirroring new-user-onboarding.spec.ts.
+// Select by data-testid / role — e2e renders in the ja-JP locale, so never
+// match on translated copy.
+test.describe("cardgroups mobile search takeover", () => {
+  test.use({ viewport: { width: 390, height: 844 } });
+
+  const runId = randomUUID().slice(0, 8);
+  const user = {
+    email: `cg-mobile-search-${runId}@example.test`,
+    password: "e2e-password",
+  };
+
+  test.beforeAll(async () => {
+    const seeded = await seedUser({
+      email: user.email,
+      password: user.password,
+      role: "general",
+      displayName: "E2E Mobile Search",
+    });
+    await seedCardgroup({ ownerId: seeded.id, name: `Alpha ${runId}` });
+    await seedCardgroup({ ownerId: seeded.id, name: `Beta ${runId}` });
+  });
+
+  test("opens the takeover from the header, filters, and closes", async ({ context, page }) => {
+    await loginAs(context, { email: user.email, password: user.password });
+    await page.goto("/cardgroups");
+
+    await expect(page.getByText(`Alpha ${runId}`)).toBeVisible();
+    await expect(page.getByText(`Beta ${runId}`)).toBeVisible();
+
+    await page.getByTestId("header-search-trigger").click();
+    const input = page.getByTestId("search-takeover-input");
+    await expect(input).toBeVisible();
+
+    await input.fill(`Alpha ${runId}`);
+    await expect(page.getByText(`Alpha ${runId}`)).toBeVisible();
+    await expect(page.getByText(`Beta ${runId}`)).toHaveCount(0);
+
+    // Close: the bar disappears; the active dot remains because the query is set.
+    await page.getByTestId("search-takeover").getByRole("button").first().click();
+    await expect(page.getByTestId("search-takeover")).toBeHidden();
+    await expect(page.getByTestId("header-search-active-dot")).toBeVisible();
+  });
+});

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -28,6 +28,7 @@
     "flamingoHome": "Flamingo home",
     "navigationMenu": "Navigation menu",
     "openMenu": "Open menu",
+    "openSearch": "Filter cardgroups",
     "primaryNavigation": "Primary navigation"
   },
   "Language": {

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -50,6 +50,10 @@
     "heading": "Settings",
     "description": "Manage your preferences."
   },
+  "Search": {
+    "back": "Close search",
+    "clear": "Clear search"
+  },
   "Learn": {
     "completeHeading": "Today's learning is complete",
     "completeMessage": "All cards for this group have been reviewed. Come back when the next review is due.",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -50,6 +50,10 @@
     "heading": "設定",
     "description": "環境設定を管理します。"
   },
+  "Search": {
+    "back": "検索を閉じる",
+    "clear": "検索をクリア"
+  },
   "Learn": {
     "completeHeading": "本日の学習が完了しました",
     "completeMessage": "このグループのすべてのカードを復習しました。次の復習時期になったらまたお越しください。",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -28,6 +28,7 @@
     "flamingoHome": "Flamingo ホーム",
     "navigationMenu": "ナビゲーションメニュー",
     "openMenu": "メニューを開く",
+    "openSearch": "カードグループを絞り込む",
     "primaryNavigation": "メインナビゲーション"
   },
   "Language": {

--- a/frontend/src/app/cardgroups/cardgroups-client.test.tsx
+++ b/frontend/src/app/cardgroups/cardgroups-client.test.tsx
@@ -1100,6 +1100,38 @@ describe("<CardgroupsClient> connection cache update (readQuery + writeQuery)", 
 });
 
 // ---------------------------------------------------------------------------
+// Mobile search takeover — flamingo:open-search / flamingo:search-state
+// ---------------------------------------------------------------------------
+
+describe("<CardgroupsClient> mobile search takeover", () => {
+  it("opens the takeover on flamingo:open-search and renders the input", async () => {
+    renderClient([], makeConnection([CG_1]));
+    // Flush the SSR seed render.
+    await screen.findByText("Spanish Vocab");
+
+    expect(screen.queryByTestId("search-takeover")).not.toBeInTheDocument();
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent("flamingo:open-search"));
+    });
+
+    expect(screen.getByTestId("search-takeover")).toBeInTheDocument();
+    expect(screen.getByTestId("search-takeover-input")).toBeInTheDocument();
+  });
+
+  it("dispatches flamingo:search-state on mount with active:false, visible:false", () => {
+    const detail = vi.fn();
+    function onState(e: Event) {
+      detail((e as CustomEvent).detail);
+    }
+    window.addEventListener("flamingo:search-state", onState);
+    renderClient([], makeConnection([CG_1]));
+    expect(detail).toHaveBeenCalledWith({ active: false, visible: false });
+    window.removeEventListener("flamingo:search-state", onState);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // S-create-limit: in-list drawer surfaces CardgroupLimitReachedError via
 // the dedicated `cardgroup-create-limit-error` testid, not the overloaded
 // unexpected-error banner.

--- a/frontend/src/app/cardgroups/cardgroups-client.tsx
+++ b/frontend/src/app/cardgroups/cardgroups-client.tsx
@@ -10,6 +10,7 @@ import { CardgroupForm } from "@/components/cardgroups/cardgroup-form";
 import { CardgroupListItem } from "@/components/cardgroups/cardgroup-list-item";
 import { CardgroupsToolbar } from "@/components/cardgroups/cardgroups-toolbar";
 import { ListingPageShell } from "@/components/layout/listing-page-shell";
+import { SearchTakeoverBar } from "@/components/search/search-takeover-bar";
 import { Button } from "@/components/ui/button";
 import { ErrorBanner } from "@/components/ui/error-banner";
 import { FormSheet, useFormSheetClose } from "@/components/ui/form-sheet";
@@ -140,6 +141,39 @@ export default function CardgroupsClient({ initialConnection }: CardgroupsClient
   const tCommon = useTranslations("Common");
   const search = useDebouncedSearch();
   const searchQuery = search.query;
+  const [searchOpen, setSearchOpen] = useState(false);
+
+  // The nav-header search trigger dispatches this; open the takeover in place.
+  useEffect(() => {
+    function handleOpenSearch() {
+      setSearchOpen(true);
+    }
+    window.addEventListener("flamingo:open-search", handleOpenSearch);
+    return () => window.removeEventListener("flamingo:open-search", handleOpenSearch);
+  }, []);
+
+  // Report filter state back to the header trigger (active dot + aria-expanded).
+  useEffect(() => {
+    window.dispatchEvent(
+      new CustomEvent("flamingo:search-state", {
+        detail: { active: searchQuery !== null && searchQuery !== "", visible: searchOpen },
+      }),
+    );
+  }, [searchQuery, searchOpen]);
+
+  // Reset the header trigger when leaving /cardgroups.
+  useEffect(() => {
+    return () => {
+      window.dispatchEvent(
+        new CustomEvent("flamingo:search-state", {
+          detail: { active: false, visible: false },
+        }),
+      );
+    };
+  }, []);
+
+  const closeSearch = useCallback(() => setSearchOpen(false), []);
+
   const [deleteCommitError, setDeleteCommitError] = useState<string | null>(null);
 
   const { scheduleDelete } = useUndoDelete();
@@ -337,126 +371,137 @@ export default function CardgroupsClient({ initialConnection }: CardgroupsClient
   const hasSearch = searchQuery !== null && searchQuery !== "";
 
   return (
-    <ListingPageShell
-      title={t("myCardgroups")}
-      description={t("browseManage")}
-      primaryActions={
-        <Button
-          type="button"
-          variant="brand"
-          className="hidden md:inline-flex"
-          onClick={openAddSheet}
-          data-testid="cardgroups-header-new-btn"
-        >
-          <span>{t("newCardgroup")}</span>
-          <Plus aria-hidden="true" />
-        </Button>
-      }
-      toolbar={
-        <CardgroupsToolbar searchInput={search.input} onSearchInputChange={search.setInput} />
-      }
-    >
-      {initialLoading && (
-        <p className="text-sm text-muted-foreground" data-testid="cardgroups-loading">
-          {tCommon("loading")}
-        </p>
-      )}
-
-      {!initialLoading && edges.length === 0 && !hasSearch && (
-        <div
-          className="flex flex-col items-center gap-3 py-8 text-center"
-          data-testid="cardgroups-empty"
-        >
-          <p className="text-sm text-muted-foreground">{t("noCardgroupsYet")}</p>
+    <>
+      <SearchTakeoverBar
+        open={searchOpen}
+        value={search.input}
+        onChange={search.setInput}
+        onClear={search.clear}
+        onClose={closeSearch}
+        placeholder={t("filterPlaceholder")}
+        ariaLabel={t("filterAriaLabel")}
+      />
+      <ListingPageShell
+        title={t("myCardgroups")}
+        description={t("browseManage")}
+        primaryActions={
           <Button
             type="button"
             variant="brand"
+            className="hidden md:inline-flex"
             onClick={openAddSheet}
-            data-testid="cardgroups-empty-cta"
+            data-testid="cardgroups-header-new-btn"
           >
             <span>{t("newCardgroup")}</span>
             <Plus aria-hidden="true" />
           </Button>
-        </div>
-      )}
-
-      {!initialLoading && edges.length === 0 && hasSearch && (
-        <p className="text-sm text-muted-foreground" data-testid="cardgroups-empty-search">
-          {t("noMatch", { query: searchQuery })}
-        </p>
-      )}
-
-      {edges.length > 0 && (
-        <ul className="space-y-3" data-testid="cardgroups-list">
-          {edges.map((edge) => (
-            <CardgroupListItem
-              key={edge.node.id}
-              id={edge.node.id}
-              name={edge.node.name}
-              updatedAt={edge.node.updatedAt as string}
-              onDelete={handleDelete}
-            />
-          ))}
-        </ul>
-      )}
-
-      {deleteCommitError && (
-        <ErrorBanner className="mt-3" data-testid="cardgroups-delete-error">
-          {deleteCommitError}
-        </ErrorBanner>
-      )}
-
-      <div ref={sentinelRef} aria-hidden="true" data-testid="cardgroups-sentinel" />
-
-      {fetchMoreError && (
-        <ErrorBanner
-          className="mt-3 flex flex-col items-center gap-2"
-          data-testid="cardgroups-fetch-more-error"
-        >
-          <span>{fetchMoreError}</span>
-          <Button type="button" variant="outline" size="sm" onClick={retryFetchMore}>
-            {tCommon("retry")}
-          </Button>
-        </ErrorBanner>
-      )}
-
-      {!fetchMoreError && fetchingMore && hasNextPage && (
-        <p
-          className="mt-3 text-center text-xs text-muted-foreground"
-          data-testid="cardgroups-loading-more"
-        >
-          {t("loadingMore")}
-        </p>
-      )}
-
-      <FormSheet
-        title={t("newCardgroup")}
-        open={addOpen}
-        onOpenChange={(nextOpen) => {
-          setAddOpen(nextOpen);
-          if (!nextOpen) {
-            setAddDirty(false);
-            setAddValidationError(null);
-            setAddAuthError(null);
-            setAddUnexpectedError(null);
-            setAddLimitError(null);
-          }
-        }}
-        submitting={creating}
-        dirty={addDirty}
-        confirmOnDismiss
-        size="sm"
+        }
+        toolbar={
+          <CardgroupsToolbar searchInput={search.input} onSearchInputChange={search.setInput} />
+        }
       >
-        <CreateCardgroupSheetContent
-          submit={handleCreateCardgroup}
+        {initialLoading && (
+          <p className="text-sm text-muted-foreground" data-testid="cardgroups-loading">
+            {tCommon("loading")}
+          </p>
+        )}
+
+        {!initialLoading && edges.length === 0 && !hasSearch && (
+          <div
+            className="flex flex-col items-center gap-3 py-8 text-center"
+            data-testid="cardgroups-empty"
+          >
+            <p className="text-sm text-muted-foreground">{t("noCardgroupsYet")}</p>
+            <Button
+              type="button"
+              variant="brand"
+              onClick={openAddSheet}
+              data-testid="cardgroups-empty-cta"
+            >
+              <span>{t("newCardgroup")}</span>
+              <Plus aria-hidden="true" />
+            </Button>
+          </div>
+        )}
+
+        {!initialLoading && edges.length === 0 && hasSearch && (
+          <p className="text-sm text-muted-foreground" data-testid="cardgroups-empty-search">
+            {t("noMatch", { query: searchQuery })}
+          </p>
+        )}
+
+        {edges.length > 0 && (
+          <ul className="space-y-3" data-testid="cardgroups-list">
+            {edges.map((edge) => (
+              <CardgroupListItem
+                key={edge.node.id}
+                id={edge.node.id}
+                name={edge.node.name}
+                updatedAt={edge.node.updatedAt as string}
+                onDelete={handleDelete}
+              />
+            ))}
+          </ul>
+        )}
+
+        {deleteCommitError && (
+          <ErrorBanner className="mt-3" data-testid="cardgroups-delete-error">
+            {deleteCommitError}
+          </ErrorBanner>
+        )}
+
+        <div ref={sentinelRef} aria-hidden="true" data-testid="cardgroups-sentinel" />
+
+        {fetchMoreError && (
+          <ErrorBanner
+            className="mt-3 flex flex-col items-center gap-2"
+            data-testid="cardgroups-fetch-more-error"
+          >
+            <span>{fetchMoreError}</span>
+            <Button type="button" variant="outline" size="sm" onClick={retryFetchMore}>
+              {tCommon("retry")}
+            </Button>
+          </ErrorBanner>
+        )}
+
+        {!fetchMoreError && fetchingMore && hasNextPage && (
+          <p
+            className="mt-3 text-center text-xs text-muted-foreground"
+            data-testid="cardgroups-loading-more"
+          >
+            {t("loadingMore")}
+          </p>
+        )}
+
+        <FormSheet
+          title={t("newCardgroup")}
+          open={addOpen}
+          onOpenChange={(nextOpen) => {
+            setAddOpen(nextOpen);
+            if (!nextOpen) {
+              setAddDirty(false);
+              setAddValidationError(null);
+              setAddAuthError(null);
+              setAddUnexpectedError(null);
+              setAddLimitError(null);
+            }
+          }}
           submitting={creating}
-          validationError={addValidationError}
-          authError={addAuthError}
-          unexpectedError={addUnexpectedError}
-          limitError={addLimitError}
-          onDirty={() => setAddDirty(true)}
-        />
-      </FormSheet>
-    </ListingPageShell>
+          dirty={addDirty}
+          confirmOnDismiss
+          size="sm"
+        >
+          <CreateCardgroupSheetContent
+            submit={handleCreateCardgroup}
+            submitting={creating}
+            validationError={addValidationError}
+            authError={addAuthError}
+            unexpectedError={addUnexpectedError}
+            limitError={addLimitError}
+            onDirty={() => setAddDirty(true)}
+          />
+        </FormSheet>
+      </ListingPageShell>
+    </>
   );
 }

--- a/frontend/src/components/cardgroups/cardgroups-toolbar.tsx
+++ b/frontend/src/components/cardgroups/cardgroups-toolbar.tsx
@@ -15,7 +15,7 @@ export function CardgroupsToolbar({ searchInput, onSearchInputChange }: Cardgrou
   const t = useTranslations("Cardgroups");
 
   return (
-    <div className="mb-6">
+    <div className="mb-6 hidden md:block">
       <input
         type="search"
         placeholder={t("filterPlaceholder")}

--- a/frontend/src/components/nav/header-search-action.test.ts
+++ b/frontend/src/components/nav/header-search-action.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { resolveHeaderSearchAction } from "./header-search-action";
+
+describe("resolveHeaderSearchAction", () => {
+  it("returns true on /cardgroups", () => {
+    expect(resolveHeaderSearchAction("/cardgroups")).toBe(true);
+  });
+
+  it("returns false on non-filterable routes", () => {
+    expect(resolveHeaderSearchAction("/")).toBe(false);
+    expect(resolveHeaderSearchAction("/catalog")).toBe(false);
+    expect(resolveHeaderSearchAction("/admin/users")).toBe(false);
+    expect(resolveHeaderSearchAction("/cardgroups/123/edit")).toBe(false);
+    expect(resolveHeaderSearchAction("/learn/123")).toBe(false);
+  });
+});

--- a/frontend/src/components/nav/header-search-action.ts
+++ b/frontend/src/components/nav/header-search-action.ts
@@ -1,0 +1,15 @@
+/**
+ * Maps the current pathname to whether the mobile header should show the
+ * search (filter) trigger. Pure function — no React/Next imports, no side
+ * effects. Mirrors `resolveHeaderCreateAction`.
+ *
+ * Routing rules:
+ * - `/cardgroups` -> true (the filter lives here)
+ * - anything else -> false
+ *
+ * Built to extend: add routes here (and wire the page) when other list
+ * screens adopt the header-takeover filter.
+ */
+export function resolveHeaderSearchAction(pathname: string): boolean {
+  return pathname === "/cardgroups";
+}

--- a/frontend/src/components/nav/logo-drawer.test.tsx
+++ b/frontend/src/components/nav/logo-drawer.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { screen, within } from "@testing-library/react";
+import { act, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { renderWithIntl } from "@/test/render-with-intl";
@@ -399,5 +399,64 @@ describe("<LogoDrawer>", () => {
     renderWithIntl(<LogoDrawer user={SIGNED_IN_USER} isAdmin={false} />);
     expect(screen.getByRole("button", { name: /add new cardgroup/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Open menu" })).toBeInTheDocument();
+  });
+
+  it("shows the search trigger on /cardgroups and dispatches flamingo:open-search on click", async () => {
+    mockUsePathname.mockReturnValue("/cardgroups");
+    const user = userEvent.setup();
+    const openSpy = vi.fn();
+    window.addEventListener("flamingo:open-search", openSpy);
+    renderWithIntl(<LogoDrawer user={SIGNED_IN_USER} isAdmin={false} />);
+
+    await user.click(screen.getByRole("button", { name: "Filter cardgroups" }));
+
+    expect(openSpy).toHaveBeenCalledTimes(1);
+    window.removeEventListener("flamingo:open-search", openSpy);
+  });
+
+  it("hides the search trigger on a non-filterable route", () => {
+    mockUsePathname.mockReturnValue("/catalog");
+    renderWithIntl(<LogoDrawer user={SIGNED_IN_USER} isAdmin={false} />);
+
+    expect(screen.queryByRole("button", { name: "Filter cardgroups" })).not.toBeInTheDocument();
+  });
+
+  it("shows the active dot when search-state active is true", () => {
+    mockUsePathname.mockReturnValue("/cardgroups");
+    renderWithIntl(<LogoDrawer user={SIGNED_IN_USER} isAdmin={false} />);
+    expect(screen.queryByTestId("header-search-active-dot")).not.toBeInTheDocument();
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent("flamingo:search-state", {
+          detail: { active: true, visible: false },
+        }),
+      );
+    });
+
+    expect(screen.getByTestId("header-search-active-dot")).toBeInTheDocument();
+  });
+
+  it("returns focus to the trigger when the bar closes (visible true -> false)", () => {
+    mockUsePathname.mockReturnValue("/cardgroups");
+    renderWithIntl(<LogoDrawer user={SIGNED_IN_USER} isAdmin={false} />);
+    const trigger = screen.getByRole("button", { name: "Filter cardgroups" });
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent("flamingo:search-state", {
+          detail: { active: false, visible: true },
+        }),
+      );
+    });
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent("flamingo:search-state", {
+          detail: { active: false, visible: false },
+        }),
+      );
+    });
+
+    expect(trigger).toHaveFocus();
   });
 });

--- a/frontend/src/components/nav/logo-drawer.test.tsx
+++ b/frontend/src/components/nav/logo-drawer.test.tsx
@@ -449,6 +449,8 @@ describe("<LogoDrawer>", () => {
         }),
       );
     });
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+
     act(() => {
       window.dispatchEvent(
         new CustomEvent("flamingo:search-state", {
@@ -456,6 +458,7 @@ describe("<LogoDrawer>", () => {
         }),
       );
     });
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
 
     expect(trigger).toHaveFocus();
   });

--- a/frontend/src/components/nav/logo-drawer.tsx
+++ b/frontend/src/components/nav/logo-drawer.tsx
@@ -1,15 +1,17 @@
 "use client";
 
-import { BookOpen, LibraryBig, Plus, User } from "lucide-react";
+import { BookOpen, LibraryBig, Plus, Search, User } from "lucide-react";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
+import { useEffect, useRef, useState } from "react";
 import { LogoutButton } from "@/app/_components/logout-button";
 import { FlamingoMark } from "@/components/brand/flamingo-mark";
 import { MobileMenuTrigger } from "@/components/nav/mobile-menu-trigger";
 import { Sheet, SheetClose, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
 import { useSheetSearchParam } from "@/lib/url/use-sheet-search-param";
 import { resolveHeaderCreateAction } from "./header-create-action";
+import { resolveHeaderSearchAction } from "./header-search-action";
 import { HeaderSignInLink } from "./header-sign-in-link";
 import { ADMIN_NAV_ITEMS } from "./nav-items";
 
@@ -32,6 +34,31 @@ export function LogoDrawer({ user, isAdmin }: LogoDrawerProps) {
   const { open } = useSheetSearchParam();
   // Anonymous users get no '+'; the resolver returns null for unknown routes too.
   const createAction = user ? resolveHeaderCreateAction(pathname) : null;
+
+  const showSearch = user ? resolveHeaderSearchAction(pathname) : false;
+  const searchTriggerRef = useRef<HTMLButtonElement>(null);
+  const prevVisibleRef = useRef(false);
+  const [searchActive, setSearchActive] = useState(false);
+  const [searchVisible, setSearchVisible] = useState(false);
+
+  // The page owns the search bar + filter state; it reports back the active
+  // (filter applied) and visible (bar open) flags so the trigger can show the
+  // active dot and reflect aria-expanded. When the bar closes, return focus to
+  // the trigger.
+  useEffect(() => {
+    function onSearchState(e: Event) {
+      const detail = (e as CustomEvent<{ active: boolean; visible: boolean }>).detail;
+      if (!detail) return;
+      setSearchActive(detail.active);
+      setSearchVisible(detail.visible);
+      if (prevVisibleRef.current && !detail.visible) {
+        searchTriggerRef.current?.focus();
+      }
+      prevVisibleRef.current = detail.visible;
+    }
+    window.addEventListener("flamingo:search-state", onSearchState);
+    return () => window.removeEventListener("flamingo:search-state", onSearchState);
+  }, []);
 
   // The '+' affordance dispatches a cancelable event so an in-context drawer can
   // claim the action (LearnAddCardSheet / cardgroup / card sheets listen and call
@@ -98,6 +125,26 @@ export function LogoDrawer({ user, isAdmin }: LogoDrawerProps) {
         <FlamingoMark className="size-7" aria-hidden="true" />
       </Link>
       <div className="flex items-center gap-1">
+        {showSearch && (
+          <button
+            ref={searchTriggerRef}
+            type="button"
+            onClick={() => window.dispatchEvent(new CustomEvent("flamingo:open-search"))}
+            aria-label={t("openSearch")}
+            aria-expanded={searchVisible}
+            data-testid="header-search-trigger"
+            className="relative rounded-md p-2 hover:bg-accent focus:outline-none focus:ring-2 focus:ring-ring"
+          >
+            <Search className="h-5 w-5" aria-hidden="true" />
+            {searchActive && (
+              <span
+                aria-hidden="true"
+                data-testid="header-search-active-dot"
+                className="absolute right-1 top-1 h-2 w-2 rounded-full bg-brand-primary"
+              />
+            )}
+          </button>
+        )}
         {createAction && (
           <button
             type="button"

--- a/frontend/src/components/search/search-takeover-bar.test.tsx
+++ b/frontend/src/components/search/search-takeover-bar.test.tsx
@@ -1,0 +1,73 @@
+// @vitest-environment jsdom
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { renderWithIntl } from "@/test/render-with-intl";
+import { SearchTakeoverBar } from "./search-takeover-bar";
+
+afterEach(() => vi.restoreAllMocks());
+
+function baseProps() {
+  return {
+    open: true,
+    value: "",
+    onChange: vi.fn(),
+    onClear: vi.fn(),
+    onClose: vi.fn(),
+    placeholder: "Filter cardgroups...",
+    ariaLabel: "Filter cardgroups",
+  };
+}
+
+describe("<SearchTakeoverBar>", () => {
+  it("renders nothing when closed", () => {
+    renderWithIntl(<SearchTakeoverBar {...baseProps()} open={false} />);
+    expect(screen.queryByTestId("search-takeover")).not.toBeInTheDocument();
+  });
+
+  it("renders a search landmark and autofocuses the input when open", () => {
+    renderWithIntl(<SearchTakeoverBar {...baseProps()} />);
+    expect(screen.getByRole("search")).toBeInTheDocument();
+    const input = screen.getByTestId("search-takeover-input");
+    expect(input).toHaveFocus();
+    expect(input).toHaveAttribute("aria-label", "Filter cardgroups");
+  });
+
+  it("calls onChange on keystroke", async () => {
+    const user = userEvent.setup();
+    const props = baseProps();
+    renderWithIntl(<SearchTakeoverBar {...props} />);
+    await user.type(screen.getByTestId("search-takeover-input"), "a");
+    expect(props.onChange).toHaveBeenCalled();
+  });
+
+  it("hides the clear button when value is empty", () => {
+    renderWithIntl(<SearchTakeoverBar {...baseProps()} value="" />);
+    expect(screen.queryByRole("button", { name: "Clear search" })).not.toBeInTheDocument();
+  });
+
+  it("shows and fires the clear button when value is non-empty", async () => {
+    const user = userEvent.setup();
+    const props = baseProps();
+    renderWithIntl(<SearchTakeoverBar {...props} value="deck" />);
+    const clearBtn = screen.getByRole("button", { name: "Clear search" });
+    await user.click(clearBtn);
+    expect(props.onClear).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onClose from the back button", async () => {
+    const user = userEvent.setup();
+    const props = baseProps();
+    renderWithIntl(<SearchTakeoverBar {...props} />);
+    await user.click(screen.getByRole("button", { name: "Close search" }));
+    expect(props.onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onClose on Escape", async () => {
+    const user = userEvent.setup();
+    const props = baseProps();
+    renderWithIntl(<SearchTakeoverBar {...props} />);
+    await user.keyboard("{Escape}");
+    expect(props.onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/components/search/search-takeover-bar.tsx
+++ b/frontend/src/components/search/search-takeover-bar.tsx
@@ -59,6 +59,7 @@ export function SearchTakeoverBar({
   if (!open) return null;
 
   return (
+    // biome-ignore lint/a11y/useSemanticElements: the <search> element is not yet mapped to role "search" by the installed aria-query, breaking getByRole("search") in vitest; role="search" on a div is a valid ARIA landmark.
     <div
       role="search"
       data-testid="search-takeover"
@@ -68,6 +69,7 @@ export function SearchTakeoverBar({
         type="button"
         onClick={onClose}
         aria-label={t("back")}
+        data-testid="search-takeover-close"
         className="rounded-md p-2 hover:bg-accent focus:outline-none focus:ring-2 focus:ring-ring"
       >
         <ArrowLeft className="h-5 w-5" aria-hidden="true" />

--- a/frontend/src/components/search/search-takeover-bar.tsx
+++ b/frontend/src/components/search/search-takeover-bar.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { ArrowLeft, Search, X } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { useEffect, useRef } from "react";
+
+interface SearchTakeoverBarProps {
+  /** Whether the bar is shown. When false the component renders nothing. */
+  open: boolean;
+  /** Current (immediate) input value. */
+  value: string;
+  /** Called on every keystroke with the new value. */
+  onChange: (value: string) => void;
+  /** Clears the field (resets the underlying query). */
+  onClear: () => void;
+  /** Closes the bar (back button / Escape). */
+  onClose: () => void;
+  /** Field placeholder — caller-specific copy. */
+  placeholder: string;
+  /** Field aria-label — caller-specific copy. */
+  ariaLabel: string;
+}
+
+/**
+ * Full-width search bar that slides over the mobile global header
+ * ("header takeover"). Mobile only (`md:hidden`). Presentational: it owns no
+ * filter state — the caller wires `value`/`onChange` to its
+ * `useDebouncedSearch` instance. Used by `/cardgroups`; built to extend to
+ * other list screens.
+ */
+export function SearchTakeoverBar({
+  open,
+  value,
+  onChange,
+  onClear,
+  onClose,
+  placeholder,
+  ariaLabel,
+}: SearchTakeoverBarProps) {
+  const t = useTranslations("Search");
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Move focus into the field when the bar opens.
+  useEffect(() => {
+    if (open) inputRef.current?.focus();
+  }, [open]);
+
+  // Close on Escape even if focus has left the input (e.g. user scrolled
+  // results). Window-level so the key works regardless of focus target.
+  useEffect(() => {
+    if (!open) return;
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      role="search"
+      data-testid="search-takeover"
+      className="fixed inset-x-0 top-0 z-50 flex h-12 items-center gap-1 border-b bg-background px-2 md:hidden motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-top-2 motion-safe:duration-200"
+    >
+      <button
+        type="button"
+        onClick={onClose}
+        aria-label={t("back")}
+        className="rounded-md p-2 hover:bg-accent focus:outline-none focus:ring-2 focus:ring-ring"
+      >
+        <ArrowLeft className="h-5 w-5" aria-hidden="true" />
+      </button>
+      <div className="relative flex-1">
+        <Search
+          className="pointer-events-none absolute left-2 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+          aria-hidden="true"
+        />
+        <input
+          ref={inputRef}
+          type="search"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={placeholder}
+          aria-label={ariaLabel}
+          data-testid="search-takeover-input"
+          className="w-full rounded-md border border-input bg-background py-2 pl-8 pr-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        />
+      </div>
+      {value !== "" && (
+        <button
+          type="button"
+          onClick={onClear}
+          aria-label={t("clear")}
+          className="rounded-md p-2 hover:bg-accent focus:outline-none focus:ring-2 focus:ring-ring"
+        >
+          <X className="h-5 w-5" aria-hidden="true" />
+        </button>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

On mobile (`<md`), the `/cardgroups` filter collapses into a magnifier icon in the global header; tapping it slides a full-width search bar over the header row ("header takeover"), and the list filters live as you type. Desktop (`md+`) keeps the existing inline filter field. The header holds the trigger only — the page keeps sole ownership of the filter state — and the two halves talk through window events, mirroring the existing add-card "+".

No related issue — UI change from a design brainstorm.

## Background / Motivation

- On `/cardgroups` the filter was a permanently-visible full-width input below the page title, eating a row of mobile viewport before any cardgroup showed.
- The filter is a name-substring filter over the user's own decks (`useDebouncedSearch` → the `search` variable), not a global search — it belongs to the page, not the global nav, so any collapse mechanism must keep filter state out of the shared header.
- The global mobile header already routes a route-aware "+" through a `flamingo:*` window event (`LogoDrawer` lives in the app shell with no React prop path to the page), giving an established pattern for a header trigger that drives page behavior.

## Design — per-boundary wiring

The trigger lives in the shell and the search bar lives in the page, so the two halves cross the shell→page boundary the same way add-card does:

- `LogoDrawer` (app shell) renders a **trigger only**, route-gated by `resolveHeaderSearchAction(pathname)` (currently `/cardgroups`). Tapping it dispatches a `flamingo:open-search` window event.
- `CardgroupsClient` (page) claims the event, opens `SearchTakeoverBar`, and wires it to its single existing `useDebouncedSearch` instance. It dispatches `flamingo:search-state` `{ active, visible }` back so the header can show the active dot, reflect `aria-expanded`, and return focus to the trigger when the bar closes.
- Filter state never enters the header: the header holds only two UI-mirror booleans.

## Changes

### Header search trigger

- `nav/header-search-action.ts` (new) — pure `resolveHeaderSearchAction(pathname): boolean`, true only for `/cardgroups`; mirrors `header-create-action.ts`, built to extend.
- `nav/logo-drawer.tsx` — on a filterable route the header renders a magnifier trigger (`header-search-trigger`, `aria-label` from `Nav.openSearch`, `aria-expanded`) left of the "+". Click dispatches `flamingo:open-search`. A `flamingo:search-state` listener drives a coral active dot (`bg-brand-primary`, `header-search-active-dot`), `aria-expanded`, and focus-return to the trigger on the bar's `visible` true→false edge.

### Search takeover bar

- `components/search/search-takeover-bar.tsx` (new) — presentational, reusable full-width bar that overlays the header row (`fixed top-0`, `md:hidden`, `motion-safe:` slide+fade, no layout shift). Back button / autofocused input / conditional clear button. `role="search"` carries a load-bearing `biome-ignore lint/a11y/useSemanticElements` — the installed `aria-query` does not map the native `<search>` element to role `search`, which would break `getByRole("search")` in vitest. Owns no filter state; `value` / `onChange` / `onClear` / `onClose` are props.

### Cardgroups page wiring

- `app/cardgroups/cardgroups-client.tsx` — subscribes to `flamingo:open-search` (opens the bar), dispatches `flamingo:search-state` on query/open change plus a reset on unmount, and renders `SearchTakeoverBar` wired to `useDebouncedSearch`. `onClose` is a stable `useCallback` to avoid the bar's Escape-listener churning on keystroke re-renders. Closing keeps a non-empty filter applied; `×` clears.
- `components/cardgroups/cardgroups-toolbar.tsx` — the inline filter field becomes `hidden md:block` (desktop only); mobile relies on the takeover. Both bind the same `useDebouncedSearch`, so a query survives an md-boundary resize.

### i18n

- `messages/en.json`, `messages/ja.json` — new `Nav.openSearch` and `Search.back` / `Search.clear` keys in both catalogs; placeholder / aria reuse the existing `Cardgroups.filterPlaceholder` / `filterAriaLabel`.

### Tests

- `nav/header-search-action.test.ts` (new) — route resolution (`/cardgroups` true; others false).
- `components/search/search-takeover-bar.test.tsx` (new) — `role="search"`, autofocus, Escape, conditional clear, back.
- `nav/logo-drawer.test.tsx` — trigger render + `flamingo:open-search` dispatch, hidden on non-filterable routes, active dot, `aria-expanded` transition, focus-return.
- `app/cardgroups/cardgroups-client.test.tsx` — `flamingo:open-search` opens the bar; `flamingo:search-state` dispatched on mount.
- `e2e/cardgroups-mobile-search.spec.ts` (new) — 390px-viewport Playwright flow: open from the header, filter, close, active dot persists; selects by `data-testid` (e2e renders in `ja-JP`).

## Verification

Full frontend gate, all green:

```bash
cd frontend && pnpm typecheck && pnpm lint && pnpm knip && pnpm test && pnpm build
```

- typecheck ✓ · lint ✓ (biome `--error-on-warnings`; one pre-existing `biome.json` schema-version info only) · knip ✓ · test ✓ (1494 passing, 160 files) · build ✓
- New i18n keys added to both catalogs; CJK / English-only grep on changed source: no output.

Runtime handles: header trigger `header-search-trigger` (+ `header-search-active-dot`); the bar `search-takeover` with input `search-takeover-input` and close `search-takeover-close`.

## Test plan

- [ ] CI gate (typecheck / lint / knip / test / build) green.
- [ ] `/cardgroups` on mobile (`<md`) — a 🔍 sits left of the "+"; the in-content filter field is gone; tapping 🔍 slides a full-width search bar over the header with a back arrow and an autofocused input.
- [ ] Type in the bar — the list filters live; clearing via `×` restores the full list.
- [ ] Close via back / Escape — the bar hides with no layout shift; a non-empty query stays applied and the 🔍 shows a coral dot; reopening restores the text.
- [ ] `/cardgroups` on desktop (`md+`) — unchanged: the inline filter field renders, no header 🔍.
- [ ] Another route (e.g. `/catalog`) on mobile — no 🔍 in the header (route-gated).
