### PR TITLE
perf(ci): move the Next.js production build off the e2e critical path

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -41,6 +41,13 @@ jobs:
     env:
       BACKEND_URL: http://localhost:1323
       E2E_BASE_URL: http://localhost:3000
+      # Pinned local-stack identity so the Next build can start before `supabase start`
+      # finishes. Deterministic for the CLI pinned in .tool-versions together with the
+      # committed supabase/config.toml, which declares neither auth.jwt_secret nor
+      # signing keys — the CLI then signs the anon JWT with its built-in secret and a
+      # fixed expiry. "Export Supabase local env" asserts both still match the stack.
+      E2E_LOCAL_API_URL: http://127.0.0.1:54321
+      E2E_LOCAL_ANON_KEY: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0
       # The e2e suite does not use introspection (__schema / __type); keep it
       # disabled to match the fail-safe production default. Quoted so YAML does
       # not coerce it to a boolean.
@@ -72,13 +79,13 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       # The Playwright browser download (network), the Supabase stack (Docker
-      # image pulls), and the backend build (CPU) are mutually independent and
-      # bottleneck on different resources, so running them concurrently cuts
-      # wall-clock setup time. The browser download and the backend build run as
-      # background steps that overlap with `supabase start`; the job reconverges
-      # at the `wait-all` below, before the backend process needs its binary and
-      # the Supabase DB URL. Each background step keeps its own log stream in the
-      # Actions UI.
+      # image pulls), the backend build (CPU) and the Next.js production build
+      # (CPU) are mutually independent and bottleneck on different resources, so
+      # running them concurrently cuts wall-clock setup time. The browser
+      # download and the two builds run as background steps that overlap with
+      # `supabase start`; the job reconverges at the `wait-all` below, before the
+      # backend process needs its binary and the Supabase DB URL. Each background
+      # step keeps its own log stream in the Actions UI.
       - name: Install Playwright Chromium
         run: pnpm --filter frontend exec playwright install --with-deps chromium
         background: true
@@ -89,6 +96,18 @@ jobs:
           go tool gqlgen generate
           go build -o /tmp/flamingo-backend ./cmd/server
         background: true
+
+      - name: Build frontend
+        # `next build` inlines NEXT_PUBLIC_* into the served bundle, so it needs the
+        # real local values rather than the post-start `supabase status` output —
+        # waiting for that output is exactly what keeps the build on the critical
+        # path. The build contacts neither the backend nor Supabase (codegen reads
+        # ../schema/*.graphql from disk), so running it this early is safe.
+        run: pnpm --filter frontend build
+        background: true
+        env:
+          NEXT_PUBLIC_SUPABASE_URL: ${{ env.E2E_LOCAL_API_URL }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ env.E2E_LOCAL_ANON_KEY }}
 
       - name: Start Supabase
         # E2E needs only postgres + kong + gotrue + postgrest; the rest is image-pull
@@ -112,6 +131,19 @@ jobs:
           : "${API_URL:?supabase status missing API_URL}"
           : "${ANON_KEY:?supabase status missing ANON_KEY}"
           : "${SERVICE_ROLE_KEY:?supabase status missing SERVICE_ROLE_KEY}"
