### PR TITLE
feat(stats): expose knownReviewCount and gate retention/lapse tiles

### DIFF
--- a/backend/graph/resolver/mapper.go
+++ b/backend/graph/resolver/mapper.go
@@ -275,11 +275,12 @@ func toSwipePerformanceModeModel(mode int) model.SwipePerformanceMode {
 // diagnostic snapshot.
 func toPerformanceMetricsModel(m service.PerformanceMetrics) *model.PerformanceMetrics {
 	return &model.PerformanceMetrics{
-		SuccessRate:   m.SuccessRate,
-		AvgDifficulty: m.AvgDifficulty,
-		RetentionRate: m.RetentionRate,
-		StudyStreak:   m.StudyStreak,
-		LapseRate:     m.LapseRate,
-		ReviewCount:   m.ReviewCount,
+		SuccessRate:      m.SuccessRate,
+		AvgDifficulty:    m.AvgDifficulty,
+		RetentionRate:    m.RetentionRate,
+		StudyStreak:      m.StudyStreak,
+		LapseRate:        m.LapseRate,
+		ReviewCount:      m.ReviewCount,
+		KnownReviewCount: m.KnownReviewCount,
 	}
 }

--- a/backend/graph/resolver/stats_resolver_test.go
+++ b/backend/graph/resolver/stats_resolver_test.go
@@ -277,7 +277,7 @@ func ctxWithCardLoaderError(base context.Context, loadErr error) context.Context
 	return loader.WithContext(base, loaders)
 }
 
-const myLearningStatsDiagnosticQuery = `{"query":"{ myLearningStats { mastery { totalStudied } performanceWindows { days365 { retentionRate successRate lapseRate studyStreak reviewCount avgDifficulty } days30 { retentionRate successRate lapseRate studyStreak reviewCount avgDifficulty } days7 { retentionRate successRate lapseRate studyStreak reviewCount avgDifficulty } } strugglingCards { card { id front } lapses stability } } }"}`
+const myLearningStatsDiagnosticQuery = `{"query":"{ myLearningStats { mastery { totalStudied } performanceWindows { days365 { retentionRate successRate lapseRate studyStreak reviewCount knownReviewCount avgDifficulty } days30 { retentionRate successRate lapseRate studyStreak reviewCount knownReviewCount avgDifficulty } days7 { retentionRate successRate lapseRate studyStreak reviewCount knownReviewCount avgDifficulty } } strugglingCards { card { id front } lapses stability } } }"}`
 
 // TestMyLearningStats_PerformanceAndStrugglingCards verifies the diagnostic half
 // of the response: all three performance snapshots map every metric field, and
