### PR TITLE
fix(stats): compute rolling-window cutoffs on the UTC clock

### DIFF
--- a/backend/internal/usecase/stats.go
+++ b/backend/internal/usecase/stats.go
@@ -16,7 +16,10 @@ const (
 	strugglingCardsLimit = 10
 	// statsWindowDays is the trailing calendar window (in days) over which the
 	// diagnostic performance snapshot is computed, so studyStreak reflects real
-	// calendar days rather than a swipe-count window.
+	// calendar days rather than a swipe-count window. Window cutoffs are computed
+	// on the UTC clock — mirroring the learn and swipe paths — so the AddDate
+	// arithmetic matches the UTC-recorded reviewed_at values regardless of the
+	// server's zone setting.
 	statsWindowDays = 365
 )
 
@@ -108,7 +111,7 @@ func (u *statsUsecase) MyLearningStats(ctx context.Context) (*LearningStatsResul
 	// Diagnostic half: performance snapshots derived from one trailing
 	// statsWindowDays calendar read (so studyStreak reflects real days, not a
 	// swipe count) plus the struggling-card ranking from the loaded FSRS rows.
-	now := u.clock.Now()
+	now := u.clock.Now().UTC()
 	swipes, err := u.swipeRepo.ListByUserSince(ctx, caller.Sub, now.AddDate(0, 0, -statsWindowDays))
 	if err != nil {
 		return nil, eris.Wrap(err, "usecase: stats: list swipes since")

--- a/backend/internal/usecase/stats_test.go
+++ b/backend/internal/usecase/stats_test.go
@@ -219,6 +219,27 @@ func TestStatsUsecase_MyLearningStats_WindowsSwipesByStatsWindowDays(t *testing.
 	assert.Empty(t, res.StrugglingCards)
 }
 
+// TestStatsUsecase_MyLearningStats_WindowCutoffUsesUTCClock pins the clock basis:
+// the cutoff is derived from the UTC instant, matching the learn and swipe paths,
+// so AddDate arithmetic lines up with the UTC-recorded reviewed_at values even
+// when the injected clock reports a non-UTC zone.
+func TestStatsUsecase_MyLearningStats_WindowCutoffUsesUTCClock(t *testing.T) {
+	t.Parallel()
+	zone := time.FixedZone("UTC+5", 5*60*60)
+	fixedNow := time.Date(2026, 7, 10, 12, 0, 0, 0, zone)
+	swipeRepo := &fakeStatsSwipeRepo{}
+	uc := NewStats(&fakeStatsFSRSRepo{totals: map[string]int{}}, swipeRepo, &fakeStatsCardgroupRepo{}, fixedClock{now: fixedNow})
+
+	res, err := uc.MyLearningStats(authedStatsCtx("user-1"))
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	require.True(t, swipeRepo.called, "MyLearningStats reads the windowed swipe history")
+	assert.Equal(t, fixedNow.UTC().AddDate(0, 0, -365), swipeRepo.sinceArg,
+		"since == now.UTC() minus statsWindowDays (365), not the zoned instant")
+	assert.Equal(t, time.UTC, swipeRepo.sinceArg.Location(),
+		"the cutoff carries the UTC location, pinning the normalization rather than only the instant")
+}
+
 func TestStatsUsecase_MyLearningStats_WindowsReflectComputeWindowedMetrics(t *testing.T) {
 	t.Parallel()
 	fixedNow := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)


### PR DESCRIPTION
## Summary

The stats read path derived its trailing-window cutoffs from the raw injected clock (`now := u.clock.Now()`), while the learn queue and swipe recording both normalize to UTC first. On a DST-observing location `AddDate` shifts the resulting instant by an hour relative to the UTC-recorded `reviewed_at` values, so boundary swipes can silently fall in or out of the 365/30/7-day windows. Normalizing the stats clock base to UTC makes the cutoff arithmetic zone-independent and aligns the stats path with the rest of the learning domain. Fixed-offset clocks (what production and dev run today) are unaffected, so this is a latent-defect fix rather than a visible behaviour change.

## Changes

### Backend

- `backend/internal/usecase/stats.go:114`: `now := u.clock.Now()` -> `now := u.clock.Now().UTC()`. The same `now` feeds `ListByUserSince` (365-day cutoff, `stats.go:115`) and `service.ComputeWindowedMetrics` (`stats.go:131`), which derives the 30- and 7-day cutoffs via `now.AddDate` (`internal/domain/service/user_performance.go:190-191`) — so all three window boundaries are now measured on the UTC clock.
- `backend/internal/usecase/stats.go:17-23`: extended the `statsWindowDays` docstring to record the clock basis — cutoffs are computed on the UTC clock, mirroring the learn and swipe paths, so `AddDate` arithmetic matches the UTC-recorded `reviewed_at` values regardless of the server's zone setting.

### Tests

- `backend/internal/usecase/stats_test.go:226` `TestStatsUsecase_MyLearningStats_WindowCutoffUsesUTCClock`: injects a fake clock returning `2026-07-10 12:00` in a `time.FixedZone("UTC+5", …)` zone and asserts the `since` argument captured by the swipe-repo fake equals `fixedNow.UTC().AddDate(0, 0, -365)`.
- The same test additionally asserts `swipeRepo.sinceArg.Location() == time.UTC`, pinning the normalization itself rather than only the resulting instant — a cutoff that merely happens to be the right instant in a non-UTC zone would still fail.

## Test plan

- [ ] `go build ./...` — success.
- [ ] `go vet ./...` — no issues.
- [ ] `go test ./... -count=1` — 2244 tests pass, 0 fail, across 23 packages (3 further packages have no test files).
- [ ] Regression: the pre-existing `TestStatsUsecase_MyLearningStats_WindowsSwipesByStatsWindowDays` (UTC fake clock) still pins the 365-day cutoff and passes unchanged, confirming the UTC path is a no-op for a UTC clock.

## Notes

`studyStreak` / `domain.LearnDayKey` remain JST-based by design (`backend/internal/domain/learn_day.go:9,27` — `StartOfLearnDay` converts via `now.In(learnDayZone)`), so the streak is computed from the same instant and is unaffected by this change. Only the window-cutoff instants move, and only when the injected clock reports a non-UTC zone.

Closes #987
