### PR TITLE
chore(stats): remove the performanceWindows rollout fallback and deprecated performance field

### DIFF
--- a/backend/graph/resolver/stats_helpers.go
+++ b/backend/graph/resolver/stats_helpers.go
@@ -75,9 +75,6 @@ func toLearningStatsModel(ctx context.Context, res *usecase.LearningStatsResult)
 		},
 		Decks:       decks,
 		OwnsAnyDeck: res.OwnsAnyDeck,
-		// Keep the legacy field populated until every independently deployed
-		// frontend has switched to performanceWindows.
-		Performance: performance365,
 		PerformanceWindows: &model.PerformanceWindows{
 			Days365: performance365,
 			Days30:  toPerformanceMetricsModel(res.Windows.Days30),

--- a/backend/graph/resolver/stats_resolver_test.go
+++ b/backend/graph/resolver/stats_resolver_test.go
@@ -277,13 +277,12 @@ func ctxWithCardLoaderError(base context.Context, loadErr error) context.Context
 	return loader.WithContext(base, loaders)
 }
 
-const myLearningStatsDiagnosticQuery = `{"query":"{ myLearningStats { mastery { totalStudied } performance { retentionRate successRate lapseRate studyStreak reviewCount avgDifficulty } performanceWindows { days365 { retentionRate successRate lapseRate studyStreak reviewCount avgDifficulty } days30 { retentionRate successRate lapseRate studyStreak reviewCount avgDifficulty } days7 { retentionRate successRate lapseRate studyStreak reviewCount avgDifficulty } } strugglingCards { card { id front } lapses stability } } }"}`
+const myLearningStatsDiagnosticQuery = `{"query":"{ myLearningStats { mastery { totalStudied } performanceWindows { days365 { retentionRate successRate lapseRate studyStreak reviewCount avgDifficulty } days30 { retentionRate successRate lapseRate studyStreak reviewCount avgDifficulty } days7 { retentionRate successRate lapseRate studyStreak reviewCount avgDifficulty } } strugglingCards { card { id front } lapses stability } } }"}`
 
 // TestMyLearningStats_PerformanceAndStrugglingCards verifies the diagnostic half
-// of the response: all three performance snapshots map every metric field, the
-// legacy performance field remains an alias for days365 during the staged
-// rollout, and the struggling-card list preserves the usecase order while
-// hydrating each Card from its id via the in-memory Card DataLoader.
+// of the response: all three performance snapshots map every metric field, and
+// the struggling-card list preserves the usecase order while hydrating each Card
+// from its id via the in-memory Card DataLoader.
 func TestMyLearningStats_PerformanceAndStrugglingCards(t *testing.T) {
 	t.Parallel()
 
@@ -337,15 +336,6 @@ func TestMyLearningStats_PerformanceAndStrugglingCards(t *testing.T) {
 			if perf[field] != value {
 				t.Fatalf("%s.%s = %v, want %v; metrics: %v", name, field, perf[field], value, perf)
 			}
-		}
-	}
-	legacy, _ := stats["performance"].(map[string]any)
-	if legacy == nil {
-		t.Fatalf("expected legacy performance field, got nil; response: %v", resp)
-	}
-	for field, value := range wants["days365"] {
-		if legacy[field] != value {
-			t.Fatalf("performance.%s = %v, want %v; metrics: %v", field, legacy[field], value, legacy)
 		}
 	}
 

--- a/frontend/src/app/stats/diagnostics-panel.test.tsx
+++ b/frontend/src/app/stats/diagnostics-panel.test.tsx
@@ -97,13 +97,4 @@ describe("<DiagnosticsPanel>", () => {
     await user.click(screen.getByRole("button", { name: "Last 7 days" }));
     expect(tile("Streak").getByText("9 days")).toBeInTheDocument();
   });
-
-  it("hides unavailable short-window controls during a legacy-backend rollout", () => {
-    renderWithIntl(
-      <DiagnosticsPanel performanceWindows={performanceWindows} showWindowSelector={false} />,
-    );
-
-    expect(screen.queryByRole("group", { name: "Diagnostics period" })).not.toBeInTheDocument();
-    expect(tile("Reviews").getByText("1,430")).toBeInTheDocument();
-  });
 });

