### PR TITLE
refactor(backend): consolidate Bio and Description onto one trinary text VO

### DIFF
--- a/backend/internal/domain/bio.go
+++ b/backend/internal/domain/bio.go
@@ -1,21 +1,20 @@
 package domain
 
-import (
-	"strings"
-
-	"github.com/rivo/uniseg"
-	"github.com/rotisserie/eris"
-)
+import "github.com/rotisserie/eris"
 
 const BioMax = 500
 
 // ErrBioTooLong is returned when the trimmed bio exceeds BioMax graphemes.
 var ErrBioTooLong = eris.Errorf("user: bio exceeds %d characters", BioMax)
 
-// Bio is the user profile bio, supporting a trinary: nil (no change),
-// pointer-to-"" (explicit clear), or pointer-to-non-empty (set).
+// Bio is the user profile bio: a trinary text value object bounded at BioMax
+// graphemes. It supports nil (no change), pointer-to-"" (explicit clear), or
+// pointer-to-non-empty (set). It embeds the shared trinaryText so the trim +
+// grapheme-cap + trinary rule and the Ptr()/IsSet() accessors are single-sourced
+// with Description; see trinary_text.go. The zero value Bio{} is the no-value case
+// (IsSet()=false).
 type Bio struct {
-	value *string
+	trinaryText
 }
 
 // ParseBio validates and trims s, preserving the trinary contract:
