### PR TITLE
refactor(frontend): extract shared CardListScreen for cards/master-cards clients

### DIFF
--- a/frontend/src/app/admin/masters/[id]/edit/cards/master-cards-client.tsx
+++ b/frontend/src/app/admin/masters/[id]/edit/cards/master-cards-client.tsx
@@ -1,22 +1,10 @@
 "use client";
 
 import { useTranslations } from "next-intl";
-import type { ReactNode, RefObject } from "react";
-import { useCallback, useEffect, useRef, useState } from "react";
-import { BulkActionBar } from "@/components/cardgroups/bulk-action-bar";
-import { CardFetchMoreError } from "@/components/cardgroups/card-fetch-more-error";
-import { CardForm } from "@/components/cardgroups/card-form";
-import { CardRow } from "@/components/cardgroups/card-row";
-import { CardSearchInput } from "@/components/cardgroups/card-search-input";
-import type { SwipeableRowHandle } from "@/components/cardgroups/swipeable-row";
-import { SearchTakeoverBar } from "@/components/search/search-takeover-bar";
-import { Button } from "@/components/ui/button";
-import { ErrorBanner } from "@/components/ui/error-banner";
-import { FormSheet, useFormSheetClose } from "@/components/ui/form-sheet";
+import type { ReactNode } from "react";
+import { CardListScreen, type SectionHeaderArgs } from "@/components/cardgroups/card-list-screen";
 import type { AdminMasterCardsConnectionQuery } from "@/generated/graphql";
-import { useBulkSelection } from "@/hooks/use-bulk-selection";
 import { useHeaderTakeoverSearch } from "@/hooks/use-header-takeover-search";
-import { getBackendErrorBanner } from "@/lib/apollo/errors";
 import { type AddMasterCardDetail, FLAMINGO_EVENT } from "@/lib/events/flamingo-events";
 import { MasterBatchImportForm } from "./master-batch-import-form";
 import { useMasterCardMutations } from "./use-master-card-mutations";
@@ -25,102 +13,6 @@ import { useMasterCardsConnection } from "./use-master-cards-connection";
 type Connection = AdminMasterCardsConnectionQuery["adminMasterCardsConnection"];
 export type MasterCardEdge = Connection["edges"][number];
 export type MasterCardConnectionPageInfo = Connection["pageInfo"];
