### PR TITLE
feat(backend): public masterCardsConnection + masterCardgroup queries for catalog deck view

### DIFF
--- a/backend/cmd/server/main_test.go
+++ b/backend/cmd/server/main_test.go
@@ -2597,6 +2597,12 @@ func (panicQueryResolver) AdminMaster(_ context.Context, _ string) (*model.Maste
 func (panicQueryResolver) AdminMasterCardsConnection(_ context.Context, _ string, _ *int, _ *string, _ *int, _ *string, _ *string, _ *model.MasterCardOrderBy, _ *model.SortOrder) (*model.MasterCardConnection, error) {
 	panic("not implemented")
 }
+func (panicQueryResolver) MasterCardsConnection(_ context.Context, _ string, _ *int, _ *string, _ *int, _ *string, _ *string, _ *model.MasterCardOrderBy, _ *model.SortOrder) (*model.MasterCardConnection, error) {
+	panic("not implemented")
+}
+func (panicQueryResolver) MasterCardgroup(_ context.Context, _ string) (*model.MasterCardgroup, error) {
+	panic("not implemented")
+}
 
 // panicResolverRoot is a generated.ResolverRoot whose Query resolver panics on
 // Health. All other sub-resolvers forward to the real resolver with nil deps

--- a/backend/graph/resolver/master_card.resolvers.go
+++ b/backend/graph/resolver/master_card.resolvers.go
@@ -128,3 +128,34 @@ func (r *queryResolver) AdminMasterCardsConnection(ctx context.Context, masterCa
 	}
 	return toMasterCardConnectionModel(ctx, out), nil
 }
+
+// MasterCardsConnection is the resolver for the masterCardsConnection field.
+func (r *queryResolver) MasterCardsConnection(ctx context.Context, masterCardgroupID string, first *int, after *string, last *int, before *string, search *string, orderBy *model.MasterCardOrderBy, orderDirection *model.SortOrder) (*model.MasterCardConnection, error) {
+	out, err := r.MasterCardUC.ListPublicMasterCards(ctx, usecase.MasterCardConnectionInput{
+		MasterCardgroupID: masterCardgroupID,
+		First:             first,
+		Last:              last,
+		After:             after,
+		Before:            before,
+		Search:            search,
+		OrderBy:           toUsecaseMasterCardOrderBy(orderBy),
+		OrderDirection:    toUsecaseSortOrder(orderDirection),
+	})
+	if err != nil {
+		return nil, gqlerr.FromUsecaseError(ctx, err)
+	}
+	return toMasterCardConnectionModel(ctx, out), nil
+}
+
+// MasterCardgroup is the resolver for the masterCardgroup field.
+func (r *queryResolver) MasterCardgroup(ctx context.Context, id string) (*model.MasterCardgroup, error) {
+	deck, err := r.MasterCatalogUC.FindPublishedMaster(ctx, id)
+	if err != nil {
+		return nil, gqlerr.FromUsecaseError(ctx, err)
+	}
+	if deck == nil {
+		return nil, nil
+	}
+	// cardCount=0 here; the frontend reads the live count from masterCardsConnection.totalCount.
+	return toMasterCardgroupModelFromParts(deck, 0), nil
+}

