### PR TITLE
refactor(backend): move start-of-learn-day (JST) boundary into domain

### DIFF
--- a/backend/internal/domain/learn_day.go
+++ b/backend/internal/domain/learn_day.go
@@ -1,0 +1,19 @@
+package domain
+
+import "time"
+
+// learnDayZone is the fixed UTC+9 offset used to compute the learner's
+// start-of-day boundary. JST observes no daylight saving, so a fixed offset
+// is exact and avoids a tzdata dependency. The product currently assumes a
+// Japan-resident learner; promote to a per-user preference if that breaks.
+var learnDayZone = time.FixedZone("JST", 9*60*60)
+
+// StartOfLearnDay returns the JST midnight at or before now. The learn queue's
+// review window includes only cards whose last_review is strictly before this
+// boundary, so a card swiped today never re-enters today's queue regardless of
+// its FSRS re-due interval. JST observes no DST, so a fixed offset is exact.
+func StartOfLearnDay(now time.Time) time.Time {
+	local := now.In(learnDayZone)
+	y, m, d := local.Date()
+	return time.Date(y, m, d, 0, 0, 0, 0, learnDayZone)
+}

--- a/backend/internal/domain/learn_day_test.go
+++ b/backend/internal/domain/learn_day_test.go
@@ -1,0 +1,49 @@
+package domain
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestStartOfLearnDay pins the JST (UTC+9) start-of-day boundary used by the
+// learn and practice windows: midnight at or before now, returned as an
+// absolute instant. Only the instant matters, not the input's location.
+func TestStartOfLearnDay(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		now  time.Time
+		want time.Time
+	}{
+		{
+			name: "just before JST midnight maps to the previous day's boundary",
+			now:  time.Date(2026, 6, 5, 14, 59, 59, 0, time.UTC), // 23:59:59 JST
+			want: time.Date(2026, 6, 4, 15, 0, 0, 0, time.UTC),   // 2026-06-05 00:00 JST
+		},
+		{
+			name: "just after JST midnight maps to the current day's boundary",
+			now:  time.Date(2026, 6, 5, 15, 0, 1, 0, time.UTC), // 2026-06-06 00:00:01 JST
+			want: time.Date(2026, 6, 5, 15, 0, 0, 0, time.UTC), // 2026-06-06 00:00 JST
+		},
+		{
+			name: "JST noon",
+			now:  time.Date(2026, 6, 5, 3, 0, 0, 0, time.UTC), // 12:00 JST
+			want: time.Date(2026, 6, 4, 15, 0, 0, 0, time.UTC),
+		},
+		{
+			name: "UTC input is converted into JST before truncation",
+			now:  time.Date(2026, 6, 6, 16, 30, 0, 0, time.UTC), // 2026-06-07 01:30 JST
+			want: time.Date(2026, 6, 6, 15, 0, 0, 0, time.UTC),  // 2026-06-07 00:00 JST
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := StartOfLearnDay(tc.now)
+			require.True(t, got.Equal(tc.want), "got %v, want instant %v", got, tc.want)
+		})
+	}
+}

