### PR TITLE
refactor(frontend): adopt useSheetForm in three low-risk create/edit sheets

### DIFF
--- a/frontend/src/app/admin/masters/[id]/edit/master-edit-header.tsx
+++ b/frontend/src/app/admin/masters/[id]/edit/master-edit-header.tsx
@@ -28,6 +28,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { FormSheet } from "@/components/ui/form-sheet";
 import { SplitButtonMenu } from "@/components/ui/split-button-menu";
+import { useSheetForm } from "@/lib/forms/use-sheet-form";
 import { cn } from "@/lib/utils";
 import type { AdminMasterDeck } from "./queries";
 
@@ -51,12 +52,17 @@ export function MasterEditHeader({ master, cardCount, onBatchImport }: Props) {
 
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [settingsDirty, setSettingsDirty] = useState(false);
-  const [validationError, setValidationError] = useState<{ field: string; message: string } | null>(
-    null,
-  );
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [publishing, setPublishing] = useState(false);
+
+  const onSettingsSaved = useCallback(() => {
+    toast.success(t("updateSuccess"));
+    setSettingsDirty(false);
+    setSettingsOpen(false);
+    router.refresh();
+  }, [t, router]);
+  const { validationError, run, clearValidationError } = useSheetForm(onSettingsSaved);
 
   const { updateMaster, deleteMaster, publishMaster, unpublishMaster, updating } =
     useMasterMutations();
@@ -73,17 +79,11 @@ export function MasterEditHeader({ master, cardCount, onBatchImport }: Props) {
 
   const handleUpdate = useCallback(
     async (values: MasterFormValues) => {
-      setValidationError(null);
-      const outcome = await updateMaster(master.id, values);
+      const outcome = await run(() => updateMaster(master.id, values));
       switch (outcome.status) {
         case "validation":
-          setValidationError({ field: outcome.field, message: outcome.message });
-          return;
         case "success":
-          toast.success(t("updateSuccess"));
-          setSettingsDirty(false);
-          setSettingsOpen(false);
-          router.refresh();
+          // `run` stored the field error / fired `onSettingsSaved` respectively.
           return;
         case "auth":
           authToast(outcome.kind);
@@ -92,7 +92,7 @@ export function MasterEditHeader({ master, cardCount, onBatchImport }: Props) {
           toast.error(t("unexpectedError"));
       }
     },
-    [master.id, updateMaster, t, authToast, router],
+    [master.id, updateMaster, run, t, authToast],
   );
 
   const handlePublishToggle = useCallback(async () => {
@@ -333,7 +333,7 @@ export function MasterEditHeader({ master, cardCount, onBatchImport }: Props) {
         open={settingsOpen}
         onOpenChange={(next) => {
           if (!next) {
-            setValidationError(null);
+            clearValidationError();
             setSettingsDirty(false);
             setSettingsOpen(false);
           }

--- a/frontend/src/app/cardgroups/new/new-cardgroup-client.tsx
+++ b/frontend/src/app/cardgroups/new/new-cardgroup-client.tsx
@@ -3,11 +3,12 @@
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import { useCreateCardgroup } from "@/app/cardgroups/use-create-cardgroup";
 import { FlamingoMark } from "@/components/brand/flamingo-mark";
 import { CardgroupForm } from "@/components/cardgroups/cardgroup-form";
 import { ErrorBanner } from "@/components/ui/error-banner";
+import { useSheetForm } from "@/lib/forms/use-sheet-form";
 
 interface NewCardgroupClientProps {
   showWelcome?: boolean;
@@ -19,13 +20,6 @@ export function NewCardgroupClient({ showWelcome = false, returnTo }: NewCardgro
   const router = useRouter();
   const t = useTranslations("Cardgroups");
   const tCommon = useTranslations("Common");
-
-  // Typed InputValidationError variant — field-level validation failure
-  // surfaced by the server. Cleared on each new submission attempt.
-  const [validationError, setValidationError] = useState<{
-    field: string;
-    message: string;
-  } | null>(null);
 
   // Semantically distinct from validationError: this surfaces a degraded
   // "Something went wrong" banner when the server returns a __typename the
@@ -46,17 +40,23 @@ export function NewCardgroupClient({ showWelcome = false, returnTo }: NewCardgro
 
   const { create, loading } = useCreateCardgroup();
 
+  // Full-page create: success navigates away (parameterized by the returned
+  // cardgroup id), so the `success` arm stays in the switch below. `useSheetForm`
+  // owns only the field-level `validationError` + its clear-on-submit reset;
+  // there is no sheet to close, so `onSuccess` is a no-op.
+  const onSuccess = useCallback(() => undefined, []);
+  const { validationError, run } = useSheetForm(onSuccess);
+
   async function handleSubmit(values: { name: string }) {
-    setValidationError(null);
     setUnexpectedPayloadError(null);
     setAuthError(null);
     setLimitError(null);
 
-    const outcome = await create(values.name);
+    const outcome = await run(() => create(values.name));
 
     switch (outcome.status) {
       case "validation":
-        setValidationError({ field: outcome.field, message: outcome.message });
+        // `run` cleared and stored the field-level error.
         return;
       case "auth":
         setAuthError(outcome.kind);

--- a/frontend/src/app/learn/[cardgroupId]/_components/learn-add-card-sheet.tsx
+++ b/frontend/src/app/learn/[cardgroupId]/_components/learn-add-card-sheet.tsx
@@ -7,6 +7,7 @@ import { useCardMutations } from "@/app/cardgroups/[id]/cards/use-card-mutations
 import { CardForm } from "@/components/cardgroups/card-form";
 import { FormSheet, useFormSheetClose } from "@/components/ui/form-sheet";
 import { FLAMINGO_EVENT, subscribeFlamingo } from "@/lib/events/flamingo-events";
+import { useSheetForm } from "@/lib/forms/use-sheet-form";
 
 function AddCardSheetContent({
   submit,
@@ -52,10 +53,13 @@ export function LearnAddCardSheet({ cardgroupId }: { cardgroupId: string }) {
   const t = useTranslations("Cards");
   const [open, setOpen] = useState(false);
   const [dirty, setDirty] = useState(false);
-  const [validationError, setValidationError] = useState<{
-    field: string;
-    message: string;
-  } | null>(null);
+
+  const onSuccessClose = useCallback(() => {
+    setDirty(false);
+    setOpen(false);
+  }, []);
+  const { validationError, run, setValidationError, clearValidationError } =
+    useSheetForm(onSuccessClose);
 
   // The Learn screen has no cards-connection subscription of its own, so the
   // shared hook's create path seeds the cardgroup's default-vars connection
@@ -68,10 +72,10 @@ export function LearnAddCardSheet({ cardgroupId }: { cardgroupId: string }) {
 
   const openSheet = useCallback(() => {
     resetCreateCard();
-    setValidationError(null);
+    clearValidationError();
     setDirty(false);
     setOpen(true);
-  }, [resetCreateCard]);
+  }, [resetCreateCard, clearValidationError]);
 
   useEffect(() => {
     return subscribeFlamingo(FLAMINGO_EVENT.addCard, (detail, event) => {
@@ -83,15 +87,8 @@ export function LearnAddCardSheet({ cardgroupId }: { cardgroupId: string }) {
 
   async function handleCreate(values: { front: string; back: string }) {
     resetCreateCard();
-    setValidationError(null);
-    const outcome = await createCard(values);
-    if (outcome.status === "success") {
-      setDirty(false);
-      setValidationError(null);
-      setOpen(false);
-    } else if (outcome.status === "validation") {
-      setValidationError({ field: outcome.field, message: outcome.message });
-    } else if (outcome.status === "unexpected") {
+    const outcome = await run(() => createCard(values));
+    if (outcome.status === "unexpected") {
       setValidationError({ field: "front", message: t("addFailed") });
     }
     // outcome.status === "rejected": the hook already logged the rejection;
@@ -107,7 +104,7 @@ export function LearnAddCardSheet({ cardgroupId }: { cardgroupId: string }) {
         if (!nextOpen) {
           resetCreateCard();
           setDirty(false);
-          setValidationError(null);
+          clearValidationError();
         }
       }}
       submitting={creating}


### PR DESCRIPTION
## Summary

`useSheetForm` (`frontend/src/lib/forms/use-sheet-form.ts`) is a shared hook that owns one create/edit sheet's field-level `validationError` state and routes a mutation-outcome union (clear error → await → `success` → `onSuccess` / `validation` → store field error / else → return the outcome for the caller's screen-specific arms). It was consumed only via `useCardSheetForm` in `card-list-screen`; several other create/edit surfaces re-rolled the same `useState<{ field; message } | null>` + manual reset + success-close by hand.

This adopts `useSheetForm` in the three lowest-risk surfaces that no other batch issue touches, so it lands conflict-free. The entangled sheets (`admin-roles-client`, `admin-masters-client`, `cardgroups-client`) are deferred to a follow-up. Behavior is unchanged: each surface still shows the field error on validation failure, closes/navigates on success, and surfaces its own `auth` / `limit` / `unexpected` banners.

## Changes

### `learn-add-card-sheet.tsx`
- Replaced the local `validationError` `useState` + manual `setValidationError(null)` resets with `useSheetForm(onSuccessClose)`, where `onSuccessClose` clears the dirty flag and closes the sheet.
- `handleCreate` now routes through `await run(() => createCard(values))`; only the screen-specific `unexpected` arm (inline `front` fallback) is kept at the call site. The `rejected` arm leaves the sheet open as before.
- The open and dismiss reset closures call `clearValidationError()`.

### `master-edit-header.tsx`
- Replaced the local `validationError` `useState` with `useSheetForm(onSettingsSaved)`, where `onSettingsSaved` fires the success toast, clears dirty, closes the settings sheet, and refreshes the route.
- `handleUpdate` now routes through `await run(() => updateMaster(...))`; `validation`/`success` are absorbed by `run`, and only the screen-specific `auth` and `unexpected` arms stay at the call site.
- The sheet dismiss reset closure calls `clearValidationError()`.

### `new-cardgroup-client.tsx`
- Replaced the local `validationError` `useState` with `useSheetForm(onSuccess)`. This is a full page (no sheet to close) whose success navigates using the returned cardgroup id, which the parameterless `onSuccess` cannot carry, so the `success` arm stays in the switch and `onSuccess` is a no-op.
- `handleSubmit` now routes through `await run(() => create(values.name))`; `validation` is absorbed by `run`, and the screen-specific `auth` / `limit` / `unexpected` / `rejected` / `success` arms stay at the call site reading `run`'s returned outcome.
- The multi-banner reset closures (auth / limit / unexpected) stay local.

No local `validationError` `useState` remains in any of the three files; their dirty-tracking and multi-banner reset closures stay local per the shared-hook contract.

## Test plan

- `pnpm --filter frontend typecheck` — pass
- `pnpm --filter frontend lint` — pass (only pre-existing biome config-version infos)
- `pnpm --filter frontend knip` — pass
- `vitest run` on the affected tests (both trees) — 71 passed:
  - `src/app/learn/[cardgroupId]/_components/learn-add-card-sheet.test.tsx`
  - `src/app/admin/masters/[id]/edit/master-edit-header.test.tsx`
  - `src/app/cardgroups/new/page.test.tsx`
  - `src/app/cardgroups/cardgroups-client.test.tsx`
  - `__tests__/admin-master-cards.test.tsx`
- `vitest run src/lib/forms/use-sheet-form.test.ts` — 17 passed
- CJK gate over the three changed files — clean

Closes #719
