### PR TITLE
refactor(frontend): route admin master/user mutation cache through shared connection-cache helpers

### DIFF
--- a/frontend/src/app/admin/masters/use-master-mutations.ts
+++ b/frontend/src/app/admin/masters/use-master-mutations.ts
@@ -1,9 +1,11 @@
 "use client";
 
 import { useApolloClient, useMutation } from "@apollo/client/react";
-import type { Reference } from "@apollo/client/utilities";
 import { useCallback } from "react";
-import type { AdminMastersQuery as AdminMastersQueryResult } from "@/generated/graphql";
+import {
+  appendConnectionEdge,
+  removeConnectionEdgeAcrossVariants,
+} from "@/lib/apollo/connection-cache";
 import { classifyToAuthOutcome } from "@/lib/apollo/errors";
 import type { MasterFormValues } from "./admin-master-form";
 import {
@@ -72,44 +74,30 @@ export function useMasterMutations() {
         // mutate the cache.
         if (data?.adminCreateMasterCardgroup?.__typename !== "CreateMasterCardgroupSuccess") return;
         const created = data.adminCreateMasterCardgroup.master;
-        // cache.modify is forbidden — readQuery + writeQuery handles the cold cache
-        // too. Write the search=null variant only; ADMIN_MASTERS_BASE_VARS keeps the
-        // key in sync with the client useConnectionPagination query. See
-        // .claude/rules/pagination.md.
-        const existing = cache.readQuery<AdminMastersQueryResult>({
-          query: AdminMastersQuery,
+        // Write the search=null variant only; ADMIN_MASTERS_BASE_VARS keeps the key
+        // in sync with the client useConnectionPagination query. The shared helper
+        // handles the warm-prepend / cold-seed branches and adds a node.id dedup
+        // guard. See .claude/rules/pagination.md.
+        appendConnectionEdge(cache, {
+          document: AdminMastersQuery,
           variables: { ...ADMIN_MASTERS_BASE_VARS, search: null },
-        });
-        const createdEdge = {
-          __typename: "MasterCatalogEdge" as const,
-          cursor: created.id,
+          connectionField: "adminMasters",
+          edgeTypename: "MasterCatalogEdge",
           node: created,
-        };
-        cache.writeQuery<AdminMastersQueryResult>({
-          query: AdminMastersQuery,
-          variables: { ...ADMIN_MASTERS_BASE_VARS, search: null },
-          data: existing?.adminMasters
-            ? {
-                adminMasters: {
-                  ...existing.adminMasters,
-                  edges: [createdEdge, ...existing.adminMasters.edges],
-                  totalCount: existing.adminMasters.totalCount + 1,
-                },
-              }
-            : {
-                adminMasters: {
-                  __typename: "MasterCatalogConnection",
-                  edges: [createdEdge],
-                  pageInfo: {
-                    __typename: "PageInfo",
-                    hasNextPage: false,
-                    hasPreviousPage: false,
-                    startCursor: created.id,
-                    endCursor: created.id,
-                  },
-                  totalCount: 1,
-                },
-              },
+          buildColdConnection: () => ({
+            __typename: "MasterCatalogConnection" as const,
+            edges: [
+              { __typename: "MasterCatalogEdge" as const, cursor: created.id, node: created },
+            ],
+            pageInfo: {
+              __typename: "PageInfo" as const,
+              hasNextPage: false,
+              hasPreviousPage: false,
+              startCursor: created.id,
+              endCursor: created.id,
+            },
+            totalCount: 1,
+          }),
         });
       },
     },
@@ -171,27 +159,11 @@ export function useMasterMutations() {
         if (!result.data?.adminDeleteMasterCardgroup) {
           throw new Error("adminDeleteMasterCardgroup returned false");
         }
-        apolloClient.cache.modify({
-          fields: {
-            adminMasters(existing, { readField }) {
-              const conn = existing as {
-                edges?: ReadonlyArray<{ node: Reference }>;
-                totalCount?: number;
-              };
-              if (!conn.edges) return existing;
-              // Filter by the normalized node id, not by `cursor` (the edge cursor is
-              // an opaque "v1:..." value that never equals the raw id).
-              const next = conn.edges.filter((edge) => readField<string>("id", edge.node) !== id);
-              if (next.length === conn.edges.length) return existing;
-              return { ...conn, edges: next, totalCount: Math.max(0, (conn.totalCount ?? 0) - 1) };
-            },
-          },
+        removeConnectionEdgeAcrossVariants(apolloClient.cache, {
+          connectionField: "adminMasters",
+          entityTypename: "MasterCardgroup",
+          id,
         });
-        const cacheId = apolloClient.cache.identify({ __typename: "MasterCardgroup", id });
-        if (cacheId) {
-          apolloClient.cache.evict({ id: cacheId });
-          apolloClient.cache.gc();
-        }
         return { status: "success" };
       } catch (err) {
         return classifyToAuthOutcome<AuthKind>(err, "useMasterMutations", "deleteMaster", {

--- a/frontend/src/app/admin/users/use-admin-user-mutations.ts
+++ b/frontend/src/app/admin/users/use-admin-user-mutations.ts
@@ -1,8 +1,8 @@
 "use client";
 
-import type { Reference } from "@apollo/client";
 import { useApolloClient, useMutation } from "@apollo/client/react";
 import { useCallback } from "react";
+import { removeConnectionEdgeAcrossVariants } from "@/lib/apollo/connection-cache";
 import { AdminDeleteUserMutation } from "./queries";
 
 /**
@@ -30,35 +30,11 @@ export function useAdminUserMutations() {
       if (!result.data?.adminDeleteUser) {
         throw new Error("adminDeleteUser returned false");
       }
-      apolloClient.cache.modify({
-        fields: {
-          users(existing, { readField }) {
-            const connection = existing as {
-              edges?: ReadonlyArray<{ node: Reference }>;
-              totalCount?: number;
-            };
-            if (!connection.edges) return existing;
-            // Filter by the normalized node id, NOT by `edge.cursor`: the backend
-            // emits an opaque "v1:..." cursor that never equals the raw user id
-            // (.claude/rules/pagination.md "Resolve an edge by node.id, never by
-            // edge.cursor"). Matches masters/cards/cardgroups.
-            const edges = connection.edges.filter(
-              (edge) => readField<string>("id", edge.node) !== id,
-            );
-            if (edges.length === connection.edges.length) return existing;
-            return {
-              ...connection,
-              edges,
-              totalCount: Math.max(0, (connection.totalCount ?? 0) - 1),
-            };
-          },
-        },
+      removeConnectionEdgeAcrossVariants(apolloClient.cache, {
+        connectionField: "users",
+        entityTypename: "User",
+        id,
       });
-      const cacheId = apolloClient.cache.identify({ __typename: "User", id });
-      if (cacheId) {
-        apolloClient.cache.evict({ id: cacheId });
-        apolloClient.cache.gc();
-      }
     },
     [apolloClient, runDeleteUser],
   );

--- a/frontend/src/lib/apollo/connection-cache.test.ts
+++ b/frontend/src/lib/apollo/connection-cache.test.ts
@@ -5,7 +5,11 @@ import {
   type CardsByCardgroupConnectionQuery,
   type CardsByCardgroupConnectionQueryVariables,
 } from "@/generated/graphql";
-import { appendConnectionEdge, removeConnectionEdges } from "./connection-cache";
+import {
+  appendConnectionEdge,
+  removeConnectionEdgeAcrossVariants,
+  removeConnectionEdges,
+} from "./connection-cache";
 
 const CARDGROUP_ID = "cg-1";
 
@@ -233,5 +237,87 @@ describe("removeConnectionEdges", () => {
 
     expect(evictSpy).toHaveBeenCalledWith({ id: "Card:a" });
     expect(gcSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("removeConnectionEdgeAcrossVariants", () => {
+  // A second cached variant of the same field, keyed on a different `search`
+  // argument. `cache.modify` visits every cached instance of the field, so a
+  // single call must drop the entity from both variants at once.
+  const FILTERED_VARS: CardsByCardgroupConnectionQueryVariables = {
+    cardgroupId: CARDGROUP_ID,
+    first: 20,
+    search: "a",
+  };
+
+  function seedVariant(
+    cache: InMemoryCache,
+    variables: CardsByCardgroupConnectionQueryVariables,
+    ids: string[],
+    totalCount = ids.length,
+  ) {
+    cache.writeQuery({
+      query: CardsByCardgroupConnectionDocument,
+      variables,
+      data: { cardsByCardgroupConnection: makeConnection(ids, totalCount) },
+    });
+  }
+
+  function readVariant(cache: InMemoryCache, variables: CardsByCardgroupConnectionQueryVariables) {
+    return cache.readQuery({ query: CardsByCardgroupConnectionDocument, variables });
+  }
+
+  it("removes the matching edge from every cached variant and clamps totalCount at 0", () => {
+    const cache = new InMemoryCache();
+    seedVariant(cache, VARS, ["a", "b", "c"], 3);
+    // The filtered variant under-counts totalCount (1) relative to its loaded
+    // edges, so removing "b" exercises the Math.max(0, …) clamp.
+    seedVariant(cache, FILTERED_VARS, ["a", "b"], 1);
+
+    removeConnectionEdgeAcrossVariants(cache, {
+      connectionField: "cardsByCardgroupConnection",
+      entityTypename: "Card",
+      id: "b",
+    });
+
+    const nullVariant = readVariant(cache, VARS);
+    expect(nullVariant?.cardsByCardgroupConnection.edges.map((e) => e.node.id)).toEqual(["a", "c"]);
+    expect(nullVariant?.cardsByCardgroupConnection.totalCount).toBe(2);
+
+    const filteredVariant = readVariant(cache, FILTERED_VARS);
+    expect(filteredVariant?.cardsByCardgroupConnection.edges.map((e) => e.node.id)).toEqual(["a"]);
+    expect(filteredVariant?.cardsByCardgroupConnection.totalCount).toBe(0);
+  });
+
+  it("evicts the normalized entity and runs gc", () => {
+    const cache = new InMemoryCache();
+    seedVariant(cache, VARS, ["a", "b"], 2);
+    const evictSpy = vi.spyOn(cache, "evict");
+    const gcSpy = vi.spyOn(cache, "gc");
+
+    removeConnectionEdgeAcrossVariants(cache, {
+      connectionField: "cardsByCardgroupConnection",
+      entityTypename: "Card",
+      id: "a",
+    });
+
+    expect(evictSpy).toHaveBeenCalledWith({ id: "Card:a" });
+    expect(gcSpy).toHaveBeenCalledTimes(1);
+    expect(cache.extract()["Card:a"]).toBeUndefined();
+  });
+
+  it("leaves a variant that does not contain the id untouched", () => {
+    const cache = new InMemoryCache();
+    seedVariant(cache, VARS, ["x", "y"], 2);
+
+    removeConnectionEdgeAcrossVariants(cache, {
+      connectionField: "cardsByCardgroupConnection",
+      entityTypename: "Card",
+      id: "z",
+    });
+
+    const result = readVariant(cache, VARS);
+    expect(result?.cardsByCardgroupConnection.edges.map((e) => e.node.id)).toEqual(["x", "y"]);
+    expect(result?.cardsByCardgroupConnection.totalCount).toBe(2);
   });
 });

--- a/frontend/src/lib/apollo/connection-cache.ts
+++ b/frontend/src/lib/apollo/connection-cache.ts
@@ -1,4 +1,4 @@
-import type { ApolloCache, OperationVariables } from "@apollo/client";
+import type { ApolloCache, OperationVariables, Reference } from "@apollo/client";
 import type { TypedDocumentNode } from "@graphql-typed-document-node/core";
 
 /**
@@ -188,4 +188,56 @@ export function removeConnectionEdges<
     cache.evict({ id: cache.identify({ __typename: entityTypename, id }) });
   }
   cache.gc();
+}
+
+interface RemoveConnectionEdgeAcrossVariantsInput {
+  /** The connection field key on the root query (e.g. `"adminMasters"`, `"users"`). */
+  connectionField: string;
+  /** The `__typename` of the entity, used to evict the normalized entry. */
+  entityTypename: string;
+  /** The id of the node to remove from every cached variant of the connection. */
+  id: string;
+}
+
+/**
+ * Remove the edge whose `node.id` matches `id` from EVERY cached variant of the
+ * connection field (across all `search`/filter argument keys at once), decrement
+ * each variant's `totalCount` (clamped at 0), then evict + gc the normalized entity.
+ *
+ * This uses `cache.modify` deliberately — unlike `removeConnectionEdges`, which
+ * targets a single `variables` key via `readQuery`/`writeQuery`, `cache.modify`
+ * visits every cached instance of the field, so a delete drops the entity from
+ * all active search-filter variants in one pass. The filter resolves the edge by
+ * the normalized `node.id` (never `edge.cursor`, which is an opaque "v1:..." value
+ * that never equals the raw id) and short-circuits when nothing matched so an
+ * unaffected variant keeps its cached reference. See `.claude/rules/pagination.md`.
+ */
+export function removeConnectionEdgeAcrossVariants(
+  cache: ApolloCache,
+  input: RemoveConnectionEdgeAcrossVariantsInput,
+): void {
+  const { connectionField, entityTypename, id } = input;
+
+  cache.modify({
+    fields: {
+      [connectionField](existing, { readField }) {
+        const conn = existing as {
+          edges?: ReadonlyArray<{ node: Reference }>;
+          totalCount?: number;
+        };
+        if (!conn.edges) return existing;
+        // Filter by the normalized node id, not by `cursor` (the edge cursor is
+        // an opaque "v1:..." value that never equals the raw id).
+        const next = conn.edges.filter((edge) => readField<string>("id", edge.node) !== id);
+        if (next.length === conn.edges.length) return existing;
+        return { ...conn, edges: next, totalCount: Math.max(0, (conn.totalCount ?? 0) - 1) };
+      },
+    },
+  });
+
+  const cacheId = cache.identify({ __typename: entityTypename, id });
+  if (cacheId) {
+    cache.evict({ id: cacheId });
+    cache.gc();
+  }
 }


### PR DESCRIPTION
## Summary

The admin master/user mutation hooks hand-inlined Apollo cache surgery that the shared
`connection-cache` helpers already (or nearly) provide:

- `useMasterMutations` **create** re-implemented `appendConnectionEdge` by hand and omitted its
  `node.id` dedup guard — duplicated and slightly buggier.
- `useMasterMutations` and `useAdminUserMutations` **delete** were near-identical `cache.modify`
  blocks with no shared helper — two copies of the "fix one, forget the sibling" trap.

The two delete paths use `cache.modify` deliberately (drop the entity from *all* cached
search-filter variants at once), which is a different strategy from the existing single-variant
`removeConnectionEdges`. So this adds a **new** helper rather than reusing that one. The
create/delete asymmetry is preserved: create writes only the `search: null` variant via
`appendConnectionEdge`; delete spans all variants via the new helper.

## Changes

### `frontend/src/lib/apollo/connection-cache.ts`

- Added `removeConnectionEdgeAcrossVariants(cache, { connectionField, entityTypename, id })`: a
  `cache.modify`-based helper that filters the edge out of every cached variant of the field by
  the normalized `node.id` (never `edge.cursor`), clamps `totalCount` at 0, short-circuits when
  a variant did not match, then evicts + gcs the normalized entity.

### `frontend/src/app/admin/masters/use-master-mutations.ts`

- Create: replaced the inline `readQuery`/`writeQuery` block with `appendConnectionEdge` (passing
  `buildColdConnection`), gaining the dedup guard for free.
- Delete: replaced the inline `cache.modify` block with `removeConnectionEdgeAcrossVariants`.
- Dropped the now-unused `Reference` and `AdminMastersQuery as AdminMastersQueryResult` imports.

### `frontend/src/app/admin/users/use-admin-user-mutations.ts`

- Delete: replaced the inline `cache.modify` block with `removeConnectionEdgeAcrossVariants`.
- Dropped the now-unused `Reference` import.

### `frontend/src/lib/apollo/connection-cache.test.ts`

- Added a `removeConnectionEdgeAcrossVariants` unit suite: filter across two variant keys, clamp
  `totalCount` at 0, evict + gc, and leave a non-matching variant untouched.

## Test plan

- `pnpm --filter frontend typecheck` — pass.
- `pnpm --filter frontend lint` — pass (only pre-existing biome config-deprecation infos).
- `pnpm --filter frontend knip` — pass (only a pre-existing config hint, unrelated).
- `vitest run` on the changed + consumer suites (`connection-cache.test.ts`,
  `use-master-mutations.test.tsx`, `use-admin-user-mutations.test.tsx`,
  `use-entity-card-mutations.test.tsx`) — 4 files, 30 tests, all passing.
- CJK gate on changed sources — clean.

Closes #712
