### PR TITLE
feat(button): add destructiveGhost variant + point link at coral

### DIFF
--- a/frontend/src/components/ui/button.test.tsx
+++ b/frontend/src/components/ui/button.test.tsx
@@ -1,0 +1,27 @@
+// @vitest-environment happy-dom
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Button } from "./button";
+
+describe("Button variants", () => {
+  it("destructiveGhost renders low-emphasis ghost-red (text-destructive on transparent, no filled bg)", () => {
+    render(<Button variant="destructiveGhost">Delete</Button>);
+    const button = screen.getByRole("button", { name: "Delete" });
+    expect(button).toHaveClass("bg-transparent", "text-destructive", "hover:bg-destructive/10");
+    // The low-emphasis trigger must NOT be the filled crimson commit variant.
+    expect(button).not.toHaveClass("bg-destructive");
+  });
+
+  it("link variant uses the coral link token, not the neutral primary", () => {
+    render(<Button variant="link">Learn more</Button>);
+    const button = screen.getByRole("button", { name: "Learn more" });
+    expect(button).toHaveClass("text-brand-link", "underline-offset-4", "hover:underline");
+    expect(button).not.toHaveClass("text-primary");
+  });
+
+  it("destructive (filled commit) keeps the crimson fill", () => {
+    render(<Button variant="destructive">Confirm delete</Button>);
+    const button = screen.getByRole("button", { name: "Confirm delete" });
+    expect(button).toHaveClass("bg-destructive", "text-destructive-foreground");
+  });
+});

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -12,10 +12,11 @@ const buttonVariants = cva(
         default: "bg-primary text-primary-foreground hover:bg-primary/90",
         brand: "bg-brand-primary text-brand-primary-foreground hover:bg-brand-primary/90",
         destructive: "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+        destructiveGhost: "bg-transparent text-destructive hover:bg-destructive/10",
         outline: "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
         secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",
         ghost: "hover:bg-accent hover:text-accent-foreground",
-        link: "text-primary underline-offset-4 hover:underline",
+        link: "text-brand-link underline-offset-4 hover:underline",
       },
       size: {
         default: "h-10 px-4 py-2",


### PR DESCRIPTION
## Summary

The coral-minimal model uses a two-tier danger treatment (a low-emphasis ghost-red trigger and a filled-crimson commit) plus a coral link color. This adds the `Button` primitive's `destructiveGhost` variant for the trigger and repoints the `link` variant at the coral `--brand-link` token, so the per-screen migration stays a pure variant swap.

Builds on #698 (PR base `feature/698-coral-destructive-tokens`), which introduces the `--brand-link` token. Part B of the coral-minimal rework.

## Changes

### Button variants (`frontend/src/components/ui/button.tsx`)

- New `destructiveGhost: "bg-transparent text-destructive hover:bg-destructive/10"` — low-emphasis danger trigger: crimson text, transparent background, faint red hover; no border, no fill.
- `link` repointed from `text-primary` to `text-brand-link` (the coral link token).
- `default`, `secondary`, `brand`, `destructive`, `outline`, `ghost`, and `defaultVariants` are unchanged.

### Variant coverage test (`frontend/src/components/ui/button.test.tsx`, new)

- Storybook is not installed on `main`, so the issue's "Storybook story" requirement is satisfied via a co-located vitest test — the repo's actual UI-verification mechanism. It asserts `destructiveGhost` renders `bg-transparent` + `text-destructive` + `hover:bg-destructive/10` (and NOT the filled `bg-destructive`), `link` renders `text-brand-link` (and NOT `text-primary`), and the filled `destructive` commit variant still carries `bg-destructive` + `text-destructive-foreground`.

## Test plan

- `pnpm --filter frontend typecheck` — clean.
- `pnpm --filter frontend lint` — clean.
- `pnpm --filter frontend test` — 1701 passed (182 files), including the 3 new button-variant tests.
- `pnpm --filter frontend build` — clean.

Closes #699
