### PR TITLE
perf(ci): exclude unused Supabase containers from the e2e stack startup

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -91,7 +91,14 @@ jobs:
         background: true
 
       - name: Start Supabase
-        run: supabase start
+        # E2E needs only postgres + kong + gotrue + postgrest; the rest is image-pull
+        # time on the critical path. realtime and storage-api stay OUT of the list on
+        # purpose: on a volume-less runner the CLI still runs their images as one-shot
+        # schema-init jobs, gated on config.toml rather than on -x, so excluding them
+        # would only move the same pulls off compose's parallel path onto a serial one.
+        # CI-only — config.toml is untouched, so a local `supabase start` is unchanged.
+        # See docs/ci.md § "Start only the Supabase containers the suite uses".
+        run: supabase start -x studio,imgproxy,mailpit,postgres-meta,edge-runtime,logflare,vector,supavisor
 
       - name: Export Supabase local env
         shell: bash

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -22,6 +22,18 @@ The job exports Supabase local keys from `supabase status -o env`; no repository
 
 The E2E workflow must trigger on backend file changes in addition to frontend and schema changes. A backend-only change (new endpoint, changed query shape, migration) can silently break the full integration while individual backend unit tests keep passing. Relying on the nightly cron to catch this introduces up to a 24-hour detection window. Add `backend/**` to the workflow's `paths:` filter so any backend push also queues an E2E run.
 
+### Start only the Supabase containers the suite uses
+
+`supabase start` boots every service enabled in `supabase/config.toml`, and on a cold runner the Docker image pulls dominate the E2E job's wall-clock. The suite needs four of them: **postgres** (migrations, seed data, and the `supabase db query --local` role seeding), **kong** (the `API_URL` gateway every Supabase call goes through), **gotrue** (`auth.admin.*` and `signInWithPassword` in `frontend/e2e/_auth.ts`, plus the app's own `auth.getUser()`), and **postgrest** (every `adminClient.from(...)`). The rest are handed to `supabase start -x`.
+
+**`realtime` and `storage-api` must stay out of the exclusion list even though no spec uses them.** When the database volume does not exist — always true on a fresh runner — the CLI runs a one-shot schema-init job built from the realtime and storage images. Those jobs are gated on `config.toml`'s `[realtime] enabled` / `[storage] enabled` flags, **not** on `-x`, so excluding the containers removes the images from the parallel pre-pull while still requiring them moments later. The pull then happens serially, mid-startup, on the critical path. Excluding them is a pessimisation, not a saving.
+
+Keep the exclusion in the workflow only. Flipping `enabled = false` in `supabase/config.toml` would strip Studio, Mailpit and Realtime from every developer's local stack too, which is not the intent — and for realtime/storage it would also change what schema the init jobs install.
+
+`supabase status -o env` still reports `API_URL`, `ANON_KEY`, `SERVICE_ROLE_KEY` and `DB_URL` with the exclusions applied, and `DB_URL` is built from `[db] port` (54322) rather than from a pooler port, so `supavisor` can be excluded without affecting the `Export Supabase local env` step. `supabase db query --local` connects to Postgres directly and does not need `postgres-meta`.
+
+If the stack ever fails to come up, narrow the list rather than reverting it, in this order: `mailpit` (gotrue is configured with an SMTP host pointing at the excluded container; harmless while no spec sends mail, since users are seeded with `email_confirm: true`), then `postgres-meta`, then `supavisor`. Each removal costs back only that image's pull time, so a partial exclusion still banks most of the win.
+
 ### Backend migration step ordering
 
 When the Go backend applies migrations via `golang-migrate` on startup (or via an explicit migrate step), tables created in those migrations — for example a `roles` table — do not exist immediately after `supabase start`. Any CI step that seeds canonical rows into backend-managed tables (e.g. `INSERT INTO roles ...`) must be placed **after** the backend has started and migrations have completed, not immediately after `supabase start`. Use a health-check or wait-on step to confirm the backend is ready before running seed SQL.


### PR DESCRIPTION
## Summary

The E2E job's wall-clock is dominated by `supabase start`, not by the tests. On the most recent green run the job took 274s wall-clock, of which `Start Supabase` alone was 186s — almost entirely Docker image pulls. The Playwright browser download (63s) and the backend build (85s) already overlap that window as `background: true` steps, so the pulls are the only thing left holding the job open, and most of them are for services this suite never touches.

This change passes `-x` to `supabase start` so the exclusion covers only containers that are neither used by the suite nor needed by the CLI's own startup. The four load-bearing services stay: postgres (migrations, seed data, `supabase db query --local`), kong (the `API_URL` gateway every Supabase call goes through), gotrue (`auth.admin.*` / `signInWithPassword` in `frontend/e2e/_auth.ts` and the app's own `auth.getUser()`), and postgrest (every `adminClient.from(...)`). It is CI-only: `supabase/config.toml` is untouched, so a developer's local `supabase start` is unchanged.

## Changes

### `.github/workflows/e2e.yml`

- `Start Supabase` now runs `supabase start -x studio,imgproxy,mailpit,postgres-meta,edge-runtime,logflare,vector,supavisor`. `kong`, `gotrue` and `postgrest` are deliberately absent from the list, and `postgres` is not an excludable container at all. Written as a plain single-line `run:` rather than a `>-` folded scalar so a future re-indent of the flag cannot silently split the command into two shell lines.
- No other step changes. `Export Supabase local env` consumes only `API_URL`, `ANON_KEY`, `SERVICE_ROLE_KEY` and `DB_URL`, all of which survive the exclusions.

