### PR TITLE
refactor(backend): extract buildUserProfilePatch to deduplicate profile patch assembly

### DIFF
--- a/backend/internal/usecase/admin_user.go
+++ b/backend/internal/usecase/admin_user.go
@@ -303,29 +303,12 @@ func (u *adminUserUsecase) EditUser(ctx context.Context, id string, input AdminE
 		return AdminEditUserOutcome{}, err
 	}
 
-	patch := repository.UserUpdate{}
-	if input.DisplayName != nil {
-		dn, err := domain.ParseDisplayName(*input.DisplayName)
-		if err != nil {
-			info, perr := liftValidationErr(translateDisplayNameErr(err))
-			if perr != nil {
-				return AdminEditUserOutcome{}, perr
-			}
-			return AdminEditUserOutcome{Validation: info}, nil
-		}
-		s := string(dn)
-		patch.DisplayName = &s
+	patch, info, err := buildUserProfilePatch(input.DisplayName, input.Bio)
+	if err != nil {
+		return AdminEditUserOutcome{}, err
 	}
-	if input.Bio != nil {
-		bio, err := domain.ParseBio(input.Bio)
-		if err != nil {
-			info, perr := liftValidationErr(translateBioErr(err))
-			if perr != nil {
-				return AdminEditUserOutcome{}, perr
-			}
-			return AdminEditUserOutcome{Validation: info}, nil
-		}
-		patch.Bio = bio.Ptr()
+	if info != nil {
+		return AdminEditUserOutcome{Validation: info}, nil
 	}
 
 	roleIDs, validation := normalizeAdminEditRoleIDs(input.RoleIDs)

--- a/backend/internal/usecase/user.go
+++ b/backend/internal/usecase/user.go
@@ -100,36 +100,65 @@ func (u *userUsecase) UpdateUser(ctx context.Context, in UpdateUserInput) (Updat
 		return UpdateProfileOutcome{}, err
 	}
 
-	dn, err := domain.ParseDisplayName(in.DisplayName)
+	patch, info, err := buildUserProfilePatch(&in.DisplayName, in.Bio)
 	if err != nil {
-		info, perr := liftValidationErr(translateDisplayNameErr(err))
-		if perr != nil {
-			return UpdateProfileOutcome{}, perr
-		}
+		return UpdateProfileOutcome{}, err
+	}
+	if info != nil {
 		return UpdateProfileOutcome{Validation: info}, nil
 	}
 
-	name := string(dn)
-	patch := repository.UserUpdate{
-		DisplayName: &name,
-	}
-	if in.Bio != nil {
-		bio, err := domain.ParseBio(in.Bio)
-		if err != nil {
-			info, perr := liftValidationErr(translateBioErr(err))
-			if perr != nil {
-				return UpdateProfileOutcome{}, perr
-			}
-			return UpdateProfileOutcome{Validation: info}, nil
-		}
-		patch.Bio = bio.Ptr()
-	}
 	appUser, err := u.repo.Update(ctx, user.Sub, patch)
 	if err != nil {
 		return UpdateProfileOutcome{}, eris.Wrap(err, "usecase: user: update: update user")
 	}
 
 	return UpdateProfileOutcome{User: appUser}, nil
+}
+
+// buildUserProfilePatch assembles a repository.UserUpdate from a profile-patch
+// input, shared by userUsecase.UpdateUser (self-service) and
+// adminUserUsecase.EditUser (admin). displayName is a *string so the one helper
+// serves both surfaces: the self-service caller passes &in.DisplayName because
+// its display name is required, while the admin caller passes the optional
+// input.DisplayName pointer. When displayName is nil the field is left
+// unchanged; when non-nil it is validated via domain.ParseDisplayName (which
+// rejects empty), so the pointer absorbs the required/optional difference
+// without changing behaviour. bio follows the trinary patch contract
+// (nil = unchanged, "" = explicit clear) via domain.ParseBio.
+//
+// The return contract mirrors liftValidationErr's routing: a *ucerr.ValidationError
+// surfaces in the second slot (*InputValidationInfo) with a nil error, so the
+// caller can populate its outcome's Validation field; any other error surfaces
+// in the third slot for the error channel. On success both are nil and the
+// assembled patch is returned. Keeping the DTO primitive (repository.UserUpdate,
+// not a VO) preserves the patch-DTO-primitive contract.
+func buildUserProfilePatch(displayName *string, bio *string) (repository.UserUpdate, *InputValidationInfo, error) {
+	patch := repository.UserUpdate{}
+	if displayName != nil {
+		dn, err := domain.ParseDisplayName(*displayName)
+		if err != nil {
+			info, perr := liftValidationErr(translateDisplayNameErr(err))
+			if perr != nil {
+				return repository.UserUpdate{}, nil, perr
+			}
+			return repository.UserUpdate{}, info, nil
+		}
+		name := string(dn)
+		patch.DisplayName = &name
+	}
+	if bio != nil {
+		b, err := domain.ParseBio(bio)
+		if err != nil {
+			info, perr := liftValidationErr(translateBioErr(err))
+			if perr != nil {
+				return repository.UserUpdate{}, nil, perr
+			}
+			return repository.UserUpdate{}, info, nil
+		}
+		patch.Bio = b.Ptr()
+	}
+	return patch, nil, nil
 }
 
 // DeleteMyAccount permanently deletes the authenticated caller's own account.

--- a/docs/backend/ddd-patterns/patch-dto-primitive-not-vo.md
+++ b/docs/backend/ddd-patterns/patch-dto-primitive-not-vo.md
@@ -36,24 +36,31 @@ out (write request to the repository).
 
 `repository.UserUpdate.Bio` is `*string`, even though the domain field
 `User.Bio` is the struct VO `Bio`. The usecase translates the validated `Bio`
-back to `*string` at the patch construction site:
+back to `*string` at the patch construction site. That construction site is the
+shared `buildUserProfilePatch` helper in `backend/internal/usecase/user.go`,
+used by both `userUsecase.UpdateUser` (self-service) and
+`adminUserUsecase.EditUser` (admin):
 
 ```go
-// backend/internal/usecase/user.go — UpdateUser
-patch := repository.UserUpdate{
-    DisplayName: &name,
-}
-if in.Bio != nil {
-    bio, err := domain.ParseBio(in.Bio)
-    if err != nil {
-        // ... liftValidationErr / translateBioErr branch
-        return UpdateProfileOutcome{Validation: info}, nil
+// backend/internal/usecase/user.go — buildUserProfilePatch
+func buildUserProfilePatch(displayName *string, bio *string) (repository.UserUpdate, *InputValidationInfo, error) {
+    patch := repository.UserUpdate{}
+    if displayName != nil {
+        // ... liftValidationErr / translateDisplayNameErr branch
+        patch.DisplayName = &name
     }
-    patch.Bio = bio.Ptr()   // <- VO → primitive at the DTO boundary
+    if bio != nil {
+        b, err := domain.ParseBio(bio)
+        if err != nil {
+            // ... liftValidationErr / translateBioErr branch
+        }
+        patch.Bio = b.Ptr()   // <- VO → primitive at the DTO boundary
+    }
+    return patch, nil, nil
 }
 ```
 
-The `if in.Bio != nil` guard is the patch contract's "field absent" branch:
+The `if bio != nil` guard is the patch contract's "field absent" branch:
 the input field is a `*string` because the input itself is a patch (the GraphQL
 mutation `UpdateProfileInput.Bio` is `*string`). Keeping the same shape on the
 DTO side keeps the translation trivial.
@@ -137,7 +144,7 @@ enforce at the storage layer. (`MasterCardgroupUpdate.Status` is deliberately
 
 - `backend/internal/repository/user.go` — `UserUpdate` (`*string` for `DisplayName`/`Bio`/`AvatarURL`).
 - `backend/internal/repository/card.go` — `CardUpdate` (`*string` for `Front`/`Back`).
-- `backend/internal/usecase/user.go` — `UpdateUser` translates `Bio.Ptr()` to `patch.Bio *string`.
+- `backend/internal/usecase/user.go` — `buildUserProfilePatch` translates `Bio.Ptr()` to `patch.Bio *string` for both `UpdateUser` and `adminUserUsecase.EditUser`.
 - `backend/internal/usecase/card.go` — `CardUsecase.Update` translates `CardText.String()` to `patch.Front/Back *string`.
 - [`docs/backend/ddd-patterns/trinary-value-object.md`](trinary-value-object.md) — the `Bio` VO's own contract.
 - [`docs/backend/ddd-patterns/context-neutral-vo-docstrings.md`](context-neutral-vo-docstrings.md) — the patch-vs-read context split for shared VOs.

--- a/docs/backend/error-wrapping/lift-validation-err-shadow-pattern.md
+++ b/docs/backend/error-wrapping/lift-validation-err-shadow-pattern.md
@@ -71,8 +71,9 @@ if err := u.authorizeCardgroup(ctx, in.CardgroupID, user.Sub); err != nil {
 ```
 
 The same two-branch shape appears in `card.go` (`Update`), `cardgroup.go`
-(`Create`, `Update`), `user.go` (`UpdateUser`), and `admin_user.go`
-(`UpdateUser`) — count grep:
+(`Create`, `Update`), and `user.go` (`buildUserProfilePatch`, the shared
+profile-patch assembler used by both `userUsecase.UpdateUser` and
+`adminUserUsecase.EditUser`) — count grep:
 
 ```bash
 grep -n 'liftValidationErr' backend/internal/usecase/*.go | grep -v _test.go
@@ -92,5 +93,7 @@ When promoting a usecase method that calls a validator returning `error`:
   shape.
 - If a method needs both a `liftValidationErr` step and a follow-up
   validator that also returns `error`, run them in sequence and overwrite
-  `info` and `err` on each step — see `backend/internal/usecase/user.go`
-  for the two-step (`displayName` then `bio`) pattern.
+  `info` and `err` on each step — see `buildUserProfilePatch` in
+  `backend/internal/usecase/user.go` for the two-step (`displayName` then
+  `bio`) pattern, which returns the residual `(*InputValidationInfo, error)`
+  pair so its callers keep the same two-branch routing.


### PR DESCRIPTION
## Summary

`domain.User` is a pure field bag, and the profile-patch assembly (`ParseDisplayName` + `ParseBio` → `repository.UserUpdate`, with identical validation-error routing) was duplicated across the self-service usecase (`userUsecase.UpdateUser`) and the admin usecase (`adminUserUsecase.EditUser`). The two blocks were line-for-line identical except that self-service treats the display name as required (`in.DisplayName string`) while admin treats it as optional (`input.DisplayName *string`). A future rule — a new reserved name, a bio normalization step — had to be applied in both places or the two surfaces would diverge.

This extracts one package-private helper, `buildUserProfilePatch(displayName *string, bio *string) (repository.UserUpdate, *InputValidationInfo, error)`, and routes both call sites through it. The `*string` display-name parameter absorbs the required/optional difference behavior-preservingly: the self-service caller passes `&in.DisplayName` (always non-nil), the admin caller passes the optional `input.DisplayName` pointer, and `domain.ParseDisplayName` still rejects empty either way. The helper's return contract mirrors `liftValidationErr`'s routing exactly — a `*ucerr.ValidationError` surfaces in the `*InputValidationInfo` slot with a nil error so the caller populates its outcome's `Validation` field, while any other error surfaces on the error channel — so **which `Validation` outcome slot each surface populates is unchanged**. The patch DTO stays primitive (`repository.UserUpdate`, not a VO), preserving the patch-DTO-primitive contract.

The change is scoped strictly to the `ParseDisplayName`/`ParseBio` patch-assembly region of `EditUser`; the `refetchUser` call and method (issue #914), the role-normalization, and the transaction/preference code are untouched.

## Changes

- `backend/internal/usecase/user.go` — added the shared `buildUserProfilePatch` helper (validates `displayName` when non-nil, validates `bio` when non-nil per the trinary patch contract, assembles `repository.UserUpdate`, and returns the residual `(*InputValidationInfo, error)` pair). Rewrote `UpdateUser` to call it with `&in.DisplayName, in.Bio` and branch on the returned `err` then `info`, replacing the inline duplicated blocks.
- `backend/internal/usecase/admin_user.go` — rewrote the `EditUser` patch-assembly region to call `buildUserProfilePatch(input.DisplayName, input.Bio)` and branch on the returned `err` then `info`, replacing the inline duplicated blocks. `refetchUser` and all role/tx code left unchanged.
- `docs/backend/ddd-patterns/patch-dto-primitive-not-vo.md` — the `UserUpdate.Bio` worked example now shows the `buildUserProfilePatch` helper and notes it serves both `UpdateUser` and `EditUser`; the Reference bullet repointed at the helper.
- `docs/backend/error-wrapping/lift-validation-err-shadow-pattern.md` — the two-branch-shape call-site list and the two-step (`displayName` then `bio`) reference now point at `buildUserProfilePatch` instead of the two former inline sites.

## Test plan

- `go tool gqlgen generate`, `go vet ./...`, `go build ./...`, `go tool go-arch-lint check --project-path .` — pass
- `go test ./internal/usecase/ -run 'TestUserUsecase_UpdateUser|TestAdminUser_EditUser' -count=1` — 47 pass (all `UpdateUser` and `EditUser` subtests, including the display-name and bio validation-variant cases, unchanged). Docker-backed integration packages (`internal/repository`, `internal/database`, `cmd/server` DB-backed tests) require testcontainers/Docker, unavailable locally, so they are CI-deferred; `go vet` / `go build` / `go-arch-lint` prove the whole tree compiles.

Closes #892
