### PR TITLE
refactor(backend): add MasterCard aggregate methods (BelongsToMasterCardgroup, UpdateFront/Back)

### DIFF
--- a/backend/internal/domain/master_card.go
+++ b/backend/internal/domain/master_card.go
@@ -23,6 +23,40 @@ type MasterCard struct {
 	UpdatedAt         time.Time
 }
 
+// BelongsToMasterCardgroup mirrors Card.BelongsToCardgroup: it reports whether
+// this master card belongs to the master cardgroup identified by
+// masterCardgroupID. Empty masterCardgroupID always returns false so callers do
+// not need a redundant nil/empty guard.
+func (m *MasterCard) BelongsToMasterCardgroup(masterCardgroupID string) bool {
+	return masterCardgroupID != "" && m.MasterCardgroupID == masterCardgroupID
+}
+
+// UpdateFront updates the master card's front text to the supplied value and
+// returns an error if the value is the zero CardText. The zero-value guard is
+// defense-in-depth: production callers parse the input through ParseCardText
+// before reaching this method, so structural invariants (length, non-empty) are
+// enforced at VO construction time. This method enforces only the aggregate-state
+// invariant that m.Front must never be the zero value. UpdatedAt is intentionally
+// not modified here; persistence is responsible for stamping the modification
+// timestamp.
+func (m *MasterCard) UpdateFront(front CardText) error {
+	if front == "" {
+		return ErrCardFrontRequired
+	}
+	m.Front = front
+	return nil
+}
+
+// UpdateBack mirrors UpdateFront for the back text; see UpdateFront for the
+// defense-in-depth rationale and the UpdatedAt non-stamping note.
+func (m *MasterCard) UpdateBack(back CardText) error {
+	if back == "" {
+		return ErrCardBackRequired
+	}
+	m.Back = back
+	return nil
+}
+
 // NewMasterCard constructs a MasterCard aggregate, mirroring NewCard: Front and
 // Back are validated and trimmed through ParseCardText with the same
 // field-specific sentinels (ErrCardFrontRequired / ErrCardFrontTooLong for

--- a/backend/internal/domain/master_card_test.go
+++ b/backend/internal/domain/master_card_test.go
@@ -66,3 +66,142 @@ func TestNewMasterCard_IDFailure(t *testing.T) {
 	require.Contains(t, err.Error(), "master card: new id")
 	require.Contains(t, err.Error(), "domain: new uuid v7")
 }
+
+func TestMasterCardBelongsToMasterCardgroup(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name              string
+		card              MasterCard
+		masterCardgroupID string
+		want              bool
+	}{
+		{
+			name:              "matching master cardgroup returns true",
+			card:              MasterCard{MasterCardgroupID: "mcg-1"},
+			masterCardgroupID: "mcg-1",
+			want:              true,
+		},
+		{
+			name:              "empty masterCardgroupID returns false",
+			card:              MasterCard{MasterCardgroupID: "mcg-1"},
+			masterCardgroupID: "",
+			want:              false,
+		},
+		{
+			name:              "mismatched masterCardgroupID returns false",
+			card:              MasterCard{MasterCardgroupID: "mcg-1"},
+			masterCardgroupID: "mcg-2",
+			want:              false,
+		},
+		{
+			name:              "both empty returns false",
+			card:              MasterCard{MasterCardgroupID: ""},
+			masterCardgroupID: "",
+			want:              false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, tc.card.BelongsToMasterCardgroup(tc.masterCardgroupID))
+		})
+	}
+}
+
+func TestMasterCardUpdateFront(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		initial   MasterCard
+		newFront  CardText
+		wantErr   error
+		wantFront CardText
+		wantBack  CardText
+	}{
+		{
+			name:      "empty CardText rejected with ErrCardFrontRequired",
+			initial:   MasterCard{ID: "c", MasterCardgroupID: "mcg", Front: "front", Back: "back"},
+			newFront:  "",
+			wantErr:   ErrCardFrontRequired,
+			wantFront: "front", // unchanged on error
+			wantBack:  "back",
+		},
+		{
+			name:      "valid CardText updates Front and returns nil",
+			initial:   MasterCard{ID: "c", MasterCardgroupID: "mcg", Front: "front", Back: "back"},
+			newFront:  "new front",
+			wantErr:   nil,
+			wantFront: "new front",
+			wantBack:  "back",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			card := tc.initial
+			err := card.UpdateFront(tc.newFront)
+
+			if tc.wantErr != nil {
+				require.ErrorIs(t, err, tc.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, tc.wantFront, card.Front)
+			// Back must remain untouched regardless of outcome.
+			require.Equal(t, tc.wantBack, card.Back)
+		})
+	}
+}
+
+func TestMasterCardUpdateBack(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		initial   MasterCard
+		newBack   CardText
+		wantErr   error
+		wantFront CardText
+		wantBack  CardText
+	}{
+		{
+			name:      "empty CardText rejected with ErrCardBackRequired",
+			initial:   MasterCard{ID: "c", MasterCardgroupID: "mcg", Front: "front", Back: "back"},
+			newBack:   "",
+			wantErr:   ErrCardBackRequired,
+			wantFront: "front",
+			wantBack:  "back", // unchanged on error
+		},
+		{
+			name:      "valid CardText updates Back and returns nil",
+			initial:   MasterCard{ID: "c", MasterCardgroupID: "mcg", Front: "front", Back: "back"},
+			newBack:   "new back",
+			wantErr:   nil,
+			wantFront: "front",
+			wantBack:  "new back",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			card := tc.initial
+			err := card.UpdateBack(tc.newBack)
+
+			if tc.wantErr != nil {
+				require.ErrorIs(t, err, tc.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+			// Front must remain untouched regardless of outcome.
+			require.Equal(t, tc.wantFront, card.Front)
+			require.Equal(t, tc.wantBack, card.Back)
+		})
+	}
+}

