### PR TITLE
refactor(backend): dedupe usecase connection cursor/orderBy/start-end plumbing

### DIFF
--- a/backend/internal/usecase/admin_user.go
+++ b/backend/internal/usecase/admin_user.go
@@ -243,8 +243,7 @@ func (u *adminUserUsecase) List(
 		out.Edges[i] = AdminUserEdge{Cursor: string(user.ID), Node: user}
 	}
 	if len(users) > 0 {
-		start := string(users[0].ID)
-		end := string(users[len(users)-1].ID)
+		start, end := firstLastCursor(users, func(u *domain.User) string { return string(u.ID) })
 		out.PageInfo.StartCursor = &start
 		out.PageInfo.EndCursor = &end
 	}

--- a/backend/internal/usecase/card.go
+++ b/backend/internal/usecase/card.go
@@ -10,7 +10,6 @@ import (
 	"gorm.io/gorm"
 
 	"backend/internal/auth"
-	"backend/internal/cursor"
 	"backend/internal/domain"
 	"backend/internal/repository"
 	"backend/internal/usecase/ucerr"
@@ -410,37 +409,23 @@ func (u *cardUsecase) ListCardsByCardgroupConnection(
 	}
 
 	out := &CardConnectionOutput{TotalCount: total, HasNext: hasNext, HasPrev: hasPrev, Cards: cards}
-	if len(cards) > 0 {
-		out.StartCur = cards[0].ID
-		out.EndCur = cards[len(cards)-1].ID
-	}
+	out.StartCur, out.EndCur = firstLastCursor(cards, func(c *domain.Card) string { return c.ID })
 	return out, nil
+}
+
+// cardOrderByColumns is the usecase→repository orderBy allowlist for cards.
+var cardOrderByColumns = map[CardOrderBy]repository.CardOrderBy{
+	CardOrderByID:        repository.CardOrderByID,
+	CardOrderByCreatedAt: repository.CardOrderByCreatedAt,
+	CardOrderByUpdatedAt: repository.CardOrderByUpdatedAt,
+	CardOrderByDue:       repository.CardOrderByDue,
 }
 
 // resolveOrderBy maps the typed usecase enums to the repository allowlist.
 // Defaults to (ID, ASC) when both are nil. The default arm is defense in
 // depth — gqlgen UnmarshalGQL already rejects invalid enum strings upstream.
 func resolveOrderBy(orderBy *CardOrderBy, dir *SortOrder) (repository.CardOrderBy, repository.SortOrder, error) {
-	field := repository.CardOrderByID
-	if orderBy != nil {
-		switch *orderBy {
-		case CardOrderByID:
-			field = repository.CardOrderByID
-		case CardOrderByCreatedAt:
-			field = repository.CardOrderByCreatedAt
-		case CardOrderByUpdatedAt:
-			field = repository.CardOrderByUpdatedAt
-		case CardOrderByDue:
-			field = repository.CardOrderByDue
-		default:
-			return "", "", ucerr.NewValidationError("orderBy", "invalid")
-		}
-	}
-	d, err := resolveSortDir(dir, repository.SortAsc)
-	if err != nil {
-		return "", "", err
-	}
-	return field, d, nil
+	return resolveOrderByColumn(orderBy, dir, cardOrderByColumns, repository.CardOrderByID, repository.SortAsc)
 }
 
 // resolveCursor decodes an opaque cursor string into a *repository.CardCursor
