### PR TITLE
refactor(frontend): route useDeleteCardgroup through the shared removeConnectionEdges helper

### DIFF
--- a/frontend/src/components/cardgroups/use-delete-cardgroup.ts
+++ b/frontend/src/components/cardgroups/use-delete-cardgroup.ts
@@ -4,6 +4,7 @@ import { useMutation } from "@apollo/client/react";
 import { useCallback } from "react";
 import { CARDGROUPS_DEFAULT_VARS, DeleteCardgroupMutation } from "@/app/cardgroups/queries";
 import { MyCardgroupsConnectionDocument } from "@/generated/graphql";
+import { removeConnectionEdges } from "@/lib/apollo/connection-cache";
 
 /**
  * Owns the cardgroup delete mutation and its Connection-delete cache surgery:
@@ -32,31 +33,14 @@ export function useDeleteCardgroup() {
         variables: { id },
         update(cache, { data }) {
           if (!data?.deleteCardgroup) return;
-
-          const existingConnection = cache.readQuery({
-            query: MyCardgroupsConnectionDocument,
+          removeConnectionEdges(cache, {
+            document: MyCardgroupsConnectionDocument,
             variables: CARDGROUPS_DEFAULT_VARS,
+            connectionField: "myCardgroupsConnection",
+            entityTypename: "Cardgroup",
+            ids: [id],
+            deletedCount: 1,
           });
-          if (existingConnection) {
-            cache.writeQuery({
-              query: MyCardgroupsConnectionDocument,
-              variables: CARDGROUPS_DEFAULT_VARS,
-              data: {
-                myCardgroupsConnection: {
-                  ...existingConnection.myCardgroupsConnection,
-                  edges: existingConnection.myCardgroupsConnection.edges.filter(
-                    (edge) => edge.node.id !== id,
-                  ),
-                  totalCount: Math.max(0, existingConnection.myCardgroupsConnection.totalCount - 1),
-                },
-              },
-            });
-          }
-
-          cache.evict({
-            id: cache.identify({ __typename: "Cardgroup", id }),
-          });
-          cache.gc();
         },
       }).catch((err) => {
         console.error("[useDeleteCardgroup] delete rejection", err);


### PR DESCRIPTION
## Summary

`useDeleteCardgroup` hand-inlined the exact "filter the deleted edge out of a cached Connection + clamp `totalCount` + evict + gc" logic that the shared `removeConnectionEdges` helper already provides. The card bulk-delete path already routes through this helper, so the cardgroup delete was the last site re-spelling the invariant by hand — a future fix to the clamp/evict behavior would have silently missed it. This routes the hook through the helper with no behavior change.

## Changes

- `components/cardgroups/use-delete-cardgroup.ts`:
  - Import `removeConnectionEdges` from `@/lib/apollo/connection-cache`.
  - Replace the inline `readQuery` / `writeQuery` (`edges.filter` + `Math.max(0, totalCount - 1)`) + `cache.evict` + `cache.gc` block in `update(cache, { data })` with a single `removeConnectionEdges` call (`document: MyCardgroupsConnectionDocument`, `variables: CARDGROUPS_DEFAULT_VARS`, `connectionField: "myCardgroupsConnection"`, `entityTypename: "Cardgroup"`, `ids: [id]`, `deletedCount: 1`).
  - The `if (!data?.deleteCardgroup) return;` guard and the `.catch` rejection handling are unchanged. No new test is added — the behavior is identical and already covered by `connection-cache.test.ts` plus the cardgroup list/header tests.

## Test plan

- `pnpm --filter frontend typecheck` — clean.
- `pnpm --filter frontend lint` — clean (only pre-existing `biome.json` deprecation infos).
- `pnpm --filter frontend knip` — clean (only a pre-existing config hint, unrelated).
- `pnpm --filter frontend exec vitest run` on the affected + consumer suites — 49 passed (4 files): `lib/apollo/connection-cache.test.ts`, `app/cardgroups/cardgroups-client.test.tsx`, `app/cardgroups/[id]/edit/cardgroup-management-client.test.tsx`, `components/cardgroups/cardgroup-header.test.tsx`.
- No CJK in the changed `.ts`; no committed generated code.

Closes #709