+          # The background "Build frontend" step baked the pinned constants into the
+          # bundle before the stack was up. If the stack disagrees, that bundle is
+          # wrong; fail here with a diagnosable message instead of at the auth gate of
+          # all 14 tests. Print prefix + length only, never a whole key.
+          if [ "$API_URL" != "$E2E_LOCAL_API_URL" ] || [ "$ANON_KEY" != "$E2E_LOCAL_ANON_KEY" ]; then
+            echo "Local Supabase identity drifted from the pinned constants used by the"
+            echo "background 'Build frontend' step; the served bundle has wrong values baked in."
+            echo "  API_URL   expected=$E2E_LOCAL_API_URL actual=$API_URL"
+            echo "  ANON_KEY  expected prefix=$(printf %.12s "$E2E_LOCAL_ANON_KEY") len=${#E2E_LOCAL_ANON_KEY}"
+            echo "            actual   prefix=$(printf %.12s "$ANON_KEY") len=${#ANON_KEY}"
+            echo "Update E2E_LOCAL_API_URL / E2E_LOCAL_ANON_KEY in the job env block."
+            exit 1
+          fi
           {
             echo "E2E_SUPABASE_URL=$API_URL"
             echo "E2E_SUPABASE_ANON_KEY=$ANON_KEY"

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -34,6 +34,16 @@ Keep the exclusion in the workflow only. Flipping `enabled = false` in `supabase
 
 If the stack ever fails to come up, narrow the list rather than reverting it, in this order: `mailpit` (gotrue is configured with an SMTP host pointing at the excluded container; harmless while no spec sends mail, since users are seeded with `email_confirm: true`), then `postgres-meta`, then `supavisor`. Each removal costs back only that image's pull time, so a partial exclusion still banks most of the win.
 
+### Pin the local Supabase identity when the Next build runs early
+
+The E2E job overlaps its slow setup work with `supabase start` using `background: true` steps that reconverge at `wait-all`. The Next.js production build belongs in that shadow too, but it cannot simply be moved there: `frontend/src/env.ts` declares `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY` as client vars, and `next build` **inlines** them into the served bundle. Unlike the frontend workflow's `lint-test-build` job, which builds with dummy values it never serves, this bundle is handed to a real browser that authenticates a seeded session against GoTrue with that key. Reading the values from `supabase status` is exactly what would keep the build on the critical path.
+
+They are therefore pinned as job-level constants (`E2E_LOCAL_API_URL`, `E2E_LOCAL_ANON_KEY`). Both are deterministic: the API URL comes from `supabase/config.toml`'s `[api] port`, and because that file declares neither `auth.jwt_secret` nor signing keys, the CLI signs the anon JWT with its built-in local secret and a fixed expiry constant rather than a wall-clock-derived one. The pin is valid for the CLI version in `.tool-versions`; a CLI bump is the thing most likely to invalidate it.
+
+`Export Supabase local env` re-reads the stack's real values and fails the job if either constant disagrees, printing each key's prefix and length rather than the key itself. Without that assertion a drifted key would surface as all 14 specs failing at the auth gate, with nothing pointing at the build step that baked in the wrong value.
+
+The build is safe this early because it touches neither service: `graphql-codegen` reads `../schema/*.graphql` from disk, and no route fetches at build time.
+
 ### Backend migration step ordering
 
 When the Go backend applies migrations via `golang-migrate` on startup (or via an explicit migrate step), tables created in those migrations — for example a `roles` table — do not exist immediately after `supabase start`. Any CI step that seeds canonical rows into backend-managed tables (e.g. `INSERT INTO roles ...`) must be placed **after** the backend has started and migrations have completed, not immediately after `supabase start`. Use a health-check or wait-on step to confirm the backend is ready before running seed SQL.

--- a/docs/e2e.md
+++ b/docs/e2e.md
@@ -135,7 +135,7 @@ First run downloads Chromium via `pnpm --filter frontend exec playwright install
 
 ## CI
 
-`.github/workflows/e2e.yml` starts Supabase, exports the local keys into the job environment, starts the Go backend, and lets Playwright build/start the Next.js app via `frontend/playwright.config.ts`. See `docs/ci.md` § "E2E workflow" for the trigger, concurrency, and retention policy.
+`.github/workflows/e2e.yml` starts Supabase, exports the local keys into the job environment, starts the Go backend, and runs Playwright. The Next.js production build is a background workflow step rather than part of `webServer`, so on CI `frontend/playwright.config.ts` only *starts* the built app; locally it still builds first. See [`docs/ci.md` § "E2E workflow"](ci.md#e2e-workflow) for the trigger, concurrency, and retention policy, and [§ "Pin the local Supabase identity when the Next build runs early"](ci.md#pin-the-local-supabase-identity-when-the-next-build-runs-early) for why the build needs pinned constants.
 
 Failure artifacts uploaded by the job:
 

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -21,13 +21,17 @@ export default defineConfig({
     screenshot: "only-on-failure",
     video: "retain-on-failure",
   },
-  // webServer runs `next build` then `next start` so tests exercise the same code
-  // path as production. `reuseExistingServer: !process.env.CI` lets a developer
-  // running `next dev` on :3000 skip both build and start. The `env` block falls
-  // back from NEXT_PUBLIC_SUPABASE_* to E2E_SUPABASE_* so a CI runner exporting
-  // only the E2E_* form still satisfies @t3-oss/env-nextjs build-time validation.
+  // webServer serves a production build so tests exercise the same code path as
+  // production. On CI that build is a background workflow step overlapping
+  // `supabase start`, so webServer only starts it; locally webServer builds first.
+  // `reuseExistingServer: !process.env.CI` lets a developer running `next dev` on
+  // :3000 skip both. The `env` block falls back from NEXT_PUBLIC_SUPABASE_* to
+  // E2E_SUPABASE_* so a CI runner exporting only the E2E_* form still satisfies
+  // @t3-oss/env-nextjs build-time validation.
   webServer: {
-    command: "pnpm --filter frontend build && pnpm --filter frontend start",
+    command: process.env.CI
+      ? "pnpm --filter frontend start"
+      : "pnpm --filter frontend build && pnpm --filter frontend start",
     url: baseURL,
     reuseExistingServer: !process.env.CI,
     timeout: 120_000,


### PR DESCRIPTION
## Summary

The E2E job already overlaps its two slowest build steps with `supabase start` using `background: true` + `wait-all`. The Next.js production build was the one build still on the critical path, because it lived inside Playwright's `webServer` command. On the baseline run `Run Playwright` took 62s, of which the first test result did not appear until 33s in — that leading window is `next build` + `next start`; the 14 tests are the remaining ~29s. Moving the build into the existing background shadow removes those ~33s from the critical path outright, and there is ample room: the shadow is 186s today against 85s + 63s + ~33s of background work.

The build cannot simply be moved as-is. `frontend/src/env.ts` declares `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY` as client vars and `next build` **inlines** them into the served bundle, and unlike the frontend workflow's `lint-test-build` job — which builds with dummy values it never serves — this bundle is handed to a real browser that authenticates a seeded session against GoTrue with that key. Waiting for `supabase status` to supply them is precisely what keeps the build on the critical path. They are therefore pinned as job-level constants and asserted against the stack once it is up, so drift fails loudly at a named step instead of silently baking a wrong key into the bundle.

## Changes

### `.github/workflows/e2e.yml`

- Job `env:` gains `E2E_LOCAL_API_URL` and `E2E_LOCAL_ANON_KEY`, with a comment recording why they are deterministic.
- New `Build frontend` background step, placed after `Generate and build backend` so it joins the same background group and reconverges at the existing `wait-all`. It maps the two constants onto `NEXT_PUBLIC_*`; `BACKEND_URL` is inherited from the job env block.
- The comment block above the background steps now names three tracks rather than two.
- `Export Supabase local env` asserts both constants against the values `supabase status` reports, printing each key's prefix and length rather than the key itself, and exits 1 on mismatch with the exact env-block names to update.

### `frontend/playwright.config.ts`

- `webServer.command` becomes `process.env.CI ? "pnpm --filter frontend start" : "pnpm --filter frontend build && pnpm --filter frontend start"`. `url`, `timeout`, `reuseExistingServer` and the whole `env:` block are unchanged — the `env` block still feeds the local build, and `BACKEND_URL` is read at runtime by the served server.
- The comment above it said `webServer` runs `next build` then `next start`, which stops being true on CI; rewritten.

### Docs

- `docs/ci.md` — new `### Pin the local Supabase identity when the Next build runs early` subsection under § "E2E workflow": why dummy values will not do here, why the two constants are deterministic, what the assertion buys, and why the build is safe before either service is up.
- `docs/e2e.md` § "CI" said the workflow "lets Playwright build/start the Next.js app". The build half is no longer true on CI; corrected, with anchor links to both `docs/ci.md` sections.

## Verification

- The pinned `E2E_LOCAL_ANON_KEY` was derived from the pinned CLI's source rather than copied: `pkg/config/apikeys.go:75-87` takes the symmetric-signing branch whenever `SigningKeysPath`/`SigningKeys` are unset — which `supabase/config.toml` leaves unset — so the anon JWT is signed with `defaultJwtSecret` and the **fixed** `defaultJwtExpiry = 1983812996` (`:18`), not a wall-clock expiry. Recomputing HS256 over `{"iss":"supabase-demo","role":"anon","exp":1983812996}` reproduces the value byte-for-byte.
- Confirmed against a **running** local stack: `supabase status -o env` reports `API_URL=http://127.0.0.1:54321` and an `ANON_KEY` string-equal to the pinned constant.
- The assertion block was replayed both ways with `bash -n` and live values: real values → passes, exit 0; a deliberately drifted key → exits 1 with the prefix/length diagnostic and no key leaked into the output.
- **`pnpm --filter frontend build` with the pinned constants and no Supabase and no backend running — exit 0**, full route table emitted. This is the CI background step's exact situation; `graphql-codegen` reads `../schema/*.graphql` from disk and no route fetches at build time.
- `yaml.safe_load` — parses; step order confirmed as `Install Playwright Chromium` / `Generate and build backend` / `Build frontend` (all `background: true`) → `Start Supabase` → `Export Supabase local env` → `wait-all`.
- `bash -n` on the extracted `Export Supabase local env` script — syntax OK.
- `actionlint` — 4 findings, all of the same two pre-existing classes as the `main` baseline (the third `background:` key is the one this change adds; `background:`/`wait-all:` are keys actionlint does not model, and the workflow runs green today).
- `tsc --noEmit` exit 0; `biome check --error-on-warnings .` exit 0; `tsc --ignoreConfig --strict` over `e2e/*.ts` exit 0 (that tree is outside `tsconfig.json`'s `include`); `playwright test --list` → `Total: 14 tests in 9 files`.
- With `CI` unset the `webServer.command` ternary still resolves to the build-then-start form, so the local path is unchanged.
- CJK check (`perl -CSD`) over all four changed files — clean. No PR-order references.

The PR's own E2E run is the remaining gate: confirm `14 passed`, that `Export Supabase local env` is green rather than exiting 1, that a `Build frontend` step appears with its own log stream and completes before `wait-all`, and that `Run Playwright` drops from 62s to roughly 30s. If `Build frontend` does not finish inside the shadow, report the measured numbers rather than reverting.

## Stacking

Based on `worktree-1178-playwright-workers` and carrying `worktree-1177-supabase-exclude-containers` merged in, because this change edits both `.github/workflows/e2e.yml` (also touched by #1177) and `frontend/playwright.config.ts` (also touched by #1178). Until #1177 lands, the diff shown here also contains its two commits — the `-x` flag on `Start Supabase` and the `### Start only the Supabase containers the suite uses` subsection in `docs/ci.md`. Everything else in the diff belongs to this change.

**Retarget to `main` and close/reopen once #1177 and #1178 have merged** — the E2E workflow is `pull_request: branches: [main]`-gated, so it does not fire while the base is a branch, and this PR's own E2E run is its gate.

Closes #1179
