### PR TITLE
fix(backend): stop card(id) from leaking card existence to non-owners

### DIFF
--- a/backend/graph/resolver/card_resolvers_test.go
+++ b/backend/graph/resolver/card_resolvers_test.go
@@ -626,3 +626,52 @@ func TestResolver_PracticeTodaysCards_MissingCardgroup(t *testing.T) {
 		t.Fatalf("expected extensions.field=cardgroupId, got %q; ext: %v", field, ext)
 	}
 }
+
+// TestResolver_Card_UnknownAndForeignBothUnauthenticated pins the schema promise
+// on the card field ("Returns UNAUTHENTICATED for non-owners (existence is not
+// leaked)"): an unknown card id and a card owned by someone else must produce the
+// same UNAUTHENTICATED wire response, never a null card with no error.
+func TestResolver_Card_UnknownAndForeignBothUnauthenticated(t *testing.T) {
+	t.Parallel()
+
+	body := `{"query":"query { card(id: \"c1\") { id } }"}`
+
+	unknownSrv := newCardSrv(
+		&cardMockRepo{findByIDErr: repository.ErrNotFound},
+		&cardMockCGRepo{},
+		cardFakeTx(),
+	)
+	unknownResp := gqlRequest(t, unknownSrv, authedCtx("u1"), body)
+
+	foreignSrv := newCardSrv(
+		&cardMockRepo{findByIDResult: &domain.Card{
+			ID:          "c1",
+			CardgroupID: domain.CardgroupID("cg1"),
+		}},
+		&cardMockCGRepo{findResult: &domain.Cardgroup{
+			ID:      domain.CardgroupID("cg1"),
+			OwnerID: "u2",
+		}},
+		cardFakeTx(),
+	)
+	foreignResp := gqlRequest(t, foreignSrv, authedCtx("u1"), body)
+
+	if code := errCode(t, unknownResp); code != "UNAUTHENTICATED" {
+		t.Fatalf("unknown id: expected UNAUTHENTICATED, got %q; response: %v", code, unknownResp)
+	}
+	if code := errCode(t, foreignResp); code != "UNAUTHENTICATED" {
+		t.Fatalf("foreign card: expected UNAUTHENTICATED, got %q; response: %v", code, foreignResp)
+	}
+
+	unknownJSON, err := json.Marshal(unknownResp)
+	if err != nil {
+		t.Fatalf("marshal unknown response: %v", err)
+	}
+	foreignJSON, err := json.Marshal(foreignResp)
+	if err != nil {
+		t.Fatalf("marshal foreign response: %v", err)
+	}
+	if string(unknownJSON) != string(foreignJSON) {
+		t.Fatalf("responses are distinguishable:\n unknown=%s\n foreign=%s", unknownJSON, foreignJSON)
+	}
+}

--- a/backend/internal/usecase/card.go
+++ b/backend/internal/usecase/card.go
@@ -212,6 +212,10 @@ const (
 	maxBulkDelete   = 100
 )
 
