### PR TITLE
feat(backend): gate rescue early-serve on 24h since the last review

### DIFF
--- a/.claude/rules/ddd-patterns.md
+++ b/.claude/rules/ddd-patterns.md
@@ -167,7 +167,9 @@ interleaved with 4 prior-day review slots (20%). Review slots prioritise rescue
 cards whose latest rating was Again or whose stability is below
 `LearnedStabilityDays`; other reviews act as filler. Rescue is day-granular up
 to the exclusive JST learn-day end, while filler must be due now, and both
-exclude cards swiped today via the JST start-of-day cutoff. SQL `random()`
+exclude cards swiped today via the JST start-of-day cutoff; a rescue card is
+additionally served early only once a whole day has elapsed since its last
+review, because a sub-24h repeat earns zero FSRS scheduling credit. SQL `random()`
 decides *which* rows enter each window (selection); the injected `*rand.Rand` in
 `OrderingPolicy.Apply` decides their arrangement (deterministic in tests) and
 interleaves at the caller-supplied `domain.NewCardRatio` (`domain.DefaultNewCardRatio`

--- a/backend/graph/resolver/card_resolvers_test.go
+++ b/backend/graph/resolver/card_resolvers_test.go
@@ -44,7 +44,7 @@ type cardMockRepo struct {
 func (m *cardMockRepo) FindByID(_ context.Context, _ string) (*domain.Card, error) {
 	return m.findByIDResult, m.findByIDErr
 }
-func (m *cardMockRepo) FindDueCardsForUser(_ context.Context, _ string, _ string, _ time.Time, _ time.Time, _ time.Time, limit int) ([]domain.DueCard, error) {
+func (m *cardMockRepo) FindDueCardsForUser(_ context.Context, _ string, _ string, _ time.Time, _ time.Time, _ time.Time, _ time.Time, limit int) ([]domain.DueCard, error) {
 	m.findDueLimit = limit
 	return m.findDueRows, m.findDueErr
 }

--- a/backend/internal/domain/learn_day.go
+++ b/backend/internal/domain/learn_day.go
@@ -24,5 +24,22 @@ func EndOfLearnDay(now time.Time) time.Time {
 	return StartOfLearnDay(now).Add(24 * time.Hour)
 }
 
+// rescueMinElapsed is the minimum wall-clock time that must pass after a review
+// before the same card may be served early through the rescue window. The FSRS
+// memory model derives elapsed days as floor(hours/24), so a repeat inside the
+// same 24 hours counts as zero elapsed days: retrievability is 1 and the
+// stability growth factor exp((1-r)*W10)-1 is exactly 0. Such a review earns no
+// scheduling credit at all, so serving the card early only burns a rescue slot
+// while leaving the card below the learned threshold.
+const rescueMinElapsed = 24 * time.Hour
+
+// RescueReviewedBefore returns the latest last_review instant a card may carry
+// and still be served early through the rescue window: exactly rescueMinElapsed
+// before now. The repository compares with `<=`, so a card last reviewed exactly
+// 24 hours ago is eligible while one reviewed 23 hours ago is not.
+func RescueReviewedBefore(now time.Time) time.Time {
+	return now.Add(-rescueMinElapsed)
+}
+
 // LearnDayKey returns the canonical JST learn-day key (YYYY-MM-DD) for t.
 func LearnDayKey(t time.Time) string { return StartOfLearnDay(t).Format(time.DateOnly) }

--- a/backend/internal/domain/learn_day_test.go
+++ b/backend/internal/domain/learn_day_test.go
@@ -77,3 +77,30 @@ func TestEndOfLearnDay(t *testing.T) {
 		})
 	}
 }
+
+// TestRescueReviewedBefore pins the rescue window's minimum-elapsed floor at
+// exactly 24 hours before now, and pins its relation to the day boundaries: the
+// floor is never later than the JST start-of-day, so it is always the tighter of
+// the two last_review bounds the rescue predicate applies.
+func TestRescueReviewedBefore(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		now  time.Time
+	}{
+		{name: "JST noon", now: time.Date(2026, 6, 5, 3, 0, 0, 0, time.UTC)},
+		{name: "exactly JST midnight", now: time.Date(2026, 6, 5, 15, 0, 0, 0, time.UTC)},
+		{name: "just before JST midnight", now: time.Date(2026, 6, 5, 14, 59, 59, 0, time.UTC)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := RescueReviewedBefore(tc.now)
+			require.True(t, got.Equal(tc.now.Add(-24*time.Hour)),
+				"got %v, want exactly 24h before %v", got, tc.now)
+			require.False(t, got.After(StartOfLearnDay(tc.now)),
+				"the rescue floor must never be later than the JST start-of-day")
+		})
+	}
+}

