### PR TITLE
feat(swipe): record the pre-swipe FSRS snapshot on swipe_records

### DIFF
--- a/backend/internal/database/cards_position_roundtrip_test.go
+++ b/backend/internal/database/cards_position_roundtrip_test.go
@@ -44,17 +44,18 @@ func TestCardsPositionDownUpRoundtrip(t *testing.T) {
 		}
 	}()
 
-	// Step back past the ten migrations newer than add_position_to_cards
+	// Step back past the eleven migrations newer than add_position_to_cards
 	// (enable_rls_schema_migrations, pin_trigger_function_search_path,
 	// restrict_definer_function_exposure, add_master_tables,
 	// add_learn_display_mode_to_user_preferences,
 	// add_user_card_fsrs_card_id_index, master_cards_front_citext,
 	// drop_master_cardgroup_metadata_columns,
 	// index_hygiene_users_swipe_records,
-	// add_new_card_ratio_to_user_preferences), then past add_position_to_cards
-	// itself. Eleven steps are required because add_position_to_cards is no longer
+	// add_new_card_ratio_to_user_preferences,
+	// add_pre_swipe_snapshot_to_swipe_records), then past add_position_to_cards
+	// itself. Twelve steps are required because add_position_to_cards is no longer
 	// near the newest migration; bump this count when adding migrations after it.
-	if err := m.Steps(-11); err != nil {
+	if err := m.Steps(-12); err != nil {
 		t.Fatalf("migrate down to before add_position_to_cards: %v", err)
 	}
 

--- a/backend/internal/database/learn_display_mode_roundtrip_test.go
+++ b/backend/internal/database/learn_display_mode_roundtrip_test.go
@@ -54,15 +54,16 @@ func TestLearnDisplayModeDownUpRoundtrip(t *testing.T) {
 		}
 	}()
 
-	// Step back six migrations newest-first: add_new_card_ratio_to_user_preferences
-	// (now the newest), index_hygiene_users_swipe_records,
+	// Step back seven migrations newest-first: add_pre_swipe_snapshot_to_swipe_records
+	// (now the newest), add_new_card_ratio_to_user_preferences,
+	// index_hygiene_users_swipe_records,
 	// drop_master_cardgroup_metadata_columns, master_cards_front_citext,
 	// add_user_card_fsrs_card_id_index,
 	// then add_learn_display_mode_to_user_preferences (the target). The Steps(1)
 	// below re-applies add_learn_display_mode, and the t.Cleanup restores the
 	// rest. Bump this count when adding migrations after
 	// add_learn_display_mode_to_user_preferences.
-	if err := m.Steps(-6); err != nil {
+	if err := m.Steps(-7); err != nil {
 		t.Fatalf("migrate down to before add_learn_display_mode_to_user_preferences: %v", err)
 	}
 

--- a/backend/internal/database/migrations/20260718000000_add_pre_swipe_snapshot_to_swipe_records.down.sql
+++ b/backend/internal/database/migrations/20260718000000_add_pre_swipe_snapshot_to_swipe_records.down.sql
@@ -1,0 +1,14 @@
+-- 20260718000000_add_pre_swipe_snapshot_to_swipe_records.down.sql
+--
+-- Reverse of 20260718000000_add_pre_swipe_snapshot_to_swipe_records.up.sql.
+--
+-- golang-migrate pgx/v5 does NOT auto-wrap migrations in a transaction; the
+-- explicit BEGIN/COMMIT below ensures all-or-nothing execution.
+
+BEGIN;
+
+ALTER TABLE public.swipe_records
+  DROP COLUMN IF EXISTS phase_before,
+  DROP COLUMN IF EXISTS scheduled_days_before;
+
+COMMIT;

--- a/backend/internal/database/migrations/20260718000000_add_pre_swipe_snapshot_to_swipe_records.up.sql
+++ b/backend/internal/database/migrations/20260718000000_add_pre_swipe_snapshot_to_swipe_records.up.sql
@@ -1,0 +1,23 @@
+-- 20260718000000_add_pre_swipe_snapshot_to_swipe_records.up.sql
+--
+-- Adds the pre-swipe FSRS snapshot to public.swipe_records:
+--   phase_before          -- the FSRS phase the card was in before this swipe
+--   scheduled_days_before -- the interval (days) scheduled at the previous review
+--
+-- Both columns are nullable with NO default and NO backfill: NULL marks a
+-- legacy row recorded before these columns existed and is a meaningful sentinel
+-- the metrics layer branches on. Deriving the pre-swipe phase from the stored
+-- post-swipe state is provably ambiguous (a Learning->Easy graduation and a
+-- Review->Hard review both land on phase Review), so the snapshot is captured
+-- on the swipe event going forward.
+--
+-- golang-migrate pgx/v5 does NOT auto-wrap migrations in a transaction; the
+-- explicit BEGIN/COMMIT below ensures all-or-nothing execution.
+
+BEGIN;
+
+ALTER TABLE public.swipe_records
+  ADD COLUMN phase_before smallint,
+  ADD COLUMN scheduled_days_before integer;
+
+COMMIT;

--- a/backend/internal/database/users_version_roundtrip_test.go
+++ b/backend/internal/database/users_version_roundtrip_test.go
@@ -38,22 +38,23 @@ func TestUsersVersionDownUpRoundtrip(t *testing.T) {
 		}
 	}()
 
