### PR TITLE
feat(frontend): move cardgroup detail action buttons to their own row

### DIFF
--- a/frontend/src/components/cardgroups/cardgroup-cards-section.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-cards-section.tsx
@@ -52,15 +52,12 @@ export function CardgroupCardsSection({
     onAddCard: () => void;
     onBatchImport: () => void;
   }) => (
-    // Desktop reflows into a single header row: the page-level header (title +
-    // count subtitle, left) and the action cluster (right) share one
-    // justify-between row, matching the shadcn-admin detail-header shape. On
-    // mobile the two stack — header on top, full-width Start learning hero below.
-    <div className="md:flex md:items-start md:justify-between md:gap-4">
-      <div className="md:min-w-0 md:flex-1">
-        {renderPageHeader?.({ totalCount, onBatchImport })}
-      </div>
-      <div className="mb-3 flex flex-col gap-2 md:mb-0 md:flex-row md:items-center md:gap-2 md:shrink-0">
+    // The page-level header (title + count subtitle) renders first; the action
+    // cluster sits on its own row below it, right-aligned on desktop. On mobile
+    // the two also stack — header on top, full-width Start learning hero below.
+    <div>
+      {renderPageHeader?.({ totalCount, onBatchImport })}
+      <div className="mb-3 flex flex-col gap-2 md:flex-row md:items-center md:justify-end md:gap-2">
         {/* Primary CTA: full-width brand hero on mobile (h-11 = 44px tap target),
             compact on desktop. Add card on mobile is provided by the global "+"
             header action, so no Add button is duplicated here on small screens.

--- a/frontend/src/components/cardgroups/cardgroup-header.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-header.tsx
@@ -126,8 +126,9 @@ export function CardgroupHeader({ cardgroup, totalCount, onBatchImport }: Props)
 
         Desktop (`>= md`): title left with the card count as a muted subtitle
         beneath it; back stays on the leading edge and the overflow trigger is
-        pushed to the trailing edge so it lands beside the page-level action
-        buttons that `CardgroupCardsSection` lays out on the same row. */}
+        pushed to the trailing edge of the title row. The page-level action
+        buttons that `CardgroupCardsSection` lays out now sit on their own row
+        below this header. */}
       <header className="mb-6 grid grid-cols-[1fr_auto_1fr] items-center gap-x-2 gap-y-1 [grid-template-areas:'back_count_overflow'_'title_title_title'] md:grid-cols-[auto_minmax(0,1fr)_auto] md:gap-y-0 md:[grid-template-areas:'back_title_overflow'_'back_count_overflow']">
         <Link
           href="/cardgroups"


### PR DESCRIPTION
## Summary

The cardgroup-detail screen (`/cardgroups/[id]/edit`) reflowed its desktop header into a single row where the deck title (left) shared a `md:justify-between` line with the **Start learning** / **Add card** actions (right). This drops those actions onto their own row directly below the title block, right-aligned on desktop, so the title row carries only the deck name, the muted card-count subtitle, and the trailing `…` overflow. Mobile is untouched — the action cluster already stacked below the header there.

No related GitHub issue (direct UX request).

## Background / Motivation

- The one-row desktop header packed the deck title, the `…` overflow, and both action buttons onto a single line; on long user-named decks the title and the trailing action cluster competed for width.
- The request was to give the **Start learning** / **Add card** actions their own row beneath the title, keeping the title row uncluttered while preserving the right-aligned action position.
- The `…` overflow stays on the title row's trailing edge (it hosts Rename / Batch import / Delete) — only the page-level action buttons move down.
- Mobile must stay exactly as-is — the actions already render stacked below the header there, so the change is desktop-only (`md+`).

## Changes

### Action buttons on their own row

- `frontend/src/components/cardgroups/cardgroup-cards-section.tsx` — replace the `md:flex md:items-start md:justify-between` wrapper (header left via `md:flex-1`, actions right via `md:shrink-0`) with a plain vertical block: the page-level header renders first, then the action cluster on its own row. The cluster gains `md:justify-end` to keep the buttons right-aligned on desktop and drops the now-unneeded `md:flex-1` header wrapper plus the `md:mb-0` / `md:shrink-0` utilities.

### Header comment

- `frontend/src/components/cardgroups/cardgroup-header.tsx` — update the desktop-layout docblock: the overflow trigger still sits on the title row's trailing edge, but the page-level action buttons now sit on a row below the header rather than beside it. The header grid itself is unchanged.

### Tests

- No test changes required. `cardgroup-cards-section.test.tsx` and `cards-client.test.tsx` assert on behavior (Start learning link, Add card button, render-prop wiring), not on layout classes, so the class-only change keeps them green.

## Verification

- typecheck ✓ (`tsc --noEmit`)
- lint ✓ (`biome check --error-on-warnings`, changed files, exit 0)
- knip ✓ (exit 0, no unused exports)
- test ✓ **1539 passing (164 files)** — `cardgroup-cards-section`, `cards-client` green with no edits
- build ✓ (`next build`, exit 0) — only standard Tailwind utilities, no new arbitrary values
- CJK ✓ — no Japanese literals in the changed `.tsx` (the diff adds English comments + utility classes only)

## Test plan

- [ ] `/cardgroups/[id]/edit` (desktop `md+`) — deck title left with the `N cards` muted subtitle beneath it; the `…` overflow on the trailing edge of the title row; **Start learning** + **Add card ▾** on their own right-aligned row directly below the title block.
- [ ] `/cardgroups/[id]/edit` (mobile `<md`) — unchanged: app-bar (back / count / overflow), deck name centered below, full-width Start learning hero, no Add card button.
- [ ] `…` overflow still holds Rename + (mobile) Batch import + Delete; Delete opens the red destructive confirm and navigates to `/cardgroups`.
- [ ] Desktop **Add card ▾** split button still works — the primary Add card opens the add sheet; the dropdown holds Add a card + Batch import.
- [ ] Desktop search input renders full-width directly below the new action row.
