### PR TITLE
refactor(frontend): typed flamingo-events module for the header/page event bus

### DIFF
--- a/frontend/src/app/admin/masters/[id]/edit/cards/master-cards-client.tsx
+++ b/frontend/src/app/admin/masters/[id]/edit/cards/master-cards-client.tsx
@@ -16,6 +16,7 @@ import type { AdminMasterCardsConnectionQuery } from "@/generated/graphql";
 import { useBulkSelection } from "@/hooks/use-bulk-selection";
 import { useHeaderTakeoverSearch } from "@/hooks/use-header-takeover-search";
 import { getBackendErrorBanner } from "@/lib/apollo/errors";
+import { type AddMasterCardDetail, FLAMINGO_EVENT } from "@/lib/events/flamingo-events";
 import { MasterBatchImportForm } from "./master-batch-import-form";
 import { useMasterCardMutations } from "./use-master-card-mutations";
 import { useMasterCardsConnection } from "./use-master-cards-connection";
@@ -264,15 +265,13 @@ export function MasterCardsClient({
   // Master cards have no separate-page create target, so there is no fallback
   // navigation to preventDefault against — the listener simply opens the sheet.
   useEffect(() => {
-    function handleAddMasterCard(event: Event) {
-      if (!(event instanceof CustomEvent)) return;
-      const detail = event.detail as { masterId?: unknown } | null;
-      if (detail?.masterId !== masterId) return;
+    function handleAddMasterCard(event: CustomEvent<AddMasterCardDetail>) {
+      if (event.detail?.masterId !== masterId) return;
       event.preventDefault();
       openAddSheet();
     }
-    window.addEventListener("flamingo:add-master-card", handleAddMasterCard);
-    return () => window.removeEventListener("flamingo:add-master-card", handleAddMasterCard);
+    window.addEventListener(FLAMINGO_EVENT.addMasterCard, handleAddMasterCard);
+    return () => window.removeEventListener(FLAMINGO_EVENT.addMasterCard, handleAddMasterCard);
   }, [masterId, openAddSheet]);
 
   async function handleCreate(values: { front: string; back: string }) {

--- a/frontend/src/app/cardgroups/[id]/cards/cards-client.tsx
+++ b/frontend/src/app/cardgroups/[id]/cards/cards-client.tsx
@@ -17,6 +17,7 @@ import type { CardsByCardgroupConnectionQuery } from "@/generated/graphql";
 import { useBulkSelection } from "@/hooks/use-bulk-selection";
 import { useHeaderTakeoverSearch } from "@/hooks/use-header-takeover-search";
 import { getBackendErrorBanner } from "@/lib/apollo/errors";
+import { type AddCardDetail, FLAMINGO_EVENT } from "@/lib/events/flamingo-events";
 import { useCardMutations } from "./use-card-mutations";
 import { useCardsConnection } from "./use-cards-connection";
 
@@ -259,17 +260,15 @@ export function CardsClient({
   const closeBatchImport = useCallback(() => setBatchImportOpen(false), []);
 
   useEffect(() => {
-    function handleAddCardEvent(event: Event) {
-      if (!(event instanceof CustomEvent)) return;
-      const detail = event.detail as { cardgroupId?: unknown } | null;
-      if (detail?.cardgroupId !== cardgroupId) return;
+    function handleAddCardEvent(event: CustomEvent<AddCardDetail>) {
+      if (event.detail?.cardgroupId !== cardgroupId) return;
 
       event.preventDefault();
       openAddSheet();
     }
 
-    window.addEventListener("flamingo:add-card", handleAddCardEvent);
-    return () => window.removeEventListener("flamingo:add-card", handleAddCardEvent);
+    window.addEventListener(FLAMINGO_EVENT.addCard, handleAddCardEvent);
+    return () => window.removeEventListener(FLAMINGO_EVENT.addCard, handleAddCardEvent);
   }, [cardgroupId, openAddSheet]);
 
   async function handleCreate(values: { front: string; back: string }) {

--- a/frontend/src/app/cardgroups/cardgroups-client.tsx
+++ b/frontend/src/app/cardgroups/cardgroups-client.tsx
@@ -21,6 +21,7 @@ import {
 } from "@/generated/graphql";
 import { useHeaderTakeoverSearch } from "@/hooks/use-header-takeover-search";
 import { getBackendErrorBanner } from "@/lib/apollo/errors";
+import { FLAMINGO_EVENT } from "@/lib/events/flamingo-events";
 import { useConnectionPagination } from "@/lib/pagination/use-connection-pagination";
 import { useUndoDelete } from "@/lib/undo-delete";
 import { CARDGROUPS_DEFAULT_VARS, DeleteCardgroupMutation } from "./queries";
@@ -179,8 +180,8 @@ export default function CardgroupsClient({ initialConnection }: CardgroupsClient
       event.preventDefault();
       openAddSheet();
     }
-    window.addEventListener("flamingo:add-cardgroup", handleAddCardgroupEvent);
-    return () => window.removeEventListener("flamingo:add-cardgroup", handleAddCardgroupEvent);
+    window.addEventListener(FLAMINGO_EVENT.addCardgroup, handleAddCardgroupEvent);
+    return () => window.removeEventListener(FLAMINGO_EVENT.addCardgroup, handleAddCardgroupEvent);
   }, [openAddSheet]);
 
   async function handleCreateCardgroup(values: { name: string }) {

--- a/frontend/src/app/learn/[cardgroupId]/_components/learn-add-card-sheet.tsx
+++ b/frontend/src/app/learn/[cardgroupId]/_components/learn-add-card-sheet.tsx
@@ -6,6 +6,7 @@ import { cardsDefaultVars } from "@/app/cardgroups/[id]/cards/queries";
 import { useCardMutations } from "@/app/cardgroups/[id]/cards/use-card-mutations";
 import { CardForm } from "@/components/cardgroups/card-form";
 import { FormSheet, useFormSheetClose } from "@/components/ui/form-sheet";
+import { type AddCardDetail, FLAMINGO_EVENT } from "@/lib/events/flamingo-events";
 
 function AddCardSheetContent({
   submit,
@@ -73,17 +74,15 @@ export function LearnAddCardSheet({ cardgroupId }: { cardgroupId: string }) {
   }, [resetCreateCard]);
 
   useEffect(() => {
-    function handleAddCardEvent(event: Event) {
-      if (!(event instanceof CustomEvent)) return;
-      const detail = event.detail as { cardgroupId?: unknown } | null;
-      if (detail?.cardgroupId !== cardgroupId) return;
+    function handleAddCardEvent(event: CustomEvent<AddCardDetail>) {
+      if (event.detail?.cardgroupId !== cardgroupId) return;
 
       event.preventDefault();
       openSheet();
     }
 
-    window.addEventListener("flamingo:add-card", handleAddCardEvent);
-    return () => window.removeEventListener("flamingo:add-card", handleAddCardEvent);
+    window.addEventListener(FLAMINGO_EVENT.addCard, handleAddCardEvent);
+    return () => window.removeEventListener(FLAMINGO_EVENT.addCard, handleAddCardEvent);
   }, [cardgroupId, openSheet]);
 
   async function handleCreate(values: { front: string; back: string }) {

--- a/frontend/src/components/nav/logo-drawer.tsx
+++ b/frontend/src/components/nav/logo-drawer.tsx
@@ -9,6 +9,11 @@ import { LogoutButton } from "@/app/_components/logout-button";
 import { FlamingoMark } from "@/components/brand/flamingo-mark";
 import { MobileMenuTrigger } from "@/components/nav/mobile-menu-trigger";
 import { Sheet, SheetClose, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
+import {
+  dispatchFlamingo,
+  FLAMINGO_EVENT,
+  type SearchStateDetail,
+} from "@/lib/events/flamingo-events";
 import { useSheetSearchParam } from "@/lib/url/use-sheet-search-param";
 import { resolveHeaderCreateAction } from "./header-create-action";
 import { resolveHeaderSearchAction } from "./header-search-action";
@@ -46,8 +51,8 @@ export function LogoDrawer({ user, isAdmin }: LogoDrawerProps) {
   // active dot and reflect aria-expanded. When the bar closes, return focus to
   // the trigger.
   useEffect(() => {
-    function onSearchState(e: Event) {
-      const detail = (e as CustomEvent<{ active: boolean; visible: boolean }>).detail;
+    function onSearchState(e: CustomEvent<SearchStateDetail>) {
+      const detail = e.detail;
       if (!detail) return;
       setSearchActive(detail.active);
       setSearchVisible(detail.visible);
@@ -56,8 +61,8 @@ export function LogoDrawer({ user, isAdmin }: LogoDrawerProps) {
       }
       prevVisibleRef.current = detail.visible;
     }
-    window.addEventListener("flamingo:search-state", onSearchState);
-    return () => window.removeEventListener("flamingo:search-state", onSearchState);
+    window.addEventListener(FLAMINGO_EVENT.searchState, onSearchState);
+    return () => window.removeEventListener(FLAMINGO_EVENT.searchState, onSearchState);
   }, []);
 
   // The '+' affordance dispatches a cancelable event so an in-context drawer can
@@ -69,18 +74,18 @@ export function LogoDrawer({ user, isAdmin }: LogoDrawerProps) {
     if (!createAction) return;
     switch (createAction.kind) {
       case "cardgroup": {
-        const event = new CustomEvent("flamingo:add-cardgroup", { cancelable: true });
-        if (window.dispatchEvent(event)) {
+        if (dispatchFlamingo(FLAMINGO_EVENT.addCardgroup, { cancelable: true })) {
           router.push("/cardgroups/new");
         }
         return;
       }
       case "card-with-group": {
-        const event = new CustomEvent("flamingo:add-card", {
-          cancelable: true,
-          detail: { cardgroupId: createAction.cardgroupId },
-        });
-        if (window.dispatchEvent(event)) {
+        if (
+          dispatchFlamingo(FLAMINGO_EVENT.addCard, {
+            cancelable: true,
+            detail: { cardgroupId: createAction.cardgroupId },
+          })
+        ) {
           // `href` is already single-encoded by the resolver, including the
           // &return=/learn/... param on learn routes — push it as-is.
           router.push(createAction.href);
@@ -99,12 +104,10 @@ export function LogoDrawer({ user, isAdmin }: LogoDrawerProps) {
       // in-page MasterCardsClient is always mounted on the edit screen and
       // claims this event to open its add-card sheet. No router.push fallback.
       case "master-card": {
-        window.dispatchEvent(
-          new CustomEvent("flamingo:add-master-card", {
-            cancelable: true,
-            detail: { masterId: createAction.masterId },
-          }),
-        );
+        dispatchFlamingo(FLAMINGO_EVENT.addMasterCard, {
+          cancelable: true,
+          detail: { masterId: createAction.masterId },
+        });
         return;
       }
       default: {
@@ -129,7 +132,7 @@ export function LogoDrawer({ user, isAdmin }: LogoDrawerProps) {
           <button
             ref={searchTriggerRef}
             type="button"
-            onClick={() => window.dispatchEvent(new CustomEvent("flamingo:open-search"))}
+            onClick={() => dispatchFlamingo(FLAMINGO_EVENT.openSearch)}
             aria-label={t("openSearch")}
             aria-expanded={searchVisible}
             data-testid="header-search-trigger"

--- a/frontend/src/hooks/use-header-takeover-search.ts
+++ b/frontend/src/hooks/use-header-takeover-search.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
+import { dispatchFlamingo, FLAMINGO_EVENT } from "@/lib/events/flamingo-events";
 import { type UseDebouncedSearchResult, useDebouncedSearch } from "./use-debounced-search";
 
 export interface UseHeaderTakeoverSearchResult extends UseDebouncedSearchResult {
@@ -27,27 +28,23 @@ export function useHeaderTakeoverSearch(opts?: {
     function handleOpenSearch() {
       setSearchOpen(true);
     }
-    window.addEventListener("flamingo:open-search", handleOpenSearch);
-    return () => window.removeEventListener("flamingo:open-search", handleOpenSearch);
+    window.addEventListener(FLAMINGO_EVENT.openSearch, handleOpenSearch);
+    return () => window.removeEventListener(FLAMINGO_EVENT.openSearch, handleOpenSearch);
   }, []);
 
   // Report filter state back to the header trigger (active dot + aria-expanded).
   useEffect(() => {
-    window.dispatchEvent(
-      new CustomEvent("flamingo:search-state", {
-        detail: { active: searchQuery !== null && searchQuery !== "", visible: searchOpen },
-      }),
-    );
+    dispatchFlamingo(FLAMINGO_EVENT.searchState, {
+      detail: { active: searchQuery !== null && searchQuery !== "", visible: searchOpen },
+    });
   }, [searchQuery, searchOpen]);
 
   // Reset the header trigger when the page unmounts (route leave).
   useEffect(() => {
     return () => {
-      window.dispatchEvent(
-        new CustomEvent("flamingo:search-state", {
-          detail: { active: false, visible: false },
-        }),
-      );
+      dispatchFlamingo(FLAMINGO_EVENT.searchState, {
+        detail: { active: false, visible: false },
+      });
     };
   }, []);
 

--- a/frontend/src/lib/events/flamingo-events.test.ts
+++ b/frontend/src/lib/events/flamingo-events.test.ts
@@ -1,0 +1,96 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  type AddCardDetail,
+  type AddMasterCardDetail,
+  dispatchFlamingo,
+  FLAMINGO_EVENT,
+  type SearchStateDetail,
+} from "./flamingo-events";
+
+// Listeners registered per-test, torn down in afterEach so a failing assertion
+// never leaks a handler into the next test.
+const registered: Array<[string, EventListener]> = [];
+function listen(type: string, handler: EventListener) {
+  window.addEventListener(type, handler);
+  registered.push([type, handler]);
+}
+afterEach(() => {
+  for (const [type, handler] of registered.splice(0)) {
+    window.removeEventListener(type, handler);
+  }
+});
+
+describe("FLAMINGO_EVENT", () => {
+  it("keeps the exact wire string values (rename regression guard)", () => {
+    // These strings are the shell <-> page contract. A rename here silently
+    // breaks every dispatcher/listener that was not updated in lockstep.
+    expect(FLAMINGO_EVENT).toEqual({
+      openSearch: "flamingo:open-search",
+      searchState: "flamingo:search-state",
+      addCardgroup: "flamingo:add-cardgroup",
+      addCard: "flamingo:add-card",
+      addMasterCard: "flamingo:add-master-card",
+    });
+  });
+});
+
+describe("dispatchFlamingo", () => {
+  it("delivers the search-state detail to a window listener", () => {
+    const received: SearchStateDetail[] = [];
+    listen(FLAMINGO_EVENT.searchState, (e) => {
+      received.push((e as CustomEvent<SearchStateDetail>).detail);
+    });
+    dispatchFlamingo(FLAMINGO_EVENT.searchState, { detail: { active: true, visible: false } });
+    expect(received).toEqual([{ active: true, visible: false }]);
+  });
+
+  it("delivers the add-card detail (cardgroupId)", () => {
+    const received: AddCardDetail[] = [];
+    listen(FLAMINGO_EVENT.addCard, (e) => {
+      received.push((e as CustomEvent<AddCardDetail>).detail);
+    });
+    dispatchFlamingo(FLAMINGO_EVENT.addCard, { detail: { cardgroupId: "g1" }, cancelable: true });
+    expect(received).toEqual([{ cardgroupId: "g1" }]);
+  });
+
+  it("delivers the add-master-card detail (masterId)", () => {
+    const received: AddMasterCardDetail[] = [];
+    listen(FLAMINGO_EVENT.addMasterCard, (e) => {
+      received.push((e as CustomEvent<AddMasterCardDetail>).detail);
+    });
+    dispatchFlamingo(FLAMINGO_EVENT.addMasterCard, {
+      detail: { masterId: "m1" },
+      cancelable: true,
+    });
+    expect(received).toEqual([{ masterId: "m1" }]);
+  });
+
+  it("dispatches a no-detail event (open-search)", () => {
+    let fired = false;
+    listen(FLAMINGO_EVENT.openSearch, () => {
+      fired = true;
+    });
+    dispatchFlamingo(FLAMINGO_EVENT.openSearch);
+    expect(fired).toBe(true);
+  });
+
+  it("returns true when no listener cancels a cancelable event", () => {
+    expect(
+      dispatchFlamingo(FLAMINGO_EVENT.addCard, {
+        detail: { cardgroupId: "g1" },
+        cancelable: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false when a listener calls preventDefault (router-push fallback gate)", () => {
+    listen(FLAMINGO_EVENT.addCard, (e) => e.preventDefault());
+    expect(
+      dispatchFlamingo(FLAMINGO_EVENT.addCard, {
+        detail: { cardgroupId: "g1" },
+        cancelable: true,
+      }),
+    ).toBe(false);
+  });
+});

--- a/frontend/src/lib/events/flamingo-events.ts
+++ b/frontend/src/lib/events/flamingo-events.ts
@@ -1,0 +1,70 @@
+// Typed contract for the global-shell <-> feature-page event bus.
+//
+// The nav header (LogoDrawer) and feature pages communicate through a handful
+// of `window` CustomEvents: the header dispatches and a page claims (the "+"
+// create affordance, the search magnifier), or a page dispatches and the header
+// reacts (the search-state active dot / aria-expanded). Centralizing the names
+// and detail shapes here makes the protocol compiler-enforced — a typo'd event
+// name or detail field becomes a type error rather than a silent runtime no-op.
+
+/** `flamingo:search-state` payload: page -> header (active dot + aria-expanded). */
+export interface SearchStateDetail {
+  /** A non-empty filter is applied. */
+  active: boolean;
+  /** The takeover bar is open. */
+  visible: boolean;
+}
+
+/** `flamingo:add-card` payload: header "+" -> the in-context card sheet. */
+export interface AddCardDetail {
+  cardgroupId: string;
+}
+
+/** `flamingo:add-master-card` payload: header "+" -> the master-cards sheet. */
+export interface AddMasterCardDetail {
+  masterId: string;
+}
+
+// Augment WindowEventMap so add/removeEventListener infer the CustomEvent detail
+// type at every call site with zero per-site annotation. Keys must be string
+// literals, so they are spelled out here and mirrored by FLAMINGO_EVENT below.
+declare global {
+  interface WindowEventMap {
+    "flamingo:open-search": CustomEvent<undefined>;
+    "flamingo:search-state": CustomEvent<SearchStateDetail>;
+    "flamingo:add-cardgroup": CustomEvent<undefined>;
+    "flamingo:add-card": CustomEvent<AddCardDetail>;
+    "flamingo:add-master-card": CustomEvent<AddMasterCardDetail>;
+  }
+}
+
+/** Canonical event names — reference these instead of raw string literals. */
+export const FLAMINGO_EVENT = {
+  openSearch: "flamingo:open-search",
+  searchState: "flamingo:search-state",
+  addCardgroup: "flamingo:add-cardgroup",
+  addCard: "flamingo:add-card",
+  addMasterCard: "flamingo:add-master-card",
+} as const;
+
+type FlamingoEventName = (typeof FLAMINGO_EVENT)[keyof typeof FLAMINGO_EVENT];
+
+type FlamingoDetail<K extends FlamingoEventName> =
+  WindowEventMap[K] extends CustomEvent<infer D> ? D : never;
+
+/**
+ * Type-safe `window.dispatchEvent(new CustomEvent(...))`. Events whose detail is
+ * `undefined` (open-search, add-cardgroup) take no init; events with a detail
+ * require it. Returns the `dispatchEvent` boolean — `false` means a listener
+ * called `preventDefault()`, which the cancelable create-events use to decide
+ * whether to fall back to a `router.push(...)`. Pass `{ cancelable: true }` for
+ * those.
+ */
+export function dispatchFlamingo<K extends FlamingoEventName>(
+  type: K,
+  ...args: FlamingoDetail<K> extends undefined
+    ? [init?: { cancelable?: boolean }]
+    : [init: { detail: FlamingoDetail<K>; cancelable?: boolean }]
+): boolean {
+  return window.dispatchEvent(new CustomEvent(type, args[0]));
+}


### PR DESCRIPTION
## Summary

Lifts the implicit shell⇄page event protocol — the `window` `CustomEvent`s the nav header (`LogoDrawer`) and feature pages exchange for the search magnifier and the "+" create affordance — into a single typed module, so the contract is compiler-enforced instead of stringly-typed. **Behavior-preserving**: every event keeps its exact wire string, so existing unit tests and the `cardgroups-mobile-search.spec.ts` e2e stay green.

Before this change the event names appeared as raw literals across 6 files, the `{ active, visible }` `search-state` detail shape was inlined twice, and there was no `WindowEventMap` augmentation — a one-character typo in an event name or detail field was a silent runtime no-op that neither the compiler nor any test could catch.

Closes #560

## Changes

### New typed event module

- `frontend/src/lib/events/flamingo-events.ts` — single source of truth for the header↔page bus. Augments `WindowEventMap` so `add`/`removeEventListener` infer the `CustomEvent` detail type per call site; exports the `SearchStateDetail` / `AddCardDetail` / `AddMasterCardDetail` interfaces, the `FLAMINGO_EVENT` name constants, and a typed `dispatchFlamingo` helper. The helper uses a conditional-tuple signature (detail required for `search-state`/`add-card`/`add-master-card`, omitted for `open-search`/`add-cardgroup`) and returns the `dispatchEvent` boolean so the cancelable create-events can gate their `router.push(...)` fallback.
- `frontend/src/lib/events/flamingo-events.test.ts` — co-located test: detail delivery for each payload event, `preventDefault` → `false` / no-cancel → `true` return for cancelable events, no-detail dispatch, and a wire-value regression guard pinning the literal strings.

### Adopt the typed bus at every dispatch / listen site

- `frontend/src/components/nav/logo-drawer.tsx` — `search-state` listener now reads `SearchStateDetail` (the inline `{ active; visible }` cast is gone); `open-search` / `add-cardgroup` / `add-card` / `add-master-card` dispatch through `dispatchFlamingo`, preserving `cancelable` and the dispatch-return → `router.push` fallback for the cardgroup/card cases.
- `frontend/src/hooks/use-header-takeover-search.ts` — `open-search` listener + the two `search-state` dispatches go through the constants/helper; the second inline `SearchStateDetail` shape is removed.
- `frontend/src/app/cardgroups/cardgroups-client.tsx` — `add-cardgroup` listener keyed on `FLAMINGO_EVENT.addCardgroup`.
- `frontend/src/app/cardgroups/[id]/cards/cards-client.tsx` and `frontend/src/app/admin/masters/[id]/edit/cards/master-cards-client.tsx` — `add-card` / `add-master-card` listeners typed via `CustomEvent<AddCardDetail>` / `CustomEvent<AddMasterCardDetail>`; the redundant `instanceof CustomEvent` guard and `as { …?: unknown }` casts are dropped.
- `frontend/src/app/learn/[cardgroupId]/_components/learn-add-card-sheet.tsx` — `add-card` listener typed the same way.

## Verification

- typecheck ✓ (`tsc --noEmit`)
- lint ✓ (`biome check --error-on-warnings`, no warnings)
- knip ✓ (no unused exports)
- test ✓ **1519 passing** — including the behavior-preservation guards (`logo-drawer.test.tsx`, `use-header-takeover-search.test.tsx`, the cards-client event-bus tests)
- build ✓ (`next build`)
- no raw `"flamingo:` string literals remain outside the module:

  ```bash
  grep -rn '"flamingo:' frontend/src --include='*.ts' --include='*.tsx' | grep -v flamingo-events.ts | grep -v test
  ```

The e2e spec `frontend/e2e/cardgroups-mobile-search.spec.ts` dispatches/selects by the unchanged wire strings + `data-testid`s, so it continues to guard the search protocol end-to-end.

## Test plan

- [ ] `/cardgroups` mobile (`<md`) — header 🔍 opens the takeover bar, filters live, active dot shows while a query is set, back/Escape closes. Unchanged.
- [ ] `/cardgroups` — header "+" opens the create-cardgroup drawer in place (cancelable path), falling back to `/cardgroups/new` when no drawer is mounted.
- [ ] `/cardgroups/[id]/edit` and `/admin/masters/[id]/edit/cards` — header "+" opens the add-card / add-master-card sheet only for the active deck (id-scoped listener).
- [ ] `/learn/[cardgroupId]` — header "+" opens the in-context add-card sheet.

## Dependency

Keystone for the search-cleanup follow-up. Blocks #561 (shared `CardSearchInput` / `CardFetchMoreError` extraction) — both touch the two cards clients, so #561 lands after this merges.
