### PR TITLE
fix(frontend): fall back to refetch when the infinite-scroll retry carries a dead cursor

### DIFF
--- a/frontend/src/lib/pagination/use-connection-pagination.test.tsx
+++ b/frontend/src/lib/pagination/use-connection-pagination.test.tsx
@@ -411,6 +411,278 @@ describe("useConnectionPagination", () => {
     expect(result.current.edges[2]?.node.id).toBe(CG_3.id);
   });
 
+  it("dead-cursor fetchMore rejection makes retryFetchMore refetch instead of re-sending the cursor", async () => {
+    // The row CG_2 points at was deleted between page fetches, so the backend
+    // rejects `after: cg-2` with a field-level BAD_USER_INPUT keyed on the
+    // cursor argument. Re-sending that cursor can never succeed, so Retry must
+    // re-issue the query from the first page. Only ONE mock is provided for the
+    // dead cursor: if Retry re-sent it, MockedProvider would have no match and
+    // the leak spy would fail the run.
+    const CG_4 = {
+      __typename: "Cardgroup" as const,
+      id: "cg-4",
+      name: "Delta",
+      updatedAt: "2024-03-01T04:00:00.000Z",
+    };
+
+    const cache = new InMemoryCache();
+    seedCache(cache, connection([CG_1, CG_2], true));
+
+    const deadCursorMock = {
+      request: {
+        query: MyCardgroupsConnectionDocument,
+        variables: { ...DEFAULT_VARS, after: CG_2.id, search: null },
+      },
+      result: {
+        errors: [
+          new GraphQLError("cursor not found", {
+            extensions: { code: "BAD_USER_INPUT", field: "after" },
+          }),
+        ],
+      },
+    };
+    // The refetch re-issues the base query (no `after`) and returns a list that
+    // no longer contains the deleted row, with a fresh cursor to continue from.
+    const refetchMock = {
+      request: { query: MyCardgroupsConnectionDocument, variables: DEFAULT_VARS },
+      result: { data: { myCardgroupsConnection: connection([CG_1, CG_3], true) } },
+    };
+    const afterRefetchMock = {
+      request: {
+        query: MyCardgroupsConnectionDocument,
+        variables: { ...DEFAULT_VARS, after: CG_3.id, search: null },
+      },
+      result: { data: { myCardgroupsConnection: connection([CG_4]) } },
+    };
+
+    const { result } = renderProbe({
+      mocks: [deadCursorMock, refetchMock, afterRefetchMock],
+      cache,
+    });
+
+    act(() => {
+      fireIntersect();
+    });
+
+    await waitFor(() => {
+      expect(result.current.fetchMoreError).not.toBeNull();
+    });
+
+    act(() => {
+      result.current.retryFetchMore();
+    });
+
+    // The refreshed first page replaces the stale edges — proof the retry went
+    // through refetch, not through fetchMore with the dead cursor.
+    await waitFor(() => {
+      expect(result.current.edges.map((e) => e.node.id)).toEqual([CG_1.id, CG_3.id]);
+    });
+    expect(result.current.fetchMoreError).toBeNull();
+
+    // The banner is cleared and the observer is re-armed, so the loop resumes
+    // off the refreshed cursor.
+    expect(latestObserver()).toBeDefined();
+    act(() => {
+      fireIntersect();
+    });
+    await waitFor(() => {
+      expect(result.current.edges).toHaveLength(3);
+    });
+    expect(result.current.edges[2]?.node.id).toBe(CG_4.id);
+  });
+
+  it("dead-cursor Retry holds the in-flight guard so a re-armed observer cannot re-send the dead cursor", async () => {
+    // Clearing the banner inside Retry re-arms the observer effect, and
+    // re-observing the still-visible sentinel delivers a fresh initial record
+    // while the refetch is still in flight. `pageInfo.endCursor` is still the
+    // dead bookmark at that instant, so unless the refetch holds the same
+    // in-flight mutex `fetchNextPage` takes, that record re-sends the dead
+    // cursor — exactly the request the dead-cursor branch exists to stop.
+    let deadCursorRequests = 0;
+    const cache = new InMemoryCache();
+    seedCache(cache, connection([CG_1, CG_2], true));
+
+    const deadCursorRequest = {
+      query: MyCardgroupsConnectionDocument,
+      variables: { ...DEFAULT_VARS, after: CG_2.id, search: null },
+    };
+    const deadCursorResult = () => {
+      deadCursorRequests += 1;
+      return {
+        errors: [
+          new GraphQLError("cursor not found", {
+            extensions: { code: "BAD_USER_INPUT", field: "after" },
+          }),
+        ],
+      };
+    };
+    // Two identical dead-cursor mocks on purpose: a leaked second request must
+    // fail on the counter assertion below (which names the defect) rather than
+    // as an unmatched-mock warning in teardown.
+    const mocks = [
+      { request: deadCursorRequest, result: deadCursorResult },
+      { request: deadCursorRequest, result: deadCursorResult },
+      {
+        request: { query: MyCardgroupsConnectionDocument, variables: DEFAULT_VARS },
+        // Keeps the refetch in flight across the observer fire below.
+        delay: 30,
+        result: { data: { myCardgroupsConnection: connection([CG_1, CG_3], true) } },
+      },
+    ];
+
+    const { result } = renderProbe({ mocks, cache });
+
+    act(() => {
+      fireIntersect();
+    });
+
+    await waitFor(() => {
+      expect(result.current.fetchMoreError).not.toBeNull();
+    });
+    expect(deadCursorRequests).toBe(1);
+
+    act(() => {
+      result.current.retryFetchMore();
+    });
+    // The banner is cleared and the observer re-armed, but the refetch has not
+    // resolved: the guard must swallow this record.
+    act(() => {
+      fireIntersect();
+    });
+
+    await waitFor(() => {
+      expect(result.current.edges.map((e) => e.node.id)).toEqual([CG_1.id, CG_3.id]);
+    });
+    expect(deadCursorRequests).toBe(1);
+    expect(result.current.fetchMoreError).toBeNull();
+  });
+
+  it("a failed dead-cursor refetch releases the in-flight guard, so a later Retry resumes the loop", async () => {
+    // The guard the Retry path takes must be released on the FAILURE arm too.
+    // A guard that leaked on rejection would wedge the observer permanently:
+    // every later intersection record would be swallowed and the list could
+    // never advance again, which is worse than the dead cursor it replaced.
+    const CG_4 = {
+      __typename: "Cardgroup" as const,
+      id: "cg-4",
+      name: "Delta",
+      updatedAt: "2024-03-01T04:00:00.000Z",
+    };
+
+    const cache = new InMemoryCache();
+    seedCache(cache, connection([CG_1, CG_2], true));
+
+    const baseRequest = { query: MyCardgroupsConnectionDocument, variables: DEFAULT_VARS };
+    const mocks = [
+      {
+        request: {
+          query: MyCardgroupsConnectionDocument,
+          variables: { ...DEFAULT_VARS, after: CG_2.id, search: null },
+        },
+        result: {
+          errors: [
+            new GraphQLError("cursor not found", {
+              extensions: { code: "BAD_USER_INPUT", field: "after" },
+            }),
+          ],
+        },
+      },
+      // First Retry: the refetch itself fails.
+      { request: baseRequest, error: new Error("network down") },
+      // Second Retry: the refetch succeeds and refreshes the cursor.
+      {
+        request: baseRequest,
+        result: { data: { myCardgroupsConnection: connection([CG_1, CG_3], true) } },
+      },
+      {
+        request: {
+          query: MyCardgroupsConnectionDocument,
+          variables: { ...DEFAULT_VARS, after: CG_3.id, search: null },
+        },
+        result: { data: { myCardgroupsConnection: connection([CG_4]) } },
+      },
+    ];
+
+    const { result } = renderProbe({ mocks, cache });
+
+    act(() => {
+      fireIntersect();
+    });
+    await waitFor(() => {
+      expect(result.current.fetchMoreError).not.toBeNull();
+    });
+
+    act(() => {
+      result.current.retryFetchMore();
+    });
+    // The failed refetch re-raises the banner and keeps Retry on this path.
+    await waitFor(() => {
+      expect(result.current.fetchMoreError).not.toBeNull();
+    });
+
+    act(() => {
+      result.current.retryFetchMore();
+    });
+    await waitFor(() => {
+      expect(result.current.edges.map((e) => e.node.id)).toEqual([CG_1.id, CG_3.id]);
+    });
+    expect(result.current.fetchMoreError).toBeNull();
+
+    // The guard is free again: the re-armed observer advances off the fresh cursor.
+    expect(latestObserver()).toBeDefined();
+    act(() => {
+      fireIntersect();
+    });
+    await waitFor(() => {
+      expect(result.current.edges).toHaveLength(3);
+    });
+    expect(result.current.edges[2]?.node.id).toBe(CG_4.id);
+  });
+
+  it("network fetchMore rejection still retries via fetchMore with the same endCursor", async () => {
+    // The transport failed, not the cursor: the bookmark is still valid, so the
+    // existing same-cursor retry path must be preserved. Both mocks are keyed on
+    // `after: cg-2` — a retry that refetched the base query instead would leave
+    // the second mock unconsumed and never reach three edges.
+    const cache = new InMemoryCache();
+    seedCache(cache, connection([CG_1, CG_2], true));
+
+    const networkErrorMock = {
+      request: {
+        query: MyCardgroupsConnectionDocument,
+        variables: { ...DEFAULT_VARS, after: CG_2.id, search: null },
+      },
+      error: new Error("network down"),
+    };
+    const retryMock = {
+      request: {
+        query: MyCardgroupsConnectionDocument,
+        variables: { ...DEFAULT_VARS, after: CG_2.id, search: null },
+      },
+      result: { data: { myCardgroupsConnection: connection([CG_3]) } },
+    };
+
+    const { result } = renderProbe({ mocks: [networkErrorMock, retryMock], cache });
+
+    act(() => {
+      fireIntersect();
+    });
+
+    await waitFor(() => {
+      expect(result.current.fetchMoreError).not.toBeNull();
+    });
+
+    act(() => {
+      result.current.retryFetchMore();
+    });
+
+    await waitFor(() => {
+      expect(result.current.edges).toHaveLength(3);
+    });
+    expect(result.current.edges[2]?.node.id).toBe(CG_3.id);
+    expect(result.current.fetchMoreError).toBeNull();
+  });
+
   it("searchQuery change clears fetchMoreError via the immediate-reset effect", async () => {
     const cache = new InMemoryCache();
     const page1 = connection([CG_1, CG_2], true);

--- a/frontend/src/lib/pagination/use-connection-pagination.ts
+++ b/frontend/src/lib/pagination/use-connection-pagination.ts
@@ -7,7 +7,26 @@ import {
 import { useQuery } from "@apollo/client/react";
 import type { RefObject } from "react";
 import { useCallback, useEffect, useEffectEvent, useRef, useState } from "react";
+import { getBackendFieldErrors } from "@/lib/apollo/errors";
 import type { FetchNextPageInput } from "@/lib/pagination/types";
+
+/** The connection arguments a backend cursor-not-found error can be keyed on. */
+const CURSOR_ARGUMENT_FIELDS = ["after", "before"] as const;
+
+/**
+ * True when a rejected page request carries the backend's dead-cursor shape: a
+ * field-level `BAD_USER_INPUT` keyed on a cursor argument. The backend emits it
+ * when the row a cursor points at no longer exists (deleted between page
+ * fetches), so re-sending the same cursor can never succeed.
+ *
+ * Classified structurally off `extensions` via the shared `getBackendFieldErrors`
+ * parser — never by substring-matching the message, per
+ * .claude/rules/frontend-rsc-error-handling.md.
+ */
+function isDeadCursorError(err: unknown): boolean {
+  const fields = getBackendFieldErrors(err);
+  return CURSOR_ARGUMENT_FIELDS.some((field) => field in fields);
+}
 
 /** Minimal `pageInfo` shape the IO loop reads: the next-page flag and the cursor. */
 interface PageInfoLike {
@@ -128,6 +147,11 @@ export function useConnectionPagination<
   // In-flight guard MUST be useRef<boolean>, not useState — see
   // docs/pagination/intersection-observer-in-flight-guard.md.
   const fetchingRef = useRef(false);
+  // Set when the last page request failed because its cursor row no longer
+  // exists. Retry then re-issues the whole query instead of re-sending the dead
+  // bookmark, which would fail identically forever. A ref (not state) because
+  // no render output reads it — the banner is driven by `fetchMoreError`.
+  const deadCursorRef = useRef(false);
 
   // When the active search query changes, any in-flight fetchMore from the
   // previous search holds a stale cursor. Reset the IO guard and error state
@@ -136,6 +160,7 @@ export function useConnectionPagination<
   // biome-ignore lint/correctness/useExhaustiveDependencies: searchQuery is an intentional trigger dependency; it is not referenced in the body because the effect resets derived IO state, not searchQuery itself.
   useEffect(() => {
     fetchingRef.current = false;
+    deadCursorRef.current = false;
     setFetchMoreError(null);
   }, [searchQuery]);
 
@@ -172,9 +197,11 @@ export function useConnectionPagination<
       })
         .then(() => {
           // Clear any previous fetchMore error on success so the observer can resume.
+          deadCursorRef.current = false;
           setFetchMoreError(null);
         })
         .catch((err) => {
+          deadCursorRef.current = isDeadCursorError(err);
           // Structured warn for operator triage: name + request context only.
           // err.message is omitted — backend messages may carry user-authored content.
           // See docs/frontend/rsc-error-handling/redact-err-message-from-console-payloads.md.
@@ -225,12 +252,53 @@ export function useConnectionPagination<
 
   const retryFetchMore = useCallback(() => {
     setFetchMoreError(null);
+    if (deadCursorRef.current) {
+      // The cursor the last request carried points at a deleted row, so the
+      // same-cursor retry below can never succeed. Re-issue the query from the
+      // first page instead; the observer loop resumes off the refreshed
+      // pageInfo. The flag is cleared only on success, so a failed refetch
+      // keeps Retry on this path rather than falling back to the dead cursor.
+      //
+      // The refetch takes the same in-flight mutex `fetchNextPage` takes at its
+      // own entry. Clearing `fetchMoreError` above re-arms the observer effect,
+      // and re-observing the still-visible sentinel delivers a fresh initial
+      // record while the refetch is still in flight — `pageInfo` has not been
+      // refreshed yet, so an unguarded observer fire would re-send the very
+      // cursor this branch exists to stop. The mutex is released in `.finally`
+      // so a failed refetch cannot wedge the observer loop shut.
+      fetchingRef.current = true;
+      refetch()
+        .then(() => {
+          deadCursorRef.current = false;
+        })
+        .catch((err) => {
+          // Structured warn for operator triage: name + request context only.
+          // err.message is omitted — backend messages may carry user-authored content.
+          console.warn(`${logScope} refetch after dead cursor failed`, {
+            name: err instanceof Error ? err.name : "unknown",
+            searchQuery,
+          });
+          setFetchMoreError(resolveFetchMoreError(err));
+        })
+        .finally(() => {
+          fetchingRef.current = false;
+        });
+      return;
+    }
     fetchNextPage({
       hasNextPage: pageInfo.hasNextPage,
       endCursor: pageInfo.endCursor ?? null,
       searchQuery,
     });
-  }, [fetchNextPage, pageInfo.endCursor, pageInfo.hasNextPage, searchQuery]);
+  }, [
+    fetchNextPage,
+    pageInfo.endCursor,
+    pageInfo.hasNextPage,
+    searchQuery,
+    refetch,
+    resolveFetchMoreError,
+    logScope,
+  ]);
 
   const fetchingMore = networkStatus === NetworkStatus.fetchMore || (loading && edges.length > 0);
 


### PR DESCRIPTION
## Summary

The infinite-scroll Retry button was a fixpoint: when the row a cursor pointed at was deleted between page fetches, the backend rejected the next page with a field-level `BAD_USER_INPUT` on the cursor argument, and `retryFetchMore` re-read the same `pageInfo.endCursor` and re-sent it — so Retry could never succeed. The shared `useConnectionPagination` hook now classifies the rejection and records whether the cursor itself is dead. Classification is structural: it reuses the existing `getBackendFieldErrors` parser from `@/lib/apollo/errors` and asks whether the returned field map is keyed on `after` or `before`, so nothing substring-matches a GraphQL message. When the recorded failure is a dead cursor, Retry calls the hook's already-exposed `refetch()` — re-issuing the query from the first page — instead of re-sending the bookmark; the flag clears only on refetch success, so a transport failure during the refetch keeps Retry on the escape-hatch path rather than falling back to the dead cursor. Plain network/transport rejections are untouched and still retry via `fetchMore` with the same `endCursor`. The dead-cursor flag also resets on the existing `searchQuery` immediate-reset effect, alongside the in-flight guard. The hook stays the single IO owner: no consuming screen changed, and the `pagination-ref-triplet-removal-rule.test.ts` guard is unaffected.

## Changes

- **`frontend/src/lib/pagination/use-connection-pagination.ts`**
  - Added a module-scoped `isDeadCursorError(err)` predicate plus the `CURSOR_ARGUMENT_FIELDS = ["after", "before"]` constant. It delegates to the shared `getBackendFieldErrors` structural parser (`@/lib/apollo/errors`) and returns true when the field map is keyed on a cursor argument — i.e. the backend's `ucerr.NewValidationError(field, "cursor not found")` shape — with no message substring matching.
  - Added a `deadCursorRef = useRef(false)` alongside the existing `fetchingRef`, with a comment explaining why it is a ref: no render output reads it (the banner is driven by `fetchMoreError`).
  - `fetchNextPage`'s `.catch` now sets `deadCursorRef.current = isDeadCursorError(err)`; its `.then` clears the flag on success. The `searchQuery` immediate-reset effect clears it too, so a new search never inherits a stale dead-cursor verdict.
  - `retryFetchMore` gained a leading dead-cursor branch: it calls `refetch()`, clears the flag in `.then`, and on rejection emits the same-style structured `console.warn` (`name` + `searchQuery`, `err.message` deliberately omitted) and restores the banner via `resolveFetchMoreError(err)`. The non-dead-cursor path falls through to the original `fetchNextPage({ hasNextPage, endCursor, searchQuery })` call unchanged. Dependency array extended with `refetch`, `resolveFetchMoreError`, `logScope`.
- **No consuming screen changed.** The five cursor-paginated list screens keep calling `retryFetchMore` with no signature change; the hook's public return type is unchanged.

### Tests

Two tests added to `frontend/src/lib/pagination/use-connection-pagination.test.tsx` (suite grew 7 → 9 tests, all passing):

- **`"dead-cursor fetchMore rejection makes retryFetchMore refetch instead of re-sending the cursor"`** — seeds page 1 `[cg-1, cg-2]` with `hasNextPage: true`, then answers the `after: "cg-2"` fetchMore with a single `GraphQLError` carrying `extensions: { code: "BAD_USER_INPUT", field: "after" }`. Exactly ONE mock exists for that dead cursor, so a Retry that re-sent it would leave MockedProvider without a match and the existing leak spy would fail the run. The test asserts Retry produces the refreshed base-query result (`edges` become `[cg-1, cg-3]`, the deleted row gone), that `fetchMoreError` is back to `null`, that the observer is re-armed (`latestObserver()` is defined), and that a subsequent intersect advances the loop off the refreshed cursor to `cg-4` — covering the "banner cleared and IO loop resumes" acceptance criterion in the same trace.
- **`"network fetchMore rejection still retries via fetchMore with the same endCursor"`** — the non-regression half. A transport-level `error: new Error("network down")` on `after: "cg-2"` is followed by a success mock keyed on the *same* `after: "cg-2"`; Retry must consume it and reach three edges. A retry that wrongly refetched the base query would leave the second mock unconsumed and never merge `cg-3`.

**Regression proof (test-first equivalent).** The dead-cursor test was verified to fail against the pre-fix behaviour: temporarily replacing `deadCursorRef.current = isDeadCursorError(err)` with `= false` produced `1 failed | 8 passed` with the leak spy reporting `Request variables: {"first":20,"search":null,"after":"cg-2"}` against available mocks `{"first":20,"search":null}` and `{"first":20,"search":null,"after":"cg-3"}` — i.e. Retry re-sending the permanently invalid bookmark. The file was restored and re-verified before running the gates.

### Review follow-up

## Review fix — dead-cursor Retry must hold the IntersectionObserver in-flight guard

Three independent review lenses converged on the same defect in the new dead-cursor branch of `retryFetchMore`, and it defeated the fix it was part of.

**The defect.** `retryFetchMore` clears `fetchMoreError` and, on the dead-cursor branch, dispatches `refetch()` — but never took `fetchingRef`, the same-tick mutex `fetchNextPage` acquires synchronously at its own entry. Clearing the banner is exactly what re-arms the observer effect (`fetchMoreError` is one of its deps), and re-observing the still-visible sentinel delivers a fresh initial `IntersectionObserver` record within a frame, far sooner than a network round-trip settles. At that instant `pageInfo.endCursor` is still the dead bookmark, so the observer callback's guard (`fetchingRef.current` false) let it through and `fetchMore({ after: <deleted-id> })` was re-issued — the precise request the change exists to stop. Its rejection then re-set `deadCursorRef` and re-rendered the "couldn't load more" banner moments after a Retry whose refetch actually succeeded. The pre-existing network-retry path was immune only because it goes through `fetchNextPage`, which takes the mutex before React commits.

**The fix.** The dead-cursor branch now mirrors `fetchNextPage`'s acquire/release shape: `fetchingRef.current = true` immediately before `refetch()`, released in a `.finally()` chained after the existing `.then`/`.catch`. `.finally` (rather than a release inside `.then`) is load-bearing — a guard leaked on the rejection arm would wedge the observer shut for the rest of the session, a strictly worse failure than the dead cursor it replaced.

**Tests.** Two new hook tests, each proven to fail without the corresponding half of the fix:

- *"dead-cursor Retry holds the in-flight guard so a re-armed observer cannot re-send the dead cursor"* — delays the refetch mock so it is still in flight, fires the observer callback synchronously after Retry, and asserts the dead cursor was requested exactly once. Two identical dead-cursor mocks are supplied on purpose so a leaked second request fails on the counter assertion (which names the defect) rather than as an unmatched-mock warning in teardown.
- *"a failed dead-cursor refetch releases the in-flight guard, so a later Retry resumes the loop"* — drives the rejection arm (failed refetch → banner re-raised → second Retry succeeds → observer advances off the refreshed cursor).

Removing the acquire turns the first test red (`expected 2 to be 1`); removing the `.finally` release turns the second test *and* the existing dead-cursor test red.

## Test plan

- [ ] frontend $ ./node_modules/.bin/tsc --noEmit — PASS (exit 0, no diagnostics)
- [ ] frontend $ ./node_modules/.bin/biome check --error-on-warnings . — PASS (exit 0; checked 520 files in 142ms, 0 errors, 2 pre-existing config-schema infos about the deprecated `linter` block in biome.jsonc)
- [ ] frontend $ ./node_modules/.bin/vitest run — PASS (206 test files, 1931 tests, 0 failed; the hook suite itself is 9 passed, up from 7)
- [ ] frontend $ ./node_modules/.bin/knip — PASS (exit 0; only the pre-existing configuration hint `@graphql-typed-document-node/core  knip.jsonc  Remove from ignoreDependencies`)
- [ ] frontend $ ./node_modules/.bin/vitest run src/app/pagination-ref-triplet-removal-rule.test.ts — PASS (1 file, 7 tests) — the guard still holds and no consuming screen gained an inline retry loop
- [ ] Pre-fix regression check (temporary edit, reverted): vitest run on the hook suite — 1 failed | 8 passed, leak spy shows Retry re-sending `after: "cg-2"`
- [ ] tsc --noEmit → exit 0 (no output)
- [ ] biome check --error-on-warnings . → exit 0; 520 files checked, 0 fixes, 2 pre-existing config-migration infos (biome.jsonc css.parser), not warnings
- [ ] vitest run (full suite) → Test Files 206 passed (206), Tests 1933 passed (1933), 12.93s
- [ ] knip → exit 0; 1 pre-existing configuration hint (@graphql-typed-document-node/core in knip.jsonc ignoreDependencies)
- [ ] git status --short in /Users/yasuflatland/projects/flamingo-armond (main checkout) → empty

## Notes

**Issue citations re-verified in the worktree at d06f30ea — all still hold, no drift.** `use-connection-pagination.ts:177-224` is the `.catch` arm with `setFetchMoreError(resolveFetchMoreError(err))` at `:186` and `if (fetchMoreError != null) return;` at `:213`; `retryFetchMore` at `:226-233`; `refetch` declared at `:89-94`, sourced at `:148`, returned at `:249`. Backend: `backend/internal/usecase/cardgroup.go:408-410` and `backend/internal/usecase/card.go:459-461` both `return nil, ucerr.NewValidationError(field, "cursor not found")` on `repository.ErrNotFound`; `backend/internal/repository/user.go:332-335` returns `ErrCursorNotFound`, mapped at `backend/internal/usecase/admin_user.go:228-232` to the same `ucerr.NewValidationError(field, "cursor not found")`.

**Why the field-name check is the right structural key.** Greps for the `field` argument show the only values ever passed are the literals `"after"` and `"before"` (`decodeCursorOrBadInput(after, "after")` / `(before, "before")` at `admin_user.go:205,209`, and the `field string` parameter threaded through the card/cardgroup cursor resolvers). So a field-level `BAD_USER_INPUT` on `after`/`before` is exactly the dead-or-malformed-cursor class, and both sub-cases want the same remedy (refetch). The check reads `extensions.code` + `extensions.field` through `getBackendFieldErrors`; the message string is never inspected.

**Design note on the ref-vs-state choice.** `deadCursorRef` is a ref, matching the file's existing `fetchingRef` idiom, because nothing in the render output branches on it — the banner is driven entirely by `fetchMoreError`, which is already state. Using state would have added a dependency to `retryFetchMore` and to the observer effect for no rendered difference.

**Failed-refetch semantics.** The flag is cleared only inside `refetch().then(...)`. If the refetch itself fails (transport down), the banner is re-raised and the *next* Retry still takes the refetch path rather than silently reverting to the known-dead cursor. This is the behaviour the issue asked for ("clear the dead-cursor flag on success").

**Diff size.** 58 lines added to the production file (comment-heavy, matching the file's existing comment density) and 124 to the test file — well inside the PR-sizing ceiling.

**Both frontend test trees checked.** `frontend/__tests__/` contains no test that exercises `useConnectionPagination`'s retry path; the guard `pagination-ref-triplet-removal-rule.test.ts` lives at `src/app/pagination-ref-triplet-removal-rule.test.ts` (not under `__tests__/` as the issue's phrasing might suggest) and passes. Language-policy greps on both changed files are clean: no CJK (`perl -CSD` scan, the macOS-correct form) and no `PR[0-9]+` references. `git -C /Users/yasuflatland/projects/flamingo-armond status --short` is empty — the main checkout was never touched.

**Scope deviations.** none — all three Scope checkboxes implemented, nothing from Out of scope touched. No backend file changed; no cursor-v2 work; the five consuming list screens are untouched (`git status --short` lists only the two hook files); banner copy and the localized `fetchMoreErrorMessage` threading are unchanged (the dead-cursor path reuses the caller-supplied `resolveFetchMoreError` exactly as the existing path does).

All three findings are the same single defect at `use-connection-pagination.ts`:261; one production edit (+12 lines, mostly the explanatory comment) resolves all three. Nothing was disputed.

Scope stayed inside the findings: only the `if (deadCursorRef.current)` branch changed, plus two added tests in the same test file. No consuming screen, backend, or doc was touched.

Worktree diff: `frontend/src/lib/pagination/use-connection-pagination.ts` +12, `frontend/src/lib/pagination/use-connection-pagination.test.tsx` +148 (uncommitted, as instructed). No git write operations were performed; the main checkout at /Users/yasuflatland/projects/flamingo-armond is clean.

One note on the RED/GREEN methodology for the release half: the *success*-path release was already implicitly pinned by the pre-existing test "dead-cursor fetchMore rejection makes retryFetchMore refetch instead of re-sending the cursor" (it fires the observer after the refetch resolves), which is why deleting the `.finally` turns two tests red rather than one.

Closes #1026
