### PR TITLE
refactor(frontend): hoist duplicated CATALOG_INITIAL + mergeCatalogConnection into app/catalog/queries.ts

### DIFF
--- a/frontend/src/app/catalog/catalog-client.tsx
+++ b/frontend/src/app/catalog/catalog-client.tsx
@@ -12,11 +12,10 @@ import {
   type MasterCatalogQueryVariables,
 } from "@/generated/graphql";
 import { useHeaderTakeoverSearch } from "@/hooks/use-header-takeover-search";
-import { EMPTY_PAGE_INFO } from "@/lib/pagination/empty-page-info";
 import { useConnectionPagination } from "@/lib/pagination/use-connection-pagination";
 import { useSeedConnectionCache } from "@/lib/pagination/use-seed-connection-cache";
 import { CatalogListItem } from "./catalog-list-item";
-import { CATALOG_DEFAULT_VARS } from "./queries";
+import { CATALOG_DEFAULT_VARS, CATALOG_INITIAL, mergeCatalogConnection } from "./queries";
 
 type Connection = MasterCatalogQuery["masterCatalog"];
 type CatalogEdge = Connection["edges"][number];
@@ -24,28 +23,6 @@ type CatalogPageInfo = Connection["pageInfo"];
 
 interface CatalogClientProps {
   initialConnection: Connection | null;
-}
-
-// Render fallback for useConnectionPagination. The client seeds the cache
-// synchronously before useQuery runs, so this is never read on the happy path;
-// it keeps the empty-edges shape the inline implementation used (`?? []`).
-const CATALOG_INITIAL = {
-  edges: [] as CatalogEdge[],
-  pageInfo: EMPTY_PAGE_INFO,
-  totalCount: 0,
-};
-
-// Concatenate the next page's edges onto the cached catalog connection.
-function mergeCatalogConnection(
-  prev: MasterCatalogQuery,
-  more: MasterCatalogQuery,
-): MasterCatalogQuery {
-  return {
-    masterCatalog: {
-      ...more.masterCatalog,
-      edges: [...prev.masterCatalog.edges, ...more.masterCatalog.edges],
-    },
-  };
 }
 
 /**

--- a/frontend/src/app/catalog/queries.ts
+++ b/frontend/src/app/catalog/queries.ts
@@ -1,5 +1,9 @@
 import { graphql } from "@/generated";
-import type { MasterCatalogQueryVariables } from "@/generated/graphql";
+import type {
+  MasterCatalogQuery as MasterCatalogQueryData,
+  MasterCatalogQueryVariables,
+} from "@/generated/graphql";
+import { EMPTY_PAGE_INFO } from "@/lib/pagination/empty-page-info";
 
 // Master catalog queries
 
@@ -19,6 +23,36 @@ export const CATALOG_DEFAULT_VARS: MasterCatalogQueryVariables = {
   first: CATALOG_PAGE_SIZE,
   search: null,
 };
+
+type CatalogConnection = MasterCatalogQueryData["masterCatalog"];
+type CatalogEdge = CatalogConnection["edges"][number];
+
+/**
+ * Render fallback for the catalog list's {@link useConnectionPagination}. Both
+ * the /catalog page ({@link CatalogClient}) and the merge-from-catalog sheet
+ * ({@link MergeFromCatalogSheet}) seed the SAME Apollo cache entry
+ * ({@link CATALOG_DEFAULT_VARS}); sharing this empty-edges shape keeps the two
+ * consumers from diverging on the same cache key. The client seeds the cache
+ * synchronously before `useQuery` runs, so this is never read on the happy path.
+ */
+export const CATALOG_INITIAL = {
+  edges: [] as CatalogEdge[],
+  pageInfo: EMPTY_PAGE_INFO,
+  totalCount: 0,
+};
+
+/** Concatenate the next page's edges onto the cached catalog connection. */
+export function mergeCatalogConnection(
+  prev: MasterCatalogQueryData,
+  more: MasterCatalogQueryData,
+): MasterCatalogQueryData {
+  return {
+    masterCatalog: {
+      ...more.masterCatalog,
+      edges: [...prev.masterCatalog.edges, ...more.masterCatalog.edges],
+    },
+  };
+}
 
 /**
  * The `MasterCardgroup` field set shared by the catalog list row

--- a/frontend/src/components/cardgroups/merge-from-catalog-sheet.tsx
+++ b/frontend/src/components/cardgroups/merge-from-catalog-sheet.tsx
@@ -6,7 +6,12 @@ import { useTranslations } from "next-intl";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useMergeFromCatalog } from "@/app/cardgroups/[id]/use-merge-from-catalog";
 import { useMergeFromCatalogPreview } from "@/app/cardgroups/[id]/use-merge-from-catalog-preview";
-import { CATALOG_DEFAULT_VARS, CatalogDeckFieldsFragment } from "@/app/catalog/queries";
+import {
+  CATALOG_DEFAULT_VARS,
+  CATALOG_INITIAL,
+  CatalogDeckFieldsFragment,
+  mergeCatalogConnection,
+} from "@/app/catalog/queries";
 import { MergeReviewPanel } from "@/components/cardgroups/merge-review-panel";
 import { ConnectionListFooter } from "@/components/layout/connection-list-footer";
 import { ErrorBanner } from "@/components/ui/error-banner";
@@ -19,7 +24,6 @@ import {
 } from "@/generated/graphql";
 import { useDebouncedSearch } from "@/hooks/use-debounced-search";
 import { getBackendErrorBanner } from "@/lib/apollo/errors";
-import { EMPTY_PAGE_INFO } from "@/lib/pagination/empty-page-info";
 import { useConnectionPagination } from "@/lib/pagination/use-connection-pagination";
 
 type Connection = MasterCatalogQuery["masterCatalog"];
@@ -39,24 +43,6 @@ export type MergeFromCatalogSheetProps = {
   targetCardgroupName: string;
   onMerged: (result: { addedCount: number; updatedCount: number }) => void;
 };
-
-const CATALOG_INITIAL = {
-  edges: [] as CatalogEdge[],
-  pageInfo: EMPTY_PAGE_INFO,
-  totalCount: 0,
-};
-
-function mergeCatalogConnection(
-  prev: MasterCatalogQuery,
-  more: MasterCatalogQuery,
-): MasterCatalogQuery {
-  return {
-    masterCatalog: {
-      ...more.masterCatalog,
-      edges: [...prev.masterCatalog.edges, ...more.masterCatalog.edges],
-    },
-  };
-}
 
 export function MergeFromCatalogSheet({
   open,


### PR DESCRIPTION
## Summary

`catalog-client.tsx` (the `/catalog` list) and `merge-from-catalog-sheet.tsx` (the
merge drawer) drive the **same** `MasterCatalogDocument` through
`useConnectionPagination` and both keyed the same Apollo cache entry via
`CATALOG_DEFAULT_VARS` — yet each declared a byte-identical `CATALOG_INITIAL`
render-fallback and `mergeCatalogConnection` edge-concat helper. Because both
consumers write to one cache entry, a divergence in either copy's edge-concat /
`totalCount` handling would silently desync the two surfaces. The shared
`app/catalog/queries.ts` module already single-sources `CATALOG_DEFAULT_VARS` and
`CatalogDeckFieldsFragment`, so the boundary existed and was bypassed for these two
artifacts.

This hoists both into `app/catalog/queries.ts` next to `CATALOG_DEFAULT_VARS` and
imports them from the two consumers. Pure hoist, no behavior change: the moved const
and function are byte-identical to the originals.

## Changes

- `frontend/src/app/catalog/queries.ts` — export `CATALOG_INITIAL` and
  `mergeCatalogConnection` (moved verbatim); add the `EMPTY_PAGE_INFO` import and the
  `CatalogConnection` / `CatalogEdge` helper types. The generated `MasterCatalogQuery`
  result type is imported aliased as `MasterCatalogQueryData` to avoid the name clash
  with this module's local `MasterCatalogQuery` graphql-document const.
- `frontend/src/app/catalog/catalog-client.tsx` — drop the local `CATALOG_INITIAL` /
  `mergeCatalogConnection` declarations and the now-unused `EMPTY_PAGE_INFO` import;
  import both from `./queries`.
- `frontend/src/components/cardgroups/merge-from-catalog-sheet.tsx` — same removal;
  import both from `@/app/catalog/queries`.

Both consumers keep their direct `useConnectionPagination` call (the
`pagination-ref-triplet-removal-rule.test.ts` guard stays green) and their local
`CatalogEdge` / `CatalogPageInfo` aliases (still used in the hook's type parameters).

## Test plan

- `tsc --noEmit`, `biome check --error-on-warnings`, `knip`, `next build` — pass
- `vitest run` — full suite green (196 files, 1831 tests). No test imported the moved
  consts, so no test changes were required.

Closes #890
