### PR TITLE
refactor(backend): extract shared duplicate-front recovery, patch staging, and bulk-delete cap for card and master-card usecases

### DIFF
--- a/backend/internal/usecase/card.go
+++ b/backend/internal/usecase/card.go
@@ -3,7 +3,6 @@ package usecase
 import (
 	"context"
 	"errors"
-	"fmt"
 	"log/slog"
 
 	"github.com/rotisserie/eris"
@@ -251,18 +250,17 @@ func (u *cardUsecase) Create(ctx context.Context, in CreateCardInput) (CreateCar
 	}
 	if err := u.cardRepo.Create(ctx, card); err != nil {
 		if errors.Is(err, repository.ErrCardDuplicateFront) {
-			existing, lookupErr := u.cardRepo.FindByCardgroupAndFront(ctx, in.CardgroupID, string(card.Front))
-			if lookupErr != nil {
-				// The lookup may race with a concurrent delete (the duplicate row vanished
-				// between the failed INSERT and this SELECT) or fail for an unrelated DB
-				// reason. Either way, surface as Internal so the client can retry; the
-				// duplicate is recoverable input, but a failed re-lookup is not.
-				return CreateCardOutcome{}, eris.Wrap(lookupErr, "usecase: card: lookup duplicate after 23505")
+			dup, recoverErr := recoverDuplicateFront(func() (string, string, error) {
+				existing, lookupErr := u.cardRepo.FindByCardgroupAndFront(ctx, in.CardgroupID, string(card.Front))
+				if lookupErr != nil {
+					return "", "", lookupErr
+				}
+				return existing.ID, string(existing.Back), nil
+			}, "usecase: card: lookup duplicate after 23505")
+			if recoverErr != nil {
+				return CreateCardOutcome{}, recoverErr
 			}
-			return CreateCardOutcome{Duplicate: &DuplicateCardInfo{
-				ExistingID:   existing.ID,
-				ExistingBack: string(existing.Back),
-			}}, nil
+			return CreateCardOutcome{Duplicate: dup}, nil
 		}
 		return CreateCardOutcome{}, eris.Wrap(err, "usecase: card: create: repo create")
 	}
@@ -286,43 +284,47 @@ func (u *cardUsecase) Update(ctx context.Context, id string, in UpdateCardInput)
 		return UpdateCardOutcome{}, err
 	}
 
+	// Validate and stage each requested field through the shared stageCardText helper.
+	// UpdateFront/UpdateBack errors are routed through eris.Wrap inside each apply
+	// closure, not translateCardErr: ParseCardText (run inside stageCardText) already
+	// returns the sentinel for empty/zero input on the validation channel. If
+	// UpdateFront/UpdateBack still rejects the parsed VO, the invariant has been
+	// violated by a programmer error, not bad user input. INTERNAL is the honest
+	// classification — surfacing as BAD_USER_INPUT would mislead the client.
 	patch := repository.CardUpdate{}
-	// UpdateFront/UpdateBack errors below are routed through eris.Wrap, not
-	// translateCardErr: ParseCardText (called immediately inside each guard)
-	// already returns the sentinel for empty/zero input on the validation
-	// channel. If UpdateFront/UpdateBack still rejects the parsed VO, the
-	// invariant has been violated by a programmer error, not bad user input.
-	// INTERNAL is the honest classification — surfacing as BAD_USER_INPUT
-	// would mislead the client.
-	if in.Front != nil {
-		front, err := domain.ParseCardText(*in.Front, domain.ErrCardFrontRequired, domain.ErrCardFrontTooLong)
-		if err != nil {
-			info, perr := liftValidationErr(translateCardErr(err))
-			if perr != nil {
-				return UpdateCardOutcome{}, perr
+	frontStaged, frontInfo, err := stageCardText(in.Front,
+		domain.ErrCardFrontRequired, domain.ErrCardFrontTooLong,
+		func(text domain.CardText) (string, error) {
+			if err := existing.UpdateFront(text); err != nil {
+				return "", eris.Wrap(err, "usecase: card: update front")
 			}
-			return UpdateCardOutcome{Validation: info}, nil
-		}
-		if err := existing.UpdateFront(front); err != nil {
-			return UpdateCardOutcome{}, eris.Wrap(err, "usecase: card: update front")
-		}
-		s := existing.Front.String()
-		patch.Front = &s
+			return existing.Front.String(), nil
+		})
+	if err != nil {
+		return UpdateCardOutcome{}, err
 	}
-	if in.Back != nil {
-		back, err := domain.ParseCardText(*in.Back, domain.ErrCardBackRequired, domain.ErrCardBackTooLong)
-		if err != nil {
-			info, perr := liftValidationErr(translateCardErr(err))
-			if perr != nil {
-				return UpdateCardOutcome{}, perr
+	if frontInfo != nil {
+		return UpdateCardOutcome{Validation: frontInfo}, nil
+	}
+	if frontStaged != nil {
+		patch.Front = frontStaged
+	}
+	backStaged, backInfo, err := stageCardText(in.Back,
+		domain.ErrCardBackRequired, domain.ErrCardBackTooLong,
+		func(text domain.CardText) (string, error) {
+			if err := existing.UpdateBack(text); err != nil {
+				return "", eris.Wrap(err, "usecase: card: update back")
 			}
-			return UpdateCardOutcome{Validation: info}, nil
-		}
-		if err := existing.UpdateBack(back); err != nil {
-			return UpdateCardOutcome{}, eris.Wrap(err, "usecase: card: update back")
-		}
-		s := existing.Back.String()
-		patch.Back = &s
+			return existing.Back.String(), nil
+		})
+	if err != nil {
+		return UpdateCardOutcome{}, err
+	}
+	if backInfo != nil {
+		return UpdateCardOutcome{Validation: backInfo}, nil
+	}
+	if backStaged != nil {
+		patch.Back = backStaged
 	}
 
 	updated, err := u.cardRepo.Update(ctx, id, patch)
@@ -504,8 +506,8 @@ func (u *cardUsecase) BulkDelete(ctx context.Context, ids []string) (int64, erro
 	if err := requireCallerSub(user); err != nil {
 		return 0, err
 	}
-	if len(ids) > maxBulkDelete {
-		return 0, ucerr.NewValidationError("ids", fmt.Sprintf("at most %d ids per call", maxBulkDelete))
+	if err := checkBulkDeleteCap(ids); err != nil {
+		return 0, err
 	}
 	if len(ids) == 0 {
 		return 0, nil

--- a/backend/internal/usecase/card_test.go
+++ b/backend/internal/usecase/card_test.go
@@ -991,6 +991,36 @@ func TestCardUsecase_Create_DuplicateLookupRace_RowVanished(t *testing.T) {
 	assertInternalChain(t, err, "usecase: card: lookup duplicate after 23505")
 }
 
+// TestCardUsecase_Create_DuplicateLookupCancelled pins the context-cancellation
+// identity of the duplicate-front re-lookup. When FindByCardgroupAndFront is
+// cancelled, the shared recoverDuplicateFront helper must return the bare
+// context.Canceled unwrapped — not an eris.Wrap of it — so the identity survives to
+// the caller. errors.Is is too weak on its own (it holds even through an eris chain),
+// so the load-bearing check is the bare err == context.Canceled equality. This
+// regression-guards the recovery drift that previously wrapped the lookup error at
+// this call site (unlike the master-card path, which already pinned the identity).
+func TestCardUsecase_Create_DuplicateLookupCancelled(t *testing.T) {
+	t.Parallel()
+	const wantCardgroupID = "cg-cancelled-id"
+
+	cardRepo := &mockCardRepository{
+		createErr:                  repository.ErrCardDuplicateFront,
+		findByCardgroupAndFrontErr: context.Canceled,
+	}
+	cgRepo := &mockCardgroupRepoForCard{findResult: &domain.Cardgroup{ID: domain.CardgroupID(wantCardgroupID), OwnerID: "u1"}}
+	uc := NewCardUsecase(nil, cardRepo, cgRepo, nil, nil, newTestLogger())
+
+	_, err := uc.Create(authedCtx("u1"), CreateCardInput{CardgroupID: wantCardgroupID, Front: "hello", Back: "world"})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected errors.Is(err, context.Canceled), got %v", err)
+	}
+	// Load-bearing: the identity must be preserved unwrapped, not buried in an eris
+	// chain, so a caller relying on == context.Canceled still matches.
+	if err != context.Canceled {
+		t.Fatalf("expected unwrapped context.Canceled (identity pinned), got %v", err)
+	}
+}
+
 // strPtr returns a pointer to s. Helper used by search passthrough tests.
 func strPtr(s string) *string { return &s }
 

--- a/backend/internal/usecase/card_write_helpers.go
+++ b/backend/internal/usecase/card_write_helpers.go
@@ -1,0 +1,100 @@
+package usecase
+
+import (
+	"fmt"
+
+	"github.com/rotisserie/eris"
+
+	"backend/internal/domain"
+	"backend/internal/usecase/ucerr"
+)
+
+// recoverDuplicateFront performs the Postgres 23505 duplicate-front recovery shared
+// by the user-card (card.go) and master-card (master_card.go) create paths. The caller
+// has already matched repository.ErrCardDuplicateFront; this helper runs the follow-up
+// lookup of the colliding row (supplied as a closure so each caller uses its own
+// aggregate-specific repository method and conflict key) and returns the existing card's
+// identity as a *DuplicateCardInfo. The duplicate is surfaced as data, not an error, so
+// the resolver maps it to the *DuplicateFrontError union variant.
+//
+// A failed re-lookup is surfaced as an error: context-cancellation identity is pinned —
+// the bare context.Canceled / context.DeadlineExceeded is returned unwrapped, so
+// errors.Is(err, context.Canceled) holds AND err == context.Canceled (the identity is
+// not lost inside an eris chain). Any other lookup failure is wrapped with the
+// caller-supplied wrapPrefix. Per the error-wrapping rule, this shared helper never
+// hardcodes a fixed layer prefix — the prefix travels from the caller so the error_chain
+// names the file that performed the operation. The lookup may race with a concurrent
+// delete (the duplicate row vanished between the failed INSERT and this SELECT) or fail
+// for an unrelated DB reason; either way it is INTERNAL so the client can retry.
+func recoverDuplicateFront(
+	lookup func() (existingID, existingBack string, err error),
+	wrapPrefix string,
+) (*DuplicateCardInfo, error) {
+	existingID, existingBack, err := lookup()
+	if err != nil {
+		if isContextDone(err) {
+			return nil, err
+		}
+		return nil, eris.Wrap(err, wrapPrefix)
+	}
+	return &DuplicateCardInfo{
+		ExistingID:   existingID,
+		ExistingBack: existingBack,
+	}, nil
+}
+
+// stageCardText validates one front/back field for the card / master-card update paths
+// and stages the parsed value into the caller's repository patch. It collapses the four
+// near-identical staging blocks (user-card front/back, master-card front/back) into a
+// single validate-then-apply pipeline.
+//
+// in is the caller's optional input pointer; nil means "leave unchanged" and the helper
+// returns (nil, nil, nil). requiredErr / tooLongErr are the field-specific domain
+// sentinels passed to ParseCardText. apply runs the aggregate mutation
+// (existing.UpdateFront / staged.UpdateBack) and returns the resulting persisted string;
+// the caller wraps any aggregate error with its own two-segment prefix inside the closure
+// (error-wrapping rule: shared helpers take the caller prefix, never hardcode it). The
+// aggregate mutations reject only the zero CardText (defense-in-depth); ParseCardText has
+// already enforced the length/non-empty invariants, so an apply error is a programmer-error
+// INTERNAL, not bad user input — hence the closure wraps with eris rather than translating.
+//
+// Exactly one of the three return values is non-nil on any non-nil-input call:
+//   - (staged, nil, nil)  success: caller assigns patch.Front/Back = staged.
+//   - (nil, info, nil)    the field failed validation: caller returns its
+//     Outcome{Validation: info} data result (business failure as data, not error).
+//   - (nil, nil, err)     a hard error (non-validation ParseCardText failure, or an apply
+//     failure): caller returns Outcome{}, err.
+func stageCardText(
+	in *string,
+	requiredErr, tooLongErr error,
+	apply func(domain.CardText) (string, error),
+) (*string, *InputValidationInfo, error) {
+	if in == nil {
+		return nil, nil, nil
+	}
+	text, err := domain.ParseCardText(*in, requiredErr, tooLongErr)
+	if err != nil {
+		info, liftErr := liftValidationErr(translateCardErr(err))
+		if liftErr != nil {
+			return nil, nil, liftErr
+		}
+		return nil, info, nil
+	}
+	s, err := apply(text)
+	if err != nil {
+		return nil, nil, err
+	}
+	return &s, nil, nil
+}
+
+// checkBulkDeleteCap enforces the shared per-call id cap for the two bulk-delete paths
+// (cardUsecase.BulkDelete, masterCardUsecase.DeleteMasterCards). It returns a
+// BAD_USER_INPUT validation error on "ids" when the batch exceeds maxBulkDelete, and nil
+// otherwise. The empty-slice short-circuit stays at each caller because the follow-on
+// action differs (a transaction vs. a direct DeleteMany) even though both return (0, nil).
+func checkBulkDeleteCap(ids []string) error {
+	if len(ids) > maxBulkDelete {
+		return ucerr.NewValidationError("ids", fmt.Sprintf("at most %d ids per call", maxBulkDelete))
+	}
+	return nil
+}

--- a/backend/internal/usecase/master_card.go
+++ b/backend/internal/usecase/master_card.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/base64"
 	"errors"
-	"fmt"
 	"log/slog"
 	"time"
 
@@ -279,21 +278,17 @@ func (u *masterCardUsecase) CreateMasterCard(ctx context.Context, in CreateMaste
 	}
 	if err := u.masterCardRepo.Create(ctx, card); err != nil {
 		if errors.Is(err, repository.ErrCardDuplicateFront) {
-			existing, lookupErr := u.masterCardRepo.FindByMasterCardgroupAndFront(ctx, in.MasterCardgroupID, string(card.Front))
-			if lookupErr != nil {
-				if isContextDone(lookupErr) {
-					return CreateMasterCardOutcome{}, lookupErr
+			dup, recoverErr := recoverDuplicateFront(func() (string, string, error) {
+				existing, lookupErr := u.masterCardRepo.FindByMasterCardgroupAndFront(ctx, in.MasterCardgroupID, string(card.Front))
+				if lookupErr != nil {
+					return "", "", lookupErr
 				}
-				// The lookup may race with a concurrent delete (the duplicate row
-				// vanished between the failed INSERT and this SELECT) or fail for an
-				// unrelated DB reason. Either way, surface as Internal so the client
-				// can retry.
-				return CreateMasterCardOutcome{}, eris.Wrap(lookupErr, "usecase: master card: lookup duplicate after 23505")
+				return existing.ID, string(existing.Back), nil
+			}, "usecase: master card: lookup duplicate after 23505")
+			if recoverErr != nil {
+				return CreateMasterCardOutcome{}, recoverErr
 			}
-			return CreateMasterCardOutcome{Duplicate: &DuplicateCardInfo{
-				ExistingID:   existing.ID,
-				ExistingBack: string(existing.Back),
-			}}, nil
+			return CreateMasterCardOutcome{Duplicate: dup}, nil
 		}
 		if errors.Is(err, repository.ErrMasterCardgroupNotFound) {
 			return CreateMasterCardOutcome{}, ucerr.NewValidationError("masterCardgroupId", "master cardgroup not found")
@@ -314,47 +309,51 @@ func (u *masterCardUsecase) UpdateMasterCard(ctx context.Context, id string, in 
 		return UpdateMasterCardOutcome{}, err
 	}
 
-	// Validate and stage each requested field through the aggregate mutation
-	// methods rather than writing the patch DTO inline (mirrors cardUsecase.Update).
-	// The patch-build path is preserved — no FindByID read round-trip: a transient
-	// MasterCard carries the parsed value into UpdateFront/UpdateBack and the
-	// resulting field is copied into the repository patch. UpdateFront/UpdateBack
-	// errors below route through eris.Wrap, not translateCardErr: ParseCardText
-	// (called immediately above each guard) already returns the sentinel for
+	// Validate and stage each requested field through the shared stageCardText helper
+	// rather than writing the patch DTO inline (mirrors cardUsecase.Update). The
+	// patch-build path is preserved — no FindByID read round-trip: a transient
+	// MasterCard carries the parsed value into UpdateFront/UpdateBack and the resulting
+	// field is copied into the repository patch. UpdateFront/UpdateBack errors are
+	// routed through eris.Wrap inside each apply closure, not translateCardErr:
+	// ParseCardText (run inside stageCardText) already returns the sentinel for
 	// empty/zero input on the validation channel. If UpdateFront/UpdateBack still
 	// rejects the parsed VO, the invariant has been violated by a programmer error,
 	// not bad user input — INTERNAL is the honest classification.
 	patch := repository.MasterCardUpdate{}
 	staged := &domain.MasterCard{}
-	if in.Front != nil {
-		front, err := domain.ParseCardText(*in.Front, domain.ErrCardFrontRequired, domain.ErrCardFrontTooLong)
-		if err != nil {
-			info, perr := liftValidationErr(translateCardErr(err))
-			if perr != nil {
-				return UpdateMasterCardOutcome{}, perr
+	frontStaged, frontInfo, err := stageCardText(in.Front,
+		domain.ErrCardFrontRequired, domain.ErrCardFrontTooLong,
+		func(text domain.CardText) (string, error) {
+			if err := staged.UpdateFront(text); err != nil {
+				return "", eris.Wrap(err, "usecase: master card: update front")
 			}
-			return UpdateMasterCardOutcome{Validation: info}, nil
-		}
-		if err := staged.UpdateFront(front); err != nil {
-			return UpdateMasterCardOutcome{}, eris.Wrap(err, "usecase: master card: update front")
-		}
-		s := staged.Front.String()
-		patch.Front = &s
+			return staged.Front.String(), nil
+		})
+	if err != nil {
+		return UpdateMasterCardOutcome{}, err
 	}
-	if in.Back != nil {
-		back, err := domain.ParseCardText(*in.Back, domain.ErrCardBackRequired, domain.ErrCardBackTooLong)
-		if err != nil {
-			info, perr := liftValidationErr(translateCardErr(err))
-			if perr != nil {
-				return UpdateMasterCardOutcome{}, perr
+	if frontInfo != nil {
+		return UpdateMasterCardOutcome{Validation: frontInfo}, nil
+	}
+	if frontStaged != nil {
+		patch.Front = frontStaged
+	}
+	backStaged, backInfo, err := stageCardText(in.Back,
+		domain.ErrCardBackRequired, domain.ErrCardBackTooLong,
+		func(text domain.CardText) (string, error) {
+			if err := staged.UpdateBack(text); err != nil {
+				return "", eris.Wrap(err, "usecase: master card: update back")
 			}
-			return UpdateMasterCardOutcome{Validation: info}, nil
-		}
-		if err := staged.UpdateBack(back); err != nil {
-			return UpdateMasterCardOutcome{}, eris.Wrap(err, "usecase: master card: update back")
-		}
-		s := staged.Back.String()
-		patch.Back = &s
+			return staged.Back.String(), nil
+		})
+	if err != nil {
+		return UpdateMasterCardOutcome{}, err
+	}
+	if backInfo != nil {
+		return UpdateMasterCardOutcome{Validation: backInfo}, nil
+	}
+	if backStaged != nil {
+		patch.Back = backStaged
 	}
 
 	updated, err := u.masterCardRepo.Update(ctx, id, patch)
@@ -395,8 +394,8 @@ func (u *masterCardUsecase) DeleteMasterCards(ctx context.Context, ids []string)
 	if _, err := u.adminGate.Require(ctx, "usecase: master card: bulk delete"); err != nil {
 		return 0, err
 	}
-	if len(ids) > maxBulkDelete {
-		return 0, ucerr.NewValidationError("ids", fmt.Sprintf("at most %d ids per call", maxBulkDelete))
+	if err := checkBulkDeleteCap(ids); err != nil {
+		return 0, err
 	}
 	if len(ids) == 0 {
 		return 0, nil


### PR DESCRIPTION
## Summary

`card.go` and `master_card.go` carried copies of the same three write-path building blocks: the Postgres `23505` duplicate-front recovery, the front/back patch-staging blocks, and the bulk-delete cap prologue. The `card.go` duplicate-recovery copy had also drifted on context-done handling — its re-lookup wrapped a cancelled `FindByCardgroupAndFront` in `eris.Wrap` instead of returning the bare sentinel, so a `context.Canceled` surfaced during the recovery lost its identity (`errors.Is` still matched through the eris chain, but the value returned to the resolver was no longer `== context.Canceled`, silently changing the wire-format classification for any `==` consumer). The `master_card.go` copy already pinned the identity via `isContextDone`.

This single-sources the three block types into package-private helpers in the `usecase` package, honoring the shared-helper contract in [`.claude/rules/error-wrapping.md`](.claude/rules/error-wrapping.md): the caller supplies the lookup closure and the two-segment `eris` wrap prefix, so no fixed layer prefix is hardcoded inside a helper body and the `error_chain` keeps naming the file that performed the operation. Extracting `recoverDuplicateFront` also fixes the `card.go` drift — the shared helper pins context-cancellation identity for both callers. Duplicate-front behavior (surfaced as `outcome.Duplicate` data → `BAD_USER_INPUT` mapping), validation-as-data behavior for update fields, and the per-caller bulk-delete partial-match log (card.go carries `user_id` and a different message) are all unchanged.

The three helpers:

- `recoverDuplicateFront(lookup, wrapPrefix)` — runs the caller-supplied colliding-row lookup, returns a `*DuplicateCardInfo` on success, pins `context.Canceled` / `context.DeadlineExceeded` unwrapped, and wraps any other lookup failure with the caller prefix as INTERNAL.
- `stageCardText(in, requiredErr, tooLongErr, apply)` — validates one optional front/back field through `ParseCardText`, routes a validation failure into an `*InputValidationInfo` data result, and runs the caller's `apply` closure (which performs the aggregate mutation and wraps its own error). Collapses the four near-identical staging blocks.
- `checkBulkDeleteCap(ids)` — returns the `BAD_USER_INPUT` cap error when a batch exceeds `maxBulkDelete`. The empty-slice short-circuit stays per-caller because the follow-on action differs (a transaction vs. a direct `DeleteMany`).

## Changes

- `backend/internal/usecase/card_write_helpers.go` (new): `recoverDuplicateFront`, `stageCardText`, and `checkBulkDeleteCap`, each with caller-supplied lookup/prefix/closure so the shared-helper no-hardcoded-prefix rule holds.
- `backend/internal/usecase/card.go`: `Create` routes the duplicate-front recovery through `recoverDuplicateFront` (which now pins the cancelled-lookup identity); `Update` stages front/back via `stageCardText`; `BulkDelete` uses `checkBulkDeleteCap`. Dropped the now-unused `fmt` import. The partial-match log (with `user_id`) is untouched.
- `backend/internal/usecase/master_card.go`: `CreateMasterCard` routes through `recoverDuplicateFront`; `UpdateMasterCard` stages front/back via `stageCardText`; `DeleteMasterCards` uses `checkBulkDeleteCap`. Dropped the now-unused `fmt` import. The outer `ErrMasterCardgroupNotFound` / `isContextDone` create-error handling and the master partial-match log are untouched.
- `backend/internal/usecase/card_test.go`: added `TestCardUsecase_Create_DuplicateLookupCancelled`, which drives the recovery with a cancelled `FindByCardgroupAndFront` and asserts both `errors.Is(err, context.Canceled)` and the load-bearing bare `err == context.Canceled` identity — a real regression guard, since the pre-extraction `card.go` copy wrapped the sentinel and would fail the `==` check.

## Test plan

- `go tool gqlgen generate`, `go vet ./...`, `go build ./...`, `go tool go-arch-lint check --project-path .` — pass
- `go test ./internal/usecase/ -run 'TestCardUsecase_Create|TestCardUsecase_Update|TestCardUsecase_BulkDelete|TestMasterCardUsecase_Create|TestMasterCardUsecase_Update|TestMasterCardUsecase_DeleteMasterCards' -count=1` — pass, including the new `TestCardUsecase_Create_DuplicateLookupCancelled` (the whole `internal/usecase` package also runs green: 795 tests, DB-free with repo fakes).
- Docker-backed integration packages (`internal/repository`, `internal/database`, `cmd/server`) require testcontainers/Docker, which is unavailable locally, so those are CI-deferred (they compile cleanly under `go vet` / `go build`).

Closes #898
