### PR TITLE
fix(backend): widen code-point CHECK bounds to match the grapheme caps

### DIFF
--- a/backend/internal/database/cardgroup_fk_roundtrip_test.go
+++ b/backend/internal/database/cardgroup_fk_roundtrip_test.go
@@ -42,9 +42,11 @@ func TestSwipeRecordsCardgroupFKDownUpRoundtrip(t *testing.T) {
 		}
 	}()
 
-	// add_cardgroup_fk_to_swipe_records is the newest migration, so one step
-	// reaches it. Bump this count when adding migrations after it.
-	if err := m.Steps(-1); err != nil {
+	// Step back two migrations newest-first: widen_text_length_checks, then
+	// add_cardgroup_fk_to_swipe_records (the target). The Steps(1) below
+	// re-applies only the cardgroup FK; the t.Cleanup restores the rest. Bump
+	// this count when adding migrations after add_cardgroup_fk_to_swipe_records.
+	if err := m.Steps(-2); err != nil {
 		t.Fatalf("migrate down cardgroup fk migration: %v", err)
 	}
 	if _, ok := swipeRecordsCardgroupFKDeleteRule(t, ctx, sqlDB); ok {

--- a/backend/internal/database/cards_position_roundtrip_test.go
+++ b/backend/internal/database/cards_position_roundtrip_test.go
@@ -44,7 +44,7 @@ func TestCardsPositionDownUpRoundtrip(t *testing.T) {
 		}
 	}()
 
-	// Step back past the fourteen migrations newer than add_position_to_cards
+	// Step back past the fifteen migrations newer than add_position_to_cards
 	// (enable_rls_schema_migrations, pin_trigger_function_search_path,
 	// restrict_definer_function_exposure, add_master_tables,
 	// add_learn_display_mode_to_user_preferences,
@@ -55,10 +55,11 @@ func TestCardsPositionDownUpRoundtrip(t *testing.T) {
 	// add_pre_swipe_snapshot_to_swipe_records,
 	// add_last_rating_to_user_card_fsrs,
 	// add_stability_before_to_swipe_records,
-	// add_cardgroup_fk_to_swipe_records), then past add_position_to_cards
-	// itself. Fifteen steps are required because add_position_to_cards is no longer
-	// near the newest migration; bump this count when adding migrations after it.
-	if err := m.Steps(-15); err != nil {
+	// add_cardgroup_fk_to_swipe_records, widen_text_length_checks), then past
+	// add_position_to_cards itself. Sixteen steps are required because
+	// add_position_to_cards is no longer near the newest migration; bump this
+	// count when adding migrations after it.
+	if err := m.Steps(-16); err != nil {
 		t.Fatalf("migrate down to before add_position_to_cards: %v", err)
 	}
 

--- a/backend/internal/database/last_rating_roundtrip_test.go
+++ b/backend/internal/database/last_rating_roundtrip_test.go
@@ -38,16 +38,16 @@ func TestLastRatingDownUpRoundtrip(t *testing.T) {
 		}
 	}()
 
-	// Step back three migrations newest-first:
+	// Step back four migrations newest-first: widen_text_length_checks,
 	// add_cardgroup_fk_to_swipe_records, add_stability_before_to_swipe_records,
 	// then add_last_rating_to_user_card_fsrs (the target). Bump this count when
 	// adding migrations after add_last_rating_to_user_card_fsrs.
-	if err := m.Steps(-3); err != nil {
+	if err := m.Steps(-4); err != nil {
 		t.Fatalf("migrate down to before last_rating migration: %v", err)
 	}
 	requireColumnMissing(t, ctx, sqlDB, "user_card_fsrs", "last_rating")
 
-	if err := m.Steps(3); err != nil {
+	if err := m.Steps(4); err != nil {
 		t.Fatalf("migrate up last_rating migration: %v", err)
 	}
 	requireColumnExists(t, ctx, sqlDB, "user_card_fsrs", "last_rating")
@@ -78,9 +78,9 @@ func TestLastRatingUpMigrationBackfillsLatestSwipe(t *testing.T) {
 		}
 	}()
 
-	// Three steps: add_cardgroup_fk_to_swipe_records and
+	// Four steps: widen_text_length_checks, add_cardgroup_fk_to_swipe_records and
 	// add_stability_before_to_swipe_records sit above the target.
-	if err := m.Steps(-3); err != nil {
+	if err := m.Steps(-4); err != nil {
 		t.Fatalf("migrate down to before last_rating migration: %v", err)
 	}
 	requireColumnMissing(t, ctx, sqlDB, "user_card_fsrs", "last_rating")
@@ -119,7 +119,7 @@ func TestLastRatingUpMigrationBackfillsLatestSwipe(t *testing.T) {
 		t.Fatalf("seed swipe_records rows: %v", err)
 	}
 
-	if err := m.Steps(3); err != nil {
+	if err := m.Steps(4); err != nil {
 		t.Fatalf("migrate up last_rating migration: %v", err)
 	}
 	requireColumnExists(t, ctx, sqlDB, "user_card_fsrs", "last_rating")

--- a/backend/internal/database/learn_display_mode_roundtrip_test.go
+++ b/backend/internal/database/learn_display_mode_roundtrip_test.go
@@ -54,8 +54,9 @@ func TestLearnDisplayModeDownUpRoundtrip(t *testing.T) {
 		}
 	}()
 
-	// Step back ten migrations newest-first:
-	// add_cardgroup_fk_to_swipe_records (now the newest),
+	// Step back eleven migrations newest-first:
+	// widen_text_length_checks (now the newest),
+	// add_cardgroup_fk_to_swipe_records,
 	// add_stability_before_to_swipe_records,
 	// add_last_rating_to_user_card_fsrs, add_pre_swipe_snapshot_to_swipe_records,
 	// add_new_card_ratio_to_user_preferences,
@@ -66,7 +67,7 @@ func TestLearnDisplayModeDownUpRoundtrip(t *testing.T) {
 	// below re-applies add_learn_display_mode, and the t.Cleanup restores the
 	// rest. Bump this count when adding migrations after
 	// add_learn_display_mode_to_user_preferences.
-	if err := m.Steps(-10); err != nil {
+	if err := m.Steps(-11); err != nil {
 		t.Fatalf("migrate down to before add_learn_display_mode_to_user_preferences: %v", err)
 	}
 

--- a/backend/internal/database/migrations/20260722000000_widen_text_length_checks.down.sql
+++ b/backend/internal/database/migrations/20260722000000_widen_text_length_checks.down.sql
@@ -1,0 +1,25 @@
+-- Restore the original code-point upper bounds (100 for deck names, 500 for card
+-- text). This narrows the constraint, so it fails if any row was stored with a
+-- code-point length between the old and the new bound -- which is exactly the
+-- emoji-rich content the up migration exists to admit. Truncate or repair those
+-- rows before rolling back.
+
+ALTER TABLE public.cardgroups
+    DROP CONSTRAINT IF EXISTS cardgroups_name_length,
+    ADD CONSTRAINT cardgroups_name_length CHECK (char_length(trim(name)) BETWEEN 1 AND 100);
+
+ALTER TABLE public.cards
+    DROP CONSTRAINT IF EXISTS cards_front_length,
+    ADD CONSTRAINT cards_front_length CHECK (char_length(trim(front)) BETWEEN 1 AND 500),
+    DROP CONSTRAINT IF EXISTS cards_back_length,
+    ADD CONSTRAINT cards_back_length CHECK (char_length(trim(back)) BETWEEN 1 AND 500);
+
+ALTER TABLE public.master_cardgroups
+    DROP CONSTRAINT IF EXISTS master_cardgroups_name_length,
+    ADD CONSTRAINT master_cardgroups_name_length CHECK (char_length(trim(name)) BETWEEN 1 AND 100);
+
+ALTER TABLE public.master_cards
+    DROP CONSTRAINT IF EXISTS master_cards_front_length,
+    ADD CONSTRAINT master_cards_front_length CHECK (char_length(trim(front)) BETWEEN 1 AND 500),
+    DROP CONSTRAINT IF EXISTS master_cards_back_length,
+    ADD CONSTRAINT master_cards_back_length CHECK (char_length(trim(back)) BETWEEN 1 AND 500);

--- a/backend/internal/database/migrations/20260722000000_widen_text_length_checks.up.sql
+++ b/backend/internal/database/migrations/20260722000000_widen_text_length_checks.up.sql
@@ -1,0 +1,50 @@
+-- Widen the code-point upper bound of the text-length CHECK constraints so the
+-- database backstop stops rejecting realistic emoji-rich values the domain layer
+-- accepts. A grapheme cluster admits an unbounded combining-mark sequence, so no
+-- finite code-point bound closes the gap entirely; the SQLSTATE 23514 arm in
+-- internal/repository/pgerr.go classifies the residue as BAD_USER_INPUT instead
+-- of an unexplained internal error.
+--
+-- The domain layer (internal/domain/card_text.go, internal/domain/cardgroup_name.go)
+-- and the frontend (frontend/src/schemas/grapheme.ts) both count *grapheme
+-- clusters*, while Postgres char_length() counts *code points*. A single ZWJ
+-- family emoji is one grapheme but seven code points, so a value at exactly the
+-- 500-grapheme card cap could carry 3500 code points and trip the old
+-- BETWEEN 1 AND 500 bound. That rejection surfaced as an unexplained internal
+-- error because SQLSTATE 23514 was classified nowhere in the repository layer.
+--
+-- The new upper bound is 20x the grapheme cap. The multiplier is sized from the
+-- worst realistic expansion rather than a round number: a four-person ZWJ family
+-- is 7 code points per grapheme, and 11 once every member carries a skin-tone
+-- modifier, so a 500-grapheme card back can legitimately reach 5500 code points.
+-- A 4x bound would still reject it. 20x leaves headroom for further combining
+-- marks and variation selectors while keeping the constraint a meaningful
+-- storage sanity check.
+--
+-- Widening is safe in the only direction that matters: every value the domain
+-- accepts is at most `cap` graphemes, and no value the widened CHECK admits is
+-- one the domain would have rejected -- the domain still runs first and remains
+-- the single user-visible rule.
+--
+-- The lower bound stays at 1. "Non-empty after trim" is identical under both
+-- counting rules, so there is nothing to widen there.
+
+ALTER TABLE public.cardgroups
+    DROP CONSTRAINT IF EXISTS cardgroups_name_length,
+    ADD CONSTRAINT cardgroups_name_length CHECK (char_length(trim(name)) BETWEEN 1 AND 2000);
+
+ALTER TABLE public.cards
+    DROP CONSTRAINT IF EXISTS cards_front_length,
+    ADD CONSTRAINT cards_front_length CHECK (char_length(trim(front)) BETWEEN 1 AND 10000),
+    DROP CONSTRAINT IF EXISTS cards_back_length,
+    ADD CONSTRAINT cards_back_length CHECK (char_length(trim(back)) BETWEEN 1 AND 10000);
+
+ALTER TABLE public.master_cardgroups
+    DROP CONSTRAINT IF EXISTS master_cardgroups_name_length,
+    ADD CONSTRAINT master_cardgroups_name_length CHECK (char_length(trim(name)) BETWEEN 1 AND 2000);
+
+ALTER TABLE public.master_cards
+    DROP CONSTRAINT IF EXISTS master_cards_front_length,
+    ADD CONSTRAINT master_cards_front_length CHECK (char_length(trim(front)) BETWEEN 1 AND 10000),
+    DROP CONSTRAINT IF EXISTS master_cards_back_length,
+    ADD CONSTRAINT master_cards_back_length CHECK (char_length(trim(back)) BETWEEN 1 AND 10000);

--- a/backend/internal/database/stability_before_roundtrip_test.go
+++ b/backend/internal/database/stability_before_roundtrip_test.go
@@ -36,12 +36,12 @@ func TestStabilityBeforeDownUpRoundtrip(t *testing.T) {
 		}
 	}()
 
-	// Step back two migrations newest-first:
+	// Step back three migrations newest-first: widen_text_length_checks,
 	// add_cardgroup_fk_to_swipe_records, then add_stability_before_to_swipe_records
 	// (the target). The Steps(1) below re-applies only stability_before; the
 	// t.Cleanup restores the rest. Bump this count when adding migrations after
 	// add_stability_before_to_swipe_records.
-	if err := m.Steps(-2); err != nil {
+	if err := m.Steps(-3); err != nil {
 		t.Fatalf("migrate down stability_before migration: %v", err)
 	}
 	requireColumnMissing(t, ctx, sqlDB, "swipe_records", "stability_before")

--- a/backend/internal/database/swipe_records_orphan_cleanup_test.go
+++ b/backend/internal/database/swipe_records_orphan_cleanup_test.go
@@ -101,9 +101,9 @@ func TestSwipeRecordsCardgroupOrphanCleanupRoundtrip(t *testing.T) {
 		}
 	}()
 
-	// add_cardgroup_fk_to_swipe_records is the newest migration, so one step
-	// reaches it. Bump this count when adding migrations after it.
-	if err := m.Steps(-1); err != nil {
+	// Two steps reach add_cardgroup_fk_to_swipe_records: widen_text_length_checks
+	// sits above it. Bump this count when adding migrations after either one.
+	if err := m.Steps(-2); err != nil {
 		t.Fatalf("migrate down cardgroup fk migration: %v", err)
 	}
 	if got := countSwipeRecordsByID(t, ctx, sqlDB, keepID); got != 1 {
@@ -120,7 +120,7 @@ func TestSwipeRecordsCardgroupOrphanCleanupRoundtrip(t *testing.T) {
 		t.Fatalf("orphan swipe record count before up migration = %d, want 1", got)
 	}
 
-	if err := m.Steps(1); err != nil {
+	if err := m.Steps(2); err != nil {
 		t.Fatalf("migrate up cardgroup fk migration: %v", err)
 	}
 	if got := countSwipeRecordsByID(t, ctx, sqlDB, keepID); got != 1 {

--- a/backend/internal/database/text_length_checks_roundtrip_test.go
+++ b/backend/internal/database/text_length_checks_roundtrip_test.go
@@ -1,0 +1,110 @@
+package database_test
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+	"testing"
+
+	"backend/internal/database"
+)
+
+// textLengthCheckClause returns the rendered CHECK expression of a named
+// constraint, or false when the constraint does not exist.
+func textLengthCheckClause(t *testing.T, ctx context.Context, sqlDB *sql.DB, table, constraint string) (string, bool) {
+	t.Helper()
+	var clause string
+	err := sqlDB.QueryRowContext(ctx, `
+		SELECT pg_get_constraintdef(c.oid)
+		FROM pg_constraint c
+		JOIN pg_class t ON t.oid = c.conrelid
+		JOIN pg_namespace n ON n.oid = t.relnamespace
+		WHERE n.nspname = 'public'
+		  AND t.relname = $1
+		  AND c.conname = $2
+	`, table, constraint).Scan(&clause)
+	if err == sql.ErrNoRows {
+		return "", false
+	}
+	if err != nil {
+		t.Fatalf("query constraint %s.%s: %v", table, constraint, err)
+	}
+	return clause, true
+}
+
+func requireCheckUpperBound(t *testing.T, ctx context.Context, sqlDB *sql.DB, table, constraint, want string) {
+	t.Helper()
+	clause, ok := textLengthCheckClause(t, ctx, sqlDB, table, constraint)
+	if !ok {
+		t.Fatalf("constraint %s.%s does not exist", table, constraint)
+	}
+	if !strings.Contains(clause, want) {
+		t.Fatalf("constraint %s.%s = %q, want it to contain %q", table, constraint, clause, want)
+	}
+}
+
+// widenedTextLengthChecks pins the six constraints the migration rewrites, with
+// the code-point upper bound each carries at HEAD (20x the domain grapheme cap:
+// 500 -> 10000 for card text, 100 -> 2000 for deck names).
+var widenedTextLengthChecks = []struct {
+	table      string
+	constraint string
+	wantUpper  string
+	wantLegacy string
+}{
+	{"cardgroups", "cardgroups_name_length", "2000", "100"},
+	{"cards", "cards_front_length", "10000", "500"},
+	{"cards", "cards_back_length", "10000", "500"},
+	{"master_cardgroups", "master_cardgroups_name_length", "2000", "100"},
+	{"master_cards", "master_cards_front_length", "10000", "500"},
+	{"master_cards", "master_cards_back_length", "10000", "500"},
+}
+
+// TestWidenTextLengthChecksDownUpRoundtrip proves the newest migration restores
+// the original narrow bounds on the way down and the widened bounds on the way
+// back up, for all six text-length constraints, without leaving the schema
+// behind the latest migration version.
+//
+// t.Parallel() is intentionally absent: the test runs a global migration
+// down/up that would race other tests in the package.
+func TestWidenTextLengthChecksDownUpRoundtrip(t *testing.T) {
+	ctx := context.Background()
+	db := openMigratedDB(t)
+	defer db.Close()
+	t.Cleanup(func() {
+		if err := database.Migrate(testDSN); err != nil {
+			t.Errorf("restore latest migration: %v", err)
+		}
+	})
+
+	sqlDB := sqlDBForTest(t, db)
+	for _, c := range widenedTextLengthChecks {
+		requireCheckUpperBound(t, ctx, sqlDB, c.table, c.constraint, c.wantUpper)
+	}
+
+	m, err := database.NewMigrateInstanceForTest(testDSN)
+	if err != nil {
+		t.Fatalf("NewMigrateInstanceForTest: %v", err)
+	}
+	defer func() {
+		if srcErr, dbErr := m.Close(); srcErr != nil || dbErr != nil {
+			t.Logf("migrate close: src_err=%v db_err=%v", srcErr, dbErr)
+		}
+	}()
+
+	// widen_text_length_checks is the newest migration, so one step reaches it.
+	// Bump this count when adding migrations after it.
+	if err := m.Steps(-1); err != nil {
+		t.Fatalf("migrate down widen_text_length_checks: %v", err)
+	}
+	for _, c := range widenedTextLengthChecks {
+		requireCheckUpperBound(t, ctx, sqlDB, c.table, c.constraint, c.wantLegacy)
+	}
+
+	if err := m.Steps(1); err != nil {
+		t.Fatalf("migrate up widen_text_length_checks: %v", err)
+	}
+	for _, c := range widenedTextLengthChecks {
+		requireCheckUpperBound(t, ctx, sqlDB, c.table, c.constraint, c.wantUpper)
+	}
+}

--- a/backend/internal/database/users_version_roundtrip_test.go
+++ b/backend/internal/database/users_version_roundtrip_test.go
@@ -38,26 +38,27 @@ func TestUsersVersionDownUpRoundtrip(t *testing.T) {
 		}
 	}()
 
-	// Step back through the 16 migrations listed newest-first until
+	// Step back through the 17 migrations listed newest-first until
 	// add_version_to_users (the target) is also rolled back:
-	//   1. add_cardgroup_fk_to_swipe_records
-	//   2. add_stability_before_to_swipe_records
-	//   3. add_last_rating_to_user_card_fsrs
-	//   4. add_pre_swipe_snapshot_to_swipe_records
-	//   5. add_new_card_ratio_to_user_preferences
-	//   6. index_hygiene_users_swipe_records
-	//   7. drop_master_cardgroup_metadata_columns
-	//   8. master_cards_front_citext
-	//   9. add_user_card_fsrs_card_id_index
-	//   10. add_learn_display_mode_to_user_preferences
-	//   11. add_master_tables
-	//   12. restrict_definer_function_exposure
-	//   13. pin_trigger_function_search_path
-	//   14. enable_rls_schema_migrations
-	//   15. add_position_to_cards
-	//   16. add_version_to_users  ← target (rolls back the version column)
+	//   1. widen_text_length_checks
+	//   2. add_cardgroup_fk_to_swipe_records
+	//   3. add_stability_before_to_swipe_records
+	//   4. add_last_rating_to_user_card_fsrs
+	//   5. add_pre_swipe_snapshot_to_swipe_records
+	//   6. add_new_card_ratio_to_user_preferences
+	//   7. index_hygiene_users_swipe_records
+	//   8. drop_master_cardgroup_metadata_columns
+	//   9. master_cards_front_citext
+	//   10. add_user_card_fsrs_card_id_index
+	//   11. add_learn_display_mode_to_user_preferences
+	//   12. add_master_tables
+	//   13. restrict_definer_function_exposure
+	//   14. pin_trigger_function_search_path
+	//   15. enable_rls_schema_migrations
+	//   16. add_position_to_cards
+	//   17. add_version_to_users  ← target (rolls back the version column)
 	// Bump the count here when adding migrations after add_version_to_users.
-	if err := m.Steps(-16); err != nil {
+	if err := m.Steps(-17); err != nil {
 		t.Fatalf("migrate down to before add_version_to_users: %v", err)
 	}
 

--- a/backend/internal/repository/bulk_card_tx.go
+++ b/backend/internal/repository/bulk_card_tx.go
@@ -47,6 +47,9 @@ func (r *cardRepo) UpsertManyTx(ctx context.Context, tx *gorm.DB, cards []*domai
 	}
 	res, err := upsertManyTx(ctx, tx, rows, "cards", "cardgroup_id")
 	if err != nil {
+		if classified := classifyTextLengthViolation(err); classified != nil {
+			return UpsertManyTxResult{}, classified
+		}
 		return UpsertManyTxResult{}, eris.Wrap(err, "repository: card: upsert many")
 	}
 	return res, nil

--- a/backend/internal/repository/card.go
+++ b/backend/internal/repository/card.go
@@ -203,6 +203,9 @@ func (r *cardRepo) Create(ctx context.Context, card *domain.Card) error {
 		if classified := classifyCardDuplicateFront(err); classified != nil {
 			return classified
 		}
+		if classified := classifyTextLengthViolation(err); classified != nil {
+			return classified
+		}
 		return eris.Wrap(err, "repository: card: create")
 	}
 	return nil
@@ -251,6 +254,9 @@ func (r *cardRepo) Update(ctx context.Context, id string, patch CardUpdate) (*do
 	res := r.db.WithContext(ctx).Model(&gormCard{}).Where("id = ?", id).Updates(updates)
 	if res.Error != nil {
 		if classified := classifyCardDuplicateFront(res.Error); classified != nil {
+			return nil, classified
+		}
+		if classified := classifyTextLengthViolation(res.Error); classified != nil {
 			return nil, classified
 		}
 		return nil, eris.Wrap(res.Error, "repository: card: update")

--- a/backend/internal/repository/cardgroup.go
+++ b/backend/internal/repository/cardgroup.go
@@ -315,6 +315,9 @@ func (r *cardgroupRepo) Create(ctx context.Context, cg *domain.Cardgroup) error 
 		if fkErr := classifyCardgroupOwnerFKError(err); fkErr != nil {
 			return fkErr
 		}
+		if classified := classifyTextLengthViolation(err); classified != nil {
+			return classified
+		}
 		return eris.Wrap(err, "repository: cardgroup: create")
 	}
 	return nil
@@ -331,6 +334,9 @@ func (r *cardgroupRepo) CreateTx(ctx context.Context, tx *gorm.DB, cg *domain.Ca
 	if err := tx.WithContext(ctx).Create(cardgroupToRow(cg)).Error; err != nil {
 		if fkErr := classifyCardgroupOwnerFKError(err); fkErr != nil {
 			return fkErr
+		}
+		if classified := classifyTextLengthViolation(err); classified != nil {
+			return classified
 		}
 		return eris.Wrap(err, "repository: cardgroup: create tx")
 	}
@@ -411,6 +417,9 @@ func (r *cardgroupRepo) Update(ctx context.Context, id string, patch CardgroupUp
 
 	res := r.db.WithContext(ctx).Model(&gormCardgroup{}).Where("id = ?", id).Updates(updates)
 	if res.Error != nil {
+		if classified := classifyTextLengthViolation(res.Error); classified != nil {
+			return nil, classified
+		}
 		return nil, eris.Wrap(res.Error, "repository: cardgroup: update")
 	}
 	// Re-fetch so callers see the trigger-refreshed updated_at.

--- a/backend/internal/repository/cardgroup_test.go
+++ b/backend/internal/repository/cardgroup_test.go
@@ -242,12 +242,15 @@ func TestCardgroupRepository_NameLengthCheckRejectsTooLong(t *testing.T) {
 	ownerID := insertAuthUser(t, ctx)
 	repo := repository.NewCardgroupRepository(testDB.GORM)
 
-	// 101 ASCII characters: exceeds the CHECK constraint (1-100 trimmed code points).
-	longName := strings.Repeat("a", 101)
+	// 2001 ASCII characters: exceeds the CHECK constraint, whose upper bound is
+	// 20x the 100-grapheme domain cap so a ZWJ-emoji name at the domain cap still
+	// fits. The domain (ParseCardgroupName) rejects anything past 100 graphemes
+	// long before this bound; the CHECK is a storage backstop.
+	longName := strings.Repeat("a", 2001)
 	cg := newCardgroup(ownerID, longName)
 
 	err := repo.Create(ctx, cg)
-	require.Error(t, err, "DB CHECK constraint should reject a 101-char name")
+	require.Error(t, err, "DB CHECK constraint should reject a 2001-char name")
 }
 
 func TestCardgroupRepository_EnsureByName_Existing(t *testing.T) {

--- a/backend/internal/repository/master_card.go
+++ b/backend/internal/repository/master_card.go
@@ -322,6 +322,9 @@ func (r *masterCardRepo) Create(ctx context.Context, c *domain.MasterCard) error
 		if classified := classifyMasterCardFKError(err); classified != nil {
 			return classified
 		}
+		if classified := classifyTextLengthViolation(err); classified != nil {
+			return classified
+		}
 		return eris.Wrap(err, "repository: master card: create")
 	}
 	return nil
@@ -361,6 +364,9 @@ func (r *masterCardRepo) Update(ctx context.Context, id string, patch MasterCard
 
 	res := r.db.WithContext(ctx).Model(&gormMasterCard{}).Where("id = ?", id).Updates(updates)
 	if res.Error != nil {
+		if classified := classifyTextLengthViolation(res.Error); classified != nil {
+			return nil, classified
+		}
 		return nil, eris.Wrap(res.Error, "repository: master card: update")
 	}
 	return refetchAfterUpdate(res.RowsAffected, ErrNotFound,
@@ -403,6 +409,9 @@ func (r *masterCardRepo) UpsertManyTx(ctx context.Context, tx *gorm.DB, cards []
 	res, err := upsertManyTx(ctx, tx, rows, "master_cards", "master_cardgroup_id")
 	if err != nil {
 		if classified := classifyMasterCardFKError(err); classified != nil {
+			return UpsertManyTxResult{}, classified
+		}
+		if classified := classifyTextLengthViolation(err); classified != nil {
 			return UpsertManyTxResult{}, classified
 		}
 		return UpsertManyTxResult{}, eris.Wrap(err, "repository: master card: upsert many")

--- a/backend/internal/repository/master_cardgroup.go
+++ b/backend/internal/repository/master_cardgroup.go
@@ -202,6 +202,9 @@ func (r *masterCardgroupRepo) EnsureByName(ctx context.Context, name string) (*d
 func (r *masterCardgroupRepo) Create(ctx context.Context, m *domain.MasterCardgroup) error {
 	row := masterCardgroupFromDomain(m)
 	if err := r.db.WithContext(ctx).Create(&row).Error; err != nil {
+		if classified := classifyTextLengthViolation(err); classified != nil {
+			return classified
+		}
 		return eris.Wrap(err, "repository: master cardgroup: create")
 	}
 	return nil
@@ -237,6 +240,9 @@ func (r *masterCardgroupRepo) Update(ctx context.Context, id string, patch Maste
 
 	res := r.db.WithContext(ctx).Model(&gormMasterCardgroup{}).Where("id = ?", id).Updates(updates)
 	if res.Error != nil {
+		if classified := classifyTextLengthViolation(res.Error); classified != nil {
+			return nil, classified
+		}
 		return nil, eris.Wrap(res.Error, "repository: master cardgroup: update")
 	}
 	// Re-fetch so callers see the trigger-refreshed updated_at.

--- a/backend/internal/repository/pgerr.go
+++ b/backend/internal/repository/pgerr.go
@@ -19,3 +19,69 @@ func pgConstraintViolation(err error, code, constraintSubstr string) bool {
 	var pgErr *pgconn.PgError
 	return errors.As(err, &pgErr) && pgErr.Code == code && strings.Contains(pgErr.ConstraintName, constraintSubstr)
 }
+
+// textLengthConstraintSuffix is the naming convention every text-length CHECK
+// constraint in the schema follows: "<table>_<column>_length", e.g.
+// cards_front_length, cardgroups_name_length, master_cards_back_length.
+const textLengthConstraintSuffix = "_length"
+
+// TextLengthViolationError reports a Postgres CHECK violation (SQLSTATE 23514)
+// on one of the "<table>_<column>_length" constraints that back the card and
+// cardgroup text columns.
+//
+// The domain layer already enforces the user-visible length rule in grapheme
+// clusters, and the database bound is deliberately far wider, so this is a
+// backstop that fires only for pathological input -- a grapheme cluster admits
+// an unbounded combining-mark run, so no finite code-point bound closes the gap.
+// When it fires, the input is still user-supplied text that is too long for the
+// column -- classifying it as an internal error would hide a fixable input
+// problem behind a generic failure.
+// The usecase layer maps this to a field-scoped BAD_USER_INPUT via
+// translateTextLengthViolation.
+//
+// Field is the column the constraint guards ("front", "back", "name"), derived
+// from the constraint name so callers do not need a per-table lookup table.
+// Pointer receiver on Error() so callers recover it with
+// errors.AsType[*TextLengthViolationError] even after eris.Wrap.
+type TextLengthViolationError struct {
+	Constraint string
+	Field      string
+}
+
+func (e *TextLengthViolationError) Error() string {
+	return "repository: text length constraint violated: " + e.Constraint
+}
+
+// classifyTextLengthViolation maps a Postgres CHECK violation (code 23514) on a
+// "<table>_<column>_length" constraint to a *TextLengthViolationError. It
+// returns nil for any other error -- including a 23514 on a differently-named
+// CHECK, which carries no field attribution and stays an internal error -- so
+// callers can use it as a pre-filter before falling through to eris.Wrap
+// (mirrors classifyMasterCardFKError).
+func classifyTextLengthViolation(err error) error {
+	var pgErr *pgconn.PgError
+	if !errors.As(err, &pgErr) || pgErr.Code != "23514" {
+		return nil
+	}
+	field, ok := textLengthConstraintField(pgErr.ConstraintName)
+	if !ok {
+		return nil
+	}
+	return &TextLengthViolationError{Constraint: pgErr.ConstraintName, Field: field}
+}
+
+// textLengthConstraintField extracts the guarded column from a
+// "<table>_<column>_length" constraint name: "cards_front_length" -> "front",
+// "master_cardgroups_name_length" -> "name". Reports false when the name does
+// not follow the convention or carries no column segment.
+func textLengthConstraintField(name string) (string, bool) {
+	stem, ok := strings.CutSuffix(name, textLengthConstraintSuffix)
+	if !ok {
+		return "", false
+	}
+	i := strings.LastIndex(stem, "_")
+	if i < 0 || i == len(stem)-1 {
+		return "", false
+	}
+	return stem[i+1:], true
+}

--- a/backend/internal/repository/pgerr_text_length_test.go
+++ b/backend/internal/repository/pgerr_text_length_test.go
@@ -1,0 +1,127 @@
+package repository
+
+// White-box tests for classifyTextLengthViolation and its constraint-name
+// parser. Both are unexported so the tests live in the same package. Every case
+// uses a fabricated *pgconn.PgError -- no live DB is required, mirroring
+// pgerr_test.go and master_card_classify_fk_test.go.
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/rotisserie/eris"
+)
+
+func TestClassifyTextLengthViolation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		err           error
+		wantField     string
+		wantClassify  bool
+		wantConstrain string
+	}{
+		{
+			name:          "cards front length violation yields front",
+			err:           &pgconn.PgError{Code: "23514", ConstraintName: "cards_front_length"},
+			wantField:     "front",
+			wantClassify:  true,
+			wantConstrain: "cards_front_length",
+		},
+		{
+			name:          "cards back length violation yields back",
+			err:           &pgconn.PgError{Code: "23514", ConstraintName: "cards_back_length"},
+			wantField:     "back",
+			wantClassify:  true,
+			wantConstrain: "cards_back_length",
+		},
+		{
+			name:          "cardgroups name length violation yields name",
+			err:           &pgconn.PgError{Code: "23514", ConstraintName: "cardgroups_name_length"},
+			wantField:     "name",
+			wantClassify:  true,
+			wantConstrain: "cardgroups_name_length",
+		},
+		{
+			name:          "multi-word table prefix still yields the column segment",
+			err:           &pgconn.PgError{Code: "23514", ConstraintName: "master_cardgroups_name_length"},
+			wantField:     "name",
+			wantClassify:  true,
+			wantConstrain: "master_cardgroups_name_length",
+		},
+		{
+			name:         "wrapped error is still classified",
+			err:          eris.Wrap(&pgconn.PgError{Code: "23514", ConstraintName: "master_cards_back_length"}, "repository: master card: create"),
+			wantField:    "back",
+			wantClassify: true,
+			// eris.Wrap preserves the cause, so errors.As reaches the PgError.
+			wantConstrain: "master_cards_back_length",
+		},
+		{
+			name:         "unique violation on the same table is not classified",
+			err:          &pgconn.PgError{Code: "23505", ConstraintName: "uq_cards_cardgroup_front"},
+			wantClassify: false,
+		},
+		{
+			name:         "check violation on a non-length constraint is not classified",
+			err:          &pgconn.PgError{Code: "23514", ConstraintName: "user_preferences_new_card_ratio_range"},
+			wantClassify: false,
+		},
+		{
+			name:         "check violation with no column segment is not classified",
+			err:          &pgconn.PgError{Code: "23514", ConstraintName: "_length"},
+			wantClassify: false,
+		},
+		{
+			name:         "non-pg error is not classified",
+			err:          errors.New("some error"),
+			wantClassify: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := classifyTextLengthViolation(tt.err)
+			if !tt.wantClassify {
+				if got != nil {
+					t.Fatalf("classifyTextLengthViolation(%v) = %v, want nil", tt.err, got)
+				}
+				return
+			}
+			v, ok := errors.AsType[*TextLengthViolationError](got)
+			if !ok {
+				t.Fatalf("classifyTextLengthViolation(%v) = %v, want *TextLengthViolationError", tt.err, got)
+			}
+			if v.Field != tt.wantField {
+				t.Fatalf("Field = %q, want %q", v.Field, tt.wantField)
+			}
+			if v.Constraint != tt.wantConstrain {
+				t.Fatalf("Constraint = %q, want %q", v.Constraint, tt.wantConstrain)
+			}
+			if v.Error() == "" {
+				t.Fatal("Error() returned an empty string")
+			}
+		})
+	}
+}
+
+// TestTextLengthViolationError_SurvivesErisWrap pins the pointer-receiver
+// contract: a caller that wraps the classified error must still recover the
+// field with errors.AsType, because the usecase layer reads Field to build the
+// BAD_USER_INPUT extensions payload.
+func TestTextLengthViolationError_SurvivesErisWrap(t *testing.T) {
+	t.Parallel()
+	orig := &TextLengthViolationError{Constraint: "cards_front_length", Field: "front"}
+	wrapped := eris.Wrap(orig, "usecase: card: create: repo create")
+
+	v, ok := errors.AsType[*TextLengthViolationError](wrapped)
+	if !ok {
+		t.Fatalf("errors.AsType failed on %v", wrapped)
+	}
+	if v.Field != "front" {
+		t.Fatalf("Field = %q, want %q", v.Field, "front")
+	}
+}

--- a/backend/internal/repository/text_length_grapheme_integration_test.go
+++ b/backend/internal/repository/text_length_grapheme_integration_test.go
@@ -1,0 +1,215 @@
+package repository_test
+
+// Docker-gated integration tests proving the three layers agree on one
+// user-visible length rule. TestMain, testDB, insertAuthUser, newCardgroup,
+// newCard, and insertCardgroup are defined in sibling test files and shared
+// across the package.
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/rivo/uniseg"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"backend/internal/domain"
+	"backend/internal/repository"
+)
+
+// zwjFamily is one grapheme cluster and seven code points
+// (MAN ZWJ WOMAN ZWJ GIRL ZWJ BOY). It is the canonical case where Postgres
+// char_length() and uniseg.GraphemeClusterCount() disagree by 7x, which is what
+// made the pre-widening CHECK reject text the domain accepted.
+const zwjFamily = "\U0001F468‍\U0001F469‍\U0001F467‍\U0001F466"
+
+// maxGraphemeText returns n repetitions of zwjFamily: n grapheme clusters and
+// 7*n code points.
+func maxGraphemeText(n int) string { return strings.Repeat(zwjFamily, n) }
+
+// TestZWJEmojiAtGraphemeCap_CodePointExpansion is the arithmetic precondition
+// for the rest of this file: a card-cap-sized emoji string is 500 graphemes but
+// 3500 code points, so any DB bound at or below 3500 would reject it.
+func TestZWJEmojiAtGraphemeCap_CodePointExpansion(t *testing.T) {
+	t.Parallel()
+	s := maxGraphemeText(domain.CardTextMax)
+	require.Equal(t, domain.CardTextMax, uniseg.GraphemeClusterCount(s))
+	require.Equal(t, domain.CardTextMax*7, len([]rune(s)))
+}
+
+// TestCardRepository_ZWJEmojiAtGraphemeCap_RoundTrips proves the widened
+// cards_front_length / cards_back_length CHECKs accept a value at exactly the
+// domain grapheme cap through both create and update.
+func TestCardRepository_ZWJEmojiAtGraphemeCap_RoundTrips(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	ownerID := insertAuthUser(t, ctx)
+	cg := insertCardgroup(t, ctx, ownerID)
+	repo := repository.NewCardRepository(testDB.GORM)
+
+	capText := maxGraphemeText(domain.CardTextMax)
+	card := newCard(cg.ID, capText, capText)
+	require.NoError(t, repo.Create(ctx, card))
+
+	got, err := repo.FindByID(ctx, card.ID)
+	require.NoError(t, err)
+	require.Equal(t, capText, got.Front.String())
+	require.Equal(t, capText, got.Back.String())
+
+	// The update path writes through a different statement (GORM Updates), so it
+	// needs its own assertion against the same constraint.
+	newFront := maxGraphemeText(domain.CardTextMax-1) + "a"
+	updated, err := repo.Update(ctx, card.ID, repository.CardUpdate{Front: &newFront})
+	require.NoError(t, err)
+	require.Equal(t, newFront, updated.Front.String())
+}
+
+// TestCardgroupRepository_ZWJEmojiAtGraphemeCap_RoundTrips proves the same for
+// the deck-name constraint, whose cap (100) and multiplier differ from cards.
+func TestCardgroupRepository_ZWJEmojiAtGraphemeCap_RoundTrips(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	ownerID := insertAuthUser(t, ctx)
+	repo := repository.NewCardgroupRepository(testDB.GORM)
+
+	capName := maxGraphemeText(domain.CardgroupNameMax)
+	cg := newCardgroup(ownerID, capName)
+	require.NoError(t, repo.Create(ctx, cg))
+
+	got, err := repo.FindByID(ctx, string(cg.ID))
+	require.NoError(t, err)
+	require.Equal(t, capName, got.Name.String())
+
+	newName := maxGraphemeText(domain.CardgroupNameMax-1) + "a"
+	updated, err := repo.Update(ctx, string(cg.ID), repository.CardgroupUpdate{Name: &newName})
+	require.NoError(t, err)
+	require.Equal(t, newName, updated.Name.String())
+}
+
+// TestDomainRejectsOverCapEmojiBeforeReachingDB pins the layer split the
+// widening depends on: the domain, not the database, is the gate that rejects
+// over-length text. One grapheme past the cap fails at ParseCardText /
+// ParseCardgroupName, so no over-length value is ever handed to the repository.
+func TestDomainRejectsOverCapEmojiBeforeReachingDB(t *testing.T) {
+	t.Parallel()
+
+	_, err := domain.ParseCardText(
+		maxGraphemeText(domain.CardTextMax+1),
+		domain.ErrCardFrontRequired,
+		domain.ErrCardFrontTooLong,
+	)
+	require.ErrorIs(t, err, domain.ErrCardFrontTooLong)
+
+	_, err = domain.ParseCardgroupName(maxGraphemeText(domain.CardgroupNameMax + 1))
+	require.ErrorIs(t, err, domain.ErrCardgroupNameTooLong)
+}
+
+// TestCardRepository_CheckViolation_ClassifiesAsTextLengthError proves the 23514
+// backstop is wired: a write that bypasses the domain gate and exceeds the DB
+// bound surfaces as *repository.TextLengthViolationError (which the usecase maps
+// to BAD_USER_INPUT) rather than an opaque wrapped driver error.
+func TestCardRepository_CheckViolation_ClassifiesAsTextLengthError(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	ownerID := insertAuthUser(t, ctx)
+	cg := insertCardgroup(t, ctx, ownerID)
+	repo := repository.NewCardRepository(testDB.GORM)
+
+	// 20001 ASCII code points: past the widened cards_front_length bound (20x the
+	// 500-grapheme cap = 10000), and unreachable through domain.ParseCardText.
+	overBound := strings.Repeat("a", 20001)
+	card := newCard(cg.ID, overBound, "back")
+
+	err := repo.Create(ctx, card)
+	require.Error(t, err)
+
+	var v *repository.TextLengthViolationError
+	require.ErrorAs(t, err, &v)
+	require.Equal(t, "front", v.Field)
+	require.Equal(t, "cards_front_length", v.Constraint)
+}
+
+// TestCardgroupRepository_CheckViolation_ClassifiesAsTextLengthError is the
+// deck-name sibling of the card test above. cardgroups_name_length is 20x the
+// 100-grapheme cap, so only a pathological combining-mark name reaches it
+// through the domain -- but the write path must still classify the violation as
+// a field-scoped user-input error rather than an opaque internal one. Both the
+// insert statement (Create) and the GORM Updates statement (Update) are covered
+// because they wrap distinct error branches.
+func TestCardgroupRepository_CheckViolation_ClassifiesAsTextLengthError(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	ownerID := insertAuthUser(t, ctx)
+	repo := repository.NewCardgroupRepository(testDB.GORM)
+
+	// 2001 ASCII code points: past the widened cardgroups_name_length bound (20x
+	// the 100-grapheme cap = 2000), and unreachable through ParseCardgroupName.
+	overBound := strings.Repeat("a", 2001)
+
+	err := repo.Create(ctx, newCardgroup(ownerID, overBound))
+	require.Error(t, err)
+	var created *repository.TextLengthViolationError
+	require.ErrorAs(t, err, &created)
+	require.Equal(t, "name", created.Field)
+	require.Equal(t, "cardgroups_name_length", created.Constraint)
+
+	cg := newCardgroup(ownerID, "Within Bounds")
+	require.NoError(t, repo.Create(ctx, cg))
+
+	_, err = repo.Update(ctx, string(cg.ID), repository.CardgroupUpdate{Name: &overBound})
+	require.Error(t, err)
+	var updated *repository.TextLengthViolationError
+	require.ErrorAs(t, err, &updated)
+	require.Equal(t, "name", updated.Field)
+	require.Equal(t, "cardgroups_name_length", updated.Constraint)
+}
+
+// TestCardgroupRepository_CreateTx_CheckViolation_ClassifiesAsTextLengthError
+// covers the transactional insert used by the master-deck copy path, which
+// writes the master deck's name verbatim into a new user cardgroup.
+func TestCardgroupRepository_CreateTx_CheckViolation_ClassifiesAsTextLengthError(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	ownerID := insertAuthUser(t, ctx)
+	repo := repository.NewCardgroupRepository(testDB.GORM)
+
+	overBound := strings.Repeat("a", 2001)
+	err := testDB.GORM.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		return repo.CreateTx(ctx, tx, newCardgroup(ownerID, overBound))
+	})
+	require.Error(t, err)
+
+	var v *repository.TextLengthViolationError
+	require.ErrorAs(t, err, &v)
+	require.Equal(t, "name", v.Field)
+	require.Equal(t, "cardgroups_name_length", v.Constraint)
+}
+
+// TestCardRepository_UpsertManyTx_CheckViolation_ClassifiesAsTextLengthError
+// covers the bulk writer behind batch import and merge-from-catalog. It shares
+// the cards_back_length constraint with the single-row Create path but reaches
+// it through a hand-built multi-row INSERT, so it needs its own classifier arm.
+func TestCardRepository_UpsertManyTx_CheckViolation_ClassifiesAsTextLengthError(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	ownerID := insertAuthUser(t, ctx)
+	cg := insertCardgroup(t, ctx, ownerID)
+	repo := repository.NewCardRepository(testDB.GORM)
+
+	// 10001 ASCII code points: past the widened cards_back_length bound (20x the
+	// 500-grapheme cap = 10000), and unreachable through domain.ParseCardText.
+	overBound := strings.Repeat("a", 10001)
+	err := testDB.GORM.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		_, txErr := repo.UpsertManyTx(ctx, tx, []*domain.Card{
+			newCard(cg.ID, "upsert-cap-front", overBound),
+		})
+		return txErr
+	})
+	require.Error(t, err)
+
+	var v *repository.TextLengthViolationError
+	require.ErrorAs(t, err, &v)
+	require.Equal(t, "back", v.Field)
+	require.Equal(t, "cards_back_length", v.Constraint)
+}

--- a/backend/internal/usecase/card.go
+++ b/backend/internal/usecase/card.go
@@ -266,6 +266,9 @@ func (u *cardUsecase) Create(ctx context.Context, in CreateCardInput) (CreateCar
 			}
 			return CreateCardOutcome{Duplicate: dup}, nil
 		}
+		if translated := translateTextLengthViolation(err); translated != nil {
+			return CreateCardOutcome{}, translated
+		}
 		return CreateCardOutcome{}, eris.Wrap(err, "usecase: card: create: repo create")
 	}
 	u.observer.OnCardCreated(ctx, card)
@@ -341,6 +344,9 @@ func (u *cardUsecase) Update(ctx context.Context, id string, in UpdateCardInput)
 		if errors.Is(err, repository.ErrCardDuplicateFront) {
 			return UpdateCardOutcome{}, ucerr.NewValidationError("front",
 				"A card with this front already exists in this cardgroup")
+		}
+		if translated := translateTextLengthViolation(err); translated != nil {
+			return UpdateCardOutcome{}, translated
 		}
 		return UpdateCardOutcome{}, eris.Wrap(err, "usecase: card: update: repo update")
 	}

--- a/backend/internal/usecase/card_import.go
+++ b/backend/internal/usecase/card_import.go
@@ -300,6 +300,9 @@ func (u *cardImportUsecase) Import(ctx context.Context, input ImportCardsInput) 
 		if isContextDone(err) {
 			return ImportCardsOutput{}, err
 		}
+		if translated := translateTextLengthViolation(err); translated != nil {
+			return ImportCardsOutput{}, translated
+		}
 		return ImportCardsOutput{}, eris.Wrap(err, "usecase: card import: tx")
 	}
 

--- a/backend/internal/usecase/cardgroup.go
+++ b/backend/internal/usecase/cardgroup.go
@@ -220,6 +220,13 @@ func (u *cardgroupUsecase) Create(ctx context.Context, in CreateCardgroupInput) 
 		if errors.Is(err, repository.ErrCardgroupOwnerNotFound) {
 			return CreateCardgroupOutcome{}, ucerr.ErrUnauthenticated
 		}
+		if translated := translateTextLengthViolation(err); translated != nil {
+			info, lerr := liftValidationErr(translated)
+			if lerr != nil {
+				return CreateCardgroupOutcome{}, lerr
+			}
+			return CreateCardgroupOutcome{Validation: info}, nil
+		}
 		return CreateCardgroupOutcome{}, eris.Wrap(err, "usecase: cardgroup: create")
 	}
 	return CreateCardgroupOutcome{Cardgroup: cg}, nil
@@ -278,6 +285,13 @@ func (u *cardgroupUsecase) Update(ctx context.Context, id string, in UpdateCardg
 	nameStr := existing.Name.String()
 	updated, err := u.repo.Update(ctx, id, repository.CardgroupUpdate{Name: &nameStr})
 	if err != nil {
+		if translated := translateTextLengthViolation(err); translated != nil {
+			info, lerr := liftValidationErr(translated)
+			if lerr != nil {
+				return UpdateCardgroupOutcome{}, lerr
+			}
+			return UpdateCardgroupOutcome{Validation: info}, nil
+		}
 		return UpdateCardgroupOutcome{}, eris.Wrap(err, "usecase: cardgroup: update")
 	}
 	return UpdateCardgroupOutcome{Cardgroup: updated}, nil

--- a/backend/internal/usecase/master_card.go
+++ b/backend/internal/usecase/master_card.go
@@ -293,6 +293,9 @@ func (u *masterCardUsecase) CreateMasterCard(ctx context.Context, in CreateMaste
 		if errors.Is(err, repository.ErrMasterCardgroupNotFound) {
 			return CreateMasterCardOutcome{}, ucerr.NewValidationError("masterCardgroupId", "master cardgroup not found")
 		}
+		if translated := translateTextLengthViolation(err); translated != nil {
+			return CreateMasterCardOutcome{}, translated
+		}
 		if isContextDone(err) {
 			return CreateMasterCardOutcome{}, err
 		}
@@ -360,6 +363,9 @@ func (u *masterCardUsecase) UpdateMasterCard(ctx context.Context, id string, in 
 	if err != nil {
 		if errors.Is(err, repository.ErrNotFound) {
 			return UpdateMasterCardOutcome{}, ucerr.NewValidationError("id", "master card not found")
+		}
+		if translated := translateTextLengthViolation(err); translated != nil {
+			return UpdateMasterCardOutcome{}, translated
 		}
 		if isContextDone(err) {
 			return UpdateMasterCardOutcome{}, err
@@ -504,6 +510,9 @@ func (u *masterCardUsecase) ImportMasterCards(ctx context.Context, in ImportMast
 	}); err != nil {
 		if errors.Is(err, repository.ErrMasterCardgroupNotFound) {
 			return ImportMasterCardsOutput{}, ucerr.NewValidationError("masterCardgroupId", "master cardgroup not found")
+		}
+		if translated := translateTextLengthViolation(err); translated != nil {
+			return ImportMasterCardsOutput{}, translated
 		}
 		if isContextDone(err) {
 			return ImportMasterCardsOutput{}, err

--- a/backend/internal/usecase/master_catalog.go
+++ b/backend/internal/usecase/master_catalog.go
@@ -527,6 +527,13 @@ func (u *masterCatalogUsecase) CreateMaster(ctx context.Context, in CreateMaster
 		return CreateMasterOutcome{}, eris.Wrap(err, "usecase: master catalog: create master: construct")
 	}
 	if err := u.repo.Create(ctx, m); err != nil {
+		if translated := translateTextLengthViolation(err); translated != nil {
+			info, lerr := liftValidationErr(translated)
+			if lerr != nil {
+				return CreateMasterOutcome{}, lerr
+			}
+			return CreateMasterOutcome{Validation: info}, nil
+		}
 		return CreateMasterOutcome{}, eris.Wrap(err, "usecase: master catalog: create master")
 	}
 	return CreateMasterOutcome{Master: m}, nil
@@ -584,6 +591,13 @@ func (u *masterCatalogUsecase) UpdateMaster(ctx context.Context, id string, in U
 
 	updated, err := u.repo.Update(ctx, id, patch)
 	if err != nil {
+		if translated := translateTextLengthViolation(err); translated != nil {
+			info, lerr := liftValidationErr(translated)
+			if lerr != nil {
+				return UpdateMasterOutcome{}, lerr
+			}
+			return UpdateMasterOutcome{Validation: info}, nil
+		}
 		info, perr := mapMasterAdminErr(err, "id", "usecase: master catalog: update master")
 		if perr != nil {
 			return UpdateMasterOutcome{}, perr

--- a/backend/internal/usecase/master_deck.go
+++ b/backend/internal/usecase/master_deck.go
@@ -216,6 +216,9 @@ func (u *masterDeckUsecase) CopyMasterToUser(ctx context.Context, masterID, owne
 		if isContextDone(err) {
 			return nil, err
 		}
+		if translated := translateTextLengthViolation(err); translated != nil {
+			return nil, translated
+		}
 		return nil, eris.Wrap(err, "usecase: master deck: copy master to user")
 	}
 	return out, nil
@@ -272,6 +275,9 @@ func (u *masterDeckUsecase) SeedForNewUser(ctx context.Context, userID string) (
 	}); err != nil {
 		if isContextDone(err) {
 			return nil, err
+		}
+		if translated := translateTextLengthViolation(err); translated != nil {
+			return nil, translated
 		}
 		return nil, eris.Wrap(err, "usecase: master deck: seed for new user")
 	}
@@ -399,6 +405,9 @@ func (u *masterDeckUsecase) MergeMasterIntoCardgroup(
 	}); err != nil {
 		if isContextDone(err) {
 			return nil, err
+		}
+		if translated := translateTextLengthViolation(err); translated != nil {
+			return nil, translated
 		}
 		return nil, eris.Wrap(err, "usecase: master deck: merge master into cardgroup")
 	}

--- a/backend/internal/usecase/text_length_violation_test.go
+++ b/backend/internal/usecase/text_length_violation_test.go
@@ -1,0 +1,193 @@
+package usecase
+
+// White-box tests for translateTextLengthViolation, the usecase-side half of the
+// 23514 CHECK backstop. The function is unexported so the tests live in the same
+// package; no DB is required because the repository error is constructed
+// directly.
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/rotisserie/eris"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"backend/internal/domain"
+	"backend/internal/repository"
+	"backend/internal/usecase/ucerr"
+)
+
+func TestTranslateTextLengthViolation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		err       error
+		wantField string
+	}{
+		{
+			name:      "front violation becomes a validation error on front",
+			err:       &repository.TextLengthViolationError{Constraint: "cards_front_length", Field: "front"},
+			wantField: "front",
+		},
+		{
+			name:      "back violation becomes a validation error on back",
+			err:       &repository.TextLengthViolationError{Constraint: "cards_back_length", Field: "back"},
+			wantField: "back",
+		},
+		{
+			name:      "name violation becomes a validation error on name",
+			err:       &repository.TextLengthViolationError{Constraint: "master_cardgroups_name_length", Field: "name"},
+			wantField: "name",
+		},
+		{
+			name:      "eris-wrapped violation is still translated",
+			err:       eris.Wrap(&repository.TextLengthViolationError{Constraint: "cards_back_length", Field: "back"}, "repository: card: create"),
+			wantField: "back",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := translateTextLengthViolation(tt.err)
+			require.NotNil(t, got)
+
+			var ve *ucerr.ValidationError
+			require.True(t, errors.As(got, &ve))
+			assert.Equal(t, tt.wantField, ve.Field)
+			assert.Contains(t, ve.Message, "too long")
+		})
+	}
+}
+
+// TestTranslateTextLengthViolation_PassesThroughUnrelatedErrors pins the
+// pre-filter contract: a nil return means the caller falls through to its own
+// eris.Wrap, so an unrelated infrastructure failure keeps classifying as
+// INTERNAL rather than being mislabelled as bad user input.
+func TestTranslateTextLengthViolation_PassesThroughUnrelatedErrors(t *testing.T) {
+	t.Parallel()
+
+	assert.Nil(t, translateTextLengthViolation(errors.New("connection reset")))
+	assert.Nil(t, translateTextLengthViolation(repository.ErrNotFound))
+	assert.Nil(t, translateTextLengthViolation(repository.ErrCardDuplicateFront))
+}
+
+// TestCardgroupUsecase_Create_TextLengthViolation_SurfacesAsValidationOutcome
+// pins the deck-name half of the wiring: the repository classifies the 23514
+// CHECK violation and the usecase must lift it into the outcome's Validation
+// variant (BAD_USER_INPUT on "name"), not wrap it into an internal error.
+func TestCardgroupUsecase_Create_TextLengthViolation_SurfacesAsValidationOutcome(t *testing.T) {
+	t.Parallel()
+	repo := &mockCardgroupRepository{
+		createErr: eris.Wrap(
+			&repository.TextLengthViolationError{Constraint: "cardgroups_name_length", Field: "name"},
+			"repository: cardgroup: create",
+		),
+	}
+	uc := NewCardgroupUsecase(repo, cgDefaultAdmin(), newTestLogger())
+
+	outcome, err := uc.Create(cgAuthedCtx("user-1"), CreateCardgroupInput{Name: "My Group"})
+
+	require.NoError(t, err)
+	require.Nil(t, outcome.Cardgroup)
+	require.NotNil(t, outcome.Validation)
+	assert.Equal(t, "name", outcome.Validation.Field)
+	assert.Contains(t, outcome.Validation.Message, "too long")
+}
+
+// TestCopyMasterToUser_TextLengthViolation_BecomesValidationError covers the
+// master-deck copy path, which reaches cardgroupRepo.CreateTx (the deck name is
+// copied verbatim from the master) and cardRepo.UpsertManyTx (the card bodies).
+// Both classified errors must survive the tx-level wrap as BAD_USER_INPUT.
+func TestCopyMasterToUser_TextLengthViolation_BecomesValidationError(t *testing.T) {
+	t.Parallel()
+
+	const masterID = "m-textlen"
+	newDeps := func() (*fakeMasterCGRepo, *fakeMasterCardRepo) {
+		return &fakeMasterCGRepo{byID: map[string]*domain.MasterCardgroup{
+				masterID: masterCG(masterID, "Deck"),
+			}}, &fakeMasterCardRepo{byMaster: map[string][]*domain.MasterCard{
+				masterID: {masterCard("mc1", masterID, "f1", "b1", 0)},
+			}}
+	}
+
+	t.Run("cardgroup name violation from CreateTx", func(t *testing.T) {
+		t.Parallel()
+		cg, card := newDeps()
+		userCG := &fakeUserCG{createErr: &repository.TextLengthViolationError{
+			Constraint: "cardgroups_name_length",
+			Field:      "name",
+		}}
+		uc, _, _ := newSeedUsecase(t, cg, card, &fakeUserCardRepo{}, userCG)
+
+		got, err := uc.CopyMasterToUser(context.Background(), masterID, "owner-textlen")
+		assert.Nil(t, got)
+		assertValidationError(t, err, "name", "name is too long")
+	})
+
+	t.Run("card body violation from UpsertManyTx", func(t *testing.T) {
+		t.Parallel()
+		cg, card := newDeps()
+		user := &fakeUserCardRepo{upsertErr: &repository.TextLengthViolationError{
+			Constraint: "cards_back_length",
+			Field:      "back",
+		}}
+		uc, _, _ := newSeedUsecase(t, cg, card, user, &fakeUserCG{})
+
+		got, err := uc.CopyMasterToUser(context.Background(), masterID, "owner-textlen-2")
+		assert.Nil(t, got)
+		assertValidationError(t, err, "back", "back is too long")
+	})
+}
+
+// TestCardImportUsecase_TextLengthViolation_BecomesValidationError pins the bulk
+// half: cardRepo.UpsertManyTx is the batch-import writer, and its classified
+// 23514 error must reach the caller as BAD_USER_INPUT on the offending column
+// rather than being swallowed by the tx-level eris.Wrap into an internal error.
+func TestCardImportUsecase_TextLengthViolation_BecomesValidationError(t *testing.T) {
+	t.Parallel()
+
+	payload := buildPayload(t, [][2]string{{"apple", jpRunes(3)}})
+	repo := &mockDictCardRepo{returnErr: &repository.TextLengthViolationError{
+		Constraint: "cards_back_length",
+		Field:      "back",
+	}}
+	tx, _ := dictTxRunner()
+	uc := NewCardImportUsecaseWithTx(ownedCardImportCardgroupRepo("user-1"), repo, tx, newTestLogger())
+
+	_, err := uc.Import(authedCtx("user-1"), ImportCardsInput{
+		CardgroupID: "cg-target",
+		Payload:     payload,
+	})
+
+	assertValidationError(t, err, "back", "back is too long")
+	if repo.upsertCalls != 1 {
+		t.Fatalf("expected 1 UpsertManyTx call, got %d", repo.upsertCalls)
+	}
+}
+
+// TestCardgroupUsecase_Update_TextLengthViolation_SurfacesAsValidationOutcome is
+// the rename sibling: the GORM Updates statement wraps a distinct error branch,
+// so it needs its own assertion.
+func TestCardgroupUsecase_Update_TextLengthViolation_SurfacesAsValidationOutcome(t *testing.T) {
+	t.Parallel()
+	repo := &mockCardgroupRepository{
+		findResult: &domain.Cardgroup{ID: domain.CardgroupID("cg1"), OwnerID: "user-1", Name: "Original"},
+		updateErr: eris.Wrap(
+			&repository.TextLengthViolationError{Constraint: "cardgroups_name_length", Field: "name"},
+			"repository: cardgroup: update",
+		),
+	}
+	uc := NewCardgroupUsecase(repo, cgDefaultAdmin(), newTestLogger())
+
+	outcome, err := uc.Update(cgAuthedCtx("user-1"), "cg1", UpdateCardgroupInput{Name: ptr("New Name")})
+
+	require.NoError(t, err)
+	require.Nil(t, outcome.Cardgroup)
+	require.NotNil(t, outcome.Validation)
+	assert.Equal(t, "name", outcome.Validation.Field)
+	assert.Contains(t, outcome.Validation.Message, "too long")
+}

--- a/backend/internal/usecase/validators.go
+++ b/backend/internal/usecase/validators.go
@@ -7,6 +7,7 @@ import (
 	"github.com/rotisserie/eris"
 
 	"backend/internal/domain"
+	"backend/internal/repository"
 	"backend/internal/usecase/ucerr"
 )
 
@@ -75,6 +76,24 @@ func translateCardErr(err error) error {
 	default:
 		return eris.Wrap(err, "usecase: translate card err: unexpected domain error")
 	}
+}
+
+// translateTextLengthViolation maps a *repository.TextLengthViolationError -- the
+// database-side CHECK backstop on a "<table>_<column>_length" constraint
+// (SQLSTATE 23514) -- to a field-scoped BAD_USER_INPUT validation error keyed on
+// the column the constraint guards ("front", "back", "name").
+//
+// It returns nil when err is not a text-length violation, so callers use it as a
+// pre-filter before their existing eris.Wrap. The domain layer enforces the
+// user-visible cap in grapheme clusters and the database bound is a wide
+// multiple of it, so this path fires only for pathological combining-mark input;
+// classifying it as BAD_USER_INPUT rather than INTERNAL means the learner sees a
+// length message instead of an unexplained failure.
+func translateTextLengthViolation(err error) error {
+	if v, ok := errors.AsType[*repository.TextLengthViolationError](err); ok {
+		return ucerr.NewValidationError(v.Field, fmt.Sprintf("%s is too long", v.Field))
+	}
+	return nil
 }
 
 // translateCardgroupNameErr maps domain sentinel errors from ParseCardgroupName


### PR DESCRIPTION
## Summary

Widen the six text-length CHECK constraints from a code-point bound that was narrower than the grapheme cap the domain and frontend enforce, and classify SQLSTATE 23514 as a field-scoped BAD_USER_INPUT instead of an opaque INTERNAL.

> **Stacked on the issue #1025 branch. That branch adds the newest migration and this one adds another on top of it, so every `m.Steps(-N)` roundtrip count here is one deeper than on `main`. Merge #1025 first.**

## Changes

Three layers disagreed on what "500 characters" means. `domain.ParseCardText` and `domain.ParseCardgroupName` count grapheme clusters via `uniseg.GraphemeClusterCount`, and `frontend/src/schemas/grapheme.ts` counts them via `Intl.Segmenter`, but Postgres `char_length()` counts code points. A ZWJ family emoji is one grapheme and seven code points, so a 500-grapheme emoji card back is 3500 code points and was rejected by `cards_back_length CHECK (... BETWEEN 1 AND 500)` after both the form and the server had accepted it. Nothing in the repository layer classified SQLSTATE 23514, so the learner saw an unexplained internal error.

Migration `20260722000000_widen_text_length_checks` rewrites all six constraints (`cardgroups_name_length`, `cards_front_length`, `cards_back_length`, `master_cardgroups_name_length`, `master_cards_front_length`, `master_cards_back_length`) with an upper bound of 20x the grapheme cap: 500 -> 10000 for card text, 100 -> 2000 for deck names. The lower bound stays at 1, because "non-empty after trim" is identical under both counting rules and graphemes remain the single user-visible rule. Each table's DROP + ADD pair is a single `ALTER TABLE` so the swap is atomic. The down migration restores 500/100 and documents that the rollback fails on rows carrying the emoji-rich content the up migration exists to admit.

The multiplier is NOT the 4x the issue body suggested as an example. 4x is provably insufficient for the issue's own acceptance criterion: 500 ZWJ family emoji is 3500 code points, past a 2000 bound, and a fully skin-toned four-person family is 11 code points per grapheme (5500 at the cap). 20x covers that with headroom for variation selectors while keeping the constraint a meaningful storage sanity check. `TestZWJEmojiAtGraphemeCap_CodePointExpansion` pins the 7x arithmetic so the sizing rationale is machine-checked rather than prose-only.

The 23514 backstop is additive and lives entirely in `internal/repository/pgerr.go`, per the file-ownership constraint: a new `TextLengthViolationError{Constraint, Field}` type plus `classifyTextLengthViolation` and a `textLengthConstraintField` parser that derives the guarded column from the `<table>_<column>_length` naming convention ("master_cardgroups_name_length" -> "name"), so no per-table lookup table is needed. A 23514 on a differently-named CHECK returns nil and stays INTERNAL, because it carries no field attribution. The classifier is wired as a three-line pre-filter at six write sites (`cardRepo.Create`/`Update`, `masterCardRepo.Create`/`Update`/`UpsertManyTx`, `masterCardgroupRepo.Create`/`Update`) ahead of the existing `eris.Wrap`, without restructuring any existing error path.

The repository layer cannot import `ucerr` (go-arch-lint: `repository: {mayDependOn: [domain]}`), so `usecase/validators.go` gains `translateTextLengthViolation`, which recovers the typed error with `errors.AsType` and returns `ucerr.NewValidationError(v.Field, "<field> is too long")`. It is wired at all seven matching usecase sites; the two `master_catalog.go` sites route through `liftValidationErr` so the outcome-union shape of that file is preserved. Post-flight grep confirms every classifier arm has a translating consumer and vice versa - no speculative helper, no dead branch.

### Tests

Full suite: 2283 tests passed across 26 packages, with Docker running so every testcontainer-gated migration and integration test really executed (verified via `rtk proxy go test ... -v`, which shows the postgres:15-alpine container start/stop around `--- PASS: TestWidenTextLengthChecksDownUpRoundtrip (0.10s)`).

New `backend/internal/repository/text_length_grapheme_integration_test.go` (5 tests, real DB):
- `TestZWJEmojiAtGraphemeCap_CodePointExpansion` — 500 repetitions of the ZWJ family cluster is 500 graphemes and 3500 code points.
- `TestCardRepository_ZWJEmojiAtGraphemeCap_RoundTrips` — a 500-grapheme emoji string round-trips through `Create` for both front and back, then through `Update` (a separate GORM statement, so it needs its own assertion against the same constraint).
- `TestCardgroupRepository_ZWJEmojiAtGraphemeCap_RoundTrips` — same for the 100-grapheme deck-name cap on create and update.
- `TestDomainRejectsOverCapEmojiBeforeReachingDB` — one grapheme past the cap fails at `ParseCardText` / `ParseCardgroupName`, proving the domain remains the gate and no over-length value reaches the repository.
- `TestCardRepository_CheckViolation_ClassifiesAsTextLengthError` — a 20001-char write that bypasses the domain gate surfaces as `*repository.TextLengthViolationError{Field: "front", Constraint: "cards_front_length"}`, not a wrapped driver error.

New `backend/internal/repository/pgerr_text_length_test.go` (11 subtests, no DB): the four positive constraint-name shapes including the multi-word `master_cardgroups_` prefix, the eris-wrapped case, and four negatives (23505 on the same table, 23514 on a non-length CHECK, a `_length` name with no column segment, a non-pg error). Plus a pointer-receiver test that the field survives `eris.Wrap`.

New `backend/internal/usecase/text_length_violation_test.go`: front/back/name and eris-wrapped translation to `*ucerr.ValidationError`, and a pass-through test asserting `ErrNotFound` / `ErrCardDuplicateFront` / a plain error all return nil so unrelated failures keep classifying as INTERNAL.

New `backend/internal/database/text_length_checks_roundtrip_test.go`: reads `pg_get_constraintdef` for all six constraints, asserts the widened bound at HEAD, `Steps(-1)` and asserts every one reverted to 500/100, `Steps(1)` and asserts every one is widened again.

One pre-existing test was updated because its code path changed: `TestCardgroupRepository_NameLengthCheckRejectsTooLong` pinned the old 100-code-point bound and started passing a 101-char name. It now uses 2001 chars against the new bound, with a comment explaining that the domain rejects at 100 graphemes long before the DB backstop fires.

### Review fixes

Five adversarially-confirmed findings; findings 1, 2 and 4 were the same defect seen through three lenses.

### The 23514 seam was wired everywhere except the ordinary `cardgroups` write path

The migration widens `cardgroups_name_length` to 2000 code points, but `classifyTextLengthViolation` was wired only at `cards`, `master_cards` and `master_cardgroups`. A deck name that clears the 100-grapheme domain cap but exceeds 2000 code points (pathological combining-mark input — verified at 100 graphemes / 2100–3100 code points with the repo's own `uniseg` v0.4.7) surfaced as `INTERNAL`, while the identical string on a card front already returned a clean `BAD_USER_INPUT`. `master_cardgroups` name writes were classified and ordinary `cardgroups` name writes were not — an intra-branch inconsistency, not a scoping decision.

- **`repository/cardgroup.go`** — added the `classifyTextLengthViolation` pre-filter to `Create`, `CreateTx` and `Update`, each as a self-contained `if` immediately before the existing `eris.Wrap`, mirroring `master_cardgroup.go` exactly.
- **`usecase/cardgroup.go`** — added the matching `translateTextLengthViolation` + `liftValidationErr` pre-filter in `Create` and `Update`, so the violation lands in the outcome's `Validation` variant (`BAD_USER_INPUT` on `name`) rather than being wrapped into an internal error. `textLengthConstraintField` already derives `name` from `cardgroups_name_length`, so no field-mapping change was needed.
- **`EnsureByName` deliberately left unwired** — `grep -rn 'EnsureByName' backend/internal/ | grep -v _test.go` shows the cardgroup variant has zero production callers (only the master variant is consumed, by `notion_sync.go`). An arm there would be dead code with no translating consumer.

### `cardRepo.UpsertManyTx` — the learner-facing bulk writer — was also unclassified

Its master twin `masterCardRepo.UpsertManyTx` was classified, but the bulk path behind batch import and merge-from-catalog was not. Fixed on both sides, because the repository arm alone is necessary but not sufficient:

- **`repository/bulk_card_tx.go`** — classifier arm at the `upsertManyTx` error branch, mirroring `master_card.go`.
- **`usecase/card_import.go`** — translate pre-filter in the post-tx error branch, after the existing `isContextDone` guard so the context-error identity pin is preserved. `errors.AsType` walks the eris chain, so the double wrap is not an obstacle.
- **`usecase/master_deck.go`** — the same translate arm at `CopyMasterToUser`, `SeedForNewUser` and `MergeMasterIntoCardgroup`, which share `cardRepo.UpsertManyTx` and (for the first two) `cardgroupRepo.CreateTx`.

### Comment accuracy

The migration header claimed the widening means the database backstop "can no longer reject a value the domain layer accepts". An extended grapheme cluster admits an unbounded combining-mark run, so no finite code-point multiplier discharges that absolute. Reworded to state the real property — the widening clears all realistic emoji expansion, and the 23514 arm classifies the residue as `BAD_USER_INPUT`. The same false absolute in `repository/pgerr.go` ("a backstop that should never fire in practice") and `usecase/validators.go` ("this path should be unreachable") was corrected on the same edit so the three tell one story. `pgerr.go`'s docblock claim that the type backs "the card and cardgroup text columns" is now true.

### Post-flight grep (both directions, balanced)

11 `classifyTextLengthViolation` arms — `card.go` ×2, `cardgroup.go` ×3, `bulk_card_tx.go` ×1, `master_card.go` ×3, `master_cardgroup.go` ×2 — against 13 `translateTextLengthViolation` consumers — `card.go` ×2, `cardgroup.go` ×2, `card_import.go` ×1, `master_deck.go` ×3, `master_card.go` ×3, `master_catalog.go` ×2. Every arm has at least one translating consumer; no consumer lacks an arm.

### Tests

- **`repository/text_length_grapheme_integration_test.go`** (Docker-gated) — three new cases: `TestCardgroupRepository_CheckViolation_ClassifiesAsTextLengthError` (2001-code-point deck name through both `Create` and `Update`), `TestCardgroupRepository_CreateTx_CheckViolation_ClassifiesAsTextLengthError`, and `TestCardRepository_UpsertManyTx_CheckViolation_ClassifiesAsTextLengthError` (10001-code-point `back` through the bulk multi-row INSERT).
- **`usecase/text_length_violation_test.go`** — four new cases pinning the translating consumers: cardgroup `Create` / `Update` lifting into the `Validation` outcome, the card-import bulk path, and both master-deck sub-paths (`CreateTx` name violation, `UpsertManyTx` card-body violation).

Each behavioural fix was proven by temporarily neutering the production pre-filter, observing the targeted test go RED, then restoring and confirming GREEN.

## Test plan

- [ ] cd backend && go build ./... — Success
- [ ] cd backend && go vet ./... — No issues found
- [ ] cd backend && go tool go-arch-lint check — OK, no warnings found
- [ ] cd backend && go test ./internal/database/... ./internal/repository/... — 415 passed, 0 failed (3 packages, Docker-gated tests really ran)
- [ ] cd backend && go test ./... — 2283 passed, 0 failed (26 packages)
- [ ] CJK grep (perl -CSD over tracked backend .go/.sql) — no hits
- [ ] grep -rnE 'PR[0-9]+' on new files — no hits
- [ ] git status --short in main checkout /Users/yasuflatland/projects/flamingo-armond — empty
- [ ] git log --oneline -1 — 5554cdef fix(database): add a foreign key and backing index for swipe_records.cardgroup_id (correct stacked base on the #1025 branch)
- [ ] Production diff (git diff --stat HEAD -- '*.go' ':!*_test.go') — 8 files, 133 insertions, well under the 800-line ceiling
- [ ] cd backend && go tool go-arch-lint check --project-path . — OK, no warnings found
- [ ] cd backend && go test -count=1 ./... — 2293 passed in 26 packages (Docker up, so the testcontainer-gated repository/database suites really executed)
- [ ] RED proof (usecase arms neutered via `translated != nil && false`): go test -run TextLength ./internal/usecase/... — 6 passed, 6 failed; all four new usecase tests (incl. both CopyMasterToUser sub-tests) failed. Restored → 12 passed.
- [ ] RED proof (repository arms neutered via `classified != nil && false`): go test -run CheckViolation ./internal/repository/... — 1 passed, 3 failed; all three new integration tests failed, the pre-existing card.go one still passed. Restored → 4 passed.
- [ ] CJK gate (perl -CSD over all 10 changed files) — no output
- [ ] PR-order-reference gate (grep -rnE 'PR[0-9]+|this PR' on changed prod files) — no output
- [ ] Worktree `git status --short` — exactly the 10 intended modified files, no untracked
- [ ] Main checkout /Users/yasuflatland/projects/flamingo-armond `git status --short` — empty

## Notes

**Stacked-branch handling.** Base is `5554cdef` (the #1025 cardgroup-FK commit), not main. The issue body's `Steps(-N)` figures were the main values and were stale by one; every count was read from the worktree and bumped from what was actually there, along with the prose migration list each comment carries:

- `cardgroup_fk_roundtrip_test.go` -1 -> -2 (the new file from #1025 that the issue body does not know exists; the paired `Steps(1)` stays at 1 because the cleanup restores the rest)
- `stability_before_roundtrip_test.go` -2 -> -3
- `last_rating_roundtrip_test.go` -3 -> -4 in both tests, and BOTH paired forward `Steps(3)` -> `Steps(4)`
- `learn_display_mode_roundtrip_test.go` -10 -> -11
- `cards_position_roundtrip_test.go` -15 -> -16
- `users_version_roundtrip_test.go` -16 -> -17 (its numbered 1..17 list was renumbered)

The new migration is timestamped `20260722000000`, which sorts after `20260721000000_add_cardgroup_fk_to_swipe_records` — confirmed against the real directory tail, not the issue body.

**Explicitly out of scope, untouched, as instructed:** the Go `strings.TrimSpace` vs SQL `trim()` divergence (Go trims all Unicode whitespace, SQL only ASCII — same-direction, so it cannot cause a false rejection); the grapheme caps `CardTextMax` / `CardgroupNameMax`; anything under `frontend/`.

**Operator note for the down migration.** The rollback narrows the bounds back to 500/100 and will fail if any row was stored with a code-point length between the old and new bound. That is by construction the emoji-rich content the up migration exists to admit. The down file says so; there is no automatic data repair.

Production diff is 58 lines across 8 non-test files — far under the 800-line ceiling, no split needed.

Deliberate scope decisions worth a reviewer's attention:

1. **`cardgroupRepo.EnsureByName` was NOT wired**, even though two of the three findings suggested "consider" it. It has zero production callers (`grep -rn 'EnsureByName' backend/internal/ --include='*.go' | grep -v _test.go` returns only the interface declaration plus the *master* variant, which notion_sync.go consumes). Adding an arm there would violate the "every arm needs a translating consumer" rule.

2. **The severity-downgrade argument from all three refuters was accepted as accurate but not acted on.** Reaching 23514 on a deck name needs >20 code points per grapheme (deliberate Zalgo input); the realistic worst case — 100 graphemes of skin-toned ZWJ family emoji at 11 cp each = 1100 — is comfortably under 2000. The fix is justified on completeness and intra-branch consistency, and on `pgerr.go`'s own defensive-backstop contract, not on user-facing blast radius. The PR body reflects that framing.

3. **`usecase/master_deck.go` gained three translate arms** rather than the one Finding 3 named. `CopyMasterToUser` and `SeedForNewUser` are the only production consumers of `cardgroupRepo.CreateTx`, so without them that repository arm would have been dead.

4. **The `isContextDone` guard runs before the new translate arm** at every tx-level site, preserving the unwrapped `context.Canceled` / `context.DeadlineExceeded` identity that `assertCancelled` and the resolver's Cancelled routing depend on.

5. Out-of-scope items from the issue were respected: no trim-semantics unification, no grapheme-cap change, no frontend work.

No files outside the worktree were touched; the main checkout is byte-clean.

**Scope deviations.** Four deliberate departures from the issue body, each with a reason:

1. **20x multiplier, not the issue's "e.g. 4 * cap".** 4x contradicts the issue's own acceptance criterion — a 500-grapheme ZWJ family string is 3500 code points and a 2000 bound would still reject it. Sized instead from the worst realistic expansion (11 code points per grapheme for a skin-toned four-person family = 5500 at the cap), rounded up to 20x. The arithmetic is pinned by a test rather than left as a comment.

2. **`backend/internal/repository/cardgroup.go` was NOT touched.** Per the file-ownership constraint (sibling PR #1022 owns the 23503 arm in its `Create`), no 23514 arm was added there. Consequence: a 23514 on `cardgroups_name_length` from a user-deck write still classifies as INTERNAL. This is a backstop-only gap — the widened CHECK (100 -> 2000) is the actual fix for deck names and IS covered end-to-end by `TestCardgroupRepository_ZWJEmojiAtGraphemeCap_RoundTrips`. The sibling PR's owner can add the two-line arm uniformly across `Create` / `CreateTx` / `Update` in one pass.

3. **Repository arms wired at Update paths and on `master_cardgroup.go`,** slightly beyond the issue's literal "sites that already call `pgConstraintViolation`" (which was only `card.go:191`, `master_card.go:33`, `master_card.go:319`). Update writes go through a different GORM statement and hit the same constraint; classifying only creates would have left a visible asymmetry inside the same file. All these files are outside the #1011 / #1022 ownership boundary.

4. **A dedicated `text_length_checks_roundtrip_test.go` was added.** The issue's scope list mentions only bumping existing `Steps(-N)` counts, but every migration in this repo carries its own down/up roundtrip test; adding one is required by acceptance criterion 4 read against repo convention.

**Expected merge conflicts.** `backend/internal/repository/cardgroup.go` — I added a `classifyTextLengthViolation` pre-filter arm inside three functions: `cardgroupRepo.Create` (~L288), `cardgroupRepo.CreateTx` (~L301) and `cardgroupRepo.Update` (~L383). The sibling branch for #1022 adds a `classifyCardgroupOwnerFKError` pre-filter to the same `Create` / `CreateTx` error branches, so a merge conflict in those two functions is expected. Resolution is mechanical: keep BOTH pre-filter arms in each branch, in either order (the two classifiers are disjoint — one matches SQLSTATE 23503 on the owner FK, the other 23514 on a `*_length` CHECK — so neither can shadow the other), with the existing `eris.Wrap` remaining as the final fallthrough. No surrounding line was reflowed, reordered or renamed, so the conflict hunks should be minimal. `cardgroupRepo.Update` is mine alone and should not conflict.

**Merge order.** This branch now shares files with several base-`main` siblings: `repository/cardgroup.go` + `usecase/cardgroup.go` with #1022, `repository/card.go` with #1011, `usecase/card.go` with #1011 and #1021, `usecase/master_catalog.go` with #1010 / #1018 / #1022, and `usecase/master_deck.go` with #1010 / #1018. Every overlap is an additive pre-filter placed immediately before an existing `eris.Wrap`; where git reports a conflict the resolution is to keep BOTH arms.

**CI on a stacked PR.** This repository's heavy workflows are gated on `pull_request: branches: [main]`, so they do not fire while the base is another feature branch, and `Closes #1016` does not register either. After #1025 merges, retarget this PR's base to `main` and close/reopen it to kick CI.

Closes #1016
