### PR TITLE
fix(frontend): dedupe swipe rating metadata and localize SwipeDirectionOverlay labels

### DIFF
--- a/frontend/src/components/learn/learn-action-bar.tsx
+++ b/frontend/src/components/learn/learn-action-bar.tsx
@@ -3,39 +3,26 @@
 import { RotateCcw, Smile, Zap } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { cn } from "@/lib/utils";
-import type { SwipeDirection } from "./types";
+import { RATING_META, type RatingTone, type SwipeDirection } from "./types";
 
 type Props = {
   onRate: (direction: SwipeDirection) => void;
   disabled?: boolean;
 };
 
-const DIRECTIONS = [
-  {
-    direction: "left",
-    labelKey: "again",
-    Icon: RotateCcw,
-    shortcut: "ArrowLeft",
-    colorClass:
-      "border-red-600 text-red-600 hover:bg-red-50 focus-visible:ring-red-500 dark:border-red-400 dark:text-red-400 dark:hover:bg-red-950",
-  },
-  {
-    direction: "down",
-    labelKey: "hard",
-    Icon: Zap,
-    shortcut: "ArrowDown",
-    colorClass:
-      "border-sky-600 text-sky-600 hover:bg-sky-50 focus-visible:ring-sky-500 dark:border-sky-400 dark:text-sky-400 dark:hover:bg-sky-950",
-  },
-  {
-    direction: "right",
-    labelKey: "easy",
-    Icon: Smile,
-    shortcut: "ArrowRight",
-    colorClass:
-      "border-emerald-600 text-emerald-600 hover:bg-emerald-50 focus-visible:ring-emerald-500 dark:border-emerald-400 dark:text-emerald-400 dark:hover:bg-emerald-950",
-  },
-] as const;
+const DIRECTIONS: { direction: SwipeDirection; Icon: typeof RotateCcw; shortcut: string }[] = [
+  { direction: "left", Icon: RotateCcw, shortcut: "ArrowLeft" },
+  { direction: "down", Icon: Zap, shortcut: "ArrowDown" },
+  { direction: "right", Icon: Smile, shortcut: "ArrowRight" },
+];
+
+// Circular-button color classes keyed by the shared rating tone. These differ
+// from the overlay chip's classes, so they stay local to this component.
+const TONE_CLASS: Record<RatingTone, string> = {
+  again: "border-red-600 text-red-600 hover:bg-red-50 focus-visible:ring-red-500",
+  hard: "border-sky-600 text-sky-600 hover:bg-sky-50 focus-visible:ring-sky-500",
+  easy: "border-emerald-600 text-emerald-600 hover:bg-emerald-50 focus-visible:ring-emerald-500",
+};
 
 export function LearnActionBar({ onRate, disabled = false }: Props) {
   const t = useTranslations("Learn");
@@ -48,25 +35,28 @@ export function LearnActionBar({ onRate, disabled = false }: Props) {
   return (
     <div className="pointer-events-none z-40 flex justify-center px-4 pt-3 pb-[calc(0.75rem+env(safe-area-inset-bottom))] md:pb-[calc(1.5rem+env(safe-area-inset-bottom))]">
       <div className="pointer-events-auto flex items-center gap-4">
-        {DIRECTIONS.map(({ direction, labelKey, Icon, shortcut, colorClass }) => (
-          <button
-            key={direction}
-            type="button"
-            aria-label={t("rateAs", { label: t(labelKey) })}
-            aria-keyshortcuts={shortcut}
-            disabled={ratingDisabled}
-            aria-disabled={ratingDisabled}
-            onClick={() => onRate(direction)}
-            className={cn(
-              "inline-flex h-14 w-14 items-center justify-center rounded-full border-2 bg-transparent transition active:scale-95",
-              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2",
-              "disabled:cursor-not-allowed disabled:opacity-50",
-              colorClass,
-            )}
-          >
-            <Icon className="h-6 w-6" aria-hidden="true" />
-          </button>
-        ))}
+        {DIRECTIONS.map(({ direction, Icon, shortcut }) => {
+          const { labelKey, tone } = RATING_META[direction];
+          return (
+            <button
+              key={direction}
+              type="button"
+              aria-label={t("rateAs", { label: t(labelKey) })}
+              aria-keyshortcuts={shortcut}
+              disabled={ratingDisabled}
+              aria-disabled={ratingDisabled}
+              onClick={() => onRate(direction)}
+              className={cn(
+                "inline-flex h-14 w-14 items-center justify-center rounded-full border-2 bg-transparent transition active:scale-95",
+                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2",
+                "disabled:cursor-not-allowed disabled:opacity-50",
+                TONE_CLASS[tone],
+              )}
+            >
+              <Icon className="h-6 w-6" aria-hidden="true" />
+            </button>
+          );
+        })}
       </div>
     </div>
   );

--- a/frontend/src/components/learn/swipe-direction-overlay.test.tsx
+++ b/frontend/src/components/learn/swipe-direction-overlay.test.tsx
@@ -1,28 +1,51 @@
 // @vitest-environment happy-dom
-import { render, screen } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
+import { renderWithIntl } from "@/test/render-with-intl";
+import jaMessages from "../../../messages/ja.json";
 import { SwipeDirectionOverlay } from "./swipe-direction-overlay";
 
-describe("SwipeDirectionOverlay — direction to label mapping", () => {
+describe("SwipeDirectionOverlay — direction to label mapping (en locale)", () => {
   it("renders 'Again' for direction left", () => {
-    render(<SwipeDirectionOverlay direction="left" intensity={1} />);
+    renderWithIntl(<SwipeDirectionOverlay direction="left" intensity={1} />);
     expect(screen.getByText("Again")).toBeInTheDocument();
   });
 
   it("renders 'Hard' for direction down", () => {
-    render(<SwipeDirectionOverlay direction="down" intensity={1} />);
+    renderWithIntl(<SwipeDirectionOverlay direction="down" intensity={1} />);
     expect(screen.getByText("Hard")).toBeInTheDocument();
   });
 
   it("renders 'Easy' for direction right", () => {
-    render(<SwipeDirectionOverlay direction="right" intensity={1} />);
+    renderWithIntl(<SwipeDirectionOverlay direction="right" intensity={1} />);
     expect(screen.getByText("Easy")).toBeInTheDocument();
+  });
+});
+
+describe("SwipeDirectionOverlay — localized labels (ja locale)", () => {
+  // Read the expected copy from the ja catalog rather than inlining the CJK
+  // literals; this proves the label flows through next-intl `t(...)` and would
+  // fail if the component reverted to hardcoded English labels.
+  it.each([
+    ["left", jaMessages.Learn.again],
+    ["down", jaMessages.Learn.hard],
+    ["right", jaMessages.Learn.easy],
+  ] as const)("renders the ja label for direction %s", (direction, label) => {
+    renderWithIntl(<SwipeDirectionOverlay direction={direction} intensity={1} />, {
+      locale: "ja",
+      messages: jaMessages,
+    });
+    expect(screen.getByText(label)).toBeInTheDocument();
+    // The English literal must NOT appear under the ja locale.
+    expect(screen.queryByText("Again")).not.toBeInTheDocument();
+    expect(screen.queryByText("Hard")).not.toBeInTheDocument();
+    expect(screen.queryByText("Easy")).not.toBeInTheDocument();
   });
 });
 
 describe("SwipeDirectionOverlay — color class mapping", () => {
   it("applies red classes for direction left", () => {
-    render(<SwipeDirectionOverlay direction="left" intensity={1} />);
+    renderWithIntl(<SwipeDirectionOverlay direction="left" intensity={1} />);
     const label = screen.getByText("Again");
     expect(label.className).toContain("border-red-500");
     expect(label.className).toContain("bg-red-500/10");
@@ -30,7 +53,7 @@ describe("SwipeDirectionOverlay — color class mapping", () => {
   });
 
   it("applies sky classes for direction down", () => {
-    render(<SwipeDirectionOverlay direction="down" intensity={1} />);
+    renderWithIntl(<SwipeDirectionOverlay direction="down" intensity={1} />);
     const label = screen.getByText("Hard");
     expect(label.className).toContain("border-sky-500");
     expect(label.className).toContain("bg-sky-500/10");
@@ -38,7 +61,7 @@ describe("SwipeDirectionOverlay — color class mapping", () => {
   });
 
   it("applies emerald classes for direction right", () => {
-    render(<SwipeDirectionOverlay direction="right" intensity={1} />);
+    renderWithIntl(<SwipeDirectionOverlay direction="right" intensity={1} />);
     const label = screen.getByText("Easy");
     expect(label.className).toContain("border-emerald-500");
     expect(label.className).toContain("bg-emerald-500/10");
@@ -53,34 +76,38 @@ describe("SwipeDirectionOverlay — intensity clamping and opacity formula", () 
   }
 
   it("sets opacity to 0.25 when intensity is 0", () => {
-    const { container } = render(<SwipeDirectionOverlay direction="right" intensity={0} />);
+    const { container } = renderWithIntl(<SwipeDirectionOverlay direction="right" intensity={0} />);
     expect(getInnerDiv(container).style.opacity).toBe("0.25");
   });
 
   it("sets opacity to 1 when intensity is 1", () => {
-    const { container } = render(<SwipeDirectionOverlay direction="right" intensity={1} />);
+    const { container } = renderWithIntl(<SwipeDirectionOverlay direction="right" intensity={1} />);
     expect(getInnerDiv(container).style.opacity).toBe("1");
   });
 
   it("sets opacity to 0.625 when intensity is 0.5", () => {
-    const { container } = render(<SwipeDirectionOverlay direction="right" intensity={0.5} />);
+    const { container } = renderWithIntl(
+      <SwipeDirectionOverlay direction="right" intensity={0.5} />,
+    );
     expect(getInnerDiv(container).style.opacity).toBe("0.625");
   });
 
   it("clamps intensity above 1 to 1 (opacity = 1)", () => {
-    const { container } = render(<SwipeDirectionOverlay direction="right" intensity={2} />);
+    const { container } = renderWithIntl(<SwipeDirectionOverlay direction="right" intensity={2} />);
     expect(getInnerDiv(container).style.opacity).toBe("1");
   });
 
   it("clamps intensity below 0 to 0 (opacity = 0.25)", () => {
-    const { container } = render(<SwipeDirectionOverlay direction="right" intensity={-1} />);
+    const { container } = renderWithIntl(
+      <SwipeDirectionOverlay direction="right" intensity={-1} />,
+    );
     expect(getInnerDiv(container).style.opacity).toBe("0.25");
   });
 });
 
 describe("SwipeDirectionOverlay — null direction", () => {
   it("returns null (empty DOM) when direction is null", () => {
-    const { container } = render(<SwipeDirectionOverlay direction={null} intensity={1} />);
+    const { container } = renderWithIntl(<SwipeDirectionOverlay direction={null} intensity={1} />);
     expect(container).toBeEmptyDOMElement();
   });
 });

--- a/frontend/src/components/learn/swipe-direction-overlay.tsx
+++ b/frontend/src/components/learn/swipe-direction-overlay.tsx
@@ -1,12 +1,15 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { cn } from "@/lib/utils";
-import type { SwipeDirection } from "./types";
+import { RATING_META, type RatingTone, type SwipeDirection } from "./types";
 
-const hints: Record<SwipeDirection, { label: string; className: string }> = {
-  left: { label: "Again", className: "border-red-500 bg-red-500/10 text-red-700" },
-  down: { label: "Hard", className: "border-sky-500 bg-sky-500/10 text-sky-700" },
-  right: { label: "Easy", className: "border-emerald-500 bg-emerald-500/10 text-emerald-700" },
+// Overlay-chip color classes keyed by the shared rating tone. These differ from
+// the action bar's circular-button classes, so they stay local to this component.
+const TONE_CLASS: Record<RatingTone, string> = {
+  again: "border-red-500 bg-red-500/10 text-red-700",
+  hard: "border-sky-500 bg-sky-500/10 text-sky-700",
+  easy: "border-emerald-500 bg-emerald-500/10 text-emerald-700",
 };
 
 type Props = {
@@ -15,8 +18,9 @@ type Props = {
 };
 
 export function SwipeDirectionOverlay({ direction, intensity }: Props) {
+  const t = useTranslations("Learn");
   if (!direction) return null;
-  const hint = hints[direction];
+  const { labelKey, tone } = RATING_META[direction];
   const clamped = Math.max(0, Math.min(intensity, 1));
 
   return (
@@ -24,11 +28,11 @@ export function SwipeDirectionOverlay({ direction, intensity }: Props) {
       <div
         className={cn(
           "rounded-xl border-2 px-10 py-6 text-2xl font-semibold uppercase tracking-wide shadow-sm transition-opacity",
-          hint.className,
+          TONE_CLASS[tone],
         )}
         style={{ opacity: 0.25 + clamped * 0.75 }}
       >
-        {hint.label}
+        {t(labelKey)}
       </div>
     </div>
   );

--- a/frontend/src/components/learn/types.ts
+++ b/frontend/src/components/learn/types.ts
@@ -12,6 +12,28 @@
 export type SwipeDirection = "left" | "right" | "down";
 
 /**
+ * Color/label identity shared by a rating across surfaces. The string also
+ * doubles as the next-intl message key under the `Learn` namespace
+ * (`again`/`hard`/`easy`), so a single token drives both the localized label
+ * and the per-surface color class map.
+ */
+export type RatingTone = "again" | "hard" | "easy";
+
+/**
+ * Single source of truth for the swipe-rating semantics. Both `LearnActionBar`
+ * and `SwipeDirectionOverlay` read the label key and color tone from here so a
+ * rating's wording or color identity is defined once. Each surface keeps its
+ * own literal Tailwind class strings keyed by `tone` (a 56px circular button's
+ * classes differ from the overlay chip's) — only the label + color *identity*
+ * is shared, not the literal classes.
+ */
+export const RATING_META: Record<SwipeDirection, { labelKey: RatingTone; tone: RatingTone }> = {
+  left: { labelKey: "again", tone: "again" },
+  down: { labelKey: "hard", tone: "hard" },
+  right: { labelKey: "easy", tone: "easy" },
+};
+
+/**
  * Re-export of the generated GraphQL `LearnDisplayMode` enum so the schema is
  * the single source of truth and the component layer can never drift from it.
  */


### PR DESCRIPTION
## Summary

The swipe-rating semantics (`left=Again`, `down=Hard`, `right=Easy`) and their color identity were encoded twice — once in `LearnActionBar`, once in `SwipeDirectionOverlay` — so changing a rating's label or color meant editing both. Worse, `SwipeDirectionOverlay` rendered hardcoded English labels (`"Again"`/`"Hard"`/`"Easy"`), bypassing next-intl while the action bar localized the same words — a user-visible i18n defect under the Japanese locale. Both files also carried dead `dark:` Tailwind variants (the app is light-only).

This introduces a single source of truth for the label key + color tone and localizes the overlay's labels.

## Changes

- **`components/learn/types.ts`** — Add `RatingTone` (`"again" | "hard" | "easy"`) and `RATING_META: Record<SwipeDirection, { labelKey; tone }>`, the single source of truth mapping each direction to its message key and color tone.
- **`components/learn/learn-action-bar.tsx`** — Derive `labelKey`/`tone` from `RATING_META[direction]`; keep the 56px circular-button class strings in a local `TONE_CLASS` map keyed by `tone`. Drop the dead `dark:` variants.
- **`components/learn/swipe-direction-overlay.tsx`** — Add `useTranslations("Learn")` and render `t(RATING_META[direction].labelKey)` instead of the hardcoded English label; key the chip classes off a local `TONE_CLASS` map. Drop the dead `dark:` variants.
- **`components/learn/swipe-direction-overlay.test.tsx`** — Render through the `renderWithIntl` harness; keep the en-locale label/color/opacity assertions and add a ja-locale case that asserts the overlay renders the localized labels (read from the `ja` catalog, so no CJK literals in the source) and that no English literal leaks through.

No new message keys were needed — the overlay reuses the existing `Learn.again`/`hard`/`easy` keys. Only `label` + color `identity` are shared; each surface keeps its own literal Tailwind classes (the button and the chip genuinely differ).

## Test plan

- `pnpm --filter frontend typecheck` — pass (exit 0).
- `pnpm --filter frontend lint` (`biome check --error-on-warnings .`) — pass (only pre-existing config-migration infos).
- `pnpm --filter frontend knip` — pass (only a pre-existing config hint, unrelated to this change).
- `pnpm --filter frontend exec vitest run src/components/learn/swipe-direction-overlay.test.tsx src/components/learn/learn-action-bar.test.tsx 'src/app/learn/[cardgroupId]/learn-client.test.tsx' 'src/app/learn/[cardgroupId]/practice-client.test.tsx' --maxWorkers=2` — 70 passed.
- CJK gate over the changed source + test files — prints nothing (no inline CJK introduced; ja copy lives in the catalog).

Closes #715
