### PR TITLE
refactor(frontend): extract FormField wrapper for label+input+error triad

### DIFF
--- a/frontend/src/components/admin/role-form.tsx
+++ b/frontend/src/components/admin/role-form.tsx
@@ -5,11 +5,9 @@ import { useTranslations } from "next-intl";
 import { useMemo } from "react";
 import { Button } from "@/components/ui/button";
 import { ErrorBanner } from "@/components/ui/error-banner";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { getBackendErrorBanner, getBackendFieldErrors } from "@/lib/apollo/errors";
 import { DirtyStateBridge } from "@/lib/forms/dirty-state-bridge";
-import { FieldError } from "@/lib/forms/field-error";
+import { FormField } from "@/lib/forms/form-field";
 import { submitFormHandler, wrapSubmit } from "@/lib/forms/submit-handler";
 import { roleSchema } from "@/schemas/role";
 
@@ -61,19 +59,13 @@ export function RoleForm({
 
       <form.Field name="name" validators={{ onChange: nameSchema, onBlur: nameSchema }}>
         {(field) => (
-          <div className="space-y-2">
-            <Label htmlFor={field.name}>{t("roleNameLabel")}</Label>
-            <Input
-              id={field.name}
-              name={field.name}
-              value={field.state.value}
-              onBlur={field.handleBlur}
-              onChange={(e) => field.handleChange(e.target.value)}
-              disabled={readOnly}
-              placeholder={t("roleNamePlaceholder")}
-            />
-            <FieldError zodErrors={field.state.meta.errors} backendError={fieldErrors.name} />
-          </div>
+          <FormField
+            field={field}
+            label={t("roleNameLabel")}
+            backendError={fieldErrors.name}
+            disabled={readOnly}
+            placeholder={t("roleNamePlaceholder")}
+          />
         )}
       </form.Field>
 

--- a/frontend/src/components/cardgroups/card-form.tsx
+++ b/frontend/src/components/cardgroups/card-form.tsx
@@ -7,10 +7,8 @@ import { useTranslations } from "next-intl";
 import { useMemo } from "react";
 import { Button } from "@/components/ui/button";
 import { ErrorBanner } from "@/components/ui/error-banner";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { getBackendErrorBanner, getBackendFieldErrors } from "@/lib/apollo/errors";
-import { FieldError } from "@/lib/forms/field-error";
+import { FormField } from "@/lib/forms/form-field";
 import { submitFormHandler, wrapSubmit } from "@/lib/forms/submit-handler";
 import { newCardSchema, updateCardSchema } from "@/schemas/card";
 
@@ -68,51 +66,31 @@ export function CardForm({
       {bannerError ? <ErrorBanner>{bannerError}</ErrorBanner> : null}
 
       <form.Field name="front" validators={{ onChange: frontSchema, onBlur: frontSchema }}>
-        {(field) => {
-          const inputId = `${idPrefix}${field.name}-field`;
-          return (
-            <div className="space-y-1">
-              <Label htmlFor={inputId}>{t("frontLabel")}</Label>
-              <Input
-                id={inputId}
-                name={field.name}
-                value={field.state.value}
-                onBlur={field.handleBlur}
-                onChange={(e) => field.handleChange(e.target.value)}
-              />
-              <FieldError
-                zodErrors={field.state.meta.errors}
-                backendError={
-                  validationError?.field === "front" ? validationError.message : fieldErrors.front
-                }
-              />
-            </div>
-          );
-        }}
+        {(field) => (
+          <FormField
+            field={field}
+            label={t("frontLabel")}
+            idOverride={`${idPrefix}${field.name}-field`}
+            className="space-y-1"
+            backendError={
+              validationError?.field === "front" ? validationError.message : fieldErrors.front
+            }
+          />
+        )}
       </form.Field>
 
       <form.Field name="back" validators={{ onChange: backSchema, onBlur: backSchema }}>
-        {(field) => {
-          const inputId = `${idPrefix}${field.name}-field`;
-          return (
-            <div className="space-y-1">
-              <Label htmlFor={inputId}>{t("backLabel")}</Label>
-              <Input
-                id={inputId}
-                name={field.name}
-                value={field.state.value}
-                onBlur={field.handleBlur}
-                onChange={(e) => field.handleChange(e.target.value)}
-              />
-              <FieldError
-                zodErrors={field.state.meta.errors}
-                backendError={
-                  validationError?.field === "back" ? validationError.message : fieldErrors.back
-                }
-              />
-            </div>
-          );
-        }}
+        {(field) => (
+          <FormField
+            field={field}
+            label={t("backLabel")}
+            idOverride={`${idPrefix}${field.name}-field`}
+            className="space-y-1"
+            backendError={
+              validationError?.field === "back" ? validationError.message : fieldErrors.back
+            }
+          />
+        )}
       </form.Field>
 
       <div className="flex items-center gap-2">

--- a/frontend/src/components/cardgroups/cardgroup-form.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-form.tsx
@@ -6,10 +6,8 @@ import type React from "react";
 import { useMemo } from "react";
 import { Button } from "@/components/ui/button";
 import { ErrorBanner } from "@/components/ui/error-banner";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { getBackendErrorBanner, getBackendFieldErrors } from "@/lib/apollo/errors";
-import { FieldError } from "@/lib/forms/field-error";
+import { FormField } from "@/lib/forms/form-field";
 import { submitFormHandler, wrapSubmit } from "@/lib/forms/submit-handler";
 import { newCardgroupSchema, updateCardgroupSchema } from "@/schemas/cardgroup";
 
@@ -71,22 +69,13 @@ export function CardgroupForm({
 
       <form.Field name="name" validators={{ onChange: nameSchema, onBlur: nameSchema }}>
         {(field) => (
-          <div className="space-y-2">
-            <Label htmlFor={field.name}>{t("nameLabel")}</Label>
-            <Input
-              id={field.name}
-              name={field.name}
-              value={field.state.value}
-              onBlur={field.handleBlur}
-              onChange={(e) => field.handleChange(e.target.value)}
-            />
-            <FieldError
-              zodErrors={field.state.meta.errors}
-              backendError={
-                validationError?.field === "name" ? validationError.message : fieldErrors.name
-              }
-            />
-          </div>
+          <FormField
+            field={field}
+            label={t("nameLabel")}
+            backendError={
+              validationError?.field === "name" ? validationError.message : fieldErrors.name
+            }
+          />
         )}
       </form.Field>
 

--- a/frontend/src/lib/forms/form-field.test.tsx
+++ b/frontend/src/lib/forms/form-field.test.tsx
@@ -1,0 +1,150 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { FormField } from "./form-field";
+
+function stringField(overrides?: {
+  name?: string;
+  value?: string;
+  errors?: unknown[];
+  handleBlur?: () => void;
+  handleChange?: (value: string) => void;
+}) {
+  return {
+    name: overrides?.name ?? "front",
+    state: { value: overrides?.value ?? "", meta: { errors: overrides?.errors ?? [] } },
+    handleBlur: overrides?.handleBlur ?? vi.fn(),
+    handleChange: overrides?.handleChange ?? vi.fn(),
+  };
+}
+
+function booleanField(overrides?: {
+  name?: string;
+  value?: boolean;
+  handleBlur?: () => void;
+  handleChange?: (value: boolean) => void;
+}) {
+  return {
+    name: overrides?.name ?? "isDefaultStarter",
+    state: { value: overrides?.value ?? false, meta: { errors: [] } },
+    handleBlur: overrides?.handleBlur ?? vi.fn(),
+    handleChange: overrides?.handleChange ?? vi.fn(),
+  };
+}
+
+describe("FormField (text)", () => {
+  it("pairs the Label htmlFor with the input id (= field.name by default)", () => {
+    render(<FormField field={stringField({ name: "name" })} label="Name" />);
+    const input = screen.getByLabelText("Name");
+    expect(input).toHaveAttribute("id", "name");
+    expect(input.tagName).toBe("INPUT");
+  });
+
+  it("uses idOverride for both the input id and the Label htmlFor", () => {
+    render(
+      <FormField field={stringField({ name: "front" })} label="Front" idOverride="c1front-field" />,
+    );
+    const input = screen.getByLabelText("Front");
+    expect(input).toHaveAttribute("id", "c1front-field");
+    // name attribute stays the raw field name, only the id is overridden.
+    expect(input).toHaveAttribute("name", "front");
+  });
+
+  it("renders the current value and threads onChange / onBlur", async () => {
+    const handleChange = vi.fn();
+    const handleBlur = vi.fn();
+    render(
+      <FormField field={stringField({ value: "hi", handleChange, handleBlur })} label="Name" />,
+    );
+    const input = screen.getByLabelText("Name") as HTMLInputElement;
+    expect(input.value).toBe("hi");
+    await userEvent.type(input, "x");
+    expect(handleChange).toHaveBeenCalled();
+    input.blur();
+    expect(handleBlur).toHaveBeenCalled();
+  });
+
+  it("renders a zod field error message", () => {
+    render(
+      <FormField field={stringField({ errors: [{ message: "name is required" }] })} label="Name" />,
+    );
+    expect(screen.getByText("name is required")).toBeInTheDocument();
+  });
+
+  it("renders the backendError when there is no zod error", () => {
+    render(<FormField field={stringField()} label="Name" backendError="already taken" />);
+    expect(screen.getByText("already taken")).toBeInTheDocument();
+  });
+
+  it("prefers the zod error over backendError when both are present", () => {
+    render(
+      <FormField
+        field={stringField({ errors: [{ message: "zod wins" }] })}
+        label="Name"
+        backendError="backend loses"
+      />,
+    );
+    expect(screen.getByText("zod wins")).toBeInTheDocument();
+    expect(screen.queryByText("backend loses")).toBeNull();
+  });
+
+  it("forwards placeholder and disabled", () => {
+    render(<FormField field={stringField()} label="Name" placeholder="Type here" disabled />);
+    const input = screen.getByLabelText("Name");
+    expect(input).toHaveAttribute("placeholder", "Type here");
+    expect(input).toBeDisabled();
+  });
+
+  it("merges a className override onto the wrapper (tailwind-merge wins last)", () => {
+    const { container } = render(
+      <FormField field={stringField()} label="Name" className="space-y-1" />,
+    );
+    const wrapper = container.firstElementChild as HTMLElement;
+    expect(wrapper.className).toContain("space-y-1");
+    expect(wrapper.className).not.toContain("space-y-2");
+  });
+});
+
+describe("FormField (textarea / number)", () => {
+  it("renders a textarea for kind=textarea", () => {
+    render(<FormField field={stringField({ name: "bio" })} label="Bio" kind="textarea" />);
+    const el = screen.getByLabelText("Bio");
+    expect(el.tagName).toBe("TEXTAREA");
+  });
+
+  it("renders a number input for kind=number", () => {
+    render(<FormField field={stringField({ name: "sortOrder" })} label="Order" kind="number" />);
+    const el = screen.getByLabelText("Order");
+    expect(el).toHaveAttribute("type", "number");
+  });
+});
+
+describe("FormField (checkbox)", () => {
+  it("renders a checkbox reflecting the boolean value, with the label after it and no FieldError row", () => {
+    render(
+      <FormField field={booleanField({ value: true })} label="Default starter" kind="checkbox" />,
+    );
+    const box = screen.getByLabelText("Default starter") as HTMLInputElement;
+    expect(box).toHaveAttribute("type", "checkbox");
+    expect(box.checked).toBe(true);
+  });
+
+  it("calls handleChange with the next checked state", async () => {
+    const handleChange = vi.fn();
+    render(
+      <FormField
+        field={booleanField({ value: false, handleChange })}
+        label="Default starter"
+        kind="checkbox"
+      />,
+    );
+    await userEvent.click(screen.getByLabelText("Default starter"));
+    expect(handleChange).toHaveBeenCalledWith(true);
+  });
+
+  it("forwards disabled to the checkbox input", () => {
+    render(<FormField field={booleanField()} label="Default starter" kind="checkbox" disabled />);
+    expect(screen.getByLabelText("Default starter")).toBeDisabled();
+  });
+});

--- a/frontend/src/lib/forms/form-field.tsx
+++ b/frontend/src/lib/forms/form-field.tsx
@@ -1,0 +1,111 @@
+import type { ReactNode } from "react";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { FieldError } from "@/lib/forms/field-error";
+import { cn } from "@/lib/utils";
+
+/** Minimal structural view of a TanStack field whose value is a string. */
+type StringFieldApi = {
+  name: string;
+  state: { value: string; meta: { errors: unknown[] } };
+  handleBlur: () => void;
+  handleChange: (value: string) => void;
+};
+
+/** Minimal structural view of a TanStack field whose value is a boolean. */
+type BooleanFieldApi = {
+  name: string;
+  state: { value: boolean; meta: { errors: unknown[] } };
+  handleBlur: () => void;
+  handleChange: (value: boolean) => void;
+};
+
+type CommonProps = {
+  /** Already-translated label text — the wrapper never calls `useTranslations`. */
+  label: string;
+  /** Resolved backend error message for this field, if any. */
+  backendError?: string;
+  /**
+   * Overrides the control `id` (and the `Label` `htmlFor`). Defaults to
+   * `field.name`. Required when several forms render the same field name on one
+   * page — e.g. `CardForm`'s `${idPrefix}front-field`.
+   */
+  idOverride?: string;
+  disabled?: boolean;
+  placeholder?: string;
+  /** Extra classes for the field wrapper. Default spacing is `space-y-2`. */
+  className?: string;
+};
+
+type FormFieldProps =
+  | (CommonProps & { kind?: "text" | "textarea" | "number"; field: StringFieldApi })
+  | (CommonProps & { kind: "checkbox"; field: BooleanFieldApi });
+
+/**
+ * The label + control + {@link FieldError} triad shared by the TanStack forms.
+ *
+ * It owns the `htmlFor`/`id` a11y pairing so the two can never drift, and threads
+ * the standard `onBlur`/`onChange` wiring for the chosen control. Labels arrive
+ * already-translated; the wrapper performs no i18n.
+ *
+ * `kind` selects the control: `"text"` (default) / `"number"` render an
+ * {@link Input}, `"textarea"` renders a {@link Textarea}, and `"checkbox"`
+ * renders an inline checkbox + label with no `FieldError` row.
+ */
+export function FormField(props: FormFieldProps) {
+  const { label, backendError, idOverride, disabled, placeholder, className } = props;
+  const id = idOverride ?? props.field.name;
+
+  if (props.kind === "checkbox") {
+    const { field } = props;
+    return (
+      <div className={cn("flex items-center gap-2", className)}>
+        <input
+          id={id}
+          name={field.name}
+          type="checkbox"
+          checked={field.state.value}
+          onBlur={field.handleBlur}
+          onChange={(e) => field.handleChange(e.target.checked)}
+          disabled={disabled}
+          className="h-4 w-4 rounded border-input"
+        />
+        <Label htmlFor={id}>{label}</Label>
+      </div>
+    );
+  }
+
+  const { field, kind } = props;
+  const control: ReactNode =
+    kind === "textarea" ? (
+      <Textarea
+        id={id}
+        name={field.name}
+        value={field.state.value}
+        onBlur={field.handleBlur}
+        onChange={(e) => field.handleChange(e.target.value)}
+        disabled={disabled}
+        placeholder={placeholder}
+      />
+    ) : (
+      <Input
+        id={id}
+        name={field.name}
+        type={kind === "number" ? "number" : undefined}
+        value={field.state.value}
+        onBlur={field.handleBlur}
+        onChange={(e) => field.handleChange(e.target.value)}
+        disabled={disabled}
+        placeholder={placeholder}
+      />
+    );
+
+  return (
+    <div className={cn("space-y-2", className)}>
+      <Label htmlFor={id}>{label}</Label>
+      {control}
+      <FieldError zodErrors={field.state.meta.errors} backendError={backendError} />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Extracts the hand-wired `Label` + control + `FieldError` triad shared by the TanStack forms into a single `<FormField>` wrapper, and adopts it in the three single-field forms. Behavior-preserving — the `htmlFor`/`id` a11y pairing now lives in one place and cannot drift.

Stacked on #597 (`submitFormHandler`). Closes #598.

## Background / Motivation

- Every TanStack form hand-wired the same `<div class="space-y-2"><Label htmlFor>…<Input/Textarea>…<FieldError/></div>` block ~12 times, repeating the `id`/`htmlFor` pairing, the `onBlur`/`onChange` wiring, and the `FieldError` tail.
- The a11y `htmlFor`/`id` pairing was duplicated at every site, so a single typo silently breaks label association. `card-form` additionally needs a custom `idPrefix` to disambiguate several CardForms on one page — easy to get wrong by hand.

## Changes

- **Add** `frontend/src/lib/forms/form-field.tsx` — `FormField`, a discriminated union over `kind: "text" | "textarea" | "number" | "checkbox"`. `text`/`number` render an `Input`, `textarea` a `Textarea`, `checkbox` an inline checkbox + label (no `FieldError` row). `id = idOverride ?? field.name` owns the `Label htmlFor` / control `id` pairing; `className` merges over the default `space-y-2` via tailwind-merge.
- **Add** `frontend/src/lib/forms/form-field.test.tsx` — 13 tests: a11y pairing, `idOverride`, value/onChange/onBlur, zod-vs-backend `FieldError` precedence (incl. the both-present tiebreak where zod wins), placeholder/disabled (text and checkbox), the className override (`space-y-1` wins), and the textarea/number/checkbox kinds.
- **Modify** `cardgroup-form.tsx` / `role-form.tsx` / `card-form.tsx` — replace the hand-wired field block with `<FormField>` and drop the now-unused `Input`/`Label`/`FieldError` imports. `role-form` threads `disabled`/`placeholder`; `card-form` threads `idOverride` + `className="space-y-1"`.

Preserved invariants: every `htmlFor`/`id` pairing (including card-form's `${idPrefix}…-field`), card-form's tighter `space-y-1` spacing, role-form's `disabled`/`placeholder`, the `onBlur` blur-validation, and the `validationError`-over-`fieldErrors` precedence.

**Scope note:** only `kind="text"` has a production consumer in this PR. `textarea` / `number` / `checkbox` are implemented (per the issue's 4-kind API) and unit-tested, ready for the later FORMS-track conversions (`admin-master` textarea/number/checkbox, `profile` textarea). They can be trimmed to text-only if a tighter wire-when-needed scope is preferred.

## Verification (in worktree)

- `tsc --noEmit` — pass. `biome check --error-on-warnings .` — clean. `knip` — clean.
- Full vitest — **1622 tests pass** (174 files; +13 from `form-field.test.tsx`).
- No CJK in changed sources; production build runs in CI.

## Test plan

- [ ] Edit a cardgroup name, a role name, and a card front/back — confirm clicking the label focuses the input and inline validation / backend errors render as before.
- [ ] On a page with two CardForms (e.g. create + inline edit), confirm each input keeps a distinct `id` (no duplicate-id a11y break).
- [ ] Submit with an empty required field — confirm the inline error appears under the correct control.
