### PR TITLE
refactor(frontend): extract the lazy edit-sheet loading gate shared by admin users/roles clients

### DIFF
--- a/docs/frontend/url-backed-sheet-state.md
+++ b/docs/frontend/url-backed-sheet-state.md
@@ -107,7 +107,22 @@ When the sheet body lazily fetches its data via `useLazyQuery`, the first render
 - `data === undefined`
 - `error === undefined`
 
-A naive sheet body branches on `data ? <Form /> : <NotFound />` and shows the "not found" banner for one frame before the effect commits and the query starts. Pass the `called` flag (and ideally a `variables.id` equality check for race safety) up into the body's `loading` decision:
+A naive sheet body branches on `data ? <Form /> : <NotFound />` and shows the "not found" banner for one frame before the effect commits and the query starts. The gate combines the `called` flag with a `variables.id` equality check (for race safety) into the body's `loading` decision. Both `/admin/users` and `/admin/roles` had identical copies of this logic, so it lives in one shared helper — `frontend/src/lib/url/use-sheet-target-loading.ts`:
+
+```ts
+type SheetTargetQueryState = {
+  called: boolean;
+  variables: { id: string | number } | undefined;
+  loading: boolean;
+};
+
+function useSheetTargetLoading(
+  id: string | null,
+  query: SheetTargetQueryState,
+): { matchesSheet: boolean; loading: boolean };
+```
+
+Consumers pass the currently-open sheet id (or `null`) and the lazy query's `called` / `variables` / `loading` fields:
 
 ```ts
 const [
@@ -121,14 +136,16 @@ const [
   },
 ] = useLazyQuery(AdminRoleQuery, { fetchPolicy: "no-cache" });
 
-const loadRoleMatchesSheet = editId !== null && loadRoleVariables?.id === editId;
-const editRoleLoading =
-  loadingEditRole || (editId !== null && (!loadRoleCalled || !loadRoleMatchesSheet));
+const { loading: editRoleLoading } = useSheetTargetLoading(editId, {
+  called: loadRoleCalled,
+  variables: loadRoleVariables,
+  loading: loadingEditRole,
+});
 
 <EditRoleSheetBody loading={editRoleLoading} role={editRole} ... />
 ```
 
-The body then renders "Loading..." until the effect fires the query, the query settles, *and* the result's variables match the currently-open sheet. Only after all three does the body branch on `role ? <Form /> : <NotFound />`.
+The helper reports `loading` until the effect fires the query, the query settles, *and* the result's variables match the currently-open sheet (`matchesSheet`). Only after all three does the body branch on `role ? <Form /> : <NotFound />`. It has its own isolated test (`use-sheet-target-loading.test.ts`) covering the closed / first-render / stale-id / matched / in-flight states.
 
 ## Race-guard: variable equality drops stale lazy-query results
 

--- a/frontend/src/app/admin/roles/admin-roles-client.tsx
+++ b/frontend/src/app/admin/roles/admin-roles-client.tsx
@@ -15,6 +15,7 @@ import { liftGraphQLCodes } from "@/lib/apollo/graphql-errors";
 import type { ValidationError } from "@/lib/forms/use-sheet-form";
 import { useUndoDelete } from "@/lib/undo-delete";
 import { useSheetSearchParam } from "@/lib/url/use-sheet-search-param";
+import { useSheetTargetLoading } from "@/lib/url/use-sheet-target-loading";
 import { SYSTEM_ROLE_NAMES } from "./queries";
 import { type AuthKind, useRoleMutations } from "./use-role-mutations";
 
