### PR TITLE
refactor(backend): extract generic takeByID not-found helper for single-row repos

### DIFF
--- a/backend/internal/repository/card.go
+++ b/backend/internal/repository/card.go
@@ -124,13 +124,9 @@ func (r *cardRepo) FindByIDTx(ctx context.Context, tx *gorm.DB, id string) (*dom
 }
 
 func findCardByID(ctx context.Context, db *gorm.DB, id string) (*domain.Card, error) {
-	var row gormCard
-	err := db.WithContext(ctx).Where("id = ?", id).Take(&row).Error
+	row, err := takeByID[gormCard](ctx, db, "id = ?", []any{id}, ErrNotFound, "repository: card: find by id")
 	if err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil, ErrNotFound
-		}
-		return nil, eris.Wrap(err, "repository: card: find by id")
+		return nil, err
 	}
 	return cardToDomain(row), nil
 }
@@ -187,15 +183,9 @@ func (r *cardRepo) Create(ctx context.Context, card *domain.Card) error {
 }
 
 func (r *cardRepo) FindByCardgroupAndFront(ctx context.Context, cardgroupID, front string) (*domain.Card, error) {
-	var row gormCard
-	err := r.db.WithContext(ctx).
-		Where("cardgroup_id = ? AND front = ?", cardgroupID, front).
-		Take(&row).Error
+	row, err := takeByID[gormCard](ctx, r.db, "cardgroup_id = ? AND front = ?", []any{cardgroupID, front}, ErrNotFound, "repository: card: find by cardgroup and front")
 	if err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil, ErrNotFound
-		}
-		return nil, eris.Wrap(err, "repository: card: find by cardgroup and front")
+		return nil, err
 	}
 	return cardToDomain(row), nil
 }

--- a/backend/internal/repository/cardgroup.go
+++ b/backend/internal/repository/cardgroup.go
@@ -94,13 +94,9 @@ func NewCardgroupRepository(db *gorm.DB) CardgroupRepository { return &cardgroup
 
 // FindByID returns the cardgroup with the given id, or ErrNotFound.
 func (r *cardgroupRepo) FindByID(ctx context.Context, id string) (*domain.Cardgroup, error) {
-	var row gormCardgroup
-	err := r.db.WithContext(ctx).Where("id = ?", id).Take(&row).Error
+	row, err := takeByID[gormCardgroup](ctx, r.db, "id = ?", []any{id}, ErrNotFound, "repository: cardgroup: find by id")
 	if err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil, ErrNotFound
-		}
-		return nil, eris.Wrap(err, "repository: cardgroup: find by id")
+		return nil, err
 	}
 	return cardgroupToDomain(row), nil
 }
@@ -108,15 +104,9 @@ func (r *cardgroupRepo) FindByID(ctx context.Context, id string) (*domain.Cardgr
 // FindByName returns the cardgroup identified by the (owner_id, name) pair, or
 // ErrNotFound when no such row exists.
 func (r *cardgroupRepo) FindByName(ctx context.Context, ownerID, name string) (*domain.Cardgroup, error) {
-	var row gormCardgroup
-	err := r.db.WithContext(ctx).
-		Where("owner_id = ? AND name = ?", ownerID, name).
-		Take(&row).Error
+	row, err := takeByID[gormCardgroup](ctx, r.db, "owner_id = ? AND name = ?", []any{ownerID, name}, ErrNotFound, "repository: cardgroup: find by name")
 	if err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil, ErrNotFound
-		}
-		return nil, eris.Wrap(err, "repository: cardgroup: find by name")
+		return nil, err
 	}
 	return cardgroupToDomain(row), nil
 }

--- a/backend/internal/repository/master_card.go
+++ b/backend/internal/repository/master_card.go
@@ -149,13 +149,9 @@ func (r *masterCardRepo) ListByMasterCardgroup(ctx context.Context, masterCardgr
 // FindByID returns the master card with the given primary key, or ErrNotFound
 // when no row matches. Single-row PK lookup mirroring cardRepo.FindByID.
 func (r *masterCardRepo) FindByID(ctx context.Context, id string) (*domain.MasterCard, error) {
-	var row gormMasterCard
-	err := r.db.WithContext(ctx).Where("id = ?", id).Take(&row).Error
+	row, err := takeByID[gormMasterCard](ctx, r.db, "id = ?", []any{id}, ErrNotFound, "repository: master card: find by id")
 	if err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil, ErrNotFound
-		}
-		return nil, eris.Wrap(err, "repository: master card: find by id")
+		return nil, err
 	}
 	return masterCardToDomain(row), nil
 }
