### PR TITLE
refactor(backend): introduce typed PerformanceMode enum in domain/service

### DIFF
--- a/backend/internal/domain/service/user_performance.go
+++ b/backend/internal/domain/service/user_performance.go
@@ -6,15 +6,24 @@ import (
 	"backend/internal/domain"
 )
 
+// PerformanceMode is the difficulty level inferred from a user's recent
+// performance. Values intentionally span ModeDifficult (0) .. ModeInWhile (4).
+type PerformanceMode int
+
 const (
-	ModeDifficult = 0
-	ModeDefault   = 1
-	ModeGood      = 2
-	ModeEasy      = 3
-	ModeInWhile   = 4
+	ModeDifficult PerformanceMode = 0
+	ModeDefault   PerformanceMode = 1
+	ModeGood      PerformanceMode = 2
+	ModeEasy      PerformanceMode = 3
+	ModeInWhile   PerformanceMode = 4
 
 	MinReviewsForModeCalculation = 20
 )
+
+// IsValid reports whether the mode is in the recognised range.
+func (m PerformanceMode) IsValid() bool {
+	return m >= ModeDifficult && m <= ModeInWhile
+}
 
 type PerformanceMetrics struct {
 	SuccessRate   float64
@@ -69,7 +78,7 @@ func ComputeMetrics(swipes []domain.SwipeRecord, now time.Time) PerformanceMetri
 	}
 }
 
-func ModeFromMetrics(m PerformanceMetrics) int {
+func ModeFromMetrics(m PerformanceMetrics) PerformanceMode {
 	if m.ReviewCount < MinReviewsForModeCalculation {
 		return ModeDefault
 	}
@@ -139,7 +148,7 @@ func ratio(numerator, denominator int) float64 {
 	return float64(numerator) / float64(denominator)
 }
 
-func clampMode(mode int) int {
+func clampMode(mode PerformanceMode) PerformanceMode {
 	if mode < ModeDifficult {
 		return ModeDifficult
 	}

--- a/backend/internal/domain/service/user_performance_test.go
+++ b/backend/internal/domain/service/user_performance_test.go
@@ -134,7 +134,7 @@ func TestModeFromMetricsThresholdBoundaries(t *testing.T) {
 		name        string
 		reviewCount int
 		successRate float64
-		want        int
+		want        PerformanceMode
 	}{
 		{"under minimum reviews defaults", 19, 1, ModeDefault},
 		{"below difficult threshold", 20, 0.599, ModeDifficult},
@@ -170,7 +170,7 @@ func TestModeFromMetricsDifficultyAdjustments(t *testing.T) {
 		name          string
 		successRate   float64
 		avgDifficulty float64
-		want          int
+		want          PerformanceMode
 	}{
 		{"high difficulty decreases mode", 0.80, 0.70, ModeDefault},
 		{"low difficulty increases mode", 0.80, 0.30, ModeEasy},
@@ -191,6 +191,30 @@ func TestModeFromMetricsDifficultyAdjustments(t *testing.T) {
 			})
 
 			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestPerformanceModeIsValid(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		mode PerformanceMode
+		want bool
+	}{
+		{"below range", -1, false},
+		{"difficult lower bound", ModeDifficult, true},
+		{"in while upper bound", ModeInWhile, true},
+		{"above range", 5, false},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tc.want, tc.mode.IsValid())
 		})
 	}
 }

--- a/backend/internal/usecase/swipe.go
+++ b/backend/internal/usecase/swipe.go
@@ -228,7 +228,7 @@ func (u *swipeUsecase) HandleSwipe(ctx context.Context, in HandleSwipeInput) (Ha
 	}
 	metrics := service.ComputeMetrics(swipeRecordsByValue(recentSwipes), now)
 	return HandleSwipeOutcome{Swipe: &SwipeOutput{
-		PerformanceMode: service.ModeFromMetrics(metrics),
+		PerformanceMode: int(service.ModeFromMetrics(metrics)),
 		Metrics:         metrics,
 	}}, nil
 }

