### PR TITLE
refactor(frontend): extract SkeletonRows so public listing skeletons reuse the ListSkeleton row loop

### DIFF
--- a/frontend/src/app/cardgroups/_components/cardgroups-skeleton.tsx
+++ b/frontend/src/app/cardgroups/_components/cardgroups-skeleton.tsx
@@ -1,3 +1,4 @@
+import { SkeletonRows } from "@/components/layout/list-skeleton";
 import { ListingPageShell } from "@/components/layout/listing-page-shell";
 import { Skeleton } from "@/components/ui/skeleton";
 
@@ -12,20 +13,18 @@ export function CardgroupsSkeleton() {
       primaryActions={<Skeleton className="hidden h-10 w-40 md:inline-flex" />}
       toolbar={<Skeleton className="h-10 w-full max-w-sm" />}
     >
-      <ul
-        className="space-y-3"
-        aria-busy="true"
-        aria-label="Loading cardgroups"
-        data-testid="cardgroups-skeleton"
-      >
-        {Array.from({ length: 5 }).map((_, i) => (
-          // biome-ignore lint/suspicious/noArrayIndexKey: static placeholder rows have no stable id.
-          <li key={i} className="rounded-lg border border-border p-4">
+      <SkeletonRows
+        rowCount={5}
+        ariaLabel="Loading cardgroups"
+        testId="cardgroups-skeleton"
+        rowClassName="rounded-lg border border-border p-4"
+        renderRow={() => (
+          <>
             <Skeleton className="h-5 w-2/3" />
             <Skeleton className="mt-2 h-4 w-1/3" />
-          </li>
-        ))}
-      </ul>
+          </>
+        )}
+      />
     </ListingPageShell>
   );
 }

--- a/frontend/src/app/catalog/_components/catalog-skeleton.tsx
+++ b/frontend/src/app/catalog/_components/catalog-skeleton.tsx
@@ -1,3 +1,4 @@
+import { SkeletonRows } from "@/components/layout/list-skeleton";
 import { ListingPageShell } from "@/components/layout/listing-page-shell";
 import { Skeleton } from "@/components/ui/skeleton";
 
@@ -12,15 +13,14 @@ export function CatalogSkeleton() {
       title={<Skeleton className="h-8 w-40" />}
       toolbar={<Skeleton className="h-10 w-full max-w-sm" />}
     >
-      <ul
+      <SkeletonRows
+        rowCount={6}
+        ariaLabel="Loading catalog"
+        testId="catalog-skeleton"
         className="space-y-2"
-        aria-busy="true"
-        aria-label="Loading catalog"
-        data-testid="catalog-skeleton"
-      >
-        {Array.from({ length: 6 }).map((_, i) => (
-          // biome-ignore lint/suspicious/noArrayIndexKey: static placeholder rows have no stable id.
-          <li key={i} className="rounded-md border border-border p-4 sm:py-3">
+        rowClassName="rounded-md border border-border p-4 sm:py-3"
+        renderRow={() => (
+          <>
             <div className="flex items-baseline gap-3">
               <Skeleton className="h-5 min-w-0 flex-1" />
               <Skeleton className="h-5 w-14 shrink-0" />
@@ -28,9 +28,9 @@ export function CatalogSkeleton() {
             <div className="mt-1.5 flex items-center gap-2">
               <Skeleton className="h-4 w-32" />
             </div>
-          </li>
-        ))}
-      </ul>
+          </>
+        )}
+      />
     </ListingPageShell>
   );
 }