@@ -290,9 +290,9 @@ func TestMyLearningStats_PerformanceAndStrugglingCards(t *testing.T) {
 		result: &usecase.LearningStatsResult{
 			Mastery: service.MasteryBreakdown{TotalStudied: 3},
 			Windows: service.WindowedMetrics{
-				Days365: service.PerformanceMetrics{SuccessRate: 0.81, AvgDifficulty: 0.41, RetentionRate: 0.91, StudyStreak: 5, LapseRate: 0.11, ReviewCount: 365},
-				Days30:  service.PerformanceMetrics{SuccessRate: 0.82, AvgDifficulty: 0.42, RetentionRate: 0.92, StudyStreak: 5, LapseRate: 0.12, ReviewCount: 30},
-				Days7:   service.PerformanceMetrics{SuccessRate: 0.83, AvgDifficulty: 0.43, RetentionRate: 0.93, StudyStreak: 5, LapseRate: 0.13, ReviewCount: 7},
+				Days365: service.PerformanceMetrics{SuccessRate: 0.81, AvgDifficulty: 0.41, RetentionRate: 0.91, StudyStreak: 5, LapseRate: 0.11, ReviewCount: 365, KnownReviewCount: 300},
+				Days30:  service.PerformanceMetrics{SuccessRate: 0.82, AvgDifficulty: 0.42, RetentionRate: 0.92, StudyStreak: 5, LapseRate: 0.12, ReviewCount: 30, KnownReviewCount: 25},
+				Days7:   service.PerformanceMetrics{SuccessRate: 0.83, AvgDifficulty: 0.43, RetentionRate: 0.93, StudyStreak: 5, LapseRate: 0.13, ReviewCount: 7, KnownReviewCount: 0},
 			},
 			StrugglingCards: []service.StrugglingCard{
 				{CardID: "card-1", Lapses: 5, Stability: 2.5},
@@ -323,9 +323,9 @@ func TestMyLearningStats_PerformanceAndStrugglingCards(t *testing.T) {
 		t.Fatalf("expected performanceWindows, got nil; response: %v", resp)
 	}
 	wants := map[string]map[string]float64{
-		"days365": {"retentionRate": 0.91, "successRate": 0.81, "lapseRate": 0.11, "avgDifficulty": 0.41, "studyStreak": 5, "reviewCount": 365},
-		"days30":  {"retentionRate": 0.92, "successRate": 0.82, "lapseRate": 0.12, "avgDifficulty": 0.42, "studyStreak": 5, "reviewCount": 30},
-		"days7":   {"retentionRate": 0.93, "successRate": 0.83, "lapseRate": 0.13, "avgDifficulty": 0.43, "studyStreak": 5, "reviewCount": 7},
+		"days365": {"retentionRate": 0.91, "successRate": 0.81, "lapseRate": 0.11, "avgDifficulty": 0.41, "studyStreak": 5, "reviewCount": 365, "knownReviewCount": 300},
+		"days30":  {"retentionRate": 0.92, "successRate": 0.82, "lapseRate": 0.12, "avgDifficulty": 0.42, "studyStreak": 5, "reviewCount": 30, "knownReviewCount": 25},
+		"days7":   {"retentionRate": 0.93, "successRate": 0.83, "lapseRate": 0.13, "avgDifficulty": 0.43, "studyStreak": 5, "reviewCount": 7, "knownReviewCount": 0},
 	}
 	for name, want := range wants {
 		perf, _ := windows[name].(map[string]any)

--- a/backend/internal/domain/service/user_performance.go
+++ b/backend/internal/domain/service/user_performance.go
@@ -167,6 +167,13 @@ type PerformanceMetrics struct {
 	StudyStreak   int
 	LapseRate     float64
 	ReviewCount   int
+	// KnownReviewCount is the denominator behind RetentionRate and LapseRate:
+	// the number of swipes in the window that passed the known-card gate. When
+	// the window has swipes but none of them pass the gate, both rates are 0;
+	// when the window holds no swipes at all, RetentionRate instead carries the
+	// neutral 0.5 placeholder. Either way, consumers must treat a 0 count as "no
+	// eligible reviews" rather than as a measured rate.
+	KnownReviewCount int
 }
 
 const (
@@ -246,12 +253,13 @@ func ComputeMetrics(swipes []domain.SwipeRecord, now time.Time) PerformanceMetri
 	}
 
 	return PerformanceMetrics{
-		SuccessRate:   float64(successes) / float64(len(swipes)),
-		AvgDifficulty: difficultySum / float64(len(swipes)),
-		RetentionRate: ratio(onTimeRecalls, reviews),
-		StudyStreak:   studyStreak(daysSeen, now),
-		LapseRate:     ratio(lapses, reviews),
-		ReviewCount:   len(swipes),
+		SuccessRate:      float64(successes) / float64(len(swipes)),
+		AvgDifficulty:    difficultySum / float64(len(swipes)),
+		RetentionRate:    ratio(onTimeRecalls, reviews),
+		StudyStreak:      studyStreak(daysSeen, now),
+		LapseRate:        ratio(lapses, reviews),
+		ReviewCount:      len(swipes),
+		KnownReviewCount: reviews,
 	}
 }
 

--- a/backend/internal/domain/service/user_performance_test.go
+++ b/backend/internal/domain/service/user_performance_test.go
@@ -301,6 +301,49 @@ func TestComputeMetrics(t *testing.T) {
 	}
 }
 
+// TestComputeMetrics_KnownReviewCount pins the denominator behind RetentionRate
+// and LapseRate as a separate wire field. A window can carry swipes while no
+// swipe passes the known-card gate, and the two rates are then 0 for lack of a
+// population rather than for measured failure — consumers distinguish the two
+// cases by KnownReviewCount, not by ReviewCount.
+func TestComputeMetrics_KnownReviewCount(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 4, 30, 3, 0, 0, 0, time.UTC)
+
+	t.Run("swipes without gated reviews leave the known-review count at zero", func(t *testing.T) {
+		t.Parallel()
+
+		got := ComputeMetrics([]domain.SwipeRecord{
+			// New-card swipe and a Learning->Easy graduation: neither is a review
+			// of an already-learned card.
+			swipeBefore(domain.RatingAgain, now, state(5, 0, 0, domain.FSRSPhaseLearning), domain.FSRSPhaseNew, 0),
+			swipeBefore(domain.RatingEasy, now, state(5, 0, 1, domain.FSRSPhaseReview), domain.FSRSPhaseLearning, 0),
+		}, now)
+
+		require.Equal(t, 2, got.ReviewCount)
+		require.Equal(t, 0, got.KnownReviewCount)
+		require.Zero(t, got.RetentionRate)
+		require.Zero(t, got.LapseRate)
+	})
+
+	t.Run("known-review count equals the gated denominator", func(t *testing.T) {
+		t.Parallel()
+
+		got := ComputeMetrics([]domain.SwipeRecord{
+			swipeBefore(domain.RatingAgain, now, stateWithLapses(5, 3, 0, domain.FSRSPhaseRelearning, 1), domain.FSRSPhaseReview, 7),
+			swipeBefore(domain.RatingHard, now, state(5, 4, 8, domain.FSRSPhaseReview), domain.FSRSPhaseReview, 7),
+			swipeBefore(domain.RatingEasy, now, state(5, 9, 10, domain.FSRSPhaseReview), domain.FSRSPhaseReview, 7),
+			swipeBefore(domain.RatingEasy, now, state(5, 0, 1, domain.FSRSPhaseReview), domain.FSRSPhaseLearning, 0),
+		}, now)
+
+		require.Equal(t, 4, got.ReviewCount)
+		require.Equal(t, 3, got.KnownReviewCount)
+		require.InDelta(t, 1.0/3.0, got.RetentionRate, 0.000000001)
+		require.InDelta(t, 1.0/3.0, got.LapseRate, 0.000000001)
+	})
+}
+
 func TestIsKnownCardReview(t *testing.T) {
 	t.Parallel()
 

--- a/frontend/__tests__/stats.test.tsx
+++ b/frontend/__tests__/stats.test.tsx
@@ -66,6 +66,7 @@ const populatedStats: MyLearningStatsQuery["myLearningStats"] = {
       lapseRate: 0.12,
       studyStreak: 9,
       reviewCount: 1430,
+      knownReviewCount: 1200,
       // Served normalized to 0..1 by the backend (rescaled ×10 for display).
       avgDifficulty: 0.62,
     },
@@ -76,6 +77,7 @@ const populatedStats: MyLearningStatsQuery["myLearningStats"] = {
       lapseRate: 0.15,
       studyStreak: 9,
       reviewCount: 300,
+      knownReviewCount: 250,
       avgDifficulty: 0.6,
     },
     days7: {
@@ -85,6 +87,7 @@ const populatedStats: MyLearningStatsQuery["myLearningStats"] = {
       lapseRate: 0.2,
       studyStreak: 9,
       reviewCount: 70,
+      knownReviewCount: 60,
       avgDifficulty: 0.58,
     },
   },

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -463,6 +463,7 @@
     "diagnosticsWindowOption": "{days}d",
     "diagnosticsWindowOptionAria": "Last {days} days",
     "diagnosticsWindowGroupAria": "Diagnostics period",
-    "diagnosticsNoActivityInWindow": "No reviews in the last {days} days."
+    "diagnosticsNoActivityInWindow": "No reviews in the last {days} days.",
+    "diagnosticsNoKnownReviews": "No reviews of learned cards yet"
   }
 }

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -463,6 +463,7 @@
     "diagnosticsWindowOption": "{days}日",
     "diagnosticsWindowOptionAria": "直近{days}日",
     "diagnosticsWindowGroupAria": "診断期間",
