### PR TITLE
feat(frontend): roll out mobile header-takeover search to catalog, masters, and users

### DIFF
--- a/frontend/src/app/admin/masters/admin-masters-client.test.tsx
+++ b/frontend/src/app/admin/masters/admin-masters-client.test.tsx
@@ -2,7 +2,7 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { MockedProvider } from "@apollo/client/testing/react";
-import { screen, waitFor } from "@testing-library/react";
+import { act, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { toast } from "sonner";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -238,5 +238,40 @@ describe("AdminMastersClient", () => {
       expect(end).toBeGreaterThan(start);
       expect(source.slice(start, end)).not.toContain("optimisticResponse");
     }
+  });
+
+  // -------------------------------------------------------------------------
+  // Mobile search takeover — flamingo:open-search opens the bar; the desktop
+  // input is gated mobile-off so the two do not double up on mobile.
+  // -------------------------------------------------------------------------
+
+  it("opens the takeover on flamingo:open-search and renders the input", async () => {
+    renderWithIntl(
+      <MockedProvider mocks={[listMock(["m-1"])]}>
+        <AdminMastersClient />
+      </MockedProvider>,
+    );
+    await screen.findByTestId("admin-masters-list");
+
+    expect(screen.queryByTestId("search-takeover")).not.toBeInTheDocument();
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent("flamingo:open-search"));
+    });
+
+    expect(screen.getByTestId("search-takeover")).toBeInTheDocument();
+    expect(screen.getByTestId("search-takeover-input")).toBeInTheDocument();
+  });
+
+  it("gates the desktop search input mobile-off (hidden md:block)", async () => {
+    renderWithIntl(
+      <MockedProvider mocks={[listMock(["m-1"])]}>
+        <AdminMastersClient />
+      </MockedProvider>,
+    );
+    await screen.findByTestId("admin-masters-list");
+
+    const desktop = screen.getByRole("searchbox", { name: /search masters/i });
+    expect(desktop.parentElement).toHaveClass("hidden", "md:block");
   });
 });

