### PR TITLE
feat(frontend): add client-side validation and a row counter to the batch-import wizard

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -178,6 +178,11 @@
   "BatchImport": {
     "cardsToImport": "Cards to import",
     "tabHint": " — separate each pair with a Tab",
+    "rowCount": "{count, number} / {max, number} rows",
+    "rowCapExceeded": "{count, number} rows — exceeds the {max, number} row limit",
+    "byteCapExceeded": "Payload is {size} — exceeds the {max} limit",
+    "frontTooLong": "front exceeds {max, number} characters ({count, number})",
+    "backTooLong": "back exceeds {max, number} characters ({count, number})",
     "validate": "Validate",
     "validating": "Validating...",
     "import": "Import",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -178,6 +178,11 @@
   "BatchImport": {
     "cardsToImport": "インポートするカード",
     "tabHint": " — タブで区切ってください",
+    "rowCount": "{count, number} / {max, number} 行",
+    "rowCapExceeded": "{count, number} 行 — 上限の {max, number} 行を超えています",
+    "byteCapExceeded": "ペイロードが {size} で、上限の {max} を超えています",
+    "frontTooLong": "表面が {max, number} 文字を超えています（{count, number}）",
+    "backTooLong": "裏面が {max, number} 文字を超えています（{count, number}）",
     "validate": "検証",
     "validating": "検証中...",
     "import": "インポート",

--- a/frontend/src/components/batch-import/batch-import-wizard.test.tsx
+++ b/frontend/src/components/batch-import/batch-import-wizard.test.tsx
@@ -590,6 +590,17 @@ describe("<BatchImportWizard>", () => {
     ).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /^validate$/i })).toBeDisabled();
   });
