### PR TITLE
refactor(frontend): move the learn prefetch merge into a pure module

### DIFF
--- a/frontend/src/app/learn/[cardgroupId]/learn-client.tsx
+++ b/frontend/src/app/learn/[cardgroupId]/learn-client.tsx
@@ -19,6 +19,7 @@ import type { LearnNextDueCardsQuery } from "@/generated/graphql";
 import { getBackendErrorBanner } from "@/lib/apollo/errors";
 import { liftGraphQLCodes } from "@/lib/apollo/graphql-errors";
 import { learnDayKey } from "@/lib/learn/learn-day";
+import { mergePrefetchedCards } from "./learn-queue";
 import { PracticeClient } from "./practice-client";
 
 type LearnCard = LearnNextDueCardsQuery["learnNextDueCards"][number];
@@ -160,37 +161,21 @@ export function LearnClient({ cardgroupId, initialCards, displayMode }: Props) {
   }, []);
 
   const prefetchInFlightRef = useRef(false);
-  // Ids of every card swiped in this session. The optimistic queue removal in
-  // `onSwipe` shrinks the queue and can re-fire the prefetch below WHILE the
-  // swipe mutation has not yet committed its FSRS write; a network-only read
-  // that beats that write still sees the card as "due" and returns it in the
-  // batch. The merge filters `incoming` against this set so a swiped card is
-  // never re-appended, which would let the learner rate it twice and record a
-  // duplicate same-day FSRS review.
-  //
-  // Ids are never pruned card-by-card. Both server-side REVIEW windows require
-  // `last_review < StartOfLearnDay(now)` (see the contract on `StartOfLearnDay`
-  // in `backend/internal/domain/learn_day.go`), and the new-card window carries
-  // no `last_review` predicate at all — it matches only cards with no FSRS row,
-  // which the swipe itself creates. So once a swipe commits, no window can
-  // return that card again WITHIN THE SAME JST LEARN DAY: any prefetched batch
-  // carrying one of these ids is a stale read that predates the commit.
-  //
-  // That invariant expires at the learn-day rollover. `StartOfLearnDay` advances
-  // at JST midnight, so a session held open past it sees the server legitimately
-  // re-serve cards swiped on the previous day. The set is therefore keyed by the
-  // JST learn day (`learnDayRef`) as well as by the cardgroup, and is discarded
-  // whenever either key changes.
+  // Ids of every card swiped in this session, scoped to the cardgroup and to the
+  // JST learn day tracked by `learnDayRef`. `mergePrefetchedCards` filters each
+  // prefetched batch against this set; the reasoning for why an already-swiped
+  // card can come back from the server at all, and why the ids stay in the set
+  // for a whole learn day rather than being pruned one by one, lives with the
+  // policy in `./learn-queue`.
   //
   // A transport failure keeps its id here too, which is harmless: the catch
-  // handler puts the card back at the queue head, so `seen` covers it for as
-  // long as it is queued and the learner can re-swipe it.
+  // handler puts the card back at the queue head, so the queue itself covers it
+  // for as long as it is queued and the learner can re-swipe it.
   const swipedThisSessionRef = useRef<Set<string>>(new Set());
-  // Set once a prefetch resolves and the dedup merge adds zero new cards: the
-  // due pool is exhausted, so every subsequent tail swipe would otherwise fire a
-  // redundant network-only query that returns nothing new. A stale batch whose
-  // ids were all swiped this session lands here too, and that verdict is correct
-  // for the same-day queue. The effect short-circuits while this is set.
+  // The exhaustion verdict returned by the last resolved merge: the due pool
+  // added nothing, so every subsequent tail swipe would otherwise fire a
+  // redundant network-only query that returns nothing new. The effect
+  // short-circuits while this is set.
   //
   // Cleared after a swipe mutation succeeds, on cardgroup change, and at the JST
   // learn-day rollover (which refills the due pool wholesale). The reset is
