### PR TITLE
refactor(frontend): extract useRoleMutations hook from admin-roles-client

### DIFF
--- a/frontend/src/app/admin/roles/admin-roles-client.tsx
+++ b/frontend/src/app/admin/roles/admin-roles-client.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useLazyQuery, useMutation } from "@apollo/client/react";
 import { Plus } from "lucide-react";
 import Link from "next/link";
 import { useTranslations } from "next-intl";
@@ -11,17 +10,27 @@ import { ListingPageShell } from "@/components/layout/listing-page-shell";
 import { Button } from "@/components/ui/button";
 import { ErrorBanner } from "@/components/ui/error-banner";
 import { FormSheet, useFormSheetClose } from "@/components/ui/form-sheet";
-import { classifyMutationAuthError, getBackendErrorBanner } from "@/lib/apollo/errors";
+import { getBackendErrorBanner } from "@/lib/apollo/errors";
 import { liftGraphQLCodes } from "@/lib/apollo/graphql-errors";
 import { useUndoDelete } from "@/lib/undo-delete";
 import { useSheetSearchParam } from "@/lib/url/use-sheet-search-param";
-import {
-  AdminCreateRoleMutation,
-  AdminDeleteRoleMutation,
-  AdminRoleQuery,
-  AdminUpdateRoleMutation,
-  SYSTEM_ROLE_NAMES,
-} from "./queries";
+import { SYSTEM_ROLE_NAMES } from "./queries";
+import { useRoleMutations } from "./use-role-mutations";
+
+/** Auth banner discriminant carried by the collapsed create/edit error state. */
+type AuthKind = "unauthenticated" | "forbidden";
+
+/** Collapsed create-sheet banner state — one of the typed outcomes the hook returns. */
+type CreateError =
+  | { kind: "validation"; field: string; message: string }
+  | { kind: "auth"; authError: AuthKind }
+  | { kind: "unexpected" };
+
+/** Collapsed edit-sheet banner state — one of the typed outcomes the hook returns. */
+type EditError =
+  | { kind: "systemRole"; message: string }
+  | { kind: "auth"; authError: AuthKind }
+  | { kind: "unexpected" };
 
 export type RoleItem = { id: string; name: string };
 
