### PR TITLE
feat(backend): myLearningStats — diagnostic metrics + struggling cards

### DIFF
--- a/backend/.go-arch-lint.yml
+++ b/backend/.go-arch-lint.yml
@@ -81,6 +81,7 @@ deps:
       - auth
       - cursor
       - domain
+      - domain_service
       - gqlerr
       - loader
       - textdic

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -194,7 +194,7 @@ func buildResolver(
 	cefrUC := usecase.NewCEFRUsecase(cefrClassifier)
 	masterCatalogUC := usecase.NewMasterCatalogUsecase(repos.masterCardgroup, masterDeckUC, adminGate, logger)
 	masterCardUC := usecase.NewMasterCardUsecase(repos.gorm, repos.masterCard, repos.masterCardgroup, adminGate, logger)
-	statsUC := usecase.NewStats(repos.userCardFSRS, repos.swipeRecord, time.Now)
+	statsUC := usecase.NewStats(repos.userCardFSRS, repos.swipeRecord, nil)
 
 	resolvers := resolver.NewResolver(userUC, cardgroupUC, cardUC, swipeUC, authSvc, cardImportUC, adminUserUC, adminRoleUC, lastViewedCardgroupUC, updateLearnDisplayModeUC, updateNewCardRatioUC, learnUC, cefrUC, masterCatalogUC, masterCardUC, statsUC)
 	return resolvers, pingHandler, notionSyncHandler, nil

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -194,7 +194,7 @@ func buildResolver(
 	cefrUC := usecase.NewCEFRUsecase(cefrClassifier)
 	masterCatalogUC := usecase.NewMasterCatalogUsecase(repos.masterCardgroup, masterDeckUC, adminGate, logger)
 	masterCardUC := usecase.NewMasterCardUsecase(repos.gorm, repos.masterCard, repos.masterCardgroup, adminGate, logger)
-	statsUC := usecase.NewStats(repos.userCardFSRS)
+	statsUC := usecase.NewStats(repos.userCardFSRS, repos.swipeRecord, time.Now)
 
 	resolvers := resolver.NewResolver(userUC, cardgroupUC, cardUC, swipeUC, authSvc, cardImportUC, adminUserUC, adminRoleUC, lastViewedCardgroupUC, updateLearnDisplayModeUC, updateNewCardRatioUC, learnUC, cefrUC, masterCatalogUC, masterCardUC, statsUC)
 	return resolvers, pingHandler, notionSyncHandler, nil

--- a/backend/graph/resolver/mapper.go
+++ b/backend/graph/resolver/mapper.go
@@ -46,9 +46,11 @@ func toCardgroupModel(cg *domain.Cardgroup) *model.Cardgroup {
 }
 
 // toLearningStatsModel maps the usecase learning-stats result to the generated
-// GraphQL model, hydrating each deck's Cardgroup from its id via the existing
-// per-request DataLoader. A missing loader registry or a Load failure is
-// surfaced as an INTERNAL/CANCELLED wire error.
+// GraphQL model, hydrating each deck's Cardgroup and each struggling card's
+// Card from their ids via the existing per-request DataLoader (loaders.Cardgroup
+// and loaders.Card respectively), each via its own two-phase Load-then-resolve
+// pass. A missing loader registry or a Load failure is surfaced as an
+// INTERNAL/CANCELLED wire error.
 func toLearningStatsModel(ctx context.Context, res *usecase.LearningStatsResult) (*model.LearningStats, error) {
 	loaders, gqlErr := loadersOrInternal(ctx)
 	if gqlErr != nil {

--- a/backend/graph/resolver/mapper.go
+++ b/backend/graph/resolver/mapper.go
@@ -8,6 +8,7 @@ import (
 
 	"backend/graph/model"
 	"backend/internal/domain"
+	"backend/internal/domain/service"
 	"backend/internal/usecase"
 )
 
@@ -76,6 +77,26 @@ func toLearningStatsModel(ctx context.Context, res *usecase.LearningStatsResult)
 			MatureCards:  d.MatureCards,
 		})
 	}
+
+	// Hydrate each struggling card from its id via the Card DataLoader, using the
+	// same two-phase Load-then-resolve so every key lands in one batch window.
+	cardThunks := make([]func() (*domain.Card, error), len(res.StrugglingCards))
+	for i, sc := range res.StrugglingCards {
+		cardThunks[i] = loaders.Card.Load(ctx, sc.CardID)
+	}
+	struggling := make([]*model.StrugglingCard, 0, len(res.StrugglingCards))
+	for i, sc := range res.StrugglingCards {
+		card, err := cardThunks[i]()
+		if err != nil {
+			return nil, classifyLoaderErr(ctx, err, "resolver: stats: struggling card")
+		}
+		struggling = append(struggling, &model.StrugglingCard{
+			Card:      toCardModel(card),
+			Lapses:    sc.Lapses,
+			Stability: sc.Stability,
+		})
+	}
+
 	return &model.LearningStats{
 		Mastery: &model.MasteryBreakdown{
 			InProgress:   res.Mastery.InProgress,
@@ -83,7 +104,9 @@ func toLearningStatsModel(ctx context.Context, res *usecase.LearningStatsResult)
 			Mature:       res.Mastery.Mature,
 			TotalStudied: res.Mastery.TotalStudied,
 		},
-		Decks: decks,
+		Decks:           decks,
+		Performance:     toPerformanceMetricsModel(res.Performance),
+		StrugglingCards: struggling,
 	}, nil
 }
 
@@ -286,13 +309,20 @@ func toSwipeResponseModel(out *usecase.SwipeOutput) *model.SwipeResponse {
 	}
 	return &model.SwipeResponse{
 		PerformanceMode: out.PerformanceMode,
-		Metrics: &model.PerformanceMetrics{
-			SuccessRate:   out.Metrics.SuccessRate,
-			AvgDifficulty: out.Metrics.AvgDifficulty,
-			RetentionRate: out.Metrics.RetentionRate,
-			StudyStreak:   out.Metrics.StudyStreak,
-			LapseRate:     out.Metrics.LapseRate,
-			ReviewCount:   out.Metrics.ReviewCount,
-		},
+		Metrics:         toPerformanceMetricsModel(out.Metrics),
+	}
+}
+
+// toPerformanceMetricsModel maps the domain-service performance value object to
+// the generated wire model. Shared by the swipe response and the learning-stats
+// diagnostic snapshot.
+func toPerformanceMetricsModel(m service.PerformanceMetrics) *model.PerformanceMetrics {
+	return &model.PerformanceMetrics{
+		SuccessRate:   m.SuccessRate,
+		AvgDifficulty: m.AvgDifficulty,
+		RetentionRate: m.RetentionRate,
+		StudyStreak:   m.StudyStreak,
+		LapseRate:     m.LapseRate,
+		ReviewCount:   m.ReviewCount,
 	}
 }

