### PR TITLE
refactor(frontend): extract shared mutation-path AuthErrorBanner leaf

### DIFF
--- a/frontend/src/app/admin/roles/admin-roles-client.tsx
+++ b/frontend/src/app/admin/roles/admin-roles-client.tsx
@@ -1,12 +1,12 @@
 "use client";
 
 import { Plus } from "lucide-react";
-import Link from "next/link";
 import { useTranslations } from "next-intl";
 import { useCallback, useEffect, useState } from "react";
 import { RoleForm } from "@/components/admin/role-form";
 import { RoleListItem } from "@/components/admin/role-list-item";
 import { ListingPageShell } from "@/components/layout/listing-page-shell";
+import { AuthErrorBanner } from "@/components/ui/auth-error-banner";
 import { Button } from "@/components/ui/button";
 import { ErrorBanner } from "@/components/ui/error-banner";
 import { FormSheet, useFormSheetClose } from "@/components/ui/form-sheet";
@@ -38,25 +38,6 @@ type Props = { initialRoles: RoleItem[] };
 
 type ValidationError = { field: string; message: string };
 
-function AuthBanner({
-  testId,
-  authError,
-}: {
-  testId: string;
-  authError: "unauthenticated" | "forbidden";
-}) {
-  const t = useTranslations("Admin");
-  return (
-    <ErrorBanner data-testid={testId}>
-      <span>{authError === "unauthenticated" ? t("sessionExpired") : t("forbidden")}</span>{" "}
-      <Link href="/login" className="underline">
-        {t("signInAgain")}
-      </Link>
-      .
-    </ErrorBanner>
-  );
-}
-
 function CreateRoleSheetBody({
   submitting,
   validationError,
@@ -79,7 +60,13 @@ function CreateRoleSheetBody({
 
   return (
     <div onInput={onDirty}>
-      {authError ? <AuthBanner testId="admin-role-new-auth-error" authError={authError} /> : null}
+      {authError ? (
+        <AuthErrorBanner
+          testId="admin-role-new-auth-error"
+          message={authError === "unauthenticated" ? t("sessionExpired") : t("forbidden")}
+          signInLabel={t("signInAgain")}
+        />
+      ) : null}
       {validationError ? (
         <ErrorBanner data-testid="admin-role-new-validation-error">
           {validationError.message}
@@ -156,7 +143,13 @@ function EditRoleSheetBody({
           {t("systemRoleBanner")}
         </div>
       ) : null}
-      {authError ? <AuthBanner testId="admin-role-edit-auth-error" authError={authError} /> : null}
+      {authError ? (
+        <AuthErrorBanner
+          testId="admin-role-edit-auth-error"
+          message={authError === "unauthenticated" ? t("sessionExpired") : t("forbidden")}
+          signInLabel={t("signInAgain")}
+        />
+      ) : null}
       {systemRoleError ? (
         <ErrorBanner data-testid="admin-role-edit-system-role-error">{systemRoleError}</ErrorBanner>
       ) : null}

--- a/frontend/src/app/cardgroups/cardgroups-client.tsx
+++ b/frontend/src/app/cardgroups/cardgroups-client.tsx
@@ -3,7 +3,6 @@
 import { NetworkStatus } from "@apollo/client";
 import { useApolloClient, useMutation } from "@apollo/client/react";
 import { Plus } from "lucide-react";
-import Link from "next/link";
 import { useTranslations } from "next-intl";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { CardgroupForm } from "@/components/cardgroups/cardgroup-form";
@@ -12,6 +11,7 @@ import { CardgroupsToolbar } from "@/components/cardgroups/cardgroups-toolbar";
 import { ConnectionListFooter } from "@/components/layout/connection-list-footer";
 import { ListingPageShell } from "@/components/layout/listing-page-shell";
 import { SearchTakeoverBar } from "@/components/search/search-takeover-bar";
+import { AuthErrorBanner } from "@/components/ui/auth-error-banner";
 import { Button } from "@/components/ui/button";
 import { ErrorBanner } from "@/components/ui/error-banner";
 import { FormSheet, useFormSheetClose } from "@/components/ui/form-sheet";
@@ -84,13 +84,11 @@ function CreateCardgroupSheetContent({
   return (
     <div onInput={onDirty} className="space-y-4">
       {authError ? (
-        <ErrorBanner data-testid="cardgroup-create-auth-error">
-          <span>{authError === "unauthenticated" ? t("sessionExpired") : t("noPermission")}</span>
-          <Link href="/login" className="underline">
-            {t("signInAgain")}
-          </Link>
-          .
-        </ErrorBanner>
+        <AuthErrorBanner
+          testId="cardgroup-create-auth-error"
+          message={authError === "unauthenticated" ? t("sessionExpired") : t("noPermission")}
+          signInLabel={t("signInAgain")}
+        />
       ) : null}
 
       {limitError ? (

--- a/frontend/src/app/cardgroups/new/new-cardgroup-client.tsx
+++ b/frontend/src/app/cardgroups/new/new-cardgroup-client.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { useCallback, useState } from "react";
 import { useCreateCardgroup } from "@/app/cardgroups/use-create-cardgroup";
 import { FlamingoMark } from "@/components/brand/flamingo-mark";
 import { CardgroupForm } from "@/components/cardgroups/cardgroup-form";
+import { AuthErrorBanner } from "@/components/ui/auth-error-banner";
 import { ErrorBanner } from "@/components/ui/error-banner";
 import { useSheetForm } from "@/lib/forms/use-sheet-form";
 
@@ -107,13 +107,12 @@ export function NewCardgroupClient({ showWelcome = false, returnTo }: NewCardgro
       )}
 
       {authError ? (
-        <ErrorBanner className="mb-4" data-testid="cardgroup-new-auth-error">
-          <span>{authError === "unauthenticated" ? t("sessionExpired") : t("noPermission")}</span>
-          <Link href="/login" className="underline">
-            {t("signInAgain")}
-          </Link>
-          .
-        </ErrorBanner>
+        <AuthErrorBanner
+          className="mb-4"
+          testId="cardgroup-new-auth-error"
+          message={authError === "unauthenticated" ? t("sessionExpired") : t("noPermission")}
+          signInLabel={t("signInAgain")}
+        />
       ) : null}
 
       {validationError ? (

--- a/frontend/src/app/catalog/[id]/catalog-deck-client.tsx
+++ b/frontend/src/app/catalog/[id]/catalog-deck-client.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import Link from "next/link";
 import { useTranslations } from "next-intl";
 import { useCallback, useState } from "react";
 import { toast } from "sonner";
@@ -9,6 +8,7 @@ import { CardSearchInput } from "@/components/cardgroups/card-search-input";
 import { ReadOnlyCardRow } from "@/components/cardgroups/read-only-card-row";
 import { ConnectionListFooter } from "@/components/layout/connection-list-footer";
 import { SearchTakeoverBar } from "@/components/search/search-takeover-bar";
+import { AuthErrorBanner } from "@/components/ui/auth-error-banner";
 import { ErrorBanner } from "@/components/ui/error-banner";
 import {
   CatalogMasterCardsConnectionDocument,
@@ -159,12 +159,11 @@ export default function CatalogDeckClient({
 
         <div className="space-y-3">
           {importAuthError ? (
-            <ErrorBanner data-testid="catalog-deck-import-auth-error">
-              <span>{t("sessionExpired")}</span>
-              <Link href="/login" className="underline">
-                {t("signInAgain")}
-              </Link>
-            </ErrorBanner>
+            <AuthErrorBanner
+              testId="catalog-deck-import-auth-error"
+              message={t("sessionExpired")}
+              signInLabel={t("signInAgain")}
+            />
           ) : null}
 
           {importError ? (

--- a/frontend/src/app/onboarding/start/onboarding-start-client.tsx
+++ b/frontend/src/app/onboarding/start/onboarding-start-client.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { type CSSProperties, useCallback, useState } from "react";
@@ -9,6 +8,7 @@ import type { CatalogCardFieldsFragment } from "@/app/catalog/queries";
 import { useImportMaster } from "@/app/catalog/use-import-master";
 import { OnboardingShell } from "@/components/onboarding/onboarding-shell";
 import { BrandSplash } from "@/components/pwa/brand-splash";
+import { AuthErrorBanner } from "@/components/ui/auth-error-banner";
 import { Button } from "@/components/ui/button";
 import { ErrorBanner } from "@/components/ui/error-banner";
 import type { FragmentType } from "@/generated/fragment-masking";
@@ -127,12 +127,11 @@ export function OnboardingStartClient({ cardgroups }: OnboardingStartClientProps
         {hasBanner && (
           <div className="mt-6 space-y-6 text-left">
             {importAuthError ? (
-              <ErrorBanner data-testid="onboarding-import-auth-error">
-                <span>{t("sessionExpired")}</span>
-                <Link href="/login" className="underline">
-                  {t("signInAgain")}
-                </Link>
-              </ErrorBanner>
+              <AuthErrorBanner
+                testId="onboarding-import-auth-error"
+                message={t("sessionExpired")}
+                signInLabel={t("signInAgain")}
+              />
             ) : null}
             {importError ? (
               <ErrorBanner data-testid="onboarding-import-error">{importError}</ErrorBanner>

--- a/frontend/src/components/ui/auth-error-banner.test.tsx
+++ b/frontend/src/components/ui/auth-error-banner.test.tsx
@@ -1,0 +1,35 @@
+// @vitest-environment happy-dom
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { AuthErrorBanner } from "./auth-error-banner";
+
+describe("<AuthErrorBanner>", () => {
+  it("renders the resolved message and a /login link with the given label and testId", () => {
+    render(
+      <AuthErrorBanner
+        testId="some-auth-error"
+        message="Your session has expired."
+        signInLabel="Sign in again"
+      />,
+    );
+
+    const banner = screen.getByTestId("some-auth-error");
+    expect(banner).toHaveTextContent("Your session has expired.");
+
+    const link = screen.getByRole("link", { name: "Sign in again" });
+    expect(link).toHaveAttribute("href", "/login");
+  });
+
+  it("forwards an optional className to the rendered banner", () => {
+    render(
+      <AuthErrorBanner
+        testId="some-auth-error"
+        message="You do not have permission."
+        signInLabel="Sign in again"
+        className="mb-4"
+      />,
+    );
+
+    expect(screen.getByTestId("some-auth-error")).toHaveClass("mb-4");
+  });
+});

--- a/frontend/src/components/ui/auth-error-banner.tsx
+++ b/frontend/src/components/ui/auth-error-banner.tsx
@@ -1,0 +1,39 @@
+import Link from "next/link";
+import { ErrorBanner } from "@/components/ui/error-banner";
+
+/**
+ * Copy slots for the mutation-path auth banner. Callers resolve these from their
+ * own i18n namespace: the consuming screens span the Admin / Cardgroups / Catalog
+ * / OnboardingStart next-intl namespaces, so the banner takes resolved strings
+ * rather than a namespace-bound `t`, keeping it a pure presentational leaf with
+ * no i18n coupling. This mirrors AdminQueryErrorBanner (the query-path sibling).
+ */
+type AuthErrorBannerProps = {
+  /** data-testid the consuming screen's tests select on. */
+  testId: string;
+  /** Resolved unauthenticated-vs-forbidden copy for the consumer's namespace. */
+  message: string;
+  /** Resolved "Sign in again" link label. */
+  signInLabel: string;
+  className?: string;
+};
+
+/**
+ * Shared degraded sign-in banner for a mid-session mutation auth failure
+ * (UNAUTHENTICATED / FORBIDDEN). Renders the resolved copy followed by a
+ * `<Link href="/login">` rather than a client-side redirect, per
+ * `.claude/rules/frontend-rsc-error-handling.md` § "Mid-session UNAUTHENTICATED
+ * in a client component: degraded banner with `<Link href="/login">`, not
+ * `redirect()`".
+ */
+export function AuthErrorBanner({ testId, message, signInLabel, className }: AuthErrorBannerProps) {
+  return (
+    <ErrorBanner className={className} data-testid={testId}>
+      <span>{message}</span>{" "}
+      <Link href="/login" className="underline">
+        {signInLabel}
+      </Link>
+      .
+    </ErrorBanner>
+  );
+}


### PR DESCRIPTION
## Summary

Five production sites hand-rolled the same mutation-path auth banner: an ErrorBanner with resolved unauthenticated-vs-forbidden copy followed by a `<Link href="/login">` sign-in prompt. This extracts a shared presentational leaf `frontend/src/components/ui/auth-error-banner.tsx` (`AuthErrorBanner`) that takes RESOLVED copy strings — mirroring the query-path `AdminQueryErrorBanner` — so it stays free of i18n coupling across the Admin / Cardgroups / Catalog / OnboardingStart next-intl namespaces. All five sites now render the leaf, each keeping its exact existing data-testid and its own forbidden-vs-noPermission wording; the now-dead local `AuthBanner` in admin-roles-client and five now-unused `next/link` imports were removed.

## Changes

- Add `frontend/src/components/ui/auth-error-banner.tsx`: `AuthErrorBanner({ testId, message, signInLabel, className? })` rendering `<ErrorBanner data-testid={testId}><span>{message}</span>{" "}<Link href="/login" className="underline">{signInLabel}</Link>.</ErrorBanner>`. Takes resolved strings (no `useTranslations`), mirroring `AdminQueryErrorBanner`. The optional `className?` mirrors `AdminQueryErrorBanner` and preserves the `mb-4` margin the full-page create site relied on.
- `admin/roles/admin-roles-client.tsx`: delete the local `AuthBanner` component and the now-unused `next/link` import; route both `admin-role-new-auth-error` and `admin-role-edit-auth-error` banners through `AuthErrorBanner` with `message = unauthenticated ? t("sessionExpired") : t("forbidden")` (Admin namespace).
- `cardgroups/cardgroups-client.tsx`: replace the inline `cardgroup-create-auth-error` banner; message keeps the Cardgroups `noPermission` key; drop unused `next/link` import.
- `cardgroups/new/new-cardgroup-client.tsx`: replace the inline `cardgroup-new-auth-error` banner, passing `className="mb-4"` to preserve spacing; drop unused `next/link` import.
- `catalog/[id]/catalog-deck-client.tsx`: replace the inline `catalog-deck-import-auth-error` banner (`message = t("sessionExpired")`, Catalog namespace); drop unused `next/link` import.
- `onboarding/start/onboarding-start-client.tsx`: replace the inline `onboarding-import-auth-error` banner (`message = t("sessionExpired")`, OnboardingStart namespace); drop unused `next/link` import.
- Add co-located `frontend/src/components/ui/auth-error-banner.test.tsx` (renders message + a `/login` link with the given label and testId; forwards `className`).

## Test plan

- `tsc --noEmit` — clean.
- `biome check --error-on-warnings .` — 479 files checked, 0 errors (2 pre-existing infos: biome schema-version notice + deprecated `recommended` field; unrelated to this change).
- `vitest run` (full suite) — 187 files / 1738 tests passed.
- Affected-area focused run (leaf test + five sites' co-located tests + the broad `__tests__/{cardgroup-edit,catalog-deck,catalog-list,cardgroups-list,admin-roles}.test.tsx`) — 12 files / 147 tests passed. Existing assertions select by data-testid, `/login` href, and the "Sign in again" link role (substring/regex/normalized matching), so the leaf's standardized markup did not break them.
- CJK gate (`perl -CSD`) over changed + new source files — printed nothing.
- `knip` — exit 0 (only the pre-existing `@graphql-typed-document-node/core` ignoreDependencies config hint).

## Notes

The leaf standardizes the trailing markup: it always renders `{" "}` before the link and a trailing `.` after it. Two consequences, both verified non-breaking by the full suite:

- The catalog and onboarding banners, which previously omitted the trailing period, now render one (markup parity with the other three sites).
- Message-catalog strings that carry a baked-in trailing space now emit a double space, which collapses to one in rendered HTML.

The forbidden-vs-`noPermission` wording split is intentionally preserved per site (the leaf is wording-agnostic); unifying that copy is a separate decision, out of scope here.

Closes #741
