### PR TITLE
refactor(backend): give NewCardRatio named sentinel errors for field attribution

### DIFF
--- a/backend/internal/domain/new_card_ratio.go
+++ b/backend/internal/domain/new_card_ratio.go
@@ -21,26 +21,39 @@ type NewCardRatio struct {
 // interleave loop counts.
 const NewCardRatioDenMax = 100
 
+// ParseNewCardRatio's rejection reasons, one sentinel per rule so callers can
+// attribute the fault to a field with errors.Is instead of re-deriving the
+// bounds. NewCardRatioDenMax is interpolated into the cap message so the
+// exported bound and the message can never drift apart.
+var (
+	ErrNewCardRatioDenominatorNotPositive = eris.New("domain: new card ratio: denominator must be positive")
+	ErrNewCardRatioShareOutOfRange        = eris.New("domain: new card ratio: numerator must satisfy 0 < num < den")
+	ErrNewCardRatioDenominatorTooLarge    = eris.Errorf("domain: new card ratio: reduced denominator exceeds max %d", NewCardRatioDenMax)
+)
+
 // DefaultNewCardRatio (4/5) is applied when a user has no stored preference.
 // New share 4, review share 1 → interleave 4:1, matching the historical
 // hard-coded 4:1 new:review interleave this VO replaces.
 var DefaultNewCardRatio = mustNewCardRatio(4, 5)
 
 // ParseNewCardRatio reduces num/den to lowest terms and validates the bounds.
-// Returns a domain error (not a silent fallback) for a non-positive
-// denominator, a share outside (0, den), a reduced denominator above
-// NewCardRatioDenMax, or a zero/negative numerator.
+// It returns a sentinel (not a silent fallback) on failure:
+// ErrNewCardRatioDenominatorNotPositive for a non-positive denominator,
+// ErrNewCardRatioShareOutOfRange for a share outside (0, den) — which covers a
+// zero or negative numerator — and ErrNewCardRatioDenominatorTooLarge for a
+// reduced denominator above NewCardRatioDenMax. The checks run in that order and
+// return on the first failure, so exactly one sentinel is ever produced.
 func ParseNewCardRatio(num, den int) (NewCardRatio, error) {
 	if den <= 0 {
-		return NewCardRatio{}, eris.Errorf("domain: new card ratio: denominator must be positive, got %d", den)
+		return NewCardRatio{}, ErrNewCardRatioDenominatorNotPositive
 	}
 	if num <= 0 || num >= den {
-		return NewCardRatio{}, eris.Errorf("domain: new card ratio: numerator must satisfy 0 < num < den, got %d/%d", num, den)
+		return NewCardRatio{}, ErrNewCardRatioShareOutOfRange
 	}
 	g := int(new(big.Int).GCD(nil, nil, big.NewInt(int64(num)), big.NewInt(int64(den))).Int64())
 	rnum, rden := num/g, den/g
 	if rden > NewCardRatioDenMax {
-		return NewCardRatio{}, eris.Errorf("domain: new card ratio: reduced denominator %d exceeds max %d", rden, NewCardRatioDenMax)
+		return NewCardRatio{}, ErrNewCardRatioDenominatorTooLarge
 	}
 	return NewCardRatio{num: rnum, den: rden}, nil
 }

--- a/backend/internal/domain/new_card_ratio.go
+++ b/backend/internal/domain/new_card_ratio.go
@@ -1,6 +1,7 @@
 package domain
 
 import (
+	"errors"
 	"math/big"
 
 	"github.com/rotisserie/eris"
@@ -23,11 +24,13 @@ const NewCardRatioDenMax = 100
 
 // ParseNewCardRatio's rejection reasons, one sentinel per rule so callers can
 // attribute the fault to a field with errors.Is instead of re-deriving the
-// bounds. NewCardRatioDenMax is interpolated into the cap message so the
-// exported bound and the message can never drift apart.
+// bounds. The bound-free reasons use plain errors.New so errors.Is matches by
+// identity rather than by eris's message equality; the cap reason follows the
+// bound-carrying sibling precedent (ErrRoleNameTooLong) and interpolates
+// NewCardRatioDenMax so the exported bound and the message cannot drift apart.
 var (
-	ErrNewCardRatioDenominatorNotPositive = eris.New("domain: new card ratio: denominator must be positive")
-	ErrNewCardRatioShareOutOfRange        = eris.New("domain: new card ratio: numerator must satisfy 0 < num < den")
+	ErrNewCardRatioDenominatorNotPositive = errors.New("domain: new card ratio: denominator must be positive")
+	ErrNewCardRatioShareOutOfRange        = errors.New("domain: new card ratio: numerator must satisfy 0 < num < den")
 	ErrNewCardRatioDenominatorTooLarge    = eris.Errorf("domain: new card ratio: reduced denominator exceeds max %d", NewCardRatioDenMax)
 )
 

--- a/backend/internal/domain/new_card_ratio_test.go
+++ b/backend/internal/domain/new_card_ratio_test.go
@@ -24,20 +24,23 @@ func TestParseNewCardRatio_RejectsOutOfBounds(t *testing.T) {
 	cases := []struct {
 		name     string
 		num, den int
+		wantErr  error
 	}{
-		{"zero denominator", 1, 0},
-		{"negative denominator", 1, -5},
-		{"zero numerator", 0, 5},
-		{"negative numerator", -1, 5},
-		{"numerator equals denominator", 3, 3},
-		{"numerator exceeds denominator", 5, 3},
-		{"reduced denominator over max", 50, 101},
+		{"zero denominator", 1, 0, ErrNewCardRatioDenominatorNotPositive},
+		{"negative denominator", 1, -5, ErrNewCardRatioDenominatorNotPositive},
+		{"zero numerator", 0, 5, ErrNewCardRatioShareOutOfRange},
+		{"negative numerator", -1, 5, ErrNewCardRatioShareOutOfRange},
+		{"numerator equals denominator", 3, 3, ErrNewCardRatioShareOutOfRange},
+		{"numerator exceeds denominator", 5, 3, ErrNewCardRatioShareOutOfRange},
+		{"reduced denominator over max", 50, 101, ErrNewCardRatioDenominatorTooLarge},
+		{"denominator over max only after reduction", 3, 303, ErrNewCardRatioDenominatorTooLarge},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			_, err := ParseNewCardRatio(tc.num, tc.den)
 			require.Error(t, err)
+			require.ErrorIs(t, err, tc.wantErr)
 		})
 	}
 }

