### PR TITLE
fix(stats): scope RetentionRate and LapseRate to reviews of already-learned cards

### DIFF
--- a/backend/internal/domain/service/user_performance.go
+++ b/backend/internal/domain/service/user_performance.go
@@ -217,7 +217,7 @@ func ComputeMetrics(swipes []domain.SwipeRecord, now time.Time) PerformanceMetri
 	}
 
 	successes := 0
-	onTime := 0
+	onTimeRecalls := 0
 	lapses := 0
 	reviews := 0
 	difficultySum := 0.0
@@ -227,13 +227,15 @@ func ComputeMetrics(swipes []domain.SwipeRecord, now time.Time) PerformanceMetri
 		if swipe.Rating.IsSuccess() {
 			successes++
 		}
-		if swipe.StateAfter.ElapsedDays <= swipe.StateAfter.ScheduledDays {
-			onTime++
-		}
+		// LapseRate and RetentionRate are scoped to reviews of already-learned
+		// cards (pre-swipe phase Review); a graduation or a Relearning re-fail
+		// contributes to neither numerator nor denominator.
 		if isKnownCardReview(swipe) {
 			reviews++
 			if swipe.Rating == domain.RatingAgain {
 				lapses++
+			} else if isOnTimeRecall(swipe) {
+				onTimeRecalls++
 			}
 		}
 
