### PR TITLE
fix(notion): rewind request body before retrying so PATCH writes survive a 429/5xx

### DIFF
--- a/backend/internal/notion/client.go
+++ b/backend/internal/notion/client.go
@@ -74,6 +74,22 @@ func (rt *retryAfterRoundTripper) RoundTrip(req *http.Request) (*http.Response, 
 		}
 		discardAndClose(res.Body)
 
+		// Rewind the request body so the next RoundTrip re-sends the full
+		// payload. http.NewRequest sets GetBody for bytes.Buffer / bytes.Reader
+		// / strings.Reader bodies, which covers every notionapi-built request.
+		// Without this, a write request's body is consumed on attempt 1 and the
+		// retry sends content-length: N with 0 bytes, which Notion rejects.
+		if req.Body != nil {
+			if req.GetBody == nil {
+				return res, nil // non-rewindable body: do not retry, surface the response
+			}
+			body, err := req.GetBody()
+			if err != nil {
+				return nil, eris.Wrap(err, "notion: rewind request body")
+			}
+			req.Body = body
+		}
+
 		if time.Since(start)+wait > rt.cfg.MaxElapsed {
 			return nil, eris.Wrap(ErrRetryElapsed, "notion: retry request")
 		}

--- a/backend/internal/notion/client_test.go
+++ b/backend/internal/notion/client_test.go
@@ -1,10 +1,13 @@
 package notion
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 )
@@ -103,6 +106,80 @@ func TestRetryAfterRoundTripperStopsAtMaxAttempts(t *testing.T) {
 	}
 }
 
+// recordingRoundTripper reads and stores each request body it receives, then
+// returns the pre-programmed status codes in order (falling back to 200 once
+// the list is exhausted). It lets a test assert what payload each retry sends.
+type recordingRoundTripper struct {
+	statuses []int
+	bodies   [][]byte
+	idx      int
+}
+
+func (s *recordingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	var body []byte
+	if req.Body != nil {
+		b, err := io.ReadAll(req.Body)
+		if err != nil {
+			return nil, err
+		}
+		_ = req.Body.Close()
+		body = b
+	}
+	s.bodies = append(s.bodies, body)
+
+	status := http.StatusOK
+	if s.idx < len(s.statuses) {
+		status = s.statuses[s.idx]
+	}
+	s.idx++
+	return &http.Response{
+		StatusCode: status,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(bytes.NewReader(nil)),
+	}, nil
+}
+
+func TestRetryAfterRoundTripperRewindsRequestBodyOnRetry(t *testing.T) {
+	t.Parallel()
+
+	const payload = `{"children":[{"type":"paragraph","paragraph":{"rich_text":[]}}]}`
+	stub := &recordingRoundTripper{statuses: []int{http.StatusTooManyRequests, http.StatusOK}}
+
+	req, err := http.NewRequest(
+		http.MethodPatch,
+		"https://api.notion.com/v1/blocks/block-id/children",
+		bytes.NewBufferString(payload),
+	)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+
+	rt := NewRetryAfterRoundTripper(RetryConfig{
+		MaxAttempts: 3,
+		MaxElapsed:  5 * time.Second,
+		Transport:   stub,
+		Sleep: func(_ context.Context, _ time.Duration) error {
+			return nil
+		},
+	})
+
+	res, err := rt.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", res.StatusCode)
+	}
+	if len(stub.bodies) != 2 {
+		t.Fatalf("attempts = %d, want 2", len(stub.bodies))
+	}
+	if got := string(stub.bodies[1]); got != payload {
+		t.Fatalf("attempt 2 body = %q, want full payload %q", got, payload)
+	}
+}
+
 func TestRetryAfterRoundTripperRetries5xxWithFallback(t *testing.T) {
 	t.Parallel()
 
@@ -138,5 +215,87 @@ func TestRetryAfterRoundTripperRetries5xxWithFallback(t *testing.T) {
 	}
 	if len(slept) != 1 || slept[0] != time.Second {
 		t.Fatalf("slept = %v, want [1s]", slept)
+	}
+}
+
+func TestRetryAfterRoundTripperSurfacesResponseForNonRewindableBody(t *testing.T) {
+	t.Parallel()
+
+	stub := &recordingRoundTripper{statuses: []int{http.StatusTooManyRequests}}
+
+	req, err := http.NewRequest(
+		http.MethodPatch,
+		"https://api.notion.com/v1/blocks/block-id/children",
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	// A body with no GetBody cannot be rewound, so a retry would re-send an
+	// empty payload. The round-tripper must surface the 429 response instead.
+	req.Body = io.NopCloser(strings.NewReader("x"))
+	req.GetBody = nil
+
+	rt := NewRetryAfterRoundTripper(RetryConfig{
+		MaxAttempts: 3,
+		MaxElapsed:  5 * time.Second,
+		Transport:   stub,
+		Sleep: func(_ context.Context, _ time.Duration) error {
+			t.Fatal("sleep must not run when the body cannot be rewound")
+			return nil
+		},
+	})
+
+	res, err := rt.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip: unexpected error %v", err)
+	}
+	if res == nil {
+		t.Fatal("RoundTrip: response must be surfaced, got nil")
+	}
+	if res.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want 429", res.StatusCode)
+	}
+	if len(stub.bodies) != 1 {
+		t.Fatalf("transport invocations = %d, want 1 (no retry)", len(stub.bodies))
+	}
+}
+
+func TestRetryAfterRoundTripperGetBodyErrorWraps(t *testing.T) {
+	t.Parallel()
+
+	const payload = `{"children":[]}`
+	stub := &recordingRoundTripper{statuses: []int{http.StatusTooManyRequests}}
+
+	req, err := http.NewRequest(
+		http.MethodPatch,
+		"https://api.notion.com/v1/blocks/block-id/children",
+		bytes.NewBuffer([]byte(payload)),
+	)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	// GetBody failing on rewind is an unrecoverable error; the round-tripper
+	// must wrap and return it rather than retry with a broken body.
+	wantErr := errors.New("rewind boom")
+	req.GetBody = func() (io.ReadCloser, error) {
+		return nil, wantErr
+	}
+
+	rt := NewRetryAfterRoundTripper(RetryConfig{
+		MaxAttempts: 3,
+		MaxElapsed:  5 * time.Second,
+		Transport:   stub,
+		Sleep: func(_ context.Context, _ time.Duration) error {
+			return nil
+		},
+	})
+
+	res, err := rt.RoundTrip(req)
+	if err == nil {
+		t.Fatalf("RoundTrip: expected error, got response %v", res)
+	}
+	if !strings.Contains(err.Error(), "notion: rewind request body") {
+		t.Fatalf("err = %q, want it to contain %q", err.Error(), "notion: rewind request body")
 	}
 }


