### PR TITLE
refactor(backend): extract shared Postgres constraint-violation predicate

### DIFF
--- a/backend/internal/repository/card.go
+++ b/backend/internal/repository/card.go
@@ -3,10 +3,8 @@ package repository
 import (
 	"context"
 	"errors"
-	"strings"
 	"time"
 
-	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/rotisserie/eris"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
@@ -181,9 +179,7 @@ func (r *cardRepo) ListFrontsByCardgroupTx(ctx context.Context, tx *gorm.DB, car
 
 func (r *cardRepo) Create(ctx context.Context, card *domain.Card) error {
 	if err := r.db.WithContext(ctx).Create(cardToRow(card)).Error; err != nil {
-		var pgErr *pgconn.PgError
-		if errors.As(err, &pgErr) && pgErr.Code == "23505" &&
-			strings.Contains(pgErr.ConstraintName, "uq_cards_cardgroup_front") {
+		if pgConstraintViolation(err, "23505", "uq_cards_cardgroup_front") {
 			return ErrCardDuplicateFront
 		}
 		return eris.Wrap(err, "repository: card: create")

--- a/backend/internal/repository/master_card.go
+++ b/backend/internal/repository/master_card.go
@@ -3,10 +3,8 @@ package repository
 import (
 	"context"
 	"errors"
-	"strings"
 	"time"
 
-	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/rotisserie/eris"
 	"gorm.io/gorm"
 
@@ -32,11 +30,7 @@ var ErrMasterCardgroupNotFound = errors.Join(
 // classification can be unit-tested with a fabricated *pgconn.PgError without a
 // live DB race (mirrors role.go's classifyFKError).
 func classifyMasterCardFKError(err error) error {
-	var pgErr *pgconn.PgError
-	if !errors.As(err, &pgErr) || pgErr.Code != "23503" {
-		return nil
-	}
-	if strings.Contains(pgErr.ConstraintName, "master_cardgroup_id") {
+	if pgConstraintViolation(err, "23503", "master_cardgroup_id") {
 		return ErrMasterCardgroupNotFound
 	}
 	return nil
@@ -322,9 +316,7 @@ func (r *masterCardRepo) Create(ctx context.Context, c *domain.MasterCard) error
 		c.ID = id
 	}
 	if err := r.db.WithContext(ctx).Create(masterCardToRow(c)).Error; err != nil {
-		var pgErr *pgconn.PgError
-		if errors.As(err, &pgErr) && pgErr.Code == "23505" &&
-			strings.Contains(pgErr.ConstraintName, "uq_master_cards_cg_front") {
+		if pgConstraintViolation(err, "23505", "uq_master_cards_cg_front") {
 			return ErrCardDuplicateFront
 		}
 		if classified := classifyMasterCardFKError(err); classified != nil {

--- a/backend/internal/repository/pgerr.go
+++ b/backend/internal/repository/pgerr.go
@@ -1,0 +1,21 @@
+package repository
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// pgConstraintViolation reports whether err unwraps to a *pgconn.PgError whose
+// SQLSTATE Code equals code and whose ConstraintName contains constraintSubstr.
+// It returns false for any non-pg error, a code mismatch, or a constraint-name
+// miss, so callers can use it as a pre-filter before falling through to
+// eris.Wrap. The SQLSTATE constant ("23503" FK, "23505" unique) and the
+// sentinel each caller returns stay at the call site; this helper only performs
+// the shared errors.As + Code + ConstraintName predicate every classify* wrapper
+// repeated.
+func pgConstraintViolation(err error, code, constraintSubstr string) bool {
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && pgErr.Code == code && strings.Contains(pgErr.ConstraintName, constraintSubstr)
+}

--- a/backend/internal/repository/pgerr_test.go
+++ b/backend/internal/repository/pgerr_test.go
@@ -1,0 +1,63 @@
+package repository
+
+// White-box tests for pgConstraintViolation. The predicate is unexported so the
+// tests live in the same package. All assertions use fabricated *pgconn.PgError
+// values — no live DB is required.
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+func TestPgConstraintViolation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		err              error
+		code             string
+		constraintSubstr string
+		want             bool
+	}{
+		{
+			name:             "matching code and substr returns true",
+			err:              &pgconn.PgError{Code: "23505", ConstraintName: "uq_cards_cardgroup_front"},
+			code:             "23505",
+			constraintSubstr: "uq_cards_cardgroup_front",
+			want:             true,
+		},
+		{
+			name:             "wrong code returns false",
+			err:              &pgconn.PgError{Code: "23503", ConstraintName: "uq_cards_cardgroup_front"},
+			code:             "23505",
+			constraintSubstr: "uq_cards_cardgroup_front",
+			want:             false,
+		},
+		{
+			name:             "non-pg error returns false",
+			err:              errors.New("some error"),
+			code:             "23505",
+			constraintSubstr: "uq_cards_cardgroup_front",
+			want:             false,
+		},
+		{
+			name:             "code match but substr miss returns false",
+			err:              &pgconn.PgError{Code: "23505", ConstraintName: "cards_pkey"},
+			code:             "23505",
+			constraintSubstr: "uq_cards_cardgroup_front",
+			want:             false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := pgConstraintViolation(tt.err, tt.code, tt.constraintSubstr); got != tt.want {
+				t.Fatalf("pgConstraintViolation(%v, %q, %q) = %v, want %v",
+					tt.err, tt.code, tt.constraintSubstr, got, tt.want)
+			}
+		})
+	}
+}

--- a/backend/internal/repository/role.go
+++ b/backend/internal/repository/role.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
-	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/rotisserie/eris"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
@@ -193,11 +192,7 @@ func (r *roleRepo) Delete(ctx context.Context, id string) error {
 // roles.name column to ErrRoleDuplicate. Returns nil for any other error so
 // callers can use it as a pre-filter before falling through to eris.Wrap.
 func classifyUniqueError(err error) error {
-	var pgErr *pgconn.PgError
-	if !errors.As(err, &pgErr) || pgErr.Code != "23505" {
-		return nil
-	}
-	if strings.Contains(pgErr.ConstraintName, "name") {
+	if pgConstraintViolation(err, "23505", "name") {
 		return ErrRoleDuplicate
 	}
 	return nil
@@ -210,14 +205,10 @@ func classifyUniqueError(err error) error {
 // FK-classification logic can be unit-tested with a fabricated *pgconn.PgError
 // without needing a live DB race.
 func classifyFKError(err error) error {
-	var pgErr *pgconn.PgError
-	if !errors.As(err, &pgErr) || pgErr.Code != "23503" {
-		return nil
-	}
-	if strings.Contains(pgErr.ConstraintName, "user_id") {
+	if pgConstraintViolation(err, "23503", "user_id") {
 		return ErrUserNotFound
 	}
-	if strings.Contains(pgErr.ConstraintName, "role_id") {
+	if pgConstraintViolation(err, "23503", "role_id") {
 		return ErrRoleNotFound
 	}
 	return nil

--- a/backend/internal/repository/user_preference.go
+++ b/backend/internal/repository/user_preference.go
@@ -3,10 +3,8 @@ package repository
 import (
 	"context"
 	"errors"
-	"strings"
 	"time"
 
-	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/rotisserie/eris"
 	"gorm.io/gorm"
 
@@ -130,11 +128,7 @@ SET last_viewed_cardgroup_id = EXCLUDED.last_viewed_cardgroup_id,
 // column name is unique to this FK in the user_preferences table. Returns nil
 // when err is not a FK violation so callers can fall through to eris.Wrap.
 func classifyUserPreferenceCardgroupFKError(err error) error {
-	var pgErr *pgconn.PgError
-	if !errors.As(err, &pgErr) || pgErr.Code != "23503" {
-		return nil
-	}
-	if strings.Contains(pgErr.ConstraintName, "last_viewed_cardgroup_id") {
+	if pgConstraintViolation(err, "23503", "last_viewed_cardgroup_id") {
 		return ErrCardgroupNotFound
 	}
 	return nil


### PR DESCRIPTION
## Summary

Six repository sites repeated the same Postgres error-classification scaffold (`var pgErr *pgconn.PgError; errors.As(err, &pgErr); pgErr.Code == "<sqlstate>"; strings.Contains(pgErr.ConstraintName, "<substr>")`). This change introduces a single shared predicate `pgConstraintViolation(err, code, constraintSubstr) bool` in a new `backend/internal/repository/pgerr.go` and routes all six sites through it. Each named `classify*` wrapper keeps its identity, its SQLSTATE constant, and its returned sentinel; only the predicate body shrinks to one helper call. The two inline `23505` checks (`card.go`, `master_card.go`) route through the same predicate. Pure predicate extraction — no behavior change.

## Changes

- Added `backend/internal/repository/pgerr.go` with `pgConstraintViolation(err error, code, constraintSubstr string) bool` — unwraps to `*pgconn.PgError` via `errors.As`, then matches `Code` and `strings.Contains(ConstraintName, ...)`; returns false for any non-pg error, code mismatch, or constraint-name miss.
- `role.go`: `classifyUniqueError` (23505 / "name" → `ErrRoleDuplicate`) and `classifyFKError` (23503 / "user_id" → `ErrUserNotFound`, "role_id" → `ErrRoleNotFound`) now delegate to the predicate; dropped the now-unused `pgconn` import.
- `master_card.go`: `classifyMasterCardFKError` (23503 / "master_cardgroup_id") plus the inline 23505 / "uq_master_cards_cg_front" check in `Create` route through the predicate; dropped unused `pgconn` and `strings` imports.
- `user_preference.go`: `classifyUserPreferenceCardgroupFKError` (23503 / "last_viewed_cardgroup_id") delegates to the predicate; dropped unused `pgconn` and `strings` imports.
- `card.go`: the inline 23505 / "uq_cards_cardgroup_front" check in `Create` routes through the predicate; dropped unused `pgconn` and `strings` imports.
- Added `backend/internal/repository/pgerr_test.go` — table test for `pgConstraintViolation` covering matching code+substr → true, wrong code → false, non-pg error → false, and code-match-but-substr-miss → false.
- Existing fabricated-`*pgconn.PgError` unit tests for the `classify*` functions remain unchanged and green.

## Test plan

- `go tool gqlgen generate` — OK (generated code gitignored, not staged)
- `go build ./...` — Success
- `go vet ./...` — No issues found
- `go test ./internal/repository/...` — 306 passed (Docker available; testcontainers ran)
- `go test ./internal/repository/ -run TestPgConstraintViolation -v` — parent + 4 subtests passed
- `gofmt -l` on all touched files — clean
- CJK check (perl -CSD) on touched files — clean

Closes #739
