### PR TITLE
feat(profile): brand-fill the display-mode toggle and outline the delete-account trigger

### DIFF
--- a/.claude/rules/frontend-design-system.md
+++ b/.claude/rules/frontend-design-system.md
@@ -38,7 +38,8 @@ Exactly **one** filled coral CTA per view; everything else steps back:
 - **Primary CTA (one per view)** → `variant="brand"` (filled coral).
 - **Secondary** → `variant="ghost"` (recommended), or `variant="outline"` in dense lists /
   dialog footers where a visible border earns its keep.
-- **Danger trigger (inline)** → `variant="destructiveGhost"`.
+- **Danger trigger (in a row / list / menu)** → `variant="destructiveGhost"`.
+- **Danger trigger (standalone, no interactive neighbours)** → `variant="destructiveOutline"`.
 - **Danger commit (confirm)** → `variant="destructive"` (filled crimson).
 - **Cancel / Keep-editing** → `variant="outline"`.
 
@@ -49,9 +50,13 @@ style a constructive action (Save, Create, Login, Import, Publish) with `destruc
 
 Danger is expressed at two emphasis levels:
 
-- **Trigger (inline)** — `variant="destructiveGhost"` (`bg-transparent text-destructive
+- **Trigger** — `variant="destructiveGhost"` (`bg-transparent text-destructive
   hover:bg-destructive/10`) + a `Trash2` icon. Red text, transparent, faint red hover —
-  **never** a filled red row. The trigger only opens the confirm.
+  **never** a filled red row. The trigger only opens the confirm. Where the trigger stands
+  alone with no interactive neighbours (a Danger-zone section, a selection toolbar), use
+  `variant="destructiveOutline"` — the same transparent red plus a `border-destructive/45`
+  border. Border is **affordance, not emphasis**: it answers "is this tappable", never "is
+  this more dangerous". Both variants sit on the same rung.
 - **Commit (confirm)** — filled `variant="destructive"` on the `AlertDialogAction` that
   actually deletes / overwrites / discards. This is the **only** filled crimson in the flow.
 
@@ -73,8 +78,8 @@ import { buttonVariants } from "@/components/ui/button";
 </AlertDialogAction>
 ```
 
-The inline trigger that *opens* the dialog is the lower tier — `variant="destructiveGhost"` +
-`Trash2` — never filled `destructive`.
+The trigger that *opens* the dialog is the lower tier — `variant="destructiveGhost"` or
+`variant="destructiveOutline"`, plus `Trash2` — never filled `destructive`.
 
 What counts as a danger confirm: permanent delete (single + bulk), overwrite of existing data,
 and discard of unsaved edits. See the worked-example table in
@@ -98,13 +103,13 @@ Two distinct surfaces, two checks:
    `cardgroup-header.tsx` (Delete group) styles its commit red inline (`bg-destructive`).
    A confirm with no danger color and a delete/overwrite/discard onClick is a bug, not a style choice.
 
-2. **Inline delete triggers (`destructiveGhost`).** An inline Delete affordance that opens a
-   confirm is the low-emphasis tier — `variant="destructiveGhost"`, transparent, never a filled
-   red row:
+2. **Delete triggers (`destructiveGhost` / `destructiveOutline`).** A Delete affordance that
+   opens a confirm is the low-emphasis tier — transparent, never a filled red row:
 
    ```bash