+
+  it("clears the client-validation region when the textarea is emptied", async () => {
+    const user = userEvent.setup();
+    renderWizard();
+    await typePayload(user, TWO_LINE_TEXT);
+    expect(screen.getByTestId("batch-import-client-validation")).toBeInTheDocument();
+    await user.clear(screen.getByLabelText(/cards to import/i));
+    await waitFor(() =>
+      expect(screen.queryByTestId("batch-import-client-validation")).not.toBeInTheDocument(),
+    );
+  });
 });
 
 describe("BatchImportWizard footer layout", () => {

--- a/frontend/src/components/batch-import/batch-import-wizard.test.tsx
+++ b/frontend/src/components/batch-import/batch-import-wizard.test.tsx
@@ -11,7 +11,16 @@ import {
 } from "@/generated/graphql";
 import { encodePayload } from "@/test/batch-import-test-utils";
 import { renderWithIntl } from "@/test/render-with-intl";
-import { BatchImportWizard, type ImportResult, resolveStep1Button } from "./batch-import-wizard";
+import {
+  BatchImportWizard,
+  formatPayloadSize,
+  type ImportResult,
+  MAX_PAYLOAD_BYTES,
+  MAX_ROWS,
+  MAX_SIDE_GRAPHEMES,
+  resolveStep1Button,
+  validateClientPayload,
+} from "./batch-import-wizard";
 
 const TARGET_ID = "tgt-1";
 const TARGET_NAME = "Spanish Vocab";
@@ -97,6 +106,76 @@ async function advanceToStep2(user: ReturnType<typeof userEvent.setup>) {
   await waitFor(() => expect(importButton).toBeEnabled());
   await user.click(importButton);
 }
+
+describe("validateClientPayload", () => {
+  it("empty string: zero rows, not blocked", () => {
+    const v = validateClientPayload("");
+    expect(v.rowCount).toBe(0);
+    expect(v.blocked).toBe(false);
+    expect(v.lengthErrors).toEqual([]);
+  });
+
+  it("counts non-blank lines as rows and skips blank / whitespace-only lines", () => {
+    const v = validateClientPayload("apple\tred\n\n   \nbanana\tyellow");
+    expect(v.rowCount).toBe(2);
+    expect(v.blocked).toBe(false);
+  });
+
+  it("splits each row on the first tab into front / back", () => {
+    // back carries a second tab; only the first tab is the separator.
+    const v = validateClientPayload("front\tback\twith tab");
+    expect(v.rowCount).toBe(1);
+    expect(v.lengthErrors).toEqual([]);
+  });
+
+  it("a 500-grapheme side is accepted; 501 is flagged", () => {
+    const ok = validateClientPayload(`${"a".repeat(500)}\t${"b".repeat(500)}`);
+    expect(ok.lengthErrors).toEqual([]);
+    expect(ok.blocked).toBe(false);
+
+    const overFront = validateClientPayload(`${"a".repeat(501)}\tshort`);
+    expect(overFront.lengthErrors).toEqual([{ line: 1, side: "front", count: 501 }]);
+    expect(overFront.blocked).toBe(true);
+
+    const overBack = validateClientPayload(`short\t${"b".repeat(501)}`);
+    expect(overBack.lengthErrors).toEqual([{ line: 1, side: "back", count: 501 }]);
+  });
+
+  it("reports the physical line number (blank lines included) for length errors", () => {
+    const text = `apple\tred\n\n${"x".repeat(600)}\tback`;
+    const v = validateClientPayload(text);
+    expect(v.lengthErrors).toEqual([{ line: 3, side: "front", count: 600 }]);
+  });
+
+  it("row cap: 5000 rows ok, 5001 over", () => {
+    const at = Array.from({ length: MAX_ROWS }, () => "a\tb").join("\n");
+    expect(validateClientPayload(at).rowCapExceeded).toBe(false);
+
+    const over = Array.from({ length: MAX_ROWS + 1 }, () => "a\tb").join("\n");
+    const v = validateClientPayload(over);
+    expect(v.rowCount).toBe(MAX_ROWS + 1);
+    expect(v.rowCapExceeded).toBe(true);
+    expect(v.blocked).toBe(true);
+  });
+
+  it("byte cap: flags a payload over 1 MiB without tripping the row cap", () => {
+    // 4000 lines x ~281 bytes ~= 1.12 MiB; each side 140 graphemes (< 500).
+    const line = `${"a".repeat(140)}\t${"b".repeat(140)}`;
+    const v = validateClientPayload(Array.from({ length: 4000 }, () => line).join("\n"));
+    expect(v.byteSize).toBeGreaterThan(MAX_PAYLOAD_BYTES);
+    expect(v.byteCapExceeded).toBe(true);
+    expect(v.rowCapExceeded).toBe(false);
+    expect(v.lengthErrors).toEqual([]);
+    expect(v.blocked).toBe(true);
+  });
+});
+
+describe("formatPayloadSize", () => {
+  it("formats bytes as MiB with one decimal", () => {
+    expect(formatPayloadSize(1258291)).toBe("1.2 MiB");
+    expect(formatPayloadSize(2 * 1024 * 1024)).toBe("2.0 MiB");
+  });
+});
 
 describe("resolveStep1Button", () => {
   it("empty: text blank -> validate, no action, disabled", () => {

--- a/frontend/src/components/batch-import/batch-import-wizard.test.tsx
+++ b/frontend/src/components/batch-import/batch-import-wizard.test.tsx
@@ -562,6 +562,34 @@ describe("<BatchImportWizard>", () => {
     await user.click(screen.getByRole("button", { name: /back to cardgroup/i }));
     expect(onCancel).toHaveBeenCalledTimes(1);
   });
+
+  it("renders a live row counter while text is present", async () => {
+    const user = userEvent.setup();
+    renderWizard();
+    await typePayload(user, TWO_LINE_TEXT);
+    expect(screen.getByTestId("batch-import-row-counter")).toHaveTextContent("2 / 5,000 rows");
+  });
+
+  it("over the row cap: disables Validate and shows the cap message", async () => {
+    const user = userEvent.setup();
+    renderWizard();
+    await typePayload(user, Array.from({ length: MAX_ROWS + 1 }, () => "a\tb").join("\n"));
+    expect(screen.getByRole("button", { name: /^validate$/i })).toBeDisabled();
+    expect(screen.getByText(/exceeds the 5,000 row limit/i)).toBeInTheDocument();
+  });
+
+  it("an over-length row: shows a line-attributed error and disables Validate", async () => {
+    const user = userEvent.setup();
+    renderWizard();
+    const overLength = MAX_SIDE_GRAPHEMES + 100;
+    await typePayload(user, `${"x".repeat(overLength)}\tback`);
+    expect(
+      screen.getByText(
+        new RegExp(`front exceeds ${MAX_SIDE_GRAPHEMES} characters \\(${overLength}\\)`, "i"),
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^validate$/i })).toBeDisabled();
+  });
 });
 
 describe("BatchImportWizard footer layout", () => {

--- a/frontend/src/components/batch-import/batch-import-wizard.test.tsx
+++ b/frontend/src/components/batch-import/batch-import-wizard.test.tsx
@@ -180,19 +180,37 @@ describe("formatPayloadSize", () => {
 describe("resolveStep1Button", () => {
   it("empty: text blank -> validate, no action, disabled", () => {
     expect(
-      resolveStep1Button({ hasText: false, validating: false, result: null, isStale: false }),
+      resolveStep1Button({
+        hasText: false,
+        validating: false,
+        result: null,
+        isStale: false,
+        clientBlocked: false,
+      }),
     ).toEqual({ labelKey: "validate", action: null, disabled: true });
   });
 
   it("ready: text present, not yet validated -> validate, validate action, enabled", () => {
     expect(
-      resolveStep1Button({ hasText: true, validating: false, result: null, isStale: false }),
+      resolveStep1Button({
+        hasText: true,
+        validating: false,
+        result: null,
+        isStale: false,
+        clientBlocked: false,
+      }),
     ).toEqual({ labelKey: "validate", action: "validate", disabled: false });
   });
 
   it("validating: request in flight -> validating, no action, disabled", () => {
     expect(
-      resolveStep1Button({ hasText: true, validating: true, result: null, isStale: false }),
+      resolveStep1Button({
+        hasText: true,
+        validating: true,
+        result: null,
+        isStale: false,
+        clientBlocked: false,
+      }),
     ).toEqual({ labelKey: "validating", action: null, disabled: true });
   });
 
@@ -203,6 +221,7 @@ describe("resolveStep1Button", () => {
         validating: false,
         result: { valid: true, parsedCards: [], errors: [] },
         isStale: false,
+        clientBlocked: false,
       }),
     ).toEqual({ labelKey: "import", action: "continue", disabled: false });
   });
@@ -214,6 +233,7 @@ describe("resolveStep1Button", () => {
         validating: false,
         result: { valid: true, parsedCards: [], errors: [] },
         isStale: true,
+        clientBlocked: false,
       }),
     ).toEqual({ labelKey: "validate", action: "validate", disabled: false });
   });
@@ -225,8 +245,33 @@ describe("resolveStep1Button", () => {
         validating: false,
         result: { valid: false, parsedCards: [], errors: [{ line: 1, message: "x" }] },
         isStale: false,
+        clientBlocked: false,
       }),
     ).toEqual({ labelKey: "validate", action: "validate", disabled: false });
+  });
+
+  it("client-blocked: text present but over a cap -> validate, no action, disabled", () => {
+    expect(
+      resolveStep1Button({
+        hasText: true,
+        validating: false,
+        result: null,
+        isStale: false,
+        clientBlocked: true,
+      }),
+    ).toEqual({ labelKey: "validate", action: null, disabled: true });
+  });
+
+  it("client-blocked wins over a stale-valid result", () => {
+    expect(
+      resolveStep1Button({
+        hasText: true,
+        validating: false,
+        result: { valid: true, parsedCards: [], errors: [] },
+        isStale: true,
+        clientBlocked: true,
+      }),
+    ).toEqual({ labelKey: "validate", action: null, disabled: true });
   });
 });
 

