### PR TITLE
fix(frontend): re-arm the infinite-scroll observer after a page that does not move the sentinel

### DIFF
--- a/frontend/src/lib/pagination/use-connection-pagination.test.tsx
+++ b/frontend/src/lib/pagination/use-connection-pagination.test.tsx
@@ -454,4 +454,80 @@ describe("useConnectionPagination", () => {
     });
     expect(result.current.queryVariables).toEqual({ ...DEFAULT_VARS, search: "x" });
   });
+
+  it("re-arms the observer after a page merge that keeps the sentinel in view (issue #790)", async () => {
+    // Model the browser's IntersectionObserver initial-record delivery: observe()
+    // queues exactly ONE intersection notification for the current layout and
+    // never re-fires without a fresh observe(). A short page whose merge does not
+    // scroll the sentinel out of view therefore only advances if the effect
+    // re-attaches (re-arms) the observer after the merge. Before the fix the
+    // observer effect's deps were [hasNextPage, fetchMoreError] — both unchanged
+    // by a successful mid-list fetchMore — so the effect never re-ran, the
+    // observer was never re-observed, and the loop stalled after one page.
+    class AutoFireIntersectionObserver {
+      private cb: IntersectionObserverCallback;
+      private disconnected = false;
+      constructor(cb: IntersectionObserverCallback) {
+        this.cb = cb;
+      }
+      observe() {
+        queueMicrotask(() => {
+          if (this.disconnected) return;
+          this.cb(
+            [{ isIntersecting: true } as IntersectionObserverEntry],
+            this as unknown as IntersectionObserver,
+          );
+        });
+      }
+      unobserve() {}
+      disconnect() {
+        this.disconnected = true;
+      }
+      takeRecords(): IntersectionObserverEntry[] {
+        return [];
+      }
+    }
+    vi.stubGlobal("IntersectionObserver", AutoFireIntersectionObserver);
+
+    const CG_4 = {
+      __typename: "Cardgroup" as const,
+      id: "cg-4",
+      name: "Delta",
+      updatedAt: "2024-03-01T04:00:00.000Z",
+    };
+
+    const cache = new InMemoryCache();
+    // page 1 (seed) and page 2 both keep hasNextPage true, so the sentinel stays
+    // "in view" across the page-2 merge; page 3 ends the loop (hasNextPage false).
+    seedCache(cache, connection([CG_1, CG_2], true));
+
+    const page2Mock = {
+      request: {
+        query: MyCardgroupsConnectionDocument,
+        variables: { ...DEFAULT_VARS, after: CG_2.id, search: null },
+      },
+      result: { data: { myCardgroupsConnection: connection([CG_3], true) } },
+    };
+    const page3Mock = {
+      request: {
+        query: MyCardgroupsConnectionDocument,
+        variables: { ...DEFAULT_VARS, after: CG_3.id, search: null },
+      },
+      result: { data: { myCardgroupsConnection: connection([CG_4]) } },
+    };
+
+    const { result } = renderProbe({ mocks: [page2Mock, page3Mock], cache });
+
+    expect(result.current.edges).toHaveLength(2);
+
+    // The initial observe fires page 2; re-arming after the merge fires page 3.
+    // On the pre-fix code the observer is never re-attached, so edges stall at 3
+    // and this waitFor times out — the regression proof.
+    await waitFor(() => {
+      expect(result.current.edges).toHaveLength(4);
+    });
+    expect(result.current.edges[2]?.node.id).toBe(CG_3.id);
+    expect(result.current.edges[3]?.node.id).toBe(CG_4.id);
+    expect(result.current.fetchMoreError).toBeNull();
+  });
 });

--- a/frontend/src/lib/pagination/use-connection-pagination.ts
+++ b/frontend/src/lib/pagination/use-connection-pagination.ts
@@ -200,6 +200,13 @@ export function useConnectionPagination<
     });
   });
 
+  // `edges.length` re-arms the observer after each successful page merge. A
+  // mid-list fetchMore leaves hasNextPage/fetchMoreError unchanged, so without
+  // this trigger the effect never re-runs and the observer's initial record —
+  // already consumed — never re-fires. Re-observing generates a fresh initial
+  // IntersectionObserver record that re-fires if the sentinel is still visible
+  // (short page / tall viewport that never scrolled the sentinel out of view).
+  // biome-ignore lint/correctness/useExhaustiveDependencies: edges.length is an intentional re-arm trigger; it is not referenced in the body because the effect detaches and re-attaches the observer after each page merge, not reads the edge count.
   useEffect(() => {
     if (!pageInfo.hasNextPage) return;
     // Stop the observer loop while a previous fetch failed; user must click Retry to resume.
@@ -214,7 +221,7 @@ export function useConnectionPagination<
 
     observer.observe(node);
     return () => observer.disconnect();
-  }, [pageInfo.hasNextPage, fetchMoreError]);
+  }, [pageInfo.hasNextPage, fetchMoreError, edges.length]);
 
   const retryFetchMore = useCallback(() => {
     setFetchMoreError(null);


### PR DESCRIPTION
## Summary

Infinite scroll permanently stalled on all five cursor-paginated list screens (they share the `useConnectionPagination` hook) whenever a fetched page did not push the sentinel out of the viewport. The IntersectionObserver effect's dependency array was `[pageInfo.hasNextPage, fetchMoreError]`; after a successful mid-list `fetchMore` both stay unchanged (`hasNextPage` still `true`, `fetchMoreError` still `null`), so the effect never re-ran and the observer was never re-observed. On a short page / tall viewport the observer's initial record had already been consumed and never re-fired, so no further pages loaded.

Adding `edges.length` to the dependency array makes the effect detach and re-attach the observer after each page merge. Re-observing generates a fresh initial `IntersectionObserver` record that re-evaluates intersection against the current layout and re-fires if the sentinel is still visible.

## Changes

- `frontend/src/lib/pagination/use-connection-pagination.ts`: add `edges.length` to the observer effect's dependency array as the re-arm trigger; document the rationale; add a `biome-ignore lint/correctness/useExhaustiveDependencies` (mirroring the sibling immediate-reset effect's `searchQuery` trigger) because `edges.length` is an intentional trigger dependency not referenced in the effect body.
- `frontend/src/lib/pagination/use-connection-pagination.test.tsx`: new hook-level regression test that models the browser's IntersectionObserver initial-record delivery (fires exactly once on `observe()`, never again without a fresh `observe()`) and asserts that a mid-list `fetchMore` returning a page that keeps the sentinel in view triggers a subsequent fetch (edges 2 → 3 → 4).

## Test plan

- `pnpm --filter frontend typecheck` / `lint` / `knip` / `build` — pass.
- `pnpm --filter frontend test` — pass (187 files, 1749 tests), including the in-flight-guard test, the Retry-after-error test, and `pagination-ref-triplet-removal-rule.test.ts`.
- Regression proof: the new test was confirmed red on the pre-fix dependency array (edges stall at 3, never reach 4) and green with the fix.

Closes #790
