### PR TITLE
refactor(frontend): extract useSheetForm for card sheet validation + outcome routing

### DIFF
--- a/frontend/src/app/admin/masters/[id]/edit/cards/master-cards-client.tsx
+++ b/frontend/src/app/admin/masters/[id]/edit/cards/master-cards-client.tsx
@@ -18,6 +18,7 @@ import { useBulkSelection } from "@/hooks/use-bulk-selection";
 import { useHeaderTakeoverSearch } from "@/hooks/use-header-takeover-search";
 import { getBackendErrorBanner } from "@/lib/apollo/errors";
 import { type AddMasterCardDetail, FLAMINGO_EVENT } from "@/lib/events/flamingo-events";
+import { useCardSheetForm } from "@/lib/forms/use-sheet-form";
 import { MasterBatchImportForm } from "./master-batch-import-form";
 import { useMasterCardMutations } from "./use-master-card-mutations";
 import { useMasterCardsConnection } from "./use-master-cards-connection";
@@ -146,19 +147,7 @@ export function MasterCardsClient({
   sectionHeader,
 }: Props) {
   const t = useTranslations("Cards");
-  const [addOpen, setAddOpen] = useState(false);
-  const [addDirty, setAddDirty] = useState(false);
   const [batchImportOpen, setBatchImportOpen] = useState(false);
-  const [createValidationError, setCreateValidationError] = useState<{
-    field: string;
-    message: string;
-  } | null>(null);
-  const [editingId, setEditingId] = useState<string | null>(null);
-  // Field-level error for the editing row (from updateCard's outcome-union).
-  const [rowValidationError, setRowValidationError] = useState<{
-    field: string;
-    message: string;
-  } | null>(null);
   // Per-card SwipeableRow handles; lets a row close any half-open sibling.
   const rowRefs = useRef<Map<string, RefObject<SwipeableRowHandle | null>>>(new Map());
   const selection = useBulkSelection<string>();
@@ -198,6 +187,14 @@ export function MasterCardsClient({
     resetCreateCard,
   } = useMasterCardMutations({ masterId, queryVariables });
 
+  const sheet = useCardSheetForm({
+    createCard,
+    updateCard,
+    resetCreateCard,
+    addFailedMessage: t("addFailed"),
+    saveFailedMessage: t("saveFailed"),
+  });
+
   const queryBannerError = getBackendErrorBanner(queryError);
   const bulkDeleteBannerError = getBackendErrorBanner(bulkDeleteError);
   // Raw per-row delete error → localized banner copy (server message or fallback).
@@ -210,14 +207,7 @@ export function MasterCardsClient({
     }
   }, []);
 
-  const editingCard = edges.find((edge) => edge.node.id === editingId)?.node;
-
-  const openAddSheet = useCallback(() => {
-    resetCreateCard();
-    setCreateValidationError(null);
-    setAddDirty(false);
-    setAddOpen(true);
-  }, [resetCreateCard]);
+  const editingCard = edges.find((edge) => edge.node.id === sheet.editingId)?.node;
 
   const openBatchImport = useCallback(() => setBatchImportOpen(true), []);
   const closeBatchImport = useCallback(() => setBatchImportOpen(false), []);
@@ -230,33 +220,11 @@ export function MasterCardsClient({
     function handleAddMasterCard(event: CustomEvent<AddMasterCardDetail>) {
       if (event.detail?.masterId !== masterId) return;
       event.preventDefault();
-      openAddSheet();
+      sheet.openAddSheet();
     }
     window.addEventListener(FLAMINGO_EVENT.addMasterCard, handleAddMasterCard);
     return () => window.removeEventListener(FLAMINGO_EVENT.addMasterCard, handleAddMasterCard);
-  }, [masterId, openAddSheet]);
-
-  async function handleCreate(values: { front: string; back: string }) {
-    resetCreateCard();
-    setCreateValidationError(null);
-    const outcome = await createCard(values);
-    switch (outcome.status) {
-      case "success":
-        setAddDirty(false);
-        setCreateValidationError(null);
-        setAddOpen(false);
-        break;
-      case "validation":
-        setCreateValidationError({ field: outcome.field, message: outcome.message });
-        break;
-      case "unexpected":
-        setCreateValidationError({ field: "front", message: t("addFailed") });
-        break;
-      case "rejected":
-        // The CardForm error banner surfaces the rejection via `createError`.
-        break;
-    }
-  }
+  }, [masterId, sheet.openAddSheet]);
 
   async function handleBulkDelete() {
     const ids = Array.from(selection.selectedIds);
@@ -269,25 +237,6 @@ export function MasterCardsClient({
         masterId,
         ids,
       });
-    }
-  }
-
-  async function handleUpdate(id: string, values: { front: string; back: string }) {
-    setRowValidationError(null);
-    const outcome = await updateCard(id, values);
-    switch (outcome.status) {
-      case "success":
-        setEditingId(null);
-        break;
-      case "validation":
-        setRowValidationError({ field: outcome.field, message: outcome.message });
-        break;
-      case "unexpected":
-        setRowValidationError({ field: "front", message: t("saveFailed") });
-        break;
-      case "rejected":
-        // The edit-sheet error banner surfaces the rejection via `updateError`.
-        break;
     }
   }
 
