### PR TITLE
fix(stats): shrink diagnostics window-toggle buttons from 44px to 36px

### DIFF
--- a/frontend/src/app/stats/diagnostics-panel.tsx
+++ b/frontend/src/app/stats/diagnostics-panel.tsx
@@ -108,7 +108,7 @@ export function DiagnosticsPanel({
                 aria-pressed={selected}
                 onClick={() => setSelectedWindow(key)}
                 className={cn(
-                  "min-h-11 min-w-11 rounded-md px-3 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+                  "min-h-9 min-w-11 rounded-md px-3 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
                   selected
                     ? "bg-brand-primary text-brand-primary-foreground"
                     : "text-muted-foreground hover:text-foreground",


### PR DESCRIPTION
## Summary

On mobile `/stats`, the diagnostics trailing-window segmented control (365 / 30 / 7 days) read as an oversized solid bar: the `min-h-11` (44px) buttons wrap the 12px label in 14px of vertical padding, and the container's 2px inset (`p-0.5`) is below the perceptual threshold, so the selected coral pill appeared to touch the tray edges. A design review traced the bulk to the button height — the concentric radius nesting (outer `rounded-lg` 10px − 2px inset = inner `rounded-md` 8px) was already exact. This lowers the buttons to `min-h-9` (36px), shrinking the control from 48px to 40px and the in-pill vertical padding to 10px. The 36px tap target still clears the WCAG 2.2 AA target-size minimum (24px).

## Changes

### Frontend

- `frontend/src/app/stats/diagnostics-panel.tsx` — window-toggle buttons drop `min-h-11` for `min-h-9`; `min-w-11` (44px tap width, which also floor-clamps the narrow "7 days" segment), the `px-3` label padding, and both radius classes are unchanged, so the pill/tray corner nesting stays concentric.

## Test plan

- [ ] `tsc --noEmit` — pass
- [ ] `biome check src/app/stats/` — pass
- [ ] `vitest run` — 206 files / 1900 tests pass
- [ ] Visual: the `/stats` diagnostics control renders 40px tall next to the heading; rating tiles and window switching behave as before

No related issue.
