### PR TITLE
docs(backend): correct studyStreak to JST learn-day bucketing, not UTC calendar days

### DIFF
--- a/docs/backend-graphql.md
+++ b/docs/backend-graphql.md
@@ -282,7 +282,7 @@ The response exposes both `performanceMode` and `metrics`. `performanceMode` is 
 
 The legacy guard is preserved: fewer than 20 reviews always returns `ModeDefault`. Average difficulty then shifts the mode by one step: `>= 0.7` lowers it, `<= 0.3` raises it, and the final value is clamped to `0..4`. Current FSRS difficulty values are stored on the `1..10` scale, so the calculator normalizes them into `0..1` before applying those boundaries.
 
-`StudyStreak` uses the server's UTC `now` supplied by the usecase. It counts consecutive calendar days with at least one swipe, starting from today. This is intentionally not locale-aware; user-local streaks require a profile time-zone field and should be introduced as a separate feature.
+`StudyStreak` buckets each swipe by its **JST learn-day** rather than by UTC calendar day. Every swipe is keyed with `domain.LearnDayKey(swipe.ReviewedAt)` and the streak walks back from `domain.StartOfLearnDay(now)`, both of which use a fixed UTC+9 offset (`time.FixedZone("JST", 9*60*60)` in [`backend/internal/domain/learn_day.go`](../backend/internal/domain/learn_day.go)). The learn-day therefore rolls over at **15:00 UTC** (JST midnight), not UTC midnight, and the streak is 0 whenever the current JST learn-day has no swipe yet. This keeps `studyStreak` consistent with the learn queue's JST start-of-day cutoff — see [`docs/backend/ddd-patterns/discovery-first-due-ordering.md` § "Contracts"](backend/ddd-patterns/discovery-first-due-ordering.md#contracts). The UTC+9 offset is hard-coded because the product currently assumes a Japan-resident learner; a per-user profile time-zone field would replace it as a separate feature.
 
 ### Integration tests
 


### PR DESCRIPTION
## Summary

`PerformanceMetrics.studyStreak` (returned on `myLearningStats` and `handleSwipe`) was documented in `docs/backend-graphql.md` as counting consecutive UTC calendar days and as "intentionally not locale-aware". Both claims are false: the implementation buckets each swipe by `domain.LearnDayKey(swipe.ReviewedAt)` and walks the streak back from `domain.StartOfLearnDay(now)`, both of which use a fixed UTC+9 (JST) offset. The learn-day rolls over at 15:00 UTC (JST midnight), 9 hours earlier than the documented UTC boundary, and the code is locale-aware (hard-coded JST).

The JST bucketing is the deliberate product decision — it keeps `studyStreak` consistent with the learn queue's JST start-of-day cutoff and matches the app's Japan-resident learners' local midnight. Only the doc was stale, so this is a docs-only change with no code change.

## Changes

- `docs/backend-graphql.md`: rewrote the study-streak paragraph to state that `studyStreak` buckets swipes by JST learn-day via `domain.LearnDayKey` / `domain.StartOfLearnDay` (fixed UTC+9), rolling over at 15:00 UTC, and that the streak is 0 when the current JST learn-day has no swipe yet. Dropped the false "uses the server's UTC `now`" and "intentionally not locale-aware" wording, and noted the future per-user profile time-zone field. Added cross-references to `backend/internal/domain/learn_day.go` and `docs/backend/ddd-patterns/discovery-first-due-ordering.md` § "Contracts" so the two specs stay in sync.

## Test plan

- Docs-only change; no production code, schema, or generated code touched. Backend build/test gates are unaffected and not re-run for a prose edit.
- Verified: English-only (CJK grep via `perl -CSD` prints nothing); every referenced file and symbol exists (`backend/internal/domain/learn_day.go` with `LearnDayKey` / `StartOfLearnDay`; `docs/backend/ddd-patterns/discovery-first-due-ordering.md` § "Contracts").

Closes #888
