### PR TITLE
refactor(backend): align repository/usecase/resolver identifier naming (9 nits)

### DIFF
--- a/backend/cmd/server/main_test.go
+++ b/backend/cmd/server/main_test.go
@@ -2325,7 +2325,7 @@ type panicUserRoleRepo struct{}
 func (panicUserRoleRepo) HasRole(_ context.Context, _ string, _ domain.RoleName) (bool, error) {
 	panic("not used in this test")
 }
-func (panicUserRoleRepo) AssignToUser(_ context.Context, _, _ string) error {
+func (panicUserRoleRepo) AssignRoleToUser(_ context.Context, _, _ string) error {
 	panic("not used in this test")
 }
 func (panicUserRoleRepo) SetUserRolesTx(_ context.Context, _ *gorm.DB, _ string, _ []string) error {

--- a/backend/graph/resolver/admin.resolvers.go
+++ b/backend/graph/resolver/admin.resolvers.go
@@ -40,7 +40,7 @@ func (r *mutationResolver) AdminEditUser(ctx context.Context, id string, input m
 		}, nil
 	}
 	if outcome.User == nil {
-		return nil, noVariantSet(ctx, "AdminEditUserOutcome")
+		return nil, newNoVariantSetError(ctx, "AdminEditUserOutcome")
 	}
 	return model.AdminEditUserSuccess{User: toUserModel(outcome.User)}, nil
 }
@@ -60,7 +60,7 @@ func (r *mutationResolver) CreateRole(ctx context.Context, name string) (model.C
 		return toInputValidationError(outcome.Validation), nil
 	}
 	if outcome.Role == nil {
-		return nil, noVariantSet(ctx, "CreateRoleOutcome")
+		return nil, newNoVariantSetError(ctx, "CreateRoleOutcome")
 	}
 	return model.CreateRoleSuccess{Role: toRoleModel(outcome.Role)}, nil
 }
@@ -84,7 +84,7 @@ func (r *mutationResolver) UpdateRole(ctx context.Context, id string, name strin
 		}, nil
 	}
 	if outcome.Role == nil {
-		return nil, noVariantSet(ctx, "UpdateRoleOutcome")
+		return nil, newNoVariantSetError(ctx, "UpdateRoleOutcome")
 	}
 	return model.UpdateRoleSuccess{Role: toRoleModel(outcome.Role)}, nil
 }

--- a/backend/graph/resolver/card.resolvers.go
+++ b/backend/graph/resolver/card.resolvers.go
@@ -93,7 +93,7 @@ func (r *mutationResolver) CreateCard(ctx context.Context, input model.NewCardIn
 		}, nil
 	}
 	if outcome.Card == nil {
-		return nil, noVariantSet(ctx, "CreateCardOutcome")
+		return nil, newNoVariantSetError(ctx, "CreateCardOutcome")
 	}
 	return model.CreateCardSuccess{Card: toCardModel(outcome.Card)}, nil
 }
@@ -116,7 +116,7 @@ func (r *mutationResolver) UpdateCard(ctx context.Context, id string, input mode
 		return toInputValidationError(outcome.Validation), nil
 	}
 	if outcome.Card == nil {
-		return nil, noVariantSet(ctx, "UpdateCardOutcome")
+		return nil, newNoVariantSetError(ctx, "UpdateCardOutcome")
 	}
 	return model.UpdateCardSuccess{Card: toCardModel(outcome.Card)}, nil
 }

--- a/backend/graph/resolver/cardgroup.resolvers.go
+++ b/backend/graph/resolver/cardgroup.resolvers.go
@@ -50,7 +50,7 @@ func (r *mutationResolver) CreateCardgroup(ctx context.Context, input model.NewC
 		}, nil
 	}
 	if outcome.Cardgroup == nil {
-		return nil, noVariantSet(ctx, "CreateCardgroupOutcome")
+		return nil, newNoVariantSetError(ctx, "CreateCardgroupOutcome")
 	}
 	return model.CreateCardgroupSuccess{Cardgroup: toCardgroupModel(outcome.Cardgroup)}, nil
 }
@@ -70,7 +70,7 @@ func (r *mutationResolver) UpdateCardgroup(ctx context.Context, id string, input
 		return toInputValidationError(outcome.Validation), nil
 	}
 	if outcome.Cardgroup == nil {
-		return nil, noVariantSet(ctx, "UpdateCardgroupOutcome")
+		return nil, newNoVariantSetError(ctx, "UpdateCardgroupOutcome")
 	}
 	return model.UpdateCardgroupSuccess{Cardgroup: toCardgroupModel(outcome.Cardgroup)}, nil
 }

--- a/backend/graph/resolver/helpers.go
+++ b/backend/graph/resolver/helpers.go
@@ -46,9 +46,9 @@ func rolesContainAdmin(roles []*domain.Role) bool {
 	return false
 }
 
-// noVariantSet builds the INTERNAL error returned when an outcome union has no
+// newNoVariantSetError builds the INTERNAL error returned when an outcome union has no
 // variant set — a programming error: the usecase returned a struct with every
 // field nil.
-func noVariantSet(ctx context.Context, name string) *gqlerror.Error {
+func newNoVariantSetError(ctx context.Context, name string) *gqlerror.Error {
 	return gqlerr.Internal(ctx, eris.New("resolver: "+name+" has no variant set"))
 }

--- a/backend/graph/resolver/helpers_test.go
+++ b/backend/graph/resolver/helpers_test.go
@@ -371,20 +371,20 @@ func TestClassifyLoaderErr_GenericErrorIsInternalWithLabel(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// noVariantSet — outcome-union "no variant" internal guard
+// newNoVariantSetError — outcome-union "no variant" internal guard
 // ---------------------------------------------------------------------------
 
-// TestNoVariantSet_MessageAndCode verifies that noVariantSet emits the exact
+// TestNewNoVariantSetError_MessageAndCode verifies that newNoVariantSetError emits the exact
 // "resolver: <name> has no variant set" message in the logged chain and an
 // INTERNAL wire code.
-func TestNoVariantSet_MessageAndCode(t *testing.T) {
+func TestNewNoVariantSetError_MessageAndCode(t *testing.T) {
 	// Not parallel: mutates the global slog default.
 	var buf bytes.Buffer
 	prev := slog.Default()
 	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, nil)))
 	t.Cleanup(func() { slog.SetDefault(prev) })
 
-	got := noVariantSet(context.Background(), "CreateCardOutcome")
+	got := newNoVariantSetError(context.Background(), "CreateCardOutcome")
 
 	require.NotNil(t, got)
 	assert.True(t, gqlerr.IsCode(got, gqlerr.CodeInternal),

--- a/backend/graph/resolver/last_viewed_cardgroup.resolvers.go
+++ b/backend/graph/resolver/last_viewed_cardgroup.resolvers.go
@@ -29,7 +29,7 @@ func (r *mutationResolver) SetLastViewedCardgroup(ctx context.Context, cardgroup
 		return toInputValidationError(outcome.Validation), nil
 	}
 	if outcome.User == nil {
-		return nil, noVariantSet(ctx, "SetLastViewedCardgroupOutcome")
+		return nil, newNoVariantSetError(ctx, "SetLastViewedCardgroupOutcome")
 	}
 	return model.SetLastViewedCardgroupSuccess{User: toUserModel(outcome.User)}, nil
 }

--- a/backend/graph/resolver/master_card.resolvers.go
+++ b/backend/graph/resolver/master_card.resolvers.go
@@ -35,7 +35,7 @@ func (r *mutationResolver) AdminCreateMasterCard(ctx context.Context, input mode
 		}, nil
 	}
 	if outcome.Card == nil {
-		return nil, noVariantSet(ctx, "CreateMasterCardOutcome")
+		return nil, newNoVariantSetError(ctx, "CreateMasterCardOutcome")
 	}
 	return model.CreateMasterCardSuccess{MasterCard: toMasterCardModel(outcome.Card)}, nil
 }
@@ -60,7 +60,7 @@ func (r *mutationResolver) AdminUpdateMasterCard(ctx context.Context, id string,
 		return toInputValidationError(outcome.Validation), nil
 	}
 	if outcome.Card == nil {
-		return nil, noVariantSet(ctx, "UpdateMasterCardOutcome")
+		return nil, newNoVariantSetError(ctx, "UpdateMasterCardOutcome")
 	}
 	return model.UpdateMasterCardSuccess{MasterCard: toMasterCardModel(outcome.Card)}, nil
 }

--- a/backend/graph/resolver/master_catalog.resolvers.go
+++ b/backend/graph/resolver/master_catalog.resolvers.go
@@ -34,7 +34,7 @@ func (r *mutationResolver) AdminCreateMasterCardgroup(ctx context.Context, input
 		return toInputValidationError(out.Validation), nil
 	}
 	if out.Master == nil {
-		return nil, noVariantSet(ctx, "CreateMasterOutcome")
+		return nil, newNoVariantSetError(ctx, "CreateMasterOutcome")
 	}
 	return model.CreateMasterCardgroupSuccess{Master: toMasterCardgroupModelFromParts(out.Master, cardCountResolvedElsewhere)}, nil
 }
