### PR TITLE
refactor(backend): hoist last-admin invariant into domain.IsLastAdmin

### DIFF
--- a/backend/internal/domain/role.go
+++ b/backend/internal/domain/role.go
@@ -24,3 +24,11 @@ func (r Role) IsSystem() bool {
 	_, ok := systemRoleNames[r.Name]
 	return ok
 }
+
+// IsLastAdmin reports whether adminCount represents the final admin in the
+// system. Deleting that account would leave the system with no admin, so callers
+// refuse the deletion. The threshold lives in the domain because it is an
+// availability invariant, not application plumbing.
+func IsLastAdmin(adminCount int64) bool {
+	return adminCount <= 1
+}

--- a/backend/internal/domain/role_test.go
+++ b/backend/internal/domain/role_test.go
@@ -52,3 +52,25 @@ func TestRoleIsSystem(t *testing.T) {
 		})
 	}
 }
+
+func TestIsLastAdmin(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		adminCount int64
+		want       bool
+	}{
+		{name: "no admins", adminCount: 0, want: true},
+		{name: "single admin", adminCount: 1, want: true},
+		{name: "two admins", adminCount: 2, want: false},
+		{name: "negative count clamps to last", adminCount: -1, want: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, IsLastAdmin(tc.adminCount))
+		})
+	}
+}

--- a/backend/internal/usecase/admin_user.go
+++ b/backend/internal/usecase/admin_user.go
@@ -453,7 +453,7 @@ func (u *adminUserUsecase) DeleteUser(ctx context.Context, id string) error {
 			}
 			return eris.Wrap(err, "usecase: admin user: delete: count admins")
 		}
-		if n <= 1 {
+		if domain.IsLastAdmin(n) {
 			return ucerr.NewForbiddenError("cannot delete the last admin account")
 		}
 	}

--- a/backend/internal/usecase/user.go
+++ b/backend/internal/usecase/user.go
@@ -206,7 +206,7 @@ func (u *userUsecase) DeleteMyAccount(ctx context.Context) error {
 			}
 			return eris.Wrap(err, "usecase: user: delete my account: count admins")
 		}
-		if n <= 1 {
+		if domain.IsLastAdmin(n) {
 			return ucerr.NewForbiddenError("cannot delete the last admin account; promote another admin first")
 		}
 	}


### PR DESCRIPTION
## Summary

The "system must always retain at least one admin" invariant was hand-coded twice with the bare `n <= 1` integer comparison — once in `usecase/admin_user.go` (`DeleteUser`) and once in `usecase/user.go` (`DeleteMyAccount`). The two blocks use different admin-detection methods (`userRoles.HasRole` vs `auth.IsAdmin`) and different user-facing messages, but the threshold rule itself (`adminCount <= 1` means "this is the last admin") is identical and had no single home in the domain layer.

This PR hoists the threshold into a package-level `domain.IsLastAdmin(adminCount int64) bool` so the availability invariant lives in one place. The two distinct error messages stay at their call sites — message wording is presentation/application, not a domain rule — and each site's admin-detection method is unchanged. **No behaviour change.**

## What changed

- `backend/internal/domain/role.go` — added `IsLastAdmin(adminCount int64) bool { return adminCount <= 1 }` with a doc comment framing it as an availability invariant.
- `backend/internal/usecase/admin_user.go` (`DeleteUser`) — inline `if n <= 1` replaced with `if domain.IsLastAdmin(n)`; message and `HasRole` detection unchanged.
- `backend/internal/usecase/user.go` (`DeleteMyAccount`) — inline `if n <= 1` replaced with `if domain.IsLastAdmin(n)`; message and `auth.IsAdmin` detection unchanged.
- `backend/internal/domain/role_test.go` — added a table-driven `TestIsLastAdmin` covering `0 → true`, `1 → true`, `2 → false`, and the negative-count edge `-1 → true` (documents the clamp posture).

## Test plan

- `go build ./...` and `go vet ./...` — clean.
- `go test ./internal/domain/... -run IsLastAdmin` — pass (4 sub-cases).
- `go test ./internal/usecase/... -run "DeleteUser|DeleteMyAccount"` — pass; the `last_admin_is_forbidden` cases for both `DeleteUser` and `DeleteMyAccount` exercise the new helper, and the existing guard outcomes are unchanged.
- Best-effort full `go test ./internal/...` — all packages green (incl. testcontainers-backed `repository` / `database` / `usecase`).

Closes #643
