### PR TITLE
fix(backend): collapse foreign-owned cardgroup(id:) to null so existence is not leaked

### DIFF
--- a/backend/cmd/server/main_test.go
+++ b/backend/cmd/server/main_test.go
@@ -1704,7 +1704,11 @@ func TestGraphQL_DeleteCardgroup_NonOwner_Unauthenticated(t *testing.T) {
 	}
 }
 
-func TestGraphQL_Cardgroup_NonOwner_Unauthenticated(t *testing.T) {
+// TestGraphQL_Cardgroup_NonOwner_ReturnsNullNoError verifies the non-disclosure
+// collapse: for an authenticated non-owner, a foreign-owned cardgroup returns the
+// byte-identical wire response as a non-existent id — both data.cardgroup = null
+// with no top-level error — so the query cannot be used as an existence oracle.
+func TestGraphQL_Cardgroup_NonOwner_ReturnsNullNoError(t *testing.T) {
 	f := newJWTFixture(t)
 	ts, _ := newGraphQLTestServer(t, f)
 	ctx := context.Background()
@@ -1715,11 +1719,36 @@ func TestGraphQL_Cardgroup_NonOwner_Unauthenticated(t *testing.T) {
 
 	subB := insertAuthUser(t, ctx)
 	tokB := f.sign(t, subB)
-	body := fmt.Sprintf(`{"query":"{ cardgroup(id: \"%s\") { id } }"}`, cgID)
-	resp := postGraphQL(t, ts.URL+"/query", body, tokB)
 
-	if code := gqlErrCode(resp); code != "UNAUTHENTICATED" {
-		t.Fatalf("expected UNAUTHENTICATED, got %q; resp=%v", code, resp)
+	// Read a real, foreign-owned cardgroup as user B.
+	foreignBody := fmt.Sprintf(`{"query":"{ cardgroup(id: \"%s\") { id name } }"}`, cgID)
+	foreignResp := postGraphQL(t, ts.URL+"/query", foreignBody, tokB)
+
+	// Read a non-existent id as the same caller.
+	missingBody := fmt.Sprintf(`{"query":"{ cardgroup(id: \"%s\") { id name } }"}`, uuid.NewString())
+	missingResp := postGraphQL(t, ts.URL+"/query", missingBody, tokB)
+
+	// Both must be data.cardgroup = null with no top-level error, and identical.
+	for name, resp := range map[string]map[string]any{"foreign-owned": foreignResp, "non-existent": missingResp} {
+		if errs, ok := resp["errors"].([]any); ok && len(errs) > 0 {
+			t.Fatalf("%s: expected no top-level error, got: %v", name, errs)
+		}
+		data, _ := resp["data"].(map[string]any)
+		cgVal, exists := data["cardgroup"]
+		if !exists {
+			t.Fatalf("%s: expected data.cardgroup key present (as null), resp=%v", name, resp)
+		}
+		if cgVal != nil {
+			t.Fatalf("%s: expected data.cardgroup == null, got %v", name, cgVal)
+		}
+	}
+
+	// json.Marshal sorts map keys, so equal marshaled bytes prove the two wire
+	// responses are indistinguishable.
+	foreignJSON, _ := json.Marshal(foreignResp)
+	missingJSON, _ := json.Marshal(missingResp)
+	if string(foreignJSON) != string(missingJSON) {
+		t.Fatalf("existence oracle: foreign-owned response %s differs from non-existent response %s", foreignJSON, missingJSON)
 	}
 }
 

--- a/backend/graph/resolver/cardgroup_resolvers_test.go
+++ b/backend/graph/resolver/cardgroup_resolvers_test.go
@@ -230,6 +230,54 @@ func TestResolver_MyCardgroupsConnection_RepoPageError_BecomesInternal(t *testin
 }
 
 // ---------------------------------------------------------------------------
+// cardgroup(id:) non-disclosure — a foreign-owned read is byte-indistinguishable
+// from a non-existent id for an authenticated caller (existence is not leaked).
+// ---------------------------------------------------------------------------
+
+const cardgroupByIDQuery = `{"query":"{ cardgroup(id: \"cg1\") { id name } }"}`
+
+// TestResolver_Cardgroup_ForeignOwned_IdenticalToNotFound proves the existence
+// oracle is closed: querying a real cardgroup owned by another user and querying
+// a non-existent id both resolve to data.cardgroup = null with no top-level
+// error, and the two wire responses are byte-identical.
+func TestResolver_Cardgroup_ForeignOwned_IdenticalToNotFound(t *testing.T) {
+	t.Parallel()
+
+	// Foreign-owned: FindByID returns a real row owned by someone other than
+	// the caller (u1).
+	foreignRepo := &mockCardgroupRepoForResolver{
+		findByIDResult: &domain.Cardgroup{ID: domain.CardgroupID("cg1"), OwnerID: "u-other", Name: "Not yours"},
+	}
+	foreignResp := gqlRequest(t, newCardgroupSrv(foreignRepo), authedCtx("u1"), cardgroupByIDQuery)
+
+	// Non-existent: FindByID reports ErrNotFound.
+	missingRepo := &mockCardgroupRepoForResolver{findByIDErr: repository.ErrNotFound}
+	missingResp := gqlRequest(t, newCardgroupSrv(missingRepo), authedCtx("u1"), cardgroupByIDQuery)
+
+	for name, resp := range map[string]map[string]any{"foreign-owned": foreignResp, "non-existent": missingResp} {
+		if errs, hasErrs := resp["errors"]; hasErrs {
+			t.Fatalf("%s: expected no top-level error, got: %v", name, errs)
+		}
+		data, _ := resp["data"].(map[string]any)
+		cgVal, exists := data["cardgroup"]
+		if !exists {
+			t.Fatalf("%s: expected data.cardgroup key present (as null), resp=%v", name, resp)
+		}
+		if cgVal != nil {
+			t.Fatalf("%s: expected data.cardgroup == null, got %v", name, cgVal)
+		}
+	}
+
+	// json.Marshal sorts map keys, so equal marshaled bytes prove the two wire
+	// responses are byte-indistinguishable.
+	foreignJSON, _ := json.Marshal(foreignResp)
+	missingJSON, _ := json.Marshal(missingResp)
+	if string(foreignJSON) != string(missingJSON) {
+		t.Fatalf("existence oracle: foreign-owned %s differs from non-existent %s", foreignJSON, missingJSON)
+	}
+}
+
+// ---------------------------------------------------------------------------
 // helpers.go — toCardgroupConnectionModel / toUsecaseOrderBy
 // ---------------------------------------------------------------------------
 //

--- a/backend/internal/usecase/cardgroup.go
+++ b/backend/internal/usecase/cardgroup.go
@@ -95,9 +95,13 @@ func NewCardgroupUsecase(repo CardgroupRepository, admin AdminChecker, logger *s
 	return &cardgroupUsecase{repo: repo, admin: admin, logger: logger}
 }
 
-// Cardgroup returns a single cardgroup by id. Non-owners receive UNAUTHENTICATED
-// rather than NOT_FOUND so the caller cannot probe existence via ID enumeration.
-// A missing row returns (nil, nil) so the nullable GraphQL field resolves to null.
+// Cardgroup returns a single cardgroup by id. A missing row and a row owned by
+// another user both return (nil, nil) so the nullable GraphQL field resolves to
+// null with no error in either case. Collapsing the two into a byte-identical
+// response stops an authenticated caller from using the query as an existence
+// oracle over other users' cardgroup ids — the same non-disclosure collapse the
+// write paths make via authorizeCardgroupOrUnauthenticated and that
+// setLastViewedCardgroup makes for "not found or not owned".
 func (u *cardgroupUsecase) Cardgroup(ctx context.Context, id string) (*domain.Cardgroup, error) {
 	user := auth.UserFrom(ctx)
 	if err := requireCallerSub(user); err != nil {
@@ -111,7 +115,9 @@ func (u *cardgroupUsecase) Cardgroup(ctx context.Context, id string) (*domain.Ca
 		return nil, eris.Wrap(err, "usecase: cardgroup: find by id")
 	}
 	if !cg.IsOwnedBy(domain.UserID(user.Sub)) {
-		return nil, ucerr.ErrUnauthenticated
+		// Foreign-owned reads collapse to the same (nil, nil) not-found shape as
+		// a missing row so existence is not leaked.
+		return nil, nil
 	}
 	return cg, nil
 }

--- a/backend/internal/usecase/cardgroup_test.go
+++ b/backend/internal/usecase/cardgroup_test.go
@@ -212,18 +212,25 @@ func TestCardgroupUsecase_Cardgroup_OwnerSeesOwn(t *testing.T) {
 	}
 }
 
-func TestCardgroupUsecase_Cardgroup_NonOwnerGetsUnauthenticated(t *testing.T) {
+// TestCardgroupUsecase_Cardgroup_NonOwner_ReturnsNilNoError pins the
+// non-disclosure collapse: a foreign-owned cardgroup returns the same (nil, nil)
+// shape as a missing row (TestCardgroupUsecase_Cardgroup_NotFound_ReturnsNilNoError),
+// so an authenticated caller cannot tell "exists but owned by someone else" from
+// "does not exist" and the query is not an existence oracle.
+func TestCardgroupUsecase_Cardgroup_NonOwner_ReturnsNilNoError(t *testing.T) {
 	t.Parallel()
 	cg := &domain.Cardgroup{ID: domain.CardgroupID("cg1"), OwnerID: "user-1", Name: "Mine"}
 	repo := &mockCardgroupRepository{findResult: cg}
 	uc := NewCardgroupUsecase(repo, cgDefaultAdmin(), newTestLogger())
 
-	_, err := uc.Cardgroup(cgAuthedCtx("user-2"), "cg1")
+	got, err := uc.Cardgroup(cgAuthedCtx("user-2"), "cg1")
 
-	if err == nil {
-		t.Fatal("expected error, got nil")
+	if err != nil {
+		t.Fatalf("expected no error (non-disclosure), got: %v", err)
 	}
-	assertUnauthenticated(t, err)
+	if got != nil {
+		t.Fatalf("expected nil cardgroup for a non-owner, got: %+v", got)
+	}
 }
 
 // --- Create tests ---

--- a/docs/backend-graphql.md
+++ b/docs/backend-graphql.md
@@ -181,10 +181,10 @@ The usecase layer defines its own narrow repository interface — a strict subse
 
 ### Authorization at the usecase layer
 
-Owner checks live in the usecase, not in Postgres RLS. The asymmetry for read vs. write is intentional per the security model:
+Owner checks live in the usecase, not in Postgres RLS. Both read and write collapse a foreign-owned id into the same outcome as a missing id so existence is never leaked; the outcome *value* differs by read vs. write:
 
-- Non-owner `cardgroup(id:)` read → return `null` (the field is nullable by spec; ID enumeration on a nullable field is acceptable).
-- Non-owner write (`updateCardgroup`, `deleteCardgroup`) → return `UNAUTHENTICATED`.
+- Non-owner `cardgroup(id:)` read → return `null`, byte-identical to a missing id (both `data.cardgroup = null`, no top-level error), so the query cannot be used as an existence oracle over other users' cardgroups.
+- Non-owner write (`updateCardgroup`, `deleteCardgroup`) → return `UNAUTHENTICATED`, byte-identical to a missing id.
 
 Although authorization itself is not delegated to Postgres, every application table in the `public` schema has Row Level Security enabled. Core user data tables now have concrete policies for direct Supabase callers:
 

--- a/schema/cardgroup.graphql
+++ b/schema/cardgroup.graphql
@@ -77,7 +77,7 @@ type CardgroupConnection {
 }
 
 extend type Query {
-  """Single cardgroup by ID. Returns UNAUTHENTICATED for non-owners (existence is not leaked)."""
+  """Single cardgroup by ID. Returns null for a non-owner or a missing id alike, so existence is not leaked."""
   cardgroup(id: ID!): Cardgroup
   """
   Paginated cardgroups owned by the authenticated caller. Forward pagination uses


### PR DESCRIPTION
## Summary

`cardgroupUsecase.Cardgroup` returned two distinguishable wire shapes for an
authenticated caller: a non-existent id resolved to `data.cardgroup = null` with
no error, while a real deck owned by another user returned a top-level
`UNAUTHENTICATED` error. That difference is a working existence oracle over other
users' cardgroup ids — exactly what `schema/cardgroup.graphql` promised to
prevent. A Z3 refinement check (`cardgroup-authz-existence-oracle`, D1) confirmed
the counterexample against production code, and the two internal specs
contradicted each other on the same input (schema said `UNAUTHENTICATED`,
`docs/backend-graphql.md` said `null`).

This collapses the foreign-owned read to the same `(nil, nil)` non-disclosure
outcome as a missing row, so not-found and foreign-owned are now
byte-shape-identical. It mirrors the `authorizeCardgroupOrUnauthenticated` and
`setLastViewedCardgroup` precedents (both already collapse not-found and
not-owned into one indistinguishable outcome) and reconciles the two docs so they
agree on the non-disclosure guarantee. Writes (`updateCardgroup` /
`deleteCardgroup`) are unchanged — they keep collapsing to `UNAUTHENTICATED`,
which is itself non-disclosure.

## Changes

- `backend/internal/usecase/cardgroup.go`: the `Cardgroup` foreign-owned branch
  now returns `nil, nil` instead of `ucerr.ErrUnauthenticated`; docstring rewritten
  to state the not-found / foreign-owned collapse and why. The resolver
  (`graph/resolver/cardgroup.resolvers.go`) needs no change — `nil, nil` already
  yields `data.cardgroup = null` with no error.
- `schema/cardgroup.graphql`: `cardgroup(id:)` description changed from "Returns
  UNAUTHENTICATED for non-owners" to "Returns null for a non-owner or a missing id
  alike, so existence is not leaked".
- `docs/backend-graphql.md`: the read/write authorization bullets now state that
  both read and write collapse a foreign-owned id into the missing-id outcome
  (read → `null`, write → `UNAUTHENTICATED`), removing the contradicting "ID
  enumeration on a nullable field is acceptable" claim.
- `backend/graph/resolver/cardgroup_resolvers_test.go`: new
  `TestResolver_Cardgroup_ForeignOwned_IdenticalToNotFound` (DB-free, gqlgen +
  mock repo) asserts the foreign-owned and non-existent responses are both
  `data.cardgroup = null` with no top-level error and are byte-identical.
- `backend/internal/usecase/cardgroup_test.go`: renamed the old
  `..._NonOwnerGetsUnauthenticated` test to `..._NonOwner_ReturnsNilNoError` and
  flipped its assertion to the new `(nil, nil)` shape.
- `backend/cmd/server/main_test.go`: rewrote the DB-backed
  `TestGraphQL_Cardgroup_NonOwner_Unauthenticated` into
  `TestGraphQL_Cardgroup_NonOwner_ReturnsNullNoError`, asserting the foreign-owned
  wire response is byte-identical to a non-existent id for an authenticated caller.

## Test plan

- `go tool gqlgen generate`, `go vet ./...`, `go build ./...`, `go tool go-arch-lint check --project-path .` — pass
- `go test ./graph/resolver/ ./internal/usecase/` — 254 + 788 pass, including the new
  `TestResolver_Cardgroup_ForeignOwned_IdenticalToNotFound` and the updated
  `TestCardgroupUsecase_Cardgroup_NonOwner_ReturnsNilNoError`. Docker-backed
  integration packages (`cmd/server`, `internal/repository`, `internal/database`)
  require testcontainers/Docker, unavailable locally, so they are skipped here
  (they compile cleanly under `go vet`) and run in CI — this covers the updated
  `TestGraphQL_Cardgroup_NonOwner_ReturnsNullNoError`.

Closes #886
