### PR TITLE
fix(backend): re-fetch master cardgroup after publish/unpublish so updatedAt is fresh

### DIFF
--- a/backend/internal/repository/master_cardgroup.go
+++ b/backend/internal/repository/master_cardgroup.go
@@ -137,9 +137,17 @@ func NewMasterCardgroupRepository(db *gorm.DB) MasterCardgroupRepository {
 
 // FindByID returns the master cardgroup with the given id, or ErrNotFound.
 func (r *masterCardgroupRepo) FindByID(ctx context.Context, id string) (*domain.MasterCardgroup, error) {
+	return findMasterCardgroupByID(r.db.WithContext(ctx), id)
+}
+
+// findMasterCardgroupByID reads one master cardgroup on the supplied session,
+// returning ErrNotFound when no row matches. Taking the session as a parameter
+// lets a transaction-scoped caller re-read the row it just wrote without
+// leaving its transaction (an outer-connection read would not see the
+// uncommitted write).
+func findMasterCardgroupByID(db *gorm.DB, id string) (*domain.MasterCardgroup, error) {
 	var row gormMasterCardgroup
-	err := r.db.WithContext(ctx).Where("id = ?", id).Take(&row).Error
-	if err != nil {
+	if err := db.Where("id = ?", id).Take(&row).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, ErrNotFound
 		}
@@ -332,11 +340,20 @@ func (r *masterCardgroupRepo) applyStatusTransition(
 		if err := transition(m); err != nil {
 			return eris.Wrap(err, "repository: master cardgroup: "+op+": apply")
 		}
-		if err := tx.Model(&gormMasterCardgroup{}).Where("id = ?", id).
-			Updates(map[string]any{"status": string(m.Status), "version": m.Version}).Error; err != nil {
-			return eris.Wrap(err, "repository: master cardgroup: "+op+": save")
+		res := tx.Model(&gormMasterCardgroup{}).Where("id = ?", id).
+			Updates(map[string]any{"status": string(m.Status), "version": m.Version})
+		if res.Error != nil {
+			return eris.Wrap(res.Error, "repository: master cardgroup: "+op+": save")
 		}
-		out = m
+		// Re-fetch inside the same transaction so callers see the
+		// trigger-refreshed updated_at rather than the pre-write aggregate.
+		fresh, err := refetchAfterUpdate(res.RowsAffected, ErrNotFound,
+			func() (*domain.MasterCardgroup, error) { return findMasterCardgroupByID(tx, id) },
+			"repository: master cardgroup: "+op+": refetch")
+		if err != nil {
+			return err
+		}
+		out = fresh
 		return nil
 	})
 	if err != nil {

--- a/backend/internal/repository/master_cardgroup_admin_test.go
+++ b/backend/internal/repository/master_cardgroup_admin_test.go
@@ -6,6 +6,7 @@ package repository_test
 //   - FindPageAnyStatus (no status filter, otherwise identical to FindPublishedPage)
 //   - Publish (sets status=published, bumps version)
 //   - Unpublish (sets status=draft, version unchanged)
+//   - Publish/Unpublish updated_at freshness (trigger-refreshed re-fetch)
 //
 // All tests run against the shared testcontainers Postgres provisioned by
 // TestMain in user_test.go. Shared helpers (newMasterCardgroupMinimal,
@@ -17,6 +18,7 @@ import (
 	"errors"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
@@ -319,6 +321,61 @@ func TestMasterCardgroupRepository_Unpublish_SetsDraftVersionUnchanged(t *testin
 	require.NoError(t, err)
 	require.Equal(t, domain.MasterStatusDraft, refetched.Status)
 	require.Equal(t, 3, refetched.Version)
+}
+
+// TestMasterCardgroupRepository_PublishUnpublish_RefreshesUpdatedAt pins the
+// re-fetch tail of the status-transition path. A BEFORE UPDATE trigger on
+// master_cardgroups rewrites updated_at to now(), so the aggregate loaded before
+// the write carries a stale timestamp; returning it would make the mutation
+// response — and the admin list cache reading from it — disagree with the
+// database until a manual refresh. Both transitions must therefore return the
+// post-write row.
+func TestMasterCardgroupRepository_PublishUnpublish_RefreshesUpdatedAt(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	repo := repository.NewMasterCardgroupRepository(testDB.GORM)
+
+	// Seed the row with a deliberately old updated_at so the baseline comparison
+	// cannot be confused by clock skew between the test host and the database.
+	m := newMasterCardgroupMinimal("Refresh UpdatedAt " + uuid.NewString())
+	m.Version = 1
+	m.Status = domain.MasterStatusDraft
+	m.CreatedAt = time.Now().UTC().Add(-2 * time.Hour)
+	m.UpdatedAt = m.CreatedAt
+	require.NoError(t, repo.Create(ctx, m))
+
+	before, err := repo.FindByID(ctx, m.ID)
+	require.NoError(t, err)
+
+	published, err := repo.Publish(ctx, m.ID)
+	require.NoError(t, err)
+	require.True(t, published.UpdatedAt.After(before.UpdatedAt),
+		"Publish must return the trigger-refreshed updated_at (before=%v, got=%v)",
+		before.UpdatedAt, published.UpdatedAt)
+
+	afterPublish, err := repo.FindByID(ctx, m.ID)
+	require.NoError(t, err)
+	require.True(t, published.UpdatedAt.Equal(afterPublish.UpdatedAt),
+		"Publish return value must match the persisted updated_at (got=%v, db=%v)",
+		published.UpdatedAt, afterPublish.UpdatedAt)
+
+	unpublished, err := repo.Unpublish(ctx, m.ID)
+	require.NoError(t, err)
+	require.True(t, unpublished.UpdatedAt.After(published.UpdatedAt),
+		"Unpublish must return the trigger-refreshed updated_at (publish=%v, got=%v)",
+		published.UpdatedAt, unpublished.UpdatedAt)
+
+	afterUnpublish, err := repo.FindByID(ctx, m.ID)
+	require.NoError(t, err)
+	require.True(t, unpublished.UpdatedAt.Equal(afterUnpublish.UpdatedAt),
+		"Unpublish return value must match the persisted updated_at (got=%v, db=%v)",
+		unpublished.UpdatedAt, afterUnpublish.UpdatedAt)
+
+	// The re-fetch must not disturb the transition outcomes themselves.
+	require.Equal(t, domain.MasterStatusPublished, published.Status)
+	require.Equal(t, 2, published.Version, "Publish bumps version 1 -> 2")
+	require.Equal(t, domain.MasterStatusDraft, unpublished.Status)
+	require.Equal(t, 2, unpublished.Version, "Unpublish leaves the version unchanged")
 }
 
 func TestMasterCardgroupRepository_Unpublish_NotFound(t *testing.T) {


### PR DESCRIPTION
## Summary

Publishing or unpublishing a master cardgroup persisted the status change but returned the in-memory aggregate loaded *before* the write. A `BEFORE UPDATE` trigger (`trg_master_cardgroups_set_updated_at`) rewrites `updated_at` to `now()` on every write, so the mutation response — and the admin list cache that reads from it — carried the pre-publish timestamp until a manual refresh. `applyStatusTransition` now re-fetches the row after the status write, reusing the existing `refetchAfterUpdate` helper exactly as the sibling `Update` method at `master_cardgroup.go:243` does, and assigns the re-fetched aggregate to `out` instead of the stale `m`. The re-fetch must run on the transaction handle, not the outer connection, so `FindByID`'s body was extracted into a package-private `findMasterCardgroupByID(db *gorm.DB, id string)` that both `FindByID` and the transaction-scoped caller share; the query shape is unchanged and `FindByID` now delegates to it. Nothing else about the transition changed: the row is still loaded `FOR UPDATE`, the domain aggregate still owns the publish/unpublish state machine, and `ErrNotFound` still originates from the pre-write locked `Take`. No resolver or frontend change is needed — the corrected aggregate flows through `toMasterCardgroupModelFromParts` unchanged.

## Changes

- `backend/internal/repository/master_cardgroup.go`
  - Extracted `FindByID`'s query body into package-private `findMasterCardgroupByID(db *gorm.DB, id string) (*domain.MasterCardgroup, error)`, which takes the GORM session as a parameter so a transaction-scoped caller can re-read its own uncommitted write. `FindByID` now delegates via `findMasterCardgroupByID(r.db.WithContext(ctx), id)`; the `WHERE id = ?` / `Take` / `ErrNotFound` / wrap-prefix behaviour is byte-identical.
  - In `applyStatusTransition`, captured the `Updates(...)` result in `res` (previously only `.Error` was inspected) and wrapped `res.Error` with the same `"repository: master cardgroup: "+op+": save"` prefix.
  - After the write, added a re-fetch through the shared `refetchAfterUpdate(res.RowsAffected, ErrNotFound, …, "repository: master cardgroup: "+op+": refetch")` helper, with the refetch closure bound to `tx` so the read stays inside the transaction. `out` is now the re-fetched aggregate, not the pre-write `m`.
  - Net production diff: +22 / −5 lines.
- `backend/internal/repository/master_cardgroup_admin_test.go`
  - Added `time` to the import block and one line to the file-header test inventory comment.

### Tests

- Added `TestMasterCardgroupRepository_PublishUnpublish_RefreshesUpdatedAt` (Docker-gated integration test in `backend/internal/repository/master_cardgroup_admin_test.go`, alongside the existing Publish/Unpublish tests). It:
  - Seeds a draft at version 1 with `CreatedAt`/`UpdatedAt` set two hours in the past, so the baseline comparison cannot be confused by clock skew between the test host and the Postgres container.
  - Asserts `Publish(...).UpdatedAt` is strictly after the pre-publish `FindByID` value, and that it `.Equal`s the value a fresh `FindByID` reads back (the direct pin on "response matches DB").
  - Asserts `Unpublish(...).UpdatedAt` is strictly after the publish timestamp, and likewise equals a fresh `FindByID` read.
  - Re-asserts the transition outcomes the re-fetch must not disturb: `published.Status == published` / `Version == 2`, `unpublished.Status == draft` / `Version == 2` (version unchanged on unpublish).
- Defect reproduction was proven, not assumed: with the production line temporarily reverted to `out = m`, the new test fails with `Publish must return the trigger-refreshed updated_at (before=2026-07-20 07:47:57.716018 +0900 JST, got=2026-07-20 07:47:57.716018 +0900 JST)`. Restoring `out = fresh` makes it pass.
- No existing test was modified. `TestMasterCardgroupRepository_Publish_NotFound` and `TestMasterCardgroupRepository_Unpublish_NotFound` still pass unchanged, confirming the nonexistent-id path is unaffected (`ErrNotFound` comes from the pre-write `FOR UPDATE` `Take`, which the change does not touch).

## Test plan

- [ ] cd backend && go build ./... — PASS (0 errors)
- [ ] cd backend && go vet ./... — PASS (no issues found)
- [ ] cd backend && go tool go-arch-lint check --project-path . — PASS ("OK - No warnings found")
- [ ] cd backend && go test ./internal/... ./graph/... — PASS (22 packages: 19 ok + 3 with no test files; 0 FAIL)
- [ ] cd backend && go test ./... — PASS (26 packages reported, 0 FAIL lines)
- [ ] cd backend && go test ./internal/repository/ -v — PASS (294 --- PASS, 0 --- FAIL) with Docker running, so the Docker-gated integration tests really executed
- [ ] cd backend && go test ./internal/repository/ -run 'TestMasterCardgroupRepository_(PublishUnpublish_RefreshesUpdatedAt|Publish_|Unpublish_)' -v — PASS (6/6): Publish_SetsPublishedAndBumpsVersion, Publish_NotFound, Publish_ConcurrentBumpsVersionExactlyOnce, Unpublish_SetsDraftVersionUnchanged, Unpublish_NotFound, PublishUnpublish_RefreshesUpdatedAt
- [ ] Negative control (fix temporarily reverted to `out = m`) — FAIL as expected on TestMasterCardgroupRepository_PublishUnpublish_RefreshesUpdatedAt; fix restored and re-run green

## Notes

Machine-verified evidence re-checked in this worktree at base commit d06f30ea; every citation in the issue still holds, though two line numbers have drifted:

- `master_cardgroup.go:320-326` (FOR UPDATE load) and `:334-337` / `:338` / `:344` (write, `out = m`, return) — CONFIRMED, matched the pre-change file exactly.
- `master_cardgroup.go:234-236` (`Update`'s `// Re-fetch so callers see the trigger-refreshed updated_at.` + `refetchAfterUpdate`) — the comment and call are present but at **:234 / :235-236 in the pre-change file only if counted from the comment**; in the current file they sit at :242-244. Reported as a drift, not an error.
- `update.go:15` (`refetchAfterUpdate` declaration) — CONFIRMED, exact line.
- `20260614000000_add_master_tables.up.sql:34-43` (`set_master_cardgroups_updated_at` setting `NEW.updated_at := now()`) and `:107-112` (`CREATE OR REPLACE TRIGGER trg_master_cardgroups_set_updated_at BEFORE UPDATE`) — CONFIRMED. The issue cited `:109-112` for the trigger; the statement actually spans `:107-112` (the `CREATE OR REPLACE TRIGGER` line is 107). Minor drift.
- `graph/resolver/master_catalog.resolvers.go:84` and `:95` (both resolvers passing the aggregate to `toMasterCardgroupModelFromParts`) — CONFIRMED.

Post-flight greps:

- `grep -rn 'refetchAfterUpdate' backend/internal/repository/*.go | grep -v _test.go` → 7 production call sites (card.go:243, cardgroup.go:382, master_card.go:366, master_cardgroup.go:243, master_cardgroup.go:350 (new), role.go:170, user.go:169) plus the declaration in update.go:15. No speculative helper introduced; `findMasterCardgroupByID` has exactly 2 callers (`FindByID` and the transaction closure), so the zero-caller deletion rule does not fire.
- All new text is ASCII English; no PR-number or "this PR" references in committed text.

Worktree hygiene: `git status --short` in the worktree lists exactly the two intended files; `git status --short` in the main checkout `/Users/yasuflatland/projects/flamingo-armond` is empty. No git write operations were performed.

For the reviewer: the `res.RowsAffected == 0` branch of `refetchAfterUpdate` is structurally unreachable here because the row is already held under `FOR UPDATE` when the write runs — it is retained deliberately so the transition path uses the same shared tail as every other aggregate `Update`, rather than open-coding a bare re-read.

**Scope deviations.** One item beyond the literal Scope bullet, kept minimal and mechanically necessary: the issue says to reuse `refetchAfterUpdate` "as `Update` does", but `Update`'s refetch closure calls `r.FindByID(ctx, id)`, which runs on the outer connection (`r.db`). Inside `applyStatusTransition` that read would not see the uncommitted write and would return the pre-transition row — the opposite of the fix. Extracting `FindByID`'s body into a session-parameterized `findMasterCardgroupByID(db *gorm.DB, id string)` (which `FindByID` then delegates to) was therefore required, not optional. This matches the established `.claude/rules/go-library-gotchas.md` guidance that a transactional read-modify-write must use the `tx` handle, and the "Tx and non-Tx repository methods share a private helper to avoid drift" pattern already used elsewhere in this package. Nothing in the Out-of-scope list was touched: no other outcome field was changed, `Update` is untouched, and no resolver or frontend file was modified.

Closes #1017
