### PR TITLE
fix(stats): clamp per-deck acquired to totalCards and correct the DeckMastery docstring

### DIFF
--- a/backend/internal/domain/service/user_performance.go
+++ b/backend/internal/domain/service/user_performance.go
@@ -14,8 +14,10 @@ import (
 type MasteryBreakdown struct{ InProgress, Learned, Mature, TotalStudied int }
 
 // DeckMastery is a per-deck acquisition summary. LearnedCards and MatureCards
-// are disjoint; acquired == LearnedCards + MatureCards, and acquired never
-// exceeds TotalCards.
+// are disjoint; acquired == LearnedCards + MatureCards. Because the stats
+// usecase reads FSRS states and deck totals in two separate, non-transactional
+// queries, a concurrent card deletion can transiently make acquired exceed
+// TotalCards; consumers must clamp acquired to TotalCards at display time.
 type DeckMastery struct {
 	CardgroupID  string
 	TotalCards   int

--- a/frontend/src/app/stats/per-deck-list.test.tsx
+++ b/frontend/src/app/stats/per-deck-list.test.tsx
@@ -1,0 +1,75 @@
+// @vitest-environment happy-dom
+import { screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { MyLearningStatsQuery } from "@/generated/graphql";
+import { renderWithIntl } from "@/test/render-with-intl";
+import { PerDeckList } from "./per-deck-list";
+
+type Decks = MyLearningStatsQuery["myLearningStats"]["decks"];
+
+function deck(overrides: Partial<Decks[number]> & { id: string; name: string }): Decks[number] {
+  const { id, name, ...rest } = overrides;
+  return {
+    __typename: "DeckMastery",
+    cardgroup: { __typename: "Cardgroup", id, name },
+    totalCards: 0,
+    learnedCards: 0,
+    matureCards: 0,
+    ...rest,
+  };
+}
+
+describe("<PerDeckList>", () => {
+  it("renders the acquired/total count, the whole-percent share, and a filled meter", () => {
+    renderWithIntl(
+      <PerDeckList
+        decks={[
+          deck({
+            id: "cg-1",
+            name: "Spanish Vocab",
+            totalCards: 500,
+            learnedCards: 100,
+            matureCards: 20,
+          }),
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("Spanish Vocab")).toBeInTheDocument();
+    // acquired = learned + mature = 120, total = 500.
+    expect(screen.getByText("120/500")).toBeInTheDocument();
+    // share = 120 / 500 = 24%.
+    expect(screen.getByText("24%")).toBeInTheDocument();
+    expect(screen.getByRole("progressbar", { name: "Spanish Vocab" })).toHaveAttribute(
+      "aria-valuenow",
+      "24",
+    );
+  });
+
+  it("clamps the count and meter to totalCards when a non-transactional snapshot overshoots", () => {
+    // The backend reads FSRS states and deck totals in two separate queries, so a
+    // concurrent card deletion can leave acquired (5) above totalCards (2). The row
+    // must render "2/2" at 100%, never the raw "5/2".
+    renderWithIntl(
+      <PerDeckList
+        decks={[
+          deck({
+            id: "cg-1",
+            name: "Spanish Vocab",
+            totalCards: 2,
+            learnedCards: 3,
+            matureCards: 2,
+          }),
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("2/2")).toBeInTheDocument();
+    expect(screen.queryByText("5/2")).not.toBeInTheDocument();
+    expect(screen.getByText("100%")).toBeInTheDocument();
+    expect(screen.getByRole("progressbar", { name: "Spanish Vocab" })).toHaveAttribute(
+      "aria-valuenow",
+      "100",
+    );
+  });
+});

--- a/frontend/src/app/stats/per-deck-list.tsx
+++ b/frontend/src/app/stats/per-deck-list.tsx
@@ -9,10 +9,16 @@ type Decks = MyLearningStatsQuery["myLearningStats"]["decks"];
 /**
  * Per-deck acquisition list for `/stats`. One row per owned deck (with at least
  * one card): the deck name, a `ProgressMeter` filled to `acquired / totalCards`,
- * the raw `acquired/total` count, and the whole-percent share. `acquired` counts
+ * the `acquired/total` count, and the whole-percent share. `acquired` counts
  * Learned + Mature cards (the two are disjoint on the backend). `totalCards === 0`
  * guards to 0% and the share is clamped to `<= 100%` (mirroring `ProgressMeter`'s
  * own defensive clamp) so the percent text can never disagree with the bar.
+ *
+ * The count text and the meter render `displayAcquired = min(acquired, totalCards)`
+ * rather than the raw `acquired`: the backend derives the two inputs from two
+ * separate, non-transactional reads (FSRS states, then deck totals), so a
+ * concurrent card deletion can transiently make `acquired` exceed `totalCards`.
+ * Clamping keeps the row from rendering a nonsensical "5/2".
  *
  * Callers must render this only for a non-empty `decks` list (`StatsClient` gates
  * on `hasDecks`); an empty list would render a headed-but-empty section.
@@ -28,6 +34,7 @@ export function PerDeckList({ decks }: { decks: Decks }) {
         {decks.map((deck) => {
           const acquired = deck.learnedCards + deck.matureCards;
           const share = deck.totalCards > 0 ? Math.min(1, acquired / deck.totalCards) : 0;
+          const displayAcquired = Math.min(acquired, deck.totalCards);
           return (
             <li key={deck.cardgroup.id} className="flex flex-col gap-1.5">
               <div className="flex items-baseline justify-between gap-2">
@@ -36,9 +43,13 @@ export function PerDeckList({ decks }: { decks: Decks }) {
                   {format.number(share, { style: "percent", maximumFractionDigits: 0 })}
                 </span>
               </div>
-              <ProgressMeter value={acquired} max={deck.totalCards} label={deck.cardgroup.name} />
+              <ProgressMeter
+                value={displayAcquired}
+                max={deck.totalCards}
+                label={deck.cardgroup.name}
+              />
               <span className="text-xs text-muted-foreground tabular-nums">
-                {t("perDeckAcquiredOfTotal", { acquired, total: deck.totalCards })}
+                {t("perDeckAcquiredOfTotal", { acquired: displayAcquired, total: deck.totalCards })}
               </span>
             </li>
           );


### PR DESCRIPTION
## Summary

`service.DeckMastery`'s docstring claimed "acquired never exceeds TotalCards", but the stats usecase produces the two inputs with two non-transactional reads (FSRS states first, card totals second). A TLA+-style interleaving trace (bounded-checked in Z3) violates the claim: read 5 mature states → user deletes 3 cards (cascade) → read totals = 2, yielding "5 / 2 cards". The frontend already clamps the percent and the progress bar, but the raw per-deck count text did not. This makes the docstring honest and clamps the remaining display seam; it deliberately does **not** wrap the two reads in a transaction (that would fan a `Tx` variant across two narrow repo interfaces and every fake, for a race that self-heals on reload).

## Changes

### Backend

- `backend/internal/domain/service/user_performance.go` — the `DeckMastery` docstring now states that, because the stats usecase reads FSRS states and deck totals in two separate queries, a concurrent card deletion can transiently make acquired exceed `TotalCards`, so consumers must clamp at display time. No code change in this file.

### Frontend

- `frontend/src/app/stats/per-deck-list.tsx` — the acquired/total count text and the `ProgressMeter` value now use `Math.min(acquired, totalCards)`; the existing clamped percent share is unchanged.

### Tests

- `frontend/src/app/stats/per-deck-list.test.tsx` — **new**; a fixture with `learnedCards + matureCards > totalCards` (5 acquired / 2 total) renders "2/2" and 100%.

## Test plan

- [ ] `go vet ./... && go build ./... && go test ./...` — green (docstring-only backend change; Docker suites in CI)
- [ ] `tsc --noEmit`, `biome`, `vitest run` — pass (new per-deck-list suite included)

Closes #957
