### PR TITLE
refactor(backend): generalize repository cursor where/order-clause engine

### DIFF
--- a/backend/internal/repository/card_pagination.go
+++ b/backend/internal/repository/card_pagination.go
@@ -133,40 +133,34 @@ func (r *cardRepo) FindPageByCardgroupForUser(
 	return out, total, nil
 }
 
+// cardCursorSpec describes the card aggregate's cursor geometry. The primary
+// sort column is `cards.<orderBy>`, except CardOrderByDue which sorts on the
+// COALESCE expression over the LEFT JOIN's nullable due column. The id tie-break
+// is aliased `cards.id`.
+func cardCursorSpec(orderBy CardOrderBy, c *CardCursor) cursorSpec {
+	field := "cards." + string(orderBy)
+	if orderBy == CardOrderByDue {
+		field = "COALESCE(ucs.due, cards.created_at)"
+	}
+	return cursorSpec{
+		alias:      "cards",
+		orderCol:   field,
+		isIDOrder:  orderBy == CardOrderByID,
+		fieldValue: func() (any, error) { return cursorFieldValue(orderBy, c) },
+	}
+}
+
 // orderClause renders the SQL ORDER BY tail. When orderBy is `id` only one
 // column appears; otherwise the secondary `id` keeps order deterministic.
 func orderClause(orderBy CardOrderBy, dir SortOrder) string {
-	d := string(dir)
-	if orderBy == CardOrderByID {
-		return "cards.id " + d
-	}
-	if orderBy == CardOrderByDue {
-		return "COALESCE(ucs.due, cards.created_at) " + d + ", cards.id " + d
-	}
-	return "cards." + string(orderBy) + " " + d + ", cards.id " + d
+	return buildOrderClause(cardCursorSpec(orderBy, nil), dir)
 }
 
 // cursorWhere builds the tuple-comparison WHERE for the supplied cursor and
 // direction. ASC yields `>`, DESC yields `<`. Returns an error when the
 // cursor lacks the column required by the active orderBy.
 func cursorWhere(orderBy CardOrderBy, dir SortOrder, c *CardCursor) (string, []any, error) {
-	op := ">"
-	if dir == SortDesc {
-		op = "<"
-	}
-	if orderBy == CardOrderByID {
-		return "cards.id " + op + " ?", []any{c.ID}, nil
-	}
-	field := "cards." + string(orderBy)
-	if orderBy == CardOrderByDue {
-		field = "COALESCE(ucs.due, cards.created_at)"
-	}
-	val, err := cursorFieldValue(orderBy, c)
-	if err != nil {
-		return "", nil, err
-	}
-	clause, args := cursorTupleWhere("cards", field, op, val, c.ID)
-	return clause, args, nil
+	return buildCursorWhere(cardCursorSpec(orderBy, c), dir, c.ID)
 }
 
 // cursorFieldValue returns the cursor value for the active orderBy field.
@@ -187,7 +181,7 @@ func cursorFieldValue(orderBy CardOrderBy, c *CardCursor) (any, error) {
 			return *c.UpdatedAt, nil
 		}
 	}
