### PR TITLE
fix(frontend): route the remaining hardcoded user-facing strings through the message catalogs

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -50,6 +50,11 @@
     "heading": "Something went wrong",
     "message": "An unexpected error occurred. Please try again."
   },
+  "RootError": {
+    "heading": "We couldn't load the app",
+    "message": "This can happen when the server is starting up. Please try again in a moment.",
+    "retry": "Try again"
+  },
   "Settings": {
     "heading": "Settings"
   },
@@ -76,7 +81,8 @@
     "sessionComplete": "Session complete",
     "sessionCompleteMessage": "There are no due cards left in this batch.",
     "reviewedCount": "{count, plural, one {You reviewed # card in this batch.} other {You reviewed # cards in this batch.}}",
-    "refreshCards": "Refresh cards"
+    "refreshCards": "Refresh cards",
+    "swipeSaveFailed": "Could not save that swipe. Please try again."
   },
   "Catalog": {
     "title": "Catalog",
@@ -99,6 +105,7 @@
     "signInAgain": "Sign in again",
     "viewDeckAriaLabel": "View {name}",
     "backToCatalog": "Back to catalog",
+    "loadingDeck": "Loading deck",
     "deckEmpty": "This deck has no cards yet.",
     "deckEmptySearch": "No cards match \"{query}\""
   },
@@ -126,6 +133,7 @@
     "renameCardgroupTitle": "Rename cardgroup",
     "deleteCardgroupTitle": "Delete cardgroup",
     "deleteCardgroupDesc": "This will permanently delete \"{name}\" and all its cards. This cannot be undone.",
+    "cardgroupDeleted": "Cardgroup \"{name}\" deleted",
     "mergeFromCatalog": "Merge from catalog",
     "mergeFromCatalogTitle": "Merge from catalog",
     "mergeSuccess": "Merge complete: added {added, number} / updated {updated, number}.",
@@ -400,6 +408,7 @@
     "editRoleTitle": "Edit role",
     "editRoleAriaLabel": "Edit role {name}",
     "deleteRoleAriaLabel": "Delete {name}",
+    "roleDeleted": "Role \"{name}\" deleted",
     "createRole": "Create",
     "deleteAuthFailed": "Your session has expired. Please sign in again.",
     "systemRole": "System role",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -50,6 +50,11 @@
     "heading": "エラーが発生しました",
     "message": "予期しないエラーが発生しました。もう一度お試しください。"
   },
+  "RootError": {
+    "heading": "アプリを読み込めませんでした",
+    "message": "サーバーの起動中に発生することがあります。少し待ってからもう一度お試しください。",
+    "retry": "もう一度試す"
+  },
   "Settings": {
     "heading": "設定"
   },
@@ -76,7 +81,8 @@
     "sessionComplete": "セッション完了",
     "sessionCompleteMessage": "このバッチに期限切れのカードはありません。",
     "reviewedCount": "{count, plural, other {このバッチで#枚のカードを復習しました。}}",
-    "refreshCards": "カードを更新"
+    "refreshCards": "カードを更新",
+    "swipeSaveFailed": "スワイプを保存できませんでした。もう一度お試しください。"
   },
   "Catalog": {
     "title": "カタログ",
@@ -99,6 +105,7 @@
     "signInAgain": "再度ログイン",
     "viewDeckAriaLabel": "{name} を見る",
     "backToCatalog": "カタログに戻る",
+    "loadingDeck": "デッキを読み込んでいます",
     "deckEmpty": "このデッキにはまだカードがありません。",
     "deckEmptySearch": "「{query}」に一致するカードはありません"
   },
@@ -126,6 +133,7 @@
     "renameCardgroupTitle": "カードグループ名を変更",
     "deleteCardgroupTitle": "カードグループを削除",
     "deleteCardgroupDesc": "「{name}」とそのすべてのカードが完全に削除されます。この操作は元に戻せません。",
+    "cardgroupDeleted": "カードグループ「{name}」を削除しました",
     "mergeFromCatalog": "カタログから統合",
     "mergeFromCatalogTitle": "カタログから統合",
     "mergeSuccess": "統合が完了しました。追加 {added, number} 件 / 更新 {updated, number} 件。",
@@ -400,6 +408,7 @@
     "editRoleTitle": "ロールを編集",
     "editRoleAriaLabel": "ロール「{name}」を編集",
     "deleteRoleAriaLabel": "「{name}」を削除",
+    "roleDeleted": "ロール「{name}」を削除しました",
     "createRole": "作成",
     "deleteAuthFailed": "セッションの有効期限が切れました。再度ログインしてください。",
     "systemRole": "システムロール",

--- a/frontend/src/app/admin/roles/admin-roles-client.test.tsx
+++ b/frontend/src/app/admin/roles/admin-roles-client.test.tsx
@@ -14,11 +14,25 @@ import {
 } from "@/generated/graphql";
 import { UndoDeleteProvider } from "@/lib/undo-delete";
 import { renderWithIntl } from "@/test/render-with-intl";
