### PR TITLE
refactor(frontend): rename component props/predicates to match behavior

### DIFF
--- a/frontend/src/app/admin/masters/admin-masters-client.tsx
+++ b/frontend/src/app/admin/masters/admin-masters-client.tsx
@@ -165,7 +165,7 @@ export function AdminMastersClient() {
         retryLabel: tCommon("retry"),
         loadingMoreLabel: t("loadingMore"),
       }}
-      loading={initialLoading}
+      initialLoading={initialLoading}
       skeleton={<AdminMastersSkeleton />}
       testIdPrefix="admin-masters"
     >

--- a/frontend/src/app/admin/users/admin-users-client.tsx
+++ b/frontend/src/app/admin/users/admin-users-client.tsx
@@ -61,7 +61,7 @@ function mergeUsersConnection(
   };
 }
 
-function UserRow({ edge, onEdit }: { edge: Edge; onEdit: (id: string) => void }) {
+function UserRowFromEdge({ edge, onEdit }: { edge: Edge; onEdit: (id: string) => void }) {
   const user = useFragment(AdminUserFieldsFragment, edge.node);
   const roles = useFragment(AdminRoleFieldsFragment, edge.node.roles);
   const rowUser: AdminUserListItem = {
@@ -254,7 +254,7 @@ export function AdminUsersClient() {
         retryLabel: tCommon("retry"),
         loadingMoreLabel: t("loadingMore"),
       }}
-      loading={initialLoading}
+      initialLoading={initialLoading}
       skeleton={<AdminUsersSkeleton />}
       testIdPrefix="admin-users"
     >
@@ -268,7 +268,7 @@ export function AdminUsersClient() {
       {edges.length > 0 && (
         <ul className="space-y-3" data-testid="admin-users-list">
           {edges.map((edge) => (
-            <UserRow
+            <UserRowFromEdge
               key={edge.cursor}
               edge={edge}
               onEdit={(id) => sheet.open({ mode: "edit", id })}

--- a/frontend/src/components/admin/paginated-admin-list-screen.tsx
+++ b/frontend/src/components/admin/paginated-admin-list-screen.tsx
@@ -59,8 +59,8 @@ interface PaginatedAdminListScreenProps {
     loadingMoreLabel: string;
   };
   /** True on the very first load (`NetworkStatus.loading` with no edges yet). */
-  loading: boolean;
-  /** Full-page skeleton rendered while `loading`. */
+  initialLoading: boolean;
+  /** Full-page skeleton rendered while `initialLoading`. */
   skeleton: ReactNode;
   /**
    * testid namespace shared across the query-error banner (`{prefix}-query-error`),
@@ -84,7 +84,7 @@ interface PaginatedAdminListScreenProps {
  *
  * The skeleton gate lives here too: a mid-session refetch must not re-trigger it
  * (that would unmount an open sheet and lose any banner), so the caller passes the
- * already-computed `loading` flag rather than a raw network status.
+ * already-computed `initialLoading` flag rather than a raw network status.
  */
 export function PaginatedAdminListScreen({
   search,
@@ -99,12 +99,12 @@ export function PaginatedAdminListScreen({
   isEmpty,
   emptyLabel,
   footer,
-  loading,
+  initialLoading,
   skeleton,
   testIdPrefix,
   children,
 }: PaginatedAdminListScreenProps) {
-  if (loading) return <>{skeleton}</>;
+  if (initialLoading) return <>{skeleton}</>;
 
   return (
     <ListingPageShell

--- a/frontend/src/components/nav/header-search-action.test.ts
+++ b/frontend/src/components/nav/header-search-action.test.ts
@@ -1,19 +1,19 @@
 import { describe, expect, it } from "vitest";
-import { resolveHeaderSearchAction } from "./header-search-action";
+import { shouldShowHeaderSearch } from "./header-search-action";
 
-describe("resolveHeaderSearchAction", () => {
+describe("shouldShowHeaderSearch", () => {
   it("returns true on filterable list routes", () => {
-    expect(resolveHeaderSearchAction("/cardgroups")).toBe(true);
-    expect(resolveHeaderSearchAction("/catalog")).toBe(true);
-    expect(resolveHeaderSearchAction("/admin/masters")).toBe(true);
-    expect(resolveHeaderSearchAction("/admin/users")).toBe(true);
+    expect(shouldShowHeaderSearch("/cardgroups")).toBe(true);
+    expect(shouldShowHeaderSearch("/catalog")).toBe(true);
+    expect(shouldShowHeaderSearch("/admin/masters")).toBe(true);
+    expect(shouldShowHeaderSearch("/admin/users")).toBe(true);
   });
 
   it("returns true on the nested card-list edit routes", () => {
-    expect(resolveHeaderSearchAction("/cardgroups/abc/edit")).toBe(true);
-    expect(resolveHeaderSearchAction("/cardgroups/abc/edit/")).toBe(true);
-    expect(resolveHeaderSearchAction("/admin/masters/abc/edit")).toBe(true);
-    expect(resolveHeaderSearchAction("/admin/masters/abc/edit/")).toBe(true);
+    expect(shouldShowHeaderSearch("/cardgroups/abc/edit")).toBe(true);
+    expect(shouldShowHeaderSearch("/cardgroups/abc/edit/")).toBe(true);
+    expect(shouldShowHeaderSearch("/admin/masters/abc/edit")).toBe(true);
+    expect(shouldShowHeaderSearch("/admin/masters/abc/edit/")).toBe(true);
   });
 
   it("returns true on the catalog deck-detail route", () => {
@@ -21,13 +21,13 @@ describe("resolveHeaderSearchAction", () => {
     // nested [id]/edit screen), the public catalog deck-detail route renders the
     // card list directly at /catalog/[id] and wires the header-takeover filter,
     // so the detail route itself is searchable.
-    expect(resolveHeaderSearchAction("/catalog/abc")).toBe(true);
-    expect(resolveHeaderSearchAction("/catalog/abc/")).toBe(true);
+    expect(shouldShowHeaderSearch("/catalog/abc")).toBe(true);
+    expect(shouldShowHeaderSearch("/catalog/abc/")).toBe(true);
   });
 
   it("returns false on non-filterable routes", () => {
-    expect(resolveHeaderSearchAction("/")).toBe(false);
-    expect(resolveHeaderSearchAction("/learn/123")).toBe(false);
+    expect(shouldShowHeaderSearch("/")).toBe(false);
+    expect(shouldShowHeaderSearch("/learn/123")).toBe(false);
   });
 
   it("returns false on the detail (non-edit) routes", () => {
@@ -36,7 +36,7 @@ describe("resolveHeaderSearchAction", () => {
     // are. (The masters list route /admin/masters is itself searchable, so it is
     // not listed here. The catalog deck-detail route is the deliberate exception,
     // covered above, because its card list renders at /catalog/[id] directly.)
-    expect(resolveHeaderSearchAction("/cardgroups/abc")).toBe(false);
-    expect(resolveHeaderSearchAction("/admin/masters/abc")).toBe(false);
+    expect(shouldShowHeaderSearch("/cardgroups/abc")).toBe(false);
+    expect(shouldShowHeaderSearch("/admin/masters/abc")).toBe(false);
   });
 });

--- a/frontend/src/components/nav/header-search-action.ts
+++ b/frontend/src/components/nav/header-search-action.ts
@@ -30,7 +30,7 @@ const SEARCH_PATTERNS: RegExp[] = [
  * Built to extend: add routes to `SEARCH_EXACT` / `SEARCH_PATTERNS` (and wire
  * the page) when other list screens adopt the header-takeover filter.
  */
-export function resolveHeaderSearchAction(pathname: string): boolean {
+export function shouldShowHeaderSearch(pathname: string): boolean {
   if (SEARCH_EXACT.has(pathname)) return true;
   return SEARCH_PATTERNS.some((re) => re.test(pathname));
 }

--- a/frontend/src/components/nav/logo-drawer.tsx
+++ b/frontend/src/components/nav/logo-drawer.tsx
@@ -18,7 +18,7 @@ import { Sheet, SheetClose, SheetContent, SheetHeader, SheetTitle } from "@/comp
 import { dispatchFlamingo, FLAMINGO_EVENT, subscribeFlamingo } from "@/lib/events/flamingo-events";
 import { useSheetSearchParam } from "@/lib/url/use-sheet-search-param";
 import { type DeckAddMenu, resolveHeaderCreateAction } from "./header-create-action";
-import { resolveHeaderSearchAction } from "./header-search-action";
+import { shouldShowHeaderSearch } from "./header-search-action";
 import { HeaderSignInLink } from "./header-sign-in-link";
 import { ADMIN_NAV_ITEMS, CORE_NAV_ITEMS, FOOTER_NAV_ITEMS } from "./nav-items";
 
@@ -44,7 +44,7 @@ export function LogoDrawer({ user, isAdmin }: LogoDrawerProps) {
   // Anonymous users get no '+'; the resolver returns null for unknown routes too.
   const createAction = user ? resolveHeaderCreateAction(pathname) : null;
 
-  const showSearch = user ? resolveHeaderSearchAction(pathname) : false;
+  const showSearch = user ? shouldShowHeaderSearch(pathname) : false;
   const searchTriggerRef = useRef<HTMLButtonElement>(null);
   const prevVisibleRef = useRef(false);
   const [searchActive, setSearchActive] = useState(false);


### PR DESCRIPTION
## Summary

Three component-API names were misleading. `resolveHeaderSearchAction` returns a `boolean`
(a should-show predicate — the consumer even binds it as `const showSearch = …`), so the
`resolve…Action` shape read like its sibling `resolveHeaderCreateAction`, which returns an
action descriptor. `PaginatedAdminListScreen`'s `loading` prop means "initial load only" (a
mid-session refetch must not set it; consumers already pass `loading={initialLoading}`). The
local unmasking wrapper `UserRow` sat one `Admin` prefix away from the imported presentational
`AdminUserRow` in the same file, so `<UserRow>` was easily mistaken for the real row. Base is
`main`; mechanical rename, no behavior change.

## Changes

- **`components/nav/header-search-action.ts`** — `resolveHeaderSearchAction` → `shouldShowHeaderSearch`.
- **`components/nav/logo-drawer.tsx`** — import + call site updated to `shouldShowHeaderSearch`.
- **`components/admin/paginated-admin-list-screen.tsx`** — the `PaginatedAdminListScreen` prop
  `loading` → `initialLoading` (interface field, destructure, `if (…)` gate, and the two docblock
  references that named the prop).
- **`app/admin/masters/admin-masters-client.tsx`** — call site prop key `loading={initialLoading}` →
  `initialLoading={initialLoading}`.
- **`app/admin/users/admin-users-client.tsx`** — call site prop key `loading={initialLoading}` →
  `initialLoading={initialLoading}`, and the local wrapper `UserRow` → `UserRowFromEdge`
  (declaration + its JSX usage). The unrelated `<AdminUserProfileSheet loading={…}>` prop and the
  imported `AdminUserRow` are left untouched.

## Tests

- **`components/nav/header-search-action.test.ts`** — import, `describe(…)` name, and every
  `expect(…)` call updated to `shouldShowHeaderSearch`.

No other test tree references these symbols (verified across `frontend/src` and `frontend/__tests__`).

## Verification

Run in the worktree against this branch (binaries invoked directly from `node_modules/.bin`):

- `tsc --noEmit` — exit 0.
- `biome check --error-on-warnings .` — exit 0 (clean; the 2 infos are pre-existing config-migration notices).
- `knip` — exit 0.
- `vitest run` — 1823 passed (195 files).
- CJK guard (`perl -CSD`) on each changed `.ts`/`.tsx` — none found.

Acceptance greps: `resolveHeaderSearchAction` and the local `UserRow` return 0 hits;
`PaginatedAdminListScreen` is invoked with `initialLoading={…}` at both call sites; the
`AdminUserProfileSheet` `loading` prop and the `resolveHeaderCreateAction` sibling are unchanged.

Closes #852
