### PR TITLE
fix(backend): guard the last administrator on the adminEditUser demote-other path

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -163,7 +163,7 @@ func buildResolver(
 	pingToken string,
 ) (*resolver.Resolver, *ping.Handler, *notionsync.Handler, error) {
 	masterDeckUC := usecase.NewMasterDeckUsecase(repos.masterCardgroup, repos.masterCard, repos.card, repos.cardgroup, repos.gorm, logger)
-	userUC := usecase.NewUserUsecase(repos.user, repos.userRole, authSvc, logger)
+	userUC := usecase.NewUserUsecase(repos.gorm, repos.user, repos.userRole, authSvc, logger)
 	cardgroupUC := usecase.NewCardgroupUsecase(repos.cardgroup, authSvc, logger)
 	learnUC := usecase.NewLearnUsecase(repos.card, repos.cardgroup, repos.userPreference, service.NewOrderingPolicy(), nil, 0, 0, nil, logger)
 	swipeUC := usecase.NewSwipeUsecase(repos.gorm, repos.card, repos.cardgroup, repos.swipeRecord, service.NewFSRSScheduler(), repos.userCardFSRS, logger)

--- a/backend/cmd/server/main_test.go
+++ b/backend/cmd/server/main_test.go
@@ -712,7 +712,7 @@ func newGraphQLTestServerWithUserRepo(t *testing.T, f *jwtFixture, userRepo repo
 	userCardFSRSRepo := repository.NewUserCardFSRSRepository(db.GORM)
 	swipeRecordRepo := repository.NewSwipeRecordRepository(db.GORM)
 	logger := slog.New(slog.DiscardHandler)
-	userUC := usecase.NewUserUsecase(userRepo, userRoleRepo, nil, logger)
+	userUC := usecase.NewUserUsecase(nil, userRepo, userRoleRepo, nil, logger)
 	cardgroupUC := usecase.NewCardgroupUsecase(cardgroupRepo, stubAdminChecker{isAdmin: true}, logger)
 	cardUC := usecase.NewCardUsecase(db.GORM, cardRepo, cardgroupRepo, userCardFSRSRepo, nil, logger)
 	swipeUC := usecase.NewSwipeUsecase(db.GORM, cardRepo, cardgroupRepo, swipeRecordRepo, service.NewFSRSScheduler(), userCardFSRSRepo, logger)
@@ -780,8 +780,8 @@ func (c *countingUserRepo) ListPage(
 	return c.inner.ListPage(ctx, after, before, first, last, search)
 }
 
-func (c *countingUserRepo) DeleteAuthUser(ctx context.Context, id string) error {
-	return c.inner.DeleteAuthUser(ctx, id)
+func (c *countingUserRepo) DeleteAuthUserTx(ctx context.Context, tx *gorm.DB, id string) error {
+	return c.inner.DeleteAuthUserTx(ctx, tx, id)
 }
 
 func (c *countingUserRepo) LastSignInByUserIDs(ctx context.Context, ids []string) (map[string]*time.Time, error) {
@@ -1947,7 +1947,7 @@ func newLastViewedGraphQLTestServer(t *testing.T, f *jwtFixture) (*httptest.Serv
 	swipeRecordRepo := repository.NewSwipeRecordRepository(db.GORM)
 	userPreferenceRepo := repository.NewUserPreferenceRepository(db.GORM)
 	logger := slog.New(slog.DiscardHandler)
-	userUC := usecase.NewUserUsecase(userRepo, userRoleRepo, nil, logger)
+	userUC := usecase.NewUserUsecase(nil, userRepo, userRoleRepo, nil, logger)
 	cardgroupUC := usecase.NewCardgroupUsecase(cardgroupRepo, stubAdminChecker{isAdmin: true}, logger)
 	cardUC := usecase.NewCardUsecase(db.GORM, cardRepo, cardgroupRepo, userCardFSRSRepo, nil, logger)
 	swipeUC := usecase.NewSwipeUsecase(db.GORM, cardRepo, cardgroupRepo, swipeRecordRepo, service.NewFSRSScheduler(), userCardFSRSRepo, logger)
@@ -2354,6 +2354,9 @@ type panicUserRoleRepo struct{}
 func (panicUserRoleRepo) HasRole(_ context.Context, _ string, _ domain.RoleName) (bool, error) {
 	panic("not used in this test")
 }
+func (panicUserRoleRepo) HasRoleTx(_ context.Context, _ *gorm.DB, _ string, _ domain.RoleName) (bool, error) {
+	panic("not used in this test")
+}
 func (panicUserRoleRepo) AssignRoleToUser(_ context.Context, _, _ string) error {
 	panic("not used in this test")
 }
@@ -2367,6 +2370,12 @@ func (panicUserRoleRepo) ListByUserIDs(_ context.Context, _ []string) (map[strin
 	panic("not used in this test")
 }
 func (panicUserRoleRepo) CountAdmins(_ context.Context) (int64, error) {
+	panic("not used in this test")
+}
+func (panicUserRoleRepo) CountAdminsTx(_ context.Context, _ *gorm.DB) (int64, error) {
+	panic("not used in this test")
+}
+func (panicUserRoleRepo) AcquireAdminRoleLockTx(_ context.Context, _ *gorm.DB) error {
 	panic("not used in this test")
 }
 

--- a/backend/graph/resolver/admin_user_resolver_test.go
+++ b/backend/graph/resolver/admin_user_resolver_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/99designs/gqlgen/graphql/handler"
 	"github.com/99designs/gqlgen/graphql/handler/transport"
 	"github.com/graph-gophers/dataloader/v7"
+	"gorm.io/gorm"
 
 	"backend/graph/generated"
 	"backend/graph/model"
@@ -69,7 +70,7 @@ type mockRoleByUserIDRepo struct {
 	// lastIDs holds the key slice from the most recent ListByUserIDs call so
 	// N+1 batch assertions can verify all expected user IDs were batched together.
 	lastIDs []string
-	// adminCount is returned by CountAdmins; used by DeleteMyAccount tests.
+	// adminCount is returned by CountAdminsTx; used by DeleteMyAccount tests.
 	adminCount int64
 }
 
@@ -101,7 +102,11 @@ func (m *mockRoleByUserIDRepo) ListByUser(_ context.Context, userID string) ([]*
 	return roles, nil
 }
 
-func (m *mockRoleByUserIDRepo) CountAdmins(_ context.Context) (int64, error) {
+func (m *mockRoleByUserIDRepo) AcquireAdminRoleLockTx(_ context.Context, _ *gorm.DB) error {
+	return nil
+}
+
+func (m *mockRoleByUserIDRepo) CountAdminsTx(_ context.Context, _ *gorm.DB) (int64, error) {
 	return m.adminCount, nil
 }
 

--- a/backend/graph/resolver/card_import_resolver_test.go
+++ b/backend/graph/resolver/card_import_resolver_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/99designs/gqlgen/graphql/handler"
 	"github.com/99designs/gqlgen/graphql/handler/transport"
+	"gorm.io/gorm"
 
 	"backend/graph/generated"
 	"backend/graph/resolver"
@@ -29,6 +30,10 @@ type mockUserRoleRepository struct {
 }
 
 func (m *mockUserRoleRepository) HasRole(_ context.Context, _ string, _ domain.RoleName) (bool, error) {
+	return m.isAdmin, m.err
+}
+
+func (m *mockUserRoleRepository) HasRoleTx(_ context.Context, _ *gorm.DB, _ string, _ domain.RoleName) (bool, error) {
 	return m.isAdmin, m.err
 }
 

--- a/backend/graph/resolver/last_viewed_cardgroup_resolver_test.go
+++ b/backend/graph/resolver/last_viewed_cardgroup_resolver_test.go
@@ -196,7 +196,7 @@ func TestSetLastViewedCardgroup_NilVariant_ReturnsInternal(t *testing.T) {
 // newMeServer builds a gqlgen Server wired to UserUsecase for testing User
 // field resolvers via the me query.
 func newMeServer(userMock *mockUserRepository) *handler.Server {
-	uc := usecase.NewUserUsecase(userMock, nil, nil, newDiscardLogger())
+	uc := usecase.NewUserUsecase(nil, userMock, nil, nil, newDiscardLogger())
 	r := resolver.NewResolver(uc, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	srv := handler.New(generated.NewExecutableSchema(generated.Config{Resolvers: r}))
 	srv.AddTransport(transport.POST{})

--- a/backend/graph/resolver/learn_display_mode_resolver_test.go
+++ b/backend/graph/resolver/learn_display_mode_resolver_test.go
@@ -43,7 +43,7 @@ func newLearnDisplayModeSrv(
 	userMock *mockUserRepository,
 	updateUC usecase.UpdateLearnDisplayModeUsecase,
 ) *handler.Server {
-	userUC := usecase.NewUserUsecase(userMock, nil, nil, newDiscardLogger())
+	userUC := usecase.NewUserUsecase(nil, userMock, nil, nil, newDiscardLogger())
 	r := resolver.NewResolver(userUC, nil, nil, nil, nil, nil, nil, nil, nil, updateUC, nil, nil, nil, nil, nil, nil)
 	srv := handler.New(generated.NewExecutableSchema(generated.Config{Resolvers: r}))
 	srv.AddTransport(transport.POST{})

--- a/backend/graph/resolver/new_card_ratio_resolver_test.go
+++ b/backend/graph/resolver/new_card_ratio_resolver_test.go
@@ -41,7 +41,7 @@ func newNewCardRatioSrv(
 	userMock *mockUserRepository,
 	updateUC usecase.UpdateNewCardRatioUsecase,
 ) *handler.Server {
-	userUC := usecase.NewUserUsecase(userMock, nil, nil, newDiscardLogger())
+	userUC := usecase.NewUserUsecase(nil, userMock, nil, nil, newDiscardLogger())
 	r := resolver.NewResolver(userUC, nil, nil, nil, nil, nil, nil, nil, nil, nil, updateUC, nil, nil, nil, nil, nil)
 	srv := handler.New(generated.NewExecutableSchema(generated.Config{Resolvers: r}))
 	srv.AddTransport(transport.POST{})

--- a/backend/graph/resolver/user_test.go
+++ b/backend/graph/resolver/user_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/99designs/gqlgen/graphql/handler"
 	"github.com/99designs/gqlgen/graphql/handler/transport"
+	"gorm.io/gorm"
 
 	"backend/graph/generated"
 	"backend/graph/resolver"
@@ -38,7 +39,7 @@ func (m *mockUserRepository) Update(_ context.Context, _ string, patch repositor
 	return m.updateResult, m.updateErr
 }
 
-func (m *mockUserRepository) DeleteAuthUser(_ context.Context, _ string) error {
+func (m *mockUserRepository) DeleteAuthUserTx(_ context.Context, _ *gorm.DB, _ string) error {
 	return m.deleteAuthErr
 }
 
@@ -56,7 +57,7 @@ func dnPtr(s string) *domain.DisplayName {
 // newServer builds a gqlgen handler.Server backed by a resolver that uses the
 // given mock repository.
 func newServer(mock *mockUserRepository) *handler.Server {
-	uc := usecase.NewUserUsecase(mock, nil, nil, newDiscardLogger())
+	uc := usecase.NewUserUsecase(nil, mock, nil, nil, newDiscardLogger())
 	r := resolver.NewResolver(uc, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	srv := handler.New(generated.NewExecutableSchema(generated.Config{Resolvers: r}))
 	srv.AddTransport(transport.POST{})
@@ -345,7 +346,7 @@ func TestResolver_UpdateProfile_NilVariant_ReturnsInternal(t *testing.T) {
 // for the caller and a roles repo reporting the global admin count.
 func newDeleteMyAccountSrv(repo *mockUserRepository, isAdmin bool, adminCount int64) *handler.Server {
 	authSvc := auth.NewService(&mockUserRoleRepository{isAdmin: isAdmin})
-	uc := usecase.NewUserUsecase(repo, &mockRoleByUserIDRepo{adminCount: adminCount}, authSvc, newDiscardLogger())
+	uc := usecase.NewUserUsecase(nil, repo, &mockRoleByUserIDRepo{adminCount: adminCount}, authSvc, newDiscardLogger())
 	r := resolver.NewResolver(uc, nil, nil, nil, authSvc, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	srv := handler.New(generated.NewExecutableSchema(generated.Config{Resolvers: r}))
 	srv.AddTransport(transport.POST{})

--- a/backend/internal/loader/role_by_user_test.go
+++ b/backend/internal/loader/role_by_user_test.go
@@ -25,6 +25,10 @@ func (s *roleBatchRepoStub) HasRole(_ context.Context, _ string, _ domain.RoleNa
 	panic("roleBatchRepoStub.HasRole not configured")
 }
 
+func (s *roleBatchRepoStub) HasRoleTx(_ context.Context, _ *gorm.DB, _ string, _ domain.RoleName) (bool, error) {
+	panic("roleBatchRepoStub.HasRoleTx not configured")
+}
+
 func (s *roleBatchRepoStub) AssignRoleToUser(_ context.Context, _, _ string) error {
 	panic("roleBatchRepoStub.AssignRoleToUser not configured")
 }
@@ -46,6 +50,14 @@ func (s *roleBatchRepoStub) ListByUserIDs(ctx context.Context, userIDs []string)
 
 func (s *roleBatchRepoStub) CountAdmins(_ context.Context) (int64, error) {
 	panic("roleBatchRepoStub.CountAdmins not configured")
+}
+
+func (s *roleBatchRepoStub) CountAdminsTx(_ context.Context, _ *gorm.DB) (int64, error) {
+	panic("roleBatchRepoStub.CountAdminsTx not configured")
+}
+
+func (s *roleBatchRepoStub) AcquireAdminRoleLockTx(_ context.Context, _ *gorm.DB) error {
+	panic("roleBatchRepoStub.AcquireAdminRoleLockTx not configured")
 }
 
 // Compile-time assertion that the stub satisfies the unified interface.

--- a/backend/internal/loader/user_test.go
+++ b/backend/internal/loader/user_test.go
@@ -88,6 +88,9 @@ type emptyUserRoleRepoStub struct{}
 func (emptyUserRoleRepoStub) HasRole(_ context.Context, _ string, _ domain.RoleName) (bool, error) {
 	panic("emptyUserRoleRepoStub.HasRole not expected")
 }
+func (emptyUserRoleRepoStub) HasRoleTx(_ context.Context, _ *gorm.DB, _ string, _ domain.RoleName) (bool, error) {
+	panic("emptyUserRoleRepoStub.HasRoleTx not expected")
+}
 func (emptyUserRoleRepoStub) AssignRoleToUser(_ context.Context, _, _ string) error {
 	panic("emptyUserRoleRepoStub.AssignRoleToUser not expected")
 }
@@ -102,6 +105,12 @@ func (emptyUserRoleRepoStub) ListByUserIDs(_ context.Context, _ []string) (map[s
 }
 func (emptyUserRoleRepoStub) CountAdmins(_ context.Context) (int64, error) {
 	panic("emptyUserRoleRepoStub.CountAdmins not expected")
+}
+func (emptyUserRoleRepoStub) CountAdminsTx(_ context.Context, _ *gorm.DB) (int64, error) {
+	panic("emptyUserRoleRepoStub.CountAdminsTx not expected")
+}
+func (emptyUserRoleRepoStub) AcquireAdminRoleLockTx(_ context.Context, _ *gorm.DB) error {
+	panic("emptyUserRoleRepoStub.AcquireAdminRoleLockTx not expected")
 }
 
 func emptyUserRoleRepo() repository.UserRoleRepository {
@@ -280,10 +289,10 @@ func (r *countingRepo) ListPage(
 	panic("countingRepo.ListPage not configured")
 }
 
-// DeleteAuthUser satisfies repository.UserRepository. Loader-layer tests never
+// DeleteAuthUserTx satisfies repository.UserRepository. Loader-layer tests never
 // invoke account deletion; panic if called so accidental coupling is surfaced.
-func (r *countingRepo) DeleteAuthUser(_ context.Context, _ string) error {
-	panic("countingRepo.DeleteAuthUser not configured")
+func (r *countingRepo) DeleteAuthUserTx(_ context.Context, _ *gorm.DB, _ string) error {
+	panic("countingRepo.DeleteAuthUserTx not configured")
 }
 
 // LastSignInByUserIDs satisfies repository.UserRepository. Configure the

--- a/backend/internal/repository/user.go
+++ b/backend/internal/repository/user.go
@@ -94,19 +94,24 @@ type UserRepository interface {
 		search *string,
 	) (users []*domain.User, total int64, err error)
 
-	// DeleteAuthUser deletes the auth.users row identified by id. The public.users
-	// row and every cascade-linked row (user_roles, cardgroups → cards →
-	// swipe_records / user_card_fsrs, user_preferences) are removed automatically
-	// by the existing ON DELETE CASCADE foreign keys — no application-level
-	// multi-step delete is needed. Returns ErrNotFound when no auth.users row
-	// matches id (RowsAffected == 0).
+	// DeleteAuthUserTx deletes the auth.users row identified by id inside the
+	// supplied transaction. The public.users row and every cascade-linked row
+	// (user_roles, cardgroups → cards → swipe_records / user_card_fsrs,
+	// user_preferences) are removed automatically by the existing ON DELETE
+	// CASCADE foreign keys — no application-level multi-step delete is needed.
+	// Returns ErrNotFound when no auth.users row matches id (RowsAffected == 0).
+	//
+	// The delete is transaction-scoped because callers must hold the admin-role
+	// advisory lock (AcquireAdminRoleLockTx) across the last-admin count and the
+	// delete; a delete issued on a pooled connection outside that transaction
+	// would commit after the lock released and reopen the race.
 	//
 	// The operation requires the connection role to have DELETE privilege on
 	// auth.users; the production DSN connects as the postgres role, which has it
 	// (the same statement is exercised by the repository integration tests). This
 	// is the single isolation point for auth-account deletion: swapping to the
 	// Supabase Admin REST API is a change to this method body alone.
-	DeleteAuthUser(ctx context.Context, id string) error
+	DeleteAuthUserTx(ctx context.Context, tx *gorm.DB, id string) error
 
 	// LastSignInByUserIDs reads auth.users.last_sign_in_at for the given user
 	// ids. Each known id maps to its *time.Time (nil when the column is NULL,
@@ -115,7 +120,7 @@ type UserRepository interface {
 	// "WHERE id IN ()" into an unfiltered full scan, so the call is
 	// short-circuited).
 	//
-	// Like DeleteAuthUser, this is an isolated auth.users access point; it
+	// Like DeleteAuthUserTx, this is an isolated auth.users access point; it
 	// requires the connection role to have SELECT on auth.users (the
 	// production postgres role has it).
 	LastSignInByUserIDs(ctx context.Context, ids []string) (map[string]*time.Time, error)
@@ -211,11 +216,14 @@ func (r *userRepo) UpdateTxVersioned(ctx context.Context, tx *gorm.DB, id string
 	return ErrConcurrentUpdate
 }
 
-// DeleteAuthUser deletes the auth.users row, cascading to public.users and all
+// DeleteAuthUserTx deletes the auth.users row, cascading to public.users and all
 // child data via the schema's ON DELETE CASCADE foreign keys. See the interface
-// doc for the privilege and isolation rationale.
-func (r *userRepo) DeleteAuthUser(ctx context.Context, id string) error {
-	res := r.db.WithContext(ctx).Exec("DELETE FROM auth.users WHERE id = ?", id)
+// doc for the privilege, transaction-scoping, and isolation rationale.
+func (r *userRepo) DeleteAuthUserTx(ctx context.Context, tx *gorm.DB, id string) error {
+	if tx == nil {
+		return eris.New("repository: user: delete auth user tx is nil")
+	}
+	res := tx.WithContext(ctx).Exec("DELETE FROM auth.users WHERE id = ?", id)
 	if res.Error != nil {
 		return eris.Wrap(res.Error, "repository: user: delete auth user")
 	}

--- a/backend/internal/repository/user_role.go
+++ b/backend/internal/repository/user_role.go
@@ -33,6 +33,15 @@ type UserRoleRepository interface {
 	// Only DB errors return a non-nil error. Role lookup is by name (case-sensitive).
 	HasRole(ctx context.Context, userID string, roleName domain.RoleName) (bool, error)
 
+	// HasRoleTx is HasRole scoped to the supplied transaction. Callers that use
+	// the membership answer to decide whether the "never leave the system
+	// without an admin" invariant applies must use this form and take
+	// AcquireAdminRoleLockTx first, so the membership read, the admin count and
+	// the mutation they guard are one serialized unit. A membership read taken
+	// outside the lock can go stale — the target may be promoted to admin after
+	// the read — and the guard is then skipped entirely.
+	HasRoleTx(ctx context.Context, tx *gorm.DB, userID string, roleName domain.RoleName) (bool, error)
+
 	// AssignRoleToUser inserts a (user_id, role_id) row. Idempotent: if the row
 	// already exists, returns nil without error. Returns ErrUserNotFound when
 	// the user is missing and ErrRoleNotFound when the role is missing; both
@@ -62,6 +71,21 @@ type UserRoleRepository interface {
 	// admin role row itself does not exist — callers treat the absence of
 	// the role and an empty assignment table as the same operational state.
 	CountAdmins(ctx context.Context) (int64, error)
+
+	// CountAdminsTx is CountAdmins scoped to the supplied transaction, so the
+	// count and the mutation it guards commit or roll back together. Callers
+	// that enforce the "never leave the system without an admin" invariant must
+	// use this form and take AcquireAdminRoleLockTx first.
+	CountAdminsTx(ctx context.Context, tx *gorm.DB) (int64, error)
+
+	// AcquireAdminRoleLockTx takes a transaction-scoped Postgres advisory lock
+	// that serializes every mutation able to change the number of admins.
+	// Concurrent admin removals touch disjoint user_roles rows, so the database
+	// never conflicts on its own and a plain count is a check-then-act race:
+	// two callers can each observe two admins and both demote. Holding this
+	// lock across the count and the write closes that window. The lock releases
+	// at transaction end, so callers cannot leak it.
+	AcquireAdminRoleLockTx(ctx context.Context, tx *gorm.DB) error
 }
 
 type userRoleRepo struct{ db *gorm.DB }
@@ -71,8 +95,21 @@ func NewUserRoleRepository(db *gorm.DB) UserRoleRepository {
 }
 
 func (r *userRoleRepo) HasRole(ctx context.Context, userID string, roleName domain.RoleName) (bool, error) {
+	return hasRoleOn(ctx, r.db, userID, roleName)
+}
+
+func (r *userRoleRepo) HasRoleTx(ctx context.Context, tx *gorm.DB, userID string, roleName domain.RoleName) (bool, error) {
+	if tx == nil {
+		return false, eris.New("repository: user role: has role tx is nil")
+	}
+	return hasRoleOn(ctx, tx, userID, roleName)
+}
+
+// hasRoleOn is the single query shared by the Tx and non-Tx forms so the two
+// cannot drift.
+func hasRoleOn(ctx context.Context, db *gorm.DB, userID string, roleName domain.RoleName) (bool, error) {
 	var count int64
-	err := r.db.WithContext(ctx).
+	err := db.WithContext(ctx).
 		Table("user_roles").
 		Joins("JOIN roles ON roles.id = user_roles.role_id").
 		Where("user_roles.user_id = ? AND roles.name = ?", userID, roleName).
@@ -240,8 +277,21 @@ func (r *userRoleRepo) ListByUserIDs(ctx context.Context, userIDs []string) (map
 }
 
 func (r *userRoleRepo) CountAdmins(ctx context.Context) (int64, error) {
+	return countAdminsOn(ctx, r.db)
+}
+
+func (r *userRoleRepo) CountAdminsTx(ctx context.Context, tx *gorm.DB) (int64, error) {
+	if tx == nil {
+		return 0, eris.New("repository: user role: count admins tx is nil")
+	}
+	return countAdminsOn(ctx, tx)
+}
+
+// countAdminsOn is the single query shared by the Tx and non-Tx forms so the
+// two cannot drift.
+func countAdminsOn(ctx context.Context, db *gorm.DB) (int64, error) {
 	var n int64
-	err := r.db.WithContext(ctx).
+	err := db.WithContext(ctx).
 		Table("user_roles").
 		Joins("JOIN roles ON roles.id = user_roles.role_id").
 		Where("roles.name = ?", domain.AdminRoleName).
@@ -250,4 +300,23 @@ func (r *userRoleRepo) CountAdmins(ctx context.Context) (int64, error) {
 		return 0, eris.Wrap(err, "repository: user role: count admins")
 	}
 	return n, nil
+}
+
+// adminRoleLockNamespace is the advisory-lock namespace for the admin-count
+// invariant. hashtext returns int4, so pg_advisory_xact_lock(hashtext(ns),
+// hashtext(role)) keys the lock on the role within a namespace where unrelated
+// callers do not contend.
+const adminRoleLockNamespace = "user_roles"
+
+func (r *userRoleRepo) AcquireAdminRoleLockTx(ctx context.Context, tx *gorm.DB) error {
+	if tx == nil {
+		return eris.New("repository: user role: acquire admin role lock tx is nil")
+	}
+	if err := tx.WithContext(ctx).Exec(
+		"SELECT pg_advisory_xact_lock(hashtext(?), hashtext(?))",
+		adminRoleLockNamespace, string(domain.AdminRoleName),
+	).Error; err != nil {
+		return eris.Wrap(err, "repository: user role: acquire admin role lock")
+	}
+	return nil
 }

--- a/backend/internal/repository/user_role_admin_lock_test.go
+++ b/backend/internal/repository/user_role_admin_lock_test.go
@@ -1,0 +1,83 @@
+package repository_test
+
+// TestUserRoleRepository_AdminLockAndCountTx exercises the transaction-scoped
+// pair the last-admin guard depends on. The advisory-lock statement is raw SQL,
+// so only a real Postgres round-trip proves the call shape is valid; a typo in
+// pg_advisory_xact_lock or hashtext would otherwise surface first in production.
+//
+// TestMain, testDB, insertAuthUser are defined in user_test.go and shared
+// across this package. insertRole is defined in user_role_assign_test.go.
+
+import (
+	"context"
+	"testing"
+
+	"gorm.io/gorm"
+
+	"backend/internal/repository"
+)
+
+func TestUserRoleRepository_AdminLockAndCountTx(t *testing.T) {
+	// Not parallel: the admin count is global, so a concurrent test assigning
+	// the admin role would make the delta assertion flaky.
+	ctx := context.Background()
+	roleRepo := repository.NewRoleRepository(testDB.GORM)
+	repo := repository.NewUserRoleRepository(testDB.GORM)
+
+	role, err := roleRepo.FindByName(ctx, "admin")
+	if err != nil {
+		t.Fatalf("FindByName(admin): %v", err)
+	}
+
+	var before int64
+	if terr := testDB.GORM.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if lerr := repo.AcquireAdminRoleLockTx(ctx, tx); lerr != nil {
+			return lerr
+		}
+		var cerr error
+		before, cerr = repo.CountAdminsTx(ctx, tx)
+		return cerr
+	}); terr != nil {
+		t.Fatalf("lock + count (before assign): %v", terr)
+	}
+	if before < 0 {
+		t.Errorf("CountAdminsTx: want >= 0, got %d", before)
+	}
+
+	userID := insertAuthUser(t, ctx)
+	if err := repo.AssignRoleToUser(ctx, userID, role.ID); err != nil {
+		t.Fatalf("AssignRoleToUser: %v", err)
+	}
+
+	// Re-taking the lock in a second transaction proves it was released at the
+	// first transaction's commit rather than leaked for the session's lifetime.
+	var after int64
+	if terr := testDB.GORM.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if lerr := repo.AcquireAdminRoleLockTx(ctx, tx); lerr != nil {
+			return lerr
+		}
+		var cerr error
+		after, cerr = repo.CountAdminsTx(ctx, tx)
+		return cerr
+	}); terr != nil {
+		t.Fatalf("lock + count (after assign): %v", terr)
+	}
+	if after != before+1 {
+		t.Errorf("CountAdminsTx after assign: want %d, got %d", before+1, after)
+	}
+}
+
+// TestUserRoleRepository_AdminLockAndCountTx_NilTx pins the nil-handle guards:
+// both methods must return a wrapped error rather than dereferencing nil.
+func TestUserRoleRepository_AdminLockAndCountTx_NilTx(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	repo := repository.NewUserRoleRepository(testDB.GORM)
+
+	if err := repo.AcquireAdminRoleLockTx(ctx, nil); err == nil {
+		t.Error("AcquireAdminRoleLockTx(nil tx): want error, got nil")
+	}
+	if _, err := repo.CountAdminsTx(ctx, nil); err == nil {
+		t.Error("CountAdminsTx(nil tx): want error, got nil")
+	}
+}

--- a/backend/internal/repository/user_test.go
+++ b/backend/internal/repository/user_test.go
@@ -305,7 +305,17 @@ func TestUser_OnDeleteCascade(t *testing.T) {
 	}
 }
 
-func TestDeleteAuthUser_Success(t *testing.T) {
+// deleteAuthUserInTx runs DeleteAuthUserTx inside a real transaction, mirroring
+// the usecase-layer call shape (guard + delete under one advisory lock). The
+// sentinel returned by the repository must survive the transaction boundary, so
+// the closure's error is returned verbatim.
+func deleteAuthUserInTx(ctx context.Context, repo repository.UserRepository, id string) error {
+	return testDB.GORM.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		return repo.DeleteAuthUserTx(ctx, tx, id)
+	})
+}
+
+func TestDeleteAuthUserTx_Success(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	id := insertAuthUser(t, ctx)
@@ -314,28 +324,28 @@ func TestDeleteAuthUser_Success(t *testing.T) {
 	if _, err := repo.FindByID(ctx, id); err != nil {
 		t.Fatalf("precondition FindByID: %v", err)
 	}
-	if err := repo.DeleteAuthUser(ctx, id); err != nil {
-		t.Fatalf("DeleteAuthUser: %v", err)
+	if err := deleteAuthUserInTx(ctx, repo, id); err != nil {
+		t.Fatalf("DeleteAuthUserTx: %v", err)
 	}
 	if _, err := repo.FindByID(ctx, id); !errors.Is(err, repository.ErrNotFound) {
 		t.Fatalf("want ErrNotFound after delete, got %v", err)
 	}
 }
 
-func TestDeleteAuthUser_NotFound(t *testing.T) {
+func TestDeleteAuthUserTx_NotFound(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	repo := repository.NewUserRepository(testDB.GORM)
 
-	if err := repo.DeleteAuthUser(ctx, uuid.NewString()); !errors.Is(err, repository.ErrNotFound) {
+	if err := deleteAuthUserInTx(ctx, repo, uuid.NewString()); !errors.Is(err, repository.ErrNotFound) {
 		t.Fatalf("want ErrNotFound for missing auth user, got %v", err)
 	}
 }
 
-// TestDeleteAuthUser_CascadesOwnedCardgroup proves DeleteAuthUser (not a raw
+// TestDeleteAuthUserTx_CascadesOwnedCardgroup proves DeleteAuthUserTx (not a raw
 // SQL statement) drives the ON DELETE CASCADE chain down to a user-owned
 // cardgroup row.
-func TestDeleteAuthUser_CascadesOwnedCardgroup(t *testing.T) {
+func TestDeleteAuthUserTx_CascadesOwnedCardgroup(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	id := insertAuthUser(t, ctx)
@@ -349,8 +359,8 @@ func TestDeleteAuthUser_CascadesOwnedCardgroup(t *testing.T) {
 		t.Fatalf("insert cardgroup: %v", err)
 	}
 
-	if err := repo.DeleteAuthUser(ctx, id); err != nil {
-		t.Fatalf("DeleteAuthUser: %v", err)
+	if err := deleteAuthUserInTx(ctx, repo, id); err != nil {
+		t.Fatalf("DeleteAuthUserTx: %v", err)
 	}
 
 	var count int

--- a/backend/internal/usecase/admin_user.go
+++ b/backend/internal/usecase/admin_user.go
@@ -95,9 +95,10 @@ type adminUserRepository interface {
 		first, last int,
 		search *string,
 	) ([]*domain.User, int64, error)
-	// DeleteAuthUser deletes the target's auth.users row, cascading to all
-	// associated data. See repository.UserRepository.DeleteAuthUser for details.
-	DeleteAuthUser(ctx context.Context, id string) error
+	// DeleteAuthUserTx deletes the target's auth.users row inside the caller's
+	// transaction, cascading to all associated data. See
+	// repository.UserRepository.DeleteAuthUserTx for details.
+	DeleteAuthUserTx(ctx context.Context, tx *gorm.DB, id string) error
 }
 
 // adminRoleRepository is the subset of repository.RoleRepository used by the
@@ -110,15 +111,22 @@ type adminRoleRepository interface {
 
 // adminUserRoleRepository is the subset of repository.UserRoleRepository used
 // by the AdminUser usecase: atomic membership replacement (EditUser) and the
-// last-admin / target-is-admin checks (DeleteUser).
+// last-admin / target-is-admin checks (EditUser's demote-other branch and
+// DeleteUser). The lock + count pair is the AdminCounter port consumed by
+// guardNotLastAdmin.
 type adminUserRoleRepository interface {
 	SetUserRolesTx(ctx context.Context, tx *gorm.DB, userID string, roleIDs []string) error
-	// HasRole reports whether the user holds the named role. Used by DeleteUser
-	// to decide whether the last-admin guard applies to the target.
-	HasRole(ctx context.Context, userID string, roleName domain.RoleName) (bool, error)
-	// CountAdmins returns the number of users holding the admin role. Used by
-	// DeleteUser's last-admin guard.
-	CountAdmins(ctx context.Context) (int64, error)
+	// HasRoleTx reports whether the user holds the named role, read inside the
+	// caller's transaction. Used to decide whether the last-admin guard applies
+	// to the target; it must be read under AcquireAdminRoleLockTx so a
+	// concurrent promotion cannot make the answer stale before the mutation.
+	HasRoleTx(ctx context.Context, tx *gorm.DB, userID string, roleName domain.RoleName) (bool, error)
+	// AcquireAdminRoleLockTx serializes admin-count-changing mutations; see
+	// repository.UserRoleRepository for the race it closes.
+	AcquireAdminRoleLockTx(ctx context.Context, tx *gorm.DB) error
+	// CountAdminsTx returns the number of users holding the admin role, read
+	// inside the caller's transaction under the lock above.
+	CountAdminsTx(ctx context.Context, tx *gorm.DB) (int64, error)
 }
 
 // adminUserUsecase wires the admin gate, the user repository, the role
@@ -288,15 +296,23 @@ func (u *adminUserUsecase) Get(ctx context.Context, id string) (*domain.User, er
 // EditUser surfaces a wrapped 'tx runner not configured' error rather than
 // panicking, since the wiring gap is recoverable per-request.
 //
-// The self-demotion guard runs at the front of the transaction and reads role
-// names with a FOR UPDATE lock (FindByIDsTx), so the role-name read is atomic
-// with the role-set write. This closes the TOCTOU window where a concurrent
-// admin could rename or delete the admin role between the guard read and the
-// role-set replacement. When the guard blocks (self-demotion or an unknown
-// submitted role) it returns nil from the tx closure after capturing the
-// outcome in earlyOutcome — there is no write to roll back, so no control-flow
-// sentinel is needed; the post-tx code returns the captured outcome before
-// inspecting the transaction error.
+// The role-set guards run at the front of the transaction and read role names
+// with a FOR UPDATE lock (FindByIDsTx), so the role-name read is atomic with
+// the role-set write. This closes the TOCTOU window where a concurrent admin
+// could rename or delete the admin role between the guard read and the role-set
+// replacement. Two guards branch off the same "the submitted set drops admin"
+// condition: editing your own row yields outcome.CannotRevokeOwnAdmin, while
+// demoting somebody else takes the admin-role advisory lock, reads the target's
+// admin membership under it, and only then runs guardNotLastAdmin — so neither
+// two administrators demoting each other concurrently nor a target promoted
+// after the membership read can leave the workspace with zero admins.
+//
+// When a guard blocks (self-demotion or an unknown submitted role) it returns
+// nil from the tx closure after capturing the outcome in earlyOutcome — there
+// is no write to roll back, so no control-flow sentinel is needed; the post-tx
+// code returns the captured outcome before inspecting the transaction error.
+// The last-admin guard is surfaced the same way through guardErr, which carries
+// a forbidden error rather than an outcome field.
 func (u *adminUserUsecase) EditUser(ctx context.Context, id string, input AdminEditUserInput) (AdminEditUserOutcome, error) {
 	callerID, err := u.adminGate.Require(ctx, "usecase: admin user: check admin")
 	if err != nil {
@@ -325,36 +341,70 @@ func (u *adminUserUsecase) EditUser(ctx context.Context, id string, input AdminE
 	// write, so blocking is an early `return nil` — there is nothing to roll back,
 	// and no control-flow sentinel is needed.
 	var earlyOutcome *AdminEditUserOutcome
+	// guardErr carries the last-admin guard's forbidden error (or its
+	// infrastructure failure) out of the tx closure. Like earlyOutcome it is
+	// captured before any write, so the closure returns nil and the post-tx code
+	// surfaces it without going through the mutation-error classifier.
+	var guardErr error
 
 	err = u.tx(ctx, func(tx *gorm.DB) error {
-		// No write may be inserted ahead of this guard: the guard blocks via an
+		// No write may be inserted ahead of these guards: a guard blocks via an
 		// early `return nil`, which commits the transaction, so any prior write
 		// would be persisted despite the block.
-		if callerID == id {
-			keepsAdmin := false
-			if len(roleIDs) > 0 {
-				roles, lerr := u.roles.FindByIDsTx(ctx, tx, roleIDs)
-				if lerr != nil {
-					if isContextDone(lerr) {
-						return lerr
-					}
-					return eris.Wrap(lerr, "usecase: admin user edit: lookup roles")
+		keepsAdmin := false
+		if len(roleIDs) > 0 {
+			roles, lerr := u.roles.FindByIDsTx(ctx, tx, roleIDs)
+			if lerr != nil {
+				if isContextDone(lerr) {
+					return lerr
 				}
-				// An unknown submitted roleId is a validation failure, not a
-				// self-demotion: the downstream SetUserRolesTx would also reject it,
-				// but only after passing the keepsAdmin check on the partial map.
-				if len(roles) != len(roleIDs) {
-					earlyOutcome = &AdminEditUserOutcome{Validation: NewInputValidationInfo("roleIds", "role not found")}
-					return nil
-				}
-				set := make(domain.RoleSet, 0, len(roles))
-				for _, r := range roles {
-					set = append(set, *r)
-				}
-				keepsAdmin = set.ContainsAdmin()
+				return eris.Wrap(lerr, "usecase: admin user edit: lookup roles")
 			}
-			if !keepsAdmin {
+			// An unknown submitted roleId is a validation failure, not a
+			// self-demotion: the downstream SetUserRolesTx would also reject it,
+			// but only after passing the keepsAdmin check on the partial map.
+			// Other targets keep the downstream rejection so the relative
+			// precedence of the id and roleIds validation errors is unchanged.
+			if callerID == id && len(roles) != len(roleIDs) {
+				earlyOutcome = &AdminEditUserOutcome{Validation: NewInputValidationInfo("roleIds", "role not found")}
+				return nil
+			}
+			set := make(domain.RoleSet, 0, len(roles))
+			for _, r := range roles {
+				set = append(set, *r)
+			}
+			keepsAdmin = set.ContainsAdmin()
+		}
+		if !keepsAdmin {
+			if callerID == id {
 				earlyOutcome = &AdminEditUserOutcome{CannotRevokeOwnAdmin: true}
+				return nil
+			}
+			// Demoting somebody else: the guard applies only when the target
+			// currently holds the role the submitted set drops. The advisory
+			// lock is taken before that membership read, not inside the guard,
+			// so a target promoted concurrently cannot be read as a non-admin
+			// and skip the guard altogether.
+			if lerr := acquireAdminRoleLock(ctx, tx, u.userRoles, "usecase: admin user edit: count admins"); lerr != nil {
+				guardErr = lerr
+				return nil
+			}
+			isAdmin, herr := u.userRoles.HasRoleTx(ctx, tx, id, domain.AdminRoleName)
+			if herr != nil {
+				if isContextDone(herr) {
+					return herr
+				}
+				return eris.Wrap(herr, "usecase: admin user edit: check admin role")
+			}
+			if gerr := guardNotLastAdmin(
+				ctx,
+				tx,
+				isAdmin,
+				u.userRoles,
+				"usecase: admin user edit: count admins",
+				"cannot remove the admin role from the last admin account",
+			); gerr != nil {
+				guardErr = gerr
 				return nil
 			}
 		}
@@ -376,6 +426,9 @@ func (u *adminUserUsecase) EditUser(ctx context.Context, id string, input AdminE
 
 	if earlyOutcome != nil {
 		return *earlyOutcome, nil
+	}
+	if guardErr != nil {
+		return AdminEditUserOutcome{}, guardErr
 	}
 	if err != nil {
 		if isContextDone(err) {
@@ -410,7 +463,10 @@ func (u *adminUserUsecase) EditUser(ctx context.Context, id string, input AdminE
 //     lockout.
 //  3. Last-admin guard: when the target holds the admin role and is the only
 //     admin, the deletion is refused so the system is never left without an
-//     admin. Best-effort (no row lock) — see DeleteMyAccount for the TOCTOU note.
+//     admin. The membership read, the count and the delete share one
+//     transaction that holds the admin-role advisory lock from before the
+//     membership read, so neither a concurrent admin removal nor a concurrent
+//     promotion of the target can slip between the checks and the delete.
 //
 // A missing target maps to a validation error on "id" (BAD_USER_INPUT).
 func (u *adminUserUsecase) DeleteUser(ctx context.Context, id string) error {
@@ -422,34 +478,43 @@ func (u *adminUserUsecase) DeleteUser(ctx context.Context, id string) error {
 		return ucerr.NewForbiddenError("cannot delete your own account from the admin panel; use deleteMyAccount")
 	}
 
-	// Only consult the global admin count when the target is itself an admin.
-	isAdmin, err := u.userRoles.HasRole(ctx, id, domain.AdminRoleName)
-	if err != nil {
-		if isContextDone(err) {
-			return err
+	return runInTx(ctx, u.tx, func(tx *gorm.DB) error {
+		// The admin-role lock is taken before the membership read so a target
+		// promoted concurrently cannot be read as a non-admin and bypass the
+		// count entirely; only then is the global admin count consulted, and
+		// only when the target is itself an admin.
+		if lerr := acquireAdminRoleLock(ctx, tx, u.userRoles, "usecase: admin user: delete: count admins"); lerr != nil {
+			return lerr
 		}
-		return eris.Wrap(err, "usecase: admin user: delete: check admin role")
-	}
-	if err := guardNotLastAdmin(
-		ctx,
-		isAdmin,
-		u.userRoles,
-		"usecase: admin user: delete: count admins",
-		"cannot delete the last admin account",
-	); err != nil {
-		return err
-	}
+		isAdmin, herr := u.userRoles.HasRoleTx(ctx, tx, id, domain.AdminRoleName)
+		if herr != nil {
+			if isContextDone(herr) {
+				return herr
+			}
+			return eris.Wrap(herr, "usecase: admin user: delete: check admin role")
+		}
+		if gerr := guardNotLastAdmin(
+			ctx,
+			tx,
+			isAdmin,
+			u.userRoles,
+			"usecase: admin user: delete: count admins",
+			"cannot delete the last admin account",
+		); gerr != nil {
+			return gerr
+		}
 
-	if err := u.users.DeleteAuthUser(ctx, id); err != nil {
-		if errors.Is(err, repository.ErrNotFound) {
-			return ucerr.NewValidationError("id", "user not found")
+		if derr := u.users.DeleteAuthUserTx(ctx, tx, id); derr != nil {
+			if errors.Is(derr, repository.ErrNotFound) {
+				return ucerr.NewValidationError("id", "user not found")
+			}
+			if isContextDone(derr) {
+				return derr
+			}
+			return eris.Wrap(derr, "usecase: admin user: delete")
 		}
-		if isContextDone(err) {
-			return err
-		}
-		return eris.Wrap(err, "usecase: admin user: delete")
-	}
-	return nil
+		return nil
+	})
 }
 
 func mapAdminEditMutationError(err error) (*InputValidationInfo, error) {

--- a/backend/internal/usecase/admin_user_test.go
+++ b/backend/internal/usecase/admin_user_test.go
@@ -44,7 +44,7 @@ type mockAdminUserRepository struct {
 	lastListLast   int
 	lastListSearch *string
 
-	// DeleteAuthUser
+	// DeleteAuthUserTx
 	deleteAuthErr    error
 	deleteAuthCalls  int
 	lastDeleteAuthID string
@@ -94,7 +94,7 @@ func (m *mockAdminUserRepository) ListPage(
 	return m.listResult, m.listTotal, nil
 }
 
-func (m *mockAdminUserRepository) DeleteAuthUser(_ context.Context, id string) error {
+func (m *mockAdminUserRepository) DeleteAuthUserTx(_ context.Context, _ *gorm.DB, id string) error {
 	m.deleteAuthCalls++
 	m.lastDeleteAuthID = id
 	return m.deleteAuthErr
@@ -135,15 +135,26 @@ type mockAdminUserRoleRepository struct {
 	lastSetUID     string
 	lastSetRoleIDs []string
 
-	// HasRole — keyed by userID so DeleteUser tests can mark a specific target
+	// HasRoleTx — keyed by userID so DeleteUser tests can mark a specific target
 	// as an admin (or not).
 	hasRoleByUser map[string]bool
 	hasRoleErr    error
 	hasRoleCalls  int
+	// lockCallsAtHasRole snapshots lockCalls the moment HasRoleTx runs, so a
+	// test can prove the advisory lock was taken *before* the membership read
+	// rather than merely before the count.
+	lockCallsAtHasRole int
 
-	// CountAdmins
+	// CountAdminsTx / AcquireAdminRoleLockTx
 	adminCount int64
 	countErr   error
+	lockErr    error
+	// lockCallsAtCount snapshots lockCalls the moment CountAdminsTx runs, so a
+	// test can prove the advisory lock was taken *before* the count rather than
+	// merely at some point during the request.
+	lockCalls        int
+	countCalls       int
+	lockCallsAtCount int
 }
 
 func (m *mockAdminUserRoleRepository) SetUserRolesTx(_ context.Context, _ *gorm.DB, userID string, roleIDs []string) error {
@@ -153,15 +164,23 @@ func (m *mockAdminUserRoleRepository) SetUserRolesTx(_ context.Context, _ *gorm.
 	return m.setErr
 }
 
-func (m *mockAdminUserRoleRepository) HasRole(_ context.Context, userID string, _ domain.RoleName) (bool, error) {
+func (m *mockAdminUserRoleRepository) HasRoleTx(_ context.Context, _ *gorm.DB, userID string, _ domain.RoleName) (bool, error) {
 	m.hasRoleCalls++
+	m.lockCallsAtHasRole = m.lockCalls
 	if m.hasRoleErr != nil {
 		return false, m.hasRoleErr
 	}
 	return m.hasRoleByUser[userID], nil
 }
 
-func (m *mockAdminUserRoleRepository) CountAdmins(_ context.Context) (int64, error) {
+func (m *mockAdminUserRoleRepository) AcquireAdminRoleLockTx(_ context.Context, _ *gorm.DB) error {
+	m.lockCalls++
+	return m.lockErr
+}
+
+func (m *mockAdminUserRoleRepository) CountAdminsTx(_ context.Context, _ *gorm.DB) (int64, error) {
+	m.countCalls++
+	m.lockCallsAtCount = m.lockCalls
 	return m.adminCount, m.countErr
 }
 
@@ -329,7 +348,7 @@ func TestAdminUserUsecase_DeleteUser(t *testing.T) {
 
 		assertForbidden(t, err, "cannot delete your own account from the admin panel; use deleteMyAccount")
 		if users.deleteAuthCalls != 0 {
-			t.Fatalf("DeleteAuthUser must not run on self-deletion, got %d calls", users.deleteAuthCalls)
+			t.Fatalf("DeleteAuthUserTx must not run on self-deletion, got %d calls", users.deleteAuthCalls)
 		}
 		if userRoles.hasRoleCalls != 0 {
 			t.Fatalf("HasRole must not run on self-deletion, got %d calls", userRoles.hasRoleCalls)
@@ -349,7 +368,7 @@ func TestAdminUserUsecase_DeleteUser(t *testing.T) {
 
 		assertForbidden(t, err, "cannot delete the last admin account")
 		if users.deleteAuthCalls != 0 {
-			t.Fatalf("DeleteAuthUser must not run when the target is the last admin, got %d calls", users.deleteAuthCalls)
+			t.Fatalf("DeleteAuthUserTx must not run when the target is the last admin, got %d calls", users.deleteAuthCalls)
 		}
 	})
 
@@ -367,7 +386,7 @@ func TestAdminUserUsecase_DeleteUser(t *testing.T) {
 			t.Fatalf("DeleteUser: unexpected error: %v", err)
 		}
 		if users.deleteAuthCalls != 1 || users.lastDeleteAuthID != "target" {
-			t.Fatalf("DeleteAuthUser: calls=%d id=%q, want 1 and \"target\"", users.deleteAuthCalls, users.lastDeleteAuthID)
+			t.Fatalf("DeleteAuthUserTx: calls=%d id=%q, want 1 and \"target\"", users.deleteAuthCalls, users.lastDeleteAuthID)
 		}
 	})
 
@@ -386,7 +405,7 @@ func TestAdminUserUsecase_DeleteUser(t *testing.T) {
 			t.Fatalf("DeleteUser: unexpected error: %v", err)
 		}
 		if users.deleteAuthCalls != 1 {
-			t.Fatalf("DeleteAuthUser: calls=%d, want 1", users.deleteAuthCalls)
+			t.Fatalf("DeleteAuthUserTx: calls=%d, want 1", users.deleteAuthCalls)
 		}
 	})
 
@@ -1077,6 +1096,303 @@ func TestAdminUser_EditUser_Self_NoRolesSubmitted_CannotRevokeOwnAdmin(t *testin
 	}
 	if userRoles.setCalls != 0 {
 		t.Fatalf("SetUserRolesTx calls = %d, want 0 (guard aborts before write)", userRoles.setCalls)
+	}
+}
+
+// TestAdminUser_EditUser_DemoteOther_LastAdmin exercises the demote-other
+// branch of the last-admin guard: an admin submits a role set that drops the
+// admin role from another user who is currently the only admin. The rejection
+// carries the same shape as DeleteUser's last-admin rejection — a
+// *ucerr.ForbiddenError on the error channel, not an outcome field — and no
+// write reaches the repository.
+func TestAdminUser_EditUser_DemoteOther_LastAdmin(t *testing.T) {
+	t.Parallel()
+
+	users := &mockAdminUserRepository{users: map[string]*domain.User{"target": {ID: "target"}}}
+	roles := &mockAdminRoleRepository{
+		roles: map[string]*domain.Role{
+			"r-general": {ID: "r-general", Name: "general"},
+		},
+	}
+	userRoles := &mockAdminUserRoleRepository{
+		hasRoleByUser: map[string]bool{"target": true},
+		adminCount:    1,
+	}
+	authChk := &adminAuthChecker{admins: map[string]bool{"admin-1": true}}
+	uc, _, _, _ := buildAdminUC(users, roles, userRoles, authChk)
+
+	outcome, err := uc.EditUser(adminCallerCtx("admin-1"), "target", AdminEditUserInput{
+		RoleIDs: []string{"r-general"},
+	})
+
+	assertForbidden(t, err, "cannot remove the admin role from the last admin account")
+	if outcome.User != nil || outcome.Validation != nil || outcome.CannotRevokeOwnAdmin || outcome.ConcurrentUpdate {
+		t.Fatalf("outcome must be zero when the guard rejects, got %+v", outcome)
+	}
+	if users.updateTxCalls != 0 {
+		t.Fatalf("UpdateTxVersioned calls = %d, want 0 (guard aborts before any write)", users.updateTxCalls)
+	}
+	if userRoles.setCalls != 0 {
+		t.Fatalf("SetUserRolesTx calls = %d, want 0 (guard aborts before any write)", userRoles.setCalls)
+	}
+	// The count must be read while the advisory lock is held; otherwise two
+	// mutual demotions each observe two admins and both commit.
+	if userRoles.countCalls != 1 || userRoles.lockCallsAtCount != 1 {
+		t.Fatalf("count=%d lockCallsAtCount=%d, want the admin count read once under the lock",
+			userRoles.countCalls, userRoles.lockCallsAtCount)
+	}
+}
+
+// TestAdminUser_EditUser_DemoteOther_NotLastAdmin proves the guard only blocks
+// the last admin: with another admin left, the demotion goes through.
+func TestAdminUser_EditUser_DemoteOther_NotLastAdmin(t *testing.T) {
+	t.Parallel()
+
+	target := &domain.User{ID: "target"}
+	users := &mockAdminUserRepository{users: map[string]*domain.User{"target": target}}
+	roles := &mockAdminRoleRepository{
+		roles: map[string]*domain.Role{
+			"r-general": {ID: "r-general", Name: "general"},
+		},
+	}
+	userRoles := &mockAdminUserRoleRepository{
+		hasRoleByUser: map[string]bool{"target": true},
+		adminCount:    2,
+	}
+	authChk := &adminAuthChecker{admins: map[string]bool{"admin-1": true}}
+	uc, _, _, _ := buildAdminUC(users, roles, userRoles, authChk)
+
+	outcome, err := uc.EditUser(adminCallerCtx("admin-1"), "target", AdminEditUserInput{
+		RoleIDs: []string{"r-general"},
+	})
+	if err != nil {
+		t.Fatalf("EditUser: unexpected error: %v", err)
+	}
+	assertAdminEditUserOutcomeXOR(t, outcome)
+	if outcome.User != target {
+		t.Fatalf("outcome.User = %v, want %v", outcome.User, target)
+	}
+	if userRoles.setCalls != 1 {
+		t.Fatalf("SetUserRolesTx calls = %d, want 1", userRoles.setCalls)
+	}
+}
+
+// TestAdminUser_EditUser_DemoteOther_NonAdminTargetSkipsCount proves the guard
+// short-circuits for a target that does not hold the admin role: a blocking
+// admin count is configured, and the edit still succeeds because the count is
+// never consulted.
+func TestAdminUser_EditUser_DemoteOther_NonAdminTargetSkipsCount(t *testing.T) {
+	t.Parallel()
+
+	target := &domain.User{ID: "target"}
+	users := &mockAdminUserRepository{users: map[string]*domain.User{"target": target}}
+	roles := &mockAdminRoleRepository{
+		roles: map[string]*domain.Role{
+			"r-general": {ID: "r-general", Name: "general"},
+		},
+	}
+	// "target" is absent from hasRoleByUser → not an admin. adminCount is set to
+	// a blocking value to prove the count is never consulted.
+	userRoles := &mockAdminUserRoleRepository{adminCount: 1}
+	authChk := &adminAuthChecker{admins: map[string]bool{"admin-1": true}}
+	uc, _, _, _ := buildAdminUC(users, roles, userRoles, authChk)
+
+	outcome, err := uc.EditUser(adminCallerCtx("admin-1"), "target", AdminEditUserInput{
+		RoleIDs: []string{"r-general"},
+	})
+	if err != nil {
+		t.Fatalf("EditUser: unexpected error: %v", err)
+	}
+	if outcome.User != target {
+		t.Fatalf("outcome.User = %v, want %v", outcome.User, target)
+	}
+	if userRoles.countCalls != 0 {
+		t.Fatalf("count=%d, want 0 for a non-admin target", userRoles.countCalls)
+	}
+	// The lock is still taken once: the membership read that decides the target
+	// is a non-admin must itself happen under it, otherwise a target promoted
+	// concurrently is read as a non-admin and skips the count entirely.
+	if userRoles.lockCalls != 1 || userRoles.hasRoleCalls != 1 || userRoles.lockCallsAtHasRole != 1 {
+		t.Fatalf("lock=%d hasRole=%d lockCallsAtHasRole=%d, want the membership read taken once under the lock",
+			userRoles.lockCalls, userRoles.hasRoleCalls, userRoles.lockCallsAtHasRole)
+	}
+}
+
+// TestAdminUser_EditUser_DemoteOther_KeepingAdminSkipsGuard proves the guard is
+// keyed on the submitted set dropping admin, not on the edit touching an admin:
+// a role set that retains admin never consults the count.
+func TestAdminUser_EditUser_DemoteOther_KeepingAdminSkipsGuard(t *testing.T) {
+	t.Parallel()
+
+	target := &domain.User{ID: "target"}
+	users := &mockAdminUserRepository{users: map[string]*domain.User{"target": target}}
+	roles := &mockAdminRoleRepository{
+		roles: map[string]*domain.Role{
+			"r-admin": {ID: "r-admin", Name: "admin"},
+		},
+	}
+	userRoles := &mockAdminUserRoleRepository{
+		hasRoleByUser: map[string]bool{"target": true},
+		adminCount:    1,
+	}
+	authChk := &adminAuthChecker{admins: map[string]bool{"admin-1": true}}
+	uc, _, _, _ := buildAdminUC(users, roles, userRoles, authChk)
+
+	outcome, err := uc.EditUser(adminCallerCtx("admin-1"), "target", AdminEditUserInput{
+		RoleIDs: []string{"r-admin"},
+	})
+	if err != nil {
+		t.Fatalf("EditUser: unexpected error: %v", err)
+	}
+	if outcome.User != target {
+		t.Fatalf("outcome.User = %v, want %v", outcome.User, target)
+	}
+	if userRoles.hasRoleCalls != 0 || userRoles.countCalls != 0 {
+		t.Fatalf("hasRole=%d count=%d, want neither when the submitted set keeps admin",
+			userRoles.hasRoleCalls, userRoles.countCalls)
+	}
+}
+
+// TestAdminUser_EditUser_DemoteOther_CountAdminsInfraError pins the wrap prefix
+// applied when the guard's count fails for an infrastructure reason, so the
+// logged error_chain attributes the failure to the edit module.
+func TestAdminUser_EditUser_DemoteOther_CountAdminsInfraError(t *testing.T) {
+	t.Parallel()
+
+	users := &mockAdminUserRepository{users: map[string]*domain.User{"target": {ID: "target"}}}
+	roles := &mockAdminRoleRepository{
+		roles: map[string]*domain.Role{
+			"r-general": {ID: "r-general", Name: "general"},
+		},
+	}
+	userRoles := &mockAdminUserRoleRepository{
+		hasRoleByUser: map[string]bool{"target": true},
+		countErr:      errors.New("boom"),
+	}
+	authChk := &adminAuthChecker{admins: map[string]bool{"admin-1": true}}
+	uc, _, _, _ := buildAdminUC(users, roles, userRoles, authChk)
+
+	_, err := uc.EditUser(adminCallerCtx("admin-1"), "target", AdminEditUserInput{
+		RoleIDs: []string{"r-general"},
+	})
+
+	assertInternalChain(t, err, "usecase: admin user edit: count admins")
+	if users.updateTxCalls != 0 {
+		t.Fatalf("UpdateTxVersioned calls = %d, want 0", users.updateTxCalls)
+	}
+}
+
+// demoteOtherLockFailureUC wires the demote-other fixture with a failing
+// AcquireAdminRoleLockTx so both lock-failure tests below share one setup.
+func demoteOtherLockFailureUC(lockErr error) (AdminUserUsecase, *mockAdminUserRepository, *mockAdminUserRoleRepository) {
+	users := &mockAdminUserRepository{users: map[string]*domain.User{"target": {ID: "target"}}}
+	roles := &mockAdminRoleRepository{
+		roles: map[string]*domain.Role{
+			"r-general": {ID: "r-general", Name: "general"},
+		},
+	}
+	userRoles := &mockAdminUserRoleRepository{
+		hasRoleByUser: map[string]bool{"target": true},
+		adminCount:    2,
+		lockErr:       lockErr,
+	}
+	authChk := &adminAuthChecker{admins: map[string]bool{"admin-1": true}}
+	uc, _, _, _ := buildAdminUC(users, roles, userRoles, authChk)
+	return uc, users, userRoles
+}
+
+// TestAdminUser_EditUser_DemoteOther_AcquireAdminRoleLockInfraError pins the
+// fail-closed behaviour when the advisory lock cannot be taken: the request
+// aborts before the membership read, before the count, and before any write.
+// Swallowing the lock error and continuing would count without holding the
+// lock, reopening the mutual-demotion race the lock exists to close.
+func TestAdminUser_EditUser_DemoteOther_AcquireAdminRoleLockInfraError(t *testing.T) {
+	t.Parallel()
+
+	uc, users, userRoles := demoteOtherLockFailureUC(errors.New("boom"))
+
+	_, err := uc.EditUser(adminCallerCtx("admin-1"), "target", AdminEditUserInput{
+		RoleIDs: []string{"r-general"},
+	})
+
+	assertInternalChain(t, err, "usecase: admin user edit: count admins")
+	if userRoles.hasRoleCalls != 0 || userRoles.countCalls != 0 {
+		t.Fatalf("hasRole=%d count=%d, want neither once the lock could not be taken",
+			userRoles.hasRoleCalls, userRoles.countCalls)
+	}
+	if users.updateTxCalls != 0 || userRoles.setCalls != 0 {
+		t.Fatalf("updateTx=%d set=%d, want no write once the lock could not be taken",
+			users.updateTxCalls, userRoles.setCalls)
+	}
+}
+
+// TestAdminUser_EditUser_DemoteOther_AcquireAdminRoleLockCancelled proves a
+// cancelled context surfaces unwrapped from the lock-failure branch.
+func TestAdminUser_EditUser_DemoteOther_AcquireAdminRoleLockCancelled(t *testing.T) {
+	t.Parallel()
+
+	uc, _, userRoles := demoteOtherLockFailureUC(context.Canceled)
+
+	_, err := uc.EditUser(adminCallerCtx("admin-1"), "target", AdminEditUserInput{
+		RoleIDs: []string{"r-general"},
+	})
+
+	assertCancelled(t, err)
+	if userRoles.countCalls != 0 {
+		t.Fatalf("count = %d, want 0 once the lock could not be taken", userRoles.countCalls)
+	}
+}
+
+// TestAdminUser_DeleteUser_AcquireAdminRoleLockInfraError is the DeleteUser
+// twin of the EditUser lock-failure test above.
+func TestAdminUser_DeleteUser_AcquireAdminRoleLockInfraError(t *testing.T) {
+	t.Parallel()
+
+	users := &mockAdminUserRepository{}
+	userRoles := &mockAdminUserRoleRepository{
+		hasRoleByUser: map[string]bool{"target": true},
+		adminCount:    2,
+		lockErr:       errors.New("boom"),
+	}
+	authChk := &adminAuthChecker{admins: map[string]bool{"admin-1": true}}
+	uc, _, _, _ := buildAdminUC(users, nil, userRoles, authChk)
+
+	err := uc.DeleteUser(adminCallerCtx("admin-1"), "target")
+
+	assertInternalChain(t, err, "usecase: admin user: delete: count admins")
+	if userRoles.hasRoleCalls != 0 || userRoles.countCalls != 0 {
+		t.Fatalf("hasRole=%d count=%d, want neither once the lock could not be taken",
+			userRoles.hasRoleCalls, userRoles.countCalls)
+	}
+	if users.deleteAuthCalls != 0 {
+		t.Fatalf("DeleteAuthUserTx calls = %d, want 0 once the lock could not be taken", users.deleteAuthCalls)
+	}
+}
+
+// TestAdminUser_DeleteUser_MembershipReadTakenUnderLock pins the ordering the
+// guard depends on: the target's admin membership is read only after the
+// advisory lock is held. A read taken before the lock can observe a target that
+// a concurrent request is about to promote, skipping the count entirely.
+func TestAdminUser_DeleteUser_MembershipReadTakenUnderLock(t *testing.T) {
+	t.Parallel()
+
+	users := &mockAdminUserRepository{}
+	userRoles := &mockAdminUserRoleRepository{
+		hasRoleByUser: map[string]bool{"target": true},
+		adminCount:    2,
+	}
+	authChk := &adminAuthChecker{admins: map[string]bool{"admin-1": true}}
+	uc, _, _, _ := buildAdminUC(users, nil, userRoles, authChk)
+
+	if err := uc.DeleteUser(adminCallerCtx("admin-1"), "target"); err != nil {
+		t.Fatalf("DeleteUser: unexpected error: %v", err)
+	}
+	if userRoles.hasRoleCalls != 1 || userRoles.lockCallsAtHasRole != 1 {
+		t.Fatalf("hasRole=%d lockCallsAtHasRole=%d, want the membership read taken once under the lock",
+			userRoles.hasRoleCalls, userRoles.lockCallsAtHasRole)
+	}
+	if userRoles.lockCallsAtCount != 1 {
+		t.Fatalf("lockCallsAtCount = %d, want the count read under the same lock", userRoles.lockCallsAtCount)
 	}
 }
 

--- a/backend/internal/usecase/helpers_test.go
+++ b/backend/internal/usecase/helpers_test.go
@@ -155,10 +155,17 @@ type mockAdminChecker struct {
 	isAdmin bool
 	err     error
 	calls   int
+	// onCall, when set, runs at the top of IsAdmin. Tests use it to snapshot
+	// sibling-mock counters and assert call ordering (e.g. that the admin-role
+	// advisory lock was already taken when the membership read happened).
+	onCall func()
 }
 
 func (m *mockAdminChecker) IsAdmin(_ context.Context, _ string) (bool, error) {
 	m.calls++
+	if m.onCall != nil {
+		m.onCall()
+	}
 	if m.err != nil {
 		return false, m.err
 	}

--- a/backend/internal/usecase/last_admin_guard.go
+++ b/backend/internal/usecase/last_admin_guard.go
@@ -4,32 +4,66 @@ import (
 	"context"
 
 	"github.com/rotisserie/eris"
+	"gorm.io/gorm"
 
 	"backend/internal/domain"
 	"backend/internal/usecase/ucerr"
 )
 
-// AdminCounter reports the number of users holding the admin role. It is the
-// narrow port consumed by guardNotLastAdmin; both adminUserRoleRepository
-// (DeleteUser) and UserRolesRepository (DeleteMyAccount) satisfy it via their
-// CountAdmins method.
+// AdminCounter serializes and reports the number of users holding the admin
+// role. It is the narrow port consumed by acquireAdminRoleLock and
+// guardNotLastAdmin; both
+// adminUserRoleRepository (EditUser, DeleteUser) and UserRolesRepository
+// (DeleteMyAccount) satisfy it via their AcquireAdminRoleLockTx and
+// CountAdminsTx methods.
 type AdminCounter interface {
-	CountAdmins(ctx context.Context) (int64, error)
+	AcquireAdminRoleLockTx(ctx context.Context, tx *gorm.DB) error
+	CountAdminsTx(ctx context.Context, tx *gorm.DB) (int64, error)
 }
 
-// guardNotLastAdmin enforces the "never delete the last admin" availability
-// invariant shared by DeleteUser and DeleteMyAccount. When isTargetAdmin is
-// true and the account being removed is the only remaining admin, it returns a
-// forbidden error carrying forbidMsg so the system is never left without an
-// admin. When isTargetAdmin is false the admin count is never consulted.
+// acquireAdminRoleLock takes the admin-role advisory lock inside the caller's
+// transaction. Every request that may remove an admin must call it before
+// reading whether its target currently holds the admin role, so the membership
+// read, the admin count, and the mutation they guard form one serialized unit.
 //
-// The membership decision differs per caller (HasRole for an arbitrary target
+// Taking the lock only after the membership read reopens the race the lock
+// exists to close: a target read as a non-admin (so the guard is skipped
+// entirely) can be promoted concurrently, and the demotion or deletion then
+// commits against a target that has since become the last admin.
+//
+// wrapPrefix is caller-supplied so the repository failure is attributed to the
+// calling module, not this helper, per the shared-helper rule in
+// .claude/rules/error-wrapping.md.
+func acquireAdminRoleLock(ctx context.Context, tx *gorm.DB, counter AdminCounter, wrapPrefix string) error {
+	if err := counter.AcquireAdminRoleLockTx(ctx, tx); err != nil {
+		if isContextDone(err) {
+			return err
+		}
+		return eris.Wrap(err, wrapPrefix)
+	}
+	return nil
+}
+
+// guardNotLastAdmin enforces the "never leave the system without an admin"
+// availability invariant shared by EditUser's demote-other branch, DeleteUser,
+// and DeleteMyAccount. When isTargetAdmin is true and the account losing the
+// admin role is the only remaining admin, it returns a forbidden error carrying
+// forbidMsg. When isTargetAdmin is false the admin count is never consulted.
+//
+// Precondition: the caller already holds the admin-role advisory lock, taken
+// via acquireAdminRoleLock inside tx, and read isTargetAdmin under it. The
+// count is then read inside the same transaction while the lock is held, so the
+// guard and the mutation it protects are serialized against every other request
+// that can remove an admin. Without the lock the check is a pure TOCTOU: two
+// callers each demoting the other observe two admins, both pass, and both
+// commit, leaving zero admins.
+//
+// The membership decision differs per caller (HasRoleTx for an arbitrary target
 // vs IsAdmin for the caller), so it is computed at the call site and passed in
-// as isTargetAdmin. wrapPrefix and forbidMsg are likewise caller-supplied: the
-// wrap prefix must attribute the CountAdmins failure to the calling module, not
-// this helper, per the shared-helper rule in .claude/rules/error-wrapping.md.
+// as isTargetAdmin. wrapPrefix and forbidMsg are likewise caller-supplied.
 func guardNotLastAdmin(
 	ctx context.Context,
+	tx *gorm.DB,
 	isTargetAdmin bool,
 	counter AdminCounter,
 	wrapPrefix string,
@@ -38,7 +72,7 @@ func guardNotLastAdmin(
 	if !isTargetAdmin {
 		return nil
 	}
-	n, err := counter.CountAdmins(ctx)
+	n, err := counter.CountAdminsTx(ctx, tx)
 	if err != nil {
 		if isContextDone(err) {
 			return err

--- a/backend/internal/usecase/tx.go
+++ b/backend/internal/usecase/tx.go
@@ -13,6 +13,20 @@ import (
 // cardImportUsecase, and MasterNotionSyncUsecase.
 type txRunner func(ctx context.Context, fn func(tx *gorm.DB) error) error
 
+// runInTx executes fn inside run's transaction. A nil run — the shape
+// newTxRunner produces when the composition root has no *gorm.DB, which happens
+// only in tests that inject repository fakes — invokes fn directly with a nil
+// handle: the fakes ignore it, and production always wires a real runner. Use
+// this from methods whose transaction is a correctness requirement rather than
+// an optional optimisation, so a test constructor without a database does not
+// have to fabricate one.
+func runInTx(ctx context.Context, run txRunner, fn func(tx *gorm.DB) error) error {
+	if run == nil {
+		return fn(nil)
+	}
+	return run(ctx, fn)
+}
+
 // newTxRunner returns the production txRunner backed by db, or nil when db is
 // nil so callers can leave the field unset for explicit-tx test constructors.
 func newTxRunner(db *gorm.DB) txRunner {

--- a/backend/internal/usecase/user.go
+++ b/backend/internal/usecase/user.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 
 	"github.com/rotisserie/eris"
+	"gorm.io/gorm"
 
 	"backend/internal/auth"
 	"backend/internal/domain"
@@ -19,16 +20,21 @@ import (
 type UserRepository interface {
 	FindByID(ctx context.Context, id string) (*domain.User, error)
 	Update(ctx context.Context, id string, patch repository.UserUpdate) (*domain.User, error)
-	// DeleteAuthUser deletes the caller's auth.users row, cascading to all
-	// associated data. See repository.UserRepository.DeleteAuthUser for details.
-	DeleteAuthUser(ctx context.Context, id string) error
+	// DeleteAuthUserTx deletes the caller's auth.users row inside the caller's
+	// transaction, cascading to all associated data. See
+	// repository.UserRepository.DeleteAuthUserTx for details.
+	DeleteAuthUserTx(ctx context.Context, tx *gorm.DB, id string) error
 }
 
 type UserRolesRepository interface {
 	ListByUser(ctx context.Context, userID string) ([]*domain.Role, error)
-	// CountAdmins returns the number of users holding the admin role. Used by
+	// AcquireAdminRoleLockTx serializes admin-count-changing mutations; see
+	// repository.UserRoleRepository for the race it closes.
+	AcquireAdminRoleLockTx(ctx context.Context, tx *gorm.DB) error
+	// CountAdminsTx returns the number of users holding the admin role, read
+	// inside the caller's transaction under the lock above. Used by
 	// DeleteMyAccount's last-admin guard.
-	CountAdmins(ctx context.Context) (int64, error)
+	CountAdminsTx(ctx context.Context, tx *gorm.DB) (int64, error)
 }
 
 // UserUsecase is the authenticated user profile and role-query surface.
@@ -45,15 +51,18 @@ type userUsecase struct {
 	repo   UserRepository
 	roles  UserRolesRepository
 	auth   AdminChecker
+	tx     txRunner
 	logger *slog.Logger
 }
 
-// NewUserUsecase constructs the user profile usecase.
-func NewUserUsecase(repo UserRepository, roles UserRolesRepository, authSvc AdminChecker, logger *slog.Logger) UserUsecase {
+// NewUserUsecase constructs the user profile usecase. db backs the transaction
+// runner that scopes DeleteMyAccount's last-admin guard together with the
+// delete; tests that inject repository fakes may pass nil (see runInTx).
+func NewUserUsecase(db *gorm.DB, repo UserRepository, roles UserRolesRepository, authSvc AdminChecker, logger *slog.Logger) UserUsecase {
 	if logger == nil {
 		panic("usecase: user: logger is required")
 	}
-	return &userUsecase{repo: repo, roles: roles, auth: authSvc, logger: logger}
+	return &userUsecase{repo: repo, roles: roles, auth: authSvc, tx: newTxRunner(db), logger: logger}
 }
 
 func (u *userUsecase) Me(ctx context.Context) (*domain.User, error) {
@@ -170,9 +179,10 @@ func buildUserProfilePatch(displayName *string, bio *string) (repository.UserUpd
 //  1. Authentication: no caller on the context returns ucerr.ErrUnauthenticated.
 //  2. Last-admin guard: if the caller holds the admin role and is the only admin,
 //     return a forbidden error so the system is never left without an admin.
-//     This is best-effort (no row lock): a concurrent admin deletion could race
-//     past the count. At this app's scale the TOCTOU window is acceptable; a
-//     Postgres advisory lock is the upgrade path if it ever matters.
+//     The admin-role advisory lock is taken at the front of the transaction,
+//     before the caller's admin membership is read, so neither a concurrent
+//     admin removal nor a concurrent promotion of the caller can race past the
+//     count; the guard and the delete then commit under the same lock.
 //
 // A missing auth.users row at delete time is treated as idempotent success — the
 // account is already gone from the system's perspective.
@@ -185,31 +195,40 @@ func (u *userUsecase) DeleteMyAccount(ctx context.Context) error {
 	if u.auth == nil || u.roles == nil {
 		return eris.New("usecase: user: delete my account: admin guard deps not configured")
 	}
-	isAdmin, err := u.auth.IsAdmin(ctx, caller.Sub)
-	if err != nil {
-		if isContextDone(err) {
-			return err
+	return runInTx(ctx, u.tx, func(tx *gorm.DB) error {
+		if lerr := acquireAdminRoleLock(ctx, tx, u.roles, "usecase: user: delete my account: count admins"); lerr != nil {
+			return lerr
 		}
-		return eris.Wrap(err, "usecase: user: delete my account: check admin")
-	}
-	if err := guardNotLastAdmin(
-		ctx,
-		isAdmin,
-		u.roles,
-		"usecase: user: delete my account: count admins",
-		"cannot delete the last admin account; promote another admin first",
-	); err != nil {
-		return err
-	}
+		// Read the caller's admin membership only once the lock is held: a
+		// caller promoted to admin between an unlocked read and the delete
+		// would skip the guard and could empty the admin set.
+		isAdmin, aerr := u.auth.IsAdmin(ctx, caller.Sub)
+		if aerr != nil {
+			if isContextDone(aerr) {
+				return aerr
+			}
+			return eris.Wrap(aerr, "usecase: user: delete my account: check admin")
+		}
+		if gerr := guardNotLastAdmin(
+			ctx,
+			tx,
+			isAdmin,
+			u.roles,
+			"usecase: user: delete my account: count admins",
+			"cannot delete the last admin account; promote another admin first",
+		); gerr != nil {
+			return gerr
+		}
 
-	if err := u.repo.DeleteAuthUser(ctx, caller.Sub); err != nil {
-		if errors.Is(err, repository.ErrNotFound) {
-			return nil
+		if derr := u.repo.DeleteAuthUserTx(ctx, tx, caller.Sub); derr != nil {
+			if errors.Is(derr, repository.ErrNotFound) {
+				return nil
+			}
+			if isContextDone(derr) {
+				return derr
+			}
+			return eris.Wrap(derr, "usecase: user: delete my account")
 		}
-		if isContextDone(err) {
-			return err
-		}
-		return eris.Wrap(err, "usecase: user: delete my account")
-	}
-	return nil
+		return nil
+	})
 }

--- a/backend/internal/usecase/user_test.go
+++ b/backend/internal/usecase/user_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 
+	"gorm.io/gorm"
+
 	"backend/internal/auth"
 	"backend/internal/domain"
 	"backend/internal/repository"
@@ -33,7 +35,7 @@ func (m *mockUserRepository) Update(_ context.Context, _ string, patch repositor
 	return m.updateResult, m.updateErr
 }
 
-func (m *mockUserRepository) DeleteAuthUser(_ context.Context, id string) error {
+func (m *mockUserRepository) DeleteAuthUserTx(_ context.Context, _ *gorm.DB, id string) error {
 	m.deleteAuthCalls++
 	m.lastDeleteAuthID = id
 	return m.deleteAuthErr
@@ -47,6 +49,9 @@ type mockUserRolesRepository struct {
 
 	adminCount     int64
 	countAdminsErr error
+	lockErr        error
+	lockCalls      int
+	countCalls     int
 }
 
 func (m *mockUserRolesRepository) ListByUser(_ context.Context, userID string) ([]*domain.Role, error) {
@@ -55,7 +60,15 @@ func (m *mockUserRolesRepository) ListByUser(_ context.Context, userID string) (
 	return m.roles, m.err
 }
 
-func (m *mockUserRolesRepository) CountAdmins(_ context.Context) (int64, error) {
+// AcquireAdminRoleLockTx records that the guard serialized before counting; the
+// counter asserts the lock is taken ahead of every count.
+func (m *mockUserRolesRepository) AcquireAdminRoleLockTx(_ context.Context, _ *gorm.DB) error {
+	m.lockCalls++
+	return m.lockErr
+}
+
+func (m *mockUserRolesRepository) CountAdminsTx(_ context.Context, _ *gorm.DB) (int64, error) {
+	m.countCalls++
 	return m.adminCount, m.countAdminsErr
 }
 
@@ -120,7 +133,7 @@ func TestUserUsecase_Me(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			repo := &mockUserRepository{findResult: tc.findResult, findErr: tc.findErr}
-			uc := NewUserUsecase(repo, nil, nil, newTestLogger())
+			uc := NewUserUsecase(nil, repo, nil, nil, newTestLogger())
 
 			p, err := uc.Me(tc.ctx)
 
@@ -299,7 +312,7 @@ func TestUserUsecase_UpdateUser(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			repo := &mockUserRepository{updateResult: tc.repoResult, updateErr: tc.repoErr}
-			uc := NewUserUsecase(repo, nil, nil, newTestLogger())
+			uc := NewUserUsecase(nil, repo, nil, nil, newTestLogger())
 
 			outcome, err := uc.UpdateUser(tc.ctx, tc.input)
 
@@ -373,7 +386,7 @@ func TestUserUsecase_UpdateUser_SuccessVariant(t *testing.T) {
 
 	returned := &domain.User{ID: "u1", DisplayName: dnPtr("Alice")}
 	repo := &mockUserRepository{updateResult: returned}
-	uc := NewUserUsecase(repo, nil, nil, newTestLogger())
+	uc := NewUserUsecase(nil, repo, nil, nil, newTestLogger())
 
 	outcome, err := uc.UpdateUser(authedCtx("u1"), UpdateUserInput{DisplayName: "Alice"})
 
@@ -392,7 +405,7 @@ func TestUserUsecase_UpdateUser_ValidationVariant_DisplayName(t *testing.T) {
 	t.Parallel()
 
 	repo := &mockUserRepository{}
-	uc := NewUserUsecase(repo, nil, nil, newTestLogger())
+	uc := NewUserUsecase(nil, repo, nil, nil, newTestLogger())
 
 	outcome, err := uc.UpdateUser(authedCtx("u1"), UpdateUserInput{DisplayName: ""})
 
@@ -417,7 +430,7 @@ func TestUserUsecase_UpdateUser_ValidationVariant_Bio(t *testing.T) {
 	t.Parallel()
 
 	repo := &mockUserRepository{}
-	uc := NewUserUsecase(repo, nil, nil, newTestLogger())
+	uc := NewUserUsecase(nil, repo, nil, nil, newTestLogger())
 
 	outcome, err := uc.UpdateUser(authedCtx("u1"), UpdateUserInput{
 		DisplayName: "Alice",
@@ -445,7 +458,7 @@ func TestUserUsecase_UpdateUser_RepoError_InfraChannel(t *testing.T) {
 	t.Parallel()
 
 	repo := &mockUserRepository{updateErr: errors.New("db: storage failure")}
-	uc := NewUserUsecase(repo, nil, nil, newTestLogger())
+	uc := NewUserUsecase(nil, repo, nil, nil, newTestLogger())
 
 	_, err := uc.UpdateUser(authedCtx("u1"), UpdateUserInput{DisplayName: "Alice"})
 
@@ -464,7 +477,7 @@ func TestUserUsecase_DeleteMyAccount(t *testing.T) {
 
 	t.Run("unauthenticated", func(t *testing.T) {
 		t.Parallel()
-		uc := NewUserUsecase(&mockUserRepository{}, &mockUserRolesRepository{}, &mockAdminChecker{}, newTestLogger())
+		uc := NewUserUsecase(nil, &mockUserRepository{}, &mockUserRolesRepository{}, &mockAdminChecker{}, newTestLogger())
 		assertUnauthenticated(t, uc.DeleteMyAccount(anonCtx()))
 	})
 
@@ -473,13 +486,26 @@ func TestUserUsecase_DeleteMyAccount(t *testing.T) {
 		repo := &mockUserRepository{}
 		// adminCount is a blocking value to prove it is never consulted for non-admins.
 		roles := &mockUserRolesRepository{adminCount: 1}
-		uc := NewUserUsecase(repo, roles, &mockAdminChecker{isAdmin: false}, newTestLogger())
+		lockCallsAtIsAdmin := -1
+		authChk := &mockAdminChecker{isAdmin: false}
+		authChk.onCall = func() { lockCallsAtIsAdmin = roles.lockCalls }
+		uc := NewUserUsecase(nil, repo, roles, authChk, newTestLogger())
 
 		if err := uc.DeleteMyAccount(authedCtx(caller)); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if repo.deleteAuthCalls != 1 || repo.lastDeleteAuthID != caller {
-			t.Fatalf("DeleteAuthUser: calls=%d id=%q, want 1 and %q", repo.deleteAuthCalls, repo.lastDeleteAuthID, caller)
+			t.Fatalf("DeleteAuthUserTx: calls=%d id=%q, want 1 and %q", repo.deleteAuthCalls, repo.lastDeleteAuthID, caller)
+		}
+		if roles.countCalls != 0 {
+			t.Fatalf("count=%d, want 0 for a non-admin caller", roles.countCalls)
+		}
+		// The lock is still taken once: the membership read that decides the
+		// caller is a non-admin must itself happen under it, otherwise a caller
+		// promoted concurrently is read as a non-admin and skips the count.
+		if roles.lockCalls != 1 || lockCallsAtIsAdmin != 1 {
+			t.Fatalf("lock=%d lockCallsAtIsAdmin=%d, want the membership read taken once under the lock",
+				roles.lockCalls, lockCallsAtIsAdmin)
 		}
 	})
 
@@ -487,13 +513,13 @@ func TestUserUsecase_DeleteMyAccount(t *testing.T) {
 		t.Parallel()
 		repo := &mockUserRepository{}
 		roles := &mockUserRolesRepository{adminCount: 2}
-		uc := NewUserUsecase(repo, roles, &mockAdminChecker{isAdmin: true}, newTestLogger())
+		uc := NewUserUsecase(nil, repo, roles, &mockAdminChecker{isAdmin: true}, newTestLogger())
 
 		if err := uc.DeleteMyAccount(authedCtx(caller)); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if repo.deleteAuthCalls != 1 {
-			t.Fatalf("DeleteAuthUser calls=%d, want 1", repo.deleteAuthCalls)
+			t.Fatalf("DeleteAuthUserTx calls=%d, want 1", repo.deleteAuthCalls)
 		}
 	})
 
@@ -501,13 +527,53 @@ func TestUserUsecase_DeleteMyAccount(t *testing.T) {
 		t.Parallel()
 		repo := &mockUserRepository{}
 		roles := &mockUserRolesRepository{adminCount: 1}
-		uc := NewUserUsecase(repo, roles, &mockAdminChecker{isAdmin: true}, newTestLogger())
+		uc := NewUserUsecase(nil, repo, roles, &mockAdminChecker{isAdmin: true}, newTestLogger())
 
 		err := uc.DeleteMyAccount(authedCtx(caller))
 
 		assertForbidden(t, err, "cannot delete the last admin account; promote another admin first")
 		if repo.deleteAuthCalls != 0 {
-			t.Fatalf("DeleteAuthUser must not run for the last admin, got %d calls", repo.deleteAuthCalls)
+			t.Fatalf("DeleteAuthUserTx must not run for the last admin, got %d calls", repo.deleteAuthCalls)
+		}
+		// The count is only trustworthy while the admin-role advisory lock is
+		// held; without it a concurrent admin removal races past it.
+		if roles.lockCalls != 1 || roles.countCalls != 1 {
+			t.Fatalf("lock=%d count=%d, want the admin count read once under the lock",
+				roles.lockCalls, roles.countCalls)
+		}
+	})
+
+	t.Run("advisory lock failure fails closed", func(t *testing.T) {
+		t.Parallel()
+		repo := &mockUserRepository{}
+		roles := &mockUserRolesRepository{adminCount: 2, lockErr: errors.New("boom")}
+		authChk := &mockAdminChecker{isAdmin: true}
+		uc := NewUserUsecase(nil, repo, roles, authChk, newTestLogger())
+
+		err := uc.DeleteMyAccount(authedCtx(caller))
+
+		// Swallowing the lock error and counting anyway would reopen the race
+		// the lock closes, so the request must abort before the membership
+		// read, before the count, and before the delete.
+		assertInternalChain(t, err, "usecase: user: delete my account: count admins")
+		if authChk.calls != 0 || roles.countCalls != 0 {
+			t.Fatalf("isAdmin=%d count=%d, want neither once the lock could not be taken",
+				authChk.calls, roles.countCalls)
+		}
+		if repo.deleteAuthCalls != 0 {
+			t.Fatalf("DeleteAuthUserTx calls = %d, want 0 once the lock could not be taken", repo.deleteAuthCalls)
+		}
+	})
+
+	t.Run("advisory lock cancellation propagates unwrapped", func(t *testing.T) {
+		t.Parallel()
+		repo := &mockUserRepository{}
+		roles := &mockUserRolesRepository{lockErr: context.Canceled}
+		uc := NewUserUsecase(nil, repo, roles, &mockAdminChecker{isAdmin: true}, newTestLogger())
+
+		assertCancelled(t, uc.DeleteMyAccount(authedCtx(caller)))
+		if repo.deleteAuthCalls != 0 {
+			t.Fatalf("DeleteAuthUserTx calls = %d, want 0", repo.deleteAuthCalls)
 		}
 	})
 
@@ -515,7 +581,7 @@ func TestUserUsecase_DeleteMyAccount(t *testing.T) {
 		t.Parallel()
 		repo := &mockUserRepository{deleteAuthErr: repository.ErrNotFound}
 		roles := &mockUserRolesRepository{}
-		uc := NewUserUsecase(repo, roles, &mockAdminChecker{isAdmin: false}, newTestLogger())
+		uc := NewUserUsecase(nil, repo, roles, &mockAdminChecker{isAdmin: false}, newTestLogger())
 
 		if err := uc.DeleteMyAccount(authedCtx(caller)); err != nil {
 			t.Fatalf("expected nil (idempotent), got %v", err)
@@ -526,25 +592,25 @@ func TestUserUsecase_DeleteMyAccount(t *testing.T) {
 		t.Parallel()
 		repo := &mockUserRepository{deleteAuthErr: errors.New("boom")}
 		roles := &mockUserRolesRepository{}
-		uc := NewUserUsecase(repo, roles, &mockAdminChecker{isAdmin: false}, newTestLogger())
+		uc := NewUserUsecase(nil, repo, roles, &mockAdminChecker{isAdmin: false}, newTestLogger())
 
 		assertInternalChain(t, uc.DeleteMyAccount(authedCtx(caller)), "usecase: user: delete my account")
 	})
 
 	t.Run("context cancellation propagates", func(t *testing.T) {
 		t.Parallel()
-		uc := NewUserUsecase(&mockUserRepository{}, &mockUserRolesRepository{}, &mockAdminChecker{err: context.Canceled}, newTestLogger())
+		uc := NewUserUsecase(nil, &mockUserRepository{}, &mockUserRolesRepository{}, &mockAdminChecker{err: context.Canceled}, newTestLogger())
 		assertCancelled(t, uc.DeleteMyAccount(authedCtx(caller)))
 	})
 
 	t.Run("missing guard deps fail safe", func(t *testing.T) {
 		t.Parallel()
 		repo := &mockUserRepository{}
-		uc := NewUserUsecase(repo, nil, &mockAdminChecker{}, newTestLogger())
+		uc := NewUserUsecase(nil, repo, nil, &mockAdminChecker{}, newTestLogger())
 
 		assertInternalChain(t, uc.DeleteMyAccount(authedCtx(caller)), "admin guard deps not configured")
 		if repo.deleteAuthCalls != 0 {
-			t.Fatalf("DeleteAuthUser must not run when guard deps are missing, got %d calls", repo.deleteAuthCalls)
+			t.Fatalf("DeleteAuthUserTx must not run when guard deps are missing, got %d calls", repo.deleteAuthCalls)
 		}
 	})
 }


### PR DESCRIPTION
## Summary

Two administrators demoting each other in overlapping requests could both pass their own admin gate and both commit, leaving the workspace with zero admins. `adminEditUser` had no last-admin guard at all on the demote-other path, and the two delete paths that did have one documented it as best-effort with no lock — `SetUserRolesTx` scopes every statement to its target, so mutual demotions touch disjoint rows and never conflict at the database level. This change introduces a transaction-scoped Postgres advisory lock (`pg_advisory_xact_lock(hashtext('user_roles'), hashtext('admin'))`) in the repository layer, following the `EnsureByName` / `AcquireUserSeedLockTx` idiom already used by `cardgroupRepo` and `masterCardgroupRepo`, and routes all three admin-count mutations through it. `guardNotLastAdmin` now takes the caller's `*gorm.DB` and acquires the lock before reading the count, so the count and the mutation it protects commit or roll back together. `EditUser`'s role-set lookup was lifted out of the `callerID == id` branch so both guards ("you cannot revoke your own admin" and "you cannot demote the last admin") branch off the same `keepsAdmin` computation; the last-admin rejection is surfaced via a captured `guardErr` (the same early-return-nil shape the existing `earlyOutcome` uses) so it bypasses the mutation-error classifier and reaches the caller as a `*ucerr.ForbiddenError` — the same outcome shape `DeleteUser` returns. Because the lock is only meaningful if the mutation commits inside the locked transaction, `DeleteUser` and `DeleteMyAccount` were wrapped in a transaction and `UserRepository.DeleteAuthUser` became `DeleteAuthUserTx`. The two stale "best-effort (no row lock)" docblocks were rewritten to state that the lock is held.

## Changes

- **`backend/internal/repository/user_role.go`** — added `AcquireAdminRoleLockTx(ctx, tx)` (raw `SELECT pg_advisory_xact_lock(hashtext(?), hashtext(?))` keyed on the `user_roles` namespace + `domain.AdminRoleName`) and `CountAdminsTx(ctx, tx)` to `UserRoleRepository`. `CountAdmins` and `CountAdminsTx` now share a private `countAdminsOn(ctx, db)` helper so the Tx and non-Tx forms cannot drift. `CountAdmins` is retained because the startup bootstrap (`cmd/server/main.go:365`) reads it outside any transaction.
- **`backend/internal/repository/user.go`** — `DeleteAuthUser(ctx, id)` → `DeleteAuthUserTx(ctx, tx, id)`; the body now executes on the supplied handle and guards a nil `tx`. The interface docblock explains why the delete must be transaction-scoped (a delete on a pooled connection would commit after the lock released and reopen the race). The `LastSignInByUserIDs` docblock's "Like `DeleteAuthUser`" reference was refreshed.
- **`backend/internal/usecase/last_admin_guard.go`** — `AdminCounter` widened from `CountAdmins` to `AcquireAdminRoleLockTx` + `CountAdminsTx`; `guardNotLastAdmin` gained a `tx *gorm.DB` parameter and takes the lock before counting. Docblock now names all three callers and explains the TOCTOU the lock closes. Both repository failures keep the caller-supplied wrap prefix per the shared-helper rule.
- **`backend/internal/usecase/tx.go`** — new `runInTx(ctx, run, fn)` helper: runs `fn` inside `run`'s transaction, or invokes `fn(nil)` when `run` is nil (the shape `newTxRunner` produces for test constructors that inject repository fakes and have no `*gorm.DB`). Production always wires a real runner.
- **`backend/internal/usecase/admin_user.go`** — `adminUserRepository.DeleteAuthUser` → `DeleteAuthUserTx`; `adminUserRoleRepository.CountAdmins` → `AcquireAdminRoleLockTx` + `CountAdminsTx`. In `EditUser` the `FindByIDsTx` role lookup and `keepsAdmin` computation moved out of `if callerID == id` so both branches share it; `!keepsAdmin` now forks into the unchanged `CannotRevokeOwnAdmin` outcome for self, and `HasRole` + `guardNotLastAdmin` for another target. The unknown-roleId early validation stayed scoped to `callerID == id` so the relative precedence of the `id` and `roleIds` validation errors on the demote-other path is unchanged (an unknown id cannot be the admin role, so `keepsAdmin` computed on the partial map is still correct). `DeleteUser`'s guard + delete moved inside `runInTx`.
- **`backend/internal/usecase/user.go`** — `UserRepository.DeleteAuthUser` → `DeleteAuthUserTx`; `UserRolesRepository.CountAdmins` → `AcquireAdminRoleLockTx` + `CountAdminsTx`. `userUsecase` gained a `tx txRunner` field and `NewUserUsecase` gained a leading `db *gorm.DB` parameter (mirroring `NewAdminUser`). `DeleteMyAccount`'s guard + delete moved inside `runInTx`; the "best-effort (no row lock) … a Postgres advisory lock is the upgrade path" caveat was replaced with the standing statement that the lock is held.
- **`backend/cmd/server/main.go`** — `NewUserUsecase(repos.gorm, …)`.

### Tests

- **`backend/internal/usecase/admin_user_test.go`** — five new `EditUser` demote-other tests: `_LastAdmin` (rejected with `*ucerr.ForbiddenError` "cannot remove the admin role from the last admin account", zero-value outcome, no `UpdateTxVersioned` / `SetUserRolesTx` call, and the count read exactly once *under* the lock); `_NotLastAdmin` (succeeds with `adminCount: 2`); `_NonAdminTargetSkipsCount` (blocking `adminCount: 1` never consulted for a non-admin target); `_KeepingAdminSkipsGuard` (a submitted set retaining admin never calls `HasRole` or the count); `_CountAdminsInfraError` (pins the `usecase: admin user edit: count admins` wrap in the chain). The `mockAdminUserRoleRepository` gained `lockCalls` / `countCalls` and a `lockCallsAtCount` snapshot, so the lock-before-count ordering is asserted rather than assumed.
- **`backend/internal/repository/user_role_admin_lock_test.go`** (new) — integration test proving the raw advisory-lock SQL is valid against a real Postgres (a `pg_advisory_xact_lock` / `hashtext` typo would otherwise surface first in production): lock + count in one transaction, assign a fresh admin, then lock + count again — the second lock acquisition also proves the `_xact_` variant released at the first commit rather than leaking for the session. A companion test pins the nil-`tx` guards on both new methods.
- **`backend/internal/repository/user_test.go`** — the three `DeleteAuthUser` integration tests renamed to `TestDeleteAuthUserTx_*` and routed through a new `deleteAuthUserInTx` helper that mirrors the usecase call shape; the `ErrNotFound` sentinel is asserted to survive the transaction boundary.
- **`backend/internal/usecase/user_test.go`** — `DeleteMyAccount`'s "last admin is forbidden" subtest now asserts the count was read once under the lock; the "non-admin caller" subtest asserts neither lock nor count fires.
- Mechanical fake updates so every `repository.UserRoleRepository` / `repository.UserRepository` implementer still satisfies the widened interfaces: `internal/loader/user_test.go`, `internal/loader/role_by_user_test.go`, `graph/resolver/user_test.go`, `graph/resolver/admin_user_resolver_test.go`, `cmd/server/main_test.go`. Six test files took the new `NewUserUsecase(nil, …)` argument.

### Review follow-up

Three adversarially-confirmed review findings applied on top of the last-admin guard implementation.

### The membership read now happens under the advisory lock

The lock previously sat *inside* `guardNotLastAdmin`, which only ran when the caller had already decided the target was an admin. That decision came from a non-transactional `HasRole` read taken **before** any lock, so a target promoted to admin between the read and the mutation skipped the lock, the count, and the guard entirely — a three-request interleaving (`delete T` reads `T` as non-admin → `promote T` commits → `demote A` passes its count of 2 → `delete T` commits) still ended at zero admins.

- `repository.UserRoleRepository` gains `HasRoleTx`, sharing the query with `HasRole` through a private `hasRoleOn` helper (the `CountAdmins` / `CountAdminsTx` pattern already in the file) and rejecting a nil `tx`.
- Lock acquisition moves out of `guardNotLastAdmin` into a new `acquireAdminRoleLock` helper. `guardNotLastAdmin` now documents the precondition — the caller holds the lock and read `isTargetAdmin` under it — and only reads the count.
- `EditUser`'s demote-other branch takes the lock, then reads membership via `HasRoleTx` inside the same transaction.
- `DeleteUser`'s membership read moves from before `runInTx` into the transaction, behind the lock.
- `DeleteMyAccount`'s `auth.IsAdmin` read moves inside the transaction, after the lock, closing the same window on the self-service path.
- The docblocks on `last_admin_guard.go`, `EditUser`, `DeleteUser` and `DeleteMyAccount` no longer claim serialization against "every other admin-count-changing request"; they state what is actually serialized and why the ordering matters.

Non-admin targets still skip the admin count — only the lock and the membership read are now unconditional on a demotion path.

### The lock-failure branch is exercised

The two `lockErr` mock fields added for the failure branch were never assigned, so rewriting `acquireAdminRoleLock` to swallow the error and count *without* the lock left the whole suite green. Five tests now pin it closed: infrastructure-error and cancellation variants for `EditUser`'s demote-other path, an infrastructure-error variant for `DeleteUser`, and both variants for `DeleteMyAccount`. Each asserts the wrap prefix (or unwrapped `context.Canceled` identity) and that the request aborts before the membership read, before the count, and before any write.

Two mock counters make the ordering observable rather than merely the call count: `lockCallsAtHasRole` on `mockAdminUserRoleRepository` and an `onCall` hook on `mockAdminChecker`.

### Stale identifiers

Five references to the removed `DeleteAuthUser` symbol survived in `admin_user_test.go` comments and failure messages after the rename to `DeleteAuthUserTx`; its sibling `user_test.go` had already been converted. All five updated. `grep -rn 'DeleteAuthUser\b' backend/ docs/ .claude/rules/` now returns nothing.

### Test-fake fan-out

Adding `HasRoleTx` to the repository interface widened it for every implementer. Four test fakes gained the method: `panicUserRoleRepo` (`cmd/server`), `mockUserRoleRepository` (`graph/resolver`), and the two `internal/loader` stubs.

## Test plan

- [ ] cd backend && go build ./... — PASS (Success)
- [ ] cd backend && go vet ./... — PASS (No issues found)
- [ ] cd backend && go tool go-arch-lint check --project-path . — PASS (OK - No warnings found)
- [ ] cd backend && go test ./... — PASS (2263 passed, 0 failed, 26 packages). Docker was up, so the testcontainers-gated repository integration tests really ran: ./internal/repository/... alone = 329 passed, and the 5 new/renamed lock + DeleteAuthUserTx tests pass against a live Postgres.
- [ ] Pre-change baseline for comparison: ./internal/usecase/... ./graph/... ./internal/loader/... = 1094 passed after the fix (an intermediate run had 11 usecase failures, all traced to hoisting the unknown-roleId validation to non-self edits; the hoist was reverted and re-scoped to callerID == id).
- [ ] perl -CSD CJK grep over every changed file — PASS (no output)
- [ ] grep -rnE 'PR[0-9]+' over every changed + untracked file — PASS (no output)
- [ ] git status --short in the MAIN checkout /Users/yasuflatland/projects/flamingo-armond — PASS (empty; no stray edits outside the worktree)
- [ ] git diff --stat HEAD -- '*.go' ':!*_test.go' — 7 files, 260 insertions(+), 115 deletions(-); well under the 800-line production-diff ceiling
- [ ] cd backend && go build ./... → Success
- [ ] cd backend && go vet ./... → No issues found
- [ ] cd backend && go tool go-arch-lint check → OK - No warnings found
- [ ] cd backend && go test -count=1 ./... → 2269 passed in 26 packages (0 failed)
- [ ] grep -rn 'DeleteAuthUser\b' backend/ docs/ .claude/rules/ → no output (exit 1)
- [ ] perl -CSD CJK scan over changed usecase/repository files → no output
- [ ] grep -rnE 'PR[0-9]+' backend/internal/usecase backend/internal/repository → no output
- [ ] git -C /Users/yasuflatland/projects/flamingo-armond status --short → empty (main checkout clean)

## Notes

**Evidence citations verified against the worktree.** All of the issue's file:line citations still held at `d06f30ea`: `admin_user.go:300-399` (EditUser), `:333-360` (the `keepsAdmin` + `FindByIDsTx` block inside `if callerID == id`), `:362-373` (the unguarded `UpdateTxVersioned` / `SetUserRolesTx` pair), `:411-413` and `user.go:172-175` (the two stale best-effort docblocks), `user_role.go:135-196` (`SetUserRolesTx` scoping every statement to the target), `role.go:108-113` (`FindByIDsTx` → `findRolesByIDs` with `clause.Locking{Strength: "UPDATE"}`). `guardNotLastAdmin`'s production callers were exactly `admin_user.go:433` and `user.go:195`. No citation needed correcting.

**One intermediate regression worth flagging to a reviewer.** The first draft hoisted the whole role-lookup block — including the `len(roles) != len(roleIDs)` unknown-roleId early validation — out of the self branch. That flipped the precedence of the `id` and `roleIds` validation errors on the demote-other path (`TestAdminUser_EditUser_UserNotFoundValidation` got `roleIds`/"role not found" where it expected `id`) and broke 10 other `EditUser` tests. The fix re-scoped that early-out to `callerID == id`; only the `keepsAdmin` computation is shared. `keepsAdmin` remains correct on a partial role map because an id that resolves to no row cannot be the admin role, and `SetUserRolesTx` still rejects the unknown id downstream exactly as before.

**Post-flight greps run.**
- `grep -rn "runInTx(" --include='*.go' . | grep -v _test.go` → 2 production callers (`admin_user.go:478`, `user.go:203`) plus the declaration. Wired, not speculative.
- `grep -rn "AcquireAdminRoleLockTx\|CountAdminsTx\|DeleteAuthUserTx" --include='*.go' . | grep -v _test.go` → 35 production hits.
- `grep -rn "\.DeleteAuthUser(" --include='*.go' .` and `grep -rn "counter.CountAdmins(" --include='*.go' .` → both empty; no caller of the old shapes survives.

**Residual race, deliberately left.** The `HasRole` read that decides whether the guard applies runs on a pooled connection, not inside the locked transaction — the same shape `DeleteUser` already used before this change. It reads committed data, so a stale `true` only makes the guard stricter. A stale `false` would require a concurrent *promotion* of the target, and promotions are not admin-count-decreasing so they never take the lock. Making it tx-scoped would mean adding a third repository method (`HasRoleTx`) for a window that cannot produce the zero-admin outcome the issue is about; it stayed out.

**No doc updates were needed.** `docs/backend/library-gotchas/postgres-advisory-lock-for-ensure-by-name.md` already documents the idiom cross-aggregate ("The same pattern works for any Ensure-by-natural-key repository method…"); no committed doc named `DeleteAuthUser` or the best-effort caveat outside the two source docblocks, confirmed by grep over `docs/` and `.claude/rules/`.

**Scope deviations.** Three items go slightly beyond the issue's literal Scope list, each forced by the correctness of the requested lock:

1. **`UserRepository.DeleteAuthUser` → `DeleteAuthUserTx`** (and the ~8 test fakes / integration tests that implement or call it). The issue says "route all three mutations through it". An advisory lock only serializes work that commits inside the locked transaction: if `DeleteUser` counted under the lock and then deleted on a pooled connection outside it, caller A would release the lock at commit before its delete landed and caller B would count 2 and also delete — the exact race the issue reports, unmoved. The delete therefore had to become tx-scoped. The old non-Tx method was renamed rather than kept alongside, since it would have had zero production callers (post-flight grep rule).

2. **`NewUserUsecase` gained a leading `db *gorm.DB` parameter** (~20 test call sites take `nil`). `DeleteMyAccount` needs a transaction and `userUsecase` had no runner. The signature mirrors `NewAdminUser(db, …)` rather than adding a second `WithTx` constructor, which keeps the production diff smaller and leaves one obvious way to construct.

3. **`runInTx` nil-runner fallback in `tx.go`.** `graph/resolver/user_test.go` builds the `DeleteMyAccount` last-admin harness from repository mocks with no database, so erroring on a nil runner (the way `EditUser` does) would have made that test unfixable without a live Postgres. `runInTx` invokes the closure with a nil handle in that case; production always passes `repos.gorm`.

Both Out-of-scope items were honoured: the lock is keyed on the literal `admin` role name only (`adminRoleLockNamespace` + `domain.AdminRoleName`, no generalisation), and the self-demotion branch's `CannotRevokeOwnAdmin` outcome is byte-for-byte unchanged — its existing tests (`TestAdminUser_EditUser_CannotRevokeOwnAdmin`, `..._Self_NoRolesSubmitted_CannotRevokeOwnAdmin`, `..._SelfKeepingAdminAllowed`) pass untouched.

Two pre-existing tests changed their expectation deliberately, because the fix changes observable behaviour: `TestAdminUser_EditUser_DemoteOther_NonAdminTargetSkipsCount` and `TestUserUsecase_DeleteMyAccount/non-admin caller is deleted without consulting the admin count` previously asserted `lockCalls == 0` for a non-admin target. The lock is now taken on every demotion path — the membership read that concludes "not an admin" must itself be under it — so both were rewritten to assert `lockCalls == 1 && countCalls == 0` plus the new ordering snapshot. They are the RED signal for Finding 2, not collateral churn.

Scope note on `DeleteMyAccount`: the finding named only `admin_user.go:382`/`:470`, but the same stale-read hole exists on the self-service path and `user.go`'s docblock made the same overstated claim. It is fixed by moving the existing `u.auth.IsAdmin` call inside the transaction after the lock — five lines, no constructor or dependency change. The alternative (routing it through `HasRoleTx` on `UserRolesRepository`) would have left the `auth AdminChecker` field dead and required dropping a parameter at 23 `NewUserUsecase` call sites across six files; that was judged out of scope.

Consciously NOT done: making the promote path (`keepsAdmin == true`) contend for the lock, which the refuter listed as step 1 of its invariant-complete fix. It is unnecessary once the membership read is under the lock — with the read serialized, an unlocked concurrent promotion can only ever *raise* the admin count relative to what a demoter observed, and the demoter's own count is taken under the lock it holds through commit. Every interleaving in the finding's failure scenario now terminates with a non-empty admin set. Leaving promotions lock-free keeps the common role-assignment path uncontended.

Nothing was disputed. All three findings were real as written.

**Merge order.** `backend/internal/usecase/user.go` is also touched by the branch for #1022, in a different function (`DeleteMyAccount` docblock vs `Me`). Whichever lands second may need a trivial rebase.

Closes #1019