@@ -59,7 +59,7 @@ func (r *mutationResolver) AdminUpdateMasterCardgroup(ctx context.Context, id st
 		return toInputValidationError(out.Validation), nil
 	}
 	if out.Master == nil {
-		return nil, noVariantSet(ctx, "UpdateMasterOutcome")
+		return nil, newNoVariantSetError(ctx, "UpdateMasterOutcome")
 	}
 	return model.UpdateMasterCardgroupSuccess{Master: toMasterCardgroupModelFromParts(out.Master, int(out.CardCount))}, nil
 }
@@ -79,7 +79,7 @@ func (r *mutationResolver) AdminPublishMasterCardgroup(ctx context.Context, id s
 		return model.MasterCardgroupEmptyError{Message: "master cardgroup has no cards and cannot be published"}, nil
 	}
 	if out.Master == nil {
-		return nil, noVariantSet(ctx, "PublishMasterOutcome")
+		return nil, newNoVariantSetError(ctx, "PublishMasterOutcome")
 	}
 	return model.PublishMasterCardgroupSuccess{Master: toMasterCardgroupModelFromParts(out.Master, int(out.CardCount))}, nil
 }
@@ -121,7 +121,7 @@ func (r *mutationResolver) ImportMasterCardgroup(ctx context.Context, masterCard
 		}, nil
 	}
 	if outcome.Cardgroup == nil {
-		return nil, noVariantSet(ctx, "ImportMasterOutcome")
+		return nil, newNoVariantSetError(ctx, "ImportMasterOutcome")
 	}
 	return model.ImportMasterCardgroupSuccess{
 		Cardgroup: toCardgroupModel(outcome.Cardgroup),
@@ -158,7 +158,7 @@ func (r *mutationResolver) MergeMasterCardgroup(ctx context.Context, input model
 		return model.MasterNotFoundError{Message: "Master cardgroup not found"}, nil
 	}
 	if outcome.Cardgroup == nil {
-		return nil, noVariantSet(ctx, "MergeMasterOutcome")
+		return nil, newNoVariantSetError(ctx, "MergeMasterOutcome")
 	}
 	return model.MergeMasterCardgroupSuccess{
 		Cardgroup:    toCardgroupModel(outcome.Cardgroup),

--- a/backend/graph/resolver/swipe.resolvers.go
+++ b/backend/graph/resolver/swipe.resolvers.go
@@ -32,7 +32,7 @@ func (r *mutationResolver) HandleSwipe(ctx context.Context, input model.HandleSw
 		return toInputValidationError(outcome.Validation), nil
 	}
 	if outcome.Swipe == nil {
-		return nil, noVariantSet(ctx, "HandleSwipeOutcome")
+		return nil, newNoVariantSetError(ctx, "HandleSwipeOutcome")
 	}
 	return model.HandleSwipeSuccess{Response: toSwipeResponseModel(outcome.Swipe)}, nil
 }

--- a/backend/graph/resolver/user.resolvers.go
+++ b/backend/graph/resolver/user.resolvers.go
@@ -31,7 +31,7 @@ func (r *mutationResolver) UpdateProfile(ctx context.Context, input model.Update
 		return toInputValidationError(outcome.Validation), nil
 	}
 	if outcome.User == nil {
-		return nil, noVariantSet(ctx, "UpdateProfileOutcome")
+		return nil, newNoVariantSetError(ctx, "UpdateProfileOutcome")
 	}
 	return model.UpdateProfileSuccess{User: toUserModel(outcome.User)}, nil
 }

--- a/backend/internal/auth/superuser.go
+++ b/backend/internal/auth/superuser.go
@@ -21,7 +21,7 @@ type adminChecker interface {
 // roleAssigner grants a role to a user. Satisfied by repository.UserRoleRepository.
 // Idempotent via ON CONFLICT DO NOTHING.
 type roleAssigner interface {
-	AssignToUser(ctx context.Context, userID, roleID string) error
+	AssignRoleToUser(ctx context.Context, userID, roleID string) error
 }
 
 // SuperUserPromoter is an Echo middleware factory that grants the admin role
@@ -33,14 +33,14 @@ type SuperUserPromoter struct {
 	assigner    roleAssigner
 	logger      *slog.Logger
 
-	// confirmed is the process-lifetime set of subs already known to hold the
+	// confirmedAdmins is the process-lifetime set of subs already known to hold the
 	// admin role. Once a sub is recorded, the middleware skips the per-request
 	// IsAdmin role query for it. A process-lifetime cache with no TTL/eviction
 	// is safe here because promotion only ever *adds* the admin role (it is
 	// never removed), and SUPER_USER_EMAILS membership cannot change without a
 	// process restart — so a cached sub never needs re-checking within a
 	// process. The zero value is ready to use.
-	confirmed sync.Map // map[string]struct{}
+	confirmedAdmins sync.Map // map[string]struct{}
 }
 
 // ParseSuperUserSet splits a comma-separated string of email addresses into a
@@ -143,8 +143,8 @@ func (p *SuperUserPromoter) Middleware() echo.MiddlewareFunc {
 
 			// Already confirmed as admin in this process: skip the role query.
 			// Promotion is idempotent and the admin role is never revoked, so a
-			// previously-confirmed sub needs no re-check (see the confirmed field).
-			if _, ok := p.confirmed.Load(u.Sub); ok {
+			// previously-confirmed sub needs no re-check (see the confirmedAdmins field).
+			if _, ok := p.confirmedAdmins.Load(u.Sub); ok {
 				return next(c)
 			}
 
@@ -158,19 +158,19 @@ func (p *SuperUserPromoter) Middleware() echo.MiddlewareFunc {
 			if isAdmin {
 				// Hot-path short-circuit: already has the role, nothing to do.
 				// Record it so subsequent requests skip the IsAdmin query.
-				p.confirmed.Store(u.Sub, struct{}{})
+				p.confirmedAdmins.Store(u.Sub, struct{}{})
 				return next(c)
 			}
 
-			if err := p.assigner.AssignToUser(ctx, u.Sub, p.adminRoleID); err != nil {
+			if err := p.assigner.AssignRoleToUser(ctx, u.Sub, p.adminRoleID); err != nil {
 				logging.LogWarn(ctx, p.logger, "superuser: role assignment failed",
-					eris.Wrap(err, "superuser: AssignToUser"),
+					eris.Wrap(err, "superuser: AssignRoleToUser"),
 					slog.String("user_id", u.Sub))
 				return next(c)
 			}
 
 			// Promotion succeeded: record the sub so future requests skip the query.
-			p.confirmed.Store(u.Sub, struct{}{})
+			p.confirmedAdmins.Store(u.Sub, struct{}{})
 			p.logger.InfoContext(ctx, "superuser: promoted to admin", slog.String("user_id", u.Sub))
 			return next(c)
 		}

--- a/backend/internal/auth/superuser_test.go
+++ b/backend/internal/auth/superuser_test.go
@@ -31,7 +31,7 @@ type stubRoleAssigner struct {
 	fn func(ctx context.Context, userID, roleID string) error
 }
 
-func (s stubRoleAssigner) AssignToUser(ctx context.Context, userID, roleID string) error {
+func (s stubRoleAssigner) AssignRoleToUser(ctx context.Context, userID, roleID string) error {
 	return s.fn(ctx, userID, roleID)
 }
 
@@ -188,7 +188,7 @@ func makeSet(emails ...string) map[string]struct{} {
 // C. Middleware tests M1–M9
 // ---------------------------------------------------------------------------
 
-// M1: empty emails map — IsAdmin and AssignToUser must never be called.
+// M1: empty emails map — IsAdmin and AssignRoleToUser must never be called.
 func TestSuperUserPromoter_M1_EmptyEmails(t *testing.T) {
 	t.Parallel()
 	var isAdminCalls, assignCalls atomic.Int64
@@ -212,7 +212,7 @@ func TestSuperUserPromoter_M1_EmptyEmails(t *testing.T) {
 		t.Errorf("expected 0 IsAdmin calls, got %d", n)
 	}
 	if n := assignCalls.Load(); n != 0 {
-		t.Errorf("expected 0 AssignToUser calls, got %d", n)
+		t.Errorf("expected 0 AssignRoleToUser calls, got %d", n)
 	}
 }
 
@@ -239,7 +239,7 @@ func TestSuperUserPromoter_M2_AnonymousRequest(t *testing.T) {
 		t.Errorf("expected 0 IsAdmin calls, got %d", n)
 	}
 	if n := assignCalls.Load(); n != 0 {
-		t.Errorf("expected 0 AssignToUser calls, got %d", n)
+		t.Errorf("expected 0 AssignRoleToUser calls, got %d", n)
 	}
 }
 
@@ -267,7 +267,7 @@ func TestSuperUserPromoter_M3_EmailNotInSet(t *testing.T) {
 		t.Errorf("expected 0 IsAdmin calls, got %d", n)
 	}
 	if n := assignCalls.Load(); n != 0 {
-		t.Errorf("expected 0 AssignToUser calls, got %d", n)
+		t.Errorf("expected 0 AssignRoleToUser calls, got %d", n)
 	}
 }
 
@@ -295,11 +295,11 @@ func TestSuperUserPromoter_M4_EmailVerifiedFalse(t *testing.T) {
 		t.Errorf("expected 0 IsAdmin calls, got %d", n)
 	}
 	if n := assignCalls.Load(); n != 0 {
-		t.Errorf("expected 0 AssignToUser calls, got %d", n)
+		t.Errorf("expected 0 AssignRoleToUser calls, got %d", n)
 	}
 }
 
-// M5: email matches + verified + already admin — IsAdmin called once, AssignToUser not called, no log.
+// M5: email matches + verified + already admin — IsAdmin called once, AssignRoleToUser not called, no log.
 func TestSuperUserPromoter_M5_AlreadyAdmin(t *testing.T) {
 	// Not parallel: captureDefaultLogger mutates global slog default.
 	var buf bytes.Buffer
@@ -326,14 +326,14 @@ func TestSuperUserPromoter_M5_AlreadyAdmin(t *testing.T) {
 		t.Errorf("expected 1 IsAdmin call, got %d", n)
 	}
 	if n := assignCalls.Load(); n != 0 {
-		t.Errorf("expected 0 AssignToUser calls, got %d", n)
+		t.Errorf("expected 0 AssignRoleToUser calls, got %d", n)
 	}
 	if buf.Len() > 0 {
 		t.Errorf("expected no log output, got: %s", buf.String())
 	}
 }
 
-// M6: email matches + verified + not yet admin — AssignToUser called, INFO log with user_id.
+// M6: email matches + verified + not yet admin — AssignRoleToUser called, INFO log with user_id.
 func TestSuperUserPromoter_M6_SuccessfulPromotion(t *testing.T) {
 	// Not parallel: captureDefaultLogger mutates global slog default.
 	var buf bytes.Buffer
@@ -366,13 +366,13 @@ func TestSuperUserPromoter_M6_SuccessfulPromotion(t *testing.T) {
 		t.Errorf("expected 1 IsAdmin call, got %d", n)
 	}
 	if n := assignCalls.Load(); n != 1 {
-		t.Errorf("expected 1 AssignToUser call, got %d", n)
+		t.Errorf("expected 1 AssignRoleToUser call, got %d", n)
 	}
 	if gotUserID != wantUserID {
-		t.Errorf("AssignToUser userID: want %q, got %q", wantUserID, gotUserID)
+		t.Errorf("AssignRoleToUser userID: want %q, got %q", wantUserID, gotUserID)
 	}
 	if gotRoleID != wantRoleID {
-		t.Errorf("AssignToUser roleID: want %q, got %q", wantRoleID, gotRoleID)
+		t.Errorf("AssignRoleToUser roleID: want %q, got %q", wantRoleID, gotRoleID)
 	}
 
 	// Verify INFO log contains user_id but not the email.
@@ -395,7 +395,7 @@ func TestSuperUserPromoter_M6_SuccessfulPromotion(t *testing.T) {
 	}
 }
 
-// M7: IsAdmin returns an error — WARN log with error_chain, AssignToUser not called, 200.
+// M7: IsAdmin returns an error — WARN log with error_chain, AssignRoleToUser not called, 200.
 func TestSuperUserPromoter_M7_IsAdminError(t *testing.T) {
 	// Not parallel: captureDefaultLogger mutates global slog default.
 	var buf bytes.Buffer
@@ -419,7 +419,7 @@ func TestSuperUserPromoter_M7_IsAdminError(t *testing.T) {
 		t.Fatalf("expected 200, got %d", rec.Code)
 	}
 	if n := assignCalls.Load(); n != 0 {
-		t.Errorf("expected 0 AssignToUser calls, got %d", n)
+		t.Errorf("expected 0 AssignRoleToUser calls, got %d", n)
 	}
 
 	records := decodeLogLines(t, &buf)
@@ -472,7 +472,7 @@ func TestSuperUserPromoter_InjectedLogger_WarnsOnAdminCheckFailure(t *testing.T)
 		return false, eris.New("db: connection refused")
 	}}
 	assigner := stubRoleAssigner{fn: func(_ context.Context, _, _ string) error {
-		t.Fatal("AssignToUser must not be called when the admin check fails")
+		t.Fatal("AssignRoleToUser must not be called when the admin check fails")
 		return nil
 	}}
 	promoter := NewSuperUserPromoter(makeSet("a@x.com"), "role-id", checker, assigner, logger)
@@ -506,8 +506,8 @@ func TestSuperUserPromoter_InjectedLogger_WarnsOnAdminCheckFailure(t *testing.T)
 	}
 }
 
