### PR TITLE
docs(fsrs): clock-skew clamp, unseen-card rule, and window invariants

### DIFF
--- a/backend/internal/domain/due_card.go
+++ b/backend/internal/domain/due_card.go
@@ -4,17 +4,22 @@ import "time"
 
 // DueCard is a Card paired with the viewer's FSRS state for queueing decisions.
 //
-// Phase is FSRSPhaseNew when the viewer has no user_card_fsrs row for the card,
-// in which case Due is the card's created_at as a stable substitute.
+// A card is unseen exactly when no user_card_fsrs row exists for the (user,
+// card) pair. The repository synthesizes such a row as Phase = FSRSPhaseNew and
+// Due = Card.CreatedAt, a stable display placeholder that keeps the read-model
+// orderable. The implication runs one way only: an unseen card always carries
+// Due == Card.CreatedAt, but a reviewed card whose scheduled Due happens to land
+// on its CreatedAt satisfies the same equality. Test Phase == FSRSPhaseNew (or
+// the FSRS row itself) for unseen; never the Due/CreatedAt equality.
 //
 // DueCard is not an aggregate; it is a view-level value shared between the
 // repository and OrderingPolicy. It lives in the domain package because the
 // ordering policy is domain logic and DueCard is its input.
 //
 // Card must not be nil; downstream consumers (OrderingPolicy.Apply) dereference