-	// Step back through the 12 migrations listed newest-first until
+	// Step back through the 13 migrations listed newest-first until
 	// add_version_to_users (the target) is also rolled back:
-	//   1. add_new_card_ratio_to_user_preferences
-	//   2. index_hygiene_users_swipe_records
-	//   3. drop_master_cardgroup_metadata_columns
-	//   4. master_cards_front_citext
-	//   5. add_user_card_fsrs_card_id_index
-	//   6. add_learn_display_mode_to_user_preferences
-	//   7. add_master_tables
-	//   8. restrict_definer_function_exposure
-	//   9. pin_trigger_function_search_path
-	//   10. enable_rls_schema_migrations
-	//   11. add_position_to_cards
-	//   12. add_version_to_users  ← target (rolls back the version column)
+	//   1. add_pre_swipe_snapshot_to_swipe_records
+	//   2. add_new_card_ratio_to_user_preferences
+	//   3. index_hygiene_users_swipe_records
+	//   4. drop_master_cardgroup_metadata_columns
+	//   5. master_cards_front_citext
+	//   6. add_user_card_fsrs_card_id_index
+	//   7. add_learn_display_mode_to_user_preferences
+	//   8. add_master_tables
+	//   9. restrict_definer_function_exposure
+	//   10. pin_trigger_function_search_path
+	//   11. enable_rls_schema_migrations
+	//   12. add_position_to_cards
+	//   13. add_version_to_users  ← target (rolls back the version column)
 	// Bump the count here when adding migrations after add_version_to_users.
