### PR TITLE
docs(graphql): sync learning-domain API docs with shipped behavior

### DIFF
--- a/docs/backend-graphql.md
+++ b/docs/backend-graphql.md
@@ -268,7 +268,7 @@ The sentinel `repository.ErrCardgroupNotFound` lives in `repository/user_prefere
 
 `backend/internal/domain/service/user_performance.go` is a stateless calculator. `SwipeUsecase.HandleSwipe` records the swipe and commits the FSRS update first, then loads the latest 100 swipe records for the user through `SwipeRecordRepository.ListRecentByUser`. This post-commit read keeps transactional rollback behavior simple and lets the just-created swipe participate in the next response's metrics.
 
-The response exposes both `performanceMode` and `metrics`. `performanceMode` is an integer in the range `0..4`:
+The response exposes both `performanceMode` and `metrics`. On the wire `performanceMode` is the `SwipePerformanceMode` enum — `DIFFICULT`, `DEFAULT`, `GOOD`, `EASY`, `MASTERED` — which corresponds in that order to the calculator's internal modes `0..4`; `toSwipePerformanceModeModel` in `backend/graph/resolver/mapper.go` performs the order-preserving conversion. The internal modes and their bands:
 
 | Mode | Label | Success-rate band before difficulty adjustment |
 |---|---|---|
@@ -276,7 +276,7 @@ The response exposes both `performanceMode` and `metrics`. `performanceMode` is 
 | `1` | Default | `0.60 <= rate < 0.75` |
 | `2` | Good | `0.75 <= rate < 0.85` |
 | `3` | Easy | `0.85 <= rate < 0.95` |
-| `4` | In While | `>= 0.95` |
+| `4` | Mastered | `>= 0.95` |
 
 The legacy guard is preserved: fewer than 20 reviews always returns `ModeDefault`. Average difficulty then shifts the mode by one step: `>= 0.7` lowers it, `<= 0.3` raises it, and the final value is clamped to `0..4`. Current FSRS difficulty values are stored on the `1..10` scale, so the calculator normalizes each one as `normalized = difficulty / 10`, clamped to `[0, 1]`, before applying those boundaries. The division is unconditional: a mastered card whose FSRS difficulty is pinned at the floor of exactly `1.0` maps to `0.1` (the low-difficulty band), not `1.0`. A strict `> 1` guard would leave the floor at `1.0` and trip the high-difficulty threshold, inverting the mode downward for the easiest cards.
 
@@ -332,19 +332,33 @@ The resolver layer for these operations lives in `backend/graph/resolver/card_im
 
 ```graphql
 """
-Next batch of cards for a learning session: randomly sampled never-seen cards interleaved 4:1 with review cards rated Again/Hard on a previous day (JST). Returns an empty list when the cardgroup has no eligible cards. See [`docs/backend/ddd-patterns/discovery-first-due-ordering.md`](backend/ddd-patterns/discovery-first-due-ordering.md) for the composition design.
+Next batch of cards for a learning session: randomly sampled never-seen cards interleaved 4:1 with review cards due today (JST); among review cards, those you failed on their last review or whose memory stability is still below the learned threshold are served first, and other due cards fill the remaining slots. Returns an empty list when the cardgroup has no eligible cards.
 Limit defaults to 20 (clamped to 100). Returns UNAUTHENTICATED if the caller does not own
 the cardgroup; BAD_USER_INPUT if the cardgroup does not exist.
+A limit of zero, a negative limit, and an explicit null are all treated as omitted and fall back to the default.
 """
 learnNextDueCards(cardgroupId: ID!, limit: Int = 20): [Card!]!
 ```
 
 The description is the contract, not a comment. It covers: normal return shape
