### PR TITLE
docs: drop the removed FSRS-override section and fix the stale startOfDayJST reference

### DIFF
--- a/docs/backend-graphql.md
+++ b/docs/backend-graphql.md
@@ -243,13 +243,11 @@ Reading the input name instead would force the guard to also know that admin exi
 - `bio` accepts up to 500 grapheme clusters (trimmed; whitespace-only collapses to explicit clear).
 - Out-of-bounds returns `gqlerr.BadUserInput("displayName", ...)` (extensions.code = "BAD_USER_INPUT", field = "displayName"). See [Validation (grapheme clusters)](#validation-grapheme-clusters) for the WHY.
 
-### Card bulk delete + FSRS override
+### Card bulk delete
 
 The `deleteCards(ids: [ID!]!) -> Int` mutation deletes cards owned by the authenticated caller and returns the count of rows actually deleted. Ownership is enforced exclusively by the SQL subselect in `DeleteByIDsTx` (`DELETE ... WHERE cardgroup_id IN (SELECT id FROM cardgroups WHERE owner_id = ?)`); this is one round-trip, atomic with respect to role changes mid-request, and avoids an authorization-bypass surface that arises when two separate layers each guard ownership — a maintainer can drop one layer believing the other still covers it. At most `maxBulkDelete = 100` ids may be supplied per call; exceeding the cap returns `BAD_USER_INPUT` on the `ids` field. `maxBulkDelete = 100` deliberately mirrors `maxPageSize = 100` so a client can delete exactly one page of results in one call — UX consistency is the reason the values match, not a Postgres bind-parameter constraint. The repository's `DeleteByIDsTx` short-circuits on `len(ids) == 0` before touching GORM: `Where("id IN ?", emptySlice).Delete(&T{})` silently omits the `IN` clause entirely and becomes an unbounded mass DELETE — the most dangerous GORM v2 hazard because it compiles cleanly.
 
 When `DeleteByIDsTx` processes fewer ids than were requested (foreign-owned ids are silently skipped), emit one structured `slog.Info` line with `user_id`, `requested`, and `processed` counts. Never log the id list itself — UUID enumeration is an information-leak vector. Without this signal, IDOR probing is invisible to operators.
-
-`NewCardInput` accepts optional all-or-nothing FSRS state overrides: nine fields (`due, stability, difficulty, elapsedDays, scheduledDays, reps, lapses, state, lastReview`) or none. Mixed input triggers `domain.ErrFSRSOverridePartial`; invalid state values trigger `domain.ErrFSRSOverrideStateInvalid`. This all-or-nothing semantics prevents mixed-state cards when importing a dictionary — a single bad value would otherwise corrupt the set. The `domain.NewFSRSStateFromInput` function centralizes the validation and sentinels; the usecase translates them to `gqlerr.BadUserInput` before returning. The resolver uses a `toFSRSOverride` helper that returns `nil` when all nine fields are nil, delegating the "all-or-none" rule entirely to the domain factory. A `*StructWithRequiredFields` schema type would encode the constraint more precisely, but requires reshaping the resolver; defer until the type is touched again.
 
 ### `setLastViewedCardgroup` and `User.lastViewedCardgroup`
 

--- a/docs/backend/library-gotchas/strict-cutoff-boundary-fixture-and-mutation-proof.md
+++ b/docs/backend/library-gotchas/strict-cutoff-boundary-fixture-and-mutation-proof.md
@@ -43,7 +43,7 @@ FAILS, then restore and confirm the diff is clean:
   `ucs.last_review <= ?`. The exact-boundary row now passes the predicate and
   enters the review window, so the `require.Equal` against the single expected
   ID fails. Restore the `<` and the test goes green again.
-- For a JST start-of-day cutoff: change `startOfDayJST(now)` to a raw `now`
+- For a JST start-of-day cutoff: change `domain.StartOfLearnDay(now)` to a raw `now`
   (`backend/internal/usecase/learn.go`). A card reviewed earlier today now sits
   before the looser cutoff and reappears in the queue, breaking the
   exclusion assertion.


### PR DESCRIPTION
## Summary

Two documentation-rot fixes surfaced by the FSRS formal-review round. `docs/backend-graphql.md` documented a nine-field `NewCardInput` FSRS-state override (`NewFSRSStateFromInput`, `ErrFSRSOverridePartial` / `ErrFSRSOverrideStateInvalid`, `toFSRSOverride`) that no longer exists — `NewCardInput` has three fields — and a library-gotcha doc referenced a `startOfDayJST` symbol that was renamed. Docs-only; no code changes.

## Changes

### Docs

- `docs/backend-graphql.md` — remove the FSRS-override paragraph and retitle the section heading `Card bulk delete + FSRS override` → `Card bulk delete`. The bulk-delete content is unchanged, and no inbound `#card-bulk-delete--fsrs-override` anchor links existed to repoint.
- `docs/backend/library-gotchas/strict-cutoff-boundary-fixture-and-mutation-proof.md` — `startOfDayJST(now)` → `domain.StartOfLearnDay(now)` (the current formula in `backend/internal/domain/learn_day.go`).

## Test plan

- [ ] `grep -rn 'NewFSRSStateFromInput\|ErrFSRSOverride' backend/ schema/ docs/backend-graphql.md` — 0 hits
- [ ] `grep -rn 'card-bulk-delete--fsrs-override' docs/ README.md` — 0 hits
- [ ] CJK / language-policy check on both edited files — clean

## Notes

- `docs/backend/ddd-patterns/discovery-first-due-ordering.md` carries the same stale `startOfDayJST` references but is rewritten by the rescue-window PR (#975); it is deliberately left untouched here so the two PRs do not edit the same file.

Closes #974
