### PR TITLE
fix(ui): unclip FormSheet focus rings and inset catalog deck rows

### DIFF
--- a/frontend/src/components/cardgroups/merge-from-catalog-sheet.test.tsx
+++ b/frontend/src/components/cardgroups/merge-from-catalog-sheet.test.tsx
@@ -221,6 +221,14 @@ describe("<MergeFromCatalogSheet>", () => {
     expect(screen.getByText("JLPT Kanji")).toBeInTheDocument();
   });
 
+  it("insets each deck row horizontally so its name lines up with the search placeholder", async () => {
+    renderSheet({ mocks: [BASE_CATALOG] });
+
+    // The search field is a design-system `<Input>` with `px-3`; a row rendered flush
+    // against the list container reads as misaligned against the placeholder above it.
+    expect(await screen.findByTestId("merge-from-catalog-row-master-1")).toHaveClass("px-3");
+  });
+
   it("selecting a row previews the diff and confirming merges", async () => {
     const user = userEvent.setup();
     const onMerged = vi.fn();

--- a/frontend/src/components/cardgroups/merge-from-catalog-sheet.tsx
+++ b/frontend/src/components/cardgroups/merge-from-catalog-sheet.tsx
@@ -266,7 +266,9 @@ export function MergeFromCatalogSheet({
                   <button
                     type="button"
                     onClick={() => void handleSelect(deck.id, deck.name)}
-                    className="flex w-full items-center justify-between gap-3 py-3 text-left hover:bg-muted/40"
+                    // `px-3` matches the search field's own horizontal padding so the deck
+                    // name lines up with the placeholder text directly above it.
+                    className="flex w-full items-center justify-between gap-3 px-3 py-3 text-left hover:bg-muted/40"
                     data-testid={`merge-from-catalog-row-${deck.id}`}
                   >
                     <span className="min-w-0">

--- a/frontend/src/components/ui/form-sheet.test.tsx
+++ b/frontend/src/components/ui/form-sheet.test.tsx
@@ -91,6 +91,19 @@ describe("<FormSheet>", () => {
     expect(screen.getByTestId("form-sheet-body")).toHaveClass("flex-1", "overflow-y-auto");
   });
 
+  it("reserves padding around the desktop sheet body so a focused field's ring is not clipped", () => {
+    renderWithIntl(
+      <FormSheet open onOpenChange={vi.fn()} title="Edit card">
+        <input aria-label="First field" />
+      </FormSheet>,
+    );
+
+    // `overflow-y-auto` clips at the padding box, and `ring-2 ring-offset-2` paints 4px
+    // outside the field's border box. `p-2` reserves that room; `-m-2` cancels it so the
+    // body keeps its original position.
+    expect(screen.getByTestId("form-sheet-body")).toHaveClass("-m-2", "p-2");
+  });
+
   it("renders a mobile drawer dialog when useIsMobile returns true", () => {
     vi.mocked(useIsMobile).mockReturnValue(true);
 
@@ -384,6 +397,20 @@ describe("<FormSheet>", () => {
       "max-h-[calc(100dvh-7rem)]",
       "overflow-y-auto",
     );
+  });
+
+  it("reserves padding above the mobile drawer body so a focused field's ring is not clipped", () => {
+    vi.mocked(useIsMobile).mockReturnValue(true);
+
+    renderWithIntl(
+      <FormSheet open onOpenChange={vi.fn()} title="Add card">
+        <input aria-label="First field" />
+      </FormSheet>,
+    );
+
+    // Same reserve as the desktop body; `px-4` already leaves horizontal room, so only the
+    // top edge needs it here.
+    expect(screen.getByTestId("form-sheet-body")).toHaveClass("-mt-2", "pt-2");
   });
 
   it("renders a string-title desktop sheet with accessible description '<title> form'", () => {

--- a/frontend/src/components/ui/form-sheet.tsx
+++ b/frontend/src/components/ui/form-sheet.tsx
@@ -131,8 +131,16 @@ function FormSheet({
             {a11yDescription}
           </DrawerDescription>
         </DrawerHeader>
+        {/*
+          `pt-2` (cancelled out by `-mt-2` so the first child keeps its position) reserves
+          scroll-container padding above the first child: `overflow-y-auto` clips at the
+          padding box, and a focused field's `ring-2 ring-offset-2` paints 4px outside its
+          border box. Without the reserve, a field flush against the top of the body — e.g.
+          the search input in `merge-from-catalog-sheet.tsx` — renders with its focus ring
+          sheared off. `px-4` already leaves horizontal room.
+        */}
         <div
-          className="flex max-h-[calc(100dvh-7rem)] flex-col gap-4 overflow-y-auto px-4 pb-4"
+          className="-mt-2 flex max-h-[calc(100dvh-7rem)] flex-col gap-4 overflow-y-auto px-4 pb-4 pt-2"
           data-testid="form-sheet-body"
         >
           {children}
@@ -150,7 +158,8 @@ function FormSheet({
             {a11yDescription}
           </SheetDescription>
         </SheetHeader>
-        <div className="-mx-2 flex-1 overflow-y-auto px-2" data-testid="form-sheet-body">
+        {/* `-m-2 p-2`: same focus-ring reserve as the drawer body, on all four sides. */}
+        <div className="-m-2 flex-1 overflow-y-auto p-2" data-testid="form-sheet-body">
           {children}
         </div>
       </SheetContent>


### PR DESCRIPTION
## Summary

The "Merge from catalog" sheet rendered its search field with the focus ring sheared off along the top edge, and the catalog deck rows sat visibly left of the placeholder text directly above them. The ring clip is a shared-surface bug: `FormSheet`'s scroll body reserved ring room horizontally (`-mx-2 … px-2`) but not vertically, and `overflow-y-auto` clips at the padding box, so any focused field flush against the top of a sheet body loses the 4px its `ring-2 ring-offset-2` paints outside its border box. The row misalignment is local to the merge sheet: the design-system `<Input>` carries `px-3` while the row button had no horizontal padding, so its content hugged the list container edge.

Both fixes are CSS-only. The `FormSheet` change applies to every consumer of the shared sheet, not just this one screen.

## Changes

### FormSheet scroll body

- `frontend/src/components/ui/form-sheet.tsx` — the desktop `SheetContent` body moves from `-mx-2 … px-2` to `-m-2 … p-2`, and the mobile `DrawerContent` body gains `-mt-2 … pt-2`. The padding is what reserves the clip room; the matching negative margin cancels it so the first child keeps its original position, the flex `gap-4` under `SheetHeader` still reads as 16px, and the sheet's `p-6` / drawer's `p-4` content edges are unchanged.
- The drawer needs only the top reserve — its existing `px-4` / `pb-4` already clear the ring on the other three sides.
- Both bodies carry a comment naming the mechanism (padding-box clipping vs. ring-offset paint area) so the negative margin is not mistaken for dead styling.

### Catalog deck rows

- `frontend/src/components/cardgroups/merge-from-catalog-sheet.tsx` — the deck-row button gains `px-3`, matching the search field's own horizontal padding. This follows `cardgroup-picker-sheet.tsx` (`rounded-md px-3 py-3`) and `batch-import-wizard.tsx` (`px-3 py-2`), the repo's other list-row buttons.
- The `<ul>`'s `divide-y divide-border` is unchanged, so the dividers stay full-bleed while row content is inset — the standard inset-content / full-bleed-divider list shape.

### Tests

- `frontend/src/components/ui/form-sheet.test.tsx` — two cases pinning the reserve, one per branch: the desktop body carries `-m-2` + `p-2`, the drawer body carries `-mt-2` + `pt-2`. Both fail if the change is reverted, since the pre-change classes were `-mx-2` / `px-2` and a bare `px-4 pb-4`.
- `frontend/src/components/cardgroups/merge-from-catalog-sheet.test.tsx` — one case asserting the rendered deck row carries `px-3`.

## Verification

Open a deck at `/cardgroups/<id>`, choose "Merge from catalog" from the header `+` menu, and click into the search field: the coral focus ring is closed on all four sides. In DevTools, `[data-testid="form-sheet-body"]` resolves to `-m-2 flex-1 overflow-y-auto p-2` on desktop and `-mt-2 … px-4 pb-4 pt-2` under 768px. Each `[data-testid^="merge-from-catalog-row-"]` carries `px-3`, and its deck name starts at the same x as the search placeholder.

## Test plan

- [ ] `tsc --noEmit` — pass (exit 0)
- [ ] `biome check --error-on-warnings src` — pass, 472 files checked, no fixes applied
- [ ] `vitest run` — 206 files / 1929 tests pass
- [ ] `knip` — clean (exit 0)
- [ ] `next build` — pass
- [ ] Visual: the merge sheet's focused search field shows an unbroken ring, and the deck name lines up with the placeholder above it
- [ ] Regression, desktop: an open `FormSheet` with a tall form still scrolls, and its first field sits at the same y as before
- [ ] Regression, mobile (<768px): the drawer variant of the same sheet keeps its header gap and `max-h-[calc(100dvh-7rem)]` scroll behaviour

## Notes

- Diagnosis is pixel-measured from the reported screenshot, not inferred: the input's border box runs y=82–121, and the coral ring `#FF6571` is present below (y=124–125) and on both sides (x=29–30, x=658–659) but absent above. The deck name's glyph left edge measured x=35 against the placeholder's x=46; in box-model terms the row was inset 0 against the field's 13px (`px-3` + 1px border), leaving a 1px residual after the fix.
- Reviewed by a 19-agent adversarial pass across five lenses (CSS box model, `FormSheet` consumer-regression sweep, refutation of the diagnosis itself, row alignment, repo conventions). Fourteen raw findings, none survived refutation; the consumer sweep returned no findings. One accepted nit — a comment claiming "the body keeps its position" when only the first child does — is folded into the `FormSheet` commit.
- Deliberately out of scope: the loading / empty / no-match paragraphs in the same sheet stay flush-left, matching every other list screen in the app (`/catalog`, `/cardgroups`, the admin lists), and the deck rows keep the UA focus outline rather than gaining the picker sheet's `focus-visible` ring.
- No Playwright run — the e2e suite needs a live Supabase + backend stack. No `data-testid` or label changed, and `frontend/e2e/` contains no reference to `merge-from-catalog`, so no spec selectors are affected.

No related issue.
