### PR TITLE
fix(frontend): open card-row editor on mobile right-side tap

### DIFF
--- a/frontend/src/components/cardgroups/card-row.test.tsx
+++ b/frontend/src/components/cardgroups/card-row.test.tsx
@@ -103,8 +103,10 @@ describe("<CardRow>", () => {
   });
 
   it("keeps the checkbox and Delete controls above the mobile overlay (z-10)", () => {
-    // The stretched edit overlay would otherwise swallow taps on these controls;
-    // relative z-10 lifts them above the pseudo so they stay independently clickable.
+    // Both wrappers paint at relative z-10 above the stretched edit overlay. The
+    // checkbox stays an interactive control on mobile; the Delete wrapper's z-10 is
+    // only there so its desktop hover-reveal paints above the overlay (its mobile
+    // tap pass-through is asserted separately below).
     renderCardRow();
 
     const checkboxWrapper = screen.getByTestId(`card-select-${CARD.id}`).parentElement;
@@ -112,6 +114,26 @@ describe("<CardRow>", () => {
 
     const deleteWrapper = screen.getByTestId(`card-delete-${CARD.id}`).parentElement;
     expect(deleteWrapper?.className).toContain("z-10");
+  });
+
+  it("lets a mobile row tap fall through the Delete wrapper to the edit overlay", () => {
+    // Bug fix: the Delete wrapper is z-10 and stops propagation, so on mobile its box
+    // (the right-hand region of the row, where the hidden Delete button is laid out)
+    // intercepted the tap and the editor never opened — only the left text column did.
+    // pointer-events-none on mobile makes the wrapper transparent to taps so they reach
+    // the after:inset-0 edit overlay; sm:pointer-events-auto restores the desktop
+    // hover-to-delete behaviour. jsdom cannot model pointer-events hit-testing, so this
+    // is pinned statically on the className.
+    renderCardRow();
+
+    const deleteWrapper = screen.getByTestId(`card-delete-${CARD.id}`).parentElement;
+    expect(deleteWrapper?.className).toContain("pointer-events-none");
+    expect(deleteWrapper?.className).toContain("sm:pointer-events-auto");
+
+    // The checkbox stays an active control on mobile, so its wrapper must NOT be made
+    // pointer-events-none — taps there toggle selection rather than open the editor.
+    const checkboxWrapper = screen.getByTestId(`card-select-${CARD.id}`).parentElement;
+    expect(checkboxWrapper?.className).not.toContain("pointer-events-none");
   });
 
   it("wraps the row content in SwipeableRow", () => {

--- a/frontend/src/components/cardgroups/card-row.tsx
+++ b/frontend/src/components/cardgroups/card-row.tsx
@@ -52,10 +52,15 @@ export function CardRow({
         {/*
          * On mobile the Delete button is hidden (pointer-events-none), leaving a dead
          * non-interactive gap on the right. The after:inset-0 pseudo stretches this edit
-         * target across the whole row so any tap (including that gap) opens the editor;
-         * the checkbox and Delete siblings carry relative z-10 to stay above the overlay.
-         * sm:after:content-none removes the overlay at >=sm so desktop keeps its current
-         * behaviour (only the text column edits, Delete reveals on hover).
+         * target across the whole row so any tap (including that gap) opens the editor.
+         * The checkbox sibling keeps relative z-10 AND pointer events because it stays an
+         * active control on mobile. The Delete sibling is z-10 too (so its desktop
+         * hover-reveal paints above the overlay) but pointer-events-none on mobile, so its
+         * box does NOT swallow the tap — the tap falls through to the edit overlay instead
+         * of being stopped by the wrapper's stopPropagation. Without this the right-hand
+         * region (the Delete wrapper's box) was the one spot a row tap did NOT open the
+         * editor on mobile. sm:pointer-events-auto + sm:after:content-none restore the
+         * desktop behaviour: only the text column edits, Delete reveals + clicks on hover.
          */}
         {/* biome-ignore lint/a11y/useSemanticElements: a native <button> here would nest the action <button> for delete (invalid HTML); role="button" preserves screen-reader semantics without the markup conflict. */}
         <div
@@ -77,7 +82,7 @@ export function CardRow({
         </div>
         {/* biome-ignore lint/a11y/noStaticElementInteractions: div is a click/keydown stopper, not an interactive element; the inner Delete <button> is the actual control. */}
         <div
-          className="relative z-10 flex shrink-0 gap-2"
+          className="pointer-events-none sm:pointer-events-auto relative z-10 flex shrink-0 gap-2"
           onClick={(e) => e.stopPropagation()}
           onKeyDown={(e) => e.stopPropagation()}
         >


### PR DESCRIPTION
## Summary

On the cardgroup-detail card list (`/cardgroups/[id]/edit`, mobile `<sm`), tapping the **right-hand region of a card row** — the empty area where the hidden Delete button is laid out — did nothing, while tapping the left text column opened the edit popup. This makes the whole row tappable on mobile so a tap anywhere (including that right-hand gap) opens the card editor, which was already the intent. Desktop (`sm+`) behavior is unchanged.

No related GitHub issue (direct UX request from a mobile screenshot).

## Background / root cause

- `CardRow` stretches an `after:inset-0` pseudo-overlay on the edit target across the whole row so that, on mobile, a tap anywhere opens the editor; `sm:after:content-none` removes it so desktop keeps a text-column-only edit target.
- The Delete-button wrapper `div` carries `relative z-10` (so its desktop hover-reveal paints above the overlay) **and** `onClick={stopPropagation}`. It had no `pointer-events` gating, so on mobile its box sat above the overlay, caught the tap, and stopped propagation — the editor never opened in that region. The Delete button itself was already `pointer-events-none` on mobile, but the wrapper was not.
- Net effect: the right-hand strip of every row (the Delete wrapper's box) was the one spot a mobile row tap did not open the editor. The left text column worked because the overlay was unobstructed there.

## Changes

### `frontend/src/components/cardgroups/card-row.tsx`

- Add `pointer-events-none sm:pointer-events-auto` to the Delete-button wrapper. On mobile the wrapper (and its already-hidden button) become transparent to taps, so the tap falls through to the `after:inset-0` edit overlay and opens the editor. `sm:pointer-events-auto` restores the desktop hover-reveal + click-to-delete behavior unchanged.
- Reduced-motion delete affordance is preserved: the button's `motion-reduce:pointer-events-auto` re-enables itself even under a `pointer-events-none` wrapper.
- Update the layout docblock to describe the corrected behavior.
- `CardRow` is shared, so the admin master-cards editor (`/admin/masters/[id]/edit/cards`) gets the same fix consistently.

### `frontend/src/components/cardgroups/card-row.test.tsx`

- Add a static regression guard asserting the Delete wrapper carries `pointer-events-none sm:pointer-events-auto`, and that the checkbox wrapper is NOT made `pointer-events-none` (it stays an active mobile control). jsdom cannot model `pointer-events` hit-testing, so the guard is pinned on the className.
- Correct the now-inaccurate comment on the existing z-10 test.

## Verification

- typecheck ✓ (`tsc --noEmit`)
- lint ✓ (`biome check --error-on-warnings`, exit 0)
- knip ✓ (exit 0)
- test ✓ **1540 passing (164 files)** — `card-row` 8 pass including the new guard
- build ✓ (`next build`, exit 0)
- CJK ✓ — added comments are English only

> Note: this is a CSS `pointer-events` / hit-testing fix; jsdom cannot reproduce real tap routing, so the unit test is a static className guard. Final behavior is best confirmed on a real mobile browser (or responsive devtools at width `<640px`).

## Test plan

- [ ] `/cardgroups/[id]/edit` (mobile `<sm`) — tapping the **right-hand empty region** of a card row opens the edit popup (previously did nothing); tapping the left text column still opens it.
- [ ] Mobile selection mode (≥1 checkbox checked) — tapping a row's right region does not open the editor (rows are `disabled`); checkbox taps still toggle selection.
- [ ] Mobile swipe-to-delete still works (left swipe ≥40% deletes the row).
- [ ] Desktop (`sm+`) — unchanged: only the text column opens the editor; hovering a row reveals the Delete button and clicking it deletes (does not open the editor).
- [ ] Admin master-cards editor (`/admin/masters/[id]/edit/cards`, mobile) — the same right-region tap now opens the card editor.