### `docs/ci.md`

- New `### Start only the Supabase containers the suite uses` subsection under § "E2E workflow": which four services are load-bearing, why `realtime`/`storage-api` must stay out of the exclusion list, why the exclusion is CI-only, and the narrowing order to use if the stack ever fails to come up. Every other non-obvious `e2e.yml` decision in this file already has such a subsection.

## Scope note: `realtime` and `storage-api` are deliberately NOT excluded

The issue's exclusion list named `realtime` and `storage-api`. Excluding them is a pessimisation, and the primary source is the pinned CLI's own code:

- `internal/db/start/start.go:184` — `SetupLocalDatabase` runs whenever `NoBackupVolume && len(fromBackup) == 0`, and `NoBackupVolume` is set from a failed `VolumeInspect`, which is always the case on a fresh runner.
- `internal/db/start/start.go:334-346` — `initSchema15` (selected because `supabase/config.toml` sets `[db] major_version = 15`) appends `initRealtimeJob` when `utils.Config.Realtime.Enabled` and `initStorageJob` when `utils.Config.Storage.Enabled`. **Neither is gated on `isContainerExcluded`**, unlike every container-start site in `internal/start/start.go`.
- `initRealtimeJob` / `initStorageJob` run `utils.Config.Realtime.Image` and `utils.Config.Storage.Image`, and `supabase/config.toml` has `[realtime] enabled = true` and `[storage] enabled = true`.

So `-x realtime,storage-api` removes those images from the concurrent compose pre-pull while still requiring them moments later for the one-shot schema-init jobs — the same bytes, pulled serially, mid-startup, on the critical path. They are left in the pull set; only their long-running containers were ever the saving, and that saving is smaller than the serialised pull.

## Verification

Verified locally against a real stack on the pinned CLI (`.tool-versions`: `supabase 2.90.0`):

- `supabase start -x studio,imgproxy,mailpit,postgres-meta,edge-runtime,logflare,vector,supavisor` — exit 0. `docker ps` afterwards shows exactly four containers, all healthy: `supabase_db`, `supabase_kong`, `supabase_auth`, `supabase_rest`.
- **gotrue boots healthy without `mailpit`** — the issue's first rollback candidate, now empirically excluded. (`GOTRUE_MAILER_AUTOCONFIRM` is on and the suite seeds users with `email_confirm: true`, so no mail is ever sent.)
- `supabase status -o env` still emits every key the workflow consumes — `API_URL`, `ANON_KEY`, `SERVICE_ROLE_KEY`, `DB_URL` — plus `GRAPHQL_URL`, `JWT_SECRET`, `PUBLISHABLE_KEY`, `REST_URL`, `SECRET_KEY`.
- `DB_URL=postgresql://postgres:postgres@127.0.0.1:54322/postgres` — port 54322 is postgres directly, not a pooler, so excluding `supavisor` is safe (third rollback candidate). `internal/status/status.go:50-53` builds it from `Config.Db.Port` unconditionally.
- `supabase db query "select 1" --local` — succeeds with `postgres-meta` excluded; `internal/db/query/query.go` connects over pgx to port 54322 (second rollback candidate).
- `supabase start --help` on the pinned CLI enumerates the excludable set as `[gotrue,realtime,storage-api,imgproxy,kong,mailpit,postgrest,postgres-meta,studio,edge-runtime,logflare,vector,supavisor]`; every name passed is a member.
- `yaml.safe_load` — parses; the `Start Supabase` step's `run` resolves to exactly `supabase start -x studio,imgproxy,mailpit,postgres-meta,edge-runtime,logflare,vector,supavisor` with no embedded newline.
- `actionlint` — 3 findings, byte-identical to the pre-existing `main` baseline for this file (two `background:` step keys and one `wait-all:` step, all of which predate this change and run green today). No new finding.
- CJK check (`perl -CSD`) over both changed files — clean. No PR-order references.

### This PR's own E2E run (run 30139843214)

- **`14 passed`.** `Export Supabase local env` green.
- `Start Supabase` **186s → 153s**; total job wall-clock **274s → 241s**.
- `supabase status` reports `Stopped services: [supabase_inbucket, supabase_imgproxy, supabase_pg_meta, supabase_studio, supabase_edge_runtime, supabase_analytics, supabase_vector, supabase_pooler]` — exactly the eight excluded services, and nothing else.
- The only `Pulling from` lines in the whole log are `supabase/postgres` and `supabase/realtime`. No excluded image was pulled.
- `supabase/realtime` being pulled despite no realtime work in the suite is the scope note above confirmed end-to-end: had it stayed in the `-x` list, that pull would have moved from the parallel pre-pull to a serial one mid-startup.

## Notes

`logflare` and `vector` are already inert — `supabase/config.toml` sets `[analytics] enabled = false` and `internal/utils/config.go` only adds them to the pull set when analytics is enabled. `edge-runtime` and `supavisor` are likewise gated on config sections this repo does not declare. All four are kept in the list to document intent; the measurable win comes from `studio`, `imgproxy`, `mailpit` and `postgres-meta`.

Closes #1177
