### PR TITLE
refactor(backend): extract resolver loader-guard / outcome-variant / cardCount helpers

### DIFF
--- a/backend/graph/resolver/admin.resolvers.go
+++ b/backend/graph/resolver/admin.resolvers.go
@@ -8,14 +8,10 @@ package resolver
 import (
 	"backend/graph/model"
 	"backend/internal/gqlerr"
-	"backend/internal/loader"
 	"backend/internal/usecase"
 	"context"
-	"errors"
 	"fmt"
 	"time"
-
-	"github.com/rotisserie/eris"
 )
 
 // AdminEditUser is the resolver for the adminEditUser field.
@@ -43,8 +39,7 @@ func (r *mutationResolver) AdminEditUser(ctx context.Context, id string, input m
 		}, nil
 	}
 	if outcome.User == nil {
-		return nil, gqlerr.Internal(ctx,
-			eris.New("resolver: AdminEditUserOutcome has no variant set"))
+		return nil, noVariantSet(ctx, "AdminEditUserOutcome")
 	}
 	return model.AdminEditUserSuccess{User: toUserModel(outcome.User)}, nil
 }
@@ -64,8 +59,7 @@ func (r *mutationResolver) CreateRole(ctx context.Context, name string) (model.C
 		return toInputValidationError(outcome.Validation), nil
 	}
 	if outcome.Role == nil {
-		return nil, gqlerr.Internal(ctx,
-			eris.New("resolver: CreateRoleOutcome has no variant set"))
+		return nil, noVariantSet(ctx, "CreateRoleOutcome")
 	}
 	return model.CreateRoleSuccess{Role: toRoleModel(outcome.Role)}, nil
 }
@@ -89,8 +83,7 @@ func (r *mutationResolver) UpdateRole(ctx context.Context, id string, name strin
 		}, nil
 	}
 	if outcome.Role == nil {
-		return nil, gqlerr.Internal(ctx,
-			eris.New("resolver: UpdateRoleOutcome has no variant set"))
+		return nil, noVariantSet(ctx, "UpdateRoleOutcome")
 	}
 	return model.UpdateRoleSuccess{Role: toRoleModel(outcome.Role)}, nil
 }
@@ -163,16 +156,13 @@ func (r *userResolver) Roles(ctx context.Context, obj *model.User) ([]*model.Rol
 // LastSignInByUserID DataLoader (batched, so the admin user list issues one
 // auth.users read per page). A nil result means the user has never signed in.
 func (r *userResolver) LastSignInAt(ctx context.Context, obj *model.User) (*time.Time, error) {
-	loaders := loader.For(ctx)
-	if loaders == nil {
-		return nil, gqlerr.Internal(ctx, eris.New("loader: middleware not installed for /query"))
+	loaders, gqlErr := loadersOrInternal(ctx)
+	if gqlErr != nil {
+		return nil, gqlErr
 	}
 	t, err := loaders.LastSignInByUserID.Load(ctx, obj.ID)()
 	if err != nil {
-		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-			return nil, gqlerr.Cancelled(ctx, err)
-		}
-		return nil, gqlerr.Internal(ctx, eris.Wrap(err, "resolver: last sign in"))
+		return nil, classifyLoaderErr(ctx, err, "resolver: last sign in")
 	}
 	return t, nil
 }

--- a/backend/graph/resolver/card.resolvers.go
+++ b/backend/graph/resolver/card.resolvers.go
@@ -20,13 +20,13 @@ import (
 
 // Cardgroup is the resolver for the cardgroup field.
 func (r *cardResolver) Cardgroup(ctx context.Context, obj *model.Card) (*model.Cardgroup, error) {
-	loaders := loader.For(ctx)
-	if loaders == nil {
-		return nil, gqlerr.Internal(ctx, eris.New("loader: middleware not installed for /query"))
+	loaders, gqlErr := loadersOrInternal(ctx)
+	if gqlErr != nil {
+		return nil, gqlErr
 	}
 	cg, err := loaders.Cardgroup.Load(ctx, obj.CardgroupID)()
 	if err != nil {
-		return nil, gqlerr.Internal(ctx, err)
+		return nil, classifyLoaderErr(ctx, err, "resolver: cardgroup")
 	}
 	return toCardgroupModel(cg), nil
 }
@@ -43,7 +43,7 @@ func (r *cardResolver) UserCardState(ctx context.Context, obj *model.Card) (*mod
 	}
 	ucs, err := loaders.UserCardFSRS.Load(ctx, obj.ID)()
 	if err != nil {
-		return nil, gqlerr.Internal(ctx, err)
+		return nil, classifyLoaderErr(ctx, err, "resolver: user card state")
 	}
 	// The "missing FSRS record means a brand-new card with default state"
 	// decision is an application policy; delegate it to LearnUC instead of
@@ -93,8 +93,7 @@ func (r *mutationResolver) CreateCard(ctx context.Context, input model.NewCardIn
 		}, nil
 	}
 	if outcome.Card == nil {
-		return nil, gqlerr.Internal(ctx,
-			eris.New("resolver: CreateCardOutcome has no variant set"))
+		return nil, noVariantSet(ctx, "CreateCardOutcome")
 	}
 	return model.CreateCardSuccess{Card: toCardModel(outcome.Card)}, nil
 }
@@ -117,8 +116,7 @@ func (r *mutationResolver) UpdateCard(ctx context.Context, id string, input mode
 		return toInputValidationError(outcome.Validation), nil
 	}
 	if outcome.Card == nil {
-		return nil, gqlerr.Internal(ctx,
-			eris.New("resolver: UpdateCardOutcome has no variant set"))
+		return nil, noVariantSet(ctx, "UpdateCardOutcome")
 	}
 	return model.UpdateCardSuccess{Card: toCardModel(outcome.Card)}, nil
 }

