### PR TITLE
fix(frontend): match mobile detail-page content width to listing pages

### DIFF
--- a/frontend/src/app/admin/masters/[id]/edit/master-management-client.tsx
+++ b/frontend/src/app/admin/masters/[id]/edit/master-management-client.tsx
@@ -19,7 +19,7 @@ export function MasterManagementClient({
   initialTotalCount,
 }: Props) {
   return (
-    <main className="p-4 md:p-8">
+    <main className="p-8">
       {/* The header is rendered inside the cards section via the render-prop so
           its card count tracks the live Apollo-cache totalCount. The section
           forwards onBatchImport so the header's mobile overflow menu can host

--- a/frontend/src/app/cardgroups/[id]/edit/cardgroup-management-client.tsx
+++ b/frontend/src/app/cardgroups/[id]/edit/cardgroup-management-client.tsx
@@ -18,7 +18,7 @@ export function CardgroupManagementClient({
   initialTotalCount,
 }: Props) {
   return (
-    <main className="p-4 md:p-8">
+    <main className="p-8">
       <CardgroupCardsSection
         cardgroupId={cardgroup.id}
         cardgroupName={cardgroup.name}

--- a/frontend/src/app/catalog/[id]/_components/catalog-deck-skeleton.tsx
+++ b/frontend/src/app/catalog/[id]/_components/catalog-deck-skeleton.tsx
@@ -8,7 +8,7 @@ import { Skeleton } from "@/components/ui/skeleton";
  */
 export function CatalogDeckSkeleton() {
   return (
-    <main className="p-4 md:p-8">
+    <main className="p-8">
       <header className="mb-6">
         <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-2">
           <Skeleton className="h-5 w-5 justify-self-start" />

--- a/frontend/src/app/catalog/[id]/catalog-deck-client.tsx
+++ b/frontend/src/app/catalog/[id]/catalog-deck-client.tsx
@@ -151,7 +151,7 @@ export default function CatalogDeckClient({
         placeholder={tCards("searchPlaceholder")}
         ariaLabel={tCards("searchAriaLabel")}
       />
-      <main className="p-4 md:p-8">
+      <main className="p-8">
         <CatalogDeckHeader
           deck={initialDeck}
           cardCount={totalCount}


### PR DESCRIPTION
## Summary

On mobile, the detail / management screens rendered their content with a narrower side margin than the listing pages, so the content block sat closer to the screen edges than the cardgroup list. This unifies the mobile content width of those screens to match the listing pages.

No tracking issue — direct UX-consistency request.

## Background / Motivation

Listing pages render through `ListingPageShell`, whose `<main>` uses `p-8` (32px padding) at every breakpoint. The detail / management screens, by contrast, used `<main className="p-4 md:p-8">` — only **16px** padding on mobile, widening to 32px at `md` and up. The two layouts were therefore identical on desktop but diverged on mobile: the detail content extended ~16px closer to each edge than the listing content.

Removing the `md:` modifier collapses the mobile padding back onto the base `p-8`, so the detail screens match the listing width on mobile. Desktop is unaffected (it was already `p-8`), keeping the change strictly mobile-scoped.

## Changes

All four screens that shared the `p-4 md:p-8` `<main>` wrapper change to `p-8`:

- `frontend/src/app/cardgroups/[id]/edit/cardgroup-management-client.tsx`
- `frontend/src/app/admin/masters/[id]/edit/master-management-client.tsx`
- `frontend/src/app/catalog/[id]/catalog-deck-client.tsx`
- `frontend/src/app/catalog/[id]/_components/catalog-deck-skeleton.tsx` — updated alongside its client so the loading placeholder keeps the same width and there is no layout shift on hydration.

Each is a one-line className change; no logic, types, or copy are touched.

## Verification

- `pnpm --filter frontend test` — **1576 passed / 168 files** (0 fail). No test references the changed className, so no test changes were required.
- `tsc --noEmit` — pass.
- `biome check --error-on-warnings` (changed files) — clean.
- `knip` — clean.
- `pnpm --filter frontend build` — success.
- No CJK in changed source; no PR-order references.

## Test plan

- [ ] On a mobile viewport, open a cardgroup detail screen (`/cardgroups/[id]`) and the cardgroup list (`/cardgroups`); confirm the content blocks share the same left/right margin.
- [ ] Repeat for the master edit screen (`/admin/masters/[id]/edit`) and the catalog deck detail (`/catalog/[id]`).
- [ ] Confirm desktop (`md` and up) layout is visually unchanged on all four screens.
