### PR TITLE
fix(backend): classify duplicate-front on updateCard as BAD_USER_INPUT instead of INTERNAL

### DIFF
--- a/backend/graph/resolver/card.resolvers.go
+++ b/backend/graph/resolver/card.resolvers.go
@@ -101,9 +101,12 @@ func (r *mutationResolver) CreateCard(ctx context.Context, input model.NewCardIn
 // UpdateCard is the resolver for the updateCard field.
 //
 // Returns a union: `model.UpdateCardSuccess` on the happy path, or
-// `model.InputValidationError` when front/back fails validation. Validation
-// failures are "errors as data" — the error return is reserved for auth and
-// infrastructure failures.
+// `model.InputValidationError` when front/back fails shape validation (empty /
+// too long) — those travel as "errors as data". The error return carries auth
+// and infrastructure failures, plus one field-level validation case the union
+// cannot express: renaming a front onto one that already exists in the same
+// cardgroup surfaces as BAD_USER_INPUT with `extensions.field == "front"`,
+// because `UpdateCardResult` has no duplicate-front variant.
 func (r *mutationResolver) UpdateCard(ctx context.Context, id string, input model.UpdateCardInput) (model.UpdateCardResult, error) {
 	outcome, err := r.CardUC.Update(ctx, id, usecase.UpdateCardInput{
 		Front: input.Front,

--- a/backend/graph/resolver/card_resolvers_test.go
+++ b/backend/graph/resolver/card_resolvers_test.go
@@ -468,6 +468,32 @@ func TestResolver_UpdateCard_InputValidation(t *testing.T) {
 	}
 }
 
+// TestResolver_UpdateCard_DuplicateFront_BadUserInput verifies that renaming a
+// card's front onto one that already exists in the same cardgroup surfaces as
+// BAD_USER_INPUT with extensions.field == "front", not as INTERNAL.
+func TestResolver_UpdateCard_DuplicateFront_BadUserInput(t *testing.T) {
+	t.Parallel()
+
+	cardRepo := &cardMockRepo{
+		findByIDResult: &domain.Card{ID: "c-1", CardgroupID: domain.CardgroupID("cg-1"), Front: "colour", Back: "OldBack"},
+		updateErr:      repository.ErrCardDuplicateFront,
+	}
+	cgRepo := &cardMockCGRepo{
+		findResult: &domain.Cardgroup{ID: domain.CardgroupID("cg-1"), OwnerID: "u-1"},
+	}
+	srv := newUpdateCardSrv(cardRepo, cgRepo)
+
+	resp := gqlRequest(t, srv, authedCtx("u-1"), updateCardMutation("c-1", "color", "OldBack"))
+
+	if code := errCode(t, resp); code != "BAD_USER_INPUT" {
+		t.Fatalf("expected BAD_USER_INPUT, got %q; response: %v", code, resp)
+	}
+	ext := errExtensions(t, resp)
+	if field, _ := ext["field"].(string); field != "front" {
+		t.Fatalf("expected extensions.field=front, got %v; response: %v", ext["field"], resp)
+	}
+}
+
 // TestResolver_UpdateCard_Unauthenticated verifies that an anonymous request
 // is rejected with UNAUTHENTICATED via gqlerr.FromUsecaseError.
 func TestResolver_UpdateCard_Unauthenticated(t *testing.T) {

--- a/backend/internal/repository/card.go
+++ b/backend/internal/repository/card.go
@@ -12,11 +12,23 @@ import (
 	"backend/internal/domain"
 )
 
-// ErrCardDuplicateFront is returned by Create when an INSERT collides with the
-// (cardgroup_id, front) unique index. Standalone — do NOT join with ErrNotFound;
-// the row was found, which is precisely the failure (see
+// ErrCardDuplicateFront is returned by Create and Update when the write collides
+// with the (cardgroup_id, front) unique index. Standalone — do NOT join with
+// ErrNotFound; the row was found, which is precisely the failure (see
 // docs/backend/error-wrapping/standalone-sentinels-not-every-joins-errnotfound.md).
 var ErrCardDuplicateFront = errors.New("repository: card with same front exists in cardgroup")
+
+// classifyCardDuplicateFront maps a Postgres unique violation on the
+// (cardgroup_id, front) index to ErrCardDuplicateFront, and returns nil for any
+// other error. Both write paths — INSERT (Create) and UPDATE (Update) — can hit
+// the same constraint, so they share this classifier rather than each spelling
+// out the code/constraint pair.
+func classifyCardDuplicateFront(err error) error {
+	if pgConstraintViolation(err, "23505", "uq_cards_cardgroup_front") {
+		return ErrCardDuplicateFront
+	}
+	return nil
+}
 
 type gormCard struct {
 	ID          string    `gorm:"column:id;primaryKey;type:uuid"`
@@ -188,8 +200,8 @@ func (r *cardRepo) ListFrontsByCardgroupTx(ctx context.Context, tx *gorm.DB, car
 
 func (r *cardRepo) Create(ctx context.Context, card *domain.Card) error {
 	if err := r.db.WithContext(ctx).Create(cardToRow(card)).Error; err != nil {
-		if pgConstraintViolation(err, "23505", "uq_cards_cardgroup_front") {
-			return ErrCardDuplicateFront
+		if classified := classifyCardDuplicateFront(err); classified != nil {
+			return classified
 		}
 		return eris.Wrap(err, "repository: card: create")
 	}
@@ -238,6 +250,9 @@ func (r *cardRepo) Update(ctx context.Context, id string, patch CardUpdate) (*do
 
 	res := r.db.WithContext(ctx).Model(&gormCard{}).Where("id = ?", id).Updates(updates)
 	if res.Error != nil {
+		if classified := classifyCardDuplicateFront(res.Error); classified != nil {
+			return nil, classified
+		}
 		return nil, eris.Wrap(res.Error, "repository: card: update")
 	}
 	return refetchAfterUpdate(res.RowsAffected, ErrNotFound,

--- a/backend/internal/repository/card_test.go
+++ b/backend/internal/repository/card_test.go
@@ -392,6 +392,30 @@ func TestCardRepo_Create_DuplicateFront(t *testing.T) {
 	}
 }
 
+// TestCardRepo_Update_DuplicateFront asserts that renaming a card's front onto
+// a front already used in the same cardgroup returns the ErrCardDuplicateFront
+// sentinel, exactly like the Create path — not a generic wrapped error.
+func TestCardRepo_Update_DuplicateFront(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	ownerID := insertAuthUser(t, ctx)
+	cg := insertCardgroup(t, ctx, ownerID)
+	repo := repository.NewCardRepository(testDB.GORM)
+
+	first := newCard(cg.ID, "taken-front", "back-one")
+	require.NoError(t, repo.Create(ctx, first))
+	second := newCard(cg.ID, "other-front", "back-two")
+	require.NoError(t, repo.Create(ctx, second))
+
+	taken := "taken-front"
+	_, err := repo.Update(ctx, second.ID, repository.CardUpdate{Front: &taken})
+	require.ErrorIs(t, err, repository.ErrCardDuplicateFront,
+		"Update onto an existing (cardgroup_id, front) must return ErrCardDuplicateFront")
+	// Standalone "found" sentinel; must not collapse into the not-found channel.
+	require.False(t, errors.Is(err, repository.ErrNotFound),
+		"ErrCardDuplicateFront must not match ErrNotFound, got %v", err)
+}
+
 func repoCardIDs(cards []domain.DueCard) []string {
 	out := make([]string, len(cards))
 	for i, dc := range cards {

--- a/backend/internal/usecase/card.go
+++ b/backend/internal/usecase/card.go
@@ -329,6 +329,15 @@ func (u *cardUsecase) Update(ctx context.Context, id string, in UpdateCardInput)
 
 	updated, err := u.cardRepo.Update(ctx, id, patch)
 	if err != nil {
+		// Renaming a front onto one that already exists in the same cardgroup is
+		// an ordinary, recoverable user mistake, not an infrastructure failure.
+		// UpdateCardResult has no duplicate variant, so it travels the error
+		// channel as a field-level validation error (BAD_USER_INPUT on "front")
+		// rather than defaulting to INTERNAL.
+		if errors.Is(err, repository.ErrCardDuplicateFront) {
+			return UpdateCardOutcome{}, ucerr.NewValidationError("front",
+				"A card with this front already exists in this cardgroup")
+		}
 		return UpdateCardOutcome{}, eris.Wrap(err, "usecase: card: update: repo update")
 	}
 	u.observer.OnCardUpdated(ctx, updated)

--- a/backend/internal/usecase/card_test.go
+++ b/backend/internal/usecase/card_test.go
@@ -497,6 +497,39 @@ func TestCardUsecase_Update_RepoError_InfraChannel(t *testing.T) {
 	assertInternalChain(t, err, "usecase: card: update: repo update")
 }
 
+// TestCardUsecase_Update_DuplicateFront_ValidationError pins the rename-onto-an
+// -existing-front case to the validation channel: the repository's
+// ErrCardDuplicateFront must surface as a field-level error on "front"
+// (BAD_USER_INPUT once the resolver converts it), never as an INTERNAL wrap.
+func TestCardUsecase_Update_DuplicateFront_ValidationError(t *testing.T) {
+	t.Parallel()
+
+	existing := &domain.Card{
+		ID:          "card1",
+		CardgroupID: domain.CardgroupID("cg1"),
+		Front:       domain.CardText("colour"),
+		Back:        domain.CardText("old back"),
+	}
+	cardRepo := &mockCardRepository{
+		findResult: existing,
+		updateErr:  repository.ErrCardDuplicateFront,
+	}
+	uc := NewCardUsecase(nil, cardRepo,
+		&mockCardgroupRepoForCard{findResult: &domain.Cardgroup{ID: domain.CardgroupID("cg1"), OwnerID: "u1"}},
+		nil, nil, newTestLogger(),
+	)
+
+	outcome, err := uc.Update(authedCtx("u1"), "card1", UpdateCardInput{Front: ptr("color")})
+
+	assertValidationError(t, err, "front", "A card with this front already exists in this cardgroup")
+	if outcome.Card != nil {
+		t.Fatal("expected nil Card on duplicate front")
+	}
+	if outcome.Validation != nil {
+		t.Fatal("duplicate front travels the error channel, not outcome.Validation")
+	}
+}
+
 func TestCardUsecase_Delete_NotFoundMasksExistence(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Renaming a card's front onto a front that already exists in the same cardgroup produced an unexplained INTERNAL error: `cardRepo.Update`'s only error path wrapped the raw GORM error, so the Postgres 23505 violation on `uq_cards_cardgroup_front` escaped unclassified and `gqlerr.FromUsecaseError` fell through to its INTERNAL default. Creating a duplicate front, by contrast, was already classified. The 23505 / `uq_cards_cardgroup_front` check is now extracted into a shared private classifier `classifyCardDuplicateFront` in `backend/internal/repository/card.go` and called from both `Create` and `Update`, so the two write paths cannot drift. `cardUsecase.Update` gains an `errors.Is(err, repository.ErrCardDuplicateFront)` branch that returns `ucerr.NewValidationError("front", …)`, which the resolver's existing `gqlerr.FromUsecaseError` call converts to BAD_USER_INPUT with `extensions.field == "front"`. `UpdateCardResult` is unchanged — no `CardDuplicateFrontError` variant was added, and the create-path `recoverDuplicateFront` recovery is untouched. Three tests were written first and confirmed failing against the unfixed code before the fix landed.

## Changes

- `backend/internal/repository/card.go`: added private `classifyCardDuplicateFront(err error) error`, which returns `ErrCardDuplicateFront` for a 23505 violation on `uq_cards_cardgroup_front` and nil otherwise; routed `Create` through it (replacing the inline `pgConstraintViolation` call) and added the same classification to `Update` ahead of its generic `eris.Wrap`. Refreshed the `ErrCardDuplicateFront` docstring from "returned by Create" to "returned by Create and Update", since the sentinel now has two producers.
- `backend/internal/usecase/card.go`: in `Update`, the repository error is checked for `repository.ErrCardDuplicateFront` before the generic wrap and mapped to `ucerr.NewValidationError("front", "A card with this front already exists in this cardgroup")`. The message matches the create path's resolver-side copy. A comment records why this travels the error channel rather than `outcome.Validation` (the `UpdateCardResult` union has no duplicate variant, so BAD_USER_INPUT on `front` is the honest wire shape).

### Tests

- `backend/internal/usecase/card_test.go` — `TestCardUsecase_Update_DuplicateFront_ValidationError`: a `mockCardRepository` whose `updateErr` is `repository.ErrCardDuplicateFront` drives `Update`; asserts via the existing `assertValidationError` helper that the returned error narrows to `*ucerr.ValidationError` with `Field == "front"` and the exact message, and that both `outcome.Card` and `outcome.Validation` stay nil (the duplicate travels the error channel, not the union's data variant).
- `backend/internal/repository/card_test.go` — `TestCardRepo_Update_DuplicateFront` (Docker-gated integration, same fixture helpers as the adjacent `TestCardRepo_Create_DuplicateFront`): inserts two cards in one cardgroup, renames the second's front onto the first's, and asserts `require.ErrorIs(err, repository.ErrCardDuplicateFront)` plus `errors.Is(err, ErrNotFound) == false` (the sentinel is standalone, mirroring the Create test's assertion).
- `backend/graph/resolver/card_resolvers_test.go` — `TestResolver_UpdateCard_DuplicateFront_BadUserInput`: drives the real gqlgen server through `newUpdateCardSrv` with a `cardMockRepo` whose `updateErr` is `ErrCardDuplicateFront`; asserts `errors[0].extensions.code == "BAD_USER_INPUT"` and `extensions.field == "front"`.
- Existing create-duplicate coverage (`TestCardRepo_Create_DuplicateFront`, the `createErr: repository.ErrCardDuplicateFront` table cases in `card_test.go`, `TestResolver_CreateCard_*`) is unchanged and still green.

### Review follow-up

- **Corrected the `UpdateCard` resolver docblock to match the error channel the duplicate-front fix actually uses.** The previous text claimed "the error return is reserved for auth and infrastructure failures", which stopped being true once `usecase.Update` began returning `ucerr.NewValidationError("front", …)` for a rename onto an existing `(cardgroup_id, front)` pair. A maintainer adding the next front-side rule would have concluded `updateCard` never emits a top-level `BAD_USER_INPUT` and written a frontend branch on `__typename === "InputValidationError"` that the duplicate case can never reach.
- The docblock now enumerates both exit shapes explicitly: `model.InputValidationError` as union data for front/back **shape** validation (empty / too long), and a top-level `BAD_USER_INPUT` with `extensions.field == "front"` on the error return for the duplicate-front collision — including the reason (`UpdateCardResult` has no duplicate-front variant).
- **Docblock, not routing.** Adding a `CardDuplicateFrontError` variant to the `UpdateCardResult` union is listed under the issue's Out of scope, and the issue's Scope bullet and acceptance criteria both name the `ucerr.NewValidationError("front", …)` / `BAD_USER_INPUT` path as the intended behaviour. The error-channel routing is correct; only its documentation had drifted.
- No production behaviour changed. The newly-documented contract is already pinned by `TestResolver_UpdateCard_DuplicateFront_BadUserInput`, and `go tool gqlgen generate` was re-run to confirm codegen preserves the hand-written comment (the CI regen-diff gate stays clean).

## Test plan

- [ ] cd backend && go build ./... — PASS
- [ ] cd backend && go vet ./... — PASS (no issues)
- [ ] cd backend && go tool go-arch-lint check --project-path . — PASS (OK - No warnings found)
- [ ] cd backend && go test ./internal/... ./graph/... — PASS, 2100 tests across 22 packages
- [ ] cd backend && go test ./... — PASS, 2259 tests across 26 packages
- [ ] gofmt -l on all 5 changed files — PASS (no output)
- [ ] Docker-gated integration proof: rtk proxy go test ./internal/repository/ -run 'TestCardRepo_(Create|Update)_DuplicateFront' -v — PASS, both tests ran against a real postgres:15-alpine testcontainer (log shows the 23505 arriving at card.go:251 on the UPDATE statement)
- [ ] go build ./... — Success
- [ ] go vet ./... — No issues found
- [ ] go tool go-arch-lint check --project-path . — OK, No warnings found
- [ ] go test -count=1 ./... — 2259 passed in 26 packages
- [ ] go test -count=1 -run TestResolver_UpdateCard_DuplicateFront_BadUserInput ./graph/resolver/ — 1 passed in 1 packages
- [ ] go tool gqlgen generate — regen leaves only the intended card.resolvers.go edit dirty (docblock preserved; CI regen-diff gate unaffected)
- [ ] git status --short in the main checkout /Users/yasuflatland/projects/flamingo-armond — empty (no stray edits outside the worktree)

## Notes

All three file:line citations in the issue body were verified against this worktree and still hold exactly: `repository/card.go:189-197` (Create's classification), `:227-245` (Update's single generic wrap at `:240-242`), `usecase/card.go:271-336` (Update with the generic wrap at `:330-333`) and `:252` (the Create duplicate branch), `schema/card.graphql:94-96` (`union UpdateCardResult = UpdateCardSuccess | InputValidationError`, unchanged). No citation drift to report.

Test-first evidence: after writing the three tests, the production fix was temporarily removed and the suite re-run. All three failed with the expected pre-fix symptoms — usecase: `got *eris.rootError: usecase: card: update: repo update: repository: card with same front exists in cardgroup`; resolver: `expected BAD_USER_INPUT, got "INTERNAL"`; repository: `Update onto an existing (cardgroup_id, front) must return ErrCardDuplicateFront`. The fix was then restored and all gates re-run from scratch.

Post-flight grep for the extracted helper (`grep -rn classifyCardDuplicateFront backend --include='*.go' | grep -v _test.go`) returns exactly the declaration plus two production call sites (`card.go:203` Create, `card.go:253` Update) — matching the planned count, so no speculative unwired helper.

Known adjacent gap left deliberately out of scope: `masterCardRepo.Update` (`backend/internal/repository/master_card.go:362-365`) has the identical unclassified-23505 shape on `uq_master_cards_cg_front`, and `masterCardUsecase.UpdateMasterCard` has no duplicate branch. That is a separate aggregate and a separate mutation; it is not in this issue's Scope and was not touched.

Working-tree hygiene: `git status --short` in the worktree lists exactly the five intended files; the main checkout at /Users/yasuflatland/projects/flamingo-armond is clean. No git write operations were performed.

**Scope deviations.** Two items beyond the literal checkbox text, both bounded and adjacent-inconsistency fixes: (1) the `ErrCardDuplicateFront` docstring was updated from "returned by Create" to "returned by Create and Update", because the same change gives the sentinel a second producer and the old docstring would have been actively wrong; (2) `Create` was switched from its inline `pgConstraintViolation` call to the new classifier — that is the "call it from both Create and Update so the two cannot drift" checkbox, stated here explicitly since it edits a previously-working line. Nothing from Out of scope was touched: no `CardDuplicateFrontError` schema variant, no `schema/card.graphql` edit, no change to `recoverDuplicateFront` or the create-path duplicate recovery.

Both confirmed findings described the same defect from two lenses and were resolved by one edit to `/Users/yasuflatland/projects/flamingo-armond/.claude/worktrees/fix-1011-update-card-dup-front/backend/graph/resolver/card.resolvers.go` (lines 103-109). Nothing was disputed.

Deliberation on the two options the reviewers named: routing the duplicate through the union would require a `CardDuplicateFrontError` variant on `UpdateCardResult`, which the issue's Out-of-scope list defers by name along with the frontend overwrite flow. The issue's Scope and AC both specify the error-channel mapping. So the docblock amendment is the correct call, and the reviewers' own fallback ("if the error-channel routing is kept, amend the docblock") applies.

Two verification points worth flagging for the PR: (1) gqlgen's `follow-schema` layout does preserve these hand-written multi-line resolver docblocks — confirmed empirically by re-running `go tool gqlgen generate` and seeing no diff beyond my edit, so this is not a comment that will silently vanish on the next regen; (2) the amended text mentions `BAD_USER_INPUT` as prose, which does not match the CI grep gate at `.github/workflows/backend.yml:111` (that gate keys on the `"code"\s*:\s*"BAD_USER_INPUT"` JSON-literal shape, not the bare token).

No git write operations were performed; the change is uncommitted for the orchestrator.

**Merge order.** `backend/internal/usecase/card.go` is also touched by the branch for #1021, in a different function (`Card` vs `Update`). Whichever lands second may need a trivial rebase.

Closes #1011
