### PR TITLE
fix(backend): pass the cardgroup counter in the merge-master vanished-destination test

### DIFF
--- a/backend/internal/usecase/master_catalog_test.go
+++ b/backend/internal/usecase/master_catalog_test.go
@@ -1381,7 +1381,7 @@ func TestMasterCatalogUsecase_MergeMaster_DestVanishedAfterCommit_NotNotFoundOut
 		stubTxRunner,
 		newTestLogger(),
 	)
-	uc := NewMasterCatalogUsecase(repo, deck, newTestAdminGate(true), newTestLogger())
+	uc := NewMasterCatalogUsecase(repo, deck, &stubCardgroupCounter{}, newTestAdminGate(true), newTestLogger())
 
 	out, err := uc.MergeMaster(authedCtx(ownerID), masterID, destID)
 	if out.NotFound {


### PR DESCRIPTION
## Summary

`main` does not compile its test binary. `go vet ./...` and `go test ./...` both fail in `backend/internal/usecase` with `not enough arguments in call to NewMasterCatalogUsecase`. The cause is a semantic merge conflict between two PRs that merged ten seconds apart and did not conflict textually: #1053 widened the constructor from four parameters to five (adding `cgCounter cardgroupOwnerCounter` for the deck-quota gate), while #1060 added a brand-new test 400 lines away that calls the four-parameter form. The three-way merge saw two edits in different regions of the same file and merged them cleanly.

`go build ./...` still passes, because it does not compile `_test.go` files — which is why the break reached `main` looking green to a build-only smoke check.

## Changes

- `backend/internal/usecase/master_catalog_test.go:1384` — pass `&stubCardgroupCounter{}` as the third argument in `TestMergeMaster_PostTxDestVanished_...`, matching every other `NewMasterCatalogUsecase` call site in the file (`:173`, `:182`, `:191`, `:200`, `:208`, …). One line, test-only; no production code changes.

## Verification

`go vet ./...` is the gate that catches this class — it type-checks `_test.go`, `go build ./...` does not. Any future merge train should run `go vet` (or `go test`) after each merge, not just `go build`.

## Test plan

- [ ] `go build ./...` — Success (also passed *before* this fix, which is the point)
- [ ] `go vet ./...` — no issues found (fails on `main` without this fix: `master_catalog_test.go:1384:68: not enough arguments in call to NewMasterCatalogUsecase`)
- [ ] `go tool go-arch-lint check` — OK, no warnings
- [ ] `go test -count=1 ./...` — green, 26 packages, 0 FAIL (Docker up, testcontainer-gated integration tests really ran). On `main` this is `FAIL backend/internal/usecase [build failed]`.

## Notes

No related issue — this is a merge-integration break on `main`, not a defect in either contributing PR. Both #1053 and #1060 were green on their own branches.

Four sibling PRs from the same batch are still open (#1054, #1061, #1064, #1067, #1070) and carry the same class of risk: #1061 renames `UserRepository.DeleteAuthUser` to `DeleteAuthUserTx` and adds a leading `*gorm.DB` to `NewUserUsecase`, while #1064 adds new call sites of both old forms. A sequential integration simulation of all eighteen branches found exactly three breaks of this shape; this is the first of them.
