### PR TITLE
refactor(frontend): fold mobile batch import into the detail-page overflow menu

### DIFF
--- a/frontend/src/app/admin/masters/[id]/edit/master-cards-section.test.tsx
+++ b/frontend/src/app/admin/masters/[id]/edit/master-cards-section.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { MockedProvider } from "@apollo/client/testing/react";
 import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { expect, it, vi } from "vitest";
 import { AdminMasterCardsConnectionDocument } from "@/generated/graphql";
 import { UndoDeleteProvider } from "@/lib/undo-delete";
@@ -39,7 +40,11 @@ const node = {
   updatedAt: "2026-01-01T00:00:00Z",
 };
 
-it("exposes a batch-import control in the toolbar (mobile-visible)", async () => {
+it("threads onBatchImport into renderPageHeader so the header can open the import sheet", async () => {
+  // The mobile batch-import control now lives in the page header's overflow
+  // menu, so the section must forward MasterCardsClient's onBatchImport up to
+  // the renderPageHeader render prop; invoking it opens the real import sheet.
+  const user = userEvent.setup();
   renderWithIntl(
     <MockedProvider
       mocks={[
@@ -68,15 +73,17 @@ it("exposes a batch-import control in the toolbar (mobile-visible)", async () =>
           initialEdges={[{ __typename: "MasterCardEdge", cursor: "c-1", node }]}
           initialPageInfo={pageInfo}
           initialTotalCount={3}
-          renderPageHeader={({ totalCount }) => <span data-testid="hdr-count">{totalCount}</span>}
+          renderPageHeader={({ onBatchImport }) => (
+            <button type="button" data-testid="hdr-import" onClick={onBatchImport}>
+              import
+            </button>
+          )}
         />
       </UndoDeleteProvider>
     </MockedProvider>,
   );
-  const importBtn = await screen.findByTestId("master-import-mobile");
-  expect(importBtn).toBeInTheDocument();
-  // The control is NOT inside a `hidden md:*` wrapper — assert it is visible.
-  expect(importBtn.closest(".hidden")).toBeNull();
+  await user.click(await screen.findByTestId("hdr-import"));
+  expect(await screen.findByTestId("batch-import-payload")).toBeInTheDocument();
 });
 
 it("renders MasterCardsClient with the seed and exposes the live count to renderPageHeader", async () => {

--- a/frontend/src/app/admin/masters/[id]/edit/master-cards-section.tsx
+++ b/frontend/src/app/admin/masters/[id]/edit/master-cards-section.tsx
@@ -19,9 +19,11 @@ type MasterCardsSectionProps = {
   initialTotalCount: number;
   /**
    * Renders the deck-level page header (title / status badge / overflow menu)
-   * with the live `totalCount`. Omitted → no page header.
+   * with the live `totalCount`. Receives `onBatchImport` so the header's mobile
+   * overflow menu can host batch import (the standalone mobile toolbar button
+   * was removed). Omitted → no page header.
    */
-  renderPageHeader?: (args: { totalCount: number }) => ReactNode;
+  renderPageHeader?: (args: { totalCount: number; onBatchImport: () => void }) => ReactNode;
 };
 
 export function MasterCardsSection({
@@ -48,20 +50,9 @@ export function MasterCardsSection({
     onBatchImport: () => void;
   }) => (
     <div>
-      {renderPageHeader?.({ totalCount })}
-      {/* Mobile (<md): import lives here; Add card is the global header "+". */}
-      <div className="mb-3 flex justify-end md:hidden">
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          onClick={onBatchImport}
-          data-testid="master-import-mobile"
-        >
-          <Import aria-hidden="true" className="h-4 w-4" />
-          {tCardgroups("batchImport")}
-        </Button>
-      </div>
+      {renderPageHeader?.({ totalCount, onBatchImport })}
+      {/* Mobile (<md): batch import lives in the page header's overflow menu;
+          Add card is the global header "+". */}
       {/* Desktop (md+): Add card + a dropdown that folds in Batch import. */}
       <div className="mb-3 hidden justify-end md:flex">
         <div className="inline-flex">

--- a/frontend/src/app/admin/masters/[id]/edit/master-edit-header.test.tsx
+++ b/frontend/src/app/admin/masters/[id]/edit/master-edit-header.test.tsx
@@ -57,6 +57,8 @@ const DECK: AdminMasterDeck = {
   updatedAt: "2026-01-01T00:00:00Z",
 };
 
+const onBatchImport = vi.fn();
+
 function renderHeader(
   overrides: Partial<AdminMasterDeck> & { cardCount?: number } = {},
   mocks: ReadonlyArray<unknown> = [],
@@ -67,7 +69,11 @@ function renderHeader(
   return render(
     <MockedProvider mocks={mocks as never}>
       <NextIntlClientProvider locale="en" messages={enMessages} timeZone="UTC">
-        <MasterEditHeader master={deck} cardCount={resolvedCardCount} />
+        <MasterEditHeader
+          master={deck}
+          cardCount={resolvedCardCount}
+          onBatchImport={onBatchImport}
+        />
       </NextIntlClientProvider>
     </MockedProvider>,
   );
@@ -280,14 +286,23 @@ describe("MasterEditHeader", () => {
     );
   });
 
-  it("mobile: overflow menu holds only Settings and Delete (no import, no publish)", async () => {
+  it("mobile: overflow menu hosts batch import alongside Settings and Delete (no publish)", async () => {
     const user = userEvent.setup();
     renderHeader({ status: "PUBLISHED", cardCount: 5 });
     await user.click(screen.getByTestId("master-edit-overflow"));
+    expect(screen.getByTestId("master-edit-import-mobile")).toBeInTheDocument();
     expect(screen.getByTestId("master-edit-deck-settings-mobile")).toBeInTheDocument();
     expect(screen.getByTestId("master-edit-delete-mobile")).toBeInTheDocument();
-    expect(screen.queryByTestId("master-edit-batch-import")).toBeNull();
+    // Publish stays on the status chip, not the overflow menu.
     expect(screen.queryByTestId("master-edit-publish-mobile")).toBeNull();
+  });
+
+  it("mobile: overflow 'Batch import' item calls onBatchImport", async () => {
+    const user = userEvent.setup();
+    renderHeader({ status: "PUBLISHED", cardCount: 5 });
+    await user.click(screen.getByTestId("master-edit-overflow"));
+    await user.click(screen.getByTestId("master-edit-import-mobile"));
+    expect(onBatchImport).toHaveBeenCalledTimes(1);
   });
 
   it("renders the inline back link to the masters list", () => {
@@ -305,7 +320,11 @@ describe("MasterEditHeader", () => {
     const { container } = render(
       <MockedProvider mocks={[]}>
         <NextIntlClientProvider locale="en" messages={enMessages} timeZone="UTC">
-          <MasterEditHeader master={{ ...DECK, cardCount: 0 }} cardCount={5} />
+          <MasterEditHeader
+            master={{ ...DECK, cardCount: 0 }}
+            cardCount={5}
+            onBatchImport={onBatchImport}
+          />
         </NextIntlClientProvider>
       </MockedProvider>,
     );

--- a/frontend/src/app/admin/masters/[id]/edit/master-edit-header.tsx
+++ b/frontend/src/app/admin/masters/[id]/edit/master-edit-header.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ChevronDown, Eye, EyeOff, MoreHorizontal, Settings, Trash2 } from "lucide-react";
+import { ChevronDown, Eye, EyeOff, Import, MoreHorizontal, Settings, Trash2 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { useCallback, useState } from "react";
@@ -34,11 +34,19 @@ import type { AdminMasterDeck } from "./queries";
 type Props = {
   master: AdminMasterDeck;
   cardCount: number;
+  /**
+   * Opens the batch-import sheet (owned by `MasterCardsClient`). Surfaced here
+   * so the mobile overflow menu can host batch import, where the standalone
+   * toolbar button was removed. Required so the wire from `MasterCardsClient`
+   * is enforced at compile time rather than silently defaulting to a no-op.
+   */
+  onBatchImport: () => void;
 };
 
-export function MasterEditHeader({ master, cardCount }: Props) {
+export function MasterEditHeader({ master, cardCount, onBatchImport }: Props) {
   const t = useTranslations("AdminMasters");
   const tCommon = useTranslations("Common");
+  const tCardgroups = useTranslations("Cardgroups");
   const router = useRouter();
 
   const [settingsOpen, setSettingsOpen] = useState(false);
@@ -226,6 +234,18 @@ export function MasterEditHeader({ master, cardCount }: Props) {
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end">
+          {/* Batch import lives here on mobile after the standalone toolbar
+              button was removed. The trigger is md:hidden, so this menu only
+              opens on mobile; desktop keeps batch import in the cards toolbar's
+              split-button menu. */}
+          <DropdownMenuItem
+            onSelect={onBatchImport}
+            data-testid="master-edit-import-mobile"
+            className="gap-2"
+          >
+            <Import aria-hidden="true" className="h-4 w-4" />
+            {tCardgroups("batchImport")}
+          </DropdownMenuItem>
           <DropdownMenuItem
             onSelect={() => setSettingsOpen(true)}
             data-testid="master-edit-deck-settings-mobile"

--- a/frontend/src/app/admin/masters/[id]/edit/master-management-client.tsx
+++ b/frontend/src/app/admin/masters/[id]/edit/master-management-client.tsx
@@ -21,17 +21,17 @@ export function MasterManagementClient({
   return (
     <main className="p-4 md:p-8">
       {/* The header is rendered inside the cards section via the render-prop so
-          its card count tracks the live Apollo-cache totalCount; batch import
-          now lives in the cards toolbar (mobile-visible), not the deck menu —
-          no count state is lifted into this component. */}
+          its card count tracks the live Apollo-cache totalCount. The section
+          forwards onBatchImport so the header's mobile overflow menu can host
+          batch import; no count state is lifted into this component. */}
       <MasterCardsSection
         masterId={master.id}
         deckName={master.name}
         initialEdges={initialEdges}
         initialPageInfo={initialPageInfo}
         initialTotalCount={initialTotalCount}
-        renderPageHeader={({ totalCount }) => (
-          <MasterEditHeader master={master} cardCount={totalCount} />
+        renderPageHeader={({ totalCount, onBatchImport }) => (
+          <MasterEditHeader master={master} cardCount={totalCount} onBatchImport={onBatchImport} />
         )}
       />
     </main>

--- a/frontend/src/app/cardgroups/[id]/edit/cardgroup-management-client.tsx
+++ b/frontend/src/app/cardgroups/[id]/edit/cardgroup-management-client.tsx
@@ -25,8 +25,12 @@ export function CardgroupManagementClient({
         initialEdges={initialEdges}
         initialPageInfo={initialPageInfo}
         initialTotalCount={initialTotalCount}
-        renderPageHeader={({ totalCount }) => (
-          <CardgroupHeader cardgroup={cardgroup} totalCount={totalCount} />
+        renderPageHeader={({ totalCount, onBatchImport }) => (
+          <CardgroupHeader
+            cardgroup={cardgroup}
+            totalCount={totalCount}
+            onBatchImport={onBatchImport}
+          />
         )}
       />
     </main>

--- a/frontend/src/components/cardgroups/cardgroup-cards-section.test.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-cards-section.test.tsx
@@ -43,7 +43,7 @@ const PAGE_INFO = {
 function renderSection(
   cardgroupId = "cg-1",
   initialTotalCount = 7,
-  renderPageHeader?: (args: { totalCount: number }) => ReactNode,
+  renderPageHeader?: (args: { totalCount: number; onBatchImport: () => void }) => ReactNode,
 ) {
   renderWithIntl(
     <CardgroupCardsSection
@@ -134,10 +134,17 @@ describe("<CardgroupCardsSection>", () => {
     expect(stub).toContainElement(screen.getByRole("button", { name: /add card \+/i }));
   });
 
-  it("exposes a mobile-visible batch-import control in the toolbar", async () => {
-    renderSection("cg-1", 4);
-    const importBtn = await screen.findByTestId("cardgroup-import-mobile");
-    expect(importBtn).toBeInTheDocument();
-    expect(importBtn.closest(".hidden")).toBeNull();
+  it("forwards onBatchImport into the renderPageHeader slot", async () => {
+    // The mobile batch-import control now lives in the page header's overflow
+    // menu, so the section must thread CardsClient's onBatchImport up to the
+    // renderPageHeader render prop, not just into its own toolbar.
+    const user = userEvent.setup();
+    renderSection("cg-1", 7, ({ onBatchImport: headerImport }) => (
+      <button type="button" data-testid="page-header-import" onClick={headerImport}>
+        header import
+      </button>
+    ));
+    await user.click(screen.getByTestId("page-header-import"));
+    expect(onBatchImport).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/components/cardgroups/cardgroup-cards-section.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-cards-section.tsx
@@ -21,10 +21,12 @@ type Props = {
   /**
    * Optional render prop that lets the parent render a page-level header with
    * the live totalCount sourced from the Apollo cache. When provided, the
-   * render prop receives `{ totalCount }` and is invoked above the toolbar row.
-   * When omitted, no page-level header is rendered.
+   * render prop receives `{ totalCount, onBatchImport }` and is invoked above
+   * the toolbar row. `onBatchImport` lets the header's overflow menu host batch
+   * import on mobile (the standalone mobile toolbar button was removed). When
+   * omitted, no page-level header is rendered.
    */
-  renderPageHeader?: (args: { totalCount: number }) => ReactNode;
+  renderPageHeader?: (args: { totalCount: number; onBatchImport: () => void }) => ReactNode;
 };
 
 export function CardgroupCardsSection({
@@ -51,28 +53,17 @@ export function CardgroupCardsSection({
     onBatchImport: () => void;
   }) => (
     <div>
-      {renderPageHeader?.({ totalCount })}
+      {renderPageHeader?.({ totalCount, onBatchImport })}
       <div className="mb-3 flex flex-col gap-2 md:flex-row md:items-center md:justify-end">
         {/* Primary CTA: full-width brand hero on mobile (h-11 = 44px tap target),
             compact on desktop. Add card on mobile is provided by the global "+"
-            header action, so no Add button is duplicated here on small screens. */}
+            header action, so no Add button is duplicated here on small screens.
+            Batch import on mobile lives in the page header's overflow menu. */}
         <Button asChild variant="brand" className="h-11 w-full px-8 md:h-9 md:w-auto md:px-4">
           <Link href={learnHref}>
             <Play aria-hidden="true" className="h-4 w-4" />
             {t("startLearning")}
           </Link>
-        </Button>
-        {/* Mobile-only import button: restores batch-import access on small screens
-            after the kebab menu was removed from the cardgroup header (Task 6). */}
-        <Button
-          type="button"
-          variant="outline"
-          className="h-11 w-full px-8 md:hidden"
-          onClick={onBatchImport}
-          data-testid="cardgroup-import-mobile"
-        >
-          <Import aria-hidden="true" className="h-4 w-4" />
-          {t("batchImport")}
         </Button>
         {/* Desktop split button: secondary Add card + dropdown with Batch import.
             Demoted to outline so Start learning is the single brand primary CTA. */}

--- a/frontend/src/components/cardgroups/cardgroup-header.test.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-header.test.tsx
@@ -11,6 +11,7 @@ import { CardgroupHeader } from "./cardgroup-header";
 
 const mockPush = vi.fn();
 const mockRefresh = vi.fn();
+const onBatchImport = vi.fn();
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: mockPush, refresh: mockRefresh }),
@@ -36,7 +37,11 @@ function makeUpdateMock(
 function renderHeader(mocks: MockedResponse[] = [], totalCount = 5) {
   renderWithIntl(
     <MockedProvider mocks={mocks}>
-      <CardgroupHeader cardgroup={CARDGROUP} totalCount={totalCount} />
+      <CardgroupHeader
+        cardgroup={CARDGROUP}
+        totalCount={totalCount}
+        onBatchImport={onBatchImport}
+      />
     </MockedProvider>,
   );
 }
@@ -45,6 +50,7 @@ describe("<CardgroupHeader>", () => {
   beforeEach(() => {
     mockPush.mockClear();
     mockRefresh.mockClear();
+    onBatchImport.mockClear();
   });
 
   it("renders the cardgroup name as h1", () => {
@@ -255,13 +261,21 @@ describe("<CardgroupHeader>", () => {
     expect(screen.queryByRole("status")).toBeNull();
   });
 
-  it("overflow menu holds rename and delete only (no import)", async () => {
+  it("overflow menu holds batch import alongside rename and delete", async () => {
     const user = userEvent.setup();
     renderHeader([], 12);
     await user.click(screen.getByRole("button", { name: /cardgroup options/i }));
-    expect(screen.getByText(/rename/i)).toBeInTheDocument();
-    expect(screen.getByText(/delete cardgroup/i)).toBeInTheDocument();
-    expect(screen.queryByText(/import/i)).toBeNull();
+    expect(screen.getByRole("menuitem", { name: /batch import/i })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: /rename/i })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: /delete cardgroup/i })).toBeInTheDocument();
+  });
+
+  it("overflow menu 'Batch import' item calls onBatchImport", async () => {
+    const user = userEvent.setup();
+    renderHeader([], 12);
+    await user.click(screen.getByRole("button", { name: /cardgroup options/i }));
+    await user.click(screen.getByRole("menuitem", { name: /batch import/i }));
+    expect(onBatchImport).toHaveBeenCalledTimes(1);
   });
 
   it("delete network rejection shows error banner and dialog stays open", async () => {

--- a/frontend/src/components/cardgroups/cardgroup-header.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-header.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { MoreHorizontal, Pencil, Trash2 } from "lucide-react";
+import { Import, MoreHorizontal, Pencil, Trash2 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { useCallback, useState } from "react";
@@ -32,9 +32,16 @@ import { getBackendErrorBanner } from "@/lib/apollo/errors";
 type Props = {
   cardgroup: { id: string; name: string };
   totalCount: number;
+  /**
+   * Opens the batch-import sheet (owned by `CardsClient`). Surfaced here so the
+   * overflow menu can host batch import on mobile, where the standalone toolbar
+   * button was removed. Required so the wire from `CardsClient` is enforced at
+   * compile time rather than silently defaulting to a no-op.
+   */
+  onBatchImport: () => void;
 };
 
-export function CardgroupHeader({ cardgroup, totalCount }: Props) {
+export function CardgroupHeader({ cardgroup, totalCount, onBatchImport }: Props) {
   const router = useRouter();
   const [renameOpen, setRenameOpen] = useState(false);
   const [renaming, setRenaming] = useState(false);
@@ -68,6 +75,17 @@ export function CardgroupHeader({ cardgroup, totalCount }: Props) {
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
+        {/* Mobile-only: batch import lives here after the standalone toolbar
+            button was removed. Hidden on desktop, where the cards toolbar's
+            split-button menu still hosts batch import. */}
+        <DropdownMenuItem
+          onSelect={onBatchImport}
+          className="gap-2 md:hidden"
+          data-testid="cardgroup-import-menuitem"
+        >
+          <Import className="h-4 w-4" />
+          {t("batchImport")}
+        </DropdownMenuItem>
         <DropdownMenuItem onSelect={() => setRenameOpen(true)} className="gap-2">
           <Pencil className="h-4 w-4" />
           {t("rename")}


### PR DESCRIPTION
## Summary

The prior detail-header redesign surfaced **batch import as a standalone mobile button** in the cards toolbar on two screens — the cardgroup-detail screen (`/cardgroups/[id]/edit`, a full-width button under "Start learning") and the master-edit screen (`/admin/masters/[id]/edit`, a right-aligned button above the card list). That left a separate control floating between the header and the card list on small screens.

This folds that mobile button into the screen's existing `…` overflow menu, so all secondary actions live in one place on mobile and the band above the card list is just the primary CTA / list. Desktop is unchanged: each screen already hosts batch import inside its "Add card" split-button menu, which keeps "Add card" prominent for desktop workflows. The import menu item is mobile-only (`md:hidden` on the cardgroup item; the master mobile overflow trigger is already `md:hidden`).

`onBatchImport` is threaded as a **required** prop down each screen's `renderPageHeader` render-prop chain, so the wire from the sheet-owning client is enforced at compile time rather than silently defaulting to a no-op.

No related GitHub issue (direct UX request).

## Changes

### Cardgroup-detail header (`/cardgroups/[id]/edit`)

- `frontend/src/components/cardgroups/cardgroup-header.tsx` — add a required `onBatchImport` prop and a mobile-only (`md:hidden`) **Batch import** item (`cardgroup-import-menuitem`) at the top of the `…` menu, above Rename / Delete.
- `frontend/src/components/cardgroups/cardgroup-cards-section.tsx` — remove the full-width mobile import button (`cardgroup-import-mobile`); forward `onBatchImport` into the `renderPageHeader` slot. Desktop "Start learning" CTA + Add-card split-button (which still hosts import) unchanged.
- `frontend/src/app/cardgroups/[id]/edit/cardgroup-management-client.tsx` — thread `onBatchImport` from the section into `CardgroupHeader`.

### Master-edit header (`/admin/masters/[id]/edit`)

- `frontend/src/app/admin/masters/[id]/edit/master-edit-header.tsx` — add a required `onBatchImport` prop and a **Batch import** item (`master-edit-import-mobile`) at the top of the mobile `…` overflow (`master-edit-overflow`), above Deck settings / Delete. The status-chip publish toggle is untouched.
- `frontend/src/app/admin/masters/[id]/edit/master-cards-section.tsx` — remove the right-aligned mobile import button (`master-import-mobile`); forward `onBatchImport` into the `renderPageHeader` slot. Desktop Add-card + import split-button unchanged.
- `frontend/src/app/admin/masters/[id]/edit/master-management-client.tsx` — thread `onBatchImport` into `MasterEditHeader`.

Both screens reuse the existing `Cardgroups.batchImport` message key — no new copy.

### Tests

- `cardgroup-header.test.tsx` / `master-edit-header.test.tsx` — the "menu holds … no import" specs are rewritten to assert the `…` menu now hosts Batch import alongside the lifecycle items and that the item fires `onBatchImport`; harnesses pass the new required prop.
- `cardgroup-cards-section.test.tsx` / `master-cards-section.test.tsx` — the removed mobile-button specs are replaced with wiring specs that the section forwards `onBatchImport` into `renderPageHeader` (master: invoking it opens the real import sheet).

## Verification

- typecheck ✓ (`tsc --noEmit`)
- lint ✓ (`biome check --error-on-warnings`, 382 files, no warnings)
- knip ✓ (no unused exports / orphan imports)
- test ✓ **1531 passing (163 files)**
- build ✓ (`next build`)
- CJK ✓ — no Japanese literals in any changed `.tsx` (copy lives only in the message catalogs)
- e2e unaffected — `cardgroup-import.spec.ts` reaches batch import through the desktop cards-toolbar split button (`cardgroup-add-more-options`), which is untouched; the removed `*-import-mobile` test IDs have no references in `src` / `__tests__` / `e2e`.

## Test plan

- [ ] **Cardgroup mobile (`<md`)** — under **Advanced Cards**, the band shows only "Start learning"; the `…` menu holds **一括インポート** (top) + 名前変更 + 削除; tapping 一括インポート opens the import sheet.
- [ ] **Cardgroup desktop (`md+`)** — Add card + import split-button still hosts 一括インポート; the `…` menu shows rename + delete only (no import item).
- [ ] **Master mobile (`<md`)** — the `…` overflow holds **一括インポート** (top) + 設定 + 削除; the publish status-chip is unchanged; no floating import button above the list.
- [ ] **Master desktop (`md+`)** — publish split-button + settings/delete dropdown unchanged; Add card + 一括インポート split-button still hosts import.
