### PR TITLE
refactor(frontend): remove page-title subtitles across feature pages

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -48,8 +48,7 @@
     "message": "An unexpected error occurred. Please try again."
   },
   "Settings": {
-    "heading": "Settings",
-    "description": "Manage your preferences."
+    "heading": "Settings"
   },
   "Search": {
     "back": "Close search",
@@ -77,7 +76,6 @@
   },
   "Catalog": {
     "title": "Catalog",
-    "description": "Browse published cardgroups and import them.",
     "searchPlaceholder": "Search cardgroups...",
     "searchAriaLabel": "Search catalog cardgroups",
     "import": "Import",
@@ -98,7 +96,6 @@
   "Cardgroups": {
     "updatedAt": "Updated {date}",
     "myCardgroups": "My cardgroups",
-    "browseManage": "Browse and manage the cardgroups you have created.",
     "newCardgroup": "New cardgroup",
     "noCardgroupsYet": "No cardgroups yet",
     "noMatch": "No cardgroups match \"{query}\"",
@@ -285,7 +282,6 @@
   },
   "AdminMasters": {
     "title": "Masters",
-    "description": "Manage master decks shown in the public catalog.",
     "searchPlaceholder": "Search masters...",
     "searchLabel": "Search masters",
     "newMaster": "New master",
@@ -376,7 +372,6 @@
     "systemRoleBanner": "This is a system role. Its name cannot be changed.",
     "newRole": "New role",
     "noRolesYet": "No roles yet",
-    "rolesDescription": "Manage roles available to assign to users.",
     "editRoleTitle": "Edit role",
     "createRole": "Create",
     "deleteAuthFailed": "Your session has expired. Please sign in again.",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -48,8 +48,7 @@
     "message": "予期しないエラーが発生しました。もう一度お試しください。"
   },
   "Settings": {
-    "heading": "設定",
-    "description": "環境設定を管理します。"
+    "heading": "設定"
   },
   "Search": {
     "back": "検索を閉じる",
@@ -77,7 +76,6 @@
   },
   "Catalog": {
     "title": "カタログ",
-    "description": "公開されたカードグループを閲覧し、自分のカードグループにインポートできます。",
     "searchPlaceholder": "カードグループを検索...",
     "searchAriaLabel": "カタログのカードグループを検索",
     "import": "インポート",
@@ -98,7 +96,6 @@
   "Cardgroups": {
     "updatedAt": "{date}に更新",
     "myCardgroups": "マイカードグループ",
-    "browseManage": "作成したカードグループを閲覧・管理します。",
     "newCardgroup": "新規カードグループ",
     "noCardgroupsYet": "カードグループがありません",
     "noMatch": "「{query}」に一致するカードグループはありません",
@@ -285,7 +282,6 @@
   },
   "AdminMasters": {
     "title": "マスター",
-    "description": "公開カタログに表示するマスターデッキを管理します。",
     "searchPlaceholder": "マスターを検索...",
     "searchLabel": "マスターを検索",
     "newMaster": "新規マスター",
@@ -376,7 +372,6 @@
     "systemRoleBanner": "これはシステムロールです。名前は変更できません。",
     "newRole": "新しいロール",
     "noRolesYet": "ロールがありません",
-    "rolesDescription": "ユーザーに割り当て可能なロールを管理します。",
     "editRoleTitle": "ロールを編集",
     "createRole": "作成",
     "deleteAuthFailed": "セッションの有効期限が切れました。再度ログインしてください。",

--- a/frontend/src/app/admin/masters/admin-masters-client.tsx
+++ b/frontend/src/app/admin/masters/admin-masters-client.tsx
@@ -148,7 +148,6 @@ export function AdminMastersClient() {
             <span className="text-sm font-normal text-muted-foreground">({totalCount})</span>
           </span>
         }
-        description={t("description")}
         primaryActions={
           <Button
             type="button"

--- a/frontend/src/app/admin/roles/admin-roles-client.test.tsx
+++ b/frontend/src/app/admin/roles/admin-roles-client.test.tsx
@@ -114,7 +114,7 @@ afterEach(() => {
 // ---------------------------------------------------------------------------
 
 describe("AdminRolesClient", () => {
-  it("wires the ListingPageShell with title, description, and New role CTA", () => {
+  it("wires the ListingPageShell with title and New role CTA", () => {
     renderWithIntl(
       <MockedProvider mocks={[]}>
         <UndoDeleteProvider>
@@ -125,7 +125,6 @@ describe("AdminRolesClient", () => {
 
     expect(screen.getByRole("heading", { level: 1, name: "Roles" })).toBeInTheDocument();
     expect(screen.getByRole("main")).toBeInTheDocument();
-    expect(screen.getByText("Manage roles available to assign to users.")).toBeInTheDocument();
   });
 
   it("New role button opens ?new=true", async () => {

--- a/frontend/src/app/admin/roles/admin-roles-client.tsx
+++ b/frontend/src/app/admin/roles/admin-roles-client.tsx
@@ -408,7 +408,6 @@ export function AdminRolesClient({ initialRoles }: Props) {
   return (
     <ListingPageShell
       title={tNav("roles")}
-      description={t("rolesDescription")}
       primaryActions={
         <Button
           type="button"

--- a/frontend/src/app/admin/roles/admin-roles-skeleton.tsx
+++ b/frontend/src/app/admin/roles/admin-roles-skeleton.tsx
@@ -13,7 +13,6 @@ export function AdminRolesSkeleton() {
       <div className="flex flex-wrap items-end justify-between gap-2">
         <div>
           <Skeleton className="h-8 w-24" />
-          <Skeleton className="mt-2 h-4 w-64" />
         </div>
         <div className="flex items-center gap-2">
           <Skeleton className="hidden h-10 w-28 md:inline-flex" />

--- a/frontend/src/app/cardgroups/_components/cardgroups-skeleton.tsx
+++ b/frontend/src/app/cardgroups/_components/cardgroups-skeleton.tsx
@@ -9,7 +9,6 @@ export function CardgroupsSkeleton() {
   return (
     <ListingPageShell
       title={<Skeleton className="h-8 w-48" />}
-      description={<Skeleton className="mt-2 h-4 w-72" />}
       primaryActions={<Skeleton className="hidden h-10 w-40 md:inline-flex" />}
       toolbar={<Skeleton className="h-10 w-full max-w-sm" />}
     >

--- a/frontend/src/app/cardgroups/cardgroups-client.tsx
+++ b/frontend/src/app/cardgroups/cardgroups-client.tsx
@@ -352,7 +352,6 @@ export default function CardgroupsClient({ initialConnection }: CardgroupsClient
       />
       <ListingPageShell
         title={t("myCardgroups")}
-        description={t("browseManage")}
         primaryActions={
           <Button
             type="button"

--- a/frontend/src/app/catalog/_components/catalog-skeleton.tsx
+++ b/frontend/src/app/catalog/_components/catalog-skeleton.tsx
@@ -10,7 +10,6 @@ export function CatalogSkeleton() {
   return (
     <ListingPageShell
       title={<Skeleton className="h-8 w-40" />}
-      description={<Skeleton className="mt-2 h-4 w-80" />}
       toolbar={<Skeleton className="h-10 w-full max-w-sm" />}
     >
       <ul

--- a/frontend/src/app/catalog/catalog-client.tsx
+++ b/frontend/src/app/catalog/catalog-client.tsx
@@ -207,7 +207,6 @@ export default function CatalogClient({ initialConnection }: CatalogClientProps)
       />
       <ListingPageShell
         title={t("title")}
-        description={t("description")}
         toolbar={
           <div className="mb-2 hidden md:block">
             <input

--- a/frontend/src/app/profile/profile-page-client.tsx
+++ b/frontend/src/app/profile/profile-page-client.tsx
@@ -141,7 +141,6 @@ export function ProfilePageClient({ email, initial, displayMode }: Props) {
         <section className="space-y-4">
           <div>
             <h2 className="text-xl font-semibold">{tSettings("heading")}</h2>
-            <p className="text-sm text-muted-foreground">{tSettings("description")}</p>
           </div>
           <LanguageSwitcher />
           <DisplayModeSection initialMode={displayMode} />


### PR DESCRIPTION
## Summary

Every listing page rendered a gray descriptive sentence under its page title — e.g. `/cardgroups` showed "Browse and manage the cardgroups you have created." beneath **My cardgroups**. This removes that subtitle from all feature pages: it added a band of low-value copy that the title and page content already make obvious. The subtitle was a single `description` prop on the shared `ListingPageShell`, so each removal is a one-line drop plus the matching loading-skeleton placeholder and the now-orphan en/ja message keys.

No related GitHub issue.

## Changes

### Drop the `description` subtitle on every listing page

- `frontend/src/app/cardgroups/cardgroups-client.tsx` — remove `description={t("browseManage")}` (My cardgroups).
- `frontend/src/app/catalog/catalog-client.tsx` — remove `description={t("description")}` (Catalog).
- `frontend/src/app/admin/masters/admin-masters-client.tsx` — remove `description={t("description")}` (Masters).
- `frontend/src/app/admin/roles/admin-roles-client.tsx` — remove `description={t("rolesDescription")}` (Roles).
- `frontend/src/app/profile/profile-page-client.tsx` — remove the `<p>{tSettings("description")}</p>` line under the **Settings** section heading.

The shared `ListingPageShell` keeps its optional `description?` prop (still exercised by `listing-page-shell.test.tsx`); only the per-page usages are removed. Count metadata under titles (`X cards`, `(N)`) is intentionally kept — it is data, not a description.

### Match the loading skeletons

The skeletons mirrored the resolved layout's description bar; without this change the skeleton would flash a gray bar the loaded page no longer has (CLS mismatch).

- `frontend/src/app/catalog/_components/catalog-skeleton.tsx` and `frontend/src/app/cardgroups/_components/cardgroups-skeleton.tsx` — remove the `description={<Skeleton … />}` slot.
- `frontend/src/app/admin/roles/admin-roles-skeleton.tsx` — remove the `<Skeleton className="mt-2 h-4 w-64" />` description line (this skeleton hand-builds the `ListingPageShell` geometry).

### Prune the orphan message keys

Remove the now-unused keys from **both** `frontend/messages/en.json` and `frontend/messages/ja.json`: `Cardgroups.browseManage`, `Catalog.description`, `AdminMasters.description`, `AdminRoles.rolesDescription`, `Settings.description`. en/ja key parity is preserved (350 = 350).

### Tests

- `frontend/src/app/admin/roles/admin-roles-client.test.tsx` — the one spec that asserted the rendered subtitle drops that assertion, and its title narrows to "wires the ListingPageShell with title and New role CTA". No other test referenced the removed copy.

## Verification

- typecheck ✓ (`tsc --noEmit`)
- lint ✓ (`biome check --error-on-warnings`, no warnings)
- knip ✓ (no unused exports / orphan imports)
- test ✓ **1519 passing (162 files)**
- build ✓ (`next build`)
- i18n parity ✓ — en/ja both 350 keys, no diff; no orphan references to the removed keys:

  ```bash
  grep -rn "browseManage\|rolesDescription" frontend/src frontend/messages  # -> nothing
  ```

## Test plan

- [ ] `/cardgroups` — the title **My cardgroups** / マイカードグループ renders with no gray subtitle beneath it; the card list and New button are unchanged.
- [ ] `/catalog`, `/admin/masters`, `/admin/roles` — title only, no descriptive subtitle; search / New / list behavior unchanged.
- [ ] `/profile` — the **Settings** / 設定 section heading renders with no "Manage your preferences." line beneath it; LanguageSwitcher and display-mode controls unchanged.
- [ ] Loading state (throttled network) for `/cardgroups`, `/catalog`, `/admin/roles` — the skeleton shows the title bar but no description bar, and there is no layout shift when content resolves.
