### PR TITLE
perf(frontend): cap the batch-import preview rows and memoize the result tables

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -207,6 +207,7 @@
     "showPreview": "Show preview ({count})",
     "hideErrors": "Hide errors",
     "showErrors": "Show errors ({count})",
+    "andMoreRows": "…and {count, plural, one {# more row} other {# more rows}}",
     "errorLine": "Line {line}:",
     "previewLine": "Line",
     "previewFront": "Front",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -207,6 +207,7 @@
     "showPreview": "プレビューを表示 ({count})",
     "hideErrors": "エラーを非表示",
     "showErrors": "エラーを表示 ({count})",
+    "andMoreRows": "…ほか{count}行",
     "errorLine": "{line}行目:",
     "previewLine": "行",
     "previewFront": "表面",

--- a/frontend/src/components/batch-import/batch-import-wizard.test.tsx
+++ b/frontend/src/components/batch-import/batch-import-wizard.test.tsx
@@ -4,14 +4,77 @@ import type { MockedResponse } from "@apollo/client/testing";
 import { MockedProvider } from "@apollo/client/testing/react";
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { useState } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Render-count probe: wrap next-intl's `useTranslations` (calling through to the
+// real impl, so translations still resolve) and count invocations. A component
+// calls `useTranslations` exactly once per render, so this counts renders.
+const intlProbe = vi.hoisted(() => ({ calls: 0 }));
+vi.mock("next-intl", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("next-intl")>();
+  return {
+    ...actual,
+    useTranslations: (...args: Parameters<typeof actual.useTranslations>) => {
+      intlProbe.calls += 1;
+      return actual.useTranslations(...args);
+    },
+  };
+});
+
 import {
   CardsByCardgroupConnectionDocument,
   ValidateCardImportDocument,
 } from "@/generated/graphql";
 import { encodePayload } from "@/test/batch-import-test-utils";
 import { renderWithIntl } from "@/test/render-with-intl";
-import { BatchImportWizard, type ImportResult, resolveStep1Button } from "./batch-import-wizard";
+import {
+  BatchImportWizard,
+  ErrorList,
+  type ImportResult,
+  resolveStep1Button,
+  ValidateResult,
+} from "./batch-import-wizard";
+
+// Mirrors PREVIEW_ROW_CAP in batch-import-wizard.tsx. Kept as a local literal so
+// the test pins the documented cap rather than importing an internal constant.
+const PREVIEW_ROW_CAP = 200;
+
+function makeValidResult(n: number): MockedResponse["result"] {
+  return {
+    data: {
+      validateCardImport: {
+        __typename: "CardImportValidationResult" as const,
+        valid: true,
+        parsedCards: Array.from({ length: n }, (_, i) => ({
+          __typename: "ParsedCard" as const,
+          front: `f${i + 1}`,
+          back: `b${i + 1}`,
+          line: i + 1,
+        })),
+        errors: [],
+      },
+    },
+  };
+}
+
+function makeInvalidResult(n: number): MockedResponse["result"] {
+  return {
+    data: {
+      validateCardImport: {
+        __typename: "CardImportValidationResult" as const,
+        valid: false,
+        parsedCards: [],
+        errors: Array.from({ length: n }, (_, i) => ({
+          __typename: "CardImportError" as const,
+          line: i + 1,
+          message: `err${i + 1}`,
+          kind: "UNRECOGNIZED" as const,
+        })),
+      },
+    },
+  };
+}
 
 const TARGET_ID = "tgt-1";
 const TARGET_NAME = "Spanish Vocab";
