### PR TITLE
feat(frontend): add ProgressMeter and StatTile stats primitives

### DIFF
--- a/frontend/src/components/ui/progress-meter.test.tsx
+++ b/frontend/src/components/ui/progress-meter.test.tsx
@@ -1,0 +1,44 @@
+// @vitest-environment happy-dom
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { ProgressMeter } from "./progress-meter";
+
+describe("ProgressMeter", () => {
+  it("renders a progressbar whose accessible name equals the label", () => {
+    render(<ProgressMeter value={10} max={20} label="Acquisition progress" />);
+    const bar = screen.getByRole("progressbar", { name: "Acquisition progress" });
+    expect(bar).toBeTruthy();
+  });
+
+  it("computes aria-valuenow and fill width from value / max", () => {
+    render(<ProgressMeter value={120} max={500} label="progress" />);
+    const bar = screen.getByRole("progressbar");
+    expect(bar.getAttribute("aria-valuenow")).toBe("24");
+    const fill = bar.firstElementChild as HTMLElement;
+    expect(fill.style.width).toBe("24%");
+  });
+
+  it("reaches 100 when value equals max", () => {
+    render(<ProgressMeter value={210} max={210} label="progress" />);
+    const bar = screen.getByRole("progressbar");
+    expect(bar.getAttribute("aria-valuenow")).toBe("100");
+  });
+
+  it("returns 0 and emits no NaN when max is 0", () => {
+    const { container } = render(<ProgressMeter value={5} max={0} label="progress" />);
+    const bar = screen.getByRole("progressbar");
+    expect(bar.getAttribute("aria-valuenow")).toBe("0");
+    const fill = bar.firstElementChild as HTMLElement;
+    expect(fill.style.width).toBe("0%");
+    expect(container.textContent ?? "").not.toContain("NaN");
+  });
+
+  it("clamps to 100 when value exceeds max", () => {
+    render(<ProgressMeter value={999} max={100} label="progress" />);
+    const bar = screen.getByRole("progressbar");
+    expect(bar.getAttribute("aria-valuenow")).toBe("100");
+    const fill = bar.firstElementChild as HTMLElement;
+    expect(fill.style.width).toBe("100%");
+  });
+});

--- a/frontend/src/components/ui/progress-meter.test.tsx
+++ b/frontend/src/components/ui/progress-meter.test.tsx
@@ -41,4 +41,41 @@ describe("ProgressMeter", () => {
     const fill = bar.firstElementChild as HTMLElement;
     expect(fill.style.width).toBe("100%");
   });
+
+  it("clamps a negative value to 0", () => {
+    render(<ProgressMeter value={-5} max={100} label="progress" />);
+    const bar = screen.getByRole("progressbar");
+    expect(bar.getAttribute("aria-valuenow")).toBe("0");
+    const fill = bar.firstElementChild as HTMLElement;
+    expect(fill.style.width).toBe("0%");
+  });
+
+  it("renders 0 (no NaN, no false full bar) when value is not finite", () => {
+    const { container } = render(<ProgressMeter value={Number.NaN} max={100} label="progress" />);
+    const bar = screen.getByRole("progressbar");
+    expect(bar.getAttribute("aria-valuenow")).toBe("0");
+    const fill = bar.firstElementChild as HTMLElement;
+    expect(fill.style.width).toBe("0%");
+    expect(container.textContent ?? "").not.toContain("NaN");
+  });
+
+  it("forwards className onto the track element", () => {
+    render(<ProgressMeter value={1} max={2} label="progress" className="h-3" />);
+    expect(screen.getByRole("progressbar").className).toContain("h-3");
+  });
+
+  it("rounds aria-valuenow but keeps the fill width at full precision", () => {
+    render(<ProgressMeter value={1} max={3} label="progress" />);
+    const bar = screen.getByRole("progressbar");
+    expect(bar.getAttribute("aria-valuenow")).toBe("33");
+    const fill = bar.firstElementChild as HTMLElement;
+    expect(fill.style.width.startsWith("33.3")).toBe(true);
+  });
+
+  it("exposes a static [0, 100] range", () => {
+    render(<ProgressMeter value={1} max={2} label="progress" />);
+    const bar = screen.getByRole("progressbar");
+    expect(bar.getAttribute("aria-valuemin")).toBe("0");
+    expect(bar.getAttribute("aria-valuemax")).toBe("100");
+  });
 });

