### PR TITLE
refactor(frontend): extract shared CardSearchInput + CardFetchMoreError from cards clients

### DIFF
--- a/frontend/src/app/admin/masters/[id]/edit/cards/master-cards-client.tsx
+++ b/frontend/src/app/admin/masters/[id]/edit/cards/master-cards-client.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { Search } from "lucide-react";
 import { useTranslations } from "next-intl";
 import type { ReactNode, RefObject } from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { BulkActionBar } from "@/components/cardgroups/bulk-action-bar";
+import { CardFetchMoreError } from "@/components/cardgroups/card-fetch-more-error";
 import { CardForm } from "@/components/cardgroups/card-form";
 import { CardRow } from "@/components/cardgroups/card-row";
+import { CardSearchInput } from "@/components/cardgroups/card-search-input";
 import type { SwipeableRowHandle } from "@/components/cardgroups/swipeable-row";
 import { SearchTakeoverBar } from "@/components/search/search-takeover-bar";
 import { Button } from "@/components/ui/button";
@@ -24,45 +25,6 @@ import { useMasterCardsConnection } from "./use-master-cards-connection";
 type Connection = AdminMasterCardsConnectionQuery["adminMasterCardsConnection"];
 export type MasterCardEdge = Connection["edges"][number];
 export type MasterCardConnectionPageInfo = Connection["pageInfo"];
