### PR TITLE
fix(cardgroups): emphasize bulk-delete trigger, demote cancel to ghost

### DIFF
--- a/docs/frontend/design-system.md
+++ b/docs/frontend/design-system.md
@@ -110,6 +110,21 @@ A filled red row in a list is the anti-pattern this two-tier replaces: it shouts
 before the user has expressed any delete intent. Ghost-red at the trigger, filled crimson only at
 the commit.
 
+### Selection toolbars: the destructive action is the bar's primary
+
+A contextual selection bar — e.g. the cards bulk-action bar
+([`bulk-action-bar.tsx`](../../frontend/src/components/cardgroups/bulk-action-bar.tsx)) — is the
+one place where a danger trigger is also the **primary** action of its view: the user entered
+selection mode *in order to* delete. There the inline `destructiveGhost` trigger carries a local
+affordance border (`border border-destructive/45`) so it reads as clearly tappable and findable,
+and its sibling **Cancel is demoted from `outline` to `ghost`** so the single bordered control is
+the destructive one. This is a deliberate, local exception to the "Cancel → `outline`" ladder row
+above: emphasis tracks intent, and the bar's intent is to delete. The trigger stays transparent
+(border only, never a filled red row), and the real safety gate remains the filled `destructive`
+commit in the confirm dialog. Standalone danger triggers outside a selection bar (Delete account,
+Delete user) keep the plain borderless `destructiveGhost` — there delete is a rare, dangerous
+escape hatch, not the view's purpose, so it stays recessive.
+
 ## Button variants
 
 [`Button`](../../frontend/src/components/ui/button.tsx) exposes these variants. Pick by intent,

--- a/frontend/src/components/cardgroups/bulk-action-bar.test.tsx
+++ b/frontend/src/components/cardgroups/bulk-action-bar.test.tsx
@@ -1,0 +1,31 @@
+// @vitest-environment happy-dom
+import { screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { renderWithIntl } from "@/test/render-with-intl";
+import { BulkActionBar } from "./bulk-action-bar";
+
+describe("BulkActionBar hierarchy", () => {
+  function renderBar() {
+    renderWithIntl(<BulkActionBar count={2} busy={false} onConfirm={vi.fn()} onClear={vi.fn()} />);
+  }
+
+  // Delete is the bar's emphasized primary: the only bordered button, carrying a
+  // visible red border for affordance/findability while staying a low-emphasis
+  // ghost (transparent, red text — never the filled crimson commit).
+  it("renders Delete selected as the only bordered, red-text action", () => {
+    renderBar();
+    const del = screen.getByTestId("cards-bulk-delete-button");
+    expect(del).toHaveClass("border", "border-destructive/45", "text-destructive");
+    // Still a trigger, not the filled commit.
+    expect(del).not.toHaveClass("bg-destructive");
+  });
+
+  // Cancel is the quiet escape: demoted from outline to ghost, so it carries no
+  // border and does not compete with Delete for emphasis.
+  it("renders Cancel as a borderless ghost escape", () => {
+    renderBar();
+    const cancel = screen.getByRole("button", { name: /^cancel$/i });
+    expect(cancel).not.toHaveClass("border");
+    expect(cancel).not.toHaveClass("border-input");
+  });
+});

--- a/frontend/src/components/cardgroups/bulk-action-bar.tsx
+++ b/frontend/src/components/cardgroups/bulk-action-bar.tsx
@@ -41,7 +41,7 @@ export function BulkActionBar({ count, busy, onConfirm, onClear }: BulkActionBar
             size="sm"
             disabled={busy}
             data-testid="cards-bulk-delete-button"
-            className="w-full sm:w-auto"
+            className="w-full border border-destructive/45 sm:w-auto"
           >
             {tCommon("deleteSelected")}
             <Trash2 aria-hidden="true" className="ml-1.5 h-4 w-4" />
@@ -64,7 +64,7 @@ export function BulkActionBar({ count, busy, onConfirm, onClear }: BulkActionBar
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
-      <Button variant="outline" size="sm" className="w-full sm:w-auto" onClick={onClear}>
+      <Button variant="ghost" size="sm" className="w-full sm:w-auto" onClick={onClear}>
         {tCommon("cancel")}
         <X aria-hidden="true" className="ml-1.5 h-4 w-4" />
       </Button>


### PR DESCRIPTION
## Summary

The cards bulk-action bar paired a borderless `Delete selected` (`destructiveGhost`) directly above a bordered `Cancel` (`outline`), inverting the emphasis: the bordered Cancel read as the real button and the borderless Delete read like a label — weak affordance, especially on mobile. Since the bar exists only because the user entered selection mode *to delete*, this makes Delete the bar's emphasized primary (a local affordance border on the trigger) and demotes Cancel to a borderless ghost, so the single bordered control is the destructive one. The real safety gate is unchanged: the filled `destructive` commit stays in the confirm dialog.

This addresses no GitHub issue — it was scoped from a principal UI/UX review. Standalone danger triggers (Delete account, Delete user) keep the plain borderless `destructiveGhost`; the shared variant is untouched.

## Changes

### Bulk-action bar hierarchy (`components/cardgroups/bulk-action-bar.tsx`)

- `cards-bulk-delete-button`: keeps `variant="destructiveGhost"` and gains a local `border border-destructive/45` — the only bordered control in the bar (affordance + emphasis), still transparent with red text, never a filled red row.
- Cancel button: `variant="outline"` → `variant="ghost"` (borderless), so it no longer competes with Delete for emphasis. Its `Cancel` label + `X` icon are unchanged.
- `components/ui/button.tsx` and the shared `destructiveGhost` variant are deliberately untouched — the border is local to this bar, so standalone triggers stay recessive.

### Docs (`docs/frontend/design-system.md`)

- New "Selection toolbars: the destructive action is the bar's primary" note under the danger two-tier: documents the deliberate, local exception to the `Cancel → outline` ladder row (emphasis tracks intent — the bar's intent is to delete), and that standalone danger triggers outside a selection bar stay plain `destructiveGhost`.

### Tests (`components/cardgroups/bulk-action-bar.test.tsx`, new)

- Narrow component test pinning the new hierarchy: Delete is the only bordered, red-text action (`border`, `border-destructive/45`, `text-destructive`, not `bg-destructive`); Cancel is a borderless ghost (no `border` / `border-input`).
- The broad `cards-bulk-delete` suite (T3b trigger-not-filled, T5 cancel-by-role) and the co-located `cards-client` suite stay green — neither asserts on the changed classes.

## Test plan

- `pnpm --filter frontend typecheck` — clean.
- `pnpm --filter frontend lint` (biome `--error-on-warnings`) — clean.
- `pnpm --filter frontend test` — 1706 passed (183 files), including the new `bulk-action-bar.test.tsx`.
- No CJK in changed `.tsx`/docs; no committed generated code.
