### PR TITLE
fix(frontend): stop admin-only newCardRatio from crashing /profile

### DIFF
--- a/frontend/src/app/profile/page.test.tsx
+++ b/frontend/src/app/profile/page.test.tsx
@@ -57,8 +57,13 @@ function makeMeData(opts: { displayName?: string; bio?: string } = {}) {
       displayName: opts.displayName ?? "Test User",
       bio: opts.bio ?? "My bio",
       avatarUrl: null,
+      learnDisplayMode: "FLIP_TO_REVEAL",
     },
   };
+}
+
+function makeRatioData(numerator: number, denominator: number) {
+  return { me: { id: "u-1", newCardRatio: { numerator, denominator } } };
 }
 
 function setAuthHeaders(status: string, email?: string | null) {
@@ -67,6 +72,16 @@ function setAuthHeaders(status: string, email?: string | null) {
     h.set("x-user-email", email);
   }
   vi.mocked(headers).mockResolvedValue(h as Awaited<ReturnType<typeof headers>>);
+}
+
+function setAdminAuthHeaders(email = "admin@test.com") {
+  vi.mocked(headers).mockResolvedValue(
+    new Headers({
+      "x-auth-status": "authenticated",
+      "x-user-email": email,
+      "x-user-is-admin": "true",
+    }) as Awaited<ReturnType<typeof headers>>,
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -234,12 +249,92 @@ describe("ProfilePage — happy path", () => {
 });
 
 // ---------------------------------------------------------------------------
+// newCardRatio: admin-only, failure-tolerant secondary fetch
+// ---------------------------------------------------------------------------
+
+describe("ProfilePage — newCardRatio (admin-only, failure-tolerant)", () => {
+  test("non-admin → newCardRatio is not fetched; only the core query runs", async () => {
+    // Default beforeEach headers are authenticated but NOT admin.
+    vi.mocked(gqlFetch).mockResolvedValueOnce(makeMeData() as never);
+
+    const result = await ProfilePage();
+
+    // Exactly one gqlFetch: the core Me query. The ratio query is skipped.
+    expect(gqlFetch).toHaveBeenCalledTimes(1);
+    const el = findProfileFormElement(result);
+    expect(el?.props.isAdmin).toBe(false);
+  });
+
+  test("admin → newCardRatio fetched via a second query and forwarded", async () => {
+    setAdminAuthHeaders();
+    vi.mocked(gqlFetch)
+      .mockResolvedValueOnce(makeMeData() as never) // core Me query
+      .mockResolvedValueOnce(makeRatioData(3, 4) as never); // MeNewCardRatio query
+
+    const result = await ProfilePage();
+
+    expect(gqlFetch).toHaveBeenCalledTimes(2);
+    const el = findProfileFormElement(result);
+    expect(el?.props.isAdmin).toBe(true);
+    expect(el?.props.newCardRatio).toEqual({ numerator: 3, denominator: 4 });
+  });
+
+  test("admin → newCardRatio fetch failure degrades to the default; profile still renders", async () => {
+    setAdminAuthHeaders();
+    vi.mocked(gqlFetch)
+      .mockResolvedValueOnce(makeMeData() as never) // core Me query succeeds
+      .mockRejectedValueOnce(
+        // Simulates a backend that cannot serve newCardRatio yet (schema desync).
+        new Error(
+          `GraphQL errors: ${JSON.stringify([
+            { message: 'Cannot query field "newCardRatio" on type "User".' },
+          ])}`,
+        ),
+      );
+
+    const result = await ProfilePage();
+
+    // The page does NOT throw and does NOT redirect — the failure is swallowed.
+    expect(redirect).not.toHaveBeenCalled();
+    const el = findProfileFormElement(result);
+    // Falls back to the backend default ratio (4/5).
+    expect(el?.props.newCardRatio).toEqual({ numerator: 4, denominator: 5 });
+    // The degradation is logged for operator triage, name-only (PII redaction).
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("[profile] newCardRatio fetch failed"),
+      { name: "Error" },
+    );
+  });
+
+  test("admin → newCardRatio UNAUTHENTICATED redirects to /login (session expired mid-request)", async () => {
+    setAdminAuthHeaders();
+    vi.mocked(gqlFetch)
+      .mockResolvedValueOnce(makeMeData() as never) // core Me query succeeds
+      .mockRejectedValueOnce(
+        // A genuine UNAUTHENTICATED (not a schema-desync validation error) still
+        // redirects, preserving the repo-wide auth-gated-RSC invariant.
+        new Error(
+          `GraphQL errors: ${JSON.stringify([{ extensions: { code: "UNAUTHENTICATED" } }])}`,
+        ),
+      );
+
+    await expect(ProfilePage()).rejects.toThrow(`${REDIRECT_PREFIX}/login`);
+
+    expect(redirect).toHaveBeenCalledWith("/login");
+    // The redirect path is taken before the degrade-and-log branch.
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // JSX tree helpers
 // ---------------------------------------------------------------------------
 
 type ProfileFormProps = {
   email: string | null;
   initial: { displayName: string; bio: string };
+  isAdmin: boolean;
+  newCardRatio: { numerator: number; denominator: number };
 };
 
 /**

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -10,6 +10,9 @@ import { ProfilePageClient } from "./profile-page-client";
 
 export const metadata: Metadata = { title: "Profile" };
 
+// Core profile every viewer needs. Deliberately excludes newCardRatio: that
+// field backs only the admin-only slider, so its availability must never gate
+// the core profile load. It is fetched separately in MeNewCardRatioQuery below.
 const MeQuery = graphql(`
   query Me {
     me {
@@ -18,6 +21,19 @@ const MeQuery = graphql(`
       bio
       avatarUrl
       learnDisplayMode
+    }
+  }
+`);
+
+// newCardRatio backs the admin-only new-card-ratio slider. It is fetched
+// separately, and only for admins, so a backend that cannot yet serve the field
+// — e.g. during a rolling deploy where the frontend ships this query before the
+// backend serves it — degrades the slider to its default instead of crashing
+// the whole /profile page for every user.
+const MeNewCardRatioQuery = graphql(`
+  query MeNewCardRatio {
+    me {
+      id
       newCardRatio {
         numerator
         denominator
@@ -25,6 +41,10 @@ const MeQuery = graphql(`
     }
   }
 `);
+
+// Mirrors domain.DefaultNewCardRatio on the backend: 4/5 = 80% new cards. Used
+// when the caller is an admin but the ratio fetch fails.
+const DEFAULT_NEW_CARD_RATIO = { numerator: 4, denominator: 5 };
 
 export default async function ProfilePage() {
   const auth = readAuthContext(await headers());
@@ -46,6 +66,29 @@ export default async function ProfilePage() {
     throw new Error("/profile: me returned null with no error");
   }
 
+  // The admin-only ratio is a secondary, optional fetch. A genuine
+  // UNAUTHENTICATED (session expired between the two fetches) still redirects to
+  // /login, keeping the repo-wide auth-gated-RSC invariant. Any OTHER failure —
+  // notably a backend that cannot serve the field yet (schema desync raises a
+  // validation error, not UNAUTHENTICATED) — degrades the slider to the default
+  // so the core profile above stays up instead of crashing for every user.
+  let newCardRatio: { numerator: number; denominator: number } = DEFAULT_NEW_CARD_RATIO;
+  if (auth.isAdmin) {
+    try {
+      const ratioData = await gqlFetch(MeNewCardRatioQuery, { revalidate: 0 });
+      if (ratioData.me?.newCardRatio) {
+        newCardRatio = ratioData.me.newCardRatio;
+      }
+    } catch (err) {
+      if (isUnauthenticatedGraphQLError(err)) {
+        redirect("/login");
+      }
+      console.error("[profile] newCardRatio fetch failed; using default:", {
+        name: err instanceof Error ? err.name : "unknown",
+      });
+    }
+  }
+
   return (
     <ProfilePageClient
       email={auth.email}
@@ -54,7 +97,7 @@ export default async function ProfilePage() {
         bio: data.me.bio ?? "",
       }}
       displayMode={data.me.learnDisplayMode}
-      newCardRatio={data.me.newCardRatio}
+      newCardRatio={newCardRatio}
       isAdmin={auth.isAdmin}
     />
   );

--- a/frontend/src/app/profile/profile-page-client.test.tsx
+++ b/frontend/src/app/profile/profile-page-client.test.tsx
@@ -91,7 +91,7 @@ describe("<ProfilePageClient>", () => {
           email="alice@example.com"
           initial={initial}
           displayMode="FLIP_TO_REVEAL"
-          newCardRatio={{ __typename: "NewCardRatio", numerator: 4, denominator: 5 }}
+          newCardRatio={{ numerator: 4, denominator: 5 }}
           isAdmin={false}
         />
       </MockedProvider>,
@@ -115,7 +115,7 @@ describe("<ProfilePageClient>", () => {
           email="alice@example.com"
           initial={initial}
           displayMode="FLIP_TO_REVEAL"
-          newCardRatio={{ __typename: "NewCardRatio", numerator: 4, denominator: 5 }}
+          newCardRatio={{ numerator: 4, denominator: 5 }}
           isAdmin={false}
         />
       </MockedProvider>,
@@ -134,7 +134,7 @@ describe("<ProfilePageClient>", () => {
           email="alice@example.com"
           initial={initial}
           displayMode="FLIP_TO_REVEAL"
-          newCardRatio={{ __typename: "NewCardRatio", numerator: 4, denominator: 5 }}
+          newCardRatio={{ numerator: 4, denominator: 5 }}
           isAdmin={true}
         />
       </MockedProvider>,
@@ -155,7 +155,7 @@ describe("<ProfilePageClient>", () => {
           email="alice@example.com"
           initial={initial}
           displayMode="FLIP_TO_REVEAL"
-          newCardRatio={{ __typename: "NewCardRatio", numerator: 4, denominator: 5 }}
+          newCardRatio={{ numerator: 4, denominator: 5 }}
           isAdmin={false}
         />
       </MockedProvider>,
@@ -174,7 +174,7 @@ describe("<ProfilePageClient>", () => {
           email="alice@example.com"
           initial={initial}
           displayMode="FLIP_TO_REVEAL"
-          newCardRatio={{ __typename: "NewCardRatio", numerator: 4, denominator: 5 }}
+          newCardRatio={{ numerator: 4, denominator: 5 }}
           isAdmin={false}
         />
       </MockedProvider>,
@@ -194,7 +194,7 @@ describe("<ProfilePageClient>", () => {
           email="alice@example.com"
           initial={initial}
           displayMode="FLIP_TO_REVEAL"
-          newCardRatio={{ __typename: "NewCardRatio", numerator: 4, denominator: 5 }}
+          newCardRatio={{ numerator: 4, denominator: 5 }}
           isAdmin={false}
         />
       </MockedProvider>,
@@ -218,7 +218,7 @@ describe("<ProfilePageClient>", () => {
           email="alice@example.com"
           initial={initial}
           displayMode="FLIP_TO_REVEAL"
-          newCardRatio={{ __typename: "NewCardRatio", numerator: 4, denominator: 5 }}
+          newCardRatio={{ numerator: 4, denominator: 5 }}
           isAdmin={false}
         />
       </MockedProvider>,
@@ -268,7 +268,7 @@ describe("<ProfilePageClient>", () => {
           email="alice@example.com"
           initial={initial}
           displayMode="FLIP_TO_REVEAL"
-          newCardRatio={{ __typename: "NewCardRatio", numerator: 4, denominator: 5 }}
+          newCardRatio={{ numerator: 4, denominator: 5 }}
           isAdmin={false}
         />
       </MockedProvider>,
@@ -297,7 +297,7 @@ describe("<ProfilePageClient>", () => {
           email="alice@example.com"
           initial={initial}
           displayMode="FLIP_TO_REVEAL"
-          newCardRatio={{ __typename: "NewCardRatio", numerator: 4, denominator: 5 }}
+          newCardRatio={{ numerator: 4, denominator: 5 }}
           isAdmin={false}
         />
       </MockedProvider>,

--- a/frontend/src/app/profile/profile-page-client.tsx
+++ b/frontend/src/app/profile/profile-page-client.tsx
@@ -7,7 +7,7 @@ import { useCallback, useRef, useState } from "react";
 import { LanguageSwitcher } from "@/components/settings/language-switcher";
 import { Button } from "@/components/ui/button";
 import { FormSheet, useFormSheetClose } from "@/components/ui/form-sheet";
-import type { LearnDisplayMode, MeQuery } from "@/generated/graphql";
+import type { LearnDisplayMode } from "@/generated/graphql";
 import { useSheetSearchParam } from "@/lib/url/use-sheet-search-param";
 import { DeleteAccountSection } from "./delete-account-section";
 import { DisplayModeSection } from "./display-mode-section";
@@ -18,7 +18,10 @@ type Props = {
   email: string | null;
   initial: { displayName: string; bio: string };
   displayMode: LearnDisplayMode;
-  newCardRatio: NonNullable<MeQuery["me"]>["newCardRatio"];
+  // Structural shape rather than a query-derived type: the ratio is fetched by a
+  // separate, admin-only, failure-tolerant query in page.tsx and falls back to a
+  // plain default object, so it is not tied to any single query's result type.
+  newCardRatio: { numerator: number; denominator: number };
   isAdmin: boolean;
 };
 


### PR DESCRIPTION
## Summary

`/profile` crashed to its error boundary ("Couldn't load your profile") for **every** user whenever the deployed backend could not resolve `newCardRatio`. The core `Me` query fetched `newCardRatio { numerator denominator }` inline, but that field is only ever displayed by the admin-only new-card-ratio slider (`isAdmin ? <NewCardRatioSection/> : null`). Because `newCardRatio` is non-null, a backend that cannot serve it — e.g. during a rolling deploy where the frontend ships the query before the backend serves the field — fails the whole `me` query, `gqlFetch` throws, and the RSC render aborts into the route's `error.tsx`.

The backend resolver / loader / repository / migration for `newCardRatio` are correct (the `me { newCardRatio }` resolver test passes). The fragility was purely that an admin-only, non-core field could take down the core profile load for everyone. The fix splits the fetch so the admin-only field can no longer gate the core profile.

## Changes

- `frontend/src/app/profile/page.tsx`: remove `newCardRatio` from the core `Me` query; add a separate `MeNewCardRatio` query fetched only when `auth.isAdmin`, wrapped in a failure-tolerant `try/catch`. A genuine `UNAUTHENTICATED` still `redirect("/login")` (preserving the repo-wide auth-gated-RSC invariant); every other failure — including the schema-desync validation error that motivated this — falls back to `DEFAULT_NEW_CARD_RATIO` (4/5, mirroring `domain.DefaultNewCardRatio`) so the core profile always renders. Non-admins never request the field at all.
- `frontend/src/app/profile/profile-page-client.tsx`: type the `newCardRatio` prop as a structural `{ numerator: number; denominator: number }` instead of deriving it from `MeQuery`, since the value now comes from either the separate query or a plain default object.
- `frontend/src/app/profile/page.test.tsx`: add coverage for the non-admin no-fetch path, the admin separate-fetch-and-forward path, the admin fetch-failure-degrades-to-default path, and the admin `UNAUTHENTICATED`-redirects path.
- `frontend/src/app/profile/profile-page-client.test.tsx`: drop the fake `__typename` from `newCardRatio` fixtures to match the structural prop type.

## Test plan

- `pnpm --filter frontend codegen` — regenerates the `MeNewCardRatio` type and the slimmed `Me` type.
- `pnpm --filter frontend typecheck` — 0 errors; `lint` / `knip` / `build` — pass.
- `pnpm --filter frontend test` — 1775 passed (190 files); the two profile suites hold 28 tests, including the 4 new admin-path branches.
- Runtime: against a backend that does not serve `newCardRatio`, `/profile` renders the core profile (admin slider at the 4/5 default) instead of the error boundary, and the server logs `[profile] newCardRatio fetch failed; using default:`. Against a healthy backend the slider shows and saves the real ratio.

## Deploy note

This PR is the resilience layer only. For the slider to show and save the real ratio, the backend must be deployed with the `newCardRatio` schema + migration applied; until then admins see the default 80% and slider saves roll back (no data corruption).

No linked issue: opened directly from the `/profile` runtime error report.
