### PR TITLE
feat(frontend): replace listing-page count (N) with a localized count pill

### DIFF
--- a/frontend/__tests__/admin-masters-list.test.tsx
+++ b/frontend/__tests__/admin-masters-list.test.tsx
@@ -253,8 +253,8 @@ describe("AdminMastersClient (broad page test)", () => {
     // List container rendered.
     expect(screen.getByTestId("admin-masters-list")).toBeInTheDocument();
 
-    // totalCount shown (3 in parens).
-    expect(screen.getByText("(3)")).toBeInTheDocument();
+    // totalCount shown as the "N total" pill label.
+    expect(screen.getByText("3 total")).toBeInTheDocument();
 
     // Each row links to the edit page — no edit sheet.
     expect(screen.getByRole("link", { name: /edit deck m-1/i })).toHaveAttribute(

--- a/frontend/__tests__/admin-users-list.test.tsx
+++ b/frontend/__tests__/admin-users-list.test.tsx
@@ -228,8 +228,8 @@ describe("AdminUsersClient", () => {
     expect(screen.queryByRole("checkbox", { name: "general" })).not.toBeInTheDocument();
     expect(screen.getAllByRole("button", { name: /edit user/i })).toHaveLength(3);
 
-    // totalCount shown (3 in parens).
-    expect(screen.getByText("(3)")).toBeInTheDocument();
+    // totalCount shown as the "N total" pill label.
+    expect(screen.getByText("3 total")).toBeInTheDocument();
   });
 
   // T2: Debounced search — typing "ali" issues ONE query with search:"ali" after 300ms.

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -15,7 +15,8 @@
     "keepEditing": "Keep editing",
     "discard": "Discard",
     "cannotBeUndone": "This action cannot be undone.",
-    "deleteSelected": "Delete selected"
+    "deleteSelected": "Delete selected",
+    "totalCount": "{count, number} total"
   },
   "Nav": {
     "cardgroups": "Cardgroups",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -15,7 +15,8 @@
     "keepEditing": "編集を続ける",
     "discard": "破棄",
     "cannotBeUndone": "この操作は元に戻せません。",
-    "deleteSelected": "選択を削除"
+    "deleteSelected": "選択を削除",
+    "totalCount": "全{count, number}件"
   },
   "Nav": {
     "cardgroups": "カードグループ",

--- a/frontend/src/app/admin/masters/admin-masters-client.tsx
+++ b/frontend/src/app/admin/masters/admin-masters-client.tsx
@@ -144,6 +144,7 @@ export function AdminMastersClient() {
       <ListingPageShell
         title={t("title")}
         count={totalCount}
+        countLabel={tCommon("totalCount", { count: totalCount })}
         primaryActions={
           <Button
             type="button"

--- a/frontend/src/app/admin/roles/admin-roles-client.tsx
+++ b/frontend/src/app/admin/roles/admin-roles-client.tsx
@@ -409,6 +409,7 @@ export function AdminRolesClient({ initialRoles }: Props) {
     <ListingPageShell
       title={tNav("roles")}
       count={roles.length}
+      countLabel={tCommon("totalCount", { count: roles.length })}
       primaryActions={
         <Button
           type="button"

--- a/frontend/src/app/admin/users/admin-users-client.tsx
+++ b/frontend/src/app/admin/users/admin-users-client.tsx
@@ -245,6 +245,7 @@ export function AdminUsersClient() {
       <ListingPageShell
         title={tNav("users")}
         count={totalCount}
+        countLabel={tCommon("totalCount", { count: totalCount })}
         toolbar={
           // Desktop-only search input; mobile uses the header takeover above.
           <div className="hidden md:block">

--- a/frontend/src/app/cardgroups/cardgroups-client.tsx
+++ b/frontend/src/app/cardgroups/cardgroups-client.tsx
@@ -346,6 +346,7 @@ export default function CardgroupsClient({ initialConnection }: CardgroupsClient
       <ListingPageShell
         title={t("myCardgroups")}
         count={totalCount}
+        countLabel={tCommon("totalCount", { count: totalCount })}
         primaryActions={
           <Button
             type="button"

--- a/frontend/src/app/catalog/catalog-client.tsx
+++ b/frontend/src/app/catalog/catalog-client.tsx
@@ -158,6 +158,7 @@ export default function CatalogClient({ initialConnection }: CatalogClientProps)
       <ListingPageShell
         title={t("title")}
         count={totalCount}
+        countLabel={tCommon("totalCount", { count: totalCount })}
         toolbar={
           <div className="mb-2 hidden md:block">
             <input

--- a/frontend/src/components/layout/listing-page-shell.test.tsx
+++ b/frontend/src/components/layout/listing-page-shell.test.tsx
@@ -82,7 +82,7 @@ describe("<ListingPageShell>", () => {
     expect(main?.className).toContain("p-8");
   });
 
-  it("renders the count as a muted (N) sharing the title cluster, inline beside the title on desktop", () => {
+  it("renders the count as a muted pill sharing the title cluster, inline beside the title on desktop", () => {
     render(
       <ListingPageShell title="Users" count={42}>
         <div />
@@ -90,12 +90,39 @@ describe("<ListingPageShell>", () => {
     );
 
     const heading = screen.getByRole("heading", { level: 1, name: "Users" });
-    const count = screen.getByText("(42)");
-    expect(count).toHaveClass("text-muted-foreground");
+    const count = screen.getByText("42");
+    // Muted, pill-shaped, and a static label (never an interactive control).
+    expect(count).toHaveClass("text-muted-foreground", "rounded-full");
+    expect(count.tagName).toBe("SPAN");
     // Count and title share one cluster so the count sits next to the heading.
     expect(count.parentElement).toBe(heading.parentElement);
     // Desktop lays them out on one baseline-aligned row (mobile stacks them).
     expect(heading.parentElement).toHaveClass("md:flex-row", "md:items-baseline");
+  });
+
+  it("renders countLabel inside the pill when provided", () => {
+    render(
+      <ListingPageShell title="Users" count={42} countLabel="42 total">
+        <div />
+      </ListingPageShell>,
+    );
+
+    const pill = screen.getByText("42 total");
+    expect(pill).toHaveClass("rounded-full", "text-muted-foreground");
+    expect(pill.tagName).toBe("SPAN");
+    // The bare number is replaced by the label, not shown alongside it.
+    expect(screen.queryByText("42")).toBeNull();
+  });
+
+  it("does not render the count pill when count is omitted", () => {
+    render(
+      <ListingPageShell title="Users">
+        <div />
+      </ListingPageShell>,
+    );
+
+    const heading = screen.getByRole("heading", { level: 1, name: "Users" });
+    expect(heading.parentElement?.querySelector(".rounded-full")).toBeNull();
   });
 
   it("renders the title with the shared page-title type token", () => {

--- a/frontend/src/components/layout/listing-page-shell.tsx
+++ b/frontend/src/components/layout/listing-page-shell.tsx
@@ -4,7 +4,7 @@ import { cn } from "@/lib/utils";
 interface ListingPageShellProps {
   /** Page title. Centered on mobile, left-aligned on desktop. */
   title: ReactNode;
-  /** Optional total-count badge rendered as a muted `(N)`: below the title on mobile, inline to its right on desktop. */
+  /** Optional total count rendered as a neutral pill: below the title on mobile, inline to its right on desktop. */
   count?: number;
   /** Optional fully-formatted, localized label rendered inside the count pill (e.g. "14 total"). Falls back to the bare `count` number when omitted. */
   countLabel?: ReactNode;

--- a/frontend/src/components/layout/listing-page-shell.tsx
+++ b/frontend/src/components/layout/listing-page-shell.tsx
@@ -6,6 +6,8 @@ interface ListingPageShellProps {
   title: ReactNode;
   /** Optional total-count badge rendered as a muted `(N)`: below the title on mobile, inline to its right on desktop. */
   count?: number;
+  /** Optional fully-formatted, localized label rendered inside the count pill (e.g. "14 total"). Falls back to the bare `count` number when omitted. */
+  countLabel?: ReactNode;
   /** Optional supporting copy under the title. */
   description?: ReactNode;
   /** Optional CTA cluster (desktop create button etc.): below the title on mobile, on the trailing edge of the header row on desktop. */
@@ -39,6 +41,7 @@ interface ListingPageShellProps {
 export function ListingPageShell({
   title,
   count,
+  countLabel,
   description,
   primaryActions,
   toolbar,
@@ -54,7 +57,11 @@ export function ListingPageShell({
         <div className="flex flex-col items-center gap-1 md:items-start">
           <div className="flex flex-col items-center gap-1 md:flex-row md:items-baseline md:gap-2">
             <h1 className="text-page-title font-bold leading-tight tracking-normal">{title}</h1>
-            {count != null && <span className="text-sm text-muted-foreground">({count})</span>}
+            {count != null && (
+              <span className="inline-flex items-center rounded-full border bg-muted px-2.5 py-0.5 text-sm font-medium text-muted-foreground tabular-nums">
+                {countLabel ?? count}
+              </span>
+            )}
           </div>
           {description != null && <div className="text-muted-foreground">{description}</div>}
         </div>


### PR DESCRIPTION
## Summary

The five listing-page headers rendered their total count as a bare muted `(N)` parenthetical floating under the title, which read as an unfinished, low-meaning number. This replaces it with a neutral grey, non-interactive pill carrying a localized total-count label — `N total` (en) / `全N件` (ja) — across all five listing pages via the shared `ListingPageShell`. The treatment was chosen through a principal UI/UX designer review pass over the count "あしらい".

## What changed

### Count pill in `ListingPageShell`

- `listing-page-shell.tsx`: the count render drops the `({count})` muted span for a neutral pill (`inline-flex items-center rounded-full border bg-muted px-2.5 py-0.5 text-sm font-medium text-muted-foreground tabular-nums`). A new optional `countLabel?: ReactNode` prop renders `countLabel ?? count` inside the pill; `count` stays the presence gate, so the component is backward compatible and stays **i18n-unaware** (no translation hook added). The pill is a static `<span>` with no hover/focus affordance — it must not read as a clickable filter chip. Neutral grey is deliberate: the coral `brand` token is reserved for constructive CTAs.

### Shared `Common.totalCount` message

- `messages/en.json` / `messages/ja.json`: one shared ICU message — en `"{count, number} total"`, ja `"全{count, number}件"`. The `{count, number}` placeholder applies locale-aware grouping (e.g. `1,234`). A generic counter (`N total`) was chosen over an entity-noun label (`14 users`) to avoid repeating the title and to keep a single message that serves all five pages.

### Wiring across the five listing pages

- `admin-users-client.tsx`, `admin-masters-client.tsx`, `cardgroups-client.tsx`, `catalog-client.tsx` pass `countLabel={tCommon("totalCount", { count: totalCount })}`; `admin-roles-client.tsx` uses `roles.length`. Each component already held `tCommon = useTranslations("Common")` in scope, so no new imports or hooks were added.
- The catalog / cardgroups loading skeletons pass no `count`, so the pill never renders for them; they are left untouched.

### Tests

- `listing-page-shell.test.tsx`: the count test now asserts the pill rendering (`SPAN` tag, `rounded-full`, `text-muted-foreground`, shares the title cluster), plus new cases for `countLabel` replacing the bare number and count-omitted → no pill.
- `__tests__/admin-users-list.test.tsx`, `__tests__/admin-masters-list.test.tsx`: two broad page tests flipped from asserting `(3)` to `3 total` (the en label resolved by `renderWithIntl`).

## Verification

- On any listing page (`/admin/users`, `/admin/roles`, `/admin/masters`, `/cardgroups`, `/catalog`), the count renders as a `rounded-full bg-muted` pill reading `N total` (en) / `全N件` (ja) — centered under the title on mobile, inline to its right on desktop — and is not clickable.

## Test plan

- [ ] `pnpm --filter frontend test` — full suite (176 files / 1646 tests) passes.
- [ ] `pnpm --filter frontend typecheck` — clean.
- [ ] `pnpm --filter frontend lint` (`biome check --error-on-warnings`) — clean.
- [ ] CJK / language-policy grep on the changed `.ts`/`.tsx` files — clean (the only Japanese string lives in `frontend/messages/ja.json`).

No associated issue — design-led change brainstormed via a principal UI/UX designer pass on the listing-count treatment; chose the neutral count pill with a generic `N total` label.
