### PR TITLE
fix(frontend): stop horizontal overflow on shell routes via min-w-0 content column

### DIFF
--- a/frontend/src/components/nav/app-shell.test.tsx
+++ b/frontend/src/components/nav/app-shell.test.tsx
@@ -165,6 +165,27 @@ describe("<AppShell>", () => {
     });
   });
 
+  describe("S7 — content column carries min-w-0 to prevent horizontal overflow", () => {
+    it("the column wrapping the mobile header + main content has the min-w-0 class", () => {
+      renderWithIntl(
+        <AppShell user={SIGNED_IN_USER} isAdmin={false}>
+          <div />
+        </AppShell>,
+      );
+
+      // The content column is a flex child of the SidebarProvider row. Without
+      // min-w-0 its min-width defaults to `auto` (content-based), so a long
+      // unbreakable token on any page forces the column wider than the viewport
+      // and `truncate`/`break-words` cannot clamp — the whole page overflows
+      // horizontally. This guards that the load-bearing min-w-0 stays in place.
+      // jsdom has no layout engine, so the class (not a measured width) is the
+      // assertion. The column is the parent of the mobile header.
+      const contentColumn = screen.getByTestId("mobile-header").parentElement;
+      expect(contentColumn).not.toBeNull();
+      expect(contentColumn?.className).toContain("min-w-0");
+    });
+  });
+
   describe("S6 — isAdmin=true: Admin sub-links appear in both rail and drawer", () => {
     it("the rail body contains the admin sub-links (Users, Roles) when isAdmin=true", () => {
       mockUsePathname.mockReturnValue("/");

--- a/frontend/src/components/nav/app-shell.tsx
+++ b/frontend/src/components/nav/app-shell.tsx
@@ -39,8 +39,16 @@ export function AppShell({ user, isAdmin, children }: AppShellProps) {
         <GlobalRail user={user} isAdmin={isAdmin} />
       </aside>
 
-      {/* Mobile layout (<md): top bar + logo-drawer trigger */}
-      <div className="flex flex-1 flex-col">
+      {/* Mobile layout (<md): top bar + logo-drawer trigger.
+          min-w-0 is load-bearing: this column is a flex child of the
+          SidebarProvider row, so without it min-width defaults to `auto`
+          (content-based) and a long unbreakable token in any page (a card's
+          text, a long deck name) forces the column wider than the viewport.
+          With no definite-width ancestor, `truncate`/`break-words` cannot
+          clamp and the whole page overflows horizontally. min-w-0 lets the
+          column shrink to the viewport, restoring a definite width to truncate
+          against. */}
+      <div className="flex min-w-0 flex-1 flex-col">
         <header
           data-testid="mobile-header"
           className="md:hidden flex items-center justify-between px-4 h-12 border-b"


### PR DESCRIPTION
## Summary

The cardgroup deck-detail screen (`/cardgroups/[id]/edit`) overflowed horizontally on mobile: the deck header's `…` options menu was pushed off-screen and the **Start learning** button and card rows were clipped at the right edge, with no right-hand padding. The root cause is in the shared `AppShell`, so this is a one-class fix that also closes the same latent overflow on every other shell route (catalog, admin lists, learn, …).

No related GitHub issue.

## Background / Motivation

The deck-detail content (header, hero CTA, card list) all appeared shifted right and clipped, while left padding stayed intact — the signature of a page-wide horizontal overflow.

`AppShell`'s content column — the `<div>` that wraps the mobile header and `SidebarInset` — is a **flex child of the `SidebarProvider` row**. Without `min-w-0`, a flex item's `min-width` defaults to `auto` (content-based), so the column grows to its widest descendant's min-content. A single card with a long unbreakable token (one of the deck's 438 cards), or a long deck name, then forces the column wider than the viewport. Because there is no longer a definite-width ancestor, `truncate` / `break-words` have nothing to clamp against and the **whole page** overflows — so even rows with short text look clipped, since horizontal overflow is page-global.

This completes the truncation work from #565: that change added `truncate` to the card `front`/`back` and relied on the text column's `min-w-0 flex-1`, but the ellipsis only resolves if an *ancestor* has a definite width. The missing `min-w-0` one level up at the shell meant the text column could still stretch, so `truncate` silently failed whenever a long token existed.

## Changes

### `frontend/src/components/nav/app-shell.tsx`

- The mobile/desktop content column `<div className="flex flex-1 flex-col">` gains `min-w-0`, letting it shrink to the viewport and restoring a definite width for `truncate` / `break-words` to clamp against. This is the canonical flex sidebar-layout fix and is correct on desktop too (the content area sits next to the rail).
- Added a load-bearing comment explaining why `min-w-0` must stay.

### `frontend/src/components/nav/app-shell.test.tsx`

- New spec `S7` asserts the content column (parent of the mobile header) carries `min-w-0`. jsdom has no layout engine, so the class — not a measured width — is the regression guard, in the same static-class style as the existing `S1` container-class assertions.

## Verification

Root cause and fix were confirmed empirically before coding: a faithful static reproduction of the shell + page DOM with real Tailwind utility values, measured in headless Chromium at 375px.

- repro, long card text / deck name, **before**: horizontal overflow **+662px**, `truncate` `<p>` measured **883px** (not clamped).
- repro, **after** (`min-w-0` on the column): overflow **none**, `truncate` `<p>` **221px** (clamped correctly).
- repro, short text after fix: no regression.

Toolchain (worktree, after `pnpm install` + `codegen`):

- typecheck ✓ (`tsc --noEmit`)
- lint ✓ (`biome check --error-on-warnings`, no warnings)
- test ✓ **1523 passing (162 files)**, including the new `S7` guard

## Test plan

- [ ] `/cardgroups/[id]/edit` mobile (`<md`) on a deck containing at least one card with a long unbreakable token — the page no longer scrolls horizontally; the header `…` menu, **Start learning** button, and card rows all sit within the viewport with symmetric padding; long card text truncates with `…`.
- [ ] Same deck on desktop (`>=md`) — layout unchanged next to the rail; no horizontal scrollbar.
- [ ] Spot-check another shell route with long content (e.g. `/catalog`, `/admin/masters/[id]/edit/cards`) — no horizontal overflow.
