### PR TITLE
fix(backend): fail fast when go-fsrs v4 silently reverts EnableShortTerm

### DIFF
--- a/backend/internal/domain/mastery_tier.go
+++ b/backend/internal/domain/mastery_tier.go
@@ -4,6 +4,13 @@ package domain
 // card is considered "mature" (durably retained). 21 days mirrors the Anki
 // "mature card" cutoff (Anki thresholds on scheduled interval; we apply the
 // same familiar numeric cutoff to FSRS stability).
+// Under the shipped configuration the two readings coincide: go-fsrs derives an
+// interval as s/factor * (RequestRetention^(1/decay) - 1) with
+// factor = 0.9^(1/decay) - 1, so at the default RequestRetention of exactly 0.9
+// the interval IS the stability, and ScheduledDays is round(stability) clamped to
+// [1, MaximumInterval]. That identity is what makes 21 mean the same thing on both
+// scales, and it breaks for any other retention — revisit this constant if
+// RequestRetention ever becomes configurable.
 const MatureStabilityDays = 21.0
 
 // LearnedStabilityDays is the FSRS stability (in days) at or above which a
@@ -24,12 +31,16 @@ const MatureStabilityDays = 21.0
 // divergence self-heals on that swipe, which moves the row into Review. (A
 // first-ever swipe does fail it, carrying PhaseBefore == FSRSPhaseNew, but
 // its stability is below the boundary, so both populations exclude it and the
-// parity holds.) Flipping
-// EnableShortTerm back to true would admit a card with a non-Review phase and
-// stability at or above this constant: the mastery tiles
-// would still count it as learned while the retention/lapse population dropped
-// it, and the two would diverge with no compile error and no failing test at
-// this constant's own site. Revisit this boundary if the scheduler mode changes.
+// parity holds.)
+// The flag is not reachable only by a deliberate edit: fsrs.NewFSRS replaces the
+// caller's whole Parameters value with its defaults when validation fails, and
+// those defaults enable short-term mode. service.NewFSRSScheduler asserts the
+// flag after construction precisely so that path cannot reach this constant
+// silently. Either way in — a deliberate flip or a discarded parameter — admits a
+// card with a non-Review phase and stability at or above this constant: the
+// mastery tiles would still count it as learned while the retention/lapse
+// population dropped it, with no compile error and no failing test at this
+// constant's own site. Revisit this boundary if the scheduler mode changes.
 const LearnedStabilityDays = 7.0
 
 // MasteryTier is the disjoint learning tier a card sits in.

