### PR TITLE
refactor(frontend): extract appendConnectionEdge/removeConnectionEdges cache helpers

### DIFF
--- a/frontend/src/app/admin/masters/[id]/edit/cards/use-master-card-mutations.ts
+++ b/frontend/src/app/admin/masters/[id]/edit/cards/use-master-card-mutations.ts
@@ -7,6 +7,7 @@ import {
   type AdminMasterCardsConnectionQuery,
   type AdminMasterCardsConnectionQueryVariables,
 } from "@/generated/graphql";
+import { appendConnectionEdge, removeConnectionEdges } from "@/lib/apollo/connection-cache";
 import { useUndoDelete } from "@/lib/undo-delete";
 import {
   AdminCreateMasterCard,
@@ -88,28 +89,14 @@ export function useMasterCardMutations({ masterId, queryVariables }: UseMasterCa
         if (bulkData?.adminDeleteMasterCards == null) return;
         const deletedCount = bulkData.adminDeleteMasterCards;
         if (deletedCount === 0) return;
-        const existing = cache.readQuery({
-          query: AdminMasterCardsConnectionDocument,
+        removeConnectionEdges(cache, {
+          document: AdminMasterCardsConnectionDocument,
           variables: queryVariables,
+          connectionField: "adminMasterCardsConnection",
+          entityTypename: "MasterCard",
+          ids,
+          deletedCount,
         });
-        if (existing) {
-          const next = existing.adminMasterCardsConnection;
-          cache.writeQuery({
-            query: AdminMasterCardsConnectionDocument,
-            variables: queryVariables,
-            data: {
-              adminMasterCardsConnection: {
-                ...next,
-                edges: next.edges.filter((edge) => !ids.includes(edge.node.id)),
-                totalCount: Math.max(0, next.totalCount - deletedCount),
-              },
-            },
-          });
-        }
-        for (const id of ids) {
-          cache.evict({ id: cache.identify({ __typename: "MasterCard", id }) });
-        }
-        cache.gc();
       },
     },
   );
@@ -121,30 +108,16 @@ export function useMasterCardMutations({ masterId, queryVariables }: UseMasterCa
   const [deleteRowError, setDeleteRowError] = useState<unknown>(null);
 
   // Write a freshly-created master card to the connection cached under `variables`.
+  // No `buildColdConnection`: on a cold cache this no-ops and the page's own
+  // `useQuery` owns populating the connection.
   const writeCreatedMasterCardToConnection = useCallback(
     (card: MasterCardNode, variables: AdminMasterCardsConnectionQueryVariables) => {
-      const existing = apollo.readQuery({
-        query: AdminMasterCardsConnectionDocument,
+      appendConnectionEdge(apollo.cache, {
+        document: AdminMasterCardsConnectionDocument,
         variables,
-      });
-      if (!existing) return;
-
-      const next = existing.adminMasterCardsConnection;
-      if (next.edges.some((edge) => edge.node.id === card.id)) return;
-
-      apollo.writeQuery({
-        query: AdminMasterCardsConnectionDocument,
-        variables,
-        data: {
-          adminMasterCardsConnection: {
-            ...next,
-            edges: [
-              { __typename: "MasterCardEdge" as const, cursor: card.id, node: card },
-              ...next.edges,
-            ],
-            totalCount: next.totalCount + 1,
-          },
-        },
+        connectionField: "adminMasterCardsConnection",
+        edgeTypename: "MasterCardEdge",
+        node: card,
       });
     },
     [apollo],

--- a/frontend/src/app/cardgroups/[id]/cards/use-card-mutations.ts
+++ b/frontend/src/app/cardgroups/[id]/cards/use-card-mutations.ts
@@ -13,6 +13,7 @@ import {
   type CardsByCardgroupConnectionQuery,
   type CardsByCardgroupConnectionQueryVariables,
 } from "@/generated/graphql";
+import { appendConnectionEdge, removeConnectionEdges } from "@/lib/apollo/connection-cache";
 import { useUndoDelete } from "@/lib/undo-delete";
 import { cardsDefaultVars } from "./queries";
 
@@ -86,28 +87,14 @@ export function useCardMutations({ cardgroupId, queryVariables }: UseCardMutatio
         if (bulkData?.deleteCards == null) return;
         const deletedCount = bulkData.deleteCards;
         if (deletedCount === 0) return;
-        const existing = cache.readQuery({
-          query: CardsByCardgroupConnectionDocument,
+        removeConnectionEdges(cache, {
+          document: CardsByCardgroupConnectionDocument,
           variables: queryVariables,
+          connectionField: "cardsByCardgroupConnection",
+          entityTypename: "Card",
+          ids,
+          deletedCount,
         });
-        if (existing) {
-          const next = existing.cardsByCardgroupConnection;
-          cache.writeQuery({
-            query: CardsByCardgroupConnectionDocument,
-            variables: queryVariables,
-            data: {
-              cardsByCardgroupConnection: {
-                ...next,
-                edges: next.edges.filter((edge) => !ids.includes(edge.node.id)),
-                totalCount: Math.max(0, next.totalCount - deletedCount),
-              },
-            },
-          });
-        }
-        for (const id of ids) {
-          cache.evict({ id: cache.identify({ __typename: "Card", id }) });
-        }
-        cache.gc();
       },
     },
   );
@@ -119,30 +106,16 @@ export function useCardMutations({ cardgroupId, queryVariables }: UseCardMutatio
   const [deleteRowError, setDeleteRowError] = useState<unknown>(null);
 
   // Write a freshly-created card to the connection cached under `variables`.
+  // No `buildColdConnection`: on a cold cache this no-ops and the page's own
+  // `useQuery` owns populating the connection.
   const writeCreatedCardToConnection = useCallback(
     (card: CardNode, variables: CardsByCardgroupConnectionQueryVariables) => {
-      const existing = apollo.readQuery({
-        query: CardsByCardgroupConnectionDocument,
+      appendConnectionEdge(apollo.cache, {
+        document: CardsByCardgroupConnectionDocument,
         variables,
-      });
-      if (!existing) return;
-
-      const next = existing.cardsByCardgroupConnection;
-      if (next.edges.some((edge) => edge.node.id === card.id)) return;
-
-      apollo.writeQuery({
-        query: CardsByCardgroupConnectionDocument,
-        variables,
-        data: {
-          cardsByCardgroupConnection: {
-            ...next,
-            edges: [
-              { __typename: "CardEdge" as const, cursor: card.id, node: card },
-              ...next.edges,
-            ],
-            totalCount: next.totalCount + 1,
-          },
-        },
+        connectionField: "cardsByCardgroupConnection",
+        edgeTypename: "CardEdge",
+        node: card,
       });
     },
     [apollo],

--- a/frontend/src/lib/apollo/connection-cache.test.ts
+++ b/frontend/src/lib/apollo/connection-cache.test.ts
@@ -1,0 +1,237 @@
+import { InMemoryCache } from "@apollo/client";
+import { describe, expect, it, vi } from "vitest";
+import {
+  CardsByCardgroupConnectionDocument,
+  type CardsByCardgroupConnectionQuery,
+  type CardsByCardgroupConnectionQueryVariables,
+} from "@/generated/graphql";
+import { appendConnectionEdge, removeConnectionEdges } from "./connection-cache";
+
+const CARDGROUP_ID = "cg-1";
+
+const VARS: CardsByCardgroupConnectionQueryVariables = {
+  cardgroupId: CARDGROUP_ID,
+  first: 20,
+  search: null,
+};
+
+type CardNode =
+  CardsByCardgroupConnectionQuery["cardsByCardgroupConnection"]["edges"][number]["node"];
+
+function makeNode(id: string): CardNode {
+  return {
+    __typename: "Card",
+    id,
+    front: `front-${id}`,
+    back: `back-${id}`,
+    cardgroupId: CARDGROUP_ID,
+    userCardState: { __typename: "UserCardState", due: "2026-01-01T00:00:00Z", state: 0 },
+  };
+}
+
+function makeEdge(id: string) {
+  return { __typename: "CardEdge" as const, cursor: id, node: makeNode(id) };
+}
+
+function makeConnection(
+  ids: string[],
+  totalCount = ids.length,
+): CardsByCardgroupConnectionQuery["cardsByCardgroupConnection"] {
+  return {
+    __typename: "CardConnection",
+    edges: ids.map(makeEdge),
+    pageInfo: {
+      __typename: "PageInfo",
+      hasNextPage: false,
+      hasPreviousPage: false,
+      startCursor: ids[0] ?? null,
+      endCursor: ids.at(-1) ?? null,
+    },
+    totalCount,
+  };
+}
+
+function seed(
+  cache: InMemoryCache,
+  connection: CardsByCardgroupConnectionQuery["cardsByCardgroupConnection"],
+) {
+  cache.writeQuery({
+    query: CardsByCardgroupConnectionDocument,
+    variables: VARS,
+    data: { cardsByCardgroupConnection: connection },
+  });
+}
+
+function read(cache: InMemoryCache) {
+  return cache.readQuery({ query: CardsByCardgroupConnectionDocument, variables: VARS });
+}
+
+const buildColdConnection = () => makeConnection(["cold"], 1);
+
+describe("appendConnectionEdge", () => {
+  it("no-ops on a cold cache when buildColdConnection is omitted", () => {
+    const cache = new InMemoryCache();
+
+    appendConnectionEdge(cache, {
+      document: CardsByCardgroupConnectionDocument,
+      variables: VARS,
+      connectionField: "cardsByCardgroupConnection",
+      edgeTypename: "CardEdge",
+      node: makeNode("new"),
+    });
+
+    expect(read(cache)).toBeNull();
+  });
+
+  it("seeds a fresh connection on a cold cache when buildColdConnection is provided", () => {
+    const cache = new InMemoryCache();
+
+    appendConnectionEdge(cache, {
+      document: CardsByCardgroupConnectionDocument,
+      variables: VARS,
+      connectionField: "cardsByCardgroupConnection",
+      edgeTypename: "CardEdge",
+      node: makeNode("cold"),
+      buildColdConnection,
+    });
+
+    const result = read(cache);
+    expect(result?.cardsByCardgroupConnection.edges.map((e) => e.node.id)).toEqual(["cold"]);
+    expect(result?.cardsByCardgroupConnection.totalCount).toBe(1);
+  });
+
+  it("prepends a new edge and bumps totalCount on a warm cache", () => {
+    const cache = new InMemoryCache();
+    seed(cache, makeConnection(["a", "b"], 2));
+
+    appendConnectionEdge(cache, {
+      document: CardsByCardgroupConnectionDocument,
+      variables: VARS,
+      connectionField: "cardsByCardgroupConnection",
+      edgeTypename: "CardEdge",
+      node: makeNode("new"),
+    });
+
+    const result = read(cache);
+    expect(result?.cardsByCardgroupConnection.edges.map((e) => e.node.id)).toEqual([
+      "new",
+      "a",
+      "b",
+    ]);
+    expect(result?.cardsByCardgroupConnection.totalCount).toBe(3);
+  });
+
+  it("skips the write when an edge with the same node.id already exists (dedup guard)", () => {
+    const cache = new InMemoryCache();
+    seed(cache, makeConnection(["a", "b"], 2));
+
+    appendConnectionEdge(cache, {
+      document: CardsByCardgroupConnectionDocument,
+      variables: VARS,
+      connectionField: "cardsByCardgroupConnection",
+      edgeTypename: "CardEdge",
+      node: makeNode("a"),
+    });
+
+    const result = read(cache);
+    expect(result?.cardsByCardgroupConnection.edges.map((e) => e.node.id)).toEqual(["a", "b"]);
+    expect(result?.cardsByCardgroupConnection.totalCount).toBe(2);
+  });
+});
+
+describe("removeConnectionEdges", () => {
+  it("removes a single edge and decrements totalCount (per-row delete)", () => {
+    const cache = new InMemoryCache();
+    seed(cache, makeConnection(["a", "b", "c"], 3));
+
+    removeConnectionEdges(cache, {
+      document: CardsByCardgroupConnectionDocument,
+      variables: VARS,
+      connectionField: "cardsByCardgroupConnection",
+      entityTypename: "Card",
+      ids: ["b"],
+      deletedCount: 1,
+    });
+
+    const result = read(cache);
+    expect(result?.cardsByCardgroupConnection.edges.map((e) => e.node.id)).toEqual(["a", "c"]);
+    expect(result?.cardsByCardgroupConnection.totalCount).toBe(2);
+  });
+
+  it("removes many edges in one call (bulk delete)", () => {
+    const cache = new InMemoryCache();
+    seed(cache, makeConnection(["a", "b", "c"], 3));
+
+    removeConnectionEdges(cache, {
+      document: CardsByCardgroupConnectionDocument,
+      variables: VARS,
+      connectionField: "cardsByCardgroupConnection",
+      entityTypename: "Card",
+      ids: ["a", "c"],
+      deletedCount: 2,
+    });
+
+    const result = read(cache);
+    expect(result?.cardsByCardgroupConnection.edges.map((e) => e.node.id)).toEqual(["b"]);
+    expect(result?.cardsByCardgroupConnection.totalCount).toBe(1);
+  });
+
+  it("clamps totalCount at 0 when deletedCount exceeds the loaded edge count", () => {
+    // Only one edge is in the cache, but the server deleted 5 (the rest live on
+    // pages that were never fetched into `edges`). The clamp keeps totalCount >= 0.
+    const cache = new InMemoryCache();
+    seed(cache, makeConnection(["a"], 3));
+
+    removeConnectionEdges(cache, {
+      document: CardsByCardgroupConnectionDocument,
+      variables: VARS,
+      connectionField: "cardsByCardgroupConnection",
+      entityTypename: "Card",
+      ids: ["a"],
+      deletedCount: 5,
+    });
+
+    const result = read(cache);
+    expect(result?.cardsByCardgroupConnection.edges).toEqual([]);
+    expect(result?.cardsByCardgroupConnection.totalCount).toBe(0);
+  });
+
+  it("evicts the normalized entities and runs gc", () => {
+    const cache = new InMemoryCache();
+    seed(cache, makeConnection(["a", "b"], 2));
+    const evictSpy = vi.spyOn(cache, "evict");
+    const gcSpy = vi.spyOn(cache, "gc");
+
+    removeConnectionEdges(cache, {
+      document: CardsByCardgroupConnectionDocument,
+      variables: VARS,
+      connectionField: "cardsByCardgroupConnection",
+      entityTypename: "Card",
+      ids: ["a"],
+      deletedCount: 1,
+    });
+
+    expect(evictSpy).toHaveBeenCalledWith({ id: "Card:a" });
+    expect(gcSpy).toHaveBeenCalledTimes(1);
+    // The normalized Card:a entry is gone after evict + gc.
+    expect(cache.extract()["Card:a"]).toBeUndefined();
+  });
+
+  it("still evicts + gcs on a cold cache (no connection seeded)", () => {
+    const cache = new InMemoryCache();
+    const evictSpy = vi.spyOn(cache, "evict");
+    const gcSpy = vi.spyOn(cache, "gc");
+
+    removeConnectionEdges(cache, {
+      document: CardsByCardgroupConnectionDocument,
+      variables: VARS,
+      connectionField: "cardsByCardgroupConnection",
+      entityTypename: "Card",
+      ids: ["a"],
+      deletedCount: 1,
+    });
+
+    expect(evictSpy).toHaveBeenCalledWith({ id: "Card:a" });
+    expect(gcSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/lib/apollo/connection-cache.ts
+++ b/frontend/src/lib/apollo/connection-cache.ts
@@ -1,0 +1,191 @@
+import type { ApolloCache, OperationVariables } from "@apollo/client";
+import type { TypedDocumentNode } from "@graphql-typed-document-node/core";
+
+/**
+ * Generic Relay-Connection cache helpers.
+ *
+ * The "append edge + bump totalCount" and "filter edge by node.id + clamp
+ * totalCount at 0 + evict + gc" blocks were copy-pasted across every paginated
+ * mutation hook. The cache invariants they enforce — resolve an edge by
+ * `node.id` (never `edge.cursor`), clamp `totalCount` at `Math.max(0, …)`, use
+ * `readQuery` + `writeQuery` (never `cache.modify`, which skips non-existent
+ * fields) — are documented in `.claude/rules/pagination.md`. Centralizing the
+ * mechanics here means a fix to any invariant lands once instead of being
+ * hand-propagated to N call sites.
+ *
+ * These helpers are behavior-preserving factor-outs. They take the live
+ * `variables` object by reference (never re-spell it) so the cache key matches
+ * the `useQuery`-keyed entry under any active search filter — see
+ * `docs/pagination/optimistic-rollback-cache-key.md`.
+ */
+
+/** A single `{ __typename, cursor, node }` edge of a Relay connection. */
+interface ConnectionEdge<TTypename extends string, TNode extends { id: string }> {
+  __typename: TTypename;
+  cursor: string;
+  node: TNode;
+}
+
+/** The minimal `<Type>Connection` shape these helpers read and write. */
+interface ConnectionShape<TEdge> {
+  __typename: string;
+  edges: TEdge[];
+  pageInfo: {
+    __typename: "PageInfo";
+    hasNextPage: boolean;
+    hasPreviousPage: boolean;
+    startCursor: string | null;
+    endCursor: string | null;
+  };
+  totalCount: number;
+}
+
+interface AppendConnectionEdgeInput<
+  TData,
+  TVariables extends OperationVariables,
+  K extends keyof TData,
+  TNode extends { id: string },
+> {
+  /** The connection query document (provides `TData` / `TVariables`). */
+  document: TypedDocumentNode<TData, TVariables>;
+  /**
+   * The live query variables, passed by reference so the cache key matches the
+   * `useQuery`-keyed entry. Never re-spell this object.
+   */
+  variables: TVariables;
+  /** The connection field key on `TData` (e.g. `"cardsByCardgroupConnection"`). */
+  connectionField: K;
+  /** The `__typename` of an edge (e.g. `"CardEdge"`). */
+  edgeTypename: string;
+  /** The complete node to prepend as a new edge. */
+  node: TNode;
+  /**
+   * Build a fresh connection when the cache is cold (no SSR seed). Omit to
+   * no-op on a cold cache — the card hooks rely on the page's own `useQuery`
+   * to populate the connection, so a cold-cache write would be discarded.
+   */
+  buildColdConnection?: () => TData[K];
+}
+
+interface RemoveConnectionEdgesInput<
+  TData,
+  TVariables extends OperationVariables,
+  K extends keyof TData,
+> {
+  /** The connection query document (provides `TData` / `TVariables`). */
+  document: TypedDocumentNode<TData, TVariables>;
+  /**
+   * The live query variables, passed by reference so the cache key matches the
+   * `useQuery`-keyed entry. Never re-spell this object.
+   */
+  variables: TVariables;
+  /** The connection field key on `TData` (e.g. `"cardsByCardgroupConnection"`). */
+  connectionField: K;
+  /** The `__typename` of an entity, used to evict the normalized entry. */
+  entityTypename: string;
+  /** The ids of the nodes to remove (bulk delete passes many, per-row passes one). */
+  ids: string[];
+  /**
+   * The number to decrement `totalCount` by, clamped at 0 — the deleted item may
+   * live on a page that was never fetched into `edges`, so the array filter alone
+   * underestimates the removal.
+   */
+  deletedCount: number;
+}
+
+/**
+ * Prepend a freshly-created complete node as a new `{ cursor, node }` edge to
+ * the cached connection and bump `totalCount`.
+ *
+ * Cold-cache behavior is caller-controlled:
+ * - Omit `buildColdConnection` to no-op when `readQuery` returns `null` (the
+ *   card hooks: the page's own `useQuery` owns connection population).
+ * - Provide `buildColdConnection` to seed a fresh connection (create-from-anywhere
+ *   cases that must surface the new edge on a route the user may land on directly).
+ *
+ * The dedup guard skips the write if an edge with the same `node.id` already
+ * exists. No `cache.writeFragment` is needed: the appended node carries its full
+ * projection, so `writeQuery` normalizes it into the standalone `<Type>:<id>`
+ * entry on its own.
+ */
+export function appendConnectionEdge<
+  TData,
+  TVariables extends OperationVariables,
+  K extends keyof TData,
+  TNode extends { id: string },
+>(cache: ApolloCache, input: AppendConnectionEdgeInput<TData, TVariables, K, TNode>): void {
+  const { document, variables, connectionField, edgeTypename, node, buildColdConnection } = input;
+
+  const existing = cache.readQuery({ query: document, variables });
+
+  const newEdge: ConnectionEdge<string, { id: string }> = {
+    __typename: edgeTypename,
+    cursor: node.id,
+    node,
+  };
+
+  if (!existing) {
+    if (!buildColdConnection) return;
+    cache.writeQuery({
+      query: document,
+      variables,
+      data: { [connectionField]: buildColdConnection() } as TData,
+    });
+    return;
+  }
+
+  const current = existing[connectionField] as ConnectionShape<
+    ConnectionEdge<string, { id: string }>
+  >;
+  if (current.edges.some((edge) => edge.node.id === node.id)) return;
+
+  const nextConnection = {
+    ...current,
+    edges: [newEdge, ...current.edges],
+    totalCount: current.totalCount + 1,
+  };
+
+  cache.writeQuery({
+    query: document,
+    variables,
+    data: { [connectionField]: nextConnection } as unknown as TData,
+  });
+}
+
+/**
+ * Remove edges whose `node.id` is in `ids` from the cached connection, decrement
+ * `totalCount` (clamped at 0), then evict + gc the normalized entities.
+ *
+ * Covers both bulk delete (`ids.length > 1`) and per-row delete (`ids.length === 1`).
+ * No-ops on a cold cache for the edge filter, but always evicts + gcs so the
+ * normalized entries are dropped regardless of whether the connection was seeded.
+ */
+export function removeConnectionEdges<
+  TData,
+  TVariables extends OperationVariables,
+  K extends keyof TData,
+>(cache: ApolloCache, input: RemoveConnectionEdgesInput<TData, TVariables, K>): void {
+  const { document, variables, connectionField, entityTypename, ids, deletedCount } = input;
+
+  const existing = cache.readQuery({ query: document, variables });
+  if (existing) {
+    const current = existing[connectionField] as ConnectionShape<
+      ConnectionEdge<string, { id: string }>
+    >;
+    const nextConnection = {
+      ...current,
+      edges: current.edges.filter((edge) => !ids.includes(edge.node.id)),
+      totalCount: Math.max(0, current.totalCount - deletedCount),
+    };
+    cache.writeQuery({
+      query: document,
+      variables,
+      data: { [connectionField]: nextConnection } as unknown as TData,
+    });
+  }
+
+  for (const id of ids) {
+    cache.evict({ id: cache.identify({ __typename: entityTypename, id }) });
+  }
+  cache.gc();
+}


### PR DESCRIPTION
## Summary

Extracts the duplicated Apollo **Connection cache-update** logic into two generic, well-typed helpers and adopts them in the two card-mutation hooks. Behavior-preserving factor-out — no cache pattern changes.

Closes #596.

## Background / Motivation

The "append edge + bump `totalCount`" block and the "filter edge by `node.id` + clamp `totalCount` at 0 + evict + gc" block were copy-pasted across mutation hooks. A fix to any cache invariant (the `Math.max(0, …)` clamp, resolve-by-`node.id`, cold-cache handling) had to be hand-propagated to up to five sites — the exact `totalCount`/edge-key drift class the pagination L3 rule warns about.

## Changes

- **Add** `frontend/src/lib/apollo/connection-cache.ts` — `appendConnectionEdge` / `removeConnectionEdges`, generic over the query type, the connection field key, and the node type. `appendConnectionEdge` takes an optional `buildColdConnection?`; omitting it preserves the card hooks' cold-cache **no-op**.
- **Add** `frontend/src/lib/apollo/connection-cache.test.ts` — 12 tests (cold-cache no-op, cold-cache seed, dedup guard, clamp-at-0, evict+gc-called, cold-cache-still-evicts).
- **Modify** `use-card-mutations.ts` / `use-master-card-mutations.ts` — delegate the read/transform/write/evict mechanics (net −82 lines). Out-of-scope sites (`cardgroups/cache.ts`, `use-master-mutations.ts`, `cardgroups-client.tsx`, `use-admin-user-mutations.ts`) deliberately untouched.

Preserved invariants: `variables` passed by reference, the `edges.some(e => e.node.id === node.id)` dedup guard, prepend order, `totalCount` clamp, `cache.evict` + `cache.gc` on delete, resolve-by-`node.id` (never `edge.cursor`). The per-row undoable optimistic-delete path stays inline (deferred follow-up).

## Verification (in worktree)

- `tsc --noEmit` — pass. `biome check --error-on-warnings` — clean. `knip` — clean.
- Targeted vitest — **71 tests pass** across `connection-cache`, `use-master-card-mutations`, `cards-client`, `master-cards-client`, `use-cards-connection`.
- The `client.readQuery/writeQuery` → `cache.readQuery/writeQuery` API shift was verified against installed `@apollo/client@4.2.3` (watcher broadcast still fires; the write+read round-trip is symmetric on the un-transformed codegen doc) and proven empirically by the new test.
- No CJK; production build runs in CI.

## Test plan

- [ ] Create a card in a cardgroup and a master deck — confirm it appears at the top of the list without refetch.
- [ ] Bulk-delete and single-delete cards — confirm the count decrements (never below 0) and the rows disappear.
