### PR TITLE
fix(frontend): align the rail Logout row with Profile

### DIFF
--- a/frontend/src/app/_components/logout-button.tsx
+++ b/frontend/src/app/_components/logout-button.tsx
@@ -1,37 +1,21 @@
 "use client";
 
 import { LogOut } from "lucide-react";
-import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
-import { createSupabaseBrowserClient } from "@/lib/supabase/client";
+import { useLogout } from "./use-logout";
 
 export function LogoutButton() {
   const t = useTranslations("Nav");
-  const router = useRouter();
-
-  async function handleLogout() {
-    const supabase = createSupabaseBrowserClient();
-    const { error } = await supabase.auth.signOut();
-    if (error) {
-      console.error("[logout] signOut failed:", error.message);
-      return;
-    }
-    // Navigate to /login first so the layout re-renders for that URL — the
-    // HeaderSignInLink suppresses itself on /login, avoiding the brief
-    // "Sign in" flash that occurs when refresh() re-renders the protected
-    // page's anonymous header before its server-side redirect kicks in.
-    router.replace("/login");
-    router.refresh();
-  }
+  const logout = useLogout();
 
   return (
-    // Quiet secondary sign-out, tuned to the drawer's nav-row rhythm (under the
-    // Profile link). The desktop rail's SidebarMenuButton rows run a touch
-    // tighter — the small cross-surface mismatch is intentional, not worth
-    // re-spelling per surface.
+    // Quiet secondary sign-out for the mobile drawer, tuned to the drawer's
+    // nav-row rhythm (px-3 / gap-3, matching the Profile link above it). The
+    // desktop rail renders its own Logout row as a SidebarMenuButton, so this
+    // component is drawer-only.
     <Button
-      onClick={handleLogout}
+      onClick={logout}
       type="button"
       variant="ghost"
       size="sm"

--- a/frontend/src/app/_components/use-logout.ts
+++ b/frontend/src/app/_components/use-logout.ts
@@ -1,0 +1,30 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useCallback } from "react";
+import { createSupabaseBrowserClient } from "@/lib/supabase/client";
+
+/**
+ * Sign the current user out, then return them to /login.
+ *
+ * Shared by the mobile drawer's `LogoutButton` and the desktop rail's footer
+ * Logout row so the sign-out sequence is spelled once. Navigating to /login
+ * *before* refresh() re-renders the layout for that URL: the HeaderSignInLink
+ * suppresses itself on /login, avoiding the brief "Sign in" flash that occurs
+ * when refresh() re-renders the protected page's anonymous header before its
+ * server-side redirect kicks in.
+ */
+export function useLogout() {
+  const router = useRouter();
+
+  return useCallback(async () => {
+    const supabase = createSupabaseBrowserClient();
+    const { error } = await supabase.auth.signOut();
+    if (error) {
+      console.error("[logout] signOut failed:", error.message);
+      return;
+    }
+    router.replace("/login");
+    router.refresh();
+  }, [router]);
+}

--- a/frontend/src/components/nav/global-rail.test.tsx
+++ b/frontend/src/components/nav/global-rail.test.tsx
@@ -20,14 +20,11 @@ vi.mock("next/navigation", () => ({
   usePathname: () => mockUsePathname(),
 }));
 
-// Mock LogoutButton — it reaches into Supabase/router which are not needed
-// here. Mirrors the pattern used in `logo-drawer.test.tsx`.
-vi.mock("@/app/_components/logout-button", () => ({
-  LogoutButton: () => (
-    <button type="button" data-testid="logout-button">
-      Sign out
-    </button>
-  ),
+// The rail's footer Logout row calls useLogout() for its onClick. Mock the hook
+// so the click can be asserted without reaching into Supabase/router.
+const mockLogout = vi.fn();
+vi.mock("@/app/_components/use-logout", () => ({
+  useLogout: () => mockLogout,
 }));
 
 import { SidebarProvider } from "@/components/ui/sidebar";
@@ -52,6 +49,7 @@ beforeEach(() => {
     })),
   });
   mockUsePathname.mockReturnValue("/");
+  mockLogout.mockReset();
 });
 
 afterEach(() => {
@@ -266,8 +264,8 @@ describe("<GlobalRail>", () => {
       expect(screen.queryByRole("link", { name: /users/i })).toBeNull();
       expect(screen.queryByRole("link", { name: /roles/i })).toBeNull();
 
-      // Negative: anonymous users get neither the LogoutButton nor an email line.
-      expect(screen.queryByTestId("logout-button")).toBeNull();
+      // Negative: anonymous users get neither the Logout row nor an email line.
+      expect(screen.queryByRole("button", { name: /logout/i })).toBeNull();
 
       // The logo link still renders so anonymous viewers can navigate home.
       expect(screen.getByRole("link", { name: /flamingo home/i })).toBeInTheDocument();
@@ -295,27 +293,49 @@ describe("<GlobalRail>", () => {
       expect(profileLink).toHaveAttribute("href", "/profile");
     });
 
-    it("renders the Logout button (mocked) in the footer", () => {
+    it("renders a Logout row in the footer as a SidebarMenuButton peer of Profile", () => {
       mockUsePathname.mockReturnValue("/");
       const { container } = renderRail({
         user: { email: "alice@example.com" },
         isAdmin: false,
       });
 
-      expect(within(getFooter(container)).getByTestId("logout-button")).toBeInTheDocument();
+      // Rendered as a native rail menu button (same markup as the Profile row
+      // above), not a bespoke ghost <Button> — this is what makes the left edge,
+      // gap, and height align with Profile.
+      const logoutBtn = within(getFooter(container)).getByRole("button", { name: /logout/i });
+      expect(logoutBtn).toHaveAttribute("data-sidebar", "menu-button");
     });
 
-    it("the Logout button's wrapping div carries the group-data-[collapsible=icon]:hidden class so the labelled button hides in the icon-only state", () => {
+    it("clicking the footer Logout row triggers sign-out", () => {
       mockUsePathname.mockReturnValue("/");
       const { container } = renderRail({
         user: { email: "alice@example.com" },
         isAdmin: false,
       });
 
-      const logoutBtn = within(getFooter(container)).getByTestId("logout-button");
-      const wrapper = logoutBtn.parentElement;
-      if (!wrapper) throw new Error("LogoutButton has no parent element");
-      expect(wrapper.className.includes("group-data-[collapsible=icon]:hidden")).toBe(true);
+      const logoutBtn = within(getFooter(container)).getByRole("button", { name: /logout/i });
+      act(() => {
+        fireEvent.click(logoutBtn);
+      });
+
+      expect(mockLogout).toHaveBeenCalledTimes(1);
+    });
+
+    it("keeps the Logout row mounted when the rail is collapsed (it collapses to an icon, not hidden)", () => {
+      mockUsePathname.mockReturnValue("/");
+      const { container } = renderRail(
+        { user: { email: "alice@example.com" }, isAdmin: false },
+        { defaultOpen: false },
+      );
+
+      // Unlike the old bespoke button (which lived in a
+      // group-data-[collapsible=icon]:hidden wrapper), the SidebarMenuButton
+      // stays in the DOM when collapsed and shows the icon + tooltip like every
+      // other rail item.
+      expect(
+        within(getFooter(container)).getByRole("button", { name: /logout/i }),
+      ).toBeInTheDocument();
     });
   });
 

--- a/frontend/src/components/nav/global-rail.tsx
+++ b/frontend/src/components/nav/global-rail.tsx
@@ -1,10 +1,11 @@
 "use client";
 
+import { LogOut } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { useEffect, useRef } from "react";
-import { LogoutButton } from "@/app/_components/logout-button";
+import { useLogout } from "@/app/_components/use-logout";
 import { FlamingoMark } from "@/components/brand/flamingo-mark";
 import {
   Sidebar,
@@ -41,6 +42,7 @@ export function GlobalRail({ user, isAdmin }: GlobalRailProps) {
   const t = useTranslations("Nav");
   const pathname = usePathname();
   const { state, setOpen, isMobile } = useSidebar();
+  const logout = useLogout();
 
   // Hover-flyout close timer. Use useRef (not useState) to avoid an async update
   // dropping a pointerenter that arrives in the same frame as the timeout fires
@@ -174,17 +176,22 @@ export function GlobalRail({ user, isAdmin }: GlobalRailProps) {
                 </SidebarMenuItem>
               );
             })}
-          </SidebarMenu>
 
-          {/*
-            Wrap LogoutButton in a div with the collapsed-hide class so the
-            button label collapses with the rail. The class is intentionally on
-            the wrapper, not on LogoutButton itself — that keeps LogoutButton
-            uncoupled from the rail's collapsed-state CSS group.
-          */}
-          <div className="group-data-[collapsible=icon]:hidden">
-            <LogoutButton />
-          </div>
+            {/*
+              Logout is an action, not a nav link, so it renders a <button>
+              (no `asChild`/`Link`) — but as a SidebarMenuButton it stays a
+              pixel-for-pixel peer of the Profile row above (same padding, gap,
+              height, hover background) and collapses to an icon + tooltip with
+              the rest of the rail. Sign-out logic is shared with the drawer's
+              LogoutButton via useLogout().
+            */}
+            <SidebarMenuItem>
+              <SidebarMenuButton type="button" onClick={logout} tooltip={t("logout")}>
+                <LogOut aria-hidden="true" />
+                <span>{t("logout")}</span>
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+          </SidebarMenu>
         </SidebarFooter>
       )}
 


### PR DESCRIPTION
## Summary

The desktop rail's footer rendered its Logout row with a bespoke `Button variant="ghost" size="sm"`
while the Profile row above used the rail's standard `SidebarMenuButton`. The two primitives differ
in geometry (`px-3`/`gap-3`/`h-9` vs `p-2`/`gap-2`/`h-8`), so the Logout icon and label sat ~4px to
the right of Profile and the row ran taller — and the ghost button read as an "invisible button" at
rest. This renders Logout as a `SidebarMenuButton` so it becomes a pixel-for-pixel peer of Profile.
The mobile drawer already aligned both rows (both `px-3`/`gap-3`) and is untouched.

## Changes

- `frontend/src/app/_components/use-logout.ts` — **new** hook holding the
  `signOut → router.replace("/login") → router.refresh()` sequence (and its /login-before-refresh
  rationale), so the sign-out flow is spelled once and shared by both Logout surfaces.
- `frontend/src/app/_components/logout-button.tsx` — the drawer button delegates to `useLogout()`;
  the stale "the desktop rail mismatch is intentional" comment is rewritten to note this component
  is now drawer-only.
- `frontend/src/components/nav/global-rail.tsx` — the footer Logout renders as a `SidebarMenuButton`
  (`<button onClick={logout}>` with `tooltip`, not a nav `Link`), matching Profile's left padding,
  icon-to-label gap, height, hover background, and collapse-to-icon behavior. The
  `group-data-[collapsible=icon]:hidden` wrapper is removed, so Logout collapses to an icon + tooltip
  like every other rail item instead of disappearing.

### Tests

- `frontend/src/components/nav/global-rail.test.tsx` — the mocked-`LogoutButton` testid is replaced
  with a `useLogout` spy; new assertions cover Logout rendering as `data-sidebar="menu-button"`,
  clicking it triggering sign-out, and it staying mounted (as an icon) when the rail is collapsed.
  The old collapsed-hide-wrapper test is deleted because that code path is gone.

## Test plan

- `tsc --noEmit`, `biome check --error-on-warnings`, `knip`, `next build` — pass
- `vitest run` — 203 files, 1887 tests pass (rail + drawer + app-shell + logout-button suites).

## Note

No linked issue — surfaced from a UI review of the rail footer alignment.
