### PR TITLE
fix(backend): report a committed swipe as saved when the post-commit metrics read fails

### DIFF
--- a/backend/internal/usecase/swipe.go
+++ b/backend/internal/usecase/swipe.go
@@ -12,6 +12,7 @@ import (
 	"backend/internal/auth"
 	"backend/internal/domain"
 	"backend/internal/domain/service"
+	"backend/internal/logging"
 	"backend/internal/repository"
 	"backend/internal/usecase/ucerr"
 )
@@ -161,10 +162,7 @@ func (u *swipeUsecase) HandleSwipe(ctx context.Context, in HandleSwipeInput) (Ha
 			if errors.Is(err, repository.ErrNotFound) {
 				return ucerr.NewValidationError("cardId", "card not found")
 			}
-			if isContextDone(err) {
-				return err
-			}
-			return eris.Wrap(err, "usecase: swipe: find card by id")
+			return wrapSwipeErr(err, "usecase: swipe: find card by id")
 		}
 		if !card.BelongsToCardgroup(in.CardgroupID) {
 			return ucerr.NewValidationError("cardId", "card not found")
@@ -173,10 +171,7 @@ func (u *swipeUsecase) HandleSwipe(ctx context.Context, in HandleSwipeInput) (Ha
 		now = time.Now().UTC()
 		byCardID, err := u.userFSRSRepo.FindByUserAndCardIDsTx(ctx, tx, user.Sub, []string{card.ID})
 		if err != nil {
-			if isContextDone(err) {
-				return err
-			}
-			return eris.Wrap(err, "usecase: swipe: find user-card fsrs")
+			return wrapSwipeErr(err, "usecase: swipe: find user-card fsrs")
 		}
 		current := byCardID[card.ID]
 		if current == nil {
@@ -190,20 +185,14 @@ func (u *swipeUsecase) HandleSwipe(ctx context.Context, in HandleSwipeInput) (Ha
 			return eris.Wrap(err, "usecase: swipe: apply rating")
 		}
 		if err := u.userFSRSRepo.UpsertTx(ctx, tx, current); err != nil {
-			if isContextDone(err) {
-				return err
-			}
-			return eris.Wrap(err, "usecase: swipe: upsert user-card fsrs")
+			return wrapSwipeErr(err, "usecase: swipe: upsert user-card fsrs")
 		}
 		sr, err := u.newSwipeRecord(domain.UserID(user.Sub), card.ID, card.CardgroupID, rating, now, before, current.State)
 		if err != nil {
 			return eris.Wrap(err, "usecase: swipe: new swipe record")
 		}
 		if err := u.swipeRepo.CreateTx(ctx, tx, sr); err != nil {
-			if isContextDone(err) {
-				return err
-			}
-			return eris.Wrap(err, "usecase: swipe: insert swipe record")
+			return wrapSwipeErr(err, "usecase: swipe: insert swipe record")
 		}
 		return nil
 	})
@@ -219,18 +208,48 @@ func (u *swipeUsecase) HandleSwipe(ctx context.Context, in HandleSwipeInput) (Ha
 			return HandleSwipeOutcome{Validation: info}, nil
 		}
 	}
-	recentSwipes, err := u.swipeRepo.ListRecentByUser(ctx, user.Sub, swipePerformanceSampleLimit)
+	// The transaction has committed: the FSRS row and the swipe record are
+	// durable from here on. Everything below is read-only telemetry assembly,
+	// so past this point the error channel means "the swipe was NOT persisted".
+	metrics, err := u.performanceSnapshot(ctx, user.Sub, now)
 	if err != nil {
-		if isContextDone(err) {
-			return HandleSwipeOutcome{}, err
-		}
-		return HandleSwipeOutcome{}, eris.Wrap(err, "usecase: swipe: list recent swipes")
+		return HandleSwipeOutcome{}, err
 	}
-	metrics := service.ComputeMetrics(swipeRecordsByValue(recentSwipes), now)
 	return HandleSwipeOutcome{Swipe: &SwipeOutput{
 		PerformanceMode: int(service.ModeFromMetrics(metrics)),
 		Metrics:         metrics,
 	}}, nil
