### PR TITLE
refactor(frontend): extract shared SwipeSession shell for learn and practice clients

### DIFF
--- a/frontend/src/app/learn/[cardgroupId]/_components/learn-skeleton.tsx
+++ b/frontend/src/app/learn/[cardgroupId]/_components/learn-skeleton.tsx
@@ -1,15 +1,14 @@
+import { SWIPE_SESSION_GRID_CLASS } from "@/components/learn/swipe-session";
 import { Skeleton } from "@/components/ui/skeleton";
 
-// Shape mirrors the <LearnClient> layout (banner row, card area, action bar) so
-// the layout does not shift when streamed content replaces this placeholder.
-// Used by both loading.tsx (route-segment fallback) and the in-page <Suspense>.
+// Shape mirrors the shared <SwipeSession> layout (banner row, card area, action
+// bar) so the layout does not shift when streamed content replaces this
+// placeholder. The outer grid class is imported from <SwipeSession> so the two
+// can never drift. Used by both loading.tsx (route-segment fallback) and the
+// in-page <Suspense>.
 export function LearnSkeleton() {
   return (
-    <section
-      className="grid min-h-0 flex-1 grid-rows-[auto_1fr_auto] gap-3"
-      aria-busy="true"
-      aria-label="Loading flashcards"
-    >
+    <section className={SWIPE_SESSION_GRID_CLASS} aria-busy="true" aria-label="Loading flashcards">
       {/* Banner row — empty spacer matching LearnClient's no-banner state. */}
       <div aria-hidden="true" />
 

--- a/frontend/src/app/learn/[cardgroupId]/learn-client.tsx
+++ b/frontend/src/app/learn/[cardgroupId]/learn-client.tsx
@@ -10,9 +10,7 @@ import {
   SetLastViewedCardgroupMutation,
 } from "@/app/learn/queries";
 import { AllCaughtUp } from "@/components/learn/all-caught-up";
-import { LearnActionBar } from "@/components/learn/learn-action-bar";
-import type { SwipeCardStackHandle } from "@/components/learn/swipe-card-stack";
-import { SwipeCardStack } from "@/components/learn/swipe-card-stack";
+import { SwipeSession } from "@/components/learn/swipe-session";
 import type { LearnDisplayMode, SwipeDirection } from "@/components/learn/types";
 import { ErrorBanner } from "@/components/ui/error-banner";
 import type { LearnNextDueCardsQuery } from "@/generated/graphql";
@@ -53,7 +51,6 @@ export function LearnClient({ cardgroupId, initialCards, displayMode }: Props) {
   // (FSRS-safe re-study of today's cards). It is only entered from the
   // AllCaughtUp "Study again" action when the daily learn queue is exhausted.
   const [phase, setPhase] = useState<"learn" | "practice">("learn");
-  const swipeStackRef = useRef<SwipeCardStackHandle | null>(null);
 
   const [handleSwipe, { error }] = useMutation(HandleSwipeMutation);
   const backendError = useMemo(() => getBackendErrorBanner(error), [error]);
@@ -265,14 +262,6 @@ export function LearnClient({ cardgroupId, initialCards, displayMode }: Props) {
     [cardgroupId, handleSwipe],
   );
 
-  // SwipeCardStack owns the overlay paint + commit-delay timing internally,
-  // so handleRate only needs to forward the direction through the imperative
-  // handle. Keeping handleRate stable across renders preserves React.memo
-  // bailouts on LearnActionBar.
-  const handleRate = useCallback((direction: SwipeDirection) => {
-    swipeStackRef.current?.triggerSwipe(direction);
-  }, []);
-
   if (phase === "practice") {
     return <PracticeClient cardgroupId={cardgroupId} />;
   }
@@ -282,26 +271,18 @@ export function LearnClient({ cardgroupId, initialCards, displayMode }: Props) {
   }
 
   return (
-    <section className="grid min-h-0 flex-1 grid-rows-[auto_1fr_auto] gap-3">
-      {visibleError ? (
-        <ErrorBanner className="mx-auto w-full max-w-xl">{visibleError}</ErrorBanner>
-      ) : (
-        // Placeholder so the card stays in the 1fr row and the action bar in
-        // the trailing auto row when the banner is absent. Without it, grid
-        // auto-flow would assign the action bar to the 1fr row.
-        <div aria-hidden="true" />
-      )}
-
-      <div className="relative flex min-h-0 items-center justify-center overflow-hidden">
-        <SwipeCardStack
-          ref={swipeStackRef}
-          cards={queue}
-          displayMode={displayMode}
-          onCardSwiped={onSwipe}
-          completedCount={completed}
-        />
-      </div>
-      <LearnActionBar onRate={handleRate} disabled={queue.length === 0} />
-    </section>
+    <SwipeSession
+      cards={queue}
+      displayMode={displayMode}
+      onCardSwiped={onSwipe}
+      completedCount={completed}
+      // When no banner, SwipeSession renders an `aria-hidden` spacer in the
+      // leading row so the card and action bar keep their grid rows.
+      topSlot={
+        visibleError ? (
+          <ErrorBanner className="mx-auto w-full max-w-xl">{visibleError}</ErrorBanner>
+        ) : undefined
+      }
+    />
   );
 }

--- a/frontend/src/app/learn/[cardgroupId]/practice-client.tsx
+++ b/frontend/src/app/learn/[cardgroupId]/practice-client.tsx
@@ -5,9 +5,7 @@ import { useTranslations } from "next-intl";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { PracticeTodaysCardsQuery as PracticeTodaysCardsDocument } from "@/app/learn/queries";
 import { AllCaughtUp } from "@/components/learn/all-caught-up";
-import { LearnActionBar } from "@/components/learn/learn-action-bar";
-import type { SwipeCardStackHandle } from "@/components/learn/swipe-card-stack";
-import { SwipeCardStack } from "@/components/learn/swipe-card-stack";
+import { SwipeSession } from "@/components/learn/swipe-session";
 import type { SwipeDirection } from "@/components/learn/types";
 import { Button } from "@/components/ui/button";
 import { ErrorBanner } from "@/components/ui/error-banner";
@@ -87,17 +85,11 @@ export function PracticeClient({ cardgroupId }: { cardgroupId: string }) {
     });
   }, [error, cardgroupId]);
 
