### PR TITLE
refactor(frontend): unify card mutation hooks via generic useEntityCardMutations

### DIFF
--- a/frontend/src/app/admin/masters/[id]/edit/cards/use-master-card-mutations.test.tsx
+++ b/frontend/src/app/admin/masters/[id]/edit/cards/use-master-card-mutations.test.tsx
@@ -127,8 +127,10 @@ describe("useMasterCardMutations", () => {
       join(process.cwd(), "src/app/admin/masters/[id]/edit/cards/use-master-card-mutations.ts"),
       "utf8",
     );
-    // Matches the option key `optimisticResponse:` passed to a mutation call;
-    // tolerates the documenting comment `optimisticResponse` (backtick, not colon, follows).
+    // The wrapper now delegates to useEntityCardMutations, so the mutation
+    // calls (and thus the real optimisticResponse risk) live in the generic
+    // hook — its guard is in src/lib/cards/use-entity-card-mutations.test.tsx.
+    // This assertion still pins the wrapper itself clean.
     expect(src).not.toMatch(/optimisticResponse\s*:/);
   });
 });

--- a/frontend/src/app/admin/masters/[id]/edit/cards/use-master-card-mutations.ts
+++ b/frontend/src/app/admin/masters/[id]/edit/cards/use-master-card-mutations.ts
@@ -1,14 +1,13 @@
 "use client";
 
-import { useApolloClient, useMutation } from "@apollo/client/react";
-import { useCallback, useState } from "react";
 import {
   AdminMasterCardsConnectionDocument,
-  type AdminMasterCardsConnectionQuery,
   type AdminMasterCardsConnectionQueryVariables,
 } from "@/generated/graphql";
