### PR TITLE
refactor(backend): route learn authorization through the shared authorizeCardgroupOrBadInput seam

### DIFF
--- a/backend/internal/usecase/learn.go
+++ b/backend/internal/usecase/learn.go
@@ -14,7 +14,6 @@ import (
 	"backend/internal/domain"
 	"backend/internal/domain/service"
 	"backend/internal/repository"
-	"backend/internal/usecase/ucerr"
 )
 
 const (
@@ -143,18 +142,8 @@ func (u *learnUsecase) authorizeCardgroupForLearn(ctx context.Context, cardgroup
 	if err := requireCallerSub(user); err != nil {
 		return nil, err
 	}
-	cg, err := u.cardgroupRepo.FindByID(ctx, cardgroupID)
-	if err != nil {
-		if errors.Is(err, repository.ErrNotFound) {
-			return nil, ucerr.NewValidationError("cardgroupId", "cardgroup not found")
-		}
-		if isContextDone(err) {
-			return nil, err
-		}
-		return nil, eris.Wrap(err, "usecase: find cardgroup by id")
-	}
-	if !cg.IsOwnedBy(domain.UserID(user.Sub)) {
-		return nil, ucerr.ErrUnauthenticated
+	if err := authorizeCardgroupOrBadInput(ctx, u.cardgroupRepo, domain.CardgroupID(cardgroupID), domain.UserID(user.Sub)); err != nil {
+		return nil, err
 	}
 	return user, nil
 }

--- a/backend/internal/usecase/learn_test.go
+++ b/backend/internal/usecase/learn_test.go
@@ -262,7 +262,7 @@ func TestLearnUsecaseNextDueCardsCardgroupRepoInternalError(t *testing.T) {
 
 	_, err := uc.NextDueCards(authedCtx("u-1"), "cg-1", learnIntPtr(5))
 
-	assertInternalChain(t, err, "usecase: find cardgroup by id")
+	assertInternalChain(t, err, "usecase: authorize cardgroup: find by id")
 }
 
 func TestNewLearnUsecase_PanicsOnInvalidDeps(t *testing.T) {
@@ -524,7 +524,7 @@ func TestLearnUsecasePracticeTodaysCardsAuthAndCardgroupErrors(t *testing.T) {
 			now,
 		)
 		_, err := uc.PracticeTodaysCards(authedCtx("u-1"), "cg-1", learnIntPtr(5))
-		assertInternalChain(t, err, "usecase: find cardgroup by id")
+		assertInternalChain(t, err, "usecase: authorize cardgroup: find by id")
 	})
 }
 


### PR DESCRIPTION
## Summary

`learnUsecase.authorizeCardgroupForLearn` re-implemented the exact cardgroup lookup + not-found → `ValidationError("cardgroupId", …)` + non-owner → `ErrUnauthenticated` + context-done pass-through that `ownership.authorizeCardgroupOrBadInput` already owns, adding only `requireCallerSub` and returning the `*auth.AuthUser`. The two copies had already diverged (learn wrapped infra errors as `usecase: find cardgroup by id`; the canonical seam uses `usecase: authorize cardgroup: find by id`). This routes learn through the shared seam so the ownership-error contract lives in one place.

## Changes

- `backend/internal/usecase/learn.go`: `authorizeCardgroupForLearn` now calls `requireCallerSub(user)` then delegates to `authorizeCardgroupOrBadInput(ctx, u.cardgroupRepo, domain.CardgroupID(cardgroupID), domain.UserID(user.Sub))`, returning `user` on success. Removed the duplicated `FindByID` lookup, the inline not-found/non-owner branches, and the module-less `usecase: find cardgroup by id` wrap. Dropped the now-unused `usecase/ucerr` import. Same query count.
- `backend/internal/usecase/learn_test.go`: updated the two `assertInternalChain` cardgroup-infra-error assertions to the shared seam's wrap prefix `usecase: authorize cardgroup: find by id`.

## Test plan

- `go build ./...` — pass
- `go vet ./...` — pass
- `go tool go-arch-lint check --project-path .` — pass (no warnings)
- `go test ./internal/usecase/...` — pass (68 learn/practice tests, including validation-vs-unauthenticated and internal-chain assertions)
- `go test ./...` — 1690 pass; the 5 failing packages are Docker/testcontainer integration suites that soft-skip locally (no Docker) and run in CI

Closes #865