+import enMessages from "../../../../messages/en.json";
+import jaMessages from "../../../../messages/ja.json";
 import { AdminRolesClient, type RoleItem } from "./admin-roles-client";
 
 // ---------------------------------------------------------------------------
 // Runtime mocks
 // ---------------------------------------------------------------------------
+
+// sonner mock — captures the undo-toast label so the localized copy can be
+// asserted. Without a mounted <Toaster> the real toast() is a no-op, so this
+// is the only seam that observes the label.
+let lastToastLabel: string | undefined;
+vi.mock("sonner", () => ({
+  toast: vi.fn((label: string) => {
+    lastToastLabel = label;
+    return "toast-id";
+  }),
+  Toaster: () => null,
+}));
 
 let mockPathname = "/admin/roles";
 let mockSearchParamsValue = "";
@@ -77,14 +91,27 @@ const ADMIN_ROLE: RoleItem = { id: "r-admin", name: "admin" };
 // Helpers
 // ---------------------------------------------------------------------------
 
-function renderRoles(roles: RoleItem[], mocks: unknown[] = []) {
+function renderRoles(
+  roles: RoleItem[],
+  mocks: unknown[] = [],
+  intl?: { locale: "en" | "ja"; messages: typeof enMessages },
+) {
   renderWithIntl(
     <MockedProvider mocks={mocks as never}>
       <UndoDeleteProvider>
         <AdminRolesClient initialRoles={roles} />
       </UndoDeleteProvider>
     </MockedProvider>,
+    intl,
   );
+}
+
+/**
+ * Substitutes a single ICU `{name}` argument in a raw catalog string, so the
+ * undo-toast assertions stay sourced from `messages/*.json`.
+ */
+function withName(template: string, name: string) {
+  return template.replace("{name}", name);
 }
 
 function makeCodedError(code: string): CombinedGraphQLErrors {
@@ -103,6 +130,7 @@ beforeEach(() => {
   mockPush.mockReset();
   mockReplace.mockReset();
   mockRefresh.mockReset();
+  lastToastLabel = undefined;
 });
 
 afterEach(() => {
@@ -718,6 +746,36 @@ describe("AdminRolesClient — edit role sheet", () => {
     } finally {
       warnSpy.mockRestore();
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AdminRolesClient — undo-toast label (localized copy + {name} argument)
+// ---------------------------------------------------------------------------
+
+describe("AdminRolesClient — undo-toast label", () => {
+  it.each([
+    ["en" as const, enMessages],
+    ["ja" as const, jaMessages],
+  ])("renders the %s undo-toast label with the {name} argument", async (locale, messages) => {
+    const user = userEvent.setup();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+
+    const mocks = [
+      {
+        request: { query: AdminDeleteRoleDocument, variables: { id: CUSTOM_ROLE.id } },
+        result: { data: { adminDeleteRole: true } },
+      },
+    ];
+    renderRoles([CUSTOM_ROLE], mocks, { locale, messages });
+
+    await user.click(screen.getByTestId(`admin-role-delete-btn-${CUSTOM_ROLE.id}`));
+
+    expect(lastToastLabel).toBe(withName(messages.Admin.roleDeleted, CUSTOM_ROLE.name));
+
+    act(() => vi.advanceTimersByTime(5100));
+    vi.useRealTimers();
+    await waitFor(() => {});
   });
 });
 

--- a/frontend/src/app/admin/roles/admin-roles-client.tsx
+++ b/frontend/src/app/admin/roles/admin-roles-client.tsx
@@ -276,7 +276,7 @@ export function AdminRolesClient({ initialRoles }: Props) {
 
     scheduleDelete({
       id,
-      label: `Role "${role.name}" deleted`,
+      label: t("roleDeleted", { name: role.name }),
       optimisticRollback: () => {
         setRoles((prev) => [...prev.slice(0, index), role, ...prev.slice(index)]);
       },

--- a/frontend/src/app/cardgroups/cardgroups-client.test.tsx
+++ b/frontend/src/app/cardgroups/cardgroups-client.test.tsx
@@ -16,6 +16,8 @@ import {
   type ApolloMockLeakSpyResult,
   installApolloMockLeakSpy,
 } from "../../../__tests__/utils/mock-apollo-paginated";
+import enMessages from "../../../messages/en.json";
+import jaMessages from "../../../messages/ja.json";
 import CardgroupsClient from "./cardgroups-client";
 import { CARDGROUPS_DEFAULT_VARS, CARDGROUPS_PAGE_SIZE } from "./queries";
 
@@ -168,6 +170,7 @@ function renderClient(
   mocks: unknown[],
   initialConnection: ReturnType<typeof makeConnection> | null = null,
   cache?: InMemoryCache,
+  intl?: { locale: "en" | "ja"; messages: typeof enMessages },
 ) {
   renderWithIntl(
     <MockedProvider mocks={mocks as never} cache={cache}>
@@ -175,7 +178,17 @@ function renderClient(
         <CardgroupsClient initialConnection={initialConnection} />
       </UndoDeleteProvider>
     </MockedProvider>,
+    intl,
   );
+}
+
+/**
+ * Substitutes a single ICU `{name}` argument in a raw catalog string. Keeps the
+ * undo-toast assertions sourced from `messages/*.json` instead of re-spelling
+ * the copy, so a catalog edit surfaces here rather than silently diverging.
+ */
+function withName(template: string, name: string) {
+  return template.replace("{name}", name);
 }
 
 // ---------------------------------------------------------------------------
@@ -770,12 +783,55 @@ describe("<CardgroupsClient> delete — optimistic cache update and scheduleDele
     });
     await user.click(deleteBtn);
 
-    // scheduleDelete calls sonner toast — the mock captures the label.
-    expect(lastToastLabel).toBe(`Cardgroup "${CG_1.name}" deleted`);
+    // scheduleDelete calls sonner toast — the mock captures the label. The
+    // expectation is sourced from the catalog, so a hardcoded label would fail.
+    expect(lastToastLabel).toBe(withName(enMessages.Cardgroups.cardgroupDeleted, CG_1.name));
     // The Undo callback must be present.
     expect(lastUndoAction).toBeInstanceOf(Function);
 
     // Advance to consume the pending timer so no leak is recorded.
+    vi.advanceTimersByTime(5100);
+    vi.useRealTimers();
+    await waitFor(() => {});
+  });
+
+  it("renders the undo-toast label in the active locale with the {name} argument", async () => {
+    const user = userEvent.setup();
+
+    const cache = new InMemoryCache();
+    const conn = makeConnection([CG_1]);
+    cache.writeQuery({
+      query: MyCardgroupsConnectionDocument,
+      variables: CARDGROUPS_DEFAULT_VARS,
+      data: { myCardgroupsConnection: conn },
+    });
+
+    const initialMock = {
+      request: { query: MyCardgroupsConnectionDocument, variables: CARDGROUPS_DEFAULT_VARS },
+      result: { data: { myCardgroupsConnection: conn } },
+    };
+    const deleteMock = {
+      request: { query: DeleteCardgroupDocument, variables: { id: CG_1.id } },
+      result: { data: { deleteCardgroup: true } },
+    };
+
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+
+    renderClient([initialMock, deleteMock], null, cache, {
+      locale: "ja",
+      messages: jaMessages,
+    });
+
+    expect(await screen.findByText("Spanish Vocab")).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("button", {
+        name: withName(jaMessages.Cardgroups.deleteAriaLabel, CG_1.name),
+      }),
+    );
+
+    expect(lastToastLabel).toBe(withName(jaMessages.Cardgroups.cardgroupDeleted, CG_1.name));
+
     vi.advanceTimersByTime(5100);
     vi.useRealTimers();
     await waitFor(() => {});

--- a/frontend/src/app/cardgroups/cardgroups-client.tsx
+++ b/frontend/src/app/cardgroups/cardgroups-client.tsx
@@ -262,7 +262,7 @@ export default function CardgroupsClient({ initialConnection }: CardgroupsClient
 
     scheduleDelete({
       id,
-      label: `Cardgroup "${name}" deleted`,
+      label: t("cardgroupDeleted", { name }),
       optimisticRollback: () => {
         restoreMyCardgroupSnapshot(apollo.cache, snapshot, activeVars);
       },

--- a/frontend/src/app/cards/new/loading.test.tsx
+++ b/frontend/src/app/cards/new/loading.test.tsx
@@ -1,0 +1,37 @@
+// @vitest-environment happy-dom
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import enMessages from "../../../../messages/en.json";
+import jaMessages from "../../../../messages/ja.json";
+import Loading from "./loading";
+
+// The route-segment fallback is a server component, so the catalog is reached
+// through next-intl/server rather than NextIntlClientProvider. The mock is
+// locale-switchable so the heading can be asserted in both catalogs.
+let activeMessages: typeof enMessages = enMessages;
+vi.mock("next-intl/server", () => ({
+  getTranslations: vi.fn(async (namespace: "Cards") => (key: string) => {
+    const value = (activeMessages[namespace] as Record<string, string>)[key];
+    return value ?? key;
+  }),
+}));
+
+describe("/cards/new <Loading>", () => {
+  it("renders the same localized heading key the resolved page renders", async () => {
+    activeMessages = enMessages;
+    render(await Loading());
+
+    expect(
+      screen.getByRole("heading", { name: enMessages.Cards.newCardTitle }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the heading in the active locale so it does not swap on hydration", async () => {
+    activeMessages = jaMessages;
+    render(await Loading());
+
+    expect(
+      screen.getByRole("heading", { name: jaMessages.Cards.newCardTitle }),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/cards/new/loading.tsx
+++ b/frontend/src/app/cards/new/loading.tsx
@@ -1,3 +1,4 @@
+import { getTranslations } from "next-intl/server";
 import { CardsNewSkeleton } from "./_components/cards-new-skeleton";
 
 /**
@@ -5,11 +6,16 @@ import { CardsNewSkeleton } from "./_components/cards-new-skeleton";
  * component tree for `/cards/new` is being prepared. Wraps the skeleton in
  * the same outer `<main>` / heading markup as `page.tsx` so the page chrome
  * does not shift between the loading state and the resolved page.
+ *
+ * The heading resolves the same `Cards.newCardTitle` key `page.tsx` renders, so
+ * a Japanese visitor does not see an English heading swap to Japanese once the
+ * page resolves.
  */
-export default function Loading() {
+export default async function Loading() {
+  const t = await getTranslations("Cards");
   return (
     <main className="p-8">
-      <h1 className="mb-6 text-2xl font-semibold">New card</h1>
+      <h1 className="mb-6 text-2xl font-semibold">{t("newCardTitle")}</h1>
       <CardsNewSkeleton />
     </main>
   );

--- a/frontend/src/app/catalog/[id]/_components/catalog-deck-skeleton.test.tsx
+++ b/frontend/src/app/catalog/[id]/_components/catalog-deck-skeleton.test.tsx
@@ -1,0 +1,21 @@
+// @vitest-environment happy-dom
+import { screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { renderWithIntl } from "@/test/render-with-intl";
+import enMessages from "../../../../../messages/en.json";
+import jaMessages from "../../../../../messages/ja.json";
+import { CatalogDeckSkeleton } from "./catalog-deck-skeleton";
+
+describe("<CatalogDeckSkeleton>", () => {
+  it("labels the placeholder list from the Catalog catalog namespace", () => {
+    renderWithIntl(<CatalogDeckSkeleton />);
+
+    expect(screen.getByRole("list", { name: enMessages.Catalog.loadingDeck })).toBeInTheDocument();
+  });
+
+  it("localizes the aria-label so assistive tech matches the page locale", () => {
+    renderWithIntl(<CatalogDeckSkeleton />, { locale: "ja", messages: jaMessages });
+
+    expect(screen.getByRole("list", { name: jaMessages.Catalog.loadingDeck })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/catalog/[id]/_components/catalog-deck-skeleton.tsx
+++ b/frontend/src/app/catalog/[id]/_components/catalog-deck-skeleton.tsx
@@ -1,3 +1,6 @@
+"use client";
+
+import { useTranslations } from "next-intl";
 import { Skeleton } from "@/components/ui/skeleton";
 
 /**
@@ -5,8 +8,15 @@ import { Skeleton } from "@/components/ui/skeleton";
  * resolved layout — the DetailPageHeader app bar (back / count / import) with a
  * centered title and badge row, then a single-column read-only card list — to
  * prevent CLS while `CatalogDeckContent` awaits the two parallel GraphQL fetches.
+ *
+ * Client component on purpose: this is a `<Suspense>` fallback, and next-intl's
+ * server-side `useTranslations` resolves its config through `use(...)`, which
+ * would suspend the fallback itself and escalate rendering to the parent
+ * boundary. Reading the messages from `NextIntlClientProvider` is synchronous.
  */
 export function CatalogDeckSkeleton() {
+  const t = useTranslations("Catalog");
+
   return (
     <main className="p-8">
       <header className="mb-6">
@@ -27,7 +37,7 @@ export function CatalogDeckSkeleton() {
       <ul
         className="space-y-3"
         aria-busy="true"
-        aria-label="Loading deck"
+        aria-label={t("loadingDeck")}
         data-testid="catalog-deck-skeleton"
       >
         {Array.from({ length: 6 }).map((_, i) => (

--- a/frontend/src/app/error.test.tsx
+++ b/frontend/src/app/error.test.tsx
@@ -1,6 +1,9 @@
 // @vitest-environment happy-dom
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { renderWithIntl } from "@/test/render-with-intl";
+import enMessages from "../../messages/en.json";
+import jaMessages from "../../messages/ja.json";
 import RootError from "./error";
 
 afterEach(() => {
@@ -9,17 +12,29 @@ afterEach(() => {
 
 describe("root <RootError>", () => {
   it("renders the message and a retry affordance", () => {
-    render(<RootError error={new Error("boom")} reset={vi.fn()} />);
+    renderWithIntl(<RootError error={new Error("boom")} reset={vi.fn()} />);
 
-    expect(screen.getByRole("heading", { name: /couldn't load the app/i })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /try again/i })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: enMessages.RootError.heading })).toBeInTheDocument();
+    expect(screen.getByText(enMessages.RootError.message)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: enMessages.RootError.retry })).toBeInTheDocument();
+  });
+
+  it("renders all three strings from the catalog in the active locale", () => {
+    renderWithIntl(<RootError error={new Error("boom")} reset={vi.fn()} />, {
+      locale: "ja",
+      messages: jaMessages,
+    });
+
+    expect(screen.getByRole("heading", { name: jaMessages.RootError.heading })).toBeInTheDocument();
+    expect(screen.getByText(jaMessages.RootError.message)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: jaMessages.RootError.retry })).toBeInTheDocument();
   });
 
   it("calls reset when the retry button is clicked", () => {
     const reset = vi.fn();
-    render(<RootError error={new Error("boom")} reset={reset} />);
+    renderWithIntl(<RootError error={new Error("boom")} reset={reset} />);
 
-    fireEvent.click(screen.getByRole("button", { name: /try again/i }));
+    fireEvent.click(screen.getByRole("button", { name: enMessages.RootError.retry }));
 
     expect(reset).toHaveBeenCalledTimes(1);
   });
@@ -28,7 +43,7 @@ describe("root <RootError>", () => {
     const spy = vi.spyOn(console, "error").mockImplementation(() => {});
     const error = Object.assign(new Error("secret-user-content"), { digest: "abc123" });
 
-    render(<RootError error={error} reset={vi.fn()} />);
+    renderWithIntl(<RootError error={error} reset={vi.fn()} />);
 
     expect(spy).toHaveBeenCalledWith("[error]", { name: "Error", digest: "abc123" });
     // Assert the raw message is absent explicitly, so a future switch to a

--- a/frontend/src/app/error.tsx
+++ b/frontend/src/app/error.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { useEffect } from "react";
 import { BrandSplash } from "@/components/pwa/brand-splash";
 
@@ -20,8 +21,15 @@ type RootErrorProps = {
  *
  * Errors thrown from the root layout itself are still handled by
  * `global-error.tsx`.
+ *
+ * This boundary sits *below* the `NextIntlClientProvider` mounted in the root
+ * layout, so its copy is localized through the `RootError` namespace. The
+ * `global-error.tsx` sibling replaces the root layout entirely and therefore
+ * stays hardcoded English.
  */
 export default function RootError({ error, reset }: RootErrorProps) {
+  const t = useTranslations("RootError");
+
   useEffect(() => {
     // Scope prefix for log streams. Log the error name + digest only — never the
     // message, which may carry user-supplied content (the middleware redacts the
@@ -33,17 +41,15 @@ export default function RootError({ error, reset }: RootErrorProps) {
   return (
     <BrandSplash spin={false}>
       <div className="space-y-2">
-        <h1 className="text-xl font-semibold tracking-tight">We couldn't load the app</h1>
-        <p className="mx-auto max-w-xs text-sm text-white/90">
-          This can happen when the server is starting up. Please try again in a moment.
-        </p>
+        <h1 className="text-xl font-semibold tracking-tight">{t("heading")}</h1>
+        <p className="mx-auto max-w-xs text-sm text-white/90">{t("message")}</p>
       </div>
       <button
         type="button"
         onClick={reset}
         className="rounded-lg bg-white px-8 py-3 text-sm font-medium text-brand-primary transition-colors hover:bg-white/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-brand-primary"
       >
-        Try again
+        {t("retry")}
       </button>
     </BrandSplash>
   );

--- a/frontend/src/app/learn/[cardgroupId]/learn-client.test.tsx
+++ b/frontend/src/app/learn/[cardgroupId]/learn-client.test.tsx
@@ -21,6 +21,8 @@ import {
   type ApolloMockLeakSpyResult,
   installApolloMockLeakSpy,
 } from "../../../../__tests__/utils/mock-apollo-paginated";
+import enMessages from "../../../../messages/en.json";
+import jaMessages from "../../../../messages/ja.json";
 import { LearnClient, PREFETCH_THRESHOLD } from "./learn-client";
 
 // ---------------------------------------------------------------------------
@@ -259,6 +261,8 @@ type RenderLearnClientOptions = {
    */
   skipDefaultPrefetchMocks?: boolean;
   displayMode?: LearnDisplayMode;
+  /** Locale + catalog override for the intl harness. Defaults to en. */
+  intl?: { locale: "en" | "ja"; messages: typeof enMessages };
 };
 
 function renderLearnClient(
@@ -287,6 +291,7 @@ function renderLearnClient(
         displayMode={options.displayMode ?? "ALWAYS_VISIBLE"}
       />
     </MockedProvider>,
+    options.intl,
   );
 }
 
@@ -461,7 +466,9 @@ describe("<LearnClient>", () => {
 
     await waitFor(() => {
       expect(screen.getByText("Hello")).toBeInTheDocument();
-      expect(screen.getByRole("alert")).toHaveTextContent("Could not save that swipe");
+      // Sourced from the catalog rather than re-spelled, so a reverted
+      // hardcoded literal in learn-client.tsx would fail here.
+      expect(screen.getByRole("alert")).toHaveTextContent(enMessages.Learn.swipeSaveFailed);
     });
 
     // PII redaction contract — docs/frontend/rsc-error-handling/redact-err-message-from-console-payloads.md.
@@ -476,6 +483,31 @@ describe("<LearnClient>", () => {
       name: expect.any(String),
     });
     expect(payload).not.toHaveProperty("message");
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("renders the swipe-failure banner in the active locale", async () => {
+    const user = userEvent.setup();
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const mock = {
+      request: {
+        query: HandleSwipeDocument,
+        variables: { input: { cardId: CARD_1.id, cardgroupId: CG_ID, rating: 1 } },
+      },
+      result: {
+        errors: [new GraphQLError("bad swipe", { extensions: { code: "BAD_USER_INPUT" } })],
+      },
+    };
+    renderLearnClient([mock], [CARD_1], { intl: { locale: "ja", messages: jaMessages } });
+
+    // The LearnActionBar mock renders fixed English labels, so the rating
+    // control is addressed by that label regardless of the active locale.
+    await user.click(screen.getByRole("button", { name: "Rate as Again" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(jaMessages.Learn.swipeSaveFailed);
+    });
 
     consoleErrorSpy.mockRestore();
   });

--- a/frontend/src/app/learn/[cardgroupId]/learn-client.tsx
+++ b/frontend/src/app/learn/[cardgroupId]/learn-client.tsx
@@ -2,6 +2,7 @@
 
 import { gql } from "@apollo/client";
 import { useApolloClient, useMutation } from "@apollo/client/react";
+import { useTranslations } from "next-intl";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   HandleSwipeMutation,
@@ -39,6 +40,7 @@ type Props = {
 };
 
 export function LearnClient({ cardgroupId, initialCards, displayMode }: Props) {
+  const t = useTranslations("Learn");
   const [queue, setQueue] = useState<LearnCard[]>(initialCards);
   const [completedCount, setCompletedCount] = useState(0);
   const [localError, setLocalError] = useState<string | null>(null);
@@ -313,7 +315,7 @@ export function LearnClient({ cardgroupId, initialCards, displayMode }: Props) {
         });
         setQueue((current) => [card, ...current.filter((candidate) => candidate.id !== card.id)]);
         setCompletedCount((current) => Math.max(0, current - 1));
-        setLocalError("Could not save that swipe. Please try again.");
+        setLocalError(t("swipeSaveFailed"));
         return null;
       });
 
@@ -356,7 +358,7 @@ export function LearnClient({ cardgroupId, initialCards, displayMode }: Props) {
         cardgroupId,
       });
     },
-    [cardgroupId, handleSwipe, syncLearnDay],
+    [cardgroupId, handleSwipe, syncLearnDay, t],
   );
 
   if (phase === "practice") {

--- a/frontend/src/components/nav/app-shell.test.tsx
+++ b/frontend/src/components/nav/app-shell.test.tsx
@@ -3,6 +3,8 @@ import { screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { renderWithIntl } from "@/test/render-with-intl";
+import enMessages from "../../../messages/en.json";
+import jaMessages from "../../../messages/ja.json";
 
 // Mock next/link so it renders a plain <a> in jsdom.
 vi.mock("next/link", () => ({
@@ -81,6 +83,33 @@ describe("<AppShell>", () => {
       const mobileHeader = screen.getByTestId("mobile-header");
       expect(mobileHeader).toBeInTheDocument();
       expect(mobileHeader.className).toContain("md:hidden");
+    });
+
+    it("labels the desktop rail from the Nav catalog namespace", () => {
+      renderWithIntl(
+        <AppShell user={SIGNED_IN_USER} isAdmin={false}>
+          <div />
+        </AppShell>,
+      );
+
+      expect(screen.getByTestId("rail-container")).toHaveAttribute(
+        "aria-label",
+        enMessages.Nav.primaryNavigation,
+      );
+    });
+
+    it("localizes the rail aria-label so assistive tech matches the page locale", () => {
+      renderWithIntl(
+        <AppShell user={SIGNED_IN_USER} isAdmin={false}>
+          <div />
+        </AppShell>,
+        { locale: "ja", messages: jaMessages },
+      );
+
+      expect(screen.getByTestId("rail-container")).toHaveAttribute(
+        "aria-label",
+        jaMessages.Nav.primaryNavigation,
+      );
     });
   });
 

--- a/frontend/src/components/nav/app-shell.tsx
+++ b/frontend/src/components/nav/app-shell.tsx
@@ -1,3 +1,4 @@
+import { useTranslations } from "next-intl";
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
 import { GlobalRail } from "./global-rail";
 import { LogoDrawer } from "./logo-drawer";
@@ -25,6 +26,8 @@ interface AppShellProps {
  * client nav components it mounts.
  */
 export function AppShell({ user, isAdmin, children }: AppShellProps) {
+  const t = useTranslations("Nav");
+
   return (
     <SidebarProvider>
       {/* PC layout (md+): GlobalRail is a direct child of SidebarProvider so the
@@ -34,7 +37,7 @@ export function AppShell({ user, isAdmin, children }: AppShellProps) {
       <aside
         data-testid="rail-container"
         className="hidden md:flex"
-        aria-label="Primary navigation"
+        aria-label={t("primaryNavigation")}
       >
         <GlobalRail user={user} isAdmin={isAdmin} />
       </aside>


### PR DESCRIPTION
## Summary

Routes the seven remaining user-facing hardcoded strings through the next-intl message catalogs, so a Japanese learner no longer sees English copy at the swipe-failure banner, the two undo toasts, the `/cards/new` loading heading, the root error screen, and the two screen-reader labels.

> **Stacked on the issue #1015 branch. Both change `learn-client.tsx` — #1015 adds the JST learn-day rollover reset, this one adds the `useTranslations` handle and the localized swipe-failure banner. Merge #1015 first.**

## Changes

Catalog (both `en.json` and `ja.json`, key sets kept identical — 433 keys each):

- `Learn.swipeSaveFailed`, `Catalog.loadingDeck`, `Cardgroups.cardgroupDeleted` (ICU `{name}`), `Admin.roleDeleted` (ICU `{name}`), and a new `RootError` namespace with `heading` / `message` / `retry` mirroring the existing `GlobalError` shape. `Nav.primaryNavigation` was already present in both catalogs with zero usages — no new key was added for it, only the wire-up.

Wire-up:

- `learn-client.tsx` — added `useTranslations("Learn")` (the file previously imported no next-intl at all) and swapped `setLocalError("Could not save that swipe. Please try again.")` for `setLocalError(t("swipeSaveFailed"))`. `t` was added to the `onSwipe` `useCallback` dependency array so `useExhaustiveDependencies` stays satisfied.
- `cardgroups-client.tsx` / `admin-roles-client.tsx` — the template-literal `scheduleDelete` labels became `t("cardgroupDeleted", { name })` and `t("roleDeleted", { name: role.name })`, using the `useTranslations("Cardgroups")` / `useTranslations("Admin")` handles already in scope alongside each `useUndoDelete()` call.
- `app/cards/new/loading.tsx` — now `async` and resolves the same `Cards.newCardTitle` key `page.tsx` renders, via `await getTranslations("Cards")`. This follows the established `app/loading.tsx` precedent (the only other localized route-segment fallback in the tree), which is likewise an async server component reading `next-intl/server`.
- `app/error.tsx` — added `useTranslations("RootError")` and routed all THREE strings (`<h1>`, `<p>` body, retry button) through it. `global-error.tsx` was deliberately left untouched: it replaces the root layout, so no provider is in scope.
- `catalog/[id]/_components/catalog-deck-skeleton.tsx` — added `useTranslations("Catalog")` for the `aria-label`. This component is a `<Suspense fallback>` in `catalog/[id]/page.tsx`, and next-intl's react-server `useTranslations` resolves its config through `use(getConfig())` (verified by reading `node_modules/next-intl@4.13.2/dist/esm/development/react-server/useConfig.js`), which would suspend the fallback itself and escalate rendering to the parent boundary. The file therefore gained `"use client"` so the messages are read synchronously from `NextIntlClientProvider`; the reason is recorded in its docblock.
- `components/nav/app-shell.tsx` — added `useTranslations("Nav")` and wired the pre-existing `Nav.primaryNavigation` key into the desktop rail's `aria-label`.

Production diff is 40 insertions / 13 deletions across 7 `.tsx` files, plus 20/2 across the two catalogs — well under the 800-line ceiling.

### Tests

Every new assertion sources its expected string from `messages/en.json` or `messages/ja.json` rather than re-spelling the copy, so a reverted hardcoded literal fails and a catalog edit surfaces at the assertion instead of diverging silently. Importing `jaMessages` (rather than inlining Japanese) is also what keeps the CJK gate clean in the test tree.

- `learn-client.test.tsx` — the existing failure-path assertion no longer pins `"Could not save that swipe"`; it asserts `enMessages.Learn.swipeSaveFailed`. A new test renders the client with `locale: "ja"` / `jaMessages` through the `renderWithIntl` harness (threaded in via a new `intl` option on the `renderLearnClient` helper) and asserts `jaMessages.Learn.swipeSaveFailed` on the `role="alert"` banner. The rating control is addressed by the `LearnActionBar` mock's fixed English label, which is locale-independent.
- `cardgroups-client.test.tsx` — the toast assertion at the delete test switched from `` `Cardgroup "${CG_1.name}" deleted` `` to `withName(enMessages.Cardgroups.cardgroupDeleted, CG_1.name)`. A new ja-locale test drives the same flow, finds the delete button by `jaMessages.Cardgroups.deleteAriaLabel`, and asserts the ja toast label — proving both the catalog wiring and the `{name}` interpolation.
- `admin-roles-client.test.tsx` — this file had no toast-label coverage at all, so a `sonner` mock was added (mirroring the cardgroups one) to capture the label, plus an `it.each` over `["en", enMessages]` / `["ja", jaMessages]` asserting `messages.Admin.roleDeleted` with the `{name}` argument substituted.
- `cards/new/loading.test.tsx` (new) — mirrors the existing `app/loading.test.tsx` pattern: mocks `next-intl/server`'s `getTranslations` against a locale-switchable catalog and asserts the heading renders `Cards.newCardTitle` in both en and ja.
- `error.test.tsx` — migrated from bare `render` to `renderWithIntl`; the three original tests now assert against `enMessages.RootError.*`, and a new test renders under `locale: "ja"` asserting all three ja strings. The `[error]` scope-prefix / message-redaction test is preserved unchanged.
- `catalog-deck-skeleton.test.tsx` (new) — asserts the placeholder `<ul>` is reachable as `getByRole("list", { name: … })` using `Catalog.loadingDeck` in both en and ja.
- `app-shell.test.tsx` — two new tests asserting the rail container's `aria-label` equals `enMessages.Nav.primaryNavigation` and `jaMessages.Nav.primaryNavigation`.

Full suite: 209 files, 1947 tests, all passing.

## Test plan

- [ ] tsc --noEmit — exit 0, no diagnostics
- [ ] biome check --error-on-warnings . — exit 0 (524 files checked; the two emitted 'infos' are the pre-existing biome-version-mismatch and deprecated-`recommended`-field notices in biome.json, not findings against changed files)
- [ ] vitest run — 209 test files passed, 1947 tests passed, 0 failed
- [ ] knip — exit 0 (one pre-existing configuration hint about @graphql-typed-document-node/core in knip.jsonc, untouched by this change)
- [ ] node scripts/i18n-parity.mjs — 'Parity OK — 433 keys in both catalogs.', exit 0
- [ ] next build — succeeded, full route table emitted (validates the async loading.tsx and the 'use client' skeleton compile in the real Next pipeline)
- [ ] CJK gate `perl -CSD -ne 'print "$ARGV\n" if /[\x{3040}-\x{30ff}\x{4e00}-\x{9fff}]/' $(git ls-files 'frontend/src/**/*.ts' 'frontend/src/**/*.tsx')` — NOT empty, but unchanged from the base commit: the only hits are frontend/src/app/privacy/content.ts, frontend/src/app/privacy/page.test.tsx, frontend/src/app/terms/content.ts, frontend/src/app/terms/page.test.tsx. None of those four files appears in `git status --short`, so this change introduced zero new CJK into any .ts/.tsx source. The privacy/terms legal copy is explicitly out of scope per the issue.
- [ ] grep -rn "primaryNavigation" frontend/src — 3 hits: frontend/src/components/nav/app-shell.tsx:40 (`aria-label={t("primaryNavigation")}`), frontend/src/components/nav/app-shell.test.tsx:97, frontend/src/components/nav/app-shell.test.tsx:111. Previously zero.
- [ ] Worktree `git status --short` — exactly the 14 modified + 2 new test files listed in filesChanged, nothing else
- [ ] Main checkout `/Users/yasuflatland/projects/flamingo-armond` `git status --short` — 0 lines (clean)
- [ ] Base commit confirmed as the stacked sibling: `git log --oneline -3` head is e6f43979 'fix(frontend): key the learn session swiped-id set by JST learn day'

## Notes

Two issue-body facts were re-verified in the worktree rather than trusted, since the branch is stacked on the #1015 work and the line numbers had moved:

- `setLocalError("Could not save that swipe. Please try again.")` is at `learn-client.tsx:302`, not `:282`; the test assertion that pinned it is still at `learn-client.test.tsx:464`. Both were located by grep.
- `learn-client.tsx` already imports `@/lib/learn/learn-day` from the sibling branch. The new `useTranslations` import was placed in Biome's sorted position (after `@apollo/client/react`, before `react`), and `biome check --error-on-warnings` confirms `assist/source/organizeImports` is satisfied.

The verification note in the issue held on both points: `Nav.primaryNavigation` was already in both catalogs with zero usages (wired, no new key), and `app/error.tsx` did carry three hardcoded strings including the `<p>` body paragraph — all three were converted.

Toolchain gotcha worth flagging for the commit step: the repo's PostToolUse formatter hook rewrote `import enMessages from …` to `import type enMessages from …` in three test files at the moment the symbol was only used in a type position (`typeof enMessages` in a helper signature). That produced three `TS1361` errors on the first `tsc --noEmit`. Fixed by restoring the value imports; the subsequent `biome check` run left them alone because the symbols are now also used as values. Re-run `tsc --noEmit` after any further autoformat pass over these files.

`Common.retry` ("Retry" / "再試行") already exists and is close in meaning to the new `RootError.retry` ("Try again" / "もう一度試す"). They were kept separate because the issue specifies the `RootError` namespace shape explicitly and the English copy differs; collapsing them would be a copy change, not a wiring change.

**Scope deviations.** One deviation, forced by a runtime constraint the issue did not anticipate: `catalog-deck-skeleton.tsx` gained a `"use client"` directive in addition to the `useTranslations("Catalog")` call the issue asked for. The component is a `<Suspense fallback>` in `catalog/[id]/page.tsx`; next-intl's react-server `useTranslations` resolves its config via `use(getConfig())` (confirmed by reading the installed `next-intl@4.13.2` source, not from memory), which would suspend the fallback itself and escalate rendering to the parent boundary. Making it a client component keeps the message read synchronous. The rationale is recorded in the component's docblock so a future contributor does not "fix" it back.

Two additional test files were created (`cards/new/loading.test.tsx`, `catalog-deck-skeleton.test.tsx`) because the acceptance criteria require assertions for the `/cards/new` loading heading and the deck-skeleton aria-label, and neither surface had any existing test file.

Nothing from the Out-of-scope list was touched: `global-error.tsx` is unmodified, the privacy/terms legal copy is unmodified, and no existing catalog namespace was renamed or restructured.

**CI on a stacked PR.** This repository's heavy workflows are gated on `pull_request: branches: [main]`, so they do not fire while the base is another feature branch, and `Closes #1027` does not register either. After the base PR merges, retarget this PR's base to `main` and close/reopen it to kick CI.

Closes #1027
