### PR TITLE
feat(frontend): center listing-page headers via shared ListingPageShell

### DIFF
--- a/frontend/src/app/admin/masters/admin-masters-client.tsx
+++ b/frontend/src/app/admin/masters/admin-masters-client.tsx
@@ -142,12 +142,8 @@ export function AdminMastersClient() {
         ariaLabel={t("searchLabel")}
       />
       <ListingPageShell
-        title={
-          <span className="flex items-center gap-3">
-            {t("title")}
-            <span className="text-sm font-normal text-muted-foreground">({totalCount})</span>
-          </span>
-        }
+        title={t("title")}
+        count={totalCount}
         primaryActions={
           <Button
             type="button"

--- a/frontend/src/app/admin/users/admin-users-client.tsx
+++ b/frontend/src/app/admin/users/admin-users-client.tsx
@@ -6,6 +6,7 @@ import { useTranslations } from "next-intl";
 import { useCallback, useEffect, useMemo } from "react";
 import { toast } from "sonner";
 import { AdminQueryErrorBanner } from "@/components/admin/admin-query-error-banner";
+import { ListingPageShell } from "@/components/layout/listing-page-shell";
 import { SearchTakeoverBar } from "@/components/search/search-takeover-bar";
 import { ErrorBanner } from "@/components/ui/error-banner";
 import { useFragment } from "@/generated/fragment-masking";
@@ -240,24 +241,23 @@ export function AdminUsersClient() {
         placeholder={t("searchPlaceholder")}
         ariaLabel={t("searchLabel")}
       />
-      <main className="p-8">
-        <div className="mb-6 flex items-center gap-4">
-          <h1 className="text-2xl font-semibold">{tNav("users")}</h1>
-          <span className="text-sm text-muted-foreground">({totalCount})</span>
-        </div>
-
-        {/* Search input — desktop only; mobile uses the header takeover above. */}
-        <div className="mb-6 hidden md:block">
-          <input
-            type="search"
-            placeholder={t("searchPlaceholder")}
-            value={search.input}
-            onChange={(e) => search.setInput(e.target.value)}
-            className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-            aria-label={t("searchLabel")}
-          />
-        </div>
-
+      <ListingPageShell
+        title={tNav("users")}
+        count={totalCount}
+        toolbar={
+          // Desktop-only search input; mobile uses the header takeover above.
+          <div className="hidden md:block">
+            <input
+              type="search"
+              placeholder={t("searchPlaceholder")}
+              value={search.input}
+              onChange={(e) => search.setInput(e.target.value)}
+              className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              aria-label={t("searchLabel")}
+            />
+          </div>
+        }
+      >
         {/*
         Admin users query-error banner. UNAUTHENTICATED here means the session
         expired mid-page: the server-side gate in page.tsx + the admin layout
@@ -349,7 +349,7 @@ export function AdminUsersClient() {
           onReloadRequested={reloadEditedUser}
           onDelete={handleDeleteUser}
         />
-      </main>
+      </ListingPageShell>
     </>
   );
 }

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -136,6 +136,10 @@
   --font-sans:
     var(--font-inter), system-ui, -apple-system, "Hiragino Kaku Gothic ProN", "Hiragino Sans",
     "Noto Sans JP", "Yu Gothic", Meiryo, sans-serif;
+  /* Listing-page heading scale. One token tunes the centered page title across
+     every listing page (catalog, cardgroups, roles, masters, users) at once —
+     see ListingPageShell. */
+  --text-page-title: 1.75rem;
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);

--- a/frontend/src/components/layout/listing-page-shell.test.tsx
+++ b/frontend/src/components/layout/listing-page-shell.test.tsx
@@ -79,4 +79,35 @@ describe("<ListingPageShell>", () => {
     // The base liquid-layout classes are preserved.
     expect(main?.className).toContain("p-8");
   });
+
+  it("renders the count as a parenthesized muted subtitle when count is provided", () => {
+    render(
+      <ListingPageShell title="Users" count={42}>
+        <div />
+      </ListingPageShell>,
+    );
+
+    expect(screen.getByText("(42)")).toBeInTheDocument();
+  });
+
+  it("renders the title with the shared page-title type token", () => {
+    render(
+      <ListingPageShell title="Users">
+        <div />
+      </ListingPageShell>,
+    );
+
+    expect(screen.getByRole("heading", { level: 1, name: "Users" })).toHaveClass("text-page-title");
+  });
+
+  it("centers the header block so the title, count, and actions stack centered", () => {
+    render(
+      <ListingPageShell title="Users">
+        <div />
+      </ListingPageShell>,
+    );
+
+    const heading = screen.getByRole("heading", { level: 1, name: "Users" });
+    expect(heading.parentElement).toHaveClass("items-center", "text-center");
+  });
 });

--- a/frontend/src/components/layout/listing-page-shell.tsx
+++ b/frontend/src/components/layout/listing-page-shell.tsx
@@ -2,11 +2,13 @@ import type { ReactNode } from "react";
 import { cn } from "@/lib/utils";
 
 interface ListingPageShellProps {
-  /** Page title shown as the leading heading. */
+  /** Page title shown as the centered heading. */
   title: ReactNode;
+  /** Optional total-count badge rendered as a muted `(N)` subtitle under the title. */
+  count?: number;
   /** Optional supporting copy under the title. */
   description?: ReactNode;
-  /** Optional CTA cluster aligned to the trailing edge of the header row. */
+  /** Optional CTA cluster centered below the title (desktop create button etc.). */
   primaryActions?: ReactNode;
   /** Optional toolbar slot rendered between the header row and the content. */
   toolbar?: ReactNode;
@@ -30,6 +32,7 @@ interface ListingPageShellProps {
  */
 export function ListingPageShell({
   title,
+  count,
   description,
   primaryActions,
   toolbar,
@@ -38,12 +41,13 @@ export function ListingPageShell({
 }: ListingPageShellProps) {
   return (
     <main className={cn("flex flex-1 flex-col gap-4 p-8 sm:gap-6", className)}>
-      <div className="flex flex-wrap items-end justify-between gap-2">
-        <div>
-          <h1 className="text-2xl font-bold tracking-tight">{title}</h1>
-          {description != null && <div className="text-muted-foreground">{description}</div>}
-        </div>
-        {primaryActions != null && <div className="flex items-center gap-2">{primaryActions}</div>}
+      <div className="flex flex-col items-center gap-2 text-center">
+        <h1 className="text-page-title font-bold leading-tight tracking-normal">{title}</h1>
+        {count != null && <p className="text-sm text-muted-foreground">({count})</p>}
+        {description != null && <div className="text-muted-foreground">{description}</div>}
+        {primaryActions != null && (
+          <div className="flex items-center justify-center gap-2">{primaryActions}</div>
+        )}
       </div>
       {toolbar != null && <div data-slot="toolbar">{toolbar}</div>}
       {children}


### PR DESCRIPTION
## Summary

The five listing pages — **Catalog**, **Cardgroups**, **Roles**, **Masters**, **Users** — rendered their page title as a large left-aligned `text-2xl font-bold tracking-tight` heading sharing a `justify-between` row with an inline create button. The title sat top-left (see the original `/catalog` screenshot), and **Users** was a one-off: it bypassed the shared `ListingPageShell` and used `text-2xl font-semibold` inside its own `<main>`, so its heading weight had drifted from the other four.

Create now lives in the top-bar **"+"** on mobile, so the header carries no inline action and the title can simply center. This centers every listing-page header on a single shared shell (the "tokenized system" direction): the title is centered with a new `--text-page-title` type token, the total count moves to a muted `(N)` subtitle directly under it, and **Users** is folded into `ListingPageShell` so all five pages share one header geometry. CJK headings switch from `tracking-tight` to `tracking-normal` (negative tracking reads cramped on kana). The desktop-only inline create button (`hidden md:inline-flex`) stays, now centered below the title; mobile keeps the top-bar "+".

No related GitHub issue (direct UX request).

## Changes

### Shared listing header (`ListingPageShell`)

- `frontend/src/components/layout/listing-page-shell.tsx`:
  - Restructure the header from a `flex … justify-between` row into a centered column (`flex flex-col items-center text-center`): centered `h1`, optional count subtitle, optional description, and `primaryActions` centered below.
  - Title styling becomes `text-page-title font-bold leading-tight tracking-normal` (was `text-2xl font-bold tracking-tight`).
  - Add a `count?: number` prop rendered as a muted `(N)` subtitle under the title.
- `frontend/src/app/globals.css`:
  - Add the `--text-page-title: 1.75rem` theme token (generates the `text-page-title` utility) so one knob tunes the heading scale across all five listing pages.

### Adopt the shared header

- `frontend/src/app/admin/masters/admin-masters-client.tsx`: move the inline `({totalCount})` span out of the `title` JSX into the new `count` prop; the title is now a plain string.
- `frontend/src/app/admin/users/admin-users-client.tsx`: replace the bespoke `<main className="p-8">` + `text-2xl font-semibold` heading with `ListingPageShell` (`title` + `count`), moving the desktop search `<input>` into the `toolbar` slot. Resolves the font-weight inconsistency.

Catalog, Cardgroups, and Roles inherit the centered header through the shared shell with no client-side change.

### Tests

- `frontend/src/components/layout/listing-page-shell.test.tsx`: add specs for the `count` subtitle, the `text-page-title` token on the heading, and the centered header block (`items-center text-center`).

## Verification

- typecheck ✓ (`tsc --noEmit`)
- lint ✓ (`biome check --error-on-warnings`, 430 files, no warnings)
- knip ✓ (no unused exports)
- test ✓ **1539 passing (164 files)** — `listing-page-shell` 10/10
- build ✓ (`next build`)
- CJK ✓ — no Japanese literals in the changed `.tsx` / `.css` (all copy flows through next-intl `t()`); no new message keys

## Test plan

- [ ] `/catalog` (mobile) — the title is centered; the deck card + Import button render unchanged below.
- [ ] `/cardgroups` (mobile) — title centered; create is the top-bar "+"; no inline button on mobile.
- [ ] `/cardgroups` (desktop `md+`) — title centered; the "New cardgroup" button renders centered below the title.
- [ ] `/admin/masters` — title centered with the `(N)` count as a muted subtitle (no longer inline in the heading).
- [ ] `/admin/users` — title centered, `(N)` count subtitle, desktop search input still gated `hidden md:block`; heading weight now matches the other pages.
- [ ] `/admin/roles` — title centered, create via the top-bar "+".
