### PR TITLE
refactor(usecase): single-source the import front-dedup and row-cap rules

### DIFF
--- a/backend/internal/usecase/card_import.go
+++ b/backend/internal/usecase/card_import.go
@@ -56,6 +56,11 @@ const (
 	CardImportErrKindDuplicate    CardImportErrorKind = "DUPLICATE"
 )
 
+// IsSoftSkip reports whether a row with this error kind may be silently skipped.
+func (k CardImportErrorKind) IsSoftSkip() bool {
+	return k == CardImportErrKindFrontOnly || k == CardImportErrKindBackOnly
+}
+
 // CardImportError mirrors textdic.ValidationError so callers in the resolver
 // layer can reshape it into the GraphQL model without importing the textdic
 // package directly.
@@ -222,32 +227,11 @@ func (u *cardImportUsecase) Import(ctx context.Context, input ImportCardsInput) 
 
 	mappedErrs := cardImportErrorsFromTextdic(parseErrs)
 
-	// Deduplicate parsed words by front within this payload. Postgres error 21000
-	// ("ON CONFLICT DO UPDATE command cannot affect row a second time") fires when
-	// the same conflict key appears more than once in a single INSERT statement.
-	// Last occurrence wins; earlier occurrences are dropped and reported in Errors.
-	lastIndex := make(map[string]int, len(words))
-	for i, w := range words {
-		lastIndex[w.Front] = i
-	}
-	deduped := make([]textdic.ParsedWord, 0, len(words))
-	for i, w := range words {
-		if lastIndex[w.Front] != i {
-			// w is the earlier (dropped) occurrence; the row that survives is at
-			// lastIndex, so its Back is the value that overrode this one.
-			winningBack := words[lastIndex[w.Front]].Back
-			mappedErrs = append(mappedErrs, CardImportError{
-				Line:    w.Line,
-				Message: fmt.Sprintf("duplicated front (%s) was overridden with the new back (%s)", w.Front, winningBack),
-				Kind:    CardImportErrKindDuplicate,
-				Front:   w.Front,
-				Back:    w.Back,
-			})
-			continue
-		}
-		deduped = append(deduped, w)
-	}
+	// Deduplicate parsed words by front within this payload. cards.front is
+	// plain text, so the conflict key is the front verbatim (identity key).
+	deduped, dupErrs := dedupeParsedWords(words, func(s string) string { return s })
 	words = deduped
+	mappedErrs = append(mappedErrs, dupErrs...)
 
 	// Empty (but well-formed) parse: nothing to persist; surface the parser's
 	// per-line diagnostics so the caller can act on them.
@@ -346,4 +330,39 @@ func checkImportCaps(words []textdic.ParsedWord) []capViolation {
 		}
 	}
 	return out
+}
+
+// dedupeParsedWords drops earlier duplicates by key(front), last occurrence wins,
+// and reports each dropped row as a CardImportErrKindDuplicate error.
+//
+// Postgres error 21000 ("ON CONFLICT DO UPDATE command cannot affect row a second
+// time") fires when the same conflict key appears more than once in a single
+// INSERT statement, so this dedupe must run before UpsertManyTx. The key function
+// adapts the conflict-key semantics to the target column: identity for plain-text
+// cards.front, frontMatchKey (case-fold) for citext master_cards.front so case
+// variants collapse to one row.
+func dedupeParsedWords(words []textdic.ParsedWord, key func(string) string) ([]textdic.ParsedWord, []CardImportError) {
+	lastIndex := make(map[string]int, len(words))
+	for i, w := range words {
+		lastIndex[key(w.Front)] = i
+	}
+	deduped := make([]textdic.ParsedWord, 0, len(words))
+	var dropErrors []CardImportError
+	for i, w := range words {
+		if lastIndex[key(w.Front)] != i {
+			// w is the earlier (dropped) occurrence; the row that survives is at
+			// lastIndex, so its Back is the value that overrode this one.
+			winningBack := words[lastIndex[key(w.Front)]].Back
+			dropErrors = append(dropErrors, CardImportError{
+				Line:    w.Line,
+				Message: fmt.Sprintf("duplicated front (%s) was overridden with the new back (%s)", w.Front, winningBack),
+				Kind:    CardImportErrKindDuplicate,
+				Front:   w.Front,
+				Back:    w.Back,
+			})
+			continue
+		}
+		deduped = append(deduped, w)
+	}
+	return deduped, dropErrors
 }

--- a/backend/internal/usecase/master_card.go
+++ b/backend/internal/usecase/master_card.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"strings"
 	"time"
 
 	"github.com/rotisserie/eris"
@@ -414,39 +413,20 @@ func (u *masterCardUsecase) ImportMasterCards(ctx context.Context, in ImportMast
 	}
 
 	if len(words) > cardImportParsedRowCap {
-		return ImportMasterCardsOutput{}, ucerr.NewValidationError("payload", "payload exceeds 5000 row cap")
+		return ImportMasterCardsOutput{}, ucerr.NewValidationError("payload", fmt.Sprintf("payload exceeds %d row cap", cardImportParsedRowCap))
 	}
 
 	mappedErrs := cardImportErrorsFromTextdic(parseErrs)
 
 	// Deduplicate parsed words by front within this payload (last occurrence
