### PR TITLE
refactor(backend): centralize usecase txRunner construction in newTxRunner

### DIFF
--- a/backend/internal/usecase/admin_user.go
+++ b/backend/internal/usecase/admin_user.go
@@ -160,11 +160,7 @@ func NewAdminUser(
 		panic("usecase: admin user: logger is required")
 	}
 	uc := &adminUserUsecase{users: users, roles: roles, userRoles: userRoles, adminGate: adminGate, logger: logger}
-	if db != nil {
-		uc.tx = func(ctx context.Context, fn func(tx *gorm.DB) error) error {
-			return db.WithContext(ctx).Transaction(fn)
-		}
-	}
+	uc.tx = newTxRunner(db)
 	return uc
 }
 

--- a/backend/internal/usecase/card.go
+++ b/backend/internal/usecase/card.go
@@ -96,11 +96,7 @@ func NewCardUsecase(
 		observer:      normalizeCardObserver(observer),
 		logger:        logger,
 	}
-	if db != nil {
-		uc.tx = func(ctx context.Context, fn func(tx *gorm.DB) error) error {
-			return db.WithContext(ctx).Transaction(fn)
-		}
-	}
+	uc.tx = newTxRunner(db)
 	return uc
 }
 

--- a/backend/internal/usecase/card_import.go
+++ b/backend/internal/usecase/card_import.go
@@ -121,11 +121,7 @@ func NewCardImportUsecase(cardgroupRepo CardgroupOwnershipFinder, cardRepo CardI
 		panic("usecase: card import: logger is required")
 	}
 	uc := &cardImportUsecase{cardgroupRepo: cardgroupRepo, cardRepo: cardRepo, processCardImport: textdic.Process, logger: logger}
-	if db != nil {
-		uc.tx = func(ctx context.Context, fn func(tx *gorm.DB) error) error {
-			return db.WithContext(ctx).Transaction(fn)
-		}
-	}
+	uc.tx = newTxRunner(db)
 	return uc
 }
 

--- a/backend/internal/usecase/master_card.go
+++ b/backend/internal/usecase/master_card.go
@@ -137,11 +137,7 @@ func NewMasterCardUsecase(
 		processCardImport:   textdic.Process,
 		logger:              logger,
 	}
-	if db != nil {
-		uc.tx = func(ctx context.Context, fn func(tx *gorm.DB) error) error {
-			return db.WithContext(ctx).Transaction(fn)
-		}
-	}
+	uc.tx = newTxRunner(db)
 	return uc
 }
 

--- a/backend/internal/usecase/master_deck.go
+++ b/backend/internal/usecase/master_deck.go
@@ -108,10 +108,8 @@ func NewMasterDeckUsecase(
 		masterCard: masterCard,
 		userCard:   userCard,
 		userCG:     userCG,
-		tx: func(ctx context.Context, fn func(tx *gorm.DB) error) error {
-			return db.WithContext(ctx).Transaction(fn)
-		},
-		logger: logger,
+		tx:         newTxRunner(db),
+		logger:     logger,
 	}
 }
 

--- a/backend/internal/usecase/notion_sync.go
+++ b/backend/internal/usecase/notion_sync.go
@@ -92,11 +92,7 @@ func NewMasterNotionSyncUsecase(
 		masterCardRepo:      masterCardRepo,
 		logger:              logger,
 	}
-	if db != nil {
-		uc.tx = func(ctx context.Context, fn func(tx *gorm.DB) error) error {
-			return db.WithContext(ctx).Transaction(fn)
-		}
-	}
+	uc.tx = newTxRunner(db)
 	return uc
 }
 

--- a/backend/internal/usecase/swipe.go
+++ b/backend/internal/usecase/swipe.go
@@ -106,11 +106,7 @@ func NewSwipeUsecase(
 		newSwipeRecord: domain.NewSwipeRecord,
 		logger:         logger,
 	}
