### PR TITLE
style(frontend): gap catalog deck card rows and balance header spacing

### DIFF
--- a/frontend/src/app/catalog/[id]/_components/catalog-deck-skeleton.tsx
+++ b/frontend/src/app/catalog/[id]/_components/catalog-deck-skeleton.tsx
@@ -18,21 +18,21 @@ export function CatalogDeckSkeleton() {
         <div className="mt-1 flex justify-center">
           <Skeleton className="h-8 w-48" />
         </div>
-        <div className="mt-3 flex justify-center gap-2">
+        <div className="mt-2 flex justify-center gap-2">
           <Skeleton className="h-5 w-12" />
           <Skeleton className="h-5 w-16" />
         </div>
       </header>
 
       <ul
-        className="divide-y divide-border overflow-hidden rounded-md border border-border"
+        className="space-y-3"
         aria-busy="true"
         aria-label="Loading deck"
         data-testid="catalog-deck-skeleton"
       >
         {Array.from({ length: 6 }).map((_, i) => (
           // biome-ignore lint/suspicious/noArrayIndexKey: static placeholder rows have no stable id.
-          <li key={i} className="space-y-1 px-4 py-3">
+          <li key={i} className="space-y-1 rounded-lg border border-border bg-background px-4 py-3">
             <Skeleton className="h-4 w-3/4" />
             <Skeleton className="h-4 w-1/2" />
           </li>

--- a/frontend/src/app/catalog/[id]/catalog-deck-client.tsx
+++ b/frontend/src/app/catalog/[id]/catalog-deck-client.tsx
@@ -197,10 +197,7 @@ export default function CatalogDeckClient({
           )}
 
           {edges.length > 0 && (
-            <ul
-              className="divide-y divide-border overflow-hidden rounded-md border border-border"
-              data-testid="catalog-deck-card-list"
-            >
+            <ul className="space-y-3" data-testid="catalog-deck-card-list">
               {edges.map((edge) => (
                 <li key={edge.node.id}>
                   <ReadOnlyCardRow card={edge.node} />

--- a/frontend/src/app/catalog/[id]/catalog-deck-header.tsx
+++ b/frontend/src/app/catalog/[id]/catalog-deck-header.tsx
@@ -52,24 +52,26 @@ export function CatalogDeckHeader({
         </span>
       }
     >
-      <div className="mt-3 flex flex-col items-center gap-2">
-        {(deck.language || deck.level || deck.category) && (
-          <div className="flex flex-wrap items-center justify-center gap-2">
-            {deck.language && <Badge variant="secondary">{deck.language}</Badge>}
-            {deck.level && <Badge variant="outline">{t("level", { level: deck.level })}</Badge>}
-            {deck.category && <Badge variant="outline">{deck.category}</Badge>}
-          </div>
-        )}
-        {deck.description && (
-          <p
-            className="max-w-2xl text-center text-sm text-muted-foreground"
-            data-testid="catalog-deck-description"
-          >
-            {deck.description}
-          </p>
-        )}
-      </div>
-      <div className="mt-4">
+      {(deck.language || deck.level || deck.category || deck.description) && (
+        <div className="mt-2 flex flex-col items-center gap-2">
+          {(deck.language || deck.level || deck.category) && (
+            <div className="flex flex-wrap items-center justify-center gap-2">
+              {deck.language && <Badge variant="secondary">{deck.language}</Badge>}
+              {deck.level && <Badge variant="outline">{t("level", { level: deck.level })}</Badge>}
+              {deck.category && <Badge variant="outline">{deck.category}</Badge>}
+            </div>
+          )}
+          {deck.description && (
+            <p
+              className="max-w-2xl text-center text-sm text-muted-foreground"
+              data-testid="catalog-deck-description"
+            >
+              {deck.description}
+            </p>
+          )}
+        </div>
+      )}
+      <div className="mt-2">
         <CatalogImportButton
           card={{ id: deck.id }}
           importing={importing}

--- a/frontend/src/components/cardgroups/read-only-card-row.tsx
+++ b/frontend/src/components/cardgroups/read-only-card-row.tsx
@@ -4,16 +4,23 @@ export type ReadOnlyCardRowProps = {
 
 /**
  * Presentation-only card row for the public catalog deck-detail view
- * (`/catalog/[id]`). Reuses the spacing and typography of {@link CardRow}'s text
- * content — `px-4 py-3` padding with a truncated `font-medium` front line and a
- * truncated `text-muted-foreground` back line — but carries none of the edit
- * chrome: no `SwipeableRow`, no selection checkbox, no delete button, no
- * `role="button"`/onClick. It is a pure stateless component (no hooks), so it
- * intentionally omits `"use client"`.
+ * (`/catalog/[id]`). Each row is a discrete bordered card — `rounded-lg border
+ * border-border bg-background` matching {@link CardgroupListItem}'s card chrome —
+ * so the list reads as gapped cards (the consumer's `<ul>` supplies the
+ * inter-card `space-y-3`) rather than a single divided table. It reuses
+ * {@link CardRow}'s text spacing and typography (`px-4 py-3` padding, a truncated
+ * `font-medium` front line, a truncated `text-muted-foreground` back line) but
+ * carries none of the edit chrome: no `SwipeableRow`, no selection checkbox, no
+ * delete button, no `role="button"`/onClick (it is non-interactive — there is no
+ * card-detail route to navigate to). It is a pure stateless component (no hooks),
+ * so it intentionally omits `"use client"`.
  */
 export function ReadOnlyCardRow({ card }: ReadOnlyCardRowProps) {
   return (
-    <div className="px-4 py-3" data-testid={`read-only-card-${card.id}`}>
+    <div
+      className="rounded-lg border border-border bg-background px-4 py-3"
+      data-testid={`read-only-card-${card.id}`}
+    >
       <p className="truncate text-sm font-medium">{card.front}</p>
       <p className="truncate text-sm text-muted-foreground">{card.back}</p>
     </div>


### PR DESCRIPTION
## Summary

Two visual spacing fixes on the public catalog deck-detail screen (`/catalog/[id]`), taken through a principal UI/UX designer review pass. The card list now reads as discrete gapped cards (matching the `/cardgroups` list) instead of one divided table, and the deck header's vertical spacing around the title is symmetric (8px above and below) with no empty spacer on a badge-less deck.

## What changed

### Card-row gaps (catalog deck list)

- `catalog-deck-client.tsx`: the card-list `<ul>` drops the `divide-y divide-border overflow-hidden rounded-md border border-border` table chrome for `space-y-3`, so rows are gapped instead of butted against shared dividers.
- `read-only-card-row.tsx`: each row becomes a discrete card with `rounded-lg border border-border bg-background px-4 py-3`, mirroring `CardgroupListItem`'s chrome. No hover state — the row is non-interactive (there is no card-detail route), so a hover affordance would imply a click that does nothing. Docblock updated to describe the gapped-card model.

### Header spacing (catalog deck header)

- `catalog-deck-header.tsx`: the badges/description block is now conditionally rendered, removing the empty `mt-3` spacer a deck with no badges and no description previously emitted (the hidden contributor to the perceived above/below asymmetry). The first element below the title (badges block or the import CTA) now sits at `mt-2`, matching the shared `DetailPageHeader`'s `mt-2` above the title — symmetric 8px / 8px.
- The shared `DetailPageHeader` is deliberately left untouched: bumping its `mt-2` would regress the master-edit header's status-chip binding (`mt-1` below the title), so the fix is scoped to the catalog consumer.

### Loading skeleton parity

- `catalog-deck-skeleton.tsx`: mirrors the new layout so the skeleton-to-content transition does not jump — card-list rows use `space-y-3` + per-row `rounded-lg border` chrome, and the badge row tracks the header's `mt-3` to `mt-2`.

## Test plan

- `pnpm --filter frontend test` — catalog deck/list + `read-only-card-row` suites pass (23 narrow + 16 broad page tests across `catalog-deck.test.tsx` / `catalog-list.test.tsx`).
- `tsc --noEmit` — clean.
- `biome check --error-on-warnings` on the four changed files — clean.
- CJK / language-policy grep on the changed `.tsx` files — clean.

No associated issue — directly-reported design polish on `/catalog/[id]`.
