### PR TITLE
refactor(frontend): extract one AddCardSheetContent shared by the cards and learn screens

### DIFF
--- a/frontend/src/app/learn/[cardgroupId]/_components/learn-add-card-sheet.tsx
+++ b/frontend/src/app/learn/[cardgroupId]/_components/learn-add-card-sheet.tsx
@@ -4,41 +4,10 @@ import { useTranslations } from "next-intl";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { cardsDefaultVars } from "@/app/cardgroups/[id]/cards/queries";
 import { useCardMutations } from "@/app/cardgroups/[id]/cards/use-card-mutations";
-import { CardForm } from "@/components/cardgroups/card-form";
-import { FormSheet, useFormSheetClose } from "@/components/ui/form-sheet";
+import { AddCardSheetContent } from "@/components/cards/add-card-sheet-content";
+import { FormSheet } from "@/components/ui/form-sheet";
 import { FLAMINGO_EVENT, subscribeFlamingo } from "@/lib/events/flamingo-events";
 import { useSheetForm } from "@/lib/forms/use-sheet-form";
-
-function AddCardSheetContent({
-  submit,
-  submitting,
-  error,
-  validationError,
-  onDirty,
-}: {
-  submit: (values: { front: string; back: string }) => Promise<void>;
-  submitting: boolean;
-  error: unknown;
-  validationError: { field: string; message: string } | null;
-  onDirty: () => void;
-}) {
-  const close = useFormSheetClose();
-
-  return (
-    <div onInput={onDirty}>
-      <CardForm
-        mode="create"
-        idPrefix="learn-add-card-"
-        defaultValues={{ front: "", back: "" }}
-        submit={submit}
-        submitting={submitting}
-        error={error}
-        validationError={validationError}
-        onCancel={close}
-      />
-    </div>
-  );
-}
 
 /**
  * In-context "add card" drawer for the Learn screen. Mounted independently of
@@ -112,6 +81,7 @@ export function LearnAddCardSheet({ cardgroupId }: { cardgroupId: string }) {
       confirmOnDismiss
     >
       <AddCardSheetContent
+        idPrefix="learn-add-card-"
         submit={handleCreate}
         submitting={creating}
         error={createError}

--- a/frontend/src/components/cardgroups/card-list-screen.tsx
+++ b/frontend/src/components/cardgroups/card-list-screen.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { Check } from "lucide-react";
 import { useTranslations } from "next-intl";
 import type { ReactNode, RefObject } from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -9,6 +8,7 @@ import { CardForm } from "@/components/cardgroups/card-form";
 import { CardRow } from "@/components/cardgroups/card-row";
 import { CardSearchInput } from "@/components/cardgroups/card-search-input";
 import type { SwipeableRowHandle } from "@/components/cardgroups/swipeable-row";
+import { AddCardSheetContent } from "@/components/cards/add-card-sheet-content";
 import { ConnectionListFooter } from "@/components/layout/connection-list-footer";
 import { SearchTakeoverBar } from "@/components/search/search-takeover-bar";
 import { Button } from "@/components/ui/button";
@@ -57,49 +57,6 @@ function EditCardSheetContent({
       validationError={validationError}
       onCancel={close}
     />
-  );
-}
-
-function AddCardSheetContent({
-  submit,
-  submitting,
-  error,
-  validationError,
-  onDirty,
-  addedCount,
-}: {
-  submit: (values: { front: string; back: string }) => Promise<void>;
-  submitting: boolean;
-  error: unknown;
-  validationError: { field: string; message: string } | null;
-  onDirty: () => void;
-  addedCount: number;
-}) {
-  const close = useFormSheetClose();
-  const t = useTranslations("Cards");
-
-  return (
-    <div onInput={onDirty} className="space-y-3">
-      {addedCount > 0 ? (
-        <p
-          className="flex items-center gap-1.5 text-sm text-success"
-          data-testid="add-card-added-count"
-        >
-          <Check aria-hidden="true" className="h-4 w-4" />
-          {t("addedCount", { count: addedCount })}
-        </p>
-      ) : null}
-      <CardForm
-        mode="create"
-        idPrefix="add-card-"
-        defaultValues={{ front: "", back: "" }}
-        submit={submit}
-        submitting={submitting}
-        error={error}
-        validationError={validationError}
-        onCancel={close}
-      />
-    </div>
   );
 }
 
@@ -416,6 +373,7 @@ export function CardListScreen({
           >
             <AddCardSheetContent
               key={`add-card-${sheet.createNonce}`}
+              idPrefix="add-card-"
               submit={sheet.handleCreate}
               submitting={creating}
               error={createError}

--- a/frontend/src/components/cards/add-card-sheet-content.test.tsx
+++ b/frontend/src/components/cards/add-card-sheet-content.test.tsx
@@ -1,0 +1,85 @@
+// @vitest-environment happy-dom
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { FormSheet } from "@/components/ui/form-sheet";
+import { renderWithIntl } from "@/test/render-with-intl";
+import { AddCardSheetContent } from "./add-card-sheet-content";
+
+type Props = Parameters<typeof AddCardSheetContent>[0];
+
+function renderContent(props: Partial<Props> = {}) {
+  const onOpenChange = vi.fn();
+  const merged: Props = {
+    idPrefix: "add-card-",
+    submit: vi.fn().mockResolvedValue(undefined),
+    submitting: false,
+    error: null,
+    validationError: null,
+    onDirty: vi.fn(),
+    ...props,
+  };
+  const result = renderWithIntl(
+    <FormSheet title="Add card" open onOpenChange={onOpenChange}>
+      <AddCardSheetContent {...merged} />
+    </FormSheet>,
+  );
+  return { ...result, onOpenChange, props: merged };
+}
+
+describe("<AddCardSheetContent>", () => {
+  it("renders the create form with the front and back fields", () => {
+    renderContent();
+
+    expect(screen.getByRole("textbox", { name: /front/i })).toBeInTheDocument();
+    expect(screen.getByRole("textbox", { name: /back/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^add$/i })).toBeInTheDocument();
+  });
+
+  it("namespaces the field ids with the supplied idPrefix", () => {
+    renderContent({ idPrefix: "learn-add-card-" });
+
+    expect(screen.getByRole("textbox", { name: /front/i })).toHaveAttribute(
+      "id",
+      "learn-add-card-front-field",
+    );
+  });
+
+  it("shows the added-count row when addedCount is greater than zero", () => {
+    renderContent({ addedCount: 2 });
+
+    const row = screen.getByTestId("add-card-added-count");
+    expect(row).toBeInTheDocument();
+    expect(row).toHaveTextContent("2 added");
+  });
+
+  it("hides the added-count row when addedCount is zero", () => {
+    renderContent({ addedCount: 0 });
+
+    expect(screen.queryByTestId("add-card-added-count")).toBeNull();
+  });
+
+  it("hides the added-count row when addedCount is omitted (learn path)", () => {
+    renderContent();
+
+    expect(screen.queryByTestId("add-card-added-count")).toBeNull();
+  });
+
+  it("calls onDirty when the user types into a field", async () => {
+    const user = userEvent.setup();
+    const { props } = renderContent();
+
+    await user.type(screen.getByRole("textbox", { name: /front/i }), "Hello");
+
+    expect(props.onDirty).toHaveBeenCalled();
+  });
+
+  it("requests the sheet to close when Cancel is clicked", async () => {
+    const user = userEvent.setup();
+    const { onOpenChange } = renderContent();
+
+    await user.click(screen.getByRole("button", { name: /cancel/i }));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+});

--- a/frontend/src/components/cards/add-card-sheet-content.tsx
+++ b/frontend/src/components/cards/add-card-sheet-content.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { Check } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { CardForm } from "@/components/cardgroups/card-form";
+import { useFormSheetClose } from "@/components/ui/form-sheet";
+
+/**
+ * Shared "add card" drawer body used by the cards screen
+ * (`/cardgroups/[id]/cards`) and the learn screen's in-context add sheet.
+ *
+ * `idPrefix` namespaces the form field ids per call site. When `addedCount`
+ * is provided and greater than zero, a success row surfaces the running
+ * continuous-add tally; the learn screen omits `addedCount` so the row never
+ * renders there.
+ */
+export function AddCardSheetContent({
+  idPrefix,
+  submit,
+  submitting,
+  error,
+  validationError,
+  onDirty,
+  addedCount,
+}: {
+  idPrefix: string;
+  submit: (values: { front: string; back: string }) => Promise<void>;
+  submitting: boolean;
+  error: unknown;
+  validationError: { field: string; message: string } | null;
+  onDirty: () => void;
+  addedCount?: number;
+}) {
+  const close = useFormSheetClose();
+  const t = useTranslations("Cards");
+
+  return (
+    <div onInput={onDirty} className="space-y-3">
+      {addedCount !== undefined && addedCount > 0 ? (
+        <p
+          className="flex items-center gap-1.5 text-sm text-success"
+          data-testid="add-card-added-count"
+        >
+          <Check aria-hidden="true" className="h-4 w-4" />
+          {t("addedCount", { count: addedCount })}
+        </p>
+      ) : null}
+      <CardForm
+        mode="create"
+        idPrefix={idPrefix}
+        defaultValues={{ front: "", back: "" }}
+        submit={submit}
+        submitting={submitting}
+        error={error}
+        validationError={validationError}
+        onCancel={close}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

The `AddCardSheetContent` block was defined inline and duplicated in both the cards screen and the
learn add-card sheet. This extracts one shared component.

## Changes

- `frontend/src/components/cards/add-card-sheet-content.tsx` — **new** shared component (+ co-located
  test). The `components/cards/` dir is new.
- `frontend/src/components/cardgroups/card-list-screen.tsx`,
  `frontend/src/app/learn/[cardgroupId]/_components/learn-add-card-sheet.tsx` — import the shared
  component; the local definitions are removed. Continuous-add (stay-open), form reset, and
  dirty-tracking behavior are preserved.

## Test plan

- `tsc --noEmit`, `biome check --error-on-warnings`, `knip`, `next build` — pass
- `vitest run` — 197 files, 1838 tests pass.

Closes #907
