### PR TITLE
refactor(backend): move new-card FSRS default out of card resolver into application layer

### DIFF
--- a/backend/graph/resolver/card.resolvers.go
+++ b/backend/graph/resolver/card.resolvers.go
@@ -45,9 +45,11 @@ func (r *cardResolver) UserCardState(ctx context.Context, obj *model.Card) (*mod
 	if err != nil {
 		return nil, gqlerr.Internal(ctx, err)
 	}
-	if ucs == nil {
-		ucs = domain.NewUserCardFSRSForNewCard(domain.UserID(user.Sub), obj.ID, obj.CreatedAt)
-	}
+	// The "missing FSRS record means a brand-new card with default state"
+	// decision is an application policy; delegate it to LearnUC instead of
+	// constructing the domain entity here. The DataLoader batch above stays in
+	// the resolver to preserve N+1 batching.
+	ucs = r.LearnUC.DefaultIfNew(ucs, domain.UserID(user.Sub), obj.ID, obj.CreatedAt)
 	return toModelUserCardState(ucs), nil
 }
 

--- a/backend/graph/resolver/card_user_card_state_test.go
+++ b/backend/graph/resolver/card_user_card_state_test.go
@@ -1,0 +1,141 @@
+package resolver
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"backend/graph/model"
+	"backend/internal/auth"
+	"backend/internal/domain"
+	"backend/internal/loader"
+	"backend/internal/usecase"
+)
+
+// spyLearnUsecase records the DefaultIfNew call so the resolver test can assert
+// the resolver delegates the new-card default decision rather than constructing
+// the domain entity itself. NextDueCards / PracticeTodaysCards are not exercised
+// by UserCardState; they panic to surface an unexpected call.
+type spyLearnUsecase struct {
+	gotUCS       *domain.UserCardFSRS
+	gotUserID    domain.UserID
+	gotCardID    string
+	gotCreatedAt time.Time
+	calls        int
+	ret          *domain.UserCardFSRS
+}
+
+func (s *spyLearnUsecase) NextDueCards(context.Context, string, *int) ([]*domain.Card, error) {
+	panic("spyLearnUsecase.NextDueCards must not be called by UserCardState")
+}
+
+func (s *spyLearnUsecase) PracticeTodaysCards(context.Context, string, *int) ([]*domain.Card, error) {
+	panic("spyLearnUsecase.PracticeTodaysCards must not be called by UserCardState")
+}
+
+func (s *spyLearnUsecase) DefaultIfNew(ucs *domain.UserCardFSRS, userID domain.UserID, cardID string, createdAt time.Time) *domain.UserCardFSRS {
+	s.calls++
+	s.gotUCS = ucs
+	s.gotUserID = userID
+	s.gotCardID = cardID
+	s.gotCreatedAt = createdAt
+	return s.ret
+}
+
+var _ usecase.LearnUsecase = (*spyLearnUsecase)(nil)
+
+// emptyUserCardFSRSReader satisfies the loader's narrow userCardFSRSReader by
+// returning an empty map, so the batched Load resolves to nil for every key —
+// the DataLoader's documented "card the user has never seen" contract.
+type emptyUserCardFSRSReader struct{}
+
+func (emptyUserCardFSRSReader) FindByUserAndCardIDs(context.Context, string, []string) (map[string]*domain.UserCardFSRS, error) {
+	return map[string]*domain.UserCardFSRS{}, nil
+}
+
+// TestCardResolver_UserCardState_DelegatesDefaultDecision proves the resolver no
+// longer authors the new-card FSRS default itself: the batched loader yields nil
+// (unseen card), and the resolver hands that nil to LearnUC.DefaultIfNew with the
+// viewer/card/createdAt, returning whatever the usecase decides. The "missing
+// record means default state" policy lives in the application layer.
+func TestCardResolver_UserCardState_DelegatesDefaultDecision(t *testing.T) {
+	t.Parallel()
+
+	createdAt := time.Date(2026, 5, 13, 9, 0, 0, 0, time.UTC)
+	// The sentinel the spy returns; assert it round-trips through the mapper so
+	// the resolver uses the usecase's decision verbatim.
+	decided := domain.NewUserCardFSRSForNewCard(domain.UserID("viewer-1"), "card-1", createdAt)
+	spy := &spyLearnUsecase{ret: decided}
+
+	r := &Resolver{LearnUC: spy}
+	cr := &cardResolver{r}
+
+	loaders := loader.NewWithUserCardFSRS(
+		nil, nil, nil, nil, nil, nil, nil,
+		emptyUserCardFSRSReader{},
+		"viewer-1",
+	)
+	ctx := loader.WithContext(context.Background(), loaders)
+	ctx = auth.ContextWithUser(ctx, &auth.AuthUser{Sub: "viewer-1"})
+
+	obj := &model.Card{ID: "card-1", CreatedAt: createdAt}
+	out, err := cr.UserCardState(ctx, obj)
+	require.NoError(t, err)
+	require.NotNil(t, out)
+
+	// The resolver delegated exactly once, passing the loader's nil and the
+	// viewer/card/createdAt tuple — it did not construct the entity itself.
+	require.Equal(t, 1, spy.calls)
+	require.Nil(t, spy.gotUCS, "loader yields nil for an unseen card; resolver must forward it, not pre-default it")
+	require.Equal(t, domain.UserID("viewer-1"), spy.gotUserID)
+	require.Equal(t, "card-1", spy.gotCardID)
+	require.True(t, spy.gotCreatedAt.Equal(createdAt))
+
+	// The mapped output reflects the usecase's decision, not a resolver-authored value.
+	require.Equal(t, decided.State.Due, out.Due)
+}
+
+// TestCardResolver_UserCardState_PassThroughExistingState verifies the resolver
+// also delegates when the loader returns a non-nil record: the usecase receives
+// the existing state and returns it unchanged.
+func TestCardResolver_UserCardState_PassThroughExistingState(t *testing.T) {
+	t.Parallel()
+
+	createdAt := time.Date(2026, 5, 13, 9, 0, 0, 0, time.UTC)
+	existing := domain.NewUserCardFSRSForNewCard(domain.UserID("viewer-1"), "card-1", createdAt.Add(-time.Hour))
+	spy := &spyLearnUsecase{ret: existing}
+
+	r := &Resolver{LearnUC: spy}
+	cr := &cardResolver{r}
+
+	loaders := loader.NewWithUserCardFSRS(
+		nil, nil, nil, nil, nil, nil, nil,
+		seededUserCardFSRSReader{state: existing},
+		"viewer-1",
+	)
+	ctx := loader.WithContext(context.Background(), loaders)
+	ctx = auth.ContextWithUser(ctx, &auth.AuthUser{Sub: "viewer-1"})
+
+	obj := &model.Card{ID: "card-1", CreatedAt: createdAt}
+	out, err := cr.UserCardState(ctx, obj)
+	require.NoError(t, err)
+	require.NotNil(t, out)
+
+	require.Equal(t, 1, spy.calls)
+	require.Same(t, existing, spy.gotUCS, "loader's non-nil record must be forwarded to the usecase")
+}
+
+// seededUserCardFSRSReader returns a single stored record keyed by card id.
+type seededUserCardFSRSReader struct{ state *domain.UserCardFSRS }
+
+func (s seededUserCardFSRSReader) FindByUserAndCardIDs(_ context.Context, _ string, cardIDs []string) (map[string]*domain.UserCardFSRS, error) {
+	out := map[string]*domain.UserCardFSRS{}
+	for _, id := range cardIDs {
+		if id == s.state.CardID {
+			out[id] = s.state
+		}
+	}
+	return out, nil
+}