--- a/frontend/src/components/ui/progress-meter.tsx
+++ b/frontend/src/components/ui/progress-meter.tsx
@@ -1,0 +1,35 @@
+import { cn } from "@/lib/utils";
+
+export type ProgressMeterProps = {
+  value: number;
+  max: number;
+  label: string;
+  className?: string;
+};
+
+/**
+ * Presentation-only horizontal progress meter used by the learning-stats
+ * per-deck acquisition rows. A coral fill (`bg-brand-primary`) advances over a
+ * muted track (`bg-muted`); the width is derived once from `value / max` and
+ * clamped to `[0, 100]` so a zero or negative `max` renders an empty bar rather
+ * than dividing by zero or emitting `NaN`. The outer track carries the
+ * `progressbar` a11y roles (`aria-label` / `aria-valuenow` / `aria-valuemin` /
+ * `aria-valuemax`). It is a pure stateless component (no hooks), so it
+ * intentionally omits `"use client"`.
+ */
+export function ProgressMeter({ value, max, label, className }: ProgressMeterProps) {
+  const pct = max > 0 ? Math.min(100, Math.max(0, (value / max) * 100)) : 0;
+
+  return (
+    <div
+      role="progressbar"
+      aria-label={label}
+      aria-valuenow={Math.round(pct)}
+      aria-valuemin={0}
+      aria-valuemax={100}
+      className={cn("h-2 w-full overflow-hidden rounded-full bg-muted", className)}
+    >
+      <div className="h-full rounded-full bg-brand-primary" style={{ width: `${pct}%` }} />
+    </div>
+  );
+}

--- a/frontend/src/components/ui/progress-meter.tsx
+++ b/frontend/src/components/ui/progress-meter.tsx
@@ -8,17 +8,23 @@ export type ProgressMeterProps = {
 };
 
 /**
- * Presentation-only horizontal progress meter used by the learning-stats
- * per-deck acquisition rows. A coral fill (`bg-brand-primary`) advances over a
- * muted track (`bg-muted`); the width is derived once from `value / max` and
- * clamped to `[0, 100]` so a zero or negative `max` renders an empty bar rather
- * than dividing by zero or emitting `NaN`. The outer track carries the
- * `progressbar` a11y roles (`aria-label` / `aria-valuenow` / `aria-valuemin` /
- * `aria-valuemax`). It is a pure stateless component (no hooks), so it
- * intentionally omits `"use client"`.
+ * Presentation-only horizontal progress meter for the planned learning-stats
+ * per-deck acquisition display (see `schema/stats.graphql`'s `DeckMastery`); it
+ * has no frontend consumer yet. A coral fill (`bg-brand-primary`) advances over
+ * a muted track (`bg-muted`). The rendered percentage is derived once from
+ * `value / max` and defensively clamped to `[0, 100]`: a non-positive `max`
+ * (division by zero) and a non-finite or negative `value` all collapse to an
+ * empty bar, so `aria-valuenow` and the fill width are always a valid
+ * percentage — never `NaN`, which the CSSOM would silently drop and leave the
+ * block-level fill at full container width (a misleading "100%" bar). The outer
+ * track carries the `progressbar` a11y roles (`aria-label` / `aria-valuenow` /
+ * `aria-valuemin` / `aria-valuemax`); the optional `className` merges onto that
+ * track so callers can adjust height or spacing. It is a pure stateless
+ * component (no hooks), so it intentionally omits `"use client"`.
  */
 export function ProgressMeter({ value, max, label, className }: ProgressMeterProps) {
-  const pct = max > 0 ? Math.min(100, Math.max(0, (value / max) * 100)) : 0;
+  const safeValue = Number.isFinite(value) ? value : 0;
+  const pct = max > 0 ? Math.min(100, Math.max(0, (safeValue / max) * 100)) : 0;
 
   return (
     <div

--- a/frontend/src/components/ui/stat-tile.test.tsx
+++ b/frontend/src/components/ui/stat-tile.test.tsx
@@ -20,10 +20,24 @@ describe("StatTile", () => {
   });
 
   it("renders no caption element when caption is omitted", () => {
-    render(<StatTile label="Due" value="42" />);
+    const { container } = render(<StatTile label="Due" value="42" />);
     expect(screen.queryByText("last 30 days")).toBeNull();
-    // Only the label and value paragraphs exist; no third muted caption line.
-    const muted = document.querySelectorAll("p.text-muted-foreground");
-    expect(muted.length).toBe(0);
+    // Behaviour, not markup shape: only the value paragraph exists; the caption
+    // <p> is not emitted (label is a <span>, so paragraph count === 1).
+    expect(container.querySelectorAll("p").length).toBe(1);
+  });
+
+  it("marks the value with tabular-nums so columns of tiles align", () => {
+    render(<StatTile label="Reviews" value="1,430" />);
+    expect(screen.getByText("1,430").className).toContain("tabular-nums");
+  });
+
+  it("forwards the muted icon sizing classes to the icon", () => {
+    const Star = (props: { className?: string }) => <svg data-testid="ico" {...props} />;
+    render(<StatTile label="Streak" value="12" icon={Star} />);
+    const cls = screen.getByTestId("ico").getAttribute("class") ?? "";
+    expect(cls).toContain("h-4");
+    expect(cls).toContain("w-4");
+    expect(cls).toContain("text-muted-foreground");
   });
 });

