### PR TITLE
fix(frontend): stop the learn prefetch from re-appending an in-flight-swiped card

### DIFF
--- a/frontend/src/app/learn/[cardgroupId]/learn-client.test.tsx
+++ b/frontend/src/app/learn/[cardgroupId]/learn-client.test.tsx
@@ -1361,4 +1361,262 @@ describe("<LearnClient> queue prefetch", () => {
       consoleWarnSpy.mockRestore();
     }
   });
+
+  it("does not re-append a still-in-flight swiped card returned by a racing prefetch", async () => {
+    // Regression for issue #789. `onSwipe` optimistically removes the swiped
+    // card then awaits `handleSwipe`. The removal shrinks the queue past the
+    // threshold and fires a network-only `LearnNextDueCards` prefetch WHILE the
+    // swipe mutation is still in flight. If the backend read beats the FSRS
+    // write commit, the just-swiped card still reads as "due" and comes back in
+    // the batch; because the dedup `seen` set is built from the post-removal
+    // queue (which no longer holds the card), it would be re-appended — a
+    // duplicate FSRS review. The in-flight-id filter drops it while still
+    // merging a genuinely new card from the same batch.
+    const initial = makeQueue(PREFETCH_THRESHOLD + 1); // q-1..q-6 — above threshold, no mount prefetch
+    const swipedCard = initial[0] as PrefetchCard; // q-1, "Front 1"
+    const freshCard: PrefetchCard = {
+      __typename: "Card" as const,
+      id: "p-new",
+      front: "Prefetched New",
+      back: "Prefetched Back",
+      cefrLevel: null,
+      userCardState: userCardState("2026-04-30T00:00:00Z", 0),
+      cardgroupId: CG_ID,
+    };
+    // The racing prefetch returns the just-swiped card AND a genuinely new card.
+    const prefetch = makePrefetchMock([swipedCard, freshCard]);
+    // Hold `handleSwipe` open so the prefetch resolves and merges while the swipe
+    // mutation is still pending (the FSRS write has not committed).
+    const swipe = {
+      request: {
+        query: HandleSwipeDocument,
+        variables: { input: { cardId: "q-1", cardgroupId: CG_ID, mode: 4 } },
+      },
+      delay: 80,
+      result: {
+        data: {
+          handleSwipe: {
+            __typename: "HandleSwipeSuccess" as const,
+            response: {
+              __typename: "SwipeResponse" as const,
+              performanceMode: 0,
+              metrics: DEFAULT_METRICS,
+            },
+          },
+        },
+      },
+    };
+
+    const user = userEvent.setup();
+    renderLearnClient([prefetch.mock, swipe], initial, { skipDefaultPrefetchMocks: true });
+
+    // Swipe q-1 — queue shrinks 6 → 5, crossing the threshold and firing the
+    // racing prefetch while `handleSwipe` is still pending.
+    await user.click(screen.getByRole("button", { name: "Rate as Easy" }));
+
+    // The racing prefetch fires and resolves.
+    await waitFor(() => {
+      expect(prefetch.callCount()).toBe(1);
+    });
+
+    // The genuinely new card IS merged (proving the merge ran and dedup filtered
+    // ONLY the in-flight id)...
+    await waitFor(() => {
+      const latest = capturedCardSnapshots.at(-1);
+      expect(latest?.map((c) => c.id)).toContain("p-new");
+    });
+
+    // ...but the just-swiped, still-in-flight card is NOT re-appended.
+    const merged = capturedCardSnapshots.at(-1);
+    const ids = merged?.map((c) => c.id) ?? [];
+    expect(ids).not.toContain("q-1");
+  });
+
+  it("does not re-fire prefetch on tail swipes once the due pool is exhausted", async () => {
+    // Perf regression for issue #789. Once `LearnNextDueCards` returns nothing
+    // due, the pool is exhausted; every subsequent tail swipe (queue 5 → 4 → …)
+    // would otherwise fire another redundant network-only 20-card query that
+    // returns nothing new. The exhaustion guard suppresses those until a swipe
+    // succeeds (which may make a rated card due again).
+    //
+    // Only ONE prefetch mock is supplied (the mount fetch). A second, unmatched
+    // prefetch dispatched by the tail swipe would trip the file-wide
+    // MockedProvider leak spy (`assertNoLeaks` in the shared afterEach) — the
+    // same negative-assertion idiom the "does not prefetch when queue is above
+    // threshold / empty" tests above rely on.
+    const initial = makeQueue(PREFETCH_THRESHOLD); // q-1..q-5 — at threshold
+    const prefetch = makePrefetchMock([]); // mount fetch → nothing due → exhausted
+    const swipe = {
+      request: {
+        query: HandleSwipeDocument,
+        variables: { input: { cardId: "q-1", cardgroupId: CG_ID, mode: 4 } },
+      },
+      result: {
+        data: {
+          handleSwipe: {
+            __typename: "HandleSwipeSuccess" as const,
+            response: {
+              __typename: "SwipeResponse" as const,
+              performanceMode: 0,
+              metrics: DEFAULT_METRICS,
+            },
+          },
+        },
+      },
+    };
+
+    const user = userEvent.setup();
+    renderLearnClient([prefetch.mock, swipe], initial, { skipDefaultPrefetchMocks: true });
+
+    // Mount prefetch fires once and finds nothing due.
+    await waitFor(() => {
+      expect(prefetch.callCount()).toBe(1);
+    });
+    // Let the resolved prefetch's `.then` run so the exhaustion guard is set
+    // before the swipe re-crosses the threshold.
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    // Swipe the head card — queue shrinks 5 → 4, re-crossing the threshold. With
+    // no exhaustion guard this dispatches a second, unmatched prefetch.
+    await user.click(screen.getByRole("button", { name: "Rate as Easy" }));
+
+    // Queue advanced to the next card.
+    await waitFor(() => {
+      expect(screen.getByText("Front 2")).toBeInTheDocument();
+    });
+    // Give any (buggy) second prefetch dispatch a chance to surface as a leak.
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    // Still exactly the one mount prefetch — the tail swipe fired no further
+    // query (a second dispatch also trips `assertNoLeaks` in afterEach).
+    expect(prefetch.callCount()).toBe(1);
+  });
+
+  it("resumes prefetch after a successful swipe clears the exhaustion guard", async () => {
+    // Recovery counterpart to the suppression test above (regression guard for
+    // issue #789). Once the pool is exhausted (`exhaustedRef` set), a swipe that
+    // SUCCEEDS must re-open prefetching: a rated card may become due again, so
+    // `HandleSwipeSuccess` resets `exhaustedRef`. The NEXT tail swipe that
+    // re-crosses the threshold then dispatches a fresh prefetch. If the
+    // `exhaustedRef.current = false` reset on `HandleSwipeSuccess` were removed,
+    // the guard would stay set for the rest of the session and this second
+    // prefetch would never fire — the assertions below go red.
+    //
+    // Three `LearnNextDueCards` mocks are consumed in order:
+    //  1. mount fetch → nothing due → exhausted;
+    //  2. recovery fetch (after the second swipe) → a genuinely due card,
+    //     proving prefetch resumed;
+    //  3. merging that single card leaves the queue at 4 (still ≤ threshold), so
+    //     the effect fires once more — a terminating empty fetch that
+    //     re-exhausts the pool and stops the cascade (an unmatched fourth
+    //     dispatch would trip `assertNoLeaks` in the shared afterEach).
+    // This mirrors the "warns and re-allows prefetch after a failed attempt"
+    // recovery convention (second prefetch mock + a swipe that re-crosses the
+    // threshold), extended with the extra swipe the exhaustion guard requires.
+    const initial = makeQueue(PREFETCH_THRESHOLD); // q-1..q-5 — at threshold
+    const mountPrefetch = makePrefetchMock([]); // mount fetch → nothing due → exhausted
+    const recoveryCard: PrefetchCard = {
+      __typename: "Card" as const,
+      id: "r-recovery",
+      front: "Recovered Due Card",
+      back: "Recovered Back",
+      cefrLevel: null,
+      userCardState: userCardState("2026-04-30T00:00:00Z", 0),
+      cardgroupId: CG_ID,
+    };
+    const recovery = makePrefetchMock([recoveryCard]); // after the 2nd swipe → a due card
+    const terminator = makePrefetchMock([]); // post-merge fire re-exhausts, ending the cascade
+    // Each swipe mock tracks whether its result fn ran so the test can wait for
+    // the FIRST swipe's mutation to actually resolve (which clears the guard)
+    // before dispatching the second swipe — the optimistic queue advance is
+    // synchronous and would otherwise let the second swipe race ahead of the
+    // guard reset.
+    const makeSwipeSuccess = (cardId: string) => {
+      let called = false;
+      return {
+        mock: {
+          request: {
+            query: HandleSwipeDocument,
+            variables: { input: { cardId, cardgroupId: CG_ID, mode: 4 } },
+          },
+          result: () => {
+            called = true;
+            return {
+              data: {
+                handleSwipe: {
+                  __typename: "HandleSwipeSuccess" as const,
+                  response: {
+                    __typename: "SwipeResponse" as const,
+                    performanceMode: 0,
+                    metrics: DEFAULT_METRICS,
+                  },
+                },
+              },
+            };
+          },
+        },
+        wasCalled: () => called,
+      };
+    };
+    const swipe1 = makeSwipeSuccess("q-1");
+    const swipe2 = makeSwipeSuccess("q-2");
+
+    const user = userEvent.setup();
+    renderLearnClient(
+      [mountPrefetch.mock, recovery.mock, terminator.mock, swipe1.mock, swipe2.mock],
+      initial,
+      { skipDefaultPrefetchMocks: true },
+    );
+
+    // Mount prefetch fires once and finds nothing due → exhaustion guard set.
+    await waitFor(() => {
+      expect(mountPrefetch.callCount()).toBe(1);
+    });
+    // Let the resolved mount prefetch's `.then` run so `exhaustedRef` is set.
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    // First swipe (q-1) succeeds. The optimistic removal shrinks 5 → 4 and
+    // re-fires the effect, but the guard is still set at that instant, so no
+    // prefetch fires here — the swipe's `HandleSwipeSuccess` then clears the guard.
+    await user.click(screen.getByRole("button", { name: "Rate as Easy" }));
+    // Wait for the first swipe's mutation to actually resolve (its result fn
+    // runs)...
+    await waitFor(() => {
+      expect(swipe1.wasCalled()).toBe(true);
+    });
+    // ...then drain microtasks so the `HandleSwipeSuccess` continuation clears
+    // `exhaustedRef` BEFORE the second swipe re-crosses the threshold. Without
+    // this ordering the guard would still be set when the second swipe fires.
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    // Queue advanced to the next card (q-2 is now head).
+    await waitFor(() => {
+      expect(screen.getByText("Front 2")).toBeInTheDocument();
+    });
+    // The first swipe did NOT resume prefetch — the guard held while it ran.
+    expect(recovery.callCount()).toBe(0);
+
+    // Second swipe (q-2) shrinks 4 → 3, re-crossing the threshold with the guard
+    // now cleared. This is the dispatch the exhaustion guard would suppress if it
+    // never reset — so it must fire the recovery prefetch.
+    await user.click(screen.getByRole("button", { name: "Rate as Easy" }));
+
+    // The recovery prefetch fires (its result fn runs)...
+    await waitFor(() => {
+      expect(recovery.callCount()).toBe(1);
+    });
+    // ...and the due card it returns is merged into the queue, proving prefetch
+    // resumed after the successful swipe cleared the exhaustion guard.
+    await waitFor(() => {
+      const latest = capturedCardSnapshots.at(-1);
+      expect(latest?.map((c) => c.id)).toContain("r-recovery");
+    });
+  });
 });

