### PR TITLE
feat(stats): distinguish empty-deck users from brand-new users on /stats (ownsAnyDeck)

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -194,7 +194,7 @@ func buildResolver(
 	cefrUC := usecase.NewCEFRUsecase(cefrClassifier)
 	masterCatalogUC := usecase.NewMasterCatalogUsecase(repos.masterCardgroup, masterDeckUC, adminGate, logger)
 	masterCardUC := usecase.NewMasterCardUsecase(repos.gorm, repos.masterCard, repos.masterCardgroup, adminGate, logger)
-	statsUC := usecase.NewStats(repos.userCardFSRS, repos.swipeRecord, nil)
+	statsUC := usecase.NewStats(repos.userCardFSRS, repos.swipeRecord, repos.cardgroup, nil)
 
 	resolvers := resolver.NewResolver(userUC, cardgroupUC, cardUC, swipeUC, authSvc, cardImportUC, adminUserUC, adminRoleUC, lastViewedCardgroupUC, updateLearnDisplayModeUC, updateNewCardRatioUC, learnUC, cefrUC, masterCatalogUC, masterCardUC, statsUC)
 	return resolvers, pingHandler, notionSyncHandler, nil

--- a/backend/graph/resolver/mapper.go
+++ b/backend/graph/resolver/mapper.go
@@ -107,6 +107,7 @@ func toLearningStatsModel(ctx context.Context, res *usecase.LearningStatsResult)
 			TotalStudied: res.Mastery.TotalStudied,
 		},
 		Decks:           decks,
+		OwnsAnyDeck:     res.OwnsAnyDeck,
 		Performance:     toPerformanceMetricsModel(res.Performance),
 		StrugglingCards: struggling,
 	}, nil

--- a/backend/internal/usecase/stats.go
+++ b/backend/internal/usecase/stats.go
@@ -42,29 +42,42 @@ type statsSwipeRepo interface {
 	ListByUserSince(ctx context.Context, userID string, since time.Time) ([]*domain.SwipeRecord, error)
 }
 
