### PR TITLE
refactor(frontend): extract useHeaderTakeoverSearch hook + data-drive header search matcher

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -28,7 +28,7 @@
     "flamingoHome": "Flamingo home",
     "navigationMenu": "Navigation menu",
     "openMenu": "Open menu",
-    "openSearch": "Filter cardgroups",
+    "openSearch": "Search",
     "primaryNavigation": "Primary navigation"
   },
   "Language": {

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -28,7 +28,7 @@
     "flamingoHome": "Flamingo ホーム",
     "navigationMenu": "ナビゲーションメニュー",
     "openMenu": "メニューを開く",
-    "openSearch": "カードグループを絞り込む",
+    "openSearch": "検索",
     "primaryNavigation": "メインナビゲーション"
   },
   "Language": {

--- a/frontend/src/app/cardgroups/cardgroups-client.tsx
+++ b/frontend/src/app/cardgroups/cardgroups-client.tsx
@@ -19,7 +19,7 @@ import {
   type MyCardgroupsConnectionQuery,
   type MyCardgroupsConnectionQueryVariables,
 } from "@/generated/graphql";
-import { useDebouncedSearch } from "@/hooks/use-debounced-search";
+import { useHeaderTakeoverSearch } from "@/hooks/use-header-takeover-search";
 import { getBackendErrorBanner } from "@/lib/apollo/errors";
 import { useConnectionPagination } from "@/lib/pagination/use-connection-pagination";
 import { useUndoDelete } from "@/lib/undo-delete";
@@ -139,40 +139,8 @@ export default function CardgroupsClient({ initialConnection }: CardgroupsClient
   const apollo = useApolloClient();
   const t = useTranslations("Cardgroups");
   const tCommon = useTranslations("Common");
-  const search = useDebouncedSearch();
+  const search = useHeaderTakeoverSearch();
   const searchQuery = search.query;
-  const [searchOpen, setSearchOpen] = useState(false);
-
-  // The nav-header search trigger dispatches this; open the takeover in place.
-  useEffect(() => {
-    function handleOpenSearch() {
-      setSearchOpen(true);
-    }
-    window.addEventListener("flamingo:open-search", handleOpenSearch);
-    return () => window.removeEventListener("flamingo:open-search", handleOpenSearch);
-  }, []);
-
-  // Report filter state back to the header trigger (active dot + aria-expanded).
-  useEffect(() => {
-    window.dispatchEvent(
-      new CustomEvent("flamingo:search-state", {
-        detail: { active: searchQuery !== null && searchQuery !== "", visible: searchOpen },
-      }),
-    );
-  }, [searchQuery, searchOpen]);
-
-  // Reset the header trigger when leaving /cardgroups.
-  useEffect(() => {
-    return () => {
-      window.dispatchEvent(
-        new CustomEvent("flamingo:search-state", {
-          detail: { active: false, visible: false },
-        }),
-      );
-    };
-  }, []);
-
-  const closeSearch = useCallback(() => setSearchOpen(false), []);
 
   const [deleteCommitError, setDeleteCommitError] = useState<string | null>(null);
 
@@ -373,11 +341,11 @@ export default function CardgroupsClient({ initialConnection }: CardgroupsClient
   return (
     <>
       <SearchTakeoverBar
-        open={searchOpen}
+        open={search.searchOpen}
         value={search.input}
         onChange={search.setInput}
         onClear={search.clear}
-        onClose={closeSearch}
+        onClose={search.closeSearch}
         placeholder={t("filterPlaceholder")}
         ariaLabel={t("filterAriaLabel")}
       />

--- a/frontend/src/components/nav/header-search-action.ts
+++ b/frontend/src/components/nav/header-search-action.ts
@@ -1,15 +1,21 @@
+// Exact-match routes that show the mobile header search trigger.
+const SEARCH_EXACT = new Set<string>(["/cardgroups"]);
+// Pattern routes (e.g. parameterized segments) that show the trigger.
+const SEARCH_PATTERNS: RegExp[] = [];
+
 /**
  * Maps the current pathname to whether the mobile header should show the
  * search (filter) trigger. Pure function — no React/Next imports, no side
- * effects. Mirrors `resolveHeaderCreateAction`.
+ * effects. Mirrors `resolveHeaderCreateAction`'s exact-set + regex-array shape.
  *
  * Routing rules:
  * - `/cardgroups` -> true (the filter lives here)
  * - anything else -> false
  *
- * Built to extend: add routes here (and wire the page) when other list
- * screens adopt the header-takeover filter.
+ * Built to extend: add routes to `SEARCH_EXACT` / `SEARCH_PATTERNS` (and wire
+ * the page) when other list screens adopt the header-takeover filter.
  */
 export function resolveHeaderSearchAction(pathname: string): boolean {
-  return pathname === "/cardgroups";
+  if (SEARCH_EXACT.has(pathname)) return true;
+  return SEARCH_PATTERNS.some((re) => re.test(pathname));
 }

--- a/frontend/src/components/nav/logo-drawer.test.tsx
+++ b/frontend/src/components/nav/logo-drawer.test.tsx
@@ -408,7 +408,7 @@ describe("<LogoDrawer>", () => {
     window.addEventListener("flamingo:open-search", openSpy);
     renderWithIntl(<LogoDrawer user={SIGNED_IN_USER} isAdmin={false} />);
 
-    await user.click(screen.getByRole("button", { name: "Filter cardgroups" }));
+    await user.click(screen.getByRole("button", { name: "Search" }));
 
     expect(openSpy).toHaveBeenCalledTimes(1);
     window.removeEventListener("flamingo:open-search", openSpy);
@@ -418,7 +418,7 @@ describe("<LogoDrawer>", () => {
     mockUsePathname.mockReturnValue("/catalog");
     renderWithIntl(<LogoDrawer user={SIGNED_IN_USER} isAdmin={false} />);
 
-    expect(screen.queryByRole("button", { name: "Filter cardgroups" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Search" })).not.toBeInTheDocument();
   });
 
   it("shows the active dot when search-state active is true", () => {
@@ -440,7 +440,7 @@ describe("<LogoDrawer>", () => {
   it("returns focus to the trigger when the bar closes (visible true -> false)", () => {
     mockUsePathname.mockReturnValue("/cardgroups");
     renderWithIntl(<LogoDrawer user={SIGNED_IN_USER} isAdmin={false} />);
-    const trigger = screen.getByRole("button", { name: "Filter cardgroups" });
+    const trigger = screen.getByRole("button", { name: "Search" });
 
     act(() => {
       window.dispatchEvent(

--- a/frontend/src/hooks/use-header-takeover-search.test.tsx
+++ b/frontend/src/hooks/use-header-takeover-search.test.tsx
@@ -1,0 +1,108 @@
+// @vitest-environment jsdom
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useHeaderTakeoverSearch } from "./use-header-takeover-search";
+
+type SearchStateDetail = { active: boolean; visible: boolean };
+
+// Capture every flamingo:search-state detail the hook dispatches.
+function listenSearchState() {
+  const calls: SearchStateDetail[] = [];
+  function onState(e: Event) {
+    calls.push((e as CustomEvent<SearchStateDetail>).detail);
+  }
+  window.addEventListener("flamingo:search-state", onState);
+  return {
+    calls,
+    stop: () => window.removeEventListener("flamingo:search-state", onState),
+  };
+}
+
+describe("useHeaderTakeoverSearch", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("initial state", () => {
+    it("starts closed and dispatches search-state {active:false, visible:false} on mount", () => {
+      const state = listenSearchState();
+      const { result } = renderHook(() => useHeaderTakeoverSearch());
+
+      expect(result.current.searchOpen).toBe(false);
+      expect(state.calls).toContainEqual({ active: false, visible: false });
+      state.stop();
+    });
+  });
+
+  describe("flamingo:open-search", () => {
+    it("opens the takeover when the header trigger dispatches the event", () => {
+      const { result } = renderHook(() => useHeaderTakeoverSearch());
+
+      act(() => {
+        window.dispatchEvent(new CustomEvent("flamingo:open-search"));
+      });
+
+      expect(result.current.searchOpen).toBe(true);
+    });
+  });
+
+  describe("search-state reporting", () => {
+    it("dispatches {active:true} after a non-empty query debounces", () => {
+      vi.useFakeTimers();
+      const state = listenSearchState();
+      const { result } = renderHook(() => useHeaderTakeoverSearch());
+
+      act(() => {
+        result.current.setInput("hello");
+      });
+      act(() => {
+        vi.advanceTimersByTime(300);
+      });
+
+      expect(state.calls).toContainEqual({ active: true, visible: false });
+      state.stop();
+    });
+
+    it("reports visible:true while the bar is open", () => {
+      const state = listenSearchState();
+      renderHook(() => useHeaderTakeoverSearch());
+
+      act(() => {
+        window.dispatchEvent(new CustomEvent("flamingo:open-search"));
+      });
+
+      expect(state.calls).toContainEqual({ active: false, visible: true });
+      state.stop();
+    });
+  });
+
+  describe("closeSearch", () => {
+    it("closes the takeover", () => {
+      const { result } = renderHook(() => useHeaderTakeoverSearch());
+
+      act(() => {
+        window.dispatchEvent(new CustomEvent("flamingo:open-search"));
+      });
+      expect(result.current.searchOpen).toBe(true);
+
+      act(() => {
+        result.current.closeSearch();
+      });
+      expect(result.current.searchOpen).toBe(false);
+    });
+  });
+
+  describe("unmount", () => {
+    it("resets the header trigger with {active:false, visible:false}", () => {
+      const { unmount } = renderHook(() => useHeaderTakeoverSearch());
+      const state = listenSearchState();
+
+      act(() => {
+        unmount();
+      });
+
+      expect(state.calls).toContainEqual({ active: false, visible: false });
+      state.stop();
+    });
+  });
+});

--- a/frontend/src/hooks/use-header-takeover-search.ts
+++ b/frontend/src/hooks/use-header-takeover-search.ts
@@ -1,0 +1,56 @@
+import { useCallback, useEffect, useState } from "react";
+import { type UseDebouncedSearchResult, useDebouncedSearch } from "./use-debounced-search";
+
+export interface UseHeaderTakeoverSearchResult extends UseDebouncedSearchResult {
+  /** Whether the mobile takeover bar is open. */
+  searchOpen: boolean;
+  /** Closes the takeover bar (back button / Escape). */
+  closeSearch: () => void;
+}
+
+/**
+ * Bundles useDebouncedSearch with the mobile header-takeover event-bus wiring:
+ * listens for `flamingo:open-search` (header magnifier -> open bar), dispatches
+ * `flamingo:search-state` (bar visibility + filter-active -> header trigger), and
+ * resets the trigger on unmount. The page renders <SearchTakeoverBar> with the
+ * returned { searchOpen, input, setInput, clear, closeSearch }.
+ */
+export function useHeaderTakeoverSearch(opts?: {
+  delayMs?: number;
+}): UseHeaderTakeoverSearchResult {
+  const search = useDebouncedSearch(opts);
+  const searchQuery = search.query;
+  const [searchOpen, setSearchOpen] = useState(false);
+
+  // Header magnifier -> open the takeover in place.
+  useEffect(() => {
+    function handleOpenSearch() {
+      setSearchOpen(true);
+    }
+    window.addEventListener("flamingo:open-search", handleOpenSearch);
+    return () => window.removeEventListener("flamingo:open-search", handleOpenSearch);
+  }, []);
+
+  // Report filter state back to the header trigger (active dot + aria-expanded).
+  useEffect(() => {
+    window.dispatchEvent(
+      new CustomEvent("flamingo:search-state", {
+        detail: { active: searchQuery !== null && searchQuery !== "", visible: searchOpen },
+      }),
+    );
+  }, [searchQuery, searchOpen]);
+
+  // Reset the header trigger when the page unmounts (route leave).
+  useEffect(() => {
+    return () => {
+      window.dispatchEvent(
+        new CustomEvent("flamingo:search-state", {
+          detail: { active: false, visible: false },
+        }),
+      );
+    };
+  }, []);
+
+  const closeSearch = useCallback(() => setSearchOpen(false), []);
+  return { ...search, searchOpen, closeSearch };
+}


### PR DESCRIPTION
## Summary

Extract the mobile **header-takeover search** wiring (event bus + open-state + debounce) that lived inline in `/cardgroups` into a single reusable hook, so the other list screens can adopt it with a one-line swap. This is **behavior-preserving** for `/cardgroups` and is the keystone the two rollout PRs depend on.

The search filter already worked on all five target screens (backend `search` arg + `useDebouncedSearch` + `useConnectionPagination`). What was not shared was the mobile header-magnifier UX and the ~30 lines of event-bus boilerplate in `cardgroups-client.tsx`.

Closes #554

## Changes

### New hook

- `frontend/src/hooks/use-header-takeover-search.ts` — wraps `useDebouncedSearch` with the header-takeover event-bus wiring: listens for `flamingo:open-search` (magnifier → open bar), dispatches `flamingo:search-state` (bar visibility + filter-active → header trigger), resets the trigger on unmount. Returns `{ ...debouncedSearch, searchOpen, closeSearch }`.
- `frontend/src/hooks/use-header-takeover-search.test.tsx` — co-located test: open-search opens the bar, mount/unmount dispatch `{ active:false, visible:false }`, a debounced non-empty query reports `{ active:true }`, `visible:true` while open, `closeSearch()` closes.

### Adopt the hook + data-drive the matcher

- `frontend/src/app/cardgroups/cardgroups-client.tsx` — replaces the inline `useDebouncedSearch` + three `flamingo:` effects + `searchOpen` state + `closeSearch` with `const search = useHeaderTakeoverSearch();`. `<SearchTakeoverBar>` now reads `open={search.searchOpen}` / `onClose={search.closeSearch}`. The unrelated `flamingo:add-cardgroup` create-drawer wiring is untouched.
- `frontend/src/components/nav/header-search-action.ts` — converts the single `=== "/cardgroups"` check into the extensible `SEARCH_EXACT` set + `SEARCH_PATTERNS` array, mirroring `header-create-action.ts`. Seeded with only `/cardgroups`; matcher behavior unchanged.

### Generalize the search i18n label

- `frontend/messages/en.json` / `ja.json` — `Nav.openSearch`: `"Filter cardgroups"` → `"Search"`, `"カードグループを絞り込む"` → `"検索"`. The aria-label is now shared across all five screens, so it must be generic.
- `frontend/src/components/nav/logo-drawer.test.tsx` — updates the 3 aria-label assertions (`"Filter cardgroups"` → `"Search"`) that track the renamed label.

## Verification

- typecheck ✓ (`tsc --noEmit`)
- lint ✓ (`biome check --error-on-warnings`, no warnings)
- knip ✓ (no unused exports)
- test ✓ **1500 passing (161 files)** — including the behavior-preservation guards (`cardgroups-client.test.tsx` event-bus tests, `logo-drawer.test.tsx`)
- build ✓ (`next build`)
- i18n parity ✓ (355 keys both catalogs)

The e2e spec `frontend/e2e/cardgroups-mobile-search.spec.ts` selects by `data-testid` (`header-search-trigger` / `search-takeover-*`), so the aria-label rename does not affect it; it continues to guard the extraction end-to-end.

## Test plan

- [ ] `/cardgroups` on mobile (`<md`) — tap the header 🔍; the takeover bar opens, filters live as you type, the active dot shows while a query is set, and back / Escape closes the bar. Identical to before.
- [ ] `/cardgroups` on desktop (`md+`) — unchanged inline filter field.

## Dependency

Keystone PR. Blocks the two rollout PRs (#555 / #556) — must merge first.
