### PR TITLE
feat(master-catalog): merge a catalog deck into an existing cardgroup (backend)

### DIFF
--- a/.claude/rules/go-library-gotchas.md
+++ b/.claude/rules/go-library-gotchas.md
@@ -77,6 +77,7 @@ This matters most in DataLoader batch functions, where an empty key slice is a n
 - [Testable startup helpers — anti-pattern of inline test copies and the extract-helper fix](../../docs/backend/library-gotchas/testable-startup-helpers.md)
 - [Method dispatch on a nil pointer panics — `u == nil` guards in methods are unreachable](../../docs/backend/library-gotchas/method-dispatch-nil-receiver-unreachable.md)
 - [Test stubs `t.Fatalf` on exhausted fixture access, never panic](../../docs/backend/library-gotchas/test-stub-fatal-on-exhausted-fixture.md)
+- [Call-count error injection on a fake to cover the Nth call of a twice-called repo method](../../docs/backend/library-gotchas/call-count-error-injection-for-nth-call.md)
 - [Optional feature: pass `nil` handler and let the router skip route registration](../../docs/backend/library-gotchas/optional-feature-nil-handler-skip-route.md)
 - [goyacc lexer: recover via NEWLINE to enable `error NEWLINE` grammar rules](../../docs/backend/library-gotchas/goyacc-lexer-recovery-via-newline.md)
 - [gqlgen `transport.POST` response headers must be set at construction time](../../docs/backend/library-gotchas/gqlgen-transport-post-response-headers.md)

--- a/backend/graph/resolver/master_catalog.resolvers.go
+++ b/backend/graph/resolver/master_catalog.resolvers.go
@@ -10,7 +10,6 @@ import (
 	"backend/internal/gqlerr"
 	"backend/internal/usecase"
 	"context"
-	"fmt"
 
 	"github.com/rotisserie/eris"
 )
@@ -145,8 +144,27 @@ func (r *mutationResolver) SeedDefaultStarterCardgroups(ctx context.Context) (*m
 }
 
 // MergeMasterCardgroup is the resolver for the mergeMasterCardgroup field.
+//
+// Returns a union: model.MergeMasterCardgroupSuccess on the happy path, or
+// model.MasterNotFoundError when the master id is unknown or not published.
+// Destination cardgroup auth failures (unknown → BAD_USER_INPUT, foreign →
+// UNAUTHENTICATED) travel the error return via FromUsecaseError.
 func (r *mutationResolver) MergeMasterCardgroup(ctx context.Context, input model.MergeMasterCardgroupInput) (model.MergeMasterCardgroupResult, error) {
-	panic(fmt.Errorf("not implemented: MergeMasterCardgroup - mergeMasterCardgroup"))
+	outcome, err := r.MasterCatalogUC.MergeMaster(ctx, input.MasterCardgroupID, input.CardgroupID)
+	if err != nil {
+		return nil, gqlerr.FromUsecaseError(ctx, err)
+	}
+	if outcome.NotFound {
+		return model.MasterNotFoundError{Message: "Master cardgroup not found"}, nil
+	}
+	if outcome.Cardgroup == nil {
+		return nil, noVariantSet(ctx, "MergeMasterOutcome")
+	}
+	return model.MergeMasterCardgroupSuccess{
+		Cardgroup:    toCardgroupModel(outcome.Cardgroup),
+		AddedCount:   int(outcome.Added),
+		UpdatedCount: int(outcome.Updated),
+	}, nil
 }
 
 // MasterCatalog is the resolver for the masterCatalog field.

--- a/backend/graph/resolver/master_catalog.resolvers.go
+++ b/backend/graph/resolver/master_catalog.resolvers.go
@@ -10,6 +10,7 @@ import (
 	"backend/internal/gqlerr"
 	"backend/internal/usecase"
 	"context"
+	"fmt"
 
 	"github.com/rotisserie/eris"
 )
@@ -141,6 +142,11 @@ func (r *mutationResolver) SeedDefaultStarterCardgroups(ctx context.Context) (*m
 		out = append(out, toCardgroupModel(cg))
 	}
 	return &model.SeedDefaultStartersPayload{Cardgroups: out}, nil
+}
+
+// MergeMasterCardgroup is the resolver for the mergeMasterCardgroup field.
+func (r *mutationResolver) MergeMasterCardgroup(ctx context.Context, input model.MergeMasterCardgroupInput) (model.MergeMasterCardgroupResult, error) {
+	panic(fmt.Errorf("not implemented: MergeMasterCardgroup - mergeMasterCardgroup"))
 }
 
 // MasterCatalog is the resolver for the masterCatalog field.

--- a/backend/graph/resolver/master_catalog_merge_test.go
+++ b/backend/graph/resolver/master_catalog_merge_test.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"backend/graph/model"
 	"backend/internal/domain"
 	"backend/internal/gqlerr"
@@ -64,21 +67,37 @@ func TestMergeMasterCardgroup_NotFound_AsData(t *testing.T) {
 	}
 }
 
+// TestMergeMasterCardgroup_UsecaseError_Wrapped verifies the mandatory
+// gqlerr.FromUsecaseError wrap: typed usecase errors surface with the correct
+// wire code rather than escaping uncoded — mirrors
+// TestQueryResolver_MasterCatalog_WrapsUsecaseError.
 func TestMergeMasterCardgroup_UsecaseError_Wrapped(t *testing.T) {
 	t.Parallel()
 
-	stub := &stubMasterCatalogUC{mergeErr: ucerr.ErrUnauthenticated}
-	r := &Resolver{MasterCatalogUC: stub}
-
-	res, err := r.Mutation().MergeMasterCardgroup(context.Background(), model.MergeMasterCardgroupInput{
-		MasterCardgroupID: "master-id",
-		CardgroupID:       "cg-id",
-	})
-	if res != nil {
-		t.Fatalf("expected nil union on error, got %T", res)
+	cases := []struct {
+		name string
+		err  error
+		want gqlerr.Code
+	}{
+		{"unauthenticated", ucerr.ErrUnauthenticated, gqlerr.CodeUnauthenticated},
+		{"validation", ucerr.NewValidationError("cardgroupId", "cardgroup not found"), gqlerr.CodeBadUserInput},
 	}
-	if !gqlerr.IsCode(err, gqlerr.CodeUnauthenticated) {
-		t.Fatalf("expected UNAUTHENTICATED wire error, got %v", err)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			stub := &stubMasterCatalogUC{mergeErr: tc.err}
+			r := &Resolver{MasterCatalogUC: stub}
+
+			res, err := r.Mutation().MergeMasterCardgroup(context.Background(), model.MergeMasterCardgroupInput{
+				MasterCardgroupID: "master-id",
+				CardgroupID:       "cg-id",
+			})
+			if res != nil {
+				t.Fatalf("expected nil union on error, got %T", res)
+			}
+			require.Error(t, err)
+			assert.True(t, gqlerr.IsCode(err, tc.want), "want wire code %s", tc.want)
+		})
 	}
 }
 

