### PR TITLE
feat(frontend): left-align listing-page headers on desktop

### DIFF
--- a/frontend/src/components/layout/listing-page-shell.test.tsx
+++ b/frontend/src/components/layout/listing-page-shell.test.tsx
@@ -36,14 +36,16 @@ describe("<ListingPageShell>", () => {
     expect(descriptions.length).toBe(0);
   });
 
-  it("renders primaryActions in the trailing edge of the header row", () => {
+  it("renders primaryActions on the trailing edge of the header row on desktop", () => {
     render(
       <ListingPageShell title="Users" primaryActions={<button type="button">Invite User</button>}>
         <div />
       </ListingPageShell>,
     );
 
-    expect(screen.getByRole("button", { name: "Invite User" })).toBeInTheDocument();
+    const button = screen.getByRole("button", { name: "Invite User" });
+    // The actions cluster is pushed to the trailing edge of the row on desktop.
+    expect(button.parentElement).toHaveClass("md:justify-end");
   });
 
   it("renders the toolbar slot between the header row and the body", () => {
@@ -80,14 +82,20 @@ describe("<ListingPageShell>", () => {
     expect(main?.className).toContain("p-8");
   });
 
-  it("renders the count as a parenthesized muted subtitle when count is provided", () => {
+  it("renders the count as a muted (N) sharing the title cluster, inline beside the title on desktop", () => {
     render(
       <ListingPageShell title="Users" count={42}>
         <div />
       </ListingPageShell>,
     );
 
-    expect(screen.getByText("(42)")).toBeInTheDocument();
+    const heading = screen.getByRole("heading", { level: 1, name: "Users" });
+    const count = screen.getByText("(42)");
+    expect(count).toHaveClass("text-muted-foreground");
+    // Count and title share one cluster so the count sits next to the heading.
+    expect(count.parentElement).toBe(heading.parentElement);
+    // Desktop lays them out on one baseline-aligned row (mobile stacks them).
+    expect(heading.parentElement).toHaveClass("md:flex-row", "md:items-baseline");
   });
 
   it("renders the title with the shared page-title type token", () => {
@@ -100,7 +108,7 @@ describe("<ListingPageShell>", () => {
     expect(screen.getByRole("heading", { level: 1, name: "Users" })).toHaveClass("text-page-title");
   });
 
-  it("centers the header block so the title, count, and actions stack centered", () => {
+  it("centers the header on mobile and left-aligns it with a justify-between row on desktop", () => {
     render(
       <ListingPageShell title="Users">
         <div />
@@ -108,6 +116,11 @@ describe("<ListingPageShell>", () => {
     );
 
     const heading = screen.getByRole("heading", { level: 1, name: "Users" });
-    expect(heading.parentElement).toHaveClass("items-center", "text-center");
+    const header = heading.closest('[data-slot="page-header"]');
+    expect(header).not.toBeNull();
+    // Mobile: centered column.
+    expect(header).toHaveClass("flex-col", "items-center", "text-center");
+    // Desktop: left-aligned row with the trailing edge reserved for actions.
+    expect(header).toHaveClass("md:flex-row", "md:justify-between", "md:text-left");
   });
 });

--- a/frontend/src/components/layout/listing-page-shell.tsx
+++ b/frontend/src/components/layout/listing-page-shell.tsx
@@ -2,13 +2,13 @@ import type { ReactNode } from "react";
 import { cn } from "@/lib/utils";
 
 interface ListingPageShellProps {
-  /** Page title shown as the centered heading. */
+  /** Page title. Centered on mobile, left-aligned on desktop. */
   title: ReactNode;
-  /** Optional total-count badge rendered as a muted `(N)` subtitle under the title. */
+  /** Optional total-count badge rendered as a muted `(N)`: below the title on mobile, inline to its right on desktop. */
   count?: number;
   /** Optional supporting copy under the title. */
   description?: ReactNode;
-  /** Optional CTA cluster centered below the title (desktop create button etc.). */
+  /** Optional CTA cluster (desktop create button etc.): below the title on mobile, on the trailing edge of the header row on desktop. */
   primaryActions?: ReactNode;
   /** Optional toolbar slot rendered between the header row and the content. */
   toolbar?: ReactNode;
@@ -21,10 +21,16 @@ interface ListingPageShellProps {
 /**
  * Shared shell for listing pages (admin, cardgroups, or any similar page).
  *
- * Mirrors the shadcn-admin Tasks/Users `<Main>` shape: a flex column with
- * a wrap-friendly title row, an optional toolbar slot, and the page body.
- * Padding matches the existing `p-8` adopted across listing pages
- * after the recent max-width removal, so this shell stays liquid.
+ * The header is responsive:
+ *  - Mobile (`< md`): a centered column — title, then the `(N)` count under it.
+ *    The create button is hidden here (mobile creates via the top-bar `+`).
+ *  - Desktop (`>= md`): a `justify-between` row — title with the `(N)` count
+ *    inline to its right on the leading edge, `primaryActions` on the trailing
+ *    edge. Mirrors the shadcn-admin Tasks/Users `<Main>` header shape.
+ *
+ * The optional toolbar slot (search/filter input) and the page body sit below
+ * the header in both layouts. Padding matches the existing `p-8` adopted across
+ * listing pages after the max-width removal, so this shell stays liquid.
  *
  * Intentionally unaware of authorization — admin gating lives in
  * `app/admin/layout.tsx`. ListingPageShell is reusable from any listing page
@@ -41,12 +47,21 @@ export function ListingPageShell({
 }: ListingPageShellProps) {
   return (
     <main className={cn("flex flex-1 flex-col gap-4 p-8 sm:gap-6", className)}>
-      <div className="flex flex-col items-center gap-2 text-center">
-        <h1 className="text-page-title font-bold leading-tight tracking-normal">{title}</h1>
-        {count != null && <p className="text-sm text-muted-foreground">({count})</p>}
-        {description != null && <div className="text-muted-foreground">{description}</div>}
+      <div
+        data-slot="page-header"
+        className="flex flex-col items-center gap-2 text-center md:flex-row md:items-center md:justify-between md:gap-4 md:text-left"
+      >
+        <div className="flex flex-col items-center gap-1 md:items-start">
+          <div className="flex flex-col items-center gap-1 md:flex-row md:items-baseline md:gap-2">
+            <h1 className="text-page-title font-bold leading-tight tracking-normal">{title}</h1>
+            {count != null && <span className="text-sm text-muted-foreground">({count})</span>}
+          </div>
+          {description != null && <div className="text-muted-foreground">{description}</div>}
+        </div>
         {primaryActions != null && (
-          <div className="flex items-center justify-center gap-2">{primaryActions}</div>
+          <div className="flex items-center justify-center gap-2 md:justify-end">
+            {primaryActions}
+          </div>
         )}
       </div>
       {toolbar != null && <div data-slot="toolbar">{toolbar}</div>}


### PR DESCRIPTION
## Summary

The five listing pages — **Catalog**, **Cardgroups**, **Roles**, **Masters**, **Users** — share one centered header on `ListingPageShell`: the title is centered with the `(N)` count stacked directly beneath it and the desktop create button centered below. On desktop this leaves both flanks of a full-width bar empty and reads unlike a standard dashboard list. This makes the header responsive: mobile keeps the centered column unchanged, while desktop (`md+`) becomes a `justify-between` row — the title left-aligned with the `(N)` count inline to its right, and the create action pushed to the trailing edge. The change is contained to the shared shell, so all five pages adopt it with no client-side change.

No related GitHub issue (direct UX request).

## Background / Motivation

- On desktop the centered header left both flanks of a full-width bar empty, unlike the shadcn-admin "list page" pattern (left title + trailing actions) the screens were modeled on.
- The `(N)` count sat on its own row under the title; the request was to read it inline beside the title (`マスター (1)`).
- The desktop create button (`hidden md:inline-flex`) was centered below the title rather than on the trailing edge where a list-page primary action is conventionally found.
- Mobile already works (centered title, create via the top-bar "+", search via the header magnifier) and must stay exactly as-is.

## Changes

### Responsive header (`ListingPageShell`)

- `frontend/src/components/layout/listing-page-shell.tsx`:
  - Header container becomes responsive: mobile `flex flex-col items-center text-center` (unchanged), desktop `md:flex-row md:items-center md:justify-between md:text-left`.
  - Title + count share a leading cluster — stacked and centered on mobile, `md:flex-row md:items-baseline` so the `(N)` count sits inline to the right of the title on desktop. The count is now a `<span>` (was a block `<p>` subtitle).
  - The `primaryActions` cluster gains `md:justify-end` so it lands on the trailing edge of the row on desktop; it stays hidden on mobile via the page-supplied `hidden md:inline-flex` (create remains the top-bar "+").
  - Add a stable `data-slot="page-header"` hook on the header container for tests; JSDoc updated to describe the mobile/desktop split.

All five pages inherit the new desktop layout through the shared shell with no client-side change. Pages that pass `count` (Masters, Users) show the inline `(N)`; the search/filter input keeps its existing full-width row below the header.

### Tests

- `frontend/src/components/layout/listing-page-shell.test.tsx`:
  - Replace the "centers the header block" spec with one asserting both the mobile-centered classes and the desktop `md:flex-row md:justify-between md:text-left` classes on the `data-slot="page-header"` container.
  - Rework the count spec to assert the muted `(N)` shares the title cluster and that cluster carries the desktop inline classes (`md:flex-row md:items-baseline`).
  - Strengthen the `primaryActions` spec to assert the actions cluster carries `md:justify-end`.

## Verification

- typecheck ✓ (`tsc --noEmit`)
- lint ✓ (`biome check --error-on-warnings`, exit 0 on changed files)
- knip ✓ (no unused exports)
- test ✓ **1539 passing (164 files)** — `listing-page-shell` included
- build ✓ (`next build`)
- CJK ✓ — no Japanese literals in the changed `.tsx` (copy flows through next-intl `t()`); no new message keys

## Test plan

- [ ] `/admin/masters` (desktop `md+`) — `マスター` left-aligned with `(1)` inline to its right; the "新規マスター +" button on the trailing edge of the same row; search input full-width below.
- [ ] `/admin/masters` (mobile `<md`) — title centered with `(1)` beneath it; no inline button (create via the top-bar "+"); header magnifier search unchanged.
- [ ] `/admin/users` (desktop) — title left-aligned with `(N)` inline; no trailing button (no create action); search input below.
- [ ] `/cardgroups` (desktop) — title left-aligned; the "New cardgroup" button on the trailing edge; mobile keeps the centered title + top-bar "+".
- [ ] `/admin/roles` (desktop) — title left-aligned; the "New role" button on the trailing edge.
- [ ] `/catalog` (desktop) — title left-aligned; the deck list + Import buttons render unchanged below.
