### PR TITLE
test(frontend): fix cardgroups mobile-search strict-mode flake via role locators

### DIFF
--- a/frontend/e2e/cardgroups-mobile-search.spec.ts
+++ b/frontend/e2e/cardgroups-mobile-search.spec.ts
@@ -7,6 +7,15 @@ import { loginAs, seedCardgroup, seedUser } from "./_auth";
 // phone viewport (390x844), mirroring new-user-onboarding.spec.ts.
 // Select by data-testid / role — e2e renders in the ja-JP locale, so never
 // match on translated copy.
+//
+// Assert cardgroup rows via getByRole("link"), NOT getByText: /cardgroups
+// streams its list through a <Suspense> boundary (see app/cardgroups/page.tsx),
+// so Next.js momentarily holds the resolved list inside a `<div hidden>`
+// streaming buffer before swapping it into place. getByText matches hidden text
+// too, so it intermittently resolves to two copies of a row (one live, one in
+// the hidden buffer) and trips a strict-mode violation. Hidden subtrees are
+// excluded from the accessibility tree, so a role locator only ever matches the
+// live, visible row — which is also all a real user / screen reader ever sees.
 test.describe("cardgroups mobile search takeover", () => {
   test.use({ viewport: { width: 390, height: 844 } });
 
@@ -31,16 +40,16 @@ test.describe("cardgroups mobile search takeover", () => {
     await loginAs(context, { email: user.email, password: user.password });
     await page.goto("/cardgroups");
 
-    await expect(page.getByText(`Alpha ${runId}`)).toBeVisible();
-    await expect(page.getByText(`Beta ${runId}`)).toBeVisible();
+    await expect(page.getByRole("link", { name: `Alpha ${runId}`, exact: false })).toBeVisible();
+    await expect(page.getByRole("link", { name: `Beta ${runId}`, exact: false })).toBeVisible();
 
     await page.getByTestId("header-search-trigger").click();
     const input = page.getByTestId("search-takeover-input");
     await expect(input).toBeVisible();
 
     await input.fill(`Alpha ${runId}`);
-    await expect(page.getByText(`Alpha ${runId}`)).toBeVisible();
-    await expect(page.getByText(`Beta ${runId}`)).toHaveCount(0);
+    await expect(page.getByRole("link", { name: `Alpha ${runId}`, exact: false })).toBeVisible();
+    await expect(page.getByRole("link", { name: `Beta ${runId}`, exact: false })).toHaveCount(0);
 
     // Close: the bar disappears; the active dot remains because the query is set.
     await page.getByTestId("search-takeover-close").click();


### PR DESCRIPTION
## Summary

The E2E (Playwright) job has been intermittently failing on `cardgroups-mobile-search.spec.ts` with a strict-mode violation:

```
getByText('Alpha <runId>') resolved to 2 elements:
  1) <span ...>Alpha <runId></span>  aka getByRole('link', { name: 'Alpha <runId> …更新' })
  2) <span ...>Alpha <runId></span>  aka getByText('Alpha <runId>').nth(1)   ← hidden
```

This is a **test-robustness flake, not a product bug**. The row assertions are switched from `getByText` to `getByRole("link", …)`, which only ever matches the live, visible row.

No related GitHub issue (CI flake fix).

## Background / Motivation

`/cardgroups` streams its list through a `<Suspense>` boundary (`app/cardgroups/page.tsx`), so Next.js momentarily holds the resolved list inside a `<div hidden>` streaming buffer before swapping it into the live slot. `page.getByText(name)` matches hidden text too, so it intermittently resolves to **two** copies of a row — one live, one in the hidden buffer — tripping a strict-mode violation.

Evidence that it is a hidden duplicate, invisible to real users:

- The seed inserts exactly one `Alpha` row (`seedCardgroup` is a plain `insert`).
- The failure screenshot and the captured accessibility tree both show **one** `Alpha` row — `hidden` subtrees are excluded from the accessibility tree, so screen readers / real users never see the dupe.
- The strict-mode error itself labels the live row as `getByRole('link', …)` and the hidden one only as `getByText(…).nth(1)`.

The CI history confirms the intermittent nature: it failed on the #572 and #574 merge runs but passed on #573 in between — uncorrelated to commit content (run `27852232332`).

## Changes

### `frontend/e2e/cardgroups-mobile-search.spec.ts`

- Assert cardgroup rows via `getByRole("link", { name, exact: false })` instead of `getByText(...)`. Role locators skip hidden subtrees, so the Suspense streaming buffer copy is never matched.
- Add a comment documenting the root cause so the pattern is not reintroduced.

## Verification

- typecheck ✓ — isolated `tsc --noEmit` of the spec with `@playwright/test` + node + dom types; no error on the `getByRole` calls
- lint ✓ — `biome check --error-on-warnings` (exit 0)
- parse ✓ — Playwright loads the spec (fails only on the expected module-load env requirement, after a clean parse)
- scope ✓ — only the one spec file changed; no stray edits in the main checkout

## Follow-up (out of scope)

`cardgroups-flow.spec.ts:66` uses the same `getByText(seededCardgroupName)` pattern (desktop viewport) and is in the same flake class. It has not been converted here to keep this PR scoped to the failing job; happy to follow up.
