### PR TITLE
feat(fsrs): switch scheduler to long-term mode (EnableShortTerm=false)

### DIFF
--- a/backend/internal/domain/service/fsrs_scheduler.go
+++ b/backend/internal/domain/service/fsrs_scheduler.go
@@ -12,7 +12,12 @@ import (
 type FSRSScheduler struct{ algo *fsrs.FSRS }
 
 func NewFSRSScheduler() *FSRSScheduler {
-	return &FSRSScheduler{algo: fsrs.NewFSRS(fsrs.DefaultParam())}
+	params := fsrs.DefaultParam()
+	// Long-term scheduling mode: skip the sub-day (minutes) learning steps so every
+	// review is scheduled in whole-day intervals and cards never sit in the
+	// Learning/Relearning phases. See go-fsrs Parameters.EnableShortTerm.
+	params.EnableShortTerm = false
+	return &FSRSScheduler{algo: fsrs.NewFSRS(params)}
 }
 
 // Apply returns a fresh state and does not mutate the input state.

--- a/backend/internal/domain/service/fsrs_scheduler_test.go
+++ b/backend/internal/domain/service/fsrs_scheduler_test.go
@@ -51,22 +51,26 @@ func TestFSRSSchedulerApplyGoldenTransitions(t *testing.T) {
 		lapses        int
 		outState      domain.FSRSPhase
 	}{
-		{"new_again", domain.FSRSPhaseNew, domain.RatingAgain, 1.0 / 60.0, 0.402550000000, 7.194900000000, 0, 0, 2, 0, domain.FSRSPhaseLearning},
-		{"new_hard", domain.FSRSPhaseNew, domain.RatingHard, 5.0 / 60.0, 1.183850000000, 6.488305268471, 0, 0, 2, 0, domain.FSRSPhaseLearning},
-		{"new_good", domain.FSRSPhaseNew, domain.RatingGood, 10.0 / 60.0, 3.173000000000, 5.282434422319, 0, 0, 2, 0, domain.FSRSPhaseLearning},
+		// Long-term scheduling mode (EnableShortTerm=false): every rating schedules a
+		// whole-day interval and lands in the Review phase — the sub-day Learning /
+		// Relearning steps are skipped, so the learning/review/relearning rows for a
+		// given rating collapse onto identical values.
+		{"new_again", domain.FSRSPhaseNew, domain.RatingAgain, 24, 0.402550000000, 7.194900000000, 0, 1, 2, 0, domain.FSRSPhaseReview},
+		{"new_hard", domain.FSRSPhaseNew, domain.RatingHard, 48, 1.183850000000, 6.488305268471, 0, 2, 2, 0, domain.FSRSPhaseReview},
+		{"new_good", domain.FSRSPhaseNew, domain.RatingGood, 72, 3.173000000000, 5.282434422319, 0, 3, 2, 0, domain.FSRSPhaseReview},
 		{"new_easy", domain.FSRSPhaseNew, domain.RatingEasy, 384, 15.691050000000, 3.224501589371, 0, 16, 2, 0, domain.FSRSPhaseReview},
-		{"learning_again", domain.FSRSPhaseLearning, domain.RatingAgain, 5.0 / 60.0, 1.252571310484, 6.607035107311, 1, 0, 2, 0, domain.FSRSPhaseLearning},
-		{"learning_hard", domain.FSRSPhaseLearning, domain.RatingHard, 10.0 / 60.0, 2.099603435952, 5.799433907311, 1, 0, 2, 0, domain.FSRSPhaseLearning},
-		{"learning_good", domain.FSRSPhaseLearning, domain.RatingGood, 96, 3.519428036844, 4.991832707311, 1, 4, 2, 0, domain.FSRSPhaseReview},
-		{"learning_easy", domain.FSRSPhaseLearning, domain.RatingEasy, 144, 5.899387234001, 4.184231507311, 1, 6, 2, 0, domain.FSRSPhaseReview},
-		{"review_again", domain.FSRSPhaseReview, domain.RatingAgain, 5.0 / 60.0, 0.805907963439, 6.607035107311, 1, 0, 2, 1, domain.FSRSPhaseRelearning},
+		{"learning_again", domain.FSRSPhaseLearning, domain.RatingAgain, 24, 0.805907963439, 6.607035107311, 1, 1, 2, 1, domain.FSRSPhaseReview},
+		{"learning_hard", domain.FSRSPhaseLearning, domain.RatingHard, 72, 3.167603585081, 5.799433907311, 1, 3, 2, 0, domain.FSRSPhaseReview},
+		{"learning_good", domain.FSRSPhaseLearning, domain.RatingGood, 120, 5.383816782206, 4.991832707311, 1, 5, 2, 0, domain.FSRSPhaseReview},
+		{"learning_easy", domain.FSRSPhaseLearning, domain.RatingEasy, 264, 11.122035415438, 4.184231507311, 1, 11, 2, 0, domain.FSRSPhaseReview},
+		{"review_again", domain.FSRSPhaseReview, domain.RatingAgain, 24, 0.805907963439, 6.607035107311, 1, 1, 2, 1, domain.FSRSPhaseReview},
 		{"review_hard", domain.FSRSPhaseReview, domain.RatingHard, 72, 3.167603585081, 5.799433907311, 1, 3, 2, 0, domain.FSRSPhaseReview},
 		{"review_good", domain.FSRSPhaseReview, domain.RatingGood, 120, 5.383816782206, 4.991832707311, 1, 5, 2, 0, domain.FSRSPhaseReview},
 		{"review_easy", domain.FSRSPhaseReview, domain.RatingEasy, 264, 11.122035415438, 4.184231507311, 1, 11, 2, 0, domain.FSRSPhaseReview},
-		{"relearning_again", domain.FSRSPhaseRelearning, domain.RatingAgain, 5.0 / 60.0, 1.252571310484, 6.607035107311, 1, 0, 2, 0, domain.FSRSPhaseRelearning},
-		{"relearning_hard", domain.FSRSPhaseRelearning, domain.RatingHard, 10.0 / 60.0, 2.099603435952, 5.799433907311, 1, 0, 2, 0, domain.FSRSPhaseRelearning},
-		{"relearning_good", domain.FSRSPhaseRelearning, domain.RatingGood, 96, 3.519428036844, 4.991832707311, 1, 4, 2, 0, domain.FSRSPhaseReview},
-		{"relearning_easy", domain.FSRSPhaseRelearning, domain.RatingEasy, 144, 5.899387234001, 4.184231507311, 1, 6, 2, 0, domain.FSRSPhaseReview},
+		{"relearning_again", domain.FSRSPhaseRelearning, domain.RatingAgain, 24, 0.805907963439, 6.607035107311, 1, 1, 2, 1, domain.FSRSPhaseReview},
+		{"relearning_hard", domain.FSRSPhaseRelearning, domain.RatingHard, 72, 3.167603585081, 5.799433907311, 1, 3, 2, 0, domain.FSRSPhaseReview},
+		{"relearning_good", domain.FSRSPhaseRelearning, domain.RatingGood, 120, 5.383816782206, 4.991832707311, 1, 5, 2, 0, domain.FSRSPhaseReview},
+		{"relearning_easy", domain.FSRSPhaseRelearning, domain.RatingEasy, 264, 11.122035415438, 4.184231507311, 1, 11, 2, 0, domain.FSRSPhaseReview},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
## Summary

The FSRS scheduler ran in go-fsrs's default short-term mode, so a freshly-rated card stepped through sub-day Learning / Relearning intervals (a few minutes) before graduating to Review. This switches the scheduler to **long-term mode** by setting `Parameters.EnableShortTerm = false` in `NewFSRSScheduler()`: the sub-day steps are skipped, every rating schedules a whole-day interval, and cards move straight to the Review phase.

## Changes

- `backend/internal/domain/service/fsrs_scheduler.go` — build the default go-fsrs parameters, set `EnableShortTerm = false`, and construct the `*fsrs.FSRS` from them. No import-graph change; the `Apply` signature and its pure / non-mutating contract are unchanged.
- `backend/internal/domain/service/fsrs_scheduler_test.go` — regenerate the `TestFSRSSchedulerApplyGoldenTransitions` table for long-term mode. All 16 transitions now land in `FSRSPhaseReview` with whole-day `due` intervals (24 / 48 / 72 / 120 / 264 / 384h); the `learning_*` / `review_*` / `relearning_*` rows for a given rating collapse onto identical stability / difficulty / due values because long-term mode routes learning states through the review path (and each `*_again` picks up a lapse). Values were regenerated from actual go-fsrs v3.3.1 output, then the throwaway generator was removed.

## Verification

- Rate any card and inspect its next `UserCardState`: `due` is a whole-day multiple from `now`, and `phase` is `Review` — never `Learning` / `Relearning`.

## Test plan

- [ ] `go build ./...` / `go vet ./...` — pass
- [ ] `go test ./internal/domain/service/` — golden transition table passes under long-term mode
- [ ] `go tool go-arch-lint check --project-path .` — pass (no import-graph change)
- [ ] CI integration suites (testcontainers, run with Docker) — green; no test outside the golden table asserts real-scheduler output values, so no other suite is affected by the value change

No linked issue — this branch addresses a scheduling-mode change requested directly.
