### PR TITLE
refactor(learn): trim the HandleSwipe selection to performanceMode

### DIFF
--- a/frontend/src/app/learn/[cardgroupId]/learn-client.test.tsx
+++ b/frontend/src/app/learn/[cardgroupId]/learn-client.test.tsx
@@ -195,16 +195,6 @@ const CARD_2 = {
   cardgroupId: CG_ID,
 };
 
-const DEFAULT_METRICS = {
-  __typename: "PerformanceMetrics" as const,
-  successRate: 0.5,
-  avgDifficulty: 0.5,
-  retentionRate: 0.5,
-  studyStreak: 0,
-  lapseRate: 0,
-  reviewCount: 1,
-};
-
 /**
  * Default `LearnNextDueCards` mocks returning `[]`.
  *
@@ -317,7 +307,6 @@ function makeSwipeMock(rating: 1 | 2 | 4) {
               response: {
                 __typename: "SwipeResponse" as const,
                 performanceMode: "DIFFICULT",
-                metrics: DEFAULT_METRICS,
               },
             },
           },
@@ -1038,7 +1027,6 @@ describe("<LearnClient> onSwipe identity stability", () => {
             response: {
               __typename: "SwipeResponse" as const,
               performanceMode: "DIFFICULT",
-              metrics: DEFAULT_METRICS,
             },
           },
         },
@@ -1182,7 +1170,6 @@ describe("<LearnClient> queue prefetch", () => {
             response: {
               __typename: "SwipeResponse" as const,
               performanceMode: "DIFFICULT",
-              metrics: DEFAULT_METRICS,
             },
           },
         },
@@ -1308,7 +1295,6 @@ describe("<LearnClient> queue prefetch", () => {
             response: {
               __typename: "SwipeResponse" as const,
               performanceMode: "DIFFICULT",
-              metrics: DEFAULT_METRICS,
             },
           },
         },
@@ -1400,7 +1386,6 @@ describe("<LearnClient> queue prefetch", () => {
             response: {
               __typename: "SwipeResponse" as const,
               performanceMode: "DIFFICULT",
-              metrics: DEFAULT_METRICS,
             },
           },
         },
@@ -1458,7 +1443,6 @@ describe("<LearnClient> queue prefetch", () => {
             response: {
               __typename: "SwipeResponse" as const,
               performanceMode: "DIFFICULT",
-              metrics: DEFAULT_METRICS,
             },
           },
         },
@@ -1552,7 +1536,6 @@ describe("<LearnClient> queue prefetch", () => {
                   response: {
                     __typename: "SwipeResponse" as const,
                     performanceMode: "DIFFICULT",
-                    metrics: DEFAULT_METRICS,
                   },
                 },
               },

--- a/frontend/src/app/learn/queries.ts
+++ b/frontend/src/app/learn/queries.ts
@@ -53,14 +53,6 @@ export const HandleSwipeMutation = graphql(`
       ... on HandleSwipeSuccess {
         response {
           performanceMode
-          metrics {
-            successRate
-            avgDifficulty
-            retentionRate
-            studyStreak
-            lapseRate
-            reviewCount
-          }
         }
       }
       ... on InputValidationError {


### PR DESCRIPTION
## Summary

The `HandleSwipe` mutation selected the full `metrics { successRate avgDifficulty retentionRate studyStreak lapseRate reviewCount }` block, but no production code reads any of it — `learn-client.tsx` documents that the success payload is a deliberate no-op. Beyond dead selection weight, the swipe-flow metrics are computed from a 100-swipe count window (not a calendar window), so leaving `studyStreak` selected invites a future UI to render a wrong-but-plausible number. This trims the selection to the minimal valid field.

## Changes

### Frontend

- `frontend/src/app/learn/queries.ts` — the `HandleSwipeSuccess` branch now selects only `response { performanceMode }` (a selection set cannot be empty); the `metrics { … }` block is removed and the `InputValidationError` branch is unchanged.
- `frontend/src/app/learn/[cardgroupId]/learn-client.test.tsx` — mocked `HandleSwipeSuccess.response` payloads drop `metrics` to match the trimmed document.

## Test plan

- [ ] `tsc --noEmit`, `biome`, `vitest run`, `next build` — pass
- [ ] Post-flight consumer grep: zero production readers of `.metrics` / `studyStreak` outside `queries.ts` and generated code

## Notes

- The schema field `SwipeResponse.metrics` is **not** removed — it may serve a future in-session HUD, and dropping the selection is free to reverse whereas dropping the field forces a schema migration.

Closes #958