--- a/backend/graph/resolver/master_catalog_merge_test.go
+++ b/backend/graph/resolver/master_catalog_merge_test.go
@@ -1,0 +1,103 @@
+package resolver
+
+import (
+	"context"
+	"testing"
+
+	"backend/graph/model"
+	"backend/internal/domain"
+	"backend/internal/gqlerr"
+	"backend/internal/usecase"
+	"backend/internal/usecase/ucerr"
+)
+
+func TestMergeMasterCardgroup_Success(t *testing.T) {
+	t.Parallel()
+
+	cg := &domain.Cardgroup{ID: domain.CardgroupID("cg-id"), Name: domain.CardgroupName("My Deck"), OwnerID: "owner"}
+	stub := &stubMasterCatalogUC{
+		mergeOut: usecase.MergeMasterOutcome{Cardgroup: cg, Added: 5, Updated: 2},
+	}
+	r := &Resolver{MasterCatalogUC: stub}
+
+	got, err := r.Mutation().MergeMasterCardgroup(context.Background(), model.MergeMasterCardgroupInput{
+		MasterCardgroupID: "master-id",
+		CardgroupID:       "cg-id",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	succ, ok := got.(model.MergeMasterCardgroupSuccess)
+	if !ok {
+		t.Fatalf("expected MergeMasterCardgroupSuccess, got %T", got)
+	}
+	if succ.AddedCount != 5 {
+		t.Fatalf("expected AddedCount 5, got %d", succ.AddedCount)
+	}
+	if succ.UpdatedCount != 2 {
+		t.Fatalf("expected UpdatedCount 2, got %d", succ.UpdatedCount)
+	}
+	if succ.Cardgroup == nil || succ.Cardgroup.ID != "cg-id" {
+		t.Fatalf("expected mapped cardgroup cg-id, got %+v", succ.Cardgroup)
+	}
+}
+
+func TestMergeMasterCardgroup_NotFound_AsData(t *testing.T) {
+	t.Parallel()
+
+	stub := &stubMasterCatalogUC{mergeOut: usecase.MergeMasterOutcome{NotFound: true}}
+	r := &Resolver{MasterCatalogUC: stub}
+
+	got, err := r.Mutation().MergeMasterCardgroup(context.Background(), model.MergeMasterCardgroupInput{
+		MasterCardgroupID: "master-id",
+		CardgroupID:       "cg-id",
+	})
+	if err != nil {
+		t.Fatalf("not-found must be data, not error; got %v", err)
+	}
+	notFound, ok := got.(model.MasterNotFoundError)
+	if !ok {
+		t.Fatalf("expected MasterNotFoundError, got %T", got)
+	}
+	if notFound.Message == "" {
+		t.Fatal("expected a non-empty message")
+	}
+}
+
+func TestMergeMasterCardgroup_UsecaseError_Wrapped(t *testing.T) {
+	t.Parallel()
+
+	stub := &stubMasterCatalogUC{mergeErr: ucerr.ErrUnauthenticated}
+	r := &Resolver{MasterCatalogUC: stub}
+
+	res, err := r.Mutation().MergeMasterCardgroup(context.Background(), model.MergeMasterCardgroupInput{
+		MasterCardgroupID: "master-id",
+		CardgroupID:       "cg-id",
+	})
+	if res != nil {
+		t.Fatalf("expected nil union on error, got %T", res)
+	}
+	if !gqlerr.IsCode(err, gqlerr.CodeUnauthenticated) {
+		t.Fatalf("expected UNAUTHENTICATED wire error, got %v", err)
+	}
+}
+
+func TestMergeMasterCardgroup_XORInvariantViolation(t *testing.T) {
+	t.Parallel()
+
+	// A degenerate {Cardgroup:nil, NotFound:false} outcome is a producer-contract
+	// violation; the resolver's defensive guard must surface it as INTERNAL.
+	stub := &stubMasterCatalogUC{mergeOut: usecase.MergeMasterOutcome{}}
+	r := &Resolver{MasterCatalogUC: stub}
+
+	res, err := r.Mutation().MergeMasterCardgroup(context.Background(), model.MergeMasterCardgroupInput{
+		MasterCardgroupID: "master-id",
+		CardgroupID:       "cg-id",
+	})
+	if res != nil {
+		t.Fatalf("expected nil union on invariant violation, got %T", res)
+	}
+	if !gqlerr.IsCode(err, gqlerr.CodeInternal) {
+		t.Fatalf("expected INTERNAL wire error, got %v", err)
+	}
+}

--- a/backend/graph/resolver/master_catalog_query_test.go
+++ b/backend/graph/resolver/master_catalog_query_test.go
@@ -43,6 +43,9 @@ type stubMasterCatalogUC struct {
 	importErr error
 	gotImport string
 
+	mergeOut usecase.MergeMasterOutcome
+	mergeErr error
+
 	seedOut []*domain.Cardgroup
 	seedErr error
 
@@ -95,7 +98,7 @@ func (s *stubMasterCatalogUC) SeedDefaultStarters(_ context.Context) ([]*domain.
 }
 
 func (s *stubMasterCatalogUC) MergeMaster(_ context.Context, _, _ string) (usecase.MergeMasterOutcome, error) {
-	return usecase.MergeMasterOutcome{}, nil
+	return s.mergeOut, s.mergeErr
 }
 
 // TestQueryResolver_MasterCatalog_Success verifies the resolver maps the model

--- a/backend/graph/resolver/master_catalog_query_test.go
+++ b/backend/graph/resolver/master_catalog_query_test.go
@@ -94,6 +94,10 @@ func (s *stubMasterCatalogUC) SeedDefaultStarters(_ context.Context) ([]*domain.
 	return s.seedOut, s.seedErr
 }
 
+func (s *stubMasterCatalogUC) MergeMaster(_ context.Context, _, _ string) (usecase.MergeMasterOutcome, error) {
+	return usecase.MergeMasterOutcome{}, nil
+}
+
 // TestQueryResolver_MasterCatalog_Success verifies the resolver maps the model
 // enums to usecase enums on the way in and the usecase output to the wire
 // connection on the way out.

--- a/backend/internal/usecase/master_catalog.go
+++ b/backend/internal/usecase/master_catalog.go
@@ -85,7 +85,7 @@ type MasterCatalogConnectionOutput struct {
 // masterDeckUsecaseFacade is the master-deck capability the catalog consumes:
 // snapshot a single published master (import), seed all default starters for
 // the caller, and merge a published master into an existing caller-owned
-// cardgroup. *masterDeckUsecase satisfies all three halves.
+// cardgroup. *masterDeckUsecase satisfies all three capabilities.
 type masterDeckUsecaseFacade interface {
 	CopyMasterToUserUsecase
 	SeedForNewUserUsecase

--- a/backend/internal/usecase/master_catalog.go
+++ b/backend/internal/usecase/master_catalog.go
@@ -92,15 +92,23 @@ type masterDeckUsecaseFacade interface {
 	MergeMasterIntoCardgroupUsecase
 }
 
-// MergeMasterOutcome is the usecase result of MergeMaster. On the happy path
-// Cardgroup is set and NotFound is false; NotFound=true (Cardgroup nil) when the
-// master id is unknown or not published (draft existence subsumed). Destination
-// cardgroup auth failures are returned as errors, not via this outcome.
+// MergeMasterOutcome is the usecase result of MergeMaster. On the valid paths
+// exactly one signal is set: Cardgroup on the happy path, or NotFound=true when the
+// master id is unknown or not published. Destination cardgroup auth failures are
+// returned as errors, not via this outcome.
 type MergeMasterOutcome struct {
+	// Cardgroup is the caller-owned destination after the merge. Non-nil iff NotFound is false.
 	Cardgroup *domain.Cardgroup
-	Added     int64
-	Updated   int64
-	NotFound  bool
+	// Added is the number of cards newly inserted into the destination.
+	Added int64
+	// Updated is the number of existing cards (same front) overwritten.
+	Updated int64
+	// NotFound is true when the master id is unknown or not published; draft existence
+	// is subsumed so draft ids are indistinguishable from absent ids. True iff Cardgroup
+	// is nil. The XOR is a producer contract, not a compile-time guarantee: a degenerate
+	// {Cardgroup:nil, NotFound:false} result is treated as INTERNAL by the resolver's
+	// defensive guard (noVariantSet).
+	NotFound bool
 }
 
 // MasterCatalogUsecase is the published-catalog surface plus the admin
@@ -151,11 +159,11 @@ type masterCatalogUsecase struct {
 
 // NewMasterCatalogUsecase constructs a MasterCatalogUsecase backed by the given
 // repository. deckUC is the combined deck facade (CopyMasterToUserUsecase +
-// SeedForNewUserUsecase) used by ImportMaster and SeedDefaultStarters;
-// adminGate gates every admin-management method. The public
-// ListPublishedConnection is gated by authentication only. Panics when repo,
-// deckUC, adminGate, or logger is nil — a nil required dependency is a wiring bug
-// that must fail at startup, not at first use.
+// SeedForNewUserUsecase + MergeMasterIntoCardgroupUsecase) used by ImportMaster,
+// SeedDefaultStarters, and MergeMaster; adminGate gates every admin-management
+// method. The public ListPublishedConnection is gated by authentication only.
+// Panics when repo, deckUC, adminGate, or logger is nil — a nil required
+// dependency is a wiring bug that must fail at startup, not at first use.
 func NewMasterCatalogUsecase(repo MasterCatalogRepository, deckUC masterDeckUsecaseFacade, adminGate *AdminGate, logger *slog.Logger) MasterCatalogUsecase {
 	if repo == nil {
 		panic("usecase: master catalog: repo is required")

--- a/backend/internal/usecase/master_catalog.go
+++ b/backend/internal/usecase/master_catalog.go
@@ -93,9 +93,10 @@ type masterDeckUsecaseFacade interface {
 }
 
 // MergeMasterOutcome is the usecase result of MergeMaster. On the valid paths
-// exactly one signal is set: Cardgroup on the happy path, or NotFound=true when the
-// master id is unknown or not published. Destination cardgroup auth failures are
-// returned as errors, not via this outcome.
+// exactly one outcome is active: the happy path sets Cardgroup with the Added/Updated
+// tallies and leaves NotFound false; the not-found path sets NotFound=true and leaves
+// Cardgroup nil with zero tallies. Destination cardgroup auth failures are returned as
+// errors, not via this outcome.
 type MergeMasterOutcome struct {
 	// Cardgroup is the caller-owned destination after the merge. Non-nil iff NotFound is false.
 	Cardgroup *domain.Cardgroup

--- a/backend/internal/usecase/master_catalog.go
+++ b/backend/internal/usecase/master_catalog.go
@@ -83,11 +83,24 @@ type MasterCatalogConnectionOutput struct {
 }
 
 // masterDeckUsecaseFacade is the master-deck capability the catalog consumes:
-// snapshot a single published master (import), and seed all default starters for
-// the caller. *masterDeckUsecase satisfies both halves.
+// snapshot a single published master (import), seed all default starters for
+// the caller, and merge a published master into an existing caller-owned
+// cardgroup. *masterDeckUsecase satisfies all three halves.
 type masterDeckUsecaseFacade interface {
 	CopyMasterToUserUsecase
 	SeedForNewUserUsecase
+	MergeMasterIntoCardgroupUsecase
+}
+
+// MergeMasterOutcome is the usecase result of MergeMaster. On the happy path
+// Cardgroup is set and NotFound is false; NotFound=true (Cardgroup nil) when the
+// master id is unknown or not published (draft existence subsumed). Destination
+// cardgroup auth failures are returned as errors, not via this outcome.
+type MergeMasterOutcome struct {
+	Cardgroup *domain.Cardgroup
+	Added     int64
+	Updated   int64
+	NotFound  bool
 }
 
 // MasterCatalogUsecase is the published-catalog surface plus the admin
@@ -100,6 +113,7 @@ type MasterCatalogUsecase interface {
 	// (non-disclosure gate). Anonymous callers receive UNAUTHENTICATED.
 	FindPublishedMaster(ctx context.Context, id string) (*domain.MasterCardgroup, error)
 	ImportMaster(ctx context.Context, masterID string) (ImportMasterOutcome, error)
+	MergeMaster(ctx context.Context, masterID, cardgroupID string) (MergeMasterOutcome, error)
 	SeedDefaultStarters(ctx context.Context) ([]*domain.Cardgroup, error)
 
 	// admin-gated management surface
@@ -646,6 +660,43 @@ func (u *masterCatalogUsecase) ImportMaster(ctx context.Context, masterID string
 		return ImportMasterOutcome{}, eris.Wrap(err, "usecase: master catalog: import: copy master to user")
 	}
 	return ImportMasterOutcome{Cardgroup: cg}, nil
+}
+
+// MergeMaster merges the published master cardgroup identified by masterID into
+// the caller-owned cardgroup cardgroupID. The master is gated through
+// FindPublishedByID, collapsing unknown and draft into MergeMasterOutcome{NotFound:true}
+// so draft existence is never disclosed. Destination ownership is enforced by the
+// delegated usecase (BAD_USER_INPUT for unknown, UNAUTHENTICATED for foreign),
+// surfaced as an error rather than via the outcome. Unauthenticated callers
+// receive ucerr.ErrUnauthenticated. The merge is a one-time snapshot.
+func (u *masterCatalogUsecase) MergeMaster(ctx context.Context, masterID, cardgroupID string) (MergeMasterOutcome, error) {
+	caller := auth.UserFrom(ctx)
+	if caller == nil {
+		return MergeMasterOutcome{}, ucerr.ErrUnauthenticated
+	}
+
+	if _, err := u.repo.FindPublishedByID(ctx, masterID); err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return MergeMasterOutcome{NotFound: true}, nil
+		}
+		if isContextDone(err) {
+			return MergeMasterOutcome{}, err
+		}
+		return MergeMasterOutcome{}, eris.Wrap(err, "usecase: master catalog: merge: verify published")
+	}
+
+	res, err := u.deckUC.MergeMasterIntoCardgroup(ctx, masterID, domain.CardgroupID(cardgroupID), domain.UserID(caller.Sub))
+	if err != nil {
+		if isContextDone(err) {
+			return MergeMasterOutcome{}, err
+		}
+		// Wrap unconditionally, exactly like ImportMaster wraps CopyMasterToUser.
+		// A ucerr.ValidationError / ucerr.ErrUnauthenticated from the delegated
+		// ownership gate is still classified correctly because FromUsecaseError
+		// walks the eris chain (errors.Is / errors.AsType). No pass-through guard.
+		return MergeMasterOutcome{}, eris.Wrap(err, "usecase: master catalog: merge: merge master into cardgroup")
+	}
+	return MergeMasterOutcome{Cardgroup: res.Cardgroup, Added: res.Added, Updated: res.Updated}, nil
 }
 
 // FindPublishedMaster returns a single PUBLISHED master deck by id for any

--- a/backend/internal/usecase/master_catalog_test.go
+++ b/backend/internal/usecase/master_catalog_test.go
@@ -1062,3 +1062,56 @@ func TestMasterCatalogUsecase_MergeMaster_Unauthenticated(t *testing.T) {
 		t.Fatalf("expected ErrUnauthenticated, got %v", err)
 	}
 }
+
+// TestMasterCatalogUsecase_MergeMaster_WrappedValidationError_StillClassifies pins
+// that a ucerr.ValidationError returned by the delegate survives eris.Wrap and is
+// still classifiable via errors.As at the caller boundary. MergeMaster wraps the
+// delegate error unconditionally, so this property must hold for gqlerr.FromUsecaseError
+// to map it to BAD_USER_INPUT correctly.
+func TestMasterCatalogUsecase_MergeMaster_WrappedValidationError_StillClassifies(t *testing.T) {
+	t.Parallel()
+	repo := &mockMasterCatalogRepository{
+		findPublishedByIDFn: func(id string) (*domain.MasterCardgroup, error) {
+			return &domain.MasterCardgroup{ID: id, Name: domain.CardgroupName("Master"), Status: domain.MasterStatusPublished}, nil
+		},
+	}
+	deck := &mockCopyMasterToUserUC{
+		mergeErr: ucerr.NewValidationError("cardgroupId", "cardgroup not found"),
+	}
+	uc := NewMasterCatalogUsecase(repo, deck, newTestAdminGate(true), newTestLogger())
+
+	_, err := uc.MergeMaster(authedCtx("u1"), "master-id", "cg-id")
+	if err == nil {
+		t.Fatal("expected error from merge delegate")
+	}
+	var ve *ucerr.ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("ValidationError must survive eris.Wrap chain, got %T: %v", err, err)
+	}
+	if ve.Field != "cardgroupId" {
+		t.Fatalf("want Field=cardgroupId, got %q", ve.Field)
+	}
+}
+
+// TestMasterCatalogUsecase_MergeMaster_WrappedUnauthenticated_StillClassifies pins
+// that ucerr.ErrUnauthenticated from the delegate survives eris.Wrap and is still
+// classifiable via errors.Is at the caller boundary. MergeMaster wraps the delegate
+// error unconditionally, so this property must hold for gqlerr.FromUsecaseError to
+// map it to UNAUTHENTICATED correctly.
+func TestMasterCatalogUsecase_MergeMaster_WrappedUnauthenticated_StillClassifies(t *testing.T) {
+	t.Parallel()
+	repo := &mockMasterCatalogRepository{
+		findPublishedByIDFn: func(id string) (*domain.MasterCardgroup, error) {
+			return &domain.MasterCardgroup{ID: id, Name: domain.CardgroupName("Master"), Status: domain.MasterStatusPublished}, nil
+		},
+	}
+	deck := &mockCopyMasterToUserUC{
+		mergeErr: ucerr.ErrUnauthenticated,
+	}
+	uc := NewMasterCatalogUsecase(repo, deck, newTestAdminGate(true), newTestLogger())
+
+	_, err := uc.MergeMaster(authedCtx("u1"), "master-id", "cg-id")
+	if !errors.Is(err, ucerr.ErrUnauthenticated) {
+		t.Fatalf("ErrUnauthenticated must survive eris.Wrap chain, got %T: %v", err, err)
+	}
+}

--- a/backend/internal/usecase/master_catalog_test.go
+++ b/backend/internal/usecase/master_catalog_test.go
@@ -665,6 +665,7 @@ type mockCopyMasterToUserUC struct {
 	seedErr     error
 	mergeResult *MergeMasterResult
 	mergeErr    error
+	mergeFn     func(ctx context.Context, masterID string, destCGID domain.CardgroupID, ownerID domain.UserID) (*MergeMasterResult, error)
 }
 
 func (m *mockCopyMasterToUserUC) CopyMasterToUser(ctx context.Context, masterID, ownerID string) (*domain.Cardgroup, error) {
@@ -681,7 +682,10 @@ func (m *mockCopyMasterToUserUC) SeedForNewUser(_ context.Context, _ string) ([]
 	return m.seedResult, m.seedErr
 }
 
-func (m *mockCopyMasterToUserUC) MergeMasterIntoCardgroup(_ context.Context, _ string, _ domain.CardgroupID, _ domain.UserID) (*MergeMasterResult, error) {
+func (m *mockCopyMasterToUserUC) MergeMasterIntoCardgroup(ctx context.Context, masterID string, destCGID domain.CardgroupID, ownerID domain.UserID) (*MergeMasterResult, error) {
+	if m.mergeFn != nil {
+		return m.mergeFn(ctx, masterID, destCGID, ownerID)
+	}
 	if m.mergeErr != nil {
 		return nil, m.mergeErr
 	}
@@ -1113,5 +1117,78 @@ func TestMasterCatalogUsecase_MergeMaster_WrappedUnauthenticated_StillClassifies
 	_, err := uc.MergeMaster(authedCtx("u1"), "master-id", "cg-id")
 	if !errors.Is(err, ucerr.ErrUnauthenticated) {
 		t.Fatalf("ErrUnauthenticated must survive eris.Wrap chain, got %T: %v", err, err)
+	}
+}
+
+func TestMasterCatalogUsecase_MergeMaster_VerifyPublishedError_Wrapped(t *testing.T) {
+	// A non-ErrNotFound failure from FindPublishedByID (e.g. a DB outage) is an
+	// internal error, not the errors-as-data NotFound outcome. The merge delegate
+	// must not run when the published-check itself fails.
+	t.Parallel()
+	repo := &mockMasterCatalogRepository{
+		findPublishedByIDFn: func(string) (*domain.MasterCardgroup, error) {
+			return nil, eris.New("db down")
+		},
+	}
+	deck := &mockCopyMasterToUserUC{mergeFn: func(context.Context, string, domain.CardgroupID, domain.UserID) (*MergeMasterResult, error) {
+		t.Fatal("merge delegate must not run when the published-check fails")
+		return nil, nil
+	}}
+	uc := NewMasterCatalogUsecase(repo, deck, newTestAdminGate(true), newTestLogger())
+
+	_, err := uc.MergeMaster(authedCtx("u1"), "master-id", "cg-id")
+	assertInternalChain(t, err, "usecase: master catalog: merge: verify published")
+}
+
+func TestMasterCatalogUsecase_MergeMaster_DelegateError_Wrapped(t *testing.T) {
+	// A non-ucerr infra error from the merge delegate is wrapped into the eris chain
+	// with the merge-step prefix, mirroring how ImportMaster wraps CopyMasterToUser.
+	t.Parallel()
+	repo := &mockMasterCatalogRepository{
+		findPublishedByIDFn: func(id string) (*domain.MasterCardgroup, error) {
+			return &domain.MasterCardgroup{ID: id, Name: domain.CardgroupName("Master"), Status: domain.MasterStatusPublished}, nil
+		},
+	}
+	deck := &mockCopyMasterToUserUC{mergeErr: errors.New("db down")}
+	uc := NewMasterCatalogUsecase(repo, deck, newTestAdminGate(true), newTestLogger())
+
+	_, err := uc.MergeMaster(authedCtx("u1"), "master-id", "cg-id")
+	assertInternalChain(t, err, "usecase: master catalog: merge: merge master into cardgroup")
+}
+
+func TestMasterCatalogUsecase_MergeMaster_VerifyPublished_ContextCancelled_PassesThrough(t *testing.T) {
+	// context.Canceled from the published-check must propagate unwrapped so its
+	// identity survives errors.Is at the resolver boundary (FromUsecaseError →
+	// CANCELLED). An eris.Wrap here would break the == identity contract.
+	t.Parallel()
+	repo := &mockMasterCatalogRepository{
+		findPublishedByIDFn: func(string) (*domain.MasterCardgroup, error) {
+			return nil, context.Canceled
+		},
+	}
+	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, newTestAdminGate(true), newTestLogger())
+
+	_, err := uc.MergeMaster(authedCtx("u1"), "master-id", "cg-id")
+	assertCancelled(t, err)
+	if err != context.Canceled {
+		t.Fatalf("expected unwrapped context.Canceled, got %v", err)
+	}
+}
+
+func TestMasterCatalogUsecase_MergeMaster_Delegate_ContextCancelled_PassesThrough(t *testing.T) {
+	// context.Canceled surfaced by the merge delegate must propagate unwrapped.
+	t.Parallel()
+	repo := &mockMasterCatalogRepository{
+		findPublishedByIDFn: func(id string) (*domain.MasterCardgroup, error) {
+			return &domain.MasterCardgroup{ID: id, Name: domain.CardgroupName("Master"), Status: domain.MasterStatusPublished}, nil
+		},
+	}
+	deck := &mockCopyMasterToUserUC{mergeErr: context.Canceled}
+	uc := NewMasterCatalogUsecase(repo, deck, newTestAdminGate(true), newTestLogger())
+
+	_, err := uc.MergeMaster(authedCtx("u1"), "master-id", "cg-id")
+	assertCancelled(t, err)
+	if err != context.Canceled {
+		t.Fatalf("expected unwrapped context.Canceled, got %v", err)
 	}
 }

--- a/backend/internal/usecase/master_catalog_test.go
+++ b/backend/internal/usecase/master_catalog_test.go
@@ -657,12 +657,14 @@ func TestResolveMasterCatalogPageSize_DefaultWhenAbsent(t *testing.T) {
 // ImportMaster
 // ---------------------------------------------------------------------------
 
-// mockCopyMasterToUserUC stubs the masterDeckUsecaseFacade for ImportMaster and
-// SeedDefaultStarters tests.
+// mockCopyMasterToUserUC stubs the masterDeckUsecaseFacade for ImportMaster,
+// SeedDefaultStarters, and MergeMaster tests.
 type mockCopyMasterToUserUC struct {
-	fn         func(ctx context.Context, masterID, ownerID string) (*domain.Cardgroup, error)
-	seedResult []*domain.Cardgroup
-	seedErr    error
+	fn          func(ctx context.Context, masterID, ownerID string) (*domain.Cardgroup, error)
+	seedResult  []*domain.Cardgroup
+	seedErr     error
+	mergeResult *MergeMasterResult
+	mergeErr    error
 }
 
 func (m *mockCopyMasterToUserUC) CopyMasterToUser(ctx context.Context, masterID, ownerID string) (*domain.Cardgroup, error) {
@@ -677,6 +679,13 @@ func (m *mockCopyMasterToUserUC) CopyMasterToUser(ctx context.Context, masterID,
 
 func (m *mockCopyMasterToUserUC) SeedForNewUser(_ context.Context, _ string) ([]*domain.Cardgroup, error) {
 	return m.seedResult, m.seedErr
+}
+
+func (m *mockCopyMasterToUserUC) MergeMasterIntoCardgroup(_ context.Context, _ string, _ domain.CardgroupID, _ domain.UserID) (*MergeMasterResult, error) {
+	if m.mergeErr != nil {
+		return nil, m.mergeErr
+	}
+	return m.mergeResult, nil
 }
 
 func TestImportMaster_Unauthenticated(t *testing.T) {
@@ -971,5 +980,85 @@ func TestSeedDefaultStarters_ContextCancelled_PassesThrough(t *testing.T) {
 	_, err := uc.SeedDefaultStarters(authedCtx("user-1"))
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// MergeMaster
+// ---------------------------------------------------------------------------
+
+func TestMasterCatalogUsecase_MergeMaster_DraftMaster_NotFound(t *testing.T) {
+	t.Parallel()
+	// Default mockMasterCatalogRepository.FindPublishedByID returns ErrNotFound
+	// when both findPublishedByIDFn and findByIDFn are nil — covers unknown id
+	// and draft alike (non-disclosure gate).
+	uc := NewMasterCatalogUsecase(
+		&mockMasterCatalogRepository{},
+		&mockCopyMasterToUserUC{},
+		newTestAdminGate(true),
+		newTestLogger(),
+	)
+	out, err := uc.MergeMaster(authedCtx("u1"), "master-id", "cg-id")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !out.NotFound {
+		t.Fatal("expected NotFound=true")
+	}
+	if out.Cardgroup != nil {
+		t.Fatal("expected nil Cardgroup on NotFound outcome")
+	}
+}
+
+func TestMasterCatalogUsecase_MergeMaster_Success_PassesCounts(t *testing.T) {
+	t.Parallel()
+	cg := &domain.Cardgroup{
+		ID:      domain.CardgroupID("cg-id"),
+		OwnerID: domain.UserID("owner"),
+		Name:    domain.CardgroupName("My Deck"),
+	}
+	repo := &mockMasterCatalogRepository{
+		findPublishedByIDFn: func(id string) (*domain.MasterCardgroup, error) {
+			return &domain.MasterCardgroup{ID: id, Name: domain.CardgroupName("Master"), Status: domain.MasterStatusPublished}, nil
+		},
+	}
+	deck := &mockCopyMasterToUserUC{
+		mergeResult: &MergeMasterResult{Cardgroup: cg, Added: 5, Updated: 2},
+	}
+	uc := NewMasterCatalogUsecase(repo, deck, newTestAdminGate(true), newTestLogger())
+
+	out, err := uc.MergeMaster(authedCtx("u1"), "master-id", "cg-id")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.NotFound {
+		t.Fatal("expected NotFound=false on happy path")
+	}
+	if out.Added != 5 {
+		t.Fatalf("want Added=5, got %d", out.Added)
+	}
+	if out.Updated != 2 {
+		t.Fatalf("want Updated=2, got %d", out.Updated)
+	}
+	if out.Cardgroup == nil {
+		t.Fatal("expected non-nil Cardgroup")
+	}
+	if string(out.Cardgroup.ID) != "cg-id" {
+		t.Fatalf("want Cardgroup.ID=cg-id, got %q", out.Cardgroup.ID)
+	}
+}
+
+func TestMasterCatalogUsecase_MergeMaster_Unauthenticated(t *testing.T) {
+	t.Parallel()
+	uc := NewMasterCatalogUsecase(
+		&mockMasterCatalogRepository{},
+		&mockCopyMasterToUserUC{},
+		newTestAdminGate(true),
+		newTestLogger(),
+	)
+	// context.Background() carries no auth user.
+	_, err := uc.MergeMaster(context.Background(), "master-id", "cg-id")
+	if !errors.Is(err, ucerr.ErrUnauthenticated) {
+		t.Fatalf("expected ErrUnauthenticated, got %v", err)
 	}
 }

--- a/backend/internal/usecase/master_deck.go
+++ b/backend/internal/usecase/master_deck.go
@@ -3,6 +3,7 @@ package usecase
 import (
 	"context"
 	"log/slog"
+	"time"
 
 	"github.com/rotisserie/eris"
 	"gorm.io/gorm"
@@ -34,11 +35,13 @@ type masterDeckUserCardRepo interface {
 
 // masterDeckUserCardgroupRepo is the subset of repository.CardgroupRepository the
 // master deck usecase consumes against the USER cardgroups table (not the master
-// catalog). CountByOwner backs the idempotency guard: a user who already owns at
-// least one cardgroup is not re-seeded on the next call. CreateTx inserts the
-// snapshot cardgroup using the caller's transaction handle so the insert
-// participates in the caller's transaction.
+// catalog). FindByID satisfies CardgroupOwnershipFinder so the ownership gate can
+// use u.userCG directly. CountByOwner backs the idempotency guard: a user who
+// already owns at least one cardgroup is not re-seeded on the next call. CreateTx
+// inserts the snapshot cardgroup using the caller's transaction handle so the
+// insert participates in the caller's transaction.
 type masterDeckUserCardgroupRepo interface {
+	FindByID(ctx context.Context, id string) (*domain.Cardgroup, error)
 	CountByOwner(ctx context.Context, ownerID string, search *string) (int64, error)
 	CreateTx(ctx context.Context, tx *gorm.DB, cg *domain.Cardgroup) error
 }
@@ -59,6 +62,22 @@ type SeedForNewUserUsecase interface {
 // ImportMaster); the copy is a one-time snapshot with empty FSRS/swipe state.
 type CopyMasterToUserUsecase interface {
 	CopyMasterToUser(ctx context.Context, masterID, ownerID string) (*domain.Cardgroup, error)
+}
+
+// MergeMasterResult is the tally returned by MergeMasterIntoCardgroup: the
+// destination cardgroup plus the insert/update counts from the upsert.
+type MergeMasterResult struct {
+	Cardgroup *domain.Cardgroup
+	Added     int64
+	Updated   int64
+}
+
+// MergeMasterIntoCardgroupUsecase merges a master deck's cards into an existing
+// caller-owned cardgroup. Used by mergeMasterCardgroup via MasterCatalogUsecase.
+// MergeMaster. The merge is a one-time snapshot (no live link); re-merging the
+// same deck re-syncs the destination to the current catalog content.
+type MergeMasterIntoCardgroupUsecase interface {
+	MergeMasterIntoCardgroup(ctx context.Context, masterID string, destCardgroupID domain.CardgroupID, ownerID domain.UserID) (*MergeMasterResult, error)
 }
 
 // masterDeckUsecase implements both the public copy primitive and the
@@ -228,6 +247,34 @@ func (u *masterDeckUsecase) SeedForNewUser(ctx context.Context, userID string) (
 	return seeded, nil
 }
 
+// copyMasterCardsIntoTx deep-copies the supplied master cards into the
+// destination cardgroup with a fresh id and upserts them on (cardgroup_id, front)
+// inside the caller's transaction. Callers list the master cards first and pass
+// them in, so this helper stays free of the listing step and the caller controls
+// the operation order. pin, when non-nil, overrides every copied card's
+// CreatedAt/UpdatedAt (import pins to the new cardgroup's CreatedAt for a
+// consistent batch timestamp; merge passes nil and keeps NewCard's now()).
+// Returns the insert/update tally. MUST NOT embed a fixed eris layer prefix — the
+// public callers apply their own wrap so the error_chain attributes the failure
+// to the calling operation.
+func (u *masterDeckUsecase) copyMasterCardsIntoTx(
+	ctx context.Context, tx *gorm.DB, masterCards []*domain.MasterCard, destCG domain.CardgroupID, pin *time.Time,
+) (repository.UpsertManyTxResult, error) {
+	userCards := make([]*domain.Card, 0, len(masterCards))
+	for _, mc := range masterCards {
+		card, err := domain.NewCard(destCG, mc.Front.String(), mc.Back.String(), mc.Position)
+		if err != nil {
+			return repository.UpsertManyTxResult{}, eris.Wrap(err, "new card from master")
+		}
+		if pin != nil {
+			card.CreatedAt = *pin
+			card.UpdatedAt = *pin
+		}
+		userCards = append(userCards, card)
+	}
+	return u.userCard.UpsertManyTx(ctx, tx, userCards)
+}
+
 // copyMasterToUserTx is the shared tx-aware copy core used by both
 // CopyMasterToUser (single import) and SeedForNewUser (batch). It MUST NOT embed
 // a fixed eris layer prefix: the two public callers each apply their own wrap
@@ -258,24 +305,56 @@ func (u *masterDeckUsecase) copyMasterToUserTx(ctx context.Context, tx *gorm.DB,
 		return nil, eris.Wrap(err, "create user cardgroup")
 	}
 
-	now := newCG.CreatedAt
-	userCards := make([]*domain.Card, 0, len(cards))
-	for _, mc := range cards {
-		// The source master cards are already valid; the constructor re-parses
-		// the text (idempotent) and generates the new user-card ID.
-		card, err := domain.NewCard(newCG.ID, mc.Front.String(), mc.Back.String(), mc.Position)
-		if err != nil {
-			return nil, eris.Wrap(err, "new card from master")
-		}
-		// Pin the copied batch to the cardgroup's creation timestamp.
-		card.CreatedAt = now
-		card.UpdatedAt = now
-		userCards = append(userCards, card)
-	}
-
-	if _, err := u.userCard.UpsertManyTx(ctx, tx, userCards); err != nil {
-		return nil, eris.Wrap(err, "upsert user cards")
+	pin := newCG.CreatedAt
+	if _, err := u.copyMasterCardsIntoTx(ctx, tx, cards, newCG.ID, &pin); err != nil {
+		return nil, err
 	}
 
 	return newCG, nil
+}
+
+// MergeMasterIntoCardgroup copies the master deck's cards into destCardgroupID,
+// which ownerID must own, inside its own transaction. The destination ownership
+// gate uses authorizeCardgroupOrBadInput (untrusted-input boundary): an unknown
+// cardgroup is a recoverable validation error; a foreign cardgroup is
+// UNAUTHENTICATED. Cards conflicting on (cardgroup_id, front) are overwritten
+// (back/position); ids are preserved so FSRS state survives. Returns the
+// destination cardgroup plus the add/update tally.
+func (u *masterDeckUsecase) MergeMasterIntoCardgroup(
+	ctx context.Context, masterID string, destCardgroupID domain.CardgroupID, ownerID domain.UserID,
+) (*MergeMasterResult, error) {
+	// Ownership gate runs OUTSIDE the tx and returns its ucerr typed error
+	// directly — mirrors card_import.go Import, which gates ownership before the
+	// tx and returns the ucerr unwrapped. gqlerr.FromUsecaseError classifies via
+	// errors.Is(err, ucerr.ErrUnauthenticated) and errors.AsType[*ucerr.ValidationError],
+	// both of which walk the eris chain, so this needs no wrap and the tx error
+	// path below needs no ucerr pass-through guard.
+	if err := authorizeCardgroupOrBadInput(ctx, u.userCG, destCardgroupID, ownerID); err != nil {
+		return nil, err
+	}
+
+	var res repository.UpsertManyTxResult
+	if err := u.tx(ctx, func(tx *gorm.DB) error {
+		cards, err := u.masterCard.ListByMasterCardgroup(ctx, masterID)
+		if err != nil {
+			return eris.Wrap(err, "list master cards")
+		}
+		r, err := u.copyMasterCardsIntoTx(ctx, tx, cards, destCardgroupID, nil)
+		if err != nil {
+			return err
+		}
+		res = r
+		return nil
+	}); err != nil {
+		if isContextDone(err) {
+			return nil, err
+		}
+		return nil, eris.Wrap(err, "usecase: master deck: merge master into cardgroup")
+	}
+
+	cg, err := u.userCG.FindByID(ctx, string(destCardgroupID))
+	if err != nil {
+		return nil, eris.Wrap(err, "usecase: master deck: merge master into cardgroup: find destination")
+	}
+	return &MergeMasterResult{Cardgroup: cg, Added: res.Inserted, Updated: res.Updated}, nil
 }

--- a/backend/internal/usecase/master_deck.go
+++ b/backend/internal/usecase/master_deck.go
@@ -36,10 +36,11 @@ type masterDeckUserCardRepo interface {
 // masterDeckUserCardgroupRepo is the subset of repository.CardgroupRepository the
 // master deck usecase consumes against the USER cardgroups table (not the master
 // catalog). FindByID satisfies CardgroupOwnershipFinder so the ownership gate can
-// use u.userCG directly. CountByOwner backs the idempotency guard: a user who
-// already owns at least one cardgroup is not re-seeded on the next call. CreateTx
-// inserts the snapshot cardgroup using the caller's transaction handle so the
-// insert participates in the caller's transaction.
+// use u.userCG directly; it is also called post-merge to read the destination
+// cardgroup back after the transaction commits. CountByOwner backs the idempotency
+// guard: a user who already owns at least one cardgroup is not re-seeded on the
+// next call. CreateTx inserts the snapshot cardgroup using the caller's transaction
+// handle so the insert participates in the caller's transaction.
 type masterDeckUserCardgroupRepo interface {
 	FindByID(ctx context.Context, id string) (*domain.Cardgroup, error)
 	CountByOwner(ctx context.Context, ownerID string, search *string) (int64, error)
@@ -67,6 +68,7 @@ type CopyMasterToUserUsecase interface {
 // MergeMasterResult is the tally returned by MergeMasterIntoCardgroup: the
 // destination cardgroup plus the insert/update counts from the upsert.
 type MergeMasterResult struct {
+	// Non-nil when the returned error is nil.
 	Cardgroup *domain.Cardgroup
 	Added     int64
 	Updated   int64
@@ -80,10 +82,11 @@ type MergeMasterIntoCardgroupUsecase interface {
 	MergeMasterIntoCardgroup(ctx context.Context, masterID string, destCardgroupID domain.CardgroupID, ownerID domain.UserID) (*MergeMasterResult, error)
 }
 
-// masterDeckUsecase implements both the public copy primitive and the
-// default-starter seed batch. copyMasterToUserTx is the shared tx-aware core; the
-// two public entry points each open their own transaction and supply the caller
-// wrap prefix.
+// masterDeckUsecase implements three public entry points: CopyMasterToUser (single
+// import), SeedForNewUser (default-starter batch), and MergeMasterIntoCardgroup
+// (merge into an existing caller-owned cardgroup). copyMasterToUserTx is the
+// shared tx-aware core for CopyMasterToUser and SeedForNewUser; MergeMasterIntoCardgroup
+// uses the lower-level copyMasterCardsIntoTx directly.
 type masterDeckUsecase struct {
 	masterCG   masterDeckCardgroupRepo
 	masterCard masterDeckCardRepo
@@ -337,7 +340,7 @@ func (u *masterDeckUsecase) MergeMasterIntoCardgroup(
 	if err := u.tx(ctx, func(tx *gorm.DB) error {
 		cards, err := u.masterCard.ListByMasterCardgroup(ctx, masterID)
 		if err != nil {
-			return eris.Wrap(err, "list master cards")
+			return eris.Wrap(err, "usecase: master deck: merge master into cardgroup: list master cards")
 		}
 		r, err := u.copyMasterCardsIntoTx(ctx, tx, cards, destCardgroupID, nil)
 		if err != nil {
@@ -354,6 +357,9 @@ func (u *masterDeckUsecase) MergeMasterIntoCardgroup(
 
 	cg, err := u.userCG.FindByID(ctx, string(destCardgroupID))
 	if err != nil {
+		if isContextDone(err) {
+			return nil, err
+		}
 		return nil, eris.Wrap(err, "usecase: master deck: merge master into cardgroup: find destination")
 	}
 	return &MergeMasterResult{Cardgroup: cg, Added: res.Inserted, Updated: res.Updated}, nil

--- a/backend/internal/usecase/master_deck.go
+++ b/backend/internal/usecase/master_deck.go
@@ -321,7 +321,7 @@ func (u *masterDeckUsecase) copyMasterToUserTx(ctx context.Context, tx *gorm.DB,
 // gate uses authorizeCardgroupOrBadInput (untrusted-input boundary): an unknown
 // cardgroup is a recoverable validation error; a foreign cardgroup is
 // UNAUTHENTICATED. Cards conflicting on (cardgroup_id, front) are overwritten
-// (back/position); ids are preserved so FSRS state survives. Returns the
+// (back/position/updated_at); ids are preserved so FSRS state survives. Returns the
 // destination cardgroup plus the add/update tally.
 func (u *masterDeckUsecase) MergeMasterIntoCardgroup(
 	ctx context.Context, masterID string, destCardgroupID domain.CardgroupID, ownerID domain.UserID,

--- a/backend/internal/usecase/master_deck_test.go
+++ b/backend/internal/usecase/master_deck_test.go
@@ -89,18 +89,30 @@ func (f *fakeUserCardRepo) UpsertManyTx(_ context.Context, _ *gorm.DB, cards []*
 // cardgroup handed to CreateTx (deep-copied) so assertions survive caller-side
 // mutation. byID backs FindByID for ownership checks and post-merge result
 // retrieval; a missing key returns repository.ErrNotFound.
+//
+// For tests that need FindByID to succeed on call 1 (ownership gate) but fail
+// on a later call (e.g. post-tx read), set findByIDErr and findByIDErrOnCall
+// to the 1-based call number at which the error should be injected. A zero
+// findByIDErrOnCall never injects (the default for all existing tests).
 type fakeUserCG struct {
-	count       int64
-	countErr    error
-	calls       int
-	lastUser    string
-	createErr   error
-	createCalls int
-	createdCGs  []*domain.Cardgroup
-	byID        map[string]*domain.Cardgroup
+	count             int64
+	countErr          error
+	calls             int
+	lastUser          string
+	createErr         error
+	createCalls       int
+	createdCGs        []*domain.Cardgroup
+	byID              map[string]*domain.Cardgroup
+	findByIDCalls     int
+	findByIDErr       error
+	findByIDErrOnCall int // 1-based; 0 = never inject
 }
 
 func (f *fakeUserCG) FindByID(_ context.Context, id string) (*domain.Cardgroup, error) {
+	f.findByIDCalls++
+	if f.findByIDErrOnCall != 0 && f.findByIDCalls == f.findByIDErrOnCall {
+		return nil, f.findByIDErr
+	}
 	cg, ok := f.byID[id]
 	if !ok {
 		return nil, repository.ErrNotFound
@@ -812,4 +824,68 @@ func TestMasterDeckUsecase_MergeMasterIntoCardgroup_ContextCancelled_PassesThrou
 	_, err := uc.MergeMasterIntoCardgroup(context.Background(), masterID, domain.CardgroupID(destID), domain.UserID(ownerID))
 	require.Error(t, err)
 	assertCancelled(t, err)
+}
+
+func TestMasterDeckUsecase_MergeMasterIntoCardgroup_PostTxFindByID_ContextCancelled_PassesThrough(t *testing.T) {
+	t.Parallel()
+	const ownerID = "11111111-1111-7111-8111-111111111111"
+	const destID = "22222222-2222-7222-8222-222222222222"
+	const masterID = "master-id"
+
+	// One card so the tx body executes and reaches the post-tx FindByID.
+	masterCards := []*domain.MasterCard{
+		masterCard("mc-1", masterID, "alpha", "first", 0),
+	}
+	destCG := mustCardgroup(t, destID, ownerID, "My Deck")
+
+	uc := NewMasterDeckUsecaseWithTx(
+		&fakeMasterCGRepo{},
+		&fakeMasterCardRepo{byMaster: map[string][]*domain.MasterCard{masterID: masterCards}},
+		&fakeUserCardRepo{},
+		&fakeUserCG{
+			byID:              map[string]*domain.Cardgroup{destID: destCG},
+			findByIDErr:       context.Canceled,
+			findByIDErrOnCall: 2, // call 1 = ownership gate (succeeds), call 2 = post-tx read (fails)
+		},
+		stubTxRunner,
+		newTestLogger(),
+	)
+
+	_, err := uc.MergeMasterIntoCardgroup(context.Background(), masterID, domain.CardgroupID(destID), domain.UserID(ownerID))
+	require.Error(t, err)
+	// The post-tx guard returns the bare context sentinel (no eris wrap).
+	if err != context.Canceled {
+		t.Fatalf("expected bare context.Canceled sentinel, got: %v (%T)", err, err)
+	}
+	assertCancelled(t, err)
+}
+
+func TestMasterDeckUsecase_MergeMasterIntoCardgroup_PostTxFindByIDError_PropagatesChain(t *testing.T) {
+	t.Parallel()
+	const ownerID = "11111111-1111-7111-8111-111111111111"
+	const destID = "22222222-2222-7222-8222-222222222222"
+	const masterID = "master-id"
+
+	// One card so the tx body executes and reaches the post-tx FindByID.
+	masterCards := []*domain.MasterCard{
+		masterCard("mc-1", masterID, "alpha", "first", 0),
+	}
+	destCG := mustCardgroup(t, destID, ownerID, "My Deck")
+
+	uc := NewMasterDeckUsecaseWithTx(
+		&fakeMasterCGRepo{},
+		&fakeMasterCardRepo{byMaster: map[string][]*domain.MasterCard{masterID: masterCards}},
+		&fakeUserCardRepo{},
+		&fakeUserCG{
+			byID:              map[string]*domain.Cardgroup{destID: destCG},
+			findByIDErr:       errors.New("db down"),
+			findByIDErrOnCall: 2, // call 1 = ownership gate (succeeds), call 2 = post-tx read (fails)
+		},
+		stubTxRunner,
+		newTestLogger(),
+	)
+
+	_, err := uc.MergeMasterIntoCardgroup(context.Background(), masterID, domain.CardgroupID(destID), domain.UserID(ownerID))
+	require.Error(t, err)
+	assertInternalChain(t, err, "usecase: master deck: merge master into cardgroup: find destination")
 }

--- a/backend/internal/usecase/master_deck_test.go
+++ b/backend/internal/usecase/master_deck_test.go
@@ -744,3 +744,72 @@ func TestMasterDeckUsecase_MergeMasterIntoCardgroup_EmptyDeck(t *testing.T) {
 	assert.Equal(t, int64(0), res.Updated)
 	assert.Equal(t, domain.CardgroupID(destID), res.Cardgroup.ID)
 }
+
+func TestMasterDeckUsecase_MergeMasterIntoCardgroup_ListCardsError_PropagatesChain(t *testing.T) {
+	t.Parallel()
+	const ownerID = "11111111-1111-7111-8111-111111111111"
+	const destID = "22222222-2222-7222-8222-222222222222"
+	const masterID = "master-id"
+
+	destCG := mustCardgroup(t, destID, ownerID, "My Deck")
+
+	uc := NewMasterDeckUsecaseWithTx(
+		&fakeMasterCGRepo{},
+		&fakeMasterCardRepo{listErr: errors.New("list cards failed")},
+		&fakeUserCardRepo{},
+		&fakeUserCG{byID: map[string]*domain.Cardgroup{destID: destCG}},
+		stubTxRunner,
+		newTestLogger(),
+	)
+
+	_, err := uc.MergeMasterIntoCardgroup(context.Background(), masterID, domain.CardgroupID(destID), domain.UserID(ownerID))
+	require.Error(t, err)
+	assertInternalChain(t, err, "usecase: master deck: merge master into cardgroup")
+}
+
+func TestMasterDeckUsecase_MergeMasterIntoCardgroup_UpsertCardsError_PropagatesChain(t *testing.T) {
+	t.Parallel()
+	const ownerID = "11111111-1111-7111-8111-111111111111"
+	const destID = "22222222-2222-7222-8222-222222222222"
+	const masterID = "master-id"
+
+	masterCards := []*domain.MasterCard{
+		masterCard("mc-1", masterID, "alpha", "first", 0),
+	}
+	destCG := mustCardgroup(t, destID, ownerID, "My Deck")
+
+	uc := NewMasterDeckUsecaseWithTx(
+		&fakeMasterCGRepo{},
+		&fakeMasterCardRepo{byMaster: map[string][]*domain.MasterCard{masterID: masterCards}},
+		&fakeUserCardRepo{upsertErr: errors.New("upsert failed")},
+		&fakeUserCG{byID: map[string]*domain.Cardgroup{destID: destCG}},
+		stubTxRunner,
+		newTestLogger(),
+	)
+
+	_, err := uc.MergeMasterIntoCardgroup(context.Background(), masterID, domain.CardgroupID(destID), domain.UserID(ownerID))
+	require.Error(t, err)
+	assertInternalChain(t, err, "usecase: master deck: merge master into cardgroup")
+}
+
+func TestMasterDeckUsecase_MergeMasterIntoCardgroup_ContextCancelled_PassesThrough(t *testing.T) {
+	t.Parallel()
+	const ownerID = "11111111-1111-7111-8111-111111111111"
+	const destID = "22222222-2222-7222-8222-222222222222"
+	const masterID = "master-id"
+
+	destCG := mustCardgroup(t, destID, ownerID, "My Deck")
+
+	uc := NewMasterDeckUsecaseWithTx(
+		&fakeMasterCGRepo{},
+		&fakeMasterCardRepo{listErr: context.Canceled},
+		&fakeUserCardRepo{},
+		&fakeUserCG{byID: map[string]*domain.Cardgroup{destID: destCG}},
+		stubTxRunner,
+		newTestLogger(),
+	)
+
+	_, err := uc.MergeMasterIntoCardgroup(context.Background(), masterID, domain.CardgroupID(destID), domain.UserID(ownerID))
+	require.Error(t, err)
+	assertCancelled(t, err)
+}

--- a/backend/internal/usecase/master_deck_test.go
+++ b/backend/internal/usecase/master_deck_test.go
@@ -13,6 +13,7 @@ import (
 
 	"backend/internal/domain"
 	"backend/internal/repository"
+	"backend/internal/usecase/ucerr"
 )
 
 // --- fakes -----------------------------------------------------------------
@@ -61,6 +62,9 @@ type fakeUserCardRepo struct {
 	captured   [][]*domain.Card
 	upsertErr  error
 	upsertCall int
+	// result, when Inserted or Updated is non-zero, overrides the default
+	// Inserted=len(cards) return. Used by merge tests to inject specific tallies.
+	result repository.UpsertManyTxResult
 }
 
 func (f *fakeUserCardRepo) UpsertManyTx(_ context.Context, _ *gorm.DB, cards []*domain.Card) (repository.UpsertManyTxResult, error) {
@@ -74,13 +78,17 @@ func (f *fakeUserCardRepo) UpsertManyTx(_ context.Context, _ *gorm.DB, cards []*
 	if f.upsertErr != nil {
 		return repository.UpsertManyTxResult{}, f.upsertErr
 	}
+	if f.result.Inserted != 0 || f.result.Updated != 0 {
+		return f.result, nil
+	}
 	return repository.UpsertManyTxResult{Inserted: int64(len(cards))}, nil
 }
 
 // fakeUserCG implements masterDeckUserCardgroupRepo: the idempotency-guard
 // CountByOwner plus the snapshot-cardgroup CreateTx. createdCGs records every
 // cardgroup handed to CreateTx (deep-copied) so assertions survive caller-side
-// mutation.
+// mutation. byID backs FindByID for ownership checks and post-merge result
+// retrieval; a missing key returns repository.ErrNotFound.
 type fakeUserCG struct {
 	count       int64
 	countErr    error
@@ -89,6 +97,15 @@ type fakeUserCG struct {
 	createErr   error
 	createCalls int
 	createdCGs  []*domain.Cardgroup
+	byID        map[string]*domain.Cardgroup
+}
+
+func (f *fakeUserCG) FindByID(_ context.Context, id string) (*domain.Cardgroup, error) {
+	cg, ok := f.byID[id]
+	if !ok {
+		return nil, repository.ErrNotFound
+	}
+	return cg, nil
 }
 
 func (f *fakeUserCG) CountByOwner(_ context.Context, ownerID string, _ *string) (int64, error) {
@@ -621,4 +638,84 @@ func TestCopyMasterToUser_UpsertCardsError_PropagatesChain(t *testing.T) {
 	// The bulk insert was attempted (one batch captured) before the error.
 	assert.Equal(t, 1, user.upsertCall, "the card insert was attempted")
 	require.Len(t, user.captured, 1)
+}
+
+// --- MergeMasterIntoCardgroup helpers and tests ----------------------------
+
+// stubTxRunner is a minimal txRunner for merge tests: it calls fn with a nil
+// *gorm.DB. All fakes ignore the *gorm.DB argument so nil is safe here.
+var stubTxRunner = txRunner(func(ctx context.Context, fn func(tx *gorm.DB) error) error {
+	return fn(nil)
+})
+
+// mustCardgroup builds a *domain.Cardgroup directly from the given IDs and name,
+// bypassing NewCardgroup's ID generator. Use only in tests where a deterministic
+// ID is required (e.g. to pre-populate the byID map in fakeUserCG).
+func mustCardgroup(t *testing.T, id, ownerID, name string) *domain.Cardgroup {
+	t.Helper()
+	return &domain.Cardgroup{
+		ID:      domain.CardgroupID(id),
+		OwnerID: domain.UserID(ownerID),
+		Name:    domain.CardgroupName(name),
+	}
+}
+
+func TestMasterDeckUsecase_MergeMasterIntoCardgroup_AddsAndUpdates(t *testing.T) {
+	t.Parallel()
+	const ownerID = "11111111-1111-7111-8111-111111111111"
+	const destID = "22222222-2222-7222-8222-222222222222"
+	const masterID = "master-id"
+
+	// Two master cards to merge.
+	masterCards := []*domain.MasterCard{
+		masterCard("mc-1", masterID, "alpha", "first", 0),
+		masterCard("mc-2", masterID, "beta", "second", 1),
+	}
+	destCG := mustCardgroup(t, destID, ownerID, "My Deck")
+
+	uc := NewMasterDeckUsecaseWithTx(
+		&fakeMasterCGRepo{}, // not consulted on merge path
+		&fakeMasterCardRepo{byMaster: map[string][]*domain.MasterCard{masterID: masterCards}},
+		&fakeUserCardRepo{result: repository.UpsertManyTxResult{Inserted: 1, Updated: 1}},
+		&fakeUserCG{byID: map[string]*domain.Cardgroup{destID: destCG}},
+		stubTxRunner,
+		newTestLogger(),
+	)
+
+	res, err := uc.MergeMasterIntoCardgroup(context.Background(), masterID, domain.CardgroupID(destID), domain.UserID(ownerID))
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	assert.Equal(t, int64(1), res.Added)
+	assert.Equal(t, int64(1), res.Updated)
+	assert.Equal(t, domain.CardgroupID(destID), res.Cardgroup.ID)
+}
+
+func TestMasterDeckUsecase_MergeMasterIntoCardgroup_NotOwned_Unauthenticated(t *testing.T) {
+	t.Parallel()
+	const ownerID = "11111111-1111-7111-8111-111111111111"
+	const otherID = "99999999-9999-7999-8999-999999999999"
+	const destID = "22222222-2222-7222-8222-222222222222"
+	destCG := mustCardgroup(t, destID, otherID, "Not Mine")
+
+	uc := NewMasterDeckUsecaseWithTx(
+		&fakeMasterCGRepo{}, &fakeMasterCardRepo{}, &fakeUserCardRepo{},
+		&fakeUserCG{byID: map[string]*domain.Cardgroup{destID: destCG}},
+		stubTxRunner, newTestLogger(),
+	)
+
+	_, err := uc.MergeMasterIntoCardgroup(context.Background(), "master-id", domain.CardgroupID(destID), domain.UserID(ownerID))
+	require.ErrorIs(t, err, ucerr.ErrUnauthenticated)
+}
+
+func TestMasterDeckUsecase_MergeMasterIntoCardgroup_DestNotFound_Validation(t *testing.T) {
+	t.Parallel()
+	uc := NewMasterDeckUsecaseWithTx(
+		&fakeMasterCGRepo{}, &fakeMasterCardRepo{}, &fakeUserCardRepo{},
+		&fakeUserCG{byID: map[string]*domain.Cardgroup{}}, // FindByID → ErrNotFound
+		stubTxRunner, newTestLogger(),
+	)
+	_, err := uc.MergeMasterIntoCardgroup(context.Background(), "master-id", domain.CardgroupID("33333333-3333-7333-8333-333333333333"), domain.UserID("u"))
+	var ve *ucerr.ValidationError
+	require.ErrorAs(t, err, &ve)
+	assert.Equal(t, "cardgroupId", ve.Field)
 }

--- a/backend/internal/usecase/master_deck_test.go
+++ b/backend/internal/usecase/master_deck_test.go
@@ -719,3 +719,28 @@ func TestMasterDeckUsecase_MergeMasterIntoCardgroup_DestNotFound_Validation(t *t
 	require.ErrorAs(t, err, &ve)
 	assert.Equal(t, "cardgroupId", ve.Field)
 }
+
+func TestMasterDeckUsecase_MergeMasterIntoCardgroup_EmptyDeck(t *testing.T) {
+	t.Parallel()
+	const ownerID = "11111111-1111-7111-8111-111111111111"
+	const destID = "22222222-2222-7222-8222-222222222222"
+	const masterID = "master-id-empty"
+
+	destCG := mustCardgroup(t, destID, ownerID, "My Deck")
+
+	uc := NewMasterDeckUsecaseWithTx(
+		&fakeMasterCGRepo{}, // not consulted on merge path
+		&fakeMasterCardRepo{byMaster: map[string][]*domain.MasterCard{masterID: {}}}, // zero cards
+		&fakeUserCardRepo{}, // default: Inserted=len(cards)=0, Updated=0
+		&fakeUserCG{byID: map[string]*domain.Cardgroup{destID: destCG}},
+		stubTxRunner,
+		newTestLogger(),
+	)
+
+	res, err := uc.MergeMasterIntoCardgroup(context.Background(), masterID, domain.CardgroupID(destID), domain.UserID(ownerID))
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	assert.Equal(t, int64(0), res.Added)
+	assert.Equal(t, int64(0), res.Updated)
+	assert.Equal(t, domain.CardgroupID(destID), res.Cardgroup.ID)
+}

--- a/docs/backend/library-gotchas/call-count-error-injection-for-nth-call.md
+++ b/docs/backend/library-gotchas/call-count-error-injection-for-nth-call.md
@@ -1,0 +1,66 @@
+# Call-count error injection on a fake to cover the Nth call of a twice-called repo method
+
+> Part of the [Go library gotchas](../../../.claude/rules/go-library-gotchas.md) rules.
+
+When a usecase calls the **same repository method more than once in one operation**, a
+fake that injects an error through a single error field can only exercise the *first*
+call — the later call's error branch stays untested, and a missing guard there is a
+silent gap.
+
+The canonical case is an operation that gates ownership and then re-reads the same
+aggregate: `MergeMasterIntoCardgroup` calls `u.userCG.FindByID` twice — once inside the
+pre-tx `authorizeCardgroupOrBadInput` gate, and again after the transaction commits to
+build the success payload. A fake with a plain `findByIDErr error` field fails the
+*ownership gate* (call 1) and never reaches the post-tx read (call 2), so the post-tx
+`isContextDone` guard and the `eris.Wrap(..., "...: find destination")` branch are
+unreachable by the test — exactly the branch a reviewer flagged as unguarded.
+
+**Fix:** give the fake a 1-based call counter and an "error on call N" field. The zero
+value (`0`) never injects, so every existing test that constructs the fake without the
+field is unaffected.
+
+```go
+type fakeUserCG struct {
+	byID              map[string]*domain.Cardgroup
+	findByIDCalls     int
+	findByIDErr       error
+	findByIDErrOnCall int // 1-based; 0 = never inject (default for all existing tests)
+}
+
+func (f *fakeUserCG) FindByID(_ context.Context, id string) (*domain.Cardgroup, error) {
+	f.findByIDCalls++
+	if f.findByIDErrOnCall != 0 && f.findByIDCalls == f.findByIDErrOnCall {
+		return nil, f.findByIDErr
+	}
+	if cg, ok := f.byID[id]; ok {
+		return cg, nil
+	}
+	return nil, repository.ErrNotFound
+}
+```
+
+Then the test injects on the call that reaches the branch under test (`findByIDErrOnCall: 2`
+= ownership gate succeeds on call 1, post-tx read fails on call 2):
+
+```go
+userCG := &fakeUserCG{
+	byID:              map[string]*domain.Cardgroup{destID: destCG},
+	findByIDErr:       context.Canceled, // or errors.New("db down")
+	findByIDErrOnCall: 2,
+}
+```
+
+Two follow-on assertions differ by error kind, because the boundary's handling differs:
+
+- **Context cancel on the post-tx read** is returned **bare** (the `isContextDone` guard
+  does `return nil, err` without wrapping), so assert *both* pointer identity
+  (`err != context.Canceled → t.Fatal`) **and** `assertCancelled`. This is unlike a
+  cancel raised **inside** the tx closure, which is `eris.Wrap`-ed before the outer
+  `isContextDone` returns it — there only `assertCancelled` (an `errors.Is` walk) holds.
+- **An infra error on the post-tx read** is wrapped, so assert the chain prefix:
+  `assertInternalChain(t, err, "usecase: master deck: merge master into cardgroup: find destination")`.
+
+Related: [`test-stub-fatal-on-exhausted-fixture.md`](test-stub-fatal-on-exhausted-fixture.md)
+(queue-style stubs that pop per call — a different multi-call shape) and
+[`pin-unwrapped-context-error-with-identity-check.md`](../error-wrapping/pin-unwrapped-context-error-with-identity-check.md)
+(why the bare-vs-wrapped context distinction is asserted with pointer identity).

--- a/schema/master_catalog.graphql
+++ b/schema/master_catalog.graphql
@@ -146,6 +146,28 @@ type MasterNotFoundError implements UserError {
 """Result of `importMasterCardgroup`: the imported cardgroup, or a typed not-found error returned as data."""
 union ImportMasterCardgroupResult = ImportMasterCardgroupSuccess | MasterNotFoundError
 
+"""Input for `mergeMasterCardgroup`: the published catalog deck to copy from and the caller-owned destination cardgroup to merge into."""
+input MergeMasterCardgroupInput {
+  """The published catalog deck (MasterCardgroup node id) to merge from."""
+  masterCardgroupId: ID!
+  """The caller-owned destination cardgroup to merge the cards into."""
+  cardgroupId: ID!
+}
+
+"""
+Success variant of `mergeMasterCardgroup`. `addedCount` is the number of cards
+newly inserted; `updatedCount` is the number of existing cards (same front)
+overwritten. Card ids are preserved on overwrite so FSRS state survives.
+"""
+type MergeMasterCardgroupSuccess {
+  cardgroup: Cardgroup!
+  addedCount: Int!
+  updatedCount: Int!
+}
+
+"""Result of `mergeMasterCardgroup`: the merge tally, or a typed not-found error returned as data."""
+union MergeMasterCardgroupResult = MergeMasterCardgroupSuccess | MasterNotFoundError
+
 """Payload of `seedDefaultStarterCardgroups`: the user cardgroups created by the seed (empty if none, or if the caller already owns a cardgroup)."""
 type SeedDefaultStartersPayload {
   cardgroups: [Cardgroup!]!
@@ -176,4 +198,13 @@ extend type Mutation {
   Unauthenticated callers receive UNAUTHENTICATED.
   """
   seedDefaultStarterCardgroups: SeedDefaultStartersPayload!
+  """
+  Merge a published catalog deck's cards into the caller's existing cardgroup as a
+  one-time snapshot. Cards whose front already exists in the destination are
+  overwritten (back/position); card ids are preserved so FSRS state survives.
+  An unknown or draft master returns MasterNotFoundError (draft existence is never
+  leaked). A destination cardgroup not found is BAD_USER_INPUT; not owned is
+  UNAUTHENTICATED. Unauthenticated callers receive UNAUTHENTICATED.
+  """
+  mergeMasterCardgroup(input: MergeMasterCardgroupInput!): MergeMasterCardgroupResult!
 }


### PR DESCRIPTION
## Summary

Until now the only way to bring a published catalog deck's cards into a user's library was `importMasterCardgroup`, which always creates a **new** cardgroup. There was no path to add a catalog deck's cards into a cardgroup the user **already owns**.

This adds a `mergeMasterCardgroup` mutation that copies a published catalog deck's cards into an existing caller-owned cardgroup. Cards conflicting on the existing `(cardgroup_id, front)` unique index are overwritten (`back`/`position`); the card `id` is preserved, so FSRS / learning progress survives. Like `importMasterCardgroup`, a merge is a **one-time snapshot** — but because conflict handling is overwrite-upsert, **re-merging the same deck re-syncs the destination to the current catalog content**.

This PR is **backend-only** (the API surface). The frontend UI ("Merge from catalog" on the cardgroup edit page) is the dependent follow-up #688.

Closes #687.

## Approach

The implementation mirrors the existing `importMasterCardgroup` flow end-to-end rather than inventing new shapes:

- **Layer split mirrors `ImportMaster`.** `MasterCatalogUsecase.MergeMaster` owns the published gate (`FindPublishedByID` → collapses unknown+draft into a not-found data outcome, non-disclosure) and caller authentication; `masterDeckUsecase.MergeMasterIntoCardgroup` owns the destination ownership gate + the transactional card copy.
- **Ownership gate runs outside the tx**, mirroring `card_import.go` `Import`: `authorizeCardgroupOrBadInput` returns its typed `ucerr` (`ValidationError("cardgroupId")` for not-found, `ErrUnauthenticated` for foreign) **unwrapped**. `MergeMaster` then wraps the delegated error **unconditionally** — no `errors.Is`/`errors.As` pass-through guard — because `gqlerr.FromUsecaseError` classifies via chain-walking `errors.Is`/`errors.AsType`, so a wrapped `ucerr` still maps to the right wire code (verified by dedicated tests).
- **Shared copy core extracted, original ordering preserved.** `copyMasterCardsIntoTx(masterCards, destCG, pin *time.Time)` is shared by both `copyMasterToUserTx` (import → new cardgroup, `pin = newCG.CreatedAt`) and the new merge (`pin = nil`). `copyMasterToUserTx` keeps its original list-before-create order, so no existing test assertion changed.
- **Two outcome structs, by layer.** `MergeMasterResult` (deck layer: cardgroup + Added/Updated counts) vs `MergeMasterOutcome` (catalog layer: adds the `NotFound` XOR). This matches the Import pattern and is not collapsible without crossing the layer boundary.
- **No new caps, no FSRS writes.** Catalog cards are already `domain.Card`-valid, so the free-text `checkImportCaps` does not apply; overwritten cards keep their id so existing `user_card_fsrs` rows survive.

## Changes

### Schema (`schema/master_catalog.graphql`)

- `input MergeMasterCardgroupInput { masterCardgroupId, cardgroupId }`, `type MergeMasterCardgroupSuccess { cardgroup, addedCount, updatedCount }`, `union MergeMasterCardgroupResult = MergeMasterCardgroupSuccess | MasterNotFoundError` (reuses the import not-found variant), and the `mergeMasterCardgroup` mutation. The wire arg stays `masterCardgroupId` (the catalog node is a `MasterCardgroup`).

### Usecase

- `backend/internal/usecase/master_deck.go`: extracted `copyMasterCardsIntoTx`; refactored `copyMasterToUserTx` to delegate (order preserved); added `MergeMasterIntoCardgroupUsecase` + `MergeMasterResult` + `MergeMasterIntoCardgroup` (ownership gate outside tx, post-tx `FindByID` for the payload with an `isContextDone` guard); widened the narrow `masterDeckUserCardgroupRepo` with `FindByID`.
- `backend/internal/usecase/master_catalog.go`: widened `masterDeckUsecaseFacade` with `MergeMasterIntoCardgroupUsecase`; added `MergeMasterOutcome` + `MergeMaster` (mirrors `ImportMaster`).

### Resolver (`backend/graph/resolver/master_catalog.resolvers.go`)

- `MergeMasterCardgroup` maps the outcome to the union: `MergeMasterCardgroupSuccess` (with `int(Added)`/`int(Updated)`), `MasterNotFoundError` as data, and a `noVariantSet` defensive guard for the degenerate `{Cardgroup:nil, NotFound:false}` producer-contract violation. Every error return goes through `gqlerr.FromUsecaseError`.

### Error / auth semantics

| Case | Result |
|---|---|
| master unknown or draft | `MasterNotFoundError` (errors-as-data; draft existence never leaked) |
| destination cardgroup not found | `BAD_USER_INPUT` (`ValidationError("cardgroupId")`) |
| destination not owned by caller | `UNAUTHENTICATED` |
| empty catalog deck | success with `addedCount=0, updatedCount=0` |
| unauthenticated caller | `UNAUTHENTICATED` |

## Tests

Fake-based unit tests (no Docker) across all three layers:

- **Usecase (deck):** add+update tallies, empty-deck (0/0), not-owned → `ErrUnauthenticated`, dest-not-found → `ValidationError("cardgroupId")`, list-cards / upsert error chains (`assertInternalChain`), tx-closure context-cancel, and post-tx `FindByID` context-cancel + infra-error (via a call-count error-injection fake, since `FindByID` is called by both the ownership gate and the post-tx read).
- **Usecase (catalog):** draft → NotFound, success passes counts through, unauthenticated, `verify-published` infra-error + context-cancel, delegate infra-error + context-cancel, and two tests pinning that an `eris.Wrap`-ed `ValidationError` / `ErrUnauthenticated` still classifies through `MergeMaster`.
- **Resolver:** success field mapping, NotFound-as-data, the XOR-invariant guard → INTERNAL, and a table asserting both wire codes (`UNAUTHENTICATED` + `BAD_USER_INPUT`).

`go build ./...`, `go vet ./...`, `go-arch-lint`, and `schema-lint` are clean; the gqlgen regen gate is in sync. The Docker-gated integration packages (`internal/repository`, `internal/database`, `cmd/*`) compile (`go test -c`) and are unaffected by this PR (no repository/database/cmd logic changed); they run in CI.

## Verification

- Call `mergeMasterCardgroup({ masterCardgroupId: <published>, cardgroupId: <owned> })` where the master and destination share some `front` values → `MergeMasterCardgroupSuccess` with `addedCount` = new fronts, `updatedCount` = shared fronts; the overwritten cards keep their ids (FSRS preserved).
- Re-run the same merge after the admin edits the catalog deck → the destination re-syncs (changed backs overwritten, new cards added).
- Pass a draft/unknown `masterCardgroupId` → `MasterNotFoundError` in `data` (no draft disclosure).
- Pass a `cardgroupId` you don't own → `UNAUTHENTICATED`; an unknown `cardgroupId` → `BAD_USER_INPUT` on `cardgroupId`.
