### PR TITLE
refactor(frontend): fix catalog card/deck vocabulary (a catalog row is a deck, not a card)

### DIFF
--- a/frontend/src/app/catalog/[id]/catalog-deck-header.tsx
+++ b/frontend/src/app/catalog/[id]/catalog-deck-header.tsx
@@ -62,7 +62,7 @@ export function CatalogDeckHeader({
       )}
       <div className="mt-2">
         <CatalogImportButton
-          card={{ id: deck.id }}
+          deck={{ id: deck.id }}
           importing={importing}
           imported={imported}
           onImport={onImport}

--- a/frontend/src/app/catalog/_components/catalog-import-button.test.tsx
+++ b/frontend/src/app/catalog/_components/catalog-import-button.test.tsx
@@ -10,7 +10,7 @@ const CARD = { id: "m-1" };
 describe("<CatalogImportButton>", () => {
   it("renders the idle action label and stays enabled", () => {
     renderWithIntl(
-      <CatalogImportButton card={CARD} importing={false} imported={false} onImport={vi.fn()} />,
+      <CatalogImportButton deck={CARD} importing={false} imported={false} onImport={vi.fn()} />,
     );
 
     const btn = screen.getByTestId("catalog-import-m-1");
@@ -20,7 +20,7 @@ describe("<CatalogImportButton>", () => {
 
   it("shows the in-flight label and disables the button while importing", () => {
     renderWithIntl(
-      <CatalogImportButton card={CARD} importing={true} imported={false} onImport={vi.fn()} />,
+      <CatalogImportButton deck={CARD} importing={true} imported={false} onImport={vi.fn()} />,
     );
 
     const btn = screen.getByTestId("catalog-import-m-1");
@@ -30,7 +30,7 @@ describe("<CatalogImportButton>", () => {
 
   it("shows the imported label and disables the button once imported", () => {
     renderWithIntl(
-      <CatalogImportButton card={CARD} importing={false} imported={true} onImport={vi.fn()} />,
+      <CatalogImportButton deck={CARD} importing={false} imported={true} onImport={vi.fn()} />,
     );
 
     const btn = screen.getByTestId("catalog-import-m-1");
@@ -42,7 +42,7 @@ describe("<CatalogImportButton>", () => {
     const user = userEvent.setup();
     const onImport = vi.fn();
     renderWithIntl(
-      <CatalogImportButton card={CARD} importing={false} imported={false} onImport={onImport} />,
+      <CatalogImportButton deck={CARD} importing={false} imported={false} onImport={onImport} />,
     );
 
     await user.click(screen.getByTestId("catalog-import-m-1"));
@@ -53,7 +53,7 @@ describe("<CatalogImportButton>", () => {
   it("uses custom labels and a custom testId prefix when provided", () => {
     renderWithIntl(
       <CatalogImportButton
-        card={CARD}
+        deck={CARD}
         importing={false}
         imported={false}
         onImport={vi.fn()}
@@ -71,7 +71,7 @@ describe("<CatalogImportButton>", () => {
   it("merges the passthrough className onto the rendered button", () => {
     renderWithIntl(
       <CatalogImportButton
-        card={CARD}
+        deck={CARD}
         importing={false}
         imported={false}
         onImport={vi.fn()}

--- a/frontend/src/app/catalog/_components/catalog-import-button.tsx
+++ b/frontend/src/app/catalog/_components/catalog-import-button.tsx
@@ -6,7 +6,7 @@ import { Button } from "@/components/ui/button";
 
 export type CatalogImportButtonProps = {
   /** The deck to import — only `id` is read (the click-handler arg and the `data-testid` suffix). */
-  card: { id: string };
+  deck: { id: string };
   /** True while this cardgroup's import mutation is in flight. */
   importing: boolean;
   /** True once this cardgroup has been imported in the current session. */
@@ -41,7 +41,7 @@ export type CatalogImportButtonProps = {
  * imported (done) state wins and the in-flight label is not shown.
  */
 export function CatalogImportButton({
-  card,
+  deck,
   importing,
   imported,
   onImport,
@@ -60,9 +60,9 @@ export function CatalogImportButton({
     <Button
       type="button"
       variant={imported ? "outline" : "brand"}
-      onClick={() => onImport(card.id)}
+      onClick={() => onImport(deck.id)}
       disabled={importing || imported}
-      data-testid={`${idPrefix}-${card.id}`}
+      data-testid={`${idPrefix}-${deck.id}`}
       className={className}
     >
       {imported ? (

--- a/frontend/src/app/catalog/catalog-card.tsx
+++ b/frontend/src/app/catalog/catalog-card.tsx
@@ -46,7 +46,7 @@ export function CatalogCard({
   style,
 }: CatalogCardProps) {
   const t = useTranslations("Catalog");
-  const card = useFragment(CatalogCardFieldsFragment, node);
+  const deck = useFragment(CatalogCardFieldsFragment, node);
 
   return (
     <li
@@ -58,23 +58,23 @@ export function CatalogCard({
     >
       <div className="flex flex-col gap-1">
         <h3 className="truncate font-semibold leading-[1.3] tracking-[-0.011em] text-foreground">
-          {card.name}
+          {deck.name}
         </h3>
-        {card.description && (
+        {deck.description && (
           <p className="line-clamp-2 text-sm leading-[1.55] text-muted-foreground">
-            {card.description}
+            {deck.description}
           </p>
         )}
       </div>
 
       <div className="flex flex-wrap items-center gap-1.5">
         <span className="text-[13px] tabular-nums text-muted-foreground">
-          {t("cardCount", { count: card.cardCount })}
+          {t("cardCount", { count: deck.cardCount })}
         </span>
       </div>
 
       <CatalogImportButton
-        card={card}
+        deck={deck}
         importing={importing}
         imported={imported}
         onImport={onImport}

--- a/frontend/src/app/catalog/catalog-list-item.tsx
+++ b/frontend/src/app/catalog/catalog-list-item.tsx
@@ -28,27 +28,27 @@ export type CatalogListItemProps = {
  */
 export function CatalogListItem({ node }: CatalogListItemProps) {
   const t = useTranslations("Catalog");
-  const card = useFragment(CatalogCardFieldsFragment, node);
+  const deck = useFragment(CatalogCardFieldsFragment, node);
 
   return (
     <li>
       <Link
-        href={`/catalog/${card.id}`}
-        data-testid={`catalog-row-${card.id}`}
-        aria-label={t("viewDeckAriaLabel", { name: card.name })}
+        href={`/catalog/${deck.id}`}
+        data-testid={`catalog-row-${deck.id}`}
+        aria-label={t("viewDeckAriaLabel", { name: deck.name })}
         className="group block rounded-md border border-border p-4 transition-[box-shadow,transform,background-color] duration-150 ease-out hover:-translate-y-0.5 hover:bg-accent hover:shadow-md motion-reduce:transition-none motion-reduce:hover:translate-y-0 sm:py-3"
       >
         {/* Tier 1: name (lead) + card-count stat (subordinate figure, right). */}
         <div className="flex items-baseline gap-3">
           <h3 className="min-w-0 flex-1 truncate text-[15px] font-semibold leading-[1.3] tracking-[-0.01em] text-foreground">
-            {card.name}
+            {deck.name}
           </h3>
           <span className="shrink-0 whitespace-nowrap">
             <span className="text-sm font-semibold tabular-nums text-foreground">
-              {t("cardCountStat", { count: card.cardCount })}
+              {t("cardCountStat", { count: deck.cardCount })}
             </span>{" "}
             <span className="text-[10px] text-muted-foreground">
-              {t("unitCards", { count: card.cardCount })}
+              {t("unitCards", { count: deck.cardCount })}
             </span>
           </span>
         </div>
@@ -70,14 +70,14 @@ export function CatalogListItem({ node }: CatalogListItemProps) {
             brief, harmless expand on a touch tap before navigation). Always in the
             DOM for screen readers; the deck's detail page carries the description
             for mobile-first discovery. */}
-        {card.description?.trim() && (
+        {deck.description?.trim() && (
           <div className="grid grid-rows-[0fr] opacity-0 transition-[grid-template-rows,opacity] duration-200 ease-out group-hover:grid-rows-[1fr] group-hover:opacity-100 group-focus-within:grid-rows-[1fr] group-focus-within:opacity-100 motion-reduce:transition-none">
             <div className="overflow-hidden">
               <p
-                data-testid={`catalog-row-desc-${card.id}`}
+                data-testid={`catalog-row-desc-${deck.id}`}
                 className="mt-1.5 line-clamp-1 text-[11px] leading-[1.5] text-muted-foreground"
               >
-                {card.description}
+                {deck.description}
               </p>
             </div>
           </div>


### PR DESCRIPTION
## Summary

On the `/catalog` screens the entity being rendered is a **`MasterCardgroup` (a deck)**, but
three sites named it `card`. That inverts the domain vocabulary (`Card` vs `Cardgroup`):
`card.cardCount` reads as "a card's card count", and `card.id` is a **cardgroup** id feeding a
**deck** route (`/catalog/${card.id}`). The sibling `catalog-deck-client.tsx` already uses
`deckId` for this entity, so the new name aligns the catalog list/tile with the rest of the
feature. Base is `main`; mechanical rename, no behavior change (every `data-testid` interpolates
the same id and renders the identical string).

The trap identifier `ReadOnlyCardRow card={edge.node}` in `catalog-deck-client.tsx` is left
untouched — that `card` prop holds a real `Card` (`edge.node` is a card), so its name is correct.

## Changes

- **`frontend/src/app/catalog/catalog-card.tsx`** — local `const card = useFragment(...)` → `deck`
  (and every use: `deck.name`, `deck.description`, `deck.cardCount`), and the `<CatalogImportButton
  card={card}>` call site → `deck={deck}`.
- **`frontend/src/app/catalog/catalog-list-item.tsx`** — local `const card = useFragment(...)` →
  `deck` (and every use: `deck.id` in the `/catalog/${…}` href and `catalog-row-{id}` /
  `catalog-row-desc-{id}` test ids, `deck.name`, `deck.cardCount`, `deck.description`).
- **`frontend/src/app/catalog/_components/catalog-import-button.tsx`** — prop `card` → `deck` on
  `CatalogImportButtonProps` (destructured param, `onImport(deck.id)` click-handler arg, and the
  `data-testid` suffix `${deck.id}`). The JSDoc already read "The deck to import"; it now matches
  the prop name.
- **`frontend/src/app/catalog/[id]/catalog-deck-header.tsx`** — `<CatalogImportButton card={{ id:
  deck.id }}>` → `deck={{ id: deck.id }}`.

## Tests

- **`frontend/src/app/catalog/_components/catalog-import-button.test.tsx`** — the 6
  `<CatalogImportButton card={CARD} …>` sites → `deck={CARD}` (the `CARD` fixture const name is
  unchanged). No other catalog test referenced the renamed identifiers (`catalog-card.test.tsx` /
  `catalog-list-item.test.tsx` only touch `cardCount`/"cards" copy, which is unaffected).

## Verification

Run from `frontend/`, binaries invoked directly:

- `./node_modules/.bin/tsc --noEmit` — exit 0.
- `./node_modules/.bin/biome check --error-on-warnings .` — exit 0 (only the two pre-existing
  config infos: schema-version notice + `recommended`-field deprecation).
- `./node_modules/.bin/knip` — pass.
- `./node_modules/.bin/vitest run` — 1823 passed / 195 files.
- CJK guard over each changed `.ts/.tsx` — clean.
- Acceptance greps: `grep -rn '<CatalogImportButton card=' frontend/src` → 0 hits;
  `ReadOnlyCardRow card={…}` unchanged.

Closes #850

Part of the naming-cleanup batch (#849–#853); the five file sets are disjoint and mergeable in
any order.
