### PR TITLE
refactor(frontend): add a SearchInput primitive for the hand-rolled desktop search boxes

### DIFF
--- a/frontend/src/app/catalog/catalog-client.tsx
+++ b/frontend/src/app/catalog/catalog-client.tsx
@@ -5,6 +5,7 @@ import { useTranslations } from "next-intl";
 import { useMemo } from "react";
 import { ConnectionListFooter } from "@/components/layout/connection-list-footer";
 import { ListingPageShell } from "@/components/layout/listing-page-shell";
+import { SearchInput } from "@/components/search/search-input";
 import { SearchTakeoverBar } from "@/components/search/search-takeover-bar";
 import {
   MasterCatalogDocument,
@@ -124,12 +125,10 @@ export default function CatalogClient({ initialConnection }: CatalogClientProps)
         countLabel={tCommon("totalCount", { count: totalCount })}
         toolbar={
           <div className="mb-2 hidden md:block">
-            <input
-              type="search"
+            <SearchInput
               placeholder={t("searchPlaceholder")}
               value={search.input}
               onChange={(e) => search.setInput(e.target.value)}
-              className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
               aria-label={t("searchAriaLabel")}
               data-testid="catalog-search"
             />

--- a/frontend/src/components/cardgroups/card-search-input.tsx
+++ b/frontend/src/components/cardgroups/card-search-input.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { Search } from "lucide-react";
 import { useTranslations } from "next-intl";
+import { SearchInput } from "@/components/search/search-input";
 
 export function CardSearchInput({
   value,
@@ -14,21 +14,14 @@ export function CardSearchInput({
   return (
     // Desktop only: on mobile the search moves into the header-takeover bar.
     <div className="mb-3 hidden md:block">
-      <div className="relative">
-        <Search
-          aria-hidden="true"
-          className="pointer-events-none absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
-        />
-        <input
-          type="search"
-          placeholder={t("searchPlaceholder")}
-          value={value}
-          onChange={(e) => onChange(e.target.value)}
-          className="w-full rounded-md border border-input bg-background pl-8 pr-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
-          aria-label={t("searchAriaLabel")}
-          data-testid="cards-search-input"
-        />
-      </div>
+      <SearchInput
+        icon
+        placeholder={t("searchPlaceholder")}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        aria-label={t("searchAriaLabel")}
+        data-testid="cards-search-input"
+      />
     </div>
   );
 }

--- a/frontend/src/components/cardgroups/cardgroups-toolbar.tsx
+++ b/frontend/src/components/cardgroups/cardgroups-toolbar.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useTranslations } from "next-intl";
+import { SearchInput } from "@/components/search/search-input";
 
 interface CardgroupsToolbarProps {
   searchInput: string;
@@ -16,12 +17,10 @@ export function CardgroupsToolbar({ searchInput, onSearchInputChange }: Cardgrou
 
   return (
     <div className="mb-6 hidden md:block">
-      <input
-        type="search"
+      <SearchInput
         placeholder={t("filterPlaceholder")}
         value={searchInput}
         onChange={(e) => onSearchInputChange(e.target.value)}
-        className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
         aria-label={t("filterAriaLabel")}
       />
     </div>

--- a/frontend/src/components/cardgroups/merge-from-catalog-sheet.tsx
+++ b/frontend/src/components/cardgroups/merge-from-catalog-sheet.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/app/catalog/queries";
 import { MergeReviewPanel } from "@/components/cardgroups/merge-review-panel";
 import { ConnectionListFooter } from "@/components/layout/connection-list-footer";
+import { SearchInput } from "@/components/search/search-input";
 import { ErrorBanner } from "@/components/ui/error-banner";
 import { FormSheet } from "@/components/ui/form-sheet";
 import { useFragment } from "@/generated/fragment-masking";
@@ -230,14 +231,12 @@ export function MergeFromCatalogSheet({
         ) : null
       ) : (
         <div className="flex flex-col gap-4">
-          <input
-            type="search"
+          <SearchInput
             value={searchInput}
             onChange={(event) => setSearchInput(event.target.value)}
             placeholder={tCatalog("searchPlaceholder")}
             aria-label={tCatalog("searchAriaLabel")}
             data-testid="merge-from-catalog-search"
-            className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
           />
 
           {queryBannerError ? (

--- a/frontend/src/components/search/search-input.test.tsx
+++ b/frontend/src/components/search/search-input.test.tsx
@@ -1,0 +1,56 @@
+// @vitest-environment happy-dom
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { SearchInput } from "./search-input";
+
+describe("<SearchInput>", () => {
+  it("renders a search input carrying the design-system focus-ring token", () => {
+    render(
+      <SearchInput
+        placeholder="Search decks..."
+        aria-label="Search decks"
+        value=""
+        onChange={() => {}}
+      />,
+    );
+    const input = screen.getByRole("searchbox", { name: "Search decks" });
+    expect(input).toHaveAttribute("type", "search");
+    expect(input).toHaveAttribute("placeholder", "Search decks...");
+    expect(input).toHaveClass("focus-visible:ring-ring", "focus-visible:ring-offset-2");
+  });
+
+  it("fires onChange on keystroke", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<SearchInput aria-label="Search" value="" onChange={onChange} />);
+    await user.type(screen.getByRole("searchbox", { name: "Search" }), "a");
+    expect(onChange).toHaveBeenCalled();
+  });
+
+  it("forwards data-testid to the underlying input element", () => {
+    render(
+      <SearchInput aria-label="Search" value="" onChange={() => {}} data-testid="my-search" />,
+    );
+    expect(screen.getByTestId("my-search")).toBe(screen.getByRole("searchbox", { name: "Search" }));
+  });
+
+  it("renders no leading icon by default", () => {
+    render(
+      <SearchInput aria-label="Search" value="" onChange={() => {}} data-testid="my-search" />,
+    );
+    const input = screen.getByTestId("my-search");
+    // No icon variant: the input's parent is whatever the caller wraps it in,
+    // not an internal relative-positioned icon container.
+    expect(input.parentElement?.querySelector("svg")).not.toBeInTheDocument();
+  });
+
+  it("renders a leading search icon when icon is set", () => {
+    render(
+      <SearchInput icon aria-label="Search" value="" onChange={() => {}} data-testid="my-search" />,
+    );
+    const input = screen.getByTestId("my-search");
+    expect(input.parentElement?.querySelector("svg")).toBeInTheDocument();
+    expect(input).toHaveClass("pl-8");
+  });
+});

--- a/frontend/src/components/search/search-input.tsx
+++ b/frontend/src/components/search/search-input.tsx
@@ -1,0 +1,38 @@
+import { Search } from "lucide-react";
+import * as React from "react";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+
+export interface SearchInputProps extends Omit<React.ComponentPropsWithoutRef<"input">, "type"> {
+  /**
+   * Renders a leading search icon inside the field and shifts the left
+   * padding to make room for it. Off by default — most desktop search boxes
+   * in this app render bare, matching `admin-list-search.tsx`.
+   */
+  icon?: boolean;
+}
+
+/**
+ * Design-system search field: a design-system `<Input type="search">` with
+ * an optional leading icon. Every desktop search box in the app (catalog,
+ * cardgroups, merge-from-catalog, cards) renders through this component so
+ * they share one focus-ring / sizing / placeholder-color source instead of
+ * a copy-pasted className string.
+ */
+export const SearchInput = React.forwardRef<HTMLInputElement, SearchInputProps>(
+  ({ icon = false, className, ...props }, ref) => {
+    if (!icon) {
+      return <Input type="search" className={className} ref={ref} {...props} />;
+    }
+    return (
+      <div className="relative">
+        <Search
+          aria-hidden="true"
+          className="pointer-events-none absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+        />
+        <Input type="search" className={cn("pl-8", className)} ref={ref} {...props} />
+      </div>
+    );
+  },
+);
+SearchInput.displayName = "SearchInput";


### PR DESCRIPTION
## Summary

The desktop search box was hand-rolled at four sites — each an inline `<input type="search">`
carrying the same ~189-character focus-ring / sizing class string — bypassing the design-system
`Input`. This adds a shared `SearchInput` primitive and routes all four sites through it, so the
search-field styling lives in one place.

`SearchInput` wraps the design-system `<Input type="search">` with an optional leading `Search`
icon (`icon` prop → `pl-8`), forwarding the native input API (`ComponentPropsWithoutRef<"input">`
minus `type`). `CardSearchInput` becomes a thin icon-variant wrapper over `SearchInput`, so its
two consumers (`catalog-deck-client.tsx`, `card-list-screen.tsx`) need no changes.

## Changes

- `frontend/src/components/search/search-input.tsx` — **new** `SearchInput` primitive (+ co-located
  `search-input.test.tsx`, 5 tests: search role, placeholder, focus-ring class, `onChange`,
  `data-testid` forwarding, icon default-off / on with `pl-8`).
- `frontend/src/components/cardgroups/card-search-input.tsx` — now a thin `<SearchInput icon />`
  wrapper; same `{ value, onChange }` API, `data-testid="cards-search-input"`, wrapper `className`.
- `frontend/src/components/cardgroups/cardgroups-toolbar.tsx`,
  `frontend/src/app/catalog/catalog-client.tsx`,
  `frontend/src/components/cardgroups/merge-from-catalog-sheet.tsx` — raw `<input>` → `<SearchInput>`;
  the duplicated class string removed. `data-testid`s stay on the actual `<input>` element so
  existing tests are unaffected.

Out of scope (left untouched): `search-takeover-bar.tsx` (mobile, different padding) and
`profile/delete-account-section.tsx` (a plain text input, not search).

## Test plan

- `tsc --noEmit`, `biome check --error-on-warnings`, `knip`, `next build` — pass
- `vitest run` — 197 files, 1836 tests pass (the 5 new `SearchInput` tests; no existing test needed
  changes — assertions target `data-testid`/`aria-label`/typed text, unaffected by the swap).

## Stacking

Stacked on #890 (base branch `refactor/890-catalog-queries-hoist`) — this PR's diff is scoped to
the SearchInput change. Merge #890 first, then retarget this to `main`. The follow-on
`PaginatedPublicListScreen` work (#917) consumes this primitive.

Closes #891
