### PR TITLE
fix(backend): cap the GraphQL request body size to prevent unbounded memory reads

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -46,6 +46,11 @@ import (
 
 const defaultShutdownTimeout = 25 * time.Second
 
+// queryBodyLimitBytes caps the request body at ~2 MiB. It is the single source
+// of truth for the BodyLimit installed in newRouter; main_test.go references it
+// directly so the test and the production limit can never drift.
+const queryBodyLimitBytes int64 = 2 * 1024 * 1024
+
 type serverConfig struct {
 	shutdownTimeout time.Duration
 	// introspectionEnabled is the single source of truth for whether GraphQL
@@ -258,6 +263,15 @@ func newRouter(
 	e.Use(internalmw.RequestID())
 	e.Use(middleware.Recover())
 	e.Use(middleware.RequestLogger())
+	// Cap the request body at ~2 MiB. gqlgen's transport.POST buffers the entire
+	// /query body into memory before parsing, so without this limit an
+	// unauthenticated oversized POST is a remote memory-exhaustion vector. The
+	// cap leaves headroom over the 1 MiB card-import payload plus JSON overhead.
+	// A request with an honest Content-Length header is rejected with 413 before
+	// the body is read; a chunked / no-Content-Length request is instead capped
+	// during the read by BodyLimit's wrapped limitedReader once the bytes read
+	// exceed the cap.
+	e.Use(middleware.BodyLimit(queryBodyLimitBytes))
 
 	e.GET("/", func(c *echo.Context) error {
 		return c.JSON(http.StatusOK, map[string]string{

--- a/backend/cmd/server/main_test.go
+++ b/backend/cmd/server/main_test.go
@@ -520,6 +520,77 @@ func TestGraphQLHealth(t *testing.T) {
 	}
 }
 
+// TestQueryEndpoint_RejectsOversizedBody asserts that a POST to /query whose
+// body exceeds the body-size cap is rejected with 413 before gqlgen buffers it
+// into memory. Without the middleware.BodyLimit guard in newRouter, gqlgen's
+// transport.POST reads the whole body and this request would not return 413.
+// The /query group uses noopAuthMW, so this vector is reachable unauthenticated.
+func TestQueryEndpoint_RejectsOversizedBody(t *testing.T) {
+	t.Parallel()
+	ts := newTestServer(t)
+
+	// One byte over the cap. Content is irrelevant: BodyLimit rejects on the
+	// Content-Length header before the GraphQL transport reads the body.
+	oversized := bytes.Repeat([]byte("a"), int(queryBodyLimitBytes)+1)
+	res, err := http.Post(ts.URL+"/query", "application/json", bytes.NewReader(oversized))
+	if err != nil {
+		t.Fatalf("POST /query: %v", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want %d", res.StatusCode, http.StatusRequestEntityTooLarge)
+	}
+}
+
+// TestQueryEndpoint_AcceptsLargePayloadUnderCap asserts that a legitimately
+// large request — bigger than the 1 MiB card-import cap but under the 2 MiB
+// body limit — still passes the BodyLimit guard and executes normally. The
+// query is padded to ~1.5 MiB with a trailing GraphQL comment, which the lexer
+// ignores, so { health } resolves to "ok".
+func TestQueryEndpoint_AcceptsLargePayloadUnderCap(t *testing.T) {
+	t.Parallel()
+	ts := newTestServer(t)
+
+	// 1.5 MiB of comment padding: comfortably above the 1 MiB card-import cap,
+	// comfortably below the 2 MiB body limit.
+	padding := strings.Repeat("a", 1536*1024)
+	query := "{ health }\n#" + padding
+	reqBody, err := json.Marshal(map[string]string{"query": query})
+	if err != nil {
+		t.Fatalf("marshal query: %v", err)
+	}
+	if len(reqBody) <= 1024*1024 || len(reqBody) >= int(queryBodyLimitBytes) {
+		t.Fatalf("test body size %d not between 1 MiB and the 2 MiB cap", len(reqBody))
+	}
+
+	res, err := http.Post(ts.URL+"/query", "application/json", bytes.NewReader(reqBody))
+	if err != nil {
+		t.Fatalf("POST /query: %v", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (large-but-under-cap payload must not be rejected)", res.StatusCode)
+	}
+
+	var payload struct {
+		Data struct {
+			Health string `json:"health"`
+		} `json:"data"`
+		Errors []any `json:"errors"`
+	}
+	if err := json.NewDecoder(res.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(payload.Errors) != 0 {
+		t.Fatalf("errors = %+v, want none", payload.Errors)
+	}
+	if payload.Data.Health != "ok" {
+		t.Fatalf("data.health = %q, want %q", payload.Data.Health, "ok")
+	}
+}
+
 // jwtFixture bundles an ECDSA signing key plus a JWKS endpoint that exposes its
 // public key, so integration tests can mint Supabase-shaped JWTs that the real
 // auth.AuthMiddleware will accept.


### PR DESCRIPTION
## Summary

The `/query` GraphQL endpoint had no request-body size limit. gqlgen's `transport.POST` buffers the entire request body into memory via `io.ReadAll` before any parsing, and the `/query` auth middleware is a documented anonymous passthrough, so an unauthenticated client could stream hundreds of MB per request (bounded only by `ReadTimeout`, not by bytes) and drive the process to OOM. `FixedComplexityLimit(100)` runs after the full read and cannot help.

This adds an Echo `middleware.BodyLimit` in `newRouter`, capping the request body at ~2 MiB — headroom over the 1 MiB card-import payload plus JSON overhead.

## Changes

- `backend/cmd/server/main.go` — `newRouter` installs `e.Use(middleware.BodyLimit(queryBodyLimitBytes))` alongside the existing `RequestID` / `Recover` / `RequestLogger` middleware. The limit is a package-level `const queryBodyLimitBytes int64 = 2 * 1024 * 1024` (single source of truth, also referenced by the test). A comment distinguishes the honest-`Content-Length` 413 (rejected before the body is read) from the chunked / no-`Content-Length` case (capped during the read by BodyLimit's wrapped reader). The `echo/v5/middleware` package was already imported.
- `backend/cmd/server/main_test.go` — two tests via the existing `newTestServer` (noop auth) harness, both referencing `queryBodyLimitBytes`:
  - `TestQueryEndpoint_RejectsOversizedBody`: a POST to `/query` one byte over the cap returns 413.
  - `TestQueryEndpoint_AcceptsLargePayloadUnderCap`: a ~1.5 MiB body (larger than the 1 MiB card-import cap, under the 2 MiB limit) still passes the guard and `{ health }` resolves to `"ok"`.

## Test plan

- `go build ./...` and `go vet ./...`: green; both changed files gofmt-clean.
- `go test ./...`: 1610 pass. The 5 failing packages (`cmd/server`, `cmd/seed`, `cmd/migrate-to-master`, `internal/repository`, `internal/database`) fail only because their testcontainer Postgres `TestMain` cannot start (Docker unavailable in the dev sandbox), not from any code change; they run in CI.
- The two new tests build into the `cmd/server` test binary and exercise the fixed path (413 oversized / 200 under-cap); the `middleware.BodyLimit` mechanism was additionally confirmed out-of-band (413 for a >2 MiB body, 200 for a ~1.5 MiB body).

Closes #778
