### PR TITLE
fix(e2e): stabilise the #welcome-heading assertion with .first()

### DIFF
--- a/frontend/e2e/new-user-onboarding.spec.ts
+++ b/frontend/e2e/new-user-onboarding.spec.ts
@@ -52,7 +52,12 @@ test.describe
       await page.waitForURL("**/cardgroups/new?welcome=1", { timeout: 10_000 });
       // Use the existing id="welcome-heading" to avoid locale-dependent text matching
       // (Playwright runs with ja-JP locale so translated text won't match English regex).
-      await expect(page.locator("#welcome-heading")).toBeVisible();
+      // Not a bare locator: waitForURL resolves on the URL change, and the two-hop
+      // redirect can still have the outgoing tree mounted at that instant, so the id
+      // transiently resolves to two <h1> nodes and strict mode fails. .first()
+      // re-resolves on every toBeVisible() retry and converges once the transition
+      // settles. The duplicate render itself is a real defect, tracked in #1183.
+      await expect(page.locator("#welcome-heading").first()).toBeVisible();
 
       // 2. Submit the create-cardgroup form. onCompleted pushes /cardgroups/<newId>,
       // which redirects server-side to /cardgroups/<newId>/edit. Wait for the


### PR DESCRIPTION
## Summary

`new-user-onboarding.spec.ts` asserts the welcome page has landed by matching `#welcome-heading`, but the id transiently resolves to two `<h1>` nodes during the `/` → `/onboarding/start` → `/cardgroups/new?welcome=1` chain, so Playwright's strict mode fails the bare locator. It fired in 4 of the last 9 E2E runs across three branches, including twice on `main` at `workers: 1` — it is not caused by the Playwright worker-count change. `retries: 1` masks it, so the job still reports `success` with a `1 flaky / 13 passed` line that is easy to miss.

The retry is not free, and it is landing on top of the three in-flight CI-perf PRs (#1180 / #1181 / #1182) whose whole claim is e2e wall-clock. On `main`, the `Run Playwright` step measures 62s on a clean run (30070211421) against 68s and 67s on the two flaky ones (30068420436, 30015359859) — a ~6s retry tax that is the same magnitude as the 48s/55s spread #1181 reports as its improvement. This change applies the cheap stabiliser so those measurements stop carrying flake noise; the duplicate render itself stays open in #1183.

## Changes

- `frontend/e2e/new-user-onboarding.spec.ts` — the welcome-page assertion becomes `page.locator("#welcome-heading").first()`. `.first()` re-resolves on every `toBeVisible()` retry, so it converges once the outgoing tree unmounts, where the bare locator raises `strict mode violation: locator('#welcome-heading') resolved to 2 elements` and picks the `hidden` copy. A comment records why the bare locator is not used and points at #1183 for the underlying duplicate.

## Verification

- `biome check frontend/e2e/new-user-onboarding.spec.ts` — `Checked 1 file. No fixes applied.`
- `tsc --noEmit --ignoreConfig --strict --skipLibCheck --target ES2022 --module esnext --moduleResolution bundler --types node e2e/*.ts` — exit 0. The standalone invocation is required because `frontend/tsconfig.json`'s `include` does not cover `e2e/**`, so `pnpm --filter frontend typecheck` type-checks zero e2e files.
- The suite itself cannot be run from a worktree (it needs a live Supabase + backend stack and the `E2E_SUPABASE_*` env vars), so the real check is on CI: after merge, `gh run view <RID> --log | grep -E '[0-9]+ flaky|resolved to 2 elements'` should print nothing across several runs.
- Post-flight grep: `grep -rn 'welcome-heading' frontend/ --include='*.ts' --include='*.tsx'` — the only other e2e spec that reaches this URL (`display-name-onboarding.spec.ts:69`) stops at `waitForURL` and has no heading assertion, so this is the single affected site.

## Notes

This does **not** carry `Closes #1183`. Two `<h1>` elements sharing an id is invalid HTML regardless of the test, and the mechanism producing the second copy is still unpinned (service-worker app-shell copy / React streaming window / a `router.refresh()` double-mount are the open candidates). #1183 stays open for that half, exactly as its "Suggested fix" section states.

Merge order: this should land before #1181 and #1182 so their `Run Playwright` numbers are measured against a flake-free baseline. #1180 is independent. The `.first()` line sits at `:55`, clear of the `:1-14` / `:31` hunks #1181 touches in the same file, so only a rebase is needed.

Refs #1183
