### PR TITLE
refactor(backend): generic toUsecaseOrderBy pointer-cast in resolver mapper

### DIFF
--- a/backend/graph/resolver/card.resolvers.go
+++ b/backend/graph/resolver/card.resolvers.go
@@ -174,8 +174,8 @@ func (r *queryResolver) CardsByCardgroupConnection(ctx context.Context, cardgrou
 		After:          after,
 		Before:         before,
 		Search:         search,
-		OrderBy:        toUsecaseCardOrderBy(orderBy),
-		OrderDirection: toUsecaseSortOrder(orderDirection),
+		OrderBy:        toUsecaseOrderBy[model.CardOrderBy, usecase.CardOrderBy](orderBy),
+		OrderDirection: toUsecaseOrderBy[model.SortOrder, usecase.SortOrder](orderDirection),
 	})
 	if err != nil {
 		return nil, gqlerr.FromUsecaseError(ctx, err)

--- a/backend/graph/resolver/cardgroup.resolvers.go
+++ b/backend/graph/resolver/cardgroup.resolvers.go
@@ -105,8 +105,8 @@ func (r *queryResolver) MyCardgroupsConnection(ctx context.Context, first *int, 
 		After:          after,
 		Before:         before,
 		Search:         search,
-		OrderBy:        toUsecaseCardgroupOrderBy(orderBy),
-		OrderDirection: toUsecaseSortOrder(orderDirection),
+		OrderBy:        toUsecaseOrderBy[model.CardgroupOrderBy, usecase.CardgroupOrderBy](orderBy),
+		OrderDirection: toUsecaseOrderBy[model.SortOrder, usecase.SortOrder](orderDirection),
 	})
 	if err != nil {
 		return nil, gqlerr.FromUsecaseError(ctx, err)

--- a/backend/graph/resolver/cardgroup_resolvers_test.go
+++ b/backend/graph/resolver/cardgroup_resolvers_test.go
@@ -227,7 +227,7 @@ func TestResolver_MyCardgroupsConnection_RepoCountError_BecomesInternal(t *testi
 }
 
 // ---------------------------------------------------------------------------
-// helpers.go — toCardgroupConnectionModel / toUsecaseCardgroupOrderBy
+// helpers.go — toCardgroupConnectionModel / toUsecaseOrderBy
 // ---------------------------------------------------------------------------
 //
 // These helpers live in package resolver but are package-private. The tests
@@ -235,9 +235,9 @@ func TestResolver_MyCardgroupsConnection_RepoCountError_BecomesInternal(t *testi
 //
 // - toCardgroupConnectionModel non-empty path: covered by
 //   TestResolver_MyCardgroupsConnection_Authenticated_DelegatesToUsecase.
-// - toUsecaseCardgroupOrderBy with explicit value: covered by
+// - toUsecaseOrderBy with an explicit CardgroupOrderBy value: covered by
 //   TestResolver_MyCardgroupsConnection_OrderByName_PassesThrough below.
-// - toUsecaseCardgroupOrderBy with nil (default UPDATED_AT) and the empty
+// - toUsecaseOrderBy with nil (default UPDATED_AT) and the empty
 //   connection branch: exercised by the empty-result test below.
 
 // TestResolver_MyCardgroupsConnection_Empty_ReturnsEmptyEdges verifies that an
@@ -280,7 +280,7 @@ func TestResolver_MyCardgroupsConnection_Empty_ReturnsEmptyEdges(t *testing.T) {
 }
 
 // TestResolver_MyCardgroupsConnection_OrderByName_PassesThrough verifies that
-// the schema-level orderBy=NAME enum is translated by toUsecaseCardgroupOrderBy
+// the schema-level orderBy=NAME enum is translated by toUsecaseOrderBy
 // and reaches the repository as the corresponding usecase enum. The mock
 // captures the orderBy passed to FindPageByOwner.
 func TestResolver_MyCardgroupsConnection_OrderByName_PassesThrough(t *testing.T) {

--- a/backend/graph/resolver/mapper.go
+++ b/backend/graph/resolver/mapper.go
@@ -221,43 +221,17 @@ func toRoleModels(ctx context.Context, roles []*domain.Role) []*model.Role {
 	return out
 }
 
-func toUsecaseCardOrderBy(o *model.CardOrderBy) *usecase.CardOrderBy {
+// toUsecaseOrderBy casts a pointer to a model-layer order-by / sort enum into
+// the matching usecase-layer enum, preserving the nil-passes-through contract
+// (an absent argument keeps the usecase default). Both enums share a `~string`
+// underlying type, so the cast is a direct value conversion. Callers supply the
+// type arguments explicitly, e.g.
+// toUsecaseOrderBy[model.CardOrderBy, usecase.CardOrderBy](args.OrderBy).
+func toUsecaseOrderBy[M ~string, U ~string](o *M) *U {
 	if o == nil {
 		return nil
 	}
-	v := usecase.CardOrderBy(*o)
-	return &v
-}
-
-func toUsecaseCardgroupOrderBy(o *model.CardgroupOrderBy) *usecase.CardgroupOrderBy {
-	if o == nil {
-		return nil
-	}
-	v := usecase.CardgroupOrderBy(*o)
-	return &v
-}
-
-func toUsecaseMasterCatalogOrderBy(o *model.MasterCatalogOrderBy) *usecase.MasterCatalogOrderBy {
-	if o == nil {
-		return nil
-	}
-	v := usecase.MasterCatalogOrderBy(*o)
-	return &v
-}
-
-func toUsecaseMasterCardOrderBy(o *model.MasterCardOrderBy) *usecase.MasterCardOrderBy {
-	if o == nil {
-		return nil
-	}
-	v := usecase.MasterCardOrderBy(*o)
-	return &v
-}
-
-func toUsecaseSortOrder(d *model.SortOrder) *usecase.SortOrder {
-	if d == nil {
-		return nil
-	}
-	v := usecase.SortOrder(*d)
+	v := U(*o)
 	return &v
 }
 

--- a/backend/graph/resolver/master_card.resolvers.go
+++ b/backend/graph/resolver/master_card.resolvers.go
@@ -120,8 +120,8 @@ func (r *queryResolver) AdminMasterCardsConnection(ctx context.Context, masterCa
 		After:             after,
 		Before:            before,
 		Search:            search,
-		OrderBy:           toUsecaseMasterCardOrderBy(orderBy),
-		OrderDirection:    toUsecaseSortOrder(orderDirection),
+		OrderBy:           toUsecaseOrderBy[model.MasterCardOrderBy, usecase.MasterCardOrderBy](orderBy),
+		OrderDirection:    toUsecaseOrderBy[model.SortOrder, usecase.SortOrder](orderDirection),
 	})
 	if err != nil {
 		return nil, gqlerr.FromUsecaseError(ctx, err)
@@ -138,8 +138,8 @@ func (r *queryResolver) MasterCardsConnection(ctx context.Context, masterCardgro
 		After:             after,
 		Before:            before,
 		Search:            search,
-		OrderBy:           toUsecaseMasterCardOrderBy(orderBy),
-		OrderDirection:    toUsecaseSortOrder(orderDirection),
+		OrderBy:           toUsecaseOrderBy[model.MasterCardOrderBy, usecase.MasterCardOrderBy](orderBy),
+		OrderDirection:    toUsecaseOrderBy[model.SortOrder, usecase.SortOrder](orderDirection),
 	})
 	if err != nil {
 		return nil, gqlerr.FromUsecaseError(ctx, err)

--- a/backend/graph/resolver/master_catalog.resolvers.go
+++ b/backend/graph/resolver/master_catalog.resolvers.go
@@ -162,8 +162,8 @@ func (r *queryResolver) MasterCatalog(ctx context.Context, first *int, after *st
 		After:          after,
 		Before:         before,
 		Search:         search,
-		OrderBy:        toUsecaseMasterCatalogOrderBy(orderBy),
-		OrderDirection: toUsecaseSortOrder(orderDirection),
+		OrderBy:        toUsecaseOrderBy[model.MasterCatalogOrderBy, usecase.MasterCatalogOrderBy](orderBy),
+		OrderDirection: toUsecaseOrderBy[model.SortOrder, usecase.SortOrder](orderDirection),
 	})
 	if err != nil {
 		return nil, gqlerr.FromUsecaseError(ctx, err)
@@ -179,8 +179,8 @@ func (r *queryResolver) AdminMasters(ctx context.Context, first *int, after *str
 		After:          after,
 		Before:         before,
 		Search:         search,
-		OrderBy:        toUsecaseMasterCatalogOrderBy(orderBy),
-		OrderDirection: toUsecaseSortOrder(orderDirection),
+		OrderBy:        toUsecaseOrderBy[model.MasterCatalogOrderBy, usecase.MasterCatalogOrderBy](orderBy),
+		OrderDirection: toUsecaseOrderBy[model.SortOrder, usecase.SortOrder](orderDirection),
 	})
 	if err != nil {
 		return nil, gqlerr.FromUsecaseError(ctx, err)

--- a/backend/graph/resolver/master_catalog_mapper_test.go
+++ b/backend/graph/resolver/master_catalog_mapper_test.go
@@ -163,10 +163,10 @@ func TestToMasterCatalogConnectionModel_SkipsNilNode(t *testing.T) {
 func TestToUsecaseMasterCatalogOrderBy(t *testing.T) {
 	t.Parallel()
 
-	assert.Nil(t, toUsecaseMasterCatalogOrderBy(nil))
+	assert.Nil(t, toUsecaseOrderBy[model.MasterCatalogOrderBy, usecase.MasterCatalogOrderBy](nil))
 
 	in := model.MasterCatalogOrderByName
-	got := toUsecaseMasterCatalogOrderBy(&in)
+	got := toUsecaseOrderBy[model.MasterCatalogOrderBy, usecase.MasterCatalogOrderBy](&in)
 	require.NotNil(t, got)
 	assert.Equal(t, usecase.MasterCatalogOrderByName, *got)
 }


### PR DESCRIPTION
## Summary

Collapse five structurally identical order-by / sort enum pointer-cast wrappers in `graph/resolver/mapper.go` into one generic helper `toUsecaseOrderBy[M ~string, U ~string](o *M) *U`. All ten call sites across the hand-written query resolvers now invoke the explicit-typed generic form, and the five wrappers are deleted. Behavior is unchanged — each cast was always a direct `~string` value conversion with a nil-passes-through contract.

Closes #622.

## Background / Motivation

- `toUsecaseCardOrderBy`, `toUsecaseCardgroupOrderBy`, `toUsecaseMasterCatalogOrderBy`, `toUsecaseMasterCardOrderBy`, and `toUsecaseSortOrder` were byte-for-byte identical except for their model/usecase enum types — pure mechanical boilerplate over `~string` underlying types.
- The three-enum-layer "duplication is intentional" rule protects the enum *values*, not these converter *functions*; consolidating the converters does not conflate the layers.

## Changes

- **backend/graph/resolver/mapper.go** — replaced the five `toUsecase*OrderBy` / `toUsecaseSortOrder` wrappers with one generic `toUsecaseOrderBy[M ~string, U ~string]`.
- **backend/graph/resolver/card.resolvers.go** — `OrderBy` / `OrderDirection` now use the explicit-typed generic form (`[model.CardOrderBy, usecase.CardOrderBy]`, `[model.SortOrder, usecase.SortOrder]`).
- **backend/graph/resolver/cardgroup.resolvers.go** — same conversion for `CardgroupOrderBy` + `SortOrder`.
- **backend/graph/resolver/master_card.resolvers.go** — same for both `MasterCardOrderBy` call sites + `SortOrder`.
- **backend/graph/resolver/master_catalog.resolvers.go** — same for both `MasterCatalogOrderBy` call sites + `SortOrder`.
- **backend/graph/resolver/master_catalog_mapper_test.go** — `TestToUsecaseMasterCatalogOrderBy` nil/non-nil cases now call the generic helper directly.
- **backend/graph/resolver/cardgroup_resolvers_test.go** — refreshed comment references from the deleted `toUsecaseCardgroupOrderBy` to `toUsecaseOrderBy`.

## Verification (in worktree)

- `go build ./...` — pass. `go vet ./...` — pass.
- `go test ./graph/resolver/...` — `ok backend/graph/resolver` (exit 0); the mapper nil/non-nil enum cases stay green.

## Test plan

- [ ] `go build ./... && go vet ./...` pass.
- [ ] `go test ./graph/resolver/...` passes, including `TestToUsecaseMasterCatalogOrderBy` and `TestResolver_MyCardgroupsConnection_OrderByName_PassesThrough`.
- [ ] gqlgen regen diff is clean (mapper.go and the touched `*.resolvers.go` files are hand-written, not generated).