--- a/frontend/src/app/learn/[cardgroupId]/learn-client.tsx
+++ b/frontend/src/app/learn/[cardgroupId]/learn-client.tsx
@@ -163,9 +163,36 @@ export function LearnClient({ cardgroupId, initialCards, displayMode }: Props) {
   }, []);
 
   const prefetchInFlightRef = useRef(false);
+  // Ids of cards whose `handleSwipe` mutation is currently in flight. The
+  // optimistic queue removal in `onSwipe` shrinks the queue and can re-fire the
+  // prefetch below WHILE the swipe mutation has not yet committed its FSRS
+  // write; a network-only read that beats that write still sees the card as
+  // "due" and returns it in the batch. The merge filters `incoming` against this
+  // set so the just-swiped card is not re-appended (which would cause a
+  // duplicate FSRS review). ONLY in-flight ids are filtered — once a swipe
+  // settles its id is removed, so a genuinely re-due "again" card may
+  // legitimately re-enter the queue on a later prefetch.
+  const inFlightSwipeIdsRef = useRef<Set<string>>(new Set());
+  // Set once a prefetch resolves and the dedup merge adds zero new cards: the
+  // due pool is exhausted, so every subsequent tail swipe would otherwise fire a
+  // redundant network-only query that returns nothing new. The effect
+  // short-circuits while this is set. Cleared after a swipe mutation succeeds (a
+  // rated card may become due again) and on cardgroup change.
+  const exhaustedRef = useRef(false);
+  // Tracks the cardgroup the exhaustion verdict belongs to. When the active
+  // cardgroup changes, the prefetch effect below clears `exhaustedRef` before
+  // its threshold checks, because a different deck has its own due pool and a
+  // previous "nothing due" verdict must not carry over.
+  const exhaustedForCardgroupRef = useRef(cardgroupId);
+
   useEffect(() => {
+    if (exhaustedForCardgroupRef.current !== cardgroupId) {
+      exhaustedForCardgroupRef.current = cardgroupId;
+      exhaustedRef.current = false;
+    }
     if (queue.length === 0 || queue.length > PREFETCH_THRESHOLD) return;
     if (prefetchInFlightRef.current) return;
+    if (exhaustedRef.current) return;
     prefetchInFlightRef.current = true;
     client
       .query({
@@ -176,14 +203,24 @@ export function LearnClient({ cardgroupId, initialCards, displayMode }: Props) {
       .then((result) => {
         if (!isMountedRef.current) return;
         const incoming = result.data?.learnNextDueCards ?? [];
-        if (incoming.length === 0) return;
+        if (incoming.length === 0) {
+          exhaustedRef.current = true;
+          return;
+        }
         setQueue((current) => {
           const seen = new Set(current.map((c) => c.id));
-          const merged = [...current];
-          for (const card of incoming) {
-            if (!seen.has(card.id)) merged.push(card);
+          const inFlight = inFlightSwipeIdsRef.current;
+          // Drop cards already queued (`seen`) and cards whose swipe mutation is
+          // still in flight (`inFlight`) — the latter may read as "due" if the
+          // prefetch beat the FSRS write commit.
+          const additions = incoming.filter((card) => !seen.has(card.id) && !inFlight.has(card.id));
+          if (additions.length === 0) {
+            // Nothing new survived the merge — mark the pool exhausted so tail
+            // swipes stop re-firing this query until a swipe succeeds.
+            exhaustedRef.current = true;
+            return current;
           }
-          return merged;
+          return [...current, ...additions];
         });
       })
       .catch((err) => {
@@ -203,6 +240,11 @@ export function LearnClient({ cardgroupId, initialCards, displayMode }: Props) {
     async (card: LearnCard, direction: SwipeDirection) => {
       const mode = modeFromDirection(direction);
       setLocalError(null);
+      // Mark this card's swipe as in flight BEFORE the optimistic removal so the
+      // prefetch effect (which the removal can re-fire) filters it out of any
+      // racing LearnNextDueCards batch until the FSRS write commits. The marker
+      // is cleared in the mutation's `finally` below.
+      inFlightSwipeIdsRef.current.add(card.id);
       setQueue((current) => current.filter((candidate) => candidate.id !== card.id));
       setCompleted((current) => current + 1);
 
@@ -213,19 +255,26 @@ export function LearnClient({ cardgroupId, initialCards, displayMode }: Props) {
         // See .claude/rules/pagination.md § "Drop `optimisticResponse` for mutations that can
         // fail with typed GraphQL errors". The optimistic queue advance above (via setQueue)
         // is React state and is unaffected.
-      }).catch((err) => {
-        // err.message is omitted — backend messages may echo user-authored content.
-        // See docs/frontend/rsc-error-handling/substring-matching-sdk-error-strings.md.
-        console.error("[LearnClient] handleSwipe rejected", {
-          cardId: card.id,
-          cardgroupId,
-          name: err instanceof Error ? err.name : "unknown",
+      })
+        .catch((err) => {
+          // err.message is omitted — backend messages may echo user-authored content.
+          // See docs/frontend/rsc-error-handling/substring-matching-sdk-error-strings.md.
+          console.error("[LearnClient] handleSwipe rejected", {
+            cardId: card.id,
+            cardgroupId,
+            name: err instanceof Error ? err.name : "unknown",
+          });
+          setQueue((current) => [card, ...current.filter((candidate) => candidate.id !== card.id)]);
+          setCompleted((current) => Math.max(0, current - 1));
+          setLocalError("Could not save that swipe. Please try again.");
+          return null;
+        })
+        .finally(() => {
+          // The mutation settled (success or error): the FSRS write has committed
+          // (or failed), so a later prefetch that reads this card as "due" is no
+          // longer racing an uncommitted write and may re-enter it legitimately.
+          inFlightSwipeIdsRef.current.delete(card.id);
         });
-        setQueue((current) => [card, ...current.filter((candidate) => candidate.id !== card.id)]);
-        setCompleted((current) => Math.max(0, current - 1));
-        setLocalError("Could not save that swipe. Please try again.");
-        return null;
-      });
 
       if (!result) return;
 
@@ -233,7 +282,12 @@ export function LearnClient({ cardgroupId, initialCards, displayMode }: Props) {
       // the queue and the response carries only performance telemetry that no
       // UI consumer reads today. Only the non-success branches need handling.
       const payload = result.data?.handleSwipe;
-      if (payload?.__typename === "HandleSwipeSuccess") return;
+      if (payload?.__typename === "HandleSwipeSuccess") {
+        // A rated card can become due again (e.g. an "again" rating), so re-open
+        // prefetching in case the pool was previously marked exhausted.
+        exhaustedRef.current = false;
+        return;
+      }
 
       if (payload?.__typename === "InputValidationError") {
         // Server rejected the swipe (stale card, cardgroup mismatch, invalid mode).


### PR DESCRIPTION
## Summary

The learn-session queue prefetch raced the in-flight `handleSwipe` mutation and could re-append a just-swiped card, causing a duplicate FSRS review on the app's core learning loop. The same path also fired a redundant network query on every tail-of-session swipe. Both are fixed in `frontend/src/app/learn/[cardgroupId]/learn-client.tsx`.

## Changes

- Added `inFlightSwipeIdsRef` (`useRef<Set<string>>`): `onSwipe` records the swiped card id **before** the optimistic queue removal and clears it in the mutation's `finally`. The prefetch merge filters `incoming` against this set, so a `LearnNextDueCards` batch that returns the just-swiped card (a read that beat the FSRS write commit) is no longer re-appended. Only in-flight ids are filtered — a genuinely re-due "again" card can still re-enter the queue once its swipe settles.
- Added `exhaustedRef`: when a prefetch resolves and the dedup merge adds zero new cards, the pool is marked exhausted and the prefetch effect short-circuits, so tail swipes stop firing redundant network-only queries. It clears after a swipe mutation succeeds (a rated card may become due again) and when the active cardgroup changes.

## Test plan

Extended the `queue prefetch` describe in `learn-client.test.tsx`:

- A swipe whose mutation is still pending, plus a prefetch returning the just-swiped card, does **not** re-append it, while a genuinely new card in the same batch is still merged (verified red on pre-fix code — `q-1` re-appended).
- After the due pool is exhausted, a tail swipe fires no further prefetch (verified red on pre-fix code).
- `resumes prefetch after a successful swipe clears the exhaustion guard`: proves `exhaustedRef` clears on `HandleSwipeSuccess` and prefetching resumes (verified red when the reset line is removed, green when restored).
- Gates green: `pnpm --filter frontend typecheck` / `lint` / `knip` / `test` (1751 passed) / `build`.

Closes #789