--- a/frontend/src/components/ui/stat-tile.test.tsx
+++ b/frontend/src/components/ui/stat-tile.test.tsx
@@ -1,0 +1,29 @@
+// @vitest-environment happy-dom
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { StatTile } from "./stat-tile";
+
+describe("StatTile", () => {
+  it("renders the label, the value string verbatim, and the caption when provided", () => {
+    render(<StatTile label="Retention" value="87.5%" caption="last 30 days" />);
+    expect(screen.getByText("Retention")).toBeDefined();
+    expect(screen.getByText("87.5%")).toBeDefined();
+    expect(screen.getByText("last 30 days")).toBeDefined();
+  });
+
+  it("renders an svg when an icon component is passed", () => {
+    const Star = (props: { className?: string }) => <svg data-testid="ico" {...props} />;
+    const { container } = render(<StatTile label="Streak" value="12" icon={Star} />);
+    expect(container.querySelector("svg")).not.toBeNull();
+    expect(screen.getByTestId("ico")).toBeDefined();
+  });
+
+  it("renders no caption element when caption is omitted", () => {
+    render(<StatTile label="Due" value="42" />);
+    expect(screen.queryByText("last 30 days")).toBeNull();
+    // Only the label and value paragraphs exist; no third muted caption line.
+    const muted = document.querySelectorAll("p.text-muted-foreground");
+    expect(muted.length).toBe(0);
+  });
+});

--- a/frontend/src/components/ui/stat-tile.test.tsx
+++ b/frontend/src/components/ui/stat-tile.test.tsx
@@ -4,6 +4,10 @@ import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { StatTile } from "./stat-tile";
 
