### PR TITLE
docs(stats): state the 365-day cap on studyStreak in schema and hint copy

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -439,7 +439,7 @@
     "diagnosticsRetentionHint": "Share of reviews you recalled correctly by their due date. Higher means memory is holding as planned.",
     "diagnosticsSuccessHint": "Share of swipes you rated a success. A rough gauge of how confident your answers felt.",
     "diagnosticsLapseHint": "Among already-learned cards, the share you forgot on review. Lower means they're sticking.",
-    "diagnosticsStreakHint": "Days you've studied without a gap, up to today, calculated from the last 365 days regardless of the selected period. Missing a day resets it.",
+    "diagnosticsStreakHint": "Days you've studied without a gap, up to today, calculated from the last 365 days regardless of the selected period — so the count maxes out at 365. Missing a day resets it.",
     "diagnosticsReviewsHint": "Your total swipes over the last {days} days.",
     "diagnosticsAvgDifficultyHint": "Average \"hardness\" FSRS assigns your cards (0–10; higher is harder).",
     "diagnosticsHintAriaLabel": "About {metric}",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -439,7 +439,7 @@
     "diagnosticsRetentionHint": "復習の予定日までに正しく思い出せたカードの割合です。高いほど記憶が計画どおり保持できています。",
     "diagnosticsSuccessHint": "スワイプ評価が「できた」だった割合です。学習の手ごたえの目安になります。",
     "diagnosticsLapseHint": "一度覚えたカードの復習で「忘れた」を出した割合です。低いほどしっかり定着しています。",
-    "diagnosticsStreakHint": "選択した期間にかかわらず、直近365日を基準に今日まで途切れずに学習を続けた日数です。1日でも空くと途切れます。",
+    "diagnosticsStreakHint": "選択した期間にかかわらず、直近365日を基準に今日まで途切れずに学習を続けた日数です（最大365日）。1日でも空くと途切れます。",
     "diagnosticsReviewsHint": "直近{days}日間にスワイプした合計回数です。",
     "diagnosticsAvgDifficultyHint": "FSRSがカードごとに算出する「覚えにくさ」の平均です（0〜10、高いほど難しい）。",
     "diagnosticsHintAriaLabel": "{metric}の説明",

--- a/schema/stats.graphql
+++ b/schema/stats.graphql
@@ -14,7 +14,7 @@ type LearningStats {
   ownsAnyDeck: Boolean!
 }
 
-"""Trailing rolling-window diagnostic snapshots. days30/days7 are computed from the swipes inside each window; studyStreak is always computed from the full 365-day set so long streaks are never under-reported."""
+"""Trailing rolling-window diagnostic snapshots. days30/days7 are computed from the swipes inside each window; studyStreak is always computed from the full 365-day set, so every window reports the same value. Because the source window is 365 days, the reported streak is capped at 365 days."""
 type PerformanceWindows {
   """Snapshot over the trailing 365-day window."""
   days365: PerformanceMetrics!


### PR DESCRIPTION
## Summary

`schema/stats.graphql` promised that `studyStreak` is "always computed from the full 365-day set so long streaks are **never under-reported**". A Z3 model-check produced a counterexample: the stats usecase fetches only the trailing 365 days of swipes (`statsWindowDays = 365`), so a true 465-day streak is reported as ~366. The model also proved the report is exact for any streak that fits inside the window, so the honest fix is wording, not a computation change (counting from full history was considered and rejected — it needs a new aggregate query for a diagnostics nicety that only differs after a year of unbroken daily study).

## Changes

### Schema

- `schema/stats.graphql` — the `PerformanceWindows` description now states that because the source window is 365 days, the reported streak is **capped at 365 days**.

### Frontend

- `frontend/messages/{en,ja}.json` — `Stats.diagnosticsStreakHint` updated to note the count maxes out at 365 days. `diagnosticsStreakCaption` was already accurate and is untouched.

## Test plan

- [ ] `go vet ./... && go build ./... && go test ./...` — green (Docker-gated integration suites run in CI)
- [ ] `tsc --noEmit`, `biome`, `vitest run` — pass
- [ ] `pnpm lint:schema` — pass; regenerated gqlgen/codegen output embeds the new description

## Notes

- Wording only — no change to streak computation or window filtering.
- The Go `studyStreak` docstring rides the sibling metric-fix PR (#955) to avoid a same-file conflict.

Closes #956
