### PR TITLE
refactor(domain): move the general-user cardgroup quota invariant into the domain

### DIFF
--- a/backend/graph/resolver/cardgroup_resolvers_test.go
+++ b/backend/graph/resolver/cardgroup_resolvers_test.go
@@ -448,7 +448,7 @@ func createCardgroupBodyWithLimit(name string) string {
 }
 
 // TestResolver_CreateCardgroup_LimitReached verifies that a non-admin caller
-// who already owns generalUserCardgroupLimit (5) cardgroups receives the
+// who already owns domain.GeneralUserCardgroupLimit (5) cardgroups receives the
 // CardgroupLimitReachedError union variant with the correct Limit and Current
 // fields rather than a GraphQL protocol error.
 func TestResolver_CreateCardgroup_LimitReached(t *testing.T) {

--- a/backend/internal/domain/cardgroup_quota.go
+++ b/backend/internal/domain/cardgroup_quota.go
@@ -1,0 +1,15 @@
+package domain
+
+// GeneralUserCardgroupLimit caps the number of cardgroups a non-admin owner may
+// hold. The threshold lives in the domain because it is an availability
+// invariant, mirroring IsLastAdmin, not application plumbing. Whether a given
+// owner is exempt (admins are) is an authorization concern enforced in the
+// usecase layer, not a domain invariant.
+const GeneralUserCardgroupLimit = 5
+
+// GeneralUserCardgroupQuotaReached reports whether an owner holding count
+// cardgroups has reached the general-user quota. Callers apply the admin
+// exemption before invoking this predicate.
+func GeneralUserCardgroupQuotaReached(count int64) bool {
+	return count >= GeneralUserCardgroupLimit
+}

--- a/backend/internal/domain/cardgroup_quota_test.go
+++ b/backend/internal/domain/cardgroup_quota_test.go
@@ -1,0 +1,29 @@
+package domain
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGeneralUserCardgroupQuotaReached(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		count int64
+		want  bool
+	}{
+		{name: "none", count: 0, want: false},
+		{name: "below limit", count: GeneralUserCardgroupLimit - 1, want: false},
+		{name: "at limit", count: GeneralUserCardgroupLimit, want: true},
+		{name: "over limit", count: GeneralUserCardgroupLimit + 3, want: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, GeneralUserCardgroupQuotaReached(tc.count))
+		})
+	}
+}

--- a/backend/internal/usecase/cardgroup.go
+++ b/backend/internal/usecase/cardgroup.go
@@ -78,10 +78,6 @@ type CardgroupUsecase interface {
 	ListCardgroupsByOwnerConnection(ctx context.Context, in CardgroupConnectionInput) (*CardgroupConnectionOutput, error)
 }
 
