### PR TITLE
fix(backend): stop reporting a committed merge as master-cardgroup-not-found

### DIFF
--- a/backend/internal/usecase/master_catalog.go
+++ b/backend/internal/usecase/master_catalog.go
@@ -741,9 +741,12 @@ func (u *masterCatalogUsecase) MergeMaster(ctx context.Context, masterID, cardgr
 		if errors.Is(err, repository.ErrNotFound) {
 			// The master was unpublished between the FindPublishedByID gate and the
 			// merge tx's own published-scoped re-read (TOCTOU). Collapse into the same
-			// non-disclosure not-found outcome as a pre-gate unknown/draft master. The
-			// destination ownership gate never yields ErrNotFound (it maps a missing
-			// cardgroup to a ucerr.ValidationError), so this branch is master-scoped.
+			// non-disclosure not-found outcome as a pre-gate unknown/draft master. That
+			// in-tx re-read is the only ErrNotFound producer this branch can see: the
+			// destination ownership gate maps a missing cardgroup to a
+			// ucerr.ValidationError, and the post-commit destination read-back translates
+			// its ErrNotFound into a non-sentinel internal error so a destination deleted
+			// mid-merge is never reported as a missing master.
 			return MergeMasterOutcome{NotFound: true}, nil
 		}
 		// Wrap unconditionally, exactly like ImportMaster wraps CopyMasterToUser.

--- a/backend/internal/usecase/master_catalog_test.go
+++ b/backend/internal/usecase/master_catalog_test.go
@@ -1220,6 +1220,47 @@ func TestMasterCatalogUsecase_MergeMaster_MasterUnpublishedMidFlight_ReturnsNotF
 	}
 }
 