@@ -321,7 +270,7 @@ export function MasterCardsClient({
           {typeof sectionHeader === "function"
             ? sectionHeader({
                 totalCount,
-                onAddCard: openAddSheet,
+                onAddCard: sheet.openAddSheet,
                 onBatchImport: openBatchImport,
               })
             : sectionHeader}
@@ -355,12 +304,11 @@ export function MasterCardsClient({
                         return rowRefs.current.get(card.id)!;
                       })()}
                       selected={selection.isSelected(card.id)}
-                      disabled={selection.count > 0 || editingId === card.id}
+                      disabled={selection.count > 0 || sheet.editingId === card.id}
                       onSelectToggle={() => selection.toggleSelected(card.id)}
                       onEdit={() => {
                         closeOtherRows(card.id);
-                        setRowValidationError(null);
-                        setEditingId(card.id);
+                        sheet.beginEdit(card.id);
                       }}
                       onDelete={() => deleteRow(card.id, t("cardDeleted"))}
                     />
@@ -372,25 +320,18 @@ export function MasterCardsClient({
 
           <FormSheet
             title={t("addCard")}
-            open={addOpen}
-            onOpenChange={(nextOpen) => {
-              setAddOpen(nextOpen);
-              if (!nextOpen) {
-                resetCreateCard();
-                setAddDirty(false);
-                setCreateValidationError(null);
-              }
-            }}
+            open={sheet.addOpen}
+            onOpenChange={sheet.onAddOpenChange}
             submitting={creating}
-            dirty={addDirty}
+            dirty={sheet.addDirty}
             confirmOnDismiss
           >
             <AddCardSheetContent
-              submit={handleCreate}
+              submit={sheet.handleCreate}
               submitting={creating}
               error={createError}
-              validationError={createValidationError}
-              onDirty={() => setAddDirty(true)}
+              validationError={sheet.createValidationError}
+              onDirty={sheet.markAddDirty}
             />
           </FormSheet>
 
@@ -411,22 +352,17 @@ export function MasterCardsClient({
           <FormSheet
             title={t("editCard")}
             open={editingCard !== undefined}
-            onOpenChange={(nextOpen) => {
-              if (!nextOpen) {
-                setRowValidationError(null);
-                setEditingId(null);
-              }
-            }}
+            onOpenChange={sheet.onEditOpenChange}
             submitting={updating}
             confirmOnDismiss={false}
           >
             {editingCard ? (
               <EditCardSheetContent
                 card={editingCard}
-                submit={(values) => handleUpdate(editingCard.id, values)}
+                submit={(values) => sheet.handleUpdate(editingCard.id, values)}
                 submitting={updating}
                 error={updateError}
-                validationError={rowValidationError}
+                validationError={sheet.rowValidationError}
               />
             ) : null}
           </FormSheet>

--- a/frontend/src/app/cardgroups/[id]/cards/cards-client.tsx
+++ b/frontend/src/app/cardgroups/[id]/cards/cards-client.tsx
@@ -19,6 +19,7 @@ import { useBulkSelection } from "@/hooks/use-bulk-selection";
 import { useHeaderTakeoverSearch } from "@/hooks/use-header-takeover-search";
 import { getBackendErrorBanner } from "@/lib/apollo/errors";
 import { type AddCardDetail, FLAMINGO_EVENT } from "@/lib/events/flamingo-events";
+import { useCardSheetForm } from "@/lib/forms/use-sheet-form";
 import { useCardMutations } from "./use-card-mutations";
 import { useCardsConnection } from "./use-cards-connection";
 
@@ -146,19 +147,7 @@ export function CardsClient({
   sectionHeader,
 }: Props) {
   const t = useTranslations("Cards");
-  const [addOpen, setAddOpen] = useState(false);
-  const [addDirty, setAddDirty] = useState(false);
   const [batchImportOpen, setBatchImportOpen] = useState(false);
-  const [createValidationError, setCreateValidationError] = useState<{
-    field: string;
-    message: string;
-  } | null>(null);
-  const [editingId, setEditingId] = useState<string | null>(null);
-  // Field-level error for the editing row (from updateCard's outcome-union).
-  const [rowValidationError, setRowValidationError] = useState<{
-    field: string;
-    message: string;
-  } | null>(null);
   // Per-card SwipeableRow handles; lets a row close any half-open sibling.
   const rowRefs = useRef<Map<string, RefObject<SwipeableRowHandle | null>>>(new Map());
   const selection = useBulkSelection<string>();
@@ -197,6 +186,14 @@ export function CardsClient({
     resetCreateCard,
   } = useCardMutations({ cardgroupId, queryVariables });
 
+  const sheet = useCardSheetForm({
+    createCard,
+    updateCard,
+    resetCreateCard,
+    addFailedMessage: t("addFailed"),
+    saveFailedMessage: t("saveFailed"),
+  });
+
   const queryBannerError = getBackendErrorBanner(queryError);
   const bulkDeleteBannerError = getBackendErrorBanner(bulkDeleteError);
   // Raw per-row delete error → localized banner copy (server message or fallback).
@@ -209,14 +206,7 @@ export function CardsClient({
     }
   }, []);
 
-  const editingCard = edges.find((edge) => edge.node.id === editingId)?.node;
-
-  const openAddSheet = useCallback(() => {
-    resetCreateCard();
-    setCreateValidationError(null);
-    setAddDirty(false);
-    setAddOpen(true);
-  }, [resetCreateCard]);
+  const editingCard = edges.find((edge) => edge.node.id === sheet.editingId)?.node;
 
   const openBatchImport = useCallback(() => setBatchImportOpen(true), []);
   const closeBatchImport = useCallback(() => setBatchImportOpen(false), []);
@@ -226,34 +216,12 @@ export function CardsClient({
       if (event.detail?.cardgroupId !== cardgroupId) return;
 
       event.preventDefault();
-      openAddSheet();
+      sheet.openAddSheet();
     }
 
     window.addEventListener(FLAMINGO_EVENT.addCard, handleAddCardEvent);
     return () => window.removeEventListener(FLAMINGO_EVENT.addCard, handleAddCardEvent);
-  }, [cardgroupId, openAddSheet]);
-
-  async function handleCreate(values: { front: string; back: string }) {
-    resetCreateCard();
-    setCreateValidationError(null);
-    const outcome = await createCard(values);
-    switch (outcome.status) {
-      case "success":
-        setAddDirty(false);
-        setCreateValidationError(null);
-        setAddOpen(false);
-        break;
-      case "validation":
-        setCreateValidationError({ field: outcome.field, message: outcome.message });
-        break;
-      case "unexpected":
-        setCreateValidationError({ field: "front", message: t("addFailed") });
-        break;
-      case "rejected":
-        // The CardForm error banner surfaces the rejection via `createError`.
-        break;
-    }
-  }
+  }, [cardgroupId, sheet.openAddSheet]);
 
   async function handleBulkDelete() {
     const ids = Array.from(selection.selectedIds);
@@ -266,25 +234,6 @@ export function CardsClient({
         cardgroupId,
         ids,
       });
-    }
-  }
-
-  async function handleUpdate(id: string, values: { front: string; back: string }) {
-    setRowValidationError(null);
-    const outcome = await updateCard(id, values);
-    switch (outcome.status) {
-      case "success":
-        setEditingId(null);
-        break;
-      case "validation":
-        setRowValidationError({ field: outcome.field, message: outcome.message });
-        break;
-      case "unexpected":
-        setRowValidationError({ field: "front", message: t("saveFailed") });
-        break;
-      case "rejected":
-        // The edit-sheet error banner surfaces the rejection via `updateError`.
-        break;
     }
   }
 
@@ -316,7 +265,11 @@ export function CardsClient({
               {t("cardsCount", { count: totalCount })}
             </h2>
           ) : typeof sectionHeader === "function" ? (
-            sectionHeader({ totalCount, onAddCard: openAddSheet, onBatchImport: openBatchImport })
+            sectionHeader({
+              totalCount,
+              onAddCard: sheet.openAddSheet,
+              onBatchImport: openBatchImport,
+            })
           ) : (
             sectionHeader
           )}
@@ -350,12 +303,11 @@ export function CardsClient({
                         return rowRefs.current.get(card.id)!;
                       })()}
                       selected={selection.isSelected(card.id)}
-                      disabled={selection.count > 0 || editingId === card.id}
+                      disabled={selection.count > 0 || sheet.editingId === card.id}
                       onSelectToggle={() => selection.toggleSelected(card.id)}
                       onEdit={() => {
                         closeOtherRows(card.id);
-                        setRowValidationError(null);
-                        setEditingId(card.id);
+                        sheet.beginEdit(card.id);
                       }}
                       onDelete={() => deleteRow(card.id, t("cardDeleted"))}
                     />
@@ -367,25 +319,18 @@ export function CardsClient({
 
           <FormSheet
             title={t("addCard")}
-            open={addOpen}
-            onOpenChange={(nextOpen) => {
-              setAddOpen(nextOpen);
-              if (!nextOpen) {
-                resetCreateCard();
-                setAddDirty(false);
-                setCreateValidationError(null);
-              }
-            }}
+            open={sheet.addOpen}
+            onOpenChange={sheet.onAddOpenChange}
             submitting={creating}
-            dirty={addDirty}
+            dirty={sheet.addDirty}
             confirmOnDismiss
           >
             <AddCardSheetContent
-              submit={handleCreate}
+              submit={sheet.handleCreate}
               submitting={creating}
               error={createError}
-              validationError={createValidationError}
-              onDirty={() => setAddDirty(true)}
+              validationError={sheet.createValidationError}
+              onDirty={sheet.markAddDirty}
             />
           </FormSheet>
 
@@ -415,22 +360,17 @@ export function CardsClient({
           <FormSheet
             title={t("editCard")}
             open={editingCard !== undefined}
-            onOpenChange={(nextOpen) => {
-              if (!nextOpen) {
-                setRowValidationError(null);
-                setEditingId(null);
-              }
-            }}
+            onOpenChange={sheet.onEditOpenChange}
             submitting={updating}
             confirmOnDismiss={false}
           >
             {editingCard ? (
               <EditCardSheetContent
                 card={editingCard}
-                submit={(values) => handleUpdate(editingCard.id, values)}
+                submit={(values) => sheet.handleUpdate(editingCard.id, values)}
                 submitting={updating}
                 error={updateError}
-                validationError={rowValidationError}
+                validationError={sheet.rowValidationError}
               />
             ) : null}
           </FormSheet>

--- a/frontend/src/lib/forms/use-sheet-form.test.ts
+++ b/frontend/src/lib/forms/use-sheet-form.test.ts
@@ -1,0 +1,210 @@
+// @vitest-environment jsdom
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useCardSheetForm, useSheetForm } from "./use-sheet-form";
+
+describe("useSheetForm", () => {
+  it("calls onSuccess and leaves validationError null on a success outcome", async () => {
+    const onSuccess = vi.fn();
+    const { result } = renderHook(() => useSheetForm(onSuccess));
+    await act(async () => {
+      await result.current.run(() => Promise.resolve({ status: "success" as const }));
+    });
+    expect(onSuccess).toHaveBeenCalledOnce();
+    expect(result.current.validationError).toBeNull();
+  });
+
+  it("stores the field error on a validation outcome and does not call onSuccess", async () => {
+    const onSuccess = vi.fn();
+    const { result } = renderHook(() => useSheetForm(onSuccess));
+    await act(async () => {
+      await result.current.run(() =>
+        Promise.resolve({ status: "validation" as const, field: "front", message: "too long" }),
+      );
+    });
+    expect(onSuccess).not.toHaveBeenCalled();
+    expect(result.current.validationError).toEqual({ field: "front", message: "too long" });
+  });
+
+  it("returns a non-routed outcome untouched (caller handles extra variants)", async () => {
+    const { result } = renderHook(() => useSheetForm(vi.fn()));
+    let returned: { status: string } | undefined;
+    await act(async () => {
+      returned = await result.current.run(() => Promise.resolve({ status: "unexpected" as const }));
+    });
+    expect(returned).toEqual({ status: "unexpected" });
+    expect(result.current.validationError).toBeNull();
+  });
+
+  it("clears a prior validationError at the start of the next run", async () => {
+    const { result } = renderHook(() => useSheetForm(vi.fn()));
+    act(() => result.current.setValidationError({ field: "front", message: "stale" }));
+    expect(result.current.validationError).not.toBeNull();
+    await act(async () => {
+      await result.current.run(() => Promise.resolve({ status: "rejected" as const }));
+    });
+    expect(result.current.validationError).toBeNull();
+  });
+});
+
+type CardOutcome =
+  | { status: "success" }
+  | { status: "validation"; field: string; message: string }
+  | { status: "unexpected" }
+  | { status: "rejected" };
+
+function setup(overrides?: { createOutcome?: CardOutcome; updateOutcome?: CardOutcome }) {
+  const createCard = vi.fn(
+    async () => overrides?.createOutcome ?? ({ status: "success" } as const),
+  );
+  const updateCard = vi.fn(
+    async () => overrides?.updateOutcome ?? ({ status: "success" } as const),
+  );
+  const resetCreateCard = vi.fn();
+  const hook = renderHook(() =>
+    useCardSheetForm({
+      createCard,
+      updateCard,
+      resetCreateCard,
+      addFailedMessage: "Could not add",
+      saveFailedMessage: "Could not save",
+    }),
+  );
+  return { ...hook, createCard, updateCard, resetCreateCard };
+}
+
+describe("useCardSheetForm", () => {
+  it("starts closed and clean", () => {
+    const { result } = setup();
+    expect(result.current.addOpen).toBe(false);
+    expect(result.current.addDirty).toBe(false);
+    expect(result.current.editingId).toBeNull();
+    expect(result.current.createValidationError).toBeNull();
+    expect(result.current.rowValidationError).toBeNull();
+  });
+
+  it("openAddSheet opens the sheet and resets create state", () => {
+    const { result, resetCreateCard } = setup();
+    act(() => result.current.markAddDirty());
+    act(() => result.current.openAddSheet());
+    expect(result.current.addOpen).toBe(true);
+    expect(result.current.addDirty).toBe(false);
+    expect(resetCreateCard).toHaveBeenCalled();
+  });
+
+  it("markAddDirty flips the add-sheet dirty flag", () => {
+    const { result } = setup();
+    act(() => result.current.markAddDirty());
+    expect(result.current.addDirty).toBe(true);
+  });
+
+  it("handleCreate success closes the sheet and clears dirty", async () => {
+    const { result } = setup({ createOutcome: { status: "success" } });
+    act(() => result.current.openAddSheet());
+    await act(async () => {
+      await result.current.handleCreate({ front: "f", back: "b" });
+    });
+    expect(result.current.addOpen).toBe(false);
+    expect(result.current.addDirty).toBe(false);
+    expect(result.current.createValidationError).toBeNull();
+  });
+
+  it("handleCreate validation surfaces the server field error", async () => {
+    const { result } = setup({
+      createOutcome: { status: "validation", field: "front", message: "duplicate" },
+    });
+    await act(async () => {
+      await result.current.handleCreate({ front: "f", back: "b" });
+    });
+    expect(result.current.createValidationError).toEqual({ field: "front", message: "duplicate" });
+  });
+
+  it("handleCreate unexpected falls back to the localized front error", async () => {
+    const { result } = setup({ createOutcome: { status: "unexpected" } });
+    await act(async () => {
+      await result.current.handleCreate({ front: "f", back: "b" });
+    });
+    expect(result.current.createValidationError).toEqual({
+      field: "front",
+      message: "Could not add",
+    });
+  });
+
+  it("handleCreate rejected sets no inline error (banner owns it)", async () => {
+    const { result } = setup({ createOutcome: { status: "rejected" } });
+    await act(async () => {
+      await result.current.handleCreate({ front: "f", back: "b" });
+    });
+    expect(result.current.createValidationError).toBeNull();
+  });
+
+  it("handleUpdate rejected sets no inline row error and keeps the sheet open", async () => {
+    const { result } = setup({ updateOutcome: { status: "rejected" } });
+    act(() => result.current.beginEdit("card-1"));
+    await act(async () => {
+      await result.current.handleUpdate("card-1", { front: "f", back: "b" });
+    });
+    expect(result.current.rowValidationError).toBeNull();
+    // rejected does not clear editingId — only a success outcome closes the edit sheet.
+    expect(result.current.editingId).toBe("card-1");
+  });
+
+  it("beginEdit selects the row and handleUpdate success clears it", async () => {
+    const { result } = setup({ updateOutcome: { status: "success" } });
+    act(() => result.current.beginEdit("card-1"));
+    expect(result.current.editingId).toBe("card-1");
+    await act(async () => {
+      await result.current.handleUpdate("card-1", { front: "f", back: "b" });
+    });
+    expect(result.current.editingId).toBeNull();
+  });
+
+  it("handleUpdate validation surfaces the inline row error", async () => {
+    const { result } = setup({
+      updateOutcome: { status: "validation", field: "back", message: "required" },
+    });
+    act(() => result.current.beginEdit("card-1"));
+    await act(async () => {
+      await result.current.handleUpdate("card-1", { front: "f", back: "b" });
+    });
+    expect(result.current.rowValidationError).toEqual({ field: "back", message: "required" });
+    expect(result.current.editingId).toBe("card-1");
+  });
+
+  it("handleUpdate unexpected falls back to the localized front error", async () => {
+    const { result } = setup({ updateOutcome: { status: "unexpected" } });
+    act(() => result.current.beginEdit("card-1"));
+    await act(async () => {
+      await result.current.handleUpdate("card-1", { front: "f", back: "b" });
+    });
+    expect(result.current.rowValidationError).toEqual({
+      field: "front",
+      message: "Could not save",
+    });
+  });
+
+  it("onAddOpenChange(false) clears create state", async () => {
+    const { result, resetCreateCard } = setup({
+      createOutcome: { status: "validation", field: "front", message: "dup" },
+    });
+    act(() => result.current.openAddSheet());
+    await act(async () => {
+      await result.current.handleCreate({ front: "f", back: "b" });
+    });
+    expect(result.current.createValidationError).not.toBeNull();
+    resetCreateCard.mockClear();
+    act(() => result.current.onAddOpenChange(false));
+    expect(result.current.addOpen).toBe(false);
+    expect(result.current.addDirty).toBe(false);
+    expect(result.current.createValidationError).toBeNull();
+    expect(resetCreateCard).toHaveBeenCalled();
+  });
+
+  it("onEditOpenChange(false) clears the editing row", () => {
+    const { result } = setup();
+    act(() => result.current.beginEdit("card-1"));
+    act(() => result.current.onEditOpenChange(false));
+    expect(result.current.editingId).toBeNull();
+    expect(result.current.rowValidationError).toBeNull();
+  });
+});

--- a/frontend/src/lib/forms/use-sheet-form.ts
+++ b/frontend/src/lib/forms/use-sheet-form.ts
@@ -1,0 +1,174 @@
+"use client";
+
+import { useCallback, useState } from "react";
+
+/** Field-level validation error surfaced inline under a form control. */
+export type ValidationError = { field: string; message: string };
+
+function isValidationOutcome(outcome: {
+  status: string;
+}): outcome is { status: "validation"; field: string; message: string } {
+  return outcome.status === "validation" && "field" in outcome && "message" in outcome;
+}
+
+/**
+ * Owns one sheet/form's field-level `validationError` and routes a mutation
+ * outcome union. `run(submit)` clears the error, awaits `submit()`, then:
+ * `success` → calls `onSuccess`; `validation` → stores the field error; any
+ * other status → leaves the error cleared and returns the (concrete) outcome so
+ * the caller can handle its own extra variants (`unexpected` / `rejected` /
+ * `auth` / `unauthenticated` / …).
+ */
+export function useSheetForm(onSuccess: () => void) {
+  const [validationError, setValidationError] = useState<ValidationError | null>(null);
+  const clearValidationError = useCallback(() => setValidationError(null), []);
+
+  const run = useCallback(
+    async <T extends { status: string }>(submit: () => Promise<T>): Promise<T> => {
+      setValidationError(null);
+      const outcome = await submit();
+      if (outcome.status === "success") {
+        onSuccess();
+      } else if (isValidationOutcome(outcome)) {
+        setValidationError({ field: outcome.field, message: outcome.message });
+      }
+      return outcome;
+    },
+    [onSuccess],
+  );
+
+  return { validationError, setValidationError, clearValidationError, run };
+}
+
+type CardValues = { front: string; back: string };
+
+type CardOutcome =
+  | { status: "success" }
+  | { status: "validation"; field: string; message: string }
+  | { status: "unexpected" }
+  | { status: "rejected" };
+
+export type UseCardSheetFormInput = {
+  createCard: (values: CardValues) => Promise<CardOutcome>;
+  updateCard: (id: string, values: CardValues) => Promise<CardOutcome>;
+  /** Resets the create mutation's Apollo error/loading state. */
+  resetCreateCard: () => void;
+  /** Already-translated fallback shown when a create fails unexpectedly. */
+  addFailedMessage: string;
+  /** Already-translated fallback shown when an update fails unexpectedly. */
+  saveFailedMessage: string;
+};
+
+/**
+ * The add/edit-card sheet state machine shared, byte-for-byte, by the cardgroup
+ * and master-deck card screens. Owns the add-sheet open/dirty flags, the editing
+ * row id, both field-level validation errors, and the create/update outcome
+ * routing (incl. the close-on-success and `unexpected` → inline-`front`-error
+ * fallbacks). The caller supplies the mutation runners (from
+ * `useCardMutations` / `useMasterCardMutations`) and the localized fallbacks.
+ */
+export function useCardSheetForm({
+  createCard,
+  updateCard,
+  resetCreateCard,
+  addFailedMessage,
+  saveFailedMessage,
+}: UseCardSheetFormInput) {
+  const [addOpen, setAddOpen] = useState(false);
+  const [addDirty, setAddDirty] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+
+  const createForm = useSheetForm(
+    useCallback(() => {
+      setAddDirty(false);
+      setAddOpen(false);
+    }, []),
+  );
+  const updateForm = useSheetForm(useCallback(() => setEditingId(null), []));
+
+  const {
+    clearValidationError: clearCreateError,
+    run: runCreate,
+    setValidationError: setCreateError,
+  } = createForm;
+  const {
+    clearValidationError: clearUpdateError,
+    run: runUpdate,
+    setValidationError: setUpdateError,
+  } = updateForm;
+
+  const openAddSheet = useCallback(() => {
+    resetCreateCard();
+    clearCreateError();
+    setAddDirty(false);
+    setAddOpen(true);
+  }, [resetCreateCard, clearCreateError]);
+
+  const markAddDirty = useCallback(() => setAddDirty(true), []);
+
+  const onAddOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      setAddOpen(nextOpen);
+      if (!nextOpen) {
+        resetCreateCard();
+        setAddDirty(false);
+        clearCreateError();
+      }
+    },
+    [resetCreateCard, clearCreateError],
+  );
+
+  const onEditOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      if (!nextOpen) {
+        clearUpdateError();
+        setEditingId(null);
+      }
+    },
+    [clearUpdateError],
+  );
+
+  const beginEdit = useCallback(
+    (id: string) => {
+      clearUpdateError();
+      setEditingId(id);
+    },
+    [clearUpdateError],
+  );
+
+  const handleCreate = useCallback(
+    async (values: CardValues) => {
+      resetCreateCard();
+      const outcome = await runCreate(() => createCard(values));
+      if (outcome.status === "unexpected") {
+        setCreateError({ field: "front", message: addFailedMessage });
+      }
+    },
+    [resetCreateCard, runCreate, setCreateError, createCard, addFailedMessage],
+  );
+
+  const handleUpdate = useCallback(
+    async (id: string, values: CardValues) => {
+      const outcome = await runUpdate(() => updateCard(id, values));
+      if (outcome.status === "unexpected") {
+        setUpdateError({ field: "front", message: saveFailedMessage });
+      }
+    },
+    [runUpdate, setUpdateError, updateCard, saveFailedMessage],
+  );
+
+  return {
+    addOpen,
+    addDirty,
+    markAddDirty,
+    editingId,
+    createValidationError: createForm.validationError,
+    rowValidationError: updateForm.validationError,
+    openAddSheet,
+    onAddOpenChange,
+    onEditOpenChange,
+    beginEdit,
+    handleCreate,
+    handleUpdate,
+  };
+}


