### PR TITLE
refactor(repository): move the per-user advisory-lock SQL out of the usecase layer

### DIFF
--- a/backend/internal/loader/user_test.go
+++ b/backend/internal/loader/user_test.go
@@ -135,6 +135,9 @@ func (r *countingCardgroupRepo) Create(_ context.Context, _ *domain.Cardgroup) e
 func (r *countingCardgroupRepo) CreateTx(_ context.Context, _ *gorm.DB, _ *domain.Cardgroup) error {
 	panic("countingCardgroupRepo.CreateTx not configured")
 }
+func (r *countingCardgroupRepo) AcquireUserSeedLockTx(_ context.Context, _ *gorm.DB, _ string) error {
+	panic("countingCardgroupRepo.AcquireUserSeedLockTx not configured")
+}
 func (r *countingCardgroupRepo) EnsureByName(_ context.Context, _, _ string) (*domain.Cardgroup, error) {
 	panic("countingCardgroupRepo.EnsureByName not configured")
 }

--- a/backend/internal/repository/cardgroup.go
+++ b/backend/internal/repository/cardgroup.go
@@ -82,6 +82,9 @@ type CardgroupRepository interface {
 	// handle so the insert participates in the caller's transaction. The caller
 	// is responsible for pre-filling cg.ID (uuid v7) and both timestamps.
 	CreateTx(ctx context.Context, tx *gorm.DB, cg *domain.Cardgroup) error
+	// AcquireUserSeedLockTx takes a per-user advisory lock (released at tx end)
+	// so concurrent seed-for-new-user calls for the same user do not race.
+	AcquireUserSeedLockTx(ctx context.Context, tx *gorm.DB, userID string) error
 	EnsureByName(ctx context.Context, ownerID, name string) (*domain.Cardgroup, error)
 	Update(ctx context.Context, id string, patch CardgroupUpdate) (*domain.Cardgroup, error)
 	Delete(ctx context.Context, id string) error
@@ -275,6 +278,18 @@ func (r *cardgroupRepo) Create(ctx context.Context, cg *domain.Cardgroup) error 
 func (r *cardgroupRepo) CreateTx(ctx context.Context, tx *gorm.DB, cg *domain.Cardgroup) error {
 	if err := tx.WithContext(ctx).Create(cardgroupToRow(cg)).Error; err != nil {
 		return eris.Wrap(err, "repository: cardgroup: create tx")
+	}
+	return nil
+}
+
+// AcquireUserSeedLockTx takes a per-user advisory lock (released at tx end) so
+// concurrent seed-for-new-user calls for the same user do not race. hashtext
+// returns int4, so pg_advisory_xact_lock(0, hashtext(userID)) keys the lock on
+// the user within a fixed namespace where unrelated callers do not contend; the
+// lock releases automatically at transaction end.
+func (r *cardgroupRepo) AcquireUserSeedLockTx(ctx context.Context, tx *gorm.DB, userID string) error {
+	if err := tx.Exec("SELECT pg_advisory_xact_lock(0, hashtext(?))", userID).Error; err != nil {
+		return eris.Wrap(err, "repository: cardgroup: acquire user seed lock")
 	}
 	return nil
 }

--- a/backend/internal/usecase/master_deck.go
+++ b/backend/internal/usecase/master_deck.go
@@ -47,6 +47,10 @@ type masterDeckUserCardgroupRepo interface {
 	FindByID(ctx context.Context, id string) (*domain.Cardgroup, error)
 	CountByOwner(ctx context.Context, ownerID string, search *string) (int64, error)
 	CreateTx(ctx context.Context, tx *gorm.DB, cg *domain.Cardgroup) error
+	// AcquireUserSeedLockTx takes a per-user transaction-scoped advisory lock so
+	// two concurrent seed-for-new-user calls for the same user serialize. The
+	// dialect detail (the advisory-lock SQL) lives in the repository.
+	AcquireUserSeedLockTx(ctx context.Context, tx *gorm.DB, userID string) error
 }
 
 // SeedForNewUserUsecase provisions the published default-starter master decks
@@ -224,11 +228,11 @@ func (u *masterDeckUsecase) SeedForNewUser(ctx context.Context, userID string) (
 	// convention; callers receive `[]` regardless of which path fired).
 	seeded := []*domain.Cardgroup{}
 	if err := u.tx(ctx, func(tx *gorm.DB) error {
-		// hashtext returns int4; pg_advisory_xact_lock(0, hashtext(userID)) keys
-		// the lock on the user within a fixed namespace so unrelated callers do
-		// not contend. The lock releases automatically at transaction end.
-		if err := tx.Exec("SELECT pg_advisory_xact_lock(0, hashtext(?))", userID).Error; err != nil {
-			return eris.Wrap(err, "usecase: master deck: seed for new user: advisory lock")
+		// Take a per-user transaction-scoped advisory lock so two concurrent seed
+		// attempts for the same user serialize. The advisory-lock SQL (a Postgres
+		// dialect detail) lives in the repository; the lock releases at tx end.
+		if err := u.userCG.AcquireUserSeedLockTx(ctx, tx, userID); err != nil {
+			return err
 		}
 
 		count, err := u.userCG.CountByOwner(ctx, userID, nil)

--- a/backend/internal/usecase/master_deck_test.go
+++ b/backend/internal/usecase/master_deck_test.go
@@ -120,6 +120,9 @@ type fakeUserCG struct {
 	findByIDCalls     int
 	findByIDErr       error
 	findByIDErrOnCall int // 1-based; 0 = never inject
+	lockCalls         int
+	lockUser          string
+	lockCountAtCall   int // snapshot of CountByOwner calls when the lock was taken (0 ⇒ lock before count)
 }
 
 func (f *fakeUserCG) FindByID(_ context.Context, id string) (*domain.Cardgroup, error) {
@@ -138,6 +141,16 @@ func (f *fakeUserCG) CountByOwner(_ context.Context, ownerID string, _ *string) 
 	f.calls++
 	f.lastUser = ownerID
 	return f.count, f.countErr
+}
+
+// AcquireUserSeedLockTx records that the per-user advisory lock was taken and
+// snapshots how many CountByOwner calls had run at that point, so the seed
+// usecase test can assert the lock is taken before the idempotency count.
+func (f *fakeUserCG) AcquireUserSeedLockTx(_ context.Context, _ *gorm.DB, userID string) error {
+	f.lockCalls++
+	f.lockUser = userID
+	f.lockCountAtCall = f.calls
+	return nil
 }
 
 func (f *fakeUserCG) CreateTx(_ context.Context, _ *gorm.DB, cg *domain.Cardgroup) error {
@@ -162,8 +175,9 @@ func (fakeResult) RowsAffected() (int64, error) { return 1, nil }
 // without a real database connection. Paired with WithoutReturning so the
 // cardgroup INSERT goes through ExecContext (no RETURNING → no *sql.Rows to
 // fabricate). This lets the production copy path run end-to-end — the inline
-// tx.Create for the cardgroup and the advisory-lock Exec both execute against
-// the recorder, while the card batch is captured at the userCard mock boundary.
+// tx.Create for the cardgroup executes against the recorder, while the card
+// batch is captured at the userCard mock boundary. (The advisory lock now lives
+// in the repository, so it is recorded at the fakeUserCG boundary instead.)
 type recordPool struct {
 	sqls []string
 	args [][]any
@@ -478,20 +492,19 @@ func TestSeedForNewUser_TakesAdvisoryLockBeforeCounting(t *testing.T) {
 	user := &fakeUserCardRepo{}
 	userCG := &fakeUserCG{count: 5} // short-circuit after the lock
 
-	uc, pool, _ := newSeedUsecase(t, cg, card, user, userCG)
+	uc, _, _ := newSeedUsecase(t, cg, card, user, userCG)
 
 	_, err := uc.SeedForNewUser(context.Background(), "lock-user")
 	require.NoError(t, err)
 
-	// The first statement executed against the tx is the transaction-scoped
-	// advisory lock; the idempotency COUNT (mocked) runs after it.
-	require.NotEmpty(t, pool.sqls)
-	assert.Contains(t, pool.sqls[0], "pg_advisory_xact_lock(0, hashtext(")
-	// The lock is keyed on the user id: the single bound argument is the user,
-	// so two distinct users never contend on the same advisory lock.
-	require.NotEmpty(t, pool.args)
-	require.Len(t, pool.args[0], 1)
-	assert.Equal(t, "lock-user", pool.args[0][0])
+	// The advisory lock (now owned by the repository) is taken exactly once and
+	// before the idempotency COUNT: lockCountAtCall snapshots the CountByOwner
+	// call counter at lock time, so 0 proves the lock came first.
+	assert.Equal(t, 1, userCG.lockCalls, "the advisory lock is taken once")
+	assert.Equal(t, 0, userCG.lockCountAtCall, "the lock is taken before the idempotency count")
+	// The lock is keyed on the user id, so two distinct users never contend on
+	// the same advisory lock.
+	assert.Equal(t, "lock-user", userCG.lockUser)
 }
 
 func TestSeedForNewUser_NoStarters_NoCopies(t *testing.T) {


### PR DESCRIPTION
## Summary

The usecase layer is otherwise free of raw SQL — it passes `tx` opaquely to repository methods. One spot in `SeedForNewUser` directly executed a Postgres advisory-lock statement (a database-dialect detail) in the application layer, while the repository layer already owns the same idiom in `master_cardgroup.go` and `cardgroup.go`. This moves the per-user advisory-lock SQL into a new `AcquireUserSeedLockTx` method on the cardgroup repository (the type backing `u.userCG` in production) and has `SeedForNewUser` call it through the narrow `masterDeckUserCardgroupRepo` port. The exact SQL (`SELECT pg_advisory_xact_lock(0, hashtext(?))`) and lock semantics (per-user, transaction-scoped, taken before the idempotency count) are preserved verbatim — pure refactor.

## Changes

- `backend/internal/repository/cardgroup.go`: added `AcquireUserSeedLockTx(ctx, tx, userID) error` to `*cardgroupRepo`, preserving the exact SQL and wrapping failures with `eris.Wrap(err, "repository: cardgroup: acquire user seed lock")`. Declared the method on the exported `CardgroupRepository` interface too, since `repos.cardgroup` is passed to `NewMasterDeckUsecase` as an interface value and the narrow port now requires the method.
- `backend/internal/usecase/master_deck.go`: added `AcquireUserSeedLockTx` to the consumer-defined `masterDeckUserCardgroupRepo` interface; replaced the raw `tx.Exec("SELECT pg_advisory_xact_lock(0, hashtext(?))", ...)` block in `SeedForNewUser` with `u.userCG.AcquireUserSeedLockTx(ctx, tx, userID)` (error returned bare; the outer tx-return wrap is unchanged). The hashtext/namespace explanation moved to the repository method's docstring.
- `backend/internal/usecase/master_deck_test.go`: added the `AcquireUserSeedLockTx` stub to the `fakeUserCG` fake, recording the call (count + user id + a snapshot of how many `CountByOwner` calls had run, so the lock-before-count ordering is still provable). Updated `TestSeedForNewUser_TakesAdvisoryLockBeforeCounting` to assert against the recorded lock call instead of the recording ConnPool's SQL (the lock SQL no longer flows through the usecase tx). Refreshed the now-stale `recordPool` docblock that referenced the advisory-lock Exec.
- `backend/internal/loader/user_test.go`: added the `AcquireUserSeedLockTx` panic stub to `countingCardgroupRepo`, which implements the full `repository.CardgroupRepository` interface.

## Test plan

- `go tool gqlgen generate` to bootstrap the gitignored generated code (mise trust first), then `go build ./...` and `go vet ./...` — both pass.
- `grep -rn 'pg_advisory_xact_lock' backend/internal/usecase/ | grep -v _test.go` — returns nothing (acceptance criterion).
- `go test ./...` with Docker/testcontainers running — 2059 tests pass across 26 packages, including the `SeedForNewUser` concurrency/lock tests.
- Focused `go test ./internal/usecase/ -run TestSeedForNewUser` — 8 tests pass (lock-before-count, no-op, count-error, etc.).
- `go tool go-arch-lint check --project-path .` — OK, no layering warnings (no new cross-layer imports).

Closes #759
