### PR TITLE
refactor(frontend): move cardgroup rename into overflow menu

### DIFF
--- a/frontend/src/components/cardgroups/cardgroup-header.test.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-header.test.tsx
@@ -68,28 +68,30 @@ describe("<CardgroupHeader>", () => {
     expect(screen.getByRole("button", { name: /cardgroup options/i })).toBeInTheDocument();
   });
 
-  it("renders a title-row pencil button labeled rename", () => {
+  it("does not render an inline title-row rename button (rename moved into the overflow menu)", () => {
     renderHeader();
-    expect(screen.getByRole("button", { name: /rename/i })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /^rename$/i })).toBeNull();
   });
 
-  it("kebab menu is lifecycle-only: Delete present, Rename absent", async () => {
+  it("kebab menu hosts Rename as the first item, plus Delete", async () => {
     const user = userEvent.setup();
     renderHeader();
 
     await user.click(screen.getByRole("button", { name: /cardgroup options/i }));
 
     await waitFor(() => {
-      expect(screen.getByRole("menuitem", { name: /delete cardgroup/i })).toBeInTheDocument();
+      expect(screen.getByRole("menuitem", { name: /^rename$/i })).toBeInTheDocument();
     });
-    expect(screen.queryByRole("menuitem", { name: /rename/i })).toBeNull();
+    expect(screen.getAllByRole("menuitem")[0]).toHaveTextContent(/rename/i);
+    expect(screen.getByRole("menuitem", { name: /delete cardgroup/i })).toBeInTheDocument();
   });
 
-  it("clicking the title pencil opens the Rename cardgroup FormSheet", async () => {
+  it("selecting Rename from the overflow menu opens the Rename cardgroup FormSheet", async () => {
     const user = userEvent.setup();
     renderHeader();
 
-    await user.click(screen.getByRole("button", { name: /rename/i }));
+    await user.click(screen.getByRole("button", { name: /cardgroup options/i }));
+    await user.click(await screen.findByRole("menuitem", { name: /^rename$/i }));
 
     await waitFor(() => {
       expect(screen.getByRole("heading", { name: /rename cardgroup/i })).toBeInTheDocument();
@@ -118,8 +120,9 @@ describe("<CardgroupHeader>", () => {
       ),
     ]);
 
-    await user.click(screen.getByRole("button", { name: /rename/i }));
-    await user.click(screen.getByRole("button", { name: /^save$/i }));
+    await user.click(screen.getByRole("button", { name: /cardgroup options/i }));
+    await user.click(await screen.findByRole("menuitem", { name: /^rename$/i }));
+    await user.click(await screen.findByRole("button", { name: /^save$/i }));
 
     await waitFor(() => {
       expect(screen.getByRole("button", { name: /saving/i })).toBeInTheDocument();
@@ -258,13 +261,13 @@ describe("<CardgroupHeader>", () => {
     expect(screen.queryByRole("status")).toBeNull();
   });
 
-  it("overflow menu holds batch import and delete, but not rename", async () => {
+  it("overflow menu holds rename, batch import, and delete", async () => {
     const user = userEvent.setup();
     renderHeader([], 12);
     await user.click(screen.getByRole("button", { name: /cardgroup options/i }));
+    expect(screen.getByRole("menuitem", { name: /^rename$/i })).toBeInTheDocument();
     expect(screen.getByRole("menuitem", { name: /batch import/i })).toBeInTheDocument();
     expect(screen.getByRole("menuitem", { name: /delete cardgroup/i })).toBeInTheDocument();
-    expect(screen.queryByRole("menuitem", { name: /rename/i })).toBeNull();
   });
 
   it("overflow menu 'Batch import' item calls onBatchImport", async () => {

--- a/frontend/src/components/cardgroups/cardgroup-header.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-header.tsx
@@ -75,6 +75,16 @@ export function CardgroupHeader({ cardgroup, totalCount, onBatchImport }: Props)
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
+        {/* Rename — the only editable attribute of a cardgroup, hosted as the
+            top menu item. */}
+        <DropdownMenuItem
+          onSelect={() => setRenameOpen(true)}
+          className="gap-2"
+          data-testid="cardgroup-rename-menuitem"
+        >
+          <Pencil className="h-4 w-4" />
+          {t("rename")}
+        </DropdownMenuItem>
         {/* Mobile-only: batch import lives here after the standalone toolbar
             button was removed. Hidden on desktop, where the cards toolbar's
             split-button menu still hosts batch import. */}
@@ -86,11 +96,9 @@ export function CardgroupHeader({ cardgroup, totalCount, onBatchImport }: Props)
           <Import className="h-4 w-4" />
           {t("batchImport")}
         </DropdownMenuItem>
-        {/* Rename now lives on the title-row pencil; the overflow menu is
-            lifecycle-only. The separator divides the mobile-only import item
-            from delete, so it is also md:hidden — on desktop delete is the
-            sole item and a leading separator would be a stray rule. */}
-        <DropdownMenuSeparator className="md:hidden" />
+        {/* Separator divides the constructive actions (rename, import) from the
+            destructive delete. Always shown now that rename leads the menu. */}
+        <DropdownMenuSeparator />
         <DropdownMenuItem
           onSelect={() => setDeleteDialogOpen(true)}
           className="gap-2 text-destructive focus:text-destructive"
@@ -122,22 +130,11 @@ export function CardgroupHeader({ cardgroup, totalCount, onBatchImport }: Props)
           <div className="justify-self-end">{actions}</div>
         </div>
 
-        {/* Row 2 — editable title: centered name + pencil that opens the rename
-            sheet (the only editable attribute of a cardgroup). */}
-        <div className="mt-1 flex items-center justify-center gap-1.5">
-          <h1 className="min-w-0 truncate text-2xl font-semibold leading-tight">
+        {/* Row 2 — title: centered name. Rename moved into the overflow menu. */}
+        <div className="mt-1 flex items-center justify-center">
+          <h1 className="min-w-0 truncate text-center text-2xl font-semibold leading-tight">
             {cardgroup.name}
           </h1>
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon"
-            className="shrink-0 text-muted-foreground hover:text-foreground"
-            aria-label={t("rename")}
-            onClick={() => setRenameOpen(true)}
-          >
-            <Pencil className="h-5 w-5" />
-          </Button>
         </div>
       </header>
 


### PR DESCRIPTION
## Summary

The cardgroup-detail header (`/cardgroups/[id]/edit`) carried the rename control on a title-row pencil button beside the centered deck name, leaving the `…` overflow menu lifecycle-only (Batch import on mobile + Delete). This moves rename off that pencil and back into the `…` menu, where it now **leads the menu as the top item** (Pencil icon + the existing `Cardgroups.rename` label). The title row drops the pencil and renders the centered deck name alone. Scope is the cardgroup header only — the shared `DetailPageHeader` (master-edit screen) is untouched.

No related GitHub issue (direct UX request).

## Background / Motivation

- The title-row pencil added a second interactive control to the deck-name row, competing with the name for the eye and widening the centered cluster.
- Every other secondary action already lives in the `…` menu; rename being the lone exception split "things you can do to this deck" across two surfaces.
- Consolidating rename into the overflow menu as the first item keeps all secondary actions in one predictable place and restores a clean, single-element title row.

## Changes

### Cardgroup-detail header (`/cardgroups/[id]/edit`)

- `frontend/src/components/cardgroups/cardgroup-header.tsx`:
  - Add a **Rename** item (`cardgroup-rename-menuitem`, Pencil icon + `Cardgroups.rename`) as the **top** item of the `…` dropdown; `onSelect` opens the existing rename `FormSheet`.
  - Remove the title-row `Pencil` ghost button from Row 2; the `h1` deck name now renders centered and alone.
  - Drop `md:hidden` from the `DropdownMenuSeparator` — with rename always leading the menu, the rule now meaningfully divides the constructive actions (rename, mobile-only import) from the destructive **Delete** on every breakpoint.
  - The mobile-only **Batch import** item and **Delete** item are unchanged (same test IDs, same handlers).

### Tests

- `frontend/src/components/cardgroups/cardgroup-header.test.tsx`:
  - Replace the title-row-pencil spec with one asserting no inline rename button is rendered on the header.
  - The "open Rename FormSheet" spec (and the submit-in-flight spec) now open the `…` menu and select the **Rename** menu item instead of clicking a pencil button.
  - The kebab specs assert the menu now hosts **Rename** as the first item alongside **Batch import** + **Delete** (no longer "Rename absent").

The sibling `cardgroup-management-client.test.tsx` renders `CardgroupHeader` but does not exercise rename, so it is unaffected.

## Verification

Checks run in this pass (scoped to the change):

- typecheck ✓ (`tsc --noEmit`)
- lint ✓ (`biome check --error-on-warnings` on the two changed files, no warnings)
- test ✓ — `cardgroup-header` **15/15**; related `cardgroup-management-client` + edit `page` **7/7**
- CJK ✓ — no Japanese literals in the changed `.tsx` (rename reuses `Cardgroups.rename`; no new keys)

Not run in this pass: full frontend suite, `knip`, `next build`. To confirm the menu item at runtime, open the `…` menu on `/cardgroups/[id]/edit` and look for `data-testid="cardgroup-rename-menuitem"` as the first menu item.

## Test plan

- [ ] `/cardgroups/[id]/edit` — the deck-name row shows only the centered name (no pencil button beside it).
- [ ] The `…` menu lists **Rename** first, then **Batch import** (mobile only), a separator, then **Delete cardgroup**.
- [ ] Selecting **Rename** opens the **Rename cardgroup** sheet; saving renames the deck.
- [ ] **Delete cardgroup** still opens the destructive confirm dialog and navigates to `/cardgroups` on confirm.
- [ ] Desktop (`md+`) — **Batch import** stays hidden in the `…` menu; the menu shows **Rename** + separator + **Delete**.
