### PR TITLE
feat(frontend): make catalog list row a single tap-to-view link

### DIFF
--- a/frontend/__tests__/catalog-deck.test.tsx
+++ b/frontend/__tests__/catalog-deck.test.tsx
@@ -260,7 +260,7 @@ describe("CatalogDeckPage — broad integration (RSC + deck-detail screen)", () 
 });
 
 describe("catalog list → deck-detail entry point", () => {
-  it("routes the list View button to /catalog/{id}", () => {
+  it("routes the whole list row to /catalog/{id}", () => {
     const node = makeFragmentData(
       {
         __typename: "MasterCardgroup" as const,
@@ -278,12 +278,12 @@ describe("catalog list → deck-detail entry point", () => {
     render(
       <NextIntlClientProvider locale="en" messages={enMessages} timeZone="UTC">
         <ul>
-          <CatalogListItem node={node} importing={false} imported={false} onImport={vi.fn()} />
+          <CatalogListItem node={node} />
         </ul>
       </NextIntlClientProvider>,
     );
 
-    expect(screen.getByTestId(`catalog-view-${DECK_ID}`)).toHaveAttribute(
+    expect(screen.getByTestId(`catalog-row-${DECK_ID}`)).toHaveAttribute(
       "href",
       `/catalog/${DECK_ID}`,
     );

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -94,7 +94,6 @@
     "importError": "Could not import the cardgroup. Please try again.",
     "sessionExpired": "Your session has expired. ",
     "signInAgain": "Sign in again",
-    "viewDeck": "View",
     "viewDeckAriaLabel": "View {name}",
     "backToCatalog": "Back to catalog",
     "deckEmpty": "This deck has no cards yet.",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -82,6 +82,8 @@
     "importing": "Importing...",
     "imported": "Imported",
     "cardCount": "{count, plural, one {# card} other {# cards}}",
+    "cardCountStat": "{count, number}",
+    "unitCards": "{count, plural, one {card} other {cards}}",
     "level": "Level {level}",
     "noDecks": "No cardgroups are available yet.",
     "noMatch": "No cardgroups match \"{query}\"",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -94,7 +94,6 @@
     "importError": "カードグループをインポートできませんでした。もう一度お試しください。",
     "sessionExpired": "セッションの有効期限が切れました。",
     "signInAgain": "再度ログイン",
-    "viewDeck": "見る",
     "viewDeckAriaLabel": "{name} を見る",
     "backToCatalog": "カタログに戻る",
     "deckEmpty": "このデッキにはまだカードがありません。",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -82,6 +82,8 @@
     "importing": "インポート中...",
     "imported": "インポート済み",
     "cardCount": "{count, plural, other {# 枚のカード}}",
+    "cardCountStat": "{count, number}",
+    "unitCards": "枚",
     "level": "レベル {level}",
     "noDecks": "利用可能なカードグループはまだありません。",
     "noMatch": "「{query}」に一致するカードグループはありません",

--- a/frontend/src/app/catalog/_components/catalog-skeleton.tsx
+++ b/frontend/src/app/catalog/_components/catalog-skeleton.tsx
@@ -3,8 +3,8 @@ import { Skeleton } from "@/components/ui/skeleton";
 
 /**
  * Loading placeholder for the /catalog route. Mirrors the resolved single-column
- * list layout (CatalogListItem rows — two-tier on mobile, single inline row on
- * sm+) to prevent CLS while the GraphQL fetch streams in.
+ * list layout (CatalogListItem rows — name + card-count stat over a badge row)
+ * to prevent CLS while the GraphQL fetch streams in.
  */
 export function CatalogSkeleton() {
   return (
@@ -20,12 +20,13 @@ export function CatalogSkeleton() {
       >
         {Array.from({ length: 6 }).map((_, i) => (
           // biome-ignore lint/suspicious/noArrayIndexKey: static placeholder rows have no stable id.
-          <li key={i} className="rounded-md border border-border">
-            <div className="flex flex-wrap items-center gap-x-3 gap-y-3 p-4 sm:py-3">
-              <Skeleton className="h-5 w-full sm:w-auto sm:flex-1" />
-              <Skeleton className="h-5 w-12 shrink-0" />
-              <Skeleton className="h-4 w-16 shrink-0" />
-              <Skeleton className="ml-auto h-10 w-24 shrink-0" />
+          <li key={i} className="rounded-md border border-border p-4 sm:py-3">
+            <div className="flex items-baseline gap-3">
+              <Skeleton className="h-5 min-w-0 flex-1" />
+              <Skeleton className="h-5 w-14 shrink-0" />
+            </div>
+            <div className="mt-1.5 flex items-center gap-2">
+              <Skeleton className="h-4 w-32" />
             </div>
           </li>
         ))}

--- a/frontend/src/app/catalog/catalog-client.test.tsx
+++ b/frontend/src/app/catalog/catalog-client.test.tsx
@@ -14,7 +14,9 @@ import CatalogClient from "./catalog-client";
 import { CATALOG_DEFAULT_VARS } from "./queries";
 
 // ---------------------------------------------------------------------------
-// next/link stub
+// next/link stub — CatalogClient no longer imports Link directly; the stub is
+// needed because CatalogClient renders <CatalogListItem>, which imports
+// next/link and renders <Link href={`/catalog/${id}`}>.
 // ---------------------------------------------------------------------------
 vi.mock("next/link", () => ({
   default: ({

--- a/frontend/src/app/catalog/catalog-client.test.tsx
+++ b/frontend/src/app/catalog/catalog-client.test.tsx
@@ -1,16 +1,10 @@
 // @vitest-environment jsdom
 import { InMemoryCache } from "@apollo/client";
 import { MockedProvider } from "@apollo/client/testing/react";
-import { act, screen, waitFor } from "@testing-library/react";
+import { act, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { GraphQLError } from "graphql";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { CARDGROUPS_DEFAULT_VARS } from "@/app/cardgroups/queries";
-import {
-  ImportMasterCardgroupDocument,
-  MasterCatalogDocument,
-  MyCardgroupsConnectionDocument,
-} from "@/generated/graphql";
+import { MasterCatalogDocument } from "@/generated/graphql";
 import { renderWithIntl } from "@/test/render-with-intl";
 import {
   type ApolloMockLeakSpyResult,
@@ -18,16 +12,6 @@ import {
 } from "../../../__tests__/utils/mock-apollo-paginated";
 import CatalogClient from "./catalog-client";
 import { CATALOG_DEFAULT_VARS } from "./queries";
-
-// ---------------------------------------------------------------------------
-// sonner mock — capture the success toast.
-// ---------------------------------------------------------------------------
-vi.mock("sonner", () => ({
-  toast: vi.fn(),
-  Toaster: () => null,
-}));
-
-import { toast } from "sonner";
 
 // ---------------------------------------------------------------------------
 // next/link stub
@@ -138,7 +122,7 @@ let leakSpy: ApolloMockLeakSpyResult;
 
 beforeEach(() => {
   leakSpy = installApolloMockLeakSpy({
-    operationNames: ["MasterCatalog", "ImportMasterCardgroup"],
+    operationNames: ["MasterCatalog"],
   });
   ioCallbacks = [];
   vi.stubGlobal("IntersectionObserver", FakeIntersectionObserver);
@@ -187,8 +171,7 @@ describe("<CatalogClient>", () => {
 
     expect(await screen.findByText("Business English")).toBeInTheDocument();
     expect(screen.getByText("JLPT N3 Kanji")).toBeInTheDocument();
-    expect(screen.getByTestId("catalog-import-m-1")).toBeInTheDocument();
-    expect(screen.getByTestId("catalog-import-m-2")).toBeInTheDocument();
+    expect(screen.getByTestId("catalog-row-m-1")).toHaveAttribute("href", "/catalog/m-1");
   });
 
   it("renders the empty state when no decks are published", async () => {
@@ -196,82 +179,6 @@ describe("<CatalogClient>", () => {
     renderClient([], makeConnection([]), cache);
 
     expect(await screen.findByTestId("catalog-empty")).toBeInTheDocument();
-  });
-
-  it("imports a deck on success: marks it imported and prepends it to the cardgroups cache", async () => {
-    const user = userEvent.setup();
-    const cache = new InMemoryCache();
-    const importMock = {
-      request: {
-        query: ImportMasterCardgroupDocument,
-        variables: { masterCardgroupId: "m-1" },
-      },
-      result: {
-        data: {
-          importMasterCardgroup: {
-            __typename: "ImportMasterCardgroupSuccess",
-            cardgroup: {
-              __typename: "Cardgroup",
-              id: "cg-new",
-              name: "Business English",
-              updatedAt: "2026-06-13T00:00:00.000Z",
-            },
-          },
-        },
-      },
-    };
-
-    renderClient([importMock], makeConnection([M1]), cache);
-
-    const importBtn = await screen.findByTestId("catalog-import-m-1");
-    await user.click(importBtn);
-
-    // The button flips to the "Imported" affordance and disables.
-    await waitFor(() => {
-      const btn = screen.getByTestId("catalog-import-m-1");
-      expect(btn).toBeDisabled();
-      expect(btn).toHaveTextContent("Imported");
-    });
-    expect(vi.mocked(toast)).toHaveBeenCalledWith('Added "Business English" to your cardgroups.');
-
-    // The imported deck is prepended to the /cardgroups connection cache.
-    const snapshot = cache.readQuery({
-      query: MyCardgroupsConnectionDocument,
-      variables: CARDGROUPS_DEFAULT_VARS,
-    }) as {
-      myCardgroupsConnection: { edges: { node: { id: string } }[]; totalCount: number };
-    } | null;
-    expect(snapshot?.myCardgroupsConnection.edges[0]?.node.id).toBe("cg-new");
-    expect(snapshot?.myCardgroupsConnection.totalCount).toBe(1);
-  });
-
-  it("surfaces a banner when the import returns MasterNotFoundError", async () => {
-    const user = userEvent.setup();
-    const cache = new InMemoryCache();
-    const importMock = {
-      request: {
-        query: ImportMasterCardgroupDocument,
-        variables: { masterCardgroupId: "m-1" },
-      },
-      result: {
-        data: {
-          importMasterCardgroup: {
-            __typename: "MasterNotFoundError",
-            message: "master not found",
-          },
-        },
-      },
-    };
-
-    renderClient([importMock], makeConnection([M1]), cache);
-
-    await user.click(await screen.findByTestId("catalog-import-m-1"));
-
-    expect(await screen.findByTestId("catalog-import-error")).toHaveTextContent(
-      "This cardgroup is no longer available.",
-    );
-    // The button is NOT marked imported on a not-found outcome.
-    expect(screen.getByTestId("catalog-import-m-1")).not.toBeDisabled();
   });
 
   it("appends the next page when the sentinel intersects", async () => {
@@ -325,27 +232,6 @@ describe("<CatalogClient>", () => {
     expect(await screen.findByText("JLPT N3 Kanji")).toBeInTheDocument();
   });
 
-  it("surfaces a banner when the import throws a transport error", async () => {
-    const user = userEvent.setup();
-    const cache = new InMemoryCache();
-    const importErrorMock = {
-      request: {
-        query: ImportMasterCardgroupDocument,
-        variables: { masterCardgroupId: "m-1" },
-      },
-      error: new Error("network down"),
-    };
-
-    renderClient([importErrorMock], makeConnection([M1]), cache);
-
-    await user.click(await screen.findByTestId("catalog-import-m-1"));
-
-    expect(await screen.findByTestId("catalog-import-error")).toHaveTextContent(
-      "Could not import the cardgroup.",
-    );
-    expect(screen.getByTestId("catalog-import-m-1")).not.toBeDisabled();
-  });
-
   it("debounces search input and refetches with the search variable", async () => {
     const user = userEvent.setup();
     const cache = new InMemoryCache();
@@ -371,30 +257,6 @@ describe("<CatalogClient>", () => {
     expect(screen.queryByText("Business English")).not.toBeInTheDocument();
   });
 
-  it("surfaces the sign-in banner when the import fails with UNAUTHENTICATED", async () => {
-    const user = userEvent.setup();
-    const cache = new InMemoryCache();
-    const importAuthMock = {
-      request: {
-        query: ImportMasterCardgroupDocument,
-        variables: { masterCardgroupId: "m-1" },
-      },
-      result: {
-        errors: [new GraphQLError("unauthenticated", { extensions: { code: "UNAUTHENTICATED" } })],
-      },
-    };
-
-    renderClient([importAuthMock], makeConnection([M1]), cache);
-
-    await user.click(await screen.findByTestId("catalog-import-m-1"));
-
-    expect(await screen.findByTestId("catalog-import-auth-error")).toBeInTheDocument();
-    const signInLink = screen.getByRole("link", { name: /sign in again/i });
-    expect(signInLink).toHaveAttribute("href", "/login");
-    // The card is NOT marked imported on an auth failure.
-    expect(screen.getByTestId("catalog-import-m-1")).not.toBeDisabled();
-  });
-
   it("warns and falls back to a network fetch when the SSR seed is null", async () => {
     const cache = new InMemoryCache();
     // No initialConnection ⇒ no cache seed ⇒ cache-first useQuery must fetch.
@@ -411,47 +273,6 @@ describe("<CatalogClient>", () => {
     expect(console.warn).toHaveBeenCalledWith(
       expect.stringContaining("[catalog-client] initialConnection is null"),
     );
-  });
-
-  it("serializes imports: a second import click is ignored while one is in flight", async () => {
-    const user = userEvent.setup();
-    const cache = new InMemoryCache();
-    // Only m-1 has a mock; the serialize guard must keep m-2 from firing a second
-    // mutation (an unmatched m-2 request would trip the leak spy in teardown).
-    const slowImportMock = {
-      request: {
-        query: ImportMasterCardgroupDocument,
-        variables: { masterCardgroupId: "m-1" },
-      },
-      delay: 50,
-      result: {
-        data: {
-          importMasterCardgroup: {
-            __typename: "ImportMasterCardgroupSuccess",
-            cardgroup: {
-              __typename: "Cardgroup",
-              id: "cg-new",
-              name: "Business English",
-              updatedAt: "2026-06-13T00:00:00.000Z",
-            },
-          },
-        },
-      },
-    };
-
-    renderClient([slowImportMock], makeConnection([M1, M2]), cache);
-
-    await user.click(await screen.findByTestId("catalog-import-m-1"));
-    // While m-1 is in flight, clicking m-2 must be a no-op (importingId guard).
-    await user.click(screen.getByTestId("catalog-import-m-2"));
-
-    // m-1 eventually completes (delayed mock) and flips to "Imported"; m-2 never imports.
-    await waitFor(() => {
-      const btn = screen.getByTestId("catalog-import-m-1");
-      expect(btn).toBeDisabled();
-      expect(btn).toHaveTextContent("Imported");
-    });
-    expect(screen.getByTestId("catalog-import-m-2")).not.toBeDisabled();
   });
 
   it("renders the no-match empty state when a search returns no decks", async () => {
@@ -471,29 +292,6 @@ describe("<CatalogClient>", () => {
     await user.type(screen.getByTestId("catalog-search"), "zzz");
 
     expect(await screen.findByTestId("catalog-empty-search")).toBeInTheDocument();
-  });
-
-  it("surfaces the error banner when import resolves with an unknown payload variant", async () => {
-    const user = userEvent.setup();
-    const cache = new InMemoryCache();
-    // A union variant the client was not regenerated against → the hook's
-    // unparseable-payload fallthrough returns `rejected`.
-    const unknownPayloadMock = {
-      request: {
-        query: ImportMasterCardgroupDocument,
-        variables: { masterCardgroupId: "m-1" },
-      },
-      result: { data: { importMasterCardgroup: { __typename: "SomeFutureVariant" } } },
-    };
-
-    renderClient([unknownPayloadMock], makeConnection([M1]), cache);
-
-    await user.click(await screen.findByTestId("catalog-import-m-1"));
-
-    expect(await screen.findByTestId("catalog-import-error")).toHaveTextContent(
-      "Could not import the cardgroup.",
-    );
-    expect(screen.getByTestId("catalog-import-m-1")).not.toBeDisabled();
   });
 });
 

--- a/frontend/src/app/catalog/catalog-client.tsx
+++ b/frontend/src/app/catalog/catalog-client.tsx
@@ -2,10 +2,8 @@
 
 import { NetworkStatus } from "@apollo/client";
 import { useApolloClient } from "@apollo/client/react";
-import Link from "next/link";
 import { useTranslations } from "next-intl";
-import { useCallback, useMemo, useRef, useState } from "react";
-import { toast } from "sonner";
+import { useMemo, useRef } from "react";
 import { ListingPageShell } from "@/components/layout/listing-page-shell";
 import { SearchTakeoverBar } from "@/components/search/search-takeover-bar";
 import { Button } from "@/components/ui/button";
@@ -20,7 +18,6 @@ import { EMPTY_PAGE_INFO } from "@/lib/pagination/empty-page-info";
 import { useConnectionPagination } from "@/lib/pagination/use-connection-pagination";
 import { CatalogListItem } from "./catalog-list-item";
 import { CATALOG_DEFAULT_VARS } from "./queries";
-import { useImportMaster } from "./use-import-master";
 
 type Connection = MasterCatalogQuery["masterCatalog"];
 type CatalogEdge = Connection["edges"][number];
@@ -67,9 +64,6 @@ function mergeCatalogConnection(
  *    useRef<boolean> (per docs/pagination/intersection-observer-in-flight-guard.md).
  *  - fetchMoreError halt gate — the observer short-circuits while an error banner
  *    is showing; the user must click Retry to resume.
- *  - Per-item Import via useImportMaster, surfacing success / not-found / auth /
- *    rejection. On success the imported deck is prepended to the /cardgroups
- *    connection cache inside the hook.
  */
 export default function CatalogClient({ initialConnection }: CatalogClientProps) {
   const apollo = useApolloClient();
@@ -78,16 +72,6 @@ export default function CatalogClient({ initialConnection }: CatalogClientProps)
 
   const search = useHeaderTakeoverSearch();
   const searchQuery = search.query;
-
-  // Import state. `importingId` serializes imports to one at a time;
-  // `importedIds` drives the per-card "Imported" affordance.
-  const { importMasterCardgroup } = useImportMaster();
-  const [importingId, setImportingId] = useState<string | null>(null);
-  const [importedIds, setImportedIds] = useState<ReadonlySet<string>>(() => new Set());
-  const [importError, setImportError] = useState<string | null>(null);
-  const [importAuthError, setImportAuthError] = useState<"unauthenticated" | "forbidden" | null>(
-    null,
-  );
 
   // Strict Mode double-mount safety: only write the SSR seed into the cache once.
   const seededRef = useRef(false);
@@ -157,40 +141,6 @@ export default function CatalogClient({ initialConnection }: CatalogClientProps)
   });
   const hasNextPage = pageInfo.hasNextPage;
 
-  const handleImport = useCallback(
-    async (id: string) => {
-      // Serialize: ignore a second click while another import is in flight.
-      if (importingId !== null) return;
-      setImportError(null);
-      setImportAuthError(null);
-      setImportingId(id);
-
-      const outcome = await importMasterCardgroup(id);
-      setImportingId(null);
-
-      switch (outcome.status) {
-        case "success":
-          setImportedIds((prev) => {
-            const next = new Set(prev);
-            next.add(id);
-            return next;
-          });
-          toast(t("importSuccess", { name: outcome.cardgroupName }));
-          return;
-        case "not_found":
-          setImportError(t("importNotFound"));
-          return;
-        case "auth":
-          setImportAuthError(outcome.kind);
-          return;
-        case "rejected":
-          setImportError(t("importError"));
-          return;
-      }
-    },
-    [importingId, importMasterCardgroup, t],
-  );
-
   const initialLoading = loading && edges.length === 0 && networkStatus !== NetworkStatus.fetchMore;
   const hasSearch = searchQuery !== null && searchQuery !== "";
 
@@ -221,19 +171,6 @@ export default function CatalogClient({ initialConnection }: CatalogClientProps)
           </div>
         }
       >
-        {importAuthError ? (
-          <ErrorBanner data-testid="catalog-import-auth-error">
-            <span>{t("sessionExpired")}</span>
-            <Link href="/login" className="underline">
-              {t("signInAgain")}
-            </Link>
-          </ErrorBanner>
-        ) : null}
-
-        {importError ? (
-          <ErrorBanner data-testid="catalog-import-error">{importError}</ErrorBanner>
-        ) : null}
-
         {initialLoading && (
           <p className="text-sm text-muted-foreground" data-testid="catalog-loading">
             {tCommon("loading")}
@@ -255,13 +192,7 @@ export default function CatalogClient({ initialConnection }: CatalogClientProps)
         {edges.length > 0 && (
           <ul className="space-y-2" data-testid="catalog-list">
             {edges.map((edge) => (
-              <CatalogListItem
-                key={edge.cursor}
-                node={edge.node}
-                importing={importingId === edge.node.id}
-                imported={importedIds.has(edge.node.id)}
-                onImport={handleImport}
-              />
+              <CatalogListItem key={edge.cursor} node={edge.node} />
             ))}
           </ul>
         )}

--- a/frontend/src/app/catalog/catalog-client.tsx
+++ b/frontend/src/app/catalog/catalog-client.tsx
@@ -58,10 +58,10 @@ function mergeCatalogConnection(
  *    renders immediately without a network round-trip. CATALOG_DEFAULT_VARS keeps
  *    the cache key identical to the SSR seed and the client useQuery — any
  *    mismatch silently splits the cache.
- *  - Debounced search (300ms; searchInput → searchQuery), passed as the `search`
+ *  - Debounced search (300ms; search.input → searchQuery), passed as the `search`
  *    variable on MasterCatalogQuery.
- *  - Infinite scroll via IntersectionObserver, with an in-flight guard via
- *    useRef<boolean> (per docs/pagination/intersection-observer-in-flight-guard.md).
+ *  - Infinite scroll via useConnectionPagination, which owns the IntersectionObserver
+ *    and the in-flight useRef<boolean> guard (per docs/pagination/intersection-observer-in-flight-guard.md).
  *  - fetchMoreError halt gate — the observer short-circuits while an error banner
  *    is showing; the user must click Retry to resume.
  */

--- a/frontend/src/app/catalog/catalog-list-item.test.tsx
+++ b/frontend/src/app/catalog/catalog-list-item.test.tsx
@@ -62,6 +62,7 @@ describe("<CatalogListItem>", () => {
     expect(screen.getByText("100")).toBeInTheDocument();
     expect(screen.queryByText(/^Level /)).not.toBeInTheDocument();
     expect(screen.queryByText("Business")).not.toBeInTheDocument();
+    expect(screen.queryByText("en")).not.toBeInTheDocument();
   });
 
   it("renders the singular card unit when the deck has exactly one card", () => {
@@ -99,11 +100,19 @@ describe("<CatalogListItem>", () => {
     expect(screen.queryByRole("button")).toBeNull();
     expect(screen.queryByTestId("catalog-import-m-1")).toBeNull();
     expect(screen.queryByTestId("catalog-view-m-1")).toBeNull();
+    expect(screen.getByText("›")).toHaveAttribute("aria-hidden", "true");
   });
 
   it("keeps the description in the DOM (revealed on hover/focus via CSS)", () => {
     renderItem(FULL_NODE);
-    expect(screen.getByText("Professional vocabulary")).toBeInTheDocument();
+    const desc = screen.getByTestId("catalog-row-desc-m-1");
+    expect(desc).toHaveTextContent("Professional vocabulary");
+    const revealWrapper = desc.closest("div.grid");
+    expect(revealWrapper?.className).toContain("grid-rows-[0fr]");
+    expect(revealWrapper?.className).toContain("opacity-0");
+    expect(revealWrapper?.className).toContain("group-hover:grid-rows-[1fr]");
+    expect(revealWrapper?.className).toContain("group-focus-within:grid-rows-[1fr]");
+    expect(revealWrapper?.className).toContain("motion-reduce:transition-none");
   });
 
   it("renders no description node when the deck has none", () => {

--- a/frontend/src/app/catalog/catalog-list-item.test.tsx
+++ b/frontend/src/app/catalog/catalog-list-item.test.tsx
@@ -64,6 +64,29 @@ describe("<CatalogListItem>", () => {
     expect(screen.queryByText("Business")).not.toBeInTheDocument();
   });
 
+  it("renders the singular card unit when the deck has exactly one card", () => {
+    const oneCardNode = makeFragmentData(
+      {
+        __typename: "MasterCardgroup" as const,
+        id: "m-3",
+        name: "Single Card Deck",
+        description: null,
+        language: null,
+        level: null,
+        category: null,
+        cardCount: 1,
+      },
+      CatalogCardFieldsFragment,
+    );
+    renderWithIntl(
+      <ul>
+        <CatalogListItem node={oneCardNode} />
+      </ul>,
+    );
+    expect(screen.getByText("1")).toBeInTheDocument();
+    expect(screen.getByText("card")).toBeInTheDocument();
+  });
+
   it("renders the whole row as a single link to the deck-detail page", () => {
     renderItem(FULL_NODE);
     const row = screen.getByTestId("catalog-row-m-1");

--- a/frontend/src/app/catalog/catalog-list-item.test.tsx
+++ b/frontend/src/app/catalog/catalog-list-item.test.tsx
@@ -1,7 +1,6 @@
 // @vitest-environment jsdom
 import { screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { CatalogCardFieldsFragment } from "@/app/catalog/queries";
 import { makeFragmentData } from "@/generated/fragment-masking";
 import { renderWithIntl } from "@/test/render-with-intl";
@@ -19,7 +18,7 @@ const FULL_NODE = makeFragmentData(
     language: "en",
     level: "B2",
     category: "Business",
-    cardCount: 42,
+    cardCount: 1245,
   },
   CatalogCardFieldsFragment,
 );
@@ -38,114 +37,54 @@ const BARE_NODE = makeFragmentData(
   CatalogCardFieldsFragment,
 );
 
-function renderItem(
-  node: typeof FULL_NODE,
-  props: Partial<{ importing: boolean; imported: boolean; onImport: (id: string) => void }> = {},
-) {
-  const onImport = props.onImport ?? vi.fn();
+function renderItem(node: typeof FULL_NODE) {
   renderWithIntl(
     <ul>
-      <CatalogListItem
-        node={node}
-        importing={props.importing ?? false}
-        imported={props.imported ?? false}
-        onImport={onImport}
-      />
+      <CatalogListItem node={node} />
     </ul>,
   );
-  return { onImport };
 }
 
 describe("<CatalogListItem>", () => {
-  it("renders name, card count, and metadata badges when present", () => {
+  it("renders name, the grouped card-count stat with its unit, and badges", () => {
     renderItem(FULL_NODE);
     expect(screen.getByText("Business English")).toBeInTheDocument();
-    expect(screen.getByText("42 cards")).toBeInTheDocument();
+    expect(screen.getByText("1,245")).toBeInTheDocument();
+    expect(screen.getByText("cards")).toBeInTheDocument();
     expect(screen.getByText("en")).toBeInTheDocument();
     expect(screen.getByText("Level B2")).toBeInTheDocument();
     expect(screen.getByText("Business")).toBeInTheDocument();
   });
 
-  it("does not render the description text", () => {
-    renderItem(FULL_NODE);
-    expect(screen.queryByText("Professional vocabulary")).not.toBeInTheDocument();
-  });
-
-  it("omits all metadata badges when those fields are null", () => {
+  it("renders the name and stat but omits badges when those fields are null", () => {
     renderItem(BARE_NODE);
     expect(screen.getByText("JLPT N3 Kanji")).toBeInTheDocument();
-    expect(screen.getByText("100 cards")).toBeInTheDocument();
+    expect(screen.getByText("100")).toBeInTheDocument();
     expect(screen.queryByText(/^Level /)).not.toBeInTheDocument();
     expect(screen.queryByText("Business")).not.toBeInTheDocument();
-    expect(screen.queryByText("en")).not.toBeInTheDocument();
   });
 
-  it("disables the button and shows the in-flight label while importing", () => {
-    renderItem(FULL_NODE, { importing: true });
-    const btn = screen.getByTestId("catalog-import-m-1");
-    expect(btn).toBeDisabled();
-    expect(btn).toHaveTextContent("Importing...");
+  it("renders the whole row as a single link to the deck-detail page", () => {
+    renderItem(FULL_NODE);
+    const row = screen.getByTestId("catalog-row-m-1");
+    expect(row).toHaveAttribute("href", "/catalog/m-1");
+    expect(row).toHaveAttribute("aria-label", "View Business English");
   });
 
-  it("disables the button and shows the imported label once imported", () => {
-    renderItem(FULL_NODE, { imported: true });
-    const btn = screen.getByTestId("catalog-import-m-1");
-    expect(btn).toBeDisabled();
-    expect(btn).toHaveTextContent("Imported");
-  });
-
-  it("calls onImport with the deck id when the idle button is clicked", async () => {
-    const user = userEvent.setup();
-    const onImport = vi.fn();
-    renderItem(FULL_NODE, { onImport });
-    await user.click(screen.getByTestId("catalog-import-m-1"));
-    expect(onImport).toHaveBeenCalledWith("m-1");
-  });
-
-  it("uses custom labels and a custom testId prefix when provided", () => {
-    renderWithIntl(
-      <ul>
-        <CatalogListItem
-          node={FULL_NODE}
-          importing={false}
-          imported={false}
-          onImport={vi.fn()}
-          labels={{ action: "Start with this deck", inProgress: "Starting...", done: "Added" }}
-          testIdPrefix="onboarding-deck"
-        />
-      </ul>,
-    );
-    const btn = screen.getByTestId("onboarding-deck-m-1");
-    expect(btn).toHaveTextContent("Start with this deck");
+  it("renders no Import or View button (actions moved to the detail page)", () => {
+    renderItem(FULL_NODE);
+    expect(screen.queryByRole("button")).toBeNull();
     expect(screen.queryByTestId("catalog-import-m-1")).toBeNull();
+    expect(screen.queryByTestId("catalog-view-m-1")).toBeNull();
   });
 
-  it("does not call onImport when the button is in the imported state", async () => {
-    const user = userEvent.setup();
-    const onImport = vi.fn();
-    renderItem(FULL_NODE, { imported: true, onImport });
-    await user.click(screen.getByTestId("catalog-import-m-1"));
-    expect(onImport).not.toHaveBeenCalled();
-  });
-
-  it("exposes a locale-independent row testId on the list item", () => {
+  it("keeps the description in the DOM (revealed on hover/focus via CSS)", () => {
     renderItem(FULL_NODE);
-    expect(screen.getByTestId("catalog-row-m-1")).toBeInTheDocument();
+    expect(screen.getByText("Professional vocabulary")).toBeInTheDocument();
   });
 
-  it("renders a View link routing to the deck-detail page", () => {
-    renderItem(FULL_NODE);
-    const view = screen.getByTestId("catalog-view-m-1");
-    expect(view).toHaveAttribute("href", "/catalog/m-1");
-    expect(view).toHaveTextContent("View");
-    expect(view).toHaveAttribute("aria-label", "View Business English");
-  });
-
-  it("shows the imported label when both importing and imported are true (imported wins)", () => {
-    renderItem(FULL_NODE, { importing: true, imported: true });
-    const btn = screen.getByTestId("catalog-import-m-1");
-    expect(btn).toBeDisabled();
-    expect(btn).toHaveTextContent("Imported");
-    expect(btn).not.toHaveTextContent("Importing...");
+  it("renders no description node when the deck has none", () => {
+    renderItem(BARE_NODE);
+    expect(screen.queryByTestId("catalog-row-desc-m-2")).toBeNull();
   });
 });

--- a/frontend/src/app/catalog/catalog-list-item.tsx
+++ b/frontend/src/app/catalog/catalog-list-item.tsx
@@ -6,6 +6,11 @@ import { CatalogCardFieldsFragment } from "@/app/catalog/queries";
 import { Badge } from "@/components/ui/badge";
 import { type FragmentType, useFragment } from "@/generated/fragment-masking";
 
+/**
+ * Props for {@link CatalogListItem}. The component is intentionally stateless and
+ * navigation-only — the whole row is a single Link and renders no other
+ * interactive element; all actions (e.g. Import) belong on the detail page.
+ */
 export type CatalogListItemProps = {
   /** A masked `CatalogCardFields` ref — unmasked once via `useFragment` below. */
   node: FragmentType<typeof CatalogCardFieldsFragment>;
@@ -78,9 +83,12 @@ export function CatalogListItem({ node }: CatalogListItemProps) {
 
         {/* Tier 3: description — collapsed by default, revealed on hover / focus
             (desktop progressive enhancement) via a grid-rows 0fr→1fr transition.
-            Always in the DOM for screen readers; visually hidden on touch (no
-            hover), where the deck's detail page carries the description instead. */}
-        {card.description && (
+            Tailwind's `group-hover:` compiles under `@media (hover: hover)`, so it
+            never fires on touch; `group-focus-within:` keeps the keyboard reveal (a
+            brief, harmless expand on a touch tap before navigation). Always in the
+            DOM for screen readers; the deck's detail page carries the description
+            for mobile-first discovery. */}
+        {card.description?.trim() && (
           <div className="grid grid-rows-[0fr] opacity-0 transition-[grid-template-rows,opacity] duration-200 ease-out group-hover:grid-rows-[1fr] group-hover:opacity-100 group-focus-within:grid-rows-[1fr] group-focus-within:opacity-100 motion-reduce:transition-none">
             <div className="overflow-hidden">
               <p

--- a/frontend/src/app/catalog/catalog-list-item.tsx
+++ b/frontend/src/app/catalog/catalog-list-item.tsx
@@ -2,120 +2,97 @@
 
 import Link from "next/link";
 import { useTranslations } from "next-intl";
-import { CatalogImportButton } from "@/app/catalog/_components/catalog-import-button";
 import { CatalogCardFieldsFragment } from "@/app/catalog/queries";
 import { Badge } from "@/components/ui/badge";
-import { buttonVariants } from "@/components/ui/button";
 import { type FragmentType, useFragment } from "@/generated/fragment-masking";
 
 export type CatalogListItemProps = {
   /** A masked `CatalogCardFields` ref — unmasked once via `useFragment` below. */
   node: FragmentType<typeof CatalogCardFieldsFragment>;
-  /**
-   * True while this cardgroup's import mutation is in flight. Invariant:
-   * `importing` and `imported` are never both true; if they are, the imported
-   * (done) state wins and the in-flight label is not shown.
-   */
-  importing: boolean;
-  /** True once this cardgroup has been imported in the current session. */
-  imported: boolean;
-  onImport: (id: string) => void;
-  /**
-   * Optional button label overrides. When omitted, the labels default to the
-   * `/catalog` copy (`Catalog` namespace); pass an explicit object to reuse this
-   * row in another context (e.g. an onboarding chooser). All three keys must be
-   * supplied together — partial override is not supported.
-   */
-  labels?: { action: string; inProgress: string; done: string };
-  /** Optional `data-testid` prefix on the Import button. Defaults to `"catalog-import"`. */
-  testIdPrefix?: string;
 };
 
 /**
- * List row for one published master cardgroup. Mirrors AdminMasterRow's density
- * (name + metadata + right-aligned action; mobile two-tier, desktop single inline
- * row) so the public catalog and the admin masters list speak the same perceptual
- * language for the same decks. The description is intentionally not shown — the
- * row optimises for scanning many decks. The Import button keeps the
- * locale-independent `data-testid` (`catalog-import-{id}`) so e2e — which runs in
- * the ja-JP locale — can target it without depending on translated copy.
+ * List row for one published master cardgroup on /catalog. The entire row is a
+ * single link to the deck-detail page (`/catalog/[id]`); Import has moved to that
+ * detail page, so the row carries no nested interactive element. Information
+ * hierarchy: Tier 1 = deck name (lead) + card-count stat (subordinate figure);
+ * Tier 2 = language / level / category badges (always visible); Tier 3 = the
+ * description, revealed on hover / keyboard focus via CSS — a desktop progressive
+ * enhancement, never the only path to the info (it also lives on the detail page).
+ * The locale-independent `data-testid` (`catalog-row-{id}`) lets e2e — which runs
+ * in ja-JP — target the row without depending on translated copy.
  */
-export function CatalogListItem({
-  node,
-  importing,
-  imported,
-  onImport,
-  labels,
-  testIdPrefix,
-}: CatalogListItemProps) {
+export function CatalogListItem({ node }: CatalogListItemProps) {
   const t = useTranslations("Catalog");
   const card = useFragment(CatalogCardFieldsFragment, node);
 
   return (
-    <li
-      className="rounded-md border border-border transition-colors hover:bg-accent"
-      data-testid={`catalog-row-${card.id}`}
-    >
-      {/*
-       * Mobile (default): two tiers — the name as a full-width title line, then a
-       * meta line carrying the badges + count on the left and Import on the right.
-       * Desktop (sm+): a single inline row [name][badges][count][Import]. One DOM
-       * serves both: `w-full` + `order-*` force the mobile line break, and
-       * `sm:contents` dissolves the meta wrapper on desktop so the badges and count
-       * rejoin the inline row in their own order. Spacing rhythm 16 / 12 / 8.
-       */}
-      <div className="flex flex-wrap items-center gap-x-3 gap-y-3 p-4 sm:py-3">
-        <h3
-          className="order-1 w-full min-w-0 truncate text-sm font-medium tracking-tight sm:w-auto sm:flex-1"
-          title={card.name}
-        >
-          {card.name}
-        </h3>
-
-        <div className="order-2 flex min-w-0 flex-1 flex-wrap items-center gap-2 sm:contents">
-          {card.language && (
-            <Badge variant="secondary" className="shrink-0 sm:order-2">
-              {card.language}
-            </Badge>
-          )}
-          {card.level && (
-            <Badge variant="outline" className="shrink-0 sm:order-2">
-              {t("level", { level: card.level })}
-            </Badge>
-          )}
-          {card.category && (
-            <Badge variant="outline" className="shrink-0 sm:order-2">
-              {card.category}
-            </Badge>
-          )}
-          <span className="shrink-0 text-xs tabular-nums text-muted-foreground sm:order-3">
-            {t("cardCount", { count: card.cardCount })}
+    <li>
+      <Link
+        href={`/catalog/${card.id}`}
+        data-testid={`catalog-row-${card.id}`}
+        aria-label={t("viewDeckAriaLabel", { name: card.name })}
+        className="group block rounded-md border border-border p-4 transition-[box-shadow,transform,background-color] duration-150 ease-out hover:-translate-y-0.5 hover:bg-accent hover:shadow-md motion-reduce:transition-none motion-reduce:hover:translate-y-0 sm:py-3"
+      >
+        {/* Tier 1: name (lead) + card-count stat (subordinate figure, right). */}
+        <div className="flex items-baseline gap-3">
+          <h3 className="min-w-0 flex-1 truncate text-[15px] font-semibold leading-[1.3] tracking-[-0.01em] text-foreground">
+            {card.name}
+          </h3>
+          <span className="shrink-0 whitespace-nowrap">
+            <span className="text-sm font-semibold tabular-nums text-foreground">
+              {t("cardCountStat", { count: card.cardCount })}
+            </span>{" "}
+            <span className="text-[10px] text-muted-foreground">
+              {t("unitCards", { count: card.cardCount })}
+            </span>
           </span>
         </div>
 
-        {/* View + Import sit together on the right of the meta tier (mobile) /
-            the inline row (desktop). The View link previews the deck's cards at
-            /catalog/[id]; the locale-independent data-testid lets e2e (ja-JP)
-            target it without depending on translated copy. */}
-        <div className="order-3 flex shrink-0 items-center gap-2 sm:order-4">
-          <Link
-            href={`/catalog/${card.id}`}
-            className={buttonVariants({ variant: "outline", size: "sm" })}
-            data-testid={`catalog-view-${card.id}`}
-            aria-label={t("viewDeckAriaLabel", { name: card.name })}
+        {/* Tier 2: badges (always visible) + chevron navigability affordance. */}
+        <div className="mt-1.5 flex items-center gap-2">
+          <div className="flex min-w-0 flex-1 flex-wrap items-center gap-1.5">
+            {card.language && (
+              <Badge variant="secondary" className="shrink-0">
+                {card.language}
+              </Badge>
+            )}
+            {card.level && (
+              <Badge variant="outline" className="shrink-0">
+                {t("level", { level: card.level })}
+              </Badge>
+            )}
+            {card.category && (
+              <Badge variant="outline" className="shrink-0">
+                {card.category}
+              </Badge>
+            )}
+          </div>
+          <span
+            aria-hidden="true"
+            className="shrink-0 text-border transition-transform duration-150 ease-out group-hover:translate-x-0.5 motion-reduce:transition-none motion-reduce:group-hover:translate-x-0"
           >
-            {t("viewDeck")}
-          </Link>
-          <CatalogImportButton
-            card={card}
-            importing={importing}
-            imported={imported}
-            onImport={onImport}
-            labels={labels}
-            testIdPrefix={testIdPrefix}
-          />
+            ›
+          </span>
         </div>
-      </div>
+
+        {/* Tier 3: description — collapsed by default, revealed on hover / focus
+            (desktop progressive enhancement) via a grid-rows 0fr→1fr transition.
+            Always in the DOM for screen readers; visually hidden on touch (no
+            hover), where the deck's detail page carries the description instead. */}
+        {card.description && (
+          <div className="grid grid-rows-[0fr] opacity-0 transition-[grid-template-rows,opacity] duration-200 ease-out group-hover:grid-rows-[1fr] group-hover:opacity-100 group-focus-within:grid-rows-[1fr] group-focus-within:opacity-100 motion-reduce:transition-none">
+            <div className="overflow-hidden">
+              <p
+                data-testid={`catalog-row-desc-${card.id}`}
+                className="mt-1.5 line-clamp-1 text-[11px] leading-[1.5] text-muted-foreground"
+              >
+                {card.description}
+              </p>
+            </div>
+          </div>
+        )}
+      </Link>
     </li>
   );
 }


### PR DESCRIPTION
## Summary

On the public catalog (`/catalog`), each deck row is now a **single tap target** to the deck-detail page (`/catalog/[id]`). The separate **View** button and the per-row **Import** button are removed — the whole row is one `<Link>` with no nested interactive element. The information hierarchy is re-led by the deck: the **name** is the lead, the **card count** becomes a subordinate right-aligned stat (`tabular-nums`), the language / level / category **badges stay always-visible**, and the **description** reveals on hover / keyboard focus (a desktop progressive enhancement — the detail page carries it for touch/mobile).

Import is no longer on the list row; it lives on the deck-detail page (the full-width "Import this deck" CTA from #589). `CatalogClient`'s entire per-row import state machine is deleted as a result.

No tracking issue — this is a direct design-refinement request that continues the catalog UX arc of #582 / #589.

## Background / Motivation

- The previous row read as "title + count + two competing buttons", with the coral Import button visually heavier than the deck name (inverted hierarchy) and a lot of dead vertical space.
- #582 added a **View** button beside Import; #589 promoted Import to a full-width CTA on the detail page. With Import already prominent on the detail page, a second Import on every list row was redundant and noisy.
- Making the row a single tap-to-view link makes the deck the subject and removes the action competition; Import becomes a deliberate decision taken after previewing the deck.

The direction (Variant B — name-led + right-aligned stat + intent-revealed description) was chosen from a design brainstorm and then stress-tested with an adversarial multi-lens review (accessibility / Apollo-RSC / type-design / silent-failure / comment-accuracy / test-coverage).

## Changes

### Catalog list row — `frontend/src/app/catalog/catalog-list-item.tsx`

- The whole `<li>` is now a single `<Link href="/catalog/{id}">` (locale-independent `data-testid="catalog-row-{id}"`, `aria-label` from `viewDeckAriaLabel`). No nested interactive element, so no `stopPropagation` needed.
- Removed the `CatalogImportButton` and the separate `View` `<Link>` (and its `catalog-view-{id}` testid).
- Tier 1: deck name (lead) + card-count **stat** (subordinate `tabular-nums` figure + small unit). Tier 2: badges (always visible). Tier 3: description revealed on `:hover` / `:focus-within` via a grid-rows `0fr → 1fr` transition with `motion-reduce:transition-none`. Tailwind's `group-hover:` auto-compiles under `@media (hover: hover)`, so it never fires on touch; `group-focus-within:` keeps the keyboard reveal.
- Props narrowed from six to `{ node }` — the component is now stateless / navigation-only.

### Catalog client — `frontend/src/app/catalog/catalog-client.tsx`

- Removed the entire import state machine: `useImportMaster`, `importingId` / `importedIds` / `importError` / `importAuthError`, `handleImport`, the two import `ErrorBanner`s, and the now-unused `Link` / `toast` imports.
- Renders `<CatalogListItem node={edge.node} />` with only `node`. The SSR cache-seed (`CATALOG_DEFAULT_VARS`), debounced header-takeover search, infinite scroll (`useConnectionPagination`), and the `fetchMoreError` banner + Retry are unchanged.

### Skeleton — `frontend/src/app/catalog/_components/catalog-skeleton.tsx`

- Loading rows updated to mirror the new shape (name + stat over a badge row; no button block).

### i18n — `frontend/messages/{en,ja}.json`

- Added `Catalog.cardCountStat` (`{count, number}` — grouped stat number) and `Catalog.unitCards` (`{count, plural, one {card} other {cards}}` / `枚`).
- Removed the now-dead `Catalog.viewDeck` key (the View button is gone); `viewDeckAriaLabel` stays (reused as the row's aria-label).

## Tests

- `catalog-list-item.test.tsx` — rewritten for the new row: single-link `href`, accessible name, grouped stat + singular/plural unit branch, badges present/absent, description-in-DOM + reveal-class pinning (`grid-rows-[0fr]` / `group-focus-within:grid-rows-[1fr]` / `motion-reduce:transition-none`), chevron `aria-hidden`, and **no** Import/View button.
- `catalog-client.test.tsx` — removed the six dead import-flow tests; the SSR-seed test now asserts the row link.
- `frontend/__tests__/catalog-deck.test.tsx` — the list entry-point test now targets `catalog-row-{id}` (single-link row) instead of the removed `catalog-view-{id}`.

## Verification

- `pnpm --filter frontend test` — **1564 passed / 168 files** (0 fail).
- `tsc --noEmit` — pass.
- `biome` lint — clean. `knip` — clean.
- `pnpm --filter frontend build` — success.
- No CJK in changed source (`枚` only in `ja.json`); no PR-order references.

Production diff (non-test): **3 files, +93 / −176**.

Out of scope / untouched: `CatalogCard` (the onboarding chooser — Import is its primary action), the `/catalog/[id]` detail page, `CatalogImportButton`, `use-import-master.ts`; the `CatalogCardFields` fragment is unchanged (no codegen).
