### PR TITLE
refactor(backend): add UserPreference.EffectiveNewCardRatio and remove the dead zero-ratio guard

### DIFF
--- a/backend/graph/resolver/new_card_ratio.resolvers.go
+++ b/backend/graph/resolver/new_card_ratio.resolvers.go
@@ -55,8 +55,8 @@ func (r *userResolver) NewCardRatio(ctx context.Context, obj *model.User) (*mode
 		return nil, classifyLoaderErr(ctx, err, "resolver: user preference")
 	}
 	ratio := domain.DefaultNewCardRatio
-	if pref != nil && !pref.NewCardRatio.IsZero() {
-		ratio = pref.NewCardRatio
+	if pref != nil {
+		ratio = pref.EffectiveNewCardRatio()
 	}
 	return toNewCardRatioModel(ratio), nil
 }

--- a/backend/internal/domain/user_preference.go
+++ b/backend/internal/domain/user_preference.go
@@ -8,6 +8,20 @@ type UserPreference struct {
 	UserID                UserID
 	LastViewedCardgroupID *string
 	LearnDisplayMode      LearnDisplayMode
-	NewCardRatio          NewCardRatio // zero value means "use DefaultNewCardRatio"
+	NewCardRatio          NewCardRatio // zero value means "use DefaultNewCardRatio"; read via EffectiveNewCardRatio
 	UpdatedAt             time.Time
+}
+
+// EffectiveNewCardRatio resolves the stored NewCardRatio to the ratio a read
+// path should apply, substituting DefaultNewCardRatio for the invalid zero
+// value. This method is the single home of the "zero means default" rule; read
+// sites (the learn usecase and the newCardRatio resolver) call it instead of
+// re-checking NewCardRatio.IsZero() themselves. The repository mapper's own
+// pre-defaulting in toDomainUserPreference is a DB-read normalization of
+// out-of-bounds or legacy-zero column values, not a second owner of this rule.
+func (p UserPreference) EffectiveNewCardRatio() NewCardRatio {
+	if p.NewCardRatio.IsZero() {
+		return DefaultNewCardRatio
+	}
+	return p.NewCardRatio
 }

--- a/backend/internal/domain/user_preference_test.go
+++ b/backend/internal/domain/user_preference_test.go
@@ -1,0 +1,26 @@
+package domain
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUserPreference_EffectiveNewCardRatio_ZeroFallsBackToDefault(t *testing.T) {
+	t.Parallel()
+
+	// The zero value is never produced by ParseNewCardRatio; a UserPreference
+	// carrying it (a freshly built value, or a legacy row) resolves to the default.
+	p := UserPreference{}
+	require.True(t, p.NewCardRatio.IsZero())
+	require.Equal(t, DefaultNewCardRatio, p.EffectiveNewCardRatio())
+}
+
+func TestUserPreference_EffectiveNewCardRatio_SetValueIsReturned(t *testing.T) {
+	t.Parallel()
+
+	set, err := ParseNewCardRatio(3, 4)
+	require.NoError(t, err)
+	p := UserPreference{NewCardRatio: set}
+	require.Equal(t, set, p.EffectiveNewCardRatio())
+}

--- a/backend/internal/repository/user_preference.go
+++ b/backend/internal/repository/user_preference.go
@@ -178,7 +178,12 @@ SET new_card_ratio_num = EXCLUDED.new_card_ratio_num,
 //
 // new_card_ratio_num / new_card_ratio_den follow the same non-fatal posture:
 // an out-of-bounds or legacy zero value falls back to domain.DefaultNewCardRatio
-// rather than failing the read.
+// rather than failing the read. This is a DB-read normalization, not the owner
+// of the "zero means default" business rule — that rule lives in
+// domain.UserPreference.EffectiveNewCardRatio, which read paths call. Keeping
+// the normalization here means a corrupt or legacy stored value never leaves
+// the repository as an invalid zero; the domain method is the backstop for any
+// UserPreference not constructed through this mapper.
 func toDomainUserPreference(g gormUserPreference) *domain.UserPreference {
 	mode := domain.DefaultLearnDisplayMode
 	if parsed, err := domain.ParseLearnDisplayMode(g.LearnDisplayMode); err == nil {

--- a/backend/internal/usecase/learn.go
+++ b/backend/internal/usecase/learn.go
@@ -171,11 +171,12 @@ func (u *learnUsecase) NextDueCards(ctx context.Context, cardgroupID string, lim
 	// Load the caller's per-user new-vs-review ratio. A missing preference row
 	// (ErrNotFound), a nil pref, or a zero-value ratio all fall back to the
 	// default; a real infrastructure error propagates (context-done unwrapped).
+	// EffectiveNewCardRatio owns the zero-to-default resolution.
 	ratio := domain.DefaultNewCardRatio
 	pref, err := u.userPrefs.FindByUserID(ctx, user.Sub)
 	switch {
-	case err == nil && pref != nil && !pref.NewCardRatio.IsZero():
-		ratio = pref.NewCardRatio
+	case err == nil && pref != nil:
+		ratio = pref.EffectiveNewCardRatio()
 	case err != nil && !errors.Is(err, repository.ErrNotFound):
 		if isContextDone(err) {
 			return nil, err


### PR DESCRIPTION
## Summary

`UserPreference.NewCardRatio` documented a "zero value means use DefaultNewCardRatio" rule but no domain method encoded it — the rule was re-implemented at two read sites (`learn.go` and the `newCardRatio` resolver). Because the repository mapper already substitutes `DefaultNewCardRatio` for any invalid/zero stored value, the usecase guard `!pref.NewCardRatio.IsZero()` was a branch that could never be false. This change gives the rule one home in the domain and routes both read sites through it.

## Changes

- Add `func (p UserPreference) EffectiveNewCardRatio() NewCardRatio` in `backend/internal/domain/user_preference.go`, returning `DefaultNewCardRatio` when the stored ratio is the zero value and the stored value otherwise. Its docstring names it the single owner of the zero-to-default rule.
- Route `usecase/learn.go` through the method: the dead `!pref.NewCardRatio.IsZero()` branch collapses to `pref.EffectiveNewCardRatio()` (the `pref != nil` guard stays — a value-receiver call on a nil pointer would panic).
- Route the `newCardRatio` resolver (`graph/resolver/new_card_ratio.resolvers.go`) through the same method, dropping its duplicate `!IsZero()` re-check.
- Document the single-home decision in the repository mapper `toDomainUserPreference`: its pre-defaulting stays as an explicit DB-read normalization (a corrupt/legacy zero never leaves the repo), and is explicitly NOT a second owner of the business rule — the domain method is the backstop for any `UserPreference` not built through the mapper.
- Add a domain test pinning `EffectiveNewCardRatio` for the zero-fallback and set-value cases.

Behavior is unchanged: the effective ratio is identical for zero and non-zero stored values.

## Test plan

- `go build ./...`, `go vet ./...`, and `go tool go-arch-lint check --project-path .` all pass.
- `go test ./...`: domain, domain/service, usecase, resolver, and loader packages pass, including the two new domain tests. Docker-backed integration packages (repository, database, cmd/server, cmd/seed, cmd/migrate-to-master) are skipped locally because Docker/testcontainers is unavailable; they compile cleanly and run in CI.
- Grep confirms no read path re-checks `NewCardRatio.IsZero()` anymore.

Closes #871
