### PR TITLE
feat(frontend): center master-edit publish status below the deck title

### DIFF
--- a/frontend/__tests__/admin-master-cards.test.tsx
+++ b/frontend/__tests__/admin-master-cards.test.tsx
@@ -183,11 +183,12 @@ describe("MasterManagementClient — broad page integration", () => {
     // The seeded card's front text appears in the card list.
     expect(screen.getByText("apple")).toBeInTheDocument();
 
-    // The header renders the card count in both the mobile meta row (md:hidden)
-    // and the desktop meta row (hidden md:flex). In jsdom (no CSS) both render,
-    // so getAllByText returns two matches. With count=1 the ICU plural = "1 card".
+    // The header renders the card count once in the app-bar meta cluster (the
+    // publish-status indicator moved to the title-row status slot, so the count
+    // is no longer duplicated across responsive rows). With count=1 the ICU
+    // plural = "1 card".
     await waitFor(() => {
-      expect(screen.getAllByText("1 card")).toHaveLength(2);
+      expect(screen.getAllByText("1 card")).toHaveLength(1);
     });
   });
 
@@ -231,9 +232,9 @@ describe("MasterManagementClient — broad page integration", () => {
 
     renderClient([connMock, createMock]);
 
-    // Confirm initial count before mutation. Both responsive rows render in jsdom.
+    // Confirm initial count before mutation. The count renders once in the meta.
     await waitFor(() => {
-      expect(screen.getAllByText("1 card")).toHaveLength(2);
+      expect(screen.getAllByText("1 card")).toHaveLength(1);
     });
 
     // Open the add-card sheet via the toolbar "Add card" button.
@@ -253,9 +254,9 @@ describe("MasterManagementClient — broad page integration", () => {
     // After a successful create the cache is updated (+1 to totalCount). The new
     // totalCount flows from MasterCardsClient into the renderPageHeader render-prop,
     // which re-renders MasterEditHeader with count=2. The ICU plural for count=2
-    // resolves to "2 cards". Both responsive rows render in jsdom (no CSS).
+    // resolves to "2 cards", rendered once in the meta.
     await waitFor(() => {
-      expect(screen.getAllByText("2 cards")).toHaveLength(2);
+      expect(screen.getAllByText("2 cards")).toHaveLength(1);
     });
   });
 });

--- a/frontend/src/app/admin/masters/[id]/edit/master-edit-header.test.tsx
+++ b/frontend/src/app/admin/masters/[id]/edit/master-edit-header.test.tsx
@@ -97,6 +97,24 @@ describe("MasterEditHeader", () => {
     expect(screen.getAllByText("5 cards").length).toBeGreaterThan(0);
   });
 
