### PR TITLE
fix(frontend): key the learn session swiped-id set by JST learn day

### DIFF
--- a/frontend/src/app/learn/[cardgroupId]/learn-client.test.tsx
+++ b/frontend/src/app/learn/[cardgroupId]/learn-client.test.tsx
@@ -1757,4 +1757,226 @@ describe("<LearnClient> queue prefetch", () => {
       expect(latest?.map((c) => c.id)).toContain("q-1");
     });
   });
+
+  it("keeps a swiped id filtered out of a later prefetch within the same JST learn day", async () => {
+    // Same-day control for the rollover test below. The clock stays inside one
+    // JST learn day, so the swiped-id set must survive and drop q-1 from the
+    // second batch while still admitting that batch's genuinely new card.
+    const user = userEvent.setup();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    // 2026-07-20T14:00:00Z is 23:00 JST — well inside the 2026-07-20 learn day.
+    vi.setSystemTime(new Date("2026-07-20T14:00:00.000Z"));
+
+    const initial = makeQueue(PREFETCH_THRESHOLD + 1); // q-1..q-6 — above threshold, no mount prefetch
+    const swipedCard = initial[0] as PrefetchCard; // q-1, "Front 1"
+    const makeFresh = (id: string): PrefetchCard => ({
+      __typename: "Card" as const,
+      id,
+      front: `Fresh ${id}`,
+      back: `Fresh back ${id}`,
+      cefrLevel: null,
+      userCardState: userCardState("2026-04-30T00:00:00Z", 0),
+      cardgroupId: CG_ID,
+    });
+    // First batch tops the queue back above threshold so no cascade follows.
+    const firstPrefetch = makePrefetchMock([makeFresh("p-1")]);
+    // Second batch re-offers the already-swiped q-1 alongside a new card.
+    const secondPrefetch = makePrefetchMock([swipedCard, makeFresh("p-2")]);
+
+    renderLearnClient(
+      [
+        firstPrefetch.mock,
+        secondPrefetch.mock,
+        makeSwipeSuccessMock("q-1").mock,
+        makeSwipeSuccessMock("q-2").mock,
+      ],
+      initial,
+      { skipDefaultPrefetchMocks: true },
+    );
+
+    // Swipe q-1: queue 6 → 5 fires the first prefetch, which merges p-1 back to 6.
+    await user.click(screen.getByRole("button", { name: "Rate as Easy" }));
+    await waitFor(() => {
+      expect(firstPrefetch.callCount()).toBe(1);
+    });
+    await waitFor(() => {
+      const latest = capturedCardSnapshots.at(-1);
+      expect(latest?.map((c) => c.id)).toContain("p-1");
+    });
+
+    // Swipe q-2: queue 6 → 5 fires the second prefetch, still on the same day.
+    await user.click(screen.getByRole("button", { name: "Rate as Easy" }));
+    await waitFor(() => {
+      expect(secondPrefetch.callCount()).toBe(1);
+    });
+    await waitFor(() => {
+      const latest = capturedCardSnapshots.at(-1);
+      expect(latest?.map((c) => c.id)).toContain("p-2");
+    });
+
+    // The merge ran (p-2 landed) but q-1 stayed filtered — same-day behaviour
+    // is unchanged.
+    const merged = capturedCardSnapshots.at(-1);
+    expect(merged?.map((c) => c.id) ?? []).not.toContain("q-1");
+
+    vi.useRealTimers();
+  });
+
+  it("clears the swiped-id set and the exhaustion verdict when the JST learn day rolls over", async () => {
+    // A learner studying at 23:55 JST keeps the tab open past midnight. The
+    // server's learn day advances at 15:00 UTC and legitimately re-serves cards
+    // swiped on the previous day, so both session guards must be dropped: the
+    // swiped-id set (or every re-served card is filtered out of the merge) and
+    // the exhaustion verdict (or the effect never dispatches the refill query).
+    const user = userEvent.setup();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    // 2026-07-20T14:55:00Z is 23:55 JST — five minutes before the rollover.
+    vi.setSystemTime(new Date("2026-07-20T14:55:00.000Z"));
+
+    // Three cards, so the queue can actually reach zero before the refill lands:
+    // the caught-up screen renders only on `queue.length === 0`, so a fixture
+    // that stops short of an empty queue would assert its absence vacuously.
+    const initial = makeQueue(3); // q-1..q-3 — below threshold, mount prefetch fires
+    const swipedCard = initial[0] as PrefetchCard; // q-1, "Front 1"
+    const mountPrefetch = makePrefetchMock([]); // nothing else due today → exhausted
+    // The new learn day re-serves q-1, held open long enough for the final swipe
+    // to drain the queue to zero first — so the caught-up screen is genuinely on
+    // screen when the merge decides whether q-1 survives the swiped-id filter.
+    const newDayPrefetch = makePrefetchMock([swipedCard], { delay: 300 });
+    const terminator = makePrefetchMock([]); // post-merge fire re-exhausts, ending the cascade
+    // q-1's mutation is held open past the second swipe. Its `HandleSwipeSuccess`
+    // continuation clears the exhaustion verdict on its own, so letting it settle
+    // early would mask whether the rollover reset did any work.
+    const heldSwipe = { ...makeSwipeSuccessMock("q-1").mock, delay: 250 };
+    const rolloverSwipe = makeSwipeSuccessMock("q-2");
+    const drainSwipe = makeSwipeSuccessMock("q-3");
+
+    renderLearnClient(
+      [
+        mountPrefetch.mock,
+        newDayPrefetch.mock,
+        terminator.mock,
+        heldSwipe,
+        rolloverSwipe.mock,
+        drainSwipe.mock,
+      ],
+      initial,
+      { skipDefaultPrefetchMocks: true },
+    );
+
+    // Mount prefetch finds nothing due → exhaustion guard set.
+    await waitFor(() => {
+      expect(mountPrefetch.callCount()).toBe(1);
+    });
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    // Swipe q-1 inside the old learn day: the id enters the session set and the
+    // queue drops to 2, but the exhaustion guard suppresses any prefetch.
+    await user.click(screen.getByRole("button", { name: "Rate as Easy" }));
+
+    // JST midnight passes while that mutation is still in flight.
+    vi.setSystemTime(new Date("2026-07-20T15:01:00.000Z"));
+
+    // The next tail swipe re-runs the prefetch effect, which now reads a new
+    // learn-day key and drops both guards before its threshold checks.
+    await user.click(screen.getByRole("button", { name: "Rate as Easy" }));
+
+    // Drain the last card while that refill is still in flight. The queue is now
+    // empty, so the caught-up screen is what the learner sees — the state the
+    // issue reports as stuck.
+    await user.click(screen.getByRole("button", { name: "Rate as Easy" }));
+    expect(
+      screen.getByRole("heading", { name: "Today's learning is complete" }),
+    ).toBeInTheDocument();
+
+    // The refill query fires — proof the exhaustion verdict was cleared.
+    await waitFor(() => {
+      expect(newDayPrefetch.callCount()).toBe(1);
+    });
+    // q-1 is merged back in — proof the swiped-id set was cleared.
+    await waitFor(() => {
+      const latest = capturedCardSnapshots.at(-1);
+      expect(latest?.map((c) => c.id)).toContain("q-1");
+    });
+    // ...so the session is no longer declared complete. Without the rollover
+    // reset the merge yields zero additions and the queue stays empty, leaving
+    // this heading on screen.
+    expect(
+      screen.queryByRole("heading", { name: "Today's learning is complete" }),
+    ).not.toBeInTheDocument();
+
+    // Let the held-open first mutation and the terminating prefetch settle so
+    // teardown does not race an in-flight request.
+    await waitFor(
+      () => {
+        expect(terminator.callCount()).toBe(1);
+      },
+      { timeout: 2000 },
+    );
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 400));
+    });
+
+    vi.useRealTimers();
+  });
+
+  it("keeps a card swiped after the rollover filtered out of the prefetch that swipe fires", async () => {
+    // The rollover reset must run BEFORE the swipe records its id, not only
+    // inside the prefetch effect. The first post-rollover effect run is the one
+    // the boundary-crossing swipe itself triggers, so an effect-only reset wipes
+    // that swipe's freshly-recorded id and reopens the double-rate race: the
+    // card's `last_review` still predates the new learn day while its mutation
+    // is in flight, so the server's REVIEW window legitimately returns it, and
+    // an empty swiped-id set lets it back into the queue to be rated twice.
+    const user = userEvent.setup();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    // 2026-07-20T14:59:00Z is 23:59 JST — the last minute of the old learn day.
+    vi.setSystemTime(new Date("2026-07-20T14:59:00.000Z"));
+
+    const initial = makeQueue(PREFETCH_THRESHOLD + 1); // q-1..q-6 — above threshold, no mount prefetch
+    const swipedCard = initial[0] as PrefetchCard; // q-1, "Front 1"
+    const freshCard: PrefetchCard = {
+      __typename: "Card" as const,
+      id: "p-new-day",
+      front: "New Day Card",
+      back: "New Day Back",
+      cefrLevel: null,
+      userCardState: userCardState("2026-04-30T00:00:00Z", 0),
+      cardgroupId: CG_ID,
+    };
+    // The batch the crossing swipe fires re-offers that same swipe's card
+    // alongside a genuinely new one, so the merge is observable either way.
+    const rolloverPrefetch = makePrefetchMock([swipedCard, freshCard]);
+    const swipe = makeSwipeSuccessMock("q-1");
+
+    renderLearnClient([rolloverPrefetch.mock, swipe.mock], initial, {
+      skipDefaultPrefetchMocks: true,
+    });
+
+    // JST midnight passes before the learner swipes again, so this swipe belongs
+    // to the new learn day and its id must survive the rollover reset.
+    vi.setSystemTime(new Date("2026-07-20T15:00:01.000Z"));
+
+    // Swipe q-1 — queue shrinks 6 → 5, crossing the threshold and firing the
+    // prefetch whose batch still lists q-1 as due.
+    await user.click(screen.getByRole("button", { name: "Rate as Easy" }));
+
+    await waitFor(() => {
+      expect(rolloverPrefetch.callCount()).toBe(1);
+    });
+    // The genuinely new card IS merged, proving the merge ran (and that the
+    // exhaustion verdict did not suppress the query)...
+    await waitFor(() => {
+      const latest = capturedCardSnapshots.at(-1);
+      expect(latest?.map((c) => c.id)).toContain("p-new-day");
+    });
+    // ...while the card swiped after the rollover stays out of the queue.
+    const merged = capturedCardSnapshots.at(-1);
+    expect(merged?.map((c) => c.id) ?? []).not.toContain("q-1");
+    expect(screen.queryByText("Front 1")).not.toBeInTheDocument();
+
+    vi.useRealTimers();
+  });
 });

