### PR TITLE
fix(backend): guard cursor-hydration eris.Wrap sites with isContextDone

### DIFF
--- a/backend/internal/usecase/card.go
+++ b/backend/internal/usecase/card.go
@@ -457,6 +457,9 @@ func (u *cardUsecase) resolveCardCursor(
 		if errors.Is(err, repository.ErrNotFound) {
 			return nil, ucerr.NewValidationError(field, "cursor not found")
 		}
+		if isContextDone(err) {
+			return nil, err
+		}
 		return nil, eris.Wrap(err, "usecase: card: resolve cursor: find by id")
 	}
 	if !card.BelongsToCardgroup(domain.CardgroupID(cardgroupID)) {
@@ -470,6 +473,9 @@ func (u *cardUsecase) resolveCardCursor(
 		} else if user := auth.UserFrom(ctx); user != nil {
 			byCardID, err := u.userFSRSRepo.FindByUserAndCardIDs(ctx, user.Sub, []string{id})
 			if err != nil {
+				if isContextDone(err) {
+					return nil, err
+				}
 				return nil, eris.Wrap(err, "usecase: card: resolve cursor: find user fsrs")
 			}
 			if ucs := byCardID[id]; ucs != nil {

--- a/backend/internal/usecase/card_test.go
+++ b/backend/internal/usecase/card_test.go
@@ -1230,3 +1230,63 @@ func TestCardUsecase_ListCardsByCardgroupConnection_SearchPassthrough(t *testing
 		})
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Cursor-hydration context-cancellation pass-through (resolveCardCursor)
+//
+// A context.Canceled surfaced during cursor hydration must reach the caller
+// unwrapped so the resolver's gqlerr.FromUsecaseError routes it to Cancelled
+// via errors.Is. assertCancelled alone is too weak — errors.Is walks the eris
+// chain, so it passes even for eris.Wrap(context.Canceled, ...); the bare
+// err == context.Canceled check pins that no wrap snuck in. See
+// docs/backend/error-wrapping/pin-unwrapped-context-error-with-identity-check.md.
+// ---------------------------------------------------------------------------
+
+// TestCardUsecase_ListCardsByCardgroupConnection_CursorFindByIDCancelled pins the
+// FindByID wrap site: a non-ID orderBy reaches cardRepo.FindByID during cursor
+// hydration; a context.Canceled from it must pass through unwrapped.
+func TestCardUsecase_ListCardsByCardgroupConnection_CursorFindByIDCancelled(t *testing.T) {
+	t.Parallel()
+	cardRepo := &mockCardRepository{findErr: context.Canceled}
+	uc := NewCardUsecase(nil, cardRepo,
+		&mockCardgroupRepoForCard{findResult: &domain.Cardgroup{ID: domain.CardgroupID("cg1"), OwnerID: "u1"}},
+		nil, nil, newTestLogger(),
+	)
+	_, err := uc.ListCardsByCardgroupConnection(authedCtx("u1"), CardConnectionInput{
+		CardgroupID: "cg1",
+		First:       intPtr(10),
+		After:       ptr("cur-1"),
+		OrderBy:     orderByPtr(CardOrderByDue), // non-ID ordering triggers FindByID
+	})
+
+	assertCancelled(t, err)
+	if err != context.Canceled {
+		t.Fatalf("expected unwrapped context.Canceled, got %v", err)
+	}
+}
+
+// TestCardUsecase_ListCardsByCardgroupConnection_CursorFSRSCancelled pins the FSRS
+// wrap site: OrderByDue reaches the userFSRSRepo.FindByUserAndCardIDs lookup during
+// cursor hydration; a context.Canceled from it must pass through unwrapped.
+func TestCardUsecase_ListCardsByCardgroupConnection_CursorFSRSCancelled(t *testing.T) {
+	t.Parallel()
+	cardRepo := &mockCardRepository{
+		findResult: &domain.Card{ID: "cur-1", CardgroupID: domain.CardgroupID("cg1")},
+	}
+	fsrsRepo := &mockUserCardFSRSRepository{findErr: context.Canceled}
+	uc := NewCardUsecase(nil, cardRepo,
+		&mockCardgroupRepoForCard{findResult: &domain.Cardgroup{ID: domain.CardgroupID("cg1"), OwnerID: "u1"}},
+		fsrsRepo, nil, newTestLogger(),
+	)
+	_, err := uc.ListCardsByCardgroupConnection(authedCtx("u1"), CardConnectionInput{
+		CardgroupID: "cg1",
+		First:       intPtr(10),
+		After:       ptr("cur-1"),
+		OrderBy:     orderByPtr(CardOrderByDue), // OrderByDue reaches the FSRS lookup
+	})
+
+	assertCancelled(t, err)
+	if err != context.Canceled {
+		t.Fatalf("expected unwrapped context.Canceled, got %v", err)
+	}
+}

--- a/backend/internal/usecase/cardgroup.go
+++ b/backend/internal/usecase/cardgroup.go
@@ -408,6 +408,9 @@ func (u *cardgroupUsecase) resolveCardgroupCursor(
 		if errors.Is(err, repository.ErrNotFound) {
 			return nil, ucerr.NewValidationError(field, "cursor not found")
 		}
+		if isContextDone(err) {
+			return nil, err
+		}
 		return nil, eris.Wrap(err, "usecase: cardgroup: hydrate cursor")
 	}
 	if !cg.IsOwnedBy(domain.UserID(ownerID)) {

--- a/backend/internal/usecase/cardgroup_test.go
+++ b/backend/internal/usecase/cardgroup_test.go
@@ -1965,3 +1965,28 @@ func TestCheckCardgroupLimit_CountDeadlineExceeded_IdentityPreserved(t *testing.
 		t.Fatalf("expected nil LimitInfo on deadline exceeded, got %+v", info)
 	}
 }
+
+// TestCardgroupUC_Connection_CursorFindByIDCancelled pins the cursor-hydration
+// FindByID wrap site (resolveCardgroupCursor): a context.Canceled surfaced while
+// hydrating the cursor must reach the caller unwrapped so the resolver routes it
+// to Cancelled via errors.Is. assertCancelled alone is too weak — errors.Is walks
+// the eris chain, so it passes even for eris.Wrap(context.Canceled, ...); the bare
+// err == context.Canceled check pins that no wrap snuck in. See
+// docs/backend/error-wrapping/pin-unwrapped-context-error-with-identity-check.md.
+func TestCardgroupUC_Connection_CursorFindByIDCancelled(t *testing.T) {
+	t.Parallel()
+	repo := &mockCardgroupRepository{findErr: context.Canceled}
+	uc := NewCardgroupUsecase(repo, cgDefaultAdmin(), newTestLogger())
+
+	first := 5
+	after := "cur-1"
+	_, err := uc.ListCardgroupsByOwnerConnection(cgAuthedCtx("user-1"), CardgroupConnectionInput{
+		First: &first,
+		After: &after,
+	})
+
+	assertCancelled(t, err)
+	if err != context.Canceled {
+		t.Fatalf("expected unwrapped context.Canceled, got %v", err)
+	}
+}

--- a/backend/internal/usecase/master_catalog.go
+++ b/backend/internal/usecase/master_catalog.go
@@ -357,6 +357,9 @@ func (u *masterCatalogUsecase) resolveMasterCatalogCursor(
 		if errors.Is(err, repository.ErrNotFound) {
 			return nil, ucerr.NewValidationError(field, "cursor not found")
 		}
+		if isContextDone(err) {
+			return nil, err
+		}
 		return nil, eris.Wrap(err, "usecase: master catalog: hydrate cursor")
 	}
 

--- a/backend/internal/usecase/master_catalog_test.go
+++ b/backend/internal/usecase/master_catalog_test.go
@@ -1288,3 +1288,30 @@ func TestPreviewMergeMaster_HappyPathDelegatesToDeckUC(t *testing.T) {
 		t.Fatalf("expected Added=3 Updated=1, got Added=%d Updated=%d", out.Added, out.Updated)
 	}
 }
+
+// TestListPublishedConnection_CursorFindByIDCancelled pins the cursor-hydration
+// fetchByID wrap site (resolveMasterCatalogCursor): a context.Canceled surfaced
+// while hydrating the cursor must reach the caller unwrapped so the resolver
+// routes it to Cancelled via errors.Is. assertCancelled alone is too weak —
+// errors.Is walks the eris chain, so it passes even for
+// eris.Wrap(context.Canceled, ...); the bare err == context.Canceled check pins
+// that no wrap snuck in. See
+// docs/backend/error-wrapping/pin-unwrapped-context-error-with-identity-check.md.
+func TestListPublishedConnection_CursorFindByIDCancelled(t *testing.T) {
+	t.Parallel()
+	cur := cursor.Encode("cur-1")
+	repo := &mockMasterCatalogRepository{
+		findByIDFn: func(string) (*domain.MasterCardgroup, error) { return nil, context.Canceled },
+	}
+	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, newTestAdminGate(true), newTestLogger())
+
+	_, err := uc.ListPublishedConnection(authedCtx("u1"), MasterCatalogConnectionInput{
+		First: intPtr(5),
+		After: &cur,
+	})
+
+	assertCancelled(t, err)
+	if err != context.Canceled {
+		t.Fatalf("expected unwrapped context.Canceled, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Four cursor-hydration helpers share the same decode → `FindByID` → not-found → scope-guard → switch-on-orderBy shape, but only `resolveMasterCardCursor` guarded the cancelled-`FindByID` path with `isContextDone` before its `eris.Wrap`. The other three helpers — and the second (FSRS) lookup in `resolveCardCursor` — wrapped without the guard, so a `context.Canceled` / `context.DeadlineExceeded` surfaced during cursor hydration lost its bare-sentinel identity. `errors.Is` still detected the cancellation through the eris chain, but the value returned to the resolver was `eris.Wrap(context.Canceled, ...)` rather than the raw sentinel, which silently changes the wire-format classification and breaks any downstream consumer that compares via `==`.

This is the narrow consistency fix documented in `docs/backend/error-wrapping/pin-unwrapped-context-error-with-identity-check.md` § "Multi-call free-function helpers: guard every branch". Each site now returns the raw context error unwrapped, mirroring the existing correct copy at `master_card.go:680`. This is not the generic `hydrateCursor[C]` extraction — that conflicts with the per-aggregate cursor-closure decision and does not fit `card.go`'s error-returning FSRS populate step.

## Changes

- `backend/internal/usecase/card.go` — added `if isContextDone(err) { return nil, err }` before the `FindByID` wrap and before the FSRS-lookup wrap in `resolveCardCursor`.
- `backend/internal/usecase/cardgroup.go` — added the same guard before the `FindByID` wrap in `resolveCardgroupCursor`.
- `backend/internal/usecase/master_catalog.go` — added the same guard before the `fetchByID` wrap in `resolveMasterCatalogCursor`.
- Added one identity-pin test per site (`card_test.go`, `cardgroup_test.go`, `master_catalog_test.go`). Each exercises the helper through its public connection method with a repo fake returning `context.Canceled`, then asserts both the chain (`assertCancelled`) and the bare identity (`err == context.Canceled`) — the dual assertion required because `assertCancelled` alone passes even for a wrapped context error.

## Test plan

- `go tool gqlgen generate`, `go vet ./...`, `go build ./...`, `go tool go-arch-lint check --project-path .` — pass
- `go test ./internal/usecase/ -run '...CursorFindByIDCancelled|...CursorFSRSCancelled|...' -count=1` — the four new identity-pin tests pass locally (they use repo fakes, no DB). Docker-backed integration packages (repository/database/cmd/*) require testcontainers/Docker, unavailable locally, so they are skipped here and run in CI.

Closes #913
