### PR TITLE
refactor(frontend): finish catalog card/deck vocabulary — rename CatalogCardFields fragment and CatalogCard component

### DIFF
--- a/docs/frontend/typescript-conventions/shared-presentational-component-sibling-over-layout-variant.md
+++ b/docs/frontend/typescript-conventions/shared-presentational-component-sibling-over-layout-variant.md
@@ -59,12 +59,12 @@ on the right axes:
 ## Worked example
 
 `CatalogListItem` (`frontend/src/app/catalog/catalog-list-item.tsx`) is a sibling
-of `CatalogCard` (`frontend/src/app/catalog/catalog-card.tsx`). Both unmask the
-`CatalogCardFields` fragment (`frontend/src/app/catalog/queries.ts`) and accept
+of `CatalogDeckTile` (`frontend/src/app/catalog/catalog-card.tsx`). Both unmask the
+`CatalogDeckFields` fragment (`frontend/src/app/catalog/queries.ts`) and accept
 `{ node, importing, imported, onImport, labels?, testIdPrefix? }`.
 `CatalogListItem` renders the `/catalog` list row (mirroring `AdminMasterRow`);
-`CatalogCard` keeps its fixed-width tile layout for the `/onboarding/start`
+`CatalogDeckTile` keeps its fixed-width tile layout for the `/onboarding/start`
 deck chooser. The `/catalog` migration from a card grid to a list changed only
-the catalog call site and the new sibling — `CatalogCard` and `/onboarding/start`
+the catalog call site and the new sibling — `CatalogDeckTile` and `/onboarding/start`
 were never touched. The Import `<Button>` block is duplicated between the two on
 purpose; a reviewer accepted that as the cost of leaving the shared tile intact.

--- a/frontend/__tests__/catalog-deck.test.tsx
+++ b/frontend/__tests__/catalog-deck.test.tsx
@@ -60,7 +60,7 @@ import { notFound, redirect } from "next/navigation";
 import { NextIntlClientProvider } from "next-intl";
 import CatalogDeckPage, { CatalogDeckContent } from "@/app/catalog/[id]/page";
 import { CatalogListItem } from "@/app/catalog/catalog-list-item";
-import { CatalogCardFieldsFragment } from "@/app/catalog/queries";
+import { CatalogDeckFieldsFragment } from "@/app/catalog/queries";
 import { makeFragmentData } from "@/generated/fragment-masking";
 import { gqlFetch } from "@/lib/apollo/server";
 import enMessages from "../messages/en.json";
