### PR TITLE
refactor(backend): reuse domain RoleSet.ContainsAdmin in userResolver.Roles instead of the duplicate helper

### DIFF
--- a/backend/graph/resolver/admin.resolvers.go
+++ b/backend/graph/resolver/admin.resolvers.go
@@ -8,6 +8,7 @@ package resolver
 import (
 	"backend/graph/model"
 	"backend/internal/auth"
+	"backend/internal/domain"
 	"backend/internal/gqlerr"
 	"backend/internal/usecase"
 	"context"
@@ -169,7 +170,16 @@ func (r *userResolver) Roles(ctx context.Context, obj *model.User) ([]*model.Rol
 		if err != nil {
 			return nil, classifyLoaderErr(ctx, err, "resolver: user roles: admin check")
 		}
-		if !rolesContainAdmin(callerRoles) {
+		// Reuse the domain admin-membership predicate rather than a resolver-local
+		// role loop, mirroring the adapter in usecase/admin_user.go. Nil entries
+		// from the batch loader are skipped defensively before dereferencing.
+		callerSet := make(domain.RoleSet, 0, len(callerRoles))
+		for _, role := range callerRoles {
+			if role != nil {
+				callerSet = append(callerSet, *role)
+			}
+		}
+		if !callerSet.ContainsAdmin() {
 			return nil, gqlerr.NewForbidden("admin only")
 		}
 	}

--- a/backend/graph/resolver/helpers.go
+++ b/backend/graph/resolver/helpers.go
@@ -7,7 +7,6 @@ import (
 	"github.com/rotisserie/eris"
 	"github.com/vektah/gqlparser/v2/gqlerror"
 
-	"backend/internal/domain"
 	"backend/internal/gqlerr"
 	"backend/internal/loader"
 )
@@ -32,18 +31,6 @@ func classifyLoaderErr(ctx context.Context, err error, label string) *gqlerror.E
 		return gqlerr.Cancelled(ctx, err)
 	}
 	return gqlerr.Internal(ctx, eris.Wrap(err, label))
-}
-
-// rolesContainAdmin reports whether a batched role slice (as returned by the
-// RoleByUserID DataLoader) includes the built-in admin role. Nil entries are
-// skipped defensively.
-func rolesContainAdmin(roles []*domain.Role) bool {
-	for _, role := range roles {
-		if role != nil && role.Name == domain.AdminRoleName {
-			return true
-		}
-	}
-	return false
 }
 
 // newNoVariantSetError builds the INTERNAL error returned when an outcome union has no


### PR DESCRIPTION
## Summary

`userResolver.Roles` gated its "self or admin" field access with a resolver-local
`rolesContainAdmin` helper (a loop over `role.Name == domain.AdminRoleName`), which
duplicated the domain predicate `domain.RoleSet.ContainsAdmin()` that already exists,
is tested in `role_set_test.go`, and is already consumed by
`usecase/admin_user.go`'s edit-user self-demotion guard. Two admin-membership
predicates that can silently drift is exactly the kind of DRY hazard a single-source
domain function removes.

This routes the resolver through the domain predicate: the field resolver builds a
`domain.RoleSet` from the batch-loaded `[]*domain.Role` and calls `.ContainsAdmin()`,
mirroring the adapter in `usecase/admin_user.go`. The invariant preserved is that the
self-or-admin **orchestration** stays inside the field resolver — a caller reads their
own roles unconditionally, reading another user's roles requires admin, and a rejection
still surfaces as `Forbidden("admin only")`. Only the admin-membership *predicate* moves
to the shared domain function; no `domain.CanViewUserRoles`/policy wrapper is introduced,
keeping the object-level vs. field-level authorization split described in
`docs/backend-auth.md` intact. The batch-loader adapter keeps the prior helper's
defensive nil-skip before dereferencing, so behavior is unchanged for every input.

## Changes

- `backend/graph/resolver/admin.resolvers.go`: in `userResolver.Roles`, replace the
  `rolesContainAdmin(callerRoles)` call with an inline `domain.RoleSet` build over the
  batch-loaded caller roles (nil entries skipped) and a `.ContainsAdmin()` check,
  mirroring `usecase/admin_user.go`. Adds the `backend/internal/domain` import.
- `backend/graph/resolver/helpers.go`: delete the now-unused duplicate
  `rolesContainAdmin` helper and drop the now-unused `backend/internal/domain` import.

## Test plan

- `go tool gqlgen generate`, `go vet ./...`, `go build ./...`, `go tool go-arch-lint check --project-path .` — pass
- `go test ./graph/resolver/ -run 'TestAdminUserResolver_Roles_NonAdminNonSelf_Forbidden|TestAdminUserResolver_Roles_BatchesIntoOneQueryPerPage|TestAdminUserResolver_Roles_SelfIntrospection_Allowed|TestUserResolver_Roles_Unauthenticated|TestUserResolver_Roles_MissingLoaderInternal|TestUserResolver_Roles_LoaderErrorInternal|TestUserResolver_Roles_ContextCancelled' -count=1` — 7 pass, exercising both admin-membership branches, the self-introspection skip, and the unauth/missing-loader/loader-error/cancelled guard paths.
- Docker-backed integration packages (`internal/repository`, `internal/database`, DB-backed `cmd/server` tests) are CI-deferred because testcontainers/Docker is unavailable locally; `go vet`, `go build`, and `go-arch-lint` already prove the whole tree compiles.

Closes #896