--- a/backend/graph/resolver/cardgroup.resolvers.go
+++ b/backend/graph/resolver/cardgroup.resolvers.go
@@ -9,22 +9,19 @@ import (
 	"backend/graph/generated"
 	"backend/graph/model"
 	"backend/internal/gqlerr"
-	"backend/internal/loader"
 	"backend/internal/usecase"
 	"context"
-
-	"github.com/rotisserie/eris"
 )
 
 // Owner is the resolver for the owner field.
 func (r *cardgroupResolver) Owner(ctx context.Context, obj *model.Cardgroup) (*model.User, error) {
-	loaders := loader.For(ctx)
-	if loaders == nil {
-		return nil, gqlerr.Internal(ctx, eris.New("loader: middleware not installed for /query"))
+	loaders, gqlErr := loadersOrInternal(ctx)
+	if gqlErr != nil {
+		return nil, gqlErr
 	}
 	user, err := loaders.User.Load(ctx, obj.OwnerID)()
 	if err != nil {
-		return nil, gqlerr.Internal(ctx, err)
+		return nil, classifyLoaderErr(ctx, err, "resolver: owner")
 	}
 	return toUserModel(user), nil
 }
@@ -53,8 +50,7 @@ func (r *mutationResolver) CreateCardgroup(ctx context.Context, input model.NewC
 		}, nil
 	}
 	if outcome.Cardgroup == nil {
-		return nil, gqlerr.Internal(ctx,
-			eris.New("resolver: CreateCardgroupOutcome has no variant set"))
+		return nil, noVariantSet(ctx, "CreateCardgroupOutcome")
 	}
 	return model.CreateCardgroupSuccess{Cardgroup: toCardgroupModel(outcome.Cardgroup)}, nil
 }
@@ -74,8 +70,7 @@ func (r *mutationResolver) UpdateCardgroup(ctx context.Context, id string, input
 		return toInputValidationError(outcome.Validation), nil
 	}
 	if outcome.Cardgroup == nil {
-		return nil, gqlerr.Internal(ctx,
-			eris.New("resolver: UpdateCardgroupOutcome has no variant set"))
+		return nil, noVariantSet(ctx, "UpdateCardgroupOutcome")
 	}
 	return model.UpdateCardgroupSuccess{Cardgroup: toCardgroupModel(outcome.Cardgroup)}, nil
 }