-(empty list for caught-up state), clamping behaviour, and the two error codes the
-caller must handle. Keep descriptions result-oriented (what the client observes)
-rather than implementation-oriented (what the resolver calls). Do not list error
-codes only in the resolver body — that surface is invisible to client code-generators
-and frontend teams reading the schema.
+(empty list for caught-up state), clamping behaviour, the degenerate-limit fallback,
+and the two error codes the caller must handle. Keep descriptions result-oriented
+(what the client observes) rather than implementation-oriented (what the resolver
+calls). Do not list error codes only in the resolver body — that surface is invisible
+to client code-generators and frontend teams reading the schema. The queue composition
+behind the description is documented in
+[`docs/backend/ddd-patterns/discovery-first-due-ordering.md`](backend/ddd-patterns/discovery-first-due-ordering.md).
+
+Guard order for `learnNextDueCards` and `practiceTodaysCards` (both run the shared
+`authorizeCardgroupForLearn` in `backend/internal/usecase/learn.go` before touching
+the card repository):
+
+1. `requireCallerSub(auth.UserFrom(ctx))` — nil caller or empty `Sub` ⇒ `UNAUTHENTICATED`.
+2. `authorizeCardgroupOrBadInput(...)` — missing cardgroup ⇒ `BAD_USER_INPUT` on `cardgroupId`; a cardgroup owned by another user ⇒ `UNAUTHENTICATED`.
+
+Authentication is checked first, so an unauthenticated caller receives `UNAUTHENTICATED`
+even when the requested cardgroup does not exist. That ordering keeps anonymous callers
+from using either query as an existence oracle over cardgroup ids.
 
 **Dedupe is asymmetric: `importCards` dedupes, `validateCardImport` does not.** `importCards` runs dedup and surfaces dropped rows as `CardImportError` entries with `Front`/`Back` populated. `validateCardImport` runs `textdic.Process` directly and surfaces only parser-level syntax errors — those entries never carry `Front`/`Back`. The resolver mapping site for `validateCardImport` (in `backend/graph/resolver/card_import.resolvers.go`) therefore deliberately omits `nilIfEmpty(e.Front)` calls; there is nothing to map. If a future change adds dedup to `validateCardImport`, the resolver mapping site must be updated symmetrically with `importCards`.
 