-	return nil, eris.Errorf("cursor missing %s column", orderBy)
+	return nil, eris.Errorf("repository: card: cursor missing %s column", orderBy)
 }
 
 func coalesceUserIDForJoin(userID string) string {

--- a/backend/internal/repository/cardgroup.go
+++ b/backend/internal/repository/cardgroup.go
@@ -192,14 +192,23 @@ func (r *cardgroupRepo) CountByOwner(ctx context.Context, ownerID string, search
 	return total, nil
 }
 
+// cardgroupCursorSpec describes the cardgroup aggregate's cursor geometry. The
+// columns are UNALIASED (bare `name` / `created_at` / `id`) because
+// FindPageByOwner queries the cardgroups table without an alias.
+func cardgroupCursorSpec(orderBy CardgroupOrderBy, c *CardgroupCursor) cursorSpec {
+	return cursorSpec{
+		alias:      "",
+		orderCol:   string(orderBy),
+		isIDOrder:  orderBy == CardgroupOrderByID,
+		fieldValue: func() (any, error) { return cardgroupCursorFieldValue(orderBy, c) },
+	}
+}
+
 // cardgroupOrderClause renders the SQL ORDER BY tail. When orderBy is `id`
 // only one column appears; otherwise the secondary `id` keeps the ordering
 // total.
 func cardgroupOrderClause(orderBy CardgroupOrderBy, dir SortOrder) string {
-	if orderBy == CardgroupOrderByID {
-		return "id " + string(dir)
-	}
-	return string(orderBy) + " " + string(dir) + ", id " + string(dir)
+	return buildOrderClause(cardgroupCursorSpec(orderBy, nil), dir)
 }
 
 // cardgroupCursorWhere builds the tuple-comparison WHERE for the supplied
@@ -207,20 +216,7 @@ func cardgroupOrderClause(orderBy CardgroupOrderBy, dir SortOrder) string {
 // when the cursor lacks the column required by the active orderBy — that
 // is a caller bug, not user-supplied input.
 func cardgroupCursorWhere(orderBy CardgroupOrderBy, dir SortOrder, c *CardgroupCursor) (string, []any, error) {
-	op := ">"
-	if dir == SortDesc {
-		op = "<"
-	}
-	if orderBy == CardgroupOrderByID {
-		return "id " + op + " ?", []any{c.ID}, nil
-	}
-	field := string(orderBy)
-	val, err := cardgroupCursorFieldValue(orderBy, c)
-	if err != nil {
-		return "", nil, err
-	}
-	clause, args := cursorTupleWhere("", field, op, val, c.ID)
-	return clause, args, nil
+	return buildCursorWhere(cardgroupCursorSpec(orderBy, c), dir, c.ID)
 }
 
 // cardgroupCursorFieldValue returns the cursor value for the active
@@ -241,7 +237,7 @@ func cardgroupCursorFieldValue(orderBy CardgroupOrderBy, c *CardgroupCursor) (an
 			return *c.UpdatedAt, nil
 		}
 	}
-	return nil, eris.Errorf("cardgroup cursor missing %s column", orderBy)
+	return nil, eris.Errorf("repository: cardgroup: cursor missing %s column", orderBy)
 }
 
 // FindByIDs returns a map of id → Cardgroup for all found ids. IDs that do not

--- a/backend/internal/repository/master_card.go
+++ b/backend/internal/repository/master_card.go
@@ -235,34 +235,29 @@ func (r *masterCardRepo) FindPageByMasterCardgroup(
 	return out, total, nil
 }
 
+// masterCardCursorSpec describes the master-card aggregate's cursor geometry.
+// The primary sort column and id tie-break are prefixed with the `master_cards`
+// alias used by the page query.
+func masterCardCursorSpec(orderBy MasterCardOrderBy, c *MasterCardCursor) cursorSpec {
+	return cursorSpec{
+		alias:      "master_cards",
+		orderCol:   "master_cards." + string(orderBy),
+		isIDOrder:  orderBy == MasterCardOrderByID,
+		fieldValue: func() (any, error) { return masterCardCursorFieldValue(orderBy, c) },
+	}
+}
+
 // masterCardOrderClause renders the SQL ORDER BY tail. When orderBy is `id` only
 // one column appears; otherwise the secondary `id` keeps order deterministic.
 func masterCardOrderClause(orderBy MasterCardOrderBy, dir SortOrder) string {
-	d := string(dir)
-	if orderBy == MasterCardOrderByID {
-		return "master_cards.id " + d
-	}
-	return "master_cards." + string(orderBy) + " " + d + ", master_cards.id " + d
+	return buildOrderClause(masterCardCursorSpec(orderBy, nil), dir)
 }
 
 // masterCardCursorWhere builds the tuple-comparison WHERE for the supplied cursor
 // and direction. ASC yields `>`, DESC yields `<`. Returns an error when the cursor
 // lacks the column required by the active orderBy.
 func masterCardCursorWhere(orderBy MasterCardOrderBy, dir SortOrder, c *MasterCardCursor) (string, []any, error) {
-	op := ">"
-	if dir == SortDesc {
-		op = "<"
-	}
-	if orderBy == MasterCardOrderByID {
-		return "master_cards.id " + op + " ?", []any{c.ID}, nil
-	}
-	field := "master_cards." + string(orderBy)
-	val, err := masterCardCursorFieldValue(orderBy, c)
-	if err != nil {
-		return "", nil, err
-	}
-	clause, args := cursorTupleWhere("master_cards", field, op, val, c.ID)
-	return clause, args, nil
+	return buildCursorWhere(masterCardCursorSpec(orderBy, c), dir, c.ID)
 }
 
 // masterCardCursorFieldValue returns the cursor value for the active orderBy

