### PR TITLE
perf(backend): eliminate card-import redundant work (double grapheme scan + full echo on reject)

### DIFF
--- a/backend/internal/usecase/card_import.go
+++ b/backend/internal/usecase/card_import.go
@@ -165,13 +165,24 @@ func (u *cardImportUsecase) Validate(ctx context.Context, payload string) (Valid
 		return ValidateCardImportOutcome{}, eris.Wrap(perr, "usecase: card import validate: parse")
 	}
 
+	errs := cardImportErrorsFromTextdic(parseErrs)
+	_, caps := checkImportCaps(words)
+	for _, v := range caps {
+		errs = append(errs, CardImportError{Line: v.Line, Message: v.Message, Kind: CardImportErrKindHard})
+	}
+	// Whole-payload reject (row cap): mirror Import's all-or-nothing reject and
+	// echo an empty ParsedCards rather than the full parsed set. checkImportCaps
+	// short-circuits the row cap to a single payload-level violation ahead of any
+	// per-row scan, so an over-cap payload cannot be previewed row-by-row anyway
+	// and shipping the full parsed set is wasted allocation plus wasted bytes on
+	// the wire. Below the row cap the full preview is retained so per-line errors
+	// stay actionable.
+	if len(words) > cardImportParsedRowCap {
+		return ValidateCardImportOutcome{Valid: false, Errors: errs}, nil
+	}
 	parsed := make([]ParsedCard, 0, len(words))
 	for _, w := range words {
 		parsed = append(parsed, ParsedCard{Front: w.Front, Back: w.Back, Line: w.Line})
-	}
-	errs := cardImportErrorsFromTextdic(parseErrs)
-	for _, v := range checkImportCaps(words) {
-		errs = append(errs, CardImportError{Line: v.Line, Message: v.Message, Kind: CardImportErrKindHard})
 	}
 	return ValidateCardImportOutcome{
 		Valid:       len(errs) == 0 && len(parsed) > 0,
@@ -220,16 +231,28 @@ func (u *cardImportUsecase) Import(ctx context.Context, input ImportCardsInput) 
 	// checker, so the two paths cannot diverge. Checked on the raw parsed words
 	// (before dedup) so Import and Validate agree exactly. The first violation
 	// aborts the whole batch (all-or-nothing); the row cap short-circuits ahead
-	// of any per-row length error inside the helper.
-	if caps := checkImportCaps(words); len(caps) > 0 {
+	// of any per-row length error inside the helper. On the pass path the checker
+	// hands back the already-parsed CardText VOs so the build loop below can reuse
+	// them instead of grapheme-scanning every row a second time.
+	validated, caps := checkImportCaps(words)
+	if len(caps) > 0 {
 		return ImportCardsOutput{}, ucerr.NewValidationError(caps[0].Field, caps[0].Message)
 	}
 
 	mappedErrs := cardImportErrorsFromTextdic(parseErrs)
 
+	// validated is parallel to the raw words; key each row's VOs by the dedup key
+	// (last occurrence wins, matching dedupeParsedWords' survivor) so the post-dedup
+	// build loop can look up the already-parsed VOs for the surviving rows.
+	identityKey := func(s string) string { return s }
+	voByKey := make(map[string]validatedCard, len(words))
+	for i, w := range words {
+		voByKey[identityKey(w.Front)] = validated[i]
+	}
+
 	// Deduplicate parsed words by front within this payload. cards.front is
 	// plain text, so the conflict key is the front verbatim (identity key).
-	deduped, dupErrs := dedupeParsedWords(words, func(s string) string { return s })
+	deduped, dupErrs := dedupeParsedWords(words, identityKey)
 	words = deduped
 	mappedErrs = append(mappedErrs, dupErrs...)
 
@@ -242,17 +265,19 @@ func (u *cardImportUsecase) Import(ctx context.Context, input ImportCardsInput) 
 	now := time.Now().UTC()
 	cards := make([]*domain.Card, 0, len(words))
 	for _, w := range words {
-		// Build through the enforcing constructor. The per-side length cap is now
-		// caught upstream by checkImportCaps, so NewCard's length check here is
-		// defense-in-depth; the realistic remaining failure is ID generation.
-		// Surface any error as a typed validation error rather than letting an
-		// over-length value reach the repository / DB CHECK as an opaque
+		// Build from the CardText VOs checkImportCaps already parsed for this row
+		// (single grapheme scan per row). NewCardFromValidated skips the re-scan
+		// domain.NewCard would perform; the per-side length cap was enforced
+		// upstream by checkImportCaps, and the realistic remaining failure is ID
+		// generation. Surface any error as a typed validation error rather than
+		// letting a bad value reach the repository / DB CHECK as an opaque
 		// constraint violation.
-		c, err := domain.NewCard(domain.CardgroupID(input.CardgroupID), w.Front, w.Back, 0)
+		vc := voByKey[identityKey(w.Front)]
+		c, err := domain.NewCardFromValidated(domain.CardgroupID(input.CardgroupID), vc.front, vc.back, 0)
 		if err != nil {
 			return ImportCardsOutput{}, translateCardErr(err)
 		}
-		// NewCard stamps per-card timestamps; pin the whole batch to one now.
+		// NewCardFromValidated stamps per-card timestamps; pin the whole batch to one now.
 		c.CreatedAt = now
 		c.UpdatedAt = now
 		cards = append(cards, c)
@@ -307,29 +332,46 @@ type capViolation struct {
 	Message string
 }
 
+// validatedCard bundles the trimmed, grapheme-bounded CardText VOs that
+// checkImportCaps parses for one import row. Returning them lets Import build the
+// Card via domain.NewCardFromValidated instead of re-running domain.ParseCardText
+// on the same strings — one grapheme scan per row rather than two.
+type validatedCard struct {
+	front domain.CardText
+	back  domain.CardText
+}
+
 // checkImportCaps enforces the two import caps shared by Validate and Import: the
 // parsed-row cap (cardImportParsedRowCap) and the per-side grapheme cap
 // (domain.CardTextMax). It is the single source of cap logic for both paths so
 // they cannot re-diverge.
 //
-// The row cap takes precedence and short-circuits: an over-cap payload returns
-// only the row-cap violation (the caller must cut rows before any per-row error is
-// actionable), mirroring Import's "row cap is a top-level reject" ordering. Below
-// the row cap, every row's front and back are checked via domain.ParseCardText.
-func checkImportCaps(words []textdic.ParsedWord) []capViolation {
+// The row cap takes precedence and short-circuits: an over-cap payload returns a
+// nil VO slice and only the row-cap violation (the caller must cut rows before any
+// per-row error is actionable), mirroring Import's "row cap is a top-level reject"
+// ordering. Below the row cap, every row's front and back are parsed via
+// domain.ParseCardText and the resulting VOs are returned parallel to words. When
+// the returned violation slice is empty every row passed and validated[i] holds
+// row i's front/back VOs for reuse; when it is non-empty the caller aborts the
+// whole batch, so the VO slice is unused.
+func checkImportCaps(words []textdic.ParsedWord) ([]validatedCard, []capViolation) {
 	if len(words) > cardImportParsedRowCap {
-		return []capViolation{{Line: 0, Field: "payload", Message: fmt.Sprintf("payload exceeds %d row cap", cardImportParsedRowCap)}}
+		return nil, []capViolation{{Line: 0, Field: "payload", Message: fmt.Sprintf("payload exceeds %d row cap", cardImportParsedRowCap)}}
 	}
+	validated := make([]validatedCard, len(words))
 	var out []capViolation
-	for _, w := range words {
-		if _, err := domain.ParseCardText(w.Front, domain.ErrCardFrontRequired, domain.ErrCardFrontTooLong); errors.Is(err, domain.ErrCardFrontTooLong) {
+	for i, w := range words {
+		front, ferr := domain.ParseCardText(w.Front, domain.ErrCardFrontRequired, domain.ErrCardFrontTooLong)
+		if errors.Is(ferr, domain.ErrCardFrontTooLong) {
 			out = append(out, capViolation{Line: w.Line, Field: "front", Message: fmt.Sprintf("front must be at most %d characters", domain.CardTextMax)})
 		}
-		if _, err := domain.ParseCardText(w.Back, domain.ErrCardBackRequired, domain.ErrCardBackTooLong); errors.Is(err, domain.ErrCardBackTooLong) {
+		back, berr := domain.ParseCardText(w.Back, domain.ErrCardBackRequired, domain.ErrCardBackTooLong)
+		if errors.Is(berr, domain.ErrCardBackTooLong) {
 			out = append(out, capViolation{Line: w.Line, Field: "back", Message: fmt.Sprintf("back must be at most %d characters", domain.CardTextMax)})
 		}
+		validated[i] = validatedCard{front: front, back: back}
 	}
-	return out
+	return validated, out
 }
 
 // dedupeParsedWords drops earlier duplicates by key(front), last occurrence wins,

--- a/backend/internal/usecase/card_import_test.go
+++ b/backend/internal/usecase/card_import_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"errors"
+	"os"
 	"strconv"
 	"strings"
 	"testing"
@@ -960,7 +961,9 @@ func stringFront(prefix string, n int) string {
 // TestCardImportUsecase_ValidateDetectsRowCap covers the 5000-row cap in the
 // preview path: a payload that parses to >5000 rows is reported as a single
 // payload-level HARD error (Line 0), and Valid flips to false even though every
-// row parsed cleanly.
+// row parsed cleanly. The over-cap payload is an all-or-nothing reject, so the
+// preview echoes an EMPTY ParsedCards slice (mirroring Import's whole-batch
+// reject) rather than the full parsed set the import can never persist.
 func TestCardImportUsecase_ValidateDetectsRowCap(t *testing.T) {
 	t.Parallel()
 
@@ -986,8 +989,8 @@ func TestCardImportUsecase_ValidateDetectsRowCap(t *testing.T) {
 	if e.Kind != CardImportErrKindHard || e.Line != 0 {
 		t.Fatalf("expected a HARD Line-0 row-cap error, got %+v", e)
 	}
-	if len(out.ParsedCards) != n {
-		t.Fatalf("expected %d parsed cards returned in the preview, got %d", n, len(out.ParsedCards))
+	if len(out.ParsedCards) != 0 {
+		t.Fatalf("expected an empty ParsedCards on the over-cap reject, got %d", len(out.ParsedCards))
 	}
 }
 
@@ -1062,5 +1065,75 @@ func TestCardImportUsecase_ValidateDetectsOverLengthBack(t *testing.T) {
 	}
 	if !strings.Contains(e.Message, "back") {
 		t.Fatalf("expected message to name the back side, got %q", e.Message)
+	}
+}
+
+// TestCheckImportCaps_ReturnsValidatedVOs pins the single-scan optimization at
+// its source: on the pass path checkImportCaps returns the trimmed CardText VOs
+// parallel to the input words so Import can build cards via
+// domain.NewCardFromValidated without a second grapheme scan. The row-cap
+// short-circuit returns a nil VO slice and only the payload-level violation
+// (no per-row scan).
+func TestCheckImportCaps_ReturnsValidatedVOs(t *testing.T) {
+	t.Parallel()
+
+	words := []textdic.ParsedWord{
+		{Front: "  apple  ", Back: "  " + jpRunes(3) + "  ", Line: 1},
+		{Front: "dog", Back: jpRunes(2), Line: 2},
+	}
+	validated, caps := checkImportCaps(words)
+	if len(caps) != 0 {
+		t.Fatalf("expected no cap violations, got %+v", caps)
+	}
+	if len(validated) != len(words) {
+		t.Fatalf("expected %d validated rows parallel to input, got %d", len(words), len(validated))
+	}
+	// The VOs must be the trimmed ParseCardText output, ready for reuse by
+	// NewCardFromValidated — proving the grapheme scan already happened here.
+	if validated[0].front != domain.CardText("apple") {
+		t.Fatalf("validated[0].front = %q, want trimmed %q", validated[0].front, "apple")
+	}
+	if validated[0].back != domain.CardText(jpRunes(3)) {
+		t.Fatalf("validated[0].back = %q, want trimmed back VO", validated[0].back)
+	}
+	if validated[1].front != domain.CardText("dog") {
+		t.Fatalf("validated[1].front = %q, want %q", validated[1].front, "dog")
+	}
+
+	// Over the row cap: nil VO slice + only the payload-level violation.
+	over := make([]textdic.ParsedWord, cardImportParsedRowCap+1)
+	for i := range over {
+		over[i] = textdic.ParsedWord{Front: stringFront("f", i), Back: jpRunes(2), Line: i + 1}
+	}
+	vOver, capsOver := checkImportCaps(over)
+	if vOver != nil {
+		t.Fatalf("expected a nil VO slice on the row-cap short-circuit, got len %d", len(vOver))
+	}
+	if len(capsOver) != 1 || capsOver[0].Field != "payload" || capsOver[0].Line != 0 {
+		t.Fatalf("expected a single payload-level row-cap violation, got %+v", capsOver)
+	}
+}
+
+// TestCardImport_BuildLoopReusesValidatedVOs pins the single grapheme-scan-per-row
+// optimization structurally: the Import build loop must construct cards via
+// domain.NewCardFromValidated (reusing the CardText VOs checkImportCaps already
+// parsed) and must NOT call domain.NewCard, which re-runs domain.ParseCardText — a
+// second grapheme scan of every row's front and back. A regression to NewCard
+// would silently double-scan every import batch with no behavioral difference, so
+// only a source-level guard can catch it. Mirrors the static-source regression
+// guard pattern used on the frontend.
+func TestCardImport_BuildLoopReusesValidatedVOs(t *testing.T) {
+	t.Parallel()
+
+	src, err := os.ReadFile("card_import.go")
+	if err != nil {
+		t.Fatalf("read card_import.go: %v", err)
+	}
+	s := string(src)
+	if !strings.Contains(s, "domain.NewCardFromValidated(") {
+		t.Fatal("card_import.go must build import cards via domain.NewCardFromValidated to reuse checkImportCaps' VOs (one grapheme scan per row)")
+	}
+	if strings.Contains(s, "domain.NewCard(") {
+		t.Fatal("card_import.go must not call domain.NewCard (re-runs domain.ParseCardText, double-scanning each row); use domain.NewCardFromValidated with the VOs from checkImportCaps")
 	}
 }

--- a/docs/backend/library-gotchas/preview-commit-validation-parity.md
+++ b/docs/backend/library-gotchas/preview-commit-validation-parity.md
@@ -63,19 +63,33 @@ Three properties make the parity real, not just nominal:
    out of the message is the same discipline as
    [`typed-classifier-over-string-prefix.md`](../error-wrapping/typed-classifier-over-string-prefix.md).
 
-## A downstream aggregate check stays as defense-in-depth, not dead code
+## Reuse the shared gate's parsed VOs instead of re-scanning downstream
 
 Once the shared gate runs upstream, a later aggregate-constructor check for the
-same invariant (here `domain.NewCard` re-validating front/back length) looks
-unreachable. Keep it: it is genuinely reachable via a *different* failure
-(`NewCard` also generates an ID, whose `crypto/rand` failure flows through the
-same `if err != nil`), and the length branch is correct defense-in-depth. This
-is the "retain" verdict in
-[`defense-in-depth-classification-internal.md`](../error-wrapping/defense-in-depth-classification-internal.md),
-not the "collapse" verdict in
-[`dead-pipeline-after-upstream-gate-collapse.md`](dead-pipeline-after-upstream-gate-collapse.md) —
-the distinguishing cue is that the inner check guards a *structural aggregate
-invariant* and has a second live caller path, so it is not pure dead code.
+same invariant looks unreachable. Whether to keep the second scan turns on
+whether an already-parsed value object is available to reuse:
+
+- **No validated-VO constructor available → keep the re-check as defense-in-depth.**
+  A constructor that only accepts raw strings re-runs the length check, but that
+  scan also guards a *structural aggregate invariant* and the constructor has a
+  second live failure path (e.g. `domain.NewCard` also generates an ID, whose
+  `crypto/rand` failure flows through the same `if err != nil`). That is the
+  "retain" verdict in
+  [`defense-in-depth-classification-internal.md`](../error-wrapping/defense-in-depth-classification-internal.md).
+- **A validated-VO constructor is available → reuse the VOs, do not re-scan.**
+  `checkImportCaps` returns the trimmed `domain.CardText` VOs it parsed for each
+  row; the `Import` build loop builds the `Card` via `domain.NewCardFromValidated`
+  from those VOs — one grapheme scan per row, not two. The residual
+  defense-in-depth is `NewCardFromValidated`'s zero-value guard (it rejects
+  `CardText("")` via the field sentinel) plus the same ID-generation failure path;
+  the per-side length cap is enforced upstream by `checkImportCaps`, so re-running
+  `domain.ParseCardText` in the build loop would be pure redundant work. This is
+  the "collapse" verdict in
+  [`dead-pipeline-after-upstream-gate-collapse.md`](dead-pipeline-after-upstream-gate-collapse.md)
+  applied to a *duplicated scan*: the check is not deleted, it is hoisted to its
+  single source and its output reused. A source-level guard test pins the loop to
+  `NewCardFromValidated` (a silent regression to `NewCard` would double-scan with
+  no behavioral difference).
 
 ## Verification harness
 


### PR DESCRIPTION
## Summary

The card-import path did redundant work: it grapheme-scanned every row twice (once in `checkImportCaps`, again in `domain.NewCard`) and, on a row-cap reject, `Validate` still built and returned the full parsed-card slice. This change folds the cap check into a single scan per row and returns an empty `ParsedCards` when the payload is rejected.

## Changes

- `backend/internal/usecase/card_import.go`: `checkImportCaps` now returns the validated `(front, back domain.CardText)` pairs alongside its violations; the build loop constructs cards via `domain.NewCardFromValidated` using those VOs, eliminating the second `ParseCardText` scan. `Validate` runs the payload-level row-cap check first and short-circuits with an empty `ParsedCards` when the cap fires, mirroring `Import`'s all-or-nothing reject.
- `backend/internal/usecase/card_import_test.go`: added coverage pinning single-scan card construction and the empty-`ParsedCards` reject behavior.
- `docs/backend/library-gotchas/preview-commit-validation-parity.md`: updated to reflect that `Validate` and `Import` continue to run the same cap/validation logic before dedup.

## Test plan

- Added tests asserting a rejected (>5000-row) `Validate` returns the cap violation with empty `ParsedCards`, and that valid payloads build cards with a single grapheme scan per row.
- Existing `go test ./internal/usecase/...` suites still green.
- Note: the Docker daemon was unavailable locally, so testcontainer-gated integration tests were skipped here; CI runs them.

Closes #786
