### PR TITLE
refactor(backend): use a published-scoped master read on the copy/merge write paths (TOCTOU + double read)

### DIFF
--- a/backend/internal/usecase/master_catalog.go
+++ b/backend/internal/usecase/master_catalog.go
@@ -668,8 +668,12 @@ func (u *masterCatalogUsecase) ListAdminConnection(
 // fresh cardgroup owned by the authenticated caller. The master is gated through
 // FindPublishedByID, which returns ErrNotFound for both unknown ids and draft decks,
 // so draft existence is never disclosed — both collapse to ImportMasterOutcome{NotFound:true}.
-// Unauthenticated callers receive ucerr.ErrUnauthenticated. The copy is a one-time
-// snapshot delegated to CopyMasterToUserUsecase; FSRS/swipe state starts empty.
+// The delegated copy re-reads the master through the same published-scoped method
+// inside its transaction, so a master unpublished between this gate and the write
+// also collapses to NotFound (the ErrNotFound the copy surfaces is mapped below)
+// rather than silently importing a now-draft deck. Unauthenticated callers receive
+// ucerr.ErrUnauthenticated. The copy is a one-time snapshot delegated to
+// CopyMasterToUserUsecase; FSRS/swipe state starts empty.
 func (u *masterCatalogUsecase) ImportMaster(ctx context.Context, masterID string) (ImportMasterOutcome, error) {
 	caller := auth.UserFrom(ctx)
 	if err := requireCallerSub(caller); err != nil {
@@ -691,6 +695,12 @@ func (u *masterCatalogUsecase) ImportMaster(ctx context.Context, masterID string
 		if isContextDone(err) {
 			return ImportMasterOutcome{}, err
 		}
+		if errors.Is(err, repository.ErrNotFound) {
+			// The master was unpublished between the FindPublishedByID gate and the
+			// copy's own published-scoped re-read (TOCTOU). Collapse into the same
+			// non-disclosure not-found outcome as a pre-gate unknown/draft master.
+			return ImportMasterOutcome{NotFound: true}, nil
+		}
 		return ImportMasterOutcome{}, eris.Wrap(err, "usecase: master catalog: import: copy master to user")
 	}
 	return ImportMasterOutcome{Cardgroup: cg}, nil
@@ -699,10 +709,14 @@ func (u *masterCatalogUsecase) ImportMaster(ctx context.Context, masterID string
 // MergeMaster merges the published master cardgroup identified by masterID into
 // the caller-owned cardgroup cardgroupID. The master is gated through
 // FindPublishedByID, collapsing unknown and draft into MergeMasterOutcome{NotFound:true}
-// so draft existence is never disclosed. Destination ownership is enforced by the
-// delegated usecase (BAD_USER_INPUT for unknown, UNAUTHENTICATED for foreign),
-// surfaced as an error rather than via the outcome. Unauthenticated callers
-// receive ucerr.ErrUnauthenticated. The merge is a one-time snapshot.
+// so draft existence is never disclosed. The delegated merge re-reads the master
+// through the same published-scoped method inside its transaction, so a master
+// unpublished between this gate and the write also collapses to NotFound (the
+// ErrNotFound the merge surfaces is mapped below) rather than snapshotting a
+// now-draft deck. Destination ownership is enforced by the delegated usecase
+// (BAD_USER_INPUT for unknown, UNAUTHENTICATED for foreign), surfaced as an error
+// rather than via the outcome. Unauthenticated callers receive
+// ucerr.ErrUnauthenticated. The merge is a one-time snapshot.
 func (u *masterCatalogUsecase) MergeMaster(ctx context.Context, masterID, cardgroupID string) (MergeMasterOutcome, error) {
 	caller := auth.UserFrom(ctx)
 	if err := requireCallerSub(caller); err != nil {
@@ -723,6 +737,14 @@ func (u *masterCatalogUsecase) MergeMaster(ctx context.Context, masterID, cardgr
 	if err != nil {
 		if isContextDone(err) {
 			return MergeMasterOutcome{}, err
+		}
+		if errors.Is(err, repository.ErrNotFound) {
+			// The master was unpublished between the FindPublishedByID gate and the
+			// merge tx's own published-scoped re-read (TOCTOU). Collapse into the same
+			// non-disclosure not-found outcome as a pre-gate unknown/draft master. The
+			// destination ownership gate never yields ErrNotFound (it maps a missing
+			// cardgroup to a ucerr.ValidationError), so this branch is master-scoped.
+			return MergeMasterOutcome{NotFound: true}, nil
 		}
 		// Wrap unconditionally, exactly like ImportMaster wraps CopyMasterToUser.
 		// A ucerr.ValidationError / ucerr.ErrUnauthenticated from the delegated

--- a/backend/internal/usecase/master_catalog_test.go
+++ b/backend/internal/usecase/master_catalog_test.go
@@ -733,6 +733,33 @@ func TestImportMaster_UnknownOrDraft_ReturnsNotFoundOutcome(t *testing.T) {
 	}
 }
 
+func TestImportMaster_MasterUnpublishedMidFlight_ReturnsNotFoundOutcome(t *testing.T) {
+	// TOCTOU: the master is published when the FindPublishedByID gate runs, but the
+	// delegated copy's own in-tx published-scoped re-read surfaces repository.ErrNotFound
+	// (an unpublish landed in between). ImportMaster must collapse that into the same
+	// NotFound outcome as a pre-gate unknown/draft — not a silent import, not an error.
+	repo := &mockMasterCatalogRepository{
+		findPublishedByIDFn: func(id string) (*domain.MasterCardgroup, error) {
+			return &domain.MasterCardgroup{ID: id, Name: domain.CardgroupName("Deck"), Status: domain.MasterStatusPublished}, nil
+		},
+	}
+	copyUC := &mockCopyMasterToUserUC{fn: func(context.Context, string, string) (*domain.Cardgroup, error) {
+		return nil, repository.ErrNotFound
+	}}
+	uc := NewMasterCatalogUsecase(repo, copyUC, newTestAdminGate(true), newTestLogger())
+
+	out, err := uc.ImportMaster(authedCtx("u1"), "m1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !out.NotFound {
+		t.Fatal("expected NotFound outcome for a master unpublished mid-flight")
+	}
+	if out.Cardgroup != nil {
+		t.Fatal("expected nil cardgroup on NotFound")
+	}
+}
+
 func TestImportMaster_Published_CopiesAndReturnsCardgroup(t *testing.T) {
 	repo := &mockMasterCatalogRepository{
 		findByIDFn: func(id string) (*domain.MasterCardgroup, error) {
@@ -1164,6 +1191,33 @@ func TestMasterCatalogUsecase_MergeMaster_DelegateError_Wrapped(t *testing.T) {
 
 	_, err := uc.MergeMaster(authedCtx("u1"), "master-id", "cg-id")
 	assertInternalChain(t, err, "usecase: master catalog: merge: merge master into cardgroup")
+}
+
+func TestMasterCatalogUsecase_MergeMaster_MasterUnpublishedMidFlight_ReturnsNotFoundOutcome(t *testing.T) {
+	// TOCTOU: the master is published at the FindPublishedByID gate, but the merge
+	// delegate's in-tx published-scoped re-read surfaces repository.ErrNotFound. MergeMaster
+	// must collapse that into MergeMasterOutcome{NotFound:true}, matching a pre-gate
+	// unknown/draft — not a silent merge, not an error. A ucerr.ValidationError from the
+	// destination ownership gate is unaffected (it is not repository.ErrNotFound).
+	t.Parallel()
+	repo := &mockMasterCatalogRepository{
+		findPublishedByIDFn: func(id string) (*domain.MasterCardgroup, error) {
+			return &domain.MasterCardgroup{ID: id, Name: domain.CardgroupName("Master"), Status: domain.MasterStatusPublished}, nil
+		},
+	}
+	deck := &mockCopyMasterToUserUC{mergeErr: repository.ErrNotFound}
+	uc := NewMasterCatalogUsecase(repo, deck, newTestAdminGate(true), newTestLogger())
+
+	out, err := uc.MergeMaster(authedCtx("u1"), "master-id", "cg-id")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !out.NotFound {
+		t.Fatal("expected NotFound outcome for a master unpublished mid-flight")
+	}
+	if out.Cardgroup != nil {
+		t.Fatal("expected nil cardgroup on NotFound")
+	}
 }
 
 func TestMasterCatalogUsecase_MergeMaster_VerifyPublished_ContextCancelled_PassesThrough(t *testing.T) {

--- a/backend/internal/usecase/master_deck.go
+++ b/backend/internal/usecase/master_deck.go
@@ -13,10 +13,16 @@ import (
 )
 
 // masterDeckCardgroupRepo is the subset of repository.MasterCardgroupRepository
-// the master deck usecase consumes: locate a master template and enumerate the
-// published default-starter set.
+// the master deck usecase consumes: locate a PUBLISHED master template and
+// enumerate the published default-starter set. The lookup is deliberately
+// published-scoped (FindPublishedByID, not the any-status FindByID): the copy and
+// merge write paths re-read the master through the same visibility gate that
+// MasterCatalogUsecase applies before the transaction, so an unpublish that lands
+// between that gate and the write cannot snapshot a now-draft deck (closing the
+// TOCTOU). Unknown and unpublished collapse to repository.ErrNotFound, which the
+// catalog layer maps to the same non-disclosure not-found outcome.
 type masterDeckCardgroupRepo interface {
-	FindByID(ctx context.Context, id string) (*domain.MasterCardgroup, error)
+	FindPublishedByID(ctx context.Context, id string) (*domain.MasterCardgroup, error)
 	ListPublishedDefaultStarters(ctx context.Context) ([]*domain.MasterCardgroup, error)
 }
 
@@ -302,15 +308,22 @@ func (u *masterDeckUsecase) copyMasterCardsIntoTx(
 // prefix so the logged error_chain attributes the failure to the calling
 // operation rather than this helper.
 //
+// The master is re-read through the published-scoped FindPublishedByID (not the
+// any-status FindByID), so a master unpublished between MasterCatalogUsecase's
+// FindPublishedByID gate and this copy yields repository.ErrNotFound and no rows
+// are written — closing the TOCTOU rather than silently snapshotting a draft.
+// SeedForNewUser is unaffected: it sources ids from ListPublishedDefaultStarters,
+// which already returns only published decks.
+//
 // The new cardgroup row is inserted via the cardgroup repository's CreateTx with
 // the supplied tx handle so the insert participates in the caller's transaction.
 // Cards are deep-copied with fresh ids and the new cardgroup id; FSRS/swipe
 // state is left empty by construction (no rows are written to the per-user FSRS
 // table).
 func (u *masterDeckUsecase) copyMasterToUserTx(ctx context.Context, tx *gorm.DB, masterID, ownerID string) (*domain.Cardgroup, error) {
-	master, err := u.masterCG.FindByID(ctx, masterID)
+	master, err := u.masterCG.FindPublishedByID(ctx, masterID)
 	if err != nil {
-		return nil, eris.Wrap(err, "find master cardgroup")
+		return nil, eris.Wrap(err, "find published master cardgroup")
 	}
 
 	cards, err := u.masterCard.ListByMasterCardgroup(ctx, masterID)
@@ -338,9 +351,14 @@ func (u *masterDeckUsecase) copyMasterToUserTx(ctx context.Context, tx *gorm.DB,
 // which ownerID must own, inside its own transaction. The destination ownership
 // gate uses authorizeCardgroupOrBadInput (untrusted-input boundary): an unknown
 // cardgroup is a recoverable validation error; a foreign cardgroup is
-// UNAUTHENTICATED. Cards conflicting on (cardgroup_id, front) are overwritten
-// (back/position/updated_at); ids are preserved so FSRS state survives. Returns the
-// destination cardgroup plus the add/update tally.
+// UNAUTHENTICATED. Inside the transaction the master is re-read through the
+// published-scoped FindPublishedByID before its cards are listed, so a master
+// unpublished between MasterCatalogUsecase's FindPublishedByID gate and this write
+// yields repository.ErrNotFound (which MergeMaster maps to the not-found outcome)
+// rather than snapshotting a now-draft deck — closing the TOCTOU. Cards conflicting
+// on (cardgroup_id, front) are overwritten (back/position/updated_at); ids are
+// preserved so FSRS state survives. Returns the destination cardgroup plus the
+// add/update tally.
 func (u *masterDeckUsecase) MergeMasterIntoCardgroup(
 	ctx context.Context, masterID string, destCardgroupID domain.CardgroupID, ownerID domain.UserID,
 ) (*MergeMasterResult, error) {
@@ -356,6 +374,14 @@ func (u *masterDeckUsecase) MergeMasterIntoCardgroup(
 
 	var res repository.UpsertManyTxResult
 	if err := u.tx(ctx, func(tx *gorm.DB) error {
+		// Re-read the master through the published-scoped method INSIDE the tx so an
+		// unpublish landing between MasterCatalogUsecase.MergeMaster's FindPublishedByID
+		// gate and this write cannot snapshot a now-draft deck (TOCTOU). ErrNotFound
+		// (unknown or unpublished) travels up the eris chain; MergeMaster collapses it
+		// into the same non-disclosure not-found outcome as a pre-gate unknown/draft.
+		if _, err := u.masterCG.FindPublishedByID(ctx, masterID); err != nil {
+			return eris.Wrap(err, "usecase: master deck: merge master into cardgroup: verify published master")
+		}
 		cards, err := u.masterCard.ListByMasterCardgroup(ctx, masterID)
 		if err != nil {
 			return eris.Wrap(err, "usecase: master deck: merge master into cardgroup: list master cards")

--- a/backend/internal/usecase/master_deck_test.go
+++ b/backend/internal/usecase/master_deck_test.go
@@ -27,7 +27,11 @@ type fakeMasterCGRepo struct {
 	startersCall int
 }
 
-func (f *fakeMasterCGRepo) FindByID(_ context.Context, id string) (*domain.MasterCardgroup, error) {
+// FindPublishedByID models the published-scoped master read. byID represents the
+// currently-published set: an id absent from the map returns repository.ErrNotFound,
+// which is how a test simulates a master that was unpublished after the caller's
+// gate passed (the TOCTOU regression case).
+func (f *fakeMasterCGRepo) FindPublishedByID(_ context.Context, id string) (*domain.MasterCardgroup, error) {
 	f.findCalls++
 	if f.findErr != nil {
 		return nil, f.findErr
@@ -713,7 +717,7 @@ func TestMasterDeckUsecase_MergeMasterIntoCardgroup_AddsAndUpdates(t *testing.T)
 	destCG := mustCardgroup(t, destID, ownerID, "My Deck")
 
 	uc := NewMasterDeckUsecaseWithTx(
-		&fakeMasterCGRepo{}, // not consulted on merge path
+		&fakeMasterCGRepo{byID: map[string]*domain.MasterCardgroup{masterID: masterCG(masterID, "Master")}}, // published-scoped re-read inside the tx
 		&fakeMasterCardRepo{byMaster: map[string][]*domain.MasterCard{masterID: masterCards}},
 		&fakeUserCardRepo{result: repository.UpsertManyTxResult{Inserted: 1, Updated: 1}},
 		&fakeUserCG{byID: map[string]*domain.Cardgroup{destID: destCG}},
@@ -759,6 +763,42 @@ func TestMasterDeckUsecase_MergeMasterIntoCardgroup_DestNotFound_Validation(t *t
 	assert.Equal(t, "cardgroupId", ve.Field)
 }
 
+// TestMasterDeckUsecase_MergeMasterIntoCardgroup_MasterUnpublishedMidFlight_NoImport
+// pins the TOCTOU close on the merge write path. The destination ownership gate
+// passes, but the master is no longer in the published set when the tx re-reads it
+// (modelling an unpublish that landed after MasterCatalogUsecase's FindPublishedByID
+// gate). The in-tx published-scoped re-read yields repository.ErrNotFound, so no
+// master cards are listed or upserted — a now-draft deck is never snapshotted.
+func TestMasterDeckUsecase_MergeMasterIntoCardgroup_MasterUnpublishedMidFlight_NoImport(t *testing.T) {
+	t.Parallel()
+	const ownerID = "11111111-1111-7111-8111-111111111111"
+	const destID = "22222222-2222-7222-8222-222222222222"
+	const masterID = "master-id"
+
+	// The master has cards, but is ABSENT from the published set (byID) — the state
+	// after an unpublish that landed once the caller's gate had already passed.
+	card := &fakeMasterCardRepo{byMaster: map[string][]*domain.MasterCard{
+		masterID: {masterCard("mc-1", masterID, "alpha", "first", 0)},
+	}}
+	user := &fakeUserCardRepo{}
+	destCG := mustCardgroup(t, destID, ownerID, "My Deck")
+
+	uc := NewMasterDeckUsecaseWithTx(
+		&fakeMasterCGRepo{byID: map[string]*domain.MasterCardgroup{}}, // empty published set → FindPublishedByID → ErrNotFound
+		card,
+		user,
+		&fakeUserCG{byID: map[string]*domain.Cardgroup{destID: destCG}},
+		stubTxRunner,
+		newTestLogger(),
+	)
+
+	_, err := uc.MergeMasterIntoCardgroup(context.Background(), masterID, domain.CardgroupID(destID), domain.UserID(ownerID))
+	require.Error(t, err)
+	require.ErrorIs(t, err, repository.ErrNotFound, "the published-scoped re-read must surface ErrNotFound for an unpublished master")
+	assert.Equal(t, 0, user.upsertCall, "no cards are upserted when the master is no longer published")
+	assert.Empty(t, user.captured, "no draft content is snapshotted into the destination")
+}
+
 func TestMasterDeckUsecase_MergeMasterIntoCardgroup_EmptyDeck(t *testing.T) {
 	t.Parallel()
 	const ownerID = "11111111-1111-7111-8111-111111111111"
@@ -768,8 +808,8 @@ func TestMasterDeckUsecase_MergeMasterIntoCardgroup_EmptyDeck(t *testing.T) {
 	destCG := mustCardgroup(t, destID, ownerID, "My Deck")
 
 	uc := NewMasterDeckUsecaseWithTx(
-		&fakeMasterCGRepo{}, // not consulted on merge path
-		&fakeMasterCardRepo{byMaster: map[string][]*domain.MasterCard{masterID: {}}}, // zero cards
+		&fakeMasterCGRepo{byID: map[string]*domain.MasterCardgroup{masterID: masterCG(masterID, "Master")}}, // published-scoped re-read inside the tx
+		&fakeMasterCardRepo{byMaster: map[string][]*domain.MasterCard{masterID: {}}},                        // zero cards
 		&fakeUserCardRepo{}, // default: Inserted=len(cards)=0, Updated=0
 		&fakeUserCG{byID: map[string]*domain.Cardgroup{destID: destCG}},
 		stubTxRunner,
@@ -793,7 +833,7 @@ func TestMasterDeckUsecase_MergeMasterIntoCardgroup_ListCardsError_PropagatesCha
 	destCG := mustCardgroup(t, destID, ownerID, "My Deck")
 
 	uc := NewMasterDeckUsecaseWithTx(
-		&fakeMasterCGRepo{},
+		&fakeMasterCGRepo{byID: map[string]*domain.MasterCardgroup{masterID: masterCG(masterID, "Master")}},
 		&fakeMasterCardRepo{listErr: errors.New("list cards failed")},
 		&fakeUserCardRepo{},
 		&fakeUserCG{byID: map[string]*domain.Cardgroup{destID: destCG}},
@@ -818,7 +858,7 @@ func TestMasterDeckUsecase_MergeMasterIntoCardgroup_UpsertCardsError_PropagatesC
 	destCG := mustCardgroup(t, destID, ownerID, "My Deck")
 
 	uc := NewMasterDeckUsecaseWithTx(
-		&fakeMasterCGRepo{},
+		&fakeMasterCGRepo{byID: map[string]*domain.MasterCardgroup{masterID: masterCG(masterID, "Master")}},
 		&fakeMasterCardRepo{byMaster: map[string][]*domain.MasterCard{masterID: masterCards}},
 		&fakeUserCardRepo{upsertErr: errors.New("upsert failed")},
 		&fakeUserCG{byID: map[string]*domain.Cardgroup{destID: destCG}},
@@ -840,7 +880,7 @@ func TestMasterDeckUsecase_MergeMasterIntoCardgroup_ContextCancelled_PassesThrou
 	destCG := mustCardgroup(t, destID, ownerID, "My Deck")
 
 	uc := NewMasterDeckUsecaseWithTx(
-		&fakeMasterCGRepo{},
+		&fakeMasterCGRepo{byID: map[string]*domain.MasterCardgroup{masterID: masterCG(masterID, "Master")}},
 		&fakeMasterCardRepo{listErr: context.Canceled},
 		&fakeUserCardRepo{},
 		&fakeUserCG{byID: map[string]*domain.Cardgroup{destID: destCG}},
@@ -866,7 +906,7 @@ func TestMasterDeckUsecase_MergeMasterIntoCardgroup_PostTxFindByID_ContextCancel
 	destCG := mustCardgroup(t, destID, ownerID, "My Deck")
 
 	uc := NewMasterDeckUsecaseWithTx(
-		&fakeMasterCGRepo{},
+		&fakeMasterCGRepo{byID: map[string]*domain.MasterCardgroup{masterID: masterCG(masterID, "Master")}},
 		&fakeMasterCardRepo{byMaster: map[string][]*domain.MasterCard{masterID: masterCards}},
 		&fakeUserCardRepo{},
 		&fakeUserCG{
@@ -900,7 +940,7 @@ func TestMasterDeckUsecase_MergeMasterIntoCardgroup_PostTxFindByIDError_Propagat
 	destCG := mustCardgroup(t, destID, ownerID, "My Deck")
 
 	uc := NewMasterDeckUsecaseWithTx(
-		&fakeMasterCGRepo{},
+		&fakeMasterCGRepo{byID: map[string]*domain.MasterCardgroup{masterID: masterCG(masterID, "Master")}},
 		&fakeMasterCardRepo{byMaster: map[string][]*domain.MasterCard{masterID: masterCards}},
 		&fakeUserCardRepo{},
 		&fakeUserCG{

--- a/docs/backend/ddd-patterns/notfound-collapse-non-disclosure.md
+++ b/docs/backend/ddd-patterns/notfound-collapse-non-disclosure.md
@@ -37,6 +37,20 @@ read, not reconstructed in the usecase from a richer result:
 The docstrings at each layer name the invariant ("draft existence is never leaked")
 so a future maintainer does not "helpfully" split the two cases back apart.
 
+### Write paths re-read through the same gate (TOCTOU)
+
+The gate-then-write shape has a time-of-check/time-of-use window: the caller passes
+`FindPublishedByID` at the mutation boundary, then a copy/merge transaction snapshots
+the deck. An unpublish landing in that window would import a now-draft deck if the
+transaction re-read the master through the any-status `FindByID`. The write paths
+therefore re-read through the **same** published-scoped `FindPublishedByID` inside the
+transaction (`copyMasterToUserTx`, and a fetch added before `ListByMasterCardgroup` in
+`MergeMasterIntoCardgroup`); the resulting `ErrNotFound` is mapped by `ImportMaster` /
+`MergeMaster` to the same `NotFound` outcome as a pre-gate unknown/draft. `SeedForNewUser`
+is unaffected — it already sources ids from `ListPublishedDefaultStarters`, which returns
+only published decks. This closes the TOCTOU without reversing the collapse: an unpublished
+master is indistinguishable from an unknown one on every path.
+
 ## The boundary — this is for unauthorized observers only
 
 The collapse applies when the caller has no right to know the resource exists. For
@@ -55,6 +69,12 @@ Pin the collapse where it happens, not only end-to-end:
 - Usecase: a test that both an unknown id and a draft (both surfaced as `ErrNotFound`
   by the repo mock) yield the not-found outcome with the copy/side-effect **not run**
   (`TestImportMaster_UnknownOrDraft_ReturnsNotFoundOutcome`).
+- Usecase (write-path TOCTOU): a test that a master present at the gate but unpublished
+  by the time the write transaction re-reads it yields the not-found outcome with no
+  cards written — proving the in-transaction re-read closes the window
+  (`TestMasterDeckUsecase_MergeMasterIntoCardgroup_MasterUnpublishedMidFlight_NoImport`,
+  `TestImportMaster_MasterUnpublishedMidFlight_ReturnsNotFoundOutcome`,
+  `TestMasterCatalogUsecase_MergeMaster_MasterUnpublishedMidFlight_ReturnsNotFoundOutcome`).
 - Resolver: a test that the not-found outcome maps to the typed error variant with a
   generic message (`TestMutationResolver_ImportMasterCardgroup_NotFound_ReturnsTypedError`).
 


### PR DESCRIPTION
## Summary

`ImportMaster` and `MergeMaster` check the published-visibility gate with `FindPublishedByID`, but the copy/merge transaction then re-read the master with an **any-status** read: `copyMasterToUserTx` called `masterCG.FindByID`, and `MergeMasterIntoCardgroup` never re-fetched the master at all — it listed the master's cards straight from `ListByMasterCardgroup`. An `unpublishMasterCardgroup` landing between the gate and the write tx would silently snapshot the now-draft deck into the caller's cardgroup — a TOCTOU that leaks just-unpublished content.

This routes both write paths through the **same** published-scoped `FindPublishedByID` the gate uses, re-read **inside** the transaction. The invariant is now uniform across the whole request: an unpublished-mid-flight master is indistinguishable from an unknown one on every path. The in-tx re-read surfaces `repository.ErrNotFound`, and `ImportMaster` / `MergeMaster` collapse that into the existing `NotFound` outcome — the same non-disclosure result as a pre-gate unknown/draft, not a silent import and not an internal error. `SeedForNewUser` is unaffected: it already sources ids from `ListPublishedDefaultStarters`, which returns only published decks. This aligns with the existing non-disclosure collapse (`docs/backend/ddd-patterns/notfound-collapse-non-disclosure.md`) rather than reversing it.

## Changes

- `backend/internal/usecase/master_deck.go`: narrowed the consumer interface `masterDeckCardgroupRepo` from `FindByID` to `FindPublishedByID`. `copyMasterToUserTx` now re-reads the master via `masterCG.FindPublishedByID` (wrap `find published master cardgroup`). `MergeMasterIntoCardgroup` adds a published-scoped `masterCG.FindPublishedByID` inside the tx **before** `ListByMasterCardgroup` (wrap `usecase: master deck: merge master into cardgroup: verify published master`), so an unpublished master aborts the write with `ErrNotFound` and no cards are listed or upserted. Docstrings updated to name the TOCTOU close and the `SeedForNewUser` exemption.
- `backend/internal/usecase/master_catalog.go`: `ImportMaster` and `MergeMaster` now map an `errors.Is(err, repository.ErrNotFound)` returned by the delegated copy/merge into `ImportMasterOutcome{NotFound: true}` / `MergeMasterOutcome{NotFound: true}` (after the existing `isContextDone` pass-through, before the internal wrap). The merge branch is master-scoped because the destination ownership gate maps a missing cardgroup to a `ucerr.ValidationError`, never `ErrNotFound`. Docstrings updated.
- `backend/internal/usecase/master_deck_test.go`: renamed the `fakeMasterCGRepo.FindByID` fake to `FindPublishedByID` (its `byID` map now models the published set); updated the merge tests that reach the tx to seed the master into the published set; added `TestMasterDeckUsecase_MergeMasterIntoCardgroup_MasterUnpublishedMidFlight_NoImport` (ownership passes, master absent from the published set → `ErrNotFound`, zero upserts, nothing snapshotted).
- `backend/internal/usecase/master_catalog_test.go`: added `TestImportMaster_MasterUnpublishedMidFlight_ReturnsNotFoundOutcome` and `TestMasterCatalogUsecase_MergeMaster_MasterUnpublishedMidFlight_ReturnsNotFoundOutcome` (master published at the gate, delegate surfaces `ErrNotFound` mid-flight → `NotFound` outcome, no error, nil cardgroup).
- `docs/backend/ddd-patterns/notfound-collapse-non-disclosure.md`: added a "Write paths re-read through the same gate (TOCTOU)" subsection and listed the new regression tests under "Proving it".

## Test plan

- `go tool gqlgen generate`, `go vet ./...`, `go build ./...`, `go tool go-arch-lint check --project-path .` — pass
- `go test ./internal/usecase/ -run 'TestMasterDeckUsecase_MergeMasterIntoCardgroup|TestCopyMasterToUser|TestSeedForNewUser|TestPreviewMergeMasterIntoCardgroup|TestNewMasterDeckUsecase|TestImportMaster|TestMasterCatalogUsecase_MergeMaster|TestPreviewMergeMaster|TestFindPublishedMaster|TestMasterCatalog_EmptySubCaller' -count=1` — 70 pass (the three new mid-flight-unpublish tests verified by name; the full `./internal/usecase/` package and `./graph/resolver` master tests also pass)
- Docker-backed `internal/repository` integration suites (`master_deck_copy_integration_test`, `master_catalog_merge_parity_integration_test`) are CI-deferred because testcontainers/Docker is unavailable locally; both seed PUBLISHED master fixtures, so the published-scoped re-read leaves them green.

Closes #912