-// generalUserCardgroupLimit caps the number of cardgroups a non-admin owner
-// may create. Admins are exempt. Enforced in Create via checkCardgroupLimit.
-const generalUserCardgroupLimit = 5
-
 type cardgroupUsecase struct {
 	repo   CardgroupRepository
 	admin  AdminChecker
@@ -152,8 +148,8 @@ type cardgroupOwnerCounter interface {
 }
 
 // checkCardgroupLimit returns a non-nil *CardgroupLimitInfo when a non-admin
-// owner already holds generalUserCardgroupLimit cardgroups. Admins are exempt
-// (returns nil, nil without counting). Context cancellation and deadline
+// owner already holds domain.GeneralUserCardgroupLimit cardgroups. Admins are
+// exempt (returns nil, nil without counting). Context cancellation and deadline
 // errors pass through unwrapped; other infrastructure failures propagate wrapped.
 func checkCardgroupLimit(ctx context.Context, counter cardgroupOwnerCounter, admin AdminChecker, ownerID string) (*CardgroupLimitInfo, error) {
 	isAdmin, err := admin.IsAdmin(ctx, ownerID)
@@ -173,8 +169,8 @@ func checkCardgroupLimit(ctx context.Context, counter cardgroupOwnerCounter, adm
 		}
 		return nil, eris.Wrap(err, "usecase: cardgroup: count by owner")
 	}
-	if count >= generalUserCardgroupLimit {
-		return &CardgroupLimitInfo{Limit: generalUserCardgroupLimit, Current: int(count)}, nil
+	if domain.GeneralUserCardgroupQuotaReached(count) {
+		return &CardgroupLimitInfo{Limit: domain.GeneralUserCardgroupLimit, Current: int(count)}, nil
 	}
 	return nil, nil
 }
@@ -197,7 +193,7 @@ func (u *cardgroupUsecase) Create(ctx context.Context, in CreateCardgroupInput) 
 
 	// Name validation (no DB) runs first to avoid the IsAdmin + Count queries
 	// on the common invalid-name path. Non-admins are capped at
-	// generalUserCardgroupLimit cardgroups; admins are exempt.
+	// domain.GeneralUserCardgroupLimit cardgroups; admins are exempt.
 	limit, err := checkCardgroupLimit(ctx, u.repo, u.admin, user.Sub)
 	if err != nil {
 		return CreateCardgroupOutcome{}, err

--- a/backend/internal/usecase/cardgroup_test.go
+++ b/backend/internal/usecase/cardgroup_test.go
@@ -365,7 +365,7 @@ func TestCardgroupUsecase_Create_GeneralUser_UnderLimit_Succeeds(t *testing.T) {
 // LimitReached outcome, and repo.Create is NOT called.
 func TestCardgroupUsecase_Create_GeneralUser_AtLimit_Rejected(t *testing.T) {
 	t.Parallel()
-	repo := &mockCardgroupRepository{countResult: generalUserCardgroupLimit}
+	repo := &mockCardgroupRepository{countResult: domain.GeneralUserCardgroupLimit}
 	uc := NewCardgroupUsecase(repo, &mockAdminChecker{isAdmin: false}, newTestLogger())
 
 	outcome, err := uc.Create(cgAuthedCtx("user-1"), CreateCardgroupInput{Name: "Sixth"})
@@ -379,11 +379,11 @@ func TestCardgroupUsecase_Create_GeneralUser_AtLimit_Rejected(t *testing.T) {
 	if outcome.LimitReached == nil {
 		t.Fatal("expected non-nil LimitReached at the limit")
 	}
-	if outcome.LimitReached.Limit != generalUserCardgroupLimit {
-		t.Fatalf("expected LimitReached.Limit=%d, got %d", generalUserCardgroupLimit, outcome.LimitReached.Limit)
+	if outcome.LimitReached.Limit != domain.GeneralUserCardgroupLimit {
+		t.Fatalf("expected LimitReached.Limit=%d, got %d", domain.GeneralUserCardgroupLimit, outcome.LimitReached.Limit)
 	}
-	if outcome.LimitReached.Current != generalUserCardgroupLimit {
-		t.Fatalf("expected LimitReached.Current=%d, got %d", generalUserCardgroupLimit, outcome.LimitReached.Current)
+	if outcome.LimitReached.Current != domain.GeneralUserCardgroupLimit {
+		t.Fatalf("expected LimitReached.Current=%d, got %d", domain.GeneralUserCardgroupLimit, outcome.LimitReached.Current)
 	}
 	if repo.capturedCreate != nil {
 		t.Fatal("repository.Create must not be called when the limit is reached")
@@ -423,7 +423,7 @@ func TestCardgroupUsecase_Create_Admin_SkipsCounting(t *testing.T) {
 	t.Parallel()
 	// countResult is set to the cap to prove that even when the count WOULD
 	// reject a general user, an admin is never subjected to it.
-	repo := &mockCardgroupRepository{countResult: generalUserCardgroupLimit}
+	repo := &mockCardgroupRepository{countResult: domain.GeneralUserCardgroupLimit}
 	admin := &mockAdminChecker{isAdmin: true}
 	uc := NewCardgroupUsecase(repo, admin, newTestLogger())
 
@@ -520,7 +520,7 @@ func TestCardgroupUsecase_Create_IsAdminCancelled_IdentityPreserved(t *testing.T
 // consulted.
 func TestCardgroupUsecase_Create_LimitAndInvalidName_NameValidationFirst(t *testing.T) {
 	t.Parallel()
-	repo := &mockCardgroupRepository{countResult: generalUserCardgroupLimit}
+	repo := &mockCardgroupRepository{countResult: domain.GeneralUserCardgroupLimit}
 	admin := &mockAdminChecker{isAdmin: false}
 	uc := NewCardgroupUsecase(repo, admin, newTestLogger())
 
@@ -1768,7 +1768,7 @@ func (s *stubCardgroupCounter) CountByOwner(_ context.Context, _ string, _ *stri
 // the helper returns (nil, nil) and the counter is never consulted.
 func TestCheckCardgroupLimit_Admin_Exempt(t *testing.T) {
 	t.Parallel()
-	counter := &stubCardgroupCounter{count: generalUserCardgroupLimit}
+	counter := &stubCardgroupCounter{count: domain.GeneralUserCardgroupLimit}
 	admin := &mockAdminChecker{isAdmin: true}
 
 	info, err := checkCardgroupLimit(context.Background(), counter, admin, "admin-1")
@@ -1788,7 +1788,7 @@ func TestCheckCardgroupLimit_Admin_Exempt(t *testing.T) {
 // limit returns (nil, nil) — no limit info, no error.
 func TestCheckCardgroupLimit_UnderLimit(t *testing.T) {
 	t.Parallel()
-	counter := &stubCardgroupCounter{count: generalUserCardgroupLimit - 1}
+	counter := &stubCardgroupCounter{count: domain.GeneralUserCardgroupLimit - 1}
 	admin := &mockAdminChecker{isAdmin: false}
 
 	info, err := checkCardgroupLimit(context.Background(), counter, admin, "user-1")
@@ -1814,8 +1814,8 @@ func TestCheckCardgroupLimit_AtOrOverLimit(t *testing.T) {
 		count       int64
 		wantCurrent int
 	}{
-		{name: "at limit", count: generalUserCardgroupLimit, wantCurrent: generalUserCardgroupLimit},
-		{name: "over limit", count: generalUserCardgroupLimit + 3, wantCurrent: generalUserCardgroupLimit + 3},
+		{name: "at limit", count: domain.GeneralUserCardgroupLimit, wantCurrent: domain.GeneralUserCardgroupLimit},
+		{name: "over limit", count: domain.GeneralUserCardgroupLimit + 3, wantCurrent: domain.GeneralUserCardgroupLimit + 3},
 	} {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
@@ -1831,8 +1831,8 @@ func TestCheckCardgroupLimit_AtOrOverLimit(t *testing.T) {
 			if info == nil {
 				t.Fatal("expected non-nil LimitInfo at/over the limit")
 			}
-			if info.Limit != generalUserCardgroupLimit {
-				t.Fatalf("expected Limit=%d, got %d", generalUserCardgroupLimit, info.Limit)
+			if info.Limit != domain.GeneralUserCardgroupLimit {
+				t.Fatalf("expected Limit=%d, got %d", domain.GeneralUserCardgroupLimit, info.Limit)
 			}
 			if info.Current != tc.wantCurrent {
 				t.Fatalf("expected Current=%d, got %d", tc.wantCurrent, info.Current)


### PR DESCRIPTION
## Summary

The "non-admin owner may hold at most 5 cardgroups" rule was a bare `const generalUserCardgroupLimit = 5` plus an inline `count >= generalUserCardgroupLimit` comparison in `backend/internal/usecase/cardgroup.go`, while the sibling count-threshold rule `IsLastAdmin` already lives in the domain because it is an availability invariant. This moves the quota threshold and its predicate into the domain, mirroring `IsLastAdmin`, so the "5" and its meaning are visible from the domain rather than buried in usecase implementation detail. The admin-exemption check stays in the usecase — it is an authorization concern, not a domain invariant. Behavior is unchanged.

## Changes

- Add `backend/internal/domain/cardgroup_quota.go`: exported `const GeneralUserCardgroupLimit = 5` and `func GeneralUserCardgroupQuotaReached(count int64) bool { return count >= GeneralUserCardgroupLimit }`, with a docstring that mirrors `IsLastAdmin` (availability invariant) and notes the admin exemption is an authorization concern enforced in the usecase layer.
- `backend/internal/usecase/cardgroup.go`: remove the local `generalUserCardgroupLimit` const; `checkCardgroupLimit` now calls `domain.GeneralUserCardgroupQuotaReached(count)` and builds `CardgroupLimitInfo.Limit` from `domain.GeneralUserCardgroupLimit`. Admin-exemption logic and all surrounding error handling are untouched. Docstrings/comments updated to reference the domain symbol.
- Add `backend/internal/domain/cardgroup_quota_test.go`: table test for `GeneralUserCardgroupQuotaReached` (none / below / at / over the limit), mirroring `TestIsLastAdmin`.
- `backend/internal/usecase/cardgroup_test.go`: 13 references to the removed local const repointed to `domain.GeneralUserCardgroupLimit` (the file already imports `domain`).
- `backend/graph/resolver/cardgroup_resolvers_test.go`: refreshed the one stale comment that named the removed `generalUserCardgroupLimit` symbol.

## Test plan

- `go tool gqlgen generate` to bootstrap the gitignored generated code (after `mise trust`).
- `go build ./...` — Success.
- `go vet ./...` — no issues.
- `go test ./...` (full suite, Docker/testcontainers available) — 2064 passed across 26 packages.
- `grep -rn 'generalUserCardgroupLimit' --include='*.go'` — zero residual references to the removed symbol.

## Notes

The quota const is moved, not aliased: the usecase now references `domain.GeneralUserCardgroupLimit` / `domain.GeneralUserCardgroupQuotaReached` directly, per the acceptance criteria. Admin-exemption logic was deliberately left in the usecase (out of scope for the domain move).

Closes #758
