### PR TITLE
refactor(frontend): make CardgroupHeader consume DetailPageHeader

### DIFF
--- a/frontend/src/components/cardgroups/cardgroup-header.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-header.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import { ChevronLeft, Import, MoreHorizontal, Pencil, Trash2 } from "lucide-react";
-import Link from "next/link";
+import { Import, MoreHorizontal, Pencil, Trash2 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { useCallback, useState } from "react";
 import { CardgroupRenameForm } from "@/components/cardgroups/cardgroup-rename-form";
 import { useDeleteCardgroup } from "@/components/cardgroups/use-delete-cardgroup";
+import { DetailPageHeader } from "@/components/nav/detail-page-header";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -112,39 +112,20 @@ export function CardgroupHeader({ cardgroup, totalCount, onBatchImport }: Props)
 
   return (
     <>
-      {/*
-        Single-DOM responsive header — back, count, title, and the overflow
-        menu are each rendered once and repositioned via CSS grid template
-        areas, so the layout reflows without duplicating any element (the test
-        contract expects exactly one back link, one count, one h1, and one
-        overflow trigger).
-
-        Mobile (`< md`): app-bar row — inline back (left), card count centered,
-        overflow menu (right) — with the title centered on its own row below.
-        The 1fr/auto/1fr columns keep the count truly centered regardless of
-        the back/overflow cluster widths.
-
-        Desktop (`>= md`): title left with the card count as a muted subtitle
-        beneath it; back stays on the leading edge and the overflow trigger is
-        pushed to the trailing edge of the title row. The page-level action
-        buttons that `CardgroupCardsSection` lays out now sit on their own row
-        below this header. */}
-      <header className="mb-6 grid grid-cols-[1fr_auto_1fr] items-center gap-x-2 gap-y-1 [grid-template-areas:'back_count_overflow'_'title_title_title'] md:grid-cols-[auto_minmax(0,1fr)_auto] md:gap-y-0 md:[grid-template-areas:'back_title_overflow'_'back_count_overflow']">
-        <Link
-          href="/cardgroups"
-          className="shrink-0 justify-self-start [grid-area:back] rounded-sm text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-        >
-          <ChevronLeft aria-hidden="true" className="h-5 w-5" />
-          <span className="sr-only">{t("backLink")}</span>
-        </Link>
-        <h1 className="min-w-0 truncate [grid-area:title] text-center text-2xl font-semibold leading-tight md:text-left">
-          {cardgroup.name}
-        </h1>
-        <p className="justify-self-center [grid-area:count] text-sm text-muted-foreground md:justify-self-start">
-          {t("cardsCount", { count: totalCount })}
-        </p>
-        <div className="justify-self-end [grid-area:overflow]">{actions}</div>
-      </header>
+      {/* Shared detail-page header: inline back (left), centered card-count
+          meta, and the overflow menu as the trailing action cluster, with the
+          deck name as the centered title one tier below. The 1fr/auto/1fr
+          app-bar grid keeps the count truly centered regardless of the
+          back/action cluster widths. */}
+      <DetailPageHeader
+        backHref="/cardgroups"
+        backLabel={t("backLink")}
+        title={cardgroup.name}
+        meta={
+          <p className="text-sm text-muted-foreground">{t("cardsCount", { count: totalCount })}</p>
+        }
+        actions={actions}
+      />
 
       <FormSheet
         open={renameOpen}


### PR DESCRIPTION
## Summary

Makes `CardgroupHeader` consume the shared `DetailPageHeader` — the last detail header that still hand-rolled the app-bar grid + back-link. Adopts the centered-title desktop layout (Option A) to match the other detail screens.

Closes #595.

## Background / Motivation

After the detail-header consolidation, `master-edit-header` and `catalog-deck-header` both compose `DetailPageHeader`, but `cardgroup-header` still re-implemented the `grid-cols-[1fr_auto_1fr]` + `ChevronLeft` back-link header — a repo-wide grep confirmed it was the only remaining file carrying `grid-template-areas` and a non-shared `ChevronLeft` back-link.

## Changes

- **Modify** `frontend/src/components/cardgroups/cardgroup-header.tsx` — collapse the bespoke grid into `<DetailPageHeader meta={count} actions={overflowMenu}>` (net −19 lines). No new props were added to `DetailPageHeader`.

**Deliberate visual change (Option A):** the cardgroups detail header moves from a desktop left-aligned title + muted subtitle to the shared **centered-title** layout, matching master-edit and catalog-deck. a11y is preserved (one `<h1>`, back `<Link>` with `sr-only` label); all `Cardgroups`-namespace i18n keys unchanged.

## Verification (in worktree)

- `tsc --noEmit` — pass. `biome check --error-on-warnings` — clean. `knip` — clean.
- Targeted vitest — **21 tests pass** (`cardgroup-header`, `detail-page-header`, `cardgroup-management-client`); the "exactly one back link / one count / one h1 / one overflow trigger" assertions hold under `DetailPageHeader`.
- No CJK; production build runs in CI.

## Test plan

- [ ] Open a cardgroup detail screen on desktop; confirm the title is centered and the count + overflow menu render as expected.
- [ ] On mobile, confirm the back-link, title, count, and overflow menu layout is unchanged.
