### PR TITLE
fix(cardgroups): center selected-count label on mobile bulk action bar

### DIFF
--- a/frontend/src/components/cardgroups/bulk-action-bar.tsx
+++ b/frontend/src/components/cardgroups/bulk-action-bar.tsx
@@ -31,7 +31,9 @@ export function BulkActionBar({ count, busy, onConfirm, onClear }: BulkActionBar
       className="mb-3 flex flex-col gap-2 rounded-md border border-border bg-muted/50 px-3 py-3 sm:flex-row sm:items-center sm:gap-3 sm:px-4 sm:py-2"
       data-testid="cards-bulk-action-bar"
     >
-      <span className="text-sm font-medium sm:flex-1">{t("selectedCount", { count })}</span>
+      <span className="text-center text-sm font-medium sm:flex-1 sm:text-left">
+        {t("selectedCount", { count })}
+      </span>
       <AlertDialog>
         <AlertDialogTrigger asChild>
           <Button


### PR DESCRIPTION
## Summary

After the bulk-selection action bar (`BulkActionBar`, shown above the card list once a card is selected) was made to **stack vertically on mobile** (count → full-width `Delete selected` → full-width `Cancel`), the count label (`1 selected`) stayed left-aligned in the stacked column — flush against the left edge while the two full-width buttons below it read as centered, leaving the count visually unbalanced (reported on a narrow viewport). The count label is now **centered on the stacked mobile layout** (`text-center`) and **keeps its left alignment on the `sm:` single-row layout** (`sm:text-left`), where it carries `flex-1` and sits to the left of the inline buttons exactly as before.

Decisions:

- **Center only on mobile.** On the stacked layout the label is its own full-width row, so centering it matches the centered text of the full-width buttons beneath it. At `sm:` and up the label is `flex-1` immediately left of the inline buttons, where left alignment is correct — hence `text-center sm:text-left` rather than an unconditional `text-center`.
- **Class-string-only change.** No markup, logic, or `data-testid` change; the container and the `Delete selected` / `Cancel` buttons are untouched. Only the count span's alignment classes change.

No associated GitHub issue (user-reported visual bug).

## What changed

### Count-label alignment (`components/cardgroups/bulk-action-bar.tsx`)

- Count span: `text-sm font-medium sm:flex-1` → `text-center text-sm font-medium sm:flex-1 sm:text-left`.
- The span is split across lines by the formatter; its text content (`t("selectedCount", { count })`) and the `data-testid="cards-bulk-action-bar"` container are unchanged.

## Verification

- On a mobile-width viewport, select a card: the `N selected` count label is horizontally centered above the full-width `Delete selected` / `Cancel` buttons. At `sm:` and up the label is left-aligned and `flex-1`, pushing the inline buttons to the right exactly as before. The count span carries `text-center … sm:text-left`.

## Test plan

- [x] `biome check bulk-action-bar.tsx` → clean (no fixes; biome has no Tailwind class-sort rule, so no format churn)
- [x] `tsc --noEmit` → exit 0 (class-string-only change, no type impact)
- [x] `vitest run cards-client.test.tsx` → 41 passed (co-located consumer test; asserts the `cards-bulk-action-bar` testid, no className pin)
- [x] `vitest run __tests__/cards-bulk-delete.test.tsx` → 8 passed (broad bulk-delete flow test)
- [x] `git diff --stat origin/main...HEAD` → 1 file, 3 insertions / 1 deletion
