### PR TITLE
ci(e2e): parallelize independent setup steps with background/wait-all

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -71,8 +71,24 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      # The Playwright browser download (network), the Supabase stack (Docker
+      # image pulls), and the backend build (CPU) are mutually independent and
+      # bottleneck on different resources, so running them concurrently cuts
+      # wall-clock setup time. The browser download and the backend build run as
+      # background steps that overlap with `supabase start`; the job reconverges
+      # at the `wait-all` below, before the backend process needs its binary and
+      # the Supabase DB URL. Each background step keeps its own log stream in the
+      # Actions UI.
       - name: Install Playwright Chromium
         run: pnpm --filter frontend exec playwright install --with-deps chromium
+        background: true
+
+      - name: Generate and build backend
+        working-directory: backend
+        run: |
+          go tool gqlgen generate
+          go build -o /tmp/flamingo-backend ./cmd/server
+        background: true
 
       - name: Start Supabase
         run: supabase start
@@ -98,13 +114,10 @@ jobs:
             echo "NEXT_PUBLIC_SUPABASE_ANON_KEY=$ANON_KEY"
           } >> "$GITHUB_ENV"
 
-      - name: Generate backend GraphQL
-        working-directory: backend
-        run: go tool gqlgen generate
-
-      - name: Build backend
-        working-directory: backend
-        run: go build -o /tmp/flamingo-backend ./cmd/server
+      # Reconverge the background tracks: the Playwright browser and the backend
+      # binary must both exist, and the Supabase DB URL must be exported, before
+      # the backend process starts.
+      - wait-all:
 
       - name: Start backend
         working-directory: backend


### PR DESCRIPTION
## Summary

The E2E job ran three mutually independent, slow setup steps back-to-back: the Playwright Chromium download (network), the Supabase stack startup (Docker image pulls), and the backend `gqlgen generate` + `go build` (CPU). They share no data dependency and bottleneck on different resources, so the sequential ordering wasted wall-clock time. Using GitHub Actions' step-level parallelism ([shipped 2026-06-25](https://github.blog/changelog/2026-06-25-actions-steps-can-now-be-run-in-parallel/)), the browser download and the backend build now run as `background` steps that overlap with `supabase start`, reconverging at a `wait-all` before the backend process needs its binary and the Supabase DB URL.

## Changes

- `Install Playwright Chromium` gains `background: true` — the browser download runs async while Supabase boots.
- `Generate backend GraphQL` + `Build backend` are merged into a single backgrounded `Generate and build backend` step (`go tool gqlgen generate` then `go build -o /tmp/flamingo-backend ./cmd/server`). A backgrounded step runs to completion asynchronously, so the generate-then-build dependency stays intact inside one step.
- New `wait-all` reconvergence point inserted after `Export Supabase local env` and before `Start backend`, so both background tracks (browser, backend binary) and the Supabase env export complete before the backend starts.
- The `Start backend` / `Wait for backend` service pattern (pid file + log redirect feeding the failure-artifact upload) is left unchanged.

## Test plan

- YAML well-formedness: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/e2e.yml'))"` — parses; 17 steps, 2 `background` steps, `wait-all` present.
- The `background` / `wait-all` keys are **not yet in the official workflow-syntax docs** (confirmed only by the 2026-06-25 changelog and the runner rollout), so **this PR's own E2E check is the syntax-validation gate**: if the runner rejects the keys, the workflow fails to parse and the check goes red.
- Behavior parity: the backend binary is still produced before `Start backend` (now via the merged backgrounded step), and `Wait for backend` still gates Playwright on the `/health` probe.

## Notes

No related issue — CI-only refactor prompted by the 2026-06-25 changelog. A follow-up could push `Start backend` onto `background: true` + `cancel`, but that drops the `/tmp/flamingo-backend.log` redirect the failure-artifact upload depends on, so it stayed out of scope.
