### PR TITLE
fix(backend): route the last-admin deletion guard through one shared helper

### DIFF
--- a/backend/internal/usecase/admin_user.go
+++ b/backend/internal/usecase/admin_user.go
@@ -447,17 +447,14 @@ func (u *adminUserUsecase) DeleteUser(ctx context.Context, id string) error {
 		}
 		return eris.Wrap(err, "usecase: admin user: delete: check admin role")
 	}
-	if isAdmin {
-		n, err := u.userRoles.CountAdmins(ctx)
-		if err != nil {
-			if isContextDone(err) {
-				return err
-			}
-			return eris.Wrap(err, "usecase: admin user: delete: count admins")
-		}
-		if domain.IsLastAdmin(n) {
-			return ucerr.NewForbiddenError("cannot delete the last admin account")
-		}
+	if err := guardNotLastAdmin(
+		ctx,
+		isAdmin,
+		u.userRoles,
+		"usecase: admin user: delete: count admins",
+		"cannot delete the last admin account",
+	); err != nil {
+		return err
 	}
 
 	if err := u.users.DeleteAuthUser(ctx, id); err != nil {

--- a/backend/internal/usecase/last_admin_guard.go
+++ b/backend/internal/usecase/last_admin_guard.go
@@ -1,0 +1,52 @@
+package usecase
+
+import (
+	"context"
+
+	"github.com/rotisserie/eris"
+
+	"backend/internal/domain"
+	"backend/internal/usecase/ucerr"
+)
+
+// AdminCounter reports the number of users holding the admin role. It is the
+// narrow port consumed by guardNotLastAdmin; both adminUserRoleRepository
+// (DeleteUser) and UserRolesRepository (DeleteMyAccount) satisfy it via their
+// CountAdmins method.
+type AdminCounter interface {
+	CountAdmins(ctx context.Context) (int64, error)
+}
+
+// guardNotLastAdmin enforces the "never delete the last admin" availability
+// invariant shared by DeleteUser and DeleteMyAccount. When isTargetAdmin is
+// true and the account being removed is the only remaining admin, it returns a
+// forbidden error carrying forbidMsg so the system is never left without an
+// admin. When isTargetAdmin is false the admin count is never consulted.
+//
+// The membership decision differs per caller (HasRole for an arbitrary target
+// vs IsAdmin for the caller), so it is computed at the call site and passed in
+// as isTargetAdmin. wrapPrefix and forbidMsg are likewise caller-supplied: the
+// wrap prefix must attribute the CountAdmins failure to the calling module, not
+// this helper, per the shared-helper rule in .claude/rules/error-wrapping.md.
+func guardNotLastAdmin(
+	ctx context.Context,
+	isTargetAdmin bool,
+	counter AdminCounter,
+	wrapPrefix string,
+	forbidMsg string,
+) error {
+	if !isTargetAdmin {
+		return nil
+	}
+	n, err := counter.CountAdmins(ctx)
+	if err != nil {
+		if isContextDone(err) {
+			return err
+		}
+		return eris.Wrap(err, wrapPrefix)
+	}
+	if domain.IsLastAdmin(n) {
+		return ucerr.NewForbiddenError(forbidMsg)
+	}
+	return nil
+}

--- a/backend/internal/usecase/user.go
+++ b/backend/internal/usecase/user.go
@@ -12,7 +12,6 @@ import (
 	"backend/internal/auth"
 	"backend/internal/domain"
 	"backend/internal/repository"
-	"backend/internal/usecase/ucerr"
 )
 
 // UserRepository is the consumer-driven interface used by UserUsecase.
@@ -164,17 +163,14 @@ func (u *userUsecase) DeleteMyAccount(ctx context.Context) error {
 		}
 		return eris.Wrap(err, "usecase: user: delete my account: check admin")
 	}
-	if isAdmin {
-		n, err := u.roles.CountAdmins(ctx)
-		if err != nil {
-			if isContextDone(err) {
-				return err
-			}
-			return eris.Wrap(err, "usecase: user: delete my account: count admins")
-		}
-		if domain.IsLastAdmin(n) {
-			return ucerr.NewForbiddenError("cannot delete the last admin account; promote another admin first")
-		}
+	if err := guardNotLastAdmin(
+		ctx,
+		isAdmin,
+		u.roles,
+		"usecase: user: delete my account: count admins",
+		"cannot delete the last admin account; promote another admin first",
+	); err != nil {
+		return err
 	}
 
 	if err := u.repo.DeleteAuthUser(ctx, caller.Sub); err != nil {


### PR DESCRIPTION
## Summary

The "never delete the last admin" safety guard was orchestrated twice, verbatim, in two usecases: `DeleteUser` (`admin_user.go`) and `DeleteMyAccount` (`user.go`). Both ran the same three-step block — check admin membership, `CountAdmins`, then `domain.IsLastAdmin` → forbid — wrapped in identical context-done/`eris.Wrap` boilerplate. Because leaving the system with zero admins locks everyone out, drift between the two copies is a correctness risk, not just a DRY nit.

This routes both surfaces through one package-private helper, `guardNotLastAdmin`, that owns the `CountAdmins` → `IsLastAdmin` → forbid + context-done/wrap tail. The membership decision differs per caller (`HasRole` for an arbitrary target vs `IsAdmin` for the caller), so each site computes its own membership bool and passes it in, along with its own wrap prefix and forbid message — so each surface keeps its exact wire message and error-wrap prefix (the existing tests pin both). Per `.claude/rules/error-wrapping.md`, the helper does not embed a fixed layer prefix; the caller supplies it so the logged `error_chain` still attributes the `CountAdmins` failure to the calling module.

## Changes

- Add `backend/internal/usecase/last_admin_guard.go`: the narrow `AdminCounter` port (a `CountAdmins` method, satisfied structurally by both existing narrow repo interfaces) and `guardNotLastAdmin(ctx, isTargetAdmin, counter, wrapPrefix, forbidMsg)`.
- `backend/internal/usecase/admin_user.go` `DeleteUser`: replace the inline `CountAdmins`/`IsLastAdmin`/forbid block with a `guardNotLastAdmin` call carrying `"usecase: admin user: delete: count admins"` and `"cannot delete the last admin account"`. The `HasRole` membership call stays per-site.
- `backend/internal/usecase/user.go` `DeleteMyAccount`: replace the identical block with a `guardNotLastAdmin` call carrying `"usecase: user: delete my account: count admins"` and `"cannot delete the last admin account; promote another admin first"`. The `IsAdmin` membership call stays per-site; drop the now-unused `ucerr` import (moved into the helper).

The existing `"last admin is forbidden"` subtests in `admin_user_test.go` and `user_test.go` already pin the forbid outcome and exact message on both paths; they exercise the refactored helper through the public methods and stay green unchanged.

## Test plan

- `go tool gqlgen generate`, `go vet ./...`, `go build ./...`, `go tool go-arch-lint check --project-path .` — pass
- `go test ./internal/usecase/... -count=1` — 793 passed, including the last-admin-forbidden subtests for both `DeleteUser` and `DeleteMyAccount`. Docker-backed integration packages (repository/database/cmd/*) require testcontainers/Docker, unavailable locally, so they are skipped here and run in CI.

Closes #894