--- a/backend/internal/usecase/learn.go
+++ b/backend/internal/usecase/learn.go
@@ -58,6 +58,12 @@ type LearnUsecase interface {
 	// schedule ordering is applied and nothing is written. Returns Unauthenticated
 	// when the caller does not own the cardgroup, BadUserInput when the cardgroup is missing.
 	PracticeTodaysCards(ctx context.Context, cardgroupID string, limit *int) ([]*domain.Card, error)
+	// DefaultIfNew returns ucs unchanged when the user already has a scheduling
+	// record for the card, otherwise the default new-card FSRS state. "A missing
+	// FSRS record means a brand-new card with default state" is an application
+	// policy; this method keeps that decision out of the presentation layer while
+	// the resolver retains the DataLoader batch that produces the nil input.
+	DefaultIfNew(ucs *domain.UserCardFSRS, userID domain.UserID, cardID string, createdAt time.Time) *domain.UserCardFSRS
 }
 
 type learnUsecase struct {
@@ -213,6 +219,18 @@ func (u *learnUsecase) PracticeTodaysCards(ctx context.Context, cardgroupID stri
 		cards = append(cards, row.Card)
 	}
 	return cards, nil
+}
+
+// DefaultIfNew implements the new-card FSRS default policy: a nil scheduling
+// record (the DataLoader's documented contract for a card the user has never
+// seen) is synthesized into the default new-card state; a non-nil record passes
+// through unchanged. The resolver calls this after its batched Load so the
+// "missing record means default state" decision lives in the application layer.
+func (u *learnUsecase) DefaultIfNew(ucs *domain.UserCardFSRS, userID domain.UserID, cardID string, createdAt time.Time) *domain.UserCardFSRS {
+	if ucs != nil {
+		return ucs
+	}
+	return domain.NewUserCardFSRSForNewCard(userID, cardID, createdAt)
 }
 
 func (u *learnUsecase) clampLimit(limit int) int {

--- a/backend/internal/usecase/learn_test.go
+++ b/backend/internal/usecase/learn_test.go
@@ -677,3 +677,36 @@ func TestStartOfDayJST(t *testing.T) {
 		})
 	}
 }
