### PR TITLE
perf(ci): cache Go build + run frontend tests on happy-dom

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -34,6 +34,26 @@ jobs:
         with:
           working_directory: backend
 
+      # mise-action only caches the Go toolchain install, not the build or
+      # module cache. Without this, every run recompiles all dependencies and
+      # the standard library from scratch — the dominant cost behind gqlgen
+      # generate, go-arch-lint, build, and `go test`.
+      - name: Resolve Go cache paths
+        id: go-cache
+        run: |
+          echo "build=$(go env GOCACHE)" >> "$GITHUB_OUTPUT"
+          echo "mod=$(go env GOMODCACHE)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Go build and module cache
+        uses: actions/cache@v5
+        with:
+          path: |
+            ${{ steps.go-cache.outputs.build }}
+            ${{ steps.go-cache.outputs.mod }}
+          key: ${{ runner.os }}-go-${{ hashFiles('backend/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
       - name: Download modules
         run: go mod download
 

--- a/frontend/__tests__/admin-master-cards.test.tsx
+++ b/frontend/__tests__/admin-master-cards.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 /**
  * Broad page-level test for the MasterManagementClient tree.
  * Exercises the full card-editor integration: SSR-seeded render and

--- a/frontend/__tests__/admin-masters-edit.test.tsx
+++ b/frontend/__tests__/admin-masters-edit.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { MockedProvider } from "@apollo/client/testing/react";
 import { render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";

--- a/frontend/__tests__/admin-masters-list.test.tsx
+++ b/frontend/__tests__/admin-masters-list.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { InMemoryCache } from "@apollo/client";
 import { MockedProvider } from "@apollo/client/testing/react";
 import { screen, waitFor } from "@testing-library/react";

--- a/frontend/__tests__/admin-roles-crud.test.tsx
+++ b/frontend/__tests__/admin-roles-crud.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 /**
  * Behavioural tests for the AdminRolesClient list shell.
  *

--- a/frontend/__tests__/admin-roles.test.tsx
+++ b/frontend/__tests__/admin-roles.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 /**
  * Broad page-level tests for /admin/roles (AdminRolesPage RSC).
  *

--- a/frontend/__tests__/admin-users-list.test.tsx
+++ b/frontend/__tests__/admin-users-list.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { InMemoryCache, NetworkStatus } from "@apollo/client";
 import { MockedProvider } from "@apollo/client/testing/react";
 import { screen, waitFor } from "@testing-library/react";

--- a/frontend/__tests__/admin-users-roles.test.tsx
+++ b/frontend/__tests__/admin-users-roles.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";

--- a/frontend/__tests__/cardgroup-edit.test.tsx
+++ b/frontend/__tests__/cardgroup-edit.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 /**
  * Broad page-level integration tests for the integrated cardgroup management
  * page (`/cardgroups/[id]/edit`).

--- a/frontend/__tests__/cardgroups-list.test.tsx
+++ b/frontend/__tests__/cardgroups-list.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/frontend/__tests__/cards-bulk-delete.test.tsx
+++ b/frontend/__tests__/cards-bulk-delete.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { gql, InMemoryCache } from "@apollo/client";
 import { MockedProvider } from "@apollo/client/testing/react";
 import { render, screen, waitFor } from "@testing-library/react";

--- a/frontend/__tests__/cards-pagination.test.tsx
+++ b/frontend/__tests__/cards-pagination.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { InMemoryCache } from "@apollo/client";
 import { MockedProvider } from "@apollo/client/testing/react";
 import { render, screen, waitFor } from "@testing-library/react";

--- a/frontend/__tests__/catalog-deck.test.tsx
+++ b/frontend/__tests__/catalog-deck.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 /**
  * Broad page-level integration tests for the public catalog deck-detail page
  * (`/catalog/[id]`).

--- a/frontend/__tests__/catalog-list.test.tsx
+++ b/frontend/__tests__/catalog-list.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -71,6 +71,7 @@
     "@types/react-dom": "19.2.3",
     "@vitest/coverage-v8": "^4.1.5",
     "clsx": "2.1.1",
+    "happy-dom": "^20.10.6",
     "jsdom": "^29.0.2",
     "knip": "^6.14.0",
     "postcss": "8.5.15",

--- a/frontend/src/app/_components/logout-button.test.tsx
+++ b/frontend/src/app/_components/logout-button.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/frontend/src/app/admin/masters/[id]/edit/cards/master-batch-import-form.test.tsx
+++ b/frontend/src/app/admin/masters/[id]/edit/cards/master-batch-import-form.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { ApolloClient } from "@apollo/client";

--- a/frontend/src/app/admin/masters/[id]/edit/cards/master-cards-client.test.tsx
+++ b/frontend/src/app/admin/masters/[id]/edit/cards/master-cards-client.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { MockedProvider } from "@apollo/client/testing/react";
 import { act, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/frontend/src/app/admin/masters/[id]/edit/cards/use-master-card-mutations.test.tsx
+++ b/frontend/src/app/admin/masters/[id]/edit/cards/use-master-card-mutations.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 
 import { readFileSync } from "node:fs";
 import { join } from "node:path";

--- a/frontend/src/app/admin/masters/[id]/edit/cards/use-master-cards-connection.test.tsx
+++ b/frontend/src/app/admin/masters/[id]/edit/cards/use-master-cards-connection.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { MockedProvider } from "@apollo/client/testing/react";
 import { renderHook, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";

--- a/frontend/src/app/admin/masters/[id]/edit/master-cards-section.test.tsx
+++ b/frontend/src/app/admin/masters/[id]/edit/master-cards-section.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { MockedProvider } from "@apollo/client/testing/react";
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/frontend/src/app/admin/masters/[id]/edit/master-edit-header.test.tsx
+++ b/frontend/src/app/admin/masters/[id]/edit/master-edit-header.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { MockedProvider } from "@apollo/client/testing/react";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/frontend/src/app/admin/masters/[id]/edit/page.test.tsx
+++ b/frontend/src/app/admin/masters/[id]/edit/page.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 

--- a/frontend/src/app/admin/masters/admin-master-form.test.tsx
+++ b/frontend/src/app/admin/masters/admin-master-form.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/frontend/src/app/admin/masters/admin-master-row.test.tsx
+++ b/frontend/src/app/admin/masters/admin-master-row.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 
 import { screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";

--- a/frontend/src/app/admin/masters/admin-masters-client.test.tsx
+++ b/frontend/src/app/admin/masters/admin-masters-client.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { MockedProvider } from "@apollo/client/testing/react";

--- a/frontend/src/app/admin/masters/master-status-badge.test.tsx
+++ b/frontend/src/app/admin/masters/master-status-badge.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 
 import { screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";

--- a/frontend/src/app/admin/masters/page.test.tsx
+++ b/frontend/src/app/admin/masters/page.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { describe, expect, it, vi } from "vitest";
 
 vi.mock("next/navigation", () => ({

--- a/frontend/src/app/admin/masters/use-master-mutations.test.tsx
+++ b/frontend/src/app/admin/masters/use-master-mutations.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { InMemoryCache } from "@apollo/client";
 import type { MockedResponse } from "@apollo/client/testing";
 import { MockedProvider } from "@apollo/client/testing/react";

--- a/frontend/src/app/admin/roles/admin-roles-client.test.tsx
+++ b/frontend/src/app/admin/roles/admin-roles-client.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 
 import { CombinedGraphQLErrors } from "@apollo/client/errors";
 import { MockedProvider } from "@apollo/client/testing/react";

--- a/frontend/src/app/admin/users/admin-user-profile-sheet.test.tsx
+++ b/frontend/src/app/admin/users/admin-user-profile-sheet.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 
 import { readFileSync } from "node:fs";
 import { join } from "node:path";

--- a/frontend/src/app/admin/users/admin-user-row.test.tsx
+++ b/frontend/src/app/admin/users/admin-user-row.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/frontend/src/app/admin/users/admin-users-client.test.tsx
+++ b/frontend/src/app/admin/users/admin-users-client.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 
 import { readFileSync } from "node:fs";
 import { join } from "node:path";

--- a/frontend/src/app/admin/users/page.test.tsx
+++ b/frontend/src/app/admin/users/page.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { describe, expect, it, vi } from "vitest";
 
 vi.mock("next/navigation", () => ({

--- a/frontend/src/app/admin/users/use-admin-user-mutations.test.tsx
+++ b/frontend/src/app/admin/users/use-admin-user-mutations.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { InMemoryCache } from "@apollo/client";
 import type { MockedResponse } from "@apollo/client/testing";
 import { MockedProvider } from "@apollo/client/testing/react";

--- a/frontend/src/app/cardgroups/[id]/cards/cards-client.test.tsx
+++ b/frontend/src/app/cardgroups/[id]/cards/cards-client.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { InMemoryCache } from "@apollo/client";
 import { MockedProvider } from "@apollo/client/testing/react";
 import { act, screen, waitFor } from "@testing-library/react";

--- a/frontend/src/app/cardgroups/[id]/cards/use-cards-connection.test.ts
+++ b/frontend/src/app/cardgroups/[id]/cards/use-cards-connection.test.ts
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { InMemoryCache, NetworkStatus } from "@apollo/client";
 import { MockedProvider } from "@apollo/client/testing/react";
 import { act, render, waitFor } from "@testing-library/react";

--- a/frontend/src/app/cardgroups/[id]/edit/cardgroup-management-client.test.tsx
+++ b/frontend/src/app/cardgroups/[id]/edit/cardgroup-management-client.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { renderWithIntl } from "@/test/render-with-intl";

--- a/frontend/src/app/cardgroups/[id]/edit/page.test.tsx
+++ b/frontend/src/app/cardgroups/[id]/edit/page.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 

--- a/frontend/src/app/cardgroups/[id]/use-merge-from-catalog.test.tsx
+++ b/frontend/src/app/cardgroups/[id]/use-merge-from-catalog.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { ApolloClient } from "@apollo/client";
 import type { MockedResponse } from "@apollo/client/testing";
 import { MockedProvider } from "@apollo/client/testing/react";

--- a/frontend/src/app/cardgroups/cardgroups-client.test.tsx
+++ b/frontend/src/app/cardgroups/cardgroups-client.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { InMemoryCache } from "@apollo/client";
 import { MockedProvider } from "@apollo/client/testing/react";
 import { act, screen, waitFor } from "@testing-library/react";

--- a/frontend/src/app/cardgroups/new/page.test.tsx
+++ b/frontend/src/app/cardgroups/new/page.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 
 import { InMemoryCache } from "@apollo/client";
 import { CombinedGraphQLErrors } from "@apollo/client/errors";

--- a/frontend/src/app/cardgroups/page.test.tsx
+++ b/frontend/src/app/cardgroups/page.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { render, screen } from "@testing-library/react";
 import { Suspense } from "react";
 import { describe, expect, it, vi } from "vitest";

--- a/frontend/src/app/cards/new/cards-new-client.test.tsx
+++ b/frontend/src/app/cards/new/cards-new-client.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import type { MockedResponse } from "@apollo/client/testing";
 import { MockedProvider } from "@apollo/client/testing/react";
 import { screen, waitFor, within } from "@testing-library/react";

--- a/frontend/src/app/catalog/[id]/catalog-deck-client.test.tsx
+++ b/frontend/src/app/catalog/[id]/catalog-deck-client.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { InMemoryCache } from "@apollo/client";
 import { MockedProvider } from "@apollo/client/testing/react";
 import { screen, waitFor } from "@testing-library/react";

--- a/frontend/src/app/catalog/[id]/catalog-deck-header.test.tsx
+++ b/frontend/src/app/catalog/[id]/catalog-deck-header.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";

--- a/frontend/src/app/catalog/_components/catalog-import-button.test.tsx
+++ b/frontend/src/app/catalog/_components/catalog-import-button.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";

--- a/frontend/src/app/catalog/catalog-card.test.tsx
+++ b/frontend/src/app/catalog/catalog-card.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";

--- a/frontend/src/app/catalog/catalog-client.test.tsx
+++ b/frontend/src/app/catalog/catalog-client.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { InMemoryCache } from "@apollo/client";
 import { MockedProvider } from "@apollo/client/testing/react";
 import { act, screen } from "@testing-library/react";

--- a/frontend/src/app/catalog/catalog-list-item.test.tsx
+++ b/frontend/src/app/catalog/catalog-list-item.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { CatalogCardFieldsFragment } from "@/app/catalog/queries";

--- a/frontend/src/app/error.test.tsx
+++ b/frontend/src/app/error.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import RootError from "./error";

--- a/frontend/src/app/global-error.test.tsx
+++ b/frontend/src/app/global-error.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";

--- a/frontend/src/app/learn/[cardgroupId]/_components/learn-add-card-sheet.test.tsx
+++ b/frontend/src/app/learn/[cardgroupId]/_components/learn-add-card-sheet.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { MockedProvider } from "@apollo/client/testing/react";
 import { act, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/frontend/src/app/learn/[cardgroupId]/learn-client.test.tsx
+++ b/frontend/src/app/learn/[cardgroupId]/learn-client.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { gql, InMemoryCache } from "@apollo/client";
 import { MockedProvider } from "@apollo/client/testing/react";
 import { act, screen, waitFor } from "@testing-library/react";

--- a/frontend/src/app/learn/[cardgroupId]/page.test.tsx
+++ b/frontend/src/app/learn/[cardgroupId]/page.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { render, screen } from "@testing-library/react";
 import { Suspense } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";

--- a/frontend/src/app/learn/[cardgroupId]/practice-client.test.tsx
+++ b/frontend/src/app/learn/[cardgroupId]/practice-client.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { MockedProvider } from "@apollo/client/testing/react";

--- a/frontend/src/app/loading.test.tsx
+++ b/frontend/src/app/loading.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import Loading from "./loading";

--- a/frontend/src/app/login/in-app-browser-guard.test.tsx
+++ b/frontend/src/app/login/in-app-browser-guard.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { fireEvent, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { renderWithIntl } from "@/test/render-with-intl";

--- a/frontend/src/app/login/login-button.test.tsx
+++ b/frontend/src/app/login/login-button.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { renderWithIntl } from "@/test/render-with-intl";

--- a/frontend/src/app/login/page.test.tsx
+++ b/frontend/src/app/login/page.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/frontend/src/app/not-found.test.tsx
+++ b/frontend/src/app/not-found.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { renderWithIntl } from "@/test/render-with-intl";

--- a/frontend/src/app/onboarding/onboarding-form.test.tsx
+++ b/frontend/src/app/onboarding/onboarding-form.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { MockedProvider } from "@apollo/client/testing/react";
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/frontend/src/app/onboarding/start/onboarding-start-client.test.tsx
+++ b/frontend/src/app/onboarding/start/onboarding-start-client.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";

--- a/frontend/src/app/onboarding/start/use-seed-default-starters.test.tsx
+++ b/frontend/src/app/onboarding/start/use-seed-default-starters.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { InMemoryCache } from "@apollo/client";
 import type { MockedResponse } from "@apollo/client/testing";
 import { MockedProvider } from "@apollo/client/testing/react";

--- a/frontend/src/app/privacy/page.test.tsx
+++ b/frontend/src/app/privacy/page.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 

--- a/frontend/src/app/profile/change-email/change-email-client.test.tsx
+++ b/frontend/src/app/profile/change-email/change-email-client.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 
 import { fireEvent, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/frontend/src/app/profile/change-email/page.test.tsx
+++ b/frontend/src/app/profile/change-email/page.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 
 import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";

--- a/frontend/src/app/profile/delete-account-section.test.tsx
+++ b/frontend/src/app/profile/delete-account-section.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 
 import { readFileSync } from "node:fs";
 import { join } from "node:path";

--- a/frontend/src/app/profile/error.test.tsx
+++ b/frontend/src/app/profile/error.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";

--- a/frontend/src/app/profile/profile-form.test.tsx
+++ b/frontend/src/app/profile/profile-form.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { MockedProvider } from "@apollo/client/testing/react";
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/frontend/src/app/profile/profile-page-client.test.tsx
+++ b/frontend/src/app/profile/profile-page-client.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { MockedProvider } from "@apollo/client/testing/react";
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/frontend/src/app/profile/use-update-profile.test.tsx
+++ b/frontend/src/app/profile/use-update-profile.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import type { MockedResponse } from "@apollo/client/testing";
 import { MockedProvider } from "@apollo/client/testing/react";
 import { act, renderHook } from "@testing-library/react";

--- a/frontend/src/app/terms/page.test.tsx
+++ b/frontend/src/app/terms/page.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 

--- a/frontend/src/components/admin/admin-query-error-banner.test.tsx
+++ b/frontend/src/components/admin/admin-query-error-banner.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";

--- a/frontend/src/components/auth-shell.test.tsx
+++ b/frontend/src/components/auth-shell.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { AuthShell } from "./auth-shell";

--- a/frontend/src/components/batch-import/batch-import-wizard.test.tsx
+++ b/frontend/src/components/batch-import/batch-import-wizard.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { ApolloClient } from "@apollo/client";
 import type { MockedResponse } from "@apollo/client/testing";
 import { MockedProvider } from "@apollo/client/testing/react";

--- a/frontend/src/components/cardgroups/card-form.test.tsx
+++ b/frontend/src/components/cardgroups/card-form.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { CombinedGraphQLErrors } from "@apollo/client/errors";
 import { MockedProvider } from "@apollo/client/testing/react";
 import { screen, waitFor } from "@testing-library/react";

--- a/frontend/src/components/cardgroups/card-row.test.tsx
+++ b/frontend/src/components/cardgroups/card-row.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { screen } from "@testing-library/react";
 import { createRef } from "react";
 import { describe, expect, it, vi } from "vitest";

--- a/frontend/src/components/cardgroups/cardgroup-batch-import-form.test.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-batch-import-form.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { ApolloClient } from "@apollo/client";
 import type { MockedResponse } from "@apollo/client/testing";
 import { MockedProvider } from "@apollo/client/testing/react";

--- a/frontend/src/components/cardgroups/cardgroup-cards-section.test.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-cards-section.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/frontend/src/components/cardgroups/cardgroup-chip.test.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-chip.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";

--- a/frontend/src/components/cardgroups/cardgroup-form.test.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-form.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { CombinedGraphQLErrors } from "@apollo/client/errors";
 import { MockedProvider } from "@apollo/client/testing/react";
 import { useForm } from "@tanstack/react-form";

--- a/frontend/src/components/cardgroups/cardgroup-header.test.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-header.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import type { MockedResponse } from "@apollo/client/testing";
 import { MockedProvider } from "@apollo/client/testing/react";
 import { screen, waitFor } from "@testing-library/react";

--- a/frontend/src/components/cardgroups/cardgroup-list-item.test.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-list-item.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { MockedProvider } from "@apollo/client/testing/react";
 import { screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";

--- a/frontend/src/components/cardgroups/cardgroup-picker-sheet.test.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-picker-sheet.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 /**
  * Tests for <CardgroupPickerSheet>.
  *

--- a/frontend/src/components/cardgroups/cardgroup-rename-form.test.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-rename-form.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import type { MockedResponse } from "@apollo/client/testing";
 import { MockedProvider } from "@apollo/client/testing/react";
 import { screen, waitFor } from "@testing-library/react";

--- a/frontend/src/components/cardgroups/hover-reveal-delete-button.test.tsx
+++ b/frontend/src/components/cardgroups/hover-reveal-delete-button.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";

--- a/frontend/src/components/cardgroups/merge-from-catalog-sheet.test.tsx
+++ b/frontend/src/components/cardgroups/merge-from-catalog-sheet.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { ApolloClient } from "@apollo/client";
 import type { MockedResponse } from "@apollo/client/testing";
 import { MockedProvider } from "@apollo/client/testing/react";

--- a/frontend/src/components/cardgroups/read-only-card-row.test.tsx
+++ b/frontend/src/components/cardgroups/read-only-card-row.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { ReadOnlyCardRow } from "./read-only-card-row";

--- a/frontend/src/components/cardgroups/swipeable-row.test.tsx
+++ b/frontend/src/components/cardgroups/swipeable-row.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { readFileSync } from "node:fs";
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { createRef } from "react";

--- a/frontend/src/components/conditional-shell.test.tsx
+++ b/frontend/src/components/conditional-shell.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 

--- a/frontend/src/components/layout/connection-list-footer.test.tsx
+++ b/frontend/src/components/layout/connection-list-footer.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createRef } from "react";

--- a/frontend/src/components/layout/list-skeleton.test.tsx
+++ b/frontend/src/components/layout/list-skeleton.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { ListSkeleton } from "./list-skeleton";

--- a/frontend/src/components/layout/listing-page-shell.test.tsx
+++ b/frontend/src/components/layout/listing-page-shell.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { ListingPageShell } from "./listing-page-shell";

--- a/frontend/src/components/learn/all-caught-up.test.tsx
+++ b/frontend/src/components/learn/all-caught-up.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";

--- a/frontend/src/components/learn/animated-card.test.tsx
+++ b/frontend/src/components/learn/animated-card.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 
 import { Controller } from "@react-spring/web";
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";

--- a/frontend/src/components/learn/cefr-badge.test.tsx
+++ b/frontend/src/components/learn/cefr-badge.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";

--- a/frontend/src/components/learn/learn-action-bar.test.tsx
+++ b/frontend/src/components/learn/learn-action-bar.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";

--- a/frontend/src/components/learn/swipe-card-stack.test.tsx
+++ b/frontend/src/components/learn/swipe-card-stack.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { act, fireEvent, screen } from "@testing-library/react";
 import { createRef } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";

--- a/frontend/src/components/learn/swipe-card.test.tsx
+++ b/frontend/src/components/learn/swipe-card.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { CardContent, type SwipeCardData } from "./swipe-card";

--- a/frontend/src/components/learn/swipe-direction-overlay.test.tsx
+++ b/frontend/src/components/learn/swipe-direction-overlay.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { SwipeDirectionOverlay } from "./swipe-direction-overlay";

--- a/frontend/src/components/learn/use-fit-text.dom.test.tsx
+++ b/frontend/src/components/learn/use-fit-text.dom.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { act, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useFitText } from "./use-fit-text";

--- a/frontend/src/components/nav/app-shell.test.tsx
+++ b/frontend/src/components/nav/app-shell.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";

--- a/frontend/src/components/nav/detail-page-header.test.tsx
+++ b/frontend/src/components/nav/detail-page-header.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { DetailPageHeader } from "./detail-page-header";

--- a/frontend/src/components/nav/global-rail.test.tsx
+++ b/frontend/src/components/nav/global-rail.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { act, fireEvent, screen, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { renderWithIntl } from "@/test/render-with-intl";

--- a/frontend/src/components/nav/header-sign-in-link.test.tsx
+++ b/frontend/src/components/nav/header-sign-in-link.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { renderWithIntl } from "@/test/render-with-intl";

--- a/frontend/src/components/nav/logo-drawer.test.tsx
+++ b/frontend/src/components/nav/logo-drawer.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { act, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";

--- a/frontend/src/components/nav/mobile-menu-trigger.test.tsx
+++ b/frontend/src/components/nav/mobile-menu-trigger.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { Sheet } from "@/components/ui/sheet";

--- a/frontend/src/components/onboarding/onboarding-shell.test.tsx
+++ b/frontend/src/components/onboarding/onboarding-shell.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { OnboardingShell } from "./onboarding-shell";

--- a/frontend/src/components/pwa/apple-install-hint.test.tsx
+++ b/frontend/src/components/pwa/apple-install-hint.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";

--- a/frontend/src/components/pwa/brand-splash.test.tsx
+++ b/frontend/src/components/pwa/brand-splash.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { BrandSplash } from "./brand-splash";

--- a/frontend/src/components/pwa/sw-register.test.tsx
+++ b/frontend/src/components/pwa/sw-register.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { render } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/frontend/src/components/search/search-takeover-bar.test.tsx
+++ b/frontend/src/components/search/search-takeover-bar.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";

--- a/frontend/src/components/settings/language-switcher.test.tsx
+++ b/frontend/src/components/settings/language-switcher.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/frontend/src/components/ui/error-banner.test.tsx
+++ b/frontend/src/components/ui/error-banner.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { ErrorBanner } from "./error-banner";

--- a/frontend/src/components/ui/form-sheet.test.tsx
+++ b/frontend/src/components/ui/form-sheet.test.tsx
@@ -1,4 +1,7 @@
 // @vitest-environment jsdom
+// Keep jsdom here (not happy-dom): the vaul drawer drag-dismiss test relies on
+// jsdom's pointer-event behavior to surface the `vaul-dragging` class. happy-dom
+// does not reproduce the drag physics, so this file is intentionally pinned.
 
 import { fireEvent, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/frontend/src/components/ui/sonner.test.tsx
+++ b/frontend/src/components/ui/sonner.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { act, render, screen } from "@testing-library/react";

--- a/frontend/src/components/ui/split-button-menu.test.tsx
+++ b/frontend/src/components/ui/split-button-menu.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";

--- a/frontend/src/hooks/use-bulk-selection.test.ts
+++ b/frontend/src/hooks/use-bulk-selection.test.ts
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { act, renderHook } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { useBulkSelection } from "./use-bulk-selection";

--- a/frontend/src/hooks/use-debounced-search.test.ts
+++ b/frontend/src/hooks/use-debounced-search.test.ts
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { act, renderHook } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useDebouncedSearch } from "./use-debounced-search";

--- a/frontend/src/hooks/use-header-takeover-search.test.tsx
+++ b/frontend/src/hooks/use-header-takeover-search.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { act, renderHook } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useHeaderTakeoverSearch } from "./use-header-takeover-search";

--- a/frontend/src/hooks/use-mobile.test.tsx
+++ b/frontend/src/hooks/use-mobile.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { act, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getServerSnapshot, getSnapshot, subscribe, useIsMobile } from "./use-mobile";

--- a/frontend/src/lib/events/flamingo-events.test.ts
+++ b/frontend/src/lib/events/flamingo-events.test.ts
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { afterEach, describe, expect, it } from "vitest";
 import {
   type AddCardDetail,

--- a/frontend/src/lib/forms/form-field.test.tsx
+++ b/frontend/src/lib/forms/form-field.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";

--- a/frontend/src/lib/forms/use-sheet-form.test.ts
+++ b/frontend/src/lib/forms/use-sheet-form.test.ts
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { act, renderHook } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { useCardSheetForm, useSheetForm } from "./use-sheet-form";

--- a/frontend/src/lib/pagination/use-connection-pagination.test.tsx
+++ b/frontend/src/lib/pagination/use-connection-pagination.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { InMemoryCache } from "@apollo/client";
 import { MockedProvider } from "@apollo/client/testing/react";
 import { act, render, waitFor } from "@testing-library/react";

--- a/frontend/src/lib/undo-delete.test.tsx
+++ b/frontend/src/lib/undo-delete.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 
 /**
  * Tests for UndoDeleteProvider and useUndoDelete hook.

--- a/frontend/src/lib/url/use-sheet-search-param.test.ts
+++ b/frontend/src/lib/url/use-sheet-search-param.test.ts
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { act, renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useSheetSearchParam } from "./use-sheet-search-param";

--- a/frontend/src/lib/use-reduced-motion.test.ts
+++ b/frontend/src/lib/use-reduced-motion.test.ts
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { getServerSnapshot, getSnapshot, subscribe, useReducedMotion } from "./use-reduced-motion";
 

--- a/frontend/src/test/render-with-intl.test.tsx
+++ b/frontend/src/test/render-with-intl.test.tsx
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment happy-dom
 import { screen } from "@testing-library/react";
 import { useTranslations } from "next-intl";
 import { describe, expect, it } from "vitest";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -156,6 +156,9 @@ importers:
       clsx:
         specifier: 2.1.1
         version: 2.1.1
+      happy-dom:
+        specifier: ^20.10.6
+        version: 20.10.6
       jsdom:
         specifier: ^29.0.2
         version: 29.1.1
@@ -182,7 +185,7 @@ importers:
         version: 6.1.1(typescript@6.0.3)(vite@8.0.16(@types/node@24.13.2)(jiti@2.7.0)(yaml@2.9.0))
       vitest:
         specifier: ^4.1.5
-        version: 4.1.9(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1)(vite@8.0.16(@types/node@24.13.2)(jiti@2.7.0)(yaml@2.9.0))
+        version: 4.1.9(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(happy-dom@20.10.6)(jsdom@29.1.1)(vite@8.0.16(@types/node@24.13.2)(jiti@2.7.0)(yaml@2.9.0))
 
 packages:
 
@@ -2470,6 +2473,9 @@ packages:
   '@types/react@19.2.17':
     resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
 
+  '@types/whatwg-mimetype@3.0.2':
+    resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
+
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
@@ -2675,6 +2681,10 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  buffer-image-size@0.6.4:
+    resolution: {integrity: sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==}
+    engines: {node: '>=4.0'}
+
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
@@ -2862,6 +2872,10 @@ packages:
   enhanced-resolve@5.21.6:
     resolution: {integrity: sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==}
     engines: {node: '>=10.13.0'}
+
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
 
   entities@8.0.0:
     resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
@@ -3140,6 +3154,10 @@ packages:
   graphql@16.14.2:
     resolution: {integrity: sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
+
+  happy-dom@20.10.6:
+    resolution: {integrity: sha512-6QD0ilzDDt93tX44y8tbmZdAcdTRYDhUP+Asgi6pC8Pp5IA3cvaZGyoVN/EGtlq9ziT65iPuBBn3ASLr6hCgVw==}
+    engines: {node: '>=20.0.0'}
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -4282,6 +4300,10 @@ packages:
   webidl-conversions@8.0.1:
     resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
     engines: {node: '>=20'}
+
+  whatwg-mimetype@3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
 
   whatwg-mimetype@4.0.0:
     resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
@@ -6289,7 +6311,7 @@ snapshots:
       '@stryker-mutator/util': 9.6.1
       semver: 7.8.5
       tslib: 2.8.1
-      vitest: 4.1.9(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1)(vite@8.0.16(@types/node@24.13.2)(jiti@2.7.0)(yaml@2.9.0))
+      vitest: 4.1.9(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(happy-dom@20.10.6)(jsdom@29.1.1)(vite@8.0.16(@types/node@24.13.2)(jiti@2.7.0)(yaml@2.9.0))
 
   '@supabase/auth-js@2.108.2':
     dependencies:
@@ -6566,6 +6588,8 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
+  '@types/whatwg-mimetype@3.0.2': {}
+
   '@types/ws@8.18.1':
     dependencies:
       '@types/node': 24.13.2
@@ -6594,7 +6618,7 @@ snapshots:
       obug: 2.1.3
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1)(vite@8.0.16(@types/node@24.13.2)(jiti@2.7.0)(yaml@2.9.0))
+      vitest: 4.1.9(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(happy-dom@20.10.6)(jsdom@29.1.1)(vite@8.0.16(@types/node@24.13.2)(jiti@2.7.0)(yaml@2.9.0))
 
   '@vitest/expect@4.1.9':
     dependencies:
@@ -6758,6 +6782,10 @@ snapshots:
       node-releases: 2.0.48
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
+  buffer-image-size@0.6.4:
+    dependencies:
+      '@types/node': 24.13.2
+
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
@@ -6917,6 +6945,8 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.3
+
+  entities@7.0.1: {}
 
   entities@8.0.0: {}
 
@@ -7211,6 +7241,19 @@ snapshots:
       ws: 8.21.0
 
   graphql@16.14.2: {}
+
+  happy-dom@20.10.6:
+    dependencies:
+      '@types/node': 24.13.2
+      '@types/whatwg-mimetype': 3.0.2
+      '@types/ws': 8.18.1
+      buffer-image-size: 0.6.4
+      entities: 7.0.1
+      whatwg-mimetype: 3.0.0
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   has-flag@4.0.0: {}
 
@@ -8216,7 +8259,7 @@ snapshots:
       jiti: 2.7.0
       yaml: 2.9.0
 
-  vitest@4.1.9(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1)(vite@8.0.16(@types/node@24.13.2)(jiti@2.7.0)(yaml@2.9.0)):
+  vitest@4.1.9(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(happy-dom@20.10.6)(jsdom@29.1.1)(vite@8.0.16(@types/node@24.13.2)(jiti@2.7.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.9
       '@vitest/mocker': 4.1.9(vite@8.0.16(@types/node@24.13.2)(jiti@2.7.0)(yaml@2.9.0))
@@ -8241,6 +8284,7 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.13.2
       '@vitest/coverage-v8': 4.1.9(vitest@4.1.9)
+      happy-dom: 20.10.6
       jsdom: 29.1.1
     transitivePeerDependencies:
       - msw
@@ -8256,6 +8300,8 @@ snapshots:
   web-streams-polyfill@3.3.3: {}
 
   webidl-conversions@8.0.1: {}
+
+  whatwg-mimetype@3.0.0: {}
 
   whatwg-mimetype@4.0.0: {}
 


### PR DESCRIPTION
## Summary

Two independent, measured CI test-speed wins. **Backend:** `backend.yml` had no Go
cache at all, so every run recompiled all dependencies and the standard library from
scratch — the dominant cost behind `Generate gqlgen artifacts` (30s), `go-arch-lint`
(28s), `Build`, and `go test`. This adds an `actions/cache` step for the Go build +
module cache. **Frontend:** the vitest CPU profile showed jsdom *environment creation*
(~61s) was the single largest bucket — larger than test execution itself. Swapping the
128 `// @vitest-environment jsdom` pragmas to `happy-dom` cut total CPU 123s → 80s
(−35%) while keeping per-file isolation, so all 1681 tests still pass.

Decisions:

- **happy-dom over `isolate: false`.** Disabling isolation also halved CPU (123s → 64s)
  but broke 409 tests via cross-file state leakage — high effort to untangle. happy-dom
  preserves isolation and broke only one test, so it is the low-effort win.
- **`form-sheet.test.tsx` stays pinned to jsdom.** Its vaul drawer drag-dismiss test
  relies on jsdom's pointer-event behavior to surface the `vaul-dragging` class; happy-dom
  does not reproduce the drag physics. The file carries a comment explaining the pin.
- **`pool: 'threads'` rejected.** Measured no improvement over the default `forks` pool;
  the cost is environment creation, not worker mechanism.

No associated GitHub issue. Deferred follow-ups (re-measure `-race`, `.next/cache`,
coverage-on-main-only, vitest sharding) are tracked in #693.

## What changed

### Backend CI — Go build + module cache (`.github/workflows/backend.yml`)

- Adds a `Resolve Go cache paths` step (`go env GOCACHE` / `GOMODCACHE`) and an
  `actions/cache@v5` step keyed on `hashFiles('backend/go.sum')` with a `${{ runner.os }}-go-`
  restore-keys fallback, placed after mise setup and before `go mod download`.
- mise-action only caches the Go *toolchain* install; the build/module cache was never
  persisted across runs until now.

### Frontend tests — jsdom → happy-dom

- Swaps the exact `// @vitest-environment jsdom` pragma to `// @vitest-environment happy-dom`
  in 128 test files (prose lines mentioning jsdom and the 6 `node`-environment files are
  untouched).
- Pins `frontend/src/components/ui/form-sheet.test.tsx` back to jsdom with an explanatory
  comment (vaul drag depends on jsdom pointer behavior).
- Adds `happy-dom@20.10.6` as a frontend devDependency; `pnpm-lock.yaml` updated for
  `--frozen-lockfile`.

## Verification

- **Backend:** the first post-merge run populates the cache (no speedup); the second run
  is the first cache hit — confirm `Generate gqlgen artifacts` / `go-arch-lint` / `go test`
  step times drop on that run (`gh run view <id> --json jobs`).
- **Frontend:** the `Vitest with coverage` step (~2m06s today) is expected to fall to
  ~1m20–1m30s. The vitest profile's `environment` bucket drops from ~61s to ~23s of CPU.

## Test plan

- [x] `pnpm --filter frontend test` → 178 files, 1681 tests pass (happy-dom)
- [x] `pnpm --filter frontend test:coverage` → 1681 pass under v8 coverage
- [x] `pnpm --filter frontend knip` → exit 0 (happy-dom not flagged unused)
- [x] `pnpm --filter frontend typecheck` → exit 0
- [x] `biome check --error-on-warnings` on `src` + `__tests__` → clean
- [x] `backend.yml` parses as valid YAML
- [ ] Backend CI second run shows a Go cache hit with reduced compile/test step times
- [ ] Frontend CI `Vitest with coverage` step time reduced vs. the pre-merge baseline