@@ -307,15 +303,9 @@ func (r *masterCardRepo) Create(ctx context.Context, c *domain.MasterCard) error
 // (master_cardgroup_id, front) unique key, or ErrNotFound when no row matches.
 // front is matched case-insensitively because the column is citext.
 func (r *masterCardRepo) FindByMasterCardgroupAndFront(ctx context.Context, masterCardgroupID, front string) (*domain.MasterCard, error) {
-	var row gormMasterCard
-	err := r.db.WithContext(ctx).
-		Where("master_cardgroup_id = ? AND front = ?", masterCardgroupID, front).
-		Take(&row).Error
+	row, err := takeByID[gormMasterCard](ctx, r.db, "master_cardgroup_id = ? AND front = ?", []any{masterCardgroupID, front}, ErrNotFound, "repository: master card: find by master cardgroup and front")
 	if err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil, ErrNotFound
-		}
-		return nil, eris.Wrap(err, "repository: master card: find by master cardgroup and front")
+		return nil, err
 	}
 	return masterCardToDomain(row), nil
 }

--- a/backend/internal/repository/master_cardgroup.go
+++ b/backend/internal/repository/master_cardgroup.go
@@ -147,13 +147,9 @@ func NewMasterCardgroupRepository(db *gorm.DB) MasterCardgroupRepository {
 
 // FindByID returns the master cardgroup with the given id, or ErrNotFound.
 func (r *masterCardgroupRepo) FindByID(ctx context.Context, id string) (*domain.MasterCardgroup, error) {
-	var row gormMasterCardgroup
-	err := r.db.WithContext(ctx).Where("id = ?", id).Take(&row).Error
+	row, err := takeByID[gormMasterCardgroup](ctx, r.db, "id = ?", []any{id}, ErrNotFound, "repository: master cardgroup: find by id")
 	if err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil, ErrNotFound
-		}
-		return nil, eris.Wrap(err, "repository: master cardgroup: find by id")
+		return nil, err
 	}
 	return masterCardgroupToDomain(row)
 }
@@ -302,15 +298,9 @@ func (r *masterCardgroupRepo) ListDefaultStarters(ctx context.Context) ([]*domai
 // or ErrNotFound. A draft row also returns ErrNotFound because the public
 // catalog never exposes draft decks.
 func (r *masterCardgroupRepo) FindPublishedByID(ctx context.Context, id string) (*domain.MasterCardgroup, error) {
-	var row gormMasterCardgroup
-	err := r.db.WithContext(ctx).
-		Where("id = ? AND status = ?", id, string(domain.MasterStatusPublished)).
-		Take(&row).Error
+	row, err := takeByID[gormMasterCardgroup](ctx, r.db, "id = ? AND status = ?", []any{id, string(domain.MasterStatusPublished)}, ErrNotFound, "repository: master cardgroup: find published by id")
 	if err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil, ErrNotFound
-		}
-		return nil, eris.Wrap(err, "repository: master cardgroup: find published by id")
+		return nil, err
 	}
 	return masterCardgroupToDomain(row)
 }

--- a/backend/internal/repository/role.go
+++ b/backend/internal/repository/role.go
@@ -79,25 +79,17 @@ type roleRepo struct{ db *gorm.DB }
 func NewRoleRepository(db *gorm.DB) RoleRepository { return &roleRepo{db: db} }
 
 func (r *roleRepo) FindByID(ctx context.Context, id string) (*domain.Role, error) {
-	var row gormRole
-	err := r.db.WithContext(ctx).Where("id = ?", id).Take(&row).Error
+	row, err := takeByID[gormRole](ctx, r.db, "id = ?", []any{id}, ErrRoleNotFound, "repository: find role by id")
 	if err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil, ErrRoleNotFound
-		}
-		return nil, eris.Wrap(err, "repository: find role by id")
+		return nil, err
 	}
 	return roleToDomain(row), nil
 }
 
 func (r *roleRepo) FindByName(ctx context.Context, name domain.RoleName) (*domain.Role, error) {
-	var row gormRole
-	err := r.db.WithContext(ctx).Where("name = ?", name).Take(&row).Error
+	row, err := takeByID[gormRole](ctx, r.db, "name = ?", []any{name}, ErrRoleNotFound, "repository: find role by name")
 	if err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil, ErrRoleNotFound
-		}
-		return nil, eris.Wrap(err, "repository: find role by name")
+		return nil, err
 	}
 	return roleToDomain(row), nil
 }

