### PR TITLE
fix(frontend): ignore auto-repeat keydown events in the swipe card stack

### DIFF
--- a/frontend/src/components/learn/swipe-card-stack.test.tsx
+++ b/frontend/src/components/learn/swipe-card-stack.test.tsx
@@ -727,6 +727,42 @@ describe("SwipeCardStack — keyboard triggers all three directions", () => {
 });
 
 // ---------------------------------------------------------------------------
+// describe: auto-repeat keydown is ignored
+// ---------------------------------------------------------------------------
+
+describe("SwipeCardStack — ignores auto-repeat keydown", () => {
+  it.each([
+    ["ArrowLeft", "left"],
+    ["ArrowRight", "right"],
+    ["ArrowDown", "down"],
+  ] as const)("emits no rating for a repeat '%s' keydown, but still rates on a normal press", (key, expectedDirection) => {
+    const onCardSwiped = vi.fn();
+
+    renderWithIntl(
+      <SwipeCardStack cards={[cardA]} displayMode="ALWAYS_VISIBLE" onCardSwiped={onCardSwiped} />,
+    );
+
+    // A held key auto-repeats: the browser fires keydown with repeat = true.
+    // None of those may reach triggerSwipe, so no fly-off is even queued.
+    fireEvent.keyDown(document, { key, repeat: true });
+    fireEvent.keyDown(document, { key, repeat: true });
+    expect(pendingFlyOuts).toHaveLength(0);
+    act(() => {
+      settleFlyOuts();
+    });
+    expect(onCardSwiped).not.toHaveBeenCalled();
+
+    // A deliberate discrete press still rates the active card.
+    fireEvent.keyDown(document, { key });
+    act(() => {
+      settleFlyOuts();
+    });
+    expect(onCardSwiped).toHaveBeenCalledTimes(1);
+    expect(onCardSwiped).toHaveBeenCalledWith(cardA, expectedDirection);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // describe: internal state reset after card change
 // ---------------------------------------------------------------------------
 

--- a/frontend/src/components/learn/swipe-card-stack.tsx
+++ b/frontend/src/components/learn/swipe-card-stack.tsx
@@ -201,6 +201,11 @@ export function SwipeCardStack<TCard extends SwipeCardData>({
   useEffect(() => {
     function onKeyDown(event: KeyboardEvent) {
       if (!activeCardRef.current) return;
+      // Auto-repeat from a held key is not a deliberate rating. Each repeat
+      // would advance the stack and commit an irreversible FSRS schedule step,
+      // so a resting finger could burn through the whole queue. Discrete
+      // presses (repeat === false) stay unthrottled.
+      if (event.repeat) return;
       const activeElement = document.activeElement;
       const tagName = activeElement?.tagName;
       if (tagName === "INPUT" || tagName === "TEXTAREA" || tagName === "SELECT") return;


### PR DESCRIPTION
## Summary

A learner who rests a finger on an arrow key gets one keydown per OS auto-repeat interval, and `SwipeCardStack`'s window-level `onKeyDown` handler treated every one of them as a deliberate rating. Each repeat reached `triggerSwipe`, advanced the stack, and committed an irreversible FSRS schedule step — the per-card once-guard (`exitingCardIdRef`) only collapses double-commits on the *same* card and is reset whenever the active card changes, so it offers no protection once the stack advances. Under `prefers-reduced-motion` the commit is synchronous, so the burn rate is bounded only by the key-repeat interval. The fix is a single early return on `event.repeat`, placed immediately after the no-active-card guard and before the form-element guard and the direction lookup, so a held key produces exactly one rating (the initial, non-repeat keydown) and discrete fast presses stay unthrottled. The value of the change is in the regression test: a new `it.each` over all three mapped arrow keys asserts that two `repeat: true` keydowns queue no fly-off and commit nothing, and that a subsequent normal keydown still rates the active card with the correct direction.

## Changes

- `frontend/src/components/learn/swipe-card-stack.tsx` — added `if (event.repeat) return;` to the `useEffect`-registered `onKeyDown` handler, after the `!activeCardRef.current` guard and before the form-element guard / `directionByKey` lookup, with a comment naming the mechanism (auto-repeat is not a deliberate rating; each repeat is an irreversible FSRS schedule advance) and stating that discrete presses stay unthrottled. 5 added lines, no other production change.
- `frontend/src/components/learn/swipe-card-stack.test.tsx` — added the `SwipeCardStack — ignores auto-repeat keydown` describe block (one `it.each` over `ArrowLeft`/`ArrowRight`/`ArrowDown`, 3 cases).

### Tests

- `SwipeCardStack — ignores auto-repeat keydown` (`it.each` over `["ArrowLeft","left"]`, `["ArrowRight","right"]`, `["ArrowDown","down"]`, 3 cases). Each case renders a single-card stack in `ALWAYS_VISIBLE` mode, fires two `fireEvent.keyDown(document, { key, repeat: true })` events, asserts `pendingFlyOuts` is empty (nothing even reached `triggerSwipe` — proven at the fly-off queue, not just at the commit callback), settles the fly-off queue and asserts `onCardSwiped` was never called; then fires one normal (`repeat` unset/false) keydown, settles, and asserts exactly one `onCardSwiped(cardA, expectedDirection)`. The single test therefore pins both acceptance criteria — no rating on repeat, and an unbroken normal path — per arrow key.
- Test-first confirmation: before the production edit all 3 new cases failed at the `expect(pendingFlyOuts).toHaveLength(0)` assertion with `expected [ [Function], [Function] ] to have a length of +0 but got 2` (1 file failed, 3 failed / 28 passed). After the edit the file is 31/31 green.
- The pre-existing `SwipeCardStack — keyboard triggers all three directions` describe is untouched; the new block is additive.

## Test plan

- [ ] cd frontend && ./node_modules/.bin/tsc --noEmit — PASS (exit 0, no diagnostics)
- [ ] cd frontend && ./node_modules/.bin/biome check --error-on-warnings . — PASS (exit 0; 520 files checked, no fixes applied; the 2 reported 'infos' are pre-existing biome.json notices: schema version 2.4.15 vs CLI 2.5.3, and the deprecated `recommended` field — neither is a lint finding and neither is touched by this change)
- [ ] cd frontend && ./node_modules/.bin/vitest run — PASS (206 test files passed / 206; 1932 tests passed / 1932; 9.77s)
- [ ] cd frontend && ./node_modules/.bin/knip — PASS (exit 0; 1 configuration hint only: `@graphql-typed-document-node/core` could be removed from knip.jsonc ignoreDependencies — pre-existing, unrelated)

## Notes

Citation verification against the worktree checkout — all four machine-verified evidence citations still hold at the stated line numbers (pre-edit): `swipe-card-stack.tsx:201-221` is the `useEffect`-registered `onKeyDown` with `triggerSwipe(direction)` at `:216` and only two early returns (`:203` no-active-card, `:206` form-element); `:158-159` is the `commitCard` once-guard comment plus `if (exitingCardIdRef.current === card.id) return;` inside `triggerSwipe` (the identical guard also sits in `commitCard` at `:143`); `:191-199` is the active-card reset effect with `exitingCardIdRef.current = null` at `:194`; `animated-card.tsx:22` is `const FLY_OFF_DURATION_MS = 200;`. No citation drift to report.

Guard placement: the return is after the `!activeCardRef.current` check rather than as the very first statement. Both satisfy the Scope wording ("before the direction lookup"); keeping the no-active-card guard first preserves the existing cheapest-check-first ordering and leaves that guard's diff untouched.

Language policy: the new comment and test names are English only. `perl -CSD` CJK scan over both changed files returned no hits.

Path discipline: `git status --short` in the worktree lists exactly the two intended files; `git status --short` in the main checkout (`/Users/yasuflatland/projects/flamingo-armond`) is empty.

No git write operations were performed.

**Scope deviations.** none — the diff is exactly the one Scope checkbox (the `event.repeat` early return in `swipe-card-stack.tsx`) plus the two required test assertions. Nothing from Out of scope was touched: no rate limiting of genuine discrete presses, no undo affordance, no change to the pointer/gesture path or the on-screen rating buttons, and the per-card once-guard (`exitingCardIdRef`) and the active-card reset effect are byte-identical.

Closes #1023
