### PR TITLE
refactor(backend): delete dead gqlerr.BadUserInputWithExtensions (0 callers)

### DIFF
--- a/.claude/rules/error-wrapping.md
+++ b/.claude/rules/error-wrapping.md
@@ -62,7 +62,7 @@ detection is grep-based today and pinned at single-file
 - [Sentinel layering: when to join with `errors.Join` and when to keep standalone](../../docs/backend/error-wrapping/sentinel-layering.md)
 - [Postgres FK violation classification (`23503`)](../../docs/backend/error-wrapping/postgres-fk-violation-23503.md)
 - [Postgres unique-violation classification (`23505`)](../../docs/backend/error-wrapping/postgres-unique-violation-23505.md)
-- [Two-tier API pattern: open primitive + strict/typed wrapper (`gqlerr`, env-config)](../../docs/backend/error-wrapping/two-tier-api-pattern.md)
+- [Two-tier API pattern: open primitive + strict/typed wrapper (env-config reader)](../../docs/backend/error-wrapping/two-tier-api-pattern.md)
 
 ## Logging — detailed cases (on-demand)
 
@@ -75,7 +75,7 @@ detection is grep-based today and pinned at single-file
 
 ## Errors as data — detailed cases (on-demand)
 
-- [Result Union: "errors as data" pattern — when to use `CreateCardResult`-style unions over `BadUserInputWithExtensions`](../../docs/backend/error-wrapping/result-union-errors-as-data.md)
+- [Result Union: "errors as data" pattern — when to use `CreateCardResult`-style unions for structured business failures](../../docs/backend/error-wrapping/result-union-errors-as-data.md)
 - [Outcome-union enforcement: schema-lint gate forbidding new bare-object mutations that emit typed `ucerr.*` variants](../../docs/backend/error-wrapping/outcome-union-enforcement.md)
 - [`NewInputValidationInfo` panics on empty `Field` — mirror the `ucerr.NewValidationError` invariant](../../docs/backend/error-wrapping/input-validation-info-empty-field-panic.md)
 - [Inverse `lower*` helper when a shared error classifier serves both promoted and unpromoted callers](../../docs/backend/error-wrapping/inverse-helper-for-partial-promotion.md)

--- a/backend/internal/gqlerr/errors.go
+++ b/backend/internal/gqlerr/errors.go
@@ -39,35 +39,6 @@ func BadUserInput(field, message string) *gqlerror.Error {
 	}
 }
 
-// BadUserInputWithExtensions returns a BAD_USER_INPUT error with additional
-// extensions merged into the standard {code, field} envelope. Reserved keys
-// (code, field) in extra are ignored to keep the envelope stable.
-//
-// The design places variant-specific data under an extensions.reason
-// sub-discriminator rather than a separate top-level code so that
-// IsCode(err, CodeBadUserInput) and existing field-error UI keep working without
-// modification. Reach for this helper — rather than BadUserInput — when the
-// payload needs to be structurally parsed by the frontend (e.g. to surface an
-// existing duplicate entity). For plain field validation messages, BadUserInput
-// is sufficient.
-//
-// Current callers: none. Retained as a primitive for future structured
-// BAD_USER_INPUT shapes; the previous caller BadUserInputCardDuplicateFront
-// was removed when CardDuplicateFrontError moved to the CreateCardResult union.
-func BadUserInputWithExtensions(field, message string, extra map[string]any) *gqlerror.Error {
-	ext := map[string]any{
-		"code":  string(CodeBadUserInput),
-		"field": field,
-	}
-	for k, v := range extra {
-		if k == "code" || k == "field" {
-			continue
-		}
-		ext[k] = v
-	}
-	return &gqlerror.Error{Message: message, Extensions: ext}
-}
-
 // Internal logs err at ERROR level and returns a generic INTERNAL gqlerror. The
 // optional attrs are attached to the log line only — the wire response is always
 // the same {code: INTERNAL, message: "internal server error"} shape. Use attrs

--- a/backend/internal/gqlerr/errors_test.go
+++ b/backend/internal/gqlerr/errors_test.go
@@ -50,56 +50,6 @@ func TestBadUserInput(t *testing.T) {
 	}
 }
 
