### PR TITLE
feat(frontend): add Progress entry to the global rail for /stats

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -21,6 +21,7 @@
   "Nav": {
     "cardgroups": "Cardgroups",
     "catalog": "Catalog",
+    "progress": "Progress",
     "profile": "Profile",
     "signIn": "Sign in",
     "logout": "Logout",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -21,6 +21,7 @@
   "Nav": {
     "cardgroups": "カードグループ",
     "catalog": "カタログ",
+    "progress": "学習の記録",
     "profile": "プロフィール",
     "signIn": "ログイン",
     "logout": "ログアウト",

--- a/frontend/src/components/nav/global-rail.test.tsx
+++ b/frontend/src/components/nav/global-rail.test.tsx
@@ -102,6 +102,13 @@ describe("<GlobalRail>", () => {
 
       expect(screen.getByRole("link", { name: /catalog/i })).toHaveAttribute("href", "/catalog");
     });
+
+    it("renders the Progress link pointing at /stats when signed in", () => {
+      mockUsePathname.mockReturnValue("/");
+      renderRail({ user: { email: "u@example.com" }, isAdmin: false });
+
+      expect(screen.getByRole("link", { name: /progress/i })).toHaveAttribute("href", "/stats");
+    });
   });
 
   describe("S2 — Admin gate", () => {
@@ -153,6 +160,18 @@ describe("<GlobalRail>", () => {
         "page",
       );
       expect(screen.getByRole("link", { name: /cardgroups/i })).not.toHaveAttribute("aria-current");
+    });
+
+    it("marks Progress as the current page when pathname is /stats", () => {
+      mockUsePathname.mockReturnValue("/stats");
+      renderRail({ user: { email: "u@example.com" }, isAdmin: true });
+
+      expect(screen.getByRole("link", { name: /progress/i })).toHaveAttribute(
+        "aria-current",
+        "page",
+      );
+      expect(screen.getByRole("link", { name: /cardgroups/i })).not.toHaveAttribute("aria-current");
+      expect(screen.getByRole("link", { name: /catalog/i })).not.toHaveAttribute("aria-current");
     });
 
     it("marks Catalog as the current page on a /catalog/ sub-route", () => {

--- a/frontend/src/components/nav/logo-drawer.test.tsx
+++ b/frontend/src/components/nav/logo-drawer.test.tsx
@@ -62,6 +62,17 @@ describe("<LogoDrawer>", () => {
     expect(catalogLink).toHaveAttribute("href", "/catalog");
   });
 
+  it("drawer shows the Progress link pointing at /stats", async () => {
+    const user = userEvent.setup();
+    renderWithIntl(<LogoDrawer user={SIGNED_IN_USER} isAdmin={false} />);
+
+    await user.click(screen.getByRole("button", { name: "Open menu" }));
+
+    const progressLink = screen.getByRole("link", { name: /progress/i });
+    expect(progressLink).toBeInTheDocument();
+    expect(progressLink).toHaveAttribute("href", "/stats");
+  });
+
   it("logo is a home link with aria-label='Flamingo home' and href='/'", () => {
     renderWithIntl(<LogoDrawer user={SIGNED_IN_USER} isAdmin={false} />);
 

--- a/frontend/src/components/nav/nav-items.test.ts
+++ b/frontend/src/components/nav/nav-items.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { ADMIN_NAV_ITEMS } from "./nav-items";
+import { ADMIN_NAV_ITEMS, CORE_NAV_ITEMS, resolveActiveItem } from "./nav-items";
 
 describe("ADMIN_NAV_ITEMS", () => {
   it("includes a Masters entry pointing at /admin/masters", () => {
@@ -12,5 +12,37 @@ describe("ADMIN_NAV_ITEMS", () => {
     const hrefs = ADMIN_NAV_ITEMS.map((i) => i.href);
     expect(hrefs).toContain("/admin/users");
     expect(hrefs).toContain("/admin/roles");
+  });
+});
+
+describe("CORE_NAV_ITEMS", () => {
+  it("includes a Progress entry pointing at /stats", () => {
+    const progress = CORE_NAV_ITEMS.find((i) => i.href === "/stats");
+    expect(progress).toBeDefined();
+    expect(progress?.labelKey).toBe("progress");
+  });
+
+  it("keeps the cardgroups and catalog entries", () => {
+    const hrefs = CORE_NAV_ITEMS.map((i) => i.href);
+    expect(hrefs).toContain("/cardgroups");
+    expect(hrefs).toContain("/catalog");
+  });
+});
+
+describe("resolveActiveItem", () => {
+  it("resolves /stats and its sub-routes to progress", () => {
+    expect(resolveActiveItem("/stats")).toBe("progress");
+    expect(resolveActiveItem("/stats/anything")).toBe("progress");
+  });
+
+  it("keeps the cardgroups (incl. /learn) and catalog resolution", () => {
+    expect(resolveActiveItem("/cardgroups")).toBe("cardgroups");
+    expect(resolveActiveItem("/learn/abc")).toBe("cardgroups");
+    expect(resolveActiveItem("/catalog")).toBe("catalog");
+  });
+
+  it("returns null for unrelated routes — the positive allowlist does not over-match", () => {
+    expect(resolveActiveItem("/profile")).toBeNull();
+    expect(resolveActiveItem("/admin/users")).toBeNull();
   });
 });

--- a/frontend/src/components/nav/nav-items.ts
+++ b/frontend/src/components/nav/nav-items.ts
@@ -1,4 +1,4 @@
-import { BookOpen, Library, LibraryBig, ShieldCheck, User, Users } from "lucide-react";
+import { BookOpen, ChartColumn, Library, LibraryBig, ShieldCheck, User, Users } from "lucide-react";
 import type { ComponentType } from "react";
 
 export type AdminNavItem = {
@@ -15,9 +15,9 @@ export const ADMIN_NAV_ITEMS: readonly AdminNavItem[] = [
 ] as const;
 
 export type CoreNavItem = {
-  href: "/cardgroups" | "/catalog";
+  href: "/cardgroups" | "/catalog" | "/stats";
   /** Key into the `Nav` message namespace — resolved via `useTranslations("Nav")`. */
-  labelKey: "cardgroups" | "catalog";
+  labelKey: "cardgroups" | "catalog" | "progress";
   icon: ComponentType<{ className?: string }>;
 };
 
@@ -31,6 +31,7 @@ export type CoreNavItem = {
 export const CORE_NAV_ITEMS: readonly CoreNavItem[] = [
   { href: "/cardgroups", labelKey: "cardgroups", icon: BookOpen },
   { href: "/catalog", labelKey: "catalog", icon: LibraryBig },
+  { href: "/stats", labelKey: "progress", icon: ChartColumn },
 ] as const;
 
 export type FooterNavItem = {
@@ -48,11 +49,11 @@ export const FOOTER_NAV_ITEMS: readonly FooterNavItem[] = [
 /**
  * Active center-nav item resolved from the current pathname.
  *
- * Only handles the static center items (Cardgroups, Catalog). Admin items and
- * the footer Profile link compute their own active state inline, so this type
- * deliberately does not include `"profile"` or `"admin"`.
+ * Only handles the static center items (Cardgroups, Catalog, Progress). Admin
+ * items and the footer Profile link compute their own active state inline, so
+ * this type deliberately does not include `"profile"` or `"admin"`.
  */
-export type ActiveItem = "cardgroups" | "catalog" | null;
+export type ActiveItem = "cardgroups" | "catalog" | "progress" | null;
 
 /** Matches `pathname` against a top-level route — exact match or a sub-route prefix. */
 export function matchesRoute(pathname: string, route: string): boolean {
@@ -78,6 +79,9 @@ export function resolveActiveItem(pathname: string): ActiveItem {
   }
   if (matchesRoute(pathname, "/catalog")) {
     return "catalog";
+  }
+  if (matchesRoute(pathname, "/stats")) {
+    return "progress";
   }
   return null;
 }


### PR DESCRIPTION
## Summary

Adds the **"Progress" entry to the existing global rail** so the `/stats` learning-statistics page (built in #842) is discoverable. Per the approved design this is a single data-driven nav entry — no rail/header redesign, the current app shell is kept as-is. Nav is data-driven from one file: the shared `{ href, labelKey, icon }` triple in `frontend/src/components/nav/nav-items.ts` is consumed by both `GlobalRail` (desktop) and the mobile `LogoDrawer`, so a new destination is a one-file change plus its i18n labels.

This is **PR 3 of 3** in the `/stats` frontend stack (epic #838): `#841 primitives → #842 route → #843 nav`. Base is `feat/stats-route` (#842).

## Changes

### Nav

- **`nav-items.ts`** — extend the `CoreNavItem` union (`href` gains `"/stats"`, `labelKey` gains `"progress"`), append `{ href: "/stats", labelKey: "progress", icon: ChartColumn }` to `CORE_NAV_ITEMS`, and add a `/stats → "progress"` branch to `resolveActiveItem` (the `ActiveItem` union gains `"progress"`). The resolver keeps its positive-allowlist style so future top-level routes do not silently match.

### i18n

- **`messages/en.json`** — `Nav.progress` = `"Progress"`.
- **`messages/ja.json`** — `Nav.progress` = `"学習の記録"`.

## Tests

- **`nav-items.test.ts`** — `CORE_NAV_ITEMS` includes the `/stats` → `progress` entry; `resolveActiveItem` resolves `/stats` and its sub-routes to `progress`, still resolves cardgroups/catalog, and returns `null` for unrelated routes (allowlist does not over-match).
- **`global-rail.test.tsx`** / **`logo-drawer.test.tsx`** — assert the Progress link renders in **both** the desktop rail and the mobile drawer trees (per the two-tree rule in `.claude/rules/scope-discipline.md`).

## Verification

Run in the worktree against this branch:

- `tsc --noEmit` — exit 0 (whole frontend).
- `biome check src/components/nav src/app/stats` — clean.
- `vitest run src/components/nav` — 118 passed (9 files).

Closes #843. Merging the full stack closes the epic #838.
