### PR TITLE
perf(backend): index hygiene for users + swipe_records (add created_at index, drop redundant)

### DIFF
--- a/backend/internal/database/cards_position_roundtrip_test.go
+++ b/backend/internal/database/cards_position_roundtrip_test.go
@@ -44,15 +44,16 @@ func TestCardsPositionDownUpRoundtrip(t *testing.T) {
 		}
 	}()
 
-	// Step back past the eight migrations newer than add_position_to_cards
+	// Step back past the nine migrations newer than add_position_to_cards
 	// (enable_rls_schema_migrations, pin_trigger_function_search_path,
 	// restrict_definer_function_exposure, add_master_tables,
 	// add_learn_display_mode_to_user_preferences,
 	// add_user_card_fsrs_card_id_index, master_cards_front_citext,
-	// drop_master_cardgroup_metadata_columns), then past add_position_to_cards
-	// itself. Nine steps are required because add_position_to_cards is no longer
+	// drop_master_cardgroup_metadata_columns,
+	// index_hygiene_users_swipe_records), then past add_position_to_cards
+	// itself. Ten steps are required because add_position_to_cards is no longer
 	// near the newest migration; bump this count when adding migrations after it.
-	if err := m.Steps(-9); err != nil {
+	if err := m.Steps(-10); err != nil {
 		t.Fatalf("migrate down to before add_position_to_cards: %v", err)
 	}
 

--- a/backend/internal/database/learn_display_mode_roundtrip_test.go
+++ b/backend/internal/database/learn_display_mode_roundtrip_test.go
@@ -54,13 +54,14 @@ func TestLearnDisplayModeDownUpRoundtrip(t *testing.T) {
 		}
 	}()
 
-	// Step back four migrations newest-first: drop_master_cardgroup_metadata_columns
-	// (now the newest), master_cards_front_citext, add_user_card_fsrs_card_id_index,
+	// Step back five migrations newest-first: index_hygiene_users_swipe_records
+	// (now the newest), drop_master_cardgroup_metadata_columns,
+	// master_cards_front_citext, add_user_card_fsrs_card_id_index,
 	// then add_learn_display_mode_to_user_preferences (the target). The Steps(1)
 	// below re-applies add_learn_display_mode, and the t.Cleanup restores the
 	// rest. Bump this count when adding migrations after
 	// add_learn_display_mode_to_user_preferences.
