### PR TITLE
fix(profile): show the exact stored new-card ratio, not the grid snap

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -261,6 +261,7 @@
     "newCardRatioNewLabel": "New {percent}%",
     "newCardRatioReviewLabel": "Review {percent}%",
     "newCardRatioValueText": "New {newPct}%, review {reviewPct}%",
+    "newCardRatioCustomNotice": "A custom ratio ({percent}%) is set via the API. Moving the slider replaces it with a 5% step.",
     "sessionExpired": "Your session expired. Please sign in again.",
     "couldntLoad": "Couldn't load your profile",
     "loadError": "Something went wrong while loading your profile. Please try again in a moment.",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -261,6 +261,7 @@
     "newCardRatioNewLabel": "新規 {percent}%",
     "newCardRatioReviewLabel": "復習 {percent}%",
     "newCardRatioValueText": "新規 {newPct}%、復習 {reviewPct}%",
+    "newCardRatioCustomNotice": "API 経由のカスタム値({percent}%)が設定されています。スライダーを動かすと 5% 刻みの値で上書きされます。",
     "sessionExpired": "セッションの有効期限が切れました。もう一度ログインしてください。",
     "couldntLoad": "プロフィールを読み込めませんでした",
     "loadError": "プロフィールの読み込み中に問題が発生しました。しばらくしてからもう一度お試しください。",

--- a/frontend/src/app/profile/new-card-ratio-section.test.tsx
+++ b/frontend/src/app/profile/new-card-ratio-section.test.tsx
@@ -45,6 +45,9 @@ vi.mock("@/components/ui/slider", () => ({
       <button type="button" data-testid="commit-40" onClick={() => onValueCommit?.([40])}>
         commit 40
       </button>
+      <button type="button" data-testid="commit-55" onClick={() => onValueCommit?.([55])}>
+        commit 55
+      </button>
     </div>
   ),
 }));
@@ -82,6 +85,18 @@ function makeUpdateRatioMock(
   };
 }
 