-  const swipeStackRef = useRef<SwipeCardStackHandle | null>(null);
-
   const onCardSwiped = useCallback((card: PracticeCard, direction: SwipeDirection) => {
     // The ONLY effect of a practice swipe: re-arrange the local queue. No
     // mutation, no network. again/hard re-queue the card a few positions later;
     // easy retires it for the round.
     setQueue((current) => advancePracticeQueue(current, card.id, outcomeFromDirection(direction)));
-  }, []);
-
-  const handleRate = useCallback((direction: SwipeDirection) => {
-    swipeStackRef.current?.triggerSwipe(direction);
   }, []);
 
   const studyAgain = useCallback(() => {
@@ -179,23 +171,18 @@ export function PracticeClient({ cardgroupId }: { cardgroupId: string }) {
   }
 
   return (
-    <section className="grid min-h-0 flex-1 grid-rows-[auto_1fr_auto] gap-3">
-      <div
-        className="mx-auto w-full max-w-xl rounded-md border border-border bg-muted/30 p-3 text-sm text-muted-foreground"
-        role="status"
-      >
-        {t("practiceBanner")}
-      </div>
-
-      <div className="relative flex min-h-0 items-center justify-center overflow-hidden">
-        <SwipeCardStack
-          ref={swipeStackRef}
-          cards={queue}
-          displayMode="ALWAYS_VISIBLE"
-          onCardSwiped={onCardSwiped}
-        />
-      </div>
-      <LearnActionBar onRate={handleRate} disabled={queue.length === 0} />
-    </section>
+    <SwipeSession
+      cards={queue}
+      displayMode="ALWAYS_VISIBLE"
+      onCardSwiped={onCardSwiped}
+      topSlot={
+        <div
+          className="mx-auto w-full max-w-xl rounded-md border border-border bg-muted/30 p-3 text-sm text-muted-foreground"
+          role="status"
+        >
+          {t("practiceBanner")}
+        </div>
+      }
+    />
   );
 }

--- a/frontend/src/components/learn/swipe-session.test.tsx
+++ b/frontend/src/components/learn/swipe-session.test.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment happy-dom
+import { render, screen } from "@testing-library/react";
+import { type RefObject, useImperativeHandle, useRef } from "react";
+import { describe, expect, it, vi } from "vitest";
+import type { SwipeCardData } from "@/components/learn/swipe-card";
+import type { SwipeCardStackHandle } from "@/components/learn/swipe-card-stack";
+import { SwipeSession } from "@/components/learn/swipe-session";
+
+// ---------------------------------------------------------------------------
+// Mock the heavy children so the test stays focused on SwipeSession's own shell
+// wiring (the `disabled` flag derived from `cards.length` and the `topSlot`),
+// without pulling in the next/dynamic AnimatedCard chunk or an intl provider.
+// ---------------------------------------------------------------------------
+type Direction = "left" | "down" | "right";
+
+vi.mock("@/components/learn/swipe-card-stack", () => ({
+  SwipeCardStack: (props: {
+    cards: SwipeCardData[];
+    onCardSwiped: (card: SwipeCardData, direction: Direction) => void;
+    completedCount?: number;
+    ref?: RefObject<SwipeCardStackHandle | null>;
+  }) => {
+    const activeCardRef = useRef(props.cards[0] ?? null);
+    activeCardRef.current = props.cards[0] ?? null;
+    useImperativeHandle(props.ref, () => ({
+      triggerSwipe: (direction: Direction) => {
+        const card = activeCardRef.current;
+        if (card) props.onCardSwiped(card, direction);
+      },
+    }));
+    return <div data-testid="swipe-card-stack">{props.cards.length} cards</div>;
+  },
+}));
+
+vi.mock("@/components/learn/learn-action-bar", () => ({
+  LearnActionBar: (props: { onRate: (d: Direction) => void; disabled: boolean }) => (
+    <div data-testid="learn-action-bar" data-disabled={String(props.disabled)} />
+  ),
+}));
+
+const CARD: SwipeCardData = {
+  id: "c-1",
+  front: "Hello",
+  back: "Hola",
+  cefrLevel: null,
+  userCardState: { due: "2026-04-30T00:00:00Z", state: 0 },
+  cardgroupId: "cg-1",
+};
+
+describe("<SwipeSession>", () => {
+  it("renders the topSlot content in the leading grid row", () => {
+    render(
+      <SwipeSession
+        cards={[CARD]}
+        displayMode="ALWAYS_VISIBLE"
+        onCardSwiped={() => {}}
+        topSlot={<div data-testid="top-slot">banner</div>}
+      />,
+    );
+
+    expect(screen.getByTestId("top-slot")).toBeInTheDocument();
+    expect(screen.getByTestId("swipe-card-stack")).toBeInTheDocument();
+  });
+
+  it("enables the action bar while cards remain", () => {
+    render(<SwipeSession cards={[CARD]} displayMode="ALWAYS_VISIBLE" onCardSwiped={() => {}} />);
+
+    expect(screen.getByTestId("learn-action-bar")).toHaveAttribute("data-disabled", "false");
+  });
+
+  it("disables the action bar when the card list is empty", () => {
+    render(<SwipeSession cards={[]} displayMode="ALWAYS_VISIBLE" onCardSwiped={() => {}} />);
+
+    expect(screen.getByTestId("learn-action-bar")).toHaveAttribute("data-disabled", "true");
+  });
+});

--- a/frontend/src/components/learn/swipe-session.tsx
+++ b/frontend/src/components/learn/swipe-session.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { useCallback, useRef } from "react";
+import { LearnActionBar } from "@/components/learn/learn-action-bar";
+import type { SwipeCardData } from "@/components/learn/swipe-card";
+import type { SwipeCardStackHandle } from "@/components/learn/swipe-card-stack";
+import { SwipeCardStack } from "@/components/learn/swipe-card-stack";
+import type { LearnDisplayMode, SwipeDirection } from "@/components/learn/types";
+
+/**
+ * Tailwind class for the swipe-session outer grid: three rows — a leading
+ * `auto` slot (banner / spacer), a `1fr` card area, and a trailing `auto`
+ * action bar. Exported so the loading skeleton can mirror the exact same
+ * wrapper and the layout never shifts when the streamed session replaces the
+ * placeholder.
+ */
+export const SWIPE_SESSION_GRID_CLASS = "grid min-h-0 flex-1 grid-rows-[auto_1fr_auto] gap-3";
+
+type Props<TCard extends SwipeCardData> = {
+  cards: TCard[];
+  displayMode: LearnDisplayMode;
+  onCardSwiped: (card: TCard, direction: SwipeDirection) => void;
+  /**
+   * Fills the leading `auto` grid row (an error banner, the practice banner,
+   * …). A placeholder spacer is rendered when omitted so the card stays in the
+   * `1fr` row and the action bar in the trailing `auto` row — without it, grid
+   * auto-flow would assign the action bar to the `1fr` row.
+   */
+  topSlot?: ReactNode;
+  /** Forwarded to SwipeCardStack's session-complete summary. */
+  completedCount?: number;
+};
+
+/**
+ * Presentational shell shared by LearnClient and PracticeClient: the swipe-grid
+ * layout, the card area, the SwipeCardStack, and the LearnActionBar — plus the
+ * imperative ref glue (`swipeStackRef` + `handleRate`) that lets the action bar
+ * drive a programmatic swipe.
+ *
+ * It owns NO queue/data policy. Each client keeps its own queue orchestration
+ * (LearnClient: server-write + optimistic delete + prefetch; PracticeClient:
+ * local requeue) and feeds this shell the current `cards`, a `displayMode`, an
+ * `onCardSwiped` sink, and a `topSlot`.
+ */
+export function SwipeSession<TCard extends SwipeCardData>({
+  cards,
+  displayMode,
+  onCardSwiped,
+  topSlot,
+  completedCount,
+}: Props<TCard>) {
+  const swipeStackRef = useRef<SwipeCardStackHandle | null>(null);
+
+  // SwipeCardStack owns the overlay paint + commit-delay timing internally, so
+  // handleRate only needs to forward the direction through the imperative
+  // handle. Keeping handleRate stable across renders preserves React.memo
+  // bailouts on LearnActionBar.
+  const handleRate = useCallback((direction: SwipeDirection) => {
+    swipeStackRef.current?.triggerSwipe(direction);
+  }, []);
+
+  return (
+    <section className={SWIPE_SESSION_GRID_CLASS}>
+      {topSlot ?? <div aria-hidden="true" />}
+
+      <div className="relative flex min-h-0 items-center justify-center overflow-hidden">
+        <SwipeCardStack
+          ref={swipeStackRef}
+          cards={cards}
+          displayMode={displayMode}
+          onCardSwiped={onCardSwiped}
+          completedCount={completedCount}
+        />
+      </div>
+      <LearnActionBar onRate={handleRate} disabled={cards.length === 0} />
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary

`LearnClient` and `PracticeClient` independently re-implemented the same "swipe session screen" — the three-row grid, the card area, `SwipeCardStack` + `LearnActionBar`, and the `swipeStackRef` / `handleRate` imperative glue. Several fragments were byte-identical, and a third copy of the outer grid class lived in `learn-skeleton.tsx`. A change to action-bar placement, the `disabled` rule, or the stack wiring had to be made in two (effectively three) files and could silently drift.

This extracts a presentational `SwipeSession<TCard>` shell that owns the shared shell only. Each client keeps its own queue/data policy: `LearnClient` does server-write + optimistic delete + prefetch, `PracticeClient` does FSRS-safe local requeue. Those orchestration paths are untouched, as is `SwipeCardStack` / `AnimatedCard`.

Closes #717

## Changes

### New shared shell

- `frontend/src/components/learn/swipe-session.tsx` — `SwipeSession<TCard extends SwipeCardData>` owns `swipeStackRef`, `handleRate`, the `<section>` grid, the card-area `<div>`, `<SwipeCardStack>`, and `<LearnActionBar onRate={handleRate} disabled={cards.length === 0} />`. Props: `cards`, `displayMode`, `onCardSwiped`, optional `topSlot` (fills the leading `auto` grid row; a spacer is rendered when omitted), and optional `completedCount`. Also exports `SWIPE_SESSION_GRID_CLASS` so the loading skeleton mirrors the exact outer grid.
- `frontend/src/components/learn/swipe-session.test.tsx` — focused unit test: `topSlot` renders, and `disabled` flips with `cards.length === 0`.

### Consumers

- `learn-client.tsx` — keeps all queue/data hooks; renders `<SwipeSession>` with the error-banner-or-spacer as `topSlot`. Removed the local `swipeStackRef` / `handleRate` / shell JSX and now-unused imports.
- `practice-client.tsx` — same, with the persistent practice banner as `topSlot`. FSRS-safe invariant preserved (no mutation imports added).
- `_components/learn-skeleton.tsx` — consumes the shared `SWIPE_SESSION_GRID_CLASS` constant and points its comment at `<SwipeSession>`, collapsing the third copy of the grid class.

## Test plan

All run via `pnpm --filter frontend`:

- `typecheck` — pass.
- `lint` — pass (the 2 infos are a pre-existing `biome.json` `recommended`-field deprecation, unrelated to this change).
- `knip` — pass (only a pre-existing `@graphql-typed-document-node/core` config hint).
- `vitest run` on the affected files — `swipe-session.test.tsx`, `learn-client.test.tsx`, `practice-client.test.tsx`, `page.test.tsx` (`--maxWorkers=2`): 4 files, 62 tests passed.
- CJK gate (`perl -CSD`) on all changed `.tsx` — clean.
