### PR TITLE
chore(frontend): adopt shared EMPTY_PAGE_INFO + cross-ref Apollo error modules

### DIFF
--- a/frontend/src/app/cardgroups/cardgroups-client.tsx
+++ b/frontend/src/app/cardgroups/cardgroups-client.tsx
@@ -23,6 +23,7 @@ import {
 import { useHeaderTakeoverSearch } from "@/hooks/use-header-takeover-search";
 import { getBackendErrorBanner } from "@/lib/apollo/errors";
 import { FLAMINGO_EVENT } from "@/lib/events/flamingo-events";
+import { EMPTY_PAGE_INFO } from "@/lib/pagination/empty-page-info";
 import { useConnectionPagination } from "@/lib/pagination/use-connection-pagination";
 import { useUndoDelete } from "@/lib/undo-delete";
 import { CARDGROUPS_DEFAULT_VARS, DeleteCardgroupMutation } from "./queries";
@@ -35,14 +36,6 @@ type CardgroupPageInfo = Connection["pageInfo"];
 interface CardgroupsClientProps {
   initialConnection: Connection | null;
 }
-
-const EMPTY_PAGE_INFO: CardgroupPageInfo = {
-  __typename: "PageInfo",
-  hasNextPage: false,
-  hasPreviousPage: false,
-  startCursor: null,
-  endCursor: null,
-};
 
 // Render fallback for useConnectionPagination. The client seeds the cache
 // synchronously before useQuery runs, so this is never read on the happy path;

--- a/frontend/src/lib/apollo/errors.ts
+++ b/frontend/src/lib/apollo/errors.ts
@@ -9,6 +9,11 @@
  *    Network / non-CombinedGraphQLErrors → generic network message.
  *  - classifyQueryError:  Classifies a query-level error into a typed result so
  *    callers can branch on FORBIDDEN / UNAUTHENTICATED without retrying.
+ *
+ * @see ./graphql-errors.ts for the parallel gqlFetch / RSC error classifiers
+ * (the `"GraphQL errors: "`-prefixed-`Error` shape: isUnauthenticatedGraphQLError
+ * etc.) plus liftGraphQLCodes. The two modules are a deliberate, CI-tested split
+ * — do not merge them.
  */
 
 import { CombinedGraphQLErrors } from "@apollo/client/errors";

--- a/frontend/src/lib/apollo/graphql-errors.ts
+++ b/frontend/src/lib/apollo/graphql-errors.ts
@@ -1,3 +1,15 @@
+/**
+ * gqlFetch / RSC error classifiers: parse the `"GraphQL errors: "`-prefixed
+ * `Error` that gqlFetch (server.ts) throws and read extensions.code
+ * (isUnauthenticatedGraphQLError / isForbiddenGraphQLError /
+ * isBadUserInputGraphQLError). liftGraphQLCodes additionally lifts codes from an
+ * Apollo-runtime CombinedGraphQLErrors for warn payloads.
+ *
+ * @see ./errors.ts for the parallel form-facing Apollo Client runtime
+ * (CombinedGraphQLErrors) helpers (getBackendFieldErrors / getBackendErrorBanner
+ * / classifyQueryError). The two modules are a deliberate, CI-tested split — do
+ * not merge them.
+ */
 import { CombinedGraphQLErrors } from "@apollo/client/errors";
 
 /**


### PR DESCRIPTION
## Summary

Two small cohesion stragglers from the frontend review, bundled because each is a few lines and neither needs its own PR. **Pure cleanup — zero behavior change.**

Closes #602.

## Background / Motivation

- **Item 1:** 3 of 4 cursor-list clients already import the shared `EMPTY_PAGE_INFO` (`catalog`, `admin/users`, `admin/masters`); `cardgroups-client.tsx` kept a hand-rolled, value-identical local copy — the exact duplication the shared constant exists to remove.
- **Item 2:** `graphql-errors.ts` and `errors.ts` are a deliberate, CI-tested split (do **not** merge), but a reader landing on one had no pointer to its sibling. The only smell was discoverability.

## Changes

- **`cardgroups-client.tsx`** — delete the local `const EMPTY_PAGE_INFO` and `import { EMPTY_PAGE_INFO } from "@/lib/pagination/empty-page-info"`; `CARDGROUPS_INITIAL.pageInfo` now references the shared constant. The `CardgroupPageInfo` type alias stays (still used by `useConnectionPagination<…, CardgroupPageInfo>`). `tsc` confirms the shared `PageInfo` is structurally assignable to the nominally-distinct `CardgroupPageInfo`.
- **`graphql-errors.ts` / `errors.ts`** — add a module-level `@see` docblock to each pointing at the other (comment-only, no code move). The pointers describe each module's *actual* exports: `graphql-errors.ts` holds the gqlFetch / RSC `"GraphQL errors: "`-prefixed-`Error` classifiers (`isUnauthenticatedGraphQLError` etc.) **plus** `liftGraphQLCodes`; `errors.ts` holds the form-facing Apollo-runtime `CombinedGraphQLErrors` helpers (`getBackendErrorBanner` etc.).

## Verification (in worktree)

- `tsc --noEmit` — pass. `biome check --error-on-warnings .` — clean. `knip` — no findings.
- `vitest run` — **1640 tests pass (176 files)**. `next build` — succeeds.
- Adversarial 2-lens review (value-identity + cross-ref accuracy) — clean, 0 findings.

## Test plan

- [ ] `/cardgroups` renders an empty list identically (cold cache, no SSR seed) — the render-fallback `pageInfo` is unchanged.
- [ ] No behavior change anywhere — this is a const-dedup + comment-only diff.
