### PR TITLE
refactor(frontend): unify master/cardgroup detail headers on a shared DetailPageHeader

### DIFF
--- a/frontend/__tests__/admin-master-cards.test.tsx
+++ b/frontend/__tests__/admin-master-cards.test.tsx
@@ -183,10 +183,11 @@ describe("MasterManagementClient — broad page integration", () => {
     // The seeded card's front text appears in the card list.
     expect(screen.getByText("apple")).toBeInTheDocument();
 
-    // The header status badge region renders the AdminMasters.cardCount message.
-    // With count=1 the ICU plural resolves to "1 card".
+    // The header renders the card count in both the mobile meta row (md:hidden)
+    // and the desktop meta row (hidden md:flex). In jsdom (no CSS) both render,
+    // so getAllByText returns two matches. With count=1 the ICU plural = "1 card".
     await waitFor(() => {
-      expect(screen.getByText("1 card")).toBeInTheDocument();
+      expect(screen.getAllByText("1 card")).toHaveLength(2);
     });
   });
 
@@ -230,9 +231,9 @@ describe("MasterManagementClient — broad page integration", () => {
 
     renderClient([connMock, createMock]);
 
-    // Confirm initial count before mutation.
+    // Confirm initial count before mutation. Both responsive rows render in jsdom.
     await waitFor(() => {
-      expect(screen.getByText("1 card")).toBeInTheDocument();
+      expect(screen.getAllByText("1 card")).toHaveLength(2);
     });
 
     // Open the add-card sheet via the toolbar "Add card" button.
@@ -252,9 +253,9 @@ describe("MasterManagementClient — broad page integration", () => {
     // After a successful create the cache is updated (+1 to totalCount). The new
     // totalCount flows from MasterCardsClient into the renderPageHeader render-prop,
     // which re-renders MasterEditHeader with count=2. The ICU plural for count=2
-    // resolves to "2 cards".
+    // resolves to "2 cards". Both responsive rows render in jsdom (no CSS).
     await waitFor(() => {
-      expect(screen.getByText("2 cards")).toBeInTheDocument();
+      expect(screen.getAllByText("2 cards")).toHaveLength(2);
     });
   });
 });

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -331,10 +331,11 @@
     "deleteMasterDeleting": "Deleting...",
     "deleteMasterSuccess": "Master deleted.",
     "deleteMasterFailed": "Could not delete the master. Please try again.",
-    "deckSettingsButton": "Deck settings",
+    "deckSettingsButton": "Settings",
     "deckSettingsTitle": "Deck settings",
     "backToList": "Back to masters",
