### PR TITLE
refactor(backend): fold the filtered COUNT into cardgroup FindPageByOwner

### DIFF
--- a/backend/graph/resolver/cardgroup_resolvers_test.go
+++ b/backend/graph/resolver/cardgroup_resolvers_test.go
@@ -29,9 +29,11 @@ type mockCardgroupRepoForResolver struct {
 	findByIDResult *domain.Cardgroup
 	findByIDErr    error
 
-	// FindPageByOwner / CountByOwner — the two methods MyCardgroupsConnection
-	// hits on the happy path.
+	// FindPageByOwner returns the page rows plus the filtered totalCount the
+	// connection reads. countResult/countErr remain for the filter-less
+	// CountByOwner caller (the cardgroup-limit check).
 	findPageResult []*domain.Cardgroup
+	findPageTotal  int64
 	findPageErr    error
 	countResult    int64
 	countErr       error
@@ -54,8 +56,8 @@ func (m *mockCardgroupRepoForResolver) FindPageByOwner(
 	_ repository.CardgroupOrderBy,
 	_ repository.SortOrder,
 	_ *string,
-) ([]*domain.Cardgroup, error) {
-	return m.findPageResult, m.findPageErr
+) ([]*domain.Cardgroup, int64, error) {
+	return m.findPageResult, m.findPageTotal, m.findPageErr
 }
 
 func (m *mockCardgroupRepoForResolver) CountByOwner(_ context.Context, _ string, _ *string) (int64, error) {
@@ -125,7 +127,7 @@ func TestResolver_MyCardgroupsConnection_Authenticated_DelegatesToUsecase(t *tes
 	}
 	repo := &mockCardgroupRepoForResolver{
 		findPageResult: cgs,
-		countResult:    3,
+		findPageTotal:  3,
 	}
 	srv := newCardgroupSrv(repo)
 	resp := gqlRequest(t, srv, authedCtx("u1"), myCardgroupsConnectionQuery)
@@ -210,13 +212,14 @@ func TestResolver_MyCardgroupsConnection_UsecaseError_PropagatesBadUserInput(t *
 	}
 }
 
-// TestResolver_MyCardgroupsConnection_RepoCountError_BecomesInternal
-// verifies that an unexpected repository error from CountByOwner is mapped
-// to extensions.code == INTERNAL.
-func TestResolver_MyCardgroupsConnection_RepoCountError_BecomesInternal(t *testing.T) {
+// TestResolver_MyCardgroupsConnection_RepoPageError_BecomesInternal
+// verifies that an unexpected repository error from FindPageByOwner (which
+// now also performs the totalCount COUNT) is mapped to
+// extensions.code == INTERNAL.
+func TestResolver_MyCardgroupsConnection_RepoPageError_BecomesInternal(t *testing.T) {
 	t.Parallel()
 
-	repo := &mockCardgroupRepoForResolver{countErr: errors.New("db died")}
+	repo := &mockCardgroupRepoForResolver{findPageErr: errors.New("db died")}
 	srv := newCardgroupSrv(repo)
 	resp := gqlRequest(t, srv, authedCtx("u1"), myCardgroupsConnectionQuery)
 
@@ -249,7 +252,7 @@ func TestResolver_MyCardgroupsConnection_Empty_ReturnsEmptyEdges(t *testing.T) {
 
 	repo := &mockCardgroupRepoForResolver{
 		findPageResult: []*domain.Cardgroup{},
-		countResult:    0,
+		findPageTotal:  0,
 	}
 	srv := newCardgroupSrv(repo)
 	resp := gqlRequest(t, srv, authedCtx("u1"), myCardgroupsConnectionQuery)
@@ -332,14 +335,14 @@ func (c *capturingCardgroupRepo) FindPageByOwner(
 	orderBy repository.CardgroupOrderBy,
 	dir repository.SortOrder,
 	_ *string,
-) ([]*domain.Cardgroup, error) {
+) ([]*domain.Cardgroup, int64, error) {
 	c.findPageOrderBy = orderBy
 	c.findPageDir = dir
 	c.findPageFirst = first
 	c.findPageLast = last
 	c.findPageAfter = after
 	c.findPageBefore = before
-	return c.findPageResult, c.findPageErr
+	return c.findPageResult, c.findPageTotal, c.findPageErr
 }
 
 // ---------------------------------------------------------------------------

--- a/backend/internal/loader/user_test.go
+++ b/backend/internal/loader/user_test.go
@@ -155,7 +155,7 @@ func (r *countingCardgroupRepo) FindPageByOwner(
 	_ repository.CardgroupOrderBy,
 	_ repository.SortOrder,
 	_ *string,
-) ([]*domain.Cardgroup, error) {
+) ([]*domain.Cardgroup, int64, error) {
 	panic("countingCardgroupRepo.FindPageByOwner not configured")
 }
 func (r *countingCardgroupRepo) CountByOwner(_ context.Context, _ string, _ *string) (int64, error) {

--- a/backend/internal/repository/cardgroup.go
+++ b/backend/internal/repository/cardgroup.go
@@ -58,12 +58,16 @@ type CardgroupRepository interface {
 	FindByID(ctx context.Context, id string) (*domain.Cardgroup, error)
 	FindByName(ctx context.Context, ownerID, name string) (*domain.Cardgroup, error)
 	FindByIDs(ctx context.Context, ids []string) (map[string]*domain.Cardgroup, error)
-	// FindPageByOwner returns a window of cardgroups owned by ownerID
-	// ordered by (orderBy, id). Forward paging uses (after, first); backward
-	// paging uses (before, last) and the slice is reversed in memory so the
-	// caller observes the same display order regardless of direction. An
-	// optional case-insensitive substring search filters by name (ILIKE
-	// metacharacters in the search are escaped so they match literally).
+	// FindPageByOwner returns a window of cardgroups owned by ownerID ordered
+	// by (orderBy, id) together with the total number of rows matching the same
+	// owner + search filter. Forward paging uses (after, first); backward paging
+	// uses (before, last) and the slice is reversed in memory so the caller
+	// observes the same display order regardless of direction. An optional
+	// case-insensitive substring search filters by name (ILIKE metacharacters in
+	// the search are escaped so they match literally); the returned total honours
+	// that same filter, so it never lies under an active search. The COUNT runs
+	// before the zero-page short-circuit so a caller requesting only the total
+	// still sees a real value.
 	FindPageByOwner(
 		ctx context.Context,
 		ownerID string,
@@ -72,10 +76,11 @@ type CardgroupRepository interface {
 		orderBy CardgroupOrderBy,
 		dir SortOrder,
 		search *string,
-	) ([]*domain.Cardgroup, error)
+	) ([]*domain.Cardgroup, int64, error)
 	// CountByOwner returns the total number of cardgroups owned by ownerID
-	// matching the optional search predicate. Returned independently of
-	// FindPageByOwner so the totalCount survives a zero-page request.
+	// matching the optional search predicate. Used by the filter-less callers
+	// that pass a nil search (seed and cardgroup-limit checks); the paginated
+	// connection reads its filtered total from FindPageByOwner instead.
 	CountByOwner(ctx context.Context, ownerID string, search *string) (int64, error)
 	Create(ctx context.Context, cg *domain.Cardgroup) error
 	// CreateTx inserts a new cardgroup row using the supplied transaction
@@ -131,6 +136,8 @@ func (r *cardgroupRepo) FindByName(ctx context.Context, ownerID, name string) (*
 // sees the same display order as forward paging. The search argument, when
 // non-empty after trimming, filters by `name ILIKE %escaped%` with LIKE
 // metacharacters escaped so user-supplied `%` and `_` match literally.
+// totalCount is a COUNT(*) over the SAME filtered base query, so it honours
+// the active search rather than reporting the unfiltered owner total.
 func (r *cardgroupRepo) FindPageByOwner(
 	ctx context.Context,
 	ownerID string,
@@ -139,26 +146,39 @@ func (r *cardgroupRepo) FindPageByOwner(
 	orderBy CardgroupOrderBy,
 	dir SortOrder,
 	search *string,
-) ([]*domain.Cardgroup, error) {
+) ([]*domain.Cardgroup, int64, error) {
 	first = ClampPageSize(first)
 	last = ClampPageSize(last)
 
+	// Base query scoped to the owner (and search filter, if active). Both the
+	// COUNT and the page window derive from it so totalCount applies the same
+	// predicate as the page.
+	base := r.db.WithContext(ctx).Model(&gormCardgroup{}).Where("owner_id = ?", ownerID)
+	if pattern, ok := searchLikePattern(search); ok {
+		base = base.Where("name ILIKE ?", pattern)
+	}
+
+	// totalCount comes from a COUNT(*) over the same filtered base query.
+	// Computed before the no-rows short-circuit so a caller passing first=0
+	// still observes the real count.
+	var total int64
+	if err := base.Count(&total).Error; err != nil {
+		return nil, 0, eris.Wrap(err, "repository: cardgroup: count by owner")
+	}
+
 	if first == 0 && last == 0 {
-		return []*domain.Cardgroup{}, nil
+		return []*domain.Cardgroup{}, total, nil
 	}
 
 	// Backward paging executes the query with the inverted direction and
 	// reverses the slice afterwards.
 	effectiveDir, limit, cursor, reverse := paginateSetup(dir, first, last, after, before)
 
-	q := r.db.WithContext(ctx).Model(&gormCardgroup{}).Where("owner_id = ?", ownerID)
-	if pattern, ok := searchLikePattern(search); ok {
-		q = q.Where("name ILIKE ?", pattern)
-	}
+	q := base
 	if cursor != nil {
 		clauseSQL, args, err := cardgroupCursorWhere(orderBy, effectiveDir, cursor)
 		if err != nil {
-			return nil, eris.Wrap(err, "repository: cardgroup: build cursor where")
+			return nil, 0, eris.Wrap(err, "repository: cardgroup: build cursor where")
 		}
 		q = q.Where(clauseSQL, args...)
 	}
@@ -166,7 +186,7 @@ func (r *cardgroupRepo) FindPageByOwner(
 
 	var rows []gormCardgroup
 	if err := q.Find(&rows).Error; err != nil {
-		return nil, eris.Wrap(err, "repository: cardgroup: find page by owner")
+		return nil, 0, eris.Wrap(err, "repository: cardgroup: find page by owner")
 	}
 
 	if reverse {
@@ -177,7 +197,7 @@ func (r *cardgroupRepo) FindPageByOwner(
 	for i := range rows {
 		out[i] = cardgroupToDomain(rows[i])
 	}
-	return out, nil
+	return out, total, nil
 }
 
 // CountByOwner returns the total number of cardgroups owned by ownerID

--- a/backend/internal/repository/cardgroup_test.go
+++ b/backend/internal/repository/cardgroup_test.go
@@ -387,7 +387,7 @@ func TestCardgroupRepo_FindPageByOwner_EmptyResult(t *testing.T) {
 	ownerID := insertAuthUser(t, ctx)
 	repo := repository.NewCardgroupRepository(testDB.GORM)
 
-	got, err := repo.FindPageByOwner(
+	got, _, err := repo.FindPageByOwner(
 		ctx, ownerID, nil, nil, 10, 0,
 		repository.CardgroupOrderByCreatedAt, repository.SortAsc, nil,
 	)
@@ -411,7 +411,7 @@ func TestCardgroupRepo_FindPageByOwner_ExactMatch(t *testing.T) {
 	insertNamedCardgroups(t, ctx, ownerID, []string{"Exact Match", "Other Group"})
 
 	search := "Exact Match"
-	got, err := repo.FindPageByOwner(
+	got, _, err := repo.FindPageByOwner(
 		ctx, ownerID, nil, nil, 10, 0,
 		repository.CardgroupOrderByCreatedAt, repository.SortAsc, &search,
 	)
@@ -435,7 +435,7 @@ func TestCardgroupRepo_FindPageByOwner_PartialMatch(t *testing.T) {
 	insertNamedCardgroups(t, ctx, ownerID, []string{"green apple", "apple pie", "banana"})
 
 	search := "apple"
-	got, err := repo.FindPageByOwner(
+	got, total, err := repo.FindPageByOwner(
 		ctx, ownerID, nil, nil, 10, 0,
 		repository.CardgroupOrderByCreatedAt, repository.SortAsc, &search,
 	)
@@ -446,9 +446,16 @@ func TestCardgroupRepo_FindPageByOwner_PartialMatch(t *testing.T) {
 	require.NotContains(t, names, "banana", "banana must not appear in apple search results")
 	require.Len(t, got, 2)
 
-	total, err := repo.CountByOwner(ctx, ownerID, &search)
+	// The folded totalCount must reflect the active search filter (2 of the 3
+	// seeded rows match "apple"), not the unfiltered owner total.
+	require.Equal(t, int64(2), total,
+		"totalCount from FindPageByOwner must honour the search filter, not the unfiltered total")
+
+	unfiltered, err := repo.CountByOwner(ctx, ownerID, nil)
 	require.NoError(t, err)
-	require.Equal(t, int64(2), total)
+	require.Equal(t, int64(3), unfiltered, "sanity: the owner really has 3 cardgroups")
+	require.NotEqual(t, unfiltered, total,
+		"filtered total must differ from the unfiltered total to prove the filter is applied")
 }
 
 // TestCardgroupRepo_FindPageByOwner_LIKEEscape verifies that a percent sign in
@@ -464,7 +471,7 @@ func TestCardgroupRepo_FindPageByOwner_LIKEEscape(t *testing.T) {
 	insertNamedCardgroups(t, ctx, ownerID, []string{"100%", "1000"})
 
 	search := "100%"
-	got, err := repo.FindPageByOwner(
+	got, _, err := repo.FindPageByOwner(
 		ctx, ownerID, nil, nil, 10, 0,
 		repository.CardgroupOrderByCreatedAt, repository.SortAsc, &search,
 	)
@@ -495,7 +502,7 @@ func TestCardgroupRepo_FindPageByOwner_LIKEUnderscoreEscape(t *testing.T) {
 	insertNamedCardgroups(t, ctx, ownerID, []string{"a_b", "acb"})
 
 	search := "a_b"
-	got, err := repo.FindPageByOwner(
+	got, _, err := repo.FindPageByOwner(
 		ctx, ownerID, nil, nil, 10, 0,
 		repository.CardgroupOrderByCreatedAt, repository.SortAsc, &search,
 	)
@@ -522,7 +529,7 @@ func TestCardgroupRepo_FindPageByOwner_LIKEBackslashEscape(t *testing.T) {
 
 	// Search for the literal backslash-containing name.
 	search := `back\slash`
-	got, err := repo.FindPageByOwner(
+	got, _, err := repo.FindPageByOwner(
 		ctx, ownerID, nil, nil, 10, 0,
 		repository.CardgroupOrderByCreatedAt, repository.SortAsc, &search,
 	)
@@ -548,7 +555,7 @@ func TestCardgroupRepo_FindPageByOwner_CrossTenant(t *testing.T) {
 	insertNamedCardgroups(t, ctx, ownerB, []string{"shared name", "only B"})
 
 	// Query scoped to ownerB.
-	gotB, err := repo.FindPageByOwner(
+	gotB, _, err := repo.FindPageByOwner(
 		ctx, ownerB, nil, nil, 20, 0,
 		repository.CardgroupOrderByCreatedAt, repository.SortAsc, nil,
 	)
@@ -556,7 +563,7 @@ func TestCardgroupRepo_FindPageByOwner_CrossTenant(t *testing.T) {
 	idsB := cardgroupIDSetFromSlice(gotB)
 
 	// Fetch ownerA's IDs to assert they do not bleed into ownerB's results.
-	gotA, err := repo.FindPageByOwner(
+	gotA, _, err := repo.FindPageByOwner(
 		ctx, ownerA, nil, nil, 20, 0,
 		repository.CardgroupOrderByCreatedAt, repository.SortAsc, nil,
 	)
@@ -591,7 +598,7 @@ func TestCardgroupRepo_FindPageByOwner_PlusOneFetch(t *testing.T) {
 
 	// Request first=3 (which represents the usecase sending first+1=3 when
 	// the user asked for first=2). The repo must return exactly 3 rows.
-	got, err := repo.FindPageByOwner(
+	got, _, err := repo.FindPageByOwner(
 		ctx, ownerID, nil, nil, 3, 0,
 		repository.CardgroupOrderByCreatedAt, repository.SortAsc, nil,
 	)
@@ -641,7 +648,7 @@ func TestCardgroupRepo_FindPageByOwner_OrderBy_Name_Asc(t *testing.T) {
 		string(cgs[0].ID): {}, string(cgs[1].ID): {}, string(cgs[2].ID): {},
 	}
 
-	got, err := repo.FindPageByOwner(
+	got, _, err := repo.FindPageByOwner(
 		ctx, ownerID, nil, nil, 100, 0,
 		repository.CardgroupOrderByName, repository.SortAsc, nil,
 	)
@@ -666,7 +673,7 @@ func TestCardgroupRepo_FindPageByOwner_OrderBy_Name_Desc(t *testing.T) {
 		string(cgs[0].ID): {}, string(cgs[1].ID): {}, string(cgs[2].ID): {},
 	}
 
-	got, err := repo.FindPageByOwner(
+	got, _, err := repo.FindPageByOwner(
 		ctx, ownerID, nil, nil, 100, 0,
 		repository.CardgroupOrderByName, repository.SortDesc, nil,
 	)
@@ -695,7 +702,7 @@ func TestCardgroupRepo_FindPageByOwner_OrderBy_UpdatedAt_Desc(t *testing.T) {
 	require.NoError(t, err)
 
 	want := map[string]struct{}{string(cgs[0].ID): {}, string(cgs[1].ID): {}, string(cgs[2].ID): {}}
-	got, err := repo.FindPageByOwner(
+	got, _, err := repo.FindPageByOwner(
 		ctx, ownerID, nil, nil, 100, 0,
 		repository.CardgroupOrderByUpdatedAt, repository.SortDesc, nil,
 	)
@@ -721,7 +728,7 @@ func TestCardgroupRepo_FindPageByOwner_OrderBy_UpdatedAt_Asc(t *testing.T) {
 	require.NoError(t, err)
 
 	want := map[string]struct{}{string(cgs[0].ID): {}, string(cgs[1].ID): {}, string(cgs[2].ID): {}}
-	got, err := repo.FindPageByOwner(
+	got, _, err := repo.FindPageByOwner(
 		ctx, ownerID, nil, nil, 100, 0,
 		repository.CardgroupOrderByUpdatedAt, repository.SortAsc, nil,
 	)
@@ -745,7 +752,7 @@ func TestCardgroupRepo_FindPageByOwner_OrderBy_CreatedAt_Desc(t *testing.T) {
 	cgs := insertNamedCardgroups(t, ctx, ownerID, []string{"a", "b", "c"})
 	want := map[string]struct{}{string(cgs[0].ID): {}, string(cgs[1].ID): {}, string(cgs[2].ID): {}}
 
-	got, err := repo.FindPageByOwner(
+	got, _, err := repo.FindPageByOwner(
 		ctx, ownerID, nil, nil, 100, 0,
 		repository.CardgroupOrderByCreatedAt, repository.SortDesc, nil,
 	)
@@ -768,7 +775,7 @@ func TestCardgroupRepo_FindPageByOwner_OrderBy_ID_Desc(t *testing.T) {
 	cgs := insertNamedCardgroups(t, ctx, ownerID, []string{"a", "b", "c"})
 	want := map[string]struct{}{string(cgs[0].ID): {}, string(cgs[1].ID): {}, string(cgs[2].ID): {}}
 
-	got, err := repo.FindPageByOwner(
+	got, _, err := repo.FindPageByOwner(
 		ctx, ownerID, nil, nil, 100, 0,
 		repository.CardgroupOrderByID, repository.SortDesc, nil,
 	)
@@ -803,7 +810,7 @@ func TestCardgroupRepo_FindPageByOwner_Cursor_AfterByName(t *testing.T) {
 		ID:   string(cgs[1].ID),
 		Name: &bananaName,
 	}
-	got, err := repo.FindPageByOwner(
+	got, _, err := repo.FindPageByOwner(
 		ctx, ownerID, cursor, nil, 100, 0,
 		repository.CardgroupOrderByName, repository.SortAsc, nil,
 	)
@@ -833,7 +840,7 @@ func TestCardgroupRepo_FindPageByOwner_Cursor_BackwardByCreatedAt(t *testing.T) 
 		ID:        string(cgs[3].ID),
 		CreatedAt: &cgs[3].CreatedAt,
 	}
-	got, err := repo.FindPageByOwner(
+	got, _, err := repo.FindPageByOwner(
 		ctx, ownerID, nil, cursor, 0, 2,
 		repository.CardgroupOrderByCreatedAt, repository.SortAsc, nil,
 	)
@@ -861,7 +868,7 @@ func TestCardgroupRepo_FindPageByOwner_Cursor_AfterByID(t *testing.T) {
 	sort.Strings(sortedIDs)
 
 	cursor := &repository.CardgroupCursor{ID: sortedIDs[0]}
-	got, err := repo.FindPageByOwner(
+	got, _, err := repo.FindPageByOwner(
 		ctx, ownerID, cursor, nil, 100, 0,
 		repository.CardgroupOrderByID, repository.SortAsc, nil,
 	)
@@ -886,7 +893,7 @@ func TestCardgroupRepo_FindPageByOwner_Cursor_NameTie_TupleComparison(t *testing
 	want := map[string]struct{}{string(cgs[0].ID): {}, string(cgs[1].ID): {}, string(cgs[2].ID): {}}
 
 	// Page 1: first=1 under name ASC — must be one of the two Ties.
-	page1, err := repo.FindPageByOwner(
+	page1, _, err := repo.FindPageByOwner(
 		ctx, ownerID, nil, nil, 1, 0,
 		repository.CardgroupOrderByName, repository.SortAsc, nil,
 	)
@@ -900,7 +907,7 @@ func TestCardgroupRepo_FindPageByOwner_Cursor_NameTie_TupleComparison(t *testing
 	_ = mine1
 
 	// Refetch with a high limit and pick our three deterministic rows.
-	all, err := repo.FindPageByOwner(
+	all, _, err := repo.FindPageByOwner(
 		ctx, ownerID, nil, nil, 100, 0,
 		repository.CardgroupOrderByName, repository.SortAsc, nil,
 	)
@@ -917,7 +924,7 @@ func TestCardgroupRepo_FindPageByOwner_Cursor_NameTie_TupleComparison(t *testing
 	// the second tie reachable; without it, `name > 'Tie'` would skip past it.
 	tieName := mine[0].Name.String()
 	cursor := &repository.CardgroupCursor{ID: string(mine[0].ID), Name: &tieName}
-	pageAfter, err := repo.FindPageByOwner(
+	pageAfter, _, err := repo.FindPageByOwner(
 		ctx, ownerID, cursor, nil, 100, 0,
 		repository.CardgroupOrderByName, repository.SortAsc, nil,
 	)
@@ -978,7 +985,7 @@ func TestCardgroupRepo_FindPageByOwner_EmptySearchTreatedAsNil(t *testing.T) {
 	want := map[string]struct{}{string(cgs[0].ID): {}, string(cgs[1].ID): {}}
 
 	whitespace := "   "
-	got, err := repo.FindPageByOwner(
+	got, _, err := repo.FindPageByOwner(
 		ctx, ownerID, nil, nil, 100, 0,
 		repository.CardgroupOrderByCreatedAt, repository.SortAsc, &whitespace,
 	)
@@ -999,7 +1006,7 @@ func TestCardgroupRepo_FindPageByOwner_BothFirstAndLastZero(t *testing.T) {
 
 	insertNamedCardgroups(t, ctx, ownerID, []string{"x", "y"})
 
-	got, err := repo.FindPageByOwner(
+	got, _, err := repo.FindPageByOwner(
 		ctx, ownerID, nil, nil, 0, 0,
 		repository.CardgroupOrderByCreatedAt, repository.SortAsc, nil,
 	)
@@ -1019,7 +1026,7 @@ func TestCardgroupRepo_FindPageByOwner_NegativeFirstClampedToZero(t *testing.T) 
 
 	insertNamedCardgroups(t, ctx, ownerID, []string{"x"})
 
-	got, err := repo.FindPageByOwner(
+	got, _, err := repo.FindPageByOwner(
 		ctx, ownerID, nil, nil, -10, 0,
 		repository.CardgroupOrderByCreatedAt, repository.SortAsc, nil,
 	)

--- a/backend/internal/usecase/cardgroup.go
+++ b/backend/internal/usecase/cardgroup.go
@@ -27,7 +27,7 @@ type CardgroupRepository interface {
 		orderBy repository.CardgroupOrderBy,
 		dir repository.SortOrder,
 		search *string,
-	) ([]*domain.Cardgroup, error)
+	) ([]*domain.Cardgroup, int64, error)
 	CountByOwner(ctx context.Context, ownerID string, search *string) (int64, error)
 	Create(ctx context.Context, cg *domain.Cardgroup) error
 	Update(ctx context.Context, id string, patch repository.CardgroupUpdate) (*domain.Cardgroup, error)
@@ -333,22 +333,20 @@ func (u *cardgroupUsecase) ListCardgroupsByOwnerConnection(
 		return nil, err
 	}
 
-	// totalCount comes from a separate COUNT(*) scoped to the caller and the
-	// optional search predicate. Computed before the page fetch so callers
-	// asking only for totalCount still see a real value.
-	total, err := u.repo.CountByOwner(ctx, user.Sub, in.Search)
-	if err != nil {
-		return nil, eris.Wrap(err, "usecase: cardgroup: count by owner")
-	}
-
+	// totalCount comes from FindPageByOwner's COUNT(*) over the same filtered
+	// base query, captured inside the fetch closure so it honours the active
+	// search rather than an unfiltered owner total. assemblePage always invokes
+	// fetch (even for a totalCount-only request), so total is set on every path.
+	var total int64
 	cgs, hasNext, hasPrev, err := assemblePage(first, last, after != nil, before != nil,
 		func(wantFirst, wantLast int) ([]*domain.Cardgroup, error) {
-			rows, e := u.repo.FindPageByOwner(
+			rows, t, e := u.repo.FindPageByOwner(
 				ctx, user.Sub, after, before, wantFirst, wantLast, orderBy, dir, in.Search,
 			)
 			if e != nil {
 				return nil, eris.Wrap(e, "usecase: cardgroup: find page by owner")
 			}
+			total = t
 			return rows, nil
 		},
 	)

--- a/backend/internal/usecase/cardgroup_test.go
+++ b/backend/internal/usecase/cardgroup_test.go
@@ -49,7 +49,12 @@ type mockCardgroupRepository struct {
 	deleteCalled bool
 
 	// FindPageByOwner / CountByOwner — used by pagination tests.
+	// findPageTotal is the filtered totalCount FindPageByOwner now returns
+	// alongside the page rows (the connection path reads its total from here,
+	// not from CountByOwner). countResult/countErr remain for the filter-less
+	// CountByOwner callers (the cardgroup-limit check on Create).
 	findPageResult []*domain.Cardgroup
+	findPageTotal  int64
 	findPageErr    error
 	countResult    int64
 	countErr       error
@@ -110,9 +115,10 @@ func (m *mockCardgroupRepository) Delete(_ context.Context, _ string) error {
 	return m.deleteErr
 }
 
-// FindPageByOwner returns findPageResult/findPageErr when set; otherwise nil.
-// Each call is captured in findPageCalls so tests can assert on the arguments
-// the usecase forwarded (e.g. first+1, orderBy translation, cursor hydration).
+// FindPageByOwner returns findPageResult/findPageTotal/findPageErr when set;
+// otherwise nil/0/nil. Each call is captured in findPageCalls so tests can
+// assert on the arguments the usecase forwarded (e.g. first+1, orderBy
+// translation, cursor hydration).
 func (m *mockCardgroupRepository) FindPageByOwner(
 	_ context.Context,
 	ownerID string,
@@ -121,7 +127,7 @@ func (m *mockCardgroupRepository) FindPageByOwner(
 	orderBy repository.CardgroupOrderBy,
 	dir repository.SortOrder,
 	search *string,
-) ([]*domain.Cardgroup, error) {
+) ([]*domain.Cardgroup, int64, error) {
 	m.findPageCalls = append(m.findPageCalls, findPageByOwnerCall{
 		OwnerID: ownerID,
 		After:   after,
@@ -132,7 +138,7 @@ func (m *mockCardgroupRepository) FindPageByOwner(
 		Dir:     dir,
 		Search:  search,
 	})
-	return m.findPageResult, m.findPageErr
+	return m.findPageResult, m.findPageTotal, m.findPageErr
 }
 
 // CountByOwner returns countResult/countErr when set; otherwise 0, nil.
@@ -910,10 +916,11 @@ func TestCardgroupUC_Connection_FirstPage(t *testing.T) {
 		// The third row is the "+1" the usecase requests to detect hasNextPage.
 		{ID: "cg3", OwnerID: "user-1", Name: "Gamma"},
 	}
-	// The mock returns all 3 rows (simulating repo returning first+1=3 rows).
+	// The mock returns all 3 rows (simulating repo returning first+1=3 rows)
+	// plus the filtered total FindPageByOwner now carries.
 	repo := &mockCardgroupRepository{
 		findPageResult: cgs,
-		countResult:    3,
+		findPageTotal:  3,
 	}
 	uc := NewCardgroupUsecase(repo, cgDefaultAdmin(), newTestLogger())
 
@@ -951,12 +958,14 @@ func TestCardgroupUC_Connection_Search(t *testing.T) {
 	t.Parallel()
 
 	// Only "apple" matches the search; "banana" is absent from the page result.
+	// findPageTotal is the filtered count FindPageByOwner returns, so the
+	// connection's totalCount reflects the search rather than the owner total.
 	matched := []*domain.Cardgroup{
 		{ID: "cg1", OwnerID: "user-1", Name: "apple"},
 	}
 	repo := &mockCardgroupRepository{
 		findPageResult: matched,
-		countResult:    1,
+		findPageTotal:  1,
 	}
 	uc := NewCardgroupUsecase(repo, cgDefaultAdmin(), newTestLogger())
 
@@ -1536,7 +1545,6 @@ func TestCardgroupUC_Connection_FindPageRepoError_Internal(t *testing.T) {
 	t.Parallel()
 
 	repo := &mockCardgroupRepository{
-		countResult: 5,
 		findPageErr: errors.New("db dead"),
 	}
 	uc := NewCardgroupUsecase(repo, cgDefaultAdmin(), newTestLogger())
@@ -1546,25 +1554,6 @@ func TestCardgroupUC_Connection_FindPageRepoError_Internal(t *testing.T) {
 		First: &first,
 	})
 	assertInternalChain(t, err, "usecase: cardgroup: find page by owner")
-}
-
-// TestCardgroupUC_Connection_CountError_Internal verifies that a CountByOwner
-// repository error surfaces INTERNAL before FindPageByOwner is called.
-func TestCardgroupUC_Connection_CountError_Internal(t *testing.T) {
-	t.Parallel()
-
-	repo := &mockCardgroupRepository{countErr: errors.New("count dead")}
-	uc := NewCardgroupUsecase(repo, cgDefaultAdmin(), newTestLogger())
-
-	first := 5
-	_, err := uc.ListCardgroupsByOwnerConnection(cgAuthedCtx("u1"), CardgroupConnectionInput{
-		First: &first,
-	})
-	assertInternalChain(t, err, "usecase: cardgroup: count by owner")
-	if len(repo.findPageCalls) != 0 {
-		t.Fatalf("expected no FindPageByOwner call when CountByOwner fails, got %d",
-			len(repo.findPageCalls))
-	}
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`cardgroup` was the last searchable connection that split its page query and its `totalCount` into two repository methods (`FindPageByOwner` + a standalone `CountByOwner`), forcing the usecase to feed both an identical `search`. That is the fragile two-call shape [`.claude/rules/pagination.md`](.claude/rules/pagination.md) warns against — one edit away from a "3 of 500" `totalCount` lie under an active filter. This folds the filtered `COUNT(*)` into `FindPageByOwner` so the total is always computed on the same filtered base query, matching the shape `card.go` / `master_card.go` / `master_catalog_read.go` / `user.go` already use.

## Changes

- `repository/cardgroup.go`: `FindPageByOwner` now returns `([]*domain.Cardgroup, int64, error)`. It builds a single `base` query (owner + optional `name ILIKE` search), runs `COUNT(*)` over that base before the zero-page short-circuit, and returns the filtered total on every path. `CountByOwner` is kept for the filter-less callers.
- `usecase/cardgroup.go`: the `CardgroupRepository` consumer interface mirrors the new signature; `ListCardgroupsByOwnerConnection` drops its standalone `CountByOwner` call and captures the returned total inside the `assemblePage` fetch closure (`assemblePage` always invokes `fetch`, so the total is set even for a totalCount-only request). The three filter-less `CountByOwner(ctx, …, nil)` callers (`cardgroup.go` limit check, `master_deck.go`, `stats.go`) are unchanged.
- Tests: updated the repository/usecase/resolver/loader fakes and call sites to the new signature; `TestCardgroupRepo_FindPageByOwner_PartialMatch` now asserts the folded total reflects the active search (2 of 3 seeded rows) and differs from the unfiltered owner total; deleted `TestCardgroupUC_Connection_CountError_Internal` (its code path — a standalone `CountByOwner` failing before the page fetch — no longer exists; the INTERNAL-from-repo path is covered by `TestCardgroupUC_Connection_FindPageRepoError_Internal`); renamed the resolver `RepoCountError` test to `RepoPageError` to reflect the fold.

## Test plan

- `go build ./...`, `go vet ./...`, `go tool go-arch-lint check --project-path .` — all pass.
- `go test ./...` — passes for every non-Docker package (usecase, resolver, loader, domain, …). The DB-backed packages (`internal/repository`, `internal/database`, `cmd/*`) require testcontainers/Docker, which is unavailable in this environment, so they are skipped locally and run in CI.

Closes #870
