### PR TITLE
refactor(backend): normalize usecase error-wrap prefixes to usecase: <module>: <verb>

### DIFF
--- a/backend/internal/usecase/card.go
+++ b/backend/internal/usecase/card.go
@@ -257,14 +257,14 @@ func (u *cardUsecase) Create(ctx context.Context, in CreateCardInput) (CreateCar
 				// between the failed INSERT and this SELECT) or fail for an unrelated DB
 				// reason. Either way, surface as Internal so the client can retry; the
 				// duplicate is recoverable input, but a failed re-lookup is not.
-				return CreateCardOutcome{}, eris.Wrap(lookupErr, "usecase: lookup duplicate card after 23505")
+				return CreateCardOutcome{}, eris.Wrap(lookupErr, "usecase: card: lookup duplicate after 23505")
 			}
 			return CreateCardOutcome{Duplicate: &DuplicateCardInfo{
 				ExistingID:   existing.ID,
 				ExistingBack: string(existing.Back),
 			}}, nil
 		}
-		return CreateCardOutcome{}, eris.Wrap(err, "usecase: create card: repo create")
+		return CreateCardOutcome{}, eris.Wrap(err, "usecase: card: create: repo create")
 	}
 	u.observer.OnCardCreated(ctx, card)
 	return CreateCardOutcome{Card: card}, nil
@@ -280,7 +280,7 @@ func (u *cardUsecase) Update(ctx context.Context, id string, in UpdateCardInput)
 		if errors.Is(err, repository.ErrNotFound) {
 			return UpdateCardOutcome{}, ucerr.ErrUnauthenticated
 		}
-		return UpdateCardOutcome{}, eris.Wrap(err, "usecase: update card: find by id")
+		return UpdateCardOutcome{}, eris.Wrap(err, "usecase: card: update: find by id")
 	}
 	if err := authorizeCardgroupOrUnauthenticated(ctx, u.cardgroupRepo, existing.CardgroupID, domain.UserID(user.Sub)); err != nil {
 		return UpdateCardOutcome{}, err
@@ -327,7 +327,7 @@ func (u *cardUsecase) Update(ctx context.Context, id string, in UpdateCardInput)
 
 	updated, err := u.cardRepo.Update(ctx, id, patch)
 	if err != nil {
-		return UpdateCardOutcome{}, eris.Wrap(err, "usecase: update card: repo update")
+		return UpdateCardOutcome{}, eris.Wrap(err, "usecase: card: update: repo update")
 	}
 	u.observer.OnCardUpdated(ctx, updated)
 	return UpdateCardOutcome{Card: updated}, nil
@@ -343,13 +343,13 @@ func (u *cardUsecase) Delete(ctx context.Context, id string) error {
 		if errors.Is(err, repository.ErrNotFound) {
 			return ucerr.ErrUnauthenticated
 		}
-		return eris.Wrap(err, "usecase: delete card: find by id")
+		return eris.Wrap(err, "usecase: card: delete: find by id")
 	}
 	if err := authorizeCardgroupOrUnauthenticated(ctx, u.cardgroupRepo, card.CardgroupID, domain.UserID(user.Sub)); err != nil {
 		return err
 	}
 	if err := u.cardRepo.Delete(ctx, id); err != nil {
-		return eris.Wrap(err, "usecase: delete card: repo delete")
+		return eris.Wrap(err, "usecase: card: delete: repo delete")
 	}
 	return nil
 }
@@ -398,7 +398,7 @@ func (u *cardUsecase) ListCardsByCardgroupConnection(
 				ctx, user.Sub, in.CardgroupID, after, before, wantFirst, wantLast, orderBy, dir, search,
 			)
 			if e != nil {
-				return nil, eris.Wrap(e, "usecase: list cards by cardgroup: find page")
+				return nil, eris.Wrap(e, "usecase: card: list by cardgroup: find page")
 			}
 			total = t
 			return rows, nil
