### PR TITLE
refactor(frontend): localize the practice-client error banner — remove hardcoded English copy

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -72,6 +72,7 @@
     "practiceEmptyMessage": "Review some cards in a learning session first, then come back to practice them.",
     "practiceCompleteHeading": "Practice complete",
     "practiceCompleteMessage": "You finished this practice round. Study again for another pass — your progress is never affected.",
+    "practiceLoadFailed": "Could not load today's practice cards. Please try again.",
     "sessionComplete": "Session complete",
     "sessionCompleteMessage": "There are no due cards left in this batch.",
     "reviewedCount": "{count, plural, one {You reviewed # card in this batch.} other {You reviewed # cards in this batch.}}",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -72,6 +72,7 @@
     "practiceEmptyMessage": "まず学習セッションでカードを復習してから、練習しに戻ってきてください。",
     "practiceCompleteHeading": "練習完了",
     "practiceCompleteMessage": "この練習ラウンドを終えました。もう一周したい場合はもう一度学習してください。進捗には影響しません。",
+    "practiceLoadFailed": "今日の練習カードを読み込めませんでした。もう一度お試しください。",
     "sessionComplete": "セッション完了",
     "sessionCompleteMessage": "このバッチに期限切れのカードはありません。",
     "reviewedCount": "{count, plural, other {このバッチで#枚のカードを復習しました。}}",

--- a/frontend/src/app/learn/[cardgroupId]/practice-client.tsx
+++ b/frontend/src/app/learn/[cardgroupId]/practice-client.tsx
@@ -43,6 +43,7 @@ type PracticeCard = PracticeTodaysCardsQuery["practiceTodaysCards"][number];
  */
 export function PracticeClient({ cardgroupId }: { cardgroupId: string }) {
   const t = useTranslations("Learn");
+  const tCommon = useTranslations("Common");
   const { data, loading, error, refetch } = useQuery(PracticeTodaysCardsDocument, {
     variables: { cardgroupId },
     fetchPolicy: "network-only",
@@ -128,13 +129,10 @@ export function PracticeClient({ cardgroupId }: { cardgroupId: string }) {
     return (
       <section className="flex flex-1 items-center justify-center">
         <ErrorBanner className="w-full max-w-xl">
-          <p>
-            {getBackendErrorBanner(error) ??
-              "Could not load today's practice cards. Please try again."}
-          </p>
+          <p>{getBackendErrorBanner(error) ?? t("practiceLoadFailed")}</p>
           <div className="mt-3">
             <Button type="button" variant="outline" onClick={retry}>
-              Retry
+              {tCommon("retry")}
             </Button>
           </div>
         </ErrorBanner>


### PR DESCRIPTION
## Summary

The practice-client error banner hardcoded English copy — the load-failed fallback and the
"Retry" label — bypassing the message catalogs. This routes both through next-intl.

## Changes

- `frontend/src/app/learn/[cardgroupId]/practice-client.tsx` — add `tCommon = useTranslations("Common")`;
  replace the hardcoded fallback with `t("practiceLoadFailed")` and the literal `Retry` with
  `tCommon("retry")` (reusing the existing `Common.retry` key).
- `frontend/messages/en.json`, `frontend/messages/ja.json` — add one new key `Learn.practiceLoadFailed`
  (placed after `practiceCompleteMessage`); en/ja parity maintained.

## Test plan

- `tsc --noEmit`, `biome check --error-on-warnings`, `knip`, `next build`, `i18n:parity` — pass
- `vitest run` — 196 files, 1831 tests pass. The co-located test renders via `renderWithIntl` (real
  catalog), so `t("practiceLoadFailed")` / `Common.retry` resolve to the same strings it already
  asserts — no test change needed.

Closes #889
