### PR TITLE
refactor(frontend): remove dead ariaLabel prop from SwipeableRow

### DIFF
--- a/frontend/src/components/admin/role-list-item.tsx
+++ b/frontend/src/components/admin/role-list-item.tsx
@@ -45,7 +45,7 @@ export function RoleListItem({ id, name, isSystem, busy, onEdit, onDelete }: Rol
   }
 
   return (
-    <SwipeableRow onDelete={() => onDelete(id)} disabled={busy} ariaLabel={`Delete role ${name}`}>
+    <SwipeableRow onDelete={() => onDelete(id)} disabled={busy}>
       <li
         className="group flex items-center gap-2 rounded-lg border border-border pr-2 hover:bg-accent active:bg-accent transition-colors"
         data-testid={`admin-role-row-${id}`}

--- a/frontend/src/components/cardgroups/card-row.tsx
+++ b/frontend/src/components/cardgroups/card-row.tsx
@@ -37,12 +37,7 @@ export const CardRow = memo(function CardRow({
 }: CardRowProps) {
   const t = useTranslations("Cards");
   return (
-    <SwipeableRow
-      ref={rowRef}
-      onDelete={() => onDelete(card.id)}
-      disabled={disabled}
-      ariaLabel={t("deleteCardAriaLabel")}
-    >
+    <SwipeableRow ref={rowRef} onDelete={() => onDelete(card.id)} disabled={disabled}>
       <div className="group relative flex items-center justify-between gap-4 px-4 py-3 hover:bg-accent active:bg-accent transition-colors">
         {/* biome-ignore lint/a11y/noStaticElementInteractions: span is a click/keydown stopper, not an interactive element; the inner <input> is the actual control. */}
         <span

--- a/frontend/src/components/cardgroups/cardgroup-list-item.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-list-item.tsx
@@ -26,7 +26,7 @@ export function CardgroupListItem({
   const deleteLabel = t("deleteAriaLabel", { name });
   const requestDelete = () => onDelete(id, name);
   return (
-    <SwipeableRow onDelete={requestDelete} disabled={busy} ariaLabel={deleteLabel}>
+    <SwipeableRow onDelete={requestDelete} disabled={busy}>
       <li className="group flex items-center gap-2 rounded-lg border border-border pr-2 hover:bg-accent active:bg-accent transition-colors bg-background">
         <Link href={`/cardgroups/${id}/edit`} className="flex min-w-0 flex-1 flex-col gap-1 p-4">
           <span className="truncate font-medium text-foreground">{name}</span>

--- a/frontend/src/components/cardgroups/swipeable-row.test.tsx
+++ b/frontend/src/components/cardgroups/swipeable-row.test.tsx
@@ -112,7 +112,7 @@ function simulateSwipe(element: Element, deltaX: number, deltaY = 0) {
 describe("<SwipeableRow>", () => {
   it("renders children inside the swipeable layer", () => {
     render(
-      <SwipeableRow onDelete={vi.fn()} ariaLabel={null}>
+      <SwipeableRow onDelete={vi.fn()}>
         <span>Card front</span>
       </SwipeableRow>,
     );
@@ -123,7 +123,7 @@ describe("<SwipeableRow>", () => {
   it("≥40% release → onDelete fires", async () => {
     const onDelete = vi.fn();
     render(
-      <SwipeableRow onDelete={onDelete} ariaLabel={null}>
+      <SwipeableRow onDelete={onDelete}>
         <span>Card</span>
       </SwipeableRow>,
     );
@@ -141,7 +141,7 @@ describe("<SwipeableRow>", () => {
   it("<40% release → onDelete not called and row snaps back", async () => {
     const onDelete = vi.fn();
     render(
-      <SwipeableRow onDelete={onDelete} ariaLabel={null}>
+      <SwipeableRow onDelete={onDelete}>
         <span>Card</span>
       </SwipeableRow>,
     );
@@ -157,7 +157,7 @@ describe("<SwipeableRow>", () => {
   it("vertical drag (|mx| < |my|) → no-op; onDelete not called", async () => {
     const onDelete = vi.fn();
     render(
-      <SwipeableRow onDelete={onDelete} ariaLabel={null}>
+      <SwipeableRow onDelete={onDelete}>
         <span>Card</span>
       </SwipeableRow>,
     );
@@ -173,7 +173,7 @@ describe("<SwipeableRow>", () => {
   it("disabled → gesture is cancelled; onDelete not called", async () => {
     const onDelete = vi.fn();
     render(
-      <SwipeableRow onDelete={onDelete} disabled ariaLabel={null}>
+      <SwipeableRow onDelete={onDelete} disabled>
         <span>Card</span>
       </SwipeableRow>,
     );
@@ -189,7 +189,7 @@ describe("<SwipeableRow>", () => {
     stubMatchMedia(true);
 
     render(
-      <SwipeableRow onDelete={vi.fn()} ariaLabel={null}>
+      <SwipeableRow onDelete={vi.fn()}>
         <span>Reduced motion card</span>
       </SwipeableRow>,
     );
@@ -204,7 +204,7 @@ describe("<SwipeableRow>", () => {
 
     const onDelete = vi.fn();
     const { container } = render(
-      <SwipeableRow onDelete={onDelete} ariaLabel={null}>
+      <SwipeableRow onDelete={onDelete}>
         <span>Card</span>
       </SwipeableRow>,
     );
@@ -218,7 +218,7 @@ describe("<SwipeableRow>", () => {
 
   it("renders the reveal layer with a destructive background and Trash icon", () => {
     const { container } = render(
-      <SwipeableRow onDelete={vi.fn()} ariaLabel={null}>
+      <SwipeableRow onDelete={vi.fn()}>
         <span>Card front</span>
       </SwipeableRow>,
     );
@@ -236,7 +236,7 @@ describe("<SwipeableRow>", () => {
     stubMatchMedia(true);
 
     const { container } = render(
-      <SwipeableRow onDelete={vi.fn()} ariaLabel={null}>
+      <SwipeableRow onDelete={vi.fn()}>
         <span>Card front</span>
       </SwipeableRow>,
     );
@@ -250,7 +250,7 @@ describe("<SwipeableRow>", () => {
     const ref = createRef<SwipeableRowHandle>();
 
     render(
-      <SwipeableRow ref={ref} onDelete={onDelete} ariaLabel={null}>
+      <SwipeableRow ref={ref} onDelete={onDelete}>
         <span>Card</span>
       </SwipeableRow>,
     );

--- a/frontend/src/components/cardgroups/swipeable-row.tsx
+++ b/frontend/src/components/cardgroups/swipeable-row.tsx
@@ -25,14 +25,6 @@ export interface SwipeableRowProps {
    * checkboxes receive touch events without interference.
    */
   disabled?: boolean;
-  /**
-   * Accessible label retained in the public API for future a11y fallback work.
-   * Required (`string | null`) — pass `null` to accept the default "Delete"
-   * label, or a contextual string (e.g. "Delete card") to override it.
-   * See `docs/frontend/typescript-conventions.md` § "Required
-   * `string | null` over optional `?: string | null`".
-   */
-  ariaLabel: string | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -63,7 +55,7 @@ const COMMIT_THRESHOLD = 0.4;
  * list can snap back any in-progress row when needed.
  */
 export const SwipeableRow = forwardRef<SwipeableRowHandle, SwipeableRowProps>(function SwipeableRow(
-  { children, onDelete, disabled = false, ariaLabel },
+  { children, onDelete, disabled = false },
   ref,
 ) {
   const reducedMotion = useReducedMotion();
@@ -73,7 +65,7 @@ export const SwipeableRow = forwardRef<SwipeableRowHandle, SwipeableRowProps>(fu
   }
 
   return (
-    <SwipeableRowInner ref={ref} onDelete={onDelete} disabled={disabled} ariaLabel={ariaLabel}>
+    <SwipeableRowInner ref={ref} onDelete={onDelete} disabled={disabled}>
       {children}
     </SwipeableRowInner>
   );
@@ -84,7 +76,7 @@ export const SwipeableRow = forwardRef<SwipeableRowHandle, SwipeableRowProps>(fu
 // ---------------------------------------------------------------------------
 
 const SwipeableRowInner = forwardRef<SwipeableRowHandle, SwipeableRowProps>(
-  function SwipeableRowInner({ children, onDelete, disabled, ariaLabel: _ariaLabel }, ref) {
+  function SwipeableRowInner({ children, onDelete, disabled }, ref) {
     const rowRef = useRef<HTMLDivElement>(null);
 
     const [{ x }, api] = useSpring(() => ({


### PR DESCRIPTION
## Summary

`SwipeableRow` declared an `ariaLabel: string | null` prop whose JSDoc called it "retained for future a11y fallback work", but the inner component destructured it as `ariaLabel: _ariaLabel` and **never applied it to any DOM node** — the API looked wired but did nothing. Tracing the render tree confirms the accessible label is already delivered: every `<SwipeableRow>` is paired with a `<HoverRevealDeleteButton>` that applies `aria-label={ariaLabel}` (`hover-reveal-delete-button.tsx` L57). This PR removes the dead prop from `SwipeableRow` and its four pass-through call sites.

Base is `main`; this is a dead-prop removal, **no behavior change** — the label is already supplied by the paired `HoverRevealDeleteButton`, which is untouched.

Part of the naming-cleanup batch (#849–#853); the five file sets are disjoint, so this is mergeable in parallel in any order.

## Changes

- **`components/cardgroups/swipeable-row.tsx`** — drop `ariaLabel` from `SwipeableRowProps` (type + JSDoc block), from the outer `SwipeableRow` destructure and the `<SwipeableRowInner>` pass-through, and from the `SwipeableRowInner` destructure (`ariaLabel: _ariaLabel`).
- **`components/admin/role-list-item.tsx`** — remove `ariaLabel={`Delete role ${name}`}` from `<SwipeableRow>` (the `<HoverRevealDeleteButton ariaLabel={`Delete ${name}`}>` stays).
- **`components/cardgroups/card-row.tsx`** — remove `ariaLabel={t("deleteCardAriaLabel")}` from `<SwipeableRow>` (the `<HoverRevealDeleteButton ariaLabel={t("deleteCardAriaLabel")}>` stays).
- **`components/cardgroups/cardgroup-list-item.tsx`** — remove `ariaLabel={deleteLabel}` from `<SwipeableRow>` (the `<HoverRevealDeleteButton ariaLabel={deleteLabel}>` stays).

## Tests

- **`components/cardgroups/swipeable-row.test.tsx`** — the ten `<SwipeableRow … ariaLabel={null}>` renders passed `ariaLabel` only to satisfy the (now-removed) required prop; none asserted it. Dropped the `ariaLabel={null}` from each render; every swipe-behavior test is unchanged and still passes.

## Verification

Run in the worktree against this branch (binaries invoked directly from `frontend/node_modules/.bin`):

- `tsc --noEmit` — exit 0 (whole frontend).
- `biome check --error-on-warnings .` — clean (2 pre-existing config-migration infos, unrelated).
- `knip` — pass (exit 0).
- `vitest run` — 1823 passed (195 files).
- CJK guard — no CJK in any of the 5 changed files.

Closes #853