--- a/backend/graph/resolver/master_card_resolver_test.go
+++ b/backend/graph/resolver/master_card_resolver_test.go
@@ -27,6 +27,10 @@ type stubMasterCardUC struct {
 	listOut      *usecase.MasterCardConnectionOutput
 	listErr      error
 
+	gotPublicListInput usecase.MasterCardConnectionInput
+	publicListOut      *usecase.MasterCardConnectionOutput
+	publicListErr      error
+
 	gotCreateInput usecase.CreateMasterCardInput
 	createOut      usecase.CreateMasterCardOutcome
 	createErr      error
@@ -55,6 +59,11 @@ func (s *stubMasterCardUC) AdminMaster(_ context.Context, _ string) (*usecase.Ma
 func (s *stubMasterCardUC) ListMasterCards(_ context.Context, in usecase.MasterCardConnectionInput) (*usecase.MasterCardConnectionOutput, error) {
 	s.gotListInput = in
 	return s.listOut, s.listErr
+}
+
+func (s *stubMasterCardUC) ListPublicMasterCards(_ context.Context, in usecase.MasterCardConnectionInput) (*usecase.MasterCardConnectionOutput, error) {
+	s.gotPublicListInput = in
+	return s.publicListOut, s.publicListErr
 }
 
 func (s *stubMasterCardUC) CreateMasterCard(_ context.Context, in usecase.CreateMasterCardInput) (usecase.CreateMasterCardOutcome, error) {
@@ -340,5 +349,74 @@ func TestAdminMasterCardsConnection_CursorRoundTrip(t *testing.T) {
 		decoded, decErr := cursor.Decode(edge.Cursor)
 		require.NoError(t, decErr, "edge.Cursor for node %s must be valid v1 cursor", edge.Node.ID)
 		assert.Equal(t, edge.Node.ID, decoded, "edge.Cursor must decode to node.ID")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// MasterCardsConnection (public, published-only)
+// ---------------------------------------------------------------------------
+
+// TestMasterCardsConnection_Success verifies the public resolver routes through
+// ListPublicMasterCards (NOT the admin ListMasterCards), forwards its inputs, and
+// maps the usecase output to the wire connection.
+func TestMasterCardsConnection_Success(t *testing.T) {
+	t.Parallel()
+	stub := &stubMasterCardUC{publicListOut: &usecase.MasterCardConnectionOutput{
+		Cards: []*domain.MasterCard{
+			{ID: "c1", MasterCardgroupID: "m1", Front: domain.CardText("front"), Back: domain.CardText("back"), Position: 1},
+		},
+		TotalCount: 1,
+		StartCur:   "c1",
+		EndCur:     "c1",
+	}}
+	qr := &queryResolver{&Resolver{MasterCardUC: stub}}
+
+	orderBy := model.MasterCardOrderByPosition
+	dir := model.SortOrderAsc
+	conn, err := qr.MasterCardsConnection(context.Background(), "m1", nil, nil, nil, nil, nil, &orderBy, &dir)
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+
+	// The public resolver must route through ListPublicMasterCards: the admin
+	// list input must stay zero, and the public input must carry the translated
+	// arguments.
+	assert.Equal(t, "", stub.gotListInput.MasterCardgroupID, "admin ListMasterCards must not be called")
+	assert.Equal(t, "m1", stub.gotPublicListInput.MasterCardgroupID)
+	require.NotNil(t, stub.gotPublicListInput.OrderBy)
+	assert.Equal(t, usecase.MasterCardOrderByPosition, *stub.gotPublicListInput.OrderBy)
+	require.NotNil(t, stub.gotPublicListInput.OrderDirection)
+	assert.Equal(t, usecase.SortOrderAsc, *stub.gotPublicListInput.OrderDirection)
+
+	require.Len(t, conn.Edges, 1)
+	assert.Equal(t, 1, conn.TotalCount)
+	assert.Equal(t, "c1", conn.Edges[0].Node.ID)
+	assert.Equal(t, "front", conn.Edges[0].Node.Front)
+	assert.Equal(t, "m1", conn.Edges[0].Node.MasterCardgroupID)
+}
+
+// TestMasterCardsConnection_WrapsUsecaseError verifies the mandatory
+// gqlerr.FromUsecaseError wrap: typed usecase errors surface with the correct
+// wire code rather than escaping uncoded. The validation case mirrors the
+// published-gate rejection (BAD_USER_INPUT on masterCardgroupId).
+func TestMasterCardsConnection_WrapsUsecaseError(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		err  error
+		want gqlerr.Code
+	}{
+		{"unauthenticated", ucerr.ErrUnauthenticated, gqlerr.CodeUnauthenticated},
+		{"validation", ucerr.NewValidationError("masterCardgroupId", "master deck not found"), gqlerr.CodeBadUserInput},
+		{"internal", eris.New("usecase: db: query timeout"), gqlerr.CodeInternal},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			stub := &stubMasterCardUC{publicListErr: tc.err}
+			qr := &queryResolver{&Resolver{MasterCardUC: stub}}
+			_, err := qr.MasterCardsConnection(context.Background(), "m1", nil, nil, nil, nil, nil, nil, nil)
+			require.Error(t, err)
+			assert.True(t, gqlerr.IsCode(err, tc.want), "want wire code %s", tc.want)
+		})
 	}
 }

--- a/backend/graph/resolver/master_catalog_query_test.go
+++ b/backend/graph/resolver/master_catalog_query_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/rotisserie/eris"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -44,6 +45,10 @@ type stubMasterCatalogUC struct {
 
 	seedOut []*domain.Cardgroup
 	seedErr error
+
+	gotFindPublishedID string
+	findPublishedDeck  *domain.MasterCardgroup
+	findPublishedErr   error
 }
 
 func (s *stubMasterCatalogUC) ListPublishedConnection(
@@ -51,6 +56,11 @@ func (s *stubMasterCatalogUC) ListPublishedConnection(
 ) (*usecase.MasterCatalogConnectionOutput, error) {
 	s.gotInput = in
 	return s.out, s.err
+}
+
+func (s *stubMasterCatalogUC) FindPublishedMaster(_ context.Context, id string) (*domain.MasterCardgroup, error) {
+	s.gotFindPublishedID = id
+	return s.findPublishedDeck, s.findPublishedErr
 }
 
 func (s *stubMasterCatalogUC) ListAdminConnection(_ context.Context, _ usecase.MasterCatalogConnectionInput) (*usecase.MasterCatalogConnectionOutput, error) {
@@ -140,6 +150,72 @@ func TestQueryResolver_MasterCatalog_WrapsUsecaseError(t *testing.T) {
 			t.Parallel()
 			qr := &queryResolver{&Resolver{MasterCatalogUC: &stubMasterCatalogUC{err: tc.err}}}
 			_, err := qr.MasterCatalog(context.Background(), nil, nil, nil, nil, nil, nil, nil)
+			require.Error(t, err)
+			assert.True(t, gqlerr.IsCode(err, tc.want), "want wire code %s", tc.want)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// MasterCardgroup (public, published-only single deck)
+//
+// The masterCardgroup resolver lives in master_card.resolvers.go but reads
+// through MasterCatalogUC.FindPublishedMaster, so its tests live here alongside
+// stubMasterCatalogUC.
+// ---------------------------------------------------------------------------
+
+// TestQueryResolver_MasterCardgroup_Success verifies the resolver maps the
+// published deck to *model.MasterCardgroup. cardCount is 0 here by design — the
+// frontend reads the live count from masterCardsConnection.totalCount.
+func TestQueryResolver_MasterCardgroup_Success(t *testing.T) {
+	t.Parallel()
+	stub := &stubMasterCatalogUC{findPublishedDeck: &domain.MasterCardgroup{
+		ID:      "m1",
+		Name:    domain.CardgroupName("Deck"),
+		Status:  domain.MasterStatusPublished,
+		Version: 1,
+	}}
+	qr := &queryResolver{&Resolver{MasterCatalogUC: stub}}
+
+	got, err := qr.MasterCardgroup(context.Background(), "m1")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "m1", got.ID)
+	assert.Equal(t, model.MasterCardgroupStatusPublished, got.Status)
+	assert.Equal(t, 0, got.CardCount)
+	assert.Equal(t, "m1", stub.gotFindPublishedID)
+}
+
+// TestQueryResolver_MasterCardgroup_NotFoundReturnsNil verifies an unknown or
+// DRAFT id (usecase returns nil, nil) surfaces as GraphQL null with no error —
+// the non-disclosure gate must not leak draft existence as an error.
+func TestQueryResolver_MasterCardgroup_NotFoundReturnsNil(t *testing.T) {
+	t.Parallel()
+	stub := &stubMasterCatalogUC{} // findPublishedDeck nil, findPublishedErr nil
+	qr := &queryResolver{&Resolver{MasterCatalogUC: stub}}
+
+	got, err := qr.MasterCardgroup(context.Background(), "missing")
+	require.NoError(t, err)
+	assert.Nil(t, got)
+}
+
+// TestQueryResolver_MasterCardgroup_WrapsUsecaseError verifies the mandatory
+// gqlerr.FromUsecaseError wrap for the error paths FindPublishedMaster can return.
+func TestQueryResolver_MasterCardgroup_WrapsUsecaseError(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		err  error
+		want gqlerr.Code
+	}{
+		{"unauthenticated", ucerr.ErrUnauthenticated, gqlerr.CodeUnauthenticated},
+		{"internal", eris.New("usecase: db: connection reset"), gqlerr.CodeInternal},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			qr := &queryResolver{&Resolver{MasterCatalogUC: &stubMasterCatalogUC{findPublishedErr: tc.err}}}
+			_, err := qr.MasterCardgroup(context.Background(), "m1")
 			require.Error(t, err)
 			assert.True(t, gqlerr.IsCode(err, tc.want), "want wire code %s", tc.want)
 		})

--- a/backend/internal/usecase/master_card.go
+++ b/backend/internal/usecase/master_card.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rotisserie/eris"
 	"gorm.io/gorm"
 
+	"backend/internal/auth"
 	"backend/internal/cursor"
 	"backend/internal/domain"
 	"backend/internal/repository"
@@ -33,6 +34,11 @@ type MasterCardUsecase interface {
 	// ListMasterCards paginates a master deck's cards with Relay-style forward
 	// (first/after) or backward (last/before) cursors. Admin-only.
 	ListMasterCards(ctx context.Context, in MasterCardConnectionInput) (*MasterCardConnectionOutput, error)
+	// ListPublicMasterCards paginates a PUBLISHED master deck's cards for any
+	// authenticated caller (no admin gate). The deck must be published — a DRAFT or
+	// unknown id is rejected as a validation error on "masterCardgroupId"
+	// (non-disclosure gate). Anonymous callers receive UNAUTHENTICATED.
+	ListPublicMasterCards(ctx context.Context, in MasterCardConnectionInput) (*MasterCardConnectionOutput, error)
 	// CreateMasterCard persists a new master card. Admin-only. A duplicate
 	// (case-insensitive) front is returned as data via the outcome's Duplicate
 	// field, not as an error.
@@ -564,6 +570,97 @@ func (u *masterCardUsecase) ListMasterCards(
 					return nil, e
 				}
 				return nil, eris.Wrap(e, "usecase: master card: list: find page")
+			}
+			total = t
+			return rows, nil
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// StartCur / EndCur carry the RAW node id; the resolver's connection layer
+	// applies the cursor encoder once. Encoding here would double-encode.
+	out := &MasterCardConnectionOutput{TotalCount: total, HasNext: hasNext, HasPrev: hasPrev, Cards: cards}
+	if len(cards) > 0 {
+		out.StartCur = cards[0].ID
+		out.EndCur = cards[len(cards)-1].ID
+	}
+	return out, nil
+}
+
+// ListPublicMasterCards paginates a PUBLISHED master deck's cards for any
+// authenticated caller (no admin gate). The body from the page assembly onward
+// mirrors ListMasterCards; only the gate differs — the admin gate is replaced by
+// an authentication check plus a published-only visibility gate. totalCount is the
+// search-aware count captured inside the assemblePage closure (same as the admin
+// path).
+func (u *masterCardUsecase) ListPublicMasterCards(
+	ctx context.Context, in MasterCardConnectionInput,
+) (*MasterCardConnectionOutput, error) {
+	if auth.UserFrom(ctx) == nil {
+		return nil, ucerr.ErrUnauthenticated
+	}
+	// Published-only visibility gate. FindPublishedByID returns ErrNotFound for
+	// BOTH unknown and DRAFT ids, collapsing them into one not-found so the
+	// endpoint cannot be used as a draft-existence oracle (non-disclosure gate).
+	if _, err := u.masterCardgroupRepo.FindPublishedByID(ctx, in.MasterCardgroupID); err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return nil, ucerr.NewValidationError("masterCardgroupId", "master deck not found")
+		}
+		if isContextDone(err) {
+			return nil, err
+		}
+		return nil, eris.Wrap(err, "usecase: master card: public list: find published by id")
+	}
+
+	first, last, err := resolveRelayPage(in.First, in.Last, in.After, in.Before, resolveStandardPageSize)
+	if err != nil {
+		return nil, err
+	}
+
+	orderBy, dir, err := resolveMasterCardOrderBy(in.OrderBy, in.OrderDirection)
+	if err != nil {
+		return nil, err
+	}
+
+	after, err := u.resolveMasterCardCursor(ctx, in.After, in.MasterCardgroupID, orderBy, "after")
+	if err != nil {
+		return nil, err
+	}
+	before, err := u.resolveMasterCardCursor(ctx, in.Before, in.MasterCardgroupID, orderBy, "before")
+	if err != nil {
+		return nil, err
+	}
+
+	// Normalize: nil and whitespace-only both mean "no filter". After this block
+	// a non-nil search pointer holds a non-empty, trimmed string — the repository
+	// relies on this invariant.
+	search := in.Search
+	if search != nil {
+		trimmed := strings.TrimSpace(*search)
+		if trimmed == "" {
+			search = nil
+		} else {
+			search = &trimmed
+		}
+	}
+
+	// totalCount is the search-aware count returned by FindPageByMasterCardgroup
+	// (captured inside the assemblePage closure). The repository computes it
+	// before its own no-rows short-circuit, so a totalCount-only request
+	// (first==0 && last==0) still observes the real, search-filtered count.
+	var total int64
+	cards, hasNext, hasPrev, err := assemblePage(first, last, after != nil, before != nil,
+		func(wantFirst, wantLast int) ([]*domain.MasterCard, error) {
+			rows, t, e := u.masterCardRepo.FindPageByMasterCardgroup(
+				ctx, in.MasterCardgroupID, after, before, wantFirst, wantLast, orderBy, dir, search,
+			)
+			if e != nil {
+				if isContextDone(e) {
+					return nil, e
+				}
+				return nil, eris.Wrap(e, "usecase: master card: public list: find page")
 			}
 			total = t
 			return rows, nil

--- a/backend/internal/usecase/master_card_public_test.go
+++ b/backend/internal/usecase/master_card_public_test.go
@@ -1,0 +1,217 @@
+package usecase
+
+import (
+	"context"
+	"testing"
+
+	"github.com/rotisserie/eris"
+	"github.com/stretchr/testify/require"
+
+	"backend/internal/cursor"
+	"backend/internal/domain"
+	"backend/internal/repository"
+)
+
+// ---------------------------------------------------------------------------
+// ListPublicMasterCards
+//
+// The page-assembly body reuses the SAME shared helpers as ListMasterCards
+// (resolveRelayPage / resolveMasterCardOrderBy / resolveMasterCardCursor /
+// assemblePage), exhaustively tested for the admin path in master_card_test.go.
+// These tests pin what is specific to the public method and NOT covered by the
+// admin tests: the authentication check, the published-only visibility gate, the
+// public-specific error-wrap prefixes ("usecase: master card: public list: ..."),
+// and the in-method context-cancel pass-throughs.
+// ---------------------------------------------------------------------------
+
+// publishedMasterDeck returns a PUBLISHED *domain.MasterCardgroup fixture. The
+// usecase trusts FindPublishedByID's status filter and never inspects Status, so
+// the field is set only to make the fixture self-describing.
+func publishedMasterDeck(id string) *domain.MasterCardgroup {
+	return &domain.MasterCardgroup{
+		ID:      id,
+		Name:    domain.CardgroupName("Deck " + id),
+		Status:  domain.MasterStatusPublished,
+		Version: 1,
+	}
+}
+
+func TestListPublicMasterCards_Unauthenticated(t *testing.T) {
+	t.Parallel()
+	uc := newMasterCardUC(t, &mockMasterCardReadRepo{}, &mockMasterCardgroupReadRepo{}, true)
+	_, err := uc.ListPublicMasterCards(anonCtx(), MasterCardConnectionInput{MasterCardgroupID: "id-1"})
+	assertUnauthenticated(t, err)
+}
+
+// A DRAFT or unknown deck surfaces from FindPublishedByID as ErrNotFound, which
+// the published gate maps to a BAD_USER_INPUT validation error on
+// "masterCardgroupId" (non-disclosure: draft and unknown are indistinguishable).
+// The page query must NOT run when the gate rejects the deck.
+func TestListPublicMasterCards_DraftOrUnknownDeck_BadUserInput(t *testing.T) {
+	t.Parallel()
+	mc := &mockMasterCardReadRepo{}
+	mcg := &mockMasterCardgroupReadRepo{
+		findPublishedByIDFn: func(string) (*domain.MasterCardgroup, error) { return nil, repository.ErrNotFound },
+	}
+	uc := newMasterCardUC(t, mc, mcg, true)
+	_, err := uc.ListPublicMasterCards(authedCtx("u1"), MasterCardConnectionInput{MasterCardgroupID: "missing"})
+	assertValidationError(t, err, "masterCardgroupId", "master deck not found")
+	if len(mc.findPageCalls) != 0 {
+		t.Fatalf("page query must not run when the published gate rejects the deck, got %d calls", len(mc.findPageCalls))
+	}
+}
+
+// A non-NotFound, non-context failure from the published gate is an internal
+// error wrapped into the eris chain, not a validation/forbidden error.
+func TestListPublicMasterCards_FindPublishedByID_InfraError_Wrapped(t *testing.T) {
+	t.Parallel()
+	mc := &mockMasterCardReadRepo{}
+	mcg := &mockMasterCardgroupReadRepo{
+		findPublishedByIDFn: func(string) (*domain.MasterCardgroup, error) { return nil, eris.New("db down") },
+	}
+	uc := newMasterCardUC(t, mc, mcg, true)
+	_, err := uc.ListPublicMasterCards(authedCtx("u1"), MasterCardConnectionInput{MasterCardgroupID: "id-1"})
+	assertInternalChain(t, err, "usecase: master card: public list: find published by id")
+	if len(mc.findPageCalls) != 0 {
+		t.Fatalf("page query must not run when the published gate errors, got %d calls", len(mc.findPageCalls))
+	}
+}
+
+// context.Canceled from the published gate must propagate unwrapped so its
+// identity survives errors.Is at the resolver boundary (FromUsecaseError →
+// CANCELLED). An eris.Wrap here would break the == identity contract.
+func TestListPublicMasterCards_FindPublishedByID_ContextCancelled_PassesThrough(t *testing.T) {
+	t.Parallel()
+	mcg := &mockMasterCardgroupReadRepo{
+		findPublishedByIDFn: func(string) (*domain.MasterCardgroup, error) { return nil, context.Canceled },
+	}
+	uc := newMasterCardUC(t, &mockMasterCardReadRepo{}, mcg, true)
+	_, err := uc.ListPublicMasterCards(authedCtx("u1"), MasterCardConnectionInput{MasterCardgroupID: "id-1"})
+	assertCancelled(t, err)
+	require.Equal(t, context.Canceled, err, "expected unwrapped context.Canceled, got %v", err)
+}
+
+// A published deck assembles a page: edges, search-aware totalCount, and RAW
+// (un-encoded) StartCur/EndCur. The raw-cursor assertion mirrors the admin path
+// (the resolver's connection layer encodes once; storing encoded values here
+// would double-encode).
+func TestListPublicMasterCards_Success(t *testing.T) {
+	t.Parallel()
+	rows := []*domain.MasterCard{
+		masterCardFixture("a", "id-1", 1),
+		masterCardFixture("b", "id-1", 2),
+	}
+	mc := &mockMasterCardReadRepo{findPageRows: rows, findPageTotal: 2}
+	mcg := &mockMasterCardgroupReadRepo{
+		findPublishedByIDFn: func(string) (*domain.MasterCardgroup, error) { return publishedMasterDeck("id-1"), nil },
+	}
+	uc := newMasterCardUC(t, mc, mcg, true)
+	out, err := uc.ListPublicMasterCards(authedCtx("u1"), MasterCardConnectionInput{
+		MasterCardgroupID: "id-1",
+		First:             intPtr(10),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.TotalCount != 2 {
+		t.Fatalf("expected TotalCount 2, got %d", out.TotalCount)
+	}
+	if len(out.Cards) != 2 {
+		t.Fatalf("expected 2 cards, got %d", len(out.Cards))
+	}
+	// StartCur / EndCur MUST be the RAW node ids; the resolver encodes once.
+	if out.StartCur != "a" {
+		t.Fatalf("StartCur: want raw id %q, got %q", "a", out.StartCur)
+	}
+	if out.EndCur != "b" {
+		t.Fatalf("EndCur: want raw id %q, got %q", "b", out.EndCur)
+	}
+	if out.StartCur == cursor.Encode("a") || out.EndCur == cursor.Encode("b") {
+		t.Fatalf("cursors must not be cursor.Encode(...)-encoded; got StartCur=%q EndCur=%q", out.StartCur, out.EndCur)
+	}
+}
+
+// A whitespace-only search normalizes to nil before reaching the repository
+// (same invariant ListMasterCards relies on). The published gate must pass so
+// the page query runs.
+func TestListPublicMasterCards_SearchNormalizesWhitespace(t *testing.T) {
+	t.Parallel()
+	mc := &mockMasterCardReadRepo{}
+	mcg := &mockMasterCardgroupReadRepo{
+		findPublishedByIDFn: func(string) (*domain.MasterCardgroup, error) { return publishedMasterDeck("id-1"), nil },
+	}
+	uc := newMasterCardUC(t, mc, mcg, true)
+	blank := "   "
+	_, err := uc.ListPublicMasterCards(authedCtx("u1"), MasterCardConnectionInput{
+		MasterCardgroupID: "id-1",
+		First:             intPtr(5),
+		Search:            &blank,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mc.findPageCalls[0].Search != nil {
+		t.Fatalf("whitespace-only search must normalize to nil, got %q", *mc.findPageCalls[0].Search)
+	}
+}
+
+// A repository error from the page query (AFTER the published gate passes) wraps
+// into the eris chain with the PUBLIC-specific prefix — distinct from the admin
+// path's "list: find page", so the admin RepoErrorWrapped test does not cover it.
+func TestListPublicMasterCards_FindPage_RepoError_Wrapped(t *testing.T) {
+	t.Parallel()
+	mc := &mockMasterCardReadRepo{findPageErr: eris.New("db boom")}
+	mcg := &mockMasterCardgroupReadRepo{
+		findPublishedByIDFn: func(string) (*domain.MasterCardgroup, error) { return publishedMasterDeck("id-1"), nil },
+	}
+	uc := newMasterCardUC(t, mc, mcg, true)
+	_, err := uc.ListPublicMasterCards(authedCtx("u1"), MasterCardConnectionInput{
+		MasterCardgroupID: "id-1",
+		First:             intPtr(5),
+	})
+	assertInternalChain(t, err, "usecase: master card: public list: find page")
+}
+
+// context.Canceled from the page query (the in-closure pass-through, distinct
+// from the gate's pass-through) must propagate unwrapped so its identity survives
+// errors.Is at the resolver boundary.
+func TestListPublicMasterCards_FindPage_PropagatesCancelled(t *testing.T) {
+	t.Parallel()
+	mc := &mockMasterCardReadRepo{findPageErr: context.Canceled}
+	mcg := &mockMasterCardgroupReadRepo{
+		findPublishedByIDFn: func(string) (*domain.MasterCardgroup, error) { return publishedMasterDeck("id-1"), nil },
+	}
+	uc := newMasterCardUC(t, mc, mcg, true)
+	_, err := uc.ListPublicMasterCards(authedCtx("u1"), MasterCardConnectionInput{
+		MasterCardgroupID: "id-1",
+		First:             intPtr(5),
+	})
+	assertCancelled(t, err)
+	require.Equal(t, context.Canceled, err, "expected unwrapped context.Canceled, got %v", err)
+}
+
+// context.Canceled surfaced during cursor hydration (resolveMasterCardCursor →
+// FindByID, reached when orderBy is non-ID) must propagate unwrapped end-to-end
+// through the public method. resolveMasterCardCursor is shared with the admin
+// path, but this pins that ListPublicMasterCards itself adds no wrap on that path
+// for the security-sensitive public endpoint.
+func TestListPublicMasterCards_CursorHydration_PropagatesCancelled(t *testing.T) {
+	t.Parallel()
+	mc := &mockMasterCardReadRepo{
+		findByIDFn: func(string) (*domain.MasterCard, error) { return nil, context.Canceled },
+	}
+	mcg := &mockMasterCardgroupReadRepo{
+		findPublishedByIDFn: func(string) (*domain.MasterCardgroup, error) { return publishedMasterDeck("id-1"), nil },
+	}
+	uc := newMasterCardUC(t, mc, mcg, true)
+	ob := MasterCardOrderByPosition // non-ID ordering triggers FindByID in resolveMasterCardCursor
+	after := cursor.Encode("cur-1")
+	_, err := uc.ListPublicMasterCards(authedCtx("u1"), MasterCardConnectionInput{
+		MasterCardgroupID: "id-1",
+		First:             intPtr(5),
+		After:             &after,
+		OrderBy:           &ob,
+	})
+	assertCancelled(t, err)
+	require.Equal(t, context.Canceled, err, "expected unwrapped context.Canceled, got %v", err)
+}

--- a/backend/internal/usecase/master_card_test.go
+++ b/backend/internal/usecase/master_card_test.go
@@ -199,19 +199,29 @@ func (panicMasterCardgroupRepo) Unpublish(_ context.Context, _ string) (*domain.
 	panic("not used in this test")
 }
 
-// mockMasterCardgroupReadRepo overrides FindByID (deck incl. DRAFT) and CountCards,
-// the only two methods MasterCardUsecase.AdminMaster consumes.
+// mockMasterCardgroupReadRepo overrides FindByID (deck incl. DRAFT), CountCards,
+// and FindPublishedByID (published-only deck). FindByID + CountCards back
+// MasterCardUsecase.AdminMaster; FindPublishedByID backs ListPublicMasterCards'
+// published-only visibility gate.
 type mockMasterCardgroupReadRepo struct {
 	panicMasterCardgroupRepo
 
-	findByIDFn    func(id string) (*domain.MasterCardgroup, error)
-	countCardsRes int64
-	countCardsErr error
+	findByIDFn          func(id string) (*domain.MasterCardgroup, error)
+	findPublishedByIDFn func(id string) (*domain.MasterCardgroup, error)
+	countCardsRes       int64
+	countCardsErr       error
 }
 
 func (m *mockMasterCardgroupReadRepo) FindByID(_ context.Context, id string) (*domain.MasterCardgroup, error) {
 	if m.findByIDFn != nil {
 		return m.findByIDFn(id)
+	}
+	return nil, repository.ErrNotFound
+}
+
+func (m *mockMasterCardgroupReadRepo) FindPublishedByID(_ context.Context, id string) (*domain.MasterCardgroup, error) {
+	if m.findPublishedByIDFn != nil {
+		return m.findPublishedByIDFn(id)
 	}
 	return nil, repository.ErrNotFound
 }

--- a/backend/internal/usecase/master_catalog.go
+++ b/backend/internal/usecase/master_catalog.go
@@ -98,6 +98,10 @@ type masterDeckUsecaseFacade interface {
 // admin methods additionally require AdminGate.Require to pass.
 type MasterCatalogUsecase interface {
 	ListPublishedConnection(ctx context.Context, in MasterCatalogConnectionInput) (*MasterCatalogConnectionOutput, error)
+	// FindPublishedMaster returns a single PUBLISHED master deck by id for any
+	// authenticated caller. Returns (nil, nil) for an unknown or DRAFT id
+	// (non-disclosure gate). Anonymous callers receive UNAUTHENTICATED.
+	FindPublishedMaster(ctx context.Context, id string) (*domain.MasterCardgroup, error)
 	ImportMaster(ctx context.Context, masterID string) (ImportMasterOutcome, error)
 	SeedDefaultStarters(ctx context.Context) ([]*domain.Cardgroup, error)
 
@@ -658,6 +662,28 @@ func (u *masterCatalogUsecase) ImportMaster(ctx context.Context, masterID string
 		return ImportMasterOutcome{}, eris.Wrap(err, "usecase: master catalog: import: copy master to user")
 	}
 	return ImportMasterOutcome{Cardgroup: cg}, nil
+}
+
+// FindPublishedMaster returns a single PUBLISHED master deck by id for any
+// authenticated caller. FindPublishedByID returns ErrNotFound for both unknown
+// ids and draft decks, so draft existence is never disclosed — both collapse to
+// a (nil, nil) result that the resolver maps to GraphQL null (non-disclosure
+// gate). Unauthenticated callers receive ucerr.ErrUnauthenticated.
+func (u *masterCatalogUsecase) FindPublishedMaster(ctx context.Context, id string) (*domain.MasterCardgroup, error) {
+	if auth.UserFrom(ctx) == nil {
+		return nil, ucerr.ErrUnauthenticated
+	}
+	deck, err := u.repo.FindPublishedByID(ctx, id)
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return nil, nil // unknown or draft → GraphQL null (non-disclosure)
+		}
+		if isContextDone(err) {
+			return nil, err
+		}
+		return nil, eris.Wrap(err, "usecase: master catalog: find published master")
+	}
+	return deck, nil
 }
 
 // SeedDefaultStarters copies the published default-starter master decks into the

--- a/backend/internal/usecase/master_catalog_test.go
+++ b/backend/internal/usecase/master_catalog_test.go
@@ -41,14 +41,14 @@ type mockMasterCatalogRepository struct {
 	countAdminRes   int64
 	countAdminErr   error
 	countAdminCalls []countPublishedCall
-	countCardsRes int64
-	countCardsErr error
-	createCalls   []*domain.MasterCardgroup
-	createErr     error
-	updateFn      func(id string, patch repository.MasterCardgroupUpdate) (*domain.MasterCardgroup, error)
-	deleteErr     error
-	publishFn     func(id string) (*domain.MasterCardgroup, error)
-	unpublishFn   func(id string) (*domain.MasterCardgroup, error)
+	countCardsRes   int64
+	countCardsErr   error
+	createCalls     []*domain.MasterCardgroup
+	createErr       error
+	updateFn        func(id string, patch repository.MasterCardgroupUpdate) (*domain.MasterCardgroup, error)
+	deleteErr       error
+	publishFn       func(id string) (*domain.MasterCardgroup, error)
+	unpublishFn     func(id string) (*domain.MasterCardgroup, error)
 }
 
 type findPublishedPageCall struct {
@@ -845,6 +845,86 @@ func TestImportMaster_CopyMasterToUser_ContextCancelled_PassesThrough(t *testing
 	uc := NewMasterCatalogUsecase(repo, copyUC, newTestAdminGate(true), newTestLogger())
 
 	_, err := uc.ImportMaster(authedCtx("u1"), "m1")
+	assertCancelled(t, err)
+	if err != context.Canceled {
+		t.Fatalf("expected unwrapped context.Canceled, got %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// FindPublishedMaster
+// ---------------------------------------------------------------------------
+
+func TestFindPublishedMaster_Unauthenticated(t *testing.T) {
+	uc := NewMasterCatalogUsecase(&mockMasterCatalogRepository{}, &mockCopyMasterToUserUC{}, newTestAdminGate(true), newTestLogger())
+
+	_, err := uc.FindPublishedMaster(context.Background(), "m1")
+	if !errors.Is(err, ucerr.ErrUnauthenticated) {
+		t.Fatalf("expected ErrUnauthenticated, got %v", err)
+	}
+}
+
+// A DRAFT or unknown deck surfaces from FindPublishedByID as ErrNotFound, which
+// FindPublishedMaster collapses to (nil, nil) so the resolver returns GraphQL
+// null — draft existence is never disclosed (non-disclosure gate).
+func TestFindPublishedMaster_DraftOrUnknown_ReturnsNil(t *testing.T) {
+	repo := &mockMasterCatalogRepository{
+		findPublishedByIDFn: func(string) (*domain.MasterCardgroup, error) { return nil, repository.ErrNotFound },
+	}
+	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, newTestAdminGate(true), newTestLogger())
+
+	got, err := uc.FindPublishedMaster(authedCtx("u1"), "missing")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected nil deck for unknown/draft id, got %+v", got)
+	}
+}
+
+func TestFindPublishedMaster_Success(t *testing.T) {
+	want := &domain.MasterCardgroup{ID: "m1", Name: domain.CardgroupName("Deck"), Status: domain.MasterStatusPublished, Version: 1}
+	repo := &mockMasterCatalogRepository{
+		findPublishedByIDFn: func(id string) (*domain.MasterCardgroup, error) {
+			if id != "m1" {
+				t.Fatalf("FindPublishedByID called with %q, want m1", id)
+			}
+			return want, nil
+		},
+	}
+	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, newTestAdminGate(true), newTestLogger())
+
+	got, err := uc.FindPublishedMaster(authedCtx("u1"), "m1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != want {
+		t.Fatalf("expected the published deck, got %+v", got)
+	}
+}
+
+// A non-ErrNotFound failure from FindPublishedByID (e.g. a DB outage) is an
+// internal error wrapped into the eris chain, not the nil-data non-disclosure path.
+func TestFindPublishedMaster_InfraError_Wrapped(t *testing.T) {
+	repo := &mockMasterCatalogRepository{
+		findPublishedByIDFn: func(string) (*domain.MasterCardgroup, error) { return nil, eris.New("db down") },
+	}
+	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, newTestAdminGate(true), newTestLogger())
+
+	_, err := uc.FindPublishedMaster(authedCtx("u1"), "m1")
+	assertInternalChain(t, err, "usecase: master catalog: find published master")
+}
+
+func TestFindPublishedMaster_ContextCancelled_PassesThrough(t *testing.T) {
+	// context.Canceled from the published-check must propagate unwrapped so its
+	// identity survives errors.Is at the resolver boundary (FromUsecaseError →
+	// CANCELLED). An eris.Wrap here would break the == identity contract.
+	repo := &mockMasterCatalogRepository{
+		findPublishedByIDFn: func(string) (*domain.MasterCardgroup, error) { return nil, context.Canceled },
+	}
+	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, newTestAdminGate(true), newTestLogger())
+
+	_, err := uc.FindPublishedMaster(authedCtx("u1"), "m1")
 	assertCancelled(t, err)
 	if err != context.Canceled {
 		t.Fatalf("expected unwrapped context.Canceled, got %v", err)

--- a/schema/master_card.graphql
+++ b/schema/master_card.graphql
@@ -32,6 +32,24 @@ extend type Query {
     masterCardgroupId: ID!, first: Int, after: ID, last: Int, before: ID,
     search: String, orderBy: MasterCardOrderBy = POSITION, orderDirection: SortOrder = ASC
   ): MasterCardConnection!
+  """
+  Public paginated cards in a PUBLISHED master deck, for any authenticated caller.
+  Forward (first, after) / backward (last, before). Cursor is the master card UUID.
+  Default page size 20; max 100. Optional case-insensitive substring search on
+  front OR back. A DRAFT or unknown deck is rejected as BAD_USER_INPUT on
+  `masterCardgroupId` (non-disclosure gate: draft existence is never revealed).
+  Anonymous callers receive UNAUTHENTICATED.
+  """
+  masterCardsConnection(
+    masterCardgroupId: ID!, first: Int, after: ID, last: Int, before: ID,
+    search: String, orderBy: MasterCardOrderBy = POSITION, orderDirection: SortOrder = ASC
+  ): MasterCardConnection!
+  """
+  A single PUBLISHED master deck by id, for any authenticated caller. Returns null
+  for an unknown or DRAFT id (non-disclosure gate). Anonymous callers receive
+  UNAUTHENTICATED. Mirrors `adminMaster(id)` but published-only and non-admin.
+  """
+  masterCardgroup(id: ID!): MasterCardgroup
 }
 
 """Input for creating a new master card in a master deck (admin-only)."""


### PR DESCRIPTION
## Summary

The public catalog (`/catalog`) lists master decks but exposes no public way to read a deck's individual cards — the only card-list query, `adminMasterCardsConnection`, is admin-only (FORBIDDEN for non-admins). The follow-up read-only deck-detail view at `/catalog/[id]` needs (1) a paginated public query for a PUBLISHED deck's cards and (2) a single PUBLISHED-deck lookup for the detail-header metadata on direct-landing / SSR.

This adds both, reusing the existing master-card pagination machinery behind a published-only visibility gate. No new repository methods, no interface widening, no constructor change — `masterCardUsecase` already holds `masterCardgroupRepo` whose interface already exposes `FindPublishedByID`.

Part of master-catalog **phase 2** (public catalog browse + import). Backend only; the frontend consumes these queries in the follow-up issue.

Closes #579

## Changes

### Schema (`schema/master_card.graphql`)

- Append two fields to the `extend type Query` block (after `adminMasterCardsConnection`):
  - `masterCardsConnection(masterCardgroupId, first, after, last, before, search, orderBy, orderDirection): MasterCardConnection!` — public paginated cards of a PUBLISHED deck. DRAFT/unknown deck → BAD_USER_INPUT on `masterCardgroupId` (non-disclosure gate); anonymous → UNAUTHENTICATED.
  - `masterCardgroup(id): MasterCardgroup` — single PUBLISHED deck; unknown/DRAFT → `null`; anonymous → UNAUTHENTICATED. Mirrors `adminMaster(id)` but published-only and non-admin.
- Reuses existing `MasterCardConnection` / `MasterCardEdge` / `MasterCardOrderBy` / `MasterCardgroup` — no new types.

### Usecase

- `internal/usecase/master_card.go` — `MasterCardUsecase.ListPublicMasterCards`. The page-assembly body mirrors `ListMasterCards`; only the gate differs — the admin gate is replaced by an `auth.UserFrom` check plus a published-only `FindPublishedByID` gate (`ErrNotFound` for both DRAFT and unknown → one validation error on `masterCardgroupId`, so the endpoint cannot be used as a draft-existence oracle). Adds the `auth` import.
- `internal/usecase/master_catalog.go` — `MasterCatalogUsecase.FindPublishedMaster`. Mirrors `ImportMaster`'s published gate: unknown/DRAFT collapse to `(nil, nil)` → GraphQL `null`; anonymous → `ErrUnauthenticated`; `context.Canceled` passes through unwrapped.

### Resolver (`graph/resolver/master_card.resolvers.go`)

- Implement the two generated stubs (`gqlgen` placed both in `master_card.resolvers.go` because the `follow-schema` layout groups resolvers by the schema file the fields are declared in). Each routes through the usecase and wraps errors via `gqlerr.FromUsecaseError`. `masterCardgroup` returns `cardCount = 0` by design — the frontend reads the live count from `masterCardsConnection.totalCount`.

### Tests

- `internal/usecase/master_card_public_test.go` (new) — `ListPublicMasterCards`: unauthenticated, draft/unknown → BAD_USER_INPUT, published-gate infra-error wrap, gate context-cancel pass-through, success (edges + search-aware totalCount + raw un-encoded cursors), whitespace-search normalization, page-fetch error wrap (public-specific prefix), page-fetch + cursor-hydration context-cancel pass-through.
- `internal/usecase/master_catalog_test.go` — `FindPublishedMaster`: unauthenticated, draft/unknown → nil, success, infra-error wrap, context-cancel pass-through.
- `internal/usecase/master_card_test.go` — `mockMasterCardgroupReadRepo` gains a `FindPublishedByID` override.
- `graph/resolver/master_card_resolver_test.go` — `MasterCardsConnection` happy path (asserts the public path, not admin, is invoked) + error-code wraps.
- `graph/resolver/master_catalog_query_test.go` — `MasterCardgroup` happy path, not-found → nil, error-code wraps.
- `cmd/server/main_test.go` — `panicQueryResolver` gains the two new `generated.QueryResolver` methods.

## Verification

- build ✓ (`go build ./...`) · vet ✓ (`go vet ./...`)
- test ✓ **1909 passing (26 packages)** — `go test -race -covermode=atomic ./...` (testcontainers integration included)
- go-arch-lint ✓ (no warnings) · schema-lint ✓ (0 violations, 0 drifts) · `pnpm lint:schema` ✓
- error-wrapping gates ✓ — no `fmt.Errorf("%w")`, no `&ucerr.*` struct literals in production
- CJK ✓ — no Japanese literals in changed source/schema
- Production diff: ~172 lines (well under the 800-line ceiling). `backend/graph/generated/` + `model/` are gitignored (CI regenerates).

## Test plan

- [ ] `masterCardsConnection(masterCardgroupId: <published>)` — returns the deck's cards as a Relay connection (edges, pageInfo, search-aware totalCount); `orderBy` / `search` honored.
- [ ] `masterCardsConnection(masterCardgroupId: <draft-or-unknown>)` — BAD_USER_INPUT with `extensions.field = "masterCardgroupId"`; a DRAFT id is indistinguishable from an unknown id.
- [ ] `masterCardgroup(id: <published>)` — returns the deck metadata; `masterCardgroup(id: <draft-or-unknown>)` — returns `null`.
- [ ] Anonymous caller on either query — UNAUTHENTICATED.
- [ ] `adminMasterCardsConnection` / `adminMaster` (admin-only) still behave unchanged for admins and FORBIDDEN for non-admins.