### PR DESCRIPTION
## Summary

Extracts the byte-for-byte-identical add/edit-card sheet state machine — the validation-error state, the dirty flag, the create/update outcome switch, and the close-on-success wiring — out of `cards-client` and `master-cards-client` into a shared `useCardSheetForm` hook (built on a generic `useSheetForm` primitive). Behavior-preserving dedup.

Stacked on #598 (`FormField`). Closes #605.

## Background / Motivation

- `cards-client.tsx` and `master-cards-client.tsx` carried byte-identical `handleCreate` / `handleUpdate` pairs, two `{ field; message } | null` validation-error states, the `addDirty` flag, and the FormSheet open/close-clear wiring. A fix to the outcome routing (e.g. the `unexpected` → inline-`front`-error fallback) had to be hand-propagated to both.
- The outcome-routing switch (`success` → close, `validation` → inline error, `unexpected` → fallback, `rejected` → banner) was re-written verbatim at each consumer.

## Changes

- **Add** `frontend/src/lib/forms/use-sheet-form.ts`:
  - `useSheetForm(onSuccess)` — generic primitive owning one form's `validationError` plus `run(submit)`, which clears the error, awaits the `submit()` thunk (so the clear lands before the mutation fires), routes `success` → `onSuccess` and `validation` → inline error, and returns the concrete outcome so the caller handles its own extra variants.
  - `useCardSheetForm({ createCard, updateCard, resetCreateCard, addFailedMessage, saveFailedMessage })` — composes two `useSheetForm` instances and owns the add-sheet open/dirty flags, the editing-row id, both validation errors, and the create/update handlers (including the `unexpected` → inline-`front` fallback). Returns the state + handlers the screens wire into render.
