### PR TITLE
fix(frontend): truncate card-row text and make mobile rows tappable

### DIFF
--- a/frontend/src/components/cardgroups/card-row.test.tsx
+++ b/frontend/src/components/cardgroups/card-row.test.tsx
@@ -79,6 +79,41 @@ describe("<CardRow>", () => {
     expect(cls).toContain("motion-reduce:pointer-events-auto");
   });
 
+  it("truncates the front and back text to a single line", () => {
+    // Long card text must collapse to one line per field; without truncate the
+    // back description wraps to many lines and inflates the row height.
+    renderCardRow();
+
+    expect(screen.getByText(CARD.front).className).toContain("truncate");
+    expect(screen.getByText(CARD.back).className).toContain("truncate");
+  });
+
+  it("stretches the edit target across the whole row on mobile, but not on desktop", () => {
+    // The hidden Delete button leaves a dead gap on the right on mobile; the
+    // after:inset-0 overlay makes a tap anywhere on the row open the editor.
+    // sm:after:content-none removes the overlay so desktop keeps its current
+    // text-column-only edit target.
+    renderCardRow();
+
+    const cls = screen.getByTestId(`card-edit-target-${CARD.id}`).className;
+    expect(cls).toContain("after:absolute");
+    expect(cls).toContain("after:inset-0");
+    expect(cls).toContain("after:content-['']");
+    expect(cls).toContain("sm:after:content-none");
+  });
+
+  it("keeps the checkbox and Delete controls above the mobile overlay (z-10)", () => {
+    // The stretched edit overlay would otherwise swallow taps on these controls;
+    // relative z-10 lifts them above the pseudo so they stay independently clickable.
+    renderCardRow();
+
+    const checkboxWrapper = screen.getByTestId(`card-select-${CARD.id}`).parentElement;
+    expect(checkboxWrapper?.className).toContain("z-10");
+
+    const deleteWrapper = screen.getByTestId(`card-delete-${CARD.id}`).parentElement;
+    expect(deleteWrapper?.className).toContain("z-10");
+  });
+
   it("wraps the row content in SwipeableRow", () => {
     renderCardRow();
 

--- a/frontend/src/components/cardgroups/card-row.tsx
+++ b/frontend/src/components/cardgroups/card-row.tsx
@@ -33,12 +33,12 @@ export function CardRow({
       disabled={disabled}
       ariaLabel={t("deleteCardAriaLabel")}
     >
-      <div className="group flex items-center justify-between gap-4 px-4 py-3 hover:bg-accent active:bg-accent transition-colors">
+      <div className="group relative flex items-center justify-between gap-4 px-4 py-3 hover:bg-accent active:bg-accent transition-colors">
         {/* biome-ignore lint/a11y/noStaticElementInteractions: span is a click/keydown stopper, not an interactive element; the inner <input> is the actual control. */}
         <span
           onClick={(e) => e.stopPropagation()}
           onKeyDown={(e) => e.stopPropagation()}
-          className="shrink-0"
+          className="relative z-10 shrink-0"
         >
           <input
             type="checkbox"
@@ -49,6 +49,14 @@ export function CardRow({
             data-testid={`card-select-${card.id}`}
           />
         </span>
+        {/*
+         * On mobile the Delete button is hidden (pointer-events-none), leaving a dead
+         * non-interactive gap on the right. The after:inset-0 pseudo stretches this edit
+         * target across the whole row so any tap (including that gap) opens the editor;
+         * the checkbox and Delete siblings carry relative z-10 to stay above the overlay.
+         * sm:after:content-none removes the overlay at >=sm so desktop keeps its current
+         * behaviour (only the text column edits, Delete reveals on hover).
+         */}
         {/* biome-ignore lint/a11y/useSemanticElements: a native <button> here would nest the action <button> for delete (invalid HTML); role="button" preserves screen-reader semantics without the markup conflict. */}
         <div
           role="button"
@@ -60,16 +68,16 @@ export function CardRow({
               onEdit();
             }
           }}
-          className="min-w-0 flex-1 cursor-pointer space-y-1 rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          className="min-w-0 flex-1 cursor-pointer space-y-1 rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring after:absolute after:inset-0 after:content-[''] sm:after:content-none"
           aria-label={t("editCardAriaLabel", { front: card.front })}
           data-testid={`card-edit-target-${card.id}`}
         >
-          <p className="text-sm font-medium">{card.front}</p>
-          <p className="text-sm text-muted-foreground">{card.back}</p>
+          <p className="truncate text-sm font-medium">{card.front}</p>
+          <p className="truncate text-sm text-muted-foreground">{card.back}</p>
         </div>
         {/* biome-ignore lint/a11y/noStaticElementInteractions: div is a click/keydown stopper, not an interactive element; the inner Delete <button> is the actual control. */}
         <div
-          className="flex shrink-0 gap-2"
+          className="relative z-10 flex shrink-0 gap-2"
           onClick={(e) => e.stopPropagation()}
           onKeyDown={(e) => e.stopPropagation()}
         >


### PR DESCRIPTION
## Summary

Card rows on the cardgroup list (`/cardgroups/[id]/cards`) and the master-card list (`/admin/masters/[id]/edit/cards`) let the back description wrap to many lines — inflating row height — and left a dead, non-interactive gap on the right (the hidden Delete column) that ignored taps. Both lists render the same `CardRow`, so this single-component change truncates `front`/`back` to one line each and, on mobile only, stretches the edit target across the whole row so any tap opens the editor. Desktop behaviour is unchanged.

No related GitHub issue.

## Background / Motivation

- A long card `back` (e.g. an example sentence plus its translation) wrapped to 5+ lines, making one row tower over its neighbours and breaking the list's scannable rhythm.
- On mobile the Delete button is `pointer-events-none` (delete is swipe-only), so its reserved right-hand column rendered as a visible empty box that swallowed taps and did nothing — the rest of the row opened the editor, but that gap did not.
- The checkbox and Delete siblings already carried `stopPropagation` handlers — a leftover signalling the row was once meant to be a single tap target — while the edit `onClick` had drifted onto the inner text column only.

## Changes

### Truncate front/back to one line

- `frontend/src/components/cardgroups/card-row.tsx` — both `<p>` elements (`card.front`, `card.back`) gain `truncate` (`overflow-hidden text-ellipsis whitespace-nowrap`). The parent edit column already has `min-w-0 flex-1`, so the ellipsis resolves against the row width. Each row is now a fixed two-line height (front + back).

### Whole-row tap on mobile (desktop unchanged)

- The edit target (`role="button"`) gains an `after:absolute after:inset-0 after:content-['']` overlay so a tap anywhere on the row — including the dead right gap — opens the editor. The outer row is now `relative` to anchor the overlay.
- `sm:after:content-none` removes the overlay at `>=sm`, so desktop keeps its current behaviour: only the text column edits, and Delete reveals on hover.
- The checkbox `<span>` and the Delete `<div>` gain `relative z-10` to stay above the overlay and remain independently clickable.
- The overlay pattern is used instead of moving `role="button"` onto the outer row, which would nest the Delete `<button>` / checkbox `<input>` inside an interactive ancestor (invalid HTML — the existing `biome-ignore` already guards against this).

### Tests

- `frontend/src/components/cardgroups/card-row.test.tsx` — three specs: `front`/`back` carry `truncate`; the edit target carries the mobile overlay classes plus `sm:after:content-none`; the checkbox and Delete wrappers carry `z-10`.

## Verification

- typecheck ✓ (`tsc --noEmit`)
- lint ✓ (`biome check --error-on-warnings`, no warnings)
- knip ✓ (no unused exports / orphan imports)
- test ✓ **1522 passing (162 files)**
- build ✓ (`next build`)
- one `CardRow` is shared by both lists, so a single fix covers both:

  ```bash
  grep -rln "components/cardgroups/card-row" frontend/src/app --include='*.tsx'
  # -> cardgroups/[id]/cards/cards-client.tsx
  #    admin/masters/[id]/edit/cards/master-cards-client.tsx
  ```

## Test plan

- [ ] `/cardgroups/[id]/cards` mobile (`<sm`) — a card with long `back` text shows `front` and `back` each on one line with `…`; tapping anywhere on the row (including the empty right area) opens the editor; the checkbox still toggles selection and left-swipe still deletes.
- [ ] `/cardgroups/[id]/cards` desktop (`>=sm`) — rows are one line each; clicking the text column opens the editor; the empty right area does NOT edit; hovering reveals the Delete button, which deletes.
- [ ] `/admin/masters/[id]/edit/cards` — the same two checks for the master-card list (shares `CardRow`).
- [ ] Keyboard — focus a row's edit target and press Enter/Space to open the editor (unchanged).
