### PR TITLE
fix(backend): guard swipeRecordToDomain enum casts with IsValid

### DIFF
--- a/backend/internal/repository/swipe_record.go
+++ b/backend/internal/repository/swipe_record.go
@@ -54,7 +54,10 @@ func (r *swipeRecordRepo) FindByIDs(ctx context.Context, ids []string) (map[stri
 	}
 	out := make(map[string]*domain.SwipeRecord, len(rows))
 	for i := range rows {
-		sr := swipeRecordToDomain(rows[i])
+		sr, err := swipeRecordToDomain(rows[i])
+		if err != nil {
+			return nil, err
+		}
 		out[sr.ID] = sr
 	}
 	return out, nil
@@ -70,7 +73,11 @@ func (r *swipeRecordRepo) FindByUserAndCardgroup(ctx context.Context, userID, ca
 	}
 	out := make([]*domain.SwipeRecord, len(rows))
 	for i := range rows {
-		out[i] = swipeRecordToDomain(rows[i])
+		sr, err := swipeRecordToDomain(rows[i])
+		if err != nil {
+			return nil, err
+		}
+		out[i] = sr
 	}
 	return out, nil
 }
@@ -91,7 +98,11 @@ func (r *swipeRecordRepo) ListRecentByUser(ctx context.Context, userID string, l
 
 	out := make([]*domain.SwipeRecord, len(rows))
 	for i := range rows {
-		out[i] = swipeRecordToDomain(rows[i])
+		sr, err := swipeRecordToDomain(rows[i])
+		if err != nil {
+			return nil, err
+		}
+		out[i] = sr
 	}
 	return out, nil
 }
@@ -109,7 +120,11 @@ func (r *swipeRecordRepo) ListByUserSince(ctx context.Context, userID string, si
 	}
 	out := make([]*domain.SwipeRecord, 0, len(rows))
 	for i := range rows {
-		out = append(out, swipeRecordToDomain(rows[i]))
+		sr, err := swipeRecordToDomain(rows[i])
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, sr)
 	}
 	return out, nil
 }
@@ -141,13 +156,21 @@ func swipeRecordToRow(sr *domain.SwipeRecord) *gormSwipeRecord {
 	}
 }
 
