### PR TITLE
refactor(backend): route cardgroup Update/Delete ownership through the shared ownership.go seam

### DIFF
--- a/backend/internal/usecase/cardgroup.go
+++ b/backend/internal/usecase/cardgroup.go
@@ -242,15 +242,13 @@ func (u *cardgroupUsecase) Update(ctx context.Context, id string, in UpdateCardg
 		return UpdateCardgroupOutcome{}, err
 	}
 
-	existing, err := u.repo.FindByID(ctx, id)
+	// Ownership classification (not-found / not-owned / context-done) is routed
+	// through the shared ownership.go seam. findOwnedCardgroup returns the loaded
+	// row so the patch below can operate on it without a second lookup; a missing
+	// row surfaces as UNAUTHENTICATED to prevent ID enumeration.
+	existing, err := findOwnedCardgroup(ctx, u.repo, domain.CardgroupID(id), domain.UserID(user.Sub), ucerr.ErrUnauthenticated)
 	if err != nil {
-		if errors.Is(err, repository.ErrNotFound) {
-			return UpdateCardgroupOutcome{}, ucerr.ErrUnauthenticated
-		}
-		return UpdateCardgroupOutcome{}, eris.Wrap(err, "usecase: cardgroup: find for update")
-	}
-	if !existing.IsOwnedBy(domain.UserID(user.Sub)) {
-		return UpdateCardgroupOutcome{}, ucerr.ErrUnauthenticated
+		return UpdateCardgroupOutcome{}, err
 	}
 
 	// Empty patch: no DB write, return current row.
@@ -287,15 +285,11 @@ func (u *cardgroupUsecase) Delete(ctx context.Context, id string) error {
 		return err
 	}
 