+  it("renders the publish-status indicator below the deck title, not in the app-bar meta", () => {
+    const { container } = renderHeader({ status: "PUBLISHED" });
+    // The desktop status badge follows the deck title in document order, so it
+    // sits one tier below the title rather than beside the card count.
+    const ordered = Array.from(
+      container.querySelectorAll('h1, [data-testid="master-edit-status-badge"]'),
+    );
+    expect(ordered[0]?.tagName.toLowerCase()).toBe("h1");
+    expect(ordered[1]?.getAttribute("data-testid")).toBe("master-edit-status-badge");
+  });
+
+  it("renders the card count once now that status moved out of the meta cluster", () => {
+    renderHeader();
+    // The count is breakpoint-agnostic, so it renders a single time (previously
+    // it was duplicated across the mobile and desktop meta rows).
+    expect(screen.getAllByText("5 cards")).toHaveLength(1);
+  });
+
   it("disables publish and shows the hint for an empty draft", () => {
     renderHeader({ cardCount: 0 });
     expect(screen.getByTestId("master-edit-publish")).toBeDisabled();

--- a/frontend/src/app/admin/masters/[id]/edit/master-edit-header.tsx
+++ b/frontend/src/app/admin/masters/[id]/edit/master-edit-header.tsx
@@ -162,21 +162,28 @@ export function MasterEditHeader({ master, cardCount, onBatchImport }: Props) {
   const publishLabel = published ? t("unpublish") : t("publish");
   const statusLabel = published ? t("statusPublished") : t("statusDraft");
 
+  // App-bar meta: the muted card count only. The publish-status indicator moved
+  // out to the title-row `status` slot below, so the count is breakpoint-agnostic
+  // and renders once.
   const meta = (
+    <span className="text-sm text-muted-foreground">{t("cardCount", { count: cardCount })}</span>
+  );
+
+  // Status indicator centered directly below the deck title, reading as an
+  // attribute of it. Mobile gets the interactive chip (the only publish
+  // affordance there); desktop gets the read-only badge, since the publish
+  // action lives in the app-bar split button.
+  const status = (
     <>
-      {/* Mobile: muted count + interactive status chip (publish trigger),
-          centered in the app-bar row beside the count. */}
-      <div className="flex items-center justify-center gap-2 md:hidden">
-        <span className="text-sm text-muted-foreground">
-          {t("cardCount", { count: cardCount })}
-        </span>
+      {/* Mobile: interactive status chip doubles as the publish trigger. */}
+      <div className="md:hidden">
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <button
               type="button"
               data-testid="master-edit-status-chip"
               aria-label={t("changePublishState", { state: statusLabel })}
-              className="inline-flex items-center gap-1.5 rounded-full border px-3 py-0.5 text-sm font-medium hover:bg-accent"
+              className="inline-flex min-h-11 items-center gap-1.5 rounded-full border px-3 py-1.5 text-sm font-medium hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
             >
               <span
                 aria-hidden="true"
@@ -202,13 +209,13 @@ export function MasterEditHeader({ master, cardCount, onBatchImport }: Props) {
           </DropdownMenuContent>
         </DropdownMenu>
       </div>
-      {/* Desktop: muted count + display badge, centered in the app-bar row. */}
-      <div className="hidden items-center justify-center gap-2 md:flex">
-        <span className="text-sm text-muted-foreground">
-          {t("cardCount", { count: cardCount })}
-        </span>
-        <MasterStatusBadge published={published} data-testid="master-edit-status-badge" />
-      </div>
+      {/* Desktop: read-only display badge; the publish action lives in the
+          app-bar split button. */}
+      <MasterStatusBadge
+        published={published}
+        data-testid="master-edit-status-badge"
+        className="hidden md:inline-flex"
+      />
     </>
   );
 
@@ -309,6 +316,7 @@ export function MasterEditHeader({ master, cardCount, onBatchImport }: Props) {
         title={master.name}
         meta={meta}
         actions={actions}
+        status={status}
       >
         {emptyDraft ? (
           <p

--- a/frontend/src/components/nav/detail-page-header.test.tsx
+++ b/frontend/src/components/nav/detail-page-header.test.tsx
@@ -45,4 +45,26 @@ describe("DetailPageHeader", () => {
     expect(screen.queryByTestId("actions-slot")).toBeNull();
     expect(container.querySelector("h1")?.textContent).toBe("T");
   });
+
+  it("renders the status slot below the title (after it in document order)", () => {
+    const { container } = render(
+      <DetailPageHeader
+        backHref="/x"
+        backLabel="back"
+        title="Advanced Cards"
+        status={<span data-testid="status-slot">Published</span>}
+      />,
+    );
+    expect(screen.getByTestId("status-slot")).toBeInTheDocument();
+    // querySelectorAll returns matches in document order: the title precedes the
+    // status indicator, so the status renders one tier below the title.
+    const ordered = Array.from(container.querySelectorAll('h1, [data-testid="status-slot"]'));
+    expect(ordered[0]?.tagName.toLowerCase()).toBe("h1");
+    expect(ordered[1]?.getAttribute("data-testid")).toBe("status-slot");
+  });
+
+  it("omits the status wrapper when status is not provided", () => {
+    render(<DetailPageHeader backHref="/x" backLabel="back" title="T" />);
+    expect(screen.queryByTestId("status-slot")).toBeNull();
+  });
 });

--- a/frontend/src/components/nav/detail-page-header.tsx
+++ b/frontend/src/components/nav/detail-page-header.tsx
@@ -10,23 +10,28 @@ type DetailPageHeaderProps = {
   /** Accessible (sr-only) label for the back link, e.g. t("backToList"). */
   backLabel: string;
   title: string;
-  /** Status + count cluster centered in the app-bar row, between the back
-   *  affordance and the trailing actions. The page owns its md: reflow. */
+  /** Count cluster centered in the app-bar row, between the back affordance and
+   *  the trailing actions. The page owns its md: reflow. */
   meta?: ReactNode;
   /** Trailing action cluster on the app-bar row (right). The page owns its md: reflow. */
   actions?: ReactNode;
-  /** Optional note rendered below the title, e.g. an empty-draft publish hint. */
+  /** Optional status indicator (e.g. a publish-state chip/badge) centered
+   *  directly below the title, reading as an attribute of the title. Sits one
+   *  tier above `children`. The page owns its md: reflow. */
+  status?: ReactNode;
+  /** Optional note rendered below the status slot, e.g. an empty-draft publish hint. */
   children?: ReactNode;
 };
 
 /**
  * The shared detail-page header layout: an app-bar row carrying an inline back
- * affordance (left), a centered status/count meta cluster (center), and a
- * trailing action cluster (right); the page title sits centered on its own row
- * one tier below. The 1fr/auto/1fr app-bar grid keeps the meta cluster centered
- * regardless of the back/action cluster widths. Used by the master-edit header.
- * It owns layout only — the consumer composes its own meta/actions, including
- * responsive variants.
+ * affordance (left), a centered count meta cluster (center), and a trailing
+ * action cluster (right); the page title sits centered on its own row one tier
+ * below, with an optional status indicator centered directly beneath the title.
+ * The 1fr/auto/1fr app-bar grid keeps the meta cluster centered regardless of
+ * the back/action cluster widths. Used by the master-edit header. It owns layout
+ * only — the consumer composes its own meta/actions/status, including responsive
+ * variants.
  */
 export function DetailPageHeader({
   backHref,
@@ -34,6 +39,7 @@ export function DetailPageHeader({
   title,
   meta,
   actions,
+  status,
   children,
 }: DetailPageHeaderProps) {
   return (
@@ -52,10 +58,16 @@ export function DetailPageHeader({
         <div className="justify-self-center">{meta}</div>
         <div className="flex items-center justify-self-end">{actions}</div>
       </div>
-      {/* Title row — centered, one tier below the app-bar. */}
-      <div className="mt-1 flex items-center justify-center">
+      {/* Title row — centered. A wider gap above (mt-2) than the title→status gap
+          below (mt-1) sets the title+status pair apart from the app-bar so the
+          title heads its own group rather than binding to the utility row. */}
+      <div className="mt-2 flex items-center justify-center">
         <h1 className="min-w-0 truncate text-2xl font-semibold leading-tight">{title}</h1>
       </div>
+      {/* Status row — centered directly below the title with a tight mt-1
+          (title→status 4px < app-bar→title 8px) so it binds to the title and
+          reads as an attribute of it. */}
+      {status ? <div className="mt-1 flex items-center justify-center">{status}</div> : null}
       {children}
     </header>
   );


### PR DESCRIPTION
## Summary

On the admin master-deck edit header, the publish-status indicator (the "● Published / Draft" pill) moves out of the top app-bar meta cluster — where it sat beside the card count — to a centered position directly **below the deck title**, so it reads as an attribute of the title (title = identity, status = the deck's state). The shared `DetailPageHeader` gains an optional `status` slot, and the card count now renders once.

No tracked issue — this is a UI refinement of the master-edit header.

## Background / Motivation

- The publish-status pill shared the centered app-bar meta slot with the card count, so the deck's state read as a sibling of the count rather than an attribute of the deck name — a weaker hierarchy than the title+status stack used by comparable detail headers (GitHub repo name + Public/Private, Linear title + status).
- The card count was duplicated across two responsive meta rows (`md:hidden` mobile + `hidden md:flex` desktop) only because each row bundled a different status element, so it rendered twice in the DOM.
- A principal-UI-designer review of the move flagged three follow-throughs: an inverted title/status vertical rhythm, an undersized mobile chip tap target, and a missing focus ring on the chip (now the primary mobile publish affordance).

## Changes

### Shared `DetailPageHeader` status slot

- New optional `status?: ReactNode` prop rendered centered one tier below the title, above `children` (`detail-page-header.tsx`).
- Descending vertical rhythm: app-bar→title `mt-2` (8px) > title→status `mt-1` (4px), so the title+status pair groups and detaches from the utility bar. Neutral-to-positive for the two no-status consumers (`cardgroup-header`, `catalog-deck-header`), which only inherit the slightly wider app-bar→title gap.

### Master-edit header restructure

- `meta` is now the muted card count only — a single, breakpoint-agnostic span (no longer duplicated).
- `status` carries the publish indicator: the mobile interactive chip (the publish trigger) via `md:hidden`, and the desktop read-only `MasterStatusBadge` via `hidden md:inline-flex`. The publish action stays in the desktop split button.

### Accessibility (mobile chip)

- Tap target raised to `min-h-11` (44px) + `py-1.5`, keeping the rounded-full pill shape.
- Added the header's standard focus ring (`focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2`), matching the back link and the `Button` base.

### Tests

- New placement tests pin the status slot below the title (`detail-page-header.test.tsx`, `master-edit-header.test.tsx`).
- Broad `admin-master-cards.test.tsx` count assertions updated from `toHaveLength(2)` to `toHaveLength(1)` (the count renders once now), with refreshed comments.

## Verification (in worktree)

- `pnpm typecheck` — pass. `biome check --error-on-warnings` — clean. `pnpm knip` — clean. `pnpm build` — pass.
- `pnpm vitest run` — 1,644 tests pass.
- A 4-lens principal-UI-designer review (hierarchy/spacing, design-system, a11y/interaction, responsive/edge) returned `changes-requested` with 3 findings; all were fixed, and a confirmation pass returned APPROVE.

## Test plan

- [ ] On `/admin/masters/<id>/edit`, the "● Published / Draft" pill renders centered directly below the deck title, not beside the card count.
- [ ] The card count appears exactly once, in the app-bar meta row.
- [ ] Mobile: tapping the status pill opens the publish/unpublish menu; the pill is a comfortable touch target and shows a focus ring on keyboard focus.
- [ ] Desktop: the read-only status badge sits below the title; the publish action remains in the app-bar split button.
- [ ] Sibling detail headers (`/cardgroups/<id>`, `/catalog/<id>`) render with no visual regression.