-    "diagnosticsNoActivityInWindow": "直近{days}日のレビューはありません。"
+    "diagnosticsNoActivityInWindow": "直近{days}日のレビューはありません。",
+    "diagnosticsNoKnownReviews": "対象となる復習がまだありません"
   }
 }

--- a/frontend/src/app/stats/diagnostics-panel.test.tsx
+++ b/frontend/src/app/stats/diagnostics-panel.test.tsx
@@ -17,6 +17,7 @@ const performanceWindows: PerformanceWindows = {
     lapseRate: 0.12,
     studyStreak: 9,
     reviewCount: 1430,
+    knownReviewCount: 1200,
     avgDifficulty: 0.62,
   },
   days30: {
@@ -26,6 +27,7 @@ const performanceWindows: PerformanceWindows = {
     lapseRate: 0.25,
     studyStreak: 9,
     reviewCount: 300,
+    knownReviewCount: 250,
     avgDifficulty: 0.51,
   },
   days7: {
@@ -35,6 +37,7 @@ const performanceWindows: PerformanceWindows = {
     lapseRate: 0.2,
     studyStreak: 9,
     reviewCount: 70,
+    knownReviewCount: 60,
     avgDifficulty: 0.48,
   },
 };
@@ -72,7 +75,9 @@ describe("<DiagnosticsPanel>", () => {
     const user = userEvent.setup();
     renderPanel({
       ...performanceWindows,
-      days7: { ...performanceWindows.days7, reviewCount: 0 },
+      // A dormant window carries no gated reviews either — the gated count is a
+      // subset of the total, so it can never exceed it.
+      days7: { ...performanceWindows.days7, reviewCount: 0, knownReviewCount: 0 },
     });
 
     await user.click(screen.getByRole("button", { name: "Last 7 days" }));
@@ -85,6 +90,51 @@ describe("<DiagnosticsPanel>", () => {
 
     expect(tile("Retention").getByText("78%")).toBeInTheDocument();
     expect(screen.queryByText("No reviews in the last 7 days.")).not.toBeInTheDocument();
+  });
+
+  it("replaces the gated rates with an explanatory empty state when no learned-card reviews exist", () => {
+    renderPanel({
+      ...performanceWindows,
+      days365: { ...performanceWindows.days365, knownReviewCount: 0 },
+    });
+
+    expect(tile("Retention").getByText("—")).toBeInTheDocument();
+    expect(tile("Retention").getByText("No reviews of learned cards yet")).toBeInTheDocument();
+    expect(tile("Lapse").getByText("—")).toBeInTheDocument();
+    expect(tile("Lapse").getByText("No reviews of learned cards yet")).toBeInTheDocument();
+
+    // Only the two gated tiles change; the whole-window tiles keep their values.
+    expect(tile("Success").getByText("84%")).toBeInTheDocument();
+    expect(tile("Streak").getByText("9 days")).toBeInTheDocument();
+    expect(tile("Reviews").getByText("1,430")).toBeInTheDocument();
+  });
+
+  it("falls back to the empty state when knownReviewCount is absent from the result", () => {
+    // A query under-selection or an out-of-sync mock leaves this non-null-typed
+    // field undefined at runtime; the gate must land on the empty state, never on
+    // the misleading "0%" it exists to remove.
+    const { knownReviewCount: _absent, ...days365 } = performanceWindows.days365;
+    renderPanel({
+      ...performanceWindows,
+      days365: days365 as PerformanceWindows["days365"],
+    });
+
+    expect(tile("Retention").getByText("—")).toBeInTheDocument();
+    expect(tile("Retention").getByText("No reviews of learned cards yet")).toBeInTheDocument();
+    expect(tile("Lapse").getByText("—")).toBeInTheDocument();
+    expect(tile("Lapse").getByText("No reviews of learned cards yet")).toBeInTheDocument();
+    expect(screen.queryByText("78%")).not.toBeInTheDocument();
+    expect(screen.queryByText("0%")).not.toBeInTheDocument();
+  });
+
+  it("renders the gated rates as percentages when learned-card reviews exist", () => {
+    renderPanel();
+
+    expect(tile("Retention").getByText("78%")).toBeInTheDocument();
+    expect(tile("Retention").getByText("recall success")).toBeInTheDocument();
+    expect(tile("Lapse").getByText("12%")).toBeInTheDocument();
+    expect(tile("Lapse").getByText("forgotten again")).toBeInTheDocument();
+    expect(screen.queryByText("No reviews of learned cards yet")).not.toBeInTheDocument();
   });
 
   it("shows the same full-history streak in every window", async () => {

--- a/frontend/src/app/stats/diagnostics-panel.tsx
+++ b/frontend/src/app/stats/diagnostics-panel.tsx
@@ -21,6 +21,10 @@ const WINDOW_OPTIONS: ReadonlyArray<{ key: WindowKey; days: number }> = [
 // format a 0..1 fraction as a whole-percent string.
 const PERCENT_FORMAT = { style: "percent", maximumFractionDigits: 0 } as const;
 
+// Stands in for the retention / lapse percentage when the window carries no
+// reviews of already-learned cards.
+const NO_RATE_VALUE = "—";
+
 /**
  * Diagnostics KPI row for `/stats`: six `StatTile`s over a locally selected
  * trailing window, each carrying a `StatHint` help popover. Rate
@@ -31,7 +35,10 @@ const PERCENT_FORMAT = { style: "percent", maximumFractionDigits: 0 } as const;
  * `studyStreak` uses the pluralized `diagnosticsStreakValue` message; `reviewCount`
  * is a grouped integer. Switching windows is synchronous because all snapshots
  * arrive in one query. When the selected window has no reviews, only the tile
- * area becomes an empty state so the window control remains available.
+ * area becomes an empty state so the window control remains available. When it
+ * has reviews but none of already-learned cards (no `knownReviewCount`), the
+ * retention and lapse tiles alone fall back to an explanatory empty state,
+ * because the backend reports both rates as 0 for an absent population.
  */
 export function DiagnosticsPanel({
   performanceWindows,
@@ -43,13 +50,21 @@ export function DiagnosticsPanel({
   const [selectedWindow, setSelectedWindow] = useState<WindowKey>("days365");
   const performance = performanceWindows[selectedWindow];
   const selectedDays = WINDOW_OPTIONS.find(({ key }) => key === selectedWindow)?.days ?? 365;
+  // The window has activity, but nothing that qualifies for the two gated rates.
+  // Test `!(knownReviewCount > 0)` (not `=== 0`) so that an unexpectedly-undefined
+  // value (a query / codegen / mock desync tsc cannot catch, since the field is
+  // typed non-null) falls through to the empty state below rather than back into a
+  // literal "0%" — the exact misdirection this gate removes.
+  const noKnownReviews = !(performance.knownReviewCount > 0) && performance.reviewCount > 0;
 
   const tiles = [
     {
       key: "retention",
       label: t("diagnosticsRetention"),
-      value: format.number(performance.retentionRate, PERCENT_FORMAT),
-      caption: t("diagnosticsRetentionCaption"),
+      value: noKnownReviews
+        ? NO_RATE_VALUE
+        : format.number(performance.retentionRate, PERCENT_FORMAT),
+      caption: noKnownReviews ? t("diagnosticsNoKnownReviews") : t("diagnosticsRetentionCaption"),
       hint: t("diagnosticsRetentionHint"),
     },
     {
@@ -62,8 +77,8 @@ export function DiagnosticsPanel({
     {
       key: "lapse",
       label: t("diagnosticsLapse"),
-      value: format.number(performance.lapseRate, PERCENT_FORMAT),
-      caption: t("diagnosticsLapseCaption"),
+      value: noKnownReviews ? NO_RATE_VALUE : format.number(performance.lapseRate, PERCENT_FORMAT),
+      caption: noKnownReviews ? t("diagnosticsNoKnownReviews") : t("diagnosticsLapseCaption"),
       hint: t("diagnosticsLapseHint"),
     },
     {

--- a/frontend/src/app/stats/page.test.tsx
+++ b/frontend/src/app/stats/page.test.tsx
@@ -51,6 +51,7 @@ function makeStatsData() {
           lapseRate: 0.1,
           studyStreak: 0,
           reviewCount: 0,
+          knownReviewCount: 0,
           avgDifficulty: 0.5,
         },
         days30: {
@@ -59,6 +60,7 @@ function makeStatsData() {
           lapseRate: 0.1,
           studyStreak: 0,
           reviewCount: 0,
+          knownReviewCount: 0,
           avgDifficulty: 0.5,
         },
         days7: {
@@ -67,6 +69,7 @@ function makeStatsData() {
           lapseRate: 0.1,
           studyStreak: 0,
           reviewCount: 0,
+          knownReviewCount: 0,
           avgDifficulty: 0.5,
         },
       },

--- a/frontend/src/app/stats/queries.ts
+++ b/frontend/src/app/stats/queries.ts
@@ -18,6 +18,7 @@ export const MyLearningStatsQuery = graphql(`
           lapseRate
           studyStreak
           reviewCount
+          knownReviewCount
           avgDifficulty
         }
         days30 {
@@ -26,6 +27,7 @@ export const MyLearningStatsQuery = graphql(`
           lapseRate
           studyStreak
           reviewCount
+          knownReviewCount
           avgDifficulty
         }
         days7 {
@@ -34,6 +36,7 @@ export const MyLearningStatsQuery = graphql(`
           lapseRate
           studyStreak
           reviewCount
+          knownReviewCount
           avgDifficulty
         }
       }

--- a/frontend/src/app/stats/stats-client.test.tsx
+++ b/frontend/src/app/stats/stats-client.test.tsx
@@ -42,6 +42,7 @@ const populatedStats: Stats = {
       lapseRate: 0.12,
       studyStreak: 9,
       reviewCount: 1430,
+      knownReviewCount: 1200,
       // Served normalized to 0..1 by the backend; the panel rescales ×10 → "6.2".
       avgDifficulty: 0.62,
     },
@@ -52,6 +53,7 @@ const populatedStats: Stats = {
       lapseRate: 0.15,
       studyStreak: 9,
       reviewCount: 300,
+      knownReviewCount: 250,
       avgDifficulty: 0.6,
     },
     days7: {
@@ -61,6 +63,7 @@ const populatedStats: Stats = {
       lapseRate: 0.2,
       studyStreak: 9,
       reviewCount: 70,
+      knownReviewCount: 60,
       avgDifficulty: 0.58,
     },
   },
@@ -205,7 +208,13 @@ describe("<StatsClient>", () => {
         ...populatedStats,
         performanceWindows: {
           ...populatedStats.performanceWindows,
-          days365: { ...populatedStats.performanceWindows.days365, reviewCount: 0 },
+          // A dormant window carries no gated reviews either — the gated count is
+          // a subset of the total, so it can never exceed it.
+          days365: {
+            ...populatedStats.performanceWindows.days365,
+            reviewCount: 0,
+            knownReviewCount: 0,
+          },
         },
       });
 

--- a/schema/swipe.graphql
+++ b/schema/swipe.graphql
@@ -30,6 +30,8 @@ type PerformanceMetrics {
   studyStreak: Int!
   lapseRate: Float!
   reviewCount: Int!
+  """Number of reviews in the window that qualified for retentionRate/lapseRate (reviews of already-learned cards). When the window has swipes but none of them are gated reviews, retentionRate and lapseRate are both 0; when the window is empty (reviewCount is 0 too), retentionRate instead carries a neutral 0.5 placeholder. Either way, render an explicit empty state instead of trusting those values."""
+  knownReviewCount: Int!
 }
 
 """Success variant returned by `handleSwipe` when the swipe was recorded. Carries the latest `SwipeResponse` (performance snapshot only — the client manages its own queue and prefetches the next page separately)."""


### PR DESCRIPTION
## Summary

`retentionRate` and `lapseRate` are scoped to reviews of already-learned cards, but `PerformanceMetrics` carried only the window-wide `reviewCount`, so the client could not tell "0% of eligible reviews" from "no eligible reviews yet". A learner whose window holds only new-card and graduation swipes therefore saw a literal "Retention 0%" beside a popover that defines the metric as recall of cards already learned. This exposes the gated denominator as `knownReviewCount` and renders an em dash plus "No reviews of learned cards yet" on the retention and lapse tiles when that count is 0 while `reviewCount > 0`; the other four tiles, the hint popovers, and the whole-grid empty state are untouched.

> **Stacked on #983** (`worktree-fix+stats-stability-gate`). Both branches touch `ComputeMetrics`; merge the #983 branch first.

## Changes

### Schema

- `schema/swipe.graphql` — `PerformanceMetrics` gains `knownReviewCount: Int!`, described as the population behind `retentionRate`/`lapseRate`. The description spells out both zero cases: swipes present but none gated leaves both rates at 0, an empty window leaves `retentionRate` on its neutral 0.5 placeholder — and instructs clients to render an explicit empty state rather than trust either value.

### Backend

- `backend/internal/domain/service/user_performance.go` — `PerformanceMetrics` gains `KnownReviewCount int` (`:176`), populated from the existing `reviews` counter that `isKnownCardReview` increments (`:242`) and that `ratio` already divides by for `RetentionRate` and `LapseRate` (`:258`, `:260`, `:262`). The empty-swipes early return (`:221-227`) leaves the new field at its zero value alongside the 0.5 placeholders, so a 0 count is the single signal for "no eligible reviews" in either shape.
- `backend/graph/resolver/mapper.go` — `toPerformanceMetricsModel` maps `KnownReviewCount` onto the generated `model.PerformanceMetrics` (`:284`).

### Frontend

- `frontend/src/app/stats/queries.ts` — all three window selections of `MyLearningStatsQuery` (`days365`, `days30`, `days7`) select `knownReviewCount`.
- `frontend/src/app/stats/diagnostics-panel.tsx` — new gate `noKnownReviews = !(performance.knownReviewCount > 0) && performance.reviewCount > 0` (`:58`). The negated `> 0` form is deliberate: the field is typed non-null, so a query under-selection or an out-of-sync mock yields `undefined` at runtime with no `tsc` error, and that case must land on the empty state rather than fall back to the misleading "0%". Only the `retention` and `lapse` tiles consume it — value becomes the `NO_RATE_VALUE` em dash (`:26`) and caption becomes `t("diagnosticsNoKnownReviews")`. The whole-grid `reviewCount === 0` empty state and every hint popover are unchanged.
- `frontend/messages/en.json` / `frontend/messages/ja.json` — new `Stats.diagnosticsNoKnownReviews` key ("No reviews of learned cards yet" and its Japanese translation).

### Tests

- `backend/internal/domain/service/user_performance_test.go` — new `TestComputeMetrics_KnownReviewCount`. A new-card `Again` swipe plus a Learning→Review graduation yields `ReviewCount 2`, `KnownReviewCount 0`, and both rates zero; a mixed set yields `ReviewCount 4`, `KnownReviewCount 3`, retention and lapse each 1/3 — pinning the new field as the gated denominator, not the total.
- `backend/graph/resolver/stats_resolver_test.go` — the diagnostic query string and the per-window expectation map now request and assert `knownReviewCount` (300 / 25 / 0), so a dropped mapper line fails at the wire.
- `frontend/src/app/stats/diagnostics-panel.test.tsx` — three new cases: `knownReviewCount: 0` renders the em dash and the new caption on Retention and Lapse while Success/Streak/Reviews keep 84% / 9 days / 1,430; the field omitted from the window object hits the same empty state and renders neither "78%" nor "0%"; a positive count renders the percentages with the original captions.
- Fixture sync in `frontend/src/app/stats/stats-client.test.tsx`, `frontend/src/app/stats/page.test.tsx`, and `frontend/__tests__/stats.test.tsx`. The two dormant-window fixtures set `knownReviewCount: 0` alongside `reviewCount: 0`, with a comment noting the gated count is a subset of the total and can never exceed it.

## Test plan

- [ ] `go build ./... && go vet ./... && go test ./...` — green, 2253 tests across 26 packages
- [ ] `tsc --noEmit` — clean
- [ ] `biome check --error-on-warnings .` — clean, 520 files checked
- [ ] `vitest run` — 1904 tests in 206 files, all passing
- [ ] `knip` — clean
- [ ] `next build` — succeeds
- [ ] Negative case: a window object with `knownReviewCount` absent renders the empty state, never "0%" (co-located diagnostics-panel test)

## Notes

- gqlgen and graphql-codegen outputs are gitignored (`backend/graph/generated/`, `backend/graph/model/models_gen.go`, `frontend/src/generated/`), so the schema change carries no tracked generated diff — regenerate before building.
- No Playwright spec touches `/stats` (`grep -rln 'stats' frontend/e2e` returns nothing), so the e2e suite is unaffected. It was not run here: it needs a live Supabase and backend stack.

Closes #984