-
-const FetchMoreError = ({ message, onRetry }: { message: string; onRetry: () => void }) => {
-  const tCommon = useTranslations("Common");
-  return (
-    <ErrorBanner
-      className="mt-3 flex flex-col items-center gap-2"
-      data-testid="cards-fetch-more-error"
-    >
-      <span>{message}</span>
-      <Button type="button" variant="outline" size="sm" onClick={onRetry}>
-        {tCommon("retry")}
-      </Button>
-    </ErrorBanner>
-  );
-};
-
-const SearchInput = ({ value, onChange }: { value: string; onChange: (next: string) => void }) => {
-  const t = useTranslations("Cards");
-  return (
-    // Desktop only: on mobile the search moves into the header-takeover bar.
-    <div className="mb-3 hidden md:block">
-      <div className="relative">
-        <Search
-          aria-hidden="true"
-          className="pointer-events-none absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
-        />
-        <input
-          type="search"
-          placeholder={t("searchPlaceholder")}
-          value={value}
-          onChange={(e) => onChange(e.target.value)}
-          className="w-full rounded-md border border-input bg-background pl-8 pr-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-          aria-label={t("searchAriaLabel")}
-          data-testid="cards-search-input"
-        />
-      </div>
-    </div>
-  );
-};
 
 function EditCardSheetContent({
   card,
@@ -364,7 +326,7 @@ export function MasterCardsClient({
               })
             : sectionHeader}
 
-          <SearchInput value={search.input} onChange={search.setInput} />
+          <CardSearchInput value={search.input} onChange={search.setInput} />
 
           {selection.count > 0 && (
             <BulkActionBar
@@ -470,7 +432,9 @@ export function MasterCardsClient({
           </FormSheet>
 
           <div ref={sentinelRef} aria-hidden="true" data-testid="cards-sentinel" />
-          {fetchMoreError && <FetchMoreError message={fetchMoreError} onRetry={retryFetchMore} />}
+          {fetchMoreError && (
+            <CardFetchMoreError message={fetchMoreError} onRetry={retryFetchMore} />
+          )}
           {!fetchMoreError && fetchingMore && pageInfo.hasNextPage && (
             <p className="mt-3 text-center text-xs text-muted-foreground">{t("loadingMore")}</p>
           )}

--- a/frontend/src/app/cardgroups/[id]/cards/cards-client.tsx
+++ b/frontend/src/app/cardgroups/[id]/cards/cards-client.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { Search } from "lucide-react";
 import { useTranslations } from "next-intl";
 import type { ReactNode, RefObject } from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { BulkActionBar } from "@/components/cardgroups/bulk-action-bar";
+import { CardFetchMoreError } from "@/components/cardgroups/card-fetch-more-error";
 import { CardForm } from "@/components/cardgroups/card-form";
 import { CardRow } from "@/components/cardgroups/card-row";
+import { CardSearchInput } from "@/components/cardgroups/card-search-input";
 import { CardgroupBatchImportForm } from "@/components/cardgroups/cardgroup-batch-import-form";
 import type { SwipeableRowHandle } from "@/components/cardgroups/swipeable-row";
 import { SearchTakeoverBar } from "@/components/search/search-takeover-bar";
@@ -24,45 +25,6 @@ import { useCardsConnection } from "./use-cards-connection";
 type Connection = CardsByCardgroupConnectionQuery["cardsByCardgroupConnection"];
 export type CardEdge = Connection["edges"][number];
 export type CardConnectionPageInfo = Connection["pageInfo"];
-
-const FetchMoreError = ({ message, onRetry }: { message: string; onRetry: () => void }) => {
-  const tCommon = useTranslations("Common");
-  return (
-    <ErrorBanner
-      className="mt-3 flex flex-col items-center gap-2"
-      data-testid="cards-fetch-more-error"
-    >
-      <span>{message}</span>
-      <Button type="button" variant="outline" size="sm" onClick={onRetry}>
-        {tCommon("retry")}
-      </Button>
-    </ErrorBanner>
-  );
-};
-
-const SearchInput = ({ value, onChange }: { value: string; onChange: (next: string) => void }) => {
-  const t = useTranslations("Cards");
-  return (
-    // Desktop only: on mobile the search moves into the header-takeover bar.
-    <div className="mb-3 hidden md:block">
-      <div className="relative">
-        <Search
-          aria-hidden="true"
-          className="pointer-events-none absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
-        />
-        <input
-          type="search"
-          placeholder={t("searchPlaceholder")}
-          value={value}
-          onChange={(e) => onChange(e.target.value)}
-          className="w-full rounded-md border border-input bg-background pl-8 pr-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-          aria-label={t("searchAriaLabel")}
-          data-testid="cards-search-input"
-        />
-      </div>
-    </div>
-  );
-};
 
 function EditCardSheetContent({
   card,
@@ -359,7 +321,7 @@ export function CardsClient({
             sectionHeader
           )}
 
-          <SearchInput value={search.input} onChange={search.setInput} />
+          <CardSearchInput value={search.input} onChange={search.setInput} />
 
           {selection.count > 0 && (
             <BulkActionBar
@@ -474,7 +436,9 @@ export function CardsClient({
           </FormSheet>
 
           <div ref={sentinelRef} aria-hidden="true" data-testid="cards-sentinel" />
-          {fetchMoreError && <FetchMoreError message={fetchMoreError} onRetry={retryFetchMore} />}
+          {fetchMoreError && (
+            <CardFetchMoreError message={fetchMoreError} onRetry={retryFetchMore} />
+          )}
           {!fetchMoreError && fetchingMore && pageInfo.hasNextPage && (
             <p className="mt-3 text-center text-xs text-muted-foreground">{t("loadingMore")}</p>
           )}

--- a/frontend/src/components/cardgroups/card-fetch-more-error.tsx
+++ b/frontend/src/components/cardgroups/card-fetch-more-error.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { Button } from "@/components/ui/button";
+import { ErrorBanner } from "@/components/ui/error-banner";
+
+export function CardFetchMoreError({ message, onRetry }: { message: string; onRetry: () => void }) {
+  const tCommon = useTranslations("Common");
+  return (
+    <ErrorBanner
+      className="mt-3 flex flex-col items-center gap-2"
+      data-testid="cards-fetch-more-error"
+    >
+      <span>{message}</span>
+      <Button type="button" variant="outline" size="sm" onClick={onRetry}>
+        {tCommon("retry")}
+      </Button>
+    </ErrorBanner>
+  );
+}

--- a/frontend/src/components/cardgroups/card-search-input.tsx
+++ b/frontend/src/components/cardgroups/card-search-input.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { Search } from "lucide-react";
+import { useTranslations } from "next-intl";
+
+export function CardSearchInput({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (next: string) => void;
+}) {
+  const t = useTranslations("Cards");
+  return (
+    // Desktop only: on mobile the search moves into the header-takeover bar.
+    <div className="mb-3 hidden md:block">
+      <div className="relative">
+        <Search
+          aria-hidden="true"
+          className="pointer-events-none absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+        />
+        <input
+          type="search"
+          placeholder={t("searchPlaceholder")}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          className="w-full rounded-md border border-input bg-background pl-8 pr-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          aria-label={t("searchAriaLabel")}
+          data-testid="cards-search-input"
+        />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

`cards-client.tsx` and `master-cards-client.tsx` carried **byte-identical copies** of two private subcomponents — the desktop `SearchInput` (the `hidden md:block` field that pairs with the mobile header-takeover bar) and the `FetchMoreError` retry banner. This lifts each to a single shared component under `frontend/src/components/cardgroups/`, where both clients already import `CardForm` / `CardRow` / `BulkActionBar` / `SwipeableRow`. **Behavior-preserving**: same DOM, same `data-testid`s, same i18n keys, so the co-located client tests stay green.

Before this change the same JSX (~37 lines) was duplicated across the two clients; a fix or accessibility tweak to one copy silently diverged from the other.

Closes #561

## Changes

### New shared components

- `frontend/src/components/cardgroups/card-search-input.tsx` — exports `CardSearchInput` (`Search` icon + `useTranslations("Cards")`; `data-testid="cards-search-input"`). Desktop-only field; on mobile the search lives in the header-takeover bar.
- `frontend/src/components/cardgroups/card-fetch-more-error.tsx` — exports `CardFetchMoreError` (`ErrorBanner` + `Button` + `useTranslations("Common")`; `data-testid="cards-fetch-more-error"`). Verbatim lift of the fetch-more retry banner.

Both carry `"use client"`, matching the sibling interactive components in the same directory (`bulk-action-bar.tsx`, `card-row.tsx`, `cardgroup-chip.tsx`).

### Adopt the shared components in both cards clients

- `frontend/src/app/cardgroups/[id]/cards/cards-client.tsx` and `frontend/src/app/admin/masters/[id]/edit/cards/master-cards-client.tsx` — delete the local `SearchInput` / `FetchMoreError` declarations, import the shared components, and swap the JSX usages (`<SearchInput …/>` → `<CardSearchInput …/>`, `<FetchMoreError …/>` → `<CardFetchMoreError …/>`). Props are unchanged. The now-unused `Search` (`lucide-react`) import is pruned; `ErrorBanner` and `Button` stay (still used by the query-error banners and the empty-state).

## Verification

- typecheck ✓ (`tsc --noEmit`)
- lint ✓ (`biome check --error-on-warnings`, no warnings)
- knip ✓ (no unused exports, no orphan imports)
- test ✓ **1519 passing (162 files)** — the co-located `cards-client.test.tsx` / `master-cards-client.test.tsx` stay green because the DOM and `data-testid`s are unchanged
- build ✓ (`next build`)
- both subcomponents now live in exactly one place:

  ```bash
  grep -rn "const SearchInput\|const FetchMoreError" frontend/src/app --include='*.tsx'  # -> nothing
  ```

## Test plan

- [ ] `/cardgroups/[id]/cards` desktop (`md+`) — the search field renders, filters live as you type, and the fetch-more retry banner appears + retries on a paginated fetch error. Unchanged.
- [ ] `/cardgroups/[id]/cards` mobile (`<md`) — the desktop field is hidden; search runs through the header-takeover bar. Unchanged.
- [ ] `/admin/masters/[id]/edit/cards` — same two checks for the master-cards screen.

## Dependency

Landed after #560 (the typed `flamingo-events` keystone, merged via #562) — both PRs touch the two cards clients, so this followed to avoid a conflict.