-	if err := m.Steps(-4); err != nil {
+	if err := m.Steps(-5); err != nil {
 		t.Fatalf("migrate down to before add_learn_display_mode_to_user_preferences: %v", err)
 	}
 

--- a/backend/internal/database/migrations/20260703000000_index_hygiene_users_swipe_records.down.sql
+++ b/backend/internal/database/migrations/20260703000000_index_hygiene_users_swipe_records.down.sql
@@ -1,0 +1,21 @@
+-- Reverse of 20260703000000_index_hygiene_users_swipe_records.up.sql.
+--
+-- Recreate the two dropped single-column indexes with their original
+-- definitions from 20260430080000_initial_schema.up.sql, then drop the
+-- composite (created_at DESC, id ASC) index the up migration added. Statements
+-- run in the exact reverse order of the up migration.
+--
+-- golang-migrate pgx/v5 does NOT auto-wrap migrations in a transaction; the
+-- explicit BEGIN/COMMIT below ensures all-or-nothing execution.
+
+BEGIN;
+
+CREATE INDEX IF NOT EXISTS idx_swipe_records_user_id
+    ON public.swipe_records (user_id);
+
+CREATE INDEX IF NOT EXISTS idx_users_updated_at
+    ON public.users (updated_at);
+
+DROP INDEX IF EXISTS public.idx_users_created_at_id;
+
+COMMIT;

--- a/backend/internal/database/migrations/20260703000000_index_hygiene_users_swipe_records.up.sql
+++ b/backend/internal/database/migrations/20260703000000_index_hygiene_users_swipe_records.up.sql
@@ -1,0 +1,41 @@
+-- Index hygiene for public.users and public.swipe_records.
+--
+-- 1. Add public.users (created_at DESC, id ASC).
+--    The admin users connection (repository.UserRepository.ListPage) always
+--    orders by (created_at DESC, id ASC) with a cursor predicate on
+--    (created_at, id), but the initial schema only indexed users.updated_at,
+--    a column no repository query filters or orders by. Every admin users page
+--    therefore did a sequential scan + top-N sort of public.users. The
+--    composite (created_at DESC, id ASC) matches the cursor tuple order, so it
+--    serves both forward pagination and backward pagination (via a backward
+--    index scan) as an index-ordered LIMIT scan.
+--
+-- 2. Drop public.idx_users_updated_at.
+--    No repository query filters or orders by users.updated_at; the index is
+--    pure write overhead on every profile update.
+--
+-- 3. Drop public.idx_swipe_records_user_id.
+--    swipe_records is appended on every HandleSwipe inside the user-facing swipe
+--    transaction. The single-column (user_id) index is fully covered by the two
+--    composites whose leftmost column is user_id:
+--      idx_swipe_records_user_reviewed  (user_id, reviewed_at DESC)
+--      idx_swipe_records_user_cardgroup (user_id, cardgroup_id, reviewed_at DESC)
+--    Every access path is served by a composite: the PK (FindByIDs), the
+--    user_cardgroup composite (FindByUserAndCardgroup), the user_reviewed
+--    composite (ListRecentByUser), and the ON DELETE CASCADE FK / RLS
+--    user_id-equality policies (either composite's leading column). The
+--    single-column index is redundant write overhead on the hottest write table.
+--
+-- golang-migrate pgx/v5 does NOT auto-wrap migrations in a transaction; the
+-- explicit BEGIN/COMMIT below ensures all-or-nothing execution.
+
+BEGIN;
+
+CREATE INDEX IF NOT EXISTS idx_users_created_at_id
+    ON public.users (created_at DESC, id ASC);
+
+DROP INDEX IF EXISTS public.idx_users_updated_at;
+
+DROP INDEX IF EXISTS public.idx_swipe_records_user_id;
+
+COMMIT;

--- a/backend/internal/database/users_version_roundtrip_test.go
+++ b/backend/internal/database/users_version_roundtrip_test.go
@@ -38,20 +38,21 @@ func TestUsersVersionDownUpRoundtrip(t *testing.T) {
 		}
 	}()
 
-	// Step back through the 10 migrations listed newest-first until
+	// Step back through the 11 migrations listed newest-first until
 	// add_version_to_users (the target) is also rolled back:
-	//   1. drop_master_cardgroup_metadata_columns
-	//   2. master_cards_front_citext
-	//   3. add_user_card_fsrs_card_id_index
-	//   4. add_learn_display_mode_to_user_preferences
-	//   5. add_master_tables
-	//   6. restrict_definer_function_exposure
-	//   7. pin_trigger_function_search_path
-	//   8. enable_rls_schema_migrations
-	//   9. add_position_to_cards
-	//   10. add_version_to_users  ← target (rolls back the version column)
+	//   1. index_hygiene_users_swipe_records
+	//   2. drop_master_cardgroup_metadata_columns
+	//   3. master_cards_front_citext
+	//   4. add_user_card_fsrs_card_id_index
+	//   5. add_learn_display_mode_to_user_preferences
+	//   6. add_master_tables
+	//   7. restrict_definer_function_exposure
+	//   8. pin_trigger_function_search_path
+	//   9. enable_rls_schema_migrations
+	//   10. add_position_to_cards
+	//   11. add_version_to_users  ← target (rolls back the version column)
 	// Bump the count here when adding migrations after add_version_to_users.
-	if err := m.Steps(-10); err != nil {
+	if err := m.Steps(-11); err != nil {
 		t.Fatalf("migrate down to before add_version_to_users: %v", err)
 	}
 


### PR DESCRIPTION
## Summary

The admin users list orders by `(created_at DESC, id ASC)` on an un-indexed column while the only `users` index sits on the never-queried `updated_at`, forcing a seq scan + top-N sort on every page; separately, `swipe_records` (written on every `HandleSwipe`) carries a redundant single-column `idx_swipe_records_user_id` fully covered by two existing composites. This migration adds the missing composite index, drops the vestigial `updated_at` index, and removes the redundant swipe index.

## Changes

- New migration pair `20260703000000_index_hygiene_users_swipe_records.{up,down}.sql`: up creates `idx_users_created_at_id (created_at DESC, id ASC)` and drops `idx_users_updated_at` + `idx_swipe_records_user_id`; down recreates the two dropped indexes and drops the new one.
- Updated the Docker-gated roundtrip tests to account for the new migration: `users_version_roundtrip_test.go`, `cards_position_roundtrip_test.go`, and `learn_display_mode_roundtrip_test.go` `m.Steps(-N)` counts bumped.

## Test plan

- Roundtrip step-count assertions in the three `*_roundtrip_test.go` files were updated to match the new migration count, pinning that the migration applies and rolls back cleanly.
- Existing suites still green.
- Note: the Docker daemon was unavailable locally, so testcontainer-gated integration tests were skipped here; CI runs them.

Closes #787
