### PR TITLE
fix(backend): enforce the 5-deck cardgroup quota on master catalog import

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -192,7 +192,7 @@ func buildResolver(
 	var cefrWords domain.CEFRWordList = cefr.NewWordList()
 	cefrClassifier := service.NewCEFRClassifier(cefrWords)
 	cefrUC := usecase.NewCEFRUsecase(cefrClassifier)
-	masterCatalogUC := usecase.NewMasterCatalogUsecase(repos.masterCardgroup, masterDeckUC, adminGate, logger)
+	masterCatalogUC := usecase.NewMasterCatalogUsecase(repos.masterCardgroup, masterDeckUC, repos.cardgroup, adminGate, logger)
 	masterCardUC := usecase.NewMasterCardUsecase(repos.gorm, repos.masterCard, repos.masterCardgroup, adminGate, logger)
 	statsUC := usecase.NewStats(repos.userCardFSRS, repos.swipeRecord, repos.cardgroup, nil)
 

--- a/backend/graph/resolver/master_catalog.resolvers.go
+++ b/backend/graph/resolver/master_catalog.resolvers.go
@@ -106,10 +106,12 @@ func (r *mutationResolver) AdminDeleteMasterCardgroup(ctx context.Context, id st
 
 // ImportMasterCardgroup is the resolver for the importMasterCardgroup field.
 //
-// Returns a union: model.ImportMasterCardgroupSuccess on the happy path, or
+// Returns a union: model.ImportMasterCardgroupSuccess on the happy path,
 // model.MasterNotFoundError when the master id is unknown or not published
-// (draft existence is never leaked). The not-found case is "errors as data";
-// the error return is reserved for auth and infrastructure failures.
+// (draft existence is never leaked), or model.CardgroupLimitReachedError when a
+// non-admin caller has already reached the per-user cardgroup cap. Both failure
+// cases are "errors as data"; the error return is reserved for auth and
+// infrastructure failures.
 func (r *mutationResolver) ImportMasterCardgroup(ctx context.Context, masterCardgroupID string) (model.ImportMasterCardgroupResult, error) {
 	outcome, err := r.MasterCatalogUC.ImportMaster(ctx, masterCardgroupID)
 	if err != nil {
@@ -118,6 +120,13 @@ func (r *mutationResolver) ImportMasterCardgroup(ctx context.Context, masterCard
 	if outcome.NotFound {
 		return model.MasterNotFoundError{
 			Message: "Master cardgroup not found",
+		}, nil
+	}
+	if outcome.LimitReached != nil {
+		return model.CardgroupLimitReachedError{
+			Message: "cardgroup limit reached",
+			Limit:   outcome.LimitReached.Limit,
+			Current: outcome.LimitReached.Current,
 		}, nil
 	}
 	if outcome.Cardgroup == nil {

--- a/backend/graph/resolver/master_catalog_import_test.go
+++ b/backend/graph/resolver/master_catalog_import_test.go
@@ -58,6 +58,35 @@ func TestMutationResolver_ImportMasterCardgroup_NotFound_ReturnsTypedError(t *te
 	}
 }
 
+func TestMutationResolver_ImportMasterCardgroup_LimitReached_ReturnsTypedError(t *testing.T) {
+	t.Parallel()
+
+	// The quota rejection is data, mapped to the same CardgroupLimitReachedError
+	// variant createCardgroup returns, carrying limit/current so the client can
+	// localize the copy without a second round-trip.
+	stub := &stubMasterCatalogUC{
+		importOut: usecase.ImportMasterOutcome{
+			LimitReached: &usecase.CardgroupLimitInfo{Limit: 5, Current: 5},
+		},
+	}
+	r := &Resolver{MasterCatalogUC: stub}
+
+	res, err := r.Mutation().ImportMasterCardgroup(context.Background(), "m1")
+	if err != nil {
+		t.Fatalf("limit-reached must be data, not error; got %v", err)
+	}
+	limit, ok := res.(model.CardgroupLimitReachedError)
+	if !ok {
+		t.Fatalf("expected CardgroupLimitReachedError, got %T", res)
+	}
+	if limit.Limit != 5 || limit.Current != 5 {
+		t.Fatalf("expected limit=5 current=5, got limit=%d current=%d", limit.Limit, limit.Current)
+	}
+	if limit.Message == "" {
+		t.Fatal("expected a non-empty message")
+	}
+}
+
 func TestMutationResolver_ImportMasterCardgroup_Unauthenticated_WrapsError(t *testing.T) {
 	t.Parallel()
 

--- a/backend/internal/repository/master_catalog_merge_parity_integration_test.go
+++ b/backend/internal/repository/master_catalog_merge_parity_integration_test.go
@@ -39,7 +39,7 @@ func newMasterCatalogUsecaseForParityTest(t *testing.T) usecase.MasterCatalogUse
 	cgRepo := repository.NewCardgroupRepository(testDB.GORM)
 	deckUC := usecase.NewMasterDeckUsecase(mcgRepo, mcRepo, cardRepo, cgRepo, testDB.GORM, logger)
 	adminGate := usecase.NewAdminGate(stubParityAdminChecker{})
-	return usecase.NewMasterCatalogUsecase(mcgRepo, deckUC, adminGate, logger)
+	return usecase.NewMasterCatalogUsecase(mcgRepo, deckUC, cgRepo, adminGate, logger)
 }
 
 // seedOwnedCardgroupWithCards creates a user-owned cardgroup and inserts the given

--- a/backend/internal/usecase/admin_gate.go
+++ b/backend/internal/usecase/admin_gate.go
@@ -37,6 +37,15 @@ func NewAdminGate(checker AdminChecker) *AdminGate {
 	return &AdminGate{checker: checker}
 }
 
+// IsAdmin delegates to the wrapped AdminChecker so *AdminGate itself satisfies
+// AdminChecker. Usecases that already hold an *AdminGate for their admin-gated
+// methods can therefore pass it to helpers that take a bare AdminChecker (e.g.
+// checkCardgroupLimit's admin exemption) instead of carrying a second,
+// redundant dependency on the same underlying auth service.
+func (g *AdminGate) IsAdmin(ctx context.Context, userID string) (bool, error) {
+	return g.checker.IsAdmin(ctx, userID)
+}
+
 // Require returns the caller's user ID after confirming the bearer is an
 // admin. Return paths:
 //

--- a/backend/internal/usecase/master_catalog.go
+++ b/backend/internal/usecase/master_catalog.go
@@ -154,25 +154,32 @@ type MasterCatalogUsecase interface {
 }
 
 // ImportMasterOutcome is the usecase result of ImportMaster. On the valid paths
-// exactly one signal is set: Cardgroup on the happy path, or NotFound=true when the
-// master id is unknown or not published. The not-found case is surfaced as data (the
-// MasterNotFoundError union variant) rather than as an error so the resolver can
-// return it in `data`. The XOR is a producer contract, not a compile-time guarantee:
-// a degenerate {Cardgroup:nil, NotFound:false} result is treated as INTERNAL by the
-// resolver's defensive guard.
+// exactly one signal is set: Cardgroup on the happy path, NotFound=true when the
+// master id is unknown or not published, or LimitReached when a non-admin caller
+// already owns the maximum number of cardgroups. Both failure cases are surfaced
+// as data (the MasterNotFoundError / CardgroupLimitReachedError union variants)
+// rather than as errors so the resolver can return them in `data`. The XOR is a
+// producer contract, not a compile-time guarantee: a degenerate
+// {Cardgroup:nil, NotFound:false, LimitReached:nil} result is treated as INTERNAL
+// by the resolver's defensive guard.
 type ImportMasterOutcome struct {
 	// Cardgroup is the newly created user-owned cardgroup snapshot on the happy
-	// path. Non-nil iff NotFound is false.
+	// path. Non-nil iff neither NotFound nor LimitReached is set.
 	Cardgroup *domain.Cardgroup
 	// NotFound is true when the master id is unknown or not published; it subsumes
-	// draft existence so draft ids are indistinguishable from absent ids. True iff
-	// Cardgroup is nil.
+	// draft existence so draft ids are indistinguishable from absent ids.
 	NotFound bool
+	// LimitReached is non-nil when the caller is a non-admin who already holds
+	// domain.GeneralUserCardgroupLimit cardgroups. It carries the same cap/count
+	// pair as CreateCardgroupOutcome.LimitReached so both entry points into "the
+	// caller now owns a new deck" surface the quota identically.
+	LimitReached *CardgroupLimitInfo
 }
 
 type masterCatalogUsecase struct {
 	repo      MasterCatalogRepository
 	deckUC    masterDeckUsecaseFacade
+	cgCounter cardgroupOwnerCounter
 	adminGate *AdminGate
 	logger    *slog.Logger
 }
@@ -180,16 +187,21 @@ type masterCatalogUsecase struct {
 // NewMasterCatalogUsecase constructs a MasterCatalogUsecase backed by the given
 // repository. deckUC is the combined deck facade (CopyMasterToUserUsecase +
 // SeedForNewUserUsecase + MergeMasterIntoCardgroupUsecase) used by ImportMaster,
-// SeedDefaultStarters, and MergeMaster; adminGate gates every admin-management
-// method. The public ListPublishedConnection is gated by authentication only.
-// Panics when repo, deckUC, adminGate, or logger is nil — a nil required
-// dependency is a wiring bug that must fail at startup, not at first use.
-func NewMasterCatalogUsecase(repo MasterCatalogRepository, deckUC masterDeckUsecaseFacade, adminGate *AdminGate, logger *slog.Logger) MasterCatalogUsecase {
+// SeedDefaultStarters, and MergeMaster; cgCounter counts the caller's existing
+// cardgroups for the ImportMaster quota check; adminGate gates every
+// admin-management method and supplies the quota's admin exemption. The public
+// ListPublishedConnection is gated by authentication only. Panics when repo,
+// deckUC, cgCounter, adminGate, or logger is nil — a nil required dependency is
+// a wiring bug that must fail at startup, not at first use.
+func NewMasterCatalogUsecase(repo MasterCatalogRepository, deckUC masterDeckUsecaseFacade, cgCounter cardgroupOwnerCounter, adminGate *AdminGate, logger *slog.Logger) MasterCatalogUsecase {
 	if repo == nil {
 		panic("usecase: master catalog: repo is required")
 	}
 	if deckUC == nil {
 		panic("usecase: master catalog: deckUC is required")
+	}
+	if cgCounter == nil {
+		panic("usecase: master catalog: cgCounter is required")
 	}
 	if adminGate == nil {
 		panic("usecase: master catalog: adminGate is required")
@@ -197,7 +209,7 @@ func NewMasterCatalogUsecase(repo MasterCatalogRepository, deckUC masterDeckUsec
 	if logger == nil {
 		panic("usecase: master catalog: logger is required")
 	}
-	return &masterCatalogUsecase{repo: repo, deckUC: deckUC, adminGate: adminGate, logger: logger}
+	return &masterCatalogUsecase{repo: repo, deckUC: deckUC, cgCounter: cgCounter, adminGate: adminGate, logger: logger}
 }
 
 // masterCatalogPageFetch is the repository page-fetch closure shape shared by
@@ -672,8 +684,12 @@ func (u *masterCatalogUsecase) ListAdminConnection(
 // inside its transaction, so a master unpublished between this gate and the write
 // also collapses to NotFound (the ErrNotFound the copy surfaces is mapped below)
 // rather than silently importing a now-draft deck. Unauthenticated callers receive
-// ucerr.ErrUnauthenticated. The copy is a one-time snapshot delegated to
-// CopyMasterToUserUsecase; FSRS/swipe state starts empty.
+// ucerr.ErrUnauthenticated. Import is the second entry point into "the caller now
+// owns a new cardgroup", so it applies the same per-user cardgroup quota as
+// CardgroupUsecase.Create via checkCardgroupLimit (admins exempt) — without it the
+// cap would be a property of the create form rather than an invariant of the
+// system. The copy is a one-time snapshot delegated to CopyMasterToUserUsecase;
+// FSRS/swipe state starts empty.
 func (u *masterCatalogUsecase) ImportMaster(ctx context.Context, masterID string) (ImportMasterOutcome, error) {
 	caller := auth.UserFrom(ctx)
 	if err := requireCallerSub(caller); err != nil {
@@ -688,6 +704,17 @@ func (u *masterCatalogUsecase) ImportMaster(ctx context.Context, masterID string
 			return ImportMasterOutcome{}, err
 		}
 		return ImportMasterOutcome{}, eris.Wrap(err, "usecase: master catalog: import: verify published")
+	}
+
+	// The quota runs after the published gate so a capped caller probing an
+	// unknown id still gets the non-disclosure not-found outcome, and before the
+	// copy so no cardgroup row is ever written for a rejected import.
+	limit, err := checkCardgroupLimit(ctx, u.cgCounter, u.adminGate, caller.Sub)
+	if err != nil {
+		return ImportMasterOutcome{}, err
+	}
+	if limit != nil {
+		return ImportMasterOutcome{LimitReached: limit}, nil
 	}
 
 	cg, err := u.deckUC.CopyMasterToUser(ctx, masterID, caller.Sub)

--- a/backend/internal/usecase/master_catalog_admin_test.go
+++ b/backend/internal/usecase/master_catalog_admin_test.go
@@ -40,7 +40,7 @@ func masterCardgroup(id string) *domain.MasterCardgroup {
 
 func TestMasterCatalog_CreateMaster_NonAdminForbidden(t *testing.T) {
 	t.Parallel()
-	uc := NewMasterCatalogUsecase(&mockMasterCatalogRepository{}, &mockCopyMasterToUserUC{}, newTestAdminGate(false), newTestLogger())
+	uc := NewMasterCatalogUsecase(&mockMasterCatalogRepository{}, &mockCopyMasterToUserUC{}, &stubCardgroupCounter{}, newTestAdminGate(false), newTestLogger())
 	ctx := authedCtx("u1")
 	_, err := uc.CreateMaster(ctx, CreateMasterInput{Name: "Deck"})
 	var forbidden *ucerr.ForbiddenError
@@ -49,7 +49,7 @@ func TestMasterCatalog_CreateMaster_NonAdminForbidden(t *testing.T) {
 
 func TestMasterCatalog_CreateMaster_InvalidNameValidation(t *testing.T) {
 	t.Parallel()
-	uc := NewMasterCatalogUsecase(&mockMasterCatalogRepository{}, &mockCopyMasterToUserUC{}, newTestAdminGate(true), newTestLogger())
+	uc := NewMasterCatalogUsecase(&mockMasterCatalogRepository{}, &mockCopyMasterToUserUC{}, &stubCardgroupCounter{}, newTestAdminGate(true), newTestLogger())
 	ctx := authedCtx("admin1")
 	out, err := uc.CreateMaster(ctx, CreateMasterInput{Name: "   "}) // empty after trim
 	require.NoError(t, err)
@@ -60,7 +60,7 @@ func TestMasterCatalog_CreateMaster_InvalidNameValidation(t *testing.T) {
 
 func TestMasterCatalog_CreateMaster_InvalidDescriptionValidation(t *testing.T) {
 	t.Parallel()
-	uc := NewMasterCatalogUsecase(&mockMasterCatalogRepository{}, &mockCopyMasterToUserUC{}, newTestAdminGate(true), newTestLogger())
+	uc := NewMasterCatalogUsecase(&mockMasterCatalogRepository{}, &mockCopyMasterToUserUC{}, &stubCardgroupCounter{}, newTestAdminGate(true), newTestLogger())
 	ctx := authedCtx("admin1")
 	tooLong := strings.Repeat("a", domain.DescriptionMax+1)
 	out, err := uc.CreateMaster(ctx, CreateMasterInput{Name: "My Deck", Description: &tooLong})
@@ -73,7 +73,7 @@ func TestMasterCatalog_CreateMaster_InvalidDescriptionValidation(t *testing.T) {
 func TestMasterCatalog_CreateMaster_Success(t *testing.T) {
 	t.Parallel()
 	repo := &mockMasterCatalogRepository{}
-	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, newTestAdminGate(true), newTestLogger())
+	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, &stubCardgroupCounter{}, newTestAdminGate(true), newTestLogger())
 	ctx := authedCtx("admin1")
 	out, err := uc.CreateMaster(ctx, CreateMasterInput{Name: "My Deck"})
 	require.NoError(t, err)
@@ -90,7 +90,7 @@ func TestMasterCatalog_CreateMaster_Success(t *testing.T) {
 
 func TestMasterCatalog_UpdateMaster_NonAdminForbidden(t *testing.T) {
 	t.Parallel()
-	uc := NewMasterCatalogUsecase(&mockMasterCatalogRepository{}, &mockCopyMasterToUserUC{}, newTestAdminGate(false), newTestLogger())
+	uc := NewMasterCatalogUsecase(&mockMasterCatalogRepository{}, &mockCopyMasterToUserUC{}, &stubCardgroupCounter{}, newTestAdminGate(false), newTestLogger())
 	ctx := authedCtx("u1")
 	_, err := uc.UpdateMaster(ctx, "some-id", UpdateMasterInput{})
 	var forbidden *ucerr.ForbiddenError
@@ -99,7 +99,7 @@ func TestMasterCatalog_UpdateMaster_NonAdminForbidden(t *testing.T) {
 
 func TestMasterCatalog_UpdateMaster_InvalidName(t *testing.T) {
 	t.Parallel()
-	uc := NewMasterCatalogUsecase(&mockMasterCatalogRepository{}, &mockCopyMasterToUserUC{}, newTestAdminGate(true), newTestLogger())
+	uc := NewMasterCatalogUsecase(&mockMasterCatalogRepository{}, &mockCopyMasterToUserUC{}, &stubCardgroupCounter{}, newTestAdminGate(true), newTestLogger())
 	ctx := authedCtx("admin1")
 	name := "   "
 	out, err := uc.UpdateMaster(ctx, "some-id", UpdateMasterInput{Name: &name})
@@ -111,7 +111,7 @@ func TestMasterCatalog_UpdateMaster_InvalidName(t *testing.T) {
 
 func TestMasterCatalog_UpdateMaster_InvalidDescription(t *testing.T) {
 	t.Parallel()
-	uc := NewMasterCatalogUsecase(&mockMasterCatalogRepository{}, &mockCopyMasterToUserUC{}, newTestAdminGate(true), newTestLogger())
+	uc := NewMasterCatalogUsecase(&mockMasterCatalogRepository{}, &mockCopyMasterToUserUC{}, &stubCardgroupCounter{}, newTestAdminGate(true), newTestLogger())
 	ctx := authedCtx("admin1")
 	tooLong := strings.Repeat("a", domain.DescriptionMax+1)
 	out, err := uc.UpdateMaster(ctx, "some-id", UpdateMasterInput{Description: &tooLong})
@@ -130,7 +130,7 @@ func TestMasterCatalog_UpdateMaster_Success(t *testing.T) {
 		},
 		countCardsRes: 5,
 	}
-	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, newTestAdminGate(true), newTestLogger())
+	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, &stubCardgroupCounter{}, newTestAdminGate(true), newTestLogger())
 	ctx := authedCtx("admin1")
 	newName := "Updated"
 	out, err := uc.UpdateMaster(ctx, "id-1", UpdateMasterInput{Name: &newName})
@@ -143,7 +143,7 @@ func TestMasterCatalog_UpdateMaster_Success(t *testing.T) {
 func TestMasterCatalog_UpdateMaster_NotFound(t *testing.T) {
 	t.Parallel()
 	// updateFn defaults to returning ErrNotFound when nil in mock.
-	uc := NewMasterCatalogUsecase(&mockMasterCatalogRepository{}, &mockCopyMasterToUserUC{}, newTestAdminGate(true), newTestLogger())
+	uc := NewMasterCatalogUsecase(&mockMasterCatalogRepository{}, &mockCopyMasterToUserUC{}, &stubCardgroupCounter{}, newTestAdminGate(true), newTestLogger())
 	ctx := authedCtx("admin1")
 	out, err := uc.UpdateMaster(ctx, "missing", UpdateMasterInput{})
 	require.NoError(t, err)
@@ -165,7 +165,7 @@ func TestMasterCatalog_PublishMaster_EmptyMasterRejected(t *testing.T) {
 		countCardsRes: 0,
 		publishFn:     func(_ string) (*domain.MasterCardgroup, error) { publishCalled = true; return mcg, nil },
 	}
-	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, newTestAdminGate(true), newTestLogger())
+	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, &stubCardgroupCounter{}, newTestAdminGate(true), newTestLogger())
 	ctx := authedCtx("admin1")
 	out, err := uc.PublishMaster(ctx, "id-1")
 	require.NoError(t, err)
@@ -185,7 +185,7 @@ func TestMasterCatalog_PublishMaster_Success(t *testing.T) {
 		countCardsRes: 3,
 		publishFn:     func(_ string) (*domain.MasterCardgroup, error) { return &published, nil },
 	}
-	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, newTestAdminGate(true), newTestLogger())
+	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, &stubCardgroupCounter{}, newTestAdminGate(true), newTestLogger())
 	ctx := authedCtx("admin1")
 	out, err := uc.PublishMaster(ctx, "id-1")
 	require.NoError(t, err)
@@ -209,7 +209,7 @@ func TestMasterCatalog_UnpublishMaster_Success(t *testing.T) {
 		unpublishFn:   func(_ string) (*domain.MasterCardgroup, error) { return &draft, nil },
 		countCardsRes: 7,
 	}
-	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, newTestAdminGate(true), newTestLogger())
+	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, &stubCardgroupCounter{}, newTestAdminGate(true), newTestLogger())
 	ctx := authedCtx("admin1")
 	result, err := uc.UnpublishMaster(ctx, "id-1")
 	require.NoError(t, err)
@@ -221,7 +221,7 @@ func TestMasterCatalog_UnpublishMaster_Success(t *testing.T) {
 func TestMasterCatalog_UnpublishMaster_NotFound(t *testing.T) {
 	t.Parallel()
 	// unpublishFn defaults to ErrNotFound when nil in mock.
-	uc := NewMasterCatalogUsecase(&mockMasterCatalogRepository{}, &mockCopyMasterToUserUC{}, newTestAdminGate(true), newTestLogger())
+	uc := NewMasterCatalogUsecase(&mockMasterCatalogRepository{}, &mockCopyMasterToUserUC{}, &stubCardgroupCounter{}, newTestAdminGate(true), newTestLogger())
 	ctx := authedCtx("admin1")
 	_, err := uc.UnpublishMaster(ctx, "missing")
 	// lowerValidationInfo converts the not-found info into a *ucerr.ValidationError.
@@ -236,7 +236,7 @@ func TestMasterCatalog_UnpublishMaster_NotFound(t *testing.T) {
 
 func TestMasterCatalog_DeleteMaster_NonAdminForbidden(t *testing.T) {
 	t.Parallel()
-	uc := NewMasterCatalogUsecase(&mockMasterCatalogRepository{}, &mockCopyMasterToUserUC{}, newTestAdminGate(false), newTestLogger())
+	uc := NewMasterCatalogUsecase(&mockMasterCatalogRepository{}, &mockCopyMasterToUserUC{}, &stubCardgroupCounter{}, newTestAdminGate(false), newTestLogger())
 	ctx := authedCtx("u1")
 	err := uc.DeleteMaster(ctx, "some-id")
 	var forbidden *ucerr.ForbiddenError
@@ -246,7 +246,7 @@ func TestMasterCatalog_DeleteMaster_NonAdminForbidden(t *testing.T) {
 func TestMasterCatalog_DeleteMaster_Success(t *testing.T) {
 	t.Parallel()
 	repo := &mockMasterCatalogRepository{deleteErr: nil}
-	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, newTestAdminGate(true), newTestLogger())
+	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, &stubCardgroupCounter{}, newTestAdminGate(true), newTestLogger())
 	ctx := authedCtx("admin1")
 	err := uc.DeleteMaster(ctx, "some-id")
 	require.NoError(t, err)
@@ -255,7 +255,7 @@ func TestMasterCatalog_DeleteMaster_Success(t *testing.T) {
 func TestMasterCatalog_DeleteMaster_NotFound(t *testing.T) {
 	t.Parallel()
 	repo := &mockMasterCatalogRepository{deleteErr: repository.ErrNotFound}
-	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, newTestAdminGate(true), newTestLogger())
+	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, &stubCardgroupCounter{}, newTestAdminGate(true), newTestLogger())
 	ctx := authedCtx("admin1")
 	err := uc.DeleteMaster(ctx, "some-id")
 	var ve *ucerr.ValidationError
@@ -269,7 +269,7 @@ func TestMasterCatalog_DeleteMaster_NotFound(t *testing.T) {
 
 func TestMasterCatalog_ListAdminConnection_NonAdminForbidden(t *testing.T) {
 	t.Parallel()
-	uc := NewMasterCatalogUsecase(&mockMasterCatalogRepository{}, &mockCopyMasterToUserUC{}, newTestAdminGate(false), newTestLogger())
+	uc := NewMasterCatalogUsecase(&mockMasterCatalogRepository{}, &mockCopyMasterToUserUC{}, &stubCardgroupCounter{}, newTestAdminGate(false), newTestLogger())
 	ctx := authedCtx("u1")
 	_, err := uc.ListAdminConnection(ctx, MasterCatalogConnectionInput{})
 	var forbidden *ucerr.ForbiddenError
@@ -286,7 +286,7 @@ func TestMasterCatalog_ListAdminConnection_ReturnsPage(t *testing.T) {
 		findPageAnyStatusTotal: 2,
 		findPageAnyStatus:      items,
 	}
-	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, newTestAdminGate(true), newTestLogger())
+	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, &stubCardgroupCounter{}, newTestAdminGate(true), newTestLogger())
 	ctx := authedCtx("admin1")
 	out, err := uc.ListAdminConnection(ctx, MasterCatalogConnectionInput{
 		First: intPtr(10),
@@ -307,7 +307,7 @@ func TestNewMasterCatalogUsecase_NilAdminGatePanics(t *testing.T) {
 			t.Fatal("expected panic on nil adminGate")
 		}
 	}()
-	NewMasterCatalogUsecase(&mockMasterCatalogRepository{}, &mockCopyMasterToUserUC{}, nil, newTestLogger())
+	NewMasterCatalogUsecase(&mockMasterCatalogRepository{}, &mockCopyMasterToUserUC{}, &stubCardgroupCounter{}, nil, newTestLogger())
 }
 
 // ---------------------------------------------------------------------------
@@ -327,7 +327,7 @@ func TestMasterCatalog_PublishMaster_NotFound(t *testing.T) {
 			return nil, nil
 		},
 	}
-	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, newTestAdminGate(true), newTestLogger())
+	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, &stubCardgroupCounter{}, newTestAdminGate(true), newTestLogger())
 	ctx := authedCtx("admin1")
 	_, err := uc.PublishMaster(ctx, "missing-id")
 	require.Error(t, err)
@@ -351,7 +351,7 @@ func TestMasterCatalog_UpdateMaster_CountCardsErrorAfterUpdate(t *testing.T) {
 		},
 		countCardsErr: sentinel,
 	}
-	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, newTestAdminGate(true), newTestLogger())
+	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, &stubCardgroupCounter{}, newTestAdminGate(true), newTestLogger())
 	ctx := authedCtx("admin1")
 	newName := "New name"
 	out, err := uc.UpdateMaster(ctx, "id-1", UpdateMasterInput{Name: &newName})
@@ -375,7 +375,7 @@ func TestMasterCatalog_PublishMaster_CountCardsError(t *testing.T) {
 		countCardsErr: sentinel,
 		publishFn:     func(_ string) (*domain.MasterCardgroup, error) { publishCalled = true; return mcg, nil },
 	}
-	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, newTestAdminGate(true), newTestLogger())
+	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, &stubCardgroupCounter{}, newTestAdminGate(true), newTestLogger())
 	ctx := authedCtx("admin1")
 	out, err := uc.PublishMaster(ctx, "id-1")
 	require.Error(t, err)

--- a/backend/internal/usecase/master_catalog_test.go
+++ b/backend/internal/usecase/master_catalog_test.go
@@ -170,7 +170,7 @@ func TestNewMasterCatalogUsecase_NilRepoPanics(t *testing.T) {
 			t.Fatal("expected panic on nil repo")
 		}
 	}()
-	NewMasterCatalogUsecase(nil, &mockCopyMasterToUserUC{}, newTestAdminGate(true), newTestLogger())
+	NewMasterCatalogUsecase(nil, &mockCopyMasterToUserUC{}, &stubCardgroupCounter{}, newTestAdminGate(true), newTestLogger())
 }
 
 func TestNewMasterCatalogUsecase_NilDeckUCPanics(t *testing.T) {
@@ -179,7 +179,16 @@ func TestNewMasterCatalogUsecase_NilDeckUCPanics(t *testing.T) {
 			t.Fatal("expected panic on nil deckUC")
 		}
 	}()
-	NewMasterCatalogUsecase(&mockMasterCatalogRepository{}, nil, newTestAdminGate(true), newTestLogger())
+	NewMasterCatalogUsecase(&mockMasterCatalogRepository{}, nil, &stubCardgroupCounter{}, newTestAdminGate(true), newTestLogger())
+}
+
+func TestNewMasterCatalogUsecase_NilCounterPanics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic on nil cgCounter")
+		}
+	}()
+	NewMasterCatalogUsecase(&mockMasterCatalogRepository{}, &mockCopyMasterToUserUC{}, nil, newTestAdminGate(true), newTestLogger())
 }
 
 func TestNewMasterCatalogUsecase_NilLoggerPanics(t *testing.T) {
@@ -188,7 +197,7 @@ func TestNewMasterCatalogUsecase_NilLoggerPanics(t *testing.T) {
 			t.Fatal("expected panic on nil logger")
 		}
 	}()
-	NewMasterCatalogUsecase(&mockMasterCatalogRepository{}, &mockCopyMasterToUserUC{}, newTestAdminGate(true), nil)
+	NewMasterCatalogUsecase(&mockMasterCatalogRepository{}, &mockCopyMasterToUserUC{}, &stubCardgroupCounter{}, newTestAdminGate(true), nil)
 }
 
 // ---------------------------------------------------------------------------
@@ -196,7 +205,7 @@ func TestNewMasterCatalogUsecase_NilLoggerPanics(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestListPublishedConnection_Unauthenticated(t *testing.T) {
-	uc := NewMasterCatalogUsecase(&mockMasterCatalogRepository{}, &mockCopyMasterToUserUC{}, newTestAdminGate(true), newTestLogger())
+	uc := NewMasterCatalogUsecase(&mockMasterCatalogRepository{}, &mockCopyMasterToUserUC{}, &stubCardgroupCounter{}, newTestAdminGate(true), newTestLogger())
 
 	_, err := uc.ListPublishedConnection(context.Background(), MasterCatalogConnectionInput{})
 	if !errors.Is(err, ucerr.ErrUnauthenticated) {
@@ -216,7 +225,7 @@ func TestListPublishedConnection_Forward_TrimsExtraRow_SetsHasNext(t *testing.T)
 			catalogItem("a", 10), catalogItem("b", 20), catalogItem("c", 30),
 		},
 	}
-	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, newTestAdminGate(true), newTestLogger())
+	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, &stubCardgroupCounter{}, newTestAdminGate(true), newTestLogger())
 
 	out, err := uc.ListPublishedConnection(authedCtx("u1"), MasterCatalogConnectionInput{
 		First: intPtr(2),
@@ -264,7 +273,7 @@ func TestListPublishedConnection_Forward_NoExtraRow_NoNextPage(t *testing.T) {
 		findPageTotal:  2,
 		findPageResult: []*repository.MasterCatalogItem{catalogItem("a", 1), catalogItem("b", 2)},
 	}
-	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, newTestAdminGate(true), newTestLogger())
+	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, &stubCardgroupCounter{}, newTestAdminGate(true), newTestLogger())
 
 	out, err := uc.ListPublishedConnection(authedCtx("u1"), MasterCatalogConnectionInput{First: intPtr(5)})
 	if err != nil {
@@ -295,7 +304,7 @@ func TestListPublishedConnection_Backward_TrimsLeadingRow_SetsHasPrev(t *testing
 			catalogItem("x", 1), catalogItem("y", 2), catalogItem("w", 3),
 		},
 	}
-	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, newTestAdminGate(true), newTestLogger())
+	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, &stubCardgroupCounter{}, newTestAdminGate(true), newTestLogger())
 
 	out, err := uc.ListPublishedConnection(authedCtx("u1"), MasterCatalogConnectionInput{
 		Last:   intPtr(2),
@@ -334,7 +343,7 @@ func TestListPublishedConnection_Backward_TrimsLeadingRow_SetsHasPrev(t *testing
 
 func TestListPublishedConnection_OrderByName_Desc(t *testing.T) {
 	repo := &mockMasterCatalogRepository{findPageTotal: 0, findPageResult: nil}
-	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, newTestAdminGate(true), newTestLogger())
+	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, &stubCardgroupCounter{}, newTestAdminGate(true), newTestLogger())
 
 	ob := MasterCatalogOrderByName
 	dir := SortOrderDesc
@@ -360,7 +369,7 @@ func TestListPublishedConnection_OrderByName_Desc(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestListPublishedConnection_FirstAndLast_Rejected(t *testing.T) {
-	uc := NewMasterCatalogUsecase(&mockMasterCatalogRepository{}, &mockCopyMasterToUserUC{}, newTestAdminGate(true), newTestLogger())
+	uc := NewMasterCatalogUsecase(&mockMasterCatalogRepository{}, &mockCopyMasterToUserUC{}, &stubCardgroupCounter{}, newTestAdminGate(true), newTestLogger())
 
 	_, err := uc.ListPublishedConnection(authedCtx("u1"), MasterCatalogConnectionInput{
 		First: intPtr(2),
@@ -381,7 +390,7 @@ func TestListPublishedConnection_TotalCountOnlyRequest(t *testing.T) {
 		findPageTotal:  42,
 		findPageResult: []*repository.MasterCatalogItem{},
 	}
-	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, newTestAdminGate(true), newTestLogger())
+	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, &stubCardgroupCounter{}, newTestAdminGate(true), newTestLogger())
 
 	// first=0 → no rows fetched, but the page method still runs once: assemblePage
 	// always calls the fetch closure, and findCatalogPage counts before its zero-page
@@ -404,7 +413,7 @@ func TestListPublishedConnection_TotalCountOnlyRequest(t *testing.T) {
 
 func TestListPublishedConnection_InvalidCursor(t *testing.T) {
 	repo := &mockMasterCatalogRepository{findPageTotal: 0}
-	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, newTestAdminGate(true), newTestLogger())
+	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, &stubCardgroupCounter{}, newTestAdminGate(true), newTestLogger())
 
 	bad := "%%%not-a-cursor"
 	_, err := uc.ListPublishedConnection(authedCtx("u1"), MasterCatalogConnectionInput{
@@ -430,7 +439,7 @@ func TestListPublishedConnection_CursorNotPublished(t *testing.T) {
 			return nil, repository.ErrNotFound
 		},
 	}
-	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, newTestAdminGate(true), newTestLogger())
+	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, &stubCardgroupCounter{}, newTestAdminGate(true), newTestLogger())
 
 	_, err := uc.ListPublishedConnection(authedCtx("u1"), MasterCatalogConnectionInput{
 		First: intPtr(2),
@@ -448,7 +457,7 @@ func TestListPublishedConnection_CursorNotPublished(t *testing.T) {
 
 func TestListPublishedConnection_FindPageError_Wrapped(t *testing.T) {
 	repo := &mockMasterCatalogRepository{findPageTotal: 1, findPageErr: eris.New("db down")}
-	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, newTestAdminGate(true), newTestLogger())
+	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, &stubCardgroupCounter{}, newTestAdminGate(true), newTestLogger())
 
 	_, err := uc.ListPublishedConnection(authedCtx("u1"), MasterCatalogConnectionInput{First: intPtr(2)})
 	if err == nil {
@@ -472,7 +481,7 @@ func TestListPublishedConnection_FindPageError_Wrapped(t *testing.T) {
 func TestListPublishedConnection_SearchNormalizedToNil(t *testing.T) {
 	t.Parallel()
 	repo := &mockMasterCatalogRepository{}
-	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, newTestAdminGate(true), newTestLogger())
+	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, &stubCardgroupCounter{}, newTestAdminGate(true), newTestLogger())
 
 	blank := "   "
 	_, err := uc.ListPublishedConnection(authedCtx("u1"), MasterCatalogConnectionInput{
@@ -490,7 +499,7 @@ func TestListPublishedConnection_SearchNormalizedToNil(t *testing.T) {
 func TestListPublishedConnection_SearchTrimmed(t *testing.T) {
 	t.Parallel()
 	repo := &mockMasterCatalogRepository{}
-	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, newTestAdminGate(true), newTestLogger())
+	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, &stubCardgroupCounter{}, newTestAdminGate(true), newTestLogger())
 
 	raw := "  hello  "
 	_, err := uc.ListPublishedConnection(authedCtx("u1"), MasterCatalogConnectionInput{
@@ -508,7 +517,7 @@ func TestListPublishedConnection_SearchTrimmed(t *testing.T) {
 func TestListAdminConnection_SearchNormalizedToNil(t *testing.T) {
 	t.Parallel()
 	repo := &mockMasterCatalogRepository{}
-	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, newTestAdminGate(true), newTestLogger())
+	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, &stubCardgroupCounter{}, newTestAdminGate(true), newTestLogger())
 
 	blank := "   "
 	_, err := uc.ListAdminConnection(authedCtx("admin1"), MasterCatalogConnectionInput{
@@ -526,7 +535,7 @@ func TestListAdminConnection_SearchNormalizedToNil(t *testing.T) {
 func TestListAdminConnection_SearchTrimmed(t *testing.T) {
 	t.Parallel()
 	repo := &mockMasterCatalogRepository{}
-	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, newTestAdminGate(true), newTestLogger())
+	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, &stubCardgroupCounter{}, newTestAdminGate(true), newTestLogger())
 
 	raw := "  hello  "
 	_, err := uc.ListAdminConnection(authedCtx("admin1"), MasterCatalogConnectionInput{
@@ -563,7 +572,7 @@ func TestListPublishedConnection_CursorRejectsDraftViaPublishedScope(t *testing.
 			return nil, repository.ErrNotFound
 		},
 	}
-	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, newTestAdminGate(true), newTestLogger())
+	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, &stubCardgroupCounter{}, newTestAdminGate(true), newTestLogger())
 
 	_, err := uc.ListPublishedConnection(authedCtx("u1"), MasterCatalogConnectionInput{
 		First: intPtr(2),
@@ -594,7 +603,7 @@ func TestListAdminConnection_CursorAcceptsDraftViaFindByID(t *testing.T) {
 			return nil, repository.ErrNotFound
 		},
 	}
-	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, newTestAdminGate(true), newTestLogger())
+	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, &stubCardgroupCounter{}, newTestAdminGate(true), newTestLogger())
 
 	_, err := uc.ListAdminConnection(authedCtx("admin1"), MasterCatalogConnectionInput{
 		Last:   intPtr(2),
@@ -703,7 +712,7 @@ func (m *mockCopyMasterToUserUC) PreviewMergeMasterIntoCardgroup(_ context.Conte
 }
 
 func TestImportMaster_Unauthenticated(t *testing.T) {
-	uc := NewMasterCatalogUsecase(&mockMasterCatalogRepository{}, &mockCopyMasterToUserUC{}, newTestAdminGate(true), newTestLogger())
+	uc := NewMasterCatalogUsecase(&mockMasterCatalogRepository{}, &mockCopyMasterToUserUC{}, &stubCardgroupCounter{}, newTestAdminGate(true), newTestLogger())
 
 	_, err := uc.ImportMaster(context.Background(), "m1")
 	if !errors.Is(err, ucerr.ErrUnauthenticated) {
@@ -719,7 +728,7 @@ func TestImportMaster_UnknownOrDraft_ReturnsNotFoundOutcome(t *testing.T) {
 		t.Fatal("copy must not run when the master is not published")
 		return nil, nil
 	}}
-	uc := NewMasterCatalogUsecase(repo, copyUC, newTestAdminGate(true), newTestLogger())
+	uc := NewMasterCatalogUsecase(repo, copyUC, &stubCardgroupCounter{}, newTestAdminGate(true), newTestLogger())
 
 	out, err := uc.ImportMaster(authedCtx("u1"), "missing")
 	if err != nil {
@@ -746,7 +755,7 @@ func TestImportMaster_MasterUnpublishedMidFlight_ReturnsNotFoundOutcome(t *testi
 	copyUC := &mockCopyMasterToUserUC{fn: func(context.Context, string, string) (*domain.Cardgroup, error) {
 		return nil, repository.ErrNotFound
 	}}
-	uc := NewMasterCatalogUsecase(repo, copyUC, newTestAdminGate(true), newTestLogger())
+	uc := NewMasterCatalogUsecase(repo, copyUC, &stubCardgroupCounter{}, newTestAdminGate(true), newTestLogger())
 
 	out, err := uc.ImportMaster(authedCtx("u1"), "m1")
 	if err != nil {
@@ -772,7 +781,7 @@ func TestImportMaster_Published_CopiesAndReturnsCardgroup(t *testing.T) {
 		gotMaster, gotOwner = masterID, ownerID
 		return want, nil
 	}}
-	uc := NewMasterCatalogUsecase(repo, copyUC, newTestAdminGate(true), newTestLogger())
+	uc := NewMasterCatalogUsecase(repo, copyUC, &stubCardgroupCounter{}, newTestAdminGate(true), newTestLogger())
 
 	out, err := uc.ImportMaster(authedCtx("u1"), "m1")
 	if err != nil {
@@ -789,6 +798,124 @@ func TestImportMaster_Published_CopiesAndReturnsCardgroup(t *testing.T) {
 	}
 }
 
+// TestImportMaster_NonAdminAtLimit_ReturnsLimitOutcome pins the quota on the
+// import path: a non-admin owner already holding domain.GeneralUserCardgroupLimit
+// cardgroups gets the LimitReached outcome and the copy — the only thing that
+// would create a cardgroup row — is never reached.
+func TestImportMaster_NonAdminAtLimit_ReturnsLimitOutcome(t *testing.T) {
+	repo := &mockMasterCatalogRepository{
+		findPublishedByIDFn: func(id string) (*domain.MasterCardgroup, error) {
+			return &domain.MasterCardgroup{ID: id, Name: domain.CardgroupName("Deck"), Status: domain.MasterStatusPublished}, nil
+		},
+	}
+	copyUC := &mockCopyMasterToUserUC{fn: func(context.Context, string, string) (*domain.Cardgroup, error) {
+		t.Fatal("copy must not run when the caller is at the cardgroup limit")
+		return nil, nil
+	}}
+	counter := &stubCardgroupCounter{count: domain.GeneralUserCardgroupLimit}
+	uc := NewMasterCatalogUsecase(repo, copyUC, counter, newTestAdminGate(false), newTestLogger())
+
+	out, err := uc.ImportMaster(authedCtx("u1"), "m1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.LimitReached == nil {
+		t.Fatal("expected LimitReached outcome")
+	}
+	if out.LimitReached.Limit != domain.GeneralUserCardgroupLimit || out.LimitReached.Current != domain.GeneralUserCardgroupLimit {
+		t.Fatalf("limit info = %+v, want {Limit:%d Current:%d}", *out.LimitReached, domain.GeneralUserCardgroupLimit, domain.GeneralUserCardgroupLimit)
+	}
+	if out.Cardgroup != nil || out.NotFound {
+		t.Fatalf("expected only LimitReached set, got %+v", out)
+	}
+}
+
+// TestImportMaster_NonAdminAtLimit_UnknownMaster_ReturnsNotFound pins the gate
+// ORDER, not just the two outcomes: the published gate runs before the quota, so
+// a capped non-admin probing an unknown id receives the non-disclosure NotFound
+// outcome rather than LimitReached. The counter.calls == 0 assertion is what
+// makes a reordering fail loudly — swapping the two blocks would consult the
+// quota first and answer LimitReached, turning the import path into an
+// existence oracle for a caller who cannot import anything anyway.
+func TestImportMaster_NonAdminAtLimit_UnknownMaster_ReturnsNotFound(t *testing.T) {
+	// Default mock FindPublishedByID returns repository.ErrNotFound (unknown id).
+	repo := &mockMasterCatalogRepository{}
+	copyUC := &mockCopyMasterToUserUC{fn: func(context.Context, string, string) (*domain.Cardgroup, error) {
+		t.Fatal("copy must not run for an unknown master")
+		return nil, nil
+	}}
+	counter := &stubCardgroupCounter{count: domain.GeneralUserCardgroupLimit}
+	uc := NewMasterCatalogUsecase(repo, copyUC, counter, newTestAdminGate(false), newTestLogger())
+
+	out, err := uc.ImportMaster(authedCtx("u1"), "missing")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !out.NotFound {
+		t.Fatalf("expected NotFound outcome, got %+v", out)
+	}
+	if out.LimitReached != nil {
+		t.Fatalf("published gate must precede the quota, got LimitReached %+v", *out.LimitReached)
+	}
+	if out.Cardgroup != nil {
+		t.Fatal("expected nil cardgroup on NotFound")
+	}
+	if counter.calls != 0 {
+		t.Fatalf("quota must not be consulted for an unknown master, got %d calls", counter.calls)
+	}
+}
+
+// TestImportMaster_AdminAtLimit_Succeeds pins the admin exemption: the same
+// at-cap count that rejects a general user does not block an admin, and the
+// counter is never consulted (checkCardgroupLimit short-circuits on IsAdmin).
+func TestImportMaster_AdminAtLimit_Succeeds(t *testing.T) {
+	repo := &mockMasterCatalogRepository{
+		findPublishedByIDFn: func(id string) (*domain.MasterCardgroup, error) {
+			return &domain.MasterCardgroup{ID: id, Name: domain.CardgroupName("Deck"), Status: domain.MasterStatusPublished}, nil
+		},
+	}
+	want := &domain.Cardgroup{ID: domain.CardgroupID("new-cg"), OwnerID: "admin-1", Name: domain.CardgroupName("Deck")}
+	copyUC := &mockCopyMasterToUserUC{fn: func(context.Context, string, string) (*domain.Cardgroup, error) {
+		return want, nil
+	}}
+	counter := &stubCardgroupCounter{count: domain.GeneralUserCardgroupLimit}
+	uc := NewMasterCatalogUsecase(repo, copyUC, counter, newTestAdminGate(true), newTestLogger())
+
+	out, err := uc.ImportMaster(authedCtx("admin-1"), "m1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.LimitReached != nil {
+		t.Fatalf("admin must be exempt from the cardgroup limit, got %+v", *out.LimitReached)
+	}
+	if out.Cardgroup != want {
+		t.Fatalf("expected the copied cardgroup, got %v", out.Cardgroup)
+	}
+	if counter.calls != 0 {
+		t.Fatalf("expected CountByOwner NOT to be called for an admin owner, got %d calls", counter.calls)
+	}
+}
+
+// TestImportMaster_CountByOwnerError_Wrapped verifies that a non-context error
+// from the quota's count propagates wrapped with the shared helper's prefix and
+// that no copy is attempted.
+func TestImportMaster_CountByOwnerError_Wrapped(t *testing.T) {
+	repo := &mockMasterCatalogRepository{
+		findPublishedByIDFn: func(id string) (*domain.MasterCardgroup, error) {
+			return &domain.MasterCardgroup{ID: id, Name: domain.CardgroupName("Deck"), Status: domain.MasterStatusPublished}, nil
+		},
+	}
+	copyUC := &mockCopyMasterToUserUC{fn: func(context.Context, string, string) (*domain.Cardgroup, error) {
+		t.Fatal("copy must not run when the limit check fails")
+		return nil, nil
+	}}
+	counter := &stubCardgroupCounter{err: eris.New("boom")}
+	uc := NewMasterCatalogUsecase(repo, copyUC, counter, newTestAdminGate(false), newTestLogger())
+
+	_, err := uc.ImportMaster(authedCtx("u1"), "m1")
+	assertInternalChain(t, err, "usecase: cardgroup: count by owner")
+}
+
 func TestImportMaster_CopyError_Wrapped(t *testing.T) {
 	repo := &mockMasterCatalogRepository{
 		findByIDFn: func(id string) (*domain.MasterCardgroup, error) {
@@ -798,7 +925,7 @@ func TestImportMaster_CopyError_Wrapped(t *testing.T) {
 	copyUC := &mockCopyMasterToUserUC{fn: func(context.Context, string, string) (*domain.Cardgroup, error) {
 		return nil, eris.New("boom")
 	}}
-	uc := NewMasterCatalogUsecase(repo, copyUC, newTestAdminGate(true), newTestLogger())
+	uc := NewMasterCatalogUsecase(repo, copyUC, &stubCardgroupCounter{}, newTestAdminGate(true), newTestLogger())
 
 	_, err := uc.ImportMaster(authedCtx("u1"), "m1")
 	assertInternalChain(t, err, "usecase: master catalog: import: copy master to user")
@@ -817,7 +944,7 @@ func TestImportMaster_VerifyPublishedError_Wrapped(t *testing.T) {
 		t.Fatal("copy must not run when the published-check fails")
 		return nil, nil
 	}}
-	uc := NewMasterCatalogUsecase(repo, copyUC, newTestAdminGate(true), newTestLogger())
+	uc := NewMasterCatalogUsecase(repo, copyUC, &stubCardgroupCounter{}, newTestAdminGate(true), newTestLogger())
 
 	_, err := uc.ImportMaster(authedCtx("u1"), "m1")
 	assertInternalChain(t, err, "usecase: master catalog: import: verify published")
@@ -832,7 +959,7 @@ func TestImportMaster_FindPublishedByID_ContextCancelled_PassesThrough(t *testin
 			return nil, context.Canceled
 		},
 	}
-	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, newTestAdminGate(true), newTestLogger())
+	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, &stubCardgroupCounter{}, newTestAdminGate(true), newTestLogger())
 
 	_, err := uc.ImportMaster(authedCtx("u1"), "m1")
 	assertCancelled(t, err)
@@ -851,7 +978,7 @@ func TestImportMaster_CopyMasterToUser_ContextCancelled_PassesThrough(t *testing
 	copyUC := &mockCopyMasterToUserUC{fn: func(context.Context, string, string) (*domain.Cardgroup, error) {
 		return nil, context.Canceled
 	}}
-	uc := NewMasterCatalogUsecase(repo, copyUC, newTestAdminGate(true), newTestLogger())
+	uc := NewMasterCatalogUsecase(repo, copyUC, &stubCardgroupCounter{}, newTestAdminGate(true), newTestLogger())
 
 	_, err := uc.ImportMaster(authedCtx("u1"), "m1")
 	assertCancelled(t, err)
@@ -865,7 +992,7 @@ func TestImportMaster_CopyMasterToUser_ContextCancelled_PassesThrough(t *testing
 // ---------------------------------------------------------------------------
 
 func TestFindPublishedMaster_Unauthenticated(t *testing.T) {
-	uc := NewMasterCatalogUsecase(&mockMasterCatalogRepository{}, &mockCopyMasterToUserUC{}, newTestAdminGate(true), newTestLogger())
+	uc := NewMasterCatalogUsecase(&mockMasterCatalogRepository{}, &mockCopyMasterToUserUC{}, &stubCardgroupCounter{}, newTestAdminGate(true), newTestLogger())
 
 	_, err := uc.FindPublishedMaster(context.Background(), "m1")
 	if !errors.Is(err, ucerr.ErrUnauthenticated) {
@@ -880,7 +1007,7 @@ func TestFindPublishedMaster_DraftOrUnknown_ReturnsNil(t *testing.T) {
 	repo := &mockMasterCatalogRepository{
 		findPublishedByIDFn: func(string) (*domain.MasterCardgroup, error) { return nil, repository.ErrNotFound },
 	}
-	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, newTestAdminGate(true), newTestLogger())
+	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, &stubCardgroupCounter{}, newTestAdminGate(true), newTestLogger())
 
 	got, err := uc.FindPublishedMaster(authedCtx("u1"), "missing")
 	if err != nil {
@@ -901,7 +1028,7 @@ func TestFindPublishedMaster_Success(t *testing.T) {
 			return want, nil
 		},
 	}
-	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, newTestAdminGate(true), newTestLogger())
+	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, &stubCardgroupCounter{}, newTestAdminGate(true), newTestLogger())
 
 	got, err := uc.FindPublishedMaster(authedCtx("u1"), "m1")
 	if err != nil {
@@ -918,7 +1045,7 @@ func TestFindPublishedMaster_InfraError_Wrapped(t *testing.T) {
 	repo := &mockMasterCatalogRepository{
 		findPublishedByIDFn: func(string) (*domain.MasterCardgroup, error) { return nil, eris.New("db down") },
 	}
-	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, newTestAdminGate(true), newTestLogger())
+	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, &stubCardgroupCounter{}, newTestAdminGate(true), newTestLogger())
 
 	_, err := uc.FindPublishedMaster(authedCtx("u1"), "m1")
 	assertInternalChain(t, err, "usecase: master catalog: find published master")
@@ -931,7 +1058,7 @@ func TestFindPublishedMaster_ContextCancelled_PassesThrough(t *testing.T) {
 	repo := &mockMasterCatalogRepository{
 		findPublishedByIDFn: func(string) (*domain.MasterCardgroup, error) { return nil, context.Canceled },
 	}
-	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, newTestAdminGate(true), newTestLogger())
+	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, &stubCardgroupCounter{}, newTestAdminGate(true), newTestLogger())
 
 	_, err := uc.FindPublishedMaster(authedCtx("u1"), "m1")
 	assertCancelled(t, err)
@@ -941,7 +1068,7 @@ func TestFindPublishedMaster_ContextCancelled_PassesThrough(t *testing.T) {
 }
 
 func TestListPublishedConnection_AfterWithLast_Rejected(t *testing.T) {
-	uc := NewMasterCatalogUsecase(&mockMasterCatalogRepository{}, &mockCopyMasterToUserUC{}, newTestAdminGate(true), newTestLogger())
+	uc := NewMasterCatalogUsecase(&mockMasterCatalogRepository{}, &mockCopyMasterToUserUC{}, &stubCardgroupCounter{}, newTestAdminGate(true), newTestLogger())
 
 	after := "v1:abc"
 	_, err := uc.ListPublishedConnection(authedCtx("u1"), MasterCatalogConnectionInput{
@@ -955,7 +1082,7 @@ func TestListPublishedConnection_AfterWithLast_Rejected(t *testing.T) {
 }
 
 func TestListAdminConnection_AfterWithLast_Rejected(t *testing.T) {
-	uc := NewMasterCatalogUsecase(&mockMasterCatalogRepository{}, &mockCopyMasterToUserUC{}, newTestAdminGate(true), newTestLogger())
+	uc := NewMasterCatalogUsecase(&mockMasterCatalogRepository{}, &mockCopyMasterToUserUC{}, &stubCardgroupCounter{}, newTestAdminGate(true), newTestLogger())
 
 	after := "v1:abc"
 	_, err := uc.ListAdminConnection(authedCtx("u1"), MasterCatalogConnectionInput{
@@ -973,7 +1100,7 @@ func TestListAdminConnection_AfterWithLast_Rejected(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestSeedDefaultStarters_Unauthenticated_ReturnsErrUnauthenticated(t *testing.T) {
-	uc := NewMasterCatalogUsecase(&mockMasterCatalogRepository{}, &mockCopyMasterToUserUC{}, newTestAdminGate(true), newTestLogger())
+	uc := NewMasterCatalogUsecase(&mockMasterCatalogRepository{}, &mockCopyMasterToUserUC{}, &stubCardgroupCounter{}, newTestAdminGate(true), newTestLogger())
 	_, err := uc.SeedDefaultStarters(context.Background())
 	if !errors.Is(err, ucerr.ErrUnauthenticated) {
 		t.Fatalf("expected ErrUnauthenticated, got %v", err)
@@ -983,7 +1110,7 @@ func TestSeedDefaultStarters_Unauthenticated_ReturnsErrUnauthenticated(t *testin
 func TestSeedDefaultStarters_HappyPath_ReturnsSeededCardgroups(t *testing.T) {
 	want := []*domain.Cardgroup{{ID: domain.CardgroupID("cg-1"), OwnerID: "user-1", Name: domain.CardgroupName("Starter")}}
 	deck := &mockCopyMasterToUserUC{seedResult: want}
-	uc := NewMasterCatalogUsecase(&mockMasterCatalogRepository{}, deck, newTestAdminGate(true), newTestLogger())
+	uc := NewMasterCatalogUsecase(&mockMasterCatalogRepository{}, deck, &stubCardgroupCounter{}, newTestAdminGate(true), newTestLogger())
 	got, err := uc.SeedDefaultStarters(authedCtx("user-1"))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -995,7 +1122,7 @@ func TestSeedDefaultStarters_HappyPath_ReturnsSeededCardgroups(t *testing.T) {
 
 func TestSeedDefaultStarters_NoDefaults_ReturnsEmpty(t *testing.T) {
 	deck := &mockCopyMasterToUserUC{seedResult: nil}
-	uc := NewMasterCatalogUsecase(&mockMasterCatalogRepository{}, deck, newTestAdminGate(true), newTestLogger())
+	uc := NewMasterCatalogUsecase(&mockMasterCatalogRepository{}, deck, &stubCardgroupCounter{}, newTestAdminGate(true), newTestLogger())
 	got, err := uc.SeedDefaultStarters(authedCtx("user-1"))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -1007,7 +1134,7 @@ func TestSeedDefaultStarters_NoDefaults_ReturnsEmpty(t *testing.T) {
 
 func TestSeedDefaultStarters_InfraError_WrapsChain(t *testing.T) {
 	deck := &mockCopyMasterToUserUC{seedErr: eris.New("db down")}
-	uc := NewMasterCatalogUsecase(&mockMasterCatalogRepository{}, deck, newTestAdminGate(true), newTestLogger())
+	uc := NewMasterCatalogUsecase(&mockMasterCatalogRepository{}, deck, &stubCardgroupCounter{}, newTestAdminGate(true), newTestLogger())
 	_, err := uc.SeedDefaultStarters(authedCtx("user-1"))
 	if err == nil {
 		t.Fatal("expected error, got nil")
@@ -1017,7 +1144,7 @@ func TestSeedDefaultStarters_InfraError_WrapsChain(t *testing.T) {
 
 func TestSeedDefaultStarters_ContextCancelled_PassesThrough(t *testing.T) {
 	deck := &mockCopyMasterToUserUC{seedErr: context.Canceled}
-	uc := NewMasterCatalogUsecase(&mockMasterCatalogRepository{}, deck, newTestAdminGate(true), newTestLogger())
+	uc := NewMasterCatalogUsecase(&mockMasterCatalogRepository{}, deck, &stubCardgroupCounter{}, newTestAdminGate(true), newTestLogger())
 	_, err := uc.SeedDefaultStarters(authedCtx("user-1"))
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("expected context.Canceled, got %v", err)
@@ -1036,6 +1163,7 @@ func TestMasterCatalogUsecase_MergeMaster_DraftMaster_NotFound(t *testing.T) {
 	uc := NewMasterCatalogUsecase(
 		&mockMasterCatalogRepository{},
 		&mockCopyMasterToUserUC{},
+		&stubCardgroupCounter{},
 		newTestAdminGate(true),
 		newTestLogger(),
 	)
@@ -1066,7 +1194,7 @@ func TestMasterCatalogUsecase_MergeMaster_Success_PassesCounts(t *testing.T) {
 	deck := &mockCopyMasterToUserUC{
 		mergeResult: &MergeMasterResult{Cardgroup: cg, Added: 5, Updated: 2},
 	}
-	uc := NewMasterCatalogUsecase(repo, deck, newTestAdminGate(true), newTestLogger())
+	uc := NewMasterCatalogUsecase(repo, deck, &stubCardgroupCounter{}, newTestAdminGate(true), newTestLogger())
 
 	out, err := uc.MergeMaster(authedCtx("u1"), "master-id", "cg-id")
 	if err != nil {
@@ -1094,6 +1222,7 @@ func TestMasterCatalogUsecase_MergeMaster_Unauthenticated(t *testing.T) {
 	uc := NewMasterCatalogUsecase(
 		&mockMasterCatalogRepository{},
 		&mockCopyMasterToUserUC{},
+		&stubCardgroupCounter{},
 		newTestAdminGate(true),
 		newTestLogger(),
 	)
@@ -1119,7 +1248,7 @@ func TestMasterCatalogUsecase_MergeMaster_WrappedValidationError_StillClassifies
 	deck := &mockCopyMasterToUserUC{
 		mergeErr: ucerr.NewValidationError("cardgroupId", "cardgroup not found"),
 	}
-	uc := NewMasterCatalogUsecase(repo, deck, newTestAdminGate(true), newTestLogger())
+	uc := NewMasterCatalogUsecase(repo, deck, &stubCardgroupCounter{}, newTestAdminGate(true), newTestLogger())
 
 	_, err := uc.MergeMaster(authedCtx("u1"), "master-id", "cg-id")
 	if err == nil {
@@ -1149,7 +1278,7 @@ func TestMasterCatalogUsecase_MergeMaster_WrappedUnauthenticated_StillClassifies
 	deck := &mockCopyMasterToUserUC{
 		mergeErr: ucerr.ErrUnauthenticated,
 	}
-	uc := NewMasterCatalogUsecase(repo, deck, newTestAdminGate(true), newTestLogger())
+	uc := NewMasterCatalogUsecase(repo, deck, &stubCardgroupCounter{}, newTestAdminGate(true), newTestLogger())
 
 	_, err := uc.MergeMaster(authedCtx("u1"), "master-id", "cg-id")
 	if !errors.Is(err, ucerr.ErrUnauthenticated) {
@@ -1171,7 +1300,7 @@ func TestMasterCatalogUsecase_MergeMaster_VerifyPublishedError_Wrapped(t *testin
 		t.Fatal("merge delegate must not run when the published-check fails")
 		return nil, nil
 	}}
-	uc := NewMasterCatalogUsecase(repo, deck, newTestAdminGate(true), newTestLogger())
+	uc := NewMasterCatalogUsecase(repo, deck, &stubCardgroupCounter{}, newTestAdminGate(true), newTestLogger())
 
 	_, err := uc.MergeMaster(authedCtx("u1"), "master-id", "cg-id")
 	assertInternalChain(t, err, "usecase: master catalog: merge: verify published")
@@ -1187,7 +1316,7 @@ func TestMasterCatalogUsecase_MergeMaster_DelegateError_Wrapped(t *testing.T) {
 		},
 	}
 	deck := &mockCopyMasterToUserUC{mergeErr: errors.New("db down")}
-	uc := NewMasterCatalogUsecase(repo, deck, newTestAdminGate(true), newTestLogger())
+	uc := NewMasterCatalogUsecase(repo, deck, &stubCardgroupCounter{}, newTestAdminGate(true), newTestLogger())
 
 	_, err := uc.MergeMaster(authedCtx("u1"), "master-id", "cg-id")
 	assertInternalChain(t, err, "usecase: master catalog: merge: merge master into cardgroup")
@@ -1206,7 +1335,7 @@ func TestMasterCatalogUsecase_MergeMaster_MasterUnpublishedMidFlight_ReturnsNotF
 		},
 	}
 	deck := &mockCopyMasterToUserUC{mergeErr: repository.ErrNotFound}
-	uc := NewMasterCatalogUsecase(repo, deck, newTestAdminGate(true), newTestLogger())
+	uc := NewMasterCatalogUsecase(repo, deck, &stubCardgroupCounter{}, newTestAdminGate(true), newTestLogger())
 
 	out, err := uc.MergeMaster(authedCtx("u1"), "master-id", "cg-id")
 	if err != nil {
@@ -1230,7 +1359,7 @@ func TestMasterCatalogUsecase_MergeMaster_VerifyPublished_ContextCancelled_Passe
 			return nil, context.Canceled
 		},
 	}
-	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, newTestAdminGate(true), newTestLogger())
+	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, &stubCardgroupCounter{}, newTestAdminGate(true), newTestLogger())
 
 	_, err := uc.MergeMaster(authedCtx("u1"), "master-id", "cg-id")
 	assertCancelled(t, err)
@@ -1248,7 +1377,7 @@ func TestMasterCatalogUsecase_MergeMaster_Delegate_ContextCancelled_PassesThroug
 		},
 	}
 	deck := &mockCopyMasterToUserUC{mergeErr: context.Canceled}
-	uc := NewMasterCatalogUsecase(repo, deck, newTestAdminGate(true), newTestLogger())
+	uc := NewMasterCatalogUsecase(repo, deck, &stubCardgroupCounter{}, newTestAdminGate(true), newTestLogger())
 
 	_, err := uc.MergeMaster(authedCtx("u1"), "master-id", "cg-id")
 	assertCancelled(t, err)
@@ -1261,7 +1390,7 @@ func TestMasterCatalogUsecase_MergeMaster_Delegate_ContextCancelled_PassesThroug
 
 func TestPreviewMergeMaster_UnauthenticatedCaller(t *testing.T) {
 	t.Parallel()
-	uc := NewMasterCatalogUsecase(&mockMasterCatalogRepository{}, &mockCopyMasterToUserUC{}, newTestAdminGate(true), newTestLogger())
+	uc := NewMasterCatalogUsecase(&mockMasterCatalogRepository{}, &mockCopyMasterToUserUC{}, &stubCardgroupCounter{}, newTestAdminGate(true), newTestLogger())
 
 	_, err := uc.PreviewMergeMaster(context.Background(), "m1", "cg-1")
 	if !errors.Is(err, ucerr.ErrUnauthenticated) {
@@ -1279,7 +1408,7 @@ func TestMasterCatalog_EmptySubCaller_RejectedAsUnauthenticated(t *testing.T) {
 	// A non-nil authenticated user carrying an empty Sub — the exact case
 	// requireCallerSub guards and the old nil-only check missed.
 	ctx := auth.ContextWithUser(context.Background(), &auth.AuthUser{Sub: ""})
-	uc := NewMasterCatalogUsecase(&mockMasterCatalogRepository{}, &mockCopyMasterToUserUC{}, newTestAdminGate(true), newTestLogger())
+	uc := NewMasterCatalogUsecase(&mockMasterCatalogRepository{}, &mockCopyMasterToUserUC{}, &stubCardgroupCounter{}, newTestAdminGate(true), newTestLogger())
 
 	t.Run("ImportMaster", func(t *testing.T) {
 		t.Parallel()
@@ -1306,7 +1435,7 @@ func TestPreviewMergeMaster_NotFoundWhenMasterUnpublished(t *testing.T) {
 	// not an error — the non-disclosure gate collapses unknown + draft into one signal.
 	t.Parallel()
 	repo := &mockMasterCatalogRepository{} // default: returns repository.ErrNotFound
-	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, newTestAdminGate(true), newTestLogger())
+	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, &stubCardgroupCounter{}, newTestAdminGate(true), newTestLogger())
 
 	out, err := uc.PreviewMergeMaster(authedCtx("u1"), "m1", "cg-1")
 	if err != nil {
@@ -1329,7 +1458,7 @@ func TestPreviewMergeMaster_HappyPathDelegatesToDeckUC(t *testing.T) {
 	deck := &mockCopyMasterToUserUC{
 		previewOut: PreviewMergeResult{Added: 3, Updated: 1},
 	}
-	uc := NewMasterCatalogUsecase(repo, deck, newTestAdminGate(true), newTestLogger())
+	uc := NewMasterCatalogUsecase(repo, deck, &stubCardgroupCounter{}, newTestAdminGate(true), newTestLogger())
 
 	out, err := uc.PreviewMergeMaster(authedCtx("u1"), "master-id", "cg-id")
 	if err != nil {
@@ -1357,7 +1486,7 @@ func TestListPublishedConnection_CursorFindByIDCancelled(t *testing.T) {
 	repo := &mockMasterCatalogRepository{
 		findByIDFn: func(string) (*domain.MasterCardgroup, error) { return nil, context.Canceled },
 	}
-	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, newTestAdminGate(true), newTestLogger())
+	uc := NewMasterCatalogUsecase(repo, &mockCopyMasterToUserUC{}, &stubCardgroupCounter{}, newTestAdminGate(true), newTestLogger())
 
 	_, err := uc.ListPublishedConnection(authedCtx("u1"), MasterCatalogConnectionInput{
 		First: intPtr(5),

--- a/backend/internal/usecase/master_deck.go
+++ b/backend/internal/usecase/master_deck.go
@@ -247,6 +247,9 @@ func (u *masterDeckUsecase) SeedForNewUser(ctx context.Context, userID string) (
 		}
 		if count > 0 {
 			// Already seeded (or the user created their own cardgroup): no-op.
+			// This guard is also why seeding needs no explicit cardgroup-quota
+			// check: it only ever runs for an owner holding zero cardgroups, and
+			// the published default-starter set is admin-curated and small.
 			return nil
 		}
 

--- a/frontend/src/app/catalog/[id]/catalog-deck-client.test.tsx
+++ b/frontend/src/app/catalog/[id]/catalog-deck-client.test.tsx
@@ -294,6 +294,39 @@ describe("<CatalogDeckClient>", () => {
     expect(screen.getByTestId("catalog-deck-import-deck-1")).not.toBeDisabled();
   });
 
+  it("shows the limit banner when the import returns CardgroupLimitReachedError", async () => {
+    const user = userEvent.setup();
+    const cache = new InMemoryCache();
+    const limitMock = {
+      request: {
+        query: ImportMasterCardgroupDocument,
+        variables: { masterCardgroupId: "deck-1" },
+      },
+      result: {
+        data: {
+          importMasterCardgroup: {
+            __typename: "CardgroupLimitReachedError",
+            message: "cardgroup limit reached",
+            limit: 5,
+            current: 5,
+          },
+        },
+      },
+    };
+
+    renderClient([limitMock], makeConnection([C1]), cache);
+
+    await user.click(await screen.findByTestId("catalog-deck-import-deck-1"));
+
+    // Reuses the create-form copy from the Cardgroups namespace, interpolated
+    // with the backend-supplied counts.
+    expect(await screen.findByTestId("catalog-deck-import-error")).toHaveTextContent(
+      "You already have 5 card groups (maximum 5).",
+    );
+    // Not marked imported on a limit-reached outcome.
+    expect(screen.getByTestId("catalog-deck-import-deck-1")).not.toBeDisabled();
+  });
+
   it("shows the generic error banner when the import throws a transport error", async () => {
     const user = userEvent.setup();
     const cache = new InMemoryCache();

--- a/frontend/src/app/catalog/[id]/catalog-deck-client.tsx
+++ b/frontend/src/app/catalog/[id]/catalog-deck-client.tsx
@@ -62,6 +62,9 @@ export default function CatalogDeckClient({
   const t = useTranslations("Catalog");
   const tCards = useTranslations("Cards");
   const tCommon = useTranslations("Common");
+  // The cardgroup quota is the same rule the create form enforces, so the import
+  // path reuses that feature's copy rather than duplicating it under Catalog.
+  const tCardgroups = useTranslations("Cardgroups");
 
   const search = useHeaderTakeoverSearch();
 
@@ -127,6 +130,11 @@ export default function CatalogDeckClient({
         case "not_found":
           setImportError(t("importNotFound"));
           return;
+        case "limit_reached":
+          setImportError(
+            tCardgroups("limitReached", { limit: outcome.limit, current: outcome.current }),
+          );
+          return;
         case "auth":
           setImportAuthError(outcome.kind);
           return;
@@ -135,7 +143,7 @@ export default function CatalogDeckClient({
           return;
       }
     },
-    [importing, imported, importMasterCardgroup, initialDeck.name, t],
+    [importing, imported, importMasterCardgroup, initialDeck.name, t, tCardgroups],
   );
 
   return (

--- a/frontend/src/app/catalog/queries.ts
+++ b/frontend/src/app/catalog/queries.ts
@@ -126,6 +126,11 @@ export const ImportMasterCardgroupMutation = graphql(`
       ... on MasterNotFoundError {
         message
       }
+      ... on CardgroupLimitReachedError {
+        message
+        limit
+        current
+      }
     }
   }
 `);

--- a/frontend/src/app/catalog/use-import-master.ts
+++ b/frontend/src/app/catalog/use-import-master.ts
@@ -9,8 +9,8 @@ import { ImportMasterCardgroupMutation } from "./queries";
 /**
  * Discriminated outcome of an import-master attempt. The catalog client branches
  * on `status`: `success` shows a confirmation and the imported deck appears on
- * `/cardgroups` (the connection cache is updated inside this hook); `not_found`
- * and `rejected` surface a banner; `auth` surfaces a sign-in prompt.
+ * `/cardgroups` (the connection cache is updated inside this hook); `not_found`,
+ * `limit_reached`, and `rejected` surface a banner; `auth` surfaces a sign-in prompt.
  *
  * `not_found` carries no payload: it collapses both "unknown id" and "exists but
  * unpublished", and the backend's `MasterNotFoundError.message` must never reach
@@ -26,6 +26,11 @@ import { ImportMasterCardgroupMutation } from "./queries";
 export type ImportMasterOutcome =
   | { status: "success"; cardgroupId: string; cardgroupName: string }
   | { status: "not_found" }
+  // The caller is a non-admin who already owns the maximum number of cardgroups.
+  // Unlike `not_found`, the payload IS carried: `limit` / `current` are non-sensitive
+  // counts the client interpolates into its own localized copy (the backend message
+  // is still dropped, same as everywhere else at this boundary).
+  | { status: "limit_reached"; limit: number; current: number }
   // `auth.kind` mirrors the two GraphQL auth codes. `importMasterCardgroup`
   // currently only emits UNAUTHENTICATED; `forbidden` is handled defensively so a
   // future authorization rule degrades to the sign-in prompt, not the generic
@@ -67,6 +72,9 @@ export function useImportMaster() {
           // The backend message is deliberately discarded (non-disclosure); the
           // client surfaces its own localized copy.
           return { status: "not_found" };
+        }
+        if (payload?.__typename === "CardgroupLimitReachedError") {
+          return { status: "limit_reached", limit: payload.limit, current: payload.current };
         }
         if (payload?.__typename === "ImportMasterCardgroupSuccess") {
           return {

--- a/frontend/src/app/onboarding/start/onboarding-start-client.test.tsx
+++ b/frontend/src/app/onboarding/start/onboarding-start-client.test.tsx
@@ -196,6 +196,21 @@ describe("<OnboardingStartClient>", () => {
     expect(mockPush).not.toHaveBeenCalled();
   });
 
+  it("shows the cardgroup-limit copy on a limit_reached outcome", async () => {
+    const user = userEvent.setup();
+    mockImport.mockResolvedValueOnce({ status: "limit_reached", limit: 5, current: 5 });
+
+    renderWithIntl(<OnboardingStartClient cardgroups={CARDGROUPS} />);
+    await user.click(screen.getByTestId("onboarding-deck-m-1"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("onboarding-import-error")).toHaveTextContent(
+        "You already have 5 card groups (maximum 5).",
+      );
+    });
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
   it("shows the auth banner with a sign-in link on an auth outcome", async () => {
     const user = userEvent.setup();
     mockImport.mockResolvedValueOnce({ status: "auth", kind: "unauthenticated" });

--- a/frontend/src/app/onboarding/start/onboarding-start-client.tsx
+++ b/frontend/src/app/onboarding/start/onboarding-start-client.tsx
@@ -35,6 +35,9 @@ interface OnboardingStartClientProps {
  */
 export function OnboardingStartClient({ cardgroups }: OnboardingStartClientProps) {
   const t = useTranslations("OnboardingStart");
+  // The cardgroup quota is the same rule the create form enforces, so the import
+  // path reuses that feature's copy rather than duplicating it under OnboardingStart.
+  const tCardgroups = useTranslations("Cardgroups");
   const router = useRouter();
   const { importMasterCardgroup } = useImportMaster();
   const { seedDefaultStarters } = useSeedDefaultStarters();
@@ -66,6 +69,12 @@ export function OnboardingStartClient({ cardgroups }: OnboardingStartClientProps
           setImportError(t("importNotFound"));
           setImportingId(null);
           return;
+        case "limit_reached":
+          setImportError(
+            tCardgroups("limitReached", { limit: outcome.limit, current: outcome.current }),
+          );
+          setImportingId(null);
+          return;
         case "auth":
           setImportAuthError(outcome.kind);
           setImportingId(null);
@@ -76,7 +85,7 @@ export function OnboardingStartClient({ cardgroups }: OnboardingStartClientProps
           return;
       }
     },
-    [importingId, seeding, importMasterCardgroup, router, t],
+    [importingId, seeding, importMasterCardgroup, router, t, tCardgroups],
   );
 
   const handleStartWithDefaults = useCallback(async () => {

--- a/schema/master_catalog.graphql
+++ b/schema/master_catalog.graphql
@@ -143,8 +143,17 @@ type MasterNotFoundError implements UserError {
   message: String!
 }
 
-"""Result of `importMasterCardgroup`: the imported cardgroup, or a typed not-found error returned as data."""
-union ImportMasterCardgroupResult = ImportMasterCardgroupSuccess | MasterNotFoundError
+"""
+Result of `importMasterCardgroup`: the imported cardgroup, a typed not-found error,
+or a limit-reached error when a non-admin caller has already reached the per-user
+cardgroup cap. All three are returned as data. `CardgroupLimitReachedError` is the
+same variant `createCardgroup` returns, so both entry points into "the caller now
+owns a new deck" enforce the quota identically.
+"""
+union ImportMasterCardgroupResult =
+    ImportMasterCardgroupSuccess
+  | MasterNotFoundError
+  | CardgroupLimitReachedError
 
 """Input for `mergeMasterCardgroup`: the published catalog deck to copy from and the caller-owned destination cardgroup to merge into."""
 input MergeMasterCardgroupInput {


### PR DESCRIPTION
## Summary

The per-user 5-cardgroup quota was enforced only by `CardgroupUsecase.Create`, so the catalog import path (`importMasterCardgroup`) let a learner at the cap create deck 6, 7, 8… with no upper bound and no database constraint to fall back on. The cap was a property of one form rather than an invariant of the system. `ImportMaster` now runs the same `checkCardgroupLimit` seam the create path uses — so admins stay exempt by exactly the same `IsAdmin` short-circuit — after the published-ness gate and before `CopyMasterToUser`, meaning no cardgroup row is ever written for a rejected import and a capped caller probing an unknown id still gets the non-disclosure not-found outcome. The rejection travels as data on `ImportMasterOutcome.LimitReached` in the same `*CardgroupLimitInfo` shape `CreateCardgroupOutcome.LimitReached` uses, and the resolver maps it to the `CardgroupLimitReachedError` union member now added to `ImportMasterCardgroupResult` — the same variant `createCardgroup` already returns, so both entry points into "the caller now owns a new deck" surface the quota identically. To reach the quota helper, `masterCatalogUsecase` gained a `cardgroupOwnerCounter` dependency (wired to `repos.cardgroup` in `main.go`), and `*AdminGate` gained an `IsAdmin` delegation so the already-injected gate satisfies `AdminChecker` rather than the usecase carrying a second, redundant handle on the same auth service. On the frontend, `useImportMaster` gains a `limit_reached` outcome carrying `limit` / `current`, and both consumers (`CatalogDeckClient`, `OnboardingStartClient`) render the existing `Cardgroups.limitReached` copy — no new message-catalog keys, so there is no conflict with the concurrent catalog rewrite.

## Changes

- **`schema/master_catalog.graphql`** — `ImportMasterCardgroupResult` gains `CardgroupLimitReachedError` (declared in `schema/cardgroup.graphql`); the union's docstring now names all three variants and states that the limit variant is shared with `createCardgroup`.
- **`backend/internal/usecase/master_catalog.go`** — `ImportMasterOutcome` gains `LimitReached *CardgroupLimitInfo` (docstring updated to a three-variant XOR); `masterCatalogUsecase` gains a `cgCounter cardgroupOwnerCounter` field; `NewMasterCatalogUsecase` takes the counter as a fifth-from-last parameter and panics on nil, matching the other required deps; `ImportMaster` calls `checkCardgroupLimit(ctx, u.cgCounter, u.adminGate, caller.Sub)` between the `FindPublishedByID` gate and `CopyMasterToUser`, with a comment explaining the placement (after the gate for non-disclosure, before the copy so no row is written).
- **`backend/internal/usecase/admin_gate.go`** — new `(*AdminGate).IsAdmin` delegating to the wrapped `AdminChecker`, so a usecase that already holds an `*AdminGate` can feed admin-exempt helpers without injecting a duplicate checker.
- **`backend/internal/usecase/master_deck.go`** — comment-only: the `count > 0` guard in `SeedForNewUser` now documents why seeding needs no explicit quota check (it only ever runs for an owner holding zero cardgroups). No behaviour change, per the issue's out-of-scope note.
- **`backend/graph/resolver/master_catalog.resolvers.go`** — `ImportMasterCardgroup` maps `outcome.LimitReached` to `model.CardgroupLimitReachedError{Message, Limit, Current}` with the same message string `CreateCardgroup` uses; docstring updated.
- **`backend/cmd/server/main.go`** — passes `repos.cardgroup` into `NewMasterCatalogUsecase`.
- **`frontend/src/app/catalog/queries.ts`** — `ImportMasterCardgroupMutation` selects `... on CardgroupLimitReachedError { message limit current }`.
- **`frontend/src/app/catalog/use-import-master.ts`** — `ImportMasterOutcome` gains `{ status: "limit_reached"; limit: number; current: number }` and the hook narrows on the new `__typename`. The comment records why this variant carries a payload while `not_found` does not: the counts are non-sensitive and feed the client's own localized copy, whereas the backend message is still dropped.
- **`frontend/src/app/catalog/[id]/catalog-deck-client.tsx`, `frontend/src/app/onboarding/start/onboarding-start-client.tsx`** — both add a `limit_reached` case to their exhaustive `switch` (TypeScript exhaustiveness forced both, which is how the second consumer was caught) and take a `useTranslations("Cardgroups")` handle to render `limitReached` with the backend counts. Deps arrays updated.

### Tests

- **`backend/internal/usecase/master_catalog_test.go`**
  - `TestImportMaster_NonAdminAtLimit_ReturnsLimitOutcome` — non-admin at `domain.GeneralUserCardgroupLimit` gets `LimitReached{Limit:5, Current:5}`; the copy stub `t.Fatal`s if reached, which is the "no cardgroup row is created" assertion (the copy is the only writer on this path).
  - `TestImportMaster_AdminAtLimit_Succeeds` — same at-cap count with an admin gate returns the copied cardgroup, `LimitReached` nil, and asserts `counter.calls == 0` so the admin exemption is proven to short-circuit before the count query.
  - `TestImportMaster_CountByOwnerError_Wrapped` — a non-context counter error surfaces through `assertInternalChain` with the shared helper's `usecase: cardgroup: count by owner` prefix and no copy attempt.
  - `TestNewMasterCatalogUsecase_NilCounterPanics` — mirrors the sibling nil-dep panic tests.
  - All ~60 existing `NewMasterCatalogUsecase` call sites in this file and `master_catalog_admin_test.go` take `&stubCardgroupCounter{}` (the counter fake already present in `cardgroup_test.go`, same package). `master_catalog_merge_parity_integration_test.go` passes the real `cgRepo`, matching production wiring.
- **`backend/graph/resolver/master_catalog_import_test.go`** — `TestMutationResolver_ImportMasterCardgroup_LimitReached_ReturnsTypedError` pins the outcome→union mapping: `res` is `model.CardgroupLimitReachedError` with `limit=5`, `current=5`, non-empty message, and `err == nil` (errors-as-data).
- **`frontend/src/app/catalog/[id]/catalog-deck-client.test.tsx`** — a MockedProvider response returning the new union member asserts the `catalog-deck-import-error` banner reads `"You already have 5 card groups (maximum 5)."` and that the Import button is NOT left in the disabled/imported state.
- **`frontend/src/app/onboarding/start/onboarding-start-client.test.tsx`** — the second consumer's `limit_reached` branch: `onboarding-import-error` carries the same interpolated copy and `router.push` is not called.

### Review follow-up

- **Pin the `ImportMaster` gate ordering with a test.** The docblock at `backend/internal/usecase/master_catalog.go:709-711` states that the quota deliberately runs *after* the published gate, so a capped caller probing an unknown master id still receives the non-disclosure `NotFound` outcome rather than `LimitReached`. No test exercised that combination: every `ImportMaster` test reaching the `NotFound` branch was built with `newTestAdminGate(true)` (which short-circuits `checkCardgroupLimit` on `IsAdmin`), and the two non-admin tests both stubbed `findPublishedByIDFn` to return a published master. Swapping the two blocks left the entire suite green.
- **`TestImportMaster_NonAdminAtLimit_UnknownMaster_ReturnsNotFound`** (`backend/internal/usecase/master_catalog_test.go`) closes that gap: a non-admin at `domain.GeneralUserCardgroupLimit` importing an id the default repo mock resolves to `repository.ErrNotFound`. It asserts `NotFound == true`, `LimitReached == nil`, `Cardgroup == nil`, and — the assertion that makes a reordering fail loudly rather than merely change the outcome — `counter.calls == 0`, proving the quota is never consulted for an unknown master.
- No production code changed; this is a test-only addition (+35 lines).

### Discrimination proof

| State | Result |
|---|---|
| Production order as committed | 12/12 `ImportMaster` tests PASS |
| `checkCardgroupLimit` block temporarily moved above `FindPublishedByID` | `--- FAIL: TestImportMaster_NonAdminAtLimit_UnknownMaster_ReturnsNotFound` — `expected NotFound outcome, got {Cardgroup:<nil> NotFound:false LimitReached:0x...}`; the other 11 `ImportMaster` tests still PASS |

The mutation was reverted; `git diff -- backend/internal/usecase/master_catalog.go` is empty.

## Test plan

- [ ] cd backend && go build ./... — PASS
- [ ] cd backend && go vet ./... — PASS (no issues found)
- [ ] cd backend && go tool go-arch-lint check --project-path . — PASS (OK - No warnings found, exit 0)
- [ ] cd backend && go test ./internal/... ./graph/... — PASS, 2102 tests in 22 packages
- [ ] cd backend && go test ./... — PASS, 2261 tests in 26 packages
- [ ] cd frontend && ./node_modules/.bin/tsc --noEmit — PASS (exit 0)
- [ ] cd frontend && ./node_modules/.bin/biome check --error-on-warnings . — PASS (exit 0; 520 files, 2 pre-existing config-deprecation infos, 0 diagnostics)
- [ ] cd frontend && ./node_modules/.bin/vitest run — PASS, 206 files / 1931 tests
- [ ] cd frontend && ./node_modules/.bin/knip — PASS (exit 0; 1 pre-existing config hint about @graphql-typed-document-node/core in knip.jsonc)
- [ ] CJK grep (perl -CSD over changed .go/.ts/.tsx/.graphql/.md) — clean
- [ ] grep -rnE 'PR[0-9]+' over changed trees — clean
- [ ] git status --short in the main checkout — clean (no stray edits)
- [ ] go build ./... — PASS (BUILD_OK)
- [ ] go vet ./... — PASS (VET_OK)
- [ ] go tool go-arch-lint check — PASS ("OK - No warnings found")
- [ ] go test -count=1 ./... — PASS, 23/23 packages ok, 0 FAIL (backend/internal/usecase 5.058s; backend/graph/resolver 3.731s; backend/cmd/server 3.558s)
- [ ] Targeted: go test ./internal/usecase/ -run TestImportMaster -count=1 -v — 12/12 PASS, ok 0.208s
- [ ] git -C <main-repo> status --short — empty (main checkout clean)
- [ ] git -C <worktree> diff --stat — 1 file changed, 35 insertions(+), test-only

## Notes

**Evidence citations re-verified in the worktree** (base `d06f30ea`). All held except line-number drift, which is expected and immaterial: `checkCardgroupLimit` is at `cardgroup.go:160` (admin exemption `:161-170`, quota predicate `:178`) and its sole prior caller was `Create` at `cardgroup.go:203`; `ImportMaster` was at `master_catalog.go:677` with the auth gate at `:679` and `FindPublishedByID` at `:683`; `union ImportMasterCardgroupResult` was at `schema/master_catalog.graphql:147`; `CardgroupLimitReachedError` is declared at `schema/cardgroup.graphql:34` and joined into `CreateCardgroupResult` at `:44`. `domain.GeneralUserCardgroupLimit = 5` at `cardgroup_quota.go:8`. Confirmed by reading the resolver → usecase → deck-usecase chain that no other guard existed.

**Message-catalog constraint honored.** No key was added to `frontend/messages/{en,ja}.json` — both consumers reuse the existing `Cardgroups.limitReached` (`en.json:156`, `ja.json:156`), so there is no overlap with the concurrent catalog rewrite in the sibling PR.

**Post-flight wiring grep** (excluding generated + test files):
```
backend/graph/resolver/master_catalog.resolvers.go:126:  return model.CardgroupLimitReachedError{
frontend/src/app/catalog/use-import-master.ts:76:        if (payload?.__typename === "CardgroupLimitReachedError") {
frontend/src/app/catalog/queries.ts:129:      ... on CardgroupLimitReachedError {
```
and for the client-side outcome:
```
frontend/src/app/catalog/use-import-master.ts:33 (declaration), :77 (producer)
frontend/src/app/catalog/[id]/catalog-deck-client.tsx:133 (consumer)
frontend/src/app/onboarding/start/onboarding-start-client.tsx:72 (consumer)
```
Every branch introduced is reachable from a production call site — no speculative helper, no dead union arm.

**Third test tree checked.** `grep -rln` over `frontend/e2e/` for the catalog-import / onboarding-deck testids returned nothing, so no Playwright spec exercises this path and none needed updating.

**Codegen.** Both steps ran in the worktree after the schema edit (`go tool gqlgen generate`, `pnpm --filter frontend codegen`). Their outputs (`backend/graph/{generated,model}`, `frontend/src/generated`) are gitignored and correctly absent from `git status`.

**Note for reviewers on doc drift:** `docs/backend/library-gotchas/admin-checker-inject-for-admin-exempt-business-logic.md` describes the "inject `AdminChecker` for admin-exempt rules" pattern using `cardgroupUsecase` as its worked example. That example is unchanged and still accurate; `masterCatalogUsecase` satisfies the same pattern by passing its `*AdminGate` (which now implements `AdminChecker`). No statement in that doc became false, so it was left alone rather than expanded.

**Scope deviations.** Three items beyond the literal Scope checkboxes, each forced by the change:

1. **`NewMasterCatalogUsecase` gained a `cardgroupOwnerCounter` parameter** and `*AdminGate` gained an `IsAdmin` delegation method. `checkCardgroupLimit(ctx, counter, admin, ownerID)` needs both a counter and an `AdminChecker`; `masterCatalogUsecase` previously had neither. The alternative — injecting a separate `AdminChecker` alongside the existing `*AdminGate` — would give the usecase two handles on the same `auth.Service`, so the delegation method was preferred. This fanned out to ~60 test call sites (mechanical, one extra `&stubCardgroupCounter{}` argument) plus `main.go` and one repository integration test.

2. **`OnboardingStartClient` was updated as well as `CatalogDeckClient`.** The issue named only "the client that consumes it" (singular), but `useImportMaster` has two production consumers and both switch exhaustively on `outcome.status`, so `tsc` requires both. A test was added for the second consumer too.

3. **A comment-only edit to `master_deck.go`** — the issue explicitly asked for the `SeedForNewUser` rationale to be recorded "in a code comment only, do not add a check", which is what landed.

Nothing from Out of scope was implemented: no count-then-insert race fix, no `SeedForNewUser` quota check, no `master_catalog.go` file-layout refactor.

Scope was held to the single confirmed finding — no production code touched, no opportunistic refactoring, frontend untouched. The refuter's suggested test body was adapted rather than pasted: the real helper set in this worktree is `mockMasterCatalogRepository` (whose zero value resolves `FindPublishedByID` to `repository.ErrNotFound` via the fallback chain at master_catalog_test.go:77-85), `mockCopyMasterToUserUC`, `stubCardgroupCounter` (defined in cardgroup_test.go:1796), `newTestAdminGate` (master_catalog_admin_test.go:20), `authedCtx` (user_test.go:62), `newTestLogger` (helpers_test.go:148), and the constructor order `NewMasterCatalogUsecase(repo, copyUC, counter, adminGate, logger)` — all verified by reading the files. One assertion was added beyond the suggestion (`out.Cardgroup != nil`) to match the shape of the sibling NotFound tests. The test comment is English-only and carries no PR-number or plan references, per the language policy. The refuter's test-count discrepancy (1072 vs 817) is explained by Docker-gated integration tests; my full-suite run reports package-level ok lines rather than a test count, and all 23 packages passed.

**Merge order.** `backend/internal/usecase/master_catalog.go` is also touched by the branches for #1018 (comment correction on the `ErrNotFound` branch) and #1022 (owner-FK classification in `ImportMaster`). The hunks are in different functions today, so whichever lands second may need a trivial rebase.

Closes #1010
