### PR TITLE
feat(cardgroups): host import/merge in the header add-menu + continuous add

### DIFF
--- a/frontend/e2e/admin-masters-edit.spec.ts
+++ b/frontend/e2e/admin-masters-edit.spec.ts
@@ -60,12 +60,15 @@ test.describe("admin master card CRUD", () => {
     // Assert the new card row is now visible in the list.
     await expect(page.getByText(cardFront)).toBeVisible({ timeout: 10_000 });
 
-    // Wait for the add-card sheet to finish its close animation and unmount
-    // before opening the edit sheet. The add and edit sheets share the same
-    // [id$="-back-field"] / form-sheet-body submit shape, so while the add sheet
-    // lingers mid-exit the edit-step locators below would match two elements
-    // (strict-mode violation). Gating on the add field's removal makes the edit
-    // step deterministic.
+    // The add-card sheet now STAYS OPEN after a successful create (continuous
+    // add): the fields clear and an "N added" counter shows so the user can keep
+    // adding. Dismiss it explicitly with Escape before the edit step — the add
+    // and edit sheets share the same [id$="-back-field"] / form-sheet-body submit
+    // shape, so a lingering add sheet would make the edit-step locators match two
+    // elements (strict-mode violation). The form is freshly remounted and not
+    // dirty after the save, so Escape closes it without a confirm-dismiss prompt.
+    // Gating on the add field's removal makes the edit step deterministic.
+    await page.keyboard.press("Escape");
     await expect(page.locator("#add-card-back-field")).toHaveCount(0);
 
     // EDIT: click the card's edit-target div to open the edit sheet, change back text, save.

--- a/frontend/e2e/new-user-onboarding.spec.ts
+++ b/frontend/e2e/new-user-onboarding.spec.ts
@@ -66,12 +66,13 @@ test.describe
       expect(newCardgroupId).toMatch(UUID_RE);
       await expect(page.getByRole("heading", { name: cardgroupName })).toBeVisible();
 
-      // 3. Click the nav-header "+" button. On /cardgroups/<id>/edit its
-      // aria-label is "Add new card"; clicking it opens the "Add card"
-      // FormSheet inline — no navigation to /cards/new.
-      const addCardButton = page.getByRole("button", { name: "Add new card" });
-      await expect(addCardButton).toBeVisible();
-      await addCardButton.click();
+      // 3. The nav-header "+" on /cardgroups/<id>/edit opens an Add menu
+      // (Add card / Batch import / Merge). Open it via its locale-independent
+      // testid, then choose "Add card", which dispatches the cancelable
+      // flamingo:add-card event the in-page sheet claims — opening the "Add
+      // card" FormSheet inline with no navigation to /cards/new.
+      await page.getByTestId("header-add-menu-trigger").click();
+      await page.getByTestId("header-add-card").click();
 
       // 4. FormSheet opens inline. On mobile (390x844, below md=768) FormSheet
       // renders as a vaul Drawer. Verify the form is interactive via the Front

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -188,7 +188,8 @@
     "addCardSheetTitle": "Add card",
     "selectedCount": "{count} selected",
     "deleteCardsTitle": "Delete {count} cards?",
-    "deleteConfirmCount": "Delete {count}"
+    "deleteConfirmCount": "Delete {count}",
+    "addedCount": "{count} added"
   },
   "BatchImport": {
     "cardsToImport": "Cards to import",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -188,7 +188,8 @@
     "addCardSheetTitle": "カードを追加",
     "selectedCount": "{count}件選択中",
     "deleteCardsTitle": "{count}件のカードを削除しますか？",
-    "deleteConfirmCount": "{count}件を削除"
+    "deleteConfirmCount": "{count}件を削除",
+    "addedCount": "{count}件追加"
   },
   "BatchImport": {
     "cardsToImport": "インポートするカード",

--- a/frontend/src/app/admin/masters/[id]/edit/cards/master-cards-client.test.tsx
+++ b/frontend/src/app/admin/masters/[id]/edit/cards/master-cards-client.test.tsx
@@ -169,6 +169,26 @@ describe("<MasterCardsClient>", () => {
     expect(await screen.findByTestId("batch-import-payload")).toBeInTheDocument();
   });
 
+  it("opens the batch-import sheet when flamingo:batch-import fires for this master", async () => {
+    renderClient();
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent("flamingo:batch-import", { detail: { ownerId: MASTER_ID } }),
+      );
+    });
+    expect(await screen.findByTestId("batch-import-payload")).toBeInTheDocument();
+  });
+
+  it("ignores flamingo:batch-import for a different ownerId", () => {
+    renderClient();
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent("flamingo:batch-import", { detail: { ownerId: "other" } }),
+      );
+    });
+    expect(screen.queryByTestId("batch-import-payload")).not.toBeInTheDocument();
+  });
+
   it("renders the localized fetchMore-failure banner under the ja locale", async () => {
     const pageInfoWithNext = {
       __typename: "PageInfo" as const,

--- a/frontend/src/app/admin/masters/[id]/edit/cards/master-cards-client.test.tsx
+++ b/frontend/src/app/admin/masters/[id]/edit/cards/master-cards-client.test.tsx
@@ -1,9 +1,12 @@
 // @vitest-environment happy-dom
 import { MockedProvider } from "@apollo/client/testing/react";
-import { act, screen, waitFor } from "@testing-library/react";
+import { act, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { AdminMasterCardsConnectionDocument } from "@/generated/graphql";
+import {
+  AdminCreateMasterCardDocument,
+  AdminMasterCardsConnectionDocument,
+} from "@/generated/graphql";
 import { UndoDeleteProvider } from "@/lib/undo-delete";
 import { renderWithIntl } from "@/test/render-with-intl";
 import jaMessages from "../../../../../../../messages/ja.json";
@@ -102,9 +105,9 @@ type SectionHeader =
       onBatchImport: () => void;
     }) => React.ReactNode);
 
-function renderClient(sectionHeader?: SectionHeader) {
+function renderClient(sectionHeader?: SectionHeader, extraMocks: object[] = []) {
   renderWithIntl(
-    <MockedProvider mocks={[seed]}>
+    <MockedProvider mocks={[seed, ...extraMocks] as never}>
       <UndoDeleteProvider>
         <MasterCardsClient
           masterId={MASTER_ID}
@@ -187,6 +190,48 @@ describe("<MasterCardsClient>", () => {
       );
     });
     expect(screen.queryByTestId("batch-import-payload")).not.toBeInTheDocument();
+  });
+
+  it("keeps the add sheet open after creating, shows the added count, clears the fields", async () => {
+    const createMock = {
+      request: {
+        query: AdminCreateMasterCardDocument,
+        variables: { input: { masterCardgroupId: MASTER_ID, front: "hello", back: "world" } },
+      },
+      result: {
+        data: {
+          adminCreateMasterCard: {
+            __typename: "CreateMasterCardSuccess" as const,
+            masterCard: {
+              __typename: "MasterCard" as const,
+              id: "new-1",
+              masterCardgroupId: MASTER_ID,
+              front: "hello",
+              back: "world",
+              position: 0,
+              createdAt: "2026-01-01T00:00:00Z",
+              updatedAt: "2026-01-01T00:00:00Z",
+            },
+          },
+        },
+      },
+    };
+
+    const user = userEvent.setup();
+    renderClient(undefined, [createMock]);
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent("flamingo:add-master-card", { detail: { masterId: MASTER_ID } }),
+      );
+    });
+    const sheet = await screen.findByRole("dialog");
+    await user.type(within(sheet).getByLabelText(/front/i), "hello");
+    await user.type(within(sheet).getByLabelText(/back/i), "world");
+    await user.click(within(sheet).getByRole("button", { name: /^add$/i }));
+
+    // Sheet stays open; counter shows 1; fields cleared for the next card.
+    expect(await within(sheet).findByText(/1 added/i)).toBeInTheDocument();
+    expect(within(sheet).getByLabelText(/front/i)).toHaveValue("");
   });
 
   it("renders the localized fetchMore-failure banner under the ja locale", async () => {

--- a/frontend/src/app/admin/masters/[id]/edit/master-cards-section.test.tsx
+++ b/frontend/src/app/admin/masters/[id]/edit/master-cards-section.test.tsx
@@ -1,7 +1,6 @@
 // @vitest-environment happy-dom
 import { MockedProvider } from "@apollo/client/testing/react";
 import { screen, waitFor } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
 import { expect, it, vi } from "vitest";
 import { AdminMasterCardsConnectionDocument } from "@/generated/graphql";
 import { UndoDeleteProvider } from "@/lib/undo-delete";
@@ -39,52 +38,6 @@ const node = {
   createdAt: "2026-01-01T00:00:00Z",
   updatedAt: "2026-01-01T00:00:00Z",
 };
-
-it("threads onBatchImport into renderPageHeader so the header can open the import sheet", async () => {
-  // The mobile batch-import control now lives in the page header's overflow
-  // menu, so the section must forward MasterCardsClient's onBatchImport up to
-  // the renderPageHeader render prop; invoking it opens the real import sheet.
-  const user = userEvent.setup();
-  renderWithIntl(
-    <MockedProvider
-      mocks={[
-        {
-          request: {
-            query: AdminMasterCardsConnectionDocument,
-            variables: masterCardsDefaultVars(MASTER_ID),
-          },
-          result: {
-            data: {
-              adminMasterCardsConnection: {
-                __typename: "MasterCardConnection",
-                edges: [{ __typename: "MasterCardEdge", cursor: "c-1", node }],
-                pageInfo,
-                totalCount: 3,
-              },
-            },
-          },
-        },
-      ]}
-    >
-      <UndoDeleteProvider>
-        <MasterCardsSection
-          masterId={MASTER_ID}
-          deckName="Deck One"
-          initialEdges={[{ __typename: "MasterCardEdge", cursor: "c-1", node }]}
-          initialPageInfo={pageInfo}
-          initialTotalCount={3}
-          renderPageHeader={({ onBatchImport }) => (
-            <button type="button" data-testid="hdr-import" onClick={onBatchImport}>
-              import
-            </button>
-          )}
-        />
-      </UndoDeleteProvider>
-    </MockedProvider>,
-  );
-  await user.click(await screen.findByTestId("hdr-import"));
-  expect(await screen.findByTestId("batch-import-payload")).toBeInTheDocument();
-});
 
 it("renders MasterCardsClient with the seed and exposes the live count to renderPageHeader", async () => {
   renderWithIntl(

--- a/frontend/src/app/admin/masters/[id]/edit/master-cards-section.tsx
+++ b/frontend/src/app/admin/masters/[id]/edit/master-cards-section.tsx
@@ -19,11 +19,9 @@ type MasterCardsSectionProps = {
   initialTotalCount: number;
   /**
    * Renders the deck-level page header (title / status badge / overflow menu)
-   * with the live `totalCount`. Receives `onBatchImport` so the header's mobile
-   * overflow menu can host batch import (the standalone mobile toolbar button
-   * was removed). Omitted → no page header.
+   * with the live `totalCount`. Omitted → no page header.
    */
-  renderPageHeader?: (args: { totalCount: number; onBatchImport: () => void }) => ReactNode;
+  renderPageHeader?: (args: { totalCount: number }) => ReactNode;
 };
 
 export function MasterCardsSection({
@@ -50,9 +48,9 @@ export function MasterCardsSection({
     onBatchImport: () => void;
   }) => (
     <div>
-      {renderPageHeader?.({ totalCount, onBatchImport })}
-      {/* Mobile (<md): batch import lives in the page header's overflow menu;
-          Add card is the global header "+". */}
+      {renderPageHeader?.({ totalCount })}
+      {/* Mobile (<md): both Add card and Batch import live in the global header
+          "+" Add menu; the page-header overflow is lifecycle-only. */}
       {/* Desktop (md+): Add card + a dropdown that folds in Batch import. */}
       <div className="mb-3 hidden justify-end md:flex">
         <div className="inline-flex">

--- a/frontend/src/app/admin/masters/[id]/edit/master-edit-header.test.tsx
+++ b/frontend/src/app/admin/masters/[id]/edit/master-edit-header.test.tsx
@@ -47,8 +47,6 @@ const DECK: AdminMasterDeck = {
   updatedAt: "2026-01-01T00:00:00Z",
 };
 
-const onBatchImport = vi.fn();
-
 function renderHeader(
   overrides: Partial<AdminMasterDeck> & { cardCount?: number } = {},
   mocks: ReadonlyArray<unknown> = [],
@@ -59,11 +57,7 @@ function renderHeader(
   return render(
     <MockedProvider mocks={mocks as never}>
       <NextIntlClientProvider locale="en" messages={enMessages} timeZone="UTC">
-        <MasterEditHeader
-          master={deck}
-          cardCount={resolvedCardCount}
-          onBatchImport={onBatchImport}
-        />
+        <MasterEditHeader master={deck} cardCount={resolvedCardCount} />
       </NextIntlClientProvider>
     </MockedProvider>,
   );
@@ -297,23 +291,13 @@ describe("MasterEditHeader", () => {
     );
   });
 
-  it("mobile: overflow menu hosts batch import alongside Settings and Delete (no publish)", async () => {
+  it("mobile: overflow contains only Settings and Delete (no Batch import)", async () => {
     const user = userEvent.setup();
-    renderHeader({ status: "PUBLISHED", cardCount: 5 });
+    renderHeader();
     await user.click(screen.getByTestId("master-edit-overflow"));
-    expect(screen.getByTestId("master-edit-import-mobile")).toBeInTheDocument();
+    expect(screen.queryByTestId("master-edit-import-mobile")).not.toBeInTheDocument();
     expect(screen.getByTestId("master-edit-deck-settings-mobile")).toBeInTheDocument();
     expect(screen.getByTestId("master-edit-delete-mobile")).toBeInTheDocument();
-    // Publish stays on the status chip, not the overflow menu.
-    expect(screen.queryByTestId("master-edit-publish-mobile")).toBeNull();
-  });
-
-  it("mobile: overflow 'Batch import' item calls onBatchImport", async () => {
-    const user = userEvent.setup();
-    renderHeader({ status: "PUBLISHED", cardCount: 5 });
-    await user.click(screen.getByTestId("master-edit-overflow"));
-    await user.click(screen.getByTestId("master-edit-import-mobile"));
-    expect(onBatchImport).toHaveBeenCalledTimes(1);
   });
 
   it("renders the inline back link to the masters list", () => {
@@ -331,11 +315,7 @@ describe("MasterEditHeader", () => {
     const { container } = render(
       <MockedProvider mocks={[]}>
         <NextIntlClientProvider locale="en" messages={enMessages} timeZone="UTC">
-          <MasterEditHeader
-            master={{ ...DECK, cardCount: 0 }}
-            cardCount={5}
-            onBatchImport={onBatchImport}
-          />
+          <MasterEditHeader master={{ ...DECK, cardCount: 0 }} cardCount={5} />
         </NextIntlClientProvider>
       </MockedProvider>,
     );

--- a/frontend/src/app/admin/masters/[id]/edit/master-edit-header.tsx
+++ b/frontend/src/app/admin/masters/[id]/edit/master-edit-header.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ChevronDown, Eye, EyeOff, Import, MoreHorizontal, Settings, Trash2 } from "lucide-react";
+import { ChevronDown, Eye, EyeOff, MoreHorizontal, Settings, Trash2 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { useCallback, useState } from "react";
@@ -34,19 +34,11 @@ import type { AdminMasterDeck } from "./queries";
 type Props = {
   master: AdminMasterDeck;
   cardCount: number;
-  /**
-   * Opens the batch-import sheet (owned by `MasterCardsClient`). Surfaced here
-   * so the mobile overflow menu can host batch import, where the standalone
-   * toolbar button was removed. Required so the wire from `MasterCardsClient`
-   * is enforced at compile time rather than silently defaulting to a no-op.
-   */
-  onBatchImport: () => void;
 };
 
-export function MasterEditHeader({ master, cardCount, onBatchImport }: Props) {
+export function MasterEditHeader({ master, cardCount }: Props) {
   const t = useTranslations("AdminMasters");
   const tCommon = useTranslations("Common");
-  const tCardgroups = useTranslations("Cardgroups");
   const router = useRouter();
 
   const [settingsOpen, setSettingsOpen] = useState(false);
@@ -236,18 +228,6 @@ export function MasterEditHeader({ master, cardCount, onBatchImport }: Props) {
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end">
-          {/* Batch import lives here on mobile after the standalone toolbar
-              button was removed. The trigger is md:hidden, so this menu only
-              opens on mobile; desktop keeps batch import in the cards toolbar's
-              split-button menu. */}
-          <DropdownMenuItem
-            onSelect={onBatchImport}
-            data-testid="master-edit-import-mobile"
-            className="gap-2"
-          >
-            <Import aria-hidden="true" className="h-4 w-4" />
-            {tCardgroups("batchImport")}
-          </DropdownMenuItem>
           <DropdownMenuItem
             onSelect={() => setSettingsOpen(true)}
             data-testid="master-edit-deck-settings-mobile"

--- a/frontend/src/app/admin/masters/[id]/edit/master-management-client.tsx
+++ b/frontend/src/app/admin/masters/[id]/edit/master-management-client.tsx
@@ -21,17 +21,16 @@ export function MasterManagementClient({
   return (
     <main className="p-8">
       {/* The header is rendered inside the cards section via the render-prop so
-          its card count tracks the live Apollo-cache totalCount. The section
-          forwards onBatchImport so the header's mobile overflow menu can host
-          batch import; no count state is lifted into this component. */}
+          its card count tracks the live Apollo-cache totalCount; no count state
+          is lifted into this component. */}
       <MasterCardsSection
         masterId={master.id}
         deckName={master.name}
         initialEdges={initialEdges}
         initialPageInfo={initialPageInfo}
         initialTotalCount={initialTotalCount}
-        renderPageHeader={({ totalCount, onBatchImport }) => (
-          <MasterEditHeader master={master} cardCount={totalCount} onBatchImport={onBatchImport} />
+        renderPageHeader={({ totalCount }) => (
+          <MasterEditHeader master={master} cardCount={totalCount} />
         )}
       />
     </main>

--- a/frontend/src/app/cardgroups/[id]/cards/cards-client.test.tsx
+++ b/frontend/src/app/cardgroups/[id]/cards/cards-client.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 import { InMemoryCache } from "@apollo/client";
 import { MockedProvider } from "@apollo/client/testing/react";
-import { act, screen, waitFor } from "@testing-library/react";
+import { act, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { GraphQLError } from "graphql";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -373,7 +373,7 @@ describe("<CardsClient>", () => {
     expect(screen.getByDisplayValue("Hello")).toBeInTheDocument();
   });
 
-  it("successful create inserts the card into the active connection and closes the sheet", async () => {
+  it("successful create inserts the card into the active connection, keeps the sheet open, and shows the counter", async () => {
     const user = userEvent.setup();
     const cache = new InMemoryCache();
     cache.writeQuery({
@@ -394,9 +394,10 @@ describe("<CardsClient>", () => {
 
     expect(await screen.findByText("New front")).toBeInTheDocument();
     expect(screen.getByText("Cards (3)")).toBeInTheDocument();
-    await waitFor(() => {
-      expect(screen.queryByRole("heading", { name: /add card/i })).not.toBeInTheDocument();
-    });
+    // Sheet stays open: counter increments and front field clears for the next card.
+    expect(await screen.findByTestId("add-card-added-count")).toBeInTheDocument();
+    const dialog = screen.getByRole("dialog");
+    expect(within(dialog).getByLabelText(/front/i)).toHaveValue("");
     expect(
       cache.readQuery({
         query: CardsByCardgroupConnectionDocument,
@@ -436,11 +437,14 @@ describe("<CardsClient>", () => {
     await user.type(screen.getByLabelText(/back/i), "Cebra");
     await user.click(screen.getByRole("button", { name: /^add$/i }));
 
-    await waitFor(() => {
-      expect(screen.queryByRole("heading", { name: /add card/i })).not.toBeInTheDocument();
-    });
+    // Sheet stays open (continuous add) — counter is visible; search filter still active.
+    expect(await screen.findByTestId("add-card-added-count")).toBeInTheDocument();
     expect(screen.queryByText("Zebra")).not.toBeInTheDocument();
     expect(screen.getByText("Cards (1)")).toBeInTheDocument();
+
+    // Close the sheet before interacting with the search input outside the dialog.
+    const dialog = screen.getByRole("dialog");
+    await user.click(within(dialog).getByRole("button", { name: /cancel/i }));
 
     await user.clear(screen.getByTestId("cards-search-input"));
     await vi.advanceTimersByTimeAsync(300);

--- a/frontend/src/app/cardgroups/[id]/edit/cardgroup-management-client.tsx
+++ b/frontend/src/app/cardgroups/[id]/edit/cardgroup-management-client.tsx
@@ -25,13 +25,8 @@ export function CardgroupManagementClient({
         initialEdges={initialEdges}
         initialPageInfo={initialPageInfo}
         initialTotalCount={initialTotalCount}
-        renderPageHeader={({ totalCount, onBatchImport, onMerge }) => (
-          <CardgroupHeader
-            cardgroup={cardgroup}
-            totalCount={totalCount}
-            onBatchImport={onBatchImport}
-            onMerge={onMerge}
-          />
+        renderPageHeader={({ totalCount }) => (
+          <CardgroupHeader cardgroup={cardgroup} totalCount={totalCount} />
         )}
       />
     </main>

--- a/frontend/src/components/cardgroups/card-form.tsx
+++ b/frontend/src/components/cardgroups/card-form.tsx
@@ -72,6 +72,7 @@ export function CardForm({
             label={t("frontLabel")}
             idOverride={`${idPrefix}${field.name}-field`}
             className="space-y-1"
+            autoFocus={mode === "create"}
             backendError={
               validationError?.field === "front" ? validationError.message : fieldErrors.front
             }

--- a/frontend/src/components/cardgroups/card-list-screen.tsx
+++ b/frontend/src/components/cardgroups/card-list-screen.tsx
@@ -21,7 +21,11 @@ import type {
   CreateCardOutcome,
   UpdateCardOutcome,
 } from "@/lib/cards/card-mutation-outcomes";
-import { type FlamingoEventName, subscribeFlamingo } from "@/lib/events/flamingo-events";
+import {
+  FLAMINGO_EVENT,
+  type FlamingoEventName,
+  subscribeFlamingo,
+} from "@/lib/events/flamingo-events";
 import { useCardSheetForm } from "@/lib/forms/use-sheet-form";
 
 function EditCardSheetContent({
@@ -266,6 +270,15 @@ export function CardListScreen({
       sheet.openAddSheet();
     });
   }, [addCardEvent, sheet.openAddSheet]);
+
+  // The header "+" Add menu opens batch import via a global event (mobile path);
+  // the desktop split-button calls onBatchImport directly. Both end at openBatchImport.
+  useEffect(() => {
+    return subscribeFlamingo(FLAMINGO_EVENT.batchImport, (detail) => {
+      if (detail?.ownerId !== ownerId) return;
+      openBatchImport();
+    });
+  }, [ownerId, openBatchImport]);
 
   async function handleBulkDelete() {
     const ids = Array.from(selection.selectedIds);

--- a/frontend/src/components/cardgroups/card-list-screen.tsx
+++ b/frontend/src/components/cardgroups/card-list-screen.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Check } from "lucide-react";
 import { useTranslations } from "next-intl";
 import type { ReactNode, RefObject } from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -65,17 +66,29 @@ function AddCardSheetContent({
   error,
   validationError,
   onDirty,
+  addedCount,
 }: {
   submit: (values: { front: string; back: string }) => Promise<void>;
   submitting: boolean;
   error: unknown;
   validationError: { field: string; message: string } | null;
   onDirty: () => void;
+  addedCount: number;
 }) {
   const close = useFormSheetClose();
+  const t = useTranslations("Cards");
 
   return (
-    <div onInput={onDirty}>
+    <div onInput={onDirty} className="space-y-3">
+      {addedCount > 0 ? (
+        <p
+          className="flex items-center gap-1.5 text-sm text-success"
+          data-testid="add-card-added-count"
+        >
+          <Check aria-hidden="true" className="h-4 w-4" />
+          {t("addedCount", { count: addedCount })}
+        </p>
+      ) : null}
       <CardForm
         mode="create"
         idPrefix="add-card-"
@@ -386,11 +399,13 @@ export function CardListScreen({
             confirmOnDismiss
           >
             <AddCardSheetContent
+              key={`add-card-${sheet.createNonce}`}
               submit={sheet.handleCreate}
               submitting={creating}
               error={createError}
               validationError={sheet.createValidationError}
               onDirty={sheet.markAddDirty}
+              addedCount={sheet.addedCount}
             />
           </FormSheet>
 

--- a/frontend/src/components/cardgroups/cardgroup-cards-section.test.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-cards-section.test.tsx
@@ -85,11 +85,7 @@ const PAGE_INFO = {
 function renderSection(
   cardgroupId = "cg-1",
   initialTotalCount = 7,
-  renderPageHeader?: (args: {
-    totalCount: number;
-    onBatchImport: () => void;
-    onMerge: () => void;
-  }) => ReactNode,
+  renderPageHeader?: (args: { totalCount: number }) => ReactNode,
   extraMocks: MockedResponse[] = [],
 ) {
   renderWithIntl(
@@ -181,37 +177,6 @@ describe("<CardgroupCardsSection>", () => {
     const stub = screen.getByTestId("cards-client-stub");
     expect(stub).toContainElement(screen.getByRole("link", { name: /start learning/i }));
     expect(stub).toContainElement(screen.getByRole("button", { name: /add card \+/i }));
-  });
-
-  it("forwards onBatchImport into the renderPageHeader slot", async () => {
-    // The mobile batch-import control now lives in the page header's overflow
-    // menu, so the section must thread CardsClient's onBatchImport up to the
-    // renderPageHeader render prop, not just into its own toolbar.
-    const user = userEvent.setup();
-    renderSection("cg-1", 7, ({ onBatchImport: headerImport }) => (
-      <button type="button" data-testid="page-header-import" onClick={headerImport}>
-        header import
-      </button>
-    ));
-    await user.click(screen.getByTestId("page-header-import"));
-    expect(onBatchImport).toHaveBeenCalledTimes(1);
-  });
-
-  it("forwards onMerge into the renderPageHeader slot and it opens the merge sheet", async () => {
-    // The mobile merge control lives in the page header's overflow menu, so the
-    // section must thread its onMerge callback up to the renderPageHeader prop.
-    const user = userEvent.setup();
-    renderSection("cg-1", 7, ({ onMerge: headerMerge }) => (
-      <button type="button" data-testid="page-header-merge" onClick={headerMerge}>
-        header merge
-      </button>
-    ));
-    await user.click(screen.getByTestId("page-header-merge"));
-    // onMerge is () => setMergeOpen(true), owned by the section, so clicking
-    // the slot's button opens the merge sheet.
-    await waitFor(() => {
-      expect(screen.getByTestId("merge-from-catalog-search")).toBeInTheDocument();
-    });
   });
 
   it("opens the merge sheet when flamingo:merge fires for this cardgroup", async () => {

--- a/frontend/src/components/cardgroups/cardgroup-cards-section.test.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-cards-section.test.tsx
@@ -2,7 +2,7 @@
 
 import type { MockedResponse } from "@apollo/client/testing";
 import { MockedProvider } from "@apollo/client/testing/react";
-import { screen, waitFor } from "@testing-library/react";
+import { act, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -209,6 +209,16 @@ describe("<CardgroupCardsSection>", () => {
     await user.click(screen.getByTestId("page-header-merge"));
     // onMerge is () => setMergeOpen(true), owned by the section, so clicking
     // the slot's button opens the merge sheet.
+    await waitFor(() => {
+      expect(screen.getByTestId("merge-from-catalog-search")).toBeInTheDocument();
+    });
+  });
+
+  it("opens the merge sheet when flamingo:merge fires for this cardgroup", async () => {
+    renderSection("cg-1");
+    act(() => {
+      window.dispatchEvent(new CustomEvent("flamingo:merge", { detail: { ownerId: "cg-1" } }));
+    });
     await waitFor(() => {
       expect(screen.getByTestId("merge-from-catalog-search")).toBeInTheDocument();
     });

--- a/frontend/src/components/cardgroups/cardgroup-cards-section.test.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-cards-section.test.tsx
@@ -224,6 +224,14 @@ describe("<CardgroupCardsSection>", () => {
     });
   });
 
+  it("ignores flamingo:merge for a different ownerId", () => {
+    renderSection("cg-1");
+    act(() => {
+      window.dispatchEvent(new CustomEvent("flamingo:merge", { detail: { ownerId: "other" } }));
+    });
+    expect(screen.queryByTestId("merge-from-catalog-search")).not.toBeInTheDocument();
+  });
+
   it("desktop split-button 'Merge from catalog' item opens the merge sheet", async () => {
     const user = userEvent.setup();
     renderSection("cg-1");

--- a/frontend/src/components/cardgroups/cardgroup-cards-section.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-cards-section.tsx
@@ -24,17 +24,13 @@ type Props = {
   /**
    * Optional render prop that lets the parent render a page-level header with
    * the live totalCount sourced from the Apollo cache. When provided, the
-   * render prop receives `{ totalCount, onBatchImport, onMerge }` and is
-   * invoked above the toolbar row. `onBatchImport` and `onMerge` let the
-   * header's overflow menu host those actions on mobile (the standalone mobile
-   * toolbar buttons were removed). When omitted, no page-level header is
+   * render prop receives `{ totalCount }` and is invoked above the toolbar row.
+   * Batch import and Merge are no longer threaded through here — they are
+   * handled on mobile via the global "+" Add menu and on desktop via the
+   * split-button menu in this section. When omitted, no page-level header is
    * rendered.
    */
-  renderPageHeader?: (args: {
-    totalCount: number;
-    onBatchImport: () => void;
-    onMerge: () => void;
-  }) => ReactNode;
+  renderPageHeader?: (args: { totalCount: number }) => ReactNode;
 };
 
 export function CardgroupCardsSection({
@@ -73,12 +69,13 @@ export function CardgroupCardsSection({
     // cluster sits on its own row below it, right-aligned on desktop. On mobile
     // the two also stack — header on top, full-width Start learning hero below.
     <div>
-      {renderPageHeader?.({ totalCount, onBatchImport, onMerge })}
+      {renderPageHeader?.({ totalCount })}
       <div className="mb-3 flex flex-col gap-2 md:flex-row md:items-center md:justify-end md:gap-2">
         {/* Primary CTA: full-width brand hero on mobile (h-11 = 44px tap target),
-            compact on desktop. Add card on mobile is provided by the global "+"
-            header action, so no Add button is duplicated here on small screens.
-            Batch import on mobile lives in the page header's overflow menu. */}
+            compact on desktop. On mobile, Add card, Batch import, and Merge all
+            live in the global "+" header Add menu; the page-header overflow is
+            lifecycle-only (Rename + Delete). No duplicate add/import buttons
+            are rendered here on small screens. */}
         <Button asChild variant="brand" className="h-11 w-full px-8 md:h-9 md:w-auto md:px-4">
           <Link href={learnHref}>
             <Play aria-hidden="true" className="h-4 w-4" />

--- a/frontend/src/components/cardgroups/cardgroup-cards-section.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-cards-section.tsx
@@ -3,7 +3,7 @@
 import { Import, Layers, Play, Plus } from "lucide-react";
 import Link from "next/link";
 import { useTranslations } from "next-intl";
-import { type ReactNode, useState } from "react";
+import { type ReactNode, useEffect, useState } from "react";
 import { toast } from "sonner";
 import {
   type CardConnectionPageInfo,
@@ -13,6 +13,7 @@ import {
 import { MergeFromCatalogSheet } from "@/components/cardgroups/merge-from-catalog-sheet";
 import { Button } from "@/components/ui/button";
 import { SplitButtonMenu } from "@/components/ui/split-button-menu";
+import { FLAMINGO_EVENT, subscribeFlamingo } from "@/lib/events/flamingo-events";
 
 type Props = {
   cardgroupId: string;
@@ -48,6 +49,13 @@ export function CardgroupCardsSection({
   const t = useTranslations("Cardgroups");
   const [mergeOpen, setMergeOpen] = useState(false);
   const onMerge = () => setMergeOpen(true);
+
+  useEffect(() => {
+    return subscribeFlamingo(FLAMINGO_EVENT.merge, (detail) => {
+      if (detail?.ownerId !== cardgroupId) return;
+      setMergeOpen(true);
+    });
+  }, [cardgroupId]);
 
   // The render-prop form lets CardsClient pass its live totalCount (read from
   // Apollo cache, kept in sync with delete/bulk-delete/fetchMore) into the

--- a/frontend/src/components/cardgroups/cardgroup-header.test.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-header.test.tsx
@@ -11,8 +11,6 @@ import { CardgroupHeader } from "./cardgroup-header";
 
 const mockPush = vi.fn();
 const mockRefresh = vi.fn();
-const onBatchImport = vi.fn();
-const onMerge = vi.fn();
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: mockPush, refresh: mockRefresh }),
@@ -38,12 +36,7 @@ function makeUpdateMock(
 function renderHeader(mocks: MockedResponse[] = [], totalCount = 5) {
   renderWithIntl(
     <MockedProvider mocks={mocks}>
-      <CardgroupHeader
-        cardgroup={CARDGROUP}
-        totalCount={totalCount}
-        onBatchImport={onBatchImport}
-        onMerge={onMerge}
-      />
+      <CardgroupHeader cardgroup={CARDGROUP} totalCount={totalCount} />
     </MockedProvider>,
   );
 }
@@ -69,8 +62,6 @@ describe("<CardgroupHeader>", () => {
   beforeEach(() => {
     mockPush.mockClear();
     mockRefresh.mockClear();
-    onBatchImport.mockClear();
-    onMerge.mockClear();
   });
 
   it("renders the cardgroup name as h1", () => {
@@ -249,39 +240,13 @@ describe("<CardgroupHeader>", () => {
     expect(screen.queryByRole("status")).toBeNull();
   });
 
-  it("overflow menu holds rename, batch import, and delete", async () => {
+  it("overflow contains only Rename and Delete (no import/merge)", async () => {
     const user = userEvent.setup();
-    renderHeader([], 12);
+    renderHeader();
     await user.click(screen.getByRole("button", { name: /cardgroup options/i }));
-    expect(screen.getByRole("menuitem", { name: /^rename$/i })).toBeInTheDocument();
-    expect(screen.getByRole("menuitem", { name: /batch import/i })).toBeInTheDocument();
-    expect(screen.getByRole("menuitem", { name: /delete cardgroup/i })).toBeInTheDocument();
-  });
-
-  it("overflow menu 'Batch import' item calls onBatchImport", async () => {
-    const user = userEvent.setup();
-    renderHeader([], 12);
-    await user.click(screen.getByRole("button", { name: /cardgroup options/i }));
-    await user.click(screen.getByRole("menuitem", { name: /batch import/i }));
-    expect(onBatchImport).toHaveBeenCalledTimes(1);
-  });
-
-  it("overflow menu hosts a 'Merge from catalog' item that calls onMerge", async () => {
-    const user = userEvent.setup();
-    renderHeader([], 12);
-
-    await user.click(screen.getByRole("button", { name: /cardgroup options/i }));
-
-    const mergeItem = await screen.findByTestId("cardgroup-merge-menuitem-mobile");
-    expect(mergeItem).toBeInTheDocument();
-    expect(mergeItem).toHaveTextContent(/merge from catalog/i);
-
-    await user.click(mergeItem);
-
-    // The merge sheet is now owned by CardgroupCardsSection, not the header.
-    // The header's merge item only calls the onMerge callback.
-    expect(onMerge).toHaveBeenCalledOnce();
-    expect(screen.queryByTestId("merge-from-catalog-search")).not.toBeInTheDocument();
+    expect(screen.getByTestId("cardgroup-rename-menuitem")).toBeInTheDocument();
+    expect(screen.queryByTestId("cardgroup-import-menuitem")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("cardgroup-merge-menuitem-mobile")).not.toBeInTheDocument();
   });
 
   it("delete network rejection shows error banner and dialog stays open", async () => {

--- a/frontend/src/components/cardgroups/cardgroup-header.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-header.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Import, Layers, MoreHorizontal, Pencil, Trash2 } from "lucide-react";
+import { MoreHorizontal, Pencil, Trash2 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { useState } from "react";
@@ -32,23 +32,9 @@ import { getBackendErrorBanner } from "@/lib/apollo/errors";
 type Props = {
   cardgroup: { id: string; name: string };
   totalCount: number;
-  /**
-   * Opens the batch-import sheet (owned by `CardsClient`). Surfaced here so the
-   * overflow menu can host batch import on mobile, where the standalone toolbar
-   * button was removed. Required so the wire from `CardsClient` is enforced at
-   * compile time rather than silently defaulting to a no-op.
-   */
-  onBatchImport: () => void;
-  /**
-   * Opens the merge-from-catalog sheet (owned by `CardgroupCardsSection`).
-   * Surfaced here so the overflow menu can host merge on mobile (`md:hidden`),
-   * mirroring how batch import is threaded. On desktop, the split-button menu
-   * in the cards section hosts the merge item instead.
-   */
-  onMerge: () => void;
 };
 
-export function CardgroupHeader({ cardgroup, totalCount, onBatchImport, onMerge }: Props) {
+export function CardgroupHeader({ cardgroup, totalCount }: Props) {
   const router = useRouter();
   const [renameOpen, setRenameOpen] = useState(false);
   const [renaming, setRenaming] = useState(false);
@@ -88,31 +74,11 @@ export function CardgroupHeader({ cardgroup, totalCount, onBatchImport, onMerge 
           <Pencil className="h-4 w-4" />
           {t("rename")}
         </DropdownMenuItem>
-        {/* Mobile-only: batch import lives here after the standalone toolbar
-            button was removed. Hidden on desktop, where the cards toolbar's
-            split-button menu still hosts batch import. */}
-        <DropdownMenuItem
-          onSelect={onBatchImport}
-          className="gap-2 md:hidden"
-          data-testid="cardgroup-import-menuitem"
-        >
-          <Import className="h-4 w-4" />
-          {t("batchImport")}
-        </DropdownMenuItem>
-        {/* Mobile-only: merge from catalog lives here after the sheet and
-            open-state were moved to CardgroupCardsSection. Hidden on desktop,
-            where the cards toolbar's split-button menu hosts the merge item. */}
-        <DropdownMenuItem
-          onSelect={onMerge}
-          className="gap-2 md:hidden"
-          data-testid="cardgroup-merge-menuitem-mobile"
-        >
-          <Layers className="h-4 w-4" />
-          {t("mergeFromCatalog")}
-        </DropdownMenuItem>
-        {/* Separator divides the constructive actions from Delete. On desktop
-            only Rename is visible above it; the import and merge items are
-            md:hidden (mobile-only add surfaces). */}
+        {/* Separator divides the constructive Rename action from the
+            destructive Delete action. Both Batch import and Merge are now
+            hosted in the global "+" Add menu on mobile and in the desktop
+            split-button menu in the cards section, so the overflow is
+            lifecycle-only: Rename + Delete. */}
         <DropdownMenuSeparator />
         <DropdownMenuItem
           onSelect={() => setDeleteDialogOpen(true)}

--- a/frontend/src/components/nav/header-create-action.test.ts
+++ b/frontend/src/components/nav/header-create-action.test.ts
@@ -14,47 +14,6 @@ describe("resolveHeaderCreateAction", () => {
   });
 
   describe("/cardgroups/:id/edit route", () => {
-    it.each([
-      [
-        "/cardgroups/abc/edit",
-        {
-          kind: "card-with-group",
-          label: "Add new card",
-          cardgroupId: "abc",
-          href: "/cards/new?cardgroup=abc",
-        },
-      ],
-      [
-        "/cardgroups/abc/edit/",
-        {
-          kind: "card-with-group",
-          label: "Add new card",
-          cardgroupId: "abc",
-          href: "/cards/new?cardgroup=abc",
-        },
-      ],
-      [
-        "/cardgroups/0190f9f4-3ad8-7d52-b1d0-6f6b5f5a9c2c/edit",
-        {
-          kind: "card-with-group",
-          label: "Add new card",
-          cardgroupId: "0190f9f4-3ad8-7d52-b1d0-6f6b5f5a9c2c",
-          href: "/cards/new?cardgroup=0190f9f4-3ad8-7d52-b1d0-6f6b5f5a9c2c",
-        },
-      ],
-    ])("returns card-with-group for %s", (pathname, expected) => {
-      expect(resolveHeaderCreateAction(pathname)).toEqual(expected);
-    });
-
-    it("decodes percent-encoded segment: a%2Fb -> cardgroupId a/b, href re-encodes", () => {
-      expect(resolveHeaderCreateAction("/cardgroups/a%2Fb/edit")).toEqual({
-        kind: "card-with-group",
-        label: "Add new card",
-        cardgroupId: "a/b",
-        href: "/cards/new?cardgroup=a%2Fb",
-      });
-    });
-
     it("returns null for malformed percent-escape in /cardgroups/:id/edit", () => {
       expect(resolveHeaderCreateAction("/cardgroups/%ZZ/edit")).toBeNull();
     });
@@ -124,35 +83,45 @@ describe("resolveHeaderCreateAction", () => {
   });
 
   describe("/admin/masters/:id/edit route", () => {
-    it.each([
-      ["/admin/masters/m-1/edit", "m-1"],
-      ["/admin/masters/m-1/edit/", "m-1"],
-      [
-        "/admin/masters/0190f9f4-3ad8-7d52-b1d0-6f6b5f5a9c2c/edit",
-        "0190f9f4-3ad8-7d52-b1d0-6f6b5f5a9c2c",
-      ],
-    ])("returns master-card for %s", (pathname, masterId) => {
-      expect(resolveHeaderCreateAction(pathname)).toEqual({
-        kind: "master-card",
-        label: "Add new card",
-        masterId,
-      });
-    });
-
-    it("decodes percent-encoded segment: a%2Fb -> masterId a/b", () => {
-      expect(resolveHeaderCreateAction("/admin/masters/a%2Fb/edit")).toEqual({
-        kind: "master-card",
-        label: "Add new card",
-        masterId: "a/b",
-      });
-    });
-
     it("returns null for malformed percent-escape in /admin/masters/:id/edit", () => {
       expect(resolveHeaderCreateAction("/admin/masters/%ZZ/edit")).toBeNull();
     });
 
     it("returns null for /admin/masters/m-1 (no /edit)", () => {
       expect(resolveHeaderCreateAction("/admin/masters/m-1")).toBeNull();
+    });
+  });
+
+  describe("/admin/masters/:id/edit -> deck-add-menu (master)", () => {
+    it("returns a master deck-add-menu", () => {
+      expect(resolveHeaderCreateAction("/admin/masters/m-1/edit")).toEqual({
+        kind: "deck-add-menu",
+        deck: { kind: "master", masterId: "m-1" },
+      });
+    });
+    it("decodes a%2Fb -> masterId a/b", () => {
+      expect(resolveHeaderCreateAction("/admin/masters/a%2Fb/edit")).toEqual({
+        kind: "deck-add-menu",
+        deck: { kind: "master", masterId: "a/b" },
+      });
+    });
+    it("returns null for malformed escape", () => {
+      expect(resolveHeaderCreateAction("/admin/masters/%ZZ/edit")).toBeNull();
+    });
+  });
+
+  describe("/cardgroups/:id/edit -> deck-add-menu (cardgroup)", () => {
+    it("returns a cardgroup deck-add-menu with encoded addCardHref", () => {
+      expect(resolveHeaderCreateAction("/cardgroups/abc/edit")).toEqual({
+        kind: "deck-add-menu",
+        deck: { kind: "cardgroup", cardgroupId: "abc", addCardHref: "/cards/new?cardgroup=abc" },
+      });
+    });
+    it("decodes a%2Fb and re-encodes in addCardHref", () => {
+      expect(resolveHeaderCreateAction("/cardgroups/a%2Fb/edit")).toEqual({
+        kind: "deck-add-menu",
+        deck: { kind: "cardgroup", cardgroupId: "a/b", addCardHref: "/cards/new?cardgroup=a%2Fb" },
+      });
     });
   });
 

--- a/frontend/src/components/nav/header-create-action.test.ts
+++ b/frontend/src/components/nav/header-create-action.test.ts
@@ -108,6 +108,12 @@ describe("resolveHeaderCreateAction", () => {
     it("returns null for malformed escape", () => {
       expect(resolveHeaderCreateAction("/admin/masters/%ZZ/edit")).toBeNull();
     });
+    it("matches trailing slash /admin/masters/m-1/edit/", () => {
+      expect(resolveHeaderCreateAction("/admin/masters/m-1/edit/")).toEqual({
+        kind: "deck-add-menu",
+        deck: { kind: "master", masterId: "m-1" },
+      });
+    });
   });
 
   describe("/cardgroups/:id/edit -> deck-add-menu (cardgroup)", () => {
@@ -121,6 +127,12 @@ describe("resolveHeaderCreateAction", () => {
       expect(resolveHeaderCreateAction("/cardgroups/a%2Fb/edit")).toEqual({
         kind: "deck-add-menu",
         deck: { kind: "cardgroup", cardgroupId: "a/b", addCardHref: "/cards/new?cardgroup=a%2Fb" },
+      });
+    });
+    it("matches trailing slash /cardgroups/abc/edit/", () => {
+      expect(resolveHeaderCreateAction("/cardgroups/abc/edit/")).toEqual({
+        kind: "deck-add-menu",
+        deck: { kind: "cardgroup", cardgroupId: "abc", addCardHref: "/cards/new?cardgroup=abc" },
       });
     });
   });

--- a/frontend/src/components/nav/header-create-action.ts
+++ b/frontend/src/components/nav/header-create-action.ts
@@ -24,26 +24,18 @@ export type HeaderCreateAction =
   // No href: master creation opens the create sheet the same way as role —
   // ?new=true on the current path (via useSheetSearchParam).
   | { kind: "master"; label: "Add new master" }
-  // No href: adding a card to a master deck has no separate-page target (unlike
-  // a user cardgroup, which can fall back to /cards/new). The '+' dispatches a
-  // cancelable flamingo:add-master-card event that the in-page MasterCardsClient
-  // claims; there is no navigation fallback.
-  | { kind: "master-card"; label: "Add new card"; masterId: string };
+  // Deck-detail edit screens turn the "+" into an Add menu (Add card / Batch
+  // import / Merge). `addCardHref` is the pre-encoded /cards/new fallback for the
+  // cardgroup add-card item (master has no separate-page fallback).
+  | {
+      kind: "deck-add-menu";
+      deck:
+        | { kind: "master"; masterId: string }
+        | { kind: "cardgroup"; cardgroupId: string; addCardHref: string };
+    };
 
-/**
- * Build a `card-with-group` action for the /cardgroups/:id/edit route.
- * `href` is URL-encoded, `cardgroupId` stays raw — see the JSDoc on the union
- * variant for the contract callers must observe.
- */
-function cardWithGroup(rawId: string): Extract<HeaderCreateAction, { kind: "card-with-group" }> {
-  const encodedId = encodeURIComponent(rawId);
-  return {
-    kind: "card-with-group",
-    href: `/cards/new?cardgroup=${encodedId}`,
-    label: "Add new card",
-    cardgroupId: rawId,
-  };
-}
+/** Narrowed type for the `deck-add-menu` union member. */
+export type DeckAddMenu = Extract<HeaderCreateAction, { kind: "deck-add-menu" }>;
 
 /**
  * Build a `card-with-group` action for the /learn/:id route.
@@ -71,11 +63,11 @@ function cardWithGroupFromLearn(
  *
  * Routing rules (evaluated in order):
  * - `/cardgroups`          -> create new cardgroup
- * - `/cardgroups/:id/edit` -> create card pre-filled with the cardgroup
+ * - `/cardgroups/:id/edit` -> deck-add-menu (cardgroup variant)
  * - `/learn/:id`           -> create card pre-filled with the cardgroup + return param
  * - `/admin/roles`            -> create new role
  * - `/admin/masters`          -> create new master
- * - `/admin/masters/:id/edit` -> add card to the master deck
+ * - `/admin/masters/:id/edit` -> deck-add-menu (master variant)
  * - anything else             -> `null`
  */
 export function resolveHeaderCreateAction(pathname: string): HeaderCreateAction | null {
@@ -89,7 +81,14 @@ export function resolveHeaderCreateAction(pathname: string): HeaderCreateAction 
   if (editMatch) {
     const rawId = safeDecodePathSegment(editMatch[1] as string);
     if (rawId === null) return null;
-    return cardWithGroup(rawId);
+    return {
+      kind: "deck-add-menu",
+      deck: {
+        kind: "cardgroup",
+        cardgroupId: rawId,
+        addCardHref: `/cards/new?cardgroup=${encodeURIComponent(rawId)}`,
+      },
+    };
   }
 
   const learnMatch = LEARN_RE.exec(pathname);
@@ -111,7 +110,7 @@ export function resolveHeaderCreateAction(pathname: string): HeaderCreateAction 
   if (masterEditMatch) {
     const rawId = safeDecodePathSegment(masterEditMatch[1] as string);
     if (rawId === null) return null;
-    return { kind: "master-card", label: "Add new card", masterId: rawId };
+    return { kind: "deck-add-menu", deck: { kind: "master", masterId: rawId } };
   }
 
   return null;

--- a/frontend/src/components/nav/logo-drawer.test.tsx
+++ b/frontend/src/components/nav/logo-drawer.test.tsx
@@ -215,59 +215,6 @@ describe("<LogoDrawer>", () => {
     window.removeEventListener("flamingo:add-cardgroup", listener);
   });
 
-  it("S-E1: on /cardgroups/:id/edit the '+' (Add new card) dispatches add-card with the decoded id and falls back to an encoded /cards/new href", async () => {
-    const user = userEvent.setup();
-    mockUsePathname.mockReturnValue("/cardgroups/abc-123/edit");
-    const listener = vi.fn();
-    window.addEventListener("flamingo:add-card", listener);
-    renderWithIntl(<LogoDrawer user={SIGNED_IN_USER} isAdmin={false} />);
-
-    await user.click(screen.getByRole("button", { name: /add new card/i }));
-
-    expect(listener).toHaveBeenCalledTimes(1);
-    const event = listener.mock.calls[0]?.[0] as CustomEvent<{ cardgroupId: string }>;
-    expect(event.cancelable).toBe(true);
-    expect(event.detail).toEqual({ cardgroupId: "abc-123" });
-    expect(mockPush).toHaveBeenCalledWith("/cards/new?cardgroup=abc-123");
-
-    window.removeEventListener("flamingo:add-card", listener);
-  });
-
-  it("S-E1b: on /cardgroups/:id/edit the '+' does not navigate when the add-card event is handled", async () => {
-    const user = userEvent.setup();
-    mockUsePathname.mockReturnValue("/cardgroups/abc-123/edit");
-    const listener = vi.fn((event: Event) => event.preventDefault());
-    window.addEventListener("flamingo:add-card", listener);
-    renderWithIntl(<LogoDrawer user={SIGNED_IN_USER} isAdmin={false} />);
-
-    await user.click(screen.getByRole("button", { name: /add new card/i }));
-
-    expect(listener).toHaveBeenCalledTimes(1);
-    expect(mockPush).not.toHaveBeenCalled();
-
-    window.removeEventListener("flamingo:add-card", listener);
-  });
-
-  it("edit-route special-char encoding: percent-encoded id is decoded for the event and re-encoded in the fallback href", async () => {
-    const user = userEvent.setup();
-    // %26 decodes to & — the raw cardgroupId must be "abc&evil" and href must re-encode it.
-    mockUsePathname.mockReturnValue("/cardgroups/abc%26evil/edit");
-    const listener = vi.fn();
-    window.addEventListener("flamingo:add-card", listener);
-    renderWithIntl(<LogoDrawer user={SIGNED_IN_USER} isAdmin={false} />);
-
-    await user.click(screen.getByRole("button", { name: /add new card/i }));
-
-    expect(listener).toHaveBeenCalledTimes(1);
-    const event = listener.mock.calls[0]?.[0] as CustomEvent<{ cardgroupId: string }>;
-    // cardgroupId carries the raw (decoded) value.
-    expect(event.detail).toEqual({ cardgroupId: "abc&evil" });
-    // Fallback href must re-encode the id so the URL is safe.
-    expect(mockPush).toHaveBeenCalledWith("/cards/new?cardgroup=abc%26evil");
-
-    window.removeEventListener("flamingo:add-card", listener);
-  });
-
   it("malformed edit path: '+' button is not rendered when the segment is a malformed percent-escape", () => {
     // safeDecodePathSegment returns null for %ZZ -> resolver returns null -> no '+' rendered.
     mockUsePathname.mockReturnValue("/cardgroups/abc%ZZ/edit");
@@ -330,42 +277,6 @@ describe("<LogoDrawer>", () => {
     expect(mockPush).toHaveBeenCalledTimes(1);
     const target = mockPush.mock.calls[0]?.[0] as string;
     expect(target).toContain("new=true");
-  });
-
-  it("S-ME1: on /admin/masters/:id/edit the '+' (Add new card) dispatches add-master-card with the decoded masterId and does not navigate", async () => {
-    const user = userEvent.setup();
-    mockUsePathname.mockReturnValue("/admin/masters/m-1/edit");
-    const listener = vi.fn();
-    window.addEventListener("flamingo:add-master-card", listener);
-    renderWithIntl(<LogoDrawer user={SIGNED_IN_USER} isAdmin={true} />);
-
-    await user.click(screen.getByRole("button", { name: /add new card/i }));
-
-    expect(listener).toHaveBeenCalledTimes(1);
-    const event = listener.mock.calls[0]?.[0] as CustomEvent<{ masterId: string }>;
-    expect(event.cancelable).toBe(true);
-    expect(event.detail).toEqual({ masterId: "m-1" });
-    // Master cards have no separate-page create target, so the '+' never falls
-    // back to a route push the way the cardgroup add-card '+' does.
-    expect(mockPush).not.toHaveBeenCalled();
-
-    window.removeEventListener("flamingo:add-master-card", listener);
-  });
-
-  it("S-ME2: master-edit '+' decodes a percent-encoded masterId for the event detail", async () => {
-    const user = userEvent.setup();
-    mockUsePathname.mockReturnValue("/admin/masters/a%26b/edit");
-    const listener = vi.fn();
-    window.addEventListener("flamingo:add-master-card", listener);
-    renderWithIntl(<LogoDrawer user={SIGNED_IN_USER} isAdmin={true} />);
-
-    await user.click(screen.getByRole("button", { name: /add new card/i }));
-
-    expect(listener).toHaveBeenCalledTimes(1);
-    const event = listener.mock.calls[0]?.[0] as CustomEvent<{ masterId: string }>;
-    expect(event.detail).toEqual({ masterId: "a&b" });
-
-    window.removeEventListener("flamingo:add-master-card", listener);
   });
 
   it("S-G1: on an unknown route (/profile) the '+' button is not rendered", () => {
@@ -461,5 +372,46 @@ describe("<LogoDrawer>", () => {
     expect(trigger).toHaveAttribute("aria-expanded", "false");
 
     expect(trigger).toHaveFocus();
+  });
+
+  describe("deck-add-menu '+' on deck-detail routes", () => {
+    it("master edit: '+' opens a menu with Add card + Batch import (no Merge)", async () => {
+      const user = userEvent.setup();
+      mockUsePathname.mockReturnValue("/admin/masters/m-1/edit");
+      renderWithIntl(<LogoDrawer user={SIGNED_IN_USER} isAdmin />);
+
+      await user.click(screen.getByRole("button", { name: "Add" }));
+      expect(screen.getByRole("menuitem", { name: /add card/i })).toBeInTheDocument();
+      expect(screen.getByRole("menuitem", { name: /batch import/i })).toBeInTheDocument();
+      expect(screen.queryByRole("menuitem", { name: /merge/i })).not.toBeInTheDocument();
+    });
+
+    it("master edit: Batch import item dispatches flamingo:batch-import with ownerId", async () => {
+      const user = userEvent.setup();
+      mockUsePathname.mockReturnValue("/admin/masters/m-1/edit");
+      const onEvent = vi.fn();
+      window.addEventListener("flamingo:batch-import", onEvent as EventListener);
+      renderWithIntl(<LogoDrawer user={SIGNED_IN_USER} isAdmin />);
+
+      await user.click(screen.getByRole("button", { name: "Add" }));
+      await user.click(screen.getByRole("menuitem", { name: /batch import/i }));
+      window.removeEventListener("flamingo:batch-import", onEvent as EventListener);
+
+      expect(onEvent).toHaveBeenCalledTimes(1);
+      expect((onEvent.mock.calls[0]?.[0] as CustomEvent).detail).toEqual({ ownerId: "m-1" });
+    });
+
+    it("cardgroup edit: menu has Merge, and Add card falls back to /cards/new when uncancelled", async () => {
+      const user = userEvent.setup();
+      mockUsePathname.mockReturnValue("/cardgroups/abc/edit");
+      renderWithIntl(<LogoDrawer user={SIGNED_IN_USER} isAdmin={false} />);
+
+      await user.click(screen.getByRole("button", { name: "Add" }));
+      expect(screen.getByRole("menuitem", { name: /merge from catalog/i })).toBeInTheDocument();
+      await user.click(screen.getByRole("menuitem", { name: /add card/i }));
+      // No in-page listener is mounted in this unit, so the cancelable add-card
+      // event is uncancelled and the fallback navigation fires.
+      expect(mockPush).toHaveBeenCalledWith("/cards/new?cardgroup=abc");
+    });
   });
 });

--- a/frontend/src/components/nav/logo-drawer.test.tsx
+++ b/frontend/src/components/nav/logo-drawer.test.tsx
@@ -413,5 +413,50 @@ describe("<LogoDrawer>", () => {
       // event is uncancelled and the fallback navigation fires.
       expect(mockPush).toHaveBeenCalledWith("/cards/new?cardgroup=abc");
     });
+
+    it("cardgroup edit: Add card does not navigate when the event is cancelled", async () => {
+      const user = userEvent.setup();
+      mockUsePathname.mockReturnValue("/cardgroups/abc/edit");
+      const listener = vi.fn((event: Event) => event.preventDefault());
+      window.addEventListener("flamingo:add-card", listener);
+      renderWithIntl(<LogoDrawer user={SIGNED_IN_USER} isAdmin={false} />);
+
+      await user.click(screen.getByRole("button", { name: "Add" }));
+      await user.click(screen.getByRole("menuitem", { name: /add card/i }));
+
+      expect(listener).toHaveBeenCalledTimes(1);
+      expect(mockPush).not.toHaveBeenCalled();
+      window.removeEventListener("flamingo:add-card", listener);
+    });
+
+    it("master edit: Add card dispatches flamingo:add-master-card with masterId", async () => {
+      const user = userEvent.setup();
+      mockUsePathname.mockReturnValue("/admin/masters/m-1/edit");
+      const onEvent = vi.fn();
+      window.addEventListener("flamingo:add-master-card", onEvent as EventListener);
+      renderWithIntl(<LogoDrawer user={SIGNED_IN_USER} isAdmin />);
+
+      await user.click(screen.getByRole("button", { name: "Add" }));
+      await user.click(screen.getByRole("menuitem", { name: /add card/i }));
+      window.removeEventListener("flamingo:add-master-card", onEvent as EventListener);
+
+      expect(onEvent).toHaveBeenCalledTimes(1);
+      expect((onEvent.mock.calls[0]?.[0] as CustomEvent).detail).toEqual({ masterId: "m-1" });
+    });
+
+    it("cardgroup edit: Merge item dispatches flamingo:merge with ownerId", async () => {
+      const user = userEvent.setup();
+      mockUsePathname.mockReturnValue("/cardgroups/abc/edit");
+      const onEvent = vi.fn();
+      window.addEventListener("flamingo:merge", onEvent as EventListener);
+      renderWithIntl(<LogoDrawer user={SIGNED_IN_USER} isAdmin={false} />);
+
+      await user.click(screen.getByRole("button", { name: "Add" }));
+      await user.click(screen.getByRole("menuitem", { name: /merge from catalog/i }));
+      window.removeEventListener("flamingo:merge", onEvent as EventListener);
+
+      expect(onEvent).toHaveBeenCalledTimes(1);
+      expect((onEvent.mock.calls[0]?.[0] as CustomEvent).detail).toEqual({ ownerId: "abc" });
+    });
   });
 });

--- a/frontend/src/components/nav/logo-drawer.tsx
+++ b/frontend/src/components/nav/logo-drawer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Plus, Search } from "lucide-react";
+import { Import, Layers, Plus, Search } from "lucide-react";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
@@ -8,10 +8,16 @@ import { useEffect, useRef, useState } from "react";
 import { LogoutButton } from "@/app/_components/logout-button";
 import { FlamingoMark } from "@/components/brand/flamingo-mark";
 import { MobileMenuTrigger } from "@/components/nav/mobile-menu-trigger";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { Sheet, SheetClose, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
 import { dispatchFlamingo, FLAMINGO_EVENT, subscribeFlamingo } from "@/lib/events/flamingo-events";
 import { useSheetSearchParam } from "@/lib/url/use-sheet-search-param";
-import { resolveHeaderCreateAction } from "./header-create-action";
+import { type DeckAddMenu, resolveHeaderCreateAction } from "./header-create-action";
 import { resolveHeaderSearchAction } from "./header-search-action";
 import { HeaderSignInLink } from "./header-sign-in-link";
 import { ADMIN_NAV_ITEMS, CORE_NAV_ITEMS, FOOTER_NAV_ITEMS } from "./nav-items";
@@ -28,6 +34,8 @@ const NAV_LINK_CLASS =
 
 export function LogoDrawer({ user, isAdmin }: LogoDrawerProps) {
   const t = useTranslations("Nav");
+  const tCards = useTranslations("Cards");
+  const tCardgroups = useTranslations("Cardgroups");
   const pathname = usePathname();
   const router = useRouter();
   // Hooks must run unconditionally (Rules of Hooks); only `open(...)` is called
@@ -65,6 +73,8 @@ export function LogoDrawer({ user, isAdmin }: LogoDrawerProps) {
   // state directly.
   function handleCreate() {
     if (!createAction) return;
+    // The menu kind is rendered as a dropdown, not a click-to-dispatch button.
+    if (createAction.kind === "deck-add-menu") return;
     switch (createAction.kind) {
       case "cardgroup": {
         if (dispatchFlamingo(FLAMINGO_EVENT.addCardgroup, { cancelable: true })) {
@@ -93,22 +103,34 @@ export function LogoDrawer({ user, isAdmin }: LogoDrawerProps) {
         open({ mode: "new" });
         return;
       }
-      // Adding a card to a master deck has no separate-page fallback: the
-      // in-page MasterCardsClient is always mounted on the edit screen and
-      // claims this event to open its add-card sheet. No router.push fallback.
-      case "master-card": {
-        dispatchFlamingo(FLAMINGO_EVENT.addMasterCard, {
-          cancelable: true,
-          detail: { masterId: createAction.masterId },
-        });
-        return;
-      }
       default: {
         const _exhaustive: never = createAction;
         console.error("[LogoDrawer] unhandled createAction kind", createAction);
         return;
       }
     }
+  }
+
+  function dispatchDeckAddCard(deck: DeckAddMenu["deck"]) {
+    if (deck.kind === "master") {
+      dispatchFlamingo(FLAMINGO_EVENT.addMasterCard, {
+        cancelable: true,
+        detail: { masterId: deck.masterId },
+      });
+      return;
+    }
+    if (
+      dispatchFlamingo(FLAMINGO_EVENT.addCard, {
+        cancelable: true,
+        detail: { cardgroupId: deck.cardgroupId },
+      })
+    ) {
+      router.push(deck.addCardHref);
+    }
+  }
+
+  function deckOwnerId(deck: DeckAddMenu["deck"]) {
+    return deck.kind === "master" ? deck.masterId : deck.cardgroupId;
   }
 
   return (
@@ -141,16 +163,71 @@ export function LogoDrawer({ user, isAdmin }: LogoDrawerProps) {
             )}
           </button>
         )}
-        {createAction && (
-          <button
-            type="button"
-            onClick={handleCreate}
-            aria-label={createAction.label}
-            className="rounded-md p-2 hover:bg-accent focus:outline-none focus:ring-2 focus:ring-ring"
-          >
-            <Plus className="h-5 w-5" aria-hidden="true" />
-          </button>
-        )}
+        {createAction &&
+          (createAction.kind === "deck-add-menu" ? (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <button
+                  type="button"
+                  aria-label={tCards("add")}
+                  data-testid="header-add-menu-trigger"
+                  className="rounded-md p-2 hover:bg-accent focus:outline-none focus:ring-2 focus:ring-ring"
+                >
+                  <Plus className="h-5 w-5" aria-hidden="true" />
+                </button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem
+                  className="gap-2"
+                  data-testid="header-add-card"
+                  onSelect={() => {
+                    if (createAction.kind === "deck-add-menu")
+                      dispatchDeckAddCard(createAction.deck);
+                  }}
+                >
+                  <Plus className="h-4 w-4" aria-hidden="true" />
+                  {tCards("addCard")}
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  className="gap-2"
+                  data-testid="header-batch-import"
+                  onSelect={() => {
+                    if (createAction.kind === "deck-add-menu")
+                      dispatchFlamingo(FLAMINGO_EVENT.batchImport, {
+                        detail: { ownerId: deckOwnerId(createAction.deck) },
+                      });
+                  }}
+                >
+                  <Import className="h-4 w-4" aria-hidden="true" />
+                  {tCardgroups("batchImport")}
+                </DropdownMenuItem>
+                {createAction.deck.kind === "cardgroup" && (
+                  <DropdownMenuItem
+                    className="gap-2"
+                    data-testid="header-merge"
+                    onSelect={() => {
+                      if (createAction.kind === "deck-add-menu")
+                        dispatchFlamingo(FLAMINGO_EVENT.merge, {
+                          detail: { ownerId: deckOwnerId(createAction.deck) },
+                        });
+                    }}
+                  >
+                    <Layers className="h-4 w-4" aria-hidden="true" />
+                    {tCardgroups("mergeFromCatalog")}
+                  </DropdownMenuItem>
+                )}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          ) : (
+            <button
+              type="button"
+              onClick={handleCreate}
+              aria-label={createAction.label}
+              className="rounded-md p-2 hover:bg-accent focus:outline-none focus:ring-2 focus:ring-ring"
+            >
+              <Plus className="h-5 w-5" aria-hidden="true" />
+            </button>
+          ))}
         <MobileMenuTrigger />
       </div>
 

--- a/frontend/src/lib/events/flamingo-events.test.ts
+++ b/frontend/src/lib/events/flamingo-events.test.ts
@@ -1,11 +1,13 @@
 // @vitest-environment happy-dom
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   type AddCardDetail,
   type AddMasterCardDetail,
+  type DeckOwnerDetail,
   dispatchFlamingo,
   FLAMINGO_EVENT,
   type SearchStateDetail,
+  subscribeFlamingo,
 } from "./flamingo-events";
 
 // Listeners registered per-test, torn down in afterEach so a failing assertion
@@ -31,6 +33,8 @@ describe("FLAMINGO_EVENT", () => {
       addCardgroup: "flamingo:add-cardgroup",
       addCard: "flamingo:add-card",
       addMasterCard: "flamingo:add-master-card",
+      batchImport: "flamingo:batch-import",
+      merge: "flamingo:merge",
     });
   });
 });
@@ -92,5 +96,24 @@ describe("dispatchFlamingo", () => {
         cancelable: true,
       }),
     ).toBe(false);
+  });
+});
+
+describe("batch-import + merge events", () => {
+  it("round-trips a DeckOwnerDetail payload for batch-import", () => {
+    const handler = vi.fn();
+    const off = subscribeFlamingo(FLAMINGO_EVENT.batchImport, handler);
+    dispatchFlamingo(FLAMINGO_EVENT.batchImport, { detail: { ownerId: "deck-1" } });
+    off();
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler.mock.calls[0][0]).toEqual({ ownerId: "deck-1" });
+  });
+
+  it("round-trips a DeckOwnerDetail payload for merge", () => {
+    const handler = vi.fn();
+    const off = subscribeFlamingo(FLAMINGO_EVENT.merge, handler);
+    dispatchFlamingo(FLAMINGO_EVENT.merge, { detail: { ownerId: "deck-2" } });
+    off();
+    expect(handler).toHaveBeenCalledWith({ ownerId: "deck-2" }, expect.any(CustomEvent));
   });
 });

--- a/frontend/src/lib/events/flamingo-events.test.ts
+++ b/frontend/src/lib/events/flamingo-events.test.ts
@@ -3,7 +3,6 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   type AddCardDetail,
   type AddMasterCardDetail,
-  type DeckOwnerDetail,
   dispatchFlamingo,
   FLAMINGO_EVENT,
   type SearchStateDetail,
@@ -106,7 +105,7 @@ describe("batch-import + merge events", () => {
     dispatchFlamingo(FLAMINGO_EVENT.batchImport, { detail: { ownerId: "deck-1" } });
     off();
     expect(handler).toHaveBeenCalledTimes(1);
-    expect(handler.mock.calls[0][0]).toEqual({ ownerId: "deck-1" });
+    expect(handler).toHaveBeenCalledWith({ ownerId: "deck-1" }, expect.any(CustomEvent));
   });
 
   it("round-trips a DeckOwnerDetail payload for merge", () => {

--- a/frontend/src/lib/events/flamingo-events.ts
+++ b/frontend/src/lib/events/flamingo-events.ts
@@ -25,6 +25,11 @@ export interface AddMasterCardDetail {
   masterId: string;
 }
 
+/** `flamingo:batch-import` / `flamingo:merge` payload: header "+" menu -> the in-page sheet. */
+export interface DeckOwnerDetail {
+  ownerId: string;
+}
+
 // Augment WindowEventMap so add/removeEventListener infer the CustomEvent detail
 // type at every call site with zero per-site annotation. Keys must be string
 // literals, so they are spelled out here and mirrored by FLAMINGO_EVENT below.
@@ -35,6 +40,8 @@ declare global {
     "flamingo:add-cardgroup": CustomEvent<undefined>;
     "flamingo:add-card": CustomEvent<AddCardDetail>;
     "flamingo:add-master-card": CustomEvent<AddMasterCardDetail>;
+    "flamingo:batch-import": CustomEvent<DeckOwnerDetail>;
+    "flamingo:merge": CustomEvent<DeckOwnerDetail>;
   }
 }
 
@@ -45,6 +52,8 @@ export const FLAMINGO_EVENT = {
   addCardgroup: "flamingo:add-cardgroup",
   addCard: "flamingo:add-card",
   addMasterCard: "flamingo:add-master-card",
+  batchImport: "flamingo:batch-import",
+  merge: "flamingo:merge",
 } as const;
 
 export type FlamingoEventName = (typeof FLAMINGO_EVENT)[keyof typeof FLAMINGO_EVENT];

--- a/frontend/src/lib/events/flamingo-events.ts
+++ b/frontend/src/lib/events/flamingo-events.ts
@@ -25,8 +25,11 @@ export interface AddMasterCardDetail {
   masterId: string;
 }
 
-/** `flamingo:batch-import` / `flamingo:merge` payload: header "+" menu -> the in-page sheet. */
-export interface DeckOwnerDetail {
+// `flamingo:batch-import` / `flamingo:merge` payload: header "+" menu -> the in-page
+// sheet. Not exported — consumers read `detail.ownerId` via the WindowEventMap-inferred
+// type (subscribeFlamingo's generic), never by importing this name, so exporting it would
+// trip knip's unused-export check. Referenced only by the augmentation below.
+interface DeckOwnerDetail {
   ownerId: string;
 }
 

--- a/frontend/src/lib/forms/form-field.tsx
+++ b/frontend/src/lib/forms/form-field.tsx
@@ -36,6 +36,8 @@ type CommonProps = {
   placeholder?: string;
   /** Extra classes for the field wrapper. Default spacing is `space-y-2`. */
   className?: string;
+  /** Autofocus this control on mount (e.g. the create-form's first field). */
+  autoFocus?: boolean;
 };
 
 type FormFieldProps =
@@ -54,7 +56,7 @@ type FormFieldProps =
  * renders an inline checkbox + label with no `FieldError` row.
  */
 export function FormField(props: FormFieldProps) {
-  const { label, backendError, idOverride, disabled, placeholder, className } = props;
+  const { label, backendError, idOverride, disabled, placeholder, className, autoFocus } = props;
   const id = idOverride ?? props.field.name;
 
   if (props.kind === "checkbox") {
@@ -87,6 +89,7 @@ export function FormField(props: FormFieldProps) {
         onChange={(e) => field.handleChange(e.target.value)}
         disabled={disabled}
         placeholder={placeholder}
+        autoFocus={autoFocus}
       />
     ) : (
       <Input
@@ -98,6 +101,7 @@ export function FormField(props: FormFieldProps) {
         onChange={(e) => field.handleChange(e.target.value)}
         disabled={disabled}
         placeholder={placeholder}
+        autoFocus={autoFocus}
       />
     );
 

--- a/frontend/src/lib/forms/use-sheet-form.test.ts
+++ b/frontend/src/lib/forms/use-sheet-form.test.ts
@@ -98,13 +98,13 @@ describe("useCardSheetForm", () => {
     expect(result.current.addDirty).toBe(true);
   });
 
-  it("handleCreate success closes the sheet and clears dirty", async () => {
+  it("handleCreate success keeps the sheet open and clears dirty", async () => {
     const { result } = setup({ createOutcome: { status: "success" } });
     act(() => result.current.openAddSheet());
     await act(async () => {
       await result.current.handleCreate({ front: "f", back: "b" });
     });
-    expect(result.current.addOpen).toBe(false);
+    expect(result.current.addOpen).toBe(true);
     expect(result.current.addDirty).toBe(false);
     expect(result.current.createValidationError).toBeNull();
   });
@@ -206,5 +206,51 @@ describe("useCardSheetForm", () => {
     act(() => result.current.onEditOpenChange(false));
     expect(result.current.editingId).toBeNull();
     expect(result.current.rowValidationError).toBeNull();
+  });
+});
+
+function setupContinuous(createResult: { status: string } = { status: "success" }) {
+  return renderHook(() =>
+    useCardSheetForm({
+      createCard: vi.fn().mockResolvedValue(createResult),
+      updateCard: vi.fn().mockResolvedValue({ status: "success" }),
+      resetCreateCard: vi.fn(),
+      addFailedMessage: "add failed",
+      saveFailedMessage: "save failed",
+    }),
+  );
+}
+
+describe("useCardSheetForm continuous add", () => {
+  it("keeps the sheet open and increments addedCount + createNonce on success", async () => {
+    const { result } = setupContinuous({ status: "success" });
+    act(() => result.current.openAddSheet());
+    expect(result.current.addOpen).toBe(true);
+    expect(result.current.addedCount).toBe(0);
+    const nonce0 = result.current.createNonce;
+
+    await act(async () => {
+      await result.current.handleCreate({ front: "a", back: "b" });
+    });
+    expect(result.current.addOpen).toBe(true);
+    expect(result.current.addedCount).toBe(1);
+    expect(result.current.createNonce).not.toBe(nonce0);
+
+    await act(async () => {
+      await result.current.handleCreate({ front: "c", back: "d" });
+    });
+    expect(result.current.addedCount).toBe(2);
+  });
+
+  it("resets addedCount when the sheet is dismissed", async () => {
+    const { result } = setupContinuous({ status: "success" });
+    act(() => result.current.openAddSheet());
+    await act(async () => {
+      await result.current.handleCreate({ front: "a", back: "b" });
+    });
+    expect(result.current.addedCount).toBe(1);
+    act(() => result.current.onAddOpenChange(false));
+    expect(result.current.addedCount).toBe(0);
+    expect(result.current.addOpen).toBe(false);
   });
 });

--- a/frontend/src/lib/forms/use-sheet-form.ts
+++ b/frontend/src/lib/forms/use-sheet-form.ts
@@ -77,11 +77,14 @@ export function useCardSheetForm({
   const [addOpen, setAddOpen] = useState(false);
   const [addDirty, setAddDirty] = useState(false);
   const [editingId, setEditingId] = useState<string | null>(null);
+  const [addedCount, setAddedCount] = useState(0);
+  const [createNonce, setCreateNonce] = useState(0);
 
   const createForm = useSheetForm(
     useCallback(() => {
       setAddDirty(false);
-      setAddOpen(false);
+      setAddedCount((c) => c + 1);
+      setCreateNonce((n) => n + 1);
     }, []),
   );
   const updateForm = useSheetForm(useCallback(() => setEditingId(null), []));
@@ -101,6 +104,7 @@ export function useCardSheetForm({
     resetCreateCard();
     clearCreateError();
     setAddDirty(false);
+    setAddedCount(0);
     setAddOpen(true);
   }, [resetCreateCard, clearCreateError]);
 
@@ -113,6 +117,7 @@ export function useCardSheetForm({
         resetCreateCard();
         setAddDirty(false);
         clearCreateError();
+        setAddedCount(0);
       }
     },
     [resetCreateCard, clearCreateError],
@@ -160,6 +165,8 @@ export function useCardSheetForm({
   return {
     addOpen,
     addDirty,
+    addedCount,
+    createNonce,
     markAddDirty,
     editingId,
     createValidationError: createForm.validationError,

--- a/frontend/src/lib/forms/use-sheet-form.ts
+++ b/frontend/src/lib/forms/use-sheet-form.ts
@@ -63,9 +63,11 @@ export type UseCardSheetFormInput = {
  * The add/edit-card sheet state machine shared, byte-for-byte, by the cardgroup
  * and master-deck card screens. Owns the add-sheet open/dirty flags, the editing
  * row id, both field-level validation errors, and the create/update outcome
- * routing (incl. the close-on-success and `unexpected` → inline-`front`-error
- * fallbacks). The caller supplies the mutation runners (from
- * `useCardMutations` / `useMasterCardMutations`) and the localized fallbacks.
+ * routing. A successful CREATE keeps the add sheet open and bumps
+ * `addedCount`/`createNonce` (continuous add); a successful UPDATE closes the
+ * edit sheet. Both map `unexpected` → an inline `front` error. The caller
+ * supplies the mutation runners (from `useCardMutations` /
+ * `useMasterCardMutations`) and the localized fallbacks.
  */
 export function useCardSheetForm({
   createCard,


### PR DESCRIPTION
## Summary

Batch import was an add-content action buried one tap deep in the deck-detail `···` overflow on mobile — grouped next to the lifecycle/destructive items (master: Settings/Delete; cardgroup: Rename/Delete) and split from its sibling single "Add card" on the global header `+`. Desktop had already consolidated Add / Batch import / Merge into one add-cards menu (#696); only mobile was out of step.

This moves **Batch import** (and **Merge from catalog**, cardgroup-only) onto the global header `+`, which now opens an **Add menu** on both deck-detail edit routes, and makes the `···` overflow lifecycle-only. It also makes the shared add-card sheet **stay open after each save** (clear fields, refocus Front, show a running `✓ N added` count) so building a deck no longer re-opens the sheet per card.

This addresses no GitHub issue — it was scoped from a design session. Applies to `/admin/masters/[id]/edit` and `/cardgroups/[id]/edit`; the Learn screen's separate add-card sheet is out of scope.

## Approach

- **The `+` becomes the single add-content entry on deck-detail routes.** `resolveHeaderCreateAction` returns a new `deck-add-menu` for the two edit routes (replacing the single-action `master-card` / `card-with-group`; `/learn/:id` keeps `card-with-group`). `LogoDrawer` renders the `+` as a Radix dropdown for that kind. This is the mobile-native "tap → menu" pattern mirroring the desktop split-button — not a mobile split button.
- **In-page sheets claim the events.** New cancelable `flamingo:batch-import` / `flamingo:merge` carry `{ ownerId }`; `CardListScreen` opens the import sheet (matched on `ownerId`, covering master + cardgroup), `CardgroupCardsSection` opens the merge sheet. The cardgroup "Add card" item keeps its `router.push(/cards/new)` fallback for the uncancelled case.
- **Overflow becomes lifecycle-only.** The mobile `···` import/merge items are removed and the dead `onBatchImport`/`onMerge` prop chains dropped; the desktop split-buttons still drive those via `SectionHeaderArgs`.
- **Continuous add lives in the sheet, not the header.** `useCardSheetForm`'s create-success no longer closes the add sheet — it keeps it open, bumps `addedCount` + a `createNonce` (a remount key that clears the form), and the sheet shows the counter. The menu tap is paid once; repeated single-add is faster than before.

## Changes

### Header + Add menu (`components/nav/header-create-action.ts`, `logo-drawer.tsx`)

- `HeaderCreateAction` gains `deck-add-menu` (`deck: { kind: "master"; masterId } | { kind: "cardgroup"; cardgroupId; addCardHref }`) and exports a `DeckAddMenu` alias; `master-card` is removed. The two edit routes resolve to it; `/learn/:id` is unchanged.
- `LogoDrawer` renders the `+` as a `DropdownMenu` for that kind (`header-add-menu-trigger` → `header-add-card` / `header-batch-import` / `header-merge`); items dispatch the events. The plain-button `+` is kept for every other route.

### Events + in-page subscriptions (`lib/events/flamingo-events.ts`, `components/cardgroups/card-list-screen.tsx`, `cardgroup-cards-section.tsx`)

- Adds `flamingo:batch-import` / `flamingo:merge` with a shared `DeckOwnerDetail { ownerId }`.
- `CardListScreen` subscribes to `batch-import` (opens import, matched on `ownerId`); `CardgroupCardsSection` subscribes to `merge` (opens the merge sheet).

### Lifecycle-only overflows (`app/admin/masters/[id]/edit/{master-edit-header,master-cards-section,master-management-client}.tsx`; `components/cardgroups/{cardgroup-header,cardgroup-cards-section}.tsx`, `app/cardgroups/[id]/edit/cardgroup-management-client.tsx`)

- Removes Batch import (master) and Batch import + Merge (cardgroup) from the mobile `···` menus; drops the `onBatchImport`/`onMerge` props from the headers and the `renderPageHeader` thread. Desktop split-buttons unchanged.

### Continuous add (`lib/forms/use-sheet-form.ts`, `components/cardgroups/{card-list-screen,card-form}.tsx`, `lib/forms/form-field.tsx`, `messages/{en,ja}.json`)

- `useCardSheetForm` keeps the add sheet open on create-success, exposing `addedCount` + `createNonce`. `CardListScreen` keys the add-form on `createNonce` (clears fields) and renders the `✓ N added` counter. `FormField` gains an `autoFocus` prop; `CardForm` autofocuses Front in create mode. Adds `Cards.addedCount` (en + ja).

### Tests + e2e

- Unit/integration: resolver menu shapes, the `+` dropdown dispatch (incl. cancelled add-card + dispatch payloads), import/merge subscriptions (incl. non-matching `ownerId`), the lifecycle-only overflows, the keep-open hook, and the continuous-add sheet.
- e2e repointed: `new-user-onboarding` drives the header `+` menu → Add card; `admin-masters-edit` dismisses the now-keep-open sheet (Escape) before the edit step. `cardgroup-import` is unaffected (desktop split-button path).

## Test plan

- `pnpm --filter frontend typecheck` clean; `pnpm --filter frontend lint` (biome `--error-on-warnings`) clean.
- `pnpm --filter frontend test` → 1692 pass / 180 files.
- No CJK in `.ts/.tsx` source (new Japanese only in `messages/ja.json`); no committed generated code.
- e2e (CI / live stack): the two repointed specs exercise the new `+` menu and the keep-open dismiss.