-	if err := m.Steps(-12); err != nil {
+	if err := m.Steps(-13); err != nil {
 		t.Fatalf("migrate down to before add_version_to_users: %v", err)
 	}
 

--- a/backend/internal/domain/swipe_record.go
+++ b/backend/internal/domain/swipe_record.go
@@ -15,10 +15,21 @@ type SwipeRecord struct {
 	Rating      Rating
 	ReviewedAt  time.Time
 	StateAfter  FSRSState
+	// PhaseBefore is the FSRS phase the card was in when the swipe was made;
+	// nil for rows recorded before the phase_before column existed.
+	PhaseBefore *FSRSPhase
+	// ScheduledDaysBefore is the interval (days) scheduled at the previous
+	// review; nil for legacy rows recorded before the column existed.
+	ScheduledDaysBefore *int
 }
 
-// NewSwipeRecord creates a swipe event with a fresh UUID v7.
-func NewSwipeRecord(userID UserID, cardID string, cardgroupID CardgroupID, rating Rating, reviewedAt time.Time, stateAfter FSRSState) (*SwipeRecord, error) {
+// NewSwipeRecord creates a swipe event with a fresh UUID v7. stateBefore is the
+// scheduling state captured immediately before the rating was applied; the
+// pre-swipe snapshot (PhaseBefore, ScheduledDaysBefore) is populated from it so
+// the metrics layer can distinguish, for example, a Learning->Easy graduation
+// from a genuine review of an already-learned card. stateAfter is the state the
+// swipe advanced the card to.
+func NewSwipeRecord(userID UserID, cardID string, cardgroupID CardgroupID, rating Rating, reviewedAt time.Time, stateBefore, stateAfter FSRSState) (*SwipeRecord, error) {
 	if cardgroupID == "" {
 		return nil, eris.New("swipe record: cardgroupID is required")
 	}
@@ -26,13 +37,19 @@ func NewSwipeRecord(userID UserID, cardID string, cardgroupID CardgroupID, ratin
 	if err != nil {
 		return nil, eris.Wrap(err, "swipe record: new id")
 	}
+	// Take the address of independent locals, never &stateBefore.Field: the
+	// snapshot pointers must not alias the caller's FSRSState.
+	phaseBefore := stateBefore.Phase
+	scheduledDaysBefore := stateBefore.ScheduledDays
 	return &SwipeRecord{
-		ID:          id,
-		UserID:      userID,
-		CardID:      cardID,
-		CardgroupID: cardgroupID,
-		Rating:      rating,
-		ReviewedAt:  reviewedAt,
-		StateAfter:  stateAfter,
+		ID:                  id,
+		UserID:              userID,
+		CardID:              cardID,
+		CardgroupID:         cardgroupID,
+		Rating:              rating,
+		ReviewedAt:          reviewedAt,
+		StateAfter:          stateAfter,
+		PhaseBefore:         &phaseBefore,
+		ScheduledDaysBefore: &scheduledDaysBefore,
 	}, nil
 }

--- a/backend/internal/domain/swipe_record_test.go
+++ b/backend/internal/domain/swipe_record_test.go
@@ -11,11 +11,16 @@ func TestNewSwipeRecord(t *testing.T) {
 	t.Parallel()
 
 	reviewedAt := time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC)
-	state := NewFSRSStateForNewCard(reviewedAt)
+	stateBefore := NewFSRSStateForNewCard(reviewedAt)
+	stateBefore.Phase = FSRSPhaseReview
+	stateBefore.ScheduledDays = 7
+	stateAfter := NewFSRSStateForNewCard(reviewedAt)
+	stateAfter.Phase = FSRSPhaseRelearning
+	stateAfter.ScheduledDays = 1
 
-	first, err := NewSwipeRecord("user-1", "card-1", CardgroupID("cg-1"), RatingEasy, reviewedAt, state)
+	first, err := NewSwipeRecord("user-1", "card-1", CardgroupID("cg-1"), RatingEasy, reviewedAt, stateBefore, stateAfter)
 	require.NoError(t, err)
-	second, err := NewSwipeRecord("user-1", "card-1", CardgroupID("cg-1"), RatingEasy, reviewedAt, state)
+	second, err := NewSwipeRecord("user-1", "card-1", CardgroupID("cg-1"), RatingEasy, reviewedAt, stateBefore, stateAfter)
 	require.NoError(t, err)
 
 	require.NotEmpty(t, first.ID)
@@ -25,14 +30,48 @@ func TestNewSwipeRecord(t *testing.T) {
 	require.Equal(t, CardgroupID("cg-1"), first.CardgroupID)
 	require.Equal(t, RatingEasy, first.Rating)
 	require.Equal(t, reviewedAt, first.ReviewedAt)
-	require.Equal(t, state, first.StateAfter)
+	require.Equal(t, stateAfter, first.StateAfter)
+
+	// The pre-swipe snapshot is taken from stateBefore, never from stateAfter.
+	require.NotNil(t, first.PhaseBefore)
+	require.Equal(t, FSRSPhaseReview, *first.PhaseBefore)
+	require.NotNil(t, first.ScheduledDaysBefore)
+	require.Equal(t, 7, *first.ScheduledDaysBefore)
+}
+
+// TestNewSwipeRecord_SnapshotPointersAreIndependentCopies proves the snapshot
+// pointers are fresh allocations that do not alias the caller's stateBefore, so
+// a later mutation of the caller's struct cannot corrupt the recorded event.
+// Pointer-identity assertion per
+// docs/backend/library-gotchas/defensive-copy-test-pointer-identity.md.
+func TestNewSwipeRecord_SnapshotPointersAreIndependentCopies(t *testing.T) {
+	t.Parallel()
+
+	reviewedAt := time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC)
+	stateBefore := NewFSRSStateForNewCard(reviewedAt)
+	stateBefore.Phase = FSRSPhaseReview
+	stateBefore.ScheduledDays = 7
+	stateAfter := NewFSRSStateForNewCard(reviewedAt)
+
+	rec, err := NewSwipeRecord("user-1", "card-1", CardgroupID("cg-1"), RatingGood, reviewedAt, stateBefore, stateAfter)
+	require.NoError(t, err)
+
+	require.NotSame(t, &stateBefore.Phase, rec.PhaseBefore, "PhaseBefore must not alias the caller's stateBefore")
+	require.NotSame(t, &stateBefore.ScheduledDays, rec.ScheduledDaysBefore, "ScheduledDaysBefore must not alias the caller's stateBefore")
+
+	// Mutating the caller's copy after construction must not change the record.
+	stateBefore.Phase = FSRSPhaseNew
+	stateBefore.ScheduledDays = 999
+	require.Equal(t, FSRSPhaseReview, *rec.PhaseBefore, "PhaseBefore is an independent copy")
+	require.Equal(t, 7, *rec.ScheduledDaysBefore, "ScheduledDaysBefore is an independent copy")
 }
 
 func TestNewSwipeRecord_EmptyCardgroupID(t *testing.T) {
 	t.Parallel()
 
 	reviewedAt := time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC)
+	state := NewFSRSStateForNewCard(reviewedAt)
 
-	_, err := NewSwipeRecord("user-1", "card-1", CardgroupID(""), RatingEasy, reviewedAt, NewFSRSStateForNewCard(reviewedAt))
+	_, err := NewSwipeRecord("user-1", "card-1", CardgroupID(""), RatingEasy, reviewedAt, state, state)
 	require.EqualError(t, err, "swipe record: cardgroupID is required")
 }

--- a/backend/internal/repository/swipe_record.go
+++ b/backend/internal/repository/swipe_record.go
@@ -26,6 +26,10 @@ type gormSwipeRecord struct {
 	Lapses        int       `gorm:"column:lapses"`
 	State         int       `gorm:"column:state"`
 	LastReview    time.Time `gorm:"column:last_review"`
+	// Pre-swipe snapshot columns. Nullable: a NULL marks a legacy row recorded
+	// before the columns existed.
+	PhaseBefore         *int16 `gorm:"column:phase_before"`
+	ScheduledDaysBefore *int   `gorm:"column:scheduled_days_before"`
 }
 
 func (gormSwipeRecord) TableName() string { return "swipe_records" }
@@ -137,33 +141,61 @@ func (r *swipeRecordRepo) CreateTx(ctx context.Context, tx *gorm.DB, sr *domain.
 }
 
 func swipeRecordToRow(sr *domain.SwipeRecord) *gormSwipeRecord {
+	var phaseBefore *int16
+	if sr.PhaseBefore != nil {
+		v := int16(*sr.PhaseBefore)
+		phaseBefore = &v
+	}
+	var scheduledDaysBefore *int
+	if sr.ScheduledDaysBefore != nil {
+		v := *sr.ScheduledDaysBefore
+		scheduledDaysBefore = &v
+	}
 	return &gormSwipeRecord{
-		ID:            sr.ID,
-		UserID:        string(sr.UserID),
-		CardID:        sr.CardID,
-		CardgroupID:   string(sr.CardgroupID),
-		Rating:        int(sr.Rating),
-		ReviewedAt:    sr.ReviewedAt,
-		Due:           sr.StateAfter.Due,
-		Stability:     sr.StateAfter.Stability,
-		Difficulty:    sr.StateAfter.Difficulty,
-		ElapsedDays:   sr.StateAfter.ElapsedDays,
-		ScheduledDays: sr.StateAfter.ScheduledDays,
-		Reps:          sr.StateAfter.Reps,
-		Lapses:        sr.StateAfter.Lapses,
-		State:         int(sr.StateAfter.Phase),
-		LastReview:    sr.StateAfter.LastReview,
+		ID:                  sr.ID,
+		UserID:              string(sr.UserID),
+		CardID:              sr.CardID,
+		CardgroupID:         string(sr.CardgroupID),
+		Rating:              int(sr.Rating),
+		ReviewedAt:          sr.ReviewedAt,
+		Due:                 sr.StateAfter.Due,
+		Stability:           sr.StateAfter.Stability,
+		Difficulty:          sr.StateAfter.Difficulty,
+		ElapsedDays:         sr.StateAfter.ElapsedDays,
+		ScheduledDays:       sr.StateAfter.ScheduledDays,
+		Reps:                sr.StateAfter.Reps,
+		Lapses:              sr.StateAfter.Lapses,
+		State:               int(sr.StateAfter.Phase),
+		LastReview:          sr.StateAfter.LastReview,
+		PhaseBefore:         phaseBefore,
+		ScheduledDaysBefore: scheduledDaysBefore,
 	}
 }
 
 func swipeRecordToDomain(row gormSwipeRecord) (*domain.SwipeRecord, error) {
 	rating := domain.Rating(row.Rating)
 	if !rating.IsValid() {
-		return nil, eris.Errorf("repository: invalid Rating value %d for swipe record %s", row.Rating, row.ID)
+		return nil, eris.Errorf("repository: swipe record: invalid Rating value %d for swipe record %s", row.Rating, row.ID)
 	}
 	phase := domain.FSRSPhase(row.State)
 	if !phase.IsValid() {
-		return nil, eris.Errorf("repository: invalid FSRSPhase value %d for swipe record %s", row.State, row.ID)
+		return nil, eris.Errorf("repository: swipe record: invalid FSRSPhase value %d for swipe record %s", row.State, row.ID)
+	}
+	// Pre-swipe snapshot columns are nullable (NULL = legacy row). A non-nil
+	// phase_before that is out of range is a corrupt persisted value; reject it
+	// rather than reconstitute a SwipeRecord carrying an invalid phase.
+	var phaseBefore *domain.FSRSPhase
+	if row.PhaseBefore != nil {
+		p := domain.FSRSPhase(*row.PhaseBefore)
+		if !p.IsValid() {
+			return nil, eris.Errorf("repository: swipe record: invalid phase_before value %d for swipe record %s", *row.PhaseBefore, row.ID)
+		}
+		phaseBefore = &p
+	}
+	var scheduledDaysBefore *int
+	if row.ScheduledDaysBefore != nil {
+		v := *row.ScheduledDaysBefore
+		scheduledDaysBefore = &v
 	}
 	return &domain.SwipeRecord{
 		ID:          row.ID,
@@ -183,5 +215,7 @@ func swipeRecordToDomain(row gormSwipeRecord) (*domain.SwipeRecord, error) {
 			Phase:         phase,
 			LastReview:    row.LastReview,
 		},
+		PhaseBefore:         phaseBefore,
+		ScheduledDaysBefore: scheduledDaysBefore,
 	}, nil
 }

--- a/backend/internal/repository/swipe_record_test.go
+++ b/backend/internal/repository/swipe_record_test.go
@@ -23,9 +23,12 @@ func TestSwipeRecordRepository_CreateTxAndFind(t *testing.T) {
 	card := newCard(cg.ID, "front", "back")
 	require.NoError(t, cardRepo.Create(ctx, card))
 	reviewedAt := time.Now().UTC()
+	stateBefore := domain.NewFSRSStateForNewCard(reviewedAt)
+	stateBefore.Phase = domain.FSRSPhaseReview
+	stateBefore.ScheduledDays = 3
 	state := domain.NewFSRSStateForNewCard(reviewedAt)
 	state.Reps = 1
-	sr, err := domain.NewSwipeRecord(domain.UserID(ownerID), card.ID, cg.ID, domain.RatingEasy, reviewedAt, state)
+	sr, err := domain.NewSwipeRecord(domain.UserID(ownerID), card.ID, cg.ID, domain.RatingEasy, reviewedAt, stateBefore, state)
 	require.NoError(t, err)
 
 	require.NoError(t, testDB.GORM.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
@@ -39,6 +42,11 @@ func TestSwipeRecordRepository_CreateTxAndFind(t *testing.T) {
 	require.Equal(t, cg.ID, byID[sr.ID].CardgroupID)
 	require.Equal(t, domain.RatingEasy, byID[sr.ID].Rating)
 	require.Equal(t, state.Reps, byID[sr.ID].StateAfter.Reps)
+	// The pre-swipe snapshot survives the CreateTx -> read roundtrip.
+	require.NotNil(t, byID[sr.ID].PhaseBefore)
+	require.Equal(t, domain.FSRSPhaseReview, *byID[sr.ID].PhaseBefore)
+	require.NotNil(t, byID[sr.ID].ScheduledDaysBefore)
+	require.Equal(t, 3, *byID[sr.ID].ScheduledDaysBefore)
 
 	history, err := swipeRepo.FindByUserAndCardgroup(ctx, ownerID, string(cg.ID))
 	require.NoError(t, err)
@@ -60,7 +68,7 @@ func TestSwipeRecordRepository_FindByUserAndCardgroup_UsesDenormalizedCardgroup(
 	require.NoError(t, cardRepo.Create(ctx, card))
 	reviewedAt := time.Now().UTC().Truncate(time.Microsecond)
 	state := domain.NewFSRSStateForNewCard(reviewedAt)
-	sr, err := domain.NewSwipeRecord(domain.UserID(ownerID), card.ID, cgAtSwipe.ID, domain.RatingGood, reviewedAt, state)
+	sr, err := domain.NewSwipeRecord(domain.UserID(ownerID), card.ID, cgAtSwipe.ID, domain.RatingGood, reviewedAt, state, state)
 	require.NoError(t, err)
 
 	require.NoError(t, testDB.GORM.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
@@ -286,4 +294,72 @@ func TestSwipeRecordRepository_OutOfRangeState_ReturnsError(t *testing.T) {
 			require.Contains(t, err.Error(), "invalid FSRSPhase value 99")
 		})
 	}
+}
+
+// TestSwipeRecordRepository_LegacyRowWithoutSnapshot_ReadsBackNil proves a row
+// inserted without the phase_before / scheduled_days_before columns (a legacy
+// row recorded before the migration) reads back with both snapshot pointers nil
+// — the sentinel the metrics layer branches on.
+func TestSwipeRecordRepository_LegacyRowWithoutSnapshot_ReadsBackNil(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	ownerID := insertAuthUser(t, ctx)
+	cg := insertCardgroup(t, ctx, ownerID)
+	cardRepo := repository.NewCardRepository(testDB.GORM)
+	swipeRepo := repository.NewSwipeRecordRepository(testDB.GORM)
+
+	card := newCard(cg.ID, "legacy snapshot front", "back")
+	require.NoError(t, cardRepo.Create(ctx, card))
+
+	reviewedAt := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	const rowID = "00000000-0000-0000-0000-0000000000d1"
+	// Raw insert omitting phase_before / scheduled_days_before; both default to NULL.
+	require.NoError(t, testDB.GORM.WithContext(ctx).Exec(
+		`INSERT INTO swipe_records
+		   (id, user_id, card_id, cardgroup_id, rating, reviewed_at,
+		    due, stability, difficulty, elapsed_days, scheduled_days,
+		    reps, lapses, state, last_review)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		rowID, ownerID, card.ID, string(cg.ID), int(domain.RatingGood), reviewedAt,
+		reviewedAt, 2.5, 5.0, 0, 0, 0, 0, int(domain.FSRSPhaseNew), reviewedAt,
+	).Error)
+
+	byID, err := swipeRepo.FindByIDs(ctx, []string{rowID})
+	require.NoError(t, err)
+	require.Len(t, byID, 1)
+	require.Nil(t, byID[rowID].PhaseBefore, "legacy row's phase_before reads back as nil")
+	require.Nil(t, byID[rowID].ScheduledDaysBefore, "legacy row's scheduled_days_before reads back as nil")
+}
+
+// TestSwipeRecordRepository_OutOfRangePhaseBefore_ReturnsError proves a non-nil
+// phase_before holding a value outside domain.FSRSPhase.IsValid surfaces a
+// repository error rather than reconstituting a SwipeRecord with an invalid
+// snapshot phase.
+func TestSwipeRecordRepository_OutOfRangePhaseBefore_ReturnsError(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	ownerID := insertAuthUser(t, ctx)
+	cg := insertCardgroup(t, ctx, ownerID)
+	cardRepo := repository.NewCardRepository(testDB.GORM)
+	swipeRepo := repository.NewSwipeRecordRepository(testDB.GORM)
+
+	card := newCard(cg.ID, "out of range phase_before", "back")
+	require.NoError(t, cardRepo.Create(ctx, card))
+
+	reviewedAt := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	const rowID = "00000000-0000-0000-0000-0000000000d2"
+	// state stays valid (FSRSPhaseNew); only phase_before is corrupt (99).
+	require.NoError(t, testDB.GORM.WithContext(ctx).Exec(
+		`INSERT INTO swipe_records
+		   (id, user_id, card_id, cardgroup_id, rating, reviewed_at,
+		    due, stability, difficulty, elapsed_days, scheduled_days,
+		    reps, lapses, state, last_review, phase_before, scheduled_days_before)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		rowID, ownerID, card.ID, string(cg.ID), int(domain.RatingGood), reviewedAt,
+		reviewedAt, 2.5, 5.0, 0, 0, 0, 0, int(domain.FSRSPhaseNew), reviewedAt, 99, 3,
+	).Error)
+
+	_, err := swipeRepo.FindByIDs(ctx, []string{rowID})
+	require.Error(t, err, "an out-of-range phase_before must propagate as an error")
+	require.Contains(t, err.Error(), "swipe record: invalid phase_before value 99")
 }

--- a/backend/internal/usecase/swipe.go
+++ b/backend/internal/usecase/swipe.go
@@ -51,7 +51,7 @@ type swipeUsecase struct {
 	userFSRSRepo   UserCardFSRSRepoForSwipe
 	scheduler      *service.FSRSScheduler
 	applyRating    func(current *domain.UserCardFSRS, scheduler domain.FSRSScheduler, rating domain.Rating, now time.Time) error
-	newSwipeRecord func(userID domain.UserID, cardID string, cardgroupID domain.CardgroupID, rating domain.Rating, reviewedAt time.Time, stateAfter domain.FSRSState) (*domain.SwipeRecord, error)
+	newSwipeRecord func(userID domain.UserID, cardID string, cardgroupID domain.CardgroupID, rating domain.Rating, reviewedAt time.Time, stateBefore, stateAfter domain.FSRSState) (*domain.SwipeRecord, error)
 	tx             txRunner
 	logger         *slog.Logger
 }
@@ -182,6 +182,10 @@ func (u *swipeUsecase) HandleSwipe(ctx context.Context, in HandleSwipeInput) (Ha
 		if current == nil {
 			current = domain.NewUserCardFSRSForNewCard(domain.UserID(user.Sub), card.ID, now)
 		}
+		// Snapshot the pre-swipe state before applyRating mutates current.State
+		// in place. For a brand-new card current came from
+		// NewUserCardFSRSForNewCard, so before.Phase == FSRSPhaseNew.
+		before := current.State
 		if err := u.applyRating(current, u.scheduler, rating, now); err != nil {
 			return eris.Wrap(err, "usecase: swipe: apply rating")
 		}
@@ -191,7 +195,7 @@ func (u *swipeUsecase) HandleSwipe(ctx context.Context, in HandleSwipeInput) (Ha
 			}
 			return eris.Wrap(err, "usecase: swipe: upsert user-card fsrs")
 		}
-		sr, err := u.newSwipeRecord(domain.UserID(user.Sub), card.ID, card.CardgroupID, rating, now, current.State)
+		sr, err := u.newSwipeRecord(domain.UserID(user.Sub), card.ID, card.CardgroupID, rating, now, before, current.State)
 		if err != nil {
 			return eris.Wrap(err, "usecase: swipe: new swipe record")
 		}

--- a/backend/internal/usecase/swipe_error_test.go
+++ b/backend/internal/usecase/swipe_error_test.go
@@ -162,7 +162,7 @@ func TestSwipeUsecase_HandleSwipe_NewSwipeRecordError_PinsChain(t *testing.T) {
 		userFSRSRepo,
 		newTestLogger(),
 	)
-	uc.(*swipeUsecase).newSwipeRecord = func(_ domain.UserID, _ string, _ domain.CardgroupID, _ domain.Rating, _ time.Time, _ domain.FSRSState) (*domain.SwipeRecord, error) {
+	uc.(*swipeUsecase).newSwipeRecord = func(_ domain.UserID, _ string, _ domain.CardgroupID, _ domain.Rating, _ time.Time, _, _ domain.FSRSState) (*domain.SwipeRecord, error) {
 		return nil, infraErr
 	}
 

--- a/backend/internal/usecase/swipe_performance_test.go
+++ b/backend/internal/usecase/swipe_performance_test.go
@@ -20,6 +20,12 @@ type mockSwipeRecordRepoForSwipe struct {
 	listUserID string
 	listLimit  int
 	created    *domain.SwipeRecord
+	// phaseBeforeAtCreate is a value snapshot of created.PhaseBefore taken at
+	// CreateTx call time, so an "X before Y" ordering assertion sees the
+	// pre-rating phase rather than a post-hoc read of a possibly-mutated state
+	// (docs/backend/library-gotchas/mock-snapshot-for-ordering-assertion.md).
+	phaseBeforeAtCreate *domain.FSRSPhase
+	phaseAfterAtCreate  *domain.FSRSPhase
 }
 
 func (m *mockSwipeRecordRepoForSwipe) CreateTx(_ context.Context, _ *gorm.DB, sr *domain.SwipeRecord) error {
@@ -27,6 +33,14 @@ func (m *mockSwipeRecordRepoForSwipe) CreateTx(_ context.Context, _ *gorm.DB, sr
 		return m.createErr
 	}
 	m.created = sr
+	if sr != nil {
+		if sr.PhaseBefore != nil {
+			p := *sr.PhaseBefore
+			m.phaseBeforeAtCreate = &p
+		}
+		after := sr.StateAfter.Phase
+		m.phaseAfterAtCreate = &after
+	}
 	m.recent = append([]*domain.SwipeRecord{sr}, m.recent...)
 	return nil
 }
@@ -182,6 +196,63 @@ func TestSwipeUsecase_HandleSwipeCreatesUserFSRSStateForFirstSwipe(t *testing.T)
 	}
 	if swipeRepo.created.CardgroupID != "cg-1" {
 		t.Fatalf("created swipe cardgroup=%q, want cg-1", swipeRepo.created.CardgroupID)
+	}
+}
+
+// TestSwipeUsecase_HandleSwipe_RecordsPreRatingPhase proves the swipe record
+// handed to CreateTx carries the phase the card was in BEFORE applyRating
+// mutated it, not the post-rating phase. For a brand-new card the pre-swipe
+// phase is FSRSPhaseNew; a RatingEasy graduation advances StateAfter.Phase past
+// New, so asserting PhaseBefore == New AND StateAfter.Phase != New pins that the
+// snapshot was captured before the mutation. The mock snapshots PhaseBefore at
+// CreateTx call time (docs/backend/library-gotchas/mock-snapshot-for-ordering-assertion.md).
+func TestSwipeUsecase_HandleSwipe_RecordsPreRatingPhase(t *testing.T) {
+	t.Parallel()
+
+	cardRepo := &mockCardRepository{
+		findResult: &domain.Card{
+			ID:          "card-1",
+			CardgroupID: domain.CardgroupID("cg-1"),
+		},
+	}
+	cardgroupRepo := &mockCardgroupRepoForCard{
+		findResult: &domain.Cardgroup{ID: domain.CardgroupID("cg-1"), OwnerID: "user-1"},
+	}
+	swipeRepo := &mockSwipeRecordRepoForSwipe{}
+	userFSRSRepo := &mockUserCardFSRSRepository{byCardID: map[string]*domain.UserCardFSRS{}}
+	tx, _ := fakeTxRunner()
+	uc := NewSwipeUsecaseWithTx(
+		cardRepo,
+		cardgroupRepo,
+		swipeRepo,
+		service.NewFSRSScheduler(),
+		tx,
+		userFSRSRepo,
+		newTestLogger(),
+	)
+
+	outcome, err := uc.HandleSwipe(authedCtx("user-1"), HandleSwipeInput{
+		CardID:      "card-1",
+		CardgroupID: "cg-1",
+		Rating:      int(domain.RatingEasy),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if outcome.Swipe == nil {
+		t.Fatal("expected non-nil Swipe on success")
+	}
+	if swipeRepo.phaseBeforeAtCreate == nil {
+		t.Fatal("expected a pre-swipe phase snapshot to be captured at CreateTx call time")
+	}
+	if *swipeRepo.phaseBeforeAtCreate != domain.FSRSPhaseNew {
+		t.Fatalf("PhaseBefore=%d, want FSRSPhaseNew (%d)", *swipeRepo.phaseBeforeAtCreate, domain.FSRSPhaseNew)
+	}
+	if swipeRepo.phaseAfterAtCreate == nil || *swipeRepo.phaseAfterAtCreate == domain.FSRSPhaseNew {
+		t.Fatalf("StateAfter.Phase must have advanced past FSRSPhaseNew, got %v", swipeRepo.phaseAfterAtCreate)
+	}
+	if swipeRepo.created.ScheduledDaysBefore == nil {
+		t.Fatal("expected a non-nil ScheduledDaysBefore snapshot for a swipe recorded through the constructor")
 	}
 }
 


### PR DESCRIPTION
## Summary

A formal review (Z3 model-check of the doc-declared spec against the implemented spec, with counterexamples reproduced against the installed `go-fsrs` v3.3.1 and the production `ComputeMetrics`) found that the `/stats` Retention and Lapse tiles misclassify swipes because `domain.SwipeRecord` records only the post-rating state (`StateAfter`). The user-facing meaning those tiles promise — "reviews of already-learned cards", "recalled by the due date" — needs the *pre-swipe* phase and the interval scheduled *before* the swipe, which `StateAfter` cannot recover unambiguously (a Learning→Easy graduation and a Review→Hard review both land on `Phase == Review`).

This PR is **data capture only**: it records the pre-swipe snapshot on the swipe event going forward. The metric formulas are unchanged here — that fix is the follow-up (#955), which is stacked on this branch.

## Changes

### Backend

- `backend/internal/database/migrations/20260718000000_add_pre_swipe_snapshot_to_swipe_records.{up,down}.sql` — **new** migration adding nullable `phase_before smallint` and `scheduled_days_before integer` to `swipe_records`. Nullable with no backfill: `NULL` is the meaningful "legacy row recorded before this column existed" sentinel the metrics layer branches on.
- `backend/internal/domain/swipe_record.go` — `SwipeRecord` gains `PhaseBefore *FSRSPhase` and `ScheduledDaysBefore *int`; `NewSwipeRecord` takes a new `stateBefore FSRSState` parameter and populates the pointers from independent local copies.
- `backend/internal/usecase/swipe.go` — capture `before := current.State` before `applyRating` mutates it, and thread it into the swipe-record constructor. A brand-new card's pre-swipe phase is `FSRSPhaseNew` by construction.
- `backend/internal/repository/swipe_record.go` — `gormSwipeRecord` gains the two nullable columns, mapped both directions; a non-nil-but-out-of-range `phase_before` is rejected as a corrupt persisted value. (Two adjacent pre-existing validation messages were brought onto the file's `repository: swipe record:` two-segment prefix, now that the new line sits beside them.)

### Tests

- `backend/internal/domain/swipe_record_test.go` — constructor populates the snapshot from `stateBefore`, and the pointers are independent copies (`require.NotSame`).
- `backend/internal/repository/swipe_record_test.go` — Docker-gated CreateTx→read roundtrip carries both fields; a legacy raw insert reads back `nil`/`nil`; an out-of-range `phase_before` errors.
- `backend/internal/usecase/swipe_{error,performance}_test.go` — constructor fan-out updated to the new signature.
- `backend/internal/database/{learn_display_mode,cards_position,users_version}_roundtrip_test.go` — `m.Steps` anchors bumped by one for the appended migration.

## Test plan

- [ ] `go vet ./... && go build ./... && go test ./...` — green (the migration roundtrip + new repo roundtrips are Docker-gated and run in CI; Docker was unavailable locally)
- [ ] `go tool go-arch-lint check --project-path .` — no layering violations
- [ ] `go tool gqlgen generate` — zero diff (no schema change)

## Notes

- No GraphQL/schema change — neither new column is exposed on the wire.
- The metric-formula fix that consumes these columns is #955, stacked on this branch.

Closes #954
