### PR TITLE
refactor(backend): guard FSRS stability, difficulty and phase on read

### DIFF
--- a/backend/internal/domain/fsrs_state.go
+++ b/backend/internal/domain/fsrs_state.go
@@ -1,6 +1,7 @@
 package domain
 
 import (
+	"math"
 	"time"
 )
 
@@ -22,6 +23,33 @@ func (p FSRSPhase) IsValid() bool {
 	return p >= FSRSPhaseNew && p <= FSRSPhaseRelearning
 }
 
+// MinDifficulty and MaxDifficulty bound the FSRS difficulty scale. go-fsrs
+// clamps every difficulty it produces into this closed range, and
+// NewCardDifficulty sits mid-scale, so no difficulty the application persists
+// can fall outside it.
+const (
+	MinDifficulty = 1.0
+	MaxDifficulty = 10.0
+)
+
+// IsValidStability reports whether s is a stability the scheduler can produce:
+// finite and strictly positive. The check exists because NaN and the infinities
+// fail every ordered comparison silently — an unchecked NaN stability falls
+// through both ClassifyMastery comparisons and is reported as the Learned tier,
+// and it breaks JSON marshalling of the GraphQL Float it feeds.
+func IsValidStability(s float64) bool {
+	if math.IsNaN(s) || math.IsInf(s, 0) {
+		return false
+	}
+	return s > 0
+}
+
+// IsValidDifficulty reports whether d sits within [MinDifficulty, MaxDifficulty].
+// NaN and the infinities fail the comparison and are therefore rejected too.
+func IsValidDifficulty(d float64) bool {
+	return d >= MinDifficulty && d <= MaxDifficulty
+}
+
 // FSRSState is an immutable value object. Repository code persists it as a
 // flat column block, but domain consumers treat it as one scheduling state.
 type FSRSState struct {
@@ -39,12 +67,23 @@ type FSRSState struct {
 	LastRating Rating
 }
 
+// NewCardStability and NewCardDifficulty are the placeholder scheduling values a
+// card carries until its first review. The scheduler overwrites both on that
+// first review, so neither ever influences a computed interval: they exist so a
+// never-reviewed card has a displayable, in-range state, and so the first swipe
+// records a non-zero StabilityBefore snapshot (which the statistics known-review
+// gate reads).
+const (
+	NewCardStability  = 2.5
+	NewCardDifficulty = 5.0
+)
+
 // NewFSRSStateForNewCard returns the initial scheduling state for a new card.
 func NewFSRSStateForNewCard(now time.Time) FSRSState {
 	return FSRSState{
 		Due:        now,
-		Stability:  2.5,
-		Difficulty: 5.0,
+		Stability:  NewCardStability,
+		Difficulty: NewCardDifficulty,
 		Phase:      FSRSPhaseNew,
 		LastReview: now,
 	}

--- a/backend/internal/domain/fsrs_state_test.go
+++ b/backend/internal/domain/fsrs_state_test.go
@@ -1,0 +1,71 @@
+package domain
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestIsValidStability pins both sides of the stability predicate. The accept
+// side matters as much as the reject side: the repository read guard hard-fails
+// a whole query on a false negative, so a narrowing of the predicate must break
+// a test here rather than a persisted user's read.
+func TestIsValidStability(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input float64
+		want  bool
+	}{
+		{"new card placeholder", NewCardStability, true},
+		{"smallest positive", math.SmallestNonzeroFloat64, true},
+		{"large finite", math.MaxFloat64, true},
+		{"zero", 0, false},
+		{"negative", -1.5, false},
+		{"NaN", math.NaN(), false},
+		{"positive infinity", math.Inf(1), false},
+		{"negative infinity", math.Inf(-1), false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, IsValidStability(tc.input))
+		})
+	}
+}
+
+// TestIsValidDifficulty pins the closed [MinDifficulty, MaxDifficulty] range,
+// including both inclusive endpoints. The endpoints are load-bearing: go-fsrs
+// clamps difficulty with math.Min(math.Max(d, 1), 10), so exactly 1.0 and
+// exactly 10.0 are values the scheduler legitimately emits and persists.
+// Narrowing the bounds to an open range would reject those rows.
+func TestIsValidDifficulty(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input float64
+		want  bool
+	}{
+		{"minimum boundary", MinDifficulty, true},
+		{"maximum boundary", MaxDifficulty, true},
+		{"new card placeholder", NewCardDifficulty, true},
+		{"just below minimum", 0.5, false},
+		{"just above maximum", 10.5, false},
+		{"zero", 0, false},
+		{"negative", -1, false},
+		{"NaN", math.NaN(), false},
+		{"positive infinity", math.Inf(1), false},
+		{"negative infinity", math.Inf(-1), false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, IsValidDifficulty(tc.input))
+		})
+	}
+}

--- a/backend/internal/domain/service/fsrs_scheduler.go
+++ b/backend/internal/domain/service/fsrs_scheduler.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"fmt"
 	"time"
 
 	fsrs "github.com/open-spaced-repetition/go-fsrs/v3"
