### PR TITLE
fix(backend): make IsValidStability match go-fsrs v4's admissible stability set

### DIFF
--- a/backend/internal/domain/fsrs_state.go
+++ b/backend/internal/domain/fsrs_state.go
@@ -1,7 +1,6 @@
 package domain
 
 import (
-	"math"
 	"time"
 )
 
@@ -32,16 +31,30 @@ const (
 	MaxDifficulty = 10.0
 )
 
+// MinStability and MaxStability bound the FSRS stability scale, mirroring
+// go-fsrs' sMin and sMax the way MinDifficulty and MaxDifficulty mirror dMin and
+// dMax. constrainStability clamps every stability the scheduler produces into
+// this closed range.
+//
+// MinStability is the load-bearing end. go-fsrs rejects a non-New card whose
+// stability is below it, and FSRSScheduler.Apply turns that rejection into a
+// panic, so a row under this floor is the one persisted value that can fail a
+// routine swipe. MaxStability is hygiene: the library accepts an over-large
+// stability, it simply cannot have produced one.
+const (
+	MinStability = 0.001
+	MaxStability = 36500.0
+)
+
 // IsValidStability reports whether s is a stability the scheduler can produce:
-// finite and strictly positive. The check exists because NaN and the infinities
-// fail every ordered comparison silently — an unchecked NaN stability falls
-// through both ClassifyMastery comparisons and is reported as the Learned tier,
-// and it breaks JSON marshalling of the GraphQL Float it feeds.
+// finite and within [MinStability, MaxStability]. Both ends matter. Below
+// MinStability, go-fsrs rejects the card and FSRSScheduler.Apply panics, so
+// admitting such a row only defers the failure to the next swipe. NaN and the
+// infinities fail every ordered comparison silently — an unchecked NaN stability
+// falls through both ClassifyMastery comparisons and is reported as the Learned
+// tier, and it breaks JSON marshalling of the GraphQL Float it feeds.
 func IsValidStability(s float64) bool {
-	if math.IsNaN(s) || math.IsInf(s, 0) {
-		return false
-	}
-	return s > 0
+	return s >= MinStability && s <= MaxStability
 }
 
 // IsValidDifficulty reports whether d sits within [MinDifficulty, MaxDifficulty].

--- a/backend/internal/domain/fsrs_state_test.go
+++ b/backend/internal/domain/fsrs_state_test.go
@@ -38,10 +38,10 @@ func TestFSRSPhaseIsValid(t *testing.T) {
 	}
 }
 