@@ -181,50 +190,40 @@ export function AdminRolesClient({ initialRoles }: Props) {
   const tNav = useTranslations("Nav");
   const [roles, setRoles] = useState<RoleItem[]>(initialRoles);
   const [createDirty, setCreateDirty] = useState(false);
-  const [createValidationError, setCreateValidationError] = useState<ValidationError | null>(null);
-  const [createUnexpectedPayloadError, setCreateUnexpectedPayloadError] = useState<string | null>(
-    null,
-  );
-  const [createAuthError, setCreateAuthError] = useState<"unauthenticated" | "forbidden" | null>(
-    null,
-  );
-  const [editSystemRoleError, setEditSystemRoleError] = useState<string | null>(null);
-  const [editUnexpectedPayloadError, setEditUnexpectedPayloadError] = useState<string | null>(null);
-  const [editAuthError, setEditAuthError] = useState<"unauthenticated" | "forbidden" | null>(null);
+  const [createError, setCreateError] = useState<CreateError | null>(null);
+  const [editError, setEditError] = useState<EditError | null>(null);
   const [deleteError, setDeleteError] = useState<string | null>(null);
 
-  const [createRole, { loading: creating, reset: resetCreateRole }] =
-    useMutation(AdminCreateRoleMutation);
-  const [updateRole, { loading: updating, error: updateMutationError, reset: resetUpdateRole }] =
-    useMutation(AdminUpdateRoleMutation);
-  const [deleteRoleMutate, { loading: deleting }] = useMutation(AdminDeleteRoleMutation);
-  const [
+  const {
+    createRole,
+    updateRole,
+    deleteRole,
     loadRole,
-    {
-      data: editRoleData,
-      loading: loadingEditRole,
-      error: editRoleQueryError,
-      called: loadRoleCalled,
-      variables: loadRoleVariables,
-    },
-  ] = useLazyQuery(AdminRoleQuery, { fetchPolicy: "no-cache" });
+    editRoleData,
+    loadingEditRole,
+    editRoleQueryError,
+    loadRoleCalled,
+    loadRoleVariables,
+    updateMutationError,
+    creating,
+    updating,
+    deleting,
+    resetCreateRole,
+    resetUpdateRole,
+  } = useRoleMutations();
   const { scheduleDelete } = useUndoDelete();
   const { state, open, close } = useSheetSearchParam();
   const sheetMode = state.mode;
   const editId = state.mode === "edit" ? state.id : null;
 
   const resetCreateSheetState = useCallback(() => {
-    setCreateValidationError(null);
-    setCreateUnexpectedPayloadError(null);
-    setCreateAuthError(null);
+    setCreateError(null);
     setCreateDirty(false);
     resetCreateRole();
   }, [resetCreateRole]);
 
   const resetEditSheetState = useCallback(() => {
-    setEditSystemRoleError(null);
-    setEditUnexpectedPayloadError(null);
-    setEditAuthError(null);
+    setEditError(null);
     resetUpdateRole();
   }, [resetUpdateRole]);
 
@@ -289,12 +288,12 @@ export function AdminRolesClient({ initialRoles }: Props) {
       optimisticRollback: () => {
         setRoles((prev) => [...prev.slice(0, index), role, ...prev.slice(index)]);
       },
-      commitDelete: () => deleteRoleMutate({ variables: { id } }),
+      commitDelete: () => deleteRole(id),
       onCommitFailed: (err) => {
         const codes = liftGraphQLCodes(err);
-        // This branch deliberately does NOT use the shared
-        // classifyMutationAuthError / mutationAuthBanner helpers (used by the
-        // create/update branches): those are kind-only and would discard the
+        // This branch deliberately does NOT route through the shared
+        // classifyToAuthOutcome helper (used by useRoleMutations for the
+        // create/update branches): that is kind-only and would discard the
         // server's FORBIDDEN message. UNAUTHENTICATED collapses to a generic
         // sign-in prompt — the user has no actionable detail to recover from.
         // FORBIDDEN keeps the server's specific reason because the same code
@@ -319,90 +318,53 @@ export function AdminRolesClient({ initialRoles }: Props) {
   }
 
   async function handleCreateSubmit(values: { name: string }) {
-    setCreateValidationError(null);
-    setCreateUnexpectedPayloadError(null);
-    setCreateAuthError(null);
+    setCreateError(null);
 
-    const name = values.name.trim().toLowerCase();
-    const result = await createRole({ variables: { name } }).catch((err) => {
-      const authKind = classifyMutationAuthError(err);
-      if (authKind !== "other") {
-        setCreateAuthError(authKind);
-        return null;
-      }
-      // err.message is omitted — backend messages may echo user input.
-      // codes is safe to log (fixed enum of GraphQL extension codes).
-      console.warn("[admin/roles] createRole rejected", {
-        name: err instanceof Error ? err.name : "unknown",
-        codes: liftGraphQLCodes(err),
-      });
-      return null;
-    });
-
-    if (!result) return;
-
-    const payload = result.data?.createRole;
-    const typename = payload?.__typename ?? null;
-
-    if (payload?.__typename === "InputValidationError") {
-      setCreateValidationError({ field: payload.field, message: payload.message });
-      return;
+    const outcome = await createRole(values);
+    switch (outcome.status) {
+      case "success":
+        resetCreateSheetState();
+        close({ refresh: true });
+        return;
+      case "validation":
+        setCreateError({ kind: "validation", field: outcome.field, message: outcome.message });
+        return;
+      case "auth":
+        setCreateError({ kind: "auth", authError: outcome.kind });
+        return;
+      case "unexpected":
+        setCreateError({ kind: "unexpected" });
+        return;
+      default:
+        // "rejected" — classifyToAuthOutcome already emitted a scoped warn.
+        return;
     }
-
-    if (payload?.__typename === "CreateRoleSuccess") {
-      resetCreateSheetState();
-      close({ refresh: true });
-      return;
-    }
-
-    console.warn("[admin/roles] unexpected createRole payload", {
-      typename,
-    });
-    setCreateUnexpectedPayloadError(tCommon("somethingWentWrong"));
   }
 
   async function handleEditSubmit(values: { name: string }) {
     if (!editRole) return;
 
-    setEditSystemRoleError(null);
-    setEditUnexpectedPayloadError(null);
-    setEditAuthError(null);
+    setEditError(null);
 
-    const name = values.name.trim().toLowerCase();
-    const result = await updateRole({ variables: { id: editRole.id, name } }).catch((err) => {
-      const authKind = classifyMutationAuthError(err);
-      if (authKind !== "other") {
-        setEditAuthError(authKind);
-        return null;
-      }
-      console.warn("[admin/roles] updateRole rejected", {
-        roleId: editRole.id,
-        name: err instanceof Error ? err.name : "unknown",
-        codes: liftGraphQLCodes(err),
-      });
-      return null;
-    });
-
-    if (!result) return;
-
-    const payload = result.data?.updateRole;
-    const typename = payload?.__typename ?? null;
-
-    if (payload?.__typename === "CannotModifySystemRoleError") {
-      setEditSystemRoleError(payload.message);
-      return;
+    const outcome = await updateRole(editRole.id, values);
+    switch (outcome.status) {
+      case "success":
+        resetEditSheetState();
+        close({ refresh: true });
+        return;
+      case "systemRole":
+        setEditError({ kind: "systemRole", message: outcome.message });
+        return;
+      case "auth":
+        setEditError({ kind: "auth", authError: outcome.kind });
+        return;
+      case "unexpected":
+        setEditError({ kind: "unexpected" });
+        return;
+      default:
+        // "rejected" — classifyToAuthOutcome already emitted a scoped warn.
+        return;
     }
-
-    if (payload?.__typename === "UpdateRoleSuccess") {
-      resetEditSheetState();
-      close({ refresh: true });
-      return;
-    }
-
-    console.warn("[admin/roles] unexpected updateRole payload", {
-      typename,
-    });
-    setEditUnexpectedPayloadError(tCommon("somethingWentWrong"));
   }
 
   return (
@@ -477,13 +439,12 @@ export function AdminRolesClient({ initialRoles }: Props) {
         {state.mode === "new" ? (
           <CreateRoleSheetBody
             submitting={creating}
-            validationError={createValidationError}
-            authError={createAuthError}
-            unexpectedPayloadError={createUnexpectedPayloadError}
-            onDirty={() => {
-              setCreateValidationError(null);
-              setCreateUnexpectedPayloadError(null);
-            }}
+            validationError={createError?.kind === "validation" ? createError : null}
+            authError={createError?.kind === "auth" ? createError.authError : null}
+            unexpectedPayloadError={
+              createError?.kind === "unexpected" ? tCommon("somethingWentWrong") : null
+            }
+            onDirty={() => setCreateError((prev) => (prev?.kind === "auth" ? prev : null))}
             onDirtyChange={setCreateDirty}
             submit={handleCreateSubmit}
           />
@@ -509,9 +470,11 @@ export function AdminRolesClient({ initialRoles }: Props) {
             loading={editRoleLoading}
             submitting={updating}
             mutationError={updateMutationError}
-            authError={editAuthError}
-            systemRoleError={editSystemRoleError}
-            unexpectedPayloadError={editUnexpectedPayloadError}
+            authError={editError?.kind === "auth" ? editError.authError : null}
+            systemRoleError={editError?.kind === "systemRole" ? editError.message : null}
+            unexpectedPayloadError={
+              editError?.kind === "unexpected" ? tCommon("somethingWentWrong") : null
+            }
             queryErrorBanner={editQueryErrorBanner}
             submit={handleEditSubmit}
           />

--- a/frontend/src/app/admin/roles/use-role-mutations.test.ts
+++ b/frontend/src/app/admin/roles/use-role-mutations.test.ts
@@ -1,0 +1,311 @@
+// @vitest-environment happy-dom
+import type { MockedResponse } from "@apollo/client/testing";
+import { MockedProvider } from "@apollo/client/testing/react";
+import { act, renderHook } from "@testing-library/react";
+import { GraphQLError } from "graphql";
+import { createElement, type ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  AdminCreateRoleMutation,
+  AdminDeleteRoleMutation,
+  AdminUpdateRoleMutation,
+} from "./queries";
+import { useRoleMutations } from "./use-role-mutations";
+
+function roleNode(id: string, name: string) {
+  return { __typename: "Role" as const, id, name };
+}
+
+function render(mocks: MockedResponse[]) {
+  return renderHook(() => useRoleMutations(), {
+    wrapper: ({ children }: { children: ReactNode }) =>
+      createElement(MockedProvider, { mocks }, children),
+  });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("useRoleMutations.createRole", () => {
+  it("returns success on CreateRoleSuccess", async () => {
+    const mocks: MockedResponse[] = [
+      {
+        request: { query: AdminCreateRoleMutation, variables: { name: "moderator" } },
+        result: {
+          data: {
+            createRole: { __typename: "CreateRoleSuccess", role: roleNode("r-1", "moderator") },
+          },
+        },
+      },
+    ];
+    const { result } = render(mocks);
+
+    let outcome: unknown;
+    await act(async () => {
+      outcome = await result.current.createRole({ name: "moderator" });
+    });
+
+    expect(outcome).toEqual({ status: "success" });
+  });
+
+  it("trims and lower-cases the name before mutating", async () => {
+    // The mock only matches the normalized variable, so a passing outcome proves
+    // the hook normalized "  Moderator  " to "moderator".
+    const mocks: MockedResponse[] = [
+      {
+        request: { query: AdminCreateRoleMutation, variables: { name: "moderator" } },
+        result: {
+          data: {
+            createRole: { __typename: "CreateRoleSuccess", role: roleNode("r-1", "moderator") },
+          },
+        },
+      },
+    ];
+    const { result } = render(mocks);
+
+    let outcome: unknown;
+    await act(async () => {
+      outcome = await result.current.createRole({ name: "  Moderator  " });
+    });
+
+    expect(outcome).toEqual({ status: "success" });
+  });
+
+  it("returns validation on InputValidationError", async () => {
+    const mocks: MockedResponse[] = [
+      {
+        request: { query: AdminCreateRoleMutation, variables: { name: "admin" } },
+        result: {
+          data: {
+            createRole: {
+              __typename: "InputValidationError",
+              field: "name",
+              message: "role name already exists",
+            },
+          },
+        },
+      },
+    ];
+    const { result } = render(mocks);
+
+    let outcome: unknown;
+    await act(async () => {
+      outcome = await result.current.createRole({ name: "admin" });
+    });
+
+    expect(outcome).toEqual({
+      status: "validation",
+      field: "name",
+      message: "role name already exists",
+    });
+  });
+
+  it("returns auth(forbidden) when the mutation rejects with FORBIDDEN", async () => {
+    const mocks: MockedResponse[] = [
+      {
+        request: { query: AdminCreateRoleMutation, variables: { name: "moderator" } },
+        result: { errors: [new GraphQLError("Forbidden", { extensions: { code: "FORBIDDEN" } })] },
+      },
+    ];
+    const { result } = render(mocks);
+
+    let outcome: unknown;
+    await act(async () => {
+      outcome = await result.current.createRole({ name: "moderator" });
+    });
+
+    expect(outcome).toEqual({ status: "auth", kind: "forbidden" });
+  });
+
+  it("returns rejected on a transport error", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const mocks: MockedResponse[] = [
+      {
+        request: { query: AdminCreateRoleMutation, variables: { name: "moderator" } },
+        error: new Error("network down"),
+      },
+    ];
+    const { result } = render(mocks);
+
+    let outcome: unknown;
+    await act(async () => {
+      outcome = await result.current.createRole({ name: "moderator" });
+    });
+
+    expect(outcome).toEqual({ status: "rejected" });
+  });
+
+  it("returns unexpected and warns on an unknown payload variant", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const mocks: MockedResponse[] = [
+      {
+        request: { query: AdminCreateRoleMutation, variables: { name: "moderator" } },
+        result: { data: { createRole: { __typename: "SomeFutureVariant" } } },
+      },
+    ];
+    const { result } = render(mocks);
+
+    let outcome: unknown;
+    await act(async () => {
+      outcome = await result.current.createRole({ name: "moderator" });
+    });
+
+    expect(outcome).toEqual({ status: "unexpected" });
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("unexpected createRole payload"),
+      expect.objectContaining({ typename: "SomeFutureVariant" }),
+    );
+  });
+});
+
+describe("useRoleMutations.updateRole", () => {
+  it("returns success on UpdateRoleSuccess", async () => {
+    const mocks: MockedResponse[] = [
+      {
+        request: { query: AdminUpdateRoleMutation, variables: { id: "r-1", name: "reviewer" } },
+        result: {
+          data: {
+            updateRole: { __typename: "UpdateRoleSuccess", role: roleNode("r-1", "reviewer") },
+          },
+        },
+      },
+    ];
+    const { result } = render(mocks);
+
+    let outcome: unknown;
+    await act(async () => {
+      outcome = await result.current.updateRole("r-1", { name: "Reviewer" });
+    });
+
+    expect(outcome).toEqual({ status: "success" });
+  });
+
+  it("returns systemRole carrying the server message on CannotModifySystemRoleError", async () => {
+    const mocks: MockedResponse[] = [
+      {
+        request: { query: AdminUpdateRoleMutation, variables: { id: "r-1", name: "reviewer" } },
+        result: {
+          data: {
+            updateRole: {
+              __typename: "CannotModifySystemRoleError",
+              message: 'cannot rename system role "admin"',
+              roleId: "r-1",
+              roleName: "admin",
+            },
+          },
+        },
+      },
+    ];
+    const { result } = render(mocks);
+
+    let outcome: unknown;
+    await act(async () => {
+      outcome = await result.current.updateRole("r-1", { name: "reviewer" });
+    });
+
+    expect(outcome).toEqual({
+      status: "systemRole",
+      message: 'cannot rename system role "admin"',
+    });
+  });
+
+  it("returns auth(unauthenticated) when the mutation rejects with UNAUTHENTICATED", async () => {
+    const mocks: MockedResponse[] = [
+      {
+        request: { query: AdminUpdateRoleMutation, variables: { id: "r-1", name: "reviewer" } },
+        result: {
+          errors: [
+            new GraphQLError("Unauthenticated", { extensions: { code: "UNAUTHENTICATED" } }),
+          ],
+        },
+      },
+    ];
+    const { result } = render(mocks);
+
+    let outcome: unknown;
+    await act(async () => {
+      outcome = await result.current.updateRole("r-1", { name: "reviewer" });
+    });
+
+    expect(outcome).toEqual({ status: "auth", kind: "unauthenticated" });
+  });
+
+  it("returns unexpected and warns on an unknown payload variant", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const mocks: MockedResponse[] = [
+      {
+        request: { query: AdminUpdateRoleMutation, variables: { id: "r-1", name: "reviewer" } },
+        result: { data: { updateRole: { __typename: "SomeFutureVariant" } } },
+      },
+    ];
+    const { result } = render(mocks);
+
+    let outcome: unknown;
+    await act(async () => {
+      outcome = await result.current.updateRole("r-1", { name: "reviewer" });
+    });
+
+    expect(outcome).toEqual({ status: "unexpected" });
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("unexpected updateRole payload"),
+      expect.objectContaining({ typename: "SomeFutureVariant" }),
+    );
+  });
+
+  it("returns rejected on a transport error", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const mocks: MockedResponse[] = [
+      {
+        request: { query: AdminUpdateRoleMutation, variables: { id: "r-1", name: "reviewer" } },
+        error: new Error("network down"),
+      },
+    ];
+    const { result } = render(mocks);
+
+    let outcome: unknown;
+    await act(async () => {
+      outcome = await result.current.updateRole("r-1", { name: "reviewer" });
+    });
+
+    expect(outcome).toEqual({ status: "rejected" });
+  });
+});
+
+describe("useRoleMutations.deleteRole", () => {
+  it("resolves the raw mutation result on success (no typed outcome)", async () => {
+    const mocks: MockedResponse[] = [
+      {
+        request: { query: AdminDeleteRoleMutation, variables: { id: "r-1" } },
+        result: { data: { deleteRole: true } },
+      },
+    ];
+    const { result } = render(mocks);
+
+    let res: { data?: { deleteRole?: boolean } | null } | undefined;
+    await act(async () => {
+      res = await result.current.deleteRole("r-1");
+    });
+
+    expect(res?.data?.deleteRole).toBe(true);
+  });
+
+  it("rejects so the client's onCommitFailed can classify the error", async () => {
+    const mocks: MockedResponse[] = [
+      {
+        request: { query: AdminDeleteRoleMutation, variables: { id: "r-1" } },
+        result: {
+          errors: [new GraphQLError("Forbidden", { extensions: { code: "FORBIDDEN" } })],
+        },
+      },
+    ];
+    const { result } = render(mocks);
+
+    let caught: unknown;
+    await act(async () => {
+      caught = await result.current.deleteRole("r-1").catch((err: unknown) => err);
+    });
+
+    expect(caught).toBeInstanceOf(Error);
+  });
+});

--- a/frontend/src/app/admin/roles/use-role-mutations.ts
+++ b/frontend/src/app/admin/roles/use-role-mutations.ts
@@ -1,0 +1,137 @@
+"use client";
+
+import { useLazyQuery, useMutation } from "@apollo/client/react";
+import { useCallback } from "react";
+import { classifyToAuthOutcome } from "@/lib/apollo/errors";
+import {
+  AdminCreateRoleMutation,
+  AdminDeleteRoleMutation,
+  AdminRoleQuery,
+  AdminUpdateRoleMutation,
+} from "./queries";
+
+/** Auth-relevant failure kind surfaced to the caller for banner copy selection. */
+export type AuthKind = "forbidden" | "unauthenticated";
+
+export type CreateRoleOutcome =
+  | { status: "success" }
+  | { status: "validation"; field: string; message: string }
+  | { status: "auth"; kind: AuthKind }
+  | { status: "unexpected" }
+  | { status: "rejected" };
+
+export type UpdateRoleOutcome =
+  | { status: "success" }
+  | { status: "systemRole"; message: string }
+  | { status: "auth"; kind: AuthKind }
+  | { status: "unexpected" }
+  | { status: "rejected" };
+
+/** Normalize a role name the way the backend expects: trimmed, lower-cased. */
+function normalizeName(name: string): string {
+  return name.trim().toLowerCase();
+}
+
+/**
+ * Owns the three admin-roles mutations (create / update / delete) plus the
+ * edit-sheet lazy query. The client maps the returned typed outcomes to its own
+ * banner state, sheet navigation, and the delete undo/optimistic orchestration.
+ * Mirrors the thin-outcome-hook shape of `useMasterMutations`.
+ *
+ * `createRole` / `updateRole` narrow `payload.__typename` to a discriminated
+ * outcome and fold any caught error through `classifyToAuthOutcome`. `deleteRole`
+ * exposes only the raw mutation call: roles delete keeps its local `setRoles` +
+ * `scheduleDelete` undo orchestration (and its FORBIDDEN-passthrough /
+ * UNAUTHENTICATED-collapse handling) in the client, so the hook must return the
+ * rejecting promise rather than a typed outcome.
+ *
+ * No `optimisticResponse`: typed errors (InputValidationError,
+ * CannotModifySystemRoleError, FORBIDDEN) can fail these mutations and Apollo does
+ * not reliably roll back optimistic writes for typed GraphQL errors — see
+ * .claude/rules/pagination.md.
+ */
+export function useRoleMutations() {
+  const [runCreate, { loading: creating, reset: resetCreateRole }] =
+    useMutation(AdminCreateRoleMutation);
+  const [runUpdate, { loading: updating, error: updateMutationError, reset: resetUpdateRole }] =
+    useMutation(AdminUpdateRoleMutation);
+  const [runDelete, { loading: deleting }] = useMutation(AdminDeleteRoleMutation);
+  const [
+    loadRole,
+    {
+      data: editRoleData,
+      loading: loadingEditRole,
+      error: editRoleQueryError,
+      called: loadRoleCalled,
+      variables: loadRoleVariables,
+    },
+  ] = useLazyQuery(AdminRoleQuery, { fetchPolicy: "no-cache" });
+
+  const createRole = useCallback(
+    async (values: { name: string }): Promise<CreateRoleOutcome> => {
+      try {
+        const result = await runCreate({ variables: { name: normalizeName(values.name) } });
+        const payload = result.data?.createRole;
+        const typename = payload?.__typename ?? null;
+        if (payload?.__typename === "InputValidationError") {
+          return { status: "validation", field: payload.field, message: payload.message };
+        }
+        if (payload?.__typename === "CreateRoleSuccess") {
+          return { status: "success" };
+        }
+        console.warn("[useRoleMutations] unexpected createRole payload", { typename });
+        return { status: "unexpected" };
+      } catch (err) {
+        return classifyToAuthOutcome<AuthKind>(err, "useRoleMutations", "createRole");
+      }
+    },
+    [runCreate],
+  );
+
+  const updateRole = useCallback(
+    async (id: string, values: { name: string }): Promise<UpdateRoleOutcome> => {
+      try {
+        const result = await runUpdate({ variables: { id, name: normalizeName(values.name) } });
+        const payload = result.data?.updateRole;
+        const typename = payload?.__typename ?? null;
+        if (payload?.__typename === "CannotModifySystemRoleError") {
+          return { status: "systemRole", message: payload.message };
+        }
+        if (payload?.__typename === "UpdateRoleSuccess") {
+          return { status: "success" };
+        }
+        console.warn("[useRoleMutations] unexpected updateRole payload", { typename });
+        return { status: "unexpected" };
+      } catch (err) {
+        return classifyToAuthOutcome<AuthKind>(err, "useRoleMutations", "updateRole", {
+          roleId: id,
+        });
+      }
+    },
+    [runUpdate],
+  );
+
+  // Raw mutation call only. The client drives the optimistic delete + undo
+  // toast via `scheduleDelete`; its `onCommitFailed` classifies the rejection
+  // (FORBIDDEN message passthrough, UNAUTHENTICATED collapse), so the hook must
+  // surface the rejecting promise rather than swallow it into a typed outcome.
+  const deleteRole = useCallback((id: string) => runDelete({ variables: { id } }), [runDelete]);
+
+  return {
+    createRole,
+    updateRole,
+    deleteRole,
+    loadRole,
+    editRoleData,
+    loadingEditRole,
+    editRoleQueryError,
+    loadRoleCalled,
+    loadRoleVariables,
+    updateMutationError,
+    creating,
+    updating,
+    deleting,
+    resetCreateRole,
+    resetUpdateRole,
+  };
+}


### PR DESCRIPTION
## Summary

`admin-roles-client.tsx` was the only admin screen still mixing Apollo mutation IO + payload-`__typename` narrowing + auth classification directly into the orchestrator component (the masters and users screens already moved this into hooks). This extracts a `useRoleMutations` hook that owns the three roles mutations plus the edit-sheet lazy query, bringing roles to parity, making the IO independently testable, and shrinking the god component (production diff: 93 insertions / 130 deletions in the client).

## Changes

### `frontend/src/app/admin/roles/use-role-mutations.ts` (new)

- Owns the create / update / delete mutations and the edit-sheet `loadRole` lazy query.
- `createRole(values) → CreateRoleOutcome` and `updateRole(id, values) → UpdateRoleOutcome` narrow `payload.__typename` to a discriminated typed outcome (`success` / `validation` / `systemRole` / `auth` / `unexpected` / `rejected`) and fold caught errors through the shared `classifyToAuthOutcome`. Name normalization (trim + lower-case) lives here.
- `deleteRole(id)` exposes only the raw mutation call (returns the rejecting promise): the client keeps its local `setRoles` + `scheduleDelete` optimistic/undo orchestration and its FORBIDDEN-message-passthrough / UNAUTHENTICATED-collapse handling, which a typed outcome would strip.
- No `optimisticResponse` (typed errors can fail these mutations — see `.claude/rules/pagination.md`).

### `frontend/src/app/admin/roles/admin-roles-client.tsx`

- Replaces the inline `useMutation` / `useLazyQuery` declarations and the three `mutate→catch→classify→narrow` blocks with the hook; the submit handlers now `switch` on the typed outcome. No inline `.catch(classifyMutationAuthError)` / `payload.__typename` narrowing remains.
- Collapses the six create/edit banner `useState` slots into two discriminated states (`createError`, `editError`); `deleteError` and `createDirty` are unchanged. The sheet-body components and all `data-testid`s are untouched (banner props are derived from the discriminant), so behavior is identical.

### `frontend/src/app/admin/roles/use-role-mutations.test.ts` (new)

- Co-located IO-classification coverage mirroring `use-master-mutations.test.tsx`: create (success, name-normalization, validation, auth(forbidden), rejected, unexpected), update (success, system-role copy, auth(unauthenticated), unexpected, rejected), and delete (resolves raw result, rejects so `onCommitFailed` can classify).

## Test plan

- `pnpm --filter frontend typecheck` — pass.
- `pnpm --filter frontend lint` (`biome check --error-on-warnings .`) — pass.
- `pnpm --filter frontend knip` — pass (only pre-existing config-hint debt, unrelated).
- Affected tests (both trees): `use-role-mutations.test.ts`, `admin-roles-client.test.tsx`, `__tests__/admin-roles-crud.test.tsx`, `__tests__/admin-roles.test.tsx` — 53 passed. Nav/url route-segment tests — 105 passed.
- CJK gate on changed `.ts`/`.tsx` — clean.

Closes #716