### PR DESCRIPTION
## Summary

The Notion retry transport was dead for write requests. `retryAfterRoundTripper.RoundTrip` looped over the same `*http.Request` on 429/5xx without rewinding the body, so on the production HTTP/2 path attempt 2 sent `content-length: N` with 0 body bytes (`req.GetBody` is never called automatically for a second `RoundTrip`). Notion rejected the empty-body `PATCH` with a non-retryable 400, silently losing every card writeback under exactly the rate-limit conditions the retry exists to handle. GET-based `Fetcher` calls (nil body) were unaffected.

## Changes

- `backend/internal/notion/client.go`: after draining the failed response and before sleeping, rewind the request body via `req.GetBody()` when `req.Body != nil`. A rewind error is wrapped with `eris.Wrap(err, "notion: rewind request body")`. A non-rewindable body (`req.GetBody == nil`) surfaces the response instead of retrying. `http.NewRequest` sets `GetBody` for `bytes.Buffer` / `bytes.Reader` / `strings.Reader` bodies, which covers all notionapi-built requests.

## Test plan

- `TestRetryAfterRoundTripperRewindsRequestBodyOnRetry`: a `PATCH` with a `bytes.Buffer` body against a stub returning 429 then 200 asserts attempt 2 receives the **full** payload (verified red on pre-fix code — attempt 2 body empty).
- `TestRetryAfterRoundTripperSurfacesResponseForNonRewindableBody`: a nil-`GetBody` request against a 429 stub returns `(res, nil)` with status 429 and exactly one attempt (no retry).
- `TestRetryAfterRoundTripperGetBodyErrorWraps`: a request whose `GetBody` errors returns an error wrapping `"notion: rewind request body"`.
- The four existing GET-based `client_test.go` tests still pass. `gofmt -l`, `go build ./...`, `go vet ./...` clean; `go test ./internal/notion/...` green (32 tests).

Closes #780