@@ -498,5 +561,96 @@ describe("BatchImportWizard footer layout", () => {
       await screen.findByRole("button", { name: /back to edit/i }),
       screen.getByRole("button", { name: /done/i }),
     );
+  });
+});
+
+describe("BatchImportWizard preview cap", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("caps the preview table at PREVIEW_ROW_CAP rows and summarises the rest", async () => {
+    const user = userEvent.setup();
+    renderWizard({ mocks: [validateMock(TWO_LINE_TEXT, makeValidResult(250))] });
+    await typePayload(user, TWO_LINE_TEXT);
+    await user.click(screen.getByRole("button", { name: /^validate$/i }));
+    // The collapsed toggle still reports the FULL parsed count.
+    await user.click(await screen.findByRole("button", { name: /show preview \(250\)/i }));
+    await waitFor(() => expect(screen.getByText("f1")).toBeInTheDocument());
+    // The capped row renders; rows past the cap do not.
+    expect(screen.getByText(`f${PREVIEW_ROW_CAP}`)).toBeInTheDocument();
+    expect(screen.queryByText(`f${PREVIEW_ROW_CAP + 1}`)).toBeNull();
+    expect(screen.queryByText("f250")).toBeNull();
+    // A single overflow line summarises the hidden rows.
+    expect(screen.getByText(/50 more rows/i)).toBeInTheDocument();
+  });
+
+  it("caps the error list at PREVIEW_ROW_CAP rows and summarises the rest", async () => {
+    const user = userEvent.setup();
+    renderWizard({ mocks: [validateMock(TWO_LINE_TEXT, makeInvalidResult(250))] });
+    await typePayload(user, TWO_LINE_TEXT);
+    await user.click(screen.getByRole("button", { name: /^validate$/i }));
+    // Invalid result auto-opens the error list; it renders the cap plus one summary li.
+    await waitFor(() => expect(screen.getAllByRole("listitem")).toHaveLength(PREVIEW_ROW_CAP + 1));
+    expect(screen.getByText(/50 more rows/i)).toBeInTheDocument();
+  });
+});
+
+describe("BatchImportWizard result-table memoization", () => {
+  // Structural guard: the result tables are React.memo components, so a stable
+  // `result` / `errors` prop bails out of the wizard's per-keystroke re-renders.
+  it("wraps ValidateResult and ErrorList in React.memo", () => {
+    const memoTag = Symbol.for("react.memo");
+    expect((ValidateResult as unknown as { $$typeof: symbol }).$$typeof).toBe(memoTag);
+    expect((ErrorList as unknown as { $$typeof: symbol }).$$typeof).toBe(memoTag);
+  });
+
+  // Behavioral proof via a render-count probe: `ValidateResult` calls
+  // `useTranslations` exactly once per its own render (see the module mock at
+  // the top of this file), so `intlProbe.calls` tracks its render count in this
+  // isolated tree. An unrelated parent state change leaves it unchanged (memo
+  // bail-out); a changed `result` reference bumps it (real re-render), proving
+  // the bail-out is a genuine memo hit rather than a probe that never advances.
+  it("does not re-render the preview when unrelated parent state changes", async () => {
+    const user = userEvent.setup();
+    const resultA = {
+      valid: true,
+      parsedCards: [{ front: "apple", back: "red fruit", line: 1 }],
+      errors: [],
+    };
+    const resultB = {
+      valid: true,
+      parsedCards: [{ front: "banana", back: "yellow fruit", line: 1 }],
+      errors: [],
+    };
+
+    function Harness() {
+      const [tick, setTick] = useState(0);
+      const [useB, setUseB] = useState(false);
+      return (
+        <>
+          <button type="button" data-testid="bump" onClick={() => setTick((t) => t + 1)}>
+            {tick}
+          </button>
+          <button type="button" data-testid="swap" onClick={() => setUseB(true)}>
+            swap
+          </button>
+          <ValidateResult result={useB ? resultB : resultA} />
+        </>
+      );
+    }
+
+    intlProbe.calls = 0;
+    renderWithIntl(<Harness />);
+    const baseline = intlProbe.calls;
+    expect(baseline).toBeGreaterThan(0);
+
+    // Unrelated parent state change: memoized child bails out, no extra render.
+    await user.click(screen.getByTestId("bump"));
+    expect(intlProbe.calls).toBe(baseline);
+
+    // A changed `result` reference re-renders the memoized child.
+    await user.click(screen.getByTestId("swap"));
+    await waitFor(() => expect(intlProbe.calls).toBeGreaterThan(baseline));
   });
 });

--- a/frontend/src/components/batch-import/batch-import-wizard.tsx
+++ b/frontend/src/components/batch-import/batch-import-wizard.tsx
@@ -5,7 +5,7 @@ import type { DocumentNode } from "graphql";
 import { ChevronDown } from "lucide-react";
 import { useTranslations } from "next-intl";
 import type { JSX, ReactNode } from "react";
-import { useState } from "react";
+import { memo, useState } from "react";
 import { ValidateCardImportQuery } from "@/app/cardgroups/[id]/cards/queries";
 import { Button } from "@/components/ui/button";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