--- a/backend/internal/usecase/master_card.go
+++ b/backend/internal/usecase/master_card.go
@@ -283,7 +283,18 @@ func (u *masterCardUsecase) UpdateMasterCard(ctx context.Context, id string, in 
 		return UpdateMasterCardOutcome{}, err
 	}
 
+	// Validate and stage each requested field through the aggregate mutation
+	// methods rather than writing the patch DTO inline (mirrors cardUsecase.Update).
+	// The patch-build path is preserved — no FindByID read round-trip: a transient
+	// MasterCard carries the parsed value into UpdateFront/UpdateBack and the
+	// resulting field is copied into the repository patch. UpdateFront/UpdateBack
+	// errors below route through eris.Wrap, not translateCardErr: ParseCardText
+	// (called immediately above each guard) already returns the sentinel for
+	// empty/zero input on the validation channel. If UpdateFront/UpdateBack still
+	// rejects the parsed VO, the invariant has been violated by a programmer error,
+	// not bad user input — INTERNAL is the honest classification.
 	patch := repository.MasterCardUpdate{}
+	staged := &domain.MasterCard{}
 	if in.Front != nil {
 		front, err := domain.ParseCardText(*in.Front, domain.ErrCardFrontRequired, domain.ErrCardFrontTooLong)
 		if err != nil {
@@ -293,7 +304,10 @@ func (u *masterCardUsecase) UpdateMasterCard(ctx context.Context, id string, in 
 			}
 			return UpdateMasterCardOutcome{Validation: info}, nil
 		}
-		s := front.String()
+		if err := staged.UpdateFront(front); err != nil {
+			return UpdateMasterCardOutcome{}, eris.Wrap(err, "usecase: master card: update front")
+		}
+		s := staged.Front.String()
 		patch.Front = &s
 	}
 	if in.Back != nil {
@@ -305,7 +319,10 @@ func (u *masterCardUsecase) UpdateMasterCard(ctx context.Context, id string, in 
 			}
 			return UpdateMasterCardOutcome{Validation: info}, nil
 		}
-		s := back.String()
+		if err := staged.UpdateBack(back); err != nil {
+			return UpdateMasterCardOutcome{}, eris.Wrap(err, "usecase: master card: update back")
+		}
+		s := staged.Back.String()
 		patch.Back = &s
 	}
 
@@ -761,7 +778,7 @@ func (u *masterCardUsecase) resolveMasterCardCursor(
 	// FindByID is group-agnostic — reject a cursor whose card belongs to a
 	// different master cardgroup so the cursor cannot reference rows outside the
 	// requested deck.
-	if card.MasterCardgroupID != masterCardgroupID {
+	if !card.BelongsToMasterCardgroup(masterCardgroupID) {
 		return nil, ucerr.NewValidationError(field, "cursor not found")
 	}
 


### PR DESCRIPTION
## Summary

`MasterCard` was anemic relative to its base counterpart `Card`: two invariants `Card` owns as aggregate behaviour were open-coded in the usecase. This PR mirrors `Card`'s `BelongsToMasterCardgroup`, `UpdateFront`, and `UpdateBack` onto the `MasterCard` aggregate and routes the usecase through them. Behaviour and validation semantics are preserved; no schema, wire shape, or external behaviour changes.

Closes #620.

## Background / Motivation

- The cursor cross-group guard in `resolveMasterCardCursor` was an inline string compare (`card.MasterCardgroupID != masterCardgroupID`) instead of an aggregate membership method.
- `UpdateMasterCard` built the `repository.MasterCardUpdate` patch DTO directly, bypassing the aggregate mutation methods that `Card` already owns.
- This is the HEAD of the serial `master_card.go` chain (#625/#626 build on it), so edits stay scoped and clean.

## Changes

- **backend/internal/domain/master_card.go** — added `BelongsToMasterCardgroup` (empty id returns false), `UpdateFront`, and `UpdateBack`, mirroring `Card` verbatim including the zero-value guards and the defense-in-depth / UpdatedAt-non-stamping docstrings. `MasterCardgroupID` stays a bare `string` (no typed-ID change — only the behaviour seam is added).
- **backend/internal/usecase/master_card.go** — replaced the inline cross-group compare with `!card.BelongsToMasterCardgroup(masterCardgroupID)`; routed `UpdateMasterCard`'s field staging through `UpdateFront`/`UpdateBack` via a transient aggregate (no `FindByID` read round-trip — patch-build path preserved). Post-parse mutation-method errors wrap as INTERNAL via `eris.Wrap`, matching `cardUsecase.Update`.
- **backend/internal/domain/master_card_test.go** — added `TestMasterCardBelongsToMasterCardgroup` (empty→false, match→true, mismatch→false, both-empty→false) and `TestMasterCardUpdateFront` / `TestMasterCardUpdateBack` (zero `CardText`→sentinel + untouched, valid→set), mirroring `card_test.go`.

## Verification (in worktree)

- `go build ./...` — pass. `go vet ./...` — pass.
- `go test ./internal/domain/... ./internal/usecase/...` — all packages green (domain, domain/service, usecase, usecase/ucerr). `go tool go-arch-lint check` — no warnings.

## Test plan

- [ ] `BelongsToMasterCardgroup` returns false for empty id, true for match, false for mismatch.
- [ ] `UpdateFront`/`UpdateBack` reject the zero `CardText` with the field sentinel and leave the aggregate untouched; set the field on a valid value.
- [ ] The master-card cursor cross-group test stays green (now routed through `BelongsToMasterCardgroup`).
- [ ] `UpdateMasterCard` keeps its patch-build path and validation outcomes unchanged.