### PR TITLE
refactor(backend): move ElapsedDays ownership from go-fsrs into the domain

### DIFF
--- a/backend/internal/domain/fsrs_state.go
+++ b/backend/internal/domain/fsrs_state.go
@@ -67,6 +67,25 @@ type FSRSState struct {
 	LastRating Rating
 }
 
+// ElapsedDaysAt returns the whole days elapsed since LastReview at now — the
+// value FSRSState.ElapsedDays carries. This is the application's definition, not
+// the scheduler library's: go-fsrs v4 removes Card.ElapsedDays and counts
+// elapsed days internally by UTC calendar date without exposing the result.
+// domain.rescueMinElapsed and service.isOnTimeRecall both read against this
+// definition, so changing the formula moves the 24h rescue floor and the
+// on-time-recall statistic together.
+//
+// A New card and a card with no LastReview both yield 0: neither has a prior
+// review to measure from. The now.Before branch is a clock-skew guard — Apply
+// already clamps now to LastReview before calling this, but the method must be
+// correct on its own.
+func (s FSRSState) ElapsedDaysAt(now time.Time) int {
+	if s.Phase == FSRSPhaseNew || s.LastReview.IsZero() || now.Before(s.LastReview) {
+		return 0
+	}
+	return int(now.Sub(s.LastReview).Hours() / 24)
+}
+
 // NewCardStability and NewCardDifficulty are the placeholder scheduling values a
 // card carries until its first review. The scheduler overwrites both on that
 // first review, so neither ever influences a computed interval: they exist so a

--- a/backend/internal/domain/fsrs_state_test.go
+++ b/backend/internal/domain/fsrs_state_test.go
@@ -105,6 +105,10 @@ func TestIsValidDifficulty(t *testing.T) {
 // boundary to the rescue window's admission floor. A card admitted at exactly
 // rescueMinElapsed must receive one elapsed day of scheduling credit, while a
 // card just below that floor must receive none.
+//
+// The backward-skew row is a full day early on purpose: with a sub-24h skew the
+// unguarded expression truncates to the same 0 the guard returns, so deleting
+// the guard would leave the row green.
 func TestRescueMinElapsedMatchesElapsedDayRollover(t *testing.T) {
 	t.Parallel()
 
@@ -122,7 +126,8 @@ func TestRescueMinElapsedMatchesElapsedDayRollover(t *testing.T) {
 		{"exactly 48h since last review", FSRSPhaseReview, lastReview, lastReview.Add(48 * time.Hour), 2},
 		{"new card", FSRSPhaseNew, lastReview, lastReview.Add(48 * time.Hour), 0},
 		{"no last review", FSRSPhaseReview, time.Time{}, lastReview, 0},
-		{"now before last review", FSRSPhaseReview, lastReview, lastReview.Add(-time.Second), 0},
+		{"now a second before last review", FSRSPhaseReview, lastReview, lastReview.Add(-time.Second), 0},
+		{"now a full day before last review", FSRSPhaseReview, lastReview, lastReview.Add(-25 * time.Hour), 0},
 	}
 
 	for _, tc := range tests {

--- a/backend/internal/domain/fsrs_state_test.go
+++ b/backend/internal/domain/fsrs_state_test.go
@@ -3,6 +3,7 @@ package domain
 import (
 	"math"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -96,6 +97,43 @@ func TestIsValidDifficulty(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			require.Equal(t, tc.want, IsValidDifficulty(tc.input))
+		})
+	}
+}
+
+// TestRescueMinElapsedMatchesElapsedDayRollover pins the scheduling-credit
+// boundary to the rescue window's admission floor. A card admitted at exactly
+// rescueMinElapsed must receive one elapsed day of scheduling credit, while a
+// card just below that floor must receive none.
+func TestRescueMinElapsedMatchesElapsedDayRollover(t *testing.T) {
+	t.Parallel()
+
+	lastReview := time.Date(2026, 4, 26, 0, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name       string
+		phase      FSRSPhase
+		lastReview time.Time
+		now        time.Time
+		want       int
+	}{
+		{"23h59m since last review", FSRSPhaseReview, lastReview, lastReview.Add(23*time.Hour + 59*time.Minute), 0},
+		{"exactly 24h since last review", FSRSPhaseReview, lastReview, lastReview.Add(24 * time.Hour), 1},
+		{"47h59m since last review", FSRSPhaseReview, lastReview, lastReview.Add(47*time.Hour + 59*time.Minute), 1},
+		{"exactly 48h since last review", FSRSPhaseReview, lastReview, lastReview.Add(48 * time.Hour), 2},
+		{"new card", FSRSPhaseNew, lastReview, lastReview.Add(48 * time.Hour), 0},
+		{"no last review", FSRSPhaseReview, time.Time{}, lastReview, 0},
+		{"now before last review", FSRSPhaseReview, lastReview, lastReview.Add(-time.Second), 0},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			state := FSRSState{
+				Phase:      tc.phase,
+				LastReview: tc.lastReview,
+			}
+			require.Equal(t, tc.want, state.ElapsedDaysAt(tc.now))
 		})
 	}
 }