-// TestIsValidStability pins both sides of the stability predicate. The accept
-// side matters as much as the reject side: the repository read guard hard-fails
-// a whole query on a false negative, so a narrowing of the predicate must break
-// a test here rather than a persisted user's read.
+// TestIsValidStability pins the closed [MinStability, MaxStability] range,
+// including both inclusive endpoints. Both endpoints are values go-fsrs'
+// constrainStability legitimately emits and persists, so narrowing the bounds
+// to an open range would reject real rows.
 func TestIsValidStability(t *testing.T) {
 	t.Parallel()
 
@@ -51,8 +51,12 @@ func TestIsValidStability(t *testing.T) {
 		want  bool
 	}{
 		{"new card placeholder", NewCardStability, true},
-		{"smallest positive", math.SmallestNonzeroFloat64, true},
-		{"large finite", math.MaxFloat64, true},
+		{"MinStability boundary", MinStability, true},
+		{"MaxStability boundary", MaxStability, true},
+		{"just below MinStability", 0.0009, false},
+		{"just above MaxStability", 36500.1, false},
+		{"below MinStability", math.SmallestNonzeroFloat64, false},
+		{"above MaxStability", math.MaxFloat64, false},
 		{"zero", 0, false},
 		{"negative", -1.5, false},
 		{"NaN", math.NaN(), false},

--- a/backend/internal/domain/service/fsrs_scheduler_test.go
+++ b/backend/internal/domain/service/fsrs_scheduler_test.go
@@ -96,13 +96,12 @@ func TestFSRSScheduler_Apply_InvalidRatingPanics(t *testing.T) {
 	}
 }
 
-// TestFSRSScheduler_Apply_StabilityBelowLibraryMinimumPanics pins the one v4
-// validation error the domain's own guards cannot rule out. IsValidStability
-// admits any finite positive value, while go-fsrs rejects a non-New card whose
-// stability is under its own minimum, so a corrupt persisted row reaches the
-// error arm of Next. It panics rather than returning: the SchedulingInfo that
-// accompanies the error is zero-valued, so accepting it would overwrite the row
-// with stability 0, difficulty 0 and a zero-time due.
+// TestFSRSScheduler_Apply_StabilityBelowLibraryMinimumPanics pins Apply's
+// independent behaviour for a sub-minimum stability. The repository guard now
+// rejects this value at load time, so the panic is unreachable through the
+// application. Apply is also reachable from in-process callers that never went
+// through the repository, and swallowing the error would persist a zero-valued
+// SchedulingInfo with stability 0, difficulty 0 and a zero-time due.
 func TestFSRSScheduler_Apply_StabilityBelowLibraryMinimumPanics(t *testing.T) {
 	t.Parallel()
 
@@ -116,8 +115,8 @@ func TestFSRSScheduler_Apply_StabilityBelowLibraryMinimumPanics(t *testing.T) {
 		Phase:      domain.FSRSPhaseReview,
 		LastReview: now.Add(-48 * time.Hour),
 	}
-	require.True(t, domain.IsValidStability(state.Stability),
-		"the fixture must be a stability the domain guard admits, or this proves nothing about the gap")
+	require.False(t, domain.IsValidStability(state.Stability),
+		"the fixture must be a stability the repository read guard now rejects, which is what makes Apply's own guard the last line of defence")
 
 	require.Panics(t, func() {
 		scheduler.Apply(state, domain.RatingGood, now)

--- a/backend/internal/repository/user_card_fsrs.go
+++ b/backend/internal/repository/user_card_fsrs.go
@@ -216,7 +216,10 @@ func userCardFSRSLastRating(state domain.FSRSState) *int {
 // is the one way an out-of-range value can reach the domain. Rejecting is
 // deliberate — a corrupted stability or difficulty would otherwise reach the
 // UserCardState GraphQL Floats it feeds and break JSON marshalling of the whole
-// response, which is harder to diagnose than a failed read. The sibling
+// response, which is harder to diagnose than a failed read. Reps and Lapses are
+// also checked because the scheduler widens them to uint64, where a negative
+// persisted value becomes an enormous unsigned count; ScheduledDays is checked
+// because it is never negative by construction. The sibling
 // ListFSRSStatesByUser carries the matching stability guard for the /stats
 // projection, which is the path domain.ClassifyMastery consumes.
 func userCardFSRSToDomain(row gormUserCardFSRS) (*domain.UserCardFSRS, error) {
@@ -236,6 +239,15 @@ func userCardFSRSToDomain(row gormUserCardFSRS) (*domain.UserCardFSRS, error) {
 		if !lastRating.IsValid() {
 			return nil, eris.Errorf("repository: invalid last_rating value %d for card %s", *row.LastRating, row.CardID)
 		}
+	}
+	// Reps and Lapses are unvalidated by the table (no CHECK constraints) and are
+	// widened to uint64 on the way into go-fsrs, where a negative value becomes an
+	// enormous unsigned count that the scheduler's own Reps++ then wraps to 0 —
+	// silently destroying the counter with no error. ScheduledDays feeds the
+	// GraphQL Int and the statistics, and is never negative by construction.
+	if row.Reps < 0 || row.Lapses < 0 || row.ScheduledDays < 0 {
+		return nil, eris.Errorf("repository: negative counter for card %s (reps=%d lapses=%d scheduled_days=%d)",
+			row.CardID, row.Reps, row.Lapses, row.ScheduledDays)
 	}
 	return &domain.UserCardFSRS{
 		UserID: domain.UserID(row.UserID),

--- a/backend/internal/repository/user_card_fsrs_mapper_test.go
+++ b/backend/internal/repository/user_card_fsrs_mapper_test.go
@@ -78,6 +78,16 @@ func TestUserCardFSRSToDomain_RejectsCorruptColumns(t *testing.T) {
 			wantMsg: "repository: invalid stability value -1.5 for card 00000000-0000-0000-0000-000000000002",
 		},
 		{
+			name:    "stability below MinStability",
+			mutate:  func(r *gormUserCardFSRS) { r.Stability = 0.0009 },
+			wantMsg: "repository: invalid stability value 0.0009 for card 00000000-0000-0000-0000-000000000002",
+		},
+		{
+			name:    "stability above MaxStability",
+			mutate:  func(r *gormUserCardFSRS) { r.Stability = 36500.1 },
+			wantMsg: "repository: invalid stability value 36500.1 for card 00000000-0000-0000-0000-000000000002",
+		},
+		{
 			name:    "difficulty below the minimum",
 			mutate:  func(r *gormUserCardFSRS) { r.Difficulty = domain.MinDifficulty - 0.5 },
 			wantMsg: "repository: invalid difficulty value 0.5 for card 00000000-0000-0000-0000-000000000002",
@@ -91,6 +101,21 @@ func TestUserCardFSRSToDomain_RejectsCorruptColumns(t *testing.T) {
 			name:    "last_rating outside the FSRS range",
 			mutate:  func(r *gormUserCardFSRS) { r.LastRating = &badRating },
 			wantMsg: "repository: invalid last_rating value 7 for card 00000000-0000-0000-0000-000000000002",
+		},
+		{
+			name:    "negative reps",
+			mutate:  func(r *gormUserCardFSRS) { r.Reps = -1 },
+			wantMsg: "repository: negative counter for card 00000000-0000-0000-0000-000000000002 (reps=-1 lapses=1 scheduled_days=5)",
+		},
+		{
+			name:    "negative lapses",
+			mutate:  func(r *gormUserCardFSRS) { r.Lapses = -1 },
+			wantMsg: "repository: negative counter for card 00000000-0000-0000-0000-000000000002 (reps=3 lapses=-1 scheduled_days=5)",
+		},
+		{
+			name:    "negative scheduled_days",
+			mutate:  func(r *gormUserCardFSRS) { r.ScheduledDays = -1 },
+			wantMsg: "repository: negative counter for card 00000000-0000-0000-0000-000000000002 (reps=3 lapses=1 scheduled_days=-1)",
 		},
 	}
 


### PR DESCRIPTION
## Summary

`domain.IsValidStability` accepted any finite positive value, but go-fsrs v4 rejects a non-New card whose stability is below `sMin = 0.001`. A persisted row carrying a stability in `(0, 0.001)` therefore passed the repository read guard, reached `FSRSScheduler.Apply`, hit v4's error arm and **panicked** — surfacing as an INTERNAL GraphQL error on that card's next swipe. That is the "Known limitation" recorded when go-fsrs was upgraded to v4; until now it was pinned by a test rather than prevented.

This gives stability the named bounds difficulty already had, and closes a second, quieter gap beside it: `userCardFSRSToDomain` validated phase, stability, difficulty and `last_rating` but not `reps`, `lapses` or `scheduled_days`.

## Background / Motivation

The asymmetry was the tell. `MinDifficulty` / `MaxDifficulty` already mirror the library's `dMin` / `dMax`, while stability had no named bounds at all. Z3 confirms the shape:

```
C1  domain admits a stability the library rejects .... sat   (counterexample s = 0.0005)
C2  domain admits a difficulty the library rejects ... unsat (no gap)
C3  proposed guard still admits a rejected value ..... unsat (gap fully closed)
C4  proposed guard rejects a producible value ........ unsat (rejects nothing the scheduler can emit)
C5  s > sMax makes the library reject ................ unsat (the upper bound is hygiene, not a crash fix)
```

C4 is the safety proof: v4 clamps every stability it produces through `constrainStability` into `[sMin, sMax]`, so the tightened guard cannot reject a value the application itself wrote.

The counter gap is silent rather than loud. `Apply` widens `Reps` and `Lapses` to `uint64`, so a negative persisted value becomes an enormous unsigned number, the scheduler's own `Reps++` wraps it to 0, and the row is written back with a destroyed counter — no panic, no error. The table carries no CHECK constraints, which is the reason the existing docblock already gives for re-checking every constrained column at this boundary.

## Changes

### Named stability bounds

- `backend/internal/domain/fsrs_state.go` — adds `MinStability = 0.001` and `MaxStability = 36500.0` alongside the existing difficulty block, with a docblock distinguishing the two ends: `MinStability` is load-bearing (below it the library rejects the card and `Apply` panics), `MaxStability` is hygiene (the library accepts an over-large stability, it simply cannot have produced one).
- `IsValidStability` becomes a closed-range check, `s >= MinStability && s <= MaxStability`. The explicit `math.IsNaN` / `math.IsInf` block is dropped because NaN fails both comparisons and `+Inf` fails the upper bound; the `math` import goes with it, confirmed by the compiler rather than by inspection.

### Counter validation at the repository boundary

- `backend/internal/repository/user_card_fsrs.go` — `userCardFSRSToDomain` rejects negative `reps`, `lapses` and `scheduled_days`, naming all three values in the error. Its docblock now says the counters are checked for the *widening* reason, not just the range reason.
- `ListFSRSStatesByUser` is untouched: it already calls `domain.IsValidStability` and inherits the tightening. Its docblock describes the check as mirroring `userCardFSRSToDomain`'s guards rather than stating the old "finite and positive" semantics, so there was nothing there to correct.

### Tests

- `backend/internal/domain/fsrs_state_test.go` — `TestIsValidStability` gains four rows pinning both endpoints and both just-outside values (`MinStability`, `MaxStability`, `0.0009`, `36500.1`). Two existing rows flip and were **renamed rather than deleted**, because their old names would now assert the opposite of what they check: `"smallest positive"` → `"below MinStability"`, `"large finite"` → `"above MaxStability"`. Every other row (`NewCardStability`, zero, negative, NaN, both infinities) is unchanged.
- `backend/internal/domain/service/fsrs_scheduler_test.go` — `TestFSRSScheduler_Apply_StabilityBelowLibraryMinimumPanics` keeps its subject but inverts its fixture assertion. It no longer documents a gap between two guards; it documents that `Apply` carries its own guard independent of the repository read path. The docblock records why the test still earns its place: `Apply` is reachable from in-process callers that never went through the repository, and swallowing the error would persist a zero-valued `SchedulingInfo` — stability 0, difficulty 0, zero-time due. The non-panicking `0.001` half stays; it pins the boundary.
- `backend/internal/repository/user_card_fsrs_mapper_test.go` — `TestUserCardFSRSToDomain_RejectsCorruptColumns` gains all five new corrupt values. `TestUserCardFSRSToDomain_AcceptsValidRow` passes unchanged; its fixture stability was already inside the new range.

## Verification

Run from `backend/` against a live Docker daemon.

- `gofmt -l ./internal ./cmd ./graph` — no output.
- `go build ./...` — exit 0 (this is what resolved the unused `math` import).
- `go vet ./...` — exit 0.
- `go tool go-arch-lint check --project-path .` — `OK - No warnings found`.
- `go test ./...` — all 27 packages ok, 0 failures, 0 skips.
- `go test ./internal/repository/ -count=1 -run TestUserCardFSRS` — 39 passed, uncached, container-backed.
- `grep -rn 'IsValidStability' backend/ --include='*.go'` — the definition, the two repository guards, and tests only. No other production site depends on the old semantics.
- CJK gate (`perl -CSD`) and the `PR[0-9]+` grep over the five changed files — both clean.

**Three mutation checks, all killed.** `MinStability` → `0.0` fails 3 rows; `MaxStability` → `1e308` fails 1 row; stubbing the new negative-counter condition to `if false` fails 3 rows. The last two go beyond what the issue asked for, on the grounds that a row nobody has mutated proves nothing about what it pins. All three files were restored with `cp` from a pre-mutation backup — never `git checkout` / `git restore` — and the post-restore `git diff --stat` was byte-identical to the pre-mutation state.

## Out of scope

- `FSRSState.ElapsedDays`, `isOnTimeRecall`, the snapshot columns, and the DB migration that removes them.
- The `EnableShortTerm` construction guard.
- Adding CHECK constraints to `user_card_fsrs`. The read guard is the chosen enforcement point and the docblock says why.

## Relationship to sibling PRs

Independent of #1219, #1221 and #1222 — no shared files, any merge order. **Blocks #1223**: both edit `backend/internal/domain/fsrs_state.go`, this one rewriting the validity guards and that one deleting the `ElapsedDays` field.

Closes #1220
