### PR TITLE
refactor(frontend): one makeMergeConnection for every paginated list

### DIFF
--- a/docs/pagination/migrate-list-screen-to-shared-hook.md
+++ b/docs/pagination/migrate-list-screen-to-shared-hook.md
@@ -75,7 +75,12 @@ pagination UX".
    effect, and the local `fetchMoreError` state — with one
    `useConnectionPagination(...)` call. Inject `document`, memoized `variables`,
    `searchQuery`, `selectConnection`, `buildFetchMoreVariables`,
-   `mergeConnection`, `initial`, `resolveFetchMoreError`, and `logScope`.
+   `mergeConnection`, `initial`, `resolveFetchMoreError`, and `logScope`. Build
+   `mergeConnection` with the shared
+   `makeMergeConnection<TData>(connectionField)` factory
+   (`src/lib/pagination/make-merge-connection.ts`) rather than hand-rolling the
+   edges concat, and hold the instance at module scope so its identity stays
+   stable — the hook takes it as a `useCallback` dependency.
 2. Wire the screen's Retry buttons to the hook's `retryFetchMore` (the fetchMore
    banner) and `refetch` (the initial-query-error banner). See
    [`hook-expose-actions-not-setters.md`](../frontend/typescript-conventions/hook-expose-actions-not-setters.md).

