### PR TITLE
refactor(backend): keep MasterCardgroup update consistency-only after verify-first

### DIFF
--- a/backend/internal/domain/master_cardgroup.go
+++ b/backend/internal/domain/master_cardgroup.go
@@ -26,7 +26,15 @@ func (s MasterCardgroupStatus) IsValid() bool {
 // the master catalog and is never directly owned by an end user.
 //
 // Name is a CardgroupName so the same grapheme-cluster length invariant
-// (1..CardgroupNameMax) applies without duplicating validation logic.
+// (1..CardgroupNameMax) applies without duplicating validation logic. Status is
+// the only other field that is a value object (MasterCardgroupStatus); its
+// transitions are owned by the Publish / Unpublish methods below. Every remaining
+// field (Description, Language, Level, Category, CoverImageURL, Source,
+// IsDefaultStarter, SortOrder) is free-form with no Parse or bound to protect.
+// That is why the aggregate exposes no update/patch behaviour method: there is no
+// invariant for one to guard. The admin update path (usecase.UpdateMaster) parses
+// Name through ParseCardgroupName at its single seam and assigns the free-form
+// fields directly into the repository patch.
 type MasterCardgroup struct {
 	ID               string
 	Name             CardgroupName

--- a/backend/internal/usecase/master_catalog.go
+++ b/backend/internal/usecase/master_catalog.go
@@ -445,11 +445,25 @@ func (u *masterCatalogUsecase) CreateMaster(ctx context.Context, in CreateMaster
 // Name validation failures surface via outcome.Validation; a missing row surfaces
 // as a validation error on "id". CardCount is fetched so the resolver can populate
 // the response model.
+//
+// There is deliberately no MasterCardgroup.ApplyPatch aggregate method. Of the
+// patchable fields, only Name carries a domain invariant — the CardgroupName VO's
+// grapheme-cluster length bound — and that invariant is already enforced here, at
+// the one seam, via domain.ParseCardgroupName below. Status is the only other VO on
+// the aggregate, and it is not patchable through this method: it has its own
+// dedicated lifecycle seams (Publish / Unpublish). Every remaining field
+// (Description, Language, Level, Category, CoverImageURL, Source, IsDefaultStarter,
+// SortOrder) is free-form (*string / *bool / *int) with no Parse or bound to
+// protect, so it is assigned directly into the repository patch. An ApplyPatch
+// wrapper over those fields would be an indirection layer guarding nothing.
 func (u *masterCatalogUsecase) UpdateMaster(ctx context.Context, id string, in UpdateMasterInput) (UpdateMasterOutcome, error) {
 	if _, err := u.adminGate.Require(ctx, "usecase: master catalog: update master"); err != nil {
 		return UpdateMasterOutcome{}, err
 	}
 
+	// Free-form fields (no domain invariant) flow straight into the patch; only
+	// Name routes through its VO below. See the method docstring for why no
+	// MasterCardgroup.ApplyPatch exists.
 	patch := repository.MasterCardgroupUpdate{
 		Description:      in.Description,
 		Language:         in.Language,


### PR DESCRIPTION
## Summary

Verify-first issue: confirm whether `MasterCardgroup` needs an aggregate-level update/patch method (mirroring `Card.UpdateFront`/`UpdateBack`) before adding one. Determination: no — only `Name` and `Status` carry domain invariants, both already have their seam, and every remaining patch field is free-form. This collapses to a comment-only clarification documenting why no `ApplyPatch` exists.

## What changed

- Verified `backend/internal/domain/master_cardgroup.go`: `Name` is a `CardgroupName` VO and `Status` is a `MasterCardgroupStatus` VO (both carry invariants); `Description` / `Language` / `Level` / `Category` / `CoverImageURL` / `Source` are free-form `*string`, `SortOrder` is `int`, `IsDefaultStarter` is `bool` — none carry a Parse/validation invariant. The only aggregate methods are `IsPublished` / `Publish` / `Unpublish`; there is no update/patch method.
- Verified `backend/internal/usecase/master_catalog.go` `UpdateMaster`: only the `Name` branch routes through `domain.ParseCardgroupName` + `liftValidationErr(translateCardgroupNameErr(...))`; the free-form pointer fields are direct struct assignment. `Status` is not even part of `UpdateMasterInput` — it has its own dedicated `Publish` / `Unpublish` seams.
- Added a clarifying docstring to `UpdateMaster` and to the `MasterCardgroup` aggregate documenting WHY no `MasterCardgroup.ApplyPatch` is added: only `Name`/`Status` carry invariants, both already have their seam, and an `ApplyPatch` wrapper over the free-form fields would be an indirection layer guarding nothing.
- No new aggregate method, no domain test — there is no invariant for one to protect.

## Determination

DOWNGRADE to consistency-only. The evidence (read directly from source, not the issue body) confirms the non-`Name` patch fields carry no domain invariant, so inventing a `MasterCardgroup.ApplyPatch` for free-form pointers would add an indirection layer guarding nothing. The `Name` half already routes through `domain.ParseCardgroupName` at its single seam; the free-form fields stay as direct struct assignment. The change is comment-only.

## Test plan

- `cd backend && go build ./...` — passes (rc 0)
- `cd backend && go vet ./...` — passes (rc 0)
- `cd backend && go test ./internal/...` — all packages pass (rc 0)
- CJK gate on both touched files — clean

## Stacked PR note

This PR is STACKED on #647 (`ddd3-647-usecase-page-dedup`). The base branch is `ddd3-647-usecase-page-dedup`, not `main`. GitHub will only register the closing-issue link and run the backend CI workflow (which triggers on `pull_request` to `main`) after #647 merges and this PR is retargeted to `main`.

Closes #651