-func TestBadUserInputWithExtensions(t *testing.T) {
-	t.Parallel()
-
-	t.Run("merges extra keys", func(t *testing.T) {
-		t.Parallel()
-		got := gqlerr.BadUserInputWithExtensions("front", "duplicate card", map[string]any{
-			"reason":         "CARD_DUPLICATE_FRONT",
-			"existingCardId": "abc-123",
-		})
-
-		if got.Message != "duplicate card" {
-			t.Errorf("Message = %q, want %q", got.Message, "duplicate card")
-		}
-		if code := extString(t, got, "code"); code != "BAD_USER_INPUT" {
-			t.Errorf("Extensions[code] = %q, want %q", code, "BAD_USER_INPUT")
-		}
-		if field := extString(t, got, "field"); field != "front" {
-			t.Errorf("Extensions[field] = %q, want %q", field, "front")
-		}
-		if reason := extString(t, got, "reason"); reason != "CARD_DUPLICATE_FRONT" {
-			t.Errorf("Extensions[reason] = %q, want %q", reason, "CARD_DUPLICATE_FRONT")
-		}
-		if id := extString(t, got, "existingCardId"); id != "abc-123" {
-			t.Errorf("Extensions[existingCardId] = %q, want %q", id, "abc-123")
-		}
-	})
-
-	t.Run("ignores reserved code override", func(t *testing.T) {
-		t.Parallel()
-		got := gqlerr.BadUserInputWithExtensions("front", "duplicate card", map[string]any{
-			"code": "OVERRIDE",
-		})
-
-		if code := extString(t, got, "code"); code != "BAD_USER_INPUT" {
-			t.Errorf("Extensions[code] = %q, want %q (override must be ignored)", code, "BAD_USER_INPUT")
-		}
-	})
-
-	t.Run("ignores reserved field override", func(t *testing.T) {
-		t.Parallel()
-		got := gqlerr.BadUserInputWithExtensions("front", "duplicate card", map[string]any{
-			"field": "hijacked",
-		})
-
-		if field := extString(t, got, "field"); field != "front" {
-			t.Errorf("Extensions[field] = %q, want %q (override must be ignored)", field, "front")
-		}
-	})
-}
-
 func TestInternal_message(t *testing.T) {
 	t.Parallel()
 

--- a/docs/backend/error-wrapping/result-union-errors-as-data.md
+++ b/docs/backend/error-wrapping/result-union-errors-as-data.md
@@ -7,12 +7,12 @@ frontend must branch on and render actionable UI for — as named members of a
 GraphQL union rather than as top-level `gqlerror` entries. The live example is
 `createCard`, which returns `CreateCardResult = CreateCardSuccess | CardDuplicateFrontError`.
 
-## When to use Result Union vs. `BadUserInputWithExtensions`
+## When to use Result Union vs. a plain `BadUserInput` error
 
 | Situation | Preferred approach |
 |---|---|
 | Frontend needs typed, structured data to drive UX (e.g. "overwrite existing card?" dialog showing `existingBack`) | Result Union (`CreateCardResult`) |
-| Plain field-validation failure where the frontend treats all cases uniformly (e.g. "front is required") | `BadUserInputWithExtensions` (see [`two-tier-api-pattern.md`](./two-tier-api-pattern.md)) |
+| Plain field-validation failure where the frontend treats all cases uniformly (e.g. "front is required") | A plain `gqlerr.BadUserInput(field, message)` error (`ucerr.NewValidationError` from the usecase layer) |
 
 The discriminator question: does the client need the variant's payload to make
 a meaningful UX decision? If yes, encode the outcome in the schema — the codegen
@@ -133,8 +133,7 @@ if (payload?.__typename === "CardDuplicateFrontError") {
 // happy path: payload.__typename === "CreateCardSuccess"
 ```
 
-The `extensions.code` / `extensions.reason` approach (described in
-[`two-tier-api-pattern.md`](./two-tier-api-pattern.md)) is not needed when the
+The `extensions.code` / `extensions.reason` approach is not needed when the
 discriminator comes directly from the schema. Do not add extension-code parsing
 helpers for cases already expressed as union variants — codegen provides the
 type safety those helpers tried to recover by hand.
@@ -149,8 +148,8 @@ type safety those helpers tried to recover by hand.
 | Client coupling | Switches on `__typename` — no shared constant needed | Client and server must agree on the exact `reason` string |
 
 Prefer Result Union when the variant set is small and schema-driven. Fall back
-to `BadUserInputWithExtensions` when a full union type would be disproportionate
-(e.g. a single optional extra field on an otherwise uniform validation error).
+to a plain `gqlerr.BadUserInput` error when a full union type would be
+disproportionate (e.g. an otherwise uniform validation error).
 
 ## Enforcement
 

--- a/docs/backend/error-wrapping/two-tier-api-pattern.md
+++ b/docs/backend/error-wrapping/two-tier-api-pattern.md
@@ -2,19 +2,7 @@
 
 > Part of the [error wrapping convention](../../../.claude/rules/error-wrapping.md) rules.
 
-Several places in the backend expose a shared shape: an **open, general-purpose primitive** for one-off cases, paired with a **strict or typed wrapper** that bakes the conventional decision (a specific error message, a fixed extension key, an all-or-nothing contract) into one place. The wrapper compile-checks the call site and keeps the convention in exactly one location; the primitive lets new variants land without extending the wrapper first. The two worked examples below show the pattern in two unrelated subsystems.
-
-## Worked example: `gqlerr` open helper + typed wrapper
-
-When a `BAD_USER_INPUT` error needs to carry a structured payload beyond the standard `{code, field}` envelope (e.g. an existing entity's ID and a preview field for the frontend to display), use two layers:
-
-1. **Generic open helper** — `BadUserInputWithExtensions(field, message string, extra map[string]any)` accepts any extension map. Use it for new one-off cases.
-2. **Domain-specific typed wrapper** — once a call site stabilises, wrap the generic helper in a named function so the call site is compile-checked and the extension keys are assembled in one place.
-3. **Typed reason constant** — pair the wrapper with a typed string constant so the discriminator string the frontend branches on lives in exactly one place and is never stringly-typed at the call site.
-
-The frontend discriminates on `extensions.reason` (a sub-key), not on `extensions.code`. This keeps the top-level `code` as the coarse class (`BAD_USER_INPUT`) so existing `IsCode` matchers and field-error UI keep working without modification.
-
-`BadUserInputWithExtensions` is the current primitive for this pattern (see `backend/internal/gqlerr/errors.go`). When domain variants are instead representable as schema-level union members (e.g. `createCard` returns `CreateCardResult = CreateCardSuccess | CardDuplicateFrontError`), prefer the union approach — the `__typename` discriminator is checked by the client directly, so no extensions-based reason constant is needed.
+Several places in the backend expose a shared shape: an **open, general-purpose primitive** for one-off cases, paired with a **strict or typed wrapper** that bakes the conventional decision (a specific error message, a fixed extension key, an all-or-nothing contract) into one place. The wrapper compile-checks the call site and keeps the convention in exactly one location; the primitive lets new variants land without extending the wrapper first. The worked example below shows the pattern in one such subsystem.
 
 ## Worked example: optional env-config reader + strict wrapper
 


### PR DESCRIPTION
## Summary

`gqlerr.BadUserInputWithExtensions` had zero non-test callers — its docstring self-declared "Current callers: none". Its last caller was removed when `CardDuplicateFrontError` moved to the `CreateCardResult` union. Per the repo's YAGNI rules (`scope-discipline.md` "helpers introduced but never wired" and `ddd-patterns.md` "helpers introduced but not wired must be deleted"), this unwired exported wire-format helper is discoverable dead surface a contributor might reach for instead of the union pattern, so it is removed.

## Changes

- Delete `BadUserInputWithExtensions` and its docstring from `backend/internal/gqlerr/errors.go`.
- Delete the pinning test `TestBadUserInputWithExtensions` from `backend/internal/gqlerr/errors_test.go`.
- Reconcile the docs/rules that named the deleted symbol (required by `language-policy.md`'s post-refactor grep over `docs/` and `.claude/rules/`, and because these were the discoverable surface pointing at the dead helper):
  - `docs/backend/error-wrapping/two-tier-api-pattern.md`: removed the obsolete `gqlerr` open-helper worked example (its subject no longer exists; no replacement open-with-extensions primitive remains) and kept the still-valid env-config reader example.
  - `docs/backend/error-wrapping/result-union-errors-as-data.md`: retargeted the "Result Union vs." comparison to the live `gqlerr.BadUserInput` / `ucerr.NewValidationError` path and dropped the now-dangling cross-reference to the removed two-tier section.
  - `.claude/rules/error-wrapping.md`: updated the two on-demand link titles that named the deleted symbol / the removed worked example.

## Test plan

- `grep -rn 'BadUserInputWithExtensions' backend/` → 0 matches (also 0 across `docs/`, `.claude/rules/`, `frontend/`).
- `go build ./...` → Success; `go vet ./...` → no issues.
- `go tool go-arch-lint check --project-path .` → OK, no warnings.
- `go test ./...` → 1686 passed (incl. `internal/gqlerr` 26). The 5 testcontainers-backed packages are Docker-gated and skipped locally (Docker unavailable); they compile and run in CI.

Closes #863