-	existing, err := u.repo.FindByID(ctx, id)
-	if err != nil {
-		if errors.Is(err, repository.ErrNotFound) {
-			return ucerr.ErrUnauthenticated
-		}
-		return eris.Wrap(err, "usecase: cardgroup: find for delete")
-	}
-	if !existing.IsOwnedBy(domain.UserID(user.Sub)) {
-		return ucerr.ErrUnauthenticated
+	// Ownership classification (not-found / not-owned / context-done) is routed
+	// through the shared ownership.go seam; a missing or foreign row surfaces as
+	// UNAUTHENTICATED to prevent ID enumeration.
+	if err := authorizeCardgroupOrUnauthenticated(ctx, u.repo, domain.CardgroupID(id), domain.UserID(user.Sub)); err != nil {
+		return err
 	}
 
 	if err := u.repo.Delete(ctx, id); err != nil {

--- a/backend/internal/usecase/cardgroup_test.go
+++ b/backend/internal/usecase/cardgroup_test.go
@@ -736,6 +736,28 @@ func TestCardgroupUsecase_Update_RepoError_InfraChannel(t *testing.T) {
 	assertInternalChain(t, err, "usecase: cardgroup: update")
 }
 
+// TestCardgroupUsecase_Update_FindByIDCancelled_IdentityPreserved pins the
+// context-cancellation contract for the Update ownership lookup now that it
+// routes through the shared findOwnedCardgroup seam. assertCancelled proves the
+// chain still matches; the bare-identity check (err == context.Canceled) proves
+// the seam does not eris.Wrap the sentinel, so the resolver's Cancelled routing
+// and any == comparison downstream keep working.
+func TestCardgroupUsecase_Update_FindByIDCancelled_IdentityPreserved(t *testing.T) {
+	t.Parallel()
+	repo := &mockCardgroupRepository{findErr: context.Canceled}
+	uc := NewCardgroupUsecase(repo, cgDefaultAdmin(), newTestLogger())
+
+	_, err := uc.Update(cgAuthedCtx("user-1"), "cg1", UpdateCardgroupInput{Name: ptr("New")})
+
+	assertCancelled(t, err)
+	if err != context.Canceled {
+		t.Fatalf("expected unwrapped context.Canceled, got %T: %v", err, err)
+	}
+	if repo.updateCalled {
+		t.Fatal("expected repo.Update NOT to be called when FindByID is cancelled")
+	}
+}
+
 // --- Delete tests ---
 
 func TestCardgroupUsecase_Delete_Anonymous(t *testing.T) {
@@ -794,6 +816,28 @@ func TestCardgroupUsecase_Delete_Success(t *testing.T) {
 	}
 	if !repo.deleteCalled {
 		t.Fatal("expected repo.Delete to be called")
+	}
+}
+
+// TestCardgroupUsecase_Delete_FindByIDCancelled_IdentityPreserved pins the
+// context-cancellation contract for the Delete ownership lookup now that it
+// routes through authorizeCardgroupOrUnauthenticated (ownership.go). The inline
+// gate this replaced eris.Wrapped a cancelled FindByID; the shared helper passes
+// it through unwrapped, so assertCancelled plus the bare-identity check keep the
+// resolver's Cancelled routing intact.
+func TestCardgroupUsecase_Delete_FindByIDCancelled_IdentityPreserved(t *testing.T) {
+	t.Parallel()
+	repo := &mockCardgroupRepository{findErr: context.Canceled}
+	uc := NewCardgroupUsecase(repo, cgDefaultAdmin(), newTestLogger())
+
+	err := uc.Delete(cgAuthedCtx("user-1"), "cg1")
+
+	assertCancelled(t, err)
+	if err != context.Canceled {
+		t.Fatalf("expected unwrapped context.Canceled, got %T: %v", err, err)
+	}
+	if repo.deleteCalled {
+		t.Fatal("expected repo.Delete NOT to be called when FindByID is cancelled")
 	}
 }
 

--- a/backend/internal/usecase/ownership.go
+++ b/backend/internal/usecase/ownership.go
@@ -16,56 +16,74 @@ type CardgroupOwnershipFinder interface {
 	FindByID(ctx context.Context, id string) (*domain.Cardgroup, error)
 }
 
+// findOwnedCardgroup loads the cardgroup identified by id and verifies that
+// userID owns it, returning the loaded aggregate on success. It is the shared
+// core behind authorizeCardgroupOrBadInput / authorizeCardgroupOrUnauthenticated
+// and the entity-returning entry point for callers (e.g. cardgroupUsecase.Update)
+// that need the loaded row immediately after the ownership check.
+//
+// notFoundErr is returned when the repository reports repository.ErrNotFound:
+// callers pass a validation error when id originates from untrusted input and
+// ucerr.ErrUnauthenticated when a missing row signals an authorization or
+// consistency issue. context.Canceled / context.DeadlineExceeded pass through
+// unwrapped so the resolver can route them to Cancelled via errors.Is; any other
+// infrastructure error is wrapped as INTERNAL. A found-but-foreign row always
+// returns ucerr.ErrUnauthenticated; when the caller passes ucerr.ErrUnauthenticated
+// as notFoundErr, missing and found-but-foreign collapse to one indistinguishable
+// outcome so a stale id cannot be used as an existence oracle over another user's
+// cardgroups.
+func findOwnedCardgroup(
+	ctx context.Context,
+	repo CardgroupOwnershipFinder,
+	id domain.CardgroupID,
+	userID domain.UserID,
+	notFoundErr error,
+) (*domain.Cardgroup, error) {
+	cg, err := repo.FindByID(ctx, string(id))
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return nil, notFoundErr
+		}
+		if isContextDone(err) {
+			return nil, err
+		}
+		return nil, eris.Wrap(err, "usecase: authorize cardgroup: find by id")
+	}
+	if !cg.IsOwnedBy(userID) {
+		return nil, ucerr.ErrUnauthenticated
+	}
+	return cg, nil
+}
+
 // authorizeCardgroupOrBadInput verifies that userID owns the cardgroup identified
 // by id, treating a not-found cardgroup as a validation error against the caller-
 // supplied input. Use at the boundary where id originates from untrusted user
 // input (mutation arguments, list filters) and a stale id is a recoverable
-// caller mistake rather than a security event.
+// caller mistake rather than a security event. Delegates to findOwnedCardgroup
+// and discards the loaded entity.
 func authorizeCardgroupOrBadInput(
 	ctx context.Context,
 	repo CardgroupOwnershipFinder,
 	id domain.CardgroupID,
 	userID domain.UserID,
 ) error {
-	cg, err := repo.FindByID(ctx, string(id))
-	if err != nil {
-		if errors.Is(err, repository.ErrNotFound) {
-			return ucerr.NewValidationError("cardgroupId", "cardgroup not found")
-		}
-		if isContextDone(err) {
-			return err
-		}
-		return eris.Wrap(err, "usecase: authorize cardgroup: find by id")
-	}
-	if !cg.IsOwnedBy(userID) {
-		return ucerr.ErrUnauthenticated
-	}
-	return nil
+	_, err := findOwnedCardgroup(ctx, repo, id, userID,
+		ucerr.NewValidationError("cardgroupId", "cardgroup not found"))
+	return err
 }
 
 // authorizeCardgroupOrUnauthenticated verifies that userID owns the cardgroup
 // identified by id, treating a not-found cardgroup as an authorization failure.
 // Use deeper in the application layer where id was already validated upstream
 // (e.g. resolved from a DB-fetched entity) and a missing cardgroup signals an
