### PR TITLE
fix(frontend): localize use-cards-connection fetchMore fallback message

### DIFF
--- a/frontend/src/app/cardgroups/[id]/cards/cards-client.test.tsx
+++ b/frontend/src/app/cardgroups/[id]/cards/cards-client.test.tsx
@@ -18,6 +18,7 @@ import {
   type ApolloMockLeakSpyResult,
   installApolloMockLeakSpy,
 } from "../../../../../__tests__/utils/mock-apollo-paginated";
+import jaMessages from "../../../../../messages/ja.json";
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -1572,6 +1573,66 @@ describe("<CardsClient>", () => {
     });
     // Banner cleared after success.
     expect(screen.queryByTestId("cards-fetch-more-error")).not.toBeInTheDocument();
+  });
+
+  // T4b: localized fetchMore fallback. A field-level-only error is the one
+  // shape getBackendErrorBanner returns undefined for, so the hook falls back
+  // to the caller-supplied `t("fetchMoreFailed")`. Rendered under the ja locale
+  // to prove the consumer wires the localized string (a plain network error
+  // would hit getBackendErrorBanner's own mapping and never reach the fallback).
+  it("renders the localized fetchMore-failure banner under the ja locale", async () => {
+    const cache = new InMemoryCache();
+    const page1 = connection([CARD_1, CARD_2], true);
+    cache.writeQuery({
+      query: CardsByCardgroupConnectionDocument,
+      variables: DEFAULT_VARS,
+      data: { cardsByCardgroupConnection: page1 },
+    });
+
+    const initialMock = {
+      request: { query: CardsByCardgroupConnectionDocument, variables: DEFAULT_VARS },
+      result: { data: { cardsByCardgroupConnection: page1 } },
+    };
+
+    const { CombinedGraphQLErrors } = await import("@apollo/client/errors");
+    const fieldOnlyError = new CombinedGraphQLErrors({
+      data: null,
+      errors: [{ message: "bad input", extensions: { code: "BAD_USER_INPUT", field: "search" } }],
+    });
+    const fetchMoreErrorMock = {
+      request: {
+        query: CardsByCardgroupConnectionDocument,
+        variables: { ...DEFAULT_VARS, after: CARD_2.id },
+      },
+      error: fieldOnlyError,
+    };
+
+    renderWithIntl(
+      <MockedProvider mocks={[initialMock, fetchMoreErrorMock] as never} cache={cache}>
+        <UndoDeleteProvider>
+          <CardsClient
+            cardgroupId={CG_ID}
+            cardgroupName="Test Cardgroup"
+            initialEdges={page1.edges}
+            initialPageInfo={page1.pageInfo}
+            initialTotalCount={page1.totalCount}
+          />
+        </UndoDeleteProvider>
+      </MockedProvider>,
+      { locale: "ja", messages: jaMessages },
+    );
+
+    expect(await screen.findByText("Hello")).toBeInTheDocument();
+
+    // Drive the sentinel into view → fetchMore fires and fails field-only.
+    fireIntersect();
+
+    const banner = await screen.findByTestId("cards-fetch-more-error");
+    // The localized ja copy now flows through next-intl rather than the old
+    // hardcoded English literal. Reference the catalog string to keep CJK out
+    // of source (language-policy), and assert the old English literal is absent.
+    expect(banner).toHaveTextContent(jaMessages.Cards.fetchMoreFailed);
+    expect(banner).not.toHaveTextContent("Could not load more cards");
   });
 
   // T5: closeOtherRows is the parent-side wiring; the SwipeableRow mock

--- a/frontend/src/app/cardgroups/[id]/cards/cards-client.tsx
+++ b/frontend/src/app/cardgroups/[id]/cards/cards-client.tsx
@@ -46,6 +46,7 @@ export function CardsClient({
     initialEdges,
     initialPageInfo,
     initialTotalCount,
+    fetchMoreErrorMessage: t("fetchMoreFailed"),
   });
 
   const mutations = useCardMutations({ cardgroupId, queryVariables: connection.queryVariables });

--- a/frontend/src/app/cardgroups/[id]/cards/use-cards-connection.test.ts
+++ b/frontend/src/app/cardgroups/[id]/cards/use-cards-connection.test.ts
@@ -167,7 +167,13 @@ type HookProps = {
   initialEdges: ReturnType<typeof connection>["edges"];
   initialPageInfo: ReturnType<typeof connection>["pageInfo"];
   initialTotalCount: number;
+  fetchMoreErrorMessage: string;
 };
