### PR TITLE
refactor(frontend): extract submitFormHandler + wrapSubmit for TanStack form bodies

### DIFF
--- a/frontend/src/app/admin/masters/admin-master-form.tsx
+++ b/frontend/src/app/admin/masters/admin-master-form.tsx
@@ -9,6 +9,7 @@ import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { DirtyStateBridge } from "@/lib/forms/dirty-state-bridge";
 import { FieldError } from "@/lib/forms/field-error";
+import { submitFormHandler, wrapSubmit } from "@/lib/forms/submit-handler";
 import { masterSchema } from "@/schemas/master";
 import type { AdminMasterListItem } from "./admin-master-row";
 
@@ -76,33 +77,14 @@ export function AdminMasterForm({
         isDefaultStarter: value.isDefaultStarter,
         sortOrder: sortOrderRaw === "" ? null : Number(sortOrderRaw),
       };
-      await submit(values).catch((err) => {
-        // err.message is omitted — backend messages may echo user-authored
-        // input typed into this form. See
-        // docs/frontend/rsc-error-handling/redact-err-message-from-console-payloads.md.
-        console.error("[admin-master-form] submit rejected", {
-          name: err instanceof Error ? err.name : "unknown",
-        });
-        throw err; // keep formState.isSubmitSuccessful correct
-      });
+      await wrapSubmit("admin-master-form", submit)(values);
     },
   });
 
   const nameFieldError = validationError?.field === "name" ? validationError.message : undefined;
 
   return (
-    <form
-      onSubmit={(e) => {
-        e.preventDefault();
-        e.stopPropagation();
-        form.handleSubmit().catch(() => {
-          // Inner submit handler's .catch already logged; swallow here so the
-          // re-thrown rejection does not surface as an unhandled browser
-          // promise rejection.
-        });
-      }}
-      className="space-y-4"
-    >
+    <form onSubmit={submitFormHandler(form)} className="space-y-4">
       {validationError && validationError.field !== "name" ? (
         <ErrorBanner data-testid="master-form-error">{validationError.message}</ErrorBanner>
       ) : null}

--- a/frontend/src/app/onboarding/onboarding-form.tsx
+++ b/frontend/src/app/onboarding/onboarding-form.tsx
@@ -11,6 +11,7 @@ import { ErrorBanner } from "@/components/ui/error-banner";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { FieldError } from "@/lib/forms/field-error";
+import { submitFormHandler } from "@/lib/forms/submit-handler";
 import { updateProfileSchema } from "@/schemas/profile";
 
 export function OnboardingForm() {
@@ -73,8 +74,8 @@ export function OnboardingForm() {
           return;
         case "rejected":
           setBannerMessage(outcome.banner ?? tCommon("somethingWentWrong"));
-          // Re-throw so TanStack Form keeps formState.isSubmitSuccessful=false; the
-          // outer form.handleSubmit().catch() at the JSX call site swallows it.
+          // Re-throw so TanStack Form keeps formState.isSubmitSuccessful=false;
+          // submitFormHandler (the outer onSubmit) swallows the re-thrown rejection.
           throw new Error("[OnboardingForm] update profile rejected");
       }
     },
@@ -88,15 +89,7 @@ export function OnboardingForm() {
   return (
     <OnboardingShell heading={t("welcome")} subline={t("subtitle")}>
       <form
-        onSubmit={(e) => {
-          e.preventDefault();
-          e.stopPropagation();
-          form.handleSubmit().catch(() => {
-            // The inner submit handler's .catch already logged; swallow here so the
-            // re-thrown rejection (which keeps formState.isSubmitSuccessful=false correct)
-            // does not surface as an unhandled browser promise rejection.
-          });
-        }}
+        onSubmit={submitFormHandler(form)}
         // Centered card inside the shell's centered column. Internals stay
         // text-left so the label / input / hint read as a normal form.
         className="mx-auto mt-8 w-full max-w-[420px] space-y-4 rounded-2xl border border-border/70 bg-card p-6 text-left shadow-[0_1px_2px_rgba(0,0,0,0.04),0_12px_32px_-12px_rgba(0,0,0,0.12)] sm:p-8"

--- a/frontend/src/app/profile/profile-form.tsx
+++ b/frontend/src/app/profile/profile-form.tsx
@@ -11,6 +11,7 @@ import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { DirtyStateBridge } from "@/lib/forms/dirty-state-bridge";
 import { FieldError } from "@/lib/forms/field-error";
+import { submitFormHandler } from "@/lib/forms/submit-handler";
 import { updateProfileSchema } from "@/schemas/profile";
 import { useUpdateProfile } from "./use-update-profile";
 
@@ -97,8 +98,8 @@ export function ProfileForm({
           return;
         case "rejected":
           setBannerMessage(outcome.banner ?? tCommon("somethingWentWrong"));
-          // Re-throw so TanStack Form keeps formState.isSubmitSuccessful=false; the
-          // outer form.handleSubmit().catch() at the JSX call site swallows it.
+          // Re-throw so TanStack Form keeps formState.isSubmitSuccessful=false;
+          // submitFormHandler (the outer onSubmit) swallows the re-thrown rejection.
           throw new Error("[ProfileForm] update profile rejected");
       }
     },
@@ -110,18 +111,7 @@ export function ProfileForm({
     : {};
 
   return (
-    <form
-      onSubmit={(e) => {
-        e.preventDefault();
-        e.stopPropagation();
-        form.handleSubmit().catch(() => {
-          // The inner submit handler's .catch already logged; swallow here so the
-          // re-thrown rejection (which keeps formState.isSubmitSuccessful=false correct)
-          // does not surface as an unhandled browser promise rejection.
-        });
-      }}
-      className="space-y-4"
-    >
+    <form onSubmit={submitFormHandler(form)} className="space-y-4">
       {bannerMessage ? <ErrorBanner>{bannerMessage}</ErrorBanner> : null}
 
       <div className="mb-4 space-y-2">

--- a/frontend/src/components/admin/role-form.tsx
+++ b/frontend/src/components/admin/role-form.tsx
@@ -10,6 +10,7 @@ import { Label } from "@/components/ui/label";
 import { getBackendErrorBanner, getBackendFieldErrors } from "@/lib/apollo/errors";
 import { DirtyStateBridge } from "@/lib/forms/dirty-state-bridge";
 import { FieldError } from "@/lib/forms/field-error";
+import { submitFormHandler, wrapSubmit } from "@/lib/forms/submit-handler";
 import { roleSchema } from "@/schemas/role";
 
 type RoleFormProps = {
@@ -50,31 +51,12 @@ export function RoleForm({
       name: defaultValues.name,
     },
     onSubmit: async ({ value }) => {
-      await submit(value).catch((err) => {
-        // err.message is omitted — backend messages may echo user-authored
-        // input (the role name typed into this form). See
-        // docs/frontend/rsc-error-handling/redact-err-message-from-console-payloads.md.
-        console.error("[role-form] submit rejected", {
-          name: err instanceof Error ? err.name : "unknown",
-        });
-        throw err; // keep formState.isSubmitSuccessful correct
-      });
+      await wrapSubmit("role-form", submit)(value);
     },
   });
 
   return (
-    <form
-      onSubmit={(e) => {
-        e.preventDefault();
-        e.stopPropagation();
-        form.handleSubmit().catch(() => {
-          // Inner submit handler's .catch already logged; swallow here so the
-          // re-thrown rejection (which keeps formState.isSubmitSuccessful=false
-          // correct) does not surface as an unhandled browser promise rejection.
-        });
-      }}
-      className="space-y-4"
-    >
+    <form onSubmit={submitFormHandler(form)} className="space-y-4">
       {bannerError ? <ErrorBanner>{bannerError}</ErrorBanner> : null}
 
       <form.Field name="name" validators={{ onChange: nameSchema, onBlur: nameSchema }}>

--- a/frontend/src/components/cardgroups/card-form.tsx
+++ b/frontend/src/components/cardgroups/card-form.tsx
@@ -11,6 +11,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { getBackendErrorBanner, getBackendFieldErrors } from "@/lib/apollo/errors";
 import { FieldError } from "@/lib/forms/field-error";
+import { submitFormHandler, wrapSubmit } from "@/lib/forms/submit-handler";
 import { newCardSchema, updateCardSchema } from "@/schemas/card";
 
 type Mode = "create" | "edit";
@@ -58,26 +59,12 @@ export function CardForm({
   const form = useForm({
     defaultValues: { front: defaultValues.front, back: defaultValues.back },
     onSubmit: async ({ value }) => {
-      await submit(value).catch((err) => {
-        console.error("[card-form] submit rejected", err);
-        throw err;
-      });
+      await wrapSubmit("card-form", submit)(value);
     },
   });
 
   return (
-    <form
-      onSubmit={(e) => {
-        e.preventDefault();
-        e.stopPropagation();
-        form.handleSubmit().catch(() => {
-          // The inner submit handler's .catch already logged; swallow here so the
-          // re-thrown rejection (which keeps formState.isSubmitSuccessful=false correct)
-          // does not surface as an unhandled browser promise rejection.
-        });
-      }}
-      className="space-y-3"
-    >
+    <form onSubmit={submitFormHandler(form)} className="space-y-3">
       {bannerError ? <ErrorBanner>{bannerError}</ErrorBanner> : null}
 
       <form.Field name="front" validators={{ onChange: frontSchema, onBlur: frontSchema }}>

--- a/frontend/src/components/cardgroups/cardgroup-form.test.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-form.test.tsx
@@ -6,6 +6,7 @@ import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { GraphQLError } from "graphql";
 import { describe, expect, it, vi } from "vitest";
+import { submitFormHandler, wrapSubmit } from "@/lib/forms/submit-handler";
 import { renderWithIntl } from "@/test/render-with-intl";
 import { CardgroupForm } from "./cardgroup-form";
 
@@ -23,24 +24,13 @@ function CardgroupFormWithStatus({
   const form = useForm({
     defaultValues: { name: "Test Group" },
     onSubmit: async ({ value }) => {
-      await submit(value).catch((err) => {
-        console.error("[cardgroup-form] submit rejected", err);
-        throw err; // keep formState.isSubmitSuccessful correct
-      });
+      await wrapSubmit("cardgroup-form", submit)(value);
     },
   });
 
   return (
     <>
-      <form
-        onSubmit={(e) => {
-          e.preventDefault();
-          e.stopPropagation();
-          form.handleSubmit().catch(() => {
-            // swallow re-thrown rejection to avoid unhandled browser promise rejection
-          });
-        }}
-      >
+      <form onSubmit={submitFormHandler(form)}>
         <button type="submit">Create</button>
       </form>
       <form.Subscribe selector={(state) => state.isSubmitSuccessful}>

--- a/frontend/src/components/cardgroups/cardgroup-form.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-form.tsx
@@ -10,6 +10,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { getBackendErrorBanner, getBackendFieldErrors } from "@/lib/apollo/errors";
 import { FieldError } from "@/lib/forms/field-error";
+import { submitFormHandler, wrapSubmit } from "@/lib/forms/submit-handler";
 import { newCardgroupSchema, updateCardgroupSchema } from "@/schemas/cardgroup";
 
 type Mode = "create" | "edit";
@@ -60,26 +61,12 @@ export function CardgroupForm({
       name: defaultValues.name,
     },
     onSubmit: async ({ value }) => {
-      await submit(value).catch((err) => {
-        console.error("[cardgroup-form] submit rejected", err);
-        throw err; // keep formState.isSubmitSuccessful correct
-      });
+      await wrapSubmit("cardgroup-form", submit)(value);
     },
   });
 
   return (
-    <form
-      onSubmit={(e) => {
-        e.preventDefault();
-        e.stopPropagation();
-        form.handleSubmit().catch(() => {
-          // The inner submit handler's .catch already logged; swallow here so the
-          // re-thrown rejection (which keeps formState.isSubmitSuccessful=false correct)
-          // does not surface as an unhandled browser promise rejection.
-        });
-      }}
-      className="space-y-4"
-    >
+    <form onSubmit={submitFormHandler(form)} className="space-y-4">
       {bannerError ? <ErrorBanner>{bannerError}</ErrorBanner> : null}
 
       <form.Field name="name" validators={{ onChange: nameSchema, onBlur: nameSchema }}>

--- a/frontend/src/lib/forms/submit-handler.test.ts
+++ b/frontend/src/lib/forms/submit-handler.test.ts
@@ -1,0 +1,63 @@
+import type { FormEvent } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { submitFormHandler, wrapSubmit } from "./submit-handler";
+
+function fakeEvent() {
+  return {
+    preventDefault: vi.fn(),
+    stopPropagation: vi.fn(),
+  } as unknown as FormEvent<HTMLFormElement>;
+}
+
+describe("submitFormHandler", () => {
+  it("cancels the native submit and delegates to form.handleSubmit", () => {
+    const handleSubmit = vi.fn(() => Promise.resolve());
+    const e = fakeEvent();
+    submitFormHandler({ handleSubmit })(e);
+    expect(e.preventDefault).toHaveBeenCalledOnce();
+    expect(e.stopPropagation).toHaveBeenCalledOnce();
+    expect(handleSubmit).toHaveBeenCalledOnce();
+  });
+
+  it("swallows a rejected handleSubmit so it never becomes an unhandled rejection", async () => {
+    const handleSubmit = vi.fn(() => Promise.reject(new Error("boom")));
+    expect(() => submitFormHandler({ handleSubmit })(fakeEvent())).not.toThrow();
+    // Let the swallowing microtask settle; an unhandled rejection here would fail the run.
+    await Promise.resolve();
+  });
+});
+
+describe("wrapSubmit", () => {
+  it("passes the value through and resolves on success", async () => {
+    const submit = vi.fn((_v: { name: string }) => Promise.resolve());
+    await expect(wrapSubmit("x-form", submit)({ name: "ok" })).resolves.toBeUndefined();
+    expect(submit).toHaveBeenCalledWith({ name: "ok" });
+  });
+
+  it("re-throws on rejection so formState.isSubmitSuccessful stays false", async () => {
+    const submit = vi.fn(() => Promise.reject(new Error("nope")));
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    await expect(wrapSubmit("x-form", submit)(undefined as never)).rejects.toThrow("nope");
+    errSpy.mockRestore();
+  });
+
+  it("redacts err.message from the console payload (logs only err.name)", async () => {
+    const submit = vi.fn(() => Promise.reject(new TypeError("secret user input")));
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    await expect(wrapSubmit("x-form", submit)(undefined as never)).rejects.toBeInstanceOf(
+      TypeError,
+    );
+    expect(errSpy).toHaveBeenCalledWith("[x-form] submit rejected", { name: "TypeError" });
+    const payload = errSpy.mock.calls[0]?.[1] as Record<string, unknown> | undefined;
+    expect(payload).not.toHaveProperty("message");
+    errSpy.mockRestore();
+  });
+
+  it("labels a non-Error rejection as unknown", async () => {
+    const submit = vi.fn(() => Promise.reject("plain string"));
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    await expect(wrapSubmit("x-form", submit)(undefined as never)).rejects.toBe("plain string");
+    expect(errSpy).toHaveBeenCalledWith("[x-form] submit rejected", { name: "unknown" });
+    errSpy.mockRestore();
+  });
+});

--- a/frontend/src/lib/forms/submit-handler.ts
+++ b/frontend/src/lib/forms/submit-handler.ts
@@ -1,0 +1,51 @@
+import type { FormEvent } from "react";
+
+/** Minimal structural view of a TanStack form needed to submit it. */
+type SubmittableForm = { handleSubmit: () => Promise<unknown> };
+
+/**
+ * Builds the `<form onSubmit>` handler shared by every TanStack form body.
+ *
+ * It cancels the native submit, then runs `form.handleSubmit()` and swallows
+ * the returned promise's rejection. That rejection is expected: the form's
+ * inner submit handler re-throws on failure — via {@link wrapSubmit} in the
+ * simple forms, or its own outcome-switch handler in `profile-form` /
+ * `onboarding-form` — so TanStack keeps `formState.isSubmitSuccessful` false.
+ * In every case the inner handler has already surfaced and logged the failure,
+ * so swallowing here only stops the re-thrown rejection from becoming an
+ * unhandled browser promise rejection.
+ */
+export function submitFormHandler(form: SubmittableForm) {
+  return (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    form.handleSubmit().catch(() => {
+      // Already logged by the inner submit handler; see the doc comment above.
+    });
+  };
+}
+
+/**
+ * Wraps a form's async `submit` so a rejection is logged (redacted) and
+ * re-thrown.
+ *
+ * The re-throw is load-bearing: it keeps TanStack's
+ * `formState.isSubmitSuccessful` false on failure. The log omits `err.message`
+ * because backend messages may echo user-authored input — see
+ * docs/frontend/rsc-error-handling/redact-err-message-from-console-payloads.md.
+ *
+ * @param scope console-prefix tag, e.g. `"cardgroup-form"`.
+ * @param submit the parent-supplied mutation runner.
+ */
+export function wrapSubmit<T>(
+  scope: string,
+  submit: (value: T) => Promise<void>,
+): (value: T) => Promise<void> {
+  return (value: T) =>
+    submit(value).catch((err: unknown) => {
+      console.error(`[${scope}] submit rejected`, {
+        name: err instanceof Error ? err.name : "unknown",
+      });
+      throw err; // keep formState.isSubmitSuccessful correct
+    });
+}


### PR DESCRIPTION
## Summary

Extracts the duplicated `<form onSubmit>` scaffold and inner log-and-rethrow shared by all six TanStack `useForm` bodies into two helpers in `frontend/src/lib/forms/submit-handler.ts`, and adopts them. Mechanical, behavior-preserving factor-out — zero behavior change.

Closes #597.

## Background / Motivation

Every TanStack form repeated the identical outer handler — `e.preventDefault(); e.stopPropagation(); form.handleSubmit().catch(() => {/* swallow */})` plus a 3-line explanatory comment — and four of them repeated the same inner `submit(value).catch(log; throw err)`. The **re-throw is load-bearing**: it keeps `formState.isSubmitSuccessful` false on failure (a TanStack contract). With six copies, any fix to that contract — or to the redaction policy — had to be hand-propagated to every site. Two forms also logged the **full** `err` (which can echo user-authored input) while two redacted to `err.name`; the `redact-err-message` rule wants the redacted form everywhere.

## Changes

- **Add** `frontend/src/lib/forms/submit-handler.ts` — `submitFormHandler(form)` (the shared outer handler) and `wrapSubmit(scope, submit)` (inner: redacted `{ name }` log + load-bearing re-throw).
- **Add** `frontend/src/lib/forms/submit-handler.test.ts` — re-throw propagation, redaction (no `message` leak), non-Error labelling, and the swallow-no-unhandled-rejection path.
- **Modify** all six form bodies to use `submitFormHandler`: `admin-master-form.tsx`, `profile-form.tsx`, `onboarding-form.tsx`, `role-form.tsx`, `card-form.tsx`, `cardgroup-form.tsx`.
- **Modify** the four simple forms (cardgroup/card/role/admin-master) to route their inner submit through `wrapSubmit` — this **unifies the redacted-log form**: `card-form`/`cardgroup-form` previously logged the full `err`, and now log only `{ name }`.
- `profile-form` / `onboarding-form` keep their own outcome-switch inner handler (only the outer handler is shared); their stale "JSX call site swallows it" comments were corrected to name `submitFormHandler`.
- `cardgroup-form.test.tsx`'s `isSubmitSuccessful` regression harness now mirrors production by consuming the two helpers.

Preserved invariants: the re-throw on every rejection (so `formState.isSubmitSuccessful` stays false), `preventDefault` / `stopPropagation`, the per-form `console` scope tags, and admin-master's value-transform running before submit.

## Verification (in worktree)

- `tsc --noEmit` — pass. `biome check --error-on-warnings .` — clean. `knip` — clean.
- Full vitest — **1609 tests pass** (173 files).
- No CJK in changed sources; production build runs in CI.

## Test plan

- [ ] Submit each form (cardgroup, card, role, admin master, profile, onboarding) on the happy path — confirm it saves / navigates as before.
- [ ] Force a rejecting submit — confirm the inline/banner error shows, the button re-enables, and the form does not register as successfully submitted.
