### PR TITLE
refactor(frontend): extract useSeedConnectionCache for SSR-seeded list screens

### DIFF
--- a/frontend/src/app/cardgroups/cardgroups-client.tsx
+++ b/frontend/src/app/cardgroups/cardgroups-client.tsx
@@ -5,7 +5,7 @@ import { useApolloClient, useMutation } from "@apollo/client/react";
 import { Plus } from "lucide-react";
 import Link from "next/link";
 import { useTranslations } from "next-intl";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { CardgroupForm } from "@/components/cardgroups/cardgroup-form";
 import { CardgroupListItem } from "@/components/cardgroups/cardgroup-list-item";
 import { CardgroupsToolbar } from "@/components/cardgroups/cardgroups-toolbar";
@@ -25,6 +25,7 @@ import { getBackendErrorBanner } from "@/lib/apollo/errors";
 import { FLAMINGO_EVENT, subscribeFlamingo } from "@/lib/events/flamingo-events";
 import { EMPTY_PAGE_INFO } from "@/lib/pagination/empty-page-info";
 import { useConnectionPagination } from "@/lib/pagination/use-connection-pagination";
+import { useSeedConnectionCache } from "@/lib/pagination/use-seed-connection-cache";
 import { useUndoDelete } from "@/lib/undo-delete";
 import { CARDGROUPS_DEFAULT_VARS, DeleteCardgroupMutation } from "./queries";
 import { useCreateCardgroup } from "./use-create-cardgroup";
@@ -209,31 +210,15 @@ export default function CardgroupsClient({ initialConnection }: CardgroupsClient
     }
   }
 
-  // Strict Mode double-mount safety: only write the SSR seed into the cache once.
-  const seededRef = useRef(false);
-
-  // Seed the cache synchronously during render (before useQuery runs) with the
-  // SSR initialConnection so the first useQuery pass (cache-first) finds the
-  // data already in the cache and renders without a network round-trip. Doing
-  // this in a useEffect would create a window between first paint and the
-  // post-render write where useQuery sees an empty cache.
-  // CARDGROUPS_DEFAULT_VARS keeps the cache key identical to the SSR seed and
-  // the client useQuery — any mismatch silently splits the cache.
-  // The seededRef guard is synchronous, so it survives Strict Mode's
-  // double-invoke without producing a second write.
-  if (!seededRef.current && initialConnection === null) {
-    console.warn(
-      "[cardgroups-client] initialConnection is null — SSR seed skipped; useQuery will fetch fresh",
-    );
-  }
-  if (!seededRef.current && initialConnection != null) {
-    seededRef.current = true;
-    apollo.writeQuery({
-      query: MyCardgroupsConnectionDocument,
-      variables: CARDGROUPS_DEFAULT_VARS,
-      data: { myCardgroupsConnection: initialConnection },
-    });
-  }
+  // Seed the SSR connection into the cache synchronously before useQuery runs.
+  // CARDGROUPS_DEFAULT_VARS keeps the cache key identical to the SSR seed and the
+  // client useQuery — any mismatch silently splits the cache.
+  useSeedConnectionCache({
+    document: MyCardgroupsConnectionDocument,
+    variables: CARDGROUPS_DEFAULT_VARS,
+    data: { myCardgroupsConnection: initialConnection },
+    warnScope: "cardgroups-client",
+  });
 
   // When searchQuery is null we use CARDGROUPS_DEFAULT_VARS verbatim so the
   // cache key matches the SSR seed exactly. For non-null searches we spread and

--- a/frontend/src/app/catalog/[id]/catalog-deck-client.tsx
+++ b/frontend/src/app/catalog/[id]/catalog-deck-client.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import { useApolloClient } from "@apollo/client/react";
 import Link from "next/link";
 import { useTranslations } from "next-intl";
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useState } from "react";
 import { toast } from "sonner";
 import { useImportMaster } from "@/app/catalog/use-import-master";
 import { CardSearchInput } from "@/components/cardgroups/card-search-input";
@@ -16,6 +15,7 @@ import {
   type CatalogMasterCardsConnectionQuery,
 } from "@/generated/graphql";
 import { useHeaderTakeoverSearch } from "@/hooks/use-header-takeover-search";
