### PR TITLE
perf(frontend): memoize CardRow so the card list does not re-render all gesture rows per keystroke

### DIFF
--- a/frontend/src/components/cardgroups/card-list-screen.test.tsx
+++ b/frontend/src/components/cardgroups/card-list-screen.test.tsx
@@ -1,0 +1,146 @@
+// @vitest-environment happy-dom
+import { fireEvent, screen } from "@testing-library/react";
+import { useMemo, useState } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { FLAMINGO_EVENT } from "@/lib/events/flamingo-events";
+import { renderWithIntl } from "@/test/render-with-intl";
+
+// Count every CardRow render by counting its single SwipeableRow child render.
+// The mock is unmemoized, so it re-renders iff its parent CardRow re-renders,
+// making this counter a faithful proxy for CardRow render count. Mocking the
+// gesture row also drops the @react-spring / @use-gesture dependency (canonical
+// gesture coverage lives in swipeable-row.test.tsx).
+let cardRowRenders = 0;
+vi.mock("@/components/cardgroups/swipeable-row", async () => {
+  const { forwardRef } = await import("react");
+  return {
+    SwipeableRow: forwardRef(function SwipeableRowMock(
+      {
+        children,
+      }: {
+        children: React.ReactNode;
+        onDelete: () => void;
+        disabled?: boolean;
+        ariaLabel: string | null;
+      },
+      _ref: React.Ref<{ close(): void }>,
+    ) {
+      cardRowRenders += 1;
+      return <div data-testid="swipeable-row-mock">{children}</div>;
+    }),
+  };
+});
+
+import { CardListScreen, type CardListScreenProps } from "./card-list-screen";
+
+type Edge = { cursor: string; node: { id: string; front: string; back: string } };
+
+function makeEdges(n: number): Edge[] {
+  return Array.from({ length: n }, (_, i) => ({
+    cursor: `cur-${i}`,
+    node: { id: `c-${i}`, front: `Front ${i}`, back: `Back ${i}` },
+  }));
+}
+
+/**
+ * Renders the shared list screen with stable connection + mutation identities
+ * (as the production hooks provide) so the only thing that changes across a
+ * re-render is what the individual test drives (the search input value or the
+ * bulk-selection set).
+ */
+function Harness({ edges }: { edges: Edge[] }) {
+  const [input, setInput] = useState("");
+
+  const connection = useMemo<CardListScreenProps["connection"]>(
+    () => ({
+      edges,
+      pageInfo: { hasNextPage: false },
+      totalCount: edges.length,
+      fetchingMore: false,
+      fetchMoreError: null,
+      retryFetchMore: () => {},
+      sentinelRef: { current: null },
+      queryError: null,
+    }),
+    [edges],
+  );
+
+  const mutations = useMemo<CardListScreenProps["mutations"]>(
+    () => ({
+      createCard: async () => ({ status: "success" }),
+      updateCard: async () => ({ status: "success" }),
+      deleteRow: () => {},
+      deleteCards: async () => undefined,
+      creating: false,
+      updating: false,
+      bulkDeleting: false,
+      createError: null,
+      updateError: null,
+      bulkDeleteError: null,
+      deleteRowError: null,
+      resetCreateCard: () => {},
+    }),
+    [],
+  );
+
+  const search = {
+    searchOpen: false,
+    input,
+    query: input === "" ? null : input,
+    setInput,
+    clear: () => setInput(""),
+    closeSearch: () => {},
+  } as CardListScreenProps["search"];
+
+  return (
+    <CardListScreen
+      search={search}
+      connection={connection}
+      mutations={mutations}
+      ownerId="g-1"
+      addCardEvent={{ name: FLAMINGO_EVENT.addCard, matches: () => false }}
+      bulkDeleteLog={{ scope: "[test]", ownerKey: "cardgroupId" }}
+      importSheetTitle="Import"
+      renderImportForm={() => null}
+    />
+  );
+}
+
+describe("<CardListScreen> row memoization", () => {
+  beforeEach(() => {
+    cardRowRenders = 0;
+  });
+
+  it("does not re-render the loaded gesture rows on a search keystroke", () => {
+    const edges = makeEdges(5);
+    renderWithIntl(<Harness edges={edges} />);
+
+    // One render per row on mount.
+    expect(cardRowRenders).toBe(5);
+
+    fireEvent.change(screen.getByTestId("cards-search-input"), { target: { value: "a" } });
+
+    // The screen re-renders because `search.input` changed, but every CardRow is
+    // memoized with referentially-stable props, so no row re-renders. Without the
+    // memo this would be 10 (all five rows reconciled again).
+    expect(cardRowRenders).toBe(5);
+  });
+
+  it("re-renders only the toggled row once selection mode is already active", () => {
+    const edges = makeEdges(5);
+    renderWithIntl(<Harness edges={edges} />);
+    expect(cardRowRenders).toBe(5);
+
+    // The first selection flips every row's `disabled` prop (count 0 -> 1), which
+    // disables swipe list-wide, so all five rows legitimately re-render.
+    fireEvent.click(screen.getByTestId("card-select-c-0"));
+    expect(cardRowRenders).toBe(10);
+
+    // The second selection keeps count > 0 (`disabled` unchanged for every row);
+    // only the newly toggled row's `selected` prop changes, so exactly one row
+    // re-renders. Without the memo this step would re-render all five.
+    const before = cardRowRenders;
+    fireEvent.click(screen.getByTestId("card-select-c-1"));
+    expect(cardRowRenders).toBe(before + 1);
+  });
+});