-// M8: AssignToUser returns an error — WARN log with error_chain, 200.
-func TestSuperUserPromoter_M8_AssignToUserError(t *testing.T) {
+// M8: AssignRoleToUser returns an error — WARN log with error_chain, 200.
+func TestSuperUserPromoter_M8_AssignRoleToUserError(t *testing.T) {
 	// Not parallel: captureDefaultLogger mutates global slog default.
 	var buf bytes.Buffer
 	captureDefaultLogger(t, &buf)
@@ -564,7 +564,7 @@ func TestSuperUserPromoter_M8_AssignToUserError(t *testing.T) {
 // same user before either has promoted. The stub mirrors ON CONFLICT DO NOTHING
 // by returning nil for both calls. Both goroutines must complete with 200.
 //
-// With the process-lifetime confirmed-sub cache, the exact IsAdmin/AssignToUser
+// With the process-lifetime confirmed-sub cache, the exact IsAdmin/AssignRoleToUser
 // call counts on this path are non-deterministic: if one goroutine records the
 // sub before the other reads the cache, the second skips both DB calls. So the
 // counts are bounded (at least one call to promote, at most one per goroutine)
@@ -627,7 +627,7 @@ func TestSuperUserPromoter_M9_ConcurrentFirstLogin(t *testing.T) {
 		t.Errorf("expected 1..%d IsAdmin calls, got %d", goroutines, n)
 	}
 	if n := assignCalls.Load(); n < 1 || n > int64(goroutines) {
-		t.Errorf("expected 1..%d AssignToUser calls, got %d", goroutines, n)
+		t.Errorf("expected 1..%d AssignRoleToUser calls, got %d", goroutines, n)
 	}
 }
 
@@ -660,13 +660,13 @@ func TestSuperUserPromoter_CachesConfirmedAdmin(t *testing.T) {
 		t.Errorf("expected exactly 1 IsAdmin call across %d requests, got %d", requests, n)
 	}
 	if n := assignCalls.Load(); n != 0 {
-		t.Errorf("expected 0 AssignToUser calls, got %d", n)
+		t.Errorf("expected 0 AssignRoleToUser calls, got %d", n)
 	}
 }
 
 // TestSuperUserPromoter_CachesAfterPromotion verifies a cold cache still promotes
 // correctly, and that once a sub has been promoted the confirmed-sub cache halts
-// every subsequent IsAdmin query and AssignToUser call for that sub.
+// every subsequent IsAdmin query and AssignRoleToUser call for that sub.
 func TestSuperUserPromoter_CachesAfterPromotion(t *testing.T) {
 	t.Parallel()
 	var isAdminCalls, assignCalls atomic.Int64
@@ -691,19 +691,19 @@ func TestSuperUserPromoter_CachesAfterPromotion(t *testing.T) {
 			t.Fatalf("request %d: expected 200, got %d", i, rec.Code)
 		}
 	}
-	// Cold cache: the first request runs IsAdmin then AssignToUser. Every later
+	// Cold cache: the first request runs IsAdmin then AssignRoleToUser. Every later
 	// request short-circuits on the cache, so both counters stay at 1.
 	if n := isAdminCalls.Load(); n != 1 {
 		t.Errorf("expected exactly 1 IsAdmin call across %d requests, got %d", requests, n)
 	}
 	if n := assignCalls.Load(); n != 1 {
-		t.Errorf("expected exactly 1 AssignToUser call across %d requests, got %d", requests, n)
+		t.Errorf("expected exactly 1 AssignRoleToUser call across %d requests, got %d", requests, n)
 	}
 }
 
 // TestSuperUserPromoter_AuthUserWithEmptySub verifies that a non-nil AuthUser
 // with an empty Sub field (u.Sub == "") is treated as anonymous and neither
