### PR TITLE
refactor(frontend): share core and footer nav items between GlobalRail and LogoDrawer

### DIFF
--- a/frontend/src/components/nav/global-rail.tsx
+++ b/frontend/src/components/nav/global-rail.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { BookOpen, LibraryBig, User } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useTranslations } from "next-intl";
@@ -20,7 +19,13 @@ import {
   useSidebar,
 } from "@/components/ui/sidebar";
 import { HeaderSignInLink } from "./header-sign-in-link";
-import { ADMIN_NAV_ITEMS } from "./nav-items";
+import {
+  ADMIN_NAV_ITEMS,
+  CORE_NAV_ITEMS,
+  FOOTER_NAV_ITEMS,
+  matchesRoute,
+  resolveActiveItem,
+} from "./nav-items";
 
 interface GlobalRailProps {
   /** Required user record. Callers must pass a value or explicit null. */
@@ -31,40 +36,6 @@ interface GlobalRailProps {
 
 /** Hover-out close delay (ms) — avoids flicker when crossing the rail boundary. */
 const HOVER_CLOSE_DELAY_MS = 150;
-
-/**
- * Resolve the active rail item from the current pathname.
- *
- * Only handles the static center items (Cardgroups, Catalog). Admin items and
- * the footer Profile link compute their own active state inline, so this
- * function deliberately does not return `"profile"` or `"admin"`.
- *
- * Uses a positive-allowlist style (per
- * `docs/frontend/typescript-conventions.md` § "Positive allowlist over
- * negative exclusion") so that future top-level routes do not silently match an
- * existing rail item.
- */
-type ActiveItem = "cardgroups" | "catalog" | null;
-
-/** Matches `pathname` against a top-level route — exact match or a sub-route prefix. */
-function matchesRoute(pathname: string, route: string): boolean {
-  return pathname === route || pathname.startsWith(`${route}/`);
-}
-
-function resolveActiveItem(pathname: string): ActiveItem {
-  if (
-    pathname === "/cardgroups" ||
-    pathname.startsWith("/cardgroups/") ||
-    pathname.startsWith("/cards/") ||
-    pathname.startsWith("/learn/")
-  ) {
-    return "cardgroups";
-  }
-  if (matchesRoute(pathname, "/catalog")) {
-    return "catalog";
-  }
-  return null;
-}
 
 export function GlobalRail({ user, isAdmin }: GlobalRailProps) {
   const t = useTranslations("Nav");
@@ -113,10 +84,6 @@ export function GlobalRail({ user, isAdmin }: GlobalRailProps) {
 
   const active = resolveActiveItem(pathname);
 
-  // Footer Profile link active state — computed inline because the footer
-  // Profile link is not part of `resolveActiveItem`'s center-item domain.
-  const profileActive = matchesRoute(pathname, "/profile");
-
   // Admin fallback: light up Users when /admin/<unknown> falls through,
   // so the rail always points at a valid admin destination. Encoded with a
   // literal-string discriminator on `item.href`, not a numeric index — see
@@ -143,30 +110,20 @@ export function GlobalRail({ user, isAdmin }: GlobalRailProps) {
           <SidebarGroup>
             <SidebarGroupContent>
               <SidebarMenu>
-                <SidebarMenuItem>
-                  <SidebarMenuButton
-                    asChild
-                    isActive={active === "cardgroups"}
-                    tooltip={t("cardgroups")}
-                  >
-                    <Link
-                      href="/cardgroups"
-                      aria-current={active === "cardgroups" ? "page" : undefined}
-                    >
-                      <BookOpen aria-hidden="true" />
-                      <span>{t("cardgroups")}</span>
-                    </Link>
-                  </SidebarMenuButton>
-                </SidebarMenuItem>
-
-                <SidebarMenuItem>
-                  <SidebarMenuButton asChild isActive={active === "catalog"} tooltip={t("catalog")}>
-                    <Link href="/catalog" aria-current={active === "catalog" ? "page" : undefined}>
-                      <LibraryBig aria-hidden="true" />
-                      <span>{t("catalog")}</span>
-                    </Link>
-                  </SidebarMenuButton>
-                </SidebarMenuItem>
+                {CORE_NAV_ITEMS.map((item) => {
+                  const isItemActive = active === item.labelKey;
+                  const Icon = item.icon;
+                  return (
+                    <SidebarMenuItem key={item.href}>
+                      <SidebarMenuButton asChild isActive={isItemActive} tooltip={t(item.labelKey)}>
+                        <Link href={item.href} aria-current={isItemActive ? "page" : undefined}>
+                          <Icon aria-hidden="true" />
+                          <span>{t(item.labelKey)}</span>
+                        </Link>
+                      </SidebarMenuButton>
+                    </SidebarMenuItem>
+                  );
+                })}
 
                 {isAdmin &&
                   ADMIN_NAV_ITEMS.map((item) => {
@@ -198,14 +155,25 @@ export function GlobalRail({ user, isAdmin }: GlobalRailProps) {
       {user !== null && (
         <SidebarFooter>
           <SidebarMenu>
-            <SidebarMenuItem>
-              <SidebarMenuButton asChild isActive={profileActive} tooltip={t("profile")}>
-                <Link href="/profile" aria-current={profileActive ? "page" : undefined}>
-                  <User aria-hidden="true" />
-                  <span>{t("profile")}</span>
-                </Link>
-              </SidebarMenuButton>
-            </SidebarMenuItem>
+            {/*
+              Footer item active state is computed inline via `matchesRoute`
+              because these links are not part of `resolveActiveItem`'s
+              center-item domain.
+            */}
+            {FOOTER_NAV_ITEMS.map((item) => {
+              const isItemActive = matchesRoute(pathname, item.href);
+              const Icon = item.icon;
+              return (
+                <SidebarMenuItem key={item.href}>
+                  <SidebarMenuButton asChild isActive={isItemActive} tooltip={t(item.labelKey)}>
+                    <Link href={item.href} aria-current={isItemActive ? "page" : undefined}>
+                      <Icon aria-hidden="true" />
+                      <span>{t(item.labelKey)}</span>
+                    </Link>
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
+              );
+            })}
           </SidebarMenu>
 
           {/*

--- a/frontend/src/components/nav/logo-drawer.tsx
+++ b/frontend/src/components/nav/logo-drawer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { BookOpen, LibraryBig, Plus, Search, User } from "lucide-react";
+import { Plus, Search } from "lucide-react";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
@@ -18,7 +18,7 @@ import { useSheetSearchParam } from "@/lib/url/use-sheet-search-param";
 import { resolveHeaderCreateAction } from "./header-create-action";
 import { resolveHeaderSearchAction } from "./header-search-action";
 import { HeaderSignInLink } from "./header-sign-in-link";
-import { ADMIN_NAV_ITEMS } from "./nav-items";
+import { ADMIN_NAV_ITEMS, CORE_NAV_ITEMS, FOOTER_NAV_ITEMS } from "./nav-items";
 
 interface LogoDrawerProps {
   /** Required user record. Callers must pass a value or explicit null. */
@@ -177,19 +177,17 @@ export function LogoDrawer({ user, isAdmin }: LogoDrawerProps) {
         {user && (
           <>
             <nav className="flex flex-col gap-1">
-              <SheetClose asChild>
-                <Link href="/cardgroups" className={NAV_LINK_CLASS}>
-                  <BookOpen className="h-4 w-4 shrink-0" aria-hidden="true" />
-                  {t("cardgroups")}
-                </Link>
-              </SheetClose>
-
-              <SheetClose asChild>
-                <Link href="/catalog" className={NAV_LINK_CLASS}>
-                  <LibraryBig className="h-4 w-4 shrink-0" aria-hidden="true" />
-                  {t("catalog")}
-                </Link>
-              </SheetClose>
+              {CORE_NAV_ITEMS.map((item) => {
+                const Icon = item.icon;
+                return (
+                  <SheetClose key={item.href} asChild>
+                    <Link href={item.href} className={NAV_LINK_CLASS}>
+                      <Icon className="h-4 w-4 shrink-0" aria-hidden="true" />
+                      {t(item.labelKey)}
+                    </Link>
+                  </SheetClose>
+                );
+              })}
 
               {isAdmin &&
                 ADMIN_NAV_ITEMS.map((item) => {
@@ -208,12 +206,17 @@ export function LogoDrawer({ user, isAdmin }: LogoDrawerProps) {
             <hr className="my-3 border-t" />
 
             <div className="mt-auto flex flex-col gap-2" data-testid="bottom-block">
-              <SheetClose asChild>
-                <Link href="/profile" className={NAV_LINK_CLASS}>
-                  <User className="h-4 w-4 shrink-0" aria-hidden="true" />
-                  {t("profile")}
-                </Link>
-              </SheetClose>
+              {FOOTER_NAV_ITEMS.map((item) => {
+                const Icon = item.icon;
+                return (
+                  <SheetClose key={item.href} asChild>
+                    <Link href={item.href} className={NAV_LINK_CLASS}>
+                      <Icon className="h-4 w-4 shrink-0" aria-hidden="true" />
+                      {t(item.labelKey)}
+                    </Link>
+                  </SheetClose>
+                );
+              })}
 
               <LogoutButton />
             </div>

--- a/frontend/src/components/nav/nav-items.ts
+++ b/frontend/src/components/nav/nav-items.ts
@@ -1,4 +1,4 @@
-import { Library, ShieldCheck, Users } from "lucide-react";
+import { BookOpen, Library, LibraryBig, ShieldCheck, User, Users } from "lucide-react";
 import type { ComponentType } from "react";
 
 export type AdminNavItem = {
@@ -13,3 +13,71 @@ export const ADMIN_NAV_ITEMS: readonly AdminNavItem[] = [
   { href: "/admin/roles", labelKey: "roles", icon: ShieldCheck },
   { href: "/admin/masters", labelKey: "masters", icon: Library },
 ] as const;
+
+export type CoreNavItem = {
+  href: "/cardgroups" | "/catalog";
+  /** Key into the `Nav` message namespace — resolved via `useTranslations("Nav")`. */
+  labelKey: "cardgroups" | "catalog";
+  icon: ComponentType<{ className?: string }>;
+};
+
+/**
+ * Center nav destinations shared by `GlobalRail` and `LogoDrawer`. Each consumer
+ * keeps its own JSX shell (the rail wraps these in `SidebarMenuButton` + tooltip;
+ * the drawer wraps them in `SheetClose` + `NAV_LINK_CLASS`); only the
+ * `{ href, labelKey, icon }` triple is shared, so adding a destination is a
+ * one-file change.
+ */
+export const CORE_NAV_ITEMS: readonly CoreNavItem[] = [
+  { href: "/cardgroups", labelKey: "cardgroups", icon: BookOpen },
+  { href: "/catalog", labelKey: "catalog", icon: LibraryBig },
+] as const;
+
+export type FooterNavItem = {
+  href: "/profile";
+  /** Key into the `Nav` message namespace — resolved via `useTranslations("Nav")`. */
+  labelKey: "profile";
+  icon: ComponentType<{ className?: string }>;
+};
+
+/** Footer nav destinations shared by `GlobalRail` and `LogoDrawer`. */
+export const FOOTER_NAV_ITEMS: readonly FooterNavItem[] = [
+  { href: "/profile", labelKey: "profile", icon: User },
+] as const;
+
+/**
+ * Active center-nav item resolved from the current pathname.
+ *
+ * Only handles the static center items (Cardgroups, Catalog). Admin items and
+ * the footer Profile link compute their own active state inline, so this type
+ * deliberately does not include `"profile"` or `"admin"`.
+ */
+export type ActiveItem = "cardgroups" | "catalog" | null;
+
+/** Matches `pathname` against a top-level route — exact match or a sub-route prefix. */
+export function matchesRoute(pathname: string, route: string): boolean {
+  return pathname === route || pathname.startsWith(`${route}/`);
+}
+
+/**
+ * Resolve the active center-nav item from the current pathname.
+ *
+ * Uses a positive-allowlist style (per
+ * `docs/frontend/typescript-conventions.md` § "Positive allowlist over
+ * negative exclusion") so that future top-level routes do not silently match an
+ * existing nav item.
+ */
+export function resolveActiveItem(pathname: string): ActiveItem {
+  if (
+    pathname === "/cardgroups" ||
+    pathname.startsWith("/cardgroups/") ||
+    pathname.startsWith("/cards/") ||
+    pathname.startsWith("/learn/")
+  ) {
+    return "cardgroups";
+  }
+  if (matchesRoute(pathname, "/catalog")) {
+    return "catalog";
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary

`GlobalRail` and `LogoDrawer` independently hardcoded the same center nav links (Cardgroups `/cardgroups`, Catalog `/catalog`) and footer link (Profile `/profile`). Only the **admin** items were shared (via `ADMIN_NAV_ITEMS`). This lifts the core + footer item **data** into shared arrays so adding a nav destination is a one-file change, finishing the drift-prevention `ADMIN_NAV_ITEMS` started.

Closes #599.

## Background / Motivation

- Adding a nav destination required editing both nav components in lockstep — the exact drift `ADMIN_NAV_ITEMS` exists to prevent, left half-done.
- `resolveActiveItem` / `matchesRoute` lived rail-only inside `global-rail.tsx`, so a future drawer-active feature would have had to fork them.

## Changes

- **`nav-items.ts`** — add `CORE_NAV_ITEMS` (`/cardgroups` → `BookOpen`, `/catalog` → `LibraryBig`) and `FOOTER_NAV_ITEMS` (`/profile` → `User`), each `readonly` and shaped `{ href, labelKey, icon }` mirroring `ADMIN_NAV_ITEMS`. Co-locate and export the `ActiveItem` type, `matchesRoute`, and `resolveActiveItem` (moved out of `global-rail.tsx`).
- **`global-rail.tsx`** — drop the local `ActiveItem` / `matchesRoute` / `resolveActiveItem` declarations and import them; render center items via `CORE_NAV_ITEMS.map(...)` (per-item `aria-current` from `resolveActiveItem`) and the footer via `FOOTER_NAV_ITEMS.map(...)` (`matchesRoute(pathname, item.href)`). The `SidebarMenuButton asChild` + tooltip + `aria-current` JSX shell is unchanged.
- **`logo-drawer.tsx`** — render center + footer via `.map(...)`, each link keeping its `SheetClose asChild` + `NAV_LINK_CLASS` shell and icon sizing.

Only the `{ href, labelKey, icon }` triple is shared — no JSX is flattened into a shared component, and labels stay resolved per-component via `useTranslations("Nav")` + `t(item.labelKey)`. The `Nav` keys `cardgroups` / `catalog` / `profile` already exist in both catalogs.

## Verification (in worktree)

- `tsc --noEmit` — pass. `biome check --error-on-warnings .` — clean (459 files). `knip` — no unused-export findings for the new symbols.
- `vitest run global-rail.test.tsx logo-drawer.test.tsx` — **55 tests pass** unchanged (the rendered output is byte-equivalent, so the link/active-state assertions hold).

## Test plan

- [ ] Rail and drawer both show Cardgroups, Catalog, and Profile links pointing at the same hrefs.
- [ ] Active highlighting (`aria-current="page"`) is correct on `/cardgroups`, `/catalog`, and `/profile`.
- [ ] Admin items still render for admins (unchanged `ADMIN_NAV_ITEMS` path).
