### PR TITLE
fix(frontend): redact the raw error logged in cards-new setLastViewedCardgroup catch

### DIFF
--- a/frontend/src/app/cards/new/cards-new-client.test.tsx
+++ b/frontend/src/app/cards/new/cards-new-client.test.tsx
@@ -376,6 +376,23 @@ describe("<CardsNewClient> — navigate-on-success", () => {
         expect.objectContaining({ cardgroupId: CG_ID }),
       );
     });
+
+    // PII redaction contract — docs/frontend/rsc-error-handling/redact-err-message-from-console-payloads.md.
+    // The payload must carry only narrowed fields (cardgroupId, err class name, and
+    // the safe extensions.code list from liftGraphQLCodes) — never the raw error
+    // object or its user-echoing message.
+    const warnCall = consoleWarnSpy.mock.calls.find(
+      (call: unknown[]) => call[0] === "[cards-new] setLastViewedCardgroup failed",
+    );
+    expect(warnCall).toBeDefined();
+    const payload = warnCall?.[1];
+    expect(payload).toMatchObject({
+      cardgroupId: CG_ID,
+      name: expect.any(String),
+      codes: expect.arrayContaining(["BAD_USER_INPUT"]),
+    });
+    expect(payload).not.toHaveProperty("err");
+    expect(payload).not.toHaveProperty("message");
   });
 
   it("does NOT call router.push when createCard rejects; surfaces error banner", async () => {

--- a/frontend/src/app/cards/new/cards-new-client.tsx
+++ b/frontend/src/app/cards/new/cards-new-client.tsx
@@ -22,6 +22,7 @@ import {
 import { buttonVariants } from "@/components/ui/button";
 import { ErrorBanner } from "@/components/ui/error-banner";
 import { getBackendErrorBanner, getBackendFieldErrors } from "@/lib/apollo/errors";
+import { liftGraphQLCodes } from "@/lib/apollo/graphql-errors";
 import { sanitizeReturnTo } from "@/lib/sanitize-return-to";
 
 type Cardgroup = {
@@ -174,7 +175,13 @@ export default function CardsNewClient({
   function finishCreationAndNavigate() {
     if (!currentId) return;
     void setLastViewed({ variables: { cardgroupId: currentId } }).catch((err) => {
-      console.warn("[cards-new] setLastViewedCardgroup failed", { cardgroupId: currentId, err });
+      // err.message is omitted — backend messages may echo user-authored content.
+      // See docs/frontend/rsc-error-handling/redact-err-message-from-console-payloads.md.
+      console.warn("[cards-new] setLastViewedCardgroup failed", {
+        cardgroupId: currentId,
+        name: err instanceof Error ? err.name : "unknown",
+        codes: liftGraphQLCodes(err),
+      });
     });
     router.push(returnTo ?? `/cardgroups/${currentId}/cards`);
   }


### PR DESCRIPTION
## Summary

The fire-and-forget `setLastViewedCardgroup` catch in the cards-new client logged the raw `err` object (`{ cardgroupId, err }`), violating the repo's redact-err rule: backend GraphQL messages can echo user-authored card content, so the raw error must never reach operator logs, devtools history, or a console-ingesting collector. This narrows the payload to stable, non-PII fields only.

The finding's larger shared cache-helper extraction is intentionally skipped: cards-new immediately `router.push()`es and unmounts right after this catch, so a cache `writeFragment` would be discarded and add no value here.

## Changes

- `frontend/src/app/cards/new/cards-new-client.tsx`: replaced the raw `err` in the `setLastViewedCardgroup` catch with `{ cardgroupId, name: err instanceof Error ? err.name : "unknown", codes: liftGraphQLCodes(err) }` — mirroring the sibling `learn-client.tsx` warn at the same call site. Added the `liftGraphQLCodes` import from `@/lib/apollo/graphql-errors` (safe `extensions.code` list, never `err.message`).
- `frontend/src/app/cards/new/cards-new-client.test.tsx`: extended the existing setLastViewed-rejects test with a PII-redaction guard — the warn payload must match `{ cardgroupId, name, codes }` (including `BAD_USER_INPUT` lifted from the mock) and must NOT carry `err` or `message`.

## Test plan

- `pnpm --filter frontend typecheck` (`tsc --noEmit`) — pass
- `pnpm --filter frontend lint` (`biome check --error-on-warnings .`) — pass
- `pnpm --filter frontend knip` — pass
- `vitest run src/app/cards/new/cards-new-client.test.tsx` — 24 tests pass
- `pnpm --filter frontend build` (`next build`) — pass
- CJK/ASCII grep on both changed files — clean

Closes #901