- **Add** `frontend/src/lib/forms/use-sheet-form.test.ts` — 17 tests covering the primitive's success / validation / passthrough / clear routing and the card hook's full create / update (success / validation / unexpected / rejected) / begin-edit / dirty / close lifecycle.
- **Modify** `cards-client.tsx` / `master-cards-client.tsx` — replace the five local `useState`s + `handleCreate` / `handleUpdate` / `openAddSheet` with `const sheet = useCardSheetForm({…})`; each screen drops ~55 lines. The batch-import sheet state stays local (screen-specific).

Preserved invariants: the `resetCreateCard` ordering, the synchronous validation-error clear before each submit, the close-on-success (`success` → close add-sheet / clear editing id), the `unexpected` → `{ field: "front", message }` localized fallback, and the `rejected` → banner-only behavior.

## Verification (in worktree)

- `tsc --noEmit` — pass. `biome check --error-on-warnings .` — clean. `knip` — clean.
- Full vitest — **1639 tests pass** (175 files; +17 from `use-sheet-form.test.ts`). The pre-existing `cards-client.test.tsx` / `master-cards-client.test.tsx` (49 tests) still pass against the refactored screens.
- No CJK in changed sources; production build runs in CI.

## Coordination

The card-pair conversion overlaps the **CardListScreen** issue (#604, CARDS track): if #604 lands first the two screens merge and `useCardSheetForm` is adopted inside `CardListScreen`; landing this first means `CardListScreen` inherits the hook. Either order leaves `cards-client.tsx` / `master-cards-client.tsx` as the only touch points.

## Test plan

- [ ] Add a card in a cardgroup and in a master deck — confirm the sheet closes on success, and a duplicate front shows the inline error without closing.
- [ ] Edit a card to an invalid value — confirm the inline row error appears and the sheet stays open; fix it and confirm it saves and closes.
- [ ] Force an unexpected / rejected failure — confirm the `front` fallback error / banner appears exactly as before.