@@ -248,24 +233,20 @@ export function LearnClient({ cardgroupId, initialCards, displayMode }: Props) {
       .then((result) => {
         if (!isMountedRef.current) return;
         const incoming = result.data?.learnNextDueCards ?? [];
-        if (incoming.length === 0) {
-          exhaustedRef.current = true;
-          return;
-        }
+        // The merge runs inside the updater so it always sees the freshest
+        // queue: `onSwipe`'s optimistic delete can land between this request
+        // being issued and its response arriving. Writing `exhaustedRef` here
+        // is idempotent, so Strict Mode's double-invoke of the updater is
+        // harmless. All queue policy lives in `mergePrefetchedCards`.
         setQueue((current) => {
-          const seen = new Set(current.map((c) => c.id));
-          const swiped = swipedThisSessionRef.current;
-          // Drop cards already queued (`seen`) and cards already swiped this
-          // session (`swiped`) — the latter can only reach us from a read that
-          // predates the swipe's FSRS commit.
-          const additions = incoming.filter((card) => !seen.has(card.id) && !swiped.has(card.id));
-          if (additions.length === 0) {
-            // Nothing new survived the merge — mark the pool exhausted so tail
-            // swipes stop re-firing this query until a swipe succeeds.
-            exhaustedRef.current = true;
-            return current;
-          }
-          return [...current, ...additions];
+          const merged = mergePrefetchedCards(
+            current,
+            incoming,
+            { dayKey: learnDayRef.current, ids: swipedThisSessionRef.current },
+            learnDayRef.current,
+          );
+          exhaustedRef.current = merged.exhausted;
+          return merged.queue;
         });
       })
       .catch((err) => {

--- a/frontend/src/app/learn/[cardgroupId]/learn-queue.test.ts
+++ b/frontend/src/app/learn/[cardgroupId]/learn-queue.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from "vitest";
+import { mergePrefetchedCards, type SwipedSession } from "./learn-queue";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+type Card = { id: string; front: string };
+
+const TODAY = "2026-07-20";
+const YESTERDAY = "2026-07-19";
+
+function makeCards(ids: readonly string[]): Card[] {
+  return ids.map((id) => ({ id, front: `Front ${id}` }));
+}
+
+function swipes(dayKey: string, ids: readonly string[]): SwipedSession {
+  return { dayKey, ids: new Set(ids) };
+}
+
+const NOTHING_SWIPED: SwipedSession = swipes(TODAY, []);
+
+// ---------------------------------------------------------------------------
+// Verdict 1 — empty incoming
+// ---------------------------------------------------------------------------
+
+describe("mergePrefetchedCards with an empty incoming batch", () => {
+  it("marks the pool exhausted and leaves the queue contents unchanged", () => {
+    const current = makeCards(["a", "b"]);
+    const result = mergePrefetchedCards(current, [], NOTHING_SWIPED, TODAY);
+
+    expect(result.exhausted).toBe(true);
+    expect(result.queue.map((c) => c.id)).toEqual(["a", "b"]);
+  });
+
+  it("returns the same verdict for an empty queue and an empty batch", () => {
+    const result = mergePrefetchedCards<Card>([], [], NOTHING_SWIPED, TODAY);
+
+    expect(result.exhausted).toBe(true);
+    expect(result.queue).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Verdict 2 — every incoming row filtered out
+// ---------------------------------------------------------------------------
+
+describe("mergePrefetchedCards when every incoming row is filtered out", () => {
+  it("marks the pool exhausted when the batch only repeats queued cards", () => {
+    const current = makeCards(["a", "b"]);
+    const incoming = makeCards(["a", "b"]);
+    const result = mergePrefetchedCards(current, incoming, NOTHING_SWIPED, TODAY);
+
+    expect(result.exhausted).toBe(true);
+    expect(result.queue.map((c) => c.id)).toEqual(["a", "b"]);
+  });
+
+  it("marks the pool exhausted when the batch only repeats cards swiped this learn day", () => {
+    const current = makeCards(["a"]);
+    const incoming = makeCards(["x", "y"]);
+    const result = mergePrefetchedCards(current, incoming, swipes(TODAY, ["x", "y"]), TODAY);
+
+    expect(result.exhausted).toBe(true);
+    expect(result.queue.map((c) => c.id)).toEqual(["a"]);
+  });
+
+  it("marks the pool exhausted when the queued and swiped filters together cover the batch", () => {
+    const current = makeCards(["a"]);
+    const incoming = makeCards(["a", "x"]);
+    const result = mergePrefetchedCards(current, incoming, swipes(TODAY, ["x"]), TODAY);
+
+    expect(result.exhausted).toBe(true);
+    expect(result.queue.map((c) => c.id)).toEqual(["a"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Verdict 3 — partial additions
+// ---------------------------------------------------------------------------
+
+describe("mergePrefetchedCards when some incoming rows survive the filter", () => {
+  it("appends the survivors to the tail in server order and clears the verdict", () => {
+    const current = makeCards(["a", "b"]);
+    const incoming = makeCards(["b", "c", "d"]);
+    const result = mergePrefetchedCards(current, incoming, NOTHING_SWIPED, TODAY);
+
+    expect(result.exhausted).toBe(false);
+    expect(result.queue.map((c) => c.id)).toEqual(["a", "b", "c", "d"]);
+  });
+
+  it("keeps the survivors' relative order when a swiped id sits between them", () => {
+    const current = makeCards(["a"]);
+    const incoming = makeCards(["c", "x", "b"]);
+    const result = mergePrefetchedCards(current, incoming, swipes(TODAY, ["x"]), TODAY);
+
+    expect(result.exhausted).toBe(false);
+    expect(result.queue.map((c) => c.id)).toEqual(["a", "c", "b"]);
+  });
+
+  it("appends every row when the queue is empty and nothing was swiped", () => {
+    const incoming = makeCards(["a", "b"]);
+    const result = mergePrefetchedCards<Card>([], incoming, NOTHING_SWIPED, TODAY);
+
+    expect(result.exhausted).toBe(false);
+    expect(result.queue.map((c) => c.id)).toEqual(["a", "b"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Learn-day rollover
+// ---------------------------------------------------------------------------
+
+describe("mergePrefetchedCards across the JST learn-day rollover", () => {
+  it("ignores swiped ids recorded on a previous learn day so re-served cards are admitted", () => {
+    const current = makeCards(["a"]);
+    const incoming = makeCards(["x", "y"]);
+    const result = mergePrefetchedCards(current, incoming, swipes(YESTERDAY, ["x", "y"]), TODAY);
+
+    expect(result.exhausted).toBe(false);
+    expect(result.queue.map((c) => c.id)).toEqual(["a", "x", "y"]);
+  });
+
+  it("still honours the queued-card filter when the swiped ids are stale", () => {
+    const current = makeCards(["x"]);
+    const incoming = makeCards(["x", "y"]);
+    const result = mergePrefetchedCards(current, incoming, swipes(YESTERDAY, ["x", "y"]), TODAY);
+
+    expect(result.exhausted).toBe(false);
+    expect(result.queue.map((c) => c.id)).toEqual(["x", "y"]);
+  });
+
+  it("honours the same ids while the recorded day still matches", () => {
+    const current = makeCards(["a"]);
+    const incoming = makeCards(["x", "y"]);
+    const result = mergePrefetchedCards(current, incoming, swipes(TODAY, ["x", "y"]), TODAY);
+
+    expect(result.exhausted).toBe(true);
+    expect(result.queue.map((c) => c.id)).toEqual(["a"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Immutability
+// ---------------------------------------------------------------------------
+
+describe("mergePrefetchedCards immutability", () => {
+  const cases: ReadonlyArray<{ name: string; incoming: readonly string[] }> = [
+    { name: "empty incoming", incoming: [] },
+    { name: "fully filtered incoming", incoming: ["a", "b"] },
+    { name: "partially added incoming", incoming: ["b", "c"] },
+  ];
+
+  for (const { name, incoming } of cases) {
+    it(`does not mutate its inputs for ${name}`, () => {
+      const current = makeCards(["a", "b"]);
+      const batch = makeCards(incoming);
+      const currentIds = current.map((c) => c.id);
+      const batchIds = batch.map((c) => c.id);
+      const swiped = swipes(TODAY, ["z"]);
+
+      mergePrefetchedCards(current, batch, swiped, TODAY);
+
+      expect(current.map((c) => c.id)).toEqual(currentIds);
+      expect(batch.map((c) => c.id)).toEqual(batchIds);
+      expect([...swiped.ids]).toEqual(["z"]);
+    });
+
+    it(`returns a new array instance for ${name}`, () => {
+      const current = makeCards(["a", "b"]);
+      const batch = makeCards(incoming);
+      const result = mergePrefetchedCards(current, batch, NOTHING_SWIPED, TODAY);
+
+      expect(result.queue).not.toBe(current);
+    });
+  }
+
+  it("reuses the element references it carries over", () => {
+    const current = makeCards(["a"]);
+    const incoming = makeCards(["b"]);
+    const result = mergePrefetchedCards(current, incoming, NOTHING_SWIPED, TODAY);
+
+    expect(result.queue[0]).toBe(current[0]);
+    expect(result.queue[1]).toBe(incoming[0]);
+  });
+});

--- a/frontend/src/app/learn/[cardgroupId]/learn-queue.ts
+++ b/frontend/src/app/learn/[cardgroupId]/learn-queue.ts
@@ -1,0 +1,116 @@
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * The ids of every card swiped so far in the current learn session, tagged with
+ * the JST learn day (`YYYY-MM-DD`, see `learnDayKey`) they were recorded under.
+ *
+ * The day tag is part of the value rather than an implicit assumption of the
+ * caller so `mergePrefetchedCards` is total: it can decide on its own whether a
+ * given swiped-id set still applies to the learn day being merged for.
+ */
+export type SwipedSession = {
+  readonly dayKey: string;
+  readonly ids: ReadonlySet<string>;
+};
+
+/**
+ * Outcome of merging one resolved prefetch batch into the swipe queue.
+ *
+ * - `queue` — the next queue. Always a freshly allocated array; the inputs are
+ *   never mutated.
+ * - `exhausted` — `true` when the batch added nothing, meaning the due pool has
+ *   run dry for now and further tail swipes should not re-fire the query. It is
+ *   a point-in-time verdict, not a permanent one; deciding when to clear it is
+ *   the caller's concern.
+ */
+export type PrefetchMerge<T> = {
+  readonly queue: T[];
+  readonly exhausted: boolean;
+};
+
+/**
+ * Shared empty set used when the recorded swipes belong to a past learn day.
+ * Typed `ReadonlySet` and never written to, so sharing one instance is safe.
+ */
+const NO_SWIPED_IDS: ReadonlySet<string> = new Set<string>();
+
+// ---------------------------------------------------------------------------
+// mergePrefetchedCards
+// ---------------------------------------------------------------------------
+
+/**
+ * Pure, side-effect-free policy for merging a resolved background-prefetch
+ * batch into the learn session's swipe queue.
+ *
+ * Three verdicts
+ * ──────────────
+ * 1. `incoming` is empty — the server has nothing more to serve. The queue is
+ *    returned unchanged and the pool is marked exhausted.
+ * 2. Every incoming row is filtered out — the batch carried only cards already
+ *    queued or already swiped this learn day, so it adds nothing. Same verdict
+ *    as (1): the merge made no progress, so re-querying on the next tail swipe
+ *    would just repeat the round trip.
+ * 3. Some rows survive — they are appended to the tail in the order the server
+ *    returned them, and the pool is not exhausted.
+ *
+ * Why a swiped card can come back at all
+ * ──────────────────────────────────────
+ * The consumer removes a card from the queue optimistically, which can re-fire
+ * the prefetch WHILE the swipe mutation has not yet committed its FSRS write. A
+ * `network-only` read that beats that write still sees the card as due and
+ * returns it in the batch. Re-appending it would let the learner rate the same
+ * card twice and record a duplicate same-day FSRS review, so `swiped.ids` is
+ * filtered out alongside the ids already in `current`.
+ *
+ * Why swiped ids are day-keyed rather than pruned one by one
+ * ─────────────────────────────────────────────────────────
+ * Both server-side REVIEW windows require `last_review < StartOfLearnDay(now)`
+ * (see the contract on `StartOfLearnDay` in
+ * `backend/internal/domain/learn_day.go`), and the new-card window carries no
+ * `last_review` predicate at all — it matches only cards with no FSRS row,
+ * which the swipe itself creates. So once a swipe commits, no window can return
+ * that card again WITHIN THE SAME JST LEARN DAY: any batch carrying one of
+ * those ids is a stale read that predates the commit, and the id can stay in
+ * the set for the whole day.
+ *
+ * That invariant expires at the learn-day rollover. `StartOfLearnDay` advances
+ * at JST midnight, so a session held open past it sees the server legitimately
+ * re-serve cards swiped on the previous day. When `swiped.dayKey` is not
+ * `learnDay`, the recorded ids belong to a finished day and are ignored
+ * wholesale — otherwise every re-served card would be filtered out and the
+ * refilled pool would be misread as exhausted.
+ *
+ * The day is an explicit parameter rather than an assumption because the policy
+ * has to be total over its inputs: a caller that drops its swiped-id set at the
+ * rollover and a caller that lets the tag go stale must both get the same
+ * answer. `LearnClient` is the former — it re-keys the set before recording any
+ * swipe — so its own merges always pass a matching pair.
+ *
+ * @param current   Current ordered queue. Never mutated.
+ * @param incoming  The batch the server just returned, in server order.
+ * @param swiped    Ids swiped this session plus the learn day they belong to.
+ * @param learnDay  The learn-day key the merge is being performed for.
+ * @returns         The next queue plus the exhaustion verdict.
+ */
+export function mergePrefetchedCards<T extends { id: string }>(
+  current: readonly T[],
+  incoming: readonly T[],
+  swiped: SwipedSession,
+  learnDay: string,
+): PrefetchMerge<T> {
+  if (incoming.length === 0) {
+    return { queue: [...current], exhausted: true };
+  }
+
+  const seen = new Set(current.map((card) => card.id));
+  const swipedIds = swiped.dayKey === learnDay ? swiped.ids : NO_SWIPED_IDS;
+  const additions = incoming.filter((card) => !seen.has(card.id) && !swipedIds.has(card.id));
+
+  if (additions.length === 0) {
+    return { queue: [...current], exhausted: true };
+  }
+
+  return { queue: [...current, ...additions], exhausted: false };
+}


### PR DESCRIPTION
## Summary

The decision about what a resolved background prefetch may append to the learn-session swipe queue used to live inline in `LearnClient`'s prefetch effect, spread across a `seen` set, a filter against `swipedThisSessionRef`, and two separate `exhaustedRef.current = true` branches, all justified by ~35 lines of prose comment attached to ref declarations. That policy now lives in a co-located pure module, `learn-queue.ts`, exercised directly by unit tests with no React render and no Apollo mock. No user-visible behaviour changes: the component keeps every ref and both effects, and `learn-client.test.tsx` passes unmodified (it is not in this diff).

## Changes

### Where the module lives, and why

`frontend/src/app/learn/[cardgroupId]/learn-queue.ts`, co-located beside `practice-client.tsx` / `practice-queue.ts` rather than under `frontend/src/lib/`. The issue asks for this choice to be stated explicitly, so:

- The sibling practice flow already solved the identical problem this way, and `docs/frontend/typescript-conventions/pure-policy-module-out-of-react-closures.md` uses `practice-queue.ts` as its worked example. Two policy modules for the same route, one co-located and one under `src/lib/`, would leave the next contributor with no rule to follow.
- The module is route-specific. It is generic over `<T extends { id: string }>`, but its entire contract — the stale-read race, the `StartOfLearnDay` day-keying — is about this one screen. `src/lib/` is where cross-route code lives.
- The cost is real and accepted: `frontend/stryker.config.mjs:34` scopes mutation testing to `src/lib/**/*.{ts,tsx}`, so this module gets no mutation coverage. The 18 direct unit tests below, including the three-verdict and rollover cases the issue names, are the compensating control.

### `learn-queue.ts` (new)

- `mergePrefetchedCards(current, incoming, swiped, learnDay)` returns `{ queue, exhausted }`. Verdict 1 (`incoming` empty) and verdict 2 (every row filtered by `seen` or `swipedIds`) both return the queue unchanged with `exhausted: true`; verdict 3 appends the survivors to the tail in server order with `exhausted: false`. Inputs are `readonly` and never mutated — `queue` is always a fresh array, even on the two no-op paths.
- `SwipedSession = { dayKey, ids }` — the swiped-id set carries the JST learn day it was recorded under. This deviates from the issue's literal `mergePrefetchedCards(current, incoming, swipedIds, learnDayKey)` signature: passing a bare `Set` plus a key would let a caller supply a set and a key that disagree with no way for the function to notice. Bundling the tag makes the function total over its inputs, and makes the rollover branch (`swiped.dayKey !== learnDay` → treat as empty, via the shared `NO_SWIPED_IDS`, typed `ReadonlySet` and never written to, so one instance is safe to share) testable without React.
- The invariant prose moved here from the component: why a swiped card can come back from the server at all (optimistic queue removal re-fires the prefetch before the swipe's FSRS write commits, so a `network-only` read can beat it), and why ids are day-keyed rather than pruned one at a time (both REVIEW windows require `last_review < StartOfLearnDay(now)`, and the new-card window has no `last_review` predicate — so within one JST day a returned swiped id can only be a stale read).

### `learn-client.tsx`

- The `.then` handler drops the `incoming.length === 0` early return, the `seen`/`swiped` filter, and both `exhaustedRef` assignments in favour of one `mergePrefetchedCards(...)` call inside the `setQueue` updater, then `exhaustedRef.current = merged.exhausted`.
- The merge deliberately stays *inside* the updater so it sees the freshest `current` — `onSwipe`'s optimistic delete can land between the request being issued and its response arriving. The ref write is idempotent, so React Strict Mode's double-invoke of the updater is harmless; a comment records this.
- All six refs stay (`isMountedRef`, `prefetchInFlightRef`, `swipedThisSessionRef`, `exhaustedRef`, `exhaustedForCardgroupRef`, `learnDayRef`), as do both effects and `syncLearnDay`. Net −45/+26 in this file: the comments that reasoned about backend learn-day semantics went to the module, and what remains at each ref is the React-lifecycle half (why a transport failure's id is harmless to keep, when the exhaustion verdict is cleared).

### `learn-queue.test.ts` (new)

- Verdict 1: empty batch against a non-empty queue, and against an empty queue.
- Verdict 2: batch repeating only queued ids; batch repeating only ids swiped this learn day; batch covered jointly by the two filters.
- Verdict 3: survivors appended in server order; relative order preserved when a swiped id sits between two survivors; every row appended when the queue starts empty.
- Rollover: ids tagged `2026-07-19` are ignored when merging for `2026-07-20` so re-served cards are admitted, the queued-card filter still applies while the swiped tag is stale, and the same ids are honoured when the day tag matches.
- Immutability, as an `it.each` over all three verdicts: `current`, `incoming` and `swiped.ids` are unchanged after the call, `result.queue` is never the `current` instance, and carried-over elements are the same object references.

## Verification

The behaviour-preservation claim rests on `learn-client.test.tsx` being absent from this diff — 80 KB of prefetch-threshold-keyed assertions that pass byte-identical against the extracted policy. `git diff --stat origin/main...HEAD` lists exactly three files: the component, the new module, and the new test.

To confirm the module is genuinely React-free: `grep -c react "frontend/src/app/learn/[cardgroupId]/learn-queue.ts"` returns 0, and the new test file imports only `vitest` and the module under test.

## Test plan

- [ ] `./node_modules/.bin/tsc --noEmit` — exit 0, no diagnostics
- [ ] `./node_modules/.bin/biome check --error-on-warnings .` — exit 0; 526 files checked, 0 fixes applied. The 2 "infos" are the pre-existing biome.json version-mismatch and deprecated-`recommended`-field notices, not findings against changed files.
- [ ] `./node_modules/.bin/vitest run` — 210 test files passed, 1975 tests passed, 0 failed (15.7s). On `origin/main` this is 209 files; the one new file is `learn-queue.test.ts`, which contributes 18 tests.
- [ ] `./node_modules/.bin/knip` — no unused exports or files reported; the single output line is the pre-existing `@graphql-typed-document-node/core` configuration hint in `knip.jsonc`, untouched here.
- [ ] CJK gate (`perl -CSD` over the three changed files) — no output.
- [ ] `git diff --shortstat origin/main...HEAD -- '*.ts' '*.tsx' ':!*.test.ts' ':!*.test.tsx'` — 2 files, 142 insertions / 45 deletions. Well under the 800-line production-diff ceiling, and within the issue's ~140 LOC estimate.

## Notes

`next build` was not run. This change adds no route, no server/client boundary and no new dependency — the new file is a plain `.ts` module imported by an already-client component — so `tsc --noEmit` plus the full vitest suite cover it.

The issue's line citations had drifted before this branch: the five refs it places at `:151/:159/:180/:192/:197` were at `:154/:162/:188/:201/:206`, and there are now **six** refs, not five — `learnDayRef` and `syncLearnDay` arrived with #1015. That sixth ref is why the extracted signature is day-aware at all. Both stated dependencies (#1015, #1027) are merged and present in `learn-client.tsx`.

Deliberately not done: `docs/frontend/typescript-conventions/pure-policy-module-out-of-react-closures.md` was left unedited. Citing `learn-queue.ts` as a second worked example is defensible, but the issue does not ask for it and the doc's existing `practice-queue.ts` example is not made stale by this change.

Closes #1043
