### PR TITLE
refactor(backend): route card/master_card search filters through searchLikePattern

### DIFF
--- a/backend/internal/repository/card_pagination.go
+++ b/backend/internal/repository/card_pagination.go
@@ -75,10 +75,10 @@ func (r *cardRepo) FindPageByCardgroupForUser(
 	// Base query scoped to the cardgroup.
 	base := r.db.WithContext(ctx).Model(&gormCard{}).Where("cards.cardgroup_id = ?", cardgroupID)
 
-	// Non-nil search is guaranteed by the usecase to be non-empty and trimmed.
-	// escapeLikePattern guards against LIKE metacharacter injection.
-	if search != nil {
-		pattern := "%" + escapeLikePattern(*search) + "%"
+	// searchLikePattern trims, escapes LIKE metacharacters, and drops the
+	// predicate when search is nil or blank, keeping blank-search handling
+	// consistent across every paginated repository.
+	if pattern, ok := searchLikePattern(search); ok {
 		base = base.Where("(cards.front ILIKE ? OR cards.back ILIKE ?)", pattern, pattern)
 	}
 

--- a/backend/internal/repository/card_pagination_test.go
+++ b/backend/internal/repository/card_pagination_test.go
@@ -472,6 +472,32 @@ func TestCardRepo_FindPageByCardgroup_Search_WithAfter(t *testing.T) {
 	}
 }
 
+// TestCardRepo_FindPageByCardgroup_EmptySearchTreatedAsNil verifies that an
+// all-whitespace search has no effect — same as nil — because searchLikePattern
+// returns ok=false for trimmed-empty input. The whitespace term must NOT reach
+// SQL as "%   %" (which would filter out every card) and must NOT zero the page
+// or totalCount. Mirrors the cardgroup blank-search guard.
+func TestCardRepo_FindPageByCardgroup_EmptySearchTreatedAsNil(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	ownerID := insertAuthUser(t, ctx)
+	cg := insertCardgroup(t, ctx, ownerID)
+	repo := repository.NewCardRepository(testDB.GORM)
+
+	insertCards(t, ctx, repo, cg.ID, 3)
+
+	whitespace := "   "
+	got, total, err := repo.FindPageByCardgroup(
+		ctx, string(cg.ID), nil, nil, 100, 0,
+		repository.CardOrderByID, repository.SortAsc, &whitespace,
+	)
+	require.NoError(t, err)
+	require.Equal(t, int64(3), total,
+		"all-whitespace search must NOT filter totalCount (treated as no search)")
+	require.Len(t, got, 3,
+		"all-whitespace search must NOT filter the page (treated as no search)")
+}
+
 // sortByID returns a copy of cards sorted by ID ascending.
 func sortByID(cards []*domain.Card) []*domain.Card {
 	out := make([]*domain.Card, len(cards))

--- a/backend/internal/repository/master_card.go
+++ b/backend/internal/repository/master_card.go
@@ -183,12 +183,12 @@ func (r *masterCardRepo) FindPageByMasterCardgroup(
 	// Base query scoped to the master cardgroup.
 	base := r.db.WithContext(ctx).Model(&gormMasterCard{}).Where("master_cards.master_cardgroup_id = ?", masterCardgroupID)
 
-	// Non-nil search is guaranteed by the usecase to be non-empty and trimmed.
-	// escapeLikePattern guards against LIKE metacharacter injection. The front
-	// column is citext (case-insensitive); ILIKE on both columns keeps the
-	// front/back search consistently case-insensitive.
-	if search != nil {
-		pattern := "%" + escapeLikePattern(*search) + "%"
+	// searchLikePattern trims, escapes LIKE metacharacters, and drops the
+	// predicate when search is nil or blank, keeping blank-search handling
+	// consistent across every paginated repository. The front column is citext
+	// (case-insensitive); ILIKE on both columns keeps the front/back search
+	// consistently case-insensitive.
+	if pattern, ok := searchLikePattern(search); ok {
 		base = base.Where("(master_cards.front ILIKE ? OR master_cards.back ILIKE ?)", pattern, pattern)
 	}
 

--- a/backend/internal/repository/master_card_test.go
+++ b/backend/internal/repository/master_card_test.go
@@ -793,6 +793,33 @@ func TestMasterCardRepository_FindPageByMasterCardgroup_Search(t *testing.T) {
 	require.Equal(t, pctRow.ID, gotUnd[0].ID)
 }
 
+// TestMasterCardRepository_FindPageByMasterCardgroup_EmptySearchTreatedAsNil
+// verifies that an all-whitespace search has no effect — same as nil — because
+// searchLikePattern returns ok=false for trimmed-empty input. The whitespace
+// term must NOT reach SQL as "%   %" (which would filter out every master card)
+// and must NOT zero the page or totalCount. totalCount stays deterministic
+// because it is scoped to the freshly inserted master cardgroup. Mirrors the
+// cardgroup blank-search guard.
+func TestMasterCardRepository_FindPageByMasterCardgroup_EmptySearchTreatedAsNil(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	mcg := insertMCGForCardTest(t, ctx, "MCPage-EmptySearch-Group")
+	repo := repository.NewMasterCardRepository(testDB.GORM)
+
+	insertMasterCardsSeq(t, ctx, repo, mcg.ID, "MCPage-EmptySearch", 3)
+
+	whitespace := "   "
+	got, total, err := repo.FindPageByMasterCardgroup(
+		ctx, mcg.ID, nil, nil, 100, 0,
+		repository.MasterCardOrderByPosition, repository.SortAsc, &whitespace,
+	)
+	require.NoError(t, err)
+	require.Equal(t, int64(3), total,
+		"all-whitespace search must NOT filter totalCount (treated as no search)")
+	require.Len(t, got, 3,
+		"all-whitespace search must NOT filter the page (treated as no search)")
+}
+
 // TestMasterCardRepository_FindPageByMasterCardgroup_TotalCountScopedToGroup
 // verifies totalCount is scoped to the requested master cardgroup and does not
 // count rows in other groups (which other parallel tests may also be inserting).


### PR DESCRIPTION
## Summary

Routes the two remaining inline search-filter holdouts — `card_pagination.go` and `master_card.go` — through the shared `searchLikePattern(search *string) (string, bool)` helper in `pagination.go`. This is the intended follow-up to the cursor-helper consolidation, which deliberately left these two sites inline because they then carried a different contract ("usecase-guaranteed non-empty, no trim"). Now that the helper owns the trim + empty-guard, both sites route through it, so all five paginated repositories (`card`, `cardgroup`, `master_catalog`, `master_card`, `user`) share one blank/whitespace-search path.

> **Deliberate behaviour change (not a pure no-op).** Before this PR, a whitespace-only `search = "   "` reached SQL as `%   %` in the two holdouts and filtered out every card / master card, while the other three repos already dropped it via the helper. Routing the holdouts through `searchLikePattern` makes a whitespace-only term treated as "no search" consistently across all five repositories — the page and `totalCount` are no longer zeroed by a blank search.

## What changed

- **`internal/repository/card_pagination.go`** — `FindPageByCardgroupForUser`'s inline `if search != nil { pattern := "%" + escapeLikePattern(*search) + "%"; … }` replaced with `if pattern, ok := searchLikePattern(search); ok { … }`. The redundant "Non-nil search is guaranteed by the usecase to be non-empty and trimmed" comment is removed (the repository now enforces the guard itself). `FindPageByCardgroup` delegates to this method, so its search path is covered too.
- **`internal/repository/master_card.go`** — `FindPageByMasterCardgroup`'s identical inline block replaced with the same helper call; the redundant guarantee comment removed. The citext / case-insensitivity note on the `ILIKE` columns is preserved.
- **`internal/repository/card_pagination_test.go`** — added `TestCardRepo_FindPageByCardgroup_EmptySearchTreatedAsNil`: a `search = "   "` against an isolated cardgroup must NOT filter the page or `totalCount` (asserts both stay 3). Mirrors the cardgroup blank-search guard.
- **`internal/repository/master_card_test.go`** — added `TestMasterCardRepository_FindPageByMasterCardgroup_EmptySearchTreatedAsNil`: same symmetric guard for master cards (page + `totalCount` stay 3 under a whitespace-only search).

## Test plan

- `go build ./... && go vet ./...` — pass (hard gate).
- `go tool go-arch-lint check --project-path .` — OK, no warnings.
- `go test ./internal/repository/... -run "Search|Blank|EmptySearch|Pagination|FindPageByCardgroup|FindPageByMasterCardgroup"` — green against testcontainers Postgres; the two new `EmptySearchTreatedAsNil` tests pass alongside the existing cardgroup blank-search guards.
- Backend CI runs the full suite on this PR.

Closes #645
