### PR TITLE
fix(stats): cap the reported study streak at 365 days

### DIFF
--- a/backend/internal/domain/service/user_performance.go
+++ b/backend/internal/domain/service/user_performance.go
@@ -356,9 +356,10 @@ func isOnTimeRecall(swipe domain.SwipeRecord) bool {
 
 // studyStreak counts consecutive JST learn-days ending at the current learn-day,
 // breaking on the first day with no swipe. If the current learn-day has no
-// swipe, the streak is 0. The count is bounded by the caller-supplied swipe
-// window (the stats usecase loads a trailing 365-day window), so a streak longer
-// than the window reads as at most the window length.
+// swipe, the streak is 0. The walk is bounded only by the learn-days present in
+// daysSeen, and an inclusive N-day fetch window can contribute N+1 distinct
+// learn-day keys — so the raw count can exceed the caller's window length by one.
+// Clamping to a reported cap is the caller's job; the stats usecase does it.
 func studyStreak(daysSeen map[string]struct{}, now time.Time) int {
 	streak := 0
 	for day := domain.StartOfLearnDay(now); ; day = day.AddDate(0, 0, -1) {

--- a/backend/internal/domain/service/user_performance_test.go
+++ b/backend/internal/domain/service/user_performance_test.go
@@ -421,6 +421,28 @@ func TestComputeMetrics_JSTLearnDayBoundary(t *testing.T) {
 	require.Equal(t, 2, got.StudyStreak)
 }
 
+// TestStudyStreak_ReturnsUnclampedRunLength pins the raw streak behaviour the
+// stats usecase's cap exists for: given 366 consecutive JST learn-day keys
+// ending at the current learn-day, the walk reports the full run length of 366.
+// studyStreak applies no cap of its own — it stops only at the first missing
+// day — so a run one longer than the reported 365-day maximum reaches the
+// caller intact. That the inclusive [now-365d, now] fetch window can actually
+// supply 366 learn-days is proven end to end by
+// TestStatsUsecase_MyLearningStats_StreakCappedAtStatsWindowDays in
+// backend/internal/usecase/stats_test.go, which seeds swipes across the
+// inclusive cutoff and asserts every reported window clamps back to 365.
+func TestStudyStreak_ReturnsUnclampedRunLength(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 18, 3, 0, 0, 0, time.UTC)
+	daysSeen := make(map[string]struct{}, 366)
+	for day := domain.StartOfLearnDay(now); len(daysSeen) < 366; day = day.AddDate(0, 0, -1) {
+		daysSeen[domain.LearnDayKey(day)] = struct{}{}
+	}
+
+	require.Equal(t, 366, studyStreak(daysSeen, now))
+}
+
 func TestModeFromMetricsThresholdBoundaries(t *testing.T) {
 	t.Parallel()
 

--- a/backend/internal/usecase/stats.go
+++ b/backend/internal/usecase/stats.go
@@ -124,11 +124,28 @@ func (u *statsUsecase) MyLearningStats(ctx context.Context) (*LearningStatsResul
 		return nil, eris.Wrap(err, "usecase: stats: count cardgroups by owner")
 	}
 
+	windows := service.ComputeWindowedMetrics(swipeRecordsByValue(swipes), now)
+	windows.Days365 = capStreak(windows.Days365)
+	windows.Days30 = capStreak(windows.Days30)
+	windows.Days7 = capStreak(windows.Days7)
+
 	return &LearningStatsResult{
 		Mastery:         mastery,
 		Decks:           decks,
 		OwnsAnyDeck:     count > 0,
-		Windows:         service.ComputeWindowedMetrics(swipeRecordsByValue(swipes), now),
+		Windows:         windows,
 		StrugglingCards: service.TopStruggling(states, strugglingCardsLimit),
 	}, nil
+}
+
+// capStreak clamps a computed streak to the fetch window's day count: the
+// inclusive [now-365d, now] read intersects 366 JST learn-days, one more than
+// the documented 365-day cap the schema and the client copy promise. Without the
+// clamp the reported streak also oscillates between 366 and 365 across a single
+// day, reading as a lost day to a learner who never missed one.
+func capStreak(m service.PerformanceMetrics) service.PerformanceMetrics {
+	if m.StudyStreak > statsWindowDays {
+		m.StudyStreak = statsWindowDays
+	}
+	return m
 }

--- a/backend/internal/usecase/stats_test.go
+++ b/backend/internal/usecase/stats_test.go
@@ -3,6 +3,7 @@ package usecase
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -259,6 +260,46 @@ func TestStatsUsecase_MyLearningStats_WindowsReflectComputeWindowedMetrics(t *te
 	want := service.ComputeWindowedMetrics(swipeRecordsByValue(swipes), fixedNow)
 	assert.Equal(t, want, res.Windows,
 		"Windows is ComputeWindowedMetrics over the loaded swipes at the injected now")
+}
+
+// TestStatsUsecase_MyLearningStats_StreakCappedAtStatsWindowDays pins the cap the
+// schema and the client copy promise: the inclusive [now-365d, now] read spans 366
+// JST learn-days, so a learner who studied every one of them computes a raw streak
+// of 366. Every reported window clamps that to statsWindowDays.
+func TestStatsUsecase_MyLearningStats_StreakCappedAtStatsWindowDays(t *testing.T) {
+	t.Parallel()
+	// 12:00 UTC == 21:00 JST, so every daily fixture sits inside its own JST
+	// learn-day and the earliest one lands exactly on the inclusive cutoff.
+	fixedNow := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
+	state := domain.NewFSRSStateForNewCard(fixedNow)
+	state.Phase = domain.FSRSPhaseReview
+	swipes := make([]*domain.SwipeRecord, 0, statsWindowDays+1)
+	for daysAgo := 0; daysAgo <= statsWindowDays; daysAgo++ {
+		swipes = append(swipes, &domain.SwipeRecord{
+			ID:          fmt.Sprintf("s%d", daysAgo),
+			UserID:      "user-1",
+			CardID:      "c1",
+			CardgroupID: "cg1",
+			Rating:      domain.RatingGood,
+			ReviewedAt:  fixedNow.AddDate(0, 0, -daysAgo),
+			StateAfter:  state,
+		})
+	}
+	swipeRepo := &fakeStatsSwipeRepo{swipes: swipes}
+	uc := NewStats(&fakeStatsFSRSRepo{totals: map[string]int{}}, swipeRepo, &fakeStatsCardgroupRepo{}, fixedClock{now: fixedNow})
+
+	res, err := uc.MyLearningStats(authedStatsCtx("user-1"))
+	require.NoError(t, err)
+	require.NotNil(t, res)
+
+	require.Equal(t, fixedNow.AddDate(0, 0, -statsWindowDays), swipeRepo.sinceArg,
+		"the earliest fixture lands exactly on the inclusive cutoff")
+	raw := service.ComputeWindowedMetrics(swipeRecordsByValue(swipes), fixedNow)
+	require.Equal(t, statsWindowDays+1, raw.Days365.StudyStreak,
+		"the uncapped walk sees one learn-day more than the window length")
+	assert.Equal(t, statsWindowDays, res.Windows.Days365.StudyStreak)
+	assert.Equal(t, statsWindowDays, res.Windows.Days30.StudyStreak)
+	assert.Equal(t, statsWindowDays, res.Windows.Days7.StudyStreak)
 }
 
 func TestStatsUsecase_MyLearningStats_StrugglingCardsFromFSRSRows(t *testing.T) {


### PR DESCRIPTION
## Summary

The stats read loads `[now-365d, now]` with an inclusive lower bound, and a 365-day interval whose endpoints share a JST time-of-day intersects **366** distinct JST learn-days. A learner who studied every one of them therefore computed a raw `studyStreak` of 366 — one above the cap the `PerformanceWindows` schema description and the `Stats.diagnosticsStreakHint` copy both promise — and the value flipped back to 365 later the same day once the anniversary time-of-day passed, reading as a lost day to someone who never missed one. `MyLearningStats` now clamps every reported window's streak to `statsWindowDays`.

> **Stacked on the issue #987 branch** (`worktree-fix+stats-utc-window`). The clamp sits directly on the UTC-normalized `now` and window cutoff introduced there, and touches the same two files; merge #987 first.

## Changes

### Backend

- `backend/internal/usecase/stats.go` — `MyLearningStats` now binds `service.ComputeWindowedMetrics(...)` to a local and routes `Days365`, `Days30` and `Days7` through a new `capStreak` helper that clamps `StudyStreak` down to `statsWindowDays` (365). All three windows need the clamp: `ComputeWindowedMetrics` overwrites the 30- and 7-day snapshots' `StudyStreak` with the 365-day value (`user_performance.go:198-199`), because the streak is calendar truth rather than a window-scoped metric.
- `backend/internal/domain/service/user_performance.go` — rewrite the `studyStreak` docstring. The old text claimed "a streak longer than the window reads as at most the window length", which is false: the walk stops only at the first missing day and applies no cap of its own, and an inclusive N-day fetch window can contribute N+1 learn-day keys. The new text states the raw count can exceed the window length by one and names the stats usecase as the clamp site.
- The swipe-response path is deliberately untouched: `HandleSwipe` computes its metrics over a `swipePerformanceSampleLimit` (100) recent-swipe sample (`backend/internal/usecase/swipe.go:222-229`), which cannot span more than 100 learn-days and so can never reach the cap.

### Tests

- `backend/internal/domain/service/user_performance_test.go` — `TestStudyStreak_ReturnsUnclampedRunLength` builds 366 consecutive JST learn-day keys ending at the current learn-day and asserts `studyStreak` returns 366, pinning the uncapped domain behaviour the clamp exists for.
- `backend/internal/usecase/stats_test.go` — `TestStatsUsecase_MyLearningStats_StreakCappedAtStatsWindowDays` seeds one swipe per day across `statsWindowDays + 1` consecutive days at 12:00 UTC (21:00 JST, so each fixture sits inside its own JST learn-day). It asserts the repository's `since` argument is exactly `now.AddDate(0, 0, -statsWindowDays)`, that an uncapped `ComputeWindowedMetrics` over the same fixtures reports 366, and that `Days365`, `Days30` and `Days7` all report 365.

## Test plan

- [ ] `go build ./... && go vet ./...` — clean
- [ ] `go test ./...` — green (2246 tests, 26 packages)
- [ ] `go tool go-arch-lint check` — OK, no warnings found
- [ ] `grep -rn 'StudyStreak' backend/ --include='*.go' | grep -v _test.go` — `capStreak` in `stats.go` is the only site that modifies a computed streak; `graph/resolver/mapper.go:281` merely copies it into the GraphQL model, and the swipe path's `ComputeMetrics` call is unchanged

## Notes

- No frontend or schema change is needed: `schema/stats.graphql` ("the reported streak is capped at 365 days") and `Stats.diagnosticsStreakHint` / `diagnosticsStreakCaption` in `frontend/messages/{en,ja}.json` already promise 365. The clamp makes the shipped copy true rather than requiring it to be reworded upward.
- Playwright e2e was not run (it needs a live Supabase + backend stack), but no spec is affected: `grep -rln 'streak' frontend/e2e/` returns no files.

Closes #985
