### PR TITLE
refactor(usecase): consolidate three repo-error classifier functions into classifyRepoErr

### DIFF
--- a/backend/internal/usecase/admin_role.go
+++ b/backend/internal/usecase/admin_role.go
@@ -243,33 +243,14 @@ func (u *adminRoleUsecase) Delete(ctx context.Context, id string) error {
 
 // mapAdminRoleError classifies the role-repository sentinel set into either
 // input-validation data (first slot non-nil) or a propagating error (second
-// slot non-nil). The shape mirrors mapAdminEditMutationError so promoted
-// outcome-bearing callers can route validation refusals into outcome data
-// uniformly:
-//   - repository.ErrRoleNotFound            -> InputValidationInfo{Field: notFoundField}
-//   - repository.ErrRoleDuplicate           -> InputValidationInfo{Field: "name"}
-//   - context.Canceled / DeadlineExceeded   -> passthrough via error
-//   - default                               -> eris.Wrap(err, wrap) via error
-//
-// The notFoundField argument lets callers name the request field that was bad
-// (e.g. "id" for Update / Delete / Get-from-Update) without hardcoding a
-// single field name here. Forbidden conditions are constructed at the call
-// sites, not via this mapper.
-//
-// Unpromoted callers (Update, Delete) wrap the first-slot InputValidationInfo
-// back into a *ucerr.ValidationError via lowerValidationInfo so their
-// error-returning signatures stay intact.
+// slot non-nil) by delegating to classifyRepoErr with the role-specific
+// sentinel mappings. The notFoundField argument lets callers name the request
+// field that was bad (e.g. "id" for Update / Delete / Get-from-Update).
 func mapAdminRoleError(err error, notFoundField, wrap string) (*InputValidationInfo, error) {
-	switch {
-	case errors.Is(err, repository.ErrRoleNotFound):
-		return NewInputValidationInfo(notFoundField, "role not found"), nil
-	case errors.Is(err, repository.ErrRoleDuplicate):
-		return NewInputValidationInfo("name", "role name already exists"), nil
-	case isContextDone(err):
-		return nil, err
-	default:
-		return nil, eris.Wrap(err, wrap)
-	}
+	return classifyRepoErr(err, wrap, []SentinelMapping{
+		{repository.ErrRoleNotFound, notFoundField, "role not found"},
+		{repository.ErrRoleDuplicate, "name", "role name already exists"},
+	})
 }
 
 // lowerValidationInfo is the inverse of liftValidationErr for unpromoted

--- a/backend/internal/usecase/admin_user.go
+++ b/backend/internal/usecase/admin_user.go
@@ -473,18 +473,11 @@ func (u *adminUserUsecase) DeleteUser(ctx context.Context, id string) error {
 }
 
 func mapAdminEditMutationError(err error) (*InputValidationInfo, error) {
-	switch {
-	case errors.Is(err, repository.ErrUserNotFound):
-		return NewInputValidationInfo("id", "user not found"), nil
-	case errors.Is(err, repository.ErrRoleNotFound):
-		return NewInputValidationInfo("roleIds", "role not found"), nil
-	case errors.Is(err, repository.ErrNotFound):
-		return NewInputValidationInfo("id", "user or role not found"), nil
-	case isContextDone(err):
-		return nil, err
-	default:
-		return nil, eris.Wrap(err, "usecase: admin user edit: tx")
-	}
+	return classifyRepoErr(err, "usecase: admin user edit: tx", []SentinelMapping{
+		{repository.ErrUserNotFound, "id", "user not found"},
+		{repository.ErrRoleNotFound, "roleIds", "role not found"},
+		{repository.ErrNotFound, "id", "user or role not found"},
+	})
 }
 
 // maxAdminEditRoleIDs caps the number of role ids accepted by a single

--- a/backend/internal/usecase/master_catalog.go
+++ b/backend/internal/usecase/master_catalog.go
@@ -431,21 +431,14 @@ type PublishMasterOutcome struct {
 
 // mapMasterAdminErr classifies a repository error from an admin master method
 // into either input-validation data (first slot) or a propagating error (second
-// slot), mirroring mapAdminRoleError. The ucerr.NewValidationError emission lives
-// HERE, not in the caller's method body, so the schema-lint bare-object gate does
-// not flag adminUnpublishMasterCardgroup (which returns a bare MasterCardgroup!).
-//   - repository.ErrNotFound              -> InputValidationInfo{Field: notFoundField}
-//   - context.Canceled / DeadlineExceeded -> passthrough via error
-//   - default                             -> eris.Wrap(err, wrap) via error
+// slot) by delegating to classifyRepoErr with the master-specific sentinel
+// mapping. The input-validation emission lives HERE, not in the caller's method
+// body, so the schema-lint bare-object gate does not flag
+// adminUnpublishMasterCardgroup (which returns a bare MasterCardgroup!).
 func mapMasterAdminErr(err error, notFoundField, wrap string) (*InputValidationInfo, error) {
-	switch {
-	case errors.Is(err, repository.ErrNotFound):
-		return NewInputValidationInfo(notFoundField, "master cardgroup not found"), nil
-	case isContextDone(err):
-		return nil, err
-	default:
-		return nil, eris.Wrap(err, wrap)
-	}
+	return classifyRepoErr(err, wrap, []SentinelMapping{
+		{repository.ErrNotFound, notFoundField, "master cardgroup not found"},
+	})
 }
 
 // derefOr returns *p when p is non-nil, otherwise def.

--- a/backend/internal/usecase/validators.go
+++ b/backend/internal/usecase/validators.go
@@ -132,3 +132,26 @@ func translateRoleNameErr(err error) error {
 		return eris.Wrap(err, "usecase: translate role name error")
 	}
 }
+
+// SentinelMapping maps a repository error sentinel to an input-validation field/message pair.
+type SentinelMapping struct {
+	Sentinel error
+	Field    string
+	Message  string
+}
+
+// classifyRepoErr classifies a repository error sentinel set into either input-validation data
+// or a propagating error. The mappings list defines the sentinel-to-field/message mapping;
+// if no mapping matches, context-done errors pass through unchanged and other errors are
+// wrapped with the supplied prefix per error-wrapping conventions.
+func classifyRepoErr(err error, wrap string, mappings []SentinelMapping) (*InputValidationInfo, error) {
+	for _, m := range mappings {
+		if errors.Is(err, m.Sentinel) {
+			return NewInputValidationInfo(m.Field, m.Message), nil
+		}
+	}
+	if isContextDone(err) {
+		return nil, err
+	}
+	return nil, eris.Wrap(err, wrap)
+}


### PR DESCRIPTION
## Summary

Consolidated three near-identical repository-error classifier functions (mapAdminRoleError, mapAdminEditMutationError, mapMasterAdminErr) into a single generic classifyRepoErr helper plus a SentinelMapping struct, both placed in the neutral usecase file validators.go (which already holds translateCardErr / translateRoleNameErr). The three classifiers are now thin wrappers that delegate to classifyRepoErr with their aggregate-specific sentinel mappings. Signatures are unchanged so all 11 call sites are untouched, and every sentinel match, field name, message string, and wrap prefix is preserved verbatim, making the change behavior-neutral. Also removed the manual-sync "The shape mirrors mapAdminEditMutationError" docstring burden on mapAdminRoleError.

## Changes

- Added `SentinelMapping` struct (`Sentinel error`, `Field string`, `Message string`) and generic `classifyRepoErr(err error, wrap string, mappings []SentinelMapping) (*InputValidationInfo, error)` to the neutral `backend/internal/usecase/validators.go`. The helper iterates the mappings (returning `NewInputValidationInfo(field, message)` on a sentinel match), passes context-done errors through unchanged, and wraps everything else with the caller-supplied prefix via `eris.Wrap` — exactly the prior switch semantics. No new imports needed (`errors`, `eris` already present).
- `admin_role.go`: rewrote `mapAdminRoleError` as a thin wrapper delegating to `classifyRepoErr` with `{ErrRoleNotFound, notFoundField, "role not found"}` and `{ErrRoleDuplicate, "name", "role name already exists"}`. Deleted the long "The shape mirrors mapAdminEditMutationError" manual-sync docstring (lines 244-261) and replaced it with a short doc that defers to classifyRepoErr.
- `admin_user.go`: rewrote `mapAdminEditMutationError` to delegate with wrap `"usecase: admin user edit: tx"` and mappings `{ErrUserNotFound, "id", "user not found"}`, `{ErrRoleNotFound, "roleIds", "role not found"}`, `{ErrNotFound, "id", "user or role not found"}`.
- `master_catalog.go`: rewrote `mapMasterAdminErr` to delegate with `{ErrNotFound, notFoundField, "master cardgroup not found"}`; trimmed the docstring's stale "mirroring mapAdminRoleError" bullet enumeration while preserving the load-bearing schema-lint bare-object-gate note.
- All 11 call sites unchanged (signatures preserved); verified via grep (11 callers, no `func map` self-matches).

## Test plan

- No new tests required; existing integration tests exercise all three classifiers indirectly via the admin role / admin user edit / master catalog mutation paths and remain green.
- Confirmed 11 call sites and 3 thin wrappers delegate to the single `classifyRepoErr` in validators.go.

Closes #748