@@ -266,7 +266,7 @@ describe("catalog list → deck-detail entry point", () => {
         description: null,
         cardCount: 42,
       },
-      CatalogCardFieldsFragment,
+      CatalogDeckFieldsFragment,
     );
 
     render(

--- a/frontend/src/app/catalog/_components/catalog-import-button.tsx
+++ b/frontend/src/app/catalog/_components/catalog-import-button.tsx
@@ -30,7 +30,7 @@ export type CatalogImportButtonProps = {
 };
 
 /**
- * The Import CTA shared by `CatalogCard` (full-width tile button) and
+ * The Import CTA shared by `CatalogDeckTile` (full-width tile button) and
  * `CatalogListItem` (right-aligned inline button). Owns the three-state label
  * derivation and the imported / in-flight / idle rendering so the two layouts
  * cannot drift. The locale-independent `data-testid` (`catalog-import-{id}`) lets

--- a/frontend/src/app/catalog/catalog-card.test.tsx
+++ b/frontend/src/app/catalog/catalog-card.test.tsx
@@ -2,10 +2,10 @@
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
-import { CatalogCardFieldsFragment } from "@/app/catalog/queries";
+import { CatalogDeckFieldsFragment } from "@/app/catalog/queries";
 import { makeFragmentData } from "@/generated/fragment-masking";
 import { renderWithIntl } from "@/test/render-with-intl";
-import { CatalogCard } from "./catalog-card";
+import { CatalogDeckTile } from "./catalog-card";
 
 // `makeFragmentData` is identity at runtime, so the wrapped object still carries
 // every field the component reads via `useFragment`; the wrap only supplies the
@@ -18,7 +18,7 @@ const FULL_NODE = makeFragmentData(
     description: "Professional vocabulary",
     cardCount: 42,
   },
-  CatalogCardFieldsFragment,
+  CatalogDeckFieldsFragment,
 );
 
 const BARE_NODE = makeFragmentData(
@@ -29,13 +29,13 @@ const BARE_NODE = makeFragmentData(
     description: null,
     cardCount: 100,
   },
-  CatalogCardFieldsFragment,
+  CatalogDeckFieldsFragment,
 );
 
-describe("<CatalogCard>", () => {
+describe("<CatalogDeckTile>", () => {
   it("renders name, description, and card count", () => {
     renderWithIntl(
-      <CatalogCard node={FULL_NODE} importing={false} imported={false} onImport={vi.fn()} />,
+      <CatalogDeckTile node={FULL_NODE} importing={false} imported={false} onImport={vi.fn()} />,
     );
 
     expect(screen.getByText("Business English")).toBeInTheDocument();
@@ -45,7 +45,7 @@ describe("<CatalogCard>", () => {
 
   it("omits the description when it is null", () => {
     renderWithIntl(
-      <CatalogCard node={BARE_NODE} importing={false} imported={false} onImport={vi.fn()} />,
+      <CatalogDeckTile node={BARE_NODE} importing={false} imported={false} onImport={vi.fn()} />,
     );
 
     expect(screen.getByText("JLPT N3 Kanji")).toBeInTheDocument();
@@ -54,7 +54,7 @@ describe("<CatalogCard>", () => {
 
   it("disables the button and shows the in-flight label while importing", () => {
     renderWithIntl(
-      <CatalogCard node={FULL_NODE} importing={true} imported={false} onImport={vi.fn()} />,
+      <CatalogDeckTile node={FULL_NODE} importing={true} imported={false} onImport={vi.fn()} />,
     );
 
     const btn = screen.getByTestId("catalog-import-m-1");
@@ -64,7 +64,7 @@ describe("<CatalogCard>", () => {
 
   it("disables the button and shows the imported label once imported", () => {
     renderWithIntl(
-      <CatalogCard node={FULL_NODE} importing={false} imported={true} onImport={vi.fn()} />,
+      <CatalogDeckTile node={FULL_NODE} importing={false} imported={true} onImport={vi.fn()} />,
     );
 
     const btn = screen.getByTestId("catalog-import-m-1");
@@ -76,7 +76,7 @@ describe("<CatalogCard>", () => {
     const user = userEvent.setup();
     const onImport = vi.fn();
     renderWithIntl(
-      <CatalogCard node={FULL_NODE} importing={false} imported={false} onImport={onImport} />,
+      <CatalogDeckTile node={FULL_NODE} importing={false} imported={false} onImport={onImport} />,
     );
 
     await user.click(screen.getByTestId("catalog-import-m-1"));
@@ -86,7 +86,7 @@ describe("<CatalogCard>", () => {
 
   it("uses custom labels and a custom testId prefix when provided", () => {
     renderWithIntl(
-      <CatalogCard
+      <CatalogDeckTile
         node={FULL_NODE}
         importing={false}
         imported={false}

--- a/frontend/src/app/catalog/catalog-card.tsx
+++ b/frontend/src/app/catalog/catalog-card.tsx
@@ -3,13 +3,13 @@
 import { useTranslations } from "next-intl";
 import type { CSSProperties } from "react";
 import { CatalogImportButton } from "@/app/catalog/_components/catalog-import-button";
-import { CatalogCardFieldsFragment } from "@/app/catalog/queries";
+import { CatalogDeckFieldsFragment } from "@/app/catalog/queries";
 import { type FragmentType, useFragment } from "@/generated/fragment-masking";
 import { cn } from "@/lib/utils";
 
-export type CatalogCardProps = {
-  /** A masked `CatalogCardFields` ref — unmasked once via `useFragment` below. */
-  node: FragmentType<typeof CatalogCardFieldsFragment>;
+export type CatalogDeckTileProps = {
+  /** A masked `CatalogDeckFields` ref — unmasked once via `useFragment` below. */
+  node: FragmentType<typeof CatalogDeckFieldsFragment>;
   /** True while this cardgroup's import mutation is in flight. */
   importing: boolean;
   /** True once this cardgroup has been imported in the current session. */
@@ -35,7 +35,7 @@ export type CatalogCardProps = {
  * locale-independent `data-testid` (`catalog-import-{id}`) so e2e — which runs in
  * the ja-JP locale — can target it without depending on translated copy.
  */
-export function CatalogCard({
+export function CatalogDeckTile({
   node,
   importing,
   imported,
@@ -44,9 +44,9 @@ export function CatalogCard({
   testIdPrefix,
   className,
   style,
-}: CatalogCardProps) {
+}: CatalogDeckTileProps) {
   const t = useTranslations("Catalog");
-  const deck = useFragment(CatalogCardFieldsFragment, node);
+  const deck = useFragment(CatalogDeckFieldsFragment, node);
 
   return (
     <li

--- a/frontend/src/app/catalog/catalog-list-item.test.tsx
+++ b/frontend/src/app/catalog/catalog-list-item.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 import { screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import { CatalogCardFieldsFragment } from "@/app/catalog/queries";
+import { CatalogDeckFieldsFragment } from "@/app/catalog/queries";
 import { makeFragmentData } from "@/generated/fragment-masking";
 import { renderWithIntl } from "@/test/render-with-intl";
 import { CatalogListItem } from "./catalog-list-item";
@@ -17,7 +17,7 @@ const FULL_NODE = makeFragmentData(
     description: "Professional vocabulary",
     cardCount: 1245,
   },
-  CatalogCardFieldsFragment,
+  CatalogDeckFieldsFragment,
 );
 
 const BARE_NODE = makeFragmentData(
@@ -28,7 +28,7 @@ const BARE_NODE = makeFragmentData(
     description: null,
     cardCount: 100,
   },
-  CatalogCardFieldsFragment,
+  CatalogDeckFieldsFragment,
 );
 
 function renderItem(node: typeof FULL_NODE) {
@@ -62,7 +62,7 @@ describe("<CatalogListItem>", () => {
         description: null,
         cardCount: 1,
       },
-      CatalogCardFieldsFragment,
+      CatalogDeckFieldsFragment,
     );
     renderWithIntl(
       <ul>

--- a/frontend/src/app/catalog/catalog-list-item.tsx
+++ b/frontend/src/app/catalog/catalog-list-item.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useTranslations } from "next-intl";
-import { CatalogCardFieldsFragment } from "@/app/catalog/queries";
+import { CatalogDeckFieldsFragment } from "@/app/catalog/queries";
 import { type FragmentType, useFragment } from "@/generated/fragment-masking";
 
 /**
@@ -11,8 +11,8 @@ import { type FragmentType, useFragment } from "@/generated/fragment-masking";
  * interactive element; all actions (e.g. Import) belong on the detail page.
  */
 export type CatalogListItemProps = {
-  /** A masked `CatalogCardFields` ref — unmasked once via `useFragment` below. */
-  node: FragmentType<typeof CatalogCardFieldsFragment>;
+  /** A masked `CatalogDeckFields` ref — unmasked once via `useFragment` below. */
+  node: FragmentType<typeof CatalogDeckFieldsFragment>;
 };
 
 /**
@@ -28,7 +28,7 @@ export type CatalogListItemProps = {
  */
 export function CatalogListItem({ node }: CatalogListItemProps) {
   const t = useTranslations("Catalog");
-  const deck = useFragment(CatalogCardFieldsFragment, node);
+  const deck = useFragment(CatalogDeckFieldsFragment, node);
 
   return (
     <li>

--- a/frontend/src/app/catalog/queries.ts
+++ b/frontend/src/app/catalog/queries.ts
@@ -22,7 +22,7 @@ export const CATALOG_DEFAULT_VARS: MasterCatalogQueryVariables = {
 
 /**
  * The `MasterCardgroup` field set shared by the catalog list row
- * ({@link CatalogListItem}), the onboarding chooser tile ({@link CatalogCard}),
+ * ({@link CatalogListItem}), the onboarding chooser tile ({@link CatalogDeckTile}),
  * and the merge-from-catalog sheet ({@link MergeFromCatalogSheet}).
  * `MasterCatalogQuery` (the /catalog list), `OnboardingStartQuery` (the
  * /onboarding/start chooser), and the merge sheet's inline `MasterCatalog` query
@@ -30,8 +30,8 @@ export const CATALOG_DEFAULT_VARS: MasterCatalogQueryVariables = {
  * instead of hand-mirrored node selections that can silently drift. Each consumer
  * unmasks it via `useFragment`.
  */
-export const CatalogCardFieldsFragment = graphql(`
-  fragment CatalogCardFields on MasterCardgroup {
+export const CatalogDeckFieldsFragment = graphql(`
+  fragment CatalogDeckFields on MasterCardgroup {
     id
     name
     description
@@ -62,7 +62,7 @@ export const MasterCatalogQuery = graphql(`
         cursor
         node {
           id
-          ...CatalogCardFields
+          ...CatalogDeckFields
         }
       }
       pageInfo {

--- a/frontend/src/app/onboarding/start/onboarding-start-client.test.tsx
+++ b/frontend/src/app/onboarding/start/onboarding-start-client.test.tsx
@@ -2,7 +2,7 @@
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { CatalogCardFieldsFragment } from "@/app/catalog/queries";
+import { CatalogDeckFieldsFragment } from "@/app/catalog/queries";
 import type { ImportMasterOutcome } from "@/app/catalog/use-import-master";
 import { makeFragmentData } from "@/generated/fragment-masking";
 import { renderWithIntl } from "@/test/render-with-intl";
@@ -39,7 +39,7 @@ vi.mock("./use-seed-default-starters", () => ({
 }));
 
 // Each cardgroup carries a top-level `id` (read for React keys + per-cardgroup `importing`
-// state) plus a masked `CatalogCardFields` ref the chooser hands to `CatalogCard`
+// state) plus a masked `CatalogDeckFields` ref the chooser hands to `CatalogDeckTile`
 // — mirroring the `OnboardingStartQuery` node shape. `makeFragmentData` is
 // identity at runtime, so the card's `useFragment` still sees every field.
 const M1_FIELDS = {
@@ -59,8 +59,8 @@ const M2_FIELDS = {
 };
 
 const CARDGROUPS = [
-  { id: M1_FIELDS.id, ...makeFragmentData(M1_FIELDS, CatalogCardFieldsFragment) },
-  { id: M2_FIELDS.id, ...makeFragmentData(M2_FIELDS, CatalogCardFieldsFragment) },
+  { id: M1_FIELDS.id, ...makeFragmentData(M1_FIELDS, CatalogDeckFieldsFragment) },
+  { id: M2_FIELDS.id, ...makeFragmentData(M2_FIELDS, CatalogDeckFieldsFragment) },
 ];
 
 beforeEach(() => {

--- a/frontend/src/app/onboarding/start/onboarding-start-client.tsx
+++ b/frontend/src/app/onboarding/start/onboarding-start-client.tsx
@@ -3,8 +3,8 @@
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { type CSSProperties, useCallback, useState } from "react";
-import { CatalogCard } from "@/app/catalog/catalog-card";
-import type { CatalogCardFieldsFragment } from "@/app/catalog/queries";
+import { CatalogDeckTile } from "@/app/catalog/catalog-card";
+import type { CatalogDeckFieldsFragment } from "@/app/catalog/queries";
 import { useImportMaster } from "@/app/catalog/use-import-master";
 import { OnboardingShell } from "@/components/onboarding/onboarding-shell";
 import { BrandSplash } from "@/components/pwa/brand-splash";
@@ -15,9 +15,9 @@ import type { FragmentType } from "@/generated/fragment-masking";
 import { useSeedDefaultStarters } from "./use-seed-default-starters";
 
 // `id` is read at this level (React keys, per-cardgroup `importing` state); the
-// rest of the fields travel as a masked `CatalogCardFields` ref that `CatalogCard`
+// rest of the fields travel as a masked `CatalogDeckFields` ref that `CatalogDeckTile`
 // unmasks — the same fragment the /catalog gallery feeds it.
-type MasterCardgroupNode = { id: string } & FragmentType<typeof CatalogCardFieldsFragment>;
+type MasterCardgroupNode = { id: string } & FragmentType<typeof CatalogDeckFieldsFragment>;
 
 interface OnboardingStartClientProps {
   cardgroups: MasterCardgroupNode[];
@@ -152,7 +152,7 @@ export function OnboardingStartClient({ cardgroups }: OnboardingStartClientProps
               data-testid="onboarding-deck-list"
             >
               {cardgroups.map((node, index) => (
-                <CatalogCard
+                <CatalogDeckTile
                   key={node.id}
                   node={node}
                   importing={importingId === node.id}

--- a/frontend/src/app/onboarding/start/queries.ts
+++ b/frontend/src/app/onboarding/start/queries.ts
@@ -16,7 +16,7 @@ export const OnboardingStartQuery = graphql(`
         cursor
         node {
           id
-          ...CatalogCardFields
+          ...CatalogDeckFields
         }
       }
       totalCount

--- a/frontend/src/components/cardgroups/merge-from-catalog-sheet.tsx
+++ b/frontend/src/components/cardgroups/merge-from-catalog-sheet.tsx
@@ -6,7 +6,7 @@ import { useTranslations } from "next-intl";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useMergeFromCatalog } from "@/app/cardgroups/[id]/use-merge-from-catalog";
 import { useMergeFromCatalogPreview } from "@/app/cardgroups/[id]/use-merge-from-catalog-preview";
-import { CATALOG_DEFAULT_VARS, CatalogCardFieldsFragment } from "@/app/catalog/queries";
+import { CATALOG_DEFAULT_VARS, CatalogDeckFieldsFragment } from "@/app/catalog/queries";
 import { MergeReviewPanel } from "@/components/cardgroups/merge-review-panel";
 import { ConnectionListFooter } from "@/components/layout/connection-list-footer";
 import { ErrorBanner } from "@/components/ui/error-banner";
@@ -143,8 +143,8 @@ export function MergeFromCatalogSheet({
   });
 
   const initialLoading = loading && edges.length === 0 && networkStatus !== NetworkStatus.fetchMore;
-  const catalogCards = useFragment(
-    CatalogCardFieldsFragment,
+  const decks = useFragment(
+    CatalogDeckFieldsFragment,
     edges.map((edge) => edge.node),
   );
   const queryBannerError = getBackendErrorBanner(queryError);
@@ -274,20 +274,20 @@ export function MergeFromCatalogSheet({
 
           {edges.length > 0 ? (
             <ul className="divide-y divide-border" data-testid="merge-from-catalog-list">
-              {catalogCards.map((card) => (
-                <li key={card.id}>
+              {decks.map((deck) => (
+                <li key={deck.id}>
                   <button
                     type="button"
-                    onClick={() => void handleSelect(card.id, card.name)}
+                    onClick={() => void handleSelect(deck.id, deck.name)}
                     className="flex w-full items-center justify-between gap-3 py-3 text-left hover:bg-muted/40"
-                    data-testid={`merge-from-catalog-row-${card.id}`}
+                    data-testid={`merge-from-catalog-row-${deck.id}`}
                   >
                     <span className="min-w-0">
                       <span className="block truncate text-sm font-medium text-foreground">
-                        {card.name}
+                        {deck.name}
                       </span>
                       <span className="block text-xs text-muted-foreground">
-                        {tCatalog("cardCount", { count: card.cardCount })}
+                        {tCatalog("cardCount", { count: deck.cardCount })}
                       </span>
                     </span>
                     <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" />

--- a/frontend/src/lib/apollo/server.test.ts
+++ b/frontend/src/lib/apollo/server.test.ts
@@ -62,7 +62,7 @@ describe("gqlFetch", () => {
     await gqlFetch(MasterCatalogDocument, { variables: { first: 20, search: null } });
 
     const body = JSON.parse((fetchSpy.mock.calls[0]?.[1] as RequestInit).body as string);
-    // The MasterCatalog node selection spreads `...CatalogCardFields on MasterCardgroup`,
+    // The MasterCatalog node selection spreads `...CatalogDeckFields on MasterCardgroup`,
     // a type-conditioned fragment the cache cannot resolve without __typename.
     expect(body.query).toContain("__typename");
   });


### PR DESCRIPTION
## Summary

Finishes the catalog card/deck vocabulary cleanup started in #850. A `MasterCardgroup` (a deck) was still called a "card" in the shared GraphQL fragment, the onboarding chooser tile component, and the merge-sheet locals. Because `/catalog/[id]` renders real `Card`s, the `CatalogCard*` names collided with the genuine catalog-card concept. This renames the deck-level identifiers to deck vocabulary; the real-card connection identifiers under `/catalog/[id]` are deliberately left untouched.

## Changes

- Fragment `CatalogCardFields` → `CatalogDeckFields` (export const `CatalogCardFieldsFragment` → `CatalogDeckFieldsFragment`); updated both `...CatalogCardFields` spreads (`MasterCatalog` + `OnboardingStart` queries) and every importer.
- Component `CatalogCard` → `CatalogDeckTile` (props type `CatalogCardProps` → `CatalogDeckTileProps`); updated the `/onboarding/start` call site.
- Merge-from-catalog sheet locals `catalogCards` → `decks`, `card` → `deck` (rendered `data-testid` values unchanged — only the interpolated local variable name changed).
- Regenerated GraphQL codegen; refreshed stale symbol references in the sibling-component doc and a `server.test.ts` comment.

## Test plan

- `pnpm --filter frontend typecheck` — pass
- `pnpm --filter frontend lint` (biome, `--error-on-warnings`) — pass
- `pnpm --filter frontend test` — 1826 tests / 195 files pass
- `pnpm --filter frontend build` — pass
- `pnpm --filter frontend knip` — pass
- `grep -rn 'CatalogCardFields' frontend/src` — no results (old name fully removed)

Closes #862