--- a/backend/internal/repository/take_by_id.go
+++ b/backend/internal/repository/take_by_id.go
@@ -1,0 +1,45 @@
+package repository
+
+import (
+	"context"
+	"errors"
+
+	"github.com/rotisserie/eris"
+	"gorm.io/gorm"
+)
+
+// takeByID runs a single-row lookup (db.Where(where, args...).Take) and
+// classifies the result into one of three outcomes: the populated row, the
+// caller-supplied not-found sentinel, or an infrastructure error wrapped with
+// the caller-supplied prefix.
+//
+// Both the sentinel and the wrap prefix are parameters rather than constants
+// because they vary per aggregate: most repos use ErrNotFound, roleRepo uses
+// ErrRoleNotFound, and each call site owns a distinct "repository: <aggregate>:
+// ..." wrap prefix. Passing the prefix in (instead of hardcoding one here) keeps
+// the error_chain attribution pointed at the calling aggregate's module rather
+// than this shared helper, per .claude/rules/error-wrapping.md § "Shared helpers
+// must not embed a layer prefix wrap".
+//
+// The helper deliberately stops at the Take + not-found classification and
+// returns the raw GORM row; the caller runs its own *toDomain conversion. The
+// per-aggregate converters diverge (some return a bare pointer, masterCardgroup
+// returns (*domain.MasterCardgroup, error)), so folding conversion in here would
+// not collapse cleanly.
+func takeByID[Row any](
+	ctx context.Context,
+	db *gorm.DB,
+	where string,
+	args []any,
+	notFound error,
+	wrap string,
+) (Row, error) {
+	var row Row
+	if err := db.WithContext(ctx).Where(where, args...).Take(&row).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return row, notFound
+		}
+		return row, eris.Wrap(err, wrap)
+	}
+	return row, nil
+}

--- a/backend/internal/repository/user.go
+++ b/backend/internal/repository/user.go
@@ -126,13 +126,9 @@ type userRepo struct{ db *gorm.DB }
 func NewUserRepository(db *gorm.DB) UserRepository { return &userRepo{db: db} }
 
 func (r *userRepo) FindByID(ctx context.Context, id string) (*domain.User, error) {
-	var row gormUser
-	err := r.db.WithContext(ctx).Where("id = ?", id).Take(&row).Error
+	row, err := takeByID[gormUser](ctx, r.db, "id = ?", []any{id}, ErrNotFound, "repository: user: find by id")
 	if err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil, ErrNotFound
-		}
-		return nil, eris.Wrap(err, "repository: user: find by id")
+		return nil, err
 	}
 	return userToDomain(row), nil
 }

--- a/backend/internal/repository/user_preference.go
+++ b/backend/internal/repository/user_preference.go
@@ -65,13 +65,9 @@ func NewUserPreferenceRepository(db *gorm.DB) UserPreferenceRepository {
 }
 
 func (r *userPreferenceRepo) FindByUserID(ctx context.Context, userID string) (*domain.UserPreference, error) {
-	var row gormUserPreference
-	err := r.db.WithContext(ctx).Where("user_id = ?", userID).Take(&row).Error
+	row, err := takeByID[gormUserPreference](ctx, r.db, "user_id = ?", []any{userID}, ErrNotFound, "repository: user preference: find by user_id")
 	if err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil, ErrNotFound
-		}
-		return nil, eris.Wrap(err, "repository: user preference: find by user_id")
+		return nil, err
 	}
 	return toDomainUserPreference(row), nil
 }


### PR DESCRIPTION
## Summary