+
+// Sentinel for the localized fetchMore fallback. The hook now requires the
+// caller to pass this in; the rendered-copy assertion lives in the consumer
+// test (cards-client.test.tsx) under the ja locale.
+const FETCH_MORE_MSG = "Could not load more cards. Please try again.";
 
 type HarnessOptions = {
   mocks: ReadonlyArray<unknown>;
@@ -218,6 +224,7 @@ function renderUseCardsConnection(opts: HarnessOptions) {
     initialEdges: seed.edges,
     initialPageInfo: seed.pageInfo,
     initialTotalCount: seed.totalCount,
+    fetchMoreErrorMessage: FETCH_MORE_MSG,
   };
 
   const wrap = (props: HookProps): ReactNode =>
@@ -534,6 +541,7 @@ describe("useCardsConnection", () => {
       initialEdges: page1.edges,
       initialPageInfo: page1.pageInfo,
       initialTotalCount: page1.totalCount,
+      fetchMoreErrorMessage: FETCH_MORE_MSG,
     });
 
     await waitFor(() => {
@@ -643,6 +651,7 @@ describe("useCardsConnection", () => {
       initialEdges: page1.edges,
       initialPageInfo: page1.pageInfo,
       initialTotalCount: page1.totalCount,
+      fetchMoreErrorMessage: FETCH_MORE_MSG,
     });
 
     // During the in-flight window: networkStatus is setVariables (not fetchMore),

--- a/frontend/src/app/cardgroups/[id]/cards/use-cards-connection.ts
+++ b/frontend/src/app/cardgroups/[id]/cards/use-cards-connection.ts
@@ -21,6 +21,12 @@ export interface UseCardsConnectionInput {
   initialEdges: CardEdge[];
   initialPageInfo: CardConnectionPageInfo;
   initialTotalCount: number;
+  /**
+   * Localized fallback banner for a fetchMore failure with no backend-mapped
+   * message. The hook is not a component and cannot call `useTranslations`, so
+   * the client passes the localized string in (mirrors `useMasterCardsConnection`).
+   */
+  fetchMoreErrorMessage: string;
 }
 
 export type UseCardsConnectionResult = UseConnectionPaginationResult<
@@ -50,7 +56,14 @@ function mergeCardsConnection(
 // pagination-rule invariants (in-flight guard, Effect Event observer advance,
 // split debounce-vs-immediate-reset) live in the generic hook.
 export function useCardsConnection(input: UseCardsConnectionInput): UseCardsConnectionResult {
-  const { cardgroupId, searchQuery, initialEdges, initialPageInfo, initialTotalCount } = input;
+  const {
+    cardgroupId,
+    searchQuery,
+    initialEdges,
+    initialPageInfo,
+    initialTotalCount,
+    fetchMoreErrorMessage,
+  } = input;
 
   // When searchQuery is null we use cardsDefaultVars verbatim so the cache key
   // matches the SSR seed exactly. For non-null searches we spread and override
@@ -88,8 +101,7 @@ export function useCardsConnection(input: UseCardsConnectionInput): UseCardsConn
     buildFetchMoreVariables,
     mergeConnection: mergeCardsConnection,
     initial: { edges: initialEdges, pageInfo: initialPageInfo, totalCount: initialTotalCount },
-    resolveFetchMoreError: (err) =>
-      getBackendErrorBanner(err) ?? "Could not load more cards. Please try again.",
+    resolveFetchMoreError: (err) => getBackendErrorBanner(err) ?? fetchMoreErrorMessage,
     logScope: "[cards-client]",
   });
 }


### PR DESCRIPTION
## Summary

`useCardsConnection` hardcoded an **English** fetchMore fallback message, so a Japanese-locale user who hit a field-level fetchMore error on `/cardgroups/[id]/cards` saw English text. The two sibling card-connection hooks (`useCatalogCardsConnection`, `useMasterCardsConnection`) already accept a localized `fetchMoreErrorMessage` prop, and the pagination rule flags this site as "legacy debt, not the pattern to copy." This closes the localization gap so all three hooks are shape-identical.

## Changes

- `use-cards-connection.ts`: added `fetchMoreErrorMessage: string` to `UseCardsConnectionInput` (mirrors `useMasterCardsConnection`), destructured it, and changed the resolver to `getBackendErrorBanner(err) ?? fetchMoreErrorMessage` — no more hardcoded English literal.
- `cards-client.tsx`: passes `fetchMoreErrorMessage: t("fetchMoreFailed")` into `useCardsConnection({...})` (`t = useTranslations("Cards")` was already in scope). The `Cards.fetchMoreFailed` key already exists in both message catalogs.
- `cards-client.test.tsx`: added a consumer-level test that renders `CardsClient` under the `ja` locale, drives a field-level-only `BAD_USER_INPUT` fetchMore error (the one shape `getBackendErrorBanner` returns `undefined` for), and asserts the banner shows the localized `Cards.fetchMoreFailed` copy and not the old English literal — mirroring `master-cards-client.test.tsx`.
- `use-cards-connection.test.ts`: threaded the now-required `fetchMoreErrorMessage` through the test harness `HookProps` and its `rerender` call sites.

## Test plan

- `pnpm --filter frontend typecheck` — pass.
- `pnpm --filter frontend lint` — pass (only the pre-existing biome.json deprecation infos).
- `pnpm --filter frontend knip` — pass (only a pre-existing config hint).
- `vitest run` on `cards-client.test.tsx`, `use-cards-connection.test.ts`, `__tests__/cards-pagination.test.tsx`, `__tests__/cards-bulk-delete.test.tsx` — 66 passed.
- CJK gate on changed source — clean (the ja copy is referenced via `jaMessages.Cards.fetchMoreFailed`, never inlined).

Closes #714
