### PR TITLE
refactor(frontend): adopt the FormField triad in profile and onboarding forms

### DIFF
--- a/frontend/src/app/onboarding/onboarding-form.tsx
+++ b/frontend/src/app/onboarding/onboarding-form.tsx
@@ -8,9 +8,7 @@ import { useUpdateProfile } from "@/app/profile/use-update-profile";
 import { OnboardingShell } from "@/components/onboarding/onboarding-shell";
 import { Button } from "@/components/ui/button";
 import { ErrorBanner } from "@/components/ui/error-banner";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import { FieldError } from "@/lib/forms/field-error";
+import { FormField } from "@/lib/forms/form-field";
 import { submitFormHandler } from "@/lib/forms/submit-handler";
 import { updateProfileSchema } from "@/schemas/profile";
 
@@ -101,21 +99,12 @@ export function OnboardingForm() {
           validators={{ onChange: displayNameSchema, onBlur: displayNameSchema }}
         >
           {(field) => (
-            <div className="space-y-2">
-              <Label htmlFor={field.name}>{t("displayName")}</Label>
-              <Input
-                id={field.name}
-                name={field.name}
-                value={field.state.value}
-                onBlur={field.handleBlur}
-                onChange={(e) => field.handleChange(e.target.value)}
-              />
-              <p className="text-sm text-muted-foreground">{t("displayNameHint")}</p>
-              <FieldError
-                zodErrors={field.state.meta.errors}
-                backendError={fieldErrors.displayName}
-              />
-            </div>
+            <FormField
+              field={field}
+              label={t("displayName")}
+              backendError={fieldErrors.displayName}
+              hint={<p className="text-sm text-muted-foreground">{t("displayNameHint")}</p>}
+            />
           )}
         </form.Field>
 

--- a/frontend/src/app/profile/profile-form.tsx
+++ b/frontend/src/app/profile/profile-form.tsx
@@ -6,11 +6,9 @@ import { useTranslations } from "next-intl";
 import { useCallback, useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { ErrorBanner } from "@/components/ui/error-banner";
-import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Textarea } from "@/components/ui/textarea";
 import { DirtyStateBridge } from "@/lib/forms/dirty-state-bridge";
-import { FieldError } from "@/lib/forms/field-error";
+import { FormField } from "@/lib/forms/form-field";
 import { submitFormHandler } from "@/lib/forms/submit-handler";
 import { updateProfileSchema } from "@/schemas/profile";
 import { useUpdateProfile } from "./use-update-profile";
@@ -135,46 +133,34 @@ export function ProfileForm({
         validators={{ onChange: displayNameSchema, onBlur: displayNameSchema }}
       >
         {(field) => (
-          <div className="space-y-2">
-            <Label htmlFor={field.name}>{t("displayName")}</Label>
-            <Input
-              id={field.name}
-              name={field.name}
-              value={field.state.value}
-              onBlur={field.handleBlur}
-              onChange={(e) => field.handleChange(e.target.value)}
-            />
-            <FieldError
-              zodErrors={field.state.meta.errors}
-              backendError={fieldErrors.displayName}
-            />
-          </div>
+          <FormField
+            field={field}
+            label={t("displayName")}
+            backendError={fieldErrors.displayName}
+          />
         )}
       </form.Field>
 
       <form.Field name="bio" validators={{ onChange: bioSchema, onBlur: bioSchema }}>
         {(field) => (
-          <div className="space-y-2">
-            <Label htmlFor={field.name}>{t("bio")}</Label>
-            <Textarea
-              id={field.name}
-              name={field.name}
-              value={field.state.value ?? ""}
-              onBlur={field.handleBlur}
-              onChange={(e) => field.handleChange(e.target.value)}
-            />
-            {field.state.value !== "" ? (
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                onClick={() => field.handleChange("")}
-              >
-                {t("clearBio")}
-              </Button>
-            ) : null}
-            <FieldError zodErrors={field.state.meta.errors} backendError={fieldErrors.bio} />
-          </div>
+          <FormField
+            field={field}
+            kind="textarea"
+            label={t("bio")}
+            backendError={fieldErrors.bio}
+            trailing={
+              field.state.value !== "" ? (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => field.handleChange("")}
+                >
+                  {t("clearBio")}
+                </Button>
+              ) : null
+            }
+          />
         )}
       </form.Field>
 

--- a/frontend/src/lib/forms/form-field.test.tsx
+++ b/frontend/src/lib/forms/form-field.test.tsx
@@ -120,6 +120,71 @@ describe("FormField (textarea / number)", () => {
   });
 });
 
