### PR TITLE
chore(frontend+domain): harden supabase server-only boundary and fix stale Card.Position docstring

### DIFF
--- a/backend/internal/domain/card.go
+++ b/backend/internal/domain/card.go
@@ -28,10 +28,11 @@ type Card struct {
 	Back        CardText
 	CreatedAt   time.Time
 	UpdatedAt   time.Time
-	// Position is the card's place within its cardgroup's source document
-	// (Notion sync order). It defaults to 0 for cards not created via Notion
-	// sync; the ordering policy treats cards with equal Position as one
-	// shuffle group, preserving prior behavior for non-Notion groups.
+	// Position persists the card's place within its cardgroup's source
+	// document (Notion sync order). It defaults to 0 for cards not created
+	// via Notion sync. The learn-session OrderingPolicy does not consult
+	// Position: due-card ordering is driven by the discovery-first policy in
+	// domain/service, whose DueCard view does not carry this field.
 	Position int
 }
 

--- a/frontend/src/lib/supabase/server.ts
+++ b/frontend/src/lib/supabase/server.ts
@@ -1,3 +1,4 @@
+import "server-only";
 import { createServerClient } from "@supabase/ssr";
 import { cookies } from "next/headers";
 import { env } from "@/env";


### PR DESCRIPTION
## Summary

Two small, independent consistency/accuracy fixes bundled into one tiny PR.

1. `frontend/src/lib/supabase/server.ts` read `cookies()` from `next/headers` but lacked `import "server-only"`, whereas the sibling `frontend/src/lib/apollo/server.ts` already carries it. Adding the import makes the RSC/Client build-time guard uniform across server-only modules: a Client Component that accidentally imports this module now fails at build time instead of leaking a server-only path into the browser bundle.
2. The `Card.Position` docstring in `backend/internal/domain/card.go` claimed "the ordering policy treats cards with equal Position as one shuffle group". The current `OrderingPolicy.Apply` (`backend/internal/domain/service/due_card_ordering.go`) does not consult `Position` at all — its `DueCard` view does not even carry the field; ordering is driven by the discovery-first policy. The docstring described the replaced tie-scoped-shuffle behavior and was misleading.

No behavioral change: the frontend edit is a build-time guard import, and the backend edit is comment-only.

## Changes

- `frontend/src/lib/supabase/server.ts`: add `import "server-only";` as the first line, matching `frontend/src/lib/apollo/server.ts`.
- `backend/internal/domain/card.go`: rewrite the `Card.Position` docstring to state that `Position` persists the Notion document order and that the learn-session `OrderingPolicy` does not consult it (its `DueCard` view carries no `Position`).

## Test plan

- `pnpm --filter frontend typecheck`: passes.
- `pnpm --filter frontend lint`: passes (`biome check --error-on-warnings`).
- `pnpm --filter frontend knip`: passes.
- `pnpm --filter frontend test`: passes (188 files / 1748 tests).
- `pnpm --filter frontend build`: passes.
- `cd backend && go build ./...`: passes.
- `cd backend && go vet ./...`: passes.
- `cd backend && go test ./internal/domain/...`: passes (263 tests).

Closes #761