--- a/backend/graph/resolver/cardgroup_owner_resolver_test.go
+++ b/backend/graph/resolver/cardgroup_owner_resolver_test.go
@@ -1,0 +1,72 @@
+package resolver_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/graph-gophers/dataloader/v7"
+
+	"backend/graph/model"
+	"backend/graph/resolver"
+	"backend/internal/domain"
+	"backend/internal/gqlerr"
+	"backend/internal/loader"
+)
+
+// ctxWithUserLoaderError installs a User loader whose batch function fails every
+// key with loadErr.
+func ctxWithUserLoaderError(base context.Context, loadErr error) context.Context {
+	loaders := &loader.Loaders{
+		User: dataloader.NewBatchedLoader(
+			func(_ context.Context, keys []string) []*dataloader.Result[*domain.User] {
+				out := make([]*dataloader.Result[*domain.User], len(keys))
+				for i := range keys {
+					out[i] = &dataloader.Result[*domain.User]{Error: loadErr}
+				}
+				return out
+			},
+		),
+	}
+	return loader.WithContext(base, loaders)
+}
+
+// TestCardgroupResolver_Owner_MissingLoaderMiddlewareInternal asserts the
+// nil-registry guard (now centralized in loadersOrInternal) still maps to
+// INTERNAL.
+func TestCardgroupResolver_Owner_MissingLoaderMiddlewareInternal(t *testing.T) {
+	t.Parallel()
+
+	_, err := (&resolver.Resolver{}).Cardgroup().Owner(context.Background(), &model.Cardgroup{OwnerID: "u-1"})
+	if err == nil {
+		t.Fatal("want error when loader middleware is not installed, got nil")
+	}
+	if !gqlerr.IsCode(err, gqlerr.CodeInternal) {
+		t.Fatalf("want INTERNAL wire code, got %v", err)
+	}
+}
+
+// TestCardgroupResolver_Owner_ContextCancelledReturnsCancelled pins the
+// deliberate drift fix: a cancelled context mid-DataLoader now maps to
+// CANCELLED (previously this site collapsed straight to INTERNAL).
+func TestCardgroupResolver_Owner_ContextCancelledReturnsCancelled(t *testing.T) {
+	t.Parallel()
+
+	ctx := ctxWithUserLoaderError(context.Background(), context.Canceled)
+	_, err := (&resolver.Resolver{}).Cardgroup().Owner(ctx, &model.Cardgroup{OwnerID: "u-1"})
+	if !gqlerr.IsCode(err, gqlerr.CodeCancelled) {
+		t.Fatalf("want CANCELLED wire code for context.Canceled loader error, got %v", err)
+	}
+}
+
+// TestCardgroupResolver_Owner_GenericLoaderErrorReturnsInternal verifies that a
+// generic loader error still maps to INTERNAL.
+func TestCardgroupResolver_Owner_GenericLoaderErrorReturnsInternal(t *testing.T) {
+	t.Parallel()
+
+	ctx := ctxWithUserLoaderError(context.Background(), errors.New("db down"))
+	_, err := (&resolver.Resolver{}).Cardgroup().Owner(ctx, &model.Cardgroup{OwnerID: "u-1"})
+	if !gqlerr.IsCode(err, gqlerr.CodeInternal) {
+		t.Fatalf("want INTERNAL wire code for a generic loader error, got %v", err)
+	}
+}

--- a/backend/graph/resolver/helpers.go
+++ b/backend/graph/resolver/helpers.go
@@ -1,4 +1,41 @@
 package resolver
 
+import (
+	"context"
+	"errors"
+
+	"github.com/rotisserie/eris"
+	"github.com/vektah/gqlparser/v2/gqlerror"
+
+	"backend/internal/gqlerr"
+	"backend/internal/loader"
+)
+
 // Keep this file as a small landing zone for resolver-local helpers that do
 // not belong to mapper.go, connection.go, or validation.go.
+
+// loadersOrInternal returns the per-request DataLoader registry, or an
+// INTERNAL wire error when the loader middleware is not installed.
+func loadersOrInternal(ctx context.Context) (*loader.Loaders, *gqlerror.Error) {
+	loaders := loader.For(ctx)
+	if loaders == nil {
+		return nil, gqlerr.Internal(ctx, eris.New("loader: middleware not installed for /query"))
+	}
+	return loaders, nil
+}
+
+// classifyLoaderErr maps a DataLoader Load error to the wire form: CANCELLED for
+// a cancelled/deadline-exceeded context, INTERNAL (wrapped with label) otherwise.
+func classifyLoaderErr(ctx context.Context, err error, label string) *gqlerror.Error {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return gqlerr.Cancelled(ctx, err)
+	}
+	return gqlerr.Internal(ctx, eris.Wrap(err, label))
+}
+
+// noVariantSet builds the INTERNAL error returned when an outcome union has no
+// variant set — a programming error: the usecase returned a struct with every
+// field nil.
+func noVariantSet(ctx context.Context, name string) *gqlerror.Error {
+	return gqlerr.Internal(ctx, eris.New("resolver: "+name+" has no variant set"))
+}