+// TestMasterCatalogUsecase_MergeMaster_DestVanishedAfterCommit_NotNotFoundOutcome
+// wires the real master-deck usecase so the post-commit destination read-back is
+// exercised end to end. The merge commits, then the destination cardgroup is
+// deleted concurrently and FindByID yields repository.ErrNotFound. MergeMaster
+// must surface an internal-class error rather than MergeMasterOutcome{NotFound:true},
+// which would tell the learner the catalog deck does not exist and hide both the
+// committed merge and the deleted destination.
+func TestMasterCatalogUsecase_MergeMaster_DestVanishedAfterCommit_NotNotFoundOutcome(t *testing.T) {
+	t.Parallel()
+	const ownerID = "u1"
+	const destID = "22222222-2222-7222-8222-222222222222"
+	const masterID = "master-id"
+
+	repo := &mockMasterCatalogRepository{
+		findPublishedByIDFn: func(id string) (*domain.MasterCardgroup, error) {
+			return &domain.MasterCardgroup{ID: id, Name: domain.CardgroupName("Master"), Status: domain.MasterStatusPublished}, nil
+		},
+	}
+	deck := NewMasterDeckUsecaseWithTx(
+		&fakeMasterCGRepo{byID: map[string]*domain.MasterCardgroup{masterID: masterCG(masterID, "Master")}},
+		&fakeMasterCardRepo{byMaster: map[string][]*domain.MasterCard{
+			masterID: {masterCard("mc-1", masterID, "alpha", "first", 0)},
+		}},
+		&fakeUserCardRepo{},
+		&fakeUserCG{
+			byID:              map[string]*domain.Cardgroup{destID: mustCardgroup(t, destID, ownerID, "My Deck")},
+			findByIDErr:       repository.ErrNotFound,
+			findByIDErrOnCall: 2, // call 1 = ownership gate (succeeds), call 2 = post-commit read (destination deleted)
+		},
+		stubTxRunner,
+		newTestLogger(),
+	)
+	uc := NewMasterCatalogUsecase(repo, deck, newTestAdminGate(true), newTestLogger())
+
+	out, err := uc.MergeMaster(authedCtx(ownerID), masterID, destID)
+	if out.NotFound {
+		t.Fatal("a vanished destination must not be reported as a missing master")
+	}
+	assertInternalChain(t, err, "usecase: master catalog: merge: merge master into cardgroup")
+}
+
 func TestMasterCatalogUsecase_MergeMaster_VerifyPublished_ContextCancelled_PassesThrough(t *testing.T) {
 	// context.Canceled from the published-check must propagate unwrapped so its
 	// identity survives errors.Is at the resolver boundary (FromUsecaseError →

--- a/backend/internal/usecase/master_deck.go
+++ b/backend/internal/usecase/master_deck.go
@@ -2,6 +2,7 @@ package usecase
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"time"
 
@@ -403,6 +404,16 @@ func (u *masterDeckUsecase) MergeMasterIntoCardgroup(
 	if err != nil {
 		if isContextDone(err) {
 			return nil, err
+		}
+		if errors.Is(err, repository.ErrNotFound) {
+			// The merge already committed; no FOR UPDATE is held on the destination row
+			// (the card upsert takes only an FK FOR KEY SHARE, released at commit), so a
+			// concurrent delete of the destination cardgroup can land here. Translate the
+			// sentinel into a plain internal error: letting repository.ErrNotFound travel
+			// up would make MergeMaster's master-scoped not-found branch report the
+			// *catalog* deck as missing, hiding both the committed merge and the deleted
+			// destination.
+			return nil, eris.New("usecase: master deck: merge master into cardgroup: destination cardgroup vanished after merge commit")
 		}
 		return nil, eris.Wrap(err, "usecase: master deck: merge master into cardgroup: find destination")
 	}

--- a/backend/internal/usecase/master_deck_test.go
+++ b/backend/internal/usecase/master_deck_test.go
@@ -957,6 +957,44 @@ func TestMasterDeckUsecase_MergeMasterIntoCardgroup_PostTxFindByIDError_Propagat
 	assertInternalChain(t, err, "usecase: master deck: merge master into cardgroup: find destination")
 }
 
+// TestMasterDeckUsecase_MergeMasterIntoCardgroup_PostTxDestVanished_NotErrNotFound
+// pins the translation of the post-commit destination read-back. The merge has
+// already committed when the destination cardgroup is deleted concurrently (no
+// FOR UPDATE is held on that row), so FindByID yields repository.ErrNotFound. The
+// sentinel must NOT travel up: MergeMaster maps any repository.ErrNotFound from
+// this delegate to the master-not-found outcome, which would report the catalog
+// deck as missing and hide the committed merge.
+func TestMasterDeckUsecase_MergeMasterIntoCardgroup_PostTxDestVanished_NotErrNotFound(t *testing.T) {
+	t.Parallel()
+	const ownerID = "11111111-1111-7111-8111-111111111111"
+	const destID = "22222222-2222-7222-8222-222222222222"
+	const masterID = "master-id"
+
+	// One card so the tx body executes and reaches the post-tx FindByID.
+	masterCards := []*domain.MasterCard{
+		masterCard("mc-1", masterID, "alpha", "first", 0),
+	}
+	destCG := mustCardgroup(t, destID, ownerID, "My Deck")
+
+	uc := NewMasterDeckUsecaseWithTx(
+		&fakeMasterCGRepo{byID: map[string]*domain.MasterCardgroup{masterID: masterCG(masterID, "Master")}},
+		&fakeMasterCardRepo{byMaster: map[string][]*domain.MasterCard{masterID: masterCards}},
+		&fakeUserCardRepo{},
+		&fakeUserCG{
+			byID:              map[string]*domain.Cardgroup{destID: destCG},
+			findByIDErr:       repository.ErrNotFound,
+			findByIDErrOnCall: 2, // call 1 = ownership gate (succeeds), call 2 = post-tx read (destination deleted)
+		},
+		stubTxRunner,
+		newTestLogger(),
+	)
+
+	_, err := uc.MergeMasterIntoCardgroup(context.Background(), masterID, domain.CardgroupID(destID), domain.UserID(ownerID))
+	require.Error(t, err)
+	require.NotErrorIs(t, err, repository.ErrNotFound, "the post-commit read-back must not surface the ErrNotFound sentinel")
+	assertInternalChain(t, err, "usecase: master deck: merge master into cardgroup: destination cardgroup vanished after merge commit")
+}
+
 // --- PreviewMergeMasterIntoCardgroup tests ------------------------------------
 
 func TestPreviewMergeMasterIntoCardgroup_CountsAddedAndUpdated(t *testing.T) {


### PR DESCRIPTION
## Summary

A merge of a published catalog deck into a learner-owned deck reads the destination cardgroup back *after* the transaction commits. That read-back wrapped its error unconditionally, so a `repository.ErrNotFound` raised by a concurrent delete of the destination survived `errors.Is` all the way up to `MasterCatalogUsecase.MergeMaster`, whose `errors.Is(err, repository.ErrNotFound)` branch collapses any such sentinel into `MergeMasterOutcome{NotFound: true}` — the non-disclosure outcome reserved for an unknown or unpublished master. The learner was therefore told the *catalog* deck does not exist, hiding both the already-committed merge and the vanished destination. No `FOR UPDATE` is taken on the destination row during the merge transaction (the card upsert takes only an FK `FOR KEY SHARE`, released at commit), so the interleaving is real. The fix translates the post-commit read-back's `ErrNotFound` into a non-sentinel `eris.New` error, which classifies as `INTERNAL` and can no longer be mistaken for the master-not-found outcome; the `isContextDone` pass-through immediately above it is untouched, so `context.Canceled` / `DeadlineExceeded` still propagate with their bare identity. The stale comment on `MergeMaster`'s not-found branch — which asserted the branch was master-scoped on the strength of the pre-transaction ownership gate alone — now names every `ErrNotFound` producer the branch can actually see.

## Changes

- `backend/internal/usecase/master_deck.go`: in `MergeMasterIntoCardgroup`, the post-commit `u.userCG.FindByID` failure path gains an `errors.Is(err, repository.ErrNotFound)` arm returning `eris.New("usecase: master deck: merge master into cardgroup: destination cardgroup vanished after merge commit")`, placed *after* the existing `isContextDone` pass-through (which is unchanged) and *before* the generic `eris.Wrap(..., "…: find destination")`. Adds the `errors` import.
- `backend/internal/usecase/master_catalog.go`: corrects the comment on `MergeMaster`'s `errors.Is(err, repository.ErrNotFound)` branch. It previously claimed the branch was master-scoped because "the destination ownership gate never yields ErrNotFound"; it now states that the in-tx published-scoped re-read is the only producer the branch can see, and names both reasons — the ownership gate maps a missing cardgroup to a `ucerr.ValidationError`, and the post-commit read-back translates its `ErrNotFound` into a non-sentinel internal error.

### Tests

- `backend/internal/usecase/master_deck_test.go` — `TestMasterDeckUsecase_MergeMasterIntoCardgroup_PostTxDestVanished_NotErrNotFound`: drives the real `masterDeckUsecase` with `fakeUserCG{findByIDErr: repository.ErrNotFound, findByIDErrOnCall: 2}` so call 1 (the ownership gate) succeeds and call 2 (the post-commit read-back) fails. Asserts `require.NotErrorIs(err, repository.ErrNotFound)` and pins the chain via `assertInternalChain(..., "usecase: master deck: merge master into cardgroup: destination cardgroup vanished after merge commit")`.
- `backend/internal/usecase/master_catalog_test.go` — `TestMasterCatalogUsecase_MergeMaster_DestVanishedAfterCommit_NotNotFoundOutcome`: wires the *real* deck usecase (not the `mockCopyMasterToUserUC` stub) into `NewMasterCatalogUsecase` so the whole post-commit path is exercised end to end. Asserts `out.NotFound` is false and `assertInternalChain(err, "usecase: master catalog: merge: merge master into cardgroup")` — i.e. the caller sees an INTERNAL-class error, not the master-not-found outcome. Uses the file's stdlib-assertion idiom (`t.Fatal`), matching its neighbours; `require`/`assert` are not imported there.
- Both tests were proven red against the unfixed production code by temporarily removing the new branch and re-running: the deck test reported `found: "repository: not found" in chain: "usecase: master deck: merge master into cardgroup: find destination: repository: not found"`, and the catalog test reported `a vanished destination must not be reported as a missing master`. The production file was restored and rebuilt afterwards.
- The genuine master-not-found paths are untouched and still green: `TestMasterCatalogUsecase_MergeMaster_DraftMaster_NotFound` and `TestMasterCatalogUsecase_MergeMaster_MasterUnpublishedMidFlight_ReturnsNotFoundOutcome` both still return `MergeMasterOutcome{NotFound: true}`, and `TestMasterDeckUsecase_MergeMasterIntoCardgroup_MasterUnpublishedMidFlight_NoImport` still asserts the in-tx re-read surfaces `repository.ErrNotFound`.

## Test plan

- [ ] cd backend && go build ./... — PASS (Success)
- [ ] cd backend && go vet ./... — PASS (No issues found)
- [ ] cd backend && go tool go-arch-lint check --project-path . — PASS (OK - No warnings found)
- [ ] cd backend && go test ./internal/... ./graph/... -count=1 — PASS (2099 passed in 22 packages)
- [ ] cd backend && go test ./internal/usecase/... -run MergeMaster -count=1 — PASS (26 passed in 2 packages)
- [ ] Red-state proof (production branch temporarily removed): go test ./internal/usecase/ -run PostTxDestVanished — FAIL (1 failure, as intended); -run 'MergeMaster_(PostTxDestVanished|DestVanishedAfterCommit)' — FAIL (1 failure, as intended). Production file restored, go build ./... green after restore.
- [ ] CJK gate (perl -CSD over the four changed files) — PASS (no output)
- [ ] git status --short in the MAIN checkout /Users/yasuflatland/projects/flamingo-armond — PASS (empty; no stray edits)

## Notes

Machine-verified evidence citations re-checked in the worktree against the base commit; all hold with one trivial drift: the issue cites the failure path as `master_deck.go:403-407`, and it is in fact lines 403-408 (the closing brace of the `if err != nil` block sits at 408). `master_deck.go:395` (`}); err != nil {`), `:402` (`cg, err := u.userCG.FindByID(...)`), `:404-406` (the `isContextDone` pass-through), and `master_catalog.go:741-747` / `:742-746` all matched exactly.

Production diff is 14 added lines across two files (well inside the ~25 LOC estimate and the 800-line ceiling).

Post-flight grep for other `ErrNotFound` producers reaching `MergeMaster`: within `MergeMasterIntoCardgroup` the three candidate sites are the pre-transaction `authorizeCardgroupOrBadInput` gate (maps a missing cardgroup to `ucerr.ValidationError`, verified by the still-green `TestMasterDeckUsecase_MergeMasterIntoCardgroup_DestNotFound_Validation`), the in-tx `FindPublishedByID` re-read (the intended, still-collapsing producer), and the post-commit read-back (now translated). The corrected comment enumerates exactly these.

The catalog-level test deliberately constructs the real `*masterDeckUsecase` rather than the existing `mockCopyMasterToUserUC` stub: a stub that simply returns `repository.ErrNotFound` cannot distinguish the two producers, so it would have passed both before and after the fix. Wiring the real delegate is what makes the test a genuine reachability proof.

`go test ./...` for the whole backend was not run because several packages are Docker/testcontainers-gated in this environment; `./internal/... ./graph/...` covers every package touched plus its dependents (2099 tests). The orchestrator's full-suite re-run should confirm.

**Scope deviations.** none — both Scope checkboxes implemented exactly, nothing from Out of scope touched. The destination read-back stays outside the transaction, no `FOR UPDATE` was added, no schema/resolver/frontend change was made, and the outcome union is unchanged.

**Merge order.** `backend/internal/usecase/master_catalog.go` is also touched by the branches for #1010 and #1022. The hunks are in different functions today.

Closes #1018
