### PR TITLE
ci: push autofix commits with a GitHub App token instead of AUTOFIX_PAT

### DIFF
--- a/.github/workflows/autofix-backend-generated.yml
+++ b/.github/workflows/autofix-backend-generated.yml
@@ -18,12 +18,30 @@ name: Autofix backend generated artifacts
 #
 # Token requirement (one-time operator setup)
 # -------------------------------------------
-# The commit is pushed with AUTOFIX_PAT, NOT the default GITHUB_TOKEN. A push made
-# with GITHUB_TOKEN does not trigger new workflow runs, so the required backend CI
-# check would never run on the new head SHA and the PR would stay unmergeable.
-# AUTOFIX_PAT must be a fine-grained Personal Access Token scoped to this repo with
-# "Contents: Read and write" permission, stored as the repository secret
-# AUTOFIX_PAT. Without it the workflow fails fast with an explanatory message.
+# The commit is pushed with a GitHub App installation token, NOT the default
+# GITHUB_TOKEN. A push made with GITHUB_TOKEN does not trigger new workflow
+# runs, so the required backend CI check would never run on the new head SHA
+# and the PR would stay unmergeable. A GitHub App is used instead of a PAT
+# because the app's private key never expires and the app belongs to the
+# repository, not to a human account; the short-lived installation token is
+# minted fresh on every run and is scoped to this repository only.
+#
+# One-time app registration (web UI; GitHub has no API for this):
+#   1. Settings > Developer settings > GitHub Apps > New GitHub App.
+#      - GitHub App name: flamingo-armond-autofix (any unique name works)
+#      - Homepage URL: this repository's URL
+#      - Webhook: uncheck "Active"
+#      - Repository permissions: Contents = Read and write (nothing else)
+#      - Where can this GitHub App be installed: Only on this account
+#   2. On the app's settings page: note the Client ID and generate a
+#      private key (a .pem file downloads).
+#   3. Install App > Only select repositories > this repository.
+#   4. Register the credentials on this repository - either run
+#        ansible-playbook -i playbooks/inventory.local playbooks/setup-prod.yml --tags autofix-app
+#      or set them manually:
+#        - repository variable AUTOFIX_APP_CLIENT_ID  = the app's Client ID
+#        - repository secret   AUTOFIX_APP_PRIVATE_KEY = the .pem file contents
+# Without these the workflow fails fast with an explanatory message.
 
 on:
   pull_request:
@@ -35,8 +53,10 @@ on:
       - '.tool-versions'
       - 'mise.toml'
 
+# The push uses the app installation token, so the default GITHUB_TOKEN only
+# needs read access for checkout/tool downloads.
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: autofix-backend-${{ github.head_ref }}
@@ -46,28 +66,39 @@ jobs:
   autofix:
     name: Regenerate go.sum & gqlgen artifacts
     # Same-repo branches only (Renovate and local feature branches). Never run the
-    # PAT-authenticated push for fork PRs - that would expose write credentials to
-    # untrusted code.
+    # app-token-authenticated push for fork PRs - that would expose write
+    # credentials to untrusted code.
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-24.04
     steps:
-      - name: Fail fast if AUTOFIX_PAT is missing
+      - name: Fail fast if GitHub App credentials are missing
         env:
-          AUTOFIX_PAT: ${{ secrets.AUTOFIX_PAT }}
+          CLIENT_ID: ${{ vars.AUTOFIX_APP_CLIENT_ID }}
+          PRIVATE_KEY: ${{ secrets.AUTOFIX_APP_PRIVATE_KEY }}
         run: |
-          if [ -z "$AUTOFIX_PAT" ]; then
-            echo "::error::AUTOFIX_PAT secret is not set. Create a fine-grained PAT" \
-                 "(Contents: Read and write on this repo) and add it as the" \
-                 "AUTOFIX_PAT repository secret. See the header of this workflow file."
+          if [ -z "$CLIENT_ID" ] || [ -z "$PRIVATE_KEY" ]; then
+            echo "::error::AUTOFIX_APP_CLIENT_ID repository variable or" \
+                 "AUTOFIX_APP_PRIVATE_KEY repository secret is not set. Register the" \
+                 "autofix GitHub App and its credentials - see the header of this" \
+                 "workflow file, or run: ansible-playbook -i playbooks/inventory.local" \
+                 "playbooks/setup-prod.yml --tags autofix-app"
             exit 1
           fi