+describe("FormField (hint / trailing)", () => {
+  it("renders hint content between the control and the field error", () => {
+    render(
+      <FormField
+        field={stringField({ name: "displayName" })}
+        label="Display name"
+        hint={<p>pick something memorable</p>}
+      />,
+    );
+    expect(screen.getByText("pick something memorable")).toBeInTheDocument();
+  });
+
+  it("renders trailing content (e.g. a clear button)", () => {
+    render(
+      <FormField
+        field={stringField({ name: "bio", value: "hi" })}
+        label="Bio"
+        kind="textarea"
+        trailing={
+          <button type="button" tabIndex={-1}>
+            Clear bio
+          </button>
+        }
+      />,
+    );
+    expect(screen.getByRole("button", { name: "Clear bio" })).toBeInTheDocument();
+  });
+
+  it("orders control, then hint, then trailing, then the field error", () => {
+    const { container } = render(
+      <FormField
+        field={stringField({ name: "displayName", value: "x", errors: [{ message: "required" }] })}
+        label="Display name"
+        hint={<span data-testid="hint-node">hint text</span>}
+        trailing={<span data-testid="trailing-node">trailing node</span>}
+      />,
+    );
+    const wrapper = container.firstElementChild as HTMLElement;
+    const children = Array.from(wrapper.children) as HTMLElement[];
+    const idxControl = children.findIndex((el) => el.tagName === "INPUT");
+    const idxHint = children.findIndex((el) => el.dataset.testid === "hint-node");
+    const idxTrailing = children.findIndex((el) => el.dataset.testid === "trailing-node");
+    const idxError = children.findIndex((el) => el.textContent === "required");
+
+    expect(idxControl).toBeGreaterThanOrEqual(0);
+    expect(idxControl).toBeLessThan(idxHint);
+    expect(idxHint).toBeLessThan(idxTrailing);
+    expect(idxTrailing).toBeLessThan(idxError);
+  });
+
+  it("does not render hint or trailing for the checkbox kind", () => {
+    render(
+      <FormField
+        field={booleanField()}
+        label="Default starter"
+        kind="checkbox"
+        hint={<span>should-not-appear-hint</span>}
+        trailing={<span>should-not-appear-trailing</span>}
+      />,
+    );
+    expect(screen.queryByText("should-not-appear-hint")).toBeNull();
+    expect(screen.queryByText("should-not-appear-trailing")).toBeNull();
+  });
+});
+
 describe("FormField (checkbox)", () => {
   it("renders a checkbox reflecting the boolean value, with the label after it and no FieldError row", () => {
     render(

--- a/frontend/src/lib/forms/form-field.tsx
+++ b/frontend/src/lib/forms/form-field.tsx
@@ -5,10 +5,15 @@ import { Textarea } from "@/components/ui/textarea";
 import { FieldError } from "@/lib/forms/field-error";
 import { cn } from "@/lib/utils";
 
-/** Minimal structural view of a TanStack field whose value is a string. */
+/**
+ * Minimal structural view of a TanStack field whose value is a string. The
+ * value is `string | undefined` so optional fields (e.g. a `bio` whose
+ * `undefined` means "unchanged") can be threaded through unchanged; the control
+ * coalesces `undefined` to `""` so the input stays controlled.
+ */
 type StringFieldApi = {
   name: string;
-  state: { value: string; meta: { errors: unknown[] } };
+  state: { value: string | undefined; meta: { errors: unknown[] } };
   handleBlur: () => void;
   handleChange: (value: string) => void;
 };
@@ -40,6 +45,16 @@ type CommonProps = {
   className?: string;
   /** Autofocus this control on mount (e.g. the create-form's first field). */
   autoFocus?: boolean;
+  /**
+   * Optional helper content (e.g. a muted hint paragraph) rendered between the
+   * control and the {@link FieldError} row. Not shown for the `checkbox` kind.
+   */
+  hint?: ReactNode;
+  /**
+   * Optional trailing content (e.g. an inline "Clear" button) rendered between
+   * the control and the {@link FieldError} row. Not shown for the `checkbox` kind.
+   */
+  trailing?: ReactNode;
 };
 
 type FormFieldProps =
@@ -56,10 +71,25 @@ type FormFieldProps =
  * `kind` selects the control: `"text"` (default) / `"number"` render an
  * {@link Input}, `"textarea"` renders a {@link Textarea}, and `"checkbox"`
  * renders an inline checkbox + label with no `FieldError` row.
+ *
+ * Optional `hint` and `trailing` nodes render between the control and the
+ * {@link FieldError} row (for every kind except `checkbox`) — use `hint` for a
+ * muted helper paragraph and `trailing` for an inline action such as a Clear
+ * button.
  */
 export function FormField(props: FormFieldProps) {
-  const { label, backendError, idOverride, disabled, placeholder, testId, className, autoFocus } =
-    props;
+  const {
+    label,
+    backendError,
+    idOverride,
+    disabled,
+    placeholder,
+    testId,
+    className,
+    autoFocus,
+    hint,
+    trailing,
+  } = props;
   const id = idOverride ?? props.field.name;
 
   if (props.kind === "checkbox") {
@@ -89,7 +119,7 @@ export function FormField(props: FormFieldProps) {
         id={id}
         name={field.name}
         data-testid={testId}
-        value={field.state.value}
+        value={field.state.value ?? ""}
         onBlur={field.handleBlur}
         onChange={(e) => field.handleChange(e.target.value)}
         disabled={disabled}
@@ -102,7 +132,7 @@ export function FormField(props: FormFieldProps) {
         name={field.name}
         type={kind === "number" ? "number" : undefined}
         data-testid={testId}
-        value={field.state.value}
+        value={field.state.value ?? ""}
         onBlur={field.handleBlur}
         onChange={(e) => field.handleChange(e.target.value)}
         disabled={disabled}
@@ -115,6 +145,8 @@ export function FormField(props: FormFieldProps) {
     <div className={cn("space-y-2", className)}>
       <Label htmlFor={id}>{label}</Label>
       {control}
+      {hint}
+      {trailing}
       <FieldError zodErrors={field.state.meta.errors} backendError={backendError} />
     </div>
   );


### PR DESCRIPTION
## Summary

Adopt the `FormField` triad (Label + control + FieldError) in the profile and onboarding forms,
extending `FormField` with optional hint / trailing slots so the two forms stop hand-assembling
the field scaffold.

## Changes

- `frontend/src/lib/forms/form-field.tsx` — add optional `hint?` and `trailing?` props, rendered
  between the control and `FieldError`. (+ `form-field.test.tsx` updated for the new props.)
- `frontend/src/app/profile/profile-form.tsx`, `frontend/src/app/onboarding/onboarding-form.tsx` —
  render fields through the `FormField` triad. Label association and error announcement preserved.

## Test plan

- `tsc --noEmit`, `biome check --error-on-warnings`, `knip`, `next build` — pass
- `vitest run` — full suite green.

Closes #910
