### PR TITLE
fix(stats): gate the per-deck section on hasDecks when studied > 0

### DIFF
--- a/frontend/src/app/stats/stats-client.test.tsx
+++ b/frontend/src/app/stats/stats-client.test.tsx
@@ -99,6 +99,19 @@ function renderStats(stats: Stats, intl?: { locale: "en" | "ja"; messages: typeo
   return renderWithIntl(<StatsClient stats={stats} />, intl);
 }
 
+// The explicit two-track template of the per-deck / struggling grid. It must only
+// apply while both children render: with the per-deck section gated out, a 4fr
+// track would leave the struggling list beside a dead 3fr gutter.
+const TWO_TRACK_CLASS = "lg:grid-cols-[4fr_3fr]";
+
+// The grid wrapping that pair, anchored on the struggling section (present in
+// both states asserted below) rather than on the class under test.
+function contentGrid() {
+  const grid = screen.getByText("Struggling cards").closest("section")?.parentElement;
+  if (!grid) throw new Error("content grid not found");
+  return grid;
+}
+
 describe("<StatsClient>", () => {
   describe("populated (studied > 0)", () => {
     it("renders the acquired headline and the three funnel legend counts", () => {
@@ -164,6 +177,12 @@ describe("<StatsClient>", () => {
       expect(screen.getByText("Ephemeral")).toBeInTheDocument();
       expect(screen.getByText("Japanese Kanji")).toBeInTheDocument();
       expect(screen.getByText("7 lapses")).toBeInTheDocument();
+    });
+
+    it("lays the per-deck and struggling sections out on the two-track grid", () => {
+      renderStats(populatedStats);
+
+      expect(contentGrid()).toHaveClass(TWO_TRACK_CLASS);
     });
   });
 
@@ -338,6 +357,12 @@ describe("<StatsClient>", () => {
       expect(screen.getByText("Diagnostics")).toBeInTheDocument();
       expect(screen.getByText("Struggling cards")).toBeInTheDocument();
       expect(screen.getByText("Ephemeral")).toBeInTheDocument();
+    });
+
+    it("drops the two-track grid so the struggling list spans the full width", () => {
+      renderStats(noDecksStats);
+
+      expect(contentGrid()).not.toHaveClass(TWO_TRACK_CLASS);
     });
   });
 

--- a/frontend/src/app/stats/stats-client.test.tsx
+++ b/frontend/src/app/stats/stats-client.test.tsx
@@ -318,6 +318,29 @@ describe("<StatsClient>", () => {
     });
   });
 
+  describe("populated but no decks (studied > 0 && decks === [])", () => {
+    // Reachable transiently: the backend derives the mastery totals and the
+    // per-deck totals from separate, non-transactional reads, so a deck deletion
+    // landing between them yields studied > 0 alongside an empty deck list.
+    const noDecksStats: Stats = { ...populatedStats, decks: [] };
+
+    it("omits the per-deck section instead of rendering it headed-but-empty", () => {
+      renderStats(noDecksStats);
+
+      expect(screen.queryByText("Per-deck acquisition")).not.toBeInTheDocument();
+      expect(screen.queryByText("Spanish Vocab")).not.toBeInTheDocument();
+    });
+
+    it("still renders mastery, diagnostics, and the struggling list", () => {
+      renderStats(noDecksStats);
+
+      expect(screen.getByText("820")).toBeInTheDocument();
+      expect(screen.getByText("Diagnostics")).toBeInTheDocument();
+      expect(screen.getByText("Struggling cards")).toBeInTheDocument();
+      expect(screen.getByText("Ephemeral")).toBeInTheDocument();
+    });
+  });
+
   describe("populated but no struggling cards (strugglingCards === [])", () => {
     const noStrugglingStats: Stats = { ...populatedStats, strugglingCards: [] };
 

--- a/frontend/src/app/stats/stats-client.tsx
+++ b/frontend/src/app/stats/stats-client.tsx
@@ -61,7 +61,12 @@ export function StatsClient({ stats }: { stats: MyLearningStatsQuery["myLearning
         <MasterySummary mastery={stats.mastery} />
         <DiagnosticsPanel performanceWindows={stats.performanceWindows} />
         <div className="grid gap-4 lg:grid-cols-[4fr_3fr]">
-          <PerDeckList decks={stats.decks} />
+          {/* The mastery totals and the per-deck totals come from separate,
+              non-transactional backend reads, so a deck deletion landing between
+              them yields studied > 0 with an empty deck list. Gate on `hasDecks`
+              so the section never renders headed-but-empty; the grid lays out
+              correctly with a single child. */}
+          {hasDecks ? <PerDeckList decks={stats.decks} /> : null}
           <StrugglingList cards={stats.strugglingCards} />
         </div>
       </div>

--- a/frontend/src/app/stats/stats-client.tsx
+++ b/frontend/src/app/stats/stats-client.tsx
@@ -4,6 +4,7 @@ import { useTranslations } from "next-intl";
 import type { ReactNode } from "react";
 import { ListingPageShell } from "@/components/layout/listing-page-shell";
 import type { MyLearningStatsQuery } from "@/generated/graphql";
+import { cn } from "@/lib/utils";
 import { DiagnosticsPanel } from "./diagnostics-panel";
 import { MasterySummary } from "./mastery-summary";
 import { PerDeckList } from "./per-deck-list";
@@ -60,12 +61,13 @@ export function StatsClient({ stats }: { stats: MyLearningStatsQuery["myLearning
       <div className="flex flex-col gap-4 sm:gap-6">
         <MasterySummary mastery={stats.mastery} />
         <DiagnosticsPanel performanceWindows={stats.performanceWindows} />
-        <div className="grid gap-4 lg:grid-cols-[4fr_3fr]">
-          {/* The mastery totals and the per-deck totals come from separate,
-              non-transactional backend reads, so a deck deletion landing between
-              them yields studied > 0 with an empty deck list. Gate on `hasDecks`
-              so the section never renders headed-but-empty; the grid lays out
-              correctly with a single child. */}
+        {/* The mastery totals and the per-deck totals come from separate,
+            non-transactional backend reads, so a deck deletion landing between
+            them yields studied > 0 with an empty deck list. Gate on `hasDecks`
+            so the section never renders headed-but-empty, and drop the explicit
+            two-track template with it — otherwise the surviving struggling list
+            would sit in the 4fr track with a dead 3fr gutter beside it. */}
+        <div className={cn("grid gap-4", hasDecks && "lg:grid-cols-[4fr_3fr]")}>
           {hasDecks ? <PerDeckList decks={stats.decks} /> : null}
           <StrugglingList cards={stats.strugglingCards} />
         </div>


### PR DESCRIPTION
## Summary

`PerDeckList` documents that callers must render it only for a non-empty `decks` list, but `StatsClient` honoured that only in its `studiedCount === 0` branches — the full-content branch rendered `<PerDeckList decks={stats.decks} />` unconditionally. The divergent state is reachable: the stats usecase derives the mastery totals and the per-deck totals from two separate, non-transactional repository reads (`backend/internal/usecase/stats.go:91` then `:95`), so a deck deletion landing between them yields `totalStudied > 0` alongside an empty deck list, and `/stats` renders a headed-but-empty "Per-deck acquisition" card. The full-content branch now gates on the same `hasDecks` flag the other branches use, and the two-column template is dropped with it so the surviving struggling list spans the full width instead of sitting in a 4fr track beside a dead 3fr gutter.

## Changes

### Rendering gate

- `frontend/src/app/stats/stats-client.tsx`: the `studiedCount > 0` branch renders `{hasDecks ? <PerDeckList decks={stats.decks} /> : null}` instead of an unconditional `<PerDeckList>`. `hasDecks` was already in scope (`stats.decks.length > 0`); the `studiedCount === 0` branch that still renders `PerDeckList` unconditionally is only reachable when `hasDecks` is true, because the two preceding branches absorb every `!hasDecks` case.
- Added a block comment above the grid recording *why* the gate exists (the two non-transactional backend reads) so a future reader does not simplify it back to an unconditional render.

### Grid layout

- The wrapper switched from a static `className="grid gap-4 lg:grid-cols-[4fr_3fr]"` to `cn("grid gap-4", hasDecks && "lg:grid-cols-[4fr_3fr]")`, adding the `cn` import from `@/lib/utils`. With the per-deck child gated out, the explicit two-track template would leave `StrugglingList` in the 4fr column with an empty 3fr gutter; collapsing to the implicit single column keeps it full-width.

### Tests

- New `populated but no decks (studied > 0 && decks === [])` block in `frontend/src/app/stats/stats-client.test.tsx`, built from `populatedStats` with `decks: []`:
  - the "Per-deck acquisition" heading and the deck name "Spanish Vocab" are both absent;
  - `MasterySummary` (acquired `820`), `Diagnostics`, and the struggling list (`Struggling cards`, `Ephemeral`) still render;
  - the grid does not carry `lg:grid-cols-[4fr_3fr]`.
- Added a companion assertion in the existing `populated (studied > 0)` block that the same grid *does* carry `lg:grid-cols-[4fr_3fr]` when decks are present, so the layout change is pinned in both directions.
- The grid element is resolved via a `contentGrid()` helper that walks up from the "Struggling cards" section — the one child present in both states — rather than from the class under test.

## Test plan

- [ ] `tsc --noEmit` — exit 0, no diagnostics.
- [ ] `biome check --error-on-warnings .` — exit 0 (520 files checked; the 2 remaining infos are pre-existing config-migration hints).
- [ ] `vitest run` — 206 files / 1905 tests passed; `src/app/stats/stats-client.test.tsx` alone is 21 tests passed (17 before this change, +4 here).
- [ ] `knip` — exit 0.
- [ ] `next build` — succeeds, `/stats` still emitted as a dynamic route.
- [ ] Regression: with a non-empty `decks` list the per-deck section still renders and the grid keeps its two-track template (asserted by the new populated-case test alongside the pre-existing per-deck rendering tests).

## Notes

- Backend is untouched. The root cause — two non-transactional reads in `statsUsecase.MyLearningStats` — is deliberately left in place; the docstring contract in `frontend/src/app/stats/per-deck-list.tsx:23-24` ("show a stats section only when it has content") is treated as the source of truth and the client is made to honour it. The transient state self-heals on reload.
- No Playwright spec touches `/stats` (`grep -rln "stats" frontend/e2e/` returns nothing), so there is no e2e surface to update or re-run.

Closes #986
