### PR TITLE
refactor(arch): remove repository dependency from the resolver layer and enforce it in go-arch-lint

### DIFF
--- a/backend/.go-arch-lint.yml
+++ b/backend/.go-arch-lint.yml
@@ -83,7 +83,6 @@ deps:
       - domain
       - gqlerr
       - loader
-      - repository
       - textdic
       - usecase
   cmd_server:

--- a/backend/graph/resolver/connection.go
+++ b/backend/graph/resolver/connection.go
@@ -7,7 +7,6 @@ import (
 	"backend/graph/model"
 	"backend/internal/cursor"
 	"backend/internal/domain"
-	"backend/internal/repository"
 	"backend/internal/usecase"
 )
 
@@ -102,7 +101,7 @@ func toMasterCatalogConnectionModel(ctx context.Context, out *usecase.MasterCata
 	}
 	edges := buildEdges(ctx, out.Items, "toMasterCatalogConnectionModel",
 		toMasterCardgroupModel,
-		func(item *repository.MasterCatalogItem) string { return item.Cardgroup.ID },
+		func(item *usecase.MasterCatalogItem) string { return item.Cardgroup.ID },
 		func(cur string, n *model.MasterCardgroup) *model.MasterCatalogEdge {
 			return &model.MasterCatalogEdge{Cursor: cur, Node: n}
 		},

--- a/backend/graph/resolver/last_viewed_cardgroup.resolvers.go
+++ b/backend/graph/resolver/last_viewed_cardgroup.resolvers.go
@@ -8,7 +8,7 @@ package resolver
 import (
 	"backend/graph/model"
 	"backend/internal/gqlerr"
-	"backend/internal/repository"
+	"backend/internal/loader"
 	"context"
 	"errors"
 )
@@ -53,7 +53,7 @@ func (r *userResolver) LastViewedCardgroup(ctx context.Context, obj *model.User)
 
 	cg, err := loaders.Cardgroup.Load(ctx, *pref.LastViewedCardgroupID)()
 	if err != nil {
-		if errors.Is(err, repository.ErrNotFound) {
+		if errors.Is(err, loader.ErrNotFound) {
 			return nil, nil
 		}
 		return nil, classifyLoaderErr(ctx, err, "resolver: cardgroup")

--- a/backend/graph/resolver/last_viewed_cardgroup_resolver_test.go
+++ b/backend/graph/resolver/last_viewed_cardgroup_resolver_test.go
@@ -14,7 +14,6 @@ import (
 	"backend/internal/domain"
 	"backend/internal/gqlerr"
 	"backend/internal/loader"
-	"backend/internal/repository"
 	"backend/internal/usecase"
 	"backend/internal/usecase/ucerr"
 )
@@ -70,7 +69,7 @@ func ctxWithBothLoaders(
 					if cg, ok := cgs[k]; ok {
 						out[i] = &dataloader.Result[*domain.Cardgroup]{Data: cg}
 					} else {
-						out[i] = &dataloader.Result[*domain.Cardgroup]{Error: repository.ErrNotFound}
+						out[i] = &dataloader.Result[*domain.Cardgroup]{Error: loader.ErrNotFound}
 					}
 				}
 				return out

--- a/backend/graph/resolver/mapper.go
+++ b/backend/graph/resolver/mapper.go
@@ -8,7 +8,6 @@ import (
 
 	"backend/graph/model"
 	"backend/internal/domain"
-	"backend/internal/repository"
 	"backend/internal/usecase"
 )
 
@@ -49,7 +48,7 @@ func toCardgroupModel(cg *domain.Cardgroup) *model.Cardgroup {
 // its card count) to the generated GraphQL model. The status is mapped to the
 // uppercase wire enum; an unrecognised status surfaces as the empty enum value
 // so the field still serializes.
-func toMasterCardgroupModel(item *repository.MasterCatalogItem) *model.MasterCardgroup {
+func toMasterCardgroupModel(item *usecase.MasterCatalogItem) *model.MasterCardgroup {
 	if item == nil || item.Cardgroup == nil {
 		return nil
 	}

--- a/backend/graph/resolver/master_catalog_admin_resolver_test.go
+++ b/backend/graph/resolver/master_catalog_admin_resolver_test.go
@@ -10,7 +10,6 @@ import (
 	"backend/graph/model"
 	"backend/internal/domain"
 	"backend/internal/gqlerr"
-	"backend/internal/repository"
 	"backend/internal/usecase"
 	"backend/internal/usecase/ucerr"
 )
@@ -209,7 +208,7 @@ func TestAdminDeleteMasterCardgroup_WrapsForbidden(t *testing.T) {
 func TestAdminMasters_Success(t *testing.T) {
 	t.Parallel()
 	stub := &stubMasterCatalogUC{adminOut: &usecase.MasterCatalogConnectionOutput{
-		Items: []*repository.MasterCatalogItem{
+		Items: []*usecase.MasterCatalogItem{
 			{Cardgroup: &domain.MasterCardgroup{ID: "m1", Name: domain.CardgroupName("Draft"), Status: domain.MasterStatusDraft}, CardCount: 0},
 		},
 		TotalCount: 1,

--- a/backend/graph/resolver/master_catalog_mapper_test.go
+++ b/backend/graph/resolver/master_catalog_mapper_test.go
@@ -11,7 +11,6 @@ import (
 	"backend/graph/model"
 	"backend/internal/cursor"
 	"backend/internal/domain"
-	"backend/internal/repository"
 	"backend/internal/usecase"
 )
 
@@ -46,7 +45,7 @@ func TestToMasterCardgroupModel_FullMapping(t *testing.T) {
 
 	created := time.Date(2026, 6, 13, 1, 2, 3, 0, time.UTC)
 	updated := created.Add(time.Hour)
-	item := &repository.MasterCatalogItem{
+	item := &usecase.MasterCatalogItem{
 		Cardgroup: &domain.MasterCardgroup{
 			ID:               "mcg-1",
 			Name:             domain.CardgroupName("Starter Deck"),
@@ -81,7 +80,7 @@ func TestToMasterCardgroupModel_Nil(t *testing.T) {
 	t.Parallel()
 
 	assert.Nil(t, toMasterCardgroupModel(nil))
-	assert.Nil(t, toMasterCardgroupModel(&repository.MasterCatalogItem{Cardgroup: nil, CardCount: 1}))
+	assert.Nil(t, toMasterCardgroupModel(&usecase.MasterCatalogItem{Cardgroup: nil, CardCount: 1}))
 }
 
 // TestToMasterCatalogConnectionModel_Nil returns an empty (non-nil) connection
@@ -103,7 +102,7 @@ func TestToMasterCatalogConnectionModel_Mapping(t *testing.T) {
 	t.Parallel()
 
 	out := &usecase.MasterCatalogConnectionOutput{
-		Items: []*repository.MasterCatalogItem{
+		Items: []*usecase.MasterCatalogItem{
 			{Cardgroup: &domain.MasterCardgroup{ID: "a", Name: domain.CardgroupName("A"), Status: domain.MasterStatusPublished}, CardCount: 1},
 			{Cardgroup: &domain.MasterCardgroup{ID: "b", Name: domain.CardgroupName("B"), Status: domain.MasterStatusPublished}, CardCount: 2},
 		},
@@ -136,7 +135,7 @@ func TestToMasterCatalogConnectionModel_SkipsNilNode(t *testing.T) {
 	t.Parallel()
 
 	out := &usecase.MasterCatalogConnectionOutput{
-		Items: []*repository.MasterCatalogItem{
+		Items: []*usecase.MasterCatalogItem{
 			{Cardgroup: nil, CardCount: 0},
 			{Cardgroup: &domain.MasterCardgroup{ID: "b", Name: domain.CardgroupName("B"), Status: domain.MasterStatusPublished}, CardCount: 2},
 		},

--- a/backend/graph/resolver/master_catalog_query_test.go
+++ b/backend/graph/resolver/master_catalog_query_test.go
@@ -11,7 +11,6 @@ import (
 	"backend/graph/model"
 	"backend/internal/domain"
 	"backend/internal/gqlerr"
-	"backend/internal/repository"
 	"backend/internal/usecase"
 	"backend/internal/usecase/ucerr"
 )
@@ -116,7 +115,7 @@ func TestQueryResolver_MasterCatalog_Success(t *testing.T) {
 
 	stub := &stubMasterCatalogUC{
 		out: &usecase.MasterCatalogConnectionOutput{
-			Items: []*repository.MasterCatalogItem{
+			Items: []*usecase.MasterCatalogItem{
 				{Cardgroup: &domain.MasterCardgroup{ID: "x", Name: domain.CardgroupName("X"), Status: domain.MasterStatusPublished}, CardCount: 5},
 			},
 			TotalCount: 1,

--- a/backend/internal/loader/card_test.go
+++ b/backend/internal/loader/card_test.go
@@ -10,7 +10,6 @@ import (
 
 	"backend/internal/domain"
 	"backend/internal/loader"
-	"backend/internal/repository"
 )
 
 func loadAllCards(ctx context.Context, l *loader.Loaders, ids []string) ([]*domain.Card, []error) {
@@ -92,7 +91,7 @@ func TestCardLoader_PartialNotFound(t *testing.T) {
 	if errs[0] != nil || results[0] == nil || results[0].ID != "present" {
 		t.Fatalf("present: result=%+v err=%v", results[0], errs[0])
 	}
-	if !errors.Is(errs[1], repository.ErrNotFound) {
+	if !errors.Is(errs[1], loader.ErrNotFound) {
 		t.Fatalf("missing: want ErrNotFound, got %v", errs[1])
 	}
 	if results[1] != nil {

--- a/backend/internal/loader/cardgroup_test.go
+++ b/backend/internal/loader/cardgroup_test.go
@@ -10,7 +10,6 @@ import (
 
 	"backend/internal/domain"
 	"backend/internal/loader"
-	"backend/internal/repository"
 )
 
 // loadAllCardgroups concurrently loads all ids through l.Cardgroup and returns
@@ -118,7 +117,7 @@ func TestCardgroupLoader_PartialNotFound(t *testing.T) {
 	if results[2] == nil || results[2].ID != domain.CardgroupID("present-2") {
 		t.Fatalf("present-2: bad result: %+v", results[2])
 	}
-	if !errors.Is(errs[1], repository.ErrNotFound) {
+	if !errors.Is(errs[1], loader.ErrNotFound) {
 		t.Fatalf("missing: want ErrNotFound, got %v", errs[1])
 	}
 	if results[1] != nil {

--- a/backend/internal/loader/loader.go
+++ b/backend/internal/loader/loader.go
@@ -2,6 +2,7 @@ package loader
 
 import (
 	"context"
+	"errors"
 
 	"github.com/graph-gophers/dataloader/v7"
 	"github.com/labstack/echo/v5"
@@ -12,10 +13,17 @@ import (
 	"backend/internal/repository"
 )
 
+// ErrNotFound is the loader-layer sentinel wrapped for a key absent from a batch
+// result. It lets the presentation layer (resolver) branch on a missing key via
+// errors.Is without importing the infrastructure repository package. The
+// repository keeps its own repository.ErrNotFound for method-level not-found
+// results; this sentinel is distinct and scoped to loader batch output.
+var ErrNotFound = errors.New("loader: not found")
+
 // newMapKeyedBatch builds a DataLoader batch function for an aggregate whose
 // repository exposes a map-keyed FindByIDs-style lookup. load maps the requested
 // keys to a map[id]*V; the returned batch function resolves each key to its loaded
-// value, or to eris.Wrapf(repository.ErrNotFound, "<label> <key>") when the id is
+// value, or to eris.Wrapf(ErrNotFound, "<label> <key>") when the id is
 // absent from the map. label is the caller-supplied aggregate name used in the
 // not-found wrap — the shared helper holds no fixed prefix so the error context
 // stays caller-owned (see .claude/rules/error-wrapping.md).
@@ -51,7 +59,7 @@ func newMapKeyedBatch[V any](load func(context.Context, []string) (map[string]*V
 				continue
 			}
 			out[i] = &dataloader.Result[*V]{
-				Error: eris.Wrapf(repository.ErrNotFound, "%s %s", label, k),
+				Error: eris.Wrapf(ErrNotFound, "%s %s", label, k),
 			}
 		}
 		return out

--- a/backend/internal/loader/swipe_record_test.go
+++ b/backend/internal/loader/swipe_record_test.go
@@ -12,7 +12,6 @@ import (
 
 	"backend/internal/domain"
 	"backend/internal/loader"
-	"backend/internal/repository"
 )
 
 type countingSwipeRecordRepo struct {
@@ -117,7 +116,7 @@ func TestSwipeRecordLoader_PartialNotFound(t *testing.T) {
 	if errs[0] != nil || results[0] == nil || results[0].ID != "present" {
 		t.Fatalf("present: result=%+v err=%v", results[0], errs[0])
 	}
-	if !errors.Is(errs[1], repository.ErrNotFound) {
+	if !errors.Is(errs[1], loader.ErrNotFound) {
 		t.Fatalf("missing: want ErrNotFound, got %v", errs[1])
 	}
 	if results[1] != nil {

--- a/backend/internal/loader/user_test.go
+++ b/backend/internal/loader/user_test.go
@@ -420,7 +420,7 @@ func TestUserLoader_PartialNotFound(t *testing.T) {
 	if results[2] == nil || results[2].ID != "present-2" {
 		t.Fatalf("present-2: bad result: %+v", results[2])
 	}
-	if !errors.Is(errs[1], repository.ErrNotFound) {
+	if !errors.Is(errs[1], loader.ErrNotFound) {
 		t.Fatalf("missing: want ErrNotFound, got %v", errs[1])
 	}
 	if results[1] != nil {

--- a/backend/internal/usecase/master_catalog.go
+++ b/backend/internal/usecase/master_catalog.go
@@ -71,10 +71,16 @@ type MasterCatalogConnectionInput struct {
 	OrderDirection *SortOrder
 }
 
+// MasterCatalogItem is the usecase-level read model for one catalog row.
+type MasterCatalogItem struct {
+	Cardgroup *domain.MasterCardgroup
+	CardCount int64
+}
+
 // MasterCatalogConnectionOutput is the usecase-level page result. The resolver
 // wraps it into a model.MasterCatalogConnection.
 type MasterCatalogConnectionOutput struct {
-	Items      []*repository.MasterCatalogItem
+	Items      []*MasterCatalogItem
 	TotalCount int64
 	HasNext    bool
 	HasPrev    bool
@@ -282,13 +288,17 @@ func (u *masterCatalogUsecase) listMasterCatalogCore(
 	// request still observes the real value.
 	var total int64
 	items, hasNext, hasPrev, err := assemblePage(first, last, after != nil, before != nil,
-		func(wantFirst, wantLast int) ([]*repository.MasterCatalogItem, error) {
+		func(wantFirst, wantLast int) ([]*MasterCatalogItem, error) {
 			rows, t, e := fetch(ctx, after, before, wantFirst, wantLast, orderBy, dir, search)
 			if e != nil {
 				return nil, eris.Wrap(e, opPrefix)
 			}
 			total = t
-			return rows, nil
+			out := make([]*MasterCatalogItem, len(rows))
+			for i, r := range rows {
+				out[i] = &MasterCatalogItem{Cardgroup: r.Cardgroup, CardCount: r.CardCount}
+			}
+			return out, nil
 		},
 	)
 	if err != nil {
@@ -298,7 +308,7 @@ func (u *masterCatalogUsecase) listMasterCatalogCore(
 	// StartCur / EndCur carry the RAW node id; the resolver's connection layer
 	// applies the cursor encoder once. Encoding here would double-encode.
 	out := &MasterCatalogConnectionOutput{TotalCount: total, HasNext: hasNext, HasPrev: hasPrev, Items: items}
-	out.StartCur, out.EndCur = firstLastCursor(items, func(it *repository.MasterCatalogItem) string { return it.Cardgroup.ID })
+	out.StartCur, out.EndCur = firstLastCursor(items, func(it *MasterCatalogItem) string { return it.Cardgroup.ID })
 	return out, nil
 }
 


### PR DESCRIPTION
## Summary

`backend/.go-arch-lint.yml` allowed `resolver.mayDependOn: [..., repository]`, and three non-test resolver files imported the infrastructure package `backend/internal/repository`, leaking an infra DTO and an infra sentinel into the presentation layer. With `depOnAnyVendor: true`, go-arch-lint could not catch this; only removing the allowance — after fixing the leaks — makes the rule enforce "presentation ⊥ infrastructure".

This replaces the infra DTO with a usecase-level view type, gives the loader its own not-found sentinel, removes the three resolver `repository` imports, and drops `repository` from `resolver.mayDependOn` so the boundary is now lint-enforced. No behavior change: the usecase `MasterCatalogItem` carries the identical `{ Cardgroup, CardCount }` shape, and the loader's new sentinel is matched only by the one resolver that previously matched `repository.ErrNotFound` for the loader's output. The ~30 usecase `repository.ErrNotFound` sites that classify **repository-method** outputs are untouched.

## Changes

- **Part A — usecase view type.** `internal/usecase/master_catalog.go`: add `MasterCatalogItem { Cardgroup *domain.MasterCardgroup; CardCount int64 }`; change `MasterCatalogConnectionOutput.Items` to `[]*MasterCatalogItem`; convert repo rows to usecase items inside the `assemblePage` fetch closure (the repository `fetch` still returns `[]*repository.MasterCatalogItem`); retype the `firstLastCursor` accessor. `master_catalog.go` keeps its `repository` import for the repository interface / cursor types.
- `graph/resolver/connection.go` + `graph/resolver/mapper.go`: change the `toMasterCardgroupModel` / `toMasterCatalogConnectionModel` accessor parameter from `*repository.MasterCatalogItem` to `*usecase.MasterCatalogItem` (field names identical, bodies unchanged) and delete the `repository` import from both.
- **Part B — loader sentinel.** `internal/loader/loader.go`: add `var ErrNotFound = errors.New("loader: not found")` and wrap it (instead of `repository.ErrNotFound`) for a key absent from a batch result. The loader keeps importing `repository` for the repository types it consumes.
- `graph/resolver/last_viewed_cardgroup.resolvers.go`: match `loader.ErrNotFound` (swap the `repository` import for `loader`).
- **Part C — lint rule.** `backend/.go-arch-lint.yml`: remove `repository` from `resolver.mayDependOn`.
- **Tests** (call sites of the changed type / sentinel): retype `repository.MasterCatalogItem` → `usecase.MasterCatalogItem` in `master_catalog_mapper_test.go`, `master_catalog_query_test.go`, `master_catalog_admin_resolver_test.go`; switch the four loader batch-output assertions and the resolver's injected loader error from `repository.ErrNotFound` to `loader.ErrNotFound` in `loader/{card,cardgroup,swipe_record,user}_test.go` and `last_viewed_cardgroup_resolver_test.go`. Unused `repository` imports dropped where applicable.

## Test plan

All run from `backend/` (gqlgen regenerated first — `graph/generated` is gitignored):

- `go tool gqlgen generate` — exit 0.
- `go build ./...` — success.
- `go vet ./...` — no issues.
- `go tool go-arch-lint check --project-path .` — OK, no warnings (with `repository` removed from `resolver.mayDependOn`).
- `go test ./...` — 2059 passed in 26 packages (Docker integration tests included).
- Acceptance greps: `grep -rn 'internal/repository' backend/graph/resolver/*.go | grep -v _test.go` returns nothing; `grep -rn 'errors.Is(.*loader' backend/ --include='*.go'` returns only `last_viewed_cardgroup.resolvers.go`.

## Notes

Issue step 8 (the "nit" to also drop `repository` from `auth.mayDependOn`) was **not** applied, because it is a false positive of the issue's plain-import reasoning under this repo's `deepScan: true` config. The plain import graph does show `auth` importing only `domain`/`logging` (`go list` confirms), but go-arch-lint's deepScan tracks concrete-type value-flow: the composition root passes concrete `repository.UserRoleRepository` values into `auth.NewService` / `auth.NewSuperUserPromoter`, which deepScan attributes as a `repository → auth` edge requiring `repository` in `auth.mayDependOn`. Removing it makes `go-arch-lint check` fail (verified empirically: restoring the line returns "OK - No warnings found"). The documented remedy ([`docs/backend/library-gotchas/go-arch-lint-deepscan-concrete-type-value-flow.md`](docs/backend/library-gotchas/go-arch-lint-deepscan-concrete-type-value-flow.md)) is to widen the wiring-site value to a consumer-defined port interface, but auth's ports (`roleChecker`, `adminChecker`, `roleAssigner`) are unexported, so that would require exporting auth's public API — out of scope for this change. The core #756 invariant (`resolver.mayDependOn` minus `repository`) is fully delivered.

Closes #756
