### PR TITLE
refactor(frontend): rename misleading shared apollo/cards/errors helpers

### DIFF
--- a/frontend/src/app/admin/masters/[id]/edit/cards/use-master-card-mutations.ts
+++ b/frontend/src/app/admin/masters/[id]/edit/cards/use-master-card-mutations.ts
@@ -5,7 +5,7 @@ import {
   type AdminMasterCardsConnectionQueryVariables,
 } from "@/generated/graphql";
 import {
-  createEntityCardMutationsConfig,
+  defineEntityCardMutationsConfig,
   useEntityCardMutations,
 } from "@/lib/cards/use-entity-card-mutations";
 import {
@@ -16,7 +16,7 @@ import {
   masterCardsDefaultVars,
 } from "./queries";
 
-const MASTER_CARD_MUTATIONS_CONFIG = createEntityCardMutationsConfig({
+const MASTER_CARD_MUTATIONS_CONFIG = defineEntityCardMutationsConfig({
   scope: "[useMasterCardMutations]",
   ownerLogKey: "masterId",
   createOpName: "adminCreateMasterCard",

--- a/frontend/src/app/admin/masters/use-master-mutations.ts
+++ b/frontend/src/app/admin/masters/use-master-mutations.ts
@@ -3,10 +3,10 @@
 import { useApolloClient, useMutation } from "@apollo/client/react";
 import { useCallback } from "react";
 import {
-  appendConnectionEdge,
+  prependConnectionEdge,
   removeConnectionEdgeAcrossVariants,
 } from "@/lib/apollo/connection-cache";
-import { classifyToAuthOutcome } from "@/lib/apollo/errors";
+import { classifyAndLogAuthOutcome } from "@/lib/apollo/errors";
 import type { MasterFormValues } from "./admin-master-form";
 import {
   ADMIN_MASTERS_BASE_VARS,
@@ -78,7 +78,7 @@ export function useMasterMutations() {
         // in sync with the client useConnectionPagination query. The shared helper
         // handles the warm-prepend / cold-seed branches and adds a node.id dedup
         // guard. See .claude/rules/pagination.md.
-        appendConnectionEdge(cache, {
+        prependConnectionEdge(cache, {
           document: AdminMastersQuery,
           variables: { ...ADMIN_MASTERS_BASE_VARS, search: null },
           connectionField: "adminMasters",
@@ -123,7 +123,7 @@ export function useMasterMutations() {
         console.warn("[useMasterMutations] unexpected createMaster payload", { typename });
         return { status: "unexpected" };
       } catch (err) {
-        return classifyToAuthOutcome<AuthKind>(err, "useMasterMutations", "createMaster");
+        return classifyAndLogAuthOutcome<AuthKind>(err, "useMasterMutations", "createMaster");
       }
     },
     [runCreate],
@@ -144,7 +144,7 @@ export function useMasterMutations() {
         console.warn("[useMasterMutations] unexpected updateMaster payload", { typename });
         return { status: "unexpected" };
       } catch (err) {
-        return classifyToAuthOutcome<AuthKind>(err, "useMasterMutations", "updateMaster", {
+        return classifyAndLogAuthOutcome<AuthKind>(err, "useMasterMutations", "updateMaster", {
           masterId: id,
         });
       }
@@ -166,7 +166,7 @@ export function useMasterMutations() {
         });
         return { status: "success" };
       } catch (err) {
-        return classifyToAuthOutcome<AuthKind>(err, "useMasterMutations", "deleteMaster", {
+        return classifyAndLogAuthOutcome<AuthKind>(err, "useMasterMutations", "deleteMaster", {
           masterId: id,
         });
       }
@@ -192,7 +192,7 @@ export function useMasterMutations() {
         });
         return { status: "unexpected" };
       } catch (err) {
-        return classifyToAuthOutcome<AuthKind>(err, "useMasterMutations", "publishMaster", {
+        return classifyAndLogAuthOutcome<AuthKind>(err, "useMasterMutations", "publishMaster", {
           masterId: id,
         });
       }
@@ -212,7 +212,7 @@ export function useMasterMutations() {
         }
         return { status: "success" };
       } catch (err) {
-        return classifyToAuthOutcome<AuthKind>(err, "useMasterMutations", "unpublishMaster", {
+        return classifyAndLogAuthOutcome<AuthKind>(err, "useMasterMutations", "unpublishMaster", {
           masterId: id,
         });
       }

--- a/frontend/src/app/admin/roles/admin-roles-client.tsx
+++ b/frontend/src/app/admin/roles/admin-roles-client.tsx
@@ -285,7 +285,7 @@ export function AdminRolesClient({ initialRoles }: Props) {
       onCommitFailed: (err) => {
         const codes = liftGraphQLCodes(err);
         // This branch deliberately does NOT route through the shared
-        // classifyToAuthOutcome helper (used by useRoleMutations for the
+        // classifyAndLogAuthOutcome helper (used by useRoleMutations for the
         // create/update branches): that is kind-only and would discard the
         // server's FORBIDDEN message. UNAUTHENTICATED collapses to a generic
         // sign-in prompt — the user has no actionable detail to recover from.
@@ -329,7 +329,7 @@ export function AdminRolesClient({ initialRoles }: Props) {
         setCreateError({ kind: "unexpected" });
         return;
       default:
-        // "rejected" — classifyToAuthOutcome already emitted a scoped warn.
+        // "rejected" — classifyAndLogAuthOutcome already emitted a scoped warn.
         return;
     }
   }
@@ -355,7 +355,7 @@ export function AdminRolesClient({ initialRoles }: Props) {
         setEditError({ kind: "unexpected" });
         return;
       default:
-        // "rejected" — classifyToAuthOutcome already emitted a scoped warn.
+        // "rejected" — classifyAndLogAuthOutcome already emitted a scoped warn.
         return;
     }
   }

--- a/frontend/src/app/admin/roles/use-role-mutations.ts
+++ b/frontend/src/app/admin/roles/use-role-mutations.ts
@@ -2,7 +2,7 @@
 
 import { useLazyQuery, useMutation } from "@apollo/client/react";
 import { useCallback } from "react";
-import { classifyToAuthOutcome } from "@/lib/apollo/errors";
+import { classifyAndLogAuthOutcome } from "@/lib/apollo/errors";
 import {
   AdminCreateRoleMutation,
   AdminDeleteRoleMutation,
@@ -39,7 +39,7 @@ function normalizeName(name: string): string {
  * Mirrors the thin-outcome-hook shape of `useMasterMutations`.
  *
  * `createRole` / `updateRole` narrow `payload.__typename` to a discriminated
- * outcome and fold any caught error through `classifyToAuthOutcome`. `deleteRole`
+ * outcome and fold any caught error through `classifyAndLogAuthOutcome`. `deleteRole`
  * exposes only the raw mutation call: roles delete keeps its local `setRoles` +
  * `scheduleDelete` undo orchestration (and its FORBIDDEN-passthrough /
  * UNAUTHENTICATED-collapse handling) in the client, so the hook must return the
@@ -82,7 +82,7 @@ export function useRoleMutations() {
         console.warn("[useRoleMutations] unexpected createRole payload", { typename });
         return { status: "unexpected" };
       } catch (err) {
-        return classifyToAuthOutcome<AuthKind>(err, "useRoleMutations", "createRole");
+        return classifyAndLogAuthOutcome<AuthKind>(err, "useRoleMutations", "createRole");
       }
     },
     [runCreate],
@@ -103,7 +103,7 @@ export function useRoleMutations() {
         console.warn("[useRoleMutations] unexpected updateRole payload", { typename });
         return { status: "unexpected" };
       } catch (err) {
-        return classifyToAuthOutcome<AuthKind>(err, "useRoleMutations", "updateRole", {
+        return classifyAndLogAuthOutcome<AuthKind>(err, "useRoleMutations", "updateRole", {
           roleId: id,
         });
       }

--- a/frontend/src/app/cardgroups/[id]/cards/use-card-mutations.ts
+++ b/frontend/src/app/cardgroups/[id]/cards/use-card-mutations.ts
@@ -11,7 +11,7 @@ import {
   type CardsByCardgroupConnectionQueryVariables,
 } from "@/generated/graphql";
 import {
-  createEntityCardMutationsConfig,
+  defineEntityCardMutationsConfig,
   useEntityCardMutations,
 } from "@/lib/cards/use-entity-card-mutations";
 import { cardsDefaultVars } from "./queries";
@@ -19,7 +19,7 @@ import { cardsDefaultVars } from "./queries";
 // Static config: documents, typenames, and the typed classifier/builder
 // callbacks. A module constant so the generic hook's useCallback memoization
 // stays stable across renders.
-const CARD_MUTATIONS_CONFIG = createEntityCardMutationsConfig({
+const CARD_MUTATIONS_CONFIG = defineEntityCardMutationsConfig({
   scope: "[useCardMutations]",
   ownerLogKey: "cardgroupId",
   createOpName: "createCard",

--- a/frontend/src/app/cardgroups/[id]/use-merge-from-catalog-preview.ts
+++ b/frontend/src/app/cardgroups/[id]/use-merge-from-catalog-preview.ts
@@ -3,7 +3,7 @@
 import { useLazyQuery } from "@apollo/client/react";
 import { useCallback } from "react";
 import { MergeMasterCardgroupPreviewQuery } from "@/app/catalog/queries";
-import { classifyToAuthOutcome } from "@/lib/apollo/errors";
+import { classifyAndLogAuthOutcome } from "@/lib/apollo/errors";
 
 export type MergeFromCatalogPreviewOutcome =
   | { status: "success"; addedCount: number; updatedCount: number }
@@ -44,7 +44,7 @@ export function useMergeFromCatalogPreview(targetCardgroupId: string) {
           };
         }
         if (result.error) {
-          return classifyToAuthOutcome(
+          return classifyAndLogAuthOutcome(
             result.error,
             "useMergeFromCatalogPreview",
             "mergeMasterCardgroupPreview",
@@ -58,7 +58,7 @@ export function useMergeFromCatalogPreview(targetCardgroupId: string) {
         });
         return { status: "rejected" };
       } catch (err) {
-        return classifyToAuthOutcome(
+        return classifyAndLogAuthOutcome(
           err,
           "useMergeFromCatalogPreview",
           "mergeMasterCardgroupPreview",

--- a/frontend/src/app/cardgroups/[id]/use-merge-from-catalog.ts
+++ b/frontend/src/app/cardgroups/[id]/use-merge-from-catalog.ts
@@ -8,7 +8,7 @@ import {
   CardsByCardgroupConnectionDocument,
   type CardsByCardgroupConnectionQueryVariables,
 } from "@/generated/graphql";
-import { classifyToAuthOutcome } from "@/lib/apollo/errors";
+import { classifyAndLogAuthOutcome } from "@/lib/apollo/errors";
 
 export type MergeFromCatalogOutcome =
   | { status: "success"; addedCount: number; updatedCount: number }
@@ -87,7 +87,7 @@ export function useMergeFromCatalog(targetCardgroupId: string) {
         });
         return { status: "rejected" };
       } catch (err) {
-        return classifyToAuthOutcome(err, "useMergeFromCatalog", "mergeMasterCardgroup", {
+        return classifyAndLogAuthOutcome(err, "useMergeFromCatalog", "mergeMasterCardgroup", {
           targetCardgroupId,
         });
       }

--- a/frontend/src/app/cardgroups/cache.ts
+++ b/frontend/src/app/cardgroups/cache.ts
@@ -1,7 +1,7 @@
 import type { ApolloCache } from "@apollo/client";
 import type { MyCardgroupsConnectionQuery } from "@/generated/graphql";
 import { MyCardgroupsConnectionDocument } from "@/generated/graphql";
-import { appendConnectionEdge } from "@/lib/apollo/connection-cache";
+import { prependConnectionEdge } from "@/lib/apollo/connection-cache";
 import { CARDGROUPS_DEFAULT_VARS } from "./queries";
 
 /**
@@ -25,14 +25,14 @@ type MyCardgroupNode =
  * success payload.
  *
  * Delegates the warm-prepend / cold-build / dedup mechanics to the generic
- * `appendConnectionEdge`. The cold-cache build is supplied so a user landing on
+ * `prependConnectionEdge`. The cold-cache build is supplied so a user landing on
  * `/cardgroups` or `/catalog` without an SSR seed still sees the new edge.
  * `CARDGROUPS_DEFAULT_VARS` keeps the cache key in sync with the `/cardgroups` SSR
  * seed and client `useQuery`; any mismatch makes this write invisible. See
  * .claude/rules/pagination.md.
  */
 export function prependMyCardgroupEdge(cache: ApolloCache, node: MyCardgroupNode): void {
-  appendConnectionEdge(cache, {
+  prependConnectionEdge(cache, {
     document: MyCardgroupsConnectionDocument,
     variables: CARDGROUPS_DEFAULT_VARS,
     connectionField: "myCardgroupsConnection",

--- a/frontend/src/app/cardgroups/use-create-cardgroup.ts
+++ b/frontend/src/app/cardgroups/use-create-cardgroup.ts
@@ -2,7 +2,7 @@
 
 import { useMutation } from "@apollo/client/react";
 import { useCallback } from "react";
-import { classifyToAuthOutcome } from "@/lib/apollo/errors";
+import { classifyAndLogAuthOutcome } from "@/lib/apollo/errors";
 import { prependMyCardgroupEdge } from "./cache";
 import { CreateCardgroupMutation } from "./queries";
 
@@ -69,8 +69,8 @@ export function useCreateCardgroup() {
       } catch (err) {
         // FORBIDDEN / UNAUTHENTICATED → typed auth outcome; otherwise a scoped
         // structured warn (omitting err.message, which may echo user input) and
-        // a rejected outcome. See lib/apollo/errors classifyToAuthOutcome.
-        return classifyToAuthOutcome(err, "useCreateCardgroup", "createCardgroup");
+        // a rejected outcome. See lib/apollo/errors classifyAndLogAuthOutcome.
+        return classifyAndLogAuthOutcome(err, "useCreateCardgroup", "createCardgroup");
       }
     },
     [createCardgroup],

--- a/frontend/src/app/catalog/use-import-master.ts
+++ b/frontend/src/app/catalog/use-import-master.ts
@@ -3,7 +3,7 @@
 import { useMutation } from "@apollo/client/react";
 import { useCallback } from "react";
 import { prependMyCardgroupEdge } from "@/app/cardgroups/cache";
-import { classifyToAuthOutcome } from "@/lib/apollo/errors";
+import { classifyAndLogAuthOutcome } from "@/lib/apollo/errors";
 import { ImportMasterCardgroupMutation } from "./queries";
 
 /**
@@ -84,8 +84,8 @@ export function useImportMaster() {
         // structured warn (omitting err.message, which may echo user input) and
         // a rejected outcome. The resolved-but-unparseable success-path case
         // above also collapses into `rejected` — no catalog caller distinguishes
-        // the two. See lib/apollo/errors classifyToAuthOutcome.
-        return classifyToAuthOutcome(err, "useImportMaster", "importMasterCardgroup");
+        // the two. See lib/apollo/errors classifyAndLogAuthOutcome.
+        return classifyAndLogAuthOutcome(err, "useImportMaster", "importMasterCardgroup");
       }
     },
     [importMaster],

--- a/frontend/src/lib/apollo/connection-cache.test.ts
+++ b/frontend/src/lib/apollo/connection-cache.test.ts
@@ -6,7 +6,7 @@ import {
   type CardsByCardgroupConnectionQueryVariables,
 } from "@/generated/graphql";
 import {
-  appendConnectionEdge,
+  prependConnectionEdge,
   removeConnectionEdgeAcrossVariants,
   removeConnectionEdges,
 } from "./connection-cache";
@@ -72,11 +72,11 @@ function read(cache: InMemoryCache) {
 
 const buildColdConnection = () => makeConnection(["cold"], 1);
 
-describe("appendConnectionEdge", () => {
+describe("prependConnectionEdge", () => {
   it("no-ops on a cold cache when buildColdConnection is omitted", () => {
     const cache = new InMemoryCache();
 
-    appendConnectionEdge(cache, {
+    prependConnectionEdge(cache, {
       document: CardsByCardgroupConnectionDocument,
       variables: VARS,
       connectionField: "cardsByCardgroupConnection",
@@ -90,7 +90,7 @@ describe("appendConnectionEdge", () => {
   it("seeds a fresh connection on a cold cache when buildColdConnection is provided", () => {
     const cache = new InMemoryCache();
 
-    appendConnectionEdge(cache, {
+    prependConnectionEdge(cache, {
       document: CardsByCardgroupConnectionDocument,
       variables: VARS,
       connectionField: "cardsByCardgroupConnection",
@@ -108,7 +108,7 @@ describe("appendConnectionEdge", () => {
     const cache = new InMemoryCache();
     seed(cache, makeConnection(["a", "b"], 2));
 
-    appendConnectionEdge(cache, {
+    prependConnectionEdge(cache, {
       document: CardsByCardgroupConnectionDocument,
       variables: VARS,
       connectionField: "cardsByCardgroupConnection",
@@ -129,7 +129,7 @@ describe("appendConnectionEdge", () => {
     const cache = new InMemoryCache();
     seed(cache, makeConnection(["a", "b"], 2));
 
-    appendConnectionEdge(cache, {
+    prependConnectionEdge(cache, {
       document: CardsByCardgroupConnectionDocument,
       variables: VARS,
       connectionField: "cardsByCardgroupConnection",

--- a/frontend/src/lib/apollo/connection-cache.ts
+++ b/frontend/src/lib/apollo/connection-cache.ts
@@ -4,7 +4,7 @@ import type { TypedDocumentNode } from "@graphql-typed-document-node/core";
 /**
  * Generic Relay-Connection cache helpers.
  *
- * The "append edge + bump totalCount" and "filter edge by node.id + clamp
+ * The "prepend edge + bump totalCount" and "filter edge by node.id + clamp
  * totalCount at 0 + evict + gc" blocks were copy-pasted across every paginated
  * mutation hook. The cache invariants they enforce — resolve an edge by
  * `node.id` (never `edge.cursor`), clamp `totalCount` at `Math.max(0, …)`, use
@@ -27,7 +27,7 @@ interface ConnectionEdge<TTypename extends string, TNode extends { id: string }>
 }
 
 /** The minimal `<Type>Connection` shape these helpers read and write. */
-interface ConnectionShape<TEdge> {
+interface CacheConnectionShape<TEdge> {
   __typename: string;
   edges: TEdge[];
   pageInfo: {
@@ -40,7 +40,7 @@ interface ConnectionShape<TEdge> {
   totalCount: number;
 }
 
-interface AppendConnectionEdgeInput<
+interface PrependConnectionEdgeInput<
   TData,
   TVariables extends OperationVariables,
   K extends keyof TData,
@@ -104,16 +104,16 @@ interface RemoveConnectionEdgesInput<
  *   cases that must surface the new edge on a route the user may land on directly).
  *
  * The dedup guard skips the write if an edge with the same `node.id` already
- * exists. No `cache.writeFragment` is needed: the appended node carries its full
+ * exists. No `cache.writeFragment` is needed: the prepended node carries its full
  * projection, so `writeQuery` normalizes it into the standalone `<Type>:<id>`
  * entry on its own.
  */
-export function appendConnectionEdge<
+export function prependConnectionEdge<
   TData,
   TVariables extends OperationVariables,
   K extends keyof TData,
   TNode extends { id: string },
->(cache: ApolloCache, input: AppendConnectionEdgeInput<TData, TVariables, K, TNode>): void {
+>(cache: ApolloCache, input: PrependConnectionEdgeInput<TData, TVariables, K, TNode>): void {
   const { document, variables, connectionField, edgeTypename, node, buildColdConnection } = input;
 
   const existing = cache.readQuery({ query: document, variables });
@@ -134,7 +134,7 @@ export function appendConnectionEdge<
     return;
   }
 
-  const current = existing[connectionField] as ConnectionShape<
+  const current = existing[connectionField] as CacheConnectionShape<
     ConnectionEdge<string, { id: string }>
   >;
   if (current.edges.some((edge) => edge.node.id === node.id)) return;
@@ -169,7 +169,7 @@ export function removeConnectionEdges<
 
   const existing = cache.readQuery({ query: document, variables });
   if (existing) {
-    const current = existing[connectionField] as ConnectionShape<
+    const current = existing[connectionField] as CacheConnectionShape<
       ConnectionEdge<string, { id: string }>
     >;
     const nextConnection = {

--- a/frontend/src/lib/apollo/errors.test.ts
+++ b/frontend/src/lib/apollo/errors.test.ts
@@ -1,8 +1,8 @@
 import { CombinedGraphQLErrors } from "@apollo/client/errors";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  classifyAndLogAuthOutcome,
   classifyMutationAuthError,
-  classifyToAuthOutcome,
   getBackendErrorBanner,
   getBackendFieldErrors,
   mutationAuthBanner,
@@ -242,7 +242,7 @@ describe("mutationAuthBanner", () => {
   });
 });
 
-describe("classifyToAuthOutcome", () => {
+describe("classifyAndLogAuthOutcome", () => {
   afterEach(() => {
     vi.restoreAllMocks();
   });
@@ -250,7 +250,7 @@ describe("classifyToAuthOutcome", () => {
   it("returns an auth outcome with kind forbidden for a FORBIDDEN error without warning", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const err = makeCombinedError([{ message: "Forbidden", extensions: { code: "FORBIDDEN" } }]);
-    expect(classifyToAuthOutcome(err, "useScope", "doThing")).toEqual({
+    expect(classifyAndLogAuthOutcome(err, "useScope", "doThing")).toEqual({
       status: "auth",
       kind: "forbidden",
     });
@@ -262,7 +262,7 @@ describe("classifyToAuthOutcome", () => {
     const err = makeCombinedError([
       { message: "Not authenticated", extensions: { code: "UNAUTHENTICATED" } },
     ]);
-    expect(classifyToAuthOutcome(err, "useScope", "doThing")).toEqual({
+    expect(classifyAndLogAuthOutcome(err, "useScope", "doThing")).toEqual({
       status: "auth",
       kind: "unauthenticated",
     });
@@ -274,7 +274,7 @@ describe("classifyToAuthOutcome", () => {
     const err = makeCombinedError([
       { message: "Invalid input", extensions: { code: "BAD_USER_INPUT" } },
     ]);
-    expect(classifyToAuthOutcome(err, "useScope", "doThing")).toEqual({ status: "rejected" });
+    expect(classifyAndLogAuthOutcome(err, "useScope", "doThing")).toEqual({ status: "rejected" });
     expect(warn).toHaveBeenCalledTimes(1);
     expect(warn).toHaveBeenCalledWith("[useScope] doThing rejected", {
       name: "CombinedGraphQLErrors",
@@ -284,7 +284,9 @@ describe("classifyToAuthOutcome", () => {
 
   it("returns a rejected outcome and warns with name unknown for a non-Error throw", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-    expect(classifyToAuthOutcome("boom", "useScope", "doThing")).toEqual({ status: "rejected" });
+    expect(classifyAndLogAuthOutcome("boom", "useScope", "doThing")).toEqual({
+      status: "rejected",
+    });
     expect(warn).toHaveBeenCalledWith("[useScope] doThing rejected", {
       name: "unknown",
       codes: [],
@@ -295,7 +297,7 @@ describe("classifyToAuthOutcome", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const err = new Error("Network request failed");
     expect(
-      classifyToAuthOutcome(err, "useMasterMutations", "deleteMaster", { masterId: "m-1" }),
+      classifyAndLogAuthOutcome(err, "useMasterMutations", "deleteMaster", { masterId: "m-1" }),
     ).toEqual({ status: "rejected" });
     expect(warn).toHaveBeenCalledWith("[useMasterMutations] deleteMaster rejected", {
       masterId: "m-1",

--- a/frontend/src/lib/apollo/errors.ts
+++ b/frontend/src/lib/apollo/errors.ts
@@ -148,7 +148,7 @@ export type MutationAuthKind = Exclude<MutationAuthErrorKind, "other">;
  * `"forbidden" | "unauthenticated"` pair. `classifyMutationAuthError` returns
  * the literal `"forbidden"` / `"unauthenticated"` strings, which structurally
  * satisfy any `Kind` that contains them, so the narrowing in
- * `classifyToAuthOutcome` is sound.
+ * `classifyAndLogAuthOutcome` is sound.
  */
 export type MutationCatchOutcome<Kind extends MutationAuthKind = MutationAuthKind> =
   | { status: "auth"; kind: Kind }
@@ -174,7 +174,7 @@ export type MutationCatchOutcome<Kind extends MutationAuthKind = MutationAuthKin
  * be narrowed by the caller's auth-kind union (some hooks surface both, some
  * only expect `unauthenticated`).
  */
-export function classifyToAuthOutcome<Kind extends MutationAuthKind = MutationAuthKind>(
+export function classifyAndLogAuthOutcome<Kind extends MutationAuthKind = MutationAuthKind>(
   err: unknown,
   scope: string,
   op: string,

--- a/frontend/src/lib/cards/use-entity-card-mutations.ts
+++ b/frontend/src/lib/cards/use-entity-card-mutations.ts
@@ -4,7 +4,7 @@ import type { OperationVariables } from "@apollo/client";
 import { useApolloClient, useMutation } from "@apollo/client/react";
 import type { TypedDocumentNode } from "@graphql-typed-document-node/core";
 import { useCallback, useState } from "react";
-import { appendConnectionEdge, removeConnectionEdges } from "@/lib/apollo/connection-cache";
+import { prependConnectionEdge, removeConnectionEdges } from "@/lib/apollo/connection-cache";
 import { useUndoDelete } from "@/lib/undo-delete";
 import {
   type CardFormValues,
@@ -20,7 +20,7 @@ type CardConnectionVariables = OperationVariables & { search?: string | null };
 type CardNodeLike = { id: string; front: string; back: string };
 
 /** Structural connection shape read during the optimistic per-row delete. */
-type MutableConnection = {
+type ConnectionSnapshot = {
   edges: { node: { id: string } }[];
   totalCount: number;
   [key: string]: unknown;
@@ -106,7 +106,7 @@ export interface UseEntityCardMutationsInput<TConnVars extends CardConnectionVar
  * arguments and let inference resolve the params from the documents; supply
  * explicit type arguments only if `tsc` cannot infer one.
  */
-export function createEntityCardMutationsConfig<
+export function defineEntityCardMutationsConfig<
   TConnData,
   TConnVars extends CardConnectionVariables,
   TConnKey extends keyof TConnData,
@@ -231,7 +231,7 @@ export function useEntityCardMutations<
   // `useQuery` owns populating the connection.
   const writeCreatedToConnection = useCallback(
     (node: TNode, variables: TConnVars) => {
-      appendConnectionEdge(apollo.cache, {
+      prependConnectionEdge(apollo.cache, {
         document: config.connectionDocument,
         variables,
         connectionField: config.connectionField,
@@ -317,7 +317,7 @@ export function useEntityCardMutations<
         variables: queryVariables,
       });
       if (snapshot) {
-        const current = snapshot[config.connectionField] as unknown as MutableConnection;
+        const current = snapshot[config.connectionField] as unknown as ConnectionSnapshot;
         apollo.writeQuery({
           query: config.connectionDocument,
           variables: queryVariables,


### PR DESCRIPTION
## Summary

Five shared apollo/cards/errors helpers carried names that contradicted their actual behavior. This renames the declaration and every reference (including `*.test.ts(x)`, JSDoc, module docstrings, and inline comments) to match what each helper does. The clearest offenders: `appendConnectionEdge` actually **prepends** (`edges: [newEdge, ...current.edges]`), and `classifyToAuthOutcome` is not a pure `classify*` sibling — it emits `console.warn`, so the new name surfaces that side effect. The `ConnectionShape` interface in `connection-cache.ts` also collided by name with a structurally different `ConnectionShape<TEdge, TPageInfo>` in `pagination/use-connection-pagination.ts`, so the cache-local one is disambiguated. Base is `main`; mechanical rename, no behavior change.

Bundled into one PR because the five reference sets share files (`use-entity-card-mutations.ts`, `use-master-mutations.ts`), so splitting would collide on same-file edits. This is one of a five-issue naming-cleanup batch (#849–#853) whose file sets are otherwise disjoint.

## Changes

- **`lib/apollo/connection-cache.ts`** — `appendConnectionEdge` → `prependConnectionEdge`; input type `AppendConnectionEdgeInput` → `PrependConnectionEdgeInput`; cache-local `ConnectionShape` → `CacheConnectionShape`. Module docstring "append edge" → "prepend edge" and JSDoc "appended node" → "prepended node".
- **`lib/apollo/connection-cache.test.ts`** — updated to `prependConnectionEdge`.
- **`app/cardgroups/cache.ts`**, **`lib/cards/use-entity-card-mutations.ts`**, **`app/admin/masters/use-master-mutations.ts`** — `appendConnectionEdge` import/call sites → `prependConnectionEdge`.
- **`lib/cards/use-entity-card-mutations.ts`** — `createEntityCardMutationsConfig` → `defineEntityCardMutationsConfig` (body is a pure identity pass-through for type inference); local type `MutableConnection` → `ConnectionSnapshot` (every use is strictly immutable).
- **`app/admin/masters/[id]/edit/cards/use-master-card-mutations.ts`**, **`app/cardgroups/[id]/cards/use-card-mutations.ts`** — `createEntityCardMutationsConfig` → `defineEntityCardMutationsConfig`.
- **`lib/apollo/errors.ts`** — `classifyToAuthOutcome` → `classifyAndLogAuthOutcome` (surfaces the `console.warn` side effect the `classify` prefix hid); docstring reference updated.
- **`lib/apollo/errors.test.ts`** and the 7 consumer files (`use-master-mutations.ts`, `admin/roles/admin-roles-client.tsx`, `admin/roles/use-role-mutations.ts`, `cardgroups/[id]/use-merge-from-catalog-preview.ts`, `cardgroups/[id]/use-merge-from-catalog.ts`, `cardgroups/use-create-cardgroup.ts`, `catalog/use-import-master.ts`) — `classifyToAuthOutcome` → `classifyAndLogAuthOutcome`, including inline comment references.

The `ConnectionShape<TEdge, TPageInfo>` in `lib/pagination/use-connection-pagination.ts` is a separate, generic type and was deliberately **not** touched.

## Tests

`connection-cache.test.ts` and `errors.test.ts` were updated to the new names alongside their production files; no assertions changed (pure rename). The full vitest suite passes unchanged.

## Verification

Run from `frontend/` with binaries invoked directly:

- `tsc --noEmit` — exit 0.
- `biome check --error-on-warnings .` — clean (one formatting reflow applied via `biome check --write`: import re-sort now that `classifyAndLogAuthOutcome` sorts before `classifyMutationAuthError`).
- `knip` — pass.
- `vitest run` — 1823 passed (195 files).
- Acceptance grep: each old symbol (`appendConnectionEdge` / `AppendConnectionEdgeInput`, `createEntityCardMutationsConfig`, `MutableConnection`, `classifyToAuthOutcome`, bare `ConnectionShape` in `connection-cache.ts`) returns 0 hits in `frontend/src`.
- CJK guard on all 15 changed files — clean.

Closes #849
