### PR TITLE
refactor(backend): align master_catalog totalCount with same-filter inline-count pattern

### DIFF
--- a/backend/internal/repository/master_cardgroup.go
+++ b/backend/internal/repository/master_cardgroup.go
@@ -91,13 +91,16 @@ type MasterCardgroupRepository interface {
 	Delete(ctx context.Context, id string) error
 	ListDefaultStarters(ctx context.Context) ([]*domain.MasterCardgroup, error)
 	// FindPublishedPage returns a window of PUBLISHED master cardgroups ordered
-	// by (orderBy, id), each bundled with its card count. The published filter
-	// is enforced in SQL and is never caller-overridable. Forward paging uses
-	// (after, first); backward paging uses (before, last) and the slice is
-	// reversed in memory so the caller observes the same display order
-	// regardless of direction. An optional case-insensitive substring search
-	// filters by name (ILIKE metacharacters in the search are escaped so they
-	// match literally).
+	// by (orderBy, id), each bundled with its card count, plus the search-aware
+	// total of all matching PUBLISHED rows. The published filter is enforced in
+	// SQL and is never caller-overridable. Forward paging uses (after, first);
+	// backward paging uses (before, last) and the slice is reversed in memory so
+	// the caller observes the same display order regardless of direction. An
+	// optional case-insensitive substring search filters by name (ILIKE
+	// metacharacters in the search are escaped so they match literally). The
+	// returned total applies the same status + search filter as the page query
+	// and is computed before the zero-page short-circuit, so a totalCount-only
+	// request still observes the real count.
 	FindPublishedPage(
 		ctx context.Context,
 		after, before *MasterCatalogCursor,
@@ -105,15 +108,7 @@ type MasterCardgroupRepository interface {
 		orderBy MasterCatalogOrderBy,
 		dir SortOrder,
 		search *string,
-	) ([]*MasterCatalogItem, error)
-	// CountPublished returns the total number of PUBLISHED master cardgroups
-	// matching the optional search predicate. Returned independently of
-	// FindPublishedPage so the totalCount survives a zero-page request.
-	CountPublished(ctx context.Context, search *string) (int64, error)
-	// CountAdmin returns the total number of master cardgroups of ANY status
-	// (draft or published) matching the optional search predicate. Used by the
-	// admin list to display totalCount regardless of publication status.
-	CountAdmin(ctx context.Context, search *string) (int64, error)
+	) ([]*MasterCatalogItem, int64, error)
 	// CountCards returns the number of master cards belonging to the given
 	// master cardgroup. Used by the admin UI to display a card count per deck.
 	CountCards(ctx context.Context, masterCardgroupID string) (int64, error)
@@ -122,9 +117,10 @@ type MasterCardgroupRepository interface {
 	// the public catalog. Used by the usecase to hydrate a pagination cursor.
 	FindPublishedByID(ctx context.Context, id string) (*domain.MasterCardgroup, error)
 	// FindAdminPage returns a window of master cardgroups of ANY status (draft
-	// or published), each bundled with its card count. Unlike FindPublishedPage
+	// or published), each bundled with its card count, plus the search-aware
+	// total of all matching rows regardless of status. Unlike FindPublishedPage
 	// it does not filter by status, so admin users see draft decks. All other
-	// pagination, ordering, and search semantics are identical to
+	// pagination, ordering, search, and totalCount semantics are identical to
 	// FindPublishedPage.
 	FindAdminPage(
 		ctx context.Context,
@@ -133,7 +129,7 @@ type MasterCardgroupRepository interface {
 		orderBy MasterCatalogOrderBy,
 		dir SortOrder,
 		search *string,
-	) ([]*MasterCatalogItem, error)
+	) ([]*MasterCatalogItem, int64, error)
 	// Publish atomically sets the master cardgroup status to published and
 	// increments its version by 1. Returns ErrNotFound when no row matches.
 	Publish(ctx context.Context, id string) (*domain.MasterCardgroup, error)

--- a/backend/internal/repository/master_cardgroup_admin_test.go
+++ b/backend/internal/repository/master_cardgroup_admin_test.go
@@ -1,7 +1,7 @@
 package repository_test
 
 // Integration tests for the admin master-catalog write and list operations:
-//   - CountAdmin (includes draft + published)
+//   - FindAdminPage total (includes draft + published; applies the search filter)
 //   - CountCards (correlated count over master_cards)
 //   - FindAdminPage (no status filter, otherwise identical to FindPublishedPage)
 //   - Publish (sets status=published, bumps version)
@@ -26,10 +26,10 @@ import (
 )
 
 // ---------------------------------------------------------------------------
-// CountAdmin — includes both draft and published rows
+// FindAdminPage total — includes both draft and published rows
 // ---------------------------------------------------------------------------
 
-func TestMasterCardgroupRepository_CountAdmin_IncludesDraftAndPublished(t *testing.T) {
+func TestMasterCardgroupRepository_FindAdminPage_TotalIncludesDraftAndPublished(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	repo := repository.NewMasterCardgroupRepository(testDB.GORM)
@@ -40,13 +40,14 @@ func TestMasterCardgroupRepository_CountAdmin_IncludesDraftAndPublished(t *testi
 
 	// Search on the base UUID suffix so both names match (ILIKE %base%).
 	search := base
-	total, err := repo.CountAdmin(ctx, &search)
+	_, total, err := repo.FindAdminPage(ctx, nil, nil, repository.PageCap, 0,
+		repository.MasterCatalogOrderBySortOrder, repository.SortAsc, &search)
 	require.NoError(t, err)
 	require.Equal(t, int64(2), total,
-		"CountAdmin must count both draft and published rows")
+		"FindAdminPage total must count both draft and published rows")
 }
 
-func TestMasterCardgroupRepository_CountAdmin_SearchFilter(t *testing.T) {
+func TestMasterCardgroupRepository_FindAdminPage_TotalSearchFilter(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	repo := repository.NewMasterCardgroupRepository(testDB.GORM)
@@ -56,9 +57,10 @@ func TestMasterCardgroupRepository_CountAdmin_SearchFilter(t *testing.T) {
 	insertDraftMCG(t, ctx, "AdminFilter NoMatch "+uuid.NewString())
 
 	search := "AdminFilter Match " + base
-	total, err := repo.CountAdmin(ctx, &search)
+	_, total, err := repo.FindAdminPage(ctx, nil, nil, repository.PageCap, 0,
+		repository.MasterCatalogOrderBySortOrder, repository.SortAsc, &search)
 	require.NoError(t, err)
-	require.Equal(t, int64(1), total, "search filters by name ILIKE")
+	require.Equal(t, int64(1), total, "search filters the total by name ILIKE")
 }
 
 // ---------------------------------------------------------------------------
@@ -111,7 +113,7 @@ func TestMasterCardgroupRepository_FindAdminPage_DraftVisible(t *testing.T) {
 
 	// Search on the base UUID suffix so both names match (ILIKE %base%).
 	search := base
-	page, err := repo.FindAdminPage(ctx, nil, nil, repository.PageCap, 0,
+	page, _, err := repo.FindAdminPage(ctx, nil, nil, repository.PageCap, 0,
 		repository.MasterCatalogOrderBySortOrder, repository.SortAsc, &search)
 	require.NoError(t, err)
 
@@ -140,7 +142,7 @@ func TestMasterCardgroupRepository_FindAdminPage_OrderBySortOrder(t *testing.T) 
 	ourIDs := []string{m1.ID, m2.ID, m3.ID}
 
 	search := base
-	page, err := repo.FindAdminPage(ctx, nil, nil, repository.PageCap, 0,
+	page, _, err := repo.FindAdminPage(ctx, nil, nil, repository.PageCap, 0,
 		repository.MasterCatalogOrderBySortOrder, repository.SortAsc, &search)
 	require.NoError(t, err)
 
@@ -161,7 +163,7 @@ func TestMasterCardgroupRepository_FindAdminPage_CardCountAggregation(t *testing
 
 	// Search on the base UUID suffix so both names match (ILIKE %base%).
 	search := base
-	page, err := repo.FindAdminPage(ctx, nil, nil, repository.PageCap, 0,
+	page, _, err := repo.FindAdminPage(ctx, nil, nil, repository.PageCap, 0,
 		repository.MasterCatalogOrderBySortOrder, repository.SortAsc, &search)
 	require.NoError(t, err)
 
@@ -194,7 +196,7 @@ func TestMasterCardgroupRepository_FindAdminPage_ForwardAndBackwardPagination(t 
 	search := base
 
 	// Forward page 1: first=2 yields [m1, m2].
-	fwd1, err := repo.FindAdminPage(ctx, nil, nil, 2, 0,
+	fwd1, _, err := repo.FindAdminPage(ctx, nil, nil, 2, 0,
 		repository.MasterCatalogOrderBySortOrder, repository.SortAsc, &search)
 	require.NoError(t, err)
 	ours1 := filterCatalogByIDs(fwd1, ourIDs)
@@ -203,7 +205,7 @@ func TestMasterCardgroupRepository_FindAdminPage_ForwardAndBackwardPagination(t 
 
 	// Backward before m3 yields [m1, m2] in display order.
 	beforeM3 := &repository.MasterCatalogCursor{ID: m3.ID, SortOrder: &m3.SortOrder}
-	bwd, err := repo.FindAdminPage(ctx, nil, beforeM3, 0, repository.PageCap,
+	bwd, _, err := repo.FindAdminPage(ctx, nil, beforeM3, 0, repository.PageCap,
 		repository.MasterCatalogOrderBySortOrder, repository.SortAsc, &search)
 	require.NoError(t, err)
 	oursBwd := filterCatalogByIDs(bwd, ourIDs)

--- a/backend/internal/repository/master_catalog_read.go
+++ b/backend/internal/repository/master_catalog_read.go
@@ -56,36 +56,6 @@ func (r gormMasterCatalogRow) toGorm() gormMasterCardgroup {
 	}
 }
 
-// CountPublished returns the total number of published master cardgroups
-// matching the optional search predicate. The published filter is enforced in
-// SQL and is never caller-overridable.
-func (r *masterCardgroupRepo) CountPublished(ctx context.Context, search *string) (int64, error) {
-	q := r.db.WithContext(ctx).Model(&gormMasterCardgroup{}).
-		Where("status = ?", string(domain.MasterStatusPublished))
-	if pattern, ok := searchLikePattern(search); ok {
-		q = q.Where("name ILIKE ?", pattern)
-	}
-	var total int64
-	if err := q.Count(&total).Error; err != nil {
-		return 0, eris.Wrap(err, "repository: master cardgroup: count published")
-	}
-	return total, nil
-}
-
-// CountAdmin returns the total number of master cardgroups of any status
-// (draft or published) matching the optional search predicate.
-func (r *masterCardgroupRepo) CountAdmin(ctx context.Context, search *string) (int64, error) {
-	q := r.db.WithContext(ctx).Model(&gormMasterCardgroup{})
-	if pattern, ok := searchLikePattern(search); ok {
-		q = q.Where("name ILIKE ?", pattern)
-	}
-	var total int64
-	if err := q.Count(&total).Error; err != nil {
-		return 0, eris.Wrap(err, "repository: master cardgroup: count admin")
-	}
-	return total, nil
-}
-
 // CountCards returns the number of master cards belonging to the given master
 // cardgroup.
 func (r *masterCardgroupRepo) CountCards(ctx context.Context, masterCardgroupID string) (int64, error) {
@@ -160,12 +130,29 @@ func (r *masterCardgroupRepo) findCatalogPage(
 	dir SortOrder,
 	search *string,
 	publishedOnly bool,
-) ([]*MasterCatalogItem, error) {
+) ([]*MasterCatalogItem, int64, error) {
 	first = ClampPageSize(first)
 	last = ClampPageSize(last)
 
+	// totalCount comes from a COUNT(*) on the SAME filtered base (status filter
+	// when publishedOnly, plus the optional search predicate), built
+	// independently of the cursor/order/limit so it counts the whole matching
+	// set. Computed before the no-rows short-circuit so callers asking only for
+	// totalCount still observe the real count.
+	countQ := r.db.WithContext(ctx).Model(&gormMasterCardgroup{})
+	if publishedOnly {
+		countQ = countQ.Where("status = ?", string(domain.MasterStatusPublished))
+	}
+	if pattern, ok := searchLikePattern(search); ok {
+		countQ = countQ.Where("name ILIKE ?", pattern)
+	}
+	var total int64
+	if err := countQ.Count(&total).Error; err != nil {
+		return nil, 0, eris.Wrap(err, "repository: master cardgroup: count catalog page")
+	}
+
 	if first == 0 && last == 0 {
-		return []*MasterCatalogItem{}, nil
+		return []*MasterCatalogItem{}, total, nil
 	}
 
 	// Backward paging executes the query with the inverted direction and
@@ -184,7 +171,7 @@ func (r *masterCardgroupRepo) findCatalogPage(
 	if cursor != nil {
 		clauseSQL, args, err := masterCatalogCursorWhere(orderBy, effectiveDir, cursor)
 		if err != nil {
-			return nil, eris.Wrap(err, "repository: master cardgroup: build catalog cursor where")
+			return nil, 0, eris.Wrap(err, "repository: master cardgroup: build catalog cursor where")
 		}
 		q = q.Where(clauseSQL, args...)
 	}
@@ -192,7 +179,7 @@ func (r *masterCardgroupRepo) findCatalogPage(
 
 	var rows []gormMasterCatalogRow
 	if err := q.Find(&rows).Error; err != nil {
-		return nil, eris.Wrap(err, "repository: master cardgroup: find catalog page")
+		return nil, 0, eris.Wrap(err, "repository: master cardgroup: find catalog page")
 	}
 
 	if reverse {
@@ -203,14 +190,14 @@ func (r *masterCardgroupRepo) findCatalogPage(
 	for i := range rows {
 		cg, err := masterCardgroupToDomain(rows[i].toGorm())
 		if err != nil {
-			return nil, err
+			return nil, 0, err
 		}
 		out[i] = &MasterCatalogItem{
 			Cardgroup: cg,
 			CardCount: rows[i].CardCount,
 		}
 	}
-	return out, nil
+	return out, total, nil
 }
 
 // FindPublishedPage returns the cursor-paginated published catalog list (drafts
@@ -223,7 +210,7 @@ func (r *masterCardgroupRepo) FindPublishedPage(
 	orderBy MasterCatalogOrderBy,
 	dir SortOrder,
 	search *string,
-) ([]*MasterCatalogItem, error) {
+) ([]*MasterCatalogItem, int64, error) {
 	return r.findCatalogPage(ctx, after, before, first, last, orderBy, dir, search, true)
 }
 
@@ -236,6 +223,6 @@ func (r *masterCardgroupRepo) FindAdminPage(
 	orderBy MasterCatalogOrderBy,
 	dir SortOrder,
 	search *string,
-) ([]*MasterCatalogItem, error) {
+) ([]*MasterCatalogItem, int64, error) {
 	return r.findCatalogPage(ctx, after, before, first, last, orderBy, dir, search, false)
 }

--- a/backend/internal/repository/master_catalog_test.go
+++ b/backend/internal/repository/master_catalog_test.go
@@ -1,8 +1,10 @@
 package repository_test
 
 // Integration tests for the published master-catalog read path
-// (FindPublishedPage / CountPublished / FindPublishedByID). They run against the
-// shared testcontainers Postgres provisioned by TestMain in user_test.go.
+// (FindPublishedPage / FindPublishedByID). FindPublishedPage carries the
+// search-aware total as its second return value, so there is no separate count
+// method. They run against the shared testcontainers Postgres provisioned by
+// TestMain in user_test.go.
 //
 // Shared helpers reused from master_cardgroup_test.go:
 //   - newMasterCardgroupMinimal
@@ -96,7 +98,7 @@ func TestMasterCardgroupRepository_FindPublishedPage_DraftNeverLeaks(t *testing.
 	pub := insertPublishedMCG(t, ctx, "Pub "+base, 1)
 	draft := insertDraftMCG(t, ctx, "Draft "+base)
 
-	page, err := repo.FindPublishedPage(ctx, nil, nil, repository.PageCap, 0,
+	page, _, err := repo.FindPublishedPage(ctx, nil, nil, repository.PageCap, 0,
 		repository.MasterCatalogOrderBySortOrder, repository.SortAsc, nil)
 	require.NoError(t, err)
 
@@ -120,7 +122,7 @@ func TestMasterCardgroupRepository_FindPublishedPage_CardCount(t *testing.T) {
 	insertMasterCards(t, ctx, withCards.ID, 3)
 	empty := insertPublishedMCG(t, ctx, "Empty "+base, 2)
 
-	page, err := repo.FindPublishedPage(ctx, nil, nil, repository.PageCap, 0,
+	page, _, err := repo.FindPublishedPage(ctx, nil, nil, repository.PageCap, 0,
 		repository.MasterCatalogOrderBySortOrder, repository.SortAsc, nil)
 	require.NoError(t, err)
 
@@ -134,10 +136,10 @@ func TestMasterCardgroupRepository_FindPublishedPage_CardCount(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// CountPublished
+// FindPublishedPage total: excludes drafts, applies the search filter
 // ---------------------------------------------------------------------------
 
-func TestMasterCardgroupRepository_CountPublished_ExcludesDraft(t *testing.T) {
+func TestMasterCardgroupRepository_FindPublishedPage_TotalExcludesDraft(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	repo := repository.NewMasterCardgroupRepository(testDB.GORM)
@@ -148,7 +150,8 @@ func TestMasterCardgroupRepository_CountPublished_ExcludesDraft(t *testing.T) {
 
 	// A name search isolates this test's rows from the shared DB.
 	search := "CountPub " + base
-	total, err := repo.CountPublished(ctx, &search)
+	_, total, err := repo.FindPublishedPage(ctx, nil, nil, repository.PageCap, 0,
+		repository.MasterCatalogOrderBySortOrder, repository.SortAsc, &search)
 	require.NoError(t, err)
 	require.Equal(t, int64(1), total, "only the published row matching the search counts")
 }
@@ -200,12 +203,12 @@ func TestMasterCardgroupRepository_FindPublishedPage_ForwardAndBackward(t *testi
 	// the shared parallel DB — every name ends with " "+base. Without it, a
 	// no-cursor first=N query returns the globally-lowest sort_order rows, which
 	// other parallel tests' published rows can occupy (the same isolation pattern
-	// used by CountPublished above).
+	// used by the FindPublishedPage total test above).
 	search := base
 
 	// Forward page 1: first=2, no cursor. The two lowest sort_order rows of the
 	// isolated set come back in order: [m1, m2].
-	fwd1, err := repo.FindPublishedPage(ctx, nil, nil, 2, 0,
+	fwd1, _, err := repo.FindPublishedPage(ctx, nil, nil, 2, 0,
 		repository.MasterCatalogOrderBySortOrder, repository.SortAsc, &search)
 	require.NoError(t, err)
 	ours1 := filterCatalogByIDs(fwd1, ourIDs)
@@ -214,7 +217,7 @@ func TestMasterCardgroupRepository_FindPublishedPage_ForwardAndBackward(t *testi
 
 	// Forward from m1: cursor after m1 → [m2, m3].
 	afterM1 := &repository.MasterCatalogCursor{ID: m1.ID, SortOrder: &m1.SortOrder}
-	fwd2, err := repo.FindPublishedPage(ctx, afterM1, nil, repository.PageCap, 0,
+	fwd2, _, err := repo.FindPublishedPage(ctx, afterM1, nil, repository.PageCap, 0,
 		repository.MasterCatalogOrderBySortOrder, repository.SortAsc, &search)
 	require.NoError(t, err)
 	ours2 := filterCatalogByIDs(fwd2, ourIDs)
@@ -224,7 +227,7 @@ func TestMasterCardgroupRepository_FindPublishedPage_ForwardAndBackward(t *testi
 	// Backward before m3: should yield [m1, m2] in display order after the
 	// internal direction-flip + reverse.
 	beforeM3 := &repository.MasterCatalogCursor{ID: m3.ID, SortOrder: &m3.SortOrder}
-	bwd, err := repo.FindPublishedPage(ctx, nil, beforeM3, 0, repository.PageCap,
+	bwd, _, err := repo.FindPublishedPage(ctx, nil, beforeM3, 0, repository.PageCap,
 		repository.MasterCatalogOrderBySortOrder, repository.SortAsc, &search)
 	require.NoError(t, err)
 	oursBwd := filterCatalogByIDs(bwd, ourIDs)
@@ -251,7 +254,7 @@ func TestMasterCardgroupRepository_FindPublishedPage_OrderByNameDesc(t *testing.
 	search := base
 
 	// NAME DESC, first page of 2: highest name first → [CName, BName].
-	fwd, err := repo.FindPublishedPage(ctx, nil, nil, 2, 0,
+	fwd, _, err := repo.FindPublishedPage(ctx, nil, nil, 2, 0,
 		repository.MasterCatalogOrderByName, repository.SortDesc, &search)
 	require.NoError(t, err)
 	require.Equal(t, []string{c.ID, b.ID}, catalogIDs(filterCatalogByIDs(fwd, ourIDs)),
@@ -261,7 +264,7 @@ func TestMasterCardgroupRepository_FindPublishedPage_OrderByNameDesc(t *testing.
 	// masterCatalogCursorWhere → [BName, AName].
 	cName := string(c.Name)
 	afterC := &repository.MasterCatalogCursor{ID: c.ID, Name: &cName}
-	next, err := repo.FindPublishedPage(ctx, afterC, nil, repository.PageCap, 0,
+	next, _, err := repo.FindPublishedPage(ctx, afterC, nil, repository.PageCap, 0,
 		repository.MasterCatalogOrderByName, repository.SortDesc, &search)
 	require.NoError(t, err)
 	require.Equal(t, []string{b.ID, a.ID}, catalogIDs(filterCatalogByIDs(next, ourIDs)),
@@ -281,7 +284,7 @@ func TestMasterCardgroupRepository_FindPublishedPage_MissingCursorColumn(t *test
 	// zero-value fallback would emit a wrong-but-valid predicate and skip rows;
 	// the repository must surface this caller bug as an error instead.
 	badCursor := &repository.MasterCatalogCursor{ID: uuid.NewString()} // Name == nil
-	_, err := repo.FindPublishedPage(ctx, badCursor, nil, 10, 0,
+	_, _, err := repo.FindPublishedPage(ctx, badCursor, nil, 10, 0,
 		repository.MasterCatalogOrderByName, repository.SortAsc, nil)
 	require.Error(t, err)
 }
@@ -304,14 +307,11 @@ func TestMasterCardgroupRepository_SearchEscapesLikeMetacharacters(t *testing.T)
 	b := insertPublishedMCG(t, ctx, "pct50x"+base, 2)
 
 	search := "50%" + base
-	total, err := repo.CountPublished(ctx, &search)
+	page, total, err := repo.FindPublishedPage(ctx, nil, nil, repository.PageCap, 0,
+		repository.MasterCatalogOrderBySortOrder, repository.SortAsc, &search)
 	require.NoError(t, err)
 	require.Equal(t, int64(1), total,
 		"literal '%' search counts only the deck whose name contains '50%'+base")
-
-	page, err := repo.FindPublishedPage(ctx, nil, nil, repository.PageCap, 0,
-		repository.MasterCatalogOrderBySortOrder, repository.SortAsc, &search)
-	require.NoError(t, err)
 	require.Equal(t, []string{a.ID}, catalogIDs(filterCatalogByIDs(page, []string{a.ID, b.ID})),
 		"literal '%' search returns only deck A, not B")
 }

--- a/backend/internal/usecase/master_card_test.go
+++ b/backend/internal/usecase/master_card_test.go
@@ -164,15 +164,7 @@ func (panicMasterCardgroupRepo) ListDefaultStarters(_ context.Context) ([]*domai
 func (panicMasterCardgroupRepo) FindPublishedPage(
 	_ context.Context, _, _ *repository.MasterCatalogCursor, _, _ int,
 	_ repository.MasterCatalogOrderBy, _ repository.SortOrder, _ *string,
-) ([]*repository.MasterCatalogItem, error) {
-	panic("not used in this test")
-}
-
-func (panicMasterCardgroupRepo) CountPublished(_ context.Context, _ *string) (int64, error) {
-	panic("not used in this test")
-}
-
-func (panicMasterCardgroupRepo) CountAdmin(_ context.Context, _ *string) (int64, error) {
+) ([]*repository.MasterCatalogItem, int64, error) {
 	panic("not used in this test")
 }
 
@@ -187,7 +179,7 @@ func (panicMasterCardgroupRepo) FindPublishedByID(_ context.Context, _ string) (
 func (panicMasterCardgroupRepo) FindAdminPage(
 	_ context.Context, _, _ *repository.MasterCatalogCursor, _, _ int,
 	_ repository.MasterCatalogOrderBy, _ repository.SortOrder, _ *string,
-) ([]*repository.MasterCatalogItem, error) {
+) ([]*repository.MasterCatalogItem, int64, error) {
 	panic("not used in this test")
 }
 

--- a/backend/internal/usecase/master_catalog.go
+++ b/backend/internal/usecase/master_catalog.go
@@ -28,8 +28,7 @@ type MasterCatalogRepository interface {
 		orderBy repository.MasterCatalogOrderBy,
 		dir repository.SortOrder,
 		search *string,
-	) ([]*repository.MasterCatalogItem, error)
-	CountPublished(ctx context.Context, search *string) (int64, error)
+	) ([]*repository.MasterCatalogItem, int64, error)
 	FindPublishedByID(ctx context.Context, id string) (*domain.MasterCardgroup, error)
 
 	// --- admin (new) ---
@@ -41,8 +40,7 @@ type MasterCatalogRepository interface {
 		orderBy repository.MasterCatalogOrderBy,
 		dir repository.SortOrder,
 		search *string,
-	) ([]*repository.MasterCatalogItem, error)
-	CountAdmin(ctx context.Context, search *string) (int64, error)
+	) ([]*repository.MasterCatalogItem, int64, error)
 	CountCards(ctx context.Context, masterCardgroupID string) (int64, error)
 	Create(ctx context.Context, m *domain.MasterCardgroup) error
 	Update(ctx context.Context, id string, patch repository.MasterCardgroupUpdate) (*domain.MasterCardgroup, error)
@@ -199,20 +197,18 @@ func (u *masterCatalogUsecase) ListPublishedConnection(
 	// (nil and whitespace-only both mean "no filter").
 	search := normalizeSearch(in.Search)
 
-	// totalCount comes from a separate COUNT(*) scoped to published rows and the
-	// optional search predicate. Computed before the page fetch so callers asking
-	// only for totalCount still see a real value.
-	total, err := u.repo.CountPublished(ctx, search)
-	if err != nil {
-		return nil, eris.Wrap(err, "usecase: master catalog: count published")
-	}
-
+	// totalCount is the search-aware total carried by the page method, captured
+	// inside the fetch closure. FindPublishedPage runs its COUNT(*) on the same
+	// filtered base before its zero-page short-circuit, so a totalCount-only
+	// request still observes the real value.
+	var total int64
 	items, hasNext, hasPrev, err := assemblePage(first, last, after != nil, before != nil,
 		func(wantFirst, wantLast int) ([]*repository.MasterCatalogItem, error) {
-			rows, e := u.repo.FindPublishedPage(ctx, after, before, wantFirst, wantLast, orderBy, dir, search)
+			rows, t, e := u.repo.FindPublishedPage(ctx, after, before, wantFirst, wantLast, orderBy, dir, search)
 			if e != nil {
 				return nil, eris.Wrap(e, "usecase: master catalog: find published page")
 			}
+			total = t
 			return rows, nil
 		},
 	)
@@ -568,7 +564,8 @@ func (u *masterCatalogUsecase) DeleteMaster(ctx context.Context, id string) erro
 
 // ListAdminConnection paginates ALL master cardgroups (DRAFT + PUBLISHED) for the
 // admin UI. Admin-only. Mirrors ListPublishedConnection but gates on adminGate and
-// calls the unfiltered CountAdmin / FindAdminPage repository methods.
+// calls the status-unfiltered FindAdminPage repository method (whose returned
+// total counts decks of any status).
 func (u *masterCatalogUsecase) ListAdminConnection(
 	ctx context.Context, in MasterCatalogConnectionInput,
 ) (*MasterCatalogConnectionOutput, error) {
@@ -599,17 +596,16 @@ func (u *masterCatalogUsecase) ListAdminConnection(
 	// (nil and whitespace-only both mean "no filter").
 	search := normalizeSearch(in.Search)
 
-	total, err := u.repo.CountAdmin(ctx, search)
-	if err != nil {
-		return nil, eris.Wrap(err, "usecase: master catalog: count admin")
-	}
-
+	// totalCount is the search-aware total carried by the page method, captured
+	// inside the fetch closure (see ListPublishedConnection for the contract).
+	var total int64
 	items, hasNext, hasPrev, err := assemblePage(first, last, after != nil, before != nil,
 		func(wantFirst, wantLast int) ([]*repository.MasterCatalogItem, error) {
-			rows, e := u.repo.FindAdminPage(ctx, after, before, wantFirst, wantLast, orderBy, dir, search)
+			rows, t, e := u.repo.FindAdminPage(ctx, after, before, wantFirst, wantLast, orderBy, dir, search)
 			if e != nil {
 				return nil, eris.Wrap(e, "usecase: master catalog: find admin page")
 			}
+			total = t
 			return rows, nil
 		},
 	)

--- a/backend/internal/usecase/master_catalog_admin_test.go
+++ b/backend/internal/usecase/master_catalog_admin_test.go
@@ -258,8 +258,8 @@ func TestMasterCatalog_ListAdminConnection_ReturnsPage(t *testing.T) {
 		{Cardgroup: masterCardgroup("b"), CardCount: 0},
 	}
 	repo := &mockMasterCatalogRepository{
-		countAdminRes: 2,
-		findAdminPage: items,
+		findAdminTotal: 2,
+		findAdminPage:  items,
 	}
 	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, newTestAdminGate(true), newTestLogger())
 	ctx := authedCtx("admin1")

--- a/backend/internal/usecase/master_catalog_test.go
+++ b/backend/internal/usecase/master_catalog_test.go
@@ -16,15 +16,11 @@ import (
 
 // mockMasterCatalogRepository is a manual test double for MasterCatalogRepository.
 type mockMasterCatalogRepository struct {
-	// FindPublishedPage
+	// FindPublishedPage (the search-aware total is carried by the page method)
 	findPageResult []*repository.MasterCatalogItem
+	findPageTotal  int64
 	findPageErr    error
 	findPageCalls  []findPublishedPageCall
-
-	// CountPublished
-	countResult int64
-	countErr    error
-	countCalls  []countPublishedCall
 
 	// FindByID (admin cursor resolution) and FindPublishedByID (published cursor
 	// resolution + ImportMaster's published check) are backed by separate funcs so
@@ -34,21 +30,19 @@ type mockMasterCatalogRepository struct {
 	findByIDFn          func(id string) (*domain.MasterCardgroup, error)
 	findPublishedByIDFn func(id string) (*domain.MasterCardgroup, error)
 
-	// admin methods
-	findAdminPage   []*repository.MasterCatalogItem
-	findAdminErr    error
-	findAdminCalls  []findPublishedPageCall
-	countAdminRes   int64
-	countAdminErr   error
-	countAdminCalls []countPublishedCall
-	countCardsRes   int64
-	countCardsErr   error
-	createCalls     []*domain.MasterCardgroup
-	createErr       error
-	updateFn        func(id string, patch repository.MasterCardgroupUpdate) (*domain.MasterCardgroup, error)
-	deleteErr       error
-	publishFn       func(id string) (*domain.MasterCardgroup, error)
-	unpublishFn     func(id string) (*domain.MasterCardgroup, error)
+	// admin methods (FindAdminPage carries the status-unfiltered, search-aware total)
+	findAdminPage  []*repository.MasterCatalogItem
+	findAdminTotal int64
+	findAdminErr   error
+	findAdminCalls []findPublishedPageCall
+	countCardsRes  int64
+	countCardsErr  error
+	createCalls    []*domain.MasterCardgroup
+	createErr      error
+	updateFn       func(id string, patch repository.MasterCardgroupUpdate) (*domain.MasterCardgroup, error)
+	deleteErr      error
+	publishFn      func(id string) (*domain.MasterCardgroup, error)
+	unpublishFn    func(id string) (*domain.MasterCardgroup, error)
 }
 
 type findPublishedPageCall struct {
@@ -61,10 +55,6 @@ type findPublishedPageCall struct {
 	Search  *string
 }
 
-type countPublishedCall struct {
-	Search *string
-}
-
 func (m *mockMasterCatalogRepository) FindPublishedPage(
 	_ context.Context,
 	after, before *repository.MasterCatalogCursor,
@@ -72,23 +62,15 @@ func (m *mockMasterCatalogRepository) FindPublishedPage(
 	orderBy repository.MasterCatalogOrderBy,
 	dir repository.SortOrder,
 	search *string,
-) ([]*repository.MasterCatalogItem, error) {
+) ([]*repository.MasterCatalogItem, int64, error) {
 	m.findPageCalls = append(m.findPageCalls, findPublishedPageCall{
 		After: after, Before: before, First: first, Last: last,
 		OrderBy: orderBy, Dir: dir, Search: search,
 	})
 	if m.findPageErr != nil {
-		return nil, m.findPageErr
+		return nil, 0, m.findPageErr
 	}
-	return m.findPageResult, nil
-}
-
-func (m *mockMasterCatalogRepository) CountPublished(_ context.Context, search *string) (int64, error) {
-	m.countCalls = append(m.countCalls, countPublishedCall{Search: search})
-	if m.countErr != nil {
-		return 0, m.countErr
-	}
-	return m.countResult, nil
+	return m.findPageResult, m.findPageTotal, nil
 }
 
 func (m *mockMasterCatalogRepository) FindPublishedByID(_ context.Context, id string) (*domain.MasterCardgroup, error) {
@@ -115,20 +97,15 @@ func (m *mockMasterCatalogRepository) FindAdminPage(
 	orderBy repository.MasterCatalogOrderBy,
 	dir repository.SortOrder,
 	search *string,
-) ([]*repository.MasterCatalogItem, error) {
+) ([]*repository.MasterCatalogItem, int64, error) {
 	m.findAdminCalls = append(m.findAdminCalls, findPublishedPageCall{
 		After: after, Before: before, First: first, Last: last,
 		OrderBy: orderBy, Dir: dir, Search: search,
 	})
 	if m.findAdminErr != nil {
-		return nil, m.findAdminErr
+		return nil, 0, m.findAdminErr
 	}
-	return m.findAdminPage, nil
-}
-
-func (m *mockMasterCatalogRepository) CountAdmin(_ context.Context, search *string) (int64, error) {
-	m.countAdminCalls = append(m.countAdminCalls, countPublishedCall{Search: search})
-	return m.countAdminRes, m.countAdminErr
+	return m.findAdminPage, m.findAdminTotal, nil
 }
 
 func (m *mockMasterCatalogRepository) CountCards(_ context.Context, _ string) (int64, error) {
@@ -232,7 +209,7 @@ func TestListPublishedConnection_Unauthenticated(t *testing.T) {
 
 func TestListPublishedConnection_Forward_TrimsExtraRow_SetsHasNext(t *testing.T) {
 	repo := &mockMasterCatalogRepository{
-		countResult: 5,
+		findPageTotal: 5,
 		// first=2 → usecase asks for 3 (+1). Repo returns 3 → trim to 2, hasNext=true.
 		findPageResult: []*repository.MasterCatalogItem{
 			catalogItem("a", 10), catalogItem("b", 20), catalogItem("c", 30),
@@ -283,7 +260,7 @@ func TestListPublishedConnection_Forward_TrimsExtraRow_SetsHasNext(t *testing.T)
 
 func TestListPublishedConnection_Forward_NoExtraRow_NoNextPage(t *testing.T) {
 	repo := &mockMasterCatalogRepository{
-		countResult:    2,
+		findPageTotal:  2,
 		findPageResult: []*repository.MasterCatalogItem{catalogItem("a", 1), catalogItem("b", 2)},
 	}
 	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, newTestAdminGate(true), newTestLogger())
@@ -308,7 +285,7 @@ func TestListPublishedConnection_Backward_TrimsLeadingRow_SetsHasPrev(t *testing
 	// Cursor hydration requires a published row for `before`.
 	cur := cursor.Encode("z")
 	repo := &mockMasterCatalogRepository{
-		countResult: 10,
+		findPageTotal: 10,
 		findByIDFn: func(id string) (*domain.MasterCardgroup, error) {
 			return catalogItem(id, 0).Cardgroup, nil
 		},
@@ -355,7 +332,7 @@ func TestListPublishedConnection_Backward_TrimsLeadingRow_SetsHasPrev(t *testing
 // ---------------------------------------------------------------------------
 
 func TestListPublishedConnection_OrderByName_Desc(t *testing.T) {
-	repo := &mockMasterCatalogRepository{countResult: 0, findPageResult: nil}
+	repo := &mockMasterCatalogRepository{findPageTotal: 0, findPageResult: nil}
 	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, newTestAdminGate(true), newTestLogger())
 
 	ob := MasterCatalogOrderByName
@@ -400,12 +377,14 @@ func TestListPublishedConnection_FirstAndLast_Rejected(t *testing.T) {
 
 func TestListPublishedConnection_TotalCountOnlyRequest(t *testing.T) {
 	repo := &mockMasterCatalogRepository{
-		countResult:    42,
+		findPageTotal:  42,
 		findPageResult: []*repository.MasterCatalogItem{},
 	}
 	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, newTestAdminGate(true), newTestLogger())
 
-	// first=0 → no rows fetched, but COUNT still runs.
+	// first=0 → no rows fetched, but the page method still runs once: assemblePage
+	// always calls the fetch closure, and findCatalogPage counts before its zero-page
+	// short-circuit, so the search-aware total survives a totalCount-only request.
 	out, err := uc.ListPublishedConnection(authedCtx("u1"), MasterCatalogConnectionInput{First: intPtr(0)})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -413,8 +392,8 @@ func TestListPublishedConnection_TotalCountOnlyRequest(t *testing.T) {
 	if out.TotalCount != 42 {
 		t.Fatalf("want TotalCount=42 even for empty page, got %d", out.TotalCount)
 	}
-	if len(repo.countCalls) != 1 {
-		t.Fatalf("want CountPublished invoked once, got %d", len(repo.countCalls))
+	if len(repo.findPageCalls) != 1 {
+		t.Fatalf("want FindPublishedPage invoked once, got %d", len(repo.findPageCalls))
 	}
 }
 
@@ -423,7 +402,7 @@ func TestListPublishedConnection_TotalCountOnlyRequest(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestListPublishedConnection_InvalidCursor(t *testing.T) {
-	repo := &mockMasterCatalogRepository{countResult: 0}
+	repo := &mockMasterCatalogRepository{findPageTotal: 0}
 	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, newTestAdminGate(true), newTestLogger())
 
 	bad := "%%%not-a-cursor"
@@ -445,7 +424,7 @@ func TestListPublishedConnection_CursorNotPublished(t *testing.T) {
 	// so the cursor is rejected as cursor-not-found (draft never leaks).
 	cur := cursor.Encode("draft-id")
 	repo := &mockMasterCatalogRepository{
-		countResult: 0,
+		findPageTotal: 0,
 		findByIDFn: func(_ string) (*domain.MasterCardgroup, error) {
 			return nil, repository.ErrNotFound
 		},
@@ -466,26 +445,18 @@ func TestListPublishedConnection_CursorNotPublished(t *testing.T) {
 // Repo error propagation
 // ---------------------------------------------------------------------------
 
-func TestListPublishedConnection_CountError_Wrapped(t *testing.T) {
-	repo := &mockMasterCatalogRepository{countErr: eris.New("db down")}
-	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, newTestAdminGate(true), newTestLogger())
-
-	_, err := uc.ListPublishedConnection(authedCtx("u1"), MasterCatalogConnectionInput{First: intPtr(2)})
-	if err == nil {
-		t.Fatal("want error from count failure")
-	}
-	if errors.Is(err, ucerr.ErrUnauthenticated) {
-		t.Fatal("count error must not surface as unauthenticated")
-	}
-}
-
 func TestListPublishedConnection_FindPageError_Wrapped(t *testing.T) {
-	repo := &mockMasterCatalogRepository{countResult: 1, findPageErr: eris.New("db down")}
+	repo := &mockMasterCatalogRepository{findPageTotal: 1, findPageErr: eris.New("db down")}
 	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, newTestAdminGate(true), newTestLogger())
 
 	_, err := uc.ListPublishedConnection(authedCtx("u1"), MasterCatalogConnectionInput{First: intPtr(2)})
 	if err == nil {
 		t.Fatal("want error from find-page failure")
+	}
+	// The page method now delivers both rows and total, so its failure is the only
+	// repo error path. It must not be misclassified as unauthenticated.
+	if errors.Is(err, ucerr.ErrUnauthenticated) {
+		t.Fatal("find-page error must not surface as unauthenticated")
 	}
 }
 
@@ -510,9 +481,6 @@ func TestListPublishedConnection_SearchNormalizedToNil(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if got := repo.countCalls[0].Search; got != nil {
-		t.Fatalf("whitespace-only search must normalize to nil for count, got %q", *got)
-	}
 	if got := repo.findPageCalls[0].Search; got != nil {
 		t.Fatalf("whitespace-only search must normalize to nil for page, got %q", *got)
 	}
@@ -530,9 +498,6 @@ func TestListPublishedConnection_SearchTrimmed(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
-	}
-	if got := repo.countCalls[0].Search; got == nil || *got != "hello" {
-		t.Fatalf("count search must be trimmed to %q, got %v", "hello", got)
 	}
 	if got := repo.findPageCalls[0].Search; got == nil || *got != "hello" {
 		t.Fatalf("page search must be trimmed to %q, got %v", "hello", got)
@@ -552,9 +517,6 @@ func TestListAdminConnection_SearchNormalizedToNil(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if got := repo.countAdminCalls[0].Search; got != nil {
-		t.Fatalf("whitespace-only search must normalize to nil for admin count, got %q", *got)
-	}
 	if got := repo.findAdminCalls[0].Search; got != nil {
 		t.Fatalf("whitespace-only search must normalize to nil for admin page, got %q", *got)
 	}
@@ -572,9 +534,6 @@ func TestListAdminConnection_SearchTrimmed(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
-	}
-	if got := repo.countAdminCalls[0].Search; got == nil || *got != "hello" {
-		t.Fatalf("admin count search must be trimmed to %q, got %v", "hello", got)
 	}
 	if got := repo.findAdminCalls[0].Search; got == nil || *got != "hello" {
 		t.Fatalf("admin page search must be trimmed to %q, got %v", "hello", got)
@@ -622,8 +581,8 @@ func TestListAdminConnection_CursorAcceptsDraftViaFindByID(t *testing.T) {
 	t.Parallel()
 	cur := cursor.Encode("draft-id")
 	repo := &mockMasterCatalogRepository{
-		countAdminRes: 1,
-		findAdminPage: []*repository.MasterCatalogItem{catalogItem("x", 1)},
+		findAdminTotal: 1,
+		findAdminPage:  []*repository.MasterCatalogItem{catalogItem("x", 1)},
 		// FindByID resolves the draft — the admin list includes DRAFT decks.
 		findByIDFn: func(id string) (*domain.MasterCardgroup, error) {
 			return &domain.MasterCardgroup{ID: id, Name: domain.CardgroupName("Draft"), Status: domain.MasterStatusDraft}, nil


### PR DESCRIPTION
## Summary

Aligns `master_catalog`'s `totalCount` with the same-filter inline-count pattern that `card_pagination.go` and `master_card.go` already follow: the repository page method runs its `COUNT(*)` on the **same filtered base query** and returns it, and the usecase captures that total inside the `assemblePage` fetch closure — instead of a standalone, filter-aware-but-separate `CountPublished` / `CountAdmin` call.

> **Not a bug fix.** The standalone count is currently correct (both receive the same normalized `search`). This is drift prevention per `.claude/rules/pagination.md`: a future second filter added to the page query but not to the count would compile cleanly and ship a lying `totalCount`. `master_catalog` was the lone deviation from the pattern.

> Last of the master-card DRY chain. The two predecessors are merged to `main` (#639 `listMasterCardsCore`, #640 `resolveSortDir`), so this PR now targets `main` directly and its diff is scoped to the `master_catalog` count change alone.

## What changed

- `findCatalogPage` now returns `([]*MasterCatalogItem, int64, error)`. The total is a `COUNT(*)` on the same filtered base (published-status filter when `publishedOnly` + `name ILIKE` search), run **before** the `first == 0 && last == 0` short-circuit (so a `totalCount`-only request still gets a real value). `FindPublishedPage` / `FindAdminPage` propagate the three values.
- The standalone `CountPublished` / `CountAdmin` methods are deleted — from the repository impl, the `repository.MasterCardgroupRepository` interface, and the usecase consumer port. (`CountCards` is unrelated and untouched; so is the user-role `CountAdmins`.)
- `ListPublishedConnection` / `ListAdminConnection` capture `total` inside the `assemblePage` closure (`var total int64; rows, t, e := …; total = t`), mirroring `card.go`.

## Test plan

- Repo tests: every `FindPublishedPage` / `FindAdminPage` call site updated to the 3-value form; the four standalone count tests converted to assert the **page method's returned total** (published-excludes-draft, admin-includes-draft = 2, literal-`%` ILIKE-escape = 1, admin search-filter = 1), renamed off the deleted method.
- Usecase tests: the manual mock returns the total from its page methods; the `CountPublished`/`CountAdmin` stubs and now-unused fields removed; the `TotalCountOnlyRequest` test asserts the **page** method is invoked once for a `first==0` request (proving the count-before-short-circuit path); the standalone count-error test folded into the page-error test with its not-unauthenticated regression guard preserved.
- `go build ./... && go vet ./...` clean; `go test ./internal/usecase/... ./internal/repository/...` green (testcontainers); `go tool go-arch-lint check` — OK.

Closes #627
