### PR TITLE
feat(backend): rational new-card-ratio VO + per-user read path (default 4/5)

### DIFF
--- a/.claude/rules/ddd-patterns.md
+++ b/.claude/rules/ddd-patterns.md
@@ -169,7 +169,8 @@ rating Again/Hard) over long-interval Review-state filler, and exclude cards
 swiped today via a JST start-of-day cutoff. SQL `random()` decides *which* rows
 enter each window (selection); the injected `*rand.Rand` in
 `OrderingPolicy.Apply` decides their arrangement (deterministic in tests) and
-interleaves at `NewCardRatio=4 : ReviewCardRatio=1`. This replaces a tie-scoped
+interleaves at the caller-supplied `domain.NewCardRatio` (`domain.DefaultNewCardRatio`
+= 4:1 absent a stored preference). This replaces a tie-scoped
 shuffle that never fired on dense real data (microsecond-precision `due` and
 distinct `position` make ties structurally impossible).
 

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -165,7 +165,7 @@ func buildResolver(
 	masterDeckUC := usecase.NewMasterDeckUsecase(repos.masterCardgroup, repos.masterCard, repos.card, repos.cardgroup, repos.gorm, logger)
 	userUC := usecase.NewUserUsecase(repos.user, repos.userRole, authSvc, logger)
 	cardgroupUC := usecase.NewCardgroupUsecase(repos.cardgroup, authSvc, logger)
-	learnUC := usecase.NewLearnUsecase(repos.card, repos.cardgroup, service.NewOrderingPolicy(), nil, 0, 0, nil, logger)
+	learnUC := usecase.NewLearnUsecase(repos.card, repos.cardgroup, repos.userPreference, service.NewOrderingPolicy(), nil, 0, 0, nil, logger)
 	swipeUC := usecase.NewSwipeUsecase(repos.gorm, repos.card, repos.cardgroup, repos.swipeRecord, service.NewFSRSScheduler(), repos.userCardFSRS, logger)
 	cardImportUC := usecase.NewCardImportUsecase(repos.cardgroup, repos.card, repos.gorm, logger)
 	adminUserUC := usecase.NewAdminUser(repos.gorm, repos.user, repos.role, repos.userRole, adminGate, logger)

--- a/backend/graph/resolver/card_resolvers_test.go
+++ b/backend/graph/resolver/card_resolvers_test.go
@@ -87,6 +87,15 @@ func (m *cardMockCGRepo) FindByID(_ context.Context, _ string) (*domain.Cardgrou
 	return m.findResult, m.findErr
 }
 
+// learnUserPrefsStub satisfies usecase.UserPrefsForLearn. Returning ErrNotFound
+// keeps NextDueCards on the default new-card ratio, so the learn resolver tests
+// exercise the unchanged 4:1 ordering.
+type learnUserPrefsStub struct{}
+
+func (learnUserPrefsStub) FindByUserID(_ context.Context, _ string) (*domain.UserPreference, error) {
+	return nil, repository.ErrNotFound
+}
+
 // duplicateCardMockRepo embeds cardMockRepo and overrides the two methods
 // exercised by the duplicate-front branch: Create returns ErrCardDuplicateFront
 // and FindByCardgroupAndFront returns the configured existing card.
@@ -132,6 +141,7 @@ func newLearnSrv(cardRepo *cardMockRepo, cgRepo *cardMockCGRepo) *handler.Server
 	learnUC := usecase.NewLearnUsecase(
 		cardRepo,
 		cgRepo,
+		learnUserPrefsStub{},
 		service.NewOrderingPolicy(),
 		func() *rand.Rand { return rand.New(rand.NewSource(1)) },
 		20,

--- a/backend/internal/database/cards_position_roundtrip_test.go
+++ b/backend/internal/database/cards_position_roundtrip_test.go
@@ -44,16 +44,17 @@ func TestCardsPositionDownUpRoundtrip(t *testing.T) {
 		}
 	}()
 
-	// Step back past the nine migrations newer than add_position_to_cards
+	// Step back past the ten migrations newer than add_position_to_cards
 	// (enable_rls_schema_migrations, pin_trigger_function_search_path,
 	// restrict_definer_function_exposure, add_master_tables,
 	// add_learn_display_mode_to_user_preferences,
 	// add_user_card_fsrs_card_id_index, master_cards_front_citext,
 	// drop_master_cardgroup_metadata_columns,
-	// index_hygiene_users_swipe_records), then past add_position_to_cards
-	// itself. Ten steps are required because add_position_to_cards is no longer
+	// index_hygiene_users_swipe_records,
+	// add_new_card_ratio_to_user_preferences), then past add_position_to_cards
+	// itself. Eleven steps are required because add_position_to_cards is no longer
 	// near the newest migration; bump this count when adding migrations after it.
-	if err := m.Steps(-10); err != nil {
+	if err := m.Steps(-11); err != nil {
 		t.Fatalf("migrate down to before add_position_to_cards: %v", err)
 	}
 

--- a/backend/internal/database/learn_display_mode_roundtrip_test.go
+++ b/backend/internal/database/learn_display_mode_roundtrip_test.go
@@ -54,14 +54,15 @@ func TestLearnDisplayModeDownUpRoundtrip(t *testing.T) {
 		}
 	}()
 
-	// Step back five migrations newest-first: index_hygiene_users_swipe_records
-	// (now the newest), drop_master_cardgroup_metadata_columns,
-	// master_cards_front_citext, add_user_card_fsrs_card_id_index,
+	// Step back six migrations newest-first: add_new_card_ratio_to_user_preferences
+	// (now the newest), index_hygiene_users_swipe_records,
+	// drop_master_cardgroup_metadata_columns, master_cards_front_citext,
+	// add_user_card_fsrs_card_id_index,
 	// then add_learn_display_mode_to_user_preferences (the target). The Steps(1)
 	// below re-applies add_learn_display_mode, and the t.Cleanup restores the
 	// rest. Bump this count when adding migrations after
 	// add_learn_display_mode_to_user_preferences.
-	if err := m.Steps(-5); err != nil {
+	if err := m.Steps(-6); err != nil {
 		t.Fatalf("migrate down to before add_learn_display_mode_to_user_preferences: %v", err)
 	}
 

--- a/backend/internal/database/migrations/20260705000000_add_new_card_ratio_to_user_preferences.down.sql
+++ b/backend/internal/database/migrations/20260705000000_add_new_card_ratio_to_user_preferences.down.sql
@@ -1,0 +1,15 @@
+-- 20260705000000_add_new_card_ratio_to_user_preferences.down.sql
+--
+-- Reverse of 20260705000000_add_new_card_ratio_to_user_preferences.up.sql.
+--
+-- golang-migrate pgx/v5 does NOT auto-wrap migrations in a transaction; the
+-- explicit BEGIN/COMMIT below ensures all-or-nothing execution.
+
+BEGIN;
+
+ALTER TABLE public.user_preferences
+  DROP CONSTRAINT IF EXISTS user_preferences_new_card_ratio_check,
+  DROP COLUMN IF EXISTS new_card_ratio_num,
+  DROP COLUMN IF EXISTS new_card_ratio_den;
+
+COMMIT;

--- a/backend/internal/database/migrations/20260705000000_add_new_card_ratio_to_user_preferences.up.sql
+++ b/backend/internal/database/migrations/20260705000000_add_new_card_ratio_to_user_preferences.up.sql
@@ -1,0 +1,27 @@
+-- 20260705000000_add_new_card_ratio_to_user_preferences.up.sql
+--
+-- Adds the per-user new-vs-review interleave ratio to public.user_preferences,
+-- held as an irreducible fraction new_card_ratio_num / new_card_ratio_den.
+-- The default 4/5 (new share 4, review share 1 -> interleave 4:1) keeps the
+-- ordering behaviour identical to the historical fixed 4:1 constants.
+--
+-- The CHECK is a backstop for direct DB writes; the domain value object
+-- enforces the same bounds plus gcd-reduction (which the CHECK cannot express)
+-- in application code.
+--
+-- golang-migrate pgx/v5 does NOT auto-wrap migrations in a transaction; the
+-- explicit BEGIN/COMMIT below ensures all-or-nothing execution.
+
+BEGIN;
+
+ALTER TABLE public.user_preferences
+  ADD COLUMN new_card_ratio_num int NOT NULL DEFAULT 4,
+  ADD COLUMN new_card_ratio_den int NOT NULL DEFAULT 5,
+  ADD CONSTRAINT user_preferences_new_card_ratio_check
+    CHECK (
+      new_card_ratio_num >= 1
+      AND new_card_ratio_num < new_card_ratio_den
+      AND new_card_ratio_den <= 100
+    );
+
+COMMIT;

--- a/backend/internal/database/users_version_roundtrip_test.go
+++ b/backend/internal/database/users_version_roundtrip_test.go
@@ -38,21 +38,22 @@ func TestUsersVersionDownUpRoundtrip(t *testing.T) {
 		}
 	}()
 
-	// Step back through the 11 migrations listed newest-first until
+	// Step back through the 12 migrations listed newest-first until
 	// add_version_to_users (the target) is also rolled back:
-	//   1. index_hygiene_users_swipe_records
-	//   2. drop_master_cardgroup_metadata_columns
-	//   3. master_cards_front_citext
-	//   4. add_user_card_fsrs_card_id_index
-	//   5. add_learn_display_mode_to_user_preferences
-	//   6. add_master_tables
-	//   7. restrict_definer_function_exposure
-	//   8. pin_trigger_function_search_path
-	//   9. enable_rls_schema_migrations
-	//   10. add_position_to_cards
-	//   11. add_version_to_users  ← target (rolls back the version column)
+	//   1. add_new_card_ratio_to_user_preferences
+	//   2. index_hygiene_users_swipe_records
+	//   3. drop_master_cardgroup_metadata_columns
+	//   4. master_cards_front_citext
+	//   5. add_user_card_fsrs_card_id_index
+	//   6. add_learn_display_mode_to_user_preferences
+	//   7. add_master_tables
+	//   8. restrict_definer_function_exposure
+	//   9. pin_trigger_function_search_path
+	//   10. enable_rls_schema_migrations
+	//   11. add_position_to_cards
+	//   12. add_version_to_users  ← target (rolls back the version column)
 	// Bump the count here when adding migrations after add_version_to_users.
-	if err := m.Steps(-11); err != nil {
+	if err := m.Steps(-12); err != nil {
 		t.Fatalf("migrate down to before add_version_to_users: %v", err)
 	}
 

--- a/backend/internal/domain/new_card_ratio.go
+++ b/backend/internal/domain/new_card_ratio.go
@@ -1,0 +1,69 @@
+package domain
+
+import (
+	"math/big"
+
+	"github.com/rotisserie/eris"
+)
+
+// NewCardRatio is the per-user new-vs-review interleave ratio for a learn
+// session, held as an irreducible fraction num/den. num is the new-card share
+// (interleave nRatio); den is the total, so the review share is den-num
+// (interleave rRatio). The zero value is invalid; construct via
+// ParseNewCardRatio or use DefaultNewCardRatio.
+type NewCardRatio struct {
+	num int // new-card share; invariant 1 <= num < den
+	den int // total; invariant den <= 100, gcd(num, den) == 1
+}
+
+// NewCardRatioDenMax caps the denominator so a stored ratio stays coarse enough
+// for a human-facing setting (1% resolution is more than enough) and bounds the
+// interleave loop counts.
+const NewCardRatioDenMax = 100
+
+// DefaultNewCardRatio (4/5) is applied when a user has no stored preference.
+// New share 4, review share 1 → interleave 4:1, matching the historical
+// hard-coded 4:1 new:review interleave this VO replaces.
+var DefaultNewCardRatio = mustNewCardRatio(4, 5)
+
+// ParseNewCardRatio reduces num/den to lowest terms and validates the bounds.
+// Returns a domain error (not a silent fallback) for a non-positive
+// denominator, a share outside (0, den), a reduced denominator above
+// NewCardRatioDenMax, or a zero/negative numerator.
+func ParseNewCardRatio(num, den int) (NewCardRatio, error) {
+	if den <= 0 {
+		return NewCardRatio{}, eris.Errorf("domain: new card ratio: denominator must be positive, got %d", den)
+	}
+	if num <= 0 || num >= den {
+		return NewCardRatio{}, eris.Errorf("domain: new card ratio: numerator must satisfy 0 < num < den, got %d/%d", num, den)
+	}
+	g := int(new(big.Int).GCD(nil, nil, big.NewInt(int64(num)), big.NewInt(int64(den))).Int64())
+	rnum, rden := num/g, den/g
+	if rden > NewCardRatioDenMax {
+		return NewCardRatio{}, eris.Errorf("domain: new card ratio: reduced denominator %d exceeds max %d", rden, NewCardRatioDenMax)
+	}
+	return NewCardRatio{num: rnum, den: rden}, nil
+}
+
+func mustNewCardRatio(num, den int) NewCardRatio {
+	r, err := ParseNewCardRatio(num, den)
+	if err != nil {
+		panic(err)
+	}
+	return r
+}
+
+// NewShare is the number of new cards per interleave cycle (interleave nRatio).
+func (r NewCardRatio) NewShare() int { return r.num }
+
+// ReviewShare is the number of review cards per interleave cycle (rRatio).
+func (r NewCardRatio) ReviewShare() int { return r.den - r.num }
+
+// Numerator / Denominator expose the reduced fraction for persistence and the
+// wire form (numerator = new share, denominator = total).
+func (r NewCardRatio) Numerator() int   { return r.num }
+func (r NewCardRatio) Denominator() int { return r.den }
+
+// IsZero reports whether r is the invalid zero value (never produced by
+// ParseNewCardRatio). Read paths treat the zero value as "use the default".
+func (r NewCardRatio) IsZero() bool { return r.den == 0 }

--- a/backend/internal/domain/new_card_ratio_test.go
+++ b/backend/internal/domain/new_card_ratio_test.go
@@ -1,0 +1,82 @@
+package domain
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseNewCardRatio_ReducesToLowestTerms(t *testing.T) {
+	t.Parallel()
+
+	// 8/10 reduces to 4/5 (gcd 2). New share 4, review share 1.
+	r, err := ParseNewCardRatio(8, 10)
+	require.NoError(t, err)
+	require.Equal(t, 4, r.Numerator())
+	require.Equal(t, 5, r.Denominator())
+	require.Equal(t, 4, r.NewShare())
+	require.Equal(t, 1, r.ReviewShare())
+}
+
+func TestParseNewCardRatio_RejectsOutOfBounds(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		num, den int
+	}{
+		{"zero denominator", 1, 0},
+		{"negative denominator", 1, -5},
+		{"zero numerator", 0, 5},
+		{"negative numerator", -1, 5},
+		{"numerator equals denominator", 3, 3},
+		{"numerator exceeds denominator", 5, 3},
+		{"reduced denominator over max", 50, 101},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := ParseNewCardRatio(tc.num, tc.den)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestParseNewCardRatio_AllowsMaxDenominator(t *testing.T) {
+	t.Parallel()
+
+	// 99/100 is irreducible with den == NewCardRatioDenMax, so it is accepted.
+	r, err := ParseNewCardRatio(99, NewCardRatioDenMax)
+	require.NoError(t, err)
+	require.Equal(t, 99, r.NewShare())
+	require.Equal(t, 1, r.ReviewShare())
+}
+
+func TestDefaultNewCardRatio_IsFourFifths(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, 4, DefaultNewCardRatio.Numerator())
+	require.Equal(t, 5, DefaultNewCardRatio.Denominator())
+	require.Equal(t, 4, DefaultNewCardRatio.NewShare())
+	require.Equal(t, 1, DefaultNewCardRatio.ReviewShare())
+	require.False(t, DefaultNewCardRatio.IsZero())
+}
+
+func TestNewCardRatio_SharesForThreeSevenths(t *testing.T) {
+	t.Parallel()
+
+	// 3/7 is already irreducible: new share 3, review share 4.
+	r, err := ParseNewCardRatio(3, 7)
+	require.NoError(t, err)
+	require.Equal(t, 3, r.Numerator())
+	require.Equal(t, 7, r.Denominator())
+	require.Equal(t, 3, r.NewShare())
+	require.Equal(t, 4, r.ReviewShare())
+}
+
+func TestNewCardRatio_ZeroValueIsZero(t *testing.T) {
+	t.Parallel()
+
+	var zero NewCardRatio
+	require.True(t, zero.IsZero(), "the zero value must report IsZero")
+}

--- a/backend/internal/domain/service/due_card_ordering.go
+++ b/backend/internal/domain/service/due_card_ordering.go
@@ -7,15 +7,6 @@ import (
 	"backend/internal/domain"
 )
 
-// NewCardRatio and ReviewCardRatio define the new/review interleave ratio.
-// Fixed at 4:1 (four new per one review): a default 20-card session is 16
-// never-seen discoveries plus 4 reviews of cards rated Again/Hard on a
-// previous day. Revisit if discovery pace outruns retention.
-const (
-	NewCardRatio    = 4
-	ReviewCardRatio = 1
-)
-
 // OrderingPolicy applies session-local ordering to due cards.
 //
 // The zero value is ready to use; the constructor is provided for symmetry
@@ -33,17 +24,20 @@ func NewOrderingPolicy() *OrderingPolicy { return &OrderingPolicy{} }
 //     pre-sorts learning-phase rows (Learning/Relearning) ahead of Review
 //     rows, and shuffling never crosses that boundary, so a Review-state
 //     filler can never displace a learning-phase card from the review slots.
-//  2. New and review cards are interleaved at NewCardRatio:ReviewCardRatio
-//     with review-first emission. When one bucket empties, the remaining
-//     cards from the other bucket are appended in their post-shuffle order.
+//  2. New and review cards are interleaved at the caller-supplied ratio
+//     (ratio.NewShare new per ratio.ReviewShare review) with review-first
+//     emission. When one bucket empties, the remaining cards from the other
+//     bucket are appended in their post-shuffle order.
 //
 // The caller is responsible for truncating to a per-session limit. Apply
 // returns all cards from due without imposing a length cap; the input slice
 // is not modified, as partition produces fresh slices before shuffling.
 //
 // rng must be non-nil. Tests inject a seeded *rand.Rand for deterministic
-// order; production constructs one per session.
-func (p *OrderingPolicy) Apply(due []domain.DueCard, rng *rand.Rand) []*domain.Card {
+// order; production constructs one per session. ratio is the per-user
+// new-vs-review interleave ratio; its VO invariants guarantee both shares are
+// >= 1, so interleave's positive-ratio guard is satisfied by construction.
+func (p *OrderingPolicy) Apply(due []domain.DueCard, rng *rand.Rand, ratio domain.NewCardRatio) []*domain.Card {
 	if rng == nil {
 		panic("domain/service: OrderingPolicy.Apply requires non-nil rng")
 	}
@@ -57,7 +51,7 @@ func (p *OrderingPolicy) Apply(due []domain.DueCard, rng *rand.Rand) []*domain.C
 		newCards[a], newCards[b] = newCards[b], newCards[a]
 	})
 	shuffleWithinPhase(reviewCards, rng)
-	return interleave(newCards, reviewCards, NewCardRatio, ReviewCardRatio)
+	return interleave(newCards, reviewCards, ratio.NewShare(), ratio.ReviewShare())
 }
 
 // partition splits due into new (FSRSStateNew) vs review (everything else),

--- a/backend/internal/domain/service/due_card_ordering_test.go
+++ b/backend/internal/domain/service/due_card_ordering_test.go
@@ -32,10 +32,10 @@ func cardIDs(cards []*domain.Card) []string {
 func TestOrderingPolicy_Apply_Empty(t *testing.T) {
 	t.Parallel()
 
-	got := NewOrderingPolicy().Apply(nil, rand.New(rand.NewSource(42)))
+	got := NewOrderingPolicy().Apply(nil, rand.New(rand.NewSource(42)), domain.DefaultNewCardRatio)
 	require.Empty(t, got)
 
-	got = NewOrderingPolicy().Apply([]domain.DueCard{}, rand.New(rand.NewSource(42)))
+	got = NewOrderingPolicy().Apply([]domain.DueCard{}, rand.New(rand.NewSource(42)), domain.DefaultNewCardRatio)
 	require.Empty(t, got)
 }
 
@@ -54,7 +54,7 @@ func TestOrderingPolicy_Apply_OnlyNew_AlwaysShuffled(t *testing.T) {
 		dueCard("n4", domain.FSRSStateNew, base.Add(3*time.Minute)),
 	}
 
-	got := NewOrderingPolicy().Apply(in, rand.New(rand.NewSource(42)))
+	got := NewOrderingPolicy().Apply(in, rand.New(rand.NewSource(42)), domain.DefaultNewCardRatio)
 
 	require.Equal(t, []string{"n3", "n4", "n1", "n2"}, cardIDs(got),
 		"deterministic full shuffle for seed 42")
@@ -76,7 +76,7 @@ func TestOrderingPolicy_Apply_OnlyReview_PhaseRunsShuffledIndependently(t *testi
 		dueCard("r2", domain.FSRSStateReview, base.Add(3*time.Minute)),
 	}
 
-	got := NewOrderingPolicy().Apply(in, rand.New(rand.NewSource(42)))
+	got := NewOrderingPolicy().Apply(in, rand.New(rand.NewSource(42)), domain.DefaultNewCardRatio)
 
 	require.Equal(t, []string{"l2", "l1", "r2", "r1"}, cardIDs(got),
 		"each phase run shuffles independently; learning phase stays first")
@@ -96,7 +96,7 @@ func TestOrderingPolicy_Apply_PhaseBoundaryHoldsAcrossSeeds(t *testing.T) {
 	learning := map[string]bool{"l1": true, "l2": true, "l3": true}
 
 	for _, seed := range []int64{1, 7, 42, 99} {
-		got := NewOrderingPolicy().Apply(in, rand.New(rand.NewSource(seed)))
+		got := NewOrderingPolicy().Apply(in, rand.New(rand.NewSource(seed)), domain.DefaultNewCardRatio)
 		ids := cardIDs(got)
 		require.Len(t, ids, 5)
 		for i, id := range ids[:3] {
@@ -124,11 +124,44 @@ func TestOrderingPolicy_Apply_MixedCompositionSlots(t *testing.T) {
 		in = append(in, dueCard(fmt.Sprintf("new-%d", i), domain.FSRSStateNew, base.Add(time.Duration(100+i)*time.Minute)))
 	}
 
-	got := NewOrderingPolicy().Apply(in, rand.New(rand.NewSource(42)))
+	got := NewOrderingPolicy().Apply(in, rand.New(rand.NewSource(42)), domain.DefaultNewCardRatio)
 	require.Len(t, got, 25)
 
 	for i, c := range got {
 		if i%5 == 0 {
+			require.True(t, reviewSet[c.ID], "slot %d must be a review card, got %q", i, c.ID)
+		} else {
+			require.False(t, reviewSet[c.ID], "slot %d must be a new card, got %q", i, c.ID)
+		}
+	}
+}
+
+func TestOrderingPolicy_Apply_NonDefaultRatioInterleavesOneToOne(t *testing.T) {
+	t.Parallel()
+
+	// 3 new + 3 review. The default 4/5 ratio would emit [R,N,N,N,R,R]; a 1/2
+	// ratio (new share 1, review share 1) interleaves 1:1 review-first, so
+	// review cards land in the even slots and new cards in the odd slots. The
+	// distinct slot composition proves the caller-supplied ratio reaches Apply.
+	base := time.Date(2026, 5, 20, 9, 0, 0, 0, time.UTC)
+	in := []domain.DueCard{
+		dueCard("n1", domain.FSRSStateNew, base),
+		dueCard("n2", domain.FSRSStateNew, base.Add(time.Minute)),
+		dueCard("n3", domain.FSRSStateNew, base.Add(2*time.Minute)),
+		dueCard("r1", domain.FSRSStateReview, base.Add(3*time.Minute)),
+		dueCard("r2", domain.FSRSStateReview, base.Add(4*time.Minute)),
+		dueCard("r3", domain.FSRSStateReview, base.Add(5*time.Minute)),
+	}
+	reviewSet := map[string]bool{"r1": true, "r2": true, "r3": true}
+
+	ratio, err := domain.ParseNewCardRatio(1, 2)
+	require.NoError(t, err)
+
+	got := NewOrderingPolicy().Apply(in, rand.New(rand.NewSource(42)), ratio)
+	require.Len(t, got, 6)
+
+	for i, c := range got {
+		if i%2 == 0 {
 			require.True(t, reviewSet[c.ID], "slot %d must be a review card, got %q", i, c.ID)
 		} else {
 			require.False(t, reviewSet[c.ID], "slot %d must be a new card, got %q", i, c.ID)
@@ -149,7 +182,7 @@ func TestOrderingPolicy_Apply_SetEquality(t *testing.T) {
 		dueCard("r4", domain.FSRSStateRelearning, base.Add(3*time.Minute)),
 	}
 
-	got := NewOrderingPolicy().Apply(in, rand.New(rand.NewSource(42)))
+	got := NewOrderingPolicy().Apply(in, rand.New(rand.NewSource(42)), domain.DefaultNewCardRatio)
 
 	require.Len(t, got, len(in), "no cards dropped or duplicated")
 
@@ -171,7 +204,7 @@ func TestOrderingPolicy_Apply_PanicsOnNilRng(t *testing.T) {
 	require.PanicsWithValue(t,
 		"domain/service: OrderingPolicy.Apply requires non-nil rng",
 		func() {
-			_ = NewOrderingPolicy().Apply(nil, nil)
+			_ = NewOrderingPolicy().Apply(nil, nil, domain.DefaultNewCardRatio)
 		},
 	)
 }
@@ -185,7 +218,7 @@ func TestOrderingPolicy_Apply_PanicsOnNilCard(t *testing.T) {
 	require.PanicsWithValue(t,
 		"domain/service: OrderingPolicy.Apply: DueCard.Card must not be nil",
 		func() {
-			_ = NewOrderingPolicy().Apply(due, rand.New(rand.NewSource(42)))
+			_ = NewOrderingPolicy().Apply(due, rand.New(rand.NewSource(42)), domain.DefaultNewCardRatio)
 		},
 	)
 }
@@ -202,7 +235,7 @@ func TestInterleave_TrailingReviewAppend(t *testing.T) {
 		reviewC = append(reviewC, dueCard(fmt.Sprintf("rev-%d", i), domain.FSRSStateReview, base.Add(time.Duration(i)*time.Minute)))
 	}
 
-	got := interleave(newC, reviewC, NewCardRatio, ReviewCardRatio)
+	got := interleave(newC, reviewC, 4, 1)
 
 	// Cycle 1 emits rev-0 then new-0 (new bucket exhausts the 4-slot k-loop
 	// at 1 card); the outer loop exits and the trailing-review path appends
@@ -224,7 +257,7 @@ func TestInterleave_TrailingNewAppend(t *testing.T) {
 		dueCard("rev-1", domain.FSRSStateReview, base.Add(time.Minute)),
 	}
 
-	got := interleave(newC, reviewC, NewCardRatio, ReviewCardRatio)
+	got := interleave(newC, reviewC, 4, 1)
 
 	// Cycle 1: rev-0, new-0..new-3. Cycle 2: rev-1, new-4..new-7. Review
 	// bucket is now empty so the outer loop exits; trailing-new appends

--- a/backend/internal/domain/user_preference.go
+++ b/backend/internal/domain/user_preference.go
@@ -8,5 +8,6 @@ type UserPreference struct {
 	UserID                UserID
 	LastViewedCardgroupID *string
 	LearnDisplayMode      LearnDisplayMode
+	NewCardRatio          NewCardRatio // zero value means "use DefaultNewCardRatio"
 	UpdatedAt             time.Time
 }

--- a/backend/internal/repository/user_preference.go
+++ b/backend/internal/repository/user_preference.go
@@ -18,6 +18,8 @@ type gormUserPreference struct {
 	UserID                string    `gorm:"column:user_id;primaryKey;type:uuid"`
 	LastViewedCardgroupID *string   `gorm:"column:last_viewed_cardgroup_id;type:uuid"`
 	LearnDisplayMode      string    `gorm:"column:learn_display_mode"`
+	NewCardRatioNum       int       `gorm:"column:new_card_ratio_num"`
+	NewCardRatioDen       int       `gorm:"column:new_card_ratio_den"`
 	UpdatedAt             time.Time `gorm:"column:updated_at"`
 }
 
@@ -154,15 +156,24 @@ SET learn_display_mode = EXCLUDED.learn_display_mode,
 // silent fallback keeps reads non-fatal during rolling deploys and for legacy
 // rows written before the column existed; a corrupt value in production is
 // surfaced only as the safe default, not a load error.
+//
+// new_card_ratio_num / new_card_ratio_den follow the same non-fatal posture:
+// an out-of-bounds or legacy zero value falls back to domain.DefaultNewCardRatio
+// rather than failing the read.
 func toDomainUserPreference(g gormUserPreference) *domain.UserPreference {
 	mode := domain.DefaultLearnDisplayMode
 	if parsed, err := domain.ParseLearnDisplayMode(g.LearnDisplayMode); err == nil {
 		mode = parsed
 	}
+	ratio := domain.DefaultNewCardRatio
+	if parsed, err := domain.ParseNewCardRatio(g.NewCardRatioNum, g.NewCardRatioDen); err == nil {
+		ratio = parsed
+	}
 	return &domain.UserPreference{
 		UserID:                domain.UserID(g.UserID),
 		LastViewedCardgroupID: g.LastViewedCardgroupID,
 		LearnDisplayMode:      mode,
+		NewCardRatio:          ratio,
 		UpdatedAt:             g.UpdatedAt,
 	}
 }

--- a/backend/internal/usecase/learn.go
+++ b/backend/internal/usecase/learn.go
@@ -34,6 +34,14 @@ type CardgroupRepoForLearn interface {
 	FindByID(ctx context.Context, id string) (*domain.Cardgroup, error)
 }
 
+// UserPrefsForLearn is the narrow consumer interface for reading the caller's
+// stored preferences (the per-user new-card ratio). Satisfied by
+// repository.UserPreferenceRepository. ErrNotFound (no row) and a nil pref fall
+// back to domain.DefaultNewCardRatio at the read site.
+type UserPrefsForLearn interface {
+	FindByUserID(ctx context.Context, userID string) (*domain.UserPreference, error)
+}
+
 // LearnUsecase surfaces due-card retrieval for a learning session.
 type LearnUsecase interface {
 	NextDueCards(ctx context.Context, cardgroupID string, limit *int) ([]*domain.Card, error)
@@ -53,6 +61,7 @@ type LearnUsecase interface {
 type learnUsecase struct {
 	cardRepo      CardRepoForLearn
 	cardgroupRepo CardgroupRepoForLearn
+	userPrefs     UserPrefsForLearn
 	ordering      *service.OrderingPolicy
 	randSource    func() *rand.Rand
 	clock         Clock
@@ -72,6 +81,7 @@ func (systemClock) Now() time.Time { return time.Now() }
 func NewLearnUsecase(
 	cardRepo CardRepoForLearn,
 	cardgroupRepo CardgroupRepoForLearn,
+	userPrefs UserPrefsForLearn,
 	ordering *service.OrderingPolicy,
 	randSource func() *rand.Rand,
 	defaultLimit, maxLimit int,
@@ -86,6 +96,9 @@ func NewLearnUsecase(
 	}
 	if cardgroupRepo == nil {
 		panic("usecase: learn: cardgroupRepo must not be nil")
+	}
+	if userPrefs == nil {
+		panic("usecase: learn: userPrefs must not be nil")
 	}
 	if ordering == nil {
 		ordering = service.NewOrderingPolicy()
@@ -110,6 +123,7 @@ func NewLearnUsecase(
 	return &learnUsecase{
 		cardRepo:      cardRepo,
 		cardgroupRepo: cardgroupRepo,
+		userPrefs:     userPrefs,
 		ordering:      ordering,
 		randSource:    randSource,
 		clock:         clock,
@@ -165,7 +179,21 @@ func (u *learnUsecase) NextDueCards(ctx context.Context, cardgroupID string, lim
 		}
 		return nil, eris.Wrap(err, "usecase: learn: find due cards")
 	}
-	ordered := u.ordering.Apply(due, u.randSource())
+	// Load the caller's per-user new-vs-review ratio. A missing preference row
+	// (ErrNotFound), a nil pref, or a zero-value ratio all fall back to the
+	// default; a real infrastructure error propagates (context-done unwrapped).
+	ratio := domain.DefaultNewCardRatio
+	pref, err := u.userPrefs.FindByUserID(ctx, user.Sub)
+	switch {
+	case err == nil && pref != nil && !pref.NewCardRatio.IsZero():
+		ratio = pref.NewCardRatio
+	case err != nil && !errors.Is(err, repository.ErrNotFound):
+		if isContextDone(err) {
+			return nil, err
+		}
+		return nil, eris.Wrap(err, "usecase: learn: load user preference")
+	}
+	ordered := u.ordering.Apply(due, u.randSource(), ratio)
 	if len(ordered) > n {
 		ordered = ordered[:n]
 	}

--- a/backend/internal/usecase/learn_test.go
+++ b/backend/internal/usecase/learn_test.go
@@ -64,6 +64,27 @@ func (m *mockLearnCardgroupRepo) FindByID(_ context.Context, _ string) (*domain.
 	return m.cardgroup, m.err
 }
 
+// mockLearnUserPrefs satisfies UserPrefsForLearn. When err is set it is returned
+// verbatim (e.g. repository.ErrNotFound to exercise the default-ratio path, or
+// context.Canceled to exercise the pass-through branch); otherwise pref is
+// returned so a stored non-default ratio can reach OrderingPolicy.Apply.
+type mockLearnUserPrefs struct {
+	pref  *domain.UserPreference
+	err   error
+	calls int
+}
+
+func (m *mockLearnUserPrefs) FindByUserID(_ context.Context, _ string) (*domain.UserPreference, error) {
+	m.calls++
+	return m.pref, m.err
+}
+
+// notFoundPrefs returns a userPrefs stub reporting no stored preference row, so
+// NextDueCards falls back to domain.DefaultNewCardRatio (the default 4:1 order).
+func notFoundPrefs() *mockLearnUserPrefs {
+	return &mockLearnUserPrefs{err: repository.ErrNotFound}
+}
+
 type fixedClock struct{ now time.Time }
 
 func (c fixedClock) Now() time.Time { return c.now }
@@ -80,6 +101,7 @@ func TestLearnUsecaseNextDueCards(t *testing.T) {
 	uc := NewLearnUsecase(
 		cardRepo,
 		&mockLearnCardgroupRepo{cardgroup: &domain.Cardgroup{ID: domain.CardgroupID("cg-1"), OwnerID: "u-1"}},
+		notFoundPrefs(),
 		service.NewOrderingPolicy(),
 		func() *rand.Rand { return rand.New(rand.NewSource(1)) },
 		20,
@@ -111,6 +133,7 @@ func TestLearnUsecaseNextDueCardsAuthAndCardgroupErrors(t *testing.T) {
 		uc := NewLearnUsecase(
 			&mockLearnCardRepo{},
 			&mockLearnCardgroupRepo{},
+			notFoundPrefs(),
 			service.NewOrderingPolicy(),
 			func() *rand.Rand { return rand.New(rand.NewSource(1)) },
 			20,
@@ -127,6 +150,7 @@ func TestLearnUsecaseNextDueCardsAuthAndCardgroupErrors(t *testing.T) {
 		uc := NewLearnUsecase(
 			&mockLearnCardRepo{},
 			&mockLearnCardgroupRepo{err: repository.ErrNotFound},
+			notFoundPrefs(),
 			service.NewOrderingPolicy(),
 			func() *rand.Rand { return rand.New(rand.NewSource(1)) },
 			20,
@@ -143,6 +167,7 @@ func TestLearnUsecaseNextDueCardsAuthAndCardgroupErrors(t *testing.T) {
 		uc := NewLearnUsecase(
 			&mockLearnCardRepo{},
 			&mockLearnCardgroupRepo{cardgroup: &domain.Cardgroup{ID: domain.CardgroupID("cg-1"), OwnerID: "u-2"}},
+			notFoundPrefs(),
 			service.NewOrderingPolicy(),
 			func() *rand.Rand { return rand.New(rand.NewSource(1)) },
 			20,
@@ -179,6 +204,7 @@ func TestLearnUsecaseNextDueCardsLimitClampAndEmpty(t *testing.T) {
 			uc := NewLearnUsecase(
 				cardRepo,
 				&mockLearnCardgroupRepo{cardgroup: &domain.Cardgroup{ID: domain.CardgroupID("cg-1"), OwnerID: "u-1"}},
+				notFoundPrefs(),
 				service.NewOrderingPolicy(),
 				func() *rand.Rand { return rand.New(rand.NewSource(1)) },
 				20,
@@ -204,6 +230,7 @@ func TestLearnUsecaseNextDueCardsRepoError(t *testing.T) {
 	uc := NewLearnUsecase(
 		&mockLearnCardRepo{err: errors.New("db down")},
 		&mockLearnCardgroupRepo{cardgroup: &domain.Cardgroup{ID: domain.CardgroupID("cg-1"), OwnerID: "u-1"}},
+		notFoundPrefs(),
 		service.NewOrderingPolicy(),
 		func() *rand.Rand { return rand.New(rand.NewSource(1)) },
 		20,
@@ -224,6 +251,7 @@ func TestLearnUsecaseNextDueCardsCardgroupRepoInternalError(t *testing.T) {
 	uc := NewLearnUsecase(
 		&mockLearnCardRepo{},
 		&mockLearnCardgroupRepo{err: errors.New("db down")},
+		notFoundPrefs(),
 		service.NewOrderingPolicy(),
 		func() *rand.Rand { return rand.New(rand.NewSource(1)) },
 		20,
@@ -244,19 +272,25 @@ func TestNewLearnUsecase_PanicsOnInvalidDeps(t *testing.T) {
 	t.Run("nil cardRepo", func(t *testing.T) {
 		t.Parallel()
 		require.Panics(t, func() {
-			NewLearnUsecase(nil, cgRepo, nil, nil, 20, 100, nil, newTestLogger())
+			NewLearnUsecase(nil, cgRepo, notFoundPrefs(), nil, nil, 20, 100, nil, newTestLogger())
 		})
 	})
 	t.Run("nil cardgroupRepo", func(t *testing.T) {
 		t.Parallel()
 		require.Panics(t, func() {
-			NewLearnUsecase(cardRepo, nil, nil, nil, 20, 100, nil, newTestLogger())
+			NewLearnUsecase(cardRepo, nil, notFoundPrefs(), nil, nil, 20, 100, nil, newTestLogger())
+		})
+	})
+	t.Run("nil userPrefs", func(t *testing.T) {
+		t.Parallel()
+		require.Panics(t, func() {
+			NewLearnUsecase(cardRepo, cgRepo, nil, nil, nil, 20, 100, nil, newTestLogger())
 		})
 	})
 	t.Run("defaultLimit greater than maxLimit", func(t *testing.T) {
 		t.Parallel()
 		require.Panics(t, func() {
-			NewLearnUsecase(cardRepo, cgRepo, nil, nil, 30, 20, nil, newTestLogger())
+			NewLearnUsecase(cardRepo, cgRepo, notFoundPrefs(), nil, nil, 30, 20, nil, newTestLogger())
 		})
 	})
 }
@@ -268,10 +302,10 @@ func TestLearnUsecaseNextDueCards_TruncatesToDueLimit(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, 5, 13, 9, 0, 0, 0, time.UTC)
-	// 3 new + 3 review cards. With NewCardRatio=4 : ReviewCardRatio=1 the
-	// interleave emits one review, then up to four new cards, so the first
-	// three slots are [review, new, new]. Truncating at limit=3 keeps that
-	// composition; the exact ids within a phase are shuffled, so assert the
+	// 3 new + 3 review cards. With the default ratio (new share 4 : review
+	// share 1) the interleave emits one review, then up to four new cards, so
+	// the first three slots are [review, new, new]. Truncating at limit=3 keeps
+	// that composition; the exact ids within a phase are shuffled, so assert the
 	// SHAPE (which slot is review vs new), not specific ids.
 	rows := []domain.DueCard{
 		learnDueCard("new-1", now.Add(-3*time.Hour), domain.FSRSStateNew),
@@ -285,6 +319,7 @@ func TestLearnUsecaseNextDueCards_TruncatesToDueLimit(t *testing.T) {
 	uc := NewLearnUsecase(
 		cardRepo,
 		&mockLearnCardgroupRepo{cardgroup: &domain.Cardgroup{ID: domain.CardgroupID("cg-1"), OwnerID: "u-1"}},
+		notFoundPrefs(),
 		service.NewOrderingPolicy(),
 		func() *rand.Rand { return rand.New(rand.NewSource(42)) },
 		20,
@@ -323,6 +358,7 @@ func TestLearnUsecaseNextDueCards_HappyPathReviewOnly(t *testing.T) {
 	uc := NewLearnUsecase(
 		cardRepo,
 		&mockLearnCardgroupRepo{cardgroup: &domain.Cardgroup{ID: domain.CardgroupID("cg-1"), OwnerID: "u-1"}},
+		notFoundPrefs(),
 		service.NewOrderingPolicy(),
 		func() *rand.Rand { return rand.New(rand.NewSource(7)) },
 		20,
@@ -337,6 +373,98 @@ func TestLearnUsecaseNextDueCards_HappyPathReviewOnly(t *testing.T) {
 	require.Len(t, got, 3, "result must contain exactly the requested limit")
 }
 
+// ratioRows returns 3 new + 3 review cards, the fixture used by the ratio tests.
+// The slot composition (review vs new) after Apply is deterministic; the ids
+// within a phase are shuffled, so tests assert membership, not order.
+func ratioRows(now time.Time) []domain.DueCard {
+	return []domain.DueCard{
+		learnDueCard("new-1", now.Add(-3*time.Hour), domain.FSRSStateNew),
+		learnDueCard("new-2", now.Add(-2*time.Hour), domain.FSRSStateNew),
+		learnDueCard("new-3", now.Add(-time.Hour), domain.FSRSStateNew),
+		learnDueCard("rev-1", now.Add(-6*time.Hour), domain.FSRSStateReview),
+		learnDueCard("rev-2", now.Add(-5*time.Hour), domain.FSRSStateReview),
+		learnDueCard("rev-3", now.Add(-4*time.Hour), domain.FSRSStateReview),
+	}
+}
+
+// TestLearnUsecaseNextDueCards_UsesStoredRatio verifies that a stored non-default
+// ratio (1/2) reaches OrderingPolicy.Apply: the 1:1 review-first interleave puts
+// review cards in the even slots and new cards in the odd slots, distinct from
+// the default 4:1 order [R,N,N,N,R,R].
+func TestLearnUsecaseNextDueCards_UsesStoredRatio(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 5, 13, 9, 0, 0, 0, time.UTC)
+	ratio, err := domain.ParseNewCardRatio(1, 2)
+	require.NoError(t, err)
+	prefs := &mockLearnUserPrefs{pref: &domain.UserPreference{
+		UserID:       domain.UserID("u-1"),
+		NewCardRatio: ratio,
+	}}
+	cardRepo := &mockLearnCardRepo{rows: ratioRows(now)}
+	uc := NewLearnUsecase(
+		cardRepo,
+		&mockLearnCardgroupRepo{cardgroup: &domain.Cardgroup{ID: domain.CardgroupID("cg-1"), OwnerID: "u-1"}},
+		prefs,
+		service.NewOrderingPolicy(),
+		func() *rand.Rand { return rand.New(rand.NewSource(42)) },
+		20,
+		100,
+		fixedClock{now: now},
+		newTestLogger(),
+	)
+
+	got, err := uc.NextDueCards(authedCtx("u-1"), "cg-1", learnIntPtr(6))
+
+	require.NoError(t, err)
+	require.Equal(t, 1, prefs.calls, "the stored preference must be read once")
+	require.Len(t, got, 6)
+	reviewSet := map[string]bool{"rev-1": true, "rev-2": true, "rev-3": true}
+	ids := learnCardIDs(got)
+	for i, id := range ids {
+		if i%2 == 0 {
+			require.True(t, reviewSet[id], "slot %d must be a review card, got %q", i, id)
+		} else {
+			require.False(t, reviewSet[id], "slot %d must be a new card, got %q", i, id)
+		}
+	}
+}
+
+// TestLearnUsecaseNextDueCards_ErrNotFoundUsesDefaultRatio verifies that a
+// missing preference row falls back to domain.DefaultNewCardRatio (4:1), yielding
+// the default [R,N,N,N,R,R] order for the 3-new/3-review fixture.
+func TestLearnUsecaseNextDueCards_ErrNotFoundUsesDefaultRatio(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 5, 13, 9, 0, 0, 0, time.UTC)
+	cardRepo := &mockLearnCardRepo{rows: ratioRows(now)}
+	uc := NewLearnUsecase(
+		cardRepo,
+		&mockLearnCardgroupRepo{cardgroup: &domain.Cardgroup{ID: domain.CardgroupID("cg-1"), OwnerID: "u-1"}},
+		notFoundPrefs(),
+		service.NewOrderingPolicy(),
+		func() *rand.Rand { return rand.New(rand.NewSource(42)) },
+		20,
+		100,
+		fixedClock{now: now},
+		newTestLogger(),
+	)
+
+	got, err := uc.NextDueCards(authedCtx("u-1"), "cg-1", learnIntPtr(6))
+
+	require.NoError(t, err)
+	require.Len(t, got, 6)
+	reviewSet := map[string]bool{"rev-1": true, "rev-2": true, "rev-3": true}
+	ids := learnCardIDs(got)
+	// Default 4:1 review-first: [R, N, N, N, R, R].
+	require.True(t, reviewSet[ids[0]], "slot 0 must be a review card, got %q", ids[0])
+	require.False(t, reviewSet[ids[1]], "slot 1 must be a new card, got %q", ids[1])
+	require.False(t, reviewSet[ids[2]], "slot 2 must be a new card, got %q", ids[2])
+	require.False(t, reviewSet[ids[3]], "slot 3 must be a new card, got %q", ids[3])
+	require.True(t, reviewSet[ids[4]], "slot 4 must be a review card, got %q", ids[4])
+	require.True(t, reviewSet[ids[5]], "slot 5 must be a review card, got %q", ids[5])
+}
+
 // --- PracticeTodaysCards tests ---
 
 // newPracticeUsecase builds a learnUsecase wired for practice-mode tests.
@@ -344,6 +472,7 @@ func newPracticeUsecase(cardRepo *mockLearnCardRepo, cgRepo *mockLearnCardgroupR
 	return NewLearnUsecase(
 		cardRepo,
 		cgRepo,
+		notFoundPrefs(),
 		service.NewOrderingPolicy(),
 		func() *rand.Rand { return rand.New(rand.NewSource(1)) },
 		20,
@@ -561,6 +690,7 @@ func TestLearnUsecase_NextDueCards_FindCardgroup_PropagatesCancelled(t *testing.
 	uc := NewLearnUsecase(
 		&mockLearnCardRepo{},
 		cgRepo,
+		notFoundPrefs(),
 		nil,
 		nil,
 		20,
@@ -583,6 +713,7 @@ func TestLearnUsecase_NextDueCards_FindDueCards_PropagatesDeadlineExceeded(t *te
 	uc := NewLearnUsecase(
 		cardRepo,
 		cgRepo,
+		notFoundPrefs(),
 		nil,
 		nil,
 		20,
@@ -592,6 +723,56 @@ func TestLearnUsecase_NextDueCards_FindDueCards_PropagatesDeadlineExceeded(t *te
 	)
 	_, err := uc.NextDueCards(authedCtx("u-1"), "cg-1", nil)
 	assertCancelled(t, err)
+}
+
+// TestLearnUsecaseNextDueCards_LoadUserPreferenceInternalError verifies that a
+// generic (non-context, non-ErrNotFound) error from the user-preference read is
+// wrapped with the usecase layer prefix rather than silently falling back to the
+// default ratio.
+func TestLearnUsecaseNextDueCards_LoadUserPreferenceInternalError(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 5, 13, 9, 0, 0, 0, time.UTC)
+	uc := NewLearnUsecase(
+		&mockLearnCardRepo{},
+		&mockLearnCardgroupRepo{cardgroup: &domain.Cardgroup{ID: domain.CardgroupID("cg-1"), OwnerID: "u-1"}},
+		&mockLearnUserPrefs{err: errors.New("db down")},
+		service.NewOrderingPolicy(),
+		func() *rand.Rand { return rand.New(rand.NewSource(1)) },
+		20,
+		100,
+		fixedClock{now: now},
+		newTestLogger(),
+	)
+
+	_, err := uc.NextDueCards(authedCtx("u-1"), "cg-1", learnIntPtr(5))
+
+	assertInternalChain(t, err, "usecase: learn: load user preference")
+}
+
+// TestLearnUsecaseNextDueCards_LoadUserPreferencePropagatesCancelled verifies that
+// context.Canceled from the user-preference read is propagated unwrapped, matching
+// the cardgroup/card repository context-done pass-through.
+func TestLearnUsecaseNextDueCards_LoadUserPreferencePropagatesCancelled(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 5, 13, 9, 0, 0, 0, time.UTC)
+	uc := NewLearnUsecase(
+		&mockLearnCardRepo{},
+		&mockLearnCardgroupRepo{cardgroup: &domain.Cardgroup{ID: domain.CardgroupID("cg-1"), OwnerID: "u-1"}},
+		&mockLearnUserPrefs{err: context.Canceled},
+		service.NewOrderingPolicy(),
+		func() *rand.Rand { return rand.New(rand.NewSource(1)) },
+		20,
+		100,
+		fixedClock{now: now},
+		newTestLogger(),
+	)
+
+	_, err := uc.NextDueCards(authedCtx("u-1"), "cg-1", learnIntPtr(5))
+
+	assertCancelled(t, err)
+	require.Equal(t, context.Canceled, err, "expected unwrapped context.Canceled, got %v", err)
 }
 
 // TestLearnUsecaseNextDueCards_PassesJSTStartOfDayAsReviewedBefore pins the
@@ -623,6 +804,7 @@ func TestLearnUsecaseNextDueCards_PassesJSTStartOfDayAsReviewedBefore(t *testing
 			uc := NewLearnUsecase(
 				cardRepo,
 				&mockLearnCardgroupRepo{cardgroup: &domain.Cardgroup{ID: domain.CardgroupID("cg-1"), OwnerID: "u-1"}},
+				notFoundPrefs(),
 				service.NewOrderingPolicy(),
 				func() *rand.Rand { return rand.New(rand.NewSource(1)) },
 				20,
@@ -645,6 +827,7 @@ func TestLearnUsecase_DefaultIfNew(t *testing.T) {
 	uc := NewLearnUsecase(
 		&mockLearnCardRepo{},
 		&mockLearnCardgroupRepo{},
+		notFoundPrefs(),
 		service.NewOrderingPolicy(),
 		func() *rand.Rand { return rand.New(rand.NewSource(1)) },
 		20,

--- a/docs/backend/ddd-patterns/discovery-first-due-ordering.md
+++ b/docs/backend/ddd-patterns/discovery-first-due-ordering.md
@@ -40,7 +40,7 @@ deterministic while the database does the sampling:
 | Stage | Owner | Behaviour |
 |---|---|---|
 | Selection (which rows enter each window) | `repository.FindDueCardsForUser` | Two independent `LIMIT` windows: a review window (`due <= now AND last_review < reviewedBefore`, ordered learning-phase-first via a `CASE` then `random()`) concatenated with a new window (no FSRS row, ordered by `random()`). |
-| Arrangement (order within the batch) | `service.OrderingPolicy.Apply` | Injected `*rand.Rand` shuffles the new partition fully and the review partition within same-phase runs; then interleaves at `NewCardRatio=4 : ReviewCardRatio=1` with review-first emission. |
+| Arrangement (order within the batch) | `service.OrderingPolicy.Apply` | Injected `*rand.Rand` shuffles the new partition fully and the review partition within same-phase runs; then interleaves at the caller-supplied ratio (`domain.DefaultNewCardRatio` = 4:1 absent a stored preference) with review-first emission. |
 | Truncation | `usecase.LearnUsecase.NextDueCards` | Caps the interleaved result to the session limit (`ordered[:n]`), yielding the 16/4 split for a 20-card request. |
 
 `random()` runs in Postgres and cannot be seeded from Go, so it decides only
@@ -82,7 +82,8 @@ learn ordering — new cards are sampled randomly, not walked in document order.
 
 - `backend/internal/domain/fsrs_state.go` — `FSRSCardState.IsLearningPhase()`.
 - `backend/internal/domain/service/due_card_ordering.go` — `OrderingPolicy.Apply`,
-  `shuffleWithinPhase`, `interleave`, `NewCardRatio` / `ReviewCardRatio`.
+  `shuffleWithinPhase`, `interleave` (new/review shares supplied by the caller's ratio).
+- `backend/internal/domain/new_card_ratio.go` — `NewCardRatio` VO, `DefaultNewCardRatio` (4/5, the default 4:1 interleave).
 - `backend/internal/repository/card.go` — `FindDueCardsForUser`, `findDueCardsOn`,
   `dueRowsOn` (the two-window selection).
 - `backend/internal/usecase/learn.go` — `startOfDayJST`, `LearnUsecase.NextDueCards`

--- a/docs/backend/library-gotchas/inject-rand-rand-for-deterministic-test.md
+++ b/docs/backend/library-gotchas/inject-rand-rand-for-deterministic-test.md
@@ -14,15 +14,17 @@ pass a fixed seed and can assert an exact output order.
 //
 //  1. The new partition is fully shuffled; the review partition is shuffled
 //     within same-phase runs (shuffleWithinPhase) using rng.
-//  2. New and review cards are interleaved at NewCardRatio:ReviewCardRatio.
+//  2. New and review cards are interleaved at the caller-supplied ratio
+//     (ratio.NewShare new per ratio.ReviewShare review), review-first.
 //
 // rng must be non-nil. Tests inject a seeded *rand.Rand for deterministic
-// order; production constructs one per session.
-func (p *OrderingPolicy) Apply(due []domain.DueCard, rng *rand.Rand) []*domain.Card {
+// order; production constructs one per session. ratio is the per-user
+// new-vs-review interleave ratio (domain.NewCardRatio).
+func (p *OrderingPolicy) Apply(due []domain.DueCard, rng *rand.Rand, ratio domain.NewCardRatio) []*domain.Card {
     if rng == nil {
         panic("domain/service: OrderingPolicy.Apply requires non-nil rng")
     }
-    // ... partition, shuffleWithinPhase, interleave ...
+    // ... partition, shuffleWithinPhase, interleave(newCards, reviewCards, ratio.NewShare(), ratio.ReviewShare()) ...
 }
 ```
 


### PR DESCRIPTION
## Summary

Makes the new-vs-review interleave ratio for a learn session **per-user**, as the foundation half of a 2-PR backend split. This PR introduces the rational `domain.NewCardRatio` value object and wires `LearnUsecase.NextDueCards` to read the caller's stored ratio before ordering — but keeps the column default at `4/5`, so every user's queue order is byte-for-byte unchanged. The write path (`updateNewCardRatio` mutation + `User.newCardRatio`) is PR-B (#815); no row can hold a non-default ratio yet.

## Changes

### Rational value object

- New `backend/internal/domain/new_card_ratio.go`: `NewCardRatio` holds an irreducible fraction `num/den` reduced via `math/big` GCD. `ParseNewCardRatio` enforces `1 ≤ num < den ≤ 100` and `gcd(num,den)=1`; `DefaultNewCardRatio = 4/5`. Because both `NewShare()` (`num`) and `ReviewShare()` (`den-num`) are `≥ 1` by construction, `interleave`'s positive-ratio panic guard needs no contract change. `Numerator`/`Denominator` expose the reduced fraction for persistence; `IsZero` marks the invalid zero value that read paths treat as "use the default".

### Ordering service + usecase read path

- `domain/service/due_card_ordering.go`: deleted the package-level `NewCardRatio`/`ReviewCardRatio` constants; `OrderingPolicy.Apply` now takes `ratio domain.NewCardRatio` and interleaves at `ratio.NewShare() : ratio.ReviewShare()`. `interleave` itself is unchanged.
- `usecase/learn.go`: added the narrow `UserPrefsForLearn` consumer interface and a `userPrefs` constructor parameter (nil-checked). `NextDueCards` loads the ratio before `Apply` — missing row (`ErrNotFound`), nil pref, or zero-value all fall back to the default; a real infra error is wrapped `usecase: learn: load user preference`, context-done passed through unwrapped. `PracticeTodaysCards` is untouched (it never orders).
- All 21 `NewLearnUsecase` call sites updated (`cmd/server/main.go` passes `repos.userPreference`; test stubs return `ErrNotFound` to preserve existing assertions).

### Persistence

- Migration `20260705000000_add_new_card_ratio_to_user_preferences.{up,down}.sql`: adds `new_card_ratio_num/den` (`NOT NULL DEFAULT 4/5`) with a `CHECK (num >= 1 AND num < den AND den <= 100)` backstop for direct DB writes.
- `repository/user_preference.go`: reads the two columns and converts via `ParseNewCardRatio`, falling back non-fatally to `DefaultNewCardRatio` (same posture as the sibling `LearnDisplayMode` read). No write method (that is PR-B).

### Tests + docs

- New `new_card_ratio_test.go` (reduction, bound rejection, default, shares, `IsZero`); `due_card_ordering_test.go` threads the ratio through every `Apply` and adds a non-default 1:1 case; `learn_test.go` adds a stored-ratio case, `ErrNotFound → default`, a generic-error wrap-chain case, and a context-done pass-through case. `Rat()` was dropped from the VO (zero callers).
- Refreshed the three docs that referenced the deleted constants (`ddd-patterns.md` rule + `discovery-first-due-ordering.md` + `inject-rand-rand-for-deterministic-test.md`) to the new `ratio domain.NewCardRatio` shape.
- Migration down/up roundtrip `m.Steps(-N)` counts bumped for the new 14th migration.

## Verification

- Behaviour-preserving: every user's `new_card_ratio = 4/5` (column default) → new share 4 / review share 1 → interleave 4:1, identical to the deleted constants. Confirm `learnNextDueCards` ordering is unchanged for an existing user.
- `grep -rn 'service\.NewCardRatio\|service\.ReviewCardRatio' backend/ docs/ .claude/rules/` returns nothing.

## Test plan

- [ ] `go build ./...` && `go vet ./...` — clean.
- [ ] `go tool go-arch-lint check --project-path .` — no warnings (domain imports neither usecase nor repository).
- [ ] `go test ./internal/domain/... ./internal/usecase/...` — pass.
- [ ] Migration roundtrip suite (Docker-gated, CI): `m.Steps(-N)` counts updated for the new migration.

## Dependency order

Base of a strict 3-PR chain — **#814 (this) → #815 → #816 (frontend)**. Merge in that order; #815 branches on top of this PR.

Closes #814
