### PR TITLE
refactor(backend,frontend): rename swipe mode → rating and expose performanceMode as an enum

### DIFF
--- a/backend/cmd/server/main_test.go
+++ b/backend/cmd/server/main_test.go
@@ -2082,7 +2082,7 @@ func TestGraphQL_HandleSwipe_HappyPath(t *testing.T) {
 	firstID := createTestCard(t, ts.URL, tok, cgID, "front 1", "back 1")
 
 	gqlQuery := fmt.Sprintf(`mutation {
-		handleSwipe(input: {cardId: %s, cardgroupId: %s, mode: 4}) {
+		handleSwipe(input: {cardId: %s, cardgroupId: %s, rating: 4}) {
 			__typename
 			... on HandleSwipeSuccess {
 				response {
@@ -2112,8 +2112,8 @@ func TestGraphQL_HandleSwipe_HappyPath(t *testing.T) {
 	if swipeResp == nil {
 		t.Fatalf("expected handleSwipe.response; resp=%v", resp)
 	}
-	if swipeResp["performanceMode"] != float64(1) {
-		t.Fatalf("performanceMode=%v, want 1", swipeResp["performanceMode"])
+	if swipeResp["performanceMode"] != "DEFAULT" {
+		t.Fatalf("performanceMode=%v, want DEFAULT", swipeResp["performanceMode"])
 	}
 	metrics, _ := swipeResp["metrics"].(map[string]any)
 	if metrics["reviewCount"] != float64(1) {
@@ -2140,30 +2140,30 @@ func TestGraphQL_HandleSwipe_HappyPath(t *testing.T) {
 	}
 }
 
-func TestGraphQL_HandleSwipe_InvalidModes(t *testing.T) {
+func TestGraphQL_HandleSwipe_InvalidRatings(t *testing.T) {
 	f := newJWTFixture(t)
 	ts, _ := newGraphQLTestServer(t, f)
 	ctx := context.Background()
 	sub := insertAuthUser(t, ctx)
 	tok := f.sign(t, sub)
-	cgID := createTestCardgroup(t, ts.URL, tok, "Invalid Modes")
+	cgID := createTestCardgroup(t, ts.URL, tok, "Invalid Ratings")
 	cardID := createTestCard(t, ts.URL, tok, cgID, "front", "back")
 
-	for _, mode := range []int{0, 3, 5} {
-		body := fmt.Sprintf(`{"query":"mutation { handleSwipe(input: {cardId: \"%s\", cardgroupId: \"%s\", mode: %d}) { __typename ... on InputValidationError { field message } } }"}`, cardID, cgID, mode)
+	for _, rating := range []int{0, 3, 5} {
+		body := fmt.Sprintf(`{"query":"mutation { handleSwipe(input: {cardId: \"%s\", cardgroupId: \"%s\", rating: %d}) { __typename ... on InputValidationError { field message } } }"}`, cardID, cgID, rating)
 		resp := postGraphQL(t, ts.URL+"/query", body, tok)
 		if errs, ok := resp["errors"].([]any); ok && len(errs) > 0 {
-			t.Fatalf("mode=%d: unexpected GraphQL errors: %v", mode, errs)
+			t.Fatalf("rating=%d: unexpected GraphQL errors: %v", rating, errs)
 		}
 		payload, _ := resp["data"].(map[string]any)["handleSwipe"].(map[string]any)
 		if payload == nil {
-			t.Fatalf("mode=%d: expected data.handleSwipe, got nil; resp=%v", mode, resp)
+			t.Fatalf("rating=%d: expected data.handleSwipe, got nil; resp=%v", rating, resp)
 		}
 		if payload["__typename"] != "InputValidationError" {
-			t.Fatalf("mode=%d: expected InputValidationError, got %v; resp=%v", mode, payload["__typename"], resp)
+			t.Fatalf("rating=%d: expected InputValidationError, got %v; resp=%v", rating, payload["__typename"], resp)
 		}
-		if payload["field"] != "mode" {
-			t.Fatalf("mode=%d: expected field=mode, got %q; resp=%v", mode, payload["field"], resp)
+		if payload["field"] != "rating" {
+			t.Fatalf("rating=%d: expected field=rating, got %q; resp=%v", rating, payload["field"], resp)
 		}
 	}
 }
@@ -2179,7 +2179,7 @@ func TestGraphQL_HandleSwipe_NonOwnerUnauthenticated(t *testing.T) {
 
 	subB := insertAuthUser(t, ctx)
 	tokB := f.sign(t, subB)
-	body := fmt.Sprintf(`{"query":"mutation { handleSwipe(input: {cardId: \"%s\", cardgroupId: \"%s\", mode: 4}) { __typename } }"}`, cardID, cgID)
+	body := fmt.Sprintf(`{"query":"mutation { handleSwipe(input: {cardId: \"%s\", cardgroupId: \"%s\", rating: 4}) { __typename } }"}`, cardID, cgID)
 	resp := postGraphQL(t, ts.URL+"/query", body, tokB)
 
 	if code := gqlErrCode(resp); code != "UNAUTHENTICATED" {
@@ -2200,7 +2200,7 @@ func TestGraphQL_HandleSwipe_CrossCardgroupMatchesMissingCardError(t *testing.T)
 	missingCardID := uuid.NewString()
 
 	bodyForCard := func(cardID string) string {
-		return fmt.Sprintf(`{"query":"mutation { handleSwipe(input: {cardId: \"%s\", cardgroupId: \"%s\", mode: 4}) { __typename ... on InputValidationError { field message } } }"}`, cardID, ownedCgID)
+		return fmt.Sprintf(`{"query":"mutation { handleSwipe(input: {cardId: \"%s\", cardgroupId: \"%s\", rating: 4}) { __typename ... on InputValidationError { field message } } }"}`, cardID, ownedCgID)
 	}
 	mismatchResp := postGraphQL(t, ts.URL+"/query", bodyForCard(otherCardID), tok)
 	missingResp := postGraphQL(t, ts.URL+"/query", bodyForCard(missingCardID), tok)
@@ -2265,7 +2265,7 @@ func TestHandleSwipe_RollsBackWhenSwipeRecordInsertFails(t *testing.T) {
 	_, err := uc.HandleSwipe(auth.ContextWithUser(ctx, &auth.AuthUser{Sub: sub}), usecase.HandleSwipeInput{
 		CardID:      cardID,
 		CardgroupID: domain.CardgroupID(cgID),
-		Mode:        4,
+		Rating:      4,
 	})
 	if err == nil {
 		t.Fatal("expected forced error, got nil")

--- a/backend/graph/resolver/mapper.go
+++ b/backend/graph/resolver/mapper.go
@@ -311,8 +311,30 @@ func toSwipeResponseModel(out *usecase.SwipeOutput) *model.SwipeResponse {
 		return nil
 	}
 	return &model.SwipeResponse{
-		PerformanceMode: out.PerformanceMode,
+		PerformanceMode: toSwipePerformanceModeModel(out.PerformanceMode),
 		Metrics:         toPerformanceMetricsModel(out.Metrics),
+	}
+}
+
+// toSwipePerformanceModeModel maps the usecase's int-encoded performance mode
+// (service.PerformanceMode, 0..4) to the generated wire enum. The int always
+// comes from service.ModeFromMetrics, which returns a clamped in-range value,
+// so the default arm is unreachable; it maps to DEFAULT as a fail-safe to keep
+// the non-null field serializable.
+func toSwipePerformanceModeModel(mode int) model.SwipePerformanceMode {
+	switch service.PerformanceMode(mode) {
+	case service.ModeDifficult:
+		return model.SwipePerformanceModeDifficult
+	case service.ModeDefault:
+		return model.SwipePerformanceModeDefault
+	case service.ModeGood:
+		return model.SwipePerformanceModeGood
+	case service.ModeEasy:
+		return model.SwipePerformanceModeEasy
+	case service.ModeMastered:
+		return model.SwipePerformanceModeMastered
+	default:
+		return model.SwipePerformanceModeDefault
 	}
 }
 

--- a/backend/graph/resolver/mapper_test.go
+++ b/backend/graph/resolver/mapper_test.go
@@ -3,7 +3,9 @@ package resolver
 import (
 	"testing"
 
+	"backend/graph/model"
 	"backend/internal/domain"
+	"backend/internal/domain/service"
 )
 
 // TestLearnDisplayModeMapper_RoundTrip asserts that converting a domain value to
@@ -30,4 +32,41 @@ func TestLearnDisplayModeMapper_RoundTrip(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestSwipePerformanceModeMapper asserts that toSwipePerformanceModeModel maps
+// every service.PerformanceMode to the matching generated wire enum, and that an
+// out-of-range int falls back to DEFAULT. Because the mapper matches by named
+// constant on both sides, this guards against a switch-body transposition (e.g.
+// returning GOOD for ModeMastered) — a change that compiles and passes vet but
+// only the DEFAULT arm is otherwise exercised end-to-end.
+func TestSwipePerformanceModeMapper(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		mode service.PerformanceMode
+		want model.SwipePerformanceMode
+	}{
+		{"Difficult", service.ModeDifficult, model.SwipePerformanceModeDifficult},
+		{"Default", service.ModeDefault, model.SwipePerformanceModeDefault},
+		{"Good", service.ModeGood, model.SwipePerformanceModeGood},
+		{"Easy", service.ModeEasy, model.SwipePerformanceModeEasy},
+		{"Mastered", service.ModeMastered, model.SwipePerformanceModeMastered},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := toSwipePerformanceModeModel(int(tc.mode)); got != tc.want {
+				t.Fatalf("toSwipePerformanceModeModel(%d): got %q, want %q", tc.mode, got, tc.want)
+			}
+		})
+	}
+
+	t.Run("OutOfRangeFallsBackToDefault", func(t *testing.T) {
+		t.Parallel()
+		if got := toSwipePerformanceModeModel(99); got != model.SwipePerformanceModeDefault {
+			t.Fatalf("toSwipePerformanceModeModel(99): got %q, want %q", got, model.SwipePerformanceModeDefault)
+		}
+	})
 }

--- a/backend/graph/resolver/swipe.resolvers.go
+++ b/backend/graph/resolver/swipe.resolvers.go
@@ -16,14 +16,14 @@ import (
 // HandleSwipe is the resolver for the handleSwipe field.
 //
 // Returns a union: `model.HandleSwipeSuccess` on the happy path, or
-// `model.InputValidationError` when the mode, cardId, or cardgroupId fails
+// `model.InputValidationError` when the rating, cardId, or cardgroupId fails
 // validation. Validation failures are "errors as data" — the error return is
 // reserved for auth and infrastructure failures.
 func (r *mutationResolver) HandleSwipe(ctx context.Context, input model.HandleSwipeInput) (model.HandleSwipeResult, error) {
 	outcome, err := r.SwipeUC.HandleSwipe(ctx, usecase.HandleSwipeInput{
 		CardID:      input.CardID,
 		CardgroupID: domain.CardgroupID(input.CardgroupID),
-		Mode:        input.Mode,
+		Rating:      input.Rating,
 	})
 	if err != nil {
 		return nil, gqlerr.FromUsecaseError(ctx, err)

--- a/backend/graph/resolver/swipe_resolver_test.go
+++ b/backend/graph/resolver/swipe_resolver_test.go
@@ -113,7 +113,7 @@ func newSwipeSrv(
 
 // handleSwipeMutation returns a JSON-encoded GraphQL mutation body for
 // handleSwipe, selecting across both union variants.
-func handleSwipeMutation(cardID, cardgroupID string, mode int) string {
+func handleSwipeMutation(cardID, cardgroupID string, rating int) string {
 	b, _ := json.Marshal(map[string]any{
 		"query": `mutation($input: HandleSwipeInput!) {
 			handleSwipe(input: $input) {
@@ -131,7 +131,7 @@ func handleSwipeMutation(cardID, cardgroupID string, mode int) string {
 			"input": map[string]any{
 				"cardId":      cardID,
 				"cardgroupId": cardgroupID,
-				"mode":        mode,
+				"rating":      rating,
 			},
 		},
 	})
@@ -164,7 +164,7 @@ func TestResolver_HandleSwipe_HappyPath(t *testing.T) {
 
 	srv := newSwipeSrv(cardRepo, cgRepo, swipeRepo, fsrsRepo)
 
-	// Mode 1 = Again — a valid swipe mode.
+	// Rating 1 = Again — a valid swipe rating.
 	resp := gqlRequest(t, srv, authedCtx("u-1"), handleSwipeMutation("c-1", "cg-1", 1))
 
 	if _, hasErrs := resp["errors"]; hasErrs {
@@ -184,13 +184,13 @@ func TestResolver_HandleSwipe_HappyPath(t *testing.T) {
 	}
 }
 
-// TestResolver_HandleSwipe_InputValidation verifies that an invalid swipe mode
+// TestResolver_HandleSwipe_InputValidation verifies that an invalid swipe rating
 // is surfaced as the InputValidationError union variant (errors as data), not
-// as a GraphQL protocol error. The mode validation fires before any repo calls.
+// as a GraphQL protocol error. The rating validation fires before any repo calls.
 func TestResolver_HandleSwipe_InputValidation(t *testing.T) {
 	t.Parallel()
 
-	// Repos can be minimal stubs — mode validation fires before any repo access.
+	// Repos can be minimal stubs — rating validation fires before any repo access.
 	cardRepo := &swipeCardRepo{}
 	cgRepo := &swipeCGRepo{
 		findByIDResult: &domain.Cardgroup{ID: "cg-1", OwnerID: "u-1"},
@@ -200,7 +200,7 @@ func TestResolver_HandleSwipe_InputValidation(t *testing.T) {
 
 	srv := newSwipeSrv(cardRepo, cgRepo, swipeRepo, fsrsRepo)
 
-	// Mode 999 is not a valid swipe mode → InputValidationError{field:"mode"}.
+	// Rating 999 is not a valid swipe rating → InputValidationError{field:"rating"}.
 	resp := gqlRequest(t, srv, authedCtx("u-1"), handleSwipeMutation("c-1", "cg-1", 999))
 
 	if _, hasErrs := resp["errors"]; hasErrs {
@@ -214,8 +214,8 @@ func TestResolver_HandleSwipe_InputValidation(t *testing.T) {
 	if payload["__typename"] != "InputValidationError" {
 		t.Fatalf("expected __typename=InputValidationError, got %v; response: %v", payload["__typename"], resp)
 	}
-	if payload["field"] != "mode" {
-		t.Fatalf("expected field=mode, got %v", payload["field"])
+	if payload["field"] != "rating" {
+		t.Fatalf("expected field=rating, got %v", payload["field"])
 	}
 	if payload["message"] == nil || payload["message"] == "" {
 		t.Fatalf("expected non-empty message in InputValidationError, got %v", payload["message"])
@@ -269,7 +269,7 @@ func TestResolver_HandleSwipe_InfrastructureError_ReturnsInternal(t *testing.T) 
 	srv := handler.New(generated.NewExecutableSchema(generated.Config{Resolvers: r}))
 	srv.AddTransport(transport.POST{})
 
-	// Mode 1 is valid — passes mode validation, reaches tx-runner check.
+	// Rating 1 is valid — passes rating validation, reaches tx-runner check.
 	resp := gqlRequest(t, srv, authedCtx("u-1"), handleSwipeMutation("c-1", "cg-1", 1))
 
 	code := errCode(t, resp)
@@ -324,7 +324,7 @@ func TestResolver_HandleSwipe_CardNotFound_InputValidation(t *testing.T) {
 
 	srv := newSwipeSrv(cardRepo, cgRepo, swipeRepo, fsrsRepo)
 
-	// Mode 1 = Again — passes mode validation, reaches the card lookup.
+	// Rating 1 = Again — passes rating validation, reaches the card lookup.
 	resp := gqlRequest(t, srv, authedCtx("u-1"), handleSwipeMutation("c-missing", "cg-1", 1))
 
 	if _, hasErrs := resp["errors"]; hasErrs {

--- a/backend/internal/domain/card_test.go
+++ b/backend/internal/domain/card_test.go
@@ -229,25 +229,25 @@ func TestNewFSRSStateForNewCard(t *testing.T) {
 	require.Equal(t, now, got.LastReview)
 }
 
-func TestRatingFromSwipeMode(t *testing.T) {
+func TestRatingFromSwipe(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
-		mode    int
+		rating  int
 		want    Rating
 		wantErr bool
 	}{
-		{mode: 1, want: RatingAgain},
-		{mode: 2, want: RatingHard},
-		{mode: 4, want: RatingEasy},
-		{mode: 0, wantErr: true},
-		{mode: 3, wantErr: true},
-		{mode: 5, wantErr: true},
+		{rating: 1, want: RatingAgain},
+		{rating: 2, want: RatingHard},
+		{rating: 4, want: RatingEasy},
+		{rating: 0, wantErr: true},
+		{rating: 3, wantErr: true},
+		{rating: 5, wantErr: true},
 	}
 	for _, tc := range cases {
-		t.Run(fmt.Sprintf("mode_%d", tc.mode), func(t *testing.T) {
+		t.Run(fmt.Sprintf("rating_%d", tc.rating), func(t *testing.T) {
 			t.Parallel()
-			got, err := RatingFromSwipeMode(tc.mode)
+			got, err := RatingFromSwipe(tc.rating)
 			if tc.wantErr {
 				require.Error(t, err)
 				return

--- a/backend/internal/domain/rating.go
+++ b/backend/internal/domain/rating.go
@@ -19,15 +19,15 @@ func (r Rating) IsValid() bool {
 }
 
 // IsSuccess reports whether the rating counts as a successful review (Good or
-// Easy). The 3-step swipe UI never emits RatingGood (RatingFromSwipeMode yields
+// Easy). The 3-step swipe UI never emits RatingGood (RatingFromSwipe yields
 // only 1/2/4), so "success" is effectively Easy today; the predicate stays
 // >= RatingGood to remain correct if Good is ever wired.
 func (r Rating) IsSuccess() bool { return r >= RatingGood }
 
-// RatingFromSwipeMode maps the legacy 3-step swipe UI to FSRS ratings. The UI
-// emits 1=Again, 2=Hard, and 4=Easy; it intentionally does not emit 3=Good.
-func RatingFromSwipeMode(mode int) (Rating, error) {
-	switch mode {
+// RatingFromSwipe maps the 3-step swipe UI's raw rating to an FSRS rating. The
+// UI emits 1=Again, 2=Hard, and 4=Easy; it intentionally does not emit 3=Good.
+func RatingFromSwipe(rating int) (Rating, error) {
+	switch rating {
 	case 1:
 		return RatingAgain, nil
 	case 2:
@@ -35,6 +35,6 @@ func RatingFromSwipeMode(mode int) (Rating, error) {
 	case 4:
 		return RatingEasy, nil
 	default:
-		return 0, eris.Errorf("rating: unknown swipe mode %d", mode)
+		return 0, eris.Errorf("rating: unknown swipe rating %d", rating)
 	}
 }

--- a/backend/internal/usecase/swipe.go
+++ b/backend/internal/usecase/swipe.go
@@ -59,7 +59,7 @@ type swipeUsecase struct {
 type HandleSwipeInput struct {
 	CardID      string
 	CardgroupID domain.CardgroupID
-	Mode        int
+	Rating      int
 }
 
 type SwipeOutput struct {
@@ -129,11 +129,11 @@ func (u *swipeUsecase) HandleSwipe(ctx context.Context, in HandleSwipeInput) (Ha
 	if err := requireCallerSub(user); err != nil {
 		return HandleSwipeOutcome{}, err
 	}
-	rating, err := domain.RatingFromSwipeMode(in.Mode)
+	rating, err := domain.RatingFromSwipe(in.Rating)
 	if err != nil {
 		// Use a plain user-facing message; err.Error() carries an internal layer
-		// prefix ("rating: unknown swipe mode N") that is not appropriate on the wire.
-		return HandleSwipeOutcome{Validation: NewInputValidationInfo("mode", "unknown swipe mode")}, nil
+		// prefix ("rating: unknown swipe rating N") that is not appropriate on the wire.
+		return HandleSwipeOutcome{Validation: NewInputValidationInfo("rating", "unknown swipe rating")}, nil
 	}
 	if err := authorizeCardgroupOrBadInput(ctx, u.cardgroupRepo, in.CardgroupID, domain.UserID(user.Sub)); err != nil {
 		// authorizeCardgroupOrBadInput returns ucerr.NewValidationError("cardgroupId", ...) for

--- a/backend/internal/usecase/swipe_error_test.go
+++ b/backend/internal/usecase/swipe_error_test.go
@@ -42,7 +42,7 @@ func TestSwipeUsecase_HandleSwipe_FindCardByIDError_PinsChain(t *testing.T) {
 	_, err := uc.HandleSwipe(authedCtx("user-1"), HandleSwipeInput{
 		CardID:      "card-1",
 		CardgroupID: "cg-1",
-		Mode:        int(domain.RatingEasy),
+		Rating:      int(domain.RatingEasy),
 	})
 
 	assertInternalChain(t, err, "usecase: swipe: find card by id")
@@ -83,7 +83,7 @@ func TestSwipeUsecase_HandleSwipe_FindUserCardFSRSError_PinsChain(t *testing.T) 
 	_, err := uc.HandleSwipe(authedCtx("user-1"), HandleSwipeInput{
 		CardID:      "card-1",
 		CardgroupID: "cg-1",
-		Mode:        int(domain.RatingEasy),
+		Rating:      int(domain.RatingEasy),
 	})
 
 	assertInternalChain(t, err, "usecase: swipe: find user-card fsrs")
@@ -126,7 +126,7 @@ func TestSwipeUsecase_HandleSwipe_ApplyRatingError_PinsChain(t *testing.T) {
 	_, err := uc.HandleSwipe(authedCtx("user-1"), HandleSwipeInput{
 		CardID:      "card-1",
 		CardgroupID: "cg-1",
-		Mode:        int(domain.RatingEasy),
+		Rating:      int(domain.RatingEasy),
 	})
 
 	assertInternalChain(t, err, "usecase: swipe: apply rating")
@@ -169,7 +169,7 @@ func TestSwipeUsecase_HandleSwipe_NewSwipeRecordError_PinsChain(t *testing.T) {
 	_, err := uc.HandleSwipe(authedCtx("user-1"), HandleSwipeInput{
 		CardID:      "card-1",
 		CardgroupID: "cg-1",
-		Mode:        int(domain.RatingEasy),
+		Rating:      int(domain.RatingEasy),
 	})
 
 	assertInternalChain(t, err, "usecase: swipe: new swipe record")
@@ -212,7 +212,7 @@ func TestSwipeUsecase_HandleSwipe_InsertSwipeRecordError_PinsChain(t *testing.T)
 	_, err := uc.HandleSwipe(authedCtx("user-1"), HandleSwipeInput{
 		CardID:      "card-1",
 		CardgroupID: "cg-1",
-		Mode:        int(domain.RatingEasy),
+		Rating:      int(domain.RatingEasy),
 	})
 
 	assertInternalChain(t, err, "usecase: swipe: insert swipe record")
@@ -243,7 +243,7 @@ func TestSwipeUsecase_HandleSwipe_FindCardByID_PropagatesCancelled(t *testing.T)
 	_, err := uc.HandleSwipe(authedCtx("user-1"), HandleSwipeInput{
 		CardID:      "card-1",
 		CardgroupID: "cg-1",
-		Mode:        int(domain.RatingEasy),
+		Rating:      int(domain.RatingEasy),
 	})
 
 	assertCancelled(t, err)
@@ -283,7 +283,7 @@ func TestSwipeUsecase_HandleSwipe_FindUserCardFSRS_PropagatesCancelled(t *testin
 	_, err := uc.HandleSwipe(authedCtx("user-1"), HandleSwipeInput{
 		CardID:      "card-1",
 		CardgroupID: "cg-1",
-		Mode:        int(domain.RatingEasy),
+		Rating:      int(domain.RatingEasy),
 	})
 
 	assertCancelled(t, err)
@@ -322,7 +322,7 @@ func TestSwipeUsecase_HandleSwipe_UpsertUserCardFSRS_PropagatesCancelled(t *test
 	_, err := uc.HandleSwipe(authedCtx("user-1"), HandleSwipeInput{
 		CardID:      "card-1",
 		CardgroupID: "cg-1",
-		Mode:        int(domain.RatingEasy),
+		Rating:      int(domain.RatingEasy),
 	})
 
 	assertCancelled(t, err)
@@ -363,7 +363,7 @@ func TestSwipeUsecase_HandleSwipe_InsertSwipeRecord_PropagatesCancelled(t *testi
 	_, err := uc.HandleSwipe(authedCtx("user-1"), HandleSwipeInput{
 		CardID:      "card-1",
 		CardgroupID: "cg-1",
-		Mode:        int(domain.RatingEasy),
+		Rating:      int(domain.RatingEasy),
 	})
 
 	assertCancelled(t, err)
@@ -406,7 +406,7 @@ func TestSwipeUsecase_HandleSwipe_ListRecentSwipes_PinsChain(t *testing.T) {
 	_, err := uc.HandleSwipe(authedCtx("user-1"), HandleSwipeInput{
 		CardID:      "card-1",
 		CardgroupID: "cg-1",
-		Mode:        int(domain.RatingEasy),
+		Rating:      int(domain.RatingEasy),
 	})
 
 	assertInternalChain(t, err, "usecase: swipe: list recent swipes")
@@ -448,7 +448,7 @@ func TestSwipeUsecase_HandleSwipe_ListRecentSwipes_PropagatesCancelled(t *testin
 	_, err := uc.HandleSwipe(authedCtx("user-1"), HandleSwipeInput{
 		CardID:      "card-1",
 		CardgroupID: "cg-1",
-		Mode:        int(domain.RatingEasy),
+		Rating:      int(domain.RatingEasy),
 	})
 
 	assertCancelled(t, err)
@@ -490,7 +490,7 @@ func TestSwipeUsecase_HandleSwipe_ListRecentSwipes_PropagatesDeadlineExceeded(t 
 	_, err := uc.HandleSwipe(authedCtx("user-1"), HandleSwipeInput{
 		CardID:      "card-1",
 		CardgroupID: "cg-1",
-		Mode:        int(domain.RatingEasy),
+		Rating:      int(domain.RatingEasy),
 	})
 
 	assertCancelled(t, err)

--- a/backend/internal/usecase/swipe_performance_test.go
+++ b/backend/internal/usecase/swipe_performance_test.go
@@ -100,7 +100,7 @@ func TestSwipeUsecase_HandleSwipePerformanceMode(t *testing.T) {
 			outcome, err := uc.HandleSwipe(authedCtx("user-1"), HandleSwipeInput{
 				CardID:      "card-1",
 				CardgroupID: "cg-1",
-				Mode:        int(domain.RatingEasy),
+				Rating:      int(domain.RatingEasy),
 			})
 
 			if err != nil {
@@ -159,7 +159,7 @@ func TestSwipeUsecase_HandleSwipeCreatesUserFSRSStateForFirstSwipe(t *testing.T)
 	outcome, err := uc.HandleSwipe(authedCtx("user-1"), HandleSwipeInput{
 		CardID:      "card-1",
 		CardgroupID: "cg-1",
-		Mode:        int(domain.RatingEasy),
+		Rating:      int(domain.RatingEasy),
 	})
 
 	if err != nil {
@@ -210,7 +210,7 @@ func TestSwipeUsecase_HandleSwipe_NonOwner_Unauthenticated(t *testing.T) {
 	_, err := uc.HandleSwipe(authedCtx("user-1"), HandleSwipeInput{
 		CardID:      "card-1",
 		CardgroupID: "cg-1",
-		Mode:        int(domain.RatingEasy),
+		Rating:      int(domain.RatingEasy),
 	})
 
 	assertUnauthenticated(t, err)
@@ -275,7 +275,7 @@ func TestSwipeUsecase_HandleSwipe_PropagatesUpsertError(t *testing.T) {
 	_, err := uc.HandleSwipe(authedCtx("user-1"), HandleSwipeInput{
 		CardID:      "card-1",
 		CardgroupID: "cg-1",
-		Mode:        int(domain.RatingEasy),
+		Rating:      int(domain.RatingEasy),
 	})
 
 	if err == nil {
@@ -284,11 +284,11 @@ func TestSwipeUsecase_HandleSwipe_PropagatesUpsertError(t *testing.T) {
 	assertInternalChain(t, err, "storage: simulated upsert failure")
 }
 
-// TestSwipeUsecase_HandleSwipe_InvalidMode_ValidationVariant verifies that an
-// invalid swipe mode surfaces as the outcome's Validation variant (not an
+// TestSwipeUsecase_HandleSwipe_InvalidRating_ValidationVariant verifies that an
+// invalid swipe rating surfaces as the outcome's Validation variant (not an
 // error channel error) so the resolver maps it to the InputValidationError
 // union member.
-func TestSwipeUsecase_HandleSwipe_InvalidMode_ValidationVariant(t *testing.T) {
+func TestSwipeUsecase_HandleSwipe_InvalidRating_ValidationVariant(t *testing.T) {
 	t.Parallel()
 
 	cardgroupRepo := &mockCardgroupRepoForCard{
@@ -308,7 +308,7 @@ func TestSwipeUsecase_HandleSwipe_InvalidMode_ValidationVariant(t *testing.T) {
 	outcome, err := uc.HandleSwipe(authedCtx("user-1"), HandleSwipeInput{
 		CardID:      "card-1",
 		CardgroupID: "cg-1",
-		Mode:        9999, // invalid
+		Rating:      9999, // invalid
 	})
 
 	if err != nil {
@@ -318,10 +318,10 @@ func TestSwipeUsecase_HandleSwipe_InvalidMode_ValidationVariant(t *testing.T) {
 		t.Fatal("expected nil Swipe on validation failure")
 	}
 	if outcome.Validation == nil {
-		t.Fatal("expected non-nil Validation on invalid mode")
+		t.Fatal("expected non-nil Validation on invalid rating")
 	}
-	if outcome.Validation.Field != "mode" {
-		t.Fatalf("expected Validation.Field=%q, got %q", "mode", outcome.Validation.Field)
+	if outcome.Validation.Field != "rating" {
+		t.Fatalf("expected Validation.Field=%q, got %q", "rating", outcome.Validation.Field)
 	}
 }
 
@@ -354,7 +354,7 @@ func TestSwipeUsecase_HandleSwipe_CardNotFound_ValidationVariant(t *testing.T) {
 	outcome, err := uc.HandleSwipe(authedCtx("user-1"), HandleSwipeInput{
 		CardID:      "card-missing",
 		CardgroupID: "cg-1",
-		Mode:        int(domain.RatingEasy),
+		Rating:      int(domain.RatingEasy),
 	})
 
 	if err != nil {
@@ -397,7 +397,7 @@ func TestSwipeUsecase_HandleSwipe_CardgroupNotFound_ValidationVariant(t *testing
 	outcome, err := uc.HandleSwipe(authedCtx("user-1"), HandleSwipeInput{
 		CardID:      "card-1",
 		CardgroupID: "cg-missing",
-		Mode:        int(domain.RatingEasy),
+		Rating:      int(domain.RatingEasy),
 	})
 
 	if err != nil {
@@ -449,7 +449,7 @@ func TestSwipeUsecase_HandleSwipe_CardCrossCardgroup_ValidationVariant(t *testin
 	outcome, err := uc.HandleSwipe(authedCtx("user-1"), HandleSwipeInput{
 		CardID:      "card-1",
 		CardgroupID: "cg-1",
-		Mode:        int(domain.RatingEasy),
+		Rating:      int(domain.RatingEasy),
 	})
 
 	if err != nil {

--- a/frontend/src/app/learn/[cardgroupId]/learn-client.test.tsx
+++ b/frontend/src/app/learn/[cardgroupId]/learn-client.test.tsx
@@ -300,13 +300,13 @@ function renderLearnClient(
   );
 }
 
-function makeSwipeMock(mode: 1 | 2 | 4) {
+function makeSwipeMock(rating: 1 | 2 | 4) {
   let called = false;
   return {
     mock: {
       request: {
         query: HandleSwipeDocument,
-        variables: { input: { cardId: CARD_1.id, cardgroupId: CG_ID, mode } },
+        variables: { input: { cardId: CARD_1.id, cardgroupId: CG_ID, rating } },
       },
       result: () => {
         called = true;
@@ -316,7 +316,7 @@ function makeSwipeMock(mode: 1 | 2 | 4) {
               __typename: "HandleSwipeSuccess" as const,
               response: {
                 __typename: "SwipeResponse" as const,
-                performanceMode: 0,
+                performanceMode: "DIFFICULT",
                 metrics: DEFAULT_METRICS,
               },
             },
@@ -343,7 +343,7 @@ describe("<LearnClient>", () => {
     expect(screen.queryByText("Hola")).not.toBeInTheDocument();
   });
 
-  it("keeps down rating mapped to Hard mode 2", async () => {
+  it("keeps down rating mapped to Hard rating 2", async () => {
     const user = userEvent.setup();
     const swipe = makeSwipeMock(2);
     renderLearnClient([swipe.mock]);
@@ -363,9 +363,9 @@ describe("<LearnClient>", () => {
     ["Rate as Again", 1],
     ["Rate as Hard", 2],
     ["Rate as Easy", 4],
-  ] as const)("maps %s to mode %d", async (label, mode) => {
+  ] as const)("maps %s to rating %d", async (label, rating) => {
     const user = userEvent.setup();
-    const swipe = makeSwipeMock(mode);
+    const swipe = makeSwipeMock(rating);
     renderLearnClient([swipe.mock]);
 
     await user.click(screen.getByRole("button", { name: label }));
@@ -460,7 +460,7 @@ describe("<LearnClient>", () => {
     const mock = {
       request: {
         query: HandleSwipeDocument,
-        variables: { input: { cardId: CARD_1.id, cardgroupId: CG_ID, mode: 1 } },
+        variables: { input: { cardId: CARD_1.id, cardgroupId: CG_ID, rating: 1 } },
       },
       result: {
         errors: [new GraphQLError("bad swipe", { extensions: { code: "BAD_USER_INPUT" } })],
@@ -519,7 +519,7 @@ describe("<LearnClient>", () => {
       const mock = {
         request: {
           query: HandleSwipeDocument,
-          variables: { input: { cardId: CARD_1.id, cardgroupId: CG_ID, mode: 4 } },
+          variables: { input: { cardId: CARD_1.id, cardgroupId: CG_ID, rating: 4 } },
         },
         result: {
           data: {
@@ -536,7 +536,7 @@ describe("<LearnClient>", () => {
       // without immediately hitting the empty-queue caught-up screen.
       renderLearnClient([mock], [CARD_1, CARD_2]);
 
-      // Swipe CARD_1 right (mode 4 = Easy).
+      // Swipe CARD_1 right (rating 4 = Easy).
       await user.click(screen.getByRole("button", { name: "Rate as Easy" }));
 
       // console.warn must be emitted with the structured payload for operator triage.
@@ -577,7 +577,7 @@ describe("<LearnClient>", () => {
       const mock = {
         request: {
           query: HandleSwipeDocument,
-          variables: { input: { cardId: CARD_1.id, cardgroupId: CG_ID, mode: 4 } },
+          variables: { input: { cardId: CARD_1.id, cardgroupId: CG_ID, rating: 4 } },
         },
         result: {
           data: {
@@ -1029,7 +1029,7 @@ describe("<LearnClient> onSwipe identity stability", () => {
     const swipeMock = {
       request: {
         query: HandleSwipeDocument,
-        variables: { input: { cardId: CARD_1.id, cardgroupId: CG_ID, mode: 4 } },
+        variables: { input: { cardId: CARD_1.id, cardgroupId: CG_ID, rating: 4 } },
       },
       result: {
         data: {
@@ -1037,7 +1037,7 @@ describe("<LearnClient> onSwipe identity stability", () => {
             __typename: "HandleSwipeSuccess" as const,
             response: {
               __typename: "SwipeResponse" as const,
-              performanceMode: 0,
+              performanceMode: "DIFFICULT",
               metrics: DEFAULT_METRICS,
             },
           },
@@ -1173,7 +1173,7 @@ describe("<LearnClient> queue prefetch", () => {
     const swipe = {
       request: {
         query: HandleSwipeDocument,
-        variables: { input: { cardId: "q-1", cardgroupId: CG_ID, mode: 4 } },
+        variables: { input: { cardId: "q-1", cardgroupId: CG_ID, rating: 4 } },
       },
       result: {
         data: {
@@ -1181,7 +1181,7 @@ describe("<LearnClient> queue prefetch", () => {
             __typename: "HandleSwipeSuccess" as const,
             response: {
               __typename: "SwipeResponse" as const,
-              performanceMode: 0,
+              performanceMode: "DIFFICULT",
               metrics: DEFAULT_METRICS,
             },
           },
@@ -1299,7 +1299,7 @@ describe("<LearnClient> queue prefetch", () => {
     const swipe = {
       request: {
         query: HandleSwipeDocument,
-        variables: { input: { cardId: "q-1", cardgroupId: CG_ID, mode: 4 } },
+        variables: { input: { cardId: "q-1", cardgroupId: CG_ID, rating: 4 } },
       },
       result: {
         data: {
@@ -1307,7 +1307,7 @@ describe("<LearnClient> queue prefetch", () => {
             __typename: "HandleSwipeSuccess" as const,
             response: {
               __typename: "SwipeResponse" as const,
-              performanceMode: 0,
+              performanceMode: "DIFFICULT",
               metrics: DEFAULT_METRICS,
             },
           },
@@ -1390,7 +1390,7 @@ describe("<LearnClient> queue prefetch", () => {
     const swipe = {
       request: {
         query: HandleSwipeDocument,
-        variables: { input: { cardId: "q-1", cardgroupId: CG_ID, mode: 4 } },
+        variables: { input: { cardId: "q-1", cardgroupId: CG_ID, rating: 4 } },
       },
       delay: 80,
       result: {
@@ -1399,7 +1399,7 @@ describe("<LearnClient> queue prefetch", () => {
             __typename: "HandleSwipeSuccess" as const,
             response: {
               __typename: "SwipeResponse" as const,
-              performanceMode: 0,
+              performanceMode: "DIFFICULT",
               metrics: DEFAULT_METRICS,
             },
           },
@@ -1449,7 +1449,7 @@ describe("<LearnClient> queue prefetch", () => {
     const swipe = {
       request: {
         query: HandleSwipeDocument,
-        variables: { input: { cardId: "q-1", cardgroupId: CG_ID, mode: 4 } },
+        variables: { input: { cardId: "q-1", cardgroupId: CG_ID, rating: 4 } },
       },
       result: {
         data: {
@@ -1457,7 +1457,7 @@ describe("<LearnClient> queue prefetch", () => {
             __typename: "HandleSwipeSuccess" as const,
             response: {
               __typename: "SwipeResponse" as const,
-              performanceMode: 0,
+              performanceMode: "DIFFICULT",
               metrics: DEFAULT_METRICS,
             },
           },
@@ -1541,7 +1541,7 @@ describe("<LearnClient> queue prefetch", () => {
         mock: {
           request: {
             query: HandleSwipeDocument,
-            variables: { input: { cardId, cardgroupId: CG_ID, mode: 4 } },
+            variables: { input: { cardId, cardgroupId: CG_ID, rating: 4 } },
           },
           result: () => {
             called = true;
@@ -1551,7 +1551,7 @@ describe("<LearnClient> queue prefetch", () => {
                   __typename: "HandleSwipeSuccess" as const,
                   response: {
                     __typename: "SwipeResponse" as const,
-                    performanceMode: 0,
+                    performanceMode: "DIFFICULT",
                     metrics: DEFAULT_METRICS,
                   },
                 },

--- a/frontend/src/app/learn/[cardgroupId]/learn-client.tsx
+++ b/frontend/src/app/learn/[cardgroupId]/learn-client.tsx
@@ -12,6 +12,7 @@ import {
 import { AllCaughtUp } from "@/components/learn/all-caught-up";
 import { SwipeSession } from "@/components/learn/swipe-session";
 import type { LearnDisplayMode, SwipeDirection } from "@/components/learn/types";
+import { RATING_META, SWIPE_RATING } from "@/components/learn/types";
 import { ErrorBanner } from "@/components/ui/error-banner";
 import type { LearnNextDueCardsQuery } from "@/generated/graphql";
 import { getBackendErrorBanner } from "@/lib/apollo/errors";
@@ -26,15 +27,8 @@ type LearnCard = LearnNextDueCardsQuery["learnNextDueCards"][number];
  */
 export const PREFETCH_THRESHOLD = 5;
 
-function modeFromDirection(direction: SwipeDirection): 1 | 2 | 4 {
-  switch (direction) {
-    case "left":
-      return 1;
-    case "down":
-      return 2;
-    case "right":
-      return 4;
-  }
+function ratingFromDirection(direction: SwipeDirection): 1 | 2 | 4 {
+  return SWIPE_RATING[RATING_META[direction].tone];
 }
 
 type Props = {
@@ -238,7 +232,7 @@ export function LearnClient({ cardgroupId, initialCards, displayMode }: Props) {
 
   const onSwipe = useCallback(
     async (card: LearnCard, direction: SwipeDirection) => {
-      const mode = modeFromDirection(direction);
+      const rating = ratingFromDirection(direction);
       setLocalError(null);
       // Mark this card's swipe as in flight BEFORE the optimistic removal so the
       // prefetch effect (which the removal can re-fire) filters it out of any
@@ -249,7 +243,7 @@ export function LearnClient({ cardgroupId, initialCards, displayMode }: Props) {
       setCompletedCount((current) => current + 1);
 
       const result = await handleSwipe({
-        variables: { input: { cardId: card.id, cardgroupId, mode } },
+        variables: { input: { cardId: card.id, cardgroupId, rating } },
         // optimisticResponse intentionally omitted — handleSwipe can return InputValidationError
         // and Apollo v3 does not reliably roll back optimistic writes on typed GraphQL errors.
         // See .claude/rules/pagination.md § "Drop `optimisticResponse` for mutations that can
@@ -290,7 +284,7 @@ export function LearnClient({ cardgroupId, initialCards, displayMode }: Props) {
       }
 
       if (payload?.__typename === "InputValidationError") {
-        // Server rejected the swipe (stale card, cardgroup mismatch, invalid mode).
+        // Server rejected the swipe (stale card, cardgroup mismatch, invalid rating).
         // The optimistic queue advanced so learning continues, but we surface to
         // operator telemetry — repeated firing indicates a stale prefetch.
         // payload.message is omitted — it may echo user-authored card content.

--- a/frontend/src/components/learn/types.ts
+++ b/frontend/src/components/learn/types.ts
@@ -34,6 +34,19 @@ export const RATING_META: Record<SwipeDirection, { labelKey: RatingTone; tone: R
 };
 
 /**
+ * FSRS swipe rating emitted for each rating tone. The 3-step UI emits
+ * 1=Again, 2=Hard, 4=Easy and intentionally never 3=Good. Keyed by `RatingTone`
+ * so the direction→rating mapping derives from `RATING_META`
+ * (`SWIPE_RATING[RATING_META[direction].tone]`) rather than a second, parallel
+ * direction switch with bare integer literals.
+ */
+export const SWIPE_RATING: Record<RatingTone, 1 | 2 | 4> = {
+  again: 1,
+  hard: 2,
+  easy: 4,
+};
+
+/**
  * Re-export of the generated GraphQL `LearnDisplayMode` enum so the schema is
  * the single source of truth and the component layer can never drift from it.
  */

--- a/schema/swipe.graphql
+++ b/schema/swipe.graphql
@@ -3,13 +3,22 @@ input HandleSwipeInput {
   cardId: ID!
   cardgroupId: ID!
   """1=Again, 2=Hard, 4=Easy. The 3-step UI does not emit 3=Good."""
-  mode: Int!
+  rating: Int!
+}
+
+"""Performance mode inferred from the viewer's recent swipe performance, spanning DIFFICULT (weakest) to MASTERED (strongest)."""
+enum SwipePerformanceMode {
+  DIFFICULT
+  DEFAULT
+  GOOD
+  EASY
+  MASTERED
 }
 
 """Response returned by `handleSwipe` — the latest performance snapshot for the swipe flow."""
 type SwipeResponse {
-  """Performance mode for the swipe flow, expressed as an Int in the 0..4 range."""
-  performanceMode: Int!
+  """Performance mode for the swipe flow, inferred from the viewer's recent performance."""
+  performanceMode: SwipePerformanceMode!
   metrics: PerformanceMetrics!
 }
 


### PR DESCRIPTION
## Summary

The swipe-rating concept is called **rating** everywhere in the domain (`domain.Rating`), the immutable event (`SwipeRecord.Rating`), and the DB column (`swipe_records.rating`) — only the GraphQL surface called it `mode`, a legacy misnomer that also collided with the unrelated `SwipeResponse.performanceMode`. This renames `HandleSwipeInput.mode` → `rating` and replaces the flattened `performanceMode: Int!` (which forced clients to hard-code magic numbers) with a real `SwipePerformanceMode` enum. `HandleSwipeInput.rating` deliberately stays `Int!` (the 3-step UI emits only 1/2/4 and never 3=Good, so an enum there would be awkward). No DB column or `SwipeRecord.Rating` change.

## Changes

- **schema** (`schema/swipe.graphql`): `HandleSwipeInput.mode` → `rating`; add `enum SwipePerformanceMode { DIFFICULT DEFAULT GOOD EASY MASTERED }` (aligned to `service.PerformanceMode` 0..4); retype `SwipeResponse.performanceMode` to that enum.
- **backend**: regenerated gqlgen; resolver `Mode: input.Mode` → `Rating: input.Rating`; `usecase.HandleSwipeInput.Mode` → `.Rating`; new `toSwipePerformanceModeModel` int→enum mapper in `mapper.go`; renamed `domain.RatingFromSwipeMode` → `RatingFromSwipe`; validation field/message `mode` → `rating`.
- **frontend**: regenerated codegen; `modeFromDirection` → `ratingFromDirection`, now derived from the shared `RATING_META` tone via a new `SWIPE_RATING = { again: 1, hard: 2, easy: 4 }` constant (so the direction→rating mappings share one source instead of bare integer literals); the single `handleSwipe` call site and its test mocks use `rating`; `performanceMode` mocks use the enum value.
- **tests**: backend swipe unit/resolver/integration tests and the frontend learn-client tests updated to the new field name, enum value, and validation field.

## Test plan

- Backend: `go build ./...`, `go vet ./...`, `go tool go-arch-lint check` and unit tests pass; testcontainers integration tests run in CI (Docker unavailable locally — packages compile).
- Frontend: `tsc --noEmit`, `biome check --error-on-warnings`, `vitest run` (1826 passed), `next build`, and `knip` pass; `pnpm lint:schema` passes.

Closes #861
