### PR TITLE
docs(backend): document the account-deletion cascade in the database doc

### DIFF
--- a/backend/internal/repository/user.go
+++ b/backend/internal/repository/user.go
@@ -100,6 +100,10 @@ type UserRepository interface {
 	// user_preferences) are removed automatically by the existing ON DELETE
 	// CASCADE foreign keys — no application-level multi-step delete is needed.
 	// Returns ErrNotFound when no auth.users row matches id (RowsAffected == 0).
+	// The canonical write-up of the cascade — the full foreign-key table, the
+	// single SET NULL, the two delete paths and the operator runbook for the
+	// Supabase-managed auth.* children — is docs/backend-db.md § "Account
+	// deletion — what cascades".
 	//
 	// The delete is transaction-scoped because callers must hold the admin-role
 	// advisory lock (AcquireAdminRoleLockTx) across the last-admin count and the

--- a/docs/backend-db.md
+++ b/docs/backend-db.md
@@ -93,6 +93,61 @@ The following read-path composite indexes are intentionally **not** present. The
 
 Measure before adding either: `EXPLAIN (ANALYZE, BUFFERS)` on the query plus `pg_stat_user_tables.seq_scan` / `pg_stat_statements` to confirm the index will be used.
 
+### Account deletion — what cascades
+
+Deleting an account is a **single `DELETE` against `auth.users`**. Everything a learner owns — decks, cards, review history, FSRS scheduling state, preferences and role assignments — is removed by the database's own `ON DELETE CASCADE` foreign keys; there is no application-level multi-step delete to keep in sync. The isolation point in Go is `UserRepository.DeleteAuthUserTx` (`backend/internal/repository/user.go`), which issues that one statement inside the caller's transaction.
+
+The full set of foreign keys that participate, read from the migration files:
+
+| Child column | References | `ON DELETE` | Declared in |
+|---|---|---|---|
+| `public.users.id` | `auth.users(id)` | CASCADE | `20260430080000_initial_schema.up.sql:98` |
+| `user_roles.user_id` | `public.users(id)` | CASCADE | `20260430080000_initial_schema.up.sql:110` |
+| `user_roles.role_id` | `public.roles(id)` | CASCADE | `20260430080000_initial_schema.up.sql:111` |
+| `cardgroups.owner_id` | `public.users(id)` | CASCADE | `20260430080000_initial_schema.up.sql:120` |
+| `cards.cardgroup_id` | `public.cardgroups(id)` | CASCADE | `20260430080000_initial_schema.up.sql:134` |
+| `swipe_records.user_id` | `public.users(id)` | CASCADE | `20260430080000_initial_schema.up.sql:153` |
+| `swipe_records.card_id` | `public.cards(id)` | CASCADE | `20260430080000_initial_schema.up.sql:154` |
+| `swipe_records.cardgroup_id` | `public.cardgroups(id)` | CASCADE | `20260721000000_add_cardgroup_fk_to_swipe_records.up.sql` |
+| `user_card_fsrs.user_id` | `public.users(id)` | CASCADE | `20260430080000_initial_schema.up.sql:182` |
+| `user_card_fsrs.card_id` | `public.cards(id)` | CASCADE | `20260430080000_initial_schema.up.sql:183` |
+| `user_preferences.user_id` | `public.users(id)` | CASCADE | `20260430080000_initial_schema.up.sql:205` |
+| `user_preferences.last_viewed_cardgroup_id` | `public.cardgroups(id)` | **SET NULL** | `20260430080000_initial_schema.up.sql:207` |
+| `master_cards.master_cardgroup_id` | `public.master_cardgroups(id)` | CASCADE | `20260614000000_add_master_tables.up.sql:89` |
+
+Three properties of that table are load-bearing:
+
+- **The single `SET NULL` is `user_preferences.last_viewed_cardgroup_id`.** No `RESTRICT` (and no `NO ACTION`) foreign key exists anywhere in the migration tree, so nothing can block an account delete. `SET NULL` is what lets a deck be deleted without destroying its owner's preference row; the rationale is in [§ "`user_preferences` — per-user UI continuity"](#user_preferences--per-user-ui-continuity).
+- **`roles`, `ping_records` and `master_cardgroups` carry no user-referencing column.** Deleting a user removes their `user_roles` membership rows, never the `roles` catalog itself. And because `master_cardgroups` has no owner column, **published master decks survive the deletion of the admin who created them** — there is nothing to cascade from.
+- **Every foreign key has a backing index**, so a cascade never degrades to a sequential scan; see [§ "Index strategy"](#index-strategy).
+
+#### The two delete paths
+
+Both entry points converge on the same `DeleteAuthUserTx` call and reach an **identical end state**. They share the last-admin guard (`guardNotLastAdmin`, taken under the admin-role advisory lock), and the admin path additionally refuses self-deletion. They differ on exactly one thing — what a **missing `auth.users` row** means:
+
+| Path | Usecase | Missing `auth.users` row |
+|---|---|---|
+| `deleteMyAccount` | `userUsecase.DeleteMyAccount` (`backend/internal/usecase/user.go`) | idempotent success — returns `nil`, since the account is already gone from the system's perspective |
+| `adminDeleteUser` | `adminUserUsecase.DeleteUser` (`backend/internal/usecase/admin_user.go`) | `ucerr.NewValidationError("id", "user not found")`, i.e. `BAD_USER_INPUT` on the `id` field |
+
+The asymmetry is deliberate: a self-delete is a request to reach a state ("my account is gone") that a second call has already satisfied, whereas an admin naming a nonexistent `id` has supplied bad input and should be told so.
+
+#### Runbook — verify the Supabase-managed `auth.*` cascades
+
+The repository integration tests create only a **stub** `auth.users` table (`backend/internal/database/testsupport/auth_schema.go` — `id`, `email`, `last_sign_in_at` and nothing else). They therefore cannot cover Supabase's own `auth.*` children (`auth.identities`, `auth.sessions`, `auth.refresh_tokens`, `auth.mfa_factors`, …), whose foreign keys are managed by GoTrue migrations and can change across Supabase upgrades. Verifying those is a **manual** operator check; run this against the target database and confirm every row reports `c` (CASCADE):
+
+```sql
+SELECT c.conname,
+       c.conrelid::regclass AS child_table,
+       c.confdeltype        AS on_delete_action
+FROM pg_constraint AS c
+WHERE c.contype = 'f'
+  AND c.confrelid = 'auth.users'::regclass
+ORDER BY child_table, c.conname;
+```
+
+`confdeltype` is a single character: `c` = CASCADE, `n` = SET NULL, `d` = SET DEFAULT, `r` = RESTRICT, `a` = NO ACTION. Anything other than `c` on an `auth.*` child means a delete can fail or leave a row behind, and should be investigated before the next account deletion in production.
+
 ### Postgres upsert: prerequisite UNIQUE / EXCLUSION constraint
 
 `INSERT ... ON CONFLICT (cols) ...` requires the column set to be backed by a UNIQUE constraint, UNIQUE INDEX, or EXCLUSION constraint. Plain (non-unique) indexes and CHECK constraints do not satisfy the requirement — Postgres rejects the statement with SQLSTATE `42P10` "there is no unique or exclusion constraint matching the ON CONFLICT specification". This is checked at planning time, so the failure surfaces immediately, not on a colliding row.

--- a/docs/backend-db.md
+++ b/docs/backend-db.md
@@ -97,23 +97,23 @@ Measure before adding either: `EXPLAIN (ANALYZE, BUFFERS)` on the query plus `pg
 
 Deleting an account is a **single `DELETE` against `auth.users`**. Everything a learner owns — decks, cards, review history, FSRS scheduling state, preferences and role assignments — is removed by the database's own `ON DELETE CASCADE` foreign keys; there is no application-level multi-step delete to keep in sync. The isolation point in Go is `UserRepository.DeleteAuthUserTx` (`backend/internal/repository/user.go`), which issues that one statement inside the caller's transaction.
 
-The full set of foreign keys that participate, read from the migration files:
+Every foreign key in the schema, read from the migration files. All but two fire on an account delete — `user_roles.role_id` and `master_cards.master_cardgroup_id` hang off the `roles` / `master_cardgroups` catalog tables, which carry no user-referencing column, so nothing reaches them from an `auth.users` delete:
 
 | Child column | References | `ON DELETE` | Declared in |
 |---|---|---|---|
-| `public.users.id` | `auth.users(id)` | CASCADE | `20260430080000_initial_schema.up.sql:98` |
-| `user_roles.user_id` | `public.users(id)` | CASCADE | `20260430080000_initial_schema.up.sql:110` |
-| `user_roles.role_id` | `public.roles(id)` | CASCADE | `20260430080000_initial_schema.up.sql:111` |
-| `cardgroups.owner_id` | `public.users(id)` | CASCADE | `20260430080000_initial_schema.up.sql:120` |
-| `cards.cardgroup_id` | `public.cardgroups(id)` | CASCADE | `20260430080000_initial_schema.up.sql:134` |
-| `swipe_records.user_id` | `public.users(id)` | CASCADE | `20260430080000_initial_schema.up.sql:153` |
-| `swipe_records.card_id` | `public.cards(id)` | CASCADE | `20260430080000_initial_schema.up.sql:154` |
+| `public.users.id` | `auth.users(id)` | CASCADE | `20260430080000_initial_schema.up.sql` |
+| `user_roles.user_id` | `public.users(id)` | CASCADE | `20260430080000_initial_schema.up.sql` |
+| `user_roles.role_id` | `public.roles(id)` | CASCADE | `20260430080000_initial_schema.up.sql` |
+| `cardgroups.owner_id` | `public.users(id)` | CASCADE | `20260430080000_initial_schema.up.sql` |
+| `cards.cardgroup_id` | `public.cardgroups(id)` | CASCADE | `20260430080000_initial_schema.up.sql` |
+| `swipe_records.user_id` | `public.users(id)` | CASCADE | `20260430080000_initial_schema.up.sql` |
+| `swipe_records.card_id` | `public.cards(id)` | CASCADE | `20260430080000_initial_schema.up.sql` |
 | `swipe_records.cardgroup_id` | `public.cardgroups(id)` | CASCADE | `20260721000000_add_cardgroup_fk_to_swipe_records.up.sql` |
-| `user_card_fsrs.user_id` | `public.users(id)` | CASCADE | `20260430080000_initial_schema.up.sql:182` |
-| `user_card_fsrs.card_id` | `public.cards(id)` | CASCADE | `20260430080000_initial_schema.up.sql:183` |
-| `user_preferences.user_id` | `public.users(id)` | CASCADE | `20260430080000_initial_schema.up.sql:205` |
-| `user_preferences.last_viewed_cardgroup_id` | `public.cardgroups(id)` | **SET NULL** | `20260430080000_initial_schema.up.sql:207` |
-| `master_cards.master_cardgroup_id` | `public.master_cardgroups(id)` | CASCADE | `20260614000000_add_master_tables.up.sql:89` |
+| `user_card_fsrs.user_id` | `public.users(id)` | CASCADE | `20260430080000_initial_schema.up.sql` |
+| `user_card_fsrs.card_id` | `public.cards(id)` | CASCADE | `20260430080000_initial_schema.up.sql` |
+| `user_preferences.user_id` | `public.users(id)` | CASCADE | `20260430080000_initial_schema.up.sql` |
+| `user_preferences.last_viewed_cardgroup_id` | `public.cardgroups(id)` | **SET NULL** | `20260430080000_initial_schema.up.sql` |
+| `master_cards.master_cardgroup_id` | `public.master_cardgroups(id)` | CASCADE | `20260614000000_add_master_tables.up.sql` |
 
 Three properties of that table are load-bearing:
 
@@ -147,6 +147,8 @@ ORDER BY child_table, c.conname;
 ```
 
 `confdeltype` is a single character: `c` = CASCADE, `n` = SET NULL, `d` = SET DEFAULT, `r` = RESTRICT, `a` = NO ACTION. Anything other than `c` on an `auth.*` child means a delete can fail or leave a row behind, and should be investigated before the next account deletion in production.
+
+The query reports **direct** children of `auth.users` only. GoTrue tables that reach the user through another table — `auth.refresh_tokens` and `auth.mfa_amr_claims` via `auth.sessions`, `auth.mfa_challenges` via `auth.mfa_factors` — never appear in its output, so an all-`c` result is not on its own proof that the whole chain cascades. Re-run the query with `confrelid` set to each child table returned by the first pass to walk the next hop.
 
 ### Postgres upsert: prerequisite UNIQUE / EXCLUSION constraint
 


### PR DESCRIPTION
## Summary

The account-deletion contract — one `DELETE` against `auth.users`, everything else removed by foreign keys — lived only as a Go docblock on `UserRepository.DeleteAuthUserTx` and two GraphQL field descriptions. `docs/backend-db.md`, the document an operator reads to understand the schema, had no account-deletion section at all, so "what actually gets deleted, and can it leave orphans?" could only be answered by reading the migration files. This adds that section and points the Go docblock at it.

## Changes

### `docs/backend-db.md` — new `### Account deletion — what cascades`

Placed directly after `### Index strategy`, where the foreign-key and index discussion already lives.

- A 13-row foreign-key table covering every `REFERENCES` clause in the migration tree, including `swipe_records.cardgroup_id → public.cardgroups(id) ON DELETE CASCADE` from `20260721000000_add_cardgroup_fk_to_swipe_records.up.sql` (the key #1025 landed), so the table does not need a second edit.
- Three load-bearing properties called out below the table: the single `SET NULL` is `user_preferences.last_viewed_cardgroup_id` and no `RESTRICT`/`NO ACTION` key exists anywhere, so nothing can block a delete; `roles`, `ping_records` and `master_cardgroups` carry no user-referencing column, which is why published master decks survive the deletion of the admin who created them; every foreign key has a backing index, so a cascade never degrades to a sequential scan.
- A `#### The two delete paths` sub-table contrasting `userUsecase.DeleteMyAccount` and `adminUserUsecase.DeleteUser`. Both converge on `DeleteAuthUserTx` and reach an identical end state, share `guardNotLastAdmin`, and differ on exactly one thing: a missing `auth.users` row is idempotent success (`nil`) for self-delete and `ucerr.NewValidationError("id", "user not found")` — `BAD_USER_INPUT` on `id` — for admin-delete. The rationale for the asymmetry is stated rather than left implicit.
- A `#### Runbook` with a runnable `pg_constraint` query filtering `confrelid = 'auth.users'::regclass` and projecting `confdeltype`, plus the decode table (`c` = CASCADE, `n` = SET NULL, …). It exists because `backend/internal/database/testsupport/auth_schema.go` creates only a stub `auth.users`, so the repository integration tests cannot cover Supabase's GoTrue-managed `auth.*` children.
- Symbols and file paths are named without line numbers, per [`docs/doc-organization.md` § "Describe code locations by structure, not line number"](https://github.com/yasuflatland-lf/flamingo-armond/blob/main/docs/doc-organization.md). The issue body's citations had already drifted (`DeleteAuthUser` → `DeleteAuthUserTx`, every usecase line number off by 30-60).

### `backend/internal/repository/user.go`

- Four comment lines inside the `DeleteAuthUserTx` docblock pointing at `docs/backend-db.md § "Account deletion — what cascades"` as the canonical write-up. The existing docblock text is unchanged; no signature or behaviour change.

### Review fixes

Second commit, applying confirmed review findings against the first:

- **Line-number citations dropped from the foreign-key table.** Twelve rows cited `<migration>.sql:<N>`, which `docs/doc-organization.md` forbids in committed docs. Two of them (`:205`, `:207`) pointed at bare `REFERENCES …` continuation lines that do not name the child column — exactly the silent-mislanding the rule guards against. Removing them also fixes the intra-table inconsistency where the `swipe_records.cardgroup_id` row was the only one without a suffix.
- **Table caption no longer over-claims.** It read "The full set of foreign keys that participate", but the table is the complete schema FK set: `user_roles.role_id` and `master_cards.master_cardgroup_id` hang off the `roles` / `master_cardgroups` catalog tables and are unreachable from an `auth.users` delete. The caption now says so up front instead of contradicting itself sixteen lines later.
- **Runbook coverage limit stated.** The query returns direct children of `auth.users` only, but the paragraph above it listed `auth.refresh_tokens` among the tables it verifies. Confirmed against the GoTrue migrations that `auth.refresh_tokens` reaches the user through `auth.sessions` (its `user_id` column carries no foreign key at all since `20221114143410_remove_parent_foreign_key_refresh_tokens`), as do `auth.mfa_amr_claims` and `auth.mfa_challenges` — so an all-`c` first pass was a success-shaped answer for a chain it never walked. A closing paragraph names the three second-hop tables and tells the operator to re-run with `confrelid` set to each child returned.

## Verification

Read the foreign-key table against `backend/internal/database/migrations/*.up.sql`: `grep -n 'REFERENCES' backend/internal/database/migrations/*.up.sql` returns exactly 13 keys, matching the 13 table rows one-for-one. The `pg_constraint` query is copy-pasteable as written against any Supabase database. The Go change is comment-only — `git diff` on `user.go` shows four `//` lines and nothing else.

## Test plan

- [ ] `go build ./...` — Success
- [ ] `go vet ./...` — no issues found
- [ ] `go test ./...` — 2347 tests passed across 26 packages, 0 FAIL
- [ ] `go tool go-arch-lint check` — OK, no warnings found

## Notes

Production diff is 4 lines (comment-only, `backend/internal/repository/user.go`), far under the 800-line ceiling. The issue's `Dependencies` note ("depends on #1025, land it first") is already satisfied on `main` — PR #1067 merged the `swipe_records.cardgroup_id` migration — so its row is written against the post-#1025 state.

Closes #1041
