### PR TITLE
docs(backend): document learn-session 80/20 as a full-pool target, not an invariant

### DIFF
--- a/docs/backend/ddd-patterns/caller-truncate-contract.md
+++ b/docs/backend/ddd-patterns/caller-truncate-contract.md
@@ -54,21 +54,27 @@ keep that from drifting:
 1. **The docstring on `Apply` names the responsibility explicitly.** A
    reviewer reading the call site can grep the service signature and see
    "the caller is responsible for truncating".
-2. **The repository already caps at the caller-requested limit.** The
-   service therefore receives at most `limit` rows; the truncate after
-   `Apply` is a redundant guard for the case where the ordering policy
-   would otherwise emit a longer slice (it does not today, but the guard
-   future-proofs against changes that interleave additional sources).
+2. **The two due windows return up to `2*limit` rows, so the truncate is
+   load-bearing.** The repository fetches the review window and the new
+   window as two independent `LIMIT limit` selections and concatenates them,
+   so `OrderingPolicy.Apply` receives up to `2*limit` cards (`findDueCardsOn`
+   in `backend/internal/repository/card_due.go` documents this explicitly).
+   The `ordered[:n]` truncate is therefore not a redundant guard — it
+   actively reshapes the session mix, keeping only the interleaved prefix so
+   the review / new proportion at the cut is the one the session intends. A
+   caller that omits the truncate ships up to twice the requested session
+   length.
 3. **Direct unit tests cover the post-truncate shape.** Each caller's
    tests assert the final slice length, so a missing truncate surfaces at
    review time, not in production.
 
-If a future ordering policy can legitimately emit more cards than it
-received (e.g. interleaving a separate "boosted" bucket), the truncate
-becomes load-bearing and the contract is unchanged: caller still owns the
-cap. If every call site grows to do the same truncate immediately and the
-limit becomes a session-wide config, only then is the contract a candidate
-to flip to service-truncates.
+The truncate is already load-bearing today, because the two windows can
+hand `Apply` up to `2*limit` rows. A future ordering policy that also emits
+more cards than it received (e.g. interleaving a separate "boosted" bucket)
+only widens that gap; the contract is unchanged either way — the caller
+still owns the cap. If every call site grows to do the same truncate
+immediately and the limit becomes a session-wide config, only then is the
+contract a candidate to flip to service-truncates.
 
 ## Reference
 
@@ -77,3 +83,6 @@ to flip to service-truncates.
 - `backend/internal/usecase/learn.go` — the current caller truncates after
   `Apply`. A grep for `ordering.Apply` names every active call site; any
   new caller missing the truncate is a review-time defect.
+- `backend/internal/repository/card_due.go` — `findDueCardsOn` fetches the
+  review and new windows as two independent `LIMIT` selections, returning up
+  to `2*limit` rows and making the caller's truncate load-bearing.

--- a/docs/backend/ddd-patterns/discovery-first-due-ordering.md
+++ b/docs/backend/ddd-patterns/discovery-first-due-ordering.md
@@ -17,8 +17,38 @@ whenever the keys it scopes to are dense.
 
 ## Policy
 
-A default 20-card session is **16 uniformly-sampled never-seen cards (80%)**
-interleaved with **4 prior-day review cards (20%)**:
+**80/20 is a full-pool target, not an invariant.** When both due windows are
+full — the deck has at least 16 never-seen cards *and* at least 4 eligible
+prior-day reviews — a default 20-card session composes as **16 uniformly-sampled
+never-seen cards (80%)** interleaved with **4 prior-day review cards (20%)**
+(16/4 at `n = 20` under `domain.DefaultNewCardRatio` = 4/5). That 16/4 split is
+the composition *only under full pools*; the mechanics below degrade it toward
+review whenever either pool runs short. The skew is deliberate, not a bug:
+review cards are due and time-critical (skipping them decays memory and FSRS
+scheduling), while new cards are discretionary (deferrable at no cost), so
+favoring review under a shallow pool is correct spaced-repetition behavior.
+
+Three mechanisms shape the actual mix, each biased toward review:
+
+- **Review-first per-cycle emission.** `interleave` emits `ratio.ReviewShare()`
+  review cards *before* `ratio.NewShare()` new cards on every cycle. At the 4/5
+  default that is 1 review then 4 new per cycle (`OrderingPolicy.Apply` →
+  `interleave` in `due_card_ordering.go`).
+- **Review-favoring rounding on non-divisible sizes.** When the session limit is
+  not a multiple of the ratio denominator, the trailing partial cycle emits its
+  review portion first, so the review count rounds *up* by at most one
+  `ReviewShare` rather than down. A full-pool request for 22 cards under 4/5
+  yields 5 review + 17 new (not 4 review + 18 new).
+- **Drain back-fill toward review.** The review and new windows are two
+  independent `LIMIT` selections that together return up to `2*limit` rows; the
+  caller then truncates the interleaved result to the session limit (`ordered[:n]`
+  in `LearnUsecase.NextDueCards`). As the unseen pool empties, the new bucket
+  runs out after its early contributions and `interleave` appends the remaining
+  review cards, so the session skews toward review. Near deck completion, with a
+  single never-seen card left, a 20-card session becomes 1 new + 19 review — the
+  session is review-heavy because there is almost nothing left to discover.
+
+Within those mechanisms:
 
 - **Review slots** take learning-phase cards first — those in
   `FSRSPhaseLearning` or `FSRSPhaseRelearning`, i.e. whose latest rating was