--- a/backend/internal/repository/master_catalog_read.go
+++ b/backend/internal/repository/master_catalog_read.go
@@ -69,13 +69,26 @@ func (r *masterCardgroupRepo) CountCards(ctx context.Context, masterCardgroupID 
 	return total, nil
 }
 
+// masterCatalogCursorSpec describes the catalog aggregate's cursor geometry.
+// MasterCatalogOrderBy has no `id` member, so isIDOrder is always false and both
+// the primary sort column and the `mcg.id` tie-break are always emitted. The
+// columns are prefixed with the `mcg` alias used by findCatalogPage.
+func masterCatalogCursorSpec(orderBy MasterCatalogOrderBy, c *MasterCatalogCursor) cursorSpec {
+	return cursorSpec{
+		alias:      "mcg",
+		orderCol:   "mcg." + string(orderBy),
+		isIDOrder:  false,
+		fieldValue: func() (any, error) { return masterCatalogCursorFieldValue(orderBy, c) },
+	}
+}
+
 // masterCatalogOrderClause renders the SQL ORDER BY tail with a secondary
 // mcg.id tie-break so cursors stay deterministic when the primary sort column
 // has duplicates. MasterCatalogOrderBy has no `id` member, so both columns are
 // always emitted. The columns are prefixed with the `mcg` alias used by
 // findCatalogPage.
 func masterCatalogOrderClause(orderBy MasterCatalogOrderBy, dir SortOrder) string {
-	return "mcg." + string(orderBy) + " " + string(dir) + ", mcg.id " + string(dir)
+	return buildOrderClause(masterCatalogCursorSpec(orderBy, nil), dir)
 }
 
 // masterCatalogCursorWhere builds the tuple-comparison WHERE for the supplied
@@ -84,17 +97,7 @@ func masterCatalogOrderClause(orderBy MasterCatalogOrderBy, dir SortOrder) strin
 // bug, not user-supplied input. Columns are prefixed with the `mcg` alias used
 // by findCatalogPage.
 func masterCatalogCursorWhere(orderBy MasterCatalogOrderBy, dir SortOrder, c *MasterCatalogCursor) (string, []any, error) {
-	op := ">"
-	if dir == SortDesc {
-		op = "<"
-	}
-	field := "mcg." + string(orderBy)
-	val, err := masterCatalogCursorFieldValue(orderBy, c)
-	if err != nil {
-		return "", nil, err
-	}
-	clause, args := cursorTupleWhere("mcg", field, op, val, c.ID)
-	return clause, args, nil
+	return buildCursorWhere(masterCatalogCursorSpec(orderBy, c), dir, c.ID)
 }
 
 // masterCatalogCursorFieldValue returns the cursor value for the active orderBy
@@ -115,7 +118,7 @@ func masterCatalogCursorFieldValue(orderBy MasterCatalogOrderBy, c *MasterCatalo
 			return *c.Name, nil
 		}
 	}
-	return nil, eris.Errorf("repository: master cardgroup: catalog cursor missing %s column", orderBy)
+	return nil, eris.Errorf("repository: master cardgroup: cursor missing %s column", orderBy)
 }
 
 // findCatalogPage is the shared cursor-paginated catalog engine. publishedOnly

--- a/backend/internal/repository/pagination.go
+++ b/backend/internal/repository/pagination.go
@@ -72,6 +72,73 @@ func cursorTupleWhere(alias, field, op string, fieldVal, idVal any) (string, []a
 		[]any{fieldVal, fieldVal, idVal}
 }
 