--- a/backend/graph/resolver/helpers_test.go
+++ b/backend/graph/resolver/helpers_test.go
@@ -1,15 +1,21 @@
 package resolver
 
 import (
+	"bytes"
 	"context"
+	"errors"
+	"log/slog"
 	"strings"
 	"testing"
 
+	"github.com/rotisserie/eris"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"backend/graph/model"
 	"backend/internal/domain"
+	"backend/internal/gqlerr"
+	"backend/internal/loader"
 	"backend/internal/usecase"
 )
 
@@ -282,4 +288,107 @@ func TestToMasterCardConnectionModel_FiltersNilNodes(t *testing.T) {
 	assert.NotNil(t, conn.Edges[0].Node, "edge.Node must be non-nil to satisfy MasterCardEdge schema constraint")
 	assert.Equal(t, "mc1", conn.Edges[0].Node.ID)
 	assert.Equal(t, 1, conn.TotalCount, "TotalCount should pass through from output")
+}
+
+// ---------------------------------------------------------------------------
+// loadersOrInternal — DataLoader registry nil-guard
+// ---------------------------------------------------------------------------
+
+// TestLoadersOrInternal_MissingMiddlewareReturnsInternal verifies that a context
+// without an installed loader registry yields a non-nil INTERNAL wire error and
+// a nil registry.
+func TestLoadersOrInternal_MissingMiddlewareReturnsInternal(t *testing.T) {
+	t.Parallel()
+
+	loaders, gqlErr := loadersOrInternal(context.Background())
+
+	assert.Nil(t, loaders, "registry must be nil when middleware is not installed")
+	require.NotNil(t, gqlErr, "want non-nil error when middleware is not installed")
+	assert.True(t, gqlerr.IsCode(gqlErr, gqlerr.CodeInternal),
+		"want INTERNAL wire code, got %v", gqlErr)
+}
+
+// TestLoadersOrInternal_InstalledReturnsRegistry verifies that an installed
+// loader registry is returned with a nil error.
+func TestLoadersOrInternal_InstalledReturnsRegistry(t *testing.T) {
+	t.Parallel()
+
+	want := &loader.Loaders{}
+	ctx := loader.WithContext(context.Background(), want)
+
+	loaders, gqlErr := loadersOrInternal(ctx)
+
+	assert.Nil(t, gqlErr, "want nil error when middleware is installed")
+	assert.Same(t, want, loaders, "want the installed registry returned unchanged")
+}
+
+// ---------------------------------------------------------------------------
+// classifyLoaderErr — CANCELLED vs INTERNAL ladder
+// ---------------------------------------------------------------------------
+
+// TestClassifyLoaderErr_CancelledContexts verifies that a cancelled or
+// deadline-exceeded context maps to the CANCELLED wire code.
+func TestClassifyLoaderErr_CancelledContexts(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		err  error
+	}{
+		{"context.Canceled", context.Canceled},
+		{"context.DeadlineExceeded", context.DeadlineExceeded},
+		{"wrapped context.Canceled", eris.Wrap(context.Canceled, "loader: batch")},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := classifyLoaderErr(context.Background(), tc.err, "resolver: test")
+			require.NotNil(t, got)
+			assert.True(t, gqlerr.IsCode(got, gqlerr.CodeCancelled),
+				"want CANCELLED wire code for %s, got %v", tc.name, got)
+		})
+	}
+}
+
+// TestClassifyLoaderErr_GenericErrorIsInternalWithLabel verifies that a generic
+// loader error maps to INTERNAL and that the supplied label travels in the
+// logged error_chain (the wire message itself is redacted).
+func TestClassifyLoaderErr_GenericErrorIsInternalWithLabel(t *testing.T) {
+	// Not parallel: mutates the global slog default.
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, nil)))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	const label = "resolver: owner"
+	got := classifyLoaderErr(context.Background(), errors.New("db down"), label)
+
+	require.NotNil(t, got)
+	assert.True(t, gqlerr.IsCode(got, gqlerr.CodeInternal),
+		"want INTERNAL wire code for a generic loader error, got %v", got)
+	assert.Contains(t, buf.String(), label,
+		"expected the wrap label to appear in the logged error_chain, got %q", buf.String())
+}
+
+// ---------------------------------------------------------------------------
+// noVariantSet — outcome-union "no variant" internal guard
+// ---------------------------------------------------------------------------
+
+// TestNoVariantSet_MessageAndCode verifies that noVariantSet emits the exact
+// "resolver: <name> has no variant set" message in the logged chain and an
+// INTERNAL wire code.
+func TestNoVariantSet_MessageAndCode(t *testing.T) {
+	// Not parallel: mutates the global slog default.
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, nil)))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	got := noVariantSet(context.Background(), "CreateCardOutcome")
+
+	require.NotNil(t, got)
+	assert.True(t, gqlerr.IsCode(got, gqlerr.CodeInternal),
+		"want INTERNAL wire code, got %v", got)
+	assert.Contains(t, buf.String(), "resolver: CreateCardOutcome has no variant set",
+		"expected the exact no-variant message in the logged error_chain, got %q", buf.String())
 }