--- a/frontend/src/app/admin/masters/admin-masters-client.tsx
+++ b/frontend/src/app/admin/masters/admin-masters-client.tsx
@@ -16,6 +16,7 @@ import type {
 import { useHeaderTakeoverSearch } from "@/hooks/use-header-takeover-search";
 import { classifyQueryError, getBackendErrorBanner } from "@/lib/apollo/errors";
 import { EMPTY_PAGE_INFO } from "@/lib/pagination/empty-page-info";
+import { makeMergeConnection } from "@/lib/pagination/make-merge-connection";
 import { useConnectionPagination } from "@/lib/pagination/use-connection-pagination";
 import { useSheetSearchParam } from "@/lib/url/use-sheet-search-param";
 import { AdminMasterForm, type MasterFormValues } from "./admin-master-form";
@@ -37,18 +38,10 @@ const MASTERS_INITIAL = {
   totalCount: 0,
 };
 
-// Concatenate the next page's edges onto the cached adminMasters connection.
-function mergeMastersConnection(
-  prev: AdminMastersQueryResult,
-  more: AdminMastersQueryResult,
-): AdminMastersQueryResult {
-  return {
-    adminMasters: {
-      ...more.adminMasters,
-      edges: [...prev.adminMasters.edges, ...more.adminMasters.edges],
-    },
-  };
-}
+// Concatenate the next page's edges onto the cached adminMasters connection. A
+// module-level constant so the reducer identity useConnectionPagination
+// memoizes on stays stable across renders.
+const mergeMastersConnection = makeMergeConnection<AdminMastersQueryResult>("adminMasters");
 
 export function AdminMastersClient() {
   const t = useTranslations("AdminMasters");

--- a/frontend/src/app/admin/users/admin-users-client.tsx
+++ b/frontend/src/app/admin/users/admin-users-client.tsx
@@ -19,6 +19,7 @@ import {
   type QueryErrorKind,
 } from "@/lib/apollo/errors";
 import { EMPTY_PAGE_INFO } from "@/lib/pagination/empty-page-info";
+import { makeMergeConnection } from "@/lib/pagination/make-merge-connection";
 import { useConnectionPagination } from "@/lib/pagination/use-connection-pagination";
 import { useSheetSearchParam } from "@/lib/url/use-sheet-search-param";
 import { useSheetTargetLoading } from "@/lib/url/use-sheet-target-loading";
@@ -49,18 +50,10 @@ const USERS_INITIAL = {
   totalCount: 0,
 };
 
-// Concatenate the next page's edges onto the cached users connection.
-function mergeUsersConnection(
-  prev: AdminUsersQueryResult,
-  more: AdminUsersQueryResult,
-): AdminUsersQueryResult {
-  return {
-    users: {
-      ...more.users,
-      edges: [...prev.users.edges, ...more.users.edges],
-    },
-  };
-}
+// Concatenate the next page's edges onto the cached users connection. A
+// module-level constant so the reducer identity useConnectionPagination
+// memoizes on stays stable across renders.
+const mergeUsersConnection = makeMergeConnection<AdminUsersQueryResult>("users");
 
 function UserRowFromEdge({ edge, onEdit }: { edge: Edge; onEdit: (id: string) => void }) {
   const user = useFragment(AdminUserFieldsFragment, edge.node);

--- a/frontend/src/app/cardgroups/cardgroups-client.tsx
+++ b/frontend/src/app/cardgroups/cardgroups-client.tsx
@@ -22,6 +22,7 @@ import { useHeaderTakeoverSearch } from "@/hooks/use-header-takeover-search";
 import { getBackendErrorBanner } from "@/lib/apollo/errors";
 import { FLAMINGO_EVENT, subscribeFlamingo } from "@/lib/events/flamingo-events";
 import { EMPTY_PAGE_INFO } from "@/lib/pagination/empty-page-info";
+import { makeMergeConnection } from "@/lib/pagination/make-merge-connection";
 import { useConnectionPagination } from "@/lib/pagination/use-connection-pagination";
 import { useSeedConnectionCache } from "@/lib/pagination/use-seed-connection-cache";
 import { useUndoDelete } from "@/lib/undo-delete";
@@ -46,18 +47,11 @@ const CARDGROUPS_INITIAL = {
   totalCount: 0,
 };
 
-// Concatenate the next page's edges onto the cached cardgroups connection.
-function mergeCardgroupsConnection(
-  prev: MyCardgroupsConnectionQuery,
-  more: MyCardgroupsConnectionQuery,
-): MyCardgroupsConnectionQuery {
-  return {
-    myCardgroupsConnection: {
-      ...more.myCardgroupsConnection,
-      edges: [...prev.myCardgroupsConnection.edges, ...more.myCardgroupsConnection.edges],
-    },
-  };
-}
+// Concatenate the next page's edges onto the cached cardgroups connection. A
+// module-level constant so the reducer identity useConnectionPagination
+// memoizes on stays stable across renders.
+const mergeCardgroupsConnection =
+  makeMergeConnection<MyCardgroupsConnectionQuery>("myCardgroupsConnection");
 
 function CreateCardgroupSheetContent({
   submit,

--- a/frontend/src/app/catalog/queries.ts
+++ b/frontend/src/app/catalog/queries.ts
@@ -4,6 +4,7 @@ import type {
   MasterCatalogQueryVariables,
 } from "@/generated/graphql";
 import { EMPTY_PAGE_INFO } from "@/lib/pagination/empty-page-info";
+import { makeMergeConnection } from "@/lib/pagination/make-merge-connection";
 
 // Master catalog queries
 
@@ -41,18 +42,14 @@ export const CATALOG_INITIAL = {
   totalCount: 0,
 };
 
-/** Concatenate the next page's edges onto the cached catalog connection. */
-export function mergeCatalogConnection(
-  prev: MasterCatalogQueryData,
-  more: MasterCatalogQueryData,
-): MasterCatalogQueryData {
-  return {
-    masterCatalog: {
-      ...more.masterCatalog,
-      edges: [...prev.masterCatalog.edges, ...more.masterCatalog.edges],
-    },
-  };
-}
+/**
+ * Concatenate the next page's edges onto the cached catalog connection. A single
+ * module-level instance so its two consumers ({@link CatalogClient} and
+ * {@link MergeFromCatalogSheet}), which share the {@link CATALOG_DEFAULT_VARS}
+ * cache entry, cannot diverge on the same cache key — and so the reducer
+ * identity `useConnectionPagination` memoizes on stays stable across renders.
+ */
+export const mergeCatalogConnection = makeMergeConnection<MasterCatalogQueryData>("masterCatalog");
 
 /**
  * The `MasterCardgroup` field set shared by the catalog list row

--- a/frontend/src/lib/pagination/make-merge-connection.test.ts
+++ b/frontend/src/lib/pagination/make-merge-connection.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { makeMergeConnection } from "./make-merge-connection";
+
+interface Edge {
+  cursor: string;
+  node: { id: string };
+}
+
+interface PageInfo {
+  hasNextPage: boolean;
+  endCursor: string | null;
+}
+
+interface Result {
+  items: {
+    __typename: "ItemConnection";
+    edges: Edge[];
+    pageInfo: PageInfo;
+    totalCount: number;
+  };
+}
+
+const edge = (id: string): Edge => ({ cursor: id, node: { id } });
+
+function page(edges: Edge[], pageInfo: PageInfo, totalCount: number): Result {
+  return {
+    items: { __typename: "ItemConnection", edges, pageInfo, totalCount },
+  };
+}
+
+describe("makeMergeConnection", () => {
+  const merge = makeMergeConnection<Result>("items");
+
+  it("concatenates the incoming page's edges after the cached ones", () => {
+    const prev = page([edge("a"), edge("b")], { hasNextPage: true, endCursor: "b" }, 4);
+    const more = page([edge("c"), edge("d")], { hasNextPage: false, endCursor: "d" }, 4);
+
+    expect(merge(prev, more).items.edges.map((e) => e.node.id)).toEqual(["a", "b", "c", "d"]);
+  });
+
+  it("keeps the incoming page's pageInfo and totalCount", () => {
+    const prev = page([edge("a")], { hasNextPage: true, endCursor: "a" }, 3);
+    const more = page([edge("b")], { hasNextPage: false, endCursor: "b" }, 2);
+
+    const merged = merge(prev, more);
+    expect(merged.items.pageInfo).toEqual({ hasNextPage: false, endCursor: "b" });
+    expect(merged.items.totalCount).toBe(2);
+    expect(merged.items.__typename).toBe("ItemConnection");
+  });
+
+  it("does not mutate either input", () => {
+    const prev = page([edge("a")], { hasNextPage: true, endCursor: "a" }, 2);
+    const more = page([edge("b")], { hasNextPage: false, endCursor: "b" }, 2);
+
+    merge(prev, more);
+    expect(prev.items.edges).toHaveLength(1);
+    expect(more.items.edges).toHaveLength(1);
+  });
+
+  it("carries sibling top-level fields of the incoming result through", () => {
+    interface WithSibling extends Result {
+      unrelated: string;
+    }
+    const mergeWithSibling = makeMergeConnection<WithSibling>("items");
+    const prev: WithSibling = {
+      ...page([edge("a")], { hasNextPage: true, endCursor: "a" }, 2),
+      unrelated: "stale",
+    };
+    const more: WithSibling = {
+      ...page([edge("b")], { hasNextPage: false, endCursor: "b" }, 2),
+      unrelated: "fresh",
+    };
+
+    expect(mergeWithSibling(prev, more).unrelated).toBe("fresh");
+  });
+
+  it("returns a fresh reducer per call, so consumers must hold one instance", () => {
+    expect(makeMergeConnection<Result>("items")).not.toBe(makeMergeConnection<Result>("items"));
+  });
+});

--- a/frontend/src/lib/pagination/make-merge-connection.ts
+++ b/frontend/src/lib/pagination/make-merge-connection.ts
@@ -1,0 +1,43 @@
+/**
+ * Minimal structural view of the Relay connection slice this reducer touches.
+ * Only `edges` is read; `pageInfo` / `totalCount` ride through the `...moreConn`
+ * spread untouched, so they are deliberately not modelled here.
+ */
+interface EdgesSlice {
+  edges: readonly unknown[];
+}
+
+/**
+ * Builds the `mergeConnection` reducer `useConnectionPagination` takes: it
+ * concatenates the next page's edges onto the cached connection stored under
+ * `connectionField`, keeping the incoming page's `pageInfo` / `totalCount`.
+ *
+ * This is the single implementation of that reducer in the tree. Every
+ * cursor-paginated screen builds its instance from here rather than hand-rolling
+ * the three-line concat, so a future change to the merge (deduplication, cursor
+ * handling, a page-info fix) lands in one place.
+ *
+ * The result object spreads `...more` at the top level so sibling fields of the
+ * query result are carried through, then overrides `connectionField` with the
+ * concatenated slice.
+ *
+ * The returned function is a fresh identity per call, and
+ * `useConnectionPagination` feeds `mergeConnection` into a `useCallback`
+ * dependency array — so callers MUST keep the instance referentially stable:
+ * build it once at module scope, or memoize it on `connectionField`.
+ */
+export function makeMergeConnection<TData>(
+  connectionField: keyof TData,
+): (prev: TData, more: TData) => TData {
+  return (prev, more) => {
+    const prevConn = prev[connectionField] as EdgesSlice;
+    const moreConn = more[connectionField] as EdgesSlice;
+    return {
+      ...more,
+      [connectionField]: {
+        ...moreConn,
+        edges: [...prevConn.edges, ...moreConn.edges],
+      },
+    } as TData;
+  };
+}

--- a/frontend/src/lib/pagination/use-entity-cards-connection.ts
+++ b/frontend/src/lib/pagination/use-entity-cards-connection.ts
@@ -3,6 +3,7 @@
 import type { OperationVariables, TypedDocumentNode } from "@apollo/client";
 import { useCallback, useMemo } from "react";
 import { getBackendErrorBanner } from "@/lib/apollo/errors";
+import { makeMergeConnection } from "@/lib/pagination/make-merge-connection";
 import {
   type UseConnectionPaginationResult,
   useConnectionPagination,
@@ -148,19 +149,11 @@ export function useEntityCardsConnection<
   );
 
   // Concatenate the next page's edges onto the cached connection under the
-  // config's connection field.
-  const mergeConnection = useCallback(
-    (prev: TData, more: TData): TData => {
-      const prevConn = prev[connectionField] as ConnectionShape<TEdge, TPageInfo>;
-      const moreConn = more[connectionField] as ConnectionShape<TEdge, TPageInfo>;
-      return {
-        ...more,
-        [connectionField]: {
-          ...moreConn,
-          edges: [...prevConn.edges, ...moreConn.edges],
-        },
-      } as TData;
-    },
+  // config's connection field. Memoized on `connectionField` so the reducer
+  // identity stays stable across renders — `useConnectionPagination` feeds it
+  // into a `useCallback` dependency array.
+  const mergeConnection = useMemo(
+    () => makeMergeConnection<TData>(connectionField),
     [connectionField],
   );
 


### PR DESCRIPTION
## Summary

Every cursor-paginated list in the app appends the next page by concatenating the incoming edges onto the cached ones, and that three-line reducer had been written out five times — once generically inside `use-entity-cards-connection.ts` and four more times by hand, one per screen. This extracts the generic version into `frontend/src/lib/pagination/make-merge-connection.ts` and routes all five sites through it, so a future change to the merge (deduplication, cursor handling, a `pageInfo` fix) lands in one place instead of drifting across four copies. No user-visible behaviour change.

## Changes

### New shared factory

- `frontend/src/lib/pagination/make-merge-connection.ts` (new) — `makeMergeConnection<TData>(connectionField: keyof TData): (prev, more) => TData`. The body is exactly the generalisation that already lived in `use-entity-cards-connection.ts`: spread `...more` at the top level, then override `[connectionField]` with `{ ...moreConn, edges: [...prevConn.edges, ...moreConn.edges] }`. It declares a minimal local `EdgesSlice` cast target rather than exporting either of the two private `ConnectionShape` interfaces (`use-connection-pagination.ts:38`, `use-entity-cards-connection.ts:30`) — unifying those is out of scope for this issue and neither was touched. The docblock states the referential-stability contract explicitly: the returned function is a fresh identity per call and `useConnectionPagination` feeds `mergeConnection` into a `useCallback` dep array, so callers must hold one instance.

### Call sites routed through it

- `frontend/src/lib/pagination/use-entity-cards-connection.ts` — the inline `useCallback` reducer became `useMemo(() => makeMergeConnection<TData>(connectionField), [connectionField])`, keeping the same memo key so the identity behaviour is unchanged. `ConnectionShape<TEdge, TPageInfo>` stays in the file; it is still the cast target for `selectConnection` at `:167`.
- `frontend/src/app/catalog/queries.ts` — `mergeCatalogConnection` stays an exported symbol with the same name and signature, now `= makeMergeConnection<MasterCatalogQueryData>("masterCatalog")`. Keeping the export means its two consumers (`catalog/catalog-client.tsx:97` and `components/cardgroups/merge-from-catalog-sheet.tsx:142`) still share one instance on a shared cache key and stay out of the diff entirely.
- `frontend/src/app/cardgroups/cardgroups-client.tsx` — `mergeCardgroupsConnection` (`myCardgroupsConnection`).
- `frontend/src/app/admin/users/admin-users-client.tsx` — `mergeUsersConnection` (`users`).
- `frontend/src/app/admin/masters/admin-masters-client.tsx` — `mergeMastersConnection` (`adminMasters`).

All four screen reducers are module-level `const`s, not created per render — a naive inline `makeMergeConnection("users")` in the component body would produce a new identity each render and feed `useConnectionPagination`'s dep array.

### Behavioural note carried deliberately

The four hand-rolled copies returned an object containing *only* the connection field; the factory spreads `...more`. Every one of the four query result types has a single top-level field, so the two shapes agree today, but the spread is the safer generalisation and is what survives. `make-merge-connection.test.ts` pins that difference explicitly.

### Tests and docs

- `frontend/src/lib/pagination/make-merge-connection.test.ts` (new, 5 tests) — edge concatenation order (`prev` then `more`); `pageInfo` / `totalCount` / `__typename` taken from the incoming page; neither input mutated; a sibling top-level field carried through from `more` (the spread behaviour above); and `makeMergeConnection(...) !== makeMergeConnection(...)`, which is the assertion that documents why every consumer holds a module-level or memoized instance.
- `docs/pagination/migrate-list-screen-to-shared-hook.md` — step 1 now tells a migrating screen to build `mergeConnection` from the factory and hold it at module scope, instead of hand-rolling the concat.

No existing test was modified: the five screens' fetch-more tests pass unchanged, which is the behaviour-equivalence proof.

## Verification

The post-flight greps from the issue's acceptance criteria, run in the worktree:

- `grep -rn 'edges: \[\.\.\.prev\.' frontend/src --include='*.ts' --include='*.tsx' | grep -v '\.test\.'` — **0 hits**. (The issue predicted one, inside the helper; the helper's concat reads `[...prevConn.edges, ...moreConn.edges]` off the local cast variables, so it does not match the `prev.` pattern. Zero is the correct outcome: no hand-rolled copy remains.)
- `grep -rn 'makeMergeConnection' frontend/src | grep -v '\.test\.'` — 11 lines: the declaration plus **5 production callers** (`catalog/queries.ts`, `cardgroups-client.tsx`, `admin-users-client.tsx`, `admin-masters-client.tsx`, `use-entity-cards-connection.ts`), each with its import. This matches the planned count, so the route-through did not stop short.

## Test plan

- [ ] `./node_modules/.bin/tsc --noEmit` — exit 0, no diagnostics
- [ ] `./node_modules/.bin/biome check --error-on-warnings .` — exit 0, 526 files checked, no fixes applied (the 2 emitted "infos" are the pre-existing biome-version-mismatch / deprecated-`linter` notices in `biome.json`, not findings against changed files)
- [ ] `./node_modules/.bin/vitest run` — 210 test files passed, 1962 tests passed, 0 failed
- [ ] `./node_modules/.bin/knip` — exit 0 (the new module is reachable from 5 production importers, so it is not reported as unused)
- [ ] `./node_modules/.bin/next build` — succeeded, full route table emitted

## Notes

Production diff (`git diff --shortstat origin/main...HEAD -- '*.go' '*.ts' '*.tsx' ':!*_test.go' ':!*.test.ts' ':!*.test.tsx'`) is 6 files, 74 insertions / 61 deletions — well under the 800-line ceiling.

Issue line numbers had drifted by +1 in all four cited declaration sites (`catalog/queries.ts:45-56`, `cardgroups-client.tsx:50-61`, `admin-users-client.tsx:53-64`, `admin-masters-client.tsx:41-52`), and the `mergeConnection` contract the issue cites at `use-connection-pagination.ts:51` is at `:70`. All bodies were byte-identical to the issue's quoted shape; the drift changed nothing about the work.

The issue's stated dependency on #1027 is already satisfied — that issue is closed and `cardgroups-client.tsx` on `main` already reflects it, so no rebase or ordering constraint applies.

`grep -rn mergeCatalogConnection frontend/src frontend/__tests__` confirmed no test imports the exported symbol before the change, so keeping the export name was a free choice rather than a forced one — it was kept so the two catalog consumers stay on one shared instance and out of the diff.

Closes #1048