@@ -456,12 +441,12 @@ func (u *cardUsecase) resolveCursor(
 	orderBy repository.CardOrderBy,
 	field string,
 ) (*repository.CardCursor, error) {
-	if cursorStr == nil || *cursorStr == "" {
-		return nil, nil
-	}
-	id, err := cursor.Decode(*cursorStr)
+	id, present, err := decodeCursorOrBadInput(cursorStr, field)
 	if err != nil {
-		return nil, ucerr.NewValidationError(field, "invalid cursor")
+		return nil, err
+	}
+	if !present {
+		return nil, nil
 	}
 	c := &repository.CardCursor{ID: id}
 	if orderBy == repository.CardOrderByID {

--- a/backend/internal/usecase/cardgroup.go
+++ b/backend/internal/usecase/cardgroup.go
@@ -10,7 +10,6 @@ import (
 	"github.com/rotisserie/eris"
 
 	"backend/internal/auth"
-	"backend/internal/cursor"
 	"backend/internal/domain"
 	"backend/internal/repository"
 	"backend/internal/usecase/ucerr"
@@ -362,11 +361,16 @@ func (u *cardgroupUsecase) ListCardgroupsByOwnerConnection(
 	}
 
 	out := &CardgroupConnectionOutput{TotalCount: total, HasNext: hasNext, HasPrev: hasPrev, Cardgroups: cgs}
-	if len(cgs) > 0 {
-		out.StartCur = string(cgs[0].ID)
-		out.EndCur = string(cgs[len(cgs)-1].ID)
-	}
+	out.StartCur, out.EndCur = firstLastCursor(cgs, func(cg *domain.Cardgroup) string { return string(cg.ID) })
 	return out, nil
+}
+
+// cardgroupOrderByColumns is the usecase→repository orderBy allowlist for cardgroups.
+var cardgroupOrderByColumns = map[CardgroupOrderBy]repository.CardgroupOrderBy{
+	CardgroupOrderByID:        repository.CardgroupOrderByID,
+	CardgroupOrderByCreatedAt: repository.CardgroupOrderByCreatedAt,
+	CardgroupOrderByUpdatedAt: repository.CardgroupOrderByUpdatedAt,
+	CardgroupOrderByName:      repository.CardgroupOrderByName,
 }
 
 // resolveCardgroupOrderBy maps the typed usecase enums to the repository
@@ -376,26 +380,7 @@ func (u *cardgroupUsecase) ListCardgroupsByOwnerConnection(
 func resolveCardgroupOrderBy(
 	orderBy *CardgroupOrderBy, dir *SortOrder,
 ) (repository.CardgroupOrderBy, repository.SortOrder, error) {
-	field := repository.CardgroupOrderByUpdatedAt
-	if orderBy != nil {
-		switch *orderBy {
-		case CardgroupOrderByID:
-			field = repository.CardgroupOrderByID
-		case CardgroupOrderByCreatedAt:
-			field = repository.CardgroupOrderByCreatedAt
-		case CardgroupOrderByUpdatedAt:
-			field = repository.CardgroupOrderByUpdatedAt
-		case CardgroupOrderByName:
-			field = repository.CardgroupOrderByName
-		default:
-			return "", "", ucerr.NewValidationError("orderBy", "invalid")
-		}
-	}
-	d, err := resolveSortDir(dir, repository.SortDesc)
-	if err != nil {
-		return "", "", err
-	}
-	return field, d, nil
+	return resolveOrderByColumn(orderBy, dir, cardgroupOrderByColumns, repository.CardgroupOrderByUpdatedAt, repository.SortDesc)
 }
 
 // resolveCardgroupCursor decodes an opaque cursor string into a
@@ -417,12 +402,12 @@ func (u *cardgroupUsecase) resolveCardgroupCursor(
 	orderBy repository.CardgroupOrderBy,
 	field string,
 ) (*repository.CardgroupCursor, error) {
-	if cursorStr == nil || *cursorStr == "" {
-		return nil, nil
-	}
-	id, err := cursor.Decode(*cursorStr)
+	id, present, err := decodeCursorOrBadInput(cursorStr, field)
 	if err != nil {
-		return nil, ucerr.NewValidationError(field, "invalid cursor")
+		return nil, err
+	}
+	if !present {
+		return nil, nil
 	}
 	cg, err := u.repo.FindByID(ctx, id)
 	if err != nil {

--- a/backend/internal/usecase/master_card.go
+++ b/backend/internal/usecase/master_card.go
@@ -13,7 +13,6 @@ import (
 	"gorm.io/gorm"
 
 	"backend/internal/auth"
-	"backend/internal/cursor"
 	"backend/internal/domain"
 	"backend/internal/repository"
 	"backend/internal/textdic"
@@ -632,11 +631,16 @@ func (u *masterCardUsecase) listMasterCardsCore(
 	// StartCur / EndCur carry the RAW node id; the resolver's connection layer
 	// applies the cursor encoder once. Encoding here would double-encode.
 	out := &MasterCardConnectionOutput{TotalCount: total, HasNext: hasNext, HasPrev: hasPrev, Cards: cards}
-	if len(cards) > 0 {
-		out.StartCur = cards[0].ID
-		out.EndCur = cards[len(cards)-1].ID
-	}
+	out.StartCur, out.EndCur = firstLastCursor(cards, func(c *domain.MasterCard) string { return c.ID })
 	return out, nil
+}
+
+// masterCardOrderByColumns is the usecase→repository orderBy allowlist for master cards.
+var masterCardOrderByColumns = map[MasterCardOrderBy]repository.MasterCardOrderBy{
+	MasterCardOrderByID:        repository.MasterCardOrderByID,
+	MasterCardOrderByPosition:  repository.MasterCardOrderByPosition,
+	MasterCardOrderByCreatedAt: repository.MasterCardOrderByCreatedAt,
+	MasterCardOrderByUpdatedAt: repository.MasterCardOrderByUpdatedAt,
 }
 
 // resolveMasterCardOrderBy maps the typed usecase enums to the repository
@@ -646,26 +650,7 @@ func (u *masterCardUsecase) listMasterCardsCore(
 func resolveMasterCardOrderBy(
 	orderBy *MasterCardOrderBy, dir *SortOrder,
 ) (repository.MasterCardOrderBy, repository.SortOrder, error) {
-	field := repository.MasterCardOrderByPosition
-	if orderBy != nil {
-		switch *orderBy {
-		case MasterCardOrderByID:
-			field = repository.MasterCardOrderByID
-		case MasterCardOrderByPosition:
-			field = repository.MasterCardOrderByPosition
-		case MasterCardOrderByCreatedAt:
-			field = repository.MasterCardOrderByCreatedAt
-		case MasterCardOrderByUpdatedAt:
-			field = repository.MasterCardOrderByUpdatedAt
-		default:
-			return "", "", ucerr.NewValidationError("orderBy", "invalid")
-		}
-	}
-	d, err := resolveSortDir(dir, repository.SortAsc)
-	if err != nil {
-		return "", "", err
-	}
-	return field, d, nil
+	return resolveOrderByColumn(orderBy, dir, masterCardOrderByColumns, repository.MasterCardOrderByPosition, repository.SortAsc)
 }
 
 // resolveMasterCardCursor decodes an opaque cursor string into a
@@ -688,12 +673,12 @@ func (u *masterCardUsecase) resolveMasterCardCursor(
 	orderBy repository.MasterCardOrderBy,
 	field string,
 ) (*repository.MasterCardCursor, error) {
-	if cursorStr == nil || *cursorStr == "" {
-		return nil, nil
-	}
-	id, err := cursor.Decode(*cursorStr)
+	id, present, err := decodeCursorOrBadInput(cursorStr, field)
 	if err != nil {
-		return nil, ucerr.NewValidationError(field, "invalid cursor")
+		return nil, err
+	}
+	if !present {
+		return nil, nil
 	}
 	c := &repository.MasterCardCursor{ID: id}
 	if orderBy == repository.MasterCardOrderByID {

--- a/backend/internal/usecase/master_catalog.go
+++ b/backend/internal/usecase/master_catalog.go
@@ -9,7 +9,6 @@ import (
 	"github.com/rotisserie/eris"
 
 	"backend/internal/auth"
-	"backend/internal/cursor"
 	"backend/internal/domain"
 	"backend/internal/repository"
 	"backend/internal/usecase/ucerr"
@@ -217,11 +216,15 @@ func (u *masterCatalogUsecase) ListPublishedConnection(
 	}
 
 	out := &MasterCatalogConnectionOutput{TotalCount: total, HasNext: hasNext, HasPrev: hasPrev, Items: items}
-	if len(items) > 0 {
-		out.StartCur = items[0].Cardgroup.ID
-		out.EndCur = items[len(items)-1].Cardgroup.ID
-	}
+	out.StartCur, out.EndCur = firstLastCursor(items, func(it *repository.MasterCatalogItem) string { return it.Cardgroup.ID })
 	return out, nil
+}
+
+// masterCatalogOrderByColumns is the usecase→repository orderBy allowlist for the master catalog.
+var masterCatalogOrderByColumns = map[MasterCatalogOrderBy]repository.MasterCatalogOrderBy{
+	MasterCatalogOrderBySortOrder: repository.MasterCatalogOrderBySortOrder,
+	MasterCatalogOrderByCreatedAt: repository.MasterCatalogOrderByCreatedAt,
+	MasterCatalogOrderByName:      repository.MasterCatalogOrderByName,
 }
 
 // resolveMasterCatalogOrderBy maps the typed usecase enums to the repository
@@ -231,24 +234,7 @@ func (u *masterCatalogUsecase) ListPublishedConnection(
 func resolveMasterCatalogOrderBy(
 	orderBy *MasterCatalogOrderBy, dir *SortOrder,
 ) (repository.MasterCatalogOrderBy, repository.SortOrder, error) {
-	field := repository.MasterCatalogOrderBySortOrder
-	if orderBy != nil {
-		switch *orderBy {
-		case MasterCatalogOrderBySortOrder:
-			field = repository.MasterCatalogOrderBySortOrder
-		case MasterCatalogOrderByCreatedAt:
-			field = repository.MasterCatalogOrderByCreatedAt
-		case MasterCatalogOrderByName:
-			field = repository.MasterCatalogOrderByName
-		default:
-			return "", "", ucerr.NewValidationError("orderBy", "invalid")
-		}
-	}
-	d, err := resolveSortDir(dir, repository.SortAsc)
-	if err != nil {
-		return "", "", err
-	}
-	return field, d, nil
+	return resolveOrderByColumn(orderBy, dir, masterCatalogOrderByColumns, repository.MasterCatalogOrderBySortOrder, repository.SortAsc)
 }
 
 // resolveMasterCursor decodes an opaque cursor string into a
@@ -266,12 +252,12 @@ func (u *masterCatalogUsecase) resolveMasterCursor(
 	field string,
 	publishedOnly bool,
 ) (*repository.MasterCatalogCursor, error) {
-	if cursorStr == nil || *cursorStr == "" {
-		return nil, nil
-	}
-	id, err := cursor.Decode(*cursorStr)
+	id, present, err := decodeCursorOrBadInput(cursorStr, field)
 	if err != nil {
-		return nil, ucerr.NewValidationError(field, "invalid cursor")
+		return nil, err
+	}
+	if !present {
+		return nil, nil
 	}
 	fetchByID := u.repo.FindByID
 	if publishedOnly {
@@ -614,10 +600,7 @@ func (u *masterCatalogUsecase) ListAdminConnection(
 	}
 
 	out := &MasterCatalogConnectionOutput{TotalCount: total, HasNext: hasNext, HasPrev: hasPrev, Items: items}
-	if len(items) > 0 {
-		out.StartCur = items[0].Cardgroup.ID
-		out.EndCur = items[len(items)-1].Cardgroup.ID
-	}
+	out.StartCur, out.EndCur = firstLastCursor(items, func(it *repository.MasterCatalogItem) string { return it.Cardgroup.ID })
 	return out, nil
 }
 

--- a/backend/internal/usecase/page.go
+++ b/backend/internal/usecase/page.go
@@ -1,6 +1,7 @@
 package usecase
 
 import (
+	"backend/internal/cursor"
 	"backend/internal/repository"
 	"backend/internal/usecase/ucerr"
 )
@@ -134,4 +135,62 @@ func assemblePage[T any](
 		hasNext = hasBefore
 	}
 	return items, hasNext, hasPrev, nil
+}
+
+// decodeCursorOrBadInput decodes an opaque cursor string, returning present=false
+// for a nil/empty cursor and a BAD_USER_INPUT validation error for a malformed one.
+// It covers only the decode+guard prefix shared by every aggregate's resolve*Cursor
+// method; the per-aggregate hydration (FindByID / FindPublishedByID) and the
+// repository cursor-struct population stay inline in each method.
+func decodeCursorOrBadInput(cursorStr *string, field string) (id string, present bool, err error) {
+	if cursorStr == nil || *cursorStr == "" {
+		return "", false, nil
+	}
+	id, err = cursor.Decode(*cursorStr)
+	if err != nil {
+		return "", false, ucerr.NewValidationError(field, "invalid cursor")
+	}
+	return id, true, nil
+}
+
+// resolveOrderByColumn maps the typed usecase orderBy enum to the repository
+// column via the supplied allowlist, defaulting to def when orderBy is nil, and
+// delegates the direction half to the shared resolveSortDir. An orderBy outside
+// the allowlist returns a BAD_USER_INPUT validation error; the default arm is
+// defense in depth — gqlgen UnmarshalGQL already rejects invalid enum strings
+// upstream. Each aggregate's resolve*OrderBy is a thin wrapper supplying its
+// own map + (default column, default direction).
+func resolveOrderByColumn[K comparable, V any](
+	orderBy *K,
+	dir *SortOrder,
+	allow map[K]V,
+	def V,
+	defDir repository.SortOrder,
+) (V, repository.SortOrder, error) {
+	field := def
+	if orderBy != nil {
+		col, ok := allow[*orderBy]
+		if !ok {
+			var zero V
+			return zero, "", ucerr.NewValidationError("orderBy", "invalid")
+		}
+		field = col
+	}
+	d, err := resolveSortDir(dir, defDir)
+	if err != nil {
+		var zero V
+		return zero, "", err
+	}
+	return field, d, nil
+}
+
+// firstLastCursor returns the id() of the first and last rows, or "","" when the
+// slice is empty. Shared by every connection usecase's StartCur / EndCur tail;
+// the id accessor extracts the raw node id (the resolver applies the cursor
+// encoder once downstream).
+func firstLastCursor[T any](rows []T, id func(T) string) (start, end string) {
+	if len(rows) == 0 {
+		return "", ""
+	}
+	return id(rows[0]), id(rows[len(rows)-1])
 }

--- a/backend/internal/usecase/page_test.go
+++ b/backend/internal/usecase/page_test.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"testing"
 
+	"backend/internal/cursor"
 	"backend/internal/repository"
 	"backend/internal/usecase/ucerr"
 )
@@ -389,5 +390,196 @@ func TestResolveRelayPage_InvalidComboSkipsClamp(t *testing.T) {
 	}
 	if clampCalled {
 		t.Fatal("want clamp NOT called when validation fails")
+	}
+}
+
+// TestDecodeCursorOrBadInput covers the shared decode+guard prefix extracted
+// from the four resolve*Cursor methods: a nil/empty cursor yields present=false
+// with no error, a malformed v1 envelope is a field-level BAD_USER_INPUT
+// validation error, and a well-formed cursor decodes to the raw id.
+func TestDecodeCursorOrBadInput(t *testing.T) {
+	t.Parallel()
+
+	empty := ""
+	valid := cursor.Encode("abc123")
+	// A v1 envelope with a base64 payload that cannot be decoded.
+	bad := "v1:!!!not-base64!!!"
+
+	tests := []struct {
+		name        string
+		cursorStr   *string
+		wantID      string
+		wantPresent bool
+		wantErr     bool
+	}{
+		{name: "nil -> not present, no error", cursorStr: nil, wantPresent: false},
+		{name: "empty -> not present, no error", cursorStr: &empty, wantPresent: false},
+		{name: "valid -> decoded id, present", cursorStr: &valid, wantID: "abc123", wantPresent: true},
+		{name: "malformed -> validation error", cursorStr: &bad, wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			id, present, err := decodeCursorOrBadInput(tc.cursorStr, "after")
+			if tc.wantErr {
+				var ve *ucerr.ValidationError
+				if !errors.As(err, &ve) {
+					t.Fatalf("want ValidationError, got %v", err)
+				}
+				if ve.Field != "after" {
+					t.Fatalf("want field after, got %q", ve.Field)
+				}
+				if present || id != "" {
+					t.Fatalf("want empty/not-present on error, got id=%q present=%v", id, present)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if present != tc.wantPresent {
+				t.Fatalf("present: got %v, want %v", present, tc.wantPresent)
+			}
+			if id != tc.wantID {
+				t.Fatalf("id: got %q, want %q", id, tc.wantID)
+			}
+		})
+	}
+}
+
+// TestResolveOrderByColumn covers the generic table-driven orderBy resolver each
+// aggregate's resolve*OrderBy now wraps: nil orderBy yields the default column,
+// every mapped enum yields its repository column, an unmapped enum is a
+// BAD_USER_INPUT validation error, and the direction half is delegated to
+// resolveSortDir (an invalid direction surfaces its orderDirection error).
+func TestResolveOrderByColumn(t *testing.T) {
+	t.Parallel()
+
+	allow := map[CardOrderBy]repository.CardOrderBy{
+		CardOrderByID:        repository.CardOrderByID,
+		CardOrderByCreatedAt: repository.CardOrderByCreatedAt,
+		CardOrderByUpdatedAt: repository.CardOrderByUpdatedAt,
+		CardOrderByDue:       repository.CardOrderByDue,
+	}
+
+	createdAt := CardOrderByCreatedAt
+	due := CardOrderByDue
+	bogus := CardOrderBy("BOGUS")
+	descDir := SortOrderDesc
+	bogusDir := SortOrder("SIDEWAYS")
+
+	t.Run("nil orderBy -> default column and direction", func(t *testing.T) {
+		t.Parallel()
+		field, dir, err := resolveOrderByColumn(nil, nil, allow, repository.CardOrderByID, repository.SortAsc)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if field != repository.CardOrderByID {
+			t.Fatalf("field: got %q, want %q", field, repository.CardOrderByID)
+		}
+		if dir != repository.SortAsc {
+			t.Fatalf("dir: got %q, want %q", dir, repository.SortAsc)
+		}
+	})
+
+	t.Run("mapped enum -> repository column", func(t *testing.T) {
+		t.Parallel()
+		field, _, err := resolveOrderByColumn(&createdAt, nil, allow, repository.CardOrderByID, repository.SortAsc)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if field != repository.CardOrderByCreatedAt {
+			t.Fatalf("field: got %q, want %q", field, repository.CardOrderByCreatedAt)
+		}
+	})
+
+	t.Run("mapped enum + explicit direction", func(t *testing.T) {
+		t.Parallel()
+		field, dir, err := resolveOrderByColumn(&due, &descDir, allow, repository.CardOrderByID, repository.SortAsc)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if field != repository.CardOrderByDue {
+			t.Fatalf("field: got %q, want %q", field, repository.CardOrderByDue)
+		}
+		if dir != repository.SortDesc {
+			t.Fatalf("dir: got %q, want %q", dir, repository.SortDesc)
+		}
+	})
+
+	t.Run("unmapped enum -> orderBy validation error", func(t *testing.T) {
+		t.Parallel()
+		field, dir, err := resolveOrderByColumn(&bogus, nil, allow, repository.CardOrderByID, repository.SortAsc)
+		var ve *ucerr.ValidationError
+		if !errors.As(err, &ve) {
+			t.Fatalf("want ValidationError, got %v", err)
+		}
+		if ve.Field != "orderBy" {
+			t.Fatalf("want field orderBy, got %q", ve.Field)
+		}
+		if field != "" || dir != "" {
+			t.Fatalf("want empty field/dir on error, got field=%q dir=%q", field, dir)
+		}
+	})
+
+	t.Run("invalid direction -> orderDirection validation error", func(t *testing.T) {
+		t.Parallel()
+		field, dir, err := resolveOrderByColumn(&createdAt, &bogusDir, allow, repository.CardOrderByID, repository.SortAsc)
+		var ve *ucerr.ValidationError
+		if !errors.As(err, &ve) {
+			t.Fatalf("want ValidationError, got %v", err)
+		}
+		if ve.Field != "orderDirection" {
+			t.Fatalf("want field orderDirection, got %q", ve.Field)
+		}
+		if field != "" || dir != "" {
+			t.Fatalf("want empty field/dir on error, got field=%q dir=%q", field, dir)
+		}
+	})
+}
+
+func TestFirstLastCursor(t *testing.T) {
+	t.Parallel()
+
+	id := func(s string) string { return s }
+
+	tests := []struct {
+		name      string
+		rows      []string
+		wantStart string
+		wantEnd   string
+	}{
+		{name: "empty -> empty, empty", rows: []string{}, wantStart: "", wantEnd: ""},
+		{name: "nil -> empty, empty", rows: nil, wantStart: "", wantEnd: ""},
+		{name: "single -> start == end", rows: []string{"only"}, wantStart: "only", wantEnd: "only"},
+		{name: "multi -> first and last", rows: []string{"a", "b", "c"}, wantStart: "a", wantEnd: "c"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			start, end := firstLastCursor(tc.rows, id)
+			if start != tc.wantStart {
+				t.Fatalf("start: got %q, want %q", start, tc.wantStart)
+			}
+			if end != tc.wantEnd {
+				t.Fatalf("end: got %q, want %q", end, tc.wantEnd)
+			}
+		})
+	}
+}
+
+// TestFirstLastCursor_IDAccessorAppliesCast confirms the id accessor is applied
+// to extract the raw string from a typed newtype element (mirroring the
+// string(cg.ID) / string(u.ID) call shape at the cardgroup and admin-user sites).
+func TestFirstLastCursor_IDAccessorAppliesCast(t *testing.T) {
+	t.Parallel()
+
+	type idNewtype string
+	rows := []idNewtype{"first", "mid", "last"}
+	start, end := firstLastCursor(rows, func(v idNewtype) string { return string(v) })
+	if start != "first" || end != "last" {
+		t.Fatalf("got (%q, %q), want (first, last)", start, end)
 	}
 }


### PR DESCRIPTION
## Summary

Extracts three repeated cursor-plumbing shapes from the four connection usecases (`card`, `cardgroup`, `master_card`, `master_catalog`) into reusable helpers in `internal/usecase/page.go`, alongside the existing `resolveSortDir` / `resolveStandardPageSize` / `assemblePage` / `resolveRelayPage` helpers. This is a no-behaviour-change refactor: the per-aggregate hydration, ownership/scope checks, and column population stay inline; only the shared decode+guard prefix, the table-driven orderBy mapping, and the first/last cursor tail are consolidated.

## What changed

Three new helpers in `internal/usecase/page.go`:

- **`decodeCursorOrBadInput(cursorStr *string, field string) (id string, present bool, err error)`** — the shared cursor decode+guard prefix. A nil/empty cursor returns `present=false`; a malformed cursor returns a `BAD_USER_INPUT` validation error. Wired into the prefix of each `resolve*Cursor` method. The asymmetry is respected: `card.go` / `master_card.go` build the repository cursor struct immediately after decode (ID-order fast path); `cardgroup.go` / `master_catalog.go` hydrate via `FindByID` / `FindPublishedByID` first — both kept inline.
- **`resolveOrderByColumn[K comparable, V any](orderBy *K, dir *SortOrder, allow map[K]V, def V, defDir repository.SortOrder)`** — a generic table-driven orderBy resolver. It validates `orderBy` against a per-aggregate `map[enum]column` allowlist (unknown → `BAD_USER_INPUT`), defaults to the supplied column when `orderBy` is nil, and delegates the direction half to the shared `resolveSortDir`. Each per-aggregate `resolve*OrderBy` collapses to a thin wrapper supplying its own allowlist map + (default column, default direction). The exact enum→column mappings and defaults are preserved unchanged.
- **`firstLastCursor[T any](rows []T, id func(T) string) (start, end string)`** — returns the raw id of the first/last rows, or `"",""` when empty. Wired into the `StartCur`/`EndCur` tail of all four connection outputs (both call sites in `master_catalog.go`) and the `PageInfo.StartCursor`/`EndCursor` pointer-field tail in `admin_user.go` (preserving its `len(users) > 0` guard so empty pages keep nil cursors, unchanged from before).

The now-unused `cursor` import was dropped from `card.go`, `cardgroup.go`, `master_card.go`, and `master_catalog.go` (cursor decoding now flows through `page.go`).

## Test plan

- `cd backend && go build ./... && go vet ./...` — pass (hard gate).
- `go test ./internal/usecase/...` — pass (1230 tests; all existing connection/cursor/orderBy/pagination suites for the four aggregates stay green).
- New direct unit tests in `internal/usecase/page_test.go` cover the three helpers: `decodeCursorOrBadInput` (nil/empty → not present, valid → decoded id, malformed → `BAD_USER_INPUT`), `resolveOrderByColumn` (default column when nil, each mapped enum, unmapped enum → `BAD_USER_INPUT`, invalid direction → `orderDirection` error), and `firstLastCursor` (empty/nil, single, multi, typed-newtype id accessor).
- `go tool go-arch-lint check --project-path .` — OK (no layering regression).
- `gofmt -l` on the changed files — clean.

Closes #647