-import { appendConnectionEdge, removeConnectionEdges } from "@/lib/apollo/connection-cache";
-import { useUndoDelete } from "@/lib/undo-delete";
+import {
+  createEntityCardMutationsConfig,
+  useEntityCardMutations,
+} from "@/lib/cards/use-entity-card-mutations";
 import {
   AdminCreateMasterCard,
   AdminDeleteMasterCard,
@@ -17,254 +16,77 @@ import {
   masterCardsDefaultVars,
 } from "./queries";
 
-type MasterCardNode =
-  AdminMasterCardsConnectionQuery["adminMasterCardsConnection"]["edges"][number]["node"];
-
-/** Outcome of a create attempt; the client maps it to validation / sheet / banner state. */
-type CreateCardOutcome =
-  | { status: "success" }
-  | { status: "validation"; field: string; message: string }
-  | { status: "unexpected" }
-  | { status: "rejected" };
-
-/** Outcome of an update attempt; the client maps it to the inline row validation error. */
-type UpdateCardOutcome =
-  | { status: "success" }
-  | { status: "validation"; field: string; message: string }
-  | { status: "unexpected" }
-  | { status: "rejected" };
-
-function cardMatchesSearch(card: MasterCardNode, searchValue: string): boolean {
-  const normalized = searchValue.trim().toLowerCase();
-  if (normalized === "") return true;
-  return (
-    card.front.toLowerCase().includes(normalized) || card.back.toLowerCase().includes(normalized)
-  );
-}
+const MASTER_CARD_MUTATIONS_CONFIG = createEntityCardMutationsConfig({
+  scope: "[useMasterCardMutations]",
+  ownerLogKey: "masterId",
+  createOpName: "adminCreateMasterCard",
+  updateOpName: "adminUpdateMasterCard",
+  connectionDocument: AdminMasterCardsConnectionDocument,
+  connectionField: "adminMasterCardsConnection",
+  edgeTypename: "MasterCardEdge",
+  entityTypename: "MasterCard",
+  defaultVars: masterCardsDefaultVars,
+  createDocument: AdminCreateMasterCard,
+  buildCreateVariables: (masterId, values) => ({
+    input: { masterCardgroupId: masterId, front: values.front, back: values.back },
+  }),
+  classifyCreate: (data) => {
+    const payload = data?.adminCreateMasterCard;
+    if (payload?.__typename === "CreateMasterCardSuccess") {
+      return { kind: "success", node: payload.masterCard };
+    }
+    if (payload?.__typename === "MasterCardDuplicateFrontError") {
+      return { kind: "duplicate", message: payload.message };
+    }
+    return {
+      kind: "unknown",
+      typename: (payload as { __typename?: string } | null | undefined)?.__typename ?? null,
+    };
+  },
+  updateDocument: AdminUpdateMasterCard,
+  buildUpdateVariables: (id, values) => ({
+    id,
+    input: { front: values.front, back: values.back },
+  }),
+  classifyUpdate: (data) => {
+    const payload = data?.adminUpdateMasterCard;
+    if (payload?.__typename === "UpdateMasterCardSuccess") {
+      return { kind: "success" };
+    }
+    if (payload?.__typename === "InputValidationError") {
+      return { kind: "validation", field: payload.field, message: payload.message };
+    }
+    return {
+      kind: "unknown",
+      typename: (payload as { __typename?: string } | null | undefined)?.__typename ?? null,
+    };
+  },
+  deleteOneDocument: AdminDeleteMasterCard,
+  extractDeleteOne: (data) => Boolean(data?.adminDeleteMasterCard),
+  deleteManyDocument: AdminDeleteMasterCards,
+  extractDeleteManyCount: (data) => data?.adminDeleteMasterCards,
+});
 
 export interface UseMasterCardMutationsInput {
   masterId: string;
   /**
    * The connection's active query variables (search-filter-aware). MUST be the
-   * same object the live `useQuery` is keyed on so cache reads/writes land on the
-   * right entry under any active search filter.
+   * same object the live `useQuery` is keyed on so cache reads/writes land on
+   * the right entry under any active search filter.
    * See docs/pagination/optimistic-rollback-cache-key.md.
    */
   queryVariables: AdminMasterCardsConnectionQueryVariables;
 }
 
 /**
- * Owns the four master card mutations (create / update / per-row delete / bulk delete)
- * and every Apollo cache write they perform. The client maps the returned typed
- * outcomes to sheet navigation, validation, and banner state. Mirrors the
- * thin-outcome-hook shape of `useMasterMutations` / `useAdminUserMutations`.
- *
- * No `optimisticResponse`: typed errors (MasterCardDuplicateFrontError,
- * InputValidationError, UNAUTHENTICATED, FORBIDDEN) can fail these mutations and
- * Apollo does not reliably roll back optimistic writes for typed GraphQL errors
- * — see .claude/rules/pagination.md.
+ * Owns the four master-card mutations for the `/admin/masters/[id]/edit/cards`
+ * screen, delegating all logic to the generic `useEntityCardMutations`. Thin
+ * wrapper: binds the master-card config and translates the route's `masterId`
+ * to the generic hook's `ownerId`.
  */
 export function useMasterCardMutations({ masterId, queryVariables }: UseMasterCardMutationsInput) {
-  const apollo = useApolloClient();
-  const { scheduleDelete } = useUndoDelete();
-
-  const [
-    createMasterCardMutation,
-    { loading: creating, error: createError, reset: resetCreateCard },
-  ] = useMutation(AdminCreateMasterCard);
-  // Updates propagate automatically via Apollo cache normalization (MasterCard has id).
-  const [updateMasterCardMutation, { loading: updating, error: updateError }] =
-    useMutation(AdminUpdateMasterCard);
-  // scheduleDelete (5s undo window) fires the per-row mutation imperatively.
-  const [deleteMasterCardMutation] = useMutation(AdminDeleteMasterCard);
-
-  const [deleteCardsMutation, { error: bulkDeleteError, loading: bulkDeleting }] = useMutation(
-    AdminDeleteMasterCards,
-    {
-      // queryVariables matches the live cache entry under any active search filter.
-      // See docs/pagination/optimistic-rollback-cache-key.md.
-      update(cache, { data: bulkData }, { variables: mutationVars }) {
-        const ids = mutationVars?.ids as string[] | undefined;
-        if (!ids) return;
-        if (bulkData?.adminDeleteMasterCards == null) return;
-        const deletedCount = bulkData.adminDeleteMasterCards;
-        if (deletedCount === 0) return;
-        removeConnectionEdges(cache, {
-          document: AdminMasterCardsConnectionDocument,
-          variables: queryVariables,
-          connectionField: "adminMasterCardsConnection",
-          entityTypename: "MasterCard",
-          ids,
-          deletedCount,
-        });
-      },
-    },
-  );
-
-  // Per-row delete commit error — surfaced after the 5s undo window elapses and
-  // the DELETE mutation rejects. Stored as the raw error so the client derives
-  // the localized banner copy; persists across mutation calls. See
-  // docs/pagination/do-not-reuse-mutation-error-state.md.
-  const [deleteRowError, setDeleteRowError] = useState<unknown>(null);
-
-  // Write a freshly-created master card to the connection cached under `variables`.
-  // No `buildColdConnection`: on a cold cache this no-ops and the page's own
-  // `useQuery` owns populating the connection.
-  const writeCreatedMasterCardToConnection = useCallback(
-    (card: MasterCardNode, variables: AdminMasterCardsConnectionQueryVariables) => {
-      appendConnectionEdge(apollo.cache, {
-        document: AdminMasterCardsConnectionDocument,
-        variables,
-        connectionField: "adminMasterCardsConnection",
-        edgeTypename: "MasterCardEdge",
-        node: card,
-      });
-    },
-    [apollo],
-  );
-
-  const createCard = useCallback(
-    async (values: { front: string; back: string }): Promise<CreateCardOutcome> => {
-      const result = await createMasterCardMutation({
-        variables: {
-          input: { masterCardgroupId: masterId, front: values.front, back: values.back },
-        },
-      }).catch((err) => {
-        console.error("[useMasterCardMutations] create rejection", {
-          name: err instanceof Error ? err.name : "unknown",
-          masterId,
-        });
-        return null;
-      });
-      if (!result) return { status: "rejected" };
-
-      const payload = result.data?.adminCreateMasterCard;
-      if (payload?.__typename === "CreateMasterCardSuccess") {
-        writeCreatedMasterCardToConnection(payload.masterCard, masterCardsDefaultVars(masterId));
-        if (
-          typeof queryVariables.search === "string" &&
-          cardMatchesSearch(payload.masterCard, queryVariables.search)
-        ) {
-          writeCreatedMasterCardToConnection(payload.masterCard, queryVariables);
-        }
-        return { status: "success" };
-      }
-      if (payload?.__typename === "MasterCardDuplicateFrontError") {
-        return { status: "validation", field: "front", message: payload.message };
-      }
-      const unknownPayload = payload as unknown as { __typename?: string } | null | undefined;
-      console.warn("[useMasterCardMutations] unexpected adminCreateMasterCard payload", {
-        typename: unknownPayload?.__typename ?? null,
-        masterId,
-      });
-      return { status: "unexpected" };
-    },
-    [masterId, createMasterCardMutation, queryVariables, writeCreatedMasterCardToConnection],
-  );
-
-  const updateCard = useCallback(
-    async (id: string, values: { front: string; back: string }): Promise<UpdateCardOutcome> => {
-      const result = await updateMasterCardMutation({
-        variables: { id, input: { front: values.front, back: values.back } },
-      }).catch((err) => {
-        console.error("[useMasterCardMutations] update rejection", {
-          name: err instanceof Error ? err.name : "unknown",
-          masterId,
-          cardId: id,
-        });
-        return null;
-      });
-      if (!result) return { status: "rejected" };
-
-      const payload = result.data?.adminUpdateMasterCard;
-      if (payload?.__typename === "UpdateMasterCardSuccess") {
-        return { status: "success" };
-      }
-      if (payload?.__typename === "InputValidationError") {
-        return { status: "validation", field: payload.field, message: payload.message };
-      }
-      const unknownPayload = payload as unknown as { __typename?: string } | null | undefined;
-      console.warn("[useMasterCardMutations] unexpected adminUpdateMasterCard payload", {
-        typename: unknownPayload?.__typename ?? null,
-        cardId: id,
-        masterId,
-      });
-      return { status: "unexpected" };
-    },
-    [masterId, updateMasterCardMutation],
-  );
-
-  // Per-row delete: snapshot, optimistic drop, schedule DELETE with a 5s undo
-  // window. See docs/pagination/optimistic-rollback-cache-key.md for the
-  // queryVariables rule. `label` is the caller-supplied (localized) toast title.
-  const deleteRow = useCallback(
-    (cardId: string, label: string) => {
-      const snapshot = apollo.readQuery({
-        query: AdminMasterCardsConnectionDocument,
-        variables: queryVariables,
-      });
-      if (snapshot) {
-        const next = snapshot.adminMasterCardsConnection;
-        apollo.writeQuery({
-          query: AdminMasterCardsConnectionDocument,
-          variables: queryVariables,
-          data: {
-            adminMasterCardsConnection: {
-              ...next,
-              edges: next.edges.filter((edge) => edge.node.id !== cardId),
-              totalCount: Math.max(0, next.totalCount - 1),
-            },
-          },
-        });
-      }
-      scheduleDelete({
-        id: cardId,
-        label,
-        optimisticRollback: () => {
-          if (snapshot !== null) {
-            apollo.writeQuery({
-              query: AdminMasterCardsConnectionDocument,
-              variables: queryVariables,
-              data: snapshot,
-            });
-          }
-          setDeleteRowError(null);
-        },
-        commitDelete: async () => {
-          setDeleteRowError(null);
-          const result = await deleteMasterCardMutation({ variables: { id: cardId } });
-          if (result.data?.adminDeleteMasterCard) {
-            apollo.cache.evict({
-              id: apollo.cache.identify({ __typename: "MasterCard", id: cardId }),
-            });
-            apollo.cache.gc();
-          }
-        },
-        onCommitFailed: (err) => {
-          setDeleteRowError(err);
-        },
-      });
-    },
-    [apollo, deleteMasterCardMutation, queryVariables, scheduleDelete],
-  );
-
-  const deleteCards = useCallback(
-    (ids: string[]) => deleteCardsMutation({ variables: { ids } }),
-    [deleteCardsMutation],
-  );
-
-  return {
-    createCard,
-    updateCard,
-    deleteRow,
-    deleteCards,
-    creating,
-    updating,
-    bulkDeleting,
-    createError,
-    updateError,
-    bulkDeleteError,
-    deleteRowError,
-    resetCreateCard,
-  };
+  return useEntityCardMutations(MASTER_CARD_MUTATIONS_CONFIG, {
+    ownerId: masterId,
+    queryVariables,
+  });
 }

--- a/frontend/src/app/cardgroups/[id]/cards/use-card-mutations.ts
+++ b/frontend/src/app/cardgroups/[id]/cards/use-card-mutations.ts
@@ -1,7 +1,5 @@
 "use client";
 
-import { useApolloClient, useMutation } from "@apollo/client/react";
-import { useCallback, useState } from "react";
 import {
   CreateCardMutation,
   DeleteCardMutation,
@@ -10,44 +8,74 @@ import {
 } from "@/app/cardgroups/queries";
 import {
   CardsByCardgroupConnectionDocument,
-  type CardsByCardgroupConnectionQuery,
   type CardsByCardgroupConnectionQueryVariables,
 } from "@/generated/graphql";
-import { appendConnectionEdge, removeConnectionEdges } from "@/lib/apollo/connection-cache";
-import { useUndoDelete } from "@/lib/undo-delete";
+import {
+  createEntityCardMutationsConfig,
+  useEntityCardMutations,
+} from "@/lib/cards/use-entity-card-mutations";
 import { cardsDefaultVars } from "./queries";
 
-type CardNode =
-  CardsByCardgroupConnectionQuery["cardsByCardgroupConnection"]["edges"][number]["node"];
-
-/** Outcome of a create attempt; the client maps it to validation / sheet / banner state. */
-type CreateCardOutcome =
-  | { status: "success" }
-  | { status: "validation"; field: string; message: string }
-  | { status: "unexpected" }
-  | { status: "rejected" };
-
-/** Outcome of an update attempt; the client maps it to the inline row validation error. */
-type UpdateCardOutcome =
-  | { status: "success" }
-  | { status: "validation"; field: string; message: string }
-  | { status: "unexpected" }
-  | { status: "rejected" };
-
-function cardMatchesSearch(card: CardNode, searchValue: string): boolean {
-  const normalized = searchValue.trim().toLowerCase();
-  if (normalized === "") return true;
-  return (
-    card.front.toLowerCase().includes(normalized) || card.back.toLowerCase().includes(normalized)
-  );
-}
+// Static config: documents, typenames, and the typed classifier/builder
+// callbacks. A module constant so the generic hook's useCallback memoization
+// stays stable across renders.
+const CARD_MUTATIONS_CONFIG = createEntityCardMutationsConfig({
+  scope: "[useCardMutations]",
+  ownerLogKey: "cardgroupId",
+  createOpName: "createCard",
+  updateOpName: "updateCard",
+  connectionDocument: CardsByCardgroupConnectionDocument,
+  connectionField: "cardsByCardgroupConnection",
+  edgeTypename: "CardEdge",
+  entityTypename: "Card",
+  defaultVars: cardsDefaultVars,
+  createDocument: CreateCardMutation,
+  buildCreateVariables: (cardgroupId, values) => ({
+    input: { cardgroupId, front: values.front, back: values.back },
+  }),
+  classifyCreate: (data) => {
+    const payload = data?.createCard;
+    if (payload?.__typename === "CreateCardSuccess") {
+      return { kind: "success", node: payload.card };
+    }
+    if (payload?.__typename === "CardDuplicateFrontError") {
+      return { kind: "duplicate", message: payload.message };
+    }
+    return {
+      kind: "unknown",
+      typename: (payload as { __typename?: string } | null | undefined)?.__typename ?? null,
+    };
+  },
+  updateDocument: UpdateCardMutation,
+  buildUpdateVariables: (id, values) => ({
+    id,
+    input: { front: values.front, back: values.back },
+  }),
+  classifyUpdate: (data) => {
+    const payload = data?.updateCard;
+    if (payload?.__typename === "UpdateCardSuccess") {
+      return { kind: "success" };
+    }
+    if (payload?.__typename === "InputValidationError") {
+      return { kind: "validation", field: payload.field, message: payload.message };
+    }
+    return {
+      kind: "unknown",
+      typename: (payload as { __typename?: string } | null | undefined)?.__typename ?? null,
+    };
+  },
+  deleteOneDocument: DeleteCardMutation,
+  extractDeleteOne: (data) => Boolean(data?.deleteCard),
+  deleteManyDocument: DeleteCardsMutation,
+  extractDeleteManyCount: (data) => data?.deleteCards,
+});
 
 export interface UseCardMutationsInput {
   cardgroupId: string;
   /**
    * The connection's active query variables (search-filter-aware). MUST be the
-   * same object the live `useQuery` is keyed on so cache reads/writes land on the
-   * right entry under any active search filter.
+   * same object the live `useQuery` is keyed on so cache reads/writes land on
+   * the right entry under any active search filter.
    * See docs/pagination/optimistic-rollback-cache-key.md.
    */
   queryVariables: CardsByCardgroupConnectionQueryVariables;
@@ -55,210 +83,13 @@ export interface UseCardMutationsInput {
 
 /**
  * Owns the four card mutations (create / update / per-row delete / bulk delete)
- * and every Apollo cache write they perform. The client maps the returned typed
- * outcomes to sheet navigation, validation, and banner state. Mirrors the
- * thin-outcome-hook shape of `useMasterMutations` / `useAdminUserMutations`.
- *
- * No `optimisticResponse`: typed errors (CardDuplicateFrontError,
- * InputValidationError, UNAUTHENTICATED, FORBIDDEN) can fail these mutations and
- * Apollo does not reliably roll back optimistic writes for typed GraphQL errors
- * — see .claude/rules/pagination.md.
+ * for the `/cardgroups/[id]/cards` screen, delegating all logic to the generic
+ * `useEntityCardMutations`. Thin wrapper: binds the card config and translates
+ * the route's `cardgroupId` to the generic hook's `ownerId`.
  */
 export function useCardMutations({ cardgroupId, queryVariables }: UseCardMutationsInput) {
-  const apollo = useApolloClient();
-  const { scheduleDelete } = useUndoDelete();
-
-  const [createCardMutation, { loading: creating, error: createError, reset: resetCreateCard }] =
-    useMutation(CreateCardMutation);
-  // Updates propagate automatically via Apollo cache normalization (Card has id).
-  const [updateCardMutation, { loading: updating, error: updateError }] =
-    useMutation(UpdateCardMutation);
-  // scheduleDelete (5s undo window) fires the per-row mutation imperatively.
-  const [deleteCardMutation] = useMutation(DeleteCardMutation);
-
-  const [deleteCardsMutation, { error: bulkDeleteError, loading: bulkDeleting }] = useMutation(
-    DeleteCardsMutation,
-    {
-      // queryVariables matches the live cache entry under any active search filter.
-      // See docs/pagination/optimistic-rollback-cache-key.md.
-      update(cache, { data: bulkData }, { variables: mutationVars }) {
-        const ids = mutationVars?.ids as string[] | undefined;
-        if (!ids) return;
-        if (bulkData?.deleteCards == null) return;
-        const deletedCount = bulkData.deleteCards;
-        if (deletedCount === 0) return;
-        removeConnectionEdges(cache, {
-          document: CardsByCardgroupConnectionDocument,
-          variables: queryVariables,
-          connectionField: "cardsByCardgroupConnection",
-          entityTypename: "Card",
-          ids,
-          deletedCount,
-        });
-      },
-    },
-  );
-
-  // Per-row delete commit error — surfaced after the 5s undo window elapses and
-  // the DELETE mutation rejects. Stored as the raw error so the client derives
-  // the localized banner copy; persists across mutation calls. See
-  // docs/pagination/do-not-reuse-mutation-error-state.md.
-  const [deleteRowError, setDeleteRowError] = useState<unknown>(null);
-
-  // Write a freshly-created card to the connection cached under `variables`.
-  // No `buildColdConnection`: on a cold cache this no-ops and the page's own
-  // `useQuery` owns populating the connection.
-  const writeCreatedCardToConnection = useCallback(
-    (card: CardNode, variables: CardsByCardgroupConnectionQueryVariables) => {
-      appendConnectionEdge(apollo.cache, {
-        document: CardsByCardgroupConnectionDocument,
-        variables,
-        connectionField: "cardsByCardgroupConnection",
-        edgeTypename: "CardEdge",
-        node: card,
-      });
-    },
-    [apollo],
-  );
-
-  const createCard = useCallback(
-    async (values: { front: string; back: string }): Promise<CreateCardOutcome> => {
-      const result = await createCardMutation({
-        variables: { input: { cardgroupId, front: values.front, back: values.back } },
-      }).catch((err) => {
-        console.error("[useCardMutations] create rejection", {
-          name: err instanceof Error ? err.name : "unknown",
-          cardgroupId,
-        });
-        return null;
-      });
-      if (!result) return { status: "rejected" };
-
-      const payload = result.data?.createCard;
-      if (payload?.__typename === "CreateCardSuccess") {
-        writeCreatedCardToConnection(payload.card, cardsDefaultVars(cardgroupId));
-        if (
-          typeof queryVariables.search === "string" &&
-          cardMatchesSearch(payload.card, queryVariables.search)
-        ) {
-          writeCreatedCardToConnection(payload.card, queryVariables);
-        }
-        return { status: "success" };
-      }
-      if (payload?.__typename === "CardDuplicateFrontError") {
-        return { status: "validation", field: "front", message: payload.message };
-      }
-      const unknownPayload = payload as unknown as { __typename?: string } | null | undefined;
-      console.warn("[useCardMutations] unexpected createCard payload", {
-        typename: unknownPayload?.__typename ?? null,
-        cardgroupId,
-      });
-      return { status: "unexpected" };
-    },
-    [cardgroupId, createCardMutation, queryVariables, writeCreatedCardToConnection],
-  );
-
-  const updateCard = useCallback(
-    async (id: string, values: { front: string; back: string }): Promise<UpdateCardOutcome> => {
-      const result = await updateCardMutation({
-        variables: { id, input: { front: values.front, back: values.back } },
-      }).catch((err) => {
-        console.error("[useCardMutations] update rejection", {
-          name: err instanceof Error ? err.name : "unknown",
-          cardgroupId,
-          cardId: id,
-        });
-        return null;
-      });
-      if (!result) return { status: "rejected" };
-
-      const payload = result.data?.updateCard;
-      if (payload?.__typename === "UpdateCardSuccess") {
-        return { status: "success" };
-      }
-      if (payload?.__typename === "InputValidationError") {
-        return { status: "validation", field: payload.field, message: payload.message };
-      }
-      const unknownPayload = payload as unknown as { __typename?: string } | null | undefined;
-      console.warn("[useCardMutations] unexpected updateCard payload", {
-        typename: unknownPayload?.__typename ?? null,
-        cardId: id,
-        cardgroupId,
-      });
-      return { status: "unexpected" };
-    },
-    [cardgroupId, updateCardMutation],
-  );
-
-  // Per-row delete: snapshot, optimistic drop, schedule DELETE with a 5s undo
-  // window. See docs/pagination/optimistic-rollback-cache-key.md for the
-  // queryVariables rule. `label` is the caller-supplied (localized) toast title.
-  const deleteRow = useCallback(
-    (cardId: string, label: string) => {
-      const snapshot = apollo.readQuery({
-        query: CardsByCardgroupConnectionDocument,
-        variables: queryVariables,
-      });
-      if (snapshot) {
-        const next = snapshot.cardsByCardgroupConnection;
-        apollo.writeQuery({
-          query: CardsByCardgroupConnectionDocument,
-          variables: queryVariables,
-          data: {
-            cardsByCardgroupConnection: {
-              ...next,
-              edges: next.edges.filter((edge) => edge.node.id !== cardId),
-              totalCount: Math.max(0, next.totalCount - 1),
-            },
-          },
-        });
-      }
-      scheduleDelete({
-        id: cardId,
-        label,
-        optimisticRollback: () => {
-          if (snapshot !== null) {
-            apollo.writeQuery({
-              query: CardsByCardgroupConnectionDocument,
-              variables: queryVariables,
-              data: snapshot,
-            });
-          }
-          setDeleteRowError(null);
-        },
-        commitDelete: async () => {
-          setDeleteRowError(null);
-          const result = await deleteCardMutation({ variables: { id: cardId } });
-          if (result.data?.deleteCard) {
-            apollo.cache.evict({ id: apollo.cache.identify({ __typename: "Card", id: cardId }) });
-            apollo.cache.gc();
-          }
-        },
-        onCommitFailed: (err) => {
-          setDeleteRowError(err);
-        },
-      });
-    },
-    [apollo, deleteCardMutation, queryVariables, scheduleDelete],
-  );
-
-  const deleteCards = useCallback(
-    (ids: string[]) => deleteCardsMutation({ variables: { ids } }),
-    [deleteCardsMutation],
-  );
-
-  return {
-    createCard,
-    updateCard,
-    deleteRow,
-    deleteCards,
-    creating,
-    updating,
-    bulkDeleting,
-    createError,
-    updateError,
-    bulkDeleteError,
-    deleteRowError,
-    resetCreateCard,
-  };
+  return useEntityCardMutations(CARD_MUTATIONS_CONFIG, {
+    ownerId: cardgroupId,
+    queryVariables,
+  });
 }

--- a/frontend/src/lib/cards/card-mutation-outcomes.ts
+++ b/frontend/src/lib/cards/card-mutation-outcomes.ts
@@ -1,0 +1,45 @@
+/**
+ * Shared outcome types and search predicate for the card mutation hooks.
+ *
+ * The cards (`/cardgroups/[id]/cards`) and master-cards
+ * (`/admin/masters/[id]/edit/cards`) screens both drive their create/update
+ * mutations through `useEntityCardMutations`. Their typed outcome unions and
+ * the front/back search predicate were byte-identical; centralizing them here
+ * means a change lands once instead of being kept in sync by hand.
+ */
+
+/** Outcome of a create attempt; the client maps it to validation / sheet / banner state. */
+export type CreateCardOutcome =
+  | { status: "success" }
+  | { status: "validation"; field: string; message: string }
+  | { status: "unexpected" }
+  | { status: "rejected" };
+
+/** Outcome of an update attempt; the client maps it to the inline row validation error. */
+export type UpdateCardOutcome =
+  | { status: "success" }
+  | { status: "validation"; field: string; message: string }
+  | { status: "unexpected" }
+  | { status: "rejected" };
+
+/** Form values shared by create and update. */
+export interface CardFormValues {
+  front: string;
+  back: string;
+}
+
+/**
+ * True when the card's front or back contains the (trimmed, lowercased) search
+ * term. An empty search matches everything. Decides whether a freshly-created
+ * card should also be written into the active-filter cache entry.
+ */
+export function cardMatchesSearch(
+  card: { front: string; back: string },
+  searchValue: string,
+): boolean {
+  const normalized = searchValue.trim().toLowerCase();
+  if (normalized === "") return true;
+  return (
+    card.front.toLowerCase().includes(normalized) || card.back.toLowerCase().includes(normalized)
+  );
+}

--- a/frontend/src/lib/cards/use-entity-card-mutations.test.tsx
+++ b/frontend/src/lib/cards/use-entity-card-mutations.test.tsx
@@ -1,0 +1,22 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("useEntityCardMutations", () => {
+  // The generic hook is the single owner of the four card mutations' calls, so
+  // it is the canonical location of the optimisticResponse-absence guard (the
+  // wrapper guards now sit over thin config files with no mutation calls).
+  // Typed GraphQL errors (…DuplicateFrontError, InputValidationError, FORBIDDEN)
+  // can fail these mutations and Apollo does not reliably roll back optimistic
+  // writes for typed errors. See .claude/rules/pagination.md
+  // § "Drop `optimisticResponse` for mutations that can fail with typed GraphQL errors".
+  it("does not pass optimisticResponse as a mutation option (static-source guard)", () => {
+    const src = readFileSync(
+      join(process.cwd(), "src/lib/cards/use-entity-card-mutations.ts"),
+      "utf8",
+    );
+    // Matches the option key `optimisticResponse:`; tolerates the documenting
+    // comment word `optimisticResponse` (no colon).
+    expect(src).not.toMatch(/optimisticResponse\s*:/);
+  });
+});

--- a/frontend/src/lib/cards/use-entity-card-mutations.ts
+++ b/frontend/src/lib/cards/use-entity-card-mutations.ts
@@ -1,0 +1,383 @@
+"use client";
+
+import type { OperationVariables } from "@apollo/client";
+import { useApolloClient, useMutation } from "@apollo/client/react";
+import type { TypedDocumentNode } from "@graphql-typed-document-node/core";
+import { useCallback, useState } from "react";
+import { appendConnectionEdge, removeConnectionEdges } from "@/lib/apollo/connection-cache";
+import { useUndoDelete } from "@/lib/undo-delete";
+import {
+  type CardFormValues,
+  type CreateCardOutcome,
+  cardMatchesSearch,
+  type UpdateCardOutcome,
+} from "./card-mutation-outcomes";
+
+/** Connection variables every card connection shares (search-filter aware). */
+type CardConnectionVariables = OperationVariables & { search?: string | null };
+
+/** Minimal node shape the cache writes + search predicate require. */
+type CardNodeLike = { id: string; front: string; back: string };
+
+/** Structural connection shape read during the optimistic per-row delete. */
+type MutableConnection = {
+  edges: { node: { id: string } }[];
+  totalCount: number;
+  [key: string]: unknown;
+};
+
+/** Classification of a create payload, produced by the typed wrapper. */
+type CreateClassification<TNode extends CardNodeLike> =
+  | { kind: "success"; node: TNode }
+  | { kind: "duplicate"; message: string }
+  | { kind: "unknown"; typename: string | null };
+
+/** Classification of an update payload, produced by the typed wrapper. */
+type UpdateClassification =
+  | { kind: "success" }
+  | { kind: "validation"; field: string; message: string }
+  | { kind: "unknown"; typename: string | null };
+
+export interface EntityCardMutationsConfig<
+  TConnData,
+  TConnVars extends CardConnectionVariables,
+  TConnKey extends keyof TConnData,
+  TNode extends CardNodeLike,
+  TCreateData,
+  TCreateVars extends OperationVariables,
+  TUpdateData,
+  TUpdateVars extends OperationVariables,
+  TDeleteOneData,
+  TDeleteManyData,
+> {
+  /** Log bracket tag, e.g. `"[useCardMutations]"`. */
+  scope: string;
+  /** Owner-id key used in structured log payloads, e.g. `"cardgroupId"`. */
+  ownerLogKey: string;
+  /** Operation name in the "unexpected <op> payload" warn, e.g. `"createCard"`. */
+  createOpName: string;
+  /** Operation name in the "unexpected <op> payload" warn, e.g. `"updateCard"`. */
+  updateOpName: string;
+
+  /** The connection query document, keyed for cache reads/writes. */
+  connectionDocument: TypedDocumentNode<TConnData, TConnVars>;
+  /** The connection field key on `TConnData`, e.g. `"cardsByCardgroupConnection"`. */
+  connectionField: TConnKey;
+  /** Edge `__typename`, e.g. `"CardEdge"`. */
+  edgeTypename: string;
+  /** Entity `__typename`, e.g. `"Card"`, used to evict the normalized entry. */
+  entityTypename: string;
+  /** Default connection vars factory, scoped by owner id. */
+  defaultVars: (ownerId: string) => TConnVars;
+
+  createDocument: TypedDocumentNode<TCreateData, TCreateVars>;
+  buildCreateVariables: (ownerId: string, values: CardFormValues) => TCreateVars;
+  classifyCreate: (data: TCreateData | null | undefined) => CreateClassification<TNode>;
+
+  updateDocument: TypedDocumentNode<TUpdateData, TUpdateVars>;
+  buildUpdateVariables: (id: string, values: CardFormValues) => TUpdateVars;
+  classifyUpdate: (data: TUpdateData | null | undefined) => UpdateClassification;
+
+  deleteOneDocument: TypedDocumentNode<TDeleteOneData, { id: string | number }>;
+  extractDeleteOne: (data: TDeleteOneData | null | undefined) => boolean;
+
+  deleteManyDocument: TypedDocumentNode<
+    TDeleteManyData,
+    { ids: Array<string | number> | string | number }
+  >;
+  extractDeleteManyCount: (data: TDeleteManyData | null | undefined) => number | null | undefined;
+}
+
+export interface UseEntityCardMutationsInput<TConnVars extends CardConnectionVariables> {
+  ownerId: string;
+  /**
+   * The connection's active query variables (search-filter-aware). MUST be the
+   * same object the live `useQuery` is keyed on so cache reads/writes land on
+   * the right entry under any active search filter.
+   * See docs/pagination/optimistic-rollback-cache-key.md.
+   */
+  queryVariables: TConnVars;
+}
+
+/**
+ * Identity helper that supplies the contextual type for a config literal so the
+ * wrapper's classifier/builder callbacks are fully type-checked, while keeping
+ * the config a stable module constant. Prefer calling this WITHOUT explicit type
+ * arguments and let inference resolve the params from the documents; supply
+ * explicit type arguments only if `tsc` cannot infer one.
+ */
+export function createEntityCardMutationsConfig<
+  TConnData,
+  TConnVars extends CardConnectionVariables,
+  TConnKey extends keyof TConnData,
+  TNode extends CardNodeLike,
+  TCreateData,
+  TCreateVars extends OperationVariables,
+  TUpdateData,
+  TUpdateVars extends OperationVariables,
+  TDeleteOneData,
+  TDeleteManyData,
+>(
+  config: EntityCardMutationsConfig<
+    TConnData,
+    TConnVars,
+    TConnKey,
+    TNode,
+    TCreateData,
+    TCreateVars,
+    TUpdateData,
+    TUpdateVars,
+    TDeleteOneData,
+    TDeleteManyData
+  >,
+): EntityCardMutationsConfig<
+  TConnData,
+  TConnVars,
+  TConnKey,
+  TNode,
+  TCreateData,
+  TCreateVars,
+  TUpdateData,
+  TUpdateVars,
+  TDeleteOneData,
+  TDeleteManyData
+> {
+  return config;
+}
+
+/**
+ * Generic owner of the four card mutations (create / update / per-row delete /
+ * bulk delete) and every Apollo cache write they perform, shared by the cards
+ * and master-cards screens via thin typed wrappers. The wrapper supplies a
+ * static `config` (documents, typenames, classifiers); this hook owns the
+ * orchestration, the optimistic snapshot/restore, the undo-delete wiring, and
+ * the structured logging.
+ *
+ * No `optimisticResponse`: typed errors (…DuplicateFrontError,
+ * InputValidationError, UNAUTHENTICATED, FORBIDDEN) can fail these mutations and
+ * Apollo does not reliably roll back optimistic writes for typed GraphQL errors
+ * — see .claude/rules/pagination.md.
+ */
+export function useEntityCardMutations<
+  TConnData,
+  TConnVars extends CardConnectionVariables,
+  TConnKey extends keyof TConnData,
+  TNode extends CardNodeLike,
+  TCreateData,
+  TCreateVars extends OperationVariables,
+  TUpdateData,
+  TUpdateVars extends OperationVariables,
+  TDeleteOneData,
+  TDeleteManyData,
+>(
+  config: EntityCardMutationsConfig<
+    TConnData,
+    TConnVars,
+    TConnKey,
+    TNode,
+    TCreateData,
+    TCreateVars,
+    TUpdateData,
+    TUpdateVars,
+    TDeleteOneData,
+    TDeleteManyData
+  >,
+  input: UseEntityCardMutationsInput<TConnVars>,
+) {
+  const { ownerId, queryVariables } = input;
+  const apollo = useApolloClient();
+  const { scheduleDelete } = useUndoDelete();
+
+  const [createMutation, { loading: creating, error: createError, reset: resetCreateCard }] =
+    useMutation(config.createDocument);
+  // Updates propagate automatically via Apollo cache normalization (entity has id).
+  const [updateMutation, { loading: updating, error: updateError }] = useMutation(
+    config.updateDocument,
+  );
+  // scheduleDelete (5s undo window) fires the per-row mutation imperatively.
+  const [deleteOneMutation] = useMutation(config.deleteOneDocument);
+
+  const [deleteManyMutation, { error: bulkDeleteError, loading: bulkDeleting }] = useMutation(
+    config.deleteManyDocument,
+    {
+      // queryVariables matches the live cache entry under any active search filter.
+      // See docs/pagination/optimistic-rollback-cache-key.md.
+      update(cache, { data: bulkData }, { variables: mutationVars }) {
+        const ids = mutationVars?.ids as string[] | undefined;
+        if (!ids) return;
+        const deletedCount = config.extractDeleteManyCount(bulkData);
+        if (deletedCount == null) return;
+        if (deletedCount === 0) return;
+        removeConnectionEdges(cache, {
+          document: config.connectionDocument,
+          variables: queryVariables,
+          connectionField: config.connectionField,
+          entityTypename: config.entityTypename,
+          ids,
+          deletedCount,
+        });
+      },
+    },
+  );
+
+  // Per-row delete commit error — surfaced after the 5s undo window elapses and
+  // the DELETE mutation rejects. Stored as the raw error so the client derives
+  // the localized banner copy; persists across mutation calls. See
+  // docs/pagination/do-not-reuse-mutation-error-state.md.
+  const [deleteRowError, setDeleteRowError] = useState<unknown>(null);
+
+  // Write a freshly-created card to the connection cached under `variables`.
+  // No `buildColdConnection`: on a cold cache this no-ops and the page's own
+  // `useQuery` owns populating the connection.
+  const writeCreatedToConnection = useCallback(
+    (node: TNode, variables: TConnVars) => {
+      appendConnectionEdge(apollo.cache, {
+        document: config.connectionDocument,
+        variables,
+        connectionField: config.connectionField,
+        edgeTypename: config.edgeTypename,
+        node,
+      });
+    },
+    [apollo, config],
+  );
+
+  const createCard = useCallback(
+    async (values: CardFormValues): Promise<CreateCardOutcome> => {
+      const result = await createMutation({
+        variables: config.buildCreateVariables(ownerId, values),
+      }).catch((err) => {
+        console.error(`${config.scope} create rejection`, {
+          name: err instanceof Error ? err.name : "unknown",
+          [config.ownerLogKey]: ownerId,
+        });
+        return null;
+      });
+      if (!result) return { status: "rejected" };
+
+      const classified = config.classifyCreate(result.data);
+      if (classified.kind === "success") {
+        writeCreatedToConnection(classified.node, config.defaultVars(ownerId));
+        const search = queryVariables.search;
+        if (typeof search === "string" && cardMatchesSearch(classified.node, search)) {
+          writeCreatedToConnection(classified.node, queryVariables);
+        }
+        return { status: "success" };
+      }
+      if (classified.kind === "duplicate") {
+        return { status: "validation", field: "front", message: classified.message };
+      }
+      console.warn(`${config.scope} unexpected ${config.createOpName} payload`, {
+        typename: classified.typename,
+        [config.ownerLogKey]: ownerId,
+      });
+      return { status: "unexpected" };
+    },
+    [config, ownerId, createMutation, queryVariables, writeCreatedToConnection],
+  );
+
+  const updateCard = useCallback(
+    async (id: string, values: CardFormValues): Promise<UpdateCardOutcome> => {
+      const result = await updateMutation({
+        variables: config.buildUpdateVariables(id, values),
+      }).catch((err) => {
+        console.error(`${config.scope} update rejection`, {
+          name: err instanceof Error ? err.name : "unknown",
+          [config.ownerLogKey]: ownerId,
+          cardId: id,
+        });
+        return null;
+      });
+      if (!result) return { status: "rejected" };
+
+      const classified = config.classifyUpdate(result.data);
+      if (classified.kind === "success") {
+        return { status: "success" };
+      }
+      if (classified.kind === "validation") {
+        return { status: "validation", field: classified.field, message: classified.message };
+      }
+      console.warn(`${config.scope} unexpected ${config.updateOpName} payload`, {
+        typename: classified.typename,
+        cardId: id,
+        [config.ownerLogKey]: ownerId,
+      });
+      return { status: "unexpected" };
+    },
+    [config, ownerId, updateMutation],
+  );
+
+  // Per-row delete: snapshot, optimistic drop, schedule DELETE with a 5s undo
+  // window. See docs/pagination/optimistic-rollback-cache-key.md for the
+  // queryVariables rule. `label` is the caller-supplied (localized) toast title.
+  const deleteRow = useCallback(
+    (cardId: string, label: string) => {
+      const snapshot = apollo.readQuery({
+        query: config.connectionDocument,
+        variables: queryVariables,
+      });
+      if (snapshot) {
+        const current = snapshot[config.connectionField] as unknown as MutableConnection;
+        apollo.writeQuery({
+          query: config.connectionDocument,
+          variables: queryVariables,
+          data: {
+            [config.connectionField]: {
+              ...current,
+              edges: current.edges.filter((edge) => edge.node.id !== cardId),
+              totalCount: Math.max(0, current.totalCount - 1),
+            },
+          } as unknown as TConnData,
+        });
+      }
+      scheduleDelete({
+        id: cardId,
+        label,
+        optimisticRollback: () => {
+          if (snapshot !== null) {
+            apollo.writeQuery({
+              query: config.connectionDocument,
+              variables: queryVariables,
+              data: snapshot,
+            });
+          }
+          setDeleteRowError(null);
+        },
+        commitDelete: async () => {
+          setDeleteRowError(null);
+          const result = await deleteOneMutation({ variables: { id: cardId } });
+          if (config.extractDeleteOne(result.data)) {
+            apollo.cache.evict({
+              id: apollo.cache.identify({ __typename: config.entityTypename, id: cardId }),
+            });
+            apollo.cache.gc();
+          }
+        },
+        onCommitFailed: (err) => {
+          setDeleteRowError(err);
+        },
+      });
+    },
+    [apollo, config, deleteOneMutation, queryVariables, scheduleDelete],
+  );
+
+  const deleteCards = useCallback(
+    (ids: string[]) => deleteManyMutation({ variables: { ids } }),
+    [deleteManyMutation],
+  );
+
+  return {
+    createCard,
+    updateCard,
+    deleteRow,
+    deleteCards,
+    creating,
+    updating,
+    bulkDeleting,
+    createError,
+    updateError,
+    bulkDeleteError,
+    deleteRowError,
+    resetCreateCard,
+  };
+}


### PR DESCRIPTION
## Summary

Collapses the two near-character-identical card-mutation hooks (`use-card-mutations.ts` and `use-master-card-mutations.ts`) into one generic `useEntityCardMutations(config, input)`. Each existing hook becomes a thin, fully-typed config wrapper that preserves its exact public API. Behavior-preserving refactor — no behavior change.

Closes #603.

## Background / Motivation

The cards (`/cardgroups/[id]/cards`) and master-cards (`/admin/masters/[id]/edit/cards`) hooks were twins: identical outcome unions, identical `cardMatchesSearch`, the same four mutations (create / update / per-row delete / bulk delete), and the same five Apollo cache blocks. Every line that differed was entity-name/typename churn (`Card`↔`MasterCard`, `cardgroupId`↔`masterCardgroupId`, `payload.card`↔`payload.masterCard`, `createCard`↔`adminCreateMasterCard`). Cross-validated as the single largest frontend duplication by the cohesion review. Any future card-feature change (new error code, cache tweak) had to be applied twice and kept in sync by hand. This is CARDS-track step 2 of 3 (built on the `connection-cache.ts` helpers from #596).

## Changes

- **Add** `frontend/src/lib/cards/card-mutation-outcomes.ts` — the shared `CreateCardOutcome` / `UpdateCardOutcome` unions, the `CardFormValues` shape, and `cardMatchesSearch`.
- **Add** `frontend/src/lib/cards/use-entity-card-mutations.ts` — the generic hook plus a `createEntityCardMutationsConfig` identity helper. The hook owns the orchestration, the optimistic snapshot/restore, the undo-delete wiring, the cache writes (via the #596 `appendConnectionEdge`/`removeConnectionEdges`), and the structured logging. A **classifier-callback** design keeps every `__typename` decision in the typed wrapper, where the generated unions are fully checked — the generic hook stays free of stringly-typed payload indexing.
- **Add** `frontend/src/lib/cards/use-entity-card-mutations.test.tsx` — the `optimisticResponse`-absence static-source guard, now over the generic hook (the canonical location of the mutation calls).
- **Modify** `use-card-mutations.ts` / `use-master-card-mutations.ts` → thin config wrappers (net **−345 lines** across the diff). Each binds its documents, typenames, classifiers, and `defaultVars`, and translates the route's owner id (`cardgroupId` / `masterId`) to the generic hook's `ownerId`.
- **Modify** `use-master-card-mutations.test.tsx` — comment-only update on the kept wrapper `optimisticResponse` guard, pointing at the generic-hook guard as the primary one.

Preserved exactly: both wrappers' public API (input prop shapes + all 12 returned keys), the structured `console.error`/`console.warn` payloads (scope tag, owner-key name, `cardId`, no `err.message` leak), the create double-write (default-vars + active-filter when `search` matches), the cold-cache **no-op** (no `buildColdConnection`), the per-row optimistic snapshot/restore + `evict`+`gc`, and the `Math.max(0, …)` `totalCount` clamp. The third consumer `learn-add-card-sheet.tsx` (also using `useCardMutations`) is unaffected.

## Verification (in worktree)

- `tsc --noEmit` — clean. `biome check --error-on-warnings` — clean. `knip` — clean.
- Full vitest suite — **173 files / 1604 tests pass** (the two wrapper suites exercise create-duplicate→validation, update-validation, per-row delete, and bulk-delete through the generic hook).
- `next build` — compiles + static generation succeed. No CJK in changed files.
- Type-safety note: all 10 generic params on `createEntityCardMutationsConfig` infer from the documents — no explicit type arguments needed. A 4-lens adversarial review (type-design, Apollo-cache correctness, behavior-preservation, test-integrity) returned **ship** on all four with no blockers.

## Test plan

- [ ] Create a card in a cardgroup and a master deck — confirm it appears at the top of the list without refetch (and under an active search filter when it matches).
- [ ] Single-delete a card (with the 5s undo) and bulk-delete — confirm the count decrements (never below 0) and rows disappear; undo restores the row.
- [ ] Trigger a duplicate-front create and an empty-front update — confirm the inline `front` validation message renders on both screens.