@@ -21,7 +22,21 @@ func NewFSRSScheduler() *FSRSScheduler {
 }
 
 // Apply returns a fresh state and does not mutate the input state.
+//
+// It panics when state.Phase is not a recognised FSRSPhase. The fsrs.State cast
+// below feeds a library dispatch that has no default arm, so an unrecognised
+// phase would produce a zero-valued scheduling result and silently wipe the
+// card's state. Panicking rather than returning an error keeps the single-value
+// signature of the domain.FSRSScheduler consumer interface: no caller can build
+// an invalid phase — Phase is only ever set by this method or reconstituted by
+// the repository, whose read guard already rejects an unrecognised persisted
+// value — so this is a programmer-error guard of the same kind as the
+// constructor panic in domain.NewUserCardFSRSForNewCard.
 func (s *FSRSScheduler) Apply(state domain.FSRSState, rating domain.Rating, now time.Time) domain.FSRSState {
+	if !state.Phase.IsValid() {
+		panic(fmt.Sprintf("service: fsrs scheduler: invalid FSRSPhase %d", int(state.Phase)))
+	}
+
 	// A backward clock step (NTP, cross-instance skew) would make the library's
 	// elapsed-days float negative; the float->uint64 conversion of a negative
 	// value is implementation-dependent (Go spec, Conversions) and corrupts the

--- a/backend/internal/domain/service/fsrs_scheduler_test.go
+++ b/backend/internal/domain/service/fsrs_scheduler_test.go
@@ -24,6 +24,43 @@ func TestFSRSSchedulerApplyIsPure(t *testing.T) {
 	require.Equal(t, domain.RatingEasy, got.LastRating)
 }
 
+// TestFSRSScheduler_Apply_InvalidPhasePanics pins the guard in front of the
+// fsrs.State cast. The library dispatches on that value with no default arm, so
+// an unrecognised phase would return a zero-valued scheduling result and
+// silently wipe the card's state instead of failing. No caller can construct an
+// invalid phase today — this is a programmer-error guard, so it panics rather
+// than widening the domain.FSRSScheduler signature to return an error.
+func TestFSRSScheduler_Apply_InvalidPhasePanics(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 4, 26, 0, 0, 0, 0, time.UTC)
+	scheduler := NewFSRSScheduler()
+
+	for _, phase := range []domain.FSRSPhase{-1, 4, 99} {
+		state := domain.NewFSRSStateForNewCard(now.Add(-24 * time.Hour))
+		state.Phase = phase
+
+		require.Panics(t, func() {
+			scheduler.Apply(state, domain.RatingGood, now)
+		}, "an unrecognised FSRSPhase must fail loudly, not schedule from a zero-valued result")
+	}
+
+	// Every recognised phase still schedules normally.
+	for _, phase := range []domain.FSRSPhase{
+		domain.FSRSPhaseNew,
+		domain.FSRSPhaseLearning,
+		domain.FSRSPhaseReview,
+		domain.FSRSPhaseRelearning,
+	} {
+		state := domain.NewFSRSStateForNewCard(now.Add(-24 * time.Hour))
+		state.Phase = phase
+
+		require.NotPanics(t, func() {
+			scheduler.Apply(state, domain.RatingGood, now)
+		})
+	}
+}
+
 func TestFSRSScheduler_Apply_BackwardClockSkewClamped(t *testing.T) {
 	t.Parallel()
 

--- a/backend/internal/repository/master_cardgroup.go
+++ b/backend/internal/repository/master_cardgroup.go
@@ -163,13 +163,18 @@ func findMasterCardgroupByID(db *gorm.DB, id string) (*domain.MasterCardgroup, e
 // literal 'master' namespace plus the name to serialize lookup-then-insert
 // without adding a DB-level constraint. Master cardgroups have no owner.
 //
-// name is parsed through domain.ParseCardgroupName before anything else, so an
-// empty or over-cap name fails as a typed domain sentinel
-// (domain.ErrCardgroupNameRequired / domain.ErrCardgroupNameTooLong) instead of
-// reaching the database and dying on the name-length CHECK as an unclassified
-// constraint violation. The parsed (trimmed) value is what the advisory lock,
-// the lookup and the insert all key on, so the row this method creates is always
-// the row a repeat call finds.
+// name is parsed through domain.ParseCardgroupName before anything else, so the
+// domain grapheme cap (domain.CardgroupNameMax) is what bounds a stored master
+// cardgroup name, not the far wider master_cardgroups_name_length CHECK
+// (1..2000 code points). The two previously disagreed: a blank name died on the
+// CHECK's lower bound as an unclassified constraint violation, while an over-cap
+// name between the grapheme cap and the CHECK's upper bound was persisted
+// silently. Both now fail up front as typed domain sentinels
+// (domain.ErrCardgroupNameRequired / domain.ErrCardgroupNameTooLong). The only
+// production caller parses the name itself before calling, so this is defence in
+// depth rather than a reachable behaviour change. The parsed (trimmed) value is
+// what the advisory lock, the lookup and the insert all key on, so the row this
+// method creates is always the row a repeat call finds.
 func (r *masterCardgroupRepo) EnsureByName(ctx context.Context, name string) (*domain.MasterCardgroup, error) {
 	cgName, err := domain.ParseCardgroupName(name)
 	if err != nil {

--- a/backend/internal/repository/master_cardgroup.go
+++ b/backend/internal/repository/master_cardgroup.go
@@ -162,15 +162,29 @@ func findMasterCardgroupByID(db *gorm.DB, id string) (*domain.MasterCardgroup, e
 // rows. This method takes a transaction-scoped advisory lock keyed on the
 // literal 'master' namespace plus the name to serialize lookup-then-insert
 // without adding a DB-level constraint. Master cardgroups have no owner.
+//
+// name is parsed through domain.ParseCardgroupName before anything else, so an
+// empty or over-cap name fails as a typed domain sentinel
+// (domain.ErrCardgroupNameRequired / domain.ErrCardgroupNameTooLong) instead of
+// reaching the database and dying on the name-length CHECK as an unclassified
+// constraint violation. The parsed (trimmed) value is what the advisory lock,
+// the lookup and the insert all key on, so the row this method creates is always
+// the row a repeat call finds.
 func (r *masterCardgroupRepo) EnsureByName(ctx context.Context, name string) (*domain.MasterCardgroup, error) {
+	cgName, err := domain.ParseCardgroupName(name)
+	if err != nil {
+		return nil, eris.Wrap(err, "repository: master cardgroup: ensure by name: parse name")
+	}
+	canonical := cgName.String()
+
 	var out *domain.MasterCardgroup
-	err := r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		if err := tx.Exec("SELECT pg_advisory_xact_lock(hashtext(?), hashtext(?))", "master", name).Error; err != nil {
+	err = r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Exec("SELECT pg_advisory_xact_lock(hashtext(?), hashtext(?))", "master", canonical).Error; err != nil {
 			return eris.Wrap(err, "repository: master cardgroup: ensure by name: advisory lock")
 		}
 
 		var row gormMasterCardgroup
-		err := tx.Where("name = ?", name).Take(&row).Error
+		err := tx.Where("name = ?", canonical).Take(&row).Error
 		if err == nil {
 			out, err = masterCardgroupToDomain(row)
 			return err
@@ -179,7 +193,7 @@ func (r *masterCardgroupRepo) EnsureByName(ctx context.Context, name string) (*d
 			return eris.Wrap(err, "repository: master cardgroup: ensure by name: lookup")
 		}
 
-		m, err := domain.NewMasterCardgroup(domain.CardgroupName(name), domain.Description{}, false, 0)
+		m, err := domain.NewMasterCardgroup(cgName, domain.Description{}, false, 0)
 		if err != nil {
 			return eris.Wrap(err, "repository: master cardgroup: ensure by name: construct")
 		}

--- a/backend/internal/repository/master_cardgroup_test.go
+++ b/backend/internal/repository/master_cardgroup_test.go
@@ -8,6 +8,7 @@ package repository_test
 import (
 	"context"
 	"errors"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -165,6 +166,66 @@ func TestMasterCardgroupRepository_EnsureByName_DifferentNames_DifferentIDs(t *t
 	require.NoError(t, err)
 
 	require.NotEqual(t, a.ID, b.ID, "different names must yield different IDs")
+}
+
+// TestMasterCardgroupRepository_EnsureByName_InvalidName proves EnsureByName
+// routes its name through domain.ParseCardgroupName before touching the
+// database: an over-cap or blank name fails as the typed domain sentinel rather
+// than reaching the insert and dying on the name-length CHECK as an
+// unclassified constraint violation.
+func TestMasterCardgroupRepository_EnsureByName_InvalidName(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	repo := repository.NewMasterCardgroupRepository(testDB.GORM)
+
+	cases := []struct {
+		name         string
+		input        string
+		wantSentinel error
+	}{
+		{
+			name:         "over cap",
+			input:        strings.Repeat("a", domain.CardgroupNameMax+1),
+			wantSentinel: domain.ErrCardgroupNameTooLong,
+		},
+		{
+			name:         "blank",
+			input:        "   ",
+			wantSentinel: domain.ErrCardgroupNameRequired,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := repo.EnsureByName(ctx, tc.input)
+			require.Nil(t, got)
+			require.ErrorIs(t, err, tc.wantSentinel,
+				"an invalid name must surface the domain sentinel, not a database constraint error")
+		})
+	}
+}
+
+// TestMasterCardgroupRepository_EnsureByName_TrimsName pins that the parsed
+// (trimmed) name is what the lookup and the insert both key on, so a
+// whitespace-padded name resolves to the same row as its trimmed form instead of
+// creating a second one.
+func TestMasterCardgroupRepository_EnsureByName_TrimsName(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	repo := repository.NewMasterCardgroupRepository(testDB.GORM)
+
+	name := "Ensure Trim " + uuid.NewString()
+
+	first, err := repo.EnsureByName(ctx, name)
+	require.NoError(t, err)
+	require.Equal(t, name, first.Name.String())
+
+	padded, err := repo.EnsureByName(ctx, "  "+name+"  ")
+	require.NoError(t, err)
+	require.Equal(t, first.ID, padded.ID,
+		"a whitespace-padded name must resolve to the row its trimmed form created")
 }
 
 func TestMasterCardgroupRepository_EnsureByName_Race(t *testing.T) {

--- a/backend/internal/repository/master_cardgroup_test.go
+++ b/backend/internal/repository/master_cardgroup_test.go
@@ -170,9 +170,11 @@ func TestMasterCardgroupRepository_EnsureByName_DifferentNames_DifferentIDs(t *t
 
 // TestMasterCardgroupRepository_EnsureByName_InvalidName proves EnsureByName
 // routes its name through domain.ParseCardgroupName before touching the
-// database: an over-cap or blank name fails as the typed domain sentinel rather
-// than reaching the insert and dying on the name-length CHECK as an
-// unclassified constraint violation.
+// database, so the domain grapheme cap bounds the stored name rather than the
+// far wider master_cardgroups_name_length CHECK (1..2000 code points). A blank
+// name previously died on that CHECK's lower bound as an unclassified
+// constraint violation; a 101-code-point over-cap name sat inside the CHECK and
+// was persisted silently. Both now surface the typed domain sentinel instead.
 func TestMasterCardgroupRepository_EnsureByName_InvalidName(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/backend/internal/repository/user_card_fsrs.go
+++ b/backend/internal/repository/user_card_fsrs.go
@@ -198,10 +198,24 @@ func userCardFSRSLastRating(state domain.FSRSState) *int {
 	return &rating
 }
 
+// userCardFSRSToDomain reconstitutes a persisted row into the domain aggregate.
+// Every column that the domain constrains is re-checked here rather than trusted:
+// the table carries no CHECK constraints, so a row edited outside the application
+// is the one way an out-of-range value can reach the domain. Rejecting is
+// deliberate — a corrupted stability would otherwise be classified as the Learned
+// mastery tier (NaN fails both ClassifyMastery comparisons) or break JSON
+// marshalling of the GraphQL Float it feeds, both of which are harder to diagnose
+// than a failed read.
 func userCardFSRSToDomain(row gormUserCardFSRS) (*domain.UserCardFSRS, error) {
 	state := domain.FSRSPhase(row.State)
 	if !state.IsValid() {
 		return nil, eris.Errorf("repository: invalid FSRSPhase value %d for card %s", row.State, row.CardID)
+	}
+	if !domain.IsValidStability(row.Stability) {
+		return nil, eris.Errorf("repository: invalid stability value %v for card %s", row.Stability, row.CardID)
+	}
+	if !domain.IsValidDifficulty(row.Difficulty) {
+		return nil, eris.Errorf("repository: invalid difficulty value %v for card %s", row.Difficulty, row.CardID)
 	}
 	lastRating := domain.Rating(0)
 	if row.LastRating != nil {

--- a/backend/internal/repository/user_card_fsrs.go
+++ b/backend/internal/repository/user_card_fsrs.go
@@ -76,6 +76,14 @@ func (r *userCardFSRSRepo) UpsertTx(ctx context.Context, tx *gorm.DB, u *domain.
 // ListFSRSStatesByUser returns one row per studied card for userID, joined to
 // cards for the owning cardgroup. WHERE user_card_fsrs.user_id = ? is backed by
 // the (user_id, card_id) PK.
+//
+// Phase and stability are re-checked per row, mirroring the userCardFSRSToDomain
+// guards used by FindByUserAndCardIDs. Stability is the load-bearing one on this
+// path: domain.ClassifyMastery is fed exclusively from this projection, and a
+// NaN stability falls through both of its comparisons and is reported as the
+// Learned mastery tier, besides breaking JSON marshalling of the GraphQL Float
+// StrugglingCard.stability feeds. FSRSStat carries no difficulty column, so
+// there is nothing to check for it here.
 func (r *userCardFSRSRepo) ListFSRSStatesByUser(ctx context.Context, userID string) ([]domain.FSRSStat, error) {
 	var rows []domain.FSRSStat
 	err := r.db.WithContext(ctx).
@@ -90,6 +98,9 @@ func (r *userCardFSRSRepo) ListFSRSStatesByUser(ctx context.Context, userID stri
 	for i := range rows {
 		if !rows[i].Phase.IsValid() {
 			return nil, eris.Errorf("repository: user card fsrs: invalid FSRSPhase value %d for card %s", int(rows[i].Phase), rows[i].CardID)
+		}
+		if !domain.IsValidStability(rows[i].Stability) {
+			return nil, eris.Errorf("repository: user card fsrs: invalid stability value %v for card %s", rows[i].Stability, rows[i].CardID)
 		}
 	}
 	return rows, nil
@@ -202,10 +213,11 @@ func userCardFSRSLastRating(state domain.FSRSState) *int {
 // Every column that the domain constrains is re-checked here rather than trusted:
 // the table carries no CHECK constraints, so a row edited outside the application
 // is the one way an out-of-range value can reach the domain. Rejecting is
-// deliberate — a corrupted stability would otherwise be classified as the Learned
-// mastery tier (NaN fails both ClassifyMastery comparisons) or break JSON
-// marshalling of the GraphQL Float it feeds, both of which are harder to diagnose
-// than a failed read.
+// deliberate — a corrupted stability or difficulty would otherwise reach the
+// UserCardState GraphQL Floats it feeds and break JSON marshalling of the whole
+// response, which is harder to diagnose than a failed read. The sibling
+// ListFSRSStatesByUser carries the matching stability guard for the /stats
+// projection, which is the path domain.ClassifyMastery consumes.
 func userCardFSRSToDomain(row gormUserCardFSRS) (*domain.UserCardFSRS, error) {
 	state := domain.FSRSPhase(row.State)
 	if !state.IsValid() {

--- a/backend/internal/repository/user_card_fsrs_test.go
+++ b/backend/internal/repository/user_card_fsrs_test.go
@@ -80,6 +80,63 @@ func TestUserCardFSRSRepository_FindByUserAndCardIDs_InvalidLastRating(t *testin
 	require.ErrorContains(t, err, "repository: invalid last_rating value 9 for card "+card.ID)
 }
 
+// TestUserCardFSRSRepository_FindByUserAndCardIDs_InvalidStabilityOrDifficulty
+// proves the reconstitution guard rejects a persisted stability the scheduler
+// can never produce (non-finite or non-positive) and a difficulty outside the
+// [MinDifficulty, MaxDifficulty] FSRS scale. Neither column carries a CHECK
+// constraint and no application write path yields such a value, so raw SQL is
+// the only way to seed one — the guard is defence in depth against a row edited
+// outside the application. Without it a NaN stability reconstitutes silently and
+// is classified as the Learned mastery tier (NaN fails both ClassifyMastery
+// comparisons) and breaks JSON marshalling of the GraphQL Float it feeds.
+func TestUserCardFSRSRepository_FindByUserAndCardIDs_InvalidStabilityOrDifficulty(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	ownerID := insertAuthUser(t, ctx)
+	cg := insertCardgroup(t, ctx, ownerID)
+	cardRepo := repository.NewCardRepository(testDB.GORM)
+	ucsRepo := repository.NewUserCardFSRSRepository(testDB.GORM)
+
+	cases := []struct {
+		name string
+		// stability and difficulty are SQL literals so the non-finite values can
+		// be seeded exactly as Postgres stores them in a double precision column.
+		stability  string
+		difficulty string
+		wantErr    string
+	}{
+		{name: "stability_nan", stability: "'NaN'", difficulty: "5.0", wantErr: "repository: invalid stability value"},
+		{name: "stability_positive_infinity", stability: "'Infinity'", difficulty: "5.0", wantErr: "repository: invalid stability value"},
+		{name: "stability_negative_infinity", stability: "'-Infinity'", difficulty: "5.0", wantErr: "repository: invalid stability value"},
+		{name: "stability_zero", stability: "0", difficulty: "5.0", wantErr: "repository: invalid stability value"},
+		{name: "stability_negative", stability: "-1.5", difficulty: "5.0", wantErr: "repository: invalid stability value"},
+		{name: "difficulty_below_scale", stability: "6.9", difficulty: "0.5", wantErr: "repository: invalid difficulty value"},
+		{name: "difficulty_above_scale", stability: "6.9", difficulty: "10.5", wantErr: "repository: invalid difficulty value"},
+		{name: "difficulty_nan", stability: "6.9", difficulty: "'NaN'", wantErr: "repository: invalid difficulty value"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			card := newCard(cg.ID, "fsrs-range-"+tc.name, "back")
+			require.NoError(t, cardRepo.Create(ctx, card))
+
+			now := time.Now().UTC().Truncate(time.Microsecond)
+			_, err := sqlDBHandle(t).ExecContext(ctx,
+				`INSERT INTO public.user_card_fsrs
+					(user_id, card_id, state, due, stability, difficulty, reps, lapses, last_review, last_rating, elapsed_days, scheduled_days)
+				 VALUES ($1, $2, $3, $4, `+tc.stability+`::double precision, `+tc.difficulty+`::double precision, 1, 0, $4, NULL, 1, 1)`,
+				ownerID, card.ID, int(domain.FSRSPhaseReview), now)
+			require.NoError(t, err, "seed an out-of-range scheduling row via raw SQL")
+
+			_, err = ucsRepo.FindByUserAndCardIDs(ctx, ownerID, []string{card.ID})
+			require.ErrorContains(t, err, tc.wantErr)
+			require.ErrorContains(t, err, card.ID, "the rejection must name the offending card")
+		})
+	}
+}
+
 // TestUserCardFSRSRepository_OnCardDelete_CascadesFSRSRow proves the
 // user_card_fsrs.card_id -> cards(id) FK is ON DELETE CASCADE: deleting a card
 // removes every user's FSRS row for it. This is the runtime behaviour that

--- a/backend/internal/repository/user_card_fsrs_test.go
+++ b/backend/internal/repository/user_card_fsrs_test.go
@@ -87,8 +87,9 @@ func TestUserCardFSRSRepository_FindByUserAndCardIDs_InvalidLastRating(t *testin
 // constraint and no application write path yields such a value, so raw SQL is
 // the only way to seed one — the guard is defence in depth against a row edited
 // outside the application. Without it a NaN stability reconstitutes silently and
-// is classified as the Learned mastery tier (NaN fails both ClassifyMastery
-// comparisons) and breaks JSON marshalling of the GraphQL Float it feeds.
+// breaks JSON marshalling of the UserCardState GraphQL Float it feeds. The
+// mastery-tier harm travels through the sibling ListFSRSStatesByUser projection,
+// which carries its own stability guard.
 func TestUserCardFSRSRepository_FindByUserAndCardIDs_InvalidStabilityOrDifficulty(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
@@ -342,6 +343,58 @@ func TestUserCardFSRSRepository_ListFSRSStatesByUser_InvalidPhaseErrors(t *testi
 
 	_, err = ucsRepo.ListFSRSStatesByUser(ctx, ownerID)
 	require.Error(t, err, "an invalid persisted FSRSPhase must be rejected, not silently reconstituted")
+}
+
+// TestUserCardFSRSRepository_ListFSRSStatesByUser_InvalidStabilityErrors proves
+// the stability guard mirrors the userCardFSRSToDomain one on the /stats
+// projection. This is the path domain.ClassifyMastery consumes, so an unchecked
+// NaN would be silently bucketed into the Learned mastery tier (NaN fails both
+// of its comparisons) and would break JSON marshalling of the GraphQL Float
+// StrugglingCard.stability feeds. Raw SQL is the only way to seed such a value:
+// the column carries no CHECK constraint and no application write path yields
+// one.
+func TestUserCardFSRSRepository_ListFSRSStatesByUser_InvalidStabilityErrors(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	cases := []struct {
+		name string
+		// stability is a SQL literal so the non-finite values can be seeded
+		// exactly as Postgres stores them in a double precision column.
+		stability string
+	}{
+		{name: "nan", stability: "'NaN'"},
+		{name: "positive_infinity", stability: "'Infinity'"},
+		{name: "negative_infinity", stability: "'-Infinity'"},
+		{name: "zero", stability: "0"},
+		{name: "negative", stability: "-1.5"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ownerID := insertAuthUser(t, ctx)
+			cg := insertCardgroupForUser(t, ctx, ownerID, "Invalid Stability Deck "+tc.name)
+			cardRepo := repository.NewCardRepository(testDB.GORM)
+			ucsRepo := repository.NewUserCardFSRSRepository(testDB.GORM)
+
+			card := newCard(domain.CardgroupID(cg), "bad-stability-"+tc.name, "back")
+			require.NoError(t, cardRepo.Create(ctx, card))
+
+			now := time.Now().UTC().Truncate(time.Microsecond)
+			_, err := sqlDBHandle(t).ExecContext(ctx,
+				`INSERT INTO public.user_card_fsrs
+					(user_id, card_id, state, due, stability, difficulty, reps, lapses, last_review, elapsed_days, scheduled_days)
+				 VALUES ($1, $2, $3, $4, `+tc.stability+`::double precision, 5.0, 1, 0, $4, 1, 1)`,
+				ownerID, card.ID, int(domain.FSRSPhaseReview), now)
+			require.NoError(t, err, "seed a row with an invalid stability value via raw SQL")
+
+			_, err = ucsRepo.ListFSRSStatesByUser(ctx, ownerID)
+			require.ErrorContains(t, err, "repository: user card fsrs: invalid stability value",
+				"an invalid persisted stability must be rejected, not fed to ClassifyMastery")
+		})
+	}
 }
 
 // TestUserCardFSRSRepository_CountCardsByCardgroupForUser_ScopesByOwner proves

--- a/backend/internal/usecase/validators.go
+++ b/backend/internal/usecase/validators.go
@@ -62,8 +62,11 @@ func translateBioErr(err error) error {
 }
 
 // translateCardErr maps domain Card sentinels into usecase-layer typed errors.
-// Unexpected errors are wrapped with eris.
+// Unexpected errors are wrapped with eris. Returns nil when err is nil.
 func translateCardErr(err error) error {
+	if err == nil {
+		return nil
+	}
 	switch {
 	case errors.Is(err, domain.ErrCardFrontRequired):
 		return ucerr.NewValidationError("front", "front is required")

--- a/backend/internal/usecase/validators_test.go
+++ b/backend/internal/usecase/validators_test.go
@@ -113,6 +113,63 @@ func TestValidateRelayArgs(t *testing.T) {
 	}
 }
 
+// TestTranslateCardErr pins the nil guard that keeps translateCardErr consistent
+// with its siblings: without it a nil error falls to the default arm and is
+// wrapped as an "unexpected domain error", turning a success into an INTERNAL
+// failure. The sentinel and unexpected-error arms are covered alongside it so
+// the guard cannot be added by short-circuiting the whole switch.
+func TestTranslateCardErr(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		input     error
+		wantField string
+		wantMsg   string
+		wantChain string
+	}{
+		{
+			name:  "nil passes through",
+			input: nil,
+		},
+		{
+			name:      "front required sentinel",
+			input:     domain.ErrCardFrontRequired,
+			wantField: "front",
+			wantMsg:   "front is required",
+		},
+		{
+			name:      "back too-long sentinel",
+			input:     domain.ErrCardBackTooLong,
+			wantField: "back",
+			wantMsg:   fmt.Sprintf("back must be at most %d characters", domain.CardTextMax),
+		},
+		{
+			name:      "unexpected error wraps as internal",
+			input:     errors.New("surprise"),
+			wantChain: "usecase: translate card err: unexpected domain error",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := translateCardErr(tc.input)
+
+			switch {
+			case tc.input == nil:
+				require.NoError(t, err, "a nil error must not be wrapped as an unexpected domain error")
+			case tc.wantChain != "":
+				assertInternalChain(t, err, tc.wantChain)
+			default:
+				require.Error(t, err)
+				assertValidationError(t, err, tc.wantField, tc.wantMsg)
+			}
+		})
+	}
+}
+
 // TestTranslateBioErr and TestTranslateDescriptionErr pin the thin wrappers over
 // the shared translateTrinaryTextErr body: nil passes through, the too-long
 // sentinel maps to a field-scoped ValidationError with the exact message, and any


### PR DESCRIPTION
## Summary

Four independent, file-disjoint consistency fixes across the domain and repository layers. Two of them add rejection paths at seams that already reject their neighbouring fields — the spaced-repetition read guard validated `Phase` and `LastRating` but let `Stability` and `Difficulty` through unchecked, and the scheduler wrapper cast an unvalidated `FSRSPhase` into a go-fsrs dispatch that has no default arm. The other two are cosmetic-but-real: two magic numbers that reach GraphQL without saying what they mean, and two guards a sibling function already had. None of the four is reachable from an application write path today; all four are defence in depth at the layer that owns the value.

## Changes

### Spaced-repetition read guard (`repository/user_card_fsrs.go`, `domain/fsrs_state.go`)

- `domain.IsValidStability(float64) bool` — finite and strictly positive. NaN and the infinities fail every ordered comparison silently, so they cannot be rejected by a naive range test.
- `domain.IsValidDifficulty(float64) bool` over new `MinDifficulty = 1.0` / `MaxDifficulty = 10.0` constants. The bounds come from go-fsrs `constrainDifficulty` (`parameters.go:56-58`, `math.Min(math.Max(d, 1), 10)`), so both endpoints are values the scheduler legitimately emits — the range is closed, not open.
- `userCardFSRSToDomain` rejects an invalid stability or difficulty with the same `eris.Errorf("repository: invalid …")` shape as the existing `FSRSPhase` and `Rating` guards, naming the offending `card_id`.

### Scheduler phase guard (`domain/service/fsrs_scheduler.go`)

- `FSRSScheduler.Apply` panics on `!state.Phase.IsValid()` before the `fsrs.State(state.Phase)` cast. **Panic rather than `(FSRSState, error)`** was chosen deliberately: the error return ripples to the `domain.FSRSScheduler` consumer interface, its single production caller in `ApplyRating`, six call sites in `fsrs_scheduler_test.go`, **and five test fakes** implementing the interface (`domain/user_card_fsrs_test.go`, `usecase/swipe_error_test.go`, `usecase/swipe_performance_test.go`, `cmd/server/main_test.go`, `graph/resolver/swipe_resolver_test.go`) — the issue's ripple analysis undercounted by those five. No caller can build an invalid phase (`Phase` is only ever set by this method or reconstituted by the repository, whose read guard already rejects an unrecognised persisted value), so this is a programmer-error guard of the same kind as the constructor panic in `domain.NewUserCardFSRSForNewCard`.

### Named new-card defaults (`domain/fsrs_state.go`)

- `NewCardStability = 2.5` and `NewCardDifficulty = 5.0` replace the bare literals in `NewFSRSStateForNewCard`. Values unchanged. The docstring records that the scheduler overwrites both on the first review, so neither ever influences a computed interval — they exist so a never-reviewed card has a displayable in-range state and so the first swipe records a non-zero `StabilityBefore` snapshot that the statistics known-review gate reads.

### Two small guards (`usecase/validators.go`, `repository/master_cardgroup.go`)

- `translateCardErr` gains `if err == nil { return nil }`, matching `translateCardgroupNameErr` and the documented contract of `translateBioErr`. Without it a nil error falls to the `default` arm and is wrapped as `"usecase: translate card err: unexpected domain error"` — a success turned into an INTERNAL failure. None of its five call sites reaches it with nil today; the guard removes a latent trap.
- `masterCardgroupRepo.EnsureByName` routes `name` through `domain.ParseCardgroupName` instead of the direct `domain.CardgroupName(name)` cast, returning `domain.ErrCardgroupNameRequired` / `domain.ErrCardgroupNameTooLong` before the transaction opens. The parsed (trimmed) value is what the advisory lock, the lookup and the insert all key on, so a whitespace-padded name now resolves to the row its trimmed form created rather than inserting a second one.

### Review fixes

Second commit, applying three confirmed review findings.

- **`ListFSRSStatesByUser` was the path that actually mattered.** The stability guard landed only in `userCardFSRSToDomain`, but `domain.ClassifyMastery` has exactly one production call site and it consumes `domain.FSRSStat` — a type produced exclusively by `ListFSRSStatesByUser`, which validated `Phase` only. The mastery-tier harm the first commit's docstring claimed to close was still fully open on `/stats`. Added the mirroring `domain.IsValidStability` check inside the existing per-row loop (`FSRSStat` carries no difficulty column, so only stability applies), and corrected the `userCardFSRSToDomain` docstring, which asserted a NaN-to-Learned-tier outcome its own function cannot produce.
- **`IsValidStability` / `IsValidDifficulty` had no direct unit test** — their only coverage was the Docker-gated repository integration test, and the accept-side endpoints were unpinned. Every difficulty literal in the repository test tree is `5.0`; neither `1.0` nor `10.0` appeared anywhere, so flipping `>=`/`<=` to `>`/`<` would have hard-failed `FindByUserAndCardIDs` for a saturated card while the whole suite stayed green. New `domain/fsrs_state_test.go` pins both endpoints inclusively, in the shape of the sibling `rating_test.go`.
- **The `EnsureByName` docstring described a failure mode that no longer exists.** Migration `20260722000000` (already on this branch's base) widened `master_cardgroups_name_length` to 1..2000 code points while `domain.CardgroupNameMax` is 100 graphemes, so a 101-character ASCII name previously passed the CHECK and was **persisted silently** rather than dying on it. Reworded the docstring and the mirrored test comment to state the real prior behaviour — blank names died on the CHECK's lower bound, over-cap names in the 101..2000 band were stored — and noted that the sole production caller (`usecase/notion_sync.go:123`) already parses the name itself, making this defence in depth rather than a reachable behaviour change.

## Verification

The four items share no file with each other, and `backend/internal/repository/card_due.go` is untouched as the issue requires (#1029 owns it).

Each new rejection path is unreachable from application code, so every repository test seeds its row with **raw SQL** — the `stability` and `difficulty` columns carry no CHECK constraint, and `INSERT … 'NaN'::double precision` is the only way to produce the state the guard exists for. A reviewer can confirm the guards are load-bearing by neutering one predicate and watching the corresponding table case go red.

The scheduler test asserts both directions: all three invalid phases (`-1`, `4`, `99`) panic, and all four recognised phases still schedule without panicking, so the guard cannot be satisfied by a blanket panic.

## Test plan

- [ ] `cd backend && go tool gqlgen generate` — clean, no schema drift
- [ ] `cd backend && go build ./...` — Success
- [ ] `cd backend && go vet ./...` — No issues found
- [ ] `cd backend && go tool go-arch-lint check` — OK, no warnings found
- [ ] `cd backend && go test -count=1 ./...` — 2392 passed in 26 packages, 0 FAIL
- [ ] `docker info` — up, so the testcontainer-gated repository suites really executed (not skipped)
- [ ] `go test -count=1 -run 'InvalidStabilityOrDifficulty|ListFSRSStatesByUser_InvalidStabilityErrors|EnsureByName_InvalidName|EnsureByName_TrimsName' ./internal/repository/...` — 19 passed (the 8 + 5 + 2 + 1 new cases against a real Postgres container)
- [ ] `go test -count=1 -run 'TestIsValidStability|TestIsValidDifficulty' ./internal/domain/` — 20 passed
- [ ] `go test -count=1 -run 'TestFSRSScheduler_Apply_InvalidPhasePanics' ./internal/domain/service/` — 1 passed
- [ ] `go test -count=1 -run 'TestTranslateCardErr' ./internal/usecase/` — 5 passed
- [ ] Production diff (`git diff --shortstat origin/main...HEAD -- '*.go' ':!*_test.go'`) — 5 files, 109 insertions, 7 deletions; well under the 800-line ceiling

## Notes

`domain.MinDifficulty` / `domain.MaxDifficulty` are new — no domain-level difficulty bound existed before this change. They are sourced from the installed `go-fsrs/v3@v3.3.1` clamp rather than invented, so no legitimately-persisted row can fall outside them.

Out-of-scope items from the issue were respected: no `card_due.go` edits, no `user_preference.go` enum-reconstitution change, no `stability` CHECK constraint, and no change to the numeric values of the new-card defaults.

Closes #1052