+}
+
+// performanceSnapshot assembles the read-only performance telemetry that
+// accompanies an already-committed swipe. An infrastructure failure of the
+// recent-swipe read degrades to the neutral empty-window snapshot (which
+// ModeFromMetrics maps to service.ModeDefault) and is logged rather than
+// returned, because reporting a durable swipe as failed makes the client
+// re-queue the card and review it twice. Context cancellation still propagates
+// unwrapped: the caller is being torn down and has nothing to report to.
+func (u *swipeUsecase) performanceSnapshot(ctx context.Context, userID string, now time.Time) (service.PerformanceMetrics, error) {
+	recentSwipes, err := u.swipeRepo.ListRecentByUser(ctx, userID, swipePerformanceSampleLimit)
+	if err != nil {
+		if isContextDone(err) {
+			return service.PerformanceMetrics{}, err
+		}
+		logging.LogWarn(ctx, u.logger,
+			"swipe committed but recent-swipe read failed; returning default performance snapshot",
+			eris.Wrap(err, "usecase: swipe: list recent swipes"),
+		)
+		return service.ComputeMetrics(nil, now), nil
+	}
+	return service.ComputeMetrics(swipeRecordsByValue(recentSwipes), now), nil
+}
+
+// wrapSwipeErr passes a context cancellation through unwrapped and wraps any
+// other error with the caller-supplied chain prefix.
+func wrapSwipeErr(err error, msg string) error {
+	if isContextDone(err) {
+		return err
+	}
+	return eris.Wrap(err, msg)
 }
 
 func swipeRecordsByValue(swipes []*domain.SwipeRecord) []domain.SwipeRecord {

--- a/backend/internal/usecase/swipe_error_test.go
+++ b/backend/internal/usecase/swipe_error_test.go
@@ -1,7 +1,9 @@
 package usecase
 
 import (
+	"bytes"
 	"context"
+	"log/slog"
 	"testing"
 	"time"
 
@@ -369,11 +371,14 @@ func TestSwipeUsecase_HandleSwipe_InsertSwipeRecord_PropagatesCancelled(t *testi
 	assertCancelled(t, err)
 }
 
-// TestSwipeUsecase_HandleSwipe_ListRecentSwipes_PinsChain verifies that an
-// infrastructure error from ListRecentByUser is wrapped with the canonical
-// "usecase: swipe: list recent swipes" prefix so the error_chain log attribute
-// points at the correct post-transaction operation.
-func TestSwipeUsecase_HandleSwipe_ListRecentSwipes_PinsChain(t *testing.T) {
+// TestSwipeUsecase_HandleSwipe_ListRecentSwipes_DegradesToSuccess verifies that
+// an infrastructure error from the post-commit ListRecentByUser read does NOT
+// fail the mutation: the swipe row and the FSRS row are already durable, so the
+// outcome carries the neutral empty-window snapshot (service.ModeDefault) and
+// the failure is only logged with the canonical
+// "usecase: swipe: list recent swipes" chain prefix. Reporting a committed
+// swipe as failed would make the client re-queue the card and review it twice.
+func TestSwipeUsecase_HandleSwipe_ListRecentSwipes_DegradesToSuccess(t *testing.T) {
 	t.Parallel()
 
 	infraErr := eris.New("storage: simulated list-recent infra failure")
@@ -393,6 +398,8 @@ func TestSwipeUsecase_HandleSwipe_ListRecentSwipes_PinsChain(t *testing.T) {
 		byCardID: map[string]*domain.UserCardFSRS{},
 	}
 	tx, _ := fakeTxRunner()
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
 	uc := NewSwipeUsecaseWithTx(
 		cardRepo,
 		cardgroupRepo,
@@ -400,22 +407,37 @@ func TestSwipeUsecase_HandleSwipe_ListRecentSwipes_PinsChain(t *testing.T) {
 		service.NewFSRSScheduler(),
 		tx,
 		userFSRSRepo,
-		newTestLogger(),
+		logger,
 	)
 
-	_, err := uc.HandleSwipe(authedCtx("user-1"), HandleSwipeInput{
+	out, err := uc.HandleSwipe(authedCtx("user-1"), HandleSwipeInput{
 		CardID:      "card-1",
 		CardgroupID: "cg-1",
 		Rating:      int(domain.RatingEasy),
 	})
 
-	assertInternalChain(t, err, "usecase: swipe: list recent swipes")
-	require.ErrorIs(t, err, infraErr, "error chain must preserve injected root sentinel")
+	require.NoError(t, err, "a committed swipe must not surface the post-commit read failure")
+	require.Nil(t, out.Validation)
+	require.NotNil(t, out.Swipe)
+	require.Equal(t, int(service.ModeDefault), out.Swipe.PerformanceMode)
+	require.Equal(t, 0, out.Swipe.Metrics.ReviewCount, "degraded snapshot carries no reviews")
+
+	// Both writes are still durable: the FSRS row was upserted and the swipe
+	// record was inserted inside the committed transaction.
+	require.NotNil(t, userFSRSRepo.upserted, "FSRS row must still be committed")
+	require.NotNil(t, swipeRepo.created, "swipe record must still be committed")
+
+	logged := buf.String()
+	require.Contains(t, logged, "swipe committed but recent-swipe read failed")
+	require.Contains(t, logged, "usecase: swipe: list recent swipes")
+	require.Contains(t, logged, "simulated list-recent infra failure")
 }
 
 // TestSwipeUsecase_HandleSwipe_ListRecentSwipes_PropagatesCancelled verifies
 // that context.Canceled returned from ListRecentByUser passes through unwrapped
-// after the transaction commits successfully.
+// after the transaction commits successfully. Cancellation is the deliberate
+// exception to the degrade-to-success rule: the caller is being torn down and
+// has nothing to report to.
 func TestSwipeUsecase_HandleSwipe_ListRecentSwipes_PropagatesCancelled(t *testing.T) {
 	t.Parallel()
 
@@ -457,7 +479,8 @@ func TestSwipeUsecase_HandleSwipe_ListRecentSwipes_PropagatesCancelled(t *testin
 
 // TestSwipeUsecase_HandleSwipe_ListRecentSwipes_PropagatesDeadlineExceeded
 // verifies that context.DeadlineExceeded returned from ListRecentByUser passes
-// through unwrapped after the transaction commits successfully.
+// through unwrapped after the transaction commits successfully — the same
+// deliberate exception to the degrade-to-success rule as the cancelled case.
 func TestSwipeUsecase_HandleSwipe_ListRecentSwipes_PropagatesDeadlineExceeded(t *testing.T) {
 	t.Parallel()
 

--- a/docs/backend-graphql.md
+++ b/docs/backend-graphql.md
@@ -268,6 +268,8 @@ The sentinel `repository.ErrCardgroupNotFound` lives in `repository/user_prefere
 
 `backend/internal/domain/service/user_performance.go` is a stateless calculator. `SwipeUsecase.HandleSwipe` records the swipe and commits the FSRS update first, then loads the latest 100 swipe records for the user through `SwipeRecordRepository.ListRecentByUser`. This post-commit read keeps transactional rollback behavior simple and lets the just-created swipe participate in the next response's metrics.
 
+Because the read runs after the commit, an infrastructure failure there does **not** fail the mutation: `HandleSwipe` logs the chain and returns the neutral empty-window snapshot (`ModeDefault`, zero review count) instead. The `handleSwipe` error channel therefore means exactly one thing — "the swipe was NOT persisted" — which is what lets the client re-queue the card on error without risking a double review. Context cancellation is the one exception and still propagates unwrapped, since a torn-down caller has nothing to report to.
+
 The response exposes both `performanceMode` and `metrics`. On the wire `performanceMode` is the `SwipePerformanceMode` enum — `DIFFICULT`, `DEFAULT`, `GOOD`, `EASY`, `MASTERED` — which corresponds in that order to the calculator's internal modes `0..4`; `toSwipePerformanceModeModel` in `backend/graph/resolver/mapper.go` performs the order-preserving conversion. The internal modes and their bands:
 
 | Mode | Label | Success-rate band before difficulty adjustment |


### PR DESCRIPTION
## Summary

`SwipeUsecase.HandleSwipe` ran its performance-metrics read (`SwipeRecordRepository.ListRecentByUser`) after the write transaction committed, but returned the read's failure on the mutation's error channel. A learner on a flaky connection could have a review durably written and still be told "Could not save that swipe", causing the client to re-queue the card and produce a second review of the same card — double-advancing the FSRS schedule and double-counting the swipe in statistics. The post-commit read is now extracted into a private `performanceSnapshot` method that degrades an infrastructure failure to the neutral empty-window snapshot (`ComputeMetrics(nil, now)`, which `ModeFromMetrics` maps to `service.ModeDefault`) and logs the chain through the injected usecase logger via `logging.LogWarn`. Context cancellation and deadline-exceeded still propagate unwrapped, since a torn-down caller has nothing to report to. After this change the `handleSwipe` error channel means exactly one thing: the swipe was NOT persisted. The four repeated `isContextDone` / `eris.Wrap` triplets inside the transaction closure are concentrated into a one-line `wrapSwipeErr(err, msg)` helper that takes the chain prefix from the caller (per the shared-helper rule in `.claude/rules/error-wrapping.md`), so every existing `error_chain` substring is preserved byte-for-byte. No frontend change: the client's existing failure handling becomes correct once the error channel means what it says.

## Changes

- **`backend/internal/usecase/swipe.go`**
  - Extracted the post-commit metrics assembly into `(*swipeUsecase).performanceSnapshot(ctx, userID, now) (service.PerformanceMetrics, error)`. On a non-context read failure it logs `"swipe committed but recent-swipe read failed; returning default performance snapshot"` with `eris.Wrap(err, "usecase: swipe: list recent swipes")` via `logging.LogWarn` and returns `service.ComputeMetrics(nil, now)` with a nil error; `isContextDone(err)` still returns the error unwrapped.
  - `HandleSwipe` now calls `performanceSnapshot` and carries a comment marking the commit boundary: past it the error channel means "the swipe was NOT persisted".
  - Added `wrapSwipeErr(err error, msg string) error` — context pass-through plus caller-supplied `eris.Wrap` prefix — and routed the four in-closure sites through it (`find card by id`, `find user-card fsrs`, `upsert user-card fsrs`, `insert swipe record`). Wrap messages are unchanged.
  - Added the `backend/internal/logging` import (already permitted for the `usecase` component in `backend/.go-arch-lint.yml`).
- **`docs/backend-graphql.md`** — one paragraph added under "Adaptive learning performance mode" documenting that a post-commit read failure degrades to `ModeDefault` rather than failing the mutation, that the error channel therefore means "not persisted", and that context cancellation is the one exception.

### Tests

- **`TestSwipeUsecase_HandleSwipe_ListRecentSwipes_PinsChain` → renamed `..._DegradesToSuccess`** (`backend/internal/usecase/swipe_error_test.go`). Rewritten to pin the new contract with `ListRecentByUser` returning an eris infra error: asserts `err == nil`, `out.Validation == nil`, `out.Swipe.PerformanceMode == int(service.ModeDefault)`, `out.Swipe.Metrics.ReviewCount == 0`, and that both writes are still durable (`userFSRSRepo.upserted != nil`, `swipeRepo.created != nil`). The test now injects a `slog.NewJSONHandler` over a `bytes.Buffer` (the pattern already used in `notion_sync_test.go`) and asserts the buffer contains the log message, the `usecase: swipe: list recent swipes` chain frame, and the injected root sentinel text — so the chain prefix stays pinned even though it moved from the return value to the log line.
- **`..._PropagatesCancelled` / `..._PropagatesDeadlineExceeded`** — assertions unchanged (both still `require.Equal(t, context.Canceled/DeadlineExceeded, err)`); only their docstrings gained a sentence naming cancellation as the deliberate exception to the degrade-to-success rule.
- **Test-first proof**: the new test was run against the pre-fix behaviour by temporarily restoring the `return service.PerformanceMetrics{}, eris.Wrap(...)` line — it failed with `Received unexpected error` — then the production code was restored and it passed. New-file/old-file byte restoration verified by the subsequent green run.
- No other test pinned the old behaviour: `grep -rn "ListRecentByUser\|list recent swipes" backend/` shows the only other error-injecting fake is `failingSwipeRepo` in `backend/cmd/server/main_test.go`, whose `TestHandleSwipe_RollsBackWhenSwipeRecordInsertFails` fails at `CreateTx` *inside* the transaction and is unaffected.

## Test plan

- [ ] cd backend && go build ./... — PASS (Success)
- [ ] cd backend && go vet ./... — PASS (no issues found)
- [ ] cd backend && go tool go-arch-lint check --project-path . — PASS (OK - No warnings found)
- [ ] cd backend && go test ./internal/... ./graph/... -count=1 — PASS (2097 passed in 22 packages)
- [ ] cd backend && go test ./... -count=1 — PASS (2256 passed in 26 packages)
- [ ] cd backend && go test ./internal/usecase/ -run TestSwipeUsecase_HandleSwipe_ListRecentSwipes -v -count=1 — PASS (3/3: _DegradesToSuccess, _PropagatesCancelled, _PropagatesDeadlineExceeded)
- [ ] gofmt -l on both changed .go files — PASS (no output)
- [ ] grep -rnE 'PR[0-9]+' on changed files — PASS (no output)
- [ ] perl -CSD CJK scan on changed files — PASS (no output)
- [ ] git status --short in main checkout /Users/yasuflatland/projects/flamingo-armond — PASS (clean, no output)

## Notes

Evidence-citation verification against this worktree (base `e675752f`): the issue's line numbers had drifted by a few lines but every claim held. `swipe.go:158-209` transaction closure → actually `:158-209` exactly (FSRS `UpsertTx` at `:192`, `swipeRepo.CreateTx` at `:202`, closure close at `:209`) — all confirmed. `swipe.go:222` post-commit `ListRecentByUser` and `:227` `eris.Wrap` — confirmed verbatim. `swipe_error_test.go:376` `TestSwipeUsecase_HandleSwipe_ListRecentSwipes_PinsChain` declaration — confirmed at `:376` with the sibling context tests at `:419` and `:461`. `graph/resolver/swipe.resolvers.go:29-30` `gqlerr.FromUsecaseError` pass-through — confirmed. `domain/user_card_fsrs.go:40-47` `ApplyRating` with no same-day guard — confirmed. No stale citations to report.

Post-flight helper-wiring grep (per `.claude/rules/scope-discipline.md`): `grep -c wrapSwipeErr backend/internal/usecase/swipe.go` → 6 (1 declaration + 1 docstring mention + 4 call sites, matching the 4 in-closure sites the issue named); `grep -c performanceSnapshot` → 3 (declaration + docstring + 1 call site). No zero-caller helpers were introduced.

Design choice worth a reviewer's eye: the degraded snapshot is `service.ComputeMetrics(nil, now)` rather than a hand-built `service.PerformanceMetrics{}`. `ComputeMetrics` on an empty window returns the neutral placeholder `{SuccessRate: 0.5, AvgDifficulty: 0.5, RetentionRate: 0.5}` with `ReviewCount: 0`, and `ModeFromMetrics` short-circuits any `ReviewCount < MinReviewsForModeCalculation` to `ModeDefault`. Reusing the calculator keeps the degraded path bound to the same definition of "no data" the cold-start path already emits, instead of inventing a second zero shape.

Logging uses `logging.LogWarn` (which attaches `eris.ToJSON(err, true)` under `error_chain`) rather than a bare `u.logger.WarnContext`. That is the documented helper in `.claude/rules/error-wrapping.md` § Logging, and `logging` is already in the `usecase` component's `mayDependOn` list in `backend/.go-arch-lint.yml`, so no archfile edit was needed — `go tool go-arch-lint check` is green. `internal/usecase` had no prior importer of `internal/logging`; this is the first.

The `wrapSwipeErr` helper is package-level in `usecase` but named for its file, mirroring the existing per-file helper style; it is not applied to any file other than `swipe.go`. The two remaining `eris.Wrap` calls in the closure (`apply rating`, `new swipe record`) were deliberately left alone — they wrap domain-function errors that can never be a context error, so routing them through the helper would add a dead `isContextDone` branch (`docs/backend/library-gotchas/dead-context-check-in-pass-through-helper.md`).

**Scope deviations.** One addition beyond the issue's Scope list: a two-line paragraph in `docs/backend-graphql.md` § "Adaptive learning performance mode". That section is the only prose describing the post-commit read ("This post-commit read keeps transactional rollback behavior simple…") and became incomplete about the mutation's error contract once the degrade landed — the adjacent-inconsistency clause of `.claude/rules/scope-discipline.md`. The file is 553 lines, still under the 600-line soft cap, so no split was triggered. Nothing in the issue's Scope was left undone; nothing from Out of scope was touched (no frontend file, no same-learn-day idempotency guard).

Closes #1012