-// authorization or consistency issue, not a caller mistake.
+// authorization or consistency issue, not a caller mistake. Delegates to
+// findOwnedCardgroup and discards the loaded entity.
 func authorizeCardgroupOrUnauthenticated(
 	ctx context.Context,
 	repo CardgroupOwnershipFinder,
 	id domain.CardgroupID,
 	userID domain.UserID,
 ) error {
-	cg, err := repo.FindByID(ctx, string(id))
-	if err != nil {
-		if errors.Is(err, repository.ErrNotFound) {
-			return ucerr.ErrUnauthenticated
-		}
-		if isContextDone(err) {
-			return err
-		}
-		return eris.Wrap(err, "usecase: authorize cardgroup: find by id")
-	}
-	if !cg.IsOwnedBy(userID) {
-		return ucerr.ErrUnauthenticated
-	}
-	return nil
+	_, err := findOwnedCardgroup(ctx, repo, id, userID, ucerr.ErrUnauthenticated)
+	return err
 }


### PR DESCRIPTION
## Summary

`cardgroupUsecase.Update` and `Delete` re-inlined the cardgroup lookup + not-found → `ErrUnauthenticated` + non-owner → `ErrUnauthenticated` gate that `ownership.go` already owns, and both copies had drifted: the inline branches wrapped a cancelled `FindByID` with `eris.Wrap(err, "usecase: cardgroup: find for update|delete")` instead of passing the context sentinel through unwrapped the way `authorizeCardgroupOrUnauthenticated` does. A wrapped `context.Canceled` still satisfies `errors.Is`, but it is no longer the bare sentinel the usecase-boundary contract promises — so any downstream `==` comparison (and the resolver's `Cancelled` routing) silently degrades.

This routes both write paths through the shared seam so the ownership-error contract lives in one place. `Delete` is a drop-in for `authorizeCardgroupOrUnauthenticated`. `Update` needs the loaded row for the subsequent rename/patch, so a small entity-returning core `findOwnedCardgroup(ctx, repo, id, userID, notFoundErr)` is added to `ownership.go`; both existing `authorizeCardgroup*` helpers are re-expressed over it behavior-preservingly (the `notFoundErr` argument is the only difference between them — `ValidationError` for the untrusted-input helper, `ErrUnauthenticated` for the post-validation helper). The context-cancellation identity contract now holds on both paths for free, because the shared core skips `eris.Wrap` for `isContextDone` errors.

Out of scope (unchanged): `cardgroupUsecase.Cardgroup`, whose `(nil, nil)`-on-not-found existence-oracle collapse is tracked separately.

## Changes

- `backend/internal/usecase/ownership.go`: added `findOwnedCardgroup(ctx, repo, id, userID, notFoundErr) (*domain.Cardgroup, error)` as the shared not-found/not-owned/context-done/infra-wrap core, returning the loaded aggregate on success. Re-expressed `authorizeCardgroupOrBadInput` and `authorizeCardgroupOrUnauthenticated` as thin delegators that pass the appropriate `notFoundErr` and discard the entity. No behavior change to either helper (same wrap prefix `usecase: authorize cardgroup: find by id`, same branch outcomes).
- `backend/internal/usecase/cardgroup.go`: `Update` now calls `findOwnedCardgroup(..., ucerr.ErrUnauthenticated)` and uses the returned row for the patch, replacing the inline `FindByID` + not-found/non-owner branches and the `usecase: cardgroup: find for update` wrap. `Delete` now calls `authorizeCardgroupOrUnauthenticated`, replacing its inline gate and the `usecase: cardgroup: find for delete` wrap. Both gain the `isContextDone` pass-through the inline copies lacked. Same query count.
- `backend/internal/usecase/cardgroup_test.go`: added `TestCardgroupUsecase_Update_FindByIDCancelled_IdentityPreserved` and `TestCardgroupUsecase_Delete_FindByIDCancelled_IdentityPreserved`, each asserting `assertCancelled` (chain) plus `err == context.Canceled` (bare identity) and that the write repo method is not reached, per the pin-unwrapped-context-error convention.

## Test plan

- `go tool gqlgen generate`, `go vet ./...`, `go build ./...`, `go tool go-arch-lint check --project-path .` — pass
- `go test ./internal/usecase/ -run 'TestAuthorizeCardgroupOr|TestCardgroupUsecase_Update|TestCardgroupUsecase_Delete' -count=1` — 26 pass (ownership-helper contract tests plus the Update/Delete anonymous/non-owner/not-found/success/validation/infra paths and the two new cancelled-`FindByID` identity pins)
- Docker-backed integration packages (`internal/repository`, `internal/database`, DB-backed `cmd/server` tests) are CI-deferred because testcontainers/Docker is unavailable locally; `go vet` + `go build` + `go-arch-lint` prove the whole tree compiles.

Closes #895
