### PR TITLE
refactor(backend): move newCardRatio validation into the usecase — resolver must not re-derive VO field attribution

### DIFF
--- a/backend/graph/resolver/new_card_ratio.resolvers.go
+++ b/backend/graph/resolver/new_card_ratio.resolvers.go
@@ -14,29 +14,7 @@ import (
 
 // UpdateNewCardRatio is the resolver for the updateNewCardRatio field.
 func (r *mutationResolver) UpdateNewCardRatio(ctx context.Context, numerator int, denominator int) (*model.User, error) {
-	ratio, err := domain.ParseNewCardRatio(numerator, denominator)
-	if err != nil {
-		// A ratio outside 1 <= numerator < denominator <= 100 (after reduction) is
-		// a correctable client mistake, so surface it as BAD_USER_INPUT rather than
-		// INTERNAL. The VO's error carries the precise reason; the wire message stays
-		// generic to avoid leaking internal bounds phrasing.
-		//
-		// Attribute extensions.field to the argument ParseNewCardRatio faulted on,
-		// mirroring its check order: a non-positive denominator (and a reduced
-		// denominator above NewCardRatioDenMax) map to "denominator"; a numerator
-		// outside (0, denominator) maps to "numerator".
-		field := "denominator"
-		switch {
-		case denominator <= 0:
-			field = "denominator"
-		case numerator <= 0 || numerator >= denominator:
-			field = "numerator"
-		default: // reduced denominator exceeds NewCardRatioDenMax
-			field = "denominator"
-		}
-		return nil, gqlerr.BadUserInput(field, "invalid new-card ratio")
-	}
-	user, err := r.UpdateNewCardRatioUC.Set(ctx, ratio)
+	user, err := r.UpdateNewCardRatioUC.Set(ctx, numerator, denominator)
 	if err != nil {
 		return nil, gqlerr.FromUsecaseError(ctx, err)
 	}

--- a/backend/graph/resolver/new_card_ratio_resolver_test.go
+++ b/backend/graph/resolver/new_card_ratio_resolver_test.go
@@ -12,21 +12,24 @@ import (
 	"backend/internal/domain"
 	"backend/internal/gqlerr"
 	"backend/internal/usecase"
+	"backend/internal/usecase/ucerr"
 )
 
 type mockUpdateNewCardRatioUsecase struct {
-	user      *domain.User
-	err       error
-	calls     int
-	lastRatio domain.NewCardRatio
-	onSet     func(ratio domain.NewCardRatio)
+	user    *domain.User
+	err     error
+	calls   int
+	lastNum int
+	lastDen int
+	onSet   func(num, den int)
 }
 
-func (m *mockUpdateNewCardRatioUsecase) Set(_ context.Context, ratio domain.NewCardRatio) (*domain.User, error) {
+func (m *mockUpdateNewCardRatioUsecase) Set(_ context.Context, numerator, denominator int) (*domain.User, error) {
 	m.calls++
-	m.lastRatio = ratio
+	m.lastNum = numerator
+	m.lastDen = denominator
 	if m.onSet != nil {
-		m.onSet(ratio)
+		m.onSet(numerator, denominator)
 	}
 	if m.err != nil {
 		return nil, m.err
@@ -109,7 +112,9 @@ func TestUpdateNewCardRatio_ReturnsUpdatedRatio(t *testing.T) {
 	prefs := map[string]*domain.UserPreference{}
 	mock := &mockUpdateNewCardRatioUsecase{
 		user: &domain.User{ID: "u-1"},
-		onSet: func(ratio domain.NewCardRatio) {
+		onSet: func(num, den int) {
+			// 3/7 is already reduced, so ParseNewCardRatio round-trips it.
+			ratio := mustNewCardRatio(t, num, den)
 			prefs["u-1"] = &domain.UserPreference{UserID: "u-1", NewCardRatio: ratio}
 		},
 	}
@@ -128,8 +133,8 @@ func TestUpdateNewCardRatio_ReturnsUpdatedRatio(t *testing.T) {
 	if mock.calls != 1 {
 		t.Fatalf("expected 1 Set call, got %d", mock.calls)
 	}
-	if mock.lastRatio.Numerator() != 3 || mock.lastRatio.Denominator() != 7 {
-		t.Fatalf("Set called with %d/%d, want 3/7", mock.lastRatio.Numerator(), mock.lastRatio.Denominator())
+	if mock.lastNum != 3 || mock.lastDen != 7 {
+		t.Fatalf("Set called with %d/%d, want 3/7", mock.lastNum, mock.lastDen)
 	}
 	data, _ := resp["data"].(map[string]any)
 	payload, _ := data["updateNewCardRatio"].(map[string]any)
@@ -145,13 +150,17 @@ func TestUpdateNewCardRatio_ReturnsUpdatedRatio(t *testing.T) {
 	}
 }
 
-// TestUpdateNewCardRatio_EqualNumeratorDenominatorIsBadUserInput verifies that a
-// non-fraction (numerator == denominator) is rejected at the resolver before the
-// usecase runs.
-func TestUpdateNewCardRatio_EqualNumeratorDenominatorIsBadUserInput(t *testing.T) {
+// TestUpdateNewCardRatio_UsecaseValidationErrorMapsToBadUserInput verifies the
+// resolver forwards a usecase ValidationError to the wire as BAD_USER_INPUT,
+// propagating the usecase-attributed extensions.field. The resolver no longer
+// parses the ratio or derives the field itself — that moved into the usecase,
+// which is exercised directly in update_new_card_ratio_test.go.
+func TestUpdateNewCardRatio_UsecaseValidationErrorMapsToBadUserInput(t *testing.T) {
 	t.Parallel()
 
-	mock := &mockUpdateNewCardRatioUsecase{user: &domain.User{ID: "u-1"}}
+	mock := &mockUpdateNewCardRatioUsecase{
+		err: ucerr.NewValidationError("numerator", "invalid new-card ratio"),
+	}
 	userMock := &mockUserRepository{}
 	srv := newNewCardRatioSrv(userMock, mock)
 	body := `{"query":"mutation { updateNewCardRatio(numerator: 5, denominator: 5) { id } }"}`
@@ -162,40 +171,8 @@ func TestUpdateNewCardRatio_EqualNumeratorDenominatorIsBadUserInput(t *testing.T
 	if code != string(gqlerr.CodeBadUserInput) {
 		t.Fatalf("expected BAD_USER_INPUT, got %q; response: %v", code, resp)
 	}
-	// numerator == denominator faults the numerator bound (0 < num < den), so the
-	// wire field points the client at the numerator.
 	if field, _ := errExtensions(t, resp)["field"].(string); field != "numerator" {
 		t.Fatalf("expected extensions.field = numerator, got %q; response: %v", field, resp)
-	}
-	if mock.calls != 0 {
-		t.Fatalf("usecase Set must not be called for an invalid ratio; got %d calls", mock.calls)
-	}
-}
-
-// TestUpdateNewCardRatio_ReducedDenominatorTooLargeIsBadUserInput verifies that a
-// reduced denominator above NewCardRatioDenMax (100) is rejected with
-// BAD_USER_INPUT. 1/101 is already reduced, so its denominator exceeds the cap.
-func TestUpdateNewCardRatio_ReducedDenominatorTooLargeIsBadUserInput(t *testing.T) {
-	t.Parallel()
-
-	mock := &mockUpdateNewCardRatioUsecase{user: &domain.User{ID: "u-1"}}
-	userMock := &mockUserRepository{}
-	srv := newNewCardRatioSrv(userMock, mock)
-	body := `{"query":"mutation { updateNewCardRatio(numerator: 1, denominator: 101) { id } }"}`
-
-	resp := gqlRequest(t, srv, authedCtx("u-1"), body)
-
-	code := errCode(t, resp)
-	if code != string(gqlerr.CodeBadUserInput) {
-		t.Fatalf("expected BAD_USER_INPUT, got %q; response: %v", code, resp)
-	}
-	// The reduced denominator (101) exceeds NewCardRatioDenMax, so the fault is
-	// attributed to the denominator.
-	if field, _ := errExtensions(t, resp)["field"].(string); field != "denominator" {
-		t.Fatalf("expected extensions.field = denominator, got %q; response: %v", field, resp)
-	}
-	if mock.calls != 0 {
-		t.Fatalf("usecase Set must not be called for an out-of-range ratio; got %d calls", mock.calls)
 	}
 }
 

--- a/backend/internal/usecase/update_new_card_ratio.go
+++ b/backend/internal/usecase/update_new_card_ratio.go
@@ -9,12 +9,13 @@ import (
 	"backend/internal/auth"
 	"backend/internal/domain"
 	"backend/internal/repository"
+	"backend/internal/usecase/ucerr"
 )
 
 // UpdateNewCardRatioUsecase persists the authenticated caller's preferred
 // new-card ratio and returns the refreshed user row.
 type UpdateNewCardRatioUsecase interface {
-	Set(ctx context.Context, ratio domain.NewCardRatio) (*domain.User, error)
+	Set(ctx context.Context, numerator, denominator int) (*domain.User, error)
 }
 
 // updateNewCardRatioPrefsRepo is the narrow consumer interface for the
@@ -61,19 +62,41 @@ func NewUpdateNewCardRatioWithDeps(
 	return &updateNewCardRatioUsecase{prefs: prefs, users: users, logger: logger}
 }
 
-// Set persists ratio as the caller's new-card preference and returns the
-// refreshed user row. Authorization rules:
+// Set validates numerator/denominator, persists the reduced ratio as the
+// caller's new-card preference, and returns the refreshed user row.
+// Authorization and validation rules:
 //
-//   - Anonymous (no auth context) → UNAUTHENTICATED.
-//   - Authenticated caller → updated preference + refreshed user row.
+//   - Anonymous (no auth context) → UNAUTHENTICATED. The auth check runs before
+//     validation so an invalid ratio never reveals the bounds to an
+//     unauthenticated caller.
+//   - A ratio outside 1 <= numerator < denominator <= 100 (after reduction) → a
+//     field-scoped ValidationError the resolver maps to BAD_USER_INPUT.
+//   - Authenticated caller with a valid ratio → updated preference + refreshed
+//     user row.
 //
-// ratio is an already-reduced, already-validated domain.NewCardRatio; the
-// caller (the resolver) constructs it via domain.ParseNewCardRatio, so a bad
-// wire value never reaches this method.
-func (u *updateNewCardRatioUsecase) Set(ctx context.Context, ratio domain.NewCardRatio) (*domain.User, error) {
+// The usecase owns domain.ParseNewCardRatio (previously the resolver's job) so
+// value-object validation and field attribution live in the application layer,
+// like every sibling mutation.
+func (u *updateNewCardRatioUsecase) Set(ctx context.Context, numerator, denominator int) (*domain.User, error) {
 	caller := auth.UserFrom(ctx)
 	if err := requireCallerSub(caller); err != nil {
 		return nil, err
+	}
+
+	ratio, err := domain.ParseNewCardRatio(numerator, denominator)
+	if err != nil {
+		// Attribute the fault the way domain.ParseNewCardRatio does on the
+		// reduced fraction: a non-positive denominator, or a reduced denominator
+		// above NewCardRatioDenMax, is a denominator problem; a new-card share
+		// outside the open interval (0, denominator) is a numerator problem. The
+		// share bound is ratio-invariant (num/den < 1 iff rnum/rden < 1), so this
+		// verdict matches the reduced fraction the VO actually checks. The wire
+		// message stays generic to avoid leaking internal bounds phrasing.
+		field := "denominator"
+		if denominator > 0 && (numerator <= 0 || numerator >= denominator) {
+			field = "numerator"
+		}
+		return nil, ucerr.NewValidationError(field, "invalid new-card ratio")
 	}
 
 	if err := u.prefs.UpsertNewCardRatio(ctx, caller.Sub, ratio.Numerator(), ratio.Denominator()); err != nil {

--- a/backend/internal/usecase/update_new_card_ratio_test.go
+++ b/backend/internal/usecase/update_new_card_ratio_test.go
@@ -50,7 +50,7 @@ func TestUpdateNewCardRatio_Unauthenticated(t *testing.T) {
 	users := &mockNewCardRatioUserRepo{}
 	uc := NewUpdateNewCardRatioWithDeps(prefs, users, newTestLogger())
 
-	_, err := uc.Set(anonCtx(), domain.DefaultNewCardRatio)
+	_, err := uc.Set(anonCtx(), 4, 5)
 	assertUnauthenticated(t, err)
 	if prefs.called != 0 {
 		t.Fatalf("repository must not be called when caller is anonymous; got %d calls", prefs.called)
@@ -60,17 +60,14 @@ func TestUpdateNewCardRatio_Unauthenticated(t *testing.T) {
 func TestUpdateNewCardRatio_Success(t *testing.T) {
 	t.Parallel()
 
-	// 6/10 reduces to 3/5; the usecase must persist the reduced fraction.
-	ratio, err := domain.ParseNewCardRatio(6, 10)
-	if err != nil {
-		t.Fatalf("ParseNewCardRatio: unexpected error: %v", err)
-	}
+	// 6/10 reduces to 3/5; the usecase parses the raw ints and persists the
+	// reduced fraction.
 	want := &domain.User{ID: "u1"}
 	prefs := &mockNewCardRatioPrefRepo{}
 	users := &mockNewCardRatioUserRepo{user: want}
 	uc := NewUpdateNewCardRatioWithDeps(prefs, users, newTestLogger())
 
-	got, err := uc.Set(authedCtx("u1"), ratio)
+	got, err := uc.Set(authedCtx("u1"), 6, 10)
 	if err != nil {
 		t.Fatalf("Set: unexpected error: %v", err)
 	}
@@ -102,7 +99,7 @@ func TestUpdateNewCardRatio_PrefsWriteError(t *testing.T) {
 	users := &mockNewCardRatioUserRepo{}
 	uc := NewUpdateNewCardRatioWithDeps(prefs, users, newTestLogger())
 
-	_, err := uc.Set(authedCtx("u1"), domain.DefaultNewCardRatio)
+	_, err := uc.Set(authedCtx("u1"), 4, 5)
 	if err == nil {
 		t.Fatal("Set: expected error, got nil")
 	}
@@ -124,7 +121,7 @@ func TestUpdateNewCardRatio_PrefsWriteCancelled(t *testing.T) {
 	users := &mockNewCardRatioUserRepo{}
 	uc := NewUpdateNewCardRatioWithDeps(prefs, users, newTestLogger())
 
-	_, err := uc.Set(authedCtx("u1"), domain.DefaultNewCardRatio)
+	_, err := uc.Set(authedCtx("u1"), 4, 5)
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("Set: expected errors.Is(err, context.Canceled)=true, got %v (%T)", err, err)
 	}
@@ -140,7 +137,7 @@ func TestUpdateNewCardRatio_RefetchError(t *testing.T) {
 	users := &mockNewCardRatioUserRepo{err: boom}
 	uc := NewUpdateNewCardRatioWithDeps(prefs, users, newTestLogger())
 
-	_, err := uc.Set(authedCtx("u1"), domain.DefaultNewCardRatio)
+	_, err := uc.Set(authedCtx("u1"), 4, 5)
 	if err == nil {
 		t.Fatal("Set: expected error on refetch failure, got nil")
 	}
@@ -158,8 +155,50 @@ func TestUpdateNewCardRatio_RefetchCancelled(t *testing.T) {
 	users := &mockNewCardRatioUserRepo{err: context.DeadlineExceeded}
 	uc := NewUpdateNewCardRatioWithDeps(prefs, users, newTestLogger())
 
-	_, err := uc.Set(authedCtx("u1"), domain.DefaultNewCardRatio)
+	_, err := uc.Set(authedCtx("u1"), 4, 5)
 	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("Set: expected errors.Is(err, context.DeadlineExceeded)=true, got %v (%T)", err, err)
+	}
+}
+
+// TestUpdateNewCardRatio_InvalidRatio_FieldAttribution pins the wire field a bad
+// ratio faults on to the reduced fraction domain.ParseNewCardRatio actually
+// checks: a new-card share outside (0, denominator) faults the numerator; a
+// non-positive or over-cap (reduced) denominator faults the denominator. The
+// "3/303" case reduces to 1/101, so its over-cap denominator is only visible on
+// the reduced fraction. No write runs for any invalid ratio.
+func TestUpdateNewCardRatio_InvalidRatio_FieldAttribution(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		num, den  int
+		wantField string
+	}{
+		{"numerator equals denominator", 5, 5, "numerator"},
+		{"numerator exceeds denominator", 7, 5, "numerator"},
+		{"zero numerator", 0, 5, "numerator"},
+		{"negative numerator", -1, 5, "numerator"},
+		{"non-positive denominator", 1, 0, "denominator"},
+		{"reduced denominator over cap", 1, 101, "denominator"},
+		{"reduced denominator over cap after reduction", 3, 303, "denominator"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			prefs := &mockNewCardRatioPrefRepo{}
+			users := &mockNewCardRatioUserRepo{}
+			uc := NewUpdateNewCardRatioWithDeps(prefs, users, newTestLogger())
+
+			_, err := uc.Set(authedCtx("u1"), tc.num, tc.den)
+			assertValidationError(t, err, tc.wantField, "invalid new-card ratio")
+			if prefs.called != 0 {
+				t.Fatalf("UpsertNewCardRatio must not run for an invalid ratio; got %d calls", prefs.called)
+			}
+			if users.calls != 0 {
+				t.Fatalf("FindByID must not run for an invalid ratio; got %d calls", users.calls)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

`UpdateNewCardRatio` was the only mutation resolver that performed value-object validation and field-error classification itself: it called `domain.ParseNewCardRatio` directly, then hand-reconstructed the faulting argument with a `switch` that duplicated the VO's internal check order and ran on the **raw** numerator/denominator while the VO validates the **reduced** fraction. Any change to the VO's reduction or bound-check order would silently desync `extensions.field` with no compiler or test signal.

This moves the parse + field attribution into `UpdateNewCardRatioUsecase.Set`, so validation lives in the application layer like every sibling mutation, and collapses the resolver to a thin pass-through that forwards usecase errors via `gqlerr.FromUsecaseError`.

## Changes

- `internal/usecase/update_new_card_ratio.go`: `Set` now accepts raw `(numerator, denominator int)`, owns `domain.ParseNewCardRatio`, and on failure returns `ucerr.NewValidationError` with the field attributed the way the VO faults on the reduced fraction (numerator-share fault → `"numerator"`; non-positive or over-cap reduced denominator → `"denominator"`; the share bound is ratio-invariant, so the verdict matches the reduced fraction). The auth check runs before validation so an invalid ratio never leaks bounds to an unauthenticated caller.
- `graph/resolver/new_card_ratio.resolvers.go`: deletes the inline `ParseNewCardRatio` + field `switch`; the resolver is now `Set(ctx, numerator, denominator)` → `gqlerr.FromUsecaseError` on error. It no longer imports/uses `domain.ParseNewCardRatio`.
- Tests: added `TestUpdateNewCardRatio_InvalidRatio_FieldAttribution` (table test pinning field attribution to the reduced fraction, incl. `3/303 → 1/101` over-cap); migrated the two resolver-level field tests (pinned to the removed resolver-side parse) into one resolver pass-through test that proves a usecase `ValidationError` reaches the wire as `BAD_USER_INPUT` with the propagated `extensions.field`; updated the usecase-mock signature and existing `Set` call sites to raw ints.

## Test plan

- `go build ./...` — Success
- `go vet ./...` — no issues
- `go tool go-arch-lint check --project-path .` — OK, no warnings
- `go test ./internal/usecase/... ./graph/...` — all pass (new field-attribution and resolver pass-through tests included)
- Full `go test ./...` — testcontainers/Postgres packages skipped locally (Docker unavailable); CI runs them.

Closes #860