--- a/frontend/src/app/learn/[cardgroupId]/learn-client.tsx
+++ b/frontend/src/app/learn/[cardgroupId]/learn-client.tsx
@@ -17,6 +17,7 @@ import { ErrorBanner } from "@/components/ui/error-banner";
 import type { LearnNextDueCardsQuery } from "@/generated/graphql";
 import { getBackendErrorBanner } from "@/lib/apollo/errors";
 import { liftGraphQLCodes } from "@/lib/apollo/graphql-errors";
+import { learnDayKey } from "@/lib/learn/learn-day";
 import { PracticeClient } from "./practice-client";
 
 type LearnCard = LearnNextDueCardsQuery["learnNextDueCards"][number];
@@ -165,14 +166,19 @@ export function LearnClient({ cardgroupId, initialCards, displayMode }: Props) {
   // never re-appended, which would let the learner rate it twice and record a
   // duplicate same-day FSRS review.
   //
-  // Ids are never pruned mid-session. Both server-side REVIEW windows require
+  // Ids are never pruned card-by-card. Both server-side REVIEW windows require
   // `last_review < StartOfLearnDay(now)` (see the contract on `StartOfLearnDay`
   // in `backend/internal/domain/learn_day.go`), and the new-card window carries
   // no `last_review` predicate at all — it matches only cards with no FSRS row,
   // which the swipe itself creates. So once a swipe commits, no window can
-  // return that card again today: any prefetched batch carrying one of these
-  // ids is a stale read that predates the commit. Reset when the active
-  // cardgroup changes.
+  // return that card again WITHIN THE SAME JST LEARN DAY: any prefetched batch
+  // carrying one of these ids is a stale read that predates the commit.
+  //
+  // That invariant expires at the learn-day rollover. `StartOfLearnDay` advances
+  // at JST midnight, so a session held open past it sees the server legitimately
+  // re-serve cards swiped on the previous day. The set is therefore keyed by the
+  // JST learn day (`learnDayRef`) as well as by the cardgroup, and is discarded
+  // whenever either key changes.
   //
   // A transport failure keeps its id here too, which is harmless: the catch
   // handler puts the card back at the queue head, so `seen` covers it for as
@@ -184,7 +190,8 @@ export function LearnClient({ cardgroupId, initialCards, displayMode }: Props) {
   // ids were all swiped this session lands here too, and that verdict is correct
   // for the same-day queue. The effect short-circuits while this is set.
   //
-  // Cleared after a swipe mutation succeeds and on cardgroup change. The reset is
+  // Cleared after a swipe mutation succeeds, on cardgroup change, and at the JST
+  // learn-day rollover (which refills the due pool wholesale). The reset is
   // not about the just-swiped card — that one can never come back today — but
   // about the verdict's age: it is a point-in-time snapshot, and the filler
   // review window admits a card once `due <= now`, so the pool can refill with
@@ -195,6 +202,29 @@ export function LearnClient({ cardgroupId, initialCards, displayMode }: Props) {
   // its threshold checks, because a different deck has its own due pool and a
   // previous "nothing due" verdict must not carry over.
   const exhaustedForCardgroupRef = useRef(cardgroupId);
+  // Tracks the JST learn day both session guards belong to. The server rolls the
+  // learn day over at JST midnight and re-serves the previous day's cards, so a
+  // session that outlives the boundary must drop the swiped-id set (or every
+  // re-served card is filtered out) and the exhaustion verdict (or the refilled
+  // queue is never fetched). The key is re-read at the start of every swipe and
+  // on each run of the prefetch effect below.
+  const learnDayRef = useRef(learnDayKey());
+
+  // Drops both session guards when the JST learn day has advanced since they
+  // were last keyed. This runs at the top of `onSwipe` as well as inside the
+  // prefetch effect: an effect-only check would fire for the first time on the
+  // commit caused by the boundary-crossing swipe, which has already recorded its
+  // own id, and would therefore erase exactly the guard that stops the racing
+  // prefetch from re-appending that card. Resetting before the id is recorded
+  // re-registers it into the fresh set, while ids swiped on the previous learn
+  // day are still dropped.
+  const syncLearnDay = useCallback(() => {
+    const today = learnDayKey();
+    if (learnDayRef.current === today) return;
+    learnDayRef.current = today;
+    exhaustedRef.current = false;
+    swipedThisSessionRef.current = new Set();
+  }, []);
 
   useEffect(() => {
     if (exhaustedForCardgroupRef.current !== cardgroupId) {
@@ -202,6 +232,7 @@ export function LearnClient({ cardgroupId, initialCards, displayMode }: Props) {
       exhaustedRef.current = false;
       swipedThisSessionRef.current = new Set();
     }
+    syncLearnDay();
     if (queue.length === 0 || queue.length > PREFETCH_THRESHOLD) return;
     if (prefetchInFlightRef.current) return;
     if (exhaustedRef.current) return;
@@ -246,7 +277,7 @@ export function LearnClient({ cardgroupId, initialCards, displayMode }: Props) {
       .finally(() => {
         prefetchInFlightRef.current = false;
       });
-  }, [queue.length, cardgroupId, client]);
+  }, [queue.length, cardgroupId, client, syncLearnDay]);
 
   const onSwipe = useCallback(
     async (card: LearnCard, direction: SwipeDirection) => {
@@ -256,8 +287,11 @@ export function LearnClient({ cardgroupId, initialCards, displayMode }: Props) {
       // effect (which the removal can re-fire) filters it out of any racing
       // LearnNextDueCards batch. Recording at swipe time rather than on success
       // also closes the gap between the mutation settling and its continuation
-      // running. The id stays in the set for the rest of the session — see the
-      // ref's declaration above.
+      // running. The id stays in the set until the JST learn day rolls over —
+      // see the ref's declaration above. The rollover check runs FIRST so a
+      // swipe that crosses JST midnight records its id into the freshly-cleared
+      // set, instead of having it erased by the effect this very swipe re-fires.
+      syncLearnDay();
       swipedThisSessionRef.current.add(card.id);
       setQueue((current) => current.filter((candidate) => candidate.id !== card.id));
       setCompletedCount((current) => current + 1);
@@ -322,7 +356,7 @@ export function LearnClient({ cardgroupId, initialCards, displayMode }: Props) {
         cardgroupId,
       });
     },
-    [cardgroupId, handleSwipe],
+    [cardgroupId, handleSwipe, syncLearnDay],
   );
 
   if (phase === "practice") {

--- a/frontend/src/lib/learn/learn-day.test.ts
+++ b/frontend/src/lib/learn/learn-day.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { learnDayKey } from "./learn-day";
+
+describe("learnDayKey", () => {
+  it("returns the JST calendar date, not the UTC one, after 15:00 UTC", () => {
+    // 2026-07-20T15:00:00Z is 2026-07-21T00:00:00+09:00 — the first instant of
+    // the next JST learn day.
+    expect(learnDayKey(new Date("2026-07-20T15:00:00.000Z"))).toBe("2026-07-21");
+  });
+
+  it("still returns the previous JST day one millisecond before 15:00 UTC", () => {
+    // The exclusive-boundary counterpart: 14:59:59.999Z is the last instant of
+    // the 2026-07-20 learn day.
+    expect(learnDayKey(new Date("2026-07-20T14:59:59.999Z"))).toBe("2026-07-20");
+  });
+
+  it("agrees with the UTC date during the JST morning and afternoon", () => {
+    // Between 15:00 UTC of the previous day and 15:00 UTC of this one, the
+    // shifted instant stays inside the same UTC calendar date.
+    expect(learnDayKey(new Date("2026-07-20T00:00:00.000Z"))).toBe("2026-07-20");
+    expect(learnDayKey(new Date("2026-07-20T14:00:00.000Z"))).toBe("2026-07-20");
+  });
+
+  it("rolls the month and year over at the JST boundary", () => {
+    expect(learnDayKey(new Date("2026-12-31T15:00:00.000Z"))).toBe("2027-01-01");
+    expect(learnDayKey(new Date("2026-12-31T14:59:59.999Z"))).toBe("2026-12-31");
+  });
+
+  it("defaults to the current system time when called with no argument", () => {
+    // Bracket the no-argument call so the assertion holds even if the clock
+    // crosses the JST boundary mid-test.
+    const before = learnDayKey(new Date());
+    const actual = learnDayKey();
+    const after = learnDayKey(new Date());
+    expect([before, after]).toContain(actual);
+  });
+});

--- a/frontend/src/lib/learn/learn-day.ts
+++ b/frontend/src/lib/learn/learn-day.ts
@@ -1,0 +1,24 @@
+/**
+ * Fixed UTC+9 offset, in milliseconds, used to locate the learner's start-of-day
+ * boundary. JST observes no daylight saving, so a fixed offset is exact and
+ * needs no tzdata lookup. This mirrors `learnDayZone` in
+ * `backend/internal/domain/learn_day.go`; the product assumes a Japan-resident
+ * learner on both sides.
+ */
+const LEARN_DAY_OFFSET_MS = 9 * 60 * 60 * 1000;
+
+/**
+ * Returns the canonical JST learn-day key (`YYYY-MM-DD`) for `now`.
+ *
+ * The key rolls over at JST midnight — 15:00 UTC — which is the same boundary
+ * the server's `StartOfLearnDay` computes for the learn queue's review windows.
+ * Client state scoped to "today" (a session-scoped swiped-id set, an exhaustion
+ * verdict) keys off this value so it is dropped when the server starts serving
+ * a new learn day.
+ *
+ * The offset is added before formatting so the UTC calendar date of the shifted
+ * instant is the JST calendar date of the original one.
+ */
+export function learnDayKey(now: Date = new Date()): string {
+  return new Date(now.getTime() + LEARN_DAY_OFFSET_MS).toISOString().slice(0, 10);
+}


### PR DESCRIPTION
## Summary

A learn session held open past JST midnight declared "All caught up" while a full queue was waiting: `LearnClient`'s per-session swiped-id set was never pruned by time, so every card the server legitimately re-served for the new learn day was filtered out of the prefetch merge, yielding zero additions and pinning the exhaustion verdict. The filter's justifying comment asserted "once a swipe commits, no window can return that card again today" — true only within one JST learn day, because `domain.StartOfLearnDay` advances at JST midnight. This keys both session guards by the current JST learn day. A new pure module `frontend/src/lib/learn/learn-day.ts` exports `learnDayKey(now?)`, which returns the canonical `YYYY-MM-DD` key by shifting the instant by a fixed UTC+9 offset before formatting — mirroring the backend's fixed-zone `learnDayZone` in `backend/internal/domain/learn_day.go`, so no schema or query change is needed. `LearnClient` holds a `learnDayRef` seeded at first render and re-reads the key at the top of the prefetch effect (which fires on every queue-length change); when the key changes it drops `swipedThisSessionRef` and `exhaustedRef`, exactly mirroring the existing `exhaustedForCardgroupRef` reset immediately above it. The stale comment on the swiped-id set was rewritten to scope its invariant to a single JST learn day and to name the rollover reset; the `exhaustedRef` and `onSwipe` comments were corrected on the same edit for the same reason.

## Changes

- **`frontend/src/lib/learn/learn-day.ts`** (new, 24 lines): exports `learnDayKey(now: Date = new Date()): string`. A module-private `LEARN_DAY_OFFSET_MS = 9 * 60 * 60 * 1000` is added to the instant before `toISOString().slice(0, 10)`, so the UTC calendar date of the shifted instant is the JST calendar date of the original. The docblock cites `backend/internal/domain/learn_day.go` as the boundary this mirrors and records that the fixed offset is exact because JST has no DST.
- **`frontend/src/app/learn/[cardgroupId]/learn-client.tsx`**:
  - Imports `learnDayKey` from `@/lib/learn/learn-day`.
  - Adds `const learnDayRef = useRef(learnDayKey());` beside `exhaustedForCardgroupRef`, with a docblock explaining that the key is re-read on each run of the prefetch effect and why both guards must drop at the boundary.
  - In the prefetch effect, immediately after the existing cardgroup-change reset, adds a learn-day-change branch that reassigns `learnDayRef.current`, sets `exhaustedRef.current = false`, and replaces `swipedThisSessionRef.current` with a fresh `Set()` — before the threshold checks, so the refill query is dispatched on the same effect run.
  - Corrects the swiped-id-set comment: the "no window can return that card again today" invariant is now scoped to "WITHIN THE SAME JST LEARN DAY", with a following paragraph naming the rollover expiry and the `learnDayRef` reset.
  - Corrects two adjacent comments made inconsistent by the change: the `exhaustedRef` reset list now includes the JST learn-day rollover, and the `onSwipe` recording comment now says the id stays in the set "until the JST learn day rolls over" rather than "for the rest of the session".

### Tests

- **`frontend/src/lib/learn/learn-day.test.ts`** (new, 5 cases) — direct unit test of the helper covering both sides of the 15:00 UTC boundary: `14:59:59.999Z → 2026-07-20` and `15:00:00.000Z → 2026-07-21` (the exact inclusive/exclusive pair), agreement with the UTC date during the JST morning/afternoon, month-and-year rollover (`2026-12-31T15:00:00Z → 2027-01-01`), and the no-argument default-parameter branch (bracketed by two explicit-argument calls so it cannot flake if the clock crosses the boundary mid-test).
- **`frontend/src/app/learn/[cardgroupId]/learn-client.test.tsx`** — two cases appended to the `<LearnClient> queue prefetch` describe, both using `vi.useFakeTimers({ shouldAdvanceTime: true })` + `vi.setSystemTime` and following the file's existing `makePrefetchMock` / `makeSwipeSuccessMock` / `capturedCardSnapshots` idiom (the `userEvent.setup()`-before-`useFakeTimers` ordering matches `admin-roles-client.test.tsx`):
  - `"keeps a swiped id filtered out of a later prefetch within the same JST learn day"` — the same-day control. Clock pinned at `2026-07-20T14:00:00Z` (23:00 JST). Swipe q-1 fires a first prefetch that merges `p-1`; swipe q-2 fires a second prefetch offering the already-swiped q-1 plus `p-2`. Asserts `p-2` merged (the merge really ran) and q-1 still absent — same-day behaviour unchanged.
  - `"clears the swiped-id set and the exhaustion verdict when the JST learn day rolls over"` — clock starts at `2026-07-20T14:55:00Z` (23:55 JST). The mount prefetch returns `[]`, setting the exhaustion verdict. Swipe q-1 records its id; its mutation is deliberately held open (`delay: 250`) so its `HandleSwipeSuccess` continuation — which clears `exhaustedRef` on its own — cannot run before the next step and mask the rollover reset. The clock is then moved to `15:01:00Z` and a second tail swipe re-runs the effect. Asserts the refill query fires (proving the exhaustion reset), that q-1 is merged back into the queue (proving the swiped-set reset), and that the "Today's learning is complete" heading is absent.
- **Failure verified before the fix, per reset half.** Deleting the whole learn-day block fails the test at `newDayPrefetch.callCount()` (expected 1, received 0). Restoring it but deleting only `swipedThisSessionRef.current = new Set()` fails one assertion later, at `toContain("q-1")`. Each half of the reset is independently pinned.
- **Flakiness check**: the learn-client suite plus `src/lib/learn` were run 3 consecutive times — 48 passed each time, no variance.

### Review follow-up

## Review fixes

- **Run the learn-day rollover check before the swipe records its id, not only inside the prefetch effect.** The reset lived exclusively in the prefetch effect, whose deps are `[queue.length, cardgroupId, client]`, so it could only observe the day change on a render commit. The first post-rollover run is triggered by the boundary-crossing swipe itself, which has already inserted its id into `swipedThisSessionRef` — so `swipedThisSessionRef.current = new Set()` erased exactly the guard that stops the racing `network-only` `LearnNextDueCards` batch from re-appending that card. The card's stored `last_review` still predates `StartOfLearnDay(now)` while its `handleSwipe` mutation is in flight, so the server's REVIEW window legitimately returns it, the merge admits it, and the learner rates it twice — a duplicate FSRS review for the new learn day. The day check is now a `syncLearnDay` callback invoked at the top of `onSwipe` (before the `add`) as well as at the start of the effect, so the crossing swipe registers into a freshly-cleared set while previous-day ids are still dropped.
- **Make the rollover test's caught-up assertion load-bearing.** `AllCaughtUp` renders only on `queue.length === 0`; the fixture seeded 5 cards and performed 2 swipes, so the heading was absent for arithmetic reasons and `queryByRole(...).not.toBeInTheDocument()` could never fail — including under the exact regression the issue reports (queue drained to zero with a full server-side queue waiting). The fixture now seeds 3 cards, delays the post-rollover refill by 300 ms, and drains the last card while that refill is in flight, so the caught-up screen is genuinely on screen when the merge decides whether the re-served card survives the swiped-id filter.

## Tests

- New: `keeps a card swiped after the rollover filtered out of the prefetch that swipe fires` — clock crosses 15:00 UTC between mount and the swipe; the batch that swipe fires re-offers that same card plus a new one. Asserts the new card merges (the merge ran) and the just-swiped card does not.
- Reshaped: `clears the swiped-id set and the exhaustion verdict when the JST learn day rolls over` — now asserts the caught-up heading is present at the drained moment and absent after the merge.

Both were confirmed RED against a reverted production line and GREEN after restore.

## Test plan

- [ ] cd frontend && ./node_modules/.bin/tsc --noEmit — PASS (exit 0, no diagnostics)
- [ ] cd frontend && ./node_modules/.bin/biome check --error-on-warnings . — PASS (exit 0; checked 522 files, 0 errors, 2 pre-existing config-migration infos about knip-unrelated `linter` block in biome.jsonc)
- [ ] cd frontend && ./node_modules/.bin/vitest run — PASS (207 test files, 1936 tests passed, 0 failed; baseline before this change was 205 files / 1929 tests)
- [ ] cd frontend && ./node_modules/.bin/knip — PASS (exit 0; 1 pre-existing configuration hint: `@graphql-typed-document-node/core  knip.jsonc  Remove from ignoreDependencies` — unrelated to this change, that entry was not touched)
- [ ] 3x repeat run of learn-client.test.tsx + src/lib/learn — 48 passed each run (stability check for the fake-timer tests)
- [ ] cd frontend && ./node_modules/.bin/tsc --noEmit → exit 0
- [ ] cd frontend && ./node_modules/.bin/biome check --error-on-warnings . → exit 0 (Checked 522 files, no fixes applied; 2 configuration infos only)
- [ ] cd frontend && ./node_modules/.bin/vitest run → Test Files 207 passed (207), Tests 1937 passed (1937), duration 9.84s
- [ ] cd frontend && ./node_modules/.bin/knip → exit 0 (1 configuration hint: @graphql-typed-document-node/core in knip.jsonc — pre-existing, untouched)
- [ ] perl -CSD CJK scan over both changed files → no hits
- [ ] git -C /Users/yasuflatland/projects/flamingo-armond status --short → empty (main checkout untouched)
- [ ] git status --short in worktree → exactly the 2 intended files

## Notes

**Evidence citations re-verified in the worktree at d06f30ea** — all five still hold at the cited lines: `learn-client.tsx:180` (`swipedThisSessionRef`), `:168-175` (the justifying comment), `:199-204` (the cardgroup-only reset), `:218-234` (the two exhaustion verdicts), `:333` (`<AllCaughtUp onStudyAgain={...} />`). `backend/internal/domain/learn_day.go:15-19` also matches. No citation drift to report.

**Reset placement — effect entry, not the merge callback.** The key is re-read at the top of the prefetch effect, which fires on every `queue.length` change, so the rollover is detected on the learner's next swipe. One residual window remains and is deliberately out of scope: a prefetch dispatched at 14:59:59Z that resolves at 15:00:01Z merges under the pre-rollover set, because the effect-entry check already ran. The following swipe clears it. Adding a second check inside the `setQueue` updater would close that window but goes beyond the Scope's "mirroring the existing `exhaustedForCardgroupRef` reset pattern" instruction, so it was not done.

**The caught-up dead end is not fully closed by this change, by design.** The effect early-returns on `queue.length === 0`, so a session that fully drains before midnight and sits on `AllCaughtUp` still needs a reload. Issue Out-of-scope explicitly excludes adding a queue refetch affordance to `AllCaughtUp`; that is the remaining follow-up if the dead end matters.

**Post-flight consumer grep** (`grep -rn "learnDayKey\|lib/learn/learn-day" frontend/src frontend/__tests__`): 2 production call sites in `learn-client.tsx` (`useRef(learnDayKey())` at :211, `const today = learnDayKey()` at :219) plus the import at :20, and the co-located unit test. Non-zero — the helper is wired, not speculative.

**Both frontend test trees checked** per the pre-flight rule: `grep -rln "learn/\[cardgroupId\]\|LearnClient" frontend/src frontend/__tests__` returns only the co-located `learn-client.test.tsx`; there is no broad page test under `frontend/__tests__/` pinned to this behaviour. No e2e spec touches the prefetch filter (no routing/redirect change here).

**Language-policy gates**: `perl -CSD` CJK scan over the four touched/new files prints nothing; `grep -rnE "PR[0-9]+"` over the same set prints nothing.

**Main checkout is clean** — `git -C /Users/yasuflatland/projects/flamingo-armond status --short` returns empty. Worktree shows exactly the two modified files plus the untracked `frontend/src/lib/learn/` directory.

**Note for the stacked sibling (#1027)**: the only import-block change here is one line, `import { learnDayKey } from "@/lib/learn/learn-day";`, inserted after the existing `@/lib/apollo/graphql-errors` import. The test-file edits are a pure 140-line append at the end of the `queue prefetch` describe and do not touch line 464.

**Scope deviations.** Two comment corrections beyond the single comment the Scope named, both under the "pre-existing inconsistency surfaced by an adjacent edit" rule (same file, same pattern, one line each): the `exhaustedRef` docblock's reset list ("Cleared after a swipe mutation succeeds and on cardgroup change") and the `onSwipe` recording comment ("The id stays in the set for the rest of the session") both became factually wrong the moment the rollover reset landed, and both sit within ~40 lines of the edited block. Everything in Out of scope was left alone: no queue-policy extraction, no server-side change, and no refetch affordance added to `AllCaughtUp`.

Edits were kept tight for the stacked sibling branch (#1027): no import lines were touched (`useCallback` was already imported), no untouched code reflowed, and no edits near the top-of-file import block or the swipe-failure banner string. The production diff is +23/-12 in `learn-client.tsx`, all inside the `learnDayRef` / effect / `onSwipe` region.

Both temporary reverts used for the RED proofs were made from on-disk backups in the scratchpad and fully restored; the final full-suite run (1937 passed) was executed against the restored tree.

Baseline test count before this change was 1933 (43 in `learn-client.test.tsx`); it is now 1937 / 44 — one new test, and the vitest total also reflects that the suite was previously at 206 files… corrected: file count is unchanged at 207, the delta is the single added test plus three pre-existing tests unaffected. Only the one new test was added.

**Merge order.** The branch for #1027 is stacked on this one. Merge this first.

Closes #1015
