### PR TITLE
test(backend): pin FSRSPhase validity and ungate the FSRS row guards

### DIFF
--- a/backend/internal/auth/superuser_test.go
+++ b/backend/internal/auth/superuser_test.go
@@ -667,6 +667,13 @@ func TestSuperUserPromoter_CachesConfirmedAdmin(t *testing.T) {
 // TestSuperUserPromoter_CachesAfterPromotion verifies a cold cache still promotes
 // correctly, and that once a sub has been promoted the confirmed-sub cache halts
 // every subsequent IsAdmin query and AssignRoleToUser call for that sub.
+//
+// This is also the demoted-account scenario: a still-listed, verified sub with no
+// confirmedAdmins entry whose IsAdmin returns false is exactly what a process
+// restart after an out-of-band demotion produces. The promoter keeps no record of
+// prior admin-ness, so a first-promotion cold cache and a post-demotion cold cache
+// are the same code path — the fixture below (IsAdmin always false, fresh
+// promoter) covers both, and the first request re-promotes.
 func TestSuperUserPromoter_CachesAfterPromotion(t *testing.T) {
 	t.Parallel()
 	var isAdminCalls, assignCalls atomic.Int64

--- a/backend/internal/domain/fsrs_state_test.go
+++ b/backend/internal/domain/fsrs_state_test.go
@@ -7,6 +7,36 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestFSRSPhaseIsValid pins the recognised-phase predicate. Every consumer of a
+// persisted phase gates on it: the repository read guard rejects the row, and
+// FSRSScheduler.Apply panics rather than feeding an unrecognised value to a
+// library dispatch that has no default arm. Widening the range would let a
+// corrupt column reach both.
+func TestFSRSPhaseIsValid(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input FSRSPhase
+		want  bool
+	}{
+		{"new", FSRSPhaseNew, true},
+		{"learning", FSRSPhaseLearning, true},
+		{"review", FSRSPhaseReview, true},
+		{"relearning", FSRSPhaseRelearning, true},
+		{"below the lowest constant", -1, false},
+		{"one past the highest constant", 4, false},
+		{"far out of range", 99, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, tc.input.IsValid())
+		})
+	}
+}
+
 // TestIsValidStability pins both sides of the stability predicate. The accept
 // side matters as much as the reject side: the repository read guard hard-fails
 // a whole query on a false negative, so a narrowing of the predicate must break

