### PR TITLE
refactor(repository): extract refetchAfterUpdate tail helper for the six Update methods

### DIFF
--- a/backend/internal/repository/card.go
+++ b/backend/internal/repository/card.go
@@ -231,10 +231,8 @@ func (r *cardRepo) Update(ctx context.Context, id string, patch CardUpdate) (*do
 	if res.Error != nil {
 		return nil, eris.Wrap(res.Error, "repository: card: update")
 	}
-	if res.RowsAffected == 0 {
-		return nil, ErrNotFound
-	}
-	return r.FindByID(ctx, id)
+	return refetchAfterUpdate(res.RowsAffected, ErrNotFound,
+		func() (*domain.Card, error) { return r.FindByID(ctx, id) }, "")
 }
 
 func (r *cardRepo) Delete(ctx context.Context, id string) error {

--- a/backend/internal/repository/cardgroup.go
+++ b/backend/internal/repository/cardgroup.go
@@ -343,11 +343,9 @@ func (r *cardgroupRepo) Update(ctx context.Context, id string, patch CardgroupUp
 	if res.Error != nil {
 		return nil, eris.Wrap(res.Error, "repository: cardgroup: update")
 	}
-	if res.RowsAffected == 0 {
-		return nil, ErrNotFound
-	}
 	// Re-fetch so callers see the trigger-refreshed updated_at.
-	return r.FindByID(ctx, id)
+	return refetchAfterUpdate(res.RowsAffected, ErrNotFound,
+		func() (*domain.Cardgroup, error) { return r.FindByID(ctx, id) }, "")
 }
 
 // Delete removes the cardgroup identified by id. Returns ErrNotFound when no

--- a/backend/internal/repository/master_card.go
+++ b/backend/internal/repository/master_card.go
@@ -363,10 +363,8 @@ func (r *masterCardRepo) Update(ctx context.Context, id string, patch MasterCard
 	if res.Error != nil {
 		return nil, eris.Wrap(res.Error, "repository: master card: update")
 	}
-	if res.RowsAffected == 0 {
-		return nil, ErrNotFound
-	}
-	return r.FindByID(ctx, id)
+	return refetchAfterUpdate(res.RowsAffected, ErrNotFound,
+		func() (*domain.MasterCard, error) { return r.FindByID(ctx, id) }, "")
 }
 
 // DeleteMany hard-deletes the master cards whose ids are in the list, returning

--- a/backend/internal/repository/master_cardgroup.go
+++ b/backend/internal/repository/master_cardgroup.go
@@ -231,11 +231,9 @@ func (r *masterCardgroupRepo) Update(ctx context.Context, id string, patch Maste
 	if res.Error != nil {
 		return nil, eris.Wrap(res.Error, "repository: master cardgroup: update")
 	}
-	if res.RowsAffected == 0 {
-		return nil, ErrNotFound
-	}
 	// Re-fetch so callers see the trigger-refreshed updated_at.
-	return r.FindByID(ctx, id)
+	return refetchAfterUpdate(res.RowsAffected, ErrNotFound,
+		func() (*domain.MasterCardgroup, error) { return r.FindByID(ctx, id) }, "")
 }
 
 // Delete removes the master cardgroup identified by id. Returns ErrNotFound

--- a/backend/internal/repository/role.go
+++ b/backend/internal/repository/role.go
@@ -167,14 +167,9 @@ func (r *roleRepo) Update(ctx context.Context, id, name string) (*domain.Role, e
 		}
 		return nil, eris.Wrap(res.Error, "repository: role: update")
 	}
