### PR TITLE
refactor(frontend): extract classifyToAuthOutcome for mutation catch blocks

### DIFF
--- a/frontend/src/app/admin/masters/use-master-mutations.ts
+++ b/frontend/src/app/admin/masters/use-master-mutations.ts
@@ -4,8 +4,7 @@ import { useApolloClient, useMutation } from "@apollo/client/react";
 import type { Reference } from "@apollo/client/utilities";
 import { useCallback } from "react";
 import type { AdminMastersQuery as AdminMastersQueryResult } from "@/generated/graphql";
-import { classifyMutationAuthError } from "@/lib/apollo/errors";
-import { liftGraphQLCodes } from "@/lib/apollo/graphql-errors";
+import { classifyToAuthOutcome } from "@/lib/apollo/errors";
 import type { MasterFormValues } from "./admin-master-form";
 import {
   ADMIN_MASTERS_BASE_VARS,
@@ -51,14 +50,6 @@ export type UnpublishMasterOutcome =
   | { status: "auth"; kind: AuthKind }
   | { status: "unexpected" }
   | { status: "rejected" };
-
-// FORBIDDEN / UNAUTHENTICATED → an auth outcome; anything else → null so the
-// caller falls through to its own rejected/unexpected branch.
-function authOutcome(err: unknown): { status: "auth"; kind: AuthKind } | null {
-  const kind = classifyMutationAuthError(err);
-  if (kind === "other") return null;
-  return { status: "auth", kind };
-}
 
 /**
  * Owns the five admin-masters mutations and their Apollo cache writes. The client
@@ -144,13 +135,7 @@ export function useMasterMutations() {
         console.warn("[useMasterMutations] unexpected createMaster payload", { typename });
         return { status: "unexpected" };
       } catch (err) {
-        const auth = authOutcome(err);
-        if (auth) return auth;
-        console.warn("[useMasterMutations] createMaster rejected", {
-          name: err instanceof Error ? err.name : "unknown",
-          codes: liftGraphQLCodes(err),
-        });
-        return { status: "rejected" };
+        return classifyToAuthOutcome<AuthKind>(err, "useMasterMutations", "createMaster");
       }
     },
     [runCreate],
@@ -171,14 +156,9 @@ export function useMasterMutations() {
         console.warn("[useMasterMutations] unexpected updateMaster payload", { typename });
         return { status: "unexpected" };
       } catch (err) {
-        const auth = authOutcome(err);
-        if (auth) return auth;
-        console.warn("[useMasterMutations] updateMaster rejected", {
+        return classifyToAuthOutcome<AuthKind>(err, "useMasterMutations", "updateMaster", {
           masterId: id,
-          name: err instanceof Error ? err.name : "unknown",
-          codes: liftGraphQLCodes(err),
         });
-        return { status: "rejected" };
       }
     },
     [runUpdate],
@@ -214,14 +194,9 @@ export function useMasterMutations() {
         }
         return { status: "success" };
       } catch (err) {
-        const auth = authOutcome(err);
-        if (auth) return auth;
-        console.warn("[useMasterMutations] deleteMaster rejected", {
+        return classifyToAuthOutcome<AuthKind>(err, "useMasterMutations", "deleteMaster", {
           masterId: id,
-          name: err instanceof Error ? err.name : "unknown",
-          codes: liftGraphQLCodes(err),
         });
-        return { status: "rejected" };
       }
     },
     [apolloClient, runDelete],
@@ -245,14 +220,9 @@ export function useMasterMutations() {
         });
         return { status: "unexpected" };
       } catch (err) {
-        const auth = authOutcome(err);
-        if (auth) return auth;
-        console.warn("[useMasterMutations] publishMaster rejected", {
+        return classifyToAuthOutcome<AuthKind>(err, "useMasterMutations", "publishMaster", {
           masterId: id,
-          name: err instanceof Error ? err.name : "unknown",
-          codes: liftGraphQLCodes(err),
         });
-        return { status: "rejected" };
       }
     },
     [runPublish],
@@ -270,14 +240,9 @@ export function useMasterMutations() {
         }
         return { status: "success" };
       } catch (err) {
-        const auth = authOutcome(err);
-        if (auth) return auth;
-        console.warn("[useMasterMutations] unpublishMaster rejected", {
+        return classifyToAuthOutcome<AuthKind>(err, "useMasterMutations", "unpublishMaster", {
           masterId: id,
-          name: err instanceof Error ? err.name : "unknown",
-          codes: liftGraphQLCodes(err),
         });
-        return { status: "rejected" };
       }
     },
     [runUnpublish],

--- a/frontend/src/app/cardgroups/use-create-cardgroup.ts
+++ b/frontend/src/app/cardgroups/use-create-cardgroup.ts
@@ -2,8 +2,7 @@
 
 import { useMutation } from "@apollo/client/react";
 import { useCallback } from "react";
-import { classifyMutationAuthError } from "@/lib/apollo/errors";
-import { liftGraphQLCodes } from "@/lib/apollo/graphql-errors";
+import { classifyToAuthOutcome } from "@/lib/apollo/errors";
 import { prependMyCardgroupEdge } from "./cache";
 import { CreateCardgroupMutation } from "./queries";
 
@@ -68,15 +67,10 @@ export function useCreateCardgroup() {
         console.warn("[useCreateCardgroup] unexpected createCardgroup payload", { typename });
         return { status: "unexpected" };
       } catch (err) {
-        const authKind = classifyMutationAuthError(err);
-        if (authKind !== "other") return { status: "auth", kind: authKind };
-        // err.message is omitted — backend messages may echo user input.
-        // codes is safe to log (fixed enum of GraphQL extension codes).
-        console.warn("[useCreateCardgroup] createCardgroup rejected", {
-          name: err instanceof Error ? err.name : "unknown",
-          codes: liftGraphQLCodes(err),
-        });
-        return { status: "rejected" };
+        // FORBIDDEN / UNAUTHENTICATED → typed auth outcome; otherwise a scoped
+        // structured warn (omitting err.message, which may echo user input) and
+        // a rejected outcome. See lib/apollo/errors classifyToAuthOutcome.
+        return classifyToAuthOutcome(err, "useCreateCardgroup", "createCardgroup");
       }
     },
     [createCardgroup],

--- a/frontend/src/app/catalog/use-import-master.ts
+++ b/frontend/src/app/catalog/use-import-master.ts
@@ -3,8 +3,7 @@
 import { useMutation } from "@apollo/client/react";
 import { useCallback } from "react";
 import { prependMyCardgroupEdge } from "@/app/cardgroups/cache";
-import { classifyMutationAuthError } from "@/lib/apollo/errors";
-import { liftGraphQLCodes } from "@/lib/apollo/graphql-errors";
+import { classifyToAuthOutcome } from "@/lib/apollo/errors";
 import { ImportMasterCardgroupMutation } from "./queries";
 
 /**
@@ -81,15 +80,12 @@ export function useImportMaster() {
         console.warn("[useImportMaster] unexpected importMasterCardgroup payload", { typename });
         return { status: "rejected" };
       } catch (err) {
-        const authKind = classifyMutationAuthError(err);
-        if (authKind !== "other") return { status: "auth", kind: authKind };
-        // err.message is omitted — backend messages may echo user input.
-        // codes is safe to log (fixed enum of GraphQL extension codes).
-        console.warn("[useImportMaster] importMasterCardgroup rejected", {
-          name: err instanceof Error ? err.name : "unknown",
-          codes: liftGraphQLCodes(err),
-        });
-        return { status: "rejected" };
+        // FORBIDDEN / UNAUTHENTICATED → typed auth outcome; otherwise a scoped
+        // structured warn (omitting err.message, which may echo user input) and
+        // a rejected outcome. The resolved-but-unparseable success-path case
+        // above also collapses into `rejected` — no catalog caller distinguishes
+        // the two. See lib/apollo/errors classifyToAuthOutcome.
+        return classifyToAuthOutcome(err, "useImportMaster", "importMasterCardgroup");
       }
     },
     [importMaster],

--- a/frontend/src/lib/apollo/errors.test.ts
+++ b/frontend/src/lib/apollo/errors.test.ts
@@ -1,7 +1,8 @@
 import { CombinedGraphQLErrors } from "@apollo/client/errors";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   classifyMutationAuthError,
+  classifyToAuthOutcome,
   getBackendErrorBanner,
   getBackendFieldErrors,
   mutationAuthBanner,
@@ -238,5 +239,68 @@ describe("mutationAuthBanner", () => {
 
   it("returns the fallback copy for a network error", () => {
     expect(mutationAuthBanner(new Error("Network request failed"), copy)).toBe(copy.fallback);
+  });
+});
+
+describe("classifyToAuthOutcome", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns an auth outcome with kind forbidden for a FORBIDDEN error without warning", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const err = makeCombinedError([{ message: "Forbidden", extensions: { code: "FORBIDDEN" } }]);
+    expect(classifyToAuthOutcome(err, "useScope", "doThing")).toEqual({
+      status: "auth",
+      kind: "forbidden",
+    });
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("returns an auth outcome with kind unauthenticated for an UNAUTHENTICATED error without warning", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const err = makeCombinedError([
+      { message: "Not authenticated", extensions: { code: "UNAUTHENTICATED" } },
+    ]);
+    expect(classifyToAuthOutcome(err, "useScope", "doThing")).toEqual({
+      status: "auth",
+      kind: "unauthenticated",
+    });
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("returns a rejected outcome and warns with the scoped prefix for a non-auth GraphQL error", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const err = makeCombinedError([
+      { message: "Invalid input", extensions: { code: "BAD_USER_INPUT" } },
+    ]);
+    expect(classifyToAuthOutcome(err, "useScope", "doThing")).toEqual({ status: "rejected" });
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith("[useScope] doThing rejected", {
+      name: "CombinedGraphQLErrors",
+      codes: ["BAD_USER_INPUT"],
+    });
+  });
+
+  it("returns a rejected outcome and warns with name unknown for a non-Error throw", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    expect(classifyToAuthOutcome("boom", "useScope", "doThing")).toEqual({ status: "rejected" });
+    expect(warn).toHaveBeenCalledWith("[useScope] doThing rejected", {
+      name: "unknown",
+      codes: [],
+    });
+  });
+
+  it("merges caller-supplied extra context into the warn payload", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const err = new Error("Network request failed");
+    expect(
+      classifyToAuthOutcome(err, "useMasterMutations", "deleteMaster", { masterId: "m-1" }),
+    ).toEqual({ status: "rejected" });
+    expect(warn).toHaveBeenCalledWith("[useMasterMutations] deleteMaster rejected", {
+      masterId: "m-1",
+      name: "Error",
+      codes: [],
+    });
   });
 });

--- a/frontend/src/lib/apollo/errors.ts
+++ b/frontend/src/lib/apollo/errors.ts
@@ -12,6 +12,7 @@
  */
 
 import { CombinedGraphQLErrors } from "@apollo/client/errors";
+import { liftGraphQLCodes } from "./graphql-errors";
 
 const NETWORK_ERROR = "Could not reach the server. Please try again.";
 
@@ -125,6 +126,63 @@ export function classifyMutationAuthError(err: unknown): MutationAuthErrorKind {
     }
   }
   return "other";
