### PR TITLE
refactor(frontend): extract PaginatedAdminListScreen scaffold for users/masters

### DIFF
--- a/frontend/src/app/admin/masters/admin-masters-client.tsx
+++ b/frontend/src/app/admin/masters/admin-masters-client.tsx
@@ -6,10 +6,7 @@ import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { useCallback, useMemo, useState } from "react";
 import { toast } from "sonner";
-import { AdminListSearch } from "@/components/admin/admin-list-search";
-import { AdminQueryErrorBanner } from "@/components/admin/admin-query-error-banner";
-import { ConnectionListFooter } from "@/components/layout/connection-list-footer";
-import { ListingPageShell } from "@/components/layout/listing-page-shell";
+import { PaginatedAdminListScreen } from "@/components/admin/paginated-admin-list-screen";
 import { Button } from "@/components/ui/button";
 import { FormSheet } from "@/components/ui/form-sheet";
 import type {
@@ -127,10 +124,13 @@ export function AdminMastersClient() {
 
   const initialLoading = networkStatus === NetworkStatus.loading && edges.length === 0;
 
-  if (initialLoading) return <AdminMastersSkeleton />;
-
   return (
-    <ListingPageShell
+    <PaginatedAdminListScreen
+      search={{
+        search,
+        placeholder: t("searchPlaceholder"),
+        ariaLabel: t("searchLabel"),
+      }}
       title={t("title")}
       count={totalCount}
       countLabel={tCommon("totalCount", { count: totalCount })}
@@ -146,31 +146,29 @@ export function AdminMastersClient() {
           <Plus aria-hidden="true" />
         </Button>
       }
+      queryErrorKind={queryErrorKind}
+      errorCopy={{
+        viewForbidden: t("viewForbidden"),
+        sessionExpired: t("sessionExpired"),
+        signInAgain: t("pleaseSignInAgain"),
+        retry: tCommon("retry"),
+      }}
+      onRetry={refetch}
+      isEmpty={edges.length === 0}
+      emptyLabel={t("noMastersFound")}
+      footer={{
+        sentinelRef,
+        fetchMoreError,
+        onRetry: retryFetchMore,
+        fetchingMore,
+        hasNextPage,
+        retryLabel: tCommon("retry"),
+        loadingMoreLabel: t("loadingMore"),
+      }}
+      loading={initialLoading}
+      skeleton={<AdminMastersSkeleton />}
+      testIdPrefix="admin-masters"
     >
-      <AdminListSearch
-        search={search}
-        placeholder={t("searchPlaceholder")}
-        ariaLabel={t("searchLabel")}
-      />
-
-      <AdminQueryErrorBanner
-        kind={queryErrorKind}
-        onRetry={refetch}
-        testId="admin-masters-query-error"
-        copy={{
-          viewForbidden: t("viewForbidden"),
-          sessionExpired: t("sessionExpired"),
-          signInAgain: t("pleaseSignInAgain"),
-          retry: tCommon("retry"),
-        }}
-      />
-
-      {!initialLoading && !queryErrorKind && edges.length === 0 && (
-        <p className="text-sm text-muted-foreground" data-testid="admin-masters-empty">
-          {t("noMastersFound")}
-        </p>
-      )}
-
       {edges.length > 0 && (
         <ul className="space-y-3" data-testid="admin-masters-list">
           {edges.map((edge) => (
@@ -178,17 +176,6 @@ export function AdminMastersClient() {
           ))}
         </ul>
       )}
-
-      <ConnectionListFooter
-        sentinelRef={sentinelRef}
-        fetchMoreError={fetchMoreError}
-        onRetry={retryFetchMore}
-        fetchingMore={fetchingMore}
-        hasNextPage={hasNextPage}
-        retryLabel={tCommon("retry")}
-        loadingMoreLabel={t("loadingMore")}
-        testIdPrefix="admin-masters"
-      />
 
       <FormSheet
         title={t("createMasterTitle")}
@@ -215,6 +202,6 @@ export function AdminMastersClient() {
           />
         ) : null}
       </FormSheet>
-    </ListingPageShell>
+    </PaginatedAdminListScreen>
   );
 }

--- a/frontend/src/app/admin/users/admin-users-client.tsx
+++ b/frontend/src/app/admin/users/admin-users-client.tsx
@@ -5,10 +5,7 @@ import { useLazyQuery, useQuery } from "@apollo/client/react";
 import { useTranslations } from "next-intl";
 import { useCallback, useEffect, useMemo } from "react";
 import { toast } from "sonner";
-import { AdminListSearch } from "@/components/admin/admin-list-search";
-import { AdminQueryErrorBanner } from "@/components/admin/admin-query-error-banner";
-import { ConnectionListFooter } from "@/components/layout/connection-list-footer";
-import { ListingPageShell } from "@/components/layout/listing-page-shell";
+import { PaginatedAdminListScreen } from "@/components/admin/paginated-admin-list-screen";
 import { ErrorBanner } from "@/components/ui/error-banner";
 import { useFragment } from "@/generated/fragment-masking";
 import type {
@@ -227,55 +224,44 @@ export function AdminUsersClient() {
   // (e.g. after ConcurrentUpdateError) would unmount the open sheet and lose any banner.
   const initialLoading = networkStatus === NetworkStatus.loading && edges.length === 0;
 
-  if (initialLoading) {
-    return <AdminUsersSkeleton />;
-  }
-
   return (
-    <ListingPageShell
+    <PaginatedAdminListScreen
+      search={{
+        search,
+        placeholder: t("searchPlaceholder"),
+        ariaLabel: t("searchLabel"),
+      }}
       title={tNav("users")}
       count={totalCount}
       countLabel={tCommon("totalCount", { count: totalCount })}
-      toolbar={
-        <AdminListSearch
-          search={search}
-          placeholder={t("searchPlaceholder")}
-          ariaLabel={t("searchLabel")}
-        />
-      }
+      queryErrorKind={queryErrorKind}
+      errorCopy={{
+        viewForbidden: t("viewForbidden"),
+        sessionExpired: t("sessionExpired"),
+        signInAgain: t("pleaseSignInAgain"),
+        retry: tCommon("retry"),
+      }}
+      onRetry={refetch}
+      queryErrorClassName="mb-4"
+      isEmpty={edges.length === 0}
+      emptyLabel={t("noUsersFound")}
+      footer={{
+        sentinelRef,
+        fetchMoreError,
+        onRetry: retryFetchMore,
+        fetchingMore,
+        hasNextPage,
+        retryLabel: tCommon("retry"),
+        loadingMoreLabel: t("loadingMore"),
+      }}
+      loading={initialLoading}
+      skeleton={<AdminUsersSkeleton />}
+      testIdPrefix="admin-users"
     >
-      {/*
-        Admin users query-error banner. UNAUTHENTICATED here means the session
-        expired mid-page: the server-side gate in page.tsx + the admin layout
-        block the initial load (redirecting to "/"), so the degraded /login
-        banner only fires post-mount. FORBIDDEN renders without Retry since
-        re-issuing the same query would fail again. See
-        .claude/rules/frontend-rsc-error-handling.md.
-      */}
-      <AdminQueryErrorBanner
-        kind={queryErrorKind}
-        onRetry={refetch}
-        testId="admin-users-query-error"
-        className="mb-4"
-        copy={{
-          viewForbidden: t("viewForbidden"),
-          sessionExpired: t("sessionExpired"),
-          signInAgain: t("pleaseSignInAgain"),
-          retry: tCommon("retry"),
-        }}
-      />
-
       {rolesBannerError && (
         <ErrorBanner className="mb-4" data-testid="admin-users-roles-error">
           {rolesBannerError}
         </ErrorBanner>
-      )}
-
-      {/* Empty state */}
-      {!initialLoading && !queryErrorKind && edges.length === 0 && (
-        <p className="text-sm text-muted-foreground" data-testid="admin-users-empty">
-          {t("noUsersFound")}
-        </p>
       )}
 
       {/* User list */}
@@ -291,17 +277,6 @@ export function AdminUsersClient() {
         </ul>
       )}
 
-      <ConnectionListFooter
-        sentinelRef={sentinelRef}
-        fetchMoreError={fetchMoreError}
-        onRetry={retryFetchMore}
-        fetchingMore={fetchingMore}
-        hasNextPage={hasNextPage}
-        retryLabel={tCommon("retry")}
-        loadingMoreLabel={t("loadingMore")}
-        testIdPrefix="admin-users"
-      />
-
       <AdminUserProfileSheet
         open={editUserId !== null}
         user={sheetUser}
@@ -316,6 +291,6 @@ export function AdminUsersClient() {
         onReloadRequested={reloadEditedUser}
         onDelete={handleDeleteUser}
       />
-    </ListingPageShell>
+    </PaginatedAdminListScreen>
   );
 }

--- a/frontend/src/components/admin/paginated-admin-list-screen.tsx
+++ b/frontend/src/components/admin/paginated-admin-list-screen.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import type { ReactNode, RefObject } from "react";
+import { AdminListSearch } from "@/components/admin/admin-list-search";
+import { AdminQueryErrorBanner } from "@/components/admin/admin-query-error-banner";
+import { ConnectionListFooter } from "@/components/layout/connection-list-footer";
+import { ListingPageShell } from "@/components/layout/listing-page-shell";
+import type { useHeaderTakeoverSearch } from "@/hooks/use-header-takeover-search";
+import type { QueryErrorKind } from "@/lib/apollo/errors";
+
+interface PaginatedAdminListScreenProps {
+  /**
+   * Search slice spread straight into `<AdminListSearch>`. The shape matches
+   * `AdminListSearchProps` so the scaffold can `{...search}` it without restating
+   * the field names.
+   */
+  search: {
+    search: ReturnType<typeof useHeaderTakeoverSearch>;
+    placeholder: string;
+    ariaLabel: string;
+  };
+  /** Page title rendered in the `ListingPageShell` header. */
+  title: ReactNode;
+  /** Total count rendered as the neutral header pill. */
+  count: number;
+  /** Localized count-pill label (e.g. "14 total"). */
+  countLabel: ReactNode;
+  /** Optional CTA cluster on the header's trailing edge (e.g. the masters "New" button). */
+  primaryActions?: ReactNode;
+  /** Discriminated query-error kind; null while healthy. */
+  queryErrorKind: QueryErrorKind | null;
+  /** Resolved copy for the three-branch query-error banner. */
+  errorCopy: {
+    viewForbidden: string;
+    sessionExpired: string;
+    signInAgain: string;
+    retry: string;
+  };
+  /** Re-issues the list query (the hook's `refetch`) for the banner Retry. */
+  onRetry: () => void;
+  /** Optional class merge for the query-error banner (the users screen passes "mb-4"). */
+  queryErrorClassName?: string;
+  /** True when the connection has no edges; drives the empty-state. */
+  isEmpty: boolean;
+  /** Localized empty-state copy. */
+  emptyLabel: ReactNode;
+  /**
+   * Footer slice spread straight into `<ConnectionListFooter>`. The shape matches
+   * `ConnectionListFooterProps` minus `testIdPrefix`, which the scaffold supplies
+   * from its own `testIdPrefix`.
+   */
+  footer: {
+    sentinelRef: RefObject<HTMLDivElement | null>;
+    fetchMoreError: string | null;
+    onRetry: () => void;
+    fetchingMore: boolean;
+    hasNextPage: boolean;
+    retryLabel: string;
+    loadingMoreLabel: string;
+  };
+  /** True on the very first load (`NetworkStatus.loading` with no edges yet). */
+  loading: boolean;
+  /** Full-page skeleton rendered while `loading`. */
+  skeleton: ReactNode;
+  /**
+   * testid namespace shared across the query-error banner (`{prefix}-query-error`),
+   * the empty-state (`{prefix}-empty`), and the footer sentinel/error/loading ids.
+   */
+  testIdPrefix: string;
+  /** The list `<ul>`, the screen's sheet(s), and any screen-specific banners. */
+  children: ReactNode;
+}
+
+/**
+ * Shared scaffold for the paginated admin list screens (users, masters). It owns
+ * the chrome both screens repeated near-identically — the search controls, the
+ * count pill, the query-error banner, the empty/skeleton gate, and the
+ * infinite-scroll footer — so a fix to any of those lands in one place.
+ *
+ * Each screen keeps its own `useConnectionPagination` call, merge fn, row
+ * component, and sheet(s); only the chrome moves here. The screen-specific list
+ * `<ul>` and sheet(s) arrive as `children`. Roles is intentionally not a consumer
+ * (it has no pagination/search/connection).
+ *
+ * The skeleton gate lives here too: a mid-session refetch must not re-trigger it
+ * (that would unmount an open sheet and lose any banner), so the caller passes the
+ * already-computed `loading` flag rather than a raw network status.
+ */
+export function PaginatedAdminListScreen({
+  search,
+  title,
+  count,
+  countLabel,
+  primaryActions,
+  queryErrorKind,
+  errorCopy,
+  onRetry,
+  queryErrorClassName,
+  isEmpty,
+  emptyLabel,
+  footer,
+  loading,
+  skeleton,
+  testIdPrefix,
+  children,
+}: PaginatedAdminListScreenProps) {
+  if (loading) return <>{skeleton}</>;
+
+  return (
+    <ListingPageShell
+      title={title}
+      count={count}
+      countLabel={countLabel}
+      primaryActions={primaryActions}
+      toolbar={<AdminListSearch {...search} />}
+    >
+      {/*
+        Query-error banner. UNAUTHENTICATED here means the session expired
+        mid-page: the server-side gate in page.tsx + the admin layout block the
+        initial load (redirecting to "/"), so the degraded /login banner only
+        fires post-mount. FORBIDDEN renders without Retry since re-issuing the
+        same query would fail again. See .claude/rules/frontend-rsc-error-handling.md.
+      */}
+      <AdminQueryErrorBanner
+        kind={queryErrorKind}
+        onRetry={onRetry}
+        testId={`${testIdPrefix}-query-error`}
+        className={queryErrorClassName}
+        copy={errorCopy}
+      />
+
+      {!queryErrorKind && isEmpty && (
+        <p className="text-sm text-muted-foreground" data-testid={`${testIdPrefix}-empty`}>
+          {emptyLabel}
+        </p>
+      )}
+
+      {children}
+
+      <ConnectionListFooter {...footer} testIdPrefix={testIdPrefix} />
+    </ListingPageShell>
+  );
+}


### PR DESCRIPTION
## Summary

The two paginated admin screens (users, masters) repeated ~70 lines each of
near-identical list-scaffold wiring: the search controls, the count pill, the
query-error banner, the empty/skeleton gate, and the infinite-scroll footer. A
fix to any of those had to be applied in two places. This extracts a shared
`PaginatedAdminListScreen` that owns the chrome, leaving each screen a thin
config plus its own list and sheet(s).

Builds on #718 (PR base `refactor/718-extract-admin-list-search`): this composes
the `AdminListSearch` extracted there into the larger scaffold. Roles is
intentionally not a consumer — it has no pagination/search/connection.

## Changes

### `frontend/src/components/admin/paginated-admin-list-screen.tsx` (new)

- Owns the shared chrome: `ListingPageShell` (title + count pill + optional
  `primaryActions`), `AdminListSearch` in the toolbar slot, `AdminQueryErrorBanner`,
  the empty-state `<p>`, the skeleton gate, and `ConnectionListFooter`.
- The `search` and `footer` props are bundled to match `AdminListSearchProps` and
  `ConnectionListFooterProps` so the scaffold spreads them without restating field
  names; a single `testIdPrefix` drives the `{prefix}-query-error`, `{prefix}-empty`,
  and footer sentinel/error/loading testids.
- The skeleton gate takes the already-computed `loading` flag (not a raw network
  status), preserving the "a mid-session refetch must not re-trigger the skeleton"
  invariant that keeps an open sheet and its banner mounted.

### `admin-users-client.tsx` / `admin-masters-client.tsx`

- Render `<PaginatedAdminListScreen ...>{list + sheet}</PaginatedAdminListScreen>`,
  passing each screen's config and connection state.
- Each screen keeps its own `useConnectionPagination` call, merge fn, row
  component, and sheet at the call site. The users screen still renders its
  roles-error banner as a child; the masters screen still passes its "New" button
  as `primaryActions`.
- Net result: the duplicated chrome collapses to one scaffold (61 insertions /
  99 deletions across the two clients).

## Test plan

- `pnpm --filter frontend typecheck` — pass.
- `pnpm --filter frontend lint` — pass (only the pre-existing biome.json deprecation info).
- `pnpm --filter frontend knip` — pass (exit 0; only the pre-existing `@graphql-typed-document-node/core` config hint).
- Affected tests in both trees, `vitest run --maxWorkers=2` — 9 files / 73 tests pass:
  `admin-users-client.test.tsx`, `admin-masters-client.test.tsx`,
  `admin-user-profile-sheet.test.tsx`, `admin/users/page.test.tsx`,
  `admin/masters/page.test.tsx`, `pagination-ref-triplet-removal-rule.test.ts`,
  `__tests__/admin-users-list.test.tsx`, `__tests__/admin-masters-list.test.tsx`,
  `__tests__/admin-users-roles.test.tsx`.
- CJK check — clean; no PR-order references.

Closes #721
