### PR TITLE
feat(design-system): deepen destructive crimson + coral/warning tokens

### DIFF
--- a/frontend/src/app/globals-contrast.test.ts
+++ b/frontend/src/app/globals-contrast.test.ts
@@ -1,0 +1,84 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+// The hex constants below are a hand-maintained sRGB mirror of the coral-minimal
+// oklch tokens committed in `globals.css`. The contrast block proves WCAG 2.x
+// AA (>= 4.5:1) for the token pairings that render text on a fill; the
+// drift-guard block pins each oklch declaration verbatim so a token change in
+// globals.css fails loudly and forces the hex mirror to be re-derived.
+
+/** Parse a `#rrggbb` string into 0-255 RGB channels. */
+function hexToRgb(hex: string): [number, number, number] {
+  const value = hex.replace("#", "");
+  const r = Number.parseInt(value.slice(0, 2), 16);
+  const g = Number.parseInt(value.slice(2, 4), 16);
+  const b = Number.parseInt(value.slice(4, 6), 16);
+  return [r, g, b];
+}
+
+/** sRGB channel (0-255) -> linearized channel per WCAG 2.x. */
+function linearize(channel: number): number {
+  const c = channel / 255;
+  return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+}
+
+/** Relative luminance per WCAG 2.x. */
+function relativeLuminance(hex: string): number {
+  const [r, g, b] = hexToRgb(hex);
+  return 0.2126 * linearize(r) + 0.7152 * linearize(g) + 0.0722 * linearize(b);
+}
+
+/** WCAG 2.x contrast ratio between two hex colors (>= 1, lighter:darker). */
+function contrastRatio(hex1: string, hex2: string): number {
+  const l1 = relativeLuminance(hex1);
+  const l2 = relativeLuminance(hex2);
+  const lighter = Math.max(l1, l2);
+  const darker = Math.min(l1, l2);
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+const destructive = "#c2001c";
+const brandLink = "#a8353e";
+const warning = "#f0b13f";
+const warningForeground = "#683c00";
+const destructiveForeground = "#fafafa";
+const white = "#ffffff";
+
+describe("coral-minimal token contrast", () => {
+  it("destructive-foreground on destructive fill is AA", () => {
+    expect(contrastRatio(destructiveForeground, destructive)).toBeGreaterThanOrEqual(4.5);
+  });
+
+  it("brand-link text on white is AA", () => {
+    expect(contrastRatio(brandLink, white)).toBeGreaterThanOrEqual(4.5);
+  });
+
+  it("warning-foreground text on white is AA", () => {
+    expect(contrastRatio(warningForeground, white)).toBeGreaterThanOrEqual(4.5);
+  });
+
+  it("warning-foreground on warning band is AA", () => {
+    expect(contrastRatio(warningForeground, warning)).toBeGreaterThanOrEqual(4.5);
+  });
+});
+
+describe("coral-minimal token declarations in globals.css", () => {
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  const globalsCss = readFileSync(path.resolve(here, "globals.css"), "utf8");
+
+  const TOKEN_DECLARATIONS = [
+    "--destructive: oklch(0.51 0.21 25)",
+    "--ring: oklch(0.7364 0.189 18.45)",
+    "--brand-link: oklch(0.5 0.15 20)",
+    "--warning: oklch(0.8 0.145 78)",
+    "--warning-foreground: oklch(0.4 0.1 72)",
+  ] as const;
+
+  for (const declaration of TOKEN_DECLARATIONS) {
+    it(`declares ${declaration} verbatim`, () => {
+      expect(globalsCss).toContain(declaration);
+    });
+  }
+});

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -21,14 +21,17 @@
   --muted-foreground: oklch(0.556 0 0);
   --accent: oklch(0.97 0 0);
   --accent-foreground: oklch(0.205 0 0);
-  --destructive: oklch(0.577 0.245 27.325);
+  --destructive: oklch(0.51 0.21 25);
   --destructive-foreground: oklch(0.985 0 0);
   /* Status-indicator green — used ONLY as a status dot (e.g. a published deck),
      never as a CTA color. Coral (brand) stays the only constructive CTA color. */
   --success: oklch(0.63 0.17 149);
+  /* soft amber caution band (CEFR-band style, not a button fill); foreground is AA on the band and on white. */
+  --warning: oklch(0.8 0.145 78);
+  --warning-foreground: oklch(0.4 0.1 72);
   --border: oklch(0.922 0 0);
   --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
+  --ring: oklch(0.7364 0.189 18.45);
   --radius: 0.625rem;
   /* Brand tokens — flamingo coral palette */
   --brand-primary: oklch(73.64% 0.189 18.45);
@@ -36,6 +39,8 @@
   --brand-tint: oklch(98.5% 0.012 18.45);
   --brand-tint-border: oklch(91% 0.04 18.45);
   --brand-tint-foreground: oklch(45% 0.13 18.45);
+  /* darker coral for link/accent TEXT (the L74 brand fill fails WCAG as text on white). */
+  --brand-link: oklch(0.5 0.15 20);
   /* CEFR difficulty bands — saturated-but-soft fills on the white card surface.
      Foregrounds verified WCAG AA >= 4.5:1 both on their own band fill and on
      --card (#FFFFFF); see the contrast guard in cefr-badge.test.tsx. */
@@ -109,6 +114,8 @@
   --color-destructive: var(--destructive);
   --color-destructive-foreground: var(--destructive-foreground);
   --color-success: var(--success);
+  --color-warning: var(--warning);
+  --color-warning-foreground: var(--warning-foreground);
   --color-border: var(--border);
   --color-input: var(--input);
   --color-ring: var(--ring);
@@ -117,6 +124,7 @@
   --color-brand-tint: var(--brand-tint);
   --color-brand-tint-border: var(--brand-tint-border);
   --color-brand-tint-foreground: var(--brand-tint-foreground);
+  --color-brand-link: var(--brand-link);
   --color-cefr-a: var(--cefr-a);
   --color-cefr-a-foreground: var(--cefr-a-foreground);
   --color-cefr-b: var(--cefr-b);

--- a/frontend/src/components/batch-import/batch-import-wizard.test.tsx
+++ b/frontend/src/components/batch-import/batch-import-wizard.test.tsx
@@ -312,9 +312,9 @@ describe("<BatchImportWizard>", () => {
     await advanceToStep2(user);
     await user.click(await screen.findByTestId("batch-import-confirm-btn"));
     await waitFor(() => expect(screen.getByText(/duplicate front/i)).toBeInTheDocument());
-    // Duplicate rows are counted and labelled as warnings, not errors (amber, not red).
+    // Duplicate rows are counted and labelled as warnings, not errors (warning band, not red).
     const warningRow = screen.getByText(/duplicate front/i).closest("li");
-    expect(warningRow).toHaveClass("bg-amber-50");
+    expect(warningRow).toHaveClass("bg-warning/15");
     expect(warningRow).not.toHaveClass("bg-destructive/10");
     // The result summary counts the duplicate as a warning, not an error.
     const statuses = screen.getAllByRole("status");

--- a/frontend/src/components/batch-import/batch-import-wizard.tsx
+++ b/frontend/src/components/batch-import/batch-import-wizard.tsx
@@ -155,7 +155,7 @@ function ErrorList(props: {
           className={cn(
             "rounded-md px-3 py-2 text-sm",
             isWarningKind(err.kind)
-              ? "bg-amber-50 text-amber-800"
+              ? "bg-warning/15 text-warning-foreground"
               : "bg-destructive/10 text-destructive",
           )}
         >


### PR DESCRIPTION
## Summary

Danger red (`--destructive`, L58/H27) and the flamingo coral brand (`--brand-primary`, L74/H18) read as one warm-red family — only ~9° of hue apart, separated almost entirely by a 16-point lightness gap and with no icon on danger buttons. This deepens `--destructive` to L51 (widening the gap to ~23) and adds the coral-accent and warning tokens the later coral-minimal PRs consume. The deepened token propagates to every `bg-destructive` / `text-destructive` site, so it fixes the collision app-wide on its own.

This is the keystone of the coral-minimal color-system rework; it unblocks the button-variant, danger-trigger, and docs follow-ups.

## Changes

### Tokens (`frontend/src/app/globals.css`, light `:root` + `@theme inline`)

- `--destructive`: `oklch(0.577 0.245 27.325)` → `oklch(0.51 0.21 25)` (deeper crimson; `--destructive-foreground` unchanged).
- `--ring`: `oklch(0.708 0 0)` → `oklch(0.7364 0.189 18.45)` (coral focus rings).
- New `--brand-link: oklch(0.5 0.15 20)` — darker coral for link/accent **text** (the L74 fill fails contrast as text on white).
- New `--warning: oklch(0.8 0.145 78)` + `--warning-foreground: oklch(0.4 0.1 72)` — soft amber caution band.
- Exposed `--color-brand-link`, `--color-warning`, `--color-warning-foreground` in `@theme inline`.
- The `.dark` block, `--brand-primary`, `--success`, and `--cefr-*` are untouched.

**Contrast adjustment:** the issue proposed `--warning-foreground: oklch(0.43 …)`, which fails WCAG AA on the amber band (4.33:1). It ships at `oklch(0.4 0.1 72)` (4.95:1 on the band, 9.4:1 on white) per the issue's "darken the offending L" instruction.

### Warning amber routed through the token (`batch-import-wizard.tsx`)

- The `DUPLICATE`-kind warning row now renders `bg-warning/15 text-warning-foreground` instead of raw `bg-amber-50 text-amber-800` (no visual change intended). The error branch stays `bg-destructive/10 text-destructive`.

### Contrast guard (`frontend/src/app/globals-contrast.test.ts`, new)

- A WCAG 2.x contrast guard (modeled on `cefr-badge.test.tsx`) asserts ≥ 4.5:1 for white-on-`--destructive`, `--brand-link`-on-white, and `--warning-foreground` on white **and** on the `--warning` band. A drift guard pins each new oklch declaration verbatim so a future token change fails loudly.

## Test plan

- `pnpm --filter frontend typecheck` — clean.
- `pnpm --filter frontend lint` — clean.
- `pnpm --filter frontend test` — 1698 passed (181 files), including the new contrast guard.

Closes #698
