### PR TITLE
refactor(frontend): rename local identifiers that misrepresent value/behavior

### DIFF
--- a/frontend/src/app/admin/masters/[id]/edit/master-edit-header.tsx
+++ b/frontend/src/app/admin/masters/[id]/edit/master-edit-header.tsx
@@ -62,7 +62,7 @@ export function MasterEditHeader({ master, cardCount }: Props) {
   const published = master.status === "PUBLISHED";
   const emptyDraft = master.status === "DRAFT" && cardCount === 0;
 
-  const authToast = useCallback(
+  const showAuthToast = useCallback(
     (kind: AuthKind) => {
       toast.error(kind === "forbidden" ? t("forbidden") : t("unauthenticated"));
     },
@@ -78,13 +78,13 @@ export function MasterEditHeader({ master, cardCount }: Props) {
           // `run` stored the field error / fired `onSettingsSaved` respectively.
           return;
         case "auth":
-          authToast(outcome.kind);
+          showAuthToast(outcome.kind);
           return;
         default:
           toast.error(t("unexpectedError"));
       }
     },
-    [master.id, updateMaster, run, t, authToast],
+    [master.id, updateMaster, run, t, showAuthToast],
   );
 
   const handlePublishToggle = useCallback(async () => {
@@ -98,7 +98,7 @@ export function MasterEditHeader({ master, cardCount }: Props) {
             router.refresh();
             return;
           case "auth":
-            authToast(outcome.kind);
+            showAuthToast(outcome.kind);
             return;
           default:
             toast.error(t("unexpectedError"));
@@ -115,7 +115,7 @@ export function MasterEditHeader({ master, cardCount }: Props) {
           toast.error(t("publishEmptyToast"));
           return;
         case "auth":
-          authToast(outcome.kind);
+          showAuthToast(outcome.kind);
           return;
         default:
           toast.error(t("unexpectedError"));
@@ -123,7 +123,7 @@ export function MasterEditHeader({ master, cardCount }: Props) {
     } finally {
       setPublishing(false);
     }
-  }, [published, publishMaster, unpublishMaster, master.id, t, authToast, router]);
+  }, [published, publishMaster, unpublishMaster, master.id, t, showAuthToast, router]);
 
   const handleConfirmDelete = useCallback(async () => {
     setDeleting(true);
@@ -136,7 +136,7 @@ export function MasterEditHeader({ master, cardCount }: Props) {
           router.push("/admin/masters");
           return;
         case "auth":
-          authToast(outcome.kind);
+          showAuthToast(outcome.kind);
           return;
         default:
           toast.error(t("deleteMasterFailed"));
@@ -144,7 +144,7 @@ export function MasterEditHeader({ master, cardCount }: Props) {
     } finally {
       setDeleting(false);
     }
-  }, [deleteMaster, master.id, t, authToast, router]);
+  }, [deleteMaster, master.id, t, showAuthToast, router]);
 
   const publishIcon = published ? (
     <EyeOff aria-hidden="true" className="h-4 w-4" />

--- a/frontend/src/app/admin/users/admin-user-profile-sheet.tsx
+++ b/frontend/src/app/admin/users/admin-user-profile-sheet.tsx
@@ -77,7 +77,7 @@ type Props = {
   onDelete?: (id: string) => Promise<void>;
 };
 
-function sameSet(a: ReadonlySet<string>, b: ReadonlySet<string>): boolean {
+function areSetsEqual(a: ReadonlySet<string>, b: ReadonlySet<string>): boolean {
   if (a.size !== b.size) return false;
   for (const value of a) {
     if (!b.has(value)) return false;
@@ -175,7 +175,7 @@ export function AdminUserProfileSheet({
 
   const profileDirty = useStore(form.store, (state) => state.isDirty);
   const initialRoleIds = useMemo(() => new Set(user?.roles.map((role) => role.id) ?? []), [user]);
-  const rolesDirty = !sameSet(stagedRoleIds, initialRoleIds);
+  const rolesDirty = !areSetsEqual(stagedRoleIds, initialRoleIds);
   const dirty = profileDirty || rolesDirty;
 
   useEffect(() => {

--- a/frontend/src/app/api/csp-report/route.ts
+++ b/frontend/src/app/api/csp-report/route.ts
@@ -24,7 +24,7 @@ type ReportEnvelope = {
   report: NormalizedReport;
 };
 
-function getContentTypeHeader(contentType: string | null) {
+function parseMediaType(contentType: string | null) {
   return contentType?.split(";")[0]?.trim().toLowerCase() ?? "";
 }
 
@@ -183,7 +183,7 @@ function normalizePayload(contentType: string, payload: unknown): ReportEnvelope
 }
 
 export async function POST(request: Request) {
-  const contentType = getContentTypeHeader(request.headers.get("content-type"));
+  const contentType = parseMediaType(request.headers.get("content-type"));
   const body = await readBody(request);
 
   if (!body.ok) {

--- a/frontend/src/app/cards/new/cards-new-client.tsx
+++ b/frontend/src/app/cards/new/cards-new-client.tsx
@@ -171,7 +171,7 @@ export default function CardsNewClient({
   // submit), then navigate away. When a ?return= param was supplied (and
   // passed the open-redirect guard above), push to that path; otherwise push
   // to the cardgroup's cards list. See docs/pagination/drop-optimistic-response-typed-errors.md.
-  function markCreationSucceeded() {
+  function finishCreationAndNavigate() {
     if (!currentId) return;
     void setLastViewed({ variables: { cardgroupId: currentId } }).catch((err) => {
       console.warn("[cards-new] setLastViewedCardgroup failed", { cardgroupId: currentId, err });
@@ -200,7 +200,7 @@ export default function CardsNewClient({
         });
         return;
       }
-      markCreationSucceeded();
+      finishCreationAndNavigate();
     } catch (err) {
       console.error("[cards-new-client] create card rejection", {
         name: err instanceof Error ? err.name : "unknown",
@@ -249,7 +249,7 @@ export default function CardsNewClient({
 
     if (payload?.__typename === "UpdateCardSuccess") {
       setDuplicate(null);
-      markCreationSucceeded();
+      finishCreationAndNavigate();
       return;
     }
 

--- a/frontend/src/app/learn/[cardgroupId]/learn-client.tsx
+++ b/frontend/src/app/learn/[cardgroupId]/learn-client.tsx
@@ -45,7 +45,7 @@ type Props = {
 
 export function LearnClient({ cardgroupId, initialCards, displayMode }: Props) {
   const [queue, setQueue] = useState<LearnCard[]>(initialCards);
-  const [completed, setCompleted] = useState(0);
+  const [completedCount, setCompleted] = useState(0);
   const [localError, setLocalError] = useState<string | null>(null);
   // Top-level phase switch. "practice" hands the whole screen to PracticeClient
   // (FSRS-safe re-study of today's cards). It is only entered from the
@@ -329,7 +329,7 @@ export function LearnClient({ cardgroupId, initialCards, displayMode }: Props) {
       cards={queue}
       displayMode={displayMode}
       onCardSwiped={onSwipe}
-      completedCount={completed}
+      completedCount={completedCount}
       // When no banner, SwipeSession renders an `aria-hidden` spacer in the
       // leading row so the card and action bar keep their grid rows.
       topSlot={

--- a/frontend/src/app/learn/[cardgroupId]/learn-client.tsx
+++ b/frontend/src/app/learn/[cardgroupId]/learn-client.tsx
@@ -45,7 +45,7 @@ type Props = {
 
 export function LearnClient({ cardgroupId, initialCards, displayMode }: Props) {
   const [queue, setQueue] = useState<LearnCard[]>(initialCards);
-  const [completedCount, setCompleted] = useState(0);
+  const [completedCount, setCompletedCount] = useState(0);
   const [localError, setLocalError] = useState<string | null>(null);
   // Top-level phase switch. "practice" hands the whole screen to PracticeClient
   // (FSRS-safe re-study of today's cards). It is only entered from the
@@ -246,7 +246,7 @@ export function LearnClient({ cardgroupId, initialCards, displayMode }: Props) {
       // is cleared in the mutation's `finally` below.
       inFlightSwipeIdsRef.current.add(card.id);
       setQueue((current) => current.filter((candidate) => candidate.id !== card.id));
-      setCompleted((current) => current + 1);
+      setCompletedCount((current) => current + 1);
 
       const result = await handleSwipe({
         variables: { input: { cardId: card.id, cardgroupId, mode } },
@@ -265,7 +265,7 @@ export function LearnClient({ cardgroupId, initialCards, displayMode }: Props) {
             name: err instanceof Error ? err.name : "unknown",
           });
           setQueue((current) => [card, ...current.filter((candidate) => candidate.id !== card.id)]);
-          setCompleted((current) => Math.max(0, current - 1));
+          setCompletedCount((current) => Math.max(0, current - 1));
           setLocalError("Could not save that swipe. Please try again.");
           return null;
         })

--- a/frontend/src/app/profile/change-email/change-email-client.tsx
+++ b/frontend/src/app/profile/change-email/change-email-client.tsx
@@ -22,7 +22,9 @@ type Props = {
 // Returns the translation key for the mapped user-facing message, or null when
 // the Supabase message is unmapped — null lets the caller log the raw message
 // and show generic copy.
-function classifyUpdateUserError(message: string): "emailRateLimited" | "emailAlreadyInUse" | null {
+function mapUpdateUserErrorToMessageKey(
+  message: string,
+): "emailRateLimited" | "emailAlreadyInUse" | null {
   const lower = message.toLowerCase();
   if (lower.includes("rate limit")) {
     return "emailRateLimited";
@@ -51,13 +53,13 @@ export function ChangeEmailClient({ currentEmail }: Props) {
       const supabase = createSupabaseBrowserClient();
       const { error: updateErr } = await supabase.auth.updateUser({ email: trimmed });
       if (updateErr) {
-        const classifiedKey = classifyUpdateUserError(updateErr.message);
+        const classifiedKey = mapUpdateUserErrorToMessageKey(updateErr.message);
         if (classifiedKey !== null) {
           // Classified: operators know what happened from the user copy + error.name; no raw needed.
           console.warn("[change-email] updateUser failed:", updateErr.name);
           setError(t(classifiedKey));
         } else {
-          // Unmapped: log the raw Supabase message so operators can extend classifyUpdateUserError.
+          // Unmapped: log the raw Supabase message so operators can extend mapUpdateUserErrorToMessageKey.
           // Supabase API error messages are server-generated and do not echo user-typed input,
           // so this is PII-safe.
           console.warn(

--- a/frontend/src/app/stats/stats-client.tsx
+++ b/frontend/src/app/stats/stats-client.tsx
@@ -19,15 +19,15 @@ import { StrugglingList } from "./struggling-list";
  */
 export function StatsClient({ stats }: { stats: MyLearningStatsQuery["myLearningStats"] }) {
   const t = useTranslations("Stats");
-  const studied = stats.mastery.totalStudied;
+  const studiedCount = stats.mastery.totalStudied;
   const hasDecks = stats.decks.length > 0;
 
   let content: ReactNode;
-  if (studied === 0 && !hasDecks) {
+  if (studiedCount === 0 && !hasDecks) {
     // Brand-new user: owns no deck that has any cards (the backend omits
     // zero-card decks from `decks`), and nothing studied. All sections collapse.
     content = <WelcomeEmpty />;
-  } else if (studied === 0) {
+  } else if (studiedCount === 0) {
     // Has decks but no reviews yet: per-deck rows render at 0%, and the
     // struggling slot is necessarily empty (no lapses without studied cards) —
     // rendered directly here, mirroring StrugglingList's own empty-cards guard.

--- a/frontend/src/components/batch-import/batch-import-wizard.tsx
+++ b/frontend/src/components/batch-import/batch-import-wizard.tsx
@@ -51,7 +51,7 @@ function isWarningKind(kind: CardImportErrorKind | undefined): boolean {
  * Classify a raw Apollo error into a user-facing banner string, delegating to
  * the shared backend-error banner helper.
  */
-function classifyError(err: unknown, fallback: string): string {
+function resolveErrorBanner(err: unknown, fallback: string): string {
   if (!err) return "";
   return getBackendErrorBanner(err) ?? fallback;
 }
@@ -335,10 +335,10 @@ export function BatchImportWizard(props: {
         setValidatedPayload(payloadText);
       }
       if (result.error) {
-        setBannerError(classifyError(result.error, t("unexpectedError")));
+        setBannerError(resolveErrorBanner(result.error, t("unexpectedError")));
       }
     } catch (err) {
-      setBannerError(classifyError(err, t("unexpectedError")));
+      setBannerError(resolveErrorBanner(err, t("unexpectedError")));
     }
   }
 
@@ -376,7 +376,7 @@ export function BatchImportWizard(props: {
       // Partial failure (error rows present): keep the sheet open so the result
       // banner and error rows stay visible.
     } catch (err) {
-      setBannerError(classifyError(err, t("unexpectedError")));
+      setBannerError(resolveErrorBanner(err, t("unexpectedError")));
     }
   }
 

--- a/frontend/src/lib/security/csp.ts
+++ b/frontend/src/lib/security/csp.ts
@@ -86,20 +86,20 @@ export function serializeCsp(directives: CspDirectiveMap): string {
   return serialized.join("; ");
 }
 
-function parseSupabaseUrl(url: string): URL {
+function parseUrlOrThrow(url: string): URL {
   try {
     return new URL(url);
   } catch {
-    throw new Error(`[csp] invalid supabaseUrl — not a valid URL: ${JSON.stringify(url)}`);
+    throw new Error(`[csp] invalid url: ${JSON.stringify(url)}`);
   }
 }
 
 function toOrigin(url: string): string {
-  return parseSupabaseUrl(url).origin;
+  return parseUrlOrThrow(url).origin;
 }
 
 function toWebSocketOrigin(url: string): string {
-  const parsed = parseSupabaseUrl(url);
+  const parsed = parseUrlOrThrow(url);
   if (parsed.protocol === "https:") {
     parsed.protocol = "wss:";
   } else if (parsed.protocol === "http:") {


### PR DESCRIPTION
## Summary

Nine file-local identifiers were named in a way that misrepresents their value or behavior — past-participle booleans that actually hold integer counts, "classify" helpers that return a translation key or a ready-to-render banner, a `mark…Succeeded` function whose dominant effect is navigation, and a Supabase-specific name on a generic `new URL(...)` wrapper. Each was renamed to match what it truly is. Base is main; mechanical rename, no behavior change. Every symbol was verified file-local (grep hits in one file only), so all nine ride in one PR.

## Changes

- **`app/learn/[cardgroupId]/learn-client.tsx`** — `completed` → `completedCount` (running integer count from `useState(0)`; consumer already read `completedCount={completed}`).
- **`app/stats/stats-client.tsx`** — `studied` → `studiedCount` (holds `mastery.totalStudied`). Prose comments ("nothing studied", "without studied cards") left as natural language.
- **`app/profile/change-email/change-email-client.tsx`** — `classifyUpdateUserError` → `mapUpdateUserErrorToMessageKey` (returns an i18n key fed straight into `t(...)`).
- **`components/batch-import/batch-import-wizard.tsx`** — `classifyError` → `resolveErrorBanner` (returns a user-facing banner string via `getBackendErrorBanner`).
- **`app/cards/new/cards-new-client.tsx`** — `markCreationSucceeded` → `finishCreationAndNavigate` (fires `setLastViewed` and `router.push(...)`; its dominant effect is navigation).
- **`lib/security/csp.ts`** — `parseSupabaseUrl` → `parseUrlOrThrow` (generic `new URL(url)` wrapper; also renamed the two in-file callers `toOrigin`/`toWebSocketOrigin` and genericized the thrown message to `[csp] invalid url: …`). The `HtmlCspOptions.supabaseUrl` option field is out of scope and unchanged.
- **`app/api/csp-report/route.ts`** — `getContentTypeHeader` → `parseMediaType` (strips `;`-params and returns the lowercased media type, not the header value).
- **`app/admin/users/admin-user-profile-sheet.tsx`** — `sameSet` → `areSetsEqual` (returns a boolean set-equality result).
- **`app/admin/masters/[id]/edit/master-edit-header.tsx`** — `authToast` → `showAuthToast` (a callback that fires `toast.error(...)`).

## Tests

No test files referenced any of the renamed symbols (all are module-private and exercised through behavior), so no test updates were required. The full suite was re-run to confirm the renames fan out cleanly.

## Verification

Run from `frontend/`:

- `tsc --noEmit` — exit 0
- `biome check --error-on-warnings .` — clean, exit 0
- `knip` — pass, exit 0
- `vitest run` — 1823 passed (195 files)
- CJK guard on each changed file — none found
- Acceptance grep: each old symbol (`classifyUpdateUserError`, `classifyError`, `markCreationSucceeded`, `parseSupabaseUrl`, `getContentTypeHeader`, `sameSet`, `authToast`, and the `completed`/`studied` identifiers) returns 0 hits in `frontend/src`.

Closes #851
