### PR TITLE
feat(frontend): move catalog deck import button below the deck title

### DIFF
--- a/frontend/src/app/catalog/[id]/catalog-deck-header.test.tsx
+++ b/frontend/src/app/catalog/[id]/catalog-deck-header.test.tsx
@@ -100,4 +100,22 @@ describe("<CatalogDeckHeader>", () => {
     expect(btn).toBeDisabled();
     expect(btn).toHaveTextContent("Imported");
   });
+
+  it("renders the import CTA full-width below the deck description, not in the app-bar", () => {
+    renderHeader(FULL_DECK);
+    const btn = screen.getByTestId("catalog-deck-import-deck-1");
+    // The CTA spans the content width rather than sitting in the right-aligned
+    // app-bar action cluster.
+    expect(btn).toHaveClass("w-full");
+    // It follows the description in document order (below the header content).
+    const description = screen.getByTestId("catalog-deck-description");
+    expect(
+      description.compareDocumentPosition(btn) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  it("keeps the import CTA full-width on a bare deck with no description", () => {
+    renderHeader(BARE_DECK);
+    expect(screen.getByTestId("catalog-deck-import-deck-2")).toHaveClass("w-full");
+  });
 });

--- a/frontend/src/app/catalog/[id]/catalog-deck-header.tsx
+++ b/frontend/src/app/catalog/[id]/catalog-deck-header.tsx
@@ -22,10 +22,12 @@ type CatalogDeckHeaderProps = {
 
 /**
  * Detail-page header for the public catalog deck view. Composes the shared
- * {@link DetailPageHeader} (inline back to `/catalog`, centered card count,
- * trailing "Import this deck" CTA) with the deck's catalog metadata — the
- * language / level / category badges (mirroring `CatalogListItem`) and the
- * description paragraph — rendered in the title-row slot below the app bar.
+ * {@link DetailPageHeader} (inline back to `/catalog`, centered card count) with
+ * the deck's catalog metadata — the language / level / category badges
+ * (mirroring `CatalogListItem`) and the description paragraph — and a full-width
+ * "Import this deck" CTA, all rendered in the title-row slot below the app bar.
+ * The CTA sits below the description rather than in the app-bar action cluster so
+ * it reads as the page's primary call to action.
  *
  * Import state (`importing` / `imported` / `onImport`) is owned by the client and
  * threaded in via props; this component holds no mutation state of its own.
@@ -49,15 +51,6 @@ export function CatalogDeckHeader({
           {t("cardCount", { count: cardCount })}
         </span>
       }
-      actions={
-        <CatalogImportButton
-          card={{ id: deck.id }}
-          importing={importing}
-          imported={imported}
-          onImport={onImport}
-          testIdPrefix="catalog-deck-import"
-        />
-      }
     >
       <div className="mt-3 flex flex-col items-center gap-2">
         {(deck.language || deck.level || deck.category) && (
@@ -75,6 +68,16 @@ export function CatalogDeckHeader({
             {deck.description}
           </p>
         )}
+      </div>
+      <div className="mt-4">
+        <CatalogImportButton
+          card={{ id: deck.id }}
+          importing={importing}
+          imported={imported}
+          onImport={onImport}
+          testIdPrefix="catalog-deck-import"
+          className="w-full"
+        />
       </div>
     </DetailPageHeader>
   );


### PR DESCRIPTION
## Summary

On the public catalog deck-detail view (`/catalog/[id]`), the **"Import this deck"** CTA moves out of the top-right app-bar action cluster and becomes a **full-width button below the deck description**, so it reads as the page's primary call to action instead of a small trailing toolbar button.

No tracking issue — this is a direct UX-placement request.

## Background / Motivation

The Import CTA previously sat in the `DetailPageHeader` `actions` slot (same row as the inline back affordance and the card count), where it competed with the app-bar chrome and was easy to miss on mobile. Promoting it to a full-width button directly under the title / badges / description makes the primary action unmistakable.

## Changes

- `frontend/src/app/catalog/[id]/catalog-deck-header.tsx`
  - Remove `CatalogImportButton` from the `DetailPageHeader` `actions` prop.
  - Render it instead below the badges / description block as a full-width button (`className="w-full"`), inside the title-row slot.
  - Update the component JSDoc to describe the new placement.

The `CatalogImportButton` component itself is unchanged — it keeps `variant="brand"` (the constructive-CTA coral, per the design-system rule that reserves red for danger), its three-state label logic (idle / in-flight / done), and the locale-independent `data-testid="catalog-deck-import-{id}"`. The app-bar keeps its `1fr/auto/1fr` grid, so the centered card-count stays centered with the action slot now empty.

## Tests

- `catalog-deck-header.test.tsx` — two regression guards added:
  - the import CTA carries `w-full` and follows the description in document order (below the header content, not in the app-bar);
  - a bare deck (no description) still renders the CTA full-width.
- All existing header / client tests are unchanged and pass — they target the button by `data-testid` (position-independent), which did not change.

## Verification

- `pnpm --filter frontend test` — **1576 passed / 168 files** (0 fail), including the 2 new guards (RED → GREEN confirmed).
- `tsc --noEmit` — pass.
- `biome check --error-on-warnings` (catalog) — clean.
- `knip` — clean.
- `pnpm --filter frontend build` — success.
- No CJK in changed source; no PR-order references.
