### PR TITLE
fix(backend): route ImportMasterCards through validateImportRows for cap parity

### DIFF
--- a/backend/internal/usecase/master_card.go
+++ b/backend/internal/usecase/master_card.go
@@ -445,8 +445,14 @@ func (u *masterCardUsecase) ImportMasterCards(ctx context.Context, in ImportMast
 		return ImportMasterCardsOutput{}, eris.Wrap(perr, "usecase: master card: import: parse")
 	}
 
-	if len(words) > cardImportParsedRowCap {
-		return ImportMasterCardsOutput{}, ucerr.NewValidationError("payload", fmt.Sprintf("payload exceeds %d row cap", cardImportParsedRowCap))
+	// Enforce the same caps the user path (card_import.go) reports, via the shared
+	// checker, so the master import cannot diverge from the batch-import preview.
+	// Checked on the raw parsed words (before dedup) so both the parsed-row cap and
+	// the per-side grapheme cap reject identically. The first violation aborts the
+	// whole batch (all-or-nothing). The build loop below keeps domain.NewMasterCard,
+	// so validateImportRows' returned VOs are discarded here.
+	if _, caps := validateImportRows(words); len(caps) > 0 {
+		return ImportMasterCardsOutput{}, ucerr.NewValidationError(caps[0].Field, caps[0].Message)
 	}
 
 	mappedErrs := cardImportErrorsFromTextdic(parseErrs)

--- a/backend/internal/usecase/master_card_write_test.go
+++ b/backend/internal/usecase/master_card_write_test.go
@@ -3,6 +3,7 @@ package usecase
 import (
 	"context"
 	"encoding/base64"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -710,10 +711,63 @@ func TestMasterCard_ImportMasterCards_OverCap(t *testing.T) {
 		}
 		return words, nil, nil
 	}
-	tx, _ := dictTxRunner()
-	uc := newMasterCardImportUC(t, &mockMasterCardWriteRepo{}, tx, true, process)
+	tx, calls := dictTxRunner()
+	mc := &mockMasterCardWriteRepo{}
+	uc := newMasterCardImportUC(t, mc, tx, true, process)
 	_, err := uc.ImportMasterCards(authedCtx("admin1"), ImportMasterCardsInput{MasterCardgroupID: "m1", Payload: b64("ignored")})
-	assertValidationError(t, err, "payload", "")
+	// Same message as the user path (card_import.go): both route the row cap
+	// through the shared validateImportRows checker.
+	assertValidationError(t, err, "payload", fmt.Sprintf("payload exceeds %d row cap", cardImportParsedRowCap))
+	// All-or-nothing: an over-cap payload never opens a tx or reaches the repo.
+	if *calls != 0 || mc.upsertCalls != 0 {
+		t.Fatalf("over-cap payload must not persist, got tx=%d upserts=%d", *calls, mc.upsertCalls)
+	}
+}
+
+// A row whose front exceeds the per-side grapheme cap parses cleanly through
+// textdic but is rejected pre-dedup by the shared validateImportRows checker,
+// with the SAME typed validation error (field "front", identical message) as the
+// user path in card_import.go. Before this parity fix the master path only
+// enforced the grapheme cap at construction time (post-dedup), diverging from
+// the user path and the batch-import preview.
+func TestMasterCard_ImportMasterCards_OverLengthFront(t *testing.T) {
+	t.Parallel()
+	long := strings.Repeat("a", domain.CardTextMax+1)
+	process := func(string) ([]textdic.ParsedWord, []textdic.ValidationError, error) {
+		return []textdic.ParsedWord{
+			{Front: "Apple", Back: "back-a", Line: 1},
+			{Front: long, Back: "back-b", Line: 2},
+		}, nil, nil
+	}
+	tx, calls := dictTxRunner()
+	mc := &mockMasterCardWriteRepo{}
+	uc := newMasterCardImportUC(t, mc, tx, true, process)
+	_, err := uc.ImportMasterCards(authedCtx("admin1"), ImportMasterCardsInput{MasterCardgroupID: "m1", Payload: b64("ignored")})
+	assertValidationError(t, err, "front", fmt.Sprintf("front must be at most %d characters", domain.CardTextMax))
+	if *calls != 0 || mc.upsertCalls != 0 {
+		t.Fatalf("over-length front must not persist, got tx=%d upserts=%d", *calls, mc.upsertCalls)
+	}
+}
+
+// Mirror of the front test for the back side: an over-length back is rejected
+// pre-dedup with the same typed validation error (field "back") as the user path.
+func TestMasterCard_ImportMasterCards_OverLengthBack(t *testing.T) {
+	t.Parallel()
+	long := strings.Repeat("b", domain.CardTextMax+1)
+	process := func(string) ([]textdic.ParsedWord, []textdic.ValidationError, error) {
+		return []textdic.ParsedWord{
+			{Front: "Apple", Back: "back-a", Line: 1},
+			{Front: "Banana", Back: long, Line: 2},
+		}, nil, nil
+	}
+	tx, calls := dictTxRunner()
+	mc := &mockMasterCardWriteRepo{}
+	uc := newMasterCardImportUC(t, mc, tx, true, process)
+	_, err := uc.ImportMasterCards(authedCtx("admin1"), ImportMasterCardsInput{MasterCardgroupID: "m1", Payload: b64("ignored")})
+	assertValidationError(t, err, "back", fmt.Sprintf("back must be at most %d characters", domain.CardTextMax))
+	if *calls != 0 || mc.upsertCalls != 0 {
+		t.Fatalf("over-length back must not persist, got tx=%d upserts=%d", *calls, mc.upsertCalls)
+	}
 }
 
 func TestMasterCard_ImportMasterCards_EmptyParseNoPersist(t *testing.T) {


### PR DESCRIPTION
## Summary

The user card-import path validates parsed rows through the shared `validateImportRows` cap checker (parsed-row cap + per-side grapheme cap, pre-dedup), matching the batch-import wizard's preview. `ImportMasterCards` hand-rolled only the row-cap check, so the master path diverged: the grapheme cap was enforced only at construction time (post-dedup) and the row-cap literal was duplicated.

This routes `ImportMasterCards` through the same `validateImportRows` checker, before dedup. Both caps are now single-sourced and the master import rejects over-length/over-cap input with the identical typed validation errors (same field, same message) as the user path. Construction still goes through `domain.NewMasterCard`, so the shared checker's returned VOs are discarded here — the change is purely about cap enforcement parity.

## Changes

- `backend/internal/usecase/master_card.go`: replaced the hand-rolled `len(words) > cardImportParsedRowCap` check in `ImportMasterCards` with `validateImportRows(words)`, run pre-dedup, mapping the first violation to `ucerr.NewValidationError(caps[0].Field, caps[0].Message)`. This single-sources the row-cap literal and adds pre-dedup grapheme-cap enforcement.
- `backend/internal/usecase/master_card_write_test.go`: added `TestMasterCard_ImportMasterCards_OverLengthFront` and `_OverLengthBack` asserting the master path rejects over-length front/back with the same field and message as the user path; strengthened the existing `OverCap` test to assert the exact row-cap message and that no tx/upsert runs.

## Test plan

- `go tool gqlgen generate`, `go vet ./...`, `go build ./...`, `go tool go-arch-lint check --project-path .` — pass
- `go test ./internal/usecase/ -run 'TestMasterCard_ImportMasterCards_...'` — the new over-length front/back tests and the strengthened over-cap test pass (stub-based, no DB). Docker-backed integration packages (repository/database/cmd/*) require testcontainers/Docker, unavailable locally, so they are skipped here and run in CI.

Closes #897
