### PR TITLE
fix(frontend): route hardcoded form button literals through the message catalog

### DIFF
--- a/frontend/e2e/cardgroups-flow.spec.ts
+++ b/frontend/e2e/cardgroups-flow.spec.ts
@@ -78,7 +78,8 @@ test.describe
       // the translated sheet heading.
       await newCardgroupButton.click();
       await expect(page.locator('input[name="name"]')).toBeVisible();
-      await expect(page.getByRole("button", { name: "Create" })).toBeVisible();
+      // Use data-testid to avoid locale-dependent button text (Playwright runs ja-JP).
+      await expect(page.getByTestId("cardgroup-form-submit")).toBeVisible();
 
       // The URL must NOT have navigated — the in-place drawer is the entire point.
       expect(new URL(page.url()).pathname).toBe("/cardgroups");
@@ -161,7 +162,8 @@ test.describe
       const newCgName = `E2E picker-return ${runId}`;
       // Use name attribute to avoid locale-dependent label text (Playwright runs ja-JP).
       await page.locator('input[name="name"]').fill(newCgName);
-      await page.getByRole("button", { name: "Create" }).click();
+      // Use data-testid to avoid locale-dependent button text (Playwright runs ja-JP).
+      await page.getByTestId("cardgroup-form-submit").click();
 
       // After successful creation the router pushes /cards/new?cardgroup=<newId>.
       await page.waitForURL(/\/cards\/new\?cardgroup=[0-9a-f-]{36}/, { timeout: 15_000 });
@@ -202,7 +204,8 @@ test.describe
 
       const name4a = `E2E redirect-a ${runId}`;
       await page.locator('input[name="name"]').fill(name4a);
-      await page.getByRole("button", { name: "Create" }).click();
+      // Use data-testid to avoid locale-dependent button text (Playwright runs ja-JP).
+      await page.getByTestId("cardgroup-form-submit").click();
 
       // Must land on /cardgroups/<uuid>, never on evil.com or /cards/new.
       await page.waitForURL(/\/cardgroups\/[0-9a-f-]{36}$/, { timeout: 15_000 });
@@ -219,7 +222,8 @@ test.describe
 
       const name4b = `E2E redirect-b ${runId}`;
       await page.locator('input[name="name"]').fill(name4b);
-      await page.getByRole("button", { name: "Create" }).click();
+      // Use data-testid to avoid locale-dependent button text (Playwright runs ja-JP).
+      await page.getByTestId("cardgroup-form-submit").click();
 
       await page.waitForURL(/\/cardgroups\/[0-9a-f-]{36}$/, { timeout: 15_000 });
       const finalUrl4b = page.url();

--- a/frontend/e2e/new-user-onboarding.spec.ts
+++ b/frontend/e2e/new-user-onboarding.spec.ts
@@ -59,7 +59,8 @@ test.describe
       // /edit form so we can capture the new id from the URL.
       // Use name attribute to avoid locale-dependent label text (Playwright runs ja-JP).
       await page.locator('input[name="name"]').fill(cardgroupName);
