### PR TITLE
fix(backend): bound the notion-sync request so its retry budget fits the WriteTimeout

### DIFF
--- a/backend/internal/handler/notionsync/handler.go
+++ b/backend/internal/handler/notionsync/handler.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/labstack/echo/v5"
 
@@ -26,10 +27,21 @@ type Config struct {
 	MasterCardgroupName string
 }
 
+// defaultSyncTimeout bounds the whole sync (fetch + parse + persist) so the
+// handler writes a deliverable error response before the server's 30s
+// WriteTimeout expires. Without this cap, a sync slower than the write deadline
+// still commits on the backend, but the deferred response write fails against
+// the expired connection deadline: the caller sees a connection reset for work
+// that actually succeeded, and a retry re-runs the entire sync. Kept below the
+// WriteTimeout so context cancellation, not the write deadline, terminates the
+// request.
+const defaultSyncTimeout = 25 * time.Second
+
 type Handler struct {
-	uc     SyncUsecase
-	config Config
-	logger *slog.Logger
+	uc          SyncUsecase
+	config      Config
+	logger      *slog.Logger
+	syncTimeout time.Duration
 }
 
 func New(uc SyncUsecase, cfg Config) *Handler {
@@ -39,7 +51,7 @@ func New(uc SyncUsecase, cfg Config) *Handler {
 	if cfg.Token == "" {
 		panic("notionsync.New: token must not be empty")
 	}
-	return &Handler{uc: uc, config: cfg, logger: slog.Default()}
+	return &Handler{uc: uc, config: cfg, logger: slog.Default(), syncTimeout: defaultSyncTimeout}
 }
 
 func (h *Handler) Handle(c *echo.Context) error {
@@ -50,7 +62,14 @@ func (h *Handler) Handle(c *echo.Context) error {
 		return c.JSON(http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
 	}
 
-	out, err := h.uc.Sync(c.Request().Context(), usecase.SyncToMasterInput{
+	// Cap the whole sync below the server's WriteTimeout so the deadline is hit
+	// via context cancellation (yielding a deliverable 504 via handleError)
+	// rather than by the connection write deadline (which resets the connection
+	// on work that already completed).
+	ctx, cancel := context.WithTimeout(c.Request().Context(), h.syncTimeout)
+	defer cancel()
+
+	out, err := h.uc.Sync(ctx, usecase.SyncToMasterInput{
 		PageIDs:             h.config.PageIDs,
 		MasterCardgroupName: h.config.MasterCardgroupName,
 	})

--- a/backend/internal/handler/notionsync/handler_test.go
+++ b/backend/internal/handler/notionsync/handler_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/labstack/echo/v5"
 	"github.com/rotisserie/eris"
@@ -32,6 +33,55 @@ func (s *stubSyncUsecase) Sync(_ context.Context, in usecase.SyncToMasterInput) 
 		return usecase.MasterNotionSyncOutput{}, s.err
 	}
 	return s.out, nil
+}
+
+// blockingSyncUsecase blocks until the request context is cancelled, then
+// returns ctx.Err(). It models a sync that runs longer than the handler's
+// timeout budget. The time.After arm is a safety valve: an unpatched handler
+// passes an uncancelled request context, so this stub fails fast (returning a
+// non-timeout error) instead of hanging the suite.
+type blockingSyncUsecase struct {
+	calls int
+}
+
+func (s *blockingSyncUsecase) Sync(ctx context.Context, _ usecase.SyncToMasterInput) (usecase.MasterNotionSyncOutput, error) {
+	s.calls++
+	select {
+	case <-ctx.Done():
+		return usecase.MasterNotionSyncOutput{}, ctx.Err()
+	case <-time.After(2 * time.Second):
+		return usecase.MasterNotionSyncOutput{}, errors.New("sync context was not cancelled within the deadline budget")
+	}
+}
+
+// TestHandle_SyncExceedsDeadline_Returns504 verifies that a sync exceeding the
+// handler's timeout budget is cancelled and produces a deliverable 504 response,
+// rather than running to completion and having the deferred write fail against
+// the server's WriteTimeout (a connection reset for work that succeeded). The
+// handler wraps the request context with syncTimeout below the write deadline;
+// it is shortened here so the deadline fires quickly.
+func TestHandle_SyncExceedsDeadline_Returns504(t *testing.T) {
+	t.Parallel()
+
+	uc := &blockingSyncUsecase{}
+	h := New(uc, Config{Token: "secret"})
+	h.syncTimeout = 20 * time.Millisecond
+
+	req := httptest.NewRequest(http.MethodPost, "/internal/notion-sync", strings.NewReader(""))
+	req.Header.Set("Authorization", "Bearer secret")
+	rec := httptest.NewRecorder()
+	e := echo.New()
+	c := e.NewContext(req, rec)
+
+	if err := h.Handle(c); err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if rec.Code != http.StatusGatewayTimeout {
+		t.Fatalf("status = %d, want 504", rec.Code)
+	}
+	if uc.calls != 1 {
+		t.Fatalf("usecase calls = %d, want 1", uc.calls)
+	}
 }
 
 func TestHandlerUnauthorized(t *testing.T) {

--- a/backend/internal/notion/client.go
+++ b/backend/internal/notion/client.go
@@ -17,6 +17,14 @@ var (
 	ErrRetryAttempts = errors.New("notion: retry attempts exceeded")
 )
 
+// defaultMaxElapsed bounds the cumulative Notion retry wait per request. It is
+// deliberately kept below the server's 30s WriteTimeout so a slow sync surfaces
+// a deliverable error response instead of a write-deadline connection reset.
+// Operators may raise it via NOTION_MAX_ELAPSED, but the notion-sync handler
+// independently caps the whole sync with a request-context deadline below the
+// write timeout.
+const defaultMaxElapsed = 20 * time.Second
+
 type RetryConfig struct {
 	MaxAttempts int
 	MaxElapsed  time.Duration
@@ -34,7 +42,7 @@ func NewRetryAfterRoundTripper(cfg RetryConfig) http.RoundTripper {
 		cfg.MaxAttempts = 5
 	}
 	if cfg.MaxElapsed <= 0 {
-		cfg.MaxElapsed = 2 * time.Minute
+		cfg.MaxElapsed = defaultMaxElapsed
 	}
 	if cfg.Transport == nil {
 		cfg.Transport = http.DefaultTransport

--- a/backend/internal/notion/retry_config.go
+++ b/backend/internal/notion/retry_config.go
@@ -11,12 +11,13 @@ import (
 
 // RetryConfigFromEnv reads NOTION_MAX_ATTEMPTS and NOTION_MAX_ELAPSED from the
 // environment and returns a RetryConfig with those two fields populated.
-// Defaults: MaxAttempts=5, MaxElapsed=2*time.Minute. Other RetryConfig fields
-// (Transport, Logger, Sleep) are left zero for the caller to fill.
+// Defaults: MaxAttempts=5, MaxElapsed=defaultMaxElapsed (20s, below the server's
+// 30s WriteTimeout). Other RetryConfig fields (Transport, Logger, Sleep) are
+// left zero for the caller to fill.
 func RetryConfigFromEnv() (RetryConfig, error) {
 	cfg := RetryConfig{
 		MaxAttempts: 5,
-		MaxElapsed:  2 * time.Minute,
+		MaxElapsed:  defaultMaxElapsed,
 	}
 	if raw := strings.TrimSpace(os.Getenv("NOTION_MAX_ATTEMPTS")); raw != "" {
 		n, err := strconv.Atoi(raw)

--- a/backend/internal/notion/retry_config_test.go
+++ b/backend/internal/notion/retry_config_test.go
@@ -18,7 +18,7 @@ func TestRetryConfigFromEnv(t *testing.T) {
 		{
 			name:         "defaults when no env set",
 			wantAttempts: 5,
-			wantElapsed:  2 * time.Minute,
+			wantElapsed:  20 * time.Second,
 		},
 		{
 			name:         "valid override of both vars",
@@ -64,13 +64,13 @@ func TestRetryConfigFromEnv(t *testing.T) {
 			name:         "whitespace-only NOTION_MAX_ATTEMPTS treated as unset",
 			maxAttempts:  "   ",
 			wantAttempts: 5,
-			wantElapsed:  2 * time.Minute,
+			wantElapsed:  20 * time.Second,
 		},
 		{
 			name:         "whitespace-only NOTION_MAX_ELAPSED treated as unset",
 			maxElapsed:   "   ",
 			wantAttempts: 5,
-			wantElapsed:  2 * time.Minute,
+			wantElapsed:  20 * time.Second,
 		},
 	}
 
@@ -79,12 +79,14 @@ func TestRetryConfigFromEnv(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			// t.Setenv requires sequential subtests — no t.Parallel() here.
 
-			if tc.maxAttempts != "" {
-				t.Setenv("NOTION_MAX_ATTEMPTS", tc.maxAttempts)
-			}
-			if tc.maxElapsed != "" {
-				t.Setenv("NOTION_MAX_ELAPSED", tc.maxElapsed)
-			}
+			// Set both vars unconditionally (to "" for the "unset" cases) so an
+			// ambient NOTION_MAX_* — e.g. exported from a local .env by mise —
+			// cannot leak into cases that assert the built-in defaults. An empty
+			// or whitespace-only value is treated as unset by RetryConfigFromEnv
+			// (TrimSpace == ""), and t.Setenv still restores the prior value on
+			// cleanup.
+			t.Setenv("NOTION_MAX_ATTEMPTS", tc.maxAttempts)
+			t.Setenv("NOTION_MAX_ELAPSED", tc.maxElapsed)
 
 			cfg, err := RetryConfigFromEnv()
 

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -64,7 +64,7 @@ These values target a public API on Render. Revisit if the threat model or deplo
 | `NOTION_MASTER_CARDGROUP_NAME` | no\* | — | Name of the master cardgroup in the `master_cardgroups` table that the sync job targets. |
 | `NOTION_SYNC_TOKEN` | no\* | — | Bearer token for `POST /internal/notion-sync`. |
 | `NOTION_MAX_ATTEMPTS` | no | `5` | Retry attempt cap for Notion 429/5xx responses. Must be positive when set. |
-| `NOTION_MAX_ELAPSED` | no | `2m` | Maximum cumulative Notion retry wait per request. Must be a positive Go duration when set. |
+| `NOTION_MAX_ELAPSED` | no | `20s` | Maximum cumulative Notion retry wait per request. Kept below the server's 30s `WriteTimeout`; must be a positive Go duration when set. |
 | `SUPER_USER_EMAILS` | no | *(empty)* | Comma-separated trusted email addresses promoted to `admin` on first authenticated request. See `docs/backend-auth.md` § "Bootstrap admin". |
 
 `PORT`, `SHUTDOWN_TIMEOUT`, `NOTION_MAX_ATTEMPTS`, `NOTION_MAX_ELAPSED`, and `SUPER_USER_EMAILS` are optional with safe defaults. The three `SUPABASE_JWT_*` variables, `SUPABASE_DB_URL`, and `PING_TOKEN` are strictly required — the server refuses to start if any is missing.

--- a/docs/notion-sync.md
+++ b/docs/notion-sync.md
@@ -14,7 +14,7 @@ Required:
 Optional:
 
 - `NOTION_MAX_ATTEMPTS`: default `5`.
-- `NOTION_MAX_ELAPSED`: default `2m`.
+- `NOTION_MAX_ELAPSED`: default `20s` (kept below the server's 30s `WriteTimeout`).
 
 Master cardgroups are owner-less: the destination deck is identified by `NOTION_MASTER_CARDGROUP_NAME` alone. The backend resolves the name to a master cardgroup id via `MasterCardgroupRepository.EnsureByName`, which serializes lookup-then-insert under a `pg_advisory_xact_lock(hashtext('master'), hashtext(name))` so concurrent runs cannot create duplicate-name rows. No owner UUID is required.
 
@@ -92,7 +92,7 @@ All NOTION_* values are stored in the root `.env` file (gitignored). The Makefil
 | `NOTION_MASTER_CARDGROUP_NAME` | yes | Destination master cardgroup name; created when absent. Owner-less — no owner email/UUID is required. |
 | `NOTION_SYNC_TOKEN` | yes | Shared bearer token — written to both Render env and the GHA secret (see note below) |
 | `NOTION_MAX_ATTEMPTS` | no | Defaults to `5` |
-| `NOTION_MAX_ELAPSED` | no | Defaults to `2m` |
+| `NOTION_MAX_ELAPSED` | no | Defaults to `20s` |
 
 `NOTION_SYNC_TOKEN` is deliberately written to **two destinations with the same value**: the Render service env and the `NOTION_SYNC_TOKEN` GitHub Actions secret. This is what guarantees bearer-auth integrity — the backend validates the token in the incoming `Authorization: Bearer` header, and the GHA workflow supplies it as that same secret. If the two values drift, every sync request returns `401`.
 
@@ -162,5 +162,9 @@ The endpoint maps internal sentinels to HTTP statuses as follows:
 - `502 Bad Gateway` — Notion API call failures (`ErrNotionSyncFetch`).
 - `504 Gateway Timeout` — retry budget exhausted (`NOTION_MAX_ATTEMPTS`, `NOTION_MAX_ELAPSED`) or request context cancelled / timed out.
 - `500 Internal Server Error` — persistence failures (`ErrNotionSyncPersist`) and any unmapped error.
+
+The handler wraps the whole sync in a request-context deadline (25s) that sits below the server's 30s `WriteTimeout`. This guarantees a slow sync is cancelled and returns a deliverable `504` before the connection write deadline expires — otherwise the sync commits on the backend but the response write fails against the expired deadline, so the caller sees a connection reset for work that actually succeeded and a retry re-runs the entire sync.
+
+The operator-visible tradeoff is that a legitimate large sync whose work lands in the 25–30s band now surfaces as a deliverable `504` even when the persistence step already committed. Confirm a run's true outcome from the server-side `notion sync complete` log line rather than trusting the HTTP status alone: a `504` accompanied by that log record means the sync succeeded and the timeout only truncated the response.
 
 Concurrent triggers from GitHub Actions (cron + workflow_dispatch) are serialized via the workflow's concurrency group, so only one sync runs at a time on that path.


### PR DESCRIPTION
## Summary

`POST /internal/notion-sync` runs the whole sync inline (fetch + parse + persist) and writes the JSON response only after it completes, but the single global `http.Server` sets `WriteTimeout: 30s`. Go's `WriteTimeout` sets a connection write deadline and does **not** cancel the request context, so a sync slower than 30s still commits on the backend (tx commits, "notion sync complete" logs) while the deferred response write fails against the expired deadline. The caller sees a connection reset for work that actually succeeded, and a cron/operator retry re-runs the entire sync.

This makes the budgets consistent so a slow sync is cancelled and returns a deliverable `504` before the write deadline expires.

## Changes

- `internal/handler/notionsync/handler.go`: wrap the `uc.Sync` call in a request-context deadline (`defaultSyncTimeout = 25s`), below the 30s `WriteTimeout`. `handleError` already maps `context.DeadlineExceeded` → `504`, so the response is delivered before the connection write deadline. Added a `syncTimeout` field to `Handler` (defaulted in `New`).
- `internal/notion/client.go` + `retry_config.go`: lower the default `RetryConfig.MaxElapsed` from `2m` to `20s` via a shared `defaultMaxElapsed` constant used by both `RetryConfigFromEnv` and the round-tripper zero-value fallback. The `NOTION_MAX_ELAPSED` env override is unchanged.
- `internal/handler/notionsync/handler_test.go`: new `TestHandle_SyncExceedsDeadline_Returns504` — a stub that blocks until context cancellation proves a sync exceeding the (shortened) budget yields a deliverable `504`.
- `internal/notion/retry_config_test.go`: update default-value expectations to `20s`; make the env-var cases hermetic (unconditional `t.Setenv`) so an ambient `NOTION_MAX_ELAPSED` cannot leak into the "unset" cases.
- `docs/backend.md`, `docs/notion-sync.md`: document the new `20s` default and the 25s handler cap, plus an operator note that a sync landing in the 25–30s band now surfaces as a deliverable `504` even when persistence already committed — confirm the true outcome via the server-side `notion sync complete` log rather than the HTTP status alone.

`render.yaml` and the Ansible playbooks explicitly set `NOTION_MAX_ELAPSED=2m`; those deployed-infra values are left unchanged (operator sign-off). The handler's 25s context deadline caps any larger configured value safely, so no infra change is required for correctness.

## Test plan

- `go build ./...` / `go vet ./...` — green.
- `go test ./internal/notion/... ./internal/handler/notionsync/...` — green (71 tests), including the new deadline test.
- `go test ./...` — non-Docker packages green; testcontainers-gated packages fail only on "rootless Docker not found" in the sandbox, unrelated to the change.

Closes #781
