### PR TITLE
feat(frontend): give the mobile search takeover bar more vertical room

### DIFF
--- a/frontend/src/components/search/search-takeover-bar.tsx
+++ b/frontend/src/components/search/search-takeover-bar.tsx
@@ -63,7 +63,7 @@ export function SearchTakeoverBar({
     <div
       role="search"
       data-testid="search-takeover"
-      className="fixed inset-x-0 top-0 z-50 flex h-12 items-center gap-1 border-b bg-background px-2 md:hidden motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-top-2 motion-safe:duration-200"
+      className="fixed inset-x-0 top-0 z-50 flex h-14 items-center gap-2 border-b bg-background px-3 md:hidden motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-top-2 motion-safe:duration-200"
     >
       <button
         type="button"
@@ -87,7 +87,7 @@ export function SearchTakeoverBar({
           placeholder={placeholder}
           aria-label={ariaLabel}
           data-testid="search-takeover-input"
-          className="w-full rounded-md border border-input bg-background py-2 pl-8 pr-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          className="w-full rounded-md border border-input bg-background py-2.5 pl-8 pr-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
         />
       </div>
       {value !== "" && (


### PR DESCRIPTION
## Summary

The mobile `/cardgroups` search takeover bar was cramped at the same `h-12` as the global header. This gives the bar — and only the bar, while search is open — more vertical and horizontal room. The normal header height is unchanged.

No related issue — UI polish follow-up to #551.

## Background / Motivation

- The takeover bar matched the global mobile header's tight `h-12` with only `px-2` / `gap-1`, so the search field and its back / clear controls felt cramped.
- The bar is a separate `fixed top-0` overlay from the normal header (`app-shell.tsx`, `h-12`), so its height can change independently — the extra room appears only in search mode and reverts on close.

## Changes

### Search takeover bar spacing

- `components/search/search-takeover-bar.tsx` — root: `h-12` → `h-14`, `px-2` → `px-3`, `gap-1` → `gap-2`; input: `py-2` → `py-2.5`. The normal mobile header is untouched, so only the search overlay gets the extra room. No layout shift (the bar is a fixed overlay and unmounts on close); at `h-14` it extends ~8px below the 48px header line while open.

## Verification

- typecheck ✓ · lint ✓ (biome `--error-on-warnings`; pre-existing `biome.json` schema-version info only) · test ✓ (1494 passing, 160 files)
- Runtime: open the header 🔍 on `/cardgroups` mobile — the search bar is now `h-14` with roomier padding; closing returns to the normal `h-12` header. The existing `search-takeover` / `search-takeover-input` testids are unchanged.

## Test plan

- [ ] `/cardgroups` on mobile (`<md`) — tap 🔍; the takeover bar is taller and roomier than before, and back / input / clear are no longer cramped.
- [ ] Close via back / Escape — returns to the normal-height header with no layout shift.
- [ ] `/cardgroups` on desktop (`md+`) — unchanged (inline filter field, no takeover).