-// it unconditionally. The Phase invariant (FSRSPhaseNew ↔ Due == Card.CreatedAt)
-// is established by the repository and is not enforced at the domain layer
-// today; new construction sites must reproduce it.
+// it unconditionally. The Phase/Due synthesis is established by the repository
+// and is not enforced at the domain layer today; new construction sites must
+// reproduce it.
 type DueCard struct {
 	Card  *Card
 	Phase FSRSPhase

--- a/docs/backend/ddd-patterns/aggregate-behaviour-method.md
+++ b/docs/backend/ddd-patterns/aggregate-behaviour-method.md
@@ -82,6 +82,32 @@ The usecase passes the concrete scheduler; the aggregate updates its own fields.
 `UpdatedAt` is always stamped, and the aggregate's invariants are maintained in
 one place.
 
+#### The scheduler clamps a backward-reading clock
+
+`ApplyRating` hands `now` to the scheduler unchanged, and the scheduler clamps it:
+`service.FSRSScheduler.Apply` raises `now` to `state.LastReview` whenever the
+incoming timestamp reads earlier than the stored last review. The guard is the
+`if now.Before(state.LastReview)` block at the top of `Apply` in
+[`backend/internal/domain/service/fsrs_scheduler.go`](../../../backend/internal/domain/service/fsrs_scheduler.go).
+
+The clamp is a domain safety rule, not an implementation convenience. A backward
+clock step — an NTP correction, cross-instance skew — makes the scheduling
+library's elapsed-days float negative, and Go's conversion of a negative float to
+`uint64` is implementation-dependent (Go spec, Conversions). The corrupted count
+is written straight back into the persisted scheduling state, so one skewed
+request permanently damages that card's schedule. Clamping keeps elapsed time
+non-negative, at the cost of treating a backward-skewed review as if it happened
+at the instant of the previous one. Any reimplementation of the `ApplyRating`
+path must reproduce it.
+
+**A clamped apply leaves `State.LastReview > UpdatedAt`.** `ApplyRating` stamps
+`u.UpdatedAt = now` with the *unclamped* argument while the state it stores back
+carries the *clamped* `LastReview`. The aggregate therefore holds
+`State.LastReview > UpdatedAt` until the next non-skewed swipe. Nothing
+user-visible reads that ordering — the queue predicates compare `last_review` and
+`due` against learn-day boundaries, never against `updated_at` — so the inversion
+is tolerated rather than normalised.
+
 ### Single-field aggregate mutation (`Cardgroup.Rename`, `Card.UpdateFront`/`UpdateBack`) (issues #212, #213)
 
 **Before**: `CardgroupUsecase.Update` and `CardUsecase.Update` mutated the

--- a/docs/backend/ddd-patterns/aggregate-behaviour-method.md
+++ b/docs/backend/ddd-patterns/aggregate-behaviour-method.md
@@ -100,13 +100,18 @@ non-negative, at the cost of treating a backward-skewed review as if it happened
 at the instant of the previous one. Any reimplementation of the `ApplyRating`
 path must reproduce it.
 
-**A clamped apply leaves `State.LastReview > UpdatedAt`.** `ApplyRating` stamps
-`u.UpdatedAt = now` with the *unclamped* argument while the state it stores back
-carries the *clamped* `LastReview`. The aggregate therefore holds
-`State.LastReview > UpdatedAt` until the next non-skewed swipe. Nothing
-user-visible reads that ordering — the queue predicates compare `last_review` and
-`due` against learn-day boundaries, never against `updated_at` — so the inversion
-is tolerated rather than normalised.
+**A clamped apply leaves `State.LastReview > UpdatedAt` in the in-memory
+aggregate.** `ApplyRating` stamps `u.UpdatedAt = now` with the *unclamped*
+argument while the state it stores back carries the *clamped* `LastReview`, so
+the loaded aggregate holds the inversion for the rest of the request. It does not
+travel to the row: a clamp can only fire against an existing FSRS row (a brand-new
+one is created with `LastReview = now`), so the upsert always takes the conflict
+branch, whose `DoUpdates` assigns `updated_at = now()` — and the
+`trg_user_card_fsrs_set_updated_at` BEFORE UPDATE trigger assigns `now()` again.
+The persisted `updated_at` is therefore the database clock, never the skewed
+aggregate value. The inversion is tolerated rather than normalised because
+nothing reads that ordering: the queue predicates compare `last_review` and `due`
+against learn-day boundaries, never against `updated_at`.
 
 ### Single-field aggregate mutation (`Cardgroup.Rename`, `Card.UpdateFront`/`UpdateBack`) (issues #212, #213)
 

--- a/docs/backend/ddd-patterns/discovery-first-due-ordering.md
+++ b/docs/backend/ddd-patterns/discovery-first-due-ordering.md
@@ -107,6 +107,16 @@ deterministic while the database does the sampling:
   midnight does not reappear in today's queue. The `<` vs `<=` choice is part of
   the contract and is pinned by an exact-boundary fixture; see
   [exact-boundary fixture for strict time-cutoff predicates](../library-gotchas/strict-cutoff-boundary-fixture-and-mutation-proof.md).
+- **Persisted FSRS rows are complete, and the rating is applied before the row is
+  written.** The `user_card_fsrs` schema declares `state`, `due`, and
+  `last_review` `NOT NULL`, and `SwipeUsecase.HandleSwipe` calls `ApplyRating`
+  before `UpsertTx` persists the aggregate. Every stored row therefore carries a
+  scheduled state produced by the long-term scheduler, which never emits a New
+  phase. The rescue and filler windows consequently cannot admit a phase-New row,
+  they stay disjoint from the new-card window (`ucs.due IS NULL`), and the
+  repository's window-derived `Rescue` flag is well-defined. Relaxing either NOT
+  NULL, or writing the row before applying the rating, would let a card satisfy
+  none of the three windows and vanish from every queue with no error surfaced.
 
 ## Trade-off
 
@@ -131,3 +141,7 @@ learn ordering — new cards are sampled randomly, not walked in document order.
   `findDueCardsOn`, `dueRowsOn` (the three-window selection).
 - `backend/internal/usecase/learn.go` — `LearnUsecase.NextDueCards`
   (interleave invocation and per-session truncation).
+- `backend/internal/usecase/swipe.go` — `SwipeUsecase.HandleSwipe`
+  (`ApplyRating` before `UpsertTx`).
+- `backend/internal/database/migrations/20260430080000_initial_schema.up.sql` —
+  the `user_card_fsrs` NOT NULL column set.

--- a/docs/backend/ddd-patterns/discovery-first-due-ordering.md
+++ b/docs/backend/ddd-patterns/discovery-first-due-ordering.md
@@ -110,13 +110,27 @@ deterministic while the database does the sampling:
 - **Persisted FSRS rows are complete, and the rating is applied before the row is
   written.** The `user_card_fsrs` schema declares `state`, `due`, and
   `last_review` `NOT NULL`, and `SwipeUsecase.HandleSwipe` calls `ApplyRating`
-  before `UpsertTx` persists the aggregate. Every stored row therefore carries a
-  scheduled state produced by the long-term scheduler, which never emits a New
-  phase. The rescue and filler windows consequently cannot admit a phase-New row,
-  they stay disjoint from the new-card window (`ucs.due IS NULL`), and the
-  repository's window-derived `Rescue` flag is well-defined. Relaxing either NOT
-  NULL, or writing the row before applying the rating, would let a card satisfy
-  none of the three windows and vanish from every queue with no error surfaced.
+  before `UpsertTx` persists the aggregate. Each column carries a different part
+  of the partition, and each fails differently if its NOT NULL is relaxed:
+  - **`last_review`** is the one whose NULL hides a card completely. Rescue and
+    filler test `ucs.last_review < ?` and practice tests `ucs.last_review >= ?`,
+    all unknown for NULL, while the new-card window is closed to the row because
+    its `due` is not NULL. The card then satisfies no window and vanishes from
+    every queue with no error surfaced.
+  - **`due`** does not hide the row; it moves it. Rescue and filler guard on
+    `ucs.due IS NOT NULL` while the new-card window is exactly `ucs.due IS NULL`,
+    so an already-reviewed card would be re-served as unseen and the new/review
+    disjointness the interleave relies on would break.
+  - **`state`** appears in no window predicate at all; it decides how a fetched
+    row is mapped. `dueCardsFromRows` leaves `Phase` at its `FSRSPhaseNew`
+    default when the column scans NULL, so a rescue or filler row would reach
+    `OrderingPolicy` claiming to be a new card and be interleaved as one.
+
+  The write order carries the rest: applying the rating first means every stored
+  row holds a state produced by the long-term scheduler, which never emits a New
+  phase, so no review-window row can be phase-New and the repository's
+  window-derived `Rescue` flag stays well-defined. Writing the row before applying
+  the rating would break that.
 
 ## Trade-off
 

--- a/docs/backend/ddd-patterns/view-level-value-in-domain-package.md
+++ b/docs/backend/ddd-patterns/view-level-value-in-domain-package.md
@@ -30,21 +30,29 @@ import "time"
 
 // DueCard is a Card paired with the viewer's FSRS state for queueing decisions.
 //
-// Phase is FSRSPhaseNew when the viewer has no user_card_fsrs row for the card,
-// in which case Due is the card's created_at as a stable substitute.
+// A card is unseen exactly when no user_card_fsrs row exists for the (user,
+// card) pair. The repository synthesizes such a row as Phase = FSRSPhaseNew and
+// Due = Card.CreatedAt, a stable display placeholder that keeps the read-model
+// orderable. The implication runs one way only: an unseen card always carries
+// Due == Card.CreatedAt, but a reviewed card whose scheduled Due happens to land
+// on its CreatedAt satisfies the same equality. Test Phase == FSRSPhaseNew (or
+// the FSRS row itself) for unseen; never the Due/CreatedAt equality.
 //
 // DueCard is not an aggregate; it is a view-level value shared between the
 // repository and OrderingPolicy. It lives in the domain package because the
 // ordering policy is domain logic and DueCard is its input.
 //
 // Card must not be nil; downstream consumers (OrderingPolicy.Apply) dereference
-// it unconditionally. The Phase invariant (FSRSPhaseNew ↔ Due == Card.CreatedAt)
-// is established by the repository and is not enforced at the domain layer
-// today; new construction sites must reproduce it.
+// it unconditionally. The Phase/Due synthesis is established by the repository
+// and is not enforced at the domain layer today; new construction sites must
+// reproduce it.
 type DueCard struct {
     Card  *Card
     Phase FSRSPhase
     Due   time.Time
+    // Rescue is set by the repository for rows fetched by the rescue window;
+    // OrderingPolicy must not move a non-rescue (filler) card ahead of a rescue card.
+    Rescue bool
 }
 ```
 
@@ -61,10 +69,9 @@ read-model always carries a stable, orderable timestamp. It is a display
 placeholder, not an identity, and the implication runs one way only: an unseen row
 always gets `Due == CreatedAt`, but a reviewed card whose scheduled `Due` happens
 to land on its `CreatedAt` satisfies the same equality while having an FSRS row.
-The `FSRSPhaseNew ↔ Due == Card.CreatedAt` shorthand in the docstring above holds
-in the forward direction only; treating the equality as an unseen test
-misclassifies that coincidence. Branch on `Phase == FSRSPhaseNew` (which the
-repository sets from the same join miss) or query the FSRS row directly.
+Treating the equality as an unseen test misclassifies that coincidence. Branch on
+`Phase == FSRSPhaseNew` (which the repository sets from the same join miss) or
+query the FSRS row directly.
 
 `OrderingPolicy.Apply` accepts `[]DueCard` and returns `[]*Card` — the
 read-model is the *input* type, the aggregate is the *output*. The
@@ -106,5 +113,5 @@ single trust-boundary parse exists for the read-model.
   read-model docstring.
 - `backend/internal/domain/service/due_card_ordering.go` — `OrderingPolicy.Apply`
   consumes `[]DueCard`.
-- `backend/internal/repository/card.go` — `findDueCardsOn` constructs
+- `backend/internal/repository/card_due.go` — `findDueCardsOn` constructs
   `DueCard` from the LEFT JOIN result.

--- a/docs/backend/ddd-patterns/view-level-value-in-domain-package.md
+++ b/docs/backend/ddd-patterns/view-level-value-in-domain-package.md
@@ -48,6 +48,24 @@ type DueCard struct {
 }
 ```
 
+### "Unseen" is "no FSRS row", not `Due == CreatedAt`
+
+A card is unseen for a viewer exactly when **no `user_card_fsrs` row exists for
+that (user, card) pair**. That is the definition consumers must test against; the
+repository expresses it as the LEFT JOIN miss — `ucs.due IS NULL` in the new-card
+window of `findDueCardsOn`, and a nil `State` column when mapping rows into
+`DueCard`.
+
+`Due = Card.CreatedAt` is what the repository *synthesizes* for such a row so the
+read-model always carries a stable, orderable timestamp. It is a display
+placeholder, not an identity, and the implication runs one way only: an unseen row
+always gets `Due == CreatedAt`, but a reviewed card whose scheduled `Due` happens
+to land on its `CreatedAt` satisfies the same equality while having an FSRS row.
+The `FSRSPhaseNew ↔ Due == Card.CreatedAt` shorthand in the docstring above holds
+in the forward direction only; treating the equality as an unseen test
+misclassifies that coincidence. Branch on `Phase == FSRSPhaseNew` (which the
+repository sets from the same join miss) or query the FSRS row directly.
+
 `OrderingPolicy.Apply` accepts `[]DueCard` and returns `[]*Card` — the
 read-model is the *input* type, the aggregate is the *output*. The
 repository builds `DueCard` values from a LEFT JOIN of `cards` and
@@ -60,7 +78,7 @@ construct them.
 |---|---|
 | Type is consumed by a domain service (`domain/service/*.go`) | Keep in `domain/` |
 | Type is consumed only by adapters (repository, GraphQL resolver) | Extract to `readmodel/` or keep in `repository/` |
-| Type carries domain-level invariants (e.g. `Phase ↔ Due` coupling) | Keep in `domain/` so the invariant comment is co-located |
+| Type carries domain-level invariants (e.g. the `Phase → Due` synthesis) | Keep in `domain/` so the invariant comment is co-located |
 | Type is a thin projection with no domain semantics | Adapter-side DTO is fine |
 
 The first row applies here: `OrderingPolicy.Apply` is the consumer and lives
@@ -76,7 +94,8 @@ admits both arrows.
 relationship is established by the repository's LEFT JOIN logic, not by a
 domain-side validator. The docstring is the load-bearing contract. New
 construction sites (typically test fixtures and any future migration paths)
-must read the docstring and reproduce the invariant. This is the same
+must read the docstring and reproduce the synthesis — a row with no FSRS state
+gets `Phase = FSRSPhaseNew` and `Due = Card.CreatedAt`. This is the same
 discipline as [zero-value docstring on string newtypes](zero-value-docstring-on-string-newtypes.md),
 applied to a struct value: a comment, not a compiler check, because no
 single trust-boundary parse exists for the read-model.


### PR DESCRIPTION
## Summary

A formal pass over the FSRS state machine and the learn/practice day partition found the shipped behaviour correct but three of its load-bearing rules undocumented or documented wrongly: the scheduler's backward-clock clamp is invisible in the design chapter that walks `ApplyRating`, the `DueCard` docstring asserted a two-way `FSRSPhaseNew ↔ Due == CreatedAt` equivalence that only holds in one direction, and nothing recorded that the three-window queue partition depends on `user_card_fsrs.state`/`due`/`last_review` being `NOT NULL` and on `ApplyRating` running before `UpsertTx`. This change is documentation and comments only — no production behaviour changes. It leaves a reader who reimplements the `ApplyRating` path or relaxes a schema constraint with the reasons those choices are not free.

## Changes

### Clock-skew clamp (`docs/backend/ddd-patterns/aggregate-behaviour-method.md`)

- New `#### The scheduler clamps a backward-reading clock` subsection under the `UserCardFSRS.ApplyRating()` walkthrough: `service.FSRSScheduler.Apply` raises `now` to `state.LastReview` when the incoming timestamp reads earlier, because a negative elapsed-days float reaches an implementation-dependent float-to-`uint64` conversion and the corrupted count is written back into the persisted schedule.
- Documents the transient inversion the clamp leaves: `ApplyRating` stamps `u.UpdatedAt = now` with the *unclamped* argument while storing the *clamped* `LastReview`, so the in-memory aggregate holds `State.LastReview > UpdatedAt` for the rest of the request.
- Explains why the inversion never reaches the row: a clamp can only fire against an existing FSRS row, so `UpsertTx` always takes the conflict branch, whose `DoUpdates` assigns `updated_at = now()` and whose `trg_user_card_fsrs_set_updated_at` BEFORE UPDATE trigger assigns `now()` again. The persisted `updated_at` is the database clock; no queue predicate reads that ordering anyway.

### Unseen-card definition (`docs/backend/ddd-patterns/view-level-value-in-domain-package.md`, `backend/internal/domain/due_card.go`)

- Rewrites the `DueCard` docstring in both the chapter's quoted snippet and the real source: a card is unseen exactly when no `user_card_fsrs` row exists for the (user, card) pair; `Due = Card.CreatedAt` is a synthesized display placeholder, not an identity. A reviewed card whose scheduled `Due` lands on its `CreatedAt` satisfies the same equality, so consumers must branch on `Phase == FSRSPhaseNew` or the FSRS row, never on the equality.
- New "Unseen is no FSRS row, not `Due == CreatedAt`" section spelling out how the repository expresses the definition (`ucs.due IS NULL` in the new-card window, nil `State` column when mapping rows).
- Syncs the chapter's quoted struct with the current `DueCard`, which carries the `Rescue` field; retitles the decision-table row from the `Phase ↔ Due` coupling to the one-way `Phase → Due` synthesis; repoints the reference from `backend/internal/repository/card.go` to `backend/internal/repository/card_due.go`, where `findDueCardsOn` now lives.

### Window NOT NULL invariant (`docs/backend/ddd-patterns/discovery-first-due-ordering.md`)

- New contract bullet stating the two preconditions the partition rests on: the `user_card_fsrs` schema declares `state`, `due`, and `last_review` `NOT NULL`, and `SwipeUsecase.HandleSwipe` calls `ApplyRating` before `UpsertTx`.
- Scopes the failure mode per column rather than lumping them together, because each breaks differently: a NULL `last_review` makes rescue/filler (`ucs.last_review < ?`) and practice (`ucs.last_review >= ?`) all evaluate unknown while the new-card window (`ucs.due IS NULL`) is closed to the row, so the card vanishes from every queue silently; a NULL `due` does not hide the row but moves it into the new-card window, re-serving a reviewed card as unseen; a NULL `state` appears in no predicate at all but makes `dueCardsFromRows` leave `Phase` at its `FSRSPhaseNew` default, so a rescue or filler row reaches `OrderingPolicy` claiming to be new.
- Records what the write order buys: applying the rating first means every stored row holds a state from the long-term scheduler (`EnableShortTerm = false`), which never emits a New phase, so no review-window row can be phase-New and the repository's window-derived `Rescue` flagging stays well-defined.
- Adds `backend/internal/usecase/swipe.go` and the initial-schema migration to the chapter's Reference list.

## Test plan

- [ ] `go build ./...` — success
- [ ] `go vet ./...` — no issues
- [ ] `go test ./...` — 2243 passed across 26 packages
- [ ] CJK gate over the four changed files (`perl -CSD`) — no matches
- [ ] `grep -rnE "PR[0-9]+" backend/internal/domain/due_card.go docs/backend/ddd-patterns/` — no matches
- [ ] Every symbol cited in the new prose exists on this branch: the `if now.Before(state.LastReview)` clamp in `internal/domain/service/fsrs_scheduler.go`, `u.UpdatedAt = now` in `internal/domain/user_card_fsrs.go`, `"updated_at": gorm.Expr("now()")` in `internal/repository/user_card_fsrs.go`, the three window predicates and `dueCardsFromRows` in `internal/repository/card_due.go`, the `NOT NULL` column set and `trg_user_card_fsrs_set_updated_at` in `internal/database/migrations/20260430080000_initial_schema.up.sql`.

## Notes

- The only non-doc file touched is the `DueCard` docstring in `backend/internal/domain/due_card.go`; no statement, signature, or schema changes, so no test was added or updated and no frontend or e2e surface is affected.
- The per-column split of the NOT NULL failure modes replaces the single lumped paragraph the issue sketched: review showed the three columns fail in visibly different ways (vanish / re-serve as unseen / mis-phase), and one shared sentence hid that.

Closes #990
