### PR TITLE
feat(frontend): roll out header-takeover search to cardgroup and master cards

### DIFF
--- a/frontend/e2e/admin-masters-edit.spec.ts
+++ b/frontend/e2e/admin-masters-edit.spec.ts
@@ -60,6 +60,14 @@ test.describe("admin master card CRUD", () => {
     // Assert the new card row is now visible in the list.
     await expect(page.getByText(cardFront)).toBeVisible({ timeout: 10_000 });
 
+    // Wait for the add-card sheet to finish its close animation and unmount
+    // before opening the edit sheet. The add and edit sheets share the same
+    // [id$="-back-field"] / form-sheet-body submit shape, so while the add sheet
+    // lingers mid-exit the edit-step locators below would match two elements
+    // (strict-mode violation). Gating on the add field's removal makes the edit
+    // step deterministic.
+    await expect(page.locator("#add-card-back-field")).toHaveCount(0);
+
     // EDIT: click the card's edit-target div to open the edit sheet, change back text, save.
     const editedBack = "e2eback-edited";
     // Locate the card row by front text and click its edit-target.

--- a/frontend/src/app/admin/masters/[id]/edit/cards/master-cards-client.test.tsx
+++ b/frontend/src/app/admin/masters/[id]/edit/cards/master-cards-client.test.tsx
@@ -237,3 +237,29 @@ describe("<MasterCardsClient>", () => {
     expect(banner).not.toHaveTextContent("Could not load more cards");
   });
 });
+
+// ---------------------------------------------------------------------------
+// Mobile search takeover — flamingo:open-search
+// ---------------------------------------------------------------------------
+
+describe("<MasterCardsClient> mobile search takeover", () => {
+  it("opens the takeover on flamingo:open-search and renders the input", async () => {
+    renderClient();
+    await screen.findByText("apple");
+
+    expect(screen.queryByTestId("search-takeover")).not.toBeInTheDocument();
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent("flamingo:open-search"));
+    });
+
+    expect(screen.getByTestId("search-takeover")).toBeInTheDocument();
+    expect(screen.getByTestId("search-takeover-input")).toBeInTheDocument();
+  });
+
+  it("hides the desktop search input on mobile via hidden md:block", () => {
+    renderClient();
+    const wrapper = screen.getByTestId("cards-search-input").closest("div.mb-3");
+    expect(wrapper).toHaveClass("hidden", "md:block");
+  });
+});

--- a/frontend/src/app/admin/masters/[id]/edit/cards/master-cards-client.tsx
+++ b/frontend/src/app/admin/masters/[id]/edit/cards/master-cards-client.tsx
@@ -8,12 +8,13 @@ import { BulkActionBar } from "@/components/cardgroups/bulk-action-bar";
 import { CardForm } from "@/components/cardgroups/card-form";
 import { CardRow } from "@/components/cardgroups/card-row";
 import type { SwipeableRowHandle } from "@/components/cardgroups/swipeable-row";
+import { SearchTakeoverBar } from "@/components/search/search-takeover-bar";
 import { Button } from "@/components/ui/button";
 import { ErrorBanner } from "@/components/ui/error-banner";
 import { FormSheet, useFormSheetClose } from "@/components/ui/form-sheet";
 import type { AdminMasterCardsConnectionQuery } from "@/generated/graphql";
 import { useBulkSelection } from "@/hooks/use-bulk-selection";
-import { useDebouncedSearch } from "@/hooks/use-debounced-search";
+import { useHeaderTakeoverSearch } from "@/hooks/use-header-takeover-search";
 import { getBackendErrorBanner } from "@/lib/apollo/errors";
 import { MasterBatchImportForm } from "./master-batch-import-form";
 import { useMasterCardMutations } from "./use-master-card-mutations";