--- a/frontend/src/components/cardgroups/card-list-screen.tsx
+++ b/frontend/src/components/cardgroups/card-list-screen.tsx
@@ -271,6 +271,31 @@ export function CardListScreen({
     }
   }, []);
 
+  // Stable, id-parameterized row handlers so every CardRow receives the same
+  // callback identity across renders. Combined with `memo` on CardRow, a search
+  // keystroke (which re-renders this screen via the immediate `search.input`)
+  // re-renders only the search input, not the N accumulated gesture rows.
+  const cardDeletedLabel = t("cardDeleted");
+  const getRowRef = useCallback((id: string): RefObject<SwipeableRowHandle | null> => {
+    let ref = rowRefs.current.get(id);
+    if (!ref) {
+      ref = { current: null };
+      rowRefs.current.set(id, ref);
+    }
+    return ref;
+  }, []);
+  const handleEditRow = useCallback(
+    (id: string) => {
+      closeOtherRows(id);
+      sheet.beginEdit(id);
+    },
+    [closeOtherRows, sheet.beginEdit],
+  );
+  const handleDeleteRow = useCallback(
+    (id: string) => deleteRow(id, cardDeletedLabel),
+    [deleteRow, cardDeletedLabel],
+  );
+
   const editingCard = edges.find((edge) => edge.node.id === sheet.editingId)?.node;
 
   const openBatchImport = useCallback(() => setBatchImportOpen(true), []);
@@ -368,21 +393,12 @@ export function CardListScreen({
                   <li key={card.id} className="rounded-md border border-border overflow-hidden">
                     <CardRow
                       card={card}
-                      rowRef={(() => {
-                        if (!rowRefs.current.has(card.id)) {
-                          rowRefs.current.set(card.id, { current: null });
-                        }
-                        // biome-ignore lint/style/noNonNullAssertion: we just set the entry above so it is always defined.
-                        return rowRefs.current.get(card.id)!;
-                      })()}
+                      rowRef={getRowRef(card.id)}
                       selected={selection.isSelected(card.id)}
                       disabled={selection.count > 0 || sheet.editingId === card.id}
-                      onSelectToggle={() => selection.toggleSelected(card.id)}
-                      onEdit={() => {
-                        closeOtherRows(card.id);
-                        sheet.beginEdit(card.id);
-                      }}
-                      onDelete={() => deleteRow(card.id, t("cardDeleted"))}
+                      onSelectToggle={selection.toggleSelected}
+                      onEdit={handleEditRow}
+                      onDelete={handleDeleteRow}
                     />
                   </li>
                 );

--- a/frontend/src/components/cardgroups/card-row.tsx
+++ b/frontend/src/components/cardgroups/card-row.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useTranslations } from "next-intl";
-import type { RefObject } from "react";
+import { memo, type RefObject } from "react";
 import { HoverRevealDeleteButton } from "./hover-reveal-delete-button";
 import { SwipeableRow, type SwipeableRowHandle } from "./swipeable-row";
 