@@ -244,7 +246,7 @@ func ComputeMetrics(swipes []domain.SwipeRecord, now time.Time) PerformanceMetri
 	return PerformanceMetrics{
 		SuccessRate:   float64(successes) / float64(len(swipes)),
 		AvgDifficulty: difficultySum / float64(len(swipes)),
-		RetentionRate: float64(onTime) / float64(len(swipes)),
+		RetentionRate: ratio(onTimeRecalls, reviews),
 		StudyStreak:   studyStreak(daysSeen, now),
 		LapseRate:     ratio(lapses, reviews),
 		ReviewCount:   len(swipes),
@@ -293,7 +295,24 @@ func normalizedDifficulty(difficulty float64) float64 {
 	return difficulty
 }
 
+// isKnownCardReview reports whether a swipe is a review of an already-learned
+// card — the card's pre-swipe FSRS phase was Review.
+//
+// New-format rows (PhaseBefore != nil, recorded once the phase_before column
+// existed) read the pre-swipe snapshot directly: a review iff *PhaseBefore ==
+// FSRSPhaseReview. This correctly excludes a Learning->Easy graduation (whose
+// StateAfter.Phase is Review but whose pre-swipe phase was Learning) and a
+// Relearning re-fail (whose pre-swipe phase was Relearning).
+//
+// Legacy rows (PhaseBefore == nil, recorded before the column existed and aging
+// out of the 365-day window) fall back to the historical post-swipe heuristic:
+// StateAfter.Phase == Review, or a Review->Again lapse that landed the card in
+// Relearning with a non-zero lapse count. The fallback keeps history continuous
+// rather than jumping when the new snapshot became available.
 func isKnownCardReview(swipe domain.SwipeRecord) bool {
+	if swipe.PhaseBefore != nil {
+		return *swipe.PhaseBefore == domain.FSRSPhaseReview
+	}
 	if swipe.StateAfter.Phase == domain.FSRSPhaseReview {
 		return true
 	}
@@ -302,9 +321,35 @@ func isKnownCardReview(swipe domain.SwipeRecord) bool {
 		swipe.StateAfter.Lapses > 0
 }
 
+// isOnTimeRecall reports whether a swipe is an on-time recall: the card was
+// recalled (Rating != Again) within the interval that was scheduled for it
+// before the swipe. It is only meaningful for reviews of already-learned cards;
+// ComputeMetrics consults it only inside the isKnownCardReview branch.
+//
+// New-format rows (PhaseBefore != nil) compare StateAfter.ElapsedDays against
+// the pre-swipe scheduled interval *ScheduledDaysBefore — the interval the card
+// was actually due within, so a long-overdue but successful review is not
+// counted as on time. A new-format row whose ScheduledDaysBefore is nil is
+// treated as not on time (defensive). Legacy rows (PhaseBefore == nil) fall back
+// to comparing against the post-swipe StateAfter.ScheduledDays, preserving the
+// historical heuristic for rows recorded before the snapshot existed. The
+// boundary is inclusive: ElapsedDays == the scheduled interval is on time.
+func isOnTimeRecall(swipe domain.SwipeRecord) bool {
+	if swipe.Rating == domain.RatingAgain {
+		return false
+	}
+	if swipe.PhaseBefore != nil {
+		return swipe.ScheduledDaysBefore != nil &&
+			swipe.StateAfter.ElapsedDays <= *swipe.ScheduledDaysBefore
+	}
+	return swipe.StateAfter.ElapsedDays <= swipe.StateAfter.ScheduledDays
+}
+
 // studyStreak counts consecutive JST learn-days ending at the current learn-day,
 // breaking on the first day with no swipe. If the current learn-day has no
-// swipe, the streak is 0.
+// swipe, the streak is 0. The count is bounded by the caller-supplied swipe
+// window (the stats usecase loads a trailing 365-day window), so a streak longer
+// than the window reads as at most the window length.
 func studyStreak(daysSeen map[string]struct{}, now time.Time) int {
 	streak := 0
 	for day := domain.StartOfLearnDay(now); ; day = day.AddDate(0, 0, -1) {

--- a/backend/internal/domain/service/user_performance_test.go
+++ b/backend/internal/domain/service/user_performance_test.go
@@ -30,27 +30,94 @@ func TestComputeMetrics(t *testing.T) {
 			},
 		},
 		{
-			name: "success rate counts good and easy",
+			// A Learning->Easy graduation lands in StateAfter.Phase == Review, but
+			// its pre-swipe phase was Learning, so it is not a review of an
+			// already-learned card: reviews stays 0 and both scoped rates are 0.
+			name: "new-format graduation swipe is excluded from reviews",
 			swipes: []domain.SwipeRecord{
-				swipe(domain.RatingAgain, now, state(5, 1, 1, domain.FSRSPhaseLearning)),
-				swipe(domain.RatingHard, now, state(5, 1, 1, domain.FSRSPhaseLearning)),
-				swipe(domain.RatingGood, now, state(5, 1, 1, domain.FSRSPhaseReview)),
-				swipe(domain.RatingEasy, now, state(5, 1, 1, domain.FSRSPhaseReview)),
+				swipeBefore(domain.RatingEasy, now, state(5, 1, 3, domain.FSRSPhaseReview), domain.FSRSPhaseLearning, 0),
 			},
 			want: PerformanceMetrics{
-				SuccessRate:   0.5,
+				SuccessRate:   1,
+				AvgDifficulty: 0.5,
+				RetentionRate: 0,
+				StudyStreak:   1,
+				LapseRate:     0,
+				ReviewCount:   1,
+			},
+		},
+		{
+			// A repeated Again while already Relearning is neither a lapse (FSRS
+			// increments Lapses only on Review->Again) nor a review, because the
+			// pre-swipe phase was Relearning, not Review.
+			name: "new-format relearning re-fail is excluded from reviews and lapses",
+			swipes: []domain.SwipeRecord{
+				swipeBefore(domain.RatingAgain, now, stateWithLapses(5, 2, 0, domain.FSRSPhaseRelearning, 2), domain.FSRSPhaseRelearning, 0),
+			},
+			want: PerformanceMetrics{
+				SuccessRate:   0,
+				AvgDifficulty: 0.5,
+				RetentionRate: 0,
+				StudyStreak:   1,
+				LapseRate:     0,
+				ReviewCount:   1,
+			},
+		},
+		{
+			// Review->Again is the one FSRS lapse transition: it counts as a lapse
+			// and, being an Again, is never an on-time recall.
+			name: "new-format review again is a lapse and not a retention",
+			swipes: []domain.SwipeRecord{
+				swipeBefore(domain.RatingAgain, now, stateWithLapses(5, 3, 0, domain.FSRSPhaseRelearning, 1), domain.FSRSPhaseReview, 5),
+			},
+			want: PerformanceMetrics{
+				SuccessRate:   0,
+				AvgDifficulty: 0.5,
+				RetentionRate: 0,
+				StudyStreak:   1,
+				LapseRate:     1,
+				ReviewCount:   1,
+			},
+		},
+		{
+			// Hard is not a SuccessRate success (IsSuccess is >= Good) but it IS a
+			// recall: a Review+Hard within the pre-swipe interval is a retention,
+			// so SuccessRate (0) and RetentionRate (1) diverge deliberately.
+			name: "new-format review hard on time is a retention but not a success",
+			swipes: []domain.SwipeRecord{
+				swipeBefore(domain.RatingHard, now, state(5, 4, 6, domain.FSRSPhaseReview), domain.FSRSPhaseReview, 5),
+			},
+			want: PerformanceMetrics{
+				SuccessRate:   0,
 				AvgDifficulty: 0.5,
 				RetentionRate: 1,
 				StudyStreak:   1,
 				LapseRate:     0,
-				ReviewCount:   4,
+				ReviewCount:   1,
 			},
 		},
 		{
-			name: "average difficulty normalizes fsrs scale",
+			// A successful review answered later than the interval it was due
+			// within is a review, but not an on-time recall.
+			name: "new-format review easy later than scheduled is a review but not a retention",
 			swipes: []domain.SwipeRecord{
-				swipe(domain.RatingGood, now, state(3, 1, 1, domain.FSRSPhaseReview)),
-				swipe(domain.RatingGood, now, state(7, 1, 1, domain.FSRSPhaseReview)),
+				swipeBefore(domain.RatingEasy, now, state(5, 5, 10, domain.FSRSPhaseReview), domain.FSRSPhaseReview, 2),
+			},
+			want: PerformanceMetrics{
+				SuccessRate:   1,
+				AvgDifficulty: 0.5,
+				RetentionRate: 0,
+				StudyStreak:   1,
+				LapseRate:     0,
+				ReviewCount:   1,
+			},
+		},
+		{
+			// ElapsedDays == ScheduledDaysBefore exactly is on time (inclusive
+			// boundary).
+			name: "new-format review at the exact scheduled boundary is on time",
+			swipes: []domain.SwipeRecord{
+				swipeBefore(domain.RatingGood, now, state(5, 5, 9, domain.FSRSPhaseReview), domain.FSRSPhaseReview, 5),
 			},
 			want: PerformanceMetrics{
 				SuccessRate:   1,
@@ -58,11 +125,72 @@ func TestComputeMetrics(t *testing.T) {
 				RetentionRate: 1,
 				StudyStreak:   1,
 				LapseRate:     0,
+				ReviewCount:   1,
+			},
+		},
+		{
+			// New-card swipes (pre-swipe phase New) — including a New->Easy
+			// graduation whose StateAfter.Phase is Review — are never reviews, so
+			// they move only SuccessRate and ReviewCount.
+			name: "new-format new-card swipes affect only success rate and review count",
+			swipes: []domain.SwipeRecord{
+				swipeBefore(domain.RatingAgain, now, state(5, 0, 0, domain.FSRSPhaseLearning), domain.FSRSPhaseNew, 0),
+				swipeBefore(domain.RatingEasy, now, state(5, 0, 1, domain.FSRSPhaseReview), domain.FSRSPhaseNew, 0),
+			},
+			want: PerformanceMetrics{
+				SuccessRate:   0.5,
+				AvgDifficulty: 0.5,
+				RetentionRate: 0,
+				StudyStreak:   1,
+				LapseRate:     0,
 				ReviewCount:   2,
 			},
 		},
 		{
-			name: "retention rate counts reviews completed on time",
+			// Several new-format reviews plus one graduation: reviews is 3 (the
+			// graduation is excluded from the denominator); one Again is the lapse
+			// numerator; one on-time Hard is the retention numerator.
+			name: "new-format mixed reviews scope both rates to the review denominator",
+			swipes: []domain.SwipeRecord{
+				swipeBefore(domain.RatingAgain, now, stateWithLapses(5, 3, 0, domain.FSRSPhaseRelearning, 1), domain.FSRSPhaseReview, 5),
+				swipeBefore(domain.RatingHard, now, state(5, 4, 6, domain.FSRSPhaseReview), domain.FSRSPhaseReview, 5),
+				swipeBefore(domain.RatingEasy, now, state(5, 9, 10, domain.FSRSPhaseReview), domain.FSRSPhaseReview, 5),
+				swipeBefore(domain.RatingEasy, now, state(5, 0, 1, domain.FSRSPhaseReview), domain.FSRSPhaseLearning, 0),
+			},
+			want: PerformanceMetrics{
+				SuccessRate:   0.5,
+				AvgDifficulty: 0.5,
+				RetentionRate: 1.0 / 3.0,
+				StudyStreak:   1,
+				LapseRate:     1.0 / 3.0,
+				ReviewCount:   4,
+			},
+		},
+		{
+			// Legacy rows (PhaseBefore == nil) fall back to the post-swipe
+			// heuristics: a Review-phase row and a Review->Again Relearning lapse
+			// are reviews, an Again on a Learning card is not. Pins the same
+			// review/lapse split the pre-snapshot code produced.
+			name: "legacy rows fall back to post-swipe review and lapse heuristics",
+			swipes: []domain.SwipeRecord{
+				swipe(domain.RatingGood, now, state(5, 2, 5, domain.FSRSPhaseReview)),
+				swipe(domain.RatingAgain, now, stateWithLapses(5, 1, 0, domain.FSRSPhaseRelearning, 1)),
+				swipe(domain.RatingAgain, now, state(5, 1, 0, domain.FSRSPhaseLearning)),
+			},
+			want: PerformanceMetrics{
+				SuccessRate:   1.0 / 3.0,
+				AvgDifficulty: 0.5,
+				RetentionRate: 0.5,
+				StudyStreak:   1,
+				LapseRate:     0.5,
+				ReviewCount:   3,
+			},
+		},
+		{
+			// Legacy on-time recall compares ElapsedDays against the post-swipe
+			// StateAfter.ScheduledDays: two of three Review rows are within their
+			// interval.
+			name: "legacy on-time recall uses post-swipe scheduled days",
 			swipes: []domain.SwipeRecord{
 				swipe(domain.RatingGood, now, state(5, 2, 2, domain.FSRSPhaseReview)),
 				swipe(domain.RatingGood, now, state(5, 3, 2, domain.FSRSPhaseReview)),
@@ -78,12 +206,37 @@ func TestComputeMetrics(t *testing.T) {
 			},
 		},
 		{
+			// A window that mixes legacy and new-format rows: reviews = new Hard +
+			// new Again + legacy Good = 3; lapses = new Again = 1; on-time recalls
+			// = new Hard = 1 (legacy Good is late, new graduation and legacy
+			// Again-on-Learning are not reviews).
+			name: "mixed legacy and new-format window scopes rates across both branches",
+			swipes: []domain.SwipeRecord{
+				swipeBefore(domain.RatingHard, now, state(5, 4, 9, domain.FSRSPhaseReview), domain.FSRSPhaseReview, 5),
+				swipeBefore(domain.RatingAgain, now, stateWithLapses(5, 2, 0, domain.FSRSPhaseRelearning, 1), domain.FSRSPhaseReview, 5),
+				swipeBefore(domain.RatingEasy, now, state(5, 0, 1, domain.FSRSPhaseReview), domain.FSRSPhaseLearning, 0),
+				swipe(domain.RatingGood, now, state(5, 10, 3, domain.FSRSPhaseReview)),
+				swipe(domain.RatingAgain, now, state(5, 1, 0, domain.FSRSPhaseLearning)),
+			},
+			want: PerformanceMetrics{
+				SuccessRate:   0.4,
+				AvgDifficulty: 0.5,
+				RetentionRate: 1.0 / 3.0,
+				StudyStreak:   1,
+				LapseRate:     1.0 / 3.0,
+				ReviewCount:   5,
+			},
+		},
+		{
+			// Study streak counts consecutive JST learn-days back from now; the
+			// gap at day -3 caps it at 3. All four rows are on-time new-format
+			// reviews, so the scoped rates stay at 1 / 0.
 			name: "study streak counts consecutive days from provided now",
 			swipes: []domain.SwipeRecord{
-				swipe(domain.RatingGood, now.Add(-2*time.Hour), state(5, 1, 1, domain.FSRSPhaseReview)),
-				swipe(domain.RatingGood, now.AddDate(0, 0, -1), state(5, 1, 1, domain.FSRSPhaseReview)),
-				swipe(domain.RatingGood, now.AddDate(0, 0, -2), state(5, 1, 1, domain.FSRSPhaseReview)),
-				swipe(domain.RatingGood, now.AddDate(0, 0, -4), state(5, 1, 1, domain.FSRSPhaseReview)),
+				swipeBefore(domain.RatingGood, now.Add(-2*time.Hour), state(5, 1, 5, domain.FSRSPhaseReview), domain.FSRSPhaseReview, 5),
+				swipeBefore(domain.RatingGood, now.AddDate(0, 0, -1), state(5, 1, 5, domain.FSRSPhaseReview), domain.FSRSPhaseReview, 5),
+				swipeBefore(domain.RatingGood, now.AddDate(0, 0, -2), state(5, 1, 5, domain.FSRSPhaseReview), domain.FSRSPhaseReview, 5),
+				swipeBefore(domain.RatingGood, now.AddDate(0, 0, -4), state(5, 1, 5, domain.FSRSPhaseReview), domain.FSRSPhaseReview, 5),
 			},
 			want: PerformanceMetrics{
 				SuccessRate:   1,
@@ -92,22 +245,6 @@ func TestComputeMetrics(t *testing.T) {
 				StudyStreak:   3,
 				LapseRate:     0,
 				ReviewCount:   4,
-			},
-		},
-		{
-			name: "lapse rate counts again ratings on known cards",
-			swipes: []domain.SwipeRecord{
-				swipe(domain.RatingAgain, now, stateWithLapses(5, 1, 1, domain.FSRSPhaseRelearning, 1)),
-				swipe(domain.RatingGood, now, state(5, 1, 1, domain.FSRSPhaseReview)),
-				swipe(domain.RatingAgain, now, state(5, 1, 1, domain.FSRSPhaseLearning)),
-			},
-			want: PerformanceMetrics{
-				SuccessRate:   1.0 / 3.0,
-				AvgDifficulty: 0.5,
-				RetentionRate: 1,
-				StudyStreak:   1,
-				LapseRate:     0.5,
-				ReviewCount:   3,
 			},
 		},
 	}
@@ -379,11 +516,34 @@ func TestPerformanceModeIsValid(t *testing.T) {
 	}
 }
 
+// swipe builds a legacy-format swipe record: PhaseBefore and ScheduledDaysBefore
+// are nil, so the metrics layer falls back to the post-swipe heuristics.
 func swipe(rating domain.Rating, reviewedAt time.Time, stateAfter domain.FSRSState) domain.SwipeRecord {
 	return domain.SwipeRecord{
 		Rating:     rating,
 		ReviewedAt: reviewedAt,
 		StateAfter: stateAfter,
+	}
+}
+
+// swipeBefore builds a new-format swipe record carrying the pre-swipe snapshot
+// (phaseBefore, scheduledDaysBefore) that the metrics layer reads to decide
+// review-ness and on-time recall independently of StateAfter.
+func swipeBefore(
+	rating domain.Rating,
+	reviewedAt time.Time,
+	stateAfter domain.FSRSState,
+	phaseBefore domain.FSRSPhase,
+	scheduledDaysBefore int,
+) domain.SwipeRecord {
+	pb := phaseBefore
+	sdb := scheduledDaysBefore
+	return domain.SwipeRecord{
+		Rating:              rating,
+		ReviewedAt:          reviewedAt,
+		StateAfter:          stateAfter,
+		PhaseBefore:         &pb,
+		ScheduledDaysBefore: &sdb,
 	}
 }
 

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -436,7 +436,7 @@
     "diagnosticsReviewsCaption": "total swipes",
     "diagnosticsAvgDifficulty": "Avg difficulty",
     "diagnosticsAvgDifficultyCaption": "FSRS difficulty",
-    "diagnosticsRetentionHint": "Share of reviews you recalled correctly by their due date. Higher means memory is holding as planned.",
+    "diagnosticsRetentionHint": "Among reviews of cards you had already learned, the share you recalled correctly by their scheduled date. Higher means memory is holding as planned.",
     "diagnosticsSuccessHint": "Share of swipes you rated a success. A rough gauge of how confident your answers felt.",
     "diagnosticsLapseHint": "Among already-learned cards, the share you forgot on review. Lower means they're sticking.",
     "diagnosticsStreakHint": "Days you've studied without a gap, up to today, calculated from the last 365 days regardless of the selected period. Missing a day resets it.",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -436,7 +436,7 @@
     "diagnosticsReviewsCaption": "スワイプの合計",
     "diagnosticsAvgDifficulty": "平均難易度",
     "diagnosticsAvgDifficultyCaption": "FSRSの難易度",
-    "diagnosticsRetentionHint": "復習の予定日までに正しく思い出せたカードの割合です。高いほど記憶が計画どおり保持できています。",
+    "diagnosticsRetentionHint": "一度覚えたカードの復習のうち、予定日までに正しく思い出せた割合です。高いほど記憶が計画どおり保持できています。",
     "diagnosticsSuccessHint": "スワイプ評価が「できた」だった割合です。学習の手ごたえの目安になります。",
     "diagnosticsLapseHint": "一度覚えたカードの復習で「忘れた」を出した割合です。低いほどしっかり定着しています。",
     "diagnosticsStreakHint": "選択した期間にかかわらず、直近365日を基準に今日まで途切れずに学習を続けた日数です。1日でも空くと途切れます。",


### PR DESCRIPTION
## Summary

A formal review (Z3 model-check of the doc-declared spec against the implemented spec, counterexamples reproduced against `go-fsrs` v3.3.1 and the production `ComputeMetrics`) proved the `/stats` Retention and Lapse tiles did not compute what their hint copy promised:

- **Retention** counted *every* swipe whose post-swipe `ElapsedDays <= ScheduledDays` as "recalled by the due date" — so three same-day Again swipes on new cards produced `SuccessRate 0% / RetentionRate 100%`, and a 30-days-late successful review still counted as "on time".
- **Lapse** used the post-swipe phase for its denominator, so a Learning→Easy graduation counted as a "review of an already-learned card", and a Relearning re-fail counted as a fresh lapse even though `go-fsrs` increments `Lapses` only on Review→Again.

This scopes both rates to *reviews of already-learned cards* using the pre-swipe snapshot added in #954.

> **Stacked on [#960](https://github.com/yasuflatland-lf/flamingo-armond/pull/960)** (`feat/954-swipe-pre-swipe-snapshot`). This PR's diff is only the metric change; merge #960 first.

## Changes

### Backend

- `backend/internal/domain/service/user_performance.go`
  - `isKnownCardReview` now keys on the pre-swipe phase: new-format rows (`PhaseBefore != nil`) are a review iff `*PhaseBefore == FSRSPhaseReview`; legacy rows (`nil`, aging out of the 365-day window) keep the historical post-swipe heuristic.
  - **new** `isOnTimeRecall` — `Rating != Again` and, for new-format rows, `ElapsedDays <= *ScheduledDaysBefore` (the interval the card was actually due within; nil → not on time); legacy rows compare against post-swipe `ScheduledDays`. Inclusive boundary.
  - `RetentionRate` becomes `ratio(onTimeRecalls, reviews)` and `LapseRate` stays `ratio(lapses, reviews)` — both scoped to the reviews set; the old all-swipes `onTime` counter is removed. `SuccessRate` (still over all swipes), `AvgDifficulty`, `StudyStreak`, `ReviewCount`, the empty-window placeholder, and `ModeFromMetrics` are unchanged.
  - `studyStreak` docstring notes the count is bounded by the caller-supplied 365-day window.

### Frontend

- `frontend/messages/{en,ja}.json` — `Stats.diagnosticsRetentionHint` rescoped to "reviews of cards you had already learned … recalled correctly by their scheduled date". `diagnosticsLapseHint` already said "Among already-learned cards" and is unchanged.

### Tests

- `backend/internal/domain/service/user_performance_test.go` — the metrics table is rewritten with new-format rows (graduation excluded from reviews; Relearning re-fail excluded from reviews and lapses; Review+Again is a lapse not a retention; Review+Hard on time is a retention while `SuccessRate` diverges since Hard isn't a success; Review+Easy late is a review but not a retention; exact-boundary on-time; new-card swipes touch only `SuccessRate`/`ReviewCount`), plus legacy-fallback rows and a mixed legacy+new window.

## Test plan

- [ ] `go vet ./... && go build ./... && go test ./...` — green (Docker suites in CI); `internal/domain/service` 99/99 pass
- [ ] `go tool go-arch-lint check` — clean
- [ ] `tsc --noEmit`, `biome`, `vitest run` — pass

Closes #955