--- a/backend/graph/resolver/last_viewed_cardgroup.resolvers.go
+++ b/backend/graph/resolver/last_viewed_cardgroup.resolvers.go
@@ -8,12 +8,9 @@ package resolver
 import (
 	"backend/graph/model"
 	"backend/internal/gqlerr"
-	"backend/internal/loader"
 	"backend/internal/repository"
 	"context"
 	"errors"
-
-	"github.com/rotisserie/eris"
 )
 
 // SetLastViewedCardgroup is the resolver for the setLastViewedCardgroup field.
@@ -32,8 +29,7 @@ func (r *mutationResolver) SetLastViewedCardgroup(ctx context.Context, cardgroup
 		return toInputValidationError(outcome.Validation), nil
 	}
 	if outcome.User == nil {
-		return nil, gqlerr.Internal(ctx,
-			eris.New("resolver: SetLastViewedCardgroupOutcome has no variant set"))
+		return nil, noVariantSet(ctx, "SetLastViewedCardgroupOutcome")
 	}
 	return model.SetLastViewedCardgroupSuccess{User: toUserModel(outcome.User)}, nil
 }
@@ -42,17 +38,14 @@ func (r *mutationResolver) SetLastViewedCardgroup(ctx context.Context, cardgroup
 // (batched by user_id) then CardgroupLoader (batched by cardgroup_id),
 // preventing N+1 queries across both layers.
 func (r *userResolver) LastViewedCardgroup(ctx context.Context, obj *model.User) (*model.Cardgroup, error) {
-	loaders := loader.For(ctx)
-	if loaders == nil {
-		return nil, gqlerr.Internal(ctx, eris.New("loader: middleware not installed for /query"))
+	loaders, gqlErr := loadersOrInternal(ctx)
+	if gqlErr != nil {
+		return nil, gqlErr
 	}
 
 	pref, err := loaders.UserPreference.Load(ctx, obj.ID)()
 	if err != nil {
-		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-			return nil, gqlerr.Cancelled(ctx, err)
-		}
-		return nil, gqlerr.Internal(ctx, eris.Wrap(err, "resolver: user preference"))
+		return nil, classifyLoaderErr(ctx, err, "resolver: user preference")
 	}
 	if pref == nil || pref.LastViewedCardgroupID == nil {
 		return nil, nil
@@ -63,10 +56,7 @@ func (r *userResolver) LastViewedCardgroup(ctx context.Context, obj *model.User)
 		if errors.Is(err, repository.ErrNotFound) {
 			return nil, nil
 		}
-		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-			return nil, gqlerr.Cancelled(ctx, err)
-		}
-		return nil, gqlerr.Internal(ctx, eris.Wrap(err, "resolver: cardgroup"))
+		return nil, classifyLoaderErr(ctx, err, "resolver: cardgroup")
 	}
 	return toCardgroupModel(cg), nil
 }

--- a/backend/graph/resolver/learn_display_mode.resolvers.go
+++ b/backend/graph/resolver/learn_display_mode.resolvers.go
@@ -9,9 +9,7 @@ import (
 	"backend/graph/model"
 	"backend/internal/domain"
 	"backend/internal/gqlerr"
-	"backend/internal/loader"
 	"context"
-	"errors"
 
 	"github.com/rotisserie/eris"
 )
