### PR TITLE
feat(frontend): show a publish-status dot on master deck status badges

### DIFF
--- a/frontend/src/app/admin/masters/[id]/edit/master-edit-header.test.tsx
+++ b/frontend/src/app/admin/masters/[id]/edit/master-edit-header.test.tsx
@@ -86,10 +86,13 @@ beforeEach(() => {
 afterEach(() => vi.clearAllMocks());
 
 describe("MasterEditHeader", () => {
-  it("renders the deck name, draft badge, and card count", () => {
+  it("renders the deck name, draft badge with a muted status dot, and card count", () => {
     renderHeader();
     expect(screen.getByRole("heading", { level: 1, name: "Spanish A1" })).toBeInTheDocument();
-    expect(screen.getByTestId("master-edit-status-badge")).toHaveTextContent("Draft");
+    const badge = screen.getByTestId("master-edit-status-badge");
+    expect(badge).toHaveTextContent("Draft");
+    // The desktop status badge carries a status dot (muted for a draft deck).
+    expect(badge.querySelector('[aria-hidden="true"]')?.className).toContain("bg-muted-foreground");
     // Card count renders in both the mobile and desktop meta rows.
     expect(screen.getAllByText("5 cards").length).toBeGreaterThan(0);
   });

--- a/frontend/src/app/admin/masters/[id]/edit/master-edit-header.tsx
+++ b/frontend/src/app/admin/masters/[id]/edit/master-edit-header.tsx
@@ -6,6 +6,7 @@ import { useTranslations } from "next-intl";
 import { useCallback, useState } from "react";
 import { toast } from "sonner";
 import { AdminMasterForm, type MasterFormValues } from "@/app/admin/masters/admin-master-form";
+import { MasterStatusBadge } from "@/app/admin/masters/master-status-badge";
 import { type AuthKind, useMasterMutations } from "@/app/admin/masters/use-master-mutations";
 import { DetailPageHeader } from "@/components/nav/detail-page-header";
 import {
@@ -18,7 +19,6 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
-import { Badge } from "@/components/ui/badge";
 import { Button, buttonVariants } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -203,13 +203,7 @@ export function MasterEditHeader({ master, cardCount, onBatchImport }: Props) {
       </div>
       {/* Desktop: display badge + muted count. */}
       <div className="hidden items-center gap-2 md:flex">
-        <Badge
-          variant={published ? "default" : "secondary"}
-          role="status"
-          data-testid="master-edit-status-badge"
-        >
-          {statusLabel}
-        </Badge>
+        <MasterStatusBadge published={published} data-testid="master-edit-status-badge" />
         <span className="text-sm text-muted-foreground">
           {t("cardCount", { count: cardCount })}
         </span>

--- a/frontend/src/app/admin/masters/admin-master-row.test.tsx
+++ b/frontend/src/app/admin/masters/admin-master-row.test.tsx
@@ -30,16 +30,22 @@ function renderRow(master: AdminMasterListItem) {
 }
 
 describe("AdminMasterRow", () => {
-  it("shows the name, card count, and the Draft status badge", () => {
+  it("shows the name, card count, and the Draft status badge with a muted dot", () => {
     renderRow(BASE);
     expect(screen.getByText("Spanish A1")).toBeInTheDocument();
     expect(screen.getByText("42 cards")).toBeInTheDocument();
-    expect(screen.getByTestId("master-row-status-badge")).toHaveTextContent("Draft");
+    const badge = screen.getByTestId("master-row-status-badge");
+    expect(badge).toHaveTextContent("Draft");
+    // Draft decks carry a muted status dot, not the published green.
+    expect(badge.querySelector('[aria-hidden="true"]')?.className).toContain("bg-muted-foreground");
   });
 
-  it("shows the Published status badge for a PUBLISHED master", () => {
+  it("shows the Published status badge with the green status dot for a PUBLISHED master", () => {
     renderRow({ ...BASE, status: "PUBLISHED" });
-    expect(screen.getByTestId("master-row-status-badge")).toHaveTextContent("Published");
+    const badge = screen.getByTestId("master-row-status-badge");
+    expect(badge).toHaveTextContent("Published");
+    // Published decks carry the green (--success) status dot.
+    expect(badge.querySelector('[aria-hidden="true"]')?.className).toContain("bg-success");
   });
 
   it("renders no publish toggle — the publish action lives in the Edit panel", () => {

--- a/frontend/src/app/admin/masters/admin-master-row.tsx
+++ b/frontend/src/app/admin/masters/admin-master-row.tsx
@@ -3,7 +3,7 @@
 import { Pencil } from "lucide-react";
 import Link from "next/link";
 import { useTranslations } from "next-intl";
-import { Badge } from "@/components/ui/badge";
+import { MasterStatusBadge } from "./master-status-badge";
 
 type MasterStatus = "DRAFT" | "PUBLISHED";
 
@@ -59,14 +59,11 @@ export function AdminMasterRow({ master }: Props) {
         </p>
 
         <div className="order-2 flex min-w-0 flex-1 items-center gap-2 sm:contents">
-          <Badge
-            variant={published ? "default" : "secondary"}
-            role="status"
+          <MasterStatusBadge
+            published={published}
             data-testid="master-row-status-badge"
             className="shrink-0 sm:order-1"
-          >
-            {published ? t("statusPublished") : t("statusDraft")}
-          </Badge>
+          />
           <span aria-hidden="true" className="text-muted-foreground sm:hidden">
             ·
           </span>

--- a/frontend/src/app/admin/masters/master-status-badge.test.tsx
+++ b/frontend/src/app/admin/masters/master-status-badge.test.tsx
@@ -1,0 +1,39 @@
+// @vitest-environment jsdom
+
+import { screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { renderWithIntl } from "@/test/render-with-intl";
+import { MasterStatusBadge } from "./master-status-badge";
+
+/** The status dot is the badge's only `aria-hidden` element. */
+function statusDot(badge: HTMLElement): Element | null {
+  return badge.querySelector('[aria-hidden="true"]');
+}
+
+describe("MasterStatusBadge", () => {
+  it("published: renders the green (--success) status dot and the Published label", () => {
+    renderWithIntl(<MasterStatusBadge published data-testid="status" />);
+    const badge = screen.getByTestId("status");
+    expect(badge).toHaveTextContent("Published");
+    expect(statusDot(badge)?.className).toContain("bg-success");
+  });
+
+  it("draft: renders the muted status dot and the Draft label", () => {
+    renderWithIntl(<MasterStatusBadge published={false} data-testid="status" />);
+    const badge = screen.getByTestId("status");
+    expect(badge).toHaveTextContent("Draft");
+    expect(statusDot(badge)?.className).toContain("bg-muted-foreground");
+  });
+
+  it("forwards layout className onto the badge", () => {
+    renderWithIntl(
+      <MasterStatusBadge published data-testid="status" className="shrink-0 sm:order-1" />,
+    );
+    expect(screen.getByTestId("status").className).toContain("shrink-0");
+  });
+
+  it("carries role=status so the publish state is announced", () => {
+    renderWithIntl(<MasterStatusBadge published={false} data-testid="status" />);
+    expect(screen.getByTestId("status")).toHaveAttribute("role", "status");
+  });
+});

--- a/frontend/src/app/admin/masters/master-status-badge.tsx
+++ b/frontend/src/app/admin/masters/master-status-badge.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+
+type Props = {
+  /** Whether the master deck is published; drives the dot color and the label. */
+  published: boolean;
+  /** Extra classes merged onto the badge (layout-only, e.g. `shrink-0 sm:order-1`). */
+  className?: string;
+  "data-testid"?: string;
+};
+
+/**
+ * Read-only publish-status chip for a master deck: an outline pill with a
+ * leading status dot — green (`--success`) when published, muted when draft —
+ * followed by the localized status label. Shared by the master list row and the
+ * master-edit header so every status surface reads identically (Linear/Vercel-
+ * style: the container recedes and the dot carries the "live" signal). The label
+ * always renders, so the state is never communicated by color alone.
+ *
+ * The mobile publish-toggle in the edit header composes the same visual
+ * vocabulary with a disclosure chevron; this component is read-only and is
+ * never a button.
+ */
+export function MasterStatusBadge({ published, className, "data-testid": dataTestid }: Props) {
+  const t = useTranslations("AdminMasters");
+  return (
+    <Badge
+      variant="outline"
+      role="status"
+      data-testid={dataTestid}
+      className={cn("gap-1.5", className)}
+    >
+      <span
+        aria-hidden="true"
+        className={cn("h-2 w-2 rounded-full", published ? "bg-success" : "bg-muted-foreground")}
+      />
+      {published ? t("statusPublished") : t("statusDraft")}
+    </Badge>
+  );
+}


### PR DESCRIPTION
## Summary

The master-deck publish status (**公開中 / 下書き**) rendered inconsistently across surfaces. The **masters list row** (`/admin/masters`) and the **master-edit desktop header** (`/admin/masters/[id]/edit`) showed status as a heavy solid pill (`Badge variant="default"` → near-black `bg-primary`) with **no status dot**, while the master-edit **mobile** chip already showed a green dot for a published deck. The solid-black pill reads as a primary action and competes with the row's "編集" / the header's controls, even though publish state is passive, ambient information.

This unifies all three surfaces on one shared `MasterStatusBadge`: a subtle **outline** chip with a leading status dot — green (`--success`) when published, muted when draft — followed by the localized label. The container recedes and the dot carries the "live" signal (the modern Linear/Vercel/Stripe status idiom); the label always renders, so state is never communicated by color alone. Green stays a **dot**, via the existing `--success` token — never a fill — keeping coral `brand` the only constructive CTA color and deep-red `destructive` the only danger color.

The mobile master-edit chip already used this vocabulary (it is the interactive publish toggle, with a disclosure chevron) and is unchanged; only the two read-only badges are brought in line.

No related GitHub issue (direct UX request).

## Changes

### Shared `MasterStatusBadge`

- `frontend/src/app/admin/masters/master-status-badge.tsx` — new read-only status chip: `Badge variant="outline"` + a leading `aria-hidden` dot (`bg-success` when published / `bg-muted-foreground` when draft) + `t("statusPublished" | "statusDraft")`. Carries `role="status"`; forwards `className` (layout-only) and `data-testid`. Covered by `master-status-badge.test.tsx` (both states' dot color, `className` forwarding, `role="status"`).

### Wire the read-only surfaces through it

- `frontend/src/app/admin/masters/admin-master-row.tsx` — the list-row status `Badge` (was `variant={published ? "default" : "secondary"}`) → `MasterStatusBadge` (keeps `data-testid="master-row-status-badge"` + `shrink-0 sm:order-1`). Drops the now-unused `Badge` import.
- `frontend/src/app/admin/masters/[id]/edit/master-edit-header.tsx` — the desktop status `Badge` → `MasterStatusBadge` (keeps `data-testid="master-edit-status-badge"`). Drops the now-unused `Badge` import. The mobile status chip and the overflow menu are untouched.

### Tests

- `master-status-badge.test.tsx` (new) — narrow unit test for both publish states.
- `admin-master-row.test.tsx` / `master-edit-header.test.tsx` — the status-badge specs now also assert the **consumer** renders the dot (published → `bg-success`, draft → `bg-muted-foreground`), proving the dot is wired at the consumer, not only in isolation.

## Verification

- typecheck ✓ (`tsc --noEmit`)
- lint ✓ (`biome check --error-on-warnings`, changed files, no warnings)
- knip ✓ (no unused exports / orphan imports)
- test ✓ **1535 passing (164 files)**
- build ✓ (`next build`)
- CJK ✓ — no Japanese literals in any changed `.tsx` source (labels resolve via `t()` from the message catalogs)
- Rebased onto current `main` — the batch-import-into-overflow change is integrated; the desktop-badge swap and the mobile overflow import item coexist cleanly.

## Test plan

- [ ] **Masters list (`/admin/masters`)** — a published deck's row shows `● 公開中` with a **green** dot in an outline chip (no solid-black pill); a draft shows `● 下書き` with a muted dot.
- [ ] **Master-edit desktop (`md+`)** — the header status badge matches the list: outline chip + green/muted dot + label.
- [ ] **Master-edit mobile (`<md`)** — the interactive status chip (with the publish-toggle chevron) is unchanged and visually consistent with the read-only badges.
- [ ] **Contrast** — the green dot (`--success` `#1aa44a`) is clearly visible on the outline chip's transparent background for published decks.
