### PR TITLE
feat(master-catalog): validate surviving master-deck fields (description, sortOrder)

### DIFF
--- a/backend/graph/resolver/mapper.go
+++ b/backend/graph/resolver/mapper.go
@@ -70,7 +70,7 @@ func toMasterCardgroupModelFromParts(m *domain.MasterCardgroup, cardCount int) *
 	return &model.MasterCardgroup{
 		ID:               m.ID,
 		Name:             m.Name.String(),
-		Description:      m.Description,
+		Description:      m.Description.Ptr(),
 		Version:          m.Version,
 		Status:           toMasterCardgroupStatusModel(m.Status),
 		IsDefaultStarter: m.IsDefaultStarter,

--- a/backend/graph/resolver/master_catalog_mapper_test.go
+++ b/backend/graph/resolver/master_catalog_mapper_test.go
@@ -50,7 +50,7 @@ func TestToMasterCardgroupModel_FullMapping(t *testing.T) {
 		Cardgroup: &domain.MasterCardgroup{
 			ID:               "mcg-1",
 			Name:             domain.CardgroupName("Starter Deck"),
-			Description:      strPtr("desc"),
+			Description:      domain.DescriptionFromPtr(strPtr("desc")),
 			Version:          3,
 			Status:           domain.MasterStatusPublished,
 			IsDefaultStarter: true,

--- a/backend/internal/domain/description.go
+++ b/backend/internal/domain/description.go
@@ -1,0 +1,72 @@
+package domain
+
+import (
+	"strings"
+
+	"github.com/rivo/uniseg"
+	"github.com/rotisserie/eris"
+)
+
+const DescriptionMax = 500
+
+// ErrDescriptionTooLong is returned when the trimmed description exceeds
+// DescriptionMax graphemes.
+var ErrDescriptionTooLong = eris.Errorf("master cardgroup: description exceeds %d characters", DescriptionMax)
+
+// Description is the optional master-cardgroup description, supporting a trinary:
+// nil (no change), pointer-to-"" (explicit clear), or pointer-to-non-empty (set).
+// It mirrors Bio: an optional, nullable, grapheme-bounded text field on an
+// aggregate. The zero value Description{} is the no-value case.
+type Description struct {
+	value *string
+}
+
+// ParseDescription validates and trims s, preserving the trinary contract:
+// nil means "no change"; a pointer to "" means "explicit clear"; a pointer to a
+// non-empty string means "set". Surrounding whitespace is trimmed; whitespace-only
+// inputs collapse to the explicit-clear case (Ptr() returns a pointer to "").
+// Returns ErrDescriptionTooLong if the trimmed value exceeds DescriptionMax graphemes.
+func ParseDescription(s *string) (Description, error) {
+	if s == nil {
+		return Description{}, nil
+	}
+	trimmed := strings.TrimSpace(*s)
+	if uniseg.GraphemeClusterCount(trimmed) > DescriptionMax {
+		return Description{}, ErrDescriptionTooLong
+	}
+	return Description{value: &trimmed}, nil
+}
+
+// DescriptionFromPtr maps a nullable text column to a Description: nil → Description{}
+// (IsSet()=false, NULL column); a non-nil pointer — including pointer-to-empty —
+// maps to a set Description whose Ptr() returns a defensive copy with the same
+// string value. Used by repository readers to bridge a nullable text column into
+// the typed domain field.
+func DescriptionFromPtr(p *string) Description {
+	if p == nil {
+		return Description{}
+	}
+	s := *p
+	return Description{value: &s}
+}
+
+// Ptr returns a fresh copy of the internal pointer:
+//   - nil — the Description holds no value (constructed via ParseDescription(nil) or DescriptionFromPtr(nil));
+//   - non-nil pointer to empty string — the Description holds an empty value;
+//   - non-nil pointer to non-empty string — the Description holds a populated value.
+//
+// Patch-context callers map nil → "no change", &"" → "explicit clear", &"x" → "set".
+// Read-context callers map nil → NULL column, &"" → empty stored, &"x" → populated stored.
+func (d Description) Ptr() *string {
+	if d.value == nil {
+		return nil
+	}
+	s := *d.value
+	return &s
+}
+
+// IsSet reports whether the Description carries a value (its internal pointer is
+// non-nil). Returns false for ParseDescription(nil) (patch-context: no change) and
+// for DescriptionFromPtr(nil) (read-context: NULL column / zero value Description{}).
+// Returns true for any other construction, including an explicit empty string.
+func (d Description) IsSet() bool { return d.value != nil }

--- a/backend/internal/domain/description_test.go
+++ b/backend/internal/domain/description_test.go
@@ -1,0 +1,127 @@
+package domain
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestDescriptionFromPtr verifies the helper that bridges a *string repository
+// read into the trinary VO. nil → Description{} (IsSet=false); non-nil pointer
+// copies the underlying string and exposes it via Ptr() in defensive-copy fashion.
+func TestDescriptionFromPtr(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil pointer maps to unset Description", func(t *testing.T) {
+		t.Parallel()
+		d := DescriptionFromPtr(nil)
+		require.False(t, d.IsSet())
+		require.Nil(t, d.Ptr())
+	})
+
+	t.Run("pointer to non-empty string maps to set Description", func(t *testing.T) {
+		t.Parallel()
+		s := "an intro deck"
+		d := DescriptionFromPtr(&s)
+		require.True(t, d.IsSet())
+		require.NotNil(t, d.Ptr())
+		require.Equal(t, "an intro deck", *d.Ptr())
+	})
+
+	t.Run("pointer to empty string maps to set Description holding empty string", func(t *testing.T) {
+		t.Parallel()
+		s := ""
+		d := DescriptionFromPtr(&s)
+		require.True(t, d.IsSet())
+		require.NotNil(t, d.Ptr())
+		require.Equal(t, "", *d.Ptr())
+	})
+
+	t.Run("Ptr returns a fresh pointer on each call", func(t *testing.T) {
+		t.Parallel()
+		s := "original"
+		d := DescriptionFromPtr(&s)
+		p1, p2 := d.Ptr(), d.Ptr()
+		require.NotSame(t, p1, p2, "each Ptr() call must allocate a fresh pointer")
+		require.Equal(t, *p1, *p2, "but the values must be equal")
+	})
+}
+
+func TestParseDescription(t *testing.T) {
+	t.Parallel()
+
+	const zwjEmoji = "👨‍👩‍👧‍👦"
+
+	cases := []struct {
+		name        string
+		input       *string
+		wantIsSet   bool
+		wantValue   *string
+		sentinelErr error
+	}{
+		{
+			name:      "nil input — no change",
+			input:     nil,
+			wantIsSet: false,
+			wantValue: nil,
+		},
+		{
+			name:      "empty pointer — explicit clear",
+			input:     strPtr(""),
+			wantIsSet: true,
+			wantValue: strPtr(""),
+		},
+		{
+			name:      "whitespace only — trimmed to explicit clear",
+			input:     strPtr("   "),
+			wantIsSet: true,
+			wantValue: strPtr(""),
+		},
+		{
+			name:      "normal string",
+			input:     strPtr("A short deck description"),
+			wantIsSet: true,
+			wantValue: strPtr("A short deck description"),
+		},
+		{
+			name:      "surrounding whitespace trimmed",
+			input:     strPtr("  hello  "),
+			wantIsSet: true,
+			wantValue: strPtr("hello"),
+		},
+		{
+			name:      "exactly DescriptionMax graphemes — ok",
+			input:     strPtr(strings.Repeat("a", DescriptionMax)),
+			wantIsSet: true,
+			wantValue: strPtr(strings.Repeat("a", DescriptionMax)),
+		},
+		{
+			name:        "DescriptionMax+1 ASCII chars — too long",
+			input:       strPtr(strings.Repeat("a", DescriptionMax+1)),
+			sentinelErr: ErrDescriptionTooLong,
+		},
+		{
+			name:        "DescriptionMax+1 ZWJ emojis — grapheme count, not bytes",
+			input:       strPtr(strings.Repeat(zwjEmoji, DescriptionMax+1)),
+			sentinelErr: ErrDescriptionTooLong,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := ParseDescription(tc.input)
+			if tc.sentinelErr != nil {
+				require.Error(t, err)
+				require.True(t, errors.Is(err, tc.sentinelErr), "got %v", err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.wantIsSet, got.IsSet())
+			require.Equal(t, tc.wantValue, got.Ptr())
+		})
+	}
+}

--- a/backend/internal/domain/master_cardgroup.go
+++ b/backend/internal/domain/master_cardgroup.go
@@ -26,18 +26,19 @@ func (s MasterCardgroupStatus) IsValid() bool {
 // the master catalog and is never directly owned by an end user.
 //
 // Name is a CardgroupName so the same grapheme-cluster length invariant
-// (1..CardgroupNameMax) applies without duplicating validation logic. Status is
-// the only other field that is a value object (MasterCardgroupStatus); its
-// transitions are owned by the Publish / Unpublish methods below. Every remaining
-// field (Description, IsDefaultStarter, SortOrder) is free-form with no Parse or
-// bound to protect. That is why the aggregate exposes no update/patch behaviour
-// method: there is no invariant for one to guard. The admin update path
-// (usecase.UpdateMaster) parses Name through ParseCardgroupName at its single seam
-// and assigns the free-form fields directly into the repository patch.
+// (1..CardgroupNameMax) applies without duplicating validation logic. Description
+// is a Description value object carrying the optional, grapheme-bounded
+// (0..DescriptionMax) text invariant, mirroring User.Bio. Status is a value object
+// (MasterCardgroupStatus) whose transitions are owned by the Publish / Unpublish
+// methods below. The remaining fields (IsDefaultStarter, SortOrder) are free-form
+// with no Parse or bound to protect. The admin update path (usecase.UpdateMaster)
+// parses Name through ParseCardgroupName and Description through ParseDescription at
+// their single seams and assigns the free-form fields directly into the repository
+// patch.
 type MasterCardgroup struct {
 	ID               string
 	Name             CardgroupName
-	Description      *string
+	Description      Description
 	Version          int
 	Status           MasterCardgroupStatus
 	IsDefaultStarter bool
@@ -49,14 +50,14 @@ type MasterCardgroup struct {
 // NewMasterCardgroup constructs a MasterCardgroup aggregate in its initial
 // admin-created state: Version = 1 and Status = MasterStatusDraft. It generates a
 // fresh UUID v7 ID and stamps CreatedAt and UpdatedAt with the current UTC time.
-// The name VO is validated upstream by ParseCardgroupName; callers pass the parsed
-// CardgroupName so this constructor stays free of validation branching (mirroring
-// NewCardgroup / NewCard). The Draft/Version=1 invariant is sealed here so it
-// cannot drift across the usecase and repository call sites. Returns a wrapped
-// error when ID generation fails.
+// The name and description VOs are validated upstream by ParseCardgroupName /
+// ParseDescription; callers pass the parsed value objects so this constructor stays
+// free of validation branching (mirroring NewCardgroup / NewCard). The
+// Draft/Version=1 invariant is sealed here so it cannot drift across the usecase and
+// repository call sites. Returns a wrapped error when ID generation fails.
 func NewMasterCardgroup(
 	name CardgroupName,
-	description *string,
+	description Description,
 	isDefaultStarter bool,
 	sortOrder int,
 ) (*MasterCardgroup, error) {

--- a/backend/internal/domain/master_cardgroup_test.go
+++ b/backend/internal/domain/master_cardgroup_test.go
@@ -20,13 +20,13 @@ func TestNewMasterCardgroup(t *testing.T) {
 
 		desc := "an intro deck"
 
-		m, err := NewMasterCardgroup(name, &desc, true, 5)
+		m, err := NewMasterCardgroup(name, DescriptionFromPtr(&desc), true, 5)
 		require.NoError(t, err)
 		require.NotNil(t, m)
 
 		require.NotEmpty(t, m.ID, "constructor must generate an ID")
 		require.Equal(t, name, m.Name)
-		require.Equal(t, &desc, m.Description)
+		require.Equal(t, &desc, m.Description.Ptr())
 		require.Equal(t, 1, m.Version, "a new master deck starts at version 1")
 		require.Equal(t, MasterStatusDraft, m.Status, "a new master deck starts in draft")
 		require.True(t, m.IsDefaultStarter)
@@ -41,9 +41,9 @@ func TestNewMasterCardgroup(t *testing.T) {
 		name, err := ParseCardgroupName("Minimal")
 		require.NoError(t, err)
 
-		m, err := NewMasterCardgroup(name, nil, false, 0)
+		m, err := NewMasterCardgroup(name, Description{}, false, 0)
 		require.NoError(t, err)
-		require.Nil(t, m.Description)
+		require.Nil(t, m.Description.Ptr())
 		require.Equal(t, 1, m.Version)
 		require.Equal(t, MasterStatusDraft, m.Status)
 		require.False(t, m.IsDefaultStarter)
@@ -72,7 +72,7 @@ func TestNewMasterCardgroup_IDFailure(t *testing.T) {
 	name, err := ParseCardgroupName("Starter")
 	require.NoError(t, err)
 
-	m, err := NewMasterCardgroup(name, nil, false, 0)
+	m, err := NewMasterCardgroup(name, Description{}, false, 0)
 	require.Nil(t, m)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "master cardgroup: new id")

--- a/backend/internal/repository/master_cardgroup.go
+++ b/backend/internal/repository/master_cardgroup.go
@@ -171,7 +171,7 @@ func (r *masterCardgroupRepo) EnsureByName(ctx context.Context, name string) (*d
 			return eris.Wrap(err, "repository: master cardgroup: ensure by name: lookup")
 		}
 
-		m, err := domain.NewMasterCardgroup(domain.CardgroupName(name), nil, false, 0)
+		m, err := domain.NewMasterCardgroup(domain.CardgroupName(name), domain.Description{}, false, 0)
 		if err != nil {
 			return eris.Wrap(err, "repository: master cardgroup: ensure by name: construct")
 		}
@@ -355,7 +355,7 @@ func masterCardgroupToDomain(g gormMasterCardgroup) (*domain.MasterCardgroup, er
 	return &domain.MasterCardgroup{
 		ID:               g.ID,
 		Name:             domain.CardgroupName(g.Name),
-		Description:      g.Description,
+		Description:      domain.DescriptionFromPtr(g.Description),
 		Version:          g.Version,
 		Status:           status,
 		IsDefaultStarter: g.IsDefaultStarter,
@@ -369,7 +369,7 @@ func masterCardgroupFromDomain(m *domain.MasterCardgroup) gormMasterCardgroup {
 	return gormMasterCardgroup{
 		ID:               m.ID,
 		Name:             string(m.Name),
-		Description:      m.Description,
+		Description:      m.Description.Ptr(),
 		Version:          m.Version,
 		Status:           string(m.Status),
 		IsDefaultStarter: m.IsDefaultStarter,

--- a/backend/internal/repository/master_cardgroup_test.go
+++ b/backend/internal/repository/master_cardgroup_test.go
@@ -33,7 +33,7 @@ func newMasterCardgroup(name string) *domain.MasterCardgroup {
 	return &domain.MasterCardgroup{
 		ID:               uuid.NewString(),
 		Name:             domain.CardgroupName(name),
-		Description:      &desc,
+		Description:      domain.DescriptionFromPtr(&desc),
 		Version:          ver,
 		Status:           domain.MasterCardgroupStatus(status),
 		IsDefaultStarter: isStarter,
@@ -43,14 +43,14 @@ func newMasterCardgroup(name string) *domain.MasterCardgroup {
 	}
 }
 
-// newMasterCardgroupMinimal builds a MasterCardgroup with all optional *string
-// fields set to nil. This exercises the NULL round-trip path.
+// newMasterCardgroupMinimal builds a MasterCardgroup with the optional Description
+// field cleared. This exercises the NULL round-trip path.
 func newMasterCardgroupMinimal(name string) *domain.MasterCardgroup {
 	now := time.Now().UTC()
 	return &domain.MasterCardgroup{
 		ID:               uuid.NewString(),
 		Name:             domain.CardgroupName(name),
-		Description:      nil,
+		Description:      domain.Description{},
 		Version:          1,
 		Status:           domain.MasterStatusDraft,
 		IsDefaultStarter: false,
@@ -77,8 +77,8 @@ func TestMasterCardgroupRepository_CreateAndFindByID_AllFields(t *testing.T) {
 
 	require.Equal(t, m.ID, got.ID)
 	require.Equal(t, m.Name.String(), got.Name.String())
-	require.NotNil(t, got.Description)
-	require.Equal(t, *m.Description, *got.Description)
+	require.NotNil(t, got.Description.Ptr())
+	require.Equal(t, *m.Description.Ptr(), *got.Description.Ptr())
 	require.Equal(t, m.Version, got.Version)
 	require.Equal(t, m.Status, got.Status)
 	require.Equal(t, m.IsDefaultStarter, got.IsDefaultStarter)
@@ -100,7 +100,7 @@ func TestMasterCardgroupRepository_CreateAndFindByID_NullOptionalFields(t *testi
 
 	require.Equal(t, m.ID, got.ID)
 	require.Equal(t, m.Name.String(), got.Name.String())
-	require.Nil(t, got.Description)
+	require.Nil(t, got.Description.Ptr())
 	require.Equal(t, 1, got.Version)
 	require.Equal(t, domain.MasterStatusDraft, got.Status)
 	require.False(t, got.IsDefaultStarter)
@@ -223,7 +223,7 @@ func TestMasterCardgroupRepository_Update_PartialPatch(t *testing.T) {
 	// Unchanged fields should be preserved.
 	require.Equal(t, m.Name.String(), got.Name.String())
 	require.Equal(t, m.Version, got.Version)
-	require.Nil(t, got.Description)
+	require.Nil(t, got.Description.Ptr())
 	require.False(t, got.IsDefaultStarter)
 
 	// Verify the returned row is from DB (re-fetched state).

--- a/backend/internal/usecase/master_catalog.go
+++ b/backend/internal/usecase/master_catalog.go
@@ -411,9 +411,18 @@ func (u *masterCatalogUsecase) CreateMaster(ctx context.Context, in CreateMaster
 		return CreateMasterOutcome{Validation: info}, nil
 	}
 
+	description, descErr := domain.ParseDescription(in.Description)
+	info, err = liftValidationErr(translateDescriptionErr(descErr))
+	if err != nil {
+		return CreateMasterOutcome{}, err
+	}
+	if info != nil {
+		return CreateMasterOutcome{Validation: info}, nil
+	}
+
 	m, err := domain.NewMasterCardgroup(
 		name,
-		in.Description,
+		description,
 		derefOr(in.IsDefaultStarter, false),
 		derefOr(in.SortOrder, 0),
 	)
@@ -432,31 +441,40 @@ func (u *masterCatalogUsecase) CreateMaster(ctx context.Context, in CreateMaster
 // the response model.
 //
 // There is deliberately no MasterCardgroup.ApplyPatch aggregate method. Of the
-// patchable fields, only Name carries a domain invariant — the CardgroupName VO's
-// grapheme-cluster length bound — and that invariant is already enforced here, at
-// the one seam, via domain.ParseCardgroupName below. Status is the only other VO on
-// the aggregate, and it is not patchable through this method: it has its own
-// dedicated lifecycle seams (Publish / Unpublish). Every remaining field
-// (Description, IsDefaultStarter, SortOrder) is free-form (*string / *bool / *int)
-// with no Parse or bound to protect, so it is assigned directly into the
-// repository patch. An ApplyPatch wrapper over those fields would be an
-// indirection layer guarding nothing.
+// patchable fields, Name and Description carry domain invariants — the
+// CardgroupName and Description grapheme-cluster length bounds — and both are
+// enforced here, at their single seams, via domain.ParseCardgroupName /
+// domain.ParseDescription below. Status is the only other VO on the aggregate, and
+// it is not patchable through this method: it has its own dedicated lifecycle seams
+// (Publish / Unpublish). The remaining fields (IsDefaultStarter, SortOrder) are
+// free-form (*bool / *int) with no Parse or bound to protect, so they are assigned
+// directly into the repository patch. An ApplyPatch wrapper over those fields would
+// be an indirection layer guarding nothing.
 func (u *masterCatalogUsecase) UpdateMaster(ctx context.Context, id string, in UpdateMasterInput) (UpdateMasterOutcome, error) {
 	if _, err := u.adminGate.Require(ctx, "usecase: master catalog: update master"); err != nil {
 		return UpdateMasterOutcome{}, err
 	}
 
-	// Free-form fields (no domain invariant) flow straight into the patch; only
-	// Name routes through its VO below. See the method docstring for why no
-	// MasterCardgroup.ApplyPatch exists.
+	description, descErr := domain.ParseDescription(in.Description)
+	info, err := liftValidationErr(translateDescriptionErr(descErr))
+	if err != nil {
+		return UpdateMasterOutcome{}, err
+	}
+	if info != nil {
+		return UpdateMasterOutcome{Validation: info}, nil
+	}
+
+	// Name and Description route through their VOs (above / below); the remaining
+	// free-form fields flow straight into the patch. See the method docstring for
+	// why no MasterCardgroup.ApplyPatch exists.
 	patch := repository.MasterCardgroupUpdate{
-		Description:      in.Description,
+		Description:      description.Ptr(),
 		IsDefaultStarter: in.IsDefaultStarter,
 		SortOrder:        in.SortOrder,
 	}
 	if in.Name != nil {
 		name, nameErr := domain.ParseCardgroupName(*in.Name)
-		info, err := liftValidationErr(translateCardgroupNameErr(nameErr))
+		info, err = liftValidationErr(translateCardgroupNameErr(nameErr))
 		if err != nil {
 			return UpdateMasterOutcome{}, err
 		}

--- a/backend/internal/usecase/master_catalog_admin_test.go
+++ b/backend/internal/usecase/master_catalog_admin_test.go
@@ -2,6 +2,7 @@ package usecase
 
 import (
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -57,6 +58,18 @@ func TestMasterCatalog_CreateMaster_InvalidNameValidation(t *testing.T) {
 	require.Equal(t, "name", out.Validation.Field)
 }
 
+func TestMasterCatalog_CreateMaster_InvalidDescriptionValidation(t *testing.T) {
+	t.Parallel()
+	uc := NewMasterCatalogUsecase(&mockMasterCatalogRepository{}, &mockCopyMasterToUserUC{}, newTestAdminGate(true), newTestLogger())
+	ctx := authedCtx("admin1")
+	tooLong := strings.Repeat("a", domain.DescriptionMax+1)
+	out, err := uc.CreateMaster(ctx, CreateMasterInput{Name: "My Deck", Description: &tooLong})
+	require.NoError(t, err)
+	require.Nil(t, out.Master)
+	require.NotNil(t, out.Validation)
+	require.Equal(t, "description", out.Validation.Field)
+}
+
 func TestMasterCatalog_CreateMaster_Success(t *testing.T) {
 	t.Parallel()
 	repo := &mockMasterCatalogRepository{}
@@ -94,6 +107,18 @@ func TestMasterCatalog_UpdateMaster_InvalidName(t *testing.T) {
 	require.Nil(t, out.Master)
 	require.NotNil(t, out.Validation)
 	require.Equal(t, "name", out.Validation.Field)
+}
+
+func TestMasterCatalog_UpdateMaster_InvalidDescription(t *testing.T) {
+	t.Parallel()
+	uc := NewMasterCatalogUsecase(&mockMasterCatalogRepository{}, &mockCopyMasterToUserUC{}, newTestAdminGate(true), newTestLogger())
+	ctx := authedCtx("admin1")
+	tooLong := strings.Repeat("a", domain.DescriptionMax+1)
+	out, err := uc.UpdateMaster(ctx, "some-id", UpdateMasterInput{Description: &tooLong})
+	require.NoError(t, err)
+	require.Nil(t, out.Master)
+	require.NotNil(t, out.Validation)
+	require.Equal(t, "description", out.Validation.Field)
 }
 
 func TestMasterCatalog_UpdateMaster_Success(t *testing.T) {

--- a/backend/internal/usecase/validators.go
+++ b/backend/internal/usecase/validators.go
@@ -83,6 +83,19 @@ func translateCardgroupNameErr(err error) error {
 	}
 }
 
+// translateDescriptionErr maps domain Description sentinels into usecase-layer
+// typed errors. Unexpected errors are wrapped with eris. Returns nil when err
+// is nil.
+func translateDescriptionErr(err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, domain.ErrDescriptionTooLong) {
+		return ucerr.NewValidationError("description", fmt.Sprintf("description must be at most %d characters", domain.DescriptionMax))
+	}
+	return eris.Wrap(err, "usecase: translate description error")
+}
+
 // translateDisplayNameErr maps domain DisplayName sentinels into usecase-layer
 // typed errors. Unexpected errors are wrapped with eris. Returns nil when err
 // is nil.

--- a/frontend/src/app/admin/masters/admin-master-form.test.tsx
+++ b/frontend/src/app/admin/masters/admin-master-form.test.tsx
@@ -53,6 +53,16 @@ describe("AdminMasterForm", () => {
     expect(firstCallArg).toMatchObject({ name: "New Deck", sortOrder: 7 });
   });
 
+  it("blocks submit when sortOrder is not a whole number", async () => {
+    const submit = vi.fn();
+    const user = userEvent.setup();
+    renderWithIntl(<AdminMasterForm mode="create" submitting={false} submit={submit} />);
+    await user.type(screen.getByTestId("master-field-name"), "Deck");
+    await user.type(screen.getByTestId("master-field-sortOrder"), "1.5");
+    await user.click(screen.getByTestId("master-form-submit"));
+    expect(submit).not.toHaveBeenCalled();
+  });
+
   it("prefills edit mode fields", () => {
     renderWithIntl(
       <AdminMasterForm mode="edit" master={EXISTING} submitting={false} submit={vi.fn()} />,

--- a/frontend/src/app/admin/masters/admin-master-form.tsx
+++ b/frontend/src/app/admin/masters/admin-master-form.tsx
@@ -10,7 +10,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { DirtyStateBridge } from "@/lib/forms/dirty-state-bridge";
 import { FieldError } from "@/lib/forms/field-error";
 import { submitFormHandler, wrapSubmit } from "@/lib/forms/submit-handler";
-import { masterSchema } from "@/schemas/master";
+import { masterDescriptionSchema, masterNameSchema, masterSortOrderSchema } from "@/schemas/master";
 import type { AdminMasterListItem } from "./admin-master-row";
 
 /** Values emitted by the form. Empty optional strings collapse to null. */
@@ -45,7 +45,9 @@ export function AdminMasterForm({
 }: Props) {
   const t = useTranslations("AdminMasters");
   const tCommon = useTranslations("Common");
-  const nameSchema = masterSchema.shape.name;
+  const nameSchema = masterNameSchema;
+  const descriptionSchema = masterDescriptionSchema;
+  const sortOrderSchema = masterSortOrderSchema;
 
   const form = useForm({
     defaultValues: {
@@ -56,21 +58,29 @@ export function AdminMasterForm({
     },
     onSubmit: async ({ value }) => {
       const sortOrderRaw = value.sortOrder.trim();
+      const parsedSortOrder = Number(sortOrderRaw);
       const values: MasterFormValues = {
         name: value.name.trim(),
         description: emptyToNull(value.description),
         isDefaultStarter: value.isDefaultStarter,
-        sortOrder: sortOrderRaw === "" ? null : Number(sortOrderRaw),
+        // The sortOrder field validator blocks submit on a non-integer; guard the
+        // conversion too so NaN / Infinity can never reach the mutation.
+        sortOrder:
+          sortOrderRaw !== "" && Number.isInteger(parsedSortOrder) ? parsedSortOrder : null,
       };
       await wrapSubmit("admin-master-form", submit)(values);
     },
   });
 
   const nameFieldError = validationError?.field === "name" ? validationError.message : undefined;
+  const descriptionFieldError =
+    validationError?.field === "description" ? validationError.message : undefined;
 
   return (
     <form onSubmit={submitFormHandler(form)} className="space-y-4">
-      {validationError && validationError.field !== "name" ? (
+      {validationError &&
+      validationError.field !== "name" &&
+      validationError.field !== "description" ? (
         <ErrorBanner data-testid="master-form-error">{validationError.message}</ErrorBanner>
       ) : null}
 
@@ -95,7 +105,14 @@ export function AdminMasterForm({
         )}
       </form.Field>
 
-      <form.Field name="description">
+      <form.Field
+        name="description"
+        validators={{
+          onChange: descriptionSchema,
+          onBlur: descriptionSchema,
+          onSubmit: descriptionSchema,
+        }}
+      >
         {(field) => (
           <div className="space-y-2">
             <Label htmlFor={field.name}>{t("descriptionLabel")}</Label>
@@ -104,14 +121,23 @@ export function AdminMasterForm({
               name={field.name}
               data-testid="master-field-description"
               value={field.state.value}
+              onBlur={field.handleBlur}
               onChange={(e) => field.handleChange(e.target.value)}
               placeholder={t("descriptionPlaceholder")}
             />
+            <FieldError zodErrors={field.state.meta.errors} backendError={descriptionFieldError} />
           </div>
         )}
       </form.Field>
 
-      <form.Field name="sortOrder">
+      <form.Field
+        name="sortOrder"
+        validators={{
+          onChange: sortOrderSchema,
+          onBlur: sortOrderSchema,
+          onSubmit: sortOrderSchema,
+        }}
+      >
         {(field) => (
           <div className="space-y-2">
             <Label htmlFor={field.name}>{t("sortOrderLabel")}</Label>
@@ -121,8 +147,10 @@ export function AdminMasterForm({
               type="number"
               data-testid="master-field-sortOrder"
               value={field.state.value}
+              onBlur={field.handleBlur}
               onChange={(e) => field.handleChange(e.target.value)}
             />
+            <FieldError zodErrors={field.state.meta.errors} />
           </div>
         )}
       </form.Field>

--- a/frontend/src/schemas/master.test.ts
+++ b/frontend/src/schemas/master.test.ts
@@ -22,4 +22,39 @@ describe("masterSchema", () => {
     const r = masterSchema.safeParse({ name: "a".repeat(100) });
     expect(r.success).toBe(true);
   });
+
+  it("accepts a 500-grapheme description", () => {
+    const r = masterSchema.safeParse({ name: "Deck", description: "a".repeat(500) });
+    expect(r.success).toBe(true);
+  });
+
+  it("rejects a description longer than 500 grapheme clusters", () => {
+    const r = masterSchema.safeParse({ name: "Deck", description: "a".repeat(501) });
+    expect(r.success).toBe(false);
+  });
+
+  it("allows an empty description", () => {
+    const r = masterSchema.safeParse({ name: "Deck", description: "" });
+    expect(r.success).toBe(true);
+  });
+
+  it("accepts an empty sortOrder", () => {
+    const r = masterSchema.safeParse({ name: "Deck", sortOrder: "" });
+    expect(r.success).toBe(true);
+  });
+
+  it("accepts an integer sortOrder", () => {
+    const r = masterSchema.safeParse({ name: "Deck", sortOrder: "5" });
+    expect(r.success).toBe(true);
+  });
+
+  it("rejects a decimal sortOrder", () => {
+    const r = masterSchema.safeParse({ name: "Deck", sortOrder: "1.5" });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects a non-numeric sortOrder", () => {
+    const r = masterSchema.safeParse({ name: "Deck", sortOrder: "abc" });
+    expect(r.success).toBe(false);
+  });
 });

--- a/frontend/src/schemas/master.ts
+++ b/frontend/src/schemas/master.ts
@@ -2,7 +2,9 @@ import { z } from "zod";
 import { graphemeCount } from "./grapheme";
 
 // Mirrors the backend master name rule: trimmed, 1-100 grapheme clusters.
-const masterNameSchema = z
+// Exported (non-optional, input: string) so the form consumes it as a per-field
+// TanStack Form validator, which requires a StandardSchema over `string`.
+export const masterNameSchema = z
   .string()
   .transform((s) => s.trim())
   .refine((s) => graphemeCount(s) >= 1, { message: "name is required" })
@@ -10,9 +12,35 @@ const masterNameSchema = z
     message: "name must be at most 100 characters",
   });
 
-// Single schema validates the only client-enforced field. The remaining
-// optional attributes (description, ...) are free-form strings the backend
-// validates; the form does not duplicate those rules.
+// Mirrors the backend Description value object (domain.DescriptionMax): trimmed,
+// optional, at most 500 grapheme clusters. Empty collapses to "no description".
+export const masterDescriptionSchema = z
+  .string()
+  .transform((s) => s.trim())
+  .refine((s) => graphemeCount(s) <= 500, {
+    message: "description must be at most 500 characters",
+  });
+
+// The sort-order form input is a string; allow empty (→ null on submit) or a
+// finite whole number. NaN, Infinity, and decimals are rejected before submit.
+// Frontend-only guard: the GraphQL Int type already bounds the value server-side,
+// so there is no backend value object to mirror.
+export const masterSortOrderSchema = z.string().refine(
+  (s) => {
+    const trimmed = s.trim();
+    if (trimmed === "") return true;
+    return Number.isInteger(Number(trimmed));
+  },
+  { message: "sort order must be a whole number" },
+);
+
+// name is always client-validated; description and sortOrder are optional so the
+// whole-object parse stays valid when a caller supplies only the fields it owns.
+// The form consumes each per-field schema via the standalone exports above (a
+// per-field validator needs a StandardSchema over `string`, which `.optional()`
+// here would widen to `string | undefined`).
 export const masterSchema = z.object({
   name: masterNameSchema,
+  description: masterDescriptionSchema.optional(),
+  sortOrder: masterSortOrderSchema.optional(),
 });


### PR DESCRIPTION
## Summary

After #679 removed five free-form metadata fields from the master deck, two
fields it deliberately kept — `description` and `sortOrder` — were still
accepted with no validation at any layer. This carries forward the
`description` + `sortOrder` portion of #670 (superseded by #679): a
`description` length cap and a `sortOrder` integer guard.

Decisions (carried over from #670's brainstorm, re-scoped to the two survivors):

- `description`: trimmed, optional, at most **500** grapheme clusters
  (`domain.DescriptionMax`), modelled as a `Description` value object that
  mirrors `User.Bio` (the existing optional/nullable/trinary bounded-text VO).
- Enforcement is **two-layer** — frontend Zod + backend domain VO. No DB CHECK:
  no raw-SQL path writes `description` outside the usecase, and a
  `char_length`-based CHECK would diverge from the grapheme-based VO.
- `sortOrder`: frontend-only integer/finite guard. The GraphQL `Int` type
  already bounds the value server-side, so there is no backend gap.

Closes #680.

## What changed

### Backend — `description` value object

- `domain/description.go` (new): `DescriptionMax = 500`, `ErrDescriptionTooLong`,
  and a `Description` trinary VO (`ParseDescription` / `DescriptionFromPtr` /
  `Ptr` / `IsSet`) — a verbatim mirror of `bio.go`.
- `domain/master_cardgroup.go`: `MasterCardgroup.Description` changes from
  `*string` to the `Description` VO; `NewMasterCardgroup` takes the parsed VO.
  Struct docstring updated (Description now carries a length invariant alongside
  Name).
- `repository/master_cardgroup.go`: read mapper hydrates via
  `DescriptionFromPtr`; write mapper persists via `.Ptr()`; the `EnsureByName`
  constructor call passes `domain.Description{}`.
- `graph/resolver/mapper.go`: model mapping reads `m.Description.Ptr()`.
- `usecase/master_catalog.go`: `CreateMaster` / `UpdateMaster` parse
  `description` at the seam via `domain.ParseDescription`, routing failures to
  `outcome.Validation` through `liftValidationErr(translateDescriptionErr(...))`
  — the same shape as the `bio` seam in `usecase/user.go`. `UpdateMaster`
  docstring updated.
- `usecase/validators.go`: `translateDescriptionErr` maps the sentinel to a
  `ucerr.NewValidationError("description", ...)`.

### Frontend — `description` + `sortOrder`

- `schemas/master.ts`: exports `masterDescriptionSchema` (trimmed, ≤ 500
  graphemes via the shared `graphemeCount` helper) and `masterSortOrderSchema`
  (empty, or a finite whole number — rejects NaN / Infinity / decimals).
  `masterNameSchema` is now exported too; all three are consumed as per-field
  TanStack Form validators (each is a `StandardSchema` over `string`).
- `admin-master-form.tsx`: wires the `description` field validator + inline
  `FieldError` (and routes a backend `description` field error); wires the
  `sortOrder` field validator + `FieldError`; the submit-time coercion guards
  the conversion so `NaN` / `Infinity` can never reach the mutation.

### Tests

- `domain/description_test.go` (new): `ParseDescription` / `DescriptionFromPtr`
  boundary (500/501, ZWJ-emoji grapheme counting, nil / clear / set,
  whitespace), mirroring `bio_test.go`.
- `usecase/master_catalog_admin_test.go`: over-cap `description` →
  `InputValidationError` on `description`, for both `CreateMaster` and
  `UpdateMaster`.
- Backend mapper / repository / constructor tests updated for the VO field type.
- `schemas/master.test.ts`: description boundary + sortOrder integer/decimal/
  non-numeric cases.
- `admin-master-form.test.tsx`: a non-integer `sortOrder` blocks submit.

## Verification

- In the admin master create/edit form (`/admin/masters`), a description over
  500 graphemes shows an inline field error and blocks submit; a non-integer
  `sortOrder` shows an inline error and blocks submit.
- A description over 500 graphemes that bypasses the client still returns
  `BAD_USER_INPUT` on `description` from the backend.

## Test plan

- [ ] `cd backend && go build ./... && go vet ./...` — clean.
- [ ] `cd backend && go test ./internal/domain/... ./internal/usecase/... ./graph/...` — passes. Repository round-trip tests are Docker-gated (compile verified locally; runtime runs in CI).
- [ ] `pnpm --filter frontend test` — full suite (176 files / 1655 tests) passes.
- [ ] `pnpm --filter frontend typecheck` + `biome check --error-on-warnings` — clean.
- [ ] `pnpm --filter frontend build` — succeeds.
- [ ] CJK / language-policy grep on the changed files — clean.