+
+      - name: Mint GitHub App installation token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.AUTOFIX_APP_CLIENT_ID }}
+          private-key: ${{ secrets.AUTOFIX_APP_PRIVATE_KEY }}
+          # owner/repositories omitted: the token is scoped to this repository only.
 
       - name: Checkout PR branch
         uses: actions/checkout@v7
         with:
           ref: ${{ github.head_ref }}
-          # PAT so the auto-commit re-triggers the required backend CI on the new SHA.
-          token: ${{ secrets.AUTOFIX_PAT }}
+          # App token so the auto-commit re-triggers the required backend CI on the new SHA.
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Set up mise (Go from .tool-versions)
         uses: jdx/mise-action@v4
@@ -83,17 +114,23 @@ jobs:
         run: go tool gqlgen generate
 
       - name: Commit and push if anything changed
-        # HEAD_REF is read via env (not inline ${{ }}) so a crafted branch name
-        # cannot inject into the shell command.
+        # HEAD_REF and APP_SLUG are read via env (not inline ${{ }}) so crafted
+        # values cannot inject into the shell command.
         env:
           HEAD_REF: ${{ github.head_ref }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           if [ -z "$(git status --porcelain)" ]; then
             echo "Generated artifacts already current - nothing to commit."
             exit 0
           fi
-          git config user.name  "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # Commit as the app's bot user (identity convention documented by
+          # actions/create-github-app-token). The lookup fails the step loudly
+          # if the app slug cannot be resolved.
+          BOT_USER_ID="$(gh api "/users/${APP_SLUG}[bot]" --jq .id)"
+          git config user.name  "${APP_SLUG}[bot]"
+          git config user.email "${BOT_USER_ID}+${APP_SLUG}[bot]@users.noreply.github.com"
           # gitignored outputs (graph/generated, graph/model) are excluded by add -A;
           # only go.mod, go.sum and graph/resolver/*.resolvers.go are tracked.
           git add -A

--- a/playbooks/setup-prod.yml
+++ b/playbooks/setup-prod.yml
@@ -12,6 +12,7 @@
 #   ansible-playbook playbooks/setup-prod.yml --tags loopback
 #   ansible-playbook playbooks/setup-prod.yml --tags postapply
 #   ansible-playbook playbooks/setup-prod.yml --tags seed-admin-prod
+#   ansible-playbook playbooks/setup-prod.yml --tags autofix-app
 #
 # Tag map:
 #   preflight       -> Phase 1  (pre-bring-up token/app scanner)
@@ -22,6 +23,8 @@
 #   postapply       -> Phase 6  (post-bring-up deploy kick + smoke)
 #   supabase-hooks  -> Phase 7  (enable custom_access_token hook via Management API)
 #   seed-admin-prod -> one-shot admin promotion from SUPER_USER_EMAILS (re-runnable)
+#   autofix-app     -> one-shot GitHub App credential registration for the
+#                      autofix-backend-generated workflow (re-runnable)
 #
 # supabase.yml is imported twice with different `step` vars so that
 # --tags supabase runs only Phase 2 and --tags loopback runs only Phase 5.
@@ -74,3 +77,7 @@
     - name: Seed admin role from SUPER_USER_EMAILS in production DB
       ansible.builtin.import_tasks: setup-prod/seed-admin-prod.yml
       tags: [seed-admin-prod, never]
+
+    - name: Register autofix GitHub App credentials (repository variable + secret)
+      ansible.builtin.import_tasks: setup-prod/autofix-app.yml
+      tags: [autofix-app, never]

--- a/playbooks/setup-prod/autofix-app.yml
+++ b/playbooks/setup-prod/autofix-app.yml
@@ -1,0 +1,193 @@
+---
+# One-shot: register the GitHub App credentials used by the
+# autofix-backend-generated workflow.
+#
+# The workflow (.github/workflows/autofix-backend-generated.yml) pushes
+# regenerated go.sum / gqlgen artifacts back to backend dependency PR branches
+# with a GitHub App installation token. This task file registers the app's
+# credentials on the repository:
+#   AUTOFIX_APP_CLIENT_ID   -- repository VARIABLE (not sensitive, readable back)
+#   AUTOFIX_APP_PRIVATE_KEY -- repository SECRET (contents of the app's .pem)
+#
+# The app itself must be registered by hand first (GitHub has no API for app
+# registration); the checklist lives in the workflow file header. Short form:
+# Settings > Developer settings > GitHub Apps > New GitHub App; webhook Active
+# unchecked; Repository permissions Contents = Read and write only; install on
+# this repository only; then generate a private key (.pem downloads) and note
+# the Client ID.
+#
+# Invocation (opt-in via tag; never runs as part of an untagged bring-up):
+#   ansible-playbook -i playbooks/inventory.local playbooks/setup-prod.yml --tags autofix-app
+#
+# Idempotency mirrors the RENDER_DEPLOY_HOOK_URL pattern in render.yml:
+# existence is checked first, prompts offer "press Enter to keep", and the
+# private key is streamed to gh via stdin so it never appears in argv or logs.
+
+# --- Existence checks (names only; safe to log) ---
+- name: Check whether AUTOFIX_APP_CLIENT_ID variable already exists
+  ansible.builtin.shell:
+    cmd: gh variable get AUTOFIX_APP_CLIENT_ID --repo {{ repo }}
+  register: _autofix_client_id_check
+  changed_when: false
+  failed_when: false
+
+- name: Check whether AUTOFIX_APP_PRIVATE_KEY secret already exists
+  ansible.builtin.shell:
+    cmd: gh secret list --repo {{ repo }} --json name -q '[.[] | select(.name == "AUTOFIX_APP_PRIVATE_KEY")] | length'
+  register: _autofix_key_check
+  changed_when: false
+  failed_when: false
+
+- name: Determine autofix credential presence
+  ansible.builtin.set_fact:
+    autofix_client_id_registered: "{{ _autofix_client_id_check.rc == 0 }}"
+    autofix_key_registered: "{{ (_autofix_key_check.rc == 0) and ((_autofix_key_check.stdout | default('0') | trim | int) > 0) }}"
+
+# --- Collect Client ID (not a secret; the app page shows it openly) ---
+- name: Prompt for the autofix GitHub App Client ID
+  ansible.builtin.pause:
+    prompt: |-
+      Client ID of the autofix GitHub App (shown on the app's settings page,
+      Settings > Developer settings > GitHub Apps > your app).
+
+      Client ID [current: {{ '(registered in GitHub; press Enter to keep)' if autofix_client_id_registered else '(not registered yet)' }}]
+  register: _autofix_client_id_input
+
+- name: Store autofix_client_id fact (empty if keeping existing variable)
+  ansible.builtin.set_fact:
+    autofix_client_id: "{{ _autofix_client_id_input.user_input | default('') | trim }}"
+
+- name: Require Client ID on first run
+  ansible.builtin.fail:
+    msg: |
+      AUTOFIX_APP_CLIENT_ID is not yet registered and no value was provided.
+      Copy the Client ID from the app's settings page, then re-run:
+        ansible-playbook -i playbooks/inventory.local playbooks/setup-prod.yml --tags autofix-app
+  when:
+    - (autofix_client_id | length) == 0
+    - not autofix_client_id_registered
+
+- name: Validate Client ID format
+  ansible.builtin.assert:
+    that:
+      - autofix_client_id is match('^\S+$')
+    fail_msg: |
+      The Client ID must be a single token without whitespace. Copy it verbatim
+      from the app's settings page.
+  when: (autofix_client_id | length) > 0
+
+# --- Collect private key .pem path (path prompt; multi-line paste is fragile) ---
+- name: Prompt for the autofix GitHub App private key (.pem) path
+  ansible.builtin.pause:
+    prompt: |-
+      Path to the app's private key .pem file (downloaded from the app's
+      settings page via "Generate a private key").
+
+      .pem path [current: {{ '(key registered in GitHub; press Enter to keep)' if autofix_key_registered else '(not registered yet)' }}]
+  register: _autofix_pem_input
+
+- name: Store autofix_pem_path fact (empty if keeping existing secret)
+  ansible.builtin.set_fact:
+    autofix_pem_path: "{{ _autofix_pem_input.user_input | default('') | trim | expanduser }}"
+
+- name: Require private key on first run
+  ansible.builtin.fail:
+    msg: |
+      AUTOFIX_APP_PRIVATE_KEY is not yet registered and no .pem path was
+      provided. Generate a private key on the app's settings page (a .pem file
+      downloads), then re-run:
+        ansible-playbook -i playbooks/inventory.local playbooks/setup-prod.yml --tags autofix-app
+  when:
+    - (autofix_pem_path | length) == 0
+    - not autofix_key_registered
+
+- name: Stat the .pem file
+  ansible.builtin.stat:
+    path: "{{ autofix_pem_path }}"
+  register: _autofix_pem_stat
+  when: (autofix_pem_path | length) > 0
+
+- name: Validate the .pem file exists and looks like a private key
+  ansible.builtin.shell:
+    cmd: head -n 1 {{ autofix_pem_path | quote }} | grep -q -- '-----BEGIN .*PRIVATE KEY-----'
+  register: _autofix_pem_header
+  changed_when: false
+  failed_when: false
+  when: (autofix_pem_path | length) > 0
+
+- name: Fail if the .pem path is not a GitHub App private key
+  ansible.builtin.fail:
+    msg: |
+      '{{ autofix_pem_path }}' {{ 'does not exist' if not (_autofix_pem_stat.stat.exists | default(false)) else 'does not start with a PEM private-key header' }}.
+      Point at the .pem file downloaded from the app's settings page.
+  when:
+    - (autofix_pem_path | length) > 0
+    - (not (_autofix_pem_stat.stat.exists | default(false))) or (_autofix_pem_header.rc != 0)
+
+# --- Register Client ID as a repository variable ---
+- name: Register AUTOFIX_APP_CLIENT_ID as a GitHub Actions variable
+  ansible.builtin.shell:
+    cmd: gh variable set AUTOFIX_APP_CLIENT_ID --repo {{ repo }}
+    stdin: "{{ autofix_client_id }}"
+    stdin_add_newline: false
+  register: _gh_autofix_client_id_result
+  failed_when: false
+  changed_when: _gh_autofix_client_id_result.rc == 0
+  when: (autofix_client_id | length) > 0
+
+- name: Fail with remediation if gh variable set failed
+  ansible.builtin.fail:
+    msg: |
+      gh variable set AUTOFIX_APP_CLIENT_ID failed (rc={{ _gh_autofix_client_id_result.rc }}).
+
+      gh diagnostic:
+        stderr: {{ _gh_autofix_client_id_result.stderr | default('(none)') }}
+        stdout: {{ _gh_autofix_client_id_result.stdout | default('(none)') }}
+
+      Common causes:
+        - gh CLI lost the `repo` write scope. Re-run:
+            gh auth refresh -s repo
+        - GitHub API rate limit. Wait a minute and retry.
+        - `repo` var is wrong / repo not found. Verify {{ repo }} is correct.
+
+      Then retry: ansible-playbook -i playbooks/inventory.local playbooks/setup-prod.yml --tags autofix-app
+  when:
+    - (autofix_client_id | length) > 0
+    - _gh_autofix_client_id_result.rc != 0
+
+# --- Register private key as a repository secret ---
+# The shell redirect streams the pem straight from disk into gh: the key body
+# never enters an Ansible variable, argv, or the log (belt and braces: no_log).
+- name: Register AUTOFIX_APP_PRIVATE_KEY as a GitHub Actions secret
+  ansible.builtin.shell:
+    cmd: gh secret set AUTOFIX_APP_PRIVATE_KEY --repo {{ repo }} < {{ autofix_pem_path | quote }}
+  register: _gh_autofix_key_result
+  no_log: true
+  failed_when: false
+  changed_when: _gh_autofix_key_result.rc == 0
+  when: (autofix_pem_path | length) > 0
+
+- name: Fail with remediation if gh secret set failed
+  ansible.builtin.fail:
+    msg: |
+      gh secret set AUTOFIX_APP_PRIVATE_KEY failed (rc={{ _gh_autofix_key_result.rc }}).
+
+      Common causes:
+        - gh CLI lost the `repo` write scope. Re-run:
+            gh auth refresh -s repo
+        - GitHub API rate limit. Wait a minute and retry.
+        - `repo` var is wrong / repo not found. Verify {{ repo }} is correct.
+
+      Then retry: ansible-playbook -i playbooks/inventory.local playbooks/setup-prod.yml --tags autofix-app
+  when:
+    - (autofix_pem_path | length) > 0
+    - _gh_autofix_key_result.rc != 0
+
+- name: Confirm autofix GitHub App credentials registered
+  ansible.builtin.debug:
+    msg: |
+      Autofix GitHub App credentials are registered on {{ repo }}
+      (AUTOFIX_APP_CLIENT_ID variable, AUTOFIX_APP_PRIVATE_KEY secret).
+      Next: re-fire the pull_request event on any red backend dependency PR
+      (close/reopen it, or let Renovate rebase) and the autofix workflow will
+      push the regenerated artifacts.


