### PR TITLE
fix(frontend): localize RoleListItem aria-labels to match sibling list rows

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -396,6 +396,8 @@
     "newRole": "New role",
     "noRolesYet": "No roles yet",
     "editRoleTitle": "Edit role",
+    "editRoleAriaLabel": "Edit role {name}",
+    "deleteRoleAriaLabel": "Delete {name}",
     "createRole": "Create",
     "deleteAuthFailed": "Your session has expired. Please sign in again.",
     "systemRole": "System role",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -396,6 +396,8 @@
     "newRole": "新しいロール",
     "noRolesYet": "ロールがありません",
     "editRoleTitle": "ロールを編集",
+    "editRoleAriaLabel": "ロール「{name}」を編集",
+    "deleteRoleAriaLabel": "「{name}」を削除",
     "createRole": "作成",
     "deleteAuthFailed": "セッションの有効期限が切れました。再度ログインしてください。",
     "systemRole": "システムロール",

--- a/frontend/src/components/admin/role-list-item.tsx
+++ b/frontend/src/components/admin/role-list-item.tsx
@@ -53,7 +53,7 @@ export function RoleListItem({ id, name, isSystem, busy, onEdit, onDelete }: Rol
         <button
           type="button"
           onClick={() => onEdit(id)}
-          aria-label={`Edit role ${name}`}
+          aria-label={t("editRoleAriaLabel", { name })}
           className="flex min-w-0 flex-1 flex-col gap-1 p-4 text-left"
         >
           <span className="truncate font-medium text-foreground" data-testid="admin-role-name">
@@ -63,7 +63,7 @@ export function RoleListItem({ id, name, isSystem, busy, onEdit, onDelete }: Rol
         <HoverRevealDeleteButton
           onDelete={() => onDelete(id)}
           disabled={busy}
-          ariaLabel={`Delete ${name}`}
+          ariaLabel={t("deleteRoleAriaLabel", { name })}
           data-testid={`admin-role-delete-btn-${id}`}
         />
       </li>


### PR DESCRIPTION
## Summary

`RoleListItem`'s two action aria-labels (`Edit role {name}`, `Delete {name}`) were hardcoded
English, unlike the sibling admin rows. This routes them through the already-imported `Admin`
translator so the row is localized.

## Changes

- `frontend/src/components/admin/role-list-item.tsx` — use the existing `t = useTranslations("Admin")`
  for both aria-labels (no new import).
- `frontend/messages/en.json`, `frontend/messages/ja.json` — add `editRoleAriaLabel` /
  `deleteRoleAriaLabel` to the `Admin` namespace (parity, 421 keys). Key naming mirrors
  `admin-user-row` / `admin-master-row` (`editAriaLabel`). English values preserve the existing
  wording so the button-query tests are unaffected.

## Test plan

- `tsc --noEmit`, `biome check --error-on-warnings`, `knip`, `next build`, `i18n:parity` — pass
- `vitest run` — 196 files, 1831 tests pass (admin-roles tests query by `/edit role …/i` and
  `/delete …/i`, unchanged).

Closes #902
