### PR TITLE
refactor(frontend): add subscribeFlamingo helper for typed event listeners

### DIFF
--- a/frontend/src/app/cardgroups/cardgroups-client.tsx
+++ b/frontend/src/app/cardgroups/cardgroups-client.tsx
@@ -22,7 +22,7 @@ import {
 } from "@/generated/graphql";
 import { useHeaderTakeoverSearch } from "@/hooks/use-header-takeover-search";
 import { getBackendErrorBanner } from "@/lib/apollo/errors";
-import { FLAMINGO_EVENT } from "@/lib/events/flamingo-events";
+import { FLAMINGO_EVENT, subscribeFlamingo } from "@/lib/events/flamingo-events";
 import { EMPTY_PAGE_INFO } from "@/lib/pagination/empty-page-info";
 import { useConnectionPagination } from "@/lib/pagination/use-connection-pagination";
 import { useUndoDelete } from "@/lib/undo-delete";
@@ -168,14 +168,12 @@ export default function CardgroupsClient({ initialConnection }: CardgroupsClient
   }, []);
 
   useEffect(() => {
-    function handleAddCardgroupEvent(event: Event) {
-      // Cancel any default navigation to /cardgroups/new and open the
-      // drawer in place instead.
+    // Cancel any default navigation to /cardgroups/new and open the drawer in
+    // place instead.
+    return subscribeFlamingo(FLAMINGO_EVENT.addCardgroup, (_detail, event) => {
       event.preventDefault();
       openAddSheet();
-    }
-    window.addEventListener(FLAMINGO_EVENT.addCardgroup, handleAddCardgroupEvent);
-    return () => window.removeEventListener(FLAMINGO_EVENT.addCardgroup, handleAddCardgroupEvent);
+    });
   }, [openAddSheet]);
 
   async function handleCreateCardgroup(values: { name: string }) {

--- a/frontend/src/app/learn/[cardgroupId]/_components/learn-add-card-sheet.tsx
+++ b/frontend/src/app/learn/[cardgroupId]/_components/learn-add-card-sheet.tsx
@@ -6,7 +6,7 @@ import { cardsDefaultVars } from "@/app/cardgroups/[id]/cards/queries";
 import { useCardMutations } from "@/app/cardgroups/[id]/cards/use-card-mutations";
 import { CardForm } from "@/components/cardgroups/card-form";
 import { FormSheet, useFormSheetClose } from "@/components/ui/form-sheet";
-import { type AddCardDetail, FLAMINGO_EVENT } from "@/lib/events/flamingo-events";
+import { FLAMINGO_EVENT, subscribeFlamingo } from "@/lib/events/flamingo-events";
 
 function AddCardSheetContent({
   submit,
@@ -74,15 +74,11 @@ export function LearnAddCardSheet({ cardgroupId }: { cardgroupId: string }) {
   }, [resetCreateCard]);
 
   useEffect(() => {
-    function handleAddCardEvent(event: CustomEvent<AddCardDetail>) {
-      if (event.detail?.cardgroupId !== cardgroupId) return;
-
+    return subscribeFlamingo(FLAMINGO_EVENT.addCard, (detail, event) => {
+      if (detail?.cardgroupId !== cardgroupId) return;
       event.preventDefault();
       openSheet();
-    }
-
-    window.addEventListener(FLAMINGO_EVENT.addCard, handleAddCardEvent);
-    return () => window.removeEventListener(FLAMINGO_EVENT.addCard, handleAddCardEvent);
+    });
   }, [cardgroupId, openSheet]);
 
   async function handleCreate(values: { front: string; back: string }) {

--- a/frontend/src/components/cardgroups/card-list-screen.tsx
+++ b/frontend/src/components/cardgroups/card-list-screen.tsx
@@ -21,6 +21,7 @@ import type {
   CreateCardOutcome,
   UpdateCardOutcome,
 } from "@/lib/cards/card-mutation-outcomes";
+import { type FlamingoEventName, subscribeFlamingo } from "@/lib/events/flamingo-events";
 import { useCardSheetForm } from "@/lib/forms/use-sheet-form";
 
 function EditCardSheetContent({
@@ -163,7 +164,7 @@ export interface CardListScreenProps {
    * Global add-card event wiring. `name` is the FLAMINGO_EVENT key; `matches`
    * stays a per-wrapper closure (it reads the entity-specific `detail` field).
    */
-  addCardEvent: { name: string; matches: (detail: unknown) => boolean };
+  addCardEvent: { name: FlamingoEventName; matches: (detail: unknown) => boolean };
   /** Bulk-delete rejection log shape: scope tag + the owner-id key name. */
   bulkDeleteLog: { scope: string; ownerKey: string };
   /** Optional section header (render-prop receiving live totalCount, or a node). */
@@ -259,14 +260,11 @@ export function CardListScreen({
   const closeBatchImport = useCallback(() => setBatchImportOpen(false), []);
 
   useEffect(() => {
-    function handleAddCardEvent(event: Event) {
-      const detail = (event as CustomEvent).detail;
+    return subscribeFlamingo(addCardEvent.name, (detail, event) => {
       if (!addCardEvent.matches(detail)) return;
       event.preventDefault();
       sheet.openAddSheet();
-    }
-    window.addEventListener(addCardEvent.name, handleAddCardEvent);
-    return () => window.removeEventListener(addCardEvent.name, handleAddCardEvent);
+    });
   }, [addCardEvent, sheet.openAddSheet]);
 
   async function handleBulkDelete() {

--- a/frontend/src/components/nav/logo-drawer.tsx
+++ b/frontend/src/components/nav/logo-drawer.tsx
@@ -9,11 +9,7 @@ import { LogoutButton } from "@/app/_components/logout-button";
 import { FlamingoMark } from "@/components/brand/flamingo-mark";
 import { MobileMenuTrigger } from "@/components/nav/mobile-menu-trigger";
 import { Sheet, SheetClose, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
-import {
-  dispatchFlamingo,
-  FLAMINGO_EVENT,
-  type SearchStateDetail,
-} from "@/lib/events/flamingo-events";
+import { dispatchFlamingo, FLAMINGO_EVENT, subscribeFlamingo } from "@/lib/events/flamingo-events";
 import { useSheetSearchParam } from "@/lib/url/use-sheet-search-param";
 import { resolveHeaderCreateAction } from "./header-create-action";
 import { resolveHeaderSearchAction } from "./header-search-action";
@@ -51,8 +47,7 @@ export function LogoDrawer({ user, isAdmin }: LogoDrawerProps) {
   // active dot and reflect aria-expanded. When the bar closes, return focus to
   // the trigger.
   useEffect(() => {
-    function onSearchState(e: CustomEvent<SearchStateDetail>) {
-      const detail = e.detail;
+    return subscribeFlamingo(FLAMINGO_EVENT.searchState, (detail) => {
       if (!detail) return;
       setSearchActive(detail.active);
       setSearchVisible(detail.visible);
@@ -60,9 +55,7 @@ export function LogoDrawer({ user, isAdmin }: LogoDrawerProps) {
         searchTriggerRef.current?.focus();
       }
       prevVisibleRef.current = detail.visible;
-    }
-    window.addEventListener(FLAMINGO_EVENT.searchState, onSearchState);
-    return () => window.removeEventListener(FLAMINGO_EVENT.searchState, onSearchState);
+    });
   }, []);
 
   // The '+' affordance dispatches a cancelable event so an in-context drawer can

--- a/frontend/src/hooks/use-header-takeover-search.ts
+++ b/frontend/src/hooks/use-header-takeover-search.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
-import { dispatchFlamingo, FLAMINGO_EVENT } from "@/lib/events/flamingo-events";
+import { dispatchFlamingo, FLAMINGO_EVENT, subscribeFlamingo } from "@/lib/events/flamingo-events";
 import { type UseDebouncedSearchResult, useDebouncedSearch } from "./use-debounced-search";
 
 export interface UseHeaderTakeoverSearchResult extends UseDebouncedSearchResult {
@@ -25,11 +25,7 @@ export function useHeaderTakeoverSearch(opts?: {
 
   // Header magnifier -> open the takeover in place.
   useEffect(() => {
-    function handleOpenSearch() {
-      setSearchOpen(true);
-    }
-    window.addEventListener(FLAMINGO_EVENT.openSearch, handleOpenSearch);
-    return () => window.removeEventListener(FLAMINGO_EVENT.openSearch, handleOpenSearch);
+    return subscribeFlamingo(FLAMINGO_EVENT.openSearch, () => setSearchOpen(true));
   }, []);
 
   // Report filter state back to the header trigger (active dot + aria-expanded).

--- a/frontend/src/lib/events/flamingo-events.ts
+++ b/frontend/src/lib/events/flamingo-events.ts
@@ -47,7 +47,7 @@ export const FLAMINGO_EVENT = {
   addMasterCard: "flamingo:add-master-card",
 } as const;
 
-type FlamingoEventName = (typeof FLAMINGO_EVENT)[keyof typeof FLAMINGO_EVENT];
+export type FlamingoEventName = (typeof FLAMINGO_EVENT)[keyof typeof FLAMINGO_EVENT];
 
 type FlamingoDetail<K extends FlamingoEventName> =
   WindowEventMap[K] extends CustomEvent<infer D> ? D : never;
@@ -67,4 +67,26 @@ export function dispatchFlamingo<K extends FlamingoEventName>(
     : [init: { detail: FlamingoDetail<K>; cancelable?: boolean }]
 ): boolean {
   return window.dispatchEvent(new CustomEvent(type, args[0]));
+}
+
+/**
+ * Type-safe `window.addEventListener` companion to {@link dispatchFlamingo}. The
+ * detail type is inferred from the event name via the `WindowEventMap`
+ * augmentation, so no call site needs an explicit `CustomEvent<...>` annotation.
+ * The handler receives the decoded `detail` first and the raw `CustomEvent`
+ * second — listeners that claim a cancelable create-event (add-card /
+ * add-cardgroup / add-master-card) call `event.preventDefault()` on the second
+ * argument so the dispatcher's `{ cancelable: true }` round-trip detects the
+ * claim. Returns the cleanup function — return it directly from a `useEffect`.
+ */
+export function subscribeFlamingo<K extends FlamingoEventName>(
+  type: K,
+  handler: (detail: FlamingoDetail<K>, event: CustomEvent<FlamingoDetail<K>>) => void,
+): () => void {
+  const listener = (event: Event) => {
+    const custom = event as CustomEvent<FlamingoDetail<K>>;
+    handler(custom.detail, custom);
+  };
+  window.addEventListener(type, listener);
+  return () => window.removeEventListener(type, listener);
 }


### PR DESCRIPTION
## Summary

`dispatchFlamingo` is a centralized, type-safe **emitter** for the `flamingo:` event protocol, but the **listen** end had no companion — every listener re-inlined the `useEffect` + `addEventListener` + `removeEventListener` triple, and the handler typings had drifted (redundant explicit `CustomEvent<Detail>` + detail imports in some sites, a loose `(event: Event)` that dropped `.detail` typing in others). This adds a `subscribeFlamingo` companion so the detail type is inferred everywhere and the `Event`-vs-`CustomEvent` divergence is eliminated structurally.

Closes #606.

> **Stacked on #602 — base is `worktree-cohesion-empty-pageinfo-xref`, not `main`.** Both PRs edit `cardgroups-client.tsx` in adjacent import lines (a real merge conflict, confirmed via `git merge-tree`); stacking resolves it once here so neither merge conflicts. GitHub auto-retargets this PR's base to `main` once #602 (#631) merges. **Merge #631 first.**

## Background / Motivation

- The dispatch end is compiler-enforced; the listen end was not. The same concern — subscribe to a typed flamingo event, auto-clean on unmount — was solved 5 times in 3 different ways: redundant explicit `CustomEvent<AddCardDetail>` + detail import (`learn-add-card-sheet`), a loose `(event: Event)` + `(event as CustomEvent).detail` that dropped detail typing (`cardgroups-client`, `card-list-screen`), and the inferred `CustomEvent<SearchStateDetail>` form (`logo-drawer`).
- The `WindowEventMap` augmentation already provides per-name `CustomEvent<Detail>` inference, but nothing consumed it on the listen side.

## Changes

- **`flamingo-events.ts`** — add `subscribeFlamingo<K extends FlamingoEventName>(type, handler: (detail, event) => void): () => void`. The detail type is inferred from `WindowEventMap`; the raw `CustomEvent` is passed as the second arg so cancelable-claim listeners can call `event.preventDefault()`. Returns the cleanup. `FlamingoEventName` is now exported (consumed by `card-list-screen.tsx`).
- **5 listener sites migrated** to `return subscribeFlamingo(...)` from their `useEffect`:
  - `learn-add-card-sheet.tsx` (add-card) — drops the now-redundant `AddCardDetail` import (detail inferred).
  - `cardgroups-client.tsx` (add-cardgroup) — replaces the loose `(event: Event)` handler.
  - `card-list-screen.tsx` (dynamic `addCardEvent.name`) — **prop tightened `name: string` → `name: FlamingoEventName`**; the per-wrapper `matches()` closure is unchanged and the two call sites already pass `FLAMINGO_EVENT.addCard` / `.addMasterCard`.
  - `logo-drawer.tsx` (search-state) — drops the now-redundant `SearchStateDetail` import.
  - `use-header-takeover-search.ts` (open-search).
- The cancelable `preventDefault()` round-trip is preserved — each add-* listener still calls `event.preventDefault()` on the raw event, and the match/guard ordering (`detail.cardgroupId` check / `matches(detail)`) stays ahead of `preventDefault`.

## Verification (in worktree, rebased onto #602)

- `tsc --noEmit` — pass (the generic infers detail at all 5 sites incl. the `FlamingoEventName`-union case in `card-list-screen`). `biome check --error-on-warnings .` — clean. `knip` — no findings.
- `vitest run` — **1640 tests pass (176 files)**, unchanged — existing listener-component tests fire `window.dispatchEvent(new CustomEvent(...))` and the migrated listeners receive them identically. `next build` — succeeds.
- Adversarial 4-lens review (type-inference / cancelable-behavior / completeness-dead-code / silent-failure) — clean, 0 confirmed findings.

## Test plan

- [ ] Header "+" on `/cardgroups` opens the create drawer in place (add-cardgroup claim; no navigation to `/cardgroups/new`).
- [ ] Header "+" on a cards / master-cards screen opens the add-card sheet only for the matching group/master (the `matches` guard gates before `preventDefault`).
- [ ] Header "+" on the Learn screen opens its add-card sheet (matching cardgroupId).
- [ ] Mobile header magnifier opens the takeover bar (open-search); the active dot + `aria-expanded` track filter state (search-state round-trip).