+// cursorSpec describes one aggregate's cursor geometry to the generic
+// where/order-clause builders. It collapses the repeated per-aggregate triplet
+// (XxxOrderClause / XxxCursorWhere / XxxCursorFieldValue) into data: each repo
+// builds a spec from its orderBy switch and delegates to buildOrderClause /
+// buildCursorWhere, which emit the same SQL the hand-written triplets did.
+//
+//   - alias: the table-alias prefix for the id tie-break column (`cards`,
+//     `master_cards`, `mcg`, or `""` for an unaliased `id`). Threaded straight
+//     into cursorTupleWhere and used to qualify the id column in the ORDER BY
+//     and id-only WHERE forms.
+//   - orderCol: the already-qualified primary sort expression
+//     (`cards.created_at`, `COALESCE(ucs.due, cards.created_at)`,
+//     `mcg.sort_order`, …). Ignored when isIDOrder is true.
+//   - isIDOrder: the active orderBy resolves to the id column, so only the id
+//     column is emitted (no tuple). Aggregates whose orderBy enum has no id
+//     member (master_catalog) leave this false.
+//   - fieldValue: returns the hydrated cursor value for orderCol, or the
+//     cursor-missing error. Only invoked when isIDOrder is false.
+type cursorSpec struct {
+	alias      string
+	orderCol   string
+	isIDOrder  bool
+	fieldValue func() (any, error)
+}
+
+// idColumn returns the id tie-break column qualified by the spec's alias, or a
+// bare `id` when the alias is empty (cardgroup's unaliased form).
+func (s cursorSpec) idColumn() string {
+	if s.alias == "" {
+		return "id"
+	}
+	return s.alias + ".id"
+}
+
+// buildOrderClause renders the SQL ORDER BY tail for a cursorSpec and direction.
+// An id-order spec emits only the id column; otherwise the primary sort column
+// is followed by the id column so the ordering is always total.
+func buildOrderClause(spec cursorSpec, dir SortOrder) string {
+	d := string(dir)
+	idCol := spec.idColumn()
+	if spec.isIDOrder {
+		return idCol + " " + d
+	}
+	return spec.orderCol + " " + d + ", " + idCol + " " + d
+}
+
+// buildCursorWhere builds the tuple-comparison WHERE for a cursorSpec, cursor id,
+// and direction. ASC yields `>`, DESC yields `<`. An id-order spec emits the
+// single `id op ?` form; otherwise it hydrates the cursor field value and
+// delegates to cursorTupleWhere. Returns the cursor-missing error from
+// spec.fieldValue unchanged.
+func buildCursorWhere(spec cursorSpec, dir SortOrder, idVal any) (string, []any, error) {
+	op := ">"
+	if dir == SortDesc {
+		op = "<"
+	}
+	if spec.isIDOrder {
+		return spec.idColumn() + " " + op + " ?", []any{idVal}, nil
+	}
+	val, err := spec.fieldValue()
+	if err != nil {
+		return "", nil, err
+	}
+	clause, args := cursorTupleWhere(spec.alias, spec.orderCol, op, val, idVal)
+	return clause, args, nil
+}
+
 // searchLikePattern wraps a non-empty trimmed search term in `%...%` after
 // escaping LIKE/ILIKE metacharacters so user-supplied `%` and `_` match
 // literally. Returns (pattern, false) when search is nil or trims to empty so