Collapses the repeated single-row `Take` + not-found classification block (`db.Where(...).Take(&row)` → `errors.Is(err, gorm.ErrRecordNotFound)` → typed sentinel, else `eris.Wrap`) that was copied across the aggregate repos into one generic helper `takeByID[Row any]` in `backend/internal/repository/take_by_id.go`. No behaviour change: the same sentinel and the same wrap-prefix string are emitted at every call site; only the `Take` + classification step is shared, while each caller keeps its own `*toDomain` conversion.

## What changed

- **New `takeByID[Row any](ctx, db, where string, args []any, notFound error, wrap string) (Row, error)`** in `take_by_id.go`. It runs `db.WithContext(ctx).Where(where, args...).Take(&row)` and returns one of three outcomes: the populated row, the caller-supplied `notFound` sentinel, or `eris.Wrap(err, wrap)` for an infrastructure error. The sentinel and wrap prefix are **parameters, not constants** — they vary per aggregate, and passing the prefix in keeps the `error_chain` attribution pointed at the calling aggregate's module rather than this shared helper (per [`.claude/rules/error-wrapping.md` § "Shared helpers must not embed a layer prefix wrap"](.claude/rules/error-wrapping.md)). The helper deliberately stops at the `Take` + not-found classification and returns the raw GORM row, because the per-aggregate `*toDomain` converters diverge (`masterCardgroupToDomain` returns `(*domain.MasterCardgroup, error)`; the rest return a bare pointer).
- **Routed 12 single-row lookup call sites through the helper**, each collapsing to `row, err := takeByID[...](...)` followed by its existing `*toDomain(row)`:
  - `card.go`: `findCardByID`, `FindByCardgroupAndFront`
  - `master_card.go`: `FindByID`, `FindByMasterCardgroupAndFront`
  - `cardgroup.go`: `FindByID`, `FindByName`
  - `master_cardgroup.go`: `FindByID`, `FindPublishedByID`
  - `role.go`: `FindByID`, `FindByName` (the one aggregate whose sentinel is `ErrRoleNotFound`, not `ErrNotFound`)
  - `user.go`: `FindByID`
  - `user_preference.go`: `FindByUserID`
- **Scope beyond the issue's 7 listed arms.** The issue enumerated the 7 `FindByID`/`FindByUserID` arms; the same `Take` + not-found shape also appears in 5 sibling methods in the same owned files (`card.FindByCardgroupAndFront`, `master_card.FindByMasterCardgroupAndFront`, `cardgroup.FindByName`, `role.FindByName`, `master_cardgroup.FindPublishedByID`). They are converted too, per the same-file/same-pattern rule in [`.claude/rules/scope-discipline.md`](.claude/rules/scope-discipline.md), so the helper is not left half-applied within a file.
- **Left out of scope** (genuinely different shapes, not simple single-row `Take` → `*toDomain`): the `EnsureByName` negated `!errors.Is` create-path arms (`cardgroup.go`, `master_cardgroup.go`), the `applyStatusTransition` FOR UPDATE lock path, and the `Select(...)`-projection probes in `user.UpdateTxVersioned` and the user cursor hydration.
- `role.go`'s existing wrap strings (`"repository: find role by id"` / `"repository: find role by name"`) are preserved verbatim — normalizing them to the two-segment form is a separate concern and would be a behaviour change.

## Test plan

- `cd backend && go build ./...` — pass.
- `cd backend && go vet ./...` — pass.
- `cd backend && go test -count=1 ./internal/repository/...` — pass (293 tests, testcontainers Postgres). The existing per-repo `FindByID` / `FindByName` / `FindBy*AndFront` / `FindPublishedByID` suites are the regression net: they cover both the not-found-sentinel arm and the success arm for every routed call site, and the sentinel pass-through directionality is pinned by `role` returning `ErrRoleNotFound` (`role_crud_test.go`) vs. the other sites returning `ErrNotFound`, both through the shared helper.
- `go tool go-arch-lint check --project-path .` — OK (no new imports; layer graph unchanged).
- No new direct unit test added: per [`docs/backend/library-gotchas/direct-unit-test-for-shared-helper.md`](docs/backend/library-gotchas/direct-unit-test-for-shared-helper.md) the helper's not-found and success arms are fully covered by the 12 call-site integration tests, so coverage does not drop (the 12 inline wrap lines collapse to one).

Closes #652
