### PR TITLE
fix(stats): classify mastery and scope retention/lapse by stability now that long-term FSRS pins phase to Review

### DIFF
--- a/backend/internal/domain/fsrs_stat.go
+++ b/backend/internal/domain/fsrs_stat.go
@@ -3,8 +3,8 @@ package domain
 // FSRSStat is a lightweight per-card projection of a user's FSRS state, consumed
 // by the learning-stats domain services (AggregateMastery, TopStruggling). It
 // carries no card front text — just CardID (row identity), CardgroupID (per-deck
-// bucketing), Phase/Stability (the columns ClassifyMastery needs), and Lapses
-// (the struggling-card ranking key).
+// bucketing), Phase (carried for other consumers), Stability (the column
+// ClassifyMastery needs), and Lapses (the struggling-card ranking key).
 //
 // FSRSStat is not an aggregate; it is a view-level value shared between the
 // repository (which builds it from a JOIN of user_card_fsrs and cards) and the

--- a/backend/internal/domain/mastery_tier.go
+++ b/backend/internal/domain/mastery_tier.go
@@ -1,25 +1,32 @@
 package domain
 
 // MatureStabilityDays is the FSRS stability (in days) at or above which a
-// Review-phase card is considered "mature" (durably retained). 21 days mirrors
-// the Anki "mature card" cutoff (Anki thresholds on scheduled interval; we
-// apply the same familiar numeric cutoff to FSRS stability). Single tunable;
-// the three-tier definition lives only in ClassifyMastery.
+// card is considered "mature" (durably retained). 21 days mirrors the Anki
+// "mature card" cutoff (Anki thresholds on scheduled interval; we apply the
+// same familiar numeric cutoff to FSRS stability).
 const MatureStabilityDays = 21.0
+
+// LearnedStabilityDays is the FSRS stability (in days) at or above which a
+// card counts as learned/known: the model projects at least a week of
+// retention. Under the default RequestRetention=0.9 the scheduled interval
+// equals round(stability), so a swipe's ScheduledDaysBefore snapshot reads
+// the same boundary at swipe time.
+const LearnedStabilityDays = 7.0
 
 // MasteryTier is the disjoint learning tier a card sits in.
 type MasteryTier int
 
 const (
-	TierInProgress MasteryTier = iota // New / Learning / Relearning
-	TierLearned                       // Review, stability < threshold
-	TierMature                        // Review, stability >= threshold
+	TierInProgress MasteryTier = iota // Stability below the learned threshold (still being acquired, or recently lapsed)
+	TierLearned                       // Stability at or above the learned threshold and below the mature threshold
+	TierMature                        // Stability at or above the mature threshold
 )
 
