### PR TITLE
refactor(frontend): extract useUpdateProfileSubmit shared by ProfileForm and OnboardingForm

### DIFF
--- a/frontend/src/app/onboarding/onboarding-form.tsx
+++ b/frontend/src/app/onboarding/onboarding-form.tsx
@@ -3,8 +3,8 @@
 import { useForm } from "@tanstack/react-form";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
-import { useState } from "react";
-import { useUpdateProfile } from "@/app/profile/use-update-profile";
+import { useCallback, useState } from "react";
+import { useUpdateProfileSubmit } from "@/app/profile/use-update-profile-submit";
 import { OnboardingShell } from "@/components/onboarding/onboarding-shell";
 import { Button } from "@/components/ui/button";
 import { ErrorBanner } from "@/components/ui/error-banner";
@@ -19,16 +19,6 @@ export function OnboardingForm() {
   const t = useTranslations("Onboarding");
   const tCommon = useTranslations("Common");
 
-  // Typed InputValidationError variant — field-level validation failure
-  // surfaced by the server via the outcome union. Cleared on each new submission.
-  const [validationError, setValidationError] = useState<{
-    field: string;
-    message: string;
-  } | null>(null);
-
-  // Mid-session auth failures or unexpected payloads. Cleared on each submission.
-  const [bannerMessage, setBannerMessage] = useState<string | null>(null);
-
   // Held true from a successful save until this component unmounts on the
   // `router.push("/onboarding/start")` navigation. Apollo's `loading` flips back
   // to false the instant the mutation resolves — before the App Router
@@ -39,7 +29,19 @@ export function OnboardingForm() {
   // success path; every failure branch leaves it false so the user can resubmit.
   const [navigating, setNavigating] = useState(false);
 
-  const { submit, loading } = useUpdateProfile();
+  const onSuccess = useCallback(() => {
+    // Keep the button in its "Saving…"/disabled state through the navigation that
+    // unmounts this component, so it does not flicker back to "Continue" once
+    // Apollo's `loading` clears.
+    setNavigating(true);
+    router.push("/onboarding/start");
+  }, [router]);
+
+  const { submit, bannerMessage, fieldErrors, loading } = useUpdateProfileSubmit({
+    onSuccess,
+    sessionExpiredMessage: t("sessionExpired"),
+    rejectionLabel: "[OnboardingForm] update profile rejected",
+  });
 
   const displayNameSchema = updateProfileSchema.shape.displayName;
 
@@ -48,43 +50,11 @@ export function OnboardingForm() {
       displayName: "",
     },
     onSubmit: async ({ value }) => {
-      setValidationError(null);
-      setBannerMessage(null);
-
-      const outcome = await submit({
+      await submit({
         displayName: value.displayName,
       });
-
-      switch (outcome.status) {
-        case "success":
-          // Keep the button in its "Saving…"/disabled state through the
-          // navigation that unmounts this component, so it does not flicker back
-          // to "Continue" once Apollo's `loading` clears.
-          setNavigating(true);
-          router.push("/onboarding/start");
-          return;
-        case "validation":
-          setValidationError({ field: outcome.field, message: outcome.message });
-          return;
-        case "unauthenticated":
-          setBannerMessage(t("sessionExpired"));
-          return;
-        case "unexpected":
-          setBannerMessage(tCommon("somethingWentWrong"));
-          return;
-        case "rejected":
-          setBannerMessage(outcome.banner ?? tCommon("somethingWentWrong"));
-          // Re-throw so TanStack Form keeps formState.isSubmitSuccessful=false;
-          // submitFormHandler (the outer onSubmit) swallows the re-thrown rejection.
-          throw new Error("[OnboardingForm] update profile rejected");
-      }
     },
   });
-
-  // Derive per-field backend errors from the validationError state (outcome union path).
-  const fieldErrors: Record<string, string | undefined> = validationError
-    ? { [validationError.field]: validationError.message }
-    : {};
 
   return (
     <OnboardingShell heading={t("welcome")} subline={t("subtitle")}>

--- a/frontend/src/app/profile/profile-form.tsx
+++ b/frontend/src/app/profile/profile-form.tsx
@@ -3,7 +3,7 @@
 import { useForm } from "@tanstack/react-form";
 import Link from "next/link";
 import { useTranslations } from "next-intl";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import { ErrorBanner } from "@/components/ui/error-banner";
 import { Input } from "@/components/ui/input";
@@ -13,7 +13,7 @@ import { DirtyStateBridge } from "@/lib/forms/dirty-state-bridge";
 import { FieldError } from "@/lib/forms/field-error";
 import { submitFormHandler } from "@/lib/forms/submit-handler";
 import { updateProfileSchema } from "@/schemas/profile";
-import { useUpdateProfile } from "./use-update-profile";
+import { useUpdateProfileSubmit } from "./use-update-profile-submit";
 
 type Props = {
   /** The user's email address. Required — callers must pass the value or explicit null; never collapse to "". */
@@ -40,27 +40,17 @@ export function ProfileForm({
   const t = useTranslations("Profile");
   const tCommon = useTranslations("Common");
 
-  // Typed InputValidationError variant — field-level validation failure
-  // surfaced by the server via the outcome union. Cleared on each new submission.
-  const [validationError, setValidationError] = useState<{
-    field: string;
-    message: string;
-  } | null>(null);
+  const onSuccess = useCallback(() => onSaved?.(), [onSaved]);
 
-  // Mid-session auth failures or unexpected payloads. Cleared on each submission.
-  const [bannerMessage, setBannerMessage] = useState<string | null>(null);
-
-  const { submit, loading, reset } = useUpdateProfile();
-
-  const resetLocalState = useCallback(() => {
-    setValidationError(null);
-    setBannerMessage(null);
-    reset();
-  }, [reset]);
+  const { submit, bannerMessage, fieldErrors, loading, reset } = useUpdateProfileSubmit({
+    onSuccess,
+    sessionExpiredMessage: t("sessionExpired"),
+    rejectionLabel: "[ProfileForm] update profile rejected",
+  });
 
   useEffect(() => {
-    onRegisterReset?.(resetLocalState);
-  }, [onRegisterReset, resetLocalState]);
+    onRegisterReset?.(reset);
+  }, [onRegisterReset, reset]);
 
   useEffect(() => {
     onSubmittingChange?.(loading);
@@ -75,40 +65,12 @@ export function ProfileForm({
       bio: initial.bio as string | undefined,
     },
     onSubmit: async ({ value }) => {
-      setValidationError(null);
-      setBannerMessage(null);
-
-      const outcome = await submit({
+      await submit({
         displayName: value.displayName,
         bio: value.bio,
       });
-
-      switch (outcome.status) {
-        case "success":
-          onSaved?.();
-          return;
-        case "validation":
-          setValidationError({ field: outcome.field, message: outcome.message });
-          return;
-        case "unauthenticated":
-          setBannerMessage(t("sessionExpired"));
-          return;
-        case "unexpected":
-          setBannerMessage(tCommon("somethingWentWrong"));
-          return;
-        case "rejected":
-          setBannerMessage(outcome.banner ?? tCommon("somethingWentWrong"));
-          // Re-throw so TanStack Form keeps formState.isSubmitSuccessful=false;
-          // submitFormHandler (the outer onSubmit) swallows the re-thrown rejection.
-          throw new Error("[ProfileForm] update profile rejected");
-      }
     },
   });
-
-  // Derive per-field backend errors from the validationError state (outcome union path).
-  const fieldErrors: Record<string, string | undefined> = validationError
-    ? { [validationError.field]: validationError.message }
-    : {};
 
   return (
     <form onSubmit={submitFormHandler(form)} className="space-y-4">

--- a/frontend/src/app/profile/use-update-profile-submit.test.tsx
+++ b/frontend/src/app/profile/use-update-profile-submit.test.tsx
@@ -1,0 +1,235 @@
+// @vitest-environment happy-dom
+import type { MockedResponse } from "@apollo/client/testing";
+import { MockedProvider } from "@apollo/client/testing/react";
+import { act, renderHook } from "@testing-library/react";
+import { GraphQLError } from "graphql";
+import { NextIntlClientProvider } from "next-intl";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { UpdateProfileDocument } from "@/generated/graphql";
+import enMessages from "../../../messages/en.json";
+import { useUpdateProfileSubmit } from "./use-update-profile-submit";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const INPUT = { displayName: "Alice" };
+const REQUEST = { query: UpdateProfileDocument, variables: { input: INPUT } };
+
+const SESSION_EXPIRED = "Session over — sign back in.";
+const REJECTION_LABEL = "[test] update profile rejected";
+
+function renderSubmit(mocks: MockedResponse[], onSuccess: () => void) {
+  return renderHook(
+    () =>
+      useUpdateProfileSubmit({
+        onSuccess,
+        sessionExpiredMessage: SESSION_EXPIRED,
+        rejectionLabel: REJECTION_LABEL,
+      }),
+    {
+      wrapper: ({ children }: { children: ReactNode }) => (
+        <NextIntlClientProvider locale="en" messages={enMessages} timeZone="UTC">
+          <MockedProvider mocks={mocks}>{children}</MockedProvider>
+        </NextIntlClientProvider>
+      ),
+    },
+  );
+}
+
+type RenderResult = ReturnType<typeof renderSubmit>["result"];
+
+async function runSubmit(result: RenderResult): Promise<{ threw: boolean; error?: unknown }> {
+  let threw = false;
+  let error: unknown;
+  await act(async () => {
+    try {
+      await result.current.submit(INPUT);
+    } catch (err) {
+      threw = true;
+      error = err;
+    }
+  });
+  return { threw, error };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("useUpdateProfileSubmit", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("calls onSuccess and leaves error state clear on UpdateProfileSuccess", async () => {
+    const onSuccess = vi.fn();
+    const mocks = [
+      {
+        request: REQUEST,
+        result: {
+          data: {
+            updateProfile: {
+              __typename: "UpdateProfileSuccess",
+              user: {
+                __typename: "User",
+                id: "user-1",
+                displayName: "Alice",
+                bio: null,
+                avatarUrl: null,
+              },
+            },
+          },
+        },
+      },
+    ];
+
+    const { result } = renderSubmit(mocks, onSuccess);
+    const { threw } = await runSubmit(result);
+
+    expect(threw).toBe(false);
+    expect(onSuccess).toHaveBeenCalledOnce();
+    expect(result.current.validationError).toBeNull();
+    expect(result.current.bannerMessage).toBeNull();
+    expect(result.current.fieldErrors).toEqual({});
+  });
+
+  it("maps InputValidationError to validationError + fieldErrors, no onSuccess", async () => {
+    const onSuccess = vi.fn();
+    const mocks = [
+      {
+        request: REQUEST,
+        result: {
+          data: {
+            updateProfile: {
+              __typename: "InputValidationError",
+              field: "displayName",
+              message: "displayName must be 1-50 characters",
+            },
+          },
+        },
+      },
+    ];
+
+    const { result } = renderSubmit(mocks, onSuccess);
+    const { threw } = await runSubmit(result);
+
+    expect(threw).toBe(false);
+    expect(onSuccess).not.toHaveBeenCalled();
+    expect(result.current.validationError).toEqual({
+      field: "displayName",
+      message: "displayName must be 1-50 characters",
+    });
+    expect(result.current.fieldErrors).toEqual({
+      displayName: "displayName must be 1-50 characters",
+    });
+    expect(result.current.bannerMessage).toBeNull();
+  });
+
+  it("maps UNAUTHENTICATED to the caller-supplied sessionExpiredMessage banner", async () => {
+    const onSuccess = vi.fn();
+    const mocks = [
+      {
+        request: REQUEST,
+        result: {
+          errors: [
+            new GraphQLError("Unauthenticated", { extensions: { code: "UNAUTHENTICATED" } }),
+          ],
+        },
+      },
+    ];
+
+    const { result } = renderSubmit(mocks, onSuccess);
+    const { threw } = await runSubmit(result);
+
+    expect(threw).toBe(false);
+    expect(result.current.bannerMessage).toBe(SESSION_EXPIRED);
+    expect(result.current.validationError).toBeNull();
+  });
+
+  it("maps an unknown union variant to the generic Common banner", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const onSuccess = vi.fn();
+    const mocks = [
+      {
+        request: REQUEST,
+        result: { data: { updateProfile: { __typename: "SomeFutureVariant" } } },
+      },
+    ];
+
+    const { result } = renderSubmit(mocks, onSuccess);
+    const { threw } = await runSubmit(result);
+
+    expect(threw).toBe(false);
+    expect(result.current.bannerMessage).toBe(enMessages.Common.somethingWentWrong);
+  });
+
+  it("sets the backend banner AND re-throws rejectionLabel on a non-auth GraphQL error", async () => {
+    const onSuccess = vi.fn();
+    const mocks = [
+      {
+        request: REQUEST,
+        result: {
+          errors: [
+            new GraphQLError("Something went wrong on the server", {
+              extensions: { code: "INTERNAL" },
+            }),
+          ],
+        },
+      },
+    ];
+
+    const { result } = renderSubmit(mocks, onSuccess);
+    const { threw, error } = await runSubmit(result);
+
+    expect(threw).toBe(true);
+    expect((error as Error).message).toBe(REJECTION_LABEL);
+    expect(result.current.bannerMessage).toBe("Something went wrong on the server");
+  });
+
+  it("falls back to the generic Common banner when the transport error yields no backend banner", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const onSuccess = vi.fn();
+    const mocks = [{ request: REQUEST, error: new Error("network down") }];
+
+    const { result } = renderSubmit(mocks, onSuccess);
+    const { threw, error } = await runSubmit(result);
+
+    expect(threw).toBe(true);
+    expect((error as Error).message).toBe(REJECTION_LABEL);
+    // getBackendErrorBanner maps a raw transport error to the connectivity copy.
+    expect(result.current.bannerMessage).toBe("Could not reach the server. Please try again.");
+  });
+
+  it("reset() clears validationError and bannerMessage", async () => {
+    const onSuccess = vi.fn();
+    const mocks = [
+      {
+        request: REQUEST,
+        result: {
+          data: {
+            updateProfile: {
+              __typename: "InputValidationError",
+              field: "displayName",
+              message: "displayName must be 1-50 characters",
+            },
+          },
+        },
+      },
+    ];
+
+    const { result } = renderSubmit(mocks, onSuccess);
+    await runSubmit(result);
+
+    expect(result.current.validationError).not.toBeNull();
+
+    act(() => {
+      result.current.reset();
+    });
+
+    expect(result.current.validationError).toBeNull();
+    expect(result.current.bannerMessage).toBeNull();
+    expect(result.current.fieldErrors).toEqual({});
+  });
+});

--- a/frontend/src/app/profile/use-update-profile-submit.ts
+++ b/frontend/src/app/profile/use-update-profile-submit.ts
@@ -1,0 +1,104 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { useCallback, useState } from "react";
+import type { UpdateProfileInput } from "@/generated/graphql";
+import { useUpdateProfile } from "./use-update-profile";
+
+/** Field-scoped backend validation error surfaced by the `InputValidationError` outcome variant. */
+type FieldValidationError = { field: string; message: string };
+
+type UseUpdateProfileSubmitParams = {
+  /**
+   * Runs on the `success` outcome. `ProfileForm` calls `onSaved?.()`; `OnboardingForm`
+   * sets its `navigating` flag and pushes `/onboarding/start`. Wrap in `useCallback` at the
+   * caller so the returned `submit` identity stays stable across renders.
+   */
+  onSuccess: () => void;
+  /**
+   * Localized banner for the `unauthenticated` (session-expired) outcome. The copy differs
+   * between the Profile and Onboarding namespaces, so the caller owns it (mirrors the
+   * caller-owns-i18n contract documented on `useUpdateProfile`).
+   */
+  sessionExpiredMessage: string;
+  /**
+   * Error message thrown on the `rejected` outcome so TanStack Form keeps
+   * `formState.isSubmitSuccessful` false. `submitFormHandler` (the outer `onSubmit`) swallows
+   * the re-thrown rejection.
+   */
+  rejectionLabel: string;
+};
+
+/**
+ * Presentation-side wrapper over {@link useUpdateProfile}. Owns the `validationError` /
+ * `bannerMessage` state and the outcome switch (including the `rejected` re-throw) that
+ * `ProfileForm` and `OnboardingForm` previously duplicated byte-for-byte.
+ *
+ * The generic "something went wrong" copy is resolved internally from the shared `Common`
+ * namespace; the namespace-specific `sessionExpiredMessage` and the form-specific
+ * `rejectionLabel` are caller-owned params. Returns `{ submit, validationError, bannerMessage,
+ * fieldErrors, loading, reset }`:
+ *
+ * - `submit(input)` clears the error state, runs the outcome switch, calls `onSuccess` on
+ *   success, and re-throws (`rejectionLabel`) on the `rejected` outcome.
+ * - `reset()` clears the local error state and resets the underlying Apollo mutation — used by
+ *   `ProfileForm`'s `onRegisterReset` flow; onboarding does not use it.
+ */
+export function useUpdateProfileSubmit({
+  onSuccess,
+  sessionExpiredMessage,
+  rejectionLabel,
+}: UseUpdateProfileSubmitParams) {
+  const tCommon = useTranslations("Common");
+  const { submit: submitProfile, loading, reset: resetMutation } = useUpdateProfile();
+
+  // Typed InputValidationError variant — field-level validation failure surfaced by the server
+  // via the outcome union. Cleared on each new submission.
+  const [validationError, setValidationError] = useState<FieldValidationError | null>(null);
+
+  // Mid-session auth failures or unexpected payloads. Cleared on each submission.
+  const [bannerMessage, setBannerMessage] = useState<string | null>(null);
+
+  const submit = useCallback(
+    async (input: UpdateProfileInput): Promise<void> => {
+      setValidationError(null);
+      setBannerMessage(null);
+
+      const outcome = await submitProfile(input);
+
+      switch (outcome.status) {
+        case "success":
+          onSuccess();
+          return;
+        case "validation":
+          setValidationError({ field: outcome.field, message: outcome.message });
+          return;
+        case "unauthenticated":
+          setBannerMessage(sessionExpiredMessage);
+          return;
+        case "unexpected":
+          setBannerMessage(tCommon("somethingWentWrong"));
+          return;
+        case "rejected":
+          setBannerMessage(outcome.banner ?? tCommon("somethingWentWrong"));
+          // Re-throw so TanStack Form keeps formState.isSubmitSuccessful=false;
+          // submitFormHandler (the outer onSubmit) swallows the re-thrown rejection.
+          throw new Error(rejectionLabel);
+      }
+    },
+    [submitProfile, onSuccess, sessionExpiredMessage, rejectionLabel, tCommon],
+  );
+
+  const reset = useCallback(() => {
+    setValidationError(null);
+    setBannerMessage(null);
+    resetMutation();
+  }, [resetMutation]);
+
+  // Derive per-field backend errors from the validationError state (outcome union path).
+  const fieldErrors: Record<string, string | undefined> = validationError
+    ? { [validationError.field]: validationError.message }
+    : {};
+
+  return { submit, validationError, bannerMessage, fieldErrors, loading, reset };
+}


### PR DESCRIPTION
## Summary

`ProfileForm` and `OnboardingForm` duplicated the update-profile submit flow — the outcome switch
plus the `validationError` / `bannerMessage` / `fieldErrors` state around `use-update-profile`.
This extracts a shared `useUpdateProfileSubmit` hook.

## Changes

- `frontend/src/app/profile/use-update-profile-submit.ts` — **new** hook wrapping
  `use-update-profile`'s outcome handling and the shared error/validation state. (+ co-located test.)
- `frontend/src/app/profile/profile-form.tsx`, `frontend/src/app/onboarding/onboarding-form.tsx` —
  consume the hook for the submit/mutation wiring; the JSX field blocks are untouched. Outcomes,
  error mapping, and field-error attribution are unchanged, so the existing form tests pass as-is.

## Test plan

- `tsc --noEmit`, `biome check --error-on-warnings`, `knip`, `next build` — pass
- `vitest run` — full suite green (new hook test; profile/onboarding tests unchanged).

Closes #905
