### PR TITLE
refactor(backend): standardize repository error wrap prefixes on two-segment form

### DIFF
--- a/backend/internal/repository/card.go
+++ b/backend/internal/repository/card.go
@@ -130,7 +130,7 @@ func findCardByID(ctx context.Context, db *gorm.DB, id string) (*domain.Card, er
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, ErrNotFound
 		}
-		return nil, eris.Wrap(err, "repository: find card by id")
+		return nil, eris.Wrap(err, "repository: card: find by id")
 	}
 	return cardToDomain(row), nil
 }
@@ -141,7 +141,7 @@ func (r *cardRepo) FindByIDs(ctx context.Context, ids []string) (map[string]*dom
 	}
 	var rows []gormCard
 	if err := r.db.WithContext(ctx).Where("id IN ?", ids).Find(&rows).Error; err != nil {
-		return nil, eris.Wrap(err, "repository: find cards by ids")
+		return nil, eris.Wrap(err, "repository: card: find by ids")
 	}
 	out := make(map[string]*domain.Card, len(rows))
 	for i := range rows {
@@ -157,7 +157,7 @@ func (r *cardRepo) FindByCardgroup(ctx context.Context, cardgroupID string) ([]*
 		Where("cardgroup_id = ?", cardgroupID).
 		Order("created_at ASC, id ASC").
 		Find(&rows).Error; err != nil {
-		return nil, eris.Wrap(err, "repository: find cards by cardgroup")
+		return nil, eris.Wrap(err, "repository: card: find by cardgroup")
 	}
 	out := make([]*domain.Card, len(rows))
 	for i := range rows {
@@ -181,7 +181,7 @@ func (r *cardRepo) Create(ctx context.Context, card *domain.Card) error {
 			strings.Contains(pgErr.ConstraintName, "uq_cards_cardgroup_front") {
 			return ErrCardDuplicateFront
 		}
-		return eris.Wrap(err, "repository: create card")
+		return eris.Wrap(err, "repository: card: create")
 	}
 	return nil
 }
@@ -195,7 +195,7 @@ func (r *cardRepo) FindByCardgroupAndFront(ctx context.Context, cardgroupID, fro
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, ErrNotFound
 		}
-		return nil, eris.Wrap(err, "repository: find card by cardgroup and front")
+		return nil, eris.Wrap(err, "repository: card: find by cardgroup and front")
 	}
 	return cardToDomain(row), nil
 }