--- a/frontend/src/app/admin/masters/admin-masters-client.tsx
+++ b/frontend/src/app/admin/masters/admin-masters-client.tsx
@@ -8,6 +8,7 @@ import { useCallback, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { AdminQueryErrorBanner } from "@/components/admin/admin-query-error-banner";
 import { ListingPageShell } from "@/components/layout/listing-page-shell";
+import { SearchTakeoverBar } from "@/components/search/search-takeover-bar";
 import { Button } from "@/components/ui/button";
 import { ErrorBanner } from "@/components/ui/error-banner";
 import { FormSheet } from "@/components/ui/form-sheet";
@@ -16,7 +17,7 @@ import type {
   AdminMastersQuery as AdminMastersQueryResult,
   AdminMastersQueryVariables,
 } from "@/generated/graphql";
-import { useDebouncedSearch } from "@/hooks/use-debounced-search";
+import { useHeaderTakeoverSearch } from "@/hooks/use-header-takeover-search";
 import { classifyQueryError, getBackendErrorBanner } from "@/lib/apollo/errors";
 import { EMPTY_PAGE_INFO } from "@/lib/pagination/empty-page-info";
 import { useConnectionPagination } from "@/lib/pagination/use-connection-pagination";
@@ -57,7 +58,7 @@ export function AdminMastersClient() {
   const t = useTranslations("AdminMasters");
   const tCommon = useTranslations("Common");
   const router = useRouter();
-  const search = useDebouncedSearch();
+  const search = useHeaderTakeoverSearch();
   const searchQuery = search.query;
   const [createDirty, setCreateDirty] = useState(false);
   const [createValidationError, setCreateValidationError] = useState<{
@@ -130,115 +131,126 @@ export function AdminMastersClient() {
   if (initialLoading) return <AdminMastersSkeleton />;
 
   return (
-    <ListingPageShell
-      title={
-        <span className="flex items-center gap-3">
-          {t("title")}
-          <span className="text-sm font-normal text-muted-foreground">({totalCount})</span>
-        </span>
-      }
-      description={t("description")}
-      primaryActions={
-        <Button
-          type="button"
-          variant="brand"
-          className="hidden md:inline-flex"
-          data-testid="admin-masters-new-btn"
-          onClick={() => sheet.open({ mode: "new" })}
-        >
-          <span>{t("newMaster")}</span>
-          <Plus aria-hidden="true" />
-        </Button>
-      }
-    >
-      <div>
-        <Input
-          type="search"
-          placeholder={t("searchPlaceholder")}
-          value={search.input}
-          onChange={(e) => search.setInput(e.target.value)}
-          aria-label={t("searchLabel")}
-        />
-      </div>
-
-      <AdminQueryErrorBanner
-        kind={queryErrorKind}
-        onRetry={refetch}
-        testId="admin-masters-query-error"
-        copy={{
-          viewForbidden: t("viewForbidden"),
-          sessionExpired: t("sessionExpired"),
-          signInAgain: t("pleaseSignInAgain"),
-          retry: tCommon("retry"),
-        }}
+    <>
+      <SearchTakeoverBar
+        open={search.searchOpen}
+        value={search.input}
+        onChange={search.setInput}
+        onClear={search.clear}
+        onClose={search.closeSearch}
+        placeholder={t("searchPlaceholder")}
+        ariaLabel={t("searchLabel")}
       />
-
-      {!initialLoading && !queryErrorKind && edges.length === 0 && (
-        <p className="text-sm text-muted-foreground" data-testid="admin-masters-empty">
-          {t("noMastersFound")}
-        </p>
-      )}
-
-      {edges.length > 0 && (
-        <ul className="space-y-3" data-testid="admin-masters-list">
-          {edges.map((edge) => (
-            <AdminMasterRow key={edge.cursor} master={edge.node} />
-          ))}
-        </ul>
-      )}
-
-      <div ref={sentinelRef} aria-hidden="true" data-testid="admin-masters-sentinel" />
-
-      {fetchMoreError && (
-        <ErrorBanner
-          className="mt-3 flex flex-col items-center gap-2"
-          data-testid="admin-masters-fetch-more-error"
-        >
-          <span>{fetchMoreError}</span>
-          <button
+      <ListingPageShell
+        title={
+          <span className="flex items-center gap-3">
+            {t("title")}
+            <span className="text-sm font-normal text-muted-foreground">({totalCount})</span>
+          </span>
+        }
+        description={t("description")}
+        primaryActions={
+          <Button
             type="button"
-            className="rounded-md border border-destructive/40 px-3 py-1 text-xs hover:bg-destructive/10"
-            onClick={retryFetchMore}
+            variant="brand"
+            className="hidden md:inline-flex"
+            data-testid="admin-masters-new-btn"
+            onClick={() => sheet.open({ mode: "new" })}
           >
-            {tCommon("retry")}
-          </button>
-        </ErrorBanner>
-      )}
-
-      {!fetchMoreError && fetchingMore && hasNextPage && (
-        <p
-          className="mt-3 text-center text-xs text-muted-foreground"
-          data-testid="admin-masters-loading-more"
-        >
-          {t("loadingMore")}
-        </p>
-      )}
-
-      <FormSheet
-        title={t("createMasterTitle")}
-        open={sheet.state.mode === "new"}
-        onOpenChange={(next) => {
-          if (!next) {
-            resetCreate();
-            setCreateValidationError(null);
-            setCreateDirty(false);
-            sheet.close();
-          }
-        }}
-        submitting={creating}
-        dirty={createDirty}
-        confirmOnDismiss
+            <span>{t("newMaster")}</span>
+            <Plus aria-hidden="true" />
+          </Button>
+        }
       >
-        {sheet.state.mode === "new" ? (
-          <AdminMasterForm
-            mode="create"
-            submitting={creating}
-            submit={handleCreate}
-            validationError={createValidationError}
-            onDirtyChange={setCreateDirty}
+        <div className="hidden md:block">
+          <Input
+            type="search"
+            placeholder={t("searchPlaceholder")}
+            value={search.input}
+            onChange={(e) => search.setInput(e.target.value)}
+            aria-label={t("searchLabel")}
           />
-        ) : null}
-      </FormSheet>
-    </ListingPageShell>
+        </div>
+
+        <AdminQueryErrorBanner
+          kind={queryErrorKind}
+          onRetry={refetch}
+          testId="admin-masters-query-error"
+          copy={{
+            viewForbidden: t("viewForbidden"),
+            sessionExpired: t("sessionExpired"),
+            signInAgain: t("pleaseSignInAgain"),
+            retry: tCommon("retry"),
+          }}
+        />
+
+        {!initialLoading && !queryErrorKind && edges.length === 0 && (
+          <p className="text-sm text-muted-foreground" data-testid="admin-masters-empty">
+            {t("noMastersFound")}
+          </p>
+        )}
+
+        {edges.length > 0 && (
+          <ul className="space-y-3" data-testid="admin-masters-list">
+            {edges.map((edge) => (
+              <AdminMasterRow key={edge.cursor} master={edge.node} />
+            ))}
+          </ul>
+        )}
+
+        <div ref={sentinelRef} aria-hidden="true" data-testid="admin-masters-sentinel" />
+
+        {fetchMoreError && (
+          <ErrorBanner
+            className="mt-3 flex flex-col items-center gap-2"
+            data-testid="admin-masters-fetch-more-error"
+          >
+            <span>{fetchMoreError}</span>
+            <button
+              type="button"
+              className="rounded-md border border-destructive/40 px-3 py-1 text-xs hover:bg-destructive/10"
+              onClick={retryFetchMore}
+            >
+              {tCommon("retry")}
+            </button>
+          </ErrorBanner>
+        )}
+
+        {!fetchMoreError && fetchingMore && hasNextPage && (
+          <p
+            className="mt-3 text-center text-xs text-muted-foreground"
+            data-testid="admin-masters-loading-more"
+          >
+            {t("loadingMore")}
+          </p>
+        )}
+
+        <FormSheet
+          title={t("createMasterTitle")}
+          open={sheet.state.mode === "new"}
+          onOpenChange={(next) => {
+            if (!next) {
+              resetCreate();
+              setCreateValidationError(null);
+              setCreateDirty(false);
+              sheet.close();
+            }
+          }}
+          submitting={creating}
+          dirty={createDirty}
+          confirmOnDismiss
+        >
+          {sheet.state.mode === "new" ? (
+            <AdminMasterForm
+              mode="create"
+              submitting={creating}
+              submit={handleCreate}
+              validationError={createValidationError}
+              onDirtyChange={setCreateDirty}
+            />
+          ) : null}
+        </FormSheet>
+      </ListingPageShell>
+    </>
   );
 }

--- a/frontend/src/app/admin/users/admin-users-client.test.tsx
+++ b/frontend/src/app/admin/users/admin-users-client.test.tsx
@@ -4,7 +4,7 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { InMemoryCache } from "@apollo/client";
 import { MockedProvider } from "@apollo/client/testing/react";
-import { screen, waitFor } from "@testing-library/react";
+import { act, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { GraphQLError } from "graphql";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -572,5 +572,42 @@ describe("<AdminUsersClient> delete", () => {
 
     expect(start).toBeGreaterThanOrEqual(0);
     expect(source.slice(start, end)).not.toContain("optimisticResponse");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Mobile search takeover — flamingo:open-search opens the bar; the desktop
+// input is gated mobile-off so the two do not double up on mobile.
+// ---------------------------------------------------------------------------
+
+describe("<AdminUsersClient> mobile search takeover", () => {
+  it("opens the takeover on flamingo:open-search and renders the input", async () => {
+    renderWithIntl(
+      <MockedProvider mocks={[makeUsersMock(), makeRolesMock()]}>
+        <AdminUsersClient />
+      </MockedProvider>,
+    );
+    await screen.findByTestId("admin-users-list");
+
+    expect(screen.queryByTestId("search-takeover")).not.toBeInTheDocument();
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent("flamingo:open-search"));
+    });
+
+    expect(screen.getByTestId("search-takeover")).toBeInTheDocument();
+    expect(screen.getByTestId("search-takeover-input")).toBeInTheDocument();
+  });
+
+  it("gates the desktop search input mobile-off (hidden md:block)", async () => {
+    renderWithIntl(
+      <MockedProvider mocks={[makeUsersMock(), makeRolesMock()]}>
+        <AdminUsersClient />
+      </MockedProvider>,
+    );
+    await screen.findByTestId("admin-users-list");
+
+    const desktop = screen.getByRole("searchbox", { name: /search users/i });
+    expect(desktop.parentElement).toHaveClass("hidden", "md:block");
   });
 });

--- a/frontend/src/app/admin/users/admin-users-client.tsx
+++ b/frontend/src/app/admin/users/admin-users-client.tsx
@@ -6,13 +6,14 @@ import { useTranslations } from "next-intl";
 import { useCallback, useEffect, useMemo } from "react";
 import { toast } from "sonner";
 import { AdminQueryErrorBanner } from "@/components/admin/admin-query-error-banner";
+import { SearchTakeoverBar } from "@/components/search/search-takeover-bar";
 import { ErrorBanner } from "@/components/ui/error-banner";
 import { useFragment } from "@/generated/fragment-masking";
 import type {
   AdminUsersQuery as AdminUsersQueryResult,
   AdminUsersQueryVariables,
 } from "@/generated/graphql";
-import { useDebouncedSearch } from "@/hooks/use-debounced-search";
+import { useHeaderTakeoverSearch } from "@/hooks/use-header-takeover-search";
 import {
   classifyQueryError,
   getBackendErrorBanner,
@@ -99,7 +100,7 @@ export function AdminUsersClient() {
   const t = useTranslations("Admin");
   const tCommon = useTranslations("Common");
   const tNav = useTranslations("Nav");
-  const search = useDebouncedSearch();
+  const search = useHeaderTakeoverSearch();
   const searchQuery = search.query;
   const sheet = useSheetSearchParam();
 
@@ -229,25 +230,35 @@ export function AdminUsersClient() {
   }
 
   return (
-    <main className="p-8">
-      <div className="mb-6 flex items-center gap-4">
-        <h1 className="text-2xl font-semibold">{tNav("users")}</h1>
-        <span className="text-sm text-muted-foreground">({totalCount})</span>
-      </div>
+    <>
+      <SearchTakeoverBar
+        open={search.searchOpen}
+        value={search.input}
+        onChange={search.setInput}
+        onClear={search.clear}
+        onClose={search.closeSearch}
+        placeholder={t("searchPlaceholder")}
+        ariaLabel={t("searchLabel")}
+      />
+      <main className="p-8">
+        <div className="mb-6 flex items-center gap-4">
+          <h1 className="text-2xl font-semibold">{tNav("users")}</h1>
+          <span className="text-sm text-muted-foreground">({totalCount})</span>
+        </div>
 
-      {/* Search input */}
-      <div className="mb-6">
-        <input
-          type="search"
-          placeholder={t("searchPlaceholder")}
-          value={search.input}
-          onChange={(e) => search.setInput(e.target.value)}
-          className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-          aria-label={t("searchLabel")}
-        />
-      </div>
+        {/* Search input — desktop only; mobile uses the header takeover above. */}
+        <div className="mb-6 hidden md:block">
+          <input
+            type="search"
+            placeholder={t("searchPlaceholder")}
+            value={search.input}
+            onChange={(e) => search.setInput(e.target.value)}
+            className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            aria-label={t("searchLabel")}
+          />
+        </div>
 
-      {/*
+        {/*
         Admin users query-error banner. UNAUTHENTICATED here means the session
         expired mid-page: the server-side gate in page.tsx + the admin layout
         block the initial load (redirecting to "/"), so the degraded /login
@@ -255,89 +266,90 @@ export function AdminUsersClient() {
         re-issuing the same query would fail again. See
         .claude/rules/frontend-rsc-error-handling.md.
       */}
-      <AdminQueryErrorBanner
-        kind={queryErrorKind}
-        onRetry={refetch}
-        testId="admin-users-query-error"
-        className="mb-4"
-        copy={{
-          viewForbidden: t("viewForbidden"),
-          sessionExpired: t("sessionExpired"),
-          signInAgain: t("pleaseSignInAgain"),
-          retry: tCommon("retry"),
-        }}
-      />
+        <AdminQueryErrorBanner
+          kind={queryErrorKind}
+          onRetry={refetch}
+          testId="admin-users-query-error"
+          className="mb-4"
+          copy={{
+            viewForbidden: t("viewForbidden"),
+            sessionExpired: t("sessionExpired"),
+            signInAgain: t("pleaseSignInAgain"),
+            retry: tCommon("retry"),
+          }}
+        />
 
-      {rolesBannerError && (
-        <ErrorBanner className="mb-4" data-testid="admin-users-roles-error">
-          {rolesBannerError}
-        </ErrorBanner>
-      )}
+        {rolesBannerError && (
+          <ErrorBanner className="mb-4" data-testid="admin-users-roles-error">
+            {rolesBannerError}
+          </ErrorBanner>
+        )}
 
-      {/* Empty state */}
-      {!initialLoading && !queryErrorKind && edges.length === 0 && (
-        <p className="text-sm text-muted-foreground" data-testid="admin-users-empty">
-          {t("noUsersFound")}
-        </p>
-      )}
+        {/* Empty state */}
+        {!initialLoading && !queryErrorKind && edges.length === 0 && (
+          <p className="text-sm text-muted-foreground" data-testid="admin-users-empty">
+            {t("noUsersFound")}
+          </p>
+        )}
 
-      {/* User list */}
-      {edges.length > 0 && (
-        <ul className="space-y-3" data-testid="admin-users-list">
-          {edges.map((edge) => (
-            <UserRow
-              key={edge.cursor}
-              edge={edge}
-              onEdit={(id) => sheet.open({ mode: "edit", id })}
-            />
-          ))}
-        </ul>
-      )}
+        {/* User list */}
+        {edges.length > 0 && (
+          <ul className="space-y-3" data-testid="admin-users-list">
+            {edges.map((edge) => (
+              <UserRow
+                key={edge.cursor}
+                edge={edge}
+                onEdit={(id) => sheet.open({ mode: "edit", id })}
+              />
+            ))}
+          </ul>
+        )}
 
-      {/* Intersection sentinel for infinite scroll */}
-      <div ref={sentinelRef} aria-hidden="true" data-testid="admin-users-sentinel" />
+        {/* Intersection sentinel for infinite scroll */}
+        <div ref={sentinelRef} aria-hidden="true" data-testid="admin-users-sentinel" />
 
-      {/* fetchMore error banner with Retry */}
-      {fetchMoreError && (
-        <ErrorBanner
-          className="mt-3 flex flex-col items-center gap-2"
-          data-testid="admin-users-fetch-more-error"
-        >
-          <span>{fetchMoreError}</span>
-          <button
-            type="button"
-            className="rounded-md border border-destructive/40 px-3 py-1 text-xs hover:bg-destructive/10"
-            onClick={retryFetchMore}
+        {/* fetchMore error banner with Retry */}
+        {fetchMoreError && (
+          <ErrorBanner
+            className="mt-3 flex flex-col items-center gap-2"
+            data-testid="admin-users-fetch-more-error"
           >
-            {tCommon("retry")}
-          </button>
-        </ErrorBanner>
-      )}
+            <span>{fetchMoreError}</span>
+            <button
+              type="button"
+              className="rounded-md border border-destructive/40 px-3 py-1 text-xs hover:bg-destructive/10"
+              onClick={retryFetchMore}
+            >
+              {tCommon("retry")}
+            </button>
+          </ErrorBanner>
+        )}
 
-      {/* Loading more indicator */}
-      {!fetchMoreError && fetchingMore && hasNextPage && (
-        <p
-          className="mt-3 text-center text-xs text-muted-foreground"
-          data-testid="admin-users-loading-more"
-        >
-          {t("loadingMore")}
-        </p>
-      )}
+        {/* Loading more indicator */}
+        {!fetchMoreError && fetchingMore && hasNextPage && (
+          <p
+            className="mt-3 text-center text-xs text-muted-foreground"
+            data-testid="admin-users-loading-more"
+          >
+            {t("loadingMore")}
+          </p>
+        )}
 
-      <AdminUserProfileSheet
-        open={editUserId !== null}
-        user={sheetUser}
-        loading={
-          editUserLoading ||
-          (editUserId !== null && (!editUserCalled || !editUserResultMatchesSheet))
-        }
-        allRoles={roleOptions}
-        queryError={editUserBannerError}
-        onDismiss={() => sheet.close()}
-        onSaved={() => sheet.close({ refresh: true })}
-        onReloadRequested={reloadEditedUser}
-        onDelete={handleDeleteUser}
-      />
-    </main>
+        <AdminUserProfileSheet
+          open={editUserId !== null}
+          user={sheetUser}
+          loading={
+            editUserLoading ||
+            (editUserId !== null && (!editUserCalled || !editUserResultMatchesSheet))
+          }
+          allRoles={roleOptions}
+          queryError={editUserBannerError}
+          onDismiss={() => sheet.close()}
+          onSaved={() => sheet.close({ refresh: true })}
+          onReloadRequested={reloadEditedUser}
+          onDelete={handleDeleteUser}
+        />
+      </main>
+    </>
   );
 }

--- a/frontend/src/app/catalog/catalog-client.test.tsx
+++ b/frontend/src/app/catalog/catalog-client.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { InMemoryCache } from "@apollo/client";
 import { MockedProvider } from "@apollo/client/testing/react";
-import { screen, waitFor } from "@testing-library/react";
+import { act, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { GraphQLError } from "graphql";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -494,5 +494,35 @@ describe("<CatalogClient>", () => {
       "Could not import the cardgroup.",
     );
     expect(screen.getByTestId("catalog-import-m-1")).not.toBeDisabled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Mobile search takeover — flamingo:open-search opens the bar; the desktop
+// input is gated mobile-off so the two do not double up on mobile.
+// ---------------------------------------------------------------------------
+
+describe("<CatalogClient> mobile search takeover", () => {
+  it("opens the takeover on flamingo:open-search and renders the input", async () => {
+    const cache = new InMemoryCache();
+    renderClient([], makeConnection([M1]), cache);
+    await screen.findByText("Business English");
+
+    expect(screen.queryByTestId("search-takeover")).not.toBeInTheDocument();
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent("flamingo:open-search"));
+    });
+
+    expect(screen.getByTestId("search-takeover")).toBeInTheDocument();
+    expect(screen.getByTestId("search-takeover-input")).toBeInTheDocument();
+  });
+
+  it("gates the desktop search input mobile-off (hidden md:block)", async () => {
+    const cache = new InMemoryCache();
+    renderClient([], makeConnection([M1]), cache);
+    await screen.findByText("Business English");
+
+    expect(screen.getByTestId("catalog-search").parentElement).toHaveClass("hidden", "md:block");
   });
 });

--- a/frontend/src/app/catalog/catalog-client.tsx
+++ b/frontend/src/app/catalog/catalog-client.tsx
@@ -7,6 +7,7 @@ import { useTranslations } from "next-intl";
 import { useCallback, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { ListingPageShell } from "@/components/layout/listing-page-shell";
+import { SearchTakeoverBar } from "@/components/search/search-takeover-bar";
 import { Button } from "@/components/ui/button";
 import { ErrorBanner } from "@/components/ui/error-banner";
 import {
@@ -14,7 +15,7 @@ import {
   type MasterCatalogQuery,
   type MasterCatalogQueryVariables,
 } from "@/generated/graphql";
-import { useDebouncedSearch } from "@/hooks/use-debounced-search";
+import { useHeaderTakeoverSearch } from "@/hooks/use-header-takeover-search";
 import { EMPTY_PAGE_INFO } from "@/lib/pagination/empty-page-info";
 import { useConnectionPagination } from "@/lib/pagination/use-connection-pagination";
 import { CatalogListItem } from "./catalog-list-item";
@@ -75,7 +76,7 @@ export default function CatalogClient({ initialConnection }: CatalogClientProps)
   const t = useTranslations("Catalog");
   const tCommon = useTranslations("Common");
 
-  const search = useDebouncedSearch();
+  const search = useHeaderTakeoverSearch();
   const searchQuery = search.query;
 
   // Import state. `importingId` serializes imports to one at a time;
@@ -194,90 +195,101 @@ export default function CatalogClient({ initialConnection }: CatalogClientProps)
   const hasSearch = searchQuery !== null && searchQuery !== "";
 
   return (
-    <ListingPageShell
-      title={t("title")}
-      description={t("description")}
-      toolbar={
-        <div className="mb-2">
-          <input
-            type="search"
-            placeholder={t("searchPlaceholder")}
-            value={search.input}
-            onChange={(e) => search.setInput(e.target.value)}
-            className="w-full max-w-sm rounded-md border border-input bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-            aria-label={t("searchAriaLabel")}
-            data-testid="catalog-search"
-          />
-        </div>
-      }
-    >
-      {importAuthError ? (
-        <ErrorBanner data-testid="catalog-import-auth-error">
-          <span>{t("sessionExpired")}</span>
-          <Link href="/login" className="underline">
-            {t("signInAgain")}
-          </Link>
-        </ErrorBanner>
-      ) : null}
-
-      {importError ? (
-        <ErrorBanner data-testid="catalog-import-error">{importError}</ErrorBanner>
-      ) : null}
-
-      {initialLoading && (
-        <p className="text-sm text-muted-foreground" data-testid="catalog-loading">
-          {tCommon("loading")}
-        </p>
-      )}
-
-      {!initialLoading && edges.length === 0 && !hasSearch && (
-        <p className="text-sm text-muted-foreground" data-testid="catalog-empty">
-          {t("noDecks")}
-        </p>
-      )}
-
-      {!initialLoading && edges.length === 0 && hasSearch && (
-        <p className="text-sm text-muted-foreground" data-testid="catalog-empty-search">
-          {t("noMatch", { query: searchQuery })}
-        </p>
-      )}
-
-      {edges.length > 0 && (
-        <ul className="space-y-2" data-testid="catalog-list">
-          {edges.map((edge) => (
-            <CatalogListItem
-              key={edge.cursor}
-              node={edge.node}
-              importing={importingId === edge.node.id}
-              imported={importedIds.has(edge.node.id)}
-              onImport={handleImport}
+    <>
+      <SearchTakeoverBar
+        open={search.searchOpen}
+        value={search.input}
+        onChange={search.setInput}
+        onClear={search.clear}
+        onClose={search.closeSearch}
+        placeholder={t("searchPlaceholder")}
+        ariaLabel={t("searchAriaLabel")}
+      />
+      <ListingPageShell
+        title={t("title")}
+        description={t("description")}
+        toolbar={
+          <div className="mb-2 hidden md:block">
+            <input
+              type="search"
+              placeholder={t("searchPlaceholder")}
+              value={search.input}
+              onChange={(e) => search.setInput(e.target.value)}
+              className="w-full max-w-sm rounded-md border border-input bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              aria-label={t("searchAriaLabel")}
+              data-testid="catalog-search"
             />
-          ))}
-        </ul>
-      )}
+          </div>
+        }
+      >
+        {importAuthError ? (
+          <ErrorBanner data-testid="catalog-import-auth-error">
+            <span>{t("sessionExpired")}</span>
+            <Link href="/login" className="underline">
+              {t("signInAgain")}
+            </Link>
+          </ErrorBanner>
+        ) : null}
 
-      <div ref={sentinelRef} aria-hidden="true" data-testid="catalog-sentinel" />
+        {importError ? (
+          <ErrorBanner data-testid="catalog-import-error">{importError}</ErrorBanner>
+        ) : null}
 
-      {fetchMoreError && (
-        <ErrorBanner
-          className="mt-3 flex flex-col items-center gap-2"
-          data-testid="catalog-fetch-more-error"
-        >
-          <span>{fetchMoreError}</span>
-          <Button type="button" variant="outline" size="sm" onClick={retryFetchMore}>
-            {tCommon("retry")}
-          </Button>
-        </ErrorBanner>
-      )}
+        {initialLoading && (
+          <p className="text-sm text-muted-foreground" data-testid="catalog-loading">
+            {tCommon("loading")}
+          </p>
+        )}
 
-      {!fetchMoreError && fetchingMore && hasNextPage && (
-        <p
-          className="mt-3 text-center text-xs text-muted-foreground"
-          data-testid="catalog-loading-more"
-        >
-          {t("loadingMore")}
-        </p>
-      )}
-    </ListingPageShell>
+        {!initialLoading && edges.length === 0 && !hasSearch && (
+          <p className="text-sm text-muted-foreground" data-testid="catalog-empty">
+            {t("noDecks")}
+          </p>
+        )}
+
+        {!initialLoading && edges.length === 0 && hasSearch && (
+          <p className="text-sm text-muted-foreground" data-testid="catalog-empty-search">
+            {t("noMatch", { query: searchQuery })}
+          </p>
+        )}
+
+        {edges.length > 0 && (
+          <ul className="space-y-2" data-testid="catalog-list">
+            {edges.map((edge) => (
+              <CatalogListItem
+                key={edge.cursor}
+                node={edge.node}
+                importing={importingId === edge.node.id}
+                imported={importedIds.has(edge.node.id)}
+                onImport={handleImport}
+              />
+            ))}
+          </ul>
+        )}
+
+        <div ref={sentinelRef} aria-hidden="true" data-testid="catalog-sentinel" />
+
+        {fetchMoreError && (
+          <ErrorBanner
+            className="mt-3 flex flex-col items-center gap-2"
+            data-testid="catalog-fetch-more-error"
+          >
+            <span>{fetchMoreError}</span>
+            <Button type="button" variant="outline" size="sm" onClick={retryFetchMore}>
+              {tCommon("retry")}
+            </Button>
+          </ErrorBanner>
+        )}
+
+        {!fetchMoreError && fetchingMore && hasNextPage && (
+          <p
+            className="mt-3 text-center text-xs text-muted-foreground"
+            data-testid="catalog-loading-more"
+          >
+            {t("loadingMore")}
+          </p>
+        )}
+      </ListingPageShell>
+    </>
   );
 }

--- a/frontend/src/components/nav/header-search-action.test.ts
+++ b/frontend/src/components/nav/header-search-action.test.ts
@@ -2,15 +2,17 @@ import { describe, expect, it } from "vitest";
 import { resolveHeaderSearchAction } from "./header-search-action";
 
 describe("resolveHeaderSearchAction", () => {
-  it("returns true on /cardgroups", () => {
+  it("returns true on filterable list routes", () => {
     expect(resolveHeaderSearchAction("/cardgroups")).toBe(true);
+    expect(resolveHeaderSearchAction("/catalog")).toBe(true);
+    expect(resolveHeaderSearchAction("/admin/masters")).toBe(true);
+    expect(resolveHeaderSearchAction("/admin/users")).toBe(true);
   });
 
   it("returns false on non-filterable routes", () => {
     expect(resolveHeaderSearchAction("/")).toBe(false);
-    expect(resolveHeaderSearchAction("/catalog")).toBe(false);
-    expect(resolveHeaderSearchAction("/admin/users")).toBe(false);
     expect(resolveHeaderSearchAction("/cardgroups/123/edit")).toBe(false);
+    expect(resolveHeaderSearchAction("/admin/masters/123/edit")).toBe(false);
     expect(resolveHeaderSearchAction("/learn/123")).toBe(false);
   });
 });

--- a/frontend/src/components/nav/header-search-action.ts
+++ b/frontend/src/components/nav/header-search-action.ts
@@ -1,5 +1,5 @@
 // Exact-match routes that show the mobile header search trigger.
-const SEARCH_EXACT = new Set<string>(["/cardgroups"]);
+const SEARCH_EXACT = new Set<string>(["/cardgroups", "/catalog", "/admin/masters", "/admin/users"]);
 // Pattern routes (e.g. parameterized segments) that show the trigger.
 const SEARCH_PATTERNS: RegExp[] = [];
 
@@ -9,7 +9,8 @@ const SEARCH_PATTERNS: RegExp[] = [];
  * effects. Mirrors `resolveHeaderCreateAction`'s exact-set + regex-array shape.
  *
  * Routing rules:
- * - `/cardgroups` -> true (the filter lives here)
+ * - `/cardgroups`, `/catalog`, `/admin/masters`, `/admin/users` -> true
+ *   (each list screen wires the header-takeover filter)
  * - anything else -> false
  *
  * Built to extend: add routes to `SEARCH_EXACT` / `SEARCH_PATTERNS` (and wire

--- a/frontend/src/components/nav/logo-drawer.test.tsx
+++ b/frontend/src/components/nav/logo-drawer.test.tsx
@@ -415,7 +415,7 @@ describe("<LogoDrawer>", () => {
   });
 
   it("hides the search trigger on a non-filterable route", () => {
-    mockUsePathname.mockReturnValue("/catalog");
+    mockUsePathname.mockReturnValue("/profile");
     renderWithIntl(<LogoDrawer user={SIGNED_IN_USER} isAdmin={false} />);
 
     expect(screen.queryByRole("button", { name: "Search" })).not.toBeInTheDocument();


### PR DESCRIPTION
## Summary

Roll out the mobile **header-takeover search** UX (header magnifier + `SearchTakeoverBar`) to the three **static-route** list screens — `/catalog`, `/admin/masters`, `/admin/users` — matching `/cardgroups`. Desktop keeps its existing inline input; the takeover is mobile-only by decision. Search already worked on all three (backend `search` arg + `useDebouncedSearch` + `useConnectionPagination`); this PR only unifies the mobile UX and removes the per-page divergence.

Built on the `useHeaderTakeoverSearch` hook from #554 (merged via #557) — each screen adopts it with a one-line swap. Independent of the dynamic-route rollout (#556); the only shared file is `header-search-action.ts`, touched here with a 4-line append.

Closes #555

## Changes

### Adopt the hook on the three list screens

Each client swaps `useDebouncedSearch()` → `useHeaderTakeoverSearch()`, gates its existing desktop input mobile-off (`hidden md:block`) so it does not double with the takeover, and renders `<SearchTakeoverBar>` at the top of its returned JSX. The `search.query` → `useConnectionPagination` wiring is unchanged.

- `frontend/src/app/catalog/catalog-client.tsx` — desktop `<input>` (in the `ListingPageShell` `toolbar` slot) gated `hidden md:block`; takeover uses `Catalog.searchPlaceholder` / `Catalog.searchAriaLabel`.
- `frontend/src/app/admin/masters/admin-masters-client.tsx` — shadcn `<Input>` wrapper gated `hidden md:block`; takeover uses `AdminMasters.searchPlaceholder` / `AdminMasters.searchLabel`.
- `frontend/src/app/admin/users/admin-users-client.tsx` — desktop `<input>` wrapper gated `hidden md:block`; takeover uses `Admin.searchPlaceholder` / `Admin.searchLabel`.

No new i18n keys — every placeholder / aria-label already existed in both catalogs.

### Turn on the header trigger

- `frontend/src/components/nav/header-search-action.ts` — appends `/catalog`, `/admin/masters`, `/admin/users` to `SEARCH_EXACT` so the header shows the magnifier on those routes.
- `frontend/src/components/nav/header-search-action.test.ts` — the three new routes assert `true`.
- `frontend/src/components/nav/logo-drawer.test.tsx` — the "non-filterable route" example was `/catalog` (now filterable); retargeted to `/profile` so the assertion stays meaningful.

### Tests

- Co-located narrow tests for all three clients: the takeover opens on `flamingo:open-search`, and the desktop input carries `hidden md:block`.
- Broad page tests (`__tests__/admin-masters-list.test.tsx`, `admin-users-list.test.tsx`) keep their debounced-search assertions green — the search value still drives the query; the desktop searchbox is unambiguous before the takeover opens, and jsdom ignores the `hidden md:block` class.

## Verification

- typecheck ✓ (`tsc --noEmit`)
- lint ✓ (`biome check --error-on-warnings`, no code warnings)
- knip ✓ (no unused exports)
- test ✓ **1506 passing (161 files)**
- build ✓ (`next build`)
- CJK / PR-number language checks ✓ (no hits in changed files)

## Test plan

- [ ] `/catalog`, `/admin/masters`, `/admin/users` on mobile (`<md`) — tap the header 🔍; the takeover bar opens, filters live as you type, back / Escape closes it; no second inline input is visible.
- [ ] Same three on desktop (`md+`) — the inline filter field is unchanged; no header magnifier behavior regressions.

## Note

`header-search-action.ts` is also touched by #554 and the dynamic-route rollout (#556) — land serially / rebase rather than editing it from parallel branches.
