### PR TITLE
refactor(backend): fold five DataLoader batch functions into one generic

### DIFF
--- a/backend/internal/loader/card.go
+++ b/backend/internal/loader/card.go
@@ -13,5 +13,7 @@ type cardReader interface {
 }
 
 func cardBatchFunc(repo cardReader) dataloader.BatchFunc[string, *domain.Card] {
-	return newMapKeyedBatch(repo.FindByIDs, "card")
+	return newMapKeyedBatch(func(ctx context.Context, keys []string) (map[string]*domain.Card, error) {
+		return repo.FindByIDs(ctx, keys)
+	}, "card")
 }

--- a/backend/internal/loader/card.go
+++ b/backend/internal/loader/card.go
@@ -4,10 +4,8 @@ import (
 	"context"
 
 	"github.com/graph-gophers/dataloader/v7"
-	"github.com/rotisserie/eris"
 
 	"backend/internal/domain"
-	"backend/internal/repository"
 )
 
 type cardReader interface {
@@ -15,33 +13,5 @@ type cardReader interface {
 }
 
 func cardBatchFunc(repo cardReader) dataloader.BatchFunc[string, *domain.Card] {
-	return func(ctx context.Context, keys []string) []*dataloader.Result[*domain.Card] {
-		out := make([]*dataloader.Result[*domain.Card], len(keys))
-
-		// Defensive: dataloader normally never invokes the batch fn with an
-		// empty key slice, but the GORM "WHERE id IN ()" gotcha would turn
-		// such a call into a full-table scan. Short-circuit instead.
-		if len(keys) == 0 {
-			return out
-		}
-
-		byID, err := repo.FindByIDs(ctx, keys)
-		if err != nil {
-			for i := range keys {
-				out[i] = &dataloader.Result[*domain.Card]{Error: err}
-			}
-			return out
-		}
-
-		for i, k := range keys {
-			if card, ok := byID[k]; ok {
-				out[i] = &dataloader.Result[*domain.Card]{Data: card}
-				continue
-			}
-			out[i] = &dataloader.Result[*domain.Card]{
-				Error: eris.Wrapf(repository.ErrNotFound, "card %s", k),
-			}
-		}
-		return out
-	}
+	return newMapKeyedBatch(repo.FindByIDs, "card")
 }

--- a/backend/internal/loader/cardgroup.go
+++ b/backend/internal/loader/cardgroup.go
@@ -1,36 +1,12 @@
 package loader
 
 import (
-	"context"
-
 	"github.com/graph-gophers/dataloader/v7"
-	"github.com/rotisserie/eris"
 
 	"backend/internal/domain"
 	"backend/internal/repository"
 )
 
 func cardgroupBatchFunc(repo repository.CardgroupRepository) dataloader.BatchFunc[string, *domain.Cardgroup] {
-	return func(ctx context.Context, keys []string) []*dataloader.Result[*domain.Cardgroup] {
-		out := make([]*dataloader.Result[*domain.Cardgroup], len(keys))
-
-		byID, err := repo.FindByIDs(ctx, keys)
-		if err != nil {
-			for i := range keys {
-				out[i] = &dataloader.Result[*domain.Cardgroup]{Error: err}
-			}
-			return out
-		}
-
-		for i, k := range keys {
-			if cg, ok := byID[k]; ok {
-				out[i] = &dataloader.Result[*domain.Cardgroup]{Data: cg}
-				continue
-			}
-			out[i] = &dataloader.Result[*domain.Cardgroup]{
-				Error: eris.Wrapf(repository.ErrNotFound, "cardgroup %s", k),
-			}
-		}
-		return out
-	}
+	return newMapKeyedBatch(repo.FindByIDs, "cardgroup")
 }

--- a/backend/internal/loader/cardgroup.go
+++ b/backend/internal/loader/cardgroup.go
@@ -1,6 +1,8 @@
 package loader
 
 import (
+	"context"
+
 	"github.com/graph-gophers/dataloader/v7"
 
 	"backend/internal/domain"
@@ -8,5 +10,7 @@ import (
 )
 
 func cardgroupBatchFunc(repo repository.CardgroupRepository) dataloader.BatchFunc[string, *domain.Cardgroup] {
-	return newMapKeyedBatch(repo.FindByIDs, "cardgroup")
+	return newMapKeyedBatch(func(ctx context.Context, keys []string) (map[string]*domain.Cardgroup, error) {
+		return repo.FindByIDs(ctx, keys)
+	}, "cardgroup")
 }

--- a/backend/internal/loader/loader.go
+++ b/backend/internal/loader/loader.go
@@ -5,11 +5,51 @@ import (
 
 	"github.com/graph-gophers/dataloader/v7"
 	"github.com/labstack/echo/v5"
+	"github.com/rotisserie/eris"
 
 	"backend/internal/auth"
 	"backend/internal/domain"
 	"backend/internal/repository"
 )
+
+// newMapKeyedBatch builds a DataLoader batch function for an aggregate whose
+// repository exposes a map-keyed FindByIDs-style lookup. load maps the requested
+// keys to a map[id]*V; the returned batch function resolves each key to its loaded
+// value, or to eris.Wrapf(repository.ErrNotFound, "<label> <key>") when the id is
+// absent from the map. label is the caller-supplied aggregate name used in the
+// not-found wrap — the shared helper holds no fixed prefix so the error context
+// stays caller-owned (see .claude/rules/error-wrapping.md).
+func newMapKeyedBatch[V any](load func(context.Context, []string) (map[string]*V, error), label string) dataloader.BatchFunc[string, *V] {
+	return func(ctx context.Context, keys []string) []*dataloader.Result[*V] {
+		out := make([]*dataloader.Result[*V], len(keys))
+
+		// Defensive: dataloader normally never invokes the batch fn with an
+		// empty key slice, but the GORM "WHERE id IN ()" gotcha would turn
+		// such a call into a full-table scan. Short-circuit instead.
+		if len(keys) == 0 {
+			return out
+		}
+
+		byID, err := load(ctx, keys)
+		if err != nil {
+			for i := range keys {
+				out[i] = &dataloader.Result[*V]{Error: err}
+			}
+			return out
+		}
+
+		for i, k := range keys {
+			if v, ok := byID[k]; ok {
+				out[i] = &dataloader.Result[*V]{Data: v}
+				continue
+			}
+			out[i] = &dataloader.Result[*V]{
+				Error: eris.Wrapf(repository.ErrNotFound, "%s %s", label, k),
+			}
+		}
+		return out
+	}
+}
 
 // userCardFSRSReader is the narrow interface the loader needs from the
 // UserCardFSRS repository. The loader only calls FindByUserAndCardIDs; it

--- a/backend/internal/loader/loader.go
+++ b/backend/internal/loader/loader.go
@@ -19,6 +19,13 @@ import (
 // absent from the map. label is the caller-supplied aggregate name used in the
 // not-found wrap — the shared helper holds no fixed prefix so the error context
 // stays caller-owned (see .claude/rules/error-wrapping.md).
+//
+// Callers MUST pass a closure that invokes their repository lazily
+// (func(ctx, keys) { return repo.FindByIDs(ctx, keys) }), never a bound
+// repo.FindByIDs method value. New constructs every batch function eagerly —
+// including with nil repositories in tests that do not exercise a given loader —
+// and a bound method value on a nil interface panics at construction time
+// (see .claude/rules/go-library-gotchas.md "Method dispatch on a nil pointer panics").
 func newMapKeyedBatch[V any](load func(context.Context, []string) (map[string]*V, error), label string) dataloader.BatchFunc[string, *V] {
 	return func(ctx context.Context, keys []string) []*dataloader.Result[*V] {
 		out := make([]*dataloader.Result[*V], len(keys))

--- a/backend/internal/loader/role.go
+++ b/backend/internal/loader/role.go
@@ -1,6 +1,8 @@
 package loader
 
 import (
+	"context"
+
 	"github.com/graph-gophers/dataloader/v7"
 
 	"backend/internal/domain"
@@ -8,5 +10,7 @@ import (
 )
 
 func roleBatchFunc(repo repository.RoleRepository) dataloader.BatchFunc[string, *domain.Role] {
-	return newMapKeyedBatch(repo.FindByIDs, "role")
+	return newMapKeyedBatch(func(ctx context.Context, keys []string) (map[string]*domain.Role, error) {
+		return repo.FindByIDs(ctx, keys)
+	}, "role")
 }

--- a/backend/internal/loader/role.go
+++ b/backend/internal/loader/role.go
@@ -1,36 +1,12 @@
 package loader
 
 import (
-	"context"
-
 	"github.com/graph-gophers/dataloader/v7"
-	"github.com/rotisserie/eris"
 
 	"backend/internal/domain"
 	"backend/internal/repository"
 )
 
 func roleBatchFunc(repo repository.RoleRepository) dataloader.BatchFunc[string, *domain.Role] {
-	return func(ctx context.Context, keys []string) []*dataloader.Result[*domain.Role] {
-		out := make([]*dataloader.Result[*domain.Role], len(keys))
-
-		byID, err := repo.FindByIDs(ctx, keys)
-		if err != nil {
-			for i := range keys {
-				out[i] = &dataloader.Result[*domain.Role]{Error: err}
-			}
-			return out
-		}
-
-		for i, k := range keys {
-			if role, ok := byID[k]; ok {
-				out[i] = &dataloader.Result[*domain.Role]{Data: role}
-				continue
-			}
-			out[i] = &dataloader.Result[*domain.Role]{
-				Error: eris.Wrapf(repository.ErrNotFound, "role %s", k),
-			}
-		}
-		return out
-	}
+	return newMapKeyedBatch(repo.FindByIDs, "role")
 }

--- a/backend/internal/loader/swipe_record.go
+++ b/backend/internal/loader/swipe_record.go
@@ -1,43 +1,12 @@
 package loader
 
 import (
-	"context"
-
 	"github.com/graph-gophers/dataloader/v7"
-	"github.com/rotisserie/eris"
 
 	"backend/internal/domain"
 	"backend/internal/repository"
 )
 
 func swipeRecordBatchFunc(repo repository.SwipeRecordRepository) dataloader.BatchFunc[string, *domain.SwipeRecord] {
-	return func(ctx context.Context, keys []string) []*dataloader.Result[*domain.SwipeRecord] {
-		out := make([]*dataloader.Result[*domain.SwipeRecord], len(keys))
-
-		// Defensive: dataloader normally never invokes the batch fn with an
-		// empty key slice, but the GORM "WHERE id IN ()" gotcha would turn
-		// such a call into a full-table scan. Short-circuit instead.
-		if len(keys) == 0 {
-			return out
-		}
-
-		byID, err := repo.FindByIDs(ctx, keys)
-		if err != nil {
-			for i := range keys {
-				out[i] = &dataloader.Result[*domain.SwipeRecord]{Error: err}
-			}
-			return out
-		}
-
-		for i, k := range keys {
-			if sr, ok := byID[k]; ok {
-				out[i] = &dataloader.Result[*domain.SwipeRecord]{Data: sr}
-				continue
-			}
-			out[i] = &dataloader.Result[*domain.SwipeRecord]{
-				Error: eris.Wrapf(repository.ErrNotFound, "swipe record %s", k),
-			}
-		}
-		return out
-	}
+	return newMapKeyedBatch(repo.FindByIDs, "swipe record")
 }

--- a/backend/internal/loader/swipe_record.go
+++ b/backend/internal/loader/swipe_record.go
@@ -1,6 +1,8 @@
 package loader
 
 import (
+	"context"
+
 	"github.com/graph-gophers/dataloader/v7"
 
 	"backend/internal/domain"
@@ -8,5 +10,7 @@ import (
 )
 
 func swipeRecordBatchFunc(repo repository.SwipeRecordRepository) dataloader.BatchFunc[string, *domain.SwipeRecord] {
-	return newMapKeyedBatch(repo.FindByIDs, "swipe record")
+	return newMapKeyedBatch(func(ctx context.Context, keys []string) (map[string]*domain.SwipeRecord, error) {
+		return repo.FindByIDs(ctx, keys)
+	}, "swipe record")
 }

--- a/backend/internal/loader/user.go
+++ b/backend/internal/loader/user.go
@@ -1,6 +1,8 @@
 package loader
 
 import (
+	"context"
+
 	"github.com/graph-gophers/dataloader/v7"
 
 	"backend/internal/domain"
@@ -8,5 +10,7 @@ import (
 )
 
 func userBatchFunc(repo repository.UserRepository) dataloader.BatchFunc[string, *domain.User] {
-	return newMapKeyedBatch(repo.FindByIDs, "user")
+	return newMapKeyedBatch(func(ctx context.Context, keys []string) (map[string]*domain.User, error) {
+		return repo.FindByIDs(ctx, keys)
+	}, "user")
 }

--- a/backend/internal/loader/user.go
+++ b/backend/internal/loader/user.go
@@ -1,43 +1,12 @@
 package loader
 
 import (
-	"context"
-
 	"github.com/graph-gophers/dataloader/v7"
-	"github.com/rotisserie/eris"
 
 	"backend/internal/domain"
 	"backend/internal/repository"
 )
 
 func userBatchFunc(repo repository.UserRepository) dataloader.BatchFunc[string, *domain.User] {
-	return func(ctx context.Context, keys []string) []*dataloader.Result[*domain.User] {
-		out := make([]*dataloader.Result[*domain.User], len(keys))
-
-		// Defensive: dataloader normally never invokes the batch fn with an
-		// empty key slice, but the GORM "WHERE id IN ()" gotcha would turn
-		// such a call into a full-table scan. Short-circuit instead.
-		if len(keys) == 0 {
-			return out
-		}
-
-		byID, err := repo.FindByIDs(ctx, keys)
-		if err != nil {
-			for i := range keys {
-				out[i] = &dataloader.Result[*domain.User]{Error: err}
-			}
-			return out
-		}
-
-		for i, k := range keys {
-			if user, ok := byID[k]; ok {
-				out[i] = &dataloader.Result[*domain.User]{Data: user}
-				continue
-			}
-			out[i] = &dataloader.Result[*domain.User]{
-				Error: eris.Wrapf(repository.ErrNotFound, "user %s", k),
-			}
-		}
-		return out
-	}
+	return newMapKeyedBatch(repo.FindByIDs, "user")
 }


### PR DESCRIPTION
## Summary

The five map-keyed DataLoader batch functions (card, cardgroup, role, user, swipe_record) each duplicated the same shape: short-circuit on empty keys, call a repository FindByIDs returning map[id]*V, then map every requested key to a dataloader.Result, wrapping repository.ErrNotFound for absent ids. This collapses that duplication into one generic helper, newMapKeyedBatch[V any], added to loader.go. Each of the five batch funcs becomes a one-line binding of the helper over its repo's FindByIDs method, passing only the aggregate label for the not-found wrap. The single behavior change is that cardgroup and role now also short-circuit on empty keys, matching the existing card/user/swipe_record guard and closing the GORM "WHERE id IN ()" full-table-scan gotcha.

## Changes

- Added `newMapKeyedBatch[V any](load func(context.Context, []string) (map[string]*V, error), label string) dataloader.BatchFunc[string, *V]` to `backend/internal/loader/loader.go`. It holds the uniform empty-keys guard plus the map-to-Result mapping; the not-found wrap is `eris.Wrapf(repository.ErrNotFound, "%s %s", label, k)` with the label supplied by the caller, so no fixed eris prefix is baked into the shared helper (per `.claude/rules/error-wrapping.md`).
- Rewrote `card.go`, `cardgroup.go`, `role.go`, `user.go`, `swipe_record.go` each into a single `return newMapKeyedBatch(repo.FindByIDs, "<label>")` binding (labels: `card`, `cardgroup`, `role`, `user`, `swipe record`), preserving the exact `errors.Is(..., repository.ErrNotFound)` contract the loader tests assert.
- Dropped now-unused `context`/`eris`/`repository` imports from the rewritten files; `loader.go` gained the `eris` import for the shared wrap.
- `user_card_fsrs.go` left untouched (nilable variant with a different shape, excluded per the issue).
- Behavior change scoped to cardgroup and role now short-circuiting on `len(keys) == 0`, matching the pre-existing card/user/swipe_record guard.
- Each binding passes a **lazy closure** (`func(ctx, keys) { return repo.FindByIDs(ctx, keys) }`), not a bound `repo.FindByIDs` method value. `loader.New` constructs every batch function eagerly — including with nil repos in tests that exercise only one loader (e.g. `TestCardResolver_UserCardState_DelegatesDefaultDecision`) — and a bound method value on a nil interface panics at construction. The helper doc records this contract so the closures are not "simplified" back to a method value.

## Test plan

- `go build ./...` — Success.
- `go vet ./...` — No issues found.
- `go test ./...` (full backend suite, Docker/testcontainers active) — all 23 packages pass. Verifying only `./internal/loader/...` is insufficient: the nil-safe-construction contract is exercised from `graph/resolver` and `cmd/server` integration tests that build `loader.New` with nil repos.

Closes #737
