### PR TITLE
refactor(backend): collapse the upsert-then-refetch preference mutations onto shared helpers

### DIFF
--- a/backend/internal/usecase/admin_user.go
+++ b/backend/internal/usecase/admin_user.go
@@ -408,7 +408,7 @@ func (u *adminUserUsecase) EditUser(ctx context.Context, id string, input AdminE
 		return AdminEditUserOutcome{Validation: info}, nil
 	}
 
-	user, err := u.refetchUser(ctx, id, "usecase: admin user edit: refetch")
+	user, err := refetchUser(ctx, u.users, id, "usecase: admin user edit: refetch")
 	if err != nil {
 		return AdminEditUserOutcome{}, err
 	}
@@ -517,27 +517,6 @@ func liftValidationErr(err error) (*InputValidationInfo, error) {
 		return NewInputValidationInfo(ve.Field, ve.Message), nil
 	}
 	return nil, err
-}
-
-// refetchUser loads the user after a mutation so callers see a fresh row
-// (e.g. with the trigger-refreshed updated_at). A missing row after a
-// successful mutation is unusual; surface it as INTERNAL with the supplied
-// context. The original ErrNotFound is wrapped (not replaced) so the chain
-// stays intact for errors.Is checks downstream and so the eris error_chain
-// log entry preserves the originating sentinel.
-func (u *adminUserUsecase) refetchUser(ctx context.Context, id, wrap string) (*domain.User, error) {
-	user, err := u.users.FindByID(ctx, id)
-	if err != nil {
-		switch {
-		case errors.Is(err, repository.ErrNotFound):
-			return nil, eris.Wrapf(err, "%s: user disappeared", wrap)
-		case isContextDone(err):
-			return nil, err
-		default:
-			return nil, eris.Wrap(err, wrap)
-		}
-	}
-	return user, nil
 }
 
 // resolveAdminPageSize enforces the (first XOR last) constraint and clamps

--- a/backend/internal/usecase/last_viewed_cardgroup.go
+++ b/backend/internal/usecase/last_viewed_cardgroup.go
@@ -101,16 +101,14 @@ func (u *lastViewedCardgroupUsecase) Set(ctx context.Context, cardgroupID string
 		}
 	}
 
-	user, err := u.users.FindByID(ctx, caller.Sub)
+	// ErrNotFound from the refetch means the user row vanished between the
+	// UPDATE and the read — only possible if the auth.users row was deleted
+	// concurrently. refetchUser treats it as INTERNAL (wrapping the sentinel as
+	// "... : user disappeared") like any other refetch failure, and passes
+	// context cancellation through unchanged.
+	user, err := refetchUser(ctx, u.users, caller.Sub, "usecase: last viewed cardgroup: refetch own user row")
 	if err != nil {
-		// ErrNotFound here means the user row vanished between the UPDATE and
-		// the refetch — only possible if the auth.users row was deleted
-		// concurrently. Treated as INTERNAL like any other refetch failure,
-		// with the wrapped sentinel preserved for log correlation.
-		if isContextDone(err) {
-			return SetLastViewedCardgroupOutcome{}, err
-		}
-		return SetLastViewedCardgroupOutcome{}, eris.Wrap(err, "usecase: last viewed cardgroup: refetch own user row")
+		return SetLastViewedCardgroupOutcome{}, err
 	}
 	return SetLastViewedCardgroupOutcome{User: user}, nil
 }

--- a/backend/internal/usecase/update_learn_display_mode.go
+++ b/backend/internal/usecase/update_learn_display_mode.go
@@ -4,9 +4,6 @@ import (
 	"context"
 	"log/slog"
 
-	"github.com/rotisserie/eris"
-
-	"backend/internal/auth"
 	"backend/internal/domain"
 	"backend/internal/repository"
 )