--- a/frontend/src/components/layout/list-skeleton.test.tsx
+++ b/frontend/src/components/layout/list-skeleton.test.tsx
@@ -1,7 +1,71 @@
 // @vitest-environment happy-dom
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import { ListSkeleton } from "./list-skeleton";
+import { ListSkeleton, SkeletonRows } from "./list-skeleton";
+
+describe("<SkeletonRows>", () => {
+  it("renders a busy list with the provided aria-label and testId", () => {
+    render(
+      <SkeletonRows
+        rowCount={4}
+        ariaLabel="Loading cardgroups"
+        testId="cardgroups-skeleton"
+        renderRow={() => <div data-testid="row-body" />}
+      />,
+    );
+
+    const list = screen.getByTestId("cardgroups-skeleton");
+    expect(list.tagName).toBe("UL");
+    expect(list).toHaveAttribute("aria-busy", "true");
+    expect(list).toHaveAccessibleName("Loading cardgroups");
+    expect(screen.getAllByTestId("row-body")).toHaveLength(4);
+  });
+
+  it("applies the default space-y-3 list spacing when no className is passed", () => {
+    render(
+      <SkeletonRows
+        rowCount={1}
+        ariaLabel="Loading cardgroups"
+        testId="cardgroups-skeleton"
+        renderRow={() => <div />}
+      />,
+    );
+
+    expect(screen.getByTestId("cardgroups-skeleton")).toHaveClass("space-y-3");
+  });
+
+  it("merges className onto the outer <ul> over the default spacing", () => {
+    render(
+      <SkeletonRows
+        rowCount={1}
+        ariaLabel="Loading catalog"
+        testId="catalog-skeleton"
+        className="space-y-2"
+        renderRow={() => <div />}
+      />,
+    );
+
+    expect(screen.getByTestId("catalog-skeleton")).toHaveClass("space-y-2");
+  });
+
+  it("applies rowClassName to each placeholder <li> verbatim", () => {
+    render(
+      <SkeletonRows
+        rowCount={3}
+        ariaLabel="Loading cardgroups"
+        testId="cardgroups-skeleton"
+        rowClassName="rounded-lg border border-border p-4"
+        renderRow={() => <div />}
+      />,
+    );
+
+    const items = screen.getByTestId("cardgroups-skeleton").querySelectorAll("li");
+    expect(items).toHaveLength(3);
+    for (const item of items) {
+      expect(item).toHaveClass("rounded-lg", "border", "border-border", "p-4");
+    }
+  });
+});
 
 describe("<ListSkeleton>", () => {
   it("renders a busy list with the provided aria-label and testId", () => {

--- a/frontend/src/components/layout/list-skeleton.tsx
+++ b/frontend/src/components/layout/list-skeleton.tsx
@@ -2,6 +2,53 @@ import type { ReactNode } from "react";
 import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
 
+interface SkeletonRowsProps {
+  /** Number of placeholder rows to render. */
+  rowCount: number;
+  /** Accessible name for the busy list (e.g. "Loading users"). */
+  ariaLabel: string;
+  /** `data-testid` for the busy list (e.g. "admin-users-skeleton"). */
+  testId: string;
+  /** Renders the per-row body. Called once per placeholder row. */
+  renderRow: () => ReactNode;
+  /** Optional class merge for the outer `<ul>` (e.g. list spacing). Defaults to `space-y-3`. */
+  className?: string;
+  /** Optional class merge for each placeholder `<li>`. */
+  rowClassName?: string;
+}
+
+/**
+ * The canonical busy-list row loop for listing skeletons: a `<ul aria-busy>`
+ * plus an `Array.from` placeholder-row loop. Single-sources the
+ * `noArrayIndexKey` biome-ignore for static placeholder rows so individual
+ * skeletons no longer repeat it. Consumed by `ListSkeleton` and by the public
+ * `/cardgroups` and `/catalog` skeletons.
+ */
+export function SkeletonRows({
+  rowCount,
+  ariaLabel,
+  testId,
+  renderRow,
+  className,
+  rowClassName,
+}: SkeletonRowsProps) {
+  return (
+    <ul
+      className={cn("space-y-3", className)}
+      aria-busy="true"
+      aria-label={ariaLabel}
+      data-testid={testId}
+    >
+      {Array.from({ length: rowCount }).map((_, i) => (
+        // biome-ignore lint/suspicious/noArrayIndexKey: static placeholder rows have no stable id.
+        <li key={i} className={rowClassName}>
+          {renderRow()}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
 interface ListSkeletonProps {
   /** Number of placeholder rows to render. Defaults to 5. */
   rowCount?: number;
@@ -57,14 +104,13 @@ export function ListSkeleton({
         </>
       )}
 
-      <ul className="space-y-3" aria-busy="true" aria-label={ariaLabel} data-testid={testId}>
-        {Array.from({ length: rowCount }).map((_, i) => (
-          // biome-ignore lint/suspicious/noArrayIndexKey: static placeholder rows have no stable id.
-          <li key={i} className={cn("rounded-md border border-border", rowClassName)}>
-            {renderRow()}
-          </li>
-        ))}
-      </ul>
+      <SkeletonRows
+        rowCount={rowCount}
+        ariaLabel={ariaLabel}
+        testId={testId}
+        renderRow={renderRow}
+        rowClassName={cn("rounded-md border border-border", rowClassName)}
+      />
     </main>
   );
 }


### PR DESCRIPTION
## Summary

The public cardgroups/catalog loading skeletons re-implemented the `ListSkeleton` row loop. This
extracts a `SkeletonRows` sub-component so the public skeletons reuse it.

## Changes

- `frontend/src/components/layout/list-skeleton.tsx` — add a `SkeletonRows` sub-component
  parameterizing the repeated row loop. (+ `list-skeleton.test.tsx` updated.)
- `frontend/src/app/cardgroups/_components/cardgroups-skeleton.tsx`,
  `frontend/src/app/catalog/_components/catalog-skeleton.tsx` — reuse `SkeletonRows`. Visual output
  (row count / height / spacing) is unchanged.

## Test plan

- `tsc --noEmit`, `biome check --error-on-warnings`, `knip`, `next build` — pass
- `vitest run` — full suite green.

Closes #911
