### PR TITLE
fix(domain): compute study streak on the canonical JST learn-day boundary

### DIFF
--- a/backend/internal/domain/learn_day.go
+++ b/backend/internal/domain/learn_day.go
@@ -17,3 +17,6 @@ func StartOfLearnDay(now time.Time) time.Time {
 	y, m, d := local.Date()
 	return time.Date(y, m, d, 0, 0, 0, 0, learnDayZone)
 }
+
+// LearnDayKey returns the canonical JST learn-day key (YYYY-MM-DD) for t.
+func LearnDayKey(t time.Time) string { return StartOfLearnDay(t).Format(time.DateOnly) }

--- a/backend/internal/domain/rating.go
+++ b/backend/internal/domain/rating.go
@@ -18,6 +18,12 @@ func (r Rating) IsValid() bool {
 	return r >= RatingAgain && r <= RatingEasy
 }
 
+// IsSuccess reports whether the rating counts as a successful review (Good or
+// Easy). The 3-step swipe UI never emits RatingGood (RatingFromSwipeMode yields
+// only 1/2/4), so "success" is effectively Easy today; the predicate stays
+// >= RatingGood to remain correct if Good is ever wired.
+func (r Rating) IsSuccess() bool { return r >= RatingGood }
+
 // RatingFromSwipeMode maps the legacy 3-step swipe UI to FSRS ratings. The UI
 // emits 1=Again, 2=Hard, and 4=Easy; it intentionally does not emit 3=Good.
 func RatingFromSwipeMode(mode int) (Rating, error) {

--- a/backend/internal/domain/service/user_performance.go
+++ b/backend/internal/domain/service/user_performance.go
@@ -18,6 +18,18 @@ const (
 	ModeInWhile   PerformanceMode = 4
 
 	MinReviewsForModeCalculation = 20
+
+	// Success-rate band thresholds for ModeFromMetrics. A success rate at or
+	// above each threshold selects the named mode (or higher).
+	defaultModeThreshold = 0.60
+	goodModeThreshold    = 0.75
+	easyModeThreshold    = 0.85
+	inWhileModeThreshold = 0.95
+
+	// Average-difficulty nudges shift the band-selected mode by one step:
+	// hard recent cards drop the mode, easy recent cards raise it.
+	highDifficultyThreshold = 0.7
+	lowDifficultyThreshold  = 0.3
 )
 
 // IsValid reports whether the mode is in the recognised range.
@@ -51,7 +63,7 @@ func ComputeMetrics(swipes []domain.SwipeRecord, now time.Time) PerformanceMetri
 	daysSeen := make(map[string]struct{}, len(swipes))
 
 	for _, swipe := range swipes {
-		if swipe.Rating >= domain.RatingGood {
+		if swipe.Rating.IsSuccess() {
 			successes++
 		}
 		if swipe.StateAfter.ElapsedDays <= swipe.StateAfter.ScheduledDays {
@@ -65,7 +77,7 @@ func ComputeMetrics(swipes []domain.SwipeRecord, now time.Time) PerformanceMetri
 		}
 
 		difficultySum += normalizedDifficulty(swipe.StateAfter.Difficulty)
-		daysSeen[swipe.ReviewedAt.In(now.Location()).Format(time.DateOnly)] = struct{}{}
+		daysSeen[domain.LearnDayKey(swipe.ReviewedAt)] = struct{}{}
 	}
 
 	return PerformanceMetrics{
@@ -85,19 +97,19 @@ func ModeFromMetrics(m PerformanceMetrics) PerformanceMode {
 
 	mode := ModeInWhile
 	switch {
-	case m.SuccessRate < 0.60:
+	case m.SuccessRate < defaultModeThreshold:
 		mode = ModeDifficult
-	case m.SuccessRate < 0.75:
+	case m.SuccessRate < goodModeThreshold:
 		mode = ModeDefault
-	case m.SuccessRate < 0.85:
+	case m.SuccessRate < easyModeThreshold:
 		mode = ModeGood
-	case m.SuccessRate < 0.95:
+	case m.SuccessRate < inWhileModeThreshold:
 		mode = ModeEasy
 	}
 
-	if m.AvgDifficulty >= 0.7 {
+	if m.AvgDifficulty >= highDifficultyThreshold {
 		mode--
-	} else if m.AvgDifficulty <= 0.3 {
+	} else if m.AvgDifficulty <= lowDifficultyThreshold {
 		mode++
 	}
 
@@ -126,19 +138,17 @@ func isKnownCardReview(swipe domain.SwipeRecord) bool {
 		swipe.StateAfter.Lapses > 0
 }
 
+// studyStreak counts consecutive JST learn-days ending at the current learn-day,
+// breaking on the first day with no swipe. If the current learn-day has no
+// swipe, the streak is 0.
 func studyStreak(daysSeen map[string]struct{}, now time.Time) int {
 	streak := 0
-	for day := startOfDay(now); ; day = day.AddDate(0, 0, -1) {
-		if _, ok := daysSeen[day.Format(time.DateOnly)]; !ok {
+	for day := domain.StartOfLearnDay(now); ; day = day.AddDate(0, 0, -1) {
+		if _, ok := daysSeen[domain.LearnDayKey(day)]; !ok {
 			return streak
 		}
 		streak++
 	}
-}
-
-func startOfDay(t time.Time) time.Time {
-	year, month, day := t.Date()
-	return time.Date(year, month, day, 0, 0, 0, 0, t.Location())
 }
 
 func ratio(numerator, denominator int) float64 {

--- a/backend/internal/domain/service/user_performance_test.go
+++ b/backend/internal/domain/service/user_performance_test.go
@@ -12,7 +12,9 @@ import (
 func TestComputeMetrics(t *testing.T) {
 	t.Parallel()
 
-	now := time.Date(2026, 4, 30, 15, 0, 0, 0, time.UTC)
+	// 03:00 UTC == 12:00 JST, safely inside one JST learn-day, so the
+	// relative-day fixtures below stay on consecutive JST learn-days.
+	now := time.Date(2026, 4, 30, 3, 0, 0, 0, time.UTC)
 
 	cases := []struct {
 		name   string
@@ -125,6 +127,29 @@ func TestComputeMetrics(t *testing.T) {
 			require.Equal(t, tc.want.ReviewCount, got.ReviewCount)
 		})
 	}
+}
+
+// TestComputeMetrics_JSTLearnDayBoundary proves the study streak and distinct-day
+// counting bucket on the canonical JST learn-day, not on UTC. A swipe at 00:30 JST
+// (= the previous day 15:30 UTC) must count on its JST calendar day, and a streak
+// spanning that boundary must stay unbroken. Under UTC bucketing the same fixtures
+// would yield a streak of 0.
+func TestComputeMetrics_JSTLearnDayBoundary(t *testing.T) {
+	t.Parallel()
+
+	// now is 2026-05-02 10:00 JST (= 2026-05-02 01:00 UTC); the current learn-day is 2026-05-02.
+	now := time.Date(2026, 5, 2, 1, 0, 0, 0, time.UTC)
+
+	swipes := []domain.SwipeRecord{
+		// 2026-05-02 00:30 JST: counts on 2026-05-02, not the previous UTC day.
+		swipe(domain.RatingEasy, time.Date(2026, 5, 1, 15, 30, 0, 0, time.UTC), state(5, 1, 1, domain.FSRSStateReview)),
+		// 2026-05-01 00:30 JST: the previous learn-day.
+		swipe(domain.RatingEasy, time.Date(2026, 4, 30, 15, 30, 0, 0, time.UTC), state(5, 1, 1, domain.FSRSStateReview)),
+	}
+
+	got := ComputeMetrics(swipes, now)
+
+	require.Equal(t, 2, got.StudyStreak)
 }
 
 func TestModeFromMetricsThresholdBoundaries(t *testing.T) {


### PR DESCRIPTION
## Summary

The canonical learner-day boundary is a fixed JST (UTC+9) offset, defined in `backend/internal/domain/learn_day.go` (`learnDayZone` / `StartOfLearnDay`). The learn queue already uses it, but the performance metrics (study streak, distinct study days) bucketed by UTC instead: `swipe.ReviewedAt.In(now.Location())` and a `now.Location()`-based `startOfDay`, with `now` originating as `time.Now().UTC()`. The effective day boundary was therefore UTC midnight (= 09:00 JST), so a JST learner studying between 00:00–09:00 JST was counted on the previous day, and two sessions in the same JST calendar day could split across two buckets — a user-visible streak miscount for the app's JST audience.

This routes the streak and distinct-day counting through the canonical JST learn-day boundary. The fix is self-contained in the domain layer: `LearnDayKey` / `StartOfLearnDay` convert to JST internally, so the existing UTC `now` is passed through unchanged. `swipe.go` is not touched, and the streak semantics are preserved exactly (consecutive learn-days ending at the current learn-day, breaking on the first day with no swipe; if the current learn-day has no swipe, the streak is 0).

## Changes

- `backend/internal/domain/learn_day.go`: add `LearnDayKey(t time.Time) string`, returning the canonical JST learn-day key (`StartOfLearnDay(t).Format(time.DateOnly)`).
- `backend/internal/domain/service/user_performance.go`:
  - Bucket `daysSeen` by `domain.LearnDayKey(swipe.ReviewedAt)` instead of `swipe.ReviewedAt.In(now.Location()).Format(time.DateOnly)`.
  - `studyStreak` now walks days from `domain.StartOfLearnDay(now)`, steps `day = day.AddDate(0, 0, -1)`, and tests membership via `domain.LearnDayKey(day)`. Added a docstring pinning the preserved semantics.
  - Deleted the now-unused UTC-bound `startOfDay` helper (no other callers).
- Ride-along (same file, bundled to avoid a second PR on `user_performance.go`):
  - Replaced the magic success-rate band thresholds in `ModeFromMetrics` (0.60 / 0.75 / 0.85 / 0.95) and the average-difficulty nudges (0.7 / 0.3) with named package-level constants (`defaultModeThreshold`, `goodModeThreshold`, `easyModeThreshold`, `inWhileModeThreshold`, `highDifficultyThreshold`, `lowDifficultyThreshold`), mirroring the existing `MinReviewsForModeCalculation` style. Same numeric values — no behavior change.
- `backend/internal/domain/rating.go`: add `func (r Rating) IsSuccess() bool { return r >= RatingGood }`, called from `user_performance.go` in place of the bare `swipe.Rating >= domain.RatingGood`. A docstring notes the 3-step swipe UI never emits `RatingGood` (`RatingFromSwipeMode` yields only 1/2/4), so "success" is effectively Easy today, but the predicate stays `>= RatingGood` to remain correct if Good is ever wired.
- `backend/internal/domain/service/user_performance_test.go`:
  - New `TestComputeMetrics_JSTLearnDayBoundary`: a swipe at 00:30 JST (= the previous day 15:30 UTC) counts on its JST calendar day, and a streak spanning that boundary stays unbroken (streak = 2). Under UTC bucketing the same fixtures would yield 0.
  - Moved the existing `TestComputeMetrics` fixture `now` from 15:00 UTC (exactly JST midnight) to 03:00 UTC (12:00 JST). The fixture is now safely inside one JST learn-day so the relative-day cases stay on consecutive JST learn-days; all expected metric values are unchanged.

## Test plan

Run from `backend/` (Docker available for the testcontainers suites):

- `go build ./...` — Success.
- `go vet ./...` — no issues.
- `go test ./internal/domain/...` — 264 tests pass.
- `go test ./...` — full suite, 2060 tests pass across 26 packages.
- CJK gate (`perl -CSD`) over the changed files — prints nothing.
- Main checkout left clean (no stray edits outside the worktree).

## Notes

The band-threshold and `IsSuccess` ride-alongs are behavior-neutral; the existing `TestModeFromMetricsThresholdBoundaries` / `TestModeFromMetricsDifficultyAdjustments` tests stay green with no value changes. Out of scope per the issue: the FSRS schedule and learn-queue day logic (already correct), `swipe.go`, and full GraphQL enum-ization of the performance mode.

Closes #755