@@ -214,7 +214,7 @@ func (r *cardRepo) Update(ctx context.Context, id string, patch CardUpdate) (*do
 
 	res := r.db.WithContext(ctx).Model(&gormCard{}).Where("id = ?", id).Updates(updates)
 	if res.Error != nil {
-		return nil, eris.Wrap(res.Error, "repository: update card")
+		return nil, eris.Wrap(res.Error, "repository: card: update")
 	}
 	if res.RowsAffected == 0 {
 		return nil, ErrNotFound
@@ -225,7 +225,7 @@ func (r *cardRepo) Update(ctx context.Context, id string, patch CardUpdate) (*do
 func (r *cardRepo) Delete(ctx context.Context, id string) error {
 	res := r.db.WithContext(ctx).Where("id = ?", id).Delete(&gormCard{})
 	if res.Error != nil {
-		return eris.Wrap(res.Error, "repository: delete card")
+		return eris.Wrap(res.Error, "repository: card: delete")
 	}
 	if res.RowsAffected == 0 {
 		return ErrNotFound

--- a/backend/internal/repository/cardgroup.go
+++ b/backend/internal/repository/cardgroup.go
@@ -100,7 +100,7 @@ func (r *cardgroupRepo) FindByID(ctx context.Context, id string) (*domain.Cardgr
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, ErrNotFound
 		}
-		return nil, eris.Wrap(err, "repository: find cardgroup by id")
+		return nil, eris.Wrap(err, "repository: cardgroup: find by id")
 	}
 	return cardgroupToDomain(row), nil
 }
@@ -116,7 +116,7 @@ func (r *cardgroupRepo) FindByName(ctx context.Context, ownerID, name string) (*
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, ErrNotFound
 		}
-		return nil, eris.Wrap(err, "repository: find cardgroup by name")
+		return nil, eris.Wrap(err, "repository: cardgroup: find by name")
 	}
 	return cardgroupToDomain(row), nil
 }
@@ -155,7 +155,7 @@ func (r *cardgroupRepo) FindPageByOwner(
 	if cursor != nil {
 		clauseSQL, args, err := cardgroupCursorWhere(orderBy, effectiveDir, cursor)
 		if err != nil {
-			return nil, eris.Wrap(err, "repository: build cardgroup cursor where")
+			return nil, eris.Wrap(err, "repository: cardgroup: build cursor where")
 		}
 		q = q.Where(clauseSQL, args...)
 	}
@@ -163,7 +163,7 @@ func (r *cardgroupRepo) FindPageByOwner(
 
 	var rows []gormCardgroup
 	if err := q.Find(&rows).Error; err != nil {
-		return nil, eris.Wrap(err, "repository: find cardgroup page by owner")
+		return nil, eris.Wrap(err, "repository: cardgroup: find page by owner")
 	}
 
 	if reverse {
@@ -187,7 +187,7 @@ func (r *cardgroupRepo) CountByOwner(ctx context.Context, ownerID string, search
 	}
 	var total int64
 	if err := q.Count(&total).Error; err != nil {
-		return 0, eris.Wrap(err, "repository: count cardgroups by owner")
+		return 0, eris.Wrap(err, "repository: cardgroup: count by owner")
 	}
 	return total, nil
 }
@@ -253,7 +253,7 @@ func (r *cardgroupRepo) FindByIDs(ctx context.Context, ids []string) (map[string
 	}
 	var rows []gormCardgroup
 	if err := r.db.WithContext(ctx).Where("id IN ?", ids).Find(&rows).Error; err != nil {
-		return nil, eris.Wrap(err, "repository: find cardgroups by ids")
+		return nil, eris.Wrap(err, "repository: cardgroup: find by ids")
 	}
 	out := make(map[string]*domain.Cardgroup, len(rows))
 	for i := range rows {
@@ -268,7 +268,7 @@ func (r *cardgroupRepo) FindByIDs(ctx context.Context, ids []string) (map[string
 func (r *cardgroupRepo) Create(ctx context.Context, cg *domain.Cardgroup) error {
 	row := cardgroupToRow(cg)
 	if err := r.db.WithContext(ctx).Create(row).Error; err != nil {
-		return eris.Wrap(err, "repository: create cardgroup")
+		return eris.Wrap(err, "repository: cardgroup: create")
 	}
 	return nil
 }
@@ -278,7 +278,7 @@ func (r *cardgroupRepo) Create(ctx context.Context, cg *domain.Cardgroup) error 
 // responsible for pre-filling cg.ID (uuid v7) and both timestamps.
 func (r *cardgroupRepo) CreateTx(ctx context.Context, tx *gorm.DB, cg *domain.Cardgroup) error {
 	if err := tx.WithContext(ctx).Create(cardgroupToRow(cg)).Error; err != nil {
-		return eris.Wrap(err, "repository: create cardgroup tx")
+		return eris.Wrap(err, "repository: cardgroup: create tx")
 	}
 	return nil
 }
@@ -293,7 +293,7 @@ func (r *cardgroupRepo) EnsureByName(ctx context.Context, ownerID, name string) 
 	var out *domain.Cardgroup
 	err := r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		if err := tx.Exec("SELECT pg_advisory_xact_lock(hashtext(?), hashtext(?))", ownerID, name).Error; err != nil {
-			return eris.Wrap(err, "repository: ensure cardgroup by name: advisory lock")
+			return eris.Wrap(err, "repository: cardgroup: ensure by name: advisory lock")
 		}
 
 		var row gormCardgroup
@@ -303,12 +303,12 @@ func (r *cardgroupRepo) EnsureByName(ctx context.Context, ownerID, name string) 
 			return nil
 		}
 		if !errors.Is(err, gorm.ErrRecordNotFound) {
-			return eris.Wrap(err, "repository: ensure cardgroup by name: lookup")
+			return eris.Wrap(err, "repository: cardgroup: ensure by name: lookup")
 		}
 
 		id, err := uuid.NewV7()
 		if err != nil {
-			return eris.Wrap(err, "repository: ensure cardgroup by name: uuid")
+			return eris.Wrap(err, "repository: cardgroup: ensure by name: uuid")
 		}
 		now := time.Now().UTC()
 		row = gormCardgroup{
@@ -319,7 +319,7 @@ func (r *cardgroupRepo) EnsureByName(ctx context.Context, ownerID, name string) 
 			UpdatedAt: now,
 		}
 		if err := tx.Create(&row).Error; err != nil {
-			return eris.Wrap(err, "repository: ensure cardgroup by name: create")
+			return eris.Wrap(err, "repository: cardgroup: ensure by name: create")
 		}
 		out = cardgroupToDomain(row)
 		return nil
@@ -345,7 +345,7 @@ func (r *cardgroupRepo) Update(ctx context.Context, id string, patch CardgroupUp
 
 	res := r.db.WithContext(ctx).Model(&gormCardgroup{}).Where("id = ?", id).Updates(updates)
 	if res.Error != nil {
-		return nil, eris.Wrap(res.Error, "repository: update cardgroup")
+		return nil, eris.Wrap(res.Error, "repository: cardgroup: update")
 	}
 	if res.RowsAffected == 0 {
 		return nil, ErrNotFound
@@ -359,7 +359,7 @@ func (r *cardgroupRepo) Update(ctx context.Context, id string, patch CardgroupUp
 func (r *cardgroupRepo) Delete(ctx context.Context, id string) error {
 	res := r.db.WithContext(ctx).Where("id = ?", id).Delete(&gormCardgroup{})
 	if res.Error != nil {
-		return eris.Wrap(res.Error, "repository: delete cardgroup")
+		return eris.Wrap(res.Error, "repository: cardgroup: delete")
 	}
 	if res.RowsAffected == 0 {
 		return ErrNotFound

--- a/backend/internal/repository/swipe_record.go
+++ b/backend/internal/repository/swipe_record.go
@@ -49,7 +49,7 @@ func (r *swipeRecordRepo) FindByIDs(ctx context.Context, ids []string) (map[stri
 	}
 	var rows []gormSwipeRecord
 	if err := r.db.WithContext(ctx).Where("id IN ?", ids).Find(&rows).Error; err != nil {
-		return nil, eris.Wrap(err, "repository: find swipe records by ids")
+		return nil, eris.Wrap(err, "repository: swipe record: find by ids")
 	}
 	out := make(map[string]*domain.SwipeRecord, len(rows))
 	for i := range rows {
@@ -65,7 +65,7 @@ func (r *swipeRecordRepo) FindByUserAndCardgroup(ctx context.Context, userID, ca
 		Where("user_id = ? AND cardgroup_id = ?", userID, cardgroupID).
 		Order("reviewed_at DESC, id DESC").
 		Find(&rows).Error; err != nil {
-		return nil, eris.Wrap(err, "repository: find swipe records by user and cardgroup")
+		return nil, eris.Wrap(err, "repository: swipe record: find by user and cardgroup")
 	}
 	out := make([]*domain.SwipeRecord, len(rows))
 	for i := range rows {
@@ -85,7 +85,7 @@ func (r *swipeRecordRepo) ListRecentByUser(ctx context.Context, userID string, l
 		Order("reviewed_at DESC, id DESC").
 		Limit(limit).
 		Find(&rows).Error; err != nil {
-		return nil, eris.Wrap(err, "repository: list recent swipe records by user")
+		return nil, eris.Wrap(err, "repository: swipe record: list recent by user")
 	}
 
 	out := make([]*domain.SwipeRecord, len(rows))
@@ -97,7 +97,7 @@ func (r *swipeRecordRepo) ListRecentByUser(ctx context.Context, userID string, l
 
 func (r *swipeRecordRepo) CreateTx(ctx context.Context, tx *gorm.DB, sr *domain.SwipeRecord) error {
 	if err := tx.WithContext(ctx).Create(swipeRecordToRow(sr)).Error; err != nil {
-		return eris.Wrap(err, "repository: create swipe record")
+		return eris.Wrap(err, "repository: swipe record: create")
 	}
 	return nil
 }

--- a/backend/internal/repository/user.go
+++ b/backend/internal/repository/user.go
@@ -132,7 +132,7 @@ func (r *userRepo) FindByID(ctx context.Context, id string) (*domain.User, error
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, ErrNotFound
 		}
-		return nil, eris.Wrap(err, "repository: find user by id")
+		return nil, eris.Wrap(err, "repository: user: find by id")
 	}
 	return userToDomain(row), nil
 }
@@ -144,7 +144,7 @@ func (r *userRepo) FindByIDs(ctx context.Context, ids []string) (map[string]*dom
 	}
 	var rows []gormUser
 	if err := r.db.WithContext(ctx).Where("id IN ?", ids).Find(&rows).Error; err != nil {
-		return nil, eris.Wrap(err, "repository: find users by ids")
+		return nil, eris.Wrap(err, "repository: user: find by ids")
 	}
 	out := make(map[string]*domain.User, len(rows))
 	for i := range rows {
@@ -163,7 +163,7 @@ func (r *userRepo) Update(ctx context.Context, id string, patch UserUpdate) (*do
 
 	res := r.db.WithContext(ctx).Model(&gormUser{}).Where("id = ?", id).Updates(updates)
 	if res.Error != nil {
-		return nil, eris.Wrap(res.Error, "repository: update user")
+		return nil, eris.Wrap(res.Error, "repository: user: update")
 	}
 	if res.RowsAffected == 0 {
 		return nil, ErrNotFound
@@ -179,7 +179,7 @@ func (r *userRepo) UpdateTx(ctx context.Context, tx *gorm.DB, id string, patch U
 	}
 	res := tx.WithContext(ctx).Model(&gormUser{}).Where("id = ?", id).Updates(updates)
 	if res.Error != nil {
-		return eris.Wrap(res.Error, "repository: update user tx")
+		return eris.Wrap(res.Error, "repository: user: update tx")
 	}
 	if res.RowsAffected == 0 {
 		return ErrNotFound
@@ -196,7 +196,7 @@ func (r *userRepo) UpdateTxVersioned(ctx context.Context, tx *gorm.DB, id string
 		Where("id = ? AND version = ?", id, expectedVersion).
 		Updates(updates)
 	if res.Error != nil {
-		return eris.Wrap(res.Error, "repository: update user tx versioned")
+		return eris.Wrap(res.Error, "repository: user: update tx versioned")
 	}
 	if res.RowsAffected > 0 {
 		return nil
@@ -208,7 +208,7 @@ func (r *userRepo) UpdateTxVersioned(ctx context.Context, tx *gorm.DB, id string
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return ErrNotFound
 		}
-		return eris.Wrap(err, "repository: update user tx versioned: probe user")
+		return eris.Wrap(err, "repository: user: update tx versioned: probe user")
 	}
 	return ErrConcurrentUpdate
 }
@@ -219,7 +219,7 @@ func (r *userRepo) UpdateTxVersioned(ctx context.Context, tx *gorm.DB, id string
 func (r *userRepo) DeleteAuthUser(ctx context.Context, id string) error {
 	res := r.db.WithContext(ctx).Exec("DELETE FROM auth.users WHERE id = ?", id)
 	if res.Error != nil {
-		return eris.Wrap(res.Error, "repository: delete auth user")
+		return eris.Wrap(res.Error, "repository: user: delete auth user")
 	}
 	if res.RowsAffected == 0 {
 		return ErrNotFound
@@ -239,7 +239,7 @@ func (r *userRepo) LastSignInByUserIDs(ctx context.Context, ids []string) (map[s
 		Select("id", "last_sign_in_at").
 		Where("id IN ?", ids).
 		Find(&rows).Error; err != nil {
-		return nil, eris.Wrap(err, "repository: last sign-in by user ids")
+		return nil, eris.Wrap(err, "repository: user: last sign-in by ids")
 	}
 	out := make(map[string]*time.Time, len(rows))
 	for i := range rows {
@@ -294,7 +294,7 @@ func (r *userRepo) ListPage(
 	}
 	var total int64
 	if err := countQ.Count(&total).Error; err != nil {
-		return nil, 0, eris.Wrap(err, "repository: count users")
+		return nil, 0, eris.Wrap(err, "repository: user: count")
 	}
 
 	if first == 0 && last == 0 {
@@ -335,7 +335,7 @@ func (r *userRepo) ListPage(
 			if errors.Is(err, gorm.ErrRecordNotFound) {
 				return nil, 0, ErrCursorNotFound
 			}
-			return nil, 0, eris.Wrap(err, "repository: hydrate user cursor")
+			return nil, 0, eris.Wrap(err, "repository: user: hydrate cursor")
 		}
 
 		clauseSQL, args := userCursorWhere(createdAtAsc, idAsc, cursorRow)
@@ -346,7 +346,7 @@ func (r *userRepo) ListPage(
 
 	var rows []gormUser
 	if err := q.Find(&rows).Error; err != nil {
-		return nil, 0, eris.Wrap(err, "repository: list users page")
+		return nil, 0, eris.Wrap(err, "repository: user: list page")
 	}
 
 	if reverse {

--- a/backend/internal/repository/user_card_fsrs.go
+++ b/backend/internal/repository/user_card_fsrs.go
@@ -57,7 +57,7 @@ func (r *userCardFSRSRepo) UpsertTx(ctx context.Context, tx *gorm.DB, u *domain.
 			"updated_at":     gorm.Expr("now()"),
 		}),
 	}).Create(userCardFSRSToRow(u)).Error; err != nil {
-		return eris.Wrap(err, "repository: upsert user card fsrs")
+		return eris.Wrap(err, "repository: user card fsrs: upsert")
 	}
 	return nil
 }
@@ -65,7 +65,7 @@ func (r *userCardFSRSRepo) UpsertTx(ctx context.Context, tx *gorm.DB, u *domain.
 func (r *userCardFSRSRepo) FindByUserAndCardIDs(ctx context.Context, userID string, cardIDs []string) (map[string]*domain.UserCardFSRS, error) {
 	out, err := findUserCardFSRSByUserAndCardIDs(ctx, r.db, userID, cardIDs)
 	if err != nil {
-		return nil, eris.Wrap(err, "repository: find user card fsrs by user and card ids")
+		return nil, eris.Wrap(err, "repository: user card fsrs: find by user and card ids")
 	}
 	return out, nil
 }
@@ -73,7 +73,7 @@ func (r *userCardFSRSRepo) FindByUserAndCardIDs(ctx context.Context, userID stri
 func (r *userCardFSRSRepo) FindByUserAndCardIDsTx(ctx context.Context, tx *gorm.DB, userID string, cardIDs []string) (map[string]*domain.UserCardFSRS, error) {
 	out, err := findUserCardFSRSByUserAndCardIDs(ctx, tx, userID, cardIDs)
 	if err != nil {
-		return nil, eris.Wrap(err, "repository: find user card fsrs by user and card ids tx")
+		return nil, eris.Wrap(err, "repository: user card fsrs: find by user and card ids tx")
 	}
 	return out, nil
 }

--- a/backend/internal/repository/user_preference.go
+++ b/backend/internal/repository/user_preference.go
@@ -71,7 +71,7 @@ func (r *userPreferenceRepo) FindByUserID(ctx context.Context, userID string) (*
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, ErrNotFound
 		}
-		return nil, eris.Wrap(err, "repository: find user preference by user_id")
+		return nil, eris.Wrap(err, "repository: user preference: find by user_id")
 	}
 	return toDomainUserPreference(row), nil
 }
@@ -83,7 +83,7 @@ func (r *userPreferenceRepo) FindByUserIDs(ctx context.Context, userIDs []string
 	}
 	var rows []gormUserPreference
 	if err := r.db.WithContext(ctx).Where("user_id IN ?", userIDs).Find(&rows).Error; err != nil {
-		return nil, eris.Wrap(err, "repository: find user preferences by user_ids")
+		return nil, eris.Wrap(err, "repository: user preference: find by user_ids")
 	}
 	out := make([]*domain.UserPreference, len(rows))
 	for i := range rows {
@@ -114,7 +114,7 @@ SET last_viewed_cardgroup_id = EXCLUDED.last_viewed_cardgroup_id,
 		if classified := classifyUserPreferenceCardgroupFKError(res.Error); classified != nil {
 			return classified
 		}
-		return eris.Wrap(res.Error, "repository: upsert last viewed cardgroup")
+		return eris.Wrap(res.Error, "repository: user preference: upsert last viewed cardgroup")
 	}
 	if res.RowsAffected == 0 {
 		return ErrCardgroupNotFound
@@ -148,7 +148,7 @@ SET learn_display_mode = EXCLUDED.learn_display_mode,
     updated_at         = EXCLUDED.updated_at`
 	res := r.db.WithContext(ctx).Exec(sql, userID, mode)
 	if res.Error != nil {
-		return eris.Wrap(res.Error, "repository: upsert learn display mode")
+		return eris.Wrap(res.Error, "repository: user preference: upsert learn display mode")
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

Standardizes the verb-first one-segment error-wrap prefixes in the per-aggregate repository files on the canonical two-segment `repository: <module>: <verb …>` form described in [`.claude/rules/error-wrapping.md`](.claude/rules/error-wrapping.md). The two-segment prefix lets `grep -n 'repository: card:'` return every wrap from one file regardless of the surrounding function, mirroring the convention already in place under `internal/usecase/`. This is a no-behaviour-change refactor: only the `error_chain` log attribute's greppability changes — classification and wire output are untouched.

## What changed

Each file's verb-first wraps (`"repository: find card by id"`) are rewritten module-first (`"repository: card: find by id"`), dropping the now-redundant module noun from the verb tail. Already-canonical sites (e.g. `card.go`'s `"repository: card: list fronts by cardgroup"`) and the `errors.Is`-matched sentinels (`ErrNotFound`, `ErrConcurrentUpdate`, `ErrCardDuplicateFront`, `ErrCardgroupNotFound`) are left unchanged.

- **`internal/repository/card.go`** — 7 wraps under the `card` module (`find by id`, `find by ids`, `find by cardgroup`, `create`, `find by cardgroup and front`, `update`, `delete`).
- **`internal/repository/cardgroup.go`** — 14 wraps under the `cardgroup` module, including the four `ensure by name: <step>` sub-segments (`advisory lock`, `lookup`, `uuid`, `create`).
- **`internal/repository/user.go`** — 11 wraps under the `user` module (`find by id`, `find by ids`, `update`, `update tx`, `update tx versioned` + `: probe user`, `delete auth user`, `last sign-in by ids`, `count`, `hydrate cursor`, `list page`).
- **`internal/repository/swipe_record.go`** — 4 wraps under the `swipe record` module (`find by ids`, `find by user and cardgroup`, `list recent by user`, `create`).
- **`internal/repository/user_card_fsrs.go`** — 3 wraps under the `user card fsrs` module (`upsert`, `find by user and card ids`, `find by user and card ids tx`). The originating `eris.Errorf("repository: invalid FSRSCardState …")` is left as-is (not a verb-first CRUD wrap).
- **`internal/repository/user_preference.go`** — 4 wraps under the `user preference` module (`find by user_id`, `find by user_ids`, `upsert last viewed cardgroup`, `upsert learn display mode`).

No test files were touched: a grep of the test tree found zero assertions pinned to the old `repository: <verb>` strings.

## Test plan

- `cd backend && go build ./... && go vet ./...` — pass (hard gate).
- `go vet ./internal/repository/...` — pass.
- `go test ./internal/repository/...` — green against testcontainers Postgres.
- Backend CI runs the full suite on this PR.

Closes #649
