### PR TITLE
feat(stats): add 365/30/7-day performance window switcher to /stats diagnostics

### DIFF
--- a/backend/graph/resolver/stats_helpers.go
+++ b/backend/graph/resolver/stats_helpers.go
@@ -64,6 +64,8 @@ func toLearningStatsModel(ctx context.Context, res *usecase.LearningStatsResult)
 		})
 	}
 
+	performance365 := toPerformanceMetricsModel(res.Windows.Days365)
+
 	return &model.LearningStats{
 		Mastery: &model.MasteryBreakdown{
 			InProgress:   res.Mastery.InProgress,
@@ -71,9 +73,16 @@ func toLearningStatsModel(ctx context.Context, res *usecase.LearningStatsResult)
 			Mature:       res.Mastery.Mature,
 			TotalStudied: res.Mastery.TotalStudied,
 		},
-		Decks:           decks,
-		OwnsAnyDeck:     res.OwnsAnyDeck,
-		Performance:     toPerformanceMetricsModel(res.Performance),
+		Decks:       decks,
+		OwnsAnyDeck: res.OwnsAnyDeck,
+		// Keep the legacy field populated until every independently deployed
+		// frontend has switched to performanceWindows.
+		Performance: performance365,
+		PerformanceWindows: &model.PerformanceWindows{
+			Days365: performance365,
+			Days30:  toPerformanceMetricsModel(res.Windows.Days30),
+			Days7:   toPerformanceMetricsModel(res.Windows.Days7),
+		},
 		StrugglingCards: struggling,
 	}, nil
 }

--- a/backend/graph/resolver/stats_resolver_test.go
+++ b/backend/graph/resolver/stats_resolver_test.go
@@ -277,25 +277,23 @@ func ctxWithCardLoaderError(base context.Context, loadErr error) context.Context
 	return loader.WithContext(base, loaders)
 }
 
-const myLearningStatsDiagnosticQuery = `{"query":"{ myLearningStats { mastery { totalStudied } performance { retentionRate successRate lapseRate studyStreak reviewCount avgDifficulty } strugglingCards { card { id front } lapses stability } } }"}`
+const myLearningStatsDiagnosticQuery = `{"query":"{ myLearningStats { mastery { totalStudied } performance { retentionRate successRate lapseRate studyStreak reviewCount avgDifficulty } performanceWindows { days365 { retentionRate successRate lapseRate studyStreak reviewCount avgDifficulty } days30 { retentionRate successRate lapseRate studyStreak reviewCount avgDifficulty } days7 { retentionRate successRate lapseRate studyStreak reviewCount avgDifficulty } } strugglingCards { card { id front } lapses stability } } }"}`
 
 // TestMyLearningStats_PerformanceAndStrugglingCards verifies the diagnostic half
