### PR TITLE
refactor(frontend): wire ListingPageShell count prop across all list pages

### DIFF
--- a/frontend/src/app/admin/roles/admin-roles-client.tsx
+++ b/frontend/src/app/admin/roles/admin-roles-client.tsx
@@ -408,6 +408,7 @@ export function AdminRolesClient({ initialRoles }: Props) {
   return (
     <ListingPageShell
       title={tNav("roles")}
+      count={roles.length}
       primaryActions={
         <Button
           type="button"

--- a/frontend/src/app/cardgroups/cardgroups-client.tsx
+++ b/frontend/src/app/cardgroups/cardgroups-client.tsx
@@ -259,6 +259,7 @@ export default function CardgroupsClient({ initialConnection }: CardgroupsClient
   const {
     edges,
     pageInfo,
+    totalCount,
     loading,
     networkStatus,
     fetchingMore,
@@ -353,6 +354,7 @@ export default function CardgroupsClient({ initialConnection }: CardgroupsClient
       />
       <ListingPageShell
         title={t("myCardgroups")}
+        count={totalCount}
         primaryActions={
           <Button
             type="button"

--- a/frontend/src/app/catalog/catalog-client.tsx
+++ b/frontend/src/app/catalog/catalog-client.tsx
@@ -110,6 +110,7 @@ export default function CatalogClient({ initialConnection }: CatalogClientProps)
   const {
     edges,
     pageInfo,
+    totalCount,
     loading,
     networkStatus,
     fetchingMore,
@@ -156,6 +157,7 @@ export default function CatalogClient({ initialConnection }: CatalogClientProps)
       />
       <ListingPageShell
         title={t("title")}
+        count={totalCount}
         toolbar={
           <div className="mb-2 hidden md:block">
             <input


### PR DESCRIPTION
## Summary

`ListingPageShell` renders a `(N)` count badge next to the page title when given `count`, but it was wired inconsistently: `admin/users` and `admin/masters` passed `count={totalCount}` while `cardgroups`, `catalog`, and `admin/roles` passed nothing. This adopts the **"show everywhere"** convention so the badge is consistent across every list page.

Closes #600.

## Background / Motivation

- A user-visible inconsistency when moving between list pages — the exact drift the shared shell exists to prevent.
- Not a data gap: `useConnectionPagination` already returns `totalCount`; the omitting cursor-list screens simply did not destructure it.

## Changes

- **`cardgroups-client.tsx`** — destructure `totalCount` from `useConnectionPagination` and pass `count={totalCount}` to `<ListingPageShell>`.
- **`catalog-client.tsx`** — same: destructure `totalCount`, pass `count={totalCount}`.
- **`admin-roles-client.tsx`** — roles is a flat `RoleItem[]` state array (no connection / hook `totalCount`), so pass `count={roles.length}` — which reflects the rendered list including optimistic removals.

`listing-page-shell.tsx` needed no change — the `count` slot and its JSDoc were already in place.

## Verification (in worktree)

- `tsc --noEmit` — pass. `biome check --error-on-warnings .` — clean (459 files).
- `vitest run cardgroups-client catalog-client admin-roles-client` — **58 tests pass**. No test asserted the absence of the badge, so none needed updating.

## Test plan

- [ ] `/cardgroups`, `/catalog`, and `/admin/roles` each render a `(N)` count badge next to the title.
- [ ] The count tracks the connection total under an active search filter on `/cardgroups` and `/catalog`.
- [ ] `/admin/roles` count updates correctly across create / delete (including optimistic undo).
