### PR TITLE
refactor(frontend): center cardgroup count and add title-row rename pencil

### DIFF
--- a/frontend/src/components/cardgroups/cardgroup-header.test.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-header.test.tsx
@@ -58,7 +58,7 @@ describe("<CardgroupHeader>", () => {
     expect(screen.getByRole("heading", { level: 1, name: /spanish vocab/i })).toBeInTheDocument();
   });
 
-  it("renders the totalCount as muted metadata text below the title", () => {
+  it("renders the totalCount as muted metadata text in the app-bar row", () => {
     renderHeader([], 42);
     expect(screen.getByText("42 cards")).toBeInTheDocument();
   });
@@ -68,27 +68,28 @@ describe("<CardgroupHeader>", () => {
     expect(screen.getByRole("button", { name: /cardgroup options/i })).toBeInTheDocument();
   });
 
-  it("kebab menu opens Rename and Delete cardgroup items", async () => {
-    const user = userEvent.setup();
+  it("renders a title-row pencil button labeled rename", () => {
     renderHeader();
-
-    await user.click(screen.getByRole("button", { name: /cardgroup options/i }));
-
-    await waitFor(() => {
-      expect(screen.getByRole("menuitem", { name: /rename/i })).toBeInTheDocument();
-      expect(screen.getByRole("menuitem", { name: /delete cardgroup/i })).toBeInTheDocument();
-    });
+    expect(screen.getByRole("button", { name: /rename/i })).toBeInTheDocument();
   });
 
-  it("clicking Rename opens the Rename cardgroup FormSheet", async () => {
+  it("kebab menu is lifecycle-only: Delete present, Rename absent", async () => {
     const user = userEvent.setup();
     renderHeader();
 
     await user.click(screen.getByRole("button", { name: /cardgroup options/i }));
+
     await waitFor(() => {
-      expect(screen.getByRole("menuitem", { name: /rename/i })).toBeInTheDocument();
+      expect(screen.getByRole("menuitem", { name: /delete cardgroup/i })).toBeInTheDocument();
     });
-    await user.click(screen.getByRole("menuitem", { name: /rename/i }));
+    expect(screen.queryByRole("menuitem", { name: /rename/i })).toBeNull();
+  });
+
+  it("clicking the title pencil opens the Rename cardgroup FormSheet", async () => {
+    const user = userEvent.setup();
+    renderHeader();
+
+    await user.click(screen.getByRole("button", { name: /rename/i }));
 
     await waitFor(() => {
       expect(screen.getByRole("heading", { name: /rename cardgroup/i })).toBeInTheDocument();
@@ -117,11 +118,7 @@ describe("<CardgroupHeader>", () => {
       ),
     ]);
 
-    await user.click(screen.getByRole("button", { name: /cardgroup options/i }));
-    await waitFor(() => {
-      expect(screen.getByRole("menuitem", { name: /rename/i })).toBeInTheDocument();
-    });
-    await user.click(screen.getByRole("menuitem", { name: /rename/i }));
+    await user.click(screen.getByRole("button", { name: /rename/i }));
     await user.click(screen.getByRole("button", { name: /^save$/i }));
 
     await waitFor(() => {
@@ -261,13 +258,13 @@ describe("<CardgroupHeader>", () => {
     expect(screen.queryByRole("status")).toBeNull();
   });
 
-  it("overflow menu holds batch import alongside rename and delete", async () => {
+  it("overflow menu holds batch import and delete, but not rename", async () => {
     const user = userEvent.setup();
     renderHeader([], 12);
     await user.click(screen.getByRole("button", { name: /cardgroup options/i }));
     expect(screen.getByRole("menuitem", { name: /batch import/i })).toBeInTheDocument();
-    expect(screen.getByRole("menuitem", { name: /rename/i })).toBeInTheDocument();
     expect(screen.getByRole("menuitem", { name: /delete cardgroup/i })).toBeInTheDocument();
+    expect(screen.queryByRole("menuitem", { name: /rename/i })).toBeNull();
   });
 
   it("overflow menu 'Batch import' item calls onBatchImport", async () => {

--- a/frontend/src/components/cardgroups/cardgroup-header.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-header.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import { Import, MoreHorizontal, Pencil, Trash2 } from "lucide-react";
+import { ChevronLeft, Import, MoreHorizontal, Pencil, Trash2 } from "lucide-react";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { useCallback, useState } from "react";
 import { CardgroupRenameForm } from "@/components/cardgroups/cardgroup-rename-form";
 import { useDeleteCardgroup } from "@/components/cardgroups/use-delete-cardgroup";
-import { DetailPageHeader } from "@/components/nav/detail-page-header";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -86,11 +86,11 @@ export function CardgroupHeader({ cardgroup, totalCount, onBatchImport }: Props)
           <Import className="h-4 w-4" />
           {t("batchImport")}
         </DropdownMenuItem>
-        <DropdownMenuItem onSelect={() => setRenameOpen(true)} className="gap-2">
-          <Pencil className="h-4 w-4" />
-          {t("rename")}
-        </DropdownMenuItem>
-        <DropdownMenuSeparator />
+        {/* Rename now lives on the title-row pencil; the overflow menu is
+            lifecycle-only. The separator divides the mobile-only import item
+            from delete, so it is also md:hidden — on desktop delete is the
+            sole item and a leading separator would be a stray rule. */}
+        <DropdownMenuSeparator className="md:hidden" />
         <DropdownMenuItem
           onSelect={() => setDeleteDialogOpen(true)}
           className="gap-2 text-destructive focus:text-destructive"
@@ -104,15 +104,42 @@ export function CardgroupHeader({ cardgroup, totalCount, onBatchImport }: Props)
 
   return (
     <>
-      <DetailPageHeader
-        backHref="/cardgroups"
-        backLabel={t("backLink")}
-        title={cardgroup.name}
-        meta={
-          <p className="text-sm text-muted-foreground">{t("cardsCount", { count: totalCount })}</p>
-        }
-        actions={actions}
-      />
+      <header className="mb-6">
+        {/* Row 1 — app-bar: inline back (left), card count centered, overflow
+            menu (right). The 1fr/auto/1fr grid keeps the count truly centered
+            regardless of the back/overflow cluster widths. */}
+        <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-2">
+          <Link
+            href="/cardgroups"
+            className="shrink-0 justify-self-start rounded-sm text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            <ChevronLeft aria-hidden="true" className="h-5 w-5" />
+            <span className="sr-only">{t("backLink")}</span>
+          </Link>
+          <p className="justify-self-center text-sm text-muted-foreground">
+            {t("cardsCount", { count: totalCount })}
+          </p>
+          <div className="justify-self-end">{actions}</div>
+        </div>
+
+        {/* Row 2 — editable title: centered name + pencil that opens the rename
+            sheet (the only editable attribute of a cardgroup). */}
+        <div className="mt-1 flex items-center justify-center gap-1.5">
+          <h1 className="min-w-0 truncate text-2xl font-semibold leading-tight">
+            {cardgroup.name}
+          </h1>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="shrink-0 text-muted-foreground hover:text-foreground"
+            aria-label={t("rename")}
+            onClick={() => setRenameOpen(true)}
+          >
+            <Pencil className="h-5 w-5" />
+          </Button>
+        </div>
+      </header>
 
       <FormSheet
         open={renameOpen}


### PR DESCRIPTION
## Summary

The cardgroup-detail header (`/cardgroups/[id]/edit`) rendered the deck name inline with the back chevron on the top row, the muted card count on a second line below it, and a `…` overflow menu — holding Rename, Delete, and (on mobile) Batch import — anchored to the right of that title row. Rename, the most common edit for a cardgroup (its name is the only editable attribute), was buried two taps deep in the overflow menu.

This restructures the header into a two-row app-bar layout: the top row carries the inline back link (left), the card count centered, and the overflow menu (right); the second row carries the centered deck name followed by a pencil button that opens the existing rename `FormSheet`. Rename moves out of the `…` menu onto that pencil, leaving the overflow menu lifecycle-only (Batch import on mobile + Delete). Scope is the cardgroup header only — the shared `DetailPageHeader` (still used by the master-edit screen) is untouched.

No related GitHub issue (direct UX request).

## Changes

### Cardgroup-detail header layout (`/cardgroups/[id]/edit`)

- `frontend/src/components/cardgroups/cardgroup-header.tsx`:
  - Stop rendering through `DetailPageHeader`; compose a bespoke `<header>` with two rows.
  - **Row 1 (app-bar):** `grid grid-cols-[1fr_auto_1fr]` keeps the card count truly centered regardless of the back / overflow cluster widths — inline back `<Link>` (`sr-only` label + focus ring) on the left, `{count} cards` centered, the `…` dropdown on the right.
  - **Row 2:** centered `h1` deck name + a ghost-icon `Pencil` button (`aria-label` reuses `Cardgroups.rename`) that opens the rename `FormSheet`.
  - Remove the **Rename** item from the `…` menu; it now holds the mobile-only **Batch import** item + **Delete**. The separator is `md:hidden` so desktop (Delete-only) shows no leading rule.

### Tests

- `frontend/src/components/cardgroups/cardgroup-header.test.tsx`:
  - Add a spec that the title row renders a Rename-labeled pencil button.
  - The "open Rename FormSheet" specs now click the pencil instead of the overflow Rename item.
  - The kebab specs assert the menu is lifecycle-only — **Delete** present, **Rename** absent (overflow holds Batch import + Delete).
  - Rename the count-position spec ("…below the title" → "…in the app-bar row").

The sibling `cardgroup-management-client.test.tsx` mocks `CardgroupHeader`, so it is unaffected.

## Verification

- typecheck ✓ (`tsc --noEmit`)
- lint ✓ (`biome check --error-on-warnings`, 428 files, no warnings)
- knip ✓ (no unused exports / orphan imports)
- test ✓ **1532 passing (163 files)** — `cardgroup-header` 18/18
- build ✓ (`next build`)
- CJK ✓ — no Japanese literals in the changed `.tsx` (copy lives only in the message catalogs); the pencil reuses `Cardgroups.rename`, no new keys

## Test plan

- [ ] `/cardgroups/[id]/edit` (mobile, `<md`) — top row shows the back chevron (left), `{count} cards` centered, the `…` menu (right); the deck name is centered on the second row with a pencil beside it.
- [ ] Tapping the pencil opens the **Rename cardgroup** sheet; saving renames the deck.
- [ ] The `…` menu holds **Batch import** + **Delete** only — no **Rename** item.
- [ ] Desktop (`md+`) — same two-row layout; the `…` menu shows **Delete** only (Batch import is mobile-only) with no leading separator rule.
- [ ] **Delete** still opens the destructive confirm dialog and navigates to `/cardgroups` on confirm.