@@ -36,17 +34,14 @@ func (r *mutationResolver) UpdateLearnDisplayMode(ctx context.Context, mode mode
 
 // LearnDisplayMode is the resolver for the learnDisplayMode field.
 func (r *userResolver) LearnDisplayMode(ctx context.Context, obj *model.User) (model.LearnDisplayMode, error) {
-	loaders := loader.For(ctx)
-	if loaders == nil {
-		return "", gqlerr.Internal(ctx, eris.New("loader: middleware not installed for /query"))
+	loaders, gqlErr := loadersOrInternal(ctx)
+	if gqlErr != nil {
+		return "", gqlErr
 	}
 
 	pref, err := loaders.UserPreference.Load(ctx, obj.ID)()
 	if err != nil {
-		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-			return "", gqlerr.Cancelled(ctx, err)
-		}
-		return "", gqlerr.Internal(ctx, eris.Wrap(err, "resolver: user preference"))
+		return "", classifyLoaderErr(ctx, err, "resolver: user preference")
 	}
 	mode := domain.DefaultLearnDisplayMode
 	if pref != nil {

--- a/backend/graph/resolver/mapper.go
+++ b/backend/graph/resolver/mapper.go
@@ -56,6 +56,10 @@ func toMasterCardgroupModel(item *repository.MasterCatalogItem) *model.MasterCar
 	return toMasterCardgroupModelFromParts(item.Cardgroup, int(item.CardCount))
 }
 
+// cardCountResolvedElsewhere marks a single-deck mapping whose card count is
+// served by masterCardsConnection.totalCount, not this response.
+const cardCountResolvedElsewhere = 0
+
 // toMasterCardgroupModelFromParts maps a domain master cardgroup plus a known
 // card count to the generated model. Shared by the catalog list path and the
 // admin single-entity mutation responses.

--- a/backend/graph/resolver/master_card.resolvers.go
+++ b/backend/graph/resolver/master_card.resolvers.go
@@ -10,8 +10,6 @@ import (
 	"backend/internal/gqlerr"
 	"backend/internal/usecase"
 	"context"
-
-	"github.com/rotisserie/eris"
 )
 
 // AdminCreateMasterCard is the resolver for the adminCreateMasterCard field.
@@ -37,8 +35,7 @@ func (r *mutationResolver) AdminCreateMasterCard(ctx context.Context, input mode
 		}, nil
 	}
 	if outcome.Card == nil {
-		return nil, gqlerr.Internal(ctx,
-			eris.New("resolver: CreateMasterCardOutcome has no variant set"))
+		return nil, noVariantSet(ctx, "CreateMasterCardOutcome")
 	}
 	return model.CreateMasterCardSuccess{MasterCard: toMasterCardModel(outcome.Card)}, nil
 }
@@ -63,8 +60,7 @@ func (r *mutationResolver) AdminUpdateMasterCard(ctx context.Context, id string,
 		return toInputValidationError(outcome.Validation), nil
 	}
 	if outcome.Card == nil {
-		return nil, gqlerr.Internal(ctx,
-			eris.New("resolver: UpdateMasterCardOutcome has no variant set"))
+		return nil, noVariantSet(ctx, "UpdateMasterCardOutcome")
 	}
 	return model.UpdateMasterCardSuccess{MasterCard: toMasterCardModel(outcome.Card)}, nil
 }
@@ -157,5 +153,5 @@ func (r *queryResolver) MasterCardgroup(ctx context.Context, id string) (*model.
 		return nil, nil
 	}
 	// cardCount=0 here; the frontend reads the live count from masterCardsConnection.totalCount.
-	return toMasterCardgroupModelFromParts(deck, 0), nil
+	return toMasterCardgroupModelFromParts(deck, cardCountResolvedElsewhere), nil
 }

--- a/backend/graph/resolver/master_catalog.resolvers.go
+++ b/backend/graph/resolver/master_catalog.resolvers.go
@@ -39,9 +39,9 @@ func (r *mutationResolver) AdminCreateMasterCardgroup(ctx context.Context, input
 		return toInputValidationError(out.Validation), nil
 	}
 	if out.Master == nil {
-		return nil, gqlerr.Internal(ctx, eris.New("resolver: CreateMasterOutcome has no variant set"))
+		return nil, noVariantSet(ctx, "CreateMasterOutcome")
 	}
