### PR TITLE
refactor(frontend): extract HoverRevealDeleteButton for list rows

### DIFF
--- a/frontend/src/components/admin/role-list-item.tsx
+++ b/frontend/src/components/admin/role-list-item.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import { Trash2 } from "lucide-react";
 import { useTranslations } from "next-intl";
+import { HoverRevealDeleteButton } from "@/components/cardgroups/hover-reveal-delete-button";
 import { SwipeableRow } from "@/components/cardgroups/swipeable-row";
-import { Button } from "@/components/ui/button";
 
 export type RoleListItemProps = {
   id: string;
@@ -23,8 +22,9 @@ export type RoleListItemProps = {
  * and skip the hover background — no swipe gesture, no delete button.
  *
  * The trailing delete button sits outside the link so an outer click does
- * not consume the delete affordance — same pattern as
- * frontend/src/components/cardgroups/cardgroup-list-item.tsx.
+ * not consume the delete affordance — it is the shared
+ * HoverRevealDeleteButton, the same control used by cardgroup-list-item.tsx
+ * and card-row.tsx.
  */
 export function RoleListItem({ id, name, isSystem, busy, onEdit, onDelete }: RoleListItemProps) {
   const t = useTranslations("Admin");
@@ -60,18 +60,12 @@ export function RoleListItem({ id, name, isSystem, busy, onEdit, onDelete }: Rol
             {name}
           </span>
         </button>
-        <Button
-          type="button"
-          variant="outline"
-          size="icon"
-          onClick={() => onDelete(id)}
+        <HoverRevealDeleteButton
+          onDelete={() => onDelete(id)}
           disabled={busy}
-          aria-label={`Delete ${name}`}
+          ariaLabel={`Delete ${name}`}
           data-testid={`admin-role-delete-btn-${id}`}
-          className="opacity-0 sm:group-hover:opacity-100 motion-reduce:opacity-100 transition-opacity"
-        >
-          <Trash2 aria-hidden="true" className="h-4 w-4" />
-        </Button>
+        />
       </li>
     </SwipeableRow>
   );

--- a/frontend/src/components/cardgroups/card-row.tsx
+++ b/frontend/src/components/cardgroups/card-row.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import { Trash2 } from "lucide-react";
 import { useTranslations } from "next-intl";
 import type { RefObject } from "react";
-import { Button } from "@/components/ui/button";
+import { HoverRevealDeleteButton } from "./hover-reveal-delete-button";
 import { SwipeableRow, type SwipeableRowHandle } from "./swipeable-row";
 
 export type CardRowProps = {
@@ -86,16 +85,12 @@ export function CardRow({
           onClick={(e) => e.stopPropagation()}
           onKeyDown={(e) => e.stopPropagation()}
         >
-          <Button
-            variant="outline"
-            size="icon"
-            aria-label={t("deleteCardAriaLabel")}
-            onClick={onDelete}
+          <HoverRevealDeleteButton
+            ariaLabel={t("deleteCardAriaLabel")}
+            onDelete={onDelete}
             data-testid={`card-delete-${card.id}`}
-            className="pointer-events-none opacity-0 sm:group-hover:pointer-events-auto sm:group-hover:opacity-100 sm:group-focus-within:pointer-events-auto sm:group-focus-within:opacity-100 motion-reduce:pointer-events-auto motion-reduce:opacity-100 transition-opacity"
-          >
-            <Trash2 aria-hidden="true" className="h-4 w-4" />
-          </Button>
+            className="pointer-events-none sm:group-hover:pointer-events-auto sm:group-hover:opacity-100 sm:group-focus-within:pointer-events-auto sm:group-focus-within:opacity-100 motion-reduce:pointer-events-auto"
+          />
         </div>
       </div>
     </SwipeableRow>

--- a/frontend/src/components/cardgroups/cardgroup-list-item.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-list-item.tsx
@@ -1,10 +1,9 @@
 "use client";
 
-import { Trash2 } from "lucide-react";
 import Link from "next/link";
 import { useLocale, useTranslations } from "next-intl";
+import { HoverRevealDeleteButton } from "@/components/cardgroups/hover-reveal-delete-button";
 import { SwipeableRow } from "@/components/cardgroups/swipeable-row";
-import { Button } from "@/components/ui/button";
 import { formatMediumDate } from "@/lib/format";
 
 export type CardgroupListItemProps = {
@@ -35,16 +34,12 @@ export function CardgroupListItem({
             {t("updatedAt", { date: formatMediumDate(updatedAt, locale) })}
           </span>
         </Link>
-        <Button
-          variant="outline"
-          size="icon"
-          className="pointer-events-none opacity-0 sm:group-hover:pointer-events-auto sm:group-hover:opacity-100 motion-reduce:pointer-events-auto motion-reduce:opacity-100 transition-opacity"
-          onClick={requestDelete}
+        <HoverRevealDeleteButton
+          className="pointer-events-none sm:group-hover:pointer-events-auto sm:group-hover:opacity-100 motion-reduce:pointer-events-auto"
+          onDelete={requestDelete}
           disabled={busy}
-          aria-label={deleteLabel}
-        >
-          <Trash2 className="h-4 w-4" />
-        </Button>
+          ariaLabel={deleteLabel}
+        />
       </li>
     </SwipeableRow>
   );

--- a/frontend/src/components/cardgroups/hover-reveal-delete-button.test.tsx
+++ b/frontend/src/components/cardgroups/hover-reveal-delete-button.test.tsx
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { HoverRevealDeleteButton } from "./hover-reveal-delete-button";
+
+describe("<HoverRevealDeleteButton>", () => {
+  it("renders a button with the given accessible name", () => {
+    render(<HoverRevealDeleteButton ariaLabel="Delete widget" onDelete={vi.fn()} />);
+    expect(screen.getByRole("button", { name: "Delete widget" })).toBeInTheDocument();
+  });
+
+  it("forwards data-testid to the rendered button", () => {
+    render(
+      <HoverRevealDeleteButton
+        ariaLabel="Delete widget"
+        onDelete={vi.fn()}
+        data-testid="delete-widget-1"
+      />,
+    );
+    expect(screen.getByTestId("delete-widget-1")).toBeInTheDocument();
+  });
+
+  it("fires onDelete when clicked", async () => {
+    const user = userEvent.setup();
+    const onDelete = vi.fn();
+    render(<HoverRevealDeleteButton ariaLabel="Delete widget" onDelete={onDelete} />);
+
+    await user.click(screen.getByRole("button", { name: "Delete widget" }));
+    expect(onDelete).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables the button (and blocks the click) when disabled is true", async () => {
+    const user = userEvent.setup();
+    const onDelete = vi.fn();
+    render(<HoverRevealDeleteButton ariaLabel="Delete widget" onDelete={onDelete} disabled />);
+
+    const btn = screen.getByRole("button", { name: "Delete widget" });
+    expect(btn).toBeDisabled();
+    await user.click(btn);
+    expect(onDelete).not.toHaveBeenCalled();
+  });
+
+  it("carries the base reveal classes so reduced-motion users always see it", () => {
+    // motion-reduce:opacity-100 is the load-bearing partner to SwipeableRow's
+    // reduced-motion early-return: when the swipe layer is absent this is the
+    // only delete affordance, so it must reveal under prefers-reduced-motion.
+    render(<HoverRevealDeleteButton ariaLabel="Delete widget" onDelete={vi.fn()} />);
+    const cls = screen.getByRole("button", { name: "Delete widget" }).className;
+    expect(cls).toContain("opacity-0");
+    expect(cls).toContain("sm:group-hover:opacity-100");
+    expect(cls).toContain("motion-reduce:opacity-100");
+    expect(cls).toContain("transition-opacity");
+  });
+
+  it("appends the per-row className override on top of the base reveal classes", () => {
+    // card-row passes pointer-events / focus-within tokens its overlay needs;
+    // the base reveal classes must survive the merge alongside the override.
+    render(
+      <HoverRevealDeleteButton
+        ariaLabel="Delete widget"
+        onDelete={vi.fn()}
+        className="pointer-events-none sm:group-focus-within:opacity-100"
+      />,
+    );
+    const cls = screen.getByRole("button", { name: "Delete widget" }).className;
+    expect(cls).toContain("pointer-events-none");
+    expect(cls).toContain("sm:group-focus-within:opacity-100");
+    // Base reveal tokens are not clobbered by the override.
+    expect(cls).toContain("motion-reduce:opacity-100");
+  });
+
+  it("renders the outline icon-button variant", () => {
+    render(<HoverRevealDeleteButton ariaLabel="Delete widget" onDelete={vi.fn()} />);
+    const cls = screen.getByRole("button", { name: "Delete widget" }).className;
+    // outline variant border + icon size (h-10 w-10) from buttonVariants.
+    expect(cls).toContain("border");
+    expect(cls).toContain("w-10");
+  });
+});

--- a/frontend/src/components/cardgroups/hover-reveal-delete-button.tsx
+++ b/frontend/src/components/cardgroups/hover-reveal-delete-button.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+export type HoverRevealDeleteButtonProps = {
+  /** Fired when the trailing Delete control is activated. */
+  onDelete: () => void;
+  /** Accessible name for the Delete control. */
+  ariaLabel: string;
+  /** Disables the control (e.g. while a sibling mutation is in flight). */
+  disabled?: boolean;
+  /**
+   * Per-row class overrides. The base reveal logic (opacity + motion-reduce
+   * fallback + transition) is always applied; callers append the
+   * pointer-events / focus-within / overlay-interplay tokens their row needs.
+   */
+  className?: string;
+  /** Forwarded to the rendered `<button>` (e.g. `card-delete-${id}`). */
+  "data-testid"?: string;
+};
+
+/**
+ * Trailing Delete control shared by the swipe-to-delete list rows
+ * (card / cardgroup / role). It is an `outline` icon button that stays
+ * `opacity-0` until `sm:group-hover` / `group-focus-within` on its row's
+ * `group` wrapper, with a `motion-reduce:opacity-100` fallback so it is always
+ * visible when the swipe layer is not rendered (the reduced-motion early-return
+ * in `SwipeableRow`). It sits OUTSIDE the row link/edit-target so an outer click
+ * does not consume the delete affordance.
+ *
+ * The reveal logic here is the load-bearing partner to `SwipeableRow`'s
+ * reduced-motion early-return: when the swipe layer is absent the parent owns
+ * the only delete affordance, so this button must reveal under
+ * `prefers-reduced-motion`. Keep `motion-reduce:opacity-100` in the base.
+ *
+ * Callers pass `className` to add row-specific behaviour that must NOT live in
+ * the shared default — e.g. `card-row.tsx`'s `pointer-events-none
+ * sm:pointer-events-auto` mobile tap-fallthrough and its `after:inset-0`
+ * edit-overlay interplay.
+ */
+export function HoverRevealDeleteButton({
+  onDelete,
+  ariaLabel,
+  disabled,
+  className,
+  "data-testid": dataTestid,
+}: HoverRevealDeleteButtonProps) {
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      size="icon"
+      onClick={onDelete}
+      disabled={disabled}
+      aria-label={ariaLabel}
+      data-testid={dataTestid}
+      className={cn(
+        "opacity-0 sm:group-hover:opacity-100 motion-reduce:opacity-100 transition-opacity",
+        className,
+      )}
+    >
+      <Trash2 aria-hidden="true" className="h-4 w-4" />
+    </Button>
+  );
+}


### PR DESCRIPTION
## Summary

Extracts the hover/focus-revealed Delete button shared by three list-row components into one `<HoverRevealDeleteButton>`. Behavior-preserving.

Closes #592.

## Background / Motivation

The trailing Delete button — `opacity-0` until `sm:group-hover` / `group-focus-within`, with a `motion-reduce:opacity-100` fallback, outside the row link — was copy-pasted across three rows. The `motion-reduce` reveal is the load-bearing partner to `SwipeableRow`'s reduced-motion early-return: a fix to that interaction previously had to be applied in three separate class strings.

## Changes

- **Add** `frontend/src/components/cardgroups/hover-reveal-delete-button.tsx` (+ test, 7 tests) — props `{ onDelete, ariaLabel, disabled?, className? }`.
- **Modify** `card-row.tsx`, `cardgroup-list-item.tsx`, `components/admin/role-list-item.tsx` to consume it.

`card-row.tsx` keeps its mobile-specific `pointer-events-none sm:pointer-events-auto` + `after:inset-0` overlay behavior via the `className` override — that interplay was **not** flattened into the shared default. Every `aria-label` and `data-testid` is preserved.

## Verification (in worktree)

- `tsc --noEmit` — pass. `biome check --error-on-warnings` — clean. `knip` — clean.
- Targeted vitest — **52 tests pass** across the new component test plus `card-row`, `cardgroup-list-item`, and the admin-roles row coverage.
- No CJK; production build runs in CI.

## Test plan

- [ ] Hover/focus a cardgroup row, a role row, and a card row; confirm the Delete button reveals and fires.
- [ ] With reduced-motion enabled, confirm the Delete button is visible without hover.
- [ ] On mobile, confirm the card-row tap-to-edit fallthrough still works (Delete does not capture the row tap).