--- a/docs/backend-graphql.md
+++ b/docs/backend-graphql.md
@@ -282,6 +282,19 @@ The legacy guard is preserved: fewer than 20 reviews always returns `ModeDefault
 
 `StudyStreak` buckets each swipe by its **JST learn-day** rather than by UTC calendar day. Every swipe is keyed with `domain.LearnDayKey(swipe.ReviewedAt)` and the streak walks back from `domain.StartOfLearnDay(now)`, both of which use a fixed UTC+9 offset (`time.FixedZone("JST", 9*60*60)` in [`backend/internal/domain/learn_day.go`](../backend/internal/domain/learn_day.go)). The learn-day therefore rolls over at **15:00 UTC** (JST midnight), not UTC midnight, and the streak is 0 whenever the current JST learn-day has no swipe yet. This keeps `studyStreak` consistent with the learn queue's JST start-of-day cutoff — see [`docs/backend/ddd-patterns/discovery-first-due-ordering.md` § "Contracts"](backend/ddd-patterns/discovery-first-due-ordering.md#contracts). The UTC+9 offset is hard-coded because the product currently assumes a Japan-resident learner; a per-user profile time-zone field would replace it as a separate feature.
 
+### Learn and practice queries
+
+Guard order for `learnNextDueCards` and `practiceTodaysCards` (both run the shared
+`authorizeCardgroupForLearn` in `backend/internal/usecase/learn.go` before touching
+the card repository):
+
+1. `requireCallerSub(auth.UserFrom(ctx))` — nil caller or empty `Sub` ⇒ `UNAUTHENTICATED`.
+2. `authorizeCardgroupOrBadInput(...)` — missing cardgroup ⇒ `BAD_USER_INPUT` on `cardgroupId`; a cardgroup owned by another user ⇒ `UNAUTHENTICATED`.
+
+Authentication is checked first, so an unauthenticated caller receives `UNAUTHENTICATED`
+even when the requested cardgroup does not exist. That ordering keeps anonymous callers
+from using either query as an existence oracle over cardgroup ids.
+
 ### Integration tests
 
 `backend/cmd/server/main_test.go` contains `TestGraphQL_Me_Anonymous`, `TestGraphQL_Me_Authenticated`, and `TestGraphQL_UpdateProfile_Authenticated`. These tests use the testcontainer Postgres, a local JWKS HTTP server (`jwtFixture`), and ECDSA-signed JWTs. Future GraphQL integration tests should reuse the same `jwtFixture` + `startServer` helpers rather than re-inventing the JWKS mock.
@@ -347,18 +360,9 @@ and the two error codes the caller must handle. Keep descriptions result-oriente
 calls). Do not list error codes only in the resolver body — that surface is invisible
 to client code-generators and frontend teams reading the schema. The queue composition
 behind the description is documented in
-[`docs/backend/ddd-patterns/discovery-first-due-ordering.md`](backend/ddd-patterns/discovery-first-due-ordering.md).
-
-Guard order for `learnNextDueCards` and `practiceTodaysCards` (both run the shared
-`authorizeCardgroupForLearn` in `backend/internal/usecase/learn.go` before touching
-the card repository):
-
-1. `requireCallerSub(auth.UserFrom(ctx))` — nil caller or empty `Sub` ⇒ `UNAUTHENTICATED`.
-2. `authorizeCardgroupOrBadInput(...)` — missing cardgroup ⇒ `BAD_USER_INPUT` on `cardgroupId`; a cardgroup owned by another user ⇒ `UNAUTHENTICATED`.
-
-Authentication is checked first, so an unauthenticated caller receives `UNAUTHENTICATED`
-even when the requested cardgroup does not exist. That ordering keeps anonymous callers
-from using either query as an existence oracle over cardgroup ids.
+[`docs/backend/ddd-patterns/discovery-first-due-ordering.md`](backend/ddd-patterns/discovery-first-due-ordering.md),
+and the order in which those two error codes are decided in
+[Learn and practice queries](#learn-and-practice-queries).
 
 **Dedupe is asymmetric: `importCards` dedupes, `validateCardImport` does not.** `importCards` runs dedup and surfaces dropped rows as `CardImportError` entries with `Front`/`Back` populated. `validateCardImport` runs `textdic.Process` directly and surfaces only parser-level syntax errors — those entries never carry `Front`/`Back`. The resolver mapping site for `validateCardImport` (in `backend/graph/resolver/card_import.resolvers.go`) therefore deliberately omits `nilIfEmpty(e.Front)` calls; there is nothing to map. If a future change adds dedup to `validateCardImport`, the resolver mapping site must be updated symmetrically with `importCards`.
 

--- a/schema/card.graphql
+++ b/schema/card.graphql
@@ -128,6 +128,7 @@ extend type Query {
   Next batch of cards for a learning session: randomly sampled never-seen cards interleaved 4:1 with review cards due today (JST); among review cards, those you failed on their last review or whose memory stability is still below the learned threshold are served first, and other due cards fill the remaining slots. Returns an empty list when the cardgroup has no eligible cards.
   Limit defaults to 20 (clamped to 100). Returns UNAUTHENTICATED if the caller does not own
   the cardgroup; BAD_USER_INPUT if the cardgroup does not exist.
+  A limit of zero, a negative limit, and an explicit null are all treated as omitted and fall back to the default.
   """
   learnNextDueCards(cardgroupId: ID!, limit: Int = 20): [Card!]!
   """
@@ -137,6 +138,7 @@ extend type Query {
   Order is randomized per fetch. Limit defaults to 100 (clamped to 100).
   Returns UNAUTHENTICATED if the caller does not own the cardgroup;
   BAD_USER_INPUT if the cardgroup does not exist.
+  A limit of zero, a negative limit, and an explicit null are all treated as omitted and fall back to the default.
   """
   practiceTodaysCards(cardgroupId: ID!, limit: Int = 100): [Card!]!
   """


### PR DESCRIPTION
## Summary

The formal-verification round machine-checked the learning-domain API docs against the schema and the shipped code and found four statements that no longer describe reality: `docs/backend-graphql.md` named the `>= 0.95` band "In While" (the constant is `service.ModeMastered`), typed `performanceMode` as a raw `0..4` integer (the wire field is the `SwipePerformanceMode` enum), quoted a `learnNextDueCards` docstring that had already been rewritten in `schema/card.graphql`, and left both learn/practice docstrings silent on the degenerate-`limit` and guard-order edges. This change corrects the doc statements and appends the missing degenerate-limit sentence to both schema docstrings, so a client author reading only the schema learns that `limit: 0`, a negative limit, and an explicit `null` all fall back to the default rather than returning an empty list. Behaviour is untouched — docs and schema descriptions only.

## Changes

### Schema

- `schema/card.graphql` — both `learnNextDueCards` and `practiceTodaysCards` docstrings gain `A limit of zero, a negative limit, and an explicit null are all treated as omitted and fall back to the default.` This matches the code: a nil `*int` becomes `n = 0` and `clampLimit` / `clampPracticeLimit` promote any `limit <= 0` to the default (20 for learn, 100 for practice, which is also its cap).

### Docs

- `docs/backend-graphql.md` — `performanceMode` is now described as the `SwipePerformanceMode` enum (`DIFFICULT`, `DEFAULT`, `GOOD`, `EASY`, `MASTERED`) corresponding in that order to the calculator's internal `0..4`, with `toSwipePerformanceModeModel` in `backend/graph/resolver/mapper.go` named as the order-preserving conversion. The mode table below it keeps the internal integers.
- `docs/backend-graphql.md` — the `4` row's label changes from `In While` to `Mastered`, matching `service.ModeMastered`.
- `docs/backend-graphql.md` — new `### Learn and practice queries` section states the guard order both queries share via `authorizeCardgroupForLearn`: `requireCallerSub` first (nil caller or empty `Sub` ⇒ `UNAUTHENTICATED`), then `authorizeCardgroupOrBadInput` (missing cardgroup ⇒ `BAD_USER_INPUT` on `cardgroupId`; found-but-foreign cardgroup ⇒ `UNAUTHENTICATED`). Because authentication wins, an anonymous caller cannot use either query as an existence oracle over cardgroup ids.
- `docs/backend-graphql.md` — the quoted `learnNextDueCards` docstring in the schema-descriptions-as-contract section is replaced with the current `schema/card.graphql` text verbatim (rescue/filler wording plus the new degenerate-limit sentence). The `discovery-first-due-ordering.md` pointer that used to live inside the quote moves into the surrounding prose, alongside a link to the new guard-order section, and the prose bullet list now mentions the degenerate-limit fallback.

## Test plan

- [ ] `go build ./... && go vet ./... && go test ./...` — green (2243 tests, 26 packages)
- [ ] `go tool gqlgen generate` — no tracked diff (`backend/graph/generated/` is gitignored; descriptions only, no resolver signature change)
- [ ] `graphql-codegen --config codegen.ts` then `tsc --noEmit` — clean, no tracked diff (`frontend/src/generated/` is gitignored)
- [ ] `grep -rn 'In While\|integer in the range' docs/ schema/ backend/ frontend/src` — 0 hits
- [ ] Quoted docstring in `docs/backend-graphql.md` matches `schema/card.graphql:127-133` verbatim
- [ ] Language-policy gates: `perl -CSD` CJK scan and `grep -nE "PR[0-9]+"` over both changed files — 0 hits

## Notes

- No Go, TypeScript, or resolver code changes, so no e2e spec is affected; Playwright was not run (it needs a live Supabase + backend stack).
- The rescue/filler wording in the `learnNextDueCards` docstring was already current on `main`; only the copy quoted inside `docs/backend-graphql.md` was stale, so the schema side of that correction is a no-op.

Closes #989
