### PR TITLE
refactor(frontend): hoist the outcome-to-message ternary duplicated within merge-from-catalog-sheet

### DIFF
--- a/frontend/src/components/cardgroups/merge-from-catalog-sheet.tsx
+++ b/frontend/src/components/cardgroups/merge-from-catalog-sheet.tsx
@@ -37,6 +37,24 @@ type ReviewState =
   | { phase: "ready"; addedCount: number; updatedCount: number }
   | { phase: "error"; message: string };
 
+/** Outcome shape shared by `previewMerge` and `mergeFromCatalog`'s non-success variants. */
+type MergeFailureOutcome =
+  | { status: "not_found" }
+  | { status: "auth"; kind: "unauthenticated" | "forbidden" }
+  | { status: "rejected" };
+
+/** Maps a non-success merge outcome to its localized review-error message. */
+function mergeOutcomeMessage(
+  outcome: MergeFailureOutcome,
+  t: ReturnType<typeof useTranslations<"Cardgroups">>,
+): string {
+  if (outcome.status === "not_found") return t("mergeNotFound");
+  if (outcome.status === "auth") {
+    return outcome.kind === "forbidden" ? t("noPermission") : t("sessionExpiredSignIn");
+  }
+  return t("mergeError");
+}
+
 export type MergeFromCatalogSheetProps = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -149,15 +167,7 @@ export function MergeFromCatalogSheet({
         });
         return;
       }
-      const message =
-        outcome.status === "not_found"
-          ? t("mergeNotFound")
-          : outcome.status === "auth"
-            ? outcome.kind === "forbidden"
-              ? t("noPermission")
-              : t("sessionExpiredSignIn")
-            : t("mergeError");
-      setReview({ phase: "error", message });
+      setReview({ phase: "error", message: mergeOutcomeMessage(outcome, t) });
     },
     [previewMerge, t],
   );
@@ -177,15 +187,7 @@ export function MergeFromCatalogSheet({
       onOpenChange(false);
       return;
     }
-    const message =
-      outcome.status === "not_found"
-        ? t("mergeNotFound")
-        : outcome.status === "auth"
-          ? outcome.kind === "forbidden"
-            ? t("noPermission")
-            : t("sessionExpiredSignIn")
-          : t("mergeError");
-    setReview({ phase: "error", message });
+    setReview({ phase: "error", message: mergeOutcomeMessage(outcome, t) });
     setMerging(false);
   }, [mergeFromCatalog, merging, onMerged, onOpenChange, resetTransientState, selectedDeck, t]);
 


### PR DESCRIPTION
## Summary

Inside `merge-from-catalog-sheet.tsx` the failure-outcome-to-message mapping was duplicated
across the merge-preview (`handleSelect`) and merge-commit (`handleConfirm`) paths — the same
ternary over the failure variants building the same banner copy in two places. This hoists that
logic into one local helper so the two paths cannot drift.

## Changes

- `frontend/src/components/cardgroups/merge-from-catalog-sheet.tsx` — add a module-level
  `MergeFailureOutcome` type and `mergeOutcomeMessage(outcome, t)` helper above the component;
  both `handleSelect` and `handleConfirm` call it. Copy still routes through the existing
  `Cardgroups` catalog keys (`mergeNotFound` / `noPermission` / `sessionExpiredSignIn` /
  `mergeError`); `t` is passed in (the helper is not a component). No behavior change.

## Test plan

- `tsc --noEmit`, `biome check --error-on-warnings`, `knip`, `next build` — pass
- `vitest run` — 197 files, 1836 tests pass. The co-located `merge-from-catalog-sheet.test.tsx`
  asserts rendered banner text by regex (not the helper/keys), so it is unaffected.

## Stacking

Stacked on #891 (base branch `refactor/891-search-input-primitive`) → #890. This PR's diff is
scoped to the outcome-message hoist. Merge #890 → #891 → this, retargeting each to `main` as its
parent lands.

Closes #904