--- a/frontend/src/app/stats/diagnostics-panel.tsx
+++ b/frontend/src/app/stats/diagnostics-panel.tsx
@@ -35,10 +35,8 @@ const PERCENT_FORMAT = { style: "percent", maximumFractionDigits: 0 } as const;
  */
 export function DiagnosticsPanel({
   performanceWindows,
-  showWindowSelector = true,
 }: {
   performanceWindows: PerformanceWindows;
-  showWindowSelector?: boolean;
 }) {
   const t = useTranslations("Stats");
   const format = useFormatter();
@@ -96,33 +94,31 @@ export function DiagnosticsPanel({
     <div className="flex flex-col gap-3">
       <div className="flex items-center justify-between gap-2">
         <h2 className="text-sm font-semibold">{t("diagnosticsHeading")}</h2>
-        {showWindowSelector ? (
-          <fieldset
-            aria-label={t("diagnosticsWindowGroupAria")}
-            className="inline-flex min-w-0 shrink-0 rounded-lg border-0 bg-muted p-0.5"
-          >
-            {WINDOW_OPTIONS.map(({ key, days }) => {
-              const selected = key === selectedWindow;
-              return (
-                <button
-                  key={key}
-                  type="button"
-                  aria-label={t("diagnosticsWindowOptionAria", { days })}
-                  aria-pressed={selected}
-                  onClick={() => setSelectedWindow(key)}
-                  className={cn(
-                    "min-h-11 min-w-11 rounded-md px-3 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
-                    selected
-                      ? "bg-brand-primary text-brand-primary-foreground"
-                      : "text-muted-foreground hover:text-foreground",
-                  )}
-                >
-                  {t("diagnosticsWindowOption", { days })}
-                </button>
-              );
-            })}
-          </fieldset>
-        ) : null}
+        <fieldset
+          aria-label={t("diagnosticsWindowGroupAria")}
+          className="inline-flex min-w-0 shrink-0 rounded-lg border-0 bg-muted p-0.5"
+        >
+          {WINDOW_OPTIONS.map(({ key, days }) => {
+            const selected = key === selectedWindow;
+            return (
+              <button
+                key={key}
+                type="button"
+                aria-label={t("diagnosticsWindowOptionAria", { days })}
+                aria-pressed={selected}
+                onClick={() => setSelectedWindow(key)}
+                className={cn(
+                  "min-h-11 min-w-11 rounded-md px-3 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+                  selected
+                    ? "bg-brand-primary text-brand-primary-foreground"
+                    : "text-muted-foreground hover:text-foreground",
+                )}
+              >
+                {t("diagnosticsWindowOption", { days })}
+              </button>
+            );
+          })}
+        </fieldset>
       </div>
       {performance.reviewCount === 0 ? (
         // Dormant learner: no reviews in the window. The backend returns

--- a/frontend/src/app/stats/page.test.tsx
+++ b/frontend/src/app/stats/page.test.tsx
@@ -22,18 +22,8 @@ vi.mock("@/lib/apollo/server", () => ({
 // file. The RSC page test only needs to verify the auth/error routing and that
 // the fetched stats are forwarded.
 vi.mock("./stats-client", () => ({
-  StatsClient: ({
-    stats,
-    performanceWindowsAvailable,
-  }: {
-    stats: unknown;
-    performanceWindowsAvailable?: boolean;
-  }) => (
-    <div
-      data-testid="stats-client"
-      data-has-stats={stats != null ? "true" : "false"}
-      data-performance-windows-available={String(performanceWindowsAvailable)}
-    >
+  StatsClient: ({ stats }: { stats: unknown }) => (
+    <div data-testid="stats-client" data-has-stats={stats != null ? "true" : "false"}>
       StatsClient
     </div>
   ),
@@ -81,24 +71,6 @@ function makeStatsData() {
         },
       },
       strugglingCards: [],
-    },
-  };
-}
-
-function makeLegacyStatsData() {
-  const { performanceWindows: _performanceWindows, ...stats } = makeStatsData().myLearningStats;
-  return {
-    myLearningStats: {
-      ...stats,
-      performance: {
-        __typename: "PerformanceMetrics",
-        retentionRate: 0.72,
-        successRate: 0.8,
-        lapseRate: 0.2,
-        studyStreak: 4,
-        reviewCount: 123,
-        avgDifficulty: 0.6,
-      },
     },
   };
 }
@@ -181,136 +153,6 @@ describe("StatsPage — gqlFetch error branches", () => {
       name: "Error",
     });
   });
-
-  test("old backend without performanceWindows → retries the legacy query", async () => {
-    vi.mocked(gqlFetch)
-      .mockRejectedValueOnce(
-        new Error(
-          `GraphQL errors: ${JSON.stringify([
-            {
-              message:
-                'Cannot query field "performanceWindows" on type "LearningStats". Did you mean "performance"?',
-            },
-          ])}`,
-        ),
-      )
-      .mockResolvedValueOnce(makeLegacyStatsData() as never);
-
-    const result = await StatsPage();
-
-    expect(gqlFetch).toHaveBeenCalledTimes(2);
-    expect(redirect).not.toHaveBeenCalled();
-    expect(consoleErrorSpy).not.toHaveBeenCalled();
-    const el = findStatsClientElement(result);
-    const stats = el?.props.stats as ReturnType<typeof makeStatsData>["myLearningStats"];
-    expect(stats.performanceWindows.days365.reviewCount).toBe(123);
-    expect(stats.performanceWindows.days30.reviewCount).toBe(123);
-    expect(stats.performanceWindows.days7.reviewCount).toBe(123);
-    expect(el?.props.performanceWindowsAvailable).toBe(false);
-  });
-
-  test("legacy fallback failure → logs and rethrows the fallback error", async () => {
-    const fallbackErr = new Error("GraphQL HTTP 500");
-    vi.mocked(gqlFetch)
-      .mockRejectedValueOnce(
-        new Error(
-          'GraphQL errors: [{"message":"Cannot query field \\"performanceWindows\\" on type \\"LearningStats\\"."}]',
-        ),
-      )
-      .mockRejectedValueOnce(fallbackErr);
-
-    await expect(StatsPage()).rejects.toBe(fallbackErr);
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
-      expect.stringContaining("[stats] legacy gqlFetch failed"),
-      { name: "Error" },
-    );
-  });
-
-  test("legacy resolves with null myLearningStats → clear guard error (not TypeError), no redirect", async () => {
-    vi.mocked(gqlFetch)
-      .mockRejectedValueOnce(
-        new Error(
-          `GraphQL errors: ${JSON.stringify([
-            { message: 'Cannot query field "performanceWindows" on type "LearningStats".' },
-          ])}`,
-        ),
-      )
-      // Partial response: data present but null, errors present but non-auth →
-      // gqlFetch RETURNS { myLearningStats: null } instead of throwing.
-      .mockResolvedValueOnce({ myLearningStats: null } as never);
-
-    // The null-guard surfaces a clear invariant error, not a raw TypeError from
-    // the destructure, and it is rethrown to the error boundary (no redirect).
-    await expect(StatsPage()).rejects.toThrow(
-      "/stats: legacy myLearningStats returned null with no error",
-    );
-    expect(gqlFetch).toHaveBeenCalledTimes(2);
-    expect(redirect).not.toHaveBeenCalled();
-  });
-
-  test("UNAUTHENTICATED from legacy gqlFetch → redirect /login, no console.error", async () => {
-    vi.mocked(gqlFetch)
-      .mockRejectedValueOnce(
-        new Error(
-          `GraphQL errors: ${JSON.stringify([
-            { message: 'Cannot query field "performanceWindows" on type "LearningStats".' },
-          ])}`,
-        ),
-      )
-      .mockRejectedValueOnce(
-        new Error(
-          `GraphQL errors: ${JSON.stringify([{ extensions: { code: "UNAUTHENTICATED" } }])}`,
-        ),
-      );
-
-    await expect(StatsPage()).rejects.toThrow(`${REDIRECT_PREFIX}/login`);
-    expect(redirect).toHaveBeenCalledWith("/login");
-    // The legacy redirect path swallows the error cleanly — no log.
-    expect(consoleErrorSpy).not.toHaveBeenCalled();
-  });
-
-  test("real gqlparser 'Cannot query field' wording → triggers legacy fallback", async () => {
-    // Pin the exact validation wording isPerformanceWindowsUnavailable matches.
-    // If gqlparser's phrasing drifts, this fails instead of silently disabling
-    // the rollout fallback in production.
-    vi.mocked(gqlFetch)
-      .mockRejectedValueOnce(
-        new Error(
-          `GraphQL errors: ${JSON.stringify([
-            { message: 'Cannot query field "performanceWindows" on type "LearningStats".' },
-          ])}`,
-        ),
-      )
-      .mockResolvedValueOnce(makeLegacyStatsData() as never);
-
-    const result = await StatsPage();
-
-    expect(gqlFetch).toHaveBeenCalledTimes(2);
-    expect(redirect).not.toHaveBeenCalled();
-    expect(consoleErrorSpy).not.toHaveBeenCalled();
-    const el = findStatsClientElement(result);
-    expect(el?.props.performanceWindowsAvailable).toBe(false);
-  });
-
-  test("validation error matching only some substrings → no legacy fallback, rethrows", async () => {
-    // "Cannot query field" matches but "performanceWindows"/"LearningStats" do
-    // not → the 3-substring AND must NOT fire the fallback. Locks the predicate
-    // against loosening.
-    const primaryErr = new Error(
-      `GraphQL errors: ${JSON.stringify([
-        { message: 'Cannot query field "somethingElse" on type "Query".' },
-      ])}`,
-    );
-    vi.mocked(gqlFetch).mockRejectedValueOnce(primaryErr);
-
-    await expect(StatsPage()).rejects.toBe(primaryErr);
-    expect(gqlFetch).toHaveBeenCalledTimes(1);
-    expect(redirect).not.toHaveBeenCalled();
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
-      expect.stringContaining("[stats] gqlFetch failed"),
-      { name: "Error" },
-    );
-  });
 });
 
 // ---------------------------------------------------------------------------
@@ -340,7 +182,7 @@ describe("StatsPage — data guard + happy path", () => {
 // JSX tree helper
 // ---------------------------------------------------------------------------
 
-type StatsClientProps = { stats: unknown; performanceWindowsAvailable?: boolean };
+type StatsClientProps = { stats: unknown };
 
 /**
  * Recursively search a React element tree for the StatsClient stub element so

--- a/frontend/src/app/stats/page.tsx
+++ b/frontend/src/app/stats/page.tsx
@@ -1,106 +1,32 @@
 import type { Metadata } from "next";
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
-import type {
-  LegacyMyLearningStatsQuery as LegacyMyLearningStatsQueryType,
-  MyLearningStatsQuery as MyLearningStatsQueryType,
-} from "@/generated/graphql";
+import type { MyLearningStatsQuery as MyLearningStatsQueryType } from "@/generated/graphql";
 import { isUnauthenticatedGraphQLError } from "@/lib/apollo/graphql-errors";
 import { gqlFetch } from "@/lib/apollo/server";
 import { readAuthContext } from "@/lib/supabase/auth-status";
-import { LegacyMyLearningStatsQuery, MyLearningStatsQuery } from "./queries";
+import { MyLearningStatsQuery } from "./queries";
 import { StatsClient } from "./stats-client";
 
 export const metadata: Metadata = { title: "Progress" };
-
-// Detect an old backend that predates the `performanceWindows` field by
-// matching the GraphQL validation error text. This is a DELIBERATE, SCOPED
-// exception to this repo's convention of parsing `extensions.code` rather than
-// substring-matching a GraphQL error message: validation-phase errors
-// ("Cannot query field ...") carry only the generic `GRAPHQL_VALIDATION_FAILED`
-// code with no field identity, so — unlike the `UNAUTHENTICATED` / `FORBIDDEN`
-// codes parsed structurally elsewhere in this file — the offending field name
-// is recoverable only from the message text. This is a temporary rollout shim,
-// removable once every backend exposes `performanceWindows`.
-function isPerformanceWindowsUnavailable(err: unknown): boolean {
-  return (
-    err instanceof Error &&
-    err.message.includes("Cannot query field") &&
-    err.message.includes("performanceWindows") &&
-    err.message.includes("LearningStats")
-  );
-}
-
-function adaptLegacyStats(data: LegacyMyLearningStatsQueryType): MyLearningStatsQueryType {
-  // Mirror the primary-path null-guard (see StatsPage below): a partial GraphQL
-  // response can carry `myLearningStats: null` alongside a non-auth error, in
-  // which case gqlFetch returns the data instead of throwing. Surface that as a
-  // clear invariant error rather than letting the destructure throw a raw
-  // TypeError that the fetch catch would then mislabel as a "gqlFetch failed".
-  if (!data.myLearningStats) {
-    throw new Error("/stats: legacy myLearningStats returned null with no error");
-  }
-  const { performance, ...stats } = data.myLearningStats;
-  if (!performance) {
-    throw new Error("/stats: legacy performance returned null with no error");
-  }
-  return {
-    myLearningStats: {
-      ...stats,
-      performanceWindows: {
-        __typename: "PerformanceWindows",
-        // The old API exposes only the 365-day snapshot. Reusing it keeps the
-        // page functional during rollout; real shorter windows arrive as soon
-        // as the additive backend schema is live.
-        days365: performance,
-        days30: performance,
-        days7: performance,
-      },
-    },
-  };
-}
 
 export default async function StatsPage() {
   const auth = readAuthContext(await headers());
   if (auth.status !== "authenticated") redirect("/login");
 
   let data: MyLearningStatsQueryType;
-  let performanceWindowsAvailable = true;
   try {
     data = await gqlFetch(MyLearningStatsQuery, { revalidate: 0 });
   } catch (err) {
     if (isUnauthenticatedGraphQLError(err)) redirect("/login");
-    if (isPerformanceWindowsUnavailable(err)) {
-      let legacyData: LegacyMyLearningStatsQueryType;
-      try {
-        legacyData = await gqlFetch(LegacyMyLearningStatsQuery, { revalidate: 0 });
-      } catch (legacyErr) {
-        if (isUnauthenticatedGraphQLError(legacyErr)) redirect("/login");
-        console.error("[stats] legacy gqlFetch failed:", {
-          name: legacyErr instanceof Error ? legacyErr.name : "unknown",
-        });
-        throw legacyErr;
-      }
-      // adaptLegacyStats guards the response shape and throws a clear invariant
-      // error on null data. Keep it outside the fetch try/catch so a shape
-      // failure surfaces on its own, not mislabeled as a "gqlFetch failed".
-      data = adaptLegacyStats(legacyData);
-      performanceWindowsAvailable = false;
-    } else {
-      console.error("[stats] gqlFetch failed:", {
-        name: err instanceof Error ? err.name : "unknown",
-      });
-      throw err;
-    }
+    console.error("[stats] gqlFetch failed:", {
+      name: err instanceof Error ? err.name : "unknown",
+    });
+    throw err;
   }
   if (!data.myLearningStats) {
     throw new Error("/stats: myLearningStats returned null with no error");
   }
 
-  return (
-    <StatsClient
-      stats={data.myLearningStats}
-      performanceWindowsAvailable={performanceWindowsAvailable}
-    />
-  );
+  return <StatsClient stats={data.myLearningStats} />;
 }

--- a/frontend/src/app/stats/queries.ts
+++ b/frontend/src/app/stats/queries.ts
@@ -44,33 +44,3 @@ export const MyLearningStatsQuery = graphql(`
     }
   }
 `);
-
-// Temporary rollout fallback for a frontend deployment that reaches the old
-// backend before performanceWindows is available. Remove after the additive
-// backend schema has been deployed everywhere and the old frontend is retired.
-export const LegacyMyLearningStatsQuery = graphql(`
-  query LegacyMyLearningStats {
-    myLearningStats {
-      ownsAnyDeck
-      mastery { inProgress learned mature totalStudied }
-      decks {
-        cardgroup { id name }
-        totalCards
-        learnedCards
-        matureCards
-      }
-      performance {
-        retentionRate
-        successRate
-        lapseRate
-        studyStreak
-        reviewCount
-        avgDifficulty
-      }
-      strugglingCards {
-        card { id front cardgroup { id name } }
-        lapses
-      }
-    }
-  }
-`);

--- a/frontend/src/app/stats/stats-client.tsx
+++ b/frontend/src/app/stats/stats-client.tsx
@@ -22,13 +22,7 @@ import { StrugglingList } from "./struggling-list";
  * content sections. All copy flows through `useTranslations("Stats")`;
  * number/percent formatting lives in the section components via `useFormatter()`.
  */
-export function StatsClient({
-  stats,
-  performanceWindowsAvailable = true,
-}: {
-  stats: MyLearningStatsQuery["myLearningStats"];
-  performanceWindowsAvailable?: boolean;
-}) {
+export function StatsClient({ stats }: { stats: MyLearningStatsQuery["myLearningStats"] }) {
   const t = useTranslations("Stats");
   const studiedCount = stats.mastery.totalStudied;
   const hasDecks = stats.decks.length > 0;
@@ -65,10 +59,7 @@ export function StatsClient({
     content = (
       <div className="flex flex-col gap-4 sm:gap-6">
         <MasterySummary mastery={stats.mastery} />
-        <DiagnosticsPanel
-          performanceWindows={stats.performanceWindows}
-          showWindowSelector={performanceWindowsAvailable}
-        />
+        <DiagnosticsPanel performanceWindows={stats.performanceWindows} />
         <div className="grid gap-4 lg:grid-cols-[4fr_3fr]">
           <PerDeckList decks={stats.decks} />
           <StrugglingList cards={stats.strugglingCards} />

--- a/schema/stats.graphql
+++ b/schema/stats.graphql
@@ -4,8 +4,6 @@ type LearningStats {
   mastery: MasteryBreakdown!
   """Per-deck acquisition, one entry per owned deck that has at least one card (decks with cards but no studied cards are included; empty decks are omitted)."""
   decks: [DeckMastery!]!
-  """Legacy diagnostic snapshot over the trailing 365-day window. Use performanceWindows for selectable rolling windows."""
-  performance: PerformanceMetrics! @deprecated(reason: "Use performanceWindows.days365.")
   """Diagnostic performance snapshots over trailing rolling windows."""
   performanceWindows: PerformanceWindows!
   """Cards the learner struggles with most, ranked by lapses (desc) then stability (asc), filtered to at least one lapse, capped at 10."""


### PR DESCRIPTION
## Summary

The 365/30/7-day windows feature shipped with a deliberate rollout shim: the `/stats` RSC falls back to a legacy query (duplicating the 365-day snapshot into all three windows) when the backend predates `performanceWindows`, and the backend keeps a `@deprecated performance` bridge field for old frontends. Both were marked "remove after rollout". This removes the whole bridge in one change.

> ⚠️ **Merge gate.** Do not merge until the production backend is confirmed deployed from a commit that includes `performanceWindows` (commit `12913d86` or later). Creating this PR is safe; merging it removes the field the pre-`performanceWindows` frontend would fall back to. `/stats` uses only RSC `gqlFetch` (no client Apollo), so no stale browser bundle queries the removed field once the backend has it.

## Changes

### Frontend

- `frontend/src/app/stats/page.tsx` — remove `isPerformanceWindowsUnavailable`, `adaptLegacyStats`, the legacy-query fallback branch, and the `performanceWindowsAvailable` flag. The auth redirect, `isUnauthenticatedGraphQLError` branch, error logging, and the `myLearningStats` null guard are unchanged.
- `frontend/src/app/stats/queries.ts` — delete `LegacyMyLearningStatsQuery`.
- `frontend/src/app/stats/stats-client.tsx` — drop the `performanceWindowsAvailable` prop.
- `frontend/src/app/stats/diagnostics-panel.tsx` — remove the `showWindowSelector` prop; the segmented control renders unconditionally.

### Schema / Backend

- `schema/stats.graphql` — delete the `@deprecated performance: PerformanceMetrics!` field.
- `backend/graph/resolver/stats_helpers.go` — drop the `Performance:` bridge assignment (edited before regeneration, per the codegen two-pass rule); the days365 snapshot still feeds `performanceWindows.days365`.

### Tests

- `frontend/src/app/stats/{page,diagnostics-panel,stats-client}.test.tsx`, `frontend/__tests__/stats.test.tsx`, `backend/graph/resolver/stats_resolver_test.go` — dead legacy-path / `performanceWindowsAvailable={false}` / hidden-selector / `Performance`-assertion cases are deleted in full (not gutted); primary-path coverage is kept.

## Test plan

- [ ] `go tool gqlgen generate && go vet ./... && go build ./... && go test ./...` — green (Docker suites in CI)
- [ ] `tsc --noEmit`, `biome`, `vitest run`, `next build`, `pnpm lint:schema` — pass
- [ ] No `/stats` e2e spec exists (`frontend/e2e` grep empty) — no e2e change

Closes #959