-func swipeRecordToDomain(row gormSwipeRecord) *domain.SwipeRecord {
+func swipeRecordToDomain(row gormSwipeRecord) (*domain.SwipeRecord, error) {
+	rating := domain.Rating(row.Rating)
+	if !rating.IsValid() {
+		return nil, eris.Errorf("repository: invalid Rating value %d for swipe record %s", row.Rating, row.ID)
+	}
+	phase := domain.FSRSPhase(row.State)
+	if !phase.IsValid() {
+		return nil, eris.Errorf("repository: invalid FSRSPhase value %d for swipe record %s", row.State, row.ID)
+	}
 	return &domain.SwipeRecord{
 		ID:          row.ID,
 		UserID:      domain.UserID(row.UserID),
 		CardID:      row.CardID,
 		CardgroupID: domain.CardgroupID(row.CardgroupID),
-		Rating:      domain.Rating(row.Rating),
+		Rating:      rating,
 		ReviewedAt:  row.ReviewedAt,
 		StateAfter: domain.FSRSState{
 			Due:           row.Due,
@@ -157,8 +180,8 @@ func swipeRecordToDomain(row gormSwipeRecord) *domain.SwipeRecord {
 			ScheduledDays: row.ScheduledDays,
 			Reps:          row.Reps,
 			Lapses:        row.Lapses,
-			Phase:         domain.FSRSPhase(row.State),
+			Phase:         phase,
 			LastReview:    row.LastReview,
 		},
-	}
+	}, nil
 }

--- a/backend/internal/repository/swipe_record_test.go
+++ b/backend/internal/repository/swipe_record_test.go
@@ -221,3 +221,69 @@ func TestSwipeRecordRepository_ListByUserSince_InclusiveBoundaryAndScopes(t *tes
 	require.NotContains(t, ids, idBeforeSince, "reviewed_at strictly before since is excluded")
 	require.NotContains(t, ids, idOtherAtSince, "another user's swipe is excluded")
 }
+
+// TestSwipeRecordRepository_OutOfRangeState_ReturnsError proves the reconstitution
+// guard in swipeRecordToDomain rejects a corrupt enum value instead of silently
+// miscounting it in the performance metrics, per
+// docs/backend/library-gotchas/gorm-enum-cast-isvalid.md. A row whose `state`
+// column holds an out-of-range FSRSPhase (99) must surface a non-nil error from
+// every read path, not reconstitute a SwipeRecord carrying an invalid Phase.
+//
+// The `rating` column is not exercised here because a persisted out-of-range
+// rating is impossible: the swipe_records schema enforces
+// `CHECK (rating BETWEEN 1 AND 4)`, so the rating-side IsValid() guard is
+// defense-in-depth against future schema drift or a manual SQL edit, not a
+// condition a persisted row can reach today.
+func TestSwipeRecordRepository_OutOfRangeState_ReturnsError(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	ownerID := insertAuthUser(t, ctx)
+	cg := insertCardgroup(t, ctx, ownerID)
+	cardRepo := repository.NewCardRepository(testDB.GORM)
+	swipeRepo := repository.NewSwipeRecordRepository(testDB.GORM)
+
+	card := newCard(cg.ID, "out of range state", "back")
+	require.NoError(t, cardRepo.Create(ctx, card))
+
+	reviewedAt := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	state := domain.NewFSRSStateForNewCard(reviewedAt)
+	state.Phase = domain.FSRSPhase(99) // out of range; no DB CHECK on the state column
+	corrupt := &domain.SwipeRecord{
+		ID:          "00000000-0000-0000-0000-0000000000c1",
+		UserID:      domain.UserID(ownerID),
+		CardID:      card.ID,
+		CardgroupID: cg.ID,
+		Rating:      domain.RatingEasy,
+		ReviewedAt:  reviewedAt,
+		StateAfter:  state,
+	}
+	require.NoError(t, testDB.GORM.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		return swipeRepo.CreateTx(ctx, tx, corrupt)
+	}))
+
+	reads := map[string]func() error{
+		"FindByIDs": func() error {
+			_, err := swipeRepo.FindByIDs(ctx, []string{corrupt.ID})
+			return err
+		},
+		"FindByUserAndCardgroup": func() error {
+			_, err := swipeRepo.FindByUserAndCardgroup(ctx, ownerID, string(cg.ID))
+			return err
+		},
+		"ListRecentByUser": func() error {
+			_, err := swipeRepo.ListRecentByUser(ctx, ownerID, 10)
+			return err
+		},
+		"ListByUserSince": func() error {
+			_, err := swipeRepo.ListByUserSince(ctx, ownerID, reviewedAt.Add(-time.Hour))
+			return err
+		},
+	}
+	for name, read := range reads {
+		t.Run(name, func(t *testing.T) {
+			err := read()
+			require.Error(t, err, "an out-of-range FSRSPhase must propagate as an error, not a silent success")
+			require.Contains(t, err.Error(), "invalid FSRSPhase value 99")
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`swipeRecordToDomain` reconstituted a `SwipeRecord` from its DB row by casting
`domain.Rating(row.Rating)` and `domain.FSRSPhase(row.State)` with no `IsValid()`
guard, unlike its two sibling reconstitution sites (`card_due.go`,
`user_card_fsrs.go`). A corrupt `state` value flowed unchecked into
`service.ComputeMetrics` via `user_performance.go` — a `Phase` outside the
`New..Relearning` range mis-buckets lapse/review metrics — with no error raised,
per the convention in
`docs/backend/library-gotchas/gorm-enum-cast-isvalid.md` (call `IsValid()` at
every reconstitution site).

This guards both casts in `swipeRecordToDomain`, returning `(nil, error)` via
`eris.Errorf` (mirroring `card_due.go`), and propagates the error through the
four callers in the file (`FindByIDs`, `FindByUserAndCardgroup`,
`ListRecentByUser`, `ListByUserSince`). The DataLoader interface signature
(`loader/swipe_record.go`) is unchanged.

## Changes

- `backend/internal/repository/swipe_record.go`: `swipeRecordToDomain` now returns
  `(*domain.SwipeRecord, error)`, guarding `domain.Rating(row.Rating)` and
  `domain.FSRSPhase(row.State)` with `IsValid()` and erroring on an out-of-range
  value. The four read methods propagate the error.
- `backend/internal/repository/swipe_record_test.go`: add
  `TestSwipeRecordRepository_OutOfRangeState_ReturnsError` — seeds a row with an
  out-of-range `state` (99) and asserts every read path returns an error, not a
  silent success. The `rating` half is documented as defense-in-depth only: the
  `swipe_records` schema enforces `CHECK (rating BETWEEN 1 AND 4)`, so a persisted
  out-of-range rating is unreachable today, and the rating-side guard protects
  against future schema drift or a manual SQL edit.

## Test plan

- `go tool gqlgen generate`, `go vet ./...`, `go build ./...`, `go tool go-arch-lint check --project-path .` — pass
- `go test ./internal/repository/ -run TestSwipeRecordRepository_OutOfRangeState_ReturnsError` — compiles (proven by `go vet`). Docker-backed integration packages (repository/database/cmd/*) require testcontainers/Docker, unavailable locally, so they are skipped here and run in CI.

Closes #893