--- a/frontend/src/components/batch-import/batch-import-wizard.tsx
+++ b/frontend/src/components/batch-import/batch-import-wizard.tsx
@@ -5,7 +5,7 @@ import type { DocumentNode } from "graphql";
 import { ChevronDown } from "lucide-react";
 import { useTranslations } from "next-intl";
 import type { JSX, ReactNode } from "react";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { ValidateCardImportQuery } from "@/app/cardgroups/[id]/cards/queries";
 import { Button } from "@/components/ui/button";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
@@ -443,11 +443,14 @@ export function BatchImportWizard(props: {
     setStep(1);
   }
 
+  const clientValidation = useMemo(() => validateClientPayload(payloadText), [payloadText]);
+
   const buttonSpec = resolveStep1Button({
     hasText: payloadText.trim() !== "",
     validating,
     result: validationResult,
     isStale: validatedPayload !== payloadText,
+    clientBlocked: clientValidation.blocked,
   });
 
   function onStep1ButtonClick() {
@@ -483,6 +486,53 @@ export function BatchImportWizard(props: {
               placeholder={"apple\tapple (the fruit)\nbanana\ta yellow fruit"}
             />
           </div>
+
+          {payloadText.trim() !== "" && (
+            <div className="space-y-2" data-testid="batch-import-client-validation">
+              <p
+                className={cn(
+                  "text-xs tabular-nums",
+                  clientValidation.rowCapExceeded
+                    ? "font-semibold text-destructive"
+                    : "text-muted-foreground",
+                )}
+                data-testid="batch-import-row-counter"
+              >
+                {t("rowCount", { count: clientValidation.rowCount, max: MAX_ROWS })}
+              </p>
+              {clientValidation.rowCapExceeded && (
+                <p
+                  className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive"
+                  role="alert"
+                >
+                  {t("rowCapExceeded", { count: clientValidation.rowCount, max: MAX_ROWS })}
+                </p>
+              )}
+              {clientValidation.byteCapExceeded && (
+                <p
+                  className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive"
+                  role="alert"
+                >
+                  {t("byteCapExceeded", {
+                    size: formatPayloadSize(clientValidation.byteSize),
+                    max: "1 MiB",
+                  })}
+                </p>
+              )}
+              {clientValidation.lengthErrors.length > 0 && (
+                <ErrorList
+                  role="alert"
+                  errors={clientValidation.lengthErrors.map((e) => ({
+                    line: e.line,
+                    message:
+                      e.side === "front"
+                        ? t("frontTooLong", { max: MAX_SIDE_GRAPHEMES, count: e.count })
+                        : t("backTooLong", { max: MAX_SIDE_GRAPHEMES, count: e.count }),
+                  }))}
+                />
+              )}
+            </div>
+          )}
 
           {validationResult && (
             <div

--- a/frontend/src/components/batch-import/batch-import-wizard.tsx
+++ b/frontend/src/components/batch-import/batch-import-wizard.tsx
@@ -140,6 +140,8 @@ type Step1ButtonState = {
    * input combination.
    */
   isStale: boolean;
+  /** True when client-side validation (row cap / byte cap / per-row length) blocks. */
+  clientBlocked: boolean;
 };
 
 type Step1ButtonAction = "validate" | "continue";
@@ -167,6 +169,9 @@ export function resolveStep1Button(state: Step1ButtonState): Step1ButtonSpec {
   }
   if (state.validating) {
     return { labelKey: "validating", action: null, disabled: true };
+  }
+  if (state.clientBlocked) {
+    return { labelKey: "validate", action: null, disabled: true };
   }
   if (state.result?.valid === true && !state.isStale) {
     return { labelKey: "import", action: "continue", disabled: false };

--- a/frontend/src/components/batch-import/batch-import-wizard.tsx
+++ b/frontend/src/components/batch-import/batch-import-wizard.tsx
@@ -14,6 +14,79 @@ import { Textarea } from "@/components/ui/textarea";
 import type { CardImportErrorKind } from "@/generated/graphql";
 import { getBackendErrorBanner } from "@/lib/apollo/errors";
 import { cn } from "@/lib/utils";
+import { graphemeCount } from "@/schemas/grapheme";
+
+// Mirror the backend caps so an over-cap / over-length payload is blocked client-side
+// before the server round-trip. Sources: usecase cardImportParsedRowCap (5000 rows),
+// textdic maxPayloadBytes (1 MiB), domain.NewCard / schemas/card.ts (500 graphemes/side).
+export const MAX_ROWS = 5000;
+export const MAX_PAYLOAD_BYTES = 1 << 20;
+export const MAX_SIDE_GRAPHEMES = 500;
+
+export type ClientValidation = {
+  /** Non-blank line count — a proxy for the server's parsed-row count. */
+  rowCount: number;
+  /** UTF-8 byte length of the raw textarea text. */
+  byteSize: number;
+  rowCapExceeded: boolean;
+  byteCapExceeded: boolean;
+  /** Per-row sides over the 500-grapheme cap, keyed by physical 1-based line. */
+  lengthErrors: Array<{ line: number; side: "front" | "back"; count: number }>;
+  /** True when any cap is exceeded — the Validate button is disabled. */
+  blocked: boolean;
+};
+
+/**
+ * graphemeCount(s) <= s.length always holds (each cluster spans >= 1 UTF-16 unit),
+ * so the Segmenter only runs for sides whose cheap length already exceeds the cap.
+ */
+function sideGraphemeCount(s: string): number {
+  return s.length > MAX_SIDE_GRAPHEMES ? graphemeCount(s) : s.length;
+}
+
+/**
+ * Pure client-side approximation of the server's payload validation. Not a
+ * re-implementation of the goyacc grammar: rows are non-blank lines, front/back is
+ * a first-tab split. The server remains the final guard, so a rare divergence only
+ * risks a false-positive block, never corruption.
+ */
+export function validateClientPayload(text: string): ClientValidation {
+  const byteSize = new TextEncoder().encode(text).length;
+  const lengthErrors: ClientValidation["lengthErrors"] = [];
+  let rowCount = 0;
+
+  text.split("\n").forEach((line, i) => {
+    if (line.trim() === "") return;
+    rowCount += 1;
+    const tab = line.indexOf("\t");
+    const front = (tab < 0 ? line : line.slice(0, tab)).trim();
+    const back = (tab < 0 ? "" : line.slice(tab + 1)).trim();
+    const frontCount = sideGraphemeCount(front);
+    if (frontCount > MAX_SIDE_GRAPHEMES) {
+      lengthErrors.push({ line: i + 1, side: "front", count: frontCount });
+    }
+    const backCount = sideGraphemeCount(back);
+    if (backCount > MAX_SIDE_GRAPHEMES) {
+      lengthErrors.push({ line: i + 1, side: "back", count: backCount });
+    }
+  });
+
+  const rowCapExceeded = rowCount > MAX_ROWS;
+  const byteCapExceeded = byteSize > MAX_PAYLOAD_BYTES;
+  return {
+    rowCount,
+    byteSize,
+    rowCapExceeded,
+    byteCapExceeded,
+    lengthErrors,
+    blocked: rowCapExceeded || byteCapExceeded || lengthErrors.length > 0,
+  };
+}
+
+/** Format a byte count as "N.N MiB" for the over-cap message. */
+export function formatPayloadSize(bytes: number): string {
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MiB`;
+}
 
 /**
  * Encode a UTF-8 string to base64 using the standard alphabet (with padding).


### PR DESCRIPTION
## Summary

The batch-import wizard deferred all size/shape validation to a server
round-trip, while the single-card form (`CardForm`) enforces the 500-grapheme
cap immediately — an asymmetry that surfaced over-cap / over-length payloads
late and unhelpfully. This adds a live row counter and client-side validation to
the shared `BatchImportWizard` so an over-cap or over-length payload is blocked,
line-attributed, before the round-trip.

The motivating finding: the server `Validate` (preview) step parses via
`textdic` only and never calls `domain.NewCard`, so it detects **neither** the
5000-row cap **nor** the per-side 500-grapheme cap. Those fire only at `Import`,
as a whole-batch abort with a generic top-level banner and **no line number**.
The client-side checks are therefore the only pre-round-trip, line-attributed
feedback for those two failure modes. The server remains the final guard — these
checks are UX-only, so there is no corruption path.

Decisions (architecture-reasoned at implementation time, frontend-only / no
backend, wrapper, schema, or `maxLength` changes):

- **Row counter:** a live `N / 5,000` counter under the textarea, neutral
  normally and `destructive` + bold when over the row cap, which **disables
  Validate** (no point round-tripping a payload the backend will hard-reject).
  Green stays reserved for the success/"valid" banner.
- **Per-row 500-grapheme pre-check:** inline, surfaced as line-attributed errors
  in the existing `ErrorList` UI, blocking Validate. This is the only place a
  user learns which row is too long before a failed import.
- **Byte cap:** a block message only when the payload exceeds 1 MiB; **no
  `maxLength`** on the textarea (a hard cap silently truncates a paste). The
  5000-row cap bites first in practice, so this is a secondary guard.
- **Parse proxy:** the client is not a re-implementation of the goyacc grammar —
  rows are non-blank lines, front/back is a first-tab split, and the shared
  `graphemeCount` (UAX #29) counts sides. Its only downside is a rare
  false-positive *block*; the server still guards correctness.

Closes #673.

## What changed

All logic lives in the shared `frontend/src/components/batch-import/batch-import-wizard.tsx`;
the two thin wrappers (`cardgroup-batch-import-form.tsx`,
`master-batch-import-form.tsx`) are untouched.

### Validation core (pure, exported, unit-tested)

- `validateClientPayload(text)` returns `{ rowCount, byteSize, rowCapExceeded,
  byteCapExceeded, lengthErrors, blocked }`. Caps mirror the backend exactly:
  `MAX_ROWS = 5000` (`cardImportParsedRowCap`), `MAX_PAYLOAD_BYTES = 1 << 20`
  (textdic `maxPayloadBytes`), `MAX_SIDE_GRAPHEMES = 500` (`domain.NewCard` /
  `schemas/card.ts`). `byteSize` uses `TextEncoder` (true UTF-8 length).
- An internal `sideGraphemeCount` skips the `Intl.Segmenter` when
  `s.length <= 500` — sound because `graphemeCount(s) <= s.length` always holds
  (each cluster spans ≥ 1 UTF-16 unit), so a side over the cap necessarily has
  `length > 500`. Keeps the up-to-5000-row check cheap.
- `formatPayloadSize(bytes)` formats the over-cap byte message.

### Button gate

- `resolveStep1Button` gains a required `clientBlocked` field, inserted into the
  priority chain after `validating` and before the valid/stale resolution, so a
  client-blocked payload disables Validate even past a stale-valid result. The
  discriminated-union spec shape is unchanged (no new phantom state).

### UI + wiring

- The component memoizes `validateClientPayload(payloadText)` on `payloadText`
  and threads `clientBlocked` into `resolveStep1Button`.
- A client-validation region renders between the textarea and the existing
  server-validate block: the row counter (neutral / destructive+bold), the
  row-cap and byte-cap messages, and per-row length errors via the existing
  `ErrorList` (`role="alert"`). Empty/whitespace payloads stay blocked by the
  existing `hasText` guard.

### i18n

- Five new keys in the `BatchImport` namespace of `frontend/messages/en.json`
  and `ja.json` (`rowCount`, `rowCapExceeded`, `byteCapExceeded`, `frontTooLong`,
  `backTooLong`). No inline UI strings in `.tsx`.

### Tests

- `validateClientPayload` / `formatPayloadSize`: blank-line skipping, first-tab
  split, 500/501 grapheme boundary on both sides, physical line numbers,
  5000-row boundary, 1 MiB byte boundary (without tripping the row cap), MiB
  formatting.
- `resolveStep1Button`: the new `clientBlocked` branch, including client-blocked
  winning over a stale-valid result; the six existing cases updated.
- Component: live counter render, over-cap disabling Validate, line-attributed
  length error, and the region vanishing when the textarea is cleared.

## Verification

- In the batch-import wizard (`/cardgroups/[id]/cards` import, and the admin
  master-cards import), a counter shows `N / 5,000`; pasting > 5000 non-blank
  rows turns it red and disables Validate; a row whose front or back exceeds 500
  graphemes shows `Line N: front exceeds 500 characters (...)` and disables
  Validate; a payload over 1 MiB shows a block message.
- A payload that bypasses the client (over-cap / over-length) is still rejected
  by the server at import, unchanged.

## Test plan

- [x] `pnpm --filter frontend test` — full suite (176 files / 1669 tests) passes.
- [x] `pnpm --filter frontend typecheck` (`tsc --noEmit`) — clean.
- [x] `biome check --error-on-warnings` on the changed files — clean.
- [x] `pnpm --filter frontend knip` — no new findings (only a pre-existing config hint).
- [x] `pnpm --filter frontend build` — succeeds.
- [x] CJK / language-policy grep on the changed `.tsx` source — clean (Japanese lives only in `frontend/messages/ja.json`).