@@ -253,14 +254,15 @@ export function AdminRolesClient({ initialRoles }: Props) {
   const loadedEditRole = editRoleData?.role as unknown as RoleItem | undefined;
   const editRole = state.mode === "edit" && loadedEditRole?.id === state.id ? loadedEditRole : null;
   const editQueryErrorBanner = getBackendErrorBanner(editRoleQueryError);
-  // The lazy query is fired inside a `useEffect`, so on the first render
-  // after `?edit=<id>` lands, `loadingEditRole` is still false. Treat the
-  // "called for the current id" gap as loading so the body does not flash
-  // its `Role not found` branch before the query is in flight.
-  // Mirror of admin-users-client.tsx's `editUserCalled` / `editUserResultMatchesSheet` gate.
-  const loadRoleMatchesSheet = editId !== null && loadRoleVariables?.id === editId;
-  const editRoleLoading =
-    loadingEditRole || (editId !== null && (!loadRoleCalled || !loadRoleMatchesSheet));
+  // The lazy query is fired inside a `useEffect`, so on the first render after
+  // `?edit=<id>` lands, `loadingEditRole` is still false. `useSheetTargetLoading`
+  // treats that "called for the current id" gap as loading so the body does not
+  // flash its `Role not found` branch before the query is in flight.
+  const { loading: editRoleLoading } = useSheetTargetLoading(editId, {
+    called: loadRoleCalled,
+    variables: loadRoleVariables,
+    loading: loadingEditRole,
+  });
 
   function handleDelete(id: string) {
     const index = roles.findIndex((r) => r.id === id);

--- a/frontend/src/app/admin/users/admin-users-client.tsx
+++ b/frontend/src/app/admin/users/admin-users-client.tsx
@@ -21,6 +21,7 @@ import {
 import { EMPTY_PAGE_INFO } from "@/lib/pagination/empty-page-info";
 import { useConnectionPagination } from "@/lib/pagination/use-connection-pagination";
 import { useSheetSearchParam } from "@/lib/url/use-sheet-search-param";
+import { useSheetTargetLoading } from "@/lib/url/use-sheet-target-loading";
 import { AdminUserProfileSheet } from "./admin-user-profile-sheet";
 import { type AdminUserListItem, AdminUserRow } from "./admin-user-row";
 import { AdminUsersSkeleton } from "./admin-users-skeleton";
@@ -186,7 +187,11 @@ export function AdminUsersClient() {
       }
     : null;
   const sheetUser = editUser?.id === editUserId ? editUser : null;
-  const editUserResultMatchesSheet = editUserId !== null && editUserVariables?.id === editUserId;
+  const { loading: editUserSheetLoading } = useSheetTargetLoading(editUserId, {
+    called: editUserCalled,
+    variables: editUserVariables,
+    loading: editUserLoading,
+  });
   const editUserErrorKind = classifyQueryError(editUserError);
   const editUserBannerError = formatEditUserBannerError(
     editUserErrorKind,
@@ -280,10 +285,7 @@ export function AdminUsersClient() {
       <AdminUserProfileSheet
         open={editUserId !== null}
         user={sheetUser}
-        loading={
-          editUserLoading ||
-          (editUserId !== null && (!editUserCalled || !editUserResultMatchesSheet))
-        }
+        loading={editUserSheetLoading}
         allRoles={roleOptions}
         queryError={editUserBannerError}
         onDismiss={() => sheet.close()}

--- a/frontend/src/lib/url/use-sheet-target-loading.test.ts
+++ b/frontend/src/lib/url/use-sheet-target-loading.test.ts
@@ -1,0 +1,70 @@
+// @vitest-environment happy-dom
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { useSheetTargetLoading } from "./use-sheet-target-loading";
+
+describe("useSheetTargetLoading", () => {
+  it("is not loading and does not match when no sheet is open", () => {
+    const { result } = renderHook(() =>
+      useSheetTargetLoading(null, { called: false, variables: undefined, loading: false }),
+    );
+
+    expect(result.current).toEqual({ matchesSheet: false, loading: false });
+  });
+
+  it("gates as loading on the first render before the firing effect runs", () => {
+    // URL just landed on ?edit=<id>: called is still false, no variables yet.
+    const { result } = renderHook(() =>
+      useSheetTargetLoading("user-1", { called: false, variables: undefined, loading: false }),
+    );
+
+    expect(result.current).toEqual({ matchesSheet: false, loading: true });
+  });
+
+  it("gates as loading while the query's variables still target a previous id", () => {
+    // Switched from ?edit=user-1 to ?edit=user-2 before the first query settled.
+    const { result } = renderHook(() =>
+      useSheetTargetLoading("user-2", {
+        called: true,
+        variables: { id: "user-1" },
+        loading: false,
+      }),
+    );
+
+    expect(result.current).toEqual({ matchesSheet: false, loading: true });
+  });
+
+  it("resolves once the settled result matches the open sheet id", () => {
+    const { result } = renderHook(() =>
+      useSheetTargetLoading("user-1", {
+        called: true,
+        variables: { id: "user-1" },
+        loading: false,
+      }),
+    );
+
+    expect(result.current).toEqual({ matchesSheet: true, loading: false });
+  });
+
+  it("stays loading while the query itself is in flight, even for a matching id", () => {
+    const { result } = renderHook(() =>
+      useSheetTargetLoading("role-1", {
+        called: true,
+        variables: { id: "role-1" },
+        loading: true,
+      }),
+    );
+
+    expect(result.current).toEqual({ matchesSheet: true, loading: true });
+  });
+
+  it("uses strict equality: a numeric variable id does not match a string sheet id", () => {
+    // Generated query variables type ids as `string | number`; the gate uses
+    // strict `===`, so a numeric `7` never matches the string sheet id `"7"`.
+    const { result } = renderHook(() =>
+      useSheetTargetLoading("7", { called: true, variables: { id: 7 }, loading: false }),
+    );
+
+    expect(result.current).toEqual({ matchesSheet: false, loading: true });
+  });
+});

--- a/frontend/src/lib/url/use-sheet-target-loading.ts
+++ b/frontend/src/lib/url/use-sheet-target-loading.ts
@@ -1,0 +1,55 @@
+"use client";
+
+/**
+ * Loading gate for a lazily-fetched edit-sheet target row.
+ *
+ * When a listing page opens its edit sheet via `?edit=<id>`, the target row is
+ * fetched by a `useLazyQuery` fired inside a `useEffect`. Between the URL change
+ * and that effect committing, the lazy query reports `loading === false`,
+ * `called === false`, and no data — so a naive `data ? <Form/> : <NotFound/>`
+ * body flashes its not-found branch for one frame. This helper collapses the
+ * two "still resolving the target row" states into a single `loading` flag:
+ *
+ *   1. the firing effect has not run yet (`!called`), and
+ *   2. the settled result belongs to a previously-open id, not the current one
+ *      (`!matchesSheet`) — the race-guard for switching `?edit=<id>` mid-flight.
+ *
+ * `matchesSheet` is `true` once the lazy query's own `variables.id` equals the
+ * currently-open sheet id, i.e. the settled result belongs to the open sheet.
+ *
+ * Shared by `admin-users-client.tsx` and `admin-roles-client.tsx`. See
+ * `docs/frontend/url-backed-sheet-state.md` for the full rationale.
+ */
+export type SheetTargetQueryState = {
+  /** `useLazyQuery`'s `called` flag — false until the firing effect runs. */
+  called: boolean;
+  /**
+   * `useLazyQuery`'s current `variables` — carries the last-fired `id`. The
+   * generated type widens `id` to optional (`Partial<Exact<…>>`) before the
+   * query has ever fired, so `id` may be `undefined`.
+   */
+  variables: { id?: string | number } | undefined;
+  /** `useLazyQuery`'s `loading` flag. */
+  loading: boolean;
+};
+
+export type SheetTargetLoading = {
+  /** The settled result's `variables.id` matches the currently-open sheet id. */
+  matchesSheet: boolean;
+  /** True while the target row is still resolving; drives the sheet's loading branch. */
+  loading: boolean;
+};
+
+/**
+ * @param id      The currently-open sheet's edit id, or `null` when no edit
+ *                sheet is open.
+ * @param query   The lazy query's `called` / `variables` / `loading` fields.
+ */
+export function useSheetTargetLoading(
+  id: string | null,
+  query: SheetTargetQueryState,
+): SheetTargetLoading {
+  const matchesSheet = id !== null && query.variables?.id === id;
+  const loading = query.loading || (id !== null && (!query.called || !matchesSheet));
+  return { matchesSheet, loading };
+}


### PR DESCRIPTION
## Summary

The admin users and roles clients duplicated the "resolving the `?edit=<id>` target row" loading
gate. This extracts a shared hook next to `use-sheet-search-param`.

## Changes

- `frontend/src/lib/url/use-sheet-target-loading.ts` — **new** hook encapsulating the edit-target
  loading gate. (+ co-located test.)
- `frontend/src/app/admin/users/admin-users-client.tsx`,
  `frontend/src/app/admin/roles/admin-roles-client.tsx` — consume the hook.
- `docs/frontend/url-backed-sheet-state.md` — document the new helper.

## Test plan

- `tsc --noEmit`, `biome check --error-on-warnings`, `knip`, `next build` — pass
- `vitest run` — full suite green (both admin clients' tests + broad tests).

Closes #906
