### PR TITLE
chore(deps): hold TypeScript on the latest 6.x until Next.js supports the native compiler

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -40,7 +40,7 @@
       "rangeStrategy": "replace"
     },
     {
-      "description": "Hold TypeScript on 6.x. typescript@7 is the native Go port: its package exports map resolves '.' to lib/version.cjs and it no longer ships lib/typescript.js. Next.js probes for exactly that file in dist/lib/verify-typescript-setup.js to detect TypeScript, so `next build` aborts with 'you do not have the required package(s) installed' even though `tsc --noEmit` passes. That breaks the frontend build, the Playwright webServer and the Vercel deploy at once. Lift this cap once Next.js supports the native compiler for a non-preview `typescript` dependency (it currently only special-cases @typescript/native-preview).",
+      "description": "Hold TypeScript on the latest 6.x. typescript@7 is the native Go port: its package exports map resolves '.' to lib/version.cjs and it no longer ships lib/typescript.js. Next.js probes for exactly that file in dist/lib/verify-typescript-setup.js to detect TypeScript, so `next build` aborts with 'you do not have the required package(s) installed' even though `tsc --noEmit` passes. That breaks the frontend build, the Playwright webServer and the Vercel deploy at once. allowedVersions caps how far an upgrade may go without freezing the dependency, so 6.x releases keep flowing through the normal minor/patch automerge path while 7.x is filtered out. It carries no matchUpdateTypes because Renovate rejects that combination in a single rule. Lift this cap once Next.js supports the native compiler for a non-preview `typescript` dependency (it currently only special-cases @typescript/native-preview).",
       "matchManagers": ["npm"],
       "matchPackageNames": ["typescript"],
       "allowedVersions": "<7"

--- a/renovate.json
+++ b/renovate.json
@@ -40,6 +40,12 @@
       "rangeStrategy": "replace"
     },
     {
+      "description": "Hold TypeScript on 6.x. typescript@7 is the native Go port: its package exports map resolves '.' to lib/version.cjs and it no longer ships lib/typescript.js. Next.js probes for exactly that file in dist/lib/verify-typescript-setup.js to detect TypeScript, so `next build` aborts with 'you do not have the required package(s) installed' even though `tsc --noEmit` passes. That breaks the frontend build, the Playwright webServer and the Vercel deploy at once. Lift this cap once Next.js supports the native compiler for a non-preview `typescript` dependency (it currently only special-cases @typescript/native-preview).",
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["typescript"],
+      "allowedVersions": "<7"
+    },
+    {
       "description": "GitHub Actions",
       "matchManagers": ["github-actions"],
       "groupName": "github actions",


### PR DESCRIPTION
## Summary

Cap `typescript` at `<7` in `renovate.json` so the frontend stays on the latest 6.x line and Renovate stops proposing the TypeScript 7 native compiler. `typescript@7` is the Go port: its `exports` map resolves `"."` to `lib/version.cjs` and the tarball no longer ships `lib/typescript.js`, which is the exact file Next.js probes to detect TypeScript. The result is that `next build` aborts with "It looks like you're trying to use TypeScript but do not have the required package(s) installed" **even though `tsc --noEmit` passes** — the standalone `tsc` binary still works, so the failure is invisible to the typecheck gate and only shows up at build time. One root cause, three broken checks: the frontend CI `Build` step, the Playwright `webServer` boot, and the Vercel deploy.

The cap limits how far an upgrade may go; it does not freeze the dependency. `6.0.3` is already the newest stable 6.x on npm, so the pin in `frontend/package.json` is unchanged, and any future 6.x release still flows through the existing minor/patch automerge rule.

## Changes

### `renovate.json` — new `packageRules` entry

- Added an npm-scoped rule matching `typescript` with `"allowedVersions": "<7"`, placed after the `landing dependencies` rule and before the `GitHub Actions` rule so it sits with the other npm-manager rules.
- Its `description` records the mechanism (native port -> no `lib/typescript.js` -> Next.js detection probe misses it), the fact that 6.x updates keep flowing, why the rule carries no `matchUpdateTypes`, and the lift condition — following this file's convention of documenting each rule inline rather than in `docs/`.
- No application code, dependency manifest, or lockfile is touched. `frontend/package.json` stays on `typescript` `6.0.3`; this change only stops the next Renovate run from moving it past the 6.x line.

## Verification

Verified against the published tarballs, the installed Next.js source, and the Renovate documentation source — not from release notes:

- `tar tzf` on the npm tarballs — `typescript@6.0.3` contains `package/lib/typescript.js`; `typescript@7.0.1-rc` and `7.0.2` do not (416 entries in 7.0.2; `lib/` holds only `version.cjs`, `getExePath.js`, `tsc.js`).
- `typescript@7.0.2` `package.json` declares `"exports": { ".": "./lib/version.cjs", ... }` and `"bin": { "tsc": "./bin/tsc" }` — the JS compiler API is gone, only the CLI shim and `unstable/*` subpaths remain.
- `next@16.2.10` `dist/lib/verify-typescript-setup.js:71` declares the probe `{ file: 'typescript/lib/typescript.js', pkg: 'typescript' }`. The only alternative-compiler escape hatch in that file is a `@typescript/native-preview` special case; a plain `typescript@7` dependency is not recognised.
- Renovate `docs/usage/configuration-options.md` § `packageRules.allowedVersions` — "limit how far to upgrade a dependency", with the documented Angular example using `<1.6.0` to stay on the 1.5 line. It also warns that `allowedVersions` and `matchUpdateTypes` cannot share a rule, which is why the new rule matches on package name alone.
- `npm view typescript time` — the only stable 6.x releases are `6.0.2` and `6.0.3`, so `6.0.3` is already the newest 6.x and no manifest bump is needed.

Observed failure on the open frontend-dependencies branch at `5fee9e4d`, confirming the three symptoms share this one cause:

- frontend CI `Lint, typecheck, build` — steps 11 `Biome check`, 12 `Knip` and 13 `TypeScript typecheck` all pass; step 15 `Build` fails.
- E2E — `[WebServer] It looks like you're trying to use TypeScript but do not have the required package(s) installed.` then `Process from config.webServer was not able to start.`
- Vercel — same message at `Running TypeScript ...`, `Next.js build worker exited with code: 1`.

After merge, the check is that the next Renovate run regenerates the frontend-dependencies PR **without** the `typescript 6.0.3 -> 7.0.2` row, while keeping the other major bumps in that group.

## Test plan

- [ ] `renovate.json` parses as JSON and the new rule reads back as `{matchManagers:["npm"], matchPackageNames:["typescript"], allowedVersions:"<7"}` — PASS
- [ ] `ajv validate -s renovate-schema.json -d renovate.json --spec=draft7 --strict=false` against the live `https://docs.renovatebot.com/renovate-schema.json` — PASS (`renovate.json valid`, exit 0). `allowedVersions` is confirmed present in the schema's `packageRules` item, and its own description points at `#packagerulesallowedversions`
- [ ] The new rule declares no `matchUpdateTypes`, so it does not hit the documented "`allowedVersions` and `matchUpdateTypes` cannot be used in the same package rule" restriction — PASS
- [ ] `git diff main...HEAD --stat` → `renovate.json` only, no application code in the diff
- [ ] `git status --short` in the worktree → empty; `git status --short` in the main checkout → empty
- [ ] Post-merge: next Renovate run drops the `typescript` row from the frontend-dependencies PR and the frontend CI `Build` step goes green
- [ ] Post-merge regression watch: a future `6.x` release still opens a PR and auto-merges via the existing minor/patch rule

No application test suite applies — this is a bot-config-only change with no runtime surface.

## Notes

**Timeline.** `typescript@7.0.2` was published to npm on 2026-07-08 (the first stable 7.x on `latest`; `7.0.1-rc` preceded it on 2026-06-18). With `minimumReleaseAge: "7 days"` it became eligible around 2026-07-15, and the `before 9am on monday` schedule picked it up on the next Monday run, which opened the frontend-dependencies PR at 2026-07-20 03:44 JST. So the breakage arrived on the first scheduled run after 7.0.2 cleared the age gate, not from any repository change.

**Why cap in `renovate.json` rather than pinning in `frontend/package.json`.** `frontend/package.json` already pins an exact `typescript` version, so editing it there would be overwritten by the next Renovate run. `allowedVersions` is the mechanism that makes the hold survive. `matchManagers: ["npm"]` scopes it so a future non-npm `typescript` datasource is unaffected.

**Why a cap rather than `enabled: false` or `ignoreDeps`.** Disabling updates for `typescript` outright would also stop 6.x security and patch releases. The cap keeps the dependency live on its current major line, which is the behaviour the Renovate docs describe for this option.

**Why not `@typescript/native-preview`.** Next.js does have a code path that accepts `@typescript/native-preview` as an alternative compiler, so adopting the native compiler that way is possible. That is a deliberate toolchain migration with its own risk, not something a dependency-bump PR should perform silently — this change keeps the compiler where it is and leaves that decision open.

No issue is associated with this change; it was found while diagnosing the failing frontend-dependencies Renovate PR.