-// of the response: the performance snapshot maps every metric field, and the
-// struggling-card list preserves the usecase order while hydrating each Card
-// from its id via the in-memory Card DataLoader.
+// of the response: all three performance snapshots map every metric field, the
+// legacy performance field remains an alias for days365 during the staged
+// rollout, and the struggling-card list preserves the usecase order while
+// hydrating each Card from its id via the in-memory Card DataLoader.
 func TestMyLearningStats_PerformanceAndStrugglingCards(t *testing.T) {
 	t.Parallel()
 
 	mock := &mockStatsUsecase{
 		result: &usecase.LearningStatsResult{
 			Mastery: service.MasteryBreakdown{TotalStudied: 3},
-			Performance: service.PerformanceMetrics{
-				SuccessRate:   0.8,
-				AvgDifficulty: 0.4,
-				RetentionRate: 0.9,
-				StudyStreak:   5,
-				LapseRate:     0.1,
-				ReviewCount:   42,
+			Windows: service.WindowedMetrics{
+				Days365: service.PerformanceMetrics{SuccessRate: 0.81, AvgDifficulty: 0.41, RetentionRate: 0.91, StudyStreak: 5, LapseRate: 0.11, ReviewCount: 365},
+				Days30:  service.PerformanceMetrics{SuccessRate: 0.82, AvgDifficulty: 0.42, RetentionRate: 0.92, StudyStreak: 5, LapseRate: 0.12, ReviewCount: 30},
+				Days7:   service.PerformanceMetrics{SuccessRate: 0.83, AvgDifficulty: 0.43, RetentionRate: 0.93, StudyStreak: 5, LapseRate: 0.13, ReviewCount: 7},
 			},
 			StrugglingCards: []service.StrugglingCard{
 				{CardID: "card-1", Lapses: 5, Stability: 2.5},
@@ -321,14 +319,34 @@ func TestMyLearningStats_PerformanceAndStrugglingCards(t *testing.T) {
 		t.Fatalf("expected data.myLearningStats, got nil; response: %v", resp)
 	}
 
-	perf, _ := stats["performance"].(map[string]any)
-	if perf == nil {
-		t.Fatalf("expected performance, got nil; response: %v", resp)
+	windows, _ := stats["performanceWindows"].(map[string]any)
+	if windows == nil {
+		t.Fatalf("expected performanceWindows, got nil; response: %v", resp)
 	}
-	if perf["retentionRate"] != float64(0.9) || perf["successRate"] != float64(0.8) ||
-		perf["lapseRate"] != float64(0.1) || perf["avgDifficulty"] != float64(0.4) ||
-		perf["studyStreak"] != float64(5) || perf["reviewCount"] != float64(42) {
-		t.Fatalf("performance metrics mismatch: %v", perf)
+	wants := map[string]map[string]float64{
+		"days365": {"retentionRate": 0.91, "successRate": 0.81, "lapseRate": 0.11, "avgDifficulty": 0.41, "studyStreak": 5, "reviewCount": 365},
+		"days30":  {"retentionRate": 0.92, "successRate": 0.82, "lapseRate": 0.12, "avgDifficulty": 0.42, "studyStreak": 5, "reviewCount": 30},
+		"days7":   {"retentionRate": 0.93, "successRate": 0.83, "lapseRate": 0.13, "avgDifficulty": 0.43, "studyStreak": 5, "reviewCount": 7},
+	}
+	for name, want := range wants {
+		perf, _ := windows[name].(map[string]any)
+		if perf == nil {
+			t.Fatalf("expected %s performance metrics, got nil; response: %v", name, resp)
+		}
+		for field, value := range want {
+			if perf[field] != value {
+				t.Fatalf("%s.%s = %v, want %v; metrics: %v", name, field, perf[field], value, perf)
+			}
+		}
+	}
+	legacy, _ := stats["performance"].(map[string]any)
+	if legacy == nil {
+		t.Fatalf("expected legacy performance field, got nil; response: %v", resp)
+	}
+	for field, value := range wants["days365"] {
+		if legacy[field] != value {
+			t.Fatalf("performance.%s = %v, want %v; metrics: %v", field, legacy[field], value, legacy)
+		}
 	}
 
 	struggling, _ := stats["strugglingCards"].([]any)

--- a/backend/internal/domain/service/user_performance.go
+++ b/backend/internal/domain/service/user_performance.go
@@ -166,6 +166,47 @@ type PerformanceMetrics struct {
 	ReviewCount   int
 }
 
+const (
+	performanceWindowDays30 = 30
+	performanceWindowDays7  = 7
+)
+
+// WindowedMetrics contains diagnostic snapshots for the trailing 365, 30, and
+// 7-day windows. The caller supplies the already-loaded 365-day swipe set.
+type WindowedMetrics struct {
+	Days365 PerformanceMetrics
+	Days30  PerformanceMetrics
+	Days7   PerformanceMetrics
+}
+
+// ComputeWindowedMetrics computes all diagnostic windows from one already-loaded
+// 365-day swipe set. Shorter windows include swipes exactly at their cutoff.
+// StudyStreak is calendar truth rather than a window-scoped metric, so the 30-
+// and 7-day snapshots always reuse the streak computed from the full set.
+func ComputeWindowedMetrics(swipes []domain.SwipeRecord, now time.Time) WindowedMetrics {
+	days30 := filterSwipesSince(swipes, now.AddDate(0, 0, -performanceWindowDays30))
+	days7 := filterSwipesSince(swipes, now.AddDate(0, 0, -performanceWindowDays7))
+
+	windows := WindowedMetrics{
+		Days365: ComputeMetrics(swipes, now),
+		Days30:  ComputeMetrics(days30, now),
+		Days7:   ComputeMetrics(days7, now),
+	}
+	windows.Days30.StudyStreak = windows.Days365.StudyStreak
+	windows.Days7.StudyStreak = windows.Days365.StudyStreak
+	return windows
+}
+
+func filterSwipesSince(swipes []domain.SwipeRecord, cutoff time.Time) []domain.SwipeRecord {
+	filtered := make([]domain.SwipeRecord, 0, len(swipes))
+	for _, swipe := range swipes {
+		if !swipe.ReviewedAt.Before(cutoff) {
+			filtered = append(filtered, swipe)
+		}
+	}
+	return filtered
+}
+
 func ComputeMetrics(swipes []domain.SwipeRecord, now time.Time) PerformanceMetrics {
 	if len(swipes) == 0 {
 		return PerformanceMetrics{

--- a/backend/internal/domain/service/user_performance_test.go
+++ b/backend/internal/domain/service/user_performance_test.go
@@ -129,6 +129,65 @@ func TestComputeMetrics(t *testing.T) {
 	}
 }
 
+func TestComputeWindowedMetrics(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 18, 3, 0, 0, 0, time.UTC)
+	reviewState := state(5, 1, 1, domain.FSRSPhaseReview)
+
+	t.Run("includes exact cutoff boundaries", func(t *testing.T) {
+		t.Parallel()
+
+		swipes := []domain.SwipeRecord{
+			swipe(domain.RatingGood, now, reviewState),
+			swipe(domain.RatingGood, now.AddDate(0, 0, -7), reviewState),
+			swipe(domain.RatingGood, now.AddDate(0, 0, -7).Add(-time.Nanosecond), reviewState),
+			swipe(domain.RatingGood, now.AddDate(0, 0, -30), reviewState),
+			swipe(domain.RatingGood, now.AddDate(0, 0, -30).Add(-time.Nanosecond), reviewState),
+		}
+
+		got := ComputeWindowedMetrics(swipes, now)
+
+		require.Equal(t, 5, got.Days365.ReviewCount)
+		require.Equal(t, 4, got.Days30.ReviewCount)
+		require.Equal(t, 2, got.Days7.ReviewCount)
+	})
+
+	t.Run("pins shorter-window streaks to the 365-day streak", func(t *testing.T) {
+		t.Parallel()
+
+		swipes := make([]domain.SwipeRecord, 0, 40)
+		for daysAgo := 0; daysAgo < 40; daysAgo++ {
+			swipes = append(swipes, swipe(domain.RatingGood, now.AddDate(0, 0, -daysAgo), reviewState))
+		}
+
+		got := ComputeWindowedMetrics(swipes, now)
+
+		require.Equal(t, 40, got.Days365.StudyStreak)
+		require.Equal(t, got.Days365.StudyStreak, got.Days30.StudyStreak)
+		require.Equal(t, got.Days365.StudyStreak, got.Days7.StudyStreak)
+	})
+
+	t.Run("keeps empty shorter windows neutral with a non-empty 365-day set", func(t *testing.T) {
+		t.Parallel()
+
+		got := ComputeWindowedMetrics([]domain.SwipeRecord{
+			swipe(domain.RatingEasy, now.AddDate(0, 0, -31), reviewState),
+		}, now)
+
+		require.Equal(t, 1, got.Days365.ReviewCount)
+		require.Equal(t, PerformanceMetrics{SuccessRate: 0.5, AvgDifficulty: 0.5, RetentionRate: 0.5}, got.Days30)
+		require.Equal(t, PerformanceMetrics{SuccessRate: 0.5, AvgDifficulty: 0.5, RetentionRate: 0.5}, got.Days7)
+	})
+
+	t.Run("returns neutral snapshots for fully empty input", func(t *testing.T) {
+		t.Parallel()
+
+		neutral := PerformanceMetrics{SuccessRate: 0.5, AvgDifficulty: 0.5, RetentionRate: 0.5}
+		require.Equal(t, WindowedMetrics{Days365: neutral, Days30: neutral, Days7: neutral}, ComputeWindowedMetrics(nil, now))
+	})
+}
+
 // TestComputeMetrics_JSTLearnDayBoundary proves the study streak and distinct-day
 // counting bucket on the canonical JST learn-day, not on UTC. A swipe at 00:30 JST
 // (= the previous day 15:30 UTC) must count on its JST calendar day, and a streak

--- a/backend/internal/usecase/stats.go
+++ b/backend/internal/usecase/stats.go
@@ -35,7 +35,7 @@ type statsFSRSRepo interface {
 }
 
 // statsSwipeRepo is the narrow slice of the swipe-record repository the stats
-// aggregate needs to compute the diagnostic performance snapshot over a window.
+// aggregate needs to compute the diagnostic performance snapshots.
 type statsSwipeRepo interface {
 	ListByUserSince(ctx context.Context, userID string, since time.Time) ([]*domain.SwipeRecord, error)
 }
@@ -78,7 +78,7 @@ type LearningStatsResult struct {
 	// from a user who created a deck but has not added cards yet — Decks omits
 	// empty decks, so Decks alone cannot make that distinction.
 	OwnsAnyDeck     bool
-	Performance     service.PerformanceMetrics
+	Windows         service.WindowedMetrics
 	StrugglingCards []service.StrugglingCard
 }
 
@@ -105,9 +105,9 @@ func (u *statsUsecase) MyLearningStats(ctx context.Context) (*LearningStatsResul
 		return nil, eris.Wrap(err, "usecase: stats: aggregate mastery")
 	}
 
-	// Diagnostic half: a performance snapshot over the trailing statsWindowDays
-	// calendar window (so studyStreak reflects real days, not a swipe count) plus
-	// the struggling-card ranking derived from the FSRS rows already loaded above.
+	// Diagnostic half: performance snapshots derived from one trailing
+	// statsWindowDays calendar read (so studyStreak reflects real days, not a
+	// swipe count) plus the struggling-card ranking from the loaded FSRS rows.
 	now := u.clock.Now()
 	swipes, err := u.swipeRepo.ListByUserSince(ctx, caller.Sub, now.AddDate(0, 0, -statsWindowDays))
 	if err != nil {
@@ -125,7 +125,7 @@ func (u *statsUsecase) MyLearningStats(ctx context.Context) (*LearningStatsResul
 		Mastery:         mastery,
 		Decks:           decks,
 		OwnsAnyDeck:     count > 0,
-		Performance:     service.ComputeMetrics(swipeRecordsByValue(swipes), now),
+		Windows:         service.ComputeWindowedMetrics(swipeRecordsByValue(swipes), now),
 		StrugglingCards: service.TopStruggling(states, strugglingCardsLimit),
 	}, nil
 }

--- a/backend/internal/usecase/stats_test.go
+++ b/backend/internal/usecase/stats_test.go
@@ -219,7 +219,7 @@ func TestStatsUsecase_MyLearningStats_WindowsSwipesByStatsWindowDays(t *testing.
 	assert.Empty(t, res.StrugglingCards)
 }
 
-func TestStatsUsecase_MyLearningStats_PerformanceReflectsComputeMetrics(t *testing.T) {
+func TestStatsUsecase_MyLearningStats_WindowsReflectComputeWindowedMetrics(t *testing.T) {
 	t.Parallel()
 	fixedNow := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
 	state := domain.NewFSRSStateForNewCard(fixedNow)
@@ -235,9 +235,9 @@ func TestStatsUsecase_MyLearningStats_PerformanceReflectsComputeMetrics(t *testi
 	require.NoError(t, err)
 	require.NotNil(t, res)
 
-	want := service.ComputeMetrics(swipeRecordsByValue(swipes), fixedNow)
-	assert.Equal(t, want, res.Performance,
-		"Performance is ComputeMetrics over the windowed swipes at the injected now")
+	want := service.ComputeWindowedMetrics(swipeRecordsByValue(swipes), fixedNow)
+	assert.Equal(t, want, res.Windows,
+		"Windows is ComputeWindowedMetrics over the loaded swipes at the injected now")
 }
 
 func TestStatsUsecase_MyLearningStats_StrugglingCardsFromFSRSRows(t *testing.T) {

--- a/frontend/__tests__/stats.test.tsx
+++ b/frontend/__tests__/stats.test.tsx
@@ -57,15 +57,36 @@ const populatedStats: MyLearningStatsQuery["myLearningStats"] = {
       matureCards: 20,
     },
   ],
-  performance: {
-    __typename: "PerformanceMetrics",
-    retentionRate: 0.78,
-    successRate: 0.84,
-    lapseRate: 0.12,
-    studyStreak: 9,
-    reviewCount: 1430,
-    // Served normalized to 0..1 by the backend (rescaled ×10 for display).
-    avgDifficulty: 0.62,
+  performanceWindows: {
+    __typename: "PerformanceWindows",
+    days365: {
+      __typename: "PerformanceMetrics",
+      retentionRate: 0.78,
+      successRate: 0.84,
+      lapseRate: 0.12,
+      studyStreak: 9,
+      reviewCount: 1430,
+      // Served normalized to 0..1 by the backend (rescaled ×10 for display).
+      avgDifficulty: 0.62,
+    },
+    days30: {
+      __typename: "PerformanceMetrics",
+      retentionRate: 0.75,
+      successRate: 0.8,
+      lapseRate: 0.15,
+      studyStreak: 9,
+      reviewCount: 300,
+      avgDifficulty: 0.6,
+    },
+    days7: {
+      __typename: "PerformanceMetrics",
+      retentionRate: 0.7,
+      successRate: 0.76,
+      lapseRate: 0.2,
+      studyStreak: 9,
+      reviewCount: 70,
+      avgDifficulty: 0.58,
+    },
   },
   strugglingCards: [
     {

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -430,7 +430,7 @@
     "diagnosticsLapse": "Lapse",
     "diagnosticsLapseCaption": "forgotten again",
     "diagnosticsStreak": "Streak",
-    "diagnosticsStreakCaption": "consecutive days",
+    "diagnosticsStreakCaption": "365-day streak",
     "diagnosticsStreakValue": "{days, plural, one {# day} other {# days}}",
     "diagnosticsReviews": "Reviews",
     "diagnosticsReviewsCaption": "total swipes",
@@ -439,8 +439,8 @@
     "diagnosticsRetentionHint": "Share of reviews you recalled correctly by their due date. Higher means memory is holding as planned.",
     "diagnosticsSuccessHint": "Share of swipes you rated a success. A rough gauge of how confident your answers felt.",
     "diagnosticsLapseHint": "Among already-learned cards, the share you forgot on review. Lower means they're sticking.",
-    "diagnosticsStreakHint": "Days you've studied without a gap, up to today. Missing a day resets it.",
-    "diagnosticsReviewsHint": "Your total swipes over the last 365 days.",
+    "diagnosticsStreakHint": "Days you've studied without a gap, up to today, calculated from the last 365 days regardless of the selected period. Missing a day resets it.",
+    "diagnosticsReviewsHint": "Your total swipes over the last {days} days.",
     "diagnosticsAvgDifficultyHint": "Average \"hardness\" FSRS assigns your cards (0–10; higher is harder).",
     "diagnosticsHintAriaLabel": "About {metric}",
     "perDeckHeading": "Per-deck acquisition",
@@ -460,7 +460,9 @@
     "emptyDeckBody": "You created a deck but it has no cards. Add a few cards, then study them — your mastery and progress will appear here.",
     "emptyDeckCta": "Add cards",
     "diagnosticsHeading": "Diagnostics",
-    "diagnosticsWindow": "Last 365 days",
-    "diagnosticsNoActivity": "Not enough recent activity in the last 365 days."
+    "diagnosticsWindowOption": "{days}d",
+    "diagnosticsWindowOptionAria": "Last {days} days",
+    "diagnosticsWindowGroupAria": "Diagnostics period",
+    "diagnosticsNoActivityInWindow": "No reviews in the last {days} days."
   }
 }

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -430,7 +430,7 @@
     "diagnosticsLapse": "忘却率",
     "diagnosticsLapseCaption": "再び忘れた割合",
     "diagnosticsStreak": "連続学習",
-    "diagnosticsStreakCaption": "連続した日数",
+    "diagnosticsStreakCaption": "365日基準の連続日数",
     "diagnosticsStreakValue": "{days}日",
     "diagnosticsReviews": "復習回数",
     "diagnosticsReviewsCaption": "スワイプの合計",
@@ -439,8 +439,8 @@
     "diagnosticsRetentionHint": "復習の予定日までに正しく思い出せたカードの割合です。高いほど記憶が計画どおり保持できています。",
     "diagnosticsSuccessHint": "スワイプ評価が「できた」だった割合です。学習の手ごたえの目安になります。",
     "diagnosticsLapseHint": "一度覚えたカードの復習で「忘れた」を出した割合です。低いほどしっかり定着しています。",
-    "diagnosticsStreakHint": "今日まで途切れずに学習を続けた日数です。1日でも空くと途切れます。",
-    "diagnosticsReviewsHint": "過去365日間にスワイプした合計回数です。",
+    "diagnosticsStreakHint": "選択した期間にかかわらず、直近365日を基準に今日まで途切れずに学習を続けた日数です。1日でも空くと途切れます。",
+    "diagnosticsReviewsHint": "直近{days}日間にスワイプした合計回数です。",
     "diagnosticsAvgDifficultyHint": "FSRSがカードごとに算出する「覚えにくさ」の平均です（0〜10、高いほど難しい）。",
     "diagnosticsHintAriaLabel": "{metric}の説明",
     "perDeckHeading": "デッキ別の習得状況",
@@ -460,7 +460,9 @@
     "emptyDeckBody": "デッキを作成しましたが、カードがありません。カードをいくつか追加して学習すると、習得状況と進捗がここに表示されます。",
     "emptyDeckCta": "カードを追加",
     "diagnosticsHeading": "診断",
-    "diagnosticsWindow": "過去365日間",
-    "diagnosticsNoActivity": "過去365日間の学習履歴が不足しています。"
+    "diagnosticsWindowOption": "{days}日",
+    "diagnosticsWindowOptionAria": "直近{days}日",
+    "diagnosticsWindowGroupAria": "診断期間",
+    "diagnosticsNoActivityInWindow": "直近{days}日のレビューはありません。"
   }
 }

--- a/frontend/src/app/stats/diagnostics-panel.test.tsx
+++ b/frontend/src/app/stats/diagnostics-panel.test.tsx
@@ -1,0 +1,109 @@
+// @vitest-environment happy-dom
+import { screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+import type { MyLearningStatsQuery } from "@/generated/graphql";
+import { renderWithIntl } from "@/test/render-with-intl";
+import { DiagnosticsPanel } from "./diagnostics-panel";
+
+type PerformanceWindows = MyLearningStatsQuery["myLearningStats"]["performanceWindows"];
+
+const performanceWindows: PerformanceWindows = {
+  __typename: "PerformanceWindows",
+  days365: {
+    __typename: "PerformanceMetrics",
+    retentionRate: 0.78,
+    successRate: 0.84,
+    lapseRate: 0.12,
+    studyStreak: 9,
+    reviewCount: 1430,
+    avgDifficulty: 0.62,
+  },
+  days30: {
+    __typename: "PerformanceMetrics",
+    retentionRate: 0.65,
+    successRate: 0.75,
+    lapseRate: 0.25,
+    studyStreak: 9,
+    reviewCount: 300,
+    avgDifficulty: 0.51,
+  },
+  days7: {
+    __typename: "PerformanceMetrics",
+    retentionRate: 0.7,
+    successRate: 0.8,
+    lapseRate: 0.2,
+    studyStreak: 9,
+    reviewCount: 70,
+    avgDifficulty: 0.48,
+  },
+};
+
+function renderPanel(windows: PerformanceWindows = performanceWindows) {
+  return renderWithIntl(<DiagnosticsPanel performanceWindows={windows} />);
+}
+
+function tile(label: string) {
+  const card = screen.getByText(label).closest("div")?.parentElement;
+  if (!card) throw new Error(`StatTile card not found for "${label}"`);
+  return within(card);
+}
+
+describe("<DiagnosticsPanel>", () => {
+  it("switches snapshots locally and reflects the selected segment", async () => {
+    const user = userEvent.setup();
+    renderPanel();
+
+    const days365 = screen.getByRole("button", { name: "Last 365 days" });
+    const days30 = screen.getByRole("button", { name: "Last 30 days" });
+    expect(days365).toHaveAttribute("aria-pressed", "true");
+    expect(days30).toHaveAttribute("aria-pressed", "false");
+    expect(tile("Retention").getByText("78%")).toBeInTheDocument();
+
+    await user.click(days30);
+
+    expect(days365).toHaveAttribute("aria-pressed", "false");
+    expect(days30).toHaveAttribute("aria-pressed", "true");
+    expect(tile("Retention").getByText("65%")).toBeInTheDocument();
+    expect(tile("Reviews").getByText("300")).toBeInTheDocument();
+  });
+
+  it("keeps the switcher available for an empty window and restores tiles", async () => {
+    const user = userEvent.setup();
+    renderPanel({
+      ...performanceWindows,
+      days7: { ...performanceWindows.days7, reviewCount: 0 },
+    });
+
+    await user.click(screen.getByRole("button", { name: "Last 7 days" }));
+
+    expect(screen.getByText("No reviews in the last 7 days.")).toBeInTheDocument();
+    expect(screen.getByRole("group", { name: "Diagnostics period" })).toBeInTheDocument();
+    expect(screen.queryByText("78%")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Last 365 days" }));
+
+    expect(tile("Retention").getByText("78%")).toBeInTheDocument();
+    expect(screen.queryByText("No reviews in the last 7 days.")).not.toBeInTheDocument();
+  });
+
+  it("shows the same full-history streak in every window", async () => {
+    const user = userEvent.setup();
+    renderPanel();
+
+    expect(tile("Streak").getByText("9 days")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Last 30 days" }));
+    expect(tile("Streak").getByText("9 days")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Last 7 days" }));
+    expect(tile("Streak").getByText("9 days")).toBeInTheDocument();
+  });
+
+  it("hides unavailable short-window controls during a legacy-backend rollout", () => {
+    renderWithIntl(
+      <DiagnosticsPanel performanceWindows={performanceWindows} showWindowSelector={false} />,
+    );
+
+    expect(screen.queryByRole("group", { name: "Diagnostics period" })).not.toBeInTheDocument();
+    expect(tile("Reviews").getByText("1,430")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/stats/diagnostics-panel.tsx
+++ b/frontend/src/app/stats/diagnostics-panel.tsx
@@ -1,34 +1,50 @@
 "use client";
 
 import { useFormatter, useTranslations } from "next-intl";
+import { useState } from "react";
 import { EmptyState } from "@/components/ui/empty-state";
 import { StatTile } from "@/components/ui/stat-tile";
 import type { MyLearningStatsQuery } from "@/generated/graphql";
+import { cn } from "@/lib/utils";
 import { StatHint } from "./stat-hint";
 
-// Aliased to the GraphQL type name (not the bare word `Performance`, which would
-// shadow the ambient DOM `Performance` interface in this DOM-lib file).
-type PerformanceMetrics = MyLearningStatsQuery["myLearningStats"]["performance"];
+type PerformanceWindows = MyLearningStatsQuery["myLearningStats"]["performanceWindows"];
+type WindowKey = "days365" | "days30" | "days7";
+
+const WINDOW_OPTIONS: ReadonlyArray<{ key: WindowKey; days: number }> = [
+  { key: "days365", days: 365 },
+  { key: "days30", days: 30 },
+  { key: "days7", days: 7 },
+];
 
 // Shared by the three rate tiles (retention / success / lapse) below — all three
 // format a 0..1 fraction as a whole-percent string.
 const PERCENT_FORMAT = { style: "percent", maximumFractionDigits: 0 } as const;
 
 /**
- * Diagnostics KPI row for `/stats`: six `StatTile`s over the trailing-365-day
- * window, each carrying a `StatHint` help popover in its top-right corner. Rate
+ * Diagnostics KPI row for `/stats`: six `StatTile`s over a locally selected
+ * trailing window, each carrying a `StatHint` help popover. Rate
  * metrics (`retentionRate` / `successRate` / `lapseRate`) are fractions 0..1
  * rendered as whole-percent via `useFormatter`. `avgDifficulty` is normalized by
  * the backend to 0..1 (see `service.normalizedDifficulty`), so it is rescaled ×10
  * for display on the familiar 0–10 FSRS difficulty scale, shown to one decimal.
  * `studyStreak` uses the pluralized `diagnosticsStreakValue` message; `reviewCount`
- * is a grouped integer. When `reviewCount === 0` (a dormant learner with no reviews
- * in the window) the backend returns placeholder rate values, so the tiles are
- * replaced by an empty state instead of showing fabricated data as real.
+ * is a grouped integer. Switching windows is synchronous because all snapshots
+ * arrive in one query. When the selected window has no reviews, only the tile
+ * area becomes an empty state so the window control remains available.
  */
-export function DiagnosticsPanel({ performance }: { performance: PerformanceMetrics }) {
+export function DiagnosticsPanel({
+  performanceWindows,
+  showWindowSelector = true,
+}: {
+  performanceWindows: PerformanceWindows;
+  showWindowSelector?: boolean;
+}) {
   const t = useTranslations("Stats");
   const format = useFormatter();
+  const [selectedWindow, setSelectedWindow] = useState<WindowKey>("days365");
+  const performance = performanceWindows[selectedWindow];
+  const selectedDays = WINDOW_OPTIONS.find(({ key }) => key === selectedWindow)?.days ?? 365;
 
   const tiles = [
     {
@@ -64,7 +80,7 @@ export function DiagnosticsPanel({ performance }: { performance: PerformanceMetr
       label: t("diagnosticsReviews"),
       value: format.number(performance.reviewCount),
       caption: t("diagnosticsReviewsCaption"),
-      hint: t("diagnosticsReviewsHint"),
+      hint: t("diagnosticsReviewsHint", { days: selectedDays }),
     },
     {
       key: "avgDifficulty",
@@ -78,15 +94,44 @@ export function DiagnosticsPanel({ performance }: { performance: PerformanceMetr
 
   return (
     <div className="flex flex-col gap-3">
-      <div className="flex items-baseline justify-between gap-2">
+      <div className="flex items-center justify-between gap-2">
         <h2 className="text-sm font-semibold">{t("diagnosticsHeading")}</h2>
-        <span className="shrink-0 text-xs text-muted-foreground">{t("diagnosticsWindow")}</span>
+        {showWindowSelector ? (
+          <fieldset
+            aria-label={t("diagnosticsWindowGroupAria")}
+            className="inline-flex min-w-0 shrink-0 rounded-lg border-0 bg-muted p-0.5"
+          >
+            {WINDOW_OPTIONS.map(({ key, days }) => {
+              const selected = key === selectedWindow;
+              return (
+                <button
+                  key={key}
+                  type="button"
+                  aria-label={t("diagnosticsWindowOptionAria", { days })}
+                  aria-pressed={selected}
+                  onClick={() => setSelectedWindow(key)}
+                  className={cn(
+                    "min-h-11 min-w-11 rounded-md px-3 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+                    selected
+                      ? "bg-brand-primary text-brand-primary-foreground"
+                      : "text-muted-foreground hover:text-foreground",
+                  )}
+                >
+                  {t("diagnosticsWindowOption", { days })}
+                </button>
+              );
+            })}
+          </fieldset>
+        ) : null}
       </div>
       {performance.reviewCount === 0 ? (
         // Dormant learner: no reviews in the window. The backend returns
         // placeholder rate values for an empty window, so show an empty state
         // rather than render fabricated data as if it were real.
-        <EmptyState className="p-6" body={t("diagnosticsNoActivity")} />
+        <EmptyState
+          className="p-6"
+          body={t("diagnosticsNoActivityInWindow", { days: selectedDays })}
+        />
       ) : (
         <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6">
           {tiles.map((tile) => (

--- a/frontend/src/app/stats/page.test.tsx
+++ b/frontend/src/app/stats/page.test.tsx
@@ -225,6 +225,92 @@ describe("StatsPage — gqlFetch error branches", () => {
       { name: "Error" },
     );
   });
+
+  test("legacy resolves with null myLearningStats → clear guard error (not TypeError), no redirect", async () => {
+    vi.mocked(gqlFetch)
+      .mockRejectedValueOnce(
+        new Error(
+          `GraphQL errors: ${JSON.stringify([
+            { message: 'Cannot query field "performanceWindows" on type "LearningStats".' },
+          ])}`,
+        ),
+      )
+      // Partial response: data present but null, errors present but non-auth →
+      // gqlFetch RETURNS { myLearningStats: null } instead of throwing.
+      .mockResolvedValueOnce({ myLearningStats: null } as never);
+
+    // The null-guard surfaces a clear invariant error, not a raw TypeError from
+    // the destructure, and it is rethrown to the error boundary (no redirect).
+    await expect(StatsPage()).rejects.toThrow(
+      "/stats: legacy myLearningStats returned null with no error",
+    );
+    expect(gqlFetch).toHaveBeenCalledTimes(2);
+    expect(redirect).not.toHaveBeenCalled();
+  });
+
+  test("UNAUTHENTICATED from legacy gqlFetch → redirect /login, no console.error", async () => {
+    vi.mocked(gqlFetch)
+      .mockRejectedValueOnce(
+        new Error(
+          `GraphQL errors: ${JSON.stringify([
+            { message: 'Cannot query field "performanceWindows" on type "LearningStats".' },
+          ])}`,
+        ),
+      )
+      .mockRejectedValueOnce(
+        new Error(
+          `GraphQL errors: ${JSON.stringify([{ extensions: { code: "UNAUTHENTICATED" } }])}`,
+        ),
+      );
+
+    await expect(StatsPage()).rejects.toThrow(`${REDIRECT_PREFIX}/login`);
+    expect(redirect).toHaveBeenCalledWith("/login");
+    // The legacy redirect path swallows the error cleanly — no log.
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
+
+  test("real gqlparser 'Cannot query field' wording → triggers legacy fallback", async () => {
+    // Pin the exact validation wording isPerformanceWindowsUnavailable matches.
+    // If gqlparser's phrasing drifts, this fails instead of silently disabling
+    // the rollout fallback in production.
+    vi.mocked(gqlFetch)
+      .mockRejectedValueOnce(
+        new Error(
+          `GraphQL errors: ${JSON.stringify([
+            { message: 'Cannot query field "performanceWindows" on type "LearningStats".' },
+          ])}`,
+        ),
+      )
+      .mockResolvedValueOnce(makeLegacyStatsData() as never);
+
+    const result = await StatsPage();
+
+    expect(gqlFetch).toHaveBeenCalledTimes(2);
+    expect(redirect).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+    const el = findStatsClientElement(result);
+    expect(el?.props.performanceWindowsAvailable).toBe(false);
+  });
+
+  test("validation error matching only some substrings → no legacy fallback, rethrows", async () => {
+    // "Cannot query field" matches but "performanceWindows"/"LearningStats" do
+    // not → the 3-substring AND must NOT fire the fallback. Locks the predicate
+    // against loosening.
+    const primaryErr = new Error(
+      `GraphQL errors: ${JSON.stringify([
+        { message: 'Cannot query field "somethingElse" on type "Query".' },
+      ])}`,
+    );
+    vi.mocked(gqlFetch).mockRejectedValueOnce(primaryErr);
+
+    await expect(StatsPage()).rejects.toBe(primaryErr);
+    expect(gqlFetch).toHaveBeenCalledTimes(1);
+    expect(redirect).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("[stats] gqlFetch failed"),
+      { name: "Error" },
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/app/stats/page.test.tsx
+++ b/frontend/src/app/stats/page.test.tsx
@@ -22,8 +22,18 @@ vi.mock("@/lib/apollo/server", () => ({
 // file. The RSC page test only needs to verify the auth/error routing and that
 // the fetched stats are forwarded.
 vi.mock("./stats-client", () => ({
-  StatsClient: ({ stats }: { stats: unknown }) => (
-    <div data-testid="stats-client" data-has-stats={stats != null ? "true" : "false"}>
+  StatsClient: ({
+    stats,
+    performanceWindowsAvailable,
+  }: {
+    stats: unknown;
+    performanceWindowsAvailable?: boolean;
+  }) => (
+    <div
+      data-testid="stats-client"
+      data-has-stats={stats != null ? "true" : "false"}
+      data-performance-windows-available={String(performanceWindowsAvailable)}
+    >
       StatsClient
     </div>
   ),
@@ -44,15 +54,51 @@ function makeStatsData() {
       ownsAnyDeck: true,
       mastery: { inProgress: 1, learned: 2, mature: 3, totalStudied: 6 },
       decks: [],
-      performance: {
-        retentionRate: 0.5,
-        successRate: 0.5,
-        lapseRate: 0.1,
-        studyStreak: 0,
-        reviewCount: 0,
-        avgDifficulty: 0.5,
+      performanceWindows: {
+        days365: {
+          retentionRate: 0.5,
+          successRate: 0.5,
+          lapseRate: 0.1,
+          studyStreak: 0,
+          reviewCount: 0,
+          avgDifficulty: 0.5,
+        },
+        days30: {
+          retentionRate: 0.5,
+          successRate: 0.5,
+          lapseRate: 0.1,
+          studyStreak: 0,
+          reviewCount: 0,
+          avgDifficulty: 0.5,
+        },
+        days7: {
+          retentionRate: 0.5,
+          successRate: 0.5,
+          lapseRate: 0.1,
+          studyStreak: 0,
+          reviewCount: 0,
+          avgDifficulty: 0.5,
+        },
       },
       strugglingCards: [],
+    },
+  };
+}
+
+function makeLegacyStatsData() {
+  const { performanceWindows: _performanceWindows, ...stats } = makeStatsData().myLearningStats;
+  return {
+    myLearningStats: {
+      ...stats,
+      performance: {
+        __typename: "PerformanceMetrics",
+        retentionRate: 0.72,
+        successRate: 0.8,
+        lapseRate: 0.2,
+        studyStreak: 4,
+        reviewCount: 123,
+        avgDifficulty: 0.6,
+      },
     },
   };
 }
@@ -67,6 +113,7 @@ let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
 
 beforeEach(() => {
   vi.clearAllMocks();
+  vi.mocked(gqlFetch).mockReset();
   setAuthStatus("authenticated");
   consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 });
@@ -134,6 +181,50 @@ describe("StatsPage — gqlFetch error branches", () => {
       name: "Error",
     });
   });
+
+  test("old backend without performanceWindows → retries the legacy query", async () => {
+    vi.mocked(gqlFetch)
+      .mockRejectedValueOnce(
+        new Error(
+          `GraphQL errors: ${JSON.stringify([
+            {
+              message:
+                'Cannot query field "performanceWindows" on type "LearningStats". Did you mean "performance"?',
+            },
+          ])}`,
+        ),
+      )
+      .mockResolvedValueOnce(makeLegacyStatsData() as never);
+
+    const result = await StatsPage();
+
+    expect(gqlFetch).toHaveBeenCalledTimes(2);
+    expect(redirect).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+    const el = findStatsClientElement(result);
+    const stats = el?.props.stats as ReturnType<typeof makeStatsData>["myLearningStats"];
+    expect(stats.performanceWindows.days365.reviewCount).toBe(123);
+    expect(stats.performanceWindows.days30.reviewCount).toBe(123);
+    expect(stats.performanceWindows.days7.reviewCount).toBe(123);
+    expect(el?.props.performanceWindowsAvailable).toBe(false);
+  });
+
+  test("legacy fallback failure → logs and rethrows the fallback error", async () => {
+    const fallbackErr = new Error("GraphQL HTTP 500");
+    vi.mocked(gqlFetch)
+      .mockRejectedValueOnce(
+        new Error(
+          'GraphQL errors: [{"message":"Cannot query field \\"performanceWindows\\" on type \\"LearningStats\\"."}]',
+        ),
+      )
+      .mockRejectedValueOnce(fallbackErr);
+
+    await expect(StatsPage()).rejects.toBe(fallbackErr);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("[stats] legacy gqlFetch failed"),
+      { name: "Error" },
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -163,7 +254,7 @@ describe("StatsPage — data guard + happy path", () => {
 // JSX tree helper
 // ---------------------------------------------------------------------------
 
-type StatsClientProps = { stats: unknown };
+type StatsClientProps = { stats: unknown; performanceWindowsAvailable?: boolean };
 
 /**
  * Recursively search a React element tree for the StatsClient stub element so

--- a/frontend/src/app/stats/page.tsx
+++ b/frontend/src/app/stats/page.tsx
@@ -13,6 +13,15 @@ import { StatsClient } from "./stats-client";
 
 export const metadata: Metadata = { title: "Progress" };
 
+// Detect an old backend that predates the `performanceWindows` field by
+// matching the GraphQL validation error text. This is a DELIBERATE, SCOPED
+// exception to this repo's convention of parsing `extensions.code` rather than
+// substring-matching a GraphQL error message: validation-phase errors
+// ("Cannot query field ...") carry only the generic `GRAPHQL_VALIDATION_FAILED`
+// code with no field identity, so — unlike the `UNAUTHENTICATED` / `FORBIDDEN`
+// codes parsed structurally elsewhere in this file — the offending field name
+// is recoverable only from the message text. This is a temporary rollout shim,
+// removable once every backend exposes `performanceWindows`.
 function isPerformanceWindowsUnavailable(err: unknown): boolean {
   return (
     err instanceof Error &&
@@ -23,7 +32,18 @@ function isPerformanceWindowsUnavailable(err: unknown): boolean {
 }
 
 function adaptLegacyStats(data: LegacyMyLearningStatsQueryType): MyLearningStatsQueryType {
+  // Mirror the primary-path null-guard (see StatsPage below): a partial GraphQL
+  // response can carry `myLearningStats: null` alongside a non-auth error, in
+  // which case gqlFetch returns the data instead of throwing. Surface that as a
+  // clear invariant error rather than letting the destructure throw a raw
+  // TypeError that the fetch catch would then mislabel as a "gqlFetch failed".
+  if (!data.myLearningStats) {
+    throw new Error("/stats: legacy myLearningStats returned null with no error");
+  }
   const { performance, ...stats } = data.myLearningStats;
+  if (!performance) {
+    throw new Error("/stats: legacy performance returned null with no error");
+  }
   return {
     myLearningStats: {
       ...stats,
@@ -51,10 +71,9 @@ export default async function StatsPage() {
   } catch (err) {
     if (isUnauthenticatedGraphQLError(err)) redirect("/login");
     if (isPerformanceWindowsUnavailable(err)) {
+      let legacyData: LegacyMyLearningStatsQueryType;
       try {
-        const legacyData = await gqlFetch(LegacyMyLearningStatsQuery, { revalidate: 0 });
-        data = adaptLegacyStats(legacyData);
-        performanceWindowsAvailable = false;
+        legacyData = await gqlFetch(LegacyMyLearningStatsQuery, { revalidate: 0 });
       } catch (legacyErr) {
         if (isUnauthenticatedGraphQLError(legacyErr)) redirect("/login");
         console.error("[stats] legacy gqlFetch failed:", {
@@ -62,6 +81,11 @@ export default async function StatsPage() {
         });
         throw legacyErr;
       }
+      // adaptLegacyStats guards the response shape and throws a clear invariant
+      // error on null data. Keep it outside the fetch try/catch so a shape
+      // failure surfaces on its own, not mislabeled as a "gqlFetch failed".
+      data = adaptLegacyStats(legacyData);
+      performanceWindowsAvailable = false;
     } else {
       console.error("[stats] gqlFetch failed:", {
         name: err instanceof Error ? err.name : "unknown",

--- a/frontend/src/app/stats/page.tsx
+++ b/frontend/src/app/stats/page.tsx
@@ -1,32 +1,82 @@
 import type { Metadata } from "next";
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
-import type { MyLearningStatsQuery as MyLearningStatsQueryType } from "@/generated/graphql";
+import type {
+  LegacyMyLearningStatsQuery as LegacyMyLearningStatsQueryType,
+  MyLearningStatsQuery as MyLearningStatsQueryType,
+} from "@/generated/graphql";
 import { isUnauthenticatedGraphQLError } from "@/lib/apollo/graphql-errors";
 import { gqlFetch } from "@/lib/apollo/server";
 import { readAuthContext } from "@/lib/supabase/auth-status";
-import { MyLearningStatsQuery } from "./queries";
+import { LegacyMyLearningStatsQuery, MyLearningStatsQuery } from "./queries";
 import { StatsClient } from "./stats-client";
 
 export const metadata: Metadata = { title: "Progress" };
+
+function isPerformanceWindowsUnavailable(err: unknown): boolean {
+  return (
+    err instanceof Error &&
+    err.message.includes("Cannot query field") &&
+    err.message.includes("performanceWindows") &&
+    err.message.includes("LearningStats")
+  );
+}
+
+function adaptLegacyStats(data: LegacyMyLearningStatsQueryType): MyLearningStatsQueryType {
+  const { performance, ...stats } = data.myLearningStats;
+  return {
+    myLearningStats: {
+      ...stats,
+      performanceWindows: {
+        __typename: "PerformanceWindows",
+        // The old API exposes only the 365-day snapshot. Reusing it keeps the
+        // page functional during rollout; real shorter windows arrive as soon
+        // as the additive backend schema is live.
+        days365: performance,
+        days30: performance,
+        days7: performance,
+      },
+    },
+  };
+}
 
 export default async function StatsPage() {
   const auth = readAuthContext(await headers());
   if (auth.status !== "authenticated") redirect("/login");
 
   let data: MyLearningStatsQueryType;
+  let performanceWindowsAvailable = true;
   try {
     data = await gqlFetch(MyLearningStatsQuery, { revalidate: 0 });
   } catch (err) {
     if (isUnauthenticatedGraphQLError(err)) redirect("/login");
-    console.error("[stats] gqlFetch failed:", {
-      name: err instanceof Error ? err.name : "unknown",
-    });
-    throw err;
+    if (isPerformanceWindowsUnavailable(err)) {
+      try {
+        const legacyData = await gqlFetch(LegacyMyLearningStatsQuery, { revalidate: 0 });
+        data = adaptLegacyStats(legacyData);
+        performanceWindowsAvailable = false;
+      } catch (legacyErr) {
+        if (isUnauthenticatedGraphQLError(legacyErr)) redirect("/login");
+        console.error("[stats] legacy gqlFetch failed:", {
+          name: legacyErr instanceof Error ? legacyErr.name : "unknown",
+        });
+        throw legacyErr;
+      }
+    } else {
+      console.error("[stats] gqlFetch failed:", {
+        name: err instanceof Error ? err.name : "unknown",
+      });
+      throw err;
+    }
   }
   if (!data.myLearningStats) {
     throw new Error("/stats: myLearningStats returned null with no error");
   }
 
-  return <StatsClient stats={data.myLearningStats} />;
+  return (
+    <StatsClient
+      stats={data.myLearningStats}
+      performanceWindowsAvailable={performanceWindowsAvailable}
+    />
+  );
 }

--- a/frontend/src/app/stats/queries.ts
+++ b/frontend/src/app/stats/queries.ts
@@ -11,6 +11,54 @@ export const MyLearningStatsQuery = graphql(`
         learnedCards
         matureCards
       }
+      performanceWindows {
+        days365 {
+          retentionRate
+          successRate
+          lapseRate
+          studyStreak
+          reviewCount
+          avgDifficulty
+        }
+        days30 {
+          retentionRate
+          successRate
+          lapseRate
+          studyStreak
+          reviewCount
+          avgDifficulty
+        }
+        days7 {
+          retentionRate
+          successRate
+          lapseRate
+          studyStreak
+          reviewCount
+          avgDifficulty
+        }
+      }
+      strugglingCards {
+        card { id front cardgroup { id name } }
+        lapses
+      }
+    }
+  }
+`);
+
+// Temporary rollout fallback for a frontend deployment that reaches the old
+// backend before performanceWindows is available. Remove after the additive
+// backend schema has been deployed everywhere and the old frontend is retired.
+export const LegacyMyLearningStatsQuery = graphql(`
+  query LegacyMyLearningStats {
+    myLearningStats {
+      ownsAnyDeck
+      mastery { inProgress learned mature totalStudied }
+      decks {
+        cardgroup { id name }
+        totalCards
+        learnedCards
+        matureCards
+      }
       performance {
         retentionRate
         successRate

--- a/frontend/src/app/stats/stats-client.test.tsx
+++ b/frontend/src/app/stats/stats-client.test.tsx
@@ -33,15 +33,36 @@ const populatedStats: Stats = {
       matureCards: 20,
     },
   ],
-  performance: {
-    __typename: "PerformanceMetrics",
-    retentionRate: 0.78,
-    successRate: 0.84,
-    lapseRate: 0.12,
-    studyStreak: 9,
-    reviewCount: 1430,
-    // Served normalized to 0..1 by the backend; the panel rescales ×10 → "6.2".
-    avgDifficulty: 0.62,
+  performanceWindows: {
+    __typename: "PerformanceWindows",
+    days365: {
+      __typename: "PerformanceMetrics",
+      retentionRate: 0.78,
+      successRate: 0.84,
+      lapseRate: 0.12,
+      studyStreak: 9,
+      reviewCount: 1430,
+      // Served normalized to 0..1 by the backend; the panel rescales ×10 → "6.2".
+      avgDifficulty: 0.62,
+    },
+    days30: {
+      __typename: "PerformanceMetrics",
+      retentionRate: 0.75,
+      successRate: 0.8,
+      lapseRate: 0.15,
+      studyStreak: 9,
+      reviewCount: 300,
+      avgDifficulty: 0.6,
+    },
+    days7: {
+      __typename: "PerformanceMetrics",
+      retentionRate: 0.7,
+      successRate: 0.76,
+      lapseRate: 0.2,
+      studyStreak: 9,
+      reviewCount: 70,
+      avgDifficulty: 0.58,
+    },
   },
   strugglingCards: [
     {
@@ -150,7 +171,10 @@ describe("<StatsClient>", () => {
     it("renders '1 day' for a single-day streak", () => {
       renderStats({
         ...populatedStats,
-        performance: { ...populatedStats.performance, studyStreak: 1 },
+        performanceWindows: {
+          ...populatedStats.performanceWindows,
+          days365: { ...populatedStats.performanceWindows.days365, studyStreak: 1 },
+        },
       });
       expect(screen.getByText("1 day")).toBeInTheDocument();
     });
@@ -179,12 +203,13 @@ describe("<StatsClient>", () => {
     it("replaces the diagnostic tiles with an empty state (no fabricated rates)", () => {
       renderStats({
         ...populatedStats,
-        performance: { ...populatedStats.performance, reviewCount: 0 },
+        performanceWindows: {
+          ...populatedStats.performanceWindows,
+          days365: { ...populatedStats.performanceWindows.days365, reviewCount: 0 },
+        },
       });
 
-      expect(
-        screen.getByText("Not enough recent activity in the last 365 days."),
-      ).toBeInTheDocument();
+      expect(screen.getByText("No reviews in the last 365 days.")).toBeInTheDocument();
       // The (placeholder) rate values are not shown as if they were real data.
       expect(screen.queryByText("78%")).not.toBeInTheDocument();
       // The diagnostics heading still renders above the empty state.

--- a/frontend/src/app/stats/stats-client.tsx
+++ b/frontend/src/app/stats/stats-client.tsx
@@ -22,7 +22,13 @@ import { StrugglingList } from "./struggling-list";
  * content sections. All copy flows through `useTranslations("Stats")`;
  * number/percent formatting lives in the section components via `useFormatter()`.
  */
-export function StatsClient({ stats }: { stats: MyLearningStatsQuery["myLearningStats"] }) {
+export function StatsClient({
+  stats,
+  performanceWindowsAvailable = true,
+}: {
+  stats: MyLearningStatsQuery["myLearningStats"];
+  performanceWindowsAvailable?: boolean;
+}) {
   const t = useTranslations("Stats");
   const studiedCount = stats.mastery.totalStudied;
   const hasDecks = stats.decks.length > 0;
@@ -59,7 +65,10 @@ export function StatsClient({ stats }: { stats: MyLearningStatsQuery["myLearning
     content = (
       <div className="flex flex-col gap-4 sm:gap-6">
         <MasterySummary mastery={stats.mastery} />
-        <DiagnosticsPanel performance={stats.performance} />
+        <DiagnosticsPanel
+          performanceWindows={stats.performanceWindows}
+          showWindowSelector={performanceWindowsAvailable}
+        />
         <div className="grid gap-4 lg:grid-cols-[4fr_3fr]">
           <PerDeckList decks={stats.decks} />
           <StrugglingList cards={stats.strugglingCards} />

--- a/schema/stats.graphql
+++ b/schema/stats.graphql
@@ -4,12 +4,24 @@ type LearningStats {
   mastery: MasteryBreakdown!
   """Per-deck acquisition, one entry per owned deck that has at least one card (decks with cards but no studied cards are included; empty decks are omitted)."""
   decks: [DeckMastery!]!
-  """Diagnostic performance snapshot over the trailing 365-day window (retention, success, lapse rates, study streak, review count, average difficulty)."""
-  performance: PerformanceMetrics!
+  """Legacy diagnostic snapshot over the trailing 365-day window. Use performanceWindows for selectable rolling windows."""
+  performance: PerformanceMetrics! @deprecated(reason: "Use performanceWindows.days365.")
+  """Diagnostic performance snapshots over trailing rolling windows."""
+  performanceWindows: PerformanceWindows!
   """Cards the learner struggles with most, ranked by lapses (desc) then stability (asc), filtered to at least one lapse, capped at 10."""
   strugglingCards: [StrugglingCard!]!
   """True iff the caller owns at least one deck (cardgroup), regardless of card count. Distinguishes a brand-new user (owns nothing) from one who created a deck but has not added any cards yet — `decks` omits zero-card decks, so it alone cannot make that distinction."""
   ownsAnyDeck: Boolean!
+}
+
+"""Trailing rolling-window diagnostic snapshots. days30/days7 are computed from the swipes inside each window; studyStreak is always computed from the full 365-day set so long streaks are never under-reported."""
+type PerformanceWindows {
+  """Snapshot over the trailing 365-day window."""
+  days365: PerformanceMetrics!
+  """Snapshot over the trailing 30-day window."""
+  days30: PerformanceMetrics!
+  """Snapshot over the trailing 7-day window."""
+  days7: PerformanceMetrics!
 }
 
 """A card the learner struggles with (high lapses / low stability)."""


### PR DESCRIPTION
## Summary

The `/stats` learning diagnostics reported retention, review count, and average difficulty over a single trailing 365-day window, so a strong recent week or month was diluted by the full year and there was no way to narrow the view. This adds selectable 365-day / 30-day / 7-day performance windows — a new `performanceWindows` GraphQL field and a segmented switcher on the diagnostics panel — all derived from the swipe data already loaded for the yearly view, with no extra DB reads. The change is additive and backward-compatible: the flat `performance` field is retained (now `@deprecated`) and the frontend falls back to it when talking to a backend that predates the new field.

## Changes

### Backend

- `schema/stats.graphql` — add `performanceWindows: PerformanceWindows!` (with `days365` / `days30` / `days7`, each `PerformanceMetrics!`) to `myLearningStats`; mark the flat `performance` field `@deprecated(reason: "Use performanceWindows.days365.")`. `studyStreak` is documented as always full-365-day truth so a shorter window never under-reports a long streak.
- `backend/internal/domain/service/user_performance.go` — **new** `ComputeWindowedMetrics(swipes, now)` and `WindowedMetrics` struct computing all three windows from one already-loaded 365-day swipe set; shorter windows reuse the 365-day streak.
- `backend/internal/usecase/stats.go` — `LearningStatsResult` gains a `Windows` field populated via `ComputeWindowedMetrics` over the existing windowed read.
- `backend/graph/resolver/stats_helpers.go` — map `Windows` into `model.PerformanceWindows` and keep the legacy `performance` field populated with the days365 snapshot as a rollout alias.

### Frontend

- `frontend/src/app/stats/queries.ts` — `MyLearningStatsQuery` selects the new `performanceWindows { days365/days30/days7 { … } }`; add **`LegacyMyLearningStatsQuery`** (old `performance` shape) as a rollout fallback.
- `frontend/src/app/stats/page.tsx` — detect a `performanceWindows`-unavailable error and retry with the legacy query, mapping it through `adaptLegacyStats` into the new shape; thread `performanceWindowsAvailable` to the client.
- `frontend/src/app/stats/diagnostics-panel.tsx` — add the 365d / 30d / 7d segmented switcher and a per-window empty state that keeps the switcher available.
- `frontend/src/app/stats/stats-client.tsx` — accept and thread the windowed data and availability flag to the panel.
- `frontend/messages/{en,ja}.json` — new i18n keys for the switcher and per-window empty state, both locales kept in sync.

### Tests

- `backend/internal/domain/service/user_performance_test.go`, `backend/internal/usecase/stats_test.go`, `backend/graph/resolver/stats_resolver_test.go` — cover windowed metrics, the `Windows` result, and the resolver mapping including the legacy alias.
- `frontend/src/app/stats/diagnostics-panel.test.tsx` (**new**), `page.test.tsx`, `stats-client.test.tsx`, `frontend/__tests__/stats.test.tsx` — cover the switcher, per-window empty state, full-history streak, and the legacy fallback success/failure paths.

## Test plan

- [ ] `go test ./...` — backend windowed-metrics, usecase, and resolver suites
- [ ] `tsc --noEmit`, `biome check --error-on-warnings`, `knip`, `next build` — pass
- [ ] `vitest run` — diagnostics-panel (new), stats-client, page, and `__tests__/stats` suites
- [ ] Manual: on `/stats`, toggle 365d / 30d / 7d; a window with no reviews shows the per-window empty state and keeps the switcher; the study streak is identical across all three windows
- [ ] Regression: point the frontend at a backend without `performanceWindows` — the page still renders via the legacy fallback

Closes #952