--- a/backend/internal/usecase/swipe_performance_test.go
+++ b/backend/internal/usecase/swipe_performance_test.go
@@ -50,19 +50,19 @@ func TestSwipeUsecase_HandleSwipePerformanceMode(t *testing.T) {
 		{
 			name:       "less than twenty reviews uses default mode",
 			recent:     performanceSwipes(base, 9, 9, 5),
-			wantMode:   service.ModeDefault,
+			wantMode:   int(service.ModeDefault),
 			wantReview: 19,
 		},
 		{
 			name:       "sixty percent success with high difficulty becomes difficult",
 			recent:     performanceSwipes(base, 11, 8, 8),
-			wantMode:   service.ModeDifficult,
+			wantMode:   int(service.ModeDifficult),
 			wantReview: 20,
 		},
 		{
 			name:       "ninety five percent success becomes in while",
 			recent:     performanceSwipes(base, 18, 1, 5),
-			wantMode:   service.ModeInWhile,
+			wantMode:   int(service.ModeInWhile),
 			wantReview: 20,
 		},
 	}


### PR DESCRIPTION
## Summary

Introduces a `type PerformanceMode int` newtype in `domain/service/user_performance.go`, mirroring the existing `Rating` / `FSRSState` domain-enum pattern. The five `Mode*` level constants are retyped, `ModeFromMetrics` and `clampMode` now traffic in the typed value, and a new `IsValid()` method makes an out-of-range mode an explicit concern rather than an anonymous integer. The GraphQL `Int` wire shape is preserved by casting at the usecase boundary.

Closes #624.

## Background / Motivation

- `service.ModeFromMetrics` returned a bare `int`, and the five performance-mode levels were untyped constants — an invalid mode was an anonymous integer with no compile-time or explicit guard.
- The domain already establishes the int-typed enum + `IsValid()` idiom for `Rating` and `FSRSState`; `PerformanceMode` brings the performance-level concept in line.
- The change is behavior-preserving: the GraphQL schema and `graph/model` are untouched, and the wire field stays `Int`.

## Changes

- **`backend/internal/domain/service/user_performance.go`** — added `type PerformanceMode int`; retyped the five `Mode*` constants (`ModeDifficult`..`ModeInWhile`); `ModeFromMetrics` now returns `PerformanceMode`; `clampMode` takes/returns `PerformanceMode`; added `func (m PerformanceMode) IsValid() bool`.
- **`backend/internal/usecase/swipe.go`** — cast at the boundary so `SwipeOutput.PerformanceMode` (`int`, the wire shape) is unchanged: `PerformanceMode: int(service.ModeFromMetrics(metrics))`.
- **`backend/internal/domain/service/user_performance_test.go`** — retyped the `want` table fields to `PerformanceMode` in the threshold/difficulty tests so `require.Equal` does not box-mismatch on the typed newtype; added `TestPerformanceModeIsValid` with `-1` / `ModeDifficult` / `ModeInWhile` / `5` boundary cases.
- **`backend/internal/usecase/swipe_performance_test.go`** — cast the expected `service.Mode*` constants to `int` to match the unchanged `int`-typed `SwipeOutput.PerformanceMode` comparison.

## Verification (in worktree)

- `go build ./...` — pass. `go vet ./...` — pass.
- `go test ./internal/domain/... ./internal/usecase/...` — all packages ok (`domain`, `domain/service`, `usecase`, `usecase/ucerr`). `go tool go-arch-lint check --project-path .` — OK, no warnings.

## Test plan

- [ ] `PerformanceMode.IsValid()` returns false for `-1` and `5`, true for `ModeDifficult` (0) and `ModeInWhile` (4).
- [ ] `ModeFromMetrics` returns the typed value across the success-rate and difficulty bands (existing threshold/difficulty tables).
- [ ] The `SwipeResponse.performanceMode` GraphQL field remains an `Int` (schema and `graph/model` unchanged; usecase casts at the boundary).