@@ -67,24 +64,7 @@ func NewUpdateLearnDisplayModeWithDeps(
 //   - Anonymous (no auth context) → UNAUTHENTICATED.
 //   - Authenticated caller → updated preference + refreshed user row.
 func (u *updateLearnDisplayModeUsecase) Set(ctx context.Context, mode domain.LearnDisplayMode) (*domain.User, error) {
-	caller := auth.UserFrom(ctx)
-	if err := requireCallerSub(caller); err != nil {
-		return nil, err
-	}
-
-	if err := u.prefs.UpsertLearnDisplayMode(ctx, caller.Sub, mode.String()); err != nil {
-		if isContextDone(err) {
-			return nil, err
-		}
-		return nil, eris.Wrap(err, "usecase: update learn display mode")
-	}
-
-	user, err := u.users.FindByID(ctx, caller.Sub)
-	if err != nil {
-		if isContextDone(err) {
-			return nil, err
-		}
-		return nil, eris.Wrap(err, "usecase: update learn display mode: refetch own user row")
-	}
-	return user, nil
+	return setUserPreference(ctx, func(ctx context.Context, sub string) error {
+		return u.prefs.UpsertLearnDisplayMode(ctx, sub, mode.String())
+	}, u.users, "usecase: update learn display mode")
 }

--- a/backend/internal/usecase/update_new_card_ratio.go
+++ b/backend/internal/usecase/update_new_card_ratio.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"log/slog"
 
-	"github.com/rotisserie/eris"
-
 	"backend/internal/auth"
 	"backend/internal/domain"
 	"backend/internal/repository"
@@ -78,8 +76,12 @@ func NewUpdateNewCardRatioWithDeps(
 // value-object validation and field attribution live in the application layer,
 // like every sibling mutation.
 func (u *updateNewCardRatioUsecase) Set(ctx context.Context, numerator, denominator int) (*domain.User, error) {
-	caller := auth.UserFrom(ctx)
-	if err := requireCallerSub(caller); err != nil {
+	// Auth runs before validation so an invalid ratio never short-circuits the
+	// unauthenticated path (an anonymous caller gets UNAUTHENTICATED, never a
+	// hint that the ratio was malformed). setUserPreference re-checks auth, but
+	// this guard is what fixes the auth->validate ordering the shared core,
+	// which authenticates internally, cannot express on its own.
+	if err := requireCallerSub(auth.UserFrom(ctx)); err != nil {
 		return nil, err
 	}
 
@@ -99,19 +101,7 @@ func (u *updateNewCardRatioUsecase) Set(ctx context.Context, numerator, denomina
 		return nil, ucerr.NewValidationError(field, "invalid new-card ratio")
 	}
 
-	if err := u.prefs.UpsertNewCardRatio(ctx, caller.Sub, ratio.Numerator(), ratio.Denominator()); err != nil {
-		if isContextDone(err) {
-			return nil, err
-		}
-		return nil, eris.Wrap(err, "usecase: update new card ratio")
-	}
-
-	user, err := u.users.FindByID(ctx, caller.Sub)
-	if err != nil {
-		if isContextDone(err) {
-			return nil, err
-		}
-		return nil, eris.Wrap(err, "usecase: update new card ratio: refetch own user row")
-	}
-	return user, nil
+	return setUserPreference(ctx, func(ctx context.Context, sub string) error {
+		return u.prefs.UpsertNewCardRatio(ctx, sub, ratio.Numerator(), ratio.Denominator())
+	}, u.users, "usecase: update new card ratio")
 }

--- a/backend/internal/usecase/user_preference.go
+++ b/backend/internal/usecase/user_preference.go
@@ -1,0 +1,83 @@
+package usecase
+
+import (
+	"context"
+	"errors"
+
+	"github.com/rotisserie/eris"
+
+	"backend/internal/auth"
+	"backend/internal/domain"
+	"backend/internal/repository"
+)
+
+// userFinder is the minimal read-back surface the post-mutation refetch needs:
+// a single FindByID keyed by user id. Every per-usecase consumer interface
+// (updateNewCardRatioUsersRepo, updateLearnDisplayModeUsersRepo,
+// lastViewedCardgroupUsersRepo, adminUserRepository) structurally satisfies it,
+// so refetchUser and setUserPreference accept those narrow interfaces without
+// widening any of them.
+type userFinder interface {
+	FindByID(ctx context.Context, id string) (*domain.User, error)
+}
+
+// refetchUser loads the user after a mutation so callers see a fresh row
+// (e.g. with the trigger-refreshed updated_at). A missing row after a
+// successful mutation is unusual; surface it as INTERNAL with the supplied
+// context. The original ErrNotFound is wrapped (not replaced) so the chain
+// stays intact for errors.Is checks downstream and so the eris error_chain
+// log entry preserves the originating sentinel.
+//
+// Shared by the admin edit path (AdminUser.EditUser) and the per-user
+// preference mutations (setUserPreference, last-viewed cardgroup). users is the
+// caller's own narrow FindByID interface, so no repository interface is widened.
+func refetchUser(ctx context.Context, users userFinder, id, wrap string) (*domain.User, error) {
+	user, err := users.FindByID(ctx, id)
+	if err != nil {
+		switch {
+		case errors.Is(err, repository.ErrNotFound):
+			return nil, eris.Wrapf(err, "%s: user disappeared", wrap)
+		case isContextDone(err):
+			return nil, err
+		default:
+			return nil, eris.Wrap(err, wrap)
+		}
+	}
+	return user, nil
+}
+
+// setUserPreference is the shared core for the simple upsert-then-refetch
+// preference mutations: authenticate the caller, run the caller-supplied upsert
+// closure, then refetch the user row so the resolver returns a fresh User.
+//
+// The upsert closure receives the authenticated caller sub, so each usecase
+// keeps its own narrow prefs interface (a closure over u.prefs) instead of
+// widening a shared one. wrapPrefix is the caller's error module prefix
+// (e.g. "usecase: update new card ratio"): an infra upsert failure is wrapped
+// with it, and the refetch reuses "<wrapPrefix>: refetch own user row".
+// context.Canceled / context.DeadlineExceeded pass through unwrapped.
+//
+// Preferences that carry per-mutation nuance the plain shape cannot express —
+// last-viewed's ErrCardgroupNotFound -> Validation branch and its distinct
+// outcome type — do NOT route through this core; they reuse requireCallerSub and
+// refetchUser directly.
+func setUserPreference(
+	ctx context.Context,
+	upsert func(ctx context.Context, sub string) error,
+	users userFinder,
+	wrapPrefix string,
+) (*domain.User, error) {
+	caller := auth.UserFrom(ctx)
+	if err := requireCallerSub(caller); err != nil {
+		return nil, err
+	}
+
+	if err := upsert(ctx, caller.Sub); err != nil {
+		if isContextDone(err) {
+			return nil, err
+		}
+		return nil, eris.Wrap(err, wrapPrefix)
+	}
+
+	return refetchUser(ctx, users, caller.Sub, wrapPrefix+": refetch own user row")
+}


### PR DESCRIPTION
## Summary

Three per-user preference mutations (`update_new_card_ratio.go`, `update_learn_display_mode.go`, `last_viewed_cardgroup.go`) shared a near-identical `requireCallerSub` → upsert → `FindByID` refetch → wrap shape, and the refetch tail was copied a fourth time as the `adminUserUsecase.refetchUser` method. Four copies of the same "read the user back after a mutation" logic diverged silently: only the admin copy wrapped a post-mutation `ErrNotFound` as `"…: user disappeared"`, so the three preference copies handled the "user row vanished concurrently" case with a plainer message.

This collapses the duplication onto two shared helpers in a new `user_preference.go`, single-sourcing the refetch tail and unifying the "user disappeared" handling across all four callers:

- `refetchUser(ctx, users, id, wrap)` — the package-level form of the old `adminUserUsecase.refetchUser` method. `users` is the caller's own narrow `FindByID` interface (a new package-private `userFinder`), so every consumer keeps its consumer-defined narrow repo interface and none is widened.
- `setUserPreference(ctx, upsert, users, wrapPrefix)` — the generic core capturing `auth.UserFrom` + `requireCallerSub` → upsert-closure → `refetchUser` → wrap. The upsert closure receives the authenticated caller sub, so each usecase closes over its own narrow `prefs` interface rather than sharing a widened one.

Invariants preserved: outcomes, wrap prefixes, and error classifications are unchanged. `context.Canceled` / `context.DeadlineExceeded` still pass through unwrapped at every step. The only behavioral delta is the intended unification: a post-mutation `ErrNotFound` in the three preference paths now carries the same `"…: refetch own user row: user disappeared"` suffix the admin path always used (still INTERNAL, sentinel preserved for `errors.Is`).

Two nuances kept the collapse honest rather than forced:

- `update_new_card_ratio.go` documents that auth must run **before** ratio validation so an invalid ratio never short-circuits the unauthenticated path. Because `setUserPreference` authenticates internally, the `Set` body keeps an explicit `requireCallerSub` gate ahead of `ParseNewCardRatio`, then delegates the upsert+refetch tail to the shared core; the core's inner re-check is redundant but harmless and keeps the ordering exact.
- `last_viewed_cardgroup.go` keeps its own `SetLastViewedCardgroupOutcome` return type and its `ErrCardgroupNotFound` → Validation branch, reusing **only** `refetchUser` for its tail — it is not forced through `setUserPreference`.

## Changes

- `backend/internal/usecase/user_preference.go` — new file. Declares the `userFinder` narrow interface, the package-level `refetchUser`, and the generic `setUserPreference` core.
- `backend/internal/usecase/admin_user.go` — removed the `adminUserUsecase.refetchUser` method (now the shared package-level function) and updated its `EditUser` call site to `refetchUser(ctx, u.users, id, "usecase: admin user edit: refetch")`. No other region touched.
- `backend/internal/usecase/update_new_card_ratio.go` — `Set` keeps the explicit auth-before-validate guard, then routes the upsert+refetch tail through `setUserPreference`; dropped the now-unused `eris` import.
- `backend/internal/usecase/update_learn_display_mode.go` — `Set` is now a thin adapter over `setUserPreference` (its upsert closure passes `mode.String()`); dropped the now-unused `auth` and `eris` imports.
- `backend/internal/usecase/last_viewed_cardgroup.go` — replaced the inline refetch tail with a `refetchUser(...)` call; the auth gate and `ErrCardgroupNotFound` → Validation branch are unchanged.

## Test plan

- `go tool gqlgen generate`, `go vet ./...`, `go build ./...`, `go tool go-arch-lint check --project-path .` — pass
- `go test ./internal/usecase/ -run 'TestUpdateNewCardRatio|TestUpdateLearnDisplayMode|TestLastViewedCardgroup|TestAdminUser_EditUser' -count=1` — 56 tests pass locally (repo fakes, no DB). These cover the unauthenticated, success, prefs-write-error, write-cancelled, refetch-error, refetch-cancelled, invalid-ratio field-attribution, last-viewed validation/outcome branches, and the admin `EditUser` refetch cancelled / infra-error / user-disappeared paths. Docker-backed integration packages (`repository` / `database` / `cmd/*`) require testcontainers/Docker, which is unavailable locally, so they are CI-deferred; `vet` + `build` + `arch-lint` already prove the whole tree compiles.

Closes #914