+
+func TestLearnUsecase_DefaultIfNew(t *testing.T) {
+	t.Parallel()
+
+	createdAt := time.Date(2026, 5, 13, 9, 0, 0, 0, time.UTC)
+	uc := NewLearnUsecase(
+		&mockLearnCardRepo{},
+		&mockLearnCardgroupRepo{},
+		service.NewOrderingPolicy(),
+		func() *rand.Rand { return rand.New(rand.NewSource(1)) },
+		20,
+		100,
+		fixedClock{now: createdAt},
+		newTestLogger(),
+	)
+
+	t.Run("nil input yields the default new-card state", func(t *testing.T) {
+		t.Parallel()
+		got := uc.DefaultIfNew(nil, domain.UserID("u-1"), "card-1", createdAt)
+		require.NotNil(t, got)
+		want := domain.NewUserCardFSRSForNewCard(domain.UserID("u-1"), "card-1", createdAt)
+		require.Equal(t, want, got)
+	})
+
+	t.Run("non-nil input passes through unchanged", func(t *testing.T) {
+		t.Parallel()
+		existing := domain.NewUserCardFSRSForNewCard(domain.UserID("u-9"), "card-9", createdAt.Add(-time.Hour))
+		// Pass identity-distinct userID/cardID/createdAt to prove the method does
+		// not reconstruct the record when one already exists.
+		got := uc.DefaultIfNew(existing, domain.UserID("u-1"), "card-1", createdAt)
+		require.Same(t, existing, got)
+	})
+}


### PR DESCRIPTION
## Summary

The `Card.userCardState` resolver synthesized a domain entity (`domain.NewUserCardFSRSForNewCard`) whenever the FSRS DataLoader returned `nil` for a card the viewer has never seen. Deciding that "a missing FSRS record means a brand-new card with default state" is an application-layer policy, not a presentation concern — and the direct `domain` construction was a presentation→domain layer leak. This moves that decision into `LearnUsecase.DefaultIfNew` (Option A) while keeping the DataLoader batch in the resolver so N+1 batching is preserved.

Closes #619.

## Background / Motivation

- `backend/graph/resolver/card.resolvers.go` called `domain.NewUserCardFSRSForNewCard(...)` directly — the clearest layer-purity violation in the backend (transport authoring domain state).
- The loader's `nil`-on-missing contract (`backend/internal/loader/user_card_fsrs.go`) is the correct seam; only the *decision* about what `nil` means belongs in the application layer.
- Replacing the batched `Load` with a per-card repo call would reintroduce N+1, so the batch stays in the resolver and only the post-`Load` default decision is delegated.

## Changes

- **backend/internal/usecase/learn.go** — added `DefaultIfNew(ucs *domain.UserCardFSRS, userID domain.UserID, cardID string, createdAt time.Time) *domain.UserCardFSRS` to the `LearnUsecase` interface and the `*learnUsecase` concrete type. It returns `ucs` unchanged when non-nil, otherwise the default new-card state via `domain.NewUserCardFSRSForNewCard`.
- **backend/graph/resolver/card.resolvers.go** — `UserCardState` now calls `r.LearnUC.DefaultIfNew(ucs, domain.UserID(user.Sub), obj.ID, obj.CreatedAt)` after the batched `Load`, instead of constructing the domain entity itself. The loader batch and its `nil`-on-missing contract are unchanged.
- **backend/internal/usecase/learn_test.go** — added `TestLearnUsecase_DefaultIfNew`: `nil` input yields the default new-card state; a non-nil record passes through by identity (`require.Same`).
- **backend/graph/resolver/card_user_card_state_test.go** — new white-box resolver test proving the resolver delegates: with a spy `LearnUsecase`, the loader yields `nil` for an unseen card and the resolver forwards that `nil` plus the viewer/card/createdAt tuple to `DefaultIfNew` (it does not pre-default or construct the entity), and a seeded non-nil record is forwarded unchanged.

## Verification (in worktree)

- `go build ./...` — pass. `go vet ./...` — pass.
- `go test ./graph/resolver/... ./internal/usecase/... ./internal/loader/...` — all pass; new usecase and resolver tests run and pass. `go tool go-arch-lint check --project-path .` — no warnings (layer purity restored).

## Test plan

- [ ] `Card.userCardState` returns the default new-card state for an unseen card (loader nil → application default).
- [ ] `Card.userCardState` returns the stored state unchanged for a card the viewer has already reviewed.
- [ ] `backend/graph/resolver/card.resolvers.go` no longer calls `domain.NewUserCardFSRSForNewCard`.
- [ ] DataLoader batching (no N+1) is preserved — the resolver still calls the batched `Load`.