### PR TITLE
refactor(backend): extract resolveSortDir + reuse normalizeSearch across usecase connections

### DIFF
--- a/backend/internal/usecase/card.go
+++ b/backend/internal/usecase/card.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"strings"
 
 	"github.com/rotisserie/eris"
 	"gorm.io/gorm"
@@ -392,18 +391,10 @@ func (u *cardUsecase) ListCardsByCardgroupConnection(
 		return nil, err
 	}
 
-	// Normalize: nil and whitespace-only both mean "no filter". After this
-	// block, a non-nil search pointer is guaranteed to hold a non-empty,
-	// trimmed string — the repository can rely on this invariant.
-	search := in.Search
-	if search != nil {
-		trimmed := strings.TrimSpace(*search)
-		if trimmed == "" {
-			search = nil
-		} else {
-			search = &trimmed
-		}
-	}
+	// Normalize: nil and whitespace-only both mean "no filter". After this,
+	// a non-nil search pointer is guaranteed to hold a non-empty, trimmed
+	// string — the repository can rely on this invariant.
+	search := normalizeSearch(in.Search)
 
 	var total int64
 	cards, hasNext, hasPrev, err := assemblePage(first, last, after != nil, before != nil,
@@ -449,16 +440,9 @@ func resolveOrderBy(orderBy *CardOrderBy, dir *SortOrder) (repository.CardOrderB
 			return "", "", ucerr.NewValidationError("orderBy", "invalid")
 		}
 	}
-	d := repository.SortAsc
-	if dir != nil {
-		switch *dir {
-		case SortOrderAsc:
-			d = repository.SortAsc
-		case SortOrderDesc:
-			d = repository.SortDesc
-		default:
-			return "", "", ucerr.NewValidationError("orderDirection", "invalid")
-		}
+	d, err := resolveSortDir(dir, repository.SortAsc)
+	if err != nil {
+		return "", "", err
 	}
 	return field, d, nil
 }

--- a/backend/internal/usecase/cardgroup.go
+++ b/backend/internal/usecase/cardgroup.go
@@ -391,16 +391,9 @@ func resolveCardgroupOrderBy(
 			return "", "", ucerr.NewValidationError("orderBy", "invalid")
 		}
 	}
-	d := repository.SortDesc
-	if dir != nil {
-		switch *dir {
-		case SortOrderAsc:
-			d = repository.SortAsc
-		case SortOrderDesc:
-			d = repository.SortDesc
-		default:
-			return "", "", ucerr.NewValidationError("orderDirection", "invalid")
-		}
+	d, err := resolveSortDir(dir, repository.SortDesc)
+	if err != nil {
+		return "", "", err
 	}
 	return field, d, nil
 }

--- a/backend/internal/usecase/master_card.go
+++ b/backend/internal/usecase/master_card.go
@@ -665,16 +665,9 @@ func resolveMasterCardOrderBy(
 			return "", "", ucerr.NewValidationError("orderBy", "invalid")
 		}
 	}
-	d := repository.SortAsc
-	if dir != nil {
-		switch *dir {
-		case SortOrderAsc:
-			d = repository.SortAsc
-		case SortOrderDesc:
-			d = repository.SortDesc
-		default:
-			return "", "", ucerr.NewValidationError("orderDirection", "invalid")
-		}
+	d, err := resolveSortDir(dir, repository.SortAsc)
+	if err != nil {
+		return "", "", err
 	}
 	return field, d, nil
 }

--- a/backend/internal/usecase/master_catalog.go
+++ b/backend/internal/usecase/master_catalog.go
@@ -248,16 +248,9 @@ func resolveMasterCatalogOrderBy(
 			return "", "", ucerr.NewValidationError("orderBy", "invalid")
 		}
 	}
-	d := repository.SortAsc
-	if dir != nil {
-		switch *dir {
-		case SortOrderAsc:
-			d = repository.SortAsc
-		case SortOrderDesc:
-			d = repository.SortDesc
-		default:
-			return "", "", ucerr.NewValidationError("orderDirection", "invalid")
-		}
+	d, err := resolveSortDir(dir, repository.SortAsc)
+	if err != nil {
+		return "", "", err
 	}
 	return field, d, nil
 }

--- a/backend/internal/usecase/page.go
+++ b/backend/internal/usecase/page.go
@@ -1,6 +1,28 @@
 package usecase
 