--- a/backend/internal/domain/service/fsrs_scheduler.go
+++ b/backend/internal/domain/service/fsrs_scheduler.go
@@ -26,15 +26,23 @@ func NewFSRSScheduler() *FSRSScheduler {
 // It panics when state.Phase is not a recognised FSRSPhase. The fsrs.State cast
 // below feeds a library dispatch that has no default arm, so an unrecognised
 // phase would produce a zero-valued scheduling result and silently wipe the
-// card's state. Panicking rather than returning an error keeps the single-value
-// signature of the domain.FSRSScheduler consumer interface: no caller can build
-// an invalid phase — Phase is only ever set by this method or reconstituted by
-// the repository, whose read guard already rejects an unrecognised persisted
-// value — so this is a programmer-error guard of the same kind as the
-// constructor panic in domain.NewUserCardFSRSForNewCard.
+// card's state. An out-of-range Rating also panics because grades outside the
+// domain constants are a programmer error. Panicking rather than returning an
+// error keeps the single-value signature of the domain.FSRSScheduler consumer
+// interface: no caller can build an invalid phase — Phase is only ever set by
+// this method or reconstituted by the repository, whose read guard already
+// rejects an unrecognised persisted value — so these are programmer-error
+// guards of the same kind as the constructor panic in
+// domain.NewUserCardFSRSForNewCard.
+//
+// ElapsedDays on the returned state is computed by
+// domain.FSRSState.ElapsedDaysAt, not read from the scheduler library.
 func (s *FSRSScheduler) Apply(state domain.FSRSState, rating domain.Rating, now time.Time) domain.FSRSState {
 	if !state.Phase.IsValid() {
 		panic(fmt.Sprintf("service: fsrs scheduler: invalid FSRSPhase %d", int(state.Phase)))
+	}
+	if !rating.IsValid() {
+		panic(fmt.Sprintf("service: fsrs scheduler: invalid Rating %d", int(rating)))
 	}
 
 	// A backward clock step (NTP, cross-instance skew) would make the library's
@@ -49,7 +57,6 @@ func (s *FSRSScheduler) Apply(state domain.FSRSState, rating domain.Rating, now 
 		Due:           state.Due,
 		Stability:     state.Stability,
 		Difficulty:    state.Difficulty,
-		ElapsedDays:   uint64(state.ElapsedDays),
 		ScheduledDays: uint64(state.ScheduledDays),
 		Reps:          uint64(state.Reps),
 		Lapses:        uint64(state.Lapses),
@@ -61,7 +68,7 @@ func (s *FSRSScheduler) Apply(state domain.FSRSState, rating domain.Rating, now 
 		Due:           info.Card.Due,
 		Stability:     info.Card.Stability,
 		Difficulty:    info.Card.Difficulty,
-		ElapsedDays:   int(info.Card.ElapsedDays),
+		ElapsedDays:   state.ElapsedDaysAt(now),
 		ScheduledDays: int(info.Card.ScheduledDays),
 		Reps:          int(info.Card.Reps),
 		Lapses:        int(info.Card.Lapses),

--- a/backend/internal/domain/service/fsrs_scheduler_test.go
+++ b/backend/internal/domain/service/fsrs_scheduler_test.go
@@ -62,9 +62,11 @@ func TestFSRSScheduler_Apply_InvalidPhasePanics(t *testing.T) {
 }
 
 // TestFSRSScheduler_Apply_InvalidRatingPanics pins the grade guard at the
-// scheduler boundary. An out-of-range grade is a programmer error, so allowing
-// one through would defer the failure to the scheduler library and force the
-// domain.FSRSScheduler interface to represent an unreachable recoverable error.
+// scheduler boundary. go-fsrs does not reject an out-of-range grade: Scheduler.
+// Review dispatches on it through a map with no default arm and returns a
+// zero-valued SchedulingInfo, so an unguarded call would wipe the card's
+// stability and difficulty while ElapsedDaysAt still reported real elapsed time.
+// That is the same programmer-error guard as the invalid-phase one above.
 func TestFSRSScheduler_Apply_InvalidRatingPanics(t *testing.T) {
 	t.Parallel()
 

--- a/backend/internal/domain/service/fsrs_scheduler_test.go
+++ b/backend/internal/domain/service/fsrs_scheduler_test.go
@@ -61,6 +61,39 @@ func TestFSRSScheduler_Apply_InvalidPhasePanics(t *testing.T) {
 	}
 }
 
+// TestFSRSScheduler_Apply_InvalidRatingPanics pins the grade guard at the
+// scheduler boundary. An out-of-range grade is a programmer error, so allowing
+// one through would defer the failure to the scheduler library and force the
+// domain.FSRSScheduler interface to represent an unreachable recoverable error.
+func TestFSRSScheduler_Apply_InvalidRatingPanics(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 4, 26, 0, 0, 0, 0, time.UTC)
+	scheduler := NewFSRSScheduler()
+
+	for _, rating := range []domain.Rating{0, 5} {
+		state := domain.NewFSRSStateForNewCard(now.Add(-24 * time.Hour))
+
+		require.Panics(t, func() {
+			scheduler.Apply(state, rating, now)
+		}, "an out-of-range Rating must fail loudly before reaching the scheduler library")
+	}
+
+	// Every recognised rating still schedules normally.
+	for _, rating := range []domain.Rating{
+		domain.RatingAgain,
+		domain.RatingHard,
+		domain.RatingGood,
+		domain.RatingEasy,
+	} {
+		state := domain.NewFSRSStateForNewCard(now.Add(-24 * time.Hour))
+
+		require.NotPanics(t, func() {
+			scheduler.Apply(state, rating, now)
+		})
+	}
+}
+
 func TestFSRSScheduler_Apply_BackwardClockSkewClamped(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

`service.FSRSScheduler.Apply` treated `ElapsedDays` as a value the scheduling library owned: it fed the persisted value in as an input to `fsrs.Card` and copied the library's output back out. The input was dead weight — go-fsrs v3 overwrites it before any scheduling happens (`scheduler.go:74-80`: `interval = math.Floor(now.Sub(LastReview).Hours()/24)`, then `s.current.ElapsedDays = uint64(interval)`) — while the output is a first-class domain concept with three consumers: the GraphQL field `elapsedDays: Int!` (`schema/card.graphql`), the on-time-recall statistic (`domain/service/user_performance.go`), and the persisted `swipe_records.elapsed_days` column.

go-fsrs v4 removes `Card.ElapsedDays` outright and counts elapsed days internally by UTC calendar date without exposing the result, so the application has to own the value before that upgrade can compile. This change moves the ownership **while staying on v3**, so it is behaviour-preserving in isolation: v3's formula and the new domain formula are the same `floor(hours/24)`, and the pre-existing golden test passing with every expected value unchanged is the proof. The v4 upgrade itself is #1216, which depends on this.

## Changes

### `ElapsedDays` becomes a domain-computed value

- `backend/internal/domain/fsrs_state.go` — adds `FSRSState.ElapsedDaysAt(now time.Time) int`, the application's own definition of the value `FSRSState.ElapsedDays` carries. A `New` card and a card with no `LastReview` both yield `0` (neither has a prior review to measure from); a `now` before `LastReview` yields `0` as a clock-skew guard, so the method is correct independently of `Apply`'s clamp. The docblock names `domain.rescueMinElapsed` and `service.isOnTimeRecall` as the two readers whose behaviour moves together with this formula.
- `backend/internal/domain/service/fsrs_scheduler.go` — drops `ElapsedDays: uint64(state.ElapsedDays)` from the `fsrs.Card` literal (the library discarded it) and reads the returned value from `state.ElapsedDaysAt(now)` instead of `int(info.Card.ElapsedDays)`. `state` is the pre-swipe state and `now` is the already-clamped instant.

The output is identical on v3 because v3 decides the value on two paths and the new method's guards mirror both: `scheduler.go:74-80` computes `floor((now - LastReview)/24h)` only when `State != New` and `LastReview` is non-zero, and `scheduler_longterm.go:25-26` additionally zeroes `ElapsedDays` — but `Scheduler.Review` (`scheduler.go:35-45`) dispatches on the **input** state, so that reset reaches `New` cards only, never Learning / Review / Relearning. Net v3 behaviour is `New -> 0`, everything else `-> floor(hours/24)`, which is exactly what `ElapsedDaysAt` returns.

### `Rating` joins `Phase` at the entry guard

- `backend/internal/domain/service/fsrs_scheduler.go` — `Apply` now panics on `!rating.IsValid()` alongside the existing `!state.Phase.IsValid()` check. go-fsrs v4 validates the grade and returns an error for an out-of-range value; adding the guard here, on v3, means #1216 inherits an input that cannot reach that validation. The `Apply` docblock is extended with the same programmer-error reasoning it already carries for `Phase`, plus a statement that `ElapsedDays` on the returned state is computed by the domain rather than read from the library.

### Tests

- `backend/internal/domain/fsrs_state_test.go` — new `TestRescueMinElapsedMatchesElapsedDayRollover` pins the elapsed-day rollover to the rescue window's admission floor: 23h59m -> `0`, exactly 24h -> `1`, 47h59m -> `1`, exactly 48h -> `2`, plus the three zero-yielding guards (`FSRSPhaseNew`, zero-value `LastReview`, `now` before `LastReview`). It is named after the property `domain.rescueMinElapsed` depends on rather than after the method, matching the file's convention of stating what an assertion is load-bearing for.
- `backend/internal/domain/service/fsrs_scheduler_test.go` — new `TestFSRSScheduler_Apply_InvalidRatingPanics` mirrors the shape of the existing `TestFSRSScheduler_Apply_InvalidPhasePanics`, covering `domain.Rating(0)` and `domain.Rating(5)` on the panic side and all four recognised ratings on the no-panic side. Its docstring states what the guard actually buys, read off the library source: go-fsrs does **not** reject an out-of-range grade — `Scheduler.Review` (`scheduler.go:35-47`) dispatches through `lts.next[grade]`, a map with no default arm, and returns a zero-valued `SchedulingInfo`. Unguarded, the call would wipe stability and difficulty while `ElapsedDaysAt` still reported real elapsed time — a card state that could not exist before this change, since the old code read `ElapsedDays` off that same zero-valued result.
- `TestFSRSSchedulerApplyGoldenTransitions` and `TestFSRSScheduler_Apply_BackwardClockSkewClamped` are deliberately **unedited**. The golden test's `elapsedDays` column (`0` on the four `new_*` rows, `1` on the other twelve) is the equivalence proof: if the implementation read the value from the wrong place, those sixteen rows would move.

### Clock-skew row hardened so it kills its mutant

The first draft of `TestRescueMinElapsedMatchesElapsedDayRollover` covered the `now.Before(LastReview)` guard with a **one-second** backward skew. That row was mutation-equivalent: delete the guard and `int((-1s).Hours()/24)` truncates toward zero, so the row stays green and the guard is effectively untested. A review pass flagged it, an adversarial verifier argued the mutation was already caught, and a direct probe settled it — the verifier was wrong.

The row is now a full day early (`-25h`), where the unguarded expression yields `-1`. Proven by temporarily deleting the guard from `fsrs_state.go` and re-running the test: **only** `now_a_full_day_before_last_review` fails (`expected 0, actual -1`); the one-second row, which is kept for shape, still passes. The guard was restored and `git diff` on `fsrs_state.go` is empty.

## Verification

Run from the worktree at `442589ca`.

- `gofmt -l ./internal ./cmd ./graph` — no output.
- `go build ./...` — exit 0.
- `go vet ./...` — exit 0.
- `go tool go-arch-lint check --project-path .` — `OK - No warnings found`.
- `go test ./...` — exit 0, **2747 tests passed across 27 packages** (includes the Docker-backed `repository` and `cmd/server` packages).
- The equivalence claim was re-derived against the installed library source at `go-fsrs/v3@v3.3.1`, not against release notes — specifically `scheduler.go:74-80`, `scheduler.go:35-45`, and `scheduler_longterm.go:25-26`.
- Mutation proof for the clock-skew guard, as described above.

## Out of scope

- The go-fsrs v4 upgrade, its `Next` error return, and the golden-value refresh. Those land in #1216, which is stacked on this branch.
- The `rescueMinElapsed` (`domain/learn_day.go`) and rescue-window (`repository/card_due.go`) docblocks, which justify their 24-hour floor by naming the library's `floor(hours/24)` formula. That sentence stays true on v3; #1216 restates both against `FSRSState.ElapsedDaysAt` when the library stops using that formula.
- Any change to the `elapsed_days` columns, the GraphQL schema, or the statistics that read `ElapsedDays`. This change moves where the value is computed, never its value.

Closes #1215
