### PR TITLE
fix(stats): gate retention and lapse on pre-swipe stability snapshot

### DIFF
--- a/backend/internal/database/cards_position_roundtrip_test.go
+++ b/backend/internal/database/cards_position_roundtrip_test.go
@@ -44,7 +44,7 @@ func TestCardsPositionDownUpRoundtrip(t *testing.T) {
 		}
 	}()
 
-	// Step back past the twelve migrations newer than add_position_to_cards
+	// Step back past the thirteen migrations newer than add_position_to_cards
 	// (enable_rls_schema_migrations, pin_trigger_function_search_path,
 	// restrict_definer_function_exposure, add_master_tables,
 	// add_learn_display_mode_to_user_preferences,
@@ -53,10 +53,11 @@ func TestCardsPositionDownUpRoundtrip(t *testing.T) {
 	// index_hygiene_users_swipe_records,
 	// add_new_card_ratio_to_user_preferences,
 	// add_pre_swipe_snapshot_to_swipe_records,
-	// add_last_rating_to_user_card_fsrs), then past add_position_to_cards
-	// itself. Thirteen steps are required because add_position_to_cards is no longer
+	// add_last_rating_to_user_card_fsrs,
+	// add_stability_before_to_swipe_records), then past add_position_to_cards
+	// itself. Fourteen steps are required because add_position_to_cards is no longer
 	// near the newest migration; bump this count when adding migrations after it.
-	if err := m.Steps(-13); err != nil {
+	if err := m.Steps(-14); err != nil {
 		t.Fatalf("migrate down to before add_position_to_cards: %v", err)
 	}
 

--- a/backend/internal/database/last_rating_roundtrip_test.go
+++ b/backend/internal/database/last_rating_roundtrip_test.go
@@ -9,8 +9,8 @@ import (
 	"backend/internal/database"
 )
 
-// TestLastRatingDownUpRoundtrip proves that the newest migration drops and
-// restores user_card_fsrs.last_rating without leaving the schema behind the
+// TestLastRatingDownUpRoundtrip proves that the add_last_rating migration drops
+// and restores user_card_fsrs.last_rating without leaving the schema behind the
 // latest migration version.
 //
 // t.Parallel() is intentionally absent: the test runs a global migration
@@ -38,12 +38,16 @@ func TestLastRatingDownUpRoundtrip(t *testing.T) {
 		}
 	}()
 
-	if err := m.Steps(-1); err != nil {
-		t.Fatalf("migrate down last_rating migration: %v", err)
+	// Step back two migrations newest-first:
+	// add_stability_before_to_swipe_records, then add_last_rating_to_user_card_fsrs
+	// (the target). Bump this count when adding migrations after
+	// add_last_rating_to_user_card_fsrs.
+	if err := m.Steps(-2); err != nil {
+		t.Fatalf("migrate down to before last_rating migration: %v", err)
 	}
 	requireColumnMissing(t, ctx, sqlDB, "user_card_fsrs", "last_rating")
 
-	if err := m.Steps(1); err != nil {
+	if err := m.Steps(2); err != nil {
 		t.Fatalf("migrate up last_rating migration: %v", err)
 	}
 	requireColumnExists(t, ctx, sqlDB, "user_card_fsrs", "last_rating")
@@ -74,8 +78,9 @@ func TestLastRatingUpMigrationBackfillsLatestSwipe(t *testing.T) {
 		}
 	}()
 
-	if err := m.Steps(-1); err != nil {
-		t.Fatalf("migrate down last_rating migration: %v", err)
+	// Two steps: add_stability_before_to_swipe_records sits above the target.
+	if err := m.Steps(-2); err != nil {
+		t.Fatalf("migrate down to before last_rating migration: %v", err)
 	}
 	requireColumnMissing(t, ctx, sqlDB, "user_card_fsrs", "last_rating")
 
@@ -113,7 +118,7 @@ func TestLastRatingUpMigrationBackfillsLatestSwipe(t *testing.T) {
 		t.Fatalf("seed swipe_records rows: %v", err)
 	}
 
-	if err := m.Steps(1); err != nil {
+	if err := m.Steps(2); err != nil {
 		t.Fatalf("migrate up last_rating migration: %v", err)
 	}
 	requireColumnExists(t, ctx, sqlDB, "user_card_fsrs", "last_rating")

--- a/backend/internal/database/learn_display_mode_roundtrip_test.go
+++ b/backend/internal/database/learn_display_mode_roundtrip_test.go
@@ -54,8 +54,9 @@ func TestLearnDisplayModeDownUpRoundtrip(t *testing.T) {
 		}
 	}()
 
-	// Step back eight migrations newest-first: add_last_rating_to_user_card_fsrs
-	// (now the newest), add_pre_swipe_snapshot_to_swipe_records,
+	// Step back nine migrations newest-first:
+	// add_stability_before_to_swipe_records (now the newest),
+	// add_last_rating_to_user_card_fsrs, add_pre_swipe_snapshot_to_swipe_records,
 	// add_new_card_ratio_to_user_preferences,
 	// index_hygiene_users_swipe_records,
 	// drop_master_cardgroup_metadata_columns, master_cards_front_citext,
@@ -64,7 +65,7 @@ func TestLearnDisplayModeDownUpRoundtrip(t *testing.T) {
 	// below re-applies add_learn_display_mode, and the t.Cleanup restores the
 	// rest. Bump this count when adding migrations after
 	// add_learn_display_mode_to_user_preferences.
-	if err := m.Steps(-8); err != nil {
+	if err := m.Steps(-9); err != nil {
 		t.Fatalf("migrate down to before add_learn_display_mode_to_user_preferences: %v", err)
 	}
 

--- a/backend/internal/database/migrations/20260720000000_add_stability_before_to_swipe_records.down.sql
+++ b/backend/internal/database/migrations/20260720000000_add_stability_before_to_swipe_records.down.sql
@@ -1,0 +1,13 @@
+-- 20260720000000_add_stability_before_to_swipe_records.down.sql
+--
+-- Reverse of 20260720000000_add_stability_before_to_swipe_records.up.sql.
+--
+-- golang-migrate pgx/v5 does NOT auto-wrap migrations in a transaction; the
+-- explicit BEGIN/COMMIT below ensures all-or-nothing execution.
+
+BEGIN;
+
+ALTER TABLE public.swipe_records
+  DROP COLUMN IF EXISTS stability_before;
+
+COMMIT;

--- a/backend/internal/database/migrations/20260720000000_add_stability_before_to_swipe_records.up.sql
+++ b/backend/internal/database/migrations/20260720000000_add_stability_before_to_swipe_records.up.sql
@@ -1,0 +1,22 @@
+-- 20260720000000_add_stability_before_to_swipe_records.up.sql
+--
+-- Adds the pre-swipe FSRS stability snapshot to public.swipe_records:
+--   stability_before -- the FSRS stability (days) the card held before this swipe
+--
+-- The column is nullable with NO default and NO backfill: NULL marks a row
+-- recorded before it existed and is a meaningful sentinel the metrics layer
+-- branches on. The stats "already learned" gate must test stability against
+-- domain.LearnedStabilityDays, the same boundary the mastery tiles use;
+-- scheduled_days_before is only an approximation of it, because go-fsrs clamps
+-- each rating's interval to exceed the previous rating's, so a recorded interval
+-- can outrun round(stability) by several days.
+--
+-- golang-migrate pgx/v5 does NOT auto-wrap migrations in a transaction; the
+-- explicit BEGIN/COMMIT below ensures all-or-nothing execution.
+
+BEGIN;
+
+ALTER TABLE public.swipe_records
+  ADD COLUMN stability_before double precision;
+
+COMMIT;

--- a/backend/internal/database/stability_before_roundtrip_test.go
+++ b/backend/internal/database/stability_before_roundtrip_test.go
@@ -1,0 +1,53 @@
+package database_test
+
+import (
+	"context"
+	"testing"
+
+	"backend/internal/database"
+)
+
+// TestStabilityBeforeDownUpRoundtrip proves that the newest migration drops and
+// restores swipe_records.stability_before without leaving the schema behind the
+// latest migration version.
+//
+// t.Parallel() is intentionally absent: the test runs a global migration
+// down/up that would race other tests in the package.
+func TestStabilityBeforeDownUpRoundtrip(t *testing.T) {
+	ctx := context.Background()
+	db := openMigratedDB(t)
+	defer db.Close()
+	t.Cleanup(func() {
+		if err := database.Migrate(testDSN); err != nil {
+			t.Errorf("restore latest migration: %v", err)
+		}
+	})
+
+	sqlDB := sqlDBForTest(t, db)
+	requireColumnExists(t, ctx, sqlDB, "swipe_records", "stability_before")
+
+	m, err := database.NewMigrateInstanceForTest(testDSN)
+	if err != nil {
+		t.Fatalf("NewMigrateInstanceForTest: %v", err)
+	}
+	defer func() {
+		if srcErr, dbErr := m.Close(); srcErr != nil || dbErr != nil {
+			t.Logf("migrate close: src_err=%v db_err=%v", srcErr, dbErr)
+		}
+	}()
+
+	// stability_before is the newest migration, so one step reaches it. Bump this
+	// count when adding migrations after add_stability_before_to_swipe_records.
+	if err := m.Steps(-1); err != nil {
+		t.Fatalf("migrate down stability_before migration: %v", err)
+	}
+	requireColumnMissing(t, ctx, sqlDB, "swipe_records", "stability_before")
+	// The sibling snapshot columns from the earlier migration must survive.
+	requireColumnExists(t, ctx, sqlDB, "swipe_records", "phase_before")
+	requireColumnExists(t, ctx, sqlDB, "swipe_records", "scheduled_days_before")
+
+	if err := m.Steps(1); err != nil {
+		t.Fatalf("migrate up stability_before migration: %v", err)
+	}
+	requireColumnExists(t, ctx, sqlDB, "swipe_records", "stability_before")
+}

--- a/backend/internal/database/users_version_roundtrip_test.go
+++ b/backend/internal/database/users_version_roundtrip_test.go
@@ -38,24 +38,25 @@ func TestUsersVersionDownUpRoundtrip(t *testing.T) {
 		}
 	}()
 
-	// Step back through the 14 migrations listed newest-first until
+	// Step back through the 15 migrations listed newest-first until
 	// add_version_to_users (the target) is also rolled back:
-	//   1. add_last_rating_to_user_card_fsrs
-	//   2. add_pre_swipe_snapshot_to_swipe_records
-	//   3. add_new_card_ratio_to_user_preferences
-	//   4. index_hygiene_users_swipe_records
-	//   5. drop_master_cardgroup_metadata_columns
-	//   6. master_cards_front_citext
-	//   7. add_user_card_fsrs_card_id_index
-	//   8. add_learn_display_mode_to_user_preferences
-	//   9. add_master_tables
-	//   10. restrict_definer_function_exposure
-	//   11. pin_trigger_function_search_path
-	//   12. enable_rls_schema_migrations
-	//   13. add_position_to_cards
-	//   14. add_version_to_users  ← target (rolls back the version column)
+	//   1. add_stability_before_to_swipe_records
+	//   2. add_last_rating_to_user_card_fsrs
+	//   3. add_pre_swipe_snapshot_to_swipe_records
+	//   4. add_new_card_ratio_to_user_preferences
+	//   5. index_hygiene_users_swipe_records
+	//   6. drop_master_cardgroup_metadata_columns
+	//   7. master_cards_front_citext
+	//   8. add_user_card_fsrs_card_id_index
+	//   9. add_learn_display_mode_to_user_preferences
+	//   10. add_master_tables
+	//   11. restrict_definer_function_exposure
+	//   12. pin_trigger_function_search_path
+	//   13. enable_rls_schema_migrations
+	//   14. add_position_to_cards
+	//   15. add_version_to_users  ← target (rolls back the version column)
 	// Bump the count here when adding migrations after add_version_to_users.
-	if err := m.Steps(-14); err != nil {
+	if err := m.Steps(-15); err != nil {
 		t.Fatalf("migrate down to before add_version_to_users: %v", err)
 	}
 

--- a/backend/internal/domain/mastery_tier.go
+++ b/backend/internal/domain/mastery_tier.go
@@ -8,9 +8,9 @@ const MatureStabilityDays = 21.0
 
 // LearnedStabilityDays is the FSRS stability (in days) at or above which a
 // card counts as learned/known: the model projects at least a week of
-// retention. Under the default RequestRetention=0.9 the scheduled interval
-// equals round(stability), so a swipe's ScheduledDaysBefore snapshot reads
-// the same boundary at swipe time.
+// retention. It is the single boundary both ClassifyMastery and the stats
+// known-review gate test a card's stability against, so the mastery tiles and
+// the retention/lapse population always describe the same set of cards.
 const LearnedStabilityDays = 7.0
 
 // MasteryTier is the disjoint learning tier a card sits in.

--- a/backend/internal/domain/service/user_performance.go
+++ b/backend/internal/domain/service/user_performance.go
@@ -298,25 +298,39 @@ func normalizedDifficulty(difficulty float64) float64 {
 }
 
 // isKnownCardReview reports whether a swipe is a review of an already-learned
-// card according to its pre-swipe stability snapshot.
+// card, i.e. one the mastery tiles would have shown as Learned or Mature when
+// the swipe was made. Three tiers of evidence are consulted, most faithful
+// first.
 //
-// New-format rows (PhaseBefore != nil, recorded once the phase_before column
-// existed) require both a Review phase and ScheduledDaysBefore at or above the
-// learned boundary. Under the default RequestRetention=0.9, the scheduled
-// interval equals round(stability), so ScheduledDaysBefore is a faithful
-// pre-swipe stability snapshot. PhaseBefore == Review alone stopped being
-// sufficient when long-term scheduling began sending every rating from every
-// state to Review. A nil ScheduledDaysBefore is treated as not known
-// defensively, matching isOnTimeRecall. This excludes a first-Again card's
-// second review and a lapse-recovery review at interval 1, while including the
-// next review of a graduated card at an interval such as 16 days.
+//  1. Stability snapshot (StabilityBefore != nil): known iff the pre-swipe phase
+//     was Review and the pre-swipe stability is at or above
+//     domain.LearnedStabilityDays. This is the same value and the same inclusive
+//     boundary ClassifyMastery tests, so the gate and the mastery tiles agree by
+//     construction.
+//  2. Interval heuristic (StabilityBefore == nil, PhaseBefore != nil): rows
+//     recorded after the phase snapshot but before the stability snapshot fall
+//     back to ScheduledDaysBefore at or above the learned boundary. The interval
+//     only approximates stability: go-fsrs clamps each rating's interval to
+//     exceed the previous rating's (hard >= again+1, good >= hard+1,
+//     easy >= good+1), so a recorded interval can outrun the card's stability by
+//     up to three days and admit a card the mastery tiles still call In
+//     progress. The heuristic is kept for these rows so history does not jump
+//     when the stability snapshot became available. A nil ScheduledDaysBefore is
+//     treated as not known defensively, matching isOnTimeRecall.
+//  3. Legacy fallback (PhaseBefore == nil, rows aging out of the 365-day
+//     window): the historical post-swipe heuristic — StateAfter.Phase == Review,
+//     or a Review->Again lapse that landed the card in Relearning with a
+//     non-zero lapse count.
 //
-// Legacy rows (PhaseBefore == nil, recorded before the column existed and aging
-// out of the 365-day window) fall back to the historical post-swipe heuristic:
-// StateAfter.Phase == Review, or a Review->Again lapse that landed the card in
-// Relearning with a non-zero lapse count. The fallback keeps history continuous
-// rather than jumping when the new snapshot became available.
+// PhaseBefore == Review alone stopped being sufficient when long-term
+// scheduling began sending every rating from every state to Review, which is why
+// tiers 1 and 2 both carry a magnitude test.
 func isKnownCardReview(swipe domain.SwipeRecord) bool {
+	if swipe.StabilityBefore != nil {
+		return swipe.PhaseBefore != nil &&
+			*swipe.PhaseBefore == domain.FSRSPhaseReview &&
+			*swipe.StabilityBefore >= domain.LearnedStabilityDays
+	}
 	if swipe.PhaseBefore != nil {
 		return *swipe.PhaseBefore == domain.FSRSPhaseReview &&
 			swipe.ScheduledDaysBefore != nil &&

--- a/backend/internal/domain/service/user_performance_test.go
+++ b/backend/internal/domain/service/user_performance_test.go
@@ -81,6 +81,40 @@ func TestComputeMetrics(t *testing.T) {
 			},
 		},
 		{
+			// The card's scheduled interval reached 7 while its stability was still
+			// 6.6, so the mastery tiles called it In progress. The stability
+			// snapshot keeps the Again out of the lapse numerator and out of the
+			// review denominator entirely.
+			name: "sub-learned stability keeps an interval-seven lapse out of the rates",
+			swipes: []domain.SwipeRecord{
+				swipeStability(domain.RatingAgain, now, stateWithLapses(5, 7, 0, domain.FSRSPhaseRelearning, 1), domain.FSRSPhaseReview, 7, 6.6),
+			},
+			want: PerformanceMetrics{
+				SuccessRate:   0,
+				AvgDifficulty: 0.5,
+				RetentionRate: 0,
+				StudyStreak:   1,
+				LapseRate:     0,
+				ReviewCount:   1,
+			},
+		},
+		{
+			// Exactly at the learned boundary the gate is inclusive, matching
+			// ClassifyMastery, so the review counts.
+			name: "stability at the learned boundary counts the review",
+			swipes: []domain.SwipeRecord{
+				swipeStability(domain.RatingGood, now, state(5, 7, 9, domain.FSRSPhaseReview), domain.FSRSPhaseReview, 7, 7.0),
+			},
+			want: PerformanceMetrics{
+				SuccessRate:   1,
+				AvgDifficulty: 0.5,
+				RetentionRate: 1,
+				StudyStreak:   1,
+				LapseRate:     0,
+				ReviewCount:   1,
+			},
+		},
+		{
 			// Hard is not a SuccessRate success (IsSuccess is >= Good) but it IS a
 			// recall: a Review+Hard within the pre-swipe interval is a retention,
 			// so SuccessRate (0) and RetentionRate (1) diverge deliberately.
@@ -287,11 +321,37 @@ func TestIsKnownCardReview(t *testing.T) {
 			want:  false,
 		},
 		{
+			// The scheduled interval rounds up to the learned boundary while the
+			// stability snapshot says the card is still In progress. The snapshot
+			// wins, so the review is excluded.
+			name:  "stability below the learned boundary excludes an interval-seven review",
+			swipe: swipeStability(domain.RatingAgain, time.Time{}, stateWithLapses(5, 7, 0, domain.FSRSPhaseRelearning, 1), domain.FSRSPhaseReview, 7, 6.6),
+			want:  false,
+		},
+		{
+			name:  "stability at the learned boundary is included",
+			swipe: swipeStability(domain.RatingGood, time.Time{}, state(5, 7, 9, domain.FSRSPhaseReview), domain.FSRSPhaseReview, 7, 7.0),
+			want:  true,
+		},
+		{
+			// The monotonicity clamps can push the recorded interval well past
+			// round(stability); the snapshot keeps such a row out.
+			name:  "stability snapshot overrides an interval inflated by the rating clamps",
+			swipe: swipeStability(domain.RatingGood, time.Time{}, state(5, 10, 12, domain.FSRSPhaseReview), domain.FSRSPhaseReview, 10, 4.0),
+			want:  false,
+		},
+		{
+			name:  "stability snapshot on a non-review phase is excluded",
+			swipe: swipeStability(domain.RatingGood, time.Time{}, state(5, 16, 16, domain.FSRSPhaseReview), domain.FSRSPhaseLearning, 16, 20.0),
+			want:  false,
+		},
+		{
 			name:  "interval six is below the learned boundary",
 			swipe: swipeBefore(domain.RatingGood, time.Time{}, state(5, 6, 6, domain.FSRSPhaseReview), domain.FSRSPhaseReview, 6),
 			want:  false,
 		},
 		{
+			// No stability snapshot: the transition-era interval heuristic decides.
 			name:  "interval seven is at the learned boundary",
 			swipe: swipeBefore(domain.RatingGood, time.Time{}, state(5, 7, 7, domain.FSRSPhaseReview), domain.FSRSPhaseReview, 7),
 			want:  true,
@@ -597,6 +657,23 @@ func swipe(rating domain.Rating, reviewedAt time.Time, stateAfter domain.FSRSSta
 		ReviewedAt: reviewedAt,
 		StateAfter: stateAfter,
 	}
+}
+
+// swipeStability builds a swipe record carrying the full pre-swipe snapshot,
+// including the stability the card held before the rating was applied. This is
+// the shape the metrics layer prefers over the scheduled-interval heuristic.
+func swipeStability(
+	rating domain.Rating,
+	reviewedAt time.Time,
+	stateAfter domain.FSRSState,
+	phaseBefore domain.FSRSPhase,
+	scheduledDaysBefore int,
+	stabilityBefore float64,
+) domain.SwipeRecord {
+	sr := swipeBefore(rating, reviewedAt, stateAfter, phaseBefore, scheduledDaysBefore)
+	sb := stabilityBefore
+	sr.StabilityBefore = &sb
+	return sr
 }
 
 // swipeBefore builds a new-format swipe record carrying the pre-swipe snapshot

--- a/backend/internal/domain/swipe_record.go
+++ b/backend/internal/domain/swipe_record.go
@@ -21,14 +21,17 @@ type SwipeRecord struct {
 	// ScheduledDaysBefore is the interval (days) scheduled at the previous
 	// review; nil for legacy rows recorded before the column existed.
 	ScheduledDaysBefore *int
+	// StabilityBefore is the FSRS stability (days) the card held before this
+	// swipe; nil for rows recorded before the column existed.
+	StabilityBefore *float64
 }
 
 // NewSwipeRecord creates a swipe event with a fresh UUID v7. stateBefore is the
 // scheduling state captured immediately before the rating was applied; the
-// pre-swipe snapshot (PhaseBefore, ScheduledDaysBefore) is populated from it so
-// the metrics layer can distinguish, for example, a Learning->Easy graduation
-// from a genuine review of an already-learned card. stateAfter is the state the
-// swipe advanced the card to.
+// pre-swipe snapshot (PhaseBefore, ScheduledDaysBefore, StabilityBefore) is
+// populated from it so the metrics layer can distinguish, for example, a
+// Learning->Easy graduation from a genuine review of an already-learned card.
+// stateAfter is the state the swipe advanced the card to.
 func NewSwipeRecord(userID UserID, cardID string, cardgroupID CardgroupID, rating Rating, reviewedAt time.Time, stateBefore, stateAfter FSRSState) (*SwipeRecord, error) {
 	if cardgroupID == "" {
 		return nil, eris.New("swipe record: cardgroupID is required")
@@ -41,6 +44,7 @@ func NewSwipeRecord(userID UserID, cardID string, cardgroupID CardgroupID, ratin
 	// snapshot pointers must not alias the caller's FSRSState.
 	phaseBefore := stateBefore.Phase
 	scheduledDaysBefore := stateBefore.ScheduledDays
+	stabilityBefore := stateBefore.Stability
 	return &SwipeRecord{
 		ID:                  id,
 		UserID:              userID,
@@ -51,5 +55,6 @@ func NewSwipeRecord(userID UserID, cardID string, cardgroupID CardgroupID, ratin
 		StateAfter:          stateAfter,
 		PhaseBefore:         &phaseBefore,
 		ScheduledDaysBefore: &scheduledDaysBefore,
+		StabilityBefore:     &stabilityBefore,
 	}, nil
 }

--- a/backend/internal/domain/swipe_record_test.go
+++ b/backend/internal/domain/swipe_record_test.go
@@ -14,6 +14,7 @@ func TestNewSwipeRecord(t *testing.T) {
 	stateBefore := NewFSRSStateForNewCard(reviewedAt)
 	stateBefore.Phase = FSRSPhaseReview
 	stateBefore.ScheduledDays = 7
+	stateBefore.Stability = 6.6
 	stateAfter := NewFSRSStateForNewCard(reviewedAt)
 	stateAfter.Phase = FSRSPhaseRelearning
 	stateAfter.ScheduledDays = 1
@@ -37,6 +38,8 @@ func TestNewSwipeRecord(t *testing.T) {
 	require.Equal(t, FSRSPhaseReview, *first.PhaseBefore)
 	require.NotNil(t, first.ScheduledDaysBefore)
 	require.Equal(t, 7, *first.ScheduledDaysBefore)
+	require.NotNil(t, first.StabilityBefore)
+	require.InDelta(t, 6.6, *first.StabilityBefore, 0.000000001)
 }
 
 // TestNewSwipeRecord_SnapshotPointersAreIndependentCopies proves the snapshot
@@ -51,6 +54,7 @@ func TestNewSwipeRecord_SnapshotPointersAreIndependentCopies(t *testing.T) {
 	stateBefore := NewFSRSStateForNewCard(reviewedAt)
 	stateBefore.Phase = FSRSPhaseReview
 	stateBefore.ScheduledDays = 7
+	stateBefore.Stability = 6.6
 	stateAfter := NewFSRSStateForNewCard(reviewedAt)
 
 	rec, err := NewSwipeRecord("user-1", "card-1", CardgroupID("cg-1"), RatingGood, reviewedAt, stateBefore, stateAfter)
@@ -58,12 +62,15 @@ func TestNewSwipeRecord_SnapshotPointersAreIndependentCopies(t *testing.T) {
 
 	require.NotSame(t, &stateBefore.Phase, rec.PhaseBefore, "PhaseBefore must not alias the caller's stateBefore")
 	require.NotSame(t, &stateBefore.ScheduledDays, rec.ScheduledDaysBefore, "ScheduledDaysBefore must not alias the caller's stateBefore")
+	require.NotSame(t, &stateBefore.Stability, rec.StabilityBefore, "StabilityBefore must not alias the caller's stateBefore")
 
 	// Mutating the caller's copy after construction must not change the record.
 	stateBefore.Phase = FSRSPhaseNew
 	stateBefore.ScheduledDays = 999
+	stateBefore.Stability = 999
 	require.Equal(t, FSRSPhaseReview, *rec.PhaseBefore, "PhaseBefore is an independent copy")
 	require.Equal(t, 7, *rec.ScheduledDaysBefore, "ScheduledDaysBefore is an independent copy")
+	require.InDelta(t, 6.6, *rec.StabilityBefore, 0.000000001, "StabilityBefore is an independent copy")
 }
 
 func TestNewSwipeRecord_EmptyCardgroupID(t *testing.T) {

--- a/backend/internal/repository/swipe_record.go
+++ b/backend/internal/repository/swipe_record.go
@@ -28,8 +28,9 @@ type gormSwipeRecord struct {
 	LastReview    time.Time `gorm:"column:last_review"`
 	// Pre-swipe snapshot columns. Nullable: a NULL marks a legacy row recorded
 	// before the columns existed.
-	PhaseBefore         *int16 `gorm:"column:phase_before"`
-	ScheduledDaysBefore *int   `gorm:"column:scheduled_days_before"`
+	PhaseBefore         *int16   `gorm:"column:phase_before"`
+	ScheduledDaysBefore *int     `gorm:"column:scheduled_days_before"`
+	StabilityBefore     *float64 `gorm:"column:stability_before"`
 }
 
 func (gormSwipeRecord) TableName() string { return "swipe_records" }
@@ -151,6 +152,11 @@ func swipeRecordToRow(sr *domain.SwipeRecord) *gormSwipeRecord {
 		v := *sr.ScheduledDaysBefore
 		scheduledDaysBefore = &v
 	}
+	var stabilityBefore *float64
+	if sr.StabilityBefore != nil {
+		v := *sr.StabilityBefore
+		stabilityBefore = &v
+	}
 	return &gormSwipeRecord{
 		ID:                  sr.ID,
 		UserID:              string(sr.UserID),
@@ -169,6 +175,7 @@ func swipeRecordToRow(sr *domain.SwipeRecord) *gormSwipeRecord {
 		LastReview:          sr.StateAfter.LastReview,
 		PhaseBefore:         phaseBefore,
 		ScheduledDaysBefore: scheduledDaysBefore,
+		StabilityBefore:     stabilityBefore,
 	}
 }
 
@@ -197,6 +204,11 @@ func swipeRecordToDomain(row gormSwipeRecord) (*domain.SwipeRecord, error) {
 		v := *row.ScheduledDaysBefore
 		scheduledDaysBefore = &v
 	}
+	var stabilityBefore *float64
+	if row.StabilityBefore != nil {
+		v := *row.StabilityBefore
+		stabilityBefore = &v
+	}
 	return &domain.SwipeRecord{
 		ID:          row.ID,
 		UserID:      domain.UserID(row.UserID),
@@ -217,5 +229,6 @@ func swipeRecordToDomain(row gormSwipeRecord) (*domain.SwipeRecord, error) {
 		},
 		PhaseBefore:         phaseBefore,
 		ScheduledDaysBefore: scheduledDaysBefore,
+		StabilityBefore:     stabilityBefore,
 	}, nil
 }

--- a/backend/internal/repository/swipe_record_test.go
+++ b/backend/internal/repository/swipe_record_test.go
@@ -26,6 +26,7 @@ func TestSwipeRecordRepository_CreateTxAndFind(t *testing.T) {
 	stateBefore := domain.NewFSRSStateForNewCard(reviewedAt)
 	stateBefore.Phase = domain.FSRSPhaseReview
 	stateBefore.ScheduledDays = 3
+	stateBefore.Stability = 6.6
 	state := domain.NewFSRSStateForNewCard(reviewedAt)
 	state.Reps = 1
 	sr, err := domain.NewSwipeRecord(domain.UserID(ownerID), card.ID, cg.ID, domain.RatingEasy, reviewedAt, stateBefore, state)
@@ -47,6 +48,8 @@ func TestSwipeRecordRepository_CreateTxAndFind(t *testing.T) {
 	require.Equal(t, domain.FSRSPhaseReview, *byID[sr.ID].PhaseBefore)
 	require.NotNil(t, byID[sr.ID].ScheduledDaysBefore)
 	require.Equal(t, 3, *byID[sr.ID].ScheduledDaysBefore)
+	require.NotNil(t, byID[sr.ID].StabilityBefore)
+	require.InDelta(t, 6.6, *byID[sr.ID].StabilityBefore, 0.000000001)
 
 	history, err := swipeRepo.FindByUserAndCardgroup(ctx, ownerID, string(cg.ID))
 	require.NoError(t, err)
@@ -297,9 +300,9 @@ func TestSwipeRecordRepository_OutOfRangeState_ReturnsError(t *testing.T) {
 }
 
 // TestSwipeRecordRepository_LegacyRowWithoutSnapshot_ReadsBackNil proves a row
-// inserted without the phase_before / scheduled_days_before columns (a legacy
-// row recorded before the migration) reads back with both snapshot pointers nil
-// — the sentinel the metrics layer branches on.
+// inserted without the phase_before / scheduled_days_before / stability_before
+// columns (a legacy row recorded before the migrations) reads back with every
+// snapshot pointer nil — the sentinel the metrics layer branches on.
 func TestSwipeRecordRepository_LegacyRowWithoutSnapshot_ReadsBackNil(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
@@ -313,7 +316,8 @@ func TestSwipeRecordRepository_LegacyRowWithoutSnapshot_ReadsBackNil(t *testing.
 
 	reviewedAt := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
 	const rowID = "00000000-0000-0000-0000-0000000000d1"
-	// Raw insert omitting phase_before / scheduled_days_before; both default to NULL.
+	// Raw insert omitting phase_before / scheduled_days_before / stability_before;
+	// all three default to NULL.
 	require.NoError(t, testDB.GORM.WithContext(ctx).Exec(
 		`INSERT INTO swipe_records
 		   (id, user_id, card_id, cardgroup_id, rating, reviewed_at,
@@ -329,6 +333,7 @@ func TestSwipeRecordRepository_LegacyRowWithoutSnapshot_ReadsBackNil(t *testing.
 	require.Len(t, byID, 1)
 	require.Nil(t, byID[rowID].PhaseBefore, "legacy row's phase_before reads back as nil")
 	require.Nil(t, byID[rowID].ScheduledDaysBefore, "legacy row's scheduled_days_before reads back as nil")
+	require.Nil(t, byID[rowID].StabilityBefore, "legacy row's stability_before reads back as nil")
 }
 
 // TestSwipeRecordRepository_OutOfRangePhaseBefore_ReturnsError proves a non-nil

--- a/backend/internal/usecase/swipe_performance_test.go
+++ b/backend/internal/usecase/swipe_performance_test.go
@@ -26,6 +26,9 @@ type mockSwipeRecordRepoForSwipe struct {
 	// (docs/backend/library-gotchas/mock-snapshot-for-ordering-assertion.md).
 	phaseBeforeAtCreate *domain.FSRSPhase
 	phaseAfterAtCreate  *domain.FSRSPhase
+	// stabilityBeforeAtCreate is the same kind of value snapshot for
+	// created.StabilityBefore.
+	stabilityBeforeAtCreate *float64
 }
 
 func (m *mockSwipeRecordRepoForSwipe) CreateTx(_ context.Context, _ *gorm.DB, sr *domain.SwipeRecord) error {
@@ -37,6 +40,10 @@ func (m *mockSwipeRecordRepoForSwipe) CreateTx(_ context.Context, _ *gorm.DB, sr
 		if sr.PhaseBefore != nil {
 			p := *sr.PhaseBefore
 			m.phaseBeforeAtCreate = &p
+		}
+		if sr.StabilityBefore != nil {
+			s := *sr.StabilityBefore
+			m.stabilityBeforeAtCreate = &s
 		}
 		after := sr.StateAfter.Phase
 		m.phaseAfterAtCreate = &after
@@ -204,8 +211,10 @@ func TestSwipeUsecase_HandleSwipeCreatesUserFSRSStateForFirstSwipe(t *testing.T)
 // mutated it, not the post-rating phase. For a brand-new card the pre-swipe
 // phase is FSRSPhaseNew; a RatingEasy graduation advances StateAfter.Phase past
 // New, so asserting PhaseBefore == New AND StateAfter.Phase != New pins that the
-// snapshot was captured before the mutation. The mock snapshots PhaseBefore at
-// CreateTx call time (docs/backend/library-gotchas/mock-snapshot-for-ordering-assertion.md).
+// snapshot was captured before the mutation. The same argument pins
+// StabilityBefore against the new-card starting stability. The mock snapshots
+// both at CreateTx call time
+// (docs/backend/library-gotchas/mock-snapshot-for-ordering-assertion.md).
 func TestSwipeUsecase_HandleSwipe_RecordsPreRatingPhase(t *testing.T) {
 	t.Parallel()
 
@@ -253,6 +262,18 @@ func TestSwipeUsecase_HandleSwipe_RecordsPreRatingPhase(t *testing.T) {
 	}
 	if swipeRepo.created.ScheduledDaysBefore == nil {
 		t.Fatal("expected a non-nil ScheduledDaysBefore snapshot for a swipe recorded through the constructor")
+	}
+	// A brand-new card starts at the NewFSRSStateForNewCard stability, so the
+	// snapshot must read that value and not the post-rating stability.
+	wantStability := domain.NewFSRSStateForNewCard(time.Now().UTC()).Stability
+	if swipeRepo.stabilityBeforeAtCreate == nil {
+		t.Fatal("expected a pre-swipe stability snapshot to be captured at CreateTx call time")
+	}
+	if *swipeRepo.stabilityBeforeAtCreate != wantStability {
+		t.Fatalf("StabilityBefore=%v, want %v", *swipeRepo.stabilityBeforeAtCreate, wantStability)
+	}
+	if swipeRepo.created.StateAfter.Stability == wantStability {
+		t.Fatalf("StateAfter.Stability must have advanced past the new-card stability %v", wantStability)
 	}
 }
 


### PR DESCRIPTION
## Summary

The /stats retention and lapse tiles describe their population as reviews of cards the learner had already learned, and the mastery tiles define "learned" as FSRS stability at or above `domain.LearnedStabilityDays` (7 days). The metrics layer approximated that with the pre-swipe *scheduled interval* instead, and go-fsrs clamps each rating's interval to exceed the previous rating's, so a recorded interval can outrun the card's actual stability — admitting reviews of cards the mastery tile on the same screen still calls "In progress" and skewing LapseRate up / RetentionRate down. This snapshots the pre-swipe stability onto each swipe record and gates on it directly, so the two tiles now describe the same set of cards.

## Changes

### Migration

- `20260720000000_add_stability_before_to_swipe_records.{up,down}.sql` — adds `swipe_records.stability_before double precision`, nullable with no default and no backfill; NULL is a meaningful sentinel meaning "recorded before the column existed". The three existing roundtrip step counts are bumped for the added migration (`learn_display_mode` -8→-9, `cards_position` -13→-14, `users_version` -14→-15), and `last_rating_roundtrip_test.go` moves from `Steps(-1)`/`Steps(1)` to `Steps(-2)`/`Steps(2)` because its target is no longer the newest migration.

### Backend

- `backend/internal/domain/swipe_record.go` — `SwipeRecord` gains `StabilityBefore *float64`; `NewSwipeRecord` populates it from `stateBefore.Stability` through an independent local, matching the existing no-aliasing treatment of `PhaseBefore` / `ScheduledDaysBefore`.
- `backend/internal/repository/swipe_record.go` — `gormSwipeRecord` gains a `StabilityBefore *float64` field mapped to the `stability_before` column, threaded in both directions by `swipeRecordToRow` and `swipeRecordToDomain` with the same defensive-copy shape as its sibling snapshot columns.
- `backend/internal/domain/service/user_performance.go` — `isKnownCardReview` becomes three-tier. With `StabilityBefore != nil` it returns `*PhaseBefore == FSRSPhaseReview && *StabilityBefore >= domain.LearnedStabilityDays`; with only `PhaseBefore != nil` it keeps the existing `ScheduledDaysBefore >= LearnedStabilityDays` heuristic so transition-era rows do not jump; legacy rows (`PhaseBefore == nil`) keep the post-swipe `StateAfter` fallback. `isOnTimeRecall` is unchanged — its comparison is genuinely about the scheduled interval.
- Docstrings: `mastery_tier.go`'s `LearnedStabilityDays` and `isKnownCardReview` both drop the false "the scheduled interval equals `round(stability)`" invariant. The replacement text states that `LearnedStabilityDays` is the single boundary `ClassifyMastery` and the stats gate share, and documents the per-rating monotonicity clamps (`hard >= again+1`, `good >= hard+1`, `easy >= good+1`) as the reason the interval heuristic can over-include.

### Tests

- `user_performance_test.go` — new `swipeStability` helper builds a record carrying the full snapshot. `TestComputeMetrics` gains a stability-6.6 / interval-7 Again that is now excluded from both the lapse numerator and the review denominator, and a stability-7.0 boundary case that is included. `TestIsKnownCardReview` gains four cases: sub-boundary stability beats interval 7, exact-7.0 stability is inclusive, stability 4.0 with interval 10 (the clamp-inflated shape) is excluded, and a stability snapshot on a non-Review `PhaseBefore` is excluded.
- `swipe_record_test.go` — asserts `StabilityBefore` is captured and that mutating the caller's `stateBefore.Stability` after construction does not change the record (`require.NotSame` plus a post-mutation value check).
- `repository/swipe_record_test.go` — round-trips `stability_before` through `CreateTx`/`FindByIDs`, and the raw-insert legacy-row test now asserts all three snapshot pointers read back nil.
- `usecase/swipe_performance_test.go` — the mock snapshots `StabilityBefore` at `CreateTx` call time; `TestSwipeUsecase_HandleSwipe_RecordsPreRatingPhase` pins it to the new-card starting stability and asserts `StateAfter.Stability` has moved off it, proving the snapshot predates the rating.
- `stability_before_roundtrip_test.go` — new down/up roundtrip proving the column drops and returns while `phase_before` and `scheduled_days_before` survive the step.

## Test plan

- [ ] `go build ./... && go vet ./... && go test ./...` from `backend/` — green, 2250 tests across 26 packages
- [ ] `go test ./internal/database/... -run Roundtrip` against a live Postgres — 6/6 pass, including the new `TestStabilityBeforeDownUpRoundtrip`
- [ ] `go tool go-arch-lint check --project-path .` — OK, no warnings
- [ ] `grep -rn 'round(stability)' backend/ docs/ .claude/rules/` — 2 hits, both describing the clamp over-run accurately; the false equality invariant is gone
- [ ] Negative case: a review with `scheduled_days_before = 7` but `stability_before = 6.6` is excluded from RetentionRate and LapseRate (`TestIsKnownCardReview` / `TestComputeMetrics`)

## Notes

- Nothing outside `backend/` changes, so no Playwright spec is affected and none was run (the e2e suite needs a live Supabase + backend stack).
- Rows written between the phase-snapshot migration and this one carry `phase_before` but a NULL `stability_before`; they deliberately keep the interval heuristic rather than being backfilled, so the 365-day metrics window does not shift under existing users.
- The empty-state rendering when zero reviews qualify is out of scope here.

Closes #983