@@ -135,21 +135,35 @@ function ImportStepper(props: {
 }
 
 /**
+ * Maximum number of preview / error rows rendered at once. The backend accepts
+ * up to 5000 import rows, so an uncapped preview mounts thousands of DOM nodes
+ * and re-reconciles them on every textarea keystroke. Rows beyond the cap are
+ * summarised by an "…and N more" line — the full result still imports; only the
+ * on-screen preview is truncated.
+ */
+const PREVIEW_ROW_CAP = 200;
+
+/**
  * Renders a list of line-level import/validation messages. A `DUPLICATE`-kind
  * row reads as a non-fatal warning (amber — the row still persisted via
  * last-write-wins); every other kind, and any row without a kind (validation
  * step), reads as a blocking error (red).
+ *
+ * The list is capped at `PREVIEW_ROW_CAP` rows and memoized so a referentially
+ * stable `errors` prop bails out of the wizard's per-keystroke re-renders.
  */
-function ErrorList(props: {
+export const ErrorList = memo(function ErrorList(props: {
   errors: Array<{ line: number; message: string; kind?: CardImportErrorKind }>;
   className?: string;
   role?: string;
 }): JSX.Element {
   const { errors, className, role } = props;
   const t = useTranslations("BatchImport");
+  const shown = errors.slice(0, PREVIEW_ROW_CAP);
+  const remaining = errors.length - shown.length;
   return (
     <ul className={cn("space-y-1", className)} role={role}>
-      {errors.map((err) => (
+      {shown.map((err) => (
         <li
           key={`${err.line}-${err.message}`}
           className={cn(
@@ -162,18 +176,31 @@ function ErrorList(props: {
           <span className="font-medium">{t("errorLine", { line: err.line })}</span> {err.message}
         </li>
       ))}
+      {remaining > 0 && (
+        <li className="px-3 py-2 text-sm text-muted-foreground">
+          {t("andMoreRows", { count: remaining })}
+        </li>
+      )}
     </ul>
   );
-}
+});
 
 /**
  * Unified collapsible for the validate result: a preview table when valid, an
  * error list when invalid. Collapsed when valid, open when invalid.
+ *
+ * The preview table is capped at `PREVIEW_ROW_CAP` rows and the component is
+ * memoized so a referentially stable `result` prop bails out of the wizard's
+ * per-keystroke re-renders.
  */
-function ValidateResult(props: { result: ValidationResult }): JSX.Element {
+export const ValidateResult = memo(function ValidateResult(props: {
+  result: ValidationResult;
+}): JSX.Element {
   const { result } = props;
   const t = useTranslations("BatchImport");
   const [open, setOpen] = useState<boolean>(!result.valid);
+  const previewCards = result.parsedCards.slice(0, PREVIEW_ROW_CAP);
+  const remainingRows = result.parsedCards.length - previewCards.length;
 
   let triggerLabel: string;
   if (result.valid) {
@@ -214,13 +241,20 @@ function ValidateResult(props: { result: ValidationResult }): JSX.Element {
                 </tr>
               </thead>
               <tbody>
-                {result.parsedCards.map((card) => (
+                {previewCards.map((card) => (
                   <tr key={card.line} className="border-t border-border">
                     <td className="px-3 py-2 text-muted-foreground">{card.line}</td>
                     <td className="px-3 py-2">{card.front}</td>
                     <td className="px-3 py-2">{card.back}</td>
                   </tr>
                 ))}
+                {remainingRows > 0 && (
+                  <tr className="border-t border-border">
+                    <td colSpan={3} className="px-3 py-2 text-muted-foreground">
+                      {t("andMoreRows", { count: remainingRows })}
+                    </td>
+                  </tr>
+                )}
               </tbody>
             </table>
           </div>
@@ -230,7 +264,7 @@ function ValidateResult(props: { result: ValidationResult }): JSX.Element {
       </CollapsibleContent>
     </Collapsible>
   );
-}
+});
 
 /**
  * Two-slot wizard footer: a secondary/back affordance on the left and the


### PR DESCRIPTION
## Summary
The batch-import preview rendered up to 5000 unvirtualized table rows and re-reconciled them on every textarea keystroke, blocking the main thread and lagging input on the import wizard (especially on mobile). This change caps the rendered preview and error rows and memoizes the result tables so they bail out of per-keystroke re-renders.

## Changes
- `frontend/src/components/batch-import/batch-import-wizard.tsx`: introduce `PREVIEW_ROW_CAP` (200), slice both the preview table (`ValidateResult`) and the error list (`ErrorList`) to the cap, and render a localized "…and N more rows" line for the remainder; wrap `ValidateResult` and `ErrorList` in `React.memo` so a referentially-stable prop skips re-rendering while the textarea state changes.
- `frontend/messages/en.json` / `frontend/messages/ja.json`: add the `andMoreRows` catalog entry (ICU plural), referenced via `t(...)` — no inline string literals.

## Test plan
- Added tests in `batch-import-wizard.test.tsx` covering the row cap (a >200-row result renders only the cap plus the "…and N more" line) and the memo bailout (typing in the textarea after validating a large payload does not re-render the result tables), pinning the optimization.
- Existing frontend suites (typecheck, lint, test) remain green.

Closes #791
