### PR TITLE
fix(frontend): redirect stale cardgroup edit bookmarks to /cardgroups on BAD_USER_INPUT

### DIFF
--- a/frontend/src/app/cardgroups/[id]/edit/page.test.tsx
+++ b/frontend/src/app/cardgroups/[id]/edit/page.test.tsx
@@ -90,6 +90,23 @@ describe("EditCardgroupPage", () => {
     await expect(EditCardgroupPage(makeParams("cg-1"))).rejects.toThrow("REDIRECT:/login");
   });
 
+  it("redirects to /cardgroups when the connection query returns BAD_USER_INPUT (unknown cardgroup)", async () => {
+    vi.mocked(headers).mockResolvedValue(
+      new Headers({ "x-auth-status": "authenticated" }) as never,
+    );
+    vi.mocked(gqlFetch).mockRejectedValue(
+      new Error(
+        `GraphQL errors: ${JSON.stringify([
+          { extensions: { code: "BAD_USER_INPUT", field: "cardgroupId" } },
+        ])}`,
+      ),
+    );
+
+    await expect(EditCardgroupPage(makeParams("cg-missing"))).rejects.toThrow(
+      "REDIRECT:/cardgroups",
+    );
+  });
+
   it("renders the management client with cardgroup data and initial connection counts", async () => {
     vi.mocked(headers).mockResolvedValue(
       new Headers({ "x-auth-status": "authenticated" }) as never,

--- a/frontend/src/app/cardgroups/[id]/edit/page.tsx
+++ b/frontend/src/app/cardgroups/[id]/edit/page.tsx
@@ -9,7 +9,7 @@ import type {
   CardgroupQuery as CardgroupQueryType,
   CardsByCardgroupConnectionQuery as CardsByCardgroupConnectionQueryType,
 } from "@/generated/graphql";
-import { redirectIfAuthError } from "@/lib/apollo/graphql-errors";
+import { isBadUserInputGraphQLError, redirectIfAuthError } from "@/lib/apollo/graphql-errors";
 import { gqlFetch } from "@/lib/apollo/server";
 import { requireAuthenticated } from "@/lib/supabase/auth-status";
 import { CardgroupManagementClient } from "./cardgroup-management-client";
@@ -39,6 +39,13 @@ export default async function EditCardgroupPage({ params }: Props) {
     ]);
   } catch (err) {
     redirectIfAuthError(err, "/login");
+    // The connection query authorizes the cardgroup in the usecase layer
+    // (authorizeCardgroupOrBadInput), so an unknown or deleted cardgroup
+    // surfaces as BAD_USER_INPUT before CardgroupQuery's null result is
+    // observable — redirect a stale bookmark to the listing instead of
+    // crashing to the error boundary. A foreign-owned id surfaces as
+    // UNAUTHENTICATED and is handled by redirectIfAuthError above.
+    if (isBadUserInputGraphQLError(err)) redirect("/cardgroups");
     console.error("[cardgroups/:id/edit] gqlFetch failed:", {
       name: err instanceof Error ? err.name : "unknown",
     });


### PR DESCRIPTION
## Summary

`/cardgroups/[id]/edit` fetches `CardgroupQuery` and `CardsByCardgroupConnectionQuery` in one `Promise.all`. The backend authorizes the connection query with `authorizeCardgroupOrBadInput`, so an unknown or deleted cardgroup id rejects that fetch with `BAD_USER_INPUT` — and because `CardgroupQuery`'s usecase returns `(nil, nil)` for a missing id (never an error), the `Promise.all` fails before the page's `if (!cardgroupData?.cardgroup) redirect("/cardgroups")` guard ever runs. A bookmark to a deleted cardgroup's edit page therefore crashed to the app-level error boundary instead of redirecting to the listing. Found by review round 8 (2026-07-23).

This change mirrors the established fix on the sibling learn page (`frontend/src/app/learn/[cardgroupId]/page.tsx`): inside the catch arm, after `redirectIfAuthError(err, "/login")`, a `isBadUserInputGraphQLError(err)` check redirects to `/cardgroups`. The redirect stays inside the catch — `redirect()` throws a `NEXT_REDIRECT` control-flow error, and a throw from inside the try body would be swallowed by this very catch. The foreign-owned-id case is untouched: it surfaces as `UNAUTHENTICATED` and is already handled by `redirectIfAuthError`.

## Changes

### Stale-bookmark redirect

- `frontend/src/app/cardgroups/[id]/edit/page.tsx` — import `isBadUserInputGraphQLError` from `@/lib/apollo/graphql-errors`; in the catch arm, redirect `BAD_USER_INPUT` rejections to `/cardgroups` (with a comment recording why the check lives in the catch and how the foreign-id case differs). The existing line-48 null backstop is kept unchanged for the residual race where the connection query succeeds but the cardgroup row disappears between the two fetches.

### Tests

- `frontend/src/app/cardgroups/[id]/edit/page.test.tsx` — one new branch test: a `BAD_USER_INPUT` rejection from `gqlFetch` redirects to `/cardgroups`, mirroring the learn page's test and this file's existing UNAUTHENTICATED test. The foreign-id case (`UNAUTHENTICATED` -> `/login`) is already pinned by the existing test and stays as-is.

## Verification

- Pre-flight test-discovery grep `grep -rln 'cardgroups/\[id\]/edit' frontend/src frontend/__tests__ frontend/e2e` — 3 hits, exactly matching the issue's stated list; zero e2e hits, so no Playwright spec in scope.
- `pnpm --filter frontend typecheck` — OK.
- `pnpm --filter frontend lint` — OK (biome, 534 files, no errors).
- `pnpm --filter frontend test` — PASS, 2103 tests across 214 files; the co-located edit page file runs 5 tests including the new branch test, and the untouched broad suites `frontend/__tests__/cardgroup-edit.test.tsx` / `cardgroups-detail.test.tsx` stay green.
- `pnpm --filter frontend knip` — OK (one pre-existing configuration hint only).
- `pnpm --filter frontend build` — OK.
- CJK gate (`perl -CSD` over tracked `frontend/src` sources) — only the sanctioned privacy/terms files appear.

Closes #1163