+import { useSeedConnectionCache } from "@/lib/pagination/use-seed-connection-cache";
 import type { CatalogDeck } from "./catalog-deck-header";
 import { CatalogDeckHeader } from "./catalog-deck-header";
 import { catalogCardsDefaultVars } from "./queries";
@@ -58,33 +58,29 @@ export default function CatalogDeckClient({
   initialPageInfo,
   initialTotalCount,
 }: CatalogDeckClientProps) {
-  const apollo = useApolloClient();
   const t = useTranslations("Catalog");
   const tCards = useTranslations("Cards");
   const tCommon = useTranslations("Common");
 
   const search = useHeaderTakeoverSearch();
 
-  // Strict Mode double-mount safety: only write the SSR seed into the cache once.
-  // The seededRef guard is synchronous, so it survives the double-invoke without
-  // a second write. Doing this in a useEffect would create a window between first
-  // paint and the post-render write where useQuery sees an empty cache.
-  const seededRef = useRef(false);
-  if (!seededRef.current) {
-    seededRef.current = true;
-    apollo.writeQuery({
-      query: CatalogMasterCardsConnectionDocument,
-      variables: catalogCardsDefaultVars(id),
-      data: {
-        masterCardsConnection: {
-          __typename: "MasterCardConnection",
-          edges: initialEdges,
-          pageInfo: initialPageInfo,
-          totalCount: initialTotalCount,
-        },
+  // Seed the SSR master-cards connection into the cache synchronously before
+  // useQuery runs. catalogCardsDefaultVars(id) keeps the cache key identical to
+  // the SSR seed and the client useQuery — any mismatch silently splits the
+  // cache. The connection object is built here (where __typename is assembled);
+  // initial props are required, so no warnScope/null-skip is needed.
+  useSeedConnectionCache({
+    document: CatalogMasterCardsConnectionDocument,
+    variables: catalogCardsDefaultVars(id),
+    data: {
+      masterCardsConnection: {
+        __typename: "MasterCardConnection",
+        edges: initialEdges,
+        pageInfo: initialPageInfo,
+        totalCount: initialTotalCount,
       },
-    });
-  }
+    },
+  });
 
   const { edges, pageInfo, totalCount, fetchingMore, fetchMoreError, retryFetchMore, sentinelRef } =
     useCatalogCardsConnection({

--- a/frontend/src/app/catalog/catalog-client.tsx
+++ b/frontend/src/app/catalog/catalog-client.tsx
@@ -1,9 +1,8 @@
 "use client";
 
 import { NetworkStatus } from "@apollo/client";
-import { useApolloClient } from "@apollo/client/react";
 import { useTranslations } from "next-intl";
-import { useMemo, useRef } from "react";
+import { useMemo } from "react";
 import { ConnectionListFooter } from "@/components/layout/connection-list-footer";
 import { ListingPageShell } from "@/components/layout/listing-page-shell";
 import { SearchTakeoverBar } from "@/components/search/search-takeover-bar";
@@ -15,6 +14,7 @@ import {
 import { useHeaderTakeoverSearch } from "@/hooks/use-header-takeover-search";
 import { EMPTY_PAGE_INFO } from "@/lib/pagination/empty-page-info";
 import { useConnectionPagination } from "@/lib/pagination/use-connection-pagination";
+import { useSeedConnectionCache } from "@/lib/pagination/use-seed-connection-cache";
 import { CatalogListItem } from "./catalog-list-item";
 import { CATALOG_DEFAULT_VARS } from "./queries";
 
@@ -65,35 +65,21 @@ function mergeCatalogConnection(
  *    is showing; the user must click Retry to resume.
  */
 export default function CatalogClient({ initialConnection }: CatalogClientProps) {
-  const apollo = useApolloClient();
   const t = useTranslations("Catalog");
   const tCommon = useTranslations("Common");
 
   const search = useHeaderTakeoverSearch();
   const searchQuery = search.query;
 
-  // Strict Mode double-mount safety: only write the SSR seed into the cache once.
-  const seededRef = useRef(false);
-
-  // Seed the cache synchronously during render (before useQuery runs) with the
-  // SSR initialConnection so the first useQuery pass (cache-first) finds the data
-  // already in the cache and renders without a network round-trip. Doing this in
-  // a useEffect would create a window between first paint and the post-render
-  // write where useQuery sees an empty cache. The seededRef guard is synchronous,
-  // so it survives Strict Mode's double-invoke without a second write.
-  if (!seededRef.current && initialConnection === null) {
-    console.warn(
-      "[catalog-client] initialConnection is null — SSR seed skipped; useQuery will fetch fresh",
-    );
-  }
-  if (!seededRef.current && initialConnection != null) {
-    seededRef.current = true;
-    apollo.writeQuery({
-      query: MasterCatalogDocument,
-      variables: CATALOG_DEFAULT_VARS,
-      data: { masterCatalog: initialConnection },
-    });
-  }
+  // Seed the SSR connection into the cache synchronously before useQuery runs.
+  // CATALOG_DEFAULT_VARS keeps the cache key identical to the SSR seed and the
+  // client useQuery — any mismatch silently splits the cache.
+  useSeedConnectionCache({
+    document: MasterCatalogDocument,
+    variables: CATALOG_DEFAULT_VARS,
+    data: { masterCatalog: initialConnection },
+    warnScope: "catalog-client",
+  });
 
   // When searchQuery is null we use CATALOG_DEFAULT_VARS verbatim so the cache key
   // matches the SSR seed exactly. For non-null searches we spread and override

--- a/frontend/src/lib/pagination/use-seed-connection-cache.test.ts
+++ b/frontend/src/lib/pagination/use-seed-connection-cache.test.ts
@@ -1,0 +1,137 @@
+// @vitest-environment happy-dom
+import { InMemoryCache } from "@apollo/client";
+import { MockedProvider } from "@apollo/client/testing/react";
+import { renderHook } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  MyCardgroupsConnectionDocument,
+  type MyCardgroupsConnectionQuery,
+  type MyCardgroupsConnectionQueryVariables,
+} from "@/generated/graphql";
+import { useSeedConnectionCache } from "./use-seed-connection-cache";
+
+const DEFAULT_VARS: MyCardgroupsConnectionQueryVariables = { first: 20, search: null };
+
+type CgConnection = MyCardgroupsConnectionQuery["myCardgroupsConnection"];
+
+// A complete connection slice (every field the query selects) so a cache
+// round-trip via readQuery reconstructs an equal object.
+function makeConnection(): CgConnection {
+  return {
+    __typename: "CardgroupConnection",
+    edges: [
+      {
+        __typename: "CardgroupEdge",
+        cursor: "cg-1",
+        node: {
+          __typename: "Cardgroup",
+          id: "cg-1",
+          name: "Alpha",
+          updatedAt: "2024-06-15T10:00:00.000Z",
+        },
+      },
+    ],
+    pageInfo: {
+      __typename: "PageInfo",
+      hasNextPage: false,
+      hasPreviousPage: false,
+      startCursor: "cg-1",
+      endCursor: "cg-1",
+    },
+    totalCount: 1,
+  };
+}
+
+function wrapperFor(cache: InMemoryCache) {
+  return ({ children }: { children: ReactNode }) =>
+    createElement(MockedProvider, { cache, mocks: [] }, children);
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("useSeedConnectionCache", () => {
+  it("seeds the connection into the cache once", () => {
+    const cache = new InMemoryCache();
+    const writeSpy = vi.spyOn(cache, "writeQuery");
+    const connection = makeConnection();
+
+    renderHook(
+      () =>
+        useSeedConnectionCache({
+          document: MyCardgroupsConnectionDocument,
+          variables: DEFAULT_VARS,
+          data: { myCardgroupsConnection: connection },
+        }),
+      { wrapper: wrapperFor(cache) },
+    );
+
+    expect(writeSpy).toHaveBeenCalledTimes(1);
+    expect(
+      cache.readQuery({ query: MyCardgroupsConnectionDocument, variables: DEFAULT_VARS }),
+    ).toEqual({ myCardgroupsConnection: connection });
+  });
+
+  it("is idempotent across re-renders — exactly one write survives", () => {
+    const cache = new InMemoryCache();
+    const writeSpy = vi.spyOn(cache, "writeQuery");
+
+    const { rerender } = renderHook(
+      () =>
+        useSeedConnectionCache({
+          document: MyCardgroupsConnectionDocument,
+          variables: DEFAULT_VARS,
+          data: { myCardgroupsConnection: makeConnection() },
+        }),
+      { wrapper: wrapperFor(cache) },
+    );
+
+    rerender();
+    rerender();
+
+    expect(writeSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("warns and skips the seed when the connection payload is missing and warnScope is set", () => {
+    const cache = new InMemoryCache();
+    const writeSpy = vi.spyOn(cache, "writeQuery");
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    renderHook(
+      () =>
+        useSeedConnectionCache({
+          document: MyCardgroupsConnectionDocument,
+          variables: DEFAULT_VARS,
+          data: { myCardgroupsConnection: null },
+          warnScope: "cardgroups-client",
+        }),
+      { wrapper: wrapperFor(cache) },
+    );
+
+    expect(writeSpy).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("[cardgroups-client] initialConnection is null"),
+    );
+  });
+
+  it("skips silently when the payload is missing and no warnScope is given", () => {
+    const cache = new InMemoryCache();
+    const writeSpy = vi.spyOn(cache, "writeQuery");
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    renderHook(
+      () =>
+        useSeedConnectionCache({
+          document: MyCardgroupsConnectionDocument,
+          variables: DEFAULT_VARS,
+          data: { myCardgroupsConnection: null },
+        }),
+      { wrapper: wrapperFor(cache) },
+    );
+
+    expect(writeSpy).not.toHaveBeenCalled();
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/lib/pagination/use-seed-connection-cache.ts
+++ b/frontend/src/lib/pagination/use-seed-connection-cache.ts
@@ -1,0 +1,78 @@
+import type { DocumentNode, OperationVariables } from "@apollo/client";
+import { useApolloClient } from "@apollo/client/react";
+import { useRef } from "react";
+
+export interface UseSeedConnectionCacheInput {
+  /** The typed connection query document the SSR seed is keyed on. */
+  document: DocumentNode;
+  /**
+   * The cache key for the seed. MUST be the same `<TYPE>_DEFAULT_VARS` object the
+   * client `useQuery` reads with — any mismatch silently splits the cache and the
+   * seed becomes invisible to the first cache-first read.
+   */
+  variables: OperationVariables;
+  /**
+   * The full `{ <field>: connection }` object passed straight to `writeQuery`.
+   * The seed is skipped when the connection payload is missing — i.e. `data` is
+   * null/undefined or its single field value is null/undefined (the SSR prop was
+   * absent). When `warnScope` is set, that skip emits a triage warning.
+   */
+  data: unknown;
+  /**
+   * Optional log scope. When set, a missing connection payload logs
+   * `[<warnScope>] initialConnection is null — SSR seed skipped; useQuery will
+   * fetch fresh`. Screens whose initial connection prop is required omit it.
+   */
+  warnScope?: string;
+}
+
+/**
+ * Returns the connection payload carried by a `{ <field>: connection }` wrapper,
+ * or `undefined` when it is absent. SSR-seed wrappers carry exactly one field
+ * (the connection), so the single value is the payload; any other shape falls
+ * back to the object itself so a present payload is never dropped.
+ */
+function connectionPayload(data: unknown): unknown {
+  if (data == null || typeof data !== "object") return data ?? undefined;
+  const values = Object.values(data as Record<string, unknown>);
+  return values.length === 1 ? values[0] : data;
+}
+
+/**
+ * Seeds an SSR-rendered connection into the Apollo cache exactly once,
+ * synchronously during render — before the client `useQuery` runs — so the
+ * first cache-first read finds the data already present and renders without a
+ * network round-trip.
+ *
+ * The seed is gated by a synchronous `seededRef` boolean so React Strict Mode's
+ * double-invoke still produces exactly one write. Seeding in a `useEffect` would
+ * create a window between first paint and the post-render write where `useQuery`
+ * sees an empty cache. See `docs/pagination/synchronous-ssr-cache-seed.md`.
+ *
+ * `writeQuery` is the rare write-during-render that is safe here: it does not
+ * synchronously re-render the caller, and writing the same data to the same
+ * cache key twice is idempotent.
+ */
+export function useSeedConnectionCache({
+  document,
+  variables,
+  data,
+  warnScope,
+}: UseSeedConnectionCacheInput): void {
+  const apollo = useApolloClient();
+  const seededRef = useRef(false);
+
+  if (seededRef.current) return;
+
+  if (connectionPayload(data) == null) {
+    if (warnScope) {
+      console.warn(
+        `[${warnScope}] initialConnection is null — SSR seed skipped; useQuery will fetch fresh`,
+      );
+    }
+    return;
+  }
+
+  seededRef.current = true;
+  apollo.writeQuery({ query: document, variables, data });
+}


### PR DESCRIPTION
## Summary

The synchronous SSR cache-seed block — a `seededRef` render-body guard plus `apollo.writeQuery` that seeds the paginated connection from SSR props before the client `useQuery` runs — was copy-pasted across three list screens with near-identical comments. The seeding contract is subtle (Strict-Mode double-mount guard, cache-key / SSR-mismatch footgun), so a bug in it had to be fixed in three files.

This extracts `useSeedConnectionCache` into `frontend/src/lib/pagination/use-seed-connection-cache.ts` and routes all three screens through it, collapsing the maintenance sites to one. The seed stays a synchronous render-body call (not a `useEffect`) per [`docs/pagination/synchronous-ssr-cache-seed.md`](https://github.com/yasuflatland-lf/flamingo-armond/blob/main/docs/pagination/synchronous-ssr-cache-seed.md); cache keys (`variables`) are unchanged.

Stacks on #710 (both touch `catalog-deck-client.tsx`); base is `refactor/710-catalog-deck-connection-footer`.

## Changes

- **New `useSeedConnectionCache({ document, variables, data, warnScope? })`** (`frontend/src/lib/pagination/use-seed-connection-cache.ts`). Owns the synchronous `seededRef` guard, the optional null-warn, and the single `apollo.writeQuery`. It seeds once — Strict Mode's double-invoke produces exactly one write — and skips (warning when `warnScope` is set) if the connection payload inside the `{ <field>: connection }` wrapper is missing.
- **`cardgroups-client.tsx`**: replaced the inline seed block with `useSeedConnectionCache({ document: MyCardgroupsConnectionDocument, variables: CARDGROUPS_DEFAULT_VARS, data: { myCardgroupsConnection: initialConnection }, warnScope: "cardgroups-client" })`; dropped the now-unused `useRef` import.
- **`catalog-client.tsx`**: same with the `masterCatalog` field and `warnScope: "catalog-client"`; dropped the now-unused `useApolloClient` / `useRef` imports.
- **`catalog/[id]/catalog-deck-client.tsx`**: same, passing the pre-built `{ masterCardsConnection: { __typename, … } }` object and omitting `warnScope` (its initial props are required); dropped the now-unused `useApolloClient` / `useRef` imports.
- **New `use-seed-connection-cache.test.ts`**: seeds once, idempotent across re-renders (single write), null-warn fires when the payload is missing and `warnScope` is set, and silent skip when no `warnScope`.

The `warnScope` values are `"cardgroups-client"` / `"catalog-client"` (not the issue's illustrative `"cardgroups"`) so the emitted warning string stays byte-identical to the inline blocks — `catalog-client.test.tsx` pins the `[catalog-client] initialConnection is null` prefix.

## Test plan

- `pnpm --filter frontend typecheck` — clean.
- `pnpm --filter frontend lint` — clean (2 pre-existing biome config-deprecation infos only).
- `pnpm --filter frontend knip` — clean (1 pre-existing config hint, unrelated).
- Affected tests across both trees (`--maxWorkers=2`): `use-seed-connection-cache.test.ts`, `cardgroups-client.test.tsx`, `cardgroups/page.test.tsx`, `catalog-client.test.tsx`, `catalog/[id]/catalog-deck-client.test.tsx`, `pagination-ref-triplet-removal-rule.test.ts`, `__tests__/{cardgroups-list,catalog-deck,catalog-list}.test.tsx` → 83 pass / 9 files.
- No CJK in changed `.ts/.tsx`; no generated code committed.

Closes #722