+function Star(props: { className?: string }) {
+  return <svg data-testid="ico" {...props} />;
+}
+
 describe("StatTile", () => {
   it("renders the label, the value string verbatim, and the caption when provided", () => {
     render(<StatTile label="Retention" value="87.5%" caption="last 30 days" />);
@@ -13,7 +17,6 @@ describe("StatTile", () => {
   });
 
   it("renders an svg when an icon component is passed", () => {
-    const Star = (props: { className?: string }) => <svg data-testid="ico" {...props} />;
     const { container } = render(<StatTile label="Streak" value="12" icon={Star} />);
     expect(container.querySelector("svg")).not.toBeNull();
     expect(screen.getByTestId("ico")).toBeDefined();
@@ -33,7 +36,6 @@ describe("StatTile", () => {
   });
 
   it("forwards the muted icon sizing classes to the icon", () => {
-    const Star = (props: { className?: string }) => <svg data-testid="ico" {...props} />;
     render(<StatTile label="Streak" value="12" icon={Star} />);
     const cls = screen.getByTestId("ico").getAttribute("class") ?? "";
     expect(cls).toContain("h-4");

--- a/frontend/src/components/ui/stat-tile.tsx
+++ b/frontend/src/components/ui/stat-tile.tsx
@@ -1,0 +1,34 @@
+import type { ComponentType } from "react";
+
+export type StatTileProps = {
+  label: string;
+  value: string;
+  caption?: string;
+  icon?: ComponentType<{ className?: string }>;
+};
+
+/**
+ * Presentation-only KPI card for the learning-stats diagnostics row. It renders
+ * a single pre-formatted metric — a label, a large numeric value, and an
+ * optional caption — inside shadcn card chrome (`rounded-xl border bg-card`).
+ * Number formatting (locale, units, rounding) is the CALLER's responsibility;
+ * `value` is a ready-to-render string and always carries `tabular-nums` so
+ * columns of tiles align digit-for-digit. An optional `icon` component renders
+ * muted in the header row.
+ *
+ * It is a pure stateless component (no hooks), so it intentionally omits
+ * `"use client"`.
+ */
+export function StatTile({ label, value, caption, icon }: StatTileProps) {
+  const Icon = icon;
+  return (
+    <div className="rounded-xl border bg-card text-card-foreground shadow-sm p-4">
+      <div className="flex items-center justify-between">
+        <span className="text-xs font-medium text-muted-foreground">{label}</span>
+        {Icon ? <Icon className="h-4 w-4 text-muted-foreground" /> : null}
+      </div>
+      <p className="mt-1 text-2xl font-bold tabular-nums">{value}</p>
+      {caption ? <p className="text-xs text-muted-foreground">{caption}</p> : null}
+    </div>
+  );
+}

--- a/frontend/src/components/ui/stat-tile.tsx
+++ b/frontend/src/components/ui/stat-tile.tsx
@@ -8,9 +8,10 @@ export type StatTileProps = {
 };
 
 /**
- * Presentation-only KPI card for the learning-stats diagnostics row. It renders
- * a single pre-formatted metric — a label, a large numeric value, and an
- * optional caption — inside shadcn card chrome (`rounded-xl border bg-card`).
+ * Presentation-only KPI card for the planned learning-stats diagnostics display
+ * (see `schema/stats.graphql`'s `PerformanceMetrics`); it has no frontend
+ * consumer yet. It renders a single pre-formatted metric — a label, a large
+ * numeric value, and an optional caption — inside shadcn card chrome.
  * Number formatting (locale, units, rounding) is the CALLER's responsibility;
  * `value` is a ready-to-render string and always carries `tabular-nums` so
  * columns of tiles align digit-for-digit. An optional `icon` component renders


### PR DESCRIPTION
## Summary

Adds the two reusable presentational primitives the forthcoming `/stats` learning-statistics page needs — neither existed in the codebase. `ProgressMeter` is an accessible coral progress bar for the per-deck acquisition rows; `StatTile` is a shadcn-style KPI card for the diagnostics row. Both are pure, stateless, and omit `"use client"`. They are consumed only by their co-located tests for now; the `/stats` route (#842) wires them to real `myLearningStats` data next.

This is **PR 1 of 3** in the `/stats` frontend stack (epic #838): `#841 primitives → #842 route → #843 nav`. Base is `main`.

## Changes

### `ProgressMeter` (`components/ui/progress-meter.tsx`)

- Coral track/fill meter: `bg-brand-primary` fill over a `bg-muted` track, optional `className` merged onto the track via `cn()`.
- Carries the `role="progressbar"` a11y attributes (`aria-label` / `aria-valuenow` / `aria-valuemin` / `aria-valuemax`).
- The percentage is derived once from `value / max` and defensively clamped to `[0, 100]`: a non-positive `max` (division by zero) and a non-finite or negative `value` all collapse to an empty bar via a `Number.isFinite(value)` guard, so `aria-valuenow`/width are never `NaN` — a `NaN` width is dropped by the CSSOM and would silently render a misleading full-width "100%" bar.

### `StatTile` (`components/ui/stat-tile.tsx`)

- shadcn-style KPI card: label + optional muted `lucide` icon (fixed `h-4 w-4 text-muted-foreground`) + `tabular-nums` value + optional caption.
- Number formatting (locale/units/rounding) is the caller's responsibility — `value` is a pre-formatted string, keeping the primitive logic-free.

### Tests

- `progress-meter.test.tsx` — clamp boundaries (0 / 100 / over-max / negative / non-finite), aria range, `className` passthrough, fractional-percent (rounded `aria-valuenow` vs full-precision width).
- `stat-tile.test.tsx` — label/value/caption render, `tabular-nums` on the value, icon-class forwarding, behaviour-first no-caption assertion, shared hoisted mock icon.

## Test plan

- `pnpm --filter frontend typecheck` — clean.
- `pnpm --filter frontend lint` — clean (2 pre-existing biome config-deprecation infos only).
- `pnpm --filter frontend knip` — clean (1 pre-existing config hint, unrelated).
- `pnpm --filter frontend test` — 1791 pass / 192 files (includes 15 new primitive tests).
- `pnpm --filter frontend build` — succeeds.
- No CJK in changed `.ts/.tsx`; no generated code committed.

Closes #841
