### PR TITLE
refactor(domain): declare errors.Is-matched sentinels with errors.New

### DIFF
--- a/backend/internal/domain/card.go
+++ b/backend/internal/domain/card.go
@@ -1,6 +1,7 @@
 package domain
 
 import (
+	"errors"
 	"time"
 
 	"github.com/rotisserie/eris"
@@ -8,10 +9,14 @@ import (
 
 const CardTextMax = 500
 
+// Card text validation sentinels. The bound-free reasons use plain errors.New so
+// errors.Is matches by identity rather than by eris's message equality; the
+// bound-carrying reasons stay on eris.Errorf so the exported CardTextMax and the
+// message cannot drift apart.
 var (
-	ErrCardFrontRequired = eris.New("card: front is required")
+	ErrCardFrontRequired = errors.New("card: front is required")
 	ErrCardFrontTooLong  = eris.Errorf("card: front exceeds %d characters", CardTextMax)
-	ErrCardBackRequired  = eris.New("card: back is required")
+	ErrCardBackRequired  = errors.New("card: back is required")
 	ErrCardBackTooLong   = eris.Errorf("card: back exceeds %d characters", CardTextMax)
 )
 

--- a/backend/internal/domain/cardgroup.go
+++ b/backend/internal/domain/cardgroup.go
@@ -1,6 +1,7 @@
 package domain
 
 import (
+	"errors"
 	"time"
 
 	"github.com/rotisserie/eris"
@@ -11,10 +12,13 @@ import (
 // messages without duplicating the constant.
 const CardgroupNameMax = 100
 
-// Sentinel errors for cardgroup name validation. Callers should use
-// errors.Is to match them rather than comparing message strings.
+// Sentinel errors for cardgroup name validation. Callers should use errors.Is to
+// match them rather than comparing message strings. The bound-free reason uses
+// plain errors.New so errors.Is matches by identity rather than by eris's message
+// equality; the bound-carrying reason stays on eris.Errorf so the exported
+// CardgroupNameMax and the message cannot drift apart.
 var (
-	ErrCardgroupNameRequired = eris.New("cardgroup: name is required")
+	ErrCardgroupNameRequired = errors.New("cardgroup: name is required")
 	ErrCardgroupNameTooLong  = eris.Errorf("cardgroup: name exceeds %d characters", CardgroupNameMax)
 )
 

--- a/backend/internal/domain/display_name.go
+++ b/backend/internal/domain/display_name.go
@@ -1,6 +1,7 @@
 package domain
 
 import (
+	"errors"
 	"strings"
 
 	"github.com/rivo/uniseg"
@@ -9,10 +10,14 @@ import (
 
 const DisplayNameMax = 50
 
+// Display name validation sentinels. The bound-free reasons use plain errors.New
+// so errors.Is matches by identity rather than by eris's message equality; the
+// bound-carrying reason stays on eris.Errorf so the exported DisplayNameMax and
+// the message cannot drift apart.
 var (
-	ErrDisplayNameRequired = eris.New("user: display name is required")
+	ErrDisplayNameRequired = errors.New("user: display name is required")
 	ErrDisplayNameTooLong  = eris.Errorf("user: display name exceeds %d characters", DisplayNameMax)
-	ErrDisplayNameReserved = eris.New("user: display name is reserved")
+	ErrDisplayNameReserved = errors.New("user: display name is reserved")
 )
 
 // reservedDisplayNames is the set of lowercased display names that users may not

--- a/backend/internal/domain/role_name.go
+++ b/backend/internal/domain/role_name.go
@@ -1,6 +1,7 @@
 package domain
 
 import (
+	"errors"
 	"regexp"
 	"strings"
 
@@ -14,10 +15,14 @@ const RoleNameMax = 50
 // roleNamePattern allows lowercase letters, digits, underscores, and hyphens.
 var roleNamePattern = regexp.MustCompile(`^[a-z0-9_-]+$`)
 
+// Role name validation sentinels. The bound-free reasons use plain errors.New so
+// errors.Is matches by identity rather than by eris's message equality; the
+// bound-carrying reason stays on eris.Errorf so the exported RoleNameMax and the
+// message cannot drift apart.
 var (
-	ErrRoleNameRequired = eris.New("role: name is required")
+	ErrRoleNameRequired = errors.New("role: name is required")
 	ErrRoleNameTooLong  = eris.Errorf("role: name exceeds %d characters", RoleNameMax)
-	ErrRoleNameInvalid  = eris.New("role: name must contain only lowercase letters, digits, '_', or '-'")
+	ErrRoleNameInvalid  = errors.New("role: name must contain only lowercase letters, digits, '_', or '-'")
 )
 
 // RoleName is the canonical, lowercase, slug-like identifier for an application

--- a/backend/internal/domain/sentinel_identity_test.go
+++ b/backend/internal/domain/sentinel_identity_test.go
@@ -1,0 +1,88 @@
+package domain
+
+import (
+	"testing"
+
+	"github.com/rotisserie/eris"
+	"github.com/stretchr/testify/require"
+)
+
+// domainSentinel names one package-level validation sentinel. identityMatched
+// marks the sentinels declared with plain errors.New, which errors.Is resolves by
+// pointer identity; the rest interpolate an exported bound and stay on
+// eris.Errorf, which errors.Is resolves by message equality.
+type domainSentinel struct {
+	name            string
+	err             error
+	identityMatched bool
+}
+
+// domainSentinels lists every package-level validation sentinel in this package.
+// The cross-match matrix runs over the whole list rather than the identity-matched
+// subset alone, because eris compares messages: a duplicated message on any pair
+// makes errors.Is answer true for the wrong sentinel, and the per-aggregate tables
+// are positive-only so the duplicate would make a new assertion pass instead of
+// making an existing one fail.
+var domainSentinels = []domainSentinel{
+	{"ErrCardFrontRequired", ErrCardFrontRequired, true},
+	{"ErrCardFrontTooLong", ErrCardFrontTooLong, false},
+	{"ErrCardBackRequired", ErrCardBackRequired, true},
+	{"ErrCardBackTooLong", ErrCardBackTooLong, false},
+	{"ErrCardgroupNameRequired", ErrCardgroupNameRequired, true},
+	{"ErrCardgroupNameTooLong", ErrCardgroupNameTooLong, false},
+	{"ErrDisplayNameRequired", ErrDisplayNameRequired, true},
+	{"ErrDisplayNameTooLong", ErrDisplayNameTooLong, false},
+	{"ErrDisplayNameReserved", ErrDisplayNameReserved, true},
+	{"ErrRoleNameRequired", ErrRoleNameRequired, true},
+	{"ErrRoleNameTooLong", ErrRoleNameTooLong, false},
+	{"ErrRoleNameInvalid", ErrRoleNameInvalid, true},
+	{"ErrBioTooLong", ErrBioTooLong, false},
+	{"ErrDescriptionTooLong", ErrDescriptionTooLong, false},
+	{"ErrNewCardRatioDenominatorNotPositive", ErrNewCardRatioDenominatorNotPositive, true},
+	{"ErrNewCardRatioShareOutOfRange", ErrNewCardRatioShareOutOfRange, true},
+	{"ErrNewCardRatioDenominatorTooLarge", ErrNewCardRatioDenominatorTooLarge, false},
+}
+
+func TestDomainSentinels_DoNotCrossMatch(t *testing.T) {
+	t.Parallel()
+
+	for _, subject := range domainSentinels {
+		t.Run(subject.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.ErrorIs(t, subject.err, subject.err, "a sentinel must match itself")
+			for _, other := range domainSentinels {
+				if other.name == subject.name {
+					continue
+				}
+				require.NotErrorIs(t, subject.err, other.err,
+					"%s must not match %s — a shared message string would make errors.Is attribute the fault to the wrong field",
+					subject.name, other.name)
+			}
+		})
+	}
+}
+
+func TestDomainSentinels_SurviveErisWrap(t *testing.T) {
+	t.Parallel()
+
+	for _, subject := range domainSentinels {
+		if !subject.identityMatched {
+			continue
+		}
+		t.Run(subject.name, func(t *testing.T) {
+			t.Parallel()
+
+			wrapped := eris.Wrap(subject.err, "usecase: card: create")
+			require.ErrorIs(t, wrapped, subject.err,
+				"an eris.Wrap of %s must still satisfy errors.Is", subject.name)
+			for _, other := range domainSentinels {
+				if other.name == subject.name {
+					continue
+				}
+				require.NotErrorIs(t, wrapped, other.err,
+					"an eris.Wrap of %s must not match %s", subject.name, other.name)
+			}
+		})
+	}
+}

--- a/backend/internal/domain/sentinel_identity_test.go
+++ b/backend/internal/domain/sentinel_identity_test.go
@@ -1,6 +1,7 @@
 package domain
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/rotisserie/eris"
@@ -59,6 +60,30 @@ func TestDomainSentinels_DoNotCrossMatch(t *testing.T) {
 					"%s must not match %s — a shared message string would make errors.Is attribute the fault to the wrong field",
 					subject.name, other.name)
 			}
+		})
+	}
+}
+
+// TestDomainSentinels_MatchByIdentityNotMessage pins the declaration style itself.
+// The cross-match matrix above only fires once two sentinels share a message, so it
+// stays green if a single sentinel goes back to eris.New with its current unique text.
+// An eris root answers errors.Is for ANY error carrying the same message, so comparing
+// each sentinel against a freshly built twin of its own message discriminates the two
+// declarations directly: errors.New says no, eris.New says yes.
+func TestDomainSentinels_MatchByIdentityNotMessage(t *testing.T) {
+	t.Parallel()
+
+	for _, subject := range domainSentinels {
+		if !subject.identityMatched {
+			continue
+		}
+		t.Run(subject.name, func(t *testing.T) {
+			t.Parallel()
+
+			twin := errors.New(subject.err.Error())
+			require.NotErrorIs(t, subject.err, twin,
+				"%s matches a foreign error carrying the same message, so it is matched by message rather than by identity — declare it with errors.New, not eris.New",
+				subject.name)
 		})
 	}
 }


### PR DESCRIPTION
## Summary

Seven domain validation sentinels were declared with `eris.New`, and every one of them is matched by at least one `errors.Is` / `require.ErrorIs` call site. That is precisely the case `.claude/rules/error-wrapping.md` names as forbidden, and the reason is mechanical rather than stylistic: `eris` v0.5.4's `rootError.Is` falls back to comparing the error **message** against `target.Error()`. A plain `errors.New` root has no `Is` method at all, so it can only ever match itself by pointer identity. An `eris` root will happily answer `errors.Is` true for any foreign error that happens to carry the same message string.

The consequence is silent by construction. If two sentinels ever converge on the same message — a copy-paste, a reworded validation reason, a new field whose "is required" text matches an existing one — `errors.Is(err, ErrA)` starts returning true for an `ErrB`, and the fault gets attributed to the wrong field in whatever the caller does next. The domain's per-aggregate sentinel tables are positive-only (`require.ErrorIs`), so a duplicated message makes a *new* assertion pass rather than making an existing one fail. Nothing in the suite could see it.

This converts the seven sentinels to `errors.New`, leaves the bound-carrying sentinels on `eris.Errorf` where they interpolate an exported maximum, and adds three guards that pin each distinct property the change relies on. No message text changes, no validation bound changes, no name changes, and no production behaviour changes for any caller that already matched with `errors.Is`.

## Changes

### Sentinel declarations

Seven `eris.New` sentinels become `errors.New`, with identical names and identical message strings:

- `internal/domain/card.go` — `ErrCardFrontRequired`, `ErrCardBackRequired`.
- `internal/domain/cardgroup.go` — `ErrCardgroupNameRequired`.
- `internal/domain/display_name.go` — `ErrDisplayNameRequired`, `ErrDisplayNameReserved`.
- `internal/domain/role_name.go` — `ErrRoleNameRequired`, `ErrRoleNameInvalid`.

`card.go`, `display_name.go` and `role_name.go` each gain a block comment recording the split; `cardgroup.go` already carried one and it is extended in place. Either way the next contributor adding a sentinel to one of these blocks does not have to rediscover why the two neighbours are declared differently.

### What deliberately stays on `eris.Errorf`

`ErrCardFrontTooLong`, `ErrCardBackTooLong`, `ErrCardgroupNameTooLong`, `ErrDisplayNameTooLong` and `ErrRoleNameTooLong` interpolate an exported bound (`CardTextMax`, `CardgroupNameMax`, `DisplayNameMax`, `RoleNameMax`) into their message. That is the established "exported bound constants prevent message drift" precedent, and it is worth keeping: the constant and the message it appears in cannot diverge. These sentinels legitimately match by message, which is why the identity guard below skips them rather than asserting a property they are designed not to have.

### Tests

A new `internal/domain/sentinel_identity_test.go` holds a single hand-maintained `domainSentinels` table naming all seventeen package-level validation sentinels in the package, each flagged `identityMatched` or not. Three tests read from it:

- **`TestDomainSentinels_DoNotCrossMatch`** — the full 17 × 16 sibling matrix, asserting each sentinel matches itself and no other. This runs over the *whole* list, not the identity-matched subset, because a duplicated message between two `eris.Errorf` bound-carrying sentinels is just as much a cross-match as one between two converted ones.
- **`TestDomainSentinels_MatchByIdentityNotMessage`** — for each of the nine identity-matched sentinels, builds `twin := errors.New(s.err.Error())` and asserts `require.NotErrorIs(t, s.err, twin)`. This is the guard that pins the declaration style itself.
- **`TestDomainSentinels_SurviveErisWrap`** — wraps each of those same nine sentinels (the seven converted here, plus `ErrNewCardRatioDenominatorNotPositive` and `ErrNewCardRatioShareOutOfRange`, which were already declared with `errors.New`) in `eris.Wrap(err, "usecase: card: create")` and asserts the wrapped error still satisfies `errors.Is` against its own sentinel and against none of its siblings. This is the acceptance criterion that no call site relied on `eris` behaviour: the usecase layer wraps domain errors with `eris`, and `eris.Wrap` implements `Unwrap`, so the stdlib chain walk still reaches the `errors.New` root.

### Where the negative assertions live — a deliberate deviation from the issue

The issue's third scope item asks for `require.NotErrorIs` assertions in "the domain sentinel test tables", meaning the existing per-aggregate ones. That is not what landed. `card_test.go`, `cardgroup_test.go`, `display_name_test.go` and `role_name_test.go` are untouched, and all negative coverage lives in the single new central table instead — `grep -rn 'NotErrorIs' backend/internal/domain/` returns hits only in `sentinel_identity_test.go`.

The reason is that cross-matching is a property of the sentinel *set*, not of any one aggregate. A per-aggregate negative loop can only compare a sentinel against the siblings declared in its own file, so the pair most likely to collide — two "… is required" reasons living in two different files — is exactly the pair no per-aggregate table can see. It would also mean four loops to maintain and four places to remember when a sentinel is added. One table naming all seventeen sentinels covers the full matrix from a single registration point.

The acceptance criterion the scope item exists to serve is still met: the suite gains `require.NotErrorIs` coverage proving each sentinel does not match its siblings. Only its location differs from the issue's wording, so the third scope box should be read as satisfied by one central table rather than by N scattered ones.

## Why a message-twin probe rather than a source grep

The cross-match matrix alone does not fail if this change is reverted. Reverting one sentinel to `eris.New` while leaving its message unique keeps every cross-match assertion green, because no sibling carries that message. Nothing would have pinned the declaration style the change exists to establish.

A test that reads `card.go` and asserts the absence of `eris.New` would catch the revert, but it pins file layout rather than behaviour, breaks on any harmless reformat, and says nothing about what `errors.Is` actually does at runtime. The message-twin probe is both stricter and more stable: it would also catch a future custom error type that grows a message-equality `Is` method, and it is one `require.NotErrorIs` line per sentinel with no reflection and no source parsing.

The three guards cover three distinct failure modes and are deliberately kept as three. The identity test catches a single-sentinel revert. The cross-match matrix catches a duplicated message string across two sentinels — including between two `eris.Errorf` ones, which the identity test cannot see by design. The wrap test catches a regression in the wrap path itself. Collapsing any pair loses coverage.

## Verification

The primary source for the `eris` behaviour claim was read from the module cache rather than assumed. `rootError.Is` in `github.com/rotisserie/eris@v0.5.4/eris.go` reads:

```go
func (e *rootError) Is(target error) bool {
	if err, ok := target.(*rootError); ok {
		return e.msg == err.msg
	}
	return e.msg == target.Error()
}
```

The second return is the fallback arm the message-twin probe exploits: an arbitrary foreign error whose `Error()` matches is accepted.

The identity guard was proved non-vacuous by mutation, using a `go test -overlay` so no repository file was touched. The overlay and its mutated copy are throwaways; the whole reproduction, run from `backend/`, is:

```
sed 's/ErrCardFrontRequired = errors.New/ErrCardFrontRequired = eris.New/' \
  internal/domain/card.go > /tmp/card_mutated.go
printf '{"Replace": {"%s/internal/domain/card.go": "/tmp/card_mutated.go"}}\n' "$(pwd)" \
  > /tmp/overlay.json
go test -overlay=/tmp/overlay.json -count=1 -run TestDomainSentinels -v ./internal/domain/
```

That puts `ErrCardFrontRequired` back on `eris.New` with its existing, still-unique message, and nothing else. The run exits 1 on:

```
=== NAME  TestDomainSentinels_MatchByIdentityNotMessage/ErrCardFrontRequired
    sentinel_identity_test.go:84:
        	Error:      	Target error should not be in err chain:
        	            	found: "card: front is required"
        	            	in chain: "card: front is required"
        	Messages:   	ErrCardFrontRequired matches a foreign error carrying the same message, so it is matched by message rather than by identity — declare it with errors.New, not eris.New
--- FAIL: TestDomainSentinels_MatchByIdentityNotMessage (0.00s)
    --- FAIL: TestDomainSentinels_MatchByIdentityNotMessage/ErrCardFrontRequired (0.00s)
```

That single subtest is the only failure: 36 of the 38 subtests still pass under the same overlay. The other two guards in the same file stay green — which is exactly the gap the identity test was added to close.

The acceptance grep from the issue:

```
grep -rn 'eris\.New(' backend/internal/domain/*.go
backend/internal/domain/swipe_record.go:37:		return nil, eris.New("swipe record: cardgroupID is required")
```

One hit remains, and it is the inline error the issue names as out of scope: it is constructed, wrapped and returned at a single call site and is never matched with `errors.Is`, so the rule does not apply to it.

To confirm the conversion by hand: pick any converted sentinel, build `errors.New` from its own message text, and check `errors.Is` against the sentinel. Before this change it answered true; now it answers false, while `errors.Is(eris.Wrap(sentinel, "…"), sentinel)` still answers true.

## Test plan

- [x] `cd backend && go tool gqlgen generate` — exit 0, working tree unchanged
- [x] `cd backend && go build ./...` — Success
- [x] `cd backend && go vet ./...` — No issues found
- [x] `cd backend && gofmt -l cmd internal graph` — no output
- [x] `cd backend && go test -count=1 ./...` — 2579 passed in 27 packages (23 `ok`, 4 with no test files), 0 failed
- [x] `cd backend && go test -count=1 ./internal/domain/` — `ok backend/internal/domain`
- [x] `cd backend && go test -count=1 -run TestDomainSentinels ./internal/domain/` — 38 passed
- [x] `cd backend && go tool go-arch-lint check --project-path .` — OK, no warnings found, exit 0
- [x] Mutation proof via `go test -overlay`: reverting one sentinel to `eris.New` fails the identity guard on that sentinel alone and leaves the other 36 subtests green
- [x] CJK grep (`perl -CSD`) over the new test file and the four changed sources — no output
- [x] Main checkout `git status --short` — only the pre-existing untracked `.DS_Store`, no stray edits outside the worktree
- [x] Production diff against the merge-base (`git diff --shortstat origin/main...HEAD -- '*.go' ':!*_test.go'`) — 4 files, 28 insertions, 9 deletions; well under the 800-line ceiling

## Notes

`domainSentinels` is a hand-maintained list, so a sentinel added to this package without being registered there silently gets zero coverage from all three guards. The inventory cross-check that proves the list is currently complete is `grep -rnE '(^var |^\t)Err[A-Za-z0-9]*\s*=' internal/domain/`, which returns exactly the seventeen entries in the table. That check is not automated; a guard that fails when the counts diverge would be worth adding if the sentinel set starts changing often, but for a set this stable it would be speculative now.

Out of scope and untouched, per the issue: the inline `eris.New` in `swipe_record.go` (constructed and returned, never matched), the remaining anonymous-error value objects in `learn_display_mode.go` and `rating.go` (a different defect, tracked separately), and every message string and validation bound in the package.

Closes #1104