--- a/backend/internal/repository/pagination_internal_test.go
+++ b/backend/internal/repository/pagination_internal_test.go
@@ -1,0 +1,188 @@
+package repository
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// These white-box tests pin the exact SQL strings the per-aggregate cursor
+// shims emit through the shared buildOrderClause / buildCursorWhere engine.
+// They are the DB-free half of the SQL-equivalence regression net: every
+// quirk the generalization had to preserve (card's COALESCE due branch + alias
+// "cards", cardgroup's unaliased id, master_card's alias "master_cards",
+// master_catalog's always-two-column form with alias "mcg") is asserted here so
+// a future change to the generic builders cannot silently alter a clause.
+
+func ptrTime(t time.Time) *time.Time { return &t }
+func ptrInt(i int) *int              { return &i }
+
+func TestOrderClause_Card(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		orderBy CardOrderBy
+		dir     SortOrder
+		want    string
+	}{
+		{CardOrderByID, SortAsc, "cards.id ASC"},
+		{CardOrderByID, SortDesc, "cards.id DESC"},
+		{CardOrderByCreatedAt, SortAsc, "cards.created_at ASC, cards.id ASC"},
+		{CardOrderByCreatedAt, SortDesc, "cards.created_at DESC, cards.id DESC"},
+		{CardOrderByUpdatedAt, SortAsc, "cards.updated_at ASC, cards.id ASC"},
+		{CardOrderByDue, SortAsc, "COALESCE(ucs.due, cards.created_at) ASC, cards.id ASC"},
+		{CardOrderByDue, SortDesc, "COALESCE(ucs.due, cards.created_at) DESC, cards.id DESC"},
+	}
+	for _, c := range cases {
+		require.Equal(t, c.want, orderClause(c.orderBy, c.dir))
+	}
+}
+
+func TestCursorWhere_Card(t *testing.T) {
+	t.Parallel()
+	now := time.Now().UTC()
+	cur := &CardCursor{ID: "cid", Due: ptrTime(now), CreatedAt: ptrTime(now), UpdatedAt: ptrTime(now)}
+
+	// id-order emits the single id comparison, no tuple.
+	clause, args, err := cursorWhere(CardOrderByID, SortAsc, cur)
+	require.NoError(t, err)
+	require.Equal(t, "cards.id > ?", clause)
+	require.Equal(t, []any{"cid"}, args)
+
+	clause, args, err = cursorWhere(CardOrderByID, SortDesc, cur)
+	require.NoError(t, err)
+	require.Equal(t, "cards.id < ?", clause)
+	require.Equal(t, []any{"cid"}, args)
+
+	// created_at tuple form with alias "cards".
+	clause, args, err = cursorWhere(CardOrderByCreatedAt, SortAsc, cur)
+	require.NoError(t, err)
+	require.Equal(t, "(cards.created_at > ? OR (cards.created_at = ? AND cards.id > ?))", clause)
+	require.Equal(t, []any{now, now, "cid"}, args)
+
+	// Due keeps the COALESCE primary column.
+	clause, args, err = cursorWhere(CardOrderByDue, SortDesc, cur)
+	require.NoError(t, err)
+	require.Equal(t,
+		"(COALESCE(ucs.due, cards.created_at) < ? OR (COALESCE(ucs.due, cards.created_at) = ? AND cards.id < ?))",
+		clause)
+	require.Equal(t, []any{now, now, "cid"}, args)
+
+	// Missing hydrated column is a caller bug surfaced as an error.
+	_, _, err = cursorWhere(CardOrderByCreatedAt, SortAsc, &CardCursor{ID: "cid"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "repository: card: cursor missing")
+}
+
+func TestOrderClause_Cardgroup(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		orderBy CardgroupOrderBy
+		dir     SortOrder
+		want    string
+	}{
+		{CardgroupOrderByID, SortAsc, "id ASC"},
+		{CardgroupOrderByID, SortDesc, "id DESC"},
+		{CardgroupOrderByName, SortAsc, "name ASC, id ASC"},
+		{CardgroupOrderByCreatedAt, SortDesc, "created_at DESC, id DESC"},
+		{CardgroupOrderByUpdatedAt, SortAsc, "updated_at ASC, id ASC"},
+	}
+	for _, c := range cases {
+		require.Equal(t, c.want, cardgroupOrderClause(c.orderBy, c.dir))
+	}
+}
+
+func TestCursorWhere_Cardgroup(t *testing.T) {
+	t.Parallel()
+	name := "deck"
+	cur := &CardgroupCursor{ID: "gid", Name: &name}
+
+	// id-order: unaliased bare id, no tuple.
+	clause, args, err := cardgroupCursorWhere(CardgroupOrderByID, SortAsc, cur)
+	require.NoError(t, err)
+	require.Equal(t, "id > ?", clause)
+	require.Equal(t, []any{"gid"}, args)
+
+	// name tuple form is unaliased on the id tie-break.
+	clause, args, err = cardgroupCursorWhere(CardgroupOrderByName, SortDesc, cur)
+	require.NoError(t, err)
+	require.Equal(t, "(name < ? OR (name = ? AND id < ?))", clause)
+	require.Equal(t, []any{name, name, "gid"}, args)
+
+	_, _, err = cardgroupCursorWhere(CardgroupOrderByName, SortAsc, &CardgroupCursor{ID: "gid"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "repository: cardgroup: cursor missing")
+}
+
+func TestOrderClause_MasterCard(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		orderBy MasterCardOrderBy
+		dir     SortOrder
+		want    string
+	}{
+		{MasterCardOrderByID, SortAsc, "master_cards.id ASC"},
+		{MasterCardOrderByID, SortDesc, "master_cards.id DESC"},
+		{MasterCardOrderByPosition, SortAsc, "master_cards.position ASC, master_cards.id ASC"},
+		{MasterCardOrderByCreatedAt, SortDesc, "master_cards.created_at DESC, master_cards.id DESC"},
+	}
+	for _, c := range cases {
+		require.Equal(t, c.want, masterCardOrderClause(c.orderBy, c.dir))
+	}
+}
+
+func TestCursorWhere_MasterCard(t *testing.T) {
+	t.Parallel()
+	cur := &MasterCardCursor{ID: "mid", Position: ptrInt(7)}
+
+	clause, args, err := masterCardCursorWhere(MasterCardOrderByID, SortDesc, cur)
+	require.NoError(t, err)
+	require.Equal(t, "master_cards.id < ?", clause)
+	require.Equal(t, []any{"mid"}, args)
+
+	clause, args, err = masterCardCursorWhere(MasterCardOrderByPosition, SortAsc, cur)
+	require.NoError(t, err)
+	require.Equal(t,
+		"(master_cards.position > ? OR (master_cards.position = ? AND master_cards.id > ?))",
+		clause)
+	require.Equal(t, []any{7, 7, "mid"}, args)
+
+	_, _, err = masterCardCursorWhere(MasterCardOrderByPosition, SortAsc, &MasterCardCursor{ID: "mid"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "repository: master card: cursor missing")
+}
+
+func TestOrderClause_MasterCatalog(t *testing.T) {
+	t.Parallel()
+	// MasterCatalogOrderBy has no id member, so both columns are always emitted.
+	cases := []struct {
+		orderBy MasterCatalogOrderBy
+		dir     SortOrder
+		want    string
+	}{
+		{MasterCatalogOrderBySortOrder, SortAsc, "mcg.sort_order ASC, mcg.id ASC"},
+		{MasterCatalogOrderBySortOrder, SortDesc, "mcg.sort_order DESC, mcg.id DESC"},
+		{MasterCatalogOrderByName, SortAsc, "mcg.name ASC, mcg.id ASC"},
+		{MasterCatalogOrderByCreatedAt, SortDesc, "mcg.created_at DESC, mcg.id DESC"},
+	}
+	for _, c := range cases {
+		require.Equal(t, c.want, masterCatalogOrderClause(c.orderBy, c.dir))
+	}
+}
+
+func TestCursorWhere_MasterCatalog(t *testing.T) {
+	t.Parallel()
+	cur := &MasterCatalogCursor{ID: "cgid", SortOrder: ptrInt(3)}
+
+	// Always a tuple — no id-order short-circuit for this aggregate.
+	clause, args, err := masterCatalogCursorWhere(MasterCatalogOrderBySortOrder, SortAsc, cur)
+	require.NoError(t, err)
+	require.Equal(t,
+		"(mcg.sort_order > ? OR (mcg.sort_order = ? AND mcg.id > ?))",
+		clause)
+	require.Equal(t, []any{3, 3, "cgid"}, args)
+
+	_, _, err = masterCatalogCursorWhere(MasterCatalogOrderBySortOrder, SortAsc, &MasterCatalogCursor{ID: "cgid"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "repository: master cardgroup: cursor missing")
+}


### PR DESCRIPTION
## Summary

Pull the repeated cursor triplet (`XxxOrderClause` / `XxxCursorWhere` / `XxxCursorFieldValue`) from the four paginated repos into a small `cursorSpec` + two generic builders (`buildOrderClause`, `buildCursorWhere`) in `backend/internal/repository/pagination.go`. No behaviour change: the same SQL is emitted for every orderBy/direction combination.

## What changed

- Added `cursorSpec` plus `buildOrderClause(spec, dir)` and `buildCursorWhere(spec, dir, idVal)` to `pagination.go`, alongside the existing `paginateSetup` / `cursorTupleWhere` / `searchLikePattern` helpers.
- Collapsed each repo's triplet into a per-aggregate `*CursorSpec` builder plus thin `orderClause` / `cursorWhere` shims that delegate to the generic engine, preserving every quirk exactly:
  - `card_pagination.go`: alias `cards`, keeps the `CardOrderByDue` → `COALESCE(ucs.due, cards.created_at)` branch.
  - `cardgroup.go`: unaliased `id` form.
  - `master_card.go`: alias `master_cards`.
  - `master_catalog_read.go`: alias `mcg`, always-two-column form (no `id` orderBy member).
- Standardized all four cursor-missing error messages on the two-segment `repository: <module>: cursor missing %s column` form (card and cardgroup previously lacked the `repository:` prefix; master_catalog dropped a redundant `catalog` word).
- Added `pagination_internal_test.go`: a DB-free white-box test pinning the exact SQL string each shim emits for every orderBy/direction combo, the id-only short-circuit, and the cursor-missing error per aggregate — covering the new generic builders directly.

## Test plan

- `cd backend && go build ./...` — pass.
- `cd backend && go vet ./...` — pass.
- `cd backend && go test -count=1 ./internal/repository/...` — pass (testcontainers Postgres; the existing `card_pagination_test.go` / `cardgroup_test.go` / `master_card_test.go` / `master_catalog_test.go` are the SQL-equivalence regression net, plus the new white-box clause tests).

Closes #650