-	// wins); earlier occurrences are dropped and reported. Postgres error 21000
-	// fires when a conflict key repeats in one INSERT, so the dedupe must happen
-	// before UpsertManyTx. master_cards.front is citext, so the conflict key is
-	// case-insensitive — the map key is therefore case-folded (unlike the
-	// plain-text cards.front mirror in card_import.go) so "Apple" and "apple"
-	// collapse to one row rather than both reaching the ON CONFLICT INSERT.
-	lastIndex := make(map[string]int, len(words))
-	for i, w := range words {
-		lastIndex[strings.ToLower(w.Front)] = i
-	}
-	deduped := make([]textdic.ParsedWord, 0, len(words))
-	for i, w := range words {
-		lower := strings.ToLower(w.Front)
-		if lastIndex[lower] != i {
-			winningBack := words[lastIndex[lower]].Back
-			mappedErrs = append(mappedErrs, CardImportError{
-				Line:    w.Line,
-				Message: fmt.Sprintf("duplicated front (%s) was overridden with the new back (%s)", w.Front, winningBack),
-				Kind:    CardImportErrKindDuplicate,
-				Front:   w.Front,
-				Back:    w.Back,
-			})
-			continue
-		}
-		deduped = append(deduped, w)
-	}
+	// wins); earlier occurrences are dropped and reported. master_cards.front is
+	// citext, so the conflict key is case-insensitive — frontMatchKey case-folds
+	// the dedupe key (unlike the plain-text cards.front mirror in card_import.go)
+	// so "Apple" and "apple" collapse to one row rather than both reaching the
+	// ON CONFLICT INSERT (which would trip Postgres error 21000).
+	deduped, dupErrs := dedupeParsedWords(words, frontMatchKey)
 	words = deduped
+	mappedErrs = append(mappedErrs, dupErrs...)
 
 	// Empty (but well-formed) parse: nothing to persist; surface the parser's
 	// per-line diagnostics so the caller can act on them.

--- a/backend/internal/usecase/notion_sync.go
+++ b/backend/internal/usecase/notion_sync.go
@@ -238,10 +238,7 @@ func (u *MasterNotionSyncUsecase) Sync(ctx context.Context, input SyncToMasterIn
 // obviously hard. UNKNOWN indicates a bug and also falls into the hard branch.
 func allCardImportErrorsSkipped(errs []CardImportError) bool {
 	for _, e := range errs {
-		switch e.Kind {
-		case CardImportErrKindFrontOnly, CardImportErrKindBackOnly:
-			continue
-		default:
+		if !e.Kind.IsSoftSkip() {
 			return false
 		}
 	}


### PR DESCRIPTION
## Summary

The card-import pipeline carried two byte-identical `ParsedWord` dedupe loops differing only in the key function — `card_import.go` keyed on the front verbatim (plain-text `cards.front`), `master_card.go` re-spelled `strings.ToLower` inline (citext `master_cards.front`) — plus a hardcoded `"5000"` row-cap message in `master_card.go` while `card_import.go` already derived it from the `cardImportParsedRowCap` constant. Drift in the dedupe key is what causes a production INSERT failure (Postgres 21000 — "ON CONFLICT DO UPDATE command cannot affect row a second time"), since the dedupe is exactly what prevents the conflict key from appearing twice in one INSERT.

This single-sources all three rules: one shared `dedupeParsedWords` helper parameterized by a key function, `frontMatchKey` as the single citext case-fold definition (no more inline `strings.ToLower`), and the cap message derived from the constant. The soft-skip classification also moves onto the `CardImportErrorKind` type as `IsSoftSkip()`. Pure refactor; behavior is preserved.

## Changes

- `card_import.go`: added `dedupeParsedWords(words []textdic.ParsedWord, key func(string) string) ([]textdic.ParsedWord, []CardImportError)` next to `checkImportCaps`. It drops earlier duplicates by `key(front)` (last occurrence wins) and returns the deduped slice plus one `CardImportErrKindDuplicate` error per dropped row, preserving the existing message format verbatim. The Postgres 21000 rationale moved into the helper docstring.
- `card_import.go` `Import`: replaced the inline dedupe loop with `dedupeParsedWords(words, func(s string) string { return s })` (identity key for plain-text `cards.front`), appending the returned drop errors to `mappedErrs`.
- `master_card.go` `ImportMasterCards`: replaced the inline `strings.ToLower` dedupe loop with `dedupeParsedWords(words, frontMatchKey)`, making `frontMatchKey` the single case-fold source. Dropped the now-unused `strings` import.
- `master_card.go`: changed the row-cap message from the literal `"payload exceeds 5000 row cap"` to `fmt.Sprintf("payload exceeds %d row cap", cardImportParsedRowCap)`, matching `card_import.go`.
- `card_import.go`: added `func (k CardImportErrorKind) IsSoftSkip() bool` next to the `CardImportErrorKind` consts, returning true for `FRONT_ONLY` / `BACK_ONLY`.
- `notion_sync.go`: rewrote `allCardImportErrorsSkipped` to `for _, e := range errs { if !e.Kind.IsSoftSkip() { return false } }`. Its `ParsedRow` dedupe (`dedupeParsedRows`, a different type) is untouched and already uses `frontMatchKey`.

## Test plan

- `go tool gqlgen generate` to bootstrap the gitignored generated code (mise trust first).
- `go build ./...` — success.
- `go vet ./...` — no issues.
- `go test ./...` — full module suite with Docker/testcontainers running: 2059 passed in 26 packages.
- Acceptance greps: no `strings.ToLower` and no literal `5000` remain in `master_card.go`.

Closes #757
