### PR TITLE
refactor(danger): inline delete triggers use destructiveGhost

### DIFF
--- a/frontend/__tests__/cards-bulk-delete.test.tsx
+++ b/frontend/__tests__/cards-bulk-delete.test.tsx
@@ -179,6 +179,24 @@ describe("CardsClient — bulk delete", () => {
     expect(screen.getByText("This action cannot be undone.")).toBeInTheDocument();
   });
 
+  // T3b: the bulk-delete trigger is a low-emphasis ghost while the confirm stays filled.
+  it("renders the bulk-delete trigger as a ghost while the confirm stays filled", async () => {
+    const user = userEvent.setup();
+    const cards = [makeCard(1), makeCard(2)];
+    renderCardsClient(cards, []);
+
+    await user.click(screen.getByTestId("card-select-c-1"));
+    await user.click(screen.getByTestId("card-select-c-2"));
+
+    const trigger = screen.getByTestId("cards-bulk-delete-button");
+    expect(trigger).not.toHaveClass("bg-destructive");
+    expect(trigger).toHaveClass("text-destructive");
+
+    await user.click(trigger);
+    await screen.findByRole("alertdialog");
+    expect(screen.getByTestId("cards-bulk-confirm")).toHaveClass("bg-destructive");
+  });
+
   // T4: confirming the dialog fires the mutation; rows are removed and totalCount decrements.
   it("fires the mutation on confirm; rows disappear and totalCount decrements", async () => {
     const user = userEvent.setup();

--- a/frontend/src/app/admin/users/admin-user-profile-sheet.test.tsx
+++ b/frontend/src/app/admin/users/admin-user-profile-sheet.test.tsx
@@ -591,6 +591,19 @@ describe("AdminUserProfileSheet", () => {
     expect(screen.getByTestId("admin-delete-user-trigger")).toBeInTheDocument();
   });
 
+  it("renders the delete trigger as a low-emphasis ghost while the confirm stays filled", async () => {
+    const user = userEvent.setup();
+    renderSheet({ onDelete: vi.fn() });
+
+    const trigger = screen.getByTestId("admin-delete-user-trigger");
+    expect(trigger).not.toHaveClass("bg-destructive");
+    expect(trigger).toHaveClass("text-destructive");
+
+    await user.click(trigger);
+    const confirm = await screen.findByTestId("admin-delete-user-confirm");
+    expect(confirm).toHaveClass("bg-destructive");
+  });
+
   it("confirms deletion and calls onDelete with the user id", async () => {
     const user = userEvent.setup();
     const onDelete = vi.fn<(id: string) => Promise<void>>().mockResolvedValue(undefined);

--- a/frontend/src/app/admin/users/admin-user-profile-sheet.tsx
+++ b/frontend/src/app/admin/users/admin-user-profile-sheet.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMutation } from "@apollo/client/react";
+import { Trash2 } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useEffect, useMemo, useRef, useState } from "react";
 import {
@@ -405,9 +406,10 @@ function AdminUserProfileSheetBody({
                 <AlertDialogTrigger asChild>
                   <Button
                     type="button"
-                    variant="destructive"
+                    variant="destructiveGhost"
                     data-testid="admin-delete-user-trigger"
                   >
+                    <Trash2 aria-hidden="true" className="h-4 w-4" />
                     {t("deleteUserButton")}
                   </Button>
                 </AlertDialogTrigger>

--- a/frontend/src/app/profile/delete-account-section.test.tsx
+++ b/frontend/src/app/profile/delete-account-section.test.tsx
@@ -72,6 +72,19 @@ describe("<DeleteAccountSection>", () => {
     expect(screen.getByTestId("delete-account-trigger")).toBeInTheDocument();
   });
 
+  it("renders the trigger as a low-emphasis ghost while the confirm stays filled", async () => {
+    const user = userEvent.setup();
+    renderSection();
+
+    const trigger = screen.getByTestId("delete-account-trigger");
+    expect(trigger).not.toHaveClass("bg-destructive");
+    expect(trigger).toHaveClass("text-destructive");
+
+    await user.click(trigger);
+    const confirm = await screen.findByTestId("delete-account-confirm");
+    expect(confirm).toHaveClass("bg-destructive");
+  });
+
   it("gates the confirm button on typing the exact phrase", async () => {
     const user = userEvent.setup();
     renderSection();

--- a/frontend/src/app/profile/delete-account-section.tsx
+++ b/frontend/src/app/profile/delete-account-section.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMutation } from "@apollo/client/react";
+import { Trash2 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { useState } from "react";
@@ -103,7 +104,8 @@ export function DeleteAccountSection() {
 
       <AlertDialog open={open} onOpenChange={handleOpenChange}>
         <AlertDialogTrigger asChild>
-          <Button type="button" variant="destructive" data-testid="delete-account-trigger">
+          <Button type="button" variant="destructiveGhost" data-testid="delete-account-trigger">
+            <Trash2 aria-hidden="true" className="h-4 w-4" />
             {t("deleteAccountButton")}
           </Button>
         </AlertDialogTrigger>

--- a/frontend/src/components/cardgroups/bulk-action-bar.tsx
+++ b/frontend/src/components/cardgroups/bulk-action-bar.tsx
@@ -37,7 +37,7 @@ export function BulkActionBar({ count, busy, onConfirm, onClear }: BulkActionBar
       <AlertDialog>
         <AlertDialogTrigger asChild>
           <Button
-            variant="destructive"
+            variant="destructiveGhost"
             size="sm"
             disabled={busy}
             data-testid="cards-bulk-delete-button"


### PR DESCRIPTION
## Summary

Danger is a two-tier treatment: the inline **trigger** (a Delete button in a row/toolbar that opens a confirm dialog) should be low-emphasis ghost-red, while the **commit** (the confirm inside the dialog) stays filled crimson as the point of no return — a list of filled-red rows is noisy and over-invites the click. This converts the three inline delete triggers to `variant="destructiveGhost"` with a `Trash2` icon; every confirm stays filled `destructive`.

Builds on #699 (PR base `feature/699-button-destructive-ghost`), which adds the `destructiveGhost` variant. Part C of the coral-minimal rework.

## Changes

### Triggers → `destructiveGhost` + Trash2

- `bulk-action-bar.tsx` (`cards-bulk-delete-button`): `destructive` → `destructiveGhost` (its existing Trash2 icon is kept).
- `delete-account-section.tsx` (`delete-account-trigger`): `destructive` → `destructiveGhost`, with a new leading `Trash2` icon (+ `lucide-react` import).
- `admin-user-profile-sheet.tsx` (`admin-delete-user-trigger`): `destructive` → `destructiveGhost`, with a new leading `Trash2` icon (+ import).

### Commits stay filled (unchanged)

- `delete-account-confirm` and `admin-delete-user-confirm` (plain `destructive` Buttons) and `cards-bulk-confirm` (`AlertDialogAction` with `buttonVariants({ variant: "destructive" })`) are untouched. The `AlertDialogAction` verification grep stays green.

### Tests

- Each of the three screens' tests now asserts the trigger is no longer the filled `bg-destructive` (it carries `text-destructive`) and the matching commit still renders `bg-destructive`.

## Test plan

- `pnpm --filter frontend typecheck` — clean.
- `pnpm --filter frontend lint` — clean.
- `pnpm --filter frontend test` — 1704 passed (182 files), including the 3 new trigger/commit assertions.

Closes #700