--- a/backend/graph/resolver/stats_resolver_test.go
+++ b/backend/graph/resolver/stats_resolver_test.go
@@ -12,6 +12,7 @@ import (
 	"backend/graph/generated"
 	"backend/graph/resolver"
 	"backend/internal/domain"
+	"backend/internal/domain/service"
 	"backend/internal/gqlerr"
 	"backend/internal/loader"
 	"backend/internal/usecase"
@@ -233,5 +234,175 @@ func TestMyLearningStats_Unauthenticated(t *testing.T) {
 	code := errCode(t, resp)
 	if code != string(gqlerr.CodeUnauthenticated) {
 		t.Fatalf("expected UNAUTHENTICATED, got %q", code)
+	}
+}
+
+// ctxWithCardLoader installs an in-memory Card loader (in addition to a
+// Cardgroup loader) for the diagnostic-half myLearningStats tests. A missing
+// card_id returns loader.ErrNotFound, matching production behaviour.
+func ctxWithCardLoader(base context.Context, cards map[string]*domain.Card) context.Context {
+	loaders := &loader.Loaders{
+		Card: dataloader.NewBatchedLoader(
+			func(_ context.Context, keys []string) []*dataloader.Result[*domain.Card] {
+				out := make([]*dataloader.Result[*domain.Card], len(keys))
+				for i, k := range keys {
+					if card, ok := cards[k]; ok {
+						out[i] = &dataloader.Result[*domain.Card]{Data: card}
+					} else {
+						out[i] = &dataloader.Result[*domain.Card]{Error: loader.ErrNotFound}
+					}
+				}
+				return out
+			},
+		),
+	}
+	return loader.WithContext(base, loaders)
+}
+
+// ctxWithCardLoaderError installs a Card loader whose batch function fails every
+// key with loadErr.
+func ctxWithCardLoaderError(base context.Context, loadErr error) context.Context {
+	loaders := &loader.Loaders{
+		Card: dataloader.NewBatchedLoader(
+			func(_ context.Context, keys []string) []*dataloader.Result[*domain.Card] {
+				out := make([]*dataloader.Result[*domain.Card], len(keys))
+				for i := range keys {
+					out[i] = &dataloader.Result[*domain.Card]{Error: loadErr}
+				}
+				return out
+			},
+		),
+	}
+	return loader.WithContext(base, loaders)
+}
+
+const myLearningStatsDiagnosticQuery = `{"query":"{ myLearningStats { mastery { totalStudied } performance { retentionRate successRate lapseRate studyStreak reviewCount avgDifficulty } strugglingCards { card { id front } lapses stability } } }"}`
+
+// TestMyLearningStats_PerformanceAndStrugglingCards verifies the diagnostic half
+// of the response: the performance snapshot maps every metric field, and the
+// struggling-card list preserves the usecase order while hydrating each Card
+// from its id via the in-memory Card DataLoader.
+func TestMyLearningStats_PerformanceAndStrugglingCards(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockStatsUsecase{
+		result: &usecase.LearningStatsResult{
+			Mastery: usecase.MasteryBreakdown{TotalStudied: 3},
+			Performance: service.PerformanceMetrics{
+				SuccessRate:   0.8,
+				AvgDifficulty: 0.4,
+				RetentionRate: 0.9,
+				StudyStreak:   5,
+				LapseRate:     0.1,
+				ReviewCount:   42,
+			},
+			StrugglingCards: []usecase.StrugglingCardResult{
+				{CardID: "card-1", Lapses: 5, Stability: 2.5},
+				{CardID: "card-2", Lapses: 3, Stability: 8},
+			},
+		},
+	}
+	srv := newStatsSrv(mock)
+
+	cards := map[string]*domain.Card{
+		"card-1": {ID: "card-1", Front: "alpha", CardgroupID: domain.CardgroupID("cg-1")},
+		"card-2": {ID: "card-2", Front: "beta", CardgroupID: domain.CardgroupID("cg-1")},
+	}
+	ctx := ctxWithCardLoader(authedCtx("u-1"), cards)
+	resp := gqlRequest(t, srv, ctx, myLearningStatsDiagnosticQuery)
+
+	if errs, hasErrs := resp["errors"]; hasErrs {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	data, _ := resp["data"].(map[string]any)
+	stats, _ := data["myLearningStats"].(map[string]any)
+	if stats == nil {
+		t.Fatalf("expected data.myLearningStats, got nil; response: %v", resp)
+	}
+
+	perf, _ := stats["performance"].(map[string]any)
+	if perf == nil {
+		t.Fatalf("expected performance, got nil; response: %v", resp)
+	}
+	if perf["retentionRate"] != float64(0.9) || perf["successRate"] != float64(0.8) ||
+		perf["lapseRate"] != float64(0.1) || perf["avgDifficulty"] != float64(0.4) ||
+		perf["studyStreak"] != float64(5) || perf["reviewCount"] != float64(42) {
+		t.Fatalf("performance metrics mismatch: %v", perf)
+	}
+
+	struggling, _ := stats["strugglingCards"].([]any)
+	if len(struggling) != 2 {
+		t.Fatalf("expected 2 struggling cards, got %d; response: %v", len(struggling), resp)
+	}
+
+	sc0, _ := struggling[0].(map[string]any)
+	if sc0["lapses"] != float64(5) || sc0["stability"] != float64(2.5) {
+		t.Fatalf("struggling card 0 mismatch: %v", sc0)
+	}
+	card0, _ := sc0["card"].(map[string]any)
+	if card0 == nil || card0["id"] != "card-1" || card0["front"] != "alpha" {
+		t.Fatalf("expected struggling card 0 hydrated {id: card-1, front: alpha}, got %v", card0)
+	}
+
+	sc1, _ := struggling[1].(map[string]any)
+	if sc1["lapses"] != float64(3) || sc1["stability"] != float64(8) {
+		t.Fatalf("struggling card 1 mismatch: %v", sc1)
+	}
+	card1, _ := sc1["card"].(map[string]any)
+	if card1 == nil || card1["id"] != "card-2" || card1["front"] != "beta" {
+		t.Fatalf("expected struggling card 1 hydrated {id: card-2, front: beta}, got %v", card1)
+	}
+}
+
+// TestMyLearningStats_NoLapses_ReturnsEmptyStrugglingCards verifies that a
+// learner with no struggling cards serializes strugglingCards as an empty array
+// (not null), with no Card DataLoader invoked.
+func TestMyLearningStats_NoLapses_ReturnsEmptyStrugglingCards(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockStatsUsecase{
+		result: &usecase.LearningStatsResult{
+			Mastery:         usecase.MasteryBreakdown{TotalStudied: 2},
+			StrugglingCards: []usecase.StrugglingCardResult{},
+		},
+	}
+	srv := newStatsSrv(mock)
+
+	ctx := ctxWithCardLoader(authedCtx("u-1"), map[string]*domain.Card{})
+	resp := gqlRequest(t, srv, ctx, myLearningStatsDiagnosticQuery)
+
+	if errs, hasErrs := resp["errors"]; hasErrs {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	data, _ := resp["data"].(map[string]any)
+	stats, _ := data["myLearningStats"].(map[string]any)
+	struggling, ok := stats["strugglingCards"].([]any)
+	if !ok {
+		t.Fatalf("expected strugglingCards array, got %v", stats["strugglingCards"])
+	}
+	if len(struggling) != 0 {
+		t.Fatalf("expected empty strugglingCards, got %d entries", len(struggling))
+	}
+}
+
+// TestMyLearningStats_StrugglingCardLoadError_ReturnsInternal drives the
+// struggling-card Card hydration through a Card DataLoader that fails with a
+// generic error; classifyLoaderErr must surface INTERNAL.
+func TestMyLearningStats_StrugglingCardLoadError_ReturnsInternal(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockStatsUsecase{
+		result: &usecase.LearningStatsResult{
+			StrugglingCards: []usecase.StrugglingCardResult{{CardID: "card-1", Lapses: 2, Stability: 1}},
+		},
+	}
+	srv := newStatsSrv(mock)
+
+	ctx := ctxWithCardLoaderError(authedCtx("u-1"), errors.New("db down"))
+	resp := gqlRequest(t, srv, ctx, myLearningStatsDiagnosticQuery)
+
+	code := errCode(t, resp)
+	if code != string(gqlerr.CodeInternal) {
+		t.Fatalf("expected INTERNAL for a generic Card loader error, got %q", code)
 	}
 }

--- a/backend/graph/resolver/stats_resolver_test.go
+++ b/backend/graph/resolver/stats_resolver_test.go
@@ -37,10 +37,11 @@ func newStatsSrv(uc usecase.StatsUsecase) *handler.Server {
 	return srv
 }
 
-// ctxWithCardgroupLoader installs an in-memory Cardgroup loader for
-// MyLearningStats resolver tests. A missing cardgroup_id returns
-// loader.ErrNotFound, matching production behaviour. Other Loaders fields stay
-// nil because toLearningStatsModel only reads loaders.Cardgroup.
+// ctxWithCardgroupLoader installs ONLY an in-memory Cardgroup loader for
+// MyLearningStats resolver tests with no struggling cards. A missing
+// cardgroup_id returns loader.ErrNotFound, matching production behaviour.
+// toLearningStatsModel also reads loaders.Card when StrugglingCards is
+// non-empty; use ctxWithCardLoader (below) for those cases.
 func ctxWithCardgroupLoader(base context.Context, cgs map[string]*domain.Cardgroup) context.Context {
 	loaders := &loader.Loaders{
 		Cardgroup: dataloader.NewBatchedLoader(

--- a/backend/internal/loader/swipe_record_test.go
+++ b/backend/internal/loader/swipe_record_test.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"gorm.io/gorm"
 
@@ -31,6 +32,10 @@ func (r *countingSwipeRecordRepo) FindByUserAndCardgroup(context.Context, string
 
 func (r *countingSwipeRecordRepo) ListRecentByUser(context.Context, string, int) ([]*domain.SwipeRecord, error) {
 	panic("countingSwipeRecordRepo.ListRecentByUser not configured")
+}
+
+func (r *countingSwipeRecordRepo) ListByUserSince(context.Context, string, time.Time) ([]*domain.SwipeRecord, error) {
+	panic("countingSwipeRecordRepo.ListByUserSince not configured")
 }
 
 func (r *countingSwipeRecordRepo) CreateTx(context.Context, *gorm.DB, *domain.SwipeRecord) error {

--- a/backend/internal/repository/swipe_record.go
+++ b/backend/internal/repository/swipe_record.go
@@ -34,6 +34,7 @@ type SwipeRecordRepository interface {
 	FindByIDs(ctx context.Context, ids []string) (map[string]*domain.SwipeRecord, error)
 	FindByUserAndCardgroup(ctx context.Context, userID, cardgroupID string) ([]*domain.SwipeRecord, error)
 	ListRecentByUser(ctx context.Context, userID string, limit int) ([]*domain.SwipeRecord, error)
+	ListByUserSince(ctx context.Context, userID string, since time.Time) ([]*domain.SwipeRecord, error)
 	CreateTx(ctx context.Context, tx *gorm.DB, sr *domain.SwipeRecord) error
 }
 
@@ -91,6 +92,24 @@ func (r *swipeRecordRepo) ListRecentByUser(ctx context.Context, userID string, l
 	out := make([]*domain.SwipeRecord, len(rows))
 	for i := range rows {
 		out[i] = swipeRecordToDomain(rows[i])
+	}
+	return out, nil
+}
+
+// ListByUserSince returns userID's swipes with reviewed_at >= since, in
+// unspecified order (ComputeMetrics is order-independent). Windowed read for the
+// stats diagnostic snapshot.
+func (r *swipeRecordRepo) ListByUserSince(ctx context.Context, userID string, since time.Time) ([]*domain.SwipeRecord, error) {
+	var rows []gormSwipeRecord
+	err := r.db.WithContext(ctx).
+		Where("user_id = ? AND reviewed_at >= ?", userID, since).
+		Find(&rows).Error
+	if err != nil {
+		return nil, eris.Wrap(err, "repository: swipe record: list by user since")
+	}
+	out := make([]*domain.SwipeRecord, 0, len(rows))
+	for i := range rows {
+		out = append(out, swipeRecordToDomain(rows[i]))
 	}
 	return out, nil
 }

--- a/backend/internal/repository/swipe_record_test.go
+++ b/backend/internal/repository/swipe_record_test.go
@@ -147,3 +147,77 @@ func TestSwipeRecordRepository_ListRecentByUser_OrdersAndScopes(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, empty)
 }
+
+// TestSwipeRecordRepository_ListByUserSince_InclusiveBoundaryAndScopes proves
+// ListByUserSince applies a `reviewed_at >= since` (inclusive) cutoff — the row
+// at exactly `since` is returned, the row one microsecond before is excluded —
+// and never leaks another user's swipe. Exact-boundary fixture per
+// docs/backend/library-gotchas/strict-cutoff-boundary-fixture-and-mutation-proof.md:
+// the Len==2 assertion discriminates `>=` from a strict `>` (which would drop
+// the == since row).
+func TestSwipeRecordRepository_ListByUserSince_InclusiveBoundaryAndScopes(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	ownerID := insertAuthUser(t, ctx)
+	otherUserID := insertAuthUser(t, ctx)
+	cg := insertCardgroup(t, ctx, ownerID)
+	cgOther := insertCardgroup(t, ctx, otherUserID)
+	cardRepo := repository.NewCardRepository(testDB.GORM)
+	swipeRepo := repository.NewSwipeRecordRepository(testDB.GORM)
+
+	ownerCard := newCard(cg.ID, "owner since front", "back")
+	otherCard := newCard(cgOther.ID, "other since front", "back")
+	require.NoError(t, cardRepo.Create(ctx, ownerCard))
+	require.NoError(t, cardRepo.Create(ctx, otherCard))
+
+	since := time.Date(2026, 5, 1, 9, 0, 0, 0, time.UTC)
+	before := since.Add(-time.Microsecond) // strictly before the cutoff (Postgres µs precision)
+	after := since.Add(time.Hour)
+
+	seed := func(id, userID, cardID string, cardgroupID domain.CardgroupID, reviewedAt time.Time) *domain.SwipeRecord {
+		return &domain.SwipeRecord{
+			ID:          id,
+			UserID:      domain.UserID(userID),
+			CardID:      cardID,
+			CardgroupID: cardgroupID,
+			Rating:      domain.RatingEasy,
+			ReviewedAt:  reviewedAt,
+			StateAfter:  domain.NewFSRSStateForNewCard(reviewedAt),
+		}
+	}
+
+	const (
+		idAtSince      = "00000000-0000-0000-0000-0000000000b1"
+		idBeforeSince  = "00000000-0000-0000-0000-0000000000b2"
+		idAfterSince   = "00000000-0000-0000-0000-0000000000b3"
+		idOtherAtSince = "00000000-0000-0000-0000-0000000000b4"
+	)
+
+	require.NoError(t, testDB.GORM.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		for _, sr := range []*domain.SwipeRecord{
+			seed(idAtSince, ownerID, ownerCard.ID, cg.ID, since),               // == since: included (>=)
+			seed(idBeforeSince, ownerID, ownerCard.ID, cg.ID, before),          // < since: excluded
+			seed(idAfterSince, ownerID, ownerCard.ID, cg.ID, after),            // > since: included
+			seed(idOtherAtSince, otherUserID, otherCard.ID, cgOther.ID, since), // cross-tenant: excluded
+		} {
+			if err := swipeRepo.CreateTx(ctx, tx, sr); err != nil {
+				return err
+			}
+		}
+		return nil
+	}))
+
+	got, err := swipeRepo.ListByUserSince(ctx, ownerID, since)
+	require.NoError(t, err)
+
+	ids := make(map[string]struct{}, len(got))
+	for _, sr := range got {
+		ids[sr.ID] = struct{}{}
+		require.Equal(t, ownerID, string(sr.UserID), "another user's swipe must never leak")
+	}
+	require.Len(t, got, 2, "reviewed_at == since is included (>=) and the strictly-before row is excluded")
+	require.Contains(t, ids, idAtSince, "reviewed_at == since is inclusive")
+	require.Contains(t, ids, idAfterSince)
+	require.NotContains(t, ids, idBeforeSince, "reviewed_at strictly before since is excluded")
+	require.NotContains(t, ids, idOtherAtSince, "another user's swipe is excluded")
+}

--- a/backend/internal/repository/user_card_fsrs.go
+++ b/backend/internal/repository/user_card_fsrs.go
@@ -30,13 +30,15 @@ type gormUserCardFSRS struct {
 func (gormUserCardFSRS) TableName() string { return "user_card_fsrs" }
 
 // FSRSStatRow is a lightweight projection for the stats aggregate: no front
-// text — just CardID (row identity), CardgroupID (per-deck bucketing), and
-// Phase/Stability (the columns ClassifyMastery needs).
+// text — just CardID (row identity), CardgroupID (per-deck bucketing),
+// Phase/Stability (the columns ClassifyMastery needs), and Lapses (the
+// struggling-card ranking key).
 type FSRSStatRow struct {
 	CardID      string
 	CardgroupID string
 	Phase       domain.FSRSPhase
 	Stability   float64
+	Lapses      int
 }
 
 type UserCardFSRSRepository interface {
@@ -88,7 +90,7 @@ func (r *userCardFSRSRepo) ListFSRSStatesByUser(ctx context.Context, userID stri
 	var rows []FSRSStatRow
 	err := r.db.WithContext(ctx).
 		Table("user_card_fsrs AS f").
-		Select("f.card_id AS card_id, c.cardgroup_id AS cardgroup_id, f.state AS phase, f.stability AS stability").
+		Select("f.card_id AS card_id, c.cardgroup_id AS cardgroup_id, f.state AS phase, f.stability AS stability, f.lapses AS lapses").
 		Joins("JOIN cards c ON c.id = f.card_id").
 		Where("f.user_id = ?", userID).
 		Scan(&rows).Error

--- a/backend/internal/repository/user_card_fsrs_test.go
+++ b/backend/internal/repository/user_card_fsrs_test.go
@@ -183,6 +183,7 @@ func TestUserCardFSRSRepository_ListFSRSStatesByUser_ScopesByViewer(t *testing.T
 	ownerLearned := domain.NewUserCardFSRSForNewCard(domain.UserID(ownerID), learned.ID, now)
 	ownerLearned.State.Phase = domain.FSRSPhaseReview
 	ownerLearned.State.Stability = 5
+	ownerLearned.State.Lapses = 3
 
 	// Other user studies their own card AND the owner's mature card, with a
 	// distinct stability so a leak would be detectable.
@@ -222,6 +223,7 @@ func TestUserCardFSRSRepository_ListFSRSStatesByUser_ScopesByViewer(t *testing.T
 	gotLearned, ok := byCard[learned.ID]
 	require.True(t, ok)
 	require.Equal(t, cgA, gotLearned.CardgroupID)
+	require.Equal(t, 3, gotLearned.Lapses)
 	require.InDelta(t, 5.0, gotLearned.Stability, 1e-9)
 
 	// The other user sees their own two rows, keyed correctly.

--- a/backend/internal/usecase/stats.go
+++ b/backend/internal/usecase/stats.go
@@ -3,12 +3,23 @@ package usecase
 import (
 	"context"
 	"sort"
+	"time"
 
 	"github.com/rotisserie/eris"
 
 	"backend/internal/auth"
 	"backend/internal/domain"
+	"backend/internal/domain/service"
 	"backend/internal/repository"
+)
+
+const (
+	// strugglingCardsLimit caps the struggling-card list returned to the client.
+	strugglingCardsLimit = 10
+	// statsWindowDays is the trailing calendar window (in days) over which the
+	// diagnostic performance snapshot is computed, so studyStreak reflects real
+	// calendar days rather than a swipe-count window.
+	statsWindowDays = 365
 )
 
 // StatsUsecase exposes the authenticated caller's aggregate learning
@@ -25,18 +36,44 @@ type statsFSRSRepo interface {
 	CountCardsByCardgroupForUser(ctx context.Context, userID string) (map[string]int, error)
 }
 
-type statsUsecase struct {
-	fsrsRepo statsFSRSRepo
+// statsSwipeRepo is the narrow slice of the swipe-record repository the stats
+// aggregate needs to compute the diagnostic performance snapshot over a window.
+type statsSwipeRepo interface {
+	ListByUserSince(ctx context.Context, userID string, since time.Time) ([]*domain.SwipeRecord, error)
 }
 
-// NewStats wires the stats usecase from its narrow FSRS repository dependency.
-func NewStats(fsrsRepo statsFSRSRepo) StatsUsecase { return &statsUsecase{fsrsRepo: fsrsRepo} }
+type statsUsecase struct {
+	fsrsRepo  statsFSRSRepo
+	swipeRepo statsSwipeRepo
+	now       func() time.Time
+}
+
+// NewStats wires the stats usecase from its narrow FSRS + swipe-record
+// repository dependencies and an injectable clock (pass time.Now in production,
+// a fixed clock in tests so the window/now are deterministic).
+func NewStats(fsrsRepo statsFSRSRepo, swipeRepo statsSwipeRepo, now func() time.Time) StatsUsecase {
+	if now == nil {
+		now = time.Now
+	}
+	return &statsUsecase{fsrsRepo: fsrsRepo, swipeRepo: swipeRepo, now: now}
+}
 
 // LearningStatsResult is the usecase-layer result VO. It carries cardgroup ids
-// only; the resolver hydrates the Cardgroup objects via the DataLoader.
+// and struggling-card ids only; the resolver hydrates the Cardgroup / Card
+// objects via the DataLoader.
 type LearningStatsResult struct {
-	Mastery MasteryBreakdown
-	Decks   []DeckMasteryResult
+	Mastery         MasteryBreakdown
+	Decks           []DeckMasteryResult
+	Performance     service.PerformanceMetrics
+	StrugglingCards []StrugglingCardResult
+}
+
+// StrugglingCardResult identifies a card the learner struggles with (high
+// lapses / low stability). CardID is hydrated to a Card by the resolver.
+type StrugglingCardResult struct {
+	CardID    string
+	Lapses    int
+	Stability float64
 }
 
 // MasteryBreakdown is the disjoint three-tier count across all studied cards.
@@ -120,5 +157,41 @@ func (u *statsUsecase) MyLearningStats(ctx context.Context) (*LearningStatsResul
 		})
 	}
 
-	return &LearningStatsResult{Mastery: mastery, Decks: decks}, nil
+	// Diagnostic half: a performance snapshot over the trailing statsWindowDays
+	// calendar window (so studyStreak reflects real days, not a swipe count) plus
+	// the struggling-card ranking derived from the FSRS rows already loaded above.
+	now := u.now()
+	swipes, err := u.swipeRepo.ListByUserSince(ctx, caller.Sub, now.AddDate(0, 0, -statsWindowDays))
+	if err != nil {
+		return nil, eris.Wrap(err, "usecase: stats: list swipes since")
+	}
+
+	return &LearningStatsResult{
+		Mastery:         mastery,
+		Decks:           decks,
+		Performance:     service.ComputeMetrics(swipeRecordsByValue(swipes), now),
+		StrugglingCards: topStruggling(states, strugglingCardsLimit),
+	}, nil
+}
+
+// topStruggling ranks the studied FSRS rows by struggle: filter to cards with at
+// least one lapse, sort by (Lapses desc, Stability asc), and cap at limit. The
+// result is always non-nil (an empty, non-nil slice when no card has lapsed).
+func topStruggling(states []repository.FSRSStatRow, limit int) []StrugglingCardResult {
+	out := make([]StrugglingCardResult, 0, len(states))
+	for _, s := range states {
+		if s.Lapses >= 1 {
+			out = append(out, StrugglingCardResult{CardID: s.CardID, Lapses: s.Lapses, Stability: s.Stability})
+		}
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Lapses != out[j].Lapses {
+			return out[i].Lapses > out[j].Lapses // more lapses first
+		}
+		return out[i].Stability < out[j].Stability // ties: lower stability first
+	})
+	if len(out) > limit {
+		out = out[:limit]
+	}
+	return out
 }

--- a/backend/internal/usecase/stats.go
+++ b/backend/internal/usecase/stats.go
@@ -45,17 +45,18 @@ type statsSwipeRepo interface {
 type statsUsecase struct {
 	fsrsRepo  statsFSRSRepo
 	swipeRepo statsSwipeRepo
-	now       func() time.Time
+	clock     Clock
 }
 
 // NewStats wires the stats usecase from its narrow FSRS + swipe-record
-// repository dependencies and an injectable clock (pass time.Now in production,
-// a fixed clock in tests so the window/now are deterministic).
-func NewStats(fsrsRepo statsFSRSRepo, swipeRepo statsSwipeRepo, now func() time.Time) StatsUsecase {
-	if now == nil {
-		now = time.Now
+// repository dependencies and an injectable Clock (nil defaults to
+// systemClock{} in production; tests inject a fixed Clock so the window/now
+// are deterministic). Clock is the same interface NewLearnUsecase uses.
+func NewStats(fsrsRepo statsFSRSRepo, swipeRepo statsSwipeRepo, clock Clock) StatsUsecase {
+	if clock == nil {
+		clock = systemClock{}
 	}
-	return &statsUsecase{fsrsRepo: fsrsRepo, swipeRepo: swipeRepo, now: now}
+	return &statsUsecase{fsrsRepo: fsrsRepo, swipeRepo: swipeRepo, clock: clock}
 }
 
 // LearningStatsResult is the usecase-layer result VO. It carries cardgroup ids
@@ -160,7 +161,7 @@ func (u *statsUsecase) MyLearningStats(ctx context.Context) (*LearningStatsResul
 	// Diagnostic half: a performance snapshot over the trailing statsWindowDays
 	// calendar window (so studyStreak reflects real days, not a swipe count) plus
 	// the struggling-card ranking derived from the FSRS rows already loaded above.
-	now := u.now()
+	now := u.clock.Now()
 	swipes, err := u.swipeRepo.ListByUserSince(ctx, caller.Sub, now.AddDate(0, 0, -statsWindowDays))
 	if err != nil {
 		return nil, eris.Wrap(err, "usecase: stats: list swipes since")

--- a/backend/internal/usecase/stats_test.go
+++ b/backend/internal/usecase/stats_test.go
@@ -3,7 +3,9 @@ package usecase
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/rotisserie/eris"
 	"github.com/stretchr/testify/assert"
@@ -11,6 +13,7 @@ import (
 
 	"backend/internal/auth"
 	"backend/internal/domain"
+	"backend/internal/domain/service"
 	"backend/internal/repository"
 	"backend/internal/usecase/ucerr"
 )
@@ -36,8 +39,42 @@ func (f *fakeStatsFSRSRepo) CountCardsByCardgroupForUser(_ context.Context, _ st
 	return f.totals, nil
 }
 
+// fakeStatsSwipeRepo captures the ListByUserSince arguments so tests can pin the
+// windowing (since) and tenant scoping, and returns a canned swipe slice.
+type fakeStatsSwipeRepo struct {
+	swipes    []*domain.SwipeRecord
+	err       error
+	called    bool
+	userIDArg string
+	sinceArg  time.Time
+}
+
+func (f *fakeStatsSwipeRepo) ListByUserSince(_ context.Context, userID string, since time.Time) ([]*domain.SwipeRecord, error) {
+	f.called = true
+	f.userIDArg = userID
+	f.sinceArg = since
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.swipes, nil
+}
+
+func fixedStatsClock(t time.Time) func() time.Time { return func() time.Time { return t } }
+
 func authedStatsCtx(sub string) context.Context {
 	return auth.ContextWithUser(context.Background(), &auth.AuthUser{Sub: sub})
+}
+
+func strugglingRow(card string, lapses int, stability float64) repository.FSRSStatRow {
+	return repository.FSRSStatRow{CardID: card, CardgroupID: "cg1", Phase: domain.FSRSPhaseReview, Stability: stability, Lapses: lapses}
+}
+
+func strugglingCardIDs(cards []StrugglingCardResult) []string {
+	out := make([]string, 0, len(cards))
+	for _, c := range cards {
+		out = append(out, c.CardID)
+	}
+	return out
 }
 
 func reviewRow(card, cg string, stability float64) repository.FSRSStatRow {
@@ -61,7 +98,7 @@ func TestStatsUsecase_MyLearningStats_BucketsGlobalAndPerDeck(t *testing.T) {
 		},
 		totals: map[string]int{"cg1": 5, "cg2": 3, "cg3": 2},
 	}
-	uc := NewStats(repo)
+	uc := NewStats(repo, &fakeStatsSwipeRepo{}, time.Now)
 
 	res, err := uc.MyLearningStats(authedStatsCtx("user-1"))
 	require.NoError(t, err)
@@ -102,7 +139,7 @@ func TestStatsUsecase_MyLearningStats_BucketsGlobalAndPerDeck(t *testing.T) {
 func TestStatsUsecase_MyLearningStats_EmptyHistory(t *testing.T) {
 	t.Parallel()
 	repo := &fakeStatsFSRSRepo{states: nil, totals: map[string]int{}}
-	uc := NewStats(repo)
+	uc := NewStats(repo, &fakeStatsSwipeRepo{}, time.Now)
 
 	res, err := uc.MyLearningStats(authedStatsCtx("user-1"))
 	require.NoError(t, err)
@@ -112,7 +149,7 @@ func TestStatsUsecase_MyLearningStats_EmptyHistory(t *testing.T) {
 
 func TestStatsUsecase_MyLearningStats_Unauthenticated(t *testing.T) {
 	t.Parallel()
-	uc := NewStats(&fakeStatsFSRSRepo{})
+	uc := NewStats(&fakeStatsFSRSRepo{}, &fakeStatsSwipeRepo{}, time.Now)
 
 	res, err := uc.MyLearningStats(context.Background())
 	require.Error(t, err)
@@ -123,7 +160,7 @@ func TestStatsUsecase_MyLearningStats_Unauthenticated(t *testing.T) {
 
 func TestStatsUsecase_MyLearningStats_EmptySubUnauthenticated(t *testing.T) {
 	t.Parallel()
-	uc := NewStats(&fakeStatsFSRSRepo{})
+	uc := NewStats(&fakeStatsFSRSRepo{}, &fakeStatsSwipeRepo{}, time.Now)
 
 	res, err := uc.MyLearningStats(authedStatsCtx(""))
 	require.Error(t, err)
@@ -134,7 +171,7 @@ func TestStatsUsecase_MyLearningStats_EmptySubUnauthenticated(t *testing.T) {
 func TestStatsUsecase_MyLearningStats_ListStatesError(t *testing.T) {
 	t.Parallel()
 	sentinel := eris.New("boom")
-	uc := NewStats(&fakeStatsFSRSRepo{statesErr: sentinel})
+	uc := NewStats(&fakeStatsFSRSRepo{statesErr: sentinel}, &fakeStatsSwipeRepo{}, time.Now)
 
 	res, err := uc.MyLearningStats(authedStatsCtx("user-1"))
 	require.Error(t, err)
@@ -146,11 +183,123 @@ func TestStatsUsecase_MyLearningStats_ListStatesError(t *testing.T) {
 func TestStatsUsecase_MyLearningStats_CountError(t *testing.T) {
 	t.Parallel()
 	sentinel := eris.New("boom")
-	uc := NewStats(&fakeStatsFSRSRepo{totalsErr: sentinel})
+	uc := NewStats(&fakeStatsFSRSRepo{totalsErr: sentinel}, &fakeStatsSwipeRepo{}, time.Now)
 
 	res, err := uc.MyLearningStats(authedStatsCtx("user-1"))
 	require.Error(t, err)
 	assert.Nil(t, res)
 	assert.True(t, errors.Is(err, sentinel))
 	assert.Contains(t, err.Error(), "usecase: stats: count cards by cardgroup")
+}
+
+func TestTopStruggling_FiltersExcludesZeroAndOrders(t *testing.T) {
+	t.Parallel()
+	states := []repository.FSRSStatRow{
+		strugglingRow("no-lapse", 0, 1), // filtered out (Lapses == 0)
+		strugglingRow("one-lapse", 1, 50),
+		strugglingRow("five-a", 5, 8),
+		strugglingRow("five-b", 5, 3), // same lapses, lower stability -> ranks before five-a
+	}
+
+	got := topStruggling(states, 10)
+
+	require.Len(t, got, 3, "the Lapses==0 row is excluded")
+	assert.Equal(t, []string{"five-b", "five-a", "one-lapse"}, strugglingCardIDs(got),
+		"ordered by (Lapses desc, Stability asc)")
+	for _, c := range got {
+		assert.GreaterOrEqual(t, c.Lapses, 1)
+	}
+}
+
+func TestTopStruggling_CapsAtLimit(t *testing.T) {
+	t.Parallel()
+	states := make([]repository.FSRSStatRow, 0, 15)
+	for i := 0; i < 15; i++ {
+		states = append(states, strugglingRow(fmt.Sprintf("card-%02d", i), i+1, 1))
+	}
+
+	got := topStruggling(states, strugglingCardsLimit)
+
+	require.Len(t, got, strugglingCardsLimit, "capped at strugglingCardsLimit")
+	assert.Equal(t, 15, got[0].Lapses, "highest lapses first")
+	assert.Equal(t, 6, got[strugglingCardsLimit-1].Lapses, "lowest surviving lapses at the cap boundary")
+}
+
+func TestTopStruggling_EmptyReturnsNonNilSlice(t *testing.T) {
+	t.Parallel()
+	got := topStruggling([]repository.FSRSStatRow{strugglingRow("no-lapse", 0, 1)}, 10)
+	assert.NotNil(t, got, "empty struggling set is a non-nil slice")
+	assert.Empty(t, got)
+}
+
+func TestStatsUsecase_MyLearningStats_WindowsSwipesByStatsWindowDays(t *testing.T) {
+	t.Parallel()
+	fixedNow := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
+	swipeRepo := &fakeStatsSwipeRepo{}
+	uc := NewStats(&fakeStatsFSRSRepo{totals: map[string]int{}}, swipeRepo, fixedStatsClock(fixedNow))
+
+	res, err := uc.MyLearningStats(authedStatsCtx("user-1"))
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	require.True(t, swipeRepo.called, "MyLearningStats reads the windowed swipe history")
+	assert.Equal(t, "user-1", swipeRepo.userIDArg, "scoped to the caller")
+	assert.Equal(t, fixedNow.AddDate(0, 0, -365), swipeRepo.sinceArg,
+		"since == now minus statsWindowDays (365) using the injected clock")
+	assert.NotNil(t, res.StrugglingCards, "struggling cards is always a non-nil slice")
+	assert.Empty(t, res.StrugglingCards)
+}
+
+func TestStatsUsecase_MyLearningStats_PerformanceReflectsComputeMetrics(t *testing.T) {
+	t.Parallel()
+	fixedNow := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
+	state := domain.NewFSRSStateForNewCard(fixedNow)
+	state.Phase = domain.FSRSPhaseReview
+	swipes := []*domain.SwipeRecord{
+		{ID: "s1", UserID: "user-1", CardID: "c1", CardgroupID: "cg1", Rating: domain.RatingEasy, ReviewedAt: fixedNow, StateAfter: state},
+		{ID: "s2", UserID: "user-1", CardID: "c2", CardgroupID: "cg1", Rating: domain.RatingAgain, ReviewedAt: fixedNow.AddDate(0, 0, -1), StateAfter: state},
+	}
+	swipeRepo := &fakeStatsSwipeRepo{swipes: swipes}
+	uc := NewStats(&fakeStatsFSRSRepo{totals: map[string]int{}}, swipeRepo, fixedStatsClock(fixedNow))
+
+	res, err := uc.MyLearningStats(authedStatsCtx("user-1"))
+	require.NoError(t, err)
+	require.NotNil(t, res)
+
+	want := service.ComputeMetrics(swipeRecordsByValue(swipes), fixedNow)
+	assert.Equal(t, want, res.Performance,
+		"Performance is ComputeMetrics over the windowed swipes at the injected now")
+}
+
+func TestStatsUsecase_MyLearningStats_StrugglingCardsFromFSRSRows(t *testing.T) {
+	t.Parallel()
+	fixedNow := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
+	repo := &fakeStatsFSRSRepo{
+		states: []repository.FSRSStatRow{
+			strugglingRow("clean", 0, 20), // excluded (no lapses)
+			strugglingRow("worst", 4, 2),  // most lapses
+			strugglingRow("mid", 2, 15),
+			strugglingRow("mid-fragile", 2, 3), // ties on lapses with "mid"; lower stability ranks first
+		},
+		totals: map[string]int{},
+	}
+	uc := NewStats(repo, &fakeStatsSwipeRepo{}, fixedStatsClock(fixedNow))
+
+	res, err := uc.MyLearningStats(authedStatsCtx("user-1"))
+	require.NoError(t, err)
+	require.NotNil(t, res)
+
+	require.Equal(t, []string{"worst", "mid-fragile", "mid"}, strugglingCardIDs(res.StrugglingCards))
+	assert.Equal(t, StrugglingCardResult{CardID: "worst", Lapses: 4, Stability: 2}, res.StrugglingCards[0])
+}
+
+func TestStatsUsecase_MyLearningStats_ListSwipesError(t *testing.T) {
+	t.Parallel()
+	sentinel := eris.New("boom")
+	uc := NewStats(&fakeStatsFSRSRepo{totals: map[string]int{}}, &fakeStatsSwipeRepo{err: sentinel}, time.Now)
+
+	res, err := uc.MyLearningStats(authedStatsCtx("user-1"))
+	require.Error(t, err)
+	assert.Nil(t, res)
+	assert.True(t, errors.Is(err, sentinel))
+	assert.Contains(t, err.Error(), "usecase: stats: list swipes since")
 }

--- a/backend/internal/usecase/stats_test.go
+++ b/backend/internal/usecase/stats_test.go
@@ -59,8 +59,6 @@ func (f *fakeStatsSwipeRepo) ListByUserSince(_ context.Context, userID string, s
 	return f.swipes, nil
 }
 
-func fixedStatsClock(t time.Time) func() time.Time { return func() time.Time { return t } }
-
 func authedStatsCtx(sub string) context.Context {
 	return auth.ContextWithUser(context.Background(), &auth.AuthUser{Sub: sub})
 }
@@ -98,7 +96,7 @@ func TestStatsUsecase_MyLearningStats_BucketsGlobalAndPerDeck(t *testing.T) {
 		},
 		totals: map[string]int{"cg1": 5, "cg2": 3, "cg3": 2},
 	}
-	uc := NewStats(repo, &fakeStatsSwipeRepo{}, time.Now)
+	uc := NewStats(repo, &fakeStatsSwipeRepo{}, nil)
 
 	res, err := uc.MyLearningStats(authedStatsCtx("user-1"))
 	require.NoError(t, err)
@@ -139,7 +137,7 @@ func TestStatsUsecase_MyLearningStats_BucketsGlobalAndPerDeck(t *testing.T) {
 func TestStatsUsecase_MyLearningStats_EmptyHistory(t *testing.T) {
 	t.Parallel()
 	repo := &fakeStatsFSRSRepo{states: nil, totals: map[string]int{}}
-	uc := NewStats(repo, &fakeStatsSwipeRepo{}, time.Now)
+	uc := NewStats(repo, &fakeStatsSwipeRepo{}, nil)
 
 	res, err := uc.MyLearningStats(authedStatsCtx("user-1"))
 	require.NoError(t, err)
@@ -149,7 +147,7 @@ func TestStatsUsecase_MyLearningStats_EmptyHistory(t *testing.T) {
 
 func TestStatsUsecase_MyLearningStats_Unauthenticated(t *testing.T) {
 	t.Parallel()
-	uc := NewStats(&fakeStatsFSRSRepo{}, &fakeStatsSwipeRepo{}, time.Now)
+	uc := NewStats(&fakeStatsFSRSRepo{}, &fakeStatsSwipeRepo{}, nil)
 
 	res, err := uc.MyLearningStats(context.Background())
 	require.Error(t, err)
@@ -160,7 +158,7 @@ func TestStatsUsecase_MyLearningStats_Unauthenticated(t *testing.T) {
 
 func TestStatsUsecase_MyLearningStats_EmptySubUnauthenticated(t *testing.T) {
 	t.Parallel()
-	uc := NewStats(&fakeStatsFSRSRepo{}, &fakeStatsSwipeRepo{}, time.Now)
+	uc := NewStats(&fakeStatsFSRSRepo{}, &fakeStatsSwipeRepo{}, nil)
 
 	res, err := uc.MyLearningStats(authedStatsCtx(""))
 	require.Error(t, err)
@@ -171,7 +169,7 @@ func TestStatsUsecase_MyLearningStats_EmptySubUnauthenticated(t *testing.T) {
 func TestStatsUsecase_MyLearningStats_ListStatesError(t *testing.T) {
 	t.Parallel()
 	sentinel := eris.New("boom")
-	uc := NewStats(&fakeStatsFSRSRepo{statesErr: sentinel}, &fakeStatsSwipeRepo{}, time.Now)
+	uc := NewStats(&fakeStatsFSRSRepo{statesErr: sentinel}, &fakeStatsSwipeRepo{}, nil)
 
 	res, err := uc.MyLearningStats(authedStatsCtx("user-1"))
 	require.Error(t, err)
@@ -183,7 +181,7 @@ func TestStatsUsecase_MyLearningStats_ListStatesError(t *testing.T) {
 func TestStatsUsecase_MyLearningStats_CountError(t *testing.T) {
 	t.Parallel()
 	sentinel := eris.New("boom")
-	uc := NewStats(&fakeStatsFSRSRepo{totalsErr: sentinel}, &fakeStatsSwipeRepo{}, time.Now)
+	uc := NewStats(&fakeStatsFSRSRepo{totalsErr: sentinel}, &fakeStatsSwipeRepo{}, nil)
 
 	res, err := uc.MyLearningStats(authedStatsCtx("user-1"))
 	require.Error(t, err)
@@ -236,7 +234,7 @@ func TestStatsUsecase_MyLearningStats_WindowsSwipesByStatsWindowDays(t *testing.
 	t.Parallel()
 	fixedNow := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
 	swipeRepo := &fakeStatsSwipeRepo{}
-	uc := NewStats(&fakeStatsFSRSRepo{totals: map[string]int{}}, swipeRepo, fixedStatsClock(fixedNow))
+	uc := NewStats(&fakeStatsFSRSRepo{totals: map[string]int{}}, swipeRepo, fixedClock{now: fixedNow})
 
 	res, err := uc.MyLearningStats(authedStatsCtx("user-1"))
 	require.NoError(t, err)
@@ -259,7 +257,7 @@ func TestStatsUsecase_MyLearningStats_PerformanceReflectsComputeMetrics(t *testi
 		{ID: "s2", UserID: "user-1", CardID: "c2", CardgroupID: "cg1", Rating: domain.RatingAgain, ReviewedAt: fixedNow.AddDate(0, 0, -1), StateAfter: state},
 	}
 	swipeRepo := &fakeStatsSwipeRepo{swipes: swipes}
-	uc := NewStats(&fakeStatsFSRSRepo{totals: map[string]int{}}, swipeRepo, fixedStatsClock(fixedNow))
+	uc := NewStats(&fakeStatsFSRSRepo{totals: map[string]int{}}, swipeRepo, fixedClock{now: fixedNow})
 
 	res, err := uc.MyLearningStats(authedStatsCtx("user-1"))
 	require.NoError(t, err)
@@ -282,7 +280,7 @@ func TestStatsUsecase_MyLearningStats_StrugglingCardsFromFSRSRows(t *testing.T) 
 		},
 		totals: map[string]int{},
 	}
-	uc := NewStats(repo, &fakeStatsSwipeRepo{}, fixedStatsClock(fixedNow))
+	uc := NewStats(repo, &fakeStatsSwipeRepo{}, fixedClock{now: fixedNow})
 
 	res, err := uc.MyLearningStats(authedStatsCtx("user-1"))
 	require.NoError(t, err)
@@ -295,7 +293,7 @@ func TestStatsUsecase_MyLearningStats_StrugglingCardsFromFSRSRows(t *testing.T) 
 func TestStatsUsecase_MyLearningStats_ListSwipesError(t *testing.T) {
 	t.Parallel()
 	sentinel := eris.New("boom")
-	uc := NewStats(&fakeStatsFSRSRepo{totals: map[string]int{}}, &fakeStatsSwipeRepo{err: sentinel}, time.Now)
+	uc := NewStats(&fakeStatsFSRSRepo{totals: map[string]int{}}, &fakeStatsSwipeRepo{err: sentinel}, nil)
 
 	res, err := uc.MyLearningStats(authedStatsCtx("user-1"))
 	require.Error(t, err)

--- a/schema/stats.graphql
+++ b/schema/stats.graphql
@@ -4,6 +4,20 @@ type LearningStats {
   mastery: MasteryBreakdown!
   """Per-deck acquisition, one entry per owned deck that has at least one card (decks with cards but no studied cards are included; empty decks are omitted)."""
   decks: [DeckMastery!]!
+  """Diagnostic performance snapshot over the trailing 365-day window (retention, success, lapse rates, study streak, review count, average difficulty)."""
+  performance: PerformanceMetrics!
+  """Cards the learner struggles with most, ranked by lapses (desc) then stability (asc), filtered to at least one lapse, capped at 10."""
+  strugglingCards: [StrugglingCard!]!
+}
+
+"""A card the learner struggles with (high lapses / low stability)."""
+type StrugglingCard {
+  """The struggling card."""
+  card: Card!
+  """Number of times the card lapsed (rated Again from a known-review state)."""
+  lapses: Int!
+  """The card's current FSRS memory stability, in days."""
+  stability: Float!
 }
 
 """Disjoint three-tier mastery counts across all studied cards. The three tiers sum to totalStudied."""


### PR DESCRIPTION
## Summary

Extends the `myLearningStats` GraphQL query (added in #839) with its **diagnostic half**: a `performance` snapshot (retention / success / lapse rate, study streak, review count, avg difficulty — reusing the existing `service.ComputeMetrics` over a trailing-365-day swipe window) and a `strugglingCards` list (the caller's top-10 most-lapsed cards). Backend only; stacked on #839.

Closes #837.

## Changes

### Repository — time-windowed swipe read

- `SwipeRecordRepository.ListByUserSince` — swipes with `reviewed_at >= since` (inclusive), in unspecified order (`ComputeMetrics` is order-independent), mapped via `swipeRecordToDomain`. Backed by the existing `(user_id, reviewed_at)` composite index, so no migration. A Docker-gated integration test proves the `>=` boundary (a row exactly at `since` is included, one microsecond before is excluded — `Len == 2` discriminates `>=` from `>`) plus cross-tenant scoping.
- Re-added `Lapses` to `FSRSStatRow` (which #836 had dropped as unused) and `f.lapses` to the `ListFSRSStatesByUser` select — it is the struggling-card ranking key.

### Usecase — diagnostic extension of `MyLearningStats`

- A narrow `statsSwipeRepo` interface plus an injectable `Clock` (unified with the `Clock`/`systemClock` idiom `NewLearnUsecase` already uses in the same package — `NewStats` defaults `nil → systemClock{}`). `MyLearningStats` now also fetches swipes since `now - 365d`, computes `Performance` via `service.ComputeMetrics` (reusing the existing `swipeRecordsByValue` helper), and ranks `StrugglingCards` via a pure `topStruggling` helper (filter `lapses >= 1`, `sort.SliceStable` by lapses desc then stability asc, cap 10, always non-nil). Consts `statsWindowDays = 365`, `strugglingCardsLimit = 10`.

### Schema + Resolver

- `schema/stats.graphql` — `LearningStats` gains `performance: PerformanceMetrics!` (reusing the existing type from `swipe.graphql`) and `strugglingCards: [StrugglingCard!]!`; new `StrugglingCard { card, lapses, stability }`.
- `backend/graph/resolver/mapper.go` — extracted a shared `toPerformanceMetricsModel` (now used by both `toSwipeResponseModel` and the stats snapshot, removing the previously-inline duplication); `toLearningStatsModel` hydrates each struggling card's `Card` via the Card DataLoader using the same two-phase Load-then-resolve batching as the deck path. A `resolver → internal/domain/service` edge was added to `backend/.go-arch-lint.yml` — the resolver maps the `service.PerformanceMetrics` value object to the wire model (Presentation → Domain, the legal inward direction the resolver already uses for `domain`).

### Tests

- Usecase: `topStruggling` filter / order / cap / empty-non-nil; the 365-day `since` window with a fixed injected clock; `Performance == service.ComputeMetrics(...)`; swipe-fetch error propagation.
- Repository (Docker-gated): `ListByUserSince` inclusive-boundary + cross-tenant.
- Resolver: the `performance` fields and `strugglingCards { card { id front } lapses stability }` hydration (happy path preserving usecase order; a Card-load error → `INTERNAL`; empty struggling → `[]`).

## Verification

- `go build ./...`, `go vet ./...`, `go tool go-arch-lint check` — all clean.
- `go test -race ./...` — every non-Docker package passes (1430 unit + resolver tests). The 5 testcontainers-gated packages (`internal/repository`, `internal/database`, `cmd/{server,seed,migrate-to-master}`) could not run in the authoring environment (Docker daemon unavailable); every local failure is the identical `rootless Docker not found` provider error, none from code, and the new integration tests compile-verify via `go vet`. They run on CI.
- `pnpm lint:schema` — clean.

## Test plan

- [ ] CI: `go build`, `go vet`, `go-arch-lint`, and the full `go test -race ./...` (including the testcontainers repository integration tests) are green.
- [ ] `pnpm lint:schema` green.
- [ ] Manual GraphQL (authenticated): `myLearningStats { performance { retentionRate successRate lapseRate studyStreak reviewCount avgDifficulty } strugglingCards { card { front } lapses stability } }` — struggling cards are ordered by descending `lapses` (all `>= 1`), capped at 10; a learner with no lapsed cards returns `strugglingCards: []`.

## Dependency order

Stacked on **#839** (the #836 mastery half). This PR's base is the #836 branch, so:

1. Merge #839 (base `main`) first.
2. Retarget this PR to `main` after #839 merges, then close/reopen it so the branch-gated backend CI fires. Heavy backend CI is gated on `pull_request: branches: [main]`, so it does not run while this PR targets the #836 branch.
3. #838 (`/stats` frontend) follows after both #839 and this PR merge.
