### PR TITLE
refactor(frontend): consolidate duplicated AuthKind / ValidationError types onto shared definitions

### DIFF
--- a/frontend/src/app/admin/masters/use-master-mutations.ts
+++ b/frontend/src/app/admin/masters/use-master-mutations.ts
@@ -6,7 +6,7 @@ import {
   prependConnectionEdge,
   removeConnectionEdgeAcrossVariants,
 } from "@/lib/apollo/connection-cache";
-import { classifyAndLogAuthOutcome } from "@/lib/apollo/errors";
+import { classifyAndLogAuthOutcome, type MutationAuthKind } from "@/lib/apollo/errors";
 import type { MasterFormValues } from "./admin-master-form";
 import {
   ADMIN_MASTERS_BASE_VARS,
@@ -19,7 +19,7 @@ import {
 } from "./queries";
 
 /** Auth-relevant failure kind surfaced to the caller for toast copy selection. */
-export type AuthKind = "forbidden" | "unauthenticated";
+export type AuthKind = MutationAuthKind;
 
 export type CreateMasterOutcome =
   | { status: "success"; id: string }

--- a/frontend/src/app/admin/roles/admin-roles-client.tsx
+++ b/frontend/src/app/admin/roles/admin-roles-client.tsx
@@ -12,13 +12,11 @@ import { ErrorBanner } from "@/components/ui/error-banner";
 import { FormSheet, useFormSheetClose } from "@/components/ui/form-sheet";
 import { getBackendErrorBanner } from "@/lib/apollo/errors";
 import { liftGraphQLCodes } from "@/lib/apollo/graphql-errors";
+import type { ValidationError } from "@/lib/forms/use-sheet-form";
 import { useUndoDelete } from "@/lib/undo-delete";
 import { useSheetSearchParam } from "@/lib/url/use-sheet-search-param";
 import { SYSTEM_ROLE_NAMES } from "./queries";
-import { useRoleMutations } from "./use-role-mutations";
-
-/** Auth banner discriminant carried by the collapsed create/edit error state. */
-type AuthKind = "unauthenticated" | "forbidden";
+import { type AuthKind, useRoleMutations } from "./use-role-mutations";
 
 /** Collapsed create-sheet banner state — one of the typed outcomes the hook returns. */
 type CreateError =
@@ -35,8 +33,6 @@ type EditError =
 export type RoleItem = { id: string; name: string };
 
 type Props = { initialRoles: RoleItem[] };
-
-type ValidationError = { field: string; message: string };
 
 function CreateRoleSheetBody({
   submitting,

--- a/frontend/src/app/admin/roles/use-role-mutations.ts
+++ b/frontend/src/app/admin/roles/use-role-mutations.ts
@@ -2,7 +2,7 @@
 
 import { useLazyQuery, useMutation } from "@apollo/client/react";
 import { useCallback } from "react";
-import { classifyAndLogAuthOutcome } from "@/lib/apollo/errors";
+import { classifyAndLogAuthOutcome, type MutationAuthKind } from "@/lib/apollo/errors";
 import {
   AdminCreateRoleMutation,
   AdminDeleteRoleMutation,
@@ -11,7 +11,7 @@ import {
 } from "./queries";
 
 /** Auth-relevant failure kind surfaced to the caller for banner copy selection. */
-export type AuthKind = "forbidden" | "unauthenticated";
+export type AuthKind = MutationAuthKind;
 
 export type CreateRoleOutcome =
   | { status: "success" }


### PR DESCRIPTION
## Summary

`type AuthKind = "unauthenticated" | "forbidden"` was re-declared in three admin modules while the canonical `MutationAuthKind` already existed in `@/lib/apollo/errors`, and `type ValidationError = { field; message }` was re-declared in `admin-roles-client.tsx` despite being exported from `@/lib/forms/use-sheet-form`. These copies drift silently if the backend ever adds an auth code. This change points every admin site at the shared definitions. No behavior change.

## Changes

- `use-role-mutations.ts` / `use-master-mutations.ts`: the exported `AuthKind` is now an alias `export type AuthKind = MutationAuthKind` (imported as a type from `@/lib/apollo/errors`), replacing the duplicated string-literal union. The public export name stays stable, so the existing `master-edit-header.tsx` importer is unaffected.
- `admin-roles-client.tsx`: removed the local `type AuthKind` and `type ValidationError` re-declarations; now imports `AuthKind` from `./use-role-mutations` (the roles feature's shared alias) and `ValidationError` from `@/lib/forms/use-sheet-form`.

`MutationAuthKind = Exclude<MutationAuthErrorKind, "other">` resolves to exactly `"forbidden" | "unauthenticated"`, identical to the removed literals, so all outcome unions and `classifyAndLogAuthOutcome<AuthKind>` call sites keep the same type.

## Test plan

- `tsc --noEmit` — pass
- `biome check --error-on-warnings .` (lint + import organize) — pass
- `knip` — pass
- `vitest run` — 195 files / 1826 tests pass
- `next build` — pass
- Acceptance greps: no standalone `type AuthKind = "…"` or `type ValidationError = …` re-declaration remains under `app/admin/**`; the only surviving `type ValidationError` is the canonical export in `lib/forms/use-sheet-form.ts`.

Closes #864