@@ -457,7 +457,7 @@ func (u *cardUsecase) resolveCardCursor(
 		if errors.Is(err, repository.ErrNotFound) {
 			return nil, ucerr.NewValidationError(field, "cursor not found")
 		}
-		return nil, eris.Wrap(err, "usecase: resolve cursor: find by id")
+		return nil, eris.Wrap(err, "usecase: card: resolve cursor: find by id")
 	}
 	if !card.BelongsToCardgroup(domain.CardgroupID(cardgroupID)) {
 		return nil, ucerr.NewValidationError(field, "cursor not found")
@@ -470,7 +470,7 @@ func (u *cardUsecase) resolveCardCursor(
 		} else if user := auth.UserFrom(ctx); user != nil {
 			byCardID, err := u.userFSRSRepo.FindByUserAndCardIDs(ctx, user.Sub, []string{id})
 			if err != nil {
-				return nil, eris.Wrap(err, "usecase: resolve cursor: find user fsrs")
+				return nil, eris.Wrap(err, "usecase: card: resolve cursor: find user fsrs")
 			}
 			if ucs := byCardID[id]; ucs != nil {
 				due = ucs.State.Due
@@ -506,7 +506,7 @@ func (u *cardUsecase) BulkDelete(ctx context.Context, ids []string) (int64, erro
 	}
 
 	if u.tx == nil {
-		return 0, eris.New("usecase: tx runner not configured")
+		return 0, eris.New("usecase: card: tx runner not configured")
 	}
 	var deleted int64
 	err := u.tx(ctx, func(tx *gorm.DB) error {
@@ -518,7 +518,7 @@ func (u *cardUsecase) BulkDelete(ctx context.Context, ids []string) (int64, erro
 		return nil
 	})
 	if err != nil {
-		return 0, eris.Wrap(err, "usecase: bulk delete: transaction")
+		return 0, eris.Wrap(err, "usecase: card: bulk delete: transaction")
 	}
 	if deleted < int64(len(ids)) {
 		u.logger.LogAttrs(ctx, slog.LevelInfo, "bulk delete: partial match",

--- a/backend/internal/usecase/card_test.go
+++ b/backend/internal/usecase/card_test.go
@@ -494,7 +494,7 @@ func TestCardUsecase_Update_RepoError_InfraChannel(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error from repo, got nil")
 	}
-	assertInternalChain(t, err, "usecase: update card: repo update")
+	assertInternalChain(t, err, "usecase: card: update: repo update")
 }
 
 func TestCardUsecase_Delete_NotFoundMasksExistence(t *testing.T) {
@@ -965,7 +965,7 @@ func TestCardUsecase_Create_DuplicateLookupRace(t *testing.T) {
 
 	_, err := uc.Create(authedCtx("u1"), CreateCardInput{CardgroupID: wantCardgroupID, Front: "hello", Back: "world"})
 	// Load-bearing: eris.Wrap at the call site must produce a rich chain even for external errors.
-	assertInternalChain(t, err, "usecase: lookup duplicate card after 23505")
+	assertInternalChain(t, err, "usecase: card: lookup duplicate after 23505")
 }
 
 // TestCardUsecase_Create_DuplicateLookupRace_RowVanished exercises the documented
@@ -988,7 +988,7 @@ func TestCardUsecase_Create_DuplicateLookupRace_RowVanished(t *testing.T) {
 	_, err := uc.Create(authedCtx("u1"), CreateCardInput{CardgroupID: wantCardgroupID, Front: "hello", Back: "world"})
 	// Load-bearing: eris.Wrap in production must produce a rich chain even when
 	// the wrapped error is a stdlib sentinel (no stack of its own).
-	assertInternalChain(t, err, "usecase: lookup duplicate card after 23505")
+	assertInternalChain(t, err, "usecase: card: lookup duplicate after 23505")
 }
 
 // strPtr returns a pointer to s. Helper used by search passthrough tests.

--- a/backend/internal/usecase/user.go
+++ b/backend/internal/usecase/user.go
@@ -72,7 +72,7 @@ func (u *userUsecase) Me(ctx context.Context) (*domain.User, error) {
 			"user_id", user.Sub)
 		return &domain.User{ID: domain.UserID(user.Sub)}, nil
 	}
-	return nil, eris.Wrap(err, "usecase: Me: find user by ID")
+	return nil, eris.Wrap(err, "usecase: user: me: find user by ID")
 }
 
 type UpdateUserInput struct {
@@ -127,7 +127,7 @@ func (u *userUsecase) UpdateUser(ctx context.Context, in UpdateUserInput) (Updat
 	}
 	appUser, err := u.repo.Update(ctx, user.Sub, patch)
 	if err != nil {
-		return UpdateProfileOutcome{}, eris.Wrap(err, "usecase: UpdateUser: update user")
+		return UpdateProfileOutcome{}, eris.Wrap(err, "usecase: user: update: update user")
 	}
 
 	return UpdateProfileOutcome{User: appUser}, nil

--- a/backend/internal/usecase/user_test.go
+++ b/backend/internal/usecase/user_test.go
@@ -132,7 +132,7 @@ func TestUserUsecase_Me(t *testing.T) {
 				case "UNAUTHENTICATED":
 					assertUnauthenticated(t, err)
 				case "INTERNAL":
-					assertInternalChain(t, err, "usecase: Me: find user by ID")
+					assertInternalChain(t, err, "usecase: user: me: find user by ID")
 				default:
 					t.Fatalf("unhandled wantErr code %q in test", tc.wantErr)
 				}
@@ -325,7 +325,7 @@ func TestUserUsecase_UpdateUser(t *testing.T) {
 					if err == nil {
 						t.Fatal("expected error, got nil")
 					}
-					assertInternalChain(t, err, "usecase: UpdateUser: update user")
+					assertInternalChain(t, err, "usecase: user: update: update user")
 				default:
 					t.Fatalf("unhandled wantErrCode %q in test", tc.wantErrCode)
 				}
@@ -452,7 +452,7 @@ func TestUserUsecase_UpdateUser_RepoError_InfraChannel(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error from repo, got nil")
 	}
-	assertInternalChain(t, err, "usecase: UpdateUser: update user")
+	assertInternalChain(t, err, "usecase: user: update: update user")
 }
 
 // TestUserUsecase_DeleteMyAccount exercises the self-service account-deletion


### PR DESCRIPTION
## Summary

Normalizes the `eris` error-wrap prefixes in `backend/internal/usecase/card.go` and `user.go` to the canonical `usecase: <module>: <verb> <object>` form mandated by [`error-wrapping.md`](.claude/rules/error-wrapping.md). Verb-first / method-name / module-less prefixes mis-attribute the logged `error_chain` entry and defeat the `grep 'usecase: card:'` + `assertInternalChain` contract. Pure string edits.

`learn.go:154` (the third file named in the issue) is intentionally left untouched: its module-less wrap is removed by #865. Once that lands, #866's remaining scope is exactly these two files.

## Changes

- `card.go`: module-first every wrap so all begin `usecase: card:` — `create card:`→`card: create:`, `update card:`→`card: update:`, `delete card:`→`card: delete:`, `list cards by cardgroup:`→`card: list by cardgroup:`, `resolve cursor:`→`card: resolve cursor:`, `bulk delete:`→`card: bulk delete:`, plus the two module-less strings `usecase: lookup duplicate card after 23505`→`usecase: card: lookup duplicate after 23505` (mirrors the sibling `master card:` wording) and `usecase: tx runner not configured`→`usecase: card: tx runner not configured`.
- `user.go`: `usecase: Me:`→`usecase: user: me:` and `usecase: UpdateUser:`→`usecase: user: update:`.
- `card_test.go` / `user_test.go`: updated the six `assertInternalChain` substrings that pin these wraps.

## Test plan

- `go build ./...`, `go vet ./...`, `go tool go-arch-lint check --project-path backend` — all clean.
- `go test ./internal/usecase/...` — 782 pass (exercises every changed assertion).
- `go test ./...` — 1690 pass; the only failures are Docker/testcontainers integration packages, which are green in CI.
- Backend CI grep gates verified locally (no `fmt.Errorf("%w")`, no `&ucerr.*` struct literals, no hardcoded `extensions.code`); CJK/PR-number language checks clean.

Closes #866