-   grep -rn "destructiveGhost" frontend/src --include='*.tsx' | grep -v test
+   grep -rnE "destructiveGhost|destructiveOutline" frontend/src --include='*.tsx' | grep -v '\.test\.'
    ```
 
-   An inline delete trigger styled as filled `destructive` (a red row at rest) is the
-   anti-pattern the two-tier replaces.
+   A delete trigger styled as filled `destructive` (a red row at rest) is the anti-pattern the
+   two-tier replaces. A `destructiveOutline` trigger that sits next to other interactive
+   controls should be demoted to `destructiveGhost` — the border is only earned by isolation.

--- a/docs/frontend/design-system.md
+++ b/docs/frontend/design-system.md
@@ -24,9 +24,10 @@ rule that the two colors must never co-locate:
 - **Emphasis ladder** — exactly one filled coral CTA per view; every other control steps
   back to a lower-emphasis variant. This is what keeps a screen from looking like a wall
   of coral buttons.
-- **Danger two-tier** — an inline delete *trigger* is low-emphasis ghost-red
-  (`destructiveGhost`); the data-loss *commit* inside the confirm dialog is the only
-  filled crimson. The trigger invites; the commit re-affirms.
+- **Danger two-tier** — a delete *trigger* is low-emphasis red on a transparent ground
+  (`destructiveGhost`, or `destructiveOutline` when it needs a visible border); the data-loss
+  *commit* inside the confirm dialog is the only filled crimson. The trigger invites; the
+  commit re-affirms.
 
 These supersede the older "two reds that never co-locate" defense. Coral and crimson are
 allowed to share a surface because the emphasis ladder and the two-tier already disambiguate
@@ -84,7 +85,8 @@ single primary action stays visually dominant:
 |---|---|---|
 | Primary CTA (one per view) | `brand` | filled coral |
 | Secondary action | `ghost` (or `outline` in dense lists / dialogs) | neutral, no fill until hover |
-| Danger trigger (inline) | `destructiveGhost` | red text, transparent, faint red hover |
+| Danger trigger (in a row / list) | `destructiveGhost` | red text, transparent, faint red hover |
+| Danger trigger (standalone) | `destructiveOutline` | red text, transparent, red border |
 | Danger commit (confirm) | `destructive` | filled crimson |
 | Cancel / Keep-editing | `outline` | bordered, transparent |
 
@@ -98,32 +100,55 @@ watch for: demote all but the genuine primary.
 Danger is expressed at two emphasis levels, and the level tracks how close the user is to
 irreversible loss:
 
-- **Trigger (inline) — `destructiveGhost` + a `Trash2` icon.** An inline Delete affordance is
-  low-emphasis: `bg-transparent text-destructive hover:bg-destructive/10`. It reads as red but
-  never paints a filled red row in a list. The trigger only *opens* the confirm — it does not
-  itself destroy data.
+- **Trigger — `destructiveGhost` / `destructiveOutline` + a `Trash2` icon.** A Delete affordance
+  is low-emphasis: red text on `bg-transparent`, faint red hover. It reads as red but never
+  paints a filled red row. The trigger only *opens* the confirm — it does not itself destroy
+  data.
 - **Commit (confirm) — filled `destructive`.** The `AlertDialogAction` that actually deletes /
   overwrites / discards is the **only** filled crimson in the flow. This re-affirms the
   existing filled-destructive confirm rule below, which is **unchanged**.
 
 A filled red row in a list is the anti-pattern this two-tier replaces: it shouts danger at rest,
-before the user has expressed any delete intent. Ghost-red at the trigger, filled crimson only at
-the commit.
+before the user has expressed any delete intent. Transparent red at the trigger, filled crimson
+only at the commit.
+
+### Border is affordance, not emphasis: `destructiveGhost` vs `destructiveOutline`
+
+The two trigger variants sit on the *same* rung of the ladder — both are transparent red. The
+border answers a different question than the fill does: **is this thing tappable at all?**
+
+- **`destructiveGhost` (borderless)** — the trigger lives inside a structure that already
+  supplies the affordance: a table row, a list item, an overflow menu, a sheet section with
+  sibling controls. Neighbouring hit targets tell the user this region is interactive, so the
+  border would be redundant chrome.
+- **`destructiveOutline` (bordered)** — the trigger stands alone on the page with no
+  interactive neighbours. Borderless red text in isolation reads as a static label or an inline
+  link, not a button, so the affordance has to be drawn explicitly.
+
+Reach for `destructiveOutline` only on the isolation test. It is **not** a way to make a delete
+"stand out more" — that would re-open the emphasis question the two-tier settles. The rule of
+thumb: if removing the button would leave a region with no other controls in it, it needs the
+border.
+
+Worked example: the `/profile` Danger zone
+([`delete-account-section.tsx`](../../frontend/src/app/profile/delete-account-section.tsx)) is a
+heading, a sentence, and one control. As `destructiveGhost` the trigger rendered as a red text
+row and did not read as a button; it uses `destructiveOutline`. By contrast the admin
+user-profile sheet's Delete user
+([`admin-user-profile-sheet.tsx`](../../frontend/src/app/admin/users/admin-user-profile-sheet.tsx))
+sits below other sheet controls and stays `destructiveGhost`.
 
 ### Selection toolbars: the destructive action is the bar's primary
 
 A contextual selection bar — e.g. the cards bulk-action bar
 ([`bulk-action-bar.tsx`](../../frontend/src/components/cardgroups/bulk-action-bar.tsx)) — is the
 one place where a danger trigger is also the **primary** action of its view: the user entered
-selection mode *in order to* delete. There the inline `destructiveGhost` trigger carries a local
-affordance border (`border border-destructive/45`) so it reads as clearly tappable and findable,
-and its sibling **Cancel is demoted from `outline` to `ghost`** so the single bordered control is
-the destructive one. This is a deliberate, local exception to the "Cancel → `outline`" ladder row
-above: emphasis tracks intent, and the bar's intent is to delete. The trigger stays transparent
-(border only, never a filled red row), and the real safety gate remains the filled `destructive`
-commit in the confirm dialog. Standalone danger triggers outside a selection bar (Delete account,
-Delete user) keep the plain borderless `destructiveGhost` — there delete is a rare, dangerous
-escape hatch, not the view's purpose, so it stays recessive.
+selection mode *in order to* delete. There the trigger uses `destructiveOutline` so it reads as
+clearly tappable and findable, and its sibling **Cancel is demoted from `outline` to `ghost`** so
+the single bordered control is the destructive one. This is a deliberate, local exception to the
+"Cancel → `outline`" ladder row above: emphasis tracks intent, and the bar's intent is to delete.
+The trigger stays transparent (border only, never a filled red row), and the real safety gate
+remains the filled `destructive` commit in the confirm dialog.
 
 ## Button variants
 
@@ -134,7 +159,8 @@ not by appearance:
 |---|---|---|
 | `brand` | flamingo coral (`--brand-primary`) | **Primary constructive CTA** — Save, Create, Login, Import, Publish, Study again (one per view) |
 | `destructive` | filled crimson (`--destructive`) | **Destructive / data-loss commit** — the confirm-dialog action; see the dialog convention below |
-| `destructiveGhost` | none until hover (`text-destructive`, faint red hover) | **Low-emphasis danger trigger** — inline Delete that opens a confirm |
+| `destructiveGhost` | none until hover (`text-destructive`, faint red hover) | **Low-emphasis danger trigger** — Delete inside a row / list / menu that opens a confirm |
+| `destructiveOutline` | none until hover, plus a `border-destructive/45` border | **Low-emphasis danger trigger, standalone** — same rung as `destructiveGhost`; the border supplies affordance where no interactive neighbours do |
 | `outline` | bordered, transparent | Cancel, Keep-editing, toggle-off, secondary action in dense lists / dialogs |
 | `ghost` | none until hover | **Recommended secondary** — toolbar / icon-only actions and step-back secondaries inside dense UI |
 | `link` | text + underline (coral `--brand-link`) | Inline text-link affordance |
@@ -173,8 +199,9 @@ import { buttonVariants } from "@/components/ui/button";
 (tailwind-merge) lets the later `bg-destructive` win over the default `bg-primary`, so passing
 the destructive classes via `className` is sufficient — no override of the component is needed.
 
-The inline trigger that *opens* this dialog is the lower tier: it uses `destructiveGhost`
-(transparent, red text + `Trash2`), never filled `destructive`. Only the commit above is filled.
+The trigger that *opens* this dialog is the lower tier: it uses `destructiveGhost` or
+`destructiveOutline` (transparent, red text + `Trash2`), never filled `destructive`. Only the
+commit above is filled.
 
 ### What counts as a "danger" confirm
 
@@ -190,7 +217,8 @@ data**:
 
 Constructive confirms in the same dialogs stay non-red: `AlertDialogCancel` is `outline`,
 "Keep editing" is `outline`. A constructive *primary* action elsewhere (Save / Create) is `brand`,
-never `destructive`. The inline trigger that opens any of these dialogs is `destructiveGhost`.
+never `destructive`. The trigger that opens any of these dialogs is `destructiveGhost` or
+`destructiveOutline`.
 
 ## Accessibility notes
 

--- a/frontend/src/app/profile/delete-account-section.test.tsx
+++ b/frontend/src/app/profile/delete-account-section.test.tsx
@@ -72,13 +72,16 @@ describe("<DeleteAccountSection>", () => {
     expect(screen.getByTestId("delete-account-trigger")).toBeInTheDocument();
   });
 
-  it("renders the trigger as a low-emphasis ghost while the confirm stays filled", async () => {
+  it("renders the trigger as an outlined danger button while the confirm stays filled", async () => {
     const user = userEvent.setup();
     renderSection();
 
     const trigger = screen.getByTestId("delete-account-trigger");
     expect(trigger).not.toHaveClass("bg-destructive");
     expect(trigger).toHaveClass("text-destructive");
+    // The border is what makes the trigger read as a button; the ghost variant
+    // it replaces had no visible affordance at rest.
+    expect(trigger).toHaveClass("border", "border-destructive/45");
 
     await user.click(trigger);
     const confirm = await screen.findByTestId("delete-account-confirm");

--- a/frontend/src/app/profile/delete-account-section.tsx
+++ b/frontend/src/app/profile/delete-account-section.tsx
@@ -104,7 +104,7 @@ export function DeleteAccountSection() {
 
       <AlertDialog open={open} onOpenChange={handleOpenChange}>
         <AlertDialogTrigger asChild>
-          <Button type="button" variant="destructiveGhost" data-testid="delete-account-trigger">
+          <Button type="button" variant="destructiveOutline" data-testid="delete-account-trigger">
             <Trash2 aria-hidden="true" className="h-4 w-4" />
             {t("deleteAccountButton")}
           </Button>

--- a/frontend/src/app/profile/display-mode-section.tsx
+++ b/frontend/src/app/profile/display-mode-section.tsx
@@ -79,7 +79,7 @@ export function DisplayModeSection({ initialMode }: { initialMode: LearnDisplayM
               className={cn(
                 "flex-1 rounded-sm px-3 py-1.5 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50",
                 active
-                  ? "bg-primary text-primary-foreground"
+                  ? "bg-brand-primary text-brand-primary-foreground"
                   : "text-muted-foreground hover:bg-muted",
               )}
             >

--- a/frontend/src/components/cardgroups/bulk-action-bar.tsx
+++ b/frontend/src/components/cardgroups/bulk-action-bar.tsx
@@ -37,11 +37,11 @@ export function BulkActionBar({ count, busy, onConfirm, onClear }: BulkActionBar
       <AlertDialog>
         <AlertDialogTrigger asChild>
           <Button
-            variant="destructiveGhost"
+            variant="destructiveOutline"
             size="sm"
             disabled={busy}
             data-testid="cards-bulk-delete-button"
-            className="w-full border border-destructive/45 sm:w-auto"
+            className="w-full sm:w-auto"
           >
             {tCommon("deleteSelected")}
             <Trash2 aria-hidden="true" className="ml-1.5 h-4 w-4" />

--- a/frontend/src/components/ui/button.test.tsx
+++ b/frontend/src/components/ui/button.test.tsx
@@ -12,6 +12,20 @@ describe("Button variants", () => {
     expect(button).not.toHaveClass("bg-destructive");
   });
 
+  it("destructiveOutline adds a visible border to the ghost-red trigger without filling it", () => {
+    render(<Button variant="destructiveOutline">Delete my account</Button>);
+    const button = screen.getByRole("button", { name: "Delete my account" });
+    expect(button).toHaveClass(
+      "border",
+      "border-destructive/45",
+      "bg-transparent",
+      "text-destructive",
+      "hover:bg-destructive/10",
+    );
+    // Still a trigger, not the commit: the border buys affordance, not emphasis.
+    expect(button).not.toHaveClass("bg-destructive");
+  });
+
   it("link variant uses the coral link token, not the neutral primary", () => {
     render(<Button variant="link">Learn more</Button>);
     const button = screen.getByRole("button", { name: "Learn more" });

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -13,6 +13,8 @@ const buttonVariants = cva(
         brand: "bg-brand-primary text-brand-primary-foreground hover:bg-brand-primary/90",
         destructive: "bg-destructive text-destructive-foreground hover:bg-destructive/90",
         destructiveGhost: "bg-transparent text-destructive hover:bg-destructive/10",
+        destructiveOutline:
+          "border border-destructive/45 bg-transparent text-destructive hover:bg-destructive/10",
         outline: "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
         secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",
         ghost: "hover:bg-accent hover:text-accent-foreground",


### PR DESCRIPTION
## Summary

Two `/profile` color fixes plus the shared variant they surfaced. The Display-mode segmented control painted its selected segment with `bg-primary` (neutral near-black), which contradicts the coral-minimal rule that a selected state is a brand fill; it now uses `bg-brand-primary`. The Danger-zone "Delete my account" trigger was `destructiveGhost` — borderless red text sitting alone under a heading with no interactive neighbours, so it read as a static label rather than a button. The fix is affordance, not emphasis: a new `destructiveOutline` variant keeps the transparent-red trigger tier intact and adds a border. `bulk-action-bar.tsx` had already hand-rolled that exact treatment as an inline `border border-destructive/45` on a `destructiveGhost` button, so it is routed through the new variant with no visual change.

## Changes

### Button variant

- `frontend/src/components/ui/button.tsx` — new `destructiveOutline` variant: `border border-destructive/45 bg-transparent text-destructive hover:bg-destructive/10`. Same rung of the emphasis ladder as `destructiveGhost`; the border is affordance only, never a fill.
- `frontend/src/components/cardgroups/bulk-action-bar.tsx` — bulk-delete trigger swaps `variant="destructiveGhost"` + `className="w-full border border-destructive/45 sm:w-auto"` for `variant="destructiveOutline"` + `className="w-full sm:w-auto"`. Byte-identical rendered classes, so `bulk-action-bar.test.tsx`'s existing `border-destructive/45` assertion passes unchanged.

### Profile page

- `frontend/src/app/profile/display-mode-section.tsx` — the active segment moves from `bg-primary text-primary-foreground` to `bg-brand-primary text-brand-primary-foreground`.
- `frontend/src/app/profile/delete-account-section.tsx` — the `AlertDialogTrigger` button moves from `variant="destructiveGhost"` to `variant="destructiveOutline"`. The confirm inside the dialog stays filled `destructive`, so the two-tier is preserved.

### Docs

- `docs/frontend/design-system.md` — new sub-section "Border is affordance, not emphasis: `destructiveGhost` vs `destructiveOutline`" giving the isolation test (a trigger with no interactive neighbours earns the border; one inside a row / list / menu does not) and contrasting `/profile` Danger zone against the admin user-profile sheet's Delete user. `destructiveOutline` added to the emphasis-ladder and Button-variants tables; the selection-toolbar exception now names the variant instead of describing an inline border.
- `.claude/rules/frontend-design-system.md` — ladder and two-tier sections gain the standalone-trigger row; verification grep 2 widens to `grep -rnE "destructiveGhost|destructiveOutline"` and filters test files by `\.test\.` rather than the bare substring `test`.

### Tests

- `frontend/src/components/ui/button.test.tsx` — new case asserting `destructiveOutline` carries the border plus the transparent-red classes and is **not** `bg-destructive`.
- `frontend/src/app/profile/delete-account-section.test.tsx` — the trigger-styling test is retargeted from ghost to outline: still `not.toHaveClass("bg-destructive")` and `toHaveClass("text-destructive")`, now also `toHaveClass("border", "border-destructive/45")`.

## Test plan

- [ ] `tsc --noEmit` — pass
- [ ] `biome check --error-on-warnings src` — pass
- [ ] `vitest run` — 206 files / 1901 tests pass
- [ ] `knip` — clean
- [ ] `next build` — pass
- [ ] Visual `/profile`: the selected Display-mode segment is coral, not near-black; "Delete my account" renders as a bordered red button
- [ ] Regression: opening the delete dialog still shows a filled crimson confirm, gated by the type-to-confirm phrase
- [ ] Regression `/cardgroups/<id>`: entering card-selection mode renders the bulk-delete trigger exactly as before

## Notes

- No Playwright run — the e2e suite needs a live Supabase + backend stack. No `data-testid` or label changed, so no spec selectors are affected.

No related issue.