-	return model.CreateMasterCardgroupSuccess{Master: toMasterCardgroupModelFromParts(out.Master, 0)}, nil
+	return model.CreateMasterCardgroupSuccess{Master: toMasterCardgroupModelFromParts(out.Master, cardCountResolvedElsewhere)}, nil
 }
 
 // AdminUpdateMasterCardgroup is the resolver for the adminUpdateMasterCardgroup field.
@@ -69,7 +69,7 @@ func (r *mutationResolver) AdminUpdateMasterCardgroup(ctx context.Context, id st
 		return toInputValidationError(out.Validation), nil
 	}
 	if out.Master == nil {
-		return nil, gqlerr.Internal(ctx, eris.New("resolver: UpdateMasterOutcome has no variant set"))
+		return nil, noVariantSet(ctx, "UpdateMasterOutcome")
 	}
 	return model.UpdateMasterCardgroupSuccess{Master: toMasterCardgroupModelFromParts(out.Master, int(out.CardCount))}, nil
 }
@@ -89,7 +89,7 @@ func (r *mutationResolver) AdminPublishMasterCardgroup(ctx context.Context, id s
 		return model.MasterCardgroupEmptyError{Message: "master cardgroup has no cards and cannot be published"}, nil
 	}
 	if out.Master == nil {
-		return nil, gqlerr.Internal(ctx, eris.New("resolver: PublishMasterOutcome has no variant set"))
+		return nil, noVariantSet(ctx, "PublishMasterOutcome")
 	}
 	return model.PublishMasterCardgroupSuccess{Master: toMasterCardgroupModelFromParts(out.Master, int(out.CardCount))}, nil
 }
@@ -131,8 +131,7 @@ func (r *mutationResolver) ImportMasterCardgroup(ctx context.Context, masterCard
 		}, nil
 	}
 	if outcome.Cardgroup == nil {
-		return nil, gqlerr.Internal(ctx,
-			eris.New("resolver: ImportMasterOutcome has no variant set"))
+		return nil, noVariantSet(ctx, "ImportMasterOutcome")
 	}
 	return model.ImportMasterCardgroupSuccess{
 		Cardgroup: toCardgroupModel(outcome.Cardgroup),

--- a/backend/graph/resolver/swipe.resolvers.go
+++ b/backend/graph/resolver/swipe.resolvers.go
@@ -11,8 +11,6 @@ import (
 	"backend/internal/gqlerr"
 	"backend/internal/usecase"
 	"context"
-
-	"github.com/rotisserie/eris"
 )
 
 // HandleSwipe is the resolver for the handleSwipe field.
@@ -34,8 +32,7 @@ func (r *mutationResolver) HandleSwipe(ctx context.Context, input model.HandleSw
 		return toInputValidationError(outcome.Validation), nil
 	}
 	if outcome.Swipe == nil {
-		return nil, gqlerr.Internal(ctx,
-			eris.New("resolver: HandleSwipeOutcome has no variant set"))
+		return nil, noVariantSet(ctx, "HandleSwipeOutcome")
 	}
 	return model.HandleSwipeSuccess{Response: toSwipeResponseModel(outcome.Swipe)}, nil
 }

--- a/backend/graph/resolver/user.resolvers.go
+++ b/backend/graph/resolver/user.resolvers.go
@@ -11,8 +11,6 @@ import (
 	"backend/internal/gqlerr"
 	"backend/internal/usecase"
 	"context"
-
-	"github.com/rotisserie/eris"
 )
 
 // UpdateProfile is the resolver for the updateProfile field.
@@ -33,8 +31,7 @@ func (r *mutationResolver) UpdateProfile(ctx context.Context, input model.Update
 		return toInputValidationError(outcome.Validation), nil
 	}
 	if outcome.User == nil {
-		return nil, gqlerr.Internal(ctx,
-			eris.New("resolver: UpdateProfileOutcome has no variant set"))
+		return nil, noVariantSet(ctx, "UpdateProfileOutcome")
 	}
 	return model.UpdateProfileSuccess{User: toUserModel(outcome.User)}, nil
 }


### PR DESCRIPTION
## Summary

