### PR TITLE
fix(backend): guard the User.lastSignInAt field resolver with a self-or-admin check

### DIFF
--- a/backend/graph/resolver/admin.resolvers.go
+++ b/backend/graph/resolver/admin.resolvers.go
@@ -194,12 +194,46 @@ func (r *userResolver) Roles(ctx context.Context, obj *model.User) ([]*model.Rol
 // LastSignInAt resolves auth.users.last_sign_in_at via the per-request
 // LastSignInByUserID DataLoader (batched, so the admin user list issues one
 // auth.users read per page). A nil result means the user has never signed in.
+//
+// Authorization mirrors Roles: last_sign_in_at is a privileged authentication
+// signal, and the field is reachable from every resolver that returns a User,
+// so the gate lives in the field resolver rather than on any one query. A
+// caller reads their own value unconditionally; reading another user's value
+// requires the admin role, computed from the same RoleByUserID batch.
 func (r *userResolver) LastSignInAt(ctx context.Context, obj *model.User) (*time.Time, error) {
 	loaders, gqlErr := loadersOrInternal(ctx)
 	if gqlErr != nil {
 		return nil, gqlErr
 	}
-	t, err := loaders.LastSignInByUserID.Load(ctx, obj.ID)()
+	caller := auth.UserFrom(ctx)
+	if caller == nil || caller.Sub == "" {
+		return nil, gqlerr.Unauthenticated()
+	}
+
+	// Register the target load before the admin-status load so both keys share
+	// one batch window; the page's auth.users keys then resolve in one read.
+	lastSignInThunk := loaders.LastSignInByUserID.Load(ctx, obj.ID)
+
+	if caller.Sub != obj.ID {
+		callerRoles, err := loaders.RoleByUserID.Load(ctx, caller.Sub)()
+		if err != nil {
+			return nil, classifyLoaderErr(ctx, err, "resolver: last sign in: admin check")
+		}
+		// Reuse the domain admin-membership predicate rather than a resolver-local
+		// role loop, mirroring Roles above. Nil entries from the batch loader are
+		// skipped defensively before dereferencing.
+		callerSet := make(domain.RoleSet, 0, len(callerRoles))
+		for _, role := range callerRoles {
+			if role != nil {
+				callerSet = append(callerSet, *role)
+			}
+		}
+		if !callerSet.ContainsAdmin() {
+			return nil, gqlerr.NewForbidden("admin only")
+		}
+	}
+
+	t, err := lastSignInThunk()
 	if err != nil {
 		return nil, classifyLoaderErr(ctx, err, "resolver: last sign in")
 	}

--- a/backend/graph/resolver/cardgroup.resolvers.go
+++ b/backend/graph/resolver/cardgroup.resolvers.go
@@ -14,6 +14,19 @@ import (
 )
 
 // Owner is the resolver for the owner field.
+//
+// This resolver has no gate of its own: it hands back whichever User owns the
+// cardgroup. It is safe only because no current path hands a foreign Cardgroup
+// to a non-owner — Query.cardgroup returns null for a non-owner and a missing id
+// alike, and every other edge that reaches a Cardgroup is caller-scoped.
+//
+// Do not read that as "the User type protects itself". Only two of its five
+// field resolvers run a self-or-admin check: User.roles and User.lastSignInAt.
+// The other three — User.lastViewedCardgroup, User.learnDisplayMode and
+// User.newCardRatio — resolve straight off obj.ID through the UserPreference
+// loader with no caller lookup at all. Any resolver that starts returning a
+// Cardgroup the caller does not own must therefore either gate itself or add
+// field-level guards to those three fields first.
 func (r *cardgroupResolver) Owner(ctx context.Context, obj *model.Cardgroup) (*model.User, error) {
 	loaders, gqlErr := loadersOrInternal(ctx)
 	if gqlErr != nil {

--- a/backend/graph/resolver/last_sign_in_resolver_test.go
+++ b/backend/graph/resolver/last_sign_in_resolver_test.go
@@ -3,6 +3,7 @@ package resolver_test
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -10,19 +11,70 @@ import (
 
 	"backend/graph/model"
 	"backend/graph/resolver"
+	"backend/internal/domain"
 	"backend/internal/gqlerr"
 	"backend/internal/loader"
+	"backend/internal/usecase"
 )
 
-// ctxWithLastSignInLoader installs an in-memory LastSignInByUserID loader.
-// A user id absent from m resolves to nil data (never signed in / unknown).
-func ctxWithLastSignInLoader(base context.Context, m map[string]*time.Time) context.Context {
+// lastSignInBatchCounter records how many batch calls the LastSignInByUserID
+// loader issued and the keys carried by the most recent one, so the
+// one-read-per-page property can be asserted.
+type lastSignInBatchCounter struct {
+	mu        sync.Mutex
+	calls     int
+	lastKeys  []string
+	byUserID  map[string]*time.Time
+	loadError error
+}
+
+func (c *lastSignInBatchCounter) batch(_ context.Context, keys []string) []*dataloader.Result[*time.Time] {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.calls++
+	c.lastKeys = append([]string(nil), keys...)
+	out := make([]*dataloader.Result[*time.Time], len(keys))
+	for i, k := range keys {
+		if c.loadError != nil {
+			out[i] = &dataloader.Result[*time.Time]{Error: c.loadError}
+			continue
+		}
+		out[i] = &dataloader.Result[*time.Time]{Data: c.byUserID[k]}
+	}
+	return out
+}
+
+// ctxWithLastSignIn installs an in-memory LastSignInByUserID loader alongside a
+// RoleByUserID loader backed by rolesByUser (the field resolver's admin gate
+// reads the caller's roles from the same request batch). A user id absent from
+// m resolves to nil data (never signed in / unknown).
+func ctxWithLastSignIn(base context.Context, m map[string]*time.Time, rolesByUser map[string][]*domain.Role) context.Context {
+	return ctxWithLastSignInCounter(base, &lastSignInBatchCounter{byUserID: m}, &mockRoleByUserIDRepo{byUserID: rolesByUser})
+}
+
+// ctxWithLastSignInCounter is like ctxWithLastSignIn but accepts the
+// pre-constructed backing stubs so callers can inspect their call counts after
+// the request resolves.
+func ctxWithLastSignInCounter(base context.Context, counter *lastSignInBatchCounter, roleRepo *mockRoleByUserIDRepo) context.Context {
 	loaders := &loader.Loaders{
-		LastSignInByUserID: dataloader.NewBatchedLoader(
-			func(_ context.Context, keys []string) []*dataloader.Result[*time.Time] {
-				out := make([]*dataloader.Result[*time.Time], len(keys))
+		LastSignInByUserID: dataloader.NewBatchedLoader(counter.batch),
+		RoleByUserID: dataloader.NewBatchedLoader(
+			func(ctx context.Context, keys []string) []*dataloader.Result[[]*domain.Role] {
+				out := make([]*dataloader.Result[[]*domain.Role], len(keys))
+				result, err := roleRepo.ListByUserIDs(ctx, keys)
+				if err != nil {
+					for i := range keys {
+						out[i] = &dataloader.Result[[]*domain.Role]{Error: err}
+					}
+					return out
+				}
 				for i, k := range keys {
-					out[i] = &dataloader.Result[*time.Time]{Data: m[k]}
+					roles := result[k]
+					if roles == nil {
+						roles = []*domain.Role{}
+					}
+					out[i] = &dataloader.Result[[]*domain.Role]{Data: roles}
 				}
 				return out
 			},
@@ -35,7 +87,7 @@ func TestUserResolver_LastSignInAt_ReturnsLoaderValue(t *testing.T) {
 	t.Parallel()
 
 	ts := time.Date(2026, 6, 15, 10, 30, 0, 0, time.UTC)
-	ctx := ctxWithLastSignInLoader(context.Background(), map[string]*time.Time{"u-1": &ts})
+	ctx := ctxWithLastSignIn(authedCtx("u-1"), map[string]*time.Time{"u-1": &ts}, nil)
 
 	got, err := (&resolver.Resolver{}).User().LastSignInAt(ctx, &model.User{ID: "u-1"})
 	if err != nil {
@@ -49,7 +101,7 @@ func TestUserResolver_LastSignInAt_ReturnsLoaderValue(t *testing.T) {
 func TestUserResolver_LastSignInAt_NilWhenNeverSignedIn(t *testing.T) {
 	t.Parallel()
 
-	ctx := ctxWithLastSignInLoader(context.Background(), map[string]*time.Time{})
+	ctx := ctxWithLastSignIn(authedCtx("u-2"), map[string]*time.Time{}, nil)
 
 	got, err := (&resolver.Resolver{}).User().LastSignInAt(ctx, &model.User{ID: "u-2"})
 	if err != nil {
@@ -63,7 +115,7 @@ func TestUserResolver_LastSignInAt_NilWhenNeverSignedIn(t *testing.T) {
 func TestUserResolver_LastSignInAt_MissingLoaderMiddlewareInternal(t *testing.T) {
 	t.Parallel()
 
-	_, err := (&resolver.Resolver{}).User().LastSignInAt(context.Background(), &model.User{ID: "u-1"})
+	_, err := (&resolver.Resolver{}).User().LastSignInAt(authedCtx("u-1"), &model.User{ID: "u-1"})
 	if err == nil {
 		t.Fatal("want error when loader middleware is not installed, got nil")
 	}
@@ -75,24 +127,13 @@ func TestUserResolver_LastSignInAt_MissingLoaderMiddlewareInternal(t *testing.T)
 // ctxWithLastSignInLoaderError installs a LastSignInByUserID loader whose batch
 // function fails every key with loadErr.
 func ctxWithLastSignInLoaderError(base context.Context, loadErr error) context.Context {
-	loaders := &loader.Loaders{
-		LastSignInByUserID: dataloader.NewBatchedLoader(
-			func(_ context.Context, keys []string) []*dataloader.Result[*time.Time] {
-				out := make([]*dataloader.Result[*time.Time], len(keys))
-				for i := range keys {
-					out[i] = &dataloader.Result[*time.Time]{Error: loadErr}
-				}
-				return out
-			},
-		),
-	}
-	return loader.WithContext(base, loaders)
+	return ctxWithLastSignInCounter(base, &lastSignInBatchCounter{loadError: loadErr}, &mockRoleByUserIDRepo{})
 }
 
 func TestUserResolver_LastSignInAt_ContextCancelledReturnsCancelled(t *testing.T) {
 	t.Parallel()
 
-	ctx := ctxWithLastSignInLoaderError(context.Background(), context.Canceled)
+	ctx := ctxWithLastSignInLoaderError(authedCtx("u-1"), context.Canceled)
 	_, err := (&resolver.Resolver{}).User().LastSignInAt(ctx, &model.User{ID: "u-1"})
 	if !gqlerr.IsCode(err, gqlerr.CodeCancelled) {
 		t.Fatalf("want CANCELLED wire code for context.Canceled loader error, got %v", err)
@@ -102,9 +143,208 @@ func TestUserResolver_LastSignInAt_ContextCancelledReturnsCancelled(t *testing.T
 func TestUserResolver_LastSignInAt_GenericLoaderErrorReturnsInternal(t *testing.T) {
 	t.Parallel()
 
-	ctx := ctxWithLastSignInLoaderError(context.Background(), errors.New("db down"))
+	ctx := ctxWithLastSignInLoaderError(authedCtx("u-1"), errors.New("db down"))
 	_, err := (&resolver.Resolver{}).User().LastSignInAt(ctx, &model.User{ID: "u-1"})
 	if !gqlerr.IsCode(err, gqlerr.CodeInternal) {
 		t.Fatalf("want INTERNAL wire code for a generic loader error, got %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// User.lastSignInAt self-or-admin gate
+// ---------------------------------------------------------------------------
+
+// TestUserResolver_LastSignInAt_Unauthenticated verifies that an anonymous
+// caller receives UNAUTHENTICATED even when the loaders are installed —
+// last_sign_in_at reveals whether and when an account was used, so it is never
+// readable without a caller identity.
+func TestUserResolver_LastSignInAt_Unauthenticated(t *testing.T) {
+	t.Parallel()
+
+	ts := time.Date(2026, 6, 15, 10, 30, 0, 0, time.UTC)
+	ctx := ctxWithLastSignIn(context.Background(), map[string]*time.Time{"u-1": &ts}, nil)
+
+	_, err := (&resolver.Resolver{}).User().LastSignInAt(ctx, &model.User{ID: "u-1"})
+	if !gqlerr.IsCode(err, gqlerr.CodeUnauthenticated) {
+		t.Fatalf("want UNAUTHENTICATED, got %v", err)
+	}
+}
+
+// TestUserResolver_LastSignInAt_NonAdminNonSelf_Forbidden verifies that a
+// non-admin caller reading another user's lastSignInAt receives FORBIDDEN with
+// the same "admin only" message User.roles uses, and that the timestamp does
+// not leak in the returned value.
+func TestUserResolver_LastSignInAt_NonAdminNonSelf_Forbidden(t *testing.T) {
+	t.Parallel()
+
+	ts := time.Date(2026, 6, 15, 10, 30, 0, 0, time.UTC)
+	ctx := ctxWithLastSignIn(
+		authedCtx("u-caller"),
+		map[string]*time.Time{"u-target": &ts},
+		map[string][]*domain.Role{"u-caller": {{ID: "r-general", Name: domain.GeneralRoleName}}},
+	)
+
+	got, err := (&resolver.Resolver{}).User().LastSignInAt(ctx, &model.User{ID: "u-target"})
+	if !gqlerr.IsCode(err, gqlerr.CodeForbidden) {
+		t.Fatalf("want FORBIDDEN, got %v", err)
+	}
+	if got != nil {
+		t.Fatalf("want no value on FORBIDDEN, got %v", got)
+	}
+
+	// The rejection must be indistinguishable from the User.roles one: same
+	// wire code, same message. Comparing against the error User.roles actually
+	// produces under an equivalent context pins both halves at once.
+	rolesCtx := ctxWithLastSignIn(
+		authedCtx("u-caller"),
+		nil,
+		map[string][]*domain.Role{"u-caller": {{ID: "r-general", Name: domain.GeneralRoleName}}},
+	)
+	_, rolesErr := (&resolver.Resolver{}).User().Roles(rolesCtx, &model.User{ID: "u-target"})
+	if err.Error() != rolesErr.Error() {
+		t.Fatalf("want the User.roles rejection %q, got %q", rolesErr.Error(), err.Error())
+	}
+}
+
+// TestUserResolver_LastSignInAt_Self_Allowed verifies that a non-admin caller
+// reads their own lastSignInAt without a roles lookup at all.
+func TestUserResolver_LastSignInAt_Self_Allowed(t *testing.T) {
+	t.Parallel()
+
+	ts := time.Date(2026, 6, 15, 10, 30, 0, 0, time.UTC)
+	roleRepo := &mockRoleByUserIDRepo{}
+	ctx := ctxWithLastSignInCounter(
+		authedCtx("u-self"),
+		&lastSignInBatchCounter{byUserID: map[string]*time.Time{"u-self": &ts}},
+		roleRepo,
+	)
+
+	got, err := (&resolver.Resolver{}).User().LastSignInAt(ctx, &model.User{ID: "u-self"})
+	if err != nil {
+		t.Fatalf("LastSignInAt: %v", err)
+	}
+	if got == nil || !got.Equal(ts) {
+		t.Fatalf("got %v, want %v", got, ts)
+	}
+	if roleRepo.listCallCount != 0 {
+		t.Fatalf("self path must skip the admin check, got %d roles queries", roleRepo.listCallCount)
+	}
+}
+
+// TestUserResolver_LastSignInAt_SelfNeverSignedIn_Allowed pins the nil
+// (never-signed-in) case on the self path: nil is a value, not a rejection.
+func TestUserResolver_LastSignInAt_SelfNeverSignedIn_Allowed(t *testing.T) {
+	t.Parallel()
+
+	ctx := ctxWithLastSignIn(authedCtx("u-self"), map[string]*time.Time{}, nil)
+
+	got, err := (&resolver.Resolver{}).User().LastSignInAt(ctx, &model.User{ID: "u-self"})
+	if err != nil {
+		t.Fatalf("LastSignInAt: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("got %v, want nil (never signed in)", got)
+	}
+}
+
+// TestUserResolver_LastSignInAt_Admin_Allowed verifies that an admin caller
+// reads a foreign user's lastSignInAt, including the nil never-signed-in case.
+func TestUserResolver_LastSignInAt_Admin_Allowed(t *testing.T) {
+	t.Parallel()
+
+	ts := time.Date(2026, 6, 15, 10, 30, 0, 0, time.UTC)
+	rolesByUser := map[string][]*domain.Role{
+		"admin": {{ID: "r-admin", Name: domain.AdminRoleName}},
+	}
+
+	ctx := ctxWithLastSignIn(authedCtx("admin"), map[string]*time.Time{"u-target": &ts}, rolesByUser)
+	got, err := (&resolver.Resolver{}).User().LastSignInAt(ctx, &model.User{ID: "u-target"})
+	if err != nil {
+		t.Fatalf("LastSignInAt: %v", err)
+	}
+	if got == nil || !got.Equal(ts) {
+		t.Fatalf("got %v, want %v", got, ts)
+	}
+
+	// Never-signed-in foreign user: the admin still passes the gate and reads
+	// nil rather than an error.
+	nilCtx := ctxWithLastSignIn(authedCtx("admin"), map[string]*time.Time{}, rolesByUser)
+	gotNil, err := (&resolver.Resolver{}).User().LastSignInAt(nilCtx, &model.User{ID: "u-never"})
+	if err != nil {
+		t.Fatalf("LastSignInAt (never signed in): %v", err)
+	}
+	if gotNil != nil {
+		t.Fatalf("got %v, want nil (never signed in)", gotNil)
+	}
+}
+
+// TestUserResolver_LastSignInAt_AdminCheckLoaderError verifies that a failure
+// of the caller's admin-status load classifies through classifyLoaderErr rather
+// than falling through to the value.
+func TestUserResolver_LastSignInAt_AdminCheckLoaderError(t *testing.T) {
+	t.Parallel()
+
+	ts := time.Date(2026, 6, 15, 10, 30, 0, 0, time.UTC)
+	loaders := &loader.Loaders{
+		LastSignInByUserID: dataloader.NewBatchedLoader(
+			(&lastSignInBatchCounter{byUserID: map[string]*time.Time{"u-target": &ts}}).batch,
+		),
+		RoleByUserID: dataloader.NewBatchedLoader(
+			func(_ context.Context, keys []string) []*dataloader.Result[[]*domain.Role] {
+				out := make([]*dataloader.Result[[]*domain.Role], len(keys))
+				for i := range keys {
+					out[i] = &dataloader.Result[[]*domain.Role]{Error: errors.New("db down")}
+				}
+				return out
+			},
+		),
+	}
+	ctx := loader.WithContext(authedCtx("u-caller"), loaders)
+
+	_, err := (&resolver.Resolver{}).User().LastSignInAt(ctx, &model.User{ID: "u-target"})
+	if !gqlerr.IsCode(err, gqlerr.CodeInternal) {
+		t.Fatalf("want INTERNAL for a failed admin-status load, got %v", err)
+	}
+}
+
+// usersWithLastSignInQuery requests the users list and resolves lastSignInAt
+// for each row, so the batched auth.users read can be counted.
+const usersWithLastSignInQuery = `{"query":"{ users(first: 3) { edges { node { id lastSignInAt } } } }"}`
+
+// TestAdminUserResolver_LastSignInAt_OneAuthUsersReadPerPage verifies that the
+// self-or-admin gate did not break batching: resolving lastSignInAt across a
+// page of users still issues exactly one auth.users read, with every row's key
+// in that single batch.
+func TestAdminUserResolver_LastSignInAt_OneAuthUsersReadPerPage(t *testing.T) {
+	t.Parallel()
+
+	ts := time.Date(2026, 6, 15, 10, 30, 0, 0, time.UTC)
+	mock := &mockAdminUserUsecase{
+		listResult: &usecase.AdminUserConnection{
+			Users: []*domain.User{
+				{ID: "u1"},
+				{ID: "u2"},
+				{ID: "u3"},
+			},
+			TotalCount: 3,
+		},
+	}
+	counter := &lastSignInBatchCounter{byUserID: map[string]*time.Time{"u1": &ts, "u3": &ts}}
+	roleRepo := &mockRoleByUserIDRepo{byUserID: map[string][]*domain.Role{
+		"admin": {{ID: "r-admin", Name: domain.AdminRoleName}},
+	}}
+	srv := newAdminUserSrv(mock)
+	ctx := ctxWithLastSignInCounter(authedCtx("admin"), counter, roleRepo)
+
+	resp := gqlRequest(t, srv, ctx, usersWithLastSignInQuery)
+	if errs, hasErrs := resp["errors"]; hasErrs {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+
+	if counter.calls != 1 {
+		t.Fatalf("expected exactly 1 batched auth.users read per page, got %d (keys: %v)", counter.calls, counter.lastKeys)
+	}
+	if len(counter.lastKeys) != 3 {
+		t.Fatalf("expected the single batch to carry all 3 rows, got keys: %v", counter.lastKeys)
 	}
 }


### PR DESCRIPTION
## Summary

`User.lastSignInAt` exposes a privileged authentication signal — whether and when an account was last used — but its field resolver ran no authorization check at all. It was safe only by the accident that no resolver currently hands a foreign `User` to a non-admin viewer, and nothing in the code recorded that dependency. `User.roles`, the sibling privileged field on the same type, already carries the correct self-or-admin gate; the backend auth documentation states that field-level resolvers exposing privileged data must perform their own admin-or-self check because an object-level gate on `Query.users` covers exactly one of the several entry points that return a `User`. This change applies `Roles`' guard verbatim to `LastSignInAt`: an anonymous caller gets `gqlerr.Unauthenticated()`, a caller reading their own value passes unconditionally, and reading another user's value requires the admin role computed from the same `RoleByUserID` batch, rejected with `gqlerr.NewForbidden("admin only")`. The batching property is preserved by registering the `LastSignInByUserID` load for the target before blocking on the caller's admin-status load, exactly as `Roles` does — so a page of users still costs one `auth.users` read. `Cardgroup.Owner`, the resolver most likely to one day hand a foreign `User` to a non-admin, gains a comment naming the invariant it relies on. No schema text changed, so no gqlgen regeneration was needed.

## Changes

- **`backend/graph/resolver/admin.resolvers.go`** — `userResolver.LastSignInAt` gains the self-or-admin gate. After the existing `loadersOrInternal` check it reads `auth.UserFrom(ctx)` and returns `gqlerr.Unauthenticated()` for a nil/empty-sub caller. It then registers `loaders.LastSignInByUserID.Load(ctx, obj.ID)` as a thunk *before* the admin-status load so both keys share one batch window. When `caller.Sub != obj.ID` it resolves the caller's roles via `loaders.RoleByUserID.Load(ctx, caller.Sub)()`, classifies a load failure through `classifyLoaderErr(ctx, err, "resolver: last sign in: admin check")`, builds a `domain.RoleSet` (skipping nil entries defensively, as `Roles` does) and returns `gqlerr.NewForbidden("admin only")` when `ContainsAdmin()` is false. Only then is the thunk resolved. The docstring records why the gate lives in the field resolver rather than on any one query.
- **`backend/graph/resolver/cardgroup.resolvers.go`** — six-line doc comment on `cardgroupResolver.Owner` naming the invariant: the resolver has no gate of its own, privileged `User` fields are protected field-by-field (`User.roles`, `User.lastSignInAt`), and any new privileged field on `User` must carry the same field-level guard. Behaviour unchanged, per the issue's out-of-scope list.

### Tests

All in `backend/graph/resolver/last_sign_in_resolver_test.go` (12 tests in the `LastSignIn` selector, up from 5).

- Test harness rewritten: `lastSignInBatchCounter` records batch-call count and the keys of the most recent batch; `ctxWithLastSignInCounter` installs both a `LastSignInByUserID` loader and a `RoleByUserID` loader (reusing the package's existing `mockRoleByUserIDRepo`) so the gate's admin lookup is exercisable. `ctxWithLastSignIn` is the convenience wrapper.
- The five pre-existing tests (`ReturnsLoaderValue`, `NilWhenNeverSignedIn`, `MissingLoaderMiddlewareInternal`, `ContextCancelledReturnsCancelled`, `GenericLoaderErrorReturnsInternal`) now run under `authedCtx(<same id as obj.ID>)` — they previously used a bare `context.Background()`, which the new gate correctly rejects. They still pin the same loader-error classification behaviour on the self path.
- `TestUserResolver_LastSignInAt_Unauthenticated` — anonymous caller with loaders installed gets `CodeUnauthenticated`.
- `TestUserResolver_LastSignInAt_NonAdminNonSelf_Forbidden` — a general-role caller reading `u-target` gets `CodeForbidden` and a nil value. The message is pinned *by comparison against the error `User.Roles` actually returns* under an equivalent context, so the two rejections are provably indistinguishable in code and message rather than duplicating a literal.
- `TestUserResolver_LastSignInAt_Self_Allowed` — self path returns the value and asserts `mockRoleByUserIDRepo.listCallCount == 0`, proving the admin lookup is skipped entirely.
- `TestUserResolver_LastSignInAt_SelfNeverSignedIn_Allowed` — the `nil` never-signed-in case on the self path is a value, not a rejection.
- `TestUserResolver_LastSignInAt_Admin_Allowed` — admin reads a foreign user's timestamp, and in a second context reads `nil` for a never-signed-in foreign user.
- `TestUserResolver_LastSignInAt_AdminCheckLoaderError` — a failing `RoleByUserID` batch surfaces `CodeInternal` instead of falling through to the value.
- `TestAdminUserResolver_LastSignInAt_OneAuthUsersReadPerPage` — full gqlgen request (`{ users(first: 3) { edges { node { id lastSignInAt } } } }`) through `newAdminUserSrv` with an admin caller; asserts the batch counter recorded exactly 1 call carrying all 3 row keys. This is the acceptance criterion that the gate did not break the batch window.

### Review follow-up

- **`Cardgroup.Owner` docblock now records the invariant that actually holds.** The first draft of the comment claimed privileged `User` fields are "protected field-by-field", which reads as a completeness guarantee for the whole type. Only two of `User`'s five field resolvers carry a self-or-admin check (`User.roles`, `User.lastSignInAt`); `User.lastViewedCardgroup`, `User.learnDisplayMode` and `User.newCardRatio` resolve straight off `obj.ID` through the `UserPreference` loader with no caller lookup.
- **The rewritten comment states the reachability invariant instead** — `Query.cardgroup` returns null for a non-owner and a missing id alike, and every other edge to a `Cardgroup` is caller-scoped, so no non-owner reaches a foreign `User` through this resolver today — and then names the gated and ungated field sets explicitly, so a contributor adding a shared- or published-deck resolver sees the guard work they inherit rather than concluding the type is already safe.
- **No behavioural change.** The three ungated fields are deliberately left as-is; gating them is out of scope for this branch. Comment-only edit, no schema change, no gqlgen regeneration.

## Test plan

- [ ] cd backend && go build ./... — PASS
- [ ] cd backend && go vet ./... — PASS (no issues)
- [ ] cd backend && go tool go-arch-lint check — PASS (OK - No warnings found)
- [ ] cd backend && go test ./internal/... ./graph/... — PASS, 2104 tests across 22 packages
- [ ] cd backend && go test ./... — PASS, 2263 tests across 26 packages
- [ ] cd backend && go test ./graph/resolver/ -run LastSignIn -v — PASS, 12 tests
- [ ] cd backend && gofmt -l graph/resolver/ — no output (clean)
- [ ] git status --short in main checkout /Users/yasuflatland/projects/flamingo-armond — empty (main tree untouched)
- [ ] cd backend && go build ./... → Success
- [ ] cd backend && go vet ./... → No issues found
- [ ] cd backend && go tool go-arch-lint check → OK - No warnings found
- [ ] cd backend && go test -count=1 ./... → 2263 passed in 26 packages

## Notes

Evidence-citation verification against the worktree HEAD: `admin.resolvers.go:154-192` (`Roles`, with `auth.UserFrom` at :159, `gqlerr.Unauthenticated()` at :161, the `caller.Sub != obj.ID` branch at :168 and `gqlerr.NewForbidden("admin only")` at :183) held exactly. `LastSignInAt` was at :193-207 rather than the cited :197-207 — a 4-line drift on the leading comment only, the body matched. `docs/backend-auth.md:90-113` ("Authorization gates: object-level vs. field-level", with the quoted sentence at :94) held. `schema/admin.graphql:82-87` for the `extend type User` block held (one line earlier than the cited :83-87). `cardgroup.resolvers.go:16-27` for `Owner` held. No citation was materially wrong.

Two implementation details worth a reviewer's attention. First, `err.Error()` on a `*gqlerror.Error` renders as `"input: admin only"`, not `"admin only"` — the first attempt at the byte-for-byte message assertion failed on that. Rather than hardcode the rendered string, the test compares against the error `User.Roles` returns under an equivalent context, which is a stronger pin: if either guard's message drifts, the test fails. Second, `cardgroup.resolvers.go` is a gqlgen-managed file, but gqlgen copies resolver implementations (and their leading doc comments) through on regeneration, so the added comment survives a future `go tool gqlgen generate`; the same file already carries a multi-paragraph comment on `CreateCardgroup` as precedent.

Production diff is 36 changed lines in `admin.resolvers.go` plus 6 in `cardgroup.resolvers.go` — far under the 800-line ceiling. All added text is English; no PR numbers or "this PR" phrasing in committed text.

**Scope deviations.** none — both Scope checkboxes implemented, nothing from Out of scope touched. `Cardgroup.owner` behaviour is unchanged (comment only), `schema/admin.graphql` is untouched so no gqlgen run was needed, and the guard was duplicated rather than extracted into a shared helper as the issue directs. One judgement call inside scope: the five pre-existing `LastSignInAt` tests had to be re-based onto an authenticated context, because they were written against the ungated resolver and the new `Unauthenticated()` branch fires first. They keep their original assertions.

Only 1 of the 4 raw findings survived refutation and it was documentation-only, so the diff on top of HEAD is a single comment block. Nothing was disputed. Path discipline held: `git status --short` in the main checkout at /Users/yasuflatland/projects/flamingo-armond is empty, and the worktree shows exactly one modified file (`backend/graph/resolver/cardgroup.resolvers.go`). No git write operations were performed. The CJK gate (`perl -CSD` over the edited file) is clean; the em dashes are U+2014, outside the CJK ranges. The comment carries no PR-number or "this PR" references.

Closes #1024