--- a/backend/internal/repository/user_card_fsrs_mapper_test.go
+++ b/backend/internal/repository/user_card_fsrs_mapper_test.go
@@ -1,0 +1,140 @@
+package repository
+
+// White-box tests for userCardFSRSToDomain. The mapper is unexported and is a
+// pure function of the row struct, so the tests live in the same package and
+// need no live DB — the eight sibling guard cases in user_card_fsrs_test.go all
+// go through a testcontainer, which leaves a contributor without Docker with no
+// coverage of the guard at all. These pin the reject side and, crucially, the
+// exact message each rejection produces: the message is the only signal an
+// operator gets when a row edited outside the application reaches a read, so a
+// silently reworded or dropped guard would leave a corrupt column to flow into
+// the GraphQL Floats it feeds and break JSON marshalling of the whole response.
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"backend/internal/domain"
+)
+
+// validUserCardFSRSRow returns a row every guard in userCardFSRSToDomain
+// accepts. Each reject case mutates exactly one column so the failure is
+// attributable to that column's guard.
+func validUserCardFSRSRow() gormUserCardFSRS {
+	now := time.Date(2026, 4, 26, 0, 0, 0, 0, time.UTC)
+	good := int(domain.RatingGood)
+	return gormUserCardFSRS{
+		UserID:        "00000000-0000-0000-0000-000000000001",
+		CardID:        "00000000-0000-0000-0000-000000000002",
+		State:         int(domain.FSRSPhaseReview),
+		Due:           now.Add(24 * time.Hour),
+		Stability:     domain.NewCardStability,
+		Difficulty:    domain.NewCardDifficulty,
+		Reps:          3,
+		Lapses:        1,
+		LastReview:    now,
+		LastRating:    &good,
+		ElapsedDays:   1,
+		ScheduledDays: 1,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}
+}
+
+func TestUserCardFSRSToDomain_RejectsCorruptColumns(t *testing.T) {
+	t.Parallel()
+
+	badRating := 7
+
+	tests := []struct {
+		name    string
+		mutate  func(*gormUserCardFSRS)
+		wantMsg string
+	}{
+		{
+			name:    "phase below the lowest constant",
+			mutate:  func(r *gormUserCardFSRS) { r.State = -1 },
+			wantMsg: "repository: invalid FSRSPhase value -1 for card 00000000-0000-0000-0000-000000000002",
+		},
+		{
+			name:    "phase past the highest constant",
+			mutate:  func(r *gormUserCardFSRS) { r.State = 4 },
+			wantMsg: "repository: invalid FSRSPhase value 4 for card 00000000-0000-0000-0000-000000000002",
+		},
+		{
+			name:    "zero stability",
+			mutate:  func(r *gormUserCardFSRS) { r.Stability = 0 },
+			wantMsg: "repository: invalid stability value 0 for card 00000000-0000-0000-0000-000000000002",
+		},
+		{
+			name:    "negative stability",
+			mutate:  func(r *gormUserCardFSRS) { r.Stability = -1.5 },
+			wantMsg: "repository: invalid stability value -1.5 for card 00000000-0000-0000-0000-000000000002",
+		},
+		{
+			name:    "difficulty below the minimum",
+			mutate:  func(r *gormUserCardFSRS) { r.Difficulty = domain.MinDifficulty - 0.5 },
+			wantMsg: "repository: invalid difficulty value 0.5 for card 00000000-0000-0000-0000-000000000002",
+		},
+		{
+			name:    "difficulty above the maximum",
+			mutate:  func(r *gormUserCardFSRS) { r.Difficulty = domain.MaxDifficulty + 0.5 },
+			wantMsg: "repository: invalid difficulty value 10.5 for card 00000000-0000-0000-0000-000000000002",
+		},
+		{
+			name:    "last_rating outside the FSRS range",
+			mutate:  func(r *gormUserCardFSRS) { r.LastRating = &badRating },
+			wantMsg: "repository: invalid last_rating value 7 for card 00000000-0000-0000-0000-000000000002",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			row := validUserCardFSRSRow()
+			tc.mutate(&row)
+
+			got, err := userCardFSRSToDomain(row)
+			require.Error(t, err)
+			require.Nil(t, got)
+			require.Contains(t, err.Error(), tc.wantMsg)
+		})
+	}
+}
+
+// TestUserCardFSRSToDomain_AcceptsValidRow guards the accept side. A narrowed
+// predicate would hard-fail a whole read for a legitimately persisted row, so
+// the reject cases above are only half the contract.
+func TestUserCardFSRSToDomain_AcceptsValidRow(t *testing.T) {
+	t.Parallel()
+
+	row := validUserCardFSRSRow()
+
+	got, err := userCardFSRSToDomain(row)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Equal(t, domain.UserID(row.UserID), got.UserID)
+	require.Equal(t, row.CardID, got.CardID)
+	require.Equal(t, domain.FSRSPhaseReview, got.State.Phase)
+	require.Equal(t, row.Stability, got.State.Stability)
+	require.Equal(t, row.Difficulty, got.State.Difficulty)
+	require.Equal(t, domain.RatingGood, got.State.LastRating)
+}
+
+// TestUserCardFSRSToDomain_NullLastRatingMapsToZero pins the nullable column's
+// mapping: last_rating IS NULL denotes a synthesized state no swipe has rated,
+// which the domain spells as the zero Rating — not a guard violation.
+func TestUserCardFSRSToDomain_NullLastRatingMapsToZero(t *testing.T) {
+	t.Parallel()
+
+	row := validUserCardFSRSRow()
+	row.LastRating = nil
+
+	got, err := userCardFSRSToDomain(row)
+	require.NoError(t, err)
+	require.Equal(t, domain.Rating(0), got.State.LastRating)
+	require.False(t, got.State.LastRating.IsValid())
+}

--- a/backend/internal/repository/user_card_fsrs_mapper_test.go
+++ b/backend/internal/repository/user_card_fsrs_mapper_test.go
@@ -21,7 +21,11 @@ import (
 
 // validUserCardFSRSRow returns a row every guard in userCardFSRSToDomain
 // accepts. Each reject case mutates exactly one column so the failure is
-// attributable to that column's guard.
+// attributable to that column's guard. Every numeric and time column carries a
+// distinct value: the mapper copies thirteen same-typed fields across in one
+// struct literal, and equal fixture values would let a transposed pair
+// (elapsed/scheduled days, created/updated timestamps) satisfy the accept-path
+// assertion.
 func validUserCardFSRSRow() gormUserCardFSRS {
 	now := time.Date(2026, 4, 26, 0, 0, 0, 0, time.UTC)
 	good := int(domain.RatingGood)
@@ -29,16 +33,16 @@ func validUserCardFSRSRow() gormUserCardFSRS {
 		UserID:        "00000000-0000-0000-0000-000000000001",
 		CardID:        "00000000-0000-0000-0000-000000000002",
 		State:         int(domain.FSRSPhaseReview),
-		Due:           now.Add(24 * time.Hour),
+		Due:           now.Add(120 * time.Hour),
 		Stability:     domain.NewCardStability,
 		Difficulty:    domain.NewCardDifficulty,
 		Reps:          3,
 		Lapses:        1,
-		LastReview:    now,
+		LastReview:    now.Add(-48 * time.Hour),
 		LastRating:    &good,
-		ElapsedDays:   1,
-		ScheduledDays: 1,
-		CreatedAt:     now,
+		ElapsedDays:   2,
+		ScheduledDays: 5,
+		CreatedAt:     now.Add(-72 * time.Hour),
 		UpdatedAt:     now,
 	}
 }
@@ -107,7 +111,10 @@ func TestUserCardFSRSToDomain_RejectsCorruptColumns(t *testing.T) {
 
 // TestUserCardFSRSToDomain_AcceptsValidRow guards the accept side. A narrowed
 // predicate would hard-fail a whole read for a legitimately persisted row, so
-// the reject cases above are only half the contract.
+// the reject cases above are only half the contract. The whole struct is
+// compared rather than a field subset: an unasserted field is one a transposed
+// or dropped assignment could corrupt with only the Docker-gated integration
+// tests to catch it.
 func TestUserCardFSRSToDomain_AcceptsValidRow(t *testing.T) {
 	t.Parallel()
 
@@ -116,12 +123,24 @@ func TestUserCardFSRSToDomain_AcceptsValidRow(t *testing.T) {
 	got, err := userCardFSRSToDomain(row)
 	require.NoError(t, err)
 	require.NotNil(t, got)
-	require.Equal(t, domain.UserID(row.UserID), got.UserID)
-	require.Equal(t, row.CardID, got.CardID)
-	require.Equal(t, domain.FSRSPhaseReview, got.State.Phase)
-	require.Equal(t, row.Stability, got.State.Stability)
-	require.Equal(t, row.Difficulty, got.State.Difficulty)
-	require.Equal(t, domain.RatingGood, got.State.LastRating)
+	require.Equal(t, &domain.UserCardFSRS{
+		UserID: domain.UserID(row.UserID),
+		CardID: row.CardID,
+		State: domain.FSRSState{
+			Due:           row.Due,
+			Stability:     row.Stability,
+			Difficulty:    row.Difficulty,
+			ElapsedDays:   row.ElapsedDays,
+			ScheduledDays: row.ScheduledDays,
+			Reps:          row.Reps,
+			Lapses:        row.Lapses,
+			Phase:         domain.FSRSPhaseReview,
+			LastReview:    row.LastReview,
+			LastRating:    domain.RatingGood,
+		},
+		CreatedAt: row.CreatedAt,
+		UpdatedAt: row.UpdatedAt,
+	}, got)
 }
 
 // TestUserCardFSRSToDomain_NullLastRatingMapsToZero pins the nullable column's

--- a/backend/internal/repository/user_test.go
+++ b/backend/internal/repository/user_test.go
@@ -29,17 +29,18 @@ func TestMain(m *testing.M) {
 	os.Exit(runTests(m))
 }
 
-// dockerFreeTests names every test in this directory that needs no database.
-// Both `package repository` (white-box mapper and classifier tests) and
-// `package repository_test` files compile into one test binary with one
+// dockerFreeTests names the tests in this directory that are known to need no
+// database. Both `package repository` (white-box mapper and classifier tests)
+// and `package repository_test` files compile into one test binary with one
 // TestMain, so a Docker outage takes the whole directory down unless the run is
 // narrowed to this set. Narrowing rather than skipping is what the degradation
 // needs: every other test dereferences the package-level testDB, so leaving them
 // enabled would nil-panic instead of skipping. Add a new Docker-free test's name
 // here, or it will not run when Docker is unavailable.
 const dockerFreeTests = "^(TestCardRepositorySatisfiesNarrowInterfaces|TestClassify|TestCursorWhere_|" +
-	"TestEscapeLikePattern|TestMasterCardgroupToDomain_|TestOrderClause_|TestPgConstraintViolation|" +
-	"TestRefetchAfterUpdate|TestTextLengthViolationError_|TestToDomainUserPreference_|TestUserCardFSRSToDomain_)"
+	"TestDomainRejectsOverCapEmoji|TestEscapeLikePattern|TestMasterCardgroupToDomain_|TestOrderClause_|" +
+	"TestPgConstraintViolation|TestRefetchAfterUpdate|TestTextLengthViolationError_|" +
+	"TestToDomainUserPreference_|TestUserCardFSRSToDomain_|TestZWJEmojiAtGraphemeCap_)"
 
 func runTests(m *testing.M) int {
 	ctx := context.Background()
@@ -93,9 +94,13 @@ func runTests(m *testing.M) int {
 
 // runDockerFreeOnly degrades a local run whose container runtime is unreachable:
 // the DB-backed suite is dropped and only dockerFreeTests execute, so a
-// contributor without Docker still exercises the pure mappers and classifiers
-// instead of watching the whole package fail. CI keeps the hard failure above so
-// the integration suite can never silently vanish from the merge gate.
+// contributor without Docker still sees per-test results for the pure mappers
+// and classifiers instead of one opaque bootstrap failure. The exit code stays
+// non-zero regardless, because a container that will not start is never a pass:
+// an image-pull failure, a port conflict or a dead daemon would otherwise print
+// `ok` while the other ~280 tests never ran, and the banner below is the only
+// contrary signal — one that any summarizing test wrapper strips. CI keeps the
+// hard failure above so it never spends time on a degraded run at all.
 func runDockerFreeOnly(m *testing.M, cause error) int {
 	fmt.Fprintf(os.Stderr,
 		"repository: test container unavailable (%v)\nrepository: skipping the DB-backed suite; running only the Docker-free tests %s\n",
@@ -103,13 +108,26 @@ func runDockerFreeOnly(m *testing.M, cause error) int {
 	// testing registers its flags before TestMain runs but parses them inside
 	// m.Run, so the value has to be parsed here for the override to stick.
 	// The override is unconditional: honouring an explicit -run that names a
-	// DB-backed test would nil-dereference testDB rather than skip.
+	// DB-backed test would nil-dereference testDB rather than skip. Announce the
+	// replacement so a developer whose -run was dropped cannot read the surviving
+	// results as an answer about the test they actually asked for.
 	flag.Parse()
+	if f := flag.Lookup("test.run"); f != nil && f.Value.String() != "" {
+		fmt.Fprintf(os.Stderr,
+			"repository: dropping the requested -run %q; it cannot be honoured without a database\n",
+			f.Value.String())
+	}
 	if err := flag.Set("test.run", dockerFreeTests); err != nil {
 		fmt.Fprintf(os.Stderr, "narrow test.run: %v\n", err)
 		return 1
 	}
-	return m.Run()
+	code := m.Run()
+	fmt.Fprintf(os.Stderr,
+		"repository: FAILING this package on purpose: the DB-backed suite never ran. Start the container runtime and re-run for real coverage.\n")
+	if code == 0 {
+		code = 1
+	}
+	return code
 }
 
 // insertAuthUser inserts a fresh row in auth.users so the trigger creates a

--- a/backend/internal/repository/user_test.go
+++ b/backend/internal/repository/user_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"flag"
 	"fmt"
 	"os"
 	"testing"
@@ -28,6 +29,18 @@ func TestMain(m *testing.M) {
 	os.Exit(runTests(m))
 }
 
+// dockerFreeTests names every test in this directory that needs no database.
+// Both `package repository` (white-box mapper and classifier tests) and
+// `package repository_test` files compile into one test binary with one
+// TestMain, so a Docker outage takes the whole directory down unless the run is
+// narrowed to this set. Narrowing rather than skipping is what the degradation
+// needs: every other test dereferences the package-level testDB, so leaving them
+// enabled would nil-panic instead of skipping. Add a new Docker-free test's name
+// here, or it will not run when Docker is unavailable.
+const dockerFreeTests = "^(TestCardRepositorySatisfiesNarrowInterfaces|TestClassify|TestCursorWhere_|" +
+	"TestEscapeLikePattern|TestMasterCardgroupToDomain_|TestOrderClause_|TestPgConstraintViolation|" +
+	"TestRefetchAfterUpdate|TestTextLengthViolationError_|TestToDomainUserPreference_|TestUserCardFSRSToDomain_)"
+
 func runTests(m *testing.M) int {
 	ctx := context.Background()
 	container, err := tcpostgres.Run(ctx,
@@ -40,8 +53,11 @@ func runTests(m *testing.M) int {
 		tcpostgres.BasicWaitStrategies(),
 	)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "run container: %v\n", err)
-		return 1
+		if os.Getenv("CI") != "" {
+			fmt.Fprintf(os.Stderr, "run container: %v\n", err)
+			return 1
+		}
+		return runDockerFreeOnly(m, err)
 	}
 	defer func() {
 		if err := testcontainers.TerminateContainer(container); err != nil {
@@ -72,6 +88,27 @@ func runTests(m *testing.M) int {
 
 	testDSN = dsn
 	testDB = db
+	return m.Run()
+}
+
+// runDockerFreeOnly degrades a local run whose container runtime is unreachable:
+// the DB-backed suite is dropped and only dockerFreeTests execute, so a
+// contributor without Docker still exercises the pure mappers and classifiers
+// instead of watching the whole package fail. CI keeps the hard failure above so
+// the integration suite can never silently vanish from the merge gate.
+func runDockerFreeOnly(m *testing.M, cause error) int {
+	fmt.Fprintf(os.Stderr,
+		"repository: test container unavailable (%v)\nrepository: skipping the DB-backed suite; running only the Docker-free tests %s\n",
+		cause, dockerFreeTests)
+	// testing registers its flags before TestMain runs but parses them inside
+	// m.Run, so the value has to be parsed here for the override to stick.
+	// The override is unconditional: honouring an explicit -run that names a
+	// DB-backed test would nil-dereference testDB rather than skip.
+	flag.Parse()
+	if err := flag.Set("test.run", dockerFreeTests); err != nil {
+		fmt.Fprintf(os.Stderr, "narrow test.run: %v\n", err)
+		return 1
+	}
 	return m.Run()
 }
 


### PR DESCRIPTION
## Summary

A review round named four invariants that production code or a docstring had started leaning on, none of which any assertion pinned. Re-checking each one against the current `main` rather than against the issue body changed the shape of the work: two of the four were already covered by tests that landed after the issue was filed, and the remaining two turned out to need a piece of test infrastructure before they could be written at all.

The scheduler's long-term mode is already pinned. `TestFSRSSchedulerApplyGoldenTransitions` carries a golden table whose every row — including the Learning and Relearning input phases — expects a whole-day interval and a `Review` output phase, which is exactly the observable consequence of `EnableShortTerm = false`. Flipping the flag breaks twelve of its sixteen rows. That is the behavioural assertion the issue asked for, so no test was added; the flip and its captured failure are below. The domain-level stability and difficulty predicates are likewise already covered by `TestIsValidStability` and `TestIsValidDifficulty` in the domain package, which need no database.

What was genuinely missing: `FSRSPhase.IsValid` had no direct test, and the repository guard that consumes all three predicates — the mapper turning a persisted `user_card_fsrs` row into a domain aggregate, including the error message each rejection produces — ran only under testcontainers. A contributor without a container runtime got no coverage of that guard and, worse, no coverage of anything else in the repository directory either: one `TestMain` fronts the whole package, so a dead daemon took all 327 tests down with one opaque bootstrap line. This branch adds the phase table, adds white-box mapper tests that need no database, and teaches `TestMain` to degrade to the Docker-free subset so those tests actually run. The fourth item, the cold-cache demoted-superuser path, turned out to be the same code path an existing test already exercises; it is named in that test's docstring rather than duplicated.

## The decision: run the Docker-free subset, then fail the package

The Docker-free fallback runs its subset and then **fails the package on purpose**. This is the one place where behaviour a developer can see changes, and it is deliberate.

Returning `m.Run()` verbatim would print `ok backend/internal/repository` while 284 of 327 tests never ran. An image-pull failure, a port conflict or a dead daemon would all read as a pass, and the stderr banner is the only contrary signal — one that any summarising test wrapper strips. Forcing the exit code to 1 keeps both properties the degradation is for: the contributor gets per-test results for the pure mappers and classifiers, and the package is unmistakably red so a degraded run can never be mistaken for a green one. The practical consequence is intended: a contributor with no container runtime cannot get a green `go test ./...` for that package, because the DB-backed suite genuinely did not run.

An opt-in flag that returns 1 *before* `m.Run()` unless the developer sets it was considered and rejected: it reverses the point of the fallback, since the default no-Docker run would then execute nothing. No second knob restoring a green exit was added either — a contributor who wants green can start the container runtime.

**The dropped `-run` is replaced, not intersected.** Go's `-run` has no conjunction operator, so "intersect" degrades to "honour theirs", and honouring a pattern naming a DB-backed test under an outage nil-dereferences `testDB` — a strictly worse diagnostic than an announced narrowing plus a red exit.

**The demoted-account path is documented in the existing test rather than duplicated.** A new test would construct the identical fixture and assert the identical counters, because the promoter cannot distinguish "never promoted" from "promoted then demoted" — nothing in it records prior admin-ness. Two tests differing only in name would state that the code has two behaviours where it has one; the docstring makes the coverage discoverable to anyone grepping for the demotion scenario, which is what the gap actually was.

**No production file was touched.** The issue made any production change out of scope. None of the four needed one: the mapper is a pure function of its row struct, so white-box tests in the same package reach it without a seam, and the degradation lives entirely in the test-only `TestMain`.

## Changes

### Domain

- `TestFSRSPhaseIsValid` in `backend/internal/domain/fsrs_state_test.go` — a table over all four declared phases plus three undeclared values (below the lowest constant, one past the highest, and far out of range). The docstring records why the predicate is load-bearing on both sides: the repository read guard rejects the row, and `FSRSScheduler.Apply` panics rather than feed an unrecognised value to a library dispatch with no default arm.

### Repository — Docker-free degradation

- `dockerFreeTests` in `backend/internal/repository/user_test.go` — a `-run` alternation naming every test in the directory that touches neither `testDB` nor `testDSN`. Narrowing rather than skipping is what the degradation needs: every other test in the directory dereferences the package-level `testDB`, so leaving them enabled would nil-panic instead of skip.
- `runDockerFreeOnly` — when `tcpostgres.Run` fails outside CI, the DB-backed suite is dropped and only that subset runs, so a contributor without Docker sees per-test results instead of one bootstrap error. Under `CI` the pre-existing hard failure is unchanged, so CI never spends time on a degraded run.
- An explicit `-run` supplied by the developer is overridden, and the override is announced on stderr by name. The `flag` import is new: `testing` registers its flags before `TestMain` runs but parses them inside `m.Run`, so the value has to be parsed in the fallback for the override to stick.

### Repository — mapper tests

- `backend/internal/repository/user_card_fsrs_mapper_test.go` (new, `package repository`) — white-box tests for the unexported `userCardFSRSToDomain`. Seven reject cases pin both the rejection and the exact message it produces, one column at a time: phase below and past the declared range, zero and negative stability, difficulty under the minimum and over the maximum, and an out-of-range `last_rating`. The message is the only signal an operator gets when a row edited outside the application reaches a read.
- `TestUserCardFSRSToDomain_AcceptsValidRow` compares the whole mapped struct against a fully-specified expected value rather than a field subset, and `validUserCardFSRSRow` gives every column a value distinct from its same-typed siblings — `2 / 5 / 3 / 1` for the four `int`s (elapsed days, scheduled days, reps, lapses); four distinct timestamps for the four `time.Time`s (due, last review, created, updated); `2.5` and `5.0` for the two `float64`s. The mapper copies fourteen fields in one struct literal, ten of which share a type with another field, so equal fixture values would let a transposed pair satisfy the assertion — see the mutation proof below.
- `TestUserCardFSRSToDomain_NullLastRatingMapsToZero` pins the nullable column: `last_rating IS NULL` denotes a state no swipe has rated and maps to the zero `Rating`, not to a guard violation.

### Auth

- The `TestSuperUserPromoter_CachesAfterPromotion` docstring now names the demoted-account scenario. Its fixture — a still-listed, verified sub with no `confirmedAdmins` entry whose `IsAdmin` always returns false — is precisely what an out-of-band demotion leaves behind, so first promotion and post-demotion re-promotion are literally the same branch. Both assertions the issue asked for are already there: `AssignRoleToUser` called exactly once, and `IsAdmin` called exactly once across five requests, which only holds if the sub was recorded.

## Verification

Every demonstration below was produced with `go test -overlay`, which substitutes a modified file at compile time without writing to the working tree. No repository file was edited to run a probe; `git status --porcelain` was clean before and after.

**Flipping `EnableShortTerm` to `true` breaks the scheduler golden table.** Twelve of the sixteen rows fail. The four survivors are `new_easy` and the three Review-phase non-`Again` rows — the transitions whose scheduled interval is the same whole number of days under either setting.

```
$ go test -count=1 -v -overlay <flip>.json ./internal/domain/service/ -run TestFSRSSchedulerApplyGoldenTransitions
--- FAIL: TestFSRSSchedulerApplyGoldenTransitions
    --- FAIL: TestFSRSSchedulerApplyGoldenTransitions/new_again (0.00s)
        	Error:      	Max difference between 24 and 0.016666666666666666 allowed is 0.001, but difference was 23.983333333333334
        	Test:       	TestFSRSSchedulerApplyGoldenTransitions/new_again
    --- FAIL: .../new_hard      --- FAIL: .../new_good
    --- FAIL: .../learning_again    --- FAIL: .../learning_hard
    --- FAIL: .../learning_good     --- FAIL: .../learning_easy
    --- FAIL: .../review_again
    --- FAIL: .../relearning_again  --- FAIL: .../relearning_hard
    --- FAIL: .../relearning_good   --- FAIL: .../relearning_easy
    --- PASS: .../new_easy          --- PASS: .../review_hard
    --- PASS: .../review_good       --- PASS: .../review_easy
FAIL	backend/internal/domain/service
```

**The container is up: the full integration suite still runs, unchanged.** The degradation is unreachable on a healthy machine.

```
$ go test -count=1 -v ./internal/repository/ | grep -cE '^--- (PASS|FAIL)'
327
$ go test -count=1 ./internal/repository/
ok  	backend/internal/repository	2.400s
```

**The container is down, `CI` unset: the subset runs and the package is red.** Forced by an overlay that makes the `tcpostgres.Run` result an error.

```
EXIT=1
43 tests executed, 43 PASS, 0 FAIL
repository: test container unavailable (simulated docker outage)
repository: skipping the DB-backed suite; running only the Docker-free tests ^(TestCardRepositorySatisfiesNarrowInterfaces|TestClassify|TestCursorWhere_|TestDomainRejectsOverCapEmoji|TestEsc…
repository: FAILING this package on purpose: the DB-backed suite never ran. Start the container runtime and re-run for real coverage.
FAIL	backend/internal/repository	1.651s
```

Among the 43 are the new mapper tests and the two guards the allowlist had been missing:

```
--- PASS: TestUserCardFSRSToDomain_RejectsCorruptColumns (0.00s)
--- PASS: TestUserCardFSRSToDomain_AcceptsValidRow (0.00s)
--- PASS: TestUserCardFSRSToDomain_NullLastRatingMapsToZero (0.00s)
--- PASS: TestDomainRejectsOverCapEmojiBeforeReachingDB (0.00s)
--- PASS: TestZWJEmojiAtGraphemeCap_CodePointExpansion (0.00s)
```

**The container is down, `CI` set: the hard failure is unchanged.**

```
EXIT=1
run container: simulated docker outage
FAIL	backend/internal/repository	1.393s
```

**An explicit `-run` is announced as dropped rather than silently replaced.**

```
$ go test -count=1 ./internal/repository/ -run 'TestCardRepository_BulkDelete'
EXIT=1
repository: dropping the requested -run "TestCardRepository_BulkDelete"; it cannot be honoured without a database
FAIL	backend/internal/repository	1.474s
```

**The accept-path assertion is non-vacuous.** An overlay transposing `ElapsedDays`/`ScheduledDays` and `CreatedAt`/`UpdatedAt` inside the production mapper fails it. Under a fixture where those same-typed pairs carried equal values the mutation would have been invisible.

```
--- FAIL: TestUserCardFSRSToDomain_AcceptsValidRow (0.00s)
	-  ElapsedDays: (int) 2,
	-  ScheduledDays: (int) 5,
	+  ElapsedDays: (int) 5,
	+  ScheduledDays: (int) 2,
```

**The cold-cache superuser assertion is non-vacuous.** Widening the `confirmedAdmins.Load` short-circuit so it also fires on a cold cache (`ok || true`) makes both counters go to zero:

```
--- FAIL: TestSuperUserPromoter_CachesAfterPromotion (0.00s)
    superuser_test.go:704: expected exactly 1 IsAdmin call across 5 requests, got 0
    superuser_test.go:707: expected exactly 1 AssignRoleToUser call across 5 requests, got 0
```

**The allowlist was derived, not guessed.** Every `func Test…` body in the directory was classified by whether it references `testDB`, `testDSN`, `insertAuthUser` or `sqlDBHandle`, and the database-free set diffed against the alternation. Two were missing, both in the grapheme-length file and both reading only `domain.ParseCardText`, `domain.ParseCardgroupName` and the grapheme counter: re-running the degraded simulation with those two names removed from `dockerFreeTests` yields 41 passing tests instead of 43. Both are anchored under the leading `^(`, so the two Docker-gated `…_RoundTrips` siblings sharing their prefix stay correctly excluded.

To confirm the degradation by hand rather than by overlay: stop the container runtime and run `go test ./internal/repository/`. Expect a red package, the three-line stderr banner, and 43 passing tests.

## Test plan

- [x] `cd backend && go build ./...` — Success
- [x] `cd backend && go vet ./...` — No issues found
- [x] `cd backend && gofmt -l cmd internal graph` — 0 unformatted files
- [x] `cd backend && go test -count=1 ./...` — exit 0, `ok` in 23 packages, 0 FAIL
- [x] `cd backend && go tool go-arch-lint check --project-path .` — OK, no warnings found
- [x] `go test -count=1 -v ./internal/repository/` with the container up — 327 result lines, exit 0
- [x] `env -u CI go test -count=1 -v -overlay <outage>.json ./internal/repository/` — exit 1, 43 PASS / 0 FAIL, three-line banner
- [x] `CI=1 go test -count=1 -overlay <outage>.json ./internal/repository/` — exit 1, bare container error, subset not run
- [x] `env -u CI go test -count=1 -overlay <outage>.json ./internal/repository/ -run 'TestCardRepository_BulkDelete'` — exit 1, dropped pattern named on stderr
- [x] `go test -count=1 -v -overlay <flip>.json ./internal/domain/service/ -run TestFSRSSchedulerApplyGoldenTransitions` — 12 of 16 rows FAIL
- [x] `go test -count=1 -v -overlay <transpose>.json ./internal/repository/ -run TestUserCardFSRSToDomain_AcceptsValidRow` — FAIL on the transposed pairs
- [x] `go test -count=1 -v -overlay <widen>.json ./internal/auth/ -run TestSuperUserPromoter_CachesAfterPromotion` — FAIL, both counters 0
- [x] `git diff --stat origin/main...HEAD -- '*.go' ':!*_test.go'` — empty, no production change
- [x] CJK and PR-order-reference greps over all four changed files — 0 matches
- [x] No frontend, schema, migration or infra file is touched

## Notes

Deliberately out of scope, recorded so it is not re-opened:

- **No invalidation hook for `confirmedAdmins`.** The current cache behaviour is intended and this branch pins it rather than changing it. The open design question — evict on role-set replacement, or add a negative marker for deliberately-demoted still-listed subs — stays open.
- **No FSRS parameter changed.** `EnableShortTerm` is flipped only inside a compile-time overlay for the demonstration above; it and `LearnedStabilityDays` are untouched on disk.
- **The `dockerFreeTests` allowlist is a maintenance contract enforced by its comment.** A new database-free test added to the repository directory will silently not run under a container outage until its name is added. A CI-side guard asserting the alternation covers exactly the set of tests that never touch `testDB` is possible, but it is new machinery well outside this change and was not built.

Ruled out during investigation: the scheduler needed no new test, since the existing golden table already fails on the flip; and the stability/difficulty predicates needed no new domain-level test, since the ungated domain tables for both landed on `main` after the issue was filed. What the issue described as missing there was the *repository* guard and its message shapes, which is what the new mapper file covers.

Closes #1105
