### PR TITLE
refactor(backend): collapse 4 resolver connection mappers into a generic buildEdges

### DIFF
--- a/backend/graph/resolver/connection.go
+++ b/backend/graph/resolver/connection.go
@@ -6,6 +6,8 @@ import (
 
 	"backend/graph/model"
 	"backend/internal/cursor"
+	"backend/internal/domain"
+	"backend/internal/repository"
 	"backend/internal/usecase"
 )
 
@@ -32,19 +34,44 @@ func buildPageInfo(hasNext, hasPrev bool, start, end *string) *model.PageInfo {
 	}
 }
 
+// buildEdges maps a usecase output slice into Relay edges. For every item it
+// maps the node, skips the item (logging a per-aggregate label) when the node
+// is nil so the non-null edge.node schema contract holds, and otherwise appends
+// an edge whose cursor is cursor.Encode(getID(item)). cursor.Encode is called
+// exactly once per edge inside the loop, preserving the "cursor encoding happens
+// exactly once" invariant in .claude/rules/pagination.md. The four to*ConnectionModel
+// shims below pass their node-mapper, id accessor, and edge constructor; only
+// toUserConnectionModel stays separate because its input carries pre-encoded
+// cursors rather than raw ids.
+func buildEdges[Item any, Node any, Edge any](
+	ctx context.Context,
+	items []Item,
+	label string,
+	toNode func(Item) *Node,
+	getID func(Item) string,
+	mkEdge func(cur string, n *Node) *Edge,
+) []*Edge {
+	edges := make([]*Edge, 0, len(items))
+	for _, item := range items {
+		n := toNode(item)
+		if n == nil {
+			slog.WarnContext(ctx, label+": skipping nil entry")
+			continue
+		}
+		edges = append(edges, mkEdge(cursor.Encode(getID(item)), n))
+	}
+	return edges
+}
+
 func toCardConnectionModel(ctx context.Context, out *usecase.CardConnectionOutput) *model.CardConnection {
 	if out == nil {
 		return &model.CardConnection{Edges: []*model.CardEdge{}, PageInfo: &model.PageInfo{}}
 	}
-	edges := make([]*model.CardEdge, 0, len(out.Cards))
-	for _, c := range out.Cards {
-		cm := toCardModel(c)
-		if cm == nil {
-			slog.WarnContext(ctx, "toCardConnectionModel: skipping nil entry")
-			continue
-		}
-		edges = append(edges, &model.CardEdge{Cursor: cursor.Encode(c.ID), Node: cm})
-	}
+	edges := buildEdges(ctx, out.Cards, "toCardConnectionModel",
+		toCardModel,
+		func(c *domain.Card) string { return c.ID },
+		func(cur string, n *model.Card) *model.CardEdge { return &model.CardEdge{Cursor: cur, Node: n} },
+	)
 	return &model.CardConnection{
 		Edges:      edges,
 		PageInfo:   buildPageInfo(out.HasNext, out.HasPrev, encodeCursor(out.StartCur), encodeCursor(out.EndCur)),
@@ -56,15 +83,13 @@ func toCardgroupConnectionModel(ctx context.Context, out *usecase.CardgroupConne
 	if out == nil {
 		return &model.CardgroupConnection{Edges: []*model.CardgroupEdge{}, PageInfo: &model.PageInfo{}}
 	}
-	edges := make([]*model.CardgroupEdge, 0, len(out.Cardgroups))
-	for _, cg := range out.Cardgroups {
-		cgm := toCardgroupModel(cg)
-		if cgm == nil {
-			slog.WarnContext(ctx, "toCardgroupConnectionModel: skipping nil entry")
-			continue
-		}
-		edges = append(edges, &model.CardgroupEdge{Cursor: cursor.Encode(string(cg.ID)), Node: cgm})
-	}
+	edges := buildEdges(ctx, out.Cardgroups, "toCardgroupConnectionModel",
+		toCardgroupModel,
+		func(cg *domain.Cardgroup) string { return string(cg.ID) },
+		func(cur string, n *model.Cardgroup) *model.CardgroupEdge {
+			return &model.CardgroupEdge{Cursor: cur, Node: n}
+		},
+	)
 	return &model.CardgroupConnection{
 		Edges:      edges,
 		PageInfo:   buildPageInfo(out.HasNext, out.HasPrev, encodeCursor(out.StartCur), encodeCursor(out.EndCur)),
@@ -76,15 +101,13 @@ func toMasterCatalogConnectionModel(ctx context.Context, out *usecase.MasterCata
 	if out == nil {
 		return &model.MasterCatalogConnection{Edges: []*model.MasterCatalogEdge{}, PageInfo: &model.PageInfo{}}
 	}
-	edges := make([]*model.MasterCatalogEdge, 0, len(out.Items))
-	for _, item := range out.Items {
-		mm := toMasterCardgroupModel(item)
-		if mm == nil {
-			slog.WarnContext(ctx, "toMasterCatalogConnectionModel: skipping nil entry")
-			continue
-		}
-		edges = append(edges, &model.MasterCatalogEdge{Cursor: cursor.Encode(item.Cardgroup.ID), Node: mm})
-	}
+	edges := buildEdges(ctx, out.Items, "toMasterCatalogConnectionModel",
+		toMasterCardgroupModel,
+		func(item *repository.MasterCatalogItem) string { return item.Cardgroup.ID },
+		func(cur string, n *model.MasterCardgroup) *model.MasterCatalogEdge {
+			return &model.MasterCatalogEdge{Cursor: cur, Node: n}
+		},
+	)
 	return &model.MasterCatalogConnection{
 		Edges:      edges,
 		PageInfo:   buildPageInfo(out.HasNext, out.HasPrev, encodeCursor(out.StartCur), encodeCursor(out.EndCur)),
@@ -96,15 +119,13 @@ func toMasterCardConnectionModel(ctx context.Context, out *usecase.MasterCardCon
 	if out == nil {
 		return &model.MasterCardConnection{Edges: []*model.MasterCardEdge{}, PageInfo: &model.PageInfo{}}
 	}
-	edges := make([]*model.MasterCardEdge, 0, len(out.Cards))
-	for _, c := range out.Cards {
-		cm := toMasterCardModel(c)
-		if cm == nil {
-			slog.WarnContext(ctx, "toMasterCardConnectionModel: skipping nil entry")
-			continue
-		}
-		edges = append(edges, &model.MasterCardEdge{Cursor: cursor.Encode(c.ID), Node: cm})
-	}
+	edges := buildEdges(ctx, out.Cards, "toMasterCardConnectionModel",
+		toMasterCardModel,
+		func(c *domain.MasterCard) string { return c.ID },
+		func(cur string, n *model.MasterCard) *model.MasterCardEdge {
+			return &model.MasterCardEdge{Cursor: cur, Node: n}
+		},
+	)
 	return &model.MasterCardConnection{
 		Edges:      edges,
 		PageInfo:   buildPageInfo(out.HasNext, out.HasPrev, encodeCursor(out.StartCur), encodeCursor(out.EndCur)),

--- a/backend/graph/resolver/connection_test.go
+++ b/backend/graph/resolver/connection_test.go
@@ -1,0 +1,108 @@
+package resolver
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"backend/internal/cursor"
+)
+
+// buildEdges is the generic edge mapper shared by the four to*ConnectionModel
+// shims. The shims are covered end-to-end in helpers_test.go and
+// master_catalog_mapper_test.go; these cases pin the generic's own contract
+// directly: cursor.Encode is applied exactly once per edge, nil nodes are
+// skipped, the edge constructor receives the encoded cursor and mapped node,
+// and the WarnContext label is the caller-supplied one.
+
+type buildEdgesItem struct {
+	id   string
+	node *buildEdgesNode
+}
+
+type buildEdgesNode struct {
+	id string
+}
+
+type buildEdgesEdge struct {
+	cursor string
+	node   *buildEdgesNode
+}
+
+// TestBuildEdges_EncodesCursorOncePerEdge verifies that buildEdges emits one
+// edge per non-nil node with cursor == cursor.Encode(getID(item)) and the
+// mapped node threaded through the edge constructor.
+func TestBuildEdges_EncodesCursorOncePerEdge(t *testing.T) {
+	t.Parallel()
+
+	items := []buildEdgesItem{
+		{id: "a", node: &buildEdgesNode{id: "a"}},
+		{id: "b", node: &buildEdgesNode{id: "b"}},
+	}
+
+	edges := buildEdges(context.Background(), items, "test",
+		func(it buildEdgesItem) *buildEdgesNode { return it.node },
+		func(it buildEdgesItem) string { return it.id },
+		func(cur string, n *buildEdgesNode) *buildEdgesEdge { return &buildEdgesEdge{cursor: cur, node: n} },
+	)
+
+	require.Len(t, edges, 2)
+	for i, want := range []string{"a", "b"} {
+		assert.Equal(t, cursor.Encode(want), edges[i].cursor,
+			"edges[%d].cursor must be cursor.Encode(getID(item)) exactly once", i)
+		assert.True(t, strings.HasPrefix(edges[i].cursor, "v1:"),
+			"edges[%d].cursor should carry the v1 envelope, got %q", i, edges[i].cursor)
+		require.NotNil(t, edges[i].node)
+		assert.Equal(t, want, edges[i].node.id, "edge node must be the mapped node")
+	}
+}
+
+// TestBuildEdges_SkipsNilNodesWithLabel verifies that buildEdges drops items
+// whose toNode returns nil (preserving the non-null edge.node schema contract)
+// and logs the caller-supplied label for each skip.
+func TestBuildEdges_SkipsNilNodesWithLabel(t *testing.T) {
+	// Not parallel: this test swaps the slog default to capture the warning.
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	items := []buildEdgesItem{
+		{id: "x", node: nil},
+		{id: "y", node: &buildEdgesNode{id: "y"}},
+		{id: "z", node: nil},
+	}
+
+	edges := buildEdges(context.Background(), items, "toExampleConnectionModel",
+		func(it buildEdgesItem) *buildEdgesNode { return it.node },
+		func(it buildEdgesItem) string { return it.id },
+		func(cur string, n *buildEdgesNode) *buildEdgesEdge { return &buildEdgesEdge{cursor: cur, node: n} },
+	)
+
+	require.Len(t, edges, 1, "nil-node items must be skipped")
+	assert.Equal(t, "y", edges[0].node.id)
+
+	logged := buf.String()
+	assert.Equal(t, 2, strings.Count(logged, "toExampleConnectionModel: skipping nil entry"),
+		"expected one warning per skipped nil node carrying the caller label, got: %s", logged)
+}
+
+// TestBuildEdges_EmptyInput verifies that buildEdges returns a non-nil empty
+// slice for empty input, never nil.
+func TestBuildEdges_EmptyInput(t *testing.T) {
+	t.Parallel()
+
+	edges := buildEdges(context.Background(), []buildEdgesItem{}, "test",
+		func(it buildEdgesItem) *buildEdgesNode { return it.node },
+		func(it buildEdgesItem) string { return it.id },
+		func(cur string, n *buildEdgesNode) *buildEdgesEdge { return &buildEdgesEdge{cursor: cur, node: n} },
+	)
+
+	require.NotNil(t, edges, "buildEdges must return a non-nil empty slice")
+	assert.Empty(t, edges)
+}


### PR DESCRIPTION
## Summary

`graph/resolver/connection.go` carried four near-identical `to*ConnectionModel` mappers (card / cardgroup / master_catalog / master_card) that differed only in the node-mapper, the source slice, the cursor-id accessor, and the edge/connection model types. This refactor extracts the shared edge-building loop into a generic `buildEdges` helper and rewrites the four functions as thin shims that pass their node-mapper, id accessor, and edge constructor. `toUserConnectionModel` stays separate — its input carries pre-encoded cursors, not raw ids.

Closes #621.

## Background / Motivation

- The four mappers were byte-for-byte identical modulo four points: `make` edges, loop, per-item nil-skip `slog.WarnContext`, `append(&XxxEdge{Cursor: cursor.Encode(id), Node})`, then `XxxConnection{Edges, buildPageInfo(...), TotalCount}`.
- The duplication is a drift risk: a fix to one (e.g. the nil-skip guard or the encode-once invariant) had to be applied four times by hand.
- This is the highest-ROI mechanical dedup in the round-2 review (`Impact 中 / Change-size 小`).

## Changes

- **`graph/resolver/connection.go`** — add generic `buildEdges[Item, Node, Edge](ctx, items, label, toNode, getID, mkEdge) []*Edge`. It maps each node, skips nil nodes (logging the caller-supplied `label`), and appends an edge whose cursor is `cursor.Encode(getID(item))` — `cursor.Encode` called exactly once per edge inside the loop, preserving the "cursor encoding happens exactly once" invariant in `.claude/rules/pagination.md`. The four `to*ConnectionModel` functions become thin shims that keep their `out == nil` empty-connection guard and their `buildPageInfo(..., encodeCursor(StartCur), encodeCursor(EndCur)) + TotalCount` assembly unchanged. `toUserConnectionModel` is untouched.
- **`graph/resolver/connection_test.go`** (new) — direct unit tests for the generic helper: cursor encoded exactly once per edge with the mapped node threaded through, nil nodes skipped with one warning per skip carrying the caller label, and a non-nil empty slice for empty input.

## Verification (in worktree)

- `go build ./...` — pass. `go vet ./...` — pass.
- `go test ./graph/resolver/...` — pass (`ok backend/graph/resolver`); 3 new `TestBuildEdges_*` cases plus all pre-existing connection-mapper tests green, the shims now exercising `buildEdges`.

## Test plan

- [ ] Edge cursors and `PageInfo` start/end cursors still carry the `v1:` envelope (encode-once preserved).
- [ ] Nil nodes are still skipped so the non-null `edge.node` schema contract holds, with the per-aggregate warning label intact.
- [ ] `out == nil` still returns the aggregate-specific empty connection; `TotalCount` still passes through.
- [ ] `toUserConnectionModel` behavior is unchanged.