### PR TITLE
refactor(backend): consolidate repository cursor-pagination helpers into pagination.go

### DIFF
--- a/backend/internal/repository/card_pagination.go
+++ b/backend/internal/repository/card_pagination.go
@@ -96,16 +96,7 @@ func (r *cardRepo) FindPageByCardgroupForUser(
 
 	// Backward paging executes the query with the inverted direction and
 	// reverses the slice afterwards.
-	effectiveDir := dir
-	limit := first
-	cursor := after
-	reverse := false
-	if last > 0 {
-		effectiveDir = InvertDir(dir)
-		limit = last
-		cursor = before
-		reverse = true
-	}
+	effectiveDir, limit, cursor, reverse := paginateSetup(dir, first, last, after, before)
 
 	q := base
 	if orderBy == CardOrderByDue {
@@ -174,9 +165,8 @@ func cursorWhere(orderBy CardOrderBy, dir SortOrder, c *CardCursor) (string, []a
 	if err != nil {
 		return "", nil, err
 	}
-	// Tuple compare: (field, id) op (val, c.ID).
-	return "(" + field + " " + op + " ? OR (" + field + " = ? AND cards.id " + op + " ?))",
-		[]any{val, val, c.ID}, nil
+	clause, args := cursorTupleWhere("cards", field, op, val, c.ID)
+	return clause, args, nil
 }
 
 // cursorFieldValue returns the cursor value for the active orderBy field.

--- a/backend/internal/repository/cardgroup.go
+++ b/backend/internal/repository/cardgroup.go
@@ -3,7 +3,6 @@ package repository
 import (
 	"context"
 	"errors"
-	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -147,19 +146,10 @@ func (r *cardgroupRepo) FindPageByOwner(
 
 	// Backward paging executes the query with the inverted direction and
 	// reverses the slice afterwards.
-	effectiveDir := dir
-	limit := first
-	cursor := after
-	reverse := false
-	if last > 0 {
-		effectiveDir = InvertDir(dir)
-		limit = last
-		cursor = before
-		reverse = true
-	}
+	effectiveDir, limit, cursor, reverse := paginateSetup(dir, first, last, after, before)
 
 	q := r.db.WithContext(ctx).Model(&gormCardgroup{}).Where("owner_id = ?", ownerID)
-	if pattern, ok := cardgroupSearchPattern(search); ok {
+	if pattern, ok := searchLikePattern(search); ok {
 		q = q.Where("name ILIKE ?", pattern)
 	}
 	if cursor != nil {
@@ -192,7 +182,7 @@ func (r *cardgroupRepo) FindPageByOwner(
 // a tenant cannot observe other tenants' aggregate sizes.
 func (r *cardgroupRepo) CountByOwner(ctx context.Context, ownerID string, search *string) (int64, error) {
 	q := r.db.WithContext(ctx).Model(&gormCardgroup{}).Where("owner_id = ?", ownerID)
-	if pattern, ok := cardgroupSearchPattern(search); ok {
+	if pattern, ok := searchLikePattern(search); ok {
 		q = q.Where("name ILIKE ?", pattern)
 	}
 	var total int64
@@ -200,20 +190,6 @@ func (r *cardgroupRepo) CountByOwner(ctx context.Context, ownerID string, search
 		return 0, eris.Wrap(err, "repository: count cardgroups by owner")
 	}
 	return total, nil
-}
-
-// cardgroupSearchPattern wraps a non-empty trimmed search term in `%...%`
-// after escaping LIKE metacharacters. Returns (pattern, false) when the
-// search is nil or trims empty so callers can skip the predicate.
-func cardgroupSearchPattern(search *string) (string, bool) {
-	if search == nil {
-		return "", false
-	}
-	trimmed := strings.TrimSpace(*search)
-	if trimmed == "" {
-		return "", false
-	}
-	return "%" + escapeLikePattern(trimmed) + "%", true
 }
 
 // cardgroupOrderClause renders the SQL ORDER BY tail. When orderBy is `id`
@@ -243,10 +219,8 @@ func cardgroupCursorWhere(orderBy CardgroupOrderBy, dir SortOrder, c *CardgroupC
 	if err != nil {
 		return "", nil, err
 	}
-	// Tuple compare: (field, id) op (val, c.ID). Expanded form is portable
-	// across SQL dialects (Postgres-only `(a, b) > (?, ?)` avoided).
-	return "(" + field + " " + op + " ? OR (" + field + " = ? AND id " + op + " ?))",
-		[]any{val, val, c.ID}, nil
+	clause, args := cursorTupleWhere("", field, op, val, c.ID)
+	return clause, args, nil
 }
 
 // cardgroupCursorFieldValue returns the cursor value for the active

--- a/backend/internal/repository/cardgroup_test.go
+++ b/backend/internal/repository/cardgroup_test.go
@@ -949,7 +949,7 @@ func TestCardgroupRepo_CountByOwner_NoSearch(t *testing.T) {
 
 // TestCardgroupRepo_CountByOwner_EmptySearchTreatedAsNil verifies that an
 // all-whitespace search has no effect on the count — same as nil — because
-// cardgroupSearchPattern returns ok=false for trimmed-empty input.
+// searchLikePattern returns ok=false for trimmed-empty input.
 func TestCardgroupRepo_CountByOwner_EmptySearchTreatedAsNil(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/backend/internal/repository/master_card.go
+++ b/backend/internal/repository/master_card.go
@@ -205,16 +205,7 @@ func (r *masterCardRepo) FindPageByMasterCardgroup(
 
 	// Backward paging executes with the inverted direction and reverses the
 	// returned slice so the page boundary stays at the tail.
-	effectiveDir := dir
-	limit := first
-	cur := after
-	reverse := false
-	if last > 0 {
-		effectiveDir = InvertDir(dir)
-		limit = last
-		cur = before
-		reverse = true
-	}
+	effectiveDir, limit, cur, reverse := paginateSetup(dir, first, last, after, before)
 
 	q := base.Order(masterCardOrderClause(orderBy, effectiveDir))
 
@@ -270,9 +261,8 @@ func masterCardCursorWhere(orderBy MasterCardOrderBy, dir SortOrder, c *MasterCa
 	if err != nil {
 		return "", nil, err
 	}
-	// Tuple compare: (field, id) op (val, c.ID).
-	return "(" + field + " " + op + " ? OR (" + field + " = ? AND master_cards.id " + op + " ?))",
-		[]any{val, val, c.ID}, nil
+	clause, args := cursorTupleWhere("master_cards", field, op, val, c.ID)
+	return clause, args, nil
 }
 
 // masterCardCursorFieldValue returns the cursor value for the active orderBy

--- a/backend/internal/repository/master_catalog_read.go
+++ b/backend/internal/repository/master_catalog_read.go
@@ -2,7 +2,6 @@ package repository
 
 import (
 	"context"
-	"strings"
 	"time"
 
 	"github.com/rotisserie/eris"
@@ -63,7 +62,7 @@ func (r gormMasterCatalogRow) toGorm() gormMasterCardgroup {
 func (r *masterCardgroupRepo) CountPublished(ctx context.Context, search *string) (int64, error) {
 	q := r.db.WithContext(ctx).Model(&gormMasterCardgroup{}).
 		Where("status = ?", string(domain.MasterStatusPublished))
-	if pattern, ok := masterCatalogSearchPattern(search); ok {
+	if pattern, ok := searchLikePattern(search); ok {
 		q = q.Where("name ILIKE ?", pattern)
 	}
 	var total int64
@@ -77,7 +76,7 @@ func (r *masterCardgroupRepo) CountPublished(ctx context.Context, search *string
 // (draft or published) matching the optional search predicate.
 func (r *masterCardgroupRepo) CountAdmin(ctx context.Context, search *string) (int64, error) {
 	q := r.db.WithContext(ctx).Model(&gormMasterCardgroup{})
-	if pattern, ok := masterCatalogSearchPattern(search); ok {
+	if pattern, ok := searchLikePattern(search); ok {
 		q = q.Where("name ILIKE ?", pattern)
 	}
 	var total int64
@@ -98,20 +97,6 @@ func (r *masterCardgroupRepo) CountCards(ctx context.Context, masterCardgroupID 
 		return 0, eris.Wrap(err, "repository: master cardgroup: count cards")
 	}
 	return total, nil
-}
-
-// masterCatalogSearchPattern wraps a non-empty trimmed search term in `%...%`
-// after escaping LIKE metacharacters. Returns (pattern, false) when the search
-// is nil or trims empty so callers can skip the predicate.
-func masterCatalogSearchPattern(search *string) (string, bool) {
-	if search == nil {
-		return "", false
-	}
-	trimmed := strings.TrimSpace(*search)
-	if trimmed == "" {
-		return "", false
-	}
-	return "%" + escapeLikePattern(trimmed) + "%", true
 }
 
 // masterCatalogOrderClause renders the SQL ORDER BY tail with a secondary
@@ -138,10 +123,8 @@ func masterCatalogCursorWhere(orderBy MasterCatalogOrderBy, dir SortOrder, c *Ma
 	if err != nil {
 		return "", nil, err
 	}
-	// Tuple compare: (field, id) op (val, c.ID). Expanded form is portable
-	// across SQL dialects (Postgres-only `(a, b) > (?, ?)` avoided).
-	return "(" + field + " " + op + " ? OR (" + field + " = ? AND mcg.id " + op + " ?))",
-		[]any{val, val, c.ID}, nil
+	clause, args := cursorTupleWhere("mcg", field, op, val, c.ID)
+	return clause, args, nil
 }
 
 // masterCatalogCursorFieldValue returns the cursor value for the active orderBy
@@ -187,16 +170,7 @@ func (r *masterCardgroupRepo) findCatalogPage(
 
 	// Backward paging executes the query with the inverted direction and
 	// reverses the slice afterwards.
-	effectiveDir := dir
-	limit := first
-	cursor := after
-	reverse := false
-	if last > 0 {
-		effectiveDir = InvertDir(dir)
-		limit = last
-		cursor = before
-		reverse = true
-	}
+	effectiveDir, limit, cursor, reverse := paginateSetup(dir, first, last, after, before)
 
 	q := r.db.WithContext(ctx).
 		Table("master_cardgroups AS mcg").
@@ -204,7 +178,7 @@ func (r *masterCardgroupRepo) findCatalogPage(
 	if publishedOnly {
 		q = q.Where("mcg.status = ?", string(domain.MasterStatusPublished))
 	}
-	if pattern, ok := masterCatalogSearchPattern(search); ok {
+	if pattern, ok := searchLikePattern(search); ok {
 		q = q.Where("mcg.name ILIKE ?", pattern)
 	}
 	if cursor != nil {

--- a/backend/internal/repository/pagination.go
+++ b/backend/internal/repository/pagination.go
@@ -1,5 +1,7 @@
 package repository
 
+import "strings"
+
 // PageCap is the repository-level limit that lets the +1 fetch trick survive a
 // request at the documented maximum page size. See
 // .claude/rules/pagination.md § "Page-size cap asymmetry".
@@ -34,4 +36,54 @@ func ReverseSlice[T any](xs []T) []T {
 		xs[i], xs[j] = xs[j], xs[i]
 	}
 	return xs
+}
+
+// paginateSetup computes the backward-paging direction-flip preamble shared by
+// every cursor-paginated repository (card / master_card / cardgroup /
+// master_catalog). Forward paging (last == 0) returns the requested direction,
+// `first` as the limit, the `after` cursor, and reverse == false. Backward
+// paging (last > 0) inverts the ORDER BY direction, uses `last` as the limit,
+// the `before` cursor, and reverse == true so the caller reverses the fetched
+// slice in memory to restore the natural order. Generic over the per-aggregate
+// cursor type C because the cursor value types differ (int position vs
+// *time.Time). See .claude/rules/pagination.md § "Backward pagination via
+// direction-flip + reverse".
+func paginateSetup[C any](dir SortOrder, first, last int, after, before *C) (effectiveDir SortOrder, limit int, cursor *C, reverse bool) {
+	if last > 0 {
+		return InvertDir(dir), last, before, true
+	}
+	return dir, first, after, false
+}
+
+// cursorTupleWhere builds the portable tuple-comparison WHERE clause shared by
+// every cursor-paginated repository. The expanded form
+// `field op ? OR (field = ? AND <alias>.id op ?)` is dialect-portable (the
+// Postgres-only row-constructor `(a, b) > (?, ?)` is avoided). `field` is the
+// already-qualified primary sort expression (e.g. `cards.created_at`,
+// `COALESCE(ucs.due, cards.created_at)`, `mcg.sort_order`), `alias` is the table
+// alias prefix for the id tie-break column (`cards`, `master_cards`, `mcg`, or
+// `""` for an unaliased `id`), and `op` is `>` for ASC or `<` for DESC.
+func cursorTupleWhere(alias, field, op string, fieldVal, idVal any) (string, []any) {
+	idCol := "id"
+	if alias != "" {
+		idCol = alias + ".id"
+	}
+	return "(" + field + " " + op + " ? OR (" + field + " = ? AND " + idCol + " " + op + " ?))",
+		[]any{fieldVal, fieldVal, idVal}
+}
+
+// searchLikePattern wraps a non-empty trimmed search term in `%...%` after
+// escaping LIKE/ILIKE metacharacters so user-supplied `%` and `_` match
+// literally. Returns (pattern, false) when search is nil or trims to empty so
+// callers can skip the predicate. Shared by every paginated repository that
+// accepts a search argument (card / cardgroup / master_catalog / user).
+func searchLikePattern(search *string) (string, bool) {
+	if search == nil {
+		return "", false
+	}
+	trimmed := strings.TrimSpace(*search)
+	if trimmed == "" {
+		return "", false
+	}
+	return "%" + escapeLikePattern(trimmed) + "%", true
 }

--- a/backend/internal/repository/user.go
+++ b/backend/internal/repository/user.go
@@ -3,7 +3,6 @@ package repository
 import (
 	"context"
 	"errors"
-	"strings"
 	"time"
 
 	"github.com/rotisserie/eris"
@@ -282,15 +281,7 @@ func (r *userRepo) ListPage(
 
 	// Normalise search: trim, treat blank as nil, escape ILIKE wildcards so
 	// "%" and "_" supplied by the caller match literally.
-	var searchPattern string
-	hasSearch := false
-	if search != nil {
-		trimmed := strings.TrimSpace(*search)
-		if trimmed != "" {
-			searchPattern = "%" + escapeLikePattern(trimmed) + "%"
-			hasSearch = true
-		}
-	}
+	searchPattern, hasSearch := searchLikePattern(search)
 
 	// totalCount mirrors the page predicate (search only) but ignores the
 	// cursor predicate, so callers can compute "items after this point" /


### PR DESCRIPTION
## Summary

The cursor-pagination machinery was copy-pasted across the aggregate repositories: the backward-paging direction-flip preamble, the tuple-comparison cursor `WHERE` template, and the search-`LIKE` pattern helper. This PR hoists all three into `backend/internal/repository/pagination.go` as `paginateSetup[C any]`, `cursorTupleWhere`, and `searchLikePattern`, and routes every duplicate site through them. No behaviour change; net-negative production LOC.

Closes #623.

## Background / Motivation

- The 6-line `effectiveDir/limit/cursor/reverse` direction-flip preamble was duplicated across `card_pagination.go`, `master_card.go`, `cardgroup.go`, and `master_catalog_read.go` — a bug fix had to land in 4 places.
- The portable tuple `WHERE` template `(field op ? OR (field = ? AND <alias>.id op ?))` was hand-written 4 times with only the table-alias differing.
- `cardgroupSearchPattern` and `masterCatalogSearchPattern` were byte-identical, and `user.go` inlined the same trim + escape + `%...%` wrap.

## Changes

- **`internal/repository/pagination.go`** — added `paginateSetup[C any](dir, first, last, after, before)` (generic direction-flip preamble), `cursorTupleWhere(alias, field, op, fieldVal, idVal)` (portable tuple `WHERE` builder), and `searchLikePattern(search *string) (string, bool)` (shared trim/escape/wrap). Added the `strings` import.
- **`internal/repository/card_pagination.go`** — preamble → `paginateSetup`; tuple `WHERE` → `cursorTupleWhere("cards", …)`. The two-column front/back search keeps its own inline escape (different contract: usecase-guaranteed non-empty, no trim).
- **`internal/repository/master_card.go`** — preamble → `paginateSetup`; tuple `WHERE` → `cursorTupleWhere("master_cards", …)`. Two-column search left inline (same contract as card).
- **`internal/repository/cardgroup.go`** — preamble → `paginateSetup`; tuple `WHERE` → `cursorTupleWhere("", …)`; deleted `cardgroupSearchPattern`, both callers now use `searchLikePattern`; dropped the now-unused `strings` import.
- **`internal/repository/master_catalog_read.go`** — preamble → `paginateSetup`; tuple `WHERE` → `cursorTupleWhere("mcg", …)`; deleted `masterCatalogSearchPattern`, all three callers now use `searchLikePattern`; dropped the now-unused `strings` import.
- **`internal/repository/user.go`** — inline search-pattern → `searchLikePattern`; dropped the now-unused `strings` import. The bool-pair direction-flip preamble is left as-is (fixed sort order; out of scope per the issue).
- **`internal/repository/cardgroup_test.go`** — refreshed a stale comment that named the deleted `cardgroupSearchPattern`.

## Verification (in worktree)

- `go build ./...` — pass. `go vet ./...` — pass.
- `go test ./internal/repository/...` — ok (exit 0), run against testcontainers Postgres. `go tool go-arch-lint check --project-path .` — OK, no warnings.

## Test plan

- [ ] Forward + backward + tie-break + active-search pagination stay green for card, master_card, cardgroup, master_catalog, and user aggregates.
- [ ] `cursorTupleWhere` emits the same SQL per alias (`cards.id`, `master_cards.id`, unaliased `id`, `mcg.id`) as the prior inline templates.
- [ ] `searchLikePattern` treats nil / whitespace-only search as no-filter (cardgroup/master_catalog/user count + page paths).