--- a/backend/internal/usecase/update_new_card_ratio.go
+++ b/backend/internal/usecase/update_new_card_ratio.go
@@ -2,7 +2,10 @@ package usecase
 
 import (
 	"context"
+	"errors"
 	"log/slog"
+
+	"github.com/rotisserie/eris"
 
 	"backend/internal/auth"
 	"backend/internal/domain"
@@ -87,21 +90,31 @@ func (u *updateNewCardRatioUsecase) Set(ctx context.Context, numerator, denomina
 
 	ratio, err := domain.ParseNewCardRatio(numerator, denominator)
 	if err != nil {
-		// Attribute the fault the way domain.ParseNewCardRatio does on the
-		// reduced fraction: a non-positive denominator, or a reduced denominator
-		// above NewCardRatioDenMax, is a denominator problem; a new-card share
-		// outside the open interval (0, denominator) is a numerator problem. The
-		// share bound is ratio-invariant (num/den < 1 iff rnum/rden < 1), so this
-		// verdict matches the reduced fraction the VO actually checks. The wire
-		// message stays generic to avoid leaking internal bounds phrasing.
-		field := "denominator"
-		if denominator > 0 && (numerator <= 0 || numerator >= denominator) {
-			field = "numerator"
-		}
-		return nil, ucerr.NewValidationError(field, "invalid new-card ratio")
+		return nil, translateNewCardRatioErr(err)
 	}
 
 	return setUserPreference(ctx, func(ctx context.Context, sub string) error {
 		return u.prefs.UpsertNewCardRatio(ctx, sub, ratio.Numerator(), ratio.Denominator())
 	}, u.users, "usecase: update new card ratio")
+}
+
+// translateNewCardRatioErr maps domain NewCardRatio sentinels into usecase-layer
+// typed errors, attributing each rejection to the field the caller can fix: a
+// share outside the open interval (0, denominator) faults the numerator; a
+// non-positive or over-cap reduced denominator faults the denominator. The wire
+// message stays generic so the internal bounds phrasing never leaks. Unexpected
+// errors are wrapped with eris. Returns nil when err is nil.
+func translateNewCardRatioErr(err error) error {
+	if err == nil {
+		return nil
+	}
+	switch {
+	case errors.Is(err, domain.ErrNewCardRatioShareOutOfRange):
+		return ucerr.NewValidationError("numerator", "invalid new-card ratio")
+	case errors.Is(err, domain.ErrNewCardRatioDenominatorNotPositive),
+		errors.Is(err, domain.ErrNewCardRatioDenominatorTooLarge):
+		return ucerr.NewValidationError("denominator", "invalid new-card ratio")
+	default:
+		return eris.Wrap(err, "usecase: update new card ratio: translate ratio error")
+	}
 }

--- a/backend/internal/usecase/update_new_card_ratio_test.go
+++ b/backend/internal/usecase/update_new_card_ratio_test.go
@@ -202,3 +202,17 @@ func TestUpdateNewCardRatio_InvalidRatio_FieldAttribution(t *testing.T) {
 		})
 	}
 }
