### PR TITLE
feat(frontend): cardgroup-detail one-row header + catalog search width

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -95,7 +95,7 @@
   },
   "Cardgroups": {
     "updatedAt": "Updated {date}",
-    "myCardgroups": "My cardgroups",
+    "myCardgroups": "Cardgroups",
     "newCardgroup": "New cardgroup",
     "noCardgroupsYet": "No cardgroups yet",
     "noMatch": "No cardgroups match \"{query}\"",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -95,7 +95,7 @@
   },
   "Cardgroups": {
     "updatedAt": "{date}に更新",
-    "myCardgroups": "マイカードグループ",
+    "myCardgroups": "カードグループ",
     "newCardgroup": "新規カードグループ",
     "noCardgroupsYet": "カードグループがありません",
     "noMatch": "「{query}」に一致するカードグループはありません",

--- a/frontend/src/app/catalog/catalog-client.tsx
+++ b/frontend/src/app/catalog/catalog-client.tsx
@@ -214,7 +214,7 @@ export default function CatalogClient({ initialConnection }: CatalogClientProps)
               placeholder={t("searchPlaceholder")}
               value={search.input}
               onChange={(e) => search.setInput(e.target.value)}
-              className="w-full max-w-sm rounded-md border border-input bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
               aria-label={t("searchAriaLabel")}
               data-testid="catalog-search"
             />

--- a/frontend/src/components/cardgroups/cardgroup-cards-section.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-cards-section.tsx
@@ -52,9 +52,15 @@ export function CardgroupCardsSection({
     onAddCard: () => void;
     onBatchImport: () => void;
   }) => (
-    <div>
-      {renderPageHeader?.({ totalCount, onBatchImport })}
-      <div className="mb-3 flex flex-col gap-2 md:flex-row md:items-center md:justify-end">
+    // Desktop reflows into a single header row: the page-level header (title +
+    // count subtitle, left) and the action cluster (right) share one
+    // justify-between row, matching the shadcn-admin detail-header shape. On
+    // mobile the two stack — header on top, full-width Start learning hero below.
+    <div className="md:flex md:items-start md:justify-between md:gap-4">
+      <div className="md:min-w-0 md:flex-1">
+        {renderPageHeader?.({ totalCount, onBatchImport })}
+      </div>
+      <div className="mb-3 flex flex-col gap-2 md:mb-0 md:flex-row md:items-center md:gap-2 md:shrink-0">
         {/* Primary CTA: full-width brand hero on mobile (h-11 = 44px tap target),
             compact on desktop. Add card on mobile is provided by the global "+"
             header action, so no Add button is duplicated here on small screens.

--- a/frontend/src/components/cardgroups/cardgroup-header.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-header.tsx
@@ -112,30 +112,37 @@ export function CardgroupHeader({ cardgroup, totalCount, onBatchImport }: Props)
 
   return (
     <>
-      <header className="mb-6">
-        {/* Row 1 — app-bar: inline back (left), card count centered, overflow
-            menu (right). The 1fr/auto/1fr grid keeps the count truly centered
-            regardless of the back/overflow cluster widths. */}
-        <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-2">
-          <Link
-            href="/cardgroups"
-            className="shrink-0 justify-self-start rounded-sm text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-          >
-            <ChevronLeft aria-hidden="true" className="h-5 w-5" />
-            <span className="sr-only">{t("backLink")}</span>
-          </Link>
-          <p className="justify-self-center text-sm text-muted-foreground">
-            {t("cardsCount", { count: totalCount })}
-          </p>
-          <div className="justify-self-end">{actions}</div>
-        </div>
+      {/*
+        Single-DOM responsive header — back, count, title, and the overflow
+        menu are each rendered once and repositioned via CSS grid template
+        areas, so the layout reflows without duplicating any element (the test
+        contract expects exactly one back link, one count, one h1, and one
+        overflow trigger).
 
-        {/* Row 2 — title: centered name. Rename moved into the overflow menu. */}
-        <div className="mt-1 flex items-center justify-center">
-          <h1 className="min-w-0 truncate text-center text-2xl font-semibold leading-tight">
-            {cardgroup.name}
-          </h1>
-        </div>
+        Mobile (`< md`): app-bar row — inline back (left), card count centered,
+        overflow menu (right) — with the title centered on its own row below.
+        The 1fr/auto/1fr columns keep the count truly centered regardless of
+        the back/overflow cluster widths.
+
+        Desktop (`>= md`): title left with the card count as a muted subtitle
+        beneath it; back stays on the leading edge and the overflow trigger is
+        pushed to the trailing edge so it lands beside the page-level action
+        buttons that `CardgroupCardsSection` lays out on the same row. */}
+      <header className="mb-6 grid grid-cols-[1fr_auto_1fr] items-center gap-x-2 gap-y-1 [grid-template-areas:'back_count_overflow'_'title_title_title'] md:grid-cols-[auto_minmax(0,1fr)_auto] md:gap-y-0 md:[grid-template-areas:'back_title_overflow'_'back_count_overflow']">
+        <Link
+          href="/cardgroups"
+          className="shrink-0 justify-self-start [grid-area:back] rounded-sm text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          <ChevronLeft aria-hidden="true" className="h-5 w-5" />
+          <span className="sr-only">{t("backLink")}</span>
+        </Link>
+        <h1 className="min-w-0 truncate [grid-area:title] text-center text-2xl font-semibold leading-tight md:text-left">
+          {cardgroup.name}
+        </h1>
+        <p className="justify-self-center [grid-area:count] text-sm text-muted-foreground md:justify-self-start">
+          {t("cardsCount", { count: totalCount })}
+        </p>
+        <div className="justify-self-end [grid-area:overflow]">{actions}</div>
       </header>
 
       <FormSheet


### PR DESCRIPTION
## Summary

The cardgroup-detail screen (`/cardgroups/[id]/edit`) rendered its header as a centered two-row app-bar (back / card count / overflow, deck name centered below) and pushed the **Start learning** / **Add card** actions onto a separate right-aligned row beneath it. On desktop this reads unlike the shadcn-admin detail-page pattern (title left, primary actions trailing on one row). This reflows the desktop (`md+`) header into a single row — deck title left, the card count as a muted subtitle beneath it, actions on the trailing edge — while leaving the mobile app-bar untouched. It also makes the `/catalog` search input full-width on desktop and renames the cardgroups page title to "Cardgroups".

No related GitHub issue (direct UX request).

## Background / Motivation

- The cardgroup-detail desktop header centered the title and stacked the Start learning / Add card actions on a separate row, leaving both flanks of a full-width bar empty — unlike the shadcn-admin detail-page pattern (title left, actions trailing) the screen was modeled on.
- The card count (`1259 cards`) sat in the centered app-bar; on the new single-row desktop layout it needed a home that keeps the action row uncluttered and survives long, user-named deck titles.
- The `/catalog` search input was capped at `max-w-sm`, rendering as a narrow box on desktop while the sibling list screens (`/cardgroups`, `/admin/users`) use a full-width input.
- The cardgroups page title read "My cardgroups" / `マイカードグループ`; the request was to drop the "My" prefix to plain "Cardgroups" / `カードグループ` everywhere (PC + mobile).
- Mobile must stay exactly as-is — the change is desktop-only (`md+`).

## Changes

### One-row cardgroup-detail desktop header

- `frontend/src/components/cardgroups/cardgroup-header.tsx` — collapse the two separate `<div>` rows (app-bar grid + centered title row) into a **single CSS-grid header** that reflows via `grid-template-areas`, so every element (back link, count, `<h1>`, overflow trigger) is rendered exactly once and the test contract (one of each) holds across both layouts. Mobile keeps the `1fr/auto/1fr` app-bar (back left, count centered, overflow right) with the title centered below; desktop (`md+`) switches to `auto/minmax(0,1fr)/auto` columns with areas `back title overflow` / `back count overflow` — title left, the muted card count as a subtitle directly beneath it, back on the leading edge, and the overflow trigger pushed to the trailing edge.
- `frontend/src/components/cardgroups/cardgroup-cards-section.tsx` — wrap the page-level header and the Start learning / Add card cluster in a `md:flex md:items-start md:justify-between` row so on desktop they share one line (header left via `md:flex-1 md:min-w-0`, actions right via `md:shrink-0`). On mobile the two still stack — header on top, full-width Start learning hero below — unchanged.

### Full-width catalog search

- `frontend/src/app/catalog/catalog-client.tsx` — drop `max-w-sm` from the desktop search input so it spans the full content width, matching `/cardgroups` and `/admin/users`.

### Cardgroups page-title rename

- `frontend/messages/en.json` / `ja.json` — `Cardgroups.myCardgroups`: `My cardgroups` → `Cardgroups`, `マイカードグループ` → `カードグループ`. The same key drives both the desktop and mobile page heading, so PC and mobile update together. The key name is left as `myCardgroups` — only the copy changed.

### Tests

- No test changes were required. The cardgroup-header reflow keeps every element single in the DOM, so `cardgroup-header.test.tsx` (one back link / count / `<h1>` / overflow trigger) and `cardgroup-cards-section.test.tsx` (Start learning link, Add card button) stay green against the layout-class-only change. The catalog-search and i18n edits change a className / message value that no test asserts on.

## Verification

- typecheck ✓ (`tsc --noEmit`)
- lint ✓ (`biome check --error-on-warnings`, exit 0 on changed files)
- knip ✓ (no unused exports)
- test ✓ **1539 passing (164 files)** — `cardgroup-header`, `cardgroup-cards-section`, `catalog-client` all green with no edits
- build ✓ (`next build`) — Tailwind compiles the arbitrary `grid-template-areas` utilities
- CJK ✓ — no Japanese literals in the changed `.tsx` (copy flows through next-intl `t()`); the only Japanese is the translated value in `ja.json` (sanctioned message catalog)

## Test plan

- [ ] `/cardgroups/[id]/edit` (desktop `md+`) — deck title left-aligned with `N cards` as a muted subtitle directly beneath it; **Start learning** + **Add card** on the trailing edge of the same row; the `…` overflow sits on the trailing edge beside the actions.
- [ ] `/cardgroups/[id]/edit` (mobile `<md`) — unchanged: back chevron (left), `N cards` centered, `…` overflow (right) on the app-bar; deck name centered below; full-width Start learning hero; no Add card button.
- [ ] `…` overflow still holds Rename + (mobile) Batch import + Delete; Delete opens the red destructive confirm and navigates to `/cardgroups`.
- [ ] `/catalog` (desktop) — search input spans the full content width (no narrow `max-w-sm` box); deck list + Import render unchanged below.
- [ ] `/cardgroups` (desktop + mobile) — page heading reads **Cardgroups** (en) / `カードグループ` (ja), not "My cardgroups" / `マイカードグループ`.