+// Card reads a single card the caller owns. An unknown id and a card owned by
+// someone else both return ucerr.ErrUnauthenticated, so the query cannot be used
+// as an existence oracle over another user's card ids. Update / Delete collapse
+// the same two cases identically.
 func (u *cardUsecase) Card(ctx context.Context, id string) (*domain.Card, error) {
 	user := auth.UserFrom(ctx)
 	if err := requireCallerSub(user); err != nil {
@@ -220,7 +224,7 @@ func (u *cardUsecase) Card(ctx context.Context, id string) (*domain.Card, error)
 	card, err := u.cardRepo.FindByID(ctx, id)
 	if err != nil {
 		if errors.Is(err, repository.ErrNotFound) {
-			return nil, nil
+			return nil, ucerr.ErrUnauthenticated
 		}
 		return nil, eris.Wrap(err, "usecase: card: find by id")
 	}

--- a/backend/internal/usecase/card_test.go
+++ b/backend/internal/usecase/card_test.go
@@ -509,20 +509,42 @@ func TestCardUsecase_Delete_NotFoundMasksExistence(t *testing.T) {
 	assertUnauthenticated(t, err)
 }
 
-func TestCardUsecase_Card_NotFoundReturnsNil(t *testing.T) {
+// TestCardUsecase_Card_UnknownAndForeignAreIndistinguishable pins the
+// non-disclosure contract on the card read path: probing an unknown card id and
+// probing a card owned by another user must produce identical outcomes, so the
+// query cannot be used as an existence oracle over another user's card ids.
+func TestCardUsecase_Card_UnknownAndForeignAreIndistinguishable(t *testing.T) {
 	t.Parallel()
 
-	uc := NewCardUsecase(nil, &mockCardRepository{findErr: repository.ErrNotFound},
+	unknownUC := NewCardUsecase(nil, &mockCardRepository{findErr: repository.ErrNotFound},
 		&mockCardgroupRepoForCard{},
 		nil, nil, newTestLogger(),
 	)
+	unknownCard, unknownErr := unknownUC.Card(authedCtx("u1"), "missing")
 
-	got, err := uc.Card(authedCtx("u1"), "missing")
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
+	foreignUC := NewCardUsecase(nil, &mockCardRepository{findResult: &domain.Card{
+		ID:          "card1",
+		CardgroupID: domain.CardgroupID("cg1"),
+	}},
+		&mockCardgroupRepoForCard{findResult: &domain.Cardgroup{
+			ID:      domain.CardgroupID("cg1"),
+			OwnerID: "u2",
+		}},
+		nil, nil, newTestLogger(),
+	)
+	foreignCard, foreignErr := foreignUC.Card(authedCtx("u1"), "card1")
+
+	assertUnauthenticated(t, unknownErr)
+	assertUnauthenticated(t, foreignErr)
+	if unknownCard != nil {
+		t.Fatalf("unknown id: expected nil card, got %+v", unknownCard)
 	}
-	if got != nil {
-		t.Fatalf("expected nil card, got %+v", got)
+	if foreignCard != nil {
+		t.Fatalf("foreign card: expected nil card, got %+v", foreignCard)
+	}
+	if unknownErr.Error() != foreignErr.Error() {
+		t.Fatalf("outcomes are distinguishable: unknown=%q foreign=%q",
+			unknownErr.Error(), foreignErr.Error())
 	}
 }
 


### PR DESCRIPTION
## Summary

`CardUsecase.Card` returned `nil, nil` when the repository reported `repository.ErrNotFound`, but returned `ucerr.ErrUnauthenticated` when the card existed and belonged to another user. The resolver passes both outcomes through untouched — `toCardModel(nil)` renders as `card: null` with no error, while the foreign-owner case renders as an UNAUTHENTICATED GraphQL error — so the two responses were trivially distinguishable and the `card(id:)` query worked as an existence oracle over other users' card ids. The schema promise on `schema/card.graphql:125` already states the opposite, and the write siblings `Update` / `Delete` already collapse the two cases correctly. The fix returns `ucerr.ErrUnauthenticated` on `repository.ErrNotFound` in `Card`, matching `Update` (`card.go:278-279`) and `Delete` (`card.go:345-346`). The one pre-existing test that asserted the leaky contract (`TestCardUsecase_Card_NotFoundReturnsNil`) was replaced by a test that probes both ids and asserts identical outcomes, and a new resolver test asserts byte-identical GraphQL responses for the two probes. `cardgroup(id)`'s null-collapse policy is untouched.

## Changes

- **`backend/internal/usecase/card.go`** — in `cardUsecase.Card`, the `errors.Is(err, repository.ErrNotFound)` branch now returns `nil, ucerr.ErrUnauthenticated` instead of `nil, nil`. Added a four-line docblock on `Card` stating that an unknown id and a foreign-owned card collapse to the same error so the query cannot be used as an existence oracle, and naming `Update` / `Delete` as the siblings with identical behaviour. No new import: `ucerr` was already imported for the `Update` / `Delete` branches.
- **`backend/internal/usecase/card_test.go`** — replaced `TestCardUsecase_Card_NotFoundReturnsNil` (which pinned the leaky `nil, nil` contract) with `TestCardUsecase_Card_UnknownAndForeignAreIndistinguishable`.
- **`backend/graph/resolver/card_resolvers_test.go`** — added `TestResolver_Card_UnknownAndForeignBothUnauthenticated`, the first resolver-level test for the `card` query field.

### Tests

- `TestCardUsecase_Card_UnknownAndForeignAreIndistinguishable` (`backend/internal/usecase/card_test.go`) — builds two usecases: one whose card repo returns `repository.ErrNotFound`, one whose card repo returns a card in cardgroup `cg1` owned by `u2`. Probes both as `u1` and asserts (a) `assertUnauthenticated` on each error, (b) a `nil` card on each return, (c) `unknownErr.Error() == foreignErr.Error()`. The third assertion is what makes the two outcomes provably indistinguishable rather than merely both-non-nil.
- `TestResolver_Card_UnknownAndForeignBothUnauthenticated` (`backend/graph/resolver/card_resolvers_test.go`) — drives the same two fixtures through the real gqlgen handler with `query { card(id: "c1") { id } }`, asserts `errors[0].extensions.code == "UNAUTHENTICATED"` for both, then `json.Marshal`s both full responses and asserts the bytes are equal. This pins the wire-level contract from `schema/card.graphql:125`, which the usecase test alone cannot: the pre-fix `nil, nil` path never reached an error at all, it produced `{"data":{"card":null}}`.
- **Failure proof (test-first equivalent).** After writing both tests I temporarily reverted the production line to `return nil, nil` and re-ran them: usecase test failed at `card_test.go:537` (`assertUnauthenticated: expected errors.Is(err, ErrUnauthenticated)=true`), resolver test failed at `card_resolvers_test.go:659` (`expected errors in response, got map[data:map[card:<nil>]]`). The line was then restored and all gates re-run green.

## Test plan

- [ ] cd backend && go build ./... — PASS (Success)
- [ ] cd backend && go vet ./... — PASS (No issues found)
- [ ] cd backend && go tool go-arch-lint check — PASS (OK - No warnings found)
- [ ] cd backend && go test ./internal/... ./graph/... — PASS (2098 passed in 22 packages, 0 failed)
- [ ] cd backend && go test ./internal/usecase/ -run TestCardUsecase_Card_UnknownAndForeignAreIndistinguishable — PASS (1 passed)
- [ ] cd backend && go test ./graph/resolver/ -run TestResolver_Card_UnknownAndForeignBothUnauthenticated — PASS (1 passed)
- [ ] git status --short (main checkout /Users/yasuflatland/projects/flamingo-armond) — clean, zero lines of output

## Notes

**Citation verification.** Every issue citation held exactly at the current HEAD, with no line drift: `card.go:215-231` (`Card`, with `nil, nil` at `:222-223`), `ownership.go:81-89` (`authorizeCardgroupOrUnauthenticated`, non-owner return at `:51-53`), `card.resolvers.go:141-148` (resolver, no collapse), `schema/card.graphql:125` (the schema promise), `card.go:278-279` and `:345-346` (the `Update` / `Delete` siblings). No citation needs correcting.

**Exhaustive grep for tests asserting the old `(nil, nil)` contract.** The special note in the task was the load-bearing part of this issue, so the search was run three ways over the whole backend tree:

```
grep -rn "\.Card(" --include='*_test.go' backend/    -> 9 hits
grep -rn "CardUC.Card\|Card_NotFound\|card(id"       -> 4 hits
grep -rn "card(id:" --include='*.go' backend/        -> 2 hits
```

Exactly one test asserted the old contract: `TestCardUsecase_Card_NotFoundReturnsNil` at `card_test.go:512`. Of the other `.Card(` hits, `cmd/server/main_test.go:2747` and the four `cefr_resolver_test.go` hits are `generated.CardResolver` field-resolver calls (unrelated method), and `card_test.go:1085` / `:1158` are `[]*domain.Card(nil)` slice conversions, not usecase calls. The `card(id:` grep confirmed no existing GraphQL-level test exercised the `card` query at all before this change — the only other hit is `graph/generated/generated.go:2531`, the embedded schema string. So the resolver test is net-new coverage for a previously untested query field, which is why the resolver acceptance criterion could not be satisfied by editing an existing test.

**Diff size.** 6 lines added / 1 removed in production (`card.go`), well under the 800-line ceiling; the split-decision rule does not apply.

**Path discipline.** All edits confirmed in the worktree; `git status --short` in the main checkout at `/Users/yasuflatland/projects/flamingo-armond` printed nothing.

**Scope deviations.** none. The only addition beyond the literal one-line Scope item is the four-line docblock on `Card`, which documents the non-disclosure invariant the change establishes; it carries no behavioural weight. Both Out-of-scope items were respected: `schema/card.graphql:125` is unmodified (verified — it is not in `git status`), and no cardgroup file was touched (`cardgroup.go` / `cardgroup_resolvers_test.go` are absent from the diff).

**Merge order.** `backend/internal/usecase/card.go` is also touched by the branch for #1011, in a different function (`Update` vs `Card`).

Closes #1021