+
+// TestTranslateNewCardRatioErr_NilAndDefaultArm covers the two branches
+// domain.ParseNewCardRatio can never drive: a nil error passes through, and an
+// unexpected non-domain error maps to INTERNAL rather than a validation error.
+func TestTranslateNewCardRatioErr_NilAndDefaultArm(t *testing.T) {
+	t.Parallel()
+
+	if err := translateNewCardRatioErr(nil); err != nil {
+		t.Fatalf("translateNewCardRatioErr(nil): want nil, got %v", err)
+	}
+
+	err := translateNewCardRatioErr(errors.New("surprise"))
+	assertInternalChain(t, err, "usecase: update new card ratio: translate ratio error")
+}


### PR DESCRIPTION
## Summary

`domain.ParseNewCardRatio` reported its three rejection reasons as anonymous `eris.Errorf` values, so `updateNewCardRatioUsecase.Set` could not ask *which* rule failed and instead re-implemented the bounds check by hand — `field := "denominator"; if denominator > 0 && (numerator <= 0 || numerator >= denominator) { field = "numerator" }` — behind a seven-line comment arguing that the copy still matched the value object. A bounds change in the value object would have silently rotted the field attribution and told the profile slider the wrong control was at fault. The value object now exports one named sentinel per rejection reason and the usecase matches them with `errors.Is`, following the sibling precedent already used by `ErrBioTooLong`, `ErrRoleNameTooLong` and friends. No user-visible behaviour change: the wire message stays the generic `"invalid new-card ratio"` and every existing attribution case still resolves to the same field.

## Changes

### Domain sentinels

- `backend/internal/domain/new_card_ratio.go` — added three package-level sentinels, one per rejection reason, replacing the three anonymous `eris.Errorf` returns:
  - `ErrNewCardRatioDenominatorNotPositive` for `den <= 0`
  - `ErrNewCardRatioShareOutOfRange` for `num <= 0 || num >= den` (this is the case that covers a zero or negative numerator)
  - `ErrNewCardRatioDenominatorTooLarge` for a reduced denominator above `NewCardRatioDenMax`, built with `eris.Errorf` so the exported bound constant is interpolated into the message and the two cannot drift apart — the `ErrRoleNameTooLong` precedent
- `backend/internal/domain/new_card_ratio.go` — rewrote the `ParseNewCardRatio` docblock to name the sentinel each branch returns and to state that the checks run in order and return on the first failure, so exactly one sentinel is ever produced. That ordering is what makes the usecase's `errors.Is` switch unambiguous.
- The per-call `%d` diagnostic values (`got %d`, `got %d/%d`, `reduced denominator %d`) are dropped, matching the sibling sentinel precedent. The wire message was already generic, so nothing user-facing changes.

### Usecase field attribution

- `backend/internal/usecase/update_new_card_ratio.go` — deleted the duplicated predicate and the seven-line justification comment that existed only to defend it; the error branch is now a single `return nil, translateNewCardRatioErr(err)`.
- `backend/internal/usecase/update_new_card_ratio.go` — added `translateNewCardRatioErr`, mirroring the `translateRoleNameErr` shape in `validators.go`: `ErrNewCardRatioShareOutOfRange` faults `"numerator"`, both denominator sentinels fault `"denominator"`, and anything unexpected falls through to `eris.Wrap` so it classifies as `INTERNAL` rather than being mislabelled a validation error.

