### PR TITLE
refactor(frontend): extract useCreateCardgroupForm hook to own create-cardgroup outcome routing

### DIFF
--- a/frontend/src/app/cardgroups/cardgroups-client.tsx
+++ b/frontend/src/app/cardgroups/cardgroups-client.tsx
@@ -28,7 +28,7 @@ import { useConnectionPagination } from "@/lib/pagination/use-connection-paginat
 import { useSeedConnectionCache } from "@/lib/pagination/use-seed-connection-cache";
 import { useUndoDelete } from "@/lib/undo-delete";
 import { CARDGROUPS_DEFAULT_VARS, DeleteCardgroupMutation } from "./queries";
-import { useCreateCardgroup } from "./use-create-cardgroup";
+import { useCreateCardgroupForm } from "./use-create-cardgroup-form";
 
 type Connection = MyCardgroupsConnectionQuery["myCardgroupsConnection"];
 type CardgroupEdge = Connection["edges"][number];
@@ -146,25 +146,31 @@ export default function CardgroupsClient({ initialConnection }: CardgroupsClient
   // flamingo:add-cardgroup event, by the desktop "New cardgroup" button, and
   // by the empty-state CTA. The full-page /cardgroups/new route stays for the
   // onboarding (welcome) and returnTo flows.
-  const { create: createCardgroup, loading: creating } = useCreateCardgroup();
+  const {
+    submit: submitCreateCardgroup,
+    loading: creating,
+    validationError: addValidationError,
+    authError: addAuthError,
+    limitError,
+    unexpectedError,
+    reset: resetCreateForm,
+  } = useCreateCardgroupForm();
   const [addOpen, setAddOpen] = useState(false);
   const [addDirty, setAddDirty] = useState(false);
-  const [addValidationError, setAddValidationError] = useState<{
-    field: string;
-    message: string;
-  } | null>(null);
-  const [addAuthError, setAddAuthError] = useState<"unauthenticated" | "forbidden" | null>(null);
-  const [addUnexpectedError, setAddUnexpectedError] = useState<string | null>(null);
-  const [addLimitError, setAddLimitError] = useState<string | null>(null);
+
+  // Translate the hook's structured error state to display copy. The drawer is
+  // modal, so surface a banner for both an unparseable payload ("unexpected")
+  // and a transport failure ("rejected") rather than failing silently.
+  const addLimitError = limitError
+    ? t("limitReached", { limit: limitError.limit, current: limitError.current })
+    : null;
+  const addUnexpectedError = unexpectedError ? tCommon("somethingWentWrong") : null;
 
   const openAddSheet = useCallback(() => {
-    setAddValidationError(null);
-    setAddAuthError(null);
-    setAddUnexpectedError(null);
-    setAddLimitError(null);
+    resetCreateForm();
     setAddDirty(false);
     setAddOpen(true);
-  }, []);
+  }, [resetCreateForm]);
 
   useEffect(() => {
     // Cancel any default navigation to /cardgroups/new and open the drawer in
@@ -176,35 +182,13 @@ export default function CardgroupsClient({ initialConnection }: CardgroupsClient
   }, [openAddSheet]);
 
   async function handleCreateCardgroup(values: { name: string }) {
-    setAddValidationError(null);
-    setAddAuthError(null);
-    setAddUnexpectedError(null);
-    setAddLimitError(null);
+    const outcome = await submitCreateCardgroup(values);
 
-    const outcome = await createCardgroup(values.name);
-
-    switch (outcome.status) {
-      case "validation":
-        setAddValidationError({ field: outcome.field, message: outcome.message });
-        return;
-      case "auth":
-        setAddAuthError(outcome.kind);
-        return;
-      case "limit":
-        setAddLimitError(t("limitReached", { limit: outcome.limit, current: outcome.current }));
-        return;
-      case "unexpected":
-      case "rejected":
-        // The drawer is modal, so surface a banner for both an unparseable
-        // payload and a transport failure rather than failing silently.
-        setAddUnexpectedError(tCommon("somethingWentWrong"));
-        return;
-      case "success":
-        // The connection cache is updated inside useCreateCardgroup, so the new
-        // row appears in the list without a refetch. Just close the drawer.
-        setAddDirty(false);
-        setAddOpen(false);
-        return;
+    if (outcome.status === "success") {
+      // The connection cache is updated inside useCreateCardgroup, so the new
+      // row appears in the list without a refetch. Just close the drawer.
+      setAddDirty(false);
+      setAddOpen(false);
     }
   }
 
@@ -414,10 +398,7 @@ export default function CardgroupsClient({ initialConnection }: CardgroupsClient
             setAddOpen(nextOpen);
             if (!nextOpen) {
               setAddDirty(false);
-              setAddValidationError(null);
-              setAddAuthError(null);
-              setAddUnexpectedError(null);
-              setAddLimitError(null);
+              resetCreateForm();
             }
           }}
           submitting={creating}

--- a/frontend/src/app/cardgroups/new/new-cardgroup-client.tsx
+++ b/frontend/src/app/cardgroups/new/new-cardgroup-client.tsx
@@ -2,13 +2,11 @@
 
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
-import { useCallback, useState } from "react";
-import { useCreateCardgroup } from "@/app/cardgroups/use-create-cardgroup";
+import { useCreateCardgroupForm } from "@/app/cardgroups/use-create-cardgroup-form";
 import { FlamingoMark } from "@/components/brand/flamingo-mark";
 import { CardgroupForm } from "@/components/cardgroups/cardgroup-form";
 import { AuthErrorBanner } from "@/components/ui/auth-error-banner";
 import { ErrorBanner } from "@/components/ui/error-banner";
-import { useSheetForm } from "@/lib/forms/use-sheet-form";
 
 interface NewCardgroupClientProps {
   showWelcome?: boolean;
@@ -21,65 +19,38 @@ export function NewCardgroupClient({ showWelcome = false, returnTo }: NewCardgro
   const t = useTranslations("Cardgroups");
   const tCommon = useTranslations("Common");
 
-  // Semantically distinct from validationError: this surfaces a degraded
-  // "Something went wrong" banner when the server returns a __typename the
-  // client was not regenerated against, or null payload from a partial-
-  // response null bubble.
-  const [unexpectedPayloadError, setUnexpectedPayloadError] = useState<string | null>(null);
+  // The hook owns the create mutation, outcome routing, and the structured
+  // error state (validation / auth / limit / unexpected). Auth failures are
+  // surfaced as a degraded banner with a <Link href="/login"> rather than a
+  // redirect — see .claude/rules/frontend-rsc-error-handling.md § "Mid-session
+  // UNAUTHENTICATED in a client component".
+  const { submit, loading, validationError, authError, limitError, unexpectedError } =
+    useCreateCardgroupForm();
 
-  // Server-enforced cardgroup limit reached. Rendered as a banner so the
-  // user knows creation is blocked without a field-level error indicator.
-  const [limitError, setLimitError] = useState<string | null>(null);
+  // Server-enforced cardgroup limit reached. Rendered as a banner so the user
+  // knows creation is blocked without a field-level error indicator.
+  const formattedLimitError = limitError
+    ? t("limitReached", { limit: limitError.limit, current: limitError.current })
+    : null;
 
-  // Mid-session auth failures. Cleared on each new submission attempt so a
-  // retry after re-login does not show a stale banner.
-  // Per .claude/rules/frontend-rsc-error-handling.md § "Mid-session
-  // UNAUTHENTICATED in a client component: degraded banner with
-  // <Link href="/login">, not redirect()".
-  const [authError, setAuthError] = useState<"unauthenticated" | "forbidden" | null>(null);
-
-  const { create, loading } = useCreateCardgroup();
-
-  // Full-page create: success navigates away (parameterized by the returned
-  // cardgroup id), so the `success` arm stays in the switch below. `useSheetForm`
-  // owns only the field-level `validationError` + its clear-on-submit reset;
-  // there is no sheet to close, so `onSuccess` is a no-op.
-  const onSuccess = useCallback(() => undefined, []);
-  const { validationError, run } = useSheetForm(onSuccess);
+  // Degraded "Something went wrong" banner when the server returns a __typename
+  // the client was not regenerated against, or a null payload from a partial-
+  // response null bubble. A transport rejection ("rejected") stays silent — the
+  // IO hook already warned — to preserve the established full-page behavior.
+  const unexpectedPayloadError =
+    unexpectedError === "unexpected" ? tCommon("somethingWentWrong") : null;
 
   async function handleSubmit(values: { name: string }) {
-    setUnexpectedPayloadError(null);
-    setAuthError(null);
-    setLimitError(null);
+    const outcome = await submit(values);
 
-    const outcome = await run(() => create(values.name));
-
-    switch (outcome.status) {
-      case "validation":
-        // `run` cleared and stored the field-level error.
+    if (outcome.status === "success") {
+      if (returnTo) {
+        const sep = returnTo.includes("?") ? "&" : "?";
+        router.push(`${returnTo}${sep}cardgroup=${outcome.cardgroupId}`);
         return;
-      case "auth":
-        setAuthError(outcome.kind);
-        return;
-      case "limit":
-        setLimitError(t("limitReached", { limit: outcome.limit, current: outcome.current }));
-        return;
-      case "unexpected":
-        setUnexpectedPayloadError(tCommon("somethingWentWrong"));
-        return;
-      case "rejected":
-        // Transport/network failure: the hook already warned. Stay silent (no
-        // banner) to preserve the established full-page behavior.
-        return;
-      case "success":
-        if (returnTo) {
-          const sep = returnTo.includes("?") ? "&" : "?";
-          router.push(`${returnTo}${sep}cardgroup=${outcome.cardgroupId}`);
-          return;
-        }
-        router.push(`/cardgroups/${outcome.cardgroupId}`);
-        router.refresh();
-        return;
+      }
+      router.push(`/cardgroups/${outcome.cardgroupId}`);
+      router.refresh();
     }
   }
 
@@ -121,9 +92,9 @@ export function NewCardgroupClient({ showWelcome = false, returnTo }: NewCardgro
         </ErrorBanner>
       ) : null}
 
-      {limitError ? (
+      {formattedLimitError ? (
         <ErrorBanner className="mb-4" data-testid="cardgroup-new-limit-error">
-          {limitError}
+          {formattedLimitError}
         </ErrorBanner>
       ) : null}
 

--- a/frontend/src/app/cardgroups/use-create-cardgroup-form.test.ts
+++ b/frontend/src/app/cardgroups/use-create-cardgroup-form.test.ts
@@ -1,0 +1,282 @@
+// @vitest-environment happy-dom
+import type { MockedResponse } from "@apollo/client/testing";
+import { MockedProvider } from "@apollo/client/testing/react";
+import { act, renderHook } from "@testing-library/react";
+import { GraphQLError } from "graphql";
+import { createElement, type ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { CreateCardgroupMutation } from "./queries";
+import { useCreateCardgroupForm } from "./use-create-cardgroup-form";
+
+const CREATED_CARDGROUP = {
+  __typename: "Cardgroup" as const,
+  id: "cg-1",
+  name: "My Group",
+  updatedAt: "2026-04-30T00:00:00Z",
+};
+
+function successMock(name: string): MockedResponse {
+  return {
+    request: { query: CreateCardgroupMutation, variables: { input: { name } } },
+    result: {
+      data: {
+        createCardgroup: {
+          __typename: "CreateCardgroupSuccess",
+          cardgroup: { ...CREATED_CARDGROUP, name },
+        },
+      },
+    },
+  };
+}
+
+function render(mocks: MockedResponse[]) {
+  return renderHook(() => useCreateCardgroupForm(), {
+    wrapper: ({ children }: { children: ReactNode }) =>
+      createElement(MockedProvider, { mocks }, children),
+  });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("useCreateCardgroupForm.submit", () => {
+  it("returns success and sets no error state on CreateCardgroupSuccess", async () => {
+    const { result } = render([successMock("My Group")]);
+
+    let outcome: unknown;
+    await act(async () => {
+      outcome = await result.current.submit({ name: "My Group" });
+    });
+
+    expect(outcome).toEqual({ status: "success", cardgroupId: "cg-1" });
+    expect(result.current.validationError).toBeNull();
+    expect(result.current.authError).toBeNull();
+    expect(result.current.limitError).toBeNull();
+    expect(result.current.unexpectedError).toBeNull();
+  });
+
+  it("sets validationError on InputValidationError", async () => {
+    const mocks: MockedResponse[] = [
+      {
+        request: { query: CreateCardgroupMutation, variables: { input: { name: "Dup" } } },
+        result: {
+          data: {
+            createCardgroup: {
+              __typename: "InputValidationError",
+              field: "name",
+              message: "name already exists",
+            },
+          },
+        },
+      },
+    ];
+    const { result } = render(mocks);
+
+    let outcome: unknown;
+    await act(async () => {
+      outcome = await result.current.submit({ name: "Dup" });
+    });
+
+    expect(outcome).toEqual({
+      status: "validation",
+      field: "name",
+      message: "name already exists",
+    });
+    expect(result.current.validationError).toEqual({
+      field: "name",
+      message: "name already exists",
+    });
+    expect(result.current.unexpectedError).toBeNull();
+  });
+
+  it("sets authError 'unauthenticated' when the mutation rejects with UNAUTHENTICATED", async () => {
+    const mocks: MockedResponse[] = [
+      {
+        request: { query: CreateCardgroupMutation, variables: { input: { name: "My Group" } } },
+        result: {
+          errors: [
+            new GraphQLError("Unauthenticated", { extensions: { code: "UNAUTHENTICATED" } }),
+          ],
+        },
+      },
+    ];
+    const { result } = render(mocks);
+
+    let outcome: unknown;
+    await act(async () => {
+      outcome = await result.current.submit({ name: "My Group" });
+    });
+
+    expect(outcome).toEqual({ status: "auth", kind: "unauthenticated" });
+    expect(result.current.authError).toBe("unauthenticated");
+  });
+
+  it("sets authError 'forbidden' when the mutation rejects with FORBIDDEN", async () => {
+    const mocks: MockedResponse[] = [
+      {
+        request: { query: CreateCardgroupMutation, variables: { input: { name: "My Group" } } },
+        result: { errors: [new GraphQLError("Forbidden", { extensions: { code: "FORBIDDEN" } })] },
+      },
+    ];
+    const { result } = render(mocks);
+
+    let outcome: unknown;
+    await act(async () => {
+      outcome = await result.current.submit({ name: "My Group" });
+    });
+
+    expect(outcome).toEqual({ status: "auth", kind: "forbidden" });
+    expect(result.current.authError).toBe("forbidden");
+  });
+
+  it("sets limitError on CardgroupLimitReachedError", async () => {
+    const mocks: MockedResponse[] = [
+      {
+        request: { query: CreateCardgroupMutation, variables: { input: { name: "My Group" } } },
+        result: {
+          data: {
+            createCardgroup: {
+              __typename: "CardgroupLimitReachedError",
+              message: "cardgroup limit reached",
+              limit: 5,
+              current: 5,
+            },
+          },
+        },
+      },
+    ];
+    const { result } = render(mocks);
+
+    let outcome: unknown;
+    await act(async () => {
+      outcome = await result.current.submit({ name: "My Group" });
+    });
+
+    expect(outcome).toEqual({ status: "limit", limit: 5, current: 5 });
+    expect(result.current.limitError).toEqual({ limit: 5, current: 5 });
+  });
+
+  it("sets unexpectedError 'unexpected' on an unknown payload variant", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const mocks: MockedResponse[] = [
+      {
+        request: { query: CreateCardgroupMutation, variables: { input: { name: "My Group" } } },
+        result: { data: { createCardgroup: { __typename: "SomeFutureVariant" } as never } },
+      },
+    ];
+    const { result } = render(mocks);
+
+    let outcome: unknown;
+    await act(async () => {
+      outcome = await result.current.submit({ name: "My Group" });
+    });
+
+    expect(outcome).toEqual({ status: "unexpected" });
+    expect(result.current.unexpectedError).toBe("unexpected");
+  });
+
+  it("sets unexpectedError 'unexpected' on a null payload (partial-response null bubble)", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const mocks: MockedResponse[] = [
+      {
+        request: { query: CreateCardgroupMutation, variables: { input: { name: "My Group" } } },
+        result: { data: { createCardgroup: null as never } },
+      },
+    ];
+    const { result } = render(mocks);
+
+    let outcome: unknown;
+    await act(async () => {
+      outcome = await result.current.submit({ name: "My Group" });
+    });
+
+    expect(outcome).toEqual({ status: "unexpected" });
+    expect(result.current.unexpectedError).toBe("unexpected");
+  });
+
+  it("sets unexpectedError 'rejected' on a transport error", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const mocks: MockedResponse[] = [
+      {
+        request: { query: CreateCardgroupMutation, variables: { input: { name: "My Group" } } },
+        error: new Error("network down"),
+      },
+    ];
+    const { result } = render(mocks);
+
+    let outcome: unknown;
+    await act(async () => {
+      outcome = await result.current.submit({ name: "My Group" });
+    });
+
+    expect(outcome).toEqual({ status: "rejected" });
+    expect(result.current.unexpectedError).toBe("rejected");
+  });
+
+  it("clears prior error state before the next submit (success after validation)", async () => {
+    const mocks: MockedResponse[] = [
+      {
+        request: { query: CreateCardgroupMutation, variables: { input: { name: "Dup" } } },
+        result: {
+          data: {
+            createCardgroup: {
+              __typename: "InputValidationError",
+              field: "name",
+              message: "name already exists",
+            },
+          },
+        },
+      },
+      successMock("Fresh"),
+    ];
+    const { result } = render(mocks);
+
+    await act(async () => {
+      await result.current.submit({ name: "Dup" });
+    });
+    expect(result.current.validationError).not.toBeNull();
+
+    let outcome: unknown;
+    await act(async () => {
+      outcome = await result.current.submit({ name: "Fresh" });
+    });
+
+    expect(outcome).toEqual({ status: "success", cardgroupId: "cg-1" });
+    expect(result.current.validationError).toBeNull();
+  });
+});
+
+describe("useCreateCardgroupForm.reset", () => {
+  it("clears all error state", async () => {
+    const mocks: MockedResponse[] = [
+      {
+        request: { query: CreateCardgroupMutation, variables: { input: { name: "Dup" } } },
+        result: {
+          data: {
+            createCardgroup: {
+              __typename: "InputValidationError",
+              field: "name",
+              message: "name already exists",
+            },
+          },
+        },
+      },
+    ];
+    const { result } = render(mocks);
+
+    await act(async () => {
+      await result.current.submit({ name: "Dup" });
+    });
+    expect(result.current.validationError).not.toBeNull();
+
+    act(() => {
+      result.current.reset();
+    });
+
+    expect(result.current.validationError).toBeNull();
+    expect(result.current.authError).toBeNull();
+    expect(result.current.limitError).toBeNull();
+    expect(result.current.unexpectedError).toBeNull();
+  });
+});

--- a/frontend/src/app/cardgroups/use-create-cardgroup-form.ts
+++ b/frontend/src/app/cardgroups/use-create-cardgroup-form.ts
@@ -1,0 +1,94 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import type { CreateCardgroupOutcome } from "./use-create-cardgroup";
+import { useCreateCardgroup } from "./use-create-cardgroup";
+
+/**
+ * Form state machine for create-cardgroup outcome routing and error display.
+ * Wraps the IO-only {@link useCreateCardgroup} hook (which owns the mutation,
+ * the Connection cache write, and the outcome narrowing) and adds the form-side
+ * error state — validation, auth, limit, and unexpected — that both create
+ * clients previously hand-rolled identically. Mirrors the thin-outcome-hook
+ * shape of `useRoleMutations` / `useSheetForm`: own the field-level error,
+ * delegate caller-specific side effects (drawer close, navigation) to the
+ * consumer.
+ *
+ * `submit(values)` clears all error state, calls the create mutation, routes the
+ * returned outcome into the matching error state, and returns the raw outcome so
+ * the caller can handle `success` (navigation / drawer close) without re-parsing
+ * the union.
+ *
+ * Callers translate the structured error state to display copy:
+ * - `validationError` → passed directly to `CardgroupForm`'s `validationError` prop
+ * - `authError` → resolved to banner copy for `AuthErrorBanner`
+ * - `limitError` → translated via i18n `t("limitReached", { limit, current })`
+ * - `unexpectedError` → translated via i18n `tCommon("somethingWentWrong")`;
+ *   the discriminant (`"unexpected"` vs `"rejected"`) lets each client decide
+ *   whether a transport rejection surfaces a banner (the modal drawer does; the
+ *   full-page route stays silent).
+ *
+ * The underlying mutation carries no `optimisticResponse`: typed errors
+ * (`InputValidationError`, `CardgroupLimitReachedError`, `FORBIDDEN`) can fail it
+ * and Apollo does not reliably roll back optimistic writes for typed GraphQL
+ * errors — see .claude/rules/pagination.md.
+ */
+export function useCreateCardgroupForm() {
+  const { create: createCardgroup, loading } = useCreateCardgroup();
+
+  const [validationError, setValidationError] = useState<{
+    field: string;
+    message: string;
+  } | null>(null);
+  const [authError, setAuthError] = useState<"unauthenticated" | "forbidden" | null>(null);
+  const [limitError, setLimitError] = useState<{ limit: number; current: number } | null>(null);
+  const [unexpectedError, setUnexpectedError] = useState<"unexpected" | "rejected" | null>(null);
+
+  const reset = useCallback(() => {
+    setValidationError(null);
+    setAuthError(null);
+    setLimitError(null);
+    setUnexpectedError(null);
+  }, []);
+
+  const submit = useCallback(
+    async (values: { name: string }): Promise<CreateCardgroupOutcome> => {
+      reset();
+      const outcome = await createCardgroup(values.name);
+
+      switch (outcome.status) {
+        case "validation":
+          setValidationError({ field: outcome.field, message: outcome.message });
+          break;
+        case "auth":
+          setAuthError(outcome.kind);
+          break;
+        case "limit":
+          setLimitError({ limit: outcome.limit, current: outcome.current });
+          break;
+        case "unexpected":
+          setUnexpectedError("unexpected");
+          break;
+        case "rejected":
+          setUnexpectedError("rejected");
+          break;
+        case "success":
+          // Success: no error state to set; the caller navigates / closes.
+          break;
+      }
+
+      return outcome;
+    },
+    [createCardgroup, reset],
+  );
+
+  return {
+    submit,
+    loading,
+    validationError,
+    authError,
+    limitError,
+    unexpectedError,
+    reset,
+  };
+}


### PR DESCRIPTION
## Summary

Both create-cardgroup clients (the inline drawer on `cardgroups-client.tsx` and the full-page `/cardgroups/new` route) hand-rolled identical orchestration to route the `CreateCardgroupOutcome` union into form error state. This extracts that duplication into a new `useCreateCardgroupForm` hook that wraps the IO-only `useCreateCardgroup` (which still owns the mutation + Connection cache write) and adds the validation/auth/limit/unexpected error state plus a `submit`/`reset` API, mirroring the `useRoleMutations` precedent. Both clients now consume the hook and reduce their submit handlers to `await submit(values)` + a success branch. No behavioral change: all data-testids are preserved byte-for-byte and the per-client difference for transport rejections is retained (the modal drawer surfaces a banner; the full-page route stays silent) via the hook's `unexpected`/`rejected` discriminant.

## Changes

- Add `frontend/src/app/cardgroups/use-create-cardgroup-form.ts`: form state machine wrapping `useCreateCardgroup`; exposes `submit(values) => Promise<CreateCardgroupOutcome>`, `loading`, structured `validationError`/`authError`/`limitError`/`unexpectedError` state, and `reset()`. `submit` clears errors, runs the mutation, routes the outcome, and returns it. `limitError` is `{ limit, current }` and `unexpectedError` is the discriminant `"unexpected" | "rejected"`, so each consumer maps to display copy at render time.
- Refactor `cardgroups-client.tsx` (inline drawer): replace four manual `useState` error slices + the outcome `switch` with the hook; derive `addLimitError`/`addUnexpectedError` via `t()`/`tCommon()` (banner shown for both `unexpected` and `rejected`, matching prior modal behavior); `handleCreateCardgroup` reduces to `await submitCreateCardgroup(values)` + close-on-success; `openAddSheet` and the FormSheet close handler call `resetCreateForm()`.
- Refactor `new/new-cardgroup-client.tsx` (full-page): remove `useSheetForm` + the manual error state; consume the hook; `formattedLimitError` via `t()`, `unexpectedPayloadError` only when `unexpectedError === "unexpected"` (transport `rejected` stays silent, preserving the established full-page behavior verified by the existing "generic transport rejection" test); `handleSubmit` reduces to `await submit(values)` + success navigation (returnTo / refresh).
- Add `frontend/src/app/cardgroups/use-create-cardgroup-form.test.ts`: co-located hook tests mirroring `use-role-mutations.test.ts` — success (with cardgroupId, no error state), validation, auth unauthenticated/forbidden, limit, unexpected (unknown __typename + null payload), transport rejected, clear-before-next-submit, and `reset()` clears all state.

## Test plan

- `tsc --noEmit`: passes (exit 0).
- `biome check --error-on-warnings .`: passes (exit 0).
- `knip`: passes (exit 0).
- Targeted: hook test + `cardgroups-client.test.tsx` + `new/page.test.tsx` — 3 files / 58 tests pass; all `cardgroup-create-*` and `cardgroup-new-*` testids exercised unchanged.
- CJK gate (`perl -CSD`) over changed/new `.ts`/`.tsx`: prints nothing.
- Full suite: `vitest run` (no path filter) — 188 files / 1748 tests pass.

## Notes

The issue's "After" snippet was illustrative (the issue body flags this). Applying it verbatim for the full-page client would have surfaced the degraded banner on a transport rejection too, breaking the existing `new/page.test.tsx` assertion that a generic transport rejection shows no banner (`cardgroup-new-unexpected-payload-error` must be absent). To preserve behavior, the full-page client gates its unexpected banner on `unexpectedError === "unexpected"` so the `rejected` case stays silent, while the inline drawer keeps showing the banner for both `unexpected` and `rejected` (its prior behavior). The per-client difference is retained via the hook's `"unexpected" | "rejected"` discriminant; `use-create-cardgroup.ts` (IO-only) is unchanged.

Closes #749