-// IsAdmin nor AssignToUser is called, even when the email is in the set.
+// IsAdmin nor AssignRoleToUser is called, even when the email is in the set.
 func TestSuperUserPromoter_AuthUserWithEmptySub(t *testing.T) {
 	t.Parallel()
 	var checkerCalls atomic.Int64
@@ -730,7 +730,7 @@ func TestSuperUserPromoter_AuthUserWithEmptySub(t *testing.T) {
 		t.Errorf("expected IsAdmin not called, got %d", checkerCalls.Load())
 	}
 	if assignerCalls.Load() != 0 {
-		t.Errorf("expected AssignToUser not called, got %d", assignerCalls.Load())
+		t.Errorf("expected AssignRoleToUser not called, got %d", assignerCalls.Load())
 	}
 }
 

--- a/backend/internal/domain/service/user_performance.go
+++ b/backend/internal/domain/service/user_performance.go
@@ -7,7 +7,7 @@ import (
 )
 
 // PerformanceMode is the difficulty level inferred from a user's recent
-// performance. Values intentionally span ModeDifficult (0) .. ModeInWhile (4).
+// performance. Values intentionally span ModeDifficult (0) .. ModeMastered (4).
 type PerformanceMode int
 
 const (
@@ -15,7 +15,7 @@ const (
 	ModeDefault   PerformanceMode = 1
 	ModeGood      PerformanceMode = 2
 	ModeEasy      PerformanceMode = 3
-	ModeInWhile   PerformanceMode = 4
+	ModeMastered   PerformanceMode = 4
 
 	MinReviewsForModeCalculation = 20
 
@@ -24,7 +24,7 @@ const (
 	defaultModeThreshold = 0.60
 	goodModeThreshold    = 0.75
 	easyModeThreshold    = 0.85
-	inWhileModeThreshold = 0.95
+	masteredModeThreshold = 0.95
 
 	// Average-difficulty nudges shift the band-selected mode by one step:
 	// hard recent cards drop the mode, easy recent cards raise it.
@@ -34,7 +34,7 @@ const (
 
 // IsValid reports whether the mode is in the recognised range.
 func (m PerformanceMode) IsValid() bool {
-	return m >= ModeDifficult && m <= ModeInWhile
+	return m >= ModeDifficult && m <= ModeMastered
 }
 
 type PerformanceMetrics struct {
@@ -95,7 +95,7 @@ func ModeFromMetrics(m PerformanceMetrics) PerformanceMode {
 		return ModeDefault
 	}
 
-	mode := ModeInWhile
+	mode := ModeMastered
 	switch {
 	case m.SuccessRate < defaultModeThreshold:
 		mode = ModeDifficult
@@ -103,7 +103,7 @@ func ModeFromMetrics(m PerformanceMetrics) PerformanceMode {
 		mode = ModeDefault
 	case m.SuccessRate < easyModeThreshold:
 		mode = ModeGood
-	case m.SuccessRate < inWhileModeThreshold:
+	case m.SuccessRate < masteredModeThreshold:
 		mode = ModeEasy
 	}
 
@@ -162,8 +162,8 @@ func clampMode(mode PerformanceMode) PerformanceMode {
 	if mode < ModeDifficult {
 		return ModeDifficult
 	}
-	if mode > ModeInWhile {
-		return ModeInWhile
+	if mode > ModeMastered {
+		return ModeMastered
 	}
 	return mode
 }

--- a/backend/internal/domain/service/user_performance_test.go
+++ b/backend/internal/domain/service/user_performance_test.go
@@ -168,8 +168,8 @@ func TestModeFromMetricsThresholdBoundaries(t *testing.T) {
 		{"at good threshold", 20, 0.75, ModeGood},
 		{"below easy threshold", 20, 0.849, ModeGood},
 		{"at easy threshold", 20, 0.85, ModeEasy},
-		{"below in while threshold", 20, 0.949, ModeEasy},
-		{"at in while threshold", 20, 0.95, ModeInWhile},
+		{"below mastered threshold", 20, 0.949, ModeEasy},
+		{"at mastered threshold", 20, 0.95, ModeMastered},
 	}
 
 	for _, tc := range cases {
@@ -201,7 +201,7 @@ func TestModeFromMetricsDifficultyAdjustments(t *testing.T) {
 		{"low difficulty increases mode", 0.80, 0.30, ModeEasy},
 		{"neutral difficulty leaves mode", 0.80, 0.50, ModeGood},
 		{"high difficulty clamps at difficult", 0.50, 0.90, ModeDifficult},
-		{"low difficulty clamps at in while", 0.99, 0.10, ModeInWhile},
+		{"low difficulty clamps at mastered", 0.99, 0.10, ModeMastered},
 	}
 
 	for _, tc := range cases {
@@ -230,7 +230,7 @@ func TestPerformanceModeIsValid(t *testing.T) {
 	}{
 		{"below range", -1, false},
 		{"difficult lower bound", ModeDifficult, true},
-		{"in while upper bound", ModeInWhile, true},
+		{"mastered upper bound", ModeMastered, true},
 		{"above range", 5, false},
 	}
 

--- a/backend/internal/loader/role_by_user_test.go
+++ b/backend/internal/loader/role_by_user_test.go
@@ -25,8 +25,8 @@ func (s *roleBatchRepoStub) HasRole(_ context.Context, _ string, _ domain.RoleNa
 	panic("roleBatchRepoStub.HasRole not configured")
 }
 
-func (s *roleBatchRepoStub) AssignToUser(_ context.Context, _, _ string) error {
-	panic("roleBatchRepoStub.AssignToUser not configured")
+func (s *roleBatchRepoStub) AssignRoleToUser(_ context.Context, _, _ string) error {
+	panic("roleBatchRepoStub.AssignRoleToUser not configured")
 }
 
 func (s *roleBatchRepoStub) SetUserRolesTx(_ context.Context, _ *gorm.DB, _ string, _ []string) error {

--- a/backend/internal/loader/user_test.go
+++ b/backend/internal/loader/user_test.go
@@ -88,8 +88,8 @@ type emptyUserRoleRepoStub struct{}
 func (emptyUserRoleRepoStub) HasRole(_ context.Context, _ string, _ domain.RoleName) (bool, error) {
 	panic("emptyUserRoleRepoStub.HasRole not expected")
 }
-func (emptyUserRoleRepoStub) AssignToUser(_ context.Context, _, _ string) error {
-	panic("emptyUserRoleRepoStub.AssignToUser not expected")
+func (emptyUserRoleRepoStub) AssignRoleToUser(_ context.Context, _, _ string) error {
+	panic("emptyUserRoleRepoStub.AssignRoleToUser not expected")
 }
 func (emptyUserRoleRepoStub) SetUserRolesTx(_ context.Context, _ *gorm.DB, _ string, _ []string) error {
 	panic("emptyUserRoleRepoStub.SetUserRolesTx not expected")
@@ -182,8 +182,8 @@ func (r *countingCardRepo) FindByIDs(ctx context.Context, ids []string) (map[str
 	}
 	return r.findByIDs(ctx, ids)
 }
-func (r *countingCardRepo) FindByCardgroup(_ context.Context, _ string) ([]*domain.Card, error) {
-	panic("countingCardRepo.FindByCardgroup not configured")
+func (r *countingCardRepo) ListByCardgroup(_ context.Context, _ string) ([]*domain.Card, error) {
+	panic("countingCardRepo.ListByCardgroup not configured")
 }
 func (r *countingCardRepo) ListFrontsByCardgroupTx(_ context.Context, _ *gorm.DB, _ string) ([]string, error) {
 	panic("countingCardRepo.ListFrontsByCardgroupTx not configured")

--- a/backend/internal/repository/card.go
+++ b/backend/internal/repository/card.go
@@ -39,7 +39,7 @@ type CardReadRepository interface {
 	FindByID(ctx context.Context, id string) (*domain.Card, error)
 	FindByIDForUpdateTx(ctx context.Context, tx *gorm.DB, id string) (*domain.Card, error)
 	FindByIDs(ctx context.Context, ids []string) (map[string]*domain.Card, error)
-	FindByCardgroup(ctx context.Context, cardgroupID string) ([]*domain.Card, error)
+	ListByCardgroup(ctx context.Context, cardgroupID string) ([]*domain.Card, error)
 	ListFrontsByCardgroupTx(ctx context.Context, tx *gorm.DB, cardgroupID string) ([]string, error)
 	// FindByCardgroupAndFront returns the card identified by the (cardgroup_id,
 	// front) unique key, or ErrNotFound when no such row exists. The front value
@@ -161,7 +161,7 @@ func (r *cardRepo) FindByIDs(ctx context.Context, ids []string) (map[string]*dom
 	return out, nil
 }
 
-func (r *cardRepo) FindByCardgroup(ctx context.Context, cardgroupID string) ([]*domain.Card, error) {
+func (r *cardRepo) ListByCardgroup(ctx context.Context, cardgroupID string) ([]*domain.Card, error) {
 	var rows []gormCard
 	if err := r.db.WithContext(ctx).
 		Where("cardgroup_id = ?", cardgroupID).

--- a/backend/internal/repository/card_test.go
+++ b/backend/internal/repository/card_test.go
@@ -78,7 +78,7 @@ func TestCardRepository_FindByCardgroup_Scoped(t *testing.T) {
 	require.NoError(t, repo.Create(ctx, card1))
 	require.NoError(t, repo.Create(ctx, card2))
 
-	got, err := repo.FindByCardgroup(ctx, string(cg1.ID))
+	got, err := repo.ListByCardgroup(ctx, string(cg1.ID))
 	require.NoError(t, err)
 	ids := map[string]bool{}
 	for _, card := range got {

--- a/backend/internal/repository/card_upsert_test.go
+++ b/backend/internal/repository/card_upsert_test.go
@@ -43,7 +43,7 @@ func TestCardRepository_UpsertManyTx(t *testing.T) {
 		require.Equal(t, int64(5), result.Inserted)
 		require.Equal(t, int64(0), result.Updated)
 
-		stored, err := repo.FindByCardgroup(ctx, string(cg.ID))
+		stored, err := repo.ListByCardgroup(ctx, string(cg.ID))
 		require.NoError(t, err)
 		require.Len(t, stored, 5)
 	})
@@ -94,7 +94,7 @@ func TestCardRepository_UpsertManyTx(t *testing.T) {
 		}
 
 		// Final cardgroup row count: 3 pre-existing + 2 newly inserted.
-		stored, err := repo.FindByCardgroup(ctx, string(cg.ID))
+		stored, err := repo.ListByCardgroup(ctx, string(cg.ID))
 		require.NoError(t, err)
 		require.Len(t, stored, 5)
 	})
@@ -114,7 +114,7 @@ func TestCardRepository_UpsertManyTx(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, repository.UpsertManyTxResult{}, result)
 
-		stored, err := repo.FindByCardgroup(ctx, string(cg.ID))
+		stored, err := repo.ListByCardgroup(ctx, string(cg.ID))
 		require.NoError(t, err)
 		require.Empty(t, stored)
 	})
@@ -149,13 +149,13 @@ func TestCardRepository_UpsertManyTx(t *testing.T) {
 		require.Equal(t, int64(1), result.Inserted)
 		require.Equal(t, int64(0), result.Updated)
 
-		storedA, err := repo.FindByCardgroup(ctx, string(cgA.ID))
+		storedA, err := repo.ListByCardgroup(ctx, string(cgA.ID))
 		require.NoError(t, err)
 		require.Len(t, storedA, 1)
 		require.Equal(t, domain.CardText("hello"), storedA[0].Front)
 		require.Equal(t, domain.CardText("back-A"), storedA[0].Back)
 
-		storedB, err := repo.FindByCardgroup(ctx, string(cgB.ID))
+		storedB, err := repo.ListByCardgroup(ctx, string(cgB.ID))
 		require.NoError(t, err)
 		require.Len(t, storedB, 1)
 		require.Equal(t, domain.CardText("hello"), storedB[0].Front)

--- a/backend/internal/repository/master_deck_copy_integration_test.go
+++ b/backend/internal/repository/master_deck_copy_integration_test.go
@@ -119,7 +119,7 @@ func TestCopyMasterToUser_Integration_CopiesDeckWithNoFSRSState(t *testing.T) {
 
 	// The cards landed in public.cards: reparented, fresh ids, content preserved.
 	cardRepo := repository.NewCardRepository(testDB.GORM)
-	got, err := cardRepo.FindByCardgroup(ctx, string(cg.ID))
+	got, err := cardRepo.ListByCardgroup(ctx, string(cg.ID))
 	require.NoError(t, err)
 	require.Len(t, got, 3)
 

--- a/backend/internal/repository/role.go
+++ b/backend/internal/repository/role.go
@@ -146,7 +146,7 @@ func (r *roleRepo) Create(ctx context.Context, name string) (*domain.Role, error
 
 	row := gormRole{ID: id.String(), Name: name}
 	if err := r.db.WithContext(ctx).Create(&row).Error; err != nil {
-		if classified := classifyUniqueError(err); classified != nil {
+		if classified := classifyRoleNameDuplicate(err); classified != nil {
 			return nil, classified
 		}
 		return nil, eris.Wrap(err, "repository: role: create")
@@ -162,7 +162,7 @@ func (r *roleRepo) Update(ctx context.Context, id, name string) (*domain.Role, e
 		Where("id = ?", id).
 		Updates(map[string]any{"name": name})
 	if res.Error != nil {
-		if classified := classifyUniqueError(res.Error); classified != nil {
+		if classified := classifyRoleNameDuplicate(res.Error); classified != nil {
 			return nil, classified
 		}
 		return nil, eris.Wrap(res.Error, "repository: role: update")
@@ -183,10 +183,10 @@ func (r *roleRepo) Delete(ctx context.Context, id string) error {
 	return nil
 }
 
-// classifyUniqueError maps a Postgres unique-violation (code 23505) on the
+// classifyRoleNameDuplicate maps a Postgres unique-violation (code 23505) on the
 // roles.name column to ErrRoleDuplicate. Returns nil for any other error so
 // callers can use it as a pre-filter before falling through to eris.Wrap.
-func classifyUniqueError(err error) error {
+func classifyRoleNameDuplicate(err error) error {
 	if pgConstraintViolation(err, "23505", "name") {
 		return ErrRoleDuplicate
 	}

--- a/backend/internal/repository/role_crud_test.go
+++ b/backend/internal/repository/role_crud_test.go
@@ -345,8 +345,8 @@ func TestRoleRepository_Delete_CascadesUserRoles(t *testing.T) {
 		t.Fatalf("Create: %v", err)
 	}
 	userID := insertAuthUser(t, ctx)
-	if err := userRoleRepo.AssignToUser(ctx, userID, role.ID); err != nil {
-		t.Fatalf("AssignToUser: %v", err)
+	if err := userRoleRepo.AssignRoleToUser(ctx, userID, role.ID); err != nil {
+		t.Fatalf("AssignRoleToUser: %v", err)
 	}
 
 	// Delete the role — must succeed (CASCADE removes the user_roles row).

--- a/backend/internal/repository/user_role.go
+++ b/backend/internal/repository/user_role.go
@@ -33,11 +33,11 @@ type UserRoleRepository interface {
 	// Only DB errors return a non-nil error. Role lookup is by name (case-sensitive).
 	HasRole(ctx context.Context, userID string, roleName domain.RoleName) (bool, error)
 
-	// AssignToUser inserts a (user_id, role_id) row. Idempotent: if the row
+	// AssignRoleToUser inserts a (user_id, role_id) row. Idempotent: if the row
 	// already exists, returns nil without error. Returns ErrUserNotFound when
 	// the user is missing and ErrRoleNotFound when the role is missing; both
 	// also satisfy errors.Is(_, ErrNotFound) for backward-compatible matching.
-	AssignToUser(ctx context.Context, userID, roleID string) error
+	AssignRoleToUser(ctx context.Context, userID, roleID string) error
 
 	// SetUserRolesTx replaces the user's role set inside the supplied
 	// transaction. roleIDs is the final declarative state; an empty slice
@@ -108,11 +108,11 @@ func requireExistsOn(ctx context.Context, db *gorm.DB, table, id, wrap string, n
 	return nil
 }
 
-// AssignToUser inserts a user_roles row. Idempotent via ON CONFLICT DO NOTHING.
+// AssignRoleToUser inserts a user_roles row. Idempotent via ON CONFLICT DO NOTHING.
 // Validates that both the user and role exist before inserting; returns
 // ErrUserNotFound when the user is missing and ErrRoleNotFound when the role
 // is missing.
-func (r *userRoleRepo) AssignToUser(ctx context.Context, userID, roleID string) error {
+func (r *userRoleRepo) AssignRoleToUser(ctx context.Context, userID, roleID string) error {
 	if err := r.requireExists(ctx, "users", userID, "repository: user role: assign: check user", ErrUserNotFound); err != nil {
 		return err
 	}

--- a/backend/internal/repository/user_role_assign_test.go
+++ b/backend/internal/repository/user_role_assign_test.go
@@ -31,10 +31,10 @@ func insertRole(t *testing.T, ctx context.Context, name string) string {
 }
 
 // ---------------------------------------------------------------------------
-// AssignToUser
+// AssignRoleToUser
 // ---------------------------------------------------------------------------
 
-func TestUserRoleRepository_AssignToUser_HappyPath(t *testing.T) {
+func TestUserRoleRepository_AssignRoleToUser_HappyPath(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	userID := insertAuthUser(t, ctx)
@@ -46,8 +46,8 @@ func TestUserRoleRepository_AssignToUser_HappyPath(t *testing.T) {
 		t.Fatalf("FindByName(admin): %v", err)
 	}
 
-	if err := repo.AssignToUser(ctx, userID, admin.ID); err != nil {
-		t.Fatalf("AssignToUser: %v", err)
+	if err := repo.AssignRoleToUser(ctx, userID, admin.ID); err != nil {
+		t.Fatalf("AssignRoleToUser: %v", err)
 	}
 
 	roles, err := repo.ListByUser(ctx, userID)
@@ -62,7 +62,7 @@ func TestUserRoleRepository_AssignToUser_HappyPath(t *testing.T) {
 	}
 }
 
-func TestUserRoleRepository_AssignToUser_Idempotent(t *testing.T) {
+func TestUserRoleRepository_AssignRoleToUser_Idempotent(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	userID := insertAuthUser(t, ctx)
@@ -74,12 +74,12 @@ func TestUserRoleRepository_AssignToUser_Idempotent(t *testing.T) {
 		t.Fatalf("FindByName(admin): %v", err)
 	}
 
-	if err := repo.AssignToUser(ctx, userID, admin.ID); err != nil {
-		t.Fatalf("AssignToUser (first): %v", err)
+	if err := repo.AssignRoleToUser(ctx, userID, admin.ID); err != nil {
+		t.Fatalf("AssignRoleToUser (first): %v", err)
 	}
 	// Second call must not return an error.
-	if err := repo.AssignToUser(ctx, userID, admin.ID); err != nil {
-		t.Fatalf("AssignToUser (second, idempotent): %v", err)
+	if err := repo.AssignRoleToUser(ctx, userID, admin.ID); err != nil {
+		t.Fatalf("AssignRoleToUser (second, idempotent): %v", err)
 	}
 
 	roles, err := repo.ListByUser(ctx, userID)
@@ -91,7 +91,7 @@ func TestUserRoleRepository_AssignToUser_Idempotent(t *testing.T) {
 	}
 }
 
-func TestUserRoleRepository_AssignToUser_UserNotFound(t *testing.T) {
+func TestUserRoleRepository_AssignRoleToUser_UserNotFound(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	roleRepo := repository.NewRoleRepository(testDB.GORM)
@@ -103,44 +103,44 @@ func TestUserRoleRepository_AssignToUser_UserNotFound(t *testing.T) {
 	}
 
 	missingUser := uuid.NewString()
-	err = repo.AssignToUser(ctx, missingUser, admin.ID)
+	err = repo.AssignRoleToUser(ctx, missingUser, admin.ID)
 	if !errors.Is(err, repository.ErrUserNotFound) {
-		t.Fatalf("AssignToUser(missing user): want ErrUserNotFound, got %v", err)
+		t.Fatalf("AssignRoleToUser(missing user): want ErrUserNotFound, got %v", err)
 	}
 	// Backward-compat: legacy callers that match on ErrNotFound must still see
 	// the joined sentinel.
 	if !errors.Is(err, repository.ErrNotFound) {
-		t.Fatalf("AssignToUser(missing user): want errors.Is(_, ErrNotFound) true, got %v", err)
+		t.Fatalf("AssignRoleToUser(missing user): want errors.Is(_, ErrNotFound) true, got %v", err)
 	}
 }
 
-func TestUserRoleRepository_AssignToUser_RoleNotFound(t *testing.T) {
+func TestUserRoleRepository_AssignRoleToUser_RoleNotFound(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	userID := insertAuthUser(t, ctx)
 	repo := repository.NewUserRoleRepository(testDB.GORM)
 
 	missingRole := uuid.NewString()
-	err := repo.AssignToUser(ctx, userID, missingRole)
+	err := repo.AssignRoleToUser(ctx, userID, missingRole)
 	if !errors.Is(err, repository.ErrRoleNotFound) {
-		t.Fatalf("AssignToUser(missing role): want ErrRoleNotFound, got %v", err)
+		t.Fatalf("AssignRoleToUser(missing role): want ErrRoleNotFound, got %v", err)
 	}
 	if !errors.Is(err, repository.ErrNotFound) {
-		t.Fatalf("AssignToUser(missing role): want errors.Is(_, ErrNotFound) true, got %v", err)
+		t.Fatalf("AssignRoleToUser(missing role): want errors.Is(_, ErrNotFound) true, got %v", err)
 	}
 }
 
-// TestUserRoleRepository_AssignToUser_RoleNotFoundDistinct asserts that the new
+// TestUserRoleRepository_AssignRoleToUser_RoleNotFoundDistinct asserts that the new
 // sentinels are distinct: a missing-role error must not match the
 // missing-user sentinel, and vice versa.
-func TestUserRoleRepository_AssignToUser_RoleNotFoundDistinct(t *testing.T) {
+func TestUserRoleRepository_AssignRoleToUser_RoleNotFoundDistinct(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	userID := insertAuthUser(t, ctx)
 	repo := repository.NewUserRoleRepository(testDB.GORM)
 
 	missingRole := uuid.NewString()
-	err := repo.AssignToUser(ctx, userID, missingRole)
+	err := repo.AssignRoleToUser(ctx, userID, missingRole)
 	if !errors.Is(err, repository.ErrRoleNotFound) {
 		t.Fatalf("want ErrRoleNotFound, got %v", err)
 	}
@@ -164,8 +164,8 @@ func TestUserRoleRepository_SetUserRolesTx_ReplacesRoleSet(t *testing.T) {
 	reviewerID := insertRole(t, ctx, "reviewer")
 
 	for _, roleID := range []string{adminID, generalID} {
-		if err := repo.AssignToUser(ctx, userID, roleID); err != nil {
-			t.Fatalf("AssignToUser(%s): %v", roleID, err)
+		if err := repo.AssignRoleToUser(ctx, userID, roleID); err != nil {
+			t.Fatalf("AssignRoleToUser(%s): %v", roleID, err)
 		}
 	}
 
@@ -188,8 +188,8 @@ func TestUserRoleRepository_SetUserRolesTx_EmptyTargetClearsAllRoles(t *testing.
 	adminID := insertRole(t, ctx, "admin")
 	generalID := insertRole(t, ctx, "general")
 	for _, roleID := range []string{adminID, generalID} {
-		if err := repo.AssignToUser(ctx, userID, roleID); err != nil {
-			t.Fatalf("AssignToUser(%s): %v", roleID, err)
+		if err := repo.AssignRoleToUser(ctx, userID, roleID); err != nil {
+			t.Fatalf("AssignRoleToUser(%s): %v", roleID, err)
 		}
 	}
 
@@ -253,8 +253,8 @@ func TestUserRoleRepository_SetUserRolesTx_RoleNotFoundRollsBack(t *testing.T) {
 	repo := repository.NewUserRoleRepository(testDB.GORM)
 
 	adminID := insertRole(t, ctx, "admin")
-	if err := repo.AssignToUser(ctx, userID, adminID); err != nil {
-		t.Fatalf("AssignToUser: %v", err)
+	if err := repo.AssignRoleToUser(ctx, userID, adminID); err != nil {
+		t.Fatalf("AssignRoleToUser: %v", err)
 	}
 
 	missingRole := uuid.NewString()
@@ -339,8 +339,8 @@ func TestUserRoleRepository_ListByUser_OrderedByNameAsc(t *testing.T) {
 	reviewerID := insertRole(t, ctx, "reviewer")
 
 	for _, roleID := range []string{reviewerID, adminID, generalID} {
-		if err := repo.AssignToUser(ctx, userID, roleID); err != nil {
-			t.Fatalf("AssignToUser(%s): %v", roleID, err)
+		if err := repo.AssignRoleToUser(ctx, userID, roleID); err != nil {
+			t.Fatalf("AssignRoleToUser(%s): %v", roleID, err)
 		}
 	}
 
@@ -485,14 +485,14 @@ func TestUserRoleRepository_ListByUserIDs_MultipleUsers_NameAsc(t *testing.T) {
 	// Assign in deliberate reverse-alphabetical order for each user.
 	for _, uid := range []string{userA, userB, userC} {
 		for _, rid := range []string{reviewerID, adminID} {
-			if err := repo.AssignToUser(ctx, uid, rid); err != nil {
-				t.Fatalf("AssignToUser(%s, %s): %v", uid, rid, err)
+			if err := repo.AssignRoleToUser(ctx, uid, rid); err != nil {
+				t.Fatalf("AssignRoleToUser(%s, %s): %v", uid, rid, err)
 			}
 		}
 	}
 	// userC also gets "general" to exercise a third distinct ordering.
-	if err := repo.AssignToUser(ctx, userC, generalID); err != nil {
-		t.Fatalf("AssignToUser(userC, general): %v", err)
+	if err := repo.AssignRoleToUser(ctx, userC, generalID); err != nil {
+		t.Fatalf("AssignRoleToUser(userC, general): %v", err)
 	}
 
 	result, err := repo.ListByUserIDs(ctx, []string{userA, userB, userC})
@@ -541,8 +541,8 @@ func TestUserRoleRepository_ListByUserIDs_UnknownUserAbsentFromMap(t *testing.T)
 	unknownUser := uuid.NewString()
 
 	adminID := insertRole(t, ctx, "admin")
-	if err := repo.AssignToUser(ctx, knownUser, adminID); err != nil {
-		t.Fatalf("AssignToUser: %v", err)
+	if err := repo.AssignRoleToUser(ctx, knownUser, adminID); err != nil {
+		t.Fatalf("AssignRoleToUser: %v", err)
 	}
 
 	result, err := repo.ListByUserIDs(ctx, []string{knownUser, unknownUser})

--- a/backend/internal/repository/user_role_count_admin_test.go
+++ b/backend/internal/repository/user_role_count_admin_test.go
@@ -37,8 +37,8 @@ func TestUserRoleRepository_CountAdmins(t *testing.T) {
 		t.Fatalf("FindByName(admin): %v", err)
 	}
 	userID := insertAuthUser(t, ctx)
-	if err := repo.AssignToUser(ctx, userID, role.ID); err != nil {
-		t.Fatalf("AssignToUser: %v", err)
+	if err := repo.AssignRoleToUser(ctx, userID, role.ID); err != nil {
+		t.Fatalf("AssignRoleToUser: %v", err)
 	}
 
 	n2, err := repo.CountAdmins(ctx)

--- a/backend/internal/usecase/card.go
+++ b/backend/internal/usecase/card.go
@@ -372,16 +372,16 @@ func (u *cardUsecase) ListCardsByCardgroupConnection(
 		return nil, err
 	}
 
-	orderBy, dir, err := resolveOrderBy(in.OrderBy, in.OrderDirection)
+	orderBy, dir, err := resolveCardOrderBy(in.OrderBy, in.OrderDirection)
 	if err != nil {
 		return nil, err
 	}
 
-	after, err := u.resolveCursor(ctx, in.After, in.CardgroupID, orderBy, "after")
+	after, err := u.resolveCardCursor(ctx, in.After, in.CardgroupID, orderBy, "after")
 	if err != nil {
 		return nil, err
 	}
-	before, err := u.resolveCursor(ctx, in.Before, in.CardgroupID, orderBy, "before")
+	before, err := u.resolveCardCursor(ctx, in.Before, in.CardgroupID, orderBy, "before")
 	if err != nil {
 		return nil, err
 	}
@@ -421,20 +421,20 @@ var cardOrderByColumns = map[CardOrderBy]repository.CardOrderBy{
 	CardOrderByDue:       repository.CardOrderByDue,
 }
 
-// resolveOrderBy maps the typed usecase enums to the repository allowlist.
+// resolveCardOrderBy maps the typed usecase enums to the repository allowlist.
 // Defaults to (ID, ASC) when both are nil. The default arm is defense in
 // depth — gqlgen UnmarshalGQL already rejects invalid enum strings upstream.
-func resolveOrderBy(orderBy *CardOrderBy, dir *SortOrder) (repository.CardOrderBy, repository.SortOrder, error) {
+func resolveCardOrderBy(orderBy *CardOrderBy, dir *SortOrder) (repository.CardOrderBy, repository.SortOrder, error) {
 	return resolveOrderByColumn(orderBy, dir, cardOrderByColumns, repository.CardOrderByID, repository.SortAsc)
 }
 
-// resolveCursor decodes an opaque cursor string into a *repository.CardCursor
+// resolveCardCursor decodes an opaque cursor string into a *repository.CardCursor
 // with the field needed for the active orderBy populated. The cursor may be a
 // v1 envelope ("v1:" + base64) or a legacy bare UUID; both are accepted during
 // the backward-compatibility window. Returns BAD_USER_INPUT when the cursor
 // cannot be decoded, the card cannot be found, or the card belongs to a
 // different cardgroup.
-func (u *cardUsecase) resolveCursor(
+func (u *cardUsecase) resolveCardCursor(
 	ctx context.Context,
 	cursorStr *string,
 	cardgroupID string,
@@ -466,7 +466,7 @@ func (u *cardUsecase) resolveCursor(
 	case repository.CardOrderByDue:
 		due := card.CreatedAt
 		if u.userFSRSRepo == nil {
-			u.logger.WarnContext(ctx, "card: resolveCursor: falling back to createdAt for OrderByDue because userFSRSRepo is nil or not configured")
+			u.logger.WarnContext(ctx, "card: resolveCardCursor: falling back to createdAt for OrderByDue because userFSRSRepo is nil or not configured")
 		} else if user := auth.UserFrom(ctx); user != nil {
 			byCardID, err := u.userFSRSRepo.FindByUserAndCardIDs(ctx, user.Sub, []string{id})
 			if err != nil {

--- a/backend/internal/usecase/card_import.go
+++ b/backend/internal/usecase/card_import.go
@@ -34,7 +34,8 @@ type CardImportUsecase interface {
 }
 
 // ImportCardsInput is the wire-shape consumed by CardImportUsecase.Import.
-// Payload reuses the validateCardImport base64-encoded text format.
+// Payload reuses the base64-encoded text format of the `validateCardImport`
+// GraphQL query.
 type ImportCardsInput struct {
 	CardgroupID string
 	Payload     string // standard base64-encoded plain-text card import payload

--- a/backend/internal/usecase/card_test.go
+++ b/backend/internal/usecase/card_test.go
@@ -753,7 +753,7 @@ func TestCardUsecase_ListCardsByCardgroupConnection_BackwardPaging(t *testing.T)
 }
 
 // TestCardUsecase_ListCardsByCardgroupConnection_ResolveCursorHydratesDueField
-// pins down that resolveCursor populates the field matching the active
+// pins down that resolveCardCursor populates the field matching the active
 // orderBy on the *CardCursor passed to FindPageByCardgroup.
 func TestCardUsecase_ListCardsByCardgroupConnection_ResolveCursorHydratesDueField(t *testing.T) {
 	t.Parallel()
@@ -852,7 +852,7 @@ func TestCardUsecase_ResolveCursor_MalformedV1_ReturnsBadUserInput(t *testing.T)
 		nil, nil, newTestLogger(),
 	)
 	malformed := "v1:!!!not-base64!!!"
-	_, err := uc.(*cardUsecase).resolveCursor(
+	_, err := uc.(*cardUsecase).resolveCardCursor(
 		context.Background(),
 		&malformed, "cg1", repository.CardOrderByID, "after",
 	)
@@ -871,7 +871,7 @@ func TestCardUsecase_ResolveCursor_V1EncodedID(t *testing.T) {
 	)
 	// "v1:" + base64.RawURLEncoding.EncodeToString([]byte("card-abc")) == "v1:Y2FyZC1hYmM"
 	encoded := "v1:Y2FyZC1hYmM"
-	c, err := uc.(*cardUsecase).resolveCursor(
+	c, err := uc.(*cardUsecase).resolveCardCursor(
 		context.Background(),
 		&encoded, "cg1", repository.CardOrderByID, "after",
 	)

--- a/backend/internal/usecase/master_card.go
+++ b/backend/internal/usecase/master_card.go
@@ -210,7 +210,7 @@ type UpdateMasterCardOutcome struct {
 }
 
 // ImportMasterCardsInput is the wire-shape consumed by ImportMasterCards. Payload
-// reuses the validateCardImport base64-encoded text format.
+// reuses the base64-encoded text format of the `validateCardImport` GraphQL query.
 type ImportMasterCardsInput struct {
 	MasterCardgroupID string
 	Payload           string // standard base64-encoded plain-text card import payload

--- a/backend/internal/usecase/master_catalog.go
+++ b/backend/internal/usecase/master_catalog.go
@@ -116,7 +116,7 @@ type MergeMasterOutcome struct {
 	// is subsumed so draft ids are indistinguishable from absent ids. True iff Cardgroup
 	// is nil. The XOR is a producer contract, not a compile-time guarantee: a degenerate
 	// {Cardgroup:nil, NotFound:false} result is treated as INTERNAL by the resolver's
-	// defensive guard (noVariantSet).
+	// defensive guard (newNoVariantSetError).
 	NotFound bool
 }
 
@@ -240,7 +240,7 @@ func (u *masterCatalogUsecase) ListPublishedConnection(
 // supplies the per-caller authorization / visibility check (anonymous-allowed
 // authentication for the published catalog vs. adminGate.Require for the admin
 // surface); everything from cursor resolution onward is identical except two
-// caller-supplied knobs: publishedOnly threads into resolveMasterCursor to pick the
+// caller-supplied knobs: publishedOnly threads into resolveMasterCatalogCursor to pick the
 // hydration scope (true = published catalog, a DRAFT or unknown id is rejected as
 // cursor-not-found so drafts never leak; false = admin, DRAFT decks are valid
 // cursors), and fetch is the repository page method (FindPublishedPage /
@@ -269,11 +269,11 @@ func (u *masterCatalogUsecase) listMasterCatalogCore(
 		return nil, err
 	}
 
-	after, err := u.resolveMasterCursor(ctx, in.After, orderBy, "after", publishedOnly)
+	after, err := u.resolveMasterCatalogCursor(ctx, in.After, orderBy, "after", publishedOnly)
 	if err != nil {
 		return nil, err
 	}
-	before, err := u.resolveMasterCursor(ctx, in.Before, orderBy, "before", publishedOnly)
+	before, err := u.resolveMasterCatalogCursor(ctx, in.Before, orderBy, "before", publishedOnly)
 	if err != nil {
 		return nil, err
 	}
@@ -329,7 +329,7 @@ func resolveMasterCatalogOrderBy(
 	return resolveOrderByColumn(orderBy, dir, masterCatalogOrderByColumns, repository.MasterCatalogOrderBySortOrder, repository.SortAsc)
 }
 
-// resolveMasterCursor decodes an opaque cursor string into a
+// resolveMasterCatalogCursor decodes an opaque cursor string into a
 // *repository.MasterCatalogCursor with the column required by the active orderBy
 // populated. The publishedOnly flag selects the hydration scope: true hydrates
 // via FindPublishedByID (catalog scope — a draft or unknown id is rejected as
@@ -337,7 +337,7 @@ func resolveMasterCatalogOrderBy(
 // scope — DRAFT decks are valid cursors). Returns BAD_USER_INPUT when the cursor
 // cannot be decoded or references a row outside the active scope. The scope check
 // runs even when orderBy is missing a hydratable column.
-func (u *masterCatalogUsecase) resolveMasterCursor(
+func (u *masterCatalogUsecase) resolveMasterCatalogCursor(
 	ctx context.Context,
 	cursorStr *string,
 	orderBy repository.MasterCatalogOrderBy,

--- a/backend/internal/usecase/orderby_exhaustiveness_test.go
+++ b/backend/internal/usecase/orderby_exhaustiveness_test.go
@@ -32,15 +32,15 @@ func TestResolveOrderBy_AllCardOrderByValuesMapped(t *testing.T) {
 	}
 	for _, c := range cases {
 		ob := c.in
-		got, _, err := resolveOrderBy(&ob, nil)
+		got, _, err := resolveCardOrderBy(&ob, nil)
 		if err != nil {
-			t.Errorf("resolveOrderBy(%q): unexpected error %v", c.in, err)
+			t.Errorf("resolveCardOrderBy(%q): unexpected error %v", c.in, err)
 		}
 		if got == "" {
-			t.Errorf("resolveOrderBy(%q): mapped to the empty repository value (default arm)", c.in)
+			t.Errorf("resolveCardOrderBy(%q): mapped to the empty repository value (default arm)", c.in)
 		}
 		if got != c.want {
-			t.Errorf("resolveOrderBy(%q) = %q, want %q", c.in, got, c.want)
+			t.Errorf("resolveCardOrderBy(%q) = %q, want %q", c.in, got, c.want)
 		}
 	}
 }

--- a/backend/internal/usecase/page.go
+++ b/backend/internal/usecase/page.go
@@ -107,7 +107,7 @@ func resolveRelayPage(
 //
 // hasAfter/hasBefore MUST be the post-decode cursor presence — i.e. pass
 // (resolvedAfter != nil) / (resolvedBefore != nil) using the value returned
-// by the per-aggregate resolveCursor step, NOT the raw request *string. They
+// by the per-aggregate resolve*Cursor step, NOT the raw request *string. They
 // supply the "other" page-edge flag the +1 trim cannot derive: forward paging
 // sets hasPrev from hasAfter, backward paging sets hasNext from hasBefore.
 func assemblePage[T any](

--- a/backend/internal/usecase/swipe_performance_test.go
+++ b/backend/internal/usecase/swipe_performance_test.go
@@ -60,9 +60,9 @@ func TestSwipeUsecase_HandleSwipePerformanceMode(t *testing.T) {
 			wantReview: 20,
 		},
 		{
-			name:       "ninety five percent success becomes in while",
+			name:       "ninety five percent success becomes mastered",
 			recent:     performanceSwipes(base, 18, 1, 5),
-			wantMode:   int(service.ModeInWhile),
+			wantMode:   int(service.ModeMastered),
 			wantReview: 20,
 		},
 	}


### PR DESCRIPTION
## Summary

Nine behaviour-preserving identifier renames (plus one doc-comment clarification) across the backend, so each symbol's name matches what it does. Within an aggregate a getter that returns a **collection** now reads `List…` (not `Find…`); an error/value constructor reads `new…` (not a `bool`-looking predicate); and aggregate-scoped helpers carry the aggregate in the name so a package-wide grep is unambiguous. No behaviour, signature, or error-shape changes — this is the still-open nine-nit batch that #834's note flagged as separate.

## Changes

### Repository- and auth-layer renames

- `cardRepo.FindByCardgroup` → `ListByCardgroup` (`repository/card.go`): returns `[]*domain.Card`, so the `List…` verb matches the sibling `ListByMasterCardgroup` and the intra-file `ListFrontsByCardgroupTx`. `FindByCardgroupAndFront` (single entity) correctly stays `Find…`.
- `classifyUniqueError` → `classifyRoleNameDuplicate` (`repository/role.go`): the helper only classifies the `roles.name` 23505 unique violation; the generic name was too broad next to the sibling `classifyMasterCardFKError`.
- `AssignToUser` → `AssignRoleToUser` (`repository/user_role.go`): the object (role) was missing from the name. Widest fan-out — renames the repository interface method **and** the consumer-defined `auth.roleAssigner` interface method, so every implementer (production repo, `superuser.go` call site + eris wrap string, and the four test fakes) is updated in the same change to keep satisfying both interfaces.
- `SuperUserPromoter.confirmed` field → `confirmedAdmins` (`auth/superuser.go`): the field is the process-lifetime set of subs already confirmed to hold the admin role; the bare name relied on the comment to convey "admins".

### Usecase-layer renames

- `masterCatalogUsecase.resolveMasterCursor` → `resolveMasterCatalogCursor` (`usecase/master_catalog.go`): disambiguates against the sibling `masterCardUsecase.resolveMasterCardCursor`.
- Card helpers aggregate-qualified (`usecase/card.go`): package-level `resolveOrderBy` → `resolveCardOrderBy`, method `resolveCursor` → `resolveCardCursor` (incl. the fallback log-message string), matching every other aggregate (`resolveMasterCardOrderBy`, `resolveMasterCardCursor`). The generic `page.go` comment that named `resolveCursor` is reworded to `resolve*Cursor` so it stays a live reference. `resolveOrderByColumn` (aggregate-agnostic) is untouched.
- `validateCardImport` doc-comment clarification (`usecase/card_import.go`, `master_card.go`): the two comments now read "base64-encoded text format of the `validateCardImport` GraphQL query" so a reader does not mistake the real GraphQL query field for a Go symbol. Not a symbol rename — the query field and its `ValidateCardImport` resolver are unchanged.

### Resolver-layer rename

- `noVariantSet` → `newNoVariantSetError` (`graph/resolver/helpers.go` + all outcome-union call sites): the helper *builds* a `*gqlerror.Error`, but the old name read as a boolean predicate. Renamed to the `new…Error` constructor form; the test `TestNoVariantSet_MessageAndCode` follows to `TestNewNoVariantSetError_MessageAndCode`.

### Domain-service rename

- `ModeInWhile` → `ModeMastered` and the paired `inWhileModeThreshold` → `masteredModeThreshold` (`domain/service/user_performance.go`): `InWhile` was opaque; success rate ≥ 0.95 means the user has effectively **mastered** these cards, continuing the sibling scale `ModeDifficult…ModeEasy`.

### Tests

- Updated every call site, test-function name, stub/fake method, comment, and case description that referenced an old identifier, per the language-policy stale-identifier rule (e.g. `Test…_AssignToUser_*` → `…_AssignRoleToUser_*`, `"in while"` case descriptions → `"mastered"`).

## Verification

Post-refactor grep — each **old** identifier returns zero hits across production and tests:

```bash
grep -rn  'FindByCardgroup\b' backend/ --include='*.go' | grep -v FindByCardgroupAndFront   # -> 0
grep -rn  'resolveMasterCursor\b' backend/ --include='*.go'                                 # -> 0
grep -rnE '\bresolveOrderBy\b|\bresolveCursor\b' backend/ --include='*.go' | grep -v resolveOrderByColumn  # -> 0
grep -rn  'classifyUniqueError' backend/ --include='*.go'                                    # -> 0
grep -rn  'AssignToUser'        backend/ --include='*.go'                                     # -> 0
grep -rn  'noVariantSet'        backend/ --include='*.go'                                     # -> 0
grep -rnE 'ModeInWhile|inWhileModeThreshold' backend/ --include='*.go'                        # -> 0
```

## Test plan

- [x] `go build ./...` — success.
- [x] `go vet ./...` — no issues (type-checks all test files, incl. Docker-gated `repository/` and `cmd/`).
- [x] `go tool go-arch-lint check --project-path .` — no import-graph change.
- [x] Non-Docker packages green (`graph/resolver`, `internal/auth`, `internal/domain/service`, `internal/loader`, `internal/usecase`) — cover items 1–8.
- [ ] `go test ./...` with Docker/testcontainers — full suite green (runs in backend CI; renames only, no logic change).

Closes #833