-type statsUsecase struct {
-	fsrsRepo  statsFSRSRepo
-	swipeRepo statsSwipeRepo
-	clock     Clock
+// statsCardgroupRepo is the narrow slice of the cardgroup repository the stats
+// aggregate needs to answer "does the caller own any deck?" — a count > 0 over
+// the caller's cardgroups, independent of whether those decks hold any cards.
+type statsCardgroupRepo interface {
+	CountByOwner(ctx context.Context, ownerID string, search *string) (int64, error)
 }
 
-// NewStats wires the stats usecase from its narrow FSRS + swipe-record
-// repository dependencies and an injectable Clock (nil defaults to
+type statsUsecase struct {
+	fsrsRepo      statsFSRSRepo
+	swipeRepo     statsSwipeRepo
+	cardgroupRepo statsCardgroupRepo
+	clock         Clock
+}
+
+// NewStats wires the stats usecase from its narrow FSRS + swipe-record +
+// cardgroup repository dependencies and an injectable Clock (nil defaults to
 // systemClock{} in production; tests inject a fixed Clock so the window/now
 // are deterministic). Clock is the same interface NewLearnUsecase uses.
-func NewStats(fsrsRepo statsFSRSRepo, swipeRepo statsSwipeRepo, clock Clock) StatsUsecase {
+func NewStats(fsrsRepo statsFSRSRepo, swipeRepo statsSwipeRepo, cardgroupRepo statsCardgroupRepo, clock Clock) StatsUsecase {
 	if clock == nil {
 		clock = systemClock{}
 	}
-	return &statsUsecase{fsrsRepo: fsrsRepo, swipeRepo: swipeRepo, clock: clock}
+	return &statsUsecase{fsrsRepo: fsrsRepo, swipeRepo: swipeRepo, cardgroupRepo: cardgroupRepo, clock: clock}
 }
 
 // LearningStatsResult is the usecase-layer result VO. It carries cardgroup ids
 // and struggling-card ids only; the resolver hydrates the Cardgroup / Card
 // objects via the DataLoader.
 type LearningStatsResult struct {
-	Mastery         MasteryBreakdown
-	Decks           []DeckMasteryResult
+	Mastery MasteryBreakdown
+	Decks   []DeckMasteryResult
+	// OwnsAnyDeck is true iff the caller owns at least one cardgroup, regardless
+	// of card count. It lets the client tell a brand-new user (owns nothing) apart
+	// from a user who created a deck but has not added cards yet — Decks omits
+	// empty decks, so Decks alone cannot make that distinction.
+	OwnsAnyDeck     bool
 	Performance     service.PerformanceMetrics
 	StrugglingCards []StrugglingCardResult
 }
@@ -167,9 +180,17 @@ func (u *statsUsecase) MyLearningStats(ctx context.Context) (*LearningStatsResul
 		return nil, eris.Wrap(err, "usecase: stats: list swipes since")
 	}
 
+	// Cheap ownership existence check: count > 0 means the caller owns at least
+	// one cardgroup, even if all its decks are empty (which totals/Decks omit).
+	count, err := u.cardgroupRepo.CountByOwner(ctx, caller.Sub, nil)
+	if err != nil {
+		return nil, eris.Wrap(err, "usecase: stats: count cardgroups by owner")
+	}
+
 	return &LearningStatsResult{
 		Mastery:         mastery,
 		Decks:           decks,
+		OwnsAnyDeck:     count > 0,
 		Performance:     service.ComputeMetrics(swipeRecordsByValue(swipes), now),
 		StrugglingCards: topStruggling(states, strugglingCardsLimit),
 	}, nil

--- a/backend/internal/usecase/stats_test.go
+++ b/backend/internal/usecase/stats_test.go
@@ -59,6 +59,20 @@ func (f *fakeStatsSwipeRepo) ListByUserSince(_ context.Context, userID string, s
 	return f.swipes, nil
 }
 
+// fakeStatsCardgroupRepo returns a configurable owned-deck count (and optional
+// error) for CountByOwner so tests can pin the OwnsAnyDeck signal without a DB.
+type fakeStatsCardgroupRepo struct {
+	count int64
+	err   error
+}
+
+func (f *fakeStatsCardgroupRepo) CountByOwner(_ context.Context, _ string, _ *string) (int64, error) {
+	if f.err != nil {
+		return 0, f.err
+	}
+	return f.count, nil
+}
+
 func authedStatsCtx(sub string) context.Context {
 	return auth.ContextWithUser(context.Background(), &auth.AuthUser{Sub: sub})
 }
@@ -96,7 +110,7 @@ func TestStatsUsecase_MyLearningStats_BucketsGlobalAndPerDeck(t *testing.T) {
 		},
 		totals: map[string]int{"cg1": 5, "cg2": 3, "cg3": 2},
 	}
-	uc := NewStats(repo, &fakeStatsSwipeRepo{}, nil)
+	uc := NewStats(repo, &fakeStatsSwipeRepo{}, &fakeStatsCardgroupRepo{}, nil)
 
 	res, err := uc.MyLearningStats(authedStatsCtx("user-1"))
 	require.NoError(t, err)
@@ -137,7 +151,7 @@ func TestStatsUsecase_MyLearningStats_BucketsGlobalAndPerDeck(t *testing.T) {
 func TestStatsUsecase_MyLearningStats_EmptyHistory(t *testing.T) {
 	t.Parallel()
 	repo := &fakeStatsFSRSRepo{states: nil, totals: map[string]int{}}
-	uc := NewStats(repo, &fakeStatsSwipeRepo{}, nil)
+	uc := NewStats(repo, &fakeStatsSwipeRepo{}, &fakeStatsCardgroupRepo{}, nil)
 
 	res, err := uc.MyLearningStats(authedStatsCtx("user-1"))
 	require.NoError(t, err)
@@ -147,7 +161,7 @@ func TestStatsUsecase_MyLearningStats_EmptyHistory(t *testing.T) {
 
 func TestStatsUsecase_MyLearningStats_Unauthenticated(t *testing.T) {
 	t.Parallel()
-	uc := NewStats(&fakeStatsFSRSRepo{}, &fakeStatsSwipeRepo{}, nil)
+	uc := NewStats(&fakeStatsFSRSRepo{}, &fakeStatsSwipeRepo{}, &fakeStatsCardgroupRepo{}, nil)
 
 	res, err := uc.MyLearningStats(context.Background())
 	require.Error(t, err)
@@ -158,7 +172,7 @@ func TestStatsUsecase_MyLearningStats_Unauthenticated(t *testing.T) {
 
 func TestStatsUsecase_MyLearningStats_EmptySubUnauthenticated(t *testing.T) {
 	t.Parallel()
-	uc := NewStats(&fakeStatsFSRSRepo{}, &fakeStatsSwipeRepo{}, nil)
+	uc := NewStats(&fakeStatsFSRSRepo{}, &fakeStatsSwipeRepo{}, &fakeStatsCardgroupRepo{}, nil)
 
 	res, err := uc.MyLearningStats(authedStatsCtx(""))
 	require.Error(t, err)
@@ -169,7 +183,7 @@ func TestStatsUsecase_MyLearningStats_EmptySubUnauthenticated(t *testing.T) {
 func TestStatsUsecase_MyLearningStats_ListStatesError(t *testing.T) {
 	t.Parallel()
 	sentinel := eris.New("boom")
-	uc := NewStats(&fakeStatsFSRSRepo{statesErr: sentinel}, &fakeStatsSwipeRepo{}, nil)
+	uc := NewStats(&fakeStatsFSRSRepo{statesErr: sentinel}, &fakeStatsSwipeRepo{}, &fakeStatsCardgroupRepo{}, nil)
 
 	res, err := uc.MyLearningStats(authedStatsCtx("user-1"))
 	require.Error(t, err)
@@ -181,7 +195,7 @@ func TestStatsUsecase_MyLearningStats_ListStatesError(t *testing.T) {
 func TestStatsUsecase_MyLearningStats_CountError(t *testing.T) {
 	t.Parallel()
 	sentinel := eris.New("boom")
-	uc := NewStats(&fakeStatsFSRSRepo{totalsErr: sentinel}, &fakeStatsSwipeRepo{}, nil)
+	uc := NewStats(&fakeStatsFSRSRepo{totalsErr: sentinel}, &fakeStatsSwipeRepo{}, &fakeStatsCardgroupRepo{}, nil)
 
 	res, err := uc.MyLearningStats(authedStatsCtx("user-1"))
 	require.Error(t, err)
@@ -234,7 +248,7 @@ func TestStatsUsecase_MyLearningStats_WindowsSwipesByStatsWindowDays(t *testing.
 	t.Parallel()
 	fixedNow := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
 	swipeRepo := &fakeStatsSwipeRepo{}
-	uc := NewStats(&fakeStatsFSRSRepo{totals: map[string]int{}}, swipeRepo, fixedClock{now: fixedNow})
+	uc := NewStats(&fakeStatsFSRSRepo{totals: map[string]int{}}, swipeRepo, &fakeStatsCardgroupRepo{}, fixedClock{now: fixedNow})
 
 	res, err := uc.MyLearningStats(authedStatsCtx("user-1"))
 	require.NoError(t, err)
@@ -257,7 +271,7 @@ func TestStatsUsecase_MyLearningStats_PerformanceReflectsComputeMetrics(t *testi
 		{ID: "s2", UserID: "user-1", CardID: "c2", CardgroupID: "cg1", Rating: domain.RatingAgain, ReviewedAt: fixedNow.AddDate(0, 0, -1), StateAfter: state},
 	}
 	swipeRepo := &fakeStatsSwipeRepo{swipes: swipes}
-	uc := NewStats(&fakeStatsFSRSRepo{totals: map[string]int{}}, swipeRepo, fixedClock{now: fixedNow})
+	uc := NewStats(&fakeStatsFSRSRepo{totals: map[string]int{}}, swipeRepo, &fakeStatsCardgroupRepo{}, fixedClock{now: fixedNow})
 
 	res, err := uc.MyLearningStats(authedStatsCtx("user-1"))
 	require.NoError(t, err)
@@ -280,7 +294,7 @@ func TestStatsUsecase_MyLearningStats_StrugglingCardsFromFSRSRows(t *testing.T) 
 		},
 		totals: map[string]int{},
 	}
-	uc := NewStats(repo, &fakeStatsSwipeRepo{}, fixedClock{now: fixedNow})
+	uc := NewStats(repo, &fakeStatsSwipeRepo{}, &fakeStatsCardgroupRepo{}, fixedClock{now: fixedNow})
 
 	res, err := uc.MyLearningStats(authedStatsCtx("user-1"))
 	require.NoError(t, err)
@@ -293,11 +307,74 @@ func TestStatsUsecase_MyLearningStats_StrugglingCardsFromFSRSRows(t *testing.T) 
 func TestStatsUsecase_MyLearningStats_ListSwipesError(t *testing.T) {
 	t.Parallel()
 	sentinel := eris.New("boom")
-	uc := NewStats(&fakeStatsFSRSRepo{totals: map[string]int{}}, &fakeStatsSwipeRepo{err: sentinel}, nil)
+	uc := NewStats(&fakeStatsFSRSRepo{totals: map[string]int{}}, &fakeStatsSwipeRepo{err: sentinel}, &fakeStatsCardgroupRepo{}, nil)
 
 	res, err := uc.MyLearningStats(authedStatsCtx("user-1"))
 	require.Error(t, err)
 	assert.Nil(t, res)
 	assert.True(t, errors.Is(err, sentinel))
 	assert.Contains(t, err.Error(), "usecase: stats: list swipes since")
+}
+
+// TestStatsUsecase_MyLearningStats_OwnsAnyDeck_TrulyNew covers a brand-new user
+// who owns no cardgroup: CountByOwner returns 0, so OwnsAnyDeck is false and
+// Decks is empty.
+func TestStatsUsecase_MyLearningStats_OwnsAnyDeck_TrulyNew(t *testing.T) {
+	t.Parallel()
+	repo := &fakeStatsFSRSRepo{states: nil, totals: map[string]int{}}
+	uc := NewStats(repo, &fakeStatsSwipeRepo{}, &fakeStatsCardgroupRepo{count: 0}, nil)
+
+	res, err := uc.MyLearningStats(authedStatsCtx("user-1"))
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	assert.False(t, res.OwnsAnyDeck, "a user owning no cardgroup is not OwnsAnyDeck")
+	assert.Empty(t, res.Decks)
+}
+
+// TestStatsUsecase_MyLearningStats_OwnsAnyDeck_EmptyDeck covers a user who owns
+// a cardgroup with zero cards and has studied nothing: CountByOwner returns 1,
+// so OwnsAnyDeck is true even though Decks (built from card totals) is empty.
+func TestStatsUsecase_MyLearningStats_OwnsAnyDeck_EmptyDeck(t *testing.T) {
+	t.Parallel()
+	repo := &fakeStatsFSRSRepo{states: nil, totals: map[string]int{}}
+	uc := NewStats(repo, &fakeStatsSwipeRepo{}, &fakeStatsCardgroupRepo{count: 1}, nil)
+
+	res, err := uc.MyLearningStats(authedStatsCtx("user-1"))
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	assert.True(t, res.OwnsAnyDeck, "owning an empty deck still counts as OwnsAnyDeck")
+	assert.Empty(t, res.Decks, "an empty deck is omitted from Decks (no card totals)")
+}
+
+// TestStatsUsecase_MyLearningStats_OwnsAnyDeck_DeckWithCards covers a user who
+// owns a non-empty deck and has studied cards: CountByOwner returns 1, Decks is
+// non-empty, and OwnsAnyDeck is true.
+func TestStatsUsecase_MyLearningStats_OwnsAnyDeck_DeckWithCards(t *testing.T) {
+	t.Parallel()
+	repo := &fakeStatsFSRSRepo{
+		states: []repository.FSRSStatRow{reviewRow("a", "cg1", 30)},
+		totals: map[string]int{"cg1": 1},
+	}
+	uc := NewStats(repo, &fakeStatsSwipeRepo{}, &fakeStatsCardgroupRepo{count: 1}, nil)
+
+	res, err := uc.MyLearningStats(authedStatsCtx("user-1"))
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	assert.True(t, res.OwnsAnyDeck)
+	require.Len(t, res.Decks, 1)
+	assert.Equal(t, "cg1", res.Decks[0].CardgroupID)
+}
+
+// TestStatsUsecase_MyLearningStats_CountByOwnerError covers a CountByOwner
+// failure: MyLearningStats returns the eris-wrapped error.
+func TestStatsUsecase_MyLearningStats_CountByOwnerError(t *testing.T) {
+	t.Parallel()
+	sentinel := eris.New("boom")
+	uc := NewStats(&fakeStatsFSRSRepo{totals: map[string]int{}}, &fakeStatsSwipeRepo{}, &fakeStatsCardgroupRepo{err: sentinel}, nil)
+
+	res, err := uc.MyLearningStats(authedStatsCtx("user-1"))
+	require.Error(t, err)
+	assert.Nil(t, res)
+	assert.True(t, errors.Is(err, sentinel))
+	assert.Contains(t, err.Error(), "usecase: stats: count cardgroups by owner")
 }

--- a/frontend/__tests__/stats.test.tsx
+++ b/frontend/__tests__/stats.test.tsx
@@ -40,6 +40,7 @@ import { renderWithIntl } from "@/test/render-with-intl";
 // flow-detail assertions live in the co-located stats-client.test.tsx.
 const populatedStats: MyLearningStatsQuery["myLearningStats"] = {
   __typename: "LearningStats",
+  ownsAnyDeck: true,
   mastery: {
     __typename: "MasteryBreakdown",
     inProgress: 420,

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -446,6 +446,9 @@
     "emptyNotStudied": "No progress to show yet",
     "emptyNotStudiedBody": "Study a few cards and your mastery breakdown and diagnostic metrics will appear here.",
     "emptyStartStudying": "Start studying",
+    "emptyDeck": "Your deck has no cards yet",
+    "emptyDeckBody": "You created a deck but it has no cards. Add a few cards, then study them — your mastery and progress will appear here.",
+    "emptyDeckCta": "Add cards",
     "diagnosticsHeading": "Diagnostics",
     "diagnosticsWindow": "Last 365 days",
     "diagnosticsNoActivity": "Not enough recent activity in the last 365 days."

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -446,6 +446,9 @@
     "emptyNotStudied": "まだ表示できる記録がありません",
     "emptyNotStudiedBody": "カードをいくつか学習すると、習得状況の内訳と診断指標がここに表示されます。",
     "emptyStartStudying": "学習を始める",
+    "emptyDeck": "デッキにまだカードがありません",
+    "emptyDeckBody": "デッキを作成しましたが、カードがありません。カードをいくつか追加して学習すると、習得状況と進捗がここに表示されます。",
+    "emptyDeckCta": "カードを追加",
     "diagnosticsHeading": "診断",
     "diagnosticsWindow": "過去365日間",
     "diagnosticsNoActivity": "過去365日間の学習履歴が不足しています。"

--- a/frontend/src/app/stats/page.test.tsx
+++ b/frontend/src/app/stats/page.test.tsx
@@ -41,6 +41,7 @@ import { gqlFetch } from "@/lib/apollo/server";
 function makeStatsData() {
   return {
     myLearningStats: {
+      ownsAnyDeck: true,
       mastery: { inProgress: 1, learned: 2, mature: 3, totalStudied: 6 },
       decks: [],
       performance: {

--- a/frontend/src/app/stats/queries.ts
+++ b/frontend/src/app/stats/queries.ts
@@ -3,6 +3,7 @@ import { graphql } from "@/generated";
 export const MyLearningStatsQuery = graphql(`
   query MyLearningStats {
     myLearningStats {
+      ownsAnyDeck
       mastery { inProgress learned mature totalStudied }
       decks {
         cardgroup { id name }

--- a/frontend/src/app/stats/stats-client.test.tsx
+++ b/frontend/src/app/stats/stats-client.test.tsx
@@ -16,6 +16,7 @@ type Stats = MyLearningStatsQuery["myLearningStats"];
 //   deck share = (100 + 20) / 500 = 24%  -> aria-valuenow "24"
 const populatedStats: Stats = {
   __typename: "LearningStats",
+  ownsAnyDeck: true,
   mastery: {
     __typename: "MasteryBreakdown",
     inProgress: 420,
@@ -177,9 +178,10 @@ describe("<StatsClient>", () => {
     });
   });
 
-  describe("brand-new user (studied === 0 && decks === [])", () => {
+  describe("truly-new user (studied === 0 && decks === [] && !ownsAnyDeck)", () => {
     const welcomeStats: Stats = {
       ...populatedStats,
+      ownsAnyDeck: false,
       mastery: zeroMastery,
       decks: [],
       strugglingCards: [],
@@ -197,10 +199,46 @@ describe("<StatsClient>", () => {
         "href",
         "/cardgroups/new",
       );
+      // The empty-deck state is for owners; the truly-new user never sees it.
+      expect(screen.queryByText("Your deck has no cards yet")).not.toBeInTheDocument();
     });
 
     it("collapses every content section (mastery / diagnostics / per-deck / struggling absent)", () => {
       renderStats(welcomeStats);
+
+      expect(screen.queryByText("Words acquired")).not.toBeInTheDocument();
+      expect(screen.queryByText("Retention")).not.toBeInTheDocument();
+      expect(screen.queryByText("Per-deck acquisition")).not.toBeInTheDocument();
+      expect(screen.queryByText("Struggling cards")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("empty-deck user (studied === 0 && decks === [] && ownsAnyDeck)", () => {
+    // Owns at least one cardgroup, but every deck is empty (the backend omits
+    // zero-card decks from `decks`), so `decks` is [] yet `ownsAnyDeck` is true.
+    const emptyDeckStats: Stats = {
+      ...populatedStats,
+      ownsAnyDeck: true,
+      mastery: zeroMastery,
+      decks: [],
+      strugglingCards: [],
+    };
+
+    it("renders the empty-deck state (add cards CTA), not the welcome state", () => {
+      renderStats(emptyDeckStats);
+
+      expect(screen.getByText("Your deck has no cards yet")).toBeInTheDocument();
+      expect(screen.getByRole("link", { name: "Add cards" })).toHaveAttribute(
+        "href",
+        "/cardgroups",
+      );
+      // Distinguished from the truly-new user: no welcome copy, no catalog CTA.
+      expect(screen.queryByText("Your progress starts here")).not.toBeInTheDocument();
+      expect(screen.queryByRole("link", { name: "Browse the catalog" })).not.toBeInTheDocument();
+    });
+
+    it("collapses every content section (mastery / diagnostics / per-deck / struggling absent)", () => {
+      renderStats(emptyDeckStats);
 
       expect(screen.queryByText("Words acquired")).not.toBeInTheDocument();
       expect(screen.queryByText("Retention")).not.toBeInTheDocument();

--- a/frontend/src/app/stats/stats-client.tsx
+++ b/frontend/src/app/stats/stats-client.tsx
@@ -7,26 +7,41 @@ import type { MyLearningStatsQuery } from "@/generated/graphql";
 import { DiagnosticsPanel } from "./diagnostics-panel";
 import { MasterySummary } from "./mastery-summary";
 import { PerDeckList } from "./per-deck-list";
-import { NotStudiedEmpty, StrugglingEmpty, WelcomeEmpty } from "./stats-empty-states";
+import {
+  EmptyDeckEmpty,
+  NotStudiedEmpty,
+  StrugglingEmpty,
+  WelcomeEmpty,
+} from "./stats-empty-states";
 import { StrugglingList } from "./struggling-list";
 
 /**
  * Presentational shell for `/stats`. Data arrives fully-fetched from the RSC
  * (`page.tsx`) as a prop — no Apollo hooks here — and this component only routes
- * the three data-absence cases and lays out the four content sections. All copy
- * flows through `useTranslations("Stats")`; number/percent formatting lives in
- * the section components via `useFormatter()`.
+ * the data-absence cases (welcome / empty-deck / not-studied) and lays out the
+ * content sections. All copy flows through `useTranslations("Stats")`;
+ * number/percent formatting lives in the section components via `useFormatter()`.
  */
 export function StatsClient({ stats }: { stats: MyLearningStatsQuery["myLearningStats"] }) {
   const t = useTranslations("Stats");
   const studied = stats.mastery.totalStudied;
   const hasDecks = stats.decks.length > 0;
+  const ownsAnyDeck = stats.ownsAnyDeck;
 
   let content: ReactNode;
-  if (studied === 0 && !hasDecks) {
-    // Brand-new user: owns no deck that has any cards (the backend omits
-    // zero-card decks from `decks`), and nothing studied. All sections collapse.
+  if (studied === 0 && !hasDecks && ownsAnyDeck === false) {
+    // Truly-new user: owns no cardgroup at all, and nothing studied. All
+    // sections collapse to the welcome empty state. Test `ownsAnyDeck === false`
+    // (not `!ownsAnyDeck`) so that an unexpectedly-undefined value (a query /
+    // codegen / mock desync tsc cannot catch, since the field is typed non-null)
+    // falls through to EmptyDeckEmpty below rather than back into this
+    // "create a deck" nudge — the exact misdirection this feature removes.
     content = <WelcomeEmpty />;
+  } else if (studied === 0 && !hasDecks) {
+    // Owns at least one cardgroup but every deck is empty (the backend omits
+    // zero-card decks from `decks`), and nothing studied. Nudge the user to add
+    // cards rather than telling them to create a deck they already have.
+    content = <EmptyDeckEmpty />;
   } else if (studied === 0) {
     // Has decks but no reviews yet: per-deck rows render at 0%, and the
     // struggling slot is necessarily empty (no lapses without studied cards) —

--- a/frontend/src/app/stats/stats-empty-states.tsx
+++ b/frontend/src/app/stats/stats-empty-states.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { CircleCheck, Sprout, TrendingUp } from "lucide-react";
+import { CircleCheck, FilePlus2, Sprout, TrendingUp } from "lucide-react";
 import Link from "next/link";
 import { useTranslations } from "next-intl";
 import { buttonVariants } from "@/components/ui/button";
@@ -14,8 +14,9 @@ import { buttonVariants } from "@/components/ui/button";
  */
 
 /**
- * Brand-new user (no decks, nothing studied). Two CTAs: browse the catalog
- * (primary) or create a deck (secondary).
+ * Truly-new user who owns no cardgroup at all, and nothing studied. Two CTAs:
+ * browse the catalog (primary) or create a deck (secondary). Distinct from
+ * `EmptyDeckEmpty`, which is the "owns a deck but it has no cards yet" case.
  */
 export function WelcomeEmpty() {
   const t = useTranslations("Stats");
@@ -30,6 +31,26 @@ export function WelcomeEmpty() {
         </Link>
         <Link href="/cardgroups/new" className={buttonVariants({ variant: "outline" })}>
           {t("emptyCreateDeck")}
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Owns at least one cardgroup but every deck is empty (the backend omits
+ * zero-card decks from `decks`), and nothing studied. One CTA: go add cards.
+ */
+export function EmptyDeckEmpty() {
+  const t = useTranslations("Stats");
+  return (
+    <div className="flex flex-col items-center rounded-lg border border-dashed border-border p-8 text-center">
+      <FilePlus2 aria-hidden="true" className="h-8 w-8 text-muted-foreground" />
+      <h2 className="mt-2 text-xl font-semibold">{t("emptyDeck")}</h2>
+      <p className="mx-auto mt-2 max-w-md text-sm text-muted-foreground">{t("emptyDeckBody")}</p>
+      <div className="mt-6 flex justify-center">
+        <Link href="/cardgroups" className={buttonVariants({ variant: "brand" })}>
+          {t("emptyDeckCta")}
         </Link>
       </div>
     </div>

--- a/schema/stats.graphql
+++ b/schema/stats.graphql
@@ -8,6 +8,8 @@ type LearningStats {
   performance: PerformanceMetrics!
   """Cards the learner struggles with most, ranked by lapses (desc) then stability (asc), filtered to at least one lapse, capped at 10."""
   strugglingCards: [StrugglingCard!]!
+  """True iff the caller owns at least one deck (cardgroup), regardless of card count. Distinguishes a brand-new user (owns nothing) from one who created a deck but has not added any cards yet — `decks` omits zero-card decks, so it alone cannot make that distinction."""
+  ownsAnyDeck: Boolean!
 }
 
 """A card the learner struggles with (high lapses / low stability)."""


### PR DESCRIPTION
## Summary

Adds an `ownsAnyDeck` signal to `myLearningStats` so `/stats` can tell a **brand-new user**
(owns no cardgroup) apart from a user who **created a deck but has not added any cards yet**.
`myLearningStats.decks` omits zero-card decks (the backend's `CountCardsByCardgroupForUser`
uses an INNER JOIN to `cards`), so before this change both cases collapsed to `decks === []`
and the second user was told to "create a deck" they already had. `/stats` now routes three
states: truly-new → `WelcomeEmpty`, empty-deck → a new `EmptyDeckEmpty` ("Add cards"),
has-cards-not-studied → the existing `NotStudiedEmpty`.

Surfaced by the #842 silent-failure review (which only corrected the misleading comment).
Full-stack (schema + backend + frontend); base is `main`.

## Changes

### Schema

- **`schema/stats.graphql`** — `type LearningStats` gains `ownsAnyDeck: Boolean!` (true iff the
  caller owns ≥1 cardgroup, regardless of card count), with a field description. `gqlgen` and
  `graphql-codegen` regenerate from this (both generated trees are gitignored).

### Backend

- **`internal/usecase/stats.go`** — `LearningStatsResult` gains `OwnsAnyDeck bool`. A new narrow
  consumer interface `statsCardgroupRepo` (mirroring `statsFSRSRepo` / `statsSwipeRepo`) is
  injected through `NewStats` (`cardgroupRepo` added before `clock`; `nil → systemClock` default
  preserved). `MyLearningStats` sets `OwnsAnyDeck = CountByOwner(ctx, sub, nil) > 0`, wrapping the
  infra error with `eris.Wrap(..., "usecase: stats: count cardgroups by owner")`.
- **`graph/resolver/mapper.go`** — `toLearningStatsModel` maps `OwnsAnyDeck` onto
  `model.LearningStats`.
- **`cmd/server/main.go`** — threads `repos.cardgroup` into `NewStats`.

#### Design decision — reuse `CountByOwner`, do not add `ExistsByOwner`

The issue floated a dedicated `ExistsByOwner`. `cmd/server/main.go` passes `repos.cardgroup`
typed as the wide `repository.CardgroupRepository` interface into `NewStats`, so a new method
would have to land on that interface and fan out to every fake (loader, `master_deck`, resolver
harnesses). The existing owner-scoped `CountByOwner(ctx, ownerID, nil) > 0` answers "owns any
deck" with **zero fan-out** and no new repository method — a `nil` search short-circuits the
`ILIKE` branch, degenerating to an indexed `COUNT(*) WHERE owner_id = ?`. Its cross-tenant
scoping is already covered by `TestCardgroupRepo_FindPageByOwner_CrossTenant` and
`TestCardgroupRepo_CountByOwner_NoSearch`, so **no new repository integration test is needed**.

### Frontend

- **`app/stats/queries.ts`** — selects `ownsAnyDeck`; codegen regenerated.
- **`app/stats/stats-client.tsx`** — three-way empty-state split. The truly-new branch tests
  `ownsAnyDeck === false` (not `!ownsAnyDeck`) so an unexpectedly-`undefined` value (a
  query/codegen/mock desync `tsc` cannot catch, since the field is typed non-null) falls through
  to `EmptyDeckEmpty` rather than back into the "create a deck" nudge this feature removes.
- **`app/stats/stats-empty-states.tsx`** — new `EmptyDeckEmpty` (`FilePlus2`, one filled `brand`
  CTA → `/cardgroups`), matching the sibling empty-state markup and the emphasis ladder.
- **`messages/{en,ja}.json`** — new `Stats.emptyDeck` / `emptyDeckBody` / `emptyDeckCta` keys
  (Japanese only in the catalog; no inline CJK in source).

## Test plan

- `cd backend && go build ./... && go vet ./...` — clean.
- `go test ./internal/usecase/... ./graph/...` — pass (Docker-free; the 5 full-suite failures
  under `go test ./...` are testcontainer/Docker-unavailable integration packages, CI-deferred).
  New usecase subtests: owns-nothing → `OwnsAnyDeck false`, owns-empty-deck → `true`,
  owns-deck-with-cards → `true`, and `CountByOwner` error → eris-wrapped propagation.
- `pnpm --filter frontend typecheck` / `lint` / `knip` — clean (only pre-existing config infos).
- `pnpm --filter frontend test` — 1825 pass / 195 files (new empty-deck routing case; every
  `myLearningStats` fixture updated to carry `ownsAnyDeck`).
- `pnpm --filter frontend build` — succeeds; `/stats` renders.
- `pnpm lint:schema` clean; CJK guard clean over changed `.ts/.tsx`; no generated code committed.

Closes #845

Related: #842 (surfaced this), #838 (epic).