-      await page.getByRole("button", { name: "Create" }).click();
+      // Use data-testid to avoid locale-dependent button text (Playwright runs ja-JP).
+      await page.getByTestId("cardgroup-form-submit").click();
       await page.waitForURL(/\/cardgroups\/[0-9a-f-]{36}\/edit$/, { timeout: 15_000 });
       const newCardgroupId = page.url().split("/").slice(-2, -1)[0] ?? "";
       expect(newCardgroupId).toMatch(UUID_RE);

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -2,6 +2,7 @@
   "Common": {
     "save": "Save",
     "saving": "Saving...",
+    "create": "Create",
     "cancel": "Cancel",
     "loading": "Loading...",
     "retry": "Retry",
@@ -138,6 +139,7 @@
     "limitReached": "You already have {current} card groups (maximum {limit})."
   },
   "Cards": {
+    "add": "Add",
     "addSomeCards": "Add some new cards to get started.",
     "noMatch": "No cards match \"{search}\"",
     "clearSearch": "Clear search",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -2,6 +2,7 @@
   "Common": {
     "save": "保存",
     "saving": "保存中...",
+    "create": "作成",
     "cancel": "キャンセル",
     "loading": "読み込み中...",
     "retry": "再試行",
@@ -138,6 +139,7 @@
     "limitReached": "すでに{current}個のカードグループがあります（上限{limit}個）。"
   },
   "Cards": {
+    "add": "追加",
     "addSomeCards": "新しいカードを追加して始めましょう。",
     "noMatch": "「{search}」に一致するカードがありません",
     "clearSearch": "検索をクリア",

--- a/frontend/src/app/learn/[cardgroupId]/_components/learn-add-card-sheet.tsx
+++ b/frontend/src/app/learn/[cardgroupId]/_components/learn-add-card-sheet.tsx
@@ -96,7 +96,7 @@ export function LearnAddCardSheet({ cardgroupId }: { cardgroupId: string }) {
     } else if (outcome.status === "validation") {
       setValidationError({ field: outcome.field, message: outcome.message });
     } else if (outcome.status === "unexpected") {
-      setValidationError({ field: "front", message: "Add failed. Please try again." });
+      setValidationError({ field: "front", message: t("addFailed") });
     }
     // outcome.status === "rejected": the hook already logged the rejection;
     // leave the sheet open so the user can retry.

--- a/frontend/src/components/admin/role-form.tsx
+++ b/frontend/src/components/admin/role-form.tsx
@@ -75,7 +75,7 @@ export function RoleForm({
         </Button>
         {onCancel ? (
           <Button type="button" variant="outline" onClick={onCancel}>
-            Cancel
+            {tCommon("cancel")}
           </Button>
         ) : null}
       </div>

--- a/frontend/src/components/cardgroups/card-form.tsx
+++ b/frontend/src/components/cardgroups/card-form.tsx
@@ -46,7 +46,7 @@ export function CardForm({
 }: CardFormProps) {
   const t = useTranslations("Cards");
   const tCommon = useTranslations("Common");
-  const resolvedLabel = submitLabel ?? (mode === "create" ? "Add" : "Save");
+  const resolvedLabel = submitLabel ?? (mode === "create" ? t("add") : tCommon("save"));
   const schema = mode === "create" ? newCardSchema.omit({ cardgroupId: true }) : updateCardSchema;
   const frontSchema = schema.shape.front;
   const backSchema = schema.shape.back;
@@ -99,7 +99,7 @@ export function CardForm({
         </Button>
         {onCancel && (
           <Button type="button" variant="outline" onClick={onCancel}>
-            Cancel
+            {tCommon("cancel")}
           </Button>
         )}
       </div>

--- a/frontend/src/components/cardgroups/cardgroup-form.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-form.tsx
@@ -46,7 +46,7 @@ export function CardgroupForm({
 }: CardgroupFormProps) {
   const t = useTranslations("Cardgroups");
   const tCommon = useTranslations("Common");
-  const resolvedLabel = submitLabel ?? (mode === "create" ? "Create" : "Save");
+  const resolvedLabel = submitLabel ?? (mode === "create" ? tCommon("create") : tCommon("save"));
 
   const schema = mode === "create" ? newCardgroupSchema : updateCardgroupSchema;
   const nameSchema = schema.shape.name;
@@ -80,7 +80,12 @@ export function CardgroupForm({
       </form.Field>
 
       <div className="flex items-center gap-2">
-        <Button type="submit" variant="brand" disabled={submitting}>
+        <Button
+          type="submit"
+          variant="brand"
+          disabled={submitting}
+          data-testid="cardgroup-form-submit"
+        >
           {submitting ? tCommon("saving") : resolvedLabel}
         </Button>
         {secondarySlot}


### PR DESCRIPTION
## Summary

Several form components shipped **hardcoded English UI strings** as fallback defaults or literal JSX text, violating the English-only-via-catalog rule (committed UI strings live only in `frontend/messages/*.json`). Because the `?? "Add"` / `"Cancel"` literals silently ship English when a consumer omits the prop — and the app renders Japanese in the `ja` locale (and e2e runs in `ja-JP`) — these were latent locale bugs, not just policy nits. This routes them through the message catalog.

Closes #601.

## Background / Motivation

- `card-form` / `cardgroup-form` resolved their submit label with English literal fallbacks (`?? (mode === "create" ? "Add"/"Create" : "Save")`), and `card-form` / `role-form` had literal `Cancel` JSX text.
- `learn-add-card-sheet` set an inline English error `"Add failed. Please try again."` while its siblings (`cards-client` / `master-cards-client`) already used `t("addFailed")`.

## Changes

- **`card-form.tsx`** — `"Add"` → `t("add")`, `"Save"` → `tCommon("save")`, `Cancel` JSX → `{tCommon("cancel")}`.
- **`cardgroup-form.tsx`** — `"Create"` → `tCommon("create")`, `"Save"` → `tCommon("save")`; add a locale-independent `data-testid="cardgroup-form-submit"` to the submit button.
- **`role-form.tsx`** — `Cancel` JSX → `{tCommon("cancel")}`.
- **`learn-add-card-sheet.tsx`** — inline `"Add failed. Please try again."` → `t("addFailed")` (reuses the existing `Cards.addFailed` key).
- **`messages/en.json` + `ja.json`** — add the two new keys only (`Common.create` = `Create` / `作成`, `Cards.add` = `Add` / `追加`); `save`, `cancel`, `addFailed` already existed and are reused. Catalogs stay key-parallel (359 keys each).
- **`e2e/cardgroups-flow.spec.ts` (4 sites) + `e2e/new-user-onboarding.spec.ts` (1 site)** — `getByRole("button", { name: "Create" })` → `getByTestId("cardgroup-form-submit")`. Playwright runs in `ja-JP`, so the now-localized button renders `作成`; selecting by `data-testid` keeps the specs locale-independent.

## Verification (in worktree)

- `tsc --noEmit` — pass. `biome check --error-on-warnings .` — clean (459 files). `i18n:parity` — `Parity OK — 359 keys in both catalogs`.
- `vitest run card-form cardgroup-form learn-add-card-sheet` — **30 tests pass** (vitest renders the English catalog, so existing label assertions hold).
- CJK source gate (`perl -CSD`) — clean on every changed source file (the Japanese copy lives only in `messages/ja.json`, which is exempt).

## Test plan

- [ ] In the `ja` locale, the card / cardgroup submit buttons and Cancel buttons render the Japanese copy, not English.
- [ ] An unexpected add failure in the learn add-card sheet shows the localized "add failed" message.
- [ ] e2e `cardgroups-flow` and `new-user-onboarding` pass under `ja-JP` (the create button is found by `data-testid`).