@@ -24,14 +23,8 @@ type Bio struct {
 // whitespace-only inputs collapse to the explicit-clear case (Ptr() returns
 // a pointer to ""). Returns ErrBioTooLong if the trimmed value exceeds BioMax graphemes.
 func ParseBio(s *string) (Bio, error) {
-	if s == nil {
-		return Bio{}, nil
-	}
-	trimmed := strings.TrimSpace(*s)
-	if uniseg.GraphemeClusterCount(trimmed) > BioMax {
-		return Bio{}, ErrBioTooLong
-	}
-	return Bio{value: &trimmed}, nil
+	t, err := parseTrinaryText(s, BioMax, ErrBioTooLong)
+	return Bio{t}, err
 }
 
 // BioFromPtr maps a nullable text column to a Bio: nil → Bio{} (IsSet()=false,
@@ -40,30 +33,5 @@ func ParseBio(s *string) (Bio, error) {
 // Used by repository readers to bridge a nullable text column into the typed
 // domain field.
 func BioFromPtr(p *string) Bio {
-	if p == nil {
-		return Bio{}
-	}
-	s := *p
-	return Bio{value: &s}
+	return Bio{trinaryTextFromPtr(p)}
 }
-
-// Ptr returns a fresh copy of the internal pointer:
-//   - nil — the Bio holds no value (constructed via ParseBio(nil) or BioFromPtr(nil));
-//   - non-nil pointer to empty string — the Bio holds an empty value;
-//   - non-nil pointer to non-empty string — the Bio holds a populated value.
-//
-// Patch-context callers map nil → "no change", &"" → "explicit clear", &"x" → "set".
-// Read-context callers map nil → NULL column, &"" → empty stored, &"x" → populated stored.
-func (b Bio) Ptr() *string {
-	if b.value == nil {
-		return nil
-	}
-	s := *b.value
-	return &s
-}
-
-// IsSet reports whether the Bio carries a value (its internal pointer is non-nil).
-// Returns false for ParseBio(nil) (patch-context: no change) and for BioFromPtr(nil)
-// (read-context: NULL column / zero value Bio{}). Returns true for any other
-// construction, including an explicit empty string.
-func (b Bio) IsSet() bool { return b.value != nil }

--- a/backend/internal/domain/description.go
+++ b/backend/internal/domain/description.go
@@ -1,11 +1,6 @@
 package domain
 
-import (
-	"strings"
-
-	"github.com/rivo/uniseg"
-	"github.com/rotisserie/eris"
-)
+import "github.com/rotisserie/eris"
 
 const DescriptionMax = 500
 
@@ -13,12 +8,14 @@ const DescriptionMax = 500
 // DescriptionMax graphemes.
 var ErrDescriptionTooLong = eris.Errorf("master cardgroup: description exceeds %d characters", DescriptionMax)
 
-// Description is the optional master-cardgroup description, supporting a trinary:
-// nil (no change), pointer-to-"" (explicit clear), or pointer-to-non-empty (set).
-// It mirrors Bio: an optional, nullable, grapheme-bounded text field on an
-// aggregate. The zero value Description{} is the no-value case.
+// Description is the optional master-cardgroup description: a trinary text value
+// object bounded at DescriptionMax graphemes. It supports nil (no change),
+// pointer-to-"" (explicit clear), or pointer-to-non-empty (set). It embeds the
+// shared trinaryText so the trim + grapheme-cap + trinary rule and the
+// Ptr()/IsSet() accessors are single-sourced with Bio; see trinary_text.go. The
+// zero value Description{} is the no-value case (IsSet()=false).
 type Description struct {
-	value *string
+	trinaryText
 }
 
 // ParseDescription validates and trims s, preserving the trinary contract:
@@ -27,14 +24,8 @@ type Description struct {
 // inputs collapse to the explicit-clear case (Ptr() returns a pointer to "").
 // Returns ErrDescriptionTooLong if the trimmed value exceeds DescriptionMax graphemes.
 func ParseDescription(s *string) (Description, error) {
-	if s == nil {
-		return Description{}, nil
-	}
-	trimmed := strings.TrimSpace(*s)
-	if uniseg.GraphemeClusterCount(trimmed) > DescriptionMax {
-		return Description{}, ErrDescriptionTooLong
-	}
-	return Description{value: &trimmed}, nil
+	t, err := parseTrinaryText(s, DescriptionMax, ErrDescriptionTooLong)
+	return Description{t}, err
 }
 
 // DescriptionFromPtr maps a nullable text column to a Description: nil → Description{}
@@ -43,30 +34,5 @@ func ParseDescription(s *string) (Description, error) {
 // string value. Used by repository readers to bridge a nullable text column into
 // the typed domain field.
 func DescriptionFromPtr(p *string) Description {
-	if p == nil {
-		return Description{}
-	}
-	s := *p
-	return Description{value: &s}
+	return Description{trinaryTextFromPtr(p)}
 }
-
-// Ptr returns a fresh copy of the internal pointer:
-//   - nil — the Description holds no value (constructed via ParseDescription(nil) or DescriptionFromPtr(nil));
-//   - non-nil pointer to empty string — the Description holds an empty value;
-//   - non-nil pointer to non-empty string — the Description holds a populated value.
-//
-// Patch-context callers map nil → "no change", &"" → "explicit clear", &"x" → "set".
-// Read-context callers map nil → NULL column, &"" → empty stored, &"x" → populated stored.
-func (d Description) Ptr() *string {
-	if d.value == nil {
-		return nil
-	}
-	s := *d.value
-	return &s
-}
-
-// IsSet reports whether the Description carries a value (its internal pointer is
-// non-nil). Returns false for ParseDescription(nil) (patch-context: no change) and
-// for DescriptionFromPtr(nil) (read-context: NULL column / zero value Description{}).
-// Returns true for any other construction, including an explicit empty string.
-func (d Description) IsSet() bool { return d.value != nil }

--- a/backend/internal/domain/trinary_text.go
+++ b/backend/internal/domain/trinary_text.go
@@ -1,0 +1,77 @@
+package domain
+
+import (
+	"strings"
+
+	"github.com/rivo/uniseg"
+)
+
+// trinaryText is the shared value object behind the optional, trimmed,
+// grapheme-bounded text fields Bio and Description. It encodes a trinary via a
+// private *string:
+//   - nil          — no value ("no change" in a patch context; NULL column in a read context)
+//   - &""          — an explicit empty value ("explicit clear" / empty stored)
+//   - &"non-empty" — a populated value ("set" / populated stored)
+//
+// The VO is field-agnostic: parseTrinaryText takes the caller-supplied cap and
+// too-long sentinel, mirroring ParseCardText's caller-supplied sentinels. Bio and
+// Description embed it so the trim + grapheme-cap + trinary rule is single-sourced.
+type trinaryText struct {
+	value *string
+}
+
+// parseTrinaryText validates and trims s, preserving the trinary contract:
+// nil means "no change"; a pointer to "" means "explicit clear"; a pointer to a
+// non-empty string means "set". Surrounding whitespace is trimmed; whitespace-only
+// inputs collapse to the explicit-clear case (Ptr() returns a pointer to "").
+// Returns tooLongErr if the trimmed value exceeds max graphemes. It panics on a
+// nil tooLongErr sentinel, mirroring ParseCardText's construction-boundary guard:
+// a nil sentinel would return a nil error on a too-long input, which the caller
+// would misread as "valid".
+func parseTrinaryText(s *string, max int, tooLongErr error) (trinaryText, error) {
+	if tooLongErr == nil {
+		panic("domain: parseTrinaryText requires a non-nil tooLongErr sentinel")
+	}
+	if s == nil {
+		return trinaryText{}, nil
+	}
+	trimmed := strings.TrimSpace(*s)
+	if uniseg.GraphemeClusterCount(trimmed) > max {
+		return trinaryText{}, tooLongErr
+	}
+	return trinaryText{value: &trimmed}, nil
+}
+
+// trinaryTextFromPtr maps a nullable text column to a trinaryText: nil → the
+// no-value case (IsSet()=false, NULL column); a non-nil pointer — including
+// pointer-to-empty — maps to a set value whose Ptr() returns a defensive copy with
+// the same string value. Used by repository readers to bridge a nullable text
+// column into the typed domain field.
+func trinaryTextFromPtr(p *string) trinaryText {
+	if p == nil {
+		return trinaryText{}
+	}
+	s := *p
+	return trinaryText{value: &s}
+}
+
+// Ptr returns a fresh copy of the internal pointer:
+//   - nil — no value (constructed from a nil input);
+//   - non-nil pointer to empty string — an empty value;
+//   - non-nil pointer to non-empty string — a populated value.
+//
+// Patch-context callers map nil → "no change", &"" → "explicit clear", &"x" → "set".
+// Read-context callers map nil → NULL column, &"" → empty stored, &"x" → populated stored.
+func (t trinaryText) Ptr() *string {
+	if t.value == nil {
+		return nil
+	}
+	s := *t.value
+	return &s
+}
+
+// IsSet reports whether the value carries a payload (its internal pointer is
+// non-nil). Returns false for a nil-input parse (patch-context: no change) and for
+// a nil-pointer read (read-context: NULL column / zero value). Returns true for any
+// other construction, including an explicit empty string.
+func (t trinaryText) IsSet() bool { return t.value != nil }

--- a/backend/internal/usecase/validators.go
+++ b/backend/internal/usecase/validators.go
@@ -37,16 +37,27 @@ func validateRelayArgs(first, last *int, after, before *string) error {
 	return nil
 }
 
-// translateBioErr maps domain Bio sentinels into usecase-layer typed errors.
-// Unexpected errors are wrapped with eris. Returns nil when err is nil.
-func translateBioErr(err error) error {
+// translateTrinaryTextErr maps a domain trinary-text sentinel (Bio / Description
+// too-long) into a usecase-layer typed error. It is the shared body of
+// translateBioErr and translateDescriptionErr: err == nil returns nil; a match on
+// tooLong returns a field-scoped ValidationError whose message references max; any
+// other error is wrapped with the caller-supplied prefix (the prefix travels from
+// the caller so the error_chain names the calling field's module, per the shared-
+// helper wrap convention).
+func translateTrinaryTextErr(err error, field string, max int, tooLong error, wrap string) error {
 	if err == nil {
 		return nil
 	}
-	if errors.Is(err, domain.ErrBioTooLong) {
-		return ucerr.NewValidationError("bio", fmt.Sprintf("bio must be at most %d characters", domain.BioMax))
+	if errors.Is(err, tooLong) {
+		return ucerr.NewValidationError(field, fmt.Sprintf("%s must be at most %d characters", field, max))
 	}
-	return eris.Wrap(err, "usecase: translate bio error")
+	return eris.Wrap(err, wrap)
+}
+
+// translateBioErr maps domain Bio sentinels into usecase-layer typed errors.
+// Unexpected errors are wrapped with eris. Returns nil when err is nil.
+func translateBioErr(err error) error {
+	return translateTrinaryTextErr(err, "bio", domain.BioMax, domain.ErrBioTooLong, "usecase: translate bio error")
 }
 
 // translateCardErr maps domain Card sentinels into usecase-layer typed errors.
@@ -87,13 +98,7 @@ func translateCardgroupNameErr(err error) error {
 // typed errors. Unexpected errors are wrapped with eris. Returns nil when err
 // is nil.
 func translateDescriptionErr(err error) error {
-	if err == nil {
-		return nil
-	}
-	if errors.Is(err, domain.ErrDescriptionTooLong) {
-		return ucerr.NewValidationError("description", fmt.Sprintf("description must be at most %d characters", domain.DescriptionMax))
-	}
-	return eris.Wrap(err, "usecase: translate description error")
+	return translateTrinaryTextErr(err, "description", domain.DescriptionMax, domain.ErrDescriptionTooLong, "usecase: translate description error")
 }
 
 // translateDisplayNameErr maps domain DisplayName sentinels into usecase-layer

--- a/backend/internal/usecase/validators_test.go
+++ b/backend/internal/usecase/validators_test.go
@@ -2,6 +2,7 @@ package usecase
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -105,6 +106,102 @@ func TestValidateRelayArgs(t *testing.T) {
 			if tc.wantField == "" {
 				require.NoError(t, err)
 			} else {
+				require.Error(t, err)
+				assertValidationError(t, err, tc.wantField, tc.wantMsg)
+			}
+		})
+	}
+}
+
+// TestTranslateBioErr and TestTranslateDescriptionErr pin the thin wrappers over
+// the shared translateTrinaryTextErr body: nil passes through, the too-long
+// sentinel maps to a field-scoped ValidationError with the exact message, and any
+// other error wraps into the field-specific internal chain.
+func TestTranslateBioErr(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		input     error
+		wantField string
+		wantMsg   string
+		wantChain string
+	}{
+		{
+			name:  "nil passes through",
+			input: nil,
+		},
+		{
+			name:      "too-long sentinel",
+			input:     domain.ErrBioTooLong,
+			wantField: "bio",
+			wantMsg:   fmt.Sprintf("bio must be at most %d characters", domain.BioMax),
+		},
+		{
+			name:      "unexpected error wraps as internal",
+			input:     errors.New("surprise"),
+			wantChain: "usecase: translate bio error",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := translateBioErr(tc.input)
+
+			switch {
+			case tc.input == nil:
+				require.NoError(t, err)
+			case tc.wantChain != "":
+				assertInternalChain(t, err, tc.wantChain)
+			default:
+				require.Error(t, err)
+				assertValidationError(t, err, tc.wantField, tc.wantMsg)
+			}
+		})
+	}
+}
+
+func TestTranslateDescriptionErr(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		input     error
+		wantField string
+		wantMsg   string
+		wantChain string
+	}{
+		{
+			name:  "nil passes through",
+			input: nil,
+		},
+		{
+			name:      "too-long sentinel",
+			input:     domain.ErrDescriptionTooLong,
+			wantField: "description",
+			wantMsg:   fmt.Sprintf("description must be at most %d characters", domain.DescriptionMax),
+		},
+		{
+			name:      "unexpected error wraps as internal",
+			input:     errors.New("surprise"),
+			wantChain: "usecase: translate description error",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := translateDescriptionErr(tc.input)
+
+			switch {
+			case tc.input == nil:
+				require.NoError(t, err)
+			case tc.wantChain != "":
+				assertInternalChain(t, err, tc.wantChain)
+			default:
 				require.Error(t, err)
 				assertValidationError(t, err, tc.wantField, tc.wantMsg)
 			}

--- a/docs/backend/ddd-patterns/trinary-value-object.md
+++ b/docs/backend/ddd-patterns/trinary-value-object.md
@@ -18,35 +18,62 @@ independently — the flag can say "set" while the pointer says `nil`, or vice v
 
 ## What
 
-`Bio` encodes the trinary as a struct with a private `*string`:
+The trinary is single-sourced in one field-agnostic value object, `trinaryText`,
+that carries a private `*string`. Its parser mirrors `ParseCardText`: the caller
+supplies the grapheme cap and the too-long sentinel, so the VO stays field-agnostic
+(see [`caller-supplied-sentinels-in-parser.md`](caller-supplied-sentinels-in-parser.md)).
+
+```go
+// domain/trinary_text.go
+
+type trinaryText struct {
+    value *string
+}
+
+func parseTrinaryText(s *string, max int, tooLongErr error) (trinaryText, error) {
+    if tooLongErr == nil {
+        panic("domain: parseTrinaryText requires a non-nil tooLongErr sentinel")
+    }
+    if s == nil {
+        return trinaryText{}, nil        // no change
+    }
+    trimmed := strings.TrimSpace(*s)
+    if uniseg.GraphemeClusterCount(trimmed) > max {
+        return trinaryText{}, tooLongErr
+    }
+    return trinaryText{value: &trimmed}, nil
+}
+
+func (t trinaryText) IsSet() bool { return t.value != nil }
+
+func (t trinaryText) Ptr() *string {
+    if t.value == nil {
+        return nil
+    }
+    s := *t.value
+    return &s    // copy to prevent aliasing mutation
+}
+```
+
+`Bio` and `Description` are distinct exported types that embed `trinaryText`, so
+`IsSet()`/`Ptr()` and the trim + grapheme-cap + trinary rule are shared. Each field
+keeps its own cap constant and too-long sentinel; the `Parse*` and `*FromPtr` entry
+points stay stable so consumers do not churn:
 
 ```go
 // domain/bio.go
 
-type Bio struct {
-    value *string
-}
+type Bio struct{ trinaryText }
 
 func ParseBio(s *string) (Bio, error) {
-    if s == nil {
-        return Bio{}, nil        // no change
-    }
-    trimmed := strings.TrimSpace(*s)
-    if uniseg.GraphemeClusterCount(trimmed) > BioMax {
-        return Bio{}, ErrBioTooLong
-    }
-    return Bio{value: &trimmed}, nil
+    t, err := parseTrinaryText(s, BioMax, ErrBioTooLong)
+    return Bio{t}, err
 }
 
-func (b Bio) IsSet() bool   { return b.value != nil }
+func BioFromPtr(p *string) Bio { return Bio{trinaryTextFromPtr(p)} }
 
-func (b Bio) Ptr() *string {
-    if b.value == nil {
-        return nil
-    }
-    s := *b.value
-    return &s    // copy to prevent aliasing mutation
-}
+// domain/description.go — Description embeds the same trinaryText, passing
+// DescriptionMax / ErrDescriptionTooLong to the same parseTrinaryText body.
 ```
 
 - `ParseBio(nil)` → `Bio{}` (no change): `IsSet()` returns `false`.
@@ -57,7 +84,7 @@ func (b Bio) Ptr() *string {
   to `"hello"`.
 
 `Ptr()` returns a copy of the pointer's target so external mutation of the
-returned pointer does not alter the `Bio`'s internal state.
+returned pointer does not alter the value object's internal state.
 
 ## Usecase guard
 


### PR DESCRIPTION
## Summary

`domain.Bio` (`domain/bio.go`) and `domain.Description` (`domain/description.go`) were ~70-line structural clones of the same value object — trim + 500-grapheme cap + a trinary (`nil` = no change / `&""` = explicit clear / `&"x"` = set) — with zero behavioral nuance between them. Their `translate*Err` helpers in `usecase/validators.go` were twin copies too. Two independent copies of one rule drift silently: a fix or cap change to one is easy to forget in the other.

This extracts one field-agnostic trinary text VO, `domain.trinaryText`, whose `parseTrinaryText` takes the caller-supplied cap and too-long sentinel — mirroring `ParseCardText`'s caller-supplied sentinels (the same pattern that lets one `CardText` VO serve both `Card.Front` and `Card.Back`). `Bio` and `Description` become distinct exported types that embed `trinaryText`, so `IsSet()` / `Ptr()` and the trim + grapheme-cap + trinary rule are single-sourced while the two types stay non-interchangeable across their aggregates (`User.Bio` vs `MasterCardgroup.Description`). The invariant is that the trinary rule now lives in exactly one place and each field only supplies its own cap constant and sentinel.

The public entry points — `ParseBio`, `ParseDescription`, `BioFromPtr`, `DescriptionFromPtr`, the `Bio` / `Description` field types, and the `BioMax` / `DescriptionMax` / `ErrBioTooLong` / `ErrDescriptionTooLong` constants and sentinels — keep identical signatures, so no consumer churns. The twin translate helpers are collapsed into one shared `translateTrinaryTextErr(err, field, max, tooLong, wrap)` body; `translateBioErr` and `translateDescriptionErr` are retained as named thin wrappers with unchanged `func(error) error` signatures (live callers in `usecase/user.go`, `usecase/admin_user.go`, `usecase/master_catalog.go`; issue #892 also relies on `translateBioErr` being callable). The shared helper takes the wrap prefix as a parameter so each field's `error_chain` still names its own module, per the shared-helper wrap convention.

This is a behavior-preserving refactor — no wire-format, message, or validation change.

## Changes

- `backend/internal/domain/trinary_text.go` (new) — the shared field-agnostic VO: `trinaryText` struct with a private `*string`, `parseTrinaryText(s, max, tooLongErr)` (panics on a nil sentinel, mirroring `ParseCardText`), `trinaryTextFromPtr`, and the `Ptr()` (defensive-copy) / `IsSet()` accessors.
- `backend/internal/domain/bio.go` — `Bio` re-expressed as `struct{ trinaryText }`; `ParseBio` / `BioFromPtr` now delegate to the shared parser with `BioMax` / `ErrBioTooLong`. `BioMax` and `ErrBioTooLong` unchanged.
- `backend/internal/domain/description.go` — `Description` re-expressed as `struct{ trinaryText }`; `ParseDescription` / `DescriptionFromPtr` delegate to the shared parser with `DescriptionMax` / `ErrDescriptionTooLong`. `DescriptionMax` and `ErrDescriptionTooLong` unchanged.
- `backend/internal/usecase/validators.go` — extracted `translateTrinaryTextErr` as the shared body; `translateBioErr` and `translateDescriptionErr` retained as one-line named wrappers with unchanged signatures and identical output (field, message, and wrap chain).
- `backend/internal/usecase/validators_test.go` — added `TestTranslateBioErr` and `TestTranslateDescriptionErr` (mirroring the existing `TestTranslateDisplayNameErr` template) pinning nil pass-through, the too-long → field-scoped `ValidationError` with exact message, and the unexpected-error → field-specific internal chain. There was no prior coverage for these two helpers.
- `docs/backend/ddd-patterns/trinary-value-object.md` — refreshed the worked-example code block, which showed the now-superseded `type Bio struct { value *string }` with methods on `Bio`, to show the shared `trinaryText` VO and `Bio` / `Description` embedding it.

## Test plan

- `go tool gqlgen generate`, `go vet ./...`, `go build ./...`, `go tool go-arch-lint check --project-path .` — pass
- `go test ./internal/domain/ -run 'TestParseBio|TestBioFromPtr|TestParseDescription|TestDescriptionFromPtr|TestUserShape|TestNewMasterCardgroup|TestMasterCardgroup' -count=1` — 49 pass (existing `bio_test.go` / `description_test.go` behavior preserved: 500-grapheme cap, empty-clears, absent-keeps, ZWJ grapheme counting, defensive-copy `Ptr()`).
- `go test ./internal/usecase/ -run 'TestTranslateBioErr|TestTranslateDescriptionErr|TestTranslateDisplayNameErr|TestValidateRelayArgs' -count=1` — 27 pass, including the two new translate-helper tests.
- Docker-backed integration packages (`internal/repository`, `internal/database`, `cmd/server`) require testcontainers/Docker, unavailable locally, so they are skipped here (they compile cleanly under `go vet`) and run in CI.

Closes #900
