### PR TITLE
fix(frontend): add focus-ring offset to search inputs

### DIFF
--- a/frontend/src/app/admin/users/admin-users-client.tsx
+++ b/frontend/src/app/admin/users/admin-users-client.tsx
@@ -254,7 +254,7 @@ export function AdminUsersClient() {
               placeholder={t("searchPlaceholder")}
               value={search.input}
               onChange={(e) => search.setInput(e.target.value)}
-              className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
               aria-label={t("searchLabel")}
             />
           </div>

--- a/frontend/src/app/catalog/catalog-client.tsx
+++ b/frontend/src/app/catalog/catalog-client.tsx
@@ -166,7 +166,7 @@ export default function CatalogClient({ initialConnection }: CatalogClientProps)
               placeholder={t("searchPlaceholder")}
               value={search.input}
               onChange={(e) => search.setInput(e.target.value)}
-              className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
               aria-label={t("searchAriaLabel")}
               data-testid="catalog-search"
             />

--- a/frontend/src/components/cardgroups/card-search-input.tsx
+++ b/frontend/src/components/cardgroups/card-search-input.tsx
@@ -24,7 +24,7 @@ export function CardSearchInput({
           placeholder={t("searchPlaceholder")}
           value={value}
           onChange={(e) => onChange(e.target.value)}
-          className="w-full rounded-md border border-input bg-background pl-8 pr-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          className="w-full rounded-md border border-input bg-background pl-8 pr-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
           aria-label={t("searchAriaLabel")}
           data-testid="cards-search-input"
         />

--- a/frontend/src/components/cardgroups/cardgroups-toolbar.tsx
+++ b/frontend/src/components/cardgroups/cardgroups-toolbar.tsx
@@ -21,7 +21,7 @@ export function CardgroupsToolbar({ searchInput, onSearchInputChange }: Cardgrou
         placeholder={t("filterPlaceholder")}
         value={searchInput}
         onChange={(e) => onSearchInputChange(e.target.value)}
-        className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
         aria-label={t("filterAriaLabel")}
       />
     </div>

--- a/frontend/src/components/cardgroups/merge-from-catalog-sheet.tsx
+++ b/frontend/src/components/cardgroups/merge-from-catalog-sheet.tsx
@@ -220,7 +220,7 @@ export function MergeFromCatalogSheet({
             placeholder={tCatalog("searchPlaceholder")}
             aria-label={tCatalog("searchAriaLabel")}
             data-testid="merge-from-catalog-search"
-            className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
           />
 
           {banner ? (

--- a/frontend/src/components/search/search-takeover-bar.tsx
+++ b/frontend/src/components/search/search-takeover-bar.tsx
@@ -87,7 +87,7 @@ export function SearchTakeoverBar({
           placeholder={placeholder}
           aria-label={ariaLabel}
           data-testid="search-takeover-input"
-          className="w-full rounded-md border border-input bg-background py-2.5 pl-8 pr-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          className="w-full rounded-md border border-input bg-background py-2.5 pl-8 pr-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
         />
       </div>
       {value !== "" && (


### PR DESCRIPTION
## Summary

The search-input focus ring rendered flush against the `border-input` edge, producing a thick gray "double border" on focus — most visible in the new Merge-from-catalog sheet (the reported case). The six hand-rolled `<input type="search">` elements were missing the `ring-offset` classes that the shared shadcn `Input` component already carries, so the gray focus ring (`ring-2 ring-ring`) stacked directly on the gray border with no gap. This adds `focus-visible:ring-offset-2 focus-visible:ring-offset-background` to each, so the focus ring renders as the clean shadcn halo (a white gap between border and ring), matching the canonical `<Input>` already used in `admin-masters-client.tsx`.

Decisions:

- **Fixed all six hand-rolled inputs, not just the reported sheet.** All six share the identical class string and the identical defect, so fixing only the Merge sheet would leave its focus state inconsistent with `/catalog`, `/admin/users`, and the rest. `admin-masters-client.tsx` already uses the shared `<Input>` and needed no change — it is the canonical pattern the other six now match.
- **Kept the neutral `ring-ring` color (no recolor).** The design system uses a neutral gray focus ring by intent; the only defect was the missing offset, so the fix is purely additive offset classes.

No associated GitHub issue (user-reported visual bug).

## What changed

### Search-input focus ring

- Added `focus-visible:ring-offset-2 focus-visible:ring-offset-background` to the six hand-rolled `<input type="search">` elements:
  - `components/cardgroups/merge-from-catalog-sheet.tsx` (reported case)
  - `app/catalog/catalog-client.tsx` (`/catalog`)
  - `app/admin/users/admin-users-client.tsx` (`/admin/users`)
  - `components/cardgroups/cardgroups-toolbar.tsx` (`/cardgroups` filter)
  - `components/cardgroups/card-search-input.tsx` (card search)
  - `components/search/search-takeover-bar.tsx` (mobile search takeover)
- `app/admin/masters/admin-masters-client.tsx` uses the shared `<Input>` and is unchanged.

## Verification

- Focus any search input (e.g. open Merge-from-catalog on a cardgroup, focus "Search cardgroups…"): the ring is now a separated halo with a white gap, not a thick flush gray frame. The input's `className` carries `focus-visible:ring-offset-2 focus-visible:ring-offset-background`.

## Test plan

- [x] `git diff --stat main...HEAD` → 6 files, 6 insertions / 6 deletions (one class addition per file).
- [x] No test pins the focus-ring `className` (grep over `*.test.tsx` — empty).
- [x] biome has no Tailwind class-sort rule and never splits string literals → no lint/format churn; no type impact (class-string-only change).
- [ ] `pnpm --filter frontend lint && pnpm --filter frontend typecheck && pnpm --filter frontend test` — not yet run (fresh worktree, deps not installed); CSS-class-only change is not type/test-detectable, the meaningful check is visual.