-// ClassifyMastery buckets an FSRS state into exactly one tier. matureStabilityDays
-// is passed (not read from the const) so tests can pin the boundary.
-func ClassifyMastery(state FSRSState, matureStabilityDays float64) MasteryTier {
-	if state.Phase != FSRSPhaseReview {
+// ClassifyMastery buckets an FSRS state into exactly one tier by memory
+// stability. Thresholds are passed (not read from the consts) so tests can pin
+// the boundaries.
+func ClassifyMastery(state FSRSState, learnedStabilityDays, matureStabilityDays float64) MasteryTier {
+	if state.Stability < learnedStabilityDays {
 		return TierInProgress
 	}
 	if state.Stability >= matureStabilityDays {

--- a/backend/internal/domain/mastery_tier_test.go
+++ b/backend/internal/domain/mastery_tier_test.go
@@ -27,6 +27,7 @@ func TestClassifyMastery_Boundary(t *testing.T) {
 		{"legacy learning phase in learned band", FSRSPhaseLearning, 15.0, TierLearned},
 		{"just below mature threshold", FSRSPhaseReview, 20.999, TierLearned},
 		{"at mature threshold", FSRSPhaseReview, 21.0, TierMature},
+		{"above mature threshold", FSRSPhaseReview, 21.1, TierMature},
 	}
 
 	for _, tc := range cases {

--- a/backend/internal/domain/mastery_tier_test.go
+++ b/backend/internal/domain/mastery_tier_test.go
@@ -6,14 +6,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestClassifyMastery_Boundary pins the three-tier mastery classifier at the
-// stability boundary (21d, inclusive) across every FSRSPhase. The threshold is
-// passed explicitly so the boundary is exercised independently of the
-// MatureStabilityDays const.
+// TestClassifyMastery_Boundary pins both inclusive stability boundaries and
+// confirms that legacy phase values do not affect the tier.
 func TestClassifyMastery_Boundary(t *testing.T) {
 	t.Parallel()
 
-	const threshold = 21.0
+	const (
+		learnedThreshold = 7.0
+		matureThreshold  = 21.0
+	)
 
 	cases := []struct {
 		name      string
@@ -21,20 +22,11 @@ func TestClassifyMastery_Boundary(t *testing.T) {
 		stability float64
 		want      MasteryTier
 	}{
-		// Non-Review phases are always InProgress regardless of stability.
-		{"new below threshold", FSRSPhaseNew, 20.9, TierInProgress},
-		{"new at threshold", FSRSPhaseNew, 21.0, TierInProgress},
-		{"new above threshold", FSRSPhaseNew, 21.1, TierInProgress},
-		{"learning below threshold", FSRSPhaseLearning, 20.9, TierInProgress},
-		{"learning at threshold", FSRSPhaseLearning, 21.0, TierInProgress},
-		{"learning above threshold", FSRSPhaseLearning, 21.1, TierInProgress},
-		{"relearning below threshold", FSRSPhaseRelearning, 20.9, TierInProgress},
-		{"relearning at threshold", FSRSPhaseRelearning, 21.0, TierInProgress},
-		{"relearning above threshold", FSRSPhaseRelearning, 21.1, TierInProgress},
-		// Review phase splits on the inclusive 21d boundary.
-		{"review just below threshold", FSRSPhaseReview, 20.9, TierLearned},
-		{"review at threshold is mature", FSRSPhaseReview, 21.0, TierMature},
-		{"review just above threshold", FSRSPhaseReview, 21.1, TierMature},
+		{"just below learned threshold", FSRSPhaseReview, 6.999, TierInProgress},
+		{"at learned threshold", FSRSPhaseReview, 7.0, TierLearned},
+		{"legacy learning phase in learned band", FSRSPhaseLearning, 15.0, TierLearned},
+		{"just below mature threshold", FSRSPhaseReview, 20.999, TierLearned},
+		{"at mature threshold", FSRSPhaseReview, 21.0, TierMature},
 	}
 
 	for _, tc := range cases {
@@ -42,21 +34,21 @@ func TestClassifyMastery_Boundary(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			state := FSRSState{Phase: tc.phase, Stability: tc.stability}
-			require.Equal(t, tc.want, ClassifyMastery(state, threshold),
+			require.Equal(t, tc.want, ClassifyMastery(state, learnedThreshold, matureThreshold),
 				"phase=%d stability=%v", tc.phase, tc.stability)
 		})
 	}
 }
 
-// TestMatureStabilityDays_DefaultBoundary confirms the shipped default const
-// buckets a Review card of exactly 21d stability as Mature.
-func TestMatureStabilityDays_DefaultBoundary(t *testing.T) {
+// TestMasteryStabilityDays_DefaultBoundaries confirms the shipped thresholds.
+func TestMasteryStabilityDays_DefaultBoundaries(t *testing.T) {
 	t.Parallel()
+	require.Equal(t, 7.0, LearnedStabilityDays)
 	require.Equal(t, 21.0, MatureStabilityDays)
 
-	atThreshold := FSRSState{Phase: FSRSPhaseReview, Stability: MatureStabilityDays}
-	require.Equal(t, TierMature, ClassifyMastery(atThreshold, MatureStabilityDays))
+	atLearnedThreshold := FSRSState{Phase: FSRSPhaseReview, Stability: LearnedStabilityDays}
+	require.Equal(t, TierLearned, ClassifyMastery(atLearnedThreshold, LearnedStabilityDays, MatureStabilityDays))
 
-	belowThreshold := FSRSState{Phase: FSRSPhaseReview, Stability: MatureStabilityDays - 0.1}
-	require.Equal(t, TierLearned, ClassifyMastery(belowThreshold, MatureStabilityDays))
+	atMatureThreshold := FSRSState{Phase: FSRSPhaseReview, Stability: MatureStabilityDays}
+	require.Equal(t, TierMature, ClassifyMastery(atMatureThreshold, LearnedStabilityDays, MatureStabilityDays))
 }

--- a/backend/internal/domain/service/learning_stats_test.go
+++ b/backend/internal/domain/service/learning_stats_test.go
@@ -71,6 +71,15 @@ func TestAggregateMastery(t *testing.T) {
 			wantDecks:   []DeckMastery{{CardgroupID: "cg1", TotalCards: 1, LearnedCards: 1, MatureCards: 0}},
 		},
 		{
+			name: "review-phase acquisition card (low stability) is InProgress",
+			stats: []domain.FSRSStat{
+				fsrsStat("acquiring", "cg1", domain.FSRSPhaseReview, 3, 2),
+			},
+			totals:      map[string]int{"cg1": 1},
+			wantMastery: MasteryBreakdown{InProgress: 1, TotalStudied: 1},
+			wantDecks:   []DeckMastery{{CardgroupID: "cg1", TotalCards: 1}},
+		},
+		{
 			name: "studied card whose deck is absent from totals counts globally but has no deck row",
 			stats: []domain.FSRSStat{
 				fsrsStat("x", "cgX", domain.FSRSPhaseReview, 30, 0),

--- a/backend/internal/domain/service/user_performance.go
+++ b/backend/internal/domain/service/user_performance.go
@@ -21,8 +21,8 @@ type MasteryBreakdown struct{ InProgress, Learned, Mature, TotalStudied int }
 type DeckMastery struct {
 	CardgroupID  string
 	TotalCards   int
-	LearnedCards int // disjoint: Review & stability < MatureStabilityDays
-	MatureCards  int // disjoint: Review & stability >= MatureStabilityDays
+	LearnedCards int // disjoint: learned threshold <= stability < mature threshold
+	MatureCards  int // disjoint: stability >= mature threshold
 }
 
 // StrugglingCard identifies a card the learner struggles with (high lapses /
@@ -57,6 +57,7 @@ func AggregateMastery(stats []domain.FSRSStat, deckCardTotals map[string]int) (M
 	for _, s := range stats {
 		tier := domain.ClassifyMastery(
 			domain.FSRSState{Phase: s.Phase, Stability: s.Stability},
+			domain.LearnedStabilityDays,
 			domain.MatureStabilityDays,
 		)
 		acc := perDeck[s.CardgroupID]
@@ -229,9 +230,8 @@ func ComputeMetrics(swipes []domain.SwipeRecord, now time.Time) PerformanceMetri
 		if swipe.Rating.IsSuccess() {
 			successes++
 		}
-		// LapseRate and RetentionRate are scoped to reviews of already-learned
-		// cards (pre-swipe phase Review); a graduation or a Relearning re-fail
-		// contributes to neither numerator nor denominator.
+		// LapseRate and RetentionRate are scoped to reviews whose pre-swipe
+		// stability snapshot is in the learned band.
 		if isKnownCardReview(swipe) {
 			reviews++
 			if swipe.Rating == domain.RatingAgain {
@@ -298,13 +298,18 @@ func normalizedDifficulty(difficulty float64) float64 {
 }
 
 // isKnownCardReview reports whether a swipe is a review of an already-learned
-// card — the card's pre-swipe FSRS phase was Review.
+// card according to its pre-swipe stability snapshot.
 //
 // New-format rows (PhaseBefore != nil, recorded once the phase_before column
-// existed) read the pre-swipe snapshot directly: a review iff *PhaseBefore ==
-// FSRSPhaseReview. This correctly excludes a Learning->Easy graduation (whose
-// StateAfter.Phase is Review but whose pre-swipe phase was Learning) and a
-// Relearning re-fail (whose pre-swipe phase was Relearning).
+// existed) require both a Review phase and ScheduledDaysBefore at or above the
+// learned boundary. Under the default RequestRetention=0.9, the scheduled
+// interval equals round(stability), so ScheduledDaysBefore is a faithful
+// pre-swipe stability snapshot. PhaseBefore == Review alone stopped being
+// sufficient when long-term scheduling began sending every rating from every
+// state to Review. A nil ScheduledDaysBefore is treated as not known
+// defensively, matching isOnTimeRecall. This excludes a first-Again card's
+// second review and a lapse-recovery review at interval 1, while including the
+// next review of a graduated card at an interval such as 16 days.
 //
 // Legacy rows (PhaseBefore == nil, recorded before the column existed and aging
 // out of the 365-day window) fall back to the historical post-swipe heuristic:
@@ -313,7 +318,9 @@ func normalizedDifficulty(difficulty float64) float64 {
 // rather than jumping when the new snapshot became available.
 func isKnownCardReview(swipe domain.SwipeRecord) bool {
 	if swipe.PhaseBefore != nil {
-		return *swipe.PhaseBefore == domain.FSRSPhaseReview
+		return *swipe.PhaseBefore == domain.FSRSPhaseReview &&
+			swipe.ScheduledDaysBefore != nil &&
+			float64(*swipe.ScheduledDaysBefore) >= domain.LearnedStabilityDays
 	}
 	if swipe.StateAfter.Phase == domain.FSRSPhaseReview {
 		return true

--- a/backend/internal/domain/service/user_performance.go
+++ b/backend/internal/domain/service/user_performance.go
@@ -56,7 +56,7 @@ func AggregateMastery(stats []domain.FSRSStat, deckCardTotals map[string]int) (M
 	mastery := MasteryBreakdown{TotalStudied: len(stats)}
 	for _, s := range stats {
 		tier := domain.ClassifyMastery(
-			domain.FSRSState{Phase: s.Phase, Stability: s.Stability},
+			domain.FSRSState{Stability: s.Stability},
 			domain.LearnedStabilityDays,
 			domain.MatureStabilityDays,
 		)

--- a/backend/internal/domain/service/user_performance_test.go
+++ b/backend/internal/domain/service/user_performance_test.go
@@ -313,6 +313,21 @@ func TestIsKnownCardReview(t *testing.T) {
 			swipe: swipeBefore(domain.RatingGood, time.Time{}, state(5, 16, 16, domain.FSRSPhaseReview), domain.FSRSPhaseLearning, 16),
 			want:  false,
 		},
+		{
+			name:  "legacy Good with post-swipe Review phase is included",
+			swipe: swipe(domain.RatingGood, time.Time{}, state(5, 7, 7, domain.FSRSPhaseReview)),
+			want:  true,
+		},
+		{
+			name:  "legacy Again with post-swipe Relearning phase and lapses is included",
+			swipe: swipe(domain.RatingAgain, time.Time{}, stateWithLapses(5, 1, 0, domain.FSRSPhaseRelearning, 1)),
+			want:  true,
+		},
+		{
+			name:  "legacy Again with post-swipe Learning phase is excluded",
+			swipe: swipe(domain.RatingAgain, time.Time{}, state(5, 1, 0, domain.FSRSPhaseLearning)),
+			want:  false,
+		},
 	}
 
 	for _, tc := range cases {

--- a/backend/internal/domain/service/user_performance_test.go
+++ b/backend/internal/domain/service/user_performance_test.go
@@ -65,10 +65,11 @@ func TestComputeMetrics(t *testing.T) {
 		},
 		{
 			// Review->Again is the one FSRS lapse transition: it counts as a lapse
-			// and, being an Again, is never an on-time recall.
+			// once the pre-swipe stability is learned and, being an Again, is never
+			// an on-time recall.
 			name: "new-format review again is a lapse and not a retention",
 			swipes: []domain.SwipeRecord{
-				swipeBefore(domain.RatingAgain, now, stateWithLapses(5, 3, 0, domain.FSRSPhaseRelearning, 1), domain.FSRSPhaseReview, 5),
+				swipeBefore(domain.RatingAgain, now, stateWithLapses(5, 3, 0, domain.FSRSPhaseRelearning, 1), domain.FSRSPhaseReview, 7),
 			},
 			want: PerformanceMetrics{
 				SuccessRate:   0,
@@ -85,7 +86,7 @@ func TestComputeMetrics(t *testing.T) {
 			// so SuccessRate (0) and RetentionRate (1) diverge deliberately.
 			name: "new-format review hard on time is a retention but not a success",
 			swipes: []domain.SwipeRecord{
-				swipeBefore(domain.RatingHard, now, state(5, 4, 6, domain.FSRSPhaseReview), domain.FSRSPhaseReview, 5),
+				swipeBefore(domain.RatingHard, now, state(5, 4, 8, domain.FSRSPhaseReview), domain.FSRSPhaseReview, 7),
 			},
 			want: PerformanceMetrics{
 				SuccessRate:   0,
@@ -101,7 +102,7 @@ func TestComputeMetrics(t *testing.T) {
 			// within is a review, but not an on-time recall.
 			name: "new-format review easy later than scheduled is a review but not a retention",
 			swipes: []domain.SwipeRecord{
-				swipeBefore(domain.RatingEasy, now, state(5, 5, 10, domain.FSRSPhaseReview), domain.FSRSPhaseReview, 2),
+				swipeBefore(domain.RatingEasy, now, state(5, 8, 10, domain.FSRSPhaseReview), domain.FSRSPhaseReview, 7),
 			},
 			want: PerformanceMetrics{
 				SuccessRate:   1,
@@ -117,7 +118,7 @@ func TestComputeMetrics(t *testing.T) {
 			// boundary).
 			name: "new-format review at the exact scheduled boundary is on time",
 			swipes: []domain.SwipeRecord{
-				swipeBefore(domain.RatingGood, now, state(5, 5, 9, domain.FSRSPhaseReview), domain.FSRSPhaseReview, 5),
+				swipeBefore(domain.RatingGood, now, state(5, 7, 9, domain.FSRSPhaseReview), domain.FSRSPhaseReview, 7),
 			},
 			want: PerformanceMetrics{
 				SuccessRate:   1,
@@ -152,9 +153,9 @@ func TestComputeMetrics(t *testing.T) {
 			// numerator; one on-time Hard is the retention numerator.
 			name: "new-format mixed reviews scope both rates to the review denominator",
 			swipes: []domain.SwipeRecord{
-				swipeBefore(domain.RatingAgain, now, stateWithLapses(5, 3, 0, domain.FSRSPhaseRelearning, 1), domain.FSRSPhaseReview, 5),
-				swipeBefore(domain.RatingHard, now, state(5, 4, 6, domain.FSRSPhaseReview), domain.FSRSPhaseReview, 5),
-				swipeBefore(domain.RatingEasy, now, state(5, 9, 10, domain.FSRSPhaseReview), domain.FSRSPhaseReview, 5),
+				swipeBefore(domain.RatingAgain, now, stateWithLapses(5, 3, 0, domain.FSRSPhaseRelearning, 1), domain.FSRSPhaseReview, 7),
+				swipeBefore(domain.RatingHard, now, state(5, 4, 8, domain.FSRSPhaseReview), domain.FSRSPhaseReview, 7),
+				swipeBefore(domain.RatingEasy, now, state(5, 9, 10, domain.FSRSPhaseReview), domain.FSRSPhaseReview, 7),
 				swipeBefore(domain.RatingEasy, now, state(5, 0, 1, domain.FSRSPhaseReview), domain.FSRSPhaseLearning, 0),
 			},
 			want: PerformanceMetrics{
@@ -212,8 +213,8 @@ func TestComputeMetrics(t *testing.T) {
 			// Again-on-Learning are not reviews).
 			name: "mixed legacy and new-format window scopes rates across both branches",
 			swipes: []domain.SwipeRecord{
-				swipeBefore(domain.RatingHard, now, state(5, 4, 9, domain.FSRSPhaseReview), domain.FSRSPhaseReview, 5),
-				swipeBefore(domain.RatingAgain, now, stateWithLapses(5, 2, 0, domain.FSRSPhaseRelearning, 1), domain.FSRSPhaseReview, 5),
+				swipeBefore(domain.RatingHard, now, state(5, 4, 9, domain.FSRSPhaseReview), domain.FSRSPhaseReview, 7),
+				swipeBefore(domain.RatingAgain, now, stateWithLapses(5, 2, 0, domain.FSRSPhaseRelearning, 1), domain.FSRSPhaseReview, 7),
 				swipeBefore(domain.RatingEasy, now, state(5, 0, 1, domain.FSRSPhaseReview), domain.FSRSPhaseLearning, 0),
 				swipe(domain.RatingGood, now, state(5, 10, 3, domain.FSRSPhaseReview)),
 				swipe(domain.RatingAgain, now, state(5, 1, 0, domain.FSRSPhaseLearning)),
@@ -233,10 +234,10 @@ func TestComputeMetrics(t *testing.T) {
 			// reviews, so the scoped rates stay at 1 / 0.
 			name: "study streak counts consecutive days from provided now",
 			swipes: []domain.SwipeRecord{
-				swipeBefore(domain.RatingGood, now.Add(-2*time.Hour), state(5, 1, 5, domain.FSRSPhaseReview), domain.FSRSPhaseReview, 5),
-				swipeBefore(domain.RatingGood, now.AddDate(0, 0, -1), state(5, 1, 5, domain.FSRSPhaseReview), domain.FSRSPhaseReview, 5),
-				swipeBefore(domain.RatingGood, now.AddDate(0, 0, -2), state(5, 1, 5, domain.FSRSPhaseReview), domain.FSRSPhaseReview, 5),
-				swipeBefore(domain.RatingGood, now.AddDate(0, 0, -4), state(5, 1, 5, domain.FSRSPhaseReview), domain.FSRSPhaseReview, 5),
+				swipeBefore(domain.RatingGood, now.Add(-2*time.Hour), state(5, 1, 7, domain.FSRSPhaseReview), domain.FSRSPhaseReview, 7),
+				swipeBefore(domain.RatingGood, now.AddDate(0, 0, -1), state(5, 1, 7, domain.FSRSPhaseReview), domain.FSRSPhaseReview, 7),
+				swipeBefore(domain.RatingGood, now.AddDate(0, 0, -2), state(5, 1, 7, domain.FSRSPhaseReview), domain.FSRSPhaseReview, 7),
+				swipeBefore(domain.RatingGood, now.AddDate(0, 0, -4), state(5, 1, 7, domain.FSRSPhaseReview), domain.FSRSPhaseReview, 7),
 			},
 			want: PerformanceMetrics{
 				SuccessRate:   1,
@@ -262,6 +263,63 @@ func TestComputeMetrics(t *testing.T) {
 			require.Equal(t, tc.want.StudyStreak, got.StudyStreak)
 			require.InDelta(t, tc.want.LapseRate, got.LapseRate, 0.000000001)
 			require.Equal(t, tc.want.ReviewCount, got.ReviewCount)
+		})
+	}
+}
+
+func TestIsKnownCardReview(t *testing.T) {
+	t.Parallel()
+
+	reviewPhase := domain.FSRSPhaseReview
+	cases := []struct {
+		name  string
+		swipe domain.SwipeRecord
+		want  bool
+	}{
+		{
+			name:  "first-Again card second review at interval one is excluded",
+			swipe: swipeBefore(domain.RatingAgain, time.Time{}, state(5, 1, 1, domain.FSRSPhaseReview), domain.FSRSPhaseReview, 1),
+			want:  false,
+		},
+		{
+			name:  "lapse recovery review at interval one is excluded",
+			swipe: swipeBefore(domain.RatingGood, time.Time{}, stateWithLapses(5, 1, 1, domain.FSRSPhaseReview, 1), domain.FSRSPhaseReview, 1),
+			want:  false,
+		},
+		{
+			name:  "interval six is below the learned boundary",
+			swipe: swipeBefore(domain.RatingGood, time.Time{}, state(5, 6, 6, domain.FSRSPhaseReview), domain.FSRSPhaseReview, 6),
+			want:  false,
+		},
+		{
+			name:  "interval seven is at the learned boundary",
+			swipe: swipeBefore(domain.RatingGood, time.Time{}, state(5, 7, 7, domain.FSRSPhaseReview), domain.FSRSPhaseReview, 7),
+			want:  true,
+		},
+		{
+			name:  "graduated card next review at interval sixteen is included",
+			swipe: swipeBefore(domain.RatingGood, time.Time{}, state(5, 16, 16, domain.FSRSPhaseReview), domain.FSRSPhaseReview, 16),
+			want:  true,
+		},
+		{
+			name: "new-format row without scheduled interval is excluded",
+			swipe: domain.SwipeRecord{
+				PhaseBefore: &reviewPhase,
+			},
+			want: false,
+		},
+		{
+			name:  "non-review phase is excluded above the stability boundary",
+			swipe: swipeBefore(domain.RatingGood, time.Time{}, state(5, 16, 16, domain.FSRSPhaseReview), domain.FSRSPhaseLearning, 16),
+			want:  false,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, isKnownCardReview(tc.swipe))
 		})
 	}
 }

--- a/schema/stats.graphql
+++ b/schema/stats.graphql
@@ -26,7 +26,7 @@ type PerformanceWindows {
 type StrugglingCard {
   """The struggling card."""
   card: Card!
-  """Number of times the card lapsed (rated Again from a known-review state)."""
+  """Number of times the card was rated Again on a repeat exposure (the FSRS lapse counter)."""
   lapses: Int!
   """The card's current FSRS memory stability, in days."""
   stability: Float!
@@ -34,11 +34,11 @@ type StrugglingCard {
 
 """Disjoint three-tier mastery counts across all studied cards. The three tiers sum to totalStudied."""
 type MasteryBreakdown {
-  """Cards not yet in the Review phase (New / Learning / Relearning)."""
+  """Studied cards whose memory stability is below the learned threshold (7 days) — still being acquired, or recently lapsed."""
   inProgress: Int!
-  """Review-phase cards below the maturity stability threshold."""
+  """Cards whose stability is between the learned threshold (7 days) and the maturity threshold (21 days)."""
   learned: Int!
-  """Review-phase cards at or above the maturity stability threshold (durably retained)."""
+  """Cards at or above the maturity stability threshold (21 days; durably retained)."""
   mature: Int!
   """Total number of studied cards; equals inProgress + learned + mature."""
   totalStudied: Int!


### PR DESCRIPTION
## Summary

The long-term scheduler switch (`EnableShortTerm=false`) makes `go-fsrs` send every rating from every state to phase `Review`, so `Learning`/`Relearning` are unreachable for new `user_card_fsrs` rows (confirmed by TLC complete state-space search). Two `/stats` consumers keyed on the now-dead phase label are re-expressed in terms of FSRS **stability** — the source of truth — via a new shared `domain.LearnedStabilityDays = 7.0`. This fixes `MasteryBreakdown.inProgress` being structurally `0` post-switch and restores the review-scoped Retention/Lapse semantics that the switch had silently broken.

## Changes

### Backend

- `backend/internal/domain/mastery_tier.go` — new `LearnedStabilityDays = 7.0`; `ClassifyMastery` becomes a pure stability-band classifier (`S < 7` → InProgress, `7 ≤ S < 21` → Learned, `S ≥ 21` → Mature) taking both thresholds as params; phase is no longer consulted. A card rated Again on its first exposure (stability `~0.4`) now classifies as InProgress instead of Learned.
- `backend/internal/domain/service/user_performance.go` — `isKnownCardReview`'s new-format branch additionally requires `*ScheduledDaysBefore >= LearnedStabilityDays`. Because the scheduled interval equals `round(stability)` at the default `RequestRetention=0.9`, the existing snapshot column is a faithful pre-swipe stability record — **no migration needed**. `AggregateMastery` passes both thresholds to `ClassifyMastery`.

### Schema

- `schema/stats.graphql` — `MasteryBreakdown.{inProgress,learned,mature}` and `StrugglingCard.lapses` descriptions updated to the stability wording. The struggling lapses counter itself is unchanged — acquisition failures are legitimate struggle signal.

### Tests

- `mastery_tier_test.go` — stability-band boundary fixtures (6.999/7.0, 20.999/21.0) plus a phase-independence case.
- `user_performance_test.go` — `isKnownCardReview` fixtures at `ScheduledDaysBefore` 1/6/7/16 and a nil-snapshot defensive case; the legacy nil-`PhaseBefore` fallback is unchanged; the `AggregateMastery` sum invariant holds.

## Test plan

- [ ] `go vet ./... && go build ./... && go test ./...` — green (2228 tests, 26 packages)
- [ ] `go tool gqlgen generate` — no tracked diff (descriptions only)
- [ ] `grep -rn 'New / Learning / Relearning' backend/ schema/` — 0 hits

Closes #973