@@ -41,7 +42,8 @@ const FetchMoreError = ({ message, onRetry }: { message: string; onRetry: () => 
 const SearchInput = ({ value, onChange }: { value: string; onChange: (next: string) => void }) => {
   const t = useTranslations("Cards");
   return (
-    <div className="mb-3">
+    // Desktop only: on mobile the search moves into the header-takeover bar.
+    <div className="mb-3 hidden md:block">
       <div className="relative">
         <Search
           aria-hidden="true"
@@ -197,7 +199,7 @@ export function MasterCardsClient({
   // Per-card SwipeableRow handles; lets a row close any half-open sibling.
   const rowRefs = useRef<Map<string, RefObject<SwipeableRowHandle | null>>>(new Map());
   const selection = useBulkSelection<string>();
-  const search = useDebouncedSearch();
+  const search = useHeaderTakeoverSearch();
 
   const {
     edges,
@@ -329,141 +331,152 @@ export function MasterCardsClient({
   }
 
   return (
-    <div className="space-y-3">
-      {queryBannerError && (
-        <ErrorBanner data-testid="cards-query-error">{queryBannerError}</ErrorBanner>
-      )}
-      {deleteRowBannerError && (
-        <ErrorBanner data-testid="cards-delete-error">{deleteRowBannerError}</ErrorBanner>
-      )}
-      {bulkDeleteBannerError && (
-        <ErrorBanner data-testid="cards-bulk-delete-error">{bulkDeleteBannerError}</ErrorBanner>
-      )}
+    <>
+      <SearchTakeoverBar
+        open={search.searchOpen}
+        value={search.input}
+        onChange={search.setInput}
+        onClear={search.clear}
+        onClose={search.closeSearch}
+        placeholder={t("searchPlaceholder")}
+        ariaLabel={t("searchAriaLabel")}
+      />
+      <div className="space-y-3">
+        {queryBannerError && (
+          <ErrorBanner data-testid="cards-query-error">{queryBannerError}</ErrorBanner>
+        )}
+        {deleteRowBannerError && (
+          <ErrorBanner data-testid="cards-delete-error">{deleteRowBannerError}</ErrorBanner>
+        )}
+        {bulkDeleteBannerError && (
+          <ErrorBanner data-testid="cards-bulk-delete-error">{bulkDeleteBannerError}</ErrorBanner>
+        )}
 
-      <section>
-        {/* Page header (deck title/badge/kebab + the desktop add/import toolbar)
+        <section>
+          {/* Page header (deck title/badge/kebab + the desktop add/import toolbar)
             is supplied by the parent via the render-prop, so it receives the
             live totalCount and the add/import openers. On mobile the openers are
             reached through the global "+" header and the deck overflow menu. */}
-        {typeof sectionHeader === "function"
-          ? sectionHeader({
-              totalCount,
-              onAddCard: openAddSheet,
-              onBatchImport: openBatchImport,
-            })
-          : sectionHeader}
+          {typeof sectionHeader === "function"
+            ? sectionHeader({
+                totalCount,
+                onAddCard: openAddSheet,
+                onBatchImport: openBatchImport,
+              })
+            : sectionHeader}
 
-        <SearchInput value={search.input} onChange={search.setInput} />
+          <SearchInput value={search.input} onChange={search.setInput} />
 
-        {selection.count > 0 && (
-          <BulkActionBar
-            count={selection.count}
-            busy={bulkDeleting}
-            onConfirm={handleBulkDelete}
-            onClear={selection.clearSelection}
-          />
-        )}
-
-        {edges.length === 0 ? (
-          <EmptyState search={search.query} onClear={search.clear} />
-        ) : (
-          <ul className="space-y-3">
-            {edges.map((edge) => {
-              const card = edge.node;
-              return (
-                <li key={card.id} className="rounded-md border border-border overflow-hidden">
-                  <CardRow
-                    card={card}
-                    rowRef={(() => {
-                      if (!rowRefs.current.has(card.id)) {
-                        rowRefs.current.set(card.id, { current: null });
-                      }
-                      // biome-ignore lint/style/noNonNullAssertion: we just set the entry above so it is always defined.
-                      return rowRefs.current.get(card.id)!;
-                    })()}
-                    selected={selection.isSelected(card.id)}
-                    disabled={selection.count > 0 || editingId === card.id}
-                    onSelectToggle={() => selection.toggleSelected(card.id)}
-                    onEdit={() => {
-                      closeOtherRows(card.id);
-                      setRowValidationError(null);
-                      setEditingId(card.id);
-                    }}
-                    onDelete={() => deleteRow(card.id, t("cardDeleted"))}
-                  />
-                </li>
-              );
-            })}
-          </ul>
-        )}
-
-        <FormSheet
-          title={t("addCard")}
-          open={addOpen}
-          onOpenChange={(nextOpen) => {
-            setAddOpen(nextOpen);
-            if (!nextOpen) {
-              resetCreateCard();
-              setAddDirty(false);
-              setCreateValidationError(null);
-            }
-          }}
-          submitting={creating}
-          dirty={addDirty}
-          confirmOnDismiss
-        >
-          <AddCardSheetContent
-            submit={handleCreate}
-            submitting={creating}
-            error={createError}
-            validationError={createValidationError}
-            onDirty={() => setAddDirty(true)}
-          />
-        </FormSheet>
-
-        <FormSheet
-          title={deckName}
-          open={batchImportOpen}
-          onOpenChange={setBatchImportOpen}
-          size="lg"
-        >
-          <MasterBatchImportForm
-            masterId={masterId}
-            deckName={deckName}
-            onImported={closeBatchImport}
-            onCancel={closeBatchImport}
-          />
-        </FormSheet>
-
-        <FormSheet
-          title={t("editCard")}
-          open={editingCard !== undefined}
-          onOpenChange={(nextOpen) => {
-            if (!nextOpen) {
-              setRowValidationError(null);
-              setEditingId(null);
-            }
-          }}
-          submitting={updating}
-          confirmOnDismiss={false}
-        >
-          {editingCard ? (
-            <EditCardSheetContent
-              card={editingCard}
-              submit={(values) => handleUpdate(editingCard.id, values)}
-              submitting={updating}
-              error={updateError}
-              validationError={rowValidationError}
+          {selection.count > 0 && (
+            <BulkActionBar
+              count={selection.count}
+              busy={bulkDeleting}
+              onConfirm={handleBulkDelete}
+              onClear={selection.clearSelection}
             />
-          ) : null}
-        </FormSheet>
+          )}
 
-        <div ref={sentinelRef} aria-hidden="true" data-testid="cards-sentinel" />
-        {fetchMoreError && <FetchMoreError message={fetchMoreError} onRetry={retryFetchMore} />}
-        {!fetchMoreError && fetchingMore && pageInfo.hasNextPage && (
-          <p className="mt-3 text-center text-xs text-muted-foreground">{t("loadingMore")}</p>
-        )}
-      </section>
-    </div>
+          {edges.length === 0 ? (
+            <EmptyState search={search.query} onClear={search.clear} />
+          ) : (
+            <ul className="space-y-3">
+              {edges.map((edge) => {
+                const card = edge.node;
+                return (
+                  <li key={card.id} className="rounded-md border border-border overflow-hidden">
+                    <CardRow
+                      card={card}
+                      rowRef={(() => {
+                        if (!rowRefs.current.has(card.id)) {
+                          rowRefs.current.set(card.id, { current: null });
+                        }
+                        // biome-ignore lint/style/noNonNullAssertion: we just set the entry above so it is always defined.
+                        return rowRefs.current.get(card.id)!;
+                      })()}
+                      selected={selection.isSelected(card.id)}
+                      disabled={selection.count > 0 || editingId === card.id}
+                      onSelectToggle={() => selection.toggleSelected(card.id)}
+                      onEdit={() => {
+                        closeOtherRows(card.id);
+                        setRowValidationError(null);
+                        setEditingId(card.id);
+                      }}
+                      onDelete={() => deleteRow(card.id, t("cardDeleted"))}
+                    />
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+
+          <FormSheet
+            title={t("addCard")}
+            open={addOpen}
+            onOpenChange={(nextOpen) => {
+              setAddOpen(nextOpen);
+              if (!nextOpen) {
+                resetCreateCard();
+                setAddDirty(false);
+                setCreateValidationError(null);
+              }
+            }}
+            submitting={creating}
+            dirty={addDirty}
+            confirmOnDismiss
+          >
+            <AddCardSheetContent
+              submit={handleCreate}
+              submitting={creating}
+              error={createError}
+              validationError={createValidationError}
+              onDirty={() => setAddDirty(true)}
+            />
+          </FormSheet>
+
+          <FormSheet
+            title={deckName}
+            open={batchImportOpen}
+            onOpenChange={setBatchImportOpen}
+            size="lg"
+          >
+            <MasterBatchImportForm
+              masterId={masterId}
+              deckName={deckName}
+              onImported={closeBatchImport}
+              onCancel={closeBatchImport}
+            />
+          </FormSheet>
+
+          <FormSheet
+            title={t("editCard")}
+            open={editingCard !== undefined}
+            onOpenChange={(nextOpen) => {
+              if (!nextOpen) {
+                setRowValidationError(null);
+                setEditingId(null);
+              }
+            }}
+            submitting={updating}
+            confirmOnDismiss={false}
+          >
+            {editingCard ? (
+              <EditCardSheetContent
+                card={editingCard}
+                submit={(values) => handleUpdate(editingCard.id, values)}
+                submitting={updating}
+                error={updateError}
+                validationError={rowValidationError}
+              />
+            ) : null}
+          </FormSheet>
+
+          <div ref={sentinelRef} aria-hidden="true" data-testid="cards-sentinel" />
+          {fetchMoreError && <FetchMoreError message={fetchMoreError} onRetry={retryFetchMore} />}
+          {!fetchMoreError && fetchingMore && pageInfo.hasNextPage && (
+            <p className="mt-3 text-center text-xs text-muted-foreground">{t("loadingMore")}</p>
+          )}
+        </section>
+      </div>
+    </>
   );
 }

--- a/frontend/src/app/cardgroups/[id]/cards/cards-client.test.tsx
+++ b/frontend/src/app/cardgroups/[id]/cards/cards-client.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { InMemoryCache } from "@apollo/client";
 import { MockedProvider } from "@apollo/client/testing/react";
-import { screen, waitFor } from "@testing-library/react";
+import { act, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { GraphQLError } from "graphql";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -1629,5 +1629,32 @@ describe("<CardsClient>", () => {
     expect(screen.getByRole("button", { name: /^save$/i })).toBeInTheDocument();
     // No spinner — the mutation has resolved, not pending.
     expect(screen.queryByText(/saving/i)).not.toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Mobile search takeover — flamingo:open-search
+// ---------------------------------------------------------------------------
+
+describe("<CardsClient> mobile search takeover", () => {
+  it("opens the takeover on flamingo:open-search and renders the input", async () => {
+    renderClient([]);
+    // Flush the SSR seed render.
+    await screen.findByText("Hello");
+
+    expect(screen.queryByTestId("search-takeover")).not.toBeInTheDocument();
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent("flamingo:open-search"));
+    });
+
+    expect(screen.getByTestId("search-takeover")).toBeInTheDocument();
+    expect(screen.getByTestId("search-takeover-input")).toBeInTheDocument();
+  });
+
+  it("hides the desktop search input on mobile via hidden md:block", () => {
+    renderClient([]);
+    const wrapper = screen.getByTestId("cards-search-input").closest("div.mb-3");
+    expect(wrapper).toHaveClass("hidden", "md:block");
   });
 });

--- a/frontend/src/app/cardgroups/[id]/cards/cards-client.tsx
+++ b/frontend/src/app/cardgroups/[id]/cards/cards-client.tsx
@@ -9,12 +9,13 @@ import { CardForm } from "@/components/cardgroups/card-form";
 import { CardRow } from "@/components/cardgroups/card-row";
 import { CardgroupBatchImportForm } from "@/components/cardgroups/cardgroup-batch-import-form";
 import type { SwipeableRowHandle } from "@/components/cardgroups/swipeable-row";
+import { SearchTakeoverBar } from "@/components/search/search-takeover-bar";
 import { Button } from "@/components/ui/button";
 import { ErrorBanner } from "@/components/ui/error-banner";
 import { FormSheet, useFormSheetClose } from "@/components/ui/form-sheet";
 import type { CardsByCardgroupConnectionQuery } from "@/generated/graphql";
 import { useBulkSelection } from "@/hooks/use-bulk-selection";
-import { useDebouncedSearch } from "@/hooks/use-debounced-search";
+import { useHeaderTakeoverSearch } from "@/hooks/use-header-takeover-search";
 import { getBackendErrorBanner } from "@/lib/apollo/errors";
 import { useCardMutations } from "./use-card-mutations";
 import { useCardsConnection } from "./use-cards-connection";
@@ -41,7 +42,8 @@ const FetchMoreError = ({ message, onRetry }: { message: string; onRetry: () => 
 const SearchInput = ({ value, onChange }: { value: string; onChange: (next: string) => void }) => {
   const t = useTranslations("Cards");
   return (
-    <div className="mb-3">
+    // Desktop only: on mobile the search moves into the header-takeover bar.
+    <div className="mb-3 hidden md:block">
       <div className="relative">
         <Search
           aria-hidden="true"
@@ -197,7 +199,7 @@ export function CardsClient({
   // Per-card SwipeableRow handles; lets a row close any half-open sibling.
   const rowRefs = useRef<Map<string, RefObject<SwipeableRowHandle | null>>>(new Map());
   const selection = useBulkSelection<string>();
-  const search = useDebouncedSearch();
+  const search = useHeaderTakeoverSearch();
 
   const {
     edges,
@@ -326,148 +328,159 @@ export function CardsClient({
   }
 
   return (
-    <div className="space-y-3">
-      {queryBannerError && (
-        <ErrorBanner data-testid="cards-query-error">{queryBannerError}</ErrorBanner>
-      )}
-      {deleteRowBannerError && (
-        <ErrorBanner data-testid="cards-delete-error">{deleteRowBannerError}</ErrorBanner>
-      )}
-      {bulkDeleteBannerError && (
-        <ErrorBanner data-testid="cards-bulk-delete-error">{bulkDeleteBannerError}</ErrorBanner>
-      )}
-
-      <section>
-        {sectionHeader === undefined ? (
-          <h2 className="mb-3 text-sm font-medium uppercase tracking-wide text-muted-foreground">
-            {t("cardsCount", { count: totalCount })}
-          </h2>
-        ) : typeof sectionHeader === "function" ? (
-          sectionHeader({ totalCount, onAddCard: openAddSheet, onBatchImport: openBatchImport })
-        ) : (
-          sectionHeader
+    <>
+      <SearchTakeoverBar
+        open={search.searchOpen}
+        value={search.input}
+        onChange={search.setInput}
+        onClear={search.clear}
+        onClose={search.closeSearch}
+        placeholder={t("searchPlaceholder")}
+        ariaLabel={t("searchAriaLabel")}
+      />
+      <div className="space-y-3">
+        {queryBannerError && (
+          <ErrorBanner data-testid="cards-query-error">{queryBannerError}</ErrorBanner>
+        )}
+        {deleteRowBannerError && (
+          <ErrorBanner data-testid="cards-delete-error">{deleteRowBannerError}</ErrorBanner>
+        )}
+        {bulkDeleteBannerError && (
+          <ErrorBanner data-testid="cards-bulk-delete-error">{bulkDeleteBannerError}</ErrorBanner>
         )}
 
-        <SearchInput value={search.input} onChange={search.setInput} />
+        <section>
+          {sectionHeader === undefined ? (
+            <h2 className="mb-3 text-sm font-medium uppercase tracking-wide text-muted-foreground">
+              {t("cardsCount", { count: totalCount })}
+            </h2>
+          ) : typeof sectionHeader === "function" ? (
+            sectionHeader({ totalCount, onAddCard: openAddSheet, onBatchImport: openBatchImport })
+          ) : (
+            sectionHeader
+          )}
 
-        {selection.count > 0 && (
-          <BulkActionBar
-            count={selection.count}
-            busy={bulkDeleting}
-            onConfirm={handleBulkDelete}
-            onClear={selection.clearSelection}
-          />
-        )}
+          <SearchInput value={search.input} onChange={search.setInput} />
 
-        {edges.length === 0 ? (
-          <EmptyState search={search.query} onClear={search.clear} />
-        ) : (
-          <ul className="space-y-3">
-            {edges.map((edge) => {
-              const card = edge.node;
-              return (
-                <li key={card.id} className="rounded-md border border-border overflow-hidden">
-                  <CardRow
-                    card={card}
-                    rowRef={(() => {
-                      if (!rowRefs.current.has(card.id)) {
-                        rowRefs.current.set(card.id, { current: null });
-                      }
-                      // biome-ignore lint/style/noNonNullAssertion: we just set the entry above so it is always defined.
-                      return rowRefs.current.get(card.id)!;
-                    })()}
-                    selected={selection.isSelected(card.id)}
-                    disabled={selection.count > 0 || editingId === card.id}
-                    onSelectToggle={() => selection.toggleSelected(card.id)}
-                    onEdit={() => {
-                      closeOtherRows(card.id);
-                      setRowValidationError(null);
-                      setEditingId(card.id);
-                    }}
-                    onDelete={() => deleteRow(card.id, t("cardDeleted"))}
-                  />
-                </li>
-              );
-            })}
-          </ul>
-        )}
-
-        <FormSheet
-          title={t("addCard")}
-          open={addOpen}
-          onOpenChange={(nextOpen) => {
-            setAddOpen(nextOpen);
-            if (!nextOpen) {
-              resetCreateCard();
-              setAddDirty(false);
-              setCreateValidationError(null);
-            }
-          }}
-          submitting={creating}
-          dirty={addDirty}
-          confirmOnDismiss
-        >
-          <AddCardSheetContent
-            submit={handleCreate}
-            submitting={creating}
-            error={createError}
-            validationError={createValidationError}
-            onDirty={() => setAddDirty(true)}
-          />
-        </FormSheet>
-
-        {/* Object-first: header shows only the destination cardgroup (the high-risk variable); the verb lives in the sr-only accessible name. Intentional deviation from the verb-first sheets. */}
-        <FormSheet
-          title={
-            <span
-              className="block overflow-hidden text-ellipsis whitespace-nowrap"
-              title={cardgroupName}
-            >
-              <span className="sr-only">{t("batchImportSrOnly")}</span>
-              {cardgroupName}
-            </span>
-          }
-          open={batchImportOpen}
-          onOpenChange={setBatchImportOpen}
-          size="lg"
-        >
-          <CardgroupBatchImportForm
-            cardgroupId={cardgroupId}
-            cardgroupName={cardgroupName}
-            onImported={closeBatchImport}
-            onCancel={closeBatchImport}
-          />
-        </FormSheet>
-
-        <FormSheet
-          title={t("editCard")}
-          open={editingCard !== undefined}
-          onOpenChange={(nextOpen) => {
-            if (!nextOpen) {
-              setRowValidationError(null);
-              setEditingId(null);
-            }
-          }}
-          submitting={updating}
-          confirmOnDismiss={false}
-        >
-          {editingCard ? (
-            <EditCardSheetContent
-              card={editingCard}
-              submit={(values) => handleUpdate(editingCard.id, values)}
-              submitting={updating}
-              error={updateError}
-              validationError={rowValidationError}
+          {selection.count > 0 && (
+            <BulkActionBar
+              count={selection.count}
+              busy={bulkDeleting}
+              onConfirm={handleBulkDelete}
+              onClear={selection.clearSelection}
             />
-          ) : null}
-        </FormSheet>
+          )}
 
-        <div ref={sentinelRef} aria-hidden="true" data-testid="cards-sentinel" />
-        {fetchMoreError && <FetchMoreError message={fetchMoreError} onRetry={retryFetchMore} />}
-        {!fetchMoreError && fetchingMore && pageInfo.hasNextPage && (
-          <p className="mt-3 text-center text-xs text-muted-foreground">{t("loadingMore")}</p>
-        )}
-      </section>
-    </div>
+          {edges.length === 0 ? (
+            <EmptyState search={search.query} onClear={search.clear} />
+          ) : (
+            <ul className="space-y-3">
+              {edges.map((edge) => {
+                const card = edge.node;
+                return (
+                  <li key={card.id} className="rounded-md border border-border overflow-hidden">
+                    <CardRow
+                      card={card}
+                      rowRef={(() => {
+                        if (!rowRefs.current.has(card.id)) {
+                          rowRefs.current.set(card.id, { current: null });
+                        }
+                        // biome-ignore lint/style/noNonNullAssertion: we just set the entry above so it is always defined.
+                        return rowRefs.current.get(card.id)!;
+                      })()}
+                      selected={selection.isSelected(card.id)}
+                      disabled={selection.count > 0 || editingId === card.id}
+                      onSelectToggle={() => selection.toggleSelected(card.id)}
+                      onEdit={() => {
+                        closeOtherRows(card.id);
+                        setRowValidationError(null);
+                        setEditingId(card.id);
+                      }}
+                      onDelete={() => deleteRow(card.id, t("cardDeleted"))}
+                    />
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+
+          <FormSheet
+            title={t("addCard")}
+            open={addOpen}
+            onOpenChange={(nextOpen) => {
+              setAddOpen(nextOpen);
+              if (!nextOpen) {
+                resetCreateCard();
+                setAddDirty(false);
+                setCreateValidationError(null);
+              }
+            }}
+            submitting={creating}
+            dirty={addDirty}
+            confirmOnDismiss
+          >
+            <AddCardSheetContent
+              submit={handleCreate}
+              submitting={creating}
+              error={createError}
+              validationError={createValidationError}
+              onDirty={() => setAddDirty(true)}
+            />
+          </FormSheet>
+
+          {/* Object-first: header shows only the destination cardgroup (the high-risk variable); the verb lives in the sr-only accessible name. Intentional deviation from the verb-first sheets. */}
+          <FormSheet
+            title={
+              <span
+                className="block overflow-hidden text-ellipsis whitespace-nowrap"
+                title={cardgroupName}
+              >
+                <span className="sr-only">{t("batchImportSrOnly")}</span>
+                {cardgroupName}
+              </span>
+            }
+            open={batchImportOpen}
+            onOpenChange={setBatchImportOpen}
+            size="lg"
+          >
+            <CardgroupBatchImportForm
+              cardgroupId={cardgroupId}
+              cardgroupName={cardgroupName}
+              onImported={closeBatchImport}
+              onCancel={closeBatchImport}
+            />
+          </FormSheet>
+
+          <FormSheet
+            title={t("editCard")}
+            open={editingCard !== undefined}
+            onOpenChange={(nextOpen) => {
+              if (!nextOpen) {
+                setRowValidationError(null);
+                setEditingId(null);
+              }
+            }}
+            submitting={updating}
+            confirmOnDismiss={false}
+          >
+            {editingCard ? (
+              <EditCardSheetContent
+                card={editingCard}
+                submit={(values) => handleUpdate(editingCard.id, values)}
+                submitting={updating}
+                error={updateError}
+                validationError={rowValidationError}
+              />
+            ) : null}
+          </FormSheet>
+
+          <div ref={sentinelRef} aria-hidden="true" data-testid="cards-sentinel" />
+          {fetchMoreError && <FetchMoreError message={fetchMoreError} onRetry={retryFetchMore} />}
+          {!fetchMoreError && fetchingMore && pageInfo.hasNextPage && (
+            <p className="mt-3 text-center text-xs text-muted-foreground">{t("loadingMore")}</p>
+          )}
+        </section>
+      </div>
+    </>
   );
 }

--- a/frontend/src/components/nav/header-search-action.test.ts
+++ b/frontend/src/components/nav/header-search-action.test.ts
@@ -6,11 +6,25 @@ describe("resolveHeaderSearchAction", () => {
     expect(resolveHeaderSearchAction("/cardgroups")).toBe(true);
   });
 
+  it("returns true on the nested card-list edit routes", () => {
+    expect(resolveHeaderSearchAction("/cardgroups/abc/edit")).toBe(true);
+    expect(resolveHeaderSearchAction("/cardgroups/abc/edit/")).toBe(true);
+    expect(resolveHeaderSearchAction("/admin/masters/abc/edit")).toBe(true);
+    expect(resolveHeaderSearchAction("/admin/masters/abc/edit/")).toBe(true);
+  });
+
   it("returns false on non-filterable routes", () => {
     expect(resolveHeaderSearchAction("/")).toBe(false);
     expect(resolveHeaderSearchAction("/catalog")).toBe(false);
     expect(resolveHeaderSearchAction("/admin/users")).toBe(false);
-    expect(resolveHeaderSearchAction("/cardgroups/123/edit")).toBe(false);
     expect(resolveHeaderSearchAction("/learn/123")).toBe(false);
+  });
+
+  it("returns false on the list/detail siblings of the edit routes", () => {
+    // Cardgroup detail (no /edit segment) and the masters list/detail are not
+    // searchable card-list screens (the masters list filter is its own rollout).
+    expect(resolveHeaderSearchAction("/cardgroups/abc")).toBe(false);
+    expect(resolveHeaderSearchAction("/admin/masters")).toBe(false);
+    expect(resolveHeaderSearchAction("/admin/masters/abc")).toBe(false);
   });
 });

--- a/frontend/src/components/nav/header-search-action.ts
+++ b/frontend/src/components/nav/header-search-action.ts
@@ -1,7 +1,12 @@
 // Exact-match routes that show the mobile header search trigger.
 const SEARCH_EXACT = new Set<string>(["/cardgroups"]);
 // Pattern routes (e.g. parameterized segments) that show the trigger.
-const SEARCH_PATTERNS: RegExp[] = [];
+// Mirrors the `[id]/edit` regexes in `header-create-action.ts` so the magnifier
+// and the "+" appear together on the nested card-list screens.
+const SEARCH_PATTERNS: RegExp[] = [
+  /^\/cardgroups\/[^/]+\/edit(\/|$)/,
+  /^\/admin\/masters\/[^/]+\/edit(\/|$)/,
+];
 
 /**
  * Maps the current pathname to whether the mobile header should show the
@@ -10,6 +15,8 @@ const SEARCH_PATTERNS: RegExp[] = [];
  *
  * Routing rules:
  * - `/cardgroups` -> true (the filter lives here)
+ * - `/cardgroups/:id/edit` -> true (cardgroup cards search)
+ * - `/admin/masters/:id/edit` -> true (master cards search)
  * - anything else -> false
  *
  * Built to extend: add routes to `SEARCH_EXACT` / `SEARCH_PATTERNS` (and wire


### PR DESCRIPTION
## Summary

Roll out the mobile **header-takeover search** to the two dynamic-route, nested card-list screens — **cardgroup cards** (`/cardgroups/[id]/edit`) and **master cards** (`/admin/masters/[id]/edit`). Same recipe as the `/cardgroups` keystone (#554), applied to screens whose search input lives several layers deep in the client.

The search filter already worked on both screens (backend `search` arg + `useDebouncedSearch` + the per-screen connection hook). What was missing was the mobile header-magnifier UX. This PR only adds that — it is behavior-preserving for desktop.

Closes #556

## Changes

### Data-drive the matcher

- `frontend/src/components/nav/header-search-action.ts` — appends two `[id]/edit` regexes to `SEARCH_PATTERNS` (`/^\/cardgroups\/[^/]+\/edit(\/|$)/`, `/^\/admin\/masters\/[^/]+\/edit(\/|$)/`), mirroring the `[id]/edit` patterns in `header-create-action.ts`. `/cardgroups` stays `true` (the keystone); the two nested edit routes now show the header magnifier.
- `frontend/src/components/nav/header-search-action.test.ts` — asserts `true` for `/cardgroups/abc/edit` and `/admin/masters/abc/edit` (with trailing-slash variants), and `false` for the list/detail siblings (`/cardgroups/abc`, `/admin/masters`, `/admin/masters/abc`).

### Adopt the hook on the two clients

- `frontend/src/app/cardgroups/[id]/cards/cards-client.tsx` and `frontend/src/app/admin/masters/[id]/edit/cards/master-cards-client.tsx` — swap `useDebouncedSearch()` → `useHeaderTakeoverSearch()`, gate the desktop `SearchInput` mobile-off via `hidden md:block`, and mount `<SearchTakeoverBar>` (mobile only) wired with the `Cards` namespace strings (`searchPlaceholder` / `searchAriaLabel`). The unrelated add-card / batch-import wiring is untouched.
- Co-located tests (`cards-client.test.tsx`, `master-cards-client.test.tsx`) — add a "mobile search takeover" block: `flamingo:open-search` opens the takeover and renders its input; the desktop input carries `hidden md:block`.

## Note on the matcher assertions

The issue body listed `/cardgroups` under "false", but `/cardgroups` is the #554 keystone route and must stay `true` (an existing test already asserts this). The matcher tests follow the architecturally-correct behavior: `/cardgroups` and both `[id]/edit` routes are `true`; only the non-searchable list/detail siblings are `false`.

## Verification

- typecheck ✓ (`tsc --noEmit`)
- lint ✓ (`biome check --error-on-warnings`, no warnings)
- knip ✓ (no unused exports)
- test ✓ **1506 passing (161 files)** — including the new narrow takeover tests, the matcher tests, and the broad page tests (`__tests__/cards-list.test.tsx`, `__tests__/admin-master-cards.test.tsx`)
- build ✓ (`next build`)

## Test plan

- [ ] `/cardgroups/[id]/edit` on mobile (`<md`) — tap the header 🔍; the takeover opens, filters cards live as you type, back / Escape closes it. The header shows magnifier + "+".
- [ ] `/admin/masters/[id]/edit` on mobile — same takeover UX; the deck's "+" add-card affordance still works alongside the magnifier.
- [ ] Both screens on desktop (`md+`) — unchanged inline search field.

## Dependency

Depends on #554 (the `useHeaderTakeoverSearch` hook), already merged via #557. Independent of #555 — shares only the one-line matcher append in `header-search-action.ts`.
