### PR TITLE
fix(learn): dedup the prefetch merge against cards swiped this session

### DIFF
--- a/frontend/src/app/learn/[cardgroupId]/learn-client.test.tsx
+++ b/frontend/src/app/learn/[cardgroupId]/learn-client.test.tsx
@@ -1102,9 +1102,11 @@ type PrefetchCard = ReturnType<typeof makeQueue>[number];
  * Builds a LearnNextDueCards mock that returns `cards` and tracks call count.
  * Optional `delay` (ms) holds the response open, allowing tests to fire the
  * effect multiple times before the first response resolves — used to verify
- * the in-flight guard prevents concurrent prefetch requests.
+ * the in-flight guard prevents concurrent prefetch requests. Optional
+ * `cardgroupId` targets a deck other than the default one, for tests that
+ * switch the active cardgroup mid-session.
  */
-function makePrefetchMock(cards: PrefetchCard[], opts?: { delay?: number }) {
+function makePrefetchMock(cards: PrefetchCard[], opts?: { delay?: number; cardgroupId?: string }) {
   let calls = 0;
   const mock: {
     request: { query: typeof LearnNextDueCardsDocument; variables: object };
@@ -1113,7 +1115,7 @@ function makePrefetchMock(cards: PrefetchCard[], opts?: { delay?: number }) {
   } = {
     request: {
       query: LearnNextDueCardsDocument,
-      variables: { cardgroupId: CG_ID, limit: LEARN_PAGE_LIMIT },
+      variables: { cardgroupId: opts?.cardgroupId ?? CG_ID, limit: LEARN_PAGE_LIMIT },
     },
     result: () => {
       calls += 1;
@@ -1124,6 +1126,40 @@ function makePrefetchMock(cards: PrefetchCard[], opts?: { delay?: number }) {
     mock.delay = opts.delay;
   }
   return { mock, callCount: () => calls };
+}
+
+/**
+ * Builds a successful `HandleSwipe` mock for `cardId` (rating 4 / Easy) that
+ * records whether its result fn ran. Tests await `wasCalled()` when they must
+ * order a later event after the mutation actually resolves: the optimistic
+ * queue advance is synchronous, so waiting on the rendered queue would let the
+ * next step race the mutation's continuation.
+ */
+function makeSwipeSuccessMock(cardId: string) {
+  let called = false;
+  return {
+    mock: {
+      request: {
+        query: HandleSwipeDocument,
+        variables: { input: { cardId, cardgroupId: CG_ID, rating: 4 } },
+      },
+      result: () => {
+        called = true;
+        return {
+          data: {
+            handleSwipe: {
+              __typename: "HandleSwipeSuccess" as const,
+              response: {
+                __typename: "SwipeResponse" as const,
+                performanceMode: "DIFFICULT",
+              },
+            },
+          },
+        };
+      },
+    },
+    wasCalled: () => called,
+  };
 }
 
 describe("<LearnClient> queue prefetch", () => {
@@ -1356,8 +1392,8 @@ describe("<LearnClient> queue prefetch", () => {
     // write commit, the just-swiped card still reads as "due" and comes back in
     // the batch; because the dedup `seen` set is built from the post-removal
     // queue (which no longer holds the card), it would be re-appended — a
-    // duplicate FSRS review. The in-flight-id filter drops it while still
-    // merging a genuinely new card from the same batch.
+    // duplicate FSRS review. The session-scoped swiped-id filter drops it while
+    // still merging a genuinely new card from the same batch.
     const initial = makeQueue(PREFETCH_THRESHOLD + 1); // q-1..q-6 — above threshold, no mount prefetch
     const swipedCard = initial[0] as PrefetchCard; // q-1, "Front 1"
     const freshCard: PrefetchCard = {
@@ -1405,7 +1441,7 @@ describe("<LearnClient> queue prefetch", () => {
     });
 
     // The genuinely new card IS merged (proving the merge ran and dedup filtered
-    // ONLY the in-flight id)...
+    // ONLY the swiped id)...
     await waitFor(() => {
       const latest = capturedCardSnapshots.at(-1);
       expect(latest?.map((c) => c.id)).toContain("p-new");
@@ -1519,34 +1555,8 @@ describe("<LearnClient> queue prefetch", () => {
     // before dispatching the second swipe — the optimistic queue advance is
     // synchronous and would otherwise let the second swipe race ahead of the
     // guard reset.
-    const makeSwipeSuccess = (cardId: string) => {
-      let called = false;
-      return {
-        mock: {
-          request: {
-            query: HandleSwipeDocument,
-            variables: { input: { cardId, cardgroupId: CG_ID, rating: 4 } },
-          },
-          result: () => {
-            called = true;
-            return {
-              data: {
-                handleSwipe: {
-                  __typename: "HandleSwipeSuccess" as const,
-                  response: {
-                    __typename: "SwipeResponse" as const,
-                    performanceMode: "DIFFICULT",
-                  },
-                },
-              },
-            };
-          },
-        },
-        wasCalled: () => called,
-      };
-    };
-    const swipe1 = makeSwipeSuccess("q-1");
-    const swipe2 = makeSwipeSuccess("q-2");
+    const swipe1 = makeSwipeSuccessMock("q-1");
+    const swipe2 = makeSwipeSuccessMock("q-2");
 
     const user = userEvent.setup();
     renderLearnClient(
@@ -1600,6 +1610,150 @@ describe("<LearnClient> queue prefetch", () => {
     await waitFor(() => {
       const latest = capturedCardSnapshots.at(-1);
       expect(latest?.map((c) => c.id)).toContain("r-recovery");
+    });
+  });
+
+  it("does not re-append a card whose prefetch snapshot predates its swipe commit", async () => {
+    // Settled-swipe counterpart to the in-flight test above. Here the swipe
+    // mutation resolves FIRST and the racing prefetch — whose server read ran
+    // before the FSRS write committed — resolves afterwards, still carrying the
+    // swiped card. A filter keyed on in-flight ids alone would have released the
+    // id by then and let the card back into the queue, where rating it a second
+    // time records a duplicate same-day FSRS review. The server never returns a
+    // same-day-swiped card (`StartOfLearnDay` in
+    // backend/internal/domain/learn_day.go), so the session-scoped swiped-id set
+    // treats such a batch entry as the stale read it is.
+    const initial = makeQueue(PREFETCH_THRESHOLD + 1); // q-1..q-6 — above threshold, no mount prefetch
+    const swipedCard = initial[0] as PrefetchCard; // q-1, "Front 1"
+    const freshCard: PrefetchCard = {
+      __typename: "Card" as const,
+      id: "p-late",
+      front: "Late Prefetched",
+      back: "Late Back",
+      cefrLevel: null,
+      userCardState: userCardState("2026-04-30T00:00:00Z", 0),
+      cardgroupId: CG_ID,
+    };
+    // The stale batch is held open long enough for the swipe mutation to settle
+    // first; the settle is awaited explicitly below rather than inferred from
+    // the delay, so the ordering the regression depends on is deterministic.
+    const prefetch = makePrefetchMock([swipedCard, freshCard], { delay: 300 });
+    // No delay — `handleSwipe` settles before the prefetch response lands.
+    const swipe = makeSwipeSuccessMock("q-1");
+
+    const user = userEvent.setup();
+    renderLearnClient([prefetch.mock, swipe.mock], initial, { skipDefaultPrefetchMocks: true });
+
+    // Swipe q-1 — queue shrinks 6 → 5, crossing the threshold and firing the
+    // prefetch whose snapshot still lists q-1 as due.
+    await user.click(screen.getByRole("button", { name: "Rate as Easy" }));
+
+    // Wait for the mutation to resolve, then drain microtasks so its
+    // continuation has fully run before the stale batch merges.
+    await waitFor(() => {
+      expect(swipe.wasCalled()).toBe(true);
+    });
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    await waitFor(
+      () => {
+        expect(prefetch.callCount()).toBe(1);
+      },
+      { timeout: 1000 },
+    );
+
+    // The genuinely new card IS merged, proving the merge ran...
+    await waitFor(() => {
+      const latest = capturedCardSnapshots.at(-1);
+      expect(latest?.map((c) => c.id)).toContain("p-late");
+    });
+
+    // ...while the settled, already-swiped card stays out of the queue and is
+    // never rendered again.
+    const merged = capturedCardSnapshots.at(-1);
+    expect(merged?.map((c) => c.id) ?? []).not.toContain("q-1");
+    expect(screen.queryByText("Front 1")).not.toBeInTheDocument();
+  });
+
+  it("resets the swiped-session filter when the active cardgroup changes", async () => {
+    // The swiped-id set is scoped to one deck's session: a different cardgroup
+    // has its own due pool, so an id recorded against the previous deck must not
+    // suppress a legitimate prefetch result after the switch. This mirrors the
+    // reset of `exhaustedRef` in the same guard.
+    const OTHER_CG_ID = "cg-2";
+    const initial = makeQueue(PREFETCH_THRESHOLD + 1); // q-1..q-6 — above threshold
+    const swipedCard = initial[0] as PrefetchCard; // q-1, "Front 1"
+    // Deck A's prefetch (fired by the optimistic removal) finds nothing due.
+    const prefetchA = makePrefetchMock([]);
+    // Deck B returns a card with the id swiped in deck A. Reusing the id is the
+    // point of the fixture — the filter must not carry across decks.
+    const prefetchB = makePrefetchMock([{ ...swipedCard, cardgroupId: OTHER_CG_ID }], {
+      cardgroupId: OTHER_CG_ID,
+    });
+    const swipe = makeSwipeSuccessMock("q-1");
+    // The persist-last-viewed effect fires once per cardgroup, so both decks
+    // need a no-op mock or the file-wide leak spy records an unmatched request.
+    const persistB = {
+      request: {
+        query: SetLastViewedCardgroupDocument,
+        variables: { cardgroupId: OTHER_CG_ID },
+      },
+      result: {
+        data: {
+          setLastViewedCardgroup: {
+            __typename: "SetLastViewedCardgroupSuccess" as const,
+            user: {
+              __typename: "User" as const,
+              id: "u-default",
+              lastViewedCardgroup: { __typename: "Cardgroup" as const, id: OTHER_CG_ID },
+            },
+          },
+        },
+      },
+    };
+
+    const mocks = [prefetchA.mock, prefetchB.mock, swipe.mock, makeDefaultPersistMock(), persistB];
+
+    const user = userEvent.setup();
+    const { rerender } = renderWithIntl(
+      <MockedProvider mocks={mocks as never}>
+        <LearnClient cardgroupId={CG_ID} initialCards={initial} displayMode="ALWAYS_VISIBLE" />
+      </MockedProvider>,
+    );
+
+    // Swipe q-1 in deck A — queue shrinks 6 → 5 and deck A's prefetch resolves
+    // empty, recording q-1 in the session set along the way.
+    await user.click(screen.getByRole("button", { name: "Rate as Easy" }));
+    await waitFor(() => {
+      expect(prefetchA.callCount()).toBe(1);
+    });
+    // Let the resolved prefetch's `.then` and the in-flight reset run before the
+    // deck switch re-evaluates the effect.
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    rerender(
+      <MockedProvider mocks={mocks as never}>
+        <LearnClient
+          cardgroupId={OTHER_CG_ID}
+          initialCards={initial}
+          displayMode="ALWAYS_VISIBLE"
+        />
+      </MockedProvider>,
+    );
+
+    // The deck change resets the guards, so the queue (still at threshold)
+    // dispatches deck B's prefetch.
+    await waitFor(() => {
+      expect(prefetchB.callCount()).toBe(1);
+    });
+    // q-1 is appended: the previous deck's swipe no longer filters it.
+    await waitFor(() => {
+      const latest = capturedCardSnapshots.at(-1);
+      expect(latest?.map((c) => c.id)).toContain("q-1");
     });
   });
 });

--- a/frontend/src/app/learn/[cardgroupId]/learn-client.test.tsx
+++ b/frontend/src/app/learn/[cardgroupId]/learn-client.test.tsx
@@ -1519,7 +1519,8 @@ describe("<LearnClient> queue prefetch", () => {
   it("resumes prefetch after a successful swipe clears the exhaustion guard", async () => {
     // Recovery counterpart to the suppression test above (regression guard for
     // issue #789). Once the pool is exhausted (`exhaustedRef` set), a swipe that
-    // SUCCEEDS must re-open prefetching: a rated card may become due again, so
+    // SUCCEEDS must re-open prefetching: the exhaustion verdict is a
+    // point-in-time snapshot that newly-due cards can outdate, so
     // `HandleSwipeSuccess` resets `exhaustedRef`. The NEXT tail swipe that
     // re-crosses the threshold then dispatches a fresh prefetch. If the
     // `exhaustedRef.current = false` reset on `HandleSwipeSuccess` were removed,

--- a/frontend/src/app/learn/[cardgroupId]/learn-client.tsx
+++ b/frontend/src/app/learn/[cardgroupId]/learn-client.tsx
@@ -165,12 +165,14 @@ export function LearnClient({ cardgroupId, initialCards, displayMode }: Props) {
   // never re-appended, which would let the learner rate it twice and record a
   // duplicate same-day FSRS review.
   //
-  // Ids are never pruned mid-session. Every server-side due window requires
-  // `last_review < StartOfLearnDay(now)` (see the contract on
-  // `StartOfLearnDay` in `backend/internal/domain/learn_day.go`), so a card
-  // swiped today can never legitimately re-enter today's queue — any prefetched
-  // batch carrying one of these ids is a stale read that predates the swipe's
-  // commit. Reset when the active cardgroup changes.
+  // Ids are never pruned mid-session. Both server-side REVIEW windows require
+  // `last_review < StartOfLearnDay(now)` (see the contract on `StartOfLearnDay`
+  // in `backend/internal/domain/learn_day.go`), and the new-card window carries
+  // no `last_review` predicate at all — it matches only cards with no FSRS row,
+  // which the swipe itself creates. So once a swipe commits, no window can
+  // return that card again today: any prefetched batch carrying one of these
+  // ids is a stale read that predates the commit. Reset when the active
+  // cardgroup changes.
   //
   // A transport failure keeps its id here too, which is harmless: the catch
   // handler puts the card back at the queue head, so `seen` covers it for as
@@ -180,9 +182,13 @@ export function LearnClient({ cardgroupId, initialCards, displayMode }: Props) {
   // due pool is exhausted, so every subsequent tail swipe would otherwise fire a
   // redundant network-only query that returns nothing new. A stale batch whose
   // ids were all swiped this session lands here too, and that verdict is correct
-  // for the same-day queue. The effect short-circuits while this is set. Cleared
-  // after a swipe mutation succeeds (a rated card may become due again) and on
-  // cardgroup change.
+  // for the same-day queue. The effect short-circuits while this is set.
+  //
+  // Cleared after a swipe mutation succeeds and on cardgroup change. The reset is
+  // not about the just-swiped card — that one can never come back today — but
+  // about the verdict's age: it is a point-in-time snapshot, and the filler
+  // review window admits a card once `due <= now`, so the pool can refill with
+  // newly-due cards while the session runs.
   const exhaustedRef = useRef(false);
   // Tracks the cardgroup the exhaustion verdict belongs to. When the active
   // cardgroup changes, the prefetch effect below clears `exhaustedRef` before
@@ -284,8 +290,10 @@ export function LearnClient({ cardgroupId, initialCards, displayMode }: Props) {
       // UI consumer reads today. Only the non-success branches need handling.
       const payload = result.data?.handleSwipe;
       if (payload?.__typename === "HandleSwipeSuccess") {
-        // A rated card can become due again (e.g. an "again" rating), so re-open
-        // prefetching in case the pool was previously marked exhausted.
+        // Re-open prefetching in case the pool was previously marked exhausted.
+        // That verdict may predate cards that have since become due (the filler
+        // review window admits a card once its `due` has arrived); the
+        // just-swiped card itself never returns today.
         exhaustedRef.current = false;
         return;
       }

--- a/frontend/src/app/learn/[cardgroupId]/learn-client.tsx
+++ b/frontend/src/app/learn/[cardgroupId]/learn-client.tsx
@@ -157,21 +157,32 @@ export function LearnClient({ cardgroupId, initialCards, displayMode }: Props) {
   }, []);
 
   const prefetchInFlightRef = useRef(false);
-  // Ids of cards whose `handleSwipe` mutation is currently in flight. The
-  // optimistic queue removal in `onSwipe` shrinks the queue and can re-fire the
-  // prefetch below WHILE the swipe mutation has not yet committed its FSRS
-  // write; a network-only read that beats that write still sees the card as
-  // "due" and returns it in the batch. The merge filters `incoming` against this
-  // set so the just-swiped card is not re-appended (which would cause a
-  // duplicate FSRS review). ONLY in-flight ids are filtered — once a swipe
-  // settles its id is removed, so a genuinely re-due "again" card may
-  // legitimately re-enter the queue on a later prefetch.
-  const inFlightSwipeIdsRef = useRef<Set<string>>(new Set());
+  // Ids of every card swiped in this session. The optimistic queue removal in
+  // `onSwipe` shrinks the queue and can re-fire the prefetch below WHILE the
+  // swipe mutation has not yet committed its FSRS write; a network-only read
+  // that beats that write still sees the card as "due" and returns it in the
+  // batch. The merge filters `incoming` against this set so a swiped card is
+  // never re-appended, which would let the learner rate it twice and record a
+  // duplicate same-day FSRS review.
+  //
+  // Ids are never pruned mid-session. Every server-side due window requires
+  // `last_review < StartOfLearnDay(now)` (see the contract on
+  // `StartOfLearnDay` in `backend/internal/domain/learn_day.go`), so a card
+  // swiped today can never legitimately re-enter today's queue — any prefetched
+  // batch carrying one of these ids is a stale read that predates the swipe's
+  // commit. Reset when the active cardgroup changes.
+  //
+  // A transport failure keeps its id here too, which is harmless: the catch
+  // handler puts the card back at the queue head, so `seen` covers it for as
+  // long as it is queued and the learner can re-swipe it.
+  const swipedThisSessionRef = useRef<Set<string>>(new Set());
   // Set once a prefetch resolves and the dedup merge adds zero new cards: the
   // due pool is exhausted, so every subsequent tail swipe would otherwise fire a
-  // redundant network-only query that returns nothing new. The effect
-  // short-circuits while this is set. Cleared after a swipe mutation succeeds (a
-  // rated card may become due again) and on cardgroup change.
+  // redundant network-only query that returns nothing new. A stale batch whose
+  // ids were all swiped this session lands here too, and that verdict is correct
+  // for the same-day queue. The effect short-circuits while this is set. Cleared
+  // after a swipe mutation succeeds (a rated card may become due again) and on
+  // cardgroup change.
   const exhaustedRef = useRef(false);
   // Tracks the cardgroup the exhaustion verdict belongs to. When the active
   // cardgroup changes, the prefetch effect below clears `exhaustedRef` before
@@ -183,6 +194,7 @@ export function LearnClient({ cardgroupId, initialCards, displayMode }: Props) {
     if (exhaustedForCardgroupRef.current !== cardgroupId) {
       exhaustedForCardgroupRef.current = cardgroupId;
       exhaustedRef.current = false;
+      swipedThisSessionRef.current = new Set();
     }
     if (queue.length === 0 || queue.length > PREFETCH_THRESHOLD) return;
     if (prefetchInFlightRef.current) return;
@@ -203,11 +215,11 @@ export function LearnClient({ cardgroupId, initialCards, displayMode }: Props) {
         }
         setQueue((current) => {
           const seen = new Set(current.map((c) => c.id));
-          const inFlight = inFlightSwipeIdsRef.current;
-          // Drop cards already queued (`seen`) and cards whose swipe mutation is
-          // still in flight (`inFlight`) — the latter may read as "due" if the
-          // prefetch beat the FSRS write commit.
-          const additions = incoming.filter((card) => !seen.has(card.id) && !inFlight.has(card.id));
+          const swiped = swipedThisSessionRef.current;
+          // Drop cards already queued (`seen`) and cards already swiped this
+          // session (`swiped`) — the latter can only reach us from a read that
+          // predates the swipe's FSRS commit.
+          const additions = incoming.filter((card) => !seen.has(card.id) && !swiped.has(card.id));
           if (additions.length === 0) {
             // Nothing new survived the merge — mark the pool exhausted so tail
             // swipes stop re-firing this query until a swipe succeeds.
@@ -234,11 +246,13 @@ export function LearnClient({ cardgroupId, initialCards, displayMode }: Props) {
     async (card: LearnCard, direction: SwipeDirection) => {
       const rating = ratingFromDirection(direction);
       setLocalError(null);
-      // Mark this card's swipe as in flight BEFORE the optimistic removal so the
-      // prefetch effect (which the removal can re-fire) filters it out of any
-      // racing LearnNextDueCards batch until the FSRS write commits. The marker
-      // is cleared in the mutation's `finally` below.
-      inFlightSwipeIdsRef.current.add(card.id);
+      // Record the card as swiped BEFORE the optimistic removal so the prefetch
+      // effect (which the removal can re-fire) filters it out of any racing
+      // LearnNextDueCards batch. Recording at swipe time rather than on success
+      // also closes the gap between the mutation settling and its continuation
+      // running. The id stays in the set for the rest of the session — see the
+      // ref's declaration above.
+      swipedThisSessionRef.current.add(card.id);
       setQueue((current) => current.filter((candidate) => candidate.id !== card.id));
       setCompletedCount((current) => current + 1);
 
@@ -249,26 +263,19 @@ export function LearnClient({ cardgroupId, initialCards, displayMode }: Props) {
         // See .claude/rules/pagination.md § "Drop `optimisticResponse` for mutations that can
         // fail with typed GraphQL errors". The optimistic queue advance above (via setQueue)
         // is React state and is unaffected.
-      })
-        .catch((err) => {
-          // err.message is omitted — backend messages may echo user-authored content.
-          // See docs/frontend/rsc-error-handling/substring-matching-sdk-error-strings.md.
-          console.error("[LearnClient] handleSwipe rejected", {
-            cardId: card.id,
-            cardgroupId,
-            name: err instanceof Error ? err.name : "unknown",
-          });
-          setQueue((current) => [card, ...current.filter((candidate) => candidate.id !== card.id)]);
-          setCompletedCount((current) => Math.max(0, current - 1));
-          setLocalError("Could not save that swipe. Please try again.");
-          return null;
-        })
-        .finally(() => {
-          // The mutation settled (success or error): the FSRS write has committed
-          // (or failed), so a later prefetch that reads this card as "due" is no
-          // longer racing an uncommitted write and may re-enter it legitimately.
-          inFlightSwipeIdsRef.current.delete(card.id);
+      }).catch((err) => {
+        // err.message is omitted — backend messages may echo user-authored content.
+        // See docs/frontend/rsc-error-handling/substring-matching-sdk-error-strings.md.
+        console.error("[LearnClient] handleSwipe rejected", {
+          cardId: card.id,
+          cardgroupId,
+          name: err instanceof Error ? err.name : "unknown",
         });
+        setQueue((current) => [card, ...current.filter((candidate) => candidate.id !== card.id)]);
+        setCompletedCount((current) => Math.max(0, current - 1));
+        setLocalError("Could not save that swipe. Please try again.");
+        return null;
+      });
 
       if (!result) return;
 


### PR DESCRIPTION
## Summary

`LearnClient` filtered its prefetch merge against ids whose `handleSwipe` mutation was still in flight, and released each id in the mutation's `finally`. A `LearnNextDueCards` read that started before the FSRS write committed still sees the card as due, so when the mutation response lands first the id is already released and the stale batch re-appends the card to the queue tail — the learner rates it a second time and the backend records a duplicate same-day FSRS review. The filter is now keyed on every card swiped in the session, which the server-side due windows guarantee can never legitimately reappear on the same learn day.

## Changes

### Queue dedup

- `frontend/src/app/learn/[cardgroupId]/learn-client.tsx`: replaced `inFlightSwipeIdsRef` with `swipedThisSessionRef`, a `Set<string>` that is never pruned mid-session.
- The prefetch merge filters `incoming` with `!seen.has(card.id) && !swiped.has(card.id)`, so a batch entry that was already swiped is treated as the stale read it is.
- `onSwipe` still records the id *before* the optimistic queue removal (which is what can re-fire the prefetch effect), but nothing deletes it afterwards — the `handleSwipe` promise chain lost its `.finally` block entirely and now ends at the existing `.catch`.
- The set is reset alongside `exhaustedRef` in the cardgroup-change guard at the top of the prefetch effect, so a different deck's due pool is never suppressed by the previous deck's swipes.
- A transport failure keeps the id in the set; the `.catch` handler already restores the card to the queue head, so `seen` covers it for as long as it stays queued and the learner can re-swipe it.

### Comments

- The ref docblock now cites the server contract instead of the old "a genuinely re-due 'again' card may legitimately re-enter the queue" justification: the rescue and filler review windows both require `ucs.last_review < ?` (start of learn day), and the new-card window matches only `ucs.due IS NULL` — a row the swipe's FSRS upsert creates. So no window can return the card again today.
- The `exhaustedRef` docblock and the `HandleSwipeSuccess` reset comment were corrected for the same reason: the reset is not about the just-swiped card becoming due again, but about the exhaustion verdict being a point-in-time snapshot that the filler window (`due <= now`) can outdate while the session runs.
- Noted that a stale batch whose entries were all swiped this session now trips the `additions.length === 0` exhaustion branch, which is the correct verdict for the same-day queue and self-heals on the next successful swipe.

### Tests

- New: "does not re-append a card whose prefetch snapshot predates its swipe commit" — holds the prefetch response open (`delay: 300`) while the swipe mutation resolves, waits explicitly on the mutation's result fn and drains microtasks so the settle ordering is deterministic, then asserts the fresh card `p-late` is merged while `q-1` is absent from the queue snapshot and its front text is not re-rendered.
- New: "resets the swiped-session filter when the active cardgroup changes" — swipes `q-1` in `cg-1` (whose prefetch returns nothing), rerenders with `cg-2` whose prefetch returns the same id, and asserts `q-1` IS appended.
- Extracted the inline `makeSwipeSuccess` factory from the exhaustion-recovery test into a file-level `makeSwipeSuccessMock(cardId)` helper shared by all three tests; `makePrefetchMock` gained an optional `cardgroupId` for the deck-switch fixture.
- Refreshed the comments in the pre-existing in-flight race test and the exhaustion-recovery test that named the old in-flight-only filter.

## Test plan

- [ ] `./node_modules/.bin/tsc --noEmit` — exit 0
- [ ] `./node_modules/.bin/biome check --error-on-warnings .` — exit 0, 520 files checked
- [ ] `./node_modules/.bin/vitest run` — 206 files / 1903 tests passed
- [ ] `./node_modules/.bin/vitest run "src/app/learn/[cardgroupId]/learn-client.test.tsx"` — 41 tests passed
- [ ] `./node_modules/.bin/knip` — exit 0
- [ ] `./node_modules/.bin/next build` — exit 0

## Notes

- The settled-swipe test is the regression guard for the removed `.finally` block: it awaits the mutation's result fn and drains microtasks before the delayed prefetch merges, so under the old in-flight-only filter the id would already be released and `q-1` would be back in the queue snapshot.

- Frontend only — no backend, schema, or codegen changes. The server-side contract this relies on (`StartOfLearnDay` in `backend/internal/domain/learn_day.go`, the three windows in `backend/internal/repository/card_due.go`) is unchanged and was read to confirm the comment claims.
- `grep -rln "learn-client\|LearnNextDueCards\|inFlightSwipeIds" frontend/src frontend/__tests__ frontend/e2e` returns no hit under `frontend/e2e` and no hit under `frontend/__tests__`, so no Playwright spec or broad page test pins the old merge behaviour. Playwright is not runnable from this worktree (needs a live Supabase + backend stack), so no e2e run is claimed.

Closes #982