+}
+
+/**
+ * The auth-relevant kinds a caught mutation error can resolve to once the
+ * non-auth `"other"` case is folded into `rejected`. This is the auth-kind
+ * union the mutation hooks surface to their callers.
+ */
+export type MutationAuthKind = Exclude<MutationAuthErrorKind, "other">;
+
+/**
+ * Discriminated outcome of folding a caught mutation error: a typed `auth`
+ * outcome for FORBIDDEN / UNAUTHENTICATED, otherwise `rejected`.
+ *
+ * `Kind` is the caller's auth-kind union and defaults to the full
+ * `"forbidden" | "unauthenticated"` pair. `classifyMutationAuthError` returns
+ * the literal `"forbidden"` / `"unauthenticated"` strings, which structurally
+ * satisfy any `Kind` that contains them, so the narrowing in
+ * `classifyToAuthOutcome` is sound.
+ */
+export type MutationCatchOutcome<Kind extends MutationAuthKind = MutationAuthKind> =
+  | { status: "auth"; kind: Kind }
+  | { status: "rejected" };
+
+/**
+ * Fold a caught mutation-level error into the discriminated `auth` / `rejected`
+ * outcome shared by the auth-classifying mutation hooks. This single-sources the
+ * `catch`-block boilerplate those hooks repeat:
+ *
+ *  - FORBIDDEN / UNAUTHENTICATED → `{ status: "auth", kind }` so the caller can
+ *    pick sign-in / permission toast copy.
+ *  - Anything else (a non-auth GraphQL error, a transport failure) → emits a
+ *    scoped structured `console.warn` and returns `{ status: "rejected" }`.
+ *
+ * The warn carries `err.name` and the lifted `extensions.code` list (via
+ * `liftGraphQLCodes`) plus any caller-supplied `extra` context (e.g. an entity
+ * id). `err.message` is intentionally omitted — backend messages may echo user
+ * input. `scope` and `op` parameterize the per-hook warn prefix
+ * (`"[scope] op rejected"`) so each hook keeps its own telemetry label.
+ *
+ * `Kind` defaults to the full `"forbidden" | "unauthenticated"` union but can
+ * be narrowed by the caller's auth-kind union (some hooks surface both, some
+ * only expect `unauthenticated`).
+ */
+export function classifyToAuthOutcome<Kind extends MutationAuthKind = MutationAuthKind>(
+  err: unknown,
+  scope: string,
+  op: string,
+  extra?: Record<string, unknown>,
+): MutationCatchOutcome<Kind> {
+  const kind = classifyMutationAuthError(err);
+  if (kind !== "other") return { status: "auth", kind: kind as Kind };
+  console.warn(`[${scope}] ${op} rejected`, {
+    ...extra,
+    name: err instanceof Error ? err.name : "unknown",
+    codes: liftGraphQLCodes(err),
+  });
+  return { status: "rejected" };
 }
 
 /**


### PR DESCRIPTION
## Summary

Extracts the repeated auth-classifying mutation `catch` boilerplate into a `classifyToAuthOutcome` helper and adopts it in the non-card mutation hooks. Error-path-only refactor — behavior-preserving.

Closes #594.

## Background / Motivation

The same `catch` shape — try `classifyMutationAuthError` → return the `{ status: "auth", kind }` outcome, else `console.warn(scope, { codes: liftGraphQLCodes(err) })` and return `{ status: "rejected" }` — was repeated ~8 times (5× alone inside `useMasterMutations`). Single-sourcing keeps the telemetry shape and the auth/rejected mapping consistent.

## Changes

- **Modify** `frontend/src/lib/apollo/errors.ts` — add `classifyToAuthOutcome`, generic over the per-hook auth-kind union; it performs the scoped `liftGraphQLCodes` warn and returns the discriminated outcome.
- **Modify** `use-master-mutations.ts` (the `authOutcome` local + its 5 catch blocks), `use-create-cardgroup.ts`, `use-import-master.ts`.
- **Modify** `errors.test.ts` — coverage for the new helper.

Preserved: each hook's `console.warn` scope string is parameterized (not lost), and `use-import-master`'s deliberate collapse of `unexpected` into `rejected` is **not** reintroduced.

## Verification (in worktree)

- `tsc --noEmit` — pass. `biome check --error-on-warnings` — clean. `knip` — clean.
- Targeted vitest — **391 tests pass** across the changed modules + all consumers (`errors`, `use-master-mutations`, `admin-masters-client`, cardgroup-create, import-master suites).
- No CJK; production build runs in CI.

## Test plan

- [ ] Trigger a forbidden master mutation (non-admin) and a forbidden cardgroup create; confirm the auth banner copy is unchanged.
- [ ] Trigger an unexpected backend error on import-master; confirm it still surfaces as the rejected outcome (no new "unexpected" branch).