-	if res.RowsAffected == 0 {
-		return nil, ErrRoleNotFound
-	}
-	role, err := r.FindByID(ctx, id)
-	if err != nil {
-		return nil, eris.Wrap(err, "repository: role: update: find after update")
-	}
-	return role, nil
+	return refetchAfterUpdate(res.RowsAffected, ErrRoleNotFound,
+		func() (*domain.Role, error) { return r.FindByID(ctx, id) },
+		"repository: role: update: find after update")
 }
 
 func (r *roleRepo) Delete(ctx context.Context, id string) error {

--- a/backend/internal/repository/update.go
+++ b/backend/internal/repository/update.go
@@ -1,0 +1,27 @@
+package repository
+
+import "github.com/rotisserie/eris"
+
+// refetchAfterUpdate is the shared tail of the aggregate Update methods. Given the
+// RowsAffected count of a completed Updates call, it returns notFoundErr when no
+// row matched, otherwise re-fetches the fresh row via refetch (so callers observe
+// trigger-refreshed columns such as updated_at). A non-empty refetchErrPrefix wraps
+// a refetch failure with that caller-supplied prefix; pass "" to return the refetch
+// error unwrapped. The caller runs Updates and classifies/wraps res.Error before
+// calling this helper — that step diverges per aggregate (e.g. role classifies a
+// unique violation) and is deliberately NOT owned here (see
+// .claude/rules/error-wrapping.md: shared helpers take a caller-supplied prefix,
+// never a fixed one).
+func refetchAfterUpdate[T any](rowsAffected int64, notFoundErr error, refetch func() (*T, error), refetchErrPrefix string) (*T, error) {
+	if rowsAffected == 0 {
+		return nil, notFoundErr
+	}
+	row, err := refetch()
+	if err != nil {
+		if refetchErrPrefix != "" {
+			return nil, eris.Wrap(err, refetchErrPrefix)
+		}
+		return nil, err
+	}
+	return row, nil
+}

--- a/backend/internal/repository/update_test.go
+++ b/backend/internal/repository/update_test.go
@@ -1,0 +1,81 @@
+package repository
+
+// White-box tests for refetchAfterUpdate, the shared tail of the aggregate Update
+// methods. The helper is unexported so the tests live in the same package. No live
+// DB is required — the refetch closure is a fake.
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestRefetchAfterUpdate(t *testing.T) {
+	t.Parallel()
+
+	type row struct{ id string }
+
+	notFound := errors.New("not found")
+	refetchFail := errors.New("boom")
+
+	t.Run("rows affected zero returns notFoundErr without refetching", func(t *testing.T) {
+		t.Parallel()
+
+		called := false
+		got, err := refetchAfterUpdate(0, notFound,
+			func() (*row, error) { called = true; return &row{id: "x"}, nil }, "")
+		if got != nil {
+			t.Fatalf("got = %v, want nil", got)
+		}
+		if !errors.Is(err, notFound) {
+			t.Fatalf("err = %v, want notFound", err)
+		}
+		if called {
+			t.Fatalf("refetch was called for a zero-rows update")
+		}
+	})
+
+	t.Run("rows affected positive returns the refetched row", func(t *testing.T) {
+		t.Parallel()
+
+		want := &row{id: "abc"}
+		got, err := refetchAfterUpdate(1, notFound,
+			func() (*row, error) { return want, nil }, "")
+		if err != nil {
+			t.Fatalf("err = %v, want nil", err)
+		}
+		if got != want {
+			t.Fatalf("got = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("refetch error with prefix is wrapped and preserves the cause", func(t *testing.T) {
+		t.Parallel()
+
+		const prefix = "repository: role: update: find after update"
+		got, err := refetchAfterUpdate(1, notFound,
+			func() (*row, error) { return nil, refetchFail }, prefix)
+		if got != nil {
+			t.Fatalf("got = %v, want nil", got)
+		}
+		if !errors.Is(err, refetchFail) {
+			t.Fatalf("err = %v, want chain to refetchFail", err)
+		}
+		if !strings.Contains(err.Error(), prefix) {
+			t.Fatalf("err = %q, want it to contain prefix %q", err.Error(), prefix)
+		}
+	})
+
+	t.Run("refetch error with empty prefix is returned unwrapped", func(t *testing.T) {
+		t.Parallel()
+
+		got, err := refetchAfterUpdate(1, notFound,
+			func() (*row, error) { return nil, refetchFail }, "")
+		if got != nil {
+			t.Fatalf("got = %v, want nil", got)
+		}
+		if err != refetchFail {
+			t.Fatalf("err = %v, want the exact refetchFail error (unwrapped)", err)
+		}
+	})
+}

--- a/backend/internal/repository/user.go
+++ b/backend/internal/repository/user.go
@@ -165,11 +165,9 @@ func (r *userRepo) Update(ctx context.Context, id string, patch UserUpdate) (*do
 	if res.Error != nil {
 		return nil, eris.Wrap(res.Error, "repository: user: update")
 	}
-	if res.RowsAffected == 0 {
-		return nil, ErrNotFound
-	}
 	// Re-fetch so callers see the trigger-refreshed updated_at.
-	return r.FindByID(ctx, id)
+	return refetchAfterUpdate(res.RowsAffected, ErrNotFound,
+		func() (*domain.User, error) { return r.FindByID(ctx, id) }, "")
 }
 
 func (r *userRepo) UpdateTx(ctx context.Context, tx *gorm.DB, id string, patch UserUpdate) error {


### PR DESCRIPTION
## Summary

Collapses the duplicated post-Updates tail (`RowsAffected==0 -> notFound -> refetch`) shared by the six repository aggregate Update methods (card, cardgroup, master_card, master_cardgroup, role, user) into one generic helper `refetchAfterUpdate[T any]` in a new shared file `backend/internal/repository/update.go`. The helper owns ONLY the tail; each method still runs its own `Updates(...)` and `res.Error` handling at the call site, because that step diverges per aggregate (role classifies a 23505 via `classifyUniqueError`; the others just `eris.Wrap`). Per-site behavior is byte-identical: card/cardgroup/master_card/master_cardgroup/user pass `refetchErrPrefix=""` (unwrapped refetch error), role passes `"repository: role: update: find after update"` (its existing wrap). Pure refactor, ~-15 net production lines.

## Changes

- Added `refetchAfterUpdate[T any](rowsAffected int64, notFoundErr error, refetch func() (*T, error), refetchErrPrefix string) (*T, error)` to new `backend/internal/repository/update.go`. Returns `notFoundErr` when `rowsAffected == 0`; otherwise calls `refetch`, wrapping a failure with `eris.Wrap(err, refetchErrPrefix)` only when the prefix is non-empty, else returning it unwrapped.
- Converted all six Update methods to call the helper for the tail, leaving each method's `Updates(...)` + `res.Error` handling untouched:
  - `card.go` cardRepo.Update -> `ErrNotFound`, prefix `""`.
  - `cardgroup.go` cardgroupRepo.Update -> `ErrNotFound`, prefix `""` (kept the "trigger-refreshed updated_at" comment).
  - `master_card.go` masterCardRepo.Update -> `ErrNotFound`, prefix `""`.
  - `master_cardgroup.go` masterCardgroupRepo.Update -> `ErrNotFound`, prefix `""` (kept comment).
  - `role.go` roleRepo.Update -> `ErrRoleNotFound`, prefix `"repository: role: update: find after update"`; `classifyUniqueError` branch on `res.Error` unchanged.
  - `user.go` userRepo.Update -> `ErrNotFound`, prefix `""` (kept comment).
- Added `backend/internal/repository/update_test.go`: a Docker-free white-box table test covering the four branches (rowsAffected==0 -> notFoundErr with refetch NOT called; >0+ok -> row; refetch err + prefix -> wrapped with `errors.Is` to the cause preserved and prefix present; refetch err + "" -> exact unwrapped error).
- Did NOT standardize role's refetch wrap onto the others (would change their error-chain shape); excluded Delete methods, user.UpdateTx/UpdateTxVersioned, and user_preference UPSERT (no Updates->RowsAffected->refetch tail).

## Test plan

- `go tool gqlgen generate` to bootstrap gitignored generated code (mise trust first), then `go build ./...` and `go vet ./...`.
- Full module test suite with Docker/testcontainers running.
- Focused run of the new `TestRefetchAfterUpdate` (all 4 subtests).
- Existing aggregate Update integration tests (card/cardgroup/master_*/role/user) stay green within the repository package run.

Closes #747