Three small idioms were copy-pasted across `backend/graph/resolver/`: the DataLoader nil-guard, the "outcome union has no variant set" internal-error guard, and a bare `0` cardCount literal at single-deck mapping sites. This PR centralizes each into the existing `helpers.go` / `mapper.go` landing zones — `loadersOrInternal`, `classifyLoaderErr`, `noVariantSet`, and a named `cardCountResolvedElsewhere` constant — and routes every call site through them. Net effect is one source of truth per idiom, so the next added site is consistent by construction.

**Deliberate, narrow behaviour change.** Three of the five DataLoader-backed field resolvers had **drifted**: `card.Cardgroup`, `card.UserCardState`, and `cardgroup.Owner` collapsed every `Load` error straight to `INTERNAL`, omitting the `context.Canceled` / `context.DeadlineExceeded` → `CANCELLED` branch that the other two fields (`LastSignInAt`, `LastViewedCardgroup` / `LearnDisplayMode`) already applied. Routing all five through `classifyLoaderErr` gives the three drifted sites the CANCELLED branch, so a cancelled mid-DataLoader request now maps to `CANCELLED` consistently instead of `INTERNAL` on some fields and `CANCELLED` on others. This is the intended fix, not a side effect. The `noVariantSet` and cardCount changes carry no behaviour change (the variant message stays byte-identical; the literal stays `0`).

## What changed

- **`graph/resolver/helpers.go`** — added `loadersOrInternal(ctx)` (registry nil-guard → INTERNAL), `classifyLoaderErr(ctx, err, label)` (CANCELLED for cancelled/deadline contexts, else INTERNAL wrapped with the caller-supplied label), and `noVariantSet(ctx, name)` (the `"resolver: <name> has no variant set"` INTERNAL guard).
- **`graph/resolver/mapper.go`** — added `const cardCountResolvedElsewhere = 0` with a doc comment explaining the single-deck count is served by `masterCardsConnection.totalCount`.
- **5 DataLoader field resolvers** now call `loadersOrInternal` + `classifyLoaderErr`: `card.Cardgroup` / `card.UserCardState`, `cardgroup.Owner`, `admin.LastSignInAt`, `last_viewed_cardgroup.LastViewedCardgroup`, `learn_display_mode.LearnDisplayMode`. `UserCardState` keeps its extra `loaders.UserCardFSRS == nil` check + distinct message inline (it guards a second nil beyond the registry); `LastViewedCardgroup` keeps its `repository.ErrNotFound → nil` pre-branch.
- **16 "has no variant set" sites** across `admin`, `card`, `cardgroup`, `last_viewed_cardgroup`, `master_card`, `master_catalog`, `swipe`, `user` resolvers now call `noVariantSet(ctx, "<OutcomeName>")`, collapsing the one/two-line `gqlerr.Internal(ctx, eris.New(...))` forms.
- **2 single-deck mapping sites** (`master_catalog.AdminCreateMasterCardgroup`, `master_card.MasterCardgroup`) pass `cardCountResolvedElsewhere` to `toMasterCardgroupModelFromParts`. The four call sites that pass a real `int(...)` count are unchanged.
- Dropped now-unused imports (`errors`, `loader`, `eris`) from the resolver files that no longer reference them.

## Test plan

- New direct unit tests in `graph/resolver/helpers_test.go`: `loadersOrInternal` (nil-loader → INTERNAL error + nil registry; installed loader → registry returned, nil error); `classifyLoaderErr` (`context.Canceled` / `context.DeadlineExceeded` / wrapped-cancel → CANCELLED; generic error → INTERNAL with the label present in the logged `error_chain`); `noVariantSet` (exact `"resolver: <name> has no variant set"` message in the chain + INTERNAL code).
- New `graph/resolver/cardgroup_owner_resolver_test.go` pins the deliberate drift fix at the resolver boundary for `cardgroup.Owner`: missing-middleware → INTERNAL, cancelled context → CANCELLED, generic loader error → INTERNAL.
- Local gate (worktree): `cd backend && go build ./... && go vet ./...` clean; `go test ./graph/resolver/... -run "LoadersOrInternal|ClassifyLoaderErr|NoVariantSet"` green; full `go test ./graph/resolver/...` green; `go tool go-arch-lint check --project-path .` — OK, no warnings.
- CI will run `go build ./... && go vet ./... && go test ./...` plus the error-wrapping and layering gates.

Closes #644