@@ -10,12 +10,23 @@ export type CardRowProps = {
   rowRef: RefObject<SwipeableRowHandle | null>;
   selected: boolean;
   disabled: boolean;
-  onSelectToggle: () => void;
-  onEdit: () => void;
-  onDelete: () => void;
+  /**
+   * Card-id-parameterized callbacks so the parent can pass a single stable
+   * handler for every row (rather than a fresh per-row closure). This keeps the
+   * `memo` bailout below intact: an unrelated re-render of the list (e.g. a
+   * search keystroke) does not re-render every gesture-bound row.
+   */
+  onSelectToggle: (id: string) => void;
+  onEdit: (id: string) => void;
+  onDelete: (id: string) => void;
 };
 
-export function CardRow({
+// Wrapped in `memo`: the card list accumulates all fetched rows (no
+// virtualization), so without this every row re-renders on each search keystroke
+// or selection toggle, remounting a `useSpring`/`useDrag` gesture controller per
+// row. All props are referentially stable (Apollo cache node, per-id ref, stable
+// handlers), so the bailout holds and only genuinely-changed rows re-render.
+export const CardRow = memo(function CardRow({
   card,
   rowRef,
   selected,
@@ -28,7 +39,7 @@ export function CardRow({
   return (
     <SwipeableRow
       ref={rowRef}
-      onDelete={onDelete}
+      onDelete={() => onDelete(card.id)}
       disabled={disabled}
       ariaLabel={t("deleteCardAriaLabel")}
     >
@@ -43,7 +54,7 @@ export function CardRow({
             type="checkbox"
             className="h-4 w-4 cursor-pointer accent-primary"
             checked={selected}
-            onChange={onSelectToggle}
+            onChange={() => onSelectToggle(card.id)}
             aria-label={t("selectCardAriaLabel")}
             data-testid={`card-select-${card.id}`}
           />
@@ -65,11 +76,11 @@ export function CardRow({
         <div
           role="button"
           tabIndex={0}
-          onClick={onEdit}
+          onClick={() => onEdit(card.id)}
           onKeyDown={(e) => {
             if (e.key === "Enter" || e.key === " ") {
               e.preventDefault();
-              onEdit();
+              onEdit(card.id);
             }
           }}
           className="min-w-0 flex-1 cursor-pointer space-y-1 rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring after:absolute after:inset-0 after:content-[''] sm:after:content-none"
@@ -87,7 +98,7 @@ export function CardRow({
         >
           <HoverRevealDeleteButton
             ariaLabel={t("deleteCardAriaLabel")}
-            onDelete={onDelete}
+            onDelete={() => onDelete(card.id)}
             data-testid={`card-delete-${card.id}`}
             className="pointer-events-none sm:group-hover:pointer-events-auto sm:group-hover:opacity-100 sm:group-focus-within:pointer-events-auto sm:group-focus-within:opacity-100 motion-reduce:pointer-events-auto"
           />
@@ -95,4 +106,4 @@ export function CardRow({
       </div>
     </SwipeableRow>
   );
-}
+});


### PR DESCRIPTION
## Summary

The shared card list re-rendered every accumulated gesture-bound row on each search keystroke and selection toggle, because `CardRow` was unmemoized and received fresh inline closures per row. With infinite scroll accumulating all fetched edges (no virtualization), every keystroke re-ran a full-list reconciliation of gesture-bound rows on the highest-traffic editing screens. This change memoizes `CardRow` and passes id-stable handlers so `React.memo` bailouts hold.

## Changes

- `frontend/src/components/cardgroups/card-row.tsx`: wrap `CardRow` in `React.memo` and change its callbacks to take the card id (`onSelectToggle(id)` / `onEdit(id)` / `onDelete(id)`), so callers can pass referentially stable handlers instead of per-row inline closures.
- `frontend/src/components/cardgroups/card-list-screen.tsx`: pass id-stable, `useCallback`-backed handlers into `CardRow` (leaning on the already id-parameterized `selection.toggleSelected` and `useCallback`-stable `closeOtherRows`) so a search keystroke re-renders only the input and a selection toggle re-renders only the toggled row.

## Test plan

- `frontend/src/components/cardgroups/card-list-screen.test.tsx`: new render-count spy tests asserting that after N rows load, a search keystroke re-renders only the input (not the N rows), and a selection toggle re-renders only the toggled row — pinning the memoization optimization.
- Both consumers (`cards-client.tsx` and admin `master-cards-client.tsx`) still work: swipe-to-reveal actions, edit, delete, and bulk select.
- `pnpm --filter frontend typecheck && pnpm --filter frontend lint && pnpm --filter frontend test` green.

Closes #792
