### PR TITLE
fix(frontend): use buttonVariants(destructive) for the cardgroup-header delete commit

### DIFF
--- a/frontend/src/components/cardgroups/cardgroup-header.tsx
+++ b/frontend/src/components/cardgroups/cardgroup-header.tsx
@@ -17,7 +17,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
-import { Button } from "@/components/ui/button";
+import { Button, buttonVariants } from "@/components/ui/button";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -138,7 +138,7 @@ export function CardgroupHeader({ cardgroup, totalCount }: Props) {
           <AlertDialogFooter>
             <AlertDialogCancel disabled={deleting}>{tCommon("cancel")}</AlertDialogCancel>
             <AlertDialogAction
-              className="bg-destructive text-destructive-foreground"
+              className={buttonVariants({ variant: "destructive" })}
               disabled={deleting}
               onClick={(e) => {
                 e.preventDefault();


### PR DESCRIPTION
## Summary

The cardgroup-header delete-confirm commit styled its destructive button with inline
utility classes (`bg-destructive text-destructive-foreground`) instead of the
design-system `buttonVariants({ variant: "destructive" })`. The design-system rule
([`.claude/rules/frontend-design-system.md`](.claude/rules/frontend-design-system.md))
states a destructive **commit** MUST carry the `destructive` variant and calls a
no-danger-color confirm "a bug, not a style choice"; the inline form also drifts from
the four sibling confirm commits (`admin-master-form`, `bulk-action-bar`,
`cards-new-client`, `form-sheet`) that already route through `buttonVariants`.

This routes the delete commit through the design-system variant so the button picks up
the full destructive treatment (hover, focus-ring, disabled) rather than the bare fill
pair. Visual and behavioral parity is preserved — the deepened-crimson commit still
reads as the only filled danger in the flow.

## Changes

- `frontend/src/components/cardgroups/cardgroup-header.tsx` — import `buttonVariants`
  alongside `Button`; replace the inline `className="bg-destructive text-destructive-foreground"`
  on the delete-commit `AlertDialogAction` with `className={buttonVariants({ variant: "destructive" })}`.

## Test plan

- `tsc --noEmit`, `biome check --error-on-warnings`, `knip`, `next build` — pass
- `vitest run` — full suite green (196 files, 1831 tests); `cardgroup-header.test.tsx`
  (14 tests) unaffected, delete-confirm flow unchanged.

Closes #903
