### PR TITLE
perf(backend): add a validated-VO Card constructor to skip re-validating master cards

### DIFF
--- a/backend/internal/domain/card.go
+++ b/backend/internal/domain/card.go
@@ -75,6 +75,37 @@ func NewCard(cardgroupID CardgroupID, front, back string, position int) (*Card, 
 	}, nil
 }
 
+// NewCardFromValidated builds a Card from already-parsed CardText value objects,
+// skipping ParseCardText re-validation. Callers must pass VOs produced by a prior
+// Parse (e.g. MasterCard.Front/Back); the zero-value CardText is rejected via the
+// field-specific sentinel because the newtype's zero value is invalid by contract.
+// A fresh UUID v7 ID is generated and CreatedAt/UpdatedAt are stamped with the
+// current UTC time, mirroring NewCard; batch callers may override both with a
+// shared timestamp before persisting. Use NewCard for the untrusted string-input
+// path that still needs grapheme-bounds validation.
+func NewCardFromValidated(cardgroupID CardgroupID, front, back CardText, position int) (*Card, error) {
+	if front == "" {
+		return nil, ErrCardFrontRequired
+	}
+	if back == "" {
+		return nil, ErrCardBackRequired
+	}
+	id, err := NewID()
+	if err != nil {
+		return nil, eris.Wrap(err, "card: new id")
+	}
+	now := time.Now().UTC()
+	return &Card{
+		ID:          id,
+		CardgroupID: cardgroupID,
+		Front:       front,
+		Back:        back,
+		Position:    position,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}, nil
+}
+
 // UpdateFront updates the card's front text to the supplied value and returns an
 // error if the value is the zero CardText. The zero-value guard is defense-in-depth:
 // production callers parse the input through ParseCardText before reaching this

--- a/backend/internal/domain/card_test.go
+++ b/backend/internal/domain/card_test.go
@@ -99,6 +99,68 @@ func TestNewCard_IDFailure(t *testing.T) {
 	require.Contains(t, err.Error(), "domain: new uuid v7")
 }
 
+func TestNewCardFromValidated(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid VOs construct a fully-formed card without re-validation", func(t *testing.T) {
+		t.Parallel()
+
+		c, err := NewCardFromValidated(CardgroupID("cg-1"), CardText("front"), CardText("back"), 7)
+		require.NoError(t, err)
+		require.NotEmpty(t, c.ID, "constructor must generate an ID")
+		require.Equal(t, CardgroupID("cg-1"), c.CardgroupID)
+		require.Equal(t, CardText("front"), c.Front)
+		require.Equal(t, CardText("back"), c.Back)
+		require.Equal(t, 7, c.Position)
+		require.False(t, c.CreatedAt.IsZero(), "constructor must stamp CreatedAt")
+		require.Equal(t, c.CreatedAt, c.UpdatedAt, "CreatedAt and UpdatedAt must match at construction")
+	})
+
+	t.Run("VOs are stored verbatim, not re-parsed", func(t *testing.T) {
+		t.Parallel()
+
+		// A CardText VO with surrounding whitespace can only exist if a caller
+		// bypasses ParseCardText; NewCardFromValidated must not trim it, proving
+		// it skips ParseCardText.
+		c, err := NewCardFromValidated(CardgroupID("cg"), CardText("  raw  "), CardText("back"), 0)
+		require.NoError(t, err)
+		require.Equal(t, CardText("  raw  "), c.Front, "front must be stored verbatim, not re-trimmed")
+	})
+
+	cases := []struct {
+		name        string
+		front       CardText
+		back        CardText
+		sentinelErr error
+	}{
+		{"zero front VO rejected", CardText(""), CardText("back"), ErrCardFrontRequired},
+		{"zero back VO rejected", CardText("front"), CardText(""), ErrCardBackRequired},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			c, err := NewCardFromValidated(CardgroupID("cg"), tc.front, tc.back, 0)
+			require.Nil(t, c, "no aggregate may be constructed from a zero-value CardText")
+			require.ErrorIs(t, err, tc.sentinelErr, "got %v", err)
+		})
+	}
+}
+
+// TestNewCardFromValidated_IDFailure pins the id-generation failure path through
+// the newV7 test seam; the non-zero VO checks run first, so valid VOs reach NewID.
+func TestNewCardFromValidated_IDFailure(t *testing.T) {
+	orig := newV7
+	newV7 = func() (uuid.UUID, error) { return uuid.UUID{}, errors.New("crypto/rand unavailable") }
+	t.Cleanup(func() { newV7 = orig })
+
+	c, err := NewCardFromValidated(CardgroupID("cg"), CardText("front"), CardText("back"), 0)
+	require.Nil(t, c)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "card: new id")
+	require.Contains(t, err.Error(), "domain: new uuid v7")
+}
+
 func TestCardBelongsToCardgroup(t *testing.T) {
 	t.Parallel()
 

--- a/backend/internal/usecase/master_deck.go
+++ b/backend/internal/usecase/master_deck.go
@@ -274,7 +274,7 @@ func (u *masterDeckUsecase) SeedForNewUser(ctx context.Context, userID string) (
 // them in, so this helper stays free of the listing step and the caller controls
 // the operation order. pin, when non-nil, overrides every copied card's
 // CreatedAt/UpdatedAt (import pins to the new cardgroup's CreatedAt for a
-// consistent batch timestamp; merge passes nil and keeps NewCard's now()).
+// consistent batch timestamp; merge passes nil and keeps the constructor's now()).
 // Returns the insert/update tally. MUST NOT embed a fixed eris layer prefix — the
 // public callers apply their own wrap so the error_chain attributes the failure
 // to the calling operation.
@@ -283,7 +283,7 @@ func (u *masterDeckUsecase) copyMasterCardsIntoTx(
 ) (repository.UpsertManyTxResult, error) {
 	userCards := make([]*domain.Card, 0, len(masterCards))
 	for _, mc := range masterCards {
-		card, err := domain.NewCard(destCG, mc.Front.String(), mc.Back.String(), mc.Position)
+		card, err := domain.NewCardFromValidated(destCG, mc.Front, mc.Back, mc.Position)
 		if err != nil {
 			return repository.UpsertManyTxResult{}, eris.Wrap(err, "new card from master")
 		}


### PR DESCRIPTION
## Summary

Copying a master deck re-validated already-valid card text through `domain.NewCard` on every import/merge/seed, inside the transaction — a redundant grapheme scan of known-good `CardText` value objects. This adds a validated-VO constructor so `copyMasterCardsIntoTx` skips the re-validation and copies straight from the parsed VOs.

## Changes
- Add `NewCardFromValidated` to `backend/internal/domain/card.go`: builds a `Card` from already-parsed `CardText` VOs, rejecting the zero-value `CardText` and generating the ID via `domain.NewID`, without re-running `ParseCardText`.
- Use `NewCardFromValidated` in `backend/internal/usecase/master_deck.go` `copyMasterCardsIntoTx`, passing `mc.Front` / `mc.Back` directly (no `.String()` round-trip). The existing string-input `NewCard` stays for the untrusted import path.

## Test plan
- New unit tests in `backend/internal/domain/card_test.go` cover the happy path (fields and a valid generated ID) and the zero-VO rejection, pinning that the constructor skips `ParseCardText` while still guarding invalid input.
- Existing suites still green (`go build ./...`, `go test ./...`).
- Note: the Docker daemon was unavailable locally, so testcontainer-gated integration tests were skipped here; CI runs them.

Closes #779