+/**
+ * Adds up the two rendered percentages. The labels are complements of a single
+ * tenths count, so the pair must total exactly 100 for every stored ratio. The
+ * anchored patterns keep the aria-valuetext line ("New 35%, review 65%") out of
+ * the match.
+ */
+function renderedLabelSum(): number {
+  const read = (pattern: RegExp) =>
+    Number((screen.getByText(pattern).textContent ?? "").replace(/[^\d.]/g, ""));
+  return read(/^New [\d.]+%$/) + read(/^Review [\d.]+%$/);
+}
+
 describe("<NewCardRatioSection>", () => {
   it("derives the initial percent from initialRatio ({4,5} -> 80)", () => {
     renderWithIntl(
@@ -99,11 +114,11 @@ describe("<NewCardRatioSection>", () => {
     expect(screen.getByTestId("slider-root")).not.toHaveAttribute("aria-describedby");
   });
 
-  it("treats a reduced on-grid fraction ({11,20} -> 55) as on-grid despite float division", () => {
+  it("treats a reduced on-grid fraction ({11,20} -> 55) as on-grid", () => {
     // The backend reduces every stored fraction, so committing the slider's own
-    // 55% position stores 11/20 — and (11 / 20) * 100 is 55.00000000000001.
-    // Exact float equality against the grid would report the slider's own last
-    // write as a custom ratio set through the API.
+    // 55% position stores 11/20. The grid test divides 20 * 11 by 20 exactly,
+    // so the slider's own last write is never reported back as a custom ratio —
+    // the quotient (11 / 20) * 100 is 55.00000000000001 and never compared.
     renderWithIntl(
       <MockedProvider mocks={[]}>
         <NewCardRatioSection initialRatio={{ numerator: 11, denominator: 20 }} />
@@ -118,7 +133,8 @@ describe("<NewCardRatioSection>", () => {
   });
 
   it("keeps the two labels summing to 100 on a .x5 exact percent ({1,16} -> 6.25)", () => {
-    // Rounding each side independently would print 6.3% / 93.8%.
+    // The review side is the complement of the same tenths count, so it reads
+    // 93.7% rather than the 93.8% independent round-half-up would produce.
     renderWithIntl(
       <MockedProvider mocks={[]}>
         <NewCardRatioSection initialRatio={{ numerator: 1, denominator: 16 }} />
@@ -129,16 +145,47 @@ describe("<NewCardRatioSection>", () => {
     expect(screen.getByText("Review 93.7%")).toBeInTheDocument();
   });
 
-  it("derives the initial percent from a reduced fraction ({3,20} -> 15)", () => {
+  // Off-grid fractions with no hard-coded expected labels: the sum is the only
+  // assertion, so a regression that rounds each side on its own — and prints a
+  // pair totalling 100.1% — fails here and nowhere else in this file.
+  it.each([
+    { numerator: 5, denominator: 99 },
+    { numerator: 49, denominator: 99 },
+    { numerator: 1, denominator: 7 },
+    { numerator: 1, denominator: 6 },
+    { numerator: 2, denominator: 3 },
+  ])("keeps the two labels summing to 100 for an off-grid ratio ({$numerator,$denominator})", ({
+    numerator,
+    denominator,
+  }) => {
     renderWithIntl(
       <MockedProvider mocks={[]}>
-        <NewCardRatioSection initialRatio={{ numerator: 3, denominator: 20 }} />
+        <NewCardRatioSection initialRatio={{ numerator, denominator }} />
       </MockedProvider>,
     );
 
-    expect(screen.getByTestId("slider-value")).toHaveTextContent("15");
-    expect(screen.getByText("New 15%")).toBeInTheDocument();
-    expect(screen.getByText("Review 85%")).toBeInTheDocument();
+    expect(renderedLabelSum()).toBe(100);
+    expect(screen.getByTestId("new-card-ratio-custom-notice")).toBeInTheDocument();
+  });
+
+  it.each([
+    { numerator: 3, denominator: 20, percent: 15 },
+    { numerator: 1, denominator: 2, percent: 50 },
+  ])("derives the initial percent from a reduced fraction ({$numerator,$denominator} -> $percent)", ({
+    numerator,
+    denominator,
+    percent,
+  }) => {
+    renderWithIntl(
+      <MockedProvider mocks={[]}>
+        <NewCardRatioSection initialRatio={{ numerator, denominator }} />
+      </MockedProvider>,
+    );
+
+    expect(screen.getByTestId("slider-value")).toHaveTextContent(String(percent));
+    expect(screen.getByText(`New ${percent}%`)).toBeInTheDocument();
+    expect(screen.getByText(`Review ${100 - percent}%`)).toBeInTheDocument();
+    expect(screen.queryByTestId("new-card-ratio-custom-notice")).not.toBeInTheDocument();
   });
 
   it("shows an off-grid stored ratio ({33,100}) exactly and discloses the overwrite", () => {
@@ -177,6 +224,48 @@ describe("<NewCardRatioSection>", () => {
     expect(screen.getByTestId("new-card-ratio-custom-notice")).toHaveTextContent(
       "A custom ratio (33.3%) is set via the API.",
     );
+  });
+
+  // The API accepts shares on both sides of the control's [5, 95] span, so the
+  // position clamps at either end while the labels and the notice keep
+  // reporting the stored share. 1/100 rounds to grid step 0 and 39/40 to grid
+  // step 100; both are legitimate stored values.
+  it.each([
+    {
+      numerator: 1,
+      denominator: 100,
+      control: "5",
+      newLabel: "New 1%",
+      reviewLabel: "Review 99%",
+      notice: "A custom ratio (1%) is set via the API.",
+    },
+    {
+      numerator: 39,
+      denominator: 40,
+      control: "95",
+      newLabel: "New 97.5%",
+      reviewLabel: "Review 2.5%",
+      notice: "A custom ratio (97.5%) is set via the API.",
+    },
+  ])("parks the control at $control for a stored ratio outside the slider's range ({$numerator,$denominator})", ({
+    numerator,
+    denominator,
+    control,
+    newLabel,
+    reviewLabel,
+    notice,
+  }) => {
+    renderWithIntl(
+      <MockedProvider mocks={[]}>
+        <NewCardRatioSection initialRatio={{ numerator, denominator }} />
+      </MockedProvider>,
+    );
+
+    // Exact text, not toHaveTextContent: "5" also matches a stray 35 or 55.
+    expect(screen.getByTestId("slider-value").textContent).toBe(control);
+    expect(screen.getByText(newLabel)).toBeInTheDocument();
+    expect(screen.getByText(reviewLabel)).toBeInTheDocument();
+    expect(screen.getByTestId("new-card-ratio-custom-notice")).toHaveTextContent(notice);
   });
 
   it("shows the dragged grid value while the slider is moving, off-grid stored value or not", async () => {
@@ -234,6 +323,41 @@ describe("<NewCardRatioSection>", () => {
     // No save happens until release, so the mutation must not have fired.
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(onCalled).not.toHaveBeenCalled();
+  });
+
+  it("fires no mutation when a commit re-selects the stored ratio ({11,20} -> 55)", async () => {
+    const user = userEvent.setup();
+    const called55 = vi.fn();
+    const called40 = vi.fn();
+
+    // 11/20 is the reduced form of the slider's own 55% write, so re-committing
+    // 55 asks for the value already stored and must stay local. A 55/100 mock
+    // is supplied so a redundant save would match and show up as a called spy.
+    //
+    // The follow-up commit to 40 is the synchronization point that makes the
+    // negative assertion deterministic rather than a timing window: it does
+    // fire, so by the time its spy has been called any earlier 55/100 request
+    // would already have resolved. (A redundant 55 save would also hold
+    // `loading` and swallow the 40 click, failing on the same waitFor.)
+    renderWithIntl(
+      <MockedProvider
+        mocks={[
+          makeUpdateRatioMock(55, { onCalled: called55 }),
+          makeUpdateRatioMock(40, { onCalled: called40 }),
+        ]}
+      >
+        <NewCardRatioSection initialRatio={{ numerator: 11, denominator: 20 }} />
+      </MockedProvider>,
+    );
+
+    await user.click(screen.getByTestId("commit-55"));
+    expect(screen.getByText("New 55%")).toBeInTheDocument();
+    expect(screen.getByText("Review 45%")).toBeInTheDocument();
+
+    await user.click(screen.getByTestId("commit-40"));
+    await waitFor(() => expect(called40).toHaveBeenCalledTimes(1));
+
+    expect(called55).not.toHaveBeenCalled();
   });
 
   it("onValueCommit fires updateNewCardRatio with { numerator: percent, denominator: 100 }", async () => {

--- a/frontend/src/app/profile/new-card-ratio-section.test.tsx
+++ b/frontend/src/app/profile/new-card-ratio-section.test.tsx
@@ -38,6 +38,9 @@ vi.mock("@/components/ui/slider", () => ({
       <button type="button" data-testid="commit-90" onClick={() => onValueCommit?.([90])}>
         commit 90
       </button>
+      <button type="button" data-testid="commit-40" onClick={() => onValueCommit?.([40])}>
+        commit 40
+      </button>
     </div>
   ),
 }));
@@ -87,6 +90,8 @@ describe("<NewCardRatioSection>", () => {
     expect(screen.getByText("New 80%")).toBeInTheDocument();
     expect(screen.getByText("Review 20%")).toBeInTheDocument();
     expect(screen.getByTestId("slider-valuetext")).toHaveTextContent("New 80%, review 20%");
+    // On-grid stored value: nothing to disclose.
+    expect(screen.queryByTestId("new-card-ratio-custom-notice")).not.toBeInTheDocument();
   });
 
   it("derives the initial percent from a reduced fraction ({3,20} -> 15)", () => {
@@ -99,6 +104,73 @@ describe("<NewCardRatioSection>", () => {
     expect(screen.getByTestId("slider-value")).toHaveTextContent("15");
     expect(screen.getByText("New 15%")).toBeInTheDocument();
     expect(screen.getByText("Review 85%")).toBeInTheDocument();
+  });
+
+  it("shows an off-grid stored ratio ({33,100}) exactly and discloses the overwrite", () => {
+    // `updateNewCardRatio` accepts any reduced fraction, so 33/100 is a
+    // legitimate stored value the 5%-step slider cannot represent: the labels
+    // must read 33/67 even though the control sits at the 35 grid position.
+    renderWithIntl(
+      <MockedProvider mocks={[]}>
+        <NewCardRatioSection initialRatio={{ numerator: 33, denominator: 100 }} />
+      </MockedProvider>,
+    );
+
+    expect(screen.getByText("New 33%")).toBeInTheDocument();
+    expect(screen.getByText("Review 67%")).toBeInTheDocument();
+    expect(screen.getByTestId("slider-value")).toHaveTextContent("35");
+
+    const notice = screen.getByTestId("new-card-ratio-custom-notice");
+    expect(notice).toHaveTextContent("A custom ratio (33%) is set via the API.");
+  });
+
+  it("rounds a repeating off-grid ratio ({1,3}) to one decimal", () => {
+    renderWithIntl(
+      <MockedProvider mocks={[]}>
+        <NewCardRatioSection initialRatio={{ numerator: 1, denominator: 3 }} />
+      </MockedProvider>,
+    );
+
+    expect(screen.getByText("New 33.3%")).toBeInTheDocument();
+    expect(screen.getByText("Review 66.7%")).toBeInTheDocument();
+    expect(screen.getByTestId("new-card-ratio-custom-notice")).toHaveTextContent(
+      "A custom ratio (33.3%) is set via the API.",
+    );
+  });
+
+  it("shows the dragged grid value while the slider is moving, off-grid stored value or not", async () => {
+    const user = userEvent.setup();
+
+    renderWithIntl(
+      <MockedProvider mocks={[]}>
+        <NewCardRatioSection initialRatio={{ numerator: 33, denominator: 100 }} />
+      </MockedProvider>,
+    );
+
+    await user.click(screen.getByTestId("change-90"));
+
+    expect(screen.getByText("New 90%")).toBeInTheDocument();
+    expect(screen.getByText("Review 10%")).toBeInTheDocument();
+    // The stored value is still the off-grid one until a commit succeeds.
+    expect(screen.getByTestId("new-card-ratio-custom-notice")).toBeInTheDocument();
+  });
+
+  it("drops the off-grid notice once a commit replaces the stored ratio", async () => {
+    const user = userEvent.setup();
+    const onCalled = vi.fn();
+
+    renderWithIntl(
+      <MockedProvider mocks={[makeUpdateRatioMock(40, { onCalled })]}>
+        <NewCardRatioSection initialRatio={{ numerator: 33, denominator: 100 }} />
+      </MockedProvider>,
+    );
+
+    await user.click(screen.getByTestId("commit-40"));
+    await waitFor(() => expect(onCalled).toHaveBeenCalledTimes(1));
+
+    await waitFor(() => expect(screen.getByText("New 40%")).toBeInTheDocument());
+    expect(screen.getByText("Review 60%")).toBeInTheDocument();
+    expect(screen.queryByTestId("new-card-ratio-custom-notice")).not.toBeInTheDocument();
   });
 
   it("onValueChange updates the label but fires no mutation", async () => {

--- a/frontend/src/app/profile/new-card-ratio-section.test.tsx
+++ b/frontend/src/app/profile/new-card-ratio-section.test.tsx
@@ -20,13 +20,17 @@ vi.mock("@/components/ui/slider", () => ({
     onValueChange,
     onValueCommit,
     "aria-valuetext": ariaValueText,
+    "aria-describedby": ariaDescribedBy,
   }: {
     value: number[];
     onValueChange?: (value: number[]) => void;
     onValueCommit?: (value: number[]) => void;
     "aria-valuetext"?: string;
+    "aria-describedby"?: string;
   }) => (
-    <div>
+    // The real wrapper forwards both aria props onto the role=slider thumb, so
+    // the double carries them on one element the assertions can read.
+    <div data-testid="slider-root" aria-describedby={ariaDescribedBy}>
       <div data-testid="slider-value">{value[0]}</div>
       <div data-testid="slider-valuetext">{ariaValueText}</div>
       <button type="button" data-testid="change-90" onClick={() => onValueChange?.([90])}>
@@ -90,8 +94,39 @@ describe("<NewCardRatioSection>", () => {
     expect(screen.getByText("New 80%")).toBeInTheDocument();
     expect(screen.getByText("Review 20%")).toBeInTheDocument();
     expect(screen.getByTestId("slider-valuetext")).toHaveTextContent("New 80%, review 20%");
-    // On-grid stored value: nothing to disclose.
+    // On-grid stored value: nothing to disclose, so nothing to describe either.
     expect(screen.queryByTestId("new-card-ratio-custom-notice")).not.toBeInTheDocument();
+    expect(screen.getByTestId("slider-root")).not.toHaveAttribute("aria-describedby");
+  });
+
+  it("treats a reduced on-grid fraction ({11,20} -> 55) as on-grid despite float division", () => {
+    // The backend reduces every stored fraction, so committing the slider's own
+    // 55% position stores 11/20 — and (11 / 20) * 100 is 55.00000000000001.
+    // Exact float equality against the grid would report the slider's own last
+    // write as a custom ratio set through the API.
+    renderWithIntl(
+      <MockedProvider mocks={[]}>
+        <NewCardRatioSection initialRatio={{ numerator: 11, denominator: 20 }} />
+      </MockedProvider>,
+    );
+
+    expect(screen.getByText("New 55%")).toBeInTheDocument();
+    expect(screen.getByText("Review 45%")).toBeInTheDocument();
+    expect(screen.getByTestId("slider-value")).toHaveTextContent("55");
+    expect(screen.queryByTestId("new-card-ratio-custom-notice")).not.toBeInTheDocument();
+    expect(screen.getByTestId("slider-root")).not.toHaveAttribute("aria-describedby");
+  });
+
+  it("keeps the two labels summing to 100 on a .x5 exact percent ({1,16} -> 6.25)", () => {
+    // Rounding each side independently would print 6.3% / 93.8%.
+    renderWithIntl(
+      <MockedProvider mocks={[]}>
+        <NewCardRatioSection initialRatio={{ numerator: 1, denominator: 16 }} />
+      </MockedProvider>,
+    );
+
+    expect(screen.getByText("New 6.3%")).toBeInTheDocument();
+    expect(screen.getByText("Review 93.7%")).toBeInTheDocument();
   });
 
   it("derives the initial percent from a reduced fraction ({3,20} -> 15)", () => {
@@ -122,6 +157,12 @@ describe("<NewCardRatioSection>", () => {
 
     const notice = screen.getByTestId("new-card-ratio-custom-notice");
     expect(notice).toHaveTextContent("A custom ratio (33%) is set via the API.");
+
+    // aria-valuetext stays faithful to where the control sits; the exact stored
+    // value reaches assistive tech through the notice instead.
+    expect(screen.getByTestId("slider-valuetext")).toHaveTextContent("New 35%, review 65%");
+    expect(notice.id).not.toBe("");
+    expect(screen.getByTestId("slider-root")).toHaveAttribute("aria-describedby", notice.id);
   });
 
   it("rounds a repeating off-grid ratio ({1,3}) to one decimal", () => {

--- a/frontend/src/app/profile/new-card-ratio-section.tsx
+++ b/frontend/src/app/profile/new-card-ratio-section.tsx
@@ -13,12 +13,22 @@ const MIN = 5;
 const MAX = 95;
 const STEP = 5;
 
-// Snap a stored (possibly reduced) fraction onto the 5% grid, clamped to
-// [MIN, MAX]. The default 4/5 -> 80 is already on-grid; the snap is defensive
-// for legacy rows.
-function snapPercent(numerator: number, denominator: number): number {
-  const raw = (numerator / denominator) * 100;
-  return Math.min(MAX, Math.max(MIN, Math.round(raw / STEP) * STEP));
+/** Exact share of new cards a stored (possibly reduced) fraction stands for. */
+function exactPercent(numerator: number, denominator: number): number {
+  return (numerator / denominator) * 100;
+}
+
+// Snap a percent onto the 5% grid, clamped to [MIN, MAX]. `updateNewCardRatio`
+// accepts any reduced fraction with 1 <= numerator < denominator <= 100, so an
+// off-grid ratio (33/100) is a legitimate stored state; the snap only positions
+// the 5%-step control and never stands in for the stored value.
+function snapPercent(percent: number): number {
+  return Math.min(MAX, Math.max(MIN, Math.round(percent / STEP) * STEP));
+}
+
+/** At most one decimal, so 1/3 reads 33.3% while 4/5 stays 80%. */
+function roundForDisplay(percent: number): number {
+  return Math.round(percent * 10) / 10;
 }
 
 type Props = { initialRatio: { numerator: number; denominator: number } };
@@ -31,33 +41,51 @@ type Props = { initialRatio: { numerator: number; denominator: number } };
  * on failure. No Apollo `optimisticResponse`: the mutation can return
  * UNAUTHENTICATED and Apollo v3 does not reliably roll those back.
  *
+ * The labels report the exact stored ratio, not the slider's grid position, so
+ * an off-grid value set through the API stays visible; a note discloses that
+ * moving the slider overwrites it with a 5% step.
+ *
  * This component assumes it is only mounted for admins — the parent gates on
  * `isAdmin`.
  */
 export function NewCardRatioSection({ initialRatio }: Props) {
   const t = useTranslations("Profile");
   const tCommon = useTranslations("Common");
+  // Slider position: always on the 5% grid.
   const [percent, setPercent] = useState(() =>
-    snapPercent(initialRatio.numerator, initialRatio.denominator),
+    snapPercent(exactPercent(initialRatio.numerator, initialRatio.denominator)),
   );
+  // Last server-confirmed value, exact rather than snapped: what the labels
+  // show whenever the slider is at rest.
+  const [confirmedPercent, setConfirmedPercent] = useState(() =>
+    exactPercent(initialRatio.numerator, initialRatio.denominator),
+  );
+  // True while the user drags or a save is in flight, when the labels must
+  // track the slider instead of the not-yet-replaced server-confirmed value.
+  const [trackingSlider, setTrackingSlider] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
   const [updateRatio, { loading }] = useMutation(UpdateNewCardRatioMutation);
-  // Last server-confirmed value; rollback target after intermediate
-  // onValueChange updates.
-  const committedRef = useRef(percent);
+  // Rollback target after intermediate onValueChange updates; a ref so a commit
+  // reads the latest confirmed value without waiting for a re-render.
+  const confirmedRef = useRef(confirmedPercent);
 
   async function handleCommit(next: number) {
-    if (next === committedRef.current || loading) return;
-    const previous = committedRef.current;
+    if (loading) return;
+    if (next === confirmedRef.current) {
+      setTrackingSlider(false);
+      return;
+    }
+    const previous = confirmedRef.current;
     setSaveError(null);
     setPercent(next);
     try {
       await updateRatio({ variables: { numerator: next, denominator: 100 } });
-      committedRef.current = next;
+      confirmedRef.current = next;
+      setConfirmedPercent(next);
     } catch (err) {
       // Roll the slider back to the last server-confirmed value so the UI never
       // shows a ratio the server rejected.
-      setPercent(previous);
+      setPercent(snapPercent(previous));
       setSaveError(
         mutationAuthBanner(err, {
           forbidden: tCommon("forbidden"),
@@ -66,18 +94,23 @@ export function NewCardRatioSection({ initialRatio }: Props) {
         }),
       );
       console.warn("[profile] updateNewCardRatio rejected", { codes: liftGraphQLCodes(err) });
+    } finally {
+      setTrackingSlider(false);
     }
   }
+
+  const displayPercent = trackingSlider ? percent : confirmedPercent;
+  const isOffGrid = confirmedPercent !== snapPercent(confirmedPercent);
 
   return (
     <fieldset className="flex flex-col gap-2 border-0 p-0">
       <legend className="mb-2 text-sm font-medium leading-none">{t("newCardRatio")}</legend>
       <div className="flex max-w-xs items-baseline justify-between">
         <span className="text-sm font-semibold text-brand-link">
-          {t("newCardRatioNewLabel", { percent })}
+          {t("newCardRatioNewLabel", { percent: roundForDisplay(displayPercent) })}
         </span>
         <span className="text-sm text-muted-foreground">
-          {t("newCardRatioReviewLabel", { percent: 100 - percent })}
+          {t("newCardRatioReviewLabel", { percent: roundForDisplay(100 - displayPercent) })}
         </span>
       </div>
       <Slider
@@ -89,7 +122,10 @@ export function NewCardRatioSection({ initialRatio }: Props) {
         disabled={loading}
         aria-label={t("newCardRatio")}
         aria-valuetext={t("newCardRatioValueText", { newPct: percent, reviewPct: 100 - percent })}
-        onValueChange={([next = percent]) => setPercent(next)}
+        onValueChange={([next = percent]) => {
+          setTrackingSlider(true);
+          setPercent(next);
+        }}
         onValueCommit={([next = percent]) => handleCommit(next)}
         data-testid="new-card-ratio-slider"
       />
@@ -97,6 +133,14 @@ export function NewCardRatioSection({ initialRatio }: Props) {
         <span>{MIN}%</span>
         <span>{MAX}%</span>
       </div>
+      {isOffGrid ? (
+        <p
+          className="max-w-xs text-xs text-muted-foreground"
+          data-testid="new-card-ratio-custom-notice"
+        >
+          {t("newCardRatioCustomNotice", { percent: roundForDisplay(confirmedPercent) })}
+        </p>
+      ) : null}
       {saveError ? <ErrorBanner data-testid="new-card-ratio-error">{saveError}</ErrorBanner> : null}
     </fieldset>
   );

--- a/frontend/src/app/profile/new-card-ratio-section.tsx
+++ b/frontend/src/app/profile/new-card-ratio-section.tsx
@@ -2,7 +2,7 @@
 
 import { useMutation } from "@apollo/client/react";
 import { useTranslations } from "next-intl";
-import { useRef, useState } from "react";
+import { useId, useRef, useState } from "react";
 import { UpdateNewCardRatioMutation } from "@/app/learn/queries";
 import { ErrorBanner } from "@/components/ui/error-banner";
 import { Slider } from "@/components/ui/slider";
@@ -43,7 +43,9 @@ type Props = { initialRatio: { numerator: number; denominator: number } };
  *
  * The labels report the exact stored ratio, not the slider's grid position, so
  * an off-grid value set through the API stays visible; a note discloses that
- * moving the slider overwrites it with a 5% step.
+ * moving the slider overwrites it with a 5% step, and `aria-describedby` ties
+ * that note to the thumb so a screen reader reaches the stored value too —
+ * `aria-valuetext` stays faithful to where the control actually sits.
  *
  * This component assumes it is only mounted for admins — the parent gates on
  * `isAdmin`.
@@ -51,6 +53,7 @@ type Props = { initialRatio: { numerator: number; denominator: number } };
 export function NewCardRatioSection({ initialRatio }: Props) {
   const t = useTranslations("Profile");
   const tCommon = useTranslations("Common");
+  const noticeId = useId();
   // Slider position: always on the 5% grid.
   const [percent, setPercent] = useState(() =>
     snapPercent(exactPercent(initialRatio.numerator, initialRatio.denominator)),
@@ -100,17 +103,29 @@ export function NewCardRatioSection({ initialRatio }: Props) {
   }
 
   const displayPercent = trackingSlider ? percent : confirmedPercent;
-  const isOffGrid = confirmedPercent !== snapPercent(confirmedPercent);
+  const displayNewPercent = roundForDisplay(displayPercent);
+  // The review side is derived from the already-rounded new-card value instead
+  // of being rounded on its own: an exact percent landing on a .x5 boundary
+  // (1/16 = 6.25) rounds up on both sides and the pair reads 6.3% / 93.8%.
+  const displayReviewPercent = roundForDisplay(100 - displayNewPercent);
+  const noticePercent = roundForDisplay(confirmedPercent);
+  // Compare what the label prints, not the raw quotient. The backend reduces
+  // every stored fraction, so a value the slider itself wrote comes back as
+  // 11/20, and `(11 / 20) * 100` is 55.00000000000001 in IEEE-754 — exact
+  // equality against the grid would call it a custom ratio. Rounding first is
+  // safe: the closest an accepted off-grid fraction gets to the grid is 5/99
+  // (0.05 percentage points), which still rounds clear of it.
+  const isOffGrid = noticePercent !== snapPercent(noticePercent);
 
   return (
     <fieldset className="flex flex-col gap-2 border-0 p-0">
       <legend className="mb-2 text-sm font-medium leading-none">{t("newCardRatio")}</legend>
       <div className="flex max-w-xs items-baseline justify-between">
         <span className="text-sm font-semibold text-brand-link">
-          {t("newCardRatioNewLabel", { percent: roundForDisplay(displayPercent) })}
+          {t("newCardRatioNewLabel", { percent: displayNewPercent })}
         </span>
         <span className="text-sm text-muted-foreground">
-          {t("newCardRatioReviewLabel", { percent: roundForDisplay(100 - displayPercent) })}
+          {t("newCardRatioReviewLabel", { percent: displayReviewPercent })}
         </span>
       </div>
       <Slider
@@ -122,6 +137,7 @@ export function NewCardRatioSection({ initialRatio }: Props) {
         disabled={loading}
         aria-label={t("newCardRatio")}
         aria-valuetext={t("newCardRatioValueText", { newPct: percent, reviewPct: 100 - percent })}
+        aria-describedby={isOffGrid ? noticeId : undefined}
         onValueChange={([next = percent]) => {
           setTrackingSlider(true);
           setPercent(next);
@@ -135,10 +151,11 @@ export function NewCardRatioSection({ initialRatio }: Props) {
       </div>
       {isOffGrid ? (
         <p
+          id={noticeId}
           className="max-w-xs text-xs text-muted-foreground"
           data-testid="new-card-ratio-custom-notice"
         >
-          {t("newCardRatioCustomNotice", { percent: roundForDisplay(confirmedPercent) })}
+          {t("newCardRatioCustomNotice", { percent: noticePercent })}
         </p>
       ) : null}
       {saveError ? <ErrorBanner data-testid="new-card-ratio-error">{saveError}</ErrorBanner> : null}

--- a/frontend/src/app/profile/new-card-ratio-section.tsx
+++ b/frontend/src/app/profile/new-card-ratio-section.tsx
@@ -13,25 +13,68 @@ const MIN = 5;
 const MAX = 95;
 const STEP = 5;
 
-/** Exact share of new cards a stored (possibly reduced) fraction stands for. */
-function exactPercent(numerator: number, denominator: number): number {
-  return (numerator / denominator) * 100;
+type Ratio = { numerator: number; denominator: number };
+
+// `updateNewCardRatio` accepts any reduced fraction with
+// 1 <= numerator < denominator <= 100, so an off-grid ratio (33/100) is a
+// legitimate stored state. That stored value IS a rational number, and every
+// question this component asks about it — is it on the 5% grid, where does the
+// control sit, what do the labels read — has an exact integer answer, so the
+// helpers below scale to integers before dividing instead of dividing first and
+// rounding the IEEE-754 error away afterwards.
+
+/**
+ * Exact share of new cards in tenths of a percent (0..1000), round-half-up:
+ * 1000n/d rounded is `floor((2000n + d) / 2d)`. Every term is a safe integer
+ * because 2000n <= 200000. JS has no integer division, so the quotient is a
+ * float — but the `Math.floor` is still exact: a non-integral quotient of these
+ * operands sits at least 1/2d away from any integer, and d <= 100 puts that at
+ * 0.005 or more, many orders of magnitude beyond double rounding error. An
+ * integral quotient divides exactly.
+ */
+function shareTenths({ numerator, denominator }: Ratio): number {
+  return Math.floor((2000 * numerator + denominator) / (2 * denominator));
 }
 
-// Snap a percent onto the 5% grid, clamped to [MIN, MAX]. `updateNewCardRatio`
-// accepts any reduced fraction with 1 <= numerator < denominator <= 100, so an
-// off-grid ratio (33/100) is a legitimate stored state; the snap only positions
-// the 5%-step control and never stands in for the stored value.
-function snapPercent(percent: number): number {
-  return Math.min(MAX, Math.max(MIN, Math.round(percent / STEP) * STEP));
+/**
+ * True when the exact share 100n/d is a whole multiple of 5, which happens
+ * exactly when d divides 20n. n < d keeps the share strictly inside (0, 100),
+ * so an on-grid share always lands within [MIN, MAX] and the clamp never
+ * interacts with this test.
+ */
+function isOnGrid({ numerator, denominator }: Ratio): boolean {
+  return (20 * numerator) % denominator === 0;
 }
 
-/** At most one decimal, so 1/3 reads 33.3% while 4/5 stays 80%. */
-function roundForDisplay(percent: number): number {
-  return Math.round(percent * 10) / 10;
+/**
+ * Position of the 5%-step control: the nearest grid step to the exact share,
+ * clamped to [MIN, MAX]. The grid index is 20n/d rounded half-up, i.e.
+ * `floor((40n + d) / 2d)`. Its `Math.floor` is exact for the same reason as
+ * `shareTenths`: these operands put every non-integral quotient at least
+ * 1/2d >= 0.005 clear of the nearest integer. The control only positions itself
+ * here — it never stands in for the stored value.
+ */
+function gridPercent({ numerator, denominator }: Ratio): number {
+  const gridIndex = Math.floor((40 * numerator + denominator) / (2 * denominator));
+  return Math.min(MAX, Math.max(MIN, STEP * gridIndex));
 }
 
-type Props = { initialRatio: { numerator: number; denominator: number } };
+/** True when the stored ratio is exactly `percent`%, i.e. 100n/d === percent. */
+function equalsPercent({ numerator, denominator }: Ratio, percent: number): boolean {
+  return 100 * numerator === percent * denominator;
+}
+
+/**
+ * The number the ICU message interpolates: 800 -> 80, 333 -> 33.3. Dividing a
+ * tenths integer by 10 yields the only float that reaches the UI, and it is
+ * exact in the only sense that matters here — the quotient is the double
+ * nearest that decimal, so it prints back as the same one-decimal string.
+ */
+function tenthsToPercent(tenths: number): number {
+  return tenths / 10;
+}
+
+type Props = { initialRatio: Ratio };
 
 /**
  * New-card ratio slider on `/profile`: lets the signed-in user pick what share
@@ -55,14 +98,11 @@ export function NewCardRatioSection({ initialRatio }: Props) {
   const tCommon = useTranslations("Common");
   const noticeId = useId();
   // Slider position: always on the 5% grid.
-  const [percent, setPercent] = useState(() =>
-    snapPercent(exactPercent(initialRatio.numerator, initialRatio.denominator)),
-  );
-  // Last server-confirmed value, exact rather than snapped: what the labels
-  // show whenever the slider is at rest.
-  const [confirmedPercent, setConfirmedPercent] = useState(() =>
-    exactPercent(initialRatio.numerator, initialRatio.denominator),
-  );
+  const [percent, setPercent] = useState(() => gridPercent(initialRatio));
+  // Last server-confirmed ratio, kept as the stored fraction rather than a
+  // percent: it is what the labels report whenever the slider is at rest, and
+  // the exact-integer helpers all read a fraction.
+  const [confirmedRatio, setConfirmedRatio] = useState<Ratio>(initialRatio);
   // True while the user drags or a save is in flight, when the labels must
   // track the slider instead of the not-yet-replaced server-confirmed value.
   const [trackingSlider, setTrackingSlider] = useState(false);
@@ -70,11 +110,11 @@ export function NewCardRatioSection({ initialRatio }: Props) {
   const [updateRatio, { loading }] = useMutation(UpdateNewCardRatioMutation);
   // Rollback target after intermediate onValueChange updates; a ref so a commit
   // reads the latest confirmed value without waiting for a re-render.
-  const confirmedRef = useRef(confirmedPercent);
+  const confirmedRef = useRef(confirmedRatio);
 
   async function handleCommit(next: number) {
     if (loading) return;
-    if (next === confirmedRef.current) {
+    if (equalsPercent(confirmedRef.current, next)) {
       setTrackingSlider(false);
       return;
     }
@@ -83,12 +123,13 @@ export function NewCardRatioSection({ initialRatio }: Props) {
     setPercent(next);
     try {
       await updateRatio({ variables: { numerator: next, denominator: 100 } });
-      confirmedRef.current = next;
-      setConfirmedPercent(next);
+      const committed = { numerator: next, denominator: 100 };
+      confirmedRef.current = committed;
+      setConfirmedRatio(committed);
     } catch (err) {
       // Roll the slider back to the last server-confirmed value so the UI never
       // shows a ratio the server rejected.
-      setPercent(snapPercent(previous));
+      setPercent(gridPercent(previous));
       setSaveError(
         mutationAuthBanner(err, {
           forbidden: tCommon("forbidden"),
@@ -102,20 +143,18 @@ export function NewCardRatioSection({ initialRatio }: Props) {
     }
   }
 
-  const displayPercent = trackingSlider ? percent : confirmedPercent;
-  const displayNewPercent = roundForDisplay(displayPercent);
-  // The review side is derived from the already-rounded new-card value instead
-  // of being rounded on its own: an exact percent landing on a .x5 boundary
-  // (1/16 = 6.25) rounds up on both sides and the pair reads 6.3% / 93.8%.
-  const displayReviewPercent = roundForDisplay(100 - displayNewPercent);
-  const noticePercent = roundForDisplay(confirmedPercent);
-  // Compare what the label prints, not the raw quotient. The backend reduces
-  // every stored fraction, so a value the slider itself wrote comes back as
-  // 11/20, and `(11 / 20) * 100` is 55.00000000000001 in IEEE-754 — exact
-  // equality against the grid would call it a custom ratio. Rounding first is
-  // safe: the closest an accepted off-grid fraction gets to the grid is 5/99
-  // (0.05 percentage points), which still rounds clear of it.
-  const isOffGrid = noticePercent !== snapPercent(noticePercent);
+  // A dragged value is a whole percent, so it is already an exact tenths count.
+  const displayTenths = trackingSlider ? percent * 10 : shareTenths(confirmedRatio);
+  const displayNewPercent = tenthsToPercent(displayTenths);
+  // The review side is the complement of the same tenths count, so the pair
+  // sums to exactly 100.0 by construction — rounding each side on its own would
+  // print 6.3% / 93.8% for an exact share landing on a .x5 boundary (1/16).
+  const displayReviewPercent = tenthsToPercent(1000 - displayTenths);
+  // The stored share only prints as a grid value when it IS one: an off-grid
+  // share sits at least 5/99 of a percentage point from the grid, further than
+  // the tenths rounding can travel.
+  const noticePercent = tenthsToPercent(shareTenths(confirmedRatio));
+  const isOffGrid = !isOnGrid(confirmedRatio);
 
   return (
     <fieldset className="flex flex-col gap-2 border-0 p-0">

--- a/frontend/src/components/ui/slider.test.tsx
+++ b/frontend/src/components/ui/slider.test.tsx
@@ -32,6 +32,26 @@ describe("<Slider>", () => {
     expect(slider).toHaveAttribute("aria-valuenow", "80");
   });
 
+  it("forwards aria-describedby onto the role=slider thumb, not the root", () => {
+    render(
+      <>
+        <Slider
+          min={5}
+          max={95}
+          step={5}
+          value={[35]}
+          aria-label="New card ratio"
+          aria-describedby="ratio-note"
+        />
+        <p id="ratio-note">A custom ratio is set via the API.</p>
+      </>,
+    );
+
+    // Radix spreads leftover props onto the root, which carries no ARIA role,
+    // so the description would never be announced from there.
+    expect(screen.getByRole("slider")).toHaveAttribute("aria-describedby", "ratio-note");
+  });
+
   it("moves the value by step on ArrowRight / ArrowLeft", async () => {
     const user = userEvent.setup();
     render(<ControlledSlider />);

--- a/frontend/src/components/ui/slider.tsx
+++ b/frontend/src/components/ui/slider.tsx
@@ -13,33 +13,47 @@ import { cn } from "@/lib/utils";
  * uses); the thumb is white with a coral border and a `--ring` focus ring. Arrow
  * keys move the value by `step` (Radix built-in).
  *
- * Consumers supply `aria-label` / `aria-valuetext`; both are forwarded to the
- * thumb — the element Radix marks `role="slider"` — because Radix does not emit
- * `aria-valuetext` on its own and only reads `aria-label` off the thumb, not the
- * root. Forwarding here is what lets assistive tech announce the value text.
+ * Consumers supply `aria-label` / `aria-valuetext` / `aria-describedby`; all
+ * three are forwarded to the thumb — the element Radix marks `role="slider"` —
+ * because Radix spreads the remaining props onto the root and only reads
+ * `aria-label` off the thumb. An `aria-describedby` left on the root would name
+ * a description for an element assistive tech never lands on, so forwarding here
+ * is what lets a screen reader announce the value text and any attached note.
  */
 const Slider = React.forwardRef<
   React.ElementRef<typeof SliderPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root>
->(({ className, "aria-label": ariaLabel, "aria-valuetext": ariaValueText, ...props }, ref) => (
-  <SliderPrimitive.Root
-    ref={ref}
-    className={cn(
-      "relative flex w-full touch-none select-none items-center data-[disabled]:opacity-50",
+>(
+  (
+    {
       className,
-    )}
-    {...props}
-  >
-    <SliderPrimitive.Track className="relative h-2 w-full grow overflow-hidden rounded-full bg-muted">
-      <SliderPrimitive.Range className="absolute h-full bg-brand-primary" />
-    </SliderPrimitive.Track>
-    <SliderPrimitive.Thumb
-      aria-label={ariaLabel}
-      aria-valuetext={ariaValueText}
-      className="block h-5 w-5 rounded-full border-2 border-brand-primary bg-white shadow ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50"
-    />
-  </SliderPrimitive.Root>
-));
+      "aria-label": ariaLabel,
+      "aria-valuetext": ariaValueText,
+      "aria-describedby": ariaDescribedBy,
+      ...props
+    },
+    ref,
+  ) => (
+    <SliderPrimitive.Root
+      ref={ref}
+      className={cn(
+        "relative flex w-full touch-none select-none items-center data-[disabled]:opacity-50",
+        className,
+      )}
+      {...props}
+    >
+      <SliderPrimitive.Track className="relative h-2 w-full grow overflow-hidden rounded-full bg-muted">
+        <SliderPrimitive.Range className="absolute h-full bg-brand-primary" />
+      </SliderPrimitive.Track>
+      <SliderPrimitive.Thumb
+        aria-label={ariaLabel}
+        aria-valuetext={ariaValueText}
+        aria-describedby={ariaDescribedBy}
+        className="block h-5 w-5 rounded-full border-2 border-brand-primary bg-white shadow ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50"
+      />
+    </SliderPrimitive.Root>
+  ),
+);
 Slider.displayName = SliderPrimitive.Root.displayName;
 
 export { Slider };


### PR DESCRIPTION
## Summary

`updateNewCardRatio` accepts any reduced fraction with `1 <= numerator < denominator <= 100`, so an off-grid stored ratio such as 33/100 is a legitimate state that the 5%-step `/profile` slider cannot represent — and the labels reported the snapped grid position (35%) as if it were the stored value, while the learn queue interleaved with the exact 33/100. The section now derives everything it renders from exact integer arithmetic on the stored `{ numerator, denominator }` pair: the labels report the stored share, the control positions itself independently, and a note under the slider discloses that moving it overwrites the stored ratio with a 5% step. The shared `Slider` gained `aria-describedby` forwarding so that note reaches assistive tech. The section is admin-gated, so the surface is `/profile` for admins only.

## Changes

### Exact-rational display

- `frontend/src/app/profile/new-card-ratio-section.tsx` — the float `snapPercent` pipeline is gone. Four integer helpers replace it: `isOnGrid` is `(20 * numerator) % denominator === 0`; `shareTenths` is the stored share in tenths of a percent, `Math.floor((2000n + d) / 2d)`; `gridPercent` is the control's step index `Math.floor((40n + d) / 2d)` scaled by `STEP` and clamped into `[MIN, MAX]` (5–95); `equalsPercent` is `100n === percent * d`. No question the component asks about the stored ratio goes through a division-then-round.
- Displayed pair sums to exactly 100 structurally: the new side is `displayTenths / 10` and the review side is `(1000 - displayTenths) / 10`, the complement of the *same* tenths count. Rounding each side independently would print `6.3% / 93.8%` for a share landing on a `.x5` boundary (1/16).
- State split: `confirmedRatio` holds the last server-confirmed fraction (not a percent) and drives the labels at rest; `percent` holds the grid position and drives the control; `trackingSlider` switches the labels onto the dragged whole-percent value during a drag and while a save is in flight. Failed saves roll the control back via `setPercent(gridPercent(previous))`.
- `handleCommit`'s no-op guard is the exact `equalsPercent(confirmedRef.current, next)`, so re-committing the slider's own last write — stored as the GCD-reduced 11/20 after a 55% commit — fires no mutation.
- The off-grid note renders only when `!isOnGrid(confirmedRatio)`, carries a `useId()` id, and is wired to the thumb via `aria-describedby`. `aria-valuetext` deliberately keeps reporting the grid position, since that is where the control actually sits.

### Shared slider accessibility

- `frontend/src/components/ui/slider.tsx` — `aria-describedby` is destructured out of the forwarded props and set on `SliderPrimitive.Thumb` alongside `aria-label` / `aria-valuetext`. Radix spreads leftover props onto the Root, which carries no ARIA role, so a description left there names an element assistive tech never lands on. The docblock now covers all three forwarded attributes.

### Message catalogs

- `frontend/messages/en.json` / `ja.json` — new `Profile.newCardRatioCustomNotice` key interpolating the stored `{percent}` and stating that moving the slider replaces it with a 5% step.

### Tests

- `frontend/src/app/profile/new-card-ratio-section.test.tsx` — the slider double now renders a `slider-root` carrying `aria-describedby` so the wiring is assertable, plus `commit-40` / `commit-55` triggers. New cases: 11/20 (the reduced form of the slider's own 55% write) is treated as on-grid with no notice and no `aria-describedby`; 33/100 renders `New 33%` / `Review 67%` with the control parked at 35, the notice present, and `aria-describedby` equal to the notice's id; 1/3 rounds to `33.3%` / `66.7%`; 1/16 prints `6.3%` / `93.7%` (complement, not independent rounding); a parameterised set of off-grid fractions (5/99, 49/99, 1/7, 1/6, 2/3) asserts only that the two rendered labels sum to 100, which is the assertion an independent-rounding regression fails; 1/100 and 39/40 park the control at 5 and 95 while the labels keep reporting 1% / 97.5%; dragging shows the dragged grid value while the off-grid notice stays until a commit lands; committing 40 over a stored 33/100 drops the notice; and committing 55 over a stored 11/20 fires no mutation, with a following commit to 40 as the synchronisation point that makes the negative assertion deterministic.
- `frontend/src/components/ui/slider.test.tsx` — new case asserting `aria-describedby` lands on the `role="slider"` thumb, not the root.

## Test plan

- [ ] `tsc --noEmit` — pass (exit 0)
- [ ] `biome check --error-on-warnings .` — pass, 520 files checked, no fixes applied
- [ ] `vitest run` — 206 files / 1917 tests pass
- [ ] `knip` — clean (exit 0)
- [ ] `next build` — pass
- [ ] Manual `/profile` as an admin: with an on-grid stored ratio the labels match the slider and no note renders; after setting an off-grid ratio through the API the labels report it exactly, the control parks on the nearest step, and the note appears
- [ ] Regression: dragging the slider tracks the dragged value in the labels, and releasing on the already-stored value issues no mutation

## Notes

- No Playwright run — the e2e suite needs a live Supabase + backend stack. `frontend/e2e/i18n-language-switch.spec.ts` is the only spec that visits `/profile`; it drives the language `combobox` and asserts nothing about this section, which is admin-gated at `profile-page-client.tsx` and not rendered for the e2e user. No `data-testid` was renamed and the added `new-card-ratio-custom-notice` element is not a combobox, so that spec's single-combobox assumption is unaffected.
- Backend untouched — the accepted range and the GCD reduction that turns a 55% slider commit into a stored 11/20 both live in `backend/internal/domain/new_card_ratio.go` and are unchanged.

Closes #988
