### PR TITLE
fix(backend): normalize FSRS difficulty at the 1.0 floor so performanceMode does not invert

### DIFF
--- a/backend/internal/domain/service/user_performance.go
+++ b/backend/internal/domain/service/user_performance.go
@@ -15,15 +15,15 @@ const (
 	ModeDefault   PerformanceMode = 1
 	ModeGood      PerformanceMode = 2
 	ModeEasy      PerformanceMode = 3
-	ModeMastered   PerformanceMode = 4
+	ModeMastered  PerformanceMode = 4
 
 	MinReviewsForModeCalculation = 20
 
 	// Success-rate band thresholds for ModeFromMetrics. A success rate at or
 	// above each threshold selects the named mode (or higher).
-	defaultModeThreshold = 0.60
-	goodModeThreshold    = 0.75
-	easyModeThreshold    = 0.85
+	defaultModeThreshold  = 0.60
+	goodModeThreshold     = 0.75
+	easyModeThreshold     = 0.85
 	masteredModeThreshold = 0.95
 
 	// Average-difficulty nudges shift the band-selected mode by one step:
@@ -116,10 +116,13 @@ func ModeFromMetrics(m PerformanceMetrics) PerformanceMode {
 	return clampMode(mode)
 }
 
+// normalizedDifficulty maps a stored FSRS difficulty on the 1..10 scale into
+// 0..1 as difficulty/10, clamped to [0,1]. The division is unconditional so a
+// mastered card pinned at the FSRS floor of exactly 1.0 normalizes to 0.1 (the
+// low-difficulty band) rather than 1.0; a strict `> 1` guard would leave the
+// floor at 1.0 and trip the high-difficulty threshold, inverting the mode down.
 func normalizedDifficulty(difficulty float64) float64 {
-	if difficulty > 1 {
-		difficulty = difficulty / 10
-	}
+	difficulty = difficulty / 10
 	if difficulty < 0 {
 		return 0
 	}

--- a/backend/internal/domain/service/user_performance_test.go
+++ b/backend/internal/domain/service/user_performance_test.go
@@ -220,6 +220,82 @@ func TestModeFromMetricsDifficultyAdjustments(t *testing.T) {
 	}
 }
 
+// TestNormalizedDifficulty pins the difficulty/10 mapping at its boundary
+// values. The FSRS floor of exactly 1.0 must normalize to 0.1 (the
+// low-difficulty band), not 1.0 — the bug that inverted the mode for mastered
+// cards left a strict `> 1` guard that skipped the division at the floor.
+func TestNormalizedDifficulty(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		difficulty float64
+		want       float64
+	}{
+		{"fsrs floor maps to low band", 1.0, 0.1},
+		{"just above floor", 1.5, 0.15},
+		{"midscale", 5.0, 0.5},
+		{"fsrs ceiling maps to one", 10.0, 1.0},
+		{"zero maps to zero", 0.0, 0.0},
+		{"negative clamps to zero", -3.0, 0.0},
+		{"above ceiling clamps to one", 12.0, 1.0},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.InDelta(t, tc.want, normalizedDifficulty(tc.difficulty), 0.000000001)
+		})
+	}
+}
+
+// TestNormalizedDifficultyMonotonic proves the normalization is non-decreasing
+// as the stored difficulty rises across the full 1..10 FSRS scale, so a harder
+// card never normalizes lower than an easier one.
+func TestNormalizedDifficultyMonotonic(t *testing.T) {
+	t.Parallel()
+
+	prev := normalizedDifficulty(1.0)
+	for d := 1.0; d <= 10.0; d += 0.5 {
+		got := normalizedDifficulty(d)
+		require.GreaterOrEqualf(t, got, prev,
+			"normalizedDifficulty must be non-decreasing: difficulty %.1f gave %.4f after %.4f", d, got, prev)
+		prev = got
+	}
+}
+
+// TestModeFromMetricsFSRSFloorNotDecremented drives a 20-swipe history whose
+// cards all sit at the FSRS difficulty floor of 1.0. The mastered cards must
+// normalize into the low-difficulty band (0.1) and raise the mode, never trip
+// the high-difficulty threshold and decrement it below the success-rate band.
+func TestModeFromMetricsFSRSFloorNotDecremented(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 4, 30, 3, 0, 0, 0, time.UTC)
+
+	swipes := make([]domain.SwipeRecord, 0, MinReviewsForModeCalculation)
+	for i := 0; i < 16; i++ {
+		swipes = append(swipes, swipe(domain.RatingGood, now, state(1.0, 1, 1, domain.FSRSPhaseReview)))
+	}
+	for i := 0; i < 4; i++ {
+		swipes = append(swipes, swipe(domain.RatingAgain, now, state(1.0, 1, 1, domain.FSRSPhaseReview)))
+	}
+
+	metrics := ComputeMetrics(swipes, now)
+	// 16/20 successes selects the Good success-rate band (0.75 <= rate < 0.85).
+	require.InDelta(t, 0.80, metrics.SuccessRate, 0.000000001)
+	// All cards at the floor normalize to 0.1, the low-difficulty band.
+	require.InDelta(t, 0.10, metrics.AvgDifficulty, 0.000000001)
+
+	got := ModeFromMetrics(metrics)
+	// The floor difficulty is <= 0.3, so the mode is raised to ModeEasy; it must
+	// not be decremented below the Good band the success rate selected.
+	require.GreaterOrEqual(t, int(got), int(ModeGood))
+	require.Equal(t, ModeEasy, got)
+}
+
 func TestPerformanceModeIsValid(t *testing.T) {
 	t.Parallel()
 

--- a/docs/backend-graphql.md
+++ b/docs/backend-graphql.md
@@ -280,7 +280,7 @@ The response exposes both `performanceMode` and `metrics`. `performanceMode` is 
 | `3` | Easy | `0.85 <= rate < 0.95` |
 | `4` | In While | `>= 0.95` |
 
-The legacy guard is preserved: fewer than 20 reviews always returns `ModeDefault`. Average difficulty then shifts the mode by one step: `>= 0.7` lowers it, `<= 0.3` raises it, and the final value is clamped to `0..4`. Current FSRS difficulty values are stored on the `1..10` scale, so the calculator normalizes them into `0..1` before applying those boundaries.
+The legacy guard is preserved: fewer than 20 reviews always returns `ModeDefault`. Average difficulty then shifts the mode by one step: `>= 0.7` lowers it, `<= 0.3` raises it, and the final value is clamped to `0..4`. Current FSRS difficulty values are stored on the `1..10` scale, so the calculator normalizes each one as `normalized = difficulty / 10`, clamped to `[0, 1]`, before applying those boundaries. The division is unconditional: a mastered card whose FSRS difficulty is pinned at the floor of exactly `1.0` maps to `0.1` (the low-difficulty band), not `1.0`. A strict `> 1` guard would leave the floor at `1.0` and trip the high-difficulty threshold, inverting the mode downward for the easiest cards.
 
 `StudyStreak` uses the server's UTC `now` supplied by the usecase. It counts consecutive calendar days with at least one swipe, starting from today. This is intentionally not locale-aware; user-local streaks require a profile time-zone field and should be introduced as a separate feature.
 


### PR DESCRIPTION
## Summary

`performanceMode` (returned on every `handleSwipe` and on `myLearningStats`) is derived from the learner's recent-swipe `AvgDifficulty`, computed by `normalizedDifficulty`, which is documented to map the stored `1..10` FSRS difficulty into `0..1` before applying the band boundaries. The implementation guarded the division with `if difficulty > 1`, so it skipped the `/10` step at **exactly** `1.0`.

go-fsrs `constrainDifficulty` = `min(max(d,1),10)` drives a well-learned card's difficulty to the clamp floor of exactly `1.0` and pins it there. Under the strict `> 1` guard those easiest cards read as `AvgDifficulty = 1.0`, which trips `highDifficultyThreshold (0.7)` and **lowers** the band instead of raising it — precisely when a learner cruises through mastered material the adaptive mode is pushed down. The map was also non-monotone at the floor (`1.0 → 1.0` while `7.5 → 0.75`).

This normalizes unconditionally as `difficulty / 10` (keeping the existing `[0, 1]` clamps), so `1.0 → 0.1`, `7.5 → 0.75`, `10 → 1.0`, and the mapping is monotone.

## Changes

- `backend/internal/domain/service/user_performance.go`: `normalizedDifficulty` drops the `if difficulty > 1` guard and divides by 10 unconditionally, keeping the lower/upper clamps to `[0, 1]`. Added a docstring stating the exact formula and the floor-inversion the guard caused. (gofmt also realigned the adjacent const block that was touched.)
- `docs/backend-graphql.md` "Adaptive learning performance mode": states the exact formula `normalized = difficulty / 10` clamped to `[0, 1]`, and that a stored `1.0` maps to `0.1`.
- `backend/internal/domain/service/user_performance_test.go` (pure unit, no DB): `TestNormalizedDifficulty` pins the boundary values (`1.0 → 0.1`, `1.5 → 0.15`, `10.0 → 1.0`, plus the clamps); `TestNormalizedDifficultyMonotonic` asserts the mapping is non-decreasing across `[1, 10]`; `TestModeFromMetricsFSRSFloorNotDecremented` drives a 20-swipe history all at the FSRS floor (`1.0`) and asserts `performanceMode` is raised to `ModeEasy` and not decremented below the Good success-rate band.

## Test plan

- `go tool gqlgen generate`, `go vet ./...`, `go build ./...`, `go tool go-arch-lint check --project-path .` — pass
- `go test ./internal/domain/service/ -count=1` — passes, including the three new tests and the existing `TestComputeMetrics` / `TestModeFromMetrics*` cases (`5.0 → 0.5`, `3.0/7.0 → 0.3/0.7` still hold). This is a pure-unit package with no DB dependency. Docker-backed integration packages (repository/database/cmd/*) require testcontainers/Docker, unavailable locally, so they are skipped here and run in CI.

Closes #885
