### PR TITLE
perf(ci): run e2e specs on 2 Playwright workers, pin the catalog precondition

### DIFF
--- a/docs/e2e.md
+++ b/docs/e2e.md
@@ -47,7 +47,18 @@ Each seed call site already randomises the natural key (e.g. `runId = randomUUID
 
 ### `test.describe.serial` for DB-dependent sequences
 
-`fullyParallel: false` in `playwright.config.ts` prevents specs in different files from interleaving, but it is not sufficient to guarantee order within a single file when `test.only` or `--repeat-each` is active. When tests in a file share database state (e.g. a seeded card deck that successive tests consume), wrap them in `test.describe.serial` so Playwright enforces strict sequential execution regardless of flags. Without `serial`, a retry or `test.only` invocation can break the assumed order and cause a test to see a database state that a previous test was meant to set up.
+`fullyParallel: false` in `playwright.config.ts` keeps the tests *inside* one file sequential, but it is not sufficient to guarantee order within a single file when `test.only` or `--repeat-each` is active. When tests in a file share database state (e.g. a seeded card deck that successive tests consume), wrap them in `test.describe.serial` so Playwright enforces strict sequential execution regardless of flags. Without `serial`, a retry or `test.only` invocation can break the assumed order and cause a test to see a database state that a previous test was meant to set up.
+
+`fullyParallel: false` says nothing about *different* files: Playwright's unit of parallelism is the file, so with `workers > 1` two spec files run concurrently against the same Supabase. Cross-file isolation comes from the worker count alone, and CI runs `workers: 2`.
+
+### Global state is shared across workers
+
+Per-spec fixtures are already isolated — every spec derives a `runId` and prefixes its users, cardgroups and cards with it. Two tables are genuinely global and outlive any one file:
+
+- `roles` — `ensureRole()` upserts on the `name` unique. Concurrent `INSERT ... ON CONFLICT DO UPDATE` is safe under READ COMMITTED, and the workflow pre-seeds both canonical rows before Playwright starts.
+- `master_cardgroups` — the published catalog. `/onboarding/start` redirects to `/cardgroups/new?welcome=1` only while `masterCatalog.totalCount === 0`, and `new-user-onboarding.spec.ts` / `display-name-onboarding.spec.ts` both assert that redirect target. The catalog counts decks that are `PUBLISHED` **and** hold at least one card, so the suite stays green only because the one spec that seeds masters (`admin-masters-edit.spec.ts`) seeds them `DRAFT`.
+
+`assertNoPublishedMasters()` in `frontend/e2e/_auth.ts` pins the second precondition from both onboarding specs' `beforeAll`. It is a snapshot, not a lock: it turns a mis-seeded fixture into a named error instead of an opaque `waitForURL` timeout, but it cannot stop a concurrently-running file from publishing a deck after it has run, and it does not see a deck published through the admin UI rather than through `seedMaster`. A spec that genuinely needs a published master should not fight the guard — give it a worker-scoped fixture or a project dependency so it cannot overlap the onboarding specs.
 
 ### Do not assert on optimistic-update intermediate states
 

--- a/frontend/e2e/_auth.ts
+++ b/frontend/e2e/_auth.ts
@@ -178,7 +178,7 @@ export async function loginAs(
   if (error) {
     if (error.status === 429) {
       throw new Error(
-        `Rate-limited; consider raising rate_limit_email_sent in supabase/config.toml or reusing sessions: ${error.message}`,
+        `Rate-limited; consider raising auth.rate_limit.sign_in_sign_ups in supabase/config.toml or reusing sessions: ${error.message}`,
       );
     }
     throw error;
@@ -232,6 +232,13 @@ type SeedMasterInput = {
   cards?: { front: string; back: string }[];
 };
 
+/**
+ * Seeds a master cardgroup (default DRAFT) with optional cards. Publishing one —
+ * here via status: "PUBLISHED", or through the admin UI in another spec — makes the
+ * catalog non-empty and breaks new-user-onboarding.spec.ts and
+ * display-name-onboarding.spec.ts. assertNoPublishedMasters() catches this seed
+ * path; the UI path and cross-worker timing it cannot. See docs/e2e.md.
+ */
 export async function seedMaster({ name, status = "DRAFT", cards = [] }: SeedMasterInput) {
   const { data, error } = await adminClient
     .from("master_cardgroups")
@@ -251,6 +258,37 @@ export async function seedMaster({ name, status = "DRAFT", cards = [] }: SeedMas
     if (cardErr) throw new Error(`seedMaster cards(${name}): ${cardErr.message}`);
   }
   return data;
+}
+
+/**
+ * Asserts no PUBLISHED master deck exists — the precondition behind
+ * `/onboarding/start`'s fallback to /cardgroups/new?welcome=1, which fires only while
+ * masterCatalog.totalCount === 0. Deliberately stricter than that gate, which also
+ * requires the deck to hold cards. Sampled once in beforeAll, so it catches a bad seed
+ * rather than locking out a concurrently-running worker. See docs/e2e.md.
+ */
+export async function assertNoPublishedMasters() {
+  const { count, error } = await adminClient
+    .from("master_cardgroups")
+    .select("id", { count: "exact", head: true })
+    .eq("status", "published");
+  if (error) throw error;
+  // postgrest-js leaves `count` null when the response carries no parseable
+  // content-range, and leaves `error` null with it; `count ?? 0` would turn that
+  // into a silently passing guard.
+  if (typeof count !== "number") {
+    throw new Error(
+      "assertNoPublishedMasters: Supabase returned no row count for master_cardgroups",
+    );
+  }
+  if (count > 0) {
+    throw new Error(
+      `Expected an empty published master catalog, found ${count}. ` +
+        "/onboarding/start only falls back to /cardgroups/new?welcome=1 when " +
+        "masterCatalog.totalCount === 0; a PUBLISHED master deck breaks " +
+        "new-user-onboarding.spec.ts and display-name-onboarding.spec.ts.",
+    );
+  }
 }
 
 async function ensureRole(role: RoleName) {

--- a/frontend/e2e/display-name-onboarding.spec.ts
+++ b/frontend/e2e/display-name-onboarding.spec.ts
@@ -1,13 +1,14 @@
 import { randomUUID } from "node:crypto";
 import { expect, test } from "@playwright/test";
-import { loginAs, seedUser } from "./_auth";
+import { assertNoPublishedMasters, loginAs, seedUser } from "./_auth";
 
 // Scenario: a user whose displayName is empty is redirected to /onboarding, fills
 // in a display name, and submits. OnboardingForm pushes /onboarding/start (the
-// first-deck chooser); because the e2e DB seeds no master decks, that route hits
-// its empty-catalog fallback and redirects to /cardgroups/new?welcome=1, which is
-// the URL this test waits for. Seeding a master deck would make the chooser render
-// and stay on /onboarding/start instead.
+// first-deck chooser); because the e2e DB holds no PUBLISHED master deck — the only
+// ones any spec seeds are DRAFT — that route hits its empty-catalog fallback and
+// redirects to /cardgroups/new?welcome=1, which is the URL this test waits for.
+// Publishing a deck with cards would make the chooser render and stay on
+// /onboarding/start instead; assertNoPublishedMasters() in beforeAll pins that.
 //
 // The first hop is now owned by the MIDDLEWARE display-name gate, not by the home
 // RSC: the gate redirects every non-exempt path to /onboarding while displayName is
@@ -26,6 +27,7 @@ const onboarder = {
 test.describe
   .serial("display name onboarding redirect", () => {
     test.beforeAll(async () => {
+      await assertNoPublishedMasters();
       // Seed with displayName: "" so isUserOnboarded() returns false and the
       // middleware gate redirects to /onboarding instead of letting the home RSC
       // route the user on to /cardgroups.

--- a/frontend/e2e/new-user-onboarding.spec.ts
+++ b/frontend/e2e/new-user-onboarding.spec.ts
@@ -1,13 +1,15 @@
 import { randomUUID } from "node:crypto";
 import { expect, test } from "@playwright/test";
-import { loginAs, seedUser } from "./_auth";
+import { assertNoPublishedMasters, loginAs, seedUser } from "./_auth";
 
 // Scenario: a brand-new user (zero cardgroups, no last_viewed) is funnelled by
 // the HomePage chain to /onboarding/start (the first-deck chooser). Because the
-// e2e DB seeds no master decks, that route hits its empty-catalog fallback and
-// redirects to /cardgroups/new?welcome=1, where the user creates their first
-// cardgroup; the nav-header "+" button then opens the inline "Add card"
-// FormSheet on the cardgroup edit page (no navigation to /cards/new).
+// e2e DB holds no PUBLISHED master deck — the only ones any spec seeds are DRAFT —
+// that route hits its empty-catalog fallback and redirects to
+// /cardgroups/new?welcome=1, where the user creates their first cardgroup; the
+// nav-header "+" button then opens the inline "Add card" FormSheet on the
+// cardgroup edit page (no navigation to /cards/new). assertNoPublishedMasters()
+// in beforeAll pins that precondition.
 
 const runId = randomUUID().slice(0, 8);
 const newcomer = {
@@ -29,6 +31,7 @@ test.describe
     test.use({ viewport: { width: 390, height: 844 } });
 
     test.beforeAll(async () => {
+      await assertNoPublishedMasters();
       // Seed only the auth user + role; deliberately NO cardgroup so the home
       // RSC routes the deckless-onboarded user to /onboarding/start on first
       // login (which falls back to /cardgroups/new?welcome=1 — see file header).

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -7,7 +7,11 @@ export default defineConfig({
   fullyParallel: false,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,
-  workers: process.env.CI ? 1 : undefined,
+  // File-level parallelism only: `fullyParallel: false` above keeps each file's
+  // tests sequential, which the `test.describe.serial` files and the
+  // `beforeAll`-seeded fixtures rely on. 2 rather than 4 because the runner also
+  // hosts postgres, the Next server and the Go backend.
+  workers: process.env.CI ? 2 : undefined,
   reporter: process.env.CI ? [["html"], ["github"], ["list"]] : [["html"], ["list"]],
   use: {
     baseURL,


### PR DESCRIPTION
## Summary

`frontend/playwright.config.ts` pinned CI to a single worker, so the 14 specs executed strictly one after another — ~29s of a 274s job, with individual tests running 765ms–4.2s. Raising the worker count to 2 recovers roughly half of that. `fullyParallel: false` stays as-is: with it, Playwright parallelises at *file* granularity and keeps every test inside a file sequential, which is exactly what six `test.describe.serial` spec files and several `beforeAll`-seeded fixtures require.

Raising the worker count also promotes one latent coupling into a genuine order-dependent flake, so it is fixed in the same change. `/onboarding/start` redirects to `/cardgroups/new?welcome=1` only while `masterCatalog.totalCount === 0`, and `new-user-onboarding.spec.ts` / `display-name-onboarding.spec.ts` both assert that redirect target. The precondition holds today only by accident of the seed data — `masterCatalog` resolves through `ListPublishedConnection` (published-only), and the one spec that seeds masters uses `status: "DRAFT"`. A new `assertNoPublishedMasters()` makes the dependency explicit at both call sites, so a future spec that publishes a deck fails with a named error instead of an opaque `waitForURL` timeout.

## Changes

### Worker count

- `frontend/playwright.config.ts` — `workers: process.env.CI ? 2 : undefined`, with a comment recording why file-level parallelism is the only kind this suite tolerates and why 2 rather than 4 (the runner also hosts postgres, the Next server and the Go backend). `fullyParallel`, `retries` and everything else are unchanged.

### Empty-published-catalog precondition

- `frontend/e2e/_auth.ts` — new exported `assertNoPublishedMasters()`, a `head`+`count: "exact"` read of `master_cardgroups` filtered on `status = 'published'`. The filter value is lowercase because `seedMaster` writes `status.toLowerCase()` and the column is `text NOT NULL DEFAULT 'draft'` with `CHECK (status IN ('draft','published'))` (`20260614000000_add_master_tables.up.sql:72,78`). A non-numeric `count` is thrown rather than coalesced to 0 — postgrest-js leaves `count` null with `error` also null when the response carries no parseable `content-range`, and `count ?? 0` would turn the guard into a silent no-op.
- `frontend/e2e/new-user-onboarding.spec.ts`, `frontend/e2e/display-name-onboarding.spec.ts` — call it as the first statement of `test.beforeAll`.
- `frontend/e2e/_auth.ts` — `seedMaster` gains a docstring warning that publishing a deck (here or through the admin UI) breaks both onboarding specs.

### Adjacent corrections surfaced by the change

- `frontend/e2e/{new-user,display-name}-onboarding.spec.ts` headers claimed "the e2e DB seeds no master decks". That is false — `admin-masters-edit.spec.ts` seeds two — and `display-name-onboarding.spec.ts` went further with "Seeding a master deck would make the chooser render", which the two existing DRAFT decks directly contradict. Both headers now state the actual load-bearing fact: no deck is PUBLISHED. The new assertion sits immediately below them, so the mismatch became visible.
- `frontend/e2e/_auth.ts` — the 429 branch of `loginAs` suggested raising `rate_limit_email_sent`. A `signInWithPassword` 429 is governed by `auth.rate_limit.sign_in_sign_ups` (default 30 per 5 minutes per IP; `email_sent` defaults to 2/hour and requires SMTP). Doubling the workers compresses the suite's 15 sign-ins toward a single window, so this is the message a developer is now more likely to read.
- `docs/e2e.md` — "`fullyParallel: false` … prevents specs in different files from interleaving" was true only because `workers` was 1. Playwright's unit of parallelism is the file, so the sentence is corrected and a `### Global state is shared across workers` subsection records the two genuinely global tables (`roles`, `master_cardgroups`), why `roles` is safe, and what `assertNoPublishedMasters()` does and does not guarantee.

## Verification

- `tsc --noEmit` — exit 0.
- `biome check --error-on-warnings .` — exit 0 (2 `info`-level notices about `biome.json`'s own schema version, pre-existing and not in the diff).
- `frontend/tsconfig.json`'s `include` does **not** cover `e2e/**` (`tsc --noEmit --listFiles | grep -c '/frontend/e2e/'` returns 0), and Playwright transpiles specs with esbuild, so the repo's typecheck gate would not have caught a type error in the new helper. Closed manually: `tsc --noEmit --ignoreConfig --strict` over all of `e2e/*.ts` — exit 0.
- `playwright test --list` — `Total: 14 tests in 9 files`, unchanged from baseline.
- The helper's exact query shape was run against a live local Supabase stack: `head`+`count` returns a **number**, and the uppercase probe `.eq("status","PUBLISHED")` returns 0 against a row whose stored value is `published` — confirming the lowercase filter is the correct one and that an uppercase filter would have been a silent false-negative guard.
- `assertNoPublishedMasters` call-site grep outside `_auth.ts`: 2, matching the plan.
- CJK check (`perl -CSD`) over all five changed files — clean. No PR-order references.

### This PR's own E2E runs (run 30139844638, both attempts)

- Attempt 1: `13 passed / 1 flaky` — see the flake note below. Attempt 2 (re-run, as the issue's order-dependence check requires): **`14 passed`**.
- **Two workers demonstrably ran.** Test completions interleave across spec files rather than forming one per-file chain: `cardgroup-import` → `admin-masters-edit` → `cardgroup-import` → `cardgroups-flow` → `admin-masters-edit` → `cardgroups-flow` → `cardgroups-mobile-search` → … That ordering is impossible with a single worker.
- `Run Playwright` **62s → 48s** (attempt 1) / **55s** (attempt 2).
- Zero `Rate-limited` occurrences in either log.
- `assertNoPublishedMasters()` did not fire, as expected: no spec publishes a master deck.

### The attempt-1 flake is pre-existing and unrelated

`new-user-onboarding.spec.ts:58` failed on `#welcome-heading` resolving to two elements (strict-mode violation) before passing on retry. This is **not** caused by the worker change — the identical failure occurs on `main` at `workers: 1`, in runs 30068420436 and 30015359859, and in 4 of the last 9 E2E runs across three branches. Root cause and fix tracked separately in #1183; deliberately not folded into this PR, which owns issue #1178 only.

## Known limitation

`assertNoPublishedMasters()` is a `beforeAll` snapshot, not a lock. Under two workers a concurrently-running file could publish a deck after the assertion passes, and it does not observe a deck published through the admin UI rather than through `seedMaster`. It is a regression tripwire that converts a silent timeout into a named error — nothing today can trip it, since the only master-seeding spec seeds DRAFT. A spec that genuinely needs a published master should get a worker-scoped fixture or a project dependency rather than fight the guard; this is written down in `docs/e2e.md` next to the guard's description.

Closes #1178