-    "masterOptions": "Deck options"
+    "masterOptions": "Deck options",
+    "changePublishState": "Change publish state (current: {state})"
   },
   "Admin": {
     "searchPlaceholder": "Search users...",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -331,10 +331,11 @@
     "deleteMasterDeleting": "削除中...",
     "deleteMasterSuccess": "マスターを削除しました。",
     "deleteMasterFailed": "マスターを削除できませんでした。もう一度お試しください。",
-    "deckSettingsButton": "デッキ設定",
+    "deckSettingsButton": "設定",
     "deckSettingsTitle": "デッキ設定",
     "backToList": "一覧へ戻る",
-    "masterOptions": "デッキ操作"
+    "masterOptions": "デッキ操作",
+    "changePublishState": "公開状態を変更（現在: {state}）"
   },
   "Admin": {
     "searchPlaceholder": "ユーザーを検索...",

--- a/frontend/src/app/admin/masters/[id]/edit/master-cards-section.test.tsx
+++ b/frontend/src/app/admin/masters/[id]/edit/master-cards-section.test.tsx
@@ -39,6 +39,46 @@ const node = {
   updatedAt: "2026-01-01T00:00:00Z",
 };
 
+it("exposes a batch-import control in the toolbar (mobile-visible)", async () => {
+  renderWithIntl(
+    <MockedProvider
+      mocks={[
+        {
+          request: {
+            query: AdminMasterCardsConnectionDocument,
+            variables: masterCardsDefaultVars(MASTER_ID),
+          },
+          result: {
+            data: {
+              adminMasterCardsConnection: {
+                __typename: "MasterCardConnection",
+                edges: [{ __typename: "MasterCardEdge", cursor: "c-1", node }],
+                pageInfo,
+                totalCount: 3,
+              },
+            },
+          },
+        },
+      ]}
+    >
+      <UndoDeleteProvider>
+        <MasterCardsSection
+          masterId={MASTER_ID}
+          deckName="Deck One"
+          initialEdges={[{ __typename: "MasterCardEdge", cursor: "c-1", node }]}
+          initialPageInfo={pageInfo}
+          initialTotalCount={3}
+          renderPageHeader={({ totalCount }) => <span data-testid="hdr-count">{totalCount}</span>}
+        />
+      </UndoDeleteProvider>
+    </MockedProvider>,
+  );
+  const importBtn = await screen.findByTestId("master-import-mobile");
+  expect(importBtn).toBeInTheDocument();
+  // The control is NOT inside a `hidden md:*` wrapper — assert it is visible.
+  expect(importBtn.closest(".hidden")).toBeNull();
+});
+
 it("renders MasterCardsClient with the seed and exposes the live count to renderPageHeader", async () => {
   renderWithIntl(
     <MockedProvider

--- a/frontend/src/app/admin/masters/[id]/edit/master-cards-section.tsx
+++ b/frontend/src/app/admin/masters/[id]/edit/master-cards-section.tsx
@@ -19,11 +19,9 @@ type MasterCardsSectionProps = {
   initialTotalCount: number;
   /**
    * Renders the deck-level page header (title / status badge / overflow menu)
-   * with the live `totalCount` and the batch-import opener. "Add card" is
-   * reached separately: the global header "+" on mobile, the desktop toolbar
-   * split button rendered below. Omitted → no page header.
+   * with the live `totalCount`. Omitted → no page header.
    */
-  renderPageHeader?: (args: { totalCount: number; onBatchImport: () => void }) => ReactNode;
+  renderPageHeader?: (args: { totalCount: number }) => ReactNode;
 };
 
 export function MasterCardsSection({
@@ -50,10 +48,21 @@ export function MasterCardsSection({
     onBatchImport: () => void;
   }) => (
     <div>
-      {renderPageHeader?.({ totalCount, onBatchImport })}
-      {/* Desktop-only (md+) action cluster: Add card + a dropdown that folds in
-          Batch import. Below md, Add card is the global header "+" and Batch
-          import lives in the deck overflow menu, so nothing renders here. */}
+      {renderPageHeader?.({ totalCount })}
+      {/* Mobile (<md): import lives here; Add card is the global header "+". */}
+      <div className="mb-3 flex justify-end md:hidden">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={onBatchImport}
+          data-testid="master-import-mobile"
+        >
+          <Import aria-hidden="true" className="h-4 w-4" />
+          {tCardgroups("batchImport")}
+        </Button>
+      </div>
+      {/* Desktop (md+): Add card + a dropdown that folds in Batch import. */}
       <div className="mb-3 hidden justify-end md:flex">
         <div className="inline-flex">
           <Button

--- a/frontend/src/app/admin/masters/[id]/edit/master-edit-header.test.tsx
+++ b/frontend/src/app/admin/masters/[id]/edit/master-edit-header.test.tsx
@@ -58,14 +58,20 @@ const DECK: AdminMasterDeck = {
 };
 
 function renderHeader(
-  deck: AdminMasterDeck,
+  overrides: Partial<AdminMasterDeck> & { cardCount?: number; onBatchImport?: () => void } = {},
   mocks: ReadonlyArray<unknown> = [],
-  onBatchImport?: () => void,
 ) {
+  const { cardCount, onBatchImport, ...deckOverrides } = overrides;
+  const deck = { ...DECK, ...deckOverrides };
+  const resolvedCardCount = cardCount ?? deck.cardCount;
   return render(
     <MockedProvider mocks={mocks as never}>
       <NextIntlClientProvider locale="en" messages={enMessages} timeZone="UTC">
-        <MasterEditHeader master={deck} cardCount={deck.cardCount} onBatchImport={onBatchImport} />
+        <MasterEditHeader
+          master={deck}
+          cardCount={resolvedCardCount}
+          onBatchImport={onBatchImport}
+        />
       </NextIntlClientProvider>
     </MockedProvider>,
   );
@@ -79,21 +85,22 @@ afterEach(() => vi.clearAllMocks());
 
 describe("MasterEditHeader", () => {
   it("renders the deck name, draft badge, and card count", () => {
-    renderHeader(DECK);
+    renderHeader();
     expect(screen.getByRole("heading", { level: 1, name: "Spanish A1" })).toBeInTheDocument();
     expect(screen.getByTestId("master-edit-status-badge")).toHaveTextContent("Draft");
-    expect(screen.getByText("5 cards")).toBeInTheDocument();
+    // Card count renders in both the mobile and desktop meta rows.
+    expect(screen.getAllByText("5 cards").length).toBeGreaterThan(0);
   });
 
   it("disables publish and shows the hint for an empty draft", () => {
-    renderHeader({ ...DECK, cardCount: 0 });
+    renderHeader({ cardCount: 0 });
     expect(screen.getByTestId("master-edit-publish")).toBeDisabled();
     expect(screen.getByTestId("master-edit-empty-hint")).toBeInTheDocument();
   });
 
   it("opens the deck-settings dialog with the metadata form (no publish/delete sections)", async () => {
     const user = userEvent.setup();
-    renderHeader(DECK);
+    renderHeader();
     // Deck settings now lives in the desktop split-button dropdown.
     await user.click(screen.getByTestId("master-edit-more-options"));
     await user.click(screen.getByTestId("master-edit-deck-settings"));
@@ -118,7 +125,7 @@ describe("MasterEditHeader", () => {
         },
       },
     ];
-    renderHeader(DECK, mocks);
+    renderHeader({}, mocks);
     await user.click(screen.getByTestId("master-edit-publish"));
     await waitFor(() => expect(refresh).toHaveBeenCalledTimes(1));
   });
@@ -135,7 +142,7 @@ describe("MasterEditHeader", () => {
         },
       },
     ];
-    renderHeader({ ...DECK, status: "PUBLISHED" }, mocks);
+    renderHeader({ status: "PUBLISHED" }, mocks);
     await user.click(screen.getByTestId("master-edit-publish"));
     await waitFor(() => expect(refresh).toHaveBeenCalledTimes(1));
   });
@@ -148,7 +155,7 @@ describe("MasterEditHeader", () => {
         result: { data: { adminDeleteMasterCardgroup: true } },
       },
     ];
-    renderHeader(DECK, mocks);
+    renderHeader({}, mocks);
     // Delete now lives in the desktop split-button dropdown.
     await user.click(screen.getByTestId("master-edit-more-options"));
     await user.click(screen.getByTestId("master-edit-delete"));
@@ -176,7 +183,7 @@ describe("MasterEditHeader", () => {
         },
       },
     ];
-    renderHeader(DECK, mocks);
+    renderHeader({}, mocks);
     // Open the deck-settings dialog from the desktop split-button dropdown.
     await user.click(screen.getByTestId("master-edit-more-options"));
     await user.click(screen.getByTestId("master-edit-deck-settings"));
@@ -207,7 +214,7 @@ describe("MasterEditHeader", () => {
         },
       },
     ];
-    renderHeader(DECK, mocks);
+    renderHeader({}, mocks);
     await user.click(screen.getByTestId("master-edit-more-options"));
     await user.click(screen.getByTestId("master-edit-deck-settings"));
     expect(await screen.findByTestId("master-field-name")).toBeInTheDocument();
@@ -229,66 +236,77 @@ describe("MasterEditHeader", () => {
       },
     ];
     // DRAFT deck with cards so the publish button is enabled.
-    renderHeader(DECK, mocks);
+    renderHeader({}, mocks);
     await user.click(screen.getByTestId("master-edit-publish"));
     await waitFor(() => expect(toast.error).toHaveBeenCalled());
     expect(refresh).not.toHaveBeenCalled();
   });
 
-  it("overflow menu (mobile): opens deck-settings and delete from the dropdown", async () => {
+  it("mobile: overflow menu opens deck-settings sheet", async () => {
     const user = userEvent.setup();
-    renderHeader(DECK);
+    renderHeader();
     const overflow = screen.getByTestId("master-edit-overflow");
     await user.click(overflow);
     // Deck settings entry triggers the settings sheet.
-    const settingsItem = await screen.findByRole("menuitem", { name: /deck settings/i });
+    const settingsItem = await screen.findByTestId("master-edit-deck-settings-mobile");
     await user.click(settingsItem);
     expect(await screen.findByTestId("master-field-name")).toBeInTheDocument();
   });
 
-  it("overflow menu (mobile): the publish toggle publishes the deck and refreshes", async () => {
+  it("mobile: status chip opens the publish toggle and calls the mutation", async () => {
     const user = userEvent.setup();
     const mocks = [
       {
-        request: { query: AdminPublishMasterMutation, variables: { id: "m-1" } },
+        request: { query: AdminUnpublishMasterMutation, variables: { id: "m-1" } },
         result: {
           data: {
-            adminPublishMasterCardgroup: {
-              __typename: "PublishMasterCardgroupSuccess",
-              master: { ...DECK, status: "PUBLISHED" },
-            },
+            adminUnpublishMasterCardgroup: { ...DECK, status: "DRAFT" },
           },
         },
       },
     ];
-    renderHeader(DECK, mocks);
-    await user.click(screen.getByTestId("master-edit-overflow"));
-    await user.click(await screen.findByTestId("master-edit-publish-mobile"));
+    renderHeader({ status: "PUBLISHED", cardCount: 1246 }, mocks);
+    await user.click(screen.getByTestId("master-edit-status-chip"));
+    const toggle = screen.getByTestId("master-edit-publish-mobile");
+    expect(toggle).toHaveTextContent(/Unpublish/);
+    await user.click(toggle);
     await waitFor(() => expect(refresh).toHaveBeenCalledTimes(1));
   });
 
-  it("overflow menu (mobile): renders a Bulk import item that calls onBatchImport", async () => {
+  it("mobile: status chip publish item is disabled for an empty draft, with the hint", async () => {
     const user = userEvent.setup();
-    const onBatchImport = vi.fn();
-    renderHeader(DECK, [], onBatchImport);
-    await user.click(screen.getByTestId("master-edit-overflow"));
-    const importItem = await screen.findByTestId("master-edit-batch-import");
-    expect(importItem).toHaveTextContent(/batch import/i);
-    await user.click(importItem);
-    expect(onBatchImport).toHaveBeenCalledTimes(1);
+    renderHeader({ status: "DRAFT", cardCount: 0 });
+    expect(screen.getByTestId("master-edit-empty-hint")).toBeInTheDocument();
+    await user.click(screen.getByTestId("master-edit-status-chip"));
+    expect(screen.getByTestId("master-edit-publish-mobile")).toHaveAttribute(
+      "aria-disabled",
+      "true",
+    );
   });
 
-  it("overflow menu (mobile): omits the Bulk import item when onBatchImport is not provided", async () => {
+  it("mobile: overflow menu holds only Settings and Delete (no import, no publish)", async () => {
     const user = userEvent.setup();
-    renderHeader(DECK);
+    renderHeader({ status: "PUBLISHED", cardCount: 5, onBatchImport: vi.fn() });
     await user.click(screen.getByTestId("master-edit-overflow"));
-    // The deck-settings item proves the menu opened; the import item is absent.
-    expect(await screen.findByTestId("master-edit-deck-settings-mobile")).toBeInTheDocument();
-    expect(screen.queryByTestId("master-edit-batch-import")).not.toBeInTheDocument();
+    expect(screen.getByTestId("master-edit-deck-settings-mobile")).toBeInTheDocument();
+    expect(screen.getByTestId("master-edit-delete-mobile")).toBeInTheDocument();
+    expect(screen.queryByTestId("master-edit-batch-import")).toBeNull();
+    expect(screen.queryByTestId("master-edit-publish-mobile")).toBeNull();
+  });
+
+  it("renders the inline back link to the masters list", () => {
+    renderHeader({ status: "DRAFT", cardCount: 3 });
+    expect(screen.getByRole("link", { name: /一覧|list|Masters|戻る/i })).toHaveAttribute(
+      "href",
+      "/admin/masters",
+    );
   });
 
   it("displays the cardCount prop (live count), not master.cardCount", () => {
-    render(
+    // master.cardCount is 0 but the live cardCount prop is 5 — publish must be enabled.
+    // renderHeader spreads overrides onto DECK; here we explicitly pass cardCount=5 while
+    // the base DECK.cardCount would be 0 if we change it. To isolate, render directly.
+    const { container } = render(
       <MockedProvider mocks={[]}>
         <NextIntlClientProvider locale="en" messages={enMessages} timeZone="UTC">
           <MasterEditHeader master={{ ...DECK, cardCount: 0 }} cardCount={5} />
@@ -296,6 +314,7 @@ describe("MasterEditHeader", () => {
       </MockedProvider>,
     );
     // Publish is enabled because the LIVE count is 5, even though master.cardCount is 0.
-    expect(screen.getByTestId("master-edit-publish")).not.toBeDisabled();
+    const publishBtn = container.querySelector('[data-testid="master-edit-publish"]');
+    expect(publishBtn).not.toBeDisabled();
   });
 });

--- a/frontend/src/app/admin/masters/[id]/edit/master-edit-header.test.tsx
+++ b/frontend/src/app/admin/masters/[id]/edit/master-edit-header.test.tsx
@@ -58,20 +58,16 @@ const DECK: AdminMasterDeck = {
 };
 
 function renderHeader(
-  overrides: Partial<AdminMasterDeck> & { cardCount?: number; onBatchImport?: () => void } = {},
+  overrides: Partial<AdminMasterDeck> & { cardCount?: number } = {},
   mocks: ReadonlyArray<unknown> = [],
 ) {
-  const { cardCount, onBatchImport, ...deckOverrides } = overrides;
+  const { cardCount, ...deckOverrides } = overrides;
   const deck = { ...DECK, ...deckOverrides };
   const resolvedCardCount = cardCount ?? deck.cardCount;
   return render(
     <MockedProvider mocks={mocks as never}>
       <NextIntlClientProvider locale="en" messages={enMessages} timeZone="UTC">
-        <MasterEditHeader
-          master={deck}
-          cardCount={resolvedCardCount}
-          onBatchImport={onBatchImport}
-        />
+        <MasterEditHeader master={deck} cardCount={resolvedCardCount} />
       </NextIntlClientProvider>
     </MockedProvider>,
   );
@@ -286,7 +282,7 @@ describe("MasterEditHeader", () => {
 
   it("mobile: overflow menu holds only Settings and Delete (no import, no publish)", async () => {
     const user = userEvent.setup();
-    renderHeader({ status: "PUBLISHED", cardCount: 5, onBatchImport: vi.fn() });
+    renderHeader({ status: "PUBLISHED", cardCount: 5 });
     await user.click(screen.getByTestId("master-edit-overflow"));
     expect(screen.getByTestId("master-edit-deck-settings-mobile")).toBeInTheDocument();
     expect(screen.getByTestId("master-edit-delete-mobile")).toBeInTheDocument();

--- a/frontend/src/app/admin/masters/[id]/edit/master-edit-header.test.tsx
+++ b/frontend/src/app/admin/masters/[id]/edit/master-edit-header.test.tsx
@@ -292,7 +292,7 @@ describe("MasterEditHeader", () => {
 
   it("renders the inline back link to the masters list", () => {
     renderHeader({ status: "DRAFT", cardCount: 3 });
-    expect(screen.getByRole("link", { name: /一覧|list|Masters|戻る/i })).toHaveAttribute(
+    expect(screen.getByRole("link", { name: /back to masters/i })).toHaveAttribute(
       "href",
       "/admin/masters",
     );

--- a/frontend/src/app/admin/masters/[id]/edit/master-edit-header.tsx
+++ b/frontend/src/app/admin/masters/[id]/edit/master-edit-header.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { Eye, EyeOff, Import, MoreHorizontal, Settings, Trash2 } from "lucide-react";
+import { ChevronDown, Eye, EyeOff, MoreHorizontal, Settings, Trash2 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { useCallback, useState } from "react";
 import { toast } from "sonner";
 import { AdminMasterForm, type MasterFormValues } from "@/app/admin/masters/admin-master-form";
 import { type AuthKind, useMasterMutations } from "@/app/admin/masters/use-master-mutations";
+import { DetailPageHeader } from "@/components/nav/detail-page-header";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -23,11 +24,11 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { FormSheet } from "@/components/ui/form-sheet";
 import { SplitButtonMenu } from "@/components/ui/split-button-menu";
+import { cn } from "@/lib/utils";
 import type { AdminMasterDeck } from "./queries";
 
 type Props = {
@@ -37,14 +38,15 @@ type Props = {
    * Opens the batch-import sheet owned by MasterCardsClient. Wired only on the
    * mobile overflow menu — desktop reaches batch import through the cards
    * toolbar's split button. Omitted (e.g. in isolated tests) → no import item.
+   * Kept in props for backward compatibility; removed from the overflow menu in
+   * this refactor (batch import moves to the cards toolbar in the next task).
    */
   onBatchImport?: () => void;
 };
 
-export function MasterEditHeader({ master, cardCount, onBatchImport }: Props) {
+export function MasterEditHeader({ master, cardCount, onBatchImport: _onBatchImport }: Props) {
   const t = useTranslations("AdminMasters");
   const tCommon = useTranslations("Common");
-  const tCardgroups = useTranslations("Cardgroups");
   const router = useRouter();
 
   const [settingsOpen, setSettingsOpen] = useState(false);
@@ -158,136 +160,155 @@ export function MasterEditHeader({ master, cardCount, onBatchImport }: Props) {
     <Eye aria-hidden="true" className="h-4 w-4" />
   );
   const publishLabel = published ? t("unpublish") : t("publish");
+  const statusLabel = published ? t("statusPublished") : t("statusDraft");
+
+  const meta = (
+    <>
+      {/* Mobile: interactive status chip (publish trigger) + muted count. */}
+      <div className="flex items-center justify-between gap-2 md:hidden">
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <button
+              type="button"
+              data-testid="master-edit-status-chip"
+              aria-label={t("changePublishState", { state: statusLabel })}
+              className="inline-flex items-center gap-1.5 rounded-full border px-3 py-0.5 text-sm font-medium hover:bg-accent"
+            >
+              <span
+                aria-hidden="true"
+                className={cn(
+                  "h-2 w-2 rounded-full",
+                  published ? "bg-success" : "bg-muted-foreground",
+                )}
+              />
+              {statusLabel}
+              <ChevronDown aria-hidden="true" className="h-3.5 w-3.5 text-muted-foreground" />
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="start">
+            <DropdownMenuItem
+              onSelect={handlePublishToggle}
+              disabled={publishing || emptyDraft}
+              data-testid="master-edit-publish-mobile"
+              className="gap-2"
+            >
+              {publishIcon}
+              {publishLabel}
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+        <span className="text-sm text-muted-foreground">
+          {t("cardCount", { count: cardCount })}
+        </span>
+      </div>
+      {/* Desktop: display badge + muted count. */}
+      <div className="hidden items-center gap-2 md:flex">
+        <Badge
+          variant={published ? "default" : "secondary"}
+          role="status"
+          data-testid="master-edit-status-badge"
+        >
+          {statusLabel}
+        </Badge>
+        <span className="text-sm text-muted-foreground">
+          {t("cardCount", { count: cardCount })}
+        </span>
+      </div>
+    </>
+  );
+
+  const actions = (
+    <>
+      {/* Mobile overflow: deck-lifecycle only (settings + delete). */}
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="shrink-0 md:hidden"
+            data-testid="master-edit-overflow"
+            aria-label={t("masterOptions")}
+          >
+            <MoreHorizontal aria-hidden="true" className="h-4 w-4" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem
+            onSelect={() => setSettingsOpen(true)}
+            data-testid="master-edit-deck-settings-mobile"
+            className="gap-2"
+          >
+            <Settings aria-hidden="true" className="h-4 w-4" />
+            {t("deckSettingsButton")}
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            onSelect={() => setDeleteOpen(true)}
+            data-testid="master-edit-delete-mobile"
+            className="gap-2 text-destructive focus:text-destructive"
+          >
+            <Trash2 aria-hidden="true" className="h-4 w-4" />
+            {t("deleteMasterButton")}
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      {/* Desktop split button: publish primary + settings/delete dropdown. */}
+      <div className="hidden shrink-0 items-center md:flex">
+        <Button
+          type="button"
+          variant={published ? "outline" : "brand"}
+          className="rounded-r-none"
+          data-testid="master-edit-publish"
+          aria-pressed={published}
+          disabled={publishing || emptyDraft}
+          onClick={handlePublishToggle}
+        >
+          {publishIcon}
+          {publishing ? tCommon("loading") : publishLabel}
+        </Button>
+        <SplitButtonMenu
+          triggerLabel={t("masterOptions")}
+          variant={published ? "outline" : "brand"}
+          size="default"
+          data-testid="master-edit-more-options"
+          items={[
+            {
+              key: "settings",
+              icon: <Settings aria-hidden="true" className="h-4 w-4" />,
+              label: t("deckSettingsButton"),
+              onSelect: () => setSettingsOpen(true),
+              "data-testid": "master-edit-deck-settings",
+            },
+            {
+              key: "delete",
+              icon: <Trash2 aria-hidden="true" className="h-4 w-4" />,
+              label: t("deleteMasterButton"),
+              onSelect: () => setDeleteOpen(true),
+              destructive: true,
+              "data-testid": "master-edit-delete",
+            },
+          ]}
+        />
+      </div>
+    </>
+  );
 
   return (
     <>
-      {/* Mobile (<md): the title takes the full line width and the actions
-          collapse into the meta row (kebab). Desktop (md+): title left, the
-          publish split button on the right. The md breakpoint matches the app
-          shell — the global header "+" shows below md, the rail at md+. */}
-      <div className="mb-6 flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
-        <div className="min-w-0 md:flex-1">
-          <h1 className="text-2xl font-semibold leading-tight break-words">{master.name}</h1>
-          <div className="mt-1 flex items-center justify-between gap-2">
-            <div className="flex items-center gap-2">
-              <Badge
-                variant={published ? "default" : "secondary"}
-                role="status"
-                data-testid="master-edit-status-badge"
-              >
-                {published ? t("statusPublished") : t("statusDraft")}
-              </Badge>
-              <span className="text-sm text-muted-foreground">
-                {t("cardCount", { count: cardCount })}
-              </span>
-            </div>
-
-            {/* Mobile management menu: publish toggle + deck settings + delete. */}
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon"
-                  className="shrink-0 md:hidden"
-                  data-testid="master-edit-overflow"
-                  aria-label={t("masterOptions")}
-                >
-                  <MoreHorizontal aria-hidden="true" className="h-4 w-4" />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end">
-                {/* Bulk import is a card-content action — grouped above a
-                    separator, apart from the deck-lifecycle items below. On
-                    mobile, "Add card" is the global header "+" and batch import
-                    lives here; desktop reaches both via the cards toolbar. */}
-                {onBatchImport ? (
-                  <>
-                    <DropdownMenuItem
-                      onSelect={onBatchImport}
-                      data-testid="master-edit-batch-import"
-                      className="gap-2"
-                    >
-                      <Import aria-hidden="true" className="h-4 w-4" />
-                      {tCardgroups("batchImport")}
-                    </DropdownMenuItem>
-                    <DropdownMenuSeparator />
-                  </>
-                ) : null}
-                <DropdownMenuItem
-                  onSelect={handlePublishToggle}
-                  disabled={publishing || emptyDraft}
-                  data-testid="master-edit-publish-mobile"
-                  className="gap-2"
-                >
-                  {publishIcon}
-                  {publishLabel}
-                </DropdownMenuItem>
-                <DropdownMenuItem
-                  onSelect={() => setSettingsOpen(true)}
-                  data-testid="master-edit-deck-settings-mobile"
-                  className="gap-2"
-                >
-                  <Settings aria-hidden="true" className="h-4 w-4" />
-                  {t("deckSettingsButton")}
-                </DropdownMenuItem>
-                <DropdownMenuItem
-                  onSelect={() => setDeleteOpen(true)}
-                  data-testid="master-edit-delete-mobile"
-                  className="gap-2 text-destructive focus:text-destructive"
-                >
-                  <Trash2 aria-hidden="true" className="h-4 w-4" />
-                  {t("deleteMasterButton")}
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
-          </div>
-          {emptyDraft ? (
-            <p className="mt-1 text-xs text-muted-foreground" data-testid="master-edit-empty-hint">
-              {t("publishEmptyHint")}
-            </p>
-          ) : null}
-        </div>
-
-        {/* Desktop split button: publish primary + dropdown (deck settings, delete). */}
-        <div className="hidden shrink-0 items-center md:flex">
-          <Button
-            type="button"
-            variant={published ? "outline" : "brand"}
-            className="rounded-r-none"
-            data-testid="master-edit-publish"
-            aria-pressed={published}
-            disabled={publishing || emptyDraft}
-            onClick={handlePublishToggle}
-          >
-            {publishIcon}
-            {publishing ? tCommon("loading") : publishLabel}
-          </Button>
-          <SplitButtonMenu
-            triggerLabel={t("masterOptions")}
-            variant={published ? "outline" : "brand"}
-            size="default"
-            data-testid="master-edit-more-options"
-            items={[
-              {
-                key: "settings",
-                icon: <Settings aria-hidden="true" className="h-4 w-4" />,
-                label: t("deckSettingsButton"),
-                onSelect: () => setSettingsOpen(true),
-                "data-testid": "master-edit-deck-settings",
-              },
-              {
-                key: "delete",
-                icon: <Trash2 aria-hidden="true" className="h-4 w-4" />,
-                label: t("deleteMasterButton"),
-                onSelect: () => setDeleteOpen(true),
-                destructive: true,
-                "data-testid": "master-edit-delete",
-              },
-            ]}
-          />
-        </div>
-      </div>
+      <DetailPageHeader
+        backHref="/admin/masters"
+        backLabel={t("backToList")}
+        title={master.name}
+        meta={meta}
+        actions={actions}
+      >
+        {emptyDraft ? (
+          <p className="mt-1 text-xs text-muted-foreground" data-testid="master-edit-empty-hint">
+            {t("publishEmptyHint")}
+          </p>
+        ) : null}
+      </DetailPageHeader>
 
       <FormSheet
         title={t("deckSettingsTitle")}

--- a/frontend/src/app/admin/masters/[id]/edit/master-edit-header.tsx
+++ b/frontend/src/app/admin/masters/[id]/edit/master-edit-header.tsx
@@ -34,17 +34,9 @@ import type { AdminMasterDeck } from "./queries";
 type Props = {
   master: AdminMasterDeck;
   cardCount: number;
-  /**
-   * Opens the batch-import sheet owned by MasterCardsClient. Wired only on the
-   * mobile overflow menu — desktop reaches batch import through the cards
-   * toolbar's split button. Omitted (e.g. in isolated tests) → no import item.
-   * Kept in props for backward compatibility; removed from the overflow menu in
-   * this refactor (batch import moves to the cards toolbar in the next task).
-   */
-  onBatchImport?: () => void;
 };
 
-export function MasterEditHeader({ master, cardCount, onBatchImport: _onBatchImport }: Props) {
+export function MasterEditHeader({ master, cardCount }: Props) {
   const t = useTranslations("AdminMasters");
   const tCommon = useTranslations("Common");
   const router = useRouter();

--- a/frontend/src/app/admin/masters/[id]/edit/master-management-client.tsx
+++ b/frontend/src/app/admin/masters/[id]/edit/master-management-client.tsx
@@ -21,17 +21,17 @@ export function MasterManagementClient({
   return (
     <main className="p-4 md:p-8">
       {/* The header is rendered inside the cards section via the render-prop so
-          its card count tracks the live Apollo-cache totalCount, and the deck
-          overflow menu's batch-import item is wired to the cards client's
-          import sheet — no count state is lifted into this component. */}
+          its card count tracks the live Apollo-cache totalCount; batch import
+          now lives in the cards toolbar (mobile-visible), not the deck menu —
+          no count state is lifted into this component. */}
       <MasterCardsSection
         masterId={master.id}
         deckName={master.name}
         initialEdges={initialEdges}
         initialPageInfo={initialPageInfo}
         initialTotalCount={initialTotalCount}
-        renderPageHeader={({ totalCount, onBatchImport }) => (
-          <MasterEditHeader master={master} cardCount={totalCount} onBatchImport={onBatchImport} />
+        renderPageHeader={({ totalCount }) => (
+          <MasterEditHeader master={master} cardCount={totalCount} />
         )}
       />
     </main>

--- a/frontend/src/app/admin/masters/[id]/edit/master-management-client.tsx
+++ b/frontend/src/app/admin/masters/[id]/edit/master-management-client.tsx
@@ -1,8 +1,5 @@
 "use client";
 
-import { ChevronLeft } from "lucide-react";
-import Link from "next/link";
-import { useTranslations } from "next-intl";
 import type { MasterCardConnectionPageInfo, MasterCardEdge } from "./cards/master-cards-client";
 import { MasterCardsSection } from "./master-cards-section";
 import { MasterEditHeader } from "./master-edit-header";
@@ -21,19 +18,8 @@ export function MasterManagementClient({
   initialPageInfo,
   initialTotalCount,
 }: Props) {
-  const t = useTranslations("AdminMasters");
   return (
     <main className="p-4 md:p-8">
-      <div className="mb-2">
-        <Link
-          href="/admin/masters"
-          className="inline-flex items-center text-muted-foreground hover:text-foreground"
-        >
-          <ChevronLeft aria-hidden="true" className="h-5 w-5" />
-          <span className="sr-only">{t("backToList")}</span>
-        </Link>
-      </div>
-
       {/* The header is rendered inside the cards section via the render-prop so
           its card count tracks the live Apollo-cache totalCount, and the deck
           overflow menu's batch-import item is wired to the cards client's

--- a/frontend/src/app/cardgroups/[id]/edit/cardgroup-management-client.test.tsx
+++ b/frontend/src/app/cardgroups/[id]/edit/cardgroup-management-client.test.tsx
@@ -61,21 +61,6 @@ describe("<CardgroupManagementClient>", () => {
     expect(screen.getByRole("heading", { level: 1, name: /spanish vocab/i })).toBeInTheDocument();
   });
 
-  it("renders a Back link pointing to /cardgroups", () => {
-    renderWithIntl(
-      <CardgroupManagementClient
-        cardgroup={CARDGROUP}
-        initialEdges={[]}
-        initialPageInfo={PAGE_INFO}
-        initialTotalCount={0}
-      />,
-    );
-    expect(screen.getByRole("link", { name: /cardgroups/i })).toHaveAttribute(
-      "href",
-      "/cardgroups",
-    );
-  });
-
   it("passes totalCount from renderPageHeader to CardgroupHeader via the render prop", () => {
     renderWithIntl(
       <CardgroupManagementClient

--- a/frontend/src/app/cardgroups/[id]/edit/cardgroup-management-client.tsx
+++ b/frontend/src/app/cardgroups/[id]/edit/cardgroup-management-client.tsx
@@ -1,8 +1,5 @@
 "use client";
 
-import { ChevronLeft } from "lucide-react";
-import Link from "next/link";
-import { useTranslations } from "next-intl";
 import type { CardConnectionPageInfo, CardEdge } from "@/app/cardgroups/[id]/cards/cards-client";
 import { CardgroupCardsSection } from "@/components/cardgroups/cardgroup-cards-section";
 import { CardgroupHeader } from "@/components/cardgroups/cardgroup-header";
@@ -20,33 +17,16 @@ export function CardgroupManagementClient({
   initialPageInfo,
   initialTotalCount,
 }: Props) {
-  const t = useTranslations("Cardgroups");
   return (
     <main className="p-4 md:p-8">
-      {/* Compact breadcrumb: tight to the title below so the back link reads as
-          a sibling of the header, not a floating standalone row. */}
-      <div className="mb-2">
-        <Link
-          href="/cardgroups"
-          className="inline-flex items-center text-muted-foreground hover:text-foreground"
-        >
-          <ChevronLeft aria-hidden="true" className="h-5 w-5" />
-          <span className="sr-only">{t("backLink")}</span>
-        </Link>
-      </div>
-
       <CardgroupCardsSection
         cardgroupId={cardgroup.id}
         cardgroupName={cardgroup.name}
         initialEdges={initialEdges}
         initialPageInfo={initialPageInfo}
         initialTotalCount={initialTotalCount}
-        renderPageHeader={({ totalCount, onBatchImport }) => (
-          <CardgroupHeader
-            cardgroup={cardgroup}
-            totalCount={totalCount}
-            onBatchImport={onBatchImport}
-          />
+        renderPageHeader={({ totalCount }) => (
+          <CardgroupHeader cardgroup={cardgroup} totalCount={totalCount} />
         )}
       />
     </main>

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -23,6 +23,9 @@
   --accent-foreground: oklch(0.205 0 0);
   --destructive: oklch(0.577 0.245 27.325);
   --destructive-foreground: oklch(0.985 0 0);
+  /* Status-indicator green — used ONLY as a status dot (e.g. a published deck),
+     never as a CTA color. Coral (brand) stays the only constructive CTA color. */
+  --success: oklch(0.63 0.17 149);
   --border: oklch(0.922 0 0);
   --input: oklch(0.922 0 0);
   --ring: oklch(0.708 0 0);
@@ -105,6 +108,7 @@
   --color-accent-foreground: var(--accent-foreground);
   --color-destructive: var(--destructive);
   --color-destructive-foreground: var(--destructive-foreground);
+  --color-success: var(--success);
   --color-border: var(--border);
   --color-input: var(--input);
   --color-ring: var(--ring);

--- a/frontend/src/components/cardgroups/cardgroup-cards-section.test.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-cards-section.test.tsx
@@ -43,7 +43,7 @@ const PAGE_INFO = {
 function renderSection(
   cardgroupId = "cg-1",
   initialTotalCount = 7,
-  renderPageHeader?: (args: { totalCount: number; onBatchImport: () => void }) => ReactNode,
+  renderPageHeader?: (args: { totalCount: number }) => ReactNode,
 ) {
   renderWithIntl(
     <CardgroupCardsSection
@@ -134,15 +134,10 @@ describe("<CardgroupCardsSection>", () => {
     expect(stub).toContainElement(screen.getByRole("button", { name: /add card \+/i }));
   });
 
-  it("passes onBatchImport from renderPageHeader args to the header slot", () => {
-    const _headerOnBatchImport = vi.fn();
-    renderSection("cg-1", 7, ({ onBatchImport: batchFn }) => (
-      <button type="button" data-testid="page-header-batch" onClick={batchFn}>
-        page-header batch
-      </button>
-    ));
-    // The stub always passes the mock onBatchImport. The page header slot gets
-    // the same function reference from the render-prop arg.
-    expect(screen.getByTestId("page-header-batch")).toBeInTheDocument();
+  it("exposes a mobile-visible batch-import control in the toolbar", async () => {
+    renderSection("cg-1", 4);
+    const importBtn = await screen.findByTestId("cardgroup-import-mobile");
+    expect(importBtn).toBeInTheDocument();
+    expect(importBtn.closest(".hidden")).toBeNull();
   });
 });

--- a/frontend/src/components/cardgroups/cardgroup-cards-section.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-cards-section.tsx
@@ -21,10 +21,10 @@ type Props = {
   /**
    * Optional render prop that lets the parent render a page-level header with
    * the live totalCount sourced from the Apollo cache. When provided, the
-   * render prop receives `{ totalCount, onBatchImport }` and is invoked above
-   * the toolbar row. When omitted, no page-level header is rendered.
+   * render prop receives `{ totalCount }` and is invoked above the toolbar row.
+   * When omitted, no page-level header is rendered.
    */
-  renderPageHeader?: (args: { totalCount: number; onBatchImport: () => void }) => ReactNode;
+  renderPageHeader?: (args: { totalCount: number }) => ReactNode;
 };
 
 export function CardgroupCardsSection({
@@ -51,7 +51,7 @@ export function CardgroupCardsSection({
     onBatchImport: () => void;
   }) => (
     <div>
-      {renderPageHeader?.({ totalCount, onBatchImport })}
+      {renderPageHeader?.({ totalCount })}
       <div className="mb-3 flex flex-col gap-2 md:flex-row md:items-center md:justify-end">
         {/* Primary CTA: full-width brand hero on mobile (h-11 = 44px tap target),
             compact on desktop. Add card on mobile is provided by the global "+"
@@ -61,6 +61,18 @@ export function CardgroupCardsSection({
             <Play aria-hidden="true" className="h-4 w-4" />
             {t("startLearning")}
           </Link>
+        </Button>
+        {/* Mobile-only import button: restores batch-import access on small screens
+            after the kebab menu was removed from the cardgroup header (Task 6). */}
+        <Button
+          type="button"
+          variant="outline"
+          className="h-11 w-full px-8 md:hidden"
+          onClick={onBatchImport}
+          data-testid="cardgroup-import-mobile"
+        >
+          <Import aria-hidden="true" className="h-4 w-4" />
+          {t("batchImport")}
         </Button>
         {/* Desktop split button: secondary Add card + dropdown with Batch import.
             Demoted to outline so Start learning is the single brand primary CTA. */}

--- a/frontend/src/components/cardgroups/cardgroup-header.test.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-header.test.tsx
@@ -245,6 +245,25 @@ describe("<CardgroupHeader>", () => {
     expect(mockPush).not.toHaveBeenCalled();
   });
 
+  it("renders an inline back link to /cardgroups and count meta, no status", () => {
+    renderHeader([], 12);
+    expect(screen.getByRole("link", { name: /back to cardgroups/i })).toHaveAttribute(
+      "href",
+      "/cardgroups",
+    );
+    expect(screen.getByText("12 cards")).toBeInTheDocument();
+    expect(screen.queryByRole("status")).toBeNull();
+  });
+
+  it("overflow menu holds rename and delete only (no import)", async () => {
+    const user = userEvent.setup();
+    renderHeader([], 12);
+    await user.click(screen.getByRole("button", { name: /cardgroup options/i }));
+    expect(screen.getByText(/rename/i)).toBeInTheDocument();
+    expect(screen.getByText(/delete cardgroup/i)).toBeInTheDocument();
+    expect(screen.queryByText(/import/i)).toBeNull();
+  });
+
   it("delete network rejection shows error banner and dialog stays open", async () => {
     const user = userEvent.setup();
     const mocks: MockedResponse[] = [

--- a/frontend/src/components/cardgroups/cardgroup-header.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-header.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { Import, MoreHorizontal, Pencil, Trash2 } from "lucide-react";
+import { MoreHorizontal, Pencil, Trash2 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { useCallback, useState } from "react";
 import { CardgroupRenameForm } from "@/components/cardgroups/cardgroup-rename-form";
 import { useDeleteCardgroup } from "@/components/cardgroups/use-delete-cardgroup";
+import { DetailPageHeader } from "@/components/nav/detail-page-header";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -31,11 +32,9 @@ import { getBackendErrorBanner } from "@/lib/apollo/errors";
 type Props = {
   cardgroup: { id: string; name: string };
   totalCount: number;
-  /** Called when the user selects "Batch import" from the mobile options menu. */
-  onBatchImport?: () => void;
 };
 
-export function CardgroupHeader({ cardgroup, totalCount, onBatchImport }: Props) {
+export function CardgroupHeader({ cardgroup, totalCount }: Props) {
   const router = useRouter();
   const [renameOpen, setRenameOpen] = useState(false);
   const [renaming, setRenaming] = useState(false);
@@ -61,55 +60,41 @@ export function CardgroupHeader({ cardgroup, totalCount, onBatchImport }: Props)
     }
   }
 
+  const actions = (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" size="icon" aria-label={t("cardgroupOptions")}>
+          <MoreHorizontal className="h-4 w-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem onSelect={() => setRenameOpen(true)} className="gap-2">
+          <Pencil className="h-4 w-4" />
+          {t("rename")}
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem
+          onSelect={() => setDeleteDialogOpen(true)}
+          className="gap-2 text-destructive focus:text-destructive"
+        >
+          <Trash2 className="h-4 w-4" />
+          {t("deleteCardgroupTitle")}
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+
   return (
     <>
-      <div className="mb-6 flex items-start justify-between gap-3">
-        <div className="min-w-0 flex-1">
-          <h1 className="text-2xl font-semibold leading-tight break-words">{cardgroup.name}</h1>
-          {/* Count demoted from a Badge to muted metadata so the title is the
-              unambiguous anchor of the header. */}
-          <p className="mt-1 text-sm text-muted-foreground">
-            {t("cardsCount", { count: totalCount })}
-          </p>
-        </div>
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button variant="ghost" size="icon" aria-label={t("cardgroupOptions")}>
-              <MoreHorizontal className="h-4 w-4" />
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end">
-            <DropdownMenuItem onSelect={() => setRenameOpen(true)} className="gap-2">
-              <Pencil className="h-4 w-4" />
-              {t("rename")}
-            </DropdownMenuItem>
-            {onBatchImport && (
-              <>
-                <DropdownMenuSeparator />
-                {/* Batch import is shown here for mobile users;
-                    the desktop split button (hidden md:inline-flex) covers desktop. */}
-                <DropdownMenuItem onSelect={onBatchImport} className="gap-2 md:hidden">
-                  <Import className="h-4 w-4" />
-                  {t("batchImport")}
-                </DropdownMenuItem>
-              </>
-            )}
-            <DropdownMenuSeparator />
-            {/* Future reserved items (not yet implemented):
-                <DropdownMenuItem disabled>Export to TextDic</DropdownMenuItem>
-                <DropdownMenuItem disabled>Duplicate</DropdownMenuItem>
-                <DropdownMenuSeparator />
-            */}
-            <DropdownMenuItem
-              onSelect={() => setDeleteDialogOpen(true)}
-              className="gap-2 text-destructive focus:text-destructive"
-            >
-              <Trash2 className="h-4 w-4" />
-              {t("deleteCardgroupTitle")}
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
-      </div>
+      <DetailPageHeader
+        backHref="/cardgroups"
+        backLabel={t("backLink")}
+        title={cardgroup.name}
+        meta={
+          <p className="text-sm text-muted-foreground">{t("cardsCount", { count: totalCount })}</p>
+        }
+        actions={actions}
+      />
 
       <FormSheet
         open={renameOpen}

--- a/frontend/src/components/nav/detail-page-header.test.tsx
+++ b/frontend/src/components/nav/detail-page-header.test.tsx
@@ -42,6 +42,7 @@ describe("DetailPageHeader", () => {
     const { container } = render(<DetailPageHeader backHref="/x" backLabel="back" title="T" />);
     // Only the back link + title row exists; no stray slot containers.
     expect(screen.queryByTestId("meta-slot")).toBeNull();
+    expect(screen.queryByTestId("actions-slot")).toBeNull();
     expect(container.querySelector("h1")?.textContent).toBe("T");
   });
 });

--- a/frontend/src/components/nav/detail-page-header.test.tsx
+++ b/frontend/src/components/nav/detail-page-header.test.tsx
@@ -1,0 +1,47 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { DetailPageHeader } from "./detail-page-header";
+
+describe("DetailPageHeader", () => {
+  it("renders an inline back link with an sr-only label and the title", () => {
+    render(
+      <DetailPageHeader
+        backHref="/admin/masters"
+        backLabel="Back to list"
+        title="Advanced Cards"
+      />,
+    );
+    const back = screen.getByRole("link", { name: "Back to list" });
+    expect(back).toHaveAttribute("href", "/admin/masters");
+    expect(screen.getByRole("heading", { level: 1, name: "Advanced Cards" })).toBeInTheDocument();
+  });
+
+  it("renders meta, actions, and children slots when provided", () => {
+    render(
+      <DetailPageHeader
+        backHref="/x"
+        backLabel="back"
+        title="T"
+        meta={<span data-testid="meta-slot">meta</span>}
+        actions={
+          <button type="button" data-testid="actions-slot">
+            a
+          </button>
+        }
+      >
+        <p data-testid="children-slot">hint</p>
+      </DetailPageHeader>,
+    );
+    expect(screen.getByTestId("meta-slot")).toBeInTheDocument();
+    expect(screen.getByTestId("actions-slot")).toBeInTheDocument();
+    expect(screen.getByTestId("children-slot")).toBeInTheDocument();
+  });
+
+  it("omits meta and actions wrappers when not provided", () => {
+    const { container } = render(<DetailPageHeader backHref="/x" backLabel="back" title="T" />);
+    // Only the back link + title row exists; no stray slot containers.
+    expect(screen.queryByTestId("meta-slot")).toBeNull();
+    expect(container.querySelector("h1")?.textContent).toBe("T");
+  });
+});

--- a/frontend/src/components/nav/detail-page-header.tsx
+++ b/frontend/src/components/nav/detail-page-header.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { ChevronLeft } from "lucide-react";
+import Link from "next/link";
+import type { ReactNode } from "react";
+
+type DetailPageHeaderProps = {
+  /** Destination of the inline back affordance. */
+  backHref: string;
+  /** Accessible (sr-only) label for the back link, e.g. t("backToList"). */
+  backLabel: string;
+  title: string;
+  /** Status + count cluster rendered under the title. The page owns its md: reflow. */
+  meta?: ReactNode;
+  /** Trailing action cluster on the title row. The page owns its md: reflow. */
+  actions?: ReactNode;
+  /** Optional note rendered below meta, e.g. an empty-draft publish hint. */
+  children?: ReactNode;
+};
+
+/**
+ * The shared detail-page header layout: an inline back affordance flush to the
+ * title (no standalone back row), with optional meta and trailing-action slots.
+ * Used by the master-edit and cardgroup-detail headers. It owns layout only —
+ * each consumer composes its own meta/actions, including responsive variants.
+ */
+export function DetailPageHeader({
+  backHref,
+  backLabel,
+  title,
+  meta,
+  actions,
+  children,
+}: DetailPageHeaderProps) {
+  return (
+    <header className="mb-6">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-1.5">
+            <Link href={backHref} className="shrink-0 text-muted-foreground hover:text-foreground">
+              <ChevronLeft aria-hidden="true" className="h-5 w-5" />
+              <span className="sr-only">{backLabel}</span>
+            </Link>
+            <h1 className="min-w-0 truncate text-2xl font-semibold leading-tight">{title}</h1>
+          </div>
+          {meta ? <div className="mt-1">{meta}</div> : null}
+          {children}
+        </div>
+        {actions ? <div className="flex shrink-0 items-center">{actions}</div> : null}
+      </div>
+    </header>
+  );
+}

--- a/frontend/src/components/nav/detail-page-header.tsx
+++ b/frontend/src/components/nav/detail-page-header.tsx
@@ -37,7 +37,10 @@ export function DetailPageHeader({
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-1.5">
-            <Link href={backHref} className="shrink-0 text-muted-foreground hover:text-foreground">
+            <Link
+              href={backHref}
+              className="shrink-0 rounded-sm text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
               <ChevronLeft aria-hidden="true" className="h-5 w-5" />
               <span className="sr-only">{backLabel}</span>
             </Link>


### PR DESCRIPTION
## Summary

The master-edit screen (`/admin/masters/[id]/edit`) and — identically — the cardgroup-detail screen (`/cardgroups/[id]/edit`) rendered an awkward header: a **lone back-row** (`<div className="mb-2">` whose only child was a bare `ChevronLeft`) sitting in a near-empty band above the title, and a **`…` overflow menu anchored to the meta row** (the status badge + card count) so it read as belonging to "1246 枚" rather than to the deck. The master menu also **mixed a content action (batch import) with deck-lifecycle actions** (publish / settings / delete) in one undifferentiated list.

This rebuilds both headers on one shared `DetailPageHeader` layout shell: the back affordance is inlined with the title (the lone row is gone), the action cluster is owned by the title (not the count), the primary state-action (publish/unpublish on master) is exposed, and batch import moves out of the header menu into the cards toolbar (made mobile-visible). Same information architecture on mobile and desktop; only the presentation reflows.

No related GitHub issue (direct UX request).

## Changes

### Shared `DetailPageHeader` layout shell

- `frontend/src/components/nav/detail-page-header.tsx` — new presentational shell with slots `{ backHref, backLabel, title, meta?, actions?, children? }`. Renders the inline back `<Link>` (`sr-only` label + keyboard focus ring) flush with the `<h1>`, an optional meta row, a trailing actions slot, and optional children (e.g. an empty-draft hint). **Layout only** — it owns no action semantics; each consumer composes its own `meta`/`actions` including their `md:` reflow. Covered by `detail-page-header.test.tsx`.

### `--success` status-indicator token

- `frontend/src/app/globals.css` — add `--success: oklch(0.63 0.17 149)` (`:root`) + `--color-success` (`@theme`). The only sanctioned green; used solely as the published-status dot, never as a CTA color (coral `brand` stays the only constructive CTA, deep-red `destructive` stays danger).

### Master-edit header

- `frontend/src/app/admin/masters/[id]/edit/master-edit-header.tsx` — render via `DetailPageHeader`. Mobile meta = an interactive **status chip** (`master-edit-status-chip`, a `bg-success` dot when published) whose dropdown is the publish toggle (`master-edit-publish-mobile`, disabled + hint for an empty draft); the `…` overflow (`master-edit-overflow`) now holds **only** settings + delete. Desktop keeps the publish split-button + settings/delete dropdown and the status badge. Delete confirm keeps `buttonVariants({ variant: "destructive" })`.
- `frontend/src/app/admin/masters/[id]/edit/master-cards-section.tsx` — surface batch import as a mobile-visible outline button (`master-import-mobile`) in the cards toolbar; desktop Add-card + import split-button unchanged. `onBatchImport` is removed from the header prop chain.
- `frontend/src/app/admin/masters/[id]/edit/master-management-client.tsx` — delete the lone back row; the back link now lives in the header.
- `frontend/messages/{en,ja}.json` — `AdminMasters.deckSettingsButton` value → `Settings` / `設定`; add `AdminMasters.changePublishState` (chip aria-label). en/ja parity preserved.

### Cardgroup-detail header

- `frontend/src/components/cardgroups/cardgroup-header.tsx` — render via `DetailPageHeader`; meta = count only (no status — cardgroups have no publish state); `…` holds rename + delete; delete confirm keeps inline `bg-destructive`. `onBatchImport` removed.
- `frontend/src/components/cardgroups/cardgroup-cards-section.tsx` — surface batch import as a mobile-visible button (`cardgroup-import-mobile`); "Start learning" CTA + desktop split-button unchanged.
- `frontend/src/app/cardgroups/[id]/edit/cardgroup-management-client.tsx` — delete the lone back row.

### Tests

- New `detail-page-header.test.tsx`, `master-cards-section.test.tsx`; updated `master-edit-header.test.tsx`, `cardgroup-header.test.tsx`, `cardgroup-cards-section.test.tsx`.
- `frontend/__tests__/admin-master-cards.test.tsx` — the header now renders the card count in both a mobile (`md:hidden`) and desktop (`hidden md:flex`) meta row; in jsdom both render, so `getByText("N card")` → `getAllByText(...).toHaveLength(2)`.
- Removed the now-dead `cardgroup-management-client.test.tsx` "renders a Back link" test (the lone back row it exercised is gone; the back link is covered by `cardgroup-header.test.tsx`).

## Verification

- typecheck ✓ (`tsc --noEmit`)
- lint ✓ (`biome check`)
- knip ✓ (no unused exports / orphan imports)
- test ✓ **1528 passing (163 files)**
- build ✓ (`next build`)
- CJK ✓ — no Japanese literals in any changed `.tsx`/`.ts` source (copy lives only in the message catalogs):

  ```bash
  perl -CSD -ne 'print "$ARGV\n" if /[\x{3040}-\x{30ff}\x{4e00}-\x{9fff}]/' \
    $(git diff --name-only main..HEAD -- 'frontend/src/**/*.tsx' 'frontend/src/**/*.ts')  # -> nothing
  ```
- e2e specs unaffected — `admin-masters-edit.spec.ts` / `cardgroup-import.spec.ts` reach deck settings / batch import through the desktop cards-toolbar split buttons (untouched), never the removed header-overflow items.

## Test plan

- [ ] **Master mobile (`<md`)** — back chevron sits inline left of **Advanced Cards** (no empty row above); the `● 公開中` chip is to the left of the muted count; tapping the chip opens 公開/非公開; the `…` menu holds only 設定 + マスターを削除; 一括インポート is in the cards toolbar.
- [ ] **Master desktop (`md+`)** — title with inline back; status badge + count; publish split-button (publish + 設定/削除) on the right; Add card + 一括インポート in the cards toolbar.
- [ ] **Master empty draft** — chip shows 下書き, the publish item is disabled, and the empty-draft hint renders.
- [ ] **Cardgroup mobile + desktop (`/cardgroups/[id]/edit`)** — inline back, count-only meta, `…` = rename + delete, 一括インポート mobile-visible in the toolbar; "Start learning" CTA unchanged.
- [ ] **Delete confirms** (master + cardgroup) render the red destructive action.
