### PR TITLE
refactor(frontend): center master-edit count and status in the app-bar

### DIFF
--- a/frontend/src/app/admin/masters/[id]/edit/master-edit-header.tsx
+++ b/frontend/src/app/admin/masters/[id]/edit/master-edit-header.tsx
@@ -164,8 +164,12 @@ export function MasterEditHeader({ master, cardCount, onBatchImport }: Props) {
 
   const meta = (
     <>
-      {/* Mobile: interactive status chip (publish trigger) + muted count. */}
-      <div className="flex items-center justify-between gap-2 md:hidden">
+      {/* Mobile: muted count + interactive status chip (publish trigger),
+          centered in the app-bar row beside the count. */}
+      <div className="flex items-center justify-center gap-2 md:hidden">
+        <span className="text-sm text-muted-foreground">
+          {t("cardCount", { count: cardCount })}
+        </span>
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <button
@@ -185,7 +189,7 @@ export function MasterEditHeader({ master, cardCount, onBatchImport }: Props) {
               <ChevronDown aria-hidden="true" className="h-3.5 w-3.5 text-muted-foreground" />
             </button>
           </DropdownMenuTrigger>
-          <DropdownMenuContent align="start">
+          <DropdownMenuContent align="center">
             <DropdownMenuItem
               onSelect={handlePublishToggle}
               disabled={publishing || emptyDraft}
@@ -197,16 +201,13 @@ export function MasterEditHeader({ master, cardCount, onBatchImport }: Props) {
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>
-        <span className="text-sm text-muted-foreground">
-          {t("cardCount", { count: cardCount })}
-        </span>
       </div>
-      {/* Desktop: display badge + muted count. */}
-      <div className="hidden items-center gap-2 md:flex">
-        <MasterStatusBadge published={published} data-testid="master-edit-status-badge" />
+      {/* Desktop: muted count + display badge, centered in the app-bar row. */}
+      <div className="hidden items-center justify-center gap-2 md:flex">
         <span className="text-sm text-muted-foreground">
           {t("cardCount", { count: cardCount })}
         </span>
+        <MasterStatusBadge published={published} data-testid="master-edit-status-badge" />
       </div>
     </>
   );
@@ -310,7 +311,10 @@ export function MasterEditHeader({ master, cardCount, onBatchImport }: Props) {
         actions={actions}
       >
         {emptyDraft ? (
-          <p className="mt-1 text-xs text-muted-foreground" data-testid="master-edit-empty-hint">
+          <p
+            className="mt-1 text-center text-xs text-muted-foreground"
+            data-testid="master-edit-empty-hint"
+          >
             {t("publishEmptyHint")}
           </p>
         ) : null}

--- a/frontend/src/components/nav/detail-page-header.tsx
+++ b/frontend/src/components/nav/detail-page-header.tsx
@@ -10,19 +10,23 @@ type DetailPageHeaderProps = {
   /** Accessible (sr-only) label for the back link, e.g. t("backToList"). */
   backLabel: string;
   title: string;
-  /** Status + count cluster rendered under the title. The page owns its md: reflow. */
+  /** Status + count cluster centered in the app-bar row, between the back
+   *  affordance and the trailing actions. The page owns its md: reflow. */
   meta?: ReactNode;
-  /** Trailing action cluster on the title row. The page owns its md: reflow. */
+  /** Trailing action cluster on the app-bar row (right). The page owns its md: reflow. */
   actions?: ReactNode;
-  /** Optional note rendered below meta, e.g. an empty-draft publish hint. */
+  /** Optional note rendered below the title, e.g. an empty-draft publish hint. */
   children?: ReactNode;
 };
 
 /**
- * The shared detail-page header layout: an inline back affordance flush to the
- * title (no standalone back row), with optional meta and trailing-action slots.
- * Used by the master-edit and cardgroup-detail headers. It owns layout only —
- * each consumer composes its own meta/actions, including responsive variants.
+ * The shared detail-page header layout: an app-bar row carrying an inline back
+ * affordance (left), a centered status/count meta cluster (center), and a
+ * trailing action cluster (right); the page title sits centered on its own row
+ * one tier below. The 1fr/auto/1fr app-bar grid keeps the meta cluster centered
+ * regardless of the back/action cluster widths. Used by the master-edit header.
+ * It owns layout only — the consumer composes its own meta/actions, including
+ * responsive variants.
  */
 export function DetailPageHeader({
   backHref,
@@ -34,23 +38,25 @@ export function DetailPageHeader({
 }: DetailPageHeaderProps) {
   return (
     <header className="mb-6">
-      <div className="flex items-start justify-between gap-3">
-        <div className="min-w-0 flex-1">
-          <div className="flex items-center gap-1.5">
-            <Link
-              href={backHref}
-              className="shrink-0 rounded-sm text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-            >
-              <ChevronLeft aria-hidden="true" className="h-5 w-5" />
-              <span className="sr-only">{backLabel}</span>
-            </Link>
-            <h1 className="min-w-0 truncate text-2xl font-semibold leading-tight">{title}</h1>
-          </div>
-          {meta ? <div className="mt-1">{meta}</div> : null}
-          {children}
-        </div>
-        {actions ? <div className="flex shrink-0 items-center">{actions}</div> : null}
+      {/* App-bar row — inline back (left), centered meta (center), actions
+          (right). The 1fr/auto/1fr grid keeps the meta cluster truly centered
+          regardless of the back/action cluster widths. */}
+      <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-2">
+        <Link
+          href={backHref}
+          className="shrink-0 justify-self-start rounded-sm text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          <ChevronLeft aria-hidden="true" className="h-5 w-5" />
+          <span className="sr-only">{backLabel}</span>
+        </Link>
+        <div className="justify-self-center">{meta}</div>
+        <div className="flex items-center justify-self-end">{actions}</div>
       </div>
+      {/* Title row — centered, one tier below the app-bar. */}
+      <div className="mt-1 flex items-center justify-center">
+        <h1 className="min-w-0 truncate text-2xl font-semibold leading-tight">{title}</h1>
+      </div>
+      {children}
     </header>
   );
 }


### PR DESCRIPTION
## Summary

The master-edit screen (`/admin/masters/[id]/edit`) rendered the deck name inline with the back chevron on the top row, with the publish-status chip and the muted card count pushed to the opposite ends of a second row below the title. The count and the `公開中` status read as a detached band rather than as part of the deck's identity.

This restructures the header onto the same two-row app-bar layout the cardgroup-detail header already uses: the top row carries the inline back link (left), the card count + publish status centered, and the trailing actions (right); the deck title moves to its own centered row below. Scope is the master-edit header and its shared `DetailPageHeader` shell (used only by this screen) — every publish / settings / delete interaction and its `data-testid` is untouched.

No related GitHub issue (direct UX request).

## Background / Motivation

- The deck title sat inline with the back chevron, competing with it for the eye instead of being the focal point of the screen.
- The card count and `公開中` status were split to the left/right extremes of a separate row (`justify-between`), so they read as an unrelated meta band below the title rather than a single "1246 枚 · 公開中" cluster.
- The sibling cardgroup-detail header had just adopted a centered two-row app-bar (`1fr/auto/1fr` grid + centered title); the master header was the lone holdout still using the old inline-title layout.

## Changes

### Shared `DetailPageHeader` layout shell

- `frontend/src/components/nav/detail-page-header.tsx` — replace the "inline back + title, meta below" body with a two-row app-bar: **row 1** is a `grid grid-cols-[1fr_auto_1fr]` (inline back `<Link>` left via `justify-self-start`, centered `meta` slot, trailing `actions` slot right via `justify-self-end`) so the meta cluster stays centered between the back/action clusters; **row 2** is the centered `<h1>`. `children` (the empty-draft hint) render below. Docstring updated to describe the new layout and note the component is now master-edit-only (the cardgroup header hand-rolls its own).

### Master-edit header

- `frontend/src/app/admin/masters/[id]/edit/master-edit-header.tsx` — reorder the meta cluster to **count first, then status** and center it (`justify-center`) in both variants: mobile = muted count + the interactive `公開中` chip (the publish toggle), desktop = muted count + `MasterStatusBadge`. The mobile chip's publish dropdown now opens `align="center"` to sit under the centered chip. The empty-draft hint is centered (`text-center`). Publish/unpublish, deck settings, delete, and the batch-import wiring — and every `data-testid` — are unchanged.

### Tests

- No test changes were required. The existing `detail-page-header.test.tsx`, `master-edit-header.test.tsx`, and broad `__tests__/admin-masters-edit.test.tsx` assert element presence and interactions (back link, heading, status chip → publish, overflow → settings/delete, card count in both meta rows), not layout classes, so they stay green against the reflow.

## Verification

- typecheck ✓ (`tsc --noEmit`)
- lint ✓ (`biome check --error-on-warnings`, 430 files, no warnings)
- knip ✓ (no unused exports / orphan imports)
- test ✓ **1536 passing (164 files)** — `detail-page-header` + `master-edit-header` + broad `admin-masters-edit` all green with no edits
- build ✓ (`next build`)
- CJK ✓ — no Japanese literals in the changed `.tsx` (copy lives only in the message catalogs; the meta reuses existing `AdminMasters` keys, no new keys)

## Test plan

- [ ] **Master mobile (`<md`)** — top row shows the back chevron (left), then `1246 枚` followed by the `● 公開中` chip centered, then the `…` overflow (right); the deck name is centered on the second row below.
- [ ] Tapping the `● 公開中` chip opens 公開/非公開; toggling publishes/unpublishes and refreshes the route.
- [ ] **Master desktop (`md+`)** — same two-row layout: count + status badge in the app-bar center, publish split-button (publish + 設定/削除) on the right.
- [ ] **Master empty draft** — the chip shows 下書き, its publish item is disabled, and the centered empty-draft hint renders below the title.
- [ ] The `…` overflow still holds 一括インポート (mobile) + 設定 + マスターを削除; **Delete** opens the red destructive confirm and navigates to `/admin/masters` on confirm.
