### PR TITLE
refactor(frontend): extract AdminListSearch from admin users/masters clients

### DIFF
--- a/frontend/src/app/admin/masters/admin-masters-client.tsx
+++ b/frontend/src/app/admin/masters/admin-masters-client.tsx
@@ -6,13 +6,12 @@ import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { useCallback, useMemo, useState } from "react";
 import { toast } from "sonner";
+import { AdminListSearch } from "@/components/admin/admin-list-search";
 import { AdminQueryErrorBanner } from "@/components/admin/admin-query-error-banner";
 import { ConnectionListFooter } from "@/components/layout/connection-list-footer";
 import { ListingPageShell } from "@/components/layout/listing-page-shell";
-import { SearchTakeoverBar } from "@/components/search/search-takeover-bar";
 import { Button } from "@/components/ui/button";
 import { FormSheet } from "@/components/ui/form-sheet";
-import { Input } from "@/components/ui/input";
 import type {
   AdminMastersQuery as AdminMastersQueryResult,
   AdminMastersQueryVariables,
@@ -131,106 +130,91 @@ export function AdminMastersClient() {
   if (initialLoading) return <AdminMastersSkeleton />;
 
   return (
-    <>
-      <SearchTakeoverBar
-        open={search.searchOpen}
-        value={search.input}
-        onChange={search.setInput}
-        onClear={search.clear}
-        onClose={search.closeSearch}
+    <ListingPageShell
+      title={t("title")}
+      count={totalCount}
+      countLabel={tCommon("totalCount", { count: totalCount })}
+      primaryActions={
+        <Button
+          type="button"
+          variant="brand"
+          className="hidden md:inline-flex"
+          data-testid="admin-masters-new-btn"
+          onClick={() => sheet.open({ mode: "new" })}
+        >
+          <span>{t("newMaster")}</span>
+          <Plus aria-hidden="true" />
+        </Button>
+      }
+    >
+      <AdminListSearch
+        search={search}
         placeholder={t("searchPlaceholder")}
         ariaLabel={t("searchLabel")}
       />
-      <ListingPageShell
-        title={t("title")}
-        count={totalCount}
-        countLabel={tCommon("totalCount", { count: totalCount })}
-        primaryActions={
-          <Button
-            type="button"
-            variant="brand"
-            className="hidden md:inline-flex"
-            data-testid="admin-masters-new-btn"
-            onClick={() => sheet.open({ mode: "new" })}
-          >
-            <span>{t("newMaster")}</span>
-            <Plus aria-hidden="true" />
-          </Button>
-        }
+
+      <AdminQueryErrorBanner
+        kind={queryErrorKind}
+        onRetry={refetch}
+        testId="admin-masters-query-error"
+        copy={{
+          viewForbidden: t("viewForbidden"),
+          sessionExpired: t("sessionExpired"),
+          signInAgain: t("pleaseSignInAgain"),
+          retry: tCommon("retry"),
+        }}
+      />
+
+      {!initialLoading && !queryErrorKind && edges.length === 0 && (
+        <p className="text-sm text-muted-foreground" data-testid="admin-masters-empty">
+          {t("noMastersFound")}
+        </p>
+      )}
+
+      {edges.length > 0 && (
+        <ul className="space-y-3" data-testid="admin-masters-list">
+          {edges.map((edge) => (
+            <AdminMasterRow key={edge.cursor} master={edge.node} />
+          ))}
+        </ul>
+      )}
+
+      <ConnectionListFooter
+        sentinelRef={sentinelRef}
+        fetchMoreError={fetchMoreError}
+        onRetry={retryFetchMore}
+        fetchingMore={fetchingMore}
+        hasNextPage={hasNextPage}
+        retryLabel={tCommon("retry")}
+        loadingMoreLabel={t("loadingMore")}
+        testIdPrefix="admin-masters"
+      />
+
+      <FormSheet
+        title={t("createMasterTitle")}
+        open={sheet.state.mode === "new"}
+        onOpenChange={(next) => {
+          if (!next) {
+            resetCreate();
+            setCreateValidationError(null);
+            setCreateDirty(false);
+            sheet.close();
+          }
+        }}
+        submitting={creating}
+        dirty={createDirty}
+        confirmOnDismiss
       >
-        <div className="hidden md:block">
-          <Input
-            type="search"
-            placeholder={t("searchPlaceholder")}
-            value={search.input}
-            onChange={(e) => search.setInput(e.target.value)}
-            aria-label={t("searchLabel")}
+        {sheet.state.mode === "new" ? (
+          <AdminMasterForm
+            mode="create"
+            submitting={creating}
+            submit={handleCreate}
+            validationError={createValidationError}
+            onDirtyChange={setCreateDirty}
           />
-        </div>
-
-        <AdminQueryErrorBanner
-          kind={queryErrorKind}
-          onRetry={refetch}
-          testId="admin-masters-query-error"
-          copy={{
-            viewForbidden: t("viewForbidden"),
-            sessionExpired: t("sessionExpired"),
-            signInAgain: t("pleaseSignInAgain"),
-            retry: tCommon("retry"),
-          }}
-        />
-
-        {!initialLoading && !queryErrorKind && edges.length === 0 && (
-          <p className="text-sm text-muted-foreground" data-testid="admin-masters-empty">
-            {t("noMastersFound")}
-          </p>
-        )}
-
-        {edges.length > 0 && (
-          <ul className="space-y-3" data-testid="admin-masters-list">
-            {edges.map((edge) => (
-              <AdminMasterRow key={edge.cursor} master={edge.node} />
-            ))}
-          </ul>
-        )}
-
-        <ConnectionListFooter
-          sentinelRef={sentinelRef}
-          fetchMoreError={fetchMoreError}
-          onRetry={retryFetchMore}
-          fetchingMore={fetchingMore}
-          hasNextPage={hasNextPage}
-          retryLabel={tCommon("retry")}
-          loadingMoreLabel={t("loadingMore")}
-          testIdPrefix="admin-masters"
-        />
-
-        <FormSheet
-          title={t("createMasterTitle")}
-          open={sheet.state.mode === "new"}
-          onOpenChange={(next) => {
-            if (!next) {
-              resetCreate();
-              setCreateValidationError(null);
-              setCreateDirty(false);
-              sheet.close();
-            }
-          }}
-          submitting={creating}
-          dirty={createDirty}
-          confirmOnDismiss
-        >
-          {sheet.state.mode === "new" ? (
-            <AdminMasterForm
-              mode="create"
-              submitting={creating}
-              submit={handleCreate}
-              validationError={createValidationError}
-              onDirtyChange={setCreateDirty}
-            />
-          ) : null}
-        </FormSheet>
-      </ListingPageShell>
-    </>
+        ) : null}
+      </FormSheet>
+    </ListingPageShell>
   );
 }

--- a/frontend/src/app/admin/users/admin-users-client.tsx
+++ b/frontend/src/app/admin/users/admin-users-client.tsx
@@ -5,10 +5,10 @@ import { useLazyQuery, useQuery } from "@apollo/client/react";
 import { useTranslations } from "next-intl";
 import { useCallback, useEffect, useMemo } from "react";
 import { toast } from "sonner";
+import { AdminListSearch } from "@/components/admin/admin-list-search";
 import { AdminQueryErrorBanner } from "@/components/admin/admin-query-error-banner";
 import { ConnectionListFooter } from "@/components/layout/connection-list-footer";
 import { ListingPageShell } from "@/components/layout/listing-page-shell";
-import { SearchTakeoverBar } from "@/components/search/search-takeover-bar";
 import { ErrorBanner } from "@/components/ui/error-banner";
 import { useFragment } from "@/generated/fragment-masking";
 import type {
@@ -232,35 +232,19 @@ export function AdminUsersClient() {
   }
 
   return (
-    <>
-      <SearchTakeoverBar
-        open={search.searchOpen}
-        value={search.input}
-        onChange={search.setInput}
-        onClear={search.clear}
-        onClose={search.closeSearch}
-        placeholder={t("searchPlaceholder")}
-        ariaLabel={t("searchLabel")}
-      />
-      <ListingPageShell
-        title={tNav("users")}
-        count={totalCount}
-        countLabel={tCommon("totalCount", { count: totalCount })}
-        toolbar={
-          // Desktop-only search input; mobile uses the header takeover above.
-          <div className="hidden md:block">
-            <input
-              type="search"
-              placeholder={t("searchPlaceholder")}
-              value={search.input}
-              onChange={(e) => search.setInput(e.target.value)}
-              className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
-              aria-label={t("searchLabel")}
-            />
-          </div>
-        }
-      >
-        {/*
+    <ListingPageShell
+      title={tNav("users")}
+      count={totalCount}
+      countLabel={tCommon("totalCount", { count: totalCount })}
+      toolbar={
+        <AdminListSearch
+          search={search}
+          placeholder={t("searchPlaceholder")}
+          ariaLabel={t("searchLabel")}
+        />
+      }
+    >
+      {/*
         Admin users query-error banner. UNAUTHENTICATED here means the session
         expired mid-page: the server-side gate in page.tsx + the admin layout
         block the initial load (redirecting to "/"), so the degraded /login
@@ -268,71 +252,70 @@ export function AdminUsersClient() {
         re-issuing the same query would fail again. See
         .claude/rules/frontend-rsc-error-handling.md.
       */}
-        <AdminQueryErrorBanner
-          kind={queryErrorKind}
-          onRetry={refetch}
-          testId="admin-users-query-error"
-          className="mb-4"
-          copy={{
-            viewForbidden: t("viewForbidden"),
-            sessionExpired: t("sessionExpired"),
-            signInAgain: t("pleaseSignInAgain"),
-            retry: tCommon("retry"),
-          }}
-        />
+      <AdminQueryErrorBanner
+        kind={queryErrorKind}
+        onRetry={refetch}
+        testId="admin-users-query-error"
+        className="mb-4"
+        copy={{
+          viewForbidden: t("viewForbidden"),
+          sessionExpired: t("sessionExpired"),
+          signInAgain: t("pleaseSignInAgain"),
+          retry: tCommon("retry"),
+        }}
+      />
 
-        {rolesBannerError && (
-          <ErrorBanner className="mb-4" data-testid="admin-users-roles-error">
-            {rolesBannerError}
-          </ErrorBanner>
-        )}
+      {rolesBannerError && (
+        <ErrorBanner className="mb-4" data-testid="admin-users-roles-error">
+          {rolesBannerError}
+        </ErrorBanner>
+      )}
 
-        {/* Empty state */}
-        {!initialLoading && !queryErrorKind && edges.length === 0 && (
-          <p className="text-sm text-muted-foreground" data-testid="admin-users-empty">
-            {t("noUsersFound")}
-          </p>
-        )}
+      {/* Empty state */}
+      {!initialLoading && !queryErrorKind && edges.length === 0 && (
+        <p className="text-sm text-muted-foreground" data-testid="admin-users-empty">
+          {t("noUsersFound")}
+        </p>
+      )}
 
-        {/* User list */}
-        {edges.length > 0 && (
-          <ul className="space-y-3" data-testid="admin-users-list">
-            {edges.map((edge) => (
-              <UserRow
-                key={edge.cursor}
-                edge={edge}
-                onEdit={(id) => sheet.open({ mode: "edit", id })}
-              />
-            ))}
-          </ul>
-        )}
+      {/* User list */}
+      {edges.length > 0 && (
+        <ul className="space-y-3" data-testid="admin-users-list">
+          {edges.map((edge) => (
+            <UserRow
+              key={edge.cursor}
+              edge={edge}
+              onEdit={(id) => sheet.open({ mode: "edit", id })}
+            />
+          ))}
+        </ul>
+      )}
 
-        <ConnectionListFooter
-          sentinelRef={sentinelRef}
-          fetchMoreError={fetchMoreError}
-          onRetry={retryFetchMore}
-          fetchingMore={fetchingMore}
-          hasNextPage={hasNextPage}
-          retryLabel={tCommon("retry")}
-          loadingMoreLabel={t("loadingMore")}
-          testIdPrefix="admin-users"
-        />
+      <ConnectionListFooter
+        sentinelRef={sentinelRef}
+        fetchMoreError={fetchMoreError}
+        onRetry={retryFetchMore}
+        fetchingMore={fetchingMore}
+        hasNextPage={hasNextPage}
+        retryLabel={tCommon("retry")}
+        loadingMoreLabel={t("loadingMore")}
+        testIdPrefix="admin-users"
+      />
 
-        <AdminUserProfileSheet
-          open={editUserId !== null}
-          user={sheetUser}
-          loading={
-            editUserLoading ||
-            (editUserId !== null && (!editUserCalled || !editUserResultMatchesSheet))
-          }
-          allRoles={roleOptions}
-          queryError={editUserBannerError}
-          onDismiss={() => sheet.close()}
-          onSaved={() => sheet.close({ refresh: true })}
-          onReloadRequested={reloadEditedUser}
-          onDelete={handleDeleteUser}
-        />
-      </ListingPageShell>
-    </>
+      <AdminUserProfileSheet
+        open={editUserId !== null}
+        user={sheetUser}
+        loading={
+          editUserLoading ||
+          (editUserId !== null && (!editUserCalled || !editUserResultMatchesSheet))
+        }
+        allRoles={roleOptions}
+        queryError={editUserBannerError}
+        onDismiss={() => sheet.close()}
+        onSaved={() => sheet.close({ refresh: true })}
+        onReloadRequested={reloadEditedUser}
+        onDelete={handleDeleteUser}
+      />
+    </ListingPageShell>
   );
 }

--- a/frontend/src/components/admin/admin-list-search.tsx
+++ b/frontend/src/components/admin/admin-list-search.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { SearchTakeoverBar } from "@/components/search/search-takeover-bar";
+import { Input } from "@/components/ui/input";
+import type { useHeaderTakeoverSearch } from "@/hooks/use-header-takeover-search";
+
+interface AdminListSearchProps {
+  /** The header-takeover search instance owned by the consuming client. */
+  search: ReturnType<typeof useHeaderTakeoverSearch>;
+  /** Field placeholder — caller-specific copy. */
+  placeholder: string;
+  /** Field aria-label — caller-specific copy. */
+  ariaLabel: string;
+}
+
+/**
+ * Search controls shared by the paginated admin list screens (users, masters).
+ * Renders the mobile header-takeover bar plus the desktop search box, both wired
+ * to the caller's `useHeaderTakeoverSearch` instance. The client still owns the
+ * hook; this component only renders its value/onChange/open state. The desktop
+ * box uses the design-system `<Input>` so the two screens stay consistent.
+ */
+export function AdminListSearch({ search, placeholder, ariaLabel }: AdminListSearchProps) {
+  return (
+    <>
+      <SearchTakeoverBar
+        open={search.searchOpen}
+        value={search.input}
+        onChange={search.setInput}
+        onClear={search.clear}
+        onClose={search.closeSearch}
+        placeholder={placeholder}
+        ariaLabel={ariaLabel}
+      />
+      {/* Desktop-only search input; mobile uses the header takeover above. */}
+      <div className="hidden md:block">
+        <Input
+          type="search"
+          placeholder={placeholder}
+          value={search.input}
+          onChange={(e) => search.setInput(e.target.value)}
+          aria-label={ariaLabel}
+        />
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary

The two paginated admin screens (users, masters) both ran `useHeaderTakeoverSearch()` and rendered `SearchTakeoverBar` (mobile takeover) + a desktop search box with identical wiring — but disagreed on the box: users hand-coded a raw `<input type="search" className="...">`, a maintenance fork of the design-system input, while masters used the shared `<Input type="search">`. This extracts a shared `AdminListSearch` component, collapsing the duplication and fixing the inconsistency. The users desktop box now uses the design-system `<Input>`. Pure UI-wiring extraction — no search behavior or matcher change.

This is the safe first slice of the larger admin-list-scaffold extraction (the `PaginatedAdminListScreen` scaffold builds on it).

## Changes

### New shared component (`components/admin/admin-list-search.tsx`)

- `AdminListSearch({ search, placeholder, ariaLabel })` renders the mobile `SearchTakeoverBar` plus the desktop `<Input type="search">` (the shared component), both wired to the caller's `useHeaderTakeoverSearch` instance.
- The client still owns the hook; the component only renders its `searchOpen` / `input` / `setInput` / `clear` / `closeSearch` state. Seam: the whole `search` object is passed (typed `ReturnType<typeof useHeaderTakeoverSearch>`), matching how the clients read `search.*` elsewhere.

### `app/admin/users/admin-users-client.tsx`

- Replaced the standalone `<SearchTakeoverBar>` + raw `<input type="search" className="...">` toolbar with `<AdminListSearch search={search} ... />` in the `ListingPageShell` toolbar slot.
- The desktop box now renders the design-system `<Input>` — the bespoke className fork is gone.
- Dropped the now-unused `SearchTakeoverBar` import; removed the now-single-child wrapping fragment.

### `app/admin/masters/admin-masters-client.tsx`

- Replaced the standalone `<SearchTakeoverBar>` + `<Input type="search">` block with `<AdminListSearch search={search} ... />`.
- Dropped the now-unused `SearchTakeoverBar` and `Input` imports; removed the now-single-child wrapping fragment.

The bulk of the diff is reindentation from removing the redundant fragments; the semantic change is small.

## Test plan

- `pnpm --filter frontend typecheck` — clean.
- `pnpm --filter frontend lint` — clean (only pre-existing `biome.json` deprecation infos).
- `pnpm --filter frontend knip` — clean (only a pre-existing config hint).
- Affected tests in both trees (co-located + broad), 50 tests across 7 files, all green:
  - `src/app/admin/users/admin-users-client.test.tsx`, `src/app/admin/masters/admin-masters-client.test.tsx`
  - `src/app/admin/users/page.test.tsx`, `src/app/admin/masters/page.test.tsx`
  - `__tests__/admin-users-list.test.tsx`, `__tests__/admin-masters-list.test.tsx`
  - `src/app/pagination-ref-triplet-removal-rule.test.ts`
  - The users `searchbox` selector (`getByRole("searchbox", { name: /search users/i })`) resolves the shared `<Input>` unchanged — same role / `aria-label` / `type="search"`, parent still `hidden md:block`.
- CJK check (`perl -CSD`) on changed `.tsx` — clean; no committed generated code.

Closes #718
