### PR TITLE
refactor(backend): extract optional Notion wiring out of buildResolver

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -172,16 +172,11 @@ func buildResolver(
 	var notionSyncHandler *notionsync.Handler
 	var cardObserver usecase.CardObserver
 	if !notionSyncDisabled {
-		retryCfg, err := notion.RetryConfigFromEnv()
+		var err error
+		cardObserver, notionSyncHandler, err = buildNotionIntegration(repos, notionEnv, logger)
 		if err != nil {
 			return nil, nil, nil, err
 		}
-		retryCfg.Logger = logger
-		notionFetcher := notion.NewFetcher(notionEnv.NotionToken, retryCfg)
-		notionWriter := notion.NewWriter(notionEnv.NotionToken, retryCfg)
-		cardObserver = notion.NewCardWritebacker(notionWriter, notionEnv.HandlerConfig.PageIDs[0], logger)
-		notionSyncUC := usecase.NewMasterNotionSyncUsecase(notionFetcher, repos.masterCardgroup, repos.masterCard, repos.gorm, logger)
-		notionSyncHandler = notionsync.New(notionSyncUC, notionEnv.HandlerConfig)
 	}
 	cardUC := usecase.NewCardUsecase(repos.gorm, repos.card, repos.cardgroup, repos.userCardFSRS, cardObserver, logger)
 	// Type the word list as the domain.CEFRWordList port so the dependency
@@ -196,6 +191,31 @@ func buildResolver(
 
 	resolvers := resolver.NewResolver(userUC, cardgroupUC, cardUC, swipeUC, authSvc, cardImportUC, adminUserUC, adminRoleUC, lastViewedCardgroupUC, updateLearnDisplayModeUC, learnUC, cefrUC, masterCatalogUC, masterCardUC)
 	return resolvers, pingHandler, notionSyncHandler, nil
+}
+
+// buildNotionIntegration constructs the optional Notion sync infrastructure (the
+// fetcher, writer, and card writebacker) plus the sync handler, reading retry
+// tuning from the environment. Extracted from buildResolver so the optional
+// wiring and its single error path are independently testable, mirroring
+// bootstrapSuperUserPromoter. The caller gates this on notionSyncDisabled to
+// preserve the disabled-path nil semantics; the only error path is
+// notion.RetryConfigFromEnv failing on a malformed env var.
+func buildNotionIntegration(
+	repos *appRepos,
+	notionEnv notionsync.EnvConfig,
+	logger *slog.Logger,
+) (usecase.CardObserver, *notionsync.Handler, error) {
+	retryCfg, err := notion.RetryConfigFromEnv()
+	if err != nil {
+		return nil, nil, err
+	}
+	retryCfg.Logger = logger
+	notionFetcher := notion.NewFetcher(notionEnv.NotionToken, retryCfg)
+	notionWriter := notion.NewWriter(notionEnv.NotionToken, retryCfg)
+	cardObserver := notion.NewCardWritebacker(notionWriter, notionEnv.HandlerConfig.PageIDs[0], logger)
+	notionSyncUC := usecase.NewMasterNotionSyncUsecase(notionFetcher, repos.masterCardgroup, repos.masterCard, repos.gorm, logger)
+	notionSyncHandler := notionsync.New(notionSyncUC, notionEnv.HandlerConfig)
+	return cardObserver, notionSyncHandler, nil
 }
 
 func newGraphQLServer(r *resolver.Resolver, introspectionEnabled bool) *handler.Server {

--- a/backend/cmd/server/main_test.go
+++ b/backend/cmd/server/main_test.go
@@ -280,6 +280,29 @@ func TestBuildResolver_NotionEnabledRetryConfigError(t *testing.T) {
 	}
 }
 
+// TestBuildNotionIntegration_RetryConfigError drives the extracted helper's only
+// error path directly: a malformed NOTION_MAX_ATTEMPTS makes
+// notion.RetryConfigFromEnv fail, so buildNotionIntegration must return that error
+// unchanged and nil for both the card observer and the sync handler. The error
+// path returns before any DB-backed wiring, so no testcontainer Postgres is
+// needed, mirroring the fake-driven bootstrapSuperUserPromoter unit tests.
+func TestBuildNotionIntegration_RetryConfigError(t *testing.T) {
+	t.Setenv("NOTION_MAX_ATTEMPTS", "not-a-number")
+
+	observer, handler, err := buildNotionIntegration(
+		&appRepos{}, notionsync.EnvConfig{}, slog.New(slog.DiscardHandler),
+	)
+	if err == nil {
+		t.Fatal("expected error from invalid NOTION_MAX_ATTEMPTS, got nil")
+	}
+	if observer != nil {
+		t.Errorf("expected nil card observer on error, got %v", observer)
+	}
+	if handler != nil {
+		t.Errorf("expected nil notion sync handler on error, got %v", handler)
+	}
+}
+
 func freePort(t *testing.T) string {
 	t.Helper()
 	l, err := net.Listen("tcp", "127.0.0.1:0")


### PR DESCRIPTION
## Summary

Extracted the optional Notion sync wiring out of `buildResolver` into a new package-private helper `buildNotionIntegration` in `backend/cmd/server/main.go`. The helper contains the body of the former `if !notionSyncDisabled { ... }` block — reading retry tuning from the env via `notion.RetryConfigFromEnv`, constructing the fetcher/writer/card-writebacker infra, the `MasterNotionSyncUsecase`, and the `notionsync.Handler` — and returns `(usecase.CardObserver, *notionsync.Handler, error)`. `buildResolver` keeps the `notionSyncDisabled` guard at the call site so the disabled-path nil semantics are preserved, and propagates the `RetryConfigFromEnv` error unchanged (no eris wrap). This is a pure structural refactor with no behavior change, mirroring the existing `bootstrapSuperUserPromoter` extraction precedent.

## Changes

- Added `buildNotionIntegration(repos *appRepos, notionEnv notionsync.EnvConfig, logger *slog.Logger) (usecase.CardObserver, *notionsync.Handler, error)` to `backend/cmd/server/main.go`, containing the former `if`-block body. Only error path is `notion.RetryConfigFromEnv` failing; returns it unchanged.
- Collapsed the `if !notionSyncDisabled { ... }` block in `buildResolver` to call the helper: `cardObserver, notionSyncHandler, err = buildNotionIntegration(repos, notionEnv, logger)` with the existing `nil, nil, nil, err` early return on error. The `notionSyncDisabled` guard stays at the call site so the disabled path still yields nil `cardObserver` / nil handler.
- Added unit test `TestBuildNotionIntegration_RetryConfigError` to `backend/cmd/server/main_test.go` driving the helper's single error path directly (malformed `NOTION_MAX_ATTEMPTS`), asserting non-nil error plus nil observer and nil handler. The error path returns before any DB-backed wiring, so the test needs no testcontainer Postgres — mirroring the fake-driven `bootstrapSuperUserPromoter` unit tests.
- `TestBuildResolver_NotionEnabledRetryConfigError` and `TestBuildResolver_WiresResolverAndHandlers` remain unchanged and green.

## Test plan

- `go tool gqlgen generate` (worktree bootstrap; generated code is gitignored, not staged)
- `go build ./...` — Success
- `go vet ./cmd/server/...` — No issues found
- `go test ./cmd/server/...` — 66 passed
- Targeted verbose run: `TestBuildNotionIntegration_RetryConfigError` PASS (new), `TestBuildResolver_NotionEnabledRetryConfigError` PASS, `TestBuildResolver_WiresResolverAndHandlers` PASS

Closes #740