--- a/backend/internal/repository/card.go
+++ b/backend/internal/repository/card.go
@@ -91,7 +91,9 @@ type CardPageRepository interface {
 type CardSessionRepository interface {
 	// FindDueCardsForUser returns rescue reviews due before rescueDueBefore,
 	// filler reviews due by now, and never-seen cards in independent windows.
-	FindDueCardsForUser(ctx context.Context, userID, cardgroupID string, now, reviewedBefore, rescueDueBefore time.Time, limit int) ([]domain.DueCard, error)
+	// A rescue review is served early only once its last_review is at or before
+	// rescueReviewedBefore, the caller's minimum-elapsed floor.
+	FindDueCardsForUser(ctx context.Context, userID, cardgroupID string, now, reviewedBefore, rescueDueBefore, rescueReviewedBefore time.Time, limit int) ([]domain.DueCard, error)
 	// FindPracticeCardsForUser returns the FSRS-safe practice pool: cards the
 	// user already reviewed at or after reviewedAfter (the start-of-day cutoff).
 	// This is the inverse window of FindDueCardsForUser's review window — it

--- a/backend/internal/repository/card_due.go
+++ b/backend/internal/repository/card_due.go
@@ -11,8 +11,8 @@ import (
 	"backend/internal/domain"
 )
 
-func (r *cardRepo) FindDueCardsForUser(ctx context.Context, userID, cardgroupID string, now, reviewedBefore, rescueDueBefore time.Time, limit int) ([]domain.DueCard, error) {
-	return findDueCardsOn(r.db.WithContext(ctx), userID, cardgroupID, now, reviewedBefore, rescueDueBefore, limit)
+func (r *cardRepo) FindDueCardsForUser(ctx context.Context, userID, cardgroupID string, now, reviewedBefore, rescueDueBefore, rescueReviewedBefore time.Time, limit int) ([]domain.DueCard, error) {
+	return findDueCardsOn(r.db.WithContext(ctx), userID, cardgroupID, now, reviewedBefore, rescueDueBefore, rescueReviewedBefore, limit)
 }
 
 func (r *cardRepo) FindPracticeCardsForUser(ctx context.Context, userID, cardgroupID string, reviewedAfter time.Time, limit int) ([]domain.DueCard, error) {
@@ -36,7 +36,7 @@ type dueCardRow struct {
 	Due         *time.Time `gorm:"column:due"`
 }
 
-// Rescue window:   due IS NOT NULL AND due < learn-day end AND last_review < learn-day start.
+// Rescue window:   due IS NOT NULL AND due < learn-day end AND last_review < learn-day start AND last_review <= now-24h.
 // Filler window:   due IS NOT NULL AND due <= now AND last_review < learn-day start.
 // Practice window: last_review >= boundary; due not consulted.
 // Both usecase methods (NextDueCards and PracticeTodaysCards) derive the
@@ -56,7 +56,11 @@ type dueCardRow struct {
 // caller's JST start-of-today), its latest rating was Again or its stability is
 // below domain.LearnedStabilityDays, and its due is before rescueDueBefore (the
 // exclusive JST end-of-today). The day-granular due bound deliberately surfaces
-// rescue cards due later today. random() varies selection within the band.
+// rescue cards due later today. The early serve is floored by
+// rescueReviewedBefore (domain.RescueReviewedBefore, 24 hours before now):
+// FSRS counts elapsed days as floor(hours/24), so a repeat inside the same 24
+// hours earns a stability growth factor of exactly zero and the rescue slot is
+// wasted. random() varies selection within the band.
 //
 // Filler window: the same last-review guard excludes cards swiped today, but
 // only non-rescue cards whose due has arrived (due <= now) qualify. Its
@@ -66,19 +70,23 @@ type dueCardRow struct {
 // New window: no FSRS row yet; random() samples uniformly across the whole
 // unseen pool so consecutive sessions surface different cards instead of
 // walking the deterministic created_at/position (document) order.
-func findDueCardsOn(db *gorm.DB, userID, cardgroupID string, now, reviewedBefore, rescueDueBefore time.Time, limit int) ([]domain.DueCard, error) {
+func findDueCardsOn(db *gorm.DB, userID, cardgroupID string, now, reviewedBefore, rescueDueBefore, rescueReviewedBefore time.Time, limit int) ([]domain.DueCard, error) {
 	userID = coalesceUserIDForJoin(userID)
 	if limit <= 0 {
 		return []domain.DueCard{}, nil
 	}
 
+	// Only domain.RatingAgain and domain.LearnedStabilityDays are formatted into
+	// the predicate: both are compile-time constants. Every caller-supplied
+	// instant — including the rescueReviewedBefore floor — travels as a bound
+	// query argument.
 	rescueWhere := fmt.Sprintf(
-		"cards.cardgroup_id = ? AND ucs.due IS NOT NULL AND ucs.due < ? AND ucs.last_review < ? AND (ucs.last_rating = %d OR ucs.stability < %g)",
+		"cards.cardgroup_id = ? AND ucs.due IS NOT NULL AND ucs.due < ? AND ucs.last_review < ? AND ucs.last_review <= ? AND (ucs.last_rating = %d OR ucs.stability < %g)",
 		domain.RatingAgain, domain.LearnedStabilityDays,
 	)
 	rescueRows, err := dueRowsOn(db, userID,
 		rescueWhere,
-		[]any{cardgroupID, rescueDueBefore, reviewedBefore},
+		[]any{cardgroupID, rescueDueBefore, reviewedBefore, rescueReviewedBefore},
 		"random()",
 		limit,
 		"repository: card: find due cards")

--- a/backend/internal/repository/card_test.go
+++ b/backend/internal/repository/card_test.go
@@ -1352,10 +1352,19 @@ func TestCardRepository_FindPracticeCards_BoundaryComplementarity(t *testing.T) 
 		return ucsRepo.UpsertTx(ctx, tx, today)
 	}))
 
+	// This test isolates the shared boundary, so the rescue window's
+	// minimum-elapsed floor is passed wide open and every fixture clears it. The
+	// floor is a strictly tighter bound than the boundary used here, so leaving
+	// it at its real value would keep reviewedAtBoundary out of the learn window
+	// even under a mutation of the strict `<`, silently killing the documented
+	// mutation proof; the floor is pinned on its own by
+	// TestCardRepository_FindDueCards_RescueRequiresWholeDaySinceLastReview.
+	openRescueFloor := now.Add(time.Second)
+
 	// Learn window: cards reviewed strictly before the boundary, plus the
 	// never-reviewed card via the new-card window. reviewedAtBoundary and
 	// reviewedToday are excluded (learn predicate is last_review < boundary).
-	learn, err := repo.FindDueCardsForUser(ctx, ownerID, string(cg.ID), now, boundary, domain.EndOfLearnDay(now), domain.RescueReviewedBefore(now), 10)
+	learn, err := repo.FindDueCardsForUser(ctx, ownerID, string(cg.ID), now, boundary, domain.EndOfLearnDay(now), openRescueFloor, 10)
 	require.NoError(t, err)
 	require.ElementsMatch(t, []string{reviewedYesterday.ID, neverReviewed.ID}, repoCardIDs(learn),
 		"learn window holds cards reviewed before the boundary plus never-reviewed new cards")

--- a/backend/internal/repository/card_test.go
+++ b/backend/internal/repository/card_test.go
@@ -136,7 +136,7 @@ func TestCardRepository_FindDueCards_UsesPerUserFSRSRows(t *testing.T) {
 		return ucsRepo.UpsertTx(ctx, tx, state)
 	}))
 
-	due, err := repo.FindDueCardsForUser(ctx, ownerID, string(cg.ID), now, now, domain.EndOfLearnDay(now), 10)
+	due, err := repo.FindDueCardsForUser(ctx, ownerID, string(cg.ID), now, now, domain.EndOfLearnDay(now), domain.RescueReviewedBefore(now), 10)
 	require.NoError(t, err)
 	require.Equal(t, []string{dueCard.ID}, repoCardIDs(due))
 }
@@ -171,7 +171,7 @@ func TestCardRepository_FindDueCards_IgnoresOtherUsersFSRSRows(t *testing.T) {
 
 	// ownerID has no FSRS row for card → the JOIN for ownerID returns NULL →
 	// card surfaces through the new-card window.
-	got, err := repo.FindDueCardsForUser(ctx, ownerID, string(cg.ID), now, now, domain.EndOfLearnDay(now), 10)
+	got, err := repo.FindDueCardsForUser(ctx, ownerID, string(cg.ID), now, now, domain.EndOfLearnDay(now), domain.RescueReviewedBefore(now), 10)
 	require.NoError(t, err)
 	require.Equal(t, []string{card.ID}, repoCardIDs(got),
 		"otherUser's future-due row must not hide the card from the calling user's new-card window")
@@ -209,9 +209,12 @@ func TestCardRepository_FindDueCards_ScopedAndLimited(t *testing.T) {
 	repo := repository.NewCardRepository(testDB.GORM)
 	ucsRepo := repository.NewUserCardFSRSRepository(testDB.GORM)
 	now := time.Now().UTC().Truncate(time.Microsecond)
-	// Fixtures carry LastReview == now (set by NewUserCardFSRSForNewCard); a
-	// cutoff strictly after now keeps every due review inside the window.
+	// Fixtures are stamped with a LastReview well beyond the rescue window's
+	// 24-hour minimum-elapsed floor, so the band assertions below exercise the
+	// due/limit predicates rather than the floor. A cutoff strictly after now
+	// keeps every due review inside the reviewedBefore window.
 	reviewedBefore := now.Add(time.Second)
+	lastReview := now.Add(-25 * time.Hour)
 
 	dueNow := newCard(cg1.ID, "due-now", "back")
 	laterDue := newCard(cg1.ID, "later-due", "back")
@@ -231,6 +234,7 @@ func TestCardRepository_FindDueCards_ScopedAndLimited(t *testing.T) {
 		} {
 			state := domain.NewUserCardFSRSForNewCard(domain.UserID(ownerID), card.ID, now)
 			state.State.Due = due
+			state.State.LastReview = lastReview
 			if card == future {
 				state.State.Stability = domain.LearnedStabilityDays
 				state.State.LastRating = domain.RatingGood
@@ -244,7 +248,7 @@ func TestCardRepository_FindDueCards_ScopedAndLimited(t *testing.T) {
 
 	// Selection within the review phase is random() now, so a small limit picks
 	// some two of the three due review cards (never future / other-group).
-	got, err := repo.FindDueCardsForUser(ctx, ownerID, string(cg1.ID), now, reviewedBefore, domain.EndOfLearnDay(now), 2)
+	got, err := repo.FindDueCardsForUser(ctx, ownerID, string(cg1.ID), now, reviewedBefore, domain.EndOfLearnDay(now), domain.RescueReviewedBefore(now), 2)
 	require.NoError(t, err)
 	require.Len(t, got, 2)
 	due3 := map[string]bool{earlierDue.ID: true, laterDue.ID: true, dueNow.ID: true}
@@ -252,12 +256,12 @@ func TestCardRepository_FindDueCards_ScopedAndLimited(t *testing.T) {
 		require.True(t, due3[id], "limit=2 must select from the due review set, got %q", id)
 	}
 
-	got, err = repo.FindDueCardsForUser(ctx, ownerID, string(cg1.ID), now, reviewedBefore, domain.EndOfLearnDay(now), 10)
+	got, err = repo.FindDueCardsForUser(ctx, ownerID, string(cg1.ID), now, reviewedBefore, domain.EndOfLearnDay(now), domain.RescueReviewedBefore(now), 10)
 	require.NoError(t, err)
 	require.ElementsMatch(t, []string{earlierDue.ID, laterDue.ID, dueNow.ID}, repoCardIDs(got))
 	require.NotContains(t, repoCardIDs(got), otherGroup.ID, "FindDueCards must not leak cards from another cardgroup")
 
-	empty, err := repo.FindDueCardsForUser(ctx, ownerID, string(cg1.ID), now, reviewedBefore, domain.EndOfLearnDay(now), 0)
+	empty, err := repo.FindDueCardsForUser(ctx, ownerID, string(cg1.ID), now, reviewedBefore, domain.EndOfLearnDay(now), domain.RescueReviewedBefore(now), 0)
 	require.NoError(t, err)
 	require.Empty(t, empty)
 }
@@ -276,7 +280,7 @@ func TestCardRepository_FindDueCards_NoFSRSRow(t *testing.T) {
 	card := newCard(cg.ID, "no-fsrs", "back")
 	require.NoError(t, repo.Create(ctx, card))
 
-	got, err := repo.FindDueCardsForUser(ctx, ownerID, string(cg.ID), now, now, domain.EndOfLearnDay(now), 10)
+	got, err := repo.FindDueCardsForUser(ctx, ownerID, string(cg.ID), now, now, domain.EndOfLearnDay(now), domain.RescueReviewedBefore(now), 10)
 	require.NoError(t, err)
 	require.Len(t, got, 1)
 	require.Equal(t, card.ID, got[0].Card.ID)
@@ -317,6 +321,9 @@ func TestCardRepository_FindDueCards_FSRSStateMapping(t *testing.T) {
 			ucs := domain.NewUserCardFSRSForNewCard(domain.UserID(ownerID), cards[i].ID, now)
 			ucs.State.Phase = tc.state
 			ucs.State.Due = now.Add(-time.Minute) // ensure it is due
+			// Default stability (2.5) puts these rows in the rescue band, so the
+			// last review must clear the 24-hour minimum-elapsed floor.
+			ucs.State.LastReview = now.Add(-25 * time.Hour)
 			if err := ucsRepo.UpsertTx(ctx, tx, ucs); err != nil {
 				return err
 			}
@@ -324,7 +331,7 @@ func TestCardRepository_FindDueCards_FSRSStateMapping(t *testing.T) {
 		return nil
 	}))
 
-	got, err := repo.FindDueCardsForUser(ctx, ownerID, string(cg.ID), now, now.Add(time.Second), domain.EndOfLearnDay(now), 10)
+	got, err := repo.FindDueCardsForUser(ctx, ownerID, string(cg.ID), now, now.Add(time.Second), domain.EndOfLearnDay(now), domain.RescueReviewedBefore(now), 10)
 	require.NoError(t, err)
 	require.Len(t, got, len(cases))
 
@@ -354,18 +361,20 @@ func TestCardRepository_FindDueCards_InvalidState(t *testing.T) {
 	require.NoError(t, repo.Create(ctx, card))
 
 	// Insert a user_card_fsrs row directly with an invalid state value (99) so
-	// that the IsValid gate in findDueCardsOn is exercised.
+	// that the IsValid gate in findDueCardsOn is exercised. stability 0 puts the
+	// row in the rescue band, so last_review is stamped beyond the 24-hour
+	// minimum-elapsed floor to keep the row inside the rescue window.
 	sqlDB, err := testDB.GORM.DB()
 	require.NoError(t, err)
 	_, err = sqlDB.ExecContext(ctx,
 		`INSERT INTO user_card_fsrs
 		 (user_id, card_id, state, due, stability, difficulty, reps, lapses, last_review, elapsed_days, scheduled_days, created_at, updated_at)
-		 VALUES ($1, $2, $3, $4, 0, 5.0, 0, 0, $4, 0, 0, now(), now())`,
-		ownerID, card.ID, 99, now.Add(-time.Minute),
+		 VALUES ($1, $2, $3, $4, 0, 5.0, 0, 0, $5, 0, 0, now(), now())`,
+		ownerID, card.ID, 99, now.Add(-time.Minute), now.Add(-25*time.Hour),
 	)
 	require.NoError(t, err)
 
-	_, err = repo.FindDueCardsForUser(ctx, ownerID, string(cg.ID), now, now.Add(time.Second), domain.EndOfLearnDay(now), 10)
+	_, err = repo.FindDueCardsForUser(ctx, ownerID, string(cg.ID), now, now.Add(time.Second), domain.EndOfLearnDay(now), domain.RescueReviewedBefore(now), 10)
 	require.ErrorContains(t, err, "repository: card: invalid FSRSPhase 99")
 }
 
@@ -891,17 +900,19 @@ func TestCardRepository_FindDueCards_ReviewRowsPrecedeNewRows(t *testing.T) {
 	newLowPos.Position = 0
 	require.NoError(t, repo.Create(ctx, newLowPos))
 
-	// Upsert the FSRS row for reviewEarly so its effective due is now-2h.
-	// NewUserCardFSRSForNewCard sets LastReview == now; a cutoff strictly after
-	// now keeps the review row inside the window.
+	// Upsert the FSRS row for reviewEarly so its effective due is now-2h. Its
+	// default stability puts it in the rescue band, so LastReview is stamped 25h
+	// back to clear the rescue window's 24-hour minimum-elapsed floor; a cutoff
+	// strictly after now keeps the review row inside the reviewedBefore window.
 	require.NoError(t, testDB.GORM.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		state := domain.NewUserCardFSRSForNewCard(domain.UserID(ownerID), reviewEarly.ID, now)
 		state.State.Due = now.Add(-2 * time.Hour)
+		state.State.LastReview = now.Add(-25 * time.Hour)
 		state.State.Reps = 1
 		return ucsRepo.UpsertTx(ctx, tx, state)
 	}))
 
-	got, err := repo.FindDueCardsForUser(ctx, ownerID, string(cg.ID), now, now.Add(time.Second), domain.EndOfLearnDay(now), 10)
+	got, err := repo.FindDueCardsForUser(ctx, ownerID, string(cg.ID), now, now.Add(time.Second), domain.EndOfLearnDay(now), domain.RescueReviewedBefore(now), 10)
 	require.NoError(t, err)
 	require.Equal(t,
 		[]string{reviewEarly.ID, newLowPos.ID},
@@ -978,6 +989,7 @@ func TestCardRepository_FindDueCards_ReviewsNotStarvedByNewBacklog(t *testing.T)
 		} {
 			state := domain.NewUserCardFSRSForNewCard(domain.UserID(ownerID), card.ID, now)
 			state.State.Due = due
+			state.State.LastReview = now.Add(-25 * time.Hour)
 			if err := ucsRepo.UpsertTx(ctx, tx, state); err != nil {
 				return err
 			}
@@ -986,10 +998,11 @@ func TestCardRepository_FindDueCards_ReviewsNotStarvedByNewBacklog(t *testing.T)
 	}))
 
 	// limit=2 is smaller than the new-card backlog. Reviews and new cards use
-	// separate LIMIT windows, so both due reviews still surface.
-	// NewUserCardFSRSForNewCard sets LastReview == now; a cutoff strictly after
-	// now keeps both due reviews inside the window.
-	got, err := repo.FindDueCardsForUser(ctx, ownerID, string(cg.ID), now, now.Add(time.Second), domain.EndOfLearnDay(now), 2)
+	// separate LIMIT windows, so both due reviews still surface. Both review
+	// rows sit in the rescue band, so their LastReview is stamped 25h back to
+	// clear the 24-hour minimum-elapsed floor; a cutoff strictly after now keeps
+	// them inside the reviewedBefore window.
+	got, err := repo.FindDueCardsForUser(ctx, ownerID, string(cg.ID), now, now.Add(time.Second), domain.EndOfLearnDay(now), domain.RescueReviewedBefore(now), 2)
 	require.NoError(t, err)
 	ids := repoCardIDs(got)
 
@@ -1048,7 +1061,14 @@ func TestCardRepository_FindDueCards_ExcludesCardsReviewedToday(t *testing.T) {
 		return ucsRepo.UpsertTx(ctx, tx, boundary)
 	}))
 
-	got, err := repo.FindDueCardsForUser(ctx, ownerID, string(cg.ID), now, startOfToday, domain.EndOfLearnDay(now), 10)
+	// This test isolates the reviewedBefore cutoff, so the rescue window's
+	// minimum-elapsed floor is passed wide open and every fixture clears it. The
+	// floor is a strictly tighter bound than the JST start-of-day in production,
+	// so leaving it at its real value would mask a mutation of the strict `<`
+	// here; it is pinned on its own by
+	// TestCardRepository_FindDueCards_RescueRequiresWholeDaySinceLastReview.
+	openRescueFloor := now.Add(time.Second)
+	got, err := repo.FindDueCardsForUser(ctx, ownerID, string(cg.ID), now, startOfToday, domain.EndOfLearnDay(now), openRescueFloor, 10)
 	require.NoError(t, err)
 	require.Equal(t, []string{reviewedYesterday.ID}, repoCardIDs(got),
 		"only cards reviewed strictly before the boundary enter the review window")
@@ -1067,10 +1087,14 @@ func TestCardRepository_FindDueCards_RescueOutranksFiller(t *testing.T) {
 	now := time.Date(2026, 7, 19, 3, 0, 0, 0, time.UTC)
 	start := domain.StartOfLearnDay(now)
 
+	// Every fixture was last reviewed more than a whole day ago, so the rescue
+	// window's minimum-elapsed floor admits the rescue-band rows and the band
+	// ordering is the only thing under test.
+	lastReview := now.Add(-25 * time.Hour)
 	mk := func(front string, stability float64, rating domain.Rating) *domain.Card {
 		c := newCard(cg.ID, front, "back")
 		require.NoError(t, repo.Create(ctx, c))
-		upsertDueCardState(t, ctx, ucsRepo, ownerID, c, now, now.Add(-time.Hour), start.Add(-time.Hour), stability, rating)
+		upsertDueCardState(t, ctx, ucsRepo, ownerID, c, now, now.Add(-time.Hour), lastReview, stability, rating)
 		return c
 	}
 	rescueSet := map[string]bool{}
@@ -1084,7 +1108,7 @@ func TestCardRepository_FindDueCards_RescueOutranksFiller(t *testing.T) {
 		fillerSet[card.ID] = true
 	}
 
-	got, err := repo.FindDueCardsForUser(ctx, ownerID, string(cg.ID), now, start, domain.EndOfLearnDay(now), 2)
+	got, err := repo.FindDueCardsForUser(ctx, ownerID, string(cg.ID), now, start, domain.EndOfLearnDay(now), domain.RescueReviewedBefore(now), 2)
 	require.NoError(t, err)
 	require.Len(t, got, 4)
 	for i, card := range got[:2] {
@@ -1111,7 +1135,7 @@ func TestCardRepository_FindDueCards_NullLastRatingFallsIntoFiller(t *testing.T)
 	require.NoError(t, repo.Create(ctx, card))
 	upsertDueCardState(t, ctx, ucsRepo, ownerID, card, now, now.Add(-time.Hour), start.Add(-time.Hour), domain.LearnedStabilityDays, 0)
 
-	got, err := repo.FindDueCardsForUser(ctx, ownerID, string(cg.ID), now, start, domain.EndOfLearnDay(now), 10)
+	got, err := repo.FindDueCardsForUser(ctx, ownerID, string(cg.ID), now, start, domain.EndOfLearnDay(now), domain.RescueReviewedBefore(now), 10)
 	require.NoError(t, err)
 	require.Equal(t, []string{card.ID}, repoCardIDs(got))
 	require.False(t, got[0].Rescue, "NULL last_rating with learned stability belongs to filler")
@@ -1133,11 +1157,14 @@ func TestCardRepository_FindDueCards_StabilityBoundary(t *testing.T) {
 	require.NoError(t, repo.Create(ctx, below))
 	require.NoError(t, repo.Create(ctx, nullBelow))
 	require.NoError(t, repo.Create(ctx, at))
-	upsertDueCardState(t, ctx, ucsRepo, ownerID, below, now, now.Add(-time.Hour), start.Add(-time.Hour), 6.9, domain.RatingGood)
-	upsertDueCardState(t, ctx, ucsRepo, ownerID, nullBelow, now, now.Add(-time.Hour), start.Add(-time.Hour), 6.9, 0)
-	upsertDueCardState(t, ctx, ucsRepo, ownerID, at, now, now.Add(-time.Hour), start.Add(-time.Hour), 7.0, domain.RatingGood)
+	// More than a whole day since the last review, so the rescue rows clear the
+	// minimum-elapsed floor and stability alone decides the band.
+	lastReview := now.Add(-25 * time.Hour)
+	upsertDueCardState(t, ctx, ucsRepo, ownerID, below, now, now.Add(-time.Hour), lastReview, 6.9, domain.RatingGood)
+	upsertDueCardState(t, ctx, ucsRepo, ownerID, nullBelow, now, now.Add(-time.Hour), lastReview, 6.9, 0)
+	upsertDueCardState(t, ctx, ucsRepo, ownerID, at, now, now.Add(-time.Hour), lastReview, 7.0, domain.RatingGood)
 
-	got, err := repo.FindDueCardsForUser(ctx, ownerID, string(cg.ID), now, start, domain.EndOfLearnDay(now), 10)
+	got, err := repo.FindDueCardsForUser(ctx, ownerID, string(cg.ID), now, start, domain.EndOfLearnDay(now), domain.RescueReviewedBefore(now), 10)
 	require.NoError(t, err)
 	require.ElementsMatch(t, []string{below.ID, nullBelow.ID, at.ID}, repoCardIDs(got))
 	byID := make(map[string]domain.DueCard, len(got))
@@ -1169,16 +1196,77 @@ func TestCardRepository_FindDueCards_RescueUsesJSTDayEnd(t *testing.T) {
 	for _, card := range []*domain.Card{rescueToday, fillerToday, atBoundary} {
 		require.NoError(t, repo.Create(ctx, card))
 	}
-	lastReview := start.Add(-time.Hour)
+	// More than a whole day since the last review, so the rescue rows clear the
+	// minimum-elapsed floor and the due cutoff alone decides inclusion.
+	lastReview := now.Add(-25 * time.Hour)
 	upsertDueCardState(t, ctx, ucsRepo, ownerID, rescueToday, now, dueAt23JST, lastReview, 20, domain.RatingAgain)
 	upsertDueCardState(t, ctx, ucsRepo, ownerID, fillerToday, now, dueAt23JST, lastReview, 20, domain.RatingGood)
 	upsertDueCardState(t, ctx, ucsRepo, ownerID, atBoundary, now, end, lastReview, 20, domain.RatingAgain)
 
-	got, err := repo.FindDueCardsForUser(ctx, ownerID, string(cg.ID), now, start, end, 10)
+	got, err := repo.FindDueCardsForUser(ctx, ownerID, string(cg.ID), now, start, end, domain.RescueReviewedBefore(now), 10)
 	require.NoError(t, err)
 	require.Equal(t, []string{rescueToday.ID}, repoCardIDs(got),
 		"rescue due later today is included; filler due later today and rescue due exactly at day end are excluded")
 	require.True(t, got[0].Rescue)
+}
+
+// TestCardRepository_FindDueCards_RescueRequiresWholeDaySinceLastReview pins the
+// rescue window's minimum-elapsed floor. FSRS derives elapsed days as
+// floor(hours/24), so a repeat inside the same 24 hours yields a stability
+// growth factor of exactly zero: serving such a card early burns a rescue slot
+// for no scheduling credit. The fixtures reproduce the motivating case — a card
+// failed at 23:00 JST and revisited at 09:00 JST the next morning is a new JST
+// learn day (so the reviewedBefore cutoff admits it) yet only 10 hours have
+// elapsed.
+//
+// Mutation-proof: flip the new `ucs.last_review <= ?` bound to `<` in
+// card_due.go and exactlyOneDay vanishes from the result; drop the bound
+// entirely and sameNight appears.
+func TestCardRepository_FindDueCards_RescueRequiresWholeDaySinceLastReview(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	ownerID := insertAuthUser(t, ctx)
+	cg := insertCardgroup(t, ctx, ownerID)
+	repo := repository.NewCardRepository(testDB.GORM)
+	ucsRepo := repository.NewUserCardFSRSRepository(testDB.GORM)
+	// 2026-07-19 09:00 JST. The JST learn day started at 2026-07-18T15:00Z, so
+	// last_review values between 2026-07-18T00:00Z (the 24h floor) and that
+	// instant are "yesterday" for the day cutoff but under a day of elapsed time.
+	now := time.Date(2026, 7, 19, 0, 0, 0, 0, time.UTC)
+	start := domain.StartOfLearnDay(now)
+	end := domain.EndOfLearnDay(now)
+	floor := domain.RescueReviewedBefore(now)
+	require.True(t, floor.Before(start), "the 24h floor is the tighter of the two last_review bounds")
+
+	sameNight := newCard(cg.ID, "failed-at-23-jst", "back")
+	exactlyOneDay := newCard(cg.ID, "reviewed-exactly-24h-ago", "back")
+	fullDayElapsed := newCard(cg.ID, "reviewed-25h-ago", "back")
+	for _, card := range []*domain.Card{sameNight, exactlyOneDay, fullDayElapsed} {
+		require.NoError(t, repo.Create(ctx, card))
+	}
+	// All three are rescue-band rows (last rating Again) whose due has arrived.
+	due := now.Add(-time.Hour)
+	upsertDueCardState(t, ctx, ucsRepo, ownerID, sameNight, now, due, now.Add(-10*time.Hour), 20, domain.RatingAgain)
+	upsertDueCardState(t, ctx, ucsRepo, ownerID, exactlyOneDay, now, due, floor, 20, domain.RatingAgain)
+	upsertDueCardState(t, ctx, ucsRepo, ownerID, fullDayElapsed, now, due, now.Add(-25*time.Hour), 20, domain.RatingAgain)
+
+	got, err := repo.FindDueCardsForUser(ctx, ownerID, string(cg.ID), now, start, end, floor, 10)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{exactlyOneDay.ID, fullDayElapsed.ID}, repoCardIDs(got),
+		"a rescue card is served early only once a whole day has passed since its last review")
+	require.NotContains(t, repoCardIDs(got), sameNight.ID,
+		"a card reviewed 10 hours ago earns zero FSRS credit and must not take a rescue slot")
+
+	// The excluded row must not leak into the filler or new window either: the
+	// filler predicate is the inverse band and the new window requires a NULL
+	// due, so the three windows stay pairwise disjoint under the narrowed rescue
+	// predicate and the row simply has no window today.
+	seen := map[string]bool{}
+	for _, dueCard := range got {
+		require.False(t, seen[dueCard.Card.ID], "the three windows must not return a card twice")
+		seen[dueCard.Card.ID] = true
+		require.True(t, dueCard.Rescue, "both surviving rows come from the rescue window")
+	}
 }
 
 // TestCardRepository_FindDueCards_SamplesNewCardsUnderLimit replaces the old
@@ -1199,7 +1287,7 @@ func TestCardRepository_FindDueCards_SamplesNewCardsUnderLimit(t *testing.T) {
 		pool[c.ID] = true
 	}
 
-	got, err := repo.FindDueCardsForUser(ctx, ownerID, string(cg.ID), now, now, domain.EndOfLearnDay(now), 3)
+	got, err := repo.FindDueCardsForUser(ctx, ownerID, string(cg.ID), now, now, domain.EndOfLearnDay(now), domain.RescueReviewedBefore(now), 3)
 	require.NoError(t, err)
 	require.Len(t, got, 3)
 	seen := map[string]bool{}
@@ -1267,7 +1355,7 @@ func TestCardRepository_FindPracticeCards_BoundaryComplementarity(t *testing.T) 
 	// Learn window: cards reviewed strictly before the boundary, plus the
 	// never-reviewed card via the new-card window. reviewedAtBoundary and
 	// reviewedToday are excluded (learn predicate is last_review < boundary).
-	learn, err := repo.FindDueCardsForUser(ctx, ownerID, string(cg.ID), now, boundary, domain.EndOfLearnDay(now), 10)
+	learn, err := repo.FindDueCardsForUser(ctx, ownerID, string(cg.ID), now, boundary, domain.EndOfLearnDay(now), domain.RescueReviewedBefore(now), 10)
 	require.NoError(t, err)
 	require.ElementsMatch(t, []string{reviewedYesterday.ID, neverReviewed.ID}, repoCardIDs(learn),
 		"learn window holds cards reviewed before the boundary plus never-reviewed new cards")

--- a/backend/internal/usecase/learn.go
+++ b/backend/internal/usecase/learn.go
@@ -24,8 +24,9 @@ const (
 type CardRepoForLearn interface {
 	// FindDueCardsForUser receives both ends of the current JST learn day. Rescue
 	// reviews use rescueDueBefore; filler reviews use now; both exclude rows
-	// reviewed at or after reviewedBefore.
-	FindDueCardsForUser(ctx context.Context, userID, cardgroupID string, now, reviewedBefore, rescueDueBefore time.Time, limit int) ([]domain.DueCard, error)
+	// reviewed at or after reviewedBefore. rescueReviewedBefore additionally
+	// floors the rescue window's early serve at a whole day of elapsed time.
+	FindDueCardsForUser(ctx context.Context, userID, cardgroupID string, now, reviewedBefore, rescueDueBefore, rescueReviewedBefore time.Time, limit int) ([]domain.DueCard, error)
 	// FindPracticeCardsForUser returns cards the user reviewed today (the inverse
 	// window of FindDueCardsForUser): last_review at or after reviewedAfter. The
 	// server randomizes row order; the usecase preserves it verbatim.
@@ -164,7 +165,10 @@ func (u *learnUsecase) NextDueCards(ctx context.Context, cardgroupID string, lim
 	}
 	n = u.clampLimit(n)
 	now := u.clock.Now().UTC()
-	due, err := u.cardRepo.FindDueCardsForUser(ctx, user.Sub, cardgroupID, now, domain.StartOfLearnDay(now), domain.EndOfLearnDay(now), n)
+	// domain.RescueReviewedBefore(now) is the minimum-elapsed floor for the
+	// rescue window: a card repeated inside the same 24 hours earns zero FSRS
+	// scheduling credit, so it must not be served early.
+	due, err := u.cardRepo.FindDueCardsForUser(ctx, user.Sub, cardgroupID, now, domain.StartOfLearnDay(now), domain.EndOfLearnDay(now), domain.RescueReviewedBefore(now), n)
 	if err != nil {
 		if isContextDone(err) {
 			return nil, err

--- a/backend/internal/usecase/learn_test.go
+++ b/backend/internal/usecase/learn_test.go
@@ -18,13 +18,14 @@ type mockLearnCardRepo struct {
 	rows []domain.DueCard
 	err  error
 
-	cardgroupID     string
-	userID          string
-	now             time.Time
-	reviewedBefore  time.Time
-	rescueDueBefore time.Time
-	limit           int
-	calls           int
+	cardgroupID          string
+	userID               string
+	now                  time.Time
+	reviewedBefore       time.Time
+	rescueDueBefore      time.Time
+	rescueReviewedBefore time.Time
+	limit                int
+	calls                int
 
 	// Practice-mode capture fields, separate from the due-mode captures so a
 	// test exercising one window cannot read a value written by the other.
@@ -37,13 +38,14 @@ type mockLearnCardRepo struct {
 	practiceCalls         int
 }
 
-func (m *mockLearnCardRepo) FindDueCardsForUser(_ context.Context, userID, cardgroupID string, now, reviewedBefore, rescueDueBefore time.Time, limit int) ([]domain.DueCard, error) {
+func (m *mockLearnCardRepo) FindDueCardsForUser(_ context.Context, userID, cardgroupID string, now, reviewedBefore, rescueDueBefore, rescueReviewedBefore time.Time, limit int) ([]domain.DueCard, error) {
 	m.calls++
 	m.userID = userID
 	m.cardgroupID = cardgroupID
 	m.now = now
 	m.reviewedBefore = reviewedBefore
 	m.rescueDueBefore = rescueDueBefore
+	m.rescueReviewedBefore = rescueReviewedBefore
 	m.limit = limit
 	return m.rows, m.err
 }
@@ -124,6 +126,8 @@ func TestLearnUsecaseNextDueCards(t *testing.T) {
 		"JST start-of-day for 2026-05-13T09:00Z")
 	require.True(t, cardRepo.rescueDueBefore.Equal(time.Date(2026, 5, 13, 15, 0, 0, 0, time.UTC)),
 		"JST end-of-day for 2026-05-13T09:00Z")
+	require.True(t, cardRepo.rescueReviewedBefore.Equal(time.Date(2026, 5, 12, 9, 0, 0, 0, time.UTC)),
+		"rescue early-serve floor is exactly 24h before now")
 	require.ElementsMatch(t, []string{"repo-first", "repo-second"}, learnCardIDs(got))
 }
 

--- a/docs/backend/ddd-patterns/discovery-first-due-ordering.md
+++ b/docs/backend/ddd-patterns/discovery-first-due-ordering.md
@@ -54,8 +54,10 @@ Within those mechanisms:
   Again or whose FSRS stability is below `domain.LearnedStabilityDays`. The
   rescue window admits those cards when their due timestamp falls before the
   current JST learn day's exclusive end, so a rescue due later today can be
-  served early. Rows outside the rescue band act as filler only after their due
-  timestamp has arrived. A mature card last rated Hard is filler, not rescue.
+  served early — but only once a whole day has passed since the card's last
+  review (`domain.RescueReviewedBefore(now)`, 24 hours before now). Rows outside
+  the rescue band act as filler only after their due timestamp has arrived. A
+  mature card last rated Hard is filler, not rescue.
 - A card whose `last_review` is at or after the learner's JST start-of-today is
   **excluded** from the review window, so a card swiped today never reappears
   in today's queue regardless of its FSRS re-due interval.
@@ -70,7 +72,7 @@ deterministic while the database does the sampling:
 
 | Stage | Owner | Behaviour |
 |---|---|---|
-| Selection (which rows enter each window) | `repository.FindDueCardsForUser` | Three independent `LIMIT` windows, each ordered by `random()`: rescue reviews (`due < rescueDueBefore AND last_review < reviewedBefore` plus `last_rating = Again OR stability < LearnedStabilityDays`), disjoint filler reviews (`due <= now` plus the inverse band predicate), then new cards with no FSRS row. |
+| Selection (which rows enter each window) | `repository.FindDueCardsForUser` | Three independent `LIMIT` windows, each ordered by `random()`: rescue reviews (`due < rescueDueBefore AND last_review < reviewedBefore AND last_review <= rescueReviewedBefore` plus `last_rating = Again OR stability < LearnedStabilityDays`), disjoint filler reviews (`due <= now` plus the inverse band predicate), then new cards with no FSRS row. |
 | Arrangement (order within the batch) | `service.OrderingPolicy.Apply` | Injected `*rand.Rand` shuffles the new partition fully and the review partition within same-band runs; then interleaves at the caller-supplied ratio (`domain.DefaultNewCardRatio` = 4:1 absent a stored preference) with review-first emission. |
 | Truncation | `usecase.LearnUsecase.NextDueCards` | Caps the interleaved result to the session limit (`ordered[:n]`). Because the three windows return up to `3*limit` rows, this truncate is load-bearing: it yields the 16/4 split for a 20-card request only when both the combined review pool and new-card pool are full, and skews toward review when the unseen pool is short (see Policy). |
 
@@ -101,6 +103,29 @@ deterministic while the database does the sampling:
   `domain.EndOfLearnDay(now)`. A rescue due later today is eligible, while one
   due exactly at the next JST midnight is not. Filler remains time-granular and
   uses `ucs.due <= now`.
+- **A rescue card is served early only after a whole day of elapsed time.** The
+  rescue predicate additionally requires `ucs.last_review <= rescueReviewedBefore`,
+  where `rescueReviewedBefore` is `domain.RescueReviewedBefore(now)` — exactly 24
+  hours before now. FSRS derives elapsed days as `floor(hours/24)`, so a repeat
+  inside the same 24 hours counts as zero elapsed days: retrievability is 1 and
+  the stability growth factor `exp((1-r)*W10)-1` is bit-exactly 0. Because the
+  early serve deliberately surfaces cards due later today, without this floor the
+  queue manufactures zero-credit reviews — a learner who fails a card at 23:00
+  and answers it at 09:00 the next morning earns no scheduling progress, the card
+  stays below the learned threshold, and it occupies a rescue slot again in the
+  next session. The bound is non-strict: a card last reviewed exactly 24 hours
+  ago is eligible. The floor is always at or before `domain.StartOfLearnDay(now)`,
+  so within the rescue window it is the tighter of the two `last_review` bounds;
+  the day-boundary bound stays in the predicate because it is the sole
+  `last_review` guard for the filler window. The threshold is computed by the
+  usecase and passed as a bound query argument — the repository never reads the
+  clock.
+- **The rescue floor narrows, never widens, the windows.** A rescue-band card
+  blocked by the floor does not fall through to filler: the filler predicate
+  requires the inverse band (`last_rating IS DISTINCT FROM Again AND stability >=
+  LearnedStabilityDays`) and the new-card window requires a NULL `due`. The three
+  windows therefore stay pairwise disjoint, and the blocked card simply has no
+  window for that day.
 - **The review-window cutoff is strictly before the boundary.** The repository
   predicate is `ucs.last_review < ?` (strict `<`), so a card whose `last_review`
   equals the JST start-of-day exactly is excluded — a card swiped at local
@@ -113,8 +138,8 @@ deterministic while the database does the sampling:
   before `UpsertTx` persists the aggregate. Each column carries a different part
   of the partition, and each fails differently if its NOT NULL is relaxed:
   - **`last_review`** is the one whose NULL hides a card completely. Rescue and
-    filler test `ucs.last_review < ?` and practice tests `ucs.last_review >= ?`,
-    all unknown for NULL, while the new-card window is closed to the row because
+    filler test `ucs.last_review < ?` (rescue also `ucs.last_review <= ?` against
+    the 24-hour floor) and practice tests `ucs.last_review >= ?`, all unknown for NULL, while the new-card window is closed to the row because
     its `due` is not NULL. The card then satisfies no window and vanishes from
     every queue with no error surfaced.
   - **`due`** does not hide the row; it moves it. Rescue and filler guard on
@@ -136,7 +161,9 @@ deterministic while the database does the sampling:
 
 Discovery is bought at the cost of review efficiency. Rescue-band cards claim
 the review slots before filler reviews, and rescue cards due later in the JST
-day may be served before their exact due time. A large filler backlog therefore
+day may be served before their exact due time — but never within 24 hours of
+their last review, because such a repeat earns no FSRS credit at all and would
+consume a rescue slot for nothing. A large filler backlog therefore
 drains more slowly than a pure due-date order would drain it. This is deliberate:
 queue's primary job became surfacing the unseen backlog, not maximising
 retention throughput. `cards.position` remains Notion-sync metadata (assigned
@@ -145,7 +172,8 @@ learn ordering — new cards are sampled randomly, not walked in document order.
 
 ## Reference
 
-- `backend/internal/domain/learn_day.go` — `StartOfLearnDay`, `EndOfLearnDay`.
+- `backend/internal/domain/learn_day.go` — `StartOfLearnDay`, `EndOfLearnDay`,
+  `RescueReviewedBefore` (the rescue window's 24-hour minimum-elapsed floor).
 - `backend/internal/domain/mastery_tier.go` — `LearnedStabilityDays`.
 - `backend/internal/domain/due_card.go` — `DueCard.Rescue`.
 - `backend/internal/domain/service/due_card_ordering.go` — `OrderingPolicy.Apply`,


### PR DESCRIPTION
## Summary

The rescue window deliberately serves a failed card early — before its due timestamp, as long as that due falls inside the current JST learn day. FSRS derives elapsed days as `floor(hours/24)`, so a repeat inside the same 24 hours counts as zero elapsed days: retrievability is 1 and the stability growth factor `exp((1-r)*W10)-1` is bit-exactly 0. The early serve was therefore manufacturing zero-credit reviews — a learner who fails a card at 23:00 JST and answers it correctly at 09:00 the next morning is on a new learn day (so the start-of-day cutoff admits the card) but earns no scheduling progress at all: the card stays below `LearnedStabilityDays`, occupies a rescue slot again in the next session, and the mastery tiles never move. This adds a minimum-elapsed floor so a rescue card is only served early once a whole day has passed since its last review.

## Changes

### Domain: the floor lives next to the learn-day boundaries

- `backend/internal/domain/learn_day.go` — new `rescueMinElapsed = 24 * time.Hour` (unexported) and `RescueReviewedBefore(now) = now.Add(-rescueMinElapsed)`, alongside the existing `StartOfLearnDay` / `EndOfLearnDay`. The docblock records why the constant is 24h rather than an arbitrary tuning knob: it is the exact granularity of the FSRS elapsed-days floor, not a heuristic.

### Repository: one more bound query argument on the rescue predicate

- `backend/internal/repository/card_due.go` — `rescueWhere` gains `AND ucs.last_review <= ?`, and the threshold is appended to the args slice (`[]any{cardgroupID, rescueDueBefore, reviewedBefore, rescueReviewedBefore}`). It is **not** spliced through `fmt.Sprintf`: that call still formats only `domain.RatingAgain` and `domain.LearnedStabilityDays`, both compile-time constants, and a comment now states that every caller-supplied instant travels as a bound argument.
- The bound is non-strict (`<=`), so a card last reviewed exactly 24 hours ago is eligible. The day-boundary bound `ucs.last_review < ?` stays in the predicate because it remains the sole `last_review` guard for the filler window.
- The filler window (`due <= now` plus the inverse band predicate) and the new-card window (NULL `due`) are byte-identical.
- `findDueCardsOn` and `(*cardRepo).FindDueCardsForUser` take a new `rescueReviewedBefore time.Time`; the repository still never reads the clock.

### Usecase: the caller owns the clock

- `backend/internal/usecase/learn.go` — `CardRepoForLearn.FindDueCardsForUser` widened, and the single production call site `LearnUsecase.NextDueCards` supplies `domain.RescueReviewedBefore(now)` next to the existing `domain.StartOfLearnDay(now)` / `domain.EndOfLearnDay(now)`.
- `backend/internal/repository/card.go` — the matching `CardSessionRepository` declaration, with a docblock sentence naming the new floor.

### Docs

- `docs/backend/ddd-patterns/discovery-first-due-ordering.md` — all three places that described the unconditional early serve now state the floor: the "Review slots" bullet, the Selection row of the Mechanics table, and the Policy paragraph. Two new invariant bullets carry the derivation (the zero-growth-factor argument, the non-strict bound, and the fact that the floor is always at or before `StartOfLearnDay(now)` so it is the tighter of the two `last_review` bounds) and pin that narrowing rescue cannot widen anything — a blocked rescue-band row cannot fall through to filler (inverse band predicate) or to the new window (requires NULL `due`), so it simply has no window that day. The `last_review` NOT NULL bullet and the Reference list were updated for the added predicate and helper.

### Tests

- `backend/internal/repository/card_test.go` — new `TestCardRepository_FindDueCards_RescueRequiresWholeDaySinceLastReview` reproduces the motivating case at `now = 2026-07-19T00:00Z` (09:00 JST) with three rescue-band fixtures whose due has arrived: last reviewed 10h ago (excluded), exactly 24h ago (included, pinning `<=` rather than `<`), and 25h ago (included). It asserts `floor.Before(start)` so the "tighter bound" relation is machine-checked, and re-states pairwise disjointness — no card returned twice, both survivors flagged `Rescue`. The test carries its own mutation-proof note: flip `<=` to `<` and the exact-24h row vanishes; drop the bound and the 10h row appears.
- Seven pre-existing `FindDueCards` tests stamp their rescue-band fixtures' `LastReview` at `now-25h` (they previously inherited `LastReview == now` from `NewUserCardFSRSForNewCard`, which the new floor excludes), each with a comment saying which predicate the test is actually isolating.
- `backend/internal/domain/learn_day_test.go` — `TestRescueReviewedBefore` pins the value at exactly `now-24h` across three JST-relative instants and pins `!got.After(StartOfLearnDay(now))`.
- `backend/internal/usecase/learn_test.go` — `mockLearnCardRepo` captures `rescueReviewedBefore`, and `TestLearnUsecaseNextDueCards` asserts it equals `2026-05-12T09:00Z` for a `now` of `2026-05-13T09:00Z`.
- `backend/graph/resolver/card_resolvers_test.go` — `cardMockRepo.FindDueCardsForUser` widened for the new parameter.

### Review fixes

Second commit (`0c5da862`), applying two confirmed review findings.

- `backend/internal/repository/card_test.go` — `TestCardRepository_FindPracticeCards_BoundaryComplementarity` now passes a wide-open floor (`openRescueFloor := now.Add(time.Second)`) instead of the real `domain.RescueReviewedBefore(now)`. That test exists to prove the strict `<` on the shared learn/practice boundary: its `reviewedAtBoundary` fixture sits at `now-6h` with the default stability 2.5, so under the real floor it is excluded by `last_review <= now-24h` regardless of whether the boundary comparison is `<` or `<=` — and it cannot fall through to filler, which requires `stability >= 7`. The pin survived the mutation, which `docs/backend/library-gotchas/strict-cutoff-boundary-fixture-and-mutation-proof.md:85` explicitly asserts it must not. The sibling `TestCardRepository_FindDueCards_ExcludesCardsReviewedToday` already had this escape hatch in the first commit; this restores the symmetry, and both comments point at the test that pins the floor on its own.
- `.claude/rules/ddd-patterns.md` — the L3 rule paragraph enumerating the rescue window's eligibility bounds gains the floor clause. That file is auto-loaded for `backend/**` turns, and its previous text gave a wrong concrete answer on the exact scenario this change fixes: a card failed yesterday at 23:00 clears the start-of-day cutoff the rule names, so a reader would conclude it is served early.

## Verification

The behaviour change is one `AND` in one predicate, so the review path is short: read `rescueWhere` in `card_due.go` and confirm the new bound is a `?` placeholder with its value at the tail of the args slice, then confirm `NextDueCards` is the only place that computes it. `TestCardRepository_FindDueCards_RescueRequiresWholeDaySinceLastReview` is the behavioural pin and runs against a real postgres container; temporarily flipping `ucs.last_review <= ?` to `<` or deleting the clause makes it fail in the two directions its docblock names. `TestRescueReviewedBefore` is the pure-domain pin and needs no Docker.

## Test plan

- [ ] `cd backend && go tool gqlgen generate` — clean, no schema drift
- [ ] `cd backend && go build ./...` — Success
- [ ] `cd backend && go vet ./...` — no issues found
- [ ] `cd backend && go test ./...` — 2352 passed across 26 packages, 0 failed (Docker up, so every testcontainer-gated repository/database suite really executed)
- [ ] `cd backend && go tool go-arch-lint check` — OK, no warnings found
- [ ] `go test -count=1 -v -run TestCardRepository_FindDueCards_RescueRequiresWholeDaySinceLastReview ./internal/repository/` — `--- PASS` with the `postgres:15-alpine` container start/stop visible in the log, confirming the new test is not silently skipped
- [ ] Production diff (`git diff --shortstat origin/main...HEAD -- '*.go' ':!*_test.go'`) — 4 files, 42 insertions, 11 deletions; far under the 800-line ceiling

## Notes

- The `<=` vs `<` choice was made deliberately rather than inherited: a card last reviewed exactly 24 hours ago has one whole elapsed day under `floor(hours/24)`, so it earns real credit and belongs in the window. The exact-boundary fixture pins it rather than leaving it inferred.
- Narrowing rescue means a rescue-band card blocked by the floor has no window for that day at all — it is excluded from filler by the inverse band predicate. That is the intended behaviour change, and the disjointness assertions were re-stated to cover it rather than deleted.
- Out of scope and untouched, per the issue: the FSRS scheduler and its long-term mode, the mastery thresholds, the filler window and the new-card window.
- Signature fan-out landed at all six sites — two interface declarations, the production impl, the single production call site, and three test fakes (`card_test.go`, `learn_test.go`, `card_resolvers_test.go`). `go build ./...` plus `go vet ./...` are the proof, since a missed fake breaks compilation only in its own package.

Closes #1029
