### PR TITLE
fix(fsrs): clamp Apply's now to LastReview so backward clock skew cannot corrupt elapsed_days

### DIFF
--- a/backend/internal/domain/service/fsrs_scheduler.go
+++ b/backend/internal/domain/service/fsrs_scheduler.go
@@ -22,6 +22,14 @@ func NewFSRSScheduler() *FSRSScheduler {
 
 // Apply returns a fresh state and does not mutate the input state.
 func (s *FSRSScheduler) Apply(state domain.FSRSState, rating domain.Rating, now time.Time) domain.FSRSState {
+	// A backward clock step (NTP, cross-instance skew) would make the library's
+	// elapsed-days float negative; the float->uint64 conversion of a negative
+	// value is implementation-dependent (Go spec, Conversions) and corrupts the
+	// persisted state on amd64. Clamp so elapsed time can never be negative.
+	if now.Before(state.LastReview) {
+		now = state.LastReview
+	}
+
 	info := s.algo.Next(fsrs.Card{
 		Due:           state.Due,
 		Stability:     state.Stability,

--- a/backend/internal/domain/service/fsrs_scheduler_test.go
+++ b/backend/internal/domain/service/fsrs_scheduler_test.go
@@ -23,6 +23,32 @@ func TestFSRSSchedulerApplyIsPure(t *testing.T) {
 	require.Equal(t, now, got.LastReview)
 }
 
+func TestFSRSScheduler_Apply_BackwardClockSkewClamped(t *testing.T) {
+	t.Parallel()
+
+	scheduler := NewFSRSScheduler()
+
+	reviewAt := time.Date(2026, 4, 26, 0, 0, 0, 0, time.UTC)
+	// First review promotes a new card into the Review phase, stamping
+	// LastReview == reviewAt.
+	reviewed := scheduler.Apply(
+		domain.NewFSRSStateForNewCard(reviewAt.Add(-24*time.Hour)),
+		domain.RatingEasy,
+		reviewAt,
+	)
+	require.Equal(t, domain.FSRSPhaseReview, reviewed.Phase)
+	require.Equal(t, reviewAt, reviewed.LastReview)
+
+	// A backward clock step (now before LastReview) must clamp to LastReview, so
+	// the result is byte-for-byte identical to reviewing exactly at LastReview.
+	skewed := scheduler.Apply(reviewed, domain.RatingGood, reviewAt.Add(-time.Second))
+	atLastReview := scheduler.Apply(reviewed, domain.RatingGood, reviewAt)
+
+	require.Equal(t, atLastReview, skewed)
+	require.Equal(t, 0, skewed.ElapsedDays)
+	require.GreaterOrEqual(t, skewed.ScheduledDays, 1)
+}
+
 func TestFSRSSchedulerApplyGoldenTransitions(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

A formal review (Z3 + an empirical Go probe on arm64 and amd64) found that `go-fsrs` recomputes elapsed days as `floor((now - LastReview)/24h)` and casts the result to `uint64`. When `now` precedes `LastReview` — a backward NTP step, or two app instances with sub-second clock skew — the float is negative and the float→`uint64` conversion is **implementation-dependent per the Go spec**. On amd64 (production) it yields `elapsed_days = -1`, feeding `~1.8e19` days into the forgetting curve so a success rating gets the maximum stability boost; arm64 happens to saturate to `0`. This clamps `now` so elapsed time can never be negative.

## Changes

### Backend

- `backend/internal/domain/service/fsrs_scheduler.go` — `FSRSScheduler.Apply` clamps `now` to `state.LastReview` when `now.Before(state.LastReview)`, before the `s.algo.Next(...)` call. No other production change; `UserCardFSRS.ApplyRating` still stamps `UpdatedAt` with the caller's original `now`.

### Tests

- `backend/internal/domain/service/fsrs_scheduler_test.go` — **new** `TestFSRSScheduler_Apply_BackwardClockSkewClamped`: an `Apply` at `T - 1s` and at exactly `T` produce field-identical `FSRSState` with `ElapsedDays == 0` and `ScheduledDays >= 1`.

## Test plan

- [ ] `go vet ./... && go build ./... && go test ./...` — green (2228 tests, 26 packages)
- [ ] `go test ./internal/domain/service/...` — 100/100 pass

Closes #972