### Tests

- `backend/internal/domain/new_card_ratio_test.go` — the existing rejection table gained a `wantErr` column and a `require.ErrorIs` assertion, so each of the three sentinels is pinned by at least one case. Added `{"denominator over max only after reduction", 3, 303}` to cover the cap check firing on the *reduced* fraction rather than the input one.
- `backend/internal/usecase/update_new_card_ratio_test.go` — added `TestTranslateNewCardRatioErr_NilAndDefaultArm` for the two branches `ParseNewCardRatio` can never drive: a nil error passes through as nil, and an unexpected non-domain error reaches the `INTERNAL` chain rather than a validation error.
- The seven pre-existing numerator/denominator attribution cases in `TestUpdateNewCardRatio_InvalidRatio_FieldAttribution` pass unmodified, which is the behaviour-preservation proof.

### Review fixes

The second commit applies one confirmed review finding.

- `backend/internal/domain/new_card_ratio.go` — the two bound-free sentinels were first declared with `eris.New`. `eris`'s `rootError.Is` compares error *messages*, not identity (verified against the vendored eris v0.5.4: `errors.Is(eris.New("same message"), eris.New("same message")) == true`, while the `errors.New` pair is `false`). That made the field attribution this PR introduces string-equality-based, so a future duplicated message among the domain sentinels would cross-match and misattribute the field — and the new positive-only `require.ErrorIs` table could not detect it. Switched both to plain `errors.New`, which is what `.claude/rules/error-wrapping.md` prescribes for sentinels matched via `errors.Is` and what the issue's own scope bullet asked for. `ErrNewCardRatioDenominatorTooLarge` stays on `eris.Errorf` deliberately, to keep the interpolated-bound precedent; it is compared by identity at its only call site.
- A comment on the sentinel block records why the construction style differs between the two groups, so the next reader does not "normalize" them.

## Verification

The behaviour contract is that nothing user-visible moves. The proof is that `TestUpdateNewCardRatio_InvalidRatio_FieldAttribution` — which asserts `numerator` vs `denominator` for all seven invalid inputs — is untouched by this branch and still passes. A reviewer can confirm the duplicated predicate is really gone with `grep -n 'numerator >= denominator' backend/internal/usecase/update_new_card_ratio.go` (0 matches).

The sentinel construction style is the one judgement call worth a look: identity comparison (`errors.New`) for the two bound-free reasons, message-interpolating `eris.Errorf` for the cap reason so `NewCardRatioDenMax` appears in exactly one place.

Out of scope and untouched, per the issue: the three remaining anonymous-error value objects (`domain/learn_display_mode.go`, `domain/rating.go`, `domain/swipe_record.go`), every validation bound (`NewCardRatioDenMax` stays 100), `DefaultNewCardRatio`, and `repository/user_preference.go:193`, which calls `ParseNewCardRatio` but discards the error.

## Test plan

- [ ] `cd backend && go tool gqlgen generate` — clean, no schema drift
- [ ] `cd backend && go build ./...` — Success
- [ ] `cd backend && go vet ./...` — No issues found
- [ ] `cd backend && go test ./...` — 2349 passed in 26 packages, 0 failed
- [ ] `cd backend && go tool go-arch-lint check --project-path .` — OK, no warnings found
- [ ] `grep -n 'numerator >= denominator' backend/internal/usecase/update_new_card_ratio.go` — 0 matches, the duplicated predicate is gone
- [ ] Production diff (`git diff --shortstat origin/main...HEAD` over non-test Go) — 2 files, 47 insertions, 18 deletions; far under the 800-line ceiling
- [ ] Worktree `git status --porcelain` — empty

## Notes

Naming was unconstrained by the issue. The sentinels use the domain package's `Err<Type><Reason>` convention and describe the *rule* that failed rather than the field that is at fault, because the field mapping is a usecase-layer concern — the domain does not know that the profile slider has two controls. If the three out-of-scope value objects are converted later, they can follow the same shape.

`translateNewCardRatioErr` lives in `update_new_card_ratio.go` rather than `validators.go`, where the six sibling translators live. That is what the issue scoped, and it keeps the diff to two production files; moving it next to its siblings is a reasonable follow-up but would widen this PR without changing behaviour.

Closes #1045
