### PR TITLE
refactor(backend): move learning-stats mastery/struggle aggregation from the usecase into a domain service

### DIFF
--- a/backend/graph/resolver/stats_resolver_test.go
+++ b/backend/graph/resolver/stats_resolver_test.go
@@ -90,8 +90,8 @@ func TestMyLearningStats_HappyPath(t *testing.T) {
 
 	mock := &mockStatsUsecase{
 		result: &usecase.LearningStatsResult{
-			Mastery: usecase.MasteryBreakdown{InProgress: 4, Learned: 6, Mature: 10, TotalStudied: 20},
-			Decks: []usecase.DeckMasteryResult{
+			Mastery: service.MasteryBreakdown{InProgress: 4, Learned: 6, Mature: 10, TotalStudied: 20},
+			Decks: []service.DeckMastery{
 				{CardgroupID: "cg-1", TotalCards: 10, LearnedCards: 3, MatureCards: 7},
 				{CardgroupID: "cg-2", TotalCards: 5, LearnedCards: 1, MatureCards: 2},
 			},
@@ -163,7 +163,7 @@ func TestMyLearningStats_MissingLoaderMiddleware_ReturnsInternal(t *testing.T) {
 
 	mock := &mockStatsUsecase{
 		result: &usecase.LearningStatsResult{
-			Mastery: usecase.MasteryBreakdown{TotalStudied: 0},
+			Mastery: service.MasteryBreakdown{TotalStudied: 0},
 		},
 	}
 	srv := newStatsSrv(mock)
@@ -184,7 +184,7 @@ func TestMyLearningStats_CardgroupLoadError_ContextCancelledReturnsCancelled(t *
 
 	mock := &mockStatsUsecase{
 		result: &usecase.LearningStatsResult{
-			Decks: []usecase.DeckMasteryResult{{CardgroupID: "cg-1", TotalCards: 1}},
+			Decks: []service.DeckMastery{{CardgroupID: "cg-1", TotalCards: 1}},
 		},
 	}
 	srv := newStatsSrv(mock)
@@ -206,7 +206,7 @@ func TestMyLearningStats_CardgroupLoadError_GenericReturnsInternal(t *testing.T)
 
 	mock := &mockStatsUsecase{
 		result: &usecase.LearningStatsResult{
-			Decks: []usecase.DeckMasteryResult{{CardgroupID: "cg-1", TotalCards: 1}},
+			Decks: []service.DeckMastery{{CardgroupID: "cg-1", TotalCards: 1}},
 		},
 	}
 	srv := newStatsSrv(mock)
@@ -288,7 +288,7 @@ func TestMyLearningStats_PerformanceAndStrugglingCards(t *testing.T) {
 
 	mock := &mockStatsUsecase{
 		result: &usecase.LearningStatsResult{
-			Mastery: usecase.MasteryBreakdown{TotalStudied: 3},
+			Mastery: service.MasteryBreakdown{TotalStudied: 3},
 			Performance: service.PerformanceMetrics{
 				SuccessRate:   0.8,
 				AvgDifficulty: 0.4,
@@ -297,7 +297,7 @@ func TestMyLearningStats_PerformanceAndStrugglingCards(t *testing.T) {
 				LapseRate:     0.1,
 				ReviewCount:   42,
 			},
-			StrugglingCards: []usecase.StrugglingCardResult{
+			StrugglingCards: []service.StrugglingCard{
 				{CardID: "card-1", Lapses: 5, Stability: 2.5},
 				{CardID: "card-2", Lapses: 3, Stability: 8},
 			},
@@ -363,8 +363,8 @@ func TestMyLearningStats_NoLapses_ReturnsEmptyStrugglingCards(t *testing.T) {
 
 	mock := &mockStatsUsecase{
 		result: &usecase.LearningStatsResult{
-			Mastery:         usecase.MasteryBreakdown{TotalStudied: 2},
-			StrugglingCards: []usecase.StrugglingCardResult{},
+			Mastery:         service.MasteryBreakdown{TotalStudied: 2},
+			StrugglingCards: []service.StrugglingCard{},
 		},
 	}
 	srv := newStatsSrv(mock)
@@ -394,7 +394,7 @@ func TestMyLearningStats_StrugglingCardLoadError_ReturnsInternal(t *testing.T) {
 
 	mock := &mockStatsUsecase{
 		result: &usecase.LearningStatsResult{
-			StrugglingCards: []usecase.StrugglingCardResult{{CardID: "card-1", Lapses: 2, Stability: 1}},
+			StrugglingCards: []service.StrugglingCard{{CardID: "card-1", Lapses: 2, Stability: 1}},
 		},
 	}
 	srv := newStatsSrv(mock)

--- a/backend/internal/domain/fsrs_stat.go
+++ b/backend/internal/domain/fsrs_stat.go
@@ -1,0 +1,25 @@
+package domain
+
+// FSRSStat is a lightweight per-card projection of a user's FSRS state, consumed
+// by the learning-stats domain services (AggregateMastery, TopStruggling). It
+// carries no card front text — just CardID (row identity), CardgroupID (per-deck
+// bucketing), Phase/Stability (the columns ClassifyMastery needs), and Lapses
+// (the struggling-card ranking key).
+//
+// FSRSStat is not an aggregate; it is a view-level value shared between the
+// repository (which builds it from a JOIN of user_card_fsrs and cards) and the
+// learning-stats domain services (which consume it). It lives in the domain
+// package because the mastery/struggle aggregation is domain logic and FSRSStat
+// is its input — the same placement rule as DueCard. See
+// docs/backend/ddd-patterns/view-level-value-in-domain-package.md.
+//
+// FSRSStat has no ParseFSRSStat constructor: the projection is established by
+// the repository's SELECT/JOIN, not by a domain-side validator. Phase must be a
+// valid FSRSPhase (the repository rejects out-of-range values before returning).
+type FSRSStat struct {
+	CardID      string
+	CardgroupID string
+	Phase       FSRSPhase
+	Stability   float64
+	Lapses      int
+}

--- a/backend/internal/domain/service/learning_stats_test.go
+++ b/backend/internal/domain/service/learning_stats_test.go
@@ -1,0 +1,172 @@
+package service
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"backend/internal/domain"
+)
+
+func fsrsStat(card, cardgroup string, phase domain.FSRSPhase, stability float64, lapses int) domain.FSRSStat {
+	return domain.FSRSStat{CardID: card, CardgroupID: cardgroup, Phase: phase, Stability: stability, Lapses: lapses}
+}
+
+func strugglingIDs(cards []StrugglingCard) []string {
+	out := make([]string, 0, len(cards))
+	for _, c := range cards {
+		out = append(out, c.CardID)
+	}
+	return out
+}
+
+// TestAggregateMastery pins the accumulation invariant that defines "mastered":
+// every studied stat lands in exactly one of the three disjoint tiers (so
+// InProgress + Learned + Mature == TotalStudied), and one DeckMastery is emitted
+// per owned deck in deckCardTotals — CardgroupID-sorted, with the learned/mature
+// split disjoint and a zero-studied deck still emitted with learned=mature=0.
+func TestAggregateMastery(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name        string
+		stats       []domain.FSRSStat
+		totals      map[string]int
+		wantMastery MasteryBreakdown
+		wantDecks   []DeckMastery
+	}{
+		{
+			name:        "empty history yields zero breakdown and no decks",
+			stats:       nil,
+			totals:      map[string]int{},
+			wantMastery: MasteryBreakdown{},
+			wantDecks:   []DeckMastery{},
+		},
+		{
+			name: "three disjoint tiers across two decks, deterministic sort, empty deck emitted",
+			stats: []domain.FSRSStat{
+				fsrsStat("a", "cg1", domain.FSRSPhaseReview, 30, 0),                         // mature
+				fsrsStat("b", "cg1", domain.FSRSPhaseReview, 10, 0),                         // learned
+				fsrsStat("c", "cg1", domain.FSRSPhaseNew, 0, 0),                             // in progress
+				fsrsStat("d", "cg2", domain.FSRSPhaseReview, domain.MatureStabilityDays, 0), // mature (boundary, >=)
+				fsrsStat("e", "cg2", domain.FSRSPhaseLearning, 0, 0),                        // in progress
+			},
+			totals:      map[string]int{"cg1": 5, "cg2": 3, "cg3": 2},
+			wantMastery: MasteryBreakdown{InProgress: 2, Learned: 1, Mature: 2, TotalStudied: 5},
+			wantDecks: []DeckMastery{
+				{CardgroupID: "cg1", TotalCards: 5, LearnedCards: 1, MatureCards: 1},
+				{CardgroupID: "cg2", TotalCards: 3, LearnedCards: 0, MatureCards: 1},
+				{CardgroupID: "cg3", TotalCards: 2, LearnedCards: 0, MatureCards: 0},
+			},
+		},
+		{
+			name: "just below the mature boundary is Learned, not Mature",
+			stats: []domain.FSRSStat{
+				fsrsStat("b", "cg1", domain.FSRSPhaseReview, domain.MatureStabilityDays-0.01, 0),
+			},
+			totals:      map[string]int{"cg1": 1},
+			wantMastery: MasteryBreakdown{Learned: 1, TotalStudied: 1},
+			wantDecks:   []DeckMastery{{CardgroupID: "cg1", TotalCards: 1, LearnedCards: 1, MatureCards: 0}},
+		},
+		{
+			name: "studied card whose deck is absent from totals counts globally but has no deck row",
+			stats: []domain.FSRSStat{
+				fsrsStat("x", "cgX", domain.FSRSPhaseReview, 30, 0),
+			},
+			totals:      map[string]int{},
+			wantMastery: MasteryBreakdown{Mature: 1, TotalStudied: 1},
+			wantDecks:   []DeckMastery{},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			mastery, decks, err := AggregateMastery(tc.stats, tc.totals)
+			require.NoError(t, err)
+			require.Equal(t, tc.wantMastery, mastery)
+			require.Equal(t, tc.wantDecks, decks)
+
+			// The core accumulation invariant: the three tiers are disjoint and
+			// cover every studied stat.
+			require.Equal(t, mastery.TotalStudied,
+				mastery.InProgress+mastery.Learned+mastery.Mature,
+				"tiers must sum to TotalStudied")
+			require.Equal(t, len(tc.stats), mastery.TotalStudied)
+			for _, d := range decks {
+				require.LessOrEqual(t, d.LearnedCards+d.MatureCards, d.TotalCards,
+					"acquired never exceeds the denominator for deck %s", d.CardgroupID)
+			}
+		})
+	}
+}
+
+// TestTopStruggling pins the "struggling" definition: a stat with no lapse is
+// never struggling, and among lapsed stats the ranking is (Lapses desc,
+// Stability asc).
+func TestTopStruggling(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		stats   []domain.FSRSStat
+		limit   int
+		wantIDs []string
+	}{
+		{
+			name: "excludes zero-lapse stats and orders by lapses then stability",
+			stats: []domain.FSRSStat{
+				fsrsStat("no-lapse", "cg1", domain.FSRSPhaseReview, 1, 0), // filtered out (Lapses == 0)
+				fsrsStat("one-lapse", "cg1", domain.FSRSPhaseReview, 50, 1),
+				fsrsStat("five-a", "cg1", domain.FSRSPhaseReview, 8, 5),
+				fsrsStat("five-b", "cg1", domain.FSRSPhaseReview, 3, 5), // same lapses, lower stability -> first
+			},
+			limit:   10,
+			wantIDs: []string{"five-b", "five-a", "one-lapse"},
+		},
+		{
+			name: "no lapsed stats yields an empty (non-nil) slice",
+			stats: []domain.FSRSStat{
+				fsrsStat("no-lapse", "cg1", domain.FSRSPhaseReview, 1, 0),
+			},
+			limit:   10,
+			wantIDs: []string{},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := TopStruggling(tc.stats, tc.limit)
+			require.NotNil(t, got, "the struggling set is always a non-nil slice")
+			assert.Equal(t, tc.wantIDs, strugglingIDs(got))
+			for _, c := range got {
+				assert.GreaterOrEqual(t, c.Lapses, 1)
+			}
+		})
+	}
+}
+
+// TestTopStruggling_CapsAtLimit verifies the result is truncated to the limit,
+// keeping the highest-lapse stats.
+func TestTopStruggling_CapsAtLimit(t *testing.T) {
+	t.Parallel()
+
+	const limit = 10
+	stats := make([]domain.FSRSStat, 0, 15)
+	for i := 0; i < 15; i++ {
+		stats = append(stats, fsrsStat(fmt.Sprintf("card-%02d", i), "cg1", domain.FSRSPhaseReview, 1, i+1))
+	}
+
+	got := TopStruggling(stats, limit)
+
+	require.Len(t, got, limit, "capped at limit")
+	assert.Equal(t, 15, got[0].Lapses, "highest lapses first")
+	assert.Equal(t, 6, got[limit-1].Lapses, "lowest surviving lapses at the cap boundary")
+}

--- a/backend/internal/domain/service/user_performance.go
+++ b/backend/internal/domain/service/user_performance.go
@@ -1,10 +1,130 @@
 package service
 
 import (
+	"sort"
 	"time"
+
+	"github.com/rotisserie/eris"
 
 	"backend/internal/domain"
 )
+
+// MasteryBreakdown is the disjoint three-tier count across all studied cards.
+// InProgress + Learned + Mature == TotalStudied by construction.
+type MasteryBreakdown struct{ InProgress, Learned, Mature, TotalStudied int }
+
+// DeckMastery is a per-deck acquisition summary. LearnedCards and MatureCards
+// are disjoint; acquired == LearnedCards + MatureCards, and acquired never
+// exceeds TotalCards.
+type DeckMastery struct {
+	CardgroupID  string
+	TotalCards   int
+	LearnedCards int // disjoint: Review & stability < MatureStabilityDays
+	MatureCards  int // disjoint: Review & stability >= MatureStabilityDays
+}
+
+// StrugglingCard identifies a card the learner struggles with (high lapses /
+// low stability). CardID is hydrated to a Card by the resolver.
+type StrugglingCard struct {
+	CardID    string
+	Lapses    int
+	Stability float64
+}
+
+// AggregateMastery buckets studied FSRS stats into the global three-tier
+// MasteryBreakdown and a per-deck DeckMastery split. This is the definition of
+// "mastered" — a card's tier is decided by domain.ClassifyMastery, so the three
+// tiers are disjoint and cover every studied card (InProgress + Learned + Mature
+// == len(stats) == TotalStudied).
+//
+// deckCardTotals is the total card count per owned deck (only decks with at
+// least one card). One DeckMastery is emitted for every entry, sorted by
+// CardgroupID for a deterministic order, so a deck with zero studied cards still
+// appears with LearnedCards == MatureCards == 0. Studied cards whose deck is
+// absent from deckCardTotals still contribute to the global breakdown but have
+// no DeckMastery denominator.
+//
+// The default arm is defensive: domain.ClassifyMastery only ever returns the
+// three known tiers, so an unhandled tier signals a domain invariant break.
+func AggregateMastery(stats []domain.FSRSStat, deckCardTotals map[string]int) (MasteryBreakdown, []DeckMastery, error) {
+	// perDeck accumulates the disjoint learned/mature split per cardgroup while
+	// the global breakdown accrues across every studied card.
+	type deckAcc struct{ learned, mature int }
+	perDeck := make(map[string]*deckAcc, len(deckCardTotals))
+	mastery := MasteryBreakdown{TotalStudied: len(stats)}
+	for _, s := range stats {
+		tier := domain.ClassifyMastery(
+			domain.FSRSState{Phase: s.Phase, Stability: s.Stability},
+			domain.MatureStabilityDays,
+		)
+		acc := perDeck[s.CardgroupID]
+		if acc == nil {
+			acc = &deckAcc{}
+			perDeck[s.CardgroupID] = acc
+		}
+		switch tier {
+		case domain.TierInProgress:
+			mastery.InProgress++
+		case domain.TierLearned:
+			mastery.Learned++
+			acc.learned++
+		case domain.TierMature:
+			mastery.Mature++
+			acc.mature++
+		default:
+			return MasteryBreakdown{}, nil, eris.Errorf("service: aggregate mastery: unhandled MasteryTier %d", tier)
+		}
+	}
+
+	// Emit one DeckMastery for every owned deck (from deckCardTotals), so a deck
+	// with zero studied cards still appears with learned=mature=0. Sort by
+	// CardgroupID for a deterministic wire order.
+	deckIDs := make([]string, 0, len(deckCardTotals))
+	for id := range deckCardTotals {
+		deckIDs = append(deckIDs, id)
+	}
+	sort.Strings(deckIDs)
+
+	decks := make([]DeckMastery, 0, len(deckIDs))
+	for _, id := range deckIDs {
+		acc := perDeck[id]
+		var learned, mature int
+		if acc != nil {
+			learned, mature = acc.learned, acc.mature
+		}
+		decks = append(decks, DeckMastery{
+			CardgroupID:  id,
+			TotalCards:   deckCardTotals[id],
+			LearnedCards: learned,
+			MatureCards:  mature,
+		})
+	}
+	return mastery, decks, nil
+}
+
+// TopStruggling ranks studied FSRS stats by struggle: filter to cards with at
+// least one lapse, sort by (Lapses desc, Stability asc), and cap at limit. This
+// is the definition of "struggling" — a card with no lapse is never struggling,
+// and among lapsed cards more lapses (then lower stability) rank higher. The
+// result is always non-nil (an empty, non-nil slice when no card has lapsed).
+func TopStruggling(stats []domain.FSRSStat, limit int) []StrugglingCard {
+	out := make([]StrugglingCard, 0, len(stats))
+	for _, s := range stats {
+		if s.Lapses >= 1 {
+			out = append(out, StrugglingCard{CardID: s.CardID, Lapses: s.Lapses, Stability: s.Stability})
+		}
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Lapses != out[j].Lapses {
+			return out[i].Lapses > out[j].Lapses // more lapses first
+		}
+		return out[i].Stability < out[j].Stability // ties: lower stability first
+	})
+	if len(out) > limit {
+		out = out[:limit]
+	}
+	return out
+}
 
 // PerformanceMode is the difficulty level inferred from a user's recent
 // performance. Values intentionally span ModeDifficult (0) .. ModeMastered (4).

--- a/backend/internal/repository/user_card_fsrs.go
+++ b/backend/internal/repository/user_card_fsrs.go
@@ -29,25 +29,13 @@ type gormUserCardFSRS struct {
 
 func (gormUserCardFSRS) TableName() string { return "user_card_fsrs" }
 
-// FSRSStatRow is a lightweight projection for the stats aggregate: no front
-// text — just CardID (row identity), CardgroupID (per-deck bucketing),
-// Phase/Stability (the columns ClassifyMastery needs), and Lapses (the
-// struggling-card ranking key).
-type FSRSStatRow struct {
-	CardID      string
-	CardgroupID string
-	Phase       domain.FSRSPhase
-	Stability   float64
-	Lapses      int
-}
-
 type UserCardFSRSRepository interface {
 	UpsertTx(ctx context.Context, tx *gorm.DB, u *domain.UserCardFSRS) error
 	FindByUserAndCardIDs(ctx context.Context, userID string, cardIDs []string) (map[string]*domain.UserCardFSRS, error)
 	FindByUserAndCardIDsTx(ctx context.Context, tx *gorm.DB, userID string, cardIDs []string) (map[string]*domain.UserCardFSRS, error)
-	// ListFSRSStatesByUser returns one lightweight row per studied card for
-	// userID, joined to cards for the owning cardgroup.
-	ListFSRSStatesByUser(ctx context.Context, userID string) ([]FSRSStatRow, error)
+	// ListFSRSStatesByUser returns one lightweight domain.FSRSStat per studied
+	// card for userID, joined to cards for the owning cardgroup.
+	ListFSRSStatesByUser(ctx context.Context, userID string) ([]domain.FSRSStat, error)
 	// CountCardsByCardgroupForUser returns the total card count per cardgroup the
 	// user owns, for every owned deck that has at least one card (the per-deck
 	// denominators + the deck list for the acquisition rate). Decks with cards
@@ -86,8 +74,8 @@ func (r *userCardFSRSRepo) UpsertTx(ctx context.Context, tx *gorm.DB, u *domain.
 // ListFSRSStatesByUser returns one row per studied card for userID, joined to
 // cards for the owning cardgroup. WHERE user_card_fsrs.user_id = ? is backed by
 // the (user_id, card_id) PK.
-func (r *userCardFSRSRepo) ListFSRSStatesByUser(ctx context.Context, userID string) ([]FSRSStatRow, error) {
-	var rows []FSRSStatRow
+func (r *userCardFSRSRepo) ListFSRSStatesByUser(ctx context.Context, userID string) ([]domain.FSRSStat, error) {
+	var rows []domain.FSRSStat
 	err := r.db.WithContext(ctx).
 		Table("user_card_fsrs AS f").
 		Select("f.card_id AS card_id, c.cardgroup_id AS cardgroup_id, f.state AS phase, f.stability AS stability, f.lapses AS lapses").

--- a/backend/internal/repository/user_card_fsrs_test.go
+++ b/backend/internal/repository/user_card_fsrs_test.go
@@ -207,7 +207,7 @@ func TestUserCardFSRSRepository_ListFSRSStatesByUser_ScopesByViewer(t *testing.T
 	require.NoError(t, err)
 	require.Len(t, rows, 2, "owner has exactly two studied cards")
 
-	byCard := make(map[string]repository.FSRSStatRow, len(rows))
+	byCard := make(map[string]domain.FSRSStat, len(rows))
 	for _, r := range rows {
 		byCard[r.CardID] = r
 	}

--- a/backend/internal/usecase/stats.go
+++ b/backend/internal/usecase/stats.go
@@ -2,7 +2,6 @@ package usecase
 
 import (
 	"context"
-	"sort"
 	"time"
 
 	"github.com/rotisserie/eris"
@@ -10,7 +9,6 @@ import (
 	"backend/internal/auth"
 	"backend/internal/domain"
 	"backend/internal/domain/service"
-	"backend/internal/repository"
 )
 
 const (
@@ -32,7 +30,7 @@ type StatsUsecase interface {
 // stats aggregate needs. Declaring it here keeps the dependency arrow correct
 // and lets a fake satisfy it in tests.
 type statsFSRSRepo interface {
-	ListFSRSStatesByUser(ctx context.Context, userID string) ([]repository.FSRSStatRow, error)
+	ListFSRSStatesByUser(ctx context.Context, userID string) ([]domain.FSRSStat, error)
 	CountCardsByCardgroupForUser(ctx context.Context, userID string) (map[string]int, error)
 }
 
@@ -69,38 +67,19 @@ func NewStats(fsrsRepo statsFSRSRepo, swipeRepo statsSwipeRepo, cardgroupRepo st
 
 // LearningStatsResult is the usecase-layer result VO. It carries cardgroup ids
 // and struggling-card ids only; the resolver hydrates the Cardgroup / Card
-// objects via the DataLoader.
+// objects via the DataLoader. The mastery/struggle policy that fills these
+// fields lives in the domain services (service.AggregateMastery /
+// service.TopStruggling); the usecase only orchestrates the repo reads.
 type LearningStatsResult struct {
-	Mastery MasteryBreakdown
-	Decks   []DeckMasteryResult
+	Mastery service.MasteryBreakdown
+	Decks   []service.DeckMastery
 	// OwnsAnyDeck is true iff the caller owns at least one cardgroup, regardless
 	// of card count. It lets the client tell a brand-new user (owns nothing) apart
 	// from a user who created a deck but has not added cards yet — Decks omits
 	// empty decks, so Decks alone cannot make that distinction.
 	OwnsAnyDeck     bool
 	Performance     service.PerformanceMetrics
-	StrugglingCards []StrugglingCardResult
-}
-
-// StrugglingCardResult identifies a card the learner struggles with (high
-// lapses / low stability). CardID is hydrated to a Card by the resolver.
-type StrugglingCardResult struct {
-	CardID    string
-	Lapses    int
-	Stability float64
-}
-
-// MasteryBreakdown is the disjoint three-tier count across all studied cards.
-// InProgress + Learned + Mature == TotalStudied by construction.
-type MasteryBreakdown struct{ InProgress, Learned, Mature, TotalStudied int }
-
-// DeckMasteryResult is a per-deck acquisition summary. LearnedCards and
-// MatureCards are disjoint; acquired == LearnedCards + MatureCards.
-type DeckMasteryResult struct {
-	CardgroupID  string
-	TotalCards   int
-	LearnedCards int // disjoint: Review & stability < MatureStabilityDays
-	MatureCards  int // disjoint: Review & stability >= MatureStabilityDays
+	StrugglingCards []service.StrugglingCard
 }
 
 func (u *statsUsecase) MyLearningStats(ctx context.Context) (*LearningStatsResult, error) {
@@ -118,57 +97,12 @@ func (u *statsUsecase) MyLearningStats(ctx context.Context) (*LearningStatsResul
 		return nil, eris.Wrap(err, "usecase: stats: count cards by cardgroup")
 	}
 
-	// perDeck accumulates the disjoint learned/mature split per cardgroup while
-	// the global breakdown accrues across every studied card.
-	type deckAcc struct{ learned, mature int }
-	perDeck := make(map[string]*deckAcc, len(totals))
-	mastery := MasteryBreakdown{TotalStudied: len(states)}
-	for _, s := range states {
-		tier := domain.ClassifyMastery(
-			domain.FSRSState{Phase: s.Phase, Stability: s.Stability},
-			domain.MatureStabilityDays,
-		)
-		acc := perDeck[s.CardgroupID]
-		if acc == nil {
-			acc = &deckAcc{}
-			perDeck[s.CardgroupID] = acc
-		}
-		switch tier {
-		case domain.TierInProgress:
-			mastery.InProgress++
-		case domain.TierLearned:
-			mastery.Learned++
-			acc.learned++
-		case domain.TierMature:
-			mastery.Mature++
-			acc.mature++
-		default:
-			return nil, eris.Errorf("usecase: stats: unhandled MasteryTier %d", tier)
-		}
-	}
-
-	// Emit one DeckMasteryResult for every owned deck (from totals), so a deck
-	// with zero studied cards still appears with learned=mature=0. Sort by
-	// CardgroupID for a deterministic wire order.
-	deckIDs := make([]string, 0, len(totals))
-	for id := range totals {
-		deckIDs = append(deckIDs, id)
-	}
-	sort.Strings(deckIDs)
-
-	decks := make([]DeckMasteryResult, 0, len(deckIDs))
-	for _, id := range deckIDs {
-		acc := perDeck[id]
-		var learned, mature int
-		if acc != nil {
-			learned, mature = acc.learned, acc.mature
-		}
-		decks = append(decks, DeckMasteryResult{
-			CardgroupID:  id,
-			TotalCards:   totals[id],
-			LearnedCards: learned,
-			MatureCards:  mature,
-		})
+	// Mastery half: the global three-tier breakdown plus the per-deck acquisition
+	// split — the "mastered" policy — is owned by the domain service; the usecase
+	// only forwards the loaded rows.
+	mastery, decks, err := service.AggregateMastery(states, totals)
+	if err != nil {
+		return nil, eris.Wrap(err, "usecase: stats: aggregate mastery")
 	}
 
 	// Diagnostic half: a performance snapshot over the trailing statsWindowDays
@@ -192,28 +126,6 @@ func (u *statsUsecase) MyLearningStats(ctx context.Context) (*LearningStatsResul
 		Decks:           decks,
 		OwnsAnyDeck:     count > 0,
 		Performance:     service.ComputeMetrics(swipeRecordsByValue(swipes), now),
-		StrugglingCards: topStruggling(states, strugglingCardsLimit),
+		StrugglingCards: service.TopStruggling(states, strugglingCardsLimit),
 	}, nil
-}
-
-// topStruggling ranks the studied FSRS rows by struggle: filter to cards with at
-// least one lapse, sort by (Lapses desc, Stability asc), and cap at limit. The
-// result is always non-nil (an empty, non-nil slice when no card has lapsed).
-func topStruggling(states []repository.FSRSStatRow, limit int) []StrugglingCardResult {
-	out := make([]StrugglingCardResult, 0, len(states))
-	for _, s := range states {
-		if s.Lapses >= 1 {
-			out = append(out, StrugglingCardResult{CardID: s.CardID, Lapses: s.Lapses, Stability: s.Stability})
-		}
-	}
-	sort.SliceStable(out, func(i, j int) bool {
-		if out[i].Lapses != out[j].Lapses {
-			return out[i].Lapses > out[j].Lapses // more lapses first
-		}
-		return out[i].Stability < out[j].Stability // ties: lower stability first
-	})
-	if len(out) > limit {
-		out = out[:limit]
-	}
-	return out
 }

--- a/backend/internal/usecase/stats_test.go
+++ b/backend/internal/usecase/stats_test.go
@@ -3,7 +3,6 @@ package usecase
 import (
 	"context"
 	"errors"
-	"fmt"
 	"testing"
 	"time"
 
@@ -14,18 +13,17 @@ import (
 	"backend/internal/auth"
 	"backend/internal/domain"
 	"backend/internal/domain/service"
-	"backend/internal/repository"
 	"backend/internal/usecase/ucerr"
 )
 
 type fakeStatsFSRSRepo struct {
-	states    []repository.FSRSStatRow
+	states    []domain.FSRSStat
 	totals    map[string]int
 	statesErr error
 	totalsErr error
 }
 
-func (f *fakeStatsFSRSRepo) ListFSRSStatesByUser(_ context.Context, _ string) ([]repository.FSRSStatRow, error) {
+func (f *fakeStatsFSRSRepo) ListFSRSStatesByUser(_ context.Context, _ string) ([]domain.FSRSStat, error) {
 	if f.statesErr != nil {
 		return nil, f.statesErr
 	}
@@ -77,11 +75,11 @@ func authedStatsCtx(sub string) context.Context {
 	return auth.ContextWithUser(context.Background(), &auth.AuthUser{Sub: sub})
 }
 
-func strugglingRow(card string, lapses int, stability float64) repository.FSRSStatRow {
-	return repository.FSRSStatRow{CardID: card, CardgroupID: "cg1", Phase: domain.FSRSPhaseReview, Stability: stability, Lapses: lapses}
+func strugglingRow(card string, lapses int, stability float64) domain.FSRSStat {
+	return domain.FSRSStat{CardID: card, CardgroupID: "cg1", Phase: domain.FSRSPhaseReview, Stability: stability, Lapses: lapses}
 }
 
-func strugglingCardIDs(cards []StrugglingCardResult) []string {
+func strugglingCardIDs(cards []service.StrugglingCard) []string {
 	out := make([]string, 0, len(cards))
 	for _, c := range cards {
 		out = append(out, c.CardID)
@@ -89,19 +87,19 @@ func strugglingCardIDs(cards []StrugglingCardResult) []string {
 	return out
 }
 
-func reviewRow(card, cg string, stability float64) repository.FSRSStatRow {
-	return repository.FSRSStatRow{CardID: card, CardgroupID: cg, Phase: domain.FSRSPhaseReview, Stability: stability}
+func reviewRow(card, cg string, stability float64) domain.FSRSStat {
+	return domain.FSRSStat{CardID: card, CardgroupID: cg, Phase: domain.FSRSPhaseReview, Stability: stability}
 }
 
-func phaseRow(card, cg string, phase domain.FSRSPhase) repository.FSRSStatRow {
-	return repository.FSRSStatRow{CardID: card, CardgroupID: cg, Phase: phase}
+func phaseRow(card, cg string, phase domain.FSRSPhase) domain.FSRSStat {
+	return domain.FSRSStat{CardID: card, CardgroupID: cg, Phase: phase}
 }
 
 func TestStatsUsecase_MyLearningStats_BucketsGlobalAndPerDeck(t *testing.T) {
 	t.Parallel()
 
 	repo := &fakeStatsFSRSRepo{
-		states: []repository.FSRSStatRow{
+		states: []domain.FSRSStat{
 			reviewRow("a", "cg1", 30),                         // mature
 			reviewRow("b", "cg1", 10),                         // learned
 			phaseRow("c", "cg1", domain.FSRSPhaseNew),         // in progress
@@ -127,9 +125,9 @@ func TestStatsUsecase_MyLearningStats_BucketsGlobalAndPerDeck(t *testing.T) {
 		res.Mastery.InProgress+res.Mastery.Learned+res.Mastery.Mature,
 		"tiers are disjoint and cover every studied card")
 
-	// A DeckMasteryResult is emitted for every deck in totals, in deterministic
+	// A DeckMastery is emitted for every deck in totals, in deterministic
 	// (CardgroupID-sorted) order — including cg3 with zero studied cards.
-	byDeck := make(map[string]DeckMasteryResult, len(res.Decks))
+	byDeck := make(map[string]service.DeckMastery, len(res.Decks))
 	order := make([]string, 0, len(res.Decks))
 	for _, d := range res.Decks {
 		byDeck[d.CardgroupID] = d
@@ -138,9 +136,9 @@ func TestStatsUsecase_MyLearningStats_BucketsGlobalAndPerDeck(t *testing.T) {
 	require.Len(t, res.Decks, 3)
 	assert.Equal(t, []string{"cg1", "cg2", "cg3"}, order)
 
-	assert.Equal(t, DeckMasteryResult{CardgroupID: "cg1", TotalCards: 5, LearnedCards: 1, MatureCards: 1}, byDeck["cg1"])
-	assert.Equal(t, DeckMasteryResult{CardgroupID: "cg2", TotalCards: 3, LearnedCards: 0, MatureCards: 1}, byDeck["cg2"])
-	assert.Equal(t, DeckMasteryResult{CardgroupID: "cg3", TotalCards: 2, LearnedCards: 0, MatureCards: 0}, byDeck["cg3"],
+	assert.Equal(t, service.DeckMastery{CardgroupID: "cg1", TotalCards: 5, LearnedCards: 1, MatureCards: 1}, byDeck["cg1"])
+	assert.Equal(t, service.DeckMastery{CardgroupID: "cg2", TotalCards: 3, LearnedCards: 0, MatureCards: 1}, byDeck["cg2"])
+	assert.Equal(t, service.DeckMastery{CardgroupID: "cg3", TotalCards: 2, LearnedCards: 0, MatureCards: 0}, byDeck["cg3"],
 		"a deck with zero studied cards is still emitted with learned=mature=0")
 	for _, d := range res.Decks {
 		assert.LessOrEqual(t, d.LearnedCards+d.MatureCards, d.TotalCards,
@@ -155,7 +153,7 @@ func TestStatsUsecase_MyLearningStats_EmptyHistory(t *testing.T) {
 
 	res, err := uc.MyLearningStats(authedStatsCtx("user-1"))
 	require.NoError(t, err)
-	assert.Equal(t, MasteryBreakdown{}, res.Mastery)
+	assert.Equal(t, service.MasteryBreakdown{}, res.Mastery)
 	assert.Empty(t, res.Decks)
 }
 
@@ -204,46 +202,6 @@ func TestStatsUsecase_MyLearningStats_CountError(t *testing.T) {
 	assert.Contains(t, err.Error(), "usecase: stats: count cards by cardgroup")
 }
 
-func TestTopStruggling_FiltersExcludesZeroAndOrders(t *testing.T) {
-	t.Parallel()
-	states := []repository.FSRSStatRow{
-		strugglingRow("no-lapse", 0, 1), // filtered out (Lapses == 0)
-		strugglingRow("one-lapse", 1, 50),
-		strugglingRow("five-a", 5, 8),
-		strugglingRow("five-b", 5, 3), // same lapses, lower stability -> ranks before five-a
-	}
-
-	got := topStruggling(states, 10)
-
-	require.Len(t, got, 3, "the Lapses==0 row is excluded")
-	assert.Equal(t, []string{"five-b", "five-a", "one-lapse"}, strugglingCardIDs(got),
-		"ordered by (Lapses desc, Stability asc)")
-	for _, c := range got {
-		assert.GreaterOrEqual(t, c.Lapses, 1)
-	}
-}
-
-func TestTopStruggling_CapsAtLimit(t *testing.T) {
-	t.Parallel()
-	states := make([]repository.FSRSStatRow, 0, 15)
-	for i := 0; i < 15; i++ {
-		states = append(states, strugglingRow(fmt.Sprintf("card-%02d", i), i+1, 1))
-	}
-
-	got := topStruggling(states, strugglingCardsLimit)
-
-	require.Len(t, got, strugglingCardsLimit, "capped at strugglingCardsLimit")
-	assert.Equal(t, 15, got[0].Lapses, "highest lapses first")
-	assert.Equal(t, 6, got[strugglingCardsLimit-1].Lapses, "lowest surviving lapses at the cap boundary")
-}
-
-func TestTopStruggling_EmptyReturnsNonNilSlice(t *testing.T) {
-	t.Parallel()
-	got := topStruggling([]repository.FSRSStatRow{strugglingRow("no-lapse", 0, 1)}, 10)
-	assert.NotNil(t, got, "empty struggling set is a non-nil slice")
-	assert.Empty(t, got)
-}
-
 func TestStatsUsecase_MyLearningStats_WindowsSwipesByStatsWindowDays(t *testing.T) {
 	t.Parallel()
 	fixedNow := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
@@ -286,7 +244,7 @@ func TestStatsUsecase_MyLearningStats_StrugglingCardsFromFSRSRows(t *testing.T) 
 	t.Parallel()
 	fixedNow := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
 	repo := &fakeStatsFSRSRepo{
-		states: []repository.FSRSStatRow{
+		states: []domain.FSRSStat{
 			strugglingRow("clean", 0, 20), // excluded (no lapses)
 			strugglingRow("worst", 4, 2),  // most lapses
 			strugglingRow("mid", 2, 15),
@@ -301,7 +259,7 @@ func TestStatsUsecase_MyLearningStats_StrugglingCardsFromFSRSRows(t *testing.T) 
 	require.NotNil(t, res)
 
 	require.Equal(t, []string{"worst", "mid-fragile", "mid"}, strugglingCardIDs(res.StrugglingCards))
-	assert.Equal(t, StrugglingCardResult{CardID: "worst", Lapses: 4, Stability: 2}, res.StrugglingCards[0])
+	assert.Equal(t, service.StrugglingCard{CardID: "worst", Lapses: 4, Stability: 2}, res.StrugglingCards[0])
 }
 
 func TestStatsUsecase_MyLearningStats_ListSwipesError(t *testing.T) {
@@ -352,7 +310,7 @@ func TestStatsUsecase_MyLearningStats_OwnsAnyDeck_EmptyDeck(t *testing.T) {
 func TestStatsUsecase_MyLearningStats_OwnsAnyDeck_DeckWithCards(t *testing.T) {
 	t.Parallel()
 	repo := &fakeStatsFSRSRepo{
-		states: []repository.FSRSStatRow{reviewRow("a", "cg1", 30)},
+		states: []domain.FSRSStat{reviewRow("a", "cg1", 30)},
 		totals: map[string]int{"cg1": 1},
 	}
 	uc := NewStats(repo, &fakeStatsSwipeRepo{}, &fakeStatsCardgroupRepo{count: 1}, nil)


### PR DESCRIPTION
## Summary

`MyLearningStats` computed the mastery-accumulation and struggle-ranking *policy* inline in the usecase, iterating over a repository DTO (`repository.FSRSStatRow`). That policy is domain logic — the definition of "mastered" (three disjoint tiers whose counts sum to `TotalStudied`) and "struggling" (lapsed cards ranked by `Lapses desc, Stability asc`) — living in the application layer, next to the sibling `ComputeMetrics` domain service that already owns the adjacent performance policy.

This hoists the projection type into `domain/` (`domain.FSRSStat`, following the `DueCard` precedent: a domain service is the consumer, so the read-model value lives in `domain/` rather than a sibling `readmodel/` package) and moves both policies into `domain/service` beside `ComputeMetrics`. `MyLearningStats` shrinks to orchestration only — auth + three repo reads + two service calls, no policy. The `myLearningStats` wire output is unchanged; the accumulation invariant `InProgress + Learned + Mature == TotalStudied` and the deterministic (CardgroupID-sorted, empty-deck-still-emitted) per-deck split are now pinned by direct table-driven domain unit tests.

## Changes

- `internal/domain/fsrs_stat.go` (new): `domain.FSRSStat` view-level value, relocated/renamed from `repository.FSRSStatRow`. It is the read-model input the mastery/struggle services consume; the docstring follows the `DueCard` placement rule (`docs/backend/ddd-patterns/view-level-value-in-domain-package.md`).
- `internal/domain/service/user_performance.go`: add `AggregateMastery` (global three-tier `MasteryBreakdown` + per-deck `DeckMastery` split) and `TopStruggling` (lapsed-card ranking) beside `ComputeMetrics`, and move the `MasteryBreakdown` / `DeckMastery` / `StrugglingCard` result types here. `ComputeMetrics` and its FSRS 1.0-floor normalization are left untouched.
- `internal/repository/user_card_fsrs.go`: `ListFSRSStatesByUser` now returns `[]domain.FSRSStat`; the `FSRSStatRow` DTO is removed.
- `internal/usecase/stats.go`: `MyLearningStats` reduced to auth + three repo reads + `service.AggregateMastery` + `service.TopStruggling`; the inline accumulation/ranking loops, the `topStruggling` helper, and the local result-type declarations are gone. `LearningStatsResult` now carries the `service.*` types.
- `graph/resolver/stats_resolver_test.go`: retargeted to the relocated `service.MasteryBreakdown` / `service.DeckMastery` / `service.StrugglingCard` types. The `stats_helpers.go` mapper needed no change — it reads the same field names.
- Tests: new `internal/domain/service/learning_stats_test.go` adds table-driven coverage of the mastered/struggling invariants (and the relocated `TopStruggling` cap/ordering/empty tests, since that code path moved out of the usecase); usecase + repository tests retargeted to `domain.FSRSStat` / `service.*`.

## Test plan

- `go tool gqlgen generate`, `go vet ./...`, `go build ./...`, `go tool go-arch-lint check --project-path .` — pass
- `go test ./internal/domain/service/ -run 'TestAggregateMastery|TestTopStruggling|TestComputeMetrics|TestModeFromMetrics|TestNormalizedDifficulty' -count=1` (43 pass), `go test ./internal/usecase/ -run 'TestStatsUsecase_MyLearningStats' -count=1` (14 pass), `go test ./graph/resolver/ -run 'TestMyLearningStats' -count=1` (8 pass)
- Docker-backed integration packages (`internal/repository` DB tests and DB-backed `cmd/server` tests) are CI-deferred because testcontainers/Docker is unavailable locally; `go vet` + `go build` + `go-arch-lint` already prove the whole tree, including those test files, compiles.

Closes #899
