### PR TITLE
fix(cardgroups): stack bulk action bar on mobile, destructive delete

### DIFF
--- a/frontend/src/components/cardgroups/bulk-action-bar.tsx
+++ b/frontend/src/components/cardgroups/bulk-action-bar.tsx
@@ -28,17 +28,18 @@ export function BulkActionBar({ count, busy, onConfirm, onClear }: BulkActionBar
 
   return (
     <div
-      className="mb-3 flex items-center gap-3 rounded-md border border-border bg-muted/50 px-4 py-2"
+      className="mb-3 flex flex-col gap-2 rounded-md border border-border bg-muted/50 px-3 py-3 sm:flex-row sm:items-center sm:gap-3 sm:px-4 sm:py-2"
       data-testid="cards-bulk-action-bar"
     >
-      <span className="flex-1 text-sm font-medium">{t("selectedCount", { count })}</span>
+      <span className="text-sm font-medium sm:flex-1">{t("selectedCount", { count })}</span>
       <AlertDialog>
         <AlertDialogTrigger asChild>
           <Button
-            variant="outline"
+            variant="destructive"
             size="sm"
             disabled={busy}
             data-testid="cards-bulk-delete-button"
+            className="w-full sm:w-auto"
           >
             {tCommon("deleteSelected")}
             <Trash2 aria-hidden="true" className="ml-1.5 h-4 w-4" />
@@ -61,7 +62,7 @@ export function BulkActionBar({ count, busy, onConfirm, onClear }: BulkActionBar
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
-      <Button variant="outline" size="sm" onClick={onClear}>
+      <Button variant="outline" size="sm" className="w-full sm:w-auto" onClick={onClear}>
         {tCommon("cancel")}
         <X aria-hidden="true" className="ml-1.5 h-4 w-4" />
       </Button>


### PR DESCRIPTION
## Summary

The bulk-selection action bar (`BulkActionBar`, shown above the card list once a
card is selected) overflowed on mobile: the count label carried `flex-1`, so it
consumed the row and pushed `Delete selected` / `Cancel` past the right edge —
the count collapsed to two lines and `Cancel` was clipped off-screen (reported on
a ~360px viewport). The bar now **stacks vertically on mobile** (count →
full-width `Delete selected` → full-width `Cancel`) and **restores the original
single-row layout at `sm:` and up**. `Delete selected` also becomes
`variant="destructive"` (red), since it is the prominent full-width action of the
selection mode.

Decisions:

- **Stacked on mobile, single row on desktop.** The container switches between
  `flex-col` (mobile) and `sm:flex-row` so the desktop layout is unchanged; the
  count drops its always-on `flex-1` to `sm:flex-1` so it only pushes the buttons
  right on the single-row layout.
- **Delete is `destructive` at every breakpoint.** A shadcn `Button` `variant`
  is a prop, not a responsive class, so the red applies on desktop too. This is a
  deliberate, in-scope consequence of the color decision and matches the design
  system: delete / overwrite / discard actions are `destructive`. A prominent
  full-width neutral button that initiates a delete is exactly the footgun that
  rule guards against.
- **`Cancel` stays `outline`; the confirm dialog is unchanged.** The
  `AlertDialogAction` confirm already carried `buttonVariants({ variant: "destructive" })`.

No associated GitHub issue (user-reported visual bug).

## What changed

### Responsive layout (`components/cardgroups/bulk-action-bar.tsx`)

- Container: `flex items-center gap-3 px-4 py-2` → `flex flex-col gap-2 px-3 py-3 sm:flex-row sm:items-center sm:gap-3 sm:px-4 sm:py-2`.
- Count span: `flex-1 text-sm font-medium` → `text-sm font-medium sm:flex-1` (no longer forces the buttons right on the stacked layout).
- `Delete selected` and `Cancel` buttons: added `className="w-full sm:w-auto"` (full-width stacked on mobile, intrinsic width on desktop).

### Delete-button color

- `Delete selected` trigger: `variant="outline"` → `variant="destructive"`.
- `Cancel` trigger and the `AlertDialogAction` confirm are unchanged (confirm already destructive).

## Verification

- On a mobile-width viewport, select a card: the bar stacks (count line, then a
  full-width red `Delete selected`, then a full-width `Cancel`), `Cancel` is fully
  visible, and there is no horizontal overflow. At `sm:` and up the bar is a single
  row exactly as before. The delete trigger keeps
  `data-testid="cards-bulk-delete-button"` and now renders the destructive (red)
  variant; the confirm dialog's `cards-bulk-confirm` action is still red.

## Test plan

- [x] `pnpm --filter frontend lint` → exit 0
- [x] `pnpm --filter frontend typecheck` → exit 0
- [x] `vitest run cards-client` → 49 passed (co-located `cards-client.test.tsx`)
- [x] `vitest run cards-bulk-delete` → 8 passed (broad `__tests__/cards-bulk-delete.test.tsx`)
- [x] `pnpm --filter frontend build` → exit 0
- [x] `git diff --stat origin/main...HEAD` → 1 file, 5 insertions / 4 deletions
