### PR TITLE
style(frontend): increase mobile search takeover bar height to h-18

### DIFF
--- a/frontend/src/components/search/search-takeover-bar.tsx
+++ b/frontend/src/components/search/search-takeover-bar.tsx
@@ -63,7 +63,7 @@ export function SearchTakeoverBar({
     <div
       role="search"
       data-testid="search-takeover"
-      className="fixed inset-x-0 top-0 z-50 flex h-12 items-center gap-1 border-b bg-background px-2 md:hidden motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-top-2 motion-safe:duration-200"
+      className="fixed inset-x-0 top-0 z-50 flex h-18 items-center gap-1 border-b bg-background px-2 md:hidden motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-top-2 motion-safe:duration-200"
     >
       <button
         type="button"


### PR DESCRIPTION
## Summary

Increase the mobile search takeover bar height from `h-12` (48px) to `h-18` (72px) so the search input and its controls sit in a more comfortable, tappable header band on small screens.

## Changes

- `frontend/src/components/search/search-takeover-bar.tsx`: bump the takeover container from `h-12` to `h-18`. All other layout/animation classes are unchanged.

## Test plan

- Tailwind v4 (4.3.0) dynamic spacing: `h-18` resolves to 4.5rem (72px); no `tailwind.config` change is required.
- No test asserts on the bar height, so the existing search-takeover specs are unaffected.
- Manual check on a mobile viewport recommended to confirm the taller bar.

No related GitHub issue.