-import "backend/internal/usecase/ucerr"
+import (
+	"backend/internal/repository"
+	"backend/internal/usecase/ucerr"
+)
+
+// resolveSortDir maps the typed usecase SortOrder enum to the repository sort
+// direction, defaulting to def when dir is nil. The default switch arm is
+// defense in depth — gqlgen UnmarshalGQL already rejects invalid enum strings
+// upstream. Shared by every aggregate's resolve*OrderBy; only the per-aggregate
+// default direction (def) differs.
+func resolveSortDir(dir *SortOrder, def repository.SortOrder) (repository.SortOrder, error) {
+	if dir == nil {
+		return def, nil
+	}
+	switch *dir {
+	case SortOrderAsc:
+		return repository.SortAsc, nil
+	case SortOrderDesc:
+		return repository.SortDesc, nil
+	default:
+		return "", ucerr.NewValidationError("orderDirection", "invalid")
+	}
+}
 
 // resolveStandardPageSize clamps first/last to [0, maxPageSize] and rejects
 // passing both. Defaults first=defaultPageSize (20) when neither is provided,

--- a/backend/internal/usecase/page_test.go
+++ b/backend/internal/usecase/page_test.go
@@ -5,8 +5,61 @@ import (
 	"reflect"
 	"testing"
 
+	"backend/internal/repository"
 	"backend/internal/usecase/ucerr"
 )
+
+// TestResolveSortDir covers the shared SortOrder -> repository.SortOrder helper
+// extracted from the four resolve*OrderBy functions: nil falls back to the
+// caller-supplied default, ASC/DESC map to repository.SortAsc/SortDesc, and an
+// out-of-range value is a field-level orderDirection validation error.
+func TestResolveSortDir(t *testing.T) {
+	t.Parallel()
+
+	asc := SortOrderAsc
+	desc := SortOrderDesc
+	bogus := SortOrder("SIDEWAYS")
+
+	tests := []struct {
+		name    string
+		dir     *SortOrder
+		def     repository.SortOrder
+		want    repository.SortOrder
+		wantErr bool
+	}{
+		{name: "nil -> default ASC", dir: nil, def: repository.SortAsc, want: repository.SortAsc},
+		{name: "nil -> default DESC", dir: nil, def: repository.SortDesc, want: repository.SortDesc},
+		{name: "ASC -> repository.SortAsc", dir: &asc, def: repository.SortDesc, want: repository.SortAsc},
+		{name: "DESC -> repository.SortDesc", dir: &desc, def: repository.SortAsc, want: repository.SortDesc},
+		{name: "invalid -> validation error", dir: &bogus, def: repository.SortAsc, wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := resolveSortDir(tc.dir, tc.def)
+			if tc.wantErr {
+				var ve *ucerr.ValidationError
+				if !errors.As(err, &ve) {
+					t.Fatalf("want ValidationError, got %v", err)
+				}
+				if ve.Field != "orderDirection" {
+					t.Fatalf("want field orderDirection, got %q", ve.Field)
+				}
+				if got != "" {
+					t.Fatalf("want empty direction on error, got %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
 
 func TestTrimAndDetect(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Summary

Two DRY consolidations across the usecase connection resolvers. Zero behaviour change.

> Stacked on #639 (base `ddd2-625-listmastercardscore`). `Closes #626` auto-links now and auto-closes once #639 merges and this PR retargets to `main`. **Merge #639 first.**

## What changed

**A — `resolveSortDir` helper.** The four `resolve*OrderBy` functions repeated a byte-identical 8-line `SortOrder → repository.SortOrder` direction switch; only the per-aggregate **default** direction differed. Extracted one package-level helper in `page.go`:

```go
func resolveSortDir(dir *SortOrder, def repository.SortOrder) (repository.SortOrder, error)
```

All four call sites now route through it, preserving each default exactly — `card`/`master_card`/`master_catalog` = `SortAsc`, `cardgroup` = `SortDesc`. Each per-aggregate **field-enum** switch stays in place (intentional per `.claude/rules/pagination.md`). The invalid-direction path still returns `ucerr.NewValidationError("orderDirection", "invalid")`.

**B — `normalizeSearch` reuse.** `card.go`'s `ListCardsByCardgroupConnection` inlined the same trim/blank-collapse logic instead of calling the existing `normalizeSearch`. Swapped to `search := normalizeSearch(in.Search)` and dropped the now-unused `strings` import. (The two `master_card.go` sites are owned by #625/#639; `cardgroup.go` has no inline block.)

## Test plan

- New `TestResolveSortDir` table test: `nil → default (ASC/DESC)`, `ASC → SortAsc`, `DESC → SortDesc`, `invalid → orderDirection validation error`. All pass.
- `go test ./internal/usecase/... ./internal/repository/...` — green (all four aggregates' connection tests unchanged: invalid direction → `BAD_USER_INPUT`, per-aggregate default direction preserved, nil/empty/whitespace search → no filter).
- `go build ./... && go vet ./...` clean; `go tool go-arch-lint check` — OK.

Closes #626