### PR DESCRIPTION
## Summary

- The autofix-backend-generated workflow pushes regenerated `go.sum` / gqlgen artifacts back to backend dependency PR branches. It authenticated with a fine-grained PAT (`AUTOFIX_PAT`), which was never registered — the workflow fails fast on every Renovate backend PR (see #822) — and a PAT expires and belongs to a human account rather than to the repository.
- Replace the PAT with a repository-scoped GitHub App: `actions/create-github-app-token@v3` mints a short-lived installation token per run from the `AUTOFIX_APP_CLIENT_ID` repository variable + `AUTOFIX_APP_PRIVATE_KEY` repository secret. The app's private key never expires, and (unlike `GITHUB_TOKEN`) pushes made with the app token re-trigger the required backend CI on the new head SHA.
- The auto-commit is now authored as the app's bot user, and the workflow's default `GITHUB_TOKEN` permission drops from `contents: write` to `contents: read` since the push no longer uses it.
- New opt-in Ansible one-shot (`playbooks/setup-prod/autofix-app.yml`, tag `autofix-app`, `never`-tagged so untagged bring-up runs skip it) registers the credentials idempotently, mirroring the `RENDER_DEPLOY_HOOK_URL` pattern in `render.yml`: existence check, press-Enter-to-keep prompts, .pem-path input streamed to `gh secret set` via stdin.

## Operator setup (one-time, after merge)

1. Register the GitHub App in the web UI (checklist in the workflow header): webhook off, Repository permissions = Contents: Read and write only, install on this repository only; generate a private key (.pem) and note the Client ID.
2. `ansible-playbook -i playbooks/inventory.local playbooks/setup-prod.yml --tags autofix-app`
3. Re-fire the `pull_request` event on the red Renovate backend PR (close/reopen) and watch it self-heal.

## Test plan

- `actionlint` clean. (Its bundled input schema for `create-github-app-token` predates v3's `client-id` input and flags it; verified `client-id` exists and `app-id` is deprecated in v3's `action.yml`.)
- `ansible-playbook --syntax-check` passes; `--list-tasks --tags autofix-app` selects exactly the new tasks and an untagged run selects none of them.
- `grep -rn AUTOFIX_PAT` over the tree returns nothing.
- End-to-end verification happens after app registration: close/reopen the open Renovate backend PR and confirm the autofix commit lands and backend CI re-runs green.

No linked issue — one-time CI hardening; the failure it fixes is visible on any open Renovate backend dependency PR (e.g. #822).