-
-function EditCardSheetContent({
-  card,
-  submit,
-  submitting,
-  error,
-  validationError,
-}: {
-  card: { id: string; front: string; back: string };
-  submit: (values: { front: string; back: string }) => Promise<void>;
-  submitting: boolean;
-  error: unknown;
-  validationError: { field: string; message: string } | null;
-}) {
-  const close = useFormSheetClose();
-  const tCommon = useTranslations("Common");
-
-  return (
-    <CardForm
-      mode="edit"
-      idPrefix={`edit-${card.id}-`}
-      defaultValues={{ front: card.front, back: card.back }}
-      submit={submit}
-      submitLabel={tCommon("save")}
-      submitting={submitting}
-      error={error}
-      validationError={validationError}
-      onCancel={close}
-    />
-  );
-}
-
-function AddCardSheetContent({
-  submit,
-  submitting,
-  error,
-  validationError,
-  onDirty,
-}: {
-  submit: (values: { front: string; back: string }) => Promise<void>;
-  submitting: boolean;
-  error: unknown;
-  validationError: { field: string; message: string } | null;
-  onDirty: () => void;
-}) {
-  const close = useFormSheetClose();
-
-  return (
-    <div onInput={onDirty}>
-      <CardForm
-        mode="create"
-        idPrefix="add-card-"
-        defaultValues={{ front: "", back: "" }}
-        submit={submit}
-        submitting={submitting}
-        error={error}
-        validationError={validationError}
-        onCancel={close}
-      />
-    </div>
-  );
-}
-
-const EmptyState = ({ search, onClear }: { search: string | null; onClear: () => void }) => {
-  const t = useTranslations("Cards");
-  return search !== null ? (
-    <div
-      className="flex flex-col items-center gap-3 rounded-md border border-dashed border-border p-6"
-      data-testid="cards-empty-search"
-    >
-      <p className="text-sm text-muted-foreground">{t("noMatch", { search })}</p>
-      <Button
-        type="button"
-        variant="outline"
-        size="sm"
-        onClick={onClear}
-        data-testid="cards-clear-search"
-      >
-        {t("clearSearch")}
-      </Button>
-    </div>
-  ) : (
-    <div
-      className="flex flex-col items-center gap-3 rounded-md border border-dashed border-border p-6"
-      data-testid="cards-empty"
-    >
-      <p className="text-sm text-muted-foreground">{t("addSomeCards")}</p>
-    </div>
-  );
-};
-
-type SectionHeaderArgs = {
-  totalCount: number;
-  onAddCard: () => void;
-  onBatchImport: () => void;
-};
 
 type Props = {
   masterId: string;
@@ -146,35 +38,9 @@ export function MasterCardsClient({
   sectionHeader,
 }: Props) {
   const t = useTranslations("Cards");
-  const [addOpen, setAddOpen] = useState(false);
-  const [addDirty, setAddDirty] = useState(false);
-  const [batchImportOpen, setBatchImportOpen] = useState(false);
-  const [createValidationError, setCreateValidationError] = useState<{
-    field: string;
-    message: string;
-  } | null>(null);
-  const [editingId, setEditingId] = useState<string | null>(null);
-  // Field-level error for the editing row (from updateCard's outcome-union).
-  const [rowValidationError, setRowValidationError] = useState<{
-    field: string;
-    message: string;
-  } | null>(null);
-  // Per-card SwipeableRow handles; lets a row close any half-open sibling.
-  const rowRefs = useRef<Map<string, RefObject<SwipeableRowHandle | null>>>(new Map());
-  const selection = useBulkSelection<string>();
   const search = useHeaderTakeoverSearch();
 
-  const {
-    edges,
-    pageInfo,
-    totalCount,
-    fetchingMore,
-    fetchMoreError,
-    retryFetchMore,
-    sentinelRef,
-    queryVariables,
-    queryError,
-  } = useMasterCardsConnection({
+  const connection = useMasterCardsConnection({
     masterId,
     searchQuery: search.query,
     initialEdges,
@@ -183,263 +49,29 @@ export function MasterCardsClient({
     fetchMoreErrorMessage: t("fetchMoreFailed"),
   });
 
-  const {
-    createCard,
-    updateCard,
-    deleteRow,
-    deleteCards,
-    creating,
-    updating,
-    bulkDeleting,
-    createError,
-    updateError,
-    bulkDeleteError,
-    deleteRowError,
-    resetCreateCard,
-  } = useMasterCardMutations({ masterId, queryVariables });
-
-  const queryBannerError = getBackendErrorBanner(queryError);
-  const bulkDeleteBannerError = getBackendErrorBanner(bulkDeleteError);
-  // Raw per-row delete error → localized banner copy (server message or fallback).
-  const deleteRowBannerError =
-    deleteRowError !== null ? (getBackendErrorBanner(deleteRowError) ?? t("deleteError")) : null;
-
-  const closeOtherRows = useCallback((exceptCardId: string) => {
-    for (const [id, ref] of rowRefs.current.entries()) {
-      if (id !== exceptCardId) ref.current?.close();
-    }
-  }, []);
-
-  const editingCard = edges.find((edge) => edge.node.id === editingId)?.node;
-
-  const openAddSheet = useCallback(() => {
-    resetCreateCard();
-    setCreateValidationError(null);
-    setAddDirty(false);
-    setAddOpen(true);
-  }, [resetCreateCard]);
-
-  const openBatchImport = useCallback(() => setBatchImportOpen(true), []);
-  const closeBatchImport = useCallback(() => setBatchImportOpen(false), []);
-
-  // The global header "+" (LogoDrawer) dispatches flamingo:add-master-card on
-  // the master-edit route; claim it for this deck to open the add-card sheet.
-  // Master cards have no separate-page create target, so there is no fallback
-  // navigation to preventDefault against — the listener simply opens the sheet.
-  useEffect(() => {
-    function handleAddMasterCard(event: CustomEvent<AddMasterCardDetail>) {
-      if (event.detail?.masterId !== masterId) return;
-      event.preventDefault();
-      openAddSheet();
-    }
-    window.addEventListener(FLAMINGO_EVENT.addMasterCard, handleAddMasterCard);
-    return () => window.removeEventListener(FLAMINGO_EVENT.addMasterCard, handleAddMasterCard);
-  }, [masterId, openAddSheet]);
-
-  async function handleCreate(values: { front: string; back: string }) {
-    resetCreateCard();
-    setCreateValidationError(null);
-    const outcome = await createCard(values);
-    switch (outcome.status) {
-      case "success":
-        setAddDirty(false);
-        setCreateValidationError(null);
-        setAddOpen(false);
-        break;
-      case "validation":
-        setCreateValidationError({ field: outcome.field, message: outcome.message });
-        break;
-      case "unexpected":
-        setCreateValidationError({ field: "front", message: t("addFailed") });
-        break;
-      case "rejected":
-        // The CardForm error banner surfaces the rejection via `createError`.
-        break;
-    }
-  }
-
-  async function handleBulkDelete() {
-    const ids = Array.from(selection.selectedIds);
-    try {
-      await deleteCards(ids);
-      selection.clearSelection();
-    } catch (err) {
-      console.error("[MasterCardsClient] bulk delete rejection", {
-        name: err instanceof Error ? err.name : "unknown",
-        masterId,
-        ids,
-      });
-    }
-  }
-
-  async function handleUpdate(id: string, values: { front: string; back: string }) {
-    setRowValidationError(null);
-    const outcome = await updateCard(id, values);
-    switch (outcome.status) {
-      case "success":
-        setEditingId(null);
-        break;
-      case "validation":
-        setRowValidationError({ field: outcome.field, message: outcome.message });
-        break;
-      case "unexpected":
-        setRowValidationError({ field: "front", message: t("saveFailed") });
-        break;
-      case "rejected":
-        // The edit-sheet error banner surfaces the rejection via `updateError`.
-        break;
-    }
-  }
+  const mutations = useMasterCardMutations({ masterId, queryVariables: connection.queryVariables });
 
   return (
-    <>
-      <SearchTakeoverBar
-        open={search.searchOpen}
-        value={search.input}
-        onChange={search.setInput}
-        onClear={search.clear}
-        onClose={search.closeSearch}
-        placeholder={t("searchPlaceholder")}
-        ariaLabel={t("searchAriaLabel")}
-      />
-      <div className="space-y-3">
-        {queryBannerError && (
-          <ErrorBanner data-testid="cards-query-error">{queryBannerError}</ErrorBanner>
-        )}
-        {deleteRowBannerError && (
-          <ErrorBanner data-testid="cards-delete-error">{deleteRowBannerError}</ErrorBanner>
-        )}
-        {bulkDeleteBannerError && (
-          <ErrorBanner data-testid="cards-bulk-delete-error">{bulkDeleteBannerError}</ErrorBanner>
-        )}
-
-        <section>
-          {/* Page header (deck title/badge/kebab + the desktop add/import toolbar)
-            is supplied by the parent via the render-prop, so it receives the
-            live totalCount and the add/import openers. On mobile the openers are
-            reached through the global "+" header and the deck overflow menu. */}
-          {typeof sectionHeader === "function"
-            ? sectionHeader({
-                totalCount,
-                onAddCard: openAddSheet,
-                onBatchImport: openBatchImport,
-              })
-            : sectionHeader}
-
-          <CardSearchInput value={search.input} onChange={search.setInput} />
-
-          {selection.count > 0 && (
-            <BulkActionBar
-              count={selection.count}
-              busy={bulkDeleting}
-              onConfirm={handleBulkDelete}
-              onClear={selection.clearSelection}
-            />
-          )}
-
-          {edges.length === 0 ? (
-            <EmptyState search={search.query} onClear={search.clear} />
-          ) : (
-            <ul className="space-y-3">
-              {edges.map((edge) => {
-                const card = edge.node;
-                return (
-                  <li key={card.id} className="rounded-md border border-border overflow-hidden">
-                    <CardRow
-                      card={card}
-                      rowRef={(() => {
-                        if (!rowRefs.current.has(card.id)) {
-                          rowRefs.current.set(card.id, { current: null });
-                        }
-                        // biome-ignore lint/style/noNonNullAssertion: we just set the entry above so it is always defined.
-                        return rowRefs.current.get(card.id)!;
-                      })()}
-                      selected={selection.isSelected(card.id)}
-                      disabled={selection.count > 0 || editingId === card.id}
-                      onSelectToggle={() => selection.toggleSelected(card.id)}
-                      onEdit={() => {
-                        closeOtherRows(card.id);
-                        setRowValidationError(null);
-                        setEditingId(card.id);
-                      }}
-                      onDelete={() => deleteRow(card.id, t("cardDeleted"))}
-                    />
-                  </li>
-                );
-              })}
-            </ul>
-          )}
-
-          <FormSheet
-            title={t("addCard")}
-            open={addOpen}
-            onOpenChange={(nextOpen) => {
-              setAddOpen(nextOpen);
-              if (!nextOpen) {
-                resetCreateCard();
-                setAddDirty(false);
-                setCreateValidationError(null);
-              }
-            }}
-            submitting={creating}
-            dirty={addDirty}
-            confirmOnDismiss
-          >
-            <AddCardSheetContent
-              submit={handleCreate}
-              submitting={creating}
-              error={createError}
-              validationError={createValidationError}
-              onDirty={() => setAddDirty(true)}
-            />
-          </FormSheet>
-
-          <FormSheet
-            title={deckName}
-            open={batchImportOpen}
-            onOpenChange={setBatchImportOpen}
-            size="lg"
-          >
-            <MasterBatchImportForm
-              masterId={masterId}
-              deckName={deckName}
-              onImported={closeBatchImport}
-              onCancel={closeBatchImport}
-            />
-          </FormSheet>
-
-          <FormSheet
-            title={t("editCard")}
-            open={editingCard !== undefined}
-            onOpenChange={(nextOpen) => {
-              if (!nextOpen) {
-                setRowValidationError(null);
-                setEditingId(null);
-              }
-            }}
-            submitting={updating}
-            confirmOnDismiss={false}
-          >
-            {editingCard ? (
-              <EditCardSheetContent
-                card={editingCard}
-                submit={(values) => handleUpdate(editingCard.id, values)}
-                submitting={updating}
-                error={updateError}
-                validationError={rowValidationError}
-              />
-            ) : null}
-          </FormSheet>
-
-          <div ref={sentinelRef} aria-hidden="true" data-testid="cards-sentinel" />
-          {fetchMoreError && (
-            <CardFetchMoreError message={fetchMoreError} onRetry={retryFetchMore} />
-          )}
-          {!fetchMoreError && fetchingMore && pageInfo.hasNextPage && (
-            <p className="mt-3 text-center text-xs text-muted-foreground">{t("loadingMore")}</p>
-          )}
-        </section>
-      </div>
-    </>
+    <CardListScreen
+      search={search}
+      connection={connection}
+      mutations={mutations}
+      ownerId={masterId}
+      addCardEvent={{
+        name: FLAMINGO_EVENT.addMasterCard,
+        matches: (detail) => (detail as AddMasterCardDetail | undefined)?.masterId === masterId,
+      }}
+      bulkDeleteLog={{ scope: "[MasterCardsClient]", ownerKey: "masterId" }}
+      sectionHeader={sectionHeader}
+      importSheetTitle={deckName}
+      renderImportForm={({ onImported, onCancel }) => (
+        <MasterBatchImportForm
+          masterId={masterId}
+          deckName={deckName}
+          onImported={onImported}
+          onCancel={onCancel}
+        />
+      )}
+    />
   );
 }

--- a/frontend/src/app/cardgroups/[id]/cards/cards-client.tsx
+++ b/frontend/src/app/cardgroups/[id]/cards/cards-client.tsx
@@ -1,23 +1,11 @@
 "use client";
 
 import { useTranslations } from "next-intl";
-import type { ReactNode, RefObject } from "react";
-import { useCallback, useEffect, useRef, useState } from "react";
-import { BulkActionBar } from "@/components/cardgroups/bulk-action-bar";
-import { CardFetchMoreError } from "@/components/cardgroups/card-fetch-more-error";
-import { CardForm } from "@/components/cardgroups/card-form";
-import { CardRow } from "@/components/cardgroups/card-row";
-import { CardSearchInput } from "@/components/cardgroups/card-search-input";
+import type { ReactNode } from "react";
+import { CardListScreen, type SectionHeaderArgs } from "@/components/cardgroups/card-list-screen";
 import { CardgroupBatchImportForm } from "@/components/cardgroups/cardgroup-batch-import-form";
-import type { SwipeableRowHandle } from "@/components/cardgroups/swipeable-row";
-import { SearchTakeoverBar } from "@/components/search/search-takeover-bar";
-import { Button } from "@/components/ui/button";
-import { ErrorBanner } from "@/components/ui/error-banner";
-import { FormSheet, useFormSheetClose } from "@/components/ui/form-sheet";
 import type { CardsByCardgroupConnectionQuery } from "@/generated/graphql";
-import { useBulkSelection } from "@/hooks/use-bulk-selection";
 import { useHeaderTakeoverSearch } from "@/hooks/use-header-takeover-search";
-import { getBackendErrorBanner } from "@/lib/apollo/errors";
 import { type AddCardDetail, FLAMINGO_EVENT } from "@/lib/events/flamingo-events";
 import { useCardMutations } from "./use-card-mutations";
 import { useCardsConnection } from "./use-cards-connection";
@@ -25,102 +13,6 @@ import { useCardsConnection } from "./use-cards-connection";
 type Connection = CardsByCardgroupConnectionQuery["cardsByCardgroupConnection"];
 export type CardEdge = Connection["edges"][number];
 export type CardConnectionPageInfo = Connection["pageInfo"];
-
-function EditCardSheetContent({
-  card,
-  submit,
-  submitting,
-  error,
-  validationError,
-}: {
-  card: { id: string; front: string; back: string };
-  submit: (values: { front: string; back: string }) => Promise<void>;
-  submitting: boolean;
-  error: unknown;
-  validationError: { field: string; message: string } | null;
-}) {
-  const close = useFormSheetClose();
-  const tCommon = useTranslations("Common");
-
-  return (
-    <CardForm
-      mode="edit"
-      idPrefix={`edit-${card.id}-`}
-      defaultValues={{ front: card.front, back: card.back }}
-      submit={submit}
-      submitLabel={tCommon("save")}
-      submitting={submitting}
-      error={error}
-      validationError={validationError}
-      onCancel={close}
-    />
-  );
-}
-
-function AddCardSheetContent({
-  submit,
-  submitting,
-  error,
-  validationError,
-  onDirty,
-}: {
-  submit: (values: { front: string; back: string }) => Promise<void>;
-  submitting: boolean;
-  error: unknown;
-  validationError: { field: string; message: string } | null;
-  onDirty: () => void;
-}) {
-  const close = useFormSheetClose();
-
-  return (
-    <div onInput={onDirty}>
-      <CardForm
-        mode="create"
-        idPrefix="add-card-"
-        defaultValues={{ front: "", back: "" }}
-        submit={submit}
-        submitting={submitting}
-        error={error}
-        validationError={validationError}
-        onCancel={close}
-      />
-    </div>
-  );
-}
-
-const EmptyState = ({ search, onClear }: { search: string | null; onClear: () => void }) => {
-  const t = useTranslations("Cards");
-  return search !== null ? (
-    <div
-      className="flex flex-col items-center gap-3 rounded-md border border-dashed border-border p-6"
-      data-testid="cards-empty-search"
-    >
-      <p className="text-sm text-muted-foreground">{t("noMatch", { search })}</p>
-      <Button
-        type="button"
-        variant="outline"
-        size="sm"
-        onClick={onClear}
-        data-testid="cards-clear-search"
-      >
-        {t("clearSearch")}
-      </Button>
-    </div>
-  ) : (
-    <div
-      className="flex flex-col items-center gap-3 rounded-md border border-dashed border-border p-6"
-      data-testid="cards-empty"
-    >
-      <p className="text-sm text-muted-foreground">{t("addSomeCards")}</p>
-    </div>
-  );
-};
-
-type SectionHeaderArgs = {
-  totalCount: number;
-  onAddCard: () => void;
-  onBatchImport: () => void;
-};
 
 type Props = {
   cardgroupId: string;
@@ -146,35 +38,9 @@ export function CardsClient({
   sectionHeader,
 }: Props) {
   const t = useTranslations("Cards");
-  const [addOpen, setAddOpen] = useState(false);
-  const [addDirty, setAddDirty] = useState(false);
-  const [batchImportOpen, setBatchImportOpen] = useState(false);
-  const [createValidationError, setCreateValidationError] = useState<{
-    field: string;
-    message: string;
-  } | null>(null);
-  const [editingId, setEditingId] = useState<string | null>(null);
-  // Field-level error for the editing row (from updateCard's outcome-union).
-  const [rowValidationError, setRowValidationError] = useState<{
-    field: string;
-    message: string;
-  } | null>(null);
-  // Per-card SwipeableRow handles; lets a row close any half-open sibling.
-  const rowRefs = useRef<Map<string, RefObject<SwipeableRowHandle | null>>>(new Map());
-  const selection = useBulkSelection<string>();
   const search = useHeaderTakeoverSearch();
 
-  const {
-    edges,
-    pageInfo,
-    totalCount,
-    fetchingMore,
-    fetchMoreError,
-    retryFetchMore,
-    sentinelRef,
-    queryVariables,
-    queryError,
-  } = useCardsConnection({
+  const connection = useCardsConnection({
     cardgroupId,
     searchQuery: search.query,
     initialEdges,
@@ -182,268 +48,45 @@ export function CardsClient({
     initialTotalCount,
   });
 
-  const {
-    createCard,
-    updateCard,
-    deleteRow,
-    deleteCards,
-    creating,
-    updating,
-    bulkDeleting,
-    createError,
-    updateError,
-    bulkDeleteError,
-    deleteRowError,
-    resetCreateCard,
-  } = useCardMutations({ cardgroupId, queryVariables });
-
-  const queryBannerError = getBackendErrorBanner(queryError);
-  const bulkDeleteBannerError = getBackendErrorBanner(bulkDeleteError);
-  // Raw per-row delete error → localized banner copy (server message or fallback).
-  const deleteRowBannerError =
-    deleteRowError !== null ? (getBackendErrorBanner(deleteRowError) ?? t("deleteError")) : null;
-
-  const closeOtherRows = useCallback((exceptCardId: string) => {
-    for (const [id, ref] of rowRefs.current.entries()) {
-      if (id !== exceptCardId) ref.current?.close();
-    }
-  }, []);
-
-  const editingCard = edges.find((edge) => edge.node.id === editingId)?.node;
-
-  const openAddSheet = useCallback(() => {
-    resetCreateCard();
-    setCreateValidationError(null);
-    setAddDirty(false);
-    setAddOpen(true);
-  }, [resetCreateCard]);
-
-  const openBatchImport = useCallback(() => setBatchImportOpen(true), []);
-  const closeBatchImport = useCallback(() => setBatchImportOpen(false), []);
-
-  useEffect(() => {
-    function handleAddCardEvent(event: CustomEvent<AddCardDetail>) {
-      if (event.detail?.cardgroupId !== cardgroupId) return;
-
-      event.preventDefault();
-      openAddSheet();
-    }
-
-    window.addEventListener(FLAMINGO_EVENT.addCard, handleAddCardEvent);
-    return () => window.removeEventListener(FLAMINGO_EVENT.addCard, handleAddCardEvent);
-  }, [cardgroupId, openAddSheet]);
-
-  async function handleCreate(values: { front: string; back: string }) {
-    resetCreateCard();
-    setCreateValidationError(null);
-    const outcome = await createCard(values);
-    switch (outcome.status) {
-      case "success":
-        setAddDirty(false);
-        setCreateValidationError(null);
-        setAddOpen(false);
-        break;
-      case "validation":
-        setCreateValidationError({ field: outcome.field, message: outcome.message });
-        break;
-      case "unexpected":
-        setCreateValidationError({ field: "front", message: t("addFailed") });
-        break;
-      case "rejected":
-        // The CardForm error banner surfaces the rejection via `createError`.
-        break;
-    }
-  }
-
-  async function handleBulkDelete() {
-    const ids = Array.from(selection.selectedIds);
-    try {
-      await deleteCards(ids);
-      selection.clearSelection();
-    } catch (err) {
-      console.error("[CardsClient] bulk delete rejection", {
-        name: err instanceof Error ? err.name : "unknown",
-        cardgroupId,
-        ids,
-      });
-    }
-  }
-
-  async function handleUpdate(id: string, values: { front: string; back: string }) {
-    setRowValidationError(null);
-    const outcome = await updateCard(id, values);
-    switch (outcome.status) {
-      case "success":
-        setEditingId(null);
-        break;
-      case "validation":
-        setRowValidationError({ field: outcome.field, message: outcome.message });
-        break;
-      case "unexpected":
-        setRowValidationError({ field: "front", message: t("saveFailed") });
-        break;
-      case "rejected":
-        // The edit-sheet error banner surfaces the rejection via `updateError`.
-        break;
-    }
-  }
+  const mutations = useCardMutations({ cardgroupId, queryVariables: connection.queryVariables });
 
   return (
-    <>
-      <SearchTakeoverBar
-        open={search.searchOpen}
-        value={search.input}
-        onChange={search.setInput}
-        onClear={search.clear}
-        onClose={search.closeSearch}
-        placeholder={t("searchPlaceholder")}
-        ariaLabel={t("searchAriaLabel")}
-      />
-      <div className="space-y-3">
-        {queryBannerError && (
-          <ErrorBanner data-testid="cards-query-error">{queryBannerError}</ErrorBanner>
-        )}
-        {deleteRowBannerError && (
-          <ErrorBanner data-testid="cards-delete-error">{deleteRowBannerError}</ErrorBanner>
-        )}
-        {bulkDeleteBannerError && (
-          <ErrorBanner data-testid="cards-bulk-delete-error">{bulkDeleteBannerError}</ErrorBanner>
-        )}
-
-        <section>
-          {sectionHeader === undefined ? (
-            <h2 className="mb-3 text-sm font-medium uppercase tracking-wide text-muted-foreground">
-              {t("cardsCount", { count: totalCount })}
-            </h2>
-          ) : typeof sectionHeader === "function" ? (
-            sectionHeader({ totalCount, onAddCard: openAddSheet, onBatchImport: openBatchImport })
-          ) : (
-            sectionHeader
-          )}
-
-          <CardSearchInput value={search.input} onChange={search.setInput} />
-
-          {selection.count > 0 && (
-            <BulkActionBar
-              count={selection.count}
-              busy={bulkDeleting}
-              onConfirm={handleBulkDelete}
-              onClear={selection.clearSelection}
-            />
-          )}
-
-          {edges.length === 0 ? (
-            <EmptyState search={search.query} onClear={search.clear} />
-          ) : (
-            <ul className="space-y-3">
-              {edges.map((edge) => {
-                const card = edge.node;
-                return (
-                  <li key={card.id} className="rounded-md border border-border overflow-hidden">
-                    <CardRow
-                      card={card}
-                      rowRef={(() => {
-                        if (!rowRefs.current.has(card.id)) {
-                          rowRefs.current.set(card.id, { current: null });
-                        }
-                        // biome-ignore lint/style/noNonNullAssertion: we just set the entry above so it is always defined.
-                        return rowRefs.current.get(card.id)!;
-                      })()}
-                      selected={selection.isSelected(card.id)}
-                      disabled={selection.count > 0 || editingId === card.id}
-                      onSelectToggle={() => selection.toggleSelected(card.id)}
-                      onEdit={() => {
-                        closeOtherRows(card.id);
-                        setRowValidationError(null);
-                        setEditingId(card.id);
-                      }}
-                      onDelete={() => deleteRow(card.id, t("cardDeleted"))}
-                    />
-                  </li>
-                );
-              })}
-            </ul>
-          )}
-
-          <FormSheet
-            title={t("addCard")}
-            open={addOpen}
-            onOpenChange={(nextOpen) => {
-              setAddOpen(nextOpen);
-              if (!nextOpen) {
-                resetCreateCard();
-                setAddDirty(false);
-                setCreateValidationError(null);
-              }
-            }}
-            submitting={creating}
-            dirty={addDirty}
-            confirmOnDismiss
-          >
-            <AddCardSheetContent
-              submit={handleCreate}
-              submitting={creating}
-              error={createError}
-              validationError={createValidationError}
-              onDirty={() => setAddDirty(true)}
-            />
-          </FormSheet>
-
-          {/* Object-first: header shows only the destination cardgroup (the high-risk variable); the verb lives in the sr-only accessible name. Intentional deviation from the verb-first sheets. */}
-          <FormSheet
-            title={
-              <span
-                className="block overflow-hidden text-ellipsis whitespace-nowrap"
-                title={cardgroupName}
-              >
-                <span className="sr-only">{t("batchImportSrOnly")}</span>
-                {cardgroupName}
-              </span>
-            }
-            open={batchImportOpen}
-            onOpenChange={setBatchImportOpen}
-            size="lg"
-          >
-            <CardgroupBatchImportForm
-              cardgroupId={cardgroupId}
-              cardgroupName={cardgroupName}
-              onImported={closeBatchImport}
-              onCancel={closeBatchImport}
-            />
-          </FormSheet>
-
-          <FormSheet
-            title={t("editCard")}
-            open={editingCard !== undefined}
-            onOpenChange={(nextOpen) => {
-              if (!nextOpen) {
-                setRowValidationError(null);
-                setEditingId(null);
-              }
-            }}
-            submitting={updating}
-            confirmOnDismiss={false}
-          >
-            {editingCard ? (
-              <EditCardSheetContent
-                card={editingCard}
-                submit={(values) => handleUpdate(editingCard.id, values)}
-                submitting={updating}
-                error={updateError}
-                validationError={rowValidationError}
-              />
-            ) : null}
-          </FormSheet>
-
-          <div ref={sentinelRef} aria-hidden="true" data-testid="cards-sentinel" />
-          {fetchMoreError && (
-            <CardFetchMoreError message={fetchMoreError} onRetry={retryFetchMore} />
-          )}
-          {!fetchMoreError && fetchingMore && pageInfo.hasNextPage && (
-            <p className="mt-3 text-center text-xs text-muted-foreground">{t("loadingMore")}</p>
-          )}
-        </section>
-      </div>
-    </>
+    <CardListScreen
+      search={search}
+      connection={connection}
+      mutations={mutations}
+      ownerId={cardgroupId}
+      addCardEvent={{
+        name: FLAMINGO_EVENT.addCard,
+        matches: (detail) => (detail as AddCardDetail | undefined)?.cardgroupId === cardgroupId,
+      }}
+      bulkDeleteLog={{ scope: "[CardsClient]", ownerKey: "cardgroupId" }}
+      sectionHeader={sectionHeader}
+      defaultHeader={({ totalCount }) => (
+        <h2 className="mb-3 text-sm font-medium uppercase tracking-wide text-muted-foreground">
+          {t("cardsCount", { count: totalCount })}
+        </h2>
+      )}
+      importSheetTitle={
+        // Object-first: header shows only the destination cardgroup (the high-risk
+        // variable); the verb lives in the sr-only accessible name. Intentional
+        // deviation from the verb-first sheets.
+        <span
+          className="block overflow-hidden text-ellipsis whitespace-nowrap"
+          title={cardgroupName}
+        >
+          <span className="sr-only">{t("batchImportSrOnly")}</span>
+          {cardgroupName}
+        </span>
+      }
+      renderImportForm={({ onImported, onCancel }) => (
+        <CardgroupBatchImportForm
+          cardgroupId={cardgroupId}
+          cardgroupName={cardgroupName}
+          onImported={onImported}
+          onCancel={onCancel}
+        />
+      )}
+    />
   );
 }

--- a/frontend/src/components/cardgroups/card-list-screen.tsx
+++ b/frontend/src/components/cardgroups/card-list-screen.tsx
@@ -1,0 +1,483 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import type { ReactNode, RefObject } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { BulkActionBar } from "@/components/cardgroups/bulk-action-bar";
+import { CardForm } from "@/components/cardgroups/card-form";
+import { CardRow } from "@/components/cardgroups/card-row";
+import { CardSearchInput } from "@/components/cardgroups/card-search-input";
+import type { SwipeableRowHandle } from "@/components/cardgroups/swipeable-row";
+import { ConnectionListFooter } from "@/components/layout/connection-list-footer";
+import { SearchTakeoverBar } from "@/components/search/search-takeover-bar";
+import { Button } from "@/components/ui/button";
+import { ErrorBanner } from "@/components/ui/error-banner";
+import { FormSheet, useFormSheetClose } from "@/components/ui/form-sheet";
+import { useBulkSelection } from "@/hooks/use-bulk-selection";
+import type { useHeaderTakeoverSearch } from "@/hooks/use-header-takeover-search";
+import { getBackendErrorBanner } from "@/lib/apollo/errors";
+import type {
+  CardFormValues,
+  CreateCardOutcome,
+  UpdateCardOutcome,
+} from "@/lib/cards/card-mutation-outcomes";
+
+function EditCardSheetContent({
+  card,
+  submit,
+  submitting,
+  error,
+  validationError,
+}: {
+  card: { id: string; front: string; back: string };
+  submit: (values: { front: string; back: string }) => Promise<void>;
+  submitting: boolean;
+  error: unknown;
+  validationError: { field: string; message: string } | null;
+}) {
+  const close = useFormSheetClose();
+  const tCommon = useTranslations("Common");
+
+  return (
+    <CardForm
+      mode="edit"
+      idPrefix={`edit-${card.id}-`}
+      defaultValues={{ front: card.front, back: card.back }}
+      submit={submit}
+      submitLabel={tCommon("save")}
+      submitting={submitting}
+      error={error}
+      validationError={validationError}
+      onCancel={close}
+    />
+  );
+}
+
+function AddCardSheetContent({
+  submit,
+  submitting,
+  error,
+  validationError,
+  onDirty,
+}: {
+  submit: (values: { front: string; back: string }) => Promise<void>;
+  submitting: boolean;
+  error: unknown;
+  validationError: { field: string; message: string } | null;
+  onDirty: () => void;
+}) {
+  const close = useFormSheetClose();
+
+  return (
+    <div onInput={onDirty}>
+      <CardForm
+        mode="create"
+        idPrefix="add-card-"
+        defaultValues={{ front: "", back: "" }}
+        submit={submit}
+        submitting={submitting}
+        error={error}
+        validationError={validationError}
+        onCancel={close}
+      />
+    </div>
+  );
+}
+
+const EmptyState = ({ search, onClear }: { search: string | null; onClear: () => void }) => {
+  const t = useTranslations("Cards");
+  return search !== null ? (
+    <div
+      className="flex flex-col items-center gap-3 rounded-md border border-dashed border-border p-6"
+      data-testid="cards-empty-search"
+    >
+      <p className="text-sm text-muted-foreground">{t("noMatch", { search })}</p>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={onClear}
+        data-testid="cards-clear-search"
+      >
+        {t("clearSearch")}
+      </Button>
+    </div>
+  ) : (
+    <div
+      className="flex flex-col items-center gap-3 rounded-md border border-dashed border-border p-6"
+      data-testid="cards-empty"
+    >
+      <p className="text-sm text-muted-foreground">{t("addSomeCards")}</p>
+    </div>
+  );
+};
+
+export type SectionHeaderArgs = {
+  totalCount: number;
+  onAddCard: () => void;
+  onBatchImport: () => void;
+};
+
+/** A connection edge as the screen consumes it (CardRow needs only id/front/back). */
+type CardListEdge = { cursor: string; node: { id: string; front: string; back: string } };
+
+/** The connection-hook result the screen reads (a structural subset of UseConnectionPaginationResult). */
+interface CardListConnection {
+  edges: CardListEdge[];
+  pageInfo: { hasNextPage: boolean };
+  totalCount: number;
+  fetchingMore: boolean;
+  fetchMoreError: string | null;
+  retryFetchMore: () => void;
+  sentinelRef: RefObject<HTMLDivElement | null>;
+  queryError: unknown;
+}
+
+/** The card mutations the screen drives (the shape of useEntityCardMutations' return). */
+interface CardListMutations {
+  createCard: (values: CardFormValues) => Promise<CreateCardOutcome>;
+  updateCard: (id: string, values: CardFormValues) => Promise<UpdateCardOutcome>;
+  deleteRow: (cardId: string, label: string) => void;
+  deleteCards: (ids: string[]) => Promise<unknown>;
+  creating: boolean;
+  updating: boolean;
+  bulkDeleting: boolean;
+  createError: unknown;
+  updateError: unknown;
+  bulkDeleteError: unknown;
+  deleteRowError: unknown;
+  resetCreateCard: () => void;
+}
+
+export interface CardListScreenProps {
+  /** Header-takeover search state (owned by the wrapper; drives the search UI). */
+  search: ReturnType<typeof useHeaderTakeoverSearch>;
+  /** Pagination/connection result from the entity's connection hook. */
+  connection: CardListConnection;
+  /** The entity's card mutations (from useEntityCardMutations via the wrapper). */
+  mutations: CardListMutations;
+  /** Owner id (cardgroupId / masterId) — for the add-card event match and bulk-delete log. */
+  ownerId: string;
+  /**
+   * Global add-card event wiring. `name` is the FLAMINGO_EVENT key; `matches`
+   * stays a per-wrapper closure (it reads the entity-specific `detail` field).
+   */
+  addCardEvent: { name: string; matches: (detail: unknown) => boolean };
+  /** Bulk-delete rejection log shape: scope tag + the owner-id key name. */
+  bulkDeleteLog: { scope: string; ownerKey: string };
+  /** Optional section header (render-prop receiving live totalCount, or a node). */
+  sectionHeader?: ReactNode | ((args: SectionHeaderArgs) => ReactNode);
+  /**
+   * Header rendered when `sectionHeader === undefined` (cards: the count h2;
+   * master: omitted, so an undefined header renders nothing).
+   */
+  defaultHeader?: (args: SectionHeaderArgs) => ReactNode;
+  /** Batch-import sheet title (cards: ellipsis span; master: plain deck name). */
+  importSheetTitle: ReactNode;
+  /** Batch-import form slot; receives the shared close handlers. */
+  renderImportForm: (args: { onImported: () => void; onCancel: () => void }) => ReactNode;
+}
+
+/**
+ * Shared orchestration for the cards (`/cardgroups/[id]/cards`) and master-cards
+ * (`/admin/masters/[id]/edit/cards`) list screens. Owns the presentational state
+ * (sheets, editing row, row refs, bulk selection), the add/update/bulk-delete
+ * handlers, and the full render (search bar, error banners, list, three
+ * FormSheets, and the ConnectionListFooter). The two per-entity wrappers supply
+ * the connection + mutation hook results and the three behavioral divergences
+ * (default header, add-card event, batch-import sheet) as props.
+ */
+export function CardListScreen({
+  search,
+  connection,
+  mutations,
+  ownerId,
+  addCardEvent,
+  bulkDeleteLog,
+  sectionHeader,
+  defaultHeader,
+  importSheetTitle,
+  renderImportForm,
+}: CardListScreenProps) {
+  const t = useTranslations("Cards");
+  const tCommon = useTranslations("Common");
+
+  const {
+    edges,
+    pageInfo,
+    totalCount,
+    fetchingMore,
+    fetchMoreError,
+    retryFetchMore,
+    sentinelRef,
+    queryError,
+  } = connection;
+  const {
+    createCard,
+    updateCard,
+    deleteRow,
+    deleteCards,
+    creating,
+    updating,
+    bulkDeleting,
+    createError,
+    updateError,
+    bulkDeleteError,
+    deleteRowError,
+    resetCreateCard,
+  } = mutations;
+
+  const [addOpen, setAddOpen] = useState(false);
+  const [addDirty, setAddDirty] = useState(false);
+  const [batchImportOpen, setBatchImportOpen] = useState(false);
+  const [createValidationError, setCreateValidationError] = useState<{
+    field: string;
+    message: string;
+  } | null>(null);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  // Field-level error for the editing row (from updateCard's outcome-union).
+  const [rowValidationError, setRowValidationError] = useState<{
+    field: string;
+    message: string;
+  } | null>(null);
+  // Per-card SwipeableRow handles; lets a row close any half-open sibling.
+  const rowRefs = useRef<Map<string, RefObject<SwipeableRowHandle | null>>>(new Map());
+  const selection = useBulkSelection<string>();
+
+  const queryBannerError = getBackendErrorBanner(queryError);
+  const bulkDeleteBannerError = getBackendErrorBanner(bulkDeleteError);
+  // Raw per-row delete error → localized banner copy (server message or fallback).
+  const deleteRowBannerError =
+    deleteRowError !== null ? (getBackendErrorBanner(deleteRowError) ?? t("deleteError")) : null;
+
+  const closeOtherRows = useCallback((exceptCardId: string) => {
+    for (const [id, ref] of rowRefs.current.entries()) {
+      if (id !== exceptCardId) ref.current?.close();
+    }
+  }, []);
+
+  const editingCard = edges.find((edge) => edge.node.id === editingId)?.node;
+
+  const openAddSheet = useCallback(() => {
+    resetCreateCard();
+    setCreateValidationError(null);
+    setAddDirty(false);
+    setAddOpen(true);
+  }, [resetCreateCard]);
+
+  const openBatchImport = useCallback(() => setBatchImportOpen(true), []);
+  const closeBatchImport = useCallback(() => setBatchImportOpen(false), []);
+
+  useEffect(() => {
+    function handleAddCardEvent(event: Event) {
+      const detail = (event as CustomEvent).detail;
+      if (!addCardEvent.matches(detail)) return;
+      event.preventDefault();
+      openAddSheet();
+    }
+    window.addEventListener(addCardEvent.name, handleAddCardEvent);
+    return () => window.removeEventListener(addCardEvent.name, handleAddCardEvent);
+  }, [addCardEvent, openAddSheet]);
+
+  async function handleCreate(values: { front: string; back: string }) {
+    resetCreateCard();
+    setCreateValidationError(null);
+    const outcome = await createCard(values);
+    switch (outcome.status) {
+      case "success":
+        setAddDirty(false);
+        setCreateValidationError(null);
+        setAddOpen(false);
+        break;
+      case "validation":
+        setCreateValidationError({ field: outcome.field, message: outcome.message });
+        break;
+      case "unexpected":
+        setCreateValidationError({ field: "front", message: t("addFailed") });
+        break;
+      case "rejected":
+        // The CardForm error banner surfaces the rejection via `createError`.
+        break;
+    }
+  }
+
+  async function handleBulkDelete() {
+    const ids = Array.from(selection.selectedIds);
+    try {
+      await deleteCards(ids);
+      selection.clearSelection();
+    } catch (err) {
+      console.error(`${bulkDeleteLog.scope} bulk delete rejection`, {
+        name: err instanceof Error ? err.name : "unknown",
+        [bulkDeleteLog.ownerKey]: ownerId,
+        ids,
+      });
+    }
+  }
+
+  async function handleUpdate(id: string, values: { front: string; back: string }) {
+    setRowValidationError(null);
+    const outcome = await updateCard(id, values);
+    switch (outcome.status) {
+      case "success":
+        setEditingId(null);
+        break;
+      case "validation":
+        setRowValidationError({ field: outcome.field, message: outcome.message });
+        break;
+      case "unexpected":
+        setRowValidationError({ field: "front", message: t("saveFailed") });
+        break;
+      case "rejected":
+        // The edit-sheet error banner surfaces the rejection via `updateError`.
+        break;
+    }
+  }
+
+  const headerNode =
+    sectionHeader === undefined
+      ? defaultHeader?.({ totalCount, onAddCard: openAddSheet, onBatchImport: openBatchImport })
+      : typeof sectionHeader === "function"
+        ? sectionHeader({ totalCount, onAddCard: openAddSheet, onBatchImport: openBatchImport })
+        : sectionHeader;
+
+  return (
+    <>
+      <SearchTakeoverBar
+        open={search.searchOpen}
+        value={search.input}
+        onChange={search.setInput}
+        onClear={search.clear}
+        onClose={search.closeSearch}
+        placeholder={t("searchPlaceholder")}
+        ariaLabel={t("searchAriaLabel")}
+      />
+      <div className="space-y-3">
+        {queryBannerError && (
+          <ErrorBanner data-testid="cards-query-error">{queryBannerError}</ErrorBanner>
+        )}
+        {deleteRowBannerError && (
+          <ErrorBanner data-testid="cards-delete-error">{deleteRowBannerError}</ErrorBanner>
+        )}
+        {bulkDeleteBannerError && (
+          <ErrorBanner data-testid="cards-bulk-delete-error">{bulkDeleteBannerError}</ErrorBanner>
+        )}
+
+        <section>
+          {headerNode}
+
+          <CardSearchInput value={search.input} onChange={search.setInput} />
+
+          {selection.count > 0 && (
+            <BulkActionBar
+              count={selection.count}
+              busy={bulkDeleting}
+              onConfirm={handleBulkDelete}
+              onClear={selection.clearSelection}
+            />
+          )}
+
+          {edges.length === 0 ? (
+            <EmptyState search={search.query} onClear={search.clear} />
+          ) : (
+            <ul className="space-y-3">
+              {edges.map((edge) => {
+                const card = edge.node;
+                return (
+                  <li key={card.id} className="rounded-md border border-border overflow-hidden">
+                    <CardRow
+                      card={card}
+                      rowRef={(() => {
+                        if (!rowRefs.current.has(card.id)) {
+                          rowRefs.current.set(card.id, { current: null });
+                        }
+                        // biome-ignore lint/style/noNonNullAssertion: we just set the entry above so it is always defined.
+                        return rowRefs.current.get(card.id)!;
+                      })()}
+                      selected={selection.isSelected(card.id)}
+                      disabled={selection.count > 0 || editingId === card.id}
+                      onSelectToggle={() => selection.toggleSelected(card.id)}
+                      onEdit={() => {
+                        closeOtherRows(card.id);
+                        setRowValidationError(null);
+                        setEditingId(card.id);
+                      }}
+                      onDelete={() => deleteRow(card.id, t("cardDeleted"))}
+                    />
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+
+          <FormSheet
+            title={t("addCard")}
+            open={addOpen}
+            onOpenChange={(nextOpen) => {
+              setAddOpen(nextOpen);
+              if (!nextOpen) {
+                resetCreateCard();
+                setAddDirty(false);
+                setCreateValidationError(null);
+              }
+            }}
+            submitting={creating}
+            dirty={addDirty}
+            confirmOnDismiss
+          >
+            <AddCardSheetContent
+              submit={handleCreate}
+              submitting={creating}
+              error={createError}
+              validationError={createValidationError}
+              onDirty={() => setAddDirty(true)}
+            />
+          </FormSheet>
+
+          <FormSheet
+            title={importSheetTitle}
+            open={batchImportOpen}
+            onOpenChange={setBatchImportOpen}
+            size="lg"
+          >
+            {renderImportForm({ onImported: closeBatchImport, onCancel: closeBatchImport })}
+          </FormSheet>
+
+          <FormSheet
+            title={t("editCard")}
+            open={editingCard !== undefined}
+            onOpenChange={(nextOpen) => {
+              if (!nextOpen) {
+                setRowValidationError(null);
+                setEditingId(null);
+              }
+            }}
+            submitting={updating}
+            confirmOnDismiss={false}
+          >
+            {editingCard ? (
+              <EditCardSheetContent
+                card={editingCard}
+                submit={(values) => handleUpdate(editingCard.id, values)}
+                submitting={updating}
+                error={updateError}
+                validationError={rowValidationError}
+              />
+            ) : null}
+          </FormSheet>
+
+          <ConnectionListFooter
+            sentinelRef={sentinelRef}
+            fetchMoreError={fetchMoreError}
+            onRetry={retryFetchMore}
+            fetchingMore={fetchingMore}
+            hasNextPage={pageInfo.hasNextPage}
+            retryLabel={tCommon("retry")}
+            loadingMoreLabel={t("loadingMore")}
+            testIdPrefix="cards"
+          />
+        </section>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary

Lifts the shared orchestration of the two near-identical card-list client components (`cards-client.tsx` ~449 LOC and `master-cards-client.tsx` ~445 LOC) into one presentational `<CardListScreen>`, reducing both clients to thin wrappers that own only their per-entity hooks and the three real behavioral divergences. Behavior-preserving refactor — no behavior change.

Closes #604.

> **Stacked on #603** (commit `ad67ac88`). Base is `main` so the full frontend/e2e CI runs here. While #603 (PR #614) is unmerged, this PR's diff also shows #603's files; **merge #614 first** — once #603 lands on `main`, this diff reduces to just the three CardListScreen files.

## Background / Motivation

After the mutation hooks were unified (#603), the two card-list clients were still ~590 LOC of duplicated screen orchestration: the same presentational state, `rowRefs`, `BulkActionBar` gating, the `<ul>`/`CardRow` map, three `FormSheet`s, the search bar, three error banners, and the pagination footer. The nested `EditCardSheetContent` / `AddCardSheetContent` / `EmptyState` sub-components were byte-identical. This is CARDS-track step 3 of 3, and it also absorbs the card-screen pagination footer into the shared `<ConnectionListFooter>` from #591 (so #591 stayed scoped to the four listing screens).

## Changes

- **Add** `frontend/src/components/cardgroups/card-list-screen.tsx` — the shared screen. Owns the presentational state (sheets, editing row, row refs, bulk selection), the create/update/bulk-delete handlers, and the full render. Embeds `<ConnectionListFooter testIdPrefix="cards">` (reproducing `cards-sentinel` / `cards-fetch-more-error`) in place of the inline sentinel + `CardFetchMoreError` + loading-more line. The byte-identical `EditCardSheetContent` / `AddCardSheetContent` / `EmptyState` now live here once.
- **Modify** `cards-client.tsx` / `master-cards-client.tsx` → thin wrappers (net **−242 lines**). Each calls its own `useHeaderTakeoverSearch` + connection hook + mutation hook and passes the results plus the divergence props into `<CardListScreen>`. Their public `Props` and exported `*Edge` / `*ConnectionPageInfo` aliases are unchanged.

The three real divergences are passed as props, never merged away:

1. **Default header** — `defaultHeader?` (cards renders the `cardsCount` `<h2>` when `sectionHeader === undefined`; master omits it → renders nothing).
2. **Add-card event** — `addCardEvent { name, matches }` (cards: `flamingo:add-card` + `detail.cardgroupId`; master: `flamingo:add-master-card` + `detail.masterId`); the matcher closure stays per-wrapper.
3. **Batch-import sheet** — `importSheetTitle` (cards: ellipsis span + sr-only label; master: plain `deckName`) + `renderImportForm` slot (cards: `CardgroupBatchImportForm`; master: `MasterBatchImportForm`).

Plus `ownerId` + `bulkDeleteLog { scope, ownerKey }` reproduce the exact `[CardsClient]` / `[MasterCardsClient]` bulk-delete rejection log payloads.

## Verification (in worktree)

- `tsc --noEmit` — clean. `biome check --error-on-warnings` — clean. `knip` — clean (the connection/mutations structural prop interfaces are module-private).
- Full vitest suite — **173 files / 1604 tests pass**, all unchanged: the co-located `cards-client.test.tsx` (~1660 lines) and `master-cards-client.test.tsx` plus the broad `__tests__/{cards-bulk-delete,cards-pagination,cardgroup-edit,admin-master-cards,admin-masters-edit,cards-list}.test.tsx` all render the wrappers and exercise `CardListScreen` transitively.
- `next build` — compiles + 28/28 static pages. No CJK in changed files.
- `CardFetchMoreError` is intentionally **kept** (still used by `catalog-deck-client.tsx`); `pagination-ref-triplet-removal-rule.test.ts` is untouched. A 4-lens adversarial review (DOM-fidelity, prop-wiring/reachability, type-design, test-integrity) returned **ship** on all four with no blockers.

## Test plan

- [ ] On `/cardgroups/[id]/cards` and `/admin/masters/[id]/edit/cards`: add a card via the global "+" header and via the in-page add sheet — confirm the sheet opens and the card appears.
- [ ] Single-delete (with 5s undo), bulk-select + delete, and edit a card — confirm the count, the row state, and the inline `front` validation all behave as before on both screens.
- [ ] Scroll to trigger a `fetchMore`; force a failure — confirm the `cards-fetch-more-error` banner + Retry recover the list.
- [ ] Batch-import: confirm the cards sheet shows the ellipsised cardgroup name and the master sheet shows the plain deck name.