-	if db != nil {
-		uc.tx = func(ctx context.Context, fn func(tx *gorm.DB) error) error {
-			return db.WithContext(ctx).Transaction(fn)
-		}
-	}
+	uc.tx = newTxRunner(db)
 	return uc
 }
 

--- a/backend/internal/usecase/tx.go
+++ b/backend/internal/usecase/tx.go
@@ -12,3 +12,14 @@ import (
 // invokes fn with a sentinel *gorm.DB. Used by CardUsecase, SwipeUsecase,
 // cardImportUsecase, and MasterNotionSyncUsecase.
 type txRunner func(ctx context.Context, fn func(tx *gorm.DB) error) error
+
+// newTxRunner returns the production txRunner backed by db, or nil when db is
+// nil so callers can leave the field unset for explicit-tx test constructors.
+func newTxRunner(db *gorm.DB) txRunner {
+	if db == nil {
+		return nil
+	}
+	return func(ctx context.Context, fn func(tx *gorm.DB) error) error {
+		return db.WithContext(ctx).Transaction(fn)
+	}
+}

--- a/backend/internal/usecase/tx_test.go
+++ b/backend/internal/usecase/tx_test.go
@@ -1,0 +1,25 @@
+package usecase
+
+import (
+	"testing"
+
+	"gorm.io/gorm"
+)
+
+func TestNewTxRunner_NilDB_ReturnsNil(t *testing.T) {
+	t.Parallel()
+
+	if got := newTxRunner(nil); got != nil {
+		t.Fatalf("newTxRunner(nil) = non-nil txRunner, want nil")
+	}
+}
+
+func TestNewTxRunner_NonNilDB_ReturnsRunner(t *testing.T) {
+	t.Parallel()
+
+	// A zero-value *gorm.DB is enough to assert the returned func is non-nil.
+	// The runner is never invoked here, so no live connection is dereferenced.
+	if got := newTxRunner(&gorm.DB{}); got == nil {
+		t.Fatalf("newTxRunner(&gorm.DB{}) = nil txRunner, want non-nil")
+	}
+}


### PR DESCRIPTION
## Summary

Seven usecase constructors each carried a byte-for-byte identical inline `txRunner` closure that wraps `db.WithContext(ctx).Transaction(fn)`. This PR centralizes that construction in a single `newTxRunner(db *gorm.DB) txRunner` factory in the existing `usecase/tx.go`, and routes every constructor through it. The factory's `db == nil` guard subsumes the six per-site `if db != nil` guards, so callers can keep leaving `tx` unset for the explicit-tx test constructors. No behaviour change, no signature change.

## What changed

- **`internal/usecase/tx.go`** — added `newTxRunner(db *gorm.DB) txRunner`: returns `nil` when `db == nil`, otherwise the production `db.WithContext(ctx).Transaction(fn)` closure (byte-identical to the seven inline copies).
- **Six `if db != nil { uc.tx = func(...){...} }` guards collapsed to `uc.tx = newTxRunner(db)`** in `admin_user.go`, `card_import.go`, `card.go`, `master_card.go`, `notion_sync.go`, `swipe.go` — the factory's nil check replaces the per-site guard.
- **`master_deck.go`** — the struct-literal `tx:` closure is replaced with `tx: newTxRunner(db)`. Its `db == nil` panic is kept (db is guaranteed non-nil there, so the factory's guard is inert but harmless).
- **`internal/usecase/tx_test.go`** (new) — a DB-free unit test pinning the factory contract: `newTxRunner(nil)` returns a nil runner; `newTxRunner(&gorm.DB{})` returns a non-nil runner (the returned func is never invoked, so no live connection is dereferenced).

## Test plan

- `cd backend && go build ./... && go vet ./...` — pass (hard gate).
- `go tool go-arch-lint check --project-path .` — OK, no warnings.
- `go test ./internal/usecase/ -run TestNewTxRunner -count=1` — the two new pure-unit tests pass without Docker.
- `go test ./internal/usecase/...` — full suite green (715 tests via testcontainers); CI runs the full suite as well.

Closes #646