--- a/backend/internal/repository/card_due.go
+++ b/backend/internal/repository/card_due.go
@@ -39,7 +39,7 @@ type dueCardRow struct {
 // Learn window:    due IS NOT NULL AND due <= now AND last_review < boundary.
 // Practice window: last_review >= boundary; due not consulted.
 // Both usecase methods (NextDueCards and PracticeTodaysCards) derive the
-// boundary from the same startOfDayJST formula, computed once per call
+// boundary from the same domain.StartOfLearnDay formula, computed once per call
 // before hitting the repository. Changing the formula or comparator for
 // one window without the other makes a card vanish from (or appear in)
 // both queues.
@@ -103,7 +103,7 @@ func findDueCardsOn(db *gorm.DB, userID, cardgroupID string, now, reviewedBefore
 }
 
 // findPracticeCardsOn fetches the FSRS-safe practice pool: cards the user
-// already reviewed at or after the boundary (the same startOfDayJST cutoff the
+// already reviewed at or after the boundary (the same domain.StartOfLearnDay cutoff the
 // learn window uses). This is the INVERSE window of findDueCardsOn's review
 // window — practice consults last_review but not due, and uses >= where learn
 // uses <. random() gives a fresh arrangement per practice round.

--- a/backend/internal/usecase/learn.go
+++ b/backend/internal/usecase/learn.go
@@ -22,22 +22,6 @@ const (
 	maxLearnNextDueLimit     = 100
 )
 
-// jstZone is the fixed UTC+9 offset used to compute the learner's
-// start-of-day boundary. JST observes no daylight saving, so a fixed offset
-// is exact and avoids a tzdata dependency. The product currently assumes a
-// Japan-resident learner; promote to a per-user preference if that breaks.
-var jstZone = time.FixedZone("JST", 9*60*60)
-
-// startOfDayJST returns the JST midnight at or before now, as an absolute
-// instant. The learn queue's review slots include only cards whose last_review
-// is strictly before this boundary, so a card swiped today never re-enters
-// today's queue regardless of its FSRS re-due interval.
-func startOfDayJST(now time.Time) time.Time {
-	local := now.In(jstZone)
-	y, m, d := local.Date()
-	return time.Date(y, m, d, 0, 0, 0, 0, jstZone)
-}
-
 type CardRepoForLearn interface {
 	FindDueCardsForUser(ctx context.Context, userID, cardgroupID string, now, reviewedBefore time.Time, limit int) ([]domain.DueCard, error)
 	// FindPracticeCardsForUser returns cards the user reviewed today (the inverse
@@ -174,7 +158,7 @@ func (u *learnUsecase) NextDueCards(ctx context.Context, cardgroupID string, lim
 	}
 	n = u.clampLimit(n)
 	now := u.clock.Now().UTC()
-	due, err := u.cardRepo.FindDueCardsForUser(ctx, user.Sub, cardgroupID, now, startOfDayJST(now), n)
+	due, err := u.cardRepo.FindDueCardsForUser(ctx, user.Sub, cardgroupID, now, domain.StartOfLearnDay(now), n)
 	if err != nil {
 		if isContextDone(err) {
 			return nil, err
@@ -204,7 +188,7 @@ func (u *learnUsecase) PracticeTodaysCards(ctx context.Context, cardgroupID stri
 	}
 	n = u.clampPracticeLimit(n)
 	now := u.clock.Now().UTC()
-	boundary := startOfDayJST(now)
+	boundary := domain.StartOfLearnDay(now)
 	rows, err := u.cardRepo.FindPracticeCardsForUser(ctx, user.Sub, cardgroupID, boundary, n)
 	if err != nil {
 		if isContextDone(err) {

--- a/backend/internal/usecase/learn_test.go
+++ b/backend/internal/usecase/learn_test.go
@@ -469,7 +469,7 @@ func TestLearnUsecasePracticeTodaysCards_PassesJSTStartOfDayAsReviewedAfter(t *t
 	t.Parallel()
 
 	now := time.Date(2026, 6, 6, 16, 30, 0, 0, time.UTC)
-	wantBoundary := time.Date(2026, 6, 7, 0, 0, 0, 0, jstZone)
+	wantBoundary := time.Date(2026, 6, 7, 0, 0, 0, 0, time.FixedZone("JST", 9*60*60))
 	cardRepo := &mockLearnCardRepo{}
 	uc := newPracticeUsecase(
 		cardRepo,
@@ -634,46 +634,6 @@ func TestLearnUsecaseNextDueCards_PassesJSTStartOfDayAsReviewedBefore(t *testing
 			require.NoError(t, err)
 			require.True(t, cardRepo.reviewedBefore.Equal(tc.want),
 				"reviewedBefore: got %v, want instant %v", cardRepo.reviewedBefore, tc.want)
-		})
-	}
-}
-
-// TestStartOfDayJST pins the "previous day" boundary used by the review
-// slots: JST (UTC+9) midnight at or before now, returned as an instant.
-func TestStartOfDayJST(t *testing.T) {
-	t.Parallel()
-
-	cases := []struct {
-		name string
-		now  time.Time
-		want time.Time
-	}{
-		{
-			name: "just before JST midnight",
-			now:  time.Date(2026, 6, 5, 14, 59, 59, 0, time.UTC), // 23:59:59 JST
-			want: time.Date(2026, 6, 4, 15, 0, 0, 0, time.UTC),   // 2026-06-05 00:00 JST
-		},
-		{
-			name: "exactly JST midnight",
-			now:  time.Date(2026, 6, 5, 15, 0, 0, 0, time.UTC), // 2026-06-06 00:00 JST
-			want: time.Date(2026, 6, 5, 15, 0, 0, 0, time.UTC),
-		},
-		{
-			name: "JST noon",
-			now:  time.Date(2026, 6, 5, 3, 0, 0, 0, time.UTC), // 12:00 JST
-			want: time.Date(2026, 6, 4, 15, 0, 0, 0, time.UTC),
-		},
-		{
-			name: "input zone does not matter, only the instant",
-			now:  time.Date(2026, 6, 5, 12, 0, 0, 0, time.FixedZone("JST", 9*60*60)), // = 03:00 UTC
-			want: time.Date(2026, 6, 4, 15, 0, 0, 0, time.UTC),
-		},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			got := startOfDayJST(tc.now)
-			require.True(t, got.Equal(tc.want), "got %v, want instant %v", got, tc.want)
 		})
 	}
 }


### PR DESCRIPTION
## Summary

Moves the start-of-learn-day (JST) boundary computation out of the application layer and into the domain layer as `domain.StartOfLearnDay`. The boundary is a domain rule — "a card swiped today never re-enters today's queue" — so it belongs in `domain/`, not inline in `usecase/learn.go`. No behaviour change: the truncation logic and the fixed UTC+9 offset are preserved verbatim.

## What changed

- New `backend/internal/domain/learn_day.go`: `StartOfLearnDay(now time.Time) time.Time` returns JST midnight at or before `now`. The fixed UTC+9 zone lives as an unexported package var (`learnDayZone`); JST observes no DST, so a fixed offset is exact and avoids a tzdata dependency.
- `backend/internal/usecase/learn.go`: deleted the local `jstZone` var and `startOfDayJST` func; the two call sites in `NextDueCards` and `PracticeTodaysCards` now call `domain.StartOfLearnDay(now)`. The `domain` import was already present.
- `backend/internal/repository/card_due.go`: comment-only update — the two docblock references to the deleted `startOfDayJST` now name `domain.StartOfLearnDay`. No logic change.
- Tests: new `backend/internal/domain/learn_day_test.go` (DB-free) covers an instant just before JST midnight → previous day's boundary, just after → current day's boundary, JST noon, and a UTC input converted into JST before truncation. The now-dead `TestStartOfDayJST` in `learn_test.go` was deleted (its symbol moved to `domain`, where the new test is the canonical location); the one `jstZone` reference in `learn_test.go`'s practice-boundary assertion was inlined to `time.FixedZone("JST", 9*60*60)`.

`domain/service/user_performance.go`'s caller-timezone `startOfDay` is intentionally left alone — it answers a different (per-user-timezone) question and is out of scope.

## Test plan

- `cd backend && go build ./... && go vet ./...` clean.
- `go test ./internal/domain/ -run StartOfLearnDay -count=1` green (pure unit, no Docker).
- `go test ./internal/...` green via testcontainers (`usecase`, `repository`, `domain` all `ok`).
- `go tool go-arch-lint check --project-path .` — OK (the new `usecase → domain` reference is the correct inward arrow).

Closes #648
