### PR TITLE
refactor(backend): replace hand-rolled caller == nil auth checks with requireCallerSub

### DIFF
--- a/backend/internal/usecase/master_card.go
+++ b/backend/internal/usecase/master_card.go
@@ -534,8 +534,8 @@ func (u *masterCardUsecase) ListPublicMasterCards(
 	ctx context.Context, in MasterCardConnectionInput,
 ) (*MasterCardConnectionOutput, error) {
 	return u.listMasterCardsCore(ctx, in, "usecase: master card: public list", func(ctx context.Context) error {
-		if auth.UserFrom(ctx) == nil {
-			return ucerr.ErrUnauthenticated
+		if err := requireCallerSub(auth.UserFrom(ctx)); err != nil {
+			return err
 		}
 		// Published-only visibility gate. FindPublishedByID returns ErrNotFound for
 		// BOTH unknown and DRAFT ids, collapsing them into one not-found so the

--- a/backend/internal/usecase/master_catalog.go
+++ b/backend/internal/usecase/master_catalog.go
@@ -226,10 +226,7 @@ func (u *masterCatalogUsecase) ListPublishedConnection(
 ) (*MasterCatalogConnectionOutput, error) {
 	return u.listMasterCatalogCore(ctx, in, true, "usecase: master catalog: find published page",
 		func(ctx context.Context) error {
-			if auth.UserFrom(ctx) == nil {
-				return ucerr.ErrUnauthenticated
-			}
-			return nil
+			return requireCallerSub(auth.UserFrom(ctx))
 		},
 		u.repo.FindPublishedPage,
 	)
@@ -672,8 +669,8 @@ func (u *masterCatalogUsecase) ListAdminConnection(
 // snapshot delegated to CopyMasterToUserUsecase; FSRS/swipe state starts empty.
 func (u *masterCatalogUsecase) ImportMaster(ctx context.Context, masterID string) (ImportMasterOutcome, error) {
 	caller := auth.UserFrom(ctx)
-	if caller == nil {
-		return ImportMasterOutcome{}, ucerr.ErrUnauthenticated
+	if err := requireCallerSub(caller); err != nil {
+		return ImportMasterOutcome{}, err
 	}
 
 	if _, err := u.repo.FindPublishedByID(ctx, masterID); err != nil {
@@ -705,8 +702,8 @@ func (u *masterCatalogUsecase) ImportMaster(ctx context.Context, masterID string
 // receive ucerr.ErrUnauthenticated. The merge is a one-time snapshot.
 func (u *masterCatalogUsecase) MergeMaster(ctx context.Context, masterID, cardgroupID string) (MergeMasterOutcome, error) {
 	caller := auth.UserFrom(ctx)
-	if caller == nil {
-		return MergeMasterOutcome{}, ucerr.ErrUnauthenticated
+	if err := requireCallerSub(caller); err != nil {
+		return MergeMasterOutcome{}, err
 	}
 
 	if _, err := u.repo.FindPublishedByID(ctx, masterID); err != nil {
@@ -739,8 +736,8 @@ func (u *masterCatalogUsecase) MergeMaster(ctx context.Context, masterID, cardgr
 // a (nil, nil) result that the resolver maps to GraphQL null (non-disclosure
 // gate). Unauthenticated callers receive ucerr.ErrUnauthenticated.
 func (u *masterCatalogUsecase) FindPublishedMaster(ctx context.Context, id string) (*domain.MasterCardgroup, error) {
-	if auth.UserFrom(ctx) == nil {
-		return nil, ucerr.ErrUnauthenticated
+	if err := requireCallerSub(auth.UserFrom(ctx)); err != nil {
+		return nil, err
 	}
 	deck, err := u.repo.FindPublishedByID(ctx, id)
 	if err != nil {
@@ -761,8 +758,8 @@ func (u *masterCatalogUsecase) FindPublishedMaster(ctx context.Context, id strin
 // travel as errors from the delegated usecase.
 func (u *masterCatalogUsecase) PreviewMergeMaster(ctx context.Context, masterID, cardgroupID string) (PreviewMergeOutcome, error) {
 	caller := auth.UserFrom(ctx)
-	if caller == nil {
-		return PreviewMergeOutcome{}, ucerr.ErrUnauthenticated
+	if err := requireCallerSub(caller); err != nil {
+		return PreviewMergeOutcome{}, err
 	}
 
 	if _, err := u.repo.FindPublishedByID(ctx, masterID); err != nil {

--- a/backend/internal/usecase/master_catalog_test.go
+++ b/backend/internal/usecase/master_catalog_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/rotisserie/eris"
 
+	"backend/internal/auth"
 	"backend/internal/cursor"
 	"backend/internal/domain"
 	"backend/internal/repository"
@@ -1212,6 +1213,38 @@ func TestPreviewMergeMaster_UnauthenticatedCaller(t *testing.T) {
 	if !errors.Is(err, ucerr.ErrUnauthenticated) {
 		t.Fatalf("expected ErrUnauthenticated, got %v", err)
 	}
+}
+
+// TestMasterCatalog_EmptySubCaller_RejectedAsUnauthenticated pins the requireCallerSub
+// gate on the import/merge paths. A NON-NIL *auth.AuthUser whose Sub is empty must be
+// rejected as unauthenticated rather than treated as an authenticated owner with id "".
+// The prior `caller == nil` guard let this case through (the pointer is non-nil), which
+// would have carried an empty ownership identity into the copy/merge delegates.
+func TestMasterCatalog_EmptySubCaller_RejectedAsUnauthenticated(t *testing.T) {
+	t.Parallel()
+	// A non-nil authenticated user carrying an empty Sub — the exact case
+	// requireCallerSub guards and the old nil-only check missed.
+	ctx := auth.ContextWithUser(context.Background(), &auth.AuthUser{Sub: ""})
+	uc := NewMasterCatalogUsecase(&mockMasterCatalogRepository{}, &mockCopyMasterToUserUC{}, newTestAdminGate(true), newTestLogger())
+
+	t.Run("ImportMaster", func(t *testing.T) {
+		t.Parallel()
+		if _, err := uc.ImportMaster(ctx, "m1"); !errors.Is(err, ucerr.ErrUnauthenticated) {
+			t.Fatalf("expected ErrUnauthenticated, got %v", err)
+		}
+	})
+	t.Run("MergeMaster", func(t *testing.T) {
+		t.Parallel()
+		if _, err := uc.MergeMaster(ctx, "m1", "cg-1"); !errors.Is(err, ucerr.ErrUnauthenticated) {
+			t.Fatalf("expected ErrUnauthenticated, got %v", err)
+		}
+	})
+	t.Run("PreviewMergeMaster", func(t *testing.T) {
+		t.Parallel()
+		if _, err := uc.PreviewMergeMaster(ctx, "m1", "cg-1"); !errors.Is(err, ucerr.ErrUnauthenticated) {
+			t.Fatalf("expected ErrUnauthenticated, got %v", err)
+		}
+	})
 }
 
 func TestPreviewMergeMaster_NotFoundWhenMasterUnpublished(t *testing.T) {


### PR DESCRIPTION
## Summary

Three master-catalog write methods hand-rolled `if caller == nil { return ucerr.ErrUnauthenticated }` and then read `caller.Sub` as the ownership identity. A non-nil `*auth.AuthUser` carrying an empty `Sub` — the exact case `requireCallerSub` and `auth/superuser.go` guard against — passed the nil-only check and would have been treated as an authenticated owner with id `""`. This routes every master-catalog / master-card auth gate through the shared `requireCallerSub`, which rejects both `caller == nil` and `caller.Sub == ""`.

## Changes

- `usecase/master_catalog.go`: `ImportMaster`, `MergeMaster`, `PreviewMergeMaster` — replace the `if caller == nil` blocks that then read `caller.Sub` with `if err := requireCallerSub(caller); err != nil { return …, err }`.
- `usecase/master_catalog.go`: the presence-only gates at `ListPublishedConnection` (gate closure) and `FindPublishedMaster` now call `requireCallerSub(auth.UserFrom(ctx))`.
- `usecase/master_card.go`: the presence-only gate in `ListPublicMasterCards` now calls `requireCallerSub(auth.UserFrom(ctx))`.
- `usecase/master_catalog_test.go`: add `TestMasterCatalog_EmptySubCaller_RejectedAsUnauthenticated` asserting a non-nil `AuthUser{Sub: ""}` is rejected as `ucerr.ErrUnauthenticated` on the ImportMaster / MergeMaster / PreviewMergeMaster paths.

No docstrings changed — every "Unauthenticated callers receive ucerr.ErrUnauthenticated" note stays accurate because `requireCallerSub` returns that sentinel bare.

## Test plan

- `go build ./...` — pass
- `go vet ./...` — pass
- `go tool go-arch-lint check --project-path .` — OK, no warnings
- `go test ./internal/usecase/...` — pass (includes the new empty-Sub test)
- Full `go test ./...` — only the 5 testcontainers/Docker-gated packages (`cmd/migrate-to-master`, `cmd/seed`, `cmd/server`, `internal/database`, `internal/repository`) fail locally with "rootless Docker not found"; they compile and are exercised by CI.

Closes #867
