### PR TITLE
docs(readme): note optional UptimeRobot monitor in pre-conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Local development does not require any of these — `make setup` boots a local S
 
 **Notion sync (optional)** — set up a Notion integration token and page IDs to enable automated card imports. See `docs/notion-sync.md` for the full env-var matrix, local testing workflow, and production operational runbook.
 
+**Uptime monitoring (optional)** — [UptimeRobot](https://dashboard.uptimerobot.com/login?rt=false) pings the deployed services on a schedule to keep the Render free-tier backend warm and alert on downtime. See [`docs/deployment.md` § "Keep-alive ping workflow"](docs/deployment.md#keep-alive-ping-workflow) for the ping endpoint contract.
+
 ## Quick Start
 
 ### 1. Prerequisites


### PR DESCRIPTION
## Summary

The README Pre-conditions section listed only the three required deployment services (Supabase / Render / Vercel) plus the optional Notion sync, with no mention of the external uptime monitor that keeps the free-tier backend warm. This adds an optional **Uptime monitoring** note pointing at the UptimeRobot dashboard login used to keep-alive ping the deployed services, and cross-links the existing keep-alive ping runbook.

No related GitHub issue (direct documentation request).

## Background / Motivation

- The Render free tier sleeps idle services, so the first request after inactivity incurs a cold start; an external scheduled ping keeps the backend warm.
- UptimeRobot was already in operational use for that keep-alive ping but was undocumented — an operator reading Pre-conditions had no pointer to the monitor or its login.
- It is operational and optional (not required by `make setup-prod`), so it belongs alongside the existing "Notion sync (optional)" note rather than in the required-services bullet list.

## Changes

### `README.md`

- Add an **Uptime monitoring (optional)** note under Pre-conditions, mirroring the shape of the adjacent "Notion sync (optional)" note.
- Link the UptimeRobot dashboard login (`https://dashboard.uptimerobot.com/login?rt=false`).
- Anchor-link `docs/deployment.md` § "Keep-alive ping workflow" for the ping endpoint contract.

## Verification

- Anchor target ✓ — `## Keep-alive ping workflow` exists in `docs/deployment.md`, so `#keep-alive-ping-workflow` resolves to that section.
- English-only ✓ — added prose is ASCII/English, consistent with the existing README copy.
- Diff scope ✓ — `README.md` only, +2 lines.

## Test plan

- [ ] Render the README on GitHub — the new "Uptime monitoring (optional)" note appears under Pre-conditions, directly below "Notion sync (optional)".
- [ ] The UptimeRobot link opens the dashboard login page.
- [ ] The "Keep-alive ping workflow" anchor link jumps to that section in `docs/deployment.md` (not the page top).
