### PR TITLE
chore(backend): upgrade google.golang.org/grpc to v1.82.1

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -138,7 +138,7 @@ require (
 	google.golang.org/genproto v0.0.0-20260319201613-d00831a3d3e7 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect
-	google.golang.org/grpc v1.81.1 // indirect
+	google.golang.org/grpc v1.82.1 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	oss.terrastruct.com/d2 v0.5.1 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -513,8 +513,8 @@ google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyac
 google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=
 google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/grpc v1.33.2/go.mod h1:JMHMWHQWaTccqQQlmk3MJZS+GWXOdAesneDmEnv2fbc=
-google.golang.org/grpc v1.81.1 h1:VnnIIZ88UzOOKLukQi+ImGz8O1Wdp8nAGGnvOfEIWQQ=
-google.golang.org/grpc v1.81.1/go.mod h1:xGH9GfzOyMTGIOXBJmXt+BX/V0kcdQbdcuwQ/zNw42I=
+google.golang.org/grpc v1.82.1 h1:NnAxzGRA0677vCa4BUkOAnO5+FfQqVl9iUXeD0IqcGE=
+google.golang.org/grpc v1.82.1/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=


### PR DESCRIPTION
## Summary

`govulncheck` began failing every backend PR in this repository on 2026-07-27, including PRs with no Go changes at all. The cause is **GO-2026-6061**, published `2026-07-27T15:30:50Z` — hours *after* `main`'s last green backend run at `10:14Z` the same day. It reports vulnerabilities in the xDS RBAC authorization engine and the HTTP/2 transport server in `google.golang.org/grpc`, which this module carries at `v1.81.1` as an **indirect** dependency. This bumps it to `v1.82.1`, the fixed version.

Nothing about the repository changed to cause this, and no PR can go green until it lands. The `Build & test` job runs `go tool govulncheck ./...`, which exits 3 on any finding.

## Background / Motivation

The dependency is transitive, not direct — `go mod graph` shows it arriving through the OpenTelemetry OTLP trace exporter:

```
backend google.golang.org/grpc@v1.81.1
go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp@v1.44.0 google.golang.org/grpc@v1.81.1
```

The reported call path reaches it through connection teardown:

```
internal/database/pool.go:70:14: database.DB.Close calls pgxpool.Pool.Close,
  which eventually calls transport.NewHTTP2Client / http2Client.Close / http2Client.GracefulClose
```

This was reproduced on **unmodified `main` checked out locally**, which is what establishes it as environmental rather than introduced by any open PR. The advisory's own metadata confirms the timing: `{"introduced": "0"}, {"fixed": "1.82.1"}`, published `2026-07-27T15:30:50Z`.

## Changes

- `backend/go.mod` — `google.golang.org/grpc v1.81.1 // indirect` → `v1.82.1 // indirect`. The `// indirect` marker is preserved; nothing in this module imports grpc directly, and `go mod tidy` leaves it marked indirect.
- `backend/go.sum` — the two corresponding hash lines.

That is the entire diff: 2 files, 3 insertions, 3 deletions. No source file is touched.

## Verification

Run from `backend/` against a live Docker daemon.

- `go tool govulncheck ./...` — **`No vulnerabilities found.`**, exit 0. This is the check the change exists to fix; before the bump it reported `Your code is affected by 1 vulnerability from 1 module` and exited 3.
- `gofmt -l ./internal ./cmd ./graph` — no output.
- `go build ./...` — exit 0.
- `go vet ./...` — exit 0.
- `go tool go-arch-lint check --project-path .` — `OK - No warnings found`.
- `go test ./... -count=1` — all 27 packages `ok`, zero `FAIL` lines. This includes the Docker-backed `internal/repository` and `cmd/server` packages, and `internal/telemetry` — the package that actually pulls grpc in through the OTLP exporter, and therefore the one a transport-layer regression would surface in first.

## Scope

This PR addresses **no GitHub issue** — it is an unblocking change for a vulnerability advisory published after the current `main` was cut.

It is deliberately kept to the dependency bump alone so it can merge ahead of the FSRS v4 work (#1224, #1225, #1226, #1227, #1228), all of which are otherwise green and each of which currently shows exactly one red check for this same advisory and nothing else. #1226 is documentation-only, invokes no Go tooling, and is already fully green — which is what isolates the failure to `govulncheck` rather than to anything in that series.

No other dependency is upgraded, and `go mod tidy` moved no other line.
