### PR TITLE
style(frontend): slim master-edit mobile status pill

### DIFF
--- a/frontend/src/app/admin/masters/[id]/edit/master-edit-header.tsx
+++ b/frontend/src/app/admin/masters/[id]/edit/master-edit-header.tsx
@@ -183,7 +183,7 @@ export function MasterEditHeader({ master, cardCount, onBatchImport }: Props) {
               type="button"
               data-testid="master-edit-status-chip"
               aria-label={t("changePublishState", { state: statusLabel })}
-              className="inline-flex min-h-11 items-center gap-1.5 rounded-full border px-3 py-1.5 text-sm font-medium hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+              className="inline-flex min-h-9 items-center gap-1.5 rounded-full border px-3 py-1 text-sm font-medium hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
             >
               <span
                 aria-hidden="true"


### PR DESCRIPTION
## Summary

On narrow viewports the master-edit header's publish-state pill — the interactive status chip below the deck title — rendered at a 44px tap-target floor that read as chunky against the slim title row. This trims its height to 36px while keeping it comfortably tappable, bringing it closer to the slim desktop status badge.

## What changed

- `master-edit-header.tsx`: the mobile status chip (`data-testid="master-edit-status-chip"`, `md:hidden`) drops `min-h-11` (44px) → `min-h-9` (36px) and `py-1.5` (6px) → `py-1` (4px). Horizontal padding (`px-3`), the leading status dot, and the disclosure chevron are unchanged, so only the vertical thickness shrinks. 36px stays above the WCAG AA 24px minimum target size, so the publish-toggle tap target is preserved.
- The desktop read-only `MasterStatusBadge` is untouched — it already renders slim via the shared `Badge`, and the change is scoped to the chunky mobile chip only.

## Verification

- On a master-edit page (`/admin/masters/[id]/edit`) at mobile width, the `master-edit-status-chip` button computes to `min-height: 36px` (was 44px); tapping it still opens the publish/unpublish dropdown.

## Test plan

- [ ] `pnpm --filter frontend test` — `master-edit-header` suite passes (no test pins the chip's class string; the testid-keyed click tests still resolve the trigger).
- [ ] `pnpm --filter frontend typecheck` + `biome check --error-on-warnings` on the changed file — clean.

No associated issue — directly-reported visual polish on the master-edit header.