--- a/backend/internal/domain/service/fsrs_scheduler.go
+++ b/backend/internal/domain/service/fsrs_scheduler.go
@@ -12,13 +12,34 @@ import (
 // FSRSScheduler wraps go-fsrs behind a pure domain service.
 type FSRSScheduler struct{ algo *fsrs.FSRS }
 
+// NewFSRSScheduler builds the long-term-mode scheduler the whole domain assumes:
+// whole-day intervals only, and no card ever sitting in Learning or Relearning.
+//
+// Both guards below exist because fsrs.NewFSRS substitutes fsrs.DefaultParam()
+// for the caller's whole Parameters value when validation fails, and DefaultParam
+// sets EnableShortTerm = true. One out-of-range field would therefore swap in the
+// short-term scheduler with no error and no failing test: sub-day intervals would
+// return and domain.LearnedStabilityDays' mastery/statistics parity would break at
+// a site that has no compile-time link to this one.
+//
+// LearningSteps and RelearningSteps are cleared because the long-term scheduler
+// never reads them. They are not inert: clipParameters derives the W17/W18 ceiling
+// from len(RelearningSteps). That ceiling is 2.0 for any length below 2, which is
+// what both the default one-element slice and nil produce, so clearing them moves
+// no golden value — it removes the coupling.
 func NewFSRSScheduler() *FSRSScheduler {
 	params := fsrs.DefaultParam()
-	// Long-term scheduling mode: skip the sub-day (minutes) learning steps so every
-	// review is scheduled in whole-day intervals and cards never sit in the
-	// Learning/Relearning phases. See go-fsrs Parameters.EnableShortTerm.
 	params.EnableShortTerm = false
-	return &FSRSScheduler{algo: fsrs.NewFSRS(params)}
+	params.LearningSteps = nil
+	params.RelearningSteps = nil
+	if err := params.Validate(); err != nil {
+		panic(fmt.Sprintf("service: fsrs scheduler: invalid parameters: %v", err))
+	}
+	algo := fsrs.NewFSRS(params)
+	if algo.EnableShortTerm {
+		panic("service: fsrs scheduler: go-fsrs discarded EnableShortTerm = false")
+	}
+	return &FSRSScheduler{algo: algo}
 }
 
 // Apply returns a fresh state and does not mutate the input state.
@@ -43,6 +64,12 @@ func NewFSRSScheduler() *FSRSScheduler {
 //
 // ElapsedDays on the returned state is computed by
 // domain.FSRSState.ElapsedDaysAt, not read from the scheduler library.
+// fsrs.Card.RemainingSteps is deliberately not carried on FSRSState. The
+// long-term scheduler never reads it and setReviewState zeroes it on every
+// output, so a round trip through the domain is lossless. That holds only while
+// EnableShortTerm is false, which the constructor above now asserts — under
+// short-term mode the basic scheduler reads it to advance the learning step, and
+// every card would restart at step 0.
 func (s *FSRSScheduler) Apply(state domain.FSRSState, rating domain.Rating, now time.Time) domain.FSRSState {
 	if !state.Phase.IsValid() {
 		panic(fmt.Sprintf("service: fsrs scheduler: invalid FSRSPhase %d", int(state.Phase)))

--- a/backend/internal/domain/service/fsrs_scheduler_invariants_test.go
+++ b/backend/internal/domain/service/fsrs_scheduler_invariants_test.go
@@ -1,0 +1,67 @@
+package service
+
+import (
+	"math"
+	"math/rand/v2"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"backend/internal/domain"
+)
+
+func TestNewFSRSScheduler_KeepsLongTermMode(t *testing.T) {
+	t.Parallel()
+
+	algo := NewFSRSScheduler().algo
+
+	// These assertions defend against the measured silent fallback caused by
+	// RequestRetention = 0, MaximumInterval = 0 or 73000, and a NaN weight.
+	require.False(t, algo.EnableShortTerm)
+	require.Equal(t, 0.9, algo.RequestRetention)
+	require.Equal(t, 36500.0, algo.MaximumInterval)
+	require.Nil(t, algo.LearningSteps)
+	require.Nil(t, algo.RelearningSteps)
+}
+
+func TestFSRSScheduler_Apply_OutputAlwaysSatisfiesDomainGuards(t *testing.T) {
+	t.Parallel()
+
+	const iterations = 2000
+
+	rng := rand.New(rand.NewPCG(1, 2))
+	scheduler := NewFSRSScheduler()
+	now := time.Date(2026, 4, 26, 0, 0, 0, 0, time.UTC)
+	executed := 0
+
+	for i := 0; i < iterations; i++ {
+		stability := math.Exp(math.Log(0.001) + rng.Float64()*(math.Log(36500)-math.Log(0.001)))
+		lastReview := now.Add(-time.Duration(rng.IntN(401)) * 24 * time.Hour)
+		dueOffsetDays := rng.IntN(401)
+		state := domain.FSRSState{
+			Due:           lastReview.Add(time.Duration(dueOffsetDays) * 24 * time.Hour),
+			Stability:     stability,
+			Difficulty:    domain.MinDifficulty + rng.Float64()*(domain.MaxDifficulty-domain.MinDifficulty),
+			ScheduledDays: dueOffsetDays,
+			Reps:          rng.IntN(5001),
+			Lapses:        rng.IntN(5001),
+			Phase:         domain.FSRSPhase(rng.IntN(4)),
+			LastReview:    lastReview,
+		}
+		rating := domain.Rating(rng.IntN(4) + 1)
+
+		out := scheduler.Apply(state, rating, now)
+		executed++
+
+		failureMessage := "iteration %d: input=%+v rating=%d now=%s"
+		require.True(t, domain.IsValidStability(out.Stability), failureMessage, i, state, rating, now)
+		require.True(t, domain.IsValidDifficulty(out.Difficulty), failureMessage, i, state, rating, now)
+		require.GreaterOrEqual(t, out.Due.Sub(now), 24*time.Hour, failureMessage, i, state, rating, now)
+		require.Equal(t, domain.FSRSPhaseReview, out.Phase, failureMessage, i, state, rating, now)
+		require.True(t, out.LastReview.Equal(now), failureMessage, i, state, rating, now)
+		require.Equal(t, rating, out.LastRating, failureMessage, i, state, rating, now)
+	}
+
+	require.Equal(t, iterations, executed, "property sweep must execute every iteration")
+}


### PR DESCRIPTION
## Summary

`fsrs.NewFSRS` stopped being a struct wrapper in v4. It now clips the weights, validates the result, and **replaces the caller's entire `Parameters` value with `fsrs.DefaultParam()` when validation fails** — and `DefaultParam()` carries `EnableShortTerm: true`. `service.NewFSRSScheduler` sets `EnableShortTerm = false` and hands the value straight to `NewFSRS`, so a single out-of-range field anywhere in that struct silently swaps the short-term scheduler back in, with no error, no log line, and no failing test.

That flag is not a preference. It is the sole premise behind three separate domain guarantees: `domain.LearnedStabilityDays`' mastery-tile / retention-population parity, the 24-hour rescue floor's "no sub-day interval is reachable" property, and `RemainingSteps` being safely absent from `domain.FSRSState`. A reversion would not crash — it would surface as wrong statistics weeks later. This makes the failure loud at construction and records the reasoning at the two constants that depend on it.

## Background / Motivation

Measured against `v4.0.0` with a probe reproducing the constructor's exact sequence (`DefaultParam()` → set `EnableShortTerm = false` → `NewFSRS`):

```
as shipped today                       EnableShortTerm = false  OK
RequestRetention = 0.95                EnableShortTerm = false  OK
RequestRetention = 0   (zero value)    EnableShortTerm = TRUE   <-- silently reverted
MaximumInterval  = 0   (zero value)    EnableShortTerm = TRUE   <-- silently reverted
MaximumInterval  = 73000               EnableShortTerm = TRUE   <-- silently reverted
one weight NaN                         EnableShortTerm = TRUE   <-- silently reverted
LearningSteps/RelearningSteps = nil    EnableShortTerm = false  OK
```

`RequestRetention = 0` and `MaximumInterval = 0` are the values an unset config-struct field carries, so the reachable trigger is an ordinary "read retention from a user preference or env var" change, not an exotic one.

An Alloy model of the two mastery predicates (`ClassifyMastery` tests stability alone; `isKnownCardReview` tests phase **and** stability) reports `check MasteryGateParity` **SAT** — counterexample: a Learning/Relearning card with stability at or above the boundary — and `check MasteryGateParityUnderLongTerm` **UNSAT**. Long-term mode is exactly what keeps the divergent set empty.

## Changes

### Two guards at construction, neither subsuming the other

- `backend/internal/domain/service/fsrs_scheduler.go` — `NewFSRSScheduler` now calls `params.Validate()` and panics with the offending field before `NewFSRS` runs, then reads `algo.EnableShortTerm` back and panics again if the library discarded it. `Validate()` runs ahead of `NewFSRS`' internal clipping and names the field; the read-back catches any future path by which the library could drop the flag.
- `LearningSteps` / `RelearningSteps` are cleared to `nil`. They are not inert — `clipParameters` derives the W17/W18 ceiling from `len(RelearningSteps)` — but that ceiling is `2.0` for any length below 2, which is what both the default one-element slice and `nil` produce. `TestFSRSSchedulerApplyGoldenTransitions` passing with its committed values untouched is the proof that this moved nothing.

### The two dependent constants now name their premise

- `backend/internal/domain/mastery_tier.go` — `LearnedStabilityDays`' docblock previously named only a deliberate flag flip as the way in. It now names the parameter-discard path and points at the constructor assertion that closes it.
- `MatureStabilityDays`' docblock hedged that Anki thresholds on scheduled interval "and we apply the same familiar numeric cutoff to FSRS stability", implying the two scales differ. Under the shipped configuration they are the same number: go-fsrs derives an interval as `s/factor * (RequestRetention^(1/decay) - 1)` with `factor = 0.9^(1/decay) - 1`, so at `RequestRetention == 0.9` the factor cancels and the interval **is** the stability. Z3 proves the negation UNSAT for any decay. The docblock now states the identity and its precondition.

### `RemainingSteps` — why it is safely absent

`fsrs.Card` gained `RemainingSteps int` in v4 and `domain.FSRSState` does not carry it. `Apply`'s docblock now records that the long-term scheduler never reads it and `setReviewState` zeroes it on every output, so the round trip is lossless — and that this holds *only* while `EnableShortTerm` is false, which the constructor now asserts.

### Tests

- New `backend/internal/domain/service/fsrs_scheduler_invariants_test.go`.
- `TestNewFSRSScheduler_KeepsLongTermMode` pins `EnableShortTerm == false`, `RequestRetention == 0.9`, `MaximumInterval == 36500`, and both step slices `nil`, with a comment naming the four measured parameter mistakes it defends against.
- `TestFSRSScheduler_Apply_OutputAlwaysSatisfiesDomainGuards` is a property test over 2000 deterministic pseudo-random inputs (`rand.NewPCG(1, 2)`) drawn from the library's admissible set. Every output must satisfy `IsValidStability`, `IsValidDifficulty`, `Due.Sub(now) >= 24h`, `Phase == FSRSPhaseReview`, `LastReview == now` and `LastRating == rating`. The executed iteration count is asserted so the loop cannot pass vacuously.
- `TestFSRSScheduler_Apply_NeverSchedulesSubDayInterval` is deliberately kept: it pins the exact golden minimum (24.00h) rather than the inequality.

## Verification

Run from `backend/` against a live Docker daemon.

- `gofmt -l ./internal ./cmd ./graph` — no output.
- `go build ./...` — exit 0.
- `go vet ./...` — exit 0.
- `go tool go-arch-lint check --project-path .` — `OK - No warnings found`.
- `go test ./internal/domain/... ./internal/usecase/... ./graph/...` — 1784 passed, 7 packages.
- `go test ./...` — 2751 passed, 27 packages, 0 failures, 0 skips.
- `TestFSRSSchedulerApplyGoldenTransitions` passes with its committed values untouched; no golden value moved.
- CJK gate (`perl -CSD`) and the `PR[0-9]+` grep over the three changed files — both clean.

**Four mutation checks, one of which is worth recording.** Restoring an invalid `MaximumInterval` after `Validate()` fires the read-back guard; placing it before fires the distinct "invalid parameters" panic; dropping `params.LearningSteps = nil` fails `TestNewFSRSScheduler_KeepsLongTermMode` on `require.Nil`. The fourth is the interesting one: setting `EnableShortTerm = true` while *keeping* the nil step slices leaves the property test **green** — short-term mode with no learning steps still emits whole-day intervals, so that mutant is not equivalent to the real bug. The faithful reproduction is plain `fsrs.DefaultParam()`, which is exactly what `NewFSRS` substitutes on validation failure, including `LearningSteps {1, 10}` — and that one **does** fail, on the 24-hour assertion with `"1m0s" is not greater than or equal to "24h0m0s"`. The property test pins the real silent-revert path; the constructor read-back is what would catch a bare hand-edited flag flip. Neither guard subsumes the other, as claimed.

## Out of scope

- `fsrs.Retrievability`, `Rollback`, `Reschedule`, `Forget`, `MemoryStateFromSM2`.
- `domain.FSRSState.ElapsedDays` and everything downstream of it.
- The 24-hour rescue floor and the swipe replay guard.
- Making `RequestRetention` or `MaximumInterval` configurable. This only makes the failure loud if someone later does.

## Relationship to sibling PRs

Independent of #1220, #1221 and #1222 — no shared files, any merge order. **Blocks #1223**, which deletes `isKnownCardReview`'s non-Review tiers and the legacy-row paragraph in `mastery_tier.go`; that deletion is only sound once long-term mode is enforced here.

Closes #1219