@@ -41,7 +71,7 @@ deterministic while the database does the sampling:
 |---|---|---|
 | Selection (which rows enter each window) | `repository.FindDueCardsForUser` | Two independent `LIMIT` windows: a review window (`due <= now AND last_review < reviewedBefore`, ordered learning-phase-first via a `CASE` then `random()`) concatenated with a new window (no FSRS row, ordered by `random()`). |
 | Arrangement (order within the batch) | `service.OrderingPolicy.Apply` | Injected `*rand.Rand` shuffles the new partition fully and the review partition within same-phase runs; then interleaves at the caller-supplied ratio (`domain.DefaultNewCardRatio` = 4:1 absent a stored preference) with review-first emission. |
-| Truncation | `usecase.LearnUsecase.NextDueCards` | Caps the interleaved result to the session limit (`ordered[:n]`), yielding the 16/4 split for a 20-card request. |
+| Truncation | `usecase.LearnUsecase.NextDueCards` | Caps the interleaved result to the session limit (`ordered[:n]`). Because the two windows return up to `2*limit` rows, this truncate is load-bearing: it yields the 16/4 split for a 20-card request only when both windows are full, and skews toward review when the unseen pool is short (see Policy). |
 
 `random()` runs in Postgres and cannot be seeded from Go, so it decides only
 *which* rows are eligible; the deterministic arrangement is the injected


### PR DESCRIPTION
## Summary

The learn-session composition docs framed "80% new / 20% prior-day review" (16/4 at a 20-card default) as an invariant. A Z3 equivalence check confirmed the exact `n=20`, ratio `4/5`, both-windows-full point holds, but the general 80/20 framing is a **full-pool target**, not a guarantee: the algorithm deliberately degrades toward review as either pool runs short. That behavior is sound spaced-repetition pedagogy (review cards are due/time-critical; new cards are discretionary), so this is a docs-only correction — no behavior change.

This PR rewrites the Policy section of `discovery-first-due-ordering.md` to state 80/20 is the composition only when both due windows are full and then describes the actual rule (review-first per-cycle emission, review-favoring rounding on non-divisible sizes, drain back-fill toward review as the unseen pool empties). It also fixes an adjacent false claim in `caller-truncate-contract.md` that called the `ordered[:n]` truncate a "redundant guard ... (it does not today)": the two due windows return up to `2*limit` rows (`card_due.go` `findDueCardsOn`), so the truncate is load-bearing and actively reshapes the session mix.

## Changes

- `docs/backend/ddd-patterns/discovery-first-due-ordering.md` — Policy section rewritten: 80/20 (16/4 at `n=20`) is the full-pool composition; adds the three review-biasing mechanisms (review-first emission, review-favoring rounding, drain back-fill down to 1 new + rest review near deck completion). The Mechanics table Truncation row no longer states an unqualified 16/4 split and now names the truncate as load-bearing.
- `docs/backend/ddd-patterns/caller-truncate-contract.md` — item 2 of "Failure mode and mitigations" no longer calls the truncate "redundant"; it states the two windows return up to `2*limit` rows so the truncate is load-bearing. The contiguous trailing paragraph (which claimed the truncate only becomes load-bearing under a hypothetical future policy) is reconciled to say it is already load-bearing today. Added a `card_due.go` entry to the Reference section since the prose now cites `findDueCardsOn`.

## Test plan

- Docs-only change — no Go, TypeScript, or schema source was touched, so `go build` / `go vet` / `go-arch-lint` / `go test` are inert to this diff (and the worktree lacks the gitignored `graph/generated` bootstrap, so they were not run here). No code gate applies.
- Verified every code symbol cited in the new prose exists in source via grep: `NewCardRatio.NewShare` / `ReviewShare`, `DefaultNewCardRatio`, `interleave` + `OrderingPolicy.Apply` (`due_card_ordering.go`), `learnUsecase.NextDueCards` (`learn.go`), `findDueCardsOn` (`card_due.go`, whose doc-comment documents the "up to `2*limit` rows" fact), `FSRSPhase.IsLearningPhase` (`fsrs_state.go`).
- English-only / CJK gate (`perl -CSD`) clean on both edited files.

Closes